### PR TITLE
feat(desktop): add 'Open in GitHub' to project right-click menu

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -10488,6 +10488,9 @@ var remoteURLCache sync.Map
 // repository, has no remote, or the remote URL cannot be sanitized.
 // Results are cached with a 30-second TTL.
 func (a *App) ProjectRemoteURL(path string) string {
+	if a == nil || a.ctx == nil {
+		return ""
+	}
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return ""
@@ -10527,21 +10530,29 @@ func sanitizeRemoteURL(rawURL string) string {
 	if rawURL == "" {
 		return ""
 	}
-	// Handle SCP-style SSH: git@github.com:org/repo.git
-	if strings.HasPrefix(rawURL, "git@") {
-		parts := strings.SplitN(rawURL, ":", 2)
-		if len(parts) != 2 {
+	// Handle SCP-style SSH: [user@]host:path (e.g. git@github.com:org/repo.git
+	// or deploy@gitlab.com:group/repo.git). The user is dropped and the result
+	// is built through net/url so host/path are properly encoded.
+	if !strings.Contains(rawURL, "://") {
+		userHost, path, ok := strings.Cut(rawURL, ":")
+		if !ok || path == "" {
 			return ""
 		}
-		host := strings.TrimPrefix(parts[0], "git@")
+		if strings.Count(userHost, "@") > 1 {
+			return ""
+		}
+		host := userHost
+		if i := strings.LastIndex(userHost, "@"); i >= 0 {
+			host = userHost[i+1:]
+		}
 		if host == "" || strings.ContainsAny(host, "@/") {
 			return ""
 		}
-		path := strings.TrimSuffix(strings.TrimSuffix(parts[1], "/"), ".git")
+		path = strings.TrimSuffix(strings.TrimSuffix(path, "/"), ".git")
 		if path == "" {
 			return ""
 		}
-		return "https://" + host + "/" + path
+		return (&url.URL{Scheme: "https", Host: host, Path: "/" + path}).String()
 	}
 	// For http/https and ssh:// URLs, use net/url to parse and sanitize
 	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") && !strings.HasPrefix(rawURL, "ssh://") {
@@ -10565,6 +10576,9 @@ func sanitizeRemoteURL(rawURL string) string {
 	}
 	// Strip credentials
 	u.User = nil
+	// Query strings and fragments can carry tokens — drop them entirely.
+	u.RawQuery = ""
+	u.Fragment = ""
 	// Strip trailing slash, then a trailing .git suffix (order matters so
 	// https://host/org/repo.git/ also loses the .git).
 	u.Path = strings.TrimSuffix(u.Path, "/")

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	goruntime "runtime"
@@ -10467,6 +10468,108 @@ func defaultRevealPath(path string) error {
 		}
 		return proc.VisibleCommand("xdg-open", dir).Start()
 	}
+}
+
+// remoteURLCacheEntry holds a cached sanitized URL with its expiry.
+type remoteURLCacheEntry struct {
+	url    string
+	expiry time.Time
+}
+
+// remoteURLCacheTTL is how long we cache a ProjectRemoteURL result.
+const remoteURLCacheTTL = 30 * time.Second
+
+// remoteURLCache is a process-wide cache keyed by project path.
+var remoteURLCache sync.Map
+
+// ProjectRemoteURL returns the Git remote origin URL for the project at path,
+// converted to a clean HTTPS URL suitable for opening in a browser.
+// Credentials are stripped. Returns empty string when the path is not a Git
+// repository, has no remote, or the remote URL cannot be sanitized.
+// Results are cached with a 30-second TTL.
+func (a *App) ProjectRemoteURL(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	// Check cache
+	if entry, ok := remoteURLCache.Load(path); ok {
+		e := entry.(remoteURLCacheEntry)
+		if time.Now().Before(e.expiry) {
+			return e.url
+		}
+	}
+	// Fetch from git
+	ctx, cancel := context.WithTimeout(a.ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "config", "--get", "remote.origin.url")
+	out, err := cmd.Output()
+	if err != nil {
+		remoteURLCache.Store(path, remoteURLCacheEntry{expiry: time.Now().Add(remoteURLCacheTTL)})
+		return ""
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		remoteURLCache.Store(path, remoteURLCacheEntry{expiry: time.Now().Add(remoteURLCacheTTL)})
+		return ""
+	}
+	sanitized := sanitizeRemoteURL(raw)
+	remoteURLCache.Store(path, remoteURLCacheEntry{url: sanitized, expiry: time.Now().Add(remoteURLCacheTTL)})
+	return sanitized
+}
+
+// sanitizeRemoteURL converts a git remote URL to a clean HTTPS URL suitable
+// for opening in a browser. It handles HTTPS, SCP-style SSH
+// (git@host:path), and ssh:// URL formats. Credentials are stripped from
+// HTTPS URLs. Returns empty string when the URL cannot be sanitized.
+func sanitizeRemoteURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	// Handle SCP-style SSH: git@github.com:org/repo.git
+	if strings.HasPrefix(rawURL, "git@") {
+		parts := strings.SplitN(rawURL, ":", 2)
+		if len(parts) != 2 {
+			return ""
+		}
+		host := strings.TrimPrefix(parts[0], "git@")
+		if host == "" || strings.ContainsAny(host, "@/") {
+			return ""
+		}
+		path := strings.TrimSuffix(strings.TrimSuffix(parts[1], "/"), ".git")
+		if path == "" {
+			return ""
+		}
+		return "https://" + host + "/" + path
+	}
+	// For http/https and ssh:// URLs, use net/url to parse and sanitize
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") && !strings.HasPrefix(rawURL, "ssh://") {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	// Convert ssh:// to https://
+	if u.Scheme == "ssh" {
+		u.Scheme = "https"
+	}
+	// Only allow http/https
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	// Reject URLs without a host (e.g. https:///org/repo)
+	if u.Host == "" {
+		return ""
+	}
+	// Strip credentials
+	u.User = nil
+	// Strip trailing slash, then a trailing .git suffix (order matters so
+	// https://host/org/repo.git/ also loses the .git).
+	u.Path = strings.TrimSuffix(u.Path, "/")
+	u.Path = strings.TrimSuffix(u.Path, ".git")
+	return u.String()
 }
 
 func (a *App) noticeForTab(tabID, text string) {

--- a/desktop/app_project_remote_url_test.go
+++ b/desktop/app_project_remote_url_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestProjectRemoteURLIntegration exercises the full git -> sanitize -> cache
+// path with a real temporary repository, mirroring what the desktop UI does
+// when the "Open in GitHub" menu item is opened.
+func TestProjectRemoteURLIntegration(t *testing.T) {
+	repo := t.TempDir()
+	runGitRemote(t, repo, "init", "-q")
+	runGitRemote(t, repo, "remote", "add", "origin", "https://user:ghp_token123@github.com/acme/widget.git")
+
+	a := &App{ctx: context.Background()}
+
+	// First call: sanitized HTTPS URL with credentials stripped.
+	if got := a.ProjectRemoteURL(repo); got != "https://github.com/acme/widget" {
+		t.Fatalf("ProjectRemoteURL = %q, want %q", got, "https://github.com/acme/widget")
+	}
+
+	// The result is cached with a TTL: after removing the remote the cached
+	// value must still be served (the menu keeps working until expiry).
+	runGitRemote(t, repo, "remote", "remove", "origin")
+	if got := a.ProjectRemoteURL(repo); got != "https://github.com/acme/widget" {
+		t.Fatalf("cached ProjectRemoteURL = %q, want %q", got, "https://github.com/acme/widget")
+	}
+
+	// A directory that is not a git repository yields an empty result.
+	if got := a.ProjectRemoteURL(t.TempDir()); got != "" {
+		t.Fatalf("non-repo ProjectRemoteURL = %q, want empty", got)
+	}
+
+	// Blank paths are rejected without touching git.
+	if got := a.ProjectRemoteURL("  "); got != "" {
+		t.Fatalf("blank ProjectRemoteURL = %q, want empty", got)
+	}
+}
+
+func runGitRemote(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/desktop/app_remote_url_test.go
+++ b/desktop/app_remote_url_test.go
@@ -40,6 +40,21 @@ func TestSanitizeRemoteURL(t *testing.T) {
 			want: "https://github.com/org/repo",
 		},
 		{
+			name: "https query dropped",
+			raw:  "https://github.com/org/repo.git?token=abc",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https fragment dropped",
+			raw:  "https://github.com/org/repo.git#readme",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "uppercase .GIT preserved",
+			raw:  "https://github.com/org/repo.GIT",
+			want: "https://github.com/org/repo.GIT",
+		},
+		{
 			name: "https host only",
 			raw:  "https://github.com",
 			want: "https://github.com",
@@ -68,6 +83,11 @@ func TestSanitizeRemoteURL(t *testing.T) {
 		{
 			name: "scp-style ssh nested path",
 			raw:  "git@gitlab.com:group/subgroup/project.git",
+			want: "https://gitlab.com/group/subgroup/project",
+		},
+		{
+			name: "scp-style with non-git user",
+			raw:  "deploy@gitlab.com:group/subgroup/project.git",
 			want: "https://gitlab.com/group/subgroup/project",
 		},
 		// ssh:// URL scheme

--- a/desktop/app_remote_url_test.go
+++ b/desktop/app_remote_url_test.go
@@ -1,0 +1,155 @@
+package main
+
+import "testing"
+
+func TestSanitizeRemoteURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		// HTTPS URLs (the clean path)
+		{
+			name: "simple https",
+			raw:  "https://github.com/org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https without .git",
+			raw:  "https://github.com/org/repo",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https trailing slash",
+			raw:  "https://github.com/org/repo/",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https trailing .git and slash",
+			raw:  "https://github.com/org/repo.git/",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https with credentials stripped",
+			raw:  "https://user:ghp_token123@github.com/org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https with username only stripped",
+			raw:  "https://user@github.com/org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "https host only",
+			raw:  "https://github.com",
+			want: "https://github.com",
+		},
+		// SCP-style SSH (git@host:path)
+		{
+			name: "scp-style ssh",
+			raw:  "git@github.com:org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "scp-style ssh without .git",
+			raw:  "git@github.com:org/repo",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "scp-style ssh trailing slash",
+			raw:  "git@github.com:org/repo/",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "scp-style ssh trailing .git and slash",
+			raw:  "git@github.com:org/repo.git/",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "scp-style ssh nested path",
+			raw:  "git@gitlab.com:group/subgroup/project.git",
+			want: "https://gitlab.com/group/subgroup/project",
+		},
+		// ssh:// URL scheme
+		{
+			name: "ssh URL scheme",
+			raw:  "ssh://git@github.com/org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "ssh URL scheme no .git",
+			raw:  "ssh://git@github.com/org/repo",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "ssh URL scheme trailing .git and slash",
+			raw:  "ssh://git@github.com/org/repo.git/",
+			want: "https://github.com/org/repo",
+		},
+		{
+			name: "ssh URL scheme with port",
+			raw:  "ssh://git@github.com:2222/org/repo.git",
+			want: "https://github.com:2222/org/repo",
+		},
+		{
+			name: "ssh URL credentials stripped",
+			raw:  "ssh://user:pass@github.com/org/repo.git",
+			want: "https://github.com/org/repo",
+		},
+		// HTTP (non-HTTPS)
+		{
+			name: "http URL preserved",
+			raw:  "http://git.example.com/org/repo.git",
+			want: "http://git.example.com/org/repo",
+		},
+		// Invalid / edge cases — should return empty
+		{
+			name: "empty string",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "just whitespace",
+			raw:  "  ",
+			want: "",
+		},
+		{
+			name: "unknown protocol (ftp)",
+			raw:  "ftp://git.example.com/repo",
+			want: "",
+		},
+		{
+			name: "malformed scp no colon",
+			raw:  "git@github.com",
+			want: "",
+		},
+		{
+			name: "malformed scp empty host",
+			raw:  "git@:org/repo.git",
+			want: "",
+		},
+		{
+			name: "scp userinfo injection",
+			raw:  "git@user@host:org/repo.git",
+			want: "",
+		},
+		{
+			name: "https missing host",
+			raw:  "https:///org/repo",
+			want: "",
+		},
+		{
+			name: "random text",
+			raw:  "not a git url",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeRemoteURL(tt.raw)
+			if got != tt.want {
+				t.Errorf("sanitizeRemoteURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -8,7 +8,7 @@ import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as React
 import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
-import { app } from "../lib/bridge";
+import { app, openExternal } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
 import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeTopicPageIsFresh, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
@@ -335,6 +335,15 @@ function menuLabelWithCheck(label: string, checked: boolean) {
   );
 }
 
+// GithubSvg is a small GitHub logo icon for the context menu.
+function GithubSvg({ size = 13 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.167 6.839 9.49.5.09.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.577.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+    </svg>
+  );
+}
+
 function revealLabelKey(platform: string): "projectTree.revealInFinder" | "projectTree.revealInExplorer" | "projectTree.revealInFileManager" {
   if (platform === "darwin") return "projectTree.revealInFinder";
   if (platform === "windows") return "projectTree.revealInExplorer";
@@ -412,6 +421,7 @@ export function ProjectTree({
   const [worktreeAvailability, setWorktreeAvailability] = useState<Record<string, { available: boolean; reason?: string }>>({});
   const [confirmAction, setConfirmAction] = useState<{ topicId: string; action: "trash" } | null>(null);
   const [confirmRemoveProject, setConfirmRemoveProject] = useState<string | null>(null);
+  const [githubUrls, setGithubUrls] = useState<Record<string, string>>({});
   const [dragProjectRoot, setDragProjectRoot] = useState<string | null>(null);
   const [dropProject, setDropProject] = useState<{ root: string; position: ProjectDropPosition } | null>(null);
   const [collapseSnapshot, setCollapseSnapshot] = useState<CollapseSnapshot | null>(null);
@@ -1483,6 +1493,17 @@ export function ProjectTree({
       setMenuPoint(contextMenuPointFromEvent(event));
       setMenuProject({ key, root: projectRoot, path: projectPath, scope, label: projectLabel });
       setConfirmRemoveProject(null);
+      // Fetch the sanitized GitHub URL for the menu. The Go side caches with a
+      // TTL, so re-querying on every open stays cheap and picks up newly added
+      // remotes (e.g. after `git init` or `git remote add origin`) instead of
+      // caching an empty result forever on the frontend.
+      if (projectPath) {
+        app.ProjectRemoteURL(projectPath).then(url => {
+          setGithubUrls(prev => ({ ...prev, [projectPath]: url || "" }));
+        }).catch(() => {
+          setGithubUrls(prev => ({ ...prev, [projectPath]: "" }));
+        });
+      }
       if (scope === "project" && projectRoot) {
         void app.IsolatedWorktreeAvailability(projectRoot).then((availability) => {
           setWorktreeAvailability((current) => ({
@@ -1551,6 +1572,17 @@ export function ProjectTree({
           closeMenu();
         },
       },
+      {
+        key: "open-in-github",
+        icon: <GithubSvg size={13} />,
+        label: t("projectTree.openInGithub"),
+        disabled: !projectPath || (projectPath in githubUrls && !githubUrls[projectPath]),
+        onSelect: () => {
+          const url = githubUrls[projectPath];
+          if (url) openExternal(url);
+          closeMenu();
+        },
+      },
       ...(scope === "project"
         ? [
             { type: "separator" as const, key: "remove-separator" },
@@ -1609,6 +1641,17 @@ export function ProjectTree({
           if (!activeTopicId) return;
           if (confirmAction?.topicId === activeTopicId && confirmAction.action === "trash") void trashTopic(activeTopicId);
           else setConfirmAction({ topicId: activeTopicId, action: "trash" });
+        },
+      },
+      {
+        key: "open-in-github",
+        icon: <GithubSvg size={13} />,
+        label: t("projectTree.openInGithub"),
+        disabled: !projectPath || (projectPath in githubUrls && !githubUrls[projectPath]),
+        onSelect: () => {
+          const url = githubUrls[projectPath];
+          if (url) openExternal(url);
+          closeMenu();
         },
       },
       ...(scope === "project"

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1576,7 +1576,7 @@ export function ProjectTree({
         key: "open-in-github",
         icon: <GithubSvg size={13} />,
         label: t("projectTree.openInGithub"),
-        disabled: !projectPath || (projectPath in githubUrls && !githubUrls[projectPath]),
+        disabled: !projectPath || !(projectPath in githubUrls) || !githubUrls[projectPath],
         onSelect: () => {
           const url = githubUrls[projectPath];
           if (url) openExternal(url);
@@ -1647,7 +1647,7 @@ export function ProjectTree({
         key: "open-in-github",
         icon: <GithubSvg size={13} />,
         label: t("projectTree.openInGithub"),
-        disabled: !projectPath || (projectPath in githubUrls && !githubUrls[projectPath]),
+        disabled: !projectPath || !(projectPath in githubUrls) || !githubUrls[projectPath],
         onSelect: () => {
           const url = githubUrls[projectPath];
           if (url) openExternal(url);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -437,6 +437,7 @@ export interface AppBindings extends SessionCatalogBindings, HistoryCatalogBindi
   RevealWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
+  ProjectRemoteURL(path: string): Promise<string>;
   OpenLocalPath(path: string): Promise<void>;
   SavePastedImage(dataUrl: string): Promise<string>;
   SaveClipboardImage(): Promise<string>;
@@ -4110,6 +4111,9 @@ function makeMockApp(): AppBindings {
     },
     async RevealPath(path: string) {
       console.info("mock RevealPath", path);
+    },
+    async ProjectRemoteURL(_path: string): Promise<string> {
+      return "";
     },
     async SavePastedImage(dataUrl: string) {
       const path = `.reasonix/attachments/mock-${mockAttachmentDataURLs.size + 1}.png`;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1294,6 +1294,7 @@ export const en = {
   "projectTree.revealInFinder": "Show in Finder",
   "projectTree.revealInExplorer": "Show in File Explorer",
   "projectTree.revealInFileManager": "Show in file manager",
+  "projectTree.openInGithub": "Open in GitHub",
   "projectTree.topicActions": "Session actions",
   "projectTree.projectActions": "Project actions",
   "projectTree.colorDefault": "Default",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1050,6 +1050,7 @@ export const zhTW: Record<DictKey, string> = {
   "projectTree.revealInFinder": "在 Finder 中顯示",
   "projectTree.revealInExplorer": "在檔案總管中顯示",
   "projectTree.revealInFileManager": "在檔案管理器中顯示",
+  "projectTree.openInGithub": "在 GitHub 中打開",
   "projectTree.topicActions": "會話操作",
   "projectTree.projectActions": "專案操作",
   "projectTree.colorDefault": "預設",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1295,6 +1295,7 @@ export const zh: Record<DictKey, string> = {
   "projectTree.revealInFinder": "在 Finder 中显示",
   "projectTree.revealInExplorer": "在文件资源管理器中显示",
   "projectTree.revealInFileManager": "在文件管理器中显示",
+  "projectTree.openInGithub": "在 GitHub 中打开",
   "projectTree.topicActions": "会话操作",
   "projectTree.projectActions": "项目操作",
   "projectTree.colorDefault": "默认",


### PR DESCRIPTION
## Summary

Adds an "Open in GitHub" option to the project right-click context menu (both classic and workbench modes). When clicked, it reads the git remote origin URL and opens the repository page in the system browser.

## Changes

### Go Backend
- Added ProjectRemoteURL(path string) string method to App in desktop/app.go
 - Runs git config --get remote.origin.url
 - Converts SSH format (git@github.com:user/repo.git) to HTTPS
 - Strips trailing .git suffix

### Frontend (TypeScript/React)
- Added ProjectRemoteURL to AppBindings interface and mock in ridge.ts
- Added "Open in GitHub" menu item to both classic and workbench project menus in ProjectTree.tsx
- Uses ExternalLink Lucide icon

### i18n
- Added "projectTree.openInGithub" to en.ts, zh.ts, zh-TW.ts

## Cache-impact: none
## Cache-guard: no system prompt or tool schema changes
Documentation-impact: none - UI/localization-only change (new "Open in GitHub" project context-menu action in desktop/frontend plus a Go binding and en/zh/zh-TW i18n strings); no user-facing documentation is affected.