### PR TITLE
feat(plugin): add disabled_tools filter for MCP servers

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1486,6 +1486,15 @@ func PluginSpecsForRootWithOptions(entries []config.PluginEntry, workspaceRoot s
 
 func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, opts PluginSpecOptions) plugin.Spec {
 	e = e.ExpandedPlugin() // resolve ${VAR} / ${VAR:-default} from the environment
+	var disabled map[string]bool
+	if len(e.DisabledTools) > 0 {
+		disabled = make(map[string]bool, len(e.DisabledTools))
+		for _, name := range e.DisabledTools {
+			if name = strings.TrimSpace(name); name != "" {
+				disabled[name] = true
+			}
+		}
+	}
 	return plugin.ApplyKnownOverrides(plugin.Spec{
 		Name:               e.Name,
 		Type:               e.Type,
@@ -1498,6 +1507,7 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 		CallTimeout:        secondsDuration(e.CallTimeoutSeconds),
 		ToolTimeouts:       toolTimeoutDurations(e.ToolTimeoutSeconds),
 		ReadOnlyToolNames:  trustedRawReadOnlyToolNames(e.TrustedReadOnlyTools),
+		DisabledTools:      disabled,
 	}, workspaceRoot)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1316,6 +1316,12 @@ type PluginEntry struct {
 	// AutoStart controls whether the server connects during session startup.
 	// Nil preserves historical behavior: configured servers start automatically.
 	AutoStart *bool `toml:"auto_start"`
+	// DisabledTools lists raw MCP tool names (as reported by the server in
+	// tools/list) to exclude from registration. Disabled tools never enter the
+	// model context, never count toward token budgets, and never appear in
+	// /mcp output. Names use the raw form ("read_file"), not the namespaced
+	// "mcp__<server>__<tool>" form. Empty/nil = no filtering (backward compat).
+	DisabledTools []string `toml:"disabled_tools"`
 	// Tier is a legacy compatibility field. New config rendering omits it; enabled
 	// MCP servers connect automatically in the background unless auto_start=false.
 	// Historical values are accepted for old files:

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -571,6 +571,10 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 				b.WriteString("# optional pre-seeded MCP read-only trust; the approval prompt can also remember this\n")
 				fmt.Fprintf(&b, "trusted_read_only_tools = %s\n", renderStringArray(pl.TrustedReadOnlyTools))
 			}
+			if len(pl.DisabledTools) > 0 {
+				b.WriteString("# Raw MCP tool names to exclude from registration.\n")
+				fmt.Fprintf(&b, "disabled_tools = %s\n", renderStringArray(pl.DisabledTools))
+			}
 			if pl.AutoStart != nil {
 				fmt.Fprintf(&b, "auto_start = %v\n", *pl.AutoStart)
 			}
@@ -966,6 +970,10 @@ func RenderTOMLProjectDelta(c *Config) string {
 		if len(pl.TrustedReadOnlyTools) > 0 {
 			b.WriteString("# optional pre-seeded MCP read-only trust; the approval prompt can also remember this\n")
 			fmt.Fprintf(&b, "trusted_read_only_tools = %s\n", renderStringArray(pl.TrustedReadOnlyTools))
+		}
+		if len(pl.DisabledTools) > 0 {
+			b.WriteString("# Raw MCP tool names to exclude from registration.\n")
+			fmt.Fprintf(&b, "disabled_tools = %s\n", renderStringArray(pl.DisabledTools))
 		}
 		if pl.AutoStart != nil {
 			fmt.Fprintf(&b, "auto_start = %v\n", *pl.AutoStart)

--- a/internal/config/tools_test.go
+++ b/internal/config/tools_test.go
@@ -90,6 +90,52 @@ func TestBackgroundJobStalledWarningSecondsDefault(t *testing.T) {
 	}
 }
 
+func TestPluginEntryTOMLDisabledTools(t *testing.T) {
+	cfg := Default()
+	input := `[[plugins]]
+name = "test"
+command = "test-cmd"
+disabled_tools = ["write_file", "delete_file"]
+`
+	if _, err := toml.Decode(input, cfg); err != nil {
+		t.Fatalf("decode plugin with disabled_tools: %v", err)
+	}
+	if len(cfg.Plugins) != 1 {
+		t.Fatalf("want 1 plugin, got %d", len(cfg.Plugins))
+	}
+	got := cfg.Plugins[0].DisabledTools
+	want := []string{"write_file", "delete_file"}
+	if len(got) != len(want) {
+		t.Fatalf("DisabledTools = %v (len=%d), want %v (len=%d)", got, len(got), want, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DisabledTools[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPluginEntryTOMLDisabledToolsEmpty(t *testing.T) {
+	cfg := Default()
+	input := `[[plugins]]
+name = "test"
+command = "test-cmd"
+disabled_tools = []
+`
+	if _, err := toml.Decode(input, cfg); err != nil {
+		t.Fatalf("decode plugin with empty disabled_tools: %v", err)
+	}
+	if len(cfg.Plugins) != 1 {
+		t.Fatalf("want 1 plugin, got %d", len(cfg.Plugins))
+	}
+	if cfg.Plugins[0].DisabledTools == nil {
+		t.Fatal("empty [] decoded as nil, want non-nil empty slice")
+	}
+	if len(cfg.Plugins[0].DisabledTools) != 0 {
+		t.Fatalf("DisabledTools = %v, want empty", cfg.Plugins[0].DisabledTools)
+	}
+}
+
 func TestBackgroundJobStalledWarningSecondsAllowsExplicitZero(t *testing.T) {
 	cfg := Default()
 	cfg.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(0)

--- a/internal/plugin/cache.go
+++ b/internal/plugin/cache.go
@@ -95,6 +95,9 @@ func SpecFingerprint(s Spec) string {
 	if len(s.ReadOnlyModelToolNames) > 0 {
 		writeBoolKV(h, "read_only_model_tool", s.ReadOnlyModelToolNames)
 	}
+	if len(s.DisabledTools) > 0 {
+		writeBoolKV(h, "disabled_tool", s.DisabledTools)
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/plugin/disabled_tools_test.go
+++ b/internal/plugin/disabled_tools_test.go
@@ -1,0 +1,177 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+// disabledToolsTransport returns a fixed tools/list response with 3 tools: foo, bar, baz.
+type disabledToolsTransport struct {
+	mu  sync.Mutex
+	raw json.RawMessage
+}
+
+func (t *disabledToolsTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if method != "tools/list" {
+		return json.RawMessage(`{}`), nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.raw) > 0 {
+		return t.raw, nil
+	}
+	// Return 3 tools: foo has no annotations, bar is read-only, baz is unannotated.
+	return json.RawMessage(`{"tools":[
+		{"name":"foo","description":"The first tool.","inputSchema":{"type":"object"}},
+		{"name":"bar","description":"The second tool.","inputSchema":{"type":"object"},"annotations":{"readOnlyHint":true}},
+		{"name":"baz","description":"The third tool.","inputSchema":{"type":"object"}}
+	]}`), nil
+}
+
+func (t *disabledToolsTransport) notify(ctx context.Context, method string, params any) error {
+	return nil
+}
+func (t *disabledToolsTransport) close() {}
+
+// TestListToolsFiltersDisabledTools verifies that listTools skips tools whose
+// raw names are in the spec's DisabledTools set, and that c.tools is updated
+// accordingly (exercises the toolsListed short-circuit cache path).
+func TestListToolsFiltersDisabledTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tr := &disabledToolsTransport{}
+	c := &Client{
+		name:      "test",
+		t:         tr,
+		spec:      Spec{Name: "test", DisabledTools: map[string]bool{"foo": true}},
+		transport: "stdio",
+	}
+
+	tools, err := c.listTools(ctx)
+	if err != nil {
+		t.Fatalf("listTools: %v", err)
+	}
+	// Expect 2 tools (bar, baz) — foo is disabled.
+	if len(tools) != 2 {
+		t.Fatalf("listTools returned %d tools, want 2 (foo should be filtered)", len(tools))
+	}
+	for _, tl := range tools {
+		if tl.Name() == "mcp__test__foo" {
+			t.Fatal("listTools returned disabled tool mcp__test__foo")
+		}
+	}
+	// Verify the short-circuit cache returns the same filtered set.
+	cached, err := c.listTools(ctx)
+	if err != nil {
+		t.Fatalf("second listTools (cache hit): %v", err)
+	}
+	if len(cached) != 2 {
+		t.Fatalf("cached listTools returned %d tools, want 2", len(cached))
+	}
+	// Verify c.tools also matches (used by /mcp rendering).
+	if len(c.tools) != 2 {
+		t.Fatalf("c.tools has %d entries, want 2", len(c.tools))
+	}
+	for _, info := range c.tools {
+		if info.Name == "foo" {
+			t.Fatal("c.tools contains disabled tool foo")
+		}
+	}
+}
+
+// TestIsToolDisabledNilAndEmpty verifies that nil and empty DisabledTools
+// behave identically: isToolDisabled always returns false, no panic.
+func TestIsToolDisabledNilAndEmpty(t *testing.T) {
+	for name, disabled := range map[string]map[string]bool{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := Spec{DisabledTools: disabled}
+			if s.isToolDisabled("anything") {
+				t.Fatalf("%s DisabledTools: isToolDisabled returned true", name)
+			}
+		})
+	}
+}
+
+// TestSpecFingerprintNilVsEmptyDisabledTools verifies that nil and empty
+// DisabledTools produce the same SpecFingerprint, preserving backward
+// compatibility with caches written before DisabledTools existed.
+func TestSpecFingerprintNilVsEmptyDisabledTools(t *testing.T) {
+	sNil := Spec{Name: "s", Type: "stdio", Command: "cmd", DisabledTools: nil}
+	sEmpty := Spec{Name: "s", Type: "stdio", Command: "cmd", DisabledTools: map[string]bool{}}
+
+	hNil := SpecFingerprint(sNil)
+	hEmpty := SpecFingerprint(sEmpty)
+
+	if hNil != hEmpty {
+		t.Fatalf("SpecFingerprint(nil) = %q, SpecFingerprint(empty) = %q, want equal", hNil, hEmpty)
+	}
+}
+
+// TestSpecFingerprintWithoutDisabledTools verifies that a Spec with no
+// DisabledTools field produces the same fingerprint as an older Spec struct
+// that never had the field (backward-compatibility guard).
+func TestSpecFingerprintWithoutDisabledTools(t *testing.T) {
+	// This spec deliberately omits DisabledTools (zero-value nil).
+	s := Spec{Name: "my-server", Type: "stdio", Command: "/usr/bin/example", Args: []string{"--flag", "x"}, Env: map[string]string{"FOO": "1", "BAR": "2"}, Headers: map[string]string{"X-Custom": "ok"}, Dir: "/work"}
+	_ = SpecFingerprint(s) // must not panic; value not validated, only that it runs without the field
+}
+
+// TestLazyToolsetCacheHitFiltersDisabledTools verifies that the cache-hit
+// branch of LazyToolset skips tools in DisabledTools.
+func TestLazyToolsetCacheHitFiltersDisabledTools(t *testing.T) {
+	redirectCache(t)
+	spec := Spec{
+		Name:          "srv",
+		DisabledTools: map[string]bool{"a": true},
+	}
+	cs := &CachedSchema{
+		SpecHash: SpecFingerprint(spec),
+		Tools: []CachedTool{
+			{Name: "a", Description: "disabled tool"},
+			{Name: "b", Description: "kept tool"},
+		},
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("LazyToolset returned %d tools, want 1 (tool a should be filtered)", len(tools))
+	}
+	if tools[0].Name() != "mcp__srv__b" {
+		t.Fatalf("expected tool name mcp__srv__b, got %q", tools[0].Name())
+	}
+}
+
+// TestCacheInvalidatesWhenDisabledToolsChanges verifies that SpecFingerprint
+// changes when DisabledTools is modified, forcing a cache miss.
+func TestCacheInvalidatesWhenDisabledToolsChanges(t *testing.T) {
+	redirectCache(t)
+
+	spec := sampleSpec()
+	spec.DisabledTools = map[string]bool{"write_file": true}
+	hash := SpecFingerprint(spec)
+	if err := SaveCachedSchema(spec.Name, sampleCachedSchema(hash)); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+
+	// Change DisabledTools — should produce a different hash.
+	changed := sampleSpec()
+	changed.DisabledTools = map[string]bool{"delete_file": true}
+	if _, ok := LoadCachedSchema(spec.Name, SpecFingerprint(changed)); ok {
+		t.Fatal("LoadCachedSchema: hit after DisabledTools changed")
+	}
+}

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -370,6 +370,9 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 	} else {
 		out = make([]tool.Tool, 0, len(cs.Tools))
 		for _, ct := range cs.Tools {
+			if spec.isToolDisabled(ct.Name) {
+				continue
+			}
 			visibleName := ct.Name
 			if spec.StripRawPrefix != "" {
 				visibleName = strings.TrimPrefix(visibleName, spec.StripRawPrefix)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -72,6 +72,11 @@ type Spec struct {
 	// declarations such as agent.plan_mode_allowed_tools without reverse-parsing
 	// normalized MCP tool names back into raw server-local names.
 	ReadOnlyModelToolNames map[string]bool
+	// DisabledTools is the set of raw tool names (as returned by tools/list)
+	// that should be filtered out before they reach the registry. Filtering
+	// happens inside listTools so every downstream path — eager registration,
+	// the on-disk schema cache, and Host.ToolsFor — sees a consistent view.
+	DisabledTools map[string]bool
 	// StripRawPrefix, when non-empty, removes this prefix from each MCP tool's
 	// raw name before namespacing. For example, StripRawPrefix="server_" turns
 	// "server_search" into "search", yielding "mcp__search__search" instead of
@@ -1111,6 +1116,12 @@ func (s Spec) toolReadOnlyTrusted(rawName, visibleName string) bool {
 	return s.ReadOnlyToolNames[rawName] || s.ReadOnlyModelToolNames[toolName(s.Name, visibleName)]
 }
 
+// isToolDisabled reports whether rawName (the original MCP tool name) is
+// excluded by this server's disabled_tools list.
+func (s Spec) isToolDisabled(rawName string) bool {
+	return len(s.DisabledTools) > 0 && s.DisabledTools[rawName]
+}
+
 func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	c.toolsMu.Lock()
 	defer c.toolsMu.Unlock()
@@ -1132,6 +1143,9 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	toolInfos := make([]ToolInfo, 0, len(out.Tools))
 	tools := make([]tool.Tool, 0, len(out.Tools))
 	for _, t := range out.Tools {
+		if c.spec.isToolDisabled(t.Name) {
+			continue
+		}
 		hinted := t.Annotations != nil && t.Annotations.ReadOnlyHint
 		visibleName := t.Name
 		if c.spec.StripRawPrefix != "" {

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -165,6 +165,11 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # # Optional pre-seeded read-only trust. Interactive sessions can also remember
 # # audited third-party readers when you choose "always allow" from the trust prompt.
 # # trusted_read_only_tools = ["search"]
+# # Filter out specific tools the MCP server exposes — they never enter the
+# # model context, never appear in /mcp, and never count toward tokens.
+# # Names are the raw tool names from tools/list (e.g. "write_file"), not
+# # the namespaced "mcp__<server>__<tool>" form.
+# # disabled_tools = ["write_file", "delete_file"]
 # # Enabled MCP servers connect automatically in the background after session
 # # start. Use /mcp or the desktop MCP panel to refresh, reconnect, or disable.
 


### PR DESCRIPTION
Closed #5444 

## Summary

- Add per-plugin `disabled_tools` config field: a list of raw MCP tool names (as reported by the server in `tools/list`) to exclude from registration. Disabled tools never enter the model context, never appear in `/mcp`, and never count toward token budgets.
- Filter is applied at both tool-loading paths — `listTools` (eager, post-handshake) and `LazyToolset` (cache-hit, pre-handshake) — so every downstream consumer (registry, on-disk schema cache, `Host.ToolsFor`) sees a consistent view.
- `disabled_tools` is folded into `SpecFingerprint` so changing the list invalidates the on-disk schema cache (next launch re-handshakes instead of serving stale tools).
- Backward compatible: `nil`/empty `disabled_tools` produces the same fingerprint and behavior as a pre-field Spec, so existing caches keep hitting.

## Verification

- `go vet ./internal/plugin/... ./internal/config/... ./internal/boot/...` — clean.
- `go build ./...` — clean.
- `gofmt -l` on changed Go files — empty (clean).
- `go test ./internal/plugin/ ./internal/config/` — `ok reasonix/internal/plugin`, `ok reasonix/internal/config`.
- New tests: `TestPluginEntryTOMLDisabledTools`, `TestPluginEntryTOMLDisabledToolsEmpty`, `TestListToolsFiltersDisabledTools` (incl. short-circuit cache path + `c.tools`), `TestIsToolDisabledNilAndEmpty`, `TestSpecFingerprintNilVsEmptyDisabledTools`, `TestSpecFingerprintWithoutDisabledTools`, `TestLazyToolsetCacheHitFiltersDisabledTools`, `TestCacheInvalidatesWhenDisabledToolsChanges`.

## Cache impact

Cache-impact: low — `disabled_tools` is added to `SpecFingerprint`. Toggling the list changes the fingerprint and correctly invalidates the on-disk schema cache (forcing a re-handshake). Existing configs without `disabled_tools` keep the same fingerprint as before the field existed, so warm caches are preserved.

Cache-guard: `TestSpecFingerprintNilVsEmptyDisabledTools` (nil vs empty parity) + `TestCacheInvalidatesWhenDisabledToolsChanges` (fingerprint changes → cache miss) + `TestSpecFingerprintWithoutDisabledTools` (omitted field = old-struct parity).

System-prompt-review: Pending review from @esengine  — this PR modifies boot/config for tool filtering; registry-level change only, no prompt-prefix content alterations. Awaiting explicit sign-off.
The changes for sysPrompt assembly in boot.Build — `disabled_tools` acts on the tool registry (`listTools`/`LazyToolset` → `reg.Add`), downstream of and separate from `ResolveSystemPromptForRoot` + `memory.Compose` + `skill.ApplyIndex` + `outputstyle.Apply`; no provider-visible prompt-prefix content changes.