### PR TITLE
fix(desktop): disable Linux webview GPU without DRI

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -183,11 +183,11 @@ the **native** webview per OS, so the rough edges are platform-specific. What's
 handled here, and what to reach for if a target misbehaves:
 
 - **Linux / WebKitGTK** is the one real pain point — rendering varies by distro &
-  GPU driver. `main.go` sets `WebviewGpuPolicy: OnDemand` to avoid blank/flickering
-  webviews from forced compositing. If artifacts persist, launch with
-  `WEBKIT_DISABLE_COMPOSITING_MODE=1`. Test on at least one GTK target before
-  release; the CSS deliberately avoids `backdrop-filter`/blur (slow & inconsistent
-  there).
+  GPU driver. `main.go` keeps `WebviewGpuPolicy: OnDemand` when a DRI render node
+  is usable, and falls back to `Never` for xrdp/headless/software-rendered sessions
+  that cannot access `/dev/dri`. If artifacts persist, launch with
+  `WEBKIT_DISABLE_COMPOSITING_MODE=1`. Test on at least one GTK target before release;
+  the CSS deliberately avoids `backdrop-filter`/blur (slow & inconsistent there).
   - **Wayland + NVIDIA**: On KDE Plasma Wayland with NVIDIA GPUs, WebKitGTK can
     crash at startup (`Error 71: Protocol error`) due to an upstream WebKit
     explicit-sync bug (WebKit #280210, #317089, NVIDIA/egl-wayland #179).

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"embed"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/wailsapp/wails/v2"
@@ -47,7 +48,10 @@ var channel = "stable"
 // macOS release builds. Local/ad-hoc macOS builds keep the manual download path.
 var macSelfUpdate = "false"
 
-const disableWebview2GPUEnv = "REASONIX_DESKTOP_DISABLE_WEBVIEW2_GPU"
+const (
+	disableWebview2GPUEnv  = "REASONIX_DESKTOP_DISABLE_WEBVIEW2_GPU"
+	linuxDRIRenderNodeGlob = "/dev/dri/renderD*"
+)
 
 func macSelfUpdateAllowed() bool {
 	switch strings.ToLower(strings.TrimSpace(macSelfUpdate)) {
@@ -68,6 +72,20 @@ func windowsWebview2GPUDisabled() bool {
 		}
 	}
 	return channel == "canary"
+}
+
+func linuxWebviewGpuPolicy(pattern string) linux.WebviewGpuPolicy {
+	matches, err := filepath.Glob(pattern)
+	if err == nil {
+		for _, path := range matches {
+			f, err := os.OpenFile(path, os.O_RDWR, 0)
+			if err == nil {
+				_ = f.Close()
+				return linux.WebviewGpuPolicyOnDemand
+			}
+		}
+	}
+	return linux.WebviewGpuPolicyNever
 }
 
 func main() {
@@ -133,9 +151,10 @@ func main() {
 			// WebKitGTK GPU compositing is inconsistent across distros/drivers and
 			// is the one real cross-platform rough edge for a Go+webview stack:
 			// "always" can yield blank or flickering webviews on some setups, so
-			// we let the webview decide on demand. Users still hitting artifacts
-			// can fall back to WEBKIT_DISABLE_COMPOSITING_MODE=1 (see README).
-			WebviewGpuPolicy: linux.WebviewGpuPolicyOnDemand,
+			// we let the webview decide on demand when a render node is usable, and
+			// disable acceleration when remote/software-rendered sessions cannot
+			// access /dev/dri.
+			WebviewGpuPolicy: linuxWebviewGpuPolicy(linuxDRIRenderNodeGlob),
 		},
 	})
 	if err != nil {

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/options/linux"
 )
 
 // TestMain isolates user config/state/cache dirs for the whole package. Without
@@ -58,5 +61,35 @@ func TestWindowsWebview2GPUDisabled(t *testing.T) {
 				t.Fatalf("windowsWebview2GPUDisabled() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLinuxWebviewGpuPolicyDisablesGpuWithoutAccessibleRenderNode(t *testing.T) {
+	glob := filepath.Join(t.TempDir(), "renderD*")
+
+	if got := linuxWebviewGpuPolicy(glob); got != linux.WebviewGpuPolicyNever {
+		t.Fatalf("linuxWebviewGpuPolicy() = %v, want %v", got, linux.WebviewGpuPolicyNever)
+	}
+}
+
+func TestLinuxWebviewGpuPolicyDisablesGpuForInaccessibleRenderNode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "renderD128"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := linuxWebviewGpuPolicy(filepath.Join(dir, "renderD*")); got != linux.WebviewGpuPolicyNever {
+		t.Fatalf("linuxWebviewGpuPolicy() = %v, want %v", got, linux.WebviewGpuPolicyNever)
+	}
+}
+
+func TestLinuxWebviewGpuPolicyKeepsOnDemandWithAccessibleRenderNode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "renderD128"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := linuxWebviewGpuPolicy(filepath.Join(dir, "renderD*")); got != linux.WebviewGpuPolicyOnDemand {
+		t.Fatalf("linuxWebviewGpuPolicy() = %v, want %v", got, linux.WebviewGpuPolicyOnDemand)
 	}
 }


### PR DESCRIPTION
## Summary

- Code-confirmed #5229 as a Linux WebKitGTK software-rendering path: xrdp/Xorg sessions without usable DRI can leave WebKit on llvmpipe while `WebviewGpuPolicyOnDemand` is enabled.
- Keep Linux webview GPU policy on `OnDemand` only when a `/dev/dri/renderD*` node can be opened, and fall back to `Never` otherwise.
- Update the desktop Linux/WebKitGTK note to document the DRI-aware policy and keep normal GPU-backed Linux sessions unchanged.

## Verification

- `cd desktop && go test . -count=1 -run 'TestLinuxWebviewGpuPolicy|TestWindowsWebview2GPUDisabled'`
- `cd desktop && go test . -count=1`

## Cache impact

Cache-impact: none, desktop WebKitGTK startup policy and docs only; no provider-visible prompt/tool/cache-sensitive path changes.
Cache-guard: n/a — desktop-only change outside scripts/check-cache-impact.sh sensitive paths.
System-prompt-review: N/A

Closes #5229
