### PR TITLE
fix(cli/mcp): prevent command injection via $EDITOR/$VISUAL

### DIFF
--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -324,14 +324,22 @@ func mcpEditConfigLaunchCommand(path string, lookPath func(string) (string, erro
 		return mcpEditConfigLaunch{}, fmt.Errorf("no config path available")
 	}
 	if editor := strings.TrimSpace(os.Getenv("VISUAL")); editor != "" {
+		cmd, err := editorLaunchCmd(editor, path)
+		if err != nil {
+			return mcpEditConfigLaunch{}, err
+		}
 		return mcpEditConfigLaunch{
-			cmd:    exec.Command("sh", "-lc", editor+" "+shellQuote(path)),
+			cmd:    cmd,
 			editor: mcpEditorDisplayName(editor),
 		}, nil
 	}
 	if editor := strings.TrimSpace(os.Getenv("EDITOR")); editor != "" {
+		cmd, err := editorLaunchCmd(editor, path)
+		if err != nil {
+			return mcpEditConfigLaunch{}, err
+		}
 		return mcpEditConfigLaunch{
-			cmd:    exec.Command("sh", "-lc", editor+" "+shellQuote(path)),
+			cmd:    cmd,
 			editor: mcpEditorDisplayName(editor),
 		}, nil
 	}
@@ -354,7 +362,7 @@ func mcpEditConfigLaunchCommand(path string, lookPath func(string) (string, erro
 }
 
 func mcpEditorDisplayName(editor string) string {
-	fields := strings.Fields(editor)
+	fields := strings.Fields(os.ExpandEnv(editor))
 	if len(fields) == 0 {
 		return ""
 	}
@@ -417,8 +425,55 @@ func mcpConnected(ctrl control.Capabilities, name string) bool {
 	return false
 }
 
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+// editorLaunchCmd builds an exec.Cmd for an editor invocation read from the
+// VISUAL/EDITOR environment variable. The editor string may carry arguments
+// (e.g. "code --wait", "nvim -p") and shell variable / tilde references
+// (e.g. "$HOME/bin/myeditor", "~/bin/myeditor"); these are expanded without
+// invoking a shell, and the editor binary is resolved by the OS directly.
+// Shell metacharacters in the value cannot be executed — the entire value
+// is split into argv via strings.Fields after expansion, so a value like
+// "vim; rm -rf ~" becomes the literal argv ["vim;", "rm", "-rf", "<home>"]
+// and "vim;" is looked up as the program name (failing harmlessly) rather
+// than being interpreted by a shell.
+//
+// This matches the safe pattern already used by the terminal-editor
+// fallback (exec.Command(bin, path)) in the same function and avoids the
+// previous sh -lc construction that concatenated the raw editor value into
+// a shell command string.
+//
+// strings.Fields does not honor shell quoting, so an editor path containing
+// literal whitespace is unsupported — but that was already broken under the
+// prior sh -lc construction for any value not wrapped in single quotes, and
+// no common EDITOR/VISUAL value requires it. Tilde expansion only covers
+// the leading-token forms "~" and "~/..."; "~user" is not supported (and
+// was not reliably supported by the prior sh -lc path either, since $HOME
+// for another user is not available without getpwuid).
+func editorLaunchCmd(editor, path string) (*exec.Cmd, error) {
+	expanded := os.ExpandEnv(editor)
+	args := strings.Fields(expanded)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("invalid EDITOR/VISUAL value: %q", editor)
+	}
+	args[0] = expandLeadingTilde(args[0])
+	return exec.Command(args[0], append(args[1:], path)...), nil
+}
+
+// expandLeadingTilde replaces a leading "~" or "~/" prefix with the current
+// user's home directory. Other forms (e.g. "~user") are returned unchanged.
+// If the home directory cannot be determined the value is returned as-is so
+// the caller surfaces the exec failure rather than panicking.
+func expandLeadingTilde(p string) string {
+	if p != "~" && !strings.HasPrefix(p, "~/") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	if p == "~" {
+		return home
+	}
+	return home + p[1:]
 }
 
 func mcpBoolPtr(v bool) *bool { return &v }

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -362,8 +363,8 @@ func mcpEditConfigLaunchCommand(path string, lookPath func(string) (string, erro
 }
 
 func mcpEditorDisplayName(editor string) string {
-	fields := strings.Fields(os.ExpandEnv(editor))
-	if len(fields) == 0 {
+	fields, err := splitEditorCommand(os.ExpandEnv(editor))
+	if err != nil || len(fields) == 0 {
 		return ""
 	}
 	return fields[0]
@@ -430,32 +431,89 @@ func mcpConnected(ctrl control.Capabilities, name string) bool {
 // (e.g. "code --wait", "nvim -p") and shell variable / tilde references
 // (e.g. "$HOME/bin/myeditor", "~/bin/myeditor"); these are expanded without
 // invoking a shell, and the editor binary is resolved by the OS directly.
-// Shell metacharacters in the value cannot be executed — the entire value
-// is split into argv via strings.Fields after expansion, so a value like
-// "vim; rm -rf ~" becomes the literal argv ["vim;", "rm", "-rf", "<home>"]
-// and "vim;" is looked up as the program name (failing harmlessly) rather
-// than being interpreted by a shell.
+// Shell metacharacters in the value cannot be executed: the expanded value is
+// parsed only into argv words, so a value like "vim; rm -rf ~" becomes the
+// literal argv ["vim;", "rm", "-rf", "~/..."] and "vim;" is looked up as the
+// program name (failing harmlessly) rather than being interpreted by a shell.
 //
 // This matches the safe pattern already used by the terminal-editor
 // fallback (exec.Command(bin, path)) in the same function and avoids the
 // previous sh -lc construction that concatenated the raw editor value into
 // a shell command string.
 //
-// strings.Fields does not honor shell quoting, so an editor path containing
-// literal whitespace is unsupported — but that was already broken under the
-// prior sh -lc construction for any value not wrapped in single quotes, and
-// no common EDITOR/VISUAL value requires it. Tilde expansion only covers
-// the leading-token forms "~" and "~/..."; "~user" is not supported (and
-// was not reliably supported by the prior sh -lc path either, since $HOME
-// for another user is not available without getpwuid).
+// Quoting and backslash escaping are honored for word splitting only; shell
+// operators, globbing, command substitution, and redirection are not evaluated.
+// Tilde expansion only covers the leading-token forms "~" and "~/..."; "~user"
+// is not supported (and was not reliably supported by the prior sh -lc path
+// either, since $HOME for another user is not available without getpwuid).
 func editorLaunchCmd(editor, path string) (*exec.Cmd, error) {
 	expanded := os.ExpandEnv(editor)
-	args := strings.Fields(expanded)
+	args, err := splitEditorCommand(expanded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid EDITOR/VISUAL value: %w", err)
+	}
 	if len(args) == 0 {
 		return nil, fmt.Errorf("invalid EDITOR/VISUAL value: %q", editor)
 	}
 	args[0] = expandLeadingTilde(args[0])
 	return exec.Command(args[0], append(args[1:], path)...), nil
+}
+
+func splitEditorCommand(s string) ([]string, error) {
+	var args []string
+	var b strings.Builder
+	var quote rune
+	escaped := false
+	escapedQuote := rune(0)
+	inWord := false
+
+	flush := func() {
+		if inWord {
+			args = append(args, b.String())
+			b.Reset()
+			inWord = false
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case escaped:
+			if escapedQuote == '"' && r != '$' && r != '`' && r != '"' && r != '\\' {
+				b.WriteRune('\\')
+			}
+			b.WriteRune(r)
+			inWord = true
+			escaped = false
+			escapedQuote = 0
+		case r == '\\' && quote != '\'':
+			inWord = true
+			escaped = true
+			escapedQuote = quote
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				b.WriteRune(r)
+			}
+			inWord = true
+		case r == '\'' || r == '"':
+			quote = r
+			inWord = true
+		case unicode.IsSpace(r):
+			flush()
+		default:
+			b.WriteRune(r)
+			inWord = true
+		}
+	}
+	if escaped {
+		b.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %q quote", quote)
+	}
+	flush()
+	return args, nil
 }
 
 // expandLeadingTilde replaces a leading "~" or "~/" prefix with the current

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -331,11 +331,157 @@ func TestMCPEditConfigLaunchUsesVisualBeforeEditor(t *testing.T) {
 	if launch.editor != "vim" {
 		t.Fatalf("editor = %q, want vim", launch.editor)
 	}
-	if len(launch.cmd.Args) != 3 || launch.cmd.Args[0] != "sh" || launch.cmd.Args[1] != "-lc" {
-		t.Fatalf("VISUAL should run through shell, args=%v", launch.cmd.Args)
+	// VISUAL must run the editor binary directly (not via sh -lc) so that
+	// shell metacharacters in the env value cannot be executed. argv is
+	// [editorBinary, path].
+	if len(launch.cmd.Args) != 2 || launch.cmd.Args[0] != "vim" || launch.cmd.Args[1] != path {
+		t.Fatalf("VISUAL should invoke editor binary directly, args=%v", launch.cmd.Args)
 	}
-	if want := "vim " + shellQuote(path); launch.cmd.Args[2] != want {
-		t.Fatalf("shell command = %q, want %q", launch.cmd.Args[2], want)
+}
+
+// TestMCPEditConfigLaunchEditorWithArgs confirms that an EDITOR/VISUAL value
+// carrying arguments (e.g. "code --wait") is split into argv correctly and
+// the path is appended as the final argument, without going through a shell.
+func TestMCPEditConfigLaunchEditorWithArgs(t *testing.T) {
+	t.Setenv("VISUAL", "code --wait")
+	t.Setenv("EDITOR", "")
+
+	path := "/tmp/reasonix.toml"
+	launch, err := mcpEditConfigLaunchCommand(path, func(string) (string, error) {
+		t.Fatal("lookPath should not be called when VISUAL is set")
+		return "", errors.New("unexpected lookup")
+	})
+	if err != nil {
+		t.Fatalf("edit command: %v", err)
+	}
+	if launch.editor != "code" {
+		t.Fatalf("editor display name = %q, want code", launch.editor)
+	}
+	want := []string{"code", "--wait", path}
+	if len(launch.cmd.Args) != len(want) {
+		t.Fatalf("args length = %d, want %d, args=%v", len(launch.cmd.Args), len(want), launch.cmd.Args)
+	}
+	for i, w := range want {
+		if launch.cmd.Args[i] != w {
+			t.Fatalf("args[%d] = %q, want %q, full args=%v", i, launch.cmd.Args[i], w, launch.cmd.Args)
+		}
+	}
+}
+
+// TestMCPEditConfigLaunchEditorRejectsShellMetachars confirms that shell
+// metacharacters in EDITOR/VISUAL are treated as literal argv tokens and
+// never executed as a shell command — the previous sh -lc construction would
+// have run "rm" here.
+func TestMCPEditConfigLaunchEditorRejectsShellMetachars(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "vim; rm -rf /tmp/should-not-exist")
+
+	path := "/tmp/reasonix.toml"
+	launch, err := mcpEditConfigLaunchCommand(path, func(string) (string, error) {
+		t.Fatal("lookPath should not be called when EDITOR is set")
+		return "", errors.New("unexpected lookup")
+	})
+	if err != nil {
+		t.Fatalf("edit command: %v", err)
+	}
+	// The entire EDITOR value is split on whitespace, so "vim;", "rm", "-rf",
+	// and the path become separate argv tokens — none of them are interpreted
+	// by a shell. The first token "vim;" is the (literal) program name; the
+	// shell injection payload "rm" is just an argument to it.
+	wantFirst := "vim;"
+	if launch.cmd.Args[0] != wantFirst {
+		t.Fatalf("first arg = %q, want %q (shell metachars must not be executed)", launch.cmd.Args[0], wantFirst)
+	}
+	if launch.cmd.Args[len(launch.cmd.Args)-1] != path {
+		t.Fatalf("last arg should be path, args=%v", launch.cmd.Args)
+	}
+}
+
+// TestMCPEditConfigLaunchEditorExpandsEnvVar confirms that $VAR references
+// in EDITOR/VISUAL are expanded without going through a shell, preserving
+// the behavior of the prior sh -lc path for users who set values such as
+// EDITOR="$HOME/bin/myeditor" verbatim (rather than relying on the shell
+// to expand at export time).
+func TestMCPEditConfigLaunchEditorExpandsEnvVar(t *testing.T) {
+	t.Setenv("REASONIX_TEST_EDITOR_BIN", "/opt/custom/bin/myed")
+	t.Setenv("VISUAL", "$REASONIX_TEST_EDITOR_BIN --flag")
+	t.Setenv("EDITOR", "")
+
+	path := "/tmp/reasonix.toml"
+	launch, err := mcpEditConfigLaunchCommand(path, func(string) (string, error) {
+		t.Fatal("lookPath should not be called when VISUAL is set")
+		return "", errors.New("unexpected lookup")
+	})
+	if err != nil {
+		t.Fatalf("edit command: %v", err)
+	}
+	want := []string{"/opt/custom/bin/myed", "--flag", path}
+	if len(launch.cmd.Args) != len(want) {
+		t.Fatalf("args length = %d, want %d, args=%v", len(launch.cmd.Args), len(want), launch.cmd.Args)
+	}
+	for i, w := range want {
+		if launch.cmd.Args[i] != w {
+			t.Fatalf("args[%d] = %q, want %q, full args=%v", i, launch.cmd.Args[i], w, launch.cmd.Args)
+		}
+	}
+}
+
+// TestMCPEditConfigLaunchEditorExpandsTilde confirms that a leading ~ or ~/
+// in EDITOR/VISUAL is expanded to the user's home directory without a shell.
+func TestMCPEditConfigLaunchEditorExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home dir: %v", err)
+	}
+	cases := []struct {
+		name   string
+		editor string
+		want0  string
+	}{
+		{"tilde_slash", "~/bin/myed", home + "/bin/myed"},
+		{"bare_tilde", "~", home},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("VISUAL", c.editor+" --wait")
+			t.Setenv("EDITOR", "")
+			launch, err := mcpEditConfigLaunchCommand("/tmp/reasonix.toml", func(string) (string, error) {
+				t.Fatal("lookPath should not be called when VISUAL is set")
+				return "", errors.New("unexpected lookup")
+			})
+			if err != nil {
+				t.Fatalf("edit command: %v", err)
+			}
+			if launch.cmd.Args[0] != c.want0 {
+				t.Fatalf("args[0] = %q, want %q", launch.cmd.Args[0], c.want0)
+			}
+			if launch.cmd.Args[1] != "--wait" {
+				t.Fatalf("args[1] = %q, want --wait", launch.cmd.Args[1])
+			}
+		})
+	}
+}
+
+// TestMCPEditConfigLaunchEditorTildeNotInPayload confirms that a tilde
+// appearing in an injection payload (not as the leading token) is left
+// untouched and is NOT expanded into a path the shell would then execute.
+func TestMCPEditConfigLaunchEditorTildeNotInPayload(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "vim; rm -rf ~/should-not-exist")
+
+	launch, err := mcpEditConfigLaunchCommand("/tmp/reasonix.toml", func(string) (string, error) {
+		t.Fatal("lookPath should not be called when EDITOR is set")
+		return "", errors.New("unexpected lookup")
+	})
+	if err != nil {
+		t.Fatalf("edit command: %v", err)
+	}
+	// The tilde sits in the middle of the value, so it is NOT expanded; the
+	// leading token "vim;" is looked up literally and the payload "rm" never
+	// runs. This proves tilde expansion cannot be abused to make an injection
+	// payload resolve to a real path.
+	if launch.cmd.Args[0] != "vim;" {
+		t.Fatalf("args[0] = %q, want vim;", launch.cmd.Args[0])
 	}
 }
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -368,6 +368,79 @@ func TestMCPEditConfigLaunchEditorWithArgs(t *testing.T) {
 	}
 }
 
