### PR TITLE
refactor(bot): wire qq and weixin onto the connloop primitives

### DIFF
--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -106,26 +106,16 @@ type wsClient struct {
 }
 
 func (a *adapter) gatewayLoop(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
+	bot.RunWithRetry(ctx, a.logger, "qq gateway", bot.RetryConfig{}, func(ctx context.Context) error {
 		token, err := a.getAccessToken(ctx)
 		if err != nil {
-			a.logger.Error("get access token failed", "err", err)
-			time.Sleep(5 * time.Second)
-			continue
+			return err
 		}
-
-		if err := a.connectGateway(ctx, token); err != nil {
-			a.logger.Error("gateway connection failed", "err", err)
-			time.Sleep(5 * time.Second)
-			continue
-		}
-	}
+		// connectGateway blocks for the connection's lifetime, returning on
+		// disconnect or error; RunWithRetry handles the cancellation-aware
+		// backoff and reconnect.
+		return a.connectGateway(ctx, token)
+	})
 }
 
 func (a *adapter) getAccessToken(ctx context.Context) (string, error) {

--- a/internal/bot/weixin/weixin.go
+++ b/internal/bot/weixin/weixin.go
@@ -312,23 +312,21 @@ func ilinkGET(ctx context.Context, baseURL, endpoint string) (map[string]any, er
 // pollLoop 长轮询获取更新。
 func (a *adapter) pollLoop(ctx context.Context) {
 	// 启动时短暂等待让登录完成
-	select {
-	case <-ctx.Done():
+	if !bot.SleepCtx(ctx, 2*time.Second) {
 		return
-	case <-time.After(2 * time.Second):
 	}
 
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		default:
 		}
 
 		updates, err := a.getUpdates(ctx)
 		if err != nil {
 			a.logger.Error("getupdates failed", "err", err)
-			time.Sleep(5 * time.Second)
+			if !bot.SleepCtx(ctx, 5*time.Second) {
+				return
+			}
 			continue
 		}
 
@@ -338,7 +336,9 @@ func (a *adapter) pollLoop(ctx context.Context) {
 
 		// 没有更新时短暂等待
 		if len(updates) == 0 {
-			time.Sleep(500 * time.Millisecond)
+			if !bot.SleepCtx(ctx, 500*time.Millisecond) {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What

Second in the connloop series (after #5136). Replaces the `qq` and `weixin` adapters' hand-rolled connection loops with the shared primitives.

**qq** — `gatewayLoop`'s `for { check ctx; getToken; connectGateway; sleep 5s on error }` becomes a `RunWithRetry` call whose `attempt` is getToken + `connectGateway` (already a blocking, connection-lifetime call that returns on disconnect/error). This swaps the fixed, **ctx-ignoring** `time.Sleep(5s)` for a cancellation-aware **exponential backoff** (1s→30s):
- `Stop()` now takes effect promptly instead of blocking out the remaining delay.
- a flapping gateway no longer hard-reconnects every 5s.
- the two separate error log lines collapse into one `"qq gateway connection failed"` — the underlying `err` (token vs dial) still distinguishes the cause.

**weixin** — `pollLoop` is a *polling* adapter (not persistent-connection), so it keeps its loop and only swaps its three time-based waits (2s startup, 5s on error, 500ms idle) for `SleepCtx`. Same delays and poll semantics, but cancellation is now prompt.

## Verification

- `gofmt`/`go vet` clean; `go build ./...` ok.
- `go test -race ./internal/bot/...` green (both adapters' existing suites unchanged); full `go test ./...` — **52 packages, all green**.

Next: feishu onto `RunWithRetry` (separate PR, since the SDK wrapping is the one that most needs CI to exercise), then the `getOrCreateSession` TOCTOU fix.