### PR TITLE
fix(desktop): preserve plan mode button state on workspace switch (#4940)

### DIFF
--- a/desktop/tab_profile_test.go
+++ b/desktop/tab_profile_test.go
@@ -446,6 +446,32 @@ func TestSetBypassPreservesPlanMode(t *testing.T) {
 	}
 }
 
+// TestCurrentTabCollaborationModeFallsBackToTabMode 验证 controller 不可用时，
+// currentTabCollaborationMode 从持久化的 tab.mode 回退读取计划模式，
+// 避免切换工作区或 controller 重建期间前端计划按钮丢失 (#4940)。
+func TestCurrentTabCollaborationModeFallsBackToTabMode(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	tab := &WorkspaceTab{
+		ID:    "plan-fallback",
+		Scope: "project",
+		mode:  "plan",
+	}
+	if got := currentTabCollaborationMode(tab); got != "plan" {
+		t.Fatalf("collaboration mode without Ctrl = %q, want plan", got)
+	}
+
+	tab.mode = "plan-yolo"
+	if got := currentTabCollaborationMode(tab); got != "plan" {
+		t.Fatalf("collaboration mode plan-yolo without Ctrl = %q, want plan", got)
+	}
+
+	tab.mode = "normal"
+	if got := currentTabCollaborationMode(tab); got != "normal" {
+		t.Fatalf("collaboration mode normal without Ctrl = %q, want normal", got)
+	}
+}
+
 func userConfigPathForTest() string {
 	if dir, err := os.UserConfigDir(); err == nil {
 		return dir + "/reasonix/reasonix.toml"

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4261,6 +4261,11 @@ func currentTabCollaborationMode(tab *WorkspaceTab) string {
 	if tab.Ctrl != nil && tab.Ctrl.PlanMode() {
 		return "plan"
 	}
+	// controller 未就绪时，从持久化的 tab.mode 回退读取，避免计划模式按钮在
+	// 切换工作区或 controller 重建期间丢失 (#4940)
+	if tabModeHasPlan(tab.mode) {
+		return "plan"
+	}
 	if strings.TrimSpace(currentTabGoal(tab)) != "" && currentTabGoalStatus(tab) == control.GoalStatusRunning {
 		return "goal"
 	}


### PR DESCRIPTION
## Summary

修复 #4940: 切换工作区后计划模式按钮消失

**问题：** 在计划模式下，AI 完成规划后切换到其他工作区再切回来，编辑计划界面消失，计划按钮无反应。

**根因：** `currentTabCollaborationMode()` 在 `tab.Ctrl == nil`（controller 暂时不可用）时，没有像其他 tab meta 读取函数一样回退到持久化的 `tab.mode` 字段，而是直接返回 `"normal"`。这会导致 controller 重建期间前端错误地认为当前不是计划模式，从而隐藏计划按钮。

**修复：** 当 controller 未就绪时，如果持久化的 `tab.mode` 是 `plan` 或 `plan-yolo`，则回退返回 `"plan"`，保留前端计划按钮状态。

## Changes

- `desktop/tabs.go` — 在 `currentTabCollaborationMode()` 中添加 `tab.mode` 回退逻辑
- `desktop/tab_profile_test.go` — 添加 `TestCurrentTabCollaborationModeFallsBackToTabMode` 回归测试，覆盖 `plan`、`plan-yolo`、`normal`

## Verification

- 相关测试通过（包括新增回归测试和 `TestSetPlanMode`、`TestSetBypass`、`TestCollaboration`、`TestMeta`、`TestSaveTabs` 等）
- `go vet ./...` clean
- `gofmt -w` applied

Fixes #4940

## Cache impact

Cache-impact: none — 仅修改桌面端 tab 状态回退逻辑与测试，不影响系统提示或缓存前缀。
Cache-guard: N/A
