### PR TITLE
fix(desktop): load session stats from telemetry on resume (#3450)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3686,10 +3686,14 @@ func firstNonEmpty(values ...string) string {
 // ContextInfo is the prompt-vs-window gauge payload plus session totals. Used
 // and Window both zero means no context-window data yet.
 type ContextInfo struct {
-	Used          int     `json:"used"`
-	Window        int     `json:"window"`
-	SessionTokens int     `json:"sessionTokens"`
-	CompactRatio  float64 `json:"compactRatio,omitempty"`
+	Used            int     `json:"used"`
+	Window          int     `json:"window"`
+	SessionTokens   int     `json:"sessionTokens"`
+	CompactRatio    float64 `json:"compactRatio,omitempty"`
+	SessionCost     float64 `json:"sessionCost,omitempty"`
+	SessionCurrency string  `json:"sessionCurrency,omitempty"`
+	CacheHitTokens  int     `json:"cacheHitTokens,omitempty"`
+	CacheMissTokens int     `json:"cacheMissTokens,omitempty"`
 }
 
 // ContextUsage returns the latest context-window gauge numbers.
@@ -3706,15 +3710,23 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	}
 	a.mu.RUnlock()
 
-	var sessionTokens int
+	var info ContextInfo
 	if tab != nil {
-		sessionTokens = tab.telemetrySnapshot().Usage.TotalTokens
+		snap := tab.telemetrySnapshot()
+		info.SessionTokens = snap.Usage.TotalTokens
+		info.SessionCost = snap.Usage.SessionCost
+		info.SessionCurrency = snap.Usage.SessionCurrency
+		info.CacheHitTokens = snap.Usage.CacheHitTokens
+		info.CacheMissTokens = snap.Usage.CacheMissTokens
 	}
 	if ctrl == nil {
-		return ContextInfo{SessionTokens: sessionTokens}
+		return info
 	}
 	used, window := ctrl.ContextSnapshot()
