### PR TITLE
fix(agent): skip Memory v5 compiler on goal continuation turns (fixes infinite loop #5325)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -358,6 +358,15 @@ func (a *Agent) SetResponseLanguage(lang string) {
 // It is safe for desktop settings to call while other tabs are idle or running;
 // an already-started turn keeps its own Turn handle and future turns observe the
 // new runtime.
+// isGoalLoopContinue detects synthetic goal continuation turns so the
+// Memory v5 compiler can skip them — re-compiling the same synthetic
+// "Continue pursuing the active goal..." instruction on every loop
+// produces the same execution contract JSON, which some models echo back
+// as text, creating an infinite loop (#5325).
+func isGoalLoopContinue(input string) bool {
+	return strings.HasPrefix(strings.TrimSpace(input), "Continue pursuing the active goal")
+}
+
 func (a *Agent) SetMemoryCompiler(rt *memorycompiler.Runtime) {
 	if a == nil {
 		return
@@ -682,17 +691,24 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	}
 	input = a.withTurnPreferences(rawInput)
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil {
-		if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
-			a.compilerTurn = turn
-			a.emitMemoryCompilerStats(turn)
-			defer func() {
-				turn.Finish(runErr)
-				if a.compilerTurn == turn {
-					a.compilerTurn = nil
+		// Skip the Memory v5 compiler on goal continuation turns: the
+		// synthetic "Continue pursuing the active goal..." instruction is
+		// not a user-authored task and re-compiling it on every loop
+		// produces the same execution contract JSON, causing the model to
+		// echo the contract format back in an infinite loop (#5325).
+		if !isGoalLoopContinue(rawInput) {
+			if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
+				a.compilerTurn = turn
+				a.emitMemoryCompilerStats(turn)
+				defer func() {
+					turn.Finish(runErr)
+					if a.compilerTurn == turn {
+						a.compilerTurn = nil
+					}
+				}()
+				if strings.TrimSpace(compiledInput) != "" {
+					input = a.withTurnPreferences(compiledInput)
 				}
-			}()
-			if strings.TrimSpace(compiledInput) != "" {
-				input = a.withTurnPreferences(compiledInput)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Memory v5 execution compiler was re-compiling synthetic goal continuation turns on every loop iteration, producing the same `memory_v5_execution_contract` JSON repeatedly. Some models echoed this JSON back as text, causing an infinite loop where the same compiled contract was generated, fed to the model, echoed back, and re-compiled 30+ times.

## Root Cause

In `internal/agent/agent.go`, the `Run()` method calls `memCompiler.StartTurn()` for every user turn, including goal continuation turns whose input is always `"Continue pursuing the active goal..."`. The Memory v5 compiler sees the same input every time, produces the same execution contract, and the model sometimes echoes the JSON format back as assistant text, creating an infinite loop.

## Fix

Add `isGoalLoopContinue()` check in `agent.go` to skip the Memory v5 compiler on turns whose leading text matches the synthetic goal continuation instruction. The compiled contract is now only injected on user-authored tasks, not on goal loop iterations.

## Changes

- `internal/agent/agent.go`: Add `isGoalLoopContinue()` helper, wrap `StartTurn()` call with check

## Testing

- `go test ./internal/agent/` — all tests pass
- `go vet ./internal/agent/` — clean
- `gofmt` — clean

Cache-impact: low — only affects agent.go's Run() loop path for goal continuation turns
Cache-guard: `go test ./internal/agent/` passes