### PR TITLE
Harden synthetic Memory v5 turns / 加固 Memory v5 合成轮次标记

### DIFF
--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -14,31 +14,48 @@ type turnOrchestrator struct {
 	c *Controller
 }
 
+type orchestratedTurn struct {
+	input     string
+	raw       string
+	display   string
+	synthetic bool
+}
+
 func newTurnOrchestrator(c *Controller) *turnOrchestrator {
 	return &turnOrchestrator{c: c}
 }
 
 func (o *turnOrchestrator) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
+	return o.runOrchestratedTurn(ctx, orchestratedTurn{input: input, raw: raw, display: display})
+}
+
+func (o *turnOrchestrator) runSyntheticTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
+	return o.runOrchestratedTurn(ctx, orchestratedTurn{input: input, raw: raw, display: display, synthetic: true})
+}
+
+func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchestratedTurn) error {
 	c := o.c
 	c.maybeSessionStart(ctx)
-	c.maybeAutoPlan(ctx, raw)
+	if !turn.synthetic {
+		c.maybeAutoPlan(ctx, turn.raw)
+	}
 	parentSession := c.parentSessionID()
 	ctx = agent.WithParentSession(ctx, parentSession)
 	ctx = jobs.WithSession(ctx, parentSession)
-	ctx = agent.WithUserImages(ctx, c.inputImages(input))
+	ctx = agent.WithUserImages(ctx, c.inputImages(turn.input))
 	// Synthetic, controller-injected turns (goal-loop continuation,
 	// plan-approved execution, …) must not be Memory v5-compiled: compiling them
 	// re-injects a contract the model echoes back, which spins the goal loop
 	// forever (#5342, #5329). Only genuine user turns supply a compiler source.
-	if IsSyntheticUserMessage(raw) {
+	if turn.synthetic || IsSyntheticUserMessage(turn.raw) {
 		ctx = agent.WithMemoryCompilerSkip(ctx)
 	} else {
-		ctx = agent.WithMemoryCompilerSourceInput(ctx, raw)
+		ctx = agent.WithMemoryCompilerSourceInput(ctx, turn.raw)
 	}
-	input = c.Compose(input)
+	input := c.Compose(turn.input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
-	defer c.recordDisplayForNewUser(startMessages, display)
+	defer c.recordDisplayForNewUser(startMessages, turn.display)
 	// Open a checkpoint for this turn before the user message is appended, so the
 	// recorded message boundary precedes it and pre-edit snapshots land here.
 	c.beginCheckpoint(input)
@@ -136,7 +153,7 @@ func (o *turnOrchestrator) continueGoal(ctx context.Context) error {
 			turn = msg
 			c.notice("goal intercept: incomplete todos remain (override with a second [goal:complete])")
 		}
-		if err := o.runTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
+		if err := o.runSyntheticTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
 			if ctx.Err() != nil {
 				c.stopGoal(GoalStatusStopped)
 			}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -67,6 +67,49 @@ func TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorTypedSyntheticTurnDoesNotDependOnPrefix(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	c := New(Options{AutoPlan: "on", Runner: runner})
+	o := newTurnOrchestrator(c)
+
+	turn := "Controller-created follow-up with a brand-new synthetic wording:\n- inspect\n- edit\n- verify"
+	if IsSyntheticUserMessage(turn) {
+		t.Fatalf("test setup: %q unexpectedly matched the legacy synthetic prefix list", turn)
+	}
+	if err := o.runSyntheticTurnWithRawDisplay(context.Background(), turn, turn, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(runner.inputs) != 1 {
+		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
+	}
+	if strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+		t.Fatalf("typed synthetic turn should not be auto-planned, got %q", runner.inputs[0])
+	}
+	if len(runner.memoryCompilerSkips) != 1 || !runner.memoryCompilerSkips[0] {
+		t.Fatalf("typed synthetic turn was not marked skip-compile: %+v", runner.memoryCompilerSkips)
+	}
+	if len(runner.memoryCompilerInputs) != 0 {
+		t.Fatalf("typed synthetic turn supplied Memory v5 source input: %+v", runner.memoryCompilerInputs)
+	}
+}
+
+func TestTurnOrchestratorLegacySyntheticPrefixStillSkipsMemoryCompiler(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	c := New(Options{Runner: runner})
+	o := newTurnOrchestrator(c)
+
+	if err := o.runTurnWithRawDisplay(context.Background(), goalContinueTurn, goalContinueTurn, ""); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.memoryCompilerSkips) != 1 || !runner.memoryCompilerSkips[0] {
+		t.Fatalf("legacy synthetic prefix was not marked skip-compile: %+v", runner.memoryCompilerSkips)
+	}
+	if len(runner.memoryCompilerInputs) != 0 {
+		t.Fatalf("legacy synthetic prefix supplied Memory v5 source input: %+v", runner.memoryCompilerInputs)
+	}
+}
+
 func TestTurnOrchestratorStopHookIgnoresCanceledTurnContext(t *testing.T) {
 	runCtx, cancel := context.WithCancel(context.Background())
 	var stopCalls int


### PR DESCRIPTION
## Summary
- Add an explicit typed synthetic-turn path in the turn orchestrator so controller-created follow-up turns can bypass Memory v5 without depending on exact message prefixes.
- Route goal-loop continuation through that typed synthetic path, while keeping the existing `IsSyntheticUserMessage` prefix check as a compatibility fallback.
- Add regression coverage proving a brand-new synthetic wording still skips Memory v5 and auto-plan, plus coverage that legacy synthetic prefixes continue to skip Memory v5.

## Why
This is a follow-up hardening after #5391 and #5387. Those fixes stop the known Memory v5 synthetic-turn loop; this PR removes the fragile part of the contract so future controller-generated follow-up wording does not accidentally get compiled as genuine user input.

Related: #5316, #5329, #5342, #5385.

## Cache impact
Low / cache-positive. This only changes control-layer context metadata for synthetic turns. It does not change provider request serialization, system prompts, tool schemas, or genuine user-turn Memory v5 compilation.

## Verification
- `go test ./internal/control -run 'TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns|TestTurnOrchestratorTypedSyntheticTurnDoesNotDependOnPrefix|TestTurnOrchestratorLegacySyntheticPrefixStillSkipsMemoryCompiler|TestTurnOrchestratorGoalContinuationRunsStopPerUnit|TestGoalCommandAutoContinuesUntilComplete|TestPlainInputWithStrongResearchSignalAutoStartsGoal|TestGoalModeSkipsAutoPlanApproval' -count=1`
- `go test ./internal/agent -run 'TestRunSkipsMemoryCompilerForSyntheticTurn|TestRunUsesMemoryCompilerContractAsUserTurn|TestUserPreviewTextUnwrapsNestedCompilerContracts|TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution' -count=1`
- `go test ./internal/memorycompiler -run 'TestStrategyPreconditionShortTokenMatchesOnWordBoundary|TestClassifyStrategyDoesNotRouteGoalContinuationToFrontend|TestStartTurnExposesMemoryCitations' -count=1`
- `git diff --check`
- `go test ./internal/control ./internal/agent ./internal/memorycompiler -count=1`
