### PR TITLE
fix(desktop): preserve Planner transcript across settings reload (integrates #5293 + #5295) / 修复设置重载丢失 Planner 历史(集成 #5293 + #5295)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3073,13 +3073,20 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 		return []HistoryMessage{}
 	}
 	msgs := ctrl.History()
-	return historyMessages(msgs, sessionDisplayResolver(controllerSessionDir(ctrl), ctrl.SessionPath()))
+	dir := controllerSessionDir(ctrl)
+	path := ctrl.SessionPath()
+	return historyMessagesWithPlannerDisplays(msgs, sessionDisplayResolver(dir, path), sessionPlannerDisplayTurns(dir, path))
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
+	return historyMessagesWithPlannerDisplays(msgs, resolveUserContent, nil)
+}
+
+func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserContent func(string) string, plannerTurns []plannerDisplayTurn) []HistoryMessage {
 	out := make([]HistoryMessage, 0, len(msgs))
 	replayedTodoArgs := historyTodoArgsWithCompleteSteps(msgs)
 	toolResults := historyToolResultsByID(msgs)
+	plannerByUserHash := plannerTurnsByUserHash(plannerTurns)
 	for _, m := range msgs {
 		content := m.Content
 		if m.Role == provider.RoleUser {
@@ -3127,6 +3134,40 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 			hm.Content, hm.ToolResultArchived, hm.ToolResultError = historyToolResultContent(m.Content, m.ToolCallID != "")
 		}
 		out = append(out, hm)
+		if m.Role == provider.RoleUser {
+			if turns := plannerByUserHash[messageDisplayKey(m.Content)]; len(turns) > 0 {
+				out = append(out, cloneHistoryMessages(turns[0].Messages)...)
+				plannerByUserHash[messageDisplayKey(m.Content)] = turns[1:]
+			}
+		}
+	}
+	return out
+}
+
+func plannerTurnsByUserHash(turns []plannerDisplayTurn) map[string][]plannerDisplayTurn {
+	out := map[string][]plannerDisplayTurn{}
+	for _, turn := range turns {
+		if strings.TrimSpace(turn.UserHash) == "" || len(turn.Messages) == 0 {
+			continue
+		}
+		out[turn.UserHash] = append(out[turn.UserHash], turn)
+	}
+	return out
+}
+
+func cloneHistoryMessages(in []HistoryMessage) []HistoryMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]HistoryMessage, len(in))
+	copy(out, in)
+	for i := range out {
+		if len(in[i].MemoryCitations) > 0 {
+			out[i].MemoryCitations = append([]provider.MemoryCitation(nil), in[i].MemoryCitations...)
+		}
+		if len(in[i].ToolCalls) > 0 {
+			out[i].ToolCalls = append([]HistoryToolCall(nil), in[i].ToolCalls...)
+		}
 	}
 	return out
 }
@@ -3440,7 +3481,11 @@ func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return historyMessages(loaded.Snapshot(), sessionDisplayResolver(sessionDir, sessionPath)), nil
+	return historyMessagesWithPlannerDisplays(
+		loaded.Snapshot(),
+		sessionDisplayResolver(sessionDir, sessionPath),
+		sessionPlannerDisplayTurns(sessionDir, sessionPath),
+	), nil
 }
 
 type previewEventRecord struct {

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -5,7 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import type { AppBindings } from "../lib/bridge";
 import { useController } from "../lib/useController";
-import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta } from "../lib/types";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -138,13 +138,19 @@ let setActiveCalls = 0;
 let newSessionCalls = 0;
 const runningTabs = new Set<string>();
 const tabsById = new Map([tabA, tabB, tabC, tabD].map((tab) => [tab.id, tab]));
