### PR TITLE
fix(desktop): honor language setting for replies

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1097,7 +1097,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
   };
   return (
     <SettingsSection>
-      <SettingsField label={t("settings.language")}>
+      <SettingsField label={t("settings.language")} hint={t("settings.languageHint")}>
         <div className="set-seg">
           {LANGUAGE_PREFS.map((pref) => (
             <button

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1412,6 +1412,7 @@ export const en = {
   "settings.bashEnforceShort": "Jailed bash",
   "settings.bashOffShort": "Unconfined",
   "settings.language": "Language",
+  "settings.languageHint": "Controls the desktop UI and the default language for model replies. Auto follows the current user message.",
   "settings.langAuto": "Auto (system)",
   "settings.config": "config: {path}",
   "settings.generativeMusic": "Generative background music",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -868,6 +868,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.bashEnforceShort": "強制隔離",
   "settings.bashOffShort": "不受限執行",
   "settings.language": "語言",
+  "settings.languageHint": "控制桌面介面與模型回覆的預設語言。自動模式會跟隨目前使用者訊息。",
   "settings.langAuto": "自動（跟隨系統）",
   "settings.config": "設定檔：{path}",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1414,6 +1414,7 @@ export const zh: Record<DictKey, string> = {
   "settings.bashEnforceShort": "强制隔离",
   "settings.bashOffShort": "不受限运行",
   "settings.language": "语言",
+  "settings.languageHint": "控制桌面界面与模型回复的默认语言。自动模式跟随当前用户消息。",
   "settings.langAuto": "自动（跟随系统）",
   "settings.config": "配置文件：{path}",
   "settings.generativeMusic": "生成式背景音乐",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1720,13 +1720,24 @@ func (a *App) SetStatusBarItems(items []string) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopStatusBarItems(items) })
 }
 
-// SetDesktopLanguage updates only the desktop UI language. It deliberately does
-// not touch config.language, which the CLI/model-facing runtime uses.
+// SetDesktopLanguage updates the desktop UI language and the user-level response
+// language preference used by model-facing desktop sessions.
 func (a *App) SetDesktopLanguage(lang string) error {
-	if err := a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopLanguage(lang) }); err != nil {
+	responseLanguage := ""
+	if err := a.applyConfigOnly(func(c *config.Config) error {
+		if err := c.SetDesktopLanguage(lang); err != nil {
+			return err
+		}
+		if err := c.SetLanguage(lang); err != nil {
+			return err
+		}
+		responseLanguage = c.ResponseLanguage()
+		return nil
+	}); err != nil {
 		return err
 	}
 	a.updateTrayLocale(lang)
+	a.applyResponseLanguageToLiveControllers(responseLanguage)
 	return nil
 }
 
@@ -1872,6 +1883,28 @@ func (a *App) applyReasoningLanguageToLiveControllers(fallback string) {
 			mode = cfg.ReasoningLanguage()
 		}
 		tab.ctrl.SetReasoningLanguage(mode)
+	}
+}
+
+func (a *App) applyResponseLanguageToLiveControllers(fallback string) {
+	type liveTab struct {
+		root string
+		ctrl control.SessionAPI
+	}
+	var tabs []liveTab
+	a.mu.RLock()
+	for _, tab := range a.tabs {
+		if tab != nil && tab.Ctrl != nil {
+			tabs = append(tabs, liveTab{root: tab.WorkspaceRoot, ctrl: tab.Ctrl})
+		}
+	}
+	a.mu.RUnlock()
+	for _, tab := range tabs {
+		mode := fallback
+		if cfg, err := config.LoadForRoot(tab.root); err == nil {
+			mode = cfg.ResponseLanguage()
+		}
+		tab.ctrl.SetResponseLanguage(mode)
 	}
 }
 

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -532,6 +532,53 @@ func TestSetReasoningLanguagePersistsToUserConfig(t *testing.T) {
 	}
 }
 
