### PR TITLE
feat(bot): add shared connection-lifecycle primitives (connloop)

### DIFF
--- a/internal/bot/connloop.go
+++ b/internal/bot/connloop.go
@@ -1,0 +1,117 @@
+package bot
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// This file holds the shared connection-lifecycle primitives for the platform
+// adapters (qq / feishu / weixin). Each adapter previously hand-rolled the same
+// "loop forever, attempt a connection, sleep a fixed 5s on failure" shape; two of
+// them used time.Sleep, which ignores ctx and so left a Stop() blocked for the
+// remaining delay. SleepCtx fixes that; RunWithRetry folds the persistent-
+// connection reconnect loop (qq / feishu) into one cancellation-aware,
+// exponentially-backing-off helper.
+
+const (
+	defaultInitialDelay = 1 * time.Second
+	defaultMaxDelay     = 30 * time.Second
+	defaultResetAfter   = 60 * time.Second
+)
+
+// RetryConfig controls the reconnect/error backoff for RunWithRetry. The zero
+// value uses sane defaults (1s → 30s exponential, reset after 60s up).
+type RetryConfig struct {
+	// InitialDelay is the wait after the first failed/closed attempt.
+	InitialDelay time.Duration
+	// MaxDelay caps the exponential backoff.
+	MaxDelay time.Duration
+	// ResetAfter is the minimum time an attempt must stay connected for the
+	// backoff to reset to InitialDelay on its next failure — so a flaky reconnect
+	// escalates while a long-healthy connection that finally drops retries fast.
+	ResetAfter time.Duration
+}
+
+func (c RetryConfig) withDefaults() RetryConfig {
+	if c.InitialDelay <= 0 {
+		c.InitialDelay = defaultInitialDelay
+	}
+	if c.MaxDelay <= 0 {
+		c.MaxDelay = defaultMaxDelay
+	}
+	if c.MaxDelay < c.InitialDelay {
+		c.MaxDelay = c.InitialDelay
+	}
+	if c.ResetAfter <= 0 {
+		c.ResetAfter = defaultResetAfter
+	}
+	return c
+}
+
+// SleepCtx waits for d or until ctx is cancelled, whichever comes first. It
+// returns true if the full duration elapsed and false if ctx was cancelled (or
+// was already cancelled on entry). Adapter loops use it instead of time.Sleep so
+// a Stop() takes effect promptly rather than blocking out the remaining delay.
+func SleepCtx(ctx context.Context, d time.Duration) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if d <= 0 {
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// nextDelay doubles cur, capped at max. The <= 0 guard catches overflow on very
+// large durations.
+func nextDelay(cur, max time.Duration) time.Duration {
+	next := cur * 2
+	if next <= 0 || next > max {
+		next = max
+	}
+	return next
+}
+
+// RunWithRetry drives a persistent-connection adapter. It calls attempt(ctx) —
+// one full connection lifetime that blocks until the connection drops or errors —
+// then waits a cancellation-aware exponential backoff and reconnects, repeating
+// until ctx is cancelled. attempt MUST honor ctx and clean up its own connection
+// before returning; it returns nil for a clean close and an error otherwise (both
+// trigger a reconnect — only ctx cancellation stops the loop).
+func RunWithRetry(ctx context.Context, log *slog.Logger, name string, cfg RetryConfig, attempt func(context.Context) error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	cfg = cfg.withDefaults()
+	delay := cfg.InitialDelay
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		start := time.Now()
+		err := attempt(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			log.Error(name+" connection failed", "err", err)
+		} else {
+			log.Warn(name + " connection closed")
+		}
+		if time.Since(start) >= cfg.ResetAfter {
+			delay = cfg.InitialDelay
+		}
+		if !SleepCtx(ctx, delay) {
+			return
+		}
+		delay = nextDelay(delay, cfg.MaxDelay)
+	}
+}

