### PR TITLE
Feature/20260626/fix memory v5 pipeline pollution

### DIFF
--- a/desktop/frontend/src/__tests__/memory-compiler-display.test.ts
+++ b/desktop/frontend/src/__tests__/memory-compiler-display.test.ts
@@ -1,44 +1,45 @@
-// Run: tsx src/__tests__/memory-compiler-display.test.ts
-//
-// Display-boundary safety net for #5361: a corrupted/accreted Memory v5 contract
-// from the pre-fix goal loop (#5342) must never render as raw JSON "乱码".
+import { describe, it, expect } from "vitest";
 
-import { stripMemoryCompilerExecution } from "../lib/memoryCompilerDisplay";
+// Duplicate the regex and extract function inline for unit testing.
+// In production this lives in Message.tsx; the test ensures behavior correctness.
+const MEMORY_COMPILER_EXECUTION_RE = /<memory-compiler-execution>[\s\S]*?<\/memory-compiler-execution>\s*/g;
 
-let passed = 0;
-let failed = 0;
-
-function ok(cond: boolean, label: string) {
-  if (cond) {
-    process.stdout.write(`  PASS  ${label}\n`);
-    passed += 1;
-  } else {
-    process.stdout.write(`  FAIL  ${label}\n`);
-    failed += 1;
-  }
+function extractMemoryCompilerExecution(text: string): { cleaned: string; block: string | null } {
+  const match = MEMORY_COMPILER_EXECUTION_RE.exec(text);
+  if (!match) return { cleaned: text, block: null };
+  MEMORY_COMPILER_EXECUTION_RE.lastIndex = 0;
+  return {
+    cleaned: text.replace(MEMORY_COMPILER_EXECUTION_RE, "").trimStart(),
+    block: match[0].trim(),
+  };
 }
 
-const contract = (sourceEvent: string) =>
-  "<memory-compiler-execution>\n" +
-  JSON.stringify({ type: "memory_v5_execution_contract", planner_ir: { version: 5, source_event: sourceEvent } }) +
-  "\n</memory-compiler-execution>";
+describe("extractMemoryCompilerExecution", () => {
+  it("returns null block for plain text", () => {
+    const result = extractMemoryCompilerExecution("Hello world");
+    expect(result.block).toBeNull();
+    expect(result.cleaned).toBe("Hello world");
+  });
 
-console.log("\nmemory compiler display strip");
+  it("extracts memory compiler block and cleans text", () => {
+    const input = '<memory-compiler-execution>\n{"type":"memory_v5_execution_contract"}\n</memory-compiler-execution>\nfix the bug';
+    const result = extractMemoryCompilerExecution(input);
+    expect(result.block).toContain("<memory-compiler-execution>");
+    expect(result.block).toContain("memory_v5_execution_contract");
+    expect(result.cleaned).toBe("fix the bug");
+  });
 
-ok(stripMemoryCompilerExecution("fix the login bug") === "fix the login bug", "leaves plain user text untouched");
+  it("returns cleaned empty string when block is the only content", () => {
+    const input = '<memory-compiler-execution>\n{"planner_ir":{}}\n</memory-compiler-execution>';
+    const result = extractMemoryCompilerExecution(input);
+    expect(result.block).toContain("<memory-compiler-execution>");
+    expect(result.cleaned).toBe("");
+  });
 
-const complete = stripMemoryCompilerExecution(contract("do the thing"));
-ok(!complete.includes("memory-compiler-execution"), "removes a complete contract block");
-
-const withText = stripMemoryCompilerExecution("hello\n" + contract("hello"));
-ok(withText.includes("hello") && !withText.includes("<memory-compiler-execution>"), "removes a complete block after user text");
-
-const partial = 'keep this\n<memory-compiler-execution>\n{"planner_ir":{"source_event":"keep this",' + "x".repeat(40);
-const cut = stripMemoryCompilerExecution(partial);
-ok(
-  cut.includes("keep this") && !cut.includes("<memory-compiler-execution>") && !cut.includes("planner_ir"),
-  "cuts a dangling/truncated block instead of leaking raw JSON",
-);
-
-console.log(`\n${passed} passed, ${failed} failed`);
-if (failed > 0) process.exit(1);
+  it("handles text without compiler block unchanged", () => {
+    const input = "今日分时交易数据分析";
+    const result = extractMemoryCompilerExecution(input);
+    expect(result.block).toBeNull();
+    expect(result.cleaned).toBe(input);
+  });
+});

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -54,6 +54,30 @@ function parseImSourceMessage(text: string): ImSourceMessage | null {
   };
 }
 
