### PR TITLE
fix: generate unique apiKeyEnv for non-ASCII custom provider names

### DIFF
--- a/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/provider-model-refresh.test.ts
 
 import {
+  apiKeyEnvFromProviderName,
   inferredVisionModels,
   isLikelyChatModel,
   isLikelyVisionModel,
@@ -137,6 +138,21 @@ eq(
   providerApiKeyEnvForSave("Local Gateway", "GATEWAY_KEY", ""),
   "GATEWAY_KEY",
   "preserves an explicitly configured key env",
+);
+
+eq(
+  [
+    apiKeyEnvFromProviderName("商汤"),
+    apiKeyEnvFromProviderName("通义千问"),
+  ],
+  ["CUSTOM_d39b9067_API_KEY", "CUSTOM_e995c4c9_API_KEY"],
+  "generates distinct stable key envs for non-ASCII provider names",
+);
+
+eq(
+  providerApiKeyEnvForSave("商汤", "CUSTOM_API_KEY", "sk-test"),
+  "CUSTOM_API_KEY",
+  "preserves an explicitly configured legacy custom key env",
 );
 
 eq(

--- a/desktop/frontend/src/lib/providerModels.ts
+++ b/desktop/frontend/src/lib/providerModels.ts
@@ -38,7 +38,21 @@ export function apiKeyEnvFromProviderName(name: string): string {
     .toUpperCase()
     .replace(/[^A-Z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
-  return stem ? `${stem}_API_KEY` : "CUSTOM_API_KEY";
+  if (stem) return `${stem}_API_KEY`;
+  // When the provider name is entirely non-ASCII (e.g. Chinese characters),
+  // generate a stable hash suffix so each custom provider gets a unique slot.
+  const hash = fnv1a32(name.trim());
+  return `CUSTOM_${hash}_API_KEY`;
+}
+
+/** 32-bit FNV-1a hash, returns 8-char lowercase hex. Stable and deterministic. */
+function fnv1a32(s: string): string {
+  let hash = 0x811c9dc5 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    hash ^= s.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
 }
 
 export function isLikelyChatModel(model: string): boolean {

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -77,6 +77,30 @@ Do not put API key values in `config.toml`. This file is regular configuration:
 it is safe to inspect, edit, migrate, and include in diagnostics after standard
 redaction. Secrets belong in the global `.env` below.
 
+### Custom provider `api_key_env` names
+
+When a custom provider is added from the desktop settings or `reasonix setup`,
+Reasonix stores a generated `api_key_env` in `config.toml` and writes the secret
+value to the matching key in the global `.env`. The generated name is stable, so
+the same provider keeps using the same credential slot after restart.
+
+Desktop settings derive the default from the provider name. Names that normalize
+to ASCII keep readable env names such as `LOCAL_GATEWAY_API_KEY`; names made
+entirely of non-ASCII characters get a stable hash suffix such as
+`CUSTOM_d39b9067_API_KEY` so two Chinese provider names do not share
+`CUSTOM_API_KEY`.
+
+The CLI custom-provider wizard derives its default from the base URL, for
+example `https://token.sensenova.cn/v1` becomes
+`CUSTOM_TOKEN_SENSENOVA_CN_API_KEY`. Press Enter to accept that default, or type
+an explicit env name such as `CUSTOM_API_KEY` if you intentionally want to share
+one credential across providers.
+
+Existing configs are not rewritten on upgrade. If an old custom provider already
+uses `CUSTOM_API_KEY`, it will keep working with that key. If several old custom
+providers accidentally share `CUSTOM_API_KEY`, edit each provider's
+`api_key_env` to a distinct name and save the corresponding API key again.
+
 ## Global `.env`
 
 `<Reasonix home>/.env` is the single runtime source for provider API keys saved

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -84,14 +84,16 @@ Reasonix stores a generated `api_key_env` in `config.toml` and writes the secret
 value to the matching key in the global `.env`. The generated name is stable, so
 the same provider keeps using the same credential slot after restart.
 
-Desktop settings derive the default from the provider name. Names that normalize
-to ASCII keep readable env names such as `LOCAL_GATEWAY_API_KEY`; names made
+Reasonix derives the default from the provider name. Names that normalize to
+ASCII keep readable env names such as `LOCAL_GATEWAY_API_KEY`; names made
 entirely of non-ASCII characters get a stable hash suffix such as
 `CUSTOM_d39b9067_API_KEY` so two Chinese provider names do not share
 `CUSTOM_API_KEY`.
 
-The CLI custom-provider wizard derives its default from the base URL, for
-example `https://token.sensenova.cn/v1` becomes
+In the CLI custom-provider wizard, the provider name is generated from the base
+URL first, then the same provider-name rule is applied. For example
+`https://token.sensenova.cn/v1` creates provider name
+`custom-token-sensenova-cn`, whose default key env is
 `CUSTOM_TOKEN_SENSENOVA_CN_API_KEY`. Press Enter to accept that default, or type
 an explicit env name such as `CUSTOM_API_KEY` if you intentionally want to share
 one credential across providers.

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -70,6 +70,26 @@ command = "example-mcp-server"
 不要把 API key 的真实值写进 `config.toml`。这个文件是普通配置：可以查看、编辑、
 迁移，也可以在常规脱敏后用于诊断。密钥值属于下面的全局 `.env`。
 
+### 自定义 provider 的 `api_key_env` 命名
+
+通过桌面端设置或 `reasonix setup` 添加自定义 provider 时，Reasonix 会把生成的
+`api_key_env` 保存到 `config.toml`，并把真实密钥值写入全局 `.env` 中同名的 key。
+生成结果是稳定的，因此同一个 provider 重启后仍会读取同一个凭据槽位。
+
+桌面端设置页会根据 provider 名称生成默认值。能规范化成 ASCII 的名称会得到可读的
+env 名，例如 `LOCAL_GATEWAY_API_KEY`；如果名称全部由中文等非 ASCII 字符组成，则会
+生成带稳定 hash 后缀的名称，例如 `CUSTOM_d39b9067_API_KEY`，避免多个中文 provider
+都共用 `CUSTOM_API_KEY`。
+
+CLI 的自定义 provider 向导会根据 base URL 生成默认值，例如
+`https://token.sensenova.cn/v1` 会生成 `CUSTOM_TOKEN_SENSENOVA_CN_API_KEY`。
+直接回车会接受这个默认值；如果你确实想让多个 provider 共用一个凭据，也可以手动输入
+`CUSTOM_API_KEY` 或其他自定义 env 名。
+
+升级时不会自动改写已有配置。旧配置中已经使用 `CUSTOM_API_KEY` 的自定义 provider 会继续
+读取这个 key。若多个旧自定义 provider 已经意外共用了 `CUSTOM_API_KEY`，需要手动把各自的
+`api_key_env` 改成不同名称，并重新保存对应的 API key。
+
 ## 全局 `.env`
 
 `<Reasonix home>/.env` 是 Reasonix 保存的 provider API key 的唯一运行时来源。

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -76,13 +76,14 @@ command = "example-mcp-server"
 `api_key_env` 保存到 `config.toml`，并把真实密钥值写入全局 `.env` 中同名的 key。
 生成结果是稳定的，因此同一个 provider 重启后仍会读取同一个凭据槽位。
 
-桌面端设置页会根据 provider 名称生成默认值。能规范化成 ASCII 的名称会得到可读的
+Reasonix 会根据 provider 名称生成默认值。能规范化成 ASCII 的名称会得到可读的
 env 名，例如 `LOCAL_GATEWAY_API_KEY`；如果名称全部由中文等非 ASCII 字符组成，则会
 生成带稳定 hash 后缀的名称，例如 `CUSTOM_d39b9067_API_KEY`，避免多个中文 provider
 都共用 `CUSTOM_API_KEY`。
 
-CLI 的自定义 provider 向导会根据 base URL 生成默认值，例如
-`https://token.sensenova.cn/v1` 会生成 `CUSTOM_TOKEN_SENSENOVA_CN_API_KEY`。
+CLI 的自定义 provider 向导会先根据 base URL 生成 provider 名称，再套用同一套
+provider-name 规则。例如 `https://token.sensenova.cn/v1` 会生成 provider 名
+`custom-token-sensenova-cn`，默认 key env 是 `CUSTOM_TOKEN_SENSENOVA_CN_API_KEY`。
 直接回车会接受这个默认值；如果你确实想让多个 provider 共用一个凭据，也可以手动输入
 `CUSTOM_API_KEY` 或其他自定义 env 名。
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"unicode/utf16"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
@@ -1282,8 +1283,8 @@ func providerSlug(kind, baseURL string) string {
 	return kind + "-" + slug
 }
 
-func customProviderAPIKeyEnv(baseURL string) string {
-	stem := strings.ToUpper(providerSlug("custom", baseURL))
+func apiKeyEnvFromProviderName(name string) string {
+	stem := strings.ToUpper(strings.TrimSpace(name))
 	stem = strings.Map(func(r rune) rune {
 		switch {
 		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
@@ -1294,9 +1295,18 @@ func customProviderAPIKeyEnv(baseURL string) string {
 	}, stem)
 	stem = strings.Trim(stem, "_")
 	if stem == "" {
-		return "CUSTOM_API_KEY"
+		return "CUSTOM_" + fnv1a32Hex(name) + "_API_KEY"
 	}
 	return stem + "_API_KEY"
+}
+
+func fnv1a32Hex(s string) string {
+	hash := uint32(0x811c9dc5)
+	for _, unit := range utf16.Encode([]rune(strings.TrimSpace(s))) {
+		hash ^= uint32(unit)
+		hash *= 0x01000193
+	}
+	return fmt.Sprintf("%08x", hash)
 }
 
 // providerFamily is a wizard-only grouping of provider SKUs by vendor; it does
@@ -1350,8 +1360,9 @@ func promptCustomProviderManualWith(in *bufio.Scanner, baseURL, keyEnv, apiKey s
 			return nil, fmt.Errorf("base URL is required")
 		}
 	}
+	providerName := providerSlug("custom", baseURL)
 	if keyEnv == "" {
-		keyEnv = ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, customProviderAPIKeyEnv(baseURL))
+		keyEnv = ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, apiKeyEnvFromProviderName(providerName))
 	}
 	if apiKey == "" {
 		apiKey = ask(in, os.Stdout, i18n.M.CustomPromptAPIKey, "")
@@ -1364,7 +1375,7 @@ func promptCustomProviderManualWith(in *bufio.Scanner, baseURL, keyEnv, apiKey s
 		return nil, fmt.Errorf("model name is required")
 	}
 	entry := config.ProviderEntry{
-		Name: providerSlug("custom", baseURL), Kind: "openai", BaseURL: baseURL,
+		Name: providerName, Kind: "openai", BaseURL: baseURL,
 		Model: modelName, APIKeyEnv: keyEnv, ContextWindow: 128000,
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.CustomAddedFmt, entry.Name+"/"+modelName)))
@@ -1383,7 +1394,8 @@ func promptCustomProviderFromURL() ([]config.ProviderEntry, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("base URL is required")
 	}
-	keyEnv := ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, customProviderAPIKeyEnv(baseURL))
+	providerName := providerSlug("custom", baseURL)
+	keyEnv := ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, apiKeyEnvFromProviderName(providerName))
 	apiKey := ask(in, os.Stdout, i18n.M.CustomPromptAPIKey, "")
 	if apiKey != "" {
 		os.Setenv(keyEnv, apiKey)
@@ -1416,7 +1428,7 @@ func promptCustomProviderFromURL() ([]config.ProviderEntry, error) {
 		selected = append(selected, models[i])
 	}
 	entry := config.ProviderEntry{
-		Name: providerSlug("custom", baseURL), Kind: "openai", BaseURL: baseURL,
+		Name: providerName, Kind: "openai", BaseURL: baseURL,
 		Models: selected, Model: selected[0], APIKeyEnv: keyEnv, ContextWindow: 128000,
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.CustomAddedFmt, entry.Name+"/"+selected[0])))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1274,7 +1274,29 @@ func providerSlug(kind, baseURL string) string {
 			}
 		}
 	}
