### PR TITLE
fix(memory-v5): stop synthetic turns from spinning the goal loop (#5342, #5329)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -681,7 +681,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
-	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil {
+	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) {
 		if compiledInput, turn := memCompiler.StartTurn(ctx, memoryCompilerInput, a.session.Snapshot()); turn != nil {
 			a.compilerTurn = turn
 			a.emitMemoryCompilerStats(turn)

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -55,6 +55,47 @@ func TestRunMultiToolRoundEmptyIDsSurvivePairing(t *testing.T) {
 	}
 }
 
+func TestRunSkipsMemoryCompilerForSyntheticTurn(t *testing.T) {
+	rt := memorycompiler.New(t.TempDir())
+	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)
+	seed.RecordToolResults([]memorycompiler.ToolRecord{
+		{Name: "bash", Error: "exit status 1"},
+		{Name: "bash", Error: "exit status 1"},
+	})
+	seed.Finish(nil)
+
+	mp := testutil.NewMock("m", testutil.Turn{Text: "done"})
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+	// A controller-injected synthetic turn (e.g. the goal-loop continuation)
+	// marks the context so the compiler is bypassed; otherwise the echoed
+	// contract re-injects every turn and spins the loop (#5342, #5329).
+	ctx := WithMemoryCompilerSkip(context.Background())
+	if err := a.Run(ctx, "continue work"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	user := lastUserMessage(t, mp.Requests())
+	if strings.Contains(user.Content, "<memory-compiler-execution>") {
+		t.Fatalf("synthetic turn was compiled into a contract:\n%s", user.Content)
+	}
+	if !strings.Contains(user.Content, "continue work") {
+		t.Fatalf("synthetic turn text was lost:\n%s", user.Content)
+	}
+}
+
+func lastUserMessage(t *testing.T, reqs []provider.Request) provider.Message {
+	t.Helper()
+	if len(reqs) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	var user provider.Message
+	for _, msg := range reqs[0].Messages {
+		if msg.Role == provider.RoleUser {
+			user = msg
+		}
+	}
+	return user
+}
+
 func TestRunUsesMemoryCompilerContractAsUserTurn(t *testing.T) {
 	rt := memorycompiler.New(t.TempDir())
 	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)

--- a/internal/agent/memory_compiler_context.go
+++ b/internal/agent/memory_compiler_context.go
@@ -30,3 +30,29 @@ func MemoryCompilerSourceInputFromContext(ctx context.Context) (string, bool) {
 	}
 	return strings.TrimSpace(v), strings.TrimSpace(v) != ""
 }
+
+type memoryCompilerSkipContextKey struct{}
+
+// WithMemoryCompilerSkip marks a turn whose input is a synthetic,
+// controller-injected message (goal-loop continuation, plan-approved execution,
+// stream-recovery retries, …) rather than a genuine user request. Such turns
+// must not be compiled into a memory_v5_execution_contract: the contract is
+// echoed back by the model and, for the goal loop, re-injected every turn,
+// which spins the loop indefinitely (#5342, #5329). Real user turns are
+// unaffected and still compile normally.
+func WithMemoryCompilerSkip(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, memoryCompilerSkipContextKey{}, true)
+}
+
+// MemoryCompilerSkipFromContext reports whether the current turn was marked as a
+// synthetic message that should bypass Memory v5 compilation.
+func MemoryCompilerSkipFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	skip, _ := ctx.Value(memoryCompilerSkipContextKey{}).(bool)
+	return skip
+}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -33,10 +33,12 @@ func (f *fakeAutoPlanClassifier) NeedsPlan(ctx context.Context, input string, sc
 type fakeTurnRunner struct {
 	inputs               []string
 	memoryCompilerInputs []string
+	memoryCompilerSkips  []bool
 }
 
 func (f *fakeTurnRunner) Run(ctx context.Context, input string) error {
 	f.inputs = append(f.inputs, input)
+	f.memoryCompilerSkips = append(f.memoryCompilerSkips, agent.MemoryCompilerSkipFromContext(ctx))
 	if source, ok := agent.MemoryCompilerSourceInputFromContext(ctx); ok {
 		f.memoryCompilerInputs = append(f.memoryCompilerInputs, source)
 	}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -26,7 +26,15 @@ func (o *turnOrchestrator) runTurnWithRawDisplay(ctx context.Context, input, raw
 	ctx = agent.WithParentSession(ctx, parentSession)
 	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
-	ctx = agent.WithMemoryCompilerSourceInput(ctx, raw)
+	// Synthetic, controller-injected turns (goal-loop continuation,
+	// plan-approved execution, …) must not be Memory v5-compiled: compiling them
+	// re-injects a contract the model echoes back, which spins the goal loop
+	// forever (#5342, #5329). Only genuine user turns supply a compiler source.
+	if IsSyntheticUserMessage(raw) {
+		ctx = agent.WithMemoryCompilerSkip(ctx)
+	} else {
+		ctx = agent.WithMemoryCompilerSourceInput(ctx, raw)
+	}
 	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -90,7 +98,7 @@ func (o *turnOrchestrator) runTurnWithRawDisplay(ctx context.Context, input, raw
 	// later turn (even "continue") falls back to the normal per-tool approval.
 	c.approval.setPlanAutoApprove(true)
 	defer c.approval.setPlanAutoApprove(false)
-	if err := c.runner.Run(ctx, c.ComposeSynthetic(planApprovedMessage)); err != nil {
+	if err := c.runner.Run(agent.WithMemoryCompilerSkip(ctx), c.ComposeSynthetic(planApprovedMessage)); err != nil {
 		if errors.Is(err, context.Canceled) && c.CancelRequested() {
 			c.stripTurnMessagesAfter(execStart)
 		}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -35,6 +35,38 @@ func TestTurnOrchestratorRunsForegroundUnit(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns(t *testing.T) {
+	// A genuine user turn supplies a Memory v5 source and is not skipped; a
+	// synthetic controller-injected turn (the goal-loop continuation) is marked
+	// to bypass compilation so its contract can't be re-injected and loop
+	// (#5342, #5329).
+	runner := &fakeTurnRunner{}
+	c := New(Options{Runner: runner})
+	o := newTurnOrchestrator(c)
+
+	real := "fix the login bug"
+	if err := o.runTurnWithRawDisplay(context.Background(), real, real, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.runTurnWithRawDisplay(context.Background(), goalContinueTurn, goalContinueTurn, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(runner.memoryCompilerSkips) != 2 {
+		t.Fatalf("runs = %d, want 2", len(runner.memoryCompilerSkips))
+	}
+	if runner.memoryCompilerSkips[0] {
+		t.Fatalf("genuine user turn was marked skip-compile")
+	}
+	if !runner.memoryCompilerSkips[1] {
+		t.Fatalf("synthetic goal-continuation turn was NOT marked skip-compile")
+	}
+	// The genuine turn supplies a source; the synthetic one must not.
+	if len(runner.memoryCompilerInputs) != 1 || runner.memoryCompilerInputs[0] != real {
+		t.Fatalf("memory compiler sources = %v, want exactly [%q]", runner.memoryCompilerInputs, real)
+	}
+}
+
 func TestTurnOrchestratorStopHookIgnoresCanceledTurnContext(t *testing.T) {
 	runCtx, cancel := context.WithCancel(context.Background())
 	var stopCalls int

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
@@ -1478,10 +1479,9 @@ func strategyScoreWithReason(goal string, s Strategy) (float64, string) {
 		score -= penalty
 		reasons = append(reasons, fmt.Sprintf("%.2f usage penalty", penalty))
 	}
-	lowerGoal := strings.ToLower(goal)
 	for _, p := range s.Preconditions {
 		p = strings.ToLower(strings.TrimSpace(p))
-		if p != "" && strings.Contains(lowerGoal, p) {
+		if p != "" && strategyPreconditionMatches(goal, p) {
 			score += 0.75
 			reasons = append(reasons, "matched precondition "+p)
 		}
@@ -1495,6 +1495,30 @@ func strategyScoreWithReason(goal string, s Strategy) (float64, string) {
 		reasons = append(reasons, "low success history")
 	}
 	return score, strings.Join(reasons, "; ")
+}
+
+// strategyPreconditionMatches reports whether goal matches a strategy
+// precondition. Very short preconditions (<=2 runes, e.g. "ui") match only on
+// whole-token boundaries; a plain substring test let "ui" hit "pursuing",
+// "build", etc., which misrouted unrelated turns — including the synthetic
+// "Continue pursuing the active goal." message — to frontend-visual-verify.
+func strategyPreconditionMatches(goal, precondition string) bool {
+	precondition = strings.ToLower(strings.TrimSpace(precondition))
+	if precondition == "" {
+		return false
+	}
+	goal = strings.ToLower(goal)
+	if len([]rune(precondition)) > 2 {
+		return strings.Contains(goal, precondition)
+	}
+	for _, token := range strings.FieldsFunc(goal, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if token == precondition {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizedOutcomeScore(s Strategy) (float64, string) {
@@ -2707,7 +2731,7 @@ func classifyStrategy(goal string) string {
 		return "code-review"
 	case strings.Contains(lower, "bug") || strings.Contains(lower, "fix") || strings.Contains(goal, "修复"):
 		return "bugfix-reproduce-first"
-	case strings.Contains(lower, "frontend") || strings.Contains(lower, "ui") || strings.Contains(goal, "前端"):
+	case strings.Contains(lower, "frontend") || strategyPreconditionMatches(goal, "ui") || strings.Contains(goal, "前端"):
 		return "frontend-visual-verify"
 	case strings.Contains(lower, "goal") || strings.Contains(lower, "research") || strings.Contains(goal, "持续"):
 		return "long-horizon-autoresearch"

--- a/internal/memorycompiler/runtime_test.go
+++ b/internal/memorycompiler/runtime_test.go
@@ -127,6 +127,38 @@ func TestStartTurnExposesMemoryCitations(t *testing.T) {
 	}
 }
 
+func TestStrategyPreconditionShortTokenMatchesOnWordBoundary(t *testing.T) {
+	// "ui" must match the real frontend keyword but not arbitrary substrings —
+	// otherwise the synthetic "Continue pursuing the active goal." turn (and any
+	// goal/build/quiet text) misroutes to frontend-visual-verify (#5342).
+	matches := []string{"fix the ui", "UI layout broken", "tweak the ui.", "ui/ux pass"}
+	for _, g := range matches {
+		if !strategyPreconditionMatches(g, "ui") {
+			t.Errorf("strategyPreconditionMatches(%q, \"ui\") = false, want true", g)
+		}
+	}
+	nonMatches := []string{"Continue pursuing the active goal.", "build the parser", "quiet mode", "guidance notes"}
+	for _, g := range nonMatches {
+		if strategyPreconditionMatches(g, "ui") {
+			t.Errorf("strategyPreconditionMatches(%q, \"ui\") = true, want false (substring false positive)", g)
+		}
+	}
+	// Longer preconditions keep substring semantics.
+	if !strategyPreconditionMatches("optimize the frontend pipeline", "frontend") {
+		t.Errorf("long precondition lost substring match")
+	}
+}
+
+func TestClassifyStrategyDoesNotRouteGoalContinuationToFrontend(t *testing.T) {
+	goal := "Continue pursuing the active goal. If it is complete, end with [goal:complete]."
+	if got := classifyStrategy(goal); got == "frontend-visual-verify" {
+		t.Fatalf("goal-continuation classified as %q (the \"ui\" in \"pursuing\" leaked)", got)
+	}
+	if got := classifyStrategy("redesign the ui layout"); got != "frontend-visual-verify" {
+		t.Fatalf("genuine ui goal classified as %q, want frontend-visual-verify", got)
+	}
+}
+
 func TestSuccessTraceFeedsReusableStrategyAndGraph(t *testing.T) {
 	dir := t.TempDir()
 	rt := New(dir)


### PR DESCRIPTION
Fixes #5342, #5329 (and the Memory v5 routing loop reported across the v1.12.0 issues).

## Root cause

Two independent causes made the goal loop re-inject the same `memory_v5_execution_contract` every turn and never terminate:

1. **The synthetic goal-continuation turn** (`Continue pursuing the active goal. …`) was Memory v5-compiled like a real user turn. The model echoes the compiled contract back, the goal loop re-injects it, the contract accretes, and the loop never converges — surfaced as "无限发送对话30轮" (#5329) and the Memory v5 crash (#5342).
2. **`ui` matched as a bare substring** in `classifyStrategy` / strategy preconditions, so `pursuing` (and `build`, `quiet`, …) misrouted unrelated turns to `frontend-visual-verify`.

## Fix — done at the right layer

**Fix 1** is applied where a turn is *known* to be synthetic. The turn orchestrator already routes every controller-injected message and owns the canonical synthetic-message registry (`IsSyntheticUserMessage` / `syntheticPrefixes`, which already lists the goal-loop messages). It now marks synthetic turns with a new `agent.WithMemoryCompilerSkip(ctx)` instead of supplying a compiler source, and `Agent.Run` honours it.

This covers **all** synthetic turns uniformly — goal-loop continuation, plan-approved execution, and any future additions — rather than special-casing one English prefix string inside the agent. (An earlier community PR, #5360, special-cased only the `Continue pursuing` prefix in `agent.go`; this generalizes it via the existing registry at the producer layer and drops the cross-layer string coupling.)

**Fix 2** adds `strategyPreconditionMatches`: preconditions of ≤2 runes (e.g. `ui`) match only on whole-token boundaries; longer preconditions keep substring semantics.

## Tests

- `TestRunSkipsMemoryCompilerForSyntheticTurn` — agent skips compilation when the turn is marked synthetic
- `TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns` — orchestrator marks goal-continuation (not genuine user) turns
- `TestStrategyPreconditionShortTokenMatchesOnWordBoundary` / `TestClassifyStrategyDoesNotRouteGoalContinuationToFrontend` — `ui` matches real frontend goals but not `pursuing`

`go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/...` green (56 packages).

Cache-impact: low - genuine user turns compile exactly as before (the gate only adds `&& !MemoryCompilerSkipFromContext(ctx)`). For synthetic goal-loop turns the change is cache-positive: instead of an ever-growing re-injected contract, the user turn is now stable plain text, so the prompt prefix stops mutating each loop iteration.
Cache-guard: TestRunSkipsMemoryCompilerForSyntheticTurn (agent gate) + TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns (orchestrator marks synthetic, not genuine, turns) + the unchanged TestRunUsesMemoryCompilerContractAsUserTurn (genuine turns still compile).
