### PR TITLE
refactor(desktop): move overlay/modal state into a zustand store

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -46,12 +46,11 @@ import { UndoRewindBanner } from "./components/UndoRewindBanner";
 import { ClearContextCard } from "./components/ClearContextCard";
 import { StatusBar } from "./components/StatusBar";
 import { CommandPalette, type PaletteItem } from "./components/CommandPalette";
-import type { SettingsInitialFocus } from "./components/SettingsPanel";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { ContextPanel } from "./components/ContextPanel";
 import { WorkspacePanel } from "./components/WorkspacePanel";
 import { Tooltip } from "./components/Tooltip";
-import { StartupSplash, shouldShowStartupSplash } from "./components/StartupSplash";
+import { StartupSplash } from "./components/StartupSplash";
 import { OnboardingOverlay } from "./components/OnboardingOverlay";
 import { AppChrome } from "./components/AppChrome";
 import { ShortcutsCheatsheet } from "./components/ShortcutsCheatsheet";
@@ -71,7 +70,6 @@ import {
   type Mode,
   type ProjectNode,
   type SessionMeta,
-  type SettingsTab,
   type SettingsView,
   type TabMeta,
   type TokenMode,
@@ -119,6 +117,7 @@ import {
   saveSidebarWidth,
   useLayoutStore,
 } from "./store/layout";
+import { useOverlayStore } from "./store/overlays";
 import { hydrateDisplayMode } from "./lib/displayMode";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId } from "./lib/statusBarItems";
 import { sessionActivityTime } from "./lib/session";
