### PR TITLE
Fix approved-plan and Memory v5 visible noise / 修复计划批准与 Memory v5 可见噪音

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1299,10 +1299,8 @@ export default function App() {
     [activeTabId, patchActiveComposerProfile, syncModeToController],
   );
   const applyCollaborationMode = useCallback(
-    (m: CollaborationMode, options: { rememberUserIntent?: boolean } = {}): Promise<void> => {
-      if (options.rememberUserIntent !== false) {
-        userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, m === "plan");
-      }
+    (m: CollaborationMode): Promise<void> => {
+      userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, m === "plan");
       if (m === "goal") {
         patchActiveComposerProfile({ collaborationMode: "normal", goalDraftMode: true, goal: "" }, ["collaborationMode", "goal"]);
         return setControllerCollaborationMode("normal");
@@ -3231,7 +3229,7 @@ export default function App() {
                   // Approving an exit_plan_mode plan leaves plan mode; await the
                   // mode switch before sending the approval so the controller
                   // observes the updated state before it unblocks.
-                  if (state.approval!.tool === "exit_plan_mode" && allow) await applyCollaborationMode("normal", { rememberUserIntent: false });
+                  if (state.approval!.tool === "exit_plan_mode" && allow) await applyCollaborationMode("normal");
                   approve(state.approval!.id, allow, session, persist);
                 }}
                 onRevisePlan={(text) => {

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -61,6 +61,17 @@ const statsOnly = reducer(sent, { type: "event", e: memoryStatsEvent });
 eq(statsOnly, sent, "memory compiler stats do not confirm or mutate the visible turn");
 const startedThenStats = reducer(reducer(sent, { type: "event", e: { kind: "turn_started" } as WireEvent }), { type: "event", e: memoryStatsEvent });
 eq(startedThenStats.items.length, 2, "memory compiler stats do not add transcript items after turn start");
+const compilerCitationMessage = {
+  kind: "message",
+  memoryCitations: [{ kind: "compiler_reference", source: "Memory v5", note: "evidence: bash succeeded" }],
+} as WireEvent;
+const citationOnlyFinal = reducer(reducer(sent, { type: "event", e: { kind: "turn_started" } as WireEvent }), { type: "event", e: compilerCitationMessage });
+eq(citationOnlyFinal.items.length, 1, "memory compiler citations alone do not leave an empty assistant bubble");
+eq(citationOnlyFinal.items.some((it) => it.kind === "assistant"), false, "memory compiler citations alone stay hidden from the transcript");
+const textThenCitationFinal = reducer(reducer(startedThenStats, { type: "event", e: { kind: "text", text: "done" } as WireEvent }), { type: "event", e: compilerCitationMessage });
+const citedAssistant = textThenCitationFinal.items.find((it) => it.kind === "assistant");
+eq(citedAssistant?.kind === "assistant" && citedAssistant.text, "done", "memory compiler citations preserve existing assistant text");
+eq(citedAssistant?.kind === "assistant" && citedAssistant.memoryCitations?.length, 1, "memory compiler citations attach to real assistant content");
 
 const failedState = reducer(sent, { type: "send_failed", error: "Send failed: bridge unavailable" });
 const failedBubble = failedState.items.find((it) => it.kind === "user");
@@ -94,10 +105,26 @@ eq(
 );
 
 const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
 const typesSource = readFileSync(resolve(here, "../lib/types.ts"), "utf8");
 const controllerSource = readFileSync(resolve(here, "../lib/useController.ts"), "utf8");
 eq(typesSource.includes('"mcp_surface_ready"'), true, "TypeScript EventKind declares mcp_surface_ready");
 eq(controllerSource.includes('e.kind === "memory_compiler_stats" || e.kind === "mcp_surface_ready"'), true, "reducer handles mcp_surface_ready before optimistic confirmation");
+eq(
+  /state\.approval!\.tool === "exit_plan_mode" && allow\) await applyCollaborationMode\("normal"\);/.test(appSource),
+  true,
+  "plan approval clears the remembered plan restore intent before execution",
+);
+eq(
+  !/exit_plan_mode[\s\S]{0,240}rememberUserIntent:\s*false/.test(appSource),
+  true,
+  "plan approval must not preserve stale plan restore intent",
+);
+eq(
+  !appSource.includes("rememberUserIntent"),
+  true,
+  "collaboration mode changes always reconcile the remembered plan restore intent",
+);
 
 const unsent = reducer(sent, { type: "unsend" });
 eq(unsent.pendingUser, undefined, "unsend clears the pending marker");

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -551,6 +551,19 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, items, live, currentAssistant: id, seq };
     }
     case "message": {
+      const existingAssistant =
+        s.currentAssistant === undefined
+          ? undefined
+          : s.items.find((it): it is Extract<Item, { kind: "assistant" }> => it.kind === "assistant" && it.id === s.currentAssistant);
+      const text = e.text ?? s.live?.text ?? existingAssistant?.text ?? "";
+      const reasoning = e.reasoning ?? s.live?.reasoning ?? existingAssistant?.reasoning ?? "";
+      if (text.trim() === "" && reasoning.trim() === "") {
+        const items =
+          existingAssistant && existingAssistant.text.trim() === "" && existingAssistant.reasoning.trim() === "" && !existingAssistant.memoryCitations?.length
+            ? s.items.filter((it) => !(it.kind === "assistant" && it.id === existingAssistant.id))
+            : s.items;
+        return { ...s, items, live: undefined, currentAssistant: undefined };
+      }
       const { items, id, seq } = ensureAssistant(s);
       const next = items.map((it) =>
         it.kind === "assistant" && it.id === id
@@ -558,8 +571,8 @@ function applyEvent(s: State, e: WireEvent): State {
               const memoryCitations = asArray<MemoryCitation>(e.memoryCitations ?? it.memoryCitations);
               return {
                 ...it,
-                text: e.text ?? s.live?.text ?? it.text,
-                reasoning: e.reasoning ?? s.live?.reasoning ?? it.reasoning,
+                text,
+                reasoning,
                 streaming: false,
                 memoryCitations: memoryCitations.length > 0 ? memoryCitations : undefined,
               };


### PR DESCRIPTION
## Summary

- Clear the remembered manual plan-mode restore intent whenever the desktop collaboration mode changes back to normal, including `exit_plan_mode` approval.
- Prevent `turn_done` refresh from restoring plan mode immediately after an approved plan execution finishes.
- Drop Memory v5 citation-only final messages so they cannot leave an empty assistant bubble that only says "Memory v5 compiler references".
- Add frontend regression guards for both approved-plan restoration and Memory v5 citation-only transcript noise.

Fixes #5385.
Fixes #5344.
Refs #5316.

## Related Issue Matrix

- #5385 (`@rgw87`): approved plan execution can end without useful tool calls, then the desktop restores plan mode and blocks the user's follow-up. This PR fixes the remaining desktop restore-state failure. The Memory v5 synthetic-turn part is already fixed by #5387 in the base branch.
- #5344 (`@whiteS18`): Memory v5 compiler references can appear as visible transcript content without useful execution output. This PR prevents citation-only Memory v5 final messages from creating or preserving an empty assistant bubble while still attaching citations to real assistant text.
- #5316 (`@wqq2026`): broader Memory v5 compiler IR leak / user-message wrapping / autonomous-injection report. The raw contract display and corrupted-session portions are already covered in base by #5307 and #5390, while new synthetic-loop injection is covered by #5387. This PR adds the remaining visible-noise guard for citation-only final messages. It does not change the intended internal Memory v5 source-event compilation path for genuine user turns.
- #5329 (`@eghrhegpe`) and #5342 (`@sharplayerai`): repeated `memory_v5_execution_contract` injection / Memory v5 routing loop. Already fixed in base by #5387; this PR keeps that mechanism intact and builds on it.
- #4393 (`@Lumoa-dev`): requests Auto/YOLO to bypass plan approval in some auto-plan paths. Reviewed but not adopted here because current docs, UI copy, and control tests intentionally keep plan approval and ask decisions separate from ordinary tool approvals.

## Related PR Matrix

### Kept / Already Integrated In Base

- #5307 by `@ttmouse`: strips `<memory-compiler-execution>` from user-message display and replaces raw blocks with local UI metadata. This PR preserves that direction.
- #5387 by `@esengine`: generalized synthetic-turn Memory v5 skip, including plan-approved execution. This PR depends on that base behavior and does not duplicate it.
- #5390 by `@esengine`: robustly unwraps nested/corrupted Memory v5 contract display on session switch. This PR complements it by preventing citation-only live final messages from becoming standalone visible bubbles.

### Reviewed But Not Adopted

- #5331 by `@eghrhegpe`: earlier narrow Memory v5 goal-continuation skip. Superseded by #5387's producer-layer synthetic-turn handling.
- #5360 by `@GTC2080`: earlier Memory v5 goal-loop fix and short-token strategy matching. Superseded by #5387's broader merged implementation.
- #4393 proposal: auto-answering plan approval under Auto/YOLO was not adopted because plan confirmation is a collaboration gate, not an ordinary tool permission gate.

## Root Cause

#5387 already ensures the approved-plan synthetic execution turn is not Memory v5-compiled. After that fix, the remaining #5385 failure mode was in the desktop frontend: `applyCollaborationMode("normal", { rememberUserIntent: false })` updated the controller to normal mode but deliberately kept the tab's remembered plan-mode restore intent. When the turn ended and tab metadata refreshed, that stale intent could re-enable plan mode, so a follow-up like "execute the plan" would be composed as plan-mode read-only input and writer calls would be blocked.

The #5344 visible-noise path was a separate frontend reducer issue: a final `message` event that carried only Memory v5 citations could call `ensureAssistant`, leaving a standalone assistant bubble with no assistant text and only the "Memory v5 compiler references" disclosure.

## Solution

- Remove the `rememberUserIntent` escape hatch from desktop collaboration-mode changes.
- Let plan approval call the normal collaboration-mode transition, which clears the remembered plan restore intent before unblocking the backend approval.
- In the frontend reducer, ignore empty final `message` events and remove the empty current assistant placeholder instead of rendering citation-only Memory v5 content.
- Preserve citations when they attach to real assistant text.
- Pin both invariants in `send-failed.test.ts`.

## Cache Impact

Low / none for provider prefix stability. This changes only desktop frontend state reconciliation and transcript rendering. It does not modify the system prompt, tool schemas, provider request serialization, Memory v5 contracts, or Go turn composition. The existing #5387 synthetic-turn cache guard remains unchanged.

## Verification

- `pnpm --dir desktop/frontend exec tsx src/__tests__/send-failed.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/memory-compiler-display.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/history-tool-status.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-profile.test.ts`
- `pnpm --dir desktop/frontend exec tsc --noEmit`
- `pnpm --dir desktop/frontend check:css`
- `go test ./internal/control -run 'TestAutoApproveToolsStillAutoPlansAndRequiresPlanApproval|TestPlanApprovalIgnoresAutoApproveTools|TestSetAutoApproveToolsDoesNotDrainPendingPlanApproval|TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns' -count=1`
- `git diff --check`

Observed but not caused by this PR: `pnpm --dir desktop/frontend exec tsc --noEmit -p tsconfig.test.json` still reports an existing test-only `Mode` type mismatch in an unrelated capabilities-panel test file.
