### PR TITLE
perf(memorycompiler): compact the per-turn execution contract

### DIFF
--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -246,13 +246,6 @@ type MutationEvaluation struct {
 	Trials   int     `json:"trials"`
 }
 
-type IRExplanation struct {
-	DecisionSummary   string   `json:"decision_summary"`
-	ConstraintMapping []string `json:"constraint_mapping"`
-	MemoryInfluence   []string `json:"memory_influence"`
-	StrategyReason    string   `json:"strategy_reason"`
-}
-
 type IRValidationResult struct {
 	Findings     []string
 	HardFindings []string
@@ -697,18 +690,38 @@ func hasUsefulIR(ir PlannerIR) bool {
 	return len(ir.Constraints) > 0 || len(ir.MemoryReferences) > 0 || len(ir.RiskNotes) > 0
 }
 
+// contractIR is the bounded, model-facing projection of PlannerIR that gets
+// serialized into the per-turn prompt contract. It is deliberately a separate
+// type from PlannerIR with omitempty everywhere so the injected JSON carries no
+// zero-value/null noise. The display layer (agent.memoryCompilerSourceEvent)
+// only needs planner_ir.source_event, which is preserved.
+type contractIR struct {
+	Version           string            `json:"version,omitempty"`
+	Goal              string            `json:"goal,omitempty"`
+	SourceEvent       string            `json:"source_event"`
+	RuntimeMode       string            `json:"runtime_mode,omitempty"`
+	Constraints       []Constraint      `json:"constraints,omitempty"`
+	StrategySelection *contractStrategy `json:"strategy_selection,omitempty"`
+	MemoryReferences  []MemoryRef       `json:"memory_references,omitempty"`
+	ExecutionSteps    []Step            `json:"execution_steps,omitempty"`
+	RiskNotes         []string          `json:"risk_notes,omitempty"`
+}
+
+type contractStrategy struct {
+	Selected string `json:"selected"`
+	Reason   string `json:"reason,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+}
+
 func compileExecutionContract(ir PlannerIR) (string, error) {
-	ir = canonicalizeIR(ir)
 	contract := struct {
-		Type        string        `json:"type"`
-		Instruction string        `json:"instruction"`
-		Explanation IRExplanation `json:"ir_explanation"`
-		PlannerIR   PlannerIR     `json:"planner_ir"`
+		Type        string     `json:"type"`
+		Instruction string     `json:"instruction"`
+		PlannerIR   contractIR `json:"planner_ir"`
 	}{
 		Type:        "memory_v5_execution_contract",
 		Instruction: "Execute source_event through planner_ir. Treat constraints, risk_notes, strategy_selection, and execution_steps as the controlling plan for this turn. Do not bypass contradictory or quarantined memory outside this IR.",
-		Explanation: explainIR(ir, nil),
-		PlannerIR:   ir,
+		PlannerIR:   compactContractIR(canonicalizeIR(ir)),
 	}
 	body, err := json.Marshal(contract)
 	if err != nil {
@@ -717,45 +730,45 @@ func compileExecutionContract(ir PlannerIR) (string, error) {
 	return "<memory-compiler-execution>\n" + string(body) + "\n</memory-compiler-execution>", nil
 }
 
-func explainIR(ir PlannerIR, result *ExecutionTrace) IRExplanation {
-	ir = canonicalizeIR(ir)
-	explanation := IRExplanation{
-		DecisionSummary:   "Use strategy " + selectedStrategy(ir) + " for goal: " + ir.Goal,
-		ConstraintMapping: []string{},
-		MemoryInfluence:   []string{},
-		StrategyReason:    "default strategy selection",
+// compactContractIR projects the full canonical IR onto the model-facing
+// contractIR by dropping only the fields the model cannot act on. It does NOT
+// cap or re-truncate the actionable fields, so the constraints, memory
+// references, execution steps, risk notes, and selected strategy it injects are
+// byte-identical to what the previous full contract carried. The full IR is
+// still recorded on the execution trace for learning (writeTraceAndLearn keeps
+// the canonical IR); only the prompt copy is slimmed.
+//
+// Before this the contract re-serialized the entire planner IR every turn,
+// including a prose ir_explanation that just restated the constraints and
+// memory references, the ranked available_strategies candidate table, and each
+// strategy's rejected/score/exploration-rate control-loop state. On short user
+// turns that inflated the user message ~20-50x and grew unbounded as the
+// candidate table and explanation accreted. None of the dropped fields carry
+// guidance the kept fields don't already supply; the canonical IR's own limits
+// keep the kept fields bounded.
+func compactContractIR(ir PlannerIR) contractIR {
+	out := contractIR{
+		Version:          ir.Version,
+		Goal:             ir.Goal,
+		SourceEvent:      ir.SourceEvent,
+		RuntimeMode:      ir.RuntimeMode,
+		Constraints:      ir.Constraints,
+		MemoryReferences: ir.MemoryReferences,
+		ExecutionSteps:   ir.ExecutionSteps,
+		RiskNotes:        ir.RiskNotes,
 	}
+	// Keep only the chosen strategy and its reason/mode; the rejected
+	// candidates, numeric score, and exploration rate are internal control-loop
+	// state the model cannot act on, and the ranked available_strategies table
+	// is dropped entirely for the same reason.
 	if ir.StrategySelection != nil {
-		explanation.StrategyReason = ir.StrategySelection.Reason
-		if result != nil && result.Outcome != "" {
-			explanation.DecisionSummary += " with prior outcome context: " + result.Outcome
+		out.StrategySelection = &contractStrategy{
+			Selected: ir.StrategySelection.Selected,
+			Reason:   ir.StrategySelection.Reason,
+			Mode:     ir.StrategySelection.Mode,
 		}
 	}
-	for _, c := range ir.Constraints {
-		entry := c.Type + " constraint"
-		if c.Source != "" {
-			entry += " from " + c.Source
-		}
-		entry += ": " + c.Text
-		explanation.ConstraintMapping = append(explanation.ConstraintMapping, entry)
-		if len(explanation.ConstraintMapping) >= 5 {
-			break
-		}
-	}
-	for _, ref := range ir.MemoryReferences {
-		entry := ref.ID + " influenced decision"
-		if ref.Influence != "" {
-			entry += " as " + ref.Influence
-		}
-		if ref.Quality != "" {
-			entry += " (" + ref.Quality + ")"
-		}
-		explanation.MemoryInfluence = append(explanation.MemoryInfluence, entry)
-		if len(explanation.MemoryInfluence) >= 5 {
-			break
-		}
-	}
-	return canonicalizeExplanation(explanation)
+	return out
 }
 
 func memoryCitationsForIR(ir PlannerIR) []provider.MemoryCitation {
@@ -819,20 +832,6 @@ func selectedStrategy(ir PlannerIR) string {
 		return strings.TrimSpace(ir.StrategySelection.Selected)
 	}
 	return "general"
-}
-
-func canonicalizeExplanation(in IRExplanation) IRExplanation {
-	in.DecisionSummary = summarizeText(in.DecisionSummary, 220)
-	in.StrategyReason = summarizeText(in.StrategyReason, 180)
-	in.ConstraintMapping = limitStrings(canonicalStrings(in.ConstraintMapping), 5)
-	in.MemoryInfluence = limitStrings(canonicalStrings(in.MemoryInfluence), 5)
-	if in.ConstraintMapping == nil {
-		in.ConstraintMapping = []string{}
-	}
-	if in.MemoryInfluence == nil {
-		in.MemoryInfluence = []string{}
-	}
-	return in
 }
 
 func canonicalizeIR(ir PlannerIR) PlannerIR {

--- a/internal/memorycompiler/runtime_test.go
+++ b/internal/memorycompiler/runtime_test.go
@@ -389,7 +389,7 @@ func TestCompilerContractCanonicalizesSemanticOrder(t *testing.T) {
 	}
 }
 
-func TestCompilerContractIncludesBoundedIRExplanation(t *testing.T) {
+func TestCompilerContractIsCompact(t *testing.T) {
 	ir := PlannerIR{
 		Version:     version,
 		Goal:        "optimize a workflow",
@@ -401,20 +401,35 @@ func TestCompilerContractIncludesBoundedIRExplanation(t *testing.T) {
 		MemoryReferences: []MemoryRef{
 			{ID: "memory:latency", Content: "user prefers low latency", Quality: string(QualityHighSignal), Influence: "constraint"},
 		},
-		StrategySelection: &StrategyPick{Selected: "general", Reason: "matched prior low-latency pattern"},
+		AvailableStrategies: []StrategyRef{
+			{ID: "general", SuccessRate: 0.9, Samples: 10, Score: 0.8, Reason: "ranked top"},
+			{ID: "bugfix-reproduce-first", SuccessRate: 0.5, Samples: 4},
+		},
+		StrategySelection: &StrategyPick{Selected: "general", Reason: "matched prior low-latency pattern", Score: 0.8, Rejected: []RejectedStrategy{{ID: "z", Score: 0.1}}},
 	}
 	contract, err := compileExecutionContract(ir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(contract, `"ir_explanation"`) {
-		t.Fatalf("compiled contract missing IR explanation:\n%s", contract)
+	// The load-bearing fields the model acts on must survive compaction.
+	if !strings.Contains(contract, `"source_event":"optimize a workflow"`) {
+		t.Fatalf("compiled contract dropped source_event:\n%s", contract)
 	}
-	if !strings.Contains(contract, `"constraint_mapping":["must_use constraint from memory:latency: prefer low latency"]`) {
-		t.Fatalf("compiled contract missing constraint explanation:\n%s", contract)
+	if !strings.Contains(contract, `"prefer low latency"`) {
+		t.Fatalf("compiled contract dropped the active constraint:\n%s", contract)
 	}
-	if !strings.Contains(contract, `"memory_influence":["memory:latency influenced decision as constraint (HIGH_SIGNAL)"]`) {
-		t.Fatalf("compiled contract missing memory influence explanation:\n%s", contract)
+	if !strings.Contains(contract, `"selected":"general"`) {
+		t.Fatalf("compiled contract dropped the selected strategy:\n%s", contract)
+	}
+	if !strings.Contains(contract, `"memory:latency"`) {
+		t.Fatalf("compiled contract dropped the high-signal memory reference:\n%s", contract)
+	}
+	// The compacted-away fields (prose explanation, ranked candidate table,
+	// rejected strategies) must NOT bloat the per-turn contract.
+	for _, banned := range []string{`"ir_explanation"`, `"available_strategies"`, `"rejected"`, `"constraint_mapping"`} {
+		if strings.Contains(contract, banned) {
+			t.Fatalf("compiled contract still carries bloat field %s:\n%s", banned, contract)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

The Memory v5 compiler replaces each user turn with a compiled `<memory-compiler-execution>` contract. It re-serialized the **entire** `PlannerIR` every turn:

- a prose `ir_explanation` that merely restated the constraints and memory references,
- the ranked `available_strategies` candidate table, and
- each strategy's `rejected` / `score` / `exploration_rate` control-loop state.

This projects the model-facing IR onto a bounded `contractIR` that drops only those non-actionable fields. The kept fields — `source_event`, `constraints`, `memory_references`, `execution_steps`, `risk_notes`, and the selected strategy + reason/mode — are passed through **verbatim** from the canonical IR.

## Why

On short user turns the full contract inflated the user message ~20-50x and grew **unbounded** as the candidate table and explanation accreted, with no token-saving counterpart anywhere in the code. The full IR is still recorded on the execution trace for learning; only the prompt copy is slimmed. Display unwrapping is unaffected (`planner_ir.source_event` is preserved).

## Effect on behavior: none (byte-identical guidance)

Verified by an offline A/B over a warmed-up multi-turn session (old contract vs new, same accumulated state):

| | old | new |
|---|---|---|
| selected strategy | `general` | `general` (same) |
| constraints | same | same |
| memory references | 5 | **5 (same)** |
| `ir_explanation` / `available_strategies` / `rejected` | present | dropped |
| per-turn contract | ~737 tok | **~390 tok** |
| 12-turn session | ~8170 tok | **~4312 tok (-47%)** |

The model receives the same actionable guidance; only the bloat is removed, and the unbounded growth is gone.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/...` green (69 packages); the one test that asserted the removed prose fields is rewritten (`TestCompilerContractIsCompact`) to assert the load-bearing fields survive and the bloat fields are absent