### PR TITLE
Simplify subagent continuation reuse

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -270,7 +270,7 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	}
 	if strings.TrimSpace(meta.ParentSession) != strings.TrimSpace(spec.ParentSession) {
 		release()
-		return s.PrepareFork(ref, spec)
+		return s.prepareContinueFromAncestor(ref, spec)
 	}
 	if err := validateContinueOwner(meta, spec); err != nil {
 		release()
@@ -288,6 +288,125 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	meta.ParentSession = spec.ParentSession
 	meta.ParentToolCallID = spec.ParentToolCallID
 	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
+}
+
+func (s *SubagentStore) prepareContinueFromAncestor(sourceRef string, spec SubagentSpec) (*SubagentRun, error) {
+	sourceRef, err := s.nearestLineageSource(sourceRef, spec)
+	if err != nil {
+		return nil, err
+	}
+	copies, err := s.compatibleCopiesFromSource(sourceRef, spec)
+	if err != nil {
+		return nil, err
+	}
+	switch len(copies) {
+	case 0:
+		return s.PrepareFork(sourceRef, spec)
+	case 1:
+		return s.PrepareContinue(copies[0].Ref, spec)
+	default:
+		return nil, fmt.Errorf("subagent reference %q has multiple copied transcripts in current parent session %q", sourceRef, spec.ParentSession)
+	}
+}
+
+func (s *SubagentStore) nearestLineageSource(requestedRef string, spec SubagentSpec) (string, error) {
+	ancestors, err := s.sessionAncestors(spec.ParentSession)
+	if err != nil {
+		return "", err
+	}
+	for _, ancestor := range ancestors {
+		artifacts, err := ListSubagentsByParent(filepath.Dir(s.dir), ancestor)
+		if err != nil {
+			return "", err
+		}
+		var candidates []SubagentArtifact
+		for _, artifact := range artifacts {
+			if artifact.Ref == requestedRef || s.derivesFrom(artifact.Meta, requestedRef) {
+				candidates = append(candidates, artifact)
+			}
+		}
+		if len(candidates) > 1 {
+			return "", fmt.Errorf("subagent reference %q has multiple candidate transcripts in ancestor parent session %q", requestedRef, ancestor)
+		}
+		if len(candidates) == 1 {
+			if err := validateMeta(candidates[0].Meta, spec); err != nil {
+				return "", err
+			}
+			return candidates[0].Ref, nil
+		}
+	}
+	return "", fmt.Errorf("subagent reference %q is not in current parent session %q lineage", requestedRef, spec.ParentSession)
+}
+
+func (s *SubagentStore) sessionAncestors(current string) ([]string, error) {
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return nil, nil
+	}
+	sessionDir := filepath.Dir(s.dir)
+	var ancestors []string
+	seen := map[string]bool{}
+	for cursor := current; cursor != ""; {
+		if seen[cursor] {
+			return nil, fmt.Errorf("cycle at session %q", cursor)
+		}
+		seen[cursor] = true
+		meta, ok, err := LoadBranchMeta(filepath.Join(sessionDir, cursor+".jsonl"))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing branch metadata for session %q", cursor)
+		}
+		if strings.TrimSpace(meta.ID) != cursor {
+			return nil, fmt.Errorf("branch metadata for session %q declares id %q", cursor, meta.ID)
+		}
+		parent := strings.TrimSpace(meta.ParentID)
+		if parent == "" {
+			break
+		}
+		ancestors = append(ancestors, parent)
+		cursor = parent
+	}
+	return ancestors, nil
+}
+
+func (s *SubagentStore) derivesFrom(meta SubagentMeta, sourceRef string) bool {
+	sourceRef = strings.TrimSpace(sourceRef)
+	seen := map[string]bool{}
+	for cursor := strings.TrimSpace(meta.ForkedFrom); cursor != ""; {
+		if cursor == sourceRef {
+			return true
+		}
+		if seen[cursor] {
+			return false
+		}
+		seen[cursor] = true
+		parent, err := s.LoadMeta(cursor)
+		if err != nil {
+			return false
+		}
+		cursor = strings.TrimSpace(parent.ForkedFrom)
+	}
+	return false
+}
+
+func (s *SubagentStore) compatibleCopiesFromSource(sourceRef string, spec SubagentSpec) ([]SubagentArtifact, error) {
+	artifacts, err := ListSubagentsByParent(filepath.Dir(s.dir), spec.ParentSession)
+	if err != nil {
+		return nil, err
+	}
+	var copies []SubagentArtifact
+	for _, artifact := range artifacts {
+		if strings.TrimSpace(artifact.Meta.ForkedFrom) != sourceRef {
+			continue
+		}
+		if err := validateMeta(artifact.Meta, spec); err != nil {
+			return nil, err
+		}
+		copies = append(copies, artifact)
+	}
+	return copies, nil
 }
 
 func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun, error) {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -62,9 +62,10 @@ type SubagentSpec struct {
 
 // SubagentRun is a prepared transcript run. Call Release exactly once.
 type SubagentRun struct {
-	Ref     string
-	Session *Session
-	Meta    SubagentMeta
+	Ref        string
+	Session    *Session
+	Meta       SubagentMeta
+	ForkedFrom string
 
 	store   *SubagentStore
 	release func()
@@ -301,9 +302,14 @@ func (s *SubagentStore) prepareContinueFromAncestor(sourceRef string, spec Subag
 	}
 	switch len(copies) {
 	case 0:
-		return s.PrepareFork(sourceRef, spec)
+		return s.prepareFork(sourceRef, spec)
 	case 1:
-		return s.PrepareContinue(copies[0].Ref, spec)
+		run, err := s.PrepareContinue(copies[0].Ref, spec)
+		if err != nil {
+			return nil, err
+		}
+		run.ForkedFrom = sourceRef
+		return run, nil
 	default:
 		return nil, fmt.Errorf("subagent reference %q has multiple copied transcripts in current parent session %q", sourceRef, spec.ParentSession)
 	}
@@ -409,7 +415,7 @@ func (s *SubagentStore) compatibleCopiesFromSource(sourceRef string, spec Subage
 	return copies, nil
 }
 
-func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun, error) {
+func (s *SubagentStore) prepareFork(ref string, spec SubagentSpec) (*SubagentRun, error) {
 	if s == nil {
 		return nil, fmt.Errorf("subagent continuation is not available in this session")
 	}
@@ -418,7 +424,7 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 	}
 	sourceRef := strings.TrimSpace(ref)
 	if sourceRef == "" {
-		return nil, fmt.Errorf("fork_from requires a subagent reference")
+		return nil, fmt.Errorf("subagent copy requires a source reference")
 	}
 	sourceRelease, err := s.lock(sourceRef)
 	if err != nil {
@@ -458,7 +464,7 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 	now := time.Now().UTC()
 	newMeta := metaFromSpec(newRef, SubagentRunning, now, now, spec)
 	newMeta.ForkedFrom = sourceRef
-	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, store: s, release: newRelease}, nil
+	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, ForkedFrom: sourceRef, store: s, release: newRelease}, nil
 }
 
 func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
@@ -590,7 +596,7 @@ func validateContinueOwner(meta SubagentMeta, spec SubagentSpec) error {
 	if owner == "" {
 		return fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", meta.Ref)
 	}
-	return fmt.Errorf("subagent reference %q belongs to parent session %q, current parent session is %q; use fork_from to copy it into this session", meta.Ref, owner, current)
+	return fmt.Errorf("subagent reference %q belongs to parent session %q, current parent session is %q", meta.Ref, owner, current)
 }
 
 func (s *SubagentStore) validateForkOwner(meta SubagentMeta, spec SubagentSpec) error {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -39,6 +39,7 @@ type SubagentMeta struct {
 	WorkspaceRoot    string         `json:"workspaceRoot"`
 	ParentSession    string         `json:"parentSession,omitempty"`
 	ParentToolCallID string         `json:"parentToolCallId,omitempty"`
+	ForkedFrom       string         `json:"forkedFrom,omitempty"`
 	SystemPromptHash string         `json:"systemPromptHash"`
 	ToolScope        []string       `json:"toolScope"`
 	ToolSchemaHash   string         `json:"toolSchemaHash"`
@@ -267,6 +268,10 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 		release()
 		return nil, err
 	}
+	if strings.TrimSpace(meta.ParentSession) != strings.TrimSpace(spec.ParentSession) {
+		release()
+		return s.PrepareFork(ref, spec)
+	}
 	if err := validateContinueOwner(meta, spec); err != nil {
 		release()
 		return nil, err
@@ -333,6 +338,7 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 	}
 	now := time.Now().UTC()
 	newMeta := metaFromSpec(newRef, SubagentRunning, now, now, spec)
+	newMeta.ForkedFrom = sourceRef
 	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, store: s, release: newRelease}, nil
 }
 

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -291,6 +291,43 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
 }
 
