### PR TITLE
feat(accounts): email/password account service worker (id.reasonix.io)

### DIFF
--- a/workers/accounts/.gitignore
+++ b/workers/accounts/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+dist/
+# Local-only secrets for `wrangler dev` (RESEND_API_KEY, SESSION_PEPPER, ...)
+.dev.vars

--- a/workers/accounts/README.md
+++ b/workers/accounts/README.md
@@ -1,0 +1,90 @@
+# reasonix-accounts
+
+The account service for `reasonix.io`: email/password sign-up, email verification,
+sessions, password reset, and public profiles. A Cloudflare Worker (Hono) backed
+by D1. Runs at `id.reasonix.io`, separate from the internal crash dashboard.
+
+This is the backend API only — there are no HTML pages. The web frontend (and,
+later, the desktop/CLI) call these JSON endpoints.
+
+## Architecture
+
+```
+src/
+  index.ts            entry — exports the Hono app as the fetch handler
+  app.ts              middleware + route wiring
+  env.ts  types.ts  config.ts
+  auth/   crypto.ts (PBKDF2 + token hashing)  cookies.ts (session cookie)
+  db/     users.ts  sessions.ts  emailTokens.ts  index.ts (repos factory)
+  email/  index.ts (Mailer + templates)  resend.ts  types.ts
+  http/   errors.ts  cors.ts  auth.ts (session middleware)  ratelimit.ts
+  lib/    validation.ts (zod)  handle.ts
+  routes/ auth.ts  me.ts  users.ts  health.ts
+```
+
+Design notes:
+
+- **Sessions store `sha256(pepper:token)`** — the raw token only ever lives in the
+  cookie, so a DB read can't resurrect a live session. `sessions.kind` (`web`/`cli`)
+  is reserved so the future desktop/CLI device-flow login reuses this table.
+- **`password_hash` is nullable** on `users` so OAuth-only identities can be added
+  later without a rebuild.
+- **Registration is enumeration-safe**: the response never reveals whether an email
+  already exists; login/forgot return generic messages too.
+- **PBKDF2-HMAC-SHA256, 100k iterations** — the work factor is embedded in each
+  hash. 100k is Cloudflare Workers' hard cap for PBKDF2 (it rejects higher counts).
+
+## Endpoints
+
+| Method | Path                       | Auth | Notes                                   |
+| ------ | -------------------------- | ---- | --------------------------------------- |
+| POST   | `/auth/register`           | —    | `{ email, password, displayName? }`     |
+| GET    | `/auth/verify?token=`      | —    | email link → 302 to `APP_ORIGIN/login`  |
+| POST   | `/auth/login`              | —    | sets `rxid` cookie, returns `{ user }`  |
+| POST   | `/auth/logout`             | —    | clears session + cookie                 |
+| POST   | `/auth/forgot`             | —    | `{ email }` → reset link                |
+| POST   | `/auth/reset`              | —    | `{ token, password }`                    |
+| POST   | `/auth/resend-verification`| —    | `{ email }`                              |
+| GET    | `/me`                      | ✓    | the signed-in account                   |
+| PATCH  | `/me`                      | ✓    | `{ displayName?, bio?, avatarUrl?, handle? }` |
+| POST   | `/me/password`             | ✓    | `{ currentPassword, newPassword }`      |
+| DELETE | `/me`                      | ✓    | soft-delete the account                 |
+| GET    | `/u/:handle`               | —    | public profile                          |
+| GET    | `/health`                  | —    | liveness                                |
+
+Errors are `{ "error": { "code": "...", "message": "..." } }` with a matching HTTP status.
+
+## Configuration
+
+`wrangler.toml` `[vars]` (non-secret): `APP_ORIGIN`, `ALLOWED_ORIGINS`,
+`COOKIE_DOMAIN`, `EMAIL_PROVIDER` (`stub` | `resend`), `MAIL_FROM`, `ADMIN_EMAILS`.
+
+Secrets (`wrangler secret put NAME`): `SESSION_PEPPER` (any long random string),
+`RESEND_API_KEY` (only when `EMAIL_PROVIDER=resend`).
+
+When `EMAIL_PROVIDER` isn't `resend` (or no key is set) the worker logs email links
+to the console — enough to exercise every flow locally without a mail provider.
+
+## Local development
+
+```sh
+pnpm install
+pnpm db:apply:local                 # create local D1 tables
+pnpm dev                            # wrangler dev on http://localhost:8787
+```
+
+Put local secrets in `.dev.vars` (git-ignored), e.g. `SESSION_PEPPER="dev-pepper"`.
+Register a user, then read the verification link from the `wrangler dev` console.
+
+## Deploy
+
+```sh
+wrangler d1 create reasonix-accounts        # paste database_id into wrangler.toml
+wrangler d1 migrations apply reasonix-accounts --remote
+wrangler secret put SESSION_PEPPER
+wrangler secret put RESEND_API_KEY          # if EMAIL_PROVIDER=resend
+wrangler deploy
+```
+
+The `id.reasonix.io` custom domain route is declared in `wrangler.toml`; point the
+DNS/custom-domain binding at this worker in the Cloudflare dashboard on first deploy.

--- a/workers/accounts/migrations/0001_initial.sql
+++ b/workers/accounts/migrations/0001_initial.sql
@@ -1,0 +1,43 @@
+-- Reasonix accounts: users, sessions, email tokens.
+-- Apply: wrangler d1 migrations apply reasonix-accounts --local   (or --remote)
+
+CREATE TABLE IF NOT EXISTS users (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  handle         TEXT    NOT NULL UNIQUE,        -- public identity, /u/<handle>
+  email          TEXT    NOT NULL UNIQUE,        -- stored lowercased
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  password_hash  TEXT,                            -- nullable: reserved for future OAuth-only users
+  display_name   TEXT    NOT NULL DEFAULT '',
+  avatar_url     TEXT    NOT NULL DEFAULT '',
+  bio            TEXT    NOT NULL DEFAULT '',
+  role           TEXT    NOT NULL DEFAULT 'member',  -- member | admin
+  status         TEXT    NOT NULL DEFAULT 'active',  -- active | suspended | deleted
+  created_at     TEXT    NOT NULL,
+  updated_at     TEXT    NOT NULL
+);
+
+-- Sessions store sha256(raw cookie token); the raw token only ever lives in the
+-- cookie, so a DB read can't resurrect a live session. `kind` is reserved so the
+-- future desktop/CLI device-flow login reuses this same table.
+CREATE TABLE IF NOT EXISTS sessions (
+  token_hash   TEXT    PRIMARY KEY,
+  user_id      INTEGER NOT NULL,
+  kind         TEXT    NOT NULL DEFAULT 'web',    -- web | cli
+  user_agent   TEXT    NOT NULL DEFAULT '',
+  created_at   TEXT    NOT NULL,
+  last_seen_at TEXT    NOT NULL,
+  expires_at   TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS sessions_user ON sessions (user_id);
+CREATE INDEX IF NOT EXISTS sessions_expires ON sessions (expires_at);
+
+-- Single-use, hashed tokens for email verification and password reset.
+CREATE TABLE IF NOT EXISTS email_tokens (
+  token_hash TEXT    PRIMARY KEY,
+  user_id    INTEGER NOT NULL,
+  purpose    TEXT    NOT NULL,                    -- verify | reset
+  created_at TEXT    NOT NULL,
+  expires_at TEXT    NOT NULL,
+  used_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS email_tokens_user ON email_tokens (user_id);

--- a/workers/accounts/package.json
+++ b/workers/accounts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "reasonix-accounts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "db:apply:local": "wrangler d1 migrations apply reasonix-accounts --local",
+    "db:apply:remote": "wrangler d1 migrations apply reasonix-accounts --remote"
+  },
+  "dependencies": {
+    "hono": "^4.6.14",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260601.0",
+    "typescript": "^5.8.0",
+    "wrangler": "^4.102.0"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
+  }
+}

