### PR TITLE
fix(desktop): stabilize creation overview dock / 修复创作概览右侧面板布局与重开渲染

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1958,6 +1958,7 @@ export default function App() {
     if (!workspacePanelOpen) {
       return;
     }
+    setLiveWorkspacePanelRenderWidth(null);
     setWorkspacePanelMaximized(false);
     setWorkspacePanelOpen(false);
   }, [closeTransientOverlays, workspacePanelOpen]);

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -127,12 +127,37 @@ for (const selector of [
   ".context-panel__section-head span",
   ".context-panel__metric span",
   ".context-panel__metric strong",
+  ".app--creation .context-panel__mini-stat span",
+  ".app--creation .context-panel__mini-stat strong",
   ".topbar__model",
   ".composer-modebar__item span",
   ".composer-more-menu__item span",
 ]) {
   clipsSingleLine(selector);
 }
+
+eq(
+  finalDeclaration(".app--creation .layout.layout--workspace-open", "transition"),
+  "grid-template-columns 0s, min-width 0s",
+  "creation dock skips zero-width grid interpolation on open",
+);
+eq(
+  finalDeclaration(".app--creation .context-panel__usage", "animation"),
+  "none",
+  "creation overview usage card disables inherited entrance animation",
+);
+ok(
+  finalDeclaration(".app--creation .context-panel__mini-stat", "justify-content") !== "space-between",
+  "creation overview rows avoid edge-pinned value alignment",
+);
+ok(
+  finalDeclaration(".app--creation .context-panel__mini-stat", "grid-template-columns") !== "minmax(0, 1fr) auto",
+  "creation overview rows avoid the spacer grid that pushes values to the edge",
+);
+ok(
+  finalDeclaration(".app--creation .context-panel__mini-stat strong", "max-width") !== "14ch",
+  "creation overview values are not capped to a fixed 14ch width",
+);
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
 ok(

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -1,5 +1,8 @@
 // Run: tsx src/__tests__/workspace-layout.test.ts
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   availableWorkspacePanelWidth,
   resolveLiveWorkspacePanelWidth,
@@ -9,6 +12,8 @@ import {
 
 let passed = 0;
 let failed = 0;
+const testDir = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(testDir, "../App.tsx"), "utf8");
 
 function eq(a: unknown, b: unknown, label: string) {
   if (a === b) {
@@ -140,6 +145,11 @@ eq(
   }),
   212,
   "live sidebar drag recomputes dock width from the dragged sidebar width",
+);
+eq(
+  /const closeWorkspacePanel = useCallback\(\(\) => \{[\s\S]*?setLiveWorkspacePanelRenderWidth\(null\);[\s\S]*?setWorkspacePanelOpen\(false\);/.test(appSource),
+  true,
+  "closing the dock clears the transient render width before hiding the panel",
 );
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1969,6 +1969,12 @@ a[href] {
   min-width: min(560px, 100vw);
   grid-template-columns: 0px minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
+/* Skip dock-column interpolation in creation mode. WebKit can mount the
+   overview at zero inline size and fail to repaint its text on reopen. */
+.app--creation .layout.layout--workspace-open,
+.app--creation .layout.layout--workspace-open.layout--sidebar-collapsed {
+  transition: grid-template-columns 0s, min-width 0s;
+}
 .layout--workspace-maximized {
   min-width: 0;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
@@ -24038,7 +24044,7 @@ a[href] {
 .app--creation .sidebar,
 :root[data-theme-style] .app--creation .sidebar {
   --project-tree-row-radius: 9px;
-  padding: 18px 12px 14px;
+  padding: 38px 12px 14px;
   border-right: 0;
   background:
     radial-gradient(110% 70% at 18% 0%, color-mix(in srgb, var(--accent) 5%, transparent) 0%, transparent 52%),
@@ -24547,8 +24553,8 @@ a[href] {
 
 .app--creation .transcript::-webkit-scrollbar,
 :root[data-theme-style] .app--creation .transcript::-webkit-scrollbar {
-  width: 2px !important;
-  height: 2px !important;
+  width: 6px !important;
+  height: 6px !important;
   background: transparent !important;
 }
 
@@ -25631,6 +25637,7 @@ a[href] {
 
 .app--creation .context-panel__overview {
   gap: 10px;
+  min-width: 0;
 }
 
 .app--creation .context-panel__usage,
@@ -25638,13 +25645,16 @@ a[href] {
 :root[data-theme-style] .app--creation .context-panel__usage,
 :root[data-theme-style] .app--creation .context-panel__section {
   gap: 12px;
+  min-width: 0;
   padding: 11px;
+  overflow: hidden;
   border: 1px solid var(--creation-panel-border);
   border-radius: 12px;
   background: var(--creation-panel-card);
   box-shadow: var(--creation-panel-shadow);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  animation: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .app--creation .context-panel__section {
@@ -25724,16 +25734,16 @@ a[href] {
 
 .app--creation .context-panel__mini-stat {
   min-width: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 8px;
   color: color-mix(in srgb, var(--fg-dim) 84%, transparent);
   font-size: 12px;
   line-height: 1.2;
 }
 
 .app--creation .context-panel__mini-stat span {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -25742,6 +25752,12 @@ a[href] {
 }
 
 .app--creation .context-panel__mini-stat strong {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
@@ -25789,8 +25805,8 @@ a[href] {
   border-radius: 10px;
   background: var(--creation-panel-card);
   box-shadow: var(--creation-panel-shadow);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .app--creation .context-panel__metric span,


### PR DESCRIPTION
## Summary

- Supersede #5156 and #5225 with a single latest-`main-v2` integration for the creation overview dock.
- Keep creation overview mini stats as inline label/value pairs, but let values shrink only when the dock is actually narrow instead of permanently capping them to a fixed width.
- Bring over the related creation-mode polish from #5225: the larger top inset for the creation sidebar, a wider draggable transcript scrollbar, and the right-dock reopen fix that clears transient width state and skips zero-width grid interpolation in WebKit.
- Add focused regression coverage for the creation overview layout contract and the dock-close width-reset contract.

Integrated PR contributions:
- #5156 by @GTC2080
  - switched the creation overview mini stats away from the spacer-grid edge pinning
  - added creation mini-stat overflow coverage to the typography contract test
- #5225 by @assoyuan
  - fixed the creation sidebar icon/header spacing and widened the creation transcript scrollbar for dragability
  - identified the right-dock reopen rendering issue and the creation-specific dock behavior integrated here

Authorship note: @SivanCola is the primary author of this integration PR. @GTC2080 and @assoyuan contributed the original fixes integrated here and are acknowledged as collaborators / co-contributors.

Fixes #5154

## Verification

- `pnpm --dir desktop/frontend check:css`
- `corepack pnpm dlx tsx src/__tests__/typography-overflow-contract.test.ts`
- `corepack pnpm dlx tsx src/__tests__/workspace-layout.test.ts`
- `git diff --check`

## Cache impact

Cache-impact: none. Desktop frontend CSS/test only; no provider-visible prompt, memory prefix, tool schema, request serialization, compaction, or MCP/tool registration changes.
Cache-guard: `corepack pnpm dlx tsx src/__tests__/typography-overflow-contract.test.ts`
System-prompt-review: N/A
