### PR TITLE
Guard Memory v5 synthetic boundaries / 加固 Memory v5 合成边界守卫

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3138,7 +3138,7 @@ func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserCont
 		if m.Role == provider.RoleAssistant && len(m.MemoryCitations) > 0 {
 			hm.MemoryCitations = append([]provider.MemoryCitation(nil), m.MemoryCitations...)
 		}
-		if m.Role == provider.RoleUser && content != m.Content {
+		if m.Role == provider.RoleUser && content != m.Content && !agent.ContainsMemoryCompilerExecution(m.Content) {
 			hm.SubmitText = m.Content
 		}
 		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -66,6 +66,26 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	}
 }
 
+func TestHistoryMessagesDoNotReplayMemoryCompilerContract(t *testing.T) {
+	raw := historyMemoryCompilerContract(t, "ship the refactor")
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: raw},
+		{Role: provider.RoleAssistant, Content: "done"},
+	}
+
+	got := historyMessages(msgs, control.StripComposePrefixes)
+	if len(got) != 2 {
+		t.Fatalf("history length = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Content != "ship the refactor" {
+		t.Fatalf("visible user content = %q, want source_event", got[0].Content)
+	}
+	if got[0].SubmitText != "" {
+		t.Fatalf("raw Memory v5 contract should not be replay submitText, got %q", got[0].SubmitText)
+	}
+	assertNoHistoryMemoryContract(t, got[0].Content)
+}
+
 func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
