### PR TITLE
Fix desktop rewind checkpoint targeting / 修复桌面端回溯 checkpoint 定位

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3060,6 +3060,7 @@ type HistoryMessage struct {
 	Role               string                    `json:"role"`
 	Content            string                    `json:"content"`
 	SubmitText         string                    `json:"submitText,omitempty"`
+	CheckpointTurn     *int                      `json:"checkpointTurn,omitempty"`
 	Reasoning          string                    `json:"reasoning,omitempty"`
 	MemoryCitations    []provider.MemoryCitation `json:"memoryCitations,omitempty"`
 	Level              string                    `json:"level,omitempty"`
@@ -3100,20 +3101,26 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 	msgs := ctrl.History()
 	dir := controllerSessionDir(ctrl)
 	path := ctrl.SessionPath()
-	return historyMessagesWithPlannerDisplays(msgs, sessionDisplayResolver(dir, path), sessionPlannerDisplayTurns(dir, path))
+	return historyMessagesWithPlannerDisplays(
+		msgs,
+		sessionDisplayResolver(dir, path),
+		sessionPlannerDisplayTurns(dir, path),
+		ctrl.CheckpointTurnsByMessageIndex(),
+	)
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
-	return historyMessagesWithPlannerDisplays(msgs, resolveUserContent, nil)
+	return historyMessagesWithPlannerDisplays(msgs, resolveUserContent, nil, nil)
 }
 
