### PR TITLE
fix(goal): 目标模式完成时待办列表未自动更新

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1888,6 +1888,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	c.mu.Unlock()
 	c.setActiveJobSession(match.Path)
 	c.rebindCheckpoints(match.Path)
+	c.restoreTerminalGoalTodos(match.Path)
 	c.loadGuardianSession()
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("switched to branch %s", branchDisplayName(match))})
@@ -1985,6 +1986,7 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.mu.Unlock()
 	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
+	c.restoreTerminalGoalTodos(path)
 	c.loadGuardianSession()
 	c.maybeColdResumePrune(path)
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -392,6 +392,70 @@ func TestGoalStatePersistsNextToSessionPath(t *testing.T) {
 	}
 }
 
+func TestResumeRestoresTerminalGoalTodosFromSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	loaded := agent.NewSession("sys")
+	loaded.Add(provider.Message{
+		Role: provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{{
+			ID:        "todo-1",
+			Name:      "todo_write",
+			Arguments: `{"todos":[{"content":"Step 1","status":"in_progress"}]}`,
+		}},
+	})
+	loaded.Add(provider.Message{
+		Role:       provider.RoleTool,
+		ToolCallID: "todo-1",
+		Name:       "todo_write",
+		Content:    "ok",
+	})
+	if err := os.WriteFile(goalStatePath(path), []byte(`{"status":"complete","todos":[{"content":"Step 1","status":"completed"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.Resume(loaded, path)
+
+	got := c.Todos()
+	if len(got) != 1 || got[0].Content != "Step 1" || got[0].Status != "completed" {
+		t.Fatalf("Todos() after resume = %+v, want completed todos from goal-state sidecar", got)
+	}
+}
+
+func TestResumeKeepsTranscriptTodosForRunningGoalSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	loaded := agent.NewSession("sys")
+	loaded.Add(provider.Message{
+		Role: provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{{
+			ID:        "todo-1",
+			Name:      "todo_write",
+			Arguments: `{"todos":[{"content":"Step 1","status":"in_progress"}]}`,
+		}},
+	})
+	loaded.Add(provider.Message{
+		Role:       provider.RoleTool,
+		ToolCallID: "todo-1",
+		Name:       "todo_write",
+		Content:    "ok",
+	})
+	if err := os.WriteFile(goalStatePath(path), []byte(`{"status":"running","todos":[{"content":"Step 1","status":"completed"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.Resume(loaded, path)
+
+	got := c.Todos()
+	if len(got) != 1 || got[0].Content != "Step 1" || got[0].Status != "in_progress" {
+		t.Fatalf("Todos() after resume = %+v, want transcript todos while goal state is running", got)
+	}
+}
+
 func TestRunTurnRecordsDisplayForPersistedUserMessage(t *testing.T) {
 	sess := agent.NewSession("sys")
 	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	maxGoalAutoTurns  = 50
-	maxGoalIdleTurns  = 2
-	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
-	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
+	maxGoalAutoTurns   = 50
+	maxGoalIdleTurns   = 2
+	goalContinueTurn   = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	goalSelfCheckTurn  = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
+	goalCompleteNotice = "goal complete"
 )
 
 // goalMachine owns the active goal's finite-state machine and its persistence.
@@ -216,7 +217,7 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		g.blocks = 0
 		g.block = ""
 		g.interceptMsg = ""
-		notice = "goal complete"
+		notice = goalCompleteNotice
 	case GoalStatusBlocked:
 		reason := cleanGoalBlockReason(in.reason)
 		if reason == "" {
@@ -310,6 +311,19 @@ func (g *goalMachine) writeState(path string, data []byte) {
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		slog.Warn("controller: write goal state", "err", err)
+	}
+}
+
+// persistWithTodos re-persists goal state with the given todos, without
+// changing any in-memory goal fields. Used after force-completing todos on
+// goal completion so a session reload does not revert to the old incomplete
+// todo state.
+func (g *goalMachine) persistWithTodos(todos []evidence.TodoItem) {
+	g.mu.Lock()
+	path, data, ok := g.buildStateLocked(todos)
+	g.mu.Unlock()
+	if ok {
+		g.writeState(path, data)
 	}
 }
 

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -327,6 +327,37 @@ func (g *goalMachine) persistWithTodos(todos []evidence.TodoItem) {
 	}
 }
 
+// terminalTodosFromState reads the persisted goal-state sidecar and returns its
+// todo snapshot only after the goal has reached a terminal state. Running goal
+// state is not refreshed on every todo_write, so its todos may be older than the
+// transcript rebuilt by Agent.SetSession.
+func (g *goalMachine) terminalTodosFromState(sessionPath string) ([]evidence.TodoItem, bool) {
+	if strings.TrimSpace(sessionPath) == "" {
+		return nil, false
+	}
+	data, err := os.ReadFile(goalStatePath(sessionPath))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("controller: read goal state", "err", err)
+		}
+		return nil, false
+	}
+	var state goalState
+	if err := json.Unmarshal(data, &state); err != nil {
+		slog.Warn("controller: parse goal state", "err", err)
+		return nil, false
+	}
+	switch state.Status {
+	case GoalStatusComplete, GoalStatusBlocked, GoalStatusStopped:
+	default:
+		return nil, false
+	}
+	if len(state.Todos) == 0 {
+		return nil, false
+	}
+	return append([]evidence.TodoItem(nil), state.Todos...), true
+}
+
 // formatIncompleteTodos renders the reminder shown when [goal:complete] arrives
 // while the executor's canonical todos or project-readiness checks aren't done.
 // Returns empty when nothing is blocking. Pure: the caller gathers todos and the
@@ -437,4 +468,15 @@ func (c *Controller) persistGoalState(path string, data []byte, ok bool) {
 		return
 	}
 	c.goals.writeState(path, data)
+}
+
+func (c *Controller) restoreTerminalGoalTodos(sessionPath string) {
+	if c.executor == nil {
+		return
+	}
+	todos, ok := c.goals.terminalTodosFromState(sessionPath)
+	if !ok {
+		return
+	}
+	c.executor.ReplaceTodoState(todos)
 }

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -375,6 +375,146 @@ func TestGoalInterceptsCompleteWithIncompleteTodos(t *testing.T) {
 	}
 }
 