-	return kind + "-" + strings.TrimRight(b.String(), "-")
+	slug := strings.TrimRight(b.String(), "-")
+	if slug == "" {
+		sum := sha1.Sum([]byte(baseURL))
+		return kind + "-" + hex.EncodeToString(sum[:4])
+	}
+	return kind + "-" + slug
+}
+
+func customProviderAPIKeyEnv(baseURL string) string {
+	stem := strings.ToUpper(providerSlug("custom", baseURL))
+	stem = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, stem)
+	stem = strings.Trim(stem, "_")
+	if stem == "" {
+		return "CUSTOM_API_KEY"
+	}
+	return stem + "_API_KEY"
 }
 
 // providerFamily is a wizard-only grouping of provider SKUs by vendor; it does
@@ -1329,7 +1351,7 @@ func promptCustomProviderManualWith(in *bufio.Scanner, baseURL, keyEnv, apiKey s
 		}
 	}
 	if keyEnv == "" {
-		keyEnv = ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, "CUSTOM_API_KEY")
+		keyEnv = ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, customProviderAPIKeyEnv(baseURL))
 	}
 	if apiKey == "" {
 		apiKey = ask(in, os.Stdout, i18n.M.CustomPromptAPIKey, "")
@@ -1361,7 +1383,7 @@ func promptCustomProviderFromURL() ([]config.ProviderEntry, error) {
 	if baseURL == "" {
 		return nil, fmt.Errorf("base URL is required")
 	}
-	keyEnv := ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, "CUSTOM_API_KEY")
+	keyEnv := ask(in, os.Stdout, i18n.M.CustomPromptKeyEnv, customProviderAPIKeyEnv(baseURL))
 	apiKey := ask(in, os.Stdout, i18n.M.CustomPromptAPIKey, "")
 	if apiKey != "" {
 		os.Setenv(keyEnv, apiKey)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1182,6 +1182,75 @@ func TestProviderSlug(t *testing.T) {
 			t.Errorf("fallback slug = %q, want 8 hex chars after prefix", got)
 		}
 	})
