### PR TITLE
fix(tui): restore mouse wheel scrolling in transcript viewport

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2398,6 +2398,7 @@ func (m chatTUI) View() tea.View {
 	}
 	v := tea.NewView(mainArea + "\n" + strings.Join(parts, "\n"))
 	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion // wheel scrolls the transcript; text selection is handled in-app
 	// Anchor the real terminal cursor at the textarea's insertion point only when
 	// the composer is visible. input.Cursor() is relative to the textarea; offset
 	// by the viewport height + rows above + the box's top border row (+1 column

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1435,8 +1435,9 @@ func TestQueueIndicatorHiddenWhenIdle(t *testing.T) {
 }
 
 // TestViewAltScreenFillsHeight proves the switch to alt-screen: View requests
-// the alt buffer without mouse reporting, and the frame is exactly the terminal
-// height (the transcript viewport pads to fill above the pinned bottom region).
+// the alt buffer with mouse reporting for wheel scrolling and in-app text
+// selection, and the frame is exactly the terminal height (the transcript
+// viewport pads to fill above the pinned bottom region).
 func TestViewAltScreenFillsHeight(t *testing.T) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
@@ -1447,8 +1448,8 @@ func TestViewAltScreenFillsHeight(t *testing.T) {
 	if !v.AltScreen {
 		t.Error("View must request alt-screen so resize repaints the whole grid")
 	}
-	if v.MouseMode != tea.MouseModeNone {
-		t.Error("View must leave terminal mouse selection available by default")
+	if v.MouseMode != tea.MouseModeCellMotion {
+		t.Error("View must enable mouse so the wheel scrolls the transcript")
 	}
 	if lines := strings.Count(v.Content, "\n") + 1; lines != 24 {
 		t.Errorf("alt-screen frame = %d lines, want 24 (full terminal height)", lines)


### PR DESCRIPTION
# PR: Restore mouse wheel scrolling in CLI TUI transcript viewport

Closes #5334, closes #5311, closes #5324

## English

### Summary

Commit `edacf1a8` ("fix(tui): preserve native terminal selection") removed
`v.MouseMode = tea.MouseModeCellMotion` from the `View()` method, which disabled
mouse reporting in the terminal. Without mouse mode, terminals do not emit
`MouseWheelMsg` events. Many terminal emulators translate mouse wheel input into
**Up / Down arrow key** sequences instead. These arrow keys are handled by
`recallSubmittedInput()`, causing the **input history** to scroll instead of the
transcript viewport.

This PR restores `MouseModeCellMotion` on the **alt-screen path only** so that
mouse wheel events reach the viewport and scroll the transcript as expected.

### Affected issues

| Issue | Description | Platform |
|-------|-------------|----------|
| #5334 | CLI 输出的内容无法上下滚动查看，滚动时成了滚动输入框中的内容了 | Windows 11 |
| #5311 | 鼠标滚轮之前是滚动对话记录, 现在变成了滚动历史命令 | Windows Terminal → macOS |
| #5324 | Scrolling up to view past messages does not work anymore (CLI) | macOS 26.5.1 |

All three issues report the same regression caused by `edacf1a8`.

### Root cause

| Before `edacf1a8` | After `edacf1a8` | This PR |
|---|---|---|
| `MouseModeCellMotion` enabled | Mouse mode removed | `MouseModeCellMotion` restored |
| Wheel → `MouseWheelMsg` → `viewport.ScrollUp/Down` ✅ | Wheel → terminal sends ↑/↓ keys → `recallSubmittedInput()` ❌ | Wheel → `MouseWheelMsg` → `viewport.ScrollUp/Down` ✅ |

### What changed

- **`internal/cli/chat_tui.go`** (+1 line): Added back `v.MouseMode = tea.MouseModeCellMotion` in the `View()` method, only on the alt-screen (non-Termux) path.
- **`internal/cli/chat_tui_test.go`** (+5 / -4 lines): Updated `TestViewAltScreenFillsHeight` to expect `MouseModeCellMotion` instead of `MouseModeNone`. The Termux test (`TestViewTermuxUsesNativeScrollback`) is unchanged because the Termux path returns before the MouseMode line.

### What is NOT affected

- **Termux / Android**: The `nativeScrollback` path returns early from `View()` before `MouseMode` is set, keeping `MouseModeNone` (zero value). Soft-keyboard focus is preserved.
- **Desktop app**: Completely separate code path.
- **Web frontend**: Completely separate code path.
- **Keyboard scrolling**: PgUp / PgDn / Ctrl+Home / Ctrl+End are handled in `KeyPressMsg`, independent of mouse mode.
- **All slash commands, approval flows, rewind, etc.**

### Trade-off: native terminal selection vs. in-app selection

Enabling `MouseModeCellMotion` means the terminal sends all mouse events to the
application. Native terminal text selection (click-drag to select, then use the
terminal's copy shortcut) is therefore **disabled**.

However, the TUI already implements its **own text selection mechanism** that
works within the transcript viewport:

| Feature | Native terminal selection | TUI in-app selection |
|---|---|---|
| Left-drag to select | ✅ | ✅ (with visual highlight) |
| Right-click to copy | Depends on terminal | ✅ (built-in) |
| Edge auto-scroll during drag | ❌ | ✅ |
| Ctrl+C copies selection | Depends on terminal | ✅ (priority over cancel) |
| Select text in composer area | ✅ | Keyboard only |
| Mouse wheel scrolling | ❌ | ✅ |

The TUI's selection has been the primary interaction model since the project's
inception. `edacf1a8` was merged ~3 days ago (Jun 23) and introduced the
regression this PR fixes.

### Cache impact

```
Cache-impact: low — only affects CLI TUI View() method, not cache-sensitive paths
Cache-guard: go test ./internal/cli/ -run "TestViewAltScreenFillsHeight|TestViewTermuxUsesNativeScrollback"
```

---

## 中文

### 概述

修复 #5334、#5311、#5324。

提交 `edacf1a8`（"fix(tui): preserve native terminal selection"）从 `View()` 方法中移除了
`v.MouseMode = tea.MouseModeCellMotion`，导致终端不再向应用程序发送鼠标事件。没有鼠标模式时，
许多终端仿真器会将鼠标滚轮转译为 **↑ / ↓ 方向键**序列，这些方向键被 `recallSubmittedInput()`
处理，导致**输入历史**被滚动，而非 transcript viewport。

本 PR 在 **alt-screen 路径**上恢复 `MouseModeCellMotion`，使鼠标滚轮事件正常到达 viewport。

### 相关 Issue

| Issue | 描述 | 平台 |
|-------|------|------|
| #5334 | CLI 输出的内容无法上下滚动查看，滚动时成了滚动输入框中的内容了 | Windows 11 |
| #5311 | 鼠标滚轮之前是滚动对话记录, 现在变成了滚动历史命令 | Windows Terminal → macOS |
| #5324 | Scrolling up to view past messages does not work anymore (CLI) | macOS 26.5.1 |

三个 issue 报告的是同一个由 `edacf1a8` 引入的回归问题。

### 根因分析

| `edacf1a8` 之前 | `edacf1a8` 之后 | 本 PR |
|---|---|---|
| `MouseModeCellMotion` 启用 | 鼠标模式被移除 | `MouseModeCellMotion` 恢复 |
| 滚轮 → `MouseWheelMsg` → `viewport.ScrollUp/Down` ✅ | 滚轮 → 终端发送 ↑/↓ 键 → `recallSubmittedInput()` ❌ | 滚轮 → `MouseWheelMsg` → `viewport.ScrollUp/Down` ✅ |

### 改动内容

- **`internal/cli/chat_tui.go`**（+1 行）：在 `View()` 方法的 alt-screen 路径中恢复 `v.MouseMode = tea.MouseModeCellMotion`。Termux 路径不受影响。
- **`internal/cli/chat_tui_test.go`**（+5 / -4 行）：更新 `TestViewAltScreenFillsHeight` 测试，期望 `MouseModeCellMotion` 而非 `MouseModeNone`。Termux 测试（`TestViewTermuxUsesNativeScrollback`）不变。

### 不受影响的部分

- **Termux / Android**：`nativeScrollback` 路径在 `MouseMode` 设置前提前返回，保持 `MouseModeNone`。软键盘焦点不受影响。
- **桌面版**：完全独立的代码路径。
- **Web 前端**：完全独立的代码路径。
- **键盘滚动**：PgUp / PgDn / Ctrl+Home / Ctrl+End 在 `KeyPressMsg` 中处理，与鼠标模式无关。
- **所有斜杠命令、审批流、rewind 等功能**。

### 取舍：终端原生选择 vs. TUI 内置选择

启用 `MouseModeCellMotion` 后，终端会将所有鼠标事件发送给应用程序，**终端原生文本选择**（拖选后使用终端快捷键复制）因此不可用。

但 TUI 已经实现了**自己的文本选择机制**，在 transcript viewport 内功能更完善：

| 功能 | 终端原生选择 | TUI 内置选择 |
|---|---|---|
| 左键拖选 | ✅ | ✅（带视觉高亮） |
| 右键复制 | 取决于终端 | ✅（内置） |
| 拖选到边缘自动滚动 | ❌ | ✅ |
| Ctrl+C 复制选区 | 取决于终端 | ✅（优先于取消操作） |
| 选中输入框区域文字 | ✅ | 仅键盘操作 |
| 鼠标滚轮滚动 | ❌ | ✅ |

TUI 内置选择自项目初期就是主要的交互方式。`edacf1a8` 约 3 天前（6 月 23 日）合入，引入了本 PR 修复的回归。

### 缓存影响

```
Cache-impact: low — 仅影响 CLI TUI View() 方法，不影响缓存敏感路径
Cache-guard: go test ./internal/cli/ -run "TestViewAltScreenFillsHeight|TestViewTermuxUsesNativeScrollback"
```
