### PR TITLE
fix(provider): backfill Name in pairToolResults for existing tool res…

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -225,6 +225,9 @@ func toolTurnWellFormed(calls []ToolCall, results []Message) bool {
 		if results[k].ToolCallID != tc.ID {
 			return false
 		}
+		if results[k].Name != tc.Name {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -334,6 +334,7 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 		}
 		for _, tc := range calls {
 			if r, ok := byID[tc.ID]; ok {
+				r.Name = tc.Name
 				out = append(out, r)
 			} else {
 				out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
@@ -345,6 +346,7 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 		if k < len(avail) {
 			r := avail[k]
 			r.ToolCallID = tc.ID
+			r.Name = tc.Name
 			out = append(out, r)
 		} else {
 			out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -223,6 +223,20 @@ func TestSanitizeToolPairingBackfillsEmptyName(t *testing.T) {
 	}
 }
 
+func TestSanitizeToolPairingBackfillsMissingToolResultName(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "ls"}}},
+		{Role: RoleTool, ToolCallID: "c1", Content: "main.go"},
+	}
+	out := SanitizeToolPairing(in)
+	if out[1].Name != "ls" {
+		t.Fatalf("missing tool result name not backfilled: %+v", out[1])
+	}
+	if in[1].Name != "" {
+		t.Fatalf("stored history mutated: %+v", in[1])
+	}
+}
+
 // --- Pricing.Cost ---
 
 func TestPricingCostNil(t *testing.T) {


### PR DESCRIPTION
## Summary

`pairToolResults` already set `Name` on backfilled new tool results, but left it empty when reusing an existing result. If a saved session carried a tool message without `Name`, `SanitizeToolPairing` would not repair it, and DeepSeek's API rejects tool-role messages with a missing `name` field (HTTP 400). GLM's endpoint does not validate this, so the bug only surfaced after switching providers.

This PR now sets `r.Name = tc.Name` on both the id-matched and positional result reuse paths, matching the placeholder backfill behavior. A follow-up fix also treats tool results whose `Name` does not match the paired tool call as malformed in the fast path, so the repair path actually runs for saved sessions with missing tool-result names.

## Verification

- `go test ./internal/provider -run TestSanitizeToolPairingBackfillsMissingToolResultName -count=1`
- `go test ./internal/provider/... -count=1`
- `go test ./...`

## Cache impact

Cache-impact: low - only malformed histories with missing or mismatched tool-result names are rewritten immediately before provider sends; stable system prompts, tool schemas, tool order, and healthy session prefixes stay unchanged. Affected old sessions may get a one-time provider-visible message repair so DeepSeek receives the required `name` field instead of returning HTTP 400.
Cache-guard: `TestSanitizeToolPairingBackfillsMissingToolResultName` plus `go test ./internal/provider/... -count=1` verify the malformed-history repair path and provider package behavior.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior changed.

## Authorship note

@liugh-dev is the primary author of this PR. @SivanCola contributed as a collaborator by reviewing the provider fast path, adding the follow-up regression fix, and verifying the final state.
