### PR TITLE
fix(bot): close the getOrCreateSession check-create race

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -877,14 +877,26 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	ensureControllerSessionPath(ctrl)
 
 	gw.mu.Lock()
-	gw.controllers[key] = &sessionState{
+	// Re-check under the lock: while we were off-lock in boot.Build, a second
+	// message for the same key may have built and registered its own session.
+	// The first writer wins; close the controller we just built (releasing its
+	// jobs/plugin host) and reuse the existing one, so a near-simultaneous pair
+	// of opening messages can't leak a controller.
+	if existing, ok := gw.controllers[key]; ok {
+		existing.lastActive = time.Now()
+		gw.mu.Unlock()
+		ctrl.Close()
+		gw.logger.Info("bot session built concurrently; discarding duplicate", "platform", msg.Platform, "chat", hashID(msg.ChatID), "session", key[:8])
+		return existing
+	}
+	state := &sessionState{
 		ctrl:        ctrl,
 		sink:        sessionSink,
 		pendingAsks: make(map[string][]event.AskQuestion),
 		createdAt:   time.Now(),
 		lastActive:  time.Now(),
 	}
-	state := gw.controllers[key]
+	gw.controllers[key] = state
 	gw.mu.Unlock()
 
 	gw.logger.Info("bot session created", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])


### PR DESCRIPTION
## What

The last item in the bot-layer plan (after the connloop series #5136/#5137/#5139). Fixes a TOCTOU race in `BotGateway.getOrCreateSession`.

The method released `gw.mu` between the *"does this key exist?"* check and the registration of the freshly built controller, with `boot.Build` — a slow, MCP-connecting operation — in between. Two near-simultaneous opening messages for the same chat could **both** miss the cache, **both** build a controller, and the second registration would overwrite the first in `gw.controllers` — **orphaning (leaking) the first controller's jobs and plugin host**.

## Fix

Re-check under the second lock: if another goroutine already registered a session for the key, `Close()` the controller we just built (the same teardown the eviction path at `gateway.go:249` already uses) and reuse the existing one. First writer wins.

## Verification

- `gofmt`/`go vet` clean; `go build ./...` ok.
- `go test -race ./internal/bot/...` green; full `go test ./...` — all packages green.
- The race is structural (TOCTOU around an un-injectable `boot.Build`), so it's fixed by the standard double-check pattern rather than a new unit test.