@@ -125,6 +145,30 @@ func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	}
 	if got[4].Role != "assistant" || got[4].Content != "executor kept working" {
 		t.Fatalf("executor answer missing after reload: %+v", got[4])
+	}
+}
+
+func historyMemoryCompilerContract(t *testing.T, sourceEvent string) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"type": "memory_v5_execution_contract",
+		"planner_ir": map[string]any{
+			"source_event": sourceEvent,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "<memory-compiler-execution>\n" + string(body) + "\n</memory-compiler-execution>"
+}
+
+func assertNoHistoryMemoryContract(t *testing.T, text string) {
+	t.Helper()
+	if strings.Contains(text, "<memory-compiler-execution>") ||
+		strings.Contains(text, "</memory-compiler-execution>") ||
+		strings.Contains(text, "memory_v5_execution_contract") ||
+		strings.Contains(text, "planner_ir") {
+		t.Fatalf("history leaked Memory v5 contract content: %q", text)
 	}
 }
 

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -8,7 +8,16 @@ import (
 
 var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs)>.*?</(?:response-language|reasoning-language|memory-update|background-jobs)>\s*\n?`)
 
+const memoryCompilerExecutionOpen = "<memory-compiler-execution>"
+
 var reMemoryCompilerExecution = regexp.MustCompile(`(?s)<memory-compiler-execution>\s*(.*?)\s*</memory-compiler-execution>`)
+
+// ContainsMemoryCompilerExecution reports whether content includes a Memory v5
+// execution contract. Callers that prepare user-facing or replayable text should
+// unwrap it before display and avoid treating the raw contract as user-authored.
+func ContainsMemoryCompilerExecution(content string) bool {
+	return strings.Contains(content, memoryCompilerExecutionOpen)
+}
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or
@@ -50,7 +59,7 @@ func unwrapMemoryCompilerExecution(content string) string {
 	// the transcript (#5361). maxDepth bounds pathological accretion.
 	const maxDepth = 24
 	for range maxDepth {
-		if !strings.Contains(content, "<memory-compiler-execution>") {
+		if !ContainsMemoryCompilerExecution(content) {
 			return content
 		}
 		next := reMemoryCompilerExecution.ReplaceAllStringFunc(content, func(block string) string {
@@ -68,7 +77,7 @@ func unwrapMemoryCompilerExecution(content string) string {
 	// Any residual open tag is a dangling/partial/unparseable block the strict
 	// regex can't complete; drop from the first open tag onward so raw contract
 	// JSON is never surfaced. The user's actual text precedes it.
-	if idx := strings.Index(content, "<memory-compiler-execution>"); idx >= 0 {
+	if idx := strings.Index(content, memoryCompilerExecutionOpen); idx >= 0 {
 		content = strings.TrimRight(content[:idx], " \t\r\n")
 	}
 	return content

--- a/internal/control/synthetic_contract_test.go
+++ b/internal/control/synthetic_contract_test.go
@@ -1,0 +1,84 @@
+package control
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestComposedSyntheticRunsCarryMemoryCompilerSkip(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var composeCalls int
+	var coveredRunCalls int
+	var failures []string
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if isSelector(call.Fun, "ComposeSynthetic") {
+				composeCalls++
+			}
+			if !isSelector(call.Fun, "Run") || !callsSelector(call, "ComposeSynthetic") {
+				return true
+			}
+			coveredRunCalls++
+			if len(call.Args) == 0 || !callsSelector(call.Args[0], "WithMemoryCompilerSkip") {
+				failures = append(failures, fset.Position(call.Pos()).String())
+			}
+			return true
+		})
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("ComposeSynthetic runner calls without MemoryCompilerSkip at: %s", strings.Join(failures, ", "))
+	}
+	if composeCalls != coveredRunCalls {
+		t.Fatalf("ComposeSynthetic calls = %d, but only %d are direct Run calls with contract checks", composeCalls, coveredRunCalls)
+	}
+	if composeCalls == 0 {
+		t.Fatal("test did not find any ComposeSynthetic call in non-test control code")
+	}
+}
+
+func callsSelector(n ast.Node, selector string) bool {
+	found := false
+	ast.Inspect(n, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isSelector(call.Fun, selector) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isSelector(expr ast.Expr, selector string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == selector
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -33,6 +33,11 @@ func (o *turnOrchestrator) runSyntheticTurnWithRawDisplay(ctx context.Context, i
 	return o.runOrchestratedTurn(ctx, orchestratedTurn{input: input, raw: raw, display: display, synthetic: true})
 }
 
+func (o *turnOrchestrator) runComposedSyntheticTurn(ctx context.Context, text string) error {
+	c := o.c
+	return c.runner.Run(agent.WithMemoryCompilerSkip(ctx), c.ComposeSynthetic(text))
+}
+
 func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchestratedTurn) error {
 	c := o.c
 	c.maybeSessionStart(ctx)
@@ -115,7 +120,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	// later turn (even "continue") falls back to the normal per-tool approval.
 	c.approval.setPlanAutoApprove(true)
 	defer c.approval.setPlanAutoApprove(false)
-	if err := c.runner.Run(agent.WithMemoryCompilerSkip(ctx), c.ComposeSynthetic(planApprovedMessage)); err != nil {
+	if err := o.runComposedSyntheticTurn(ctx, planApprovedMessage); err != nil {
 		if errors.Is(err, context.Canceled) && c.CancelRequested() {
 			c.stripTurnMessagesAfter(execStart)
 		}


### PR DESCRIPTION
## Summary
- Add a small synthetic-turn runner helper so composed controller messages keep `MemoryCompilerSkip` paired with `ComposeSynthetic`.
- Add an AST regression test that fails if future non-test control code calls `ComposeSynthetic` outside a `Run` call protected by `WithMemoryCompilerSkip`.
- Prevent desktop history from putting raw `<memory-compiler-execution>` contracts into `submitText`, so editing/replaying a restored compiled user turn uses the visible user prompt instead of the internal Memory v5 contract.
- Add a desktop history fixture proving Memory v5 contracts unwrap for display and are not exposed as replay input.

## Why
#5387, #5391, and #5393 fixed the known Memory v5 synthetic-loop incident chain. This PR adds guardrails around the same boundary so future controller-injected synthetic turns or restored history views are less likely to reintroduce the class of bug.

Related: #5316, #5329, #5342, #5385, #5393.

## Cache impact
Low / cache-neutral. This does not change system prompts, tool schemas, provider request serialization, or real user-turn Memory v5 compilation. The runtime change is limited to desktop history replay metadata and a control-layer helper that preserves the existing synthetic skip behavior.

## Verification
- `go test ./internal/control -run 'TestComposedSyntheticRunsCarryMemoryCompilerSkip|TestTurnOrchestratorTypedSyntheticTurnDoesNotDependOnPrefix|TestTurnOrchestratorSkipsMemoryCompilerForSyntheticTurns|TestTurnOrchestratorLegacySyntheticPrefixStillSkipsMemoryCompiler|TestGoalModeSkipsAutoPlanApproval' -count=1`
- `go test ./internal/agent -run 'TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution|TestUserPreviewTextPreservesCompiledTurnPrompt|TestSessionPreviewFromMessagesPreservesCompiledFirstTurn|TestUserPreviewTextUnwrapsNestedCompilerContracts' -count=1`
- `go test . -run 'TestHistoryMessagesIncludeAssistantReasoning|TestHistoryMessagesDoNotReplayMemoryCompilerContract|TestHistoryForTabRestoresPlannerDisplayAfterReload' -count=1` from the desktop module
- `go test ./internal/control ./internal/agent ./internal/memorycompiler -count=1`
- `go test . -count=1` from the desktop module
- `go test ./... -count=1`
- `git diff --check`
