### PR TITLE
feat(desktop): double-click balance to open DeepSeek usage page

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6265,6 +6265,7 @@ type BalanceInfo struct {
 	CostDisplayCurrency string   `json:"costDisplayCurrency,omitempty"`
 	MultiCurrency       bool     `json:"multiCurrency,omitempty"`
 	Err                 string   `json:"err,omitempty"`
+	UsageURL            string   `json:"usageUrl,omitempty"`
 }
 
 // Balance queries the active provider's wallet balance (a network call). It
@@ -6302,6 +6303,7 @@ func (a *App) BalanceForTab(tabID string) BalanceInfo {
 		PrimaryCurrency:     primary,
 		CostDisplayCurrency: firstNonEmptyString(currency, primary),
 		MultiCurrency:       len(currencies) > 1,
+		UsageURL:            ctrl.UsageURL(),
 	}
 }
 

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -11,6 +11,7 @@ import { isRemoteDegradedWarning, isRemoteHostKeyMismatch, isRemoteTerminalFailu
 import type { ExtensionStatusEntry } from "../lib/useController";
 import { type BackgroundRuntimeView, type BalanceInfo, type ContextInfo, type JobView, type RemoteConnectionStatus, type RemoteHostView, type UsageSourceStats, type WireUsage } from "../lib/types";
 import { useRemoteStore } from "../store/remote";
+import { openExternal } from "../lib/bridge";
 
 type StatusBarLabelStyle = "icon" | "text";
 
@@ -419,7 +420,22 @@ export function StatusBar({
     ),
     balance: (
       <Tooltip label={balanceTitle} className="statusbar__metric statusbar__metric--balance">
-        <span className="stat stat--balance statusbar__balance">
+        <span
+          className="stat stat--balance statusbar__balance"
+          role={balance?.usageUrl ? "button" : undefined}
+          tabIndex={balance?.usageUrl ? 0 : undefined}
+          title={balance?.usageUrl ? t("status.balanceDoubleClick") : undefined}
+          onDoubleClick={() => {
+            if (balance?.usageUrl) openExternal(balance.usageUrl);
+          }}
+          onKeyDown={(e) => {
+            if ((e.key === "Enter" || e.key === " ") && balance?.usageUrl) {
+              e.preventDefault();
+              openExternal(balance.usageUrl);
+            }
+          }}
+          style={{ cursor: balance?.usageUrl ? "pointer" : "default" }}
+        >
           <MetricLabel style={metricLabelStyle} icon={<Wallet size={12} />} label={t("status.balanceLabel")} />
           <b className={balanceLabel === "-" ? "stat__value--empty" : undefined}>{balanceLabel}</b>
         </span>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -3420,7 +3420,7 @@ function makeMockApp(): AppBindings {
       // Mirror the active mock provider: deepseek-flash carries a balance_url.
       const p = settings.providers.find((x) => x.name === settings.defaultModel);
       if (!p?.balanceUrl) return { available: false, display: "" };
-          return { available: true, display: "¥128.50" };
+          return { available: true, display: "¥128.50", usageUrl: p.balanceUrl ? "https://platform.deepseek.com/usage" : "" };
         },
         async BalanceForTab() {
           return this.Balance();

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1845,6 +1845,7 @@ export interface BalanceInfo {
   costDisplayCurrency?: string;
   multiCurrency?: boolean;
   err?: string;
+  usageUrl?: string;
 }
 
 // ── Usage statistics (desktop/stats_app.go) ────────────────────────────────

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -891,6 +891,7 @@ export const en = {
   "status.tokens": "tokens",
   "status.retrying": "retrying ({attempt}/{max})…",
   "status.balanceTitle": "Wallet balance",
+  "status.balanceDoubleClick": "Double-click to open usage page",
   "status.spendTitle": "Estimated billable spend in this session, including model, subagent, and helper calls",
 
   // ── Heartbeat ──

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -669,6 +669,7 @@ export const zhTW: Record<DictKey, string> = {
   "status.tokens": "tokens",
   "status.retrying": "正在重試 ({attempt}/{max})…",
   "status.balanceTitle": "錢包餘額",
+  "status.balanceDoubleClick": "雙擊打開用量頁面",
   "status.spendTitle": "本會話估算計費費用，包含主模型、子代理和輔助呼叫",
 
   // ── Heartbeat ──

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -892,6 +892,7 @@ export const zh: Record<DictKey, string> = {
   "status.tokens": "tokens",
   "status.retrying": "正在重试 ({attempt}/{max})…",
   "status.balanceTitle": "钱包余额",
+  "status.balanceDoubleClick": "双击打开用量页面",
   "status.spendTitle": "当前会话估算计费费用，包含主模型、子代理和辅助调用",
 
   // ── Heartbeat ──

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1739,6 +1739,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		// controller must observe the final chain at Close time.
 		Cleanup:               func() { cleanup() },
 		BalanceURL:            entry.BalanceURL,
+		UsageURL:              entry.UsageURL,
 		BalanceKey:            entry.APIKey(),
 		BalanceClient:         balanceClient,
 		Jobs:                  jm,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1359,6 +1359,7 @@ type ProviderEntry struct {
 	resolvedAPIKey    string
 	resolvedSource    CredentialSource
 	BalanceURL        string `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
+	UsageURL          string `toml:"usage_url"`   // optional; provider's usage/billing web page URL (DeepSeek: https://platform.deepseek.com/usage). Empty = no double-click action in UI.
 	ContextWindow     int    `toml:"context_window"`
 	// MaxOutputTokens is a protocol-neutral total output budget for one turn.
 	// Zero means official DeepSeek omits the field (server 384K ceiling) and
@@ -1892,7 +1893,7 @@ func Default() *Config {
 			{
 				Name: "deepseek-flash", Kind: "anthropic", BaseURL: deepSeekAnthropicBaseURL,
 				Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY",
-				BalanceURL: "https://api.deepseek.com/user/balance", Thinking: "enabled",
+				BalanceURL: "https://api.deepseek.com/user/balance", UsageURL: "https://platform.deepseek.com/usage", Thinking: "enabled",
 				WebSearch: boolPointer(true), SupportedEfforts: []string{"disabled", "low", "high", "max"}, DefaultEffort: "high",
 				ContextWindow: 1_000_000, Price: deepSeekV4FlashPriceUSD(),
 				BillingCurrency: "USD", BillingMode: "payg",
@@ -1900,7 +1901,7 @@ func Default() *Config {
 			{
 				Name: "deepseek-pro", Kind: "anthropic", BaseURL: deepSeekAnthropicBaseURL,
 				Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY",
-				BalanceURL: "https://api.deepseek.com/user/balance", Thinking: "enabled",
+				BalanceURL: "https://api.deepseek.com/user/balance", UsageURL: "https://platform.deepseek.com/usage", Thinking: "enabled",
 				WebSearch: boolPointer(true), SupportedEfforts: []string{"disabled", "high", "max"}, DefaultEffort: "high",
 				ContextWindow: 1_000_000, Price: deepSeekV4ProPriceUSD(),
 				BillingCurrency: "USD", BillingMode: "payg",

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -163,6 +163,7 @@ type Controller struct {
 	// endpoint (empty when the provider declares none). Captured at build so a
 	// model/key switch — which rebuilds the controller — refreshes them.
 	balanceURL    string
+	usageURL      string
 	balanceKey    string
 	balanceClient *http.Client
 
@@ -473,6 +474,7 @@ type Options struct {
 	// BalanceURL/BalanceKey wire the active provider's optional wallet-balance
 	// endpoint and bearer key; empty when the provider declares no balance_url.
 	BalanceURL    string
+	UsageURL      string // provider's usage/billing web page; empty = no action in UI
 	BalanceKey    string
 	BalanceClient *http.Client
 	// Jobs is the session-scoped background-job manager (nil disables background jobs).
@@ -640,6 +642,7 @@ func New(opts Options) *Controller {
 		onSessionRecovered:                opts.OnSessionRecovered,
 		onSessionTransition:               opts.OnSessionTransition,
 		balanceURL:                        opts.BalanceURL,
+		usageURL:                          opts.UsageURL,
 		balanceKey:                        opts.BalanceKey,
 		balanceClient:                     opts.BalanceClient,
 		jobs:                              opts.Jobs,
@@ -4815,6 +4818,16 @@ func (c *Controller) Todos() []evidence.TodoItem {
 		return nil
 	}
 	return c.executor.CanonicalTodoState()
+}
+
+// UsageURL returns the provider's usage/billing web page URL.
+func (c *Controller) UsageURL() string {
+	return c.usageURL
+}
+
+// BalanceURL returns the provider's wallet-balance endpoint URL.
+func (c *Controller) BalanceURL() string {
+	return c.balanceURL
 }
 
 // Balance queries the active provider's wallet balance, or (nil, nil) when the

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -210,6 +210,8 @@ type Status interface {
 	ContextMaintenanceSnapshot() agent.ContextMaintenanceSnapshot
 	LastUsage() *provider.Usage
 	Balance(ctx context.Context) (*billing.Balance, error)
+	BalanceURL() string
+	UsageURL() string
 	Jobs() []jobs.View
 	Todos() []evidence.TodoItem
 }


### PR DESCRIPTION
## Summary

When using DeepSeek as the model, double-clicking the wallet balance in the status bar now opens the DeepSeek usage page (https://platform.deepseek.com/usage) in the system browser.

## Changes

### Go Backend
- Added UsageURL field to ProviderEntry config (toml: usage_url) for explicit usage page URL
- Wired UsageURL through control.Options ? Controller.UsageURL() ? BalanceInfo.UsageURL
- Set UsageURL for DeepSeek providers (https://platform.deepseek.com/usage)
- Added BalanceURL() + UsageURL() to Status interface

### Frontend (TypeScript/React)
- Replaced balanceWebUrl() heuristic with explicit usageUrl from backend
- role="button" + tabIndex + onKeyDown (Enter/Space) for keyboard accessibility
- Pointer cursor only when usageUrl is present

### i18n
- Added "status.balanceDoubleClick" to en.ts, zh.ts, zh-TW.ts

## Cache-impact: none - UsageURL is a UI data field (URL string), not a system prompt or tool schema. No agent behavior, provider request serialization, or reasoning template changed.
## Cache-guard: internal/control tests pass; desktop build passes; frontend typecheck passes
## System-prompt-review: no system prompt or tool schema changes - N/A
Documentation-impact: none - UI-only behavior change (double-clicking the status-bar balance opens the provider usage page, backed by a new optional usage_url config field); no user-facing documentation is affected.