### PR TITLE
fix: resolve session trash bugs (#5215)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1672,10 +1672,11 @@ type removedSessionRuntime struct {
 }
 
 type fallbackRuntimeTarget struct {
-	needs         bool
-	scope         string
-	workspaceRoot string
-	topicID       string
+	needs             bool
+	scope             string
+	workspaceRoot     string
+	topicID           string
+	skipTopicCreation bool // when true (e.g. after TrashTopic), don't auto-create a new topic
 }
 
 func (a *App) removeSessionRuntimeBindings(dir, sessionPath string) ([]removedSessionRuntime, fallbackRuntimeTarget) {
@@ -1731,7 +1732,7 @@ func (a *App) removeTopicRuntimeBindings(topicID string) ([]removedSessionRuntim
 		sessionDir := tabSessionDir(tab)
 		sessionPath := canonicalTabSessionPath(tab.currentSessionPath())
 		if len(removed) == 0 {
-			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot}
+			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot, skipTopicCreation: true}
 		}
 		removed = append(removed, removedRuntimeFromTab(tab, sessionDir, sessionPath))
 		delete(a.tabs, id)
@@ -1747,7 +1748,7 @@ func (a *App) removeTopicRuntimeBindings(topicID string) ([]removedSessionRuntim
 		sessionDir := tabSessionDir(tab)
 		sessionPath := canonicalTabSessionPath(tab.currentSessionPath())
 		if len(removed) == 0 {
-			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot}
+			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot, skipTopicCreation: true}
 		}
 		removed = append(removed, removedRuntimeFromTab(tab, sessionDir, sessionPath))
 		delete(a.detachedSessions, key)
@@ -1939,7 +1940,7 @@ func (a *App) openFallbackRuntime(target fallbackRuntimeTarget) error {
 	if scope == "global" {
 		root = ""
 	}
-	if topicID == "" {
+	if topicID == "" && !target.skipTopicCreation {
 		topic, err := a.CreateTopic(scope, root, "")
 		if err != nil {
 			return err

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -210,6 +210,15 @@ func validateSessionTrashTarget(dir, sessionPath, key string) error {
 	}
 	itemDir := filepath.Join(sessionTrashPath(dir), key)
 	if _, err := os.Stat(itemDir); err == nil {
+		// The trash directory already exists. If the corresponding session
+		// file is still pending cleanup from a previous delete (teardown
+		// timed out → delayed trash), allow the operation to proceed by
+		// removing the stale trash entry so the new delete can recreate
+		// it. (#5215)
+		if agent.IsCleanupPending(sessionPath) {
+			_ = os.RemoveAll(itemDir)
+			return nil
+		}
 		return fmt.Errorf("session already exists in trash: %s", key)
 	} else if !os.IsNotExist(err) {
 		return err

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1047,6 +1047,18 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	tabID := a.newUniqueTabIDLocked()
 	topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
+	// Pre-create an empty session file when sessionPath is empty so the tab
+	// is immediately deletable even before the async controller build finishes
+	// (fixes #5215 — newly created blank sessions were not deletable until
+	// buildTabControllerWithContext completed).
+	if sessionPath == "" {
+		sessionDir := desktopSessionDir(actualRoot)
+		prePath := agent.NewSessionPath(sessionDir, "")
+		if f, err := os.OpenFile(prePath, os.O_RDONLY|os.O_CREATE, 0o644); err == nil {
+			f.Close()
+		}
+		sessionPath = prePath
+	}
 	tab := &WorkspaceTab{
 		ID:               tabID,
 		Scope:            scope,
@@ -1255,6 +1267,14 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		a.tabs[tabID] = created
 		a.tabOrder = append(a.tabOrder, tabID)
 		a.activeTabID = tabID
+		// Pre-create an empty session file so the tab is immediately
+		// deletable even before the async controller build finishes (#5215).
+		preDir := desktopSessionDir(actualRoot)
+		prePath := agent.NewSessionPath(preDir, inheritedModel)
+		if f, err := os.OpenFile(prePath, os.O_RDONLY|os.O_CREATE, 0o644); err == nil {
+			f.Close()
+		}
+		created.SessionPath = prePath
 		a.saveTabsLocked()
 		meta := a.tabMeta(created, true)
 		a.mu.Unlock()
@@ -1303,6 +1323,14 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	a.tabs[tabID] = created
 	a.tabOrder = append(a.tabOrder, tabID)
 	a.activeTabID = tabID
+	// Pre-create an empty session file so the tab is immediately
+	// deletable even before the async controller build finishes (#5215).
+	preDir := desktopSessionDir(actualRoot)
+	prePath := agent.NewSessionPath(preDir, inheritedModel)
+	if f, err := os.OpenFile(prePath, os.O_RDONLY|os.O_CREATE, 0o644); err == nil {
+		f.Close()
+	}
+	created.SessionPath = prePath
 	a.saveTabsLocked()
 	meta := a.tabMeta(created, true)
 	a.mu.Unlock()


### PR DESCRIPTION
Fixes #5215

Three session trash bugs fixed:
1. TrashTopic no longer auto-creates a new topic in fallback tab (added skipTopicCreation field)
2. New blank tabs are immediately deletable (pre-create empty .jsonl and set SessionPath)
3. Allow overwriting stale trash entries during cleanup-pending deletes