### PR TITLE
Fix single-surface tab persistence / 修复单界面布局隐藏会话持久化

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -464,12 +464,17 @@ func (a *App) restoreOrBuildTabs() {
 	// Load i18n from the first available config.
 	// Prefer DesktopLanguage (desktop UI setting) over Language (CLI setting),
 	// so the user's language choice in desktop settings takes effect.
-	if cfg, err := config.Load(); err == nil {
+	startupCfg, cfgErr := config.Load()
+	if cfgErr == nil {
+		cfg := startupCfg
 		lang := cfg.DesktopLanguage()
 		if lang == "" {
 			lang = cfg.Language
 		}
 		i18n.DetectLanguage(lang)
+	}
+	if cfgErr != nil || singleSurfaceLayoutStyle(startupCfg.DesktopLayoutStyle()) {
+		f = singleSurfaceTabsFile(f)
 	}
 
 	if len(f.Tabs) > 0 {
@@ -512,6 +517,7 @@ func (a *App) restoreOrBuildTabs() {
 				a.activeTabID = ordered[0]
 			}
 		}
+		a.saveTabsLocked()
 		a.mu.Unlock()
 		for _, tab := range toBuild {
 			a.startTabControllerBuild(tab)
@@ -1941,7 +1947,9 @@ func (a *App) openFallbackRuntime(target fallbackRuntimeTarget) error {
 		topicID = topic.ID
 	}
 	var err error
-	if scope == "global" {
+	if a.singleSurfaceLayoutEnabled() {
+		_, err = a.ActivateTopic(scope, root, topicID, "")
+	} else if scope == "global" {
 		_, err = a.OpenGlobalTab(topicID)
 	} else {
 		_, err = a.OpenProjectTab(root, topicID)
@@ -2781,6 +2789,69 @@ func (a *App) RemoveWorkspace(dir string) error {
 		return fmt.Errorf("workspace path is required")
 	}
 	dir = normalizeProjectRoot(dir)
+
+	var closeTabs []*WorkspaceTab
+	var closeDetached []*WorkspaceTab
+	var fallback *WorkspaceTab
+	a.mu.Lock()
+	for _, tab := range a.tabs {
+		if tabInWorkspace(tab, dir) && tab.hasActiveRuntimeWork() {
+			a.mu.Unlock()
+			return fmt.Errorf("workspace has running sessions; stop them before removing")
+		}
+	}
+	for _, tab := range a.detachedSessions {
+		if tabInWorkspace(tab, dir) && tab.hasActiveRuntimeWork() {
+			a.mu.Unlock()
+			return fmt.Errorf("workspace has running sessions; stop them before removing")
+		}
+	}
+	for id, tab := range a.tabs {
+		if !tabInWorkspace(tab, dir) {
+			continue
+		}
+		closeTabs = append(closeTabs, tab)
+		delete(a.tabs, id)
+		a.removeTabOrderLocked(id)
+		if a.activeTabID == id {
+			a.activeTabID = ""
+		}
+	}
+	for key, tab := range a.detachedSessions {
+		if !tabInWorkspace(tab, dir) {
+			continue
+		}
+		closeDetached = append(closeDetached, tab)
+		delete(a.detachedSessions, key)
+	}
+	if len(a.tabs) == 0 {
+		fallback = a.createTabEntry("global", globalTabWorkspaceRoot(), "")
+		fallback.TopicTitle = "Global"
+		fallback.sink = &tabEventSink{tabID: fallback.ID, app: a, ctx: a.ctx}
+		a.tabs[fallback.ID] = fallback
+		a.tabOrder = append(a.tabOrder, fallback.ID)
+		a.activeTabID = fallback.ID
+	} else if a.activeTabID == "" {
+		if ordered := a.orderedTabIDsLocked(); len(ordered) > 0 {
+			a.activeTabID = ordered[0]
+		}
+	}
+	a.saveTabsLocked()
+	a.mu.Unlock()
+
+	for _, tab := range closeTabs {
+		if tab.Ctrl != nil && !tab.ReadOnly {
+			_ = tab.Ctrl.Snapshot()
+		}
+		a.closeTabRuntime(tab)
+	}
+	for _, tab := range closeDetached {
+		a.closeTabRuntime(tab)
+	}
+	if fallback != nil {
+		a.startTabControllerBuild(fallback)
+	}
+
 	forgetWorkspace(dir)
 	if err := removeProject(dir); err != nil {
 		return err
@@ -2866,11 +2937,24 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	meta, err := a.OpenProjectTab(dir, topic.ID)
+	var meta TabMeta
+	if a.singleSurfaceLayoutEnabled() {
+		meta, err = a.ActivateTopic("project", dir, topic.ID, "")
+	} else {
+		meta, err = a.OpenProjectTab(dir, topic.ID)
+	}
 	if err != nil {
 		return "", err
 	}
 	return meta.WorkspaceRoot, nil
+}
+
+func (a *App) singleSurfaceLayoutEnabled() bool {
+	cfg, _, err := a.loadDesktopUserConfigForView()
+	if err != nil {
+		return true
+	}
+	return singleSurfaceLayoutStyle(cfg.DesktopLayoutStyle())
 }
 
 // HistoryMessage is one prior turn, for the frontend to repopulate its transcript

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -877,8 +877,10 @@ export default function App() {
     closeTab,
     reorderTabs,
     openTopicSession,
+    activateTopic,
     syncActiveTab,
     ensureBlankTab,
+    ensureBlankSurface,
   } = useController();
   const { locale, setPref: setLocalePref } = useI18n();
   const t = useT();
@@ -895,6 +897,7 @@ export default function App() {
   const [settingsTarget, setSettingsTarget] = useState<SettingsTab | null>(null);
   const [settingsFocus, setSettingsFocus] = useState<SettingsInitialFocus | null>(null);
   const [desktopLayoutStyle, setDesktopLayoutStyle] = useState<DesktopLayoutStyle>("workbench");
+  const singleSurfaceLayout = desktopLayoutStyle === "workbench" || desktopLayoutStyle === "creation";
   const [startupUpdateChecksEnabled, setStartupUpdateChecksEnabled] = useState<boolean | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -1617,12 +1620,16 @@ export default function App() {
   }, [activeTab?.scope, activeTab?.workspaceRoot]);
 
   const openBlankSession = useCallback(async (scope: string, workspaceRoot: string) => {
-    await ensureBlankTab(scope, scope === "project" ? workspaceRoot : "");
+    if (singleSurfaceLayout) {
+      await ensureBlankSurface(scope, scope === "project" ? workspaceRoot : "");
+    } else {
+      await ensureBlankTab(scope, scope === "project" ? workspaceRoot : "");
+    }
     setProjectRevision((value) => value + 1);
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
     setTranscriptRevealSignal((signal) => signal + 1);
-  }, [ensureBlankTab, refreshTabMetas]);
+  }, [ensureBlankSurface, ensureBlankTab, refreshTabMetas, singleSurfaceLayout]);
 
   useEffect(() => {
     void refreshTabMetas();
@@ -2144,7 +2151,9 @@ export default function App() {
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string, sessionPath?: string) => {
     closeTransientOverlays();
     setSidebarImDetailConnectionId("");
-    if (sessionPath) {
+    if (singleSurfaceLayout) {
+      await activateTopic(scope, workspaceRoot, topicId, sessionPath || "");
+    } else if (sessionPath) {
       await openTopicSession(scope, workspaceRoot, topicId, sessionPath);
     } else if (scope === "global") {
       await openGlobalTab(topicId);
@@ -2154,7 +2163,7 @@ export default function App() {
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
     setTranscriptRevealSignal((signal) => signal + 1);
-  }, [closeTransientOverlays, openGlobalTab, openProjectTab, openTopicSession, refreshTabMetas]);
+  }, [activateTopic, closeTransientOverlays, openGlobalTab, openProjectTab, openTopicSession, refreshTabMetas, singleSurfaceLayout]);
 
   const openSidebarImConnectionSession = useCallback(async (connection: SidebarImConnection) => {
     const target = sidebarImSessionTarget(connection);
@@ -2165,15 +2174,21 @@ export default function App() {
     setSidebarImDetailConnectionId("");
     try {
       if (connection.sessionSource === "auto" && target.kind === "path") {
-        const tab = await ensureBlankTab(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "");
+        const tab = singleSurfaceLayout
+          ? await ensureBlankSurface(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "")
+          : await ensureBlankTab(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "");
         await openChannelSession(target.value, tab.id);
       } else if (target.kind === "path") {
-        const tab = await ensureBlankTab(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "");
+        const tab = singleSurfaceLayout
+          ? await ensureBlankSurface(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "")
+          : await ensureBlankTab(connection.scope, connection.scope === "project" ? connection.workspaceRoot : "");
         await resumeSession(target.value, tab.id);
       } else if (connection.scope === "project") {
-        await openProjectTab(connection.workspaceRoot, target.value);
+        if (singleSurfaceLayout) await activateTopic("project", connection.workspaceRoot, target.value);
+        else await openProjectTab(connection.workspaceRoot, target.value);
       } else {
-        await openGlobalTab(target.value);
+        if (singleSurfaceLayout) await activateTopic("global", "", target.value);
+        else await openGlobalTab(target.value);
       }
       await refreshTabMetas();
       setTabRevealSignal((value) => value + 1);
@@ -2183,7 +2198,7 @@ export default function App() {
       console.warn("bot sidebar open failed", err);
       showToast(t("sidebar.imOpenFailed", { name: connection.title }));
     }
-  }, [ensureBlankTab, openChannelSession, openGlobalTab, openProjectTab, refreshTabMetas, resumeSession, showToast, t]);
+  }, [activateTopic, ensureBlankSurface, ensureBlankTab, openChannelSession, openGlobalTab, openProjectTab, refreshTabMetas, resumeSession, showToast, singleSurfaceLayout, t]);
 
   // History drawer: project menus can open a scoped saved-session list. Idle row
   // clicks resume; running row clicks only preview through PreviewSession.
@@ -2207,24 +2222,30 @@ export default function App() {
 
   const onResumeSession = useCallback(
     async (session: SessionMeta) => {
-      if (state.running) return;
+      if (state.running && !singleSurfaceLayout) return;
       const scope = session.scope || (session.workspaceRoot ? "project" : "global");
       try {
         let targetTab: TabMeta;
         if (isChannelSession(session)) {
-          targetTab = await ensureBlankTab(scope === "project" ? "project" : "global", scope === "project" ? session.workspaceRoot || "" : "");
+          targetTab = singleSurfaceLayout
+            ? await ensureBlankSurface(scope === "project" ? "project" : "global", scope === "project" ? session.workspaceRoot || "" : "")
+            : await ensureBlankTab(scope === "project" ? "project" : "global", scope === "project" ? session.workspaceRoot || "" : "");
           await openChannelSession(session.path, targetTab.id);
         } else if (scope === "project" && session.workspaceRoot && session.topicId) {
-          targetTab = await openProjectTab(session.workspaceRoot, session.topicId);
+          targetTab = singleSurfaceLayout
+            ? await activateTopic("project", session.workspaceRoot, session.topicId, session.path)
+            : await openProjectTab(session.workspaceRoot, session.topicId);
         } else if (scope === "global" && session.topicId) {
-          targetTab = await openGlobalTab(session.topicId);
+          targetTab = singleSurfaceLayout
+            ? await activateTopic("global", "", session.topicId, session.path)
+            : await openGlobalTab(session.topicId);
         } else {
           throw new Error(scope === "global" && !session.topicId
             ? t("history.failedOpenSession")
             : (session.topicId ? "Missing workspaceRoot" : t("history.failedOpenSession")));
         }
         setHistView(null);
-        if (!isChannelSession(session)) {
+        if (!isChannelSession(session) && !singleSurfaceLayout) {
           await resumeSession(session.path, targetTab.id);
         }
         await refreshTabMetas();
@@ -2240,7 +2261,7 @@ export default function App() {
         }
       }
     },
-    [ensureBlankTab, openChannelSession, openGlobalTab, openProjectTab, refreshTabMetas, state.running, resumeSession, t, showToast],
+    [activateTopic, ensureBlankSurface, ensureBlankTab, openChannelSession, openGlobalTab, openProjectTab, refreshTabMetas, state.running, resumeSession, singleSurfaceLayout, t, showToast],
   );
 
   // Command palette: ⌘K / Ctrl+K opens a fuzzy navigator over commands and
@@ -3336,7 +3357,9 @@ export default function App() {
       {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
 
       <HeartbeatPanel open={heartbeatOpen} onClose={() => setHeartbeatOpen(false)} onOpenTopic={(scope, workspaceRoot, topicId) => {
-        if (scope === "project" && workspaceRoot) {
+        if (singleSurfaceLayout) {
+          activateTopic(scope, workspaceRoot, topicId);
+        } else if (scope === "project" && workspaceRoot) {
           openProjectTab(workspaceRoot, topicId);
         } else {
           openGlobalTab(topicId);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -306,6 +306,8 @@ export interface AppBindings {
   OpenGlobalTab(topicID: string): Promise<TabMeta>;
   OpenTopicSession(scope: string, workspaceRoot: string, topicID: string, sessionPath: string): Promise<TabMeta>;
   EnsureBlankTab(scope: string, workspaceRoot: string): Promise<TabMeta>;
+  ActivateTopic(scope: string, workspaceRoot: string, topicID: string, sessionPath: string): Promise<TabMeta>;
+  EnsureBlankSurface(scope: string, workspaceRoot: string): Promise<TabMeta>;
   SetActiveTab(tabID: string): Promise<void>;
   ReorderTabs(tabIDs: string[]): Promise<void>;
   CloseTab(tabID: string): Promise<void>;
@@ -537,7 +539,7 @@ function bridgeBreadcrumb(method: string): string {
     return `mcp ${method}`;
   if (/^(AddSkillPath|RemoveSkillPath|RefreshSkills|SetSkillEnabled|AcceptSkillSuggestion)/.test(method))
     return `skill ${method}`;
-  if (/^(OpenProjectTab|OpenGlobalTab|EnsureBlankTab|SetActiveTab|CloseTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace)/.test(method))
+  if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|EnsureBlankSurface|SetActiveTab|CloseTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace)/.test(method))
     return `nav ${method}`;
   return "";
 }
@@ -2818,6 +2820,20 @@ function makeMockApp(): AppBindings {
       }
       const topic = await this.CreateTopic(targetScope, targetRoot, "");
       return targetScope === "global" ? this.OpenGlobalTab(topic.id) : this.OpenProjectTab(targetRoot, topic.id);
+    },
+    async ActivateTopic(scope: string, workspaceRoot: string, topicID: string, sessionPath: string) {
+      const tab = sessionPath
+        ? await this.OpenTopicSession(scope, workspaceRoot, topicID, sessionPath)
+        : scope === "project"
+          ? await this.OpenProjectTab(workspaceRoot, topicID)
+          : await this.OpenGlobalTab(topicID);
+      mockTabs = mockTabs.filter((item) => item.id === tab.id).map((item) => ({ ...item, active: true }));
+      return { ...mockTabs[0] };
+    },
+    async EnsureBlankSurface(scope: string, workspaceRoot: string) {
+      const tab = await this.EnsureBlankTab(scope, workspaceRoot);
+      mockTabs = mockTabs.filter((item) => item.id === tab.id).map((item) => ({ ...item, active: true }));
+      return { ...mockTabs[0] };
     },
     async SetActiveTab(_tabID: string) {
       setMockActiveTab(_tabID);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1536,6 +1536,16 @@ export function useController() {
     return meta;
   }, [confirmBackendActiveTab, dispatchTo, loadSessionDataForTab]);
 
+  const activateTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string, sessionPath = ""): Promise<TabMeta> => {
+    const meta = await app.ActivateTopic(scope, workspaceRoot, topicId, sessionPath);
+    for (const id of Array.from(statesRef.current.keys())) {
+      if (id !== meta.id) statesRef.current.delete(id);
+    }
+    setActiveTabId(meta.id);
+    await loadSessionDataForTab(meta.id, true);
+    return meta;
+  }, [loadSessionDataForTab]);
+
   // Ensure a blank tab exists for the given scope — reuses an existing one
   // or creates a new tab, then loads its session data.
   const ensureBlankTab = useCallback(async (scope: string, workspaceRoot: string): Promise<TabMeta> => {
@@ -1547,6 +1557,16 @@ export function useController() {
     void loadSessionDataForTab(meta.id, !statesRef.current.has(meta.id), "open-topic");
     return meta;
   }, [confirmBackendActiveTab, dispatchTo, loadSessionDataForTab]);
+
+  const ensureBlankSurface = useCallback(async (scope: string, workspaceRoot: string): Promise<TabMeta> => {
+    const meta = await app.EnsureBlankSurface(scope, workspaceRoot);
+    for (const id of Array.from(statesRef.current.keys())) {
+      if (id !== meta.id) statesRef.current.delete(id);
+    }
+    setActiveTabId(meta.id);
+    await loadSessionDataForTab(meta.id, true);
+    return meta;
+  }, [loadSessionDataForTab]);
 
   const closeTab = useCallback(async (tabId: string) => {
     try {
@@ -1570,7 +1590,7 @@ export function useController() {
     newSession, clearSession, listSessions, listTrashedSessions, resumeSession, openChannelSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort, setTokenMode,
     fetchMemory, remember, forget, saveDoc,
-    switchTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, closeTab, reorderTabs,
+    switchTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, activateTopic, ensureBlankSurface, closeTab, reorderTabs,
     syncActiveTab: syncActiveTabFromBackend,
   };
 }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1749,7 +1749,13 @@ func (a *App) SetDesktopAppearance(theme, style string) error {
 // SetDesktopLayoutStyle updates only the desktop layout style. It does not
 // rebuild the active controller and must stay out of provider-visible requests.
 func (a *App) SetDesktopLayoutStyle(style string) error {
-	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopLayoutStyle(style) })
+	if err := a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopLayoutStyle(style) }); err != nil {
+		return err
+	}
+	if singleSurfaceLayoutStyle(style) {
+		return a.applySingleSurfaceTabPolicy()
+	}
+	return nil
 }
 
 // SetDesktopCheckUpdates updates only the desktop startup update-check

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1105,6 +1105,37 @@ func (a *App) OpenTopicSession(scope, workspaceRoot, topicID, sessionPath string
 	return a.openTopicTab(scope, workspaceRoot, topicID, validPath)
 }
 
+// ActivateTopic opens a topic into the single visible conversation surface used
+// by layouts without a tab strip. It delegates the actual open/reuse behavior to
+// the classic tab path, then prunes every non-active visible tab so historical
+// clicks do not accumulate hidden startup work.
+func (a *App) ActivateTopic(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
+	var meta TabMeta
+	var err error
+	if strings.TrimSpace(sessionPath) != "" {
+		meta, err = a.OpenTopicSession(scope, workspaceRoot, topicID, sessionPath)
+	} else if strings.TrimSpace(scope) == "project" {
+		meta, err = a.OpenProjectTab(workspaceRoot, topicID)
+	} else {
+		meta, err = a.OpenGlobalTab(topicID)
+	}
+	if err != nil {
+		return TabMeta{}, err
+	}
+	return a.keepOnlyVisibleTab(meta.ID)
+}
+
+// EnsureBlankSurface mirrors EnsureBlankTab for no-tab-strip layouts: after
+// creating or reusing a blank session, it removes other visible tabs while
+// preserving running runtimes as detached background sessions.
+func (a *App) EnsureBlankSurface(scope, workspaceRoot string) (TabMeta, error) {
+	meta, err := a.EnsureBlankTab(scope, workspaceRoot)
+	if err != nil {
+		return TabMeta{}, err
+	}
+	return a.keepOnlyVisibleTab(meta.ID)
+}
+
 func tabMatchesTopicTarget(tab *WorkspaceTab, scope, workspaceRoot, topicID string) bool {
 	if tab == nil || tab.Scope != scope || tab.TopicID != topicID {
 		return false
@@ -1113,6 +1144,12 @@ func tabMatchesTopicTarget(tab *WorkspaceTab, scope, workspaceRoot, topicID stri
 		return true
 	}
 	return normalizeProjectRoot(tab.WorkspaceRoot) == normalizeProjectRoot(workspaceRoot)
+}
+
+func tabInWorkspace(tab *WorkspaceTab, workspaceRoot string) bool {
+	return tab != nil &&
+		tab.Scope == "project" &&
+		normalizeProjectRoot(tab.WorkspaceRoot) == normalizeProjectRoot(workspaceRoot)
 }
 
 // EnsureBlankTab activates the existing blank tab for the target scope, or
@@ -1468,6 +1505,89 @@ func (a *App) CloseTab(tabID string) error {
 		tab.sink.clearContext() // stop further emissions (nil ctx -> Emit becomes no-op)
 	}
 	return nil
+}
+
+func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
+	a.mu.Lock()
+	active := a.tabs[tabID]
+	if active == nil {
+		a.mu.Unlock()
+		return TabMeta{}, fmt.Errorf("tab %q not found", tabID)
+	}
+	a.activeTabID = tabID
+	removed := make([]*WorkspaceTab, 0, len(a.tabs)-1)
+	for id, tab := range a.tabs {
+		if id == tabID {
+			continue
+		}
+		removed = append(removed, tab)
+		delete(a.tabs, id)
+		a.removeTabOrderLocked(id)
+	}
+	a.tabOrder = []string{tabID}
+	a.saveTabsLocked()
+	meta := a.tabMeta(active, true)
+	a.mu.Unlock()
+
+	for _, tab := range removed {
+		a.removeVisibleTabRuntime(tab)
+	}
+	a.emitProjectTreeChanged()
+	return enrichTabMeta(meta), nil
+}
+
+func (a *App) applySingleSurfaceTabPolicy() error {
+	a.mu.RLock()
+	tabID := a.activeTabID
+	if tabID == "" || a.tabs[tabID] == nil {
+		for _, id := range a.tabOrder {
+			if a.tabs[id] != nil {
+				tabID = id
+				break
+			}
+		}
+		if tabID == "" {
+			for id := range a.tabs {
+				tabID = id
+				break
+			}
+		}
+	}
+	a.mu.RUnlock()
+	if tabID == "" {
+		return nil
+	}
+	_, err := a.keepOnlyVisibleTab(tabID)
+	return err
+}
+
+func (a *App) removeVisibleTabRuntime(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	if tab.Ctrl != nil && !tab.ReadOnly {
+		_ = tab.Ctrl.Snapshot()
+	}
+	if tab.Ctrl != nil && tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
+		return
+	}
+	a.closeTabRuntime(tab)
+}
+
+func (a *App) closeTabRuntime(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	if tab.Ctrl != nil {
+		tab.Ctrl.SetSessionPath("") // future snapshots become no-ops
+		a.quiesceTabAutosave(tab)
+		tab.Ctrl.Cancel()
+		tab.Ctrl.Close()
+		a.releaseTabSharedHost(tab)
+	}
+	if tab.sink != nil {
+		tab.sink.clearContext()
+	}
 }
 
 // buildTabController assembles a controller for a tab in the background, the
@@ -2065,6 +2185,31 @@ type desktopTabEntry struct {
 type desktopTabsFile struct {
 	Tabs      []desktopTabEntry `json:"tabs"`
 	ActiveTab string            `json:"activeTab"`
+}
+
+func singleSurfaceLayoutStyle(style string) bool {
+	switch strings.ToLower(strings.TrimSpace(style)) {
+	case "workbench", "creation":
+		return true
+	default:
+		return false
+	}
+}
+
+func singleSurfaceTabsFile(f desktopTabsFile) desktopTabsFile {
+	if len(f.Tabs) <= 1 {
+		return f
+	}
+	chosen := f.Tabs[0]
+	if active := strings.TrimSpace(f.ActiveTab); active != "" {
+		for _, entry := range f.Tabs {
+			if entry.ID == active {
+				chosen = entry
+				break
+			}
+		}
+	}
+	return desktopTabsFile{Tabs: []desktopTabEntry{chosen}, ActiveTab: chosen.ID}
 }
 
 func desktopConfigDir() string {

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -91,6 +91,149 @@ func TestSetActiveTabDoesNotResetPlannerSession(t *testing.T) {
 	}
 }
 
+func TestSingleSurfaceTabsFileKeepsActiveEntry(t *testing.T) {
+	f := desktopTabsFile{
+		Tabs: []desktopTabEntry{
+			{ID: "a", Scope: "global", TopicID: "topic-a"},
+			{ID: "b", Scope: "project", WorkspaceRoot: "/tmp/project", TopicID: "topic-b"},
+			{ID: "c", Scope: "global", TopicID: "topic-c"},
+		},
+		ActiveTab: "b",
+	}
+
+	got := singleSurfaceTabsFile(f)
+	if len(got.Tabs) != 1 || got.Tabs[0].ID != "b" || got.ActiveTab != "b" {
+		t.Fatalf("single-surface tabs = %+v, want only active b", got)
+	}
+}
+
+func TestKeepOnlyVisibleTabDetachesRunningHiddenTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "running.jsonl")
+	runner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: runner, SessionDir: dir, SessionPath: path, Label: "running", Sink: event.Discard})
+	running := &WorkspaceTab{
+		ID:            "running",
+		Scope:         "global",
+		WorkspaceRoot: globalTabWorkspaceRoot(),
+		SessionPath:   path,
+		Ctrl:          ctrl,
+		Ready:         true,
+		sink:          &tabEventSink{tabID: "running"},
+		disabledMCP:   map[string]ServerView{},
+	}
+	target := &WorkspaceTab{ID: "target", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{"running": running, "target": target},
+		tabOrder:         []string{"running", "target"},
+		activeTabID:      "running",
+		detachedSessions: map[string]*WorkspaceTab{},
+	}
+
+	ctrl.Submit("block")
+	<-runner.started
+	if _, err := app.keepOnlyVisibleTab("target"); err != nil {
+		t.Fatalf("keepOnlyVisibleTab: %v", err)
+	}
+	assertTabIDs(t, app.ListTabs(), "target")
+	if !ctrl.Running() {
+		t.Fatal("single-surface pruning cancelled a running controller")
+	}
+	if _, ok := app.detachedSessions[sessionRuntimeKey(path)]; !ok {
+		t.Fatalf("detached runtime missing for %q", path)
+	}
+	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "target" {
+		t.Fatalf("persisted tabs after pruning = %+v, want only target", got)
+	}
+
+	close(runner.release)
+	waitNotRunning(t, ctrl)
+	ctrl.Close()
+}
+
+func TestRemoveWorkspaceDropsVisibleTabsAndPersistedEntries(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", Scope: "project", WorkspaceRoot: projectRoot, TopicID: "topic-project", Ready: true, disabledMCP: map[string]ServerView{}},
+			"global":  {ID: "global", Scope: "global", WorkspaceRoot: globalTabWorkspaceRoot(), TopicID: "topic-global", Ready: true, disabledMCP: map[string]ServerView{}},
+		},
+		tabOrder:         []string{"project", "global"},
+		activeTabID:      "project",
+		detachedSessions: map[string]*WorkspaceTab{},
+	}
+	app.mu.Lock()
+	app.saveTabsLocked()
+	app.mu.Unlock()
+
+	if err := app.RemoveWorkspace(projectRoot); err != nil {
+		t.Fatalf("RemoveWorkspace: %v", err)
+	}
+	assertTabIDs(t, app.ListTabs(), "global")
+	if got := app.ListWorkspaces(); len(got) != 0 {
+		t.Fatalf("workspaces after remove = %+v, want none", got)
+	}
+	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "global" {
+		t.Fatalf("persisted tabs after workspace remove = %+v, want only global", got)
+	}
+}
+
+func TestRemoveWorkspaceRejectsRunningProjectRuntime(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir project sessions: %v", err)
+	}
+	path := filepath.Join(dir, "running.jsonl")
+	runner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: runner, SessionDir: dir, SessionPath: path, Label: "running", Sink: event.Discard})
+	project := &WorkspaceTab{
+		ID:            "project",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       "topic-project",
+		SessionPath:   path,
+		Ctrl:          ctrl,
+		Ready:         true,
+		sink:          &tabEventSink{tabID: "project"},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": project,
+			"global":  {ID: "global", Scope: "global", WorkspaceRoot: globalTabWorkspaceRoot(), Ready: true, disabledMCP: map[string]ServerView{}},
+		},
+		tabOrder:         []string{"project", "global"},
+		activeTabID:      "project",
+		detachedSessions: map[string]*WorkspaceTab{},
+	}
+
+	ctrl.Submit("block")
+	<-runner.started
+	if err := app.RemoveWorkspace(projectRoot); err == nil {
+		t.Fatal("RemoveWorkspace succeeded with a running project session")
+	}
+	if got := app.ListWorkspaces(); len(got) != 1 || got[0].Path != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("workspaces after rejected remove = %+v, want project retained", got)
+	}
+
+	close(runner.release)
+	waitNotRunning(t, ctrl)
+	ctrl.Close()
+}
+
 func TestListTabsRepairsStaleOrderWithoutRacing(t *testing.T) {
 	app := testAppWithOrderedTabs(t, "a", "a", "b", "c")
 	app.tabOrder = []string{"a"}


### PR DESCRIPTION
## Summary

- Add single-surface tab activation APIs for workbench and creation layouts so opening a topic or saved session keeps only one visible tab persisted.
- Prune persisted tab state on startup for single-surface layouts, preventing previously clicked hidden sessions from being restored and built on launch.
- Clean up workspace removal so project tabs and detached project runtimes cannot restore a removed folder on the next startup, while rejecting removal if that workspace still has active runtime work.
- Keep classic layout multi-tab behavior unchanged.

Closes #5022

Related PRs: #5121, #5099. Those cover the removed-workspace reappearance path; this PR also fixes the workbench/creation hidden-tab accumulation that causes slow startup.

## Verification

- `cd desktop && go test ./...`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend test:typecheck`
- `pnpm --dir desktop/frontend test`
- `git diff --check`

## Cache impact

Cache-impact: none. This is limited to desktop tab persistence, workspace cleanup, and frontend routing for desktop layouts. It does not change provider-visible prompts, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.
