### PR TITLE
fix(desktop): clear queued events + lock ctx on sink teardown (#5352)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1110,7 +1110,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	oldSink := tab.sink
 	if oldSink != nil {
 		oldSink.tabID = detachedRuntimeTabID(oldPath)
-		oldSink.ctx = nil
+		oldSink.clearContext()
 	}
 	if oldCtrl.RuntimeStatus().Cancellable {
 		oldCtrl.Cancel()
@@ -1150,7 +1150,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 		}
 		if oldSink != nil {
 			oldSink.tabID = tab.ID
-			oldSink.ctx = a.ctx
+			oldSink.setContext(a.ctx)
 		}
 		return err
 	}
@@ -1871,7 +1871,7 @@ func tabMatchesSession(tab *WorkspaceTab, dir, sessionPath string) bool {
 func (a *App) prepareRemovedSessionRuntimes(removed []removedSessionRuntime) error {
 	for _, item := range removed {
 		if item.sink != nil {
-			item.sink.ctx = nil
+			item.sink.clearContext()
 		}
 		if item.ctrl == nil {
 			continue

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -239,7 +239,7 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 		return false
 	}
 	if tab.sink != nil {
-		tab.sink.ctx = nil
+		tab.sink.clearContext()
 	}
 	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
@@ -299,7 +299,11 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	}
 	if detached.sink != nil {
 		detached.sink.tabID = detached.ID
-		detached.sink.ctx = nil
+		// clearContext (locked nil + drain the queued emitter), not a bare
+		// ctx=nil: the latter both data-races s.ctx and leaves already-queued
+		// events to flush onto the rebound tab after this session is backgrounded
+		// (#5352 — stale "AI 不断输出" on the now-visible session).
+		detached.sink.clearContext()
 	}
 
 	a.mu.Lock()
@@ -321,7 +325,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.
 	if source.sink != nil {
 		source.sink.tabID = target.ID
 		source.sink.app = app
-		source.sink.ctx = wailsCtx
+		source.sink.setContext(wailsCtx)
 	}
 
 	target.Ctrl = source.Ctrl

--- a/desktop/tabs_sink_context_test.go
+++ b/desktop/tabs_sink_context_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// All tabEventSink context mutations go through the locked setContext /
+// clearContext accessors (no bare s.ctx = ... writes that data-race the
+// s.context() reads in emitRuntimeEvent). After clearContext the sink stops
+// emitting — emitRuntimeEvent sees a nil ctx and no-ops — and the queued
+// emitter is drained, so a detached/backgrounded session can't flush stale
+// events onto the now-rebound tab (#5352: stale "AI 不断输出" on the visible
+// session after rapid session switching).
+func TestTabEventSinkClearContextStopsEmission(t *testing.T) {
+	var mu sync.Mutex
+	var emitted int
+	s := &tabEventSink{tabID: "t"}
+	s.runtimeEvents.emit = func(context.Context, string, ...interface{}) {
+		mu.Lock()
+		emitted++
+		mu.Unlock()
+	}
+
+	s.setContext(context.Background())
+	if s.context() == nil {
+		t.Fatal("setContext did not install the context")
+	}
+
+	s.clearContext()
+	if s.context() != nil {
+		t.Fatal("clearContext did not clear the context")
+	}
+
+	// An emit after clearContext must not reach the runtime bridge.
+	s.emitRuntimeEvent(eventChannel, toWireTab(event.Event{}, s.tabID))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if emitted != 0 {
+		t.Fatalf("sink emitted %d events after clearContext, want 0", emitted)
+	}
+}


### PR DESCRIPTION
Addresses the remaining stale-event window of #5352 (pairs with #5404).

## The gap (P0-2)

When a tab's runtime is detached for replacement — single-surface session switch (`detachRuntimeForReplacement`), controller replace, session remove — the code wrote `sink.ctx = nil` **directly**. Two problems:

1. **Data race on `s.ctx`.** `emitRuntimeEvent` reads the context through the locked `s.context()`, but these teardown sites wrote `s.ctx` without the mutex (`go test -race` territory).
2. **Queued events still flush.** `ctx = nil` only stops *new* emits (`emitRuntimeEvent` no-ops on a nil ctx); the `asyncRuntimeEmitter`'s **already-queued** events are not cleared. The detached/backgrounded controller's in-flight stream events then reach the frontend and land on the tab that has since been rebound to a different session — the **"AI 不断输出，永不结束"** on the now-visible session in #5352.

## Fix — one consistent teardown path

Route **every** sink context mutation through the locked accessors that were already used elsewhere (`tabs.go:1839/1976/2059`):

- **teardown** sites → `clearContext()` (locked nil **+** `runtimeEvents.Clear()` to drain the queue)
- **re-attach** sites → `setContext()` (locked write)

This converts all six remaining bare `sink.ctx = ...` writes onto the two accessors, so there is one consistent, race-free teardown. Since `emitRuntimeEvent` already no-ops on a nil ctx, once cleared no new events enqueue either.

| site | was | now |
|---|---|---|
| `tabs.go` detach (store) | `tab.sink.ctx = nil` | `clearContext()` |
| `tabs.go` `detachRuntimeForReplacement` | `detached.sink.ctx = nil` | `clearContext()` |
| `tabs.go` `applyRuntimeTab` (re-attach) | `source.sink.ctx = wailsCtx` | `setContext()` |
| `app.go` replace controller | `oldSink.ctx = nil` | `clearContext()` |
| `app.go` restore controller | `oldSink.ctx = a.ctx` | `setContext()` |
| `app.go` remove session runtime | `item.sink.ctx = nil` | `clearContext()` |

## Test

`TestTabEventSinkClearContextStopsEmission`: after `clearContext()` the sink reports a nil context and `emitRuntimeEvent` does not reach the runtime bridge.

## Relationship to #5404

- #5404 (merged): serialize tab-bar switches through the navigation scheduler — stops two `switchTab()` from racing the backend activation ordering.
- This PR: stops a superseded session binding's **queued** events from corrupting the rebound tab.

Together they close the two residual races I found auditing #5352. (#5352 is compound and stays open pending fresh-Windows re-verification, so this references rather than auto-closes it.)

Desktop Go can't build locally here (cgo `-arch`); relies on the CI `desktop` job for build + tests.
