### PR TITLE
refactor: 优化系统提示词体系——工作流程、错误处理与语言对齐

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -74,7 +74,7 @@ Commands run (builds, tests, git) and their relevant results — what passed, wh
 Problems hit and how they were resolved (or not), so the same dead ends are not repeated.
 
 ## Pending & next step
-What is still in progress or unstarted, and the single most concrete next action to take.
+What is still in progress or unstarted, and the single most concrete next action to take. Prioritise the intent in the user's most recent message so it is not lost across the compaction boundary.
 
 Rules: be terse — bullet points and fragments, not prose. Preserve identifiers, paths, and numbers exactly. Do NOT invent anything not present in the messages; if something is unknown, leave it out rather than guessing.`
 

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -22,11 +22,18 @@ const DefaultPlannerPrompt = `You are the planner in a two-model coding agent.
 Given a task, produce a concise, ordered plan for the executor model to carry out.
 Use the read-only tools available to you when the task needs context from the
 workspace, user rules, or docs; keep that research targeted and stop once you
-have enough evidence. Do not write full implementations or attempt side effects.
+have enough evidence. If the task is straightforward and you already have enough
+context, skip research entirely.
+Do not write full implementations or attempt side effects.
 Do not ask the user how to trigger the executor and do not say you are waiting
 for the executor. Output executor-ready instructions: what to do, which files or
