### PR TITLE
refactor(control): collapse per-surface session-path wiring into Controller helpers

### DIFF
--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -706,11 +706,7 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	newCtrl.EnableInteractiveApproval()
 	sink.bindApprove(newCtrl.Approve)
 	sink.bindAnswer(newCtrl.AnswerQuestion)
-	if len(carried) > 0 {
-		newCtrl.Resume(&agent.Session{Messages: carried}, prevPath)
-	} else if prevPath != "" {
-		newCtrl.SetSessionPath(prevPath)
-	}
+	newCtrl.AdoptHistory(carried, prevPath)
 	// InheritLifecycleFrom wires two concrete controllers' turn/hook state; it's a
 	// construction concern, not part of the driving port. cur is always the
 	// *control.Controller the factory built for this session, so this is safe.

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"reasonix/internal/agent"
 	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
@@ -874,7 +873,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	}
 	ctrl.EnableInteractiveApproval()
 	ctrl.SetToolApprovalMode(toolApprovalMode)
-	ensureControllerSessionPath(ctrl)
+	ctrl.EnsureSessionPath()
 
 	gw.mu.Lock()
 	// Re-check under the lock: while we were off-lock in boot.Build, a second
@@ -901,13 +900,6 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 
 	gw.logger.Info("bot session created", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
 	return state
-}
-
-func ensureControllerSessionPath(ctrl botController) {
-	if ctrl == nil || ctrl.SessionPath() != "" || ctrl.SessionDir() == "" {
-		return
-	}
-	ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
 }
 
 // defaultBotApprovalTimeout caps how long a bot session waits for a remote

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -429,9 +429,8 @@ func runServe(args []string) int {
 	// Auto-save target: reuse the resumed file, else a fresh one — same as chat.
 	if *resume != "" {
 		ctrl.Resume(resumeSession, *resume)
-	} else if ctrl.SessionDir() != "" {
-		ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
 	}
+	ctrl.EnsureSessionPath()
 
 	fmt.Printf("reasonix serve — %s on http://%s\n", ctrl.Label(), *addr)
 	// Use graceful shutdown so SIGINT/SIGTERM drain active connections.
@@ -518,15 +517,14 @@ func chatREPL(args []string) int {
 	// file so closing/reopening keeps appending to the same history; a fresh
 	// session lands in a new file stamped with the model name.
 	if resumePath != "" {
-		if loaded, err := agent.LoadSession(resumePath); err != nil {
+		loaded, err := agent.LoadSession(resumePath)
+		if err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			return 1
-		} else {
-			ctrl.Resume(loaded, resumePath)
 		}
-	} else if ctrl.SessionDir() != "" {
-		ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
+		ctrl.Resume(loaded, resumePath)
 	}
+	ctrl.EnsureSessionPath()
 
 	// Surface a missing-key warning inside the TUI banner so the first message
 	// failing is at least pre-announced; the user can still enter chat.
@@ -578,11 +576,7 @@ func chatREPL(args []string) int {
 		// Keep the carried conversation in its existing file so the switch doesn't
 		// orphan a duplicate (#2807).
 		path := agent.ContinueSessionPath(resumePath, c.SessionDir(), c.Label())
-		if len(carry) > 0 {
-			c.Resume(&agent.Session{Messages: carry}, path)
-		} else if path != "" {
-			c.SetSessionPath(path)
-		}
+		c.AdoptHistory(carry, path)
 		c.EnableInteractiveApproval()
 		if *yolo {
 			c.SetAutoApproveTools(true)

--- a/internal/control/sessionpath.go
+++ b/internal/control/sessionpath.go
@@ -1,0 +1,37 @@
+package control
+
+import (
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+// EnsureSessionPath pins a fresh auto-save file for this controller when none is
+// set yet and a session dir is configured — the "fresh session" branch every
+// surface runs right after building a controller. It is a no-op once a resume or
+// continue has already pinned a path (SessionPath() != ""), so callers can run a
+// conditional Resume and then invoke this unconditionally. Centralises the
+// per-surface copies of this logic (the CLI chat/serve fresh branches and the
+// bot's former ensureControllerSessionPath).
+func (c *Controller) EnsureSessionPath() {
+	if c.SessionPath() != "" || c.SessionDir() == "" {
+		return
+	}
+	c.SetSessionPath(agent.NewSessionPath(c.SessionDir(), c.Label()))
+}
+
+// AdoptHistory makes a freshly built controller continue an existing
+// conversation in path: it resumes the carried messages there when there are
+// any, otherwise just points auto-save at path. An empty path with no messages
+// is a no-op. This is the shared kernel of the model/effort switch across the
+// CLI, the HTTP server, and ACP — each computes path its own way
+// (ContinueSessionPath for the CLI/serve, the pinned transcript for ACP) and
+// hands the carried history (Controller.History()) here. Keeping the
+// Resume/SetSessionPath choice in one place avoids the orphaned-duplicate class
+// of bug (#2807) recurring as each surface copied it.
+func (c *Controller) AdoptHistory(msgs []provider.Message, path string) {
+	if len(msgs) > 0 {
+		c.Resume(&agent.Session{Messages: msgs}, path)
+	} else if path != "" {
+		c.SetSessionPath(path)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -112,11 +112,7 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	// Keep the carried conversation in its existing file so the switch doesn't
 	// orphan a duplicate (#2807).
 	newPath := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if len(carried) > 0 {
-		newCtrl.Resume(&agent.Session{Messages: carried}, newPath)
-	} else if newPath != "" {
-		newCtrl.SetSessionPath(newPath)
-	}
+	newCtrl.AdoptHistory(carried, newPath)
 
 	s.ctrl = newCtrl
 	cur.Close()


### PR DESCRIPTION
## What

Two snippets of session auto-save path logic were copy-pasted across every surface that builds a `control.Controller`:

- **the "fresh session" path-stamp branch** — CLI chat, CLI serve, and the bot's local `ensureControllerSessionPath`
- **the model/effort-switch carry** — CLI, serve, and ACP, the `Resume`/`SetSessionPath` choice carrying the #2807 orphaned-duplicate fix in three separate places

This adds two focused methods to `Controller` as the single home for both, and migrates the six call sites:

| method | replaces |
|---|---|
| `EnsureSessionPath()` | the 3 'fresh session' path-stamp copies |
| `AdoptHistory(msgs, path)` | the 3 model-switch carry copies |

The bot's local `ensureControllerSessionPath` helper and its now-unused `agent` import are removed.

## Why

Not about line count — it's that the #2807/#2856-prone path logic now lives in one place instead of being re-copied (and risking re-breakage) by each surface. No `boot`/`eventwire`/`port.go` changes; deliberately *not* a wide `InitializeSession` bundler, since each surface's wiring around `EnableInteractiveApproval` genuinely differs.

## Verification

No behaviour change. `gofmt` clean, `go build ./...` passes, and `go test` (English locale) green for the affected packages: control, cli, serve, acp, bot (incl. feishu/qq/weixin).