### PR TITLE
feat: add built-in Worker Manager for parallel sub-agent execution

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
+	"reasonix/internal/worker"
 )
 
 // maxToolOutputBytes caps a single tool result before it goes into the model's
@@ -274,6 +275,8 @@ type Agent struct {
 	// run_in_background, task run_in_background, bash_output/kill_shell/wait) can
 	// reach it. nil leaves those tools to degrade gracefully.
 	jobs *jobs.Manager
+
+	workerMgr *worker.Manager
 
 	// steerQueue holds mid-turn user messages queued while the agent is
 	// running. Each is consumed once per loop iteration, persisted to the
@@ -571,6 +574,8 @@ type Options struct {
 	// Jobs is the session's background-job manager (nil disables background tools).
 	Jobs *jobs.Manager
 
+	WorkerManager *worker.Manager
+
 	// ProjectChecks are host-observable structured checks extracted during boot.
 	ProjectChecks []instruction.VerifyCheck
 
@@ -642,6 +647,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		gate:                 gate,
 		hooks:                hooks,
 		jobs:                 opts.Jobs,
+		workerMgr:            opts.WorkerManager,
 		evidence:             evidence.NewLedger(),
 		projectChecks:        append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		contextWindow:        opts.ContextWindow,
@@ -1785,6 +1791,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)
+	}
+	if a.workerMgr != nil {
+		cctx = worker.WithManager(cctx, a.workerMgr)
 	}
 	if v := a.reasoningLanguage.Load(); v != nil {
 		if lang, ok := v.(string); ok {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -42,6 +42,7 @@ import (
 	"reasonix/internal/tool"
 	"reasonix/internal/tool/builtin"
 	"reasonix/internal/tool/sessiontool"
+	"reasonix/internal/worker"
 )
 
 // ErrUnknownModel is returned by Build when the configured model can't be
@@ -182,6 +183,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
 	}
 	jm := jobs.NewManager(sink, jobs.WithStalledWarningAfter(time.Duration(cfg.BackgroundJobStalledWarningSeconds())*time.Second))
+	wm := worker.NewManager(worker.ResolveReasonix())
 	sessionDir := opts.SessionDir
 	if sessionDir == "" {
 		sessionDir = config.SessionDir()
@@ -844,6 +846,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Gate:                 headlessGate,
 		Hooks:                hookRunner,
 		Jobs:                 jm,
+		WorkerManager:        wm,
 		ProjectChecks:        projectChecks,
 		ContextWindow:        entry.ContextWindow,
 		SoftCompactRatio:     cfg.Agent.SoftCompactRatio,
@@ -928,6 +931,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		BalanceKey:             entry.APIKey(),
 		BalanceClient:          balanceClient,
 		Jobs:                   jm,
+		WorkerManager:          wm,
 		Registry:               reg,
 		PluginCtx:              ctx,
 		WorkspaceRoot:          root,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -48,6 +48,7 @@ import (
 	"reasonix/internal/skill"
 	"reasonix/internal/store"
 	"reasonix/internal/tool"
+	"reasonix/internal/worker"
 )
 
 // ErrTurnRunning reports that a caller tried to start a second foreground turn
@@ -104,6 +105,8 @@ type Controller struct {
 	// tools spawn into it; Compose drains its completion notes into the next turn;
 	// Close cancels its still-running jobs.
 	jobs *jobs.Manager
+
+	workerMgr *worker.Manager
 
 	// mcp owns the session's live tool/plugin surface — the MCP plugin Host, the
 	// tool registry the executor reads each turn, and the session-scoped context a
@@ -239,6 +242,9 @@ type Options struct {
 	BalanceClient *http.Client
 	// Jobs is the session-scoped background-job manager (nil disables background jobs).
 	Jobs *jobs.Manager
+
+	// WorkerManager is the manager for spawning background Reasonix workers.
+	WorkerManager *worker.Manager
 	// Registry is the executor's live tool set, and PluginCtx the session-scoped
 	// context; both are needed for hot-adding MCP servers via AddMCPServer.
 	Registry  *tool.Registry
@@ -312,6 +318,7 @@ func New(opts Options) *Controller {
 		balanceKey:             opts.BalanceKey,
 		balanceClient:          opts.BalanceClient,
 		jobs:                   opts.Jobs,
+		workerMgr:              opts.WorkerManager,
 		mcp:                    newMcpManager(opts.Host, opts.Registry, pluginCtx),
 		workspaceRoot:          opts.WorkspaceRoot,
 		approval:               newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),

--- a/internal/tool/builtin/worker.go
+++ b/internal/tool/builtin/worker.go
@@ -1,0 +1,128 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"reasonix/internal/tool"
+	"reasonix/internal/worker"
+)
+
+func init() {
+	tool.RegisterBuiltin(workerSpawn{})
+	tool.RegisterBuiltin(workerResult{})
+	tool.RegisterBuiltin(workerList{})
+	tool.RegisterBuiltin(workerKill{})
+}
+
+type workerSpawn struct{}
+
+func (workerSpawn) Name() string   { return "worker_spawn" }
+func (workerSpawn) ReadOnly() bool { return false }
+func (workerSpawn) Description() string {
+	return "Spawn a background Reasonix worker to run a task asynchronously. Returns a job ID immediately. Use worker_result to check progress and get output. Workers inherit your full config (MCP tools, memory, API keys)."
+}
+func (workerSpawn) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"prompt":{"type":"string","description":"The prompt for the worker to execute"},"cwd":{"type":"string","description":"Optional working directory"},"model":{"type":"string","description":"Optional model (default: deepseek-flash)"},"max_steps":{"type":"integer","description":"Optional max steps (default: 50)"}},"required":["prompt"]}`)
+}
+
+func (workerSpawn) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, ok := worker.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("worker manager not available")
+	}
+	var p struct {
+		Prompt   string `json:"prompt"`
+		CWD      string `json:"cwd"`
+		Model    string `json:"model"`
+		MaxSteps int    `json:"max_steps"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Prompt == "" {
+		return "", fmt.Errorf("prompt is required")
+	}
+	id := mgr.Spawn(p.Prompt, p.CWD, p.Model, p.MaxSteps)
+	return fmt.Sprintf(`{"job_id":"%s","status":"running","hint":"Use worker_result("%s") to check progress later."}`, id, id), nil
+}
+
+type workerResult struct{}
+
+func (workerResult) Name() string   { return "worker_result" }
+func (workerResult) ReadOnly() bool { return true }
+func (workerResult) Description() string {
+	return "Check the status and output of a spawned worker. Returns status (running/done/failed/killed), output text, and any error."
+}
+func (workerResult) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"job_id":{"type":"string","description":"Worker job ID from worker_spawn"}},"required":["job_id"]}`)
+}
+
+func (workerResult) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, ok := worker.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("worker manager not available")
+	}
+	var p struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	job, found := mgr.Result(p.JobID)
+	if !found {
+		return "", fmt.Errorf("worker %q not found", p.JobID)
+	}
+	b, _ := json.Marshal(job)
+	return string(b), nil
+}
+
+type workerList struct{}
+
+func (workerList) Name() string   { return "worker_list" }
+func (workerList) ReadOnly() bool { return true }
+func (workerList) Description() string {
+	return "List all spawned worker jobs with their statuses."
+}
+func (workerList) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{}}`)
+}
+
+func (workerList) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, ok := worker.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("worker manager not available")
+	}
+	jobs := mgr.List()
+	b, _ := json.Marshal(jobs)
+	return string(b), nil
+}
+
+type workerKill struct{}
+
+func (workerKill) Name() string   { return "worker_kill" }
+func (workerKill) ReadOnly() bool { return false }
+func (workerKill) Description() string {
+	return "Kill a running worker by job ID."
+}
+func (workerKill) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"job_id":{"type":"string","description":"Worker job ID to kill"}},"required":["job_id"]}`)
+}
+
+func (workerKill) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, ok := worker.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("worker manager not available")
+	}
+	var p struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if ok := mgr.Kill(p.JobID); !ok {
+		return "", fmt.Errorf("worker %q not found or already finished", p.JobID)
+	}
+	return fmt.Sprintf(`{"job_id":"%s","status":"killed"}`, p.JobID), nil
+}

--- a/internal/worker/context.go
+++ b/internal/worker/context.go
@@ -1,0 +1,14 @@
+package worker
+
+import "context"
+
+type ctxKey struct{}
+
+func WithManager(ctx context.Context, m *Manager) context.Context {
+	return context.WithValue(ctx, ctxKey{}, m)
+}
+
+func FromContext(ctx context.Context) (*Manager, bool) {
+	m, ok := ctx.Value(ctxKey{}).(*Manager)
+	return m, ok && m != nil
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,183 @@
+// Package worker manages background Reasonix worker instances spawned as
+// subprocesses from within the agent loop. Workers run in full isolation
+// and communicate results back through the manager.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Status string
+
+const (
+	Running Status = "running"
+	Done    Status = "done"
+	Failed  Status = "failed"
+	Killed  Status = "killed"
+)
+
+type Job struct {
+	ID        string    `json:"id"`
+	Prompt    string    `json:"prompt"`
+	Status    Status    `json:"status"`
+	Output    string    `json:"output"`
+	Error     string    `json:"error,omitempty"`
+	StartedAt time.Time `json:"started_at"`
+	EndedAt   time.Time `json:"ended_at,omitempty"`
+
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+	mu     sync.RWMutex
+}
+
+func (j *Job) Snapshot() Job {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return Job{
+		ID:        j.ID,
+		Prompt:    j.Prompt,
+		Status:    j.Status,
+		Output:    j.Output,
+		Error:     j.Error,
+		StartedAt: j.StartedAt,
+		EndedAt:   j.EndedAt,
+	}
+}
+
+type Manager struct {
+	mu       sync.RWMutex
+	jobs     map[string]*Job
+	seq      int64
+	reasonix string
+}
+
+func NewManager(reasonixPath string) *Manager {
+	if reasonixPath == "" {
+		reasonixPath = "reasonix"
+	}
+	return &Manager{
+		jobs:     map[string]*Job{},
+		reasonix: reasonixPath,
+	}
+}
+
+func (m *Manager) Spawn(prompt, cwd, model string, maxSteps int) string {
+	id := fmt.Sprintf("wrk_%d", atomic.AddInt64(&m.seq, 1))
+	if model == "" {
+		model = "deepseek-flash"
+	}
+	if maxSteps <= 0 {
+		maxSteps = 50
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	args := []string{
+		"run", "--model", model,
+		"--max-steps", fmt.Sprintf("%d", maxSteps),
+		prompt,
+	}
+	cmd := exec.CommandContext(ctx, m.reasonix, args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	cmd.Env = os.Environ()
+	job := &Job{
+		ID: id, Prompt: prompt, Status: Running,
+		StartedAt: time.Now(), cmd: cmd, cancel: cancel,
+	}
+	m.mu.Lock()
+	m.jobs[id] = job
+	m.mu.Unlock()
+	go m.run(job)
+	return id
+}
+
+func (m *Manager) run(j *Job) {
+	output, err := j.cmd.CombinedOutput()
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.EndedAt = time.Now()
+	j.Output = string(output)
+	if err != nil {
+		if j.cmd.ProcessState != nil && !j.cmd.ProcessState.Exited() {
+			j.Status = Killed
+		} else {
+			j.Status = Failed
+			j.Error = err.Error()
+		}
+	} else {
+		j.Status = Done
+	}
+}
+
+func (m *Manager) Result(id string) (Job, bool) {
+	m.mu.RLock()
+	j, ok := m.jobs[id]
+	m.mu.RUnlock()
+	if !ok {
+		return Job{}, false
+	}
+	return j.Snapshot(), true
+}
+
+func (m *Manager) List() []Job {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]Job, 0, len(m.jobs))
+	for _, j := range m.jobs {
+		out = append(out, j.Snapshot())
+	}
+	return out
+}
+
+func (m *Manager) Kill(id string) bool {
+	m.mu.RLock()
+	j, ok := m.jobs[id]
+	m.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	j.mu.RLock()
+	alive := j.Status == Running
+	j.mu.RUnlock()
+	if !alive {
+		return false
+	}
+	j.cancel()
+	return true
+}
+
+func (m *Manager) Cleanup(age time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cutoff := time.Now().Add(-age)
+	for id, j := range m.jobs {
+		j.mu.RLock()
+		status := j.Status
+		ended := j.EndedAt
+		j.mu.RUnlock()
+		if status == Running {
+			j.cancel()
+		}
+		if status != Running && (age == 0 || ended.Before(cutoff)) {
+			delete(m.jobs, id)
+		}
+	}
+}
+
+func (m *Manager) Shutdown() { m.Cleanup(0) }
+
+func ResolveReasonix() string {
+	if exe, err := os.Executable(); err == nil {
+		if abs, err := filepath.Abs(exe); err == nil {
+			return abs
+		}
+	}
+	return "reasonix"
+}


### PR DESCRIPTION
Adds worker_spawn / worker_result / worker_list / worker_kill built-in tools that spawn background Reasonix instances as subprocesses. Workers inherit the full config (MCP, memory, API keys) and run in full isolation.

New files:
- internal/worker/worker.go   — goroutine-based worker manager
- internal/worker/context.go  — context injection for tools
- internal/tool/builtin/worker.go — 4 built-in tool implementations

Modified files:
- internal/agent/agent.go     — Agent struct + context wiring
- internal/boot/boot.go       — Worker Manager creation on startup
- internal/control/controller.go — Controller Options + struct

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
