### PR TITLE
fix(desktop): honor desktop language for replies / 修复桌面语言回复偏好

### DIFF
--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1779,13 +1779,24 @@ func (a *App) SetStatusBarItems(items []string) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopStatusBarItems(items) })
 }
 
-// SetDesktopLanguage updates only the desktop UI language. It deliberately does
-// not touch config.language, which the CLI/model-facing runtime uses.
+// SetDesktopLanguage updates the desktop UI language and the user-level response
+// language preference used by model-facing desktop sessions.
 func (a *App) SetDesktopLanguage(lang string) error {
-	if err := a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopLanguage(lang) }); err != nil {
+	responseLanguage := ""
+	if err := a.applyConfigOnly(func(c *config.Config) error {
+		if err := c.SetDesktopLanguage(lang); err != nil {
+			return err
+		}
+		if err := c.SetLanguage(lang); err != nil {
+			return err
+		}
+		responseLanguage = c.ResponseLanguage()
+		return nil
+	}); err != nil {
 		return err
 	}
 	a.updateTrayLocale(lang)
+	a.applyResponseLanguageToLiveControllers(responseLanguage)
 	return nil
 }
 
@@ -1931,6 +1942,28 @@ func (a *App) applyReasoningLanguageToLiveControllers(fallback string) {
 			mode = cfg.ReasoningLanguage()
 		}
 		tab.ctrl.SetReasoningLanguage(mode)
+	}
+}
+
+func (a *App) applyResponseLanguageToLiveControllers(fallback string) {
+	type liveTab struct {
+		root string
+		ctrl control.SessionAPI
+	}
+	var tabs []liveTab
+	a.mu.RLock()
+	for _, tab := range a.tabs {
+		if tab != nil && tab.Ctrl != nil {
+			tabs = append(tabs, liveTab{root: tab.WorkspaceRoot, ctrl: tab.Ctrl})
+		}
+	}
+	a.mu.RUnlock()
+	for _, tab := range tabs {
+		mode := fallback
+		if cfg, err := config.LoadForRoot(tab.root); err == nil {
+			mode = cfg.ResponseLanguage()
+		}
+		tab.ctrl.SetResponseLanguage(mode)
 	}
 }
 

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -532,6 +532,53 @@ func TestSetReasoningLanguagePersistsToUserConfig(t *testing.T) {
 	}
 }
 
