### PR TITLE
refactor(control): extract skillSet from Controller

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -68,16 +68,16 @@ type Controller struct {
 	sink     event.Sink
 	policy   permission.Policy
 
-	label         string
-	modelRef      string
-	systemPrompt  string
-	sessionDir    string
-	commands      atomic.Pointer[[]command.Command]
-	skills        []skill.Skill
-	allSkills     []skill.Skill
-	skillStore    *skill.Store
-	allSkillStore *skill.Store
-	hooks         *hook.Runner // session hook runner; nil-safe (no hooks configured)
+	label        string
+	modelRef     string
+	systemPrompt string
+	sessionDir   string
+	commands     atomic.Pointer[[]command.Command]
+	// skills owns the session's discovered skills (enabled subset, full set, and
+	// the reloadable stores) — the skills slice of the Capabilities concern. See
+	// skill.go.
+	skills skillSet
+	hooks  *hook.Runner // session hook runner; nil-safe (no hooks configured)
 	// memory owns the loaded memory snapshot, the pending turn-tail notes queue,
 	// and write serialization behind its own locks, off c.mu — so a memory-panel
 	// save never stalls an approval or status poll. See memory.go.
@@ -298,10 +298,7 @@ func New(opts Options) *Controller {
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
 		commands:               atomic.Pointer[[]command.Command]{},
-		skills:                 opts.Skills,
-		allSkills:              opts.AllSkills,
-		skillStore:             opts.SkillStore,
-		allSkillStore:          opts.AllSkillStore,
+		skills:                 newSkillSet(opts.Skills, opts.AllSkills, opts.SkillStore, opts.AllSkillStore),
 		hooks:                  opts.Hooks,
 		memory:                 newMemoryManager(opts.Memory),
 		cleanup:                opts.Cleanup,
@@ -2389,22 +2386,13 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 // When a live Store is available, scan it on demand so skills installed during
 // this session appear without rewriting the cache-stable system prompt.
 func (c *Controller) Skills() []skill.Skill {
-	if c.skillStore != nil {
-		return c.skillStore.List()
-	}
-	return c.skills
+	return c.skills.list()
 }
 
 // AllSkills returns every discoverable skill, including disabled ones, for
 // management surfaces that need to re-enable a hidden skill.
 func (c *Controller) AllSkills() []skill.Skill {
-	if c.allSkillStore != nil {
-		return c.allSkillStore.List()
-	}
-	if len(c.allSkills) > 0 {
-		return c.allSkills
-	}
-	return c.skills
+	return c.skills.listAll()
 }
 
 // DisabledSkills returns all discoverable skills that are disabled in config.

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -479,22 +479,10 @@ func (c *Controller) RunSkill(input string) (sent string, found bool) {
 		return "", false
 	}
 	name := strings.TrimPrefix(fields[0], "/")
-	if sk, ok := c.skillByName(name); ok {
+	if sk, ok := c.skills.byName(name); ok {
 		return skill.Render(sk, strings.Join(fields[1:], " ")), true
 	}
 	return "", false
-}
-
-func (c *Controller) skillByName(name string) (skill.Skill, bool) {
-	if c.skillStore != nil {
-		return c.skillStore.Read(name)
-	}
-	for _, sk := range c.skills {
-		if sk.Name == name {
-			return sk, true
-		}
-	}
-	return skill.Skill{}, false
 }
 
 // MCPPrompt resolves a "/mcp__server__prompt args…" line: it maps the positional

--- a/internal/control/skill.go
+++ b/internal/control/skill.go
@@ -1,0 +1,62 @@
+package control
+
+import "reasonix/internal/skill"
+
+// skillSet owns the session's discovered skills: the enabled subset surfaced to
+// the model, the full set (including config-disabled ones) for management
+// surfaces, and the optional reloadable stores that supersede the
+// construction-time snapshots. It is the skills slice of the Capabilities concern
+// (alongside mcpManager).
+//
+// No lock: every field is set once at construction and only read thereafter.
+// Skills are discovered at boot and never mutated in place — SetSkillEnabled
+// persists a config preference and relies on a controller rebuild to take effect.
+type skillSet struct {
+	enabled  []skill.Skill // discovered + enabled skills (the live store supersedes when set)
+	all      []skill.Skill // every discoverable skill, including config-disabled ones
+	store    *skill.Store  // reloadable enabled-skill store; nil falls back to enabled
+	allStore *skill.Store  // reloadable all-skill store; nil falls back to all/enabled
+}
+
+func newSkillSet(enabled, all []skill.Skill, store, allStore *skill.Store) skillSet {
+	return skillSet{enabled: enabled, all: all, store: store, allStore: allStore}
+}
+
+// list returns the enabled skills, preferring the live store.
+func (s *skillSet) list() []skill.Skill {
+	if s.store != nil {
+		return s.store.List()
+	}
+	return s.enabled
+}
+
+// listAll returns every discoverable skill (including disabled), preferring the
+// live store, for management surfaces that re-enable a hidden skill.
+func (s *skillSet) listAll() []skill.Skill {
+	if s.allStore != nil {
+		return s.allStore.List()
+	}
+	if len(s.all) > 0 {
+		return s.all
+	}
+	return s.enabled
+}
+
+// byName resolves an enabled skill by name, preferring the live store.
+func (s *skillSet) byName(name string) (skill.Skill, bool) {
+	if s.store != nil {
+		return s.store.Read(name)
+	}
+	for _, sk := range s.enabled {
+		if sk.Name == name {
+			return sk, true
+		}
+	}
+	return skill.Skill{}, false
+}
+
+// discovered returns the construction-time enabled snapshot (not the live store),
+// for the /skills listing which reflects what was discovered at boot.
+func (s *skillSet) discovered() []skill.Skill {
+	return s.enabled
+}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -581,12 +581,13 @@ func memoryOneLine(s string) string {
 }
 
 func (c *Controller) skillListText() string {
-	if len(c.skills) == 0 {
+	skills := c.skills.discovered()
+	if len(skills) == 0 {
 		return i18n.M.ListSkillsNone
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, i18n.M.ListSkillsHeaderFmt+"\n", len(c.skills))
-	for _, s := range c.skills {
+	fmt.Fprintf(&b, i18n.M.ListSkillsHeaderFmt+"\n", len(skills))
+	for _, s := range skills {
 		tag := ""
 		if s.RunAs == "subagent" {
 			tag = " 🧬"


### PR DESCRIPTION
## What

Fourth in the series continuing the `Controller` god-object decomposition (after `memoryManager` #5113, `checkpointManager` #5116, `mcpManager` #5123). Group the discovered-skill fields into a `skillSet` value type — the **skills slice of the `Capabilities` concern**, pairing with the `mcpManager` from the prior step.

`skillSet` (new `internal/control/skill.go`) owns the enabled subset, the full set (including config-disabled skills), and the optional reloadable stores that supersede the construction-time snapshots, behind `list` / `listAll` / `byName` / `discovered`.

This is a **smaller, lower-risk win than the stateful managers**: skills are discovered at boot and never mutated in place, so there is no lock to move — it consolidates four related fields and their lookup logic rather than disentangling shared mutable state. It rounds out the Capabilities decomposition.

## Changes

- **New** `internal/control/skill.go` — the `skillSet` type.
- `controller.go` drops `skills` / `allSkills` / `skillStore` / `allSkillStore` for a single `skills skillSet`; `Skills` / `AllSkills` delegate.
- `input.go`: `RunSkill` resolves via `c.skills.byName`; the now-redundant `skillByName` method is removed.
- `slash.go`: the `/skills` listing reads the construction-time snapshot via `discovered()` so its output is **byte-for-byte unchanged** (it intentionally shows the boot snapshot, not the live store that `Skills()` prefers — preserved exactly).

## Why it's safe

- **Public `SessionAPI` surface is unchanged** → no frontend touched.
- `controller.go`: **3358 → 3346 lines, 41 → 38 fields**.

## Verification

- `gofmt` clean, `go vet ./internal/control/...` clean, `go build ./...` ok (every `skillSet` method has a caller — no `unused` lint).
- `go test -race ./internal/control/...` green; full `go test ./...` — **52 packages, all green**.