+func TestSetDesktopLanguagePersistsResponseLanguageAndUpdatesLiveTabs(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "reasonix.toml"), []byte("language = \"zh\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	userCtrl := control.New(control.Options{})
+	projectCtrl := control.New(control.Options{})
+	app.tabs = map[string]*WorkspaceTab{
+		"user": {
+			ID:          "user",
+			Scope:       "global",
+			Ctrl:        userCtrl,
+			Ready:       true,
+			disabledMCP: map[string]ServerView{},
+		},
+		"project": {
+			ID:            "project",
+			Scope:         "project",
+			WorkspaceRoot: projectRoot,
+			Ctrl:          projectCtrl,
+			Ready:         true,
+			disabledMCP:   map[string]ServerView{},
+		},
+	}
+	app.activeTabID = "user"
+
+	if err := app.SetDesktopLanguage("en"); err != nil {
+		t.Fatalf("SetDesktopLanguage: %v", err)
+	}
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if cfg.DesktopLanguage() != "en" || cfg.Language != "en" {
+		t.Fatalf("saved language prefs = desktop:%q response:%q, want en/en", cfg.DesktopLanguage(), cfg.Language)
+	}
+	got := userCtrl.Compose("解释这个函数")
+	if !strings.Contains(got, "<response-language>") || !strings.Contains(got, "use English") {
+		t.Fatalf("live controller Compose = %q, want English response language", got)
+	}
+	projectComposed := projectCtrl.Compose("explain this function")
+	if !strings.Contains(projectComposed, "use Simplified Chinese") {
+		t.Fatalf("project controller Compose = %q, want project zh response language", projectComposed)
+	}
+}
+
 func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -46,7 +46,7 @@ For the desktop and CLI usage of visible reasoning language, see
 
 ```toml
 default_model = "deepseek-flash"   # executor; set [agent].planner_model to add a planner
-# language    = "zh"               # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
+# language    = "zh"               # UI and default reply language; empty = auto-detect/follow current user message
 
 [ui]
 # shortcut_layout = "desktop"      # classic|desktop; compatibility setting

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -38,7 +38,7 @@ Reasonix 全局 `<Reasonix home>/.env`。项目 `.env`、home `.env`、继承的
 
 ```toml
 default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可加规划器