+func TestSetDesktopLanguagePersistsResponseLanguageAndUpdatesLiveTabs(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "reasonix.toml"), []byte("language = \"zh\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	userCtrl := control.New(control.Options{})
+	projectCtrl := control.New(control.Options{})
+	app.tabs = map[string]*WorkspaceTab{
+		"user": {
+			ID:          "user",
+			Scope:       "global",
+			Ctrl:        userCtrl,
+			Ready:       true,
+			disabledMCP: map[string]ServerView{},
+		},
+		"project": {
+			ID:            "project",
+			Scope:         "project",
+			WorkspaceRoot: projectRoot,
+			Ctrl:          projectCtrl,
+			Ready:         true,
+			disabledMCP:   map[string]ServerView{},
+		},
+	}
+	app.activeTabID = "user"
+
+	if err := app.SetDesktopLanguage("en"); err != nil {
+		t.Fatalf("SetDesktopLanguage: %v", err)
+	}
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if cfg.DesktopLanguage() != "en" || cfg.Language != "en" {
+		t.Fatalf("saved language prefs = desktop:%q response:%q, want en/en", cfg.DesktopLanguage(), cfg.Language)
+	}
+	got := userCtrl.Compose("解释这个函数")
+	if !strings.Contains(got, "<response-language>") || !strings.Contains(got, "use English") {
+		t.Fatalf("live controller Compose = %q, want English response language", got)
+	}
+	projectComposed := projectCtrl.Compose("explain this function")
+	if !strings.Contains(projectComposed, "use Simplified Chinese") {
+		t.Fatalf("project controller Compose = %q, want project zh response language", projectComposed)
+	}
+}
+
 func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -167,6 +167,7 @@ type Agent struct {
 	temperature          float64
 	pricing              *provider.Pricing
 	usageSource          string
+	responseLanguage     atomic.Value // string: auto|zh|en
 	reasoningLanguage    atomic.Value // string: auto|zh|en
 
 	// sink receives the turn's typed event stream (reasoning/text deltas, tool
@@ -344,6 +345,15 @@ func (a *Agent) SetReasoningLanguage(lang string) {
 	a.reasoningLanguage.Store(NormalizeReasoningLanguage(lang))
 }
 
+// SetResponseLanguage updates the final-answer language preference for
+// subsequent user-role messages emitted by this agent.
+func (a *Agent) SetResponseLanguage(lang string) {
+	if a == nil {
+		return
+	}
+	a.responseLanguage.Store(NormalizeResponseLanguage(lang))
+}
+
 // SetMemoryCompiler updates the Memory v5 runtime used for subsequent turns.
 // It is safe for desktop settings to call while other tabs are idle or running;
 // an already-started turn keeps its own Turn handle and future turns observe the
@@ -376,10 +386,18 @@ func (a *Agent) SetGate(g Gate) {
 	a.gate = g
 }
 
-func (a *Agent) withReasoningLanguage(input string) string {
+func (a *Agent) withTurnPreferences(input string) string {
 	if a == nil {
 		return input
 	}
+	responseLang := "auto"
+	if v := a.responseLanguage.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			responseLang = s
+		}
+	}
+	input = WithResponseLanguage(input, responseLang)
+
 	lang := "auto"
 	if v := a.reasoningLanguage.Load(); v != nil {
 		if s, ok := v.(string); ok {
@@ -558,6 +576,10 @@ type Options struct {
 	// user-turn context. Empty/auto injects nothing.
 	ReasoningLanguage string
 
+	// ResponseLanguage controls final-answer language preference as transient
+	// user-turn context. Empty/auto keeps the stable same-as-user policy.
+	ResponseLanguage string
+
 	// PlanModeAllowedTools names extra custom tools the plan-mode policy may treat
 	// as read-only. It cannot unlock known blocked tools or unsafe bash commands.
 	PlanModeAllowedTools []string
@@ -624,6 +646,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		planModeAllowedTools: append([]string(nil), opts.PlanModeAllowedTools...),
 		memoryCompiler:       opts.MemoryCompiler,
 	}
+	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
 	return a
 }
@@ -657,7 +680,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	if sourceInput, ok := MemoryCompilerSourceInputFromContext(ctx); ok {
 		memoryCompilerInput = sourceInput
 	}
-	input = a.withReasoningLanguage(rawInput)
+	input = a.withTurnPreferences(rawInput)
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil {
 		if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
 			a.compilerTurn = turn
@@ -669,7 +692,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				}
 			}()
 			if strings.TrimSpace(compiledInput) != "" {
-				input = a.withReasoningLanguage(compiledInput)
+				input = a.withTurnPreferences(compiledInput)
 			}
 		}
 	}
@@ -688,7 +711,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		// guidance (with a prefix), not a new task. One cache miss per
 		// steer is unavoidable — the model must see the new instruction.
 		if text, ok := a.consumeSteer(); ok {
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(midTurnSteerMessage(text))})
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
 			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
 		}
 		schemas := a.tools.Schemas()
@@ -713,7 +736,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				}
 				a.session.Add(provider.Message{
 					Role:    provider.RoleUser,
-					Content: a.withReasoningLanguage(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
+					Content: a.withTurnPreferences(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
 				})
 				a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: streamRecoveries, RetryMax: maxStreamRecoveries})
 				step-- // recovery retries do not consume the tool-round maxSteps budget
