### PR TITLE
feat(Makefile): add install target with existing-version guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.version=$(VERSION)
 GOEXE := $(shell go env GOEXE)
+PREFIX ?= $(HOME)/.local
+INSTALLDIR := $(PREFIX)/bin
 
-.PHONY: build vet fmt test hooks cross clean
+.PHONY: build vet fmt test hooks cross clean install
 
 build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix$(GOEXE) ./cmd/reasonix
@@ -31,3 +33,23 @@ cross:
 
 clean:
 	rm -rf bin dist
+
+install: build
+	@if [ -f "$(INSTALLDIR)/reasonix$(GOEXE)" ]; then \
+		if [ "$(FORCE)" != "1" ]; then \
+			echo "error: $(INSTALLDIR)/reasonix$(GOEXE) already exists."; \
+			echo "To overwrite, run: make install FORCE=1"; \
+			exit 1; \
+		fi; \
+		echo "warning: overwriting existing installation (FORCE=1)"; \
+	fi
+	@mkdir -p "$(INSTALLDIR)"
+	cp bin/reasonix$(GOEXE) "$(INSTALLDIR)/reasonix$(GOEXE)"
+	chmod 0755 "$(INSTALLDIR)/reasonix$(GOEXE)"
+	cp bin/reasonix-plugin-example$(GOEXE) "$(INSTALLDIR)/reasonix-plugin-example$(GOEXE)"
+	chmod 0755 "$(INSTALLDIR)/reasonix-plugin-example$(GOEXE)"
+	@echo "installed: $(INSTALLDIR)/reasonix$(GOEXE)"
+	@echo "installed: $(INSTALLDIR)/reasonix-plugin-example$(GOEXE)"
+	@echo ""
+	@echo "Make sure $(INSTALLDIR) is in your PATH."
+	@echo "Then run: reasonix setup"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Windows builds are code-signed with a free certificate provided by the
 
 ```sh
 make build      # -> bin/reasonix(.exe)
+make install    # build + install to $(PREFIX)/bin (default ~/.local/bin)
+make install FORCE=1  # overwrite existing installation
 make cross      # -> dist/ (darwin|linux|windows × amd64|arm64)
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,8 @@ Windows 构建使用 [SignPath 基金会](https://signpath.org/) 提供的免费
 
 ```sh
 make build      # -> bin/reasonix(.exe)
+make install    # 构建 + 安装到 $(PREFIX)/bin（默认 ~/.local/bin）
+make install FORCE=1  # 强制覆盖已安装版本
 make cross      # -> dist/（darwin|linux|windows × amd64|arm64）
 ```
 


### PR DESCRIPTION
## What this does | 这个 PR 做了什么

**English:**
This PR adds a proper `make install` target that automates from-source installation:
1.  Builds all binaries from source (`reasonix` + `reasonix-plugin-example`)
2.  Installs them to `$(PREFIX)/bin` (defaults to `~/.local/bin`)
3.  **Adds an existing-version guard**: if an installation already exists in the target path, it errors out and asks the user to run `make install FORCE=1` to overwrite.

Why this helps:
- Provides a one-step installation path for users who want to build from source. Previously users had to manually `cp` binaries to PATH, which could be error-prone and left users wondering if all components were installed correctly.
- The guard prevents accidental overwrites of an existing working installation (e.g. the npm-installed binary)
- Motivation: I personally ran into this issue today: after following the Quick Start and running `npm i -g reasonix`, I got a 0.x (legacy TypeScript) version instead of 1.x (Go). The configuration didn't work, and I had to manually copy the built binaries to PATH - which made me wonder if I had all required components installed properly. This PR solves that experience gap.
- Related: there is already PR #4352 addressing the npm dist-tag issue. This PR complements that by making it easier for users who want to install from source directly.

Updated both `README.md` and `README.zh-CN.md` to document the new target.

---

**中文说明:**
本 PR 添加了完整的 `make install` 目标，自动化从源码安装流程：
1.  从源码构建所有二进制文件（`reasonix` + `reasonix-plugin-example`）
2.  安装到 `$(PREFIX)/bin`（默认 `~/.local/bin`）
3.  **增加已有版本防护**：如果目标路径已经存在 reasonix 安装，会报错提示需要使用 `make install FORCE=1` 才允许覆盖。

解决的问题：
- 为从源码安装的用户提供一步到位的安装命令，之前用户需要手动 `cp` 二进制到 PATH，容易出错，而且会担心是不是漏装了组件。现在一条命令搞定，安装路径清晰易管理。
- 防护机制防止在用户没有明确要求的情况下，意外覆盖已有的安装（比如通过 npm 安装的版本）。
- **动机**：我自己今天就踩坑了：按照 README 的 Quick Start 执行 `npm i -g reasonix`，结果装完是 0.x TypeScript 旧版本，按照文档配置后完全不生效。排查之后不得不从源码构建再手动复制到 PATH，但过程中一直怀疑是不是漏装了某个组件。这个 PR 填补了这个体验缺口。
- 相关：已有 PR #4352 解决 npm 标签问题，本 PR 是补充，让想直接从源码安装的用户更省心。

同时更新了英文和简体中文 README 文档。

## Testing | 测试

- ✅ `make install` 全新安装正常工作
- ✅ `make install` 在已有安装时报错提示
- ✅ `make install FORCE=1` 成功覆盖安装
- ✅ 同时安装 `reasonix` 和 `reasonix-plugin-example` 两个二进制
- ✅ 安装完成后提示检查 PATH 环境变量

---

Fixes #5436
