### PR TITLE
Integrate desktop workspace and plan persistence fixes / 整合工作区与计划模式修复

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -88,7 +88,8 @@ import {
   hydrateComposerProfilesFromTabs,
   patchComposerProfile,
   pruneUserPlanModeIntents,
-  shouldRestoreUserPlanMode,
+  resolvePlanRestoreTabId,
+  shouldRestoreUserPlanModeForProfile,
   updateUserPlanModeIntent,
   type ComposerProfile,
   type ComposerProfileField,
@@ -1525,6 +1526,7 @@ export default function App() {
         const displayGoal = stripGoalResearchFlags(arg);
         if (displayGoal && !["status", "clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
           if (hasGoalResearchFlag(arg)) {
+            userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, false);
             patchActiveComposerProfile({
               collaborationMode: "goal",
               goalDraftMode: false,
@@ -1587,7 +1589,7 @@ export default function App() {
       if (goal.trim()) await setControllerGoal(goal);
       commitThenSend(trimmed, submitText.trim());
     },
-    [applyGoal, closeTransientOverlays, collaborationMode, composerProfile, controllerReady, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, steer, switchModel, t, toolApprovalMode, showToast],
+    [activeTabId, applyGoal, closeTransientOverlays, collaborationMode, composerProfile, controllerReady, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, steer, switchModel, t, toolApprovalMode, showToast],
   );
 
   const refreshTabMetas = useCallback(async (): Promise<TabMeta[]> => {
@@ -1599,14 +1601,19 @@ export default function App() {
   useEffect(() => {
     const unsub = onEvent((e) => {
       if (e.kind !== "turn_done") return;
-      const turnTabId = activeTabIdRef.current;
+      const turnTabId = resolvePlanRestoreTabId(e.tabId, activeTabIdRef.current);
       window.setTimeout(() => {
         setProjectRevision((value) => value + 1);
         refreshTabMetas().then((tabs) => {
           if (!turnTabId) return;
-          if (!shouldRestoreUserPlanMode(userPlanModeByTabRef.current, turnTabId)) return;
           const tab = tabs.find((item) => item.id === turnTabId);
           const baseProfile = tab ? composerProfileFromTab(tab) : defaultComposerProfile;
+          if (!shouldRestoreUserPlanModeForProfile(userPlanModeByTabRef.current, turnTabId, baseProfile)) {
+            if (baseProfile.goal.trim()) {
+              userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, turnTabId, false);
+            }
+            return;
+          }
           setComposerProfilesByTab((current) => patchComposerProfile(
             current,
             turnTabId,

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -68,6 +68,7 @@ import {
   type ComposerInsertRequest,
   type DesktopStartupSettingsView,
   type Mode,
+  modeHasPlan,
   type ProjectNode,
   type SessionMeta,
   type SettingsView,
@@ -86,8 +87,12 @@ import {
   hydrateComposerProfileFromMeta,
   hydrateComposerProfilesFromTabs,
   patchComposerProfile,
+  pruneUserPlanModeIntents,
+  shouldRestoreUserPlanMode,
+  updateUserPlanModeIntent,
   type ComposerProfile,
   type ComposerProfileField,
+  type UserPlanModeIntents,
 } from "./lib/composerProfile";
 import {
   restorableToolApprovalMode,
@@ -821,6 +826,7 @@ export default function App() {
   const t = useT();
   const [composerProfilesByTab, setComposerProfilesByTab] = useState<Record<string, ComposerProfile>>({});
   const yoloRestoreToolApprovalModesRef = useRef<Record<string, RestorableToolApprovalMode>>({});
+  const userPlanModeByTabRef = useRef<UserPlanModeIntents>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
@@ -1100,6 +1106,7 @@ export default function App() {
   const footerHeightRef = useRef(0);
   const footerRef = useRef<HTMLElement>(null);
   const runningRef = useRef(state.running);
+  const activeTabIdRef = useRef(activeTabId);
   const rightDockDetailActive = rightDockMode !== "context" && workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
@@ -1243,6 +1250,7 @@ export default function App() {
     for (const id of Object.keys(yoloRestoreToolApprovalModesRef.current)) {
       if (!ids.has(id)) delete yoloRestoreToolApprovalModesRef.current[id];
     }
+    userPlanModeByTabRef.current = pruneUserPlanModeIntents(userPlanModeByTabRef.current, ids);
     setComposerProfilesByTab((current) => hydrateComposerProfilesFromTabs(current, tabMetas));
   }, [tabMetas]);
 
@@ -1271,13 +1279,17 @@ export default function App() {
   // normal clears both.
   const applyMode = useCallback(
     (m: Mode) => {
+      userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, modeHasPlan(m));
       patchActiveComposerProfile(composerProfileWithMode(m), ["collaborationMode", "toolApprovalMode", "goal"]);
       void syncModeToController(m);
     },
-    [patchActiveComposerProfile, syncModeToController],
+    [activeTabId, patchActiveComposerProfile, syncModeToController],
   );
   const applyCollaborationMode = useCallback(
-    (m: CollaborationMode): Promise<void> => {
+    (m: CollaborationMode, options: { rememberUserIntent?: boolean } = {}): Promise<void> => {
+      if (options.rememberUserIntent !== false) {
+        userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, m === "plan");
+      }
       if (m === "goal") {
         patchActiveComposerProfile({ collaborationMode: "normal", goalDraftMode: true, goal: "" }, ["collaborationMode", "goal"]);
         return setControllerCollaborationMode("normal");
@@ -1285,7 +1297,7 @@ export default function App() {
       patchActiveComposerProfile({ collaborationMode: m, goalDraftMode: false, goal: "" }, ["collaborationMode", "goal"]);
       return setControllerCollaborationMode(m);
     },
-    [patchActiveComposerProfile, setControllerCollaborationMode],
+    [activeTabId, patchActiveComposerProfile, setControllerCollaborationMode],
   );
   const applyToolApprovalMode = useCallback(
     (m: ToolApprovalMode) => {
@@ -1315,6 +1327,7 @@ export default function App() {
   }, [activeTabId, applyToolApprovalMode, toolApprovalMode]);
   const applyGoal = useCallback(
     (nextGoal: string) => {
+      userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, false);
       const trimmed = nextGoal.trim();
       patchActiveComposerProfile({
         collaborationMode: trimmed ? "goal" : "normal",
@@ -1323,7 +1336,7 @@ export default function App() {
       }, ["collaborationMode", "goal"]);
       void (trimmed ? setControllerGoal(trimmed) : clearControllerGoal());
     },
-    [clearControllerGoal, patchActiveComposerProfile, setControllerGoal],
+    [activeTabId, clearControllerGoal, patchActiveComposerProfile, setControllerGoal],
   );
   const applyTokenMode = useCallback(
     (m: TokenMode) => {
@@ -1469,6 +1482,10 @@ export default function App() {
     runningRef.current = state.running;
   }, [state.running]);
 
+  useEffect(() => {
+    activeTabIdRef.current = activeTabId;
+  }, [activeTabId]);
+
   // handleSend intercepts slash commands that need a desktop-native action before
   // they reach the backend: "/model <ref>" rebuilds on that model, "/memory"
   // opens Settings, and "/clear" shows an in-app confirmation card. Everything else — skills (/init, …),
@@ -1582,13 +1599,29 @@ export default function App() {
   useEffect(() => {
     const unsub = onEvent((e) => {
       if (e.kind !== "turn_done") return;
+      const turnTabId = activeTabIdRef.current;
       window.setTimeout(() => {
         setProjectRevision((value) => value + 1);
-        void refreshTabMetas();
+        refreshTabMetas().then((tabs) => {
+          if (!turnTabId) return;
+          if (!shouldRestoreUserPlanMode(userPlanModeByTabRef.current, turnTabId)) return;
+          const tab = tabs.find((item) => item.id === turnTabId);
+          const baseProfile = tab ? composerProfileFromTab(tab) : defaultComposerProfile;
+          setComposerProfilesByTab((current) => patchComposerProfile(
+            current,
+            turnTabId,
+            current[turnTabId] ?? baseProfile,
+            { collaborationMode: "plan", goalDraftMode: false, goal: "" },
+            ["collaborationMode", "goal"],
+          ));
+          if (activeTabIdRef.current === turnTabId) {
+            void setControllerCollaborationMode("plan");
+          }
+        });
       }, 250);
     });
     return unsub;
-  }, [refreshTabMetas]);
+  }, [refreshTabMetas, setControllerCollaborationMode]);
 
   const blankSessionTarget = useCallback(() => {
     const activeWorkspaceRoot = activeTab?.scope === "project" ? activeTab.workspaceRoot || "" : "";
@@ -3105,7 +3138,7 @@ export default function App() {
                   // Approving an exit_plan_mode plan leaves plan mode; await the
                   // mode switch before sending the approval so the controller
                   // observes the updated state before it unblocks.
-                  if (state.approval!.tool === "exit_plan_mode" && allow) await applyCollaborationMode("normal");
+                  if (state.approval!.tool === "exit_plan_mode" && allow) await applyCollaborationMode("normal", { rememberUserIntent: false });
                   approve(state.approval!.id, allow, session, persist);
                 }}
                 onRevisePlan={(text) => {

--- a/desktop/frontend/src/__tests__/composer-profile.test.ts
+++ b/desktop/frontend/src/__tests__/composer-profile.test.ts
@@ -8,7 +8,9 @@ import {
   hydrateComposerProfilesFromTabs,
   patchComposerProfile,
   pruneUserPlanModeIntents,
+  resolvePlanRestoreTabId,
   shouldRestoreUserPlanMode,
+  shouldRestoreUserPlanModeForProfile,
   updateUserPlanModeIntent,
   type ComposerProfilesByTab,
   type UserPlanModeIntents,
@@ -162,6 +164,27 @@ console.log("\ncomposer profile");
 
   eq(shouldRestoreUserPlanMode(intents, "tab-1"), false, "closed tabs lose plan restore intent");
   eq(shouldRestoreUserPlanMode(intents, "tab-2"), true, "open tabs keep plan restore intent");
+}
+
+{
+  eq(resolvePlanRestoreTabId("finished-tab", "active-tab"), "finished-tab", "turn_done plan restore uses the event tab when present");
+  eq(resolvePlanRestoreTabId(undefined, "active-tab"), "active-tab", "turn_done plan restore falls back to the active tab for legacy events");
+}
+
+{
+  let intents: UserPlanModeIntents = {};
+  intents = updateUserPlanModeIntent(intents, "tab-1", true);
+
+  eq(
+    shouldRestoreUserPlanModeForProfile(intents, "tab-1", { goal: "research task" }),
+    false,
+    "active goals block remembered plan restoration",
+  );
+  eq(
+    shouldRestoreUserPlanModeForProfile(intents, "tab-1", { goal: "" }),
+    true,
+    "empty goals still allow remembered plan restoration",
+  );
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/__tests__/composer-profile.test.ts
+++ b/desktop/frontend/src/__tests__/composer-profile.test.ts
@@ -7,7 +7,11 @@ import {
   hydrateComposerProfileFromMeta,
   hydrateComposerProfilesFromTabs,
   patchComposerProfile,
+  pruneUserPlanModeIntents,
+  shouldRestoreUserPlanMode,
+  updateUserPlanModeIntent,
   type ComposerProfilesByTab,
+  type UserPlanModeIntents,
 } from "../lib/composerProfile";
 import type { Meta, TabMeta } from "../lib/types";
 
@@ -136,6 +140,28 @@ console.log("\ncomposer profile");
   profiles = hydrateComposerProfilesFromTabs(profiles, [tab()]);
 
   eq(Boolean(profiles["tab-2"]), false, "tab hydration removes profiles for closed tabs");
+}
+
+{
+  let intents: UserPlanModeIntents = {};
+  intents = updateUserPlanModeIntent(intents, "tab-1", true);
+  intents = updateUserPlanModeIntent(intents, "tab-2", false);
+
+  eq(shouldRestoreUserPlanMode(intents, "tab-1"), true, "manual plan intent restores only the tab that enabled it");
+  eq(shouldRestoreUserPlanMode(intents, "tab-2"), false, "normal tabs do not inherit another tab's plan intent");
+
+  intents = updateUserPlanModeIntent(intents, "tab-1", false);
+  eq(shouldRestoreUserPlanMode(intents, "tab-1"), false, "manual normal mode clears plan restore intent");
+}
+
+{
+  let intents: UserPlanModeIntents = {};
+  intents = updateUserPlanModeIntent(intents, "tab-1", true);
+  intents = updateUserPlanModeIntent(intents, "tab-2", true);
+  intents = pruneUserPlanModeIntents(intents, ["tab-2"]);
+
+  eq(shouldRestoreUserPlanMode(intents, "tab-1"), false, "closed tabs lose plan restore intent");
+  eq(shouldRestoreUserPlanMode(intents, "tab-2"), true, "open tabs keep plan restore intent");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/__tests__/workspace-split.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-split.test.ts
@@ -241,5 +241,17 @@ eq(
   "workspace filter merges backend deep search results without duplicating loaded rows",
 );
 
+eq(
+  mergeWorkspaceSearchResults(
+    [{ path: "docs/assets/", entry: { name: "assets", isDir: true } }],
+    [
+      { name: "docs/assets", isDir: true },
+      { name: "docs/guides", isDir: true },
+    ],
+  ).map((row) => `${row.path}:${row.entry.name}:${row.entry.isDir}`).join("|"),
+  "docs/assets/:assets:true|docs/guides/:guides:true",
+  "workspace filter normalizes directory search results to tree row paths",
+);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/workspace-split.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-split.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../lib/workspaceSplit";
 import { resolveWorkspacePanelWidth } from "../lib/workspaceLayout";
 import { closeWorkspacePreviewTab } from "../lib/workspacePreviewTabs";
+import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
+import { mergeWorkspaceSearchResults } from "../lib/workspaceTreeSearch";
 
 let passed = 0;
 let failed = 0;
@@ -192,6 +194,51 @@ eq(
   }),
   effectiveEvenTreeWidth,
   "entering manual resize from even split keeps the currently rendered tree width",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: "src/App.tsx",
+    actualTreeVisible: true,
+    selectedIndex: 42,
+  }),
+  true,
+  "pending file reveal scrolls once the selected row is present",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: null,
+    actualTreeVisible: true,
+    selectedIndex: 42,
+  }),
+  false,
+  "manual folder changes do not re-scroll to the previous selected file",
+);
+
+eq(
+  shouldScrollWorkspaceTreeSelection({
+    selectedPath: "src/App.tsx",
+    pendingRevealPath: "src/App.tsx",
+    actualTreeVisible: true,
+    selectedIndex: -1,
+  }),
+  false,
+  "pending file reveal waits until async directory loading exposes the row",
+);
+
+eq(
+  mergeWorkspaceSearchResults(
+    [{ path: "README.md", entry: { name: "README.md", isDir: false } }],
+    [
+      { name: "src/deep/README.md", isDir: false },
+      { name: "README.md", isDir: false },
+    ],
+  ).map((row) => `${row.path}:${row.entry.name}`).join("|"),
+  "README.md:README.md|src/deep/README.md:README.md",
+  "workspace filter merges backend deep search results without duplicating loaded rows",
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -37,6 +37,8 @@ import {
 } from "../lib/workspaceSplit";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
 import { closeWorkspacePreviewTab } from "../lib/workspacePreviewTabs";
+import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
+import { mergeWorkspaceSearchResults } from "../lib/workspaceTreeSearch";
 import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView, WorkspaceChangeView } from "../lib/types";
 import { formatWorkspaceReference, WORKSPACE_REF_DRAG_TYPE } from "../lib/workspaceDrag";
 import { cleanGitDiff } from "../lib/diff";
@@ -252,6 +254,7 @@ export function WorkspacePanel({
   const [treeMenu, setTreeMenu] = useState<{ x: number; y: number; path: string; isDir: boolean } | null>(null);
   const [treeBlankMenuPoint, setTreeBlankMenuPoint] = useState<ContextMenuPoint | null>(null);
   const [filter, setFilter] = useState("");
+  const [searchResults, setSearchResults] = useState<DirEntry[] | null>(null);
   const [scopedFilePaths, setScopedFilePaths] = useState<string[] | null>(null);
   const [scopedChangeRows, setScopedChangeRows] = useState<WorkspaceChangeListEntry[] | null>(null);
   const [treeVisible, setTreeVisible] = useState(true);
@@ -274,6 +277,7 @@ export function WorkspacePanel({
   const commitDetailRequestIdRef = useRef(0);
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
+  const pendingTreeRevealPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     openDirsRef.current = openDirs;
@@ -376,6 +380,7 @@ export function WorkspacePanel({
         }));
         setTreeWidthMode("even");
       }
+      pendingTreeRevealPathRef.current = path;
       setSelectedPath(path);
       setScopedFilePaths((current) => {
         if (current) dismissedFileListRequestIdRef.current = lastFileListRequestIdRef.current;
@@ -712,6 +717,22 @@ export function WorkspacePanel({
     ? scopedChangeRows ? t("context.changedMeta", { count: scopedChangeRows.length }) : shortCwd(cwd) || t("workspace.title")
     : currentFileDir;
   const recentFiles = useMemo(() => [...openTabs].reverse(), [openTabs]);
+
+  useEffect(() => {
+    const q = filter.trim();
+    if (!open || viewMode === "changed" || !q || scopedFilePaths) {
+      setSearchResults(null);
+      return;
+    }
+    let cancelled = false;
+    app.SearchFileRefs(q).then((results) => {
+      if (!cancelled) setSearchResults(results);
+    }).catch(() => {
+      if (!cancelled) setSearchResults(null);
+    });
+    return () => { cancelled = true; };
+  }, [filter, viewMode, scopedFilePaths, open]);
+
   const flattened = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (scopedFilePaths) {
@@ -727,10 +748,10 @@ export function WorkspacePanel({
       }
     }
     if (!q) return null;
-    return rows
+    return mergeWorkspaceSearchResults(rows, searchResults)
       .filter((row) => row.path.toLowerCase().includes(q))
       .sort((a, b) => a.path.localeCompare(b.path));
-  }, [entriesByDir, filter, scopedFilePaths]);
+  }, [entriesByDir, filter, scopedFilePaths, searchResults]);
 
   const treeRows = useMemo<TreeRow[]>(() => {
     if (flattened) {
@@ -812,11 +833,16 @@ export function WorkspacePanel({
   );
 
   useEffect(() => {
-    if (!selectedPath || !actualTreeVisible) return;
-    const selectedIndex = treeRows.findIndex((row) => row.path === selectedPath);
-    if (selectedIndex !== -1) {
-      virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
+    const pendingRevealPath = pendingTreeRevealPathRef.current;
+    if (!pendingRevealPath) return;
+    if (!selectedPath || pendingRevealPath !== selectedPath) {
+      pendingTreeRevealPathRef.current = null;
+      return;
     }
+    const selectedIndex = treeRows.findIndex((row) => row.path === selectedPath);
+    if (!shouldScrollWorkspaceTreeSelection({ selectedPath, pendingRevealPath, actualTreeVisible, selectedIndex })) return;
+    virtualizer.scrollToIndex(selectedIndex, { align: "auto" });
+    pendingTreeRevealPathRef.current = null;
   }, [selectedPath, actualTreeVisible, treeRows, virtualizer]);
 
   const panelStyle = useMemo(

--- a/desktop/frontend/src/lib/composerProfile.ts
+++ b/desktop/frontend/src/lib/composerProfile.ts
@@ -236,3 +236,15 @@ export function pruneUserPlanModeIntents(current: UserPlanModeIntents, tabIds: I
 export function shouldRestoreUserPlanMode(current: UserPlanModeIntents, tabId: string | null | undefined): boolean {
   return Boolean(tabId && current[tabId]);
 }
+
+export function resolvePlanRestoreTabId(eventTabId: string | null | undefined, activeTabId: string | null | undefined): string | null {
+  return eventTabId || activeTabId || null;
+}
+
+export function shouldRestoreUserPlanModeForProfile(
+  current: UserPlanModeIntents,
+  tabId: string | null | undefined,
+  profile?: Pick<ComposerProfile, "goal"> | null,
+): boolean {
+  return shouldRestoreUserPlanMode(current, tabId) && !profile?.goal.trim();
+}

--- a/desktop/frontend/src/lib/composerProfile.ts
+++ b/desktop/frontend/src/lib/composerProfile.ts
@@ -29,6 +29,7 @@ export interface ComposerProfile {
 }
 
 export type ComposerProfilesByTab = Record<string, ComposerProfile>;
+export type UserPlanModeIntents = Record<string, true>;
 
 const profileFields: ComposerProfileField[] = ["collaborationMode", "toolApprovalMode", "tokenMode", "goal"];
 
@@ -201,4 +202,37 @@ export function composerProfileWithMode(mode: Mode): Partial<Omit<ComposerProfil
     toolApprovalMode: modeHasAutoApproveTools(mode) ? "yolo" : "ask",
     goal: "",
   };
+}
+
+export function updateUserPlanModeIntent(
+  current: UserPlanModeIntents,
+  tabId: string | null | undefined,
+  enabled: boolean,
+): UserPlanModeIntents {
+  if (!tabId) return current;
+  if (enabled) {
+    return current[tabId] ? current : { ...current, [tabId]: true };
+  }
+  if (!current[tabId]) return current;
+  const next = { ...current };
+  delete next[tabId];
+  return next;
+}
+
+export function pruneUserPlanModeIntents(current: UserPlanModeIntents, tabIds: Iterable<string>): UserPlanModeIntents {
+  const live = new Set(tabIds);
+  let changed = false;
+  const next: UserPlanModeIntents = {};
+  for (const tabId of Object.keys(current)) {
+    if (live.has(tabId)) {
+      next[tabId] = true;
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : current;
+}
+
+export function shouldRestoreUserPlanMode(current: UserPlanModeIntents, tabId: string | null | undefined): boolean {
+  return Boolean(tabId && current[tabId]);
 }

--- a/desktop/frontend/src/lib/workspaceTreeReveal.ts
+++ b/desktop/frontend/src/lib/workspaceTreeReveal.ts
@@ -1,0 +1,18 @@
+export function shouldScrollWorkspaceTreeSelection({
+  selectedPath,
+  pendingRevealPath,
+  actualTreeVisible,
+  selectedIndex,
+}: {
+  selectedPath: string | null;
+  pendingRevealPath: string | null;
+  actualTreeVisible: boolean;
+  selectedIndex: number;
+}): boolean {
+  return Boolean(
+    selectedPath &&
+      pendingRevealPath === selectedPath &&
+      actualTreeVisible &&
+      selectedIndex >= 0,
+  );
+}

--- a/desktop/frontend/src/lib/workspaceTreeSearch.ts
+++ b/desktop/frontend/src/lib/workspaceTreeSearch.ts
@@ -10,14 +10,21 @@ function basename(path: string): string {
   return parts[parts.length - 1] || path;
 }
 
+function treeSearchPath(entry: DirEntry): string {
+  const path = entry.name.replace(/\\/g, "/");
+  if (!entry.isDir || path.endsWith("/")) return path;
+  return path + "/";
+}
+
 export function mergeWorkspaceSearchResults(rows: WorkspaceSearchRow[], results: DirEntry[] | null): WorkspaceSearchRow[] {
   if (!results || results.length === 0) return rows;
   const merged = [...rows];
   const seen = new Set(rows.map((row) => row.path));
   for (const result of results) {
-    if (seen.has(result.name)) continue;
-    merged.push({ path: result.name, entry: { name: basename(result.name), isDir: result.isDir } });
-    seen.add(result.name);
+    const path = treeSearchPath(result);
+    if (seen.has(path)) continue;
+    merged.push({ path, entry: { name: basename(path), isDir: result.isDir } });
+    seen.add(path);
   }
   return merged;
 }

--- a/desktop/frontend/src/lib/workspaceTreeSearch.ts
+++ b/desktop/frontend/src/lib/workspaceTreeSearch.ts
@@ -1,0 +1,23 @@
+import type { DirEntry } from "./types";
+
+export interface WorkspaceSearchRow {
+  path: string;
+  entry: DirEntry;
+}
+
+function basename(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] || path;
+}
+
+export function mergeWorkspaceSearchResults(rows: WorkspaceSearchRow[], results: DirEntry[] | null): WorkspaceSearchRow[] {
+  if (!results || results.length === 0) return rows;
+  const merged = [...rows];
+  const seen = new Set(rows.map((row) => row.path));
+  for (const result of results) {
+    if (seen.has(result.name)) continue;
+    merged.push({ path: result.name, entry: { name: basename(result.name), isDir: result.isDir } });
+    seen.add(result.name);
+  }
+  return merged;
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -759,7 +759,7 @@ func RenderTOMLProjectDelta(c *Config) string {
 	}
 
 	// [tools]
-	if !reflect.DeepEqual(c.Tools, d.Tools) {
+	if len(c.Tools.Enabled) > 0 || (c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0) {
 		b.WriteString("[tools]\n")
 		if len(c.Tools.Enabled) > 0 {
 			fmt.Fprintf(&b, "enabled = %s\n", renderStringArray(c.Tools.Enabled))
@@ -777,6 +777,18 @@ func RenderTOMLProjectDelta(c *Config) string {
 			fmt.Fprintf(&b, "stalled_warning_seconds = %d\n", *c.Tools.BackgroundJobs.StalledWarningSeconds)
 			b.WriteString("\n")
 		}
+	}
+
+	// [tools.shell]
+	if !reflect.DeepEqual(c.Tools.Shell, d.Tools.Shell) {
+		b.WriteString("[tools.shell]\n")
+		if c.Tools.Shell.Prefer != d.Tools.Shell.Prefer {
+			fmt.Fprintf(&b, "prefer = %q\n", c.Tools.Shell.Prefer)
+		}
+		if c.Tools.Shell.Path != d.Tools.Shell.Path {
+			fmt.Fprintf(&b, "path = %q\n", c.Tools.Shell.Path)
+		}
+		b.WriteString("\n")
 	}
 
 	// [lsp]

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -333,6 +333,18 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	b.WriteString("[tools.background_jobs]\n")
 	fmt.Fprintf(&b, "stalled_warning_seconds = %d   # warn once per background job after this many quiet seconds; 0 disables\n\n", c.BackgroundJobStalledWarningSeconds())
 
+	b.WriteString("[tools.shell]\n")
+	if c.Tools.Shell.Prefer != "" {
+		fmt.Fprintf(&b, "prefer = %q   # auto|bash|powershell|pwsh; empty/default = auto-detect\n", c.Tools.Shell.Prefer)
+	} else {
+		b.WriteString("# prefer = \"auto\"   # auto|bash|powershell|pwsh; empty/default = auto-detect\n")
+	}
+	if c.Tools.Shell.Path != "" {
+		fmt.Fprintf(&b, "path   = %q   # absolute path to the shell executable; empty = PATH lookup\n\n", c.Tools.Shell.Path)
+	} else {
+		b.WriteString("# path   = \"/opt/homebrew/bin/bash\"   # absolute path to the shell executable; empty = PATH lookup\n\n")
+	}
+
 	renderLSPConfig(&b, c.LSP)
 
 	b.WriteString("[skills]\n")

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -538,6 +538,30 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	}
 }
 
+func TestProjectDeltaRendersToolsShellOverrides(t *testing.T) {
+	c := Default()
+	c.Tools.Shell.Prefer = "bash"
+	c.Tools.Shell.Path = "/usr/local/bin/bash"
+
+	delta := RenderTOMLProjectDelta(c)
+	for _, want := range []string{"[tools.shell]", `prefer = "bash"`, `path = "/usr/local/bin/bash"`} {
+		if !strings.Contains(delta, want) {
+			t.Fatalf("project delta missing %q:\n%s", want, delta)
+		}
+	}
+	if strings.Contains(delta, "[tools]\n\n") {
+		t.Fatalf("project delta should not emit an empty [tools] block:\n%s", delta)
+	}
+
+	got := Default()
+	if _, err := toml.Decode(delta, got); err != nil {
+		t.Fatalf("decode project delta: %v\n%s", err, delta)
+	}
+	if got.Tools.Shell.Prefer != "bash" || got.Tools.Shell.Path != "/usr/local/bin/bash" {
+		t.Fatalf("tools.shell = %+v, want bash with path", got.Tools.Shell)
+	}
+}
+
 func TestProjectRenderPreservesNonDefaultLegacySections(t *testing.T) {
 	c := Default()
 	c.UI.Theme = "light"

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -122,6 +122,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Agent.RecentKeep = 4
 	orig.Tools.BashTimeoutSeconds = intPtr(900)
 	orig.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(30)
+	orig.Tools.Shell.Prefer = "bash"
+	orig.Tools.Shell.Path = "/usr/local/bin/bash"
 	orig.Permissions = PermissionsConfig{
 		Mode:  "deny",
 		Deny:  []string{"Bash(rm -rf*)"},
@@ -312,6 +314,12 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Tools.BackgroundJobs.StalledWarningSeconds == nil || *got.Tools.BackgroundJobs.StalledWarningSeconds != 30 {
 		t.Errorf("tools.background_jobs.stalled_warning_seconds = %v, want 30", got.Tools.BackgroundJobs.StalledWarningSeconds)
+	}
+	if got.Tools.Shell.Prefer != "bash" {
+		t.Errorf("tools.shell.prefer = %q, want bash", got.Tools.Shell.Prefer)
+	}
+	if got.Tools.Shell.Path != "/usr/local/bin/bash" {
+		t.Errorf("tools.shell.path = %q, want /usr/local/bin/bash", got.Tools.Shell.Path)
 	}
 	if g, _ := got.Provider("mimo-pro"); g == nil || g.BaseURL != "http://localhost:8000/v1" || g.ReasoningProtocol != "openai" {
 		t.Errorf("mimo-pro base_url not preserved: %+v", g)
@@ -510,7 +518,7 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c.Desktop.CheckUpdates = boolPtr(false)
 
 	user := RenderTOMLForScope(c, RenderScopeUser)
-	for _, want := range []string{"config_version = 3", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `check_updates = false`, "[notifications]"} {
+	for _, want := range []string{"config_version = 3", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `check_updates = false`, "[notifications]", "[tools.shell]"} {
 		if !strings.Contains(user, want) {
 			t.Fatalf("user render missing %q:\n%s", want, user)
 		}


### PR DESCRIPTION
## Summary

This integration PR combines the useful pieces from #5219 and #5220 on top of the latest `main-v2`.

What is included:
- Keep workspace tree reveal scrolling tied to explicit file selection, so expanding folders no longer snaps back to the previously selected file.
- Let the Workspace panel filter include backend `SearchFileRefs` results, so deeply nested files can appear even before their parent directories are loaded in the visible tree.
- Preserve manually selected plan mode after an approved plan turn completes, with the integration refinement that the restore intent is scoped per tab and does not leak across sessions.
- Render `[tools.shell]` in generated TOML so shell `prefer` and `path` settings survive settings save/reload round trips.

## Contribution sources

- #5219 by @lifu963 contributed the one-shot workspace tree reveal model and regression coverage for pending reveal, manual folder browsing, and async directory loading.
- #5220 by @yzz521 contributed the plan-mode persistence idea, Workspace panel deep file search, and `[tools.shell]` config rendering/persistence fix.
- This integration adds maintainer-side glue and safeguards: per-tab plan restore intent, no cross-tab controller restore after delayed `turn_done`, search-result de-duplication helper tests, and combined verification on the latest `main-v2`.

Authorship note: @lifu963 and @yzz521 are credited as co-authors in the integration commit and as co-contributors for the PRs integrated here.

## Verification

- `wails generate module` passed
- `pnpm typecheck` passed
- `pnpm test` passed
- `go test ./internal/config` passed
- `git diff --check` passed

Cache-impact: none. This changes Desktop UI state handling, Workspace panel filtering, and config TOML rendering only. It does not change system prompts, tool schemas, provider request serialization, compaction, or memory injection.
Cache-guard: `pnpm test`, `pnpm typecheck`, `go test ./internal/config`.
System-prompt-review: none.