+
+	t.Run("sha1 fallback for non-ascii host", func(t *testing.T) {
+		got := providerSlug("custom", "https://例子.测试/v1")
+		if !strings.HasPrefix(got, "custom-") || got == "custom-" {
+			t.Errorf("fallback slug = %q, want custom-<hex>", got)
+		}
+		if len(got) != len("custom-")+8 {
+			t.Errorf("fallback slug = %q, want 8 hex chars after prefix", got)
+		}
+	})
+}
+
+func TestCustomProviderAPIKeyEnv(t *testing.T) {
+	cases := []struct {
+		name, baseURL, want string
+	}{
+		{"standard host", "https://token.sensenova.cn/v1", "CUSTOM_TOKEN_SENSENOVA_CN_API_KEY"},
+		{"localhost with port", "http://localhost:11434/v1", "CUSTOM_LOCALHOST_11434_API_KEY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := customProviderAPIKeyEnv(tc.baseURL); got != tc.want {
+				t.Errorf("customProviderAPIKeyEnv(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("non-ascii host does not collapse to shared custom key", func(t *testing.T) {
+		got := customProviderAPIKeyEnv("https://例子.测试/v1")
+		if got == "CUSTOM_API_KEY" || !strings.HasPrefix(got, "CUSTOM_") || !strings.HasSuffix(got, "_API_KEY") {
+			t.Errorf("customProviderAPIKeyEnv(non-ascii) = %q, want stable CUSTOM_<hash>_API_KEY", got)
+		}
+	})
+}
+
+func TestPromptCustomProviderManualDefaultsKeyEnvFromBaseURL(t *testing.T) {
+	entries, err := promptCustomProviderManualWith(
+		bufio.NewScanner(strings.NewReader("\n\nsensenova-chat\n")),
+		"https://token.sensenova.cn/v1",
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("promptCustomProviderManualWith: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if got, want := entries[0].APIKeyEnv, "CUSTOM_TOKEN_SENSENOVA_CN_API_KEY"; got != want {
+		t.Errorf("APIKeyEnv = %q, want %q", got, want)
+	}
+}
+
+func TestPromptCustomProviderManualPreservesExplicitKeyEnv(t *testing.T) {
+	entries, err := promptCustomProviderManualWith(
+		bufio.NewScanner(strings.NewReader("\nmanual-chat\n")),
+		"https://token.sensenova.cn/v1",
+		"CUSTOM_API_KEY",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("promptCustomProviderManualWith: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if got := entries[0].APIKeyEnv; got != "CUSTOM_API_KEY" {
+		t.Errorf("APIKeyEnv = %q, want explicit CUSTOM_API_KEY", got)
+	}
 }
 
 // TestFilterStaleCustomEntries covers the wizard's auto-cleanup of legacy

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1194,25 +1194,28 @@ func TestProviderSlug(t *testing.T) {
 	})
 }
 
-func TestCustomProviderAPIKeyEnv(t *testing.T) {
+func TestAPIKeyEnvFromProviderName(t *testing.T) {
 	cases := []struct {
-		name, baseURL, want string
+		name, providerName, want string
 	}{
-		{"standard host", "https://token.sensenova.cn/v1", "CUSTOM_TOKEN_SENSENOVA_CN_API_KEY"},
-		{"localhost with port", "http://localhost:11434/v1", "CUSTOM_LOCALHOST_11434_API_KEY"},
+		{"custom host slug", "custom-token-sensenova-cn", "CUSTOM_TOKEN_SENSENOVA_CN_API_KEY"},
+		{"localhost slug with port", "custom-localhost-11434", "CUSTOM_LOCALHOST_11434_API_KEY"},
+		{"desktop-style custom name", "Local Gateway", "LOCAL_GATEWAY_API_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := customProviderAPIKeyEnv(tc.baseURL); got != tc.want {
-				t.Errorf("customProviderAPIKeyEnv(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			if got := apiKeyEnvFromProviderName(tc.providerName); got != tc.want {
+				t.Errorf("apiKeyEnvFromProviderName(%q) = %q, want %q", tc.providerName, got, tc.want)
 			}
 		})
 	}
 
-	t.Run("non-ascii host does not collapse to shared custom key", func(t *testing.T) {
-		got := customProviderAPIKeyEnv("https://例子.测试/v1")
-		if got == "CUSTOM_API_KEY" || !strings.HasPrefix(got, "CUSTOM_") || !strings.HasSuffix(got, "_API_KEY") {
-			t.Errorf("customProviderAPIKeyEnv(non-ascii) = %q, want stable CUSTOM_<hash>_API_KEY", got)
+	t.Run("non-ascii provider names use desktop-compatible hash fallback", func(t *testing.T) {
+		if got, want := apiKeyEnvFromProviderName("商汤"), "CUSTOM_d39b9067_API_KEY"; got != want {
+			t.Errorf("apiKeyEnvFromProviderName(non-ascii) = %q, want %q", got, want)
+		}
+		if got := apiKeyEnvFromProviderName("通义千问"); got == "CUSTOM_d39b9067_API_KEY" || got == "CUSTOM_API_KEY" {
+			t.Errorf("apiKeyEnvFromProviderName(second non-ascii) = %q, want distinct stable fallback", got)
 		}
 	})
 }


### PR DESCRIPTION
Previously, apiKeyEnvFromProviderName() returned `CUSTOM_API_KEY` for any provider name consisting entirely of non-ASCII characters (e.g. Chinese). All such custom providers shared the same credential slot, so adding a new one silently overwrote the previous provider's API key.

Now an FNV-1a hash suffix ensures each desktop custom provider gets a unique slot like `CUSTOM_d39b9067_API_KEY`. The CLI custom-provider wizard also derives its default key env from the generated provider name instead of defaulting every custom provider to `CUSTOM_API_KEY`.

Fixes #4708

## Summary

- Generate distinct stable default key env names for non-ASCII desktop custom provider names.
- Use the same provider-name-derived key env rule for CLI custom providers; the CLI first derives the provider name from the base URL, then generates a default such as `CUSTOM_TOKEN_SENSENOVA_CN_API_KEY` while preserving explicit user-entered env names like `CUSTOM_API_KEY`.
- Document custom provider `api_key_env` usage and upgrade notes in the config paths docs.
- Add focused regression coverage for desktop key env generation and CLI custom-provider defaults.

## Verification

- `pnpm --dir desktop/frontend exec tsx src/__tests__/provider-model-refresh.test.ts` passed.
- `go test ./internal/cli -run 'TestProviderSlug|TestAPIKeyEnvFromProviderName|TestPromptCustomProviderManual|TestConfigureKeys'` passed.
- `go test ./internal/cli` passed.
- `git diff --check` passed.

Note: `pnpm --dir desktop/frontend run test:typecheck` currently fails on an existing unrelated test type mismatch in `src/__tests__/capabilities-panel-actions.test.ts` (`"auto"` is not assignable to `Mode`).

## Cache impact

Cache-impact: none; this only changes settings-time key env generation, tests, and docs. It does not change provider request serialization, system prompts, memory prefix, tool schemas, or runtime prompt assembly.
Cache-guard: `pnpm --dir desktop/frontend exec tsx src/__tests__/provider-model-refresh.test.ts`; `go test ./internal/cli`.
System-prompt-review: N/A
