### PR TITLE
fix(boot): hint migration when api_key_env holds a literal key value

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -236,7 +236,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// (RequireKey is false so the UI stays reachable) and then fail silently on the
 	// first request, showing as an empty/dead model. Surface the cause up front.
 	if !opts.RequireKey && entry.RequiresAPIKey() && entry.APIKey() == "" {
-		sink.Emit(event.Event{Kind: event.Notice, Text: "Selected model is missing its API key.", Detail: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
+		if entry.LooksLikeLiteralAPIKeyValue() {
+			// Before 1.11, api_key_env tolerated a literal key value placed
+			// directly in the field; that fallback was removed for security.
+			// A config carried over from 1.10 (or written assuming the field
+			// took the key itself) now resolves empty — point the user at the
+			// migration rather than the generic "not set" message.
+			sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q: api_key_env looks like a raw key value, not an environment-variable or credential name. Since 1.11, api_key_env must name an env var or a credentials entry (the literal key is no longer accepted in config). Move the value into your credentials file under a name like %s and set api_key_env to that name.", modelName, suggestAPIKeyEnvName(entry.APIKeyEnv))})
+		} else {
+			sink.Emit(event.Event{Kind: event.Notice, Text: "Selected model is missing its API key.", Detail: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
+		}
 	}
 	jm := jobs.NewManager(sink, jobs.WithStalledWarningAfter(time.Duration(cfg.BackgroundJobStalledWarningSeconds())*time.Second))
 	sessionDir := opts.SessionDir
@@ -2001,4 +2010,45 @@ func providerNames(cfg *config.Config) string {
 		names[i] = p.Name
 	}
 	return strings.Join(names, "/")
+}
+
+// suggestAPIKeyEnvName derives a plausible credential/env-var name from a
+// literal key value or provider name, so the migration notice can recommend a
+// concrete target instead of just "rename it". Prefixed with the provider name
+// when known, upper-snake-cased.
+func suggestAPIKeyEnvName(providerName string) string {
+	base := strings.TrimSpace(providerName)
+	if base == "" {
+		base = "REASONIX_API_KEY"
+	}
+	// If the name already looks like an env var (UPPER_SNAKE), keep it.
+	if strings.ToUpper(base) == base && strings.ContainsAny(base, "_") {
+		return base
+	}
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 32)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			if b.Len() > 0 && strings.LastIndexByte(b.String(), '_') != b.Len()-1 {
+				b.WriteByte('_')
+			}
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "REASONIX_API_KEY"
+	}
+	if !strings.HasPrefix(out, "REASONIX_") {
+		out = "PROVIDER_" + out
+	}
+	if !strings.HasSuffix(out, "_API_KEY") {
+		out = out + "_API_KEY"
+	}
+	return out
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -189,7 +189,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// (RequireKey is false so the UI stays reachable) and then fail silently on the
 	// first request, showing as an empty/dead model. Surface the cause up front.
 	if !opts.RequireKey && entry.RequiresAPIKey() && entry.APIKey() == "" {
-		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
+		if entry.LooksLikeLiteralAPIKeyValue() {
+			// Before 1.11, api_key_env tolerated a literal key value placed
+			// directly in the field; that fallback was removed for security.
+			// A config carried over from 1.10 (or written assuming the field
+			// took the key itself) now resolves empty — point the user at the
+			// migration rather than the generic "not set" message.
+			sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q: api_key_env looks like a raw key value, not an environment-variable or credential name. Since 1.11, api_key_env must name an env var or a credentials entry (the literal key is no longer accepted in config). Move the value into your credentials file under a name like %s and set api_key_env to that name.", modelName, suggestAPIKeyEnvName(entry.APIKeyEnv))})
+		} else {
+			sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
+		}
 	}
 	jm := jobs.NewManager(sink, jobs.WithStalledWarningAfter(time.Duration(cfg.BackgroundJobStalledWarningSeconds())*time.Second))
 	sessionDir := opts.SessionDir
@@ -1565,4 +1574,45 @@ func providerNames(cfg *config.Config) string {
 		names[i] = p.Name
 	}
 	return strings.Join(names, "/")
+}
+
+// suggestAPIKeyEnvName derives a plausible credential/env-var name from a
+// literal key value or provider name, so the migration notice can recommend a
+// concrete target instead of just "rename it". Prefixed with the provider name
+// when known, upper-snake-cased.
+func suggestAPIKeyEnvName(providerName string) string {
+	base := strings.TrimSpace(providerName)
+	if base == "" {
+		base = "REASONIX_API_KEY"
+	}
+	// If the name already looks like an env var (UPPER_SNAKE), keep it.
+	if strings.ToUpper(base) == base && strings.ContainsAny(base, "_") {
+		return base
+	}
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 32)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			if b.Len() > 0 && strings.LastIndexByte(b.String(), '_') != b.Len()-1 {
+				b.WriteByte('_')
+			}
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "REASONIX_API_KEY"
+	}
+	if !strings.HasPrefix(out, "REASONIX_") {
+		out = "PROVIDER_" + out
+	}
+	if !strings.HasSuffix(out, "_API_KEY") {
+		out = out + "_API_KEY"
+	}
+	return out
 }

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -189,3 +189,60 @@ api_key_env = "`+keyEnv+`"
 		}
 	}
 }