+const eventHandlers: Array<(e: WireEvent) => void> = [];
+const readyHandlers: Array<() => void> = [];
 
 function currentTabs(): TabMeta[] {
   return [tabA, tabB, tabC, tabD].map((tab) => ({ ...tab, active: tab.id === backendActiveId, running: runningTabs.has(tab.id) }));
 }
 
 window.runtime = {
-  EventsOn: () => () => {},
+  EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(cb as (e: WireEvent) => void);
+    if (name === "agent:ready") readyHandlers.push(cb as () => void);
+    return () => {};
+  },
   BrowserOpenURL: () => {},
 };
 window.go = {
@@ -249,6 +255,24 @@ await act(async () => {
 eq(controller?.activeTabId, "tab-a", "late history for another tab does not change the active tab");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "cached A") ?? false, "late history for another tab does not overwrite the active transcript");
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "late B") ?? false), "late history stays scoped to its tab state");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "phase", text: "Planner is thinking", tabId: "tab-a" });
+  for (const handler of eventHandlers) handler({ kind: "message", text: "Planner kept", reasoning: "Planner notes", tabId: "tab-a" });
+  await flushPromises();
+});
+await waitFor("cached planner transcript", () =>
+  controller?.state.items.some((item) => item.kind === "assistant" && item.text === "Planner kept" && item.reasoning === "Planner notes") ?? false
+);
+const historyCallsBeforeReady = historyCalls.length;
+await act(async () => {
+  for (const handler of readyHandlers) handler();
+  await flushPromises();
+});
+await waitFor("ready hydration settled", () => controller?.state.hydrating === false);
+eq(historyCalls.length, historyCallsBeforeReady, "agent ready with cached transcript skips executor-only history hydration");
+ok(controller?.state.items.some((item) => item.kind === "phase" && item.text === "Planner is thinking") ?? false, "agent ready keeps cached planner phase");
+ok(controller?.state.items.some((item) => item.kind === "assistant" && item.text === "Planner kept" && item.reasoning === "Planner notes") ?? false, "agent ready keeps cached planner answer");
 
 await act(async () => {
   controller?.sendToTab("tab-c", "streaming C");

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -947,10 +947,14 @@ export function useController() {
     tabId: string,
     reset = false,
     reason: HydrateReason = "startup",
-    options: { skipHistory?: boolean; placeholderItems?: Item[] } = {},
+    options: { skipHistory?: boolean; placeholderItems?: Item[]; preserveCachedHistory?: boolean } = {},
   ) => {
     const seq = bumpSessionLoadSeq(tabId);
     const hydrateStartedAt = Date.now();
+    const skipHistory = Boolean(
+      options.skipHistory ||
+      (options.preserveCachedHistory && !reset && (statesRef.current.get(tabId)?.items.length ?? 0) > 0),
+    );
     addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
     dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: options.placeholderItems });
     if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
@@ -966,14 +970,14 @@ export function useController() {
     // without waiting for slower ancillary calls (e.g. BalanceForTab network).
     const [meta, history] = await Promise.all([
       app.MetaForTab(tabId).catch((err) => { noteFailure("meta", err); return undefined; }),
-      options.skipHistory
+      skipHistory
         ? Promise.resolve(undefined)
         : app.HistoryForTab(tabId).catch((err) => { noteFailure("history", err); return undefined; }),
     ]);
 
     if (!stillCurrent()) return;
     if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
-    if (!options.skipHistory && history !== undefined) {
+    if (!skipHistory && history !== undefined) {
       const messages = asArray(history);
       dispatchTo(tabId, { type: "history", messages });
       addBreadcrumb(
@@ -986,8 +990,9 @@ export function useController() {
           `history-done ${tabId} count=${messages.length} ms=${Date.now() - historyStartedAt}`,
         );
       }
-    } else if (options.skipHistory) {
-      addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=cached-live-turn`);
+    } else if (skipHistory) {
+      const skipReason = options.skipHistory ? "cached-live-turn" : "cached-transcript";
+      addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=${skipReason}`);
       if (reason === "switch-tab") {
         addBreadcrumb("tab.switch", `history-done ${tabId} skipped ms=${Date.now() - historyStartedAt}`);
       }
@@ -1149,7 +1154,7 @@ export function useController() {
     const offReady = onReady(() => {
       const readyTabId = activeTabIdRef.current;
       if (readyTabId) {
-        void loadSessionDataForTab(readyTabId, false, "startup");
+        void loadSessionDataForTab(readyTabId, false, "startup", { preserveCachedHistory: true });
         return;
       }
       void syncActiveTabFromBackend(false, true);

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
 )
 
 func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
@@ -62,6 +63,68 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	}
 	if got[3].Reasoning != "tool-call-only thinking" {
 		t.Fatalf("empty-content assistant reasoning = %q, want tool-call-only thinking", got[3].Reasoning)
+	}
+}
+
+func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	handoff := strings.Join([]string{
+		"# Reasonix executor handoff",
+		"",
+		"You are the executor now.",
+		"",
+		"Original task:",
+		"fix the sandbox reload bug",
+		"",
+		"Planner output:",
+		"inspect settings rebuild and preserve planner display",
+		"",
+		"Executor instructions:",
+		"- apply the fix",
+	}, "\n")
+
+	sess := agent.NewSession("system")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: handoff})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "executor kept working"})
+	ag := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: ag, SessionDir: dir, SessionPath: path, Sink: event.Discard})
+	if err := recordSessionDisplay(dir, path, handoff, "fix the sandbox reload bug"); err != nil {
+		t.Fatalf("recordSessionDisplay: %v", err)
+	}
+
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{},
+		activeTabID: "planner_tab",
+	}
+	tab := &WorkspaceTab{ID: "planner_tab", Scope: "global", Ctrl: ctrl, Ready: true, disabledMCP: map[string]ServerView{}}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs[tab.ID] = tab
+
+	tab.sink.Emit(event.Event{Kind: event.TurnStarted})
+	tab.sink.Emit(event.Event{Kind: event.Phase, Text: "deepseek-v4-pro · planning", Source: event.UsageSourcePlanner})
+	tab.sink.Emit(event.Event{Kind: event.Reasoning, Text: "planner thinking\n", Source: event.UsageSourcePlanner})
+	tab.sink.Emit(event.Event{Kind: event.Text, Text: "planner visible plan", Source: event.UsageSourcePlanner})
+	tab.sink.Emit(event.Event{Kind: event.Message, Text: "planner visible plan", Reasoning: "planner thinking\n", Source: event.UsageSourcePlanner})
+	tab.sink.Emit(event.Event{Kind: event.TurnStarted})
+	tab.sink.Emit(event.Event{Kind: event.TurnDone})
+	waitForAutosaveIdle(t, tab)
+
+	got := app.HistoryForTab(tab.ID)
+	if len(got) != 5 {
+		t.Fatalf("history length = %d, want user + planner phase + planner answer + executor answer (plus system skipped later by UI): %+v", len(got), got)
+	}
+	if got[1].Content != "fix the sandbox reload bug" {
+		t.Fatalf("user display content = %q, want original prompt", got[1].Content)
+	}
+	if got[2].Role != "phase" || !strings.Contains(got[2].Content, "planning") {
+		t.Fatalf("planner phase missing after reload: %+v", got)
+	}
+	if got[3].Role != "assistant" || got[3].Content != "planner visible plan" || got[3].Reasoning != "planner thinking\n" {
+		t.Fatalf("planner assistant display missing after reload: %+v", got[3])
+	}
+	if got[4].Role != "assistant" || got[4].Content != "executor kept working" {
+		t.Fatalf("executor answer missing after reload: %+v", got[4])
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -27,6 +27,7 @@ import (
 
 const sessionTitlesFile = ".titles.json"
 const sessionDisplayFile = ".display.json"
+const sessionPlannerDisplayFile = ".planner-display.json"
 const sessionTrashDir = ".trash"
 const sessionTrashMetaFile = ".trash-meta.json"
 
@@ -728,6 +729,13 @@ func validateTrashedSessionPath(dir, sessionPath string) (string, string, string
 
 type sessionDisplayMap map[string]map[string]string
 
+type sessionPlannerDisplayMap map[string][]plannerDisplayTurn
+
+type plannerDisplayTurn struct {
+	UserHash string           `json:"userHash"`
+	Messages []HistoryMessage `json:"messages"`
+}
+
 func messageDisplayKey(content string) string {
 	sum := sha256.Sum256([]byte(content))
 	return fmt.Sprintf("%x", sum[:])
@@ -741,6 +749,83 @@ func loadSessionDisplays(dir string) sessionDisplayMap {
 	}
 	_ = json.Unmarshal(b, &m)
 	return m
+}
+
+func sessionPlannerDisplayPath(dir string) string {
+	return filepath.Join(dir, sessionPlannerDisplayFile)
+}
+
+func loadSessionPlannerDisplays(dir string) sessionPlannerDisplayMap {
+	m := sessionPlannerDisplayMap{}
+	if strings.TrimSpace(dir) == "" {
+		return m
+	}
+	b, err := os.ReadFile(sessionPlannerDisplayPath(dir))
+	if err != nil {
+		return m
+	}
+	_ = json.Unmarshal(b, &m)
+	return m
+}
+
+func saveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".planner-display.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, sessionPlannerDisplayPath(dir))
+}
+
+func recordSessionPlannerDisplay(dir, sessionPath, userContent string, messages []HistoryMessage) error {
+	if strings.TrimSpace(sessionPath) == "" || strings.TrimSpace(userContent) == "" || len(messages) == 0 {
+		return nil
+	}
+	m := loadSessionPlannerDisplays(dir)
+	key := filepath.Base(sessionPath)
+	turn := plannerDisplayTurn{
+		UserHash: messageDisplayKey(userContent),
+		Messages: cloneHistoryMessages(messages),
+	}
+	m[key] = append(m[key], turn)
+	return saveSessionPlannerDisplays(dir, m)
+}
+
+func sessionPlannerDisplayTurns(dir, sessionPath string) []plannerDisplayTurn {
+	if strings.TrimSpace(dir) == "" || strings.TrimSpace(sessionPath) == "" {
+		return nil
+	}
+	turns := loadSessionPlannerDisplays(dir)[filepath.Base(sessionPath)]
+	if len(turns) == 0 {
+		return nil
+	}
+	out := make([]plannerDisplayTurn, 0, len(turns))
+	for _, turn := range turns {
+		if strings.TrimSpace(turn.UserHash) == "" || len(turn.Messages) == 0 {
+			continue
+		}
+		out = append(out, plannerDisplayTurn{
+			UserHash: turn.UserHash,
+			Messages: cloneHistoryMessages(turn.Messages),
+		})
+	}
+	return out
 }
 
 func saveSessionDisplays(dir string, m sessionDisplayMap) error {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -74,6 +74,13 @@ type WorkspaceTab struct {
 	usageTelemetry sessionUsageStats
 	telemMu        sync.Mutex
 
+	// plannerDisplay keeps display-only planner output for the in-flight turn.
+	// The executor session remains the model-facing transcript; this sidecar
+	// lets frontend history restore the planner cards after a rebuild/reload.
+	plannerDisplay      []HistoryMessage
+	plannerDisplayTools map[string]string
+	plannerDisplayMu    sync.Mutex
+
 	model            string // active model ref (for meta)
 	effort           *string
 	tokenMode        string
@@ -498,6 +505,145 @@ func (t *WorkspaceTab) resetTelemetry() {
 	t.telemMu.Unlock()
 }
 
+func (t *WorkspaceTab) resetPlannerDisplayTurn() {
+	t.plannerDisplayMu.Lock()
+	if len(t.plannerDisplay) == 0 {
+		t.plannerDisplayTools = nil
+	}
+	t.plannerDisplayMu.Unlock()
+}
+
+func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
+	if strings.TrimSpace(e.Source) != event.UsageSourcePlanner {
+		return
+	}
+	t.plannerDisplayMu.Lock()
+	defer t.plannerDisplayMu.Unlock()
+	switch e.Kind {
+	case event.Phase:
+		if strings.TrimSpace(e.Text) != "" {
+			t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "phase", Content: e.Text})
+		}
+	case event.Reasoning:
+		if e.Text != "" {
+			hm := t.ensurePlannerAssistantLocked()
+			hm.Reasoning += e.Text
+		}
+	case event.Text:
+		if e.Text != "" {
+			hm := t.ensurePlannerAssistantLocked()
+			hm.Content += e.Text
+		}
+	case event.Message:
+		if e.Text != "" || e.Reasoning != "" || len(e.MemoryCitations) > 0 {
+			hm := t.ensurePlannerAssistantLocked()
+			if e.Text != "" {
+				hm.Content = e.Text
+			}
+			if e.Reasoning != "" {
+				hm.Reasoning = e.Reasoning
+			}
+			if len(e.MemoryCitations) > 0 {
+				hm.MemoryCitations = append([]provider.MemoryCitation(nil), e.MemoryCitations...)
+			}
+		}
+	case event.ToolDispatch:
+		if e.Tool.Partial || strings.TrimSpace(e.Tool.Name) == "" {
+			return
+		}
+		hm := t.ensurePlannerAssistantForToolLocked()
+		call := HistoryToolCall{
+			ID:        e.Tool.ID,
+			Name:      e.Tool.Name,
+			Arguments: e.Tool.Args,
+			Subject:   historyToolSubject(e.Tool.Name, e.Tool.Args),
+			Summary:   historyToolSummary(e.Tool.Name, e.Tool.Args, ""),
+			Diff:      e.Tool.Diff,
+			Added:     e.Tool.Added,
+			Removed:   e.Tool.Removed,
+		}
+		replaced := false
+		if call.ID != "" {
+			for i := range hm.ToolCalls {
+				if hm.ToolCalls[i].ID == call.ID {
+					hm.ToolCalls[i] = call
+					replaced = true
+					break
+				}
+			}
+			if t.plannerDisplayTools == nil {
+				t.plannerDisplayTools = map[string]string{}
+			}
+			t.plannerDisplayTools[call.ID] = call.Name
+		}
+		if !replaced {
+			hm.ToolCalls = append(hm.ToolCalls, call)
+		}
+	case event.ToolResult:
+		callID := strings.TrimSpace(e.Tool.ID)
+		content := firstNonEmpty(e.Tool.Output, e.Tool.Err)
+		display, errPreview := plannerToolResultDisplay(content, e.Tool.Err != "")
+		if callID != "" {
+			updateHistoryToolCallSummary(t.plannerDisplay, callID, content)
+		}
+		toolName := e.Tool.Name
+		if toolName == "" && t.plannerDisplayTools != nil {
+			toolName = t.plannerDisplayTools[callID]
+		}
+		t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{
+			Role:            "tool",
+			ToolCallID:      callID,
+			ToolName:        toolName,
+			Content:         display,
+			ToolResultError: errPreview,
+		})
+	case event.Notice:
+		if strings.TrimSpace(e.Text) != "" {
+			level := "info"
+			if e.Level == event.LevelWarn {
+				level = "warn"
+			}
+			t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "notice", Level: level, Content: e.Text})
+		}
+	}
+}
+
+func (t *WorkspaceTab) ensurePlannerAssistantLocked() *HistoryMessage {
+	if n := len(t.plannerDisplay); n > 0 && t.plannerDisplay[n-1].Role == "assistant" {
+		return &t.plannerDisplay[n-1]
+	}
+	t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "assistant"})
+	return &t.plannerDisplay[len(t.plannerDisplay)-1]
+}
+
+func (t *WorkspaceTab) ensurePlannerAssistantForToolLocked() *HistoryMessage {
+	if n := len(t.plannerDisplay); n > 0 && t.plannerDisplay[n-1].Role == "assistant" && strings.TrimSpace(t.plannerDisplay[n-1].Content) == "" {
+		return &t.plannerDisplay[n-1]
+	}
+	t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "assistant"})
+	return &t.plannerDisplay[len(t.plannerDisplay)-1]
+}
+
+func plannerToolResultDisplay(content string, failed bool) (display, errPreview string) {
+	if strings.TrimSpace(content) == "" {
+		return "", ""
+	}
+	if failed || historyToolResultFailed(content) {
+		display = clipHistoryToolPreview(strings.TrimSpace(content))
+		return display, display
+	}
+	return "", ""
+}
+
+func (t *WorkspaceTab) takePlannerDisplayTurn() []HistoryMessage {
+	t.plannerDisplayMu.Lock()
+	defer t.plannerDisplayMu.Unlock()
+	out := cloneHistoryMessages(t.plannerDisplay)
+	t.plannerDisplay = nil
+	t.plannerDisplayTools = nil
+	return out
+}
+
 // tabEventSink wraps a parent event.Sink and prepends a tabId to every wire
 // event so the frontend can route it to the correct tab's reducer.
 type tabEventSink struct {
@@ -512,6 +658,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if s.app != nil {
 		switch e.Kind {
 		case event.TurnStarted:
+			s.resetPlannerDisplayTurn()
 			s.recordTurnStarted()
 		case event.Usage:
 			s.recordUsageTelemetry(e)
@@ -538,8 +685,12 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if e.Kind == event.ToolResult && e.Tool.Name == "read_file" && e.Tool.Err == "" {
 		s.recordReadTelemetry(e)
 	}
+	if s.app != nil {
+		s.recordPlannerDisplay(e)
+	}
 	// Persist after each turn so a force-kill loses at most the in-flight prompt.
 	if e.Kind == event.TurnDone && s.app != nil {
+		s.flushPlannerDisplay()
 		s.app.scheduleTabSnapshot(s.tabID)
 	}
 }
@@ -781,6 +932,62 @@ func (s *tabEventSink) recordUsageTelemetry(e event.Event) {
 	if sp != "" {
 		_ = saveTelemetry(sp+".telemetry.json", tab.telemetrySnapshot())
 	}
+}
+
+func (s *tabEventSink) resetPlannerDisplayTurn() {
+	tab, _ := s.eventTabAndController()
+	if tab != nil {
+		tab.resetPlannerDisplayTurn()
+	}
+}
+
+func (s *tabEventSink) recordPlannerDisplay(e event.Event) {
+	tab, _ := s.eventTabAndController()
+	if tab != nil {
+		tab.recordPlannerDisplayEvent(e)
+	}
+}
+
+func (s *tabEventSink) flushPlannerDisplay() {
+	tab, ctrl := s.eventTabAndController()
+	if tab == nil || ctrl == nil {
+		return
+	}
+	messages := tab.takePlannerDisplayTurn()
+	if len(messages) == 0 {
+		return
+	}
+	sessionPath := ctrl.SessionPath()
+	if sessionPath == "" {
+		return
+	}
+	userContent := lastUserMessageContent(ctrl.History())
+	if strings.TrimSpace(userContent) == "" {
+		return
+	}
+	_ = recordSessionPlannerDisplay(controllerSessionDir(ctrl), sessionPath, userContent, messages)
+}
+
+func (s *tabEventSink) eventTabAndController() (*WorkspaceTab, control.SessionAPI) {
+	if s.app == nil {
+		return nil, nil
+	}
+	s.app.mu.RLock()
+	defer s.app.mu.RUnlock()
+	tab := s.app.tabByEventSinkIDLocked(s.tabID)
+	if tab == nil {
+		return nil, nil
+	}
+	return tab, tab.Ctrl
+}
+
+func lastUserMessageContent(msgs []provider.Message) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == provider.RoleUser {
+			return msgs[i].Content
+		}
+	}
+	return ""
 }
 
 func (s *tabEventSink) telemetryTab() (*WorkspaceTab, string) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -173,15 +173,15 @@ func (c *Coordinator) SetPlanMode(v bool) {
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
 	if c.shouldPlan != nil && !c.shouldPlan(input) {
-		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, input)
 	}
