### PR TITLE
Preserve tab plugin context after boot / 保留标签页插件上下文

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -344,6 +344,10 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	}
 
 	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return false
+	}
 	detached := a.detachedSessions[key]
 	if detached != nil {
 		delete(a.detachedSessions, key)
@@ -1614,11 +1618,13 @@ func (a *App) tabRemovedForBuild(tab *WorkspaceTab) bool {
 	return tab.removed || a.tabs[tab.ID] != tab
 }
 
-func (a *App) clearTabBuildCancel(tab *WorkspaceTab, generation uint64, cancel context.CancelFunc) {
+func (a *App) clearTabBuildCancel(tab *WorkspaceTab, generation uint64, cancel context.CancelFunc, keepContext bool) {
 	if cancel == nil {
 		return
 	}
-	defer cancel()
+	if !keepContext {
+		defer cancel()
+	}
 	if tab == nil {
 		return
 	}
@@ -1686,7 +1692,10 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 
 func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loadedTabSession, buildCtx context.Context, buildGeneration uint64, buildCancel context.CancelFunc) {
 	defer a.recoverToPending("buildTabController")
-	defer a.clearTabBuildCancel(tab, buildGeneration, buildCancel)
+	keepBuildContext := false
+	defer func() {
+		a.clearTabBuildCancel(tab, buildGeneration, buildCancel, keepBuildContext)
+	}()
 	wailsCtx := a.ctx
 	if a.tabRemovedForBuild(tab) {
 		return
@@ -1911,6 +1920,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	tab.Label = ctrl.Label()
 	tab.Ready = true
 	tab.StartupErr = ""
+	keepBuildContext = true
 	a.mu.Unlock()
 	a.emitReady(wailsCtx)
 }

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,6 +209,85 @@ func TestKeepOnlyVisibleTabCancelsBuildingHiddenTab(t *testing.T) {
 	}
 	if !building.removed {
 		t.Fatal("building tab was not marked removed")
+	}
+}
+
+func TestClearTabBuildCancelKeepsSuccessfulControllerContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tab := &WorkspaceTab{ID: "tab", buildGeneration: 1, buildCancel: cancel}
+	app := &App{}
+
+	app.clearTabBuildCancel(tab, 1, cancel, true)
+
+	if tab.buildCancel != nil {
+		t.Fatal("build cancel was not cleared")
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("successful tab build context was cancelled")
+	default:
+	}
+}
+
+func TestClearTabBuildCancelCancelsAbandonedBuildContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tab := &WorkspaceTab{ID: "tab", buildGeneration: 1, buildCancel: cancel}
+	app := &App{}
+
+	app.clearTabBuildCancel(tab, 1, cancel, false)
+
+	if tab.buildCancel != nil {
+		t.Fatal("build cancel was not cleared")
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("abandoned tab build context was not cancelled")
+	}
+}
+
+func TestAttachExistingSessionRuntimeSkipsRemovedTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "detached.jsonl")
+	key := sessionRuntimeKey(path)
+	detachedCtrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "detached", Sink: event.Discard})
+	defer detachedCtrl.Close()
+	detached := &WorkspaceTab{
+		ID:            "detached",
+		Scope:         "global",
+		SessionPath:   path,
+		Ctrl:          detachedCtrl,
+		Ready:         true,
+		SharedHostKey: "detached-host",
+		sink:          &tabEventSink{tabID: "detached"},
+		disabledMCP:   map[string]ServerView{},
+	}
+	target := &WorkspaceTab{
+		ID:          "target",
+		Scope:       "global",
+		SessionPath: path,
+		removed:     true,
+		sink:        &tabEventSink{tabID: "target"},
+		disabledMCP: map[string]ServerView{},
+	}
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{},
+		detachedSessions: map[string]*WorkspaceTab{key: detached},
+	}
+
+	if app.attachExistingSessionRuntime(target, path, nil) {
+		t.Fatal("removed tab reattached a detached runtime")
+	}
+	if app.detachedSessions[key] != detached {
+		t.Fatal("detached runtime was removed")
+	}
+	if target.Ctrl != nil || target.Ready {
+		t.Fatal("removed target tab was mutated")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Follow up on Codex bot findings from #5133 after that PR was merged.
- Keep the tab build cancellation handle for pruning, but do not cancel the session-scoped PluginCtx once a controller is successfully installed.
- Make detached-runtime reattachment verify that the target tab is still the current visible tab while holding the app lock, preventing removed tabs from stealing detached runtimes.
- Add focused regression coverage for both lifecycle cases.

Fixes follow-up review feedback from #5133. Related: #5129, #5133

## Verification

- `cd desktop && go test . -run 'Test(ClearTabBuildCancel|AttachExistingSessionRuntimeSkipsRemovedTab|KeepOnlyVisibleTab|SetDesktopLayoutStyleAppliesPolicyAfterWorkspaceAlias|RemoveWorkspace)' -count=1`\n- `cd desktop && go test ./...`\n- `pnpm --dir desktop/frontend typecheck`\n- `pnpm --dir desktop/frontend test:typecheck`\n- `pnpm --dir desktop/frontend test`\n- `git diff --check`\n\n## Cache impact\n\nCache-impact: none. This is limited to desktop tab lifecycle and session runtime reattachment. It does not change provider-visible prompts, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.