### PR TITLE
Harden single-surface tab pruning / 加固单界面会话剪枝

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2810,6 +2810,10 @@ func (a *App) RemoveWorkspace(dir string) error {
 		if !tabInWorkspace(tab, dir) {
 			continue
 		}
+		if tab.Ctrl != nil && !tab.ReadOnly {
+			_ = tab.Ctrl.Snapshot()
+		}
+		a.markTabRemovedLocked(tab)
 		closeTabs = append(closeTabs, tab)
 		delete(a.tabs, id)
 		a.removeTabOrderLocked(id)
@@ -2840,9 +2844,6 @@ func (a *App) RemoveWorkspace(dir string) error {
 	a.mu.Unlock()
 
 	for _, tab := range closeTabs {
-		if tab.Ctrl != nil && !tab.ReadOnly {
-			_ = tab.Ctrl.Snapshot()
-		}
 		a.closeTabRuntime(tab)
 	}
 	for _, tab := range closeDetached {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1542,9 +1542,12 @@ export function useController() {
       if (id !== meta.id) statesRef.current.delete(id);
     }
     setActiveTabId(meta.id);
-    await loadSessionDataForTab(meta.id, true);
+    activeTabIdRef.current = meta.id;
+    confirmBackendActiveTab(meta.id);
+    dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
+    void loadSessionDataForTab(meta.id, true, "open-topic");
     return meta;
-  }, [loadSessionDataForTab]);
+  }, [confirmBackendActiveTab, dispatchTo, loadSessionDataForTab]);
 
   // Ensure a blank tab exists for the given scope — reuses an existing one
   // or creates a new tab, then loads its session data.
@@ -1564,9 +1567,12 @@ export function useController() {
       if (id !== meta.id) statesRef.current.delete(id);
     }
     setActiveTabId(meta.id);
-    await loadSessionDataForTab(meta.id, true);
+    activeTabIdRef.current = meta.id;
+    confirmBackendActiveTab(meta.id);
+    dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
+    void loadSessionDataForTab(meta.id, true, "open-topic");
     return meta;
