### PR TITLE
Fix TUI transcript scroll interactions / 修复 TUI 对话滚动交互

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -186,6 +186,11 @@ type chatTUI struct {
 	// column the drag is held at, so the ticker can extend the selection head.
 	autoScroll int
 	dragX      int
+	// scrollbarDrag owns left-button drags that start on the transcript scrollbar
+	// column. It is separate from text selection so the visual thumb is not a
+	// dead target and dragging it never leaves a transcript selection behind.
+	scrollbarDrag       bool
+	scrollbarGrabOffset int
 
 	// The user bubble is echoed to scrollback immediately on Enter (bubbleStartIdx
 	// marks where in the transcript it landed). It stays "un-sendable" until the
@@ -317,6 +322,16 @@ type agentEventMsg event.Event
 // maxEventDrain caps how many buffered events one Update coalesces before
 // yielding to render, so a sustained output flood still shows live progress.
 const maxEventDrain = 512
+
+const resetMouseTracking = ansi.ResetModeMouseX10 +
+	ansi.ResetModeMouseNormal +
+	ansi.ResetModeMouseHighlight +
+	ansi.ResetModeMouseButtonEvent +
+	ansi.ResetModeMouseAnyEvent +
+	ansi.ResetModeMouseExtSgr +
+	ansi.ResetModeMouseExtUtf8 +
+	ansi.ResetModeMouseExtUrxvt +
+	ansi.ResetModeMouseExtSgrPixel
 
 // compactDoneMsg reports that an async /compact pass returned. The card was
 // already drawn from the CompactionDone event; this only surfaces a failure and
@@ -664,6 +679,10 @@ func (m chatTUI) Init() tea.Cmd {
 	)
 }
 
+func suspendWithMouseReset() tea.Cmd {
+	return tea.Sequence(tea.Raw(resetMouseTracking), tea.Suspend)
+}
+
 func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	wasAtBottom := m.viewport.AtBottom()
 	prevLines := len(m.transcript)
@@ -745,11 +764,19 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Right-click copies the active selection (Windows Terminal convention);
 		// left-press in the transcript region begins a text selection — unless
