### PR TITLE
fix(desktop): 让输入框待发送内容跟随会话切换

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1123,6 +1123,13 @@ export default function App() {
     () => tabMetas.find((tab) => tab.id === activeTabId) ?? tabMetas.find((tab) => tab.active),
     [activeTabId, tabMetas],
   );
+  // Derive a session key that changes whenever the session changes, even
+  // on the same tab (single-surface workbench/creation mode).
+  const sessionKey = useMemo(() => {
+    if (!activeTab) return activeTabId ?? "";
+    return activeTab.sessionPath || activeTab.topicId || activeTab.id;
+  }, [activeTab]);
+
   const sidebarImDetailConnection = useMemo(
     () => sidebarImConnections.find((connection) => connection.id === sidebarImDetailConnectionId) ?? null,
     [sidebarImConnections, sidebarImDetailConnectionId],
@@ -3115,6 +3122,7 @@ export default function App() {
               turnTokens={state.turnTokens}
               retry={state.retry}
               transientDismissSignal={transientOverlayDismissSignal}
+              sessionKey={sessionKey}
             />
             <StatusBar
               context={state.context}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -43,6 +43,14 @@ interface WorkspaceReference {
   isDir?: boolean;
 }
 
+/** Full pending state saved per session: text + context attachments */
+interface PendingDraft {
+  text: string;
+  attachments: Attachment[];
+  workspaceRefs: WorkspaceReference[];
+  sessionRefs: SessionReference[];
+}
+
 const LONG_PASTE_MIN_CHARS = 2000;
 const LONG_PASTE_MIN_LINES = 20;
 const COMPOSER_MIN_HEIGHT = 104;
@@ -350,6 +358,7 @@ export function Composer({
   turnTokens,
   retry,
   transientDismissSignal,
+  sessionKey,
 }: {
   running: boolean;
   collaborationMode: CollaborationMode;
@@ -387,6 +396,7 @@ export function Composer({
   turnTokens?: number;
   retry?: { attempt: number; max: number };
   transientDismissSignal?: number;
+  sessionKey?: string;
 }) {
   const { t, locale } = useI18n();
   const { showToast } = useToast();
@@ -449,6 +459,14 @@ export function Composer({
   cwdRef.current = cwd;
   const attachmentDedupRef = useRef(new DedupIndex());
   const attachmentDedupKeysRef = useRef<Record<string, AttachmentDedupKey>>({});
+  // Per-session draft persistence: save input text per session so switching
+  // away and back preserves what the user was typing (issue #4902).
+  // Uses sessionKey (topicId/sessionPath) so it works in all three layout
+  // modes: classic (multi-tab), workbench & creation (single-surface).
+  const draftsByTabRef = useRef<Record<string, PendingDraft>>({});
+  const prevSessionKeyRef = useRef<string | undefined>(sessionKey);
+  const textRef = useRef(text);
+  textRef.current = text;
 
   const clearNativeClipboardPasteTimer = () => {
     if (nativeClipboardPasteTimerRef.current === null) return;
@@ -466,6 +484,37 @@ export function Composer({
     }
     wasRunning.current = running;
   }, [running, text]);
+
+  // Per-session draft persistence: save text + context attachments for the
+  // outgoing session and restore them for the incoming session whenever
+  // sessionKey changes.
+  // sessionKey changes on tab switch (classic) AND topic switch on the
+  // same tab (workbench/creation single-surface mode).
+  useEffect(() => {
+    const prev = prevSessionKeyRef.current;
+    if (prev === sessionKey) return;
+    if (prev !== undefined) {
+      draftsByTabRef.current[prev] = { text: textRef.current, attachments, workspaceRefs, sessionRefs };
+    }
+    if (sessionKey !== undefined) {
+      const draft = draftsByTabRef.current[sessionKey];
+      if (draft !== undefined) {
+        setTextCaretEnd(draft.text);
+        setAttachments(draft.attachments);
+        setWorkspaceRefs(draft.workspaceRefs);
+        setSessionRefs(draft.sessionRefs);
+      } else if (prev !== undefined) {
+        setTextCaretEnd("");
+        setAttachments([]);
+        setWorkspaceRefs([]);
+        setSessionRefs([]);
+      }
+    }
+    prevSessionKeyRef.current = sessionKey;
+    // deps: setTextCaretEnd only uses setText (stable) and taRef (ref),
+    // so excluding it from deps is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionKey]);
 
   // --- slash commands (whole-input "/token") ---
   const [commands, setCommands] = useState<CommandInfo[]>([]);


### PR DESCRIPTION
修复 #4902

## 问题
桌面端 Composer 的输入文本是全局共享的 `useState('')`，切换 tab 时
不会改变。在 Tab A 输入内容未发送，切换到 Session B 时文本仍然保留。

## 复现
1. 在会话 A 输入内容但不发送
2. 切换到会话 B
3. 会话 A 的待发送文本仍然保留，导致无法向会话 B 正常发送

## 方案
改用 `sessionKey`（基于 `topicId / sessionPath / tab.id`）作为 draft
存储 key，在三种桌面风格下都有效：

- **经典**（多标签）：不同 tab → 不同 `tab.id` → 不同 `sessionKey`
- **工作台/创作**（单画布）：同一 tab 切换话题 → `topicId` 变化 → `sessionKey` 变化

## 改动
`desktop/frontend/src/App.tsx` — +8 行：推导 `sessionKey` 并传递给 Composer
`desktop/frontend/src/components/Composer.tsx` — +34 行：用 `sessionKey` 替代 `tabId` 作为 draft 存储键，切换时自动聚焦输入框

## 附注
- 感谢 @Moeclub 反馈原问题
- PR 审核技能新增第 53 条原则 `layout-mode-state-coverage`：组件内部本地状态在三种桌面风格下生命周期不一致