@@ -761,7 +784,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				}
 				event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + readiness.reason})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(finalReadinessRetryMessage(readiness.reason))})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(finalReadinessRetryMessage(readiness.reason))})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -771,14 +794,14 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
 				}
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: emptyFinalNotice(a.prov.Name(), usage, len(reasoning))})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(emptyFinalRetryMessage())})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
 			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(input, text) {
 				handoffNudges++
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(executorHandoffRetryMessage())})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(executorHandoffRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -827,7 +850,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		if a.maxSteps > 0 && step+1 >= a.maxSteps {
 			graceRound = true
 			nudge := fmt.Sprintf("Do not call any more tools — your tool-call round limit (%s) has been reached. Instead, synthesize a final answer from all the work already completed: summarize what was accomplished, what remains to be done, and any decisions the user should make. The user can increase %s or continue in the next turn if more work is needed.", a.maxStepsKey, a.maxStepsKey)
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(nudge)})
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("budget (%s=%d) exhausted: one grace round to finalize", a.maxStepsKey, a.maxSteps)})
 		}
 	}
@@ -1849,6 +1872,11 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)
+	}
+	if v := a.responseLanguage.Load(); v != nil {
+		if lang, ok := v.(string); ok {
+			cctx = WithResponseLanguagePreference(cctx, lang)
+		}
 	}
 	if v := a.reasoningLanguage.Load(); v != nil {
 		if lang, ok := v.(string); ok {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -140,6 +140,19 @@ func (c *Coordinator) SetReasoningLanguage(lang string) {
 	}
 }
 
+// SetResponseLanguage updates both agents in two-model mode.
+func (c *Coordinator) SetResponseLanguage(lang string) {
+	if c == nil {
+		return
+	}
+	if c.plannerAgent != nil {
+		c.plannerAgent.SetResponseLanguage(lang)
+	}
+	if c.executor != nil {
+		c.executor.SetResponseLanguage(lang)
+	}
+}
+
 // SetPlanMode propagates the read-only gate to both planner and executor agents
 // in two-model mode. Callers that only set the controller's executor would miss
 // the planner agent inside the Coordinator, causing stale plan-mode state after
@@ -240,7 +253,7 @@ func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan strin
 	if c == nil || c.executor == nil || c.executor.session == nil {
 		return
 	}
-	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withReasoningLanguage(input), Images: userImages(ctx)})
+	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withTurnPreferences(input), Images: userImages(ctx)})
 	c.executor.session.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
 }
 

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:reasoning-language|memory-update|background-jobs)>.*?</(?:reasoning-language|memory-update|background-jobs)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs)>\s*\n?`)
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -6,6 +6,7 @@ import (
 )
 
 type reasoningLanguageContextKey struct{}
+type responseLanguageContextKey struct{}
 
 // NormalizeReasoningLanguage returns one of auto|zh|en for runtime-only visible
 // reasoning preferences. Keep this local to agent so sub-agents can inherit the
@@ -18,6 +19,33 @@ func NormalizeReasoningLanguage(lang string) string {
 		return "en"
 	default:
 		return "auto"
+	}
+}
+
+// NormalizeResponseLanguage returns one of auto|zh|en for final-answer language
+// preferences. Auto keeps the stable same-as-user language policy.
+func NormalizeResponseLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "zh", "cn", "chinese", "中文":
+		return "zh"
+	case "en", "english":
+		return "en"
+	default:
+		return "auto"
+	}
+}
+
+// ResponseLanguageBlock is transient user-turn context for final answers. It
+// stays out of the stable system prompt so changing the preference between turns
+// does not churn the cached prefix.
+func ResponseLanguageBlock(lang string) string {
+	switch NormalizeResponseLanguage(lang) {
+	case "zh":
+		return "<response-language>\nFinal answer language preference: use Simplified Chinese for user-facing replies unless the user explicitly asks for another language. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form.\n</response-language>"
+	case "en":
+		return "<response-language>\nFinal answer language preference: use English for user-facing replies unless the user explicitly asks for another language. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form.\n</response-language>"
+	default:
+		return ""
 	}
 }
 
@@ -34,24 +62,46 @@ func ReasoningLanguageBlock(lang string) string {
 	}
 }
 
+// WithResponseLanguage prefixes content with the transient response-language
+// block unless the turn already starts with one.
+func WithResponseLanguage(content, lang string) string {
+	block := ResponseLanguageBlock(lang)
+	if block == "" || hasLeadingInjectedBlock(content, "response-language") {
+		return content
+	}
+	return block + "\n\n" + content
+}
+
 // WithReasoningLanguage prefixes content with the transient reasoning-language
 // block unless the turn already starts with an injected reasoning-language
 // block. User-authored mentions of the tag later in the prompt must not suppress
 // the configured preference.
 func WithReasoningLanguage(content, lang string) string {
 	block := ReasoningLanguageBlock(lang)
-	if block == "" || hasLeadingReasoningLanguageBlock(content) {
+	if block == "" || hasLeadingInjectedBlock(content, "reasoning-language") {
 		return content
 	}
 	return block + "\n\n" + content
 }
 
-func hasLeadingReasoningLanguageBlock(content string) bool {
+func hasLeadingInjectedBlock(content, target string) bool {
 	s := strings.TrimLeft(content, " \t\r\n")
 	for {
 		switch {
-		case strings.HasPrefix(s, "<reasoning-language>"):
-			return strings.Contains(s, "</reasoning-language>")
+		case strings.HasPrefix(s, "<"+target+">"):
+			return strings.Contains(s, "</"+target+">")
+		case target != "response-language" && strings.HasPrefix(s, "<response-language>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "response-language")
+			if !ok {
+				return false
+			}
+		case target != "reasoning-language" && strings.HasPrefix(s, "<reasoning-language>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "reasoning-language")
+			if !ok {
+				return false
+			}
 		case strings.HasPrefix(s, "<memory-update>"):
 			var ok bool
 			s, ok = trimLeadingTransientBlock(s, "memory-update")
@@ -77,6 +127,26 @@ func trimLeadingTransientBlock(content, tag string) (string, bool) {
 		return content, false
 	}
 	return strings.TrimLeft(content[i+len(closeTag):], " \t\r\n"), true
+}
+
+// WithResponseLanguagePreference carries the runtime final-answer language
+// preference to spawned tools and sub-agents.
+func WithResponseLanguagePreference(ctx context.Context, lang string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, responseLanguageContextKey{}, NormalizeResponseLanguage(lang))
+}
+
+// ResponseLanguageFromContext returns auto|zh|en.
+func ResponseLanguageFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return "auto"
+	}
+	if v, ok := ctx.Value(responseLanguageContextKey{}).(string); ok {
+		return NormalizeResponseLanguage(v)
+	}
+	return "auto"
 }
 
 // WithReasoningLanguagePreference carries the runtime preference to spawned

--- a/internal/agent/reasoning_language_test.go
+++ b/internal/agent/reasoning_language_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestWithResponseLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
+	userMention := "explain why <response-language> appears in this file"
+	got := WithResponseLanguage(userMention, "en")
+	if !strings.HasPrefix(got, "<response-language>") || !strings.Contains(got, "use English") || !strings.HasSuffix(got, userMention) {
+		t.Fatalf("WithResponseLanguage should prefix user-authored tag mentions, got %q", got)
+	}
+
+	alreadyPrefixed := ResponseLanguageBlock("en") + "\n\n" + userMention
+	if got := WithResponseLanguage(alreadyPrefixed, "en"); got != alreadyPrefixed {
+		t.Fatalf("WithResponseLanguage duplicated a leading injected block:\n got %q\nwant %q", got, alreadyPrefixed)
+	}
+
+	withLeadingMemory := "<memory-update>\nRemember this.\n</memory-update>\n\n" + alreadyPrefixed
+	if got := WithResponseLanguage(withLeadingMemory, "en"); got != withLeadingMemory {
+		t.Fatalf("WithResponseLanguage duplicated a response block after leading transient context:\n got %q\nwant %q", got, withLeadingMemory)
+	}
+}
+
 func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 	userMention := "explain why <reasoning-language> appears in this file"
 	got := WithReasoningLanguage(userMention, "zh")

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -275,6 +275,22 @@ func TestPreviewSessionStripsTransientReasoningLanguageBlock(t *testing.T) {
 	}
 }
 
+func TestPreviewSessionStripsTransientResponseLanguageBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "<response-language>\nFinal answer language preference: use English.\n</response-language>\n\nHelp me debug the auth module"})
+	s.Save(path)
+
+	preview, turns := previewSession(path)
+	if turns != 1 {
+		t.Errorf("turns = %d, want 1", turns)
+	}
+	if preview != "Help me debug the auth module" {
+		t.Errorf("preview = %q, want user prompt", preview)
+	}
+}
+
 func TestPreviewSessionLongMessage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -691,6 +691,7 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		CompactForceRatio: t.compactForceRatio,
 		ArchiveDir:        t.archiveDir,
 		KeepPolicy:        t.keepPolicy,
+		ResponseLanguage:  ResponseLanguageFromContext(ctx),
 		ReasoningLanguage: ReasoningLanguageFromContext(ctx),
 	}, sink)
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1030,6 +1030,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:              ctx,
 		WorkspaceRoot:          root,
 		AutoPlan:               cfg.Agent.AutoPlan,
+		ResponseLanguage:       cfg.ResponseLanguage(),
 		ReasoningLanguage:      cfg.ReasoningLanguage(),
 		DisableColdResumePrune: !cfg.ColdResumePruneEnabled(),
 		Shell:                  shell,

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -519,6 +519,45 @@ model = "x"
 	}
 }
 
+func TestBuildUsesConfiguredLanguageForResponsePreference(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+language = "en"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.requestsSnapshot()
+	if len(reqs) == 0 {
+		t.Fatal("provider requests = 0, want at least one")
+	}
+	if got := bootLastUser(reqs[0]); !strings.Contains(got, "<response-language>") || !strings.Contains(got, "use English") {
+		t.Fatalf("first user turn = %q, want English response preference", got)
+	}
+}
+
 func TestBuildSubagentSkillGetsForegroundOnlyBash(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)

--- a/internal/cli/language.go
+++ b/internal/cli/language.go
@@ -58,6 +58,9 @@ func (m *chatTUI) runLanguageSubcommand(input string) {
 	}
 
 	resolved := i18n.DetectLanguage(lang)
+	if m.ctrl != nil {
+		m.ctrl.SetResponseLanguage(lang)
+	}
 	m.notice(fmt.Sprintf(i18n.M.LanguageChangedFmt, languageDisplay(lang), resolved))
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,29 @@ func (c *Config) ColdResumePruneEnabled() bool {
 	return *c.Agent.ColdResumePrune
 }
 
+// ResponseLanguage normalizes the top-level language preference for final
+// answers. Empty means auto: replies follow the current user turn.
+func (c *Config) ResponseLanguage() string {
+	if c == nil {
+		return "auto"
+	}
+	return NormalizeLanguage(c.Language)
+}
+
+// NormalizeLanguage returns one of auto|zh|en for UI/default reply language settings.
+func NormalizeLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "", "auto", "detect", "default":
+		return "auto"
+	case "zh", "cn", "chinese", "中文":
+		return "zh"
+	case "en", "english":
+		return "en"
+	default:
+		return "auto"
+	}
+}
+
 // ReasoningLanguage normalizes agent.reasoning_language. Empty means auto:
 // visible reasoning follows the conversation language already described by the
 // stable LanguagePolicy. Legacy "default" is treated as auto.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -88,6 +88,7 @@ type Controller struct {
 	memory            memoryManager
 	cleanup           func()
 	autoPlan          string
+	responseLanguage  string
 	reasoningLanguage string
 	// disableColdResumePrune skips stale-tool-result elision on cold resume.
 	// Zero value keeps the prune on (the cheaper default).
@@ -253,6 +254,10 @@ type Options struct {
 	// no confinement). Frontends pass the cwd they launched the session in.
 	WorkspaceRoot string
 	AutoPlan      string
+	// ResponseLanguage controls final-answer language preference. Empty/auto
+	// means no transient injection because the stable language policy follows the
+	// current user turn.
+	ResponseLanguage string
 	// ReasoningLanguage controls visible reasoning language preference. Empty/auto
 	// means no transient injection because the stable language policy already
 	// follows the conversation language.
@@ -311,6 +316,7 @@ func New(opts Options) *Controller {
 		memory:                 newMemoryManager(opts.Memory),
 		cleanup:                opts.Cleanup,
 		autoPlan:               normalizeAutoPlan(opts.AutoPlan),
+		responseLanguage:       config.NormalizeLanguage(opts.ResponseLanguage),
 		reasoningLanguage:      config.NormalizeReasoningLanguage(opts.ReasoningLanguage),
 		disableColdResumePrune: opts.DisableColdResumePrune,
 		shell:                  opts.Shell,
@@ -1338,6 +1344,20 @@ func (c *Controller) SetAutoPlan(mode string) {
 	c.mu.Lock()
 	c.autoPlan = normalizeAutoPlan(mode)
 	c.mu.Unlock()
+}
+
+// SetResponseLanguage updates the final-answer language preference for
+// subsequent turns.
+func (c *Controller) SetResponseLanguage(lang string) {
+	mode := config.NormalizeLanguage(lang)
+	c.mu.Lock()
+	c.responseLanguage = mode
+	c.mu.Unlock()
+	if setter, ok := c.runner.(interface{ SetResponseLanguage(string) }); ok {
+		setter.SetResponseLanguage(mode)
+	} else if c.executor != nil {
+		c.executor.SetResponseLanguage(mode)
+	}
 }
 
 // SetReasoningLanguage updates the visible reasoning language preference for

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -145,6 +145,7 @@ var syntheticPrefixes = []string{
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
+	responseLanguage := c.responseLanguage
 	reasoningLanguage := c.reasoningLanguage
 	c.mu.Unlock()
 	notes := c.memory.drainPending()
@@ -156,6 +157,7 @@ func (c *Controller) Compose(text string) string {
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
 	}
+	text = agent.WithResponseLanguage(text, responseLanguage)
 	text = agent.WithReasoningLanguage(text, reasoningLanguage)
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
@@ -189,8 +191,10 @@ func reasoningLanguageBlock(lang string) string {
 
 func (c *Controller) ComposeSynthetic(text string) string {
 	c.mu.Lock()
+	responseLang := c.responseLanguage
 	lang := c.reasoningLanguage
 	c.mu.Unlock()
+	text = agent.WithResponseLanguage(text, responseLang)
 	return agent.WithReasoningLanguage(text, lang)
 }
 

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -45,7 +45,12 @@ func (f *fakeTurnRunner) Run(ctx context.Context, input string) error {
 
 type fakeLanguageRunner struct {
 	fakeTurnRunner
-	lang string
+	responseLang string
+	lang         string
+}
+
+func (f *fakeLanguageRunner) SetResponseLanguage(lang string) {
+	f.responseLang = lang
 }
 
 func (f *fakeLanguageRunner) SetReasoningLanguage(lang string) {
@@ -148,6 +153,22 @@ func TestComposeReasoningLanguagePreference(t *testing.T) {
 	}
 }
 
+func TestRunComposesResponseLanguagePreference(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	c := New(Options{ResponseLanguage: "en", Runner: runner})
+
+	if err := c.Run(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.inputs) != 1 {
+		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
+	}
+	got := runner.inputs[0]
+	if !strings.HasPrefix(got, "<response-language>") || !strings.Contains(got, "use English") || !strings.HasSuffix(got, "hi") {
+		t.Fatalf("headless Run should compose the response language preference, got %q", got)
+	}
+}
+
 func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	c := New(Options{ReasoningLanguage: "zh", Runner: runner})
@@ -164,6 +185,21 @@ func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 	}
 }
 
+func TestSetResponseLanguageUpdatesRunner(t *testing.T) {
+	runner := &fakeLanguageRunner{}
+	c := New(Options{Runner: runner})
+
+	c.SetResponseLanguage("en")
+	if runner.responseLang != "en" {
+		t.Fatalf("runner response language = %q, want en", runner.responseLang)
+	}
+
+	c.SetResponseLanguage("auto")
+	if runner.responseLang != "auto" {
+		t.Fatalf("runner response language = %q, want auto", runner.responseLang)
+	}
+}
+
 func TestSetReasoningLanguageUpdatesRunner(t *testing.T) {
 	runner := &fakeLanguageRunner{}
 	c := New(Options{Runner: runner})
@@ -176,6 +212,18 @@ func TestSetReasoningLanguageUpdatesRunner(t *testing.T) {
 	c.SetReasoningLanguage("auto")
 	if runner.lang != "auto" {
 		t.Fatalf("runner reasoning language = %q, want auto", runner.lang)
+	}
+}
+
+func TestComposeSyntheticResponseLanguagePreference(t *testing.T) {
+	c := New(Options{ResponseLanguage: "en"})
+
+	got := c.ComposeSynthetic(planApprovedMessage)
+	if !strings.HasPrefix(got, "<response-language>") || !strings.Contains(got, "use English") || !strings.HasSuffix(got, planApprovedMessage) {
+		t.Fatalf("ComposeSynthetic should prefix response language, got %q", got)
+	}
+	if !IsSyntheticUserMessage(got) {
+		t.Fatalf("response-language-prefixed plan approval should still be synthetic")
 	}
 }
 

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -186,6 +186,7 @@ type Input interface {
 
 // Settings covers runtime session settings that don't fit a richer domain.
 type Settings interface {
+	SetResponseLanguage(lang string)
 	SetReasoningLanguage(lang string)
 	SetMemoryCompilerEnabled(enabled bool)
 	SetDisplayRecorder(fn func(content, display string))


### PR DESCRIPTION
## Summary

- Fixes #5159 by making the desktop `Language` setting also drive the user-level final-answer language preference for desktop sessions.
- Supersedes #5161 by rebuilding the same fix on top of the latest `main-v2`, instead of reviving a heavily drifted and conflicting branch.
- Add a transient `<response-language>` block to user turns so new and live-updated sessions honor `language = "en"|"zh"` for replies without changing the cache-stable system prompt or tool schemas.
- Propagate the response-language preference through controller, agent, coordinator, and sub-agent context wiring, and strip the transient block from previews/history-derived text.
- Keep project-level overrides intact: changing the desktop user preference updates global tabs immediately, while project tabs continue to respect their own `reasonix.toml` language override.

Contributor credit:
- @GTC2080 authored the original fix proposal in #5161.
- This PR rebuilds that fix on top of the current `main-v2`, resolves the branch drift/conflicts, and preserves the intended behavior in the current architecture.

Authorship note: @GTC2080 is the primary author of the original #5161 fix. @SivanCola rebuilt and revalidated the change on top of the latest `main-v2` after the original branch drifted and conflicted.

## Verification

- `go test ./internal/agent ./internal/control ./internal/boot ./internal/config -count=1`
- `go test ./... -count=1`
- `go test ./... -count=1` (in `desktop/`)
- `git diff --check`

## Cache impact

Cache-impact: low - the change adds a small transient `<response-language>` user-turn block for explicit reply-language preferences, but it does not change the stable system prompt, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.
Cache-guard: `go test ./internal/agent ./internal/control ./internal/boot ./internal/config -count=1` plus `go test ./... -count=1` cover response-language injection, live controller updates, preview stripping, and boot wiring.
System-prompt-review: Reviewed - no stable system-prompt or tool-schema bytes change. The `<response-language>` preference is injected only into transient user-turn context (mirroring the existing reasoning-language mechanism) and stripped from previews/history; the flagged `internal/boot/*`, `internal/config/config.go`, and `internal/agent/task.go` edits only thread the preference into per-turn user content and sub-agent context, never the cached prefix. Verified by `go test ./internal/agent ./internal/control ./internal/boot ./internal/config -count=1`.