-# language    = "zh"               # 界面语言；为空则按 $LANG / $REASONIX_LANG 自动检测
+# language    = "zh"               # 界面与默认回复语言；为空则自动检测/跟随当前用户消息
 
 [ui]
 # shortcut_layout = "desktop"      # classic|desktop；兼容旧配置

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -462,7 +462,7 @@ Project `reasonix.toml` does not override `agent.max_steps` or
 
 ```toml
 default_model = "deepseek"   # provider name (→ its default model) or "provider/model"
-# language    = "zh"                # ui language tag; empty = auto-detect from $LANG / $REASONIX_LANG
+# language    = "zh"                # UI and default reply language; empty = auto-detect/follow current user message
 
 [agent]
 system_prompt = "You are Reasonix, a coding agent..."  # or system_prompt_file = "..."

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -216,6 +216,7 @@ type Agent struct {
 	temperature          float64
 	pricing              *provider.Pricing
 	usageSource          string
+	responseLanguage     atomic.Value // string: auto|zh|en
 	reasoningLanguage    atomic.Value // string: auto|zh|en
 
 	// sink receives the turn's typed event stream (reasoning/text deltas, tool
@@ -386,6 +387,15 @@ func (a *Agent) SetReasoningLanguage(lang string) {
 	a.reasoningLanguage.Store(NormalizeReasoningLanguage(lang))
 }
 
+// SetResponseLanguage updates the final-answer language preference for
+// subsequent user-role messages emitted by this agent.
+func (a *Agent) SetResponseLanguage(lang string) {
+	if a == nil {
+		return
+	}
+	a.responseLanguage.Store(NormalizeResponseLanguage(lang))
+}
+
 // SetGate installs the per-call permission gate. Used by interactive CLI sessions to swap the
 // headless gate built in setup for an interactive one that prompts the user;
 // nil disables gating. Safe to call before the run loop starts.
@@ -396,17 +406,25 @@ func (a *Agent) SetGate(g Gate) {
 	a.gate = g
 }
 
-func (a *Agent) withReasoningLanguage(input string) string {
+func (a *Agent) withTurnPreferences(input string) string {
 	if a == nil {
 		return input
 	}
-	lang := "auto"
-	if v := a.reasoningLanguage.Load(); v != nil {
+	responseLang := "auto"
+	if v := a.responseLanguage.Load(); v != nil {
 		if s, ok := v.(string); ok {
-			lang = s
+			responseLang = s
 		}
 	}
-	return WithReasoningLanguage(input, lang)
+	input = WithResponseLanguage(input, responseLang)
+
+	reasoningLang := "auto"
+	if v := a.reasoningLanguage.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			reasoningLang = s
+		}
+	}
+	return WithReasoningLanguage(input, reasoningLang)
 }
 
 // SetAsker installs the asker the `ask` tool uses to question the user.
@@ -577,6 +595,9 @@ type Options struct {
 	// ReasoningLanguage controls visible reasoning language preference as transient
 	// user-turn context. Empty/auto injects nothing.
 	ReasoningLanguage string
+	// ResponseLanguage controls final-answer language preference as transient
+	// user-turn context. Empty/auto keeps the stable same-as-user policy.
+	ResponseLanguage string
 
 	// PlanModeAllowedTools names tools that bypass the plan-mode read-only gate.
 	// When a tool named here is called while planMode is true, it executes
@@ -653,6 +674,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		keepPolicy:           opts.KeepPolicy,
 		planModeAllowedTools: stringSet(opts.PlanModeAllowedTools),
 	}
+	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
 	return a
 }
@@ -681,7 +703,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	}
 	a.repeatSuccessCounts = nil
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
-	input = a.withReasoningLanguage(input)
+	input = a.withTurnPreferences(input)
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
 
 	finalReadinessBlocks := 0
@@ -697,7 +719,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		// guidance (with a prefix), not a new task. One cache miss per
 		// steer is unavoidable — the model must see the new instruction.
 		if text, ok := a.consumeSteer(); ok {
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(midTurnSteerMessage(text))})
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
 			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
 		}
 		schemas := a.tools.Schemas()
@@ -721,7 +743,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				}
 				a.session.Add(provider.Message{
 					Role:    provider.RoleUser,
-					Content: a.withReasoningLanguage(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
+					Content: a.withTurnPreferences(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
 				})
 				a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: streamRecoveries, RetryMax: maxStreamRecoveries})
 				step-- // recovery retries do not consume the tool-round maxSteps budget
@@ -768,7 +790,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				}
 				event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + readiness.reason})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(finalReadinessRetryMessage(readiness.reason))})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(finalReadinessRetryMessage(readiness.reason))})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -778,14 +800,14 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
 				}
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: emptyFinalNotice(a.prov.Name(), usage, len(reasoning))})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(emptyFinalRetryMessage())})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
 			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(input, text) {
 				handoffNudges++
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(executorHandoffRetryMessage())})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(executorHandoffRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -834,7 +856,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		if a.maxSteps > 0 && step+1 >= a.maxSteps {
 			graceRound = true
 			nudge := fmt.Sprintf("Do not call any more tools — your tool-call round limit (%s) has been reached. Instead, synthesize a final answer from all the work already completed: summarize what was accomplished, what remains to be done, and any decisions the user should make. The user can increase %s or continue in the next turn if more work is needed.", a.maxStepsKey, a.maxStepsKey)
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(nudge)})
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("budget (%s=%d) exhausted: one grace round to finalize", a.maxStepsKey, a.maxSteps)})
 		}
 	}
@@ -1785,6 +1807,11 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)
+	}
+	if v := a.responseLanguage.Load(); v != nil {
+		if lang, ok := v.(string); ok {
+			cctx = WithResponseLanguagePreference(cctx, lang)
+		}
 	}
 	if v := a.reasoningLanguage.Load(); v != nil {
 		if lang, ok := v.(string); ok {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -140,6 +140,19 @@ func (c *Coordinator) SetReasoningLanguage(lang string) {
 	}
 }
 
+// SetResponseLanguage updates both agents in two-model mode.
+func (c *Coordinator) SetResponseLanguage(lang string) {
+	if c == nil {
+		return
+	}
+	if c.plannerAgent != nil {
+		c.plannerAgent.SetResponseLanguage(lang)
+	}
+	if c.executor != nil {
+		c.executor.SetResponseLanguage(lang)
+	}
+}
+
 // SetPlanMode propagates the read-only gate to both planner and executor agents
 // in two-model mode. Callers that only set the controller's executor would miss
 // the planner agent inside the Coordinator, causing stale plan-mode state after
@@ -240,7 +253,7 @@ func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan strin
 	if c == nil || c.executor == nil || c.executor.session == nil {
 		return
 	}
-	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withReasoningLanguage(input), Images: userImages(ctx)})
+	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withTurnPreferences(input), Images: userImages(ctx)})
 	c.executor.session.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
 }
 

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -269,6 +269,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 					CompactForceRatio: p.taskTool.compactForceRatio,
 					ArchiveDir:        p.taskTool.archiveDir,
 					KeepPolicy:        p.taskTool.keepPolicy,
+					ResponseLanguage:  ResponseLanguageFromContext(ctx),
 				}, nested)
 
 				if runErr != nil {

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:reasoning-language|memory-update|background-jobs)>.*?</(?:reasoning-language|memory-update|background-jobs)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs)>\s*\n?`)
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -6,6 +6,7 @@ import (
 )
 
 type reasoningLanguageContextKey struct{}