+func (s *SubagentStore) PrepareLegacyForkFrom(ref string, spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("subagent continuation is not available in this session")
+	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, fmt.Errorf("fork_from requires a subagent reference")
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := s.LoadMeta(ref)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	owner := strings.TrimSpace(meta.ParentSession)
+	current := strings.TrimSpace(spec.ParentSession)
+	if owner == "" {
+		release()
+		return nil, fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", ref)
+	}
+	if owner == current {
+		release()
+		if err := validateMeta(meta, spec); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("fork_from cannot be safely converted for subagent reference %q in the current conversation; use continue_from to continue it in place or start a fresh subagent for independent work", ref)
+	}
+	release()
+	return s.PrepareContinue(ref, spec)
+}
+
 func (s *SubagentStore) prepareContinueFromAncestor(sourceRef string, spec SubagentSpec) (*SubagentRun, error) {
 	sourceRef, err := s.nearestLineageSource(sourceRef, spec)
 	if err != nil {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -66,9 +66,11 @@ func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
 	}
 }
 
-func TestSubagentStoreRejectsContinueFromDifferentParentSession(t *testing.T) {
-	store := NewSubagentStore(t.TempDir())
+func TestSubagentStoreRejectsContinueFromSiblingSession(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
 	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "left"
 	run, err := store.PrepareFresh(spec)
 	if err != nil {
 		t.Fatalf("PrepareFresh: %v", err)
@@ -78,10 +80,13 @@ func TestSubagentStoreRejectsContinueFromDifferentParentSession(t *testing.T) {
 	}
 	run.Release()
 
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "left", "root")
+	saveTestBranchMeta(t, sessionDir, "right", "root")
 	other := spec
-	other.ParentSession = "other-parent"
-	if _, err := store.PrepareContinue(run.Ref, other); err == nil || !strings.Contains(err.Error(), "use fork_from") {
-		t.Fatalf("PrepareContinue error = %v, want parent ownership failure", err)
+	other.ParentSession = "right"
+	if _, err := store.PrepareContinue(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
+		t.Fatalf("PrepareContinue error = %v, want lineage rejection", err)
 	}
 }
 
@@ -127,6 +132,179 @@ func TestSubagentStoreContinueFromAncestorCopiesIntoCurrentSession(t *testing.T)
 	}
 	if sourceMeta.ParentSession != "root" {
 		t.Fatalf("source parent session = %q, want root", sourceMeta.ParentSession)
+	}
+}
+
+func TestSubagentStoreContinueFromAncestorReusesCurrentSessionCopy(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	child := spec
+	child.ParentSession = "child"
+	first, err := store.PrepareContinue(run.Ref, child)
+	if err != nil {
+		t.Fatalf("first PrepareContinue: %v", err)
+	}
+	firstRef := first.Ref
+	if err := store.SaveCompleted(first); err != nil {
+		t.Fatalf("SaveCompleted first: %v", err)
+	}
+	first.Release()
+
+	second, err := store.PrepareContinue(run.Ref, child)
+	if err != nil {
+		t.Fatalf("second PrepareContinue: %v", err)
+	}
+	defer second.Release()
+	if second.Ref != firstRef {
+		t.Fatalf("second continuation ref = %q, want existing child copy %q", second.Ref, firstRef)
+	}
+}
+
+func TestSubagentStoreContinueFromOlderAncestorUsesNearestLineageCopy(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	rootRun, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh root: %v", err)
+	}
+	rootRun.Session.Add(provider.Message{Role: provider.RoleUser, Content: "root task"})
+	if err := store.SaveCompleted(rootRun); err != nil {
+		t.Fatalf("SaveCompleted root: %v", err)
+	}
+	rootRun.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	saveTestBranchMeta(t, sessionDir, "grandchild", "child")
+
+	child := spec
+	child.ParentSession = "child"
+	childRun, err := store.PrepareContinue(rootRun.Ref, child)
+	if err != nil {
+		t.Fatalf("PrepareContinue child: %v", err)
+	}
+	childRun.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "child finding"})
+	childRef := childRun.Ref
+	if err := store.SaveCompleted(childRun); err != nil {
+		t.Fatalf("SaveCompleted child: %v", err)
+	}
+	childRun.Release()
+
+	grandchild := spec
+	grandchild.ParentSession = "grandchild"
+	fromRoot, err := store.PrepareContinue(rootRun.Ref, grandchild)
+	if err != nil {
+		t.Fatalf("PrepareContinue grandchild from root: %v", err)
+	}
+	grandchildRef := fromRoot.Ref
+	if fromRoot.Meta.ForkedFrom != childRef {
+		t.Fatalf("grandchild forkedFrom = %q, want nearest child copy %q", fromRoot.Meta.ForkedFrom, childRef)
+	}
+	if got := fromRoot.Session.Snapshot(); len(got) != 3 || got[2].Content != "child finding" {
+		t.Fatalf("grandchild transcript = %+v, want child copy transcript", got)
+	}
+	if err := store.SaveCompleted(fromRoot); err != nil {
+		t.Fatalf("SaveCompleted grandchild: %v", err)
+	}
+	fromRoot.Release()
+
+	fromChild, err := store.PrepareContinue(childRef, grandchild)
+	if err != nil {
+		t.Fatalf("PrepareContinue grandchild from child: %v", err)
+	}
+	defer fromChild.Release()
+	if fromChild.Ref != grandchildRef {
+		t.Fatalf("grandchild ref from child copy = %q, want existing copy %q", fromChild.Ref, grandchildRef)
+	}
+}
+
+func TestSubagentStoreRejectsAncestorContinuationWhenCurrentCopyFailed(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted root: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	child := spec
+	child.ParentSession = "child"
+	copyRun, err := store.PrepareContinue(run.Ref, child)
+	if err != nil {
+		t.Fatalf("PrepareContinue child: %v", err)
+	}
+	if err := store.SaveFailed(copyRun); err != nil {
+		t.Fatalf("SaveFailed child copy: %v", err)
+	}
+	copyRun.Release()
+
+	if _, err := store.PrepareContinue(run.Ref, child); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("PrepareContinue error = %v, want failed current copy rejection", err)
+	}
+}
+
+func TestSubagentStoreRejectsAncestorContinuationWithMultipleCurrentCopies(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted root: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	child := spec
+	child.ParentSession = "child"
+	first, err := store.PrepareContinue(run.Ref, child)
+	if err != nil {
+		t.Fatalf("PrepareContinue first: %v", err)
+	}
+	if err := store.SaveCompleted(first); err != nil {
+		t.Fatalf("SaveCompleted first: %v", err)
+	}
+	first.Release()
+
+	second, err := store.PrepareFresh(child)
+	if err != nil {
+		t.Fatalf("PrepareFresh second: %v", err)
+	}
+	second.Meta.ForkedFrom = run.Ref
+	if err := store.SaveCompleted(second); err != nil {
+		t.Fatalf("SaveCompleted second: %v", err)
+	}
+	second.Release()
+
+	if _, err := store.PrepareContinue(run.Ref, child); err == nil || !strings.Contains(err.Error(), "multiple copied transcripts") {
+		t.Fatalf("PrepareContinue error = %v, want multiple-copy rejection", err)
 	}
 }
 

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -50,7 +50,7 @@ func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
 	}
 	run.Release()
 
