### PR TITLE
fix(agent): avoid Memory v5 goal loop injection

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -681,7 +681,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
-	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil {
+	memoryCompilerDisplayInput := strings.TrimSpace(StripTransientUserBlocks(rawInput))
+	skipMemoryCompiler := strings.HasPrefix(memoryCompilerDisplayInput, "Continue pursuing the active goal.")
+	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !skipMemoryCompiler {
 		if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
 			a.compilerTurn = turn
 			a.emitMemoryCompilerStats(turn)

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -91,6 +91,32 @@ func TestRunUsesMemoryCompilerContractAsUserTurn(t *testing.T) {
 	}
 }
 
+func TestRunSkipsMemoryCompilerForGoalContinuationTurn(t *testing.T) {
+	rt := memorycompiler.New(t.TempDir())
+	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)
+	seed.RecordToolResults([]memorycompiler.ToolRecord{
+		{Name: "bash", Error: "exit status 1"},
+		{Name: "bash", Error: "exit status 1"},
+	})
+	seed.Finish(nil)
+
+	goalContinue := "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. Otherwise do the next useful work and end with [goal:continue]."
+	mp := testutil.NewMock("m", testutil.Turn{Text: "done"})
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+	if err := a.Run(context.Background(), goalContinue); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	req := mp.Requests()[0]
+	user := req.Messages[len(req.Messages)-1]
+	if strings.Contains(user.Content, "<memory-compiler-execution>") {
+		t.Fatalf("synthetic goal continuation turn was compiled:\n%s", user.Content)
+	}
+	if !strings.HasPrefix(user.Content, "Continue pursuing the active goal.") {
+		t.Fatalf("goal continuation source was not preserved:\n%s", user.Content)
+	}
+}
+
 func TestRunCompilesMemoryGoalFromRawInputBeforeReasoningLanguage(t *testing.T) {
 	rt := memorycompiler.New(t.TempDir())
 	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"reasonix/internal/controlplane"
 	controlgraph "reasonix/internal/controlplane/control_graph"
@@ -1741,10 +1742,9 @@ func strategyScoreWithReason(goal string, s Strategy) (float64, string) {
 		score -= penalty
 		reasons = append(reasons, fmt.Sprintf("%.2f usage penalty", penalty))
 	}
-	lowerGoal := strings.ToLower(goal)
 	for _, p := range s.Preconditions {
 		p = strings.ToLower(strings.TrimSpace(p))
-		if p != "" && strings.Contains(lowerGoal, p) {
+		if p != "" && strategyPreconditionMatches(goal, p) {
 			score += 0.75
 			reasons = append(reasons, "matched precondition "+p)
 		}
@@ -1758,6 +1758,25 @@ func strategyScoreWithReason(goal string, s Strategy) (float64, string) {
 		reasons = append(reasons, "low success history")
 	}
 	return score, strings.Join(reasons, "; ")
+}
+
+func strategyPreconditionMatches(goal, precondition string) bool {
+	precondition = strings.ToLower(strings.TrimSpace(precondition))
+	if precondition == "" {
+		return false
+	}
+	goal = strings.ToLower(goal)
+	if len(precondition) <= 2 {
+		for _, token := range strings.FieldsFunc(goal, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		}) {
+			if token == precondition {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.Contains(goal, precondition)
 }
 
 func normalizedOutcomeScore(s Strategy) (float64, string) {
@@ -3349,7 +3368,7 @@ func classifyStrategy(goal string) string {
 		return "code-review"
 	case strings.Contains(lower, "bug") || strings.Contains(lower, "fix") || strings.Contains(goal, "修复"):
 		return "bugfix-reproduce-first"
-	case strings.Contains(lower, "frontend") || strings.Contains(lower, "ui") || strings.Contains(goal, "前端"):
+	case strings.Contains(lower, "frontend") || strategyPreconditionMatches(goal, "ui") || strings.Contains(goal, "前端"):
 		return "frontend-visual-verify"
 	case strings.Contains(lower, "goal") || strings.Contains(lower, "research") || strings.Contains(goal, "持续"):
 		return "long-horizon-autoresearch"

--- a/internal/memorycompiler/runtime_test.go
+++ b/internal/memorycompiler/runtime_test.go
@@ -156,6 +156,22 @@ func TestSuccessTraceFeedsReusableStrategyAndGraph(t *testing.T) {
 	assertEdge(t, st.Edges, "derived_from")
 }
 
+func TestGoalContinuationDoesNotMatchUIBySubstring(t *testing.T) {
+	goal := "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]."
+	if got := classifyStrategy(goal); got == "frontend-visual-verify" {
+		t.Fatalf("classifyStrategy(%q) = %q; pursuing must not match the ui strategy", goal, got)
+	}
+
+	ranked := rankStrategies(goal, []Strategy{
+		{ID: "frontend-visual-verify", Successes: 61, Failures: 0, Preconditions: []string{"frontend", "ui", "desktop", "前端"}},
+		{ID: "general"},
+	})
+	pick := selectStrategy(goal, ranked, 0)
+	if pick.Selected == "frontend-visual-verify" {
+		t.Fatalf("selectStrategy picked frontend for synthetic goal continuation: %+v", pick)
+	}
+}
+
 func TestGraphTraversalFiltersCorruptedMemoryAndExpandsConnectedNodes(t *testing.T) {
 	now := time.Now().UTC()
 	st := state{


### PR DESCRIPTION
## Summary

- Fixes Memory v5 compiling synthetic goal-continuation turns into repeated `memory_v5_execution_contract` user turns.
- Fixes short strategy preconditions like `ui` so they match tokens only, preventing `pursuing` from selecting `frontend-visual-verify`.
- Closes #5342.

## Verification

- `go test ./internal/agent ./internal/memorycompiler -count=1`
- `go test ./internal/control -run 'TestIsSyntheticUserMessage|TestGoal|TestTurnOrchestrator|TestAutoPlan' -count=1`
- `git diff --check`

## Cache impact

Cache-impact: low — only changes provider-visible Memory v5 behavior for synthetic goal-continuation turns and short-token strategy matching; system prompt, tool schemas, and provider prefix are unchanged.
Cache-guard: focused agent, memorycompiler, and control tests listed above.
System-prompt-review: N/A
