### PR TITLE
Import legacy sessions from explicit paths / 支持从指定旧目录导入历史会话

### DIFF
--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -190,6 +190,19 @@ same command into the composer. The command prints progress notices while it:
 4. imports memory files and sessions that were not previously imported, and
 5. prints a final summary.
 
+If old v0.x sessions live outside the known legacy locations — for example a
+Windows v0.52 install/data directory chosen during setup — pass that directory
+explicitly:
+
+```text
+/migrate --from "D:\OldReasonix"
+```
+
+The explicit form imports sessions only. The path may be the old install
+directory, a `.reasonix`/data directory, or the `sessions` directory itself;
+Reasonix checks the common layouts below that root and uses a source-specific
+marker, so a previous plain `/migrate` run does not hide the later import.
+
 The rescue command is intentionally non-destructive. It does not overwrite an
 existing `<Reasonix home>/config.toml`; if the new config already exists, copy
 any missing legacy settings across by hand. It copies legacy memory files only
@@ -203,5 +216,6 @@ Version limits:
 - `/migrate` is available only in Go-based Reasonix builds that include the
   command. If Reasonix reports `unknown command`, upgrade first and rerun it.
 - The command is not available in the legacy `0.x` TypeScript line.
-- It rescans the legacy locations listed above; it is not a backup restore tool,
-  a downgrade importer, or a general importer for arbitrary directories.
+- Plain `/migrate` rescans the legacy locations listed above. Use
+  `/migrate --from <path>` only for a known v0.x session source; it is not a
+  backup restore tool or a downgrade importer.

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -160,6 +160,16 @@ Windows:     %APPDATA%\reasonix\config.toml
 4. 导入尚未迁移过的 memory 文件和 sessions；
 5. 输出最终汇总。
 
+如果旧 v0.x sessions 不在上述已知旧路径里，例如 Windows v0.52 安装时选择了自定义安装/数据目录，可以显式指定旧目录：
+
+```text
+/migrate --from "D:\OldReasonix"
+```
+
+显式形式只导入 sessions。这个路径可以是旧安装目录、`.reasonix`/数据目录，或者
+`sessions` 目录本身；Reasonix 会在该根目录下检查常见布局，并使用按来源目录区分的
+marker，因此之前已经运行过普通 `/migrate` 也不会挡住这次后补导入。
+
 该补救命令仍然是非破坏性的。它不会覆盖已有的
 `<Reasonix home>/config.toml`；如果新配置已经存在，需要手动把旧配置里缺失的设置复制过去。旧 memory 文件只会在目标文件不存在时复制。它也会尊重 session 导入 marker，因此已经迁移过、之后又被用户删除的会话，不会在后续 `/migrate` 中被重新恢复。
 
@@ -168,4 +178,4 @@ Windows:     %APPDATA%\reasonix\config.toml
 - 自动迁移从 **v1.8.1** 开始。
 - `/migrate` 只存在于包含该命令的 Go 版 Reasonix 构建中。如果 Reasonix 提示 `unknown command`，请先升级后再运行。
 - legacy `0.x` TypeScript 线没有这个命令。
-- 它只会重新扫描上面列出的旧路径；它不是备份恢复工具、降级导入工具，也不是任意目录导入器。
+- 普通 `/migrate` 只会重新扫描上面列出的旧路径。只有确认某个目录是 v0.x session 来源时，才使用 `/migrate --from <path>`；它不是备份恢复工具或降级导入工具。

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -242,6 +242,7 @@ Mode and display shortcuts:
 | `Ctrl+B` | Expands or collapses long shell output | Works with terminal-native text selection because the TUI does not enable mouse reporting by default. |
 | Ask / Auto | No keyboard cycle | Ask is the default interactive base. Auto is not entered through `Shift+Tab`; use clients or APIs that expose the tool approval posture directly. |
 | `/goal <objective>`, `/goal --research <objective>`, `/goal --simple <objective>`, `/goal status`, `/goal clear` | Starts, checks, or clears Goal | Goal is not in any keyboard cycle; clearly long-horizon goals automatically enable AutoResearch. Ordinary prompts with strong AutoResearch signals are also upgraded into Goal. |
