### PR TITLE
fix(desktop): keep project history topics out of blank reuse

### DIFF
--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -254,6 +254,36 @@ func TestEnsureBlankTabOpensExistingProjectSidebarBlankTopic(t *testing.T) {
 	}
 }
 
+func TestEnsureBlankTabDoesNotReuseProjectTopicWithSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := robustTempDir(t)
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	existingPath := writeTopicSession(t, dir, "existing.jsonl", topic.ID, defaultTopicTitle, projectRoot)
+	if got, _ := app.findTopicSessionForTarget("project", projectRoot, topic.ID); got != existingPath {
+		t.Fatalf("precondition topic session = %q, want %q", got, existingPath)
+	}
+
+	meta, err := app.EnsureBlankTab("project", projectRoot)
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.TopicID == topic.ID {
+		t.Fatalf("EnsureBlankTab reused topic %q even though it already has session %q", topic.ID, existingPath)
+	}
+	if got, _ := app.findTopicSessionForTarget("project", projectRoot, topic.ID); got != existingPath {
+		t.Fatalf("existing topic session changed = %q, want %q", got, existingPath)
+	}
+}
+
 // NewSession skips the snapshot when the current tab has no real conversation content.
 
 func TestNewSessionNoopsWhenCurrentTabIsBlank(t *testing.T) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1381,7 +1381,27 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		}
 		openTopics[tab.TopicID] = true
 	}
-	sessionIndex, _ := topicSessionIndexForDir(config.SessionDir())
+	seenSessionDirs := map[string]bool{}
+	sessionIndexes := []topicSessionDirIndex{}
+	addSessionIndex := func(dir string) {
+		dir = cleanDesktopPath(dir)
+		if dir == "" {
+			return
+		}
+		if seenSessionDirs[dir] {
+			return
+		}
+		seenSessionDirs[dir] = true
+		if index, err := topicSessionIndexForDir(dir); err == nil {
+			sessionIndexes = append(sessionIndexes, index)
+		}
+	}
+	if scope == "project" {
+		addSessionIndex(desktopSessionDir(workspaceRoot))
+	} else {
+		addSessionIndex(config.SessionDir())
+		addSessionIndex(desktopSessionDir(globalWorkspaceRoot()))
+	}
 	for _, topicID := range topicIDs {
 		if openTopics[topicID] {
 			continue
@@ -1389,7 +1409,14 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		if topicTitleForTab(scope, workspaceRoot, topicID) != defaultTopicTitle {
 			continue
 		}
-		if topicSessionIndexHasTopic(sessionIndex, topicID) {
+		hasSession := false
+		for _, index := range sessionIndexes {
+			if topicSessionIndexHasTopic(index, topicID) {
+				hasSession = true
+				break
+			}
+		}
+		if hasSession {
 			continue
 		}
 		return topicID


### PR DESCRIPTION
## Summary

- Fix #5097 by checking the target desktop session directory before reusing an indexed blank project topic.
- Keep project topics that already have saved sessions from being reset/reused as `新的会话` when another new session is created.
- Add regression coverage for the project-topic/session case that previously reproduced the sidebar history corruption.

## Verification

- `cd desktop && go test . -run 'TestEnsureBlankTab|TestNewSessionNoopsWhenCurrentTabIsBlank' -count=1`
- `git diff --check`
- `gofmt -l desktop/tabs.go desktop/app_session_dedup_test.go`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `go test ./...`
- `cd desktop && go test ./...`

## Cache impact

Cache-impact: none. This is limited to desktop sidebar topic/session reuse and does not change provider-visible prompts, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.
Cache-guard: `cd desktop && go test . -run 'TestEnsureBlankTab|TestNewSessionNoopsWhenCurrentTabIsBlank' -count=1`
System-prompt-review: N/A

Fixes #5097
