### PR TITLE
fix(desktop): paginate restored transcript warm turns

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildTurnGroups } from "../lib/transcriptGrouping";
+import { buildTurnGroups, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -75,6 +75,23 @@ console.log("\ntranscript grouping contract");
   const elapsed = performance.now() - start;
   eq(groups.length, 10_000, "large transcript grouping keeps every turn");
   ok(elapsed < 50, `groups 10k turns in ${elapsed.toFixed(2)}ms`);
+}
+
+{
+  const firstPage = warmPagination({ turnCount: 100, hotTurns: 30, pageSize: 20, coldPage: 0 });
+  eq(firstPage.warmStartTurn, 50, "long transcripts initially render only the latest warm page");
+  eq(firstPage.warmEndTurn, 70, "warm page stops before the hot zone");
+  eq(firstPage.coldTurnCount, 50, "older cold turns stay hidden behind the load-more button");
+
+  const secondPage = warmPagination({ turnCount: 100, hotTurns: 30, pageSize: 20, coldPage: 1 });
+  eq(secondPage.warmStartTurn, 30, "loading earlier history adds one more warm page");
+  eq(secondPage.warmEndTurn, 70, "loading earlier history keeps the hot-zone boundary stable");
+  eq(secondPage.coldTurnCount, 30, "loading earlier history reduces the hidden cold count");
+
+  const shortTranscript = warmPagination({ turnCount: 25, hotTurns: 30, pageSize: 20, coldPage: 0 });
+  eq(shortTranscript.warmStartTurn, 0, "short transcripts have no warm zone");
+  eq(shortTranscript.warmEndTurn, 0, "short transcripts have no warm boundary");
+  eq(shortTranscript.coldTurnCount, 0, "short transcripts have no cold turns");
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildTurnGroups, createWarmLayerState, warmLayerForSession, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
+import { buildTurnGroups, createWarmLayerState, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -95,6 +95,13 @@ console.log("\ntranscript grouping contract");
 }
 
 {
+  eq(warmColdPageForTurn({ turn: 10, turnCount: 100, hotTurns: 30, pageSize: 20 }), 2, "jumping to cold-zone turn 10 loads enough warm pages");
+  eq(warmColdPageForTurn({ turn: 0, turnCount: 100, hotTurns: 30, pageSize: 20 }), 3, "jumping to the first warm turn loads all warm pages");
+  eq(warmColdPageForTurn({ turn: 65, turnCount: 100, hotTurns: 30, pageSize: 20 }), 0, "jumping inside the initial warm page needs no extra cold page");
+  eq(warmColdPageForTurn({ turn: 80, turnCount: 100, hotTurns: 30, pageSize: 20 }), 0, "jumping inside the hot zone needs no warm pagination");
+}
+
+{
   let state = createWarmLayerState("tab-a|0|a-u0");
   state = warmLayerWithNextColdPage(state, "tab-a|0|a-u0");
   state = warmLayerWithNextColdPage(state, "tab-a|0|a-u0");
@@ -109,6 +116,10 @@ console.log("\ntranscript grouping contract");
 
   const switchedPage = warmPagination({ turnCount: 100, hotTurns: 30, pageSize: 20, coldPage: switched.coldPage });
   eq(switchedPage.warmStartTurn, 50, "switched long transcripts render only the latest warm page first");
+
+  const paged = warmLayerWithColdPageAtLeast(switched, "tab-b|1|b-u0", 2);
+  eq(paged.coldPage, 2, "jumping to a cold-zone question raises the session warm page");
+  eq(warmLayerWithColdPageAtLeast(paged, "tab-b|1|b-u0", 1).coldPage, 2, "jumping never lowers the loaded warm page");
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildTurnGroups, warmPagination } from "../lib/transcriptGrouping";
+import { buildTurnGroups, createWarmLayerState, warmLayerForSession, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -92,6 +92,23 @@ console.log("\ntranscript grouping contract");
   eq(shortTranscript.warmStartTurn, 0, "short transcripts have no warm zone");
   eq(shortTranscript.warmEndTurn, 0, "short transcripts have no warm boundary");
   eq(shortTranscript.coldTurnCount, 0, "short transcripts have no cold turns");
+}
+
+{
+  let state = createWarmLayerState("tab-a|0|a-u0");
+  state = warmLayerWithNextColdPage(state, "tab-a|0|a-u0");
+  state = warmLayerWithNextColdPage(state, "tab-a|0|a-u0");
+  state = warmLayerWithNextColdPage(state, "tab-a|0|a-u0");
+  state = warmLayerWithExpandedTurn(state, "tab-a|0|a-u0", 10, true);
+  eq(state.coldPage, 3, "loading earlier history advances the current session page");
+  ok(state.expandedWarmTurns.has(10), "expanded warm turns stay scoped to the current session");
+
+  const switched = warmLayerForSession(state, "tab-b|1|b-u0");
+  eq(switched.coldPage, 0, "switching sessions resets warm pagination before rendering");
+  eq(switched.expandedWarmTurns.size, 0, "switching sessions clears expanded warm turns");
+
+  const switchedPage = warmPagination({ turnCount: 100, hotTurns: 30, pageSize: 20, coldPage: switched.coldPage });
+  eq(switchedPage.warmStartTurn, 50, "switched long transcripts render only the latest warm page first");
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildTurnGroups, compactQuestionText, questionAnchorId, scrollVersion, warmUserPreview, type QuestionAnchor, type TurnGroup } from "../lib/transcriptGrouping";
+import { buildTurnGroups, compactQuestionText, questionAnchorId, scrollVersion, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup } from "../lib/transcriptGrouping";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -271,9 +271,10 @@ export function Transcript({
   }, [items]);
 
   // How many turns are in the cold zone (not yet shown).
-  const warmTurnCount = turnGroups.length - Math.min(turnGroups.length, HOT_TURNS);
-  const shownWarmStart = Math.max(0, warmTurnCount - coldPage * WARM_PAGE_SIZE);
-  const coldTurnCount = shownWarmStart;
+  const { warmStartTurn, warmEndTurn, coldTurnCount } = useMemo(
+    () => warmPagination({ turnCount: turnGroups.length, hotTurns: HOT_TURNS, pageSize: WARM_PAGE_SIZE, coldPage }),
+    [coldPage, turnGroups.length],
+  );
 
   // ── The turn action menu ──────────────────────────────────────────────────
   const [openAction, setOpenAction] = useState<OpenTurnAction | null>(null);
@@ -609,7 +610,8 @@ export function Transcript({
             <WarmZone
               turnGroups={turnGroups}
               expandedWarmTurns={expandedWarmTurns}
-              shownWarmStart={shownWarmStart}
+              warmStartTurn={warmStartTurn}
+              warmEndTurn={warmEndTurn}
               coldTurnCount={coldTurnCount}
               scrollRef={scrollRef}
               warmItems={items}
@@ -667,7 +669,8 @@ export function Transcript({
 const WarmZone = memo(function WarmZone({
   turnGroups,
   expandedWarmTurns,
-  shownWarmStart,
+  warmStartTurn,
+  warmEndTurn,
   coldTurnCount,
   scrollRef,
   warmItems,
@@ -688,7 +691,8 @@ const WarmZone = memo(function WarmZone({
 }: {
   turnGroups: TurnGroup[];
   expandedWarmTurns: ReadonlySet<number>;
-  shownWarmStart: number;
+  warmStartTurn: number;
+  warmEndTurn: number;
   coldTurnCount: number;
   scrollRef: React.RefObject<HTMLDivElement | null>;
   warmItems: readonly Item[];
@@ -725,10 +729,8 @@ const WarmZone = memo(function WarmZone({
   }
 
   // 2. Warm zone: collapsed/expanded warm turn cards.
-  let warmStartTurn = 0;
   if (turnGroups.length > HOT_TURNS) {
-    warmStartTurn = turnGroups.length - HOT_TURNS - shownWarmStart;
-    for (let g = warmStartTurn; g < turnGroups.length - HOT_TURNS; g++) {
+    for (let g = warmStartTurn; g < warmEndTurn; g++) {
       const group = turnGroups[g];
       if (!group) continue;
       const expanded = expandedWarmTurns.has(g);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, scrollVersion, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
+import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -131,6 +131,7 @@ export function Transcript({
   } = useScrollManager();
   const autoScrollFrame = useRef<number | null>(null);
   const pendingRevealBottomScroll = useRef(false);
+  const pendingQuestionJump = useRef<QuestionAnchor | null>(null);
   const sessionKey = useMemo(() => `${items[0]?.id ?? ""}|${items[items.length - 1]?.id ?? ""}`, [items]);
   const warmLayerSessionKey = useMemo(() => `${tabId ?? ""}|${revealSignal}|${items[0]?.id ?? ""}`, [items, revealSignal, tabId]);
   const entranceRef = useEntranceAnimation<HTMLDivElement>(sessionKey, items.length);
@@ -281,6 +282,16 @@ export function Transcript({
     [coldPage, turnGroups.length],
   );
 
+  useLayoutEffect(() => {
+    const question = pendingQuestionJump.current;
+    if (!question) return;
+    const node = document.getElementById(questionAnchorId(question.id));
+    if (!node) return;
+    pendingQuestionJump.current = null;
+    stick.current = false;
+    smoothScrollTo(node, 12);
+  }, [expandedWarmTurns, smoothScrollTo, stick, warmStartTurn]);
+
   // ── The turn action menu ──────────────────────────────────────────────────
   const [openAction, setOpenAction] = useState<OpenTurnAction | null>(null);
   useEffect(() => {
@@ -300,15 +311,26 @@ export function Transcript({
   const jumpToQuestion = (question: QuestionAnchor) => {
     const node = document.getElementById(questionAnchorId(question.id));
     if (!node) return;
+    pendingQuestionJump.current = null;
     stick.current = false;
     smoothScrollTo(node, 12);
   };
 
   const handleJumpToQuestion = useCallback((question: QuestionAnchor) => {
+    pendingQuestionJump.current = question;
     // Auto-expand the warm turn when jumping to an old question.
     const warmTurnStart = turnGroups.length - HOT_TURNS;
     if (question.turn < warmTurnStart) {
-      setWarmLayerState((prev) => warmLayerWithExpandedTurn(prev, warmLayerSessionKey, question.turn, true));
+      const neededColdPage = warmColdPageForTurn({
+        turn: question.turn,
+        turnCount: turnGroups.length,
+        hotTurns: HOT_TURNS,
+        pageSize: WARM_PAGE_SIZE,
+      });
+      setWarmLayerState((prev) => {
+        const paged = warmLayerWithColdPageAtLeast(prev, warmLayerSessionKey, neededColdPage);
+        return warmLayerWithExpandedTurn(paged, warmLayerSessionKey, question.turn, true);
+      });
     }
     jumpToQuestion(question);
   }, [turnGroups.length, warmLayerSessionKey]);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildTurnGroups, compactQuestionText, questionAnchorId, scrollVersion, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup } from "../lib/transcriptGrouping";
+import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, scrollVersion, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -132,6 +132,7 @@ export function Transcript({
   const autoScrollFrame = useRef<number | null>(null);
   const pendingRevealBottomScroll = useRef(false);
   const sessionKey = useMemo(() => `${items[0]?.id ?? ""}|${items[items.length - 1]?.id ?? ""}`, [items]);
+  const warmLayerSessionKey = useMemo(() => `${tabId ?? ""}|${revealSignal}|${items[0]?.id ?? ""}`, [items, revealSignal, tabId]);
   const entranceRef = useEntranceAnimation<HTMLDivElement>(sessionKey, items.length);
 
   const [displayMode, setDisplayMode] = useState<DisplayMode>(() => getDisplayMode());
@@ -251,8 +252,12 @@ export function Transcript({
   }, [items]);
 
   // ── Layer state ────────────────────────────────────────────────────────────
-  const [expandedWarmTurns, setExpandedWarmTurns] = useState<Set<number>>(new Set());
-  const [coldPage, setColdPage] = useState(0);
+  const [warmLayerState, setWarmLayerState] = useState<WarmLayerState>(() => createWarmLayerState(warmLayerSessionKey));
+  const defaultWarmLayerState = useMemo<WarmLayerState>(() => createWarmLayerState(warmLayerSessionKey), [warmLayerSessionKey]);
+  const activeWarmLayerState = warmLayerState.sessionKey === warmLayerSessionKey
+    ? warmLayerState
+    : defaultWarmLayerState;
+  const { expandedWarmTurns, coldPage } = activeWarmLayerState;
 
   // Compute turn groups from the structural item list. Streaming text updates
   // keep the same items[] reference, so this stays out of the token hot path.
@@ -303,13 +308,10 @@ export function Transcript({
     // Auto-expand the warm turn when jumping to an old question.
     const warmTurnStart = turnGroups.length - HOT_TURNS;
     if (question.turn < warmTurnStart) {
-      setExpandedWarmTurns((prev) => {
-        if (prev.has(question.turn)) return prev;
-        return new Set([...prev, question.turn]);
-      });
+      setWarmLayerState((prev) => warmLayerWithExpandedTurn(prev, warmLayerSessionKey, question.turn, true));
     }
     jumpToQuestion(question);
-  }, [turnGroups.length]);
+  }, [turnGroups.length, warmLayerSessionKey]);
 
   // ── Hot zone: fully rendered from hotStartIdx to end ─────────────────────
   // Memoized separately from the assembly so streaming tokens don't rebuild
@@ -627,13 +629,9 @@ export function Transcript({
               warmOnEdit={onEditPrompt}
               tabId={tabId}
               creationMode={creationMode}
-              onToggleColdPage={() => setColdPage((p) => p + 1)}
+              onToggleColdPage={() => setWarmLayerState((prev) => warmLayerWithNextColdPage(prev, warmLayerSessionKey))}
               onToggleWarmTurn={(g, expand) => {
-                setExpandedWarmTurns((prev) => {
-                  const next = new Set(prev);
-                  if (expand) next.add(g); else next.delete(g);
-                  return next;
-                });
+                setWarmLayerState((prev) => warmLayerWithExpandedTurn(prev, warmLayerSessionKey, g, expand));
               }}
             />
           )}

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -30,6 +30,13 @@ export function warmLayerWithNextColdPage(state: WarmLayerState, sessionKey: str
   return { ...current, coldPage: current.coldPage + 1 };
 }
 
+export function warmLayerWithColdPageAtLeast(state: WarmLayerState, sessionKey: string, coldPage: number): WarmLayerState {
+  const current = warmLayerForSession(state, sessionKey);
+  const safeColdPage = Math.max(0, Math.floor(coldPage));
+  if (current.coldPage >= safeColdPage) return current;
+  return { ...current, coldPage: safeColdPage };
+}
+
 export function warmLayerWithExpandedTurn(state: WarmLayerState, sessionKey: string, turn: number, expand: boolean): WarmLayerState {
   const current = warmLayerForSession(state, sessionKey);
   const expandedWarmTurns = new Set(current.expandedWarmTurns);
@@ -120,4 +127,21 @@ export function warmPagination({ turnCount, hotTurns, pageSize, coldPage }: {
     warmEndTurn,
     coldTurnCount: warmEndTurn - shownWarmCount,
   };
+}
+
+export function warmColdPageForTurn({ turn, turnCount, hotTurns, pageSize }: {
+  turn: number;
+  turnCount: number;
+  hotTurns: number;
+  pageSize: number;
+}): number {
+  const safeTurnCount = Math.max(0, turnCount);
+  const safeHotTurns = Math.max(0, hotTurns);
+  const warmEndTurn = Math.max(0, safeTurnCount - Math.min(safeTurnCount, safeHotTurns));
+  if (warmEndTurn === 0 || turn >= warmEndTurn) return 0;
+
+  const safePageSize = Math.max(1, pageSize);
+  const targetTurn = Math.max(0, Math.floor(turn));
+  const shownTurnsNeeded = warmEndTurn - targetTurn;
+  return Math.max(0, Math.ceil(shownTurnsNeeded / safePageSize) - 1);
 }

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -73,3 +73,24 @@ export function buildTurnGroups(items: Item[]): TurnGroup[] {
   }
   return groups;
 }
+
+export function warmPagination({ turnCount, hotTurns, pageSize, coldPage }: {
+  turnCount: number;
+  hotTurns: number;
+  pageSize: number;
+  coldPage: number;
+}): { warmStartTurn: number; warmEndTurn: number; coldTurnCount: number } {
+  const safeTurnCount = Math.max(0, turnCount);
+  const safeHotTurns = Math.max(0, hotTurns);
+  const warmEndTurn = Math.max(0, safeTurnCount - Math.min(safeTurnCount, safeHotTurns));
+  if (warmEndTurn === 0) return { warmStartTurn: 0, warmEndTurn: 0, coldTurnCount: 0 };
+
+  const safePageSize = Math.max(0, pageSize);
+  const safeColdPage = Math.max(0, Math.floor(coldPage));
+  const shownWarmCount = Math.min(warmEndTurn, safePageSize * (safeColdPage + 1));
+  return {
+    warmStartTurn: warmEndTurn - shownWarmCount,
+    warmEndTurn,
+    coldTurnCount: warmEndTurn - shownWarmCount,
+  };
+}

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -11,6 +11,33 @@ export interface TurnGroup {
   endIdx: number;
 }
 
+export type WarmLayerState = {
+  sessionKey: string;
+  expandedWarmTurns: ReadonlySet<number>;
+  coldPage: number;
+};
+
+export function createWarmLayerState(sessionKey: string): WarmLayerState {
+  return { sessionKey, expandedWarmTurns: new Set(), coldPage: 0 };
+}
+
+export function warmLayerForSession(state: WarmLayerState, sessionKey: string): WarmLayerState {
+  return state.sessionKey === sessionKey ? state : createWarmLayerState(sessionKey);
+}
+
+export function warmLayerWithNextColdPage(state: WarmLayerState, sessionKey: string): WarmLayerState {
+  const current = warmLayerForSession(state, sessionKey);
+  return { ...current, coldPage: current.coldPage + 1 };
+}
+
+export function warmLayerWithExpandedTurn(state: WarmLayerState, sessionKey: string, turn: number, expand: boolean): WarmLayerState {
+  const current = warmLayerForSession(state, sessionKey);
+  const expandedWarmTurns = new Set(current.expandedWarmTurns);
+  if (expand) expandedWarmTurns.add(turn);
+  else expandedWarmTurns.delete(turn);
+  return { ...current, expandedWarmTurns };
+}
+
 export function questionAnchorId(id: string): string {
   return `question-anchor-${id}`;
 }


### PR DESCRIPTION
## Summary

- Fix restored transcript warm/cold pagination so long histories initially render only the latest warm page instead of every older warm turn.
- Reuse the transcript grouping helper layer for the pagination math and cover the boundary with a regression test.
- Reduce Desktop startup/topic-open render work for large restored transcripts.

## Verification

- PASS `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
- PASS `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts`
- FAIL (existing) `corepack pnpm --dir desktop/frontend test:typecheck` — `src/__tests__/capabilities-panel-actions.test.ts(127,5): error TS2322: Type '"auto"' is not assignable to type 'Mode'.`

## Cache impact

Cache-impact: none, UI-only transcript rendering change; no provider prompt or cache-prefix behavior changes.
Cache-guard: `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
System-prompt-review: N/A

Refs #5306
