### PR TITLE
fix(desktop): copy button scroll, small-window layout, settings modal…

### DIFF
--- a/desktop/frontend/src/components/editors/HljsCode.tsx
+++ b/desktop/frontend/src/components/editors/HljsCode.tsx
@@ -10,10 +10,12 @@ import { CopyButton } from "../CopyButton";
 const HljsCode = memo(function HljsCode({ value, language, maxHeight }: EditorProps) {
   const html = useMemo(() => highlightToHtml(value, language), [value, language]);
   return (
-    <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
-      <code dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="code-block__wrap">
+      <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
+        <code dangerouslySetInnerHTML={{ __html: html }} />
+      </pre>
       <CopyButton text={value} className="code-block__copy" />
-    </pre>
+    </div>
   );
 });
 

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -322,6 +322,14 @@ export interface AppBindings {
   TrashTopic(topicID: string): Promise<void>;
   SetTopicPinned(topicID: string, pinned: boolean): Promise<void>;
   ContextPanel(tabID: string): Promise<ContextPanelInfo>;
+  // ── Terminal ──
+  OpenTerminal(): Promise<void>;
+  OpenTerminalAt(rel: string): Promise<void>;
+  StartTerminal(): Promise<string>;
+  StartTerminalAt(rel: string): Promise<string>;
+  StopTerminal(sessionID: string): Promise<void>;
+  TerminalInput(sessionID: string, data: string): Promise<void>;
+  TerminalResize(sessionID: string, cols: number, rows: number): Promise<void>;
   // New native-feel bindings (added with the desktop native-feel plan).
   ConfirmAction(req: NativeConfirmRequest): Promise<boolean>;
   SaveWindowState(state: DesktopWindowState): Promise<void>;
@@ -3054,5 +3062,13 @@ function makeMockApp(): AppBindings {
         ],
       };
     },
+    // ── Terminal (mock) ──
+    async OpenTerminal() {},
+    async OpenTerminalAt(_rel: string) {},
+    async StartTerminal() { return "term-mock-0"; },
+    async StartTerminalAt(_rel: string) { return "term-mock-0"; },
+    async StopTerminal(_sessionID: string) {},
+    async TerminalInput(_sessionID: string, _data: string) {},
+    async TerminalResize(_sessionID: string, _cols: number, _rows: number) {},
   };
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4410,7 +4410,7 @@ a[href] {
   transition: opacity 0.12s;
 }
 .code-block__copy:hover,
-.code:hover .code-block__copy {
+.code-block__wrap:hover .code-block__copy {
   opacity: 1;
 }
 .code-block__wrap {
@@ -10852,6 +10852,9 @@ a[href] {
 
 .settings-modal {
   width: min(1360px, calc(100vw - 96px));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
 }
 
 /* ── settings centre layout ─────────────────────────────────────────────────── */
@@ -12131,6 +12134,8 @@ a[href] {
     width: 100vw;
     height: 100vh;
     border-radius: 0;
+    border: none;
+    box-shadow: none;
   }
 
   .settings-center__content {
@@ -15261,6 +15266,7 @@ a[href] {
 @media (max-width: 820px) {
   .layout {
     grid-template-columns: minmax(0, 1fr);
+    justify-content: stretch;
   }
   .sidebar {
     display: none;
@@ -15270,6 +15276,13 @@ a[href] {
   }
   .layout {
     --chrome-left-toggle-offset: var(--chrome-left-safe-offset);
+  }
+  .layout--workspace-open {
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .layout--workspace-open.layout--sidebar-collapsed {
+    min-width: 0;
   }
   .app--darwin .layout {
     --chrome-left-toggle-offset: 94px;


### PR DESCRIPTION
… border

- #5096: move CopyButton outside scrollable <pre> into .code-block__wrap so it stays pinned to the visible top-right corner
- #5100: at 820px breakpoint add justify-content:stretch and collapse workspace-open to single column with min-width:0
- #5095: add explicit border/box-shadow/border-radius to .settings-modal, clear them at 760px fullscreen breakpoint
- bridge.ts: add missing terminal method signatures to AppBindings and mock

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