-func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserContent func(string) string, plannerTurns []plannerDisplayTurn) []HistoryMessage {
+func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserContent func(string) string, plannerTurns []plannerDisplayTurn, checkpointTurns map[int]int) []HistoryMessage {
 	out := make([]HistoryMessage, 0, len(msgs))
 	replayedTodoArgs := historyTodoArgsWithCompleteSteps(msgs)
 	toolResults := historyToolResultsByID(msgs)
 	plannerByUserHash := plannerTurnsByUserHash(plannerTurns)
-	for _, m := range msgs {
+	for index, m := range msgs {
 		content := m.Content
+		var checkpointTurn *int
 		if m.Role == provider.RoleUser {
 			// Mid-turn steer messages are persisted in the session so they
 			// survive tab switches. They are surfaced as a notice (↪ text)
@@ -3129,12 +3136,16 @@ func historyMessagesWithPlannerDisplays(msgs []provider.Message, resolveUserCont
 			if control.IsSyntheticUserMessage(content) {
 				continue
 			}
+			if turn, ok := checkpointTurns[index]; ok {
+				turnCopy := turn
+				checkpointTurn = &turnCopy
+			}
 		}
 		reasoning := ""
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		hm := HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning}
+		hm := HistoryMessage{Role: string(m.Role), Content: content, CheckpointTurn: checkpointTurn, Reasoning: reasoning}
 		if m.Role == provider.RoleAssistant && len(m.MemoryCitations) > 0 {
 			hm.MemoryCitations = append([]provider.MemoryCitation(nil), m.MemoryCitations...)
 		}
@@ -3510,6 +3521,7 @@ func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
 		loaded.Snapshot(),
 		sessionDisplayResolver(sessionDir, sessionPath),
 		sessionPlannerDisplayTurns(sessionDir, sessionPath),
+		nil,
 	), nil
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2177,18 +2177,35 @@ export default function App() {
     }
 
     const items = state.items;
-    // Find the boundary: index of the Nth user message where N = turn.
-    let boundaryIdx = 0;
+    const hasCheckpointTurns = items.some((it) => it.kind === "user" && it.checkpointTurn != null);
+    let boundaryIdx = -1;
     let userCount = 0;
+    let targetUserCount = -1;
     for (let i = 0; i < items.length; i++) {
       if (items[i].kind === "user") {
-        if (userCount === turn) { boundaryIdx = i; break; }
+        const item = items[i] as Extract<Item, { kind: "user" }>;
+        const matches = hasCheckpointTurns ? item.checkpointTurn === turn : userCount === turn;
+        if (matches) {
+          boundaryIdx = i;
+          targetUserCount = userCount;
+          break;
+        }
         userCount++;
       }
     }
+    if (boundaryIdx < 0) {
+      rewind(turn, scope).then((ok) => {
+        if (!ok) return;
+        if (scope === "both") {
+          setDockRefreshKey((v) => v + 1);
+          setProjectRevision((v) => v + 1);
+        }
+      });
+      return;
+    }
 
     const prevUserCount = items.filter((it) => it.kind === "user").length;
-    const turnDiff = prevUserCount - userCount;
+    const turnDiff = prevUserCount - targetUserCount;
 
     // Save full items for undo.
     const userItem = items[boundaryIdx]?.kind === "user" ? items[boundaryIdx] as Extract<Item, { kind: "user" }> : undefined;

--- a/desktop/frontend/src/__tests__/history-tool-status.test.ts
+++ b/desktop/frontend/src/__tests__/history-tool-status.test.ts
@@ -29,6 +29,14 @@ const userTimeItems = historyMessagesToItems([
 eq(userTimeItems[0]?.kind === "user" && userTimeItems[0].createdAt, undefined, "history users without createdAt keep no timestamp");
 eq(userTimeItems[1]?.kind === "user" && userTimeItems[1].createdAt, 1_718_000_000_000, "history users preserve createdAt when present");
 
+const checkpointTurnItems = historyMessagesToItems([
+  { role: "user", content: "first", checkpointTurn: 0 },
+  { role: "assistant", content: "ok" },
+  { role: "user", content: "second", checkpointTurn: 3 },
+] as HistoryMessage[], "c").items.filter((item) => item.kind === "user");
+eq(checkpointTurnItems[0]?.kind === "user" && checkpointTurnItems[0].checkpointTurn, 0, "history users preserve checkpoint turn zero");
+eq(checkpointTurnItems[1]?.kind === "user" && checkpointTurnItems[1].checkpointTurn, 3, "history users preserve non-contiguous backend checkpoint turns");
+
 const citedAssistant = historyMessagesToItems([
   {
     role: "assistant",

--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildTurnGroups, createWarmLayerState, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
+import { buildTurnGroups, createWarmLayerState, questionTurnsById, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -66,6 +66,24 @@ console.log("\ntranscript grouping contract");
   eq(groups[0].endIdx, 4, "first group end index");
   eq(groups[0].toolCount, 2, "counts top-level tools in a turn");
   eq(groups[2].assistantPreview, "answer 2", "keeps latest assistant preview for each turn");
+}
+
+{
+  const visibleTurns = questionTurnsById([
+    { id: "u0", text: "first", turn: 0 },
+    { id: "u1", text: "second", turn: 1 },
+  ]);
+  eq(visibleTurns.get("u0"), 0, "falls back to visible ordinal when no checkpoint turns exist");
+  eq(visibleTurns.get("u1"), 1, "visible ordinal fallback increments by question");
+
+  const backendTurns = questionTurnsById([
+    { id: "u0", text: "first", turn: 0, checkpointTurn: 0 },
+    { id: "u1", text: "live without server stamp yet", turn: 1 },
+    { id: "u2", text: "after hidden synthetic", turn: 2, checkpointTurn: 3 },
+  ]);
+  eq(backendTurns.get("u0"), 0, "uses backend checkpoint turn zero when present");
+  eq(backendTurns.get("u2"), 3, "uses non-contiguous backend checkpoint turn");
+  ok(!backendTurns.has("u1"), "does not mix visible ordinal fallback into authoritative checkpoint sessions");
 }
 
 {

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -159,5 +159,23 @@ console.log("\nuse controller meta");
   eq(activeHelper.sessionCost, 0.001, "helper usage inside a turn still counts toward session cost");
 }
 
+{
+  let s = reducer(initialState, { type: "user", text: "first", seq: 0 });
+  s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+  s = reducer(s, { type: "event", e: { kind: "notice", level: "info", text: "runtime notice" } });
+  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+  const merged = reducer(s, {
+    type: "history_checkpoint_turns",
+    messages: [
+      { role: "user", content: "first", checkpointTurn: 0 },
+      { role: "assistant", content: "done" },
+    ],
+  });
+  const user = merged.items.find((item) => item.kind === "user");
+  const notice = merged.items.find((item) => item.kind === "notice" && item.text === "runtime notice");
+  eq(user?.kind === "user" && user.checkpointTurn, 0, "turn_done checkpoint merge stamps user turn zero");
+  eq(Boolean(notice), true, "turn_done checkpoint merge preserves runtime notices");
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
+import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, questionTurnsById, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -144,7 +144,7 @@ export function Transcript({
     let turn = 0;
     for (const it of items) {
       if (it.kind !== "user") continue;
-      anchors.push({ id: it.id, text: compactQuestionText(it.text), turn });
+      anchors.push({ id: it.id, text: compactQuestionText(it.text), turn, checkpointTurn: it.checkpointTurn });
       turn += 1;
     }
     return anchors;
@@ -304,7 +304,7 @@ export function Transcript({
     return () => document.removeEventListener("mousedown", onDown);
   }, [openAction]);
 
-  const userTurn = useMemo(() => new Map(questions.map((question) => [question.id, question.turn])), [questions]);
+  const userTurn = useMemo(() => questionTurnsById(questions), [questions]);
   const checkpointsByTurn = useMemo(() => new Map(checkpoints.map((checkpoint) => [checkpoint.turn, checkpoint])), [checkpoints]);
 
   // ── JumpBar integration ───────────────────────────────────────────────────

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -1,7 +1,7 @@
 import { replaceAttachmentRefsForDisplay } from "./attachmentDisplay";
 import type { Item } from "./useController";
 
-export type QuestionAnchor = { id: string; text: string; turn: number };
+export type QuestionAnchor = { id: string; text: string; turn: number; checkpointTurn?: number };
 
 export interface TurnGroup {
   userItem: Item;
@@ -53,6 +53,19 @@ export function compactQuestionText(text: string): string {
   const cleaned = replaceAttachmentRefsForDisplay(text).replace(/\s+/g, " ").trim();
   if (cleaned.length <= 80) return cleaned;
   return cleaned.slice(0, 80);
+}
+
+export function questionTurnsById(questions: QuestionAnchor[]): Map<string, number> {
+  const hasCheckpointTurns = questions.some((question) => question.checkpointTurn != null);
+  const turns = new Map<string, number>();
+  for (const question of questions) {
+    if (question.checkpointTurn != null) {
+      turns.set(question.id, question.checkpointTurn);
+    } else if (!hasCheckpointTurns) {
+      turns.set(question.id, question.turn);
+    }
+  }
+  return turns;
 }
 
 export function scrollVersion(items: Item[]): string {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -296,6 +296,7 @@ export interface HistoryMessage {
   role: string;
   content: string;
   submitText?: string;
+  checkpointTurn?: number;
   createdAt?: number;
   reasoning?: string;
   memoryCitations?: MemoryCitation[];

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -44,7 +44,7 @@ export type MessageActionState = { turn: number; scope: MessageActionScope };
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup";
 
 export type Item =
-  | { kind: "user"; id: string; text: string; submitText?: string; failed?: boolean; createdAt?: number }
+  | { kind: "user"; id: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; reasoningComplete?: boolean; memoryCitations?: MemoryCitation[] }
   | { kind: "phase"; id: string; text: string }
   | { kind: "notice"; id: string; level: "info" | "warn"; text: string }
@@ -321,6 +321,7 @@ type Action =
   | { type: "message_action_start"; action: MessageActionState }
   | { type: "message_action_done" }
   | { type: "history"; messages: HistoryMessage[] }
+  | { type: "history_checkpoint_turns"; messages: HistoryMessage[] }
   | { type: "local_notice"; level: "info" | "warn"; text: string }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
@@ -373,7 +374,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
     }
     if (m.role === "user") {
       if (m.content.trim() === "") continue;
-      items.push({ kind: "user", id: `${idPrefix}${seq}`, text: m.content, submitText: m.submitText, createdAt: m.createdAt });
+      items.push({ kind: "user", id: `${idPrefix}${seq}`, text: m.content, submitText: m.submitText, createdAt: m.createdAt, checkpointTurn: m.checkpointTurn });
       seq++;
       continue;
     }
@@ -441,6 +442,24 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
     }
   }
   return { items, seq };
+}
+
+function mergeHistoryCheckpointTurns(items: Item[], messages: HistoryMessage[]): Item[] {
+  const turns = messages
+    .filter((m) => m.role === "user" && m.content.trim() !== "")
+    .map((m) => m.checkpointTurn);
+  if (!turns.some((turn) => turn != null)) return items;
+  let userIndex = 0;
+  let changed = false;
+  const next = items.map((item) => {
+    if (item.kind !== "user") return item;
+    const turn = turns[userIndex];
+    userIndex += 1;
+    if (turn == null || item.checkpointTurn === turn) return item;
+    changed = true;
+    return { ...item, checkpointTurn: turn };
+  });
+  return changed ? next : items;
 }
 
 function positionalToolResults(messages: HistoryMessage[]): Map<string, { message: HistoryMessage; index: number }> {
@@ -825,6 +844,8 @@ export function reducer(s: State, a: Action): State {
       const { items, seq } = historyMessagesToItems(a.messages, "h", s.seq);
       return { ...s, items: compactArchivedToolItems(items), seq, hydrateHistoryLoaded: true, hydratePlaceholderItems: undefined };
     }
+    case "history_checkpoint_turns":
+      return { ...s, items: mergeHistoryCheckpointTurns(s.items, a.messages) };
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined, pendingPrompt: false };
     case "clearAsk": return { ...s, ask: undefined, pendingPrompt: false };
@@ -1151,6 +1172,11 @@ export function useController() {
         dispatchTo(targetTabId, { type: "event", e });
       }
       if (e.kind === "turn_done") {
+        if (!e.err) {
+          app.HistoryForTab(targetTabId)
+            .then((messages) => dispatchTo(targetTabId, { type: "history_checkpoint_turns", messages: asArray(messages) }))
+            .catch(() => {});
+        }
         void refreshMetaForTab(targetTabId, dispatchTo);
         app
           .ContextUsageForTab(targetTabId)

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -86,6 +86,40 @@ func TestHistoryMessagesDoNotReplayMemoryCompilerContract(t *testing.T) {
 	assertNoHistoryMemoryContract(t, got[0].Content)
 }
 
+func TestHistoryMessagesCarryCheckpointTurnsAcrossHiddenSyntheticUsers(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "first visible"},
+		{Role: provider.RoleAssistant, Content: "first answer"},
+		{Role: provider.RoleUser, Content: "Continue pursuing the active goal. If it is complete, provide the concise final result."},
+		{Role: provider.RoleAssistant, Content: "hidden continuation"},
+		{Role: provider.RoleUser, Content: "second visible"},
+		{Role: provider.RoleAssistant, Content: "second answer"},
+	}
+
+	got := historyMessagesWithPlannerDisplays(
+		msgs,
+		func(content string) string { return content },
+		nil,
+		map[int]int{1: 0, 5: 2},
+	)
+	var users []HistoryMessage
+	for _, msg := range got {
+		if msg.Role == "user" {
+			users = append(users, msg)
+		}
+	}
+	if len(users) != 2 {
+		t.Fatalf("visible users = %d, want 2: %+v", len(users), got)
+	}
+	if users[0].CheckpointTurn == nil || *users[0].CheckpointTurn != 0 {
+		t.Fatalf("first checkpoint turn = %v, want 0", users[0].CheckpointTurn)
+	}
+	if users[1].CheckpointTurn == nil || *users[1].CheckpointTurn != 2 {
+		t.Fatalf("second checkpoint turn = %v, want 2", users[1].CheckpointTurn)
+	}
+}
+
 func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -671,6 +671,9 @@ func (s *tabEventSink) Emit(e event.Event) {
 				m.persist()
 			}
 		}
+		if e.Kind == event.TurnDone {
+			s.flushPlannerDisplay()
+		}
 	}
 	s.emitRuntimeEvent(eventChannel, toWireTab(e, s.tabID))
 	if s.app != nil {
@@ -690,7 +693,6 @@ func (s *tabEventSink) Emit(e event.Event) {
 	}
 	// Persist after each turn so a force-kill loses at most the in-flight prompt.
 	if e.Kind == event.TurnDone && s.app != nil {
-		s.flushPlannerDisplay()
 		s.app.scheduleTabSnapshot(s.tabID)
 	}
 }

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -211,12 +211,6 @@ func (s *Store) List() []Meta {
 		for i, f := range c.Files {
 			paths[i] = f.Path
 		}
-		// The current in-progress turn's files haven't been committed
-		// yet — they must not participate in CanCode propagation.
-		// Include the turn itself so it still appears as a rewind point.
-		if c == s.cur {
-			paths = nil
-		}
 		out = append(out, Meta{Turn: c.Turn, Time: c.Time, Prompt: c.Prompt, Paths: paths})
 	}
 	return out
@@ -230,6 +224,43 @@ func (s *Store) all() []*Checkpoint {
 	}
 	sort.Slice(cps, func(i, j int) bool { return cps[i].Turn < cps[j].Turn })
 	return cps
+}
+
+// TruncateFrom discards checkpoints at or after fromTurn. Conversation rewind
+// removes those future turns from the transcript, so their file snapshots must
+// not remain visible or collide with newly-created checkpoints that reuse the
+// same turn numbers after the rewrite.
+func (s *Store) TruncateFrom(fromTurn int) {
+	s.mu.Lock()
+	done := s.done[:0]
+	deleteTurns := map[int]bool{}
+	for _, c := range s.done {
+		if c.Turn >= fromTurn {
+			deleteTurns[c.Turn] = true
+			continue
+		}
+		done = append(done, c)
+	}
+	for i := len(done); i < len(s.done); i++ {
+		s.done[i] = nil
+	}
+	s.done = done
+	if s.cur != nil && s.cur.Turn >= fromTurn {
+		deleteTurns[s.cur.Turn] = true
+		s.cur = nil
+		s.seen = map[string]bool{}
+	}
+	dir := s.dir
+	s.mu.Unlock()
+
+	if dir == "" || len(deleteTurns) == 0 {
+		return
+	}
+	for turn := range deleteTurns {
+		if err := os.Remove(filepath.Join(dir, fmt.Sprintf("turn-%d.json", turn))); err != nil && !os.IsNotExist(err) {
+			slog.Warn("checkpoint: truncate failed", "turn", turn, "err", err)
+		}
+	}
 }
 
 // RestoreCode reverts the workspace to its state at the start of turn `fromTurn`:

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -249,6 +249,56 @@ func TestPersistenceRoundTrip(t *testing.T) {
 	}
 }
 
+func TestListExposesCurrentTurnFiles(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a.txt")
+	write(t, a, "v0")
+	s := New("", root)
+	s.Begin(0, "edit current", 0)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: "v0"})
+
+	metas := s.List()
+	if len(metas) != 1 {
+		t.Fatalf("metas = %d, want 1", len(metas))
+	}
+	if len(metas[0].Paths) != 1 || metas[0].Paths[0] != a {
+		t.Fatalf("current turn paths = %#v, want [%q]", metas[0].Paths, a)
+	}
+}
+
+func TestTruncateFromDropsFutureCheckpointsAndFiles(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(t.TempDir(), "sess.ckpt")
+	a := filepath.Join(root, "a.txt")
+	write(t, a, "v0")
+	s := New(dir, root)
+	s.Begin(0, "first", 0)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: "v0"})
+	s.Begin(1, "second", 2)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: "v1"})
+	s.Begin(2, "third", 4)
+
+	s.TruncateFrom(1)
+
+	metas := s.List()
+	if len(metas) != 1 || metas[0].Turn != 0 {
+		t.Fatalf("metas after truncate = %+v, want only turn 0", metas)
+	}
+	if s.NextTurn() != 1 {
+		t.Fatalf("NextTurn after truncate = %d, want 1", s.NextTurn())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "turn-1.json")); !os.IsNotExist(err) {
+		t.Fatalf("turn-1 checkpoint should be deleted, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "turn-2.json")); !os.IsNotExist(err) {
+		t.Fatalf("turn-2 checkpoint should be deleted, stat err=%v", err)
+	}
+	reloaded := New(dir, root)
+	if got := reloaded.List(); len(got) != 1 || got[0].Turn != 0 {
+		t.Fatalf("reloaded metas after truncate = %+v, want only turn 0", got)
+	}
+}
+
 func BenchmarkRestoreGB18030Encoding(b *testing.B) {
 	root := b.TempDir()
 	a := filepath.Join(root, "gbk.txt")

--- a/internal/control/checkpoint.go
+++ b/internal/control/checkpoint.go
@@ -73,6 +73,23 @@ func (m *checkpointManager) begin(input string, msgIndex int) {
 	store.Begin(turn, input, msgIndex)
 }
 
+// turnsByMessageIndex returns message-log index -> checkpoint turn over live
+// boundaries. The desktop transcript uses this authoritative map instead of
+// recounting visible user bubbles, which can diverge when synthetic user-role
+// messages are hidden from the UI.
+func (m *checkpointManager) turnsByMessageIndex() map[int]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[int]int, len(m.bound))
+	for turn, index := range m.bound {
+		if existing, ok := out[index]; ok && existing < turn {
+			continue
+		}
+		out[index] = turn
+	}
+	return out
+}
+
 // boundary returns the recorded turn-start message index, if any.
 func (m *checkpointManager) boundary(turn int) (int, bool) {
 	m.mu.Lock()
@@ -119,6 +136,7 @@ func (m *checkpointManager) snapshot(ch diff.Change) {
 // after it — the conversation-rewind renumber after the message log is cut back.
 func (m *checkpointManager) truncateFrom(turn int) {
 	m.mu.Lock()
+	store := m.store
 	m.turn = turn
 	for k := range m.bound {
 		if k >= turn {
@@ -126,6 +144,9 @@ func (m *checkpointManager) truncateFrom(turn int) {
 		}
 	}
 	m.mu.Unlock()
+	if store != nil {
+		store.TruncateFrom(turn)
+	}
 }
 
 // clearBounds drops every boundary after a summarize restructures the log (so

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1602,6 +1602,10 @@ func (c *Controller) Checkpoints() []checkpoint.Meta {
 	return c.checkpoints.list()
 }
 
+func (c *Controller) CheckpointTurnsByMessageIndex() map[int]int {
+	return c.checkpoints.turnsByMessageIndex()
+}
+
 // rewindFail emits the error as a Warn notice (so a frontend that swallows the
 // returned error — e.g. the desktop bridge's .catch — still shows the user why
 // the rewind did nothing) and returns it.

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -103,6 +103,7 @@ type Goals interface {
 // operations (compact, summarize).
 type SessionHistory interface {
 	Checkpoints() []checkpoint.Meta
+	CheckpointTurnsByMessageIndex() map[int]int
 	CheckpointHasBoundary(turn int) bool
 	Rewind(turn int, scope RewindScope) error
 	Fork(turn int) (string, error)

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -61,9 +61,14 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	defer c.recordDisplayForNewUser(startMessages, turn.display)
-	// Open a checkpoint for this turn before the user message is appended, so the
-	// recorded message boundary precedes it and pre-edit snapshots land here.
-	c.beginCheckpoint(input)
+	// Open a checkpoint only for visible user turns before the user message is
+	// appended, so the recorded message boundary precedes it and pre-edit
+	// snapshots land here. Synthetic continuations stay attached to the visible
+	// turn that spawned them; otherwise hidden user-role messages would advance
+	// backend checkpoint turns without a matching frontend turn.
+	if !turn.synthetic {
+		c.beginCheckpoint(input)
+	}
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -348,6 +348,40 @@ func TestTurnOrchestratorCheckpointBoundaryPrecedesUserMessage(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorSyntheticTurnDoesNotCreateCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &recordingSessionRunner{session: sess}
+	c := New(Options{
+		Runner:      runner,
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "test",
+	})
+	o := newTurnOrchestrator(c)
+	if err := o.runTurnWithRawDisplay(context.Background(), "real prompt", "real prompt", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.runSyntheticTurnWithRawDisplay(context.Background(), "hidden follow-up", "hidden follow-up", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cps := c.Checkpoints()
+	if len(cps) != 1 {
+		t.Fatalf("checkpoints = %+v, want exactly the visible user turn", cps)
+	}
+	if cps[0].Turn != 0 || cps[0].Prompt != "real prompt" {
+		t.Fatalf("checkpoint = %+v, want turn 0 real prompt", cps[0])
+	}
+	turns := c.CheckpointTurnsByMessageIndex()
+	if len(turns) != 1 || turns[1] != 0 {
+		t.Fatalf("checkpoint turns by message index = %v, want {1:0}", turns)
+	}
+}
+
 func TestTurnOrchestratorStopHookCancelledContext(t *testing.T) {
 	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
 	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)


### PR DESCRIPTION
## Summary
- attach authoritative backend checkpoint turns to visible desktop history user messages instead of deriving rewind targets from visible bubble order
- keep synthetic/hidden continuation turns from creating standalone checkpoints, and truncate future checkpoint files after conversation rewind so reused turns cannot collide with stale state
- expose current-turn file snapshots immediately so code/both rewind buttons become available without tab switching
- refresh completed-turn checkpoint metadata without replacing live transcript-only notices

## Fixes / Refs
Fixes #5346
Refs #5312, #5252, #4620, #5358, #4714, #4633, #3660, #3438

## Cache impact
No provider-visible prompt prefix, tool schema, request serialization, or compaction policy changes.

## Verification
- `go test ./...`
- `go test -C desktop ./...`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/use-controller-meta.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/history-tool-status.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
- `git diff --check`

Known pre-existing local typecheck issue:
- `pnpm --dir desktop/frontend exec tsc --noEmit -p tsconfig.test.json --pretty false` currently stops on `src/__tests__/capabilities-panel-actions.test.ts(127,5): Type '"auto"' is not assignable to type 'Mode'.`\n