### PR TITLE
Fix two locale/load-dependent test-isolation bugs (cli i18n, bash login-shell probe)

### DIFF
--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -32,6 +32,23 @@ type stubbornTurnRunner struct {
 func TestMain(m *testing.M) {
 	old := detectTermuxTerminal
 	detectTermuxTerminal = func() bool { return false }
+
+	// Pin the UI language for the whole cli test binary. Production code
+	// (cli.Run) calls i18n.DetectLanguage("") which resolves the host locale from
+	// the environment (REASONIX_LANG/LC_ALL/LC_MESSAGES/LANG) and installs it as
+	// the global i18n.M. On a non-English dev machine that flips M to e.g.
+	// Chinese, and tests that exercise the CLI entry point (acp_test.go,
+	// cli_test.go) don't restore it — so later tests asserting English UI strings
+	// fail, but only when the whole package runs, not in isolation. Forcing a
+	// deterministic English environment keeps the suite independent of the host
+	// locale (matching CI). Tests that need another language still set it
+	// explicitly via i18n.DetectLanguage(lang) with their own cleanup.
+	os.Unsetenv("REASONIX_LANG")
+	os.Unsetenv("LC_ALL")
+	os.Unsetenv("LC_MESSAGES")
+	os.Setenv("LANG", "en_US.UTF-8")
+	i18n.DetectLanguage("en")
+
 	code := m.Run()
 	detectTermuxTerminal = old
 	os.Exit(code)

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -26,12 +26,18 @@ func TestBashMergesLoginShellPath(t *testing.T) {
 	if err := os.WriteFile(probe, []byte("#!/bin/sh\nprintf 'shell-path-ok\\n'\n"), 0o755); err != nil {
 		t.Fatalf("write probe: %v", err)
 	}
-	loginShell := filepath.Join(dir, "login-shell")
-	if err := os.WriteFile(loginShell, []byte("#!/bin/sh\nprintf '\\n__REASONIX_BASH_PATH__=%s\\n' '"+bin+":/usr/bin:/bin"+"'\n"), 0o755); err != nil {
-		t.Fatalf("write login shell: %v", err)
-	}
 
-	t.Setenv("SHELL", loginShell)
+	// Inject a deterministic login-shell PATH instead of spawning a real login
+	// shell. The real probe (defaultBashShellPATH) runs up to three
+	// interactive-login shells with a 2s timeout each; under the CPU load of
+	// `go test ./...` it times out and returns an empty PATH, so this test failed
+	// with command-not-found only in the full suite, never in isolation. This
+	// test covers merging the probed PATH into the exec environment; the probe's
+	// own parsing/merging is covered by TestParseShellPATH and TestMergePathLists.
+	prev := bashShellPATH
+	bashShellPATH = func(context.Context) string { return bin + ":/usr/bin:/bin" }
+	t.Cleanup(func() { bashShellPATH = prev })
+
 	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
 
 	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "/bin/sh"}}
@@ -39,9 +45,54 @@ func TestBashMergesLoginShellPath(t *testing.T) {
 
 	out, err := b.Execute(context.Background(), args)
 	if err != nil {
-		t.Fatalf("command should resolve through login shell PATH: %v (out=%q)", err, out)
+		t.Fatalf("command should resolve through merged login-shell PATH: %v (out=%q)", err, out)
 	}
 	if !strings.Contains(out, "shell-path-ok") {
 		t.Fatalf("output = %q, want shell-path-ok", out)
+	}
+}
+
+func TestParseShellPATH(t *testing.T) {
+	const marker = "__REASONIX_BASH_PATH__="
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"simple", marker + "/usr/local/bin:/usr/bin\n", "/usr/local/bin:/usr/bin"},
+		{"crlf", "noise\r\n" + marker + "/opt/bin:/bin\r\n", "/opt/bin:/bin"},
+		{"last marker wins", marker + "/early\n" + marker + "/late\n", "/late"},
+		{"ignores surrounding output", "login banner\n" + marker + "/p\ntrailing\n", "/p"},
+		{"absent", "no marker here\n", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseShellPATH([]byte(c.out), marker); got != c.want {
+				t.Fatalf("parseShellPATH(%q) = %q, want %q", c.out, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMergePathLists(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	cases := []struct {
+		name      string
+		primary   string
+		secondary string
+		want      string
+	}{
+		{"dedupes, primary first", "/a" + sep + "/b", "/b" + sep + "/c", "/a" + sep + "/b" + sep + "/c"},
+		{"empty secondary", "/a" + sep + "/b", "", "/a" + sep + "/b"},
+		{"empty primary", "", "/x" + sep + "/y", "/x" + sep + "/y"},
+		{"skips blank entries", "/a" + sep + sep + "/b", "", "/a" + sep + "/b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mergePathLists(c.primary, c.secondary); got != c.want {
+				t.Fatalf("mergePathLists(%q, %q) = %q, want %q", c.primary, c.secondary, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Two pre-existing `main-v2` test-isolation bugs that fail locally but pass in CI because they depend on the developer's environment (host locale / CPU load) rather than the code under test. Both surfaced while reviewing an unrelated change on a `zh_CN.UTF-8` machine; neither is specific to that work.

### 1. cli tests leak the host locale into global `i18n.M`

`cli.Run()` calls `i18n.DetectLanguage("")`, which resolves the host locale from the environment and installs it as the global `i18n.M`. Tests that exercise the CLI entry point (`acp_test.go`'s `Run(["--acp"])`, `cli_test.go`'s `Run(["version"])`, …) leave `M` set without restoring it. On a non-English machine `M` flips to e.g. Chinese, so five later tests asserting English UI strings fail — but only when the whole `internal/cli` package runs, never in isolation:

- `TestIngestSeparatesReasoningFromAnswer`
- `TestVerboseReasoningInsertsTextUnderSummary`
- `TestToolWorkingLineThenClears`
- `TestClearCommandRequiresConfirmationAndDiscardsSession`
- `TestIngestEventRoutesByKind`

**Fix:** pin a deterministic English environment in cli's existing `TestMain`. Tests that need another language still set it explicitly via `i18n.DetectLanguage(lang)` with their own cleanup.

### 2. `TestBashMergesLoginShellPath` flakes under full-suite load

The test spawned a real login shell to probe its PATH, but `defaultBashShellPATH` runs up to three interactive-login shells with a 2s timeout each. Under the CPU load of `go test ./...` the probe times out and returns an empty PATH, so the test fails with command-not-found — only in the full suite, never in isolation or in the `builtin` package alone.

**Fix:** inject a deterministic PATH via the `bashShellPATH` function var (which exists for exactly this seam) so the test no longer spawns a real shell. Adds `TestParseShellPATH` and `TestMergePathLists` covering the probe's parsing/merging directly — these pure functions had no unit test, so coverage increases rather than drops.

## Cache Impact

Cache-impact: none - This PR only changes Go test files; it does not alter provider-visible prompts, tool schemas, request serialization, compaction, memory, or runtime tool behavior.
Cache-guard: Test-only diff reviewed for provider-visible surfaces; focused checks: `go test ./internal/cli ./internal/tool/builtin`, `REASONIX_LANG=zh LC_ALL=zh_CN.UTF-8 LANG=zh_CN.UTF-8 go test ./internal/cli -shuffle=on`, and `go test ./internal/tool/builtin -run 'TestBashMergesLoginShellPath|TestParseShellPATH|TestMergePathLists'`.

## Testing

- `go test ./...` — full suite green (exit 0, 53 packages ok); all 6 previously-failing tests pass.
- `go test ./internal/cli/ -shuffle=on` — order-independent (the pollution was order-dependent).
- `go vet ./...` clean.
- Verified on a `zh_CN.UTF-8` host (the trigger environment) where the failures reproduce on unmodified `main-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