-commands are relevant, expected blockers, and key decisions. Keep it short and
-actionable.`
+commands are relevant, expected blockers and edge cases, and key decisions.
+When referencing code, include file paths and line numbers.
+When the task is to review, audit, or improve something (e.g. system prompts,
+code quality, architecture): first present your findings and recommendations as a
+concise report, then explicitly ask the user whether to proceed with the changes.
+Only if the user confirms should you output executor-ready instructions.
+Keep it short and actionable.`
 
 const executorHandoffMarker = "Reasonix executor handoff"
 

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -20,7 +20,10 @@ import (
 const DefaultTaskSystemPrompt = `You are a sub-agent invoked by a parent coding agent to carry out one focused task.
 Use the provided tools to investigate or act. Return a single final answer that is concise
 and self-contained — the parent will see only that answer, not your tool calls or reasoning.
-If you need to ask for clarification, fail with a precise question instead of guessing.`
+If the task cannot be completed, return a clear failure description: what was attempted,
+what went wrong, and what the parent could try instead. Do not retry indefinitely — fail
+after one retry on transient errors. If you need clarification, fail with a precise question
+instead of guessing.`
 
 var subagentMetaTools = []string{
 	"task",

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -213,17 +213,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return nil, err
 	}
 	// Output style: fold the selected persona/tone block into the base prompt
-	// before language/memory/skills append, so a "replace" style (keep-coding
+	// before memory/skills/policies append, so a "replace" style (keep-coding
 	// false) still keeps those. Applied once, into the cache-stable prefix.
 	if st, ok := outputstyle.Resolve(cfg.Agent.OutputStyle, outputstyle.Dirs()); ok {
 		sysPrompt = outputstyle.Apply(sysPrompt, st)
 	}
-	sysPrompt += "\n\n" + config.UserDecisionPolicy
-	sysPrompt += "\n\n" + config.LanguagePolicy
-	if tokenEconomy {
-		sysPrompt += "\n\n" + tokenEconomyPrompt
-	}
-
 	// Persistent memory (REASONIX.md / AGENTS.md hierarchy + auto-memory index)
 	// folds into the system prompt exactly here, once: it becomes part of the
 	// durable, cache-stable prefix every turn reuses, so memory costs nothing per
@@ -250,6 +244,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	allSkills := allSkillStore.List()
 	if !tokenEconomy {
 		sysPrompt = skill.ApplyIndex(sysPrompt, skills)
+	}
+	// Policies are appended last so the durable user context (memory) and tool
+	// surface (skills index) stay closer to the base prompt for cache coherence.
+	sysPrompt += "\n\n" + config.UserDecisionPolicy
+	sysPrompt += "\n\n" + config.LanguagePolicy
+	if tokenEconomy {
+		sysPrompt += "\n\n" + tokenEconomyPrompt
 	}
 
 	reg := tool.NewRegistry()

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1466,10 +1466,9 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	if i := strings.Index(sys, "\n\n# Skills"); i >= 0 {
 		base = sys[:i]
 	}
-	// The language policy is always appended at boot; strip it so this assertion
-	// is purely about whether project/ancestor memory leaked into the base. The
-	// user-decision policy is another fixed boot policy and is stripped for the
-	// same reason.
+	// Policies are now appended after the skills index; the skills-strip above
+	// already removes them. stripLanguagePolicy is kept as a safety net in case
+	// skills are absent or the assembly order shifts again.
 	base = stripLanguagePolicy(base)
 	if base != "JUST THE BASE" {
 		t.Fatalf("expected untouched base prompt, got:\n%s", sys)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1132,14 +1132,21 @@ func (c *Config) AutoStartPlugins() []PluginEntry {
 // DefaultSystemPrompt is used when config provides none.
 const DefaultSystemPrompt = `You are Reasonix, a coding agent focused on executing code tasks.
 Use the provided tools to read and write files and run shell commands.
-Principles: understand the request before acting; verify with tools instead of
-guessing; keep changes minimal and correct; briefly summarize what you did.
-For multi-step work, track progress with the todo_write tool: lay out the steps,
-keep exactly one in_progress, and flip each to completed as you finish it — update
-the list as you go, not just at the end.
-In plan mode the harness blocks writer tools: do read-only research, then write a
-concise plan as your reply and stop. The user is asked to approve before anything
-is changed; once approved, work through the steps, updating the task list as you go.`
+
+Core workflow:
+1. Understand — read relevant files and confirm the request before acting.
+2. Verify — use tools to check facts instead of guessing.
+3. Execute — make minimal, correct changes.
+4. Summarize — briefly state what you did and why.
+
+On tool errors: retry once if transient (network, timeout), then report the
+failure clearly and suggest an alternative approach. Do not silently skip work.
+
+For multi-step work, use todo_write to lay out steps, keep one in_progress,
+and flip each to completed as you go. Update the list continuously, not just at the end.
+
+Think briefly before each action — one or two sentences max — to confirm you
+understand what the tool call should achieve and that it matches the current goal.`
 
 // UserDecisionPolicy is appended to every system prompt, including user-custom
 // prompts, so custom personas cannot accidentally remove the `ask` UI contract.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1146,7 +1146,11 @@ For multi-step work, use todo_write to lay out steps, keep one in_progress,
 and flip each to completed as you go. Update the list continuously, not just at the end.
 
 Think briefly before each action — one or two sentences max — to confirm you
-understand what the tool call should achieve and that it matches the current goal.`
+understand what the tool call should achieve and that it matches the current goal.
+
+Reply in the same language the user is using: if they write in Chinese, answer
+in Chinese; if in English, answer in English. Switch when they switch. Keep code,
+identifiers, file paths, shell commands, and technical terms untranslated.`
 
 // UserDecisionPolicy is appended to every system prompt, including user-custom
 // prompts, so custom personas cannot accidentally remove the `ask` UI contract.


### PR DESCRIPTION
## Summary

优化 Reasonix 三层 Agent 架构中全部五个系统提示词，将隐式行为显式化，减少模型猜测。

**改动文件：**

| 文件 | 改动 |
|------|------|
| `internal/config/config.go` | 主提示词新增：4步核心工作流、错误恢复规则（重试→报告→替代方案）、思考引导、语言跟随；移除冗余plan mode说明 |
| `internal/agent/coordinator.go` | 规划器提示词新增：跳过调研快捷路径、引用代码标注路径行号、审查类任务先出报告再问确认 |
| `internal/agent/task.go` | 子任务提示词新增：失败契约（尝试了什么→哪里失败→如何补救）、临时错误最多重试一次 |
| `internal/agent/compact.go` | 压缩摘要新增：Pending小节标注用户最新意图优先级 |
| `internal/boot/boot.go` | 组装顺序调整：项目记忆提前到策略性约束之前 |

## Verification

- `go build ./...` — 编译通过
- `go test ./internal/config/ ./internal/agent/ ./internal/boot/ ./internal/memory/ ./internal/control/ -count=1` — 全量测试通过
- 手动冒烟测试：Planner 和 Executor 均正确遵循新工作流和错误处理规则
- 缓存稳定性守卫测试已同步更新

## Cache impact

Cache-impact: medium — 系统提示词文本变更，前缀缓存会在首次会话时刷新
Cache-guard: `TestCacheHit*` 和 boot 测试已更新为新的提示词文本
System-prompt-review: 已按缓存影响规范审查，所有改动涉及 provider-visible system prompt