### PR TITLE
fix(desktop): prevent workspace tree jump on folder expand

### DIFF
--- a/desktop/frontend/src/__tests__/workspace-split.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-split.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/workspaceSplit";
 import { resolveWorkspacePanelWidth } from "../lib/workspaceLayout";
 import { closeWorkspacePreviewTab } from "../lib/workspacePreviewTabs";
+import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
 
 let passed = 0;
 let failed = 0;
@@ -192,6 +193,39 @@ eq(
   }),
   effectiveEvenTreeWidth,
   "entering manual resize from even split keeps the currently rendered tree width",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: "src/App.tsx",
+    actualTreeVisible: true,
+    selectedIndex: 42,
+  }),
+  true,
+  "pending file reveal scrolls once the selected row is present",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: null,
+    actualTreeVisible: true,
+    selectedIndex: 42,
+  }),
+  false,
+  "manual folder changes do not re-scroll to the previous selected file",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: "src/App.tsx",
+    actualTreeVisible: true,
+    selectedIndex: -1,
+  }),
+  false,
+  "pending file reveal waits until async directory loading exposes the row",
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -37,6 +37,7 @@ import {
 } from "../lib/workspaceSplit";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
 import { closeWorkspacePreviewTab } from "../lib/workspacePreviewTabs";
+import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
 import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView, WorkspaceChangeView } from "../lib/types";
 import { formatWorkspaceReference, WORKSPACE_REF_DRAG_TYPE } from "../lib/workspaceDrag";
 import { cleanGitDiff } from "../lib/diff";
@@ -274,6 +275,7 @@ export function WorkspacePanel({
   const commitDetailRequestIdRef = useRef(0);
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
+  const pendingTreeRevealPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     openDirsRef.current = openDirs;
@@ -376,6 +378,7 @@ export function WorkspacePanel({
         }));
         setTreeWidthMode("even");
       }
+      pendingTreeRevealPathRef.current = path;
       setSelectedPath(path);
       setScopedFilePaths((current) => {
         if (current) dismissedFileListRequestIdRef.current = lastFileListRequestIdRef.current;
@@ -812,11 +815,16 @@ export function WorkspacePanel({
   );
 
   useEffect(() => {
-    if (!selectedPath || !actualTreeVisible) return;
-    const selectedIndex = treeRows.findIndex((row) => row.path === selectedPath);
-    if (selectedIndex !== -1) {
-      virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
+    const pendingRevealPath = pendingTreeRevealPathRef.current;
+    if (!pendingRevealPath) return;
+    if (!selectedPath || pendingRevealPath !== selectedPath) {
+      pendingTreeRevealPathRef.current = null;
+      return;
     }
+    const selectedIndex = treeRows.findIndex((row) => row.path === selectedPath);
+    if (!shouldScrollWorkspaceTreeSelection({ selectedPath, pendingRevealPath, actualTreeVisible, selectedIndex })) return;
+    virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
+    pendingTreeRevealPathRef.current = null;
   }, [selectedPath, actualTreeVisible, treeRows, virtualizer]);
 
   const panelStyle = useMemo(

--- a/desktop/frontend/src/lib/workspaceTreeReveal.ts
+++ b/desktop/frontend/src/lib/workspaceTreeReveal.ts
@@ -1,0 +1,18 @@
+export function shouldScrollWorkspaceTreeSelection({
+  selectedPath,
+  pendingRevealPath,
+  actualTreeVisible,
+  selectedIndex,
+}: {
+  selectedPath: string | null;
+  pendingRevealPath: string | null;
+  actualTreeVisible: boolean;
+  selectedIndex: number;
+}): boolean {
+  return Boolean(
+    selectedPath &&
+      pendingRevealPath === selectedPath &&
+      actualTreeVisible &&
+      selectedIndex >= 0,
+  );
+}


### PR DESCRIPTION
## 背景

Desktop 的 workspace 文件树存在一个滚动体验问题：用户先在文件树底部选中某个文件，再滚动到上方展开文件夹时，文件树会跳回上一次选中的文件位置。继续展开二级目录时也会重复跳回，影响浏览和定位文件。

## 做了什么

- 将文件树的“滚动到选中文件”行为改成一次性的 reveal 意图，只在明确选择/定位文件时触发。
- 当用户只是展开或折叠文件夹时，不再因为树结构变化而重新滚到旧的选中文件。
- 提取 `shouldScrollWorkspaceTreeSelection` 作为纯函数，补充回归测试覆盖 pending reveal、手动展开不回滚、异步目录加载时等待目标行出现等情况。

## 为什么这样做

原逻辑的滚动 effect 依赖 `treeRows`，所以任何目录展开、折叠或异步加载导致的树行变化，都会再次对旧的 `selectedPath` 执行 `scrollToIndex`。新的实现把滚动限定为“本次选择文件后的单次动作”，既保留选中文件时自动 reveal 的能力，也避免用户浏览目录时被旧选择抢走滚动位置。

## 预期结果与收益

- 展开/折叠文件夹时，文件树保持在用户当前浏览位置。
- 选中新文件时，预览仍正常更新。
- 外部 reveal/选择文件流程仍能在目标行出现后滚动到目标文件。
- 改善 workspace 文件树的可用性，减少浏览大型项目时的反复滚动。

## 验证

- `pnpm exec tsx src/__tests__/workspace-split.test.ts`，结果：`19 passed, 0 failed`
- `wails generate module && pnpm typecheck`，结果：通过
- `git diff --check`，结果：通过
- 真实 Desktop APP 验收：通过。验证了选中底部文件后滚回上方并展开多级文件夹，不再跳回旧选中文件；选中新文件仍正常更新预览。

Cache-impact: none。仅修改 Desktop workspace 文件树 UI 滚动逻辑，不涉及 prompt、tool schema、provider request 或 cache-sensitive 路径。
Cache-guard: `pnpm exec tsx src/__tests__/workspace-split.test.ts`。
System-prompt-review: none。