+| `/migrate`, `/migrate --from <legacy-dir>` | Retries legacy migration or imports sessions from a chosen v0.x source | Use `--from` for custom Windows v0.52 install/data directories; it imports sessions only. See [Configuration paths](./CONFIG_PATHS.md). |
 
 Picker and approval shortcuts:
 

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -220,6 +220,7 @@ Goal、由 `todo_write` 工具驱动的实时 Todo 面板，以及已配置 prov
 | `Ctrl+B` | 展开或收起较长 shell 输出 | TUI 默认不启用鼠标报告，因此可和终端原生文本选择共存。 |
 | Ask / Auto | 没有键盘循环 | Ask 是默认交互基底；Auto 不通过 `Shift+Tab` 进入，需要由暴露工具审批姿态的客户端或 API 直接设置。 |
 | `/goal <目标>`、`/goal --research <目标>`、`/goal --simple <目标>`、`/goal status`、`/goal clear` | 启动、查看或清除 Goal | Goal 不进入任何快捷键循环；明显长周期目标会自动启用 AutoResearch。普通输入命中强 AutoResearch 信号时也会自动升级为 Goal。 |
+| `/migrate`、`/migrate --from <旧目录>` | 重试旧数据迁移，或从指定 v0.x 来源导入 sessions | Windows v0.52 自定义安装/数据目录用 `--from`；该形式只导入 sessions。详见[配置路径](./CONFIG_PATHS.zh-CN.md)。 |
 
 选择器与审批：
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -80,7 +80,10 @@ config and credentials, scans legacy memory and session directories, imports
 memory files and sessions that were not previously imported, and summarizes the
 result. `/migrate` keeps the same safety rules as startup migration: it does not
 overwrite an existing `config.toml` or memory file, it respects session import
-markers, and it is not available in the legacy 0.x TypeScript line. See
+markers, and it is not available in the legacy 0.x TypeScript line. If the old
+v0.x sessions are in a custom Windows install/data directory, use
+`/migrate --from "D:\OldReasonix"` to import sessions from that explicit source.
+See
 [Configuration paths](./CONFIG_PATHS.md) for the full path list and limitations.
 
 ## What's the same

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -79,14 +81,39 @@ func MigrateLegacySessionsFromConfigDir(srcDir, globalDest string, projectDir fu
 	return migrateLegacySessions(srcDir, globalDest, legacyRoutedConfigImportMarker, projectDir)
 }
 
