### PR TITLE
fix(desktop): fix the issues of ICON position, scrollbar dragging, and the compression threshold of the right panel overview exceeding the panel / 修复“创作”风格，ICON位置、滚动条拖动、右侧面板概览压缩阈值超出面板的问题

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1893,6 +1893,7 @@ export default function App() {
     if (!workspacePanelOpen) {
       return;
     }
+    setLiveWorkspacePanelRenderWidth(null);
     setWorkspacePanelMaximized(false);
     setWorkspacePanelOpen(false);
   }, [closeTransientOverlays, workspacePanelOpen]);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -23297,6 +23297,14 @@ a[href] {
   grid-row: 1;
 }
 
+/* Opening the right dock must not animate the workspace column from 0 width;
+   WebKit can mount the overview panel at zero inline-size and leave stat text
+   permanently invisible until the next full reload. */
+.app--creation .layout.layout--workspace-open,
+.app--creation .layout.layout--workspace-open.layout--sidebar-collapsed {
+  transition: grid-template-columns 0s, min-width 0s;
+}
+
 .app--creation .layout--creation-chrome-hidden .sidebar-resizer,
 :root[data-theme-style] .app--creation .layout--creation-chrome-hidden .sidebar-resizer {
   top: 0;
@@ -23957,7 +23965,7 @@ a[href] {
 .app--creation .sidebar,
 :root[data-theme-style] .app--creation .sidebar {
   --project-tree-row-radius: 9px;
-  padding: 18px 12px 14px;
+  padding: 38px 12px 14px;
   border-right: 0;
   background:
     radial-gradient(110% 70% at 18% 0%, color-mix(in srgb, var(--accent) 5%, transparent) 0%, transparent 52%),
@@ -24466,8 +24474,8 @@ a[href] {
 
 .app--creation .transcript::-webkit-scrollbar,
 :root[data-theme-style] .app--creation .transcript::-webkit-scrollbar {
-  width: 2px !important;
-  height: 2px !important;
+  width: 6px !important;
+  height: 6px !important;
   background: transparent !important;
 }
 
@@ -25550,6 +25558,7 @@ a[href] {
 
 .app--creation .context-panel__overview {
   gap: 10px;
+  min-width: 0;
 }
 
 .app--creation .context-panel__usage,
@@ -25557,13 +25566,14 @@ a[href] {
 :root[data-theme-style] .app--creation .context-panel__usage,
 :root[data-theme-style] .app--creation .context-panel__section {
   gap: 12px;
+  min-width: 0;
   padding: 11px;
+  overflow: hidden;
   border: 1px solid var(--creation-panel-border);
   border-radius: 12px;
   background: var(--creation-panel-card);
   box-shadow: var(--creation-panel-shadow);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  animation: none;
 }
 
 .app--creation .context-panel__section {
@@ -25644,7 +25654,7 @@ a[href] {
 .app--creation .context-panel__mini-stat {
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, auto);
   align-items: baseline;
   gap: 12px;
   color: color-mix(in srgb, var(--fg-dim) 84%, transparent);
@@ -25661,6 +25671,12 @@ a[href] {
 }
 
 .app--creation .context-panel__mini-stat strong {
+  min-width: 0;
+  max-width: 100%;
+  justify-self: end;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
@@ -25708,8 +25724,6 @@ a[href] {
   border-radius: 10px;
   background: var(--creation-panel-card);
   box-shadow: var(--creation-panel-shadow);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
 }
 
 .app--creation .context-panel__metric span,


### PR DESCRIPTION
## Summary

- 调整创作风格侧栏顶部内边距（`18px → 38px`），使左上角 icon 与关闭按钮保持合理间距。
- 将创作风格 transcript 滚动条宽度从 `2px` 增至 `6px`，便于鼠标拖拽滚动。
- 修复右侧面板「概览」中压缩阈值等 mini-stat 数值超出面板的问题：值列改为可收缩的 `minmax(0, auto)`，并对 `strong` 启用 ellipsis 截断。
- 修复关闭再打开右侧面板后概览文字不显示的问题：创作风格下跳过 workspace 列宽动画（避免 WebKit 在 0 宽度挂载时文字不重绘）；移除概览卡片的 `backdrop-filter` 与入场动画；关闭面板时清除 `liveWorkspacePanelRenderWidth` 残留状态。

## Verification

- [ ] 桌面端切换至「创作」风格，确认左上角 icon 与关闭按钮间距正常。
- [ ] 在 transcript 区域滚动，确认滚动条可见且可用鼠标拖拽。
- [ ] 启动应用后打开右侧「概览」，确认「压缩阈值」等数值不超出面板（过长时显示省略号）。
- [ ] 关闭再打开右侧面板，确认概览文字（含压缩阈值）正常显示。
- [x] `cd desktop/frontend && npx tsx src/__tests__/typography-overflow-contract.test.ts`

## Cache impact

Cache-impact: none — frontend CSS/layout only; no changes to prompts, memory prefix, output style, or skill index.
Cache-guard: N/A — no cache-sensitive paths touched.
System-prompt-review: N/A