### PR TITLE
fix: 进度面板折叠状态持久化到 localStorage，移除自动弹窗

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3028,7 +3028,7 @@ export default function App() {
 
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
-            {showTodos && <TodoPanel todoKey={todoKey} todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
+            {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
             {rewindState && (
               <UndoRewindBanner
                 meta={{

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -3,31 +3,44 @@ import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
 import { PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 
+const STORAGE_KEY = "todoPanel:open";
+
+function loadOpenState(): boolean {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved === null ? true : saved === "1";
+  } catch {
+    return true;
+  }
+}
+
+function saveOpenState(open: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, open ? "1" : "0");
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
 // TodoPanel is the live task list pinned just above the composer — the kernel's
 // latest todo_write call drives it, and it updates in place as the agent flips
-// items to in_progress / completed. Completed lists collapse automatically so
-// the user still sees the final state without the footer staying tall forever.
+// items to in_progress / completed. The collapsed/expanded state is persisted
+// globally in localStorage so the user's choice sticks across sessions.
 export function TodoPanel({
-  todoKey,
   todos,
   onDismiss,
 }: {
-  todoKey: string;
   todos: Todo[];
   onDismiss: () => void;
 }) {
   const t = useT();
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(loadOpenState);
   const currentRef = useRef<HTMLLIElement | null>(null);
 
   const done = todos.filter((t) => t.status === "completed").length;
   const current = todos.find((t) => t.status === "in_progress");
   const allDone = todos.length > 0 && done === todos.length;
   const summary = current?.activeForm || current?.content || todos[todos.length - 1]?.content || "";
-
-  useEffect(() => {
-    setOpen(!allDone);
-  }, [todoKey, allDone]);
 
   useEffect(() => {
     if (!open) return;
@@ -45,7 +58,7 @@ export function TodoPanel({
       role="region"
       headerActions={
         <>
-          <PromptHeaderAction onClick={() => setOpen((value) => !value)}>
+          <PromptHeaderAction onClick={() => setOpen((value) => { const next = !value; saveOpenState(next); return next; })}>
             {open ? t("common.collapse") : t("common.expand")}
           </PromptHeaderAction>
           {allDone && (

--- a/internal/serve/auth_test.go
+++ b/internal/serve/auth_test.go
@@ -509,9 +509,14 @@ func TestSessionWrongSignature(t *testing.T) {
 
 	tok := ag.signSession()
 	dot := strings.LastIndexByte(tok, '.')
-	// Flip a hex character in the signature.
+	// Flip a hex character in the signature, ensuring it actually changes
+	// (the first nibble might already be 0 → "0" + sig[1:] would be a no-op).
 	sig := tok[dot+1:]
-	flipped := tok[:dot+1] + "0" + sig[1:]
+	target := byte('0')
+	if sig[0] == target {
+		target = 'f' // guaranteed different
+	}
+	flipped := tok[:dot+1] + string(target) + sig[1:]
 	if ag.verifySession(flipped) {
 		t.Error("wrong-signature session should not verify")
 	}


### PR DESCRIPTION
## 问题
进度面板（TodoPanel）在状态更新时自动弹窗，用户手动折叠后无法保持收起状态。Issue #4920

## 原因
useEffect 在 todoKey 变化时强制 setOpen(!allDone)，新任务到达时 allDone 为 false，导致 setOpen(true)，覆盖用户的手动折叠操作。

## 改动
3 个文件：

- **TodoPanel.tsx**: 添加 loadOpenState/saveOpenState 将折叠/展开状态持久化到 localStorage('todoPanel:open')；移除自动展开的 useEffect；展开/折叠完全由用户控制
- **App.tsx**: 从 TodoPanel props 中移除不再需要的 todoKey
- **auth_test.go**: 修复 TestSessionWrongSignature flaky test（签名首 nibble 有 1/16 概率天然是 0，翻转成空操作导致测试随机失败）

## 效果
- 用户折叠 → 一直折叠，新任务进来也不弹开
- 用户展开 → 一直展开
- 跨会话保持（全局持久化）
- 首次使用默认展开（和原来一致）
- 三种桌面风格（经典/工作台/创作）均生效

Cache-impact: low — auth_test.go 改动不会影响缓存
Cache-guard: 仅改动测试文件 auth_test.go（flaky fix）+ 前端 TodoPanel.tsx（功能改动）