### PR TITLE
fix(agent): recover todo completion after failed signoff

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1801,9 +1801,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
+			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly())
+			a.evidence.Record(rec)
 			if err == nil {
-				rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, t.ReadOnly())
-				a.evidence.Record(rec)
 				a.advanceCanonicalTodo(rec.Step)
 			}
 		} else {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -663,6 +663,49 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 	}
 }
 
+func TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	completeStep, ok := tool.LookupBuiltin("complete_step")
+	if !ok {
+		t.Fatal("complete_step builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(todoWrite)
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(completeStep)
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "todo_write", `{"todos":[{"content":"Run project script","status":"in_progress"}]}`),
+			toolCallChunk("c2", "bash", `{"command":"python \"script.py\""}`),
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Run project script",
+				"result":"script ran",
+				"evidence":[{"kind":"verification","summary":"script completed","command":"python other.py"}]
+			}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Run project script","status":"completed"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "recover after a failed complete_step"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	stepResult := lastToolResult(a.session, "complete_step")
+	if !strings.Contains(stepResult, "no matching successful bash receipt") {
+		t.Fatalf("complete_step result = %q, want the sign-off attempt to fail first", stepResult)
+	}
+	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "1 completed") {
+		t.Fatalf("todo_write result = %q, want completion recovery accepted", got)
+	}
+}
+
 func TestEvidenceFlowRecoversAfterBatchTodoCompletionRejection(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -465,12 +465,12 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 }
 
 func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, index int, current []TodoItem) bool {
-	if !hasSuccessfulProgressAfterTodoBaseline(receipts, baseline) {
-		return false
-	}
 	for i := baseline + 1; i < len(receipts); i++ {
 		r := receipts[i]
 		if r.Success || r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" || !r.StepProof {
+			continue
+		}
+		if !hasSuccessfulProgressBeforeReceipt(receipts, baseline, i) {
 			continue
 		}
 		if r.TodoStep != nil && r.TodoStep.Found {
@@ -492,8 +492,14 @@ func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, inde
 	return false
 }
 
-func hasSuccessfulProgressAfterTodoBaseline(receipts []Receipt, baseline int) bool {
-	for i := baseline + 1; i < len(receipts); i++ {
+// Recovery only trusts progress that happened before the failed sign-off.
+// Later unrelated work must not retroactively authorize an earlier completion.
+func hasSuccessfulProgressBeforeReceipt(receipts []Receipt, baseline int, before int) bool {
+	start := baseline + 1
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < before && i < len(receipts); i++ {
 		r := receipts[i]
 		if !r.Success || r.ToolName == "todo_write" || r.ToolName == "complete_step" || r.Read {
 			continue
@@ -707,24 +713,46 @@ func todoItemsField(fields map[string]json.RawMessage, key string) []TodoItem {
 	return normalizeTodos(todos)
 }
 
+// A failed complete_step can unlock todo recovery only when the payload had the
+// same structural proof shape Execute expects before host verification runs.
 func completeStepHasProof(fields map[string]json.RawMessage) bool {
+	if strings.TrimSpace(stringField(fields, "result")) == "" {
+		return false
+	}
 	raw, ok := fields["evidence"]
 	if !ok {
 		return false
 	}
 	var items []struct {
-		Kind    string `json:"kind"`
-		Summary string `json:"summary"`
+		Kind    string   `json:"kind"`
+		Summary string   `json:"summary"`
+		Command string   `json:"command"`
+		Paths   []string `json:"paths"`
 	}
-	if err := json.Unmarshal(raw, &items); err != nil {
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
 		return false
 	}
 	for _, item := range items {
-		if strings.TrimSpace(item.Kind) != "" && strings.TrimSpace(item.Summary) != "" {
-			return true
+		kind := strings.TrimSpace(item.Kind)
+		if kind == "" || strings.TrimSpace(item.Summary) == "" {
+			return false
+		}
+		switch kind {
+		case "verification":
+			if strings.TrimSpace(item.Command) == "" {
+				return false
+			}
+		case "diff", "files":
+			if len(normalizePaths(item.Paths)) == 0 {
+				return false
+			}
+		case "manual":
+			// Summary is enough for manual evidence.
+		default:
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func normalizeTodos(todos []TodoItem) []TodoItem {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -34,16 +34,17 @@ type TodoStepMatch struct {
 // Receipt is the host-runtime record of one tool call. It stays in memory for
 // the current agent turn and is not serialized into prompts or session state.
 type Receipt struct {
-	ToolName string          `json:"tool_name"`
-	Args     json.RawMessage `json:"args,omitempty"`
-	Success  bool            `json:"success"`
-	Command  string          `json:"command,omitempty"`
-	Step     string          `json:"step,omitempty"`
-	TodoStep *TodoStepMatch  `json:"todo_step,omitempty"`
-	Paths    []string        `json:"paths,omitempty"`
-	Read     bool            `json:"read,omitempty"`
-	Write    bool            `json:"write,omitempty"`
-	Todos    []TodoItem      `json:"todos,omitempty"`
+	ToolName  string          `json:"tool_name"`
+	Args      json.RawMessage `json:"args,omitempty"`
+	Success   bool            `json:"success"`
+	Command   string          `json:"command,omitempty"`
+	Step      string          `json:"step,omitempty"`
+	StepProof bool            `json:"step_proof,omitempty"`
+	TodoStep  *TodoStepMatch  `json:"todo_step,omitempty"`
+	Paths     []string        `json:"paths,omitempty"`
+	Read      bool            `json:"read,omitempty"`
+	Write     bool            `json:"write,omitempty"`
+	Todos     []TodoItem      `json:"todos,omitempty"`
 }
 
 // Ledger stores the receipts available to complete_step for the current turn.
@@ -82,7 +83,7 @@ func (l *Ledger) Record(r Receipt) {
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if r.Success && r.ToolName == "complete_step" && r.Step != "" && r.TodoStep == nil {
+	if r.ToolName == "complete_step" && r.Step != "" && r.TodoStep == nil {
 		if match := latestTodoStep(r.Step, l.receipts); match.Found {
 			r.TodoStep = &match
 		}
@@ -423,12 +424,14 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 	l.mu.Unlock()
 
 	var previous []TodoItem
+	baseline := -1
 	for i := len(receipts) - 1; i >= 0; i-- {
 		r := receipts[i]
 		if !r.Success || r.ToolName != "todo_write" {
 			continue
 		}
 		previous = r.Todos
+		baseline = i
 		hasBaseline = true
 		break
 	}
@@ -447,6 +450,9 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		if hasSuccessfulCompleteStepForTodo(receipts, index, current) {
 			continue
 		}
+		if hasFailedCompleteStepRecoveryForTodo(receipts, baseline, index, current) {
+			continue
+		}
 		missing = append(missing, TodoStepMatch{
 			Found:      true,
 			Index:      index,
@@ -456,6 +462,45 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		})
 	}
 	return missing, true
+}
+
+func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, index int, current []TodoItem) bool {
+	if !hasSuccessfulProgressAfterTodoBaseline(receipts, baseline) {
+		return false
+	}
+	for i := baseline + 1; i < len(receipts); i++ {
+		r := receipts[i]
+		if r.Success || r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" || !r.StepProof {
+			continue
+		}
+		if r.TodoStep != nil && r.TodoStep.Found {
+			if index < 1 || index > len(current) {
+				continue
+			}
+			if sameTodoMatch(current[index-1], *r.TodoStep) {
+				return true
+			}
+			if !todoContentRelates(current[index-1], *r.TodoStep) {
+				continue
+			}
+		}
+		match := matchTodoStep(r.Step, current)
+		if match.Found && match.Index == index {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSuccessfulProgressAfterTodoBaseline(receipts []Receipt, baseline int) bool {
+	for i := baseline + 1; i < len(receipts); i++ {
+		r := receipts[i]
+		if !r.Success || r.ToolName == "todo_write" || r.ToolName == "complete_step" || r.Read {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func (l *Ledger) hasSuccessfulPaths(paths []string, accept func(Receipt) bool) bool {
@@ -570,6 +615,7 @@ func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, re
 		}
 		if toolName == "complete_step" {
 			r.Step = stringField(fields, "step")
+			r.StepProof = completeStepHasProof(fields)
 		}
 		if toolName == "todo_write" {
 			r.Todos = todoItemsField(fields, "todos")
@@ -659,6 +705,26 @@ func todoItemsField(fields map[string]json.RawMessage, key string) []TodoItem {
 		return nil
 	}
 	return normalizeTodos(todos)
+}
+
+func completeStepHasProof(fields map[string]json.RawMessage) bool {
+	raw, ok := fields["evidence"]
+	if !ok {
+		return false
+	}
+	var items []struct {
+		Kind    string `json:"kind"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.Kind) != "" && strings.TrimSpace(item.Summary) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeTodos(todos []TodoItem) []TodoItem {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -163,6 +163,23 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 		t.Fatalf("complete_step should not be treated as read-only context: %+v", receipt)
 	}
 
+	missingResult := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"evidence":[{"kind":"manual","summary":"checked manually"}]
+	}`), false, true)
+	if missingResult.StepProof {
+		t.Fatalf("complete_step without result should not count as proof: %+v", missingResult)
+	}
+
+	missingCommand := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"result":"parser added",
+		"evidence":[{"kind":"verification","summary":"checked manually"}]
+	}`), false, true)
+	if missingCommand.StepProof {
+		t.Fatalf("verification evidence without command should not count as proof: %+v", missingCommand)
+	}
+
 	emptyProof := ReceiptFromToolCall("complete_step", json.RawMessage(`{
 		"step":"Add parser",
 		"result":"parser added",

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -156,8 +156,20 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 	if receipt.Step != "Add parser" {
 		t.Fatalf("complete_step step = %q", receipt.Step)
 	}
+	if !receipt.StepProof {
+		t.Fatalf("complete_step evidence proof not extracted: %+v", receipt)
+	}
 	if receipt.Read {
 		t.Fatalf("complete_step should not be treated as read-only context: %+v", receipt)
+	}
+
+	emptyProof := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"result":"parser added",
+		"evidence":[]
+	}`), false, true)
+	if emptyProof.StepProof {
+		t.Fatalf("empty complete_step evidence should not count as proof: %+v", emptyProof)
 	}
 }
 

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -110,6 +110,31 @@ func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
 	}
 }
 
+func TestTodoWriteRejectsFailedCompleteStepMissingResult(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"evidence":[{"kind":"manual","summary":"checked manually"}]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("failed complete_step without result should not authorize completion, got %v", err)
+	}
+}
+
 func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
@@ -132,5 +157,32 @@ func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.
 
 	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
 		t.Fatalf("matching failed complete_step with progress receipt should recover todo completion: %v", err)
+	}
+}
+
+func TestTodoWriteRejectsRecoveryWhenProgressIsAfterFailedCompleteStep(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[{"kind":"verification","summary":"script completed","command":"python other.py"}]
+	}`), false, true))
+	ledger.Record(evidence.Receipt{
+		ToolName: "write_file",
+		Success:  true,
+		Paths:    []string{"docs/notes.md"},
+		Write:    true,
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("progress after a failed complete_step should not authorize recovery, got %v", err)
 	}
 }

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -83,3 +83,54 @@ func TestTodoWriteIgnoresFailedCompleteStepReceipt(t *testing.T) {
 		t.Fatalf("failed complete_step should not authorize new completion, got %v", err)
 	}
 }
+
+func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("failed complete_step without proof should not authorize completion, got %v", err)
+	}
+}
+
+func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[{"kind":"verification","summary":"script completed","command":"python script.py"}]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("matching failed complete_step with progress receipt should recover todo completion: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes #5128.
- Record failed `complete_step` attempts in the evidence ledger so later todo updates can see a proof-bearing sign-off attempt instead of deadlocking on a missing successful receipt.
- Let `todo_write` recover a newly completed item only when the matching failed sign-off included evidence and the same todo baseline has a real successful progress receipt; empty failed sign-offs and no-progress completions still stay blocked.
- Add unit and agent-flow regression coverage for the recovery path and the still-blocked empty-proof path.

## Verification

- `go test ./internal/evidence ./internal/tool/builtin -run 'Test(ReceiptFromToolCall|Ledger|TodoWrite|CommandMatches|CompleteStep)' -count=1`
- `go test ./internal/agent -run TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress -count=1` (clean worktree)
- `go test ./... -count=1` (clean worktree)
- `cd desktop && go test ./... -count=1` (clean worktree; macOS linker emitted `ld: warning: ignoring duplicate libraries: '-lobjc'`)
- `git diff --check`

## Cache impact

Cache-impact: none - evidence ledger and todo transition handling only; no provider-visible prompts, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration changes.
Cache-guard: focused evidence, builtin todo, and agent-flow regression tests listed above cover the changed guard behavior.
System-prompt-review: N/A
