### PR TITLE
fix: Stop hook 使用 context.Background() 替代已取消的 ctx

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1115,7 +1115,7 @@ func (c *Controller) Run(ctx context.Context, input string) error {
 		if block, _ := c.hooks.PromptSubmit(ctx, input, c.turn); block {
 			return nil
 		}
-		defer func() { c.hooks.Stop(ctx, lastAssistantText(c.History()), c.turn) }()
+		defer func() { c.hooks.Stop(context.Background(), lastAssistantText(c.History()), c.turn) }()
 	}
 	return c.runner.Run(ctx, input)
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -70,6 +70,15 @@ func (r *sessionContextRunner) Run(ctx context.Context, input string) error {
 	return nil
 }
 
+type cancelingRunner struct {
+	cancel context.CancelFunc
+}
+
+func (r cancelingRunner) Run(_ context.Context, _ string) error {
+	r.cancel()
+	return nil
+}
+
 type fakeControlTool struct{ name string }
 
 func (t fakeControlTool) Name() string { return t.name }
@@ -291,6 +300,39 @@ func TestRunInjectsParentSessionForJobs(t *testing.T) {
 	}
 	if runner.jobSession != want {
 		t.Fatalf("jobs session = %q, want %q", runner.jobSession, want)
+	}
+}
+
+func TestRunStopHookIgnoresCanceledCallerContext(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	var stopCalls int
+	var stopErr error
+	hooks := hook.NewRunner([]hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "record-stop"},
+		Event:      hook.Stop,
+		Scope:      hook.ScopeProject,
+	}}, "", func(ctx context.Context, in hook.SpawnInput) hook.SpawnResult {
+		stopCalls++
+		stopErr = ctx.Err()
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+	c := New(Options{
+		Runner: cancelingRunner{cancel: cancel},
+		Hooks:  hooks,
+	})
+
+	if err := c.Run(runCtx, "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	if runCtx.Err() != context.Canceled {
+		t.Fatalf("caller context err = %v, want %v", runCtx.Err(), context.Canceled)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("Stop hook calls = %d, want 1", stopCalls)
+	}
+	if stopErr != nil {
+		t.Fatalf("Stop hook context err = %v, want nil", stopErr)
 	}
 }
 

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -44,7 +44,7 @@ func (o *turnOrchestrator) runTurnWithRawDisplay(ctx context.Context, input, raw
 		if block, _ := c.hooks.PromptSubmit(ctx, input, turn); block {
 			return nil // the hook's notify callback already surfaced the reason
 		}
-		defer func() { c.hooks.Stop(ctx, lastAssistantText(c.History()), turn) }()
+		defer func() { c.hooks.Stop(context.Background(), lastAssistantText(c.History()), turn) }()
 	}
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -270,3 +270,32 @@ func TestTurnOrchestratorCheckpointBoundaryPrecedesUserMessage(t *testing.T) {
 		t.Fatalf("session messages after rewind = %d, want boundary before user message", len(sess.Messages))
 	}
 }
+
+func TestTurnOrchestratorStopHookCancelledContext(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	var stopCalls int
+	hooks := hook.NewRunner([]hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "stop"},
+		Event:      hook.Stop,
+		Scope:      hook.ScopeProject,
+	}}, "", func(ctx context.Context, in hook.SpawnInput) hook.SpawnResult {
+		if ctx.Err() != nil {
+			t.Errorf("Stop hook spawner ctx.Err()=%v; want nil", ctx.Err())
+		}
+		var p hook.Payload
+		json.Unmarshal([]byte(in.Stdin), &p)
+		if p.Event == hook.Stop { stopCalls++ }
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+	c := New(Options{Runner: ag, Executor: ag, Hooks: hooks})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	o := newTurnOrchestrator(c)
+	if err := o.runTurnWithRawDisplay(ctx, "test", "test", ""); err != nil && err != context.Canceled {
+		t.Fatal(err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("Stop hooks called = %d; want 1", stopCalls)
+	}
+}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -33,6 +33,40 @@ func TestTurnOrchestratorRunsForegroundUnit(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorStopHookIgnoresCanceledTurnContext(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	var stopCalls int
+	var stopErr error
+	hooks := hook.NewRunner([]hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "record-stop"},
+		Event:      hook.Stop,
+		Scope:      hook.ScopeProject,
+	}}, "", func(ctx context.Context, in hook.SpawnInput) hook.SpawnResult {
+		stopCalls++
+		stopErr = ctx.Err()
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+	c := New(Options{
+		Runner: cancelingRunner{cancel: cancel},
+		Hooks:  hooks,
+	})
+
+	o := newTurnOrchestrator(c)
+	if err := o.runTurnWithRawDisplay(runCtx, "hello", "hello", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if runCtx.Err() != context.Canceled {
+		t.Fatalf("turn context err = %v, want %v", runCtx.Err(), context.Canceled)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("Stop hook calls = %d, want 1", stopCalls)
+	}
+	if stopErr != nil {
+		t.Fatalf("Stop hook context err = %v, want nil", stopErr)
+	}
+}
+
 type recordingSessionRunner struct {
 	session              *agent.Session
 	inputs               []string

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -285,7 +285,9 @@ func TestTurnOrchestratorStopHookCancelledContext(t *testing.T) {
 		}
 		var p hook.Payload
 		json.Unmarshal([]byte(in.Stdin), &p)
-		if p.Event == hook.Stop { stopCalls++ }
+		if p.Event == hook.Stop {
+			stopCalls++
+		}
 		return hook.SpawnResult{ExitCode: 0}
 	}, nil)
 	c := New(Options{Runner: ag, Executor: ag, Hooks: hooks})


### PR DESCRIPTION
## 概要

用户点击 Stop（或 Esc）取消正在运行的回复时，Stop hook 虽然通过 defer 触发，但 shell 命令无法执行——turn context 已被 `Controller.Cancel()` 取消，`exec.CommandContext(cancelledCtx, ...)` 立即失败。

本 PR 将 `ctx` 替换为 `context.Background()`，使清理 hook 不受取消影响。

## 关联 Issue

Closes #5281

## 变更

`internal/control/turn_orchestrator.go` —— 一行：

```
- defer func() { c.hooks.Stop(ctx, ...) }()
+ defer func() { c.hooks.Stop(context.Background(), ...) }()
```

## 为什么用 context.Background()

- Stop 是非阻塞清理 hook，不是门控事件
- 不需要 turn context，只执行用户配置的命令
- `context.Background()` 给 hook 干净的 30s 超时窗口

## 验证

- `go build ./cmd/reasonix` 通过
- 本地编译桌面版测试：取消后 Stop hook 正常执行

Cache-impact: none
Cache-guard: existing hook tests in internal/hook/