### PR TITLE
refactor(desktop): extract layout geometry state into a zustand store

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -27,7 +27,8 @@
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.0",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3
@@ -1209,6 +1212,24 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2501,5 +2522,10 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  zustand@5.0.14(@types/react@19.2.17)(react@19.2.7):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   zwitch@2.0.4: {}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -96,7 +96,28 @@ import {
   toggleYoloToolApprovalMode,
   type RestorableToolApprovalMode,
 } from "./lib/toolApprovalMode";
-import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
+import {
+  CREATION_SIDEBAR_MIN_WIDTH,
+  RIGHT_DOCK_MAX_WIDTH,
+  RIGHT_DOCK_MIN_RENDER_WIDTH,
+  RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH,
+  RIGHT_DOCK_PREVIEW_MIN_WIDTH,
+  RIGHT_DOCK_TREE_MAX_WIDTH,
+  RIGHT_DOCK_TREE_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  clampCreationSidebarWidth,
+  clampRightDockPreviewWidth,
+  clampRightDockTreeWidth,
+  clampSidebarWidth,
+  defaultRightDockTreeWidth,
+  defaultSidebarWidth,
+  saveRightDockPreviewWidth,
+  saveRightDockTreeWidth,
+  saveSidebarCollapsed,
+  saveSidebarWidth,
+  useLayoutStore,
+} from "./store/layout";
 import { hydrateDisplayMode } from "./lib/displayMode";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId } from "./lib/statusBarItems";
 import { sessionActivityTime } from "./lib/session";
@@ -121,12 +142,6 @@ import logoWordmark from "./assets/logo-wordmark.svg";
 const HistoryPanel = lazy(() => import("./components/HistoryPanel").then((module) => ({ default: module.HistoryPanel })));
 const SettingsPanel = lazy(() => import("./components/SettingsPanel").then((module) => ({ default: module.SettingsPanel })));
 
-const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
-const SIDEBAR_DEFAULT_WIDTH = 264;
-const SIDEBAR_MIN_WIDTH = 264;
-const CREATION_SIDEBAR_MIN_WIDTH = 236;
-const SIDEBAR_MAX_WIDTH = 300;
-const SIDEBAR_VIEWPORT_RATIO = 0.18;
 const CHAT_MIN_WIDTH = 400;
 const CHAT_COMFORT_MIN_WIDTH = 560;
 const WORKSPACE_RESIZER_WIDTH = 8;
@@ -157,14 +172,6 @@ function normalizeDesktopLayoutStyle(style: string | undefined): DesktopLayoutSt
   if (style === "creation") return "creation";
   return "classic";
 }
-const RIGHT_DOCK_TREE_DEFAULT_WIDTH = 300;
-const RIGHT_DOCK_TREE_MIN_WIDTH = 300;
-const RIGHT_DOCK_TREE_MAX_WIDTH = 560;
-const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
-const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
-const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
-const RIGHT_DOCK_MAX_WIDTH = 860;
-
 type RightDockMode = "context" | "files" | "changed";
 const SHOW_CONTEXT_DOCK = true;
 type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string };
@@ -618,63 +625,6 @@ function activeTopicTurnsFromTree(tree: ProjectNode[], tab?: TabMeta): number | 
   return walk(tree);
 }
 