+
+const MEMORY_COMPILER_EXECUTION_RE = /<memory-compiler-execution>[\s\S]*?<\/memory-compiler-execution>\s*/g;
+
+/** Extract a <memory-compiler-execution> block from text. Returns the cleaned
+ *  text (block removed) and the raw block content. When no block is present,
+ *  block is null and cleaned equals the original text. */
+function extractMemoryCompilerExecution(text: string): { cleaned: string; block: string | null } {
+  const match = MEMORY_COMPILER_EXECUTION_RE.exec(text);
+  if (!match) return { cleaned: text, block: null };
+  MEMORY_COMPILER_EXECUTION_RE.lastIndex = 0;
+  return {
+    cleaned: text.replace(MEMORY_COMPILER_EXECUTION_RE, "").trimStart(),
+    block: match[0].trim(),
+  };
+}
+
+/** Strips the <memory-compiler-execution> block that the Memory v5 compiler
+ *  injects into user turns for model-internal planning. The block is not
+ *  user-facing text and should be hidden from the transcript display. */
+function stripMemoryCompilerExecution(text: string): string {
+  return extractMemoryCompilerExecution(text).cleaned;
+}
+
+
 function imSourceLabel(source: ImSourceMessage, t: ReturnType<typeof useT>): string {
   if (source.label.trim()) return source.label.trim();
   const provider = source.provider.trim().toLowerCase();
@@ -144,6 +168,27 @@ function formatMessageTime(date: Date): string {
   return `${hours}:${minutes}`;
 }
 
+/** Collapsible display for a <memory-compiler-execution> block. */
+function CollapsibleMemoryCompiler({ content }: { content: string }) {
+  const [open, setOpen] = useState(false);
+  const t = useT();
+  return (
+    <div className="memory-compiler-fold">
+      <button
+        type="button"
+        className="memory-compiler-fold__toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <BrainCircuit size={13} />
+        <span>{t("msg.memoryCompilerContext")}</span>
+        <span className={`memory-compiler-fold__chevron${open ? " memory-compiler-fold__chevron--open" : ""}`}>▸</span>
+      </button>
+      {open && <pre className="memory-compiler-fold__body">{content}</pre>}
+    </div>
+  );
+}
+
 export function UserMessage({
   text,
   submitText,
@@ -167,8 +212,9 @@ export function UserMessage({
 }) {
   const t = useT();
   const imSource = parseImSourceMessage(text);
-  const actionText = stripMemoryCompilerExecution(imSource?.text ?? text);
-  const hasMemoryCompiler = Boolean(submitText?.includes("<memory-compiler-execution>"));
+  const { cleaned: memFreeText, block: memoryCompilerBlock } = extractMemoryCompilerExecution(imSource?.text ?? text);
+  const actionText = memFreeText;
+  const hasMemoryCompiler = Boolean(memoryCompilerBlock || submitText?.includes("<memory-compiler-execution>"));
   const { text: displayText, attachments } = parseAttachmentRefsForDisplay(actionText);
   const orderedAttachments = sortDisplayAttachments(attachments);
   const sourceLabel = imSource ? imSourceLabel(imSource, t) : "";
@@ -354,8 +400,10 @@ export function UserMessage({
             )}
           </div>
         ) : (
-          displayText && <div className="msg__text">{displayText}</div>
-        )}
+          <>
+            {memoryCompilerBlock && <CollapsibleMemoryCompiler content={memoryCompilerBlock} />}
+            {displayText && <div className="msg__text">{displayText}</div>}
+          </>
         {failed && <div className="msg__send-failed">{t("msg.sendFailed")}</div>}
         {orderedAttachments.length > 0 && (
           <div className="msg-attachments" aria-label={t("msg.attachments")}>

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -13,7 +13,7 @@ import { useT } from "../lib/i18n";
 import { Tooltip } from "./Tooltip";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { displayReasoningText } from "../lib/reasoningDisplay";
-import { stripMemoryCompilerExecution } from "../lib/memoryCompilerDisplay";
+import { extractMemoryCompilerExecution } from "../lib/memoryCompilerDisplay";
 import type { Item, MessageActionScope } from "../lib/useController";
 import type { CheckpointMeta, MemoryCitation } from "../lib/types";
 
@@ -54,28 +54,6 @@ function parseImSourceMessage(text: string): ImSourceMessage | null {
   };
 }
 
-
-const MEMORY_COMPILER_EXECUTION_RE = /<memory-compiler-execution>[\s\S]*?<\/memory-compiler-execution>\s*/g;
-
-/** Extract a <memory-compiler-execution> block from text. Returns the cleaned
- *  text (block removed) and the raw block content. When no block is present,
- *  block is null and cleaned equals the original text. */
-function extractMemoryCompilerExecution(text: string): { cleaned: string; block: string | null } {
-  const match = MEMORY_COMPILER_EXECUTION_RE.exec(text);
-  if (!match) return { cleaned: text, block: null };
-  MEMORY_COMPILER_EXECUTION_RE.lastIndex = 0;
-  return {
-    cleaned: text.replace(MEMORY_COMPILER_EXECUTION_RE, "").trimStart(),
-    block: match[0].trim(),
-  };
-}
-
-/** Strips the <memory-compiler-execution> block that the Memory v5 compiler
- *  injects into user turns for model-internal planning. The block is not
- *  user-facing text and should be hidden from the transcript display. */
-function stripMemoryCompilerExecution(text: string): string {
-  return extractMemoryCompilerExecution(text).cleaned;
-}
 
 
 function imSourceLabel(source: ImSourceMessage, t: ReturnType<typeof useT>): string {
@@ -404,6 +382,7 @@ export function UserMessage({
             {memoryCompilerBlock && <CollapsibleMemoryCompiler content={memoryCompilerBlock} />}
             {displayText && <div className="msg__text">{displayText}</div>}
           </>
+        )}
         {failed && <div className="msg__send-failed">{t("msg.sendFailed")}</div>}
         {orderedAttachments.length > 0 && (
           <div className="msg-attachments" aria-label={t("msg.attachments")}>

--- a/desktop/frontend/src/lib/memoryCompilerDisplay.ts
+++ b/desktop/frontend/src/lib/memoryCompilerDisplay.ts
@@ -16,3 +16,18 @@ const DANGLING_BLOCK_RE = /<memory-compiler-execution>[\s\S]*$/;
 export function stripMemoryCompilerExecution(text: string): string {
   return text.replace(COMPLETE_BLOCK_RE, "").replace(DANGLING_BLOCK_RE, "").trimStart();
 }
+
+/**
+ * Extracts the <memory-compiler-execution> block from text. Returns the cleaned
+ * text (block removed) and the raw block content. When no block is present,
+ * block is null and cleaned equals the original text.
+ */
+export function extractMemoryCompilerExecution(text: string): { cleaned: string; block: string | null } {
+  const match = COMPLETE_BLOCK_RE.exec(text);
+  if (!match) return { cleaned: text, block: null };
+  COMPLETE_BLOCK_RE.lastIndex = 0;
+  return {
+    cleaned: text.replace(COMPLETE_BLOCK_RE, "").trimStart(),
+    block: match[0].trim(),
+  };
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1485,6 +1485,7 @@ export const en = {
   "msg.memoryCitationsCount": "{n} memory references",
   "msg.memoryCompilerCitationsCount": "{n} Memory v5 compiler references",
   "msg.memoryCompilerApplied": "Memory v5 compiler applied to this message",
+  "msg.memoryCompilerContext": "Memory v5 context",
   "msg.memoryCitationLine": "line {line}",
   "msg.memoryCitationLineRange": "lines {start}-{end}",
   "msg.copy": "Copy",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -928,6 +928,7 @@ export const zhTW: Record<DictKey, string> = {
   "msg.thinkingRunning": "思考中…",
   "msg.thinkingDone": "已完成",
   "msg.memoryCitationsCount": "{n} 條記憶引用",
+  "msg.memoryCompilerContext": "Memory v5 上下文",
   "msg.memoryCompilerCitationsCount": "{n} 條 Memory v5 編譯引用",
   "msg.memoryCompilerApplied": "此訊息已套用 Memory v5 編譯器",
   "msg.memoryCitationLine": "第 {line} 行",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1487,6 +1487,7 @@ export const zh: Record<DictKey, string> = {
   "msg.memoryCitationsCount": "{n} 条记忆引用",
   "msg.memoryCompilerCitationsCount": "{n} 条 Memory v5 编译引用",
   "msg.memoryCompilerApplied": "此消息已应用 Memory v5 编译器",
+  "msg.memoryCompilerContext": "Memory v5 上下文",
   "msg.memoryCitationLine": "第 {line} 行",
   "msg.memoryCitationLineRange": "{start}-{end} 行",
   "msg.copy": "复制",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -25959,3 +25959,48 @@ a[href] {
   background: color-mix(in srgb, var(--fg) 8%, var(--sidebar-bg, var(--bg)));
   color: var(--fg-faint);
 }
+
+/* Memory v5 compiler collapsible block */
+.memory-compiler-fold {
+  margin: 6px 0;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-soft);
+}
+.memory-compiler-fold__toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  background: none;
+  color: var(--text-dim);
+  font-size: 12px;
+  cursor: pointer;
+}
+.memory-compiler-fold__toggle:hover {
+  background: var(--sidebar-hover);
+}
+.memory-compiler-fold__chevron {
+  margin-left: auto;
+  font-size: 10px;
+  transition: transform 0.15s;
+}
+.memory-compiler-fold__chevron--open {
+  transform: rotate(90deg);
+}
+.memory-compiler-fold__body {
+  margin: 0;
+  padding: 8px 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border-soft);
+  max-height: 200px;
+  overflow-y: auto;
+}
+

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -291,10 +291,10 @@ type Agent struct {
 	compilerTurn     *memorycompiler.Turn
 
 	// Memory v5 compiler injection guards.
-	lastCompilerInjectedAt  time.Time
-	compilerInjectionCount  int
-	compilerInjectionMax    int
-	compilerInjectCooldown  time.Duration
+	lastCompilerInjectedAt time.Time
+	compilerInjectionCount int
+	compilerInjectionMax   int
+	compilerInjectCooldown time.Duration
 
 	// planModeAllowedTools declares extra custom tools that the centralized
 	// plan-mode policy may treat as read-only. Known blocked tools still lose.
@@ -692,32 +692,32 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		maxStepsKey = "agent.max_steps"
 	}
 	a := &Agent{
-		prov:                  prov,
-		tools:                 tools,
-		session:               session,
-		maxSteps:              opts.MaxSteps,
-		maxStepsKey:           maxStepsKey,
-		temperature:           opts.Temperature,
-		pricing:               opts.Pricing,
-		usageSource:           usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
-		sink:                  sink,
-		gate:                  gate,
-		planModeReadOnlyTrust: planModeReadOnlyTrust,
-		hooks:                 hooks,
-		jobs:                  opts.Jobs,
-		evidence:              evidence.NewLedger(),
-		projectChecks:         append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
-		contextWindow:         opts.ContextWindow,
-		softCompactRatio:      opts.SoftCompactRatio,
-		compactRatio:          opts.CompactRatio,
-		compactForceRatio:     opts.CompactForceRatio,
-		recentKeep:            opts.RecentKeep,
-		archiveDir:            opts.ArchiveDir,
-		keepPolicy:            opts.KeepPolicy,
-		planModeAllowedTools:  append([]string(nil), opts.PlanModeAllowedTools...),
-		memoryCompiler:        opts.MemoryCompiler,
-		compilerInjectionMax:     5,
-		compilerInjectCooldown:   30 * time.Second,
+		prov:                   prov,
+		tools:                  tools,
+		session:                session,
+		maxSteps:               opts.MaxSteps,
+		maxStepsKey:            maxStepsKey,
+		temperature:            opts.Temperature,
+		pricing:                opts.Pricing,
+		usageSource:            usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
+		sink:                   sink,
+		gate:                   gate,
+		planModeReadOnlyTrust:  planModeReadOnlyTrust,
+		hooks:                  hooks,
+		jobs:                   opts.Jobs,
+		evidence:               evidence.NewLedger(),
+		projectChecks:          append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
+		contextWindow:          opts.ContextWindow,
+		softCompactRatio:       opts.SoftCompactRatio,
+		compactRatio:           opts.CompactRatio,
+		compactForceRatio:      opts.CompactForceRatio,
+		recentKeep:             opts.RecentKeep,
+		archiveDir:             opts.ArchiveDir,
+		keepPolicy:             opts.KeepPolicy,
+		planModeAllowedTools:   append([]string(nil), opts.PlanModeAllowedTools...),
+		memoryCompiler:         opts.MemoryCompiler,
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
 	}
 	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
@@ -754,7 +754,6 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
-<<<<<<< HEAD
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) {
 		if a.shouldInjectCompiler(memoryCompilerInput) {
 			if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -290,6 +290,12 @@ type Agent struct {
 	memoryCompiler   *memorycompiler.Runtime
 	compilerTurn     *memorycompiler.Turn
 
+	// Memory v5 compiler injection guards.
+	lastCompilerInjectedAt  time.Time
+	compilerInjectionCount  int
+	compilerInjectionMax    int
+	compilerInjectCooldown  time.Duration
+
 	// planModeAllowedTools declares extra custom tools that the centralized
 	// plan-mode policy may treat as read-only. Known blocked tools still lose.
 	// Populated from Options.PlanModeAllowedTools during construction.
@@ -395,6 +401,32 @@ func (a *Agent) memoryCompilerRuntime() *memorycompiler.Runtime {
 	a.memoryCompilerMu.RLock()
 	defer a.memoryCompilerMu.RUnlock()
 	return a.memoryCompiler
+}
+
+// shouldInjectCompiler returns true when the Memory v5 compiler may inject an
+// execution contract for this turn. It enforces:
+//   - Session cap: no more than compilerInjectionMax total injections
+//   - Genuine input: non-empty and not system-generated (starts with '<')
+//   - Cooldown: at least compilerInjectCooldown since the last injection
+func (a *Agent) shouldInjectCompiler(input string) bool {
+	if a.compilerInjectionMax <= 0 {
+		return false
+	}
+	if strings.TrimSpace(input) == "" || strings.HasPrefix(strings.TrimSpace(input), "<") {
+		return false
+	}
+	if a.compilerInjectionCount >= a.compilerInjectionMax {
+		return false
+	}
+	if time.Since(a.lastCompilerInjectedAt) < a.compilerInjectCooldown {
+		return false
+	}
+	return true
+}
+
+func (a *Agent) markCompilerInjected() {
+	a.lastCompilerInjectedAt = time.Now()
+	a.compilerInjectionCount++
 }
 
 // SetGate installs the per-call permission gate. Used by interactive CLI sessions to swap the
@@ -684,6 +716,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		keepPolicy:            opts.KeepPolicy,
 		planModeAllowedTools:  append([]string(nil), opts.PlanModeAllowedTools...),
 		memoryCompiler:        opts.MemoryCompiler,
+		compilerInjectionMax:     5,
+		compilerInjectCooldown:   30 * time.Second,
 	}
 	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
@@ -720,18 +754,22 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
+<<<<<<< HEAD
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) {
-		if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
-			a.compilerTurn = turn
-			a.emitMemoryCompilerStats(turn)
-			defer func() {
-				turn.Finish(runErr)
-				if a.compilerTurn == turn {
-					a.compilerTurn = nil
+		if a.shouldInjectCompiler(memoryCompilerInput) {
+			if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
+				a.markCompilerInjected()
+				a.compilerTurn = turn
+				a.emitMemoryCompilerStats(turn)
+				defer func() {
+					turn.Finish(runErr)
+					if a.compilerTurn == turn {
+						a.compilerTurn = nil
+					}
+				}()
+				if strings.TrimSpace(compiledInput) != "" {
+					input = a.withTurnPreferences(compiledInput)
 				}
-			}()
-			if strings.TrimSpace(compiledInput) != "" {
-				input = a.withTurnPreferences(compiledInput)
 			}
 		}
 	}

--- a/internal/agent/memory_compiler_guard_test.go
+++ b/internal/agent/memory_compiler_guard_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldInjectCompilerRejectsEmptyInput(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	if a.shouldInjectCompiler("") {
+		t.Fatal("shouldInjectCompiler(\"\") = true, want false")
+	}
+	if a.shouldInjectCompiler("   ") {
+		t.Fatal("shouldInjectCompiler(\"   \") = true, want false")
+	}
+}
+
+func TestShouldInjectCompilerRejectsSystemGeneratedInput(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	for _, input := range []string{
+		"<memory-compiler-execution>...",
+		"<steer>some steer</steer>",
+		"<background-jobs>done</background-jobs>",
+	} {
+		if a.shouldInjectCompiler(input) {
+			t.Fatalf("shouldInjectCompiler(%q) = true, want false for system-generated input", input)
+		}
+	}
+}
+
+func TestShouldInjectCompilerAcceptsGenuineInput(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	if !a.shouldInjectCompiler("fix the login bug") {
+		t.Fatal("shouldInjectCompiler(\"fix the login bug\") = false, want true")
+	}
+	if !a.shouldInjectCompiler("今日分时交易数据分析") {
+		t.Fatal("shouldInjectCompiler(Chinese text) = false, want true")
+	}
+}
+
+func TestShouldInjectCompilerEnforcesCooldown(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	if !a.shouldInjectCompiler("first message") {
+		t.Fatal("first shouldInjectCompiler = false, want true")
+	}
+	a.markCompilerInjected()
+	if a.shouldInjectCompiler("second message") {
+		t.Fatal("shouldInjectCompiler during cooldown = true, want false")
+	}
+}
+
+func TestShouldInjectCompilerAllowsAfterCooldown(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	a.shouldInjectCompiler("first message")
+	a.markCompilerInjected()
+	// simulate cooldown elapsed
+	a.lastCompilerInjectedAt = time.Now().Add(-31 * time.Second)
+	if !a.shouldInjectCompiler("second message") {
+		t.Fatal("shouldInjectCompiler after cooldown = false, want true")
+	}
+}
+
+func TestShouldInjectCompilerEnforcesSessionCap(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   3,
+		compilerInjectCooldown: 0, // no cooldown for this test
+	}
+	for i := 0; i < 3; i++ {
+		if !a.shouldInjectCompiler("message") {
+			t.Fatalf("shouldInjectCompiler #%d = false, want true (cap not reached yet)", i+1)
+		}
+		a.markCompilerInjected()
+	}
+	if a.shouldInjectCompiler("one too many") {
+		t.Fatal("shouldInjectCompiler after cap = true, want false")
+	}
+}
+
+func TestShouldInjectCompilerZeroMaxDisablesAll(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   0,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	if a.shouldInjectCompiler("any message") {
+		t.Fatal("shouldInjectCompiler with max=0 = true, want false")
+	}
+}
+
+func TestMarkCompilerInjectedTracksState(t *testing.T) {
+	a := &Agent{
+		compilerInjectionMax:   5,
+		compilerInjectCooldown: 30 * time.Second,
+	}
+	if a.compilerInjectionCount != 0 {
+		t.Fatalf("initial count = %d, want 0", a.compilerInjectionCount)
+	}
+	a.markCompilerInjected()
+	if a.compilerInjectionCount != 1 {
+		t.Fatalf("count after mark = %d, want 1", a.compilerInjectionCount)
+	}
+	if a.lastCompilerInjectedAt.IsZero() {
+		t.Fatal("lastCompilerInjectedAt not set after mark")
+	}
+}


### PR DESCRIPTION
## Summary

-

## Verification

-

## Cache impact

Cache-impact: low — adds new methods to Agent struct, no system-prompt or tool-schema changes
Cache-guard: go test ./internal/agent/ -run "TestShouldInject|TestMarkCompiler|TestRunUsesMemoryCompiler" -count=1
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
