### PR TITLE
fix(tui): expand paste placeholders before queuing interject during r…

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1083,12 +1083,12 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
 					// Save the edited text back to the queue slot.
-					m.pendingInterject[m.queueEditCursor] = line
+					m.pendingInterject[m.queueEditCursor] = m.expandPastedBlocks(line)
 					m.notice(fmt.Sprintf("queue [%d] updated", m.queueEditCursor+1))
 					m.queueEditCursor = -1
 					m.queueEditDraft = ""
 				} else {
-					m.pendingInterject = append(m.pendingInterject, line)
+					m.pendingInterject = append(m.pendingInterject, m.expandPastedBlocks(line))
 					m.notice("feedback queued — will send when the current turn finishes")
 					m.queueEditCursor = -1
 					m.queueEditDraft = ""

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1325,6 +1325,65 @@ func TestQueueNewMessageOnEnterDuringRunning(t *testing.T) {
 	}
 }
 
+func TestQueuedFoldedPasteExpandsBeforeInterjectSend(t *testing.T) {
+	runner := &recordingTurnRunner{}
+	events := make(chan event.Event, 8)
+	ctrl := control.New(control.Options{
+		Runner:     runner,
+		Sink:       event.FuncSink(func(e event.Event) { events <- e }),
+		SessionDir: t.TempDir(),
+		Label:      "test",
+	})
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	m.eventCh = make(chan event.Event, 8)
+	m.state = tuiRunning
+
+	pasted := strings.Repeat("queued pasted content\n", 10)
+	model, _ := m.Update(tea.PasteMsg{Content: pasted})
+	m = model.(chatTUI)
+
+	display := strings.TrimSpace(m.input.Value())
+	if !strings.Contains(display, "[Pasted text #1") {
+		t.Fatalf("paste should be folded, got %q", display)
+	}
+
+	model, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = model.(chatTUI)
+
+	if len(m.pendingInterject) != 1 {
+		t.Fatalf("queue should have 1 item, got %d", len(m.pendingInterject))
+	}
+	queued := m.pendingInterject[0]
+	if queued == display {
+		t.Fatalf("queued interject kept the folded placeholder: %q", queued)
+	}
+	for _, want := range []string{
+		"queued pasted content",
+		"--- Begin [Pasted text #1",
+		"--- End [Pasted text #1",
+	} {
+		if !strings.Contains(queued, want) {
+			t.Fatalf("queued interject missing %q in:\n%s", want, queued)
+		}
+	}
+
+	model, _ = m.Update(agentEventMsg(event.Event{Kind: event.TurnDone}))
+	m = model.(chatTUI)
+	waitForCLIEvent(t, events, event.TurnDone)
+
+	if len(runner.inputs) != 1 {
+		t.Fatalf("runner should receive queued interject, inputs=%q", runner.inputs)
+	}
+	sent := runner.inputs[0]
+	if sent == display {
+		t.Fatalf("runner received the folded placeholder: %q", sent)
+	}
+	if !strings.Contains(sent, "queued pasted content") {
+		t.Fatalf("runner input missing pasted content:\n%s", sent)
+	}
+}
+
 func TestQueueNavigationResetOnNonUpDownKey(t *testing.T) {
 	m := newTestChatTUI()
 	m.state = tuiRunning


### PR DESCRIPTION
When multi-line text is pasted during model reasoning (tuiRunning), it is folded to a [Pasted text #N · M lines] placeholder. Pressing Enter queued the placeholder text directly into pendingInterject, and pastedBlocks were cleared before TurnDone could send the queued feedback. The model then received the placeholder instead of the pasted content.

Expand paste blocks with expandPastedBlocks() before storing new or edited interject queue entries, matching the normal send path.

Fixes #5423.

## Summary

- Expand folded paste placeholders before storing running-turn feedback in pendingInterject.
- Add a regression test for the tuiRunning queue path so TurnDone sends the original pasted content.

## Verification

- `go test ./internal/cli -run "Test(QueuedFoldedPasteExpandsBeforeInterjectSend|QueueNewMessageOnEnterDuringRunning|PasteFoldExpandOnSubmit)"`
- `go test ./internal/cli`

## Cache impact

Cache-impact: none; this only changes user-message queue contents and regression coverage. It does not modify system prompts, tool schemas, provider request serialization, memory prefix, compaction, or reasoning upload.
Cache-guard: `go test ./internal/cli -run "Test(QueuedFoldedPasteExpandsBeforeInterjectSend|QueueNewMessageOnEnterDuringRunning|PasteFoldExpandOnSubmit)"`
System-prompt-review: N/A
