### PR TITLE
fix(desktop): preserve collaboration mode during session rebuild

### DIFF
--- a/desktop/tab_profile_test.go
+++ b/desktop/tab_profile_test.go
@@ -432,6 +432,32 @@ func TestMetaReportsGoalStatus(t *testing.T) {
 	}
 }
 
+func TestMetaReportsStoredCollaborationModeWhileControllerRebuilds(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	tab := testTab("a", t.TempDir())
+	tab.Ctrl.Close()
+	tab.Ctrl = nil
+	tab.mode = "plan-yolo"
+	tab.toolApprovalMode = control.ToolApprovalYolo
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	meta := app.MetaForTab(tab.ID)
+	if meta.CollaborationMode != "plan" || meta.ToolApprovalMode != control.ToolApprovalYolo {
+		t.Fatalf("rebuilding plan-yolo meta = %+v, want plan/yolo", meta)
+	}
+
+	tab.mode = "normal"
+	tab.goal = "finish the goal runner"
+	meta = app.MetaForTab(tab.ID)
+	if meta.CollaborationMode != "goal" || meta.Goal != "finish the goal runner" || meta.GoalStatus != control.GoalStatusRunning {
+		t.Fatalf("rebuilding goal meta = %+v, want running goal", meta)
+	}
+}
+
 func TestSetPlanModePreservesAutoApproveTools(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5059,7 +5059,7 @@ func currentTabCollaborationMode(tab *WorkspaceTab) string {
 	if tab == nil {
 		return "normal"
 	}
-	if tab.Ctrl != nil && tab.Ctrl.PlanMode() {
+	if tabModeHasPlan(currentTabMode(tab)) {
 		return "plan"
 	}
 	if strings.TrimSpace(currentTabGoal(tab)) != "" && currentTabGoalStatus(tab) == control.GoalStatusRunning {


### PR DESCRIPTION
Fixes #5374.

Summary:
- keep collaboration mode derived from the stored tab mode while a session controller is rebuilding
- cover the rebuild window for plan/yolo and goal metadata

Verification:
- go test . (desktop)
- npm exec -- tsx src/__tests__/composer-profile.test.ts

Related Contribution Credit:
- #5170 by @liaoyl830 independently investigated the same collaboration-mode fallback problem around `currentTabCollaborationMode()` during controller rebuild/workspace switching, and proposed preserving Plan state from the stored tab mode. The final merged implementation in this PR uses the shared `currentTabMode(tab)` helper, but #5170 contributed useful root-cause analysis and regression-test coverage for the same class of issue.
