### PR TITLE
fix(desktop): preserve transcript on settings reload

### DIFF
--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -5,7 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import type { AppBindings } from "../lib/bridge";
 import { useController } from "../lib/useController";
-import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta } from "../lib/types";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -138,13 +138,19 @@ let setActiveCalls = 0;
 let newSessionCalls = 0;
 const runningTabs = new Set<string>();
 const tabsById = new Map([tabA, tabB, tabC, tabD].map((tab) => [tab.id, tab]));
+const eventHandlers: Array<(e: WireEvent) => void> = [];
+const readyHandlers: Array<() => void> = [];
 
 function currentTabs(): TabMeta[] {
   return [tabA, tabB, tabC, tabD].map((tab) => ({ ...tab, active: tab.id === backendActiveId, running: runningTabs.has(tab.id) }));
 }
 
 window.runtime = {
-  EventsOn: () => () => {},
+  EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(cb as (e: WireEvent) => void);
+    if (name === "agent:ready") readyHandlers.push(cb as () => void);
+    return () => {};
+  },
   BrowserOpenURL: () => {},
 };
 window.go = {
@@ -249,6 +255,24 @@ await act(async () => {
 eq(controller?.activeTabId, "tab-a", "late history for another tab does not change the active tab");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "cached A") ?? false, "late history for another tab does not overwrite the active transcript");
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "late B") ?? false), "late history stays scoped to its tab state");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "phase", text: "Planner is thinking", tabId: "tab-a" });
+  for (const handler of eventHandlers) handler({ kind: "message", text: "Planner kept", reasoning: "Planner notes", tabId: "tab-a" });
+  await flushPromises();
+});
+await waitFor("cached planner transcript", () =>
+  controller?.state.items.some((item) => item.kind === "assistant" && item.text === "Planner kept" && item.reasoning === "Planner notes") ?? false
+);
+const historyCallsBeforeReady = historyCalls.length;
+await act(async () => {
+  for (const handler of readyHandlers) handler();
+  await flushPromises();
+});
+await waitFor("ready hydration settled", () => controller?.state.hydrating === false);
+eq(historyCalls.length, historyCallsBeforeReady, "agent ready with cached transcript skips executor-only history hydration");
+ok(controller?.state.items.some((item) => item.kind === "phase" && item.text === "Planner is thinking") ?? false, "agent ready keeps cached planner phase");
+ok(controller?.state.items.some((item) => item.kind === "assistant" && item.text === "Planner kept" && item.reasoning === "Planner notes") ?? false, "agent ready keeps cached planner answer");
 
 await act(async () => {
   controller?.sendToTab("tab-c", "streaming C");

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -947,10 +947,14 @@ export function useController() {
     tabId: string,
     reset = false,
     reason: HydrateReason = "startup",
-    options: { skipHistory?: boolean; placeholderItems?: Item[] } = {},
+    options: { skipHistory?: boolean; placeholderItems?: Item[]; preserveCachedHistory?: boolean } = {},
   ) => {
     const seq = bumpSessionLoadSeq(tabId);
     const hydrateStartedAt = Date.now();
+    const skipHistory = Boolean(
+      options.skipHistory ||
+      (options.preserveCachedHistory && !reset && (statesRef.current.get(tabId)?.items.length ?? 0) > 0),
+    );
     addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
     dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: options.placeholderItems });
     if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
@@ -966,14 +970,14 @@ export function useController() {
     // without waiting for slower ancillary calls (e.g. BalanceForTab network).
     const [meta, history] = await Promise.all([
       app.MetaForTab(tabId).catch((err) => { noteFailure("meta", err); return undefined; }),
-      options.skipHistory
+      skipHistory
         ? Promise.resolve(undefined)
         : app.HistoryForTab(tabId).catch((err) => { noteFailure("history", err); return undefined; }),
     ]);
 
     if (!stillCurrent()) return;
     if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
-    if (!options.skipHistory && history !== undefined) {
+    if (!skipHistory && history !== undefined) {
       const messages = asArray(history);
       dispatchTo(tabId, { type: "history", messages });
       addBreadcrumb(
@@ -986,8 +990,9 @@ export function useController() {
           `history-done ${tabId} count=${messages.length} ms=${Date.now() - historyStartedAt}`,
         );
       }
-    } else if (options.skipHistory) {
-      addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=cached-live-turn`);
+    } else if (skipHistory) {
+      const skipReason = options.skipHistory ? "cached-live-turn" : "cached-transcript";
+      addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=${skipReason}`);
       if (reason === "switch-tab") {
         addBreadcrumb("tab.switch", `history-done ${tabId} skipped ms=${Date.now() - historyStartedAt}`);
       }
@@ -1149,7 +1154,7 @@ export function useController() {
     const offReady = onReady(() => {
       const readyTabId = activeTabIdRef.current;
       if (readyTabId) {
-        void loadSessionDataForTab(readyTabId, false, "startup");
+        void loadSessionDataForTab(readyTabId, false, "startup", { preserveCachedHistory: true });
         return;
       }
       void syncActiveTabFromBackend(false, true);


### PR DESCRIPTION
## Summary

- Preserve the active desktop transcript when an `agent:ready` event rehydrates an already-loaded tab after settings rebuilds the controller.
- Prevent executor-only `HistoryForTab` results from replacing cached Planner phase/reasoning output after sandbox workspace root changes.
- Add regression coverage for ready-event hydration with cached Planner transcript state.
- Fixes #5287.

## Verification

- PASS: `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- PASS: `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/settings-refresh-snapshot.test.tsx`
- FAIL, existing unrelated type errors in untouched tests: `cd desktop/frontend && corepack pnpm run test:typecheck`
  - `src/__tests__/composer-profile.test.ts(150,63): Type '""' is not assignable to type 'ToolApprovalMode | undefined'.`
  - `src/__tests__/composer-profile.test.ts(154,71): Type '""' is not assignable to type 'ToolApprovalMode | undefined'.`
  - `src/__tests__/use-controller-meta.test.ts(90,39): Type '""' is not assignable to type 'ToolApprovalMode | undefined'.`

## Cache impact

Cache-impact: none. Frontend hydration behavior only; provider-visible prompts, tool schemas, serialization, and compaction are unchanged.
Cache-guard: `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/tab-switch-hydration.test.tsx`
System-prompt-review: N/A
