### PR TITLE
refactor(desktop): move right-dock layout config into the zustand store

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -104,6 +104,7 @@ import {
   RIGHT_DOCK_PREVIEW_MIN_WIDTH,
   RIGHT_DOCK_TREE_MAX_WIDTH,
   RIGHT_DOCK_TREE_MIN_WIDTH,
+  type RightDockMode,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
   clampCreationSidebarWidth,
@@ -172,7 +173,6 @@ function normalizeDesktopLayoutStyle(style: string | undefined): DesktopLayoutSt
   if (style === "creation") return "creation";
   return "classic";
 }
-type RightDockMode = "context" | "files" | "changed";
 const SHOW_CONTEXT_DOCK = true;
 type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string };
 type DesktopPlatform = "darwin" | "windows" | "linux";
@@ -859,12 +859,14 @@ export default function App() {
   const setSidebarWidth = useLayoutStore((s) => s.setSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
-  const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
+  const workspacePanelOpen = useLayoutStore((s) => s.workspacePanelOpen);
+  const setWorkspacePanelOpen = useLayoutStore((s) => s.setWorkspacePanelOpen);
   const rightDockTreeWidth = useLayoutStore((s) => s.rightDockTreeWidth);
   const setRightDockTreeWidth = useLayoutStore((s) => s.setRightDockTreeWidth);
   const rightDockPreviewWidth = useLayoutStore((s) => s.rightDockPreviewWidth);
   const setRightDockPreviewWidth = useLayoutStore((s) => s.setRightDockPreviewWidth);
-  const [workspacePreviewActive, setWorkspacePreviewActive] = useState(false);
+  const workspacePreviewActive = useLayoutStore((s) => s.workspacePreviewActive);
+  const setWorkspacePreviewActive = useLayoutStore((s) => s.setWorkspacePreviewActive);
   // Bump dockRefreshKey after each turn so WorkspacePanel/ContextPanel re-fetch
   // workspace changes, git history, and session metadata after AI tool writes.
   useEffect(() => {
@@ -878,8 +880,10 @@ export default function App() {
   }, []);
 
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);
-  const [workspacePanelMaximized, setWorkspacePanelMaximized] = useState(false);
-  const [rightDockMode, setRightDockMode] = useState<RightDockMode>("context");
+  const workspacePanelMaximized = useLayoutStore((s) => s.workspacePanelMaximized);
+  const setWorkspacePanelMaximized = useLayoutStore((s) => s.setWorkspacePanelMaximized);
+  const rightDockMode = useLayoutStore((s) => s.rightDockMode);
+  const setRightDockMode = useLayoutStore((s) => s.setRightDockMode);
   const [dockRefreshKey, setDockRefreshKey] = useState(0);
   const [projectRevision, setProjectRevision] = useState(0);
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -11,6 +11,7 @@
 // invoking the exported save* helpers exactly where they did before, so the
 // on-disk localStorage schema and write timing are byte-identical.
 
+import type { Dispatch, SetStateAction } from "react";
 import { create } from "zustand";
 
 import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
@@ -103,15 +104,39 @@ export function saveRightDockPreviewWidth(width: number): void {
   saveLayoutSize("rightDockPreviewWidth", width, clampRightDockPreviewWidth);
 }
 
+// rightDockMode selects what the right dock shows; the workspace-panel flags are
+// its open/maximized/preview layout configuration. None of these four are
+// persisted — they reset to the defaults below on launch, exactly as the prior
+// App-local useState did. (The truly view-local interaction ephemera — resize
+// drag flags, button-press animation flags, measured footer height, viewport
+// width — deliberately stay as useState in App.tsx; they have no cross-component
+// readers and don't belong in shared state.)
+export type RightDockMode = "context" | "files" | "changed";
+
+// resolve mirrors React's setState contract: a setter accepts either the next
+// value or an updater (prev => next), so the migrated call sites — including
+// functional toggles like setWorkspacePanelMaximized(v => !v) — are drop-in.
+function resolve<T>(prev: T, update: SetStateAction<T>): T {
+  return typeof update === "function" ? (update as (value: T) => T)(prev) : update;
+}
+
 export type LayoutState = {
   sidebarCollapsed: boolean;
   sidebarWidth: number;
   rightDockTreeWidth: number;
   rightDockPreviewWidth: number;
+  workspacePanelOpen: boolean;
+  workspacePanelMaximized: boolean;
+  workspacePreviewActive: boolean;
+  rightDockMode: RightDockMode;
   setSidebarCollapsed: (collapsed: boolean) => void;
   setSidebarWidth: (width: number) => void;
   setRightDockTreeWidth: (width: number) => void;
   setRightDockPreviewWidth: (width: number) => void;
+  setWorkspacePanelOpen: Dispatch<SetStateAction<boolean>>;
+  setWorkspacePanelMaximized: Dispatch<SetStateAction<boolean>>;
+  setWorkspacePreviewActive: Dispatch<SetStateAction<boolean>>;
+  setRightDockMode: Dispatch<SetStateAction<RightDockMode>>;
 };
 
 export const useLayoutStore = create<LayoutState>((set) => ({
@@ -119,8 +144,16 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarWidth: loadSidebarWidth(),
   rightDockTreeWidth: loadRightDockTreeWidth(),
   rightDockPreviewWidth: loadRightDockPreviewWidth(),
+  workspacePanelOpen: true,
+  workspacePanelMaximized: false,
+  workspacePreviewActive: false,
+  rightDockMode: "context",
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
   setRightDockTreeWidth: (width) => set({ rightDockTreeWidth: width }),
   setRightDockPreviewWidth: (width) => set({ rightDockPreviewWidth: width }),
+  setWorkspacePanelOpen: (update) => set((s) => ({ workspacePanelOpen: resolve(s.workspacePanelOpen, update) })),
+  setWorkspacePanelMaximized: (update) => set((s) => ({ workspacePanelMaximized: resolve(s.workspacePanelMaximized, update) })),
+  setWorkspacePreviewActive: (update) => set((s) => ({ workspacePreviewActive: resolve(s.workspacePreviewActive, update) })),
+  setRightDockMode: (update) => set((s) => ({ rightDockMode: resolve(s.rightDockMode, update) })),
 }));


### PR DESCRIPTION
## What

Second slice of the desktop **frontend state-layer modernization** (follows #5150, which created `src/store/layout.ts`).

Moves the four **non-persisted layout configuration flags** out of `App.tsx` useState into the layout store, read via selectors:
- `workspacePanelOpen`
- `workspacePanelMaximized`
- `workspacePreviewActive`
- `rightDockMode` (and its `RightDockMode` type)

These describe the right dock's layout configuration and are read broadly across the render tree (`rightDockMode` alone has 17 sites; `workspacePanelMaximized` is already prop-drilled to `AppChrome`), so a shared store removes real coupling.

## Deliberately left as local useState

The purely view-local interaction ephemera — resize-drag flags (`sidebarResizing`, `workspacePanelResizing`), button-press animation flags (`sidebarTogglePressed`, `workspaceTogglePressed`), measured `footerHeight`, and `viewportWidth` — **stay** as `App`-local `useState`. They have no cross-component readers (2–4 sites each, all inside `App.tsx`), so promoting them to shared state would be a regression, not a cleanup. Not everything belongs in the store.

## Behavior

Unchanged. The flags are not persisted and initialize to the same defaults the `useState` calls used. Their store setters mirror React's `Dispatch<SetStateAction<T>>`, so every existing call site is drop-in — including the functional toggle `setWorkspacePanelMaximized(v => !v)`.

## Verification

- `tsc --noEmit` (main + `tsconfig.test.json`) — clean under `noUnusedLocals`/`noUnusedParameters`
- `pnpm build` (css checks + tsc + vite) ✓
- `pnpm test` — full frontend suite, all green