-	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning"})
+	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning", Source: event.UsageSourcePlanner})
 	plan, err := c.plan(ctx, input)
 	if err != nil {
 		return fmt.Errorf("planner: %w", err)
 	}
-	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
+	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 	if isNoOpPlan(plan) {
 		c.persistExecutorNoOp(ctx, input, plan)
 		c.sink.Emit(event.Event{Kind: event.Text, Text: plan})
@@ -279,7 +279,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 		switch chunk.Type {
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)
-			c.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text})
+			c.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text, Source: event.UsageSourcePlanner})
 		case provider.ChunkUsage:
 			usage = chunk.Usage
 		case provider.ChunkError:
@@ -288,7 +288,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 	}
 	// Closes the planner's raw text block (no markdown redraw) and prints its
 	// usage line, mirroring the old Fprintln + printUsage tail.
-	c.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: c.plannerPricing, UsageSource: event.UsageSourcePlanner})
+	c.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: c.plannerPricing, Source: event.UsageSourcePlanner, UsageSource: event.UsageSourcePlanner})
 
 	plan := text.String()
 	c.plannerSess.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
@@ -321,6 +321,9 @@ func plannerSink(sink event.Sink) event.Sink {
 		case event.TurnStarted, event.TurnDone:
 			return
 		default:
+			if e.Source == "" {
+				e.Source = event.UsageSourcePlanner
+			}
 			sink.Emit(e)
 		}
 	})

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -247,6 +247,7 @@ type Event struct {
 	Tool             Tool                      // ToolDispatch / ToolResult
 	Usage            *provider.Usage           // Usage
 	Pricing          *provider.Pricing         // Usage: for cost display (nil = omit cost)
+	Source           string                    // optional display/event source (executor, planner, subagent, ...)
 	UsageSource      string                    // Usage: billable call source; empty means executor for compatibility
 	CacheDiagnostics *CacheDiagnostics         // Usage: cache-churn attribution (nil = N/A)
 	// SessionHit/SessionMiss carry cumulative cache tokens across the whole


### PR DESCRIPTION
## Summary

Integration PR that fully resolves #5287 (dual-model sessions lose Planner thinking/output when changing the sandbox workspace root triggers a controller rebuild). The bug spans two layers, so this combines two complementary, non-overlapping contributor fixes into one verified change instead of asking either author to absorb the other layer.

Without both layers the bug is only half-fixed: #5293 alone loses Planner output on a full page reload (in-memory cache gone), and #5295 alone still lets the live `agent:ready` rehydration overwrite the in-memory Planner transcript before persistence is read back.

## Contributions

### Frontend hydration — from #5293, authored by @GTC2080
- Preserve the active desktop transcript when an `agent:ready` event rehydrates an already-loaded tab after settings rebuild the controller.
- Add a `preserveCachedHistory` option to `loadSessionDataForTab`: on `agent:ready`, skip the executor-only `HistoryForTab` fetch when the tab already holds a cached transcript (`!reset && items.length > 0`), so cold startup still hydrates normally.
- Distinguish `cached-live-turn` vs `cached-transcript` skip reasons for breadcrumbs.
- Regression coverage: `agent:ready` with a cached Planner transcript skips executor-only history hydration and keeps cached Planner phase + answer.
- Files: `desktop/frontend/src/lib/useController.ts`, `desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx`.

### Backend persistence — from #5295, authored by @dengbushi
- Persist Planner-only display events beside the desktop session transcript and restore them through `HistoryForTab` / session previews after controller rebuilds or reloads.
- Tag coordinator events with planner/executor source metadata so desktop history can capture Planner phase, reasoning, text, tool, and notice display output without mutating the executor model transcript.
- Regression coverage: `TestHistoryForTabRestoresPlannerDisplayAfterReload` and focused desktop history/autosave tests.
- Files: `desktop/app.go`, `desktop/sessions.go`, `desktop/tabs.go`, `desktop/history_test.go`, `internal/agent/coordinator.go`, `internal/event/event.go`.

## Why one integration PR

The two fixes touch different layers with zero file overlap and are each partial on their own. Per the maintainer integration approach, they are combined here with both original commits preserved (authorship intact in git history) rather than rebuilt or squashed. #5293 and #5295 are superseded by this PR and should be closed and cross-linked once this merges.

## Verification

- PASS: `cd desktop/frontend && tsx src/__tests__/tab-switch-hydration.test.tsx` (23/23, incl. ready-event Planner-transcript regression)
- PASS: `cd desktop && go test . -run 'TestHistoryForTabRestoresPlannerDisplayAfterReload|TestHistory|TestPreviewSessionMessages|TestTurnDonePersistsSession|TestNonTurnDoneDoesNotPersist|TestCloseTabNoResurrectionFromAutosave|TestCloseTabSurvivorKeepsAutosave' -count=1`
- PASS: `go test ./internal/event ./internal/agent -count=1`
- PASS: `git diff --check`
- Pre-existing unrelated `tsc` errors in untouched tests (`composer-profile.test.ts`, `use-controller-meta.test.ts`: `toolApprovalMode: ""`) are present on `main-v2` and are not touched by this PR; the changed files are type-clean.

## Authorship note

@GTC2080 and @dengbushi are co-contributors to this shared-repository fix. @GTC2080 authored the frontend hydration fix (originally #5293). @dengbushi authored the backend Planner-history persistence fix (originally #5295). @SivanCola assembled the integration branch on top of the latest `main-v2`, preserved both original commits, and verified the combined result.

## Cache impact

Cache-impact: none - frontend hydration behavior plus desktop session-history persistence and coordinator event source tagging. No change to provider-visible prompts, memory prefix, tool schemas, tool ordering, request serialization, compaction, or MCP/tool registration.
Cache-guard: `cd desktop/frontend && tsx src/__tests__/tab-switch-hydration.test.tsx` plus `cd desktop && go test .` history/autosave tests and `go test ./internal/event ./internal/agent`.
System-prompt-review: N/A - no system-prompt-sensitive files changed (no `internal/boot/*`, `internal/config/config.go`, `internal/agent/task.go`, memory, skill, or system-prompt files).
