### PR TITLE
fix: 工作台/创作模式下新建对话显示旧对话的问题

### DIFF
--- a/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
+++ b/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
@@ -181,6 +181,52 @@ eq(controller?.state.items.length, 0, "stale history load cannot repopulate a ne
 await act(async () => {
   root.unmount();
 });
+
+const guardedStartupTabs = deferred<TabMeta[]>();
+let ensureBlankSurfaceCalls = 0;
+window.go.main.App = {
+  ListTabs: async () => guardedStartupTabs.promise,
+  MetaForTab: async () => meta(),
+  ContextUsageForTab: async () => context,
+  EffortForTab: async () => effort,
+  BalanceForTab: async () => balance,
+  JobsForTab: async () => jobs,
+  CheckpointsForTab: async () => checkpoints,
+  HistoryForTab: async () => [],
+  ReplayPendingPrompts: async () => {},
+  EnsureBlankSurface: async () => {
+    ensureBlankSurfaceCalls += 1;
+    return tabMeta({ id: "tab-new", topicId: "topic-new", topicTitle: "New session" });
+  },
+} as Partial<AppBindings> as AppBindings;
+
+controller = undefined;
+const guardRoot = createRoot(rootEl);
+
+await act(async () => {
+  guardRoot.render(<Probe />);
+  await flushPromises();
+});
+
+await act(async () => {
+  await controller?.ensureBlankSurface("project", "/repo");
+  await flushPromises();
+});
+
+eq(ensureBlankSurfaceCalls, 1, "EnsureBlankSurface is called once");
+eq(controller?.activeTabId, "tab-new", "blank surface becomes active before startup sync resolves");
+
+await act(async () => {
+  guardedStartupTabs.resolve([tabMeta({ id: "tab-old", topicId: "topic-old", topicTitle: "Old session" })]);
+  await guardedStartupTabs.promise;
+  await flushPromises();
+});
+
+eq(controller?.activeTabId, "tab-new", "guarded startup sync cannot restore an older active tab");
+
+await act(async () => {
+  guardRoot.unmount();
+});
 dom.window.close();
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -992,9 +992,16 @@ export function useController() {
     }
   }, []);
 
-  const syncActiveTabFromBackend = useCallback(async (reset = false): Promise<string | undefined> => {
+  const syncActiveTabFromBackend = useCallback(async (reset = false, guard = false): Promise<string | undefined> => {
     const active = await activeTabFromBackend();
     if (!active) return undefined;
+    // When guard is true, skip if the frontend already settled on a
+    // different tab while we were fetching — this prevents fire-and-forget
+    // calls from mount/onReady from overwriting a user-initiated tab switch
+    // (e.g. handleNewTab → ensureBlankSurface / switchTab).
+    if (guard && activeTabIdRef.current && activeTabIdRef.current !== active.id) {
+      return active.id;
+    }
     setActiveTabId(active.id);
     activeTabIdRef.current = active.id;
     confirmBackendActiveTab(active.id);
@@ -1086,10 +1093,10 @@ export function useController() {
         void loadSessionDataForTab(readyTabId, false, "startup");
         return;
       }
-      void syncActiveTabFromBackend();
+      void syncActiveTabFromBackend(false, true);
     });
 
-    void syncActiveTabFromBackend();
+    void syncActiveTabFromBackend(false, true);
     // The event subscription is live now, so ask the backend to re-emit any
     // approval/ask prompt that was already blocking a tab before this load —
     // otherwise a session left mid-confirmation shows "waiting" with no modal


### PR DESCRIPTION
工作台和创作模式使用 `ensureBlankSurface`（单 surface 布局）创建新对话时，
与 mount/onReady 时 fire-and-forget 调用的 `syncActiveTabFromBackend`
存在竞态条件：后者异步返回后会用旧的 backend tab 覆盖新创建的空白 tab。

修复：给 `syncActiveTabFromBackend` 增加 `guard` 参数，mount/onReady 的
fire-and-forget 调用传入 `guard=true`，在异步获取 backend 结果后检查
`activeTabIdRef.current` 是否已被用户操作改变，若是则跳过覆盖。