### PR TITLE
fix: prevent deadlock between complete_step and todo_write (#5128)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1801,9 +1801,14 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
-			if err == nil {
-				rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, t.ReadOnly())
-				a.evidence.Record(rec)
+			// Record even failed complete_step receipts: a model that tried to
+			// sign off with evidence but hit a technical mismatch (command
+			// quoting, etc.) acted in good faith and shouldn't be deadlocked
+			// when it falls back to todo_write. See #5128.
+			success := err == nil
+			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), success, t.ReadOnly())
+			a.evidence.Record(rec)
+			if success {
 				a.advanceCanonicalTodo(rec.Step)
 			}
 		} else {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -532,7 +532,7 @@ func TestEvidenceFlowRejectsUncitedCommand(t *testing.T) {
 	}
 
 	got := toolResult(a.session, "complete_step")
-	if !strings.Contains(got, "no matching successful bash receipt") {
+	if !strings.Contains(got, "has no matching successful receipt") {
 		t.Fatalf("complete_step result = %q, want the uncited command rejected", got)
 	}
 	if strings.Contains(got, "host-verified") {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -447,6 +447,12 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		if hasSuccessfulCompleteStepForTodo(receipts, index, current) {
 			continue
 		}
+		// If a complete_step was attempted for this step but failed on a
+		// technicality (e.g. command mismatch), the model acted in good faith.
+		// Allow the todo_write completion so a mismatch doesn't cause deadlock.
+		if hasAttemptedCompleteStepForTodo(receipts, index, current) {
+			continue
+		}
 		missing = append(missing, TodoStepMatch{
 			Found:      true,
 			Index:      index,
@@ -711,8 +717,34 @@ func hasSuccessfulCompleteStepForTodo(receipts []Receipt, index int, current []T
 			if sameTodoMatch(current[index-1], *r.TodoStep) {
 				return true
 			}
-			// Content changed: allow the index/text fallback only when old and
-			// new overlap, so a replaced todo can't reuse an old receipt.
+			if !todoContentRelates(current[index-1], *r.TodoStep) {
+				continue
+			}
+		}
+		match := matchTodoStep(r.Step, current)
+		if match.Found && match.Index == index {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAttemptedCompleteStepForTodo is like hasSuccessfulCompleteStepForTodo but
+// accepts failed complete_step receipts too. A model that attempted to sign off
+// with evidence but hit a technical mismatch (e.g. command quoting) acted in
+// good faith and shouldn't be deadlocked. See #5128.
+func hasAttemptedCompleteStepForTodo(receipts []Receipt, index int, current []TodoItem) bool {
+	for _, r := range receipts {
+		if r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" {
+			continue
+		}
+		if r.TodoStep != nil && r.TodoStep.Found {
+			if index < 1 || index > len(current) {
+				continue
+			}
+			if sameTodoMatch(current[index-1], *r.TodoStep) {
+				return true
+			}
 			if !todoContentRelates(current[index-1], *r.TodoStep) {
 				continue
 			}

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -281,13 +281,16 @@ func TestLedgerRequiresCompleteStepForNewCompletedTodos(t *testing.T) {
 		t.Fatalf("missing = %+v, want only Add parser", missing)
 	}
 
+	// A failed complete_step that matches the step still authorizes completion:
+	// the model acted in good faith and shouldn't deadlock on a technicality
+	// like command quoting. See #5128.
 	ledger.Record(Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	missing, hasBaseline = ledger.UnverifiedCompletedTodos(current)
 	if !hasBaseline {
 		t.Fatal("expected prior todo_write baseline after failed complete_step")
 	}
-	if len(missing) != 1 || missing[0].Content != "Add parser" {
-		t.Fatalf("failed complete_step should not authorize completion, missing = %+v", missing)
+	if len(missing) != 0 {
+		t.Fatalf("attempted complete_step should authorize completion despite failure, missing = %+v", missing)
 	}
 
 	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "Add parser"})

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -151,7 +151,8 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 				if ledger.HasFailedCommand(command) {
 					return 0, 0, fmt.Errorf("evidence %d: verification command %q ran but exited non-zero, so it can't prove the step; if the non-zero exit is itself the expected proof (e.g. a file is gone), re-run it so it succeeds (append \"|| true\") and sign off again", i+1, command)
 				}
-				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful bash receipt in this turn%s", i+1, command, receiptHint("commands run this turn", ledger.SuccessfulCommands(5)))
+				hint := allCommandHints(ctx, ledger)
+				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful receipt — cite the command exactly as it ran in the session%s", i+1, command, hint)
 			}
 			hostVerified++
 		case "diff":
@@ -337,6 +338,53 @@ func receiptHint(label string, items []string) string {
 		}
 	}
 	return fmt.Sprintf("; %s: %q — cite one as it actually ran, or run the check now", label, items)
+}
+
+// allCommandHints builds a combined hint from both the per-turn ledger and the
+// full session history, so the model can self-correct a mismatched citation.
+func allCommandHints(ctx context.Context, ledger *evidence.Ledger) string {
+	seen := map[string]bool{}
+	var cmds []string
+	if ledger != nil {
+		for _, c := range ledger.SuccessfulCommands(8) {
+			if !seen[c] {
+				seen[c] = true
+				cmds = append(cmds, c)
+			}
+		}
+	}
+	if msgs, ok := evidence.SessionMessagesFromContext(ctx); ok {
+		failed := failedCallIDs(msgs)
+		for _, msg := range msgs {
+			for _, tc := range msg.ToolCalls {
+				if failed[tc.ID] {
+					continue
+				}
+				c := extractCommandFromCall(tc.Name, tc.Arguments)
+				if c == "" || seen[c] {
+					continue
+				}
+				seen[c] = true
+				cmds = append(cmds, c)
+				if len(cmds) >= 12 {
+					break
+				}
+			}
+			if len(cmds) >= 12 {
+				break
+			}
+		}
+	}
+	if len(cmds) == 0 {
+		return ""
+	}
+	// Truncate long entries for readability.
+	for i, c := range cmds {
+		if len(c) > 80 {
+			cmds[i] = c[:80] + "…"
+		}
+	}
+	return fmt.Sprintf("; commands that ran: %q — pick the matching one and retry complete_step", cmds)
 }
 
 func firstWord(s string) string {

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -67,19 +67,24 @@ func TestTodoWriteAllowsInitialCompletedWithoutBaseline(t *testing.T) {
 	}
 }
 
-func TestTodoWriteIgnoresFailedCompleteStepReceipt(t *testing.T) {
+func TestTodoWriteAllowsCompletionAfterAttemptedCompleteStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
 		Success:  true,
 		Todos:    []evidence.TodoItem{{Content: "Add parser", Status: "in_progress"}},
 	})
+	// A failed complete_step for the same step still authorizes completion —
+	// the model acted in good faith and shouldn't deadlock. See #5128.
 	ledger.Record(evidence.Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step should not authorize new completion, got %v", err)
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("attempted complete_step should authorize completion: %v", err)
+	}
+	if !strings.Contains(out, "1 total") {
+		t.Fatalf("unexpected output: %s", out)
 	}
 }


### PR DESCRIPTION
Two fixes for the circular gate that freezes the task list when a complete_step is rejected on a technicality like command quoting:

1. Better error messages in verifyCommandFromSession: when a command citation doesn't match, the error now lists ALL commands from both the per-turn ledger and session history, formatted so the model can self-correct with the exact string.

2. Allow attempted (failed) complete_step to authorize todo_write completions: hasAttemptedCompleteStepForTodo accepts any complete_step receipt (not just successful), recognizing the model acted in good faith. A technical mismatch won't deadlock the list.

Tests updated: TestLedgerRequiresCompleteStepForNewCompletedTodos, TestTodoWriteAllowsCompletionAfterAttemptedCompleteStep, TestEvidenceFlowRejectsUncitedCommand (error message format).

## Summary

-

## Verification

-

## Cache impact

Cache-impact: low
Cache-guard: go test ./internal/agent/ ./internal/evidence/ ./internal/tool/builtin/ ./internal/control/
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
