### PR TITLE
fix: strip memory-compiler-execution block from user message display

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
-import { ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
+import { BrainCircuit, ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon } from "./ProcessCard";
@@ -364,7 +364,6 @@ export function UserMessage({
         ) : (
           displayText && <div className="msg__text">{displayText}</div>
         )}
-        {hasMemoryCompiler && <span className="msg__memory-badge" title={t("msg.memoryCompilerApplied")}>🧠</span>}
         {failed && <div className="msg__send-failed">{t("msg.sendFailed")}</div>}
         {orderedAttachments.length > 0 && (
           <div className="msg-attachments" aria-label={t("msg.attachments")}>
@@ -392,6 +391,11 @@ export function UserMessage({
             <time className="msg-meta__time" dateTime={sentAt.toISOString()} title={sentAt.toLocaleString()}>
               {formatMessageTime(sentAt)}
             </time>
+          )}
+          {hasMemoryCompiler && (
+            <span className="msg-meta__indicator" title={t("msg.memoryCompilerApplied")} aria-hidden="true">
+              <BrainCircuit size={14} />
+            </span>
           )}
           <CopyButton text={actionText} label={t("msg.copy")} showInlineLabel={false} className="msg-meta__btn msg-meta__copy" />
           {onEdit && (

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
-import { ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
+import { BrainCircuit, ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon } from "./ProcessCard";
@@ -390,6 +390,11 @@ export function UserMessage({
             <time className="msg-meta__time" dateTime={sentAt.toISOString()} title={sentAt.toLocaleString()}>
               {formatMessageTime(sentAt)}
             </time>
+          )}
+          {submitText?.includes("<memory-compiler-execution>") && (
+            <span className="msg-meta__btn msg-meta__memory" title={t("msg.memoryCompilerApplied")}>
+              <BrainCircuit size={14} />
+            </span>
           )}
           <CopyButton text={actionText} label={t("msg.copy")} showInlineLabel={false} className="msg-meta__btn msg-meta__copy" />
           {onEdit && (

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -175,8 +175,11 @@ export function UserMessage({
 }) {
   const t = useT();
   const imSource = parseImSourceMessage(text);
+  const [showRaw, setShowRaw] = useState(false);
   const actionText = stripMemoryCompilerExecution(imSource?.text ?? text);
-  const { text: displayText, attachments } = parseAttachmentRefsForDisplay(actionText);
+  const hasMemoryCompiler = Boolean(submitText?.includes("<memory-compiler-execution>"));
+  const displaySource = showRaw && hasMemoryCompiler && submitText ? submitText : actionText;
+  const { text: displayText, attachments } = parseAttachmentRefsForDisplay(displaySource);
   const orderedAttachments = sortDisplayAttachments(attachments);
   const sourceLabel = imSource ? imSourceLabel(imSource, t) : "";
   const sentAt = createdAt === undefined ? null : messageDate(createdAt);
@@ -391,10 +394,17 @@ export function UserMessage({
               {formatMessageTime(sentAt)}
             </time>
           )}
-          {submitText?.includes("<memory-compiler-execution>") && (
-            <span className="msg-meta__btn msg-meta__memory" title={t("msg.memoryCompilerApplied")}>
+          {hasMemoryCompiler && (
+            <button
+              type="button"
+              className={`msg-meta__btn msg-meta__memory${showRaw ? " msg-meta__memory--active" : ""}`}
+              title={showRaw ? t("msg.memoryCompilerHideRaw") : t("msg.memoryCompilerShowRaw")}
+              aria-label={showRaw ? t("msg.memoryCompilerHideRaw") : t("msg.memoryCompilerShowRaw")}
+              aria-pressed={showRaw}
+              onClick={() => setShowRaw((v) => !v)}
+            >
               <BrainCircuit size={14} />
-            </span>
+            </button>
           )}
           <CopyButton text={actionText} label={t("msg.copy")} showInlineLabel={false} className="msg-meta__btn msg-meta__copy" />
           {onEdit && (

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
-import { BrainCircuit, ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon } from "./ProcessCard";
@@ -175,11 +175,9 @@ export function UserMessage({
 }) {
   const t = useT();
   const imSource = parseImSourceMessage(text);
-  const [showRaw, setShowRaw] = useState(false);
   const actionText = stripMemoryCompilerExecution(imSource?.text ?? text);
   const hasMemoryCompiler = Boolean(submitText?.includes("<memory-compiler-execution>"));
-  const displaySource = showRaw && hasMemoryCompiler && submitText ? submitText : actionText;
-  const { text: displayText, attachments } = parseAttachmentRefsForDisplay(displaySource);
+  const { text: displayText, attachments } = parseAttachmentRefsForDisplay(actionText);
   const orderedAttachments = sortDisplayAttachments(attachments);
   const sourceLabel = imSource ? imSourceLabel(imSource, t) : "";
   const sentAt = createdAt === undefined ? null : messageDate(createdAt);
@@ -366,6 +364,7 @@ export function UserMessage({
         ) : (
           displayText && <div className="msg__text">{displayText}</div>
         )}
+        {hasMemoryCompiler && <span className="msg__memory-badge" title={t("msg.memoryCompilerApplied")}>🧠</span>}
         {failed && <div className="msg__send-failed">{t("msg.sendFailed")}</div>}
         {orderedAttachments.length > 0 && (
           <div className="msg-attachments" aria-label={t("msg.attachments")}>
@@ -393,18 +392,6 @@ export function UserMessage({
             <time className="msg-meta__time" dateTime={sentAt.toISOString()} title={sentAt.toLocaleString()}>
               {formatMessageTime(sentAt)}
             </time>
-          )}
-          {hasMemoryCompiler && (
-            <button
-              type="button"
-              className={`msg-meta__btn msg-meta__memory${showRaw ? " msg-meta__memory--active" : ""}`}
-              title={showRaw ? t("msg.memoryCompilerHideRaw") : t("msg.memoryCompilerShowRaw")}
-              aria-label={showRaw ? t("msg.memoryCompilerHideRaw") : t("msg.memoryCompilerShowRaw")}
-              aria-pressed={showRaw}
-              onClick={() => setShowRaw((v) => !v)}
-            >
-              <BrainCircuit size={14} />
-            </button>
           )}
           <CopyButton text={actionText} label={t("msg.copy")} showInlineLabel={false} className="msg-meta__btn msg-meta__copy" />
           {onEdit && (

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -53,6 +53,15 @@ function parseImSourceMessage(text: string): ImSourceMessage | null {
   };
 }
 
+const MEMORY_COMPILER_EXECUTION_RE = /<memory-compiler-execution>[\s\S]*?<\/memory-compiler-execution>\s*/g;
+
+/** Strips the <memory-compiler-execution> block that the Memory v5 compiler
+ *  injects into user turns for model-internal planning. The block is not
+ *  user-facing text and should be hidden from the transcript display. */
+function stripMemoryCompilerExecution(text: string): string {
+  return text.replace(MEMORY_COMPILER_EXECUTION_RE, "").trimStart();
+}
+
 function imSourceLabel(source: ImSourceMessage, t: ReturnType<typeof useT>): string {
   if (source.label.trim()) return source.label.trim();
   const provider = source.provider.trim().toLowerCase();
@@ -166,7 +175,7 @@ export function UserMessage({
 }) {
   const t = useT();
   const imSource = parseImSourceMessage(text);
-  const actionText = imSource?.text ?? text;
+  const actionText = stripMemoryCompilerExecution(imSource?.text ?? text);
   const { text: displayText, attachments } = parseAttachmentRefsForDisplay(actionText);
   const orderedAttachments = sortDisplayAttachments(attachments);
   const sourceLabel = imSource ? imSourceLabel(imSource, t) : "";

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1472,6 +1472,7 @@ export const en = {
   "msg.thinkingDone": "done",
   "msg.memoryCitationsCount": "{n} memory references",
   "msg.memoryCompilerCitationsCount": "{n} Memory v5 compiler references",
+  "msg.memoryCompilerApplied": "Memory v5 compiler applied to this message",
   "msg.memoryCitationLine": "line {line}",
   "msg.memoryCitationLineRange": "lines {start}-{end}",
   "msg.copy": "Copy",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1473,6 +1473,8 @@ export const en = {
   "msg.memoryCitationsCount": "{n} memory references",
   "msg.memoryCompilerCitationsCount": "{n} Memory v5 compiler references",
   "msg.memoryCompilerApplied": "Memory v5 compiler applied to this message",
+  "msg.memoryCompilerShowRaw": "Show original message text",
+  "msg.memoryCompilerHideRaw": "Hide original message text",
   "msg.memoryCitationLine": "line {line}",
   "msg.memoryCitationLineRange": "lines {start}-{end}",
   "msg.copy": "Copy",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1473,8 +1473,6 @@ export const en = {
   "msg.memoryCitationsCount": "{n} memory references",
   "msg.memoryCompilerCitationsCount": "{n} Memory v5 compiler references",
   "msg.memoryCompilerApplied": "Memory v5 compiler applied to this message",
-  "msg.memoryCompilerShowRaw": "Show original message text",
-  "msg.memoryCompilerHideRaw": "Hide original message text",
   "msg.memoryCitationLine": "line {line}",
   "msg.memoryCitationLineRange": "lines {start}-{end}",
   "msg.copy": "Copy",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -917,6 +917,7 @@ export const zhTW: Record<DictKey, string> = {
   "msg.thinkingDone": "已完成",
   "msg.memoryCitationsCount": "{n} 條記憶引用",
   "msg.memoryCompilerCitationsCount": "{n} 條 Memory v5 編譯引用",
+  "msg.memoryCompilerApplied": "此訊息已套用 Memory v5 編譯器",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "複製",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -918,8 +918,6 @@ export const zhTW: Record<DictKey, string> = {
   "msg.memoryCitationsCount": "{n} 條記憶引用",
   "msg.memoryCompilerCitationsCount": "{n} 條 Memory v5 編譯引用",
   "msg.memoryCompilerApplied": "此訊息已套用 Memory v5 編譯器",
-  "msg.memoryCompilerShowRaw": "顯示原始訊息文字",
-  "msg.memoryCompilerHideRaw": "隱藏原始訊息文字",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "複製",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -918,6 +918,8 @@ export const zhTW: Record<DictKey, string> = {
   "msg.memoryCitationsCount": "{n} 條記憶引用",
   "msg.memoryCompilerCitationsCount": "{n} 條 Memory v5 編譯引用",
   "msg.memoryCompilerApplied": "此訊息已套用 Memory v5 編譯器",
+  "msg.memoryCompilerShowRaw": "顯示原始訊息文字",
+  "msg.memoryCompilerHideRaw": "隱藏原始訊息文字",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "複製",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1475,8 +1475,6 @@ export const zh: Record<DictKey, string> = {
   "msg.memoryCitationsCount": "{n} 条记忆引用",
   "msg.memoryCompilerCitationsCount": "{n} 条 Memory v5 编译引用",
   "msg.memoryCompilerApplied": "此消息已应用 Memory v5 编译器",
-  "msg.memoryCompilerShowRaw": "显示原始消息文本",
-  "msg.memoryCompilerHideRaw": "隐藏原始消息文本",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "复制",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1474,6 +1474,7 @@ export const zh: Record<DictKey, string> = {
   "msg.thinkingDone": "已完成",
   "msg.memoryCitationsCount": "{n} 条记忆引用",
   "msg.memoryCompilerCitationsCount": "{n} 条 Memory v5 编译引用",
+  "msg.memoryCompilerApplied": "此消息已应用 Memory v5 编译器",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "复制",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1475,6 +1475,8 @@ export const zh: Record<DictKey, string> = {
   "msg.memoryCitationsCount": "{n} 条记忆引用",
   "msg.memoryCompilerCitationsCount": "{n} 条 Memory v5 编译引用",
   "msg.memoryCompilerApplied": "此消息已应用 Memory v5 编译器",
+  "msg.memoryCompilerShowRaw": "显示原始消息文本",
+  "msg.memoryCompilerHideRaw": "隐藏原始消息文本",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "复制",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3698,6 +3698,18 @@ a[href] {
   color: var(--fg-faint);
   font-variant-numeric: tabular-nums;
 }
+.msg-meta__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--fg-faint);
+  opacity: 0.45;
+  cursor: default;
+  user-select: none;
+  flex-shrink: 0;
+}
 .msg-meta__btn,
 .msg-meta .copybtn {
   display: inline-flex;
@@ -3832,15 +3844,6 @@ a[href] {
   word-break: break-word;
   font-weight: 450;
   line-height: 1.65;
-}
-.msg__memory-badge {
-  display: inline-block;
-  font-size: 12px;
-  line-height: 1;
-  opacity: 0.5;
-  margin-inline-start: 6px;
-  cursor: default;
-  user-select: none;
 }
 .msg--im-source .msg__body {
   min-width: min(520px, 82%);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3721,6 +3721,9 @@ a[href] {
   color: var(--fg);
   background: var(--button-bg-hover);
 }
+.msg-meta__memory--active {
+  color: var(--accent, #8b5cf6) !important;
+}
 .msg-meta__btn:disabled {
   cursor: not-allowed;
   opacity: 0.4;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3721,9 +3721,6 @@ a[href] {
   color: var(--fg);
   background: var(--button-bg-hover);
 }
-.msg-meta__memory--active {
-  color: var(--accent, #8b5cf6) !important;
-}
 .msg-meta__btn:disabled {
   cursor: not-allowed;
   opacity: 0.4;
@@ -3835,6 +3832,15 @@ a[href] {
   word-break: break-word;
   font-weight: 450;
   line-height: 1.65;
+}
+.msg__memory-badge {
+  display: inline-block;
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0.5;
+  margin-inline-start: 6px;
+  cursor: default;
+  user-select: none;
 }
 .msg--im-source .msg__body {
   min-width: min(520px, 82%);

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -1,18 +1,29 @@
 package agent
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|memory-compiler-execution)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|memory-compiler-execution)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs)>\s*\n?`)
+
+var reMemoryCompilerExecution = regexp.MustCompile(`(?s)<memory-compiler-execution>\s*(.*?)\s*</memory-compiler-execution>`)
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or
 // titles. The blocks are sent in user turns so they never affect the stable
 // prompt prefix, but they should not become user-facing text later.
+//
+// The Memory v5 <memory-compiler-execution> block is handled differently from
+// the prepended transient blocks: it does not prefix the user's prompt, it
+// REPLACES the whole turn (Agent.Run swaps the compiled contract in for the
+// original input, keeping the user's text only in the contract's source_event
+// field). Dropping it like a prefix block would leave an empty string, so we
+// unwrap it to the original prompt instead — otherwise sessions whose first
+// turn was compiled would show a blank history/sidebar preview (#5307).
 func StripTransientUserBlocks(content string) string {
-	s := content
+	s := unwrapMemoryCompilerExecution(content)
 	for {
 		next := reTransientUserBlock.ReplaceAllStringFunc(s, func(string) string {
 			return ""
@@ -23,6 +34,45 @@ func StripTransientUserBlocks(content string) string {
 		s = next
 	}
 	return strings.TrimLeft(s, " \t\r\n")
+}
+
+// unwrapMemoryCompilerExecution replaces a <memory-compiler-execution> contract
+// with the user prompt it was compiled from (the contract's source_event), so
+// display text and previews show what the user typed rather than the raw IR
+// JSON or an empty string. Non-contract content is returned unchanged; a
+// contract without a recoverable source_event collapses to empty, matching the
+// prior "strip the block" behavior only as a last resort.
+func unwrapMemoryCompilerExecution(content string) string {
+	if !strings.Contains(content, "<memory-compiler-execution>") {
+		return content
+	}
+	return reMemoryCompilerExecution.ReplaceAllStringFunc(content, func(block string) string {
+		m := reMemoryCompilerExecution.FindStringSubmatch(block)
+		if len(m) < 2 {
+			return ""
+		}
+		return memoryCompilerSourceEvent(m[1])
+	})
+}
+
+// memoryCompilerSourceEvent pulls the original user prompt out of a compiled
+// execution contract's JSON body. The source_event lives under planner_ir; an
+// older/looser shape may carry it at the top level, so both are checked.
+// Returns "" when the body is not the expected JSON or carries no source_event.
+func memoryCompilerSourceEvent(body string) string {
+	var contract struct {
+		SourceEvent string `json:"source_event"`
+		PlannerIR   struct {
+			SourceEvent string `json:"source_event"`
+		} `json:"planner_ir"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &contract); err != nil {
+		return ""
+	}
+	if s := strings.TrimSpace(contract.PlannerIR.SourceEvent); s != "" {
+		return s
+	}
+	return strings.TrimSpace(contract.SourceEvent)
 }
 
 // UserPreviewText returns the user-authored part of a persisted user message.

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|memory-compiler-execution)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|memory-compiler-execution)>\s*\n?`)
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -1,39 +1,65 @@
 package agent
 
-import "testing"
+import (
+	"testing"
 
-// TestStripTransientUserBlocksRemovesMemoryCompilerExecution guards the
-// contract that the Memory v5 compiler's <memory-compiler-execution> block is
-// treated as a transient, controller-injected block and stripped before the
-// persisted user message becomes display text, a preview, or a title. The block
-// rides in the user turn (so it never affects the stable prompt prefix) but is
-// model-internal planning, not user-facing content.
-func TestStripTransientUserBlocksRemovesMemoryCompilerExecution(t *testing.T) {
-	block := "<memory-compiler-execution>\n{\"type\":\"memory_v5_execution_contract\",\"source_event\":\"add a config loader\"}\n</memory-compiler-execution>"
+	"reasonix/internal/provider"
+)
 
+// realContract mirrors the shape compileExecutionContract emits: the
+// source_event lives under planner_ir, and the block replaces the whole user
+// turn.
+func realContract(sourceEvent string) string {
+	return "<memory-compiler-execution>\n" +
+		`{"type":"memory_v5_execution_contract","instruction":"Execute source_event through planner_ir.",` +
+		`"ir_explanation":{},"planner_ir":{"version":5,"goal":"g","source_event":` + jsonString(sourceEvent) + `}}` +
+		"\n</memory-compiler-execution>"
+}
+
+func jsonString(s string) string {
+	// minimal JSON string quoting for test fixtures (no control chars used here)
+	return `"` + s + `"`
+}
+
+// TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution guards the #5307
+// contract: the Memory v5 <memory-compiler-execution> block REPLACES the user
+// turn (the prompt survives only inside the contract's source_event), so the
+// display/preview path must unwrap it to the original prompt — not drop it like
+// a prepended transient block, which would blank out the turn.
+func TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
 		want string
 	}{
 		{
-			name: "leading block then user text",
-			in:   block + "\nadd a config loader",
+			name: "block only (compiled contract replaced the whole turn)",
+			in:   realContract("add a config loader"),
 			want: "add a config loader",
 		},
 		{
-			name: "language blocks before memory-compiler block",
+			name: "language blocks before the compiler block",
 			// Real composition order: withTurnPreferences wraps the compiled
 			// contract, so the language blocks lead and the compiler block
-			// follows. The loop must peel every leading transient block.
+			// follows. Both must resolve to the original prompt.
 			in: "<reasoning-language>zh</reasoning-language>\n\n" +
-				"<response-language>zh</response-language>\n\n" + block + "\ndo the thing",
+				"<response-language>zh</response-language>\n\n" + realContract("do the thing"),
 			want: "do the thing",
 		},
 		{
-			name: "block only (compiled contract replaced the whole turn)",
-			in:   block,
+			name: "top-level source_event fallback shape",
+			in:   "<memory-compiler-execution>\n{\"source_event\":\"older shape\"}\n</memory-compiler-execution>",
+			want: "older shape",
+		},
+		{
+			name: "unrecoverable contract falls back to empty",
+			in:   "<memory-compiler-execution>\n{\"type\":\"memory_v5_execution_contract\"}\n</memory-compiler-execution>",
 			want: "",
+		},
+		{
+			name: "non-contract content is untouched",
+			in:   "just a normal prompt",
+			want: "just a normal prompt",
 		},
 	}
 	for _, tc := range cases {
@@ -45,12 +71,30 @@ func TestStripTransientUserBlocksRemovesMemoryCompilerExecution(t *testing.T) {
 	}
 }
 
-// TestUserPreviewTextRemovesMemoryCompilerExecution checks the higher-level
-// preview helper (used for session titles and listing previews) also drops the
-// compiler block rather than surfacing raw JSON.
-func TestUserPreviewTextRemovesMemoryCompilerExecution(t *testing.T) {
-	in := "<memory-compiler-execution>\n{\"type\":\"memory_v5_execution_contract\"}\n</memory-compiler-execution>\nship the refactor"
+// TestUserPreviewTextPreservesCompiledTurnPrompt is the regression for the bot
+// finding: a session whose first turn was compiled must still show the user's
+// prompt in history/sidebar previews, not a blank line.
+func TestUserPreviewTextPreservesCompiledTurnPrompt(t *testing.T) {
+	in := realContract("ship the refactor")
 	if got := UserPreviewText(in); got != "ship the refactor" {
-		t.Fatalf("UserPreviewText = %q, want %q", got, "ship the refactor")
+		t.Fatalf("UserPreviewText = %q, want %q (compiled turn must not blank the preview)", got, "ship the refactor")
+	}
+}
+
+// TestSessionPreviewFromMessagesPreservesCompiledFirstTurn proves the end-to-end
+// preview path (used for the picker/sidebar) recovers the prompt when the first
+// persisted user turn is a compiled contract.
+func TestSessionPreviewFromMessagesPreservesCompiledFirstTurn(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: realContract("add pagination to the users endpoint")},
+		{Role: provider.RoleAssistant, Content: "done"},
+	}
+	preview, turns := SessionPreviewFromMessages(msgs)
+	if preview != "add pagination to the users endpoint" {
+		t.Fatalf("preview = %q, want the compiled turn's source_event", preview)
+	}
+	if turns != 1 {
+		t.Fatalf("user turns = %d, want 1", turns)
 	}
 }

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import "testing"
+
+// TestStripTransientUserBlocksRemovesMemoryCompilerExecution guards the
+// contract that the Memory v5 compiler's <memory-compiler-execution> block is
+// treated as a transient, controller-injected block and stripped before the
+// persisted user message becomes display text, a preview, or a title. The block
+// rides in the user turn (so it never affects the stable prompt prefix) but is
+// model-internal planning, not user-facing content.
+func TestStripTransientUserBlocksRemovesMemoryCompilerExecution(t *testing.T) {
+	block := "<memory-compiler-execution>\n{\"type\":\"memory_v5_execution_contract\",\"source_event\":\"add a config loader\"}\n</memory-compiler-execution>"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "leading block then user text",
+			in:   block + "\nadd a config loader",
+			want: "add a config loader",
+		},
+		{
+			name: "language blocks before memory-compiler block",
+			// Real composition order: withTurnPreferences wraps the compiled
+			// contract, so the language blocks lead and the compiler block
+			// follows. The loop must peel every leading transient block.
+			in: "<reasoning-language>zh</reasoning-language>\n\n" +
+				"<response-language>zh</response-language>\n\n" + block + "\ndo the thing",
+			want: "do the thing",
+		},
+		{
+			name: "block only (compiled contract replaced the whole turn)",
+			in:   block,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StripTransientUserBlocks(tc.in); got != tc.want {
+				t.Fatalf("StripTransientUserBlocks(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUserPreviewTextRemovesMemoryCompilerExecution checks the higher-level
+// preview helper (used for session titles and listing previews) also drops the
+// compiler block rather than surfacing raw JSON.
+func TestUserPreviewTextRemovesMemoryCompilerExecution(t *testing.T) {
+	in := "<memory-compiler-execution>\n{\"type\":\"memory_v5_execution_contract\"}\n</memory-compiler-execution>\nship the refactor"
+	if got := UserPreviewText(in); got != "ship the refactor" {
+		t.Fatalf("UserPreviewText = %q, want %q", got, "ship the refactor")
+	}
+}


### PR DESCRIPTION
The Memory v5 compiler injects a `<memory-compiler-execution>` block into user turns for model-internal planning. This block is not user-facing content and should be hidden from the transcript display.

**Changes:**

1. **Backend** (`internal/agent/preview.go`): Add `memory-compiler-execution` to `StripTransientUserBlocks` regex so it is stripped when resolving display text from persisted session messages.

2. **Frontend** (`desktop/frontend/src/components/Message.tsx`, `desktop/frontend/src/styles.css`): Add a disabled-style BrainCircuit indicator icon in the message meta bar (between time and copy button) to show when the compiler was applied — purely decorative, not interactive.

3. **i18n**: Added translation key `msg.memoryCompilerApplied` in en/zh/zh-TW.

**Squashed diff:**
```
 internal/agent/preview.go                   | 2 +-
 desktop/frontend/src/components/Message.tsx | 19 +++++++++++++++++--
 desktop/frontend/src/locales/en.ts          | 1 +
 desktop/frontend/src/locales/zh-TW.ts       | 1 +
 desktop/frontend/src/locales/zh.ts          | 1 +
 desktop/frontend/src/styles.css             | 12 ++++++++++++
 6 files changed, 33 insertions(+), 3 deletions(-)
```