+
+// TestBuildNoticesLiteralAPIKeyValue: a config carried over from before 1.11
+// (or written assuming api_key_env took the key itself) places a raw key value
+// in the field. It must resolve empty and emit the targeted migration hint
+// (naming the 1.11 change and a suggested credential name), not the generic
+// "key not set" notice. See issue #5325.
+func TestBuildNoticesLiteralAPIKeyValue(t *testing.T) {
+	const literalKey = "sk-ant-api03-1234567890abcdefghijklmnopqrstuv1234567890"
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "x"
+
+[[providers]]
+name = "x"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "m"
+api_key_env = "`+literalKey+`"
+`)
+
+	var notices []string
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should succeed with RequireKey=false even with a literal key value: %v", err)
+	}
+	defer ctrl.Close()
+
+	var hint string
+	for _, n := range notices {
+		if strings.Contains(n, "looks like a raw key value") {
+			hint = n
+			break
+		}
+	}
+	if hint == "" {
+		t.Fatalf("expected the literal-value migration hint; got %v", notices)
+	}
+	// Must NOT be the generic message — that is the whole point of the detection.
+	for _, substr := range []string{"is not set", "requests will fail until you set it"} {
+		if strings.Contains(hint, substr) {
+			t.Fatalf("literal-value hint should not include the generic %q; got %q", substr, hint)
+		}
+	}
+	// Must reference the 1.11 migration and suggest a credential name.
+	for _, want := range []string{"1.11", "credentials"} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("literal-value hint should mention %q; got %q", want, hint)
+		}
+	}
+}

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -142,3 +142,60 @@ api_key_env = "`+keyEnv+`"
 		}
 	}
 }
+
+// TestBuildNoticesLiteralAPIKeyValue: a config carried over from before 1.11
+// (or written assuming api_key_env took the key itself) places a raw key value
+// in the field. It must resolve empty and emit the targeted migration hint
+// (naming the 1.11 change and a suggested credential name), not the generic
+// "key not set" notice. See issue #5325.
+func TestBuildNoticesLiteralAPIKeyValue(t *testing.T) {
+	const literalKey = "sk-ant-api03-1234567890abcdefghijklmnopqrstuv1234567890"
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "x"
+
+[[providers]]
+name = "x"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "m"
+api_key_env = "`+literalKey+`"
+`)
+
+	var notices []string
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should succeed with RequireKey=false even with a literal key value: %v", err)
+	}
+	defer ctrl.Close()
+
+	var hint string
+	for _, n := range notices {
+		if strings.Contains(n, "looks like a raw key value") {
+			hint = n
+			break
+		}
+	}
+	if hint == "" {
+		t.Fatalf("expected the literal-value migration hint; got %v", notices)
+	}
+	// Must NOT be the generic message — that is the whole point of the detection.
+	for _, substr := range []string{"is not set", "requests will fail until you set it"} {
+		if strings.Contains(hint, substr) {
+			t.Fatalf("literal-value hint should not include the generic %q; got %q", substr, hint)
+		}
+	}
+	// Must reference the 1.11 migration and suggest a credential name.
+	for _, want := range []string{"1.11", "credentials"} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("literal-value hint should mention %q; got %q", want, hint)
+		}
+	}
+}