+// MigrateLegacySessionsFromExplicitDir imports sessions from a user-selected
+// legacy directory. It uses a source-specific marker so a previous default
+// /migrate pass cannot hide later imports from a custom Windows install/data
+// directory.
+func MigrateLegacySessionsFromExplicitDir(srcDir, globalDest string, projectDir func(workspaceRoot string) string) (int, error) {
+	marker := explicitLegacyImportMarker(srcDir)
+	return migrateLegacySessionsWithMarkers(srcDir, globalDest, marker, marker+".jsonl", projectDir)
+}
+
+func explicitLegacyImportMarker(srcDir string) string {
+	key := strings.TrimSpace(srcDir)
+	if abs, err := filepath.Abs(key); err == nil {
+		key = abs
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(key)))
+	return ".legacy-imported.explicit." + hex.EncodeToString(sum[:8])
+}
+
 func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(string) string) (int, error) {
+	return migrateLegacySessionsWithMarkers(srcDir, globalDest, marker, legacyJsonlPassMarker, projectDir)
+}
+
+func migrateLegacySessionsWithMarkers(srcDir, globalDest, marker, jsonlMarker string, projectDir func(string) string) (int, error) {
 	if strings.TrimSpace(marker) == "" {
 		marker = legacyImportMarker
+	}
+	if strings.TrimSpace(jsonlMarker) == "" {
+		jsonlMarker = legacyJsonlPassMarker
 	}
 	// Gate on both the routed marker AND the jsonl marker: an existing upgrader
 	// whose events pass already stamped the routed marker must still reach the
 	// .jsonl-only / subdir passes below (Pass 1 is idempotent via dest checks).
-	if importMarkerExists(globalDest, marker) && importMarkerExists(globalDest, legacyJsonlPassMarker) {
+	if importMarkerExists(globalDest, marker) && importMarkerExists(globalDest, jsonlMarker) {
 		// The one-time full passes already ran for this source. Still run the
 		// bounded re-home pass: a user who downgrades to a pre-routing build
 		// (which writes every session to the flat dir) and then upgrades again
@@ -177,7 +204,7 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	// desktop, subagent, and later-version chat sessions). The pass is gated by
 	// its own marker so existing upgraders whose events passes completed still
 	// get their .jsonl-only sessions imported.
-	if !importMarkerExists(globalDest, legacyJsonlPassMarker) {
+	if !importMarkerExists(globalDest, jsonlMarker) {
 		n, failed := importJsonlSessions(entries, srcDir, globalDest, hasEvents, projectDir)
 		imported += n
 		hadArtifactFailure = hadArtifactFailure || failed
@@ -261,7 +288,7 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	if hadArtifactFailure {
 		return imported, nil
 	}
-	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker, legacyJsonlPassMarker)
+	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker, jsonlMarker)
 	return imported, nil
 }
 

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -105,6 +105,32 @@ func TestMigrateLegacySessionsRunsOnce(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacySessionsFromExplicitDirIgnoresDefaultMarkers(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "custom-install.jsonl"), []byte(legacyMessageLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeImportMarkers(dest, legacyRoutedHomeImportMarker, legacyJsonlPassMarker)
+
+	if n, err := MigrateLegacySessions(src, dest, nil); err != nil || n != 0 {
+		t.Fatalf("default migrate with markers: n=%d err=%v, want 0 nil", n, err)
+	}
+	n, err := MigrateLegacySessionsFromExplicitDir(src, dest, nil)
+	if err != nil {
+		t.Fatalf("explicit migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("explicit imported %d sessions, want 1", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "custom-install.jsonl")); err != nil {
+		t.Fatalf("explicit imported session missing: %v", err)
+	}
+	if n, err := MigrateLegacySessionsFromExplicitDir(src, dest, nil); err != nil || n != 0 {
+		t.Fatalf("explicit migrate should be source-marker idempotent: n=%d err=%v", n, err)
+	}
+}
+
 func TestMigrateLegacySessionsRoutedPassIgnoresFlatMarkers(t *testing.T) {
 	src := t.TempDir()
 	dest := t.TempDir()

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3366,7 +3366,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.showMemory()
 	case "/migrate", "/migration":
 		m.echoLocalCommand(input)
-		migration.RunLegacyRescue(event.FuncSink(func(e event.Event) {
+		migration.RunLegacyRescueCommand(strings.TrimSpace(strings.TrimPrefix(input, cmd)), event.FuncSink(func(e event.Event) {
 			if e.Kind == event.Notice {
 				m.notice(e.Text)
 			}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1701,6 +1701,33 @@ func TestSlashMigrateShowsProgress(t *testing.T) {
 	}
 }
 
+func TestSlashMigrateFromImportsExplicitSessions(t *testing.T) {
+	home := isolateCLIConfigHome(t)
+	legacySessions := filepath.Join(home, "Old Reasonix", "sessions")
+	if err := os.MkdirAll(legacySessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacySessions, "old-chat.jsonl"), []byte(`{"role":"user","content":"hello from old install"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatTUI()
+
+	input := `/migrate --from "` + filepath.Dir(legacySessions) + `"`
+	if cmd := m.runSlashCommand(input); cmd != nil {
+		t.Fatal("/migrate --from should run locally without returning a command")
+	}
+	out := strings.Join(m.transcript, "\n")
+	for _, want := range []string{
+		input,
+		"migration rescue: scanning explicit legacy sessions from " + filepath.Dir(legacySessions),
+		"imported 1 past session(s) from " + legacySessions,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in transcript:\n%s", want, out)
+		}
+	}
+}
+
 // TestDoubleCtrlCQuit verifies that Ctrl+C while idle requires a double-press
 // within the 1.5s window to actually quit. A single press shows a hint; a
 // second press within the window returns tea.Quit.

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -397,7 +397,8 @@ func (c *Controller) managementNotice(trimmed string) bool {
 	case "/memory-v5":
 		c.memoryV5Notice(fields)
 	case "/migrate", "/migration":
-		migration.RunLegacyRescue(c.sink)
+		args := strings.TrimSpace(strings.TrimPrefix(trimmed, fields[0]))
+		migration.RunLegacyRescueCommand(args, c.sink)
 	case "/skill", "/skills":
 		sub := ""
 		if len(fields) >= 2 {

--- a/internal/control/slash_test.go
+++ b/internal/control/slash_test.go
@@ -1,6 +1,8 @@
 package control
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -281,6 +283,36 @@ func TestManagementMigrateEmitsProgress(t *testing.T) {
 		"migration rescue: scanning legacy memory",
 		"migration rescue: scanning legacy sessions",
 		"migration rescue complete:",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing notice %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestManagementMigrateFromImportsExplicitSessions(t *testing.T) {
+	home := isolateControlConfigHome(t)
+	legacySessions := filepath.Join(home, "Old Reasonix", "sessions")
+	if err := os.MkdirAll(legacySessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacySessions, "old-chat.jsonl"), []byte(`{"role":"user","content":"hello from old install"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var notices []string
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})})
+
+	if !c.managementNotice(`/migrate --from "` + filepath.Dir(legacySessions) + `"`) {
+		t.Fatal("/migrate --from was not handled")
+	}
+	joined := strings.Join(notices, "\n")
+	for _, want := range []string{
+		"migration rescue: scanning explicit legacy sessions from " + filepath.Dir(legacySessions),
+		"imported 1 past session(s) from " + legacySessions,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("missing notice %q in:\n%s", want, joined)

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -104,6 +104,65 @@ func RunLegacyRescue(sink event.Sink) Result {
 	return result
 }
 
+// RunLegacyRescueCommand handles the /migrate argument form shared by the CLI
+// TUI and desktop submit path. With no arguments it runs the default rescue;
+// with --from it imports sessions from a user-selected legacy directory.
+func RunLegacyRescueCommand(args string, sink event.Sink) Result {
+	source, explicit, err := parseLegacyRescueArgs(args)
+	if err != nil {
+		sink = event.Sync(sink)
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "migration rescue: " + err.Error()})
+		return Result{SessionErrs: []error{err}}
+	}
+	if explicit {
+		return RunLegacySessionImportFrom(source, sink)
+	}
+	return RunLegacyRescue(sink)
+}
+
+// RunLegacySessionImportFrom imports sessions from a user-selected legacy root.
+// The root may be the old install directory, a data directory, or the sessions
+// directory itself. Only sessions are imported; config and credentials stay on
+// the default non-destructive migration path.
+func RunLegacySessionImportFrom(sourceRoot string, sink event.Sink) Result {
+	sink = event.Sync(sink)
+	emit := func(level event.Level, text string) {
+		sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	}
+	result := Result{}
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	emit(event.LevelInfo, "migration rescue: scanning explicit legacy sessions from "+sourceRoot)
+	sources, err := explicitLegacySessionSources(sourceRoot)
+	if err != nil {
+		result.SessionErrs = append(result.SessionErrs, err)
+		emit(event.LevelWarn, "migration rescue: "+err.Error())
+		emit(event.LevelInfo, result.Summary())
+		return result
+	}
+	if len(sources) == 0 {
+		emit(event.LevelInfo, "migration rescue: no legacy session directories found under "+sourceRoot)
+		emit(event.LevelInfo, result.Summary())
+		return result
+	}
+	for _, src := range sources {
+		n, err := agent.MigrateLegacySessionsFromExplicitDir(src.dir, config.SessionDir(), config.ProjectSessionDir)
+		if err != nil {
+			result.SessionErrs = append(result.SessionErrs, fmt.Errorf("%s: %w", src.label, err))
+			emit(event.LevelWarn, "migration rescue: skipped "+src.label+": "+err.Error())
+			continue
+		}
+		if n > 0 {
+			result.SessionImports = append(result.SessionImports, SessionImport{Source: src.label, Destination: config.SessionDir(), Count: n})
+			emit(event.LevelInfo, fmt.Sprintf("imported %d past session(s) from %s — resume them with --resume or the history panel", n, src.label))
+		}
+	}
+	if len(result.SessionImports) == 0 && len(result.SessionErrs) == 0 {
+		emit(event.LevelInfo, "migration rescue: no legacy sessions needed migration from "+sourceRoot)
+	}
+	emit(event.LevelInfo, result.Summary())
+	return result
+}
+
 // MigrateLegacyMemorySources imports older memory stores during normal boot.
 // It stays quiet unless files were actually copied.
 func MigrateLegacyMemorySources(sink event.Sink) []MemoryImport {
@@ -386,6 +445,117 @@ func migrateLegacySessionSources(sink event.Sink, verbose bool) sessionMigration
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "migration rescue: no legacy sessions needed migration"})
 	}
 	return result
+}
+
+type explicitSessionSource struct {
+	dir   string
+	label string
+}
+
+func parseLegacyRescueArgs(args string) (source string, explicit bool, err error) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "", false, nil
+	}
+	const flag = "--from"
+	switch {
+	case args == flag:
+		return "", false, fmt.Errorf("--from requires a legacy directory path")
+	case strings.HasPrefix(args, flag+"="):
+		source = strings.TrimSpace(strings.TrimPrefix(args, flag+"="))
+	case len(args) > len(flag) && strings.HasPrefix(args, flag) && (args[len(flag)] == ' ' || args[len(flag)] == '\t'):
+		source = strings.TrimSpace(args[len(flag):])
+	default:
+		first := args
+		if i := strings.IndexAny(first, " \t"); i >= 0 {
+			first = first[:i]
+		}
+		return "", false, fmt.Errorf("unknown /migrate option %q; use /migrate --from <legacy-dir>", first)
+	}
+	source = trimMatchingQuotes(source)
+	if source == "" {
+		return "", false, fmt.Errorf("--from requires a legacy directory path")
+	}
+	return source, true, nil
+}
+
+func trimMatchingQuotes(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return s
+	}
+	if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+func explicitLegacySessionSources(root string) ([]explicitSessionSource, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("--from requires a legacy directory path")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("legacy directory %s is not readable: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("legacy path %s is not a directory", root)
+	}
+	candidates := []string{
+		filepath.Join(root, "sessions"),
+		filepath.Join(root, ".reasonix", "sessions"),
+		filepath.Join(root, "reasonix", "sessions"),
+	}
+	var out []explicitSessionSource
+	seen := map[string]bool{}
+	for _, dir := range candidates {
+		key := cleanAbs(dir)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		if dirLooksLikeLegacySessionDir(dir) {
+			out = append(out, explicitSessionSource{dir: dir, label: dir})
+		}
+	}
+	if len(out) == 0 && dirLooksLikeLegacySessionDir(root) {
+		out = append(out, explicitSessionSource{dir: root, label: root})
+	}
+	return out, nil
+}
+
+func dirLooksLikeLegacySessionDir(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && legacySessionArtifactName(entry.Name()) {
+			return true
+		}
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "subagents" {
+			continue
+		}
+		subEntries, err := os.ReadDir(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		for _, sub := range subEntries {
+			if !sub.IsDir() && legacySessionArtifactName(sub.Name()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func legacySessionArtifactName(name string) bool {
+	return strings.HasSuffix(name, ".events.jsonl") ||
+		strings.HasSuffix(name, ".jsonl") ||
+		strings.HasSuffix(name, ".jsonl.bak")
 }
 
 func samePath(a, b string) bool {

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -145,6 +145,53 @@ func TestRunLegacyRescueNoopStillShowsProgress(t *testing.T) {
 	}
 }
 
+func TestRunLegacyRescueCommandImportsFromExplicitInstallDir(t *testing.T) {
+	home := isolateMigrationHome(t)
+	installRoot := filepath.Join(home, "Custom Reasonix")
+	legacySessions := filepath.Join(installRoot, "sessions")
+	if err := os.MkdirAll(legacySessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacySessions, "custom-chat.jsonl"), []byte(legacyMessageLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	currentSessions := config.SessionDir()
+	if err := os.MkdirAll(currentSessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{".legacy-imported.v2-routed", ".legacy-imported.v3-jsonl"} {
+		if err := os.WriteFile(filepath.Join(currentSessions, marker), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var notices []string
+	res := RunLegacyRescueCommand(`--from "`+installRoot+`"`, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	}))
+	if len(res.SessionErrs) != 0 {
+		t.Fatalf("session migration errors: %v", res.SessionErrs)
+	}
+	if got := totalImported(res.SessionImports); got != 1 {
+		t.Fatalf("imported sessions = %d, want 1; imports=%+v", got, res.SessionImports)
+	}
+	if _, err := os.Stat(filepath.Join(currentSessions, "custom-chat.jsonl")); err != nil {
+		t.Fatalf("explicit imported session missing: %v", err)
+	}
+	joined := strings.Join(notices, "\n")
+	for _, want := range []string{
+		"migration rescue: scanning explicit legacy sessions from " + installRoot,
+		"imported 1 past session(s) from " + legacySessions,
+		"migration rescue complete: imported 1 past session(s)",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing notice %q in:\n%s", want, joined)
+		}
+	}
+}
+
 func TestMigrateLegacySessionSourcesSkipsCurrentProjectTree(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- add `/migrate --from <legacy-dir>` to import v0.x sessions from a user-selected legacy install/data directory
- use source-specific import markers so a previous plain `/migrate` run does not hide later explicit imports
- document the Windows custom install/data directory workflow in the migration and configuration guides

## Cache impact

No prompt-prefix, provider request serialization, tool schema, or system prompt changes. This only affects local slash-command handling and legacy session migration.

## Verification

- `go test ./internal/agent ./internal/migration ./internal/control ./internal/cli`
- `go test ./internal/boot`