+type responseLanguageContextKey struct{}
 
 // NormalizeReasoningLanguage returns one of auto|zh|en for runtime-only visible
 // reasoning preferences. Keep this local to agent so sub-agents can inherit the
@@ -18,6 +19,33 @@ func NormalizeReasoningLanguage(lang string) string {
 		return "en"
 	default:
 		return "auto"
+	}
+}
+
+// NormalizeResponseLanguage returns one of auto|zh|en for final-answer language
+// preferences. Auto keeps the stable same-as-user language policy.
+func NormalizeResponseLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "zh", "cn", "chinese", "中文":
+		return "zh"
+	case "en", "english":
+		return "en"
+	default:
+		return "auto"
+	}
+}
+
+// ResponseLanguageBlock is transient user-turn context for final answers. It
+// stays out of the stable system prompt so changing the preference between turns
+// does not churn the cached prefix.
+func ResponseLanguageBlock(lang string) string {
+	switch NormalizeResponseLanguage(lang) {
+	case "zh":
+		return "<response-language>\nFinal answer language preference: use Simplified Chinese for user-facing replies unless the user explicitly asks for another language. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form.\n</response-language>"
+	case "en":
+		return "<response-language>\nFinal answer language preference: use English for user-facing replies unless the user explicitly asks for another language. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form.\n</response-language>"
+	default:
+		return ""
 	}
 }
 
@@ -34,24 +62,46 @@ func ReasoningLanguageBlock(lang string) string {
 	}
 }
 