-	forked, err := store.PrepareFork(run.Ref, spec)
+	forked, err := store.prepareFork(run.Ref, spec)
 	if err != nil {
 		t.Fatalf("PrepareFork: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestSubagentStoreForkFromAncestorSessionCreatesCurrentOwner(t *testing.T) {
 	saveTestBranchMeta(t, sessionDir, "child", "root")
 	other := spec
 	other.ParentSession = "child"
-	forked, err := store.PrepareFork(run.Ref, other)
+	forked, err := store.prepareFork(run.Ref, other)
 	if err != nil {
 		t.Fatalf("PrepareFork: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestSubagentStoreRejectsForkWhenSourceOwnerMetaMissing(t *testing.T) {
 
 	other := spec
 	other.ParentSession = "child"
-	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+	if _, err := store.prepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
 		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
@@ -367,7 +367,7 @@ func TestSubagentStoreRejectsForkWhenSourceOwnerMetaCorrupt(t *testing.T) {
 
 	other := spec
 	other.ParentSession = "child"
-	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+	if _, err := store.prepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
 		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
@@ -381,7 +381,7 @@ func TestSubagentStoreRejectsForkWhenSourceOwnerMetaIDDiffers(t *testing.T) {
 
 	other := spec
 	other.ParentSession = "child"
-	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+	if _, err := store.prepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
 		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
@@ -405,7 +405,7 @@ func TestSubagentStoreRejectsForkFromSiblingSession(t *testing.T) {
 	saveTestBranchMeta(t, sessionDir, "right", "root")
 	other := spec
 	other.ParentSession = "right"
-	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
+	if _, err := store.prepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
 		t.Fatalf("PrepareFork error = %v, want lineage rejection", err)
 	}
 }
@@ -428,7 +428,7 @@ func TestSubagentStoreRejectsForkFromUnrelatedSession(t *testing.T) {
 	saveTestBranchMeta(t, sessionDir, "current", "root")
 	other := spec
 	other.ParentSession = "current"
-	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
+	if _, err := store.prepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
 		t.Fatalf("PrepareFork error = %v, want unrelated session rejection", err)
 	}
 }
@@ -449,7 +449,7 @@ func TestSubagentStoreRejectsForkWhenLineageCannotBeProven(t *testing.T) {
 
 	other := spec
 	other.ParentSession = "child"
-	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+	if _, err := store.prepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
 		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
@@ -467,7 +467,7 @@ func TestSubagentStoreForkReleasesSourceLockAfterCopy(t *testing.T) {
 	}
 	run.Release()
 
-	forked, err := store.PrepareFork(run.Ref, spec)
+	forked, err := store.prepareFork(run.Ref, spec)
 	if err != nil {
 		t.Fatalf("PrepareFork: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestSubagentStoreSaveFailedPersistsTranscriptAndRejectsReuse(t *testing.T) 
 	if _, err := store.PrepareContinue(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
 		t.Fatalf("PrepareContinue error = %v, want failed ref rejection", err)
 	}
-	if _, err := store.PrepareFork(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+	if _, err := store.prepareFork(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
 		t.Fatalf("PrepareFork error = %v, want failed ref rejection", err)
 	}
 }
@@ -586,7 +586,7 @@ func TestSubagentStoreCleanupStaleRunningMarksInterrupted(t *testing.T) {
 	if _, err := store.PrepareContinue(ref, spec); err == nil || !strings.Contains(err.Error(), "interrupted by a previous shutdown or crash") {
 		t.Fatalf("PrepareContinue error = %v, want interrupted rejection", err)
 	}
-	if _, err := store.PrepareFork(ref, spec); err == nil || !strings.Contains(err.Error(), "cannot be continued or forked") {
+	if _, err := store.prepareFork(ref, spec); err == nil || !strings.Contains(err.Error(), "cannot be continued or forked") {
 		t.Fatalf("PrepareFork error = %v, want interrupted fork rejection", err)
 	}
 }

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -85,6 +85,51 @@ func TestSubagentStoreRejectsContinueFromDifferentParentSession(t *testing.T) {
 	}
 }
 
+func TestSubagentStoreContinueFromAncestorCopiesIntoCurrentSession(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	child := spec
+	child.ParentSession = "child"
+	continued, err := store.PrepareContinue(run.Ref, child)
+	if err != nil {
+		t.Fatalf("PrepareContinue: %v", err)
+	}
+	defer continued.Release()
+	if continued.Ref == run.Ref {
+		t.Fatalf("continued ref should be copied into child session, got source ref %q", continued.Ref)
+	}
+	if continued.Meta.ParentSession != "child" {
+		t.Fatalf("continued parent session = %q, want child", continued.Meta.ParentSession)
+	}
+	if continued.Meta.ForkedFrom != run.Ref {
+		t.Fatalf("forkedFrom = %q, want %q", continued.Meta.ForkedFrom, run.Ref)
+	}
+	if got := continued.Session.Snapshot(); len(got) != 2 || got[1].Content != "review diff" {
+		t.Fatalf("continued transcript = %+v, want copied source transcript", got)
+	}
+	sourceMeta, err := store.LoadMeta(run.Ref)
+	if err != nil {
+		t.Fatalf("LoadMeta source: %v", err)
+	}
+	if sourceMeta.ParentSession != "root" {
+		t.Fatalf("source parent session = %q, want root", sourceMeta.ParentSession)
+	}
+}
+
 func TestSubagentStoreForkFromAncestorSessionCreatesCurrentOwner(t *testing.T) {
 	sessionDir := t.TempDir()
 	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -135,6 +135,61 @@ func TestSubagentStoreContinueFromAncestorCopiesIntoCurrentSession(t *testing.T)
 	}
 }
 
+func TestSubagentStoreLegacyForkFromAncestorConvertsToContinueCopy(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	child := spec
+	child.ParentSession = "child"
+	continued, err := store.PrepareLegacyForkFrom(run.Ref, child)
+	if err != nil {
+		t.Fatalf("PrepareLegacyForkFrom: %v", err)
+	}
+	defer continued.Release()
+	if continued.Ref == run.Ref {
+		t.Fatalf("legacy fork ref should be copied into child session, got source ref %q", continued.Ref)
+	}
+	if continued.Meta.ParentSession != "child" {
+		t.Fatalf("continued parent session = %q, want child", continued.Meta.ParentSession)
+	}
+	if continued.Meta.ForkedFrom != run.Ref {
+		t.Fatalf("forkedFrom = %q, want %q", continued.Meta.ForkedFrom, run.Ref)
+	}
+	if got := continued.Session.Snapshot(); len(got) != 2 || got[1].Content != "review diff" {
+		t.Fatalf("continued transcript = %+v, want copied source transcript", got)
+	}
+}
+
+func TestSubagentStoreRejectsLegacyForkFromCurrentSession(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	if _, err := store.PrepareLegacyForkFrom(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "cannot be safely converted") {
+		t.Fatalf("PrepareLegacyForkFrom error = %v, want unsafe conversion rejection", err)
+	}
+}
+
 func TestSubagentStoreContinueFromAncestorReusesCurrentSessionCopy(t *testing.T) {
 	sessionDir := t.TempDir()
 	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -200,8 +200,7 @@ func (t *TaskTool) Schema() json.RawMessage {
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires a compatible subagent identity, including tools, model, effort, and workspace."},
-  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation on the same thread, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires a compatible subagent identity, including tools, model, effort, and workspace. Mutually exclusive with continue_from."}
+  "continue_from":{"type":"string","description":"Continue a prior compatible subagent transcript in the current conversation context. Pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. If the ref belongs to an ancestor conversation, the framework continues a current-conversation copy."}
 },
 "required":["prompt"]
 }`)
@@ -250,7 +249,6 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		Model           string   `json:"model"`
 		Effort          string   `json:"effort"`
 		ContinueFrom    string   `json:"continue_from"`
-		ForkFrom        string   `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -277,7 +275,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	subReg := t.buildSubReg(p.Tools)
 	modelRef, effortRef := t.effectiveProfile(p.Model, p.Effort)
 	parentID, parent, _, _ := CallContext(ctx)
-	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom, p.ForkFrom)
+	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom)
 	if err != nil {
 		return "", err
 	}
@@ -315,21 +313,21 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			defer func() {
 				if r := recover(); r != nil {
 					panicErr := fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
-					result = FormatSubagentResult("", run.Ref, true)
+					result = FormatSubagentRunResult("", run, true)
 					err = errors.Join(panicErr, t.transcripts.SaveFailed(run))
 				}
 			}()
 			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session)
 			if err != nil {
-				return FormatSubagentResult("", run.Ref, true), errors.Join(err, t.transcripts.SaveFailed(run))
+				return FormatSubagentRunResult("", run, true), errors.Join(err, t.transcripts.SaveFailed(run))
 			}
 			if err := t.transcripts.SaveCompleted(run); err != nil {
-				return FormatSubagentResult("", run.Ref, true), errors.Join(err, t.transcripts.SaveFailed(run))
+				return FormatSubagentRunResult("", run, true), errors.Join(err, t.transcripts.SaveFailed(run))
 			}
-			return FormatSubagentResult(answer, run.Ref, false), nil
+			return FormatSubagentRunResult(answer, run, false), nil
 		})
 		if run != nil && run.Ref != "" {
-			return fmt.Sprintf("Started background task %q (%s).\nSubagent reference: %s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, run.Ref), nil
+			return fmt.Sprintf("Started background task %q (%s).\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, FormatSubagentReference(run)), nil
 		}
 		return fmt.Sprintf("Started background task %q (%s). It runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label), nil
 	}
@@ -344,18 +342,14 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		if err := t.transcripts.SaveCompleted(run); err != nil {
 			return "", errors.Join(err, t.transcripts.SaveFailed(run))
 		}
-		return FormatSubagentResult(answer, run.Ref, false), nil
+		return FormatSubagentRunResult(answer, run, false), nil
 	}
 	return answer, nil
 }
 
-func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom, forkFrom string) (*SubagentRun, error) {
+func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom string) (*SubagentRun, error) {
 	continueFrom = strings.TrimSpace(continueFrom)
-	forkFrom = strings.TrimSpace(forkFrom)
 	parentSession = strings.TrimSpace(parentSession)
-	if continueFrom != "" && forkFrom != "" {
-		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive")
-	}
 	if t.transcripts == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
@@ -364,8 +358,8 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	// exactly as before persisted transcripts existed — instead of failing the
 	// call. Continuation/fork need a persisted owner, so they error here.
 	if parentSession == "" {
-		if continueFrom != "" || forkFrom != "" {
-			return nil, fmt.Errorf("continue_from/fork_from require a persisted session; none is active in this run")
+		if continueFrom != "" {
+			return nil, fmt.Errorf("continue_from requires a persisted session; none is active in this run")
 		}
 		return EphemeralSubagentRun(t.sysPrompt), nil
 	}
@@ -381,11 +375,8 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 		Model:            identityModel,
 		Effort:           identityEffort,
 	}
-	if continueFrom != "" || forkFrom != "" {
-		if continueFrom != "" {
-			return t.transcripts.PrepareContinue(continueFrom, spec)
-		}
-		return t.transcripts.PrepareFork(forkFrom, spec)
+	if continueFrom != "" {
+		return t.transcripts.PrepareContinue(continueFrom, spec)
 	}
 	return t.transcripts.PrepareFresh(spec)
 }
@@ -518,17 +509,34 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 	}, sink)
 }
 
