### PR TITLE
fix(planmode): allow the full read-only bash command set while planning (#5341)

### DIFF
--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -1,95 +1,32 @@
 package permission
 
-import "strings"
+import (
+	"strings"
 
-// readOnlyBashCommands is the set of commands considered read-only — they
-// don't modify filesystem state, network state, or process state. Each
-// entry is the first word of a bash command (lowercased). Commands not in
-// this set that might also be read-only (e.g. "git log") are handled
-// separately by isReadOnlyBashSubject.
-var readOnlyBashCommands = map[string]bool{
-	"cat": true, "head": true, "tail": true, "less": true, "more": true,
-	"ls": true, "find": true, "locate": true, "which": true, "whereis": true, "type": true,
-	"grep": true, "egrep": true, "fgrep": true, "rg": true,
-	"echo": true, "printf": true,
-	"pwd": true, "cd": true, "whoami": true, "id": true, "uname": true, "hostname": true,
-	"date": true, "env": true, "printenv": true,
-	"wc": true, "sort": true, "uniq": true, "cut": true, "tr": true,
-	"stat": true, "file": true, "du": true, "df": true,
-	"ps": true, "top": true, "htop": true,
-	"diff": true, "cmp": true, "comm": true,
-	"man": true, "info": true, "help": true,
-	"true": true, "false": true, "test": true, "[": true,
-	"basename": true, "dirname": true, "realpath": true, "readlink": true,
-}
+	"reasonix/internal/shellsafe"
+)
 
-// readOnlyBashPrefixes are command prefixes where the second word
-// determines read-only status. Each maps to the set of read-only
-// subcommands.
-var readOnlyBashPrefixes = map[string]map[string]bool{
-	"git": {
-		"log": true, "status": true, "diff": true, "show": true,
-		"tag":   true,
-		"blame": true, "grep": true, "ls-files": true, "ls-tree": true,
-		"rev-parse": true, "rev-list": true, "describe": true, "reflog": true,
-		"shortlog": true, "whatchanged": true, "cherry": true,
-		"cat-file": true, "for-each-ref": true, "name-rev": true,
-	},
-	"go": {
-		"vet": true, "doc": true, "list": true,
-		"version": true, "env": true,
-	},
-	"npm": {
-		"ls": true, "list": true, "view": true, "info": true,
-		"outdated": true, "audit": true,
-	},
-	"cargo": {
-		"check": true, "doc": true, "search": true,
-	},
-	"docker": {
-		"ps": true, "images": true, "inspect": true, "logs": true,
-		"stats": true, "info": true, "version": true,
-	},
-	"kubectl": {
-		"get": true, "describe": true, "logs": true, "explain": true,
-		"api-resources": true, "api-versions": true,
-	},
-}
-
-// isReadOnlyBashSubject returns true when a bash command is a known
-// read-only operation. The subject is the JSON arg value extracted by
-// Subject() — for bash it is the raw command string.
+// isReadOnlyBashSubject returns true when a bash command is a known read-only
+// operation. The subject is the JSON arg value extracted by Subject() — for bash
+// it is the raw command string. Command membership comes from the shared
+// shellsafe tables (one source of truth with the plan-mode gate, #5341); the
+// argument rigor below is permission-specific.
 func isReadOnlyBashSubject(subject string) bool {
-	cmd := strings.TrimSpace(subject)
-	if cmd == "" {
+	base, sub, ok := shellsafe.CommandIsReadOnly(subject)
+	if !ok {
 		return false
 	}
-	if containsShellSyntax(cmd) {
-		return false
-	}
-	fields := strings.Fields(cmd)
-	if len(fields) == 0 {
-		return false
-	}
-	base := strings.ToLower(fields[0])
-
-	// Check single-word read-only commands.
-	if readOnlyBashCommands[base] {
+	fields := strings.Fields(strings.TrimSpace(subject))
+	if sub == "" {
 		return !hasUnsafeReadOnlyArgs(base, fields[1:])
 	}
-
-	// Check prefix commands (git log, go vet, etc.).
-	if len(fields) > 1 {
-		if sub, ok := readOnlyBashPrefixes[base]; ok {
-			subcmd := strings.ToLower(fields[1])
-			return sub[subcmd] && !hasUnsafePrefixArgs(base, subcmd, fields[2:])
-		}
-	}
-	return false
+	return !hasUnsafePrefixArgs(base, sub, fields[2:])
 }
 
+// containsShellSyntax delegates to the shared classifier; retained for the other
+// permission call sites (permission.go).
 func containsShellSyntax(cmd string) bool {
-	return strings.ContainsAny(cmd, ";|&<>\n`") || strings.Contains(cmd, "$(")
+	return shellsafe.ContainsShellSyntax(cmd)
 }
 
 func hasUnsafeReadOnlyArgs(base string, args []string) bool {

--- a/internal/planmode/policy.go
+++ b/internal/planmode/policy.go
@@ -6,7 +6,8 @@ import (
 	"sort"
 	"strings"
 	"unicode"
-	"unicode/utf8"
+
+	"reasonix/internal/shellsafe"
 )
 
 // Marker is the model-facing plan-mode instruction block. It rides in the user
@@ -105,17 +106,6 @@ var planSafeReadOnly = map[string]bool{
 	"web_fetch":   true,
 	"bash_output": true, // observes an already-running job's buffered output; no new side effect
 	"wait":        true, // observes job status; cannot start, preserve, or kill processes
-}
-
-var bashMetachars = []string{"&&", "||", ">>", "<<", "$(", "\x60", ";", "|", ">", "<", "&", "\n", "\r"}
-
-var safeBashCommands = []string{
-	"git status", "git diff", "git log", "git show",
-	"git ls-files", "git grep", "git blame",
-	"ls", "cat", "grep", "find", "head", "tail", "pwd",
-	"echo", "wc", "which", "type", "uname", "hostname",
-	"go version", "go list", "go doc", "go vet",
-	"node -v", "npm list", "python --version",
 }
 
 var findWriteArgs = map[string]bool{
@@ -314,93 +304,86 @@ func decideBash(args json.RawMessage) Decision {
 		}
 	}
 	cmd := strings.TrimSpace(p.Command)
-	lower := strings.ToLower(cmd)
 
-	for _, mc := range bashMetachars {
-		if strings.Contains(lower, mc) {
-			return Decision{
-				Blocked: true,
-				Message: fmt.Sprintf("blocked: bash command in plan mode must not contain shell operators (%q). Use separate calls for chained commands.", mc),
-			}
+	if shellsafe.ContainsShellSyntax(cmd) {
+		return Decision{
+			Blocked: true,
+			Message: "blocked: bash command in plan mode must not contain shell operators. Use separate calls for chained commands.",
 		}
 	}
 
-	for _, safe := range safeBashCommands {
-		if !bashMatchesSafePrefix(lower, safe) {
-			continue
+	base, sub, ok := shellsafe.CommandIsReadOnly(cmd)
+	if !ok {
+		return Decision{
+			Blocked: true,
+			Message: fmt.Sprintf("blocked: bash commands in plan mode must be read-only. %q is not a known read-only command. Use read-only tools for exploration, then exit plan mode to run this command.", cmd),
 		}
-		arg, err := unsafeSafeCommandArg(cmd, safe)
-		if err != "" {
-			return Decision{
-				Blocked: true,
-				Message: fmt.Sprintf("blocked: bash command in plan mode has malformed shell quoting (%s). Use a simple read-only command while planning.", err),
-			}
-		}
-		if arg != "" {
-			return Decision{
-				Blocked: true,
-				Message: fmt.Sprintf("blocked: bash command in plan mode uses a write-capable argument (%q). Use a read-only command while planning.", arg),
-			}
-		}
-		return Decision{}
 	}
-
-	return Decision{
-		Blocked: true,
-		Message: fmt.Sprintf("blocked: bash commands in plan mode must be read-only. %q is not in the safe command list. Use read-only tools for exploration, then exit plan mode to run this command.", cmd),
+	if arg, malformed := unsafePlanModeArg(cmd, base, sub); malformed != "" {
+		return Decision{
+			Blocked: true,
+			Message: fmt.Sprintf("blocked: bash command in plan mode has malformed shell quoting (%s). Use a simple read-only command while planning.", malformed),
+		}
+	} else if arg != "" {
+		return Decision{
+			Blocked: true,
+			Message: fmt.Sprintf("blocked: bash command in plan mode uses a write-capable argument (%q). Use a read-only command while planning.", arg),
+		}
 	}
+	return Decision{}
 }
 
-func bashMatchesSafePrefix(lower, safe string) bool {
-	if !strings.HasPrefix(lower, safe) {
-		return false
-	}
-	if len(lower) == len(safe) {
-		return true
-	}
-	r, _ := utf8.DecodeRuneInString(lower[len(safe):])
-	return unicode.IsSpace(r)
-}
-
-func unsafeSafeCommandArg(cmd, safe string) (string, string) {
+// unsafePlanModeArg applies plan-mode's stricter, quote-aware argument check on
+// top of the shared read-only command classification: a write-capable flag on
+// an otherwise read-only command (git --output, git grep --open-files-in-pager,
+// find -exec, go list -mod=mod, …) is refused while planning even though the
+// base command is read-only. Returns the offending arg, or a malformed-quoting
+// description. Plan mode is intentionally stricter here than permission's
+// auto-approve arg check.
+func unsafePlanModeArg(cmd, base, sub string) (arg, malformed string) {
 	fields, err := shellFields(cmd)
 	if err != "" {
 		return "", err
 	}
-	base := strings.Fields(safe)
-	if len(fields) <= len(base) {
+	skip := 1
+	if sub != "" {
+		skip = 2
+	}
+	if len(fields) <= skip {
 		return "", ""
 	}
-	args := fields[len(base):]
+	args := fields[skip:]
 	lowerArgs := make([]string, len(args))
-	for i, arg := range args {
-		lowerArgs[i] = strings.ToLower(arg)
+	for i, a := range args {
+		lowerArgs[i] = strings.ToLower(a)
 	}
-	if strings.HasPrefix(safe, "git ") {
-		for _, arg := range lowerArgs {
-			if arg == "--output" || strings.HasPrefix(arg, "--output=") || arg == "--ext-diff" {
-				return arg, ""
+	switch base {
+	case "git":
+		for i, la := range lowerArgs {
+			if la == "--output" || strings.HasPrefix(la, "--output=") || la == "--ext-diff" {
+				return args[i], ""
 			}
 		}
-	}
-	switch safe {
-	case "git grep":
-		for i, arg := range args {
-			lowerArg := lowerArgs[i]
-			if arg == "-O" || strings.HasPrefix(arg, "-O") || strings.HasPrefix(lowerArg, "--open-files-in-pager") {
-				return arg, ""
+		if sub == "grep" {
+			for i, a := range args {
+				la := lowerArgs[i]
+				if a == "-O" || strings.HasPrefix(a, "-O") || strings.HasPrefix(la, "--open-files-in-pager") {
+					return a, ""
+				}
 			}
 		}
 	case "find":
-		for _, arg := range lowerArgs {
-			if findWriteArgs[arg] {
-				return arg, ""
+		for i, la := range lowerArgs {
+			if findWriteArgs[la] {
+				return args[i], ""
 			}
 		}
-	case "go list", "go vet":
-		for _, arg := range lowerArgs {
-			if goWriteOrExecArgs[arg] || strings.HasPrefix(arg, "-mod=mod") || strings.HasPrefix(arg, "-modfile=") || strings.HasPrefix(arg, "-toolexec=") || strings.HasPrefix(arg, "-vettool=") {
-				return arg, ""
+	case "go":
+		if sub == "list" || sub == "vet" {
+			for i, la := range lowerArgs {
+				if goWriteOrExecArgs[la] || strings.HasPrefix(la, "-mod=mod") || strings.HasPrefix(la, "-modfile=") || strings.HasPrefix(la, "-toolexec=") || strings.HasPrefix(la, "-vettool=") {
+					return args[i], ""
+				}
 			}
 		}
 	}

--- a/internal/planmode/policy_test.go
+++ b/internal/planmode/policy_test.go
@@ -225,3 +225,39 @@ func TestDecideUntrustedReadOnlyFailsClosedThenOverride(t *testing.T) {
 		t.Fatalf("a trusted read-only tool should be allowed: %s", d.Message)
 	}
 }
+
+// TestPlanModeAllowsSharedReadOnlyBashSet is the #5341 regression: plan mode now
+// classifies bash commands against the same shellsafe table the permission
+// auto-approve path uses, so read-only git/tooling commands beyond the old
+// status/diff/log/show short list are runnable while planning. Write-capable
+// commands and write-capable args remain blocked.
+func TestPlanModeAllowsSharedReadOnlyBashSet(t *testing.T) {
+	bash := func(cmd string) Call {
+		args, err := json.Marshal(map[string]any{"command": cmd})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return Call{Name: "bash", Args: args}
+	}
+
+	for _, cmd := range []string{
+		"git rev-parse --abbrev-ref HEAD", "git describe --tags", "git reflog",
+		"git for-each-ref", "git cat-file -p HEAD", "git ls-tree HEAD",
+		"go env", "npm view react version", "docker ps", "kubectl get pods",
+	} {
+		if d := (Policy{}).Decide(bash(cmd)); d.Blocked {
+			t.Errorf("plan mode blocked read-only %q: %s", cmd, d.Message)
+		}
+	}
+
+	for _, cmd := range []string{
+		"git checkout main", "git commit -m x", "git branch -d feature",
+		"go build ./...", "npm install",
+		"git status && rm -rf /", "git status > out.txt",
+		"git grep foo --open-files-in-pager=sh", "go list ./... -mod=mod",
+	} {
+		if d := (Policy{}).Decide(bash(cmd)); !d.Blocked {
+			t.Errorf("plan mode allowed unsafe %q", cmd)
+		}
+	}
+}

--- a/internal/shellsafe/shellsafe.go
+++ b/internal/shellsafe/shellsafe.go
@@ -1,0 +1,104 @@
+// Package shellsafe is the single source of truth for which shell commands are
+// read-only — they don't modify filesystem, network, or process state. Both the
+// permission auto-approve path (internal/permission) and the plan-mode gate
+// (internal/planmode) classify command membership against these tables, so the
+// two can't drift (the drift was #5341: a git subcommand auto-approved by
+// permission yet blocked while planning). Each consumer still layers its own
+// argument-rigor on top — plan mode is intentionally stricter than auto-approve.
+package shellsafe
+
+import "strings"
+
+// ReadOnlyCommands holds single-word commands whose base name alone implies a
+// read-only operation. The first word of a command (lowercased) is looked up
+// here. Commands that are read-only only for certain subcommands (e.g. git) are
+// in ReadOnlyPrefixes.
+var ReadOnlyCommands = map[string]bool{
+	"cat": true, "head": true, "tail": true, "less": true, "more": true,
+	"ls": true, "find": true, "locate": true, "which": true, "whereis": true, "type": true,
+	"grep": true, "egrep": true, "fgrep": true, "rg": true,
+	"echo": true, "printf": true,
+	"pwd": true, "cd": true, "whoami": true, "id": true, "uname": true, "hostname": true,
+	"date": true, "env": true, "printenv": true,
+	"wc": true, "sort": true, "uniq": true, "cut": true, "tr": true,
+	"stat": true, "file": true, "du": true, "df": true,
+	"ps": true, "top": true, "htop": true,
+	"diff": true, "cmp": true, "comm": true,
+	"man": true, "info": true, "help": true,
+	"true": true, "false": true, "test": true, "[": true,
+	"basename": true, "dirname": true, "realpath": true, "readlink": true,
+}
+
+// ReadOnlyPrefixes maps a base command to the set of subcommands (the second
+// word) that are read-only. A subcommand not listed here is treated as not
+// read-only (fail-closed): write-capable subcommands (git branch/remote/config,
+// go build/test, npm install, …) are deliberately absent.
+var ReadOnlyPrefixes = map[string]map[string]bool{
+	"git": {
+		"log": true, "status": true, "diff": true, "show": true,
+		"tag":   true,
+		"blame": true, "grep": true, "ls-files": true, "ls-tree": true,
+		"rev-parse": true, "rev-list": true, "describe": true, "reflog": true,
+		"shortlog": true, "whatchanged": true, "cherry": true,
+		"cat-file": true, "for-each-ref": true, "name-rev": true,
+	},
+	"go": {
+		"vet": true, "doc": true, "list": true,
+		"version": true, "env": true,
+	},
+	"npm": {
+		"ls": true, "list": true, "view": true, "info": true,
+		"outdated": true, "audit": true,
+	},
+	"cargo": {
+		"check": true, "doc": true, "search": true,
+	},
+	"docker": {
+		"ps": true, "images": true, "inspect": true, "logs": true,
+		"stats": true, "info": true, "version": true,
+	},
+	"kubectl": {
+		"get": true, "describe": true, "logs": true, "explain": true,
+		"api-resources": true, "api-versions": true,
+	},
+	// Version/help probes for common runtimes (the second word is a flag).
+	"node":    {"-v": true, "--version": true},
+	"python":  {"--version": true, "-v": true, "-V": true},
+	"python3": {"--version": true, "-v": true, "-V": true},
+}
+
+// ContainsShellSyntax reports whether a command uses shell operators or
+// substitution — chaining/redirection/expansion can smuggle a write past a
+// read-only base-word check, so any such command is treated as not read-only.
+func ContainsShellSyntax(cmd string) bool {
+	return strings.ContainsAny(cmd, ";|&<>\n\r`") || strings.Contains(cmd, "$(")
+}
+
+// CommandIsReadOnly reports whether the command's base/subcommand is in the
+// read-only tables, ignoring argument rigor (which each consumer applies). It
+// returns the base and subcommand so callers can run their own arg checks.
+// ok is false when the command contains shell syntax or the base/subcommand is
+// not a known read-only operation.
+func CommandIsReadOnly(command string) (base, sub string, ok bool) {
+	cmd := strings.TrimSpace(command)
+	if cmd == "" || ContainsShellSyntax(cmd) {
+		return "", "", false
+	}
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return "", "", false
+	}
+	base = strings.ToLower(fields[0])
+	if ReadOnlyCommands[base] {
+		return base, "", true
+	}
+	if len(fields) > 1 {
+		if subs, prefixed := ReadOnlyPrefixes[base]; prefixed {
+			sub = strings.ToLower(fields[1])
+			if subs[sub] {
+				return base, sub, true
+			}
+		}
+	}
+	return "", "", false
+}

--- a/internal/shellsafe/shellsafe_test.go
+++ b/internal/shellsafe/shellsafe_test.go
@@ -1,0 +1,56 @@
+package shellsafe
+
+import "testing"
+
+func TestCommandIsReadOnly(t *testing.T) {
+	readOnly := []string{
+		// git read-only subcommands (the #5341 set, beyond status/diff/log/show).
+		"git status", "git diff HEAD", "git log --oneline", "git show",
+		"git rev-parse HEAD", "git describe --tags", "git reflog",
+		"git for-each-ref", "git cat-file -p HEAD", "git ls-tree HEAD",
+		"git rev-list --count HEAD", "git shortlog", "git name-rev HEAD",
+		// general read-only commands.
+		"ls -la", "cat go.mod", "grep -r foo .", "pwd", "head -n5 x", "stat x", "du -sh .",
+		// tooling probes.
+		"go version", "go env", "go list ./...", "go doc fmt",
+		"npm view react version", "npm outdated", "cargo check",
+		"docker ps", "docker images", "kubectl get pods",
+		"node -v", "node --version", "python --version", "python3 --version",
+	}
+	for _, c := range readOnly {
+		if _, _, ok := CommandIsReadOnly(c); !ok {
+			t.Errorf("CommandIsReadOnly(%q) = false, want true", c)
+		}
+	}
+
+	notReadOnly := []string{
+		// write-capable commands / subcommands.
+		"rm -rf /", "git push", "git commit -m x", "git checkout main",
+		"git reset --hard", "git branch -d feature", "git remote add o url",
+		"go build ./...", "go test ./...", "npm install", "docker rm x",
+		"kubectl apply -f x.yaml", "mv a b", "chmod 777 x",
+		// shell syntax can smuggle a write past a read-only base word.
+		"git status && rm -rf /", "cat a | tee b", "echo $(rm x)",
+		"git status > out.txt", "ls; rm x", "git log `whoami`",
+		// unknown command.
+		"frobnicate --all",
+	}
+	for _, c := range notReadOnly {
+		if _, _, ok := CommandIsReadOnly(c); ok {
+			t.Errorf("CommandIsReadOnly(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestContainsShellSyntax(t *testing.T) {
+	for _, c := range []string{"a && b", "a || b", "a | b", "a; b", "a > f", "a < f", "a & ", "$(x)", "`x`", "a\nb"} {
+		if !ContainsShellSyntax(c) {
+			t.Errorf("ContainsShellSyntax(%q) = false, want true", c)
+		}
+	}
+	for _, c := range []string{"git status", "ls -la", "grep foo bar.go"} {
+		if ContainsShellSyntax(c) {
+			t.Errorf("ContainsShellSyntax(%q) = true, want false", c)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5341.

## The problem

In plan mode the model could run only a short hard-coded bash allowlist — `git status/diff/log/show`, `ls`, `cat`, `grep`, a few `go`/`npm` probes. So read-only git commands the user needs to gather planning info — `git rev-parse`, `git describe`, `git reflog`, `git for-each-ref`, `git cat-file`, `git ls-tree`, plus `go env`, `npm view`, `docker ps`, `kubectl get`, … — were **blocked**, even though the permission auto-approve path already trusts them as read-only.

Root cause: **two independent read-only command tables had drifted** — `planmode.safeBashCommands` (a small slice) vs `permission`'s `readOnlyBashCommands` / `readOnlyBashPrefixes` (the comprehensive, audited set).

## Fix — one source of truth

New `internal/shellsafe` package holds the **canonical** read-only command/prefix tables + the shell-syntax guard (`ContainsShellSyntax`). Both the permission auto-approve path and the plan-mode gate classify command membership against it, so they can't drift again.

Each consumer keeps its own **argument** rigor layered on top — and that's deliberate: **plan mode stays stricter than auto-approve**. It still refuses, while planning:
- write-capable args on a read-only base: `git --output`, `git grep --open-files-in-pager`, `find -exec`, `go list -mod=mod`
- any shell operators / chaining (`&&`, `|`, `>`, `$(…)`, backticks)
- background execution / process preservation

So this **widens the read-only command set without weakening either gate's write-arg checks**. The only auto-approve change is that permission now also treats `node -v` / `python --version` as read-only (both side-effect-free) — the safe direction.

## Tests

- `internal/shellsafe`: classifier table — read-only git/tooling commands true; write subcommands, shell-syntax-smuggled writes (`git status && rm -rf /`), and unknown commands false.
- `internal/planmode` `TestPlanModeAllowsSharedReadOnlyBashSet`: the #5341 git/tooling set is allowed while planning; write-capable commands, shell operators, and write-capable args stay blocked.
- All existing `permission` / `planmode` tests pass unchanged (the prior quoted-write-arg cases still block).
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/...` green (57 packages).

## Note on the cluster

This is the read-only-bash policy piece of the plan-mode issue cluster. #5385 (approved plan not executed) was already fixed by #5391; #5354 (plan UI race on session switch) overlaps the #5352 race work (#5404/#5406) and needs fresh re-verification.
