### PR TITLE
fix: 关闭侧栏后输入框宽度撑满窗口 + jump-bar/滚动条不影响历史消息对齐

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -135,6 +135,10 @@ for (const selector of [
 }
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
+ok(
+  /@container\s*\(max-width:\s*760px\)[\s\S]*?\.composer-meta--has-intent-chip\s+\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*1 1 160px[\s\S]*?\.composer-meta__control--effort\s*\{[\s\S]*?display\s*:\s*none[\s\S]*?\.composer-meta__control--more\s*\{[\s\S]*?display\s*:\s*inline-flex/.test(styles),
+  "composer compact controls activate at the capped theme width",
+);
 eq(finalDeclaration(".md table", "overflow-x"), "auto", "markdown tables scroll horizontally");
 eq(finalDeclaration(".code", "overflow"), "auto", "code blocks scroll instead of widening the layout");
 ok(

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -602,10 +602,6 @@ export function Transcript({
       >
         {empty && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
 
-        {!empty && showQuestionNav && (
-          <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
-        )}
-
         <LiveStreamContext.Provider value={live}>
           {turnGroups.length > HOT_TURNS && (
             <WarmZone
@@ -642,6 +638,10 @@ export function Transcript({
           </div>
         </LiveStreamContext.Provider>
       </div>
+
+      {!empty && showQuestionNav && (
+        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
+      )}
 
       {!empty && !isAtBottom && (
         <button

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3066,7 +3066,7 @@ a[href] {
   overflow-y: auto;
   overflow-y: overlay;
   overflow-x: hidden;
-  scrollbar-gutter: auto;
+  scrollbar-gutter: stable both-edges;
   padding: 24px 32px 32px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5574,14 +5574,19 @@ a[href] {
   flex-shrink: 0;
 }
 
-@container (max-width: 620px) {
+@container (max-width: 760px) {
   .composer-meta {
     gap: 8px;
     padding-inline: 10px;
   }
 
   .composer-meta__control--model {
-    flex: 0 0 auto;
+    flex: 1 1 160px;
+    max-width: min(320px, 50vw);
+  }
+
+  .composer-meta--has-intent-chip .composer-meta__control--model {
+    flex: 1 1 160px;
     max-width: min(320px, 50vw);
   }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3302,20 +3302,19 @@ a[href] {
 }
 
 .transcript > .jump-bar {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  margin: 0;
   max-width: none;
-  margin-left: auto;
-  margin-right: -48px;
 }
 .jump-bar {
-  position: sticky;
-  top: 50%;
   z-index: var(--z-inline-sticky);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   width: 56px;
   height: 240px;
-  margin-bottom: -240px;
   padding: 0 12px;
   opacity: 0;
   pointer-events: none;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3064,7 +3064,9 @@ a[href] {
   position: relative;
   height: 100%;
   overflow-y: auto;
+  overflow-y: overlay;
   overflow-x: hidden;
+  scrollbar-gutter: auto;
   padding: 24px 32px 32px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
@@ -20811,8 +20813,8 @@ a[href] {
 
 :root[data-theme-style] .composer-wrap {
   width: 100%;
-  max-width: none;
-  margin: 0;
+  max-width: var(--maxw);
+  margin: 0 auto;
 }
 
 :root[data-theme-style] .composer-card {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -20828,7 +20828,6 @@ a[href] {
 :root[data-theme-style] .composer-card:focus-within {
   border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
-  transform: translateY(-1px);
 }
 
 :root[data-theme-style] .composer {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3301,12 +3301,14 @@ a[href] {
   white-space: nowrap;
 }
 
-.transcript > .jump-bar {
+.transcript-shell > .jump-bar {
   position: absolute;
   top: 50%;
   right: 0;
-  margin: 0;
+  z-index: var(--z-inline-sticky);
   max-width: none;
+  margin: 0;
+  transform: translate(4px, -50%);
 }
 .jump-bar {
   z-index: var(--z-inline-sticky);
@@ -3318,7 +3320,6 @@ a[href] {
   padding: 0 12px;
   opacity: 0;
   pointer-events: none;
-  transform: translate(4px, -50%);
   animation: jump-bar-in 0.18s ease-out 0.08s forwards;
 }
 .jump-scroll {


### PR DESCRIPTION
# 问题

关闭左侧和右侧侧栏后，聊天输入框自适应铺满整个窗口宽度，导致单行输入框视觉宽度过大（工作台模式）。

jump-bar（快捷跳转条）和滚动条出现/消失时会导致历史消息区域偏移。

# 修复（3 commits）

## 1. 工作台模式下输入框居中

`[data-theme-style] .composer-wrap` 的 `max-width: none` 覆盖了 `--maxw: 760px`，改为 `max-width: var(--maxw); margin: 0 auto`。

## 2. Jump-bar 移出 transcript

QuestionJumpBar 从 `.transcript` 内部移到 `.transcript-shell` 下，CSS 改用 `position: absolute; top: 50%; right: 0`，不参与 transcript 子元素布局。

## 3. 滚动条不影响内容对齐

`scrollbar-gutter: stable both-edges` 在两侧对称预留空间，滚动条出现/消失不影响历史消息居中。

# 改动

- `desktop/frontend/src/components/Transcript.tsx`: QuestionJumpBar 移出 `.transcript`
- `desktop/frontend/src/styles.css`: composer-wrap max-width, jump-bar 定位, scrollbar-gutter

Fixes #4465