### PR TITLE
refactor(control): extract mcpManager from Controller

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -72,7 +72,6 @@ type Controller struct {
 	modelRef      string
 	systemPrompt  string
 	sessionDir    string
-	host          *plugin.Host
 	commands      atomic.Pointer[[]command.Command]
 	skills        []skill.Skill
 	allSkills     []skill.Skill
@@ -106,12 +105,12 @@ type Controller struct {
 	// Close cancels its still-running jobs.
 	jobs *jobs.Manager
 
-	// reg is the live tool registry the executor reads each turn; pluginCtx is the
-	// session-scoped context a hot-added stdio server binds its subprocess to.
-	// Together they let AddMCPServer connect a server mid-session and have its tools
-	// available on the next turn (see AddMCPServer / RemoveMCPServer).
-	reg       *tool.Registry
-	pluginCtx context.Context
+	// mcp owns the session's live tool/plugin surface — the MCP plugin Host, the
+	// tool registry the executor reads each turn, and the session-scoped context a
+	// hot-added stdio server binds its subprocess to — behind its own lock, off
+	// c.mu. The Controller keeps the config-facing orchestration (persisting
+	// reasonix.toml on add/remove, building specs from entries). See mcp.go.
+	mcp mcpManager
 
 	// goals owns the active goal's FSM (status, intercepts, idle/turn counters)
 	// and its persistence, behind its own mutex so a per-turn goal save never
@@ -298,7 +297,6 @@ func New(opts Options) *Controller {
 		systemPrompt:           opts.SystemPrompt,
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
-		host:                   opts.Host,
 		commands:               atomic.Pointer[[]command.Command]{},
 		skills:                 opts.Skills,
 		allSkills:              opts.AllSkills,
@@ -317,8 +315,7 @@ func New(opts Options) *Controller {
 		balanceKey:             opts.BalanceKey,
 		balanceClient:          opts.BalanceClient,
 		jobs:                   opts.Jobs,
-		reg:                    opts.Registry,
-		pluginCtx:              pluginCtx,
+		mcp:                    newMcpManager(opts.Host, opts.Registry, pluginCtx),
 		workspaceRoot:          opts.WorkspaceRoot,
 		approval:               newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
@@ -2343,7 +2340,7 @@ func (c *Controller) Balance(ctx context.Context) (*billing.Balance, error) {
 
 // Host returns the running MCP host (nil when no plugins), for frontends that
 // list servers / resolve MCP prompts.
-func (c *Controller) Host() *plugin.Host { return c.host }
+func (c *Controller) Host() *plugin.Host { return c.mcp.hostRef() }
 
 // Commands returns the loaded custom slash commands.
 func (c *Controller) Commands() []command.Command {
@@ -2382,9 +2379,7 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 			Render:      func(args []string) string { return cmd.Render(args) },
 		})
 	}
-	if c.reg != nil {
-		c.reg.Add(command.NewSlashCommandTool(entries))
-	}
+	c.mcp.registerTool(command.NewSlashCommandTool(entries))
 	cmdSlice := cmds
 	c.commands.Store(&cmdSlice)
 	return loadErr
@@ -2492,9 +2487,11 @@ func (c *Controller) ConnectMCPServer(e config.PluginEntry) (int, error) {
 	return c.connectMCPServer(e)
 }
 
+// connectMCPServer expands an entry's ${VARS}, applies the known-server
+// overrides scoped to the workspace, and connects it live via the mcp manager.
 func (c *Controller) connectMCPServer(e config.PluginEntry) (int, error) {
 	exp := e.ExpandedPlugin()
-	return c.connectMCPSpec(plugin.ApplyKnownOverrides(plugin.Spec{
+	return c.mcp.connectSpec(plugin.ApplyKnownOverrides(plugin.Spec{
 		Name:    exp.Name,
 		Type:    exp.Type,
 		Command: exp.Command,
@@ -2503,32 +2500,6 @@ func (c *Controller) connectMCPServer(e config.PluginEntry) (int, error) {
 		URL:     exp.URL,
 		Headers: exp.Headers,
 	}, c.WorkspaceRoot()))
-}
-
-func (c *Controller) connectMCPSpec(s plugin.Spec) (int, error) {
-	if c.host == nil {
-		c.host = plugin.NewHost()
-	}
-	tools, err := c.host.Add(c.pluginCtx, s)
-	if err != nil {
-		if !plugin.IsServerAlreadyConnected(err) {
-			return 0, err
-		}
-		toolsCtx, cancel := context.WithTimeout(c.pluginCtx, 5*time.Second)
-		defer cancel()
-		tools, err = c.host.ToolsFor(toolsCtx, s.Name)
-		if err != nil {
-			return 0, err
-		}
-	}
-	if c.reg != nil {
-		c.reg.ResumePrefix(plugin.ToolPrefix(s.Name))
-		c.reg.RemovePrefix(plugin.ToolPrefix(s.Name))
-		for _, t := range tools {
-			c.reg.Add(t)
-		}
-	}
-	return len(tools), nil
 }
 
 // ImportMCPEntries persists selected MCP entries and attempts to connect them
@@ -2558,7 +2529,7 @@ func (c *Controller) ImportMCPEntries(entries []config.PluginEntry) (total, adde
 		return 0, 0, 0, 0, 0, 0, err
 	}
 	for _, e := range entries {
-		if c.host != nil && containsString(c.host.ServerNames(), e.Name) {
+		if c.mcp.hasServer(e.Name) {
 			skipped++
 			continue
 		}
@@ -2569,15 +2540,6 @@ func (c *Controller) ImportMCPEntries(entries []config.PluginEntry) (total, adde
 		connected++
 	}
 	return len(entries), added, updated, connected, failed, skipped, nil
-}
-
-func containsString(ss []string, want string) bool {
-	for _, s := range ss {
-		if s == want {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Controller) ConfiguredMCPNames() []string {
@@ -2598,10 +2560,8 @@ func (c *Controller) DisconnectedMCPNames() []string {
 		return nil
 	}
 	connected := map[string]bool{}
-	if c.host != nil {
-		for _, name := range c.host.ServerNames() {
-			connected[name] = true
-		}
+	for _, name := range c.mcp.serverNames() {
+		connected[name] = true
 	}
 	var names []string
 	for _, p := range cfg.Plugins {
@@ -2631,22 +2591,15 @@ func (c *Controller) ConnectConfiguredMCPServer(name string) (int, error) {
 // the config save fails). A server declared in .mcp.json disconnects for this
 // session but returns on the next start, since that file isn't ours to edit.
 func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error) {
-	if c.host != nil {
-		if prefix, ok := c.host.Remove(name); ok {
-			disconnected = true
-			if c.reg != nil {
-				c.reg.RemovePrefix(prefix)
-			}
-		}
-	}
+	disconnected = c.mcp.disconnect(name)
 	cfg, lerr := config.Load()
 	if lerr != nil {
 		return disconnected, lerr
 	}
 	inConfig := cfg.RemovePlugin(name)
 	if inConfig {
-		if !disconnected && c.reg != nil {
-			c.reg.RemovePrefix(plugin.ToolPrefix(name))
+		if !disconnected {
+			c.mcp.removeToolPrefix(name)
 		}
 		if serr := cfg.Save(); serr != nil {
 			return disconnected, serr
@@ -2663,18 +2616,10 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 // on the next session start, or now via ConnectConfiguredMCPServer (the "on").
 // Reports whether a live server was actually disconnected.
 func (c *Controller) DisconnectMCPServer(name string) bool {
-	disconnected := false
-	if c.host != nil {
-		if prefix, ok := c.host.Remove(name); ok {
-			disconnected = true
-			if c.reg != nil {
-				c.reg.RemovePrefix(prefix)
-			}
-		}
-	}
+	disconnected := c.mcp.disconnect(name)
 	removedPlaceholder := 0
-	if !disconnected && c.reg != nil {
-		removedPlaceholder = c.reg.RemovePrefix(plugin.ToolPrefix(name))
+	if !disconnected {
+		removedPlaceholder = c.mcp.removeToolPrefix(name)
 	}
 	return disconnected || removedPlaceholder > 0
 }
@@ -2684,11 +2629,7 @@ func (c *Controller) DisconnectMCPServer(name string) bool {
 // shared client stays alive for sibling tabs, while this session's registry drops
 // the server's provider-visible tools before the next turn.
 func (c *Controller) UnregisterMCPServerTools(name string) bool {
-	if c.reg == nil {
-		return false
-	}
-	c.reg.SuspendPrefix(plugin.ToolPrefix(name))
-	return true
+	return c.mcp.suspendToolPrefix(name)
 }
 
 // Label returns the human-readable model label, e.g. "deepseek-flash".

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -502,16 +502,13 @@ func (c *Controller) skillByName(name string) (skill.Skill, bool) {
 // the MCP server (an async prompts/get). found is false when no such prompt
 // exists; err carries a fetch failure. Honours ctx.
 func (c *Controller) MCPPrompt(ctx context.Context, input string) (sent string, found bool, err error) {
-	if c.host == nil {
-		return "", false, nil
-	}
 	fields := strings.Fields(input)
 	if len(fields) == 0 {
 		return "", false, nil
 	}
 	name := strings.TrimPrefix(fields[0], "/")
 
-	prompts := c.host.Prompts()
+	prompts := c.mcp.prompts()
 	idx := -1
 	for i := range prompts {
 		if prompts[i].Name == name {

--- a/internal/control/mcp.go
+++ b/internal/control/mcp.go
@@ -1,0 +1,171 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"reasonix/internal/plugin"
+	"reasonix/internal/tool"
+)
+
+// mcpManager owns the session's live tool/plugin surface: the MCP plugin Host
+// (live server connections), the tool Registry the executor reads each turn, and
+// the session-scoped context a hot-added stdio server binds its subprocess to.
+// Like approvalManager it holds the live plumbing behind its own lock, off c.mu —
+// the Controller keeps the config-facing orchestration (persisting reasonix.toml
+// on add/remove, building specs from entries).
+//
+// mu guards the lazy host creation and host-pointer reads. The registry is
+// internally thread-safe (its own RWMutex) and pluginCtx is write-once, so the
+// lock is held only briefly — never across the host's network/subprocess I/O.
+// host is either injected at construction (the desktop shared-host path) or
+// created lazily on the first connect; once set it never reverts to nil.
+type mcpManager struct {
+	mu        sync.Mutex
+	host      *plugin.Host
+	reg       *tool.Registry
+	pluginCtx context.Context
+}
+
+func newMcpManager(host *plugin.Host, reg *tool.Registry, pluginCtx context.Context) mcpManager {
+	return mcpManager{host: host, reg: reg, pluginCtx: pluginCtx}
+}
+
+// hostRef returns the live plugin host (nil until one is injected or lazily
+// created), for the SessionAPI Host() accessor and the nil-safe read wrappers.
+func (m *mcpManager) hostRef() *plugin.Host {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.host
+}
+
+// connectSpec connects (or attaches to an already-connected) MCP server and
+// registers its tools, replacing any prior tools under the same prefix. Returns
+// the tool count. The host's network/subprocess I/O runs off mu.
+func (m *mcpManager) connectSpec(s plugin.Spec) (int, error) {
+	m.mu.Lock()
+	if m.host == nil {
+		m.host = plugin.NewHost()
+	}
+	host, ctx, reg := m.host, m.pluginCtx, m.reg
+	m.mu.Unlock()
+
+	tools, err := host.Add(ctx, s)
+	if err != nil {
+		if !plugin.IsServerAlreadyConnected(err) {
+			return 0, err
+		}
+		toolsCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		tools, err = host.ToolsFor(toolsCtx, s.Name)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if reg != nil {
+		reg.ResumePrefix(plugin.ToolPrefix(s.Name))
+		reg.RemovePrefix(plugin.ToolPrefix(s.Name))
+		for _, t := range tools {
+			reg.Add(t)
+		}
+	}
+	return len(tools), nil
+}
+
+// disconnect drops a live server and its tools from the registry. Reports whether
+// a live server was removed.
+func (m *mcpManager) disconnect(name string) bool {
+	host := m.hostRef()
+	if host == nil {
+		return false
+	}
+	prefix, ok := host.Remove(name)
+	if ok {
+		if reg := m.registry(); reg != nil {
+			reg.RemovePrefix(prefix)
+		}
+	}
+	return ok
+}
+
+// removeToolPrefix drops a server's tools from the registry without touching the
+// host — the placeholder / not-connected path. Returns the number removed.
+func (m *mcpManager) removeToolPrefix(name string) int {
+	reg := m.registry()
+	if reg == nil {
+		return 0
+	}
+	return reg.RemovePrefix(plugin.ToolPrefix(name))
+}
+
+// suspendToolPrefix hides a server's tools from this session's registry while a
+// shared host keeps the client alive for sibling sessions.
+func (m *mcpManager) suspendToolPrefix(name string) bool {
+	reg := m.registry()
+	if reg == nil {
+		return false
+	}
+	reg.SuspendPrefix(plugin.ToolPrefix(name))
+	return true
+}
+
+// registerTool adds a built-in tool to the live registry (e.g. the slash-command
+// tool rebuilt by ReloadCommands). No-op when no registry is bound.
+func (m *mcpManager) registerTool(t tool.Tool) {
+	if reg := m.registry(); reg != nil {
+		reg.Add(t)
+	}
+}
+
+// registry returns the shared tool registry under mu (write-once, but read under
+// the lock for consistency with the host pointer).
+func (m *mcpManager) registry() *tool.Registry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.reg
+}
+
+// serverNames lists the live server names (nil when no host is connected).
+func (m *mcpManager) serverNames() []string {
+	if h := m.hostRef(); h != nil {
+		return h.ServerNames()
+	}
+	return nil
+}
+
+// hasServer reports whether a server is live.
+func (m *mcpManager) hasServer(name string) bool {
+	for _, n := range m.serverNames() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// prompts lists the live MCP prompts (nil when no host is connected).
+func (m *mcpManager) prompts() []plugin.Prompt {
+	if h := m.hostRef(); h != nil {
+		return h.Prompts()
+	}
+	return nil
+}
+
+// failures lists the recorded MCP startup failures (nil when no host).
+func (m *mcpManager) failures() []plugin.Failure {
+	if h := m.hostRef(); h != nil {
+		return h.Failures()
+	}
+	return nil
+}
+
+// readResource reads an MCP resource. Errors when no host is connected.
+func (m *mcpManager) readResource(ctx context.Context, server, uri string) (string, error) {
+	h := m.hostRef()
+	if h == nil {
+		return "", fmt.Errorf("no MCP servers connected")
+	}
+	return h.ReadResource(ctx, server, uri)
+}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -111,10 +111,8 @@ func (c *Controller) detectRefs(line string) []ref {
 
 func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 	known := map[string]bool{}
-	if c.host != nil {
-		for _, n := range c.host.ServerNames() {
-			known[n] = true
-		}
+	for _, n := range c.mcp.serverNames() {
+		known[n] = true
 	}
 
 	var refs []ref
@@ -438,7 +436,7 @@ func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bo
 	for _, r := range refs {
 		switch r.kind {
 		case refResource:
-			text, err := c.host.ReadResource(ctx, r.server, r.uri)
+			text, err := c.mcp.readResource(ctx, r.server, r.uri)
 			if err != nil {
 				errs = append(errs, "@"+r.raw+" — "+err.Error())
 				continue

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -614,17 +614,18 @@ func (c *Controller) hookListText() string {
 }
 
 func (c *Controller) mcpListText() string {
-	if c.host == nil || (len(c.host.ServerNames()) == 0 && len(c.host.Failures()) == 0) {
+	names := c.mcp.serverNames()
+	if len(names) == 0 && len(c.mcp.failures()) == 0 {
 		return i18n.M.ListMcpNone
 	}
 	var b strings.Builder
-	if len(c.host.ServerNames()) > 0 {
+	if len(names) > 0 {
 		b.WriteString(i18n.M.ListMcpHeader + "\n")
-		for _, name := range c.host.ServerNames() {
+		for _, name := range names {
 			fmt.Fprintf(&b, "  %s\n", name)
 		}
 	}
-	if failures := c.host.Failures(); len(failures) > 0 {
+	if failures := c.mcp.failures(); len(failures) > 0 {
 		if b.Len() > 0 {
 			b.WriteString("\n")
 		}


### PR DESCRIPTION
## What

Third in the series continuing the `Controller` god-object decomposition (after `memoryManager` #5113 and `checkpointManager` #5116). Carve the **live tool/plugin surface** out into an `mcpManager` collaborator.

`mcpManager` (new `internal/control/mcp.go`) owns the MCP plugin `Host` (live server connections), the tool `Registry` the executor reads each turn, and the session-scoped context a hot-added stdio server binds its subprocess to — behind its own lock, off `c.mu`. Following the `approvalManager` precedent, **only the live plumbing moves**; the Controller keeps the config-facing orchestration (persisting `reasonix.toml` on add/remove, building specs from entries).

## Bonus: closes a latent race

The lazy `c.host = plugin.NewHost()` creation in `connectMCPSpec` was previously an **unsynchronized field write**. It now happens under the manager's lock — and since the host pointer, once set, never reverts to nil, every read is safe. (The registry was already internally thread-safe; `pluginCtx` is write-once.) The lock is never held across the host's network/subprocess I/O.

## Changes

- **New** `internal/control/mcp.go` — the manager (`connectSpec` / `disconnect` / `removeToolPrefix` / `suspendToolPrefix` / `registerTool` / `serverNames` / `hasServer` / `prompts` / `failures` / `readResource` / `hostRef`).
- `controller.go` drops the `host` / `reg` / `pluginCtx` fields for a single `mcp mcpManager`; `AddMCPServer` / `RemoveMCPServer` / `DisconnectMCPServer` / `ImportMCPEntries` / `ConnectConfiguredMCPServer` / `ReloadCommands` / `Host` delegate. The dead `containsString` helper is removed in favor of `hasServer`.
- `input.go` (`MCPPrompt`), `refs.go` (server-name detection + `readResource`), `slash.go` (`/mcp` listing) read through the manager.

## Why it's safe

- **Public `SessionAPI` surface is unchanged** → no frontend touched (incl. the desktop shared-host path, which injects `opts.Host` — the manager takes it at construction). Behavior-preserving: each MCP connect/disconnect/import path keeps its exact semantics.
- `controller.go`: **3417 → 3358 lines, 43 → 41 fields**.

## Verification

- `gofmt` clean, `go vet ./internal/control/...` clean, `go build ./...` ok.
- `go test -race ./internal/control/...` green (MCP add/remove/registry tests).
- Full `go test ./...` — **52 packages, all green**. Desktop module (separate cgo module) covered by CI's `desktop` job.