### PR TITLE
输入框有内容时 Cmd+1..9 快捷键仍可切换对话

### DIFF
--- a/desktop/frontend/src/__tests__/keyboard-shortcuts.test.ts
+++ b/desktop/frontend/src/__tests__/keyboard-shortcuts.test.ts
@@ -1,5 +1,7 @@
 // Run: tsx src/__tests__/keyboard-shortcuts.test.ts
 
+import { JSDOM } from "jsdom";
+
 import {
   defaultShortcutCombo,
   formatShortcutCombo,
@@ -36,6 +38,22 @@ function event(key: string, modifiers: { ctrlKey?: boolean; metaKey?: boolean; a
   };
 }
 
+function eventWithTarget(
+  key: string,
+  target: EventTarget | null,
+  modifiers: { ctrlKey?: boolean; metaKey?: boolean; altKey?: boolean; shiftKey?: boolean; defaultPrevented?: boolean } = {},
+) {
+  return {
+    key,
+    ctrlKey: modifiers.ctrlKey ?? false,
+    metaKey: modifiers.metaKey ?? false,
+    altKey: modifiers.altKey ?? false,
+    shiftKey: modifiers.shiftKey ?? false,
+    defaultPrevented: modifiers.defaultPrevented ?? false,
+    target,
+  };
+}
+
 console.log("\nkeyboard shortcuts");
 
 eq(isCloseTabShortcut(event("w", { metaKey: true }), "darwin"), true, "Cmd+W closes tabs on macOS");
@@ -66,6 +84,16 @@ eq(topicShortcutIndexFromEvent(event("9", { metaKey: true }), "windows"), null, 
 eq(topicShortcutIndexFromEvent(event("1", { ctrlKey: true, shiftKey: true }), "linux"), null, "topic shortcuts reject extra modifiers");
 eq(topicShortcutIndexFromEvent(event("0", { metaKey: true }), "darwin"), null, "Cmd+0 is not a topic shortcut");
 eq(topicShortcutIndexFromEvent(event("1", { metaKey: true, defaultPrevented: true }), "darwin"), null, "topic shortcuts yield to already-handled custom shortcuts");
+{
+  const dom = new JSDOM("<!doctype html><html><body><input /><textarea></textarea></body></html>");
+  const previousHTMLElement = globalThis.HTMLElement;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  const input = dom.window.document.querySelector("input");
+  const textarea = dom.window.document.querySelector("textarea");
+  eq(topicShortcutIndexFromEvent(eventWithTarget("1", input, { metaKey: true }), "darwin"), 0, "Cmd+1 still works when an input has focus");
+  eq(topicShortcutIndexFromEvent(eventWithTarget("9", textarea, { ctrlKey: true }), "windows"), 8, "Ctrl+9 still works when a textarea has focus");
+  globalThis.HTMLElement = previousHTMLElement;
+}
 eq(topicShortcutLabel(1, "darwin"), "⌘1", "topic badge uses the macOS command glyph");
 eq(topicShortcutLabel(1, "windows"), "Ctrl+1", "topic badge uses the Windows control modifier");
 

--- a/desktop/frontend/src/lib/topicShortcuts.ts
+++ b/desktop/frontend/src/lib/topicShortcuts.ts
@@ -10,7 +10,6 @@ import {
   defaultShortcutCombo,
   detectShortcutPlatform,
   formatShortcutCombo,
-  isEditableTarget,
   isShortcutRecorderTarget,
   matchesShortcut,
   type ShortcutAction,
@@ -51,7 +50,11 @@ export function topicShortcutIndexFromEvent(
   platform: ShortcutPlatform = detectShortcutPlatform(),
 ): number | null {
   if (event.defaultPrevented) return null;
-  if (isShortcutRecorderTarget(event.target ?? null) || isEditableTarget(event.target ?? null)) return null;
+  // Allow Cmd/Ctrl+1-9 even when focus is in an editable element (input/textarea)
+  // because these are application-level navigation shortcuts, not editor keys
+  // like Cmd+C/V/Z. Only block during shortcut-recording mode. Matches CodeX
+  // behavior where topic shortcuts work regardless of input focus state.
+  if (isShortcutRecorderTarget(event.target ?? null)) return null;
   for (let index = 1; index <= 9; index += 1) {
     if (matchesShortcut(event, topicShortcutAction(index), platform)) return index - 1;
   }


### PR DESCRIPTION
## 问题

在底部输入框内有输入内容时，Cmd+1/2/3/4 等快捷键被屏蔽了，无法通过快捷键切换对话。

## 原因

`topicShortcutIndexFromEvent` 中使用了 `isEditableTarget` 守卫，只要焦点在任何 `<input>`/`<textarea>` 上就跳过快捷键处理，无论输入框有无内容。

## 修复

移除 `isEditableTarget` 守卫。Cmd+1..9 是应用级导航快捷键（非编辑器标准键如 Cmd+C/V/Z），移除后在任何输入状态下都能触发对话切换，与 CodeX 行为一致。

## 变更

`desktop/frontend/src/lib/topicShortcuts.ts` — 删除 isEditableTarget 导入和守卫条件