### PR TITLE
Fix desktop session hydration latency / 修复桌面会话加载延迟

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3094,9 +3094,25 @@ func (a *App) History() []HistoryMessage {
 }
 
 func (a *App) HistoryForTab(tabID string) []HistoryMessage {
-	ctrl := a.ctrlByTabID(tabID)
+	a.mu.RLock()
+	tab := a.tabByIDLocked(tabID)
+	var ctrl control.SessionAPI
+	var sessionDir, sessionPath string
+	if tab != nil {
+		ctrl = tab.Ctrl
+		sessionDir = tabSessionDir(tab)
+		sessionPath = tab.currentSessionPath()
+	}
+	a.mu.RUnlock()
 	if ctrl == nil {
-		return []HistoryMessage{}
+		if strings.TrimSpace(sessionPath) == "" {
+			return []HistoryMessage{}
+		}
+		messages, err := previewSessionMessages(sessionDir, sessionPath)
+		if err != nil {
+			return []HistoryMessage{}
+		}
+		return messages
 	}
 	msgs := ctrl.History()
 	dir := controllerSessionDir(ctrl)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2386,10 +2386,6 @@ export default function App() {
           ? t("history.failedOpenSession")
           : (session.topicId ? "Missing workspaceRoot" : t("history.failedOpenSession")));
       }
-      if (!isChannelSession(session) && !singleSurfaceLayout) {
-        if (!latest()) return;
-        await resumeSession(session.path, targetTab.id);
-      }
       if (!latest()) return;
       seedActiveTabMeta(targetTab);
       setHistView(null);

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -219,6 +219,11 @@ ok(
 );
 
 ok(
+  !/await resumeSession\(session\.path, targetTab\.id\);/.test(navigationBlock),
+  "history navigation does not re-resume a session that OpenTopicSession already pinned",
+);
+
+ok(
   /<HeartbeatPanel[\s\S]*onOpenTopic=\{\(scope, workspaceRoot, topicId\) => \{[\s\S]*void handleOpenTopic\(scope, workspaceRoot, topicId\);[\s\S]*\}\}/.test(appSource),
   "heartbeat topic navigation uses the guarded open-topic path",
 );

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -182,6 +182,35 @@ func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	}
 }
 