+func TestMCPEditConfigLaunchEditorParsesShellStyleQuotes(t *testing.T) {
+	path := "/tmp/reasonix.toml"
+	cases := []struct {
+		name       string
+		editor     string
+		wantEditor string
+		wantArgs   []string
+	}{
+		{
+			name:       "empty fallback arg",
+			editor:     "emacsclient -c -a ''",
+			wantEditor: "emacsclient",
+			wantArgs:   []string{"emacsclient", "-c", "-a", "", path},
+		},
+		{
+			name:       "quoted editor path",
+			editor:     "'/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code' --wait",
+			wantEditor: "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+			wantArgs:   []string{"/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code", "--wait", path},
+		},
+		{
+			name:       "escaped whitespace",
+			editor:     `/opt/My\ Editor/bin/edit --flag`,
+			wantEditor: "/opt/My Editor/bin/edit",
+			wantArgs:   []string{"/opt/My Editor/bin/edit", "--flag", path},
+		},
+		{
+			name:       "quoted arg",
+			editor:     `nvim --cmd "set tabstop=2"`,
+			wantEditor: "nvim",
+			wantArgs:   []string{"nvim", "--cmd", "set tabstop=2", path},
+		},
+		{
+			name:       "double quoted literal backslashes",
+			editor:     `nvim "C:\tmp\file"`,
+			wantEditor: "nvim",
+			wantArgs:   []string{"nvim", `C:\tmp\file`, path},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("VISUAL", c.editor)
+			t.Setenv("EDITOR", "")
+			launch, err := mcpEditConfigLaunchCommand(path, func(string) (string, error) {
+				t.Fatal("lookPath should not be called when VISUAL is set")
+				return "", errors.New("unexpected lookup")
+			})
+			if err != nil {
+				t.Fatalf("edit command: %v", err)
+			}
+			if launch.editor != c.wantEditor {
+				t.Fatalf("editor display name = %q, want %q", launch.editor, c.wantEditor)
+			}
+			if !reflect.DeepEqual(launch.cmd.Args, c.wantArgs) {
+				t.Fatalf("args = %#v, want %#v", launch.cmd.Args, c.wantArgs)
+			}
+		})
+	}
+}
+
+func TestMCPEditConfigLaunchEditorRejectsUnterminatedQuote(t *testing.T) {
+	t.Setenv("VISUAL", `code --wait "unterminated`)
+	t.Setenv("EDITOR", "")
+
+	_, err := mcpEditConfigLaunchCommand("/tmp/reasonix.toml", func(string) (string, error) {
+		t.Fatal("lookPath should not be called when VISUAL is set")
+		return "", errors.New("unexpected lookup")
+	})
+	if err == nil {
+		t.Fatal("expected unterminated quote error")
+	}
+}
+
 // TestMCPEditConfigLaunchEditorRejectsShellMetachars confirms that shell
 // metacharacters in EDITOR/VISUAL are treated as literal argv tokens and
 // never executed as a shell command — the previous sh -lc construction would