-  }, [loadSessionDataForTab]);
+  }, [confirmBackendActiveTab, dispatchTo, loadSessionDataForTab]);
 
   const closeTab = useCallback(async (tabId: string) => {
     try {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1749,10 +1749,17 @@ func (a *App) SetDesktopAppearance(theme, style string) error {
 // SetDesktopLayoutStyle updates only the desktop layout style. It does not
 // rebuild the active controller and must stay out of provider-visible requests.
 func (a *App) SetDesktopLayoutStyle(style string) error {
-	if err := a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopLayoutStyle(style) }); err != nil {
+	normalized := ""
+	if err := a.applyConfigOnly(func(c *config.Config) error {
+		if err := c.SetDesktopLayoutStyle(style); err != nil {
+			return err
+		}
+		normalized = c.DesktopLayoutStyle()
+		return nil
+	}); err != nil {
 		return err
 	}
-	if singleSurfaceLayoutStyle(style) {
+	if singleSurfaceLayoutStyle(normalized) {
 		return a.applySingleSurfaceTabPolicy()
 	}
 	return nil

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -35,19 +35,22 @@ import (
 // memory, permissions) scoped to a workspace root, so multiple projects and
 // topics can be active concurrently without interfering.
 type WorkspaceTab struct {
-	ID            string             // stable random id
-	Scope         string             // "project" | "global"
-	WorkspaceRoot string             // project root dir (empty for global)
-	SharedHostKey string             // opaque key for the shared plugin host (set by buildTabController)
-	TopicID       string             // topic within the project
-	TopicTitle    string             // display title
-	SessionPath   string             // exact .jsonl file this tab continues
-	ReadOnly      bool               // true for external channel transcripts opened for browsing
-	Ctrl          control.SessionAPI // nil while booting / on error
-	Label         string             // model label (for the tab badge)
-	Ready         bool               // true once boot.Build completes
-	StartupErr    string             // build error, surfaced to the frontend
-	sink          *tabEventSink      // routes events with this tab's ID
+	ID              string             // stable random id
+	Scope           string             // "project" | "global"
+	WorkspaceRoot   string             // project root dir (empty for global)
+	SharedHostKey   string             // opaque key for the shared plugin host (set by buildTabController)
+	TopicID         string             // topic within the project
+	TopicTitle      string             // display title
+	SessionPath     string             // exact .jsonl file this tab continues
+	ReadOnly        bool               // true for external channel transcripts opened for browsing
+	Ctrl            control.SessionAPI // nil while booting / on error
+	Label           string             // model label (for the tab badge)
+	Ready           bool               // true once boot.Build completes
+	StartupErr      string             // build error, surfaced to the frontend
+	sink            *tabEventSink      // routes events with this tab's ID
+	buildCancel     context.CancelFunc // cancels in-flight boot for tabs removed before Ready
+	buildGeneration uint64             // identifies the current in-flight build
+	removed         bool               // set when the visible tab is pruned/closed before build completes
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
@@ -1457,6 +1460,9 @@ func (a *App) CloseTab(tabID string) error {
 	if tab.Ctrl != nil && !tab.ReadOnly {
 		_ = tab.Ctrl.Snapshot()
 	}
+	if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
+		a.markTabRemovedLocked(tab)
+	}
 
 	ordered := a.orderedTabIDsLocked()
 	closedIndex := -1
@@ -1520,6 +1526,12 @@ func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
 		if id == tabID {
 			continue
 		}
+		if tab.Ctrl != nil && !tab.ReadOnly {
+			_ = tab.Ctrl.Snapshot()
+		}
+		if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
+			a.markTabRemovedLocked(tab)
+		}
 		removed = append(removed, tab)
 		delete(a.tabs, id)
 		a.removeTabOrderLocked(id)
@@ -1571,7 +1583,49 @@ func (a *App) removeVisibleTabRuntime(tab *WorkspaceTab) {
 	if tab.Ctrl != nil && tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
 		return
 	}
+	a.markTabRemoved(tab)
 	a.closeTabRuntime(tab)
+}
+
+func (a *App) markTabRemoved(tab *WorkspaceTab) {
+	a.mu.Lock()
+	a.markTabRemovedLocked(tab)
+	a.mu.Unlock()
+}
+
+func (a *App) markTabRemovedLocked(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	tab.removed = true
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+		tab.buildCancel = nil
+	}
+}
+
+func (a *App) tabRemovedForBuild(tab *WorkspaceTab) bool {
+	if tab == nil {
+		return true
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return tab.removed || a.tabs[tab.ID] != tab
+}
+
+func (a *App) clearTabBuildCancel(tab *WorkspaceTab, generation uint64, cancel context.CancelFunc) {
+	if cancel == nil {
+		return
+	}
+	defer cancel()
+	if tab == nil {
+		return
+	}
+	a.mu.Lock()
+	if tab.buildGeneration == generation {
+		tab.buildCancel = nil
+	}
+	a.mu.Unlock()
 }
 
 func (a *App) closeTabRuntime(tab *WorkspaceTab) {
@@ -1594,11 +1648,22 @@ func (a *App) closeTabRuntime(tab *WorkspaceTab) {
 // same way buildController works for the single-controller App. On success it
 // wires the controller and flips Ready; on failure it stores StartupErr.
 func (a *App) startTabControllerBuild(tab *WorkspaceTab) {
-	if a.ctx == nil {
-		a.buildTabController(tab)
+	buildCtx, cancel := context.WithCancel(a.bootContext())
+	a.mu.Lock()
+	if tab == nil || tab.removed {
+		a.mu.Unlock()
+		cancel()
 		return
 	}
-	go a.buildTabController(tab)
+	tab.buildGeneration++
+	generation := tab.buildGeneration
+	tab.buildCancel = cancel
+	a.mu.Unlock()
+	if a.ctx == nil {
+		a.buildTabControllerWithContext(tab, loadedTabSession{}, buildCtx, generation, cancel)
+		return
+	}
+	go a.buildTabControllerWithContext(tab, loadedTabSession{}, buildCtx, generation, cancel)
 }
 
 func (a *App) buildTabController(tab *WorkspaceTab) {
@@ -1615,9 +1680,16 @@ func (s loadedTabSession) matches(path string) bool {
 }
 
 func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSession loadedTabSession) {
+	a.buildTabControllerWithContext(tab, loadedSession, a.bootContext(), 0, nil)
+}
+
+func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loadedTabSession, buildCtx context.Context, buildGeneration uint64, buildCancel context.CancelFunc) {
 	defer a.recoverToPending("buildTabController")
+	defer a.clearTabBuildCancel(tab, buildGeneration, buildCancel)
 	wailsCtx := a.ctx
-	buildCtx := a.bootContext()
+	if a.tabRemovedForBuild(tab) {
+		return
+	}
 
 	a.reconcileTabWithPinnedSessionMeta(tab)
 
@@ -1633,6 +1705,10 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		a.mu.Lock()
+		if tab.removed || a.tabs[tab.ID] != tab {
+			a.mu.Unlock()
+			return
+		}
 		tab.StartupErr = err.Error()
 		tab.Ready = true
 		a.mu.Unlock()
@@ -1640,6 +1716,9 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 		return
 	}
 
+	if a.tabRemovedForBuild(tab) {
+		return
+	}
 	if tab.sink != nil {
 		tab.sink.setContext(wailsCtx)
 	}
@@ -1701,6 +1780,10 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 	}
 
 	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return
+	}
 	tab.model = model
 	tab.Label = model
 	a.saveTabsLocked()
@@ -1728,11 +1811,21 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 	})
 	if err != nil {
 		a.mu.Lock()
+		if tab.removed || a.tabs[tab.ID] != tab {
+			a.releaseTabSharedHost(tab)
+			a.mu.Unlock()
+			return
+		}
 		tab.StartupErr = err.Error()
 		tab.Ready = true
 		a.releaseTabSharedHost(tab)
 		a.mu.Unlock()
 		a.emitReady(wailsCtx)
+		return
+	}
+	if a.tabRemovedForBuild(tab) {
+		ctrl.Close()
+		a.releaseTabSharedHost(tab)
 		return
 	}
 
@@ -1807,6 +1900,12 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 	}
 
 	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		ctrl.Close()
+		a.releaseTabSharedHost(tab)
+		return
+	}
 	tab.Ctrl = ctrl
 	tab.Label = ctrl.Label()
 	tab.Ready = true

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -60,6 +60,18 @@ func (s *resetCountingSession) ResetPlannerSession() {
 	s.resets++
 }
 
+type snapshotObservingSession struct {
+	control.SessionAPI
+	onSnapshot func()
+}
+
+func (s *snapshotObservingSession) Snapshot() error {
+	if s.onSnapshot != nil {
+		s.onSnapshot()
+	}
+	return nil
+}
+
 func TestListTabsKeepsExplicitOrderWhenActiveChanges(t *testing.T) {
 	app := testAppWithOrderedTabs(t, "b", "a", "b", "c")
 
@@ -104,6 +116,19 @@ func TestSingleSurfaceTabsFileKeepsActiveEntry(t *testing.T) {
 	got := singleSurfaceTabsFile(f)
 	if len(got.Tabs) != 1 || got.Tabs[0].ID != "b" || got.ActiveTab != "b" {
 		t.Fatalf("single-surface tabs = %+v, want only active b", got)
+	}
+}
+
+func TestSetDesktopLayoutStyleAppliesPolicyAfterWorkspaceAlias(t *testing.T) {
+	app := testAppWithOrderedTabs(t, "b", "a", "b", "c")
+
+	if err := app.SetDesktopLayoutStyle("workspace"); err != nil {
+		t.Fatalf("SetDesktopLayoutStyle(workspace): %v", err)
+	}
+
+	assertTabIDs(t, app.ListTabs(), "b")
+	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "b" || got.ActiveTab != "b" {
+		t.Fatalf("persisted tabs after workspace alias = %+v, want only active b", got)
 	}
 }
 
@@ -155,6 +180,37 @@ func TestKeepOnlyVisibleTabDetachesRunningHiddenTab(t *testing.T) {
 	ctrl.Close()
 }
 
+func TestKeepOnlyVisibleTabCancelsBuildingHiddenTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	cancelled := false
+	building := &WorkspaceTab{
+		ID:          "building",
+		Scope:       "global",
+		Ready:       false,
+		buildCancel: func() { cancelled = true },
+		sink:        &tabEventSink{tabID: "building"},
+		disabledMCP: map[string]ServerView{},
+	}
+	target := &WorkspaceTab{ID: "target", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"building": building, "target": target},
+		tabOrder:    []string{"building", "target"},
+		activeTabID: "building",
+	}
+
+	if _, err := app.keepOnlyVisibleTab("target"); err != nil {
+		t.Fatalf("keepOnlyVisibleTab: %v", err)
+	}
+
+	assertTabIDs(t, app.ListTabs(), "target")
+	if !cancelled {
+		t.Fatal("building tab build was not cancelled")
+	}
+	if !building.removed {
+		t.Fatal("building tab was not marked removed")
+	}
+}
+
 func TestRemoveWorkspaceDropsVisibleTabsAndPersistedEntries(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()
@@ -183,6 +239,37 @@ func TestRemoveWorkspaceDropsVisibleTabsAndPersistedEntries(t *testing.T) {
 	}
 	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "global" {
 		t.Fatalf("persisted tabs after workspace remove = %+v, want only global", got)
+	}
+}
+
+func TestRemoveWorkspaceSnapshotsProjectTabBeforeRemovingBinding(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", Scope: "project", WorkspaceRoot: projectRoot, TopicID: "topic-project", Ready: true, disabledMCP: map[string]ServerView{}},
+			"global":  {ID: "global", Scope: "global", WorkspaceRoot: globalTabWorkspaceRoot(), TopicID: "topic-global", Ready: true, disabledMCP: map[string]ServerView{}},
+		},
+		tabOrder:         []string{"project", "global"},
+		activeTabID:      "project",
+		detachedSessions: map[string]*WorkspaceTab{},
+	}
+	sawBindingDuringSnapshot := false
+	app.tabs["project"].Ctrl = &snapshotObservingSession{
+		SessionAPI: control.New(control.Options{Label: "project"}),
+		onSnapshot: func() {
+			sawBindingDuringSnapshot = app.tabs["project"] != nil
+		},
+	}
+
+	if err := app.RemoveWorkspace(projectRoot); err != nil {
+		t.Fatalf("RemoveWorkspace: %v", err)
+	}
+	if !sawBindingDuringSnapshot {
+		t.Fatal("project tab was removed from app.tabs before Snapshot")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Follow up on bot review findings from #5129 after that PR was merged.
- Keep single-surface frontend activation in sync with backend active-tab bookkeeping, matching the regular tab open paths.
- Apply single-surface tab pruning after layout style alias normalization, so `workspace` is handled the same as `workbench`.
- Snapshot workspace tabs before removing them from `a.tabs`, preserving the session-delete race guard used by `CloseTab`.
- Cancel and mark pruned/closed tabs that are still building, and make `buildTabController` drop completed controllers for tabs that were removed before boot finished.

Related: #5129

## Verification

- `cd desktop && go test . -run 'Test(SetDesktopLayoutStyleAppliesPolicyAfterWorkspaceAlias|KeepOnlyVisibleTab|RemoveWorkspace)' -count=1`
- `cd desktop && go test ./...`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend test:typecheck`
- `pnpm --dir desktop/frontend test`
- `git diff --check`

## Cache impact

Cache-impact: none. This is limited to desktop tab lifecycle, workspace cleanup, and frontend active-tab bookkeeping. It does not change provider-visible prompts, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.
