### PR TITLE
fix(cli): show current version in upgrade success message

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -160,8 +160,12 @@ func upgradeCommand(args []string, version string) int {
 		return 1
 	}
 
-	fmt.Printf(i18n.M.UpgradeSuccessFmt+"\n", cur, latest)
+	fmt.Println(upgradeSuccessMessage(cur, latest))
 	return 0
+}
+
+func upgradeSuccessMessage(cur, latest string) string {
+	return fmt.Sprintf(i18n.M.UpgradeSuccessFmt, cur, latest)
 }
 
 // normalizeVersion returns v as valid semver ("vX.Y.Z") or ok=false for dev.

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -160,7 +160,7 @@ func upgradeCommand(args []string, version string) int {
 		return 1
 	}
 
-	fmt.Printf(i18n.M.UpgradeSuccessFmt+"\n", latest)
+	fmt.Printf(i18n.M.UpgradeSuccessFmt+"\n", cur, latest)
 	return 0
 }
 

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -58,6 +59,25 @@ func TestVerifyChecksum(t *testing.T) {
 			t.Error("expected not-found error")
 		}
 	})
+}
+
+func TestUpgradeSuccessMessageIncludesCurrentAndLatestVersions(t *testing.T) {
+	cur := "v1.10.0"
+	latest := "v1.11.0"
+
+	got := upgradeSuccessMessage(cur, latest)
+	if !strings.Contains(got, cur) {
+		t.Fatalf("success message %q does not include current version %q", got, cur)
+	}
+	if !strings.Contains(got, latest) {
+		t.Fatalf("success message %q does not include latest version %q", got, latest)
+	}
+	if strings.Index(got, cur) > strings.Index(got, latest) {
+		t.Fatalf("success message %q should report current version before latest version", got)
+	}
+	if strings.Contains(got, "%!") {
+		t.Fatalf("success message %q contains a missing fmt argument marker", got)
+	}
 }
 
 func TestExtractFromTarGz(t *testing.T) {


### PR DESCRIPTION

## Summary

```
[LINUX USE EN US]
$ reasonix update
Checking for updates…
Current: v1.10.0 → Latest: v1.11.0
Downloading reasonix-linux-amd64.tar.gz (7.8 MiB)…
Verifying checksum…
Replacing binary…
Updated v1.11.0 → %!s(MISSING)
```

## Verification

```
[DARWIN USE ZH CN]
$ reasonix update
正在检查更新…
当前：v0.0.1 → 最新：v1.11.0
正在下载 reasonix-darwin-arm64.tar.gz（7.3 MiB）…
正在校验 SHA256…
正在替换二进制文件…
已更新 v0.0.1 → v1.11.0
```

## Cache impact

NO 
