### PR TITLE
fix(desktop): 修复代码块复制按钮跟随滚动条移动的问题

### DIFF
--- a/desktop/frontend/src/components/editors/HljsCode.tsx
+++ b/desktop/frontend/src/components/editors/HljsCode.tsx
@@ -10,10 +10,12 @@ import { CopyButton } from "../CopyButton";
 const HljsCode = memo(function HljsCode({ value, language, maxHeight }: EditorProps) {
   const html = useMemo(() => highlightToHtml(value, language), [value, language]);
   return (
-    <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
-      <code dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="code-block__wrap">
+      <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
+        <code dangerouslySetInnerHTML={{ __html: html }} />
+      </pre>
       <CopyButton text={value} className="code-block__copy" />
-    </pre>
+    </div>
   );
 });
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4363,7 +4363,7 @@ a[href] {
   transition: opacity 0.12s;
 }
 .code-block__copy:hover,
-.code:hover .code-block__copy {
+.code-block__wrap:hover .code-block__copy {
   opacity: 1;
 }
 .code-block__wrap {
@@ -24603,8 +24603,8 @@ a[href] {
   word-break: break-word;
 }
 
-.app--creation .msg--assistant .md .code:not([data-lang]) .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code:not([data-lang]) .code-block__copy {
+.app--creation .msg--assistant .md .code:not([data-lang]) + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code:not([data-lang]) + .code-block__copy {
   top: 2px;
   right: 2px;
   color: color-mix(in srgb, var(--fg-faint) 58%, var(--bg));
@@ -24672,16 +24672,16 @@ a[href] {
   content: ">";
 }
 
-.app--creation .msg--assistant .md .code[data-lang="bash"] .code-block__copy,
-.app--creation .msg--assistant .md .code[data-lang="shell"] .code-block__copy,
-.app--creation .msg--assistant .md .code[data-lang="sh"] .code-block__copy,
-.app--creation .msg--assistant .md .code[data-lang="powershell"] .code-block__copy,
-.app--creation .msg--assistant .md .code[data-lang="pwsh"] .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="bash"] .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="shell"] .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="sh"] .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="powershell"] .code-block__copy,
-:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="pwsh"] .code-block__copy {
+.app--creation .msg--assistant .md .code[data-lang="bash"] + .code-block__copy,
+.app--creation .msg--assistant .md .code[data-lang="shell"] + .code-block__copy,
+.app--creation .msg--assistant .md .code[data-lang="sh"] + .code-block__copy,
+.app--creation .msg--assistant .md .code[data-lang="powershell"] + .code-block__copy,
+.app--creation .msg--assistant .md .code[data-lang="pwsh"] + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="bash"] + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="shell"] + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="sh"] + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="powershell"] + .code-block__copy,
+:root[data-theme-style] .app--creation .msg--assistant .md .code[data-lang="pwsh"] + .code-block__copy {
   top: 5px;
   right: 5px;
   color: color-mix(in srgb, var(--fg-faint) 58%, var(--bg));


### PR DESCRIPTION
## Summary

- 修复桌面端代码块复制按钮跟随滚动条移动的 bug：将 `CopyButton` 从可滚动的 `<pre>` 内移到 `.code-block__wrap` 包装层，使按钮 fixed 在代码块右上角；CSS 选择器从 descendant 改为 adjacent sibling (`+`)。

## Verification

- 在桌面端渲染包含长代码块的对话消息，确认：
  - 拖动代码块横向/纵向滚动条时，复制按钮始终固定在右上角
  - hover 代码块任意位置均显示复制按钮
  - 滚动条行为与修复前一致（hover 时显示）

## Cache impact

Cache-impact: none — 仅前端 CSS/DOM 修复，不涉及 Go 内核、provider、system prompt、tool schema 等缓存敏感路径。

Cache-guard: N/A — 无缓存敏感变更。

System-prompt-review: N/A — 无 provider 可见的 prompt/memory/output 变更。