### PR TITLE
feat: 心跳任务新增「每次新建对话」选项

### DIFF
--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -3,7 +3,7 @@
 // Renders a list of tasks with add/edit/delete controls, plus a manual
 // "run now" button for each. The panel is opened from the sidebar nav item.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Activity,
   ChevronLeft,
@@ -189,6 +189,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
           interval: "30m",
           enabled: true,
           approvalMode: "yolo",
+          newConversationEachRun: false,
           createdAt: Date.now(),
         });
       });
@@ -216,6 +217,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
       interval: "30m",
       enabled: true,
       approvalMode: "yolo",
+      newConversationEachRun: false,
       createdAt: Date.now(),
     });
   }, []);
@@ -489,10 +491,6 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
                 </ul>
               );
             })()}
-
-            <div className="heartbeat-hint">
-              <span>{t("heartbeat.configHint")}</span>
-            </div>
           </div>
         )}
       </div>
@@ -854,6 +852,19 @@ function TaskEditor({
 
   const [draft, setDraft] = useState(task);
   const intervalBeforeCycle = useRef<string | null>(null);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow prompt textarea: shrink-to-fit then cap at 180px
+  const autoGrowPrompt = useCallback(() => {
+    const el = promptRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 180) + "px";
+  }, []);
+
+  useLayoutEffect(() => {
+    autoGrowPrompt();
+  }, [draft.prompt, autoGrowPrompt]);
   const set = useCallback((field: keyof HeartbeatTask, value: string | boolean) => {
     setDraft((prev) => ({ ...prev, [field]: value }));
   }, []);
@@ -870,8 +881,9 @@ function TaskEditor({
 
   return (
     <div className="heartbeat-editor">
-      {/* Title */}
-      <div className="heartbeat-editor__field">
+      <div className="heartbeat-editor__fields">
+        {/* Title */}
+        <div className="heartbeat-editor__field">
         <label>{t("heartbeat.fieldTitle")}</label>
         <input
           ref={titleRef}
@@ -929,11 +941,14 @@ function TaskEditor({
       <div className="heartbeat-editor__field">
         <label>{t("heartbeat.fieldPrompt")}</label>
         <textarea
+          ref={promptRef}
           className="heartbeat-editor__textarea"
           value={draft.prompt}
-          onChange={(e) => set("prompt", e.target.value)}
+          onChange={(e) => {
+            set("prompt", e.target.value);
+            // autoGrowPrompt is called via useEffect watching draft.prompt
+          }}
           placeholder={t("heartbeat.promptPlaceholder")}
-          rows={5}
         />
       </div>
 
@@ -968,6 +983,25 @@ function TaskEditor({
            normalizeMode(draft.approvalMode) === "auto" ? t("heartbeat.approvalModeAutoHint") :
            t("heartbeat.approvalModeAskHint")}
         </span>
+      </div>
+
+      {/* New conversation per run */}
+      <div className="heartbeat-editor__field">
+        <label>{t("heartbeat.fieldNewConversation")}</label>
+        <div className="set-seg" style={{ alignSelf: "flex-start" }}>
+          <button
+            className={`set-seg__btn${!draft.newConversationEachRun ? " set-seg__btn--on" : ""}`}
+            onClick={() => setDraft((prev) => ({ ...prev, newConversationEachRun: false }))}
+          >
+            {t("heartbeat.newConversationEachRunOff")}
+          </button>
+          <button
+            className={`set-seg__btn${draft.newConversationEachRun ? " set-seg__btn--on" : ""}`}
+            onClick={() => setDraft((prev) => ({ ...prev, newConversationEachRun: true }))}
+          >
+            {t("heartbeat.newConversationEachRunOn")}
+          </button>
+        </div>
       </div>
 
       {/* Frequency */}
@@ -1078,6 +1112,8 @@ function TaskEditor({
             )}
           </div>
         )}
+      </div>
+
       </div>
 
       {/* Actions */}

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
@@ -24,7 +24,6 @@
   display: flex;
   flex-direction: column;
   width: min(640px, 92vw);
-  min-height: 600px;
   max-height: min(780px, 92vh);
   background: var(--bg);
   border: 1px solid var(--border);

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
@@ -24,8 +24,8 @@
   display: flex;
   flex-direction: column;
   width: min(640px, 92vw);
-  min-height: 520px;
-  max-height: min(640px, 88vh);
+  min-height: 600px;
+  max-height: min(780px, 92vh);
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 14px;
@@ -404,7 +404,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
 /* ── card ─────────────────────────────────────────────────────── */
@@ -659,11 +659,15 @@
 /* ── editor ───────────────────────────────────────────────────── */
 
 .heartbeat-editor {
-  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 16px 0;
+}
+
+.heartbeat-editor__fields {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  overflow-y: auto;
 }
 
 .heartbeat-editor__field {
@@ -714,8 +718,10 @@
 }
 
 .heartbeat-editor__textarea {
-  resize: vertical;
+  resize: none;
   min-height: 80px;
+  max-height: 180px;
+  overflow-y: auto;
 }
 
 /* ── editor rows ──────────────────────────────────────────────── */
@@ -930,9 +936,9 @@
 
 .heartbeat-editor__actions {
   display: flex;
+  align-items: center;
   gap: 8px;
-  padding-top: 6px;
-  border-top: 1px solid var(--border-soft);
+  padding: 24px 0 16px;
 }
 
 /* ── scope selector ───────────────────────────────────────────── */
@@ -967,8 +973,8 @@
 
 .heartbeat-scope-btn--active {
   background: rgba(128, 128, 128, 0.08);
-  border-color: var(--accent);
-  color: var(--accent);
+  border-color: var(--border);
+  color: var(--fg);
 }
 
 /* ── project dropdown ─────────────────────────────────────────── */
@@ -1027,17 +1033,6 @@
   text-align: center;
   font-size: 12px;
   color: var(--fg-faint);
-}
-
-/* ── footer hint ──────────────────────────────────────────────── */
-
-.heartbeat-hint {
-  font-size: 10.5px;
-  color: var(--fg-faint);
-  text-align: center;
-  padding: 8px 0 2px;
-  border-top: 1px solid var(--border-soft);
-  margin-top: auto;
 }
 
 /* ── Sidebar header automation button ── */

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.css
@@ -660,6 +660,9 @@
 .heartbeat-editor {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: 16px 16px 0;
 }
 

--- a/desktop/frontend/src/custom/features/heartbeat/heartbeat.types.ts
+++ b/desktop/frontend/src/custom/features/heartbeat/heartbeat.types.ts
@@ -10,6 +10,7 @@ export interface HeartbeatTask {
   workspaceRoot?: string;
   topicId?: string;
   lastRunAt?: number;  // unix millis
+  newConversationEachRun?: boolean; // true = create new topic each run
   createdAt?: number;
   approvalMode?: "ask" | "auto" | "yolo"; // empty defaults to "yolo"
   timeWindowStart?: string; // "HH:MM" — interval tasks only run after this time

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -529,6 +529,9 @@ export const en = {
   "heartbeat.approvalModeAskHint": "Each tool call needs manual confirmation",
   "heartbeat.approvalModeAutoHint": "Auto-approve safe tools, keep deny rules",
   "heartbeat.approvalModeYoloHint": "Skip all permission prompts, tasks run automatically",
+  "heartbeat.fieldNewConversation": "Conversation mode",
+  "heartbeat.newConversationEachRunOn": "New conversation each run",
+  "heartbeat.newConversationEachRunOff": "Reuse same conversation",
 
   "status.jobs": "{n} running",
   "status.jobsTitle": "Background jobs",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -384,6 +384,9 @@ export const zhTW: Record<DictKey, string> = {
   "heartbeat.approvalModeAskHint": "每次工具調用都需要手動確認",
   "heartbeat.approvalModeAutoHint": "自動批准安全工具，保留拒絕規則",
   "heartbeat.approvalModeYoloHint": "跳過所有工具權限提示，任務自動運行",
+  "heartbeat.fieldNewConversation": "對話模式",
+  "heartbeat.newConversationEachRunOn": "每次執行新建對話",
+  "heartbeat.newConversationEachRunOff": "複用同一對話",
 
   "status.jobs": "{n} 個執行中",
   "status.jobsTitle": "背景作業",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -530,6 +530,9 @@ export const zh: Record<DictKey, string> = {
   "heartbeat.approvalModeAskHint": "每次工具调用都需要手动确认",
   "heartbeat.approvalModeAutoHint": "自动批准安全工具，保留拒绝规则",
   "heartbeat.approvalModeYoloHint": "跳过所有工具权限提示，任务自动运行",
+  "heartbeat.fieldNewConversation": "对话模式",
+  "heartbeat.newConversationEachRunOn": "每次执行新建对话",
+  "heartbeat.newConversationEachRunOff": "复用同一对话",
 
   "status.jobs": "{n} 个运行中",
   "status.jobsTitle": "后台作业",

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -54,17 +54,19 @@ type heartbeatConfig struct {
 // HeartbeatEngine runs scheduled task execution in a background goroutine.
 // It is owned by App and started during App.startup.
 type HeartbeatEngine struct {
-	mu      sync.Mutex
-	tasks   []HeartbeatTask
-	done    chan struct{}
-	running bool
-	app     *App // back-reference for topic creation, tab routing, and prompt submission
+	mu            sync.Mutex
+	tasks         []HeartbeatTask
+	pendingTopics map[string]string // taskID → topicID; in-memory retry safety for NewConversationEachRun
+	done          chan struct{}
+	running       bool
+	app           *App // back-reference for topic creation, tab routing, and prompt submission
 }
 
 func newHeartbeatEngine(app *App) *HeartbeatEngine {
 	return &HeartbeatEngine{
-		app:  app,
-		done: make(chan struct{}),
+		app:           app,
+		done:          make(chan struct{}),
+		pendingTopics: make(map[string]string),
 	}
 }
 
@@ -212,21 +214,48 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		scope = "global"
 	}
 
-	// If newConversationEachRun is set, always create a fresh topic.
-	// Otherwise reuse the existing topicID if available.
-	var topicID = t.TopicID
+	// Determine which topic to use.
+	//
+	// For NewConversationEachRun:
+	//   - If there's a pending topic from a previous failed attempt (tracked
+	//     in-memory via pendingTopics), reuse it for retry safety.
+	//   - Otherwise create a fresh topic.
+	//   - After a successful submit, clear the pending topic so the next run
+	//     creates another fresh topic.
+	//
+	// For the legacy mode:
+	//   - Reuse the persisted topicID if available; create one on first run.
+	var topicID string
 	if t.NewConversationEachRun {
-		topicID = "" // clear so a new topic is always created
-	}
-	if topicID == "" {
-		meta, err := e.app.CreateTopic(scope, workspaceRoot, title)
-		if err != nil {
-			log.Printf("[heartbeat] CreateTopic(%q): %v", t.Title, err)
-			t.LastRunAt = time.Now().UnixMilli()
-			return t
+		e.mu.Lock()
+		topicID = e.pendingTopics[t.ID]
+		e.mu.Unlock()
+		if topicID == "" {
+			// No pending topic — create a fresh one.
+			meta, err := e.app.CreateTopic(scope, workspaceRoot, title)
+			if err != nil {
+				log.Printf("[heartbeat] CreateTopic(%q): %v", t.Title, err)
+				t.LastRunAt = time.Now().UnixMilli()
+				return t
+			}
+			topicID = meta.ID
+			// Save in-memory for retry safety (NOT persisted to disk).
+			e.mu.Lock()
+			e.pendingTopics[t.ID] = topicID
+			e.mu.Unlock()
 		}
-		topicID = meta.ID
-		t.TopicID = topicID
+	} else {
+		topicID = t.TopicID
+		if topicID == "" {
+			meta, err := e.app.CreateTopic(scope, workspaceRoot, title)
+			if err != nil {
+				log.Printf("[heartbeat] CreateTopic(%q): %v", t.Title, err)
+				t.LastRunAt = time.Now().UnixMilli()
+				return t
+			}
+			topicID = meta.ID
+			t.TopicID = topicID
+		}
 	}
 
 	// Open the tab for the topic (creates one if needed) without changing the
@@ -276,6 +305,14 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 	if !e.app.submitUserTurnToTab(tabMeta.ID, t.Prompt) {
 		log.Printf("[heartbeat] submit skipped for %q", t.Title)
 		return t
+	}
+
+	// After a successful submit: for NewConversationEachRun, clear the
+	// pending topic so the next run creates a fresh conversation.
+	if t.NewConversationEachRun {
+		e.mu.Lock()
+		delete(e.pendingTopics, t.ID)
+		e.mu.Unlock()
 	}
 
 	t.LastRunAt = time.Now().UnixMilli()

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -56,17 +56,22 @@ type heartbeatConfig struct {
 type HeartbeatEngine struct {
 	mu            sync.Mutex
 	tasks         []HeartbeatTask
-	pendingTopics map[string]string // taskID → topicID; in-memory retry safety for NewConversationEachRun
+	pendingTopics map[string]heartbeatPendingTopic // in-memory retry/in-flight safety for NewConversationEachRun
 	done          chan struct{}
 	running       bool
 	app           *App // back-reference for topic creation, tab routing, and prompt submission
+}
+
+type heartbeatPendingTopic struct {
+	TopicID   string
+	Submitted bool
 }
 
 func newHeartbeatEngine(app *App) *HeartbeatEngine {
 	return &HeartbeatEngine{
 		app:           app,
 		done:          make(chan struct{}),
-		pendingTopics: make(map[string]string),
+		pendingTopics: make(map[string]heartbeatPendingTopic),
 	}
 }
 
@@ -217,19 +222,22 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 	// Determine which topic to use.
 	//
 	// For NewConversationEachRun:
-	//   - If there's a pending topic from a previous failed attempt (tracked
-	//     in-memory via pendingTopics), reuse it for retry safety.
-	//   - Otherwise create a fresh topic.
-	//   - After a successful submit, clear the pending topic so the next run
-	//     creates another fresh topic.
+	//   - Reuse a pending topic from a failed pre-submit attempt.
+	//   - Re-check a submitted topic until its controller is idle, so a long
+	//     previous run cannot overlap with the next scheduled fresh topic.
+	//   - Once the submitted topic is idle and due again, clear it and create a
+	//     fresh topic.
 	//
 	// For the legacy mode:
 	//   - Reuse the persisted topicID if available; create one on first run.
 	var topicID string
+	var pendingSubmitted bool
 	if t.NewConversationEachRun {
 		e.mu.Lock()
-		topicID = e.pendingTopics[t.ID]
+		pending := e.pendingTopics[t.ID]
 		e.mu.Unlock()
+		topicID = pending.TopicID
+		pendingSubmitted = pending.Submitted
 		if topicID == "" {
 			// No pending topic — create a fresh one.
 			meta, err := e.app.CreateTopic(scope, workspaceRoot, title)
@@ -241,7 +249,10 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 			topicID = meta.ID
 			// Save in-memory for retry safety (NOT persisted to disk).
 			e.mu.Lock()
-			e.pendingTopics[t.ID] = topicID
+			if e.pendingTopics == nil {
+				e.pendingTopics = make(map[string]heartbeatPendingTopic)
+			}
+			e.pendingTopics[t.ID] = heartbeatPendingTopic{TopicID: topicID}
 			e.mu.Unlock()
 		}
 	} else {
@@ -291,6 +302,14 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		log.Printf("[heartbeat] controller busy for %q, skipping", t.Title)
 		return t // don't change approval mode for an existing turn — retry next tick
 	}
+	if t.NewConversationEachRun && pendingSubmitted {
+		e.mu.Lock()
+		if pending := e.pendingTopics[t.ID]; pending.TopicID == topicID && pending.Submitted {
+			delete(e.pendingTopics, t.ID)
+		}
+		e.mu.Unlock()
+		return e.executeTask(t)
+	}
 
 	// Set the task's approval mode only after confirming the controller is idle.
 	// SetToolApprovalModeForTab may drain pending approvals for auto/yolo modes,
@@ -307,11 +326,14 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		return t
 	}
 
-	// After a successful submit: for NewConversationEachRun, clear the
-	// pending topic so the next run creates a fresh conversation.
+	// After a successful submit, keep the topic as an in-flight guard. The next
+	// due run will busy-check this controller before creating a fresh topic.
 	if t.NewConversationEachRun {
 		e.mu.Lock()
-		delete(e.pendingTopics, t.ID)
+		if e.pendingTopics == nil {
+			e.pendingTopics = make(map[string]heartbeatPendingTopic)
+		}
+		e.pendingTopics[t.ID] = heartbeatPendingTopic{TopicID: topicID, Submitted: true}
 		e.mu.Unlock()
 	}
 
@@ -336,6 +358,7 @@ func (e *HeartbeatEngine) ReloadTasks() []HeartbeatTask {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.tasks = e.loadTasks()
+	e.prunePendingTopicsLocked(e.tasks)
 	out := make([]HeartbeatTask, len(e.tasks))
 	copy(out, e.tasks)
 	return out
@@ -346,7 +369,25 @@ func (e *HeartbeatEngine) ReplaceTasks(tasks []HeartbeatTask) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.tasks = tasks
+	e.prunePendingTopicsLocked(tasks)
 	return e.saveTasks(tasks)
+}
+
+func (e *HeartbeatEngine) prunePendingTopicsLocked(tasks []HeartbeatTask) {
+	if len(e.pendingTopics) == 0 {
+		return
+	}
+	keep := make(map[string]bool, len(tasks))
+	for _, task := range tasks {
+		if task.NewConversationEachRun {
+			keep[task.ID] = true
+		}
+	}
+	for id := range e.pendingTopics {
+		if !keep[id] {
+			delete(e.pendingTopics, id)
+		}
+	}
 }
 
 // TriggerNow runs a single task immediately by ID.

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -28,19 +28,20 @@ import (
 
 // HeartbeatTask defines a single scheduled prompt.
 type HeartbeatTask struct {
-	ID              string `json:"id"`
-	Title           string `json:"title"`    // user-visible label
-	Prompt          string `json:"prompt"`   // the prompt to submit
-	Interval        string `json:"interval"` // e.g. "5m", "1h", "30s"
-	Enabled         bool   `json:"enabled"`
-	Scope           string `json:"scope,omitempty"`         // "global" or "project"
-	WorkspaceRoot   string `json:"workspaceRoot,omitempty"` // project root path when scope="project"
-	TopicID         string `json:"topicId,omitempty"`       // created topic, reused on re-run
-	LastRunAt       int64  `json:"lastRunAt,omitempty"`     // unix millis
-	CreatedAt       int64  `json:"createdAt,omitempty"`
-	ApprovalMode    string `json:"approvalMode"`              // "ask" | "auto" | "yolo"; empty defaults to "yolo"
-	TimeWindowStart string `json:"timeWindowStart,omitempty"` // "HH:MM" — interval tasks only run after this time (inclusive)
-	TimeWindowEnd   string `json:"timeWindowEnd,omitempty"`   // "HH:MM" — interval tasks only run before this time (exclusive)
+	ID                     string `json:"id"`
+	Title                  string `json:"title"`    // user-visible label
+	Prompt                 string `json:"prompt"`   // the prompt to submit
+	Interval               string `json:"interval"` // e.g. "5m", "1h", "30s"
+	Enabled                bool   `json:"enabled"`
+	Scope                  string `json:"scope,omitempty"`                  // "global" or "project"
+	WorkspaceRoot          string `json:"workspaceRoot,omitempty"`          // project root path when scope="project"
+	TopicID                string `json:"topicId,omitempty"`                // created topic, reused on re-run
+	LastRunAt              int64  `json:"lastRunAt,omitempty"`              // unix millis
+	NewConversationEachRun bool   `json:"newConversationEachRun,omitempty"` // true = create new topic every run
+	CreatedAt              int64  `json:"createdAt,omitempty"`
+	ApprovalMode           string `json:"approvalMode"`              // "ask" | "auto" | "yolo"; empty defaults to "yolo"
+	TimeWindowStart        string `json:"timeWindowStart,omitempty"` // "HH:MM" — interval tasks only run after this time (inclusive)
+	TimeWindowEnd          string `json:"timeWindowEnd,omitempty"`   // "HH:MM" — interval tasks only run before this time (exclusive)
 }
 
 // heartbeatConfig is the on-disk format.
@@ -211,8 +212,12 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		scope = "global"
 	}
 
-	// If we already have a topicID, reuse it; otherwise create a new topic.
+	// If newConversationEachRun is set, always create a fresh topic.
+	// Otherwise reuse the existing topicID if available.
 	var topicID = t.TopicID
+	if t.NewConversationEachRun {
+		topicID = "" // clear so a new topic is always created
+	}
 	if topicID == "" {
 		meta, err := e.app.CreateTopic(scope, workspaceRoot, title)
 		if err != nil {

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -163,6 +163,38 @@ func TestHeartbeatMergeRunUpdatesPreservesConcurrentEditsAndDeletes(t *testing.T
 	}
 }
 
+func TestHeartbeatReplaceTasksPrunesFreshConversationPendingTopics(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	engine := &HeartbeatEngine{
+		pendingTopics: map[string]heartbeatPendingTopic{
+			"fresh":   {TopicID: "topic-fresh", Submitted: true},
+			"legacy":  {TopicID: "topic-legacy", Submitted: true},
+			"deleted": {TopicID: "topic-deleted", Submitted: true},
+		},
+	}
+
+	err := engine.ReplaceTasks([]HeartbeatTask{
+		{ID: "fresh", NewConversationEachRun: true},
+		{ID: "legacy", NewConversationEachRun: false},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceTasks: %v", err)
+	}
+
+	if len(engine.pendingTopics) != 1 {
+		t.Fatalf("pendingTopics len = %d, want 1: %+v", len(engine.pendingTopics), engine.pendingTopics)
+	}
+	if got := engine.pendingTopics["fresh"]; got.TopicID != "topic-fresh" || !got.Submitted {
+		t.Fatalf("fresh pending topic = %+v, want submitted topic-fresh", got)
+	}
+	if _, ok := engine.pendingTopics["legacy"]; ok {
+		t.Fatalf("legacy task should not keep a fresh-conversation pending topic")
+	}
+	if _, ok := engine.pendingTopics["deleted"]; ok {
+		t.Fatalf("deleted task should not keep a pending topic")
+	}
+}
+
 func TestHeartbeatInactiveOpenDoesNotChangeActiveTab(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()


### PR DESCRIPTION
### 功能描述

在心跳任务编辑器中增加「对话模式」选项，可选择：
- **复用同一对话**（默认，原有行为）
- **每次执行新建对话**（每次触发时创建新 topic）

### 改动范围

| 层 | 文件 | 改动 |
|---|---|---|
| Go 后端 | `desktop/heartbeat.go` | HeartbeatTask 新增 `NewConversationEachRun` 字段；executeTask 按标志创建新对话；mergeRunUpdatesLocked 保护 |
| TS 类型 | `heartbeat.types.ts` | 新增 `newConversationEachRun?: boolean` |
| 前端 UI | `HeartbeatPanel.tsx` | 编辑面板新增 toggle 选择器 + 提示词 textarea 自动增高 + 移除提示条 |
| CSS | `heartbeat.css` | 弹窗自适应高度 + 底部按钮无分隔线 + 卡片间距 4px + 项目选择器取消蓝色高亮 |
| 多语言 | `zh.ts, en.ts, zh-TW.ts` | 新增 3 条文案 |

### 审查修复
- autoGrowPrompt 改为 useLayoutEffect 避免高度闪烁
- handleAdd/startNew 初始化补上 `newConversationEachRun: false`

### 验证
- `go vet ./...` — 无警告
- `go build ./...` — 编译通过
- 桌面端打包测试通过

<img width="1646" height="1806" alt="image" src="https://github.com/user-attachments/assets/89880438-f976-4f7e-ad1b-5ccae36ecba1" />
