### PR TITLE
左侧边栏双击对话名称可重命名

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   defaultExpandedProjectTreeKeys,
   activeSessionAncestorKeys,
   projectTreeTopicOpenRequest,
+  projectTreeShouldSuppressOpenForRename,
 } from "../components/ProjectTree";
 import type { ProjectNode } from "../lib/types";
 
@@ -101,6 +102,33 @@ eq(
   }),
   { scope: "project", workspaceRoot: "/repo", topicId: "topic-project", sessionPath: undefined },
   "regular project topic still opens by topic",
+);
+
+eq(
+  projectTreeShouldSuppressOpenForRename(
+    { rowKey: "topic-a", canRename: true },
+    { rowKey: "topic-a", canRename: true },
+  ),
+  true,
+  "second click on the same renameable topic suppresses open for inline rename",
+);
+
+eq(
+  projectTreeShouldSuppressOpenForRename(
+    { rowKey: "session-a", canRename: false },
+    { rowKey: "session-a", canRename: false },
+  ),
+  false,
+  "runtime session double-click still allows the session row to open",
+);
+
+eq(
+  projectTreeShouldSuppressOpenForRename(
+    { rowKey: "topic-a", canRename: true },
+    { rowKey: "topic-b", canRename: true },
+  ),
+  false,
+  "quickly clicking a different topic still opens the new target",
 );
 
 eq(

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -488,6 +488,7 @@ export function ProjectTree({
   const visibleTopicsCollectorRef = useRef<TopicShortcutEntry[]>([]);
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const manuallyCollapsedRef = useRef(manuallyCollapsed);
 
   const closeMenu = useCallback(() => {
@@ -1079,9 +1080,16 @@ export function ProjectTree({
             className="project-tree__topic-main"
             title={title}
             style={{ paddingLeft: 14 + depth * 16 }}
-            onClick={(event) => {
-              if (creationTopics && event.detail > 1) return;
-              if (openRequest) onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
+            onClick={() => {
+              if (clickTimerRef.current !== null) {
+                clearTimeout(clickTimerRef.current);
+                clickTimerRef.current = null;
+                return;
+              }
+              clickTimerRef.current = setTimeout(() => {
+                clickTimerRef.current = null;
+                if (openRequest) onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
+              }, 200);
             }}
             onKeyDown={(event) => {
               if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
@@ -1091,6 +1099,10 @@ export function ProjectTree({
             onDoubleClick={(event) => {
               if (isSessionNode) return;
               event.stopPropagation();
+              if (clickTimerRef.current !== null) {
+                clearTimeout(clickTimerRef.current);
+                clickTimerRef.current = null;
+              }
               startRenameTopic(node, label);
             }}
           >

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1086,6 +1086,11 @@ export function ProjectTree({
                 openTopicMenu(event);
               }
             }}
+            onDoubleClick={(event) => {
+              if (isSessionNode) return;
+              event.stopPropagation();
+              startRenameTopic(node, label);
+            }}
           >
             <span className="project-tree__topic-copy">
               <span className="project-tree__topic-heading">

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -489,6 +489,11 @@ export function ProjectTree({
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current);
+    };
+  }, []);
   const manuallyCollapsedRef = useRef(manuallyCollapsed);
 
   const closeMenu = useCallback(() => {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1039,7 +1039,7 @@ export function ProjectTree({
         return (
           <div
             key={key}
-            className={`project-tree__topic project-tree__topic--editing${active ? " project-tree__topic--active" : ""}${imSource ? " project-tree__topic--im-source" : ""}`}
+            className={`project-tree__topic project-tree__topic--editing${active ? " project-tree__topic--active" : ""}${imSource ? " project-tree__topic--im-source" : ""}${meta ? " project-tree__topic--has-meta" : ""}`}
             style={{ paddingLeft: 14 + depth * 16 }}
           >
             <input
@@ -1079,7 +1079,8 @@ export function ProjectTree({
             className="project-tree__topic-main"
             title={title}
             style={{ paddingLeft: 14 + depth * 16 }}
-            onClick={() => {
+            onClick={(event) => {
+              if (creationTopics && event.detail > 1) return;
               if (openRequest) onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
             }}
             onKeyDown={(event) => {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1047,6 +1047,7 @@ export function ProjectTree({
               className="project-tree__topic-input"
               value={topicDraft}
               onChange={(event) => setTopicDraft(event.target.value)}
+              onFocus={(event) => event.target.select()}
               onKeyDown={(event) => {
                 if (event.key === "Enter") void commitRenameTopic(topicId);
                 if (event.key === "Escape") setEditingTopic(null);

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -77,6 +77,22 @@ export function projectTreeTopicOpenRequest(node: ProjectNode): ProjectTreeTopic
   };
 }
 
+type ProjectTreeTopicClickTarget = {
+  rowKey: string;
+  canRename: boolean;
+};
+
+type ProjectTreePendingTopicOpen = ProjectTreeTopicClickTarget & {
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export function projectTreeShouldSuppressOpenForRename(
+  pending: ProjectTreeTopicClickTarget | null,
+  next: ProjectTreeTopicClickTarget,
+): boolean {
+  return Boolean(pending && pending.rowKey === next.rowKey && pending.canRename && next.canRename);
+}
+
 export type ProjectTreeFolderDisclosure = {
   canExpand: boolean;
   isOpen: boolean;
@@ -488,10 +504,10 @@ export function ProjectTree({
   const visibleTopicsCollectorRef = useRef<TopicShortcutEntry[]>([]);
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clickTimerRef = useRef<ProjectTreePendingTopicOpen | null>(null);
   useEffect(() => {
     return () => {
-      if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current);
+      if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current.timer);
     };
   }, []);
   const manuallyCollapsedRef = useRef(manuallyCollapsed);
@@ -1086,15 +1102,19 @@ export function ProjectTree({
             title={title}
             style={{ paddingLeft: 14 + depth * 16 }}
             onClick={() => {
-              if (clickTimerRef.current !== null) {
-                clearTimeout(clickTimerRef.current);
+              if (!openRequest) return;
+              const nextClick = { rowKey: key, canRename: !isSessionNode };
+              const pending = clickTimerRef.current;
+              if (pending !== null) {
+                clearTimeout(pending.timer);
                 clickTimerRef.current = null;
-                return;
+                if (projectTreeShouldSuppressOpenForRename(pending, nextClick)) return;
               }
-              clickTimerRef.current = setTimeout(() => {
-                clickTimerRef.current = null;
-                if (openRequest) onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
+              const timer = setTimeout(() => {
+                if (clickTimerRef.current?.timer === timer) clickTimerRef.current = null;
+                onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
               }, 200);
+              clickTimerRef.current = { ...nextClick, timer };
             }}
             onKeyDown={(event) => {
               if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
@@ -1104,8 +1124,8 @@ export function ProjectTree({
             onDoubleClick={(event) => {
               if (isSessionNode) return;
               event.stopPropagation();
-              if (clickTimerRef.current !== null) {
-                clearTimeout(clickTimerRef.current);
+              if (clickTimerRef.current !== null && clickTimerRef.current.rowKey === key) {
+                clearTimeout(clickTimerRef.current.timer);
                 clickTimerRef.current = null;
               }
               startRenameTopic(node, label);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17953,7 +17953,7 @@ a[href] {
   --wails-draggable: no-drag;
   flex: 1 1 auto;
   min-width: 0;
-  height: 26px;
+  align-self: stretch;
   border: 1px solid var(--accent-soft);
   border-radius: 7px;
   background: var(--bg-elev);


### PR DESCRIPTION
## 功能描述

在左侧边栏（ProjectTree）中实现双击对话名称进入内联重命名模式。

### 改动内容

- **双击触发**：在 topic 行主按钮上添加 ，调用已有  逻辑
- **输入框样式**： → ，白框撑满整行高，消除与蓝灰选中背景的重叠缝隙
- **自动全选**：，双击后整个文本进入选中状态，可直接打字替换
- **行高保持**：编辑态 div 补齐  类名，经典模式下不会因进入编辑而改变行高
- **双击不跳转**：用  延迟 200ms 执行 ，双击时第一下点击也不触发导航/滚动到顶部
- **卸载清理**：组件卸载时  清理残留定时器

### 覆盖模式

- ✅ 经典模式
- ✅ 工作台模式
- ✅ 创作模式（双击不改位置）

Closes: #N/A

<img width="706" height="936" alt="image" src="https://github.com/user-attachments/assets/b171ca54-b941-4ac8-a15e-f0895732c366" />
<img width="764" height="722" alt="image" src="https://github.com/user-attachments/assets/b9f76654-0134-42c7-baa0-bbe3e4204eda" />
<img width="792" height="832" alt="image" src="https://github.com/user-attachments/assets/46e1aa9c-06fa-43b9-9400-787d8352b8e7" />

