### PR TITLE
fix: use OSC 52 directly for clipboard instead of platform-tool-then-…

### DIFF
--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/agent"
@@ -1860,10 +1859,6 @@ func TestCtrlCClearsThenDoublePressQuits(t *testing.T) {
 // with an active text selection copies the selected text to clipboard instead
 // of arming the double-press quit gesture.
 func TestCtrlCCopySelection(t *testing.T) {
-	var copied string
-	clipboardWriteAll = func(text string) error { copied = text; return nil }
-	defer func() { clipboardWriteAll = clipboard.WriteAll }()
-
 	m := newTestChatTUI()
 	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: 4}
 
@@ -1894,11 +1889,8 @@ func TestCtrlCCopySelection(t *testing.T) {
 		t.Fatal("Ctrl+C on selection should return a cmd (clipboard + finalize)")
 	}
 
-	// Execute the command — it should trigger the clipboard stub.
+	// Execute the command (copyToClipboard → OSC 52).
 	cmd()
-	if copied != "hello" {
-		t.Errorf("clipboard should contain selected text %q, got %q", "hello", copied)
-	}
 
 	// Second Ctrl+C should now arm quit (selection is gone).
 	_, cmd2 := m2.Update(ctrlC)
@@ -1985,10 +1977,6 @@ func TestTruncateSubject(t *testing.T) {
 // branch above the clear-input branch so the user's draft survives. After
 // the copy the user can still press Ctrl+C again to clear the composer.
 func TestCtrlCCopyBeatsClearInput(t *testing.T) {
-	var copied string
-	clipboardWriteAll = func(text string) error { copied = text; return nil }
-	defer func() { clipboardWriteAll = clipboard.WriteAll }()
-
 	m := newTestChatTUI()
 	m.input.SetValue("draft I'm typing") // non-empty composer
 	m.transcript = []string{"selected text"}
@@ -2006,9 +1994,10 @@ func TestCtrlCCopyBeatsClearInput(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected clipboard cmd")
 	}
-	cmd()
-	if copied != "selected" {
-		t.Errorf("clipboard = %q, want %q", copied, "selected")
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, c := range batch {
+			c()
+		}
 	}
 
 	// Second Ctrl+C (no selection, non-empty composer) clears the draft.

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -6,7 +6,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -22,24 +21,11 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
-// clipboardWriteAll is the platform clipboard writer; a var so tests can force
-// the failure path (the tmux / SSH scenario) without a real display server.
-var clipboardWriteAll = clipboard.WriteAll
-
-// copyToClipboard writes text to the system clipboard. It first tries the
-// platform tool (xclip / xsel / wl-copy / pbcopy) via atotto; when that fails —
-// typically inside tmux or over SSH where the display server is unreachable — it
-// falls back to OSC 52, which tmux and modern terminals forward to the host
-// clipboard. tea.SetClipboard's command is *run* here so the message it yields
-// (handled by the runtime) reaches the event loop; returning the command itself
-// would be dropped as an unrecognized message and emit nothing.
+// copyToClipboard writes text to the system clipboard via OSC 52, which works
+// over SSH, tmux, and modern terminals. The local platform clipboard tool is
+// not needed — OSC 52 is widely supported.
 func copyToClipboard(text string) tea.Cmd {
-	return func() tea.Msg {
-		if err := clipboardWriteAll(text); err != nil {
-			return tea.SetClipboard(text)()
-		}
-		return nil
-	}
+	return tea.SetClipboard(text)
 }
 
 // autoScrollMsg drives one step of edge-drag scrolling while a selection is held

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -21,9 +21,10 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
-// copyToClipboard writes text to the system clipboard via OSC 52, which works
-// over SSH, tmux, and modern terminals. The local platform clipboard tool is
-// not needed — OSC 52 is widely supported.
+// copyToClipboard writes text through the terminal via OSC 52. That targets the
+// terminal-side clipboard in common SSH/tmux setups when the terminal permits it;
+// platform clipboard tools can instead succeed on the remote host and skip the
+// terminal clipboard path entirely.
 func copyToClipboard(text string) tea.Cmd {
 	return tea.SetClipboard(text)
 }

--- a/internal/cli/transcript_test.go
+++ b/internal/cli/transcript_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
@@ -70,29 +69,10 @@ func TestSelectedTextMultiLine(t *testing.T) {
 	}
 }
 
-func TestCopyToClipboardPlatformSuccess(t *testing.T) {
-	defer func(fn func(string) error) { clipboardWriteAll = fn }(clipboardWriteAll)
-	var got string
-	clipboardWriteAll = func(s string) error { got = s; return nil }
-
-	if msg := copyToClipboard("hello")(); msg != nil {
-		t.Errorf("platform write succeeded; want nil msg (no OSC 52 fallback), got %#v", msg)
-	}
-	if got != "hello" {
-		t.Errorf("clipboardWriteAll got %q, want %q", got, "hello")
-	}
-}
-
-func TestCopyToClipboardOSC52Fallback(t *testing.T) {
-	defer func(fn func(string) error) { clipboardWriteAll = fn }(clipboardWriteAll)
-	clipboardWriteAll = func(string) error { return errors.New("no display (tmux/ssh)") }
-
-	// On failure the command must return the *message* tea.SetClipboard yields —
-	// the runtime handles it by emitting OSC 52 (bubbletea tea.go: setClipboardMsg
-	// -> ansi.SetSystemClipboard). Returning the command itself would be dropped.
-	got := copyToClipboard("copied text")()
-	want := tea.SetClipboard("copied text")()
+func TestCopyToClipboard(t *testing.T) {
+	got := copyToClipboard("hello")()
+	want := tea.SetClipboard("hello")()
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("fallback msg = %#v (%T), want the runtime-handled setClipboardMsg %#v (%T)", got, got, want, want)
+		t.Fatalf("copyToClipboard returned %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
Remove the direct `atotto/clipboard` write path from `copyToClipboard` and the two-tier strategy that tried platform clipboard tools (`xclip`/`wl-copy`/`pbcopy`) before falling back to OSC 52.

Over SSH, a platform clipboard tool can succeed on the remote host, which prevents the OSC 52 fallback from reaching the user's terminal-side clipboard. Using Bubble Tea's `tea.SetClipboard` keeps transcript selection copy on the terminal clipboard path directly.

## Summary

- Simplify transcript selection copy to use `tea.SetClipboard` / OSC 52 directly.
- Remove the test-only `clipboardWriteAll` injection and the platform-success/fallback split.
- Keep Ctrl+C selection tests focused on TUI behavior instead of platform clipboard stubs.
- Clarify that OSC 52 depends on terminal support and avoids remote-host clipboard writes in common SSH/tmux flows.

## Verification

- `go test ./internal/cli`

## Cache impact

Cache-impact: none — CLI/TUI clipboard-copy behavior only; no provider request serialization, system prompt, memory prefix, tool schema, or compaction behavior changes.
Cache-guard: existing cache-impact guard passed on the PR; no cache-sensitive surface changed.
System-prompt-review: N/A — no provider-visible prompt or prefix changes.
