### PR TITLE
fix(desktop): fix deleted project still showing after restart

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2794,18 +2794,9 @@ func (a *App) RemoveWorkspace(dir string) error {
 	var closeDetached []*WorkspaceTab
 	var fallback *WorkspaceTab
 	a.mu.Lock()
-	for _, tab := range a.tabs {
-		if tabInWorkspace(tab, dir) && tab.hasActiveRuntimeWork() {
-			a.mu.Unlock()
-			return fmt.Errorf("workspace has running sessions; stop them before removing")
-		}
-	}
-	for _, tab := range a.detachedSessions {
-		if tabInWorkspace(tab, dir) && tab.hasActiveRuntimeWork() {
-			a.mu.Unlock()
-			return fmt.Errorf("workspace has running sessions; stop them before removing")
-		}
-	}
+	// Force-remove even when a tab has active runtime work: closeTabRuntime
+	// snapshots before cancelling, so the session is preserved without
+	// blocking the removal.
 	for id, tab := range a.tabs {
 		if !tabInWorkspace(tab, dir) {
 			continue
@@ -2859,7 +2850,7 @@ func (a *App) RemoveWorkspace(dir string) error {
 	}
 	// If the removed workspace was the active one, clear the pointer
 	// so we don't leave a stale reference to a deleted project.
-	if loadWorkspace() == dir {
+	if sameDesktopPath(loadWorkspace(), dir) {
 		if remaining := loadProjectsFile(); len(remaining.Projects) > 0 {
 			// Fall back to the first remaining project
 			saveWorkspace(remaining.Projects[0].Root)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1157,7 +1157,7 @@ func tabMatchesTopicTarget(tab *WorkspaceTab, scope, workspaceRoot, topicID stri
 func tabInWorkspace(tab *WorkspaceTab, workspaceRoot string) bool {
 	return tab != nil &&
 		tab.Scope == "project" &&
-		normalizeProjectRoot(tab.WorkspaceRoot) == normalizeProjectRoot(workspaceRoot)
+		sameDesktopPath(tab.WorkspaceRoot, workspaceRoot)
 }
 
 // EnsureBlankTab activates the existing blank tab for the target scope, or
@@ -2863,7 +2863,7 @@ func removeProject(root string) error {
 	f := loadProjectsFile()
 	projects := make([]desktopProject, 0, len(f.Projects))
 	for _, p := range f.Projects {
-		if p.Root != root {
+		if !sameDesktopPath(p.Root, root) {
 			projects = append(projects, p)
 		}
 	}

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -353,7 +353,7 @@ func TestRemoveWorkspaceSnapshotsProjectTabBeforeRemovingBinding(t *testing.T) {
 	}
 }
 
-func TestRemoveWorkspaceRejectsRunningProjectRuntime(t *testing.T) {
+func TestRemoveWorkspaceForceCancelsRunningProjectRuntime(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()
 	if err := addProject(projectRoot, "Project"); err != nil {
@@ -386,18 +386,31 @@ func TestRemoveWorkspaceRejectsRunningProjectRuntime(t *testing.T) {
 		activeTabID:      "project",
 		detachedSessions: map[string]*WorkspaceTab{},
 	}
+	app.mu.Lock()
+	app.saveTabsLocked()
+	app.mu.Unlock()
 
 	ctrl.Submit("block")
 	<-runner.started
-	if err := app.RemoveWorkspace(projectRoot); err == nil {
-		t.Fatal("RemoveWorkspace succeeded with a running project session")
+	// A running session used to abort RemoveWorkspace silently — the frontend
+	// swallowed the error and the project resurrected after a restart. Now the
+	// runtime is force-cancelled and the project is removed for real.
+	if err := app.RemoveWorkspace(projectRoot); err != nil {
+		t.Fatalf("RemoveWorkspace with running session: %v", err)
 	}
-	if got := app.ListWorkspaces(); len(got) != 1 || got[0].Path != normalizeProjectRoot(projectRoot) {
-		t.Fatalf("workspaces after rejected remove = %+v, want project retained", got)
-	}
-
-	close(runner.release)
 	waitNotRunning(t, ctrl)
+	close(runner.release)
+
+	assertTabIDs(t, app.ListTabs(), "global")
+	if got := app.ListWorkspaces(); len(got) != 0 {
+		t.Fatalf("workspaces after force remove = %+v, want none", got)
+	}
+	if got := loadProjectsFile().Projects; len(got) != 0 {
+		t.Fatalf("projects after force remove = %+v, want none", got)
+	}
+	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "global" {
+		t.Fatalf("persisted tabs after force remove = %+v, want only global", got)
+	}
 	ctrl.Close()
 }
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1008,6 +1008,50 @@ func TestRemoveWorkspaceUsesSharedProjectRegistryForCurrentProject(t *testing.T)
 	}
 }
 
+func TestRemoveWorkspaceRemovesWindowsPathCaseVariantsFromPersistentRegistries(t *testing.T) {
+	if os.PathSeparator != '\\' {
+		t.Skip("Windows path comparison regression")
+	}
+	isolateDesktopUserDirs(t)
+
+	storedRoot := `C:\Workspace\GamePlatform`
+	removeRoot := `c:\workspace\gameplatform`
+	if err := addProject(storedRoot, "GamePlatform"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	rememberWorkspace(storedRoot)
+	saveWorkspace(storedRoot)
+
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", Scope: "project", WorkspaceRoot: storedRoot, TopicID: "topic-project", Ready: true, disabledMCP: map[string]ServerView{}},
+			"global":  {ID: "global", Scope: "global", WorkspaceRoot: globalTabWorkspaceRoot(), Ready: true, disabledMCP: map[string]ServerView{}},
+		},
+		tabOrder:         []string{"project", "global"},
+		activeTabID:      "project",
+		detachedSessions: map[string]*WorkspaceTab{},
+	}
+	app.mu.Lock()
+	app.saveTabsLocked()
+	app.mu.Unlock()
+
+	if err := app.RemoveWorkspace(removeRoot); err != nil {
+		t.Fatalf("RemoveWorkspace: %v", err)
+	}
+	if got := loadProjectsFile().Projects; len(got) != 0 {
+		t.Fatalf("projects after case-variant remove = %+v, want none", got)
+	}
+	if got := loadWorkspaces(); len(got) != 0 {
+		t.Fatalf("legacy workspaces after case-variant remove = %+v, want none", got)
+	}
+	if got := loadWorkspace(); got != "" {
+		t.Fatalf("active workspace after case-variant remove = %q, want empty", got)
+	}
+	if got := loadTabsFile(); len(got.Tabs) != 1 || got.Tabs[0].ID != "global" {
+		t.Fatalf("persisted tabs after case-variant remove = %+v, want only global", got)
+	}
+}
+
 func TestRestoredProjectTabUsesStoredTopicTitle(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/workspace.go
+++ b/desktop/workspace.go
@@ -134,7 +134,7 @@ func forgetWorkspace(dir string) {
 		if abs, err := filepath.Abs(path); err == nil {
 			path = abs
 		}
-		if path != dir {
+		if !sameDesktopPath(path, dir) {
 			paths = append(paths, path)
 		}
 	}


### PR DESCRIPTION
# 移除项目后重启 Desktop 又出现项目

## 一、问题现象

在 reasonix-desktop 中，从侧边栏右键「移除项目」移除一个项目后，UI 上该项目消失，但**重启应用后项目又自动出现**，包含其历史会话。

## 二、根因

移除操作实际上没有完整执行：项目条目和它的 tab 残留在磁盘上的状态文件中，重启后被恢复流程重新加载并写回，导致"复活"。

### 旧代码的防御性设计与契约脱节

旧 `RemoveWorkspace` 在开头做了一段前置安全检查：扫描该项目下的所有 tab，若发现"运行中"的会话（正在跑的对话、pending prompt、后台任务），就**释放写锁并返回 error**，让用户先手动停止会话。设计意图是保护用户，避免运行中会话被强行打断造成丢失。

```go
for _, tab := range a.tabs {
    if tabInWorkspace(tab, dir) && tab.hasActiveRuntimeWork() {
        a.mu.Unlock()                       // 已持锁，返回前必须释放
        return fmt.Errorf("workspace has running sessions; stop them before removing")
    }
}
```

这段保护逻辑本身**没写错**，但它的成立前提是「调用方会处理这个 error」。而前端 `ProjectTree.tsx` 虽 `await` 了返回值，却**没处理 error**，反而无条件清掉了本地 UI 状态：

| 环节 | 后端意图 | 实际发生 |
|---|---|---|
| 有运行中会话 | 返回 error，提示用户先停止 | error 被吞，用户无感知 |
| UI 表现 | 项目应保持显示 | 项目从侧边栏消失（前端本地状态被清） |
| 磁盘状态 | 一动不动（符合"未删除"） | 一动不动 |
| 重启后 | 项目还在（符合"未删除"） | 项目"复活"（用户以为删了） |

于是出现**认知错位**：后端拒绝并报了错，但保护信号没送达用户，用户看到 UI 上项目消失了，以为删成功，实则磁盘未动，重启后复活。

### 完整复活链路

```
用户点击"移除"（项目恰好有运行中会话）
        │
        ▼
RemoveWorkspace 开头拦截（app.go 旧代码）：
   if tab.hasActiveRuntimeWork() → return error  ←─ 静默中止，后续清理全不执行
        │
        ▼
前端 ProjectTree.tsx 吞掉 error，无提示
   （用户以为删成功了，其实只是前端本地状态变了）
        │
        ▼  ──── 重启 ────
        │
restoreOrBuildTabs 读取 desktop-tabs.json → 恢复残留的项目 tab
        │
        ▼
每个 project tab 的 buildTabControllerWithContext 执行
        │
        ▼
ensureTopicIndexed("project", <root>, ...)
   → tabs.go:3192: 项目不在列表 → append 新项目 → saveProjectsFile
        │
        ▼
项目"复活"，写回 desktop-projects.json
```

### 两个独立诱因（同一症状，不同触发路径）

| 路径 | 触发条件 | 修复 |
|---|---|---|
| **路径 A** | 项目有运行中会话 → `RemoveWorkspace` 静默中止（契约脱节） | 移除拦截，强制取消会话 |
| **路径 B** | Windows 上路径大小写不一致 → 即使执行到 `removeProject`/`forgetWorkspace` 也匹配不到记录 | 用 `sameDesktopPath` 替代 `==` |

两条路径都会导致持久化文件里的项目条目删不掉，重启后被恢复流程读回而复活，需一并修复。

## 三、解决方案

### 1. 后端：强制移除运行中会话（`desktop/app.go`）

删除 `RemoveWorkspace` 开头"有运行中会话就中止"的拦截。后续的 `closeTabRuntime` 本身就实现了 **Snapshot → Cancel → Close** 的完整流程，运行中会话会被先快照保存再取消，项目和 tab 都会被真正删除。相比"修前端提示用户先停止会话"，强制移除点一次即生效，更符合用户"不要这个项目"的明确意图，也不会丢数据（会话已先快照落盘）。

### 2. 后端：Windows 路径大小写无关比较（4 处）

`desktop/app.go`、`desktop/tabs.go`（2 处）、`desktop/workspace.go` 中，把项目删除/匹配相关的 `==` 比较改为已有的 `sameDesktopPath` helper（该 helper 在 Windows 上做 `EqualFold`，其它平台精确比较）。

### 3. 测试（2 个）

- 改写旧的拒绝测试为强制移除测试：验证有运行中会话时仍能强制移除
- 新增 Windows 大小写变体回归测试：验证大小写不同的路径也能删干净