### PR TITLE
feat: 拖拽文件夹到输入框自动插入路径文本

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6399,7 +6399,7 @@ func (a *App) AttachmentDataURL(path string) (string, error) {
 // image or out-of-tree file is copied into .reasonix/attachments. A directory
 // dropped from outside the workspace is returned as "folder" for text insertion.
 type DroppedItem struct {
-	Kind       string `json:"kind"` // "workspace" | "attachment"
+	Kind       string `json:"kind"` // "workspace" | "attachment" | "folder"
 	Path       string `json:"path"`
 	IsDir      bool   `json:"isDir,omitempty"`
 	PreviewURL string `json:"previewUrl,omitempty"`
@@ -6429,8 +6429,9 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 			return nil
 		}
 		if info.IsDir() {
-			// Return the absolute path for direct text insertion in the composer
-			item = DroppedItem{Kind: "folder", Path: path}
+			// Return the normalized absolute path for direct text insertion
+			// in the composer; filepath.ToSlash ensures Windows compatibility.
+			item = DroppedItem{Kind: "folder", Path: filepath.ToSlash(path), IsDir: true}
 			return nil
 		}
 		rel, err := control.SaveAttachmentFile(path)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6396,7 +6396,8 @@ func (a *App) AttachmentDataURL(path string) (string, error) {
 
 // DroppedItem is one OS-dropped file resolved into a composer context entry: an
 // in-tree file becomes a workspace @reference (read in place, no copy), while an
-// image or out-of-tree file is copied into .reasonix/attachments.
+// image or out-of-tree file is copied into .reasonix/attachments. A directory
+// dropped from outside the workspace is returned as "folder" for text insertion.
 type DroppedItem struct {
 	Kind       string `json:"kind"` // "workspace" | "attachment"
 	Path       string `json:"path"`
@@ -6407,7 +6408,8 @@ type DroppedItem struct {
 // AttachDropped turns an absolute path from the native file-drop bridge into a
 // composer context entry. Images are stored as attachments so the chip shows a
 // thumbnail; other in-workspace files are referenced relatively (no copy); files
-// outside the workspace are copied into .reasonix/attachments.
+// outside the workspace are copied into .reasonix/attachments; directories
+// outside the workspace are returned as "folder" for direct path insertion.
 func (a *App) AttachDropped(path string) (DroppedItem, error) {
 	var item DroppedItem
 	err := a.withActiveWorkspaceDo(func() error {
@@ -6427,7 +6429,9 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 			return nil
 		}
 		if info.IsDir() {
-			return fmt.Errorf("can only attach files from outside the workspace")
+			// Return the absolute path for direct text insertion in the composer
+			item = DroppedItem{Kind: "folder", Path: path}
+			return nil
 		}
 		rel, err := control.SaveAttachmentFile(path)
 		if err != nil {

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -249,7 +249,7 @@ func TestAttachDroppedOutsideWorkspaceDirReturnsFolder(t *testing.T) {
 	if got.Kind != "folder" {
 		t.Fatalf("got kind=%q, want %q", got.Kind, "folder")
 	}
-	if got.Path != outsideDir {
-		t.Fatalf("got path=%q, want %q (the original absolute path)", got.Path, outsideDir)
+	if got.Path != filepath.ToSlash(outsideDir) {
+		t.Fatalf("got path=%q, want %q (the normalized absolute path)", got.Path, filepath.ToSlash(outsideDir))
 	}
 }

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -225,3 +225,31 @@ func TestAttachDroppedImageStoresThumbnail(t *testing.T) {
 		t.Fatalf("preview = %q, want png data URL", got.PreviewURL)
 	}
 }
+
+func TestAttachDroppedOutsideWorkspaceDirReturnsFolder(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	outside := t.TempDir()
+	// Create a subdirectory inside the temp dir
+	outsideDir := filepath.Join(outside, "myfolder")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&App{}).AttachDropped(outsideDir)
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if got.Kind != "folder" {
+		t.Fatalf("got kind=%q, want %q", got.Kind, "folder")
+	}
+	if got.Path != outsideDir {
+		t.Fatalf("got path=%q, want %q (the original absolute path)", got.Path, outsideDir)
+	}
+}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1230,6 +1230,9 @@ export function Composer({
           // input. Use textRef (synced with text state) instead of the stale
           // closure `text` or DOM value to avoid race conditions when multiple
           // drops arrive before React re-renders.
+          // Skip insertion if the user switched drafts while we were awaiting
+          // AttachDropped — the path would land in the wrong input.
+          if (activeDraftKeyRef.current !== sourceDraftKey) continue;
           const currentText = textRef.current;
           const sep = currentText.length > 0 && !currentText.endsWith(" ") ? " " : "";
           const next = currentText + sep + item.path + " ";

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1226,12 +1226,15 @@ export function Composer({
         if (attachmentSeenInDraft(sourceDraftKey, key)) continue;
         const item = await app.AttachDropped(path);
         if (item.kind === "folder") {
-          // Dropped directories become plain text paths appended to the composer input.
-          // Read from the live textarea DOM value to avoid stale closure (the
-          // onFilesDropped callback captures attachDroppedPaths from first render).
-          const currentText = taRef.current?.value ?? text;
+          // Dropped directories become plain text paths appended to the composer
+          // input. Use textRef (synced with text state) instead of the stale
+          // closure `text` or DOM value to avoid race conditions when multiple
+          // drops arrive before React re-renders.
+          const currentText = textRef.current;
           const sep = currentText.length > 0 && !currentText.endsWith(" ") ? " " : "";
-          setTextCaretEnd(currentText + sep + item.path + " ");
+          const next = currentText + sep + item.path + " ";
+          textRef.current = next;
+          setTextCaretEnd(next);
         } else if (item.kind === "workspace") {
           addWorkspaceReferenceToDraft(sourceDraftKey, { path: item.path, isDir: item.isDir });
         } else {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1226,9 +1226,12 @@ export function Composer({
         if (attachmentSeenInDraft(sourceDraftKey, key)) continue;
         const item = await app.AttachDropped(path);
         if (item.kind === "folder") {
-          // Dropped directories become plain text paths in the composer input
-          const sep = text.length > 0 && !text.endsWith(" ") ? " " : "";
-          setTextCaretEnd(text + sep + item.path + " ");
+          // Dropped directories become plain text paths appended to the composer input.
+          // Read from the live textarea DOM value to avoid stale closure (the
+          // onFilesDropped callback captures attachDroppedPaths from first render).
+          const currentText = taRef.current?.value ?? text;
+          const sep = currentText.length > 0 && !currentText.endsWith(" ") ? " " : "";
+          setTextCaretEnd(currentText + sep + item.path + " ");
         } else if (item.kind === "workspace") {
           addWorkspaceReferenceToDraft(sourceDraftKey, { path: item.path, isDir: item.isDir });
         } else {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1216,7 +1216,7 @@ export function Composer({
 
   // OS file drops arrive as absolute paths through the native bridge (the webview
   // withholds them from the HTML drop event); the kernel resolves each into a
-  // workspace @reference or a stored attachment.
+  // workspace @reference or a stored attachment; directories are inserted as text.
   const attachDroppedPaths = async (paths: string[], sourceDraftKey = activeDraftKeyRef.current) => {
     setDragOver(false);
     for (const path of paths) {
@@ -1225,7 +1225,11 @@ export function Composer({
         const key = { hash: "", source: `path:${path}` };
         if (attachmentSeenInDraft(sourceDraftKey, key)) continue;
         const item = await app.AttachDropped(path);
-        if (item.kind === "workspace") {
+        if (item.kind === "folder") {
+          // Dropped directories become plain text paths in the composer input
+          const sep = text.length > 0 && !text.endsWith(" ") ? " " : "";
+          setTextCaretEnd(text + sep + item.path + " ");
+        } else if (item.kind === "workspace") {
           addWorkspaceReferenceToDraft(sourceDraftKey, { path: item.path, isDir: item.isDir });
         } else {
           addAttachmentToDraft(sourceDraftKey, { path: item.path, previewUrl: item.previewUrl, displayName: baseName(path) }, key);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -2321,6 +2321,11 @@ function makeMockApp(): AppBindings {
     },
     async AttachDropped(path: string) {
       const name = path.split(/[/\\]/).filter(Boolean).pop() ?? path;
+      // Rough heuristic for dev mock: paths without a file extension are treated as folders
+      const hasExt = /\.\w{1,6}$/i.test(name);
+      if (!hasExt) {
+        return { kind: "folder" as const, path };
+      }
       return { kind: "attachment" as const, path: `.reasonix/attachments/mock-${name}` };
     },
     async AttachmentDataURL(_path: string) {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -496,7 +496,7 @@ export interface DirEntry {
 }
 
 export interface DroppedItem {
-  kind: "workspace" | "attachment";
+  kind: "workspace" | "attachment" | "folder";
   path: string;
   isDir?: boolean;
   previewUrl?: string;


### PR DESCRIPTION
## Summary

从 Finder 拖拽文件夹到 Composer 输入框区域时，自动将文件夹的绝对路径作为纯文本插入输入框，而不是报错或添加为附件。

## Changes

- **Go (app.go)**: 工作区外的目录拖拽不再报错，返回 `DroppedItem{Kind:"folder", Path, IsDir:true}`，使用 `filepath.ToSlash` 确保 Windows 兼容
- **Frontend (types.ts)**: `DroppedItem.kind` 增加 `"folder"` 类型
- **Frontend (Composer.tsx)**: 在 `attachDroppedPaths` 中新增 `kind==="folder"` 分支，用 `textRef` 追加路径文本到输入框（支持连续拖拽、不覆盖已有文本）
- **Test**: 新增 `TestAttachDroppedOutsideWorkspaceDirReturnsFolder` 覆盖新路径
- **Mock (bridge.ts)**: dev mock 支持 folder 分支

## Review

- [x] macOS 实测通过
- [x] 已有文本不丢失（追加而非覆盖）
- [x] 连续拖拽多个文件夹无竞态条件
- [x] Go 测试全部通过（6/6）
- [x] `wails build` 编译通过
- [x] 多重走查（pr-review + ponytail-review + review）所有 blocker 已修复

Refs #5370

Note: this PR covers the folder-drag portion of #5370 only; the font-size/custom scaling request remains open for follow-up.