### PR TITLE
fix(heartbeat): 每次新建对话后更新 topicId 到最新

### DIFF
--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -227,6 +227,8 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 	//     previous run cannot overlap with the next scheduled fresh topic.
 	//   - Once the submitted topic is idle and due again, clear it and create a
 	//     fresh topic.
+	//   - topicId is always updated to the latest conversation so the task list
+	//     always points to the most recent session regardless of mode switch.
 	//
 	// For the legacy mode:
 	//   - Reuse the persisted topicID if available; create one on first run.
@@ -247,6 +249,7 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 				return t
 			}
 			topicID = meta.ID
+			t.TopicID = topicID // always persist the latest topic
 			// Save in-memory for retry safety (NOT persisted to disk).
 			e.mu.Lock()
 			if e.pendingTopics == nil {

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -70,6 +71,53 @@ func (s heartbeatStatusStub) RuntimeStatus() control.RuntimeStatus {
 	return s.status
 }
 
+type heartbeatExecuteTaskCtrlStub struct {
+	control.SessionAPI
+	status       control.RuntimeStatus
+	submitted    []string
+	approvalMode string
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) RuntimeStatus() control.RuntimeStatus {
+	return s.status
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) SubmitUserTurn(input, display string) {
+	s.submitted = append(s.submitted, input)
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) SetToolApprovalMode(mode string) {
+	s.approvalMode = mode
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) PlanMode() bool {
+	return false
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) AutoApproveTools() bool {
+	return false
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) Goal() string {
+	return ""
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) ToolApprovalMode() string {
+	return s.approvalMode
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) SetSessionPath(string) {}
+
+func (s *heartbeatExecuteTaskCtrlStub) SessionPath() string {
+	return ""
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) SessionDir() string {
+	return ""
+}
+
+func (s *heartbeatExecuteTaskCtrlStub) Close() {}
+
 func TestHeartbeatControllerBusyIncludesPendingPrompt(t *testing.T) {
 	if heartbeatControllerBusy(heartbeatStatusStub{status: control.RuntimeStatus{Running: false, PendingPrompt: false}}) {
 		t.Fatal("idle controller should be available for heartbeat execution")
@@ -79,6 +127,86 @@ func TestHeartbeatControllerBusyIncludesPendingPrompt(t *testing.T) {
 	}
 	if !heartbeatControllerBusy(heartbeatStatusStub{status: control.RuntimeStatus{PendingPrompt: true}}) {
 		t.Fatal("pending prompt should keep controller busy")
+	}
+}
+
+func TestHeartbeatExecuteTaskPersistsFreshConversationTopicID(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.runtimeEvents.emit = func(context.Context, string, ...interface{}) {}
+	engine := &HeartbeatEngine{
+		app:           app,
+		pendingTopics: map[string]heartbeatPendingTopic{},
+	}
+	ctrl := &heartbeatExecuteTaskCtrlStub{}
+	injected := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-injected:
+				return
+			case <-ticker.C:
+				var cancel context.CancelFunc
+				var tabToInject *WorkspaceTab
+				app.mu.Lock()
+				for _, tab := range app.tabs {
+					if tab == nil {
+						continue
+					}
+					tab.removed = true
+					cancel = tab.buildCancel
+					tabToInject = tab
+					break
+				}
+				app.mu.Unlock()
+				if tabToInject == nil {
+					continue
+				}
+				if cancel != nil {
+					cancel()
+				}
+				app.mu.Lock()
+				if tabToInject.Ctrl == nil {
+					tabToInject.Ctrl = ctrl
+					tabToInject.Ready = true
+					tabToInject.StartupErr = ""
+					app.mu.Unlock()
+					close(injected)
+					return
+				}
+				app.mu.Unlock()
+			}
+		}
+	}()
+
+	got := engine.executeTask(HeartbeatTask{
+		ID:                     "fresh",
+		Title:                  "Fresh",
+		Prompt:                 "ping",
+		NewConversationEachRun: true,
+		ApprovalMode:           "auto",
+	})
+
+	if got.TopicID == "" {
+		t.Fatal("fresh conversation task should return the newly created topic ID")
+	}
+	if got.LastRunAt == 0 {
+		t.Fatal("fresh conversation task should update LastRunAt after submit")
+	}
+	if len(ctrl.submitted) != 1 || ctrl.submitted[0] != "ping" {
+		t.Fatalf("submitted prompts = %v, want [ping]", ctrl.submitted)
+	}
+	if ctrl.approvalMode != "auto" {
+		t.Fatalf("approval mode = %q, want auto", ctrl.approvalMode)
+	}
+	pending := engine.pendingTopics["fresh"]
+	if pending.TopicID != got.TopicID || !pending.Submitted {
+		t.Fatalf("pending topic = %+v, want submitted %q", pending, got.TopicID)
 	}
 }
 


### PR DESCRIPTION
## Bug

自动化任务选择「每次新建对话」(`NewConversationEachRun=true`) 时，每次执行确实创建了新的对话，但配置文件 `heartbeat-tasks.json` 中的 `topicId` 没有被更新。导致：

1. 任务列表始终指向第一个创建的对话，而不是最新的
2. 如果用户后切回「复用同一对话」模式，会继续往第一个旧对话里写内容

## 根因

原 PR（`24a2d9f47`）中，`executeTask` 在创建新 topic 后写了 `t.TopicID = topicID`。

但在 CR 重构（`0d884e0b7`）引入 `pendingTopics` 内存防护机制时，`NewConversationEachRun` 分支下**遗漏了这行**：

```go
// ❌ 重构后 NewConversationEachRun 路径下缺失
// t.TopicID = topicID
```

而「复用同一对话」的 else 分支保留了这行，不符合"无论哪种模式，`topicId` 始终存最后一个对话 ID"的设计。

## 修复

补回 `t.TopicID = topicID`，确保配置文件始终记录最新的对话 ID：

```go
// executeTask — NewConversationEachRun 分支
topicID = meta.ID
t.TopicID = topicID // ← 补回
```

这样无论用户切换哪种模式，`topicId` 始终指向最新创建的对话。