### PR TITLE
feat(config): expose reasoning_effort selector for generic OpenAI-compatible providers

### DIFF
--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1571,26 +1571,37 @@ func TestUpsertProviderNormalizesCustomEffortFields(t *testing.T) {
 	}
 }
 
-func TestEffortCapabilityEmptySupportedEffortsNotConfigurable(t *testing.T) {
-	// mimo-pro without SupportedEfforts: no built-in heuristic, /effort must reject.
+func TestEffortCapabilityGenericOpenAIExposesStandardScale(t *testing.T) {
+	// A generic OpenAI-compatible provider we don't otherwise recognise (here a
+	// MiMo gateway) now exposes the standard reasoning_effort selector rather than
+	// hiding it, so third-party proxies aren't silently stripped of /effort (#4729).
 	e := &ProviderEntry{
 		Name:    "mimo-pro",
 		Kind:    "openai",
 		BaseURL: "https://token-plan-cn.xiaomimimo.com/v1",
 		Model:   "mimo-v2.5-pro",
 	}
-	if cap := EffortCapabilityForEntry(e); cap.Supported {
-		t.Fatalf("mimo-pro without SupportedEfforts should not be configurable, got %+v", cap)
+	cap := EffortCapabilityForEntry(e)
+	wantLevels := []string{"auto", "low", "medium", "high"}
+	if !cap.Supported || len(cap.Levels) != len(wantLevels) || cap.Default != "auto" {
+		t.Fatalf("generic openai provider should expose auto/low/medium/high (default auto), got %+v", cap)
 	}
-	if _, err := NormalizeEffort(e, "high"); err == nil {
-		t.Fatal("NormalizeEffort should reject level for unsupported provider")
+	for i, l := range wantLevels {
+		if cap.Levels[i] != l {
+			t.Errorf("levels[%d] = %q, want %q", i, cap.Levels[i], l)
+		}
 	}
-	// `supported_efforts = []` (empty slice) is treated like nil — the v2 design
-	// has no way to opt out of the built-in heuristic; users either configure
-	// levels or leave the field unset.
+	// The standard scale is accepted; "max" clamps to the OpenAI ceiling and
+	// "off" means no override.
+	for in, want := range map[string]string{"high": "high", "medium": "medium", "max": "high", "off": ""} {
+		if got, err := NormalizeEffort(e, in); err != nil || got != want {
+			t.Errorf("NormalizeEffort(%q) = %q/%v, want %q/nil", in, got, err, want)
+		}
+	}
+	// An empty supported_efforts slice is treated like nil — same generic scale.
 	e2 := *e
 	e2.SupportedEfforts = []string{}
-	if cap := EffortCapabilityForEntry(&e2); cap.Supported {
-		t.Fatalf("empty supported_efforts should also fall through to the heuristic, got %+v", cap)
+	if cap := EffortCapabilityForEntry(&e2); !cap.Supported {
+		t.Fatalf("empty supported_efforts should fall through to the generic scale, got %+v", cap)
 	}
 }

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -76,6 +76,13 @@ func EffortCapabilityForEntry(e *ProviderEntry) EffortCapability {
 		return EffortCapability{Supported: true, Levels: []string{"auto", "adaptive", "disabled"}, Default: "adaptive"}
 	case e != nil && e.Kind == "anthropic":
 		return EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high", "xhigh", "max"}, Default: "auto"}
+	case e != nil && e.Kind == "openai":
+		// Generic OpenAI-compatible provider (third-party proxy, gateway, etc.)
+		// that we don't otherwise recognise: expose the standard reasoning_effort
+		// selector rather than hiding it. Default "auto" sends nothing, so a model
+		// that ignores reasoning_effort is unaffected; a DeepSeek-V4-behind-a-proxy
+		// still gets effort honoured by the backend (#4729).
+		return openAIEffortCapability()
 	default:
 		return EffortCapability{}
 	}
@@ -146,6 +153,20 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 			return level, nil
 		default:
 			return "", fmt.Errorf("usage: /effort auto|low|medium|high|xhigh|max")
+		}
+	case e != nil && e.Kind == "openai":
+		// Generic OpenAI-compatible provider: accept the standard scale. "max" /
+		// "xhigh" are DeepSeek-isms some backends 400 on, so clamp to the OpenAI
+		// ceiling; "off" means no override (#4729).
+		switch level {
+		case "low", "medium", "high":
+			return level, nil
+		case "max", "xhigh":
+			return "high", nil
+		case "off":
+			return "", nil
+		default:
+			return "", fmt.Errorf("usage: /effort auto|low|medium|high")
 		}
 	default:
 		return "", effortNotConfigurableError(e)


### PR DESCRIPTION
Closes #4729.

## Problem

The `/effort` selector (and the desktop Effort control) only appeared for backends Reasonix recognises — native DeepSeek, MiniMax, Anthropic, or a provider with an explicit `supported_efforts` list. Any other OpenAI-compatible provider (third-party proxies such as SiliconFlow / OpenRouter, or a custom gateway) fell through to "not configurable" and the selector was **hidden** — so the same DeepSeek-V4 model lost its reasoning-depth control just by switching channels.

## Change

Generic `openai`-kind providers now expose the standard `reasoning_effort` scale: `auto` / `low` / `medium` / `high`.

- Default is `auto`, which sends **nothing** — a backend that ignores `reasoning_effort` is completely unaffected, so this is safe for non-reasoning models.
- Picking a level sends `reasoning_effort` through; the backend honours or ignores it (per the issue's preferred option 1).
- `max` / `xhigh` clamp to the OpenAI ceiling (`high`); `off` means no override.

Backends with their own protocol are untouched: DeepSeek (`thinking` + effort), MiniMax / Zhipu (`thinking.type`), explicit `reasoning_protocol`, model-registry entries, and `reasoning_protocol = "none"` (which still hides the selector) all keep their existing behaviour. The wire path already serialises `reasoning_effort` for generic providers (`TestBuildRequestNonDeepSeekOmitsThinking`), so this PR is purely the capability/normalize gating plus its test.

## 中文说明

此前只有 DeepSeek/MiniMax/Anthropic 等被识别的后端才显示思考深度选择器,第三方 OpenAI 兼容代理(硅基流动、OpenRouter 等)会被直接隐藏,导致"换个渠道用同一个 DeepSeek V4 就没了 effort 选项"。现在通用 openai 供应商也暴露标准 `reasoning_effort`(auto/low/medium/high):默认 auto 不发送任何参数,选了才发,后端不支持就忽略,不会报错。

---

Cache-impact: none — config-layer `/effort` capability/normalize only; the request prefix is unchanged unless the user actively selects a non-auto level, which is the existing generic `reasoning_effort` path.
Cache-guard: `TestEffortCapabilityGenericOpenAIExposesStandardScale`; `TestBuildRequestNonDeepSeekOmitsThinking` still pins the wire serialization.
System-prompt-review: n/a — no system prompt, memory prefix, output style, or skill index change.