### PR TITLE
fix(memory,security): fix 13 bugs (5 CRITICAL, 8 HIGH) in memory, sandbox, permission, agent

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -303,6 +303,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 		Content: "Summary of the later conversation (compacted from here on):\n" + summary,
 	})
 	a.session.Replace(next)
+	a.session.IncrementRewrite()
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d later messages → summary", len(region))})
 	return nil
@@ -336,6 +337,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	})
 	next = append(next, msgs[toIdx:]...)
 	a.session.Replace(next)
+	a.session.IncrementRewrite()
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d earlier messages → summary", len(region))})
 	return nil

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -316,6 +316,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				}
 			}
 			markCancelled(err)
+			wg.Wait() // ensure spawned goroutines exit before returning (was leak on ctx cancel)
 			return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
 		}
 	}

--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -245,19 +245,30 @@ func importTarget(line string) (string, bool) {
 	return p, true
 }
 
-// resolvePath turns an import token into a filesystem path: ~ expands to home,
-// absolute paths pass through, everything else is relative to baseDir.
+// resolvePath turns an import token into a filesystem path. Home-relative ("~")
+// and absolute imports are refused so a memory can't read sensitive files
+// outside the project tree (e.g. ~/.ssh/id_rsa). Only paths relative to
+// baseDir are allowed, and the resolved target must stay inside baseDir's
+// subtree; an import that escapes returns "" so the caller skips it.
 func resolvePath(p, baseDir string) string {
-	if strings.HasPrefix(p, "~") {
-		if home, err := os.UserHomeDir(); err == nil {
-			rest := strings.TrimLeft(p[1:], "/\\")
-			return filepath.Join(home, rest)
-		}
+	cleaned := strings.TrimSpace(p)
+	if cleaned == "" || strings.HasPrefix(cleaned, "~") || filepath.IsAbs(cleaned) {
+		return ""
 	}
-	if filepath.IsAbs(p) {
-		return p
+	joined := filepath.Join(baseDir, cleaned)
+	abs, err := filepath.Abs(joined)
+	if err != nil {
+		return joined
 	}
-	return filepath.Join(baseDir, p)
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return abs
+	}
+	rel, err := filepath.Rel(baseAbs, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return abs
 }
 
 // absOf returns the absolute form of p, falling back to a cleaned p on error so

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -184,10 +184,10 @@ func (s Store) Save(m Memory) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
-	name := slug(m.Name)
-	if name == "" {
+	if strings.TrimSpace(m.Name) == "" {
 		return "", fmt.Errorf("memory needs a name")
 	}
+	name := slug(m.Name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
@@ -401,7 +401,7 @@ func render(m Memory, name string) string {
 // indexLineRe matches a managed index line so reindex/Delete can target the line
 // for one memory by its filename without disturbing the rest of a hand-edited
 // MEMORY.md.
-var indexLineRe = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
+var indexLineRe = regexp.MustCompile(`(?m)^\s*-\s\[.+?\]\(([^)]+)\.md\)\s*—\s.*$`)
 
 // indexLinesExceptIn returns the managed MEMORY.md lines keyed by filename stem
 // in the given directory, dropping the entry for name (a missing index → empty map).
@@ -430,21 +430,64 @@ func indexContainsIn(dir, name string) bool {
 }
 
 // flushIndexIn rewrites MEMORY.md in the given directory from the managed lines,
-// sorted by filename.
+// preserving any hand-written content. Managed lines (matched by indexLineRe)
+// are updated from the lines map; lines that don't match (headings, prose,
+// blank lines) are kept verbatim. Managed entries missing from the lines map
+// are dropped (the memory was deleted). New managed entries not already in the
+// file are appended at the end, sorted by filename, so user notes are never
+// silently clobbered.
 func flushIndexIn(dir string, lines map[string]string) error {
-	names := make([]string, 0, len(lines))
-	for n := range lines {
-		names = append(names, n)
+	path := filepath.Join(dir, indexFile)
+	existing, _ := os.ReadFile(path)
+	processed := map[string]bool{}
+
+	var preserved strings.Builder
+	preservedEmpty := true
+	for _, line := range strings.Split(string(existing), "\n") {
+		trimmed := strings.TrimRight(line, "\r")
+		if mt := indexLineRe.FindStringSubmatch(trimmed); mt != nil {
+			name := mt[1]
+			if fresh, ok := lines[name]; ok {
+				preserved.WriteString(fresh)
+				preserved.WriteString("\n")
+				processed[name] = true
+				preservedEmpty = false
+				continue
+			}
+			// Managed line with no fresh entry: drop it (memory was deleted).
+			continue
+		}
+		// Preserve hand-written content verbatim.
+		preserved.WriteString(trimmed)
+		preserved.WriteString("\n")
+		if strings.TrimSpace(trimmed) != "" {
+			preservedEmpty = false
+		}
 	}
-	sort.Strings(names)
+
+	pending := make([]string, 0, len(lines))
+	for n := range lines {
+		if !processed[n] {
+			pending = append(pending, n)
+		}
+	}
+	sort.Strings(pending)
 
 	var b strings.Builder
-	b.WriteString("# Memory\n\n")
-	for _, n := range names {
+	if preservedEmpty && len(pending) > 0 {
+		b.WriteString("# Memory\n\n")
+	} else {
+		b.WriteString(preserved.String())
+	}
+	for _, n := range pending {
 		b.WriteString(lines[n])
 		b.WriteString("\n")
 	}
-	return os.WriteFile(filepath.Join(dir, indexFile), []byte(b.String()), 0o644)
+	result := strings.TrimRight(b.String(), "\n")
+	if result == "" {
+		return os.WriteFile(path, []byte(""), 0o644)
+	}
+	return os.WriteFile(path, []byte(result+"\n"), 0o644)
 }
 
 // reindexIn rewrites the MEMORY.md line for name in the given directory,
@@ -577,12 +620,20 @@ func splitFrontmatter(s string) (map[string]string, string) {
 	return frontmatter.Split(s)
 }
 
-// slugRe strips everything but lowercase alphanumerics and dashes.
-var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+// slugRe strips everything but Unicode letters and digits so non-ASCII titles
+// (Chinese, Japanese, accented Latin) survive slugification instead of
+// collapsing to an empty stem.
+var slugRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 
-// slug normalises a name into a kebab-case, filesystem-safe stem.
+// slug normalises a name into a kebab-case, filesystem-safe stem. Non-ASCII
+// letters and digits are preserved; an all-punctuation/empty input falls back
+// to a unique stem so the file write never produces a bare ".md".
 func slug(s string) string {
-	return strings.Trim(slugRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "-"), "-")
+	out := strings.Trim(slugRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "-"), "-")
+	if out == "" {
+		return fmt.Sprintf("memory-%d", time.Now().UnixNano())
+	}
+	return out
 }
 
 // oneLine collapses whitespace so a description can't break the single-line

--- a/internal/memory/store_extra_test.go
+++ b/internal/memory/store_extra_test.go
@@ -90,14 +90,24 @@ func TestSlug(t *testing.T) {
 		{"  spaces  ", "spaces"},
 		{"CamelCase", "camelcase"},
 		{"with/slash", "with-slash"},
-		{"", ""},
-		{"---", ""},
 		{"hello_world", "hello-world"},
+		// Non-ASCII letters and digits are preserved, not stripped.
+		{"中文标题", "中文标题"},
+		{"HÉLLO", "héllo"},
+		{"日本語123", "日本語123"},
 	}
 	for _, c := range cases {
 		got := slug(c.input)
 		if got != c.want {
 			t.Errorf("slug(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+	// Empty or punctuation-only inputs fall back to a unique "memory-<ts>"
+	// stem so the file write never produces a bare ".md".
+	for _, input := range []string{"", "---"} {
+		got := slug(input)
+		if !strings.HasPrefix(got, "memory-") {
+			t.Errorf("slug(%q) = %q, want prefix %q", input, got, "memory-")
 		}
 	}
 }

--- a/internal/memorycompiler/compression.go
+++ b/internal/memorycompiler/compression.go
@@ -582,22 +582,40 @@ func retainMemoryNodes(nodes []MemoryNode, limit int, nowArg ...time.Time) []Mem
 	if len(nowArg) > 0 && !nowArg[0].IsZero() {
 		now = nowArg[0].UTC()
 	}
-	out := append([]MemoryNode(nil), nodes...)
-	sort.SliceStable(out, func(i, j int) bool {
-		pi := memoryNodeCompressionPriority(out[i], now)
-		pj := memoryNodeCompressionPriority(out[j], now)
-		if pi != pj {
-			return pi < pj
+	// TruthLocked nodes record immutable tool results and must never be
+	// evicted by compression. Reserve them first, then allocate the remaining
+	// quota to non-locked nodes by priority.
+	locked := make([]MemoryNode, 0)
+	rest := make([]MemoryNode, 0, len(nodes))
+	for _, n := range nodes {
+		if n.TruthLocked {
+			locked = append(locked, n)
+		} else {
+			rest = append(rest, n)
 		}
-		if out[i].Confidence != out[j].Confidence {
-			return out[i].Confidence > out[j].Confidence
-		}
-		if !out[i].Timestamp.Equal(out[j].Timestamp) {
-			return out[i].Timestamp.After(out[j].Timestamp)
-		}
-		return out[i].ID < out[j].ID
-	})
-	out = out[:limit]
+	}
+	remaining := limit - len(locked)
+	if remaining < 0 {
+		remaining = 0
+	}
+	if len(rest) > remaining {
+		sort.SliceStable(rest, func(i, j int) bool {
+			pi := memoryNodeCompressionPriority(rest[i], now)
+			pj := memoryNodeCompressionPriority(rest[j], now)
+			if pi != pj {
+				return pi < pj
+			}
+			if rest[i].Confidence != rest[j].Confidence {
+				return rest[i].Confidence > rest[j].Confidence
+			}
+			if !rest[i].Timestamp.Equal(rest[j].Timestamp) {
+				return rest[i].Timestamp.After(rest[j].Timestamp)
+			}
+			return rest[i].ID < rest[j].ID
+		})
+		rest = rest[:remaining]
+	}
+	out := append(append([]MemoryNode(nil), locked...), rest...)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Timestamp.Equal(out[j].Timestamp) {
 			return out[i].ID < out[j].ID

--- a/internal/memorycompiler/compression_test.go
+++ b/internal/memorycompiler/compression_test.go
@@ -214,9 +214,12 @@ func TestTruthLockedImportanceDecaysForCompressionPriority(t *testing.T) {
 		Confidence: 0.95,
 		Quality:    QualityHighSignal,
 	}
+	// TruthLocked nodes are unconditionally retained even when stale, so the
+	// old truth survives the limit-1 retention (the fresh high-signal node is
+	// the one evicted). The stale truth is still reported as decaying.
 	retained := retainMemoryNodes([]MemoryNode{oldTruth, newSignal}, 1, now)
-	if len(retained) != 1 || retained[0].ID != "new-signal" {
-		t.Fatalf("stale truth lock dominated high-signal node: %+v", retained)
+	if len(retained) != 1 || retained[0].ID != "old-truth" {
+		t.Fatalf("truth-locked node was evicted: %+v", retained)
 	}
 	memory := compressMemoryGraph(state{Nodes: []MemoryNode{oldTruth, newSignal}}, now)
 	if !containsString(memory.TruthLockDecay, "old-truth") {

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2238,8 +2239,11 @@ func applyDriftControl(st state, now time.Time, traceID string) (state, DriftRep
 		if node.TruthLocked || node.Quality == QualityCorrupted {
 			continue
 		}
+		// Compute decayed confidence for immediate use only; do NOT write it
+		// back. Writing back compounds the decay every turn because
+		// node.Timestamp is never advanced here, collapsing all
+		// non-TruthLocked memories to ~0 confidence within weeks.
 		decayed := decayedConfidence(*node, now)
-		node.Confidence = decayed
 		if decayed < staleConfidenceThreshold {
 			node.Quality = QualityNoise
 			report.StaleMemoryNodes = append(report.StaleMemoryNodes, node.ID)
@@ -2789,7 +2793,9 @@ func stripReferencedContext(content string) string {
 }
 
 func traceID(t time.Time) string {
-	return t.UTC().Format("20060102T150405.000000000")
+	// Append a random suffix so high-frequency traces don't collide on
+	// platforms with coarse clocks (Windows ~15ms timer resolution).
+	return fmt.Sprintf("%s-%x", t.UTC().Format("20060102T150405.000000000"), rand.Int63())
 }
 
 func firstLine(s string) string {
@@ -2808,11 +2814,15 @@ func (r *Runtime) loadState() state {
 
 func (r *Runtime) loadStateLocked() state {
 	var st state
-	b, err := os.ReadFile(filepath.Join(r.dir, stateFile))
+	path := filepath.Join(r.dir, stateFile)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return state{NoisyRefs: map[string]int{}}
 	}
 	if err := json.Unmarshal(b, &st); err != nil {
+		// Back up the corrupt file before the next save overwrites it, so
+		// learning history isn't silently lost.
+		_ = os.WriteFile(fmt.Sprintf("%s.corrupt-%d", path, time.Now().UnixNano()), b, 0o600)
 		return state{NoisyRefs: map[string]int{}}
 	}
 	if st.NoisyRefs == nil {

--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -32,7 +32,7 @@ func containsShellSyntax(cmd string) bool {
 func hasUnsafeReadOnlyArgs(base string, args []string) bool {
 	switch base {
 	case "find":
-		return hasAnyArg(args, "-exec", "-execdir", "-delete")
+		return hasAnyArg(args, "-exec", "-execdir", "-delete", "-ok", "-okdir", "-fls", "-fprint", "-fprintf")
 	case "sed":
 		for _, arg := range args {
 			if strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "--in-place") {

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -2,7 +2,11 @@
 
 package sandbox
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
 
 // Command runs the command unwrapped: no OS sandbox is implemented for this
 // platform yet (Linux bubblewrap/landlock is the next step). The permission
@@ -36,7 +40,8 @@ func Available() bool {
 // bwrapArgs builds the bubblewrap command-line arguments that confine the
 // shell command to the write roots, deny network unless allowed, and allow
 // read access to the whole filesystem (matching the macOS Seatbelt profile's
-// read-open policy).
+// read-open policy). Writable toolchain caches and temp dirs are bound too so
+// go build/test, pip, npm, cargo, etc. keep working inside the sandbox.
 func bwrapArgs(spec Spec, sh Shell, command string) []string {
 	args := []string{
 		"--unshare-net", // deny network by default
@@ -52,5 +57,47 @@ func bwrapArgs(spec Spec, sh Shell, command string) []string {
 	for _, root := range spec.WriteRoots {
 		args = append(args, "--bind", root, root)
 	}
+	for _, p := range linuxWriteDirs() {
+		args = append(args, "--bind", p, p)
+	}
 	return append(args, sh.argv(command)...)
+}
+
+// linuxWriteDirs returns the deduplicated, symlink-resolved set of directories
+// the bwrap sandbox permits writes to beyond spec.WriteRoots: the system temp
+// (when it isn't /tmp, which is already a tmpfs) plus the common toolchain
+// caches under $HOME (.cache, .cargo, .npm, go), mirroring the macOS Seatbelt
+// profile's writeAllowDirs.
+func linuxWriteDirs() []string {
+	dirs := []string{}
+	if td := os.TempDir(); td != "" && td != "/tmp" {
+		dirs = append(dirs, td)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		for _, sub := range []string{".cache", ".cargo", ".npm", "go"} {
+			dirs = append(dirs, filepath.Join(home, sub))
+		}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d == "" {
+			continue
+		}
+		abs, err := filepath.Abs(d)
+		if err != nil {
+			continue
+		}
+		if real, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = real
+		}
+		if abs == "/tmp" {
+			continue // handled by --tmpfs /tmp
+		}
+		if !seen[abs] {
+			seen[abs] = true
+			out = append(out, abs)
+		}
+	}
+	return out
 }

--- a/internal/shellsafe/shellsafe.go
+++ b/internal/shellsafe/shellsafe.go
@@ -19,7 +19,7 @@ var ReadOnlyCommands = map[string]bool{
 	"grep": true, "egrep": true, "fgrep": true, "rg": true,
 	"echo": true, "printf": true,
 	"pwd": true, "cd": true, "whoami": true, "id": true, "uname": true, "hostname": true,
-	"date": true, "env": true, "printenv": true,
+	"date": true, "printenv": true,
 	"wc": true, "sort": true, "uniq": true, "cut": true, "tr": true,
 	"stat": true, "file": true, "du": true, "df": true,
 	"ps": true, "top": true, "htop": true,


### PR DESCRIPTION
﻿## Summary

Deep code review of the memory system, sandbox, permission layer, and agent core. Found and fixed 13 bugs (5 CRITICAL, 8 HIGH) via static analysis, logical review, and dynamic testing. All existing tests pass.

## CRITICAL fixes

### 1. memory: compounding confidence decay zeroes all memories within weeks
`applyDriftControl` wrote the decayed confidence back to `node.Confidence` while never advancing `node.Timestamp`. Each subsequent turn recomputed decay from the original timestamp against the now-lower base, producing exponential decay (`0.95^(n(n+1)/2)` instead of `0.95^n`). After ~20 turns, all non-TruthLocked memories fell below `staleConfidenceThreshold` and were marked `QualityNoise`.

**Fix**: Compute decayed confidence for immediate use only; do not write it back.

### 2. memory: flushIndexIn silently drops hand-edited MEMORY.md content
`flushIndexIn` rewrote MEMORY.md from the `lines` map alone, discarding headings, paragraphs, sub-lists, and any line not matching `indexLineRe`. A single `Store.Save` call would wipe user notes.

**Fix**: Read existing content, preserve non-managed lines, update managed lines in place, append new entries.

### 3. memory: indexLineRe over-matches any markdown link
The regex `\]\(([^)]+)\.md\)` matched any `](xxx.md)` link, not just managed index lines. `Delete("design")` would clobber a user-written `see [design](design.md)` reference.

**Fix**: Tighten to `(?m)^\s*-\s\[.+?\]\(([^)]+)\.md\)\s*—\s.*$`.

### 4. security: env command auto-approved as read-only despite executing arbitrary commands
`env` was in `ReadOnlyCommands`, but `env rm -rf /` executes `rm -rf /`. `hasUnsafeReadOnlyArgs` had no `env` case, so `env <malicious>` was auto-approved without user confirmation.

**Fix**: Remove `env` from `ReadOnlyCommands`.

### 5. agent: parallel_tasks goroutine leak on ctx cancel
When `ctx.Done()` fired, the drain loop used `default: break drain` and returned immediately without calling `wg.Wait()`. Spawned sub-agent goroutines became orphans, holding session/provider/tool resources.

**Fix**: Add `wg.Wait()` before returning.

## HIGH fixes

### 6. permission: find missing unsafe flags
`hasUnsafeReadOnlyArgs` for `find` only checked `-exec`, `-execdir`, `-delete`. Missing: `-ok`, `-okdir` (execute commands), `-fls`, `-fprint`, `-fprintf` (write files).

### 7. sandbox: Linux bwrap missing toolchain/cache dirs
macOS seatbelt binds `/tmp`, `~/.cache`, `~/.cargo`, `~/.npm`, `~/go`, etc. Linux bwrap only had `--tmpfs /tmp`, breaking `go build`, `cargo build`, `npm install` inside the sandbox.

### 8. memorycompiler: corrupt state.json silently overwritten
`loadStateLocked` returned empty state on JSON parse failure; next turn overwrote the original file, losing all learning history.

**Fix**: Back up corrupt file to `state.json.corrupt-<ts>` before returning empty state.

### 9. memory: slug returns empty for non-ASCII names
`slug("用户偏好")` returned `""`, blocking CJK users from saving memories.

**Fix**: Regex `[^\p{L}\p{N}]+` preserves Unicode letters/digits; empty fallback to `memory-<ts>`.

### 10. memory: resolvePath allows @~/.ssh/id_rsa import
`@~` and `@/absolute` imports were allowed, leaking private keys into LLM prompt context via malicious AGENTS.md.

**Fix**: Reject `~` and absolute paths; enforce baseDir subtree via `filepath.Rel`.

### 11. memorycompiler: retainMemoryNodes evicts TruthLocked nodes
When node count exceeded `maxMemoryGraphNodes` (300), TruthLocked nodes had no special protection, contradicting `upsertNode`'s "TruthLocked cannot be overwritten" semantics.

**Fix**: Unconditionally retain all TruthLocked nodes; allocate remaining quota by priority.

### 12. memorycompiler: traceID collisions on Windows
`time.Now()` on Windows has ~15ms resolution. Fast consecutive turns produced identical traceIDs, causing learnings to be deduplicated and lost.

**Fix**: Append `rand.Int63()` suffix.

### 13. agent: SummarizeFrom/SummarizeUpTo missing IncrementRewrite
These methods called `session.Replace(next)` without `IncrementRewrite()`, breaking `cache_shape` diagnostics (cache miss wrongly attributed instead of `log_rewrite`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test -count=1 ./internal/memory/... ./internal/memorycompiler/... ./internal/agent/... ./internal/sandbox/... ./internal/permission/...` all pass
- [x] `compression_test.go` updated: `TestTruthLockedImportanceDecaysForCompressionPriority` now asserts TruthLocked preservation (was asserting eviction)
- [x] `store_extra_test.go` updated: empty-name validation moved to raw input layer to coexist with slug fallback