+// TestGoalOverrideCompletesRemainingTodos verifies that when the goal
+// completes via the second [goal:complete] override (non-strict mode), any
+// remaining incomplete canonical todos are force-completed and a synthetic
+// todo_write event is emitted so the frontend panel reflects the final state.
+func TestGoalOverrideCompletesRemainingTodos(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("All done.\n\n[goal:complete]"),
+		textTurn("All done.\n\n[goal:complete]"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Step 1", Status: "in_progress"},
+		{Content: "Step 2", Status: "pending"},
+	})
+
+	var tools []event.Event
+	done := make(chan event.Event, 1)
+	c := New(Options{
+		Runner:   ag,
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.ToolDispatch, event.ToolResult:
+				tools = append(tools, e)
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+
+	c.Submit("/goal do everything")
+	<-done // wait for the goal loop to finish
+
+	if c.GoalStatus() != GoalStatusComplete {
+		t.Fatalf("GoalStatus() = %q, want complete", c.GoalStatus())
+	}
+
+	// All todos in the executor must be force-completed.
+	for _, td := range c.executor.CanonicalTodoState() {
+		if td.Status != "completed" {
+			t.Fatalf("canonical todo %q = %s, want completed after goal override", td.Content, td.Status)
+		}
+	}
+
+	// Must have emitted a synthetic todo_write (ToolDispatch + ToolResult)
+	// from completeRemainingGoalTodos.
+	hasSynthetic := false
+	for _, e := range tools {
+		if e.Tool.ID == "goal-final" && e.Tool.Name == "todo_write" {
+			hasSynthetic = true
+			break
+		}
+	}
+	if !hasSynthetic {
+		t.Fatal("expected synthetic todo_write event (ID=goal-final) after goal override completion")
+	}
+}
+
+// TestCompleteRemainingGoalTodosEdgeCases verifies that the helper is a no-op
+// when there are no incomplete todos or no todos at all.
+func TestCompleteRemainingGoalTodosEdgeCases(t *testing.T) {
+	t.Run("empty todo list does nothing", func(t *testing.T) {
+		ag := agent.New(nil, nil, agent.NewSession(""), agent.Options{}, event.Discard)
+		c := New(Options{Executor: ag, Sink: event.Discard})
+		c.completeRemainingGoalTodos()
+		if len(ag.CanonicalTodoState()) != 0 {
+			t.Fatal("expected no changes to empty todo list")
+		}
+	})
+
+	t.Run("all completed does nothing", func(t *testing.T) {
+		ag := agent.New(nil, nil, agent.NewSession(""), agent.Options{}, event.Discard)
+		ag.SeedTodoState([]evidence.TodoItem{
+			{Content: "A", Status: "completed"},
+			{Content: "B", Status: "completed"},
+		})
+		var events []event.Event
+		c := New(Options{
+			Executor: ag,
+			Sink: event.FuncSink(func(e event.Event) {
+				events = append(events, e)
+			}),
+		})
+		c.completeRemainingGoalTodos()
+		if len(events) > 0 {
+			t.Fatalf("expected no events when all todos already completed, got %d", len(events))
+		}
+	})
+
+	t.Run("force-completes mixed todos", func(t *testing.T) {
+		ag := agent.New(nil, nil, agent.NewSession(""), agent.Options{}, event.Discard)
+		ag.SeedTodoState([]evidence.TodoItem{
+			{Content: "A", Status: "completed"},
+			{Content: "B", Status: "in_progress"},
+			{Content: "C", Status: "pending"},
+		})
+		var captured []event.Event
+		c := New(Options{
+			Executor: ag,
+			Sink: event.FuncSink(func(e event.Event) {
+				if e.Kind == event.ToolDispatch || e.Kind == event.ToolResult {
+					captured = append(captured, e)
+				}
+			}),
+		})
+		c.completeRemainingGoalTodos()
+		// All must be completed.
+		for _, td := range ag.CanonicalTodoState() {
+			if td.Status != "completed" {
+				t.Fatalf("todo %q = %s, want completed", td.Content, td.Status)
+			}
+		}
+		// Must include a ToolDispatch+ToolResult for the synthetic todo_write.
+		if len(captured) != 2 {
+			t.Fatalf("expected 2 synthetic events (dispatch+result), got %d", len(captured))
+		}
+		if captured[0].Kind != event.ToolDispatch || captured[0].Tool.Name != "todo_write" {
+			t.Fatalf("first event should be ToolDispatch for todo_write, got %+v", captured[0].Kind)
+		}
+		if captured[1].Kind != event.ToolResult || captured[1].Tool.Name != "todo_write" {
+			t.Fatalf("second event should be ToolResult for todo_write, got %+v", captured[1].Kind)
+		}
+	})
+
+	t.Run("empty-string status treated as incomplete", func(t *testing.T) {
+		ag := agent.New(nil, nil, agent.NewSession(""), agent.Options{}, event.Discard)
+		ag.SeedTodoState([]evidence.TodoItem{
+			{Content: "A", Status: ""},
+			{Content: "B", Status: "completed"},
+		})
+		c := New(Options{Executor: ag, Sink: event.Discard})
+		c.completeRemainingGoalTodos()
+		for _, td := range ag.CanonicalTodoState() {
+			if td.Status != "completed" {
+				t.Fatalf("empty-string todo %q should be force-completed, got %q", td.Content, td.Status)
+			}
+		}
+	})
+}
+
 // TestStrictGoalBlocksRepeatedComplete verifies that in strict mode, every
 // [goal:complete] with incomplete todos is intercepted — no override allowed.
 func TestStrictGoalBlocksRepeatedComplete(t *testing.T) {

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -2,9 +2,12 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 )
 
@@ -193,5 +196,37 @@ func (o *turnOrchestrator) advanceGoalAfterTurn() bool {
 	if res.notice != "" {
 		c.notice(res.notice)
 	}
+	if res.notice == goalCompleteNotice && c.executor != nil {
+		c.completeRemainingGoalTodos()
+	}
 	return res.cont
+}
+
+// completeRemainingGoalTodos force-completes any remaining incomplete canonical
+// todos when the goal FSM transitions to completed and emits a synthetic
+// todo_write event so the frontend panel reflects the final state. Handles the
+// second [goal:complete] override (non-strict) where the model does not mark
+// each todo individually.
+func (c *Controller) completeRemainingGoalTodos() {
+	todos := c.executor.CanonicalTodoState()
+	if len(evidence.IncompleteTodos(todos)) == 0 {
+		return
+	}
+	for i := range todos {
+		todos[i].Status = "completed"
+	}
+	args, err := json.Marshal(map[string]any{"todos": todos})
+	if err != nil {
+		return
+	}
+	t := event.Tool{ID: "goal-final", Name: "todo_write", Args: string(args), ReadOnly: true}
+	c.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
+	t.Output = "goal completed"
+	c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
+	c.executor.ReplaceTodoState(todos)
+	// Persist the completed todo state so a session reload does not revert
+	// to the old incomplete list — the synthetic todo_write events are not
+	// part of the session transcript and rebuildTodoState would otherwise
+	// reconstruct the stale pre-completion state.
+	c.goals.persistWithTodos(todos)
 }


### PR DESCRIPTION
## 问题

在「目标」协作模式下，模型完成所有工作并显示「全部完成」后，下方待办面板仍可能停在旧状态，例如仍显示 `0/5 进行中`，进度条没有自动更新为全部完成。

关联 Issue：#5339

## 根因

Goal FSM 在 non-strict 模式下允许第二次 `[goal:complete]` 作为 override 通过。这个路径会把 goal 标记为 complete，但原实现没有同步更新 canonical todos，也没有向前端发出合成 `todo_write`，所以 live 待办面板仍显示旧的 `pending` / `in_progress` 快照。

后续 review 还发现一个恢复链路问题：合成 `todo_write` 事件不是 provider transcript 的真实消息。仅更新 live executor 后，`Controller.Resume -> Agent.SetSession -> rebuildTodoState` 会从旧 `.jsonl` transcript 中的真实 `todo_write` 重建 todos，导致 reload/resume 后又回到未完成状态。

## 修复

- 在 `advanceGoalAfterTurn()` 中，当 goal FSM 转换为 completed 状态时调用 `completeRemainingGoalTodos()`。
- `completeRemainingGoalTodos()` 会把剩余 incomplete canonical todos 标记为 `completed`，并发出合成 `ToolDispatch` + `ToolResult`，让 live UI 面板立即更新。
- 完成后的 todo 快照会写入 goal-state sidecar，避免 synthetic event 不进 transcript 后丢失最终状态。
- `Controller.Resume` 和 branch switch 在 `Agent.SetSession` 从 transcript 重建 todos 后，会读取 terminal goal-state sidecar 并恢复 persisted todos。
- 只接受 terminal goal state（`complete` / `blocked` / `stopped`）里的 todos；running goal sidecar 会被忽略，避免旧 sidecar 快照覆盖 transcript 中更新的真实 `todo_write`。

## 文件变更

| 文件 | 说明 |
|---|---|
| `internal/control/turn_orchestrator.go` | goal 完成时补齐剩余 todos、发出合成 `todo_write`、持久化最终 todo 快照 |
| `internal/control/goal.go` | 添加 `goalCompleteNotice`、terminal sidecar todo 读取与恢复 helper |
| `internal/control/controller.go` | resume / branch switch 后恢复 terminal goal todos |
| `internal/control/goal_test.go` | 覆盖 goal override 后自动完成 todos 及边界状态 |
| `internal/control/controller_test.go` | 覆盖 resume 恢复 terminal sidecar todos，以及 running sidecar 不覆盖 transcript |

## 测试覆盖

- `TestGoalOverrideCompletesRemainingTodos`：两次 `[goal:complete]` override 后，todos 全部 completed 且合成事件被发出。
- `TestCompleteRemainingGoalTodosEdgeCases`：覆盖空列表、全已完成、混合状态、空字符串状态。
- `TestResumeRestoresTerminalGoalTodosFromSidecar`：terminal sidecar 中的 completed todos 会在 resume 后恢复。
- `TestResumeKeepsTranscriptTodosForRunningGoalSidecar`：running sidecar 不会覆盖 transcript 重建出的 todo 状态。

## 验证

- `go test ./internal/control -run 'TestResumeRestoresTerminalGoalTodosFromSidecar|TestResumeKeepsTranscriptTodosForRunningGoalSidecar|TestGoalOverrideCompletesRemainingTodos|TestCompleteRemainingGoalTodosEdgeCases' -count=1` passed
- `go test ./internal/control -count=1` passed
- `git diff --check` passed

## 取舍与影响

- Cache impact: low. 本 PR 不改 system prompt、tool schema、provider request serialization，也不改变常规 `complete_step` 路径。
- `.jsonl` 仍保持 provider transcript 语义；controller-owned goal completion state 通过 goal-state sidecar 恢复。
- non-strict override 的语义保持不变：第二次 `[goal:complete]` 代表接受完成声明，因此剩余 todos 会被收尾为 completed。需要强校验时仍应使用 strict goal mode。

## Authorship note

@ttmouse is the primary author of this PR. @SivanCola contributed the follow-up review fix for resume/branch-switch restoration and the focused regression tests.