@@ -824,26 +823,34 @@ export default function App() {
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
-  const [startupSplashVisible, setStartupSplashVisible] = useState<boolean>(() => shouldShowStartupSplash());
+  const startupSplashVisible = useOverlayStore((s) => s.startupSplashVisible);
+  const setStartupSplashVisible = useOverlayStore((s) => s.setStartupSplashVisible);
   // null until the mount probe resolves; true shows the overlay. Probed once —
   // clearing the key mid-session is the Settings panel's job, not the gate's.
-  const [needsOnboarding, setNeedsOnboarding] = useState<boolean | null>(null);
-  const [settingsTarget, setSettingsTarget] = useState<SettingsTab | null>(null);
-  const [settingsFocus, setSettingsFocus] = useState<SettingsInitialFocus | null>(null);
+  const needsOnboarding = useOverlayStore((s) => s.needsOnboarding);
+  const setNeedsOnboarding = useOverlayStore((s) => s.setNeedsOnboarding);
+  const settingsTarget = useOverlayStore((s) => s.settingsTarget);
+  const setSettingsTarget = useOverlayStore((s) => s.setSettingsTarget);
+  const settingsFocus = useOverlayStore((s) => s.settingsFocus);
+  const setSettingsFocus = useOverlayStore((s) => s.setSettingsFocus);
   const [desktopLayoutStyle, setDesktopLayoutStyle] = useState<DesktopLayoutStyle>("workbench");
   const singleSurfaceLayout = desktopLayoutStyle === "workbench" || desktopLayoutStyle === "creation";
   const [startupUpdateChecksEnabled, setStartupUpdateChecksEnabled] = useState<boolean | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
-  const [paletteOpen, setPaletteOpen] = useState(false);
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const [paletteSessions, setPaletteSessions] = useState<SessionMeta[]>([]);
+  const paletteOpen = useOverlayStore((s) => s.paletteOpen);
+  const setPaletteOpen = useOverlayStore((s) => s.setPaletteOpen);
+  const shortcutsOpen = useOverlayStore((s) => s.shortcutsOpen);
+  const setShortcutsOpen = useOverlayStore((s) => s.setShortcutsOpen);
+  const paletteSessions = useOverlayStore((s) => s.paletteSessions);
+  const setPaletteSessions = useOverlayStore((s) => s.setPaletteSessions);
   const { showToast } = useToast();
   const [sidebarImConnections, setSidebarImConnections] = useState<SidebarImConnection[]>([]);
   const [imTopicSources, setImTopicSources] = useState<Record<string, SidebarImTopicSource>>({});
   const [sidebarImDetailConnectionId, setSidebarImDetailConnectionId] = useState("");
   const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useLayoutStore((s) => s.setSidebarCollapsed);
-  const [heartbeatOpen, setHeartbeatOpen] = useState(false);
+  const heartbeatOpen = useOverlayStore((s) => s.heartbeatOpen);
+  const setHeartbeatOpen = useOverlayStore((s) => s.setHeartbeatOpen);
   type TimeFilter = "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
   const [topicTimeFilter, setTopicTimeFilter] = useState<TimeFilter>(() => {
     try {
@@ -888,15 +895,19 @@ export default function App() {
   const [projectRevision, setProjectRevision] = useState(0);
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);
   const [composerInsertRequest, setComposerInsertRequest] = useState<ComposerInsertRequest | null>(null);
-  const [transientOverlayDismissSignal, setTransientOverlayDismissSignal] = useState(0);
+  const transientOverlayDismissSignal = useOverlayStore((s) => s.transientOverlayDismissSignal);
+  const setTransientOverlayDismissSignal = useOverlayStore((s) => s.setTransientOverlayDismissSignal);
   const [desktopPlatform, setDesktopPlatform] = useState<DesktopPlatform>(detectBrowserPlatform);
   const [statusBarStyle, setStatusBarStyle] = useState<"icon" | "text">("text");
   const [statusBarItems, setStatusBarItems] = useState<StatusBarItemId[]>(() => [...DEFAULT_STATUS_BAR_ITEMS]);
   const [renamingTopicId, setRenamingTopicId] = useState<string | null>(null);
   const [topicTitleDraft, setTopicTitleDraft] = useState("");
-  const [topicExportOpen, setTopicExportOpen] = useState(false);
-  const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
-  const [sidebarSearchFocusSignal, setSidebarSearchFocusSignal] = useState(0);
+  const topicExportOpen = useOverlayStore((s) => s.topicExportOpen);
+  const setTopicExportOpen = useOverlayStore((s) => s.setTopicExportOpen);
+  const sidebarSearchOpen = useOverlayStore((s) => s.sidebarSearchOpen);
+  const setSidebarSearchOpen = useOverlayStore((s) => s.setSidebarSearchOpen);
+  const sidebarSearchFocusSignal = useOverlayStore((s) => s.sidebarSearchFocusSignal);
+  const setSidebarSearchFocusSignal = useOverlayStore((s) => s.setSidebarSearchFocusSignal);
   const [sidebarTogglePressed, setSidebarTogglePressed] = useState(false);
   const [workspaceTogglePressed, setWorkspaceTogglePressed] = useState(false);
   const [clearContextPending, setClearContextPending] = useState(false);

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -16,6 +16,8 @@ import { create } from "zustand";
 
 import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 
+import { applySetState } from "./setState";
+
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
 const SIDEBAR_DEFAULT_WIDTH = 264;
 export const SIDEBAR_MIN_WIDTH = 264;
@@ -113,13 +115,6 @@ export function saveRightDockPreviewWidth(width: number): void {
 // readers and don't belong in shared state.)
 export type RightDockMode = "context" | "files" | "changed";
 
-// resolve mirrors React's setState contract: a setter accepts either the next
-// value or an updater (prev => next), so the migrated call sites — including
-// functional toggles like setWorkspacePanelMaximized(v => !v) — are drop-in.
-function resolve<T>(prev: T, update: SetStateAction<T>): T {
-  return typeof update === "function" ? (update as (value: T) => T)(prev) : update;
-}
-
 export type LayoutState = {
   sidebarCollapsed: boolean;
   sidebarWidth: number;
@@ -152,8 +147,8 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
   setRightDockTreeWidth: (width) => set({ rightDockTreeWidth: width }),
   setRightDockPreviewWidth: (width) => set({ rightDockPreviewWidth: width }),
-  setWorkspacePanelOpen: (update) => set((s) => ({ workspacePanelOpen: resolve(s.workspacePanelOpen, update) })),
-  setWorkspacePanelMaximized: (update) => set((s) => ({ workspacePanelMaximized: resolve(s.workspacePanelMaximized, update) })),
-  setWorkspacePreviewActive: (update) => set((s) => ({ workspacePreviewActive: resolve(s.workspacePreviewActive, update) })),
-  setRightDockMode: (update) => set((s) => ({ rightDockMode: resolve(s.rightDockMode, update) })),
+  setWorkspacePanelOpen: (update) => set((s) => ({ workspacePanelOpen: applySetState(s.workspacePanelOpen, update) })),
+  setWorkspacePanelMaximized: (update) => set((s) => ({ workspacePanelMaximized: applySetState(s.workspacePanelMaximized, update) })),
+  setWorkspacePreviewActive: (update) => set((s) => ({ workspacePreviewActive: applySetState(s.workspacePreviewActive, update) })),
+  setRightDockMode: (update) => set((s) => ({ rightDockMode: applySetState(s.rightDockMode, update) })),
 }));

--- a/desktop/frontend/src/store/overlays.ts
+++ b/desktop/frontend/src/store/overlays.ts
@@ -1,0 +1,74 @@
+// overlays owns the transient surfaces layered over the workspace — the command
+// palette, the settings panel's open target/focus, the shortcuts / heartbeat /
+// topic-export dialogs, sidebar search, the startup splash, and the onboarding
+// gate — plus two imperative coordination signals (dismiss-all overlays, and
+// sidebar-search focus) that callers bump to trigger an effect downstream.
+//
+// None of this is persisted (the splash uses sessionStorage internally via
+// shouldShowStartupSplash). Every atom initializes to the same value the prior
+// App-local useState used, and setters mirror Dispatch<SetStateAction<T>>, so
+// the migrated call sites — including functional toggles/bumps — are drop-in and
+// behavior is unchanged.
+
+import type { Dispatch, SetStateAction } from "react";
+import { create } from "zustand";
+
+import type { SettingsInitialFocus } from "../components/SettingsPanel";
+import { shouldShowStartupSplash } from "../components/StartupSplash";
+import type { SessionMeta, SettingsTab } from "../lib/types";
+
+import { applySetState } from "./setState";
+
+export type OverlayState = {
+  settingsTarget: SettingsTab | null;
+  settingsFocus: SettingsInitialFocus | null;
+  paletteOpen: boolean;
+  paletteSessions: SessionMeta[];
+  shortcutsOpen: boolean;
+  heartbeatOpen: boolean;
+  topicExportOpen: boolean;
+  sidebarSearchOpen: boolean;
+  sidebarSearchFocusSignal: number;
+  transientOverlayDismissSignal: number;
+  startupSplashVisible: boolean;
+  needsOnboarding: boolean | null;
+  setSettingsTarget: Dispatch<SetStateAction<SettingsTab | null>>;
+  setSettingsFocus: Dispatch<SetStateAction<SettingsInitialFocus | null>>;
+  setPaletteOpen: Dispatch<SetStateAction<boolean>>;
+  setPaletteSessions: Dispatch<SetStateAction<SessionMeta[]>>;
+  setShortcutsOpen: Dispatch<SetStateAction<boolean>>;
+  setHeartbeatOpen: Dispatch<SetStateAction<boolean>>;
+  setTopicExportOpen: Dispatch<SetStateAction<boolean>>;
+  setSidebarSearchOpen: Dispatch<SetStateAction<boolean>>;
+  setSidebarSearchFocusSignal: Dispatch<SetStateAction<number>>;
+  setTransientOverlayDismissSignal: Dispatch<SetStateAction<number>>;
+  setStartupSplashVisible: Dispatch<SetStateAction<boolean>>;
+  setNeedsOnboarding: Dispatch<SetStateAction<boolean | null>>;
+};
+
+export const useOverlayStore = create<OverlayState>((set) => ({
+  settingsTarget: null,
+  settingsFocus: null,
+  paletteOpen: false,
+  paletteSessions: [],
+  shortcutsOpen: false,
+  heartbeatOpen: false,
+  topicExportOpen: false,
+  sidebarSearchOpen: false,
+  sidebarSearchFocusSignal: 0,
+  transientOverlayDismissSignal: 0,
+  startupSplashVisible: shouldShowStartupSplash(),
+  needsOnboarding: null,
+  setSettingsTarget: (update) => set((s) => ({ settingsTarget: applySetState(s.settingsTarget, update) })),
+  setSettingsFocus: (update) => set((s) => ({ settingsFocus: applySetState(s.settingsFocus, update) })),
+  setPaletteOpen: (update) => set((s) => ({ paletteOpen: applySetState(s.paletteOpen, update) })),
+  setPaletteSessions: (update) => set((s) => ({ paletteSessions: applySetState(s.paletteSessions, update) })),
+  setShortcutsOpen: (update) => set((s) => ({ shortcutsOpen: applySetState(s.shortcutsOpen, update) })),
+  setHeartbeatOpen: (update) => set((s) => ({ heartbeatOpen: applySetState(s.heartbeatOpen, update) })),
+  setTopicExportOpen: (update) => set((s) => ({ topicExportOpen: applySetState(s.topicExportOpen, update) })),
+  setSidebarSearchOpen: (update) => set((s) => ({ sidebarSearchOpen: applySetState(s.sidebarSearchOpen, update) })),
+  setSidebarSearchFocusSignal: (update) => set((s) => ({ sidebarSearchFocusSignal: applySetState(s.sidebarSearchFocusSignal, update) })),
+  setTransientOverlayDismissSignal: (update) => set((s) => ({ transientOverlayDismissSignal: applySetState(s.transientOverlayDismissSignal, update) })),
+  setStartupSplashVisible: (update) => set((s) => ({ startupSplashVisible: applySetState(s.startupSplashVisible, update) })),
+  setNeedsOnboarding: (update) => set((s) => ({ needsOnboarding: applySetState(s.needsOnboarding, update) })),
+}));

--- a/desktop/frontend/src/store/setState.ts
+++ b/desktop/frontend/src/store/setState.ts
@@ -1,0 +1,10 @@
+import type { SetStateAction } from "react";
+
+// applySetState mirrors React's setState contract: resolve the next value from
+// either a direct value or an updater (prev => next). It lets a zustand store
+// expose Dispatch<SetStateAction<T>> setters that are drop-in replacements for
+// useState — so migrated call sites, including functional updaters like
+// setOpen(v => !v), need no changes.
+export function applySetState<T>(prev: T, update: SetStateAction<T>): T {
+  return typeof update === "function" ? (update as (value: T) => T)(prev) : update;
+}


### PR DESCRIPTION
## What

Third slice of the desktop **frontend state-layer modernization** (follows #5150 and #5151).

Creates `src/store/overlays.ts` (zustand) and moves the **12 transient overlay/modal atoms** out of `App.tsx` useState, read via selectors:

- `settingsTarget` / `settingsFocus` — settings panel open target + focus
- `paletteOpen` / `paletteSessions` — command palette open state + its session list
- `shortcutsOpen`, `heartbeatOpen`, `topicExportOpen`, `sidebarSearchOpen` — dialog/search open flags
- `sidebarSearchFocusSignal`, `transientOverlayDismissSignal` — imperative coordination signals (bump → effect)
- `startupSplashVisible`, `needsOnboarding` — startup splash + onboarding gate

## Behavior

Unchanged. Nothing here is persisted, and every atom keeps its prior initial value (the splash still probes `sessionStorage` via `shouldShowStartupSplash`, now from the store initializer). Setters mirror `Dispatch<SetStateAction<T>>`, so all call sites are drop-in — including functional updaters like `setPaletteOpen(c => ...)` and the signal bumps `setSidebarSearchFocusSignal(s => s + 1)`.

## Also

Extracts the `SetStateAction` resolver shared by the layout and overlays stores into `src/store/setState.ts` (`applySetState`) and points `layout.ts` at it to drop the duplicate introduced in #5151.

## Result

`App.tsx` is down to **33 useState** (from 54 at the start of this track).

## Verification

- `tsc --noEmit` (main + `tsconfig.test.json`) — clean under `noUnusedLocals`/`noUnusedParameters`
- `pnpm build` (css checks + tsc + vite) ✓
- `pnpm test` — full frontend suite, all green