--- a/internal/bot/connloop_test.go
+++ b/internal/bot/connloop_test.go
@@ -1,0 +1,132 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestSleepCtxCompletes(t *testing.T) {
+	if !SleepCtx(context.Background(), time.Millisecond) {
+		t.Fatal("SleepCtx should return true when the full delay elapses")
+	}
+}
+
+func TestSleepCtxCancelledReturnsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	if SleepCtx(ctx, 10*time.Second) {
+		t.Fatal("SleepCtx should return false when ctx is cancelled mid-wait")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("SleepCtx ignored cancellation: waited %v", elapsed)
+	}
+}
+
+func TestSleepCtxAlreadyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if SleepCtx(ctx, time.Second) {
+		t.Fatal("SleepCtx should return false immediately when ctx is already cancelled")
+	}
+}
+
+func TestNextDelay(t *testing.T) {
+	maxD := 30 * time.Second
+	cases := []struct{ cur, want time.Duration }{
+		{1 * time.Second, 2 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, 30 * time.Second}, // doubling past max → capped
+		{30 * time.Second, 30 * time.Second}, // stays at max
+	}
+	for _, c := range cases {
+		if got := nextDelay(c.cur, maxD); got != c.want {
+			t.Errorf("nextDelay(%v, %v) = %v, want %v", c.cur, maxD, got, c.want)
+		}
+	}
+}
+
+func TestRetryConfigDefaults(t *testing.T) {
+	got := RetryConfig{}.withDefaults()
+	if got.InitialDelay != defaultInitialDelay || got.MaxDelay != defaultMaxDelay || got.ResetAfter != defaultResetAfter {
+		t.Fatalf("zero RetryConfig defaults = %+v", got)
+	}
+	// MaxDelay below InitialDelay is clamped up to InitialDelay.
+	got = RetryConfig{InitialDelay: 5 * time.Second, MaxDelay: time.Second}.withDefaults()
+	if got.MaxDelay != 5*time.Second {
+		t.Fatalf("MaxDelay should clamp up to InitialDelay, got %v", got.MaxDelay)
+	}
+}
+
+func TestRunWithRetryNotCalledWhenContextAlreadyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls atomic.Int32
+	RunWithRetry(ctx, discardLogger(), "test", RetryConfig{InitialDelay: time.Millisecond}, func(context.Context) error {
+		calls.Add(1)
+		return nil
+	})
+	if n := calls.Load(); n != 0 {
+		t.Fatalf("attempt ran %d times for an already-cancelled ctx, want 0", n)
+	}
+}
+
+func TestRunWithRetryRetriesUntilCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		RunWithRetry(ctx, discardLogger(), "test", RetryConfig{InitialDelay: time.Millisecond, MaxDelay: time.Millisecond}, func(context.Context) error {
+			// Stop the loop from inside the attempt once we've reconnected 3 times.
+			if calls.Add(1) >= 3 {
+				cancel()
+			}
+			return errors.New("dropped")
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunWithRetry did not return after ctx cancellation")
+	}
+	if n := calls.Load(); n != 3 {
+		t.Fatalf("attempt ran %d times, want exactly 3", n)
+	}
+}
+
+func TestRunWithRetryCancelDuringBackoffReturnsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		// Large backoff: the only way this returns quickly is if the backoff wait
+		// honors ctx cancellation.
+		RunWithRetry(ctx, discardLogger(), "test", RetryConfig{InitialDelay: 10 * time.Second, MaxDelay: 10 * time.Second}, func(context.Context) error {
+			return errors.New("dropped")
+		})
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunWithRetry ignored cancellation during backoff")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("RunWithRetry took %v to honor cancellation during backoff", elapsed)
+	}
+}


### PR DESCRIPTION
## What

First of a small series unifying the IM adapters' connection handling. The three platform adapters (`qq` / `feishu` / `weixin`) each hand-roll the **same** loop shape — *"loop forever, attempt a connection, wait a fixed 5s on failure"* — with two consistent flaws:

- **qq & weixin** wait with `time.Sleep(5s)`, which **ignores `ctx`** → a `Stop()` stays blocked for the remaining delay and the backoff is uncancellable. (feishu uses `timer + select`, which is correct.)
- **none** of the three backs off exponentially — a flapping gateway hard-reconnects every 5s.

This PR adds the shared primitives the adapters will delegate to. **No existing adapter is changed yet** — that's the follow-ups (qq+weixin, then feishu, then the `getOrCreateSession` TOCTOU). This one is purely additive, so it's zero-risk to land.

## API (`internal/bot/connloop.go`, package `bot`)

- `SleepCtx(ctx, d) bool` — cancellation-aware sleep; returns `false` if `ctx` is cancelled mid-wait. Replaces the raw `time.Sleep` in the adapter loops.
- `RunWithRetry(ctx, log, name, cfg, attempt)` — drives a persistent-connection adapter (qq/feishu): runs `attempt` (one connection lifetime, blocking until drop/error), then reconnects after a cancellation-aware **exponential backoff** (1s→30s, reset after 60s healthy), until `ctx` is cancelled.
- `RetryConfig` with sane zero-value defaults.

> weixin is a *polling* adapter, not persistent-connection, so it will use `SleepCtx` directly (gaining the cancellation fix) rather than `RunWithRetry` — the abstraction is intentionally layered, not one-size-fits-all.

## Verification

- `gofmt`/`go vet` clean; new file fully unit-tested: cancellation (mid-wait + already-cancelled), exact retry count, backoff doubling+cap, config defaults.
- `go test -race ./internal/bot/...` green (new tests + all three existing adapter suites); full `go test ./...` — **52 packages, all green**.