### PR TITLE
fix(serve/auth): handle crypto/rand.Read error in signSession

### DIFF
--- a/internal/serve/auth.go
+++ b/internal/serve/auth.go
@@ -458,8 +458,10 @@ func (ag *authGate) signSession() string {
 	nonce := make([]byte, 16)
 	if _, err := rand.Read(nonce); err != nil {
 		// crypto/rand.Read cannot fail on modern systems; panic rather than
-		// fall back to an all-zero nonce that would make the session cookie
-		// trivially forgeable and bypass authentication.
+		// fall back to an all-zero nonce. Forging a cookie still requires the
+		// PBKDF2-derived sessKey, so this is not an auth bypass, but a constant
+		// nonce weakens session token uniqueness/unpredictability and is the
+		// same anti-pattern generateToken/sessionKeyForPasswordHash panic on.
 		panic("serve/auth: crypto/rand.Read failed: " + err.Error())
 	}
 

--- a/internal/serve/auth.go
+++ b/internal/serve/auth.go
@@ -456,7 +456,12 @@ func redirectToSafeTarget(w http.ResponseWriter, r *http.Request, raw string, st
 func (ag *authGate) signSession() string {
 	expiry := time.Now().Add(sessionDuration).Unix()
 	nonce := make([]byte, 16)
-	_, _ = rand.Read(nonce)
+	if _, err := rand.Read(nonce); err != nil {
+		// crypto/rand.Read cannot fail on modern systems; panic rather than
+		// fall back to an all-zero nonce that would make the session cookie
+		// trivially forgeable and bypass authentication.
+		panic("serve/auth: crypto/rand.Read failed: " + err.Error())
+	}
 
 	payload := strconv.FormatInt(expiry, 10) + "|" + base64.RawURLEncoding.EncodeToString(nonce)
 	mac := hmac.New(sha256.New, ag.sessKey)


### PR DESCRIPTION
signSession() silently discarded the error from rand.Read, leaving the
session nonce all-zero on failure. While this does not directly bypass
authentication (forging a cookie still requires the PBKDF2-derived
sessKey), it weakens the unpredictability of password-mode session
cookies and is an explicit anti-pattern inconsistent with the same
file's generateToken() and sessionKeyForPasswordHash(), both of which
panic on rand.Read failure.

Now panics with a descriptive message, matching the existing convention.