-func FormatSubagentResult(answer, ref string, failed bool) string {
-	if ref == "" {
+func FormatSubagentReference(run *SubagentRun) string {
+	if run == nil || run.Ref == "" {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Subagent reference: %s\n", run.Ref)
+	if strings.TrimSpace(run.ForkedFrom) != "" {
+		fmt.Fprintf(&b, "Forked from: %s\n", strings.TrimSpace(run.ForkedFrom))
+		b.WriteString("The requested ref resolves to an ancestor conversation transcript, so the framework continues a copy owned by the current conversation. To continue this copied subagent transcript in a later call, pass ")
+		b.WriteString(run.Ref)
+		b.WriteString(" as `continue_from`. Start a fresh subagent when the next task is independent.")
+		return b.String()
+	}
+	b.WriteString("To continue this same subagent transcript in a later call, pass this ref as `continue_from`. Start a fresh subagent when the next task is independent.")
+	return b.String()
+}
+
+func FormatSubagentRunResult(answer string, run *SubagentRun, failed bool) string {
+	if run == nil || run.Ref == "" {
 		return answer
 	}
 	if failed {
 		if answer == "" {
-			return "Subagent reference (failed): " + ref
+			return "Subagent reference (failed): " + run.Ref
 		}
-		return "Subagent reference (failed): " + ref + "\n\nFinal answer:\n" + answer
+		return "Subagent reference (failed): " + run.Ref + "\n\nFinal answer:\n" + answer
 	}
-	return "Subagent reference: " + ref + "\n\nFinal answer:\n" + answer
+	return FormatSubagentReference(run) + "\n\nFinal answer:\n" + answer
 }
 
 // RunSubAgentWithSession continues an existing sub-agent session with prompt and

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -249,6 +249,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		Model           string   `json:"model"`
 		Effort          string   `json:"effort"`
 		ContinueFrom    string   `json:"continue_from"`
+		ForkFrom        string   `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -275,7 +276,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	subReg := t.buildSubReg(p.Tools)
 	modelRef, effortRef := t.effectiveProfile(p.Model, p.Effort)
 	parentID, parent, _, _ := CallContext(ctx)
-	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom)
+	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom, p.ForkFrom)
 	if err != nil {
 		return "", err
 	}
@@ -347,9 +348,13 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	return answer, nil
 }
 
-func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom string) (*SubagentRun, error) {
+func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom, legacyForkFrom string) (*SubagentRun, error) {
 	continueFrom = strings.TrimSpace(continueFrom)
+	legacyForkFrom = strings.TrimSpace(legacyForkFrom)
 	parentSession = strings.TrimSpace(parentSession)
+	if continueFrom != "" && legacyForkFrom != "" {
+		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
+	}
 	if t.transcripts == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
@@ -358,8 +363,8 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	// exactly as before persisted transcripts existed — instead of failing the
 	// call. Continuation/fork need a persisted owner, so they error here.
 	if parentSession == "" {
-		if continueFrom != "" {
-			return nil, fmt.Errorf("continue_from requires a persisted session; none is active in this run")
+		if continueFrom != "" || legacyForkFrom != "" {
+			return nil, fmt.Errorf("subagent continuation requires a persisted session; none is active in this run")
 		}
 		return EphemeralSubagentRun(t.sysPrompt), nil
 	}
@@ -377,6 +382,9 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	}
 	if continueFrom != "" {
 		return t.transcripts.PrepareContinue(continueFrom, spec)
+	}
+	if legacyForkFrom != "" {
+		return t.transcripts.PrepareLegacyForkFrom(legacyForkFrom, spec)
 	}
 	return t.transcripts.PrepareFresh(spec)
 }

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -473,6 +473,71 @@ func TestTaskToolBackgroundResultIncludesReferenceGuidance(t *testing.T) {
 	}
 }
 
+func TestTaskToolBackgroundAncestorContinuationIncludesForkGuidance(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "root answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "child background answer"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	rootCtx := WithParentSession(context.Background(), "root")
+	rootOut, err := task.Execute(rootCtx, []byte(`{"prompt":"root task"}`))
+	if err != nil {
+		t.Fatalf("root Execute: %v", err)
+	}
+	rootRef := subagentRefFromOutput(t, rootOut)
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "root.jsonl"), BranchMeta{}); err != nil {
+		t.Fatalf("SaveBranchMeta root: %v", err)
+	}
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "child.jsonl"), BranchMeta{ParentID: "root"}); err != nil {
+		t.Fatalf("SaveBranchMeta child: %v", err)
+	}
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	childCtx := WithParentSession(context.Background(), "child")
+	childCtx = jobs.WithSession(childCtx, "child")
+	childCtx = jobs.WithManager(childCtx, jm)
+	startOut, err := task.Execute(childCtx, []byte(`{"prompt":"child task","continue_from":"`+rootRef+`","run_in_background":true}`))
+	if err != nil {
+		t.Fatalf("child Execute: %v", err)
+	}
+	childRef := subagentRefFromOutput(t, startOut)
+	if childRef == rootRef {
+		t.Fatalf("child ref = source ref %q, want copied ref", childRef)
+	}
+	if !strings.Contains(startOut, "Forked from: "+rootRef) ||
+		!strings.Contains(startOut, "The requested ref resolves to an ancestor conversation transcript") ||
+		strings.Contains(startOut, "Final answer:") {
+		t.Fatalf("start output = %q, want fork guidance without final answer", startOut)
+	}
+	jobID := extractJobID(startOut)
+	if jobID == "" {
+		t.Fatalf("no background job id in output:\n%s", startOut)
+	}
+	res := jm.WaitForSession(context.Background(), "child", []string{jobID}, 5)
+	if len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background job result = %+v, want succeeded", res)
+	}
+	if !strings.Contains(res[0].Output, "Subagent reference: "+childRef) ||
+		!strings.Contains(res[0].Output, "Forked from: "+rootRef) ||
+		!strings.Contains(res[0].Output, "The requested ref resolves to an ancestor conversation transcript") ||
+		!strings.Contains(res[0].Output, "Final answer:\nchild background answer") {
+		t.Fatalf("job output = %q, want copied ref guidance and final answer", res[0].Output)
+	}
+}
+
 func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "answer"},

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -35,6 +36,9 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	if !strings.Contains(out, "found 3 callers of Foo") {
 		t.Errorf("got %q, want sub-agent final answer", out)
 	}
+	if !strings.Contains(out, "To continue this same subagent transcript in a later call, pass this ref as `continue_from`. Start a fresh subagent when the next task is independent.") {
+		t.Errorf("got %q, want continuation guidance", out)
+	}
 
 	// The sub-agent must have received the prompt as its user message and
 	// the configured system prompt at the top — proving the session was
@@ -44,6 +48,26 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	}
 	if got := lastUser(sub.lastReq); got != "find callers of Foo" {
 		t.Errorf("sub-agent user = %q, want the prompt verbatim", got)
+	}
+}
+
+func TestTaskToolSchemaExposesOnlyContinueFromForPersistence(t *testing.T) {
+	task := NewTaskTool(&mockProvider{name: "sub"}, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil)
+	schema := string(task.Schema())
+	if !strings.Contains(schema, `"continue_from"`) {
+		t.Fatalf("task schema = %s, want continue_from", schema)
+	}
+	if strings.Contains(schema, "fork_from") {
+		t.Fatalf("task schema = %s, want no fork_from", schema)
+	}
+}
+
+func TestParallelTasksSchemaDoesNotExposePersistentContinuation(t *testing.T) {
+	task := NewTaskTool(&mockProvider{name: "sub"}, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil)
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+	schema := string(parallel.Schema())
+	if strings.Contains(schema, "continue_from") || strings.Contains(schema, "fork_from") {
+		t.Fatalf("parallel_tasks schema = %s, want no persistent continuation fields", schema)
 	}
 }
 
@@ -268,6 +292,58 @@ func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	}
 	if msgs[1].Content != "first task" || msgs[2].Content != "first answer" || lastUser(sub.requests[1]) != "second task" {
 		t.Fatalf("continued request messages = %+v, want first task/answer then second task", msgs)
+	}
+}
+
+func TestTaskToolContinueFromAncestorReturnsCopiedReferenceGuidance(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "root answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "child answer"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	rootCtx := WithParentSession(context.Background(), "root")
+	first, err := task.Execute(rootCtx, []byte(`{"prompt":"root task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	rootRef := subagentRefFromOutput(t, first)
+
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "root.jsonl"), BranchMeta{}); err != nil {
+		t.Fatalf("SaveBranchMeta root: %v", err)
+	}
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "child.jsonl"), BranchMeta{ParentID: "root"}); err != nil {
+		t.Fatalf("SaveBranchMeta child: %v", err)
+	}
+
+	childCtx := WithParentSession(context.Background(), "child")
+	second, err := task.Execute(childCtx, []byte(`{"prompt":"child task","continue_from":"`+rootRef+`"}`))
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	childRef := subagentRefFromOutput(t, second)
+	if childRef == rootRef {
+		t.Fatalf("child ref = source ref %q, want copied ref", childRef)
+	}
+	if !strings.Contains(second, "Forked from: "+rootRef) {
+		t.Fatalf("second output = %q, want Forked from source ref", second)
+	}
+	if !strings.Contains(second, "The requested ref resolves to an ancestor conversation transcript") {
+		t.Fatalf("second output = %q, want ancestor-copy guidance", second)
+	}
+	if !strings.Contains(second, "Final answer:\nchild answer") {
+		t.Fatalf("second output = %q, want final answer", second)
 	}
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -434,6 +434,45 @@ func TestTaskToolBackgroundPanicPersistsFailedMetadata(t *testing.T) {
 	}
 }
 
