### PR TITLE
refactor(bot): wire feishu onto the connloop primitives

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -171,12 +171,7 @@ func (a *adapter) runWebSocket(ctx context.Context) {
 		return
 	}
 	eventHandler := a.newEventDispatcher()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	bot.RunWithRetry(ctx, a.logger, "feishu sdk websocket", bot.RetryConfig{}, func(ctx context.Context) error {
 		opts := []larkws.ClientOption{
 			larkws.WithEventHandler(eventHandler),
 			larkws.WithLogLevel(larkcore.LogLevelError),
@@ -191,28 +186,20 @@ func (a *adapter) runWebSocket(ctx context.Context) {
 		}
 		client := larkws.NewClient(a.cfg.AppID, secret, opts...)
 		a.wsClient = client
+		// client.Start blocks; run it off-loop so cancellation closes the client
+		// immediately rather than waiting for Start to notice ctx. RunWithRetry
+		// handles the reconnect backoff.
 		errCh := make(chan error, 1)
 		go func() { errCh <- client.Start(ctx) }()
 		select {
 		case <-ctx.Done():
 			client.Close()
-			return
+			return nil
 		case err := <-errCh:
 			client.Close()
-			if err != nil {
-				a.logger.Error("feishu sdk websocket stopped", "err", err)
-			} else {
-				a.logger.Warn("feishu sdk websocket stopped without error")
-			}
+			return err
 		}
-		timer := time.NewTimer(5 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return
-		case <-timer.C:
-		}
-	}
+	})
 }
 
 func (a *adapter) newEventDispatcher() *dispatcher.EventDispatcher {


### PR DESCRIPTION
## What

Third in the connloop series (after #5136, #5137), completing the adoption across all three IM adapters. Replaces feishu's hand-rolled reconnect loop with `RunWithRetry`.

The attempt keeps the SDK's blocking `client.Start` in an off-loop goroutine so a `ctx` cancellation closes the client **immediately** rather than waiting for `Start` to notice — behavior identical to before. What changes is only the outer reconnect wait: the manual `time.NewTimer(5s)` becomes `RunWithRetry`'s cancellation-aware **exponential backoff** (1s→30s).

The SDK's own `WithAutoReconnect(true)` still handles in-connection blips; `RunWithRetry` is the outer "SDK fully exited" fallback — same layering as before.

## Verification

- `gofmt`/`go vet` clean; `go build ./...` ok (the `time` import remains, still used by the dedup window).
- `go test -race ./internal/bot/...` green (feishu suite included); full `go test ./...` — all packages green.

After this: the `getOrCreateSession` TOCTOU fix (gateway.go) is the last item in the bot-layer plan.