--- a/workers/accounts/pnpm-lock.yaml
+++ b/workers/accounts/pnpm-lock.yaml
@@ -1,0 +1,906 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.27
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260601.0
+        version: 4.20260627.1
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.102.0
+        version: 4.105.0(@cloudflare/workers-types@4.20260627.1)
+
+packages:
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260625.1':
+    resolution: {integrity: sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260625.1':
+    resolution: {integrity: sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260625.1':
+    resolution: {integrity: sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260625.1':
+    resolution: {integrity: sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260625.1':
+    resolution: {integrity: sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260627.1':
+    resolution: {integrity: sha512-QhVvier1eW9Ydw96N/Ez79i5CSGy7h39JucrUejQmAWQw9qBdlB1aOTjaD93EGYrV0t9U81YWetI3LcaxxILNw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  miniflare@4.20260625.0:
+    resolution: {integrity: sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  workerd@1.20260625.1:
+    resolution: {integrity: sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.105.0:
+    resolution: {integrity: sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260625.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260625.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260625.1
+
+  '@cloudflare/workerd-darwin-64@1.20260625.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260625.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260625.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260625.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260625.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260627.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
+
+  blake3-wasm@2.1.5: {}
+
+  cookie@1.1.1: {}
+
+  detect-libc@2.1.2: {}
+
+  error-stack-parser-es@1.0.5: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  hono@4.12.27: {}
+
+  kleur@4.1.5: {}
+
+  miniflare@4.20260625.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260625.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  semver@7.8.5: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  supports-color@10.2.2: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  workerd@1.20260625.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260625.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260625.1
+      '@cloudflare/workerd-linux-64': 1.20260625.1
+      '@cloudflare/workerd-linux-arm64': 1.20260625.1
+      '@cloudflare/workerd-windows-64': 1.20260625.1
+
+  wrangler@4.105.0(@cloudflare/workers-types@4.20260627.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260625.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260625.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260625.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260627.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.21.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
+
+  zod@3.25.76: {}

--- a/workers/accounts/src/app.ts
+++ b/workers/accounts/src/app.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+import type { AppEnv } from "./env";
+import { corsMiddleware } from "./http/cors";
+import { loadUser } from "./http/auth";
+import { errorHandler, notFoundHandler } from "./http/errors";
+import health from "./routes/health";
+import auth from "./routes/auth";
+import me from "./routes/me";
+import users from "./routes/users";
+
+const app = new Hono<AppEnv>();
+
+app.onError(errorHandler);
+app.notFound(notFoundHandler);
+
+app.use("*", corsMiddleware);
+app.use("*", loadUser);
+
+app.route("/", health);
+app.route("/auth", auth);
+app.route("/me", me);
+app.route("/u", users);
+
+export default app;

--- a/workers/accounts/src/auth/cookies.ts
+++ b/workers/accounts/src/auth/cookies.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { getCookie, setCookie, deleteCookie } from "hono/cookie";
+import type { AppEnv } from "../env";
+import { SESSION_COOKIE, SESSION_TTL_MS } from "../config";
+
+// Secure cookies are dropped over plain http, so honour the request scheme:
+// https in production, http under `wrangler dev` on localhost.
+function isSecure(c: Context<AppEnv>): boolean {
+  return new URL(c.req.url).protocol === "https:";
+}
+
+export function readSessionToken(c: Context<AppEnv>): string | undefined {
+  return getCookie(c, SESSION_COOKIE);
+}
+
+export function setSessionCookie(c: Context<AppEnv>, token: string): void {
+  const domain = c.env.COOKIE_DOMAIN?.trim();
+  setCookie(c, SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: isSecure(c),
+    sameSite: "Lax",
+    path: "/",
+    maxAge: Math.floor(SESSION_TTL_MS / 1000),
+    ...(domain ? { domain } : {}),
+  });
+}
+
+export function clearSessionCookie(c: Context<AppEnv>): void {
+  const domain = c.env.COOKIE_DOMAIN?.trim();
+  deleteCookie(c, SESSION_COOKIE, {
+    path: "/",
+    secure: isSecure(c),
+    ...(domain ? { domain } : {}),
+  });
+}

--- a/workers/accounts/src/auth/crypto.ts
+++ b/workers/accounts/src/auth/crypto.ts
@@ -1,0 +1,74 @@
+// Password hashing (PBKDF2-HMAC-SHA256) and token helpers, built on the Web
+// Crypto API available in the Workers runtime. Ported from the crash-report
+// worker and hardened: tokens are stored hashed, peppered with a server secret.
+import { PBKDF2_ITERATIONS } from "../config";
+
+const encoder = new TextEncoder();
+
+function toBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (const byte of bytes) s += String.fromCharCode(byte);
+  return btoa(s);
+}
+
+function fromBase64(s: string): Uint8Array {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let s = "";
+  for (const byte of bytes) s += byte.toString(16).padStart(2, "0");
+  return s;
+}
+
+async function deriveBits(password: string, salt: Uint8Array, iterations: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey("raw", encoder.encode(password), "PBKDF2", false, ["deriveBits"]);
+  const bits = await crypto.subtle.deriveBits({ name: "PBKDF2", salt, iterations, hash: "SHA-256" }, key, 256);
+  return new Uint8Array(bits);
+}
+
+// Stored as `pbkdf2$<iters>$<salt-b64>$<hash-b64>` so the work factor travels
+// with the hash and can be raised without invalidating older passwords.
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const hash = await deriveBits(password, salt, PBKDF2_ITERATIONS);
+  return `pbkdf2$${PBKDF2_ITERATIONS}$${toBase64(salt)}$${toBase64(hash)}`;
+}
+
+export async function verifyPassword(password: string, stored: string | null): Promise<boolean> {
+  if (!stored) return false;
+  const [scheme, iters, saltB64, hashB64] = stored.split("$");
+  if (scheme !== "pbkdf2" || !iters || !saltB64 || !hashB64) return false;
+  const got = await deriveBits(password, fromBase64(saltB64), Number(iters));
+  const want = fromBase64(hashB64);
+  return got.byteLength === want.byteLength && crypto.subtle.timingSafeEqual(got, want);
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+  return toHex(new Uint8Array(digest));
+}
+
+// 256 bits of entropy as hex — used for session cookies and email links.
+export function generateToken(): string {
+  return toHex(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+// Look-up key for a token: only the peppered hash is ever stored, so a DB read
+// can neither resurrect a session nor redeem an email link.
+export function hashToken(pepper: string, token: string): Promise<string> {
+  return sha256Hex(`${pepper}:${token}`);
+}
+
+// A short random suffix for handle generation. Hex-encodes crypto bytes (a
+// bijection — no modulo, so no bias) and trims to length. Hex digits are all
+// valid handle characters.
+export function randomSuffix(len: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(Math.ceil(len / 2)));
+  let s = "";
+  for (const byte of bytes) s += byte.toString(16).padStart(2, "0");
+  return s.slice(0, len);
+}

--- a/workers/accounts/src/config.ts
+++ b/workers/accounts/src/config.ts
@@ -1,0 +1,16 @@
+// Tunable constants for the account service. Durations are in milliseconds.
+
+export const SESSION_COOKIE = "rxid";
+
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const VERIFY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const RESET_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// PBKDF2-HMAC-SHA256 work factor. Cloudflare Workers hard-caps PBKDF2 at 100k
+// iterations (it throws NotSupportedError above that), so this is the platform
+// ceiling. The value is embedded in each stored hash, so it can be raised later
+// (e.g. if the cap is lifted) without breaking existing logins.
+export const PBKDF2_ITERATIONS = 100_000;
+
+export const MIN_PASSWORD = 8;
+export const MAX_PASSWORD = 200;

--- a/workers/accounts/src/db/emailTokens.ts
+++ b/workers/accounts/src/db/emailTokens.ts
@@ -1,0 +1,46 @@
+import { generateToken, hashToken } from "../auth/crypto";
+
+export type EmailTokenPurpose = "verify" | "reset";
+
+export class EmailTokenRepo {
+  constructor(
+    private readonly db: D1Database,
+    private readonly pepper: string,
+  ) {}
+
+  // Issues a single-use token and returns the raw value for the email link.
+  async issue(userId: number, purpose: EmailTokenPurpose, ttlMs: number): Promise<string> {
+    const token = generateToken();
+    const tokenHash = await hashToken(this.pepper, token);
+    const now = new Date();
+    const expires = new Date(now.getTime() + ttlMs);
+    await this.db
+      .prepare("INSERT INTO email_tokens (token_hash, user_id, purpose, created_at, expires_at) VALUES (?1, ?2, ?3, ?4, ?5)")
+      .bind(tokenHash, userId, purpose, now.toISOString(), expires.toISOString())
+      .run();
+    return token;
+  }
+
+  // Atomically redeems a token: a single UPDATE ... RETURNING marks it used and
+  // hands back the user id, so a token can never be consumed twice.
+  async consume(token: string, purpose: EmailTokenPurpose): Promise<number | null> {
+    const tokenHash = await hashToken(this.pepper, token);
+    const now = new Date().toISOString();
+    const row = await this.db
+      .prepare(
+        `UPDATE email_tokens SET used_at = ?1
+         WHERE token_hash = ?2 AND purpose = ?3 AND used_at IS NULL AND expires_at > ?1
+         RETURNING user_id`,
+      )
+      .bind(now, tokenHash, purpose)
+      .first<{ user_id: number }>();
+    return row?.user_id ?? null;
+  }
+
+  async invalidateForUser(userId: number, purpose: EmailTokenPurpose): Promise<void> {
+    await this.db
+      .prepare("UPDATE email_tokens SET used_at = ?1 WHERE user_id = ?2 AND purpose = ?3 AND used_at IS NULL")
+      .bind(new Date().toISOString(), userId, purpose)
+      .run();
+  }
+}

--- a/workers/accounts/src/db/index.ts
+++ b/workers/accounts/src/db/index.ts
@@ -1,0 +1,23 @@
+import type { Bindings } from "../env";
+import { UserRepo } from "./users";
+import { SessionRepo } from "./sessions";
+import { EmailTokenRepo } from "./emailTokens";
+
+export interface Repos {
+  users: UserRepo;
+  sessions: SessionRepo;
+  emailTokens: EmailTokenRepo;
+}
+
+// Builds the repository layer from request bindings. The session pepper is a
+// secret; absent (e.g. first local run) it degrades to an empty pepper.
+export function repos(env: Bindings): Repos {
+  const pepper = env.SESSION_PEPPER ?? "";
+  return {
+    users: new UserRepo(env.DB),
+    sessions: new SessionRepo(env.DB, pepper),
+    emailTokens: new EmailTokenRepo(env.DB, pepper),
+  };
+}
+
+export { UserRepo, SessionRepo, EmailTokenRepo };

--- a/workers/accounts/src/db/sessions.ts
+++ b/workers/accounts/src/db/sessions.ts
@@ -1,0 +1,65 @@
+import type { UserRow } from "../types";
+import { generateToken, hashToken } from "../auth/crypto";
+import { SESSION_TTL_MS } from "../config";
+
+export interface NewSession {
+  kind?: "web" | "cli";
+  userAgent?: string;
+  ttlMs?: number;
+}
+
+export class SessionRepo {
+  constructor(
+    private readonly db: D1Database,
+    private readonly pepper: string,
+  ) {}
+
+  // Persists sha256(pepper:token) and returns the raw token for the cookie.
+  async create(userId: number, opts: NewSession = {}): Promise<string> {
+    const token = generateToken();
+    const tokenHash = await hashToken(this.pepper, token);
+    const now = new Date();
+    const expires = new Date(now.getTime() + (opts.ttlMs ?? SESSION_TTL_MS));
+    await this.db
+      .prepare(
+        `INSERT INTO sessions (token_hash, user_id, kind, user_agent, created_at, last_seen_at, expires_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6)`,
+      )
+      .bind(tokenHash, userId, opts.kind ?? "web", (opts.userAgent ?? "").slice(0, 256), now.toISOString(), expires.toISOString())
+      .run();
+    return token;
+  }
+
+  // Resolves a cookie token to its active user, pruning the row if expired.
+  async resolve(token: string): Promise<UserRow | null> {
+    const tokenHash = await hashToken(this.pepper, token);
+    const row = await this.db
+      .prepare(
+        `SELECT u.*, s.expires_at AS s_expires
+         FROM sessions s JOIN users u ON u.id = s.user_id
+         WHERE s.token_hash = ?1`,
+      )
+      .bind(tokenHash)
+      .first<UserRow & { s_expires: string }>();
+    if (!row) return null;
+    if (row.s_expires <= new Date().toISOString()) {
+      await this.deleteByHash(tokenHash);
+      return null;
+    }
+    if (row.status !== "active") return null;
+    const { s_expires: _ignored, ...user } = row;
+    return user;
+  }
+
+  async deleteByToken(token: string): Promise<void> {
+    await this.deleteByHash(await hashToken(this.pepper, token));
+  }
+
+  async deleteAllForUser(userId: number): Promise<void> {
+    await this.db.prepare("DELETE FROM sessions WHERE user_id = ?1").bind(userId).run();
+  }
+
+  private async deleteByHash(tokenHash: string): Promise<void> {
+    await this.db.prepare("DELETE FROM sessions WHERE token_hash = ?1").bind(tokenHash).run();
+  }
+}

--- a/workers/accounts/src/db/users.ts
+++ b/workers/accounts/src/db/users.ts
@@ -1,0 +1,91 @@
+import type { Role, UserRow } from "../types";
+
+export interface NewUser {
+  handle: string;
+  email: string; // already lowercased
+  passwordHash: string;
+  displayName: string;
+  role: Role;
+}
+
+export interface ProfilePatch {
+  handle?: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export class UserRepo {
+  constructor(private readonly db: D1Database) {}
+
+  byId(id: number): Promise<UserRow | null> {
+    return this.db.prepare("SELECT * FROM users WHERE id = ?1").bind(id).first<UserRow>();
+  }
+
+  byEmail(email: string): Promise<UserRow | null> {
+    return this.db.prepare("SELECT * FROM users WHERE email = ?1").bind(email).first<UserRow>();
+  }
+
+  byHandle(handle: string): Promise<UserRow | null> {
+    return this.db.prepare("SELECT * FROM users WHERE handle = ?1").bind(handle).first<UserRow>();
+  }
+
+  async handleTaken(handle: string): Promise<boolean> {
+    const row = await this.db.prepare("SELECT 1 AS x FROM users WHERE handle = ?1 LIMIT 1").bind(handle).first<{ x: number }>();
+    return row !== null;
+  }
+
+  async create(input: NewUser): Promise<UserRow> {
+    const now = new Date().toISOString();
+    const res = await this.db
+      .prepare(
+        `INSERT INTO users (handle, email, email_verified, password_hash, display_name, avatar_url, bio, role, status, created_at, updated_at)
+         VALUES (?1, ?2, 0, ?3, ?4, '', '', ?5, 'active', ?6, ?6)`,
+      )
+      .bind(input.handle, input.email, input.passwordHash, input.displayName, input.role, now)
+      .run();
+    const row = await this.byId(Number(res.meta.last_row_id));
+    if (!row) throw new Error("user row missing right after insert");
+    return row;
+  }
+
+  async markEmailVerified(id: number): Promise<void> {
+    await this.db
+      .prepare("UPDATE users SET email_verified = 1, updated_at = ?2 WHERE id = ?1")
+      .bind(id, new Date().toISOString())
+      .run();
+  }
+
+  async updatePassword(id: number, passwordHash: string): Promise<void> {
+    await this.db
+      .prepare("UPDATE users SET password_hash = ?2, updated_at = ?3 WHERE id = ?1")
+      .bind(id, passwordHash, new Date().toISOString())
+      .run();
+  }
+
+  async updateProfile(id: number, patch: ProfilePatch): Promise<UserRow> {
+    const sets: string[] = [];
+    const binds: unknown[] = [];
+    const add = (col: string, value: unknown): void => {
+      binds.push(value);
+      sets.push(`${col} = ?${binds.length}`);
+    };
+    if (patch.handle !== undefined) add("handle", patch.handle);
+    if (patch.displayName !== undefined) add("display_name", patch.displayName);
+    if (patch.bio !== undefined) add("bio", patch.bio);
+    if (patch.avatarUrl !== undefined) add("avatar_url", patch.avatarUrl);
+    add("updated_at", new Date().toISOString());
+    binds.push(id);
+    await this.db.prepare(`UPDATE users SET ${sets.join(", ")} WHERE id = ?${binds.length}`).bind(...binds).run();
+    const row = await this.byId(id);
+    if (!row) throw new Error("user row missing after profile update");
+    return row;
+  }
+
+  async softDelete(id: number): Promise<void> {
+    await this.db
+      .prepare("UPDATE users SET status = 'deleted', updated_at = ?2 WHERE id = ?1")
+      .bind(id, new Date().toISOString())
+      .run();
+  }
+}

--- a/workers/accounts/src/email/index.ts
+++ b/workers/accounts/src/email/index.ts
@@ -1,0 +1,75 @@
+import type { Bindings } from "../env";
+import type { EmailMessage, Mailer } from "./types";
+import { ResendMailer } from "./resend";
+
+export type { EmailMessage, Mailer } from "./types";
+
+// Dev-time fallback: write the message (and any link inside it) to the worker
+// console so flows can be exercised without configuring a mail provider.
+class ConsoleMailer implements Mailer {
+  constructor(private readonly from: string) {}
+  async send(msg: EmailMessage): Promise<void> {
+    console.log(`[email:stub] from=${this.from} to=${msg.to}\nsubject: ${msg.subject}\n${msg.text}`);
+  }
+}
+
+export function buildMailer(env: Bindings): Mailer {
+  if (env.EMAIL_PROVIDER?.toLowerCase() === "resend" && env.RESEND_API_KEY) {
+    return new ResendMailer(env.RESEND_API_KEY, env.MAIL_FROM);
+  }
+  return new ConsoleMailer(env.MAIL_FROM);
+}
+
+function layout(heading: string, intro: string, ctaLabel: string, ctaUrl: string, footer: string): string {
+  return `<!doctype html>
+<html><body style="margin:0;background:#0b0d12;font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#e6e8ee;padding:32px">
+  <div style="max-width:480px;margin:0 auto;background:#12151c;border:1px solid #242938;border-radius:14px;padding:28px">
+    <h1 style="margin:0 0 12px;font-size:18px">${heading}</h1>
+    <p style="margin:0 0 20px;line-height:1.6;color:#aeb4c2">${intro}</p>
+    <a href="${ctaUrl}" style="display:inline-block;background:#5b8cff;color:#fff;text-decoration:none;padding:11px 18px;border-radius:9px;font-weight:600">${ctaLabel}</a>
+    <p style="margin:20px 0 0;font-size:12px;color:#717892;word-break:break-all">${footer}</p>
+  </div>
+</body></html>`;
+}
+
+export function verifyEmail(link: string): Omit<EmailMessage, "to"> {
+  return {
+    subject: "Confirm your Reasonix email",
+    text: `Welcome to Reasonix! Confirm your email to activate your account:\n\n${link}\n\nThis link expires in 24 hours. If you didn't sign up, ignore this email.`,
+    html: layout(
+      "Confirm your email",
+      "Welcome to Reasonix! Confirm your email address to activate your account. This link expires in 24 hours.",
+      "Confirm email",
+      link,
+      `Or paste this link: ${link}`,
+    ),
+  };
+}
+
+export function resetEmail(link: string): Omit<EmailMessage, "to"> {
+  return {
+    subject: "Reset your Reasonix password",
+    text: `Someone requested a password reset for your Reasonix account. Set a new password here:\n\n${link}\n\nThis link expires in 1 hour. If it wasn't you, you can safely ignore this email.`,
+    html: layout(
+      "Reset your password",
+      "Someone requested a password reset for your Reasonix account. This link expires in 1 hour. If it wasn't you, ignore this email.",
+      "Reset password",
+      link,
+      `Or paste this link: ${link}`,
+    ),
+  };
+}
+
+export function accountExistsEmail(loginUrl: string, resetUrl: string): Omit<EmailMessage, "to"> {
+  return {
+    subject: "You already have a Reasonix account",
+    text: `Someone tried to register with this email, but an account already exists.\n\nSign in: ${loginUrl}\nForgot your password? ${resetUrl}\n\nIf this wasn't you, no action is needed.`,
+    html: layout(
+      "You already have an account",
+      "Someone tried to register with this email, but an account already exists. You can sign in, or reset your password if you've forgotten it.",
+      "Sign in",
+      loginUrl,
+      `Forgot your password? ${resetUrl}`,
+    ),
+  };
+}

--- a/workers/accounts/src/email/resend.ts
+++ b/workers/accounts/src/email/resend.ts
@@ -1,0 +1,31 @@
+import type { EmailMessage, Mailer } from "./types";
+
+// Minimal Resend HTTP client. Workers can't open SMTP, so transactional mail
+// goes through Resend's REST API.
+export class ResendMailer implements Mailer {
+  constructor(
+    private readonly apiKey: string,
+    private readonly from: string,
+  ) {}
+
+  async send(msg: EmailMessage): Promise<void> {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: this.from,
+        to: msg.to,
+        subject: msg.subject,
+        text: msg.text,
+        html: msg.html,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`resend send failed: ${res.status} ${detail.slice(0, 300)}`);
+    }
+  }
+}

--- a/workers/accounts/src/email/types.ts
+++ b/workers/accounts/src/email/types.ts
@@ -1,0 +1,10 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export interface Mailer {
+  send(msg: EmailMessage): Promise<void>;
+}

--- a/workers/accounts/src/env.ts
+++ b/workers/accounts/src/env.ts
@@ -1,0 +1,31 @@
+import type { AccountUser } from "./types";
+
+// Cloudflare's native rate-limit binding (configured under [[unsafe.bindings]]).
+export interface RateLimiter {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
+}
+
+export interface Bindings {
+  DB: D1Database;
+  AUTH_LIMITER?: RateLimiter;
+
+  // Plain vars (wrangler.toml [vars]).
+  APP_ORIGIN: string;
+  ALLOWED_ORIGINS: string;
+  COOKIE_DOMAIN: string;
+  EMAIL_PROVIDER: string;
+  MAIL_FROM: string;
+  ADMIN_EMAILS?: string;
+
+  // Secrets (wrangler secret put ...).
+  SESSION_PEPPER?: string;
+  RESEND_API_KEY?: string;
+}
+
+// Per-request values set by middleware. `user` is null until a valid session is
+// resolved; requireAuth guarantees it is non-null for protected routes.
+export interface Variables {
+  user: AccountUser | null;
+}
+
+export type AppEnv = { Bindings: Bindings; Variables: Variables };

--- a/workers/accounts/src/http/auth.ts
+++ b/workers/accounts/src/http/auth.ts
@@ -1,0 +1,32 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { AppEnv } from "../env";
+import type { AccountUser } from "../types";
+import { toAccountUser } from "../types";
+import { repos } from "../db";
+import { readSessionToken } from "../auth/cookies";
+import { ApiError } from "./errors";
+
+// Resolves the session cookie (if any) and stashes the user on the context.
+// Runs for every request; never rejects.
+export const loadUser: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const token = readSessionToken(c);
+  let user: AccountUser | null = null;
+  if (token) {
+    const row = await repos(c.env).sessions.resolve(token);
+    if (row) user = toAccountUser(row);
+  }
+  c.set("user", user);
+  await next();
+};
+
+// Gate for protected routes. Pairs with currentUser() in handlers.
+export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
+  if (!c.get("user")) throw new ApiError(401, "unauthorized", "Sign in to continue.");
+  await next();
+};
+
+export function currentUser(c: Context<AppEnv>): AccountUser {
+  const user = c.get("user");
+  if (!user) throw new ApiError(401, "unauthorized", "Sign in to continue.");
+  return user;
+}

--- a/workers/accounts/src/http/cors.ts
+++ b/workers/accounts/src/http/cors.ts
@@ -1,0 +1,20 @@
+import type { MiddlewareHandler } from "hono";
+import { cors } from "hono/cors";
+import type { AppEnv } from "../env";
+
+// CORS with credentials: only origins listed in ALLOWED_ORIGINS get an
+// Access-Control-Allow-Origin header, and it always echoes the exact origin
+// (never "*", which is incompatible with cookies).
+export const corsMiddleware: MiddlewareHandler<AppEnv> = (c, next) => {
+  const allowed = (c.env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return cors({
+    origin: (origin) => (allowed.includes(origin) ? origin : null),
+    credentials: true,
+    allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type"],
+    maxAge: 86400,
+  })(c, next);
+};

--- a/workers/accounts/src/http/errors.ts
+++ b/workers/accounts/src/http/errors.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../env";
+
+// A client-safe error: the code/message pair is sent verbatim to the caller, so
+// never put internal detail in here.
+export class ApiError extends Error {
+  constructor(
+    public readonly status: ContentfulStatusCode,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export function errorHandler(err: Error, c: Context<AppEnv>): Response {
+  if (err instanceof ApiError) {
+    return c.json({ error: { code: err.code, message: err.message } }, err.status);
+  }
+  if (err instanceof SyntaxError) {
+    return c.json({ error: { code: "invalid_json", message: "Request body must be valid JSON." } }, 400);
+  }
+  if (err instanceof HTTPException) {
+    return err.getResponse();
+  }
+  console.error("unhandled error:", err);
+  return c.json({ error: { code: "internal", message: "Something went wrong." } }, 500);
+}
+
+export function notFoundHandler(c: Context<AppEnv>): Response {
+  return c.json({ error: { code: "not_found", message: "Not found." } }, 404);
+}

--- a/workers/accounts/src/http/ratelimit.ts
+++ b/workers/accounts/src/http/ratelimit.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../env";
+import { ApiError } from "./errors";
+
+// Per-IP throttle for sensitive auth endpoints. The binding may be absent under
+// local `wrangler dev`, in which case the limiter is simply skipped.
+export const authRateLimit: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const limiter = c.env.AUTH_LIMITER;
+  if (limiter) {
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const { success } = await limiter.limit({ key: ip });
+    if (!success) {
+      throw new ApiError(429, "rate_limited", "Too many attempts. Please wait a minute and try again.");
+    }
+  }
+  await next();
+};

--- a/workers/accounts/src/index.ts
+++ b/workers/accounts/src/index.ts
@@ -1,0 +1,5 @@
+// Reasonix account service — email/password auth, sessions, and public profiles
+// for reasonix.io. The Hono app is itself the Workers fetch handler.
+import app from "./app";
+
+export default app;

--- a/workers/accounts/src/lib/handle.ts
+++ b/workers/accounts/src/lib/handle.ts
@@ -1,0 +1,35 @@
+import { randomSuffix } from "../auth/crypto";
+
+// Names that must never become a public handle (routes, infra, impersonation).
+const RESERVED = new Set([
+  "admin", "administrator", "root", "system", "support", "help", "about", "api",
+  "auth", "login", "logout", "register", "signup", "signin", "reset", "verify",
+  "forgot", "account", "settings", "me", "u", "user", "users", "profile",
+  "reasonix", "www", "mail", "no-reply", "noreply", "null", "undefined", "anonymous",
+]);
+
+// Lowercase, collapse runs of disallowed characters to single underscores, and
+// trim underscores from the ends.
+export function normalizeHandle(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+// 3–30 chars, [a-z0-9_], must start and end with an alphanumeric, not reserved.
+export function isValidHandle(handle: string): boolean {
+  if (handle.length < 3 || handle.length > 30) return false;
+  if (!/^[a-z0-9](?:[a-z0-9_]*[a-z0-9])?$/.test(handle)) return false;
+  return !RESERVED.has(handle);
+}
+
+// A normalized, valid starting handle derived from the email local-part. Falls
+// back to a random "user…" handle when the local-part can't yield a valid one.
+export function deriveHandleBase(email: string): string {
+  let base = normalizeHandle(email.split("@")[0] ?? "");
+  if (base.length > 24) base = base.slice(0, 24).replace(/_+$/g, "");
+  if (base.length < 3 || RESERVED.has(base)) base = `user${randomSuffix(4)}`;
+  return base;
+}

--- a/workers/accounts/src/lib/validation.ts
+++ b/workers/accounts/src/lib/validation.ts
@@ -1,0 +1,71 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../env";
+import { MAX_PASSWORD, MIN_PASSWORD } from "../config";
+import { ApiError } from "../http/errors";
+
+const email = z.string().trim().toLowerCase().email().max(254);
+const password = z.string().min(MIN_PASSWORD, `Password must be at least ${MIN_PASSWORD} characters.`).max(MAX_PASSWORD);
+
+export const RegisterSchema = z.object({
+  email,
+  password,
+  displayName: z.string().trim().max(80).optional(),
+});
+
+export const LoginSchema = z.object({
+  email,
+  password: z.string().min(1).max(MAX_PASSWORD),
+});
+
+export const ForgotSchema = z.object({ email });
+export const ResendSchema = z.object({ email });
+
+export const ResetSchema = z.object({
+  token: z.string().min(10).max(256),
+  password,
+});
+
+export const VerifyQuerySchema = z.object({
+  token: z.string().min(10).max(256),
+});
+
+export const ProfileSchema = z
+  .object({
+    displayName: z.string().trim().max(80).optional(),
+    bio: z.string().trim().max(500).optional(),
+    avatarUrl: z.union([z.string().url().max(500), z.literal("")]).optional(),
+    handle: z.string().trim().min(3).max(30).optional(),
+  })
+  .strict();
+
+export const PasswordChangeSchema = z.object({
+  currentPassword: z.string().min(1).max(MAX_PASSWORD),
+  newPassword: password,
+});
+
+function firstIssue(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) return "Some fields are invalid.";
+  const path = issue.path.join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export async function parseBody<S extends z.ZodTypeAny>(c: Context<AppEnv>, schema: S): Promise<z.infer<S>> {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    throw new ApiError(400, "invalid_json", "Request body must be valid JSON.");
+  }
+  const result = schema.safeParse(raw);
+  if (!result.success) throw new ApiError(422, "invalid_input", firstIssue(result.error));
+  return result.data;
+}
+
+export function parseQuery<S extends z.ZodTypeAny>(c: Context<AppEnv>, schema: S): z.infer<S> {
+  const params = Object.fromEntries(new URL(c.req.url).searchParams);
+  const result = schema.safeParse(params);
+  if (!result.success) throw new ApiError(422, "invalid_input", firstIssue(result.error));
+  return result.data;
+}

--- a/workers/accounts/src/routes/auth.ts
+++ b/workers/accounts/src/routes/auth.ts
@@ -1,0 +1,139 @@
+import { Hono } from "hono";
+import type { AppEnv, Bindings } from "../env";
+import type { Role } from "../types";
+import { toAccountUser } from "../types";
+import { repos, UserRepo } from "../db";
+import { buildMailer, verifyEmail, resetEmail, accountExistsEmail } from "../email";
+import { hashPassword, verifyPassword, randomSuffix } from "../auth/crypto";
+import { setSessionCookie, clearSessionCookie, readSessionToken } from "../auth/cookies";
+import { authRateLimit } from "../http/ratelimit";
+import { ApiError } from "../http/errors";
+import { deriveHandleBase, isValidHandle } from "../lib/handle";
+import { parseBody, RegisterSchema, LoginSchema, ForgotSchema, ResetSchema, ResendSchema } from "../lib/validation";
+import { VERIFY_TTL_MS, RESET_TTL_MS } from "../config";
+
+const auth = new Hono<AppEnv>();
+
+// Throttle every auth endpoint per source IP.
+auth.use("*", authRateLimit);
+
+function isAdminEmail(env: Bindings, email: string): boolean {
+  const list = (env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(email);
+}
+
+// Find a free, valid handle starting from a derived base, appending digits on
+// collision and falling back to a random handle as a last resort.
+async function uniqueHandle(users: UserRepo, base: string): Promise<string> {
+  if (isValidHandle(base) && !(await users.handleTaken(base))) return base;
+  for (let i = 0; i < 5; i++) {
+    const candidate = `${base}${randomSuffix(i < 2 ? 2 : 4)}`.slice(0, 30).replace(/_+$/g, "");
+    if (isValidHandle(candidate) && !(await users.handleTaken(candidate))) return candidate;
+  }
+  return `user${randomSuffix(8)}`;
+}
+
+function verifyLink(c: { req: { url: string } }, token: string): string {
+  return `${new URL(c.req.url).origin}/auth/verify?token=${token}`;
+}
+
+// Register is deliberately enumeration-safe: the response is identical whether or
+// not the email already exists. New emails get a verification link; existing ones
+// get a resend or an "account already exists" nudge — never a different status.
+auth.post("/register", async (c) => {
+  const { email, password, displayName } = await parseBody(c, RegisterSchema);
+  const { users, emailTokens } = repos(c.env);
+  const mailer = buildMailer(c.env);
+  const existing = await users.byEmail(email);
+
+  if (!existing) {
+    const handle = await uniqueHandle(users, deriveHandleBase(email));
+    const role: Role = isAdminEmail(c.env, email) ? "admin" : "member";
+    const user = await users.create({ handle, email, passwordHash: await hashPassword(password), displayName: displayName ?? "", role });
+    const token = await emailTokens.issue(user.id, "verify", VERIFY_TTL_MS);
+    await mailer.send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+  } else if (existing.email_verified === 0) {
+    await emailTokens.invalidateForUser(existing.id, "verify");
+    const token = await emailTokens.issue(existing.id, "verify", VERIFY_TTL_MS);
+    await mailer.send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+  } else {
+    await mailer.send({ to: email, ...accountExistsEmail(`${c.env.APP_ORIGIN}/login`, `${c.env.APP_ORIGIN}/forgot`) });
+  }
+
+  return c.json({ ok: true, message: "If that address is valid, check your inbox to confirm your account." });
+});
+
+// Email link target. Always lands the browser back on the site; never leaks
+// whether the token was good beyond the ?verified flag.
+auth.get("/verify", async (c) => {
+  const token = c.req.query("token") ?? "";
+  const { emailTokens, users } = repos(c.env);
+  let ok = false;
+  if (token.length >= 10) {
+    const userId = await emailTokens.consume(token, "verify");
+    if (userId !== null) {
+      await users.markEmailVerified(userId);
+      ok = true;
+    }
+  }
+  return c.redirect(`${c.env.APP_ORIGIN}/login?verified=${ok ? "1" : "0"}`, 302);
+});
+
+auth.post("/login", async (c) => {
+  const { email, password } = await parseBody(c, LoginSchema);
+  const { users, sessions } = repos(c.env);
+  const user = await users.byEmail(email);
+  const ok = user ? await verifyPassword(password, user.password_hash) : false;
+  if (!user || !ok) throw new ApiError(401, "invalid_credentials", "Incorrect email or password.");
+  if (user.status !== "active") throw new ApiError(403, "account_unavailable", "This account is not available.");
+
+  const token = await sessions.create(user.id, { userAgent: c.req.header("user-agent") ?? "" });
+  setSessionCookie(c, token);
+  return c.json({ user: toAccountUser(user) });
+});
+
+auth.post("/logout", async (c) => {
+  const token = readSessionToken(c);
+  if (token) await repos(c.env).sessions.deleteByToken(token);
+  clearSessionCookie(c);
+  return c.json({ ok: true });
+});
+
+auth.post("/forgot", async (c) => {
+  const { email } = await parseBody(c, ForgotSchema);
+  const { users, emailTokens } = repos(c.env);
+  const user = await users.byEmail(email);
+  if (user && user.status === "active") {
+    await emailTokens.invalidateForUser(user.id, "reset");
+    const token = await emailTokens.issue(user.id, "reset", RESET_TTL_MS);
+    await buildMailer(c.env).send({ to: email, ...resetEmail(`${c.env.APP_ORIGIN}/reset?token=${token}`) });
+  }
+  return c.json({ ok: true, message: "If that account exists, a reset link is on its way." });
+});
+
+auth.post("/reset", async (c) => {
+  const { token, password } = await parseBody(c, ResetSchema);
+  const { users, emailTokens, sessions } = repos(c.env);
+  const userId = await emailTokens.consume(token, "reset");
+  if (userId === null) throw new ApiError(400, "invalid_token", "This reset link is invalid or has expired.");
+  await users.updatePassword(userId, await hashPassword(password));
+  await sessions.deleteAllForUser(userId); // force a fresh sign-in everywhere
+  return c.json({ ok: true, message: "Password updated. You can now sign in." });
+});
+
+auth.post("/resend-verification", async (c) => {
+  const { email } = await parseBody(c, ResendSchema);
+  const { users, emailTokens } = repos(c.env);
+  const user = await users.byEmail(email);
+  if (user && user.email_verified === 0) {
+    await emailTokens.invalidateForUser(user.id, "verify");
+    const token = await emailTokens.issue(user.id, "verify", VERIFY_TTL_MS);
+    await buildMailer(c.env).send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+  }
+  return c.json({ ok: true, message: "If that address needs confirming, a new link is on its way." });
+});
+
+export default auth;

--- a/workers/accounts/src/routes/health.ts
+++ b/workers/accounts/src/routes/health.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+
+const health = new Hono<AppEnv>();
+
+health.get("/", (c) => c.json({ ok: true, service: "accounts" }));
+health.get("/health", (c) => c.json({ ok: true, service: "accounts" }));
+
+export default health;

--- a/workers/accounts/src/routes/me.ts
+++ b/workers/accounts/src/routes/me.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { toAccountUser } from "../types";
+import { repos } from "../db";
+import type { ProfilePatch } from "../db/users";
+import { requireAuth, currentUser } from "../http/auth";
+import { ApiError } from "../http/errors";
+import { hashPassword, verifyPassword } from "../auth/crypto";
+import { setSessionCookie, clearSessionCookie } from "../auth/cookies";
+import { isValidHandle } from "../lib/handle";
+import { parseBody, ProfileSchema, PasswordChangeSchema } from "../lib/validation";
+
+const me = new Hono<AppEnv>();
+
+// Everything under /me requires a session.
+me.use("*", requireAuth);
+
+me.get("/", (c) => c.json({ user: currentUser(c) }));
+
+me.patch("/", async (c) => {
+  const user = currentUser(c);
+  const patch = await parseBody(c, ProfileSchema);
+  const { users } = repos(c.env);
+
+  const update: ProfilePatch = {};
+  if (patch.handle !== undefined) {
+    const handle = patch.handle.toLowerCase();
+    if (!isValidHandle(handle)) {
+      throw new ApiError(422, "invalid_handle", "Handles are 3–30 chars: letters, numbers, and underscores.");
+    }
+    if (handle !== user.handle) {
+      if (await users.handleTaken(handle)) throw new ApiError(409, "handle_taken", "That handle is already taken.");
+      update.handle = handle;
+    }
+  }
+  if (patch.displayName !== undefined) update.displayName = patch.displayName;
+  if (patch.bio !== undefined) update.bio = patch.bio;
+  if (patch.avatarUrl !== undefined) update.avatarUrl = patch.avatarUrl;
+
+  const row = await users.updateProfile(user.id, update);
+  return c.json({ user: toAccountUser(row) });
+});
+
+me.post("/password", async (c) => {
+  const user = currentUser(c);
+  const { currentPassword, newPassword } = await parseBody(c, PasswordChangeSchema);
+  const { users, sessions } = repos(c.env);
+
+  const row = await users.byId(user.id);
+  if (!row || !(await verifyPassword(currentPassword, row.password_hash))) {
+    throw new ApiError(400, "invalid_password", "Your current password is incorrect.");
+  }
+  await users.updatePassword(user.id, await hashPassword(newPassword));
+
+  // Drop every session, then mint a fresh one so this device stays signed in.
+  await sessions.deleteAllForUser(user.id);
+  setSessionCookie(c, await sessions.create(user.id, { userAgent: c.req.header("user-agent") ?? "" }));
+  return c.json({ ok: true });
+});
+
+me.delete("/", async (c) => {
+  const user = currentUser(c);
+  const { users, sessions } = repos(c.env);
+  await users.softDelete(user.id);
+  await sessions.deleteAllForUser(user.id);
+  clearSessionCookie(c);
+  return c.json({ ok: true });
+});
+
+export default me;

--- a/workers/accounts/src/routes/users.ts
+++ b/workers/accounts/src/routes/users.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { toPublicUser } from "../types";
+import { repos } from "../db";
+import { ApiError } from "../http/errors";
+
+const users = new Hono<AppEnv>();
+
+// Public profile. Suspended/deleted accounts are indistinguishable from missing.
+users.get("/:handle", async (c) => {
+  const handle = c.req.param("handle").toLowerCase();
+  const row = await repos(c.env).users.byHandle(handle);
+  if (!row || row.status !== "active") throw new ApiError(404, "not_found", "No such profile.");
+  return c.json({ user: toPublicUser(row) });
+});
+
+export default users;

--- a/workers/accounts/src/types.ts
+++ b/workers/accounts/src/types.ts
@@ -1,0 +1,67 @@
+export type Role = "member" | "admin";
+export type UserStatus = "active" | "suspended" | "deleted";
+
+// A full `users` row as stored in D1.
+export interface UserRow {
+  id: number;
+  handle: string;
+  email: string;
+  email_verified: number;
+  password_hash: string | null;
+  display_name: string;
+  avatar_url: string;
+  bio: string;
+  role: Role;
+  status: UserStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+// The authenticated owner's view of their own account (login, /me). Camel-cased
+// and free of the password hash, so it is safe to serialize directly.
+export interface AccountUser {
+  id: number;
+  handle: string;
+  email: string;
+  emailVerified: boolean;
+  displayName: string;
+  avatarUrl: string;
+  bio: string;
+  role: Role;
+  status: UserStatus;
+  createdAt: string;
+}
+
+// What anyone may see at /u/<handle>. No email, no role, no status.
+export interface PublicUser {
+  handle: string;
+  displayName: string;
+  avatarUrl: string;
+  bio: string;
+  joinedAt: string;
+}
+
+export function toAccountUser(row: UserRow): AccountUser {
+  return {
+    id: row.id,
+    handle: row.handle,
+    email: row.email,
+    emailVerified: row.email_verified === 1,
+    displayName: row.display_name,
+    avatarUrl: row.avatar_url,
+    bio: row.bio,
+    role: row.role,
+    status: row.status,
+    createdAt: row.created_at,
+  };
+}
+
+export function toPublicUser(row: UserRow): PublicUser {
+  return {
+    handle: row.handle,
+    displayName: row.display_name || row.handle,
+    avatarUrl: row.avatar_url,
+    bio: row.bio,
+    joinedAt: row.created_at,
+  };
+}

--- a/workers/accounts/tsconfig.json
+++ b/workers/accounts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/workers/accounts/wrangler.toml
+++ b/workers/accounts/wrangler.toml
@@ -1,0 +1,40 @@
+# Account service for reasonix.io — email/password auth, sessions, profiles.
+# First deploy:
+#   wrangler d1 create reasonix-accounts        # paste database_id below
+#   wrangler d1 migrations apply reasonix-accounts --remote
+#   wrangler secret put SESSION_PEPPER          # any long random string
+#   wrangler secret put RESEND_API_KEY          # only if EMAIL_PROVIDER=resend
+#   wrangler deploy
+name = "reasonix-accounts"
+main = "src/index.ts"
+compatibility_date = "2026-06-01"
+
+routes = [{ pattern = "id.reasonix.io", custom_domain = true }]
+
+[vars]
+# Where the web frontend lives — used for email links and post-verify redirects.
+APP_ORIGIN = "https://reasonix.io"
+# Browsers that may call this API with credentials (comma-separated).
+ALLOWED_ORIGINS = "https://reasonix.io,https://www.reasonix.io"
+# Cookie scope. ".reasonix.io" lets the apex + any subdomain (and the future CLI)
+# share the session. Leave empty for host-only (local dev).
+COOKIE_DOMAIN = ".reasonix.io"
+# "stub" logs email links to the worker console (local dev); "resend" sends real
+# mail via RESEND_API_KEY.
+EMAIL_PROVIDER = "resend"
+MAIL_FROM = "Reasonix <no-reply@reasonix.io>"
+# Comma-separated emails minted as admins on first sign-up.
+ADMIN_EMAILS = ""
+
+[[d1_databases]]
+binding = "DB"
+database_name = "reasonix-accounts"
+database_id = "bae20011-a6fe-4fad-ae61-a3aaac605e0c"
+migrations_dir = "migrations"
+
+# Per-IP throttle for the sensitive auth endpoints (login/register/forgot/reset).
+[[unsafe.bindings]]
+name = "AUTH_LIMITER"
+type = "ratelimit"
+namespace_id = "2001"
+simple = { limit = 10, period = 60 }


### PR DESCRIPTION
## Summary

Adds `workers/accounts` — a new Cloudflare Worker (Hono + zod + D1) that provides
the self-owned account system for `reasonix.io`, served at `id.reasonix.io` and
kept separate from the internal crash dashboard. **Backend API only; no frontend
pages yet.** This is phase 0 + 1 of the accounts → community roadmap (email/password
first; third-party OAuth and desktop/CLI login deferred but the schema reserves them).

## What's included

Email/password **registration with email verification**, **login/logout**,
**password reset**, **sessions**, profile read/update, account deletion, and a
**public profile** endpoint.

| Method | Path | Auth |
| --- | --- | --- |
| POST | `/auth/register` `/auth/login` `/auth/logout` | — |
| GET | `/auth/verify` | — |
| POST | `/auth/forgot` `/auth/reset` `/auth/resend-verification` | — |
| GET / PATCH / DELETE | `/me` | ✓ |
| POST | `/me/password` | ✓ |
| GET | `/u/:handle` | — |
| GET | `/health` | — |

## Architecture & security

- Layered: `routes / db (repositories) / auth (primitives) / email (pluggable) /
  http (middleware) / lib`. Reuses the proven PBKDF2/session/CSRF approach from the
  crash worker but in a clean, separated structure (own worker, own D1 database).
- Sessions store `sha256(pepper:token)` — the raw token only ever lives in the
  cookie, so a DB read can't resurrect a live session.
- Registration is **enumeration-safe** (identical response whether or not the email
  exists); login and password reset return generic messages. Email tokens are
  single-use via `UPDATE ... RETURNING`.
- `HttpOnly` + `Secure` + `SameSite=Lax` cookie, scoped `Domain=.reasonix.io`;
  credentialed CORS limited to `ALLOWED_ORIGINS`; per-IP rate limiting on auth routes.
- **PBKDF2-HMAC-SHA256 at 100k iterations** — this is the Cloudflare Workers hard
  cap (it rejects higher counts); the work factor is embedded in each stored hash.
- Forward-compatible schema: `password_hash` is nullable (room for future OAuth
  identities) and `sessions.kind` (`web`/`cli`) is reserved for a later desktop/CLI
  device login that reuses the same tables.

## Verification

- `tsc --noEmit` passes under strict + `verbatimModuleSyntax` + `noUncheckedIndexedAccess`.
- Local (`wrangler dev`) and **production** (`id.reasonix.io`) smoke-tested end to
  end: register → email verify → login (cookie) → `/me` → profile update → public
  profile, plus negative paths (401 unauthorized, 401 bad credentials, single-use
  reset token, 409 handle conflict, 422 reserved handle, 422 weak password,
  soft-delete invalidates sessions).

## Deployment status

Already deployed to the `reasonix.io` Cloudflare account: D1 `reasonix-accounts`
created and migrated, `SESSION_PEPPER` secret set, `id.reasonix.io` custom domain
live (TLS provisioned). Email currently runs in **stub/console mode** (links logged,
visible via `wrangler tail`); adding the `RESEND_API_KEY` secret flips it to real
delivery with no redeploy.

## Deferred (by design)

Frontend pages (`/login`, `/register`, ...), third-party OAuth, and desktop/CLI
device login. A minor follow-up: equalize login timing for a non-existent email
(currently mitigated by rate limiting + generic responses).