+func TestTaskToolBackgroundResultIncludesReferenceGuidance(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "background answer"},
+		{Type: provider.ChunkDone},
+	}}
+	store := NewSubagentStore(t.TempDir())
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctx := testTaskContext()
+	ctx = jobs.WithSession(ctx, "parent-session")
+	ctx = jobs.WithManager(ctx, jm)
+	out, err := task.Execute(ctx, []byte(`{"prompt":"background task","run_in_background":true}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, out)
+	if !strings.Contains(out, "To continue this same subagent transcript in a later call") {
+		t.Fatalf("start output = %q, want reference guidance", out)
+	}
+	jobID := extractJobID(out)
+	if jobID == "" {
+		t.Fatalf("no background job id in output:\n%s", out)
+	}
+	res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5)
+	if len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background job result = %+v, want succeeded", res)
+	}
+	if !strings.Contains(res[0].Output, "Subagent reference: "+ref) ||
+		!strings.Contains(res[0].Output, "To continue this same subagent transcript in a later call") ||
+		!strings.Contains(res[0].Output, "Final answer:\nbackground answer") {
+		t.Fatalf("job output = %q, want reference guidance and final answer", res[0].Output)
+	}
+}
+
 func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "answer"},

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -347,6 +347,81 @@ func TestTaskToolContinueFromAncestorReturnsCopiedReferenceGuidance(t *testing.T
 	}
 }
 
+func TestTaskToolLegacyForkFromAncestorConvertsToCopiedReference(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "root answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "child answer"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	rootCtx := WithParentSession(context.Background(), "root")
+	first, err := task.Execute(rootCtx, []byte(`{"prompt":"root task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	rootRef := subagentRefFromOutput(t, first)
+
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "root.jsonl"), BranchMeta{}); err != nil {
+		t.Fatalf("SaveBranchMeta root: %v", err)
+	}
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "child.jsonl"), BranchMeta{ParentID: "root"}); err != nil {
+		t.Fatalf("SaveBranchMeta child: %v", err)
+	}
+
+	childCtx := WithParentSession(context.Background(), "child")
+	second, err := task.Execute(childCtx, []byte(`{"prompt":"child task","fork_from":"`+rootRef+`"}`))
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	childRef := subagentRefFromOutput(t, second)
+	if childRef == rootRef {
+		t.Fatalf("child ref = source ref %q, want copied ref", childRef)
+	}
+	if !strings.Contains(second, "Forked from: "+rootRef) ||
+		!strings.Contains(second, "Final answer:\nchild answer") {
+		t.Fatalf("second output = %q, want copied reference guidance and final answer", second)
+	}
+}
+
+func TestTaskToolRejectsLegacyForkFromCurrentSession(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "first answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "should not run"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
+
+	first, err := task.Execute(testTaskContext(), []byte(`{"prompt":"first task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, first)
+	_, err = task.Execute(testTaskContext(), []byte(`{"prompt":"second task","fork_from":"`+ref+`"}`))
+	if err == nil || !strings.Contains(err.Error(), "cannot be safely converted") {
+		t.Fatalf("legacy fork error = %v, want unsafe conversion rejection", err)
+	}
+	if len(sub.requests) != 1 {
+		t.Fatalf("provider requests = %d, want only first run", len(sub.requests))
+	}
+}
+
 func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.T) {
 	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
 		{

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -591,20 +591,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			prov, price, ctxWin = p, pr, cw
 		}
 		subReg := agent.SubagentToolRegistry(reg, sk.AllowedTools)
-		continueFrom, forkFrom := strings.TrimSpace(runOpts.ContinueFrom), strings.TrimSpace(runOpts.ForkFrom)
-		if continueFrom != "" && forkFrom != "" {
-			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive")
-		}
+		continueFrom := strings.TrimSpace(runOpts.ContinueFrom)
 		parentID, _, _, _ := agent.CallContext(sctx)
 		parentSession := agent.ParentSession(sctx)
 		var run *agent.SubagentRun
 		if subagentStore == nil || parentSession == "" {
 			// Headless runs (e.g. `reasonix run`) have no persistent session to
 			// own a transcript. Run the skill sub-agent ephemerally, as before
-			// persisted transcripts existed, instead of failing. Continuation and
-			// fork need a persisted owner, so they error here.
-			if continueFrom != "" || forkFrom != "" {
-				return "", fmt.Errorf("continue_from/fork_from require a persisted session; none is active in this run")
+			// persisted transcripts existed, instead of failing. Continuation needs
+			// a persisted owner, so it errors here.
+			if continueFrom != "" {
+				return "", fmt.Errorf("continue_from requires a persisted session; none is active in this run")
 			}
 			run = agent.EphemeralSubagentRun(sk.Body)
 		} else {
@@ -621,12 +618,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				Effort:           identityEffort,
 			}
 			var prepErr error
-			switch {
-			case continueFrom != "":
+			if continueFrom != "" {
 				run, prepErr = subagentStore.PrepareContinue(continueFrom, spec)
-			case forkFrom != "":
-				run, prepErr = subagentStore.PrepareFork(forkFrom, spec)
-			default:
+			} else {
 				run, prepErr = subagentStore.PrepareFresh(spec)
 			}
 			if prepErr != nil {
@@ -658,7 +652,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if err := subagentStore.SaveCompleted(run); err != nil {
 			return "", errors.Join(err, subagentStore.SaveFailed(run))
 		}
-		return agent.FormatSubagentResult(answer, run.Ref, false), nil
+		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}
 	skillProfile := func(sk skill.Skill) *event.Profile {
 		model, effort := subagentModelRef(cfg, sk), subagentEffortRef(cfg, sk)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -592,6 +592,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		subReg := agent.SubagentToolRegistry(reg, sk.AllowedTools)
 		continueFrom := strings.TrimSpace(runOpts.ContinueFrom)
+		legacyForkFrom := strings.TrimSpace(runOpts.ForkFrom)
+		if continueFrom != "" && legacyForkFrom != "" {
+			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
+		}
 		parentID, _, _, _ := agent.CallContext(sctx)
 		parentSession := agent.ParentSession(sctx)
 		var run *agent.SubagentRun
@@ -600,8 +604,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			// own a transcript. Run the skill sub-agent ephemerally, as before
 			// persisted transcripts existed, instead of failing. Continuation needs
 			// a persisted owner, so it errors here.
-			if continueFrom != "" {
-				return "", fmt.Errorf("continue_from requires a persisted session; none is active in this run")
+			if continueFrom != "" || legacyForkFrom != "" {
+				return "", fmt.Errorf("subagent continuation requires a persisted session; none is active in this run")
 			}
 			run = agent.EphemeralSubagentRun(sk.Body)
 		} else {
@@ -620,6 +624,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			var prepErr error
 			if continueFrom != "" {
 				run, prepErr = subagentStore.PrepareContinue(continueFrom, spec)
+			} else if legacyForkFrom != "" {
+				run, prepErr = subagentStore.PrepareLegacyForkFrom(legacyForkFrom, spec)
 			} else {
 				run, prepErr = subagentStore.PrepareFresh(spec)
 			}

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -19,7 +19,6 @@ import (
 // silently inlining, which would lose the isolation the author asked for).
 type SubagentRunOptions struct {
 	ContinueFrom string
-	ForkFrom     string
 }
 
 type SubagentRunner func(ctx context.Context, sk Skill, task string, opts SubagentRunOptions) (string, error)
@@ -67,8 +66,7 @@ func (*runSkillTool) Schema() json.RawMessage {
 "properties":{
   "name":{"type":"string","description":"Skill identifier as it appears in the pinned Skills index (e.g. 'explore', 'review'). Case-sensitive. Just the identifier, not the [🧬 subagent] tag."},
   "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Only valid for runAs=subagent skills."},
-  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation, use continue_from. Only valid for runAs=subagent skills. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}
+  "continue_from":{"type":"string","description":"Continue a prior compatible subagent transcript in the current conversation context. Only valid for runAs=subagent skills. Pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."}
 },
 "required":["name"]
 }`)
@@ -79,7 +77,6 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 		Continue  string `json:"continue_from"`
-		Fork      string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -93,7 +90,7 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		return "", fmt.Errorf("unknown skill %q — available: %s", name, availableNames(t.store))
 	}
 	rawArgs := strings.TrimSpace(p.Arguments)
-	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
+	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue)}
 
 	if sk.RunAs == RunSubagent {
 		if t.runner == nil {
@@ -104,8 +101,8 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		}
 		return t.runner(ctx, sk, rawArgs, opts)
 	}