-	return ContextInfo{Used: used, Window: window, SessionTokens: sessionTokens, CompactRatio: ctrl.CompactRatio()}
+	info.Used = used
+	info.Window = window
+	info.CompactRatio = ctrl.CompactRatio()
+	return info
 }
 
 // BalanceInfo is the wallet-balance readout for the status bar. Available is true

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -134,6 +134,31 @@ console.log("\nuse controller meta");
 }
 
 {
+  const restoredContext = reducer(initialState, {
+    type: "context",
+    context: {
+      used: 42,
+      window: 200,
+      sessionTokens: 120,
+      compactRatio: 0.5,
+      sessionCost: 0.012,
+      sessionCurrency: "$",
+      cacheHitTokens: 80,
+      cacheMissTokens: 20,
+    },
+  });
+  const reset = reducer(restoredContext, { type: "reset" });
+  eq(reset.context.used, 0, "reset clears context used tokens");
+  eq(reset.context.window, 200, "reset preserves context window");
+  eq(reset.context.sessionTokens, 0, "reset clears context session tokens");
+  eq(reset.context.cacheHitTokens, undefined, "reset clears restored cache hit tokens");
+  eq(reset.context.cacheMissTokens, undefined, "reset clears restored cache miss tokens");
+  eq(reset.context.sessionCost, undefined, "reset clears restored context session cost");
+  eq(reset.sessionCost, 0, "reset clears restored session cost state");
+  eq(reset.sessionCurrency, "¥", "reset restores default session currency");
+}
+
+{
   const idleExecutor = reducer(
     { ...initialState, context: { used: 0, window: 200, sessionTokens: 0 } },
     { type: "event", e: { kind: "usage", usage: usage("executor") } },

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -78,6 +78,15 @@ function avgRate(u?: WireUsage): string | null {
   return formatRate(u.sessionCacheHitTokens, denom);
 }
 
+// contextAvgRate computes the session-aggregate cache-hit % from ContextInfo
+// cache tokens (loaded from persisted telemetry on session resume). Used as a
+// fallback when no live WireUsage is available yet.
+function contextAvgRate(ctx: ContextInfo): string | null {
+  const hit = ctx.cacheHitTokens ?? 0;
+  const miss = ctx.cacheMissTokens ?? 0;
+  return formatRate(hit, hit + miss);
+}
+
 function rateValueClass(rate: string | null): string {
   if (rate === null) return "stat__value--empty";
   const pct = Number.parseFloat(rate);
@@ -179,7 +188,7 @@ export function StatusBar({
   const compactNear = pct !== null && compactPct !== null && pct >= Math.max(0, compactPct - 10);
   const compactReached = pct !== null && compactPct !== null && pct >= compactPct;
   const nowPct = nowRate(usage);
-  const avgPct = avgRate(usage);
+  const avgPct = avgRate(usage) ?? contextAvgRate(context);
   const jobsList = jobs ?? [];
   const turnCostLabel = formatMoneyLocalized(turnCost, currency, { locale });
   const costLabel = formatMoneyLocalized(cost, currency, { locale });

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -396,6 +396,10 @@ export interface ContextInfo {
   window: number;
   sessionTokens: number;
   compactRatio?: number;
+  sessionCost?: number;
+  sessionCurrency?: string;
+  cacheHitTokens?: number;
+  cacheMissTokens?: number;
 }
 
 export interface Meta {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -786,7 +786,11 @@ export function reducer(s: State, a: Action): State {
       const sessionTokens = typeof a.context.sessionTokens === "number"
         ? Math.max(0, a.context.sessionTokens)
         : s.sessionTokens;
-      return { ...s, context: a.context, sessionTokens };
+      const sessionCost = typeof a.context.sessionCost === "number" && a.context.sessionCost > 0
+        ? a.context.sessionCost
+        : s.sessionCost;
+      const sessionCurrency = a.context.sessionCurrency || s.sessionCurrency;
+      return { ...s, context: a.context, sessionTokens, sessionCost, sessionCurrency };
     }
     case "balance": return { ...s, balance: a.balance };
     case "effort": return { ...s, effort: a.effort };

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -819,7 +819,7 @@ export function reducer(s: State, a: Action): State {
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined, pendingPrompt: false };
     case "clearAsk": return { ...s, ask: undefined, pendingPrompt: false };
-    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1 };
+    case "reset": return { ...initialState, meta: s.meta, context: { used: 0, window: s.context.window, sessionTokens: 0, compactRatio: s.context.compactRatio }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -74,8 +74,15 @@ func TestWorkspaceTabAggregatesSessionUsageTelemetry(t *testing.T) {
 	}
 
 	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
-	if context := app.ContextUsageForTab("tab"); context.SessionTokens != 140 {
+	context := app.ContextUsageForTab("tab")
+	if context.SessionTokens != 140 {
 		t.Fatalf("context usage session tokens = %d, want 140", context.SessionTokens)
+	}
+	if context.SessionCost <= 0 || context.SessionCurrency != "¥" {
+		t.Fatalf("context usage cost = %f %q, want positive ¥", context.SessionCost, context.SessionCurrency)
+	}
+	if context.CacheHitTokens != 70 || context.CacheMissTokens != 30 {
+		t.Fatalf("context usage cache tokens = hit %d miss %d, want 70/30", context.CacheHitTokens, context.CacheMissTokens)
 	}
 	if panel := app.ContextPanel("tab"); panel.TotalTokens != 140 {
 		t.Fatalf("context panel total tokens = %d, want 140", panel.TotalTokens)


### PR DESCRIPTION
Closes #3450

## Problem

After closing and reopening the Reasonix desktop app, session stats (session cost, currency, cache hit rate) show as 0 or dash (-). Only after sending a new message do the correct stats appear. The telemetry data IS persisted to `.jsonl.telemetry.json` files, but it's never loaded into the frontend `State` on session resume.

### What was happening

The backend `ContextUsageForTab` returned `sessionTokens` from persisted telemetry (correct), but `sessionCost`, `sessionCurrency`, and cache stats were never included. The frontend `State` only received these from live `usage` events during turns. On resume (before the first message), no `usage` events have fired, so these fields stay at their zero defaults.

**StatusBar displayed:**
- sessionCost: `¥0.00` (should be actual cost from telemetry)
- sessionCurrency: `¥` (should be actual currency from telemetry)
- Cache hit rate (avg): `-` (should be computed from telemetry's cumulative cache tokens)

## Changes

### 1. `desktop/app.go` — Extended `ContextInfo` struct

Added `SessionCost`, `SessionCurrency`, `CacheHitTokens`, `CacheMissTokens` fields. Populated from `tab.telemetrySnapshot().Usage` in `ContextUsageForTab`.

### 2. `desktop/frontend/src/lib/types.ts` — Extended `ContextInfo` interface

Added matching optional fields to the TypeScript interface.

### 3. `desktop/frontend/src/lib/useController.ts` — Updated `case "context"` reducer

The reducer now loads `sessionCost` and `sessionCurrency` from the context payload (backed by telemetry) when the values are present and positive.

### 4. `desktop/frontend/src/components/StatusBar.tsx` — Added `contextAvgRate` fallback

When no live `WireUsage` is available (resume before first message), the cache hit rate (avg) is now computed from `context.cacheHitTokens` and `context.cacheMissTokens` (loaded from telemetry), instead of showing "-".

## Files Changed

| File | Change |
|---|---|
| `desktop/app.go` | Extended `ContextInfo` with 4 new fields, populated from telemetry snapshot |
| `desktop/frontend/src/lib/types.ts` | Added 4 optional fields to `ContextInfo` interface |
| `desktop/frontend/src/lib/useController.ts` | Updated `case "context"` reducer to load sessionCost/sessionCurrency |
| `desktop/frontend/src/components/StatusBar.tsx` | Added `contextAvgRate` helper, used as fallback for cache hit rate |
