### PR TITLE
fix(desktop): coalesce tab-bar switches through the navigation scheduler (#5352)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2007,13 +2007,36 @@ export default function App() {
     setComposerInsertRequest({ id: Date.now(), text });
   }, []);
 
+  // Coalesce tab-bar switches through the same last-click-wins scheduler that
+  // openTopic/blank/resume navigation uses, so rapidly clicking between two
+  // running sessions can't run two switchTab() calls concurrently. Concurrent
+  // switches race on the backend SetActiveTab/confirmBackendActiveTab ordering,
+  // which lands events + hydration on the wrong session (#5352). switchTab's own
+  // loadSessionDataForTab is already seq-guarded; this serializes the backend
+  // activation around it.
+  const tabSwitchSeqRef = useRef(0);
+  const tabSwitchRunningRef = useRef(false);
+  const tabSwitchPendingRef = useRef<PendingNavigationRequest<{ tabId: string; optimisticTab?: TabMeta }> | null>(null);
+  const enqueueTabSwitch = useCallback(
+    (tabId: string, optimisticTab?: TabMeta): Promise<void> =>
+      enqueueNavigationRequest(
+        { seqRef: tabSwitchSeqRef, runningRef: tabSwitchRunningRef, pendingRef: tabSwitchPendingRef },
+        { tabId, optimisticTab },
+        async (request) => {
+          await switchTab(request.tabId, request.optimisticTab);
+          await refreshTabMetas();
+        },
+      ),
+    [switchTab, refreshTabMetas],
+  );
+
   const handleTabChange = useCallback((id: string) => {
     closeTransientOverlays();
     const selected = tabMetas.find((tab) => tab.id === id);
     setTabMetas((current) => current.map((tab) => ({ ...tab, active: tab.id === id })));
-    void switchTab(id, selected).then(() => refreshTabMetas());
+    void enqueueTabSwitch(id, selected);
     setTabRevealSignal((signal) => signal + 1);
-  }, [closeTransientOverlays, refreshTabMetas, switchTab, tabMetas]);
+  }, [closeTransientOverlays, enqueueTabSwitch, tabMetas]);
 
   const handleTabClose = useCallback(async (id: string) => {
     closeTransientOverlays();
@@ -2050,11 +2073,11 @@ export default function App() {
     if (nextActiveTabId && currentIds.includes(nextActiveTabId)) {
       const selected = tabMetas.find((tab) => tab.id === nextActiveTabId);
       setTabMetas((current) => current.map((tab) => ({ ...tab, active: tab.id === nextActiveTabId })));
-      void switchTab(nextActiveTabId, selected);
+      void enqueueTabSwitch(nextActiveTabId, selected);
     }
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
-  }, [closeTab, closeTransientOverlays, refreshTabMetas, switchTab, tabMetas]);
+  }, [closeTab, closeTransientOverlays, enqueueTabSwitch, refreshTabMetas, tabMetas]);
 
   const handleTabsReorder = useCallback(async (ids: string[]) => {
     setTabOrderIds(ids);

--- a/desktop/frontend/src/__tests__/open-topic-coalescing.test.tsx
+++ b/desktop/frontend/src/__tests__/open-topic-coalescing.test.tsx
@@ -3,7 +3,7 @@
 import { JSDOM } from "jsdom";
 import React, { act, useCallback, useRef } from "react";
 import { createRoot } from "react-dom/client";
-import { enqueueOpenTopicRequest, type PendingOpenTopicRequest } from "../lib/openTopicCoalescing";
+import { enqueueNavigationRequest, enqueueOpenTopicRequest, type PendingOpenTopicRequest } from "../lib/openTopicCoalescing";
 
 let passed = 0;
 let failed = 0;
@@ -183,6 +183,45 @@ await act(async () => {
   root.unmount();
 });
 dom.window.close();
+
+// Tab-bar switches (App.handleTabChange) route through the same scheduler so
+// rapidly clicking between two running sessions can't run switchTab()
+// concurrently — concurrent switches race the backend SetActiveTab ordering and
+// land events on the wrong session (#5352). This guards serialization (no two
+// run()s overlap) + last-click-wins.
+{
+  const refs = { seqRef: { current: 0 }, runningRef: { current: false }, pendingRef: { current: null as any } };
+  let active = 0;
+  let maxConcurrent = 0;
+  const ran: string[] = [];
+  const gates = new Map<string, ReturnType<typeof deferred<void>>>();
+  const gate = (id: string) => {
+    if (!gates.has(id)) gates.set(id, deferred<void>());
+    return gates.get(id)!;
+  };
+  const switchTab = (req: { tabId: string }) =>
+    enqueueNavigationRequest(refs, { tabId: req.tabId }, async (r) => {
+      active += 1;
+      maxConcurrent = Math.max(maxConcurrent, active);
+      await gate(r.tabId).promise;
+      ran.push(r.tabId);
+      active -= 1;
+    });
+
+  const pA = switchTab({ tabId: "A" }); // starts running
+  const pB = switchTab({ tabId: "B" }); // coalesced away (superseded while A runs)
+  const pC = switchTab({ tabId: "C" }); // latest pending
+  gate("A").resolve();
+  await pA;
+  await flushPromises();
+  gate("C").resolve();
+  await pC;
+  await pB;
+  await flushPromises();
+
+  eq(ran.join(","), "A,C", "tab switches serialize: only the running + latest run, middle coalesces");
+  eq(maxConcurrent, 1, "no two tab switches run concurrently (no backend SetActiveTab race)");
+}
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
Addresses #5352 (one of the residual races; see note below).

## Context

`#5352` is a compound desktop concurrency issue triggered by rapidly switching between two **running** sessions (symptoms: the visible composer shows another session's text, the assistant keeps streaming and never ends, the approval bar bounces). Several fixes are already merged (#5313, #5355, #5397, #5387, #5390, #5391, #5393, #5395). This PR closes one remaining gap I found while auditing the switch path.

## The gap

`#5397` unified topic / blank / sidebar-IM / resume-session navigation onto a **last-click-wins coalescing scheduler** (`lib/openTopicCoalescing.ts`). But the **tab-bar click** path — `App.handleTabChange` / `handleTabsClose` — still called `switchTab()` **directly, fire-and-forget**:

```ts
void switchTab(id, selected).then(() => refreshTabMetas());
```

`switchTab()` fires `app.SetActiveTab()` + `confirmBackendActiveTab()` asynchronously. Clicking between two running tabs quickly runs **two `switchTab()` calls concurrently**, racing the backend active-tab ordering — so events/hydration can land on the wrong session. This is a primary trigger for the "用户输入变了 / AI 不断输出" symptoms.

## Fix — unify every navigation entry point on one scheduler

Route tab switches through the same `enqueueNavigationRequest` primitive (with their own refs) so they **serialize** and **last-click-wins**, exactly like the other navigation entry points. `switchTab`'s `loadSessionDataForTab` is already seq-guarded; this serializes the backend activation around it.

## Test

Added to `open-topic-coalescing.test.tsx`: rapid A→B→C tab switches run serially (`A,C` — the middle coalesces) with **no two `run()`s overlapping** (`maxConcurrent === 1`, i.e. no concurrent `SetActiveTab`). `tsc --noEmit` clean; `app-chrome-tabs` (60), `tab-switch-hydration` (23), `new-session-load-race` (12) all green.

## Recommended follow-up (NOT in this PR — needs backend verification)

Wire events are routed by `tabId` only (`useController.ts:1156` `targetTabId = e.tabId || activeTabIdRef.current`) with **no session-generation guard**. When a controller is detached/rebound (`desktop/tabs.go` sets `sink.ctx = nil` but does not clear the already-queued emitter), its in-flight events can still land on the tab and corrupt the now-current session's transcript. Closing that window needs a session-identity/epoch stamp on wire events + a frontend drop of mismatched events (or clearing the emitter queue on detach). I left it out here because it's a backend change that should be verified against a real Windows multi-session run; happy to do it as a separate PR.

Since #5352 is compound and needs re-verification on a fresh build, this references rather than auto-closes it.
