### PR TITLE
Improve opaque script error reporting / 改进不透明脚本错误上报

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -4,6 +4,7 @@ import {
   buildCrashPayload,
   buildPerformancePayload,
   formatPerformanceContext,
+  globalCrashReportReason,
   normalizeCrashError,
   parseReportedPerf,
   performanceLabelForReason,
@@ -79,6 +80,25 @@ eq(
   }),
   false,
   "checks ErrorEvent.error when ErrorEvent.message is a wrapper",
+);
+eq(
+  globalCrashReportReason({
+    defaultPrevented: false,
+    message: "Script error.",
+    filename: "wails://wails/assets/index-abc123.js",
+    lineno: 42,
+    colno: 7,
+  }),
+  "Script error.\nfilename=wails://wails/assets/index-abc123.js lineno=42 colno=7",
+  "adds script location to opaque window.error messages",
+);
+eq(
+  globalCrashReportReason({
+    defaultPrevented: false,
+    message: "Script error.",
+  }),
+  "Script error.",
+  "keeps opaque script errors bare when WebView provides no location",
 );
 
 const perf: PerformanceSnapshot = {

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -535,10 +535,14 @@ export function reportCrash(label: string, err: unknown, extra?: string) {
 type GlobalCrashEventLike = Pick<Event, "defaultPrevented"> & {
   message?: unknown;
   error?: unknown;
+  filename?: unknown;
+  lineno?: unknown;
+  colno?: unknown;
 };
 
 const RESIZE_OBSERVER_LOOP_MESSAGE_RE =
   /^ResizeObserver loop (?:limit exceeded|completed with undelivered notifications\.?)$/;
+const OPAQUE_SCRIPT_ERROR_MESSAGE = "Script error.";
 
 function globalCrashEventMessages(e: GlobalCrashEventLike): string[] {
   const messages: string[] = [];
@@ -560,6 +564,24 @@ export function shouldReportGlobalCrashEvent(e: GlobalCrashEventLike): boolean {
   if (e.defaultPrevented) return false;
   if (globalCrashEventMessages(e).some((message) => RESIZE_OBSERVER_LOOP_MESSAGE_RE.test(message))) return false;
   return true;
+}
+
+function globalScriptErrorLocation(e: GlobalCrashEventLike): string {
+  const parts: string[] = [];
+  if (typeof e.filename === "string" && e.filename.trim()) parts.push(`filename=${e.filename.trim()}`);
+  if (typeof e.lineno === "number" && Number.isFinite(e.lineno) && e.lineno > 0) parts.push(`lineno=${e.lineno}`);
+  if (typeof e.colno === "number" && Number.isFinite(e.colno) && e.colno > 0) parts.push(`colno=${e.colno}`);
+  return parts.join(" ");
+}
+
+export function globalCrashReportReason(e: GlobalCrashEventLike): unknown {
+  if (e.error !== undefined && e.error !== null) return e.error;
+  const message = typeof e.message === "string" ? e.message.trim() : e.message;
+  if (message === OPAQUE_SCRIPT_ERROR_MESSAGE) {
+    const location = globalScriptErrorLocation(e);
+    if (location) return `${OPAQUE_SCRIPT_ERROR_MESSAGE}\n${location}`;
+  }
+  return e.message;
 }
 
 export function shouldPromptForPerformanceLabel(
@@ -664,7 +686,7 @@ export function installPerformancePressureMonitor() {
 
 export function installGlobalCrashHandlers() {
   window.addEventListener("error", (e) => {
-    if (shouldReportGlobalCrashEvent(e)) reportCrash("window.error", e.error ?? e.message);
+    if (shouldReportGlobalCrashEvent(e)) reportCrash("window.error", globalCrashReportReason(e));
   });
   window.addEventListener("unhandledrejection", (e) => {
     if (shouldReportGlobalCrashEvent(e)) reportCrash("unhandledrejection", e.reason);

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -245,12 +245,37 @@ export function crashTitle(message: string): string {
   return head.slice(0, 200);
 }
 
+type SeverityInput = {
+  kind: string;
+  source: string;
+  label: string;
+  errorType: string;
+  errorMessage: string;
+  topFrame: string;
+};
+
+export function isOpaqueScriptErrorReport(input: SeverityInput): boolean {
+  return (
+    input.kind === "crash" &&
+    input.source === "frontend.global" &&
+    input.label === "window.error" &&
+    input.errorType === "string" &&
+    input.errorMessage.trim() === "Script error." &&
+    input.topFrame.trim() === ""
+  );
+}
+
 function severityForKind(kind: string): string {
   if (kind === "crash") return "high";
   if (kind === "performance") return "medium";
   if (kind === "bot") return "medium";
   if (kind === "exception") return "medium";
   return "low";
+}
+
+export function severityForReport(input: SeverityInput): string {
+  if (isOpaqueScriptErrorReport(input)) return "low";
+  return severityForKind(input.kind);
 }
 
 async function sha256Hex(s: string): Promise<string> {
@@ -308,7 +333,7 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   const errorType = r.errorType ?? "";
   const buildCommit = r.buildCommit ?? "";
   const channel = r.channel ?? "";
-  const severity = severityForKind(r.kind);
+  const severity = severityForReport({ kind: r.kind, source, label, errorType, errorMessage, topFrame });
   const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
     .bind(fingerprint)
     .first<{ status: string }>();
@@ -330,6 +355,16 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
        label = ?7,
        error_type = ?8,
        top_frame = ?9,
+       severity = CASE
+         WHEN ?10 = 'low'
+           AND ?2 = 'crash'
+           AND ?6 = 'frontend.global'
+           AND ?7 = 'window.error'
+           AND ?8 = 'string'
+           AND ?9 = ''
+         THEN ?10
+         ELSE severity
+       END,
        last_os = ?11,
        last_arch = ?12,
        last_build_commit = ?13,

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -355,16 +355,6 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
        label = ?7,
        error_type = ?8,
        top_frame = ?9,
-       severity = CASE
-         WHEN ?10 = 'low'
-           AND ?2 = 'crash'
-           AND ?6 = 'frontend.global'
-           AND ?7 = 'window.error'
-           AND ?8 = 'string'
-           AND ?9 = ''
-         THEN ?10
-         ELSE severity
-       END,
        last_os = ?11,
        last_arch = ?12,
        last_build_commit = ?13,


### PR DESCRIPTION
## Summary

- Include `filename`, `lineno`, and `colno` when WebView reports an opaque `window.error` as `Script error.` without an `Error` object.
- Lower crash dashboard severity for legacy bare `frontend.global` / `window.error` / `Script error.` groups that still have no location data.
- Keep located opaque script errors classified as high severity so newly actionable reports remain visible.

## Verification

- `npx tsx src/__tests__/crash-reporting.test.ts`
- `npm run typecheck` in `desktop/frontend`
- `npm run test:typecheck` in `desktop/frontend`
- `npm run typecheck` in `workers/crash-report`
- Verified worker severity classification: bare `Script error.` => `low`; located `Script error.` => `high`

## Cache impact

Cache-impact: none — crash reporting and dashboard ingestion only; no provider request, prompt prefix, tool schema, memory prefix, compaction, or model-facing behavior changes.
Cache-guard: not run — this change is outside cache-sensitive request construction and prefix surfaces.
System-prompt-review: N/A