### PR TITLE
fix(config): add Windows home fallback for config discovery

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -7,6 +7,18 @@ import (
 	"strings"
 )
 
+var (
+	runtimeGOOS     = runtime.GOOS
+	osUserHomeDir   = os.UserHomeDir
+	osUserConfigDir = func() string {
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			return ""
+		}
+		return dir
+	}
+)
+
 func userConfigPath() string {
 	dir := userConfigDir()
 	if dir == "" {
@@ -23,17 +35,22 @@ func reasonixHomeDir() string {
 	if dir := cleanEnvDir("REASONIX_HOME"); dir != "" {
 		return dir
 	}
-	if runtime.GOOS != "windows" {
-		if home, err := os.UserHomeDir(); err == nil && home != "" {
-			return filepath.Join(home, ".reasonix")
+	if runtimeGOOS == "windows" {
+		if dir := osUserConfigDir(); dir != "" {
+			return filepath.Join(dir, "reasonix")
+		}
+		if home, err := osUserHomeDir(); err == nil && home != "" {
+			return filepath.Join(home, "AppData", "Roaming", "reasonix")
 		}
 		return ""
 	}
-	dir := osUserConfigDir()
-	if dir == "" {
-		return ""
+	if home, err := osUserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".reasonix")
 	}
-	return filepath.Join(dir, "reasonix")
+	if dir := osUserConfigDir(); dir != "" {
+		return filepath.Join(dir, "reasonix")
+	}
+	return ""
 }
 
 func userConfigLoadPath() string {
@@ -85,7 +102,7 @@ func userConfigCandidatePaths() []string {
 }
 
 func legacyXDGConfigPaths() []string {
-	if runtime.GOOS == "windows" {
+	if runtimeGOOS == "windows" {
 		return nil
 	}
 	seen := map[string]bool{}
@@ -104,7 +121,7 @@ func legacyXDGConfigPaths() []string {
 	if dir := cleanEnvDir("XDG_CONFIG_HOME"); dir != "" {
 		add(filepath.Join(dir, "reasonix", "config.toml"))
 	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
+	if home, err := osUserHomeDir(); err == nil && home != "" {
 		add(filepath.Join(home, ".config", "reasonix", "config.toml"))
 	}
 	return paths
@@ -140,14 +157,6 @@ func userCacheDir() string {
 	return filepath.Join(dir, "reasonix")
 }
 
-func osUserConfigDir() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return ""
-	}
-	return dir
-}
-
 func cleanEnvDir(name string) string {
 	dir := strings.TrimSpace(os.Getenv(name))
 	if dir == "" {
@@ -155,11 +164,11 @@ func cleanEnvDir(name string) string {
 	}
 	dir = ExpandVars(dir)
 	if dir == "~" {
-		if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if home, err := osUserHomeDir(); err == nil && home != "" {
 			dir = home
 		}
 	} else if strings.HasPrefix(dir, "~/") || strings.HasPrefix(dir, `~\`) {
-		if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if home, err := osUserHomeDir(); err == nil && home != "" {
 			dir = filepath.Join(home, dir[2:])
 		}
 	}
@@ -194,7 +203,7 @@ func userConfigDisplayPath() string {
 	if p == "" {
 		return "<os-config-dir>/reasonix/config.toml"
 	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
+	if home, err := osUserHomeDir(); err == nil && home != "" {
 		if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") {
 			return "~/" + filepath.ToSlash(rel)
 		}
@@ -204,8 +213,9 @@ func userConfigDisplayPath() string {
 
 // UserConfigPath is the user-global config.toml. It lives under Reasonix home:
 // REASONIX_HOME/config.toml, then ~/.reasonix/config.toml on Unix-like systems,
-// or %AppData%/reasonix/config.toml on Windows. "" when the user config dir
-// can't be resolved.
+// or %AppData%/reasonix/config.toml on Windows. If %AppData% is unavailable on
+// Windows, it falls back to %USERPROFILE%/AppData/Roaming/reasonix/config.toml.
+// "" when the user config dir can't be resolved.
 func UserConfigPath() string { return userConfigPath() }
 
 // LegacyUserConfigPath is the old OS app-support config.toml path when it
@@ -238,7 +248,8 @@ func LegacyUserConfigPaths() []string {
 
 // ReasonixHomeDir is the current Reasonix home directory. It honors
 // REASONIX_HOME, then uses ~/.reasonix on macOS/Linux or %APPDATA%/reasonix on
-// Windows.
+// Windows, with a %USERPROFILE%/AppData/Roaming fallback when %APPDATA% is
+// unavailable.
 func ReasonixHomeDir() string { return reasonixHomeDir() }
 
 // UserCredentialsPath is the reasonix-owned global .env file under Reasonix
@@ -384,7 +395,7 @@ func CommandDirsForRoot(root string) []string {
 	for _, legacy := range legacyXDGConfigPaths() {
 		add(filepath.Join(filepath.Dir(legacy), "commands"))
 	}
-	if home, err := os.UserHomeDir(); err == nil {
+	if home, err := osUserHomeDir(); err == nil {
 		for _, dir := range conventionSubdirsAsc(home, "commands") {
 			add(dir)
 		}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -62,6 +62,41 @@ func TestUserConfigPathHonorsReasonixHome(t *testing.T) {
 	}
 }
 
+func TestLoadForRootUsesWindowsHomeFallbackWhenConfigDirUnavailable(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	oldGOOS := runtimeGOOS
+	oldConfigDir := osUserConfigDir
+	oldHomeDir := osUserHomeDir
+	runtimeGOOS = "windows"
+	osUserConfigDir = func() string { return "" }
+	osUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		runtimeGOOS = oldGOOS
+		osUserConfigDir = oldConfigDir
+		osUserHomeDir = oldHomeDir
+	})
+
+	t.Setenv("REASONIX_HOME", "")
+
+	configPath := filepath.Join(home, "AppData", "Roaming", "reasonix", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("default_model = \"custom/from-home\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot() error = %v", err)
+	}
+	if cfg.DefaultModel != "custom/from-home" {
+		t.Fatalf("DefaultModel = %q, want %q", cfg.DefaultModel, "custom/from-home")
+	}
+}
+
 func TestRenderTOMLHeaderShowsResolvedConfigPath(t *testing.T) {
 	isolateUserConfigHome(t)
 	out := RenderTOML(Default())


### PR DESCRIPTION
## Summary
- fall back to `%USERPROFILE%/AppData/Roaming/reasonix` when Windows config dir lookup is unavailable
- keep `REASONIX_HOME` and `%APPDATA%` precedence unchanged
- add a regression test for `LoadForRoot` using the home-dir fallback

Fixes #5250

## Verification
- `go test ./internal/config -count=1`
- `go test ./internal/acp ./internal/boot ./internal/config ./internal/mcpdiag ./internal/tool/sessiontool -count=1`
- `gofmt -l internal/config/paths.go internal/config/render_test.go`
- `git diff --check origin/main-v2..HEAD`