### PR TITLE
fix(desktop): 回溯乐观 UI 跨 tab 污染导致其他会话显示为空

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2040,6 +2040,11 @@ export default function App() {
 
   const handleTabClose = useCallback(async (id: string) => {
     closeTransientOverlays();
+    // Clear any pending optimistic rewind for the closing tab.
+    if (rewindStateRef.current?.tabId === id) {
+      setRewindState(null);
+      rewindStateRef.current = null;
+    }
     setComposerProfilesByTab((current) => {
       if (!(id in current)) return current;
       const next = { ...current };
@@ -2064,6 +2069,11 @@ export default function App() {
 
   const handleTabsClose = useCallback(async (ids: string[], nextActiveTabId?: string) => {
     closeTransientOverlays();
+    // Clear any pending optimistic rewind if the originating tab is among those being closed.
+    if (rewindStateRef.current && ids.includes(rewindStateRef.current.tabId)) {
+      setRewindState(null);
+      rewindStateRef.current = null;
+    }
     const currentIds = tabMetas.map((tab) => tab.id);
     const targets = ids.filter((id, index) => currentIds.includes(id) && ids.indexOf(id) === index);
     if (targets.length === 0) return;
@@ -2101,10 +2111,11 @@ export default function App() {
   type RewindState = {
     turn: number;
     scope: string;
-    fullItems: Item[];     // pre-truncation items (for undo)
-    boundaryIdx: number;   // first item index of the rewound-to turn
-    turnDiff: number;      // turns rolled back
-    prompt: string;        // user message text for composer fill
+    tabId: string;           // the tab that initiated the optimistic rewind
+    fullItems: Item[];       // pre-truncation items (for undo)
+    boundaryIdx: number;     // first item index of the rewound-to turn
+    turnDiff: number;        // turns rolled back
+    prompt: string;          // user message text for composer fill
   };
   const [rewindState, setRewindState] = useState<RewindState | null>(null);
   const [rewindCommitting, setRewindCommitting] = useState(false);
@@ -2119,18 +2130,18 @@ export default function App() {
   const transcriptHydrating = state.hydrating && !state.hydrateHistoryLoaded;
   const transcriptItems = hydratePlaceholderActive ? state.hydratePlaceholderItems! : state.items;
 
-  // Display items: truncated when an optimistic rewind is pending.
+  // Display items: truncated when an optimistic rewind is pending for the current tab.
   const displayItems = useMemo(() => {
-    if (!rewindState) return transcriptItems;
+    if (!rewindState || rewindState.tabId !== activeTabId) return transcriptItems;
     return transcriptItems.slice(0, rewindState.boundaryIdx).filter((it) => it.kind !== "compaction");
-  }, [transcriptItems, rewindState]);
+  }, [transcriptItems, rewindState, activeTabId]);
 
   // send wrapper: commits any pending optimistic rewind before sending.
   const commitThenSend = useCallback(async (displayText: string, submitText?: string) => {
     if (activeTab?.readOnly) throw new Error("channel session is read-only");
     if (!controllerReady) throw new Error("workspace is still starting");
     const rs = rewindStateRef.current;
-    if (rs) {
+    if (rs && rs.tabId === activeTabId) {
       rewindStateRef.current = null;
       setRewindState(null);
       setRewindCommitting(true);
@@ -2154,7 +2165,7 @@ export default function App() {
       }
     }
     await send(displayText, submitText);
-  }, [activeTab?.readOnly, controllerReady, send, rewind]);
+  }, [activeTab?.readOnly, activeTabId, controllerReady, send, rewind]);
 
   const handleTranscriptPrompt = useCallback((text: string) => {
     if (!controllerReady) return;
@@ -2233,9 +2244,11 @@ export default function App() {
     // Save full items for undo.
     const userItem = items[boundaryIdx]?.kind === "user" ? items[boundaryIdx] as Extract<Item, { kind: "user" }> : undefined;
     const prompt = userItem?.text ?? "";
+    if (!activeTabId) return;
     setRewindState({
       turn,
       scope,
+      tabId: activeTabId,
       fullItems: items,
       boundaryIdx,
       turnDiff,
@@ -2251,7 +2264,7 @@ export default function App() {
 
   const handleEditPrompt = useCallback(async (turn: number, displayText: string, submitText?: string): Promise<boolean> => {
     const sourceTabId = activeTabId;
-    if (!sourceTabId || activeTab?.readOnly || !controllerReady || hydratePlaceholderActive || rewindStateRef.current || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending) return false;
+    if (!sourceTabId || activeTab?.readOnly || !controllerReady || hydratePlaceholderActive || (rewindStateRef.current && rewindStateRef.current.tabId === activeTabId) || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending) return false;
     const next = displayText.trim();
     if (!next) return false;
     const submit = (submitText ?? displayText).trim();
@@ -3249,7 +3262,7 @@ export default function App() {
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
-                rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || rewindState != null || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+                rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || (rewindState != null && rewindState.tabId === activeTabId) || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
                 running={state.running || rewindCommitting}
                 welcomeVariant={sidebarCreation ? "creation" : "default"}
                 creationMode={sidebarCreation}
@@ -3264,7 +3277,7 @@ export default function App() {
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
-            {rewindState && (
+            {rewindState && rewindState.tabId === activeTabId && (
               <UndoRewindBanner
                 meta={{
                   turns: rewindState.turnDiff,

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3262,7 +3262,7 @@ export default function App() {
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
-                rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || (rewindState != null && rewindState.tabId === activeTabId) || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+                rewindDisabled={Boolean(activeTab?.readOnly) || !controllerReady || hydratePlaceholderActive || rewindState != null || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
                 running={state.running || rewindCommitting}
                 welcomeVariant={sidebarCreation ? "creation" : "default"}
                 creationMode={sidebarCreation}


### PR DESCRIPTION
### 问题

#4633 中用户在早期轮次点击"回溯-回滚代码和对话"后，所有会话内容均显示为空。重启 APP 后数据恢复。

### 根因

`RewindState`（App 级全局 React state）不含 tab ID，切换 tab 后仍以 `rewindState.boundaryIdx` 截断其他 tab 的 `transcriptItems`，导致其他会话 transcript 显示为空。

### 修复

全部在 `desktop/frontend/src/App.tsx`：

| 改动 | 效果 |
|---|---|
| `RewindState` 新增 `tabId: string` | 记录发起乐观回溯的 tab |
| `displayItems` 加 `tabId` 匹配检查 | 仅截断源 tab 的 transcript |
| UndoRewindBanner 加 `tabId` 检查 | 仅显示在源 tab |
| `rewindDisabled` 加 `tabId` 检查 | 仅禁用源 tab 的回溯按钮 |
| `handleEditPrompt` 加 `tabId` 检查 | 仅阻止同 tab 的发信 |
| `commitThenSend` 加 `tabId` 检查 | 跳过非源 tab 的 pending rewind |
| `handleTabClose` / `handleTabsClose` | 关闭源 tab 时清理 orphaned rewindState |

### 验证

- TypeScript 编译通过（无新增类型错误）
- 仅 1 文件改动，+25/-12 行
- 所有 8 处 rewindState 引用逐行审计

Cache-impact: none — 纯前端改动，不涉及缓存路径
Cache-guard: 无（前端文件不影响后端缓存）