+func TestHistoryForTabUsesPinnedSessionBeforeControllerReady(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "pending-controller.jsonl")
+	writeHistoryTestSession(t, path, "warm prompt")
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:            "pending",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   path,
+		Ready:         false,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	got := app.HistoryForTab(tab.ID)
+	if len(got) != 1 || got[0].Role != "user" || got[0].Content != "warm prompt" {
+		t.Fatalf("pending controller history = %+v, want warm prompt", got)
+	}
+}
+
 func historyMemoryCompilerContract(t *testing.T, sourceEvent string) string {
 	t.Helper()
 	body, err := json.Marshal(map[string]any{

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -495,6 +495,13 @@ type Client struct {
 	resources []Resource
 	toolsMu   sync.Mutex
 	tools     []ToolInfo
+
+	// toolAdapters caches the model-visible remote tool adapters produced by
+	// the first successful tools/list call. Shared hosts reuse Client instances
+	// across controllers, so subsequent ToolsFor calls must not re-query slow
+	// MCP servers just to rebuild identical schemas.
+	toolsListed  bool
+	toolAdapters []tool.Tool
 }
 
 func (c *Client) auxiliaryClient(ctx context.Context) (*Client, context.Context, context.CancelFunc, error) {
@@ -541,8 +548,10 @@ func (h *Host) Servers() []ServerStatus {
 			Name:      c.name,
 			Transport: c.transport,
 			Tools:     c.toolCount,
-			ToolList:  append([]ToolInfo(nil), c.tools...),
 		}
+		c.toolsMu.Lock()
+		s.ToolList = append([]ToolInfo(nil), c.tools...)
+		c.toolsMu.Unlock()
 		for _, p := range h.prompts {
 			if p.Server == c.name {
 				s.Prompts++
@@ -721,6 +730,9 @@ func (h *Host) ToolsFor(ctx context.Context, name string) ([]tool.Tool, error) {
 	c := h.client(name)
 	if c == nil {
 		return nil, fmt.Errorf("client %q not found on shared host", name)
+	}
+	if tools, ok := c.cachedTools(); ok {
+		return tools, nil
 	}
 	return c.listTools(ctx)
 }
@@ -1016,6 +1028,9 @@ func (s Spec) toolReadOnlyTrusted(rawName, visibleName string) bool {
 func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	c.toolsMu.Lock()
 	defer c.toolsMu.Unlock()
+	if c.toolsListed {
+		return append([]tool.Tool(nil), c.toolAdapters...), nil
+	}
 
 	res, err := c.call(ctx, "tools/list", map[string]any{})
 	if err != nil {
@@ -1049,8 +1064,20 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 		})
 	}
 	sort.SliceStable(toolInfos, func(i, j int) bool { return toolInfos[i].Name < toolInfos[j].Name })
+	sortedTools := sortToolsByName(tools)
 	c.tools = toolInfos
-	return sortToolsByName(tools), nil
+	c.toolAdapters = append([]tool.Tool(nil), sortedTools...)
+	c.toolsListed = true
+	return append([]tool.Tool(nil), sortedTools...), nil
+}
+
+func (c *Client) cachedTools() ([]tool.Tool, bool) {
+	c.toolsMu.Lock()
+	defer c.toolsMu.Unlock()
+	if !c.toolsListed {
+		return nil, false
+	}
+	return append([]tool.Tool(nil), c.toolAdapters...), true
 }
 
 // toolName builds the model-visible namespaced name "mcp__<server>__<tool>",

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -9,12 +9,43 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
+
+type countingToolsTransport struct {
+	mu    sync.Mutex
+	calls int
+	raw   json.RawMessage
+}
+
+func (t *countingToolsTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if method != "tools/list" {
+		return json.RawMessage(`{}`), nil
+	}
+	t.mu.Lock()
+	t.calls++
+	t.mu.Unlock()
+	if len(t.raw) > 0 {
+		return t.raw, nil
+	}
+	return json.RawMessage(`{"tools":[{"name":"zed","description":"Sorted after echo.","inputSchema":{"type":"object"}},{"name":"echo","description":"Echo back the message.","inputSchema":{"type":"object","properties":{"msg":{"type":"string"}},"required":["z","msg"]},"annotations":{"readOnlyHint":true}}]}`), nil
+}
+
+func (t *countingToolsTransport) notify(ctx context.Context, method string, params any) error {
+	return nil
+}
+func (t *countingToolsTransport) close() {}
+
+func (t *countingToolsTransport) toolsListCalls() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
 // helper mode) through the full MCP handshake and a tool call, exercising
@@ -52,6 +83,83 @@ func TestStdioEndToEnd(t *testing.T) {
 	}
 	if out != "echo: hi" {
 		t.Fatalf("result: want %q, got %q", "echo: hi", out)
+	}
+}
+
+func TestHostToolsForReusesCachedTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tr := &countingToolsTransport{}
+	host := NewHost()
+	defer host.Close()
+	host.clients = []*Client{{
+		name:      "mock",
+		t:         tr,
+		spec:      Spec{Name: "mock"},
+		transport: "stdio",
+	}}
+
+	first, err := host.ToolsFor(ctx, "mock")
+	if err != nil {
+		t.Fatalf("first ToolsFor: %v", err)
+	}
+	second, err := host.ToolsFor(ctx, "mock")
+	if err != nil {
+		t.Fatalf("second ToolsFor: %v", err)
+	}
+	if got := tr.toolsListCalls(); got != 1 {
+		t.Fatalf("tools/list calls = %d, want 1", got)
+	}
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("ToolsFor lengths = %d and %d, want 2 each", len(first), len(second))
+	}
+	if got := first[0].Name(); got != "mcp__mock__echo" {
+		t.Fatalf("first tool name = %q, want sorted echo first", got)
+	}
+	if got, want := string(second[0].Schema()), string(first[0].Schema()); got != want {
+		t.Fatalf("cached schema changed:\n first=%s\nsecond=%s", want, got)
+	}
+	if !second[0].ReadOnly() {
+		t.Fatal("cached tool lost readOnlyHint")
+	}
+
+	statuses := host.Servers()
+	if len(statuses) != 1 || len(statuses[0].ToolList) != 2 {
+		t.Fatalf("server tool status = %+v, want cached tool metadata", statuses)
+	}
+	if statuses[0].ToolList[0].Name != "echo" || !statuses[0].ToolList[0].ReadOnlyHint {
+		t.Fatalf("tool metadata = %+v, want sorted echo with readOnlyHint", statuses[0].ToolList)
+	}
+}
+
+func TestHostToolsForCachesEmptyToolList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tr := &countingToolsTransport{raw: json.RawMessage(`{"tools":[]}`)}
+	host := NewHost()
+	defer host.Close()
+	host.clients = []*Client{{
+		name:      "empty",
+		t:         tr,
+		spec:      Spec{Name: "empty"},
+		transport: "stdio",
+	}}
+
+	first, err := host.ToolsFor(ctx, "empty")
+	if err != nil {
+		t.Fatalf("first ToolsFor: %v", err)
+	}
+	second, err := host.ToolsFor(ctx, "empty")
+	if err != nil {
+		t.Fatalf("second ToolsFor: %v", err)
+	}
+	if len(first) != 0 || len(second) != 0 {
+		t.Fatalf("ToolsFor lengths = %d and %d, want 0 each", len(first), len(second))
+	}
+	if got := tr.toolsListCalls(); got != 1 {
+		t.Fatalf("empty tools/list calls = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preview the pinned session transcript while a newly opened desktop tab is still waiting for its controller, so history navigation does not briefly render the empty Welcome state.
- Avoid re-running `ResumeSessionForTab` after `OpenTopicSession` already pins the selected history session.
- Reuse the first successful MCP `tools/list` adapters on a shared host, preventing repeated list calls during controller rebuilds while preserving model-visible tool metadata.

## Related
- Refs #5248
- Refs #5224
- Refs #5404

## Cache impact
Cache-impact: low - Reuses already discovered MCP tool adapters per connected client; provider-visible tool names, descriptions, schema bytes, read-only flags, and sorting are preserved.
Cache-guard: `go test -race ./internal/plugin -run 'TestHostToolsFor(ReusesCachedTools|CachesEmptyToolList)' -count=1` plus `go test ./internal/plugin -count=1`

The MCP change caches the first successful `tools/list` result per connected client and returns copied slices to callers. Regression coverage checks cached schema/read-only retention and empty tool-list caching.

## Verification
- `go test . -run 'TestHistoryForTab(UsesPinnedSessionBeforeControllerReady|RestoresPlannerDisplayAfterReload)|TestRebindTabToLoadedSessionReusesPreloadedTranscript' -count=1` in the desktop module
- `npm exec -- tsx src/__tests__/app-chrome-tabs.test.ts`
- `npm exec -- tsx src/__tests__/tab-switch-hydration.test.tsx`
- `npm exec -- tsx src/__tests__/new-session-load-race.test.tsx`
- `npm exec -- tsx src/__tests__/transcript-grouping.test.ts`
- `go test -race ./internal/plugin -run 'TestHostToolsFor(ReusesCachedTools|CachesEmptyToolList)' -count=1`
- `go test ./internal/plugin -count=1`
- `go test ./... -count=1`
- `git diff --check origin/main-v2...HEAD`