+// WithResponseLanguage prefixes content with the transient response-language
+// block unless the turn already starts with one.
+func WithResponseLanguage(content, lang string) string {
+	block := ResponseLanguageBlock(lang)
+	if block == "" || hasLeadingInjectedBlock(content, "response-language") {
+		return content
+	}
+	return block + "\n\n" + content
+}
+
 // WithReasoningLanguage prefixes content with the transient reasoning-language
 // block unless the turn already starts with an injected reasoning-language
 // block. User-authored mentions of the tag later in the prompt must not suppress
 // the configured preference.
 func WithReasoningLanguage(content, lang string) string {
 	block := ReasoningLanguageBlock(lang)
-	if block == "" || hasLeadingReasoningLanguageBlock(content) {
+	if block == "" || hasLeadingInjectedBlock(content, "reasoning-language") {
 		return content
 	}
 	return block + "\n\n" + content
 }
 
-func hasLeadingReasoningLanguageBlock(content string) bool {
+func hasLeadingInjectedBlock(content, target string) bool {
 	s := strings.TrimLeft(content, " \t\r\n")
 	for {
 		switch {
-		case strings.HasPrefix(s, "<reasoning-language>"):
-			return strings.Contains(s, "</reasoning-language>")
+		case strings.HasPrefix(s, "<"+target+">"):
+			return strings.Contains(s, "</"+target+">")
+		case target != "response-language" && strings.HasPrefix(s, "<response-language>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "response-language")
+			if !ok {
+				return false
+			}
+		case target != "reasoning-language" && strings.HasPrefix(s, "<reasoning-language>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "reasoning-language")
+			if !ok {
+				return false
+			}
 		case strings.HasPrefix(s, "<memory-update>"):
 			var ok bool
 			s, ok = trimLeadingTransientBlock(s, "memory-update")
@@ -77,6 +127,26 @@ func trimLeadingTransientBlock(content, tag string) (string, bool) {
 		return content, false
 	}
 	return strings.TrimLeft(content[i+len(closeTag):], " \t\r\n"), true
+}
+
+// WithResponseLanguagePreference carries the runtime final-answer language
+// preference to spawned tools and sub-agents.
+func WithResponseLanguagePreference(ctx context.Context, lang string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, responseLanguageContextKey{}, NormalizeResponseLanguage(lang))
+}
+
+// ResponseLanguageFromContext returns auto|zh|en.
+func ResponseLanguageFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return "auto"
+	}
+	if v, ok := ctx.Value(responseLanguageContextKey{}).(string); ok {
+		return NormalizeResponseLanguage(v)
+	}
+	return "auto"
 }
 
 // WithReasoningLanguagePreference carries the runtime preference to spawned

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -275,6 +275,22 @@ func TestPreviewSessionStripsTransientReasoningLanguageBlock(t *testing.T) {
 	}
 }
 
+func TestPreviewSessionStripsTransientResponseLanguageBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "<response-language>\nFinal answer language preference: use English.\n</response-language>\n\nHelp me debug the auth module"})
+	s.Save(path)
+
+	preview, turns := previewSession(path)
+	if turns != 1 {
+		t.Errorf("turns = %d, want 1", turns)
+	}
+	if preview != "Help me debug the auth module" {
+		t.Errorf("preview = %q, want user prompt", preview)
+	}
+}
+
 func TestPreviewSessionLongMessage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -514,6 +514,7 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		CompactForceRatio: t.compactForceRatio,
 		ArchiveDir:        t.archiveDir,
 		KeepPolicy:        t.keepPolicy,
+		ResponseLanguage:  ResponseLanguageFromContext(ctx),
 		ReasoningLanguage: ReasoningLanguageFromContext(ctx),
 	}, sink)
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -650,6 +650,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			RecentKeep:        cfg.Agent.RecentKeep,
 			ArchiveDir:        config.ArchiveDir(),
 			KeepPolicy:        keepPolicy,
+			ResponseLanguage:  agent.ResponseLanguageFromContext(sctx),
 			ReasoningLanguage: agent.ReasoningLanguageFromContext(sctx),
 		}, agent.NestedSink(sctx, event.Discard))
 		if err != nil {
@@ -852,6 +853,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		RecentKeep:           cfg.Agent.RecentKeep,
 		ArchiveDir:           config.ArchiveDir(),
 		KeepPolicy:           keepPolicy,
+		ResponseLanguage:     cfg.ResponseLanguage(),
 		ReasoningLanguage:    cfg.ReasoningLanguage(),
 		PlanModeAllowedTools: cfg.Agent.PlanModeAllowedTools,
 	}, sink)
@@ -900,6 +902,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				RecentKeep:        cfg.Agent.RecentKeep,
 				ArchiveDir:        config.ArchiveDir(),
 				KeepPolicy:        keepPolicy,
+				ResponseLanguage:  cfg.ResponseLanguage(),
 				ReasoningLanguage: cfg.ReasoningLanguage(),
 			}, executor, cfg.Agent.Temperature, sink, control.NewPlannerGate(classifier))
 			label = entry.Model + " + planner " + pe.Model
@@ -932,6 +935,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:              ctx,
 		WorkspaceRoot:          root,
 		AutoPlan:               cfg.Agent.AutoPlan,
+		ResponseLanguage:       cfg.ResponseLanguage(),
 		ReasoningLanguage:      cfg.ReasoningLanguage(),
 		DisableColdResumePrune: !cfg.ColdResumePruneEnabled(),
 		Shell:                  shell,

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/agent/testutil"
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/memory"
 	"reasonix/internal/netclient"