### PR DESCRIPTION
## Summary

`mcpEditConfigLaunchCommand` concatenated the raw `$VISUAL`/`$EDITOR` value
into a `sh -lc "<editor> <path>"` command string. Only the path was
shell-quoted, so an editor value like `vim; rm -rf ~` (or any environment
pollution) would execute arbitrary shell commands.

## Severity

Command-injection hardening for local environment-controlled editor values.
Exploitation requires the environment variable to be set to a malicious value;
this is not remote-input execution, but it is still a real local attack surface
for shared accounts, compromised tooling, or untrusted config sources. Removing
the shell interpretation layer makes the MCP config editor launch path safer.

## Fix

Replace the `sh -lc` construction with `editorLaunchCmd`:
1. Expand `$VAR` references via `os.ExpandEnv` (no shell)
2. Parse the editor value into argv with shell-style quote/backslash handling
   for word splitting only (supports `code --wait`, `emacsclient -a ''`, and
   quoted editor paths)
3. Expand leading `~` / `~/` via `os.UserHomeDir` (no shell)
4. `exec.Command(args[0], append(args[1:], path)...)` -- binary resolved by OS

Shell metacharacters become literal argv tokens and cannot be executed. This
matches the safe pattern already used by the terminal-editor fallback
(`exec.Command(bin, path)`) in the same function.

