### PR TITLE
feat(i18n): add MB unit to download progress display

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1574,7 +1574,7 @@ export const en = {
   "updater.installNow": "Update now",
   "updater.goToDownload": "Go to download page",
   "updater.macHint": "Automatic install isn't available for this macOS build — please download and install manually.",
-  "updater.downloading": "Downloading… {done} / {total} ({pct}%)",
+  "updater.downloading": "Downloading… {done} MB / {total} MB ({pct}%)",
   "updater.verifying": "Verifying signature…",
   "updater.installing": "Installing — Reasonix will restart…",
   "updater.applying": "Installing…",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1009,7 +1009,7 @@ export const zhTW: Record<DictKey, string> = {
   "updater.installNow": "立即更新",
   "updater.goToDownload": "前往下載頁",
   "updater.macHint": "目前 macOS 建置暫不支援自動安裝，請前往下載頁手動安裝。",
-  "updater.downloading": "下載中… {done} / {total}（{pct}%）",
+  "updater.downloading": "下載中… {done} MB / {total} MB（{pct}%）",
   "updater.verifying": "正在驗證簽章…",
   "updater.installing": "正在安裝，應用程式即將重新啟動…",
   "updater.applying": "正在安裝…",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1576,7 +1576,7 @@ export const zh: Record<DictKey, string> = {
   "updater.installNow": "立即更新",
   "updater.goToDownload": "前往下载页",
   "updater.macHint": "当前 macOS 构建暂不支持自动安装，请前往下载页手动安装。",
-  "updater.downloading": "下载中… {done} / {total}（{pct}%）",
+  "updater.downloading": "下载中… {done} MB / {total} MB（{pct}%）",
   "updater.verifying": "正在验证签名…",
   "updater.installing": "正在安装，应用即将重启…",
   "updater.applying": "正在安装…",


### PR DESCRIPTION
Show 'MB' after the numeric values in the updater's downloading status text across all three locales (en, zh, zh-TW).

<img width="830" height="250" alt="image" src="https://github.com/user-attachments/assets/305feb75-d3ff-4fc6-94c7-e9192e133fd3" />


## Summary

```
  "updater.downloading": "下载中… {done} / {total}（{pct}%）",
```

to

```
  "updater.downloading": "下载中… {done} MB / {total} MB（{pct}%）",
```



## Cache impact

NO