-		// the click lands on a shell-output hint line, which toggles expand.
+		// the click lands on the scrollbar or a shell-output hint line.
 		if msg.Button == tea.MouseRight && m.sel.active && !m.sel.empty() {
 			text := m.selectedText()
 			m.sel = selection{}
 			return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
+		}
+		if msg.Button == tea.MouseLeft && m.inScrollbar(msg.X, msg.Y) {
+			m.sel = selection{}
+			m.autoScroll = 0
+			m.scrollbarDrag = true
+			m.scrollbarGrabOffset = m.scrollbarGrabRowOffset(msg.Y)
+			m.dragScrollbar(msg.Y)
+			return m, nil
 		}
 		if msg.Button == tea.MouseLeft && msg.Y < m.viewport.Height() {
 			// Check if the clicked line is a shell-output hint.
@@ -768,6 +795,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseMotionMsg:
+		if m.scrollbarDrag {
+			m.dragScrollbar(msg.Y)
+			return m, nil
+		}
 		// Drag extends the live selection (CellMotion only reports motion while
 		// a button is held, so this is a drag). A drag held against the top or
 		// bottom edge starts an auto-scroll ticker so the selection can run past
@@ -809,6 +840,12 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Release finalizes the selection; the highlight stays on as the visual
 		// "what's selected" cue and a right-click copies it. A plain click (no
 		// drag) clears any prior selection.
+		if m.scrollbarDrag {
+			m.dragScrollbar(msg.Y)
+			m.scrollbarDrag = false
+			m.scrollbarGrabOffset = 0
+			return m, nil
+		}
 		m.autoScroll = 0 // stop edge auto-scroll
 		if msg.Button == tea.MouseLeft && m.sel.active && m.sel.empty() {
 			m.sel = selection{}
@@ -852,7 +889,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.GotoBottom()
 			return m, finalize(m, cmds)
 		case "ctrl+z":
-			return m, tea.Suspend
+			return m, suspendWithMouseReset()
 		}
 		// A question card is modal: keys drive it. In its free-text ("Type
 		// something") mode, the keystroke goes to the textarea — Enter confirms the

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -903,6 +904,134 @@ func TestCtrlHomeEndScrollKeyBindings(t *testing.T) {
 	cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModCtrl})
 	if !cur.viewport.AtBottom() {
 		t.Fatalf("ctrl+end should scroll to bottom, AtBottom=%v, YOffset=%d", cur.viewport.AtBottom(), cur.viewport.YOffset())
+	}
+}
+
+func TestMouseWheelAndPageKeysScrollTranscript(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+	for i := 0; i < 40; i++ {
+		cur = adv(cur, notice)
+	}
+	if !cur.viewport.AtBottom() {
+		t.Fatal("viewport should start at bottom after overflowing output")
+	}
+	bottom := cur.viewport.YOffset()
+	if bottom <= cur.viewport.Height()+3 {
+		t.Fatalf("test transcript did not overflow enough: bottom=%d height=%d", bottom, cur.viewport.Height())
+	}
+
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if got, want := cur.viewport.YOffset(), bottom-3; got != want {
+		t.Fatalf("wheel-up YOffset = %d, want %d", got, want)
+	}
+
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if got := cur.viewport.YOffset(); got != bottom {
+		t.Fatalf("wheel-down should return by one wheel step, YOffset=%d want bottom=%d", got, bottom)
+	}
+
+	cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyPgUp})
+	pageUp := cur.viewport.YOffset()
+	if got, want := pageUp, bottom-cur.viewport.Height(); got != want {
+		t.Fatalf("PageUp YOffset = %d, want %d", got, want)
+	}
+
+	cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyPgDown})
+	if got := cur.viewport.YOffset(); got != bottom {
+		t.Fatalf("PageDown should return to bottom from one page up, YOffset=%d want %d", got, bottom)
+	}
+}
+
+func TestRunningStreamPreservesScrolledReadingPosition(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+	for i := 0; i < 40; i++ {
+		cur = adv(cur, notice)
+	}
+	cur.state = tuiRunning
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	readOffset := cur.viewport.YOffset()
+	if cur.viewport.AtBottom() {
+		t.Fatal("wheel-up should leave the bottom before streaming output arrives")
+	}
+
+	cur = adv(cur, agentEventMsg(event.Event{Kind: event.Text, Text: "streamed paragraph\n\n"}))
+	if cur.viewport.AtBottom() {
+		t.Fatal("streaming output must not yank a scrolled-up reader back to bottom")
+	}
+	if got := cur.viewport.YOffset(); got != readOffset {
+		t.Fatalf("streaming output should preserve reading offset, got %d want %d", got, readOffset)
+	}
+
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if got, want := cur.viewport.YOffset(), readOffset+3; got != want {
+		t.Fatalf("wheel-down while running should move one wheel step, got %d want %d", got, want)
+	}
+	if cur.viewport.AtBottom() {
+		t.Fatal("one wheel-down step from the reading position should not jump straight to bottom")
+	}
+}
+
+func TestTranscriptScrollbarClickAndDrag(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+	for i := 0; i < 40; i++ {
+		cur = adv(cur, notice)
+	}
+	cur.viewport.GotoTop()
+	barX := cur.viewport.Width()
+	bottomRow := cur.viewport.Height() - 1
+
+	cur = adv(cur, tea.MouseClickMsg{X: barX, Y: 0, Button: tea.MouseLeft})
+	if cur.sel.active {
+		t.Fatal("clicking the scrollbar must not start transcript selection")
+	}
+	if !cur.scrollbarDrag {
+		t.Fatal("left-click on scrollbar should start scrollbar drag")
+	}
+
+	cur = adv(cur, tea.MouseMotionMsg{X: barX, Y: bottomRow, Button: tea.MouseLeft})
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("dragging scrollbar to bottom should reach bottom, YOffset=%d", cur.viewport.YOffset())
+	}
+	if cur.sel.active {
+		t.Fatal("dragging the scrollbar must not leave a transcript selection")
+	}
+
+	cur = adv(cur, tea.MouseReleaseMsg{X: barX, Y: bottomRow, Button: tea.MouseLeft})
+	if cur.scrollbarDrag {
+		t.Fatal("mouse release should end scrollbar drag")
+	}
+	if cur.sel.active {
+		t.Fatal("scrollbar release must not create a text selection")
+	}
+
+	cur.viewport.GotoTop()
+	cur = adv(cur, tea.MouseClickMsg{X: barX - 1, Y: 0, Button: tea.MouseLeft})
+	if !cur.sel.active {
+		t.Fatal("clicking the transcript content column next to the scrollbar should still start selection")
 	}
 }
 
@@ -1823,16 +1952,36 @@ func TestRunningStatusShowsCancelRequested(t *testing.T) {
 	}
 }
 