--- a/internal/config/api_key_env_literal_test.go
+++ b/internal/config/api_key_env_literal_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+// TestLooksLikeLiteralAPIKeyValue guards the migration-hint heuristic for
+// configs carried over from before 1.11, where api_key_env held the key value
+// itself. The heuristic must catch real secret shapes and never misclassify a
+// legitimate UPPER_SNAKE env-var name.
+func TestLooksLikeLiteralAPIKeyValue(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"short env var name", "OPENAI_API_KEY", false},
+		{"short underscored name", "REASONIX_TEST_KEY_UNSET", false},
+		{"lowercase short name (not a secret)", "my_key", false},
+		{"sk- prefixed secret", "sk-proj-1234567890abcdefghij1234567890", true},
+		{"AIza google key", "AIzaSyABCDEFG1234567890abcdefghij1234567890", true},
+		{"anthropic prefix", "sk-ant-api03-1234567890abcdefghij1234567890", true},
+		{"long mixed-case with dot", "akia1234567890.something/with-path-and-mixed-case-1234567890", true},
+		{"long UPPER no lowercase (env var)", "A_VERY_LONG_UPPER_SNAKE_NAME_THAT_IS_NOT_A_SECRET_AT_ALL", false},
+		{"digits only long", "1234567890123456789012345678901234567890", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &ProviderEntry{APIKeyEnv: tc.env}
+			if got := e.LooksLikeLiteralAPIKeyValue(); got != tc.want {
+				t.Fatalf("LooksLikeLiteralAPIKeyValue(%q) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSuggestAPIKeyEnvName is in package boot; this only covers the config-side
+// predicate. Nil-safety check.
+func TestLooksLikeLiteralAPIKeyValueNilSafe(t *testing.T) {
+	var e *ProviderEntry
+	if e.LooksLikeLiteralAPIKeyValue() {
+		t.Fatal("nil entry must not look like a literal value")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1730,6 +1730,55 @@ func (e *ProviderEntry) APIKey() string {
 	return value
 }
 
+// looksLikeLiteralAPIKeyValue reports whether the configured api_key_env looks
+// like a raw API key value rather than an environment-variable or credential
+// name. Reasonix resolves api_key_env as a *name* looked up in credentials/.env;
+// before 1.11 it also tolerated a literal value placed directly in the field.
+// That fallback was removed to keep the secret out of the config file, so a
+// config carried over from 1.10 or earlier (or written by a user who assumed
+// the field took the key itself) now resolves to an empty APIKey and surfaces
+// only a generic "key not set" notice. Detecting this case lets callers emit a
+// targeted migration hint instead of the generic message.
+//
+// Heuristics, intentionally conservative so a legitimate env-var name is never
+// misclassified: a real secret is long and usually carries a provider prefix,
+// while env-var names are short and UPPER_SNAKE_CASE. Pure digits or a single
+// short token are not enough.
+func (e *ProviderEntry) LooksLikeLiteralAPIKeyValue() bool {
+	if e == nil {
+		return false
+	}
+	v := strings.TrimSpace(e.APIKeyEnv)
+	if len(v) < 32 {
+		return false
+	}
+	// Env-var names are conventionally UPPER_SNAKE_CASE; a value mixing case or
+	// containing lowercase letters/dashes past a short prefix is not one.
+	hasLower := false
+	for _, r := range v {
+		if r >= 'a' && r <= 'z' || r == '-' || r == '.' {
+			hasLower = true
+			break
+		}
+	}
+	if !hasLower {
+		return false
+	}
+	// Common provider key prefixes; absence does not rule out a literal value,
+	// but presence is strong evidence.
+	for _, p := range []string{"sk-", "sk_", "AIza", "cr_", "hf_", "xai-", "ANTHROPIC"} {
+		if strings.HasPrefix(v, p) {
+			return true
+		}
+	}
+	// A long, mixed-case string with a dot or slash (e.g. service-account JSON
+	// fragments, JWT-like blobs) is not an env-var name.
+	if strings.ContainsAny(v, "./=") && len(v) >= 40 {
+		return true
+	}
+	return false
+}
+
 // ResolveAPIKeyFromProcessEnvForProbe pins a setup-time, user-entered key onto
 // this entry for an immediate connectivity probe. Normal runtime resolution does
 // not call this; loaded provider entries still resolve only from Reasonix's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1391,6 +1391,55 @@ func (e *ProviderEntry) APIKey() string {
 	return value
 }
 
+// looksLikeLiteralAPIKeyValue reports whether the configured api_key_env looks
+// like a raw API key value rather than an environment-variable or credential
+// name. Reasonix resolves api_key_env as a *name* looked up in credentials/.env;
+// before 1.11 it also tolerated a literal value placed directly in the field.
+// That fallback was removed to keep the secret out of the config file, so a
+// config carried over from 1.10 or earlier (or written by a user who assumed
+// the field took the key itself) now resolves to an empty APIKey and surfaces
+// only a generic "key not set" notice. Detecting this case lets callers emit a
+// targeted migration hint instead of the generic message.
+//
+// Heuristics, intentionally conservative so a legitimate env-var name is never
+// misclassified: a real secret is long and usually carries a provider prefix,
+// while env-var names are short and UPPER_SNAKE_CASE. Pure digits or a single
+// short token are not enough.
+func (e *ProviderEntry) LooksLikeLiteralAPIKeyValue() bool {
+	if e == nil {
+		return false
+	}
+	v := strings.TrimSpace(e.APIKeyEnv)
+	if len(v) < 32 {
+		return false
+	}
+	// Env-var names are conventionally UPPER_SNAKE_CASE; a value mixing case or
+	// containing lowercase letters/dashes past a short prefix is not one.
+	hasLower := false
+	for _, r := range v {
+		if r >= 'a' && r <= 'z' || r == '-' || r == '.' {
+			hasLower = true
+			break
+		}
+	}
+	if !hasLower {
+		return false
+	}
+	// Common provider key prefixes; absence does not rule out a literal value,
+	// but presence is strong evidence.
+	for _, p := range []string{"sk-", "sk_", "AIza", "cr_", "hf_", "xai-", "ANTHROPIC"} {
+		if strings.HasPrefix(v, p) {
+			return true
+		}
+	}
+	// A long, mixed-case string with a dot or slash (e.g. service-account JSON
+	// fragments, JWT-like blobs) is not an env-var name.
+	if strings.ContainsAny(v, "./=") && len(v) >= 40 {
+		return true
+	}
+	return false
+}
+
 // ResolveAPIKeyFromProcessEnvForProbe pins a setup-time, user-entered key onto
 // this entry for an immediate connectivity probe. Normal runtime resolution does
 // not call this; loaded provider entries still resolve only from Reasonix's


### PR DESCRIPTION
Resolves #5325.

Since 1.11, api_key_env resolves strictly as an env-var or credentials name — the pre-1.11 fallback that treated the field's value as the key itself was removed to keep secrets out of the config file. Configs carried over from 1.10 (or written assuming the field took the key) now resolve to an empty APIKey and surface only the generic 'key not set' notice, which does not point at the real cause.

This adds a conservative LooksLikeLiteralAPIKeyValue() heuristic (long + lowercase/punctuated, or a known provider prefix like sk-/AIza/sk-ant) and, when it fires, emits a targeted migration hint naming the 1.11 change and a suggested credential name — instead of the generic message. It does NOT restore the literal-value fallback, which was an intentional security tightening.

Changes:
- config: ProviderEntry.LooksLikeLiteralAPIKeyValue() + nil-safe
- boot: branch the missing-key notice; suggestAPIKeyEnvName() helper
- tests: 11 heuristic cases + a Build-level notice test

Verification: go build ./... ok; go test ./internal/config/... ./internal/boot/... ok (incl. new TestBuildNoticesLiteralAPIKeyValue). gofmt clean.

---

Cache-impact: none - the new branch runs only inside the existing `if entry.RequiresAPIKey() && entry.APIKey() == ""` startup notice path; it changes no tool schema, no prompt assembly, no message structure, so the model-facing cache shape is unaffected.
Cache-guard: TestBuildNoticesMissingAPIKey (existing, generic unset path) + TestBuildNoticesLiteralAPIKeyValue (new, literal-value hint path) together guard the notice branch — the generic message still fires for real env-var names, the migration hint only for literal values.
System-prompt-review: not applicable — this PR changes only a human-facing startup notice emitted via sink.Emit; it touches no system prompt, no tool schema, no model-facing content. boot.go is flagged as system-prompt-sensitive by the guard because adjacent code assembles prompts, but the changed lines are notice-only.