-	if opts.ContinueFrom != "" || opts.ForkFrom != "" {
-		return "", fmt.Errorf("run_skill: continue_from/fork_from are only valid for runAs=subagent skills")
+	if opts.ContinueFrom != "" {
+		return "", fmt.Errorf("run_skill: continue_from is only valid for runAs=subagent skills")
 	}
 	return renderInline(sk, rawArgs), nil
 }
@@ -211,14 +208,13 @@ func (t *subagentSkillTool) Description() string { return t.description }
 
 func (t *subagentSkillTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"task":{"type":"string","description":` +
-		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."},"fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}},"required":["task"]}`)
+		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Continue a prior compatible subagent transcript in the current conversation context. Pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."}},"required":["task"]}`)
 }
 
 func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
 		Task     string `json:"task"`
 		Continue string `json:"continue_from"`
-		Fork     string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -239,7 +235,7 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if t.runner == nil {
 		return "", fmt.Errorf("%s: no subagent runner is configured in this session", t.toolName)
 	}
-	return t.runner(ctx, sk, task, SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)})
+	return t.runner(ctx, sk, task, SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue)})
 }
 
 func (t *subagentSkillTool) ResolveProfile(json.RawMessage) *event.Profile {

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -19,6 +19,7 @@ import (
 // silently inlining, which would lose the isolation the author asked for).
 type SubagentRunOptions struct {
 	ContinueFrom string
+	ForkFrom     string
 }
 
 type SubagentRunner func(ctx context.Context, sk Skill, task string, opts SubagentRunOptions) (string, error)
@@ -77,6 +78,7 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 		Continue  string `json:"continue_from"`
+		Fork      string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -90,7 +92,10 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		return "", fmt.Errorf("unknown skill %q — available: %s", name, availableNames(t.store))
 	}
 	rawArgs := strings.TrimSpace(p.Arguments)
-	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue)}
+	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
+	if opts.ContinueFrom != "" && opts.ForkFrom != "" {
+		return "", fmt.Errorf("run_skill: continue_from and fork_from are mutually exclusive; pass only continue_from")
+	}
 
 	if sk.RunAs == RunSubagent {
 		if t.runner == nil {
@@ -101,8 +106,8 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		}
 		return t.runner(ctx, sk, rawArgs, opts)
 	}