-func TestCtrlZSendsSuspend(t *testing.T) {
+func TestCtrlZResetsMouseTrackingBeforeSuspend(t *testing.T) {
 	m := newTestChatTUI()
 	ctrlZ := tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl}
 
 	_, cmd := m.Update(ctrlZ)
 	if cmd == nil {
-		t.Fatal("expected Ctrl+Z to return a suspend command")
+		t.Fatal("expected Ctrl+Z to return a suspend sequence")
 	}
-	if msg := cmd(); msg != (tea.SuspendMsg{}) {
-		t.Fatalf("expected tea.SuspendMsg, got %T", msg)
+	msg := cmd()
+	seq := reflect.ValueOf(msg)
+	if seq.Kind() != reflect.Slice || seq.Len() != 2 {
+		t.Fatalf("expected Ctrl+Z to return a two-command sequence, got %T", msg)
+	}
+	first, ok := seq.Index(0).Interface().(tea.Cmd)
+	if !ok {
+		t.Fatalf("first sequence item is %T, want tea.Cmd", seq.Index(0).Interface())
+	}
+	raw, ok := first().(tea.RawMsg)
+	if !ok {
+		t.Fatalf("first Ctrl+Z command = %T, want tea.RawMsg", first())
+	}
+	if got := fmt.Sprint(raw.Msg); got != resetMouseTracking {
+		t.Fatalf("Ctrl+Z mouse reset = %q, want %q", got, resetMouseTracking)
+	}
+	second, ok := seq.Index(1).Interface().(tea.Cmd)
+	if !ok {
+		t.Fatalf("second sequence item is %T, want tea.Cmd", seq.Index(1).Interface())
+	}
+	if msg := second(); msg != (tea.SuspendMsg{}) {
+		t.Fatalf("second Ctrl+Z command = %T, want tea.SuspendMsg", msg)
 	}
 }
 

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -176,6 +176,26 @@ func scrollbarThumb(height, yoff, total int) (start, size int) {
 	return start, size
 }
 
+func scrollbarYOffset(height, row, total, grabOffset int) int {
+	if total <= height {
+		return 0
+	}
+	_, thumbSize := scrollbarThumb(height, 0, total)
+	maxTop := height - thumbSize
+	if maxTop <= 0 {
+		return 0
+	}
+	top := row - grabOffset
+	if top < 0 {
+		top = 0
+	}
+	if top > maxTop {
+		top = maxTop
+	}
+	maxYoff := total - height
+	return (top*maxYoff + maxTop/2) / maxTop
+}
+
 func scrollbarCell(row, total, height, thumbStart, thumbSize int) string {
 	if total <= height {
 		return " "
@@ -184,6 +204,26 @@ func scrollbarCell(row, total, height, thumbStart, thumbSize int) string {
 		return scrollThumbStyle.Render("█")
 	}
 	return scrollTrackStyle.Render("│")
+}
+
+func (m chatTUI) inScrollbar(x, y int) bool {
+	if m.nativeScrollback {
+		return false
+	}
+	h := m.viewport.Height()
+	return h > 0 && y >= 0 && y < h && x == m.viewport.Width() && len(m.wrappedLines) > h
+}
+
+func (m chatTUI) scrollbarGrabRowOffset(row int) int {
+	thumbStart, thumbSize := scrollbarThumb(m.viewport.Height(), m.viewport.YOffset(), len(m.wrappedLines))
+	if row >= thumbStart && row < thumbStart+thumbSize {
+		return row - thumbStart
+	}
+	return thumbSize / 2
+}
+
+func (m *chatTUI) dragScrollbar(row int) {
+	m.viewport.SetYOffset(scrollbarYOffset(m.viewport.Height(), row, len(m.wrappedLines), m.scrollbarGrabOffset))
 }
 
 // transcriptCaret maps a screen cell (x, y) in the transcript region to an


### PR DESCRIPTION
## Summary

Fixes #3473, fixes #3173, fixes #4016.

- Make the CLI transcript scrollbar interactive: left-click/drag on the reserved rightmost column scrolls the viewport instead of starting text selection, while the adjacent transcript content column still starts selection.
- Keep transcript scrolling contracts explicit: mouse wheel scrolls in fixed transcript steps, PgUp/PgDown page the transcript, and streaming output preserves a scrolled-up reading position instead of snapping back to bottom.
- Reset terminal mouse tracking before Ctrl+Z suspend so SGR mouse sequences do not leak into the shell if the TUI is paused while mouse reporting is enabled.

## Contributor Context

- Builds on #5378 by @yekern, already merged into `main-v2`, which restored `MouseModeCellMotion` so terminals deliver wheel events to the TUI transcript viewport. This PR keeps that invariant covered and adds the remaining scrollbar, running-stream, and suspend hardening.

## Cache Impact

Cache-impact: low — CLI TUI event handling and tests only. No provider request serialization, prompt prefix, tool schema, memory, or compaction paths changed.

## Verification

- `go test ./internal/cli -run 'Test(CtrlZResetsMouseTrackingBeforeSuspend|MouseWheelAndPageKeysScrollTranscript|RunningStreamPreservesScrolledReadingPosition|TranscriptScrollbarClickAndDrag)' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./...`
