### PR TITLE
fix(desktop): keep overview stats aligned

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -127,12 +127,24 @@ for (const selector of [
   ".context-panel__section-head span",
   ".context-panel__metric span",
   ".context-panel__metric strong",
+  ".app--creation .context-panel__mini-stat span",
+  ".app--creation .context-panel__mini-stat strong",
   ".topbar__model",
   ".composer-modebar__item span",
   ".composer-more-menu__item span",
 ]) {
   clipsSingleLine(selector);
 }
+
+eq(
+  finalDeclaration(".app--creation .context-panel__mini-stat", "display"),
+  "flex",
+  "creation overview rows keep values next to their labels",
+);
+ok(
+  finalDeclaration(".app--creation .context-panel__mini-stat", "justify-content") !== "space-between",
+  "creation overview rows avoid edge-pinned value alignment",
+);
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
 eq(finalDeclaration(".md table", "overflow-x"), "auto", "markdown tables scroll horizontally");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -25596,10 +25596,9 @@ a[href] {
 
 .app--creation .context-panel__mini-stat {
   min-width: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 8px;
   color: color-mix(in srgb, var(--fg-dim) 84%, transparent);
   font-size: 12px;
   line-height: 1.2;
@@ -25614,6 +25613,12 @@ a[href] {
 }
 
 .app--creation .context-panel__mini-stat strong {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 14ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg);
   font-weight: 600;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## Summary

- Fix #5154 by rendering the creation-mode context overview mini stats as inline label/value pairs instead of a spacer grid that pins values to the card edge.
- Add a typography overflow contract for the creation overview mini-stat labels and values so the narrow right dock stays stable at larger text sizes.

## Verification

- `corepack pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts`
- `go run github.com/wailsapp/wails/v2/cmd/wails@v2.12.0 generate module`
- `go test ./...`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && corepack pnpm run test:all)`
- `(cd desktop/frontend && corepack pnpm run build)`
- `git diff --check`

## Cache impact

Cache-impact: none. Desktop frontend CSS/test only; no provider-visible prompt, memory prefix, tool schema, request serialization, compaction, or MCP/tool registration changes.
Cache-guard: `corepack pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts`
System-prompt-review: N/A

Fixes #5154