-function clampSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
-}
-
-function clampCreationSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
-}
-
-function clampStoredSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
-}
-
-function clampRightDockPreviewWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_MAX_WIDTH, Math.max(RIGHT_DOCK_PREVIEW_MIN_WIDTH, Math.round(width)));
-}
-
-function clampRightDockTreeWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_TREE_MAX_WIDTH, Math.max(RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
-}
-
-function defaultSidebarWidth(): number {
-  if (typeof window !== "undefined") {
-    return clampSidebarWidth(window.innerWidth * SIDEBAR_VIEWPORT_RATIO);
-  }
-  return SIDEBAR_DEFAULT_WIDTH;
-}
-
-function defaultRightDockTreeWidth(): number {
-  return RIGHT_DOCK_TREE_DEFAULT_WIDTH;
-}
-
-function loadSidebarCollapsed(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
-function saveSidebarCollapsed(collapsed: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
-  } catch {
-    /* ignore storage failures */
-  }
-}
-
-function loadSidebarWidth(): number {
-  return loadLayoutSize("sidebarWidthGraphite", defaultSidebarWidth(), clampStoredSidebarWidth);
-}
-
-function saveSidebarWidth(width: number): void {
-  saveLayoutSize("sidebarWidthGraphite", width, clampStoredSidebarWidth);
-}
-
 function normalizeDesktopPlatform(value: string): DesktopPlatform {
   if (value === "darwin" || value === "windows") return value;
   return "linux";
@@ -695,22 +645,6 @@ function detectBrowserPlatform(): DesktopPlatform {
   if (/Win/i.test(marker)) return "windows";
   if (/Mac/i.test(marker)) return "darwin";
   return "linux";
-}
-
-function loadRightDockTreeWidth(): number {
-  return loadLayoutSize("rightDockTreeWidth", defaultRightDockTreeWidth(), clampRightDockTreeWidth);
-}
-
-function saveRightDockTreeWidth(width: number): void {
-  saveLayoutSize("rightDockTreeWidth", width, clampRightDockTreeWidth);
-}
-
-function loadRightDockPreviewWidth(): number {
-  return loadLayoutSize("rightDockPreviewWidth", RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH, clampRightDockPreviewWidth);
-}
-
-function saveRightDockPreviewWidth(width: number): void {
-  saveLayoutSize("rightDockPreviewWidth", width, clampRightDockPreviewWidth);
 }
 
 function tabWorkspaceTitle(tab?: TabMeta): string {
@@ -907,7 +841,8 @@ export default function App() {
   const [sidebarImConnections, setSidebarImConnections] = useState<SidebarImConnection[]>([]);
   const [imTopicSources, setImTopicSources] = useState<Record<string, SidebarImTopicSource>>({});
   const [sidebarImDetailConnectionId, setSidebarImDetailConnectionId] = useState("");
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
+  const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed);
+  const setSidebarCollapsed = useLayoutStore((s) => s.setSidebarCollapsed);
   const [heartbeatOpen, setHeartbeatOpen] = useState(false);
   type TimeFilter = "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
   const [topicTimeFilter, setTopicTimeFilter] = useState<TimeFilter>(() => {
@@ -920,12 +855,15 @@ export default function App() {
   useEffect(() => {
     try { localStorage.setItem("projectTree:timeFilter", topicTimeFilter); } catch { /* ignore */ }
   }, [topicTimeFilter]);
-  const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
+  const sidebarWidth = useLayoutStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useLayoutStore((s) => s.setSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
-  const [rightDockTreeWidth, setRightDockTreeWidth] = useState(loadRightDockTreeWidth);
-  const [rightDockPreviewWidth, setRightDockPreviewWidth] = useState(loadRightDockPreviewWidth);
+  const rightDockTreeWidth = useLayoutStore((s) => s.rightDockTreeWidth);
+  const setRightDockTreeWidth = useLayoutStore((s) => s.setRightDockTreeWidth);
+  const rightDockPreviewWidth = useLayoutStore((s) => s.rightDockPreviewWidth);
+  const setRightDockPreviewWidth = useLayoutStore((s) => s.setRightDockPreviewWidth);
   const [workspacePreviewActive, setWorkspacePreviewActive] = useState(false);
   // Bump dockRefreshKey after each turn so WorkspacePanel/ContextPanel re-fetch
   // workspace changes, git history, and session metadata after AI tool writes.

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -1,0 +1,126 @@
+// layout owns the desktop shell's geometry state — sidebar + right-dock widths
+// and the sidebar collapse flag — as a selectable store rather than App-local
+// useState. Components read a single slice via selector (only that slice
+// re-renders), with no prop drilling. The geometry constants, clamps, and the
+// localStorage-backed load/save helpers live here too: they are layout-domain
+// knowledge that belongs with the store, and keeping them here lets the store
+// initialize itself from persisted state at module load without depending on App.
+//
+// Persistence behavior is intentionally unchanged from the previous App-local
+// implementation: the store's setters are pure (state only), and callers keep
+// invoking the exported save* helpers exactly where they did before, so the
+// on-disk localStorage schema and write timing are byte-identical.
+
+import { create } from "zustand";
+
+import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
+
+const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
+const SIDEBAR_DEFAULT_WIDTH = 264;
+export const SIDEBAR_MIN_WIDTH = 264;
+export const CREATION_SIDEBAR_MIN_WIDTH = 236;
+export const SIDEBAR_MAX_WIDTH = 300;
+const SIDEBAR_VIEWPORT_RATIO = 0.18;
+
+const RIGHT_DOCK_TREE_DEFAULT_WIDTH = 300;
+export const RIGHT_DOCK_TREE_MIN_WIDTH = 300;
+export const RIGHT_DOCK_TREE_MAX_WIDTH = 560;
+export const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
+export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
+export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
+export const RIGHT_DOCK_MAX_WIDTH = 860;
+
+export function clampSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
+export function clampCreationSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
+function clampStoredSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
+export function clampRightDockPreviewWidth(width: number): number {
+  return Math.min(RIGHT_DOCK_MAX_WIDTH, Math.max(RIGHT_DOCK_PREVIEW_MIN_WIDTH, Math.round(width)));
+}
+
+export function clampRightDockTreeWidth(width: number): number {
+  return Math.min(RIGHT_DOCK_TREE_MAX_WIDTH, Math.max(RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
+}
+
+export function defaultSidebarWidth(): number {
+  if (typeof window !== "undefined") {
+    return clampSidebarWidth(window.innerWidth * SIDEBAR_VIEWPORT_RATIO);
+  }
+  return SIDEBAR_DEFAULT_WIDTH;
+}
+
+export function defaultRightDockTreeWidth(): number {
+  return RIGHT_DOCK_TREE_DEFAULT_WIDTH;
+}
+
+function loadSidebarCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveSidebarCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+function loadSidebarWidth(): number {
+  return loadLayoutSize("sidebarWidthGraphite", defaultSidebarWidth(), clampStoredSidebarWidth);
+}
+
+export function saveSidebarWidth(width: number): void {
+  saveLayoutSize("sidebarWidthGraphite", width, clampStoredSidebarWidth);
+}
+
+function loadRightDockTreeWidth(): number {
+  return loadLayoutSize("rightDockTreeWidth", defaultRightDockTreeWidth(), clampRightDockTreeWidth);
+}
+
+export function saveRightDockTreeWidth(width: number): void {
+  saveLayoutSize("rightDockTreeWidth", width, clampRightDockTreeWidth);
+}
+
+function loadRightDockPreviewWidth(): number {
+  return loadLayoutSize("rightDockPreviewWidth", RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH, clampRightDockPreviewWidth);
+}
+
+export function saveRightDockPreviewWidth(width: number): void {
+  saveLayoutSize("rightDockPreviewWidth", width, clampRightDockPreviewWidth);
+}
+
+export type LayoutState = {
+  sidebarCollapsed: boolean;
+  sidebarWidth: number;
+  rightDockTreeWidth: number;
+  rightDockPreviewWidth: number;
+  setSidebarCollapsed: (collapsed: boolean) => void;
+  setSidebarWidth: (width: number) => void;
+  setRightDockTreeWidth: (width: number) => void;
+  setRightDockPreviewWidth: (width: number) => void;
+};
+
+export const useLayoutStore = create<LayoutState>((set) => ({
+  sidebarCollapsed: loadSidebarCollapsed(),
+  sidebarWidth: loadSidebarWidth(),
+  rightDockTreeWidth: loadRightDockTreeWidth(),
+  rightDockPreviewWidth: loadRightDockPreviewWidth(),
+  setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+  setSidebarWidth: (width) => set({ sidebarWidth: width }),
+  setRightDockTreeWidth: (width) => set({ rightDockTreeWidth: width }),
+  setRightDockPreviewWidth: (width) => set({ rightDockPreviewWidth: width }),
+}));


### PR DESCRIPTION
## What

First slice of the desktop **frontend state-layer modernization**. `App.tsx` (3371 lines) holds **54 useState** with no state-management layer — all state lives in one component and is prop-drilled down. This introduces a selectable store and migrates the first cohesive slice.

Creates `src/store/layout.ts` (zustand) owning the desktop shell's **layout geometry**:
- 4 atoms: `sidebarCollapsed`, `sidebarWidth`, `rightDockTreeWidth`, `rightDockPreviewWidth`
- plus the geometry constants (`SIDEBAR_*`/`RIGHT_DOCK_*`), clamps, and the localStorage load/save helpers — moved out of `App.tsx` because they are layout-domain knowledge and let the store self-initialize at module load.

`App.tsx` now reads each atom via a selector (`useLayoutStore(s => s.x)`) and imports the shared geometry helpers. Local variable names are unchanged, so all ~20 existing usage sites compile untouched; only the `useState` declaration lines change. Net **−35 lines** in `App.tsx`.

## Behavior

**Byte-identical**, zero migration:
- store setters are pure (state only)
- callers keep invoking the same `save*` helpers exactly where they did before
- localStorage schema and write timing are unchanged

## Why zustand

Selector subscriptions (only the touched slice re-renders), no provider nesting, actions colocated with state — the right fit for a 50+ useState component. Adds `zustand@^5` (~1KB).

## Verification

- `tsc --noEmit` (main + `tsconfig.test.json`) — both clean under `noUnusedLocals`/`noUnusedParameters`
- `pnpm build` (css checks + tsc + vite) ✓
- `pnpm test` — full frontend suite, 42 files incl. `app-chrome-tabs` / `workspace-layout` (layout coverage), all green

Follow-up slices (transient layout flags, overlays/modals, tabs/topics, …) will land in separate PRs.