-	if opts.ContinueFrom != "" {
-		return "", fmt.Errorf("run_skill: continue_from is only valid for runAs=subagent skills")
+	if opts.ContinueFrom != "" || opts.ForkFrom != "" {
+		return "", fmt.Errorf("run_skill: subagent continuation is only valid for runAs=subagent skills")
 	}
 	return renderInline(sk, rawArgs), nil
 }
@@ -215,6 +220,7 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	var p struct {
 		Task     string `json:"task"`
 		Continue string `json:"continue_from"`
+		Fork     string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -235,7 +241,11 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if t.runner == nil {
 		return "", fmt.Errorf("%s: no subagent runner is configured in this session", t.toolName)
 	}
-	return t.runner(ctx, sk, task, SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue)})
+	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
+	if opts.ContinueFrom != "" && opts.ForkFrom != "" {
+		return "", fmt.Errorf("%s: continue_from and fork_from are mutually exclusive; pass only continue_from", t.toolName)
+	}
+	return t.runner(ctx, sk, task, opts)
 }
 
 func (t *subagentSkillTool) ResolveProfile(json.RawMessage) *event.Profile {

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -161,8 +161,30 @@ func TestBuiltinSubagentToolsPassContinuationOptions(t *testing.T) {
 	if _, err := review.Execute(context.Background(), json.RawMessage(`{"task":"again","continue_from":"sa_prev"}`)); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if got.ContinueFrom != "sa_prev" || got.ForkFrom != "" {
+	if got.ContinueFrom != "sa_prev" {
 		t.Fatalf("continuation opts = %+v, want continue_from sa_prev", got)
+	}
+}
+
+func TestSubagentSkillSchemasExposeOnlyContinueFromForPersistence(t *testing.T) {
+	runSkill := NewRunSkillTool(New(Options{HomeDir: t.TempDir(), DisableBuiltins: true}), nil)
+	runSchema := string(runSkill.Schema())
+	if !strings.Contains(runSchema, `"continue_from"`) {
+		t.Fatalf("run_skill schema = %s, want continue_from", runSchema)
+	}
+	if strings.Contains(runSchema, "fork_from") {
+		t.Fatalf("run_skill schema = %s, want no fork_from", runSchema)
+	}
+
+	tools := BuiltinSubagentTools(New(Options{HomeDir: t.TempDir()}), nil)
+	for _, tl := range tools {
+		schema := string(tl.Schema())
+		if !strings.Contains(schema, `"continue_from"`) {
+			t.Fatalf("%s schema = %s, want continue_from", tl.Name(), schema)
+		}
+		if strings.Contains(schema, "fork_from") {
+			t.Fatalf("%s schema = %s, want no fork_from", tl.Name(), schema)
+		}
 	}
 }
 

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -166,6 +166,49 @@ func TestBuiltinSubagentToolsPassContinuationOptions(t *testing.T) {
 	}
 }
 
+func TestRunSkillToolPassesLegacyForkOption(t *testing.T) {
+	var got SubagentRunOptions
+	runner := func(_ context.Context, _ Skill, _ string, opts SubagentRunOptions) (string, error) {
+		got = opts
+		return "ok", nil
+	}
+	runSkill := NewRunSkillTool(New(Options{HomeDir: t.TempDir()}), runner)
+	if _, err := runSkill.Execute(context.Background(), json.RawMessage(`{"name":"review","arguments":"again","fork_from":"sa_prev"}`)); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got.ForkFrom != "sa_prev" {
+		t.Fatalf("continuation opts = %+v, want fork_from sa_prev", got)
+	}
+}
+
+func TestBuiltinSubagentToolsPassLegacyForkOption(t *testing.T) {
+	var got SubagentRunOptions
+	runner := func(_ context.Context, _ Skill, _ string, opts SubagentRunOptions) (string, error) {
+		got = opts
+		return "ok", nil
+	}
+	tools := BuiltinSubagentTools(New(Options{HomeDir: t.TempDir()}), runner)
+	var review interface {
+		Name() string
+		Execute(context.Context, json.RawMessage) (string, error)
+	}
+	for _, tl := range tools {
+		if tl.Name() == "review" {
+			review = tl
+			break
+		}
+	}
+	if review == nil {
+		t.Fatal("review wrapper tool not built")
+	}
+	if _, err := review.Execute(context.Background(), json.RawMessage(`{"task":"again","fork_from":"sa_prev"}`)); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got.ForkFrom != "sa_prev" {
+		t.Fatalf("continuation opts = %+v, want fork_from sa_prev", got)
+	}
+}
+
 func TestSubagentSkillSchemasExposeOnlyContinueFromForPersistence(t *testing.T) {
 	runSkill := NewRunSkillTool(New(Options{HomeDir: t.TempDir(), DisableBuiltins: true}), nil)
 	runSchema := string(runSkill.Schema())


### PR DESCRIPTION
## 背景

当前持久化 subagent 复用同时暴露 `continue_from` 和 `fork_from`。在 fork 会话中，Agent 通常只知道自己想继续某个 subagent，让模型显式选择 `fork_from` 会把框架层的会话归属细节泄露给模型。

## 做了什么

- 将模型可见的 subagent 复用入口简化为只使用 `continue_from`，移除 `task`、`run_skill` 和 dedicated subagent skill tools 中的 `fork_from`。
- 在 storage/framework 层解析 ancestor-owned ref：沿当前会话 lineage 找最近的兼容 source，并懒复制到当前会话后继续。
- 为递归 fork、同会话幂等复用、sibling/unrelated 拒绝、failed/interrupted copy 拒绝、重复 copy 拒绝补充测试。
- 更新 subagent result 文案，让返回的 `Subagent reference` 明确表示后续 continuation 应使用的 active ref；ancestor 复制场景会显示 `Forked from`。
- 覆盖后台 `task` 的启动返回与 `wait` 最终返回，确保两阶段都带有正确 ref guidance。

## 为什么这样做

这样 Agent 只表达“继续这个 subagent transcript”的意图；是否需要复制、复制哪个最近 lineage source、以及如何避免重复 copy，都由框架层保证。这样能降低 prompt/schema 复杂度，也避免 fork 会话中误用旧 ref 导致重复分叉或上下文回退。

## 预期结果与收益

- Agent 后续只需要传 `continue_from=<ref>`。
- fork 会话中继续父会话 subagent 时，会自动得到当前会话自己的 copied ref。
- 多层 fork 会优先继承最近的 subagent copy，避免丢失中间会话追加的上下文。
- 同一会话重复误传旧 ancestor ref 不会创建第二份 copy。
- `parallel_tasks` 继续不暴露持久化 continuation 参数，本轮不扩大并行任务语义。

## 验证

- `go test ./internal/agent ./internal/skill ./internal/boot -count=1`
- `gofmt -w internal/agent/subagent_store.go internal/agent/subagent_store_test.go internal/agent/task.go internal/agent/task_test.go internal/boot/boot.go internal/skill/tools.go internal/skill/tools_test.go && go test ./...`

Cache-impact: medium - 本 PR 修改了 subagent tool schemas 和 subagent tool result 文案，会影响模型可见工具接口与工具结果。
Cache-guard: go test ./internal/agent ./internal/skill ./internal/boot -count=1；gofmt -w touched files && go test ./...
System-prompt-review: lifu963 reviewed and approved this model-visible tool schema/result-text change in local review; no system prompt, memory prefix, or skill index injection text changed.