Shell operators, globbing, command substitution, and redirection are
intentionally not evaluated. The now-unused `shellQuote` helper is removed.

## Behavior preservation

| EDITOR value | Prior (`sh -lc`) | New (`exec`) |
| --- | --- | --- |
| `vim` | works | works |
| `code --wait` | works | works |
| `emacsclient -c -a ''` | works | works, including the empty argument |
| `$HOME/bin/x` | shell expands | `ExpandEnv` expands |
| `~/bin/x` | shell expands | leading tilde expands |
| `'/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code' --wait` | shell parses quoted path | argv parser preserves quoted path |
| `vim; rm -rf ~` | executes `rm` | safe literal argv, no shell execution |

## Tests

- `TestMCPEditConfigLaunchUsesVisualBeforeEditor` -- direct invocation
- `TestMCPEditConfigLaunchEditorWithArgs` -- `code --wait` arg splitting
- `TestMCPEditConfigLaunchEditorParsesShellStyleQuotes` -- shell-style quotes,
  empty quoted args, escaped whitespace, and literal backslashes
- `TestMCPEditConfigLaunchEditorRejectsUnterminatedQuote` -- invalid quoted
  editor values fail cleanly
- `TestMCPEditConfigLaunchEditorRejectsShellMetachars` -- injection defense
- `TestMCPEditConfigLaunchEditorExpandsEnvVar` -- `$VAR` expansion
- `TestMCPEditConfigLaunchEditorExpandsTilde` -- `~` / `~/` expansion
- `TestMCPEditConfigLaunchEditorTildeNotInPayload` -- tilde not abused
- `TestMCPEditConfigLaunchFallsBackToTerminalEditor` -- fallback unchanged

## Verification

- `go test ./internal/cli -run 'TestMCPEditConfigLaunch'` -- pass
- `go test ./internal/cli` -- pass
- `git diff --check` -- pass

## Cache-impact

None. This only changes local CLI process construction for the MCP config editor
launch path.

## Authorship note

@YoungDan-hero is the primary author of this PR. @SivanCola contributed a
maintainer follow-up that preserves shell-style quoted editor values while
keeping the no-shell launch path.
