### PR TITLE
Default workspace panel to collapsed / 默认收起工作区面板

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -11,6 +11,7 @@ const commandPaletteSource = readFileSync(resolve(testDir, "../components/Comman
 const projectTreeSource = readFileSync(resolve(testDir, "../components/ProjectTree.tsx"), "utf8");
 const topicShortcutsSource = readFileSync(resolve(testDir, "../lib/topicShortcuts.ts"), "utf8");
 const transcriptSource = readFileSync(resolve(testDir, "../components/Transcript.tsx"), "utf8");
+const layoutStoreSource = readFileSync(resolve(testDir, "../store/layout.ts"), "utf8");
 const stylesSource = readFileSync(resolve(testDir, "../styles.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
 let passed = 0;
@@ -66,6 +67,12 @@ for (const propName of ["onTabChange", "onTabClose", "onTabsClose", "onTabsReord
 ok(
   /app-chrome__tab-strip/.test(appChromeSource),
   "AppChrome markup includes classic tab strip containers",
+);
+
+ok(
+  /const WORKSPACE_PANEL_DEFAULT_OPEN = false;/.test(layoutStoreSource) &&
+    /workspacePanelOpen:\s*WORKSPACE_PANEL_DEFAULT_OPEN/.test(layoutStoreSource),
+  "right dock starts collapsed on launch",
 );
 
 ok(

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -32,6 +32,7 @@ export const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
 export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 export const RIGHT_DOCK_MAX_WIDTH = 860;
+const WORKSPACE_PANEL_DEFAULT_OPEN = false;
 
 export function clampSidebarWidth(width: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
@@ -139,7 +140,7 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarWidth: loadSidebarWidth(),
   rightDockTreeWidth: loadRightDockTreeWidth(),
   rightDockPreviewWidth: loadRightDockPreviewWidth(),
-  workspacePanelOpen: true,
+  workspacePanelOpen: WORKSPACE_PANEL_DEFAULT_OPEN,
   workspacePanelMaximized: false,
   workspacePreviewActive: false,
   rightDockMode: "context",


### PR DESCRIPTION
## Summary
- Default the desktop workspace/right dock panel to collapsed on startup.
- Keep the existing manual expand affordance and persisted width preferences unchanged.
- Add a source-level regression check so the default does not drift back to expanded.

## Verification
- `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts`
- `pnpm test:typecheck`
- Browser reload verified the dock is not rendered by default and the toggle offers "Expand workspace".