### PR TITLE
Integrate #5128 signoff recovery fixes / 整合 #5128 签退恢复修复

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1865,9 +1865,14 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
-			if err == nil {
-				rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, t.ReadOnly())
-				a.evidence.Record(rec)
+			// Record even failed complete_step receipts: a model that tried to
+			// sign off with evidence but hit a technical mismatch (command
+			// quoting, etc.) acted in good faith and shouldn't be deadlocked
+			// when it falls back to todo_write. See #5128.
+			success := err == nil
+			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), success, t.ReadOnly())
+			a.evidence.Record(rec)
+			if success {
 				a.advanceCanonicalTodo(rec.Step)
 			}
 		} else {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1865,14 +1865,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
-			// Record even failed complete_step receipts: a model that tried to
-			// sign off with evidence but hit a technical mismatch (command
-			// quoting, etc.) acted in good faith and shouldn't be deadlocked
-			// when it falls back to todo_write. See #5128.
-			success := err == nil
-			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), success, t.ReadOnly())
+			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly())
 			a.evidence.Record(rec)
-			if success {
+			if err == nil {
 				a.advanceCanonicalTodo(rec.Step)
 			}
 		} else {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -532,7 +532,7 @@ func TestEvidenceFlowRejectsUncitedCommand(t *testing.T) {
 	}
 
 	got := toolResult(a.session, "complete_step")
-	if !strings.Contains(got, "no matching successful bash receipt") {
+	if !strings.Contains(got, "has no matching successful receipt") {
 		t.Fatalf("complete_step result = %q, want the uncited command rejected", got)
 	}
 	if strings.Contains(got, "host-verified") {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -663,6 +663,49 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 	}
 }
 
+func TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	completeStep, ok := tool.LookupBuiltin("complete_step")
+	if !ok {
+		t.Fatal("complete_step builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(todoWrite)
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(completeStep)
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "todo_write", `{"todos":[{"content":"Run project script","status":"in_progress"}]}`),
+			toolCallChunk("c2", "bash", `{"command":"python \"script.py\""}`),
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Run project script",
+				"result":"script ran",
+				"evidence":[{"kind":"verification","summary":"script completed","command":"python other.py"}]
+			}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Run project script","status":"completed"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "recover after a failed complete_step"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	stepResult := lastToolResult(a.session, "complete_step")
+	if !strings.Contains(stepResult, "no matching successful bash receipt") {
+		t.Fatalf("complete_step result = %q, want the sign-off attempt to fail first", stepResult)
+	}
+	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "1 completed") {
+		t.Fatalf("todo_write result = %q, want completion recovery accepted", got)
+	}
+}
+
 func TestEvidenceFlowRecoversAfterBatchTodoCompletionRejection(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -698,8 +698,14 @@ func TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress(t
 	}
 
 	stepResult := lastToolResult(a.session, "complete_step")
-	if !strings.Contains(stepResult, "no matching successful bash receipt") {
+	if !strings.Contains(stepResult, "no matching successful receipt") {
 		t.Fatalf("complete_step result = %q, want the sign-off attempt to fail first", stepResult)
+	}
+	if !strings.Contains(stepResult, `python \"script.py\"`) {
+		t.Fatalf("complete_step result = %q, want the self-correction hint to include the real command", stepResult)
+	}
+	if strings.Contains(stepResult, "todo_write") {
+		t.Fatalf("complete_step result = %q, want command hints without todo tool noise", stepResult)
 	}
 	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "1 completed") {
 		t.Fatalf("todo_write result = %q, want completion recovery accepted", got)

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -447,6 +447,12 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		if hasSuccessfulCompleteStepForTodo(receipts, index, current) {
 			continue
 		}
+		// If a complete_step was attempted for this step but failed on a
+		// technicality (e.g. command mismatch), the model acted in good faith.
+		// Allow the todo_write completion so a mismatch doesn't cause deadlock.
+		if hasAttemptedCompleteStepForTodo(receipts, index, current) {
+			continue
+		}
 		missing = append(missing, TodoStepMatch{
 			Found:      true,
 			Index:      index,
@@ -711,8 +717,34 @@ func hasSuccessfulCompleteStepForTodo(receipts []Receipt, index int, current []T
 			if sameTodoMatch(current[index-1], *r.TodoStep) {
 				return true
 			}
-			// Content changed: allow the index/text fallback only when old and
-			// new overlap, so a replaced todo can't reuse an old receipt.
+			if !todoContentRelates(current[index-1], *r.TodoStep) {
+				continue
+			}
+		}
+		match := matchTodoStep(r.Step, current)
+		if match.Found && match.Index == index {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAttemptedCompleteStepForTodo is like hasSuccessfulCompleteStepForTodo but
+// accepts failed complete_step receipts too. A model that attempted to sign off
+// with evidence but hit a technical mismatch (e.g. command quoting) acted in
+// good faith and shouldn't be deadlocked. See #5128.
+func hasAttemptedCompleteStepForTodo(receipts []Receipt, index int, current []TodoItem) bool {
+	for _, r := range receipts {
+		if r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" {
+			continue
+		}
+		if r.TodoStep != nil && r.TodoStep.Found {
+			if index < 1 || index > len(current) {
+				continue
+			}
+			if sameTodoMatch(current[index-1], *r.TodoStep) {
+				return true
+			}
 			if !todoContentRelates(current[index-1], *r.TodoStep) {
 				continue
 			}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -465,12 +465,12 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 }
 
 func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, index int, current []TodoItem) bool {
-	if !hasSuccessfulProgressAfterTodoBaseline(receipts, baseline) {
-		return false
-	}
 	for i := baseline + 1; i < len(receipts); i++ {
 		r := receipts[i]
 		if r.Success || r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" || !r.StepProof {
+			continue
+		}
+		if !hasSuccessfulProgressBeforeReceipt(receipts, baseline, i) {
 			continue
 		}
 		if r.TodoStep != nil && r.TodoStep.Found {
@@ -492,8 +492,14 @@ func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, inde
 	return false
 }
 
-func hasSuccessfulProgressAfterTodoBaseline(receipts []Receipt, baseline int) bool {
-	for i := baseline + 1; i < len(receipts); i++ {
+// Recovery only trusts progress that happened before the failed sign-off.
+// Later unrelated work must not retroactively authorize an earlier completion.
+func hasSuccessfulProgressBeforeReceipt(receipts []Receipt, baseline int, before int) bool {
+	start := baseline + 1
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < before && i < len(receipts); i++ {
 		r := receipts[i]
 		if !r.Success || r.ToolName == "todo_write" || r.ToolName == "complete_step" || r.Read {
 			continue
@@ -707,24 +713,46 @@ func todoItemsField(fields map[string]json.RawMessage, key string) []TodoItem {
 	return normalizeTodos(todos)
 }
 
+// A failed complete_step can unlock todo recovery only when the payload had the
+// same structural proof shape Execute expects before host verification runs.
 func completeStepHasProof(fields map[string]json.RawMessage) bool {
+	if strings.TrimSpace(stringField(fields, "result")) == "" {
+		return false
+	}
 	raw, ok := fields["evidence"]
 	if !ok {
 		return false
 	}
 	var items []struct {
-		Kind    string `json:"kind"`
-		Summary string `json:"summary"`
+		Kind    string   `json:"kind"`
+		Summary string   `json:"summary"`
+		Command string   `json:"command"`
+		Paths   []string `json:"paths"`
 	}
-	if err := json.Unmarshal(raw, &items); err != nil {
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
 		return false
 	}
 	for _, item := range items {
-		if strings.TrimSpace(item.Kind) != "" && strings.TrimSpace(item.Summary) != "" {
-			return true
+		kind := strings.TrimSpace(item.Kind)
+		if kind == "" || strings.TrimSpace(item.Summary) == "" {
+			return false
+		}
+		switch kind {
+		case "verification":
+			if strings.TrimSpace(item.Command) == "" {
+				return false
+			}
+		case "diff", "files":
+			if len(normalizePaths(item.Paths)) == 0 {
+				return false
+			}
+		case "manual":
+			// Summary is enough for manual evidence.
+		default:
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func normalizeTodos(todos []TodoItem) []TodoItem {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -817,34 +817,6 @@ func hasSuccessfulCompleteStepForTodo(receipts []Receipt, index int, current []T
 	return false
 }
 
-// hasAttemptedCompleteStepForTodo is like hasSuccessfulCompleteStepForTodo but
-// accepts failed complete_step receipts too. A model that attempted to sign off
-// with evidence but hit a technical mismatch (e.g. command quoting) acted in
-// good faith and shouldn't be deadlocked. See #5128.
-func hasAttemptedCompleteStepForTodo(receipts []Receipt, index int, current []TodoItem) bool {
-	for _, r := range receipts {
-		if r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" {
-			continue
-		}
-		if r.TodoStep != nil && r.TodoStep.Found {
-			if index < 1 || index > len(current) {
-				continue
-			}
-			if sameTodoMatch(current[index-1], *r.TodoStep) {
-				return true
-			}
-			if !todoContentRelates(current[index-1], *r.TodoStep) {
-				continue
-			}
-		}
-		match := matchTodoStep(r.Step, current)
-		if match.Found && match.Index == index {
-			return true
-		}
-	}
-	return false
-}
-
 func latestTodoStep(step string, receipts []Receipt) TodoStepMatch {
 	for i := len(receipts) - 1; i >= 0; i-- {
 		r := receipts[i]

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -34,16 +34,17 @@ type TodoStepMatch struct {
 // Receipt is the host-runtime record of one tool call. It stays in memory for
 // the current agent turn and is not serialized into prompts or session state.
 type Receipt struct {
-	ToolName string          `json:"tool_name"`
-	Args     json.RawMessage `json:"args,omitempty"`
-	Success  bool            `json:"success"`
-	Command  string          `json:"command,omitempty"`
-	Step     string          `json:"step,omitempty"`
-	TodoStep *TodoStepMatch  `json:"todo_step,omitempty"`
-	Paths    []string        `json:"paths,omitempty"`
-	Read     bool            `json:"read,omitempty"`
-	Write    bool            `json:"write,omitempty"`
-	Todos    []TodoItem      `json:"todos,omitempty"`
+	ToolName  string          `json:"tool_name"`
+	Args      json.RawMessage `json:"args,omitempty"`
+	Success   bool            `json:"success"`
+	Command   string          `json:"command,omitempty"`
+	Step      string          `json:"step,omitempty"`
+	StepProof bool            `json:"step_proof,omitempty"`
+	TodoStep  *TodoStepMatch  `json:"todo_step,omitempty"`
+	Paths     []string        `json:"paths,omitempty"`
+	Read      bool            `json:"read,omitempty"`
+	Write     bool            `json:"write,omitempty"`
+	Todos     []TodoItem      `json:"todos,omitempty"`
 }
 
 // Ledger stores the receipts available to complete_step for the current turn.
@@ -82,7 +83,7 @@ func (l *Ledger) Record(r Receipt) {
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if r.Success && r.ToolName == "complete_step" && r.Step != "" && r.TodoStep == nil {
+	if r.ToolName == "complete_step" && r.Step != "" && r.TodoStep == nil {
 		if match := latestTodoStep(r.Step, l.receipts); match.Found {
 			r.TodoStep = &match
 		}
@@ -423,12 +424,14 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 	l.mu.Unlock()
 
 	var previous []TodoItem
+	baseline := -1
 	for i := len(receipts) - 1; i >= 0; i-- {
 		r := receipts[i]
 		if !r.Success || r.ToolName != "todo_write" {
 			continue
 		}
 		previous = r.Todos
+		baseline = i
 		hasBaseline = true
 		break
 	}
@@ -447,10 +450,7 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		if hasSuccessfulCompleteStepForTodo(receipts, index, current) {
 			continue
 		}
-		// If a complete_step was attempted for this step but failed on a
-		// technicality (e.g. command mismatch), the model acted in good faith.
-		// Allow the todo_write completion so a mismatch doesn't cause deadlock.
-		if hasAttemptedCompleteStepForTodo(receipts, index, current) {
+		if hasFailedCompleteStepRecoveryForTodo(receipts, baseline, index, current) {
 			continue
 		}
 		missing = append(missing, TodoStepMatch{
@@ -462,6 +462,45 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 		})
 	}
 	return missing, true
+}
+
+func hasFailedCompleteStepRecoveryForTodo(receipts []Receipt, baseline int, index int, current []TodoItem) bool {
+	if !hasSuccessfulProgressAfterTodoBaseline(receipts, baseline) {
+		return false
+	}
+	for i := baseline + 1; i < len(receipts); i++ {
+		r := receipts[i]
+		if r.Success || r.ToolName != "complete_step" || strings.TrimSpace(r.Step) == "" || !r.StepProof {
+			continue
+		}
+		if r.TodoStep != nil && r.TodoStep.Found {
+			if index < 1 || index > len(current) {
+				continue
+			}
+			if sameTodoMatch(current[index-1], *r.TodoStep) {
+				return true
+			}
+			if !todoContentRelates(current[index-1], *r.TodoStep) {
+				continue
+			}
+		}
+		match := matchTodoStep(r.Step, current)
+		if match.Found && match.Index == index {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSuccessfulProgressAfterTodoBaseline(receipts []Receipt, baseline int) bool {
+	for i := baseline + 1; i < len(receipts); i++ {
+		r := receipts[i]
+		if !r.Success || r.ToolName == "todo_write" || r.ToolName == "complete_step" || r.Read {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func (l *Ledger) hasSuccessfulPaths(paths []string, accept func(Receipt) bool) bool {
@@ -576,6 +615,7 @@ func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, re
 		}
 		if toolName == "complete_step" {
 			r.Step = stringField(fields, "step")
+			r.StepProof = completeStepHasProof(fields)
 		}
 		if toolName == "todo_write" {
 			r.Todos = todoItemsField(fields, "todos")
@@ -665,6 +705,26 @@ func todoItemsField(fields map[string]json.RawMessage, key string) []TodoItem {
 		return nil
 	}
 	return normalizeTodos(todos)
+}
+
+func completeStepHasProof(fields map[string]json.RawMessage) bool {
+	raw, ok := fields["evidence"]
+	if !ok {
+		return false
+	}
+	var items []struct {
+		Kind    string `json:"kind"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.Kind) != "" && strings.TrimSpace(item.Summary) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeTodos(todos []TodoItem) []TodoItem {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -281,13 +281,16 @@ func TestLedgerRequiresCompleteStepForNewCompletedTodos(t *testing.T) {
 		t.Fatalf("missing = %+v, want only Add parser", missing)
 	}
 
+	// A failed complete_step that matches the step still authorizes completion:
+	// the model acted in good faith and shouldn't deadlock on a technicality
+	// like command quoting. See #5128.
 	ledger.Record(Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	missing, hasBaseline = ledger.UnverifiedCompletedTodos(current)
 	if !hasBaseline {
 		t.Fatal("expected prior todo_write baseline after failed complete_step")
 	}
-	if len(missing) != 1 || missing[0].Content != "Add parser" {
-		t.Fatalf("failed complete_step should not authorize completion, missing = %+v", missing)
+	if len(missing) != 0 {
+		t.Fatalf("attempted complete_step should authorize completion despite failure, missing = %+v", missing)
 	}
 
 	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "Add parser"})

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -163,6 +163,23 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 		t.Fatalf("complete_step should not be treated as read-only context: %+v", receipt)
 	}
 
+	missingResult := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"evidence":[{"kind":"manual","summary":"checked manually"}]
+	}`), false, true)
+	if missingResult.StepProof {
+		t.Fatalf("complete_step without result should not count as proof: %+v", missingResult)
+	}
+
+	missingCommand := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"result":"parser added",
+		"evidence":[{"kind":"verification","summary":"checked manually"}]
+	}`), false, true)
+	if missingCommand.StepProof {
+		t.Fatalf("verification evidence without command should not count as proof: %+v", missingCommand)
+	}
+
 	emptyProof := ReceiptFromToolCall("complete_step", json.RawMessage(`{
 		"step":"Add parser",
 		"result":"parser added",

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -156,8 +156,20 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 	if receipt.Step != "Add parser" {
 		t.Fatalf("complete_step step = %q", receipt.Step)
 	}
+	if !receipt.StepProof {
+		t.Fatalf("complete_step evidence proof not extracted: %+v", receipt)
+	}
 	if receipt.Read {
 		t.Fatalf("complete_step should not be treated as read-only context: %+v", receipt)
+	}
+
+	emptyProof := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Add parser",
+		"result":"parser added",
+		"evidence":[]
+	}`), false, true)
+	if emptyProof.StepProof {
+		t.Fatalf("empty complete_step evidence should not count as proof: %+v", emptyProof)
 	}
 }
 

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -310,16 +310,13 @@ func TestLedgerRequiresCompleteStepForNewCompletedTodos(t *testing.T) {
 		t.Fatalf("missing = %+v, want only Add parser", missing)
 	}
 
-	// A failed complete_step that matches the step still authorizes completion:
-	// the model acted in good faith and shouldn't deadlock on a technicality
-	// like command quoting. See #5128.
 	ledger.Record(Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	missing, hasBaseline = ledger.UnverifiedCompletedTodos(current)
 	if !hasBaseline {
 		t.Fatal("expected prior todo_write baseline after failed complete_step")
 	}
-	if len(missing) != 0 {
-		t.Fatalf("attempted complete_step should authorize completion despite failure, missing = %+v", missing)
+	if len(missing) != 1 || missing[0].Content != "Add parser" {
+		t.Fatalf("failed complete_step without proof-bearing recovery should not authorize completion, missing = %+v", missing)
 	}
 
 	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "Add parser"})

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -157,7 +157,8 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 				if ledger.HasFailedCommand(command) {
 					return 0, 0, fmt.Errorf("evidence %d: verification command %q ran but exited non-zero, so it can't prove the step; if the non-zero exit is itself the expected proof (e.g. a file is gone), re-run it so it succeeds (append \"|| true\") and sign off again", i+1, command)
 				}
-				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful bash receipt in this turn%s", i+1, command, receiptHint("commands run this turn", ledger.SuccessfulCommands(5)))
+				hint := allCommandHints(ctx, ledger)
+				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful receipt — cite the command exactly as it ran in the session%s", i+1, command, hint)
 			}
 			hostVerified++
 		case "diff":
@@ -343,6 +344,53 @@ func receiptHint(label string, items []string) string {
 		}
 	}
 	return fmt.Sprintf("; %s: %q — cite one as it actually ran, or run the check now", label, items)
+}
+
+// allCommandHints builds a combined hint from both the per-turn ledger and the
+// full session history, so the model can self-correct a mismatched citation.
+func allCommandHints(ctx context.Context, ledger *evidence.Ledger) string {
+	seen := map[string]bool{}
+	var cmds []string
+	if ledger != nil {
+		for _, c := range ledger.SuccessfulCommands(8) {
+			if !seen[c] {
+				seen[c] = true
+				cmds = append(cmds, c)
+			}
+		}
+	}
+	if msgs, ok := evidence.SessionMessagesFromContext(ctx); ok {
+		failed := failedCallIDs(msgs)
+		for _, msg := range msgs {
+			for _, tc := range msg.ToolCalls {
+				if failed[tc.ID] {
+					continue
+				}
+				c := extractCommandFromCall(tc.Name, tc.Arguments)
+				if c == "" || seen[c] {
+					continue
+				}
+				seen[c] = true
+				cmds = append(cmds, c)
+				if len(cmds) >= 12 {
+					break
+				}
+			}
+			if len(cmds) >= 12 {
+				break
+			}
+		}
+	}
+	if len(cmds) == 0 {
+		return ""
+	}
+	// Truncate long entries for readability.
+	for i, c := range cmds {
+		if len(c) > 80 {
+			cmds[i] = c[:80] + "…"
+		}
+	}
+	return fmt.Sprintf("; commands that ran: %q — pick the matching one and retry complete_step", cmds)
 }
 
 func firstWord(s string) string {

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -366,6 +366,9 @@ func allCommandHints(ctx context.Context, ledger *evidence.Ledger) string {
 				if failed[tc.ID] {
 					continue
 				}
+				if tc.Name == "todo_write" || tc.Name == "complete_step" {
+					continue
+				}
 				c := extractCommandFromCall(tc.Name, tc.Arguments)
 				if c == "" || seen[c] {
 					continue

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -67,19 +67,24 @@ func TestTodoWriteAllowsInitialCompletedWithoutBaseline(t *testing.T) {
 	}
 }
 
-func TestTodoWriteIgnoresFailedCompleteStepReceipt(t *testing.T) {
+func TestTodoWriteAllowsCompletionAfterAttemptedCompleteStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
 		Success:  true,
 		Todos:    []evidence.TodoItem{{Content: "Add parser", Status: "in_progress"}},
 	})
+	// A failed complete_step for the same step still authorizes completion —
+	// the model acted in good faith and shouldn't deadlock. See #5128.
 	ledger.Record(evidence.Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step should not authorize new completion, got %v", err)
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("attempted complete_step should authorize completion: %v", err)
+	}
+	if !strings.Contains(out, "1 total") {
+		t.Fatalf("unexpected output: %s", out)
 	}
 }

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -115,6 +115,31 @@ func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
 	}
 }
 
+func TestTodoWriteRejectsFailedCompleteStepMissingResult(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"evidence":[{"kind":"manual","summary":"checked manually"}]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("failed complete_step without result should not authorize completion, got %v", err)
+	}
+}
+
 func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
@@ -137,5 +162,32 @@ func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.
 
 	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
 		t.Fatalf("matching failed complete_step with progress receipt should recover todo completion: %v", err)
+	}
+}
+
+func TestTodoWriteRejectsRecoveryWhenProgressIsAfterFailedCompleteStep(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[{"kind":"verification","summary":"script completed","command":"python other.py"}]
+	}`), false, true))
+	ledger.Record(evidence.Receipt{
+		ToolName: "write_file",
+		Success:  true,
+		Paths:    []string{"docs/notes.md"},
+		Write:    true,
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("progress after a failed complete_step should not authorize recovery, got %v", err)
 	}
 }

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -88,3 +88,54 @@ func TestTodoWriteAllowsCompletionAfterAttemptedCompleteStep(t *testing.T) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
+
+func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("failed complete_step without proof should not authorize completion, got %v", err)
+	}
+}
+
+func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Run project script", Status: "in_progress"}},
+	})
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `python "script.py"`,
+	})
+	ledger.Record(evidence.ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Run project script",
+		"result":"script ran",
+		"evidence":[{"kind":"verification","summary":"script completed","command":"python script.py"}]
+	}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
+
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("matching failed complete_step with progress receipt should recover todo completion: %v", err)
+	}
+}

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -67,25 +67,20 @@ func TestTodoWriteAllowsInitialCompletedWithoutBaseline(t *testing.T) {
 	}
 }
 
-func TestTodoWriteAllowsCompletionAfterAttemptedCompleteStep(t *testing.T) {
+func TestTodoWriteRejectsFailedCompleteStepReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
 		Success:  true,
 		Todos:    []evidence.TodoItem{{Content: "Add parser", Status: "in_progress"}},
 	})
-	// A failed complete_step for the same step still authorizes completion —
-	// the model acted in good faith and shouldn't deadlock. See #5128.
 	ledger.Record(evidence.Receipt{ToolName: "complete_step", Success: false, Step: "Add parser"})
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	out, err := (todoWrite{}).Execute(ctx, args)
-	if err != nil {
-		t.Fatalf("attempted complete_step should authorize completion: %v", err)
-	}
-	if !strings.Contains(out, "1 total") {
-		t.Fatalf("unexpected output: %s", out)
+	_, err := (todoWrite{}).Execute(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "complete_step") {
+		t.Fatalf("failed complete_step without proof-bearing recovery should not authorize completion, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #5131 and #5163 with one integration branch on top of the latest `main-v2`.
- Preserve @myipanta's command self-correction improvement: when a `complete_step` verification citation mismatches, the rejection now surfaces the exact successful commands seen in the turn/session so the model can retry with the real command string.
- Preserve @GTC2080's proof-bearing failed-signoff recovery path: the evidence ledger records failed `complete_step` attempts and `todo_write` can recover only when the failed signoff carried structurally valid proof and the same todo baseline already has real successful progress.
- Tighten the final boundary so malformed failed signoffs, empty proof, and progress that happens only after the failed signoff still do **not** authorize completion.
- Align the unit and agent-flow coverage with the final contract, including a regression that keeps command hints free of `todo_write` / `complete_step` noise.

## Contributor Credit

- @myipanta contributed the command-citation diagnosis and self-correction UX that is preserved here.
- @GTC2080 contributed the proof-bearing failed-signoff recovery model and the matching evidence/todo regression coverage that is preserved here.
- @SivanCola integrated both approaches on the latest `main-v2`, tightened the final recovery boundary, and verified the combined fix.

Authorship note: this branch preserves authored commits from @myipanta and @GTC2080 so the merged history can credit them as repository contributors.

## Verification

- `go test ./internal/evidence ./internal/tool/builtin -run 'Test(ReceiptFromToolCall|Ledger|TodoWrite|CommandMatches|CompleteStep)' -count=1`
- `go test ./internal/agent -run 'TestEvidenceFlow(RejectsUncitedCommand|RecoversTodoCompletionAfterFailedCompleteStepWithProgress|FailedCompleteStepDoesNotAuthorizeTodoCompletion|RejectsStepMissingFromTodoWrite)' -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Cache impact

Cache-impact: none - the integration only changes evidence/todo recovery and error hint behavior; no provider-visible prompts, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration changes.
Cache-guard: the focused evidence/builtin/agent tests above plus `go test ./... -count=1` cover the merged contract.
System-prompt-review: N/A