@@ -1502,6 +1503,39 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	sys := systemMessage(ctrl.History())
 	if !strings.Contains(sys, config.LanguagePolicy) {
 		t.Fatalf("language policy missing from system prompt:\n%s", sys)
+	}
+}
+
+func TestBuildUsesConfiguredLanguageForResponsePreference(t *testing.T) {
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+language = "en"
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	ctrl, err := Build(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	got := ctrl.Compose("解释这个函数")
+	if !strings.Contains(got, "<response-language>") || !strings.Contains(got, "use English") {
+		t.Fatalf("configured language should ride the next user turn, got %q", got)
+	}
+	if stripped := control.StripComposePrefixes(got); stripped != "解释这个函数" {
+		t.Fatalf("StripComposePrefixes = %q, want raw user text", stripped)
 	}
 }
 

--- a/internal/cli/language.go
+++ b/internal/cli/language.go
@@ -58,6 +58,9 @@ func (m *chatTUI) runLanguageSubcommand(input string) {
 	}
 
 	resolved := i18n.DetectLanguage(lang)
+	if m.ctrl != nil {
+		m.ctrl.SetResponseLanguage(lang)
+	}
 	m.notice(fmt.Sprintf(i18n.M.LanguageChangedFmt, languageDisplay(lang), resolved))
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,7 @@ func SkillNameKey(name string) string {
 type Config struct {
 	ConfigVersion    int                 `toml:"config_version"`
 	DefaultModel     string              `toml:"default_model"`
-	Language         string              `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
+	Language         string              `toml:"language"` // UI/default reply language tag (e.g. "zh"); empty = auto-detect/follow current user message
 	CredentialsStore string              `toml:"credentials_store"`
 	UI               UIConfig            `toml:"ui"`
 	Desktop          DesktopConfig       `toml:"desktop"`
@@ -183,6 +183,27 @@ func (c *Config) DesktopLanguage() string {
 		return "zh"
 	default:
 		return ""
+	}
+}
+
+// ResponseLanguage normalizes the top-level language preference for final
+// answers. Empty means auto: replies follow the current user turn.
+func (c *Config) ResponseLanguage() string {
+	if c == nil {
+		return "auto"
+	}
+	return NormalizeLanguage(c.Language)
+}
+
+// NormalizeLanguage returns one of auto|zh|en for UI/default reply language settings.
+func NormalizeLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "zh", "cn", "chinese", "中文":
+		return "zh"
+	case "en", "english":
+		return "en"
+	default:
+		return "auto"
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -52,9 +52,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	fmt.Fprintf(&b, "config_version = %d   # schema marker for diagnostics; old versions may ignore it\n", configVersion(c))
 	fmt.Fprintf(&b, "default_model = %q\n", c.DefaultModel)
 	if c.Language != "" {
-		fmt.Fprintf(&b, "language      = %q   # ui/model language; empty = auto-detect from $LANG / $REASONIX_LANG\n", c.Language)
+		fmt.Fprintf(&b, "language      = %q   # UI and default reply language; empty = auto-detect/follow current user message\n", c.Language)
 	} else {
-		b.WriteString("# language      = \"zh\"   # ui/model language; empty = auto-detect from $LANG / $REASONIX_LANG\n")
+		b.WriteString("# language      = \"zh\"   # UI and default reply language; empty = auto-detect/follow current user message\n")
 	}
 	if scope != RenderScopeProject {
 		fmt.Fprintf(&b, "credentials_store = %q   # legacy compatibility; provider keys are saved in Reasonix's global .env\n", normalizeCredentialsStore(c.CredentialsStore))

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -84,6 +84,7 @@ type Controller struct {
 	memory            memoryManager
 	cleanup           func()
 	autoPlan          string
+	responseLanguage  string
 	reasoningLanguage string
 	// disableColdResumePrune skips stale-tool-result elision on cold resume.
 	// Zero value keeps the prune on (the cheaper default).
@@ -247,6 +248,10 @@ type Options struct {
 	// no confinement). Frontends pass the cwd they launched the session in.
 	WorkspaceRoot string
 	AutoPlan      string
+	// ResponseLanguage controls final-answer language preference. Empty/auto
+	// means no transient injection because the stable language policy follows the
+	// current user turn.
+	ResponseLanguage string
 	// ReasoningLanguage controls visible reasoning language preference. Empty/auto
 	// means no transient injection because the stable language policy already
 	// follows the conversation language.
@@ -303,6 +308,7 @@ func New(opts Options) *Controller {
 		memory:                 newMemoryManager(opts.Memory),
 		cleanup:                opts.Cleanup,
 		autoPlan:               normalizeAutoPlan(opts.AutoPlan),
+		responseLanguage:       config.NormalizeLanguage(opts.ResponseLanguage),
 		reasoningLanguage:      config.NormalizeReasoningLanguage(opts.ReasoningLanguage),
 		disableColdResumePrune: opts.DisableColdResumePrune,
 		shell:                  opts.Shell,
@@ -1455,6 +1461,20 @@ func (c *Controller) SetReasoningLanguage(lang string) {
 		setter.SetReasoningLanguage(mode)
 	} else if c.executor != nil {
 		c.executor.SetReasoningLanguage(mode)
+	}
+}
+
+// SetResponseLanguage updates the final-answer language preference for
+// subsequent turns.
+func (c *Controller) SetResponseLanguage(lang string) {
+	mode := config.NormalizeLanguage(lang)
+	c.mu.Lock()
+	c.responseLanguage = mode
+	c.mu.Unlock()
+	if setter, ok := c.runner.(interface{ SetResponseLanguage(string) }); ok {
+		setter.SetResponseLanguage(mode)
+	} else if c.executor != nil {
+		c.executor.SetResponseLanguage(mode)
 	}
 }
 

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -137,6 +137,7 @@ var syntheticPrefixes = []string{
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
+	responseLanguage := c.responseLanguage
 	reasoningLanguage := c.reasoningLanguage
 	c.mu.Unlock()
 	notes := c.memory.drainPending()
@@ -148,6 +149,7 @@ func (c *Controller) Compose(text string) string {
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
 	}
+	text = agent.WithResponseLanguage(text, responseLanguage)
 	text = agent.WithReasoningLanguage(text, reasoningLanguage)
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
@@ -181,8 +183,10 @@ func reasoningLanguageBlock(lang string) string {
 
 func (c *Controller) ComposeSynthetic(text string) string {
 	c.mu.Lock()
+	responseLang := c.responseLanguage
 	lang := c.reasoningLanguage
 	c.mu.Unlock()
+	text = agent.WithResponseLanguage(text, responseLang)
 	return agent.WithReasoningLanguage(text, lang)
 }
 

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -186,6 +186,7 @@ type Input interface {
 
 // Settings covers runtime session settings that don't fit a richer domain.
 type Settings interface {
+	SetResponseLanguage(lang string)
 	SetReasoningLanguage(lang string)
 	SetDisplayRecorder(fn func(content, display string))
 }

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -5,7 +5,7 @@
 # Reasonix's global ~/.reasonix/.env. Never put API key values here.
 
 default_model = "deepseek"   # a provider name (→ its default model) or "provider/model"
-# language      = "zh"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
+# language      = "zh"   # UI and default reply language; empty = auto-detect/follow current user message
 
 [ui]
 theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can override per run


### PR DESCRIPTION
## Summary

- Fixes #5159 by making the desktop Language setting also persist the model response-language preference.
- Carries `language = "en"|"zh"` into model turns through a small transient `<response-language>` block, so the cache-stable system prompt and tool schemas stay unchanged.
- Keeps Thinking language scoped to visible reasoning only, strips transient language blocks from history previews, and documents the updated Language setting behavior.

## Verification

- `go test ./internal/agent ./internal/control ./internal/boot ./internal/config -count=1`
- `cd desktop && go test . -count=1`
- `go test ./...`
- `cd desktop && go test ./...`
- `cd desktop/frontend && corepack pnpm run typecheck`
- `cd desktop/frontend && corepack pnpm run test:typecheck`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `git diff --check && gofmt -l .`

## Cache impact

Cache-impact: low — explicit response-language preferences add a small transient user-turn block; cache-stable system prompt, memory prefix, tool schemas, tool ordering, request serialization, compaction, and MCP/tool registration are unchanged.
Cache-guard: go test ./internal/boot -run TestBuildUsesConfiguredLanguageForResponsePreference -count=1 plus go test ./internal/agent -run TestPreviewSessionStripsTransientResponseLanguageBlock -count=1 cover transient injection and preview stripping.
System-prompt-review: not required because this does not change the system prompt, memory prefix, output style, or skill index; the new language preference rides user-turn context.
