### PR TITLE
Fix memory and permission hardening regressions / 修复记忆与权限加固回归

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -303,6 +303,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 		Content: "Summary of the later conversation (compacted from here on):\n" + summary,
 	})
 	a.session.Replace(next)
+	a.session.IncrementRewrite()
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d later messages → summary", len(region))})
 	return nil
@@ -336,6 +337,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	})
 	next = append(next, msgs[toIdx:]...)
 	a.session.Replace(next)
+	a.session.IncrementRewrite()
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d earlier messages → summary", len(region))})
 	return nil

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -316,6 +316,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				}
 			}
 			markCancelled(err)
+			wg.Wait()
 			return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
 		}
 	}

--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -195,10 +195,10 @@ func gitRoot(dir string) string {
 }
 
 // resolveImports inlines lines that are exactly "@<path>" by replacing them with
-// the referenced file's content. Paths resolve relative to baseDir, with a
-// leading ~ expanded to home and absolute paths honored as-is. Recurses up to
-// maxImportDepth with cycle detection via seen (absolute paths). An import that
-// cannot be read is left as-is so the user can see what failed.
+// the referenced file's content. Imports must stay inside the importing file's
+// directory after symlink resolution. Recurses up to maxImportDepth with cycle
+// detection via seen (absolute paths). An import that cannot be read is left
+// as-is so the user can see what failed.
 func resolveImports(body, baseDir string, seen map[string]bool, depth int) string {
 	if depth >= maxImportDepth {
 		return body
@@ -210,6 +210,9 @@ func resolveImports(body, baseDir string, seen map[string]bool, depth int) strin
 			continue
 		}
 		path := resolvePath(target, baseDir)
+		if path == "" {
+			continue
+		}
 		abs := absOf(path)
 		if seen[abs] {
 			lines[i] = line + "  <!-- skipped: import cycle -->"
@@ -245,19 +248,37 @@ func importTarget(line string) (string, bool) {
 	return p, true
 }
 
-// resolvePath turns an import token into a filesystem path: ~ expands to home,
-// absolute paths pass through, everything else is relative to baseDir.
+// resolvePath turns an import token into a filesystem path. Home-relative ("~")
+// and absolute imports are refused so a memory can't read sensitive files
+// outside the project tree. Relative imports must remain inside baseDir after
+// symlink resolution.
 func resolvePath(p, baseDir string) string {
-	if strings.HasPrefix(p, "~") {
-		if home, err := os.UserHomeDir(); err == nil {
-			rest := strings.TrimLeft(p[1:], "/\\")
-			return filepath.Join(home, rest)
-		}
+	cleaned := strings.TrimSpace(p)
+	if cleaned == "" || strings.HasPrefix(cleaned, "~") || filepath.IsAbs(cleaned) {
+		return ""
 	}
-	if filepath.IsAbs(p) {
-		return p
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return ""
 	}
-	return filepath.Join(baseDir, p)
+	baseReal, err := filepath.EvalSymlinks(baseAbs)
+	if err != nil {
+		return ""
+	}
+	joined := filepath.Join(baseReal, cleaned)
+	abs, err := filepath.Abs(joined)
+	if err != nil {
+		return ""
+	}
+	targetReal, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		targetReal = abs
+	}
+	rel, err := filepath.Rel(baseReal, targetReal)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return ""
+	}
+	return targetReal
 }
 
 // absOf returns the absolute form of p, falling back to a cleaned p on error so

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -89,6 +89,48 @@ func TestImportResolution(t *testing.T) {
 	}
 }
 
+func TestImportResolutionRejectsEscapes(t *testing.T) {
+	proj := t.TempDir()
+	mustMkdir(t, filepath.Join(proj, ".git"))
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.md"), "SECRET")
+	mustWrite(t, filepath.Join(proj, "REASONIX.md"), "Top\n@/abs/path.md\n@~/secret.md\n@../secret.md\nBottom")
+
+	set := Load(Options{CWD: proj})
+	if len(set.Docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(set.Docs))
+	}
+	body := set.Docs[0].Body
+	if strings.Contains(body, "SECRET") {
+		t.Fatalf("unsafe import was inlined: %q", body)
+	}
+	for _, directive := range []string{"@/abs/path.md", "@~/secret.md", "@../secret.md"} {
+		if !strings.Contains(body, directive) {
+			t.Fatalf("unsafe directive %q should be left visible, body: %q", directive, body)
+		}
+	}
+}
+
+func TestImportResolutionRejectsSymlinkEscape(t *testing.T) {
+	proj := t.TempDir()
+	mustMkdir(t, filepath.Join(proj, ".git"))
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.md"), "SECRET")
+	if err := os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(proj, "linked.md")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	mustWrite(t, filepath.Join(proj, "REASONIX.md"), "Top\n@linked.md\nBottom")
+
+	set := Load(Options{CWD: proj})
+	if len(set.Docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(set.Docs))
+	}
+	body := set.Docs[0].Body
+	if strings.Contains(body, "SECRET") || !strings.Contains(body, "@linked.md") {
+		t.Fatalf("symlink escape should not be inlined, body: %q", body)
+	}
+}
+
 // TestImportCycleDoesNotHang verifies cycle detection terminates.
 func TestImportCycleDoesNotHang(t *testing.T) {
 	proj := t.TempDir()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -184,9 +184,12 @@ func (s Store) Save(m Memory) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
+	if strings.TrimSpace(m.Name) == "" {
+		return "", fmt.Errorf("memory needs a name")
+	}
 	name := slug(m.Name)
 	if name == "" {
-		return "", fmt.Errorf("memory needs a name")
+		return "", fmt.Errorf("memory name needs at least one letter or digit")
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
@@ -401,7 +404,7 @@ func render(m Memory, name string) string {
 // indexLineRe matches a managed index line so reindex/Delete can target the line
 // for one memory by its filename without disturbing the rest of a hand-edited
 // MEMORY.md.
-var indexLineRe = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
+var indexLineRe = regexp.MustCompile(`(?m)^\s*-\s\[.+?\]\(([^)]+)\.md\)\s*—\s.*$`)
 
 // indexLinesExceptIn returns the managed MEMORY.md lines keyed by filename stem
 // in the given directory, dropping the entry for name (a missing index → empty map).
@@ -430,21 +433,56 @@ func indexContainsIn(dir, name string) bool {
 }
 
 // flushIndexIn rewrites MEMORY.md in the given directory from the managed lines,
-// sorted by filename.
+// preserving hand-written content. Managed lines are updated or removed, and
+// new managed entries are appended in sorted order.
 func flushIndexIn(dir string, lines map[string]string) error {
+	path := filepath.Join(dir, indexFile)
+	existing, _ := os.ReadFile(path)
+	processed := map[string]bool{}
+	var preserved strings.Builder
+	preservedEmpty := true
+	for _, line := range strings.Split(string(existing), "\n") {
+		trimmed := strings.TrimRight(line, "\r")
+		if mt := indexLineRe.FindStringSubmatch(trimmed); mt != nil {
+			name := mt[1]
+			if fresh, ok := lines[name]; ok {
+				preserved.WriteString(fresh)
+				preserved.WriteString("\n")
+				processed[name] = true
+				preservedEmpty = false
+			}
+			continue
+		}
+		preserved.WriteString(trimmed)
+		preserved.WriteString("\n")
+		if strings.TrimSpace(trimmed) != "" {
+			preservedEmpty = false
+		}
+	}
+
 	names := make([]string, 0, len(lines))
 	for n := range lines {
-		names = append(names, n)
+		if !processed[n] {
+			names = append(names, n)
+		}
 	}
 	sort.Strings(names)
 
 	var b strings.Builder
-	b.WriteString("# Memory\n\n")
+	if preservedEmpty && len(names) > 0 {
+		b.WriteString("# Memory\n\n")
+	} else {
+		b.WriteString(preserved.String())
+	}
 	for _, n := range names {
 		b.WriteString(lines[n])
 		b.WriteString("\n")
 	}
-	return os.WriteFile(filepath.Join(dir, indexFile), []byte(b.String()), 0o644)
+	result := strings.TrimRight(b.String(), "\n")
+	if result == "" {
+		return os.WriteFile(path, []byte(""), 0o644)
+	}
+	return os.WriteFile(path, []byte(result+"\n"), 0o644)
 }
 
 // reindexIn rewrites the MEMORY.md line for name in the given directory,
@@ -577,8 +615,8 @@ func splitFrontmatter(s string) (map[string]string, string) {
 	return frontmatter.Split(s)
 }
 
-// slugRe strips everything but lowercase alphanumerics and dashes.
-var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+// slugRe strips everything but Unicode letters and digits.
+var slugRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 
 // slug normalises a name into a kebab-case, filesystem-safe stem.
 func slug(s string) string {

--- a/internal/memory/store_extra_test.go
+++ b/internal/memory/store_extra_test.go
@@ -93,12 +93,29 @@ func TestSlug(t *testing.T) {
 		{"", ""},
 		{"---", ""},
 		{"hello_world", "hello-world"},
+		{"中文标题", "中文标题"},
+		{"HÉLLO", "héllo"},
+		{"日本語123", "日本語123"},
 	}
 	for _, c := range cases {
 		got := slug(c.input)
 		if got != c.want {
 			t.Errorf("slug(%q) = %q, want %q", c.input, got, c.want)
 		}
+	}
+}
+
+func TestStoreSaveUnicodeAndRejectsEmptySlug(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	path, err := s.Save(Memory{Name: "中文标题", Description: "d", Type: TypeProject, Body: "body"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(path) != "中文标题.md" {
+		t.Fatalf("unicode name path = %q", path)
+	}
+	if _, err := s.Save(Memory{Name: "---", Description: "d", Type: TypeProject, Body: "body"}); err == nil {
+		t.Fatal("punctuation-only name should be rejected")
 	}
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -69,12 +69,32 @@ func TestStoreIndexPreservesHandEdits(t *testing.T) {
 	if _, err := s.Save(Memory{Name: "alpha", Description: "first", Type: TypeProject, Body: "x"}); err != nil {
 		t.Fatal(err)
 	}
+	indexPath := filepath.Join(s.Dir, indexFile)
+	handEdited := "# Memory\n\nUser note before managed lines.\n\n" + mustReadString(t, indexPath) + "\nSee [design](design.md) for context.\n"
+	if err := os.WriteFile(indexPath, []byte(handEdited), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := s.Save(Memory{Name: "beta", Description: "second", Type: TypeProject, Body: "y"}); err != nil {
 		t.Fatal(err)
 	}
-	idx := s.Index()
-	if !strings.Contains(idx, "alpha.md") || !strings.Contains(idx, "beta.md") {
-		t.Fatalf("an entry was lost on the second save:\n%s", idx)
+	raw := mustReadString(t, indexPath)
+	for _, want := range []string{"User note before managed lines.", "See [design](design.md) for context.", "alpha.md", "beta.md"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("MEMORY.md lost %q:\n%s", want, raw)
+		}
+	}
+	if strings.Count(raw, "alpha.md") != 1 || strings.Count(raw, "beta.md") != 1 {
+		t.Fatalf("managed lines were duplicated:\n%s", raw)
+	}
+	if err := s.Delete("alpha"); err != nil {
+		t.Fatal(err)
+	}
+	raw = mustReadString(t, indexPath)
+	if strings.Contains(raw, "alpha.md") {
+		t.Fatalf("deleted managed line remained:\n%s", raw)
+	}
+	if !strings.Contains(raw, "See [design](design.md) for context.") {
+		t.Fatalf("ordinary markdown link was treated as managed:\n%s", raw)
 	}
 }
 
@@ -266,6 +286,15 @@ func TestStoreArchiveFlushesStaleIndexWithoutFile(t *testing.T) {
 	if !strings.Contains(idx, "beta.md") {
 		t.Fatalf("unrelated index line should remain:\n%s", idx)
 	}
+}
+
+func mustReadString(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func TestStoreListArchivedNewestFirst(t *testing.T) {

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2239,7 +2240,6 @@ func applyDriftControl(st state, now time.Time, traceID string) (state, DriftRep
 			continue
 		}
 		decayed := decayedConfidence(*node, now)
-		node.Confidence = decayed
 		if decayed < staleConfidenceThreshold {
 			node.Quality = QualityNoise
 			report.StaleMemoryNodes = append(report.StaleMemoryNodes, node.ID)
@@ -2789,7 +2789,7 @@ func stripReferencedContext(content string) string {
 }
 
 func traceID(t time.Time) string {
-	return t.UTC().Format("20060102T150405.000000000")
+	return fmt.Sprintf("%s-%x", t.UTC().Format("20060102T150405.000000000"), rand.Int63())
 }
 
 func firstLine(s string) string {
@@ -2808,11 +2808,13 @@ func (r *Runtime) loadState() state {
 
 func (r *Runtime) loadStateLocked() state {
 	var st state
-	b, err := os.ReadFile(filepath.Join(r.dir, stateFile))
+	path := filepath.Join(r.dir, stateFile)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return state{NoisyRefs: map[string]int{}}
 	}
 	if err := json.Unmarshal(b, &st); err != nil {
+		_ = os.WriteFile(fmt.Sprintf("%s.corrupt-%d", path, time.Now().UnixNano()), b, 0o600)
 		return state{NoisyRefs: map[string]int{}}
 	}
 	if st.NoisyRefs == nil {

--- a/internal/memorycompiler/runtime_test.go
+++ b/internal/memorycompiler/runtime_test.go
@@ -774,6 +774,9 @@ func TestDriftControlReportsStaleConflictingAndOverusedState(t *testing.T) {
 	assertNode(t, next.Nodes, func(n MemoryNode) bool {
 		return n.ID == "old-fact" && n.Quality == QualityNoise
 	}, "stale node marked as noise")
+	assertNode(t, next.Nodes, func(n MemoryNode) bool {
+		return n.ID == "old-fact" && n.Confidence == 0.1
+	}, "drift control should not persist decayed confidence")
 }
 
 func TestTruthLockedNodeCannotBeOverwritten(t *testing.T) {
@@ -798,6 +801,46 @@ func TestTruthLockedNodeCannotBeOverwritten(t *testing.T) {
 	})
 	if nodes[0].Content != "original result" {
 		t.Fatalf("truth-locked node was overwritten: %+v", nodes[0])
+	}
+}
+
+func TestLoadStateBacksUpCorruptState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateFile)
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := New(dir)
+	st := r.loadState()
+	if st.NoisyRefs == nil {
+		t.Fatal("loadState should return initialized empty state")
+	}
+	matches, err := filepath.Glob(path + ".corrupt-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("corrupt backup count = %d, want 1", len(matches))
+	}
+	b, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "{not-json" {
+		t.Fatalf("backup content = %q", b)
+	}
+}
+
+func TestTraceIDIncludesCollisionGuard(t *testing.T) {
+	now := time.Unix(123, 456).UTC()
+	a := traceID(now)
+	b := traceID(now)
+	prefix := now.Format("20060102T150405.000000000") + "-"
+	if !strings.HasPrefix(a, prefix) || !strings.HasPrefix(b, prefix) {
+		t.Fatalf("trace IDs missing timestamp prefix: %q %q", a, b)
+	}
+	if a == b {
+		t.Fatalf("trace IDs collided for the same timestamp: %q", a)
 	}
 }
 

--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -32,7 +32,7 @@ func containsShellSyntax(cmd string) bool {
 func hasUnsafeReadOnlyArgs(base string, args []string) bool {
 	switch base {
 	case "find":
-		return hasAnyArg(args, "-exec", "-execdir", "-delete")
+		return hasAnyArg(args, "-exec", "-execdir", "-delete", "-ok", "-okdir", "-fls", "-fprint", "-fprint0", "-fprintf")
 	case "sed":
 		for _, arg := range args {
 			if strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "--in-place") {

--- a/internal/permission/bash_readonly_test.go
+++ b/internal/permission/bash_readonly_test.go
@@ -23,6 +23,7 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"stat main.go", true},
 		{"du -sh .", true},
 		{"diff a.go b.go", true},
+		{"printenv PATH", true},
 
 		// Git read-only
 		{"git log", true},
@@ -50,6 +51,7 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		// Not read-only
 		{"rm file.txt", false},
 		{"rm -rf /", false},
+		{"env rm -rf /", false},
 		{"git commit -m 'msg'", false},
 		{"git branch", false},
 		{"git branch feature/new", false},
@@ -74,7 +76,13 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"ls & rm file.txt", false},
 		{"find . -name '*.go' | xargs gofmt -w", false},
 		{"find . -name '*.go' -exec rm {} \\;", false},
+		{"find . -name '*.go' -ok rm {} \\;", false},
+		{"find . -name '*.go' -okdir rm {} \\;", false},
 		{"find . -name '*.tmp' -delete", false},
+		{"find . -name '*.go' -fls files.txt", false},
+		{"find . -name '*.go' -fprint files.txt", false},
+		{"find . -name '*.go' -fprint0 files.txt", false},
+		{"find . -name '*.go' -fprintf files.txt '%p\\n'", false},
 		{"awk '{print $1}' file.txt", false},
 		{"awk 'BEGIN{system(\"touch /tmp/reasonix-awk-test\")}'", false},
 		{"awk 'BEGIN{print \"evil\" > \"/tmp/reasonix-awk-test\"}'", false},

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -5,10 +5,10 @@
 // allowed. This is the *enforcement* layer beneath the permission rules
 // (*policy*): a permitted command still cannot escape the box.
 //
-// Only macOS (Seatbelt via sandbox-exec) is implemented; on every other OS, or
-// when the OS tooling is missing, Command falls back to running the command
-// unwrapped (see Available). Confining the in-process file-writer built-ins is
-// handled separately, in package tool/builtin.
+// macOS uses Seatbelt via sandbox-exec, Linux uses bubblewrap when available,
+// and platforms without OS tooling fall back to running the command unwrapped
+// (see Available). Confining the in-process file-writer built-ins is handled
+// separately, in package tool/builtin.
 package sandbox
 
 // Spec describes how to confine one command. The zero value (Mode == "") does

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -251,8 +251,14 @@ func TestCommandNonDarwin(t *testing.T) {
 	}
 	spec := Spec{Mode: "enforce", WriteRoots: []string{"/tmp"}}
 	cmd, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "sh"}, "echo hi")
+	if Available() {
+		if !wrapped || cmd[0] == "sh" {
+			t.Fatalf("non-darwin enforce with available sandbox should wrap: %v wrapped=%v", cmd, wrapped)
+		}
+		return
+	}
 	if wrapped {
-		t.Error("non-darwin should never wrap")
+		t.Error("non-darwin without sandbox should not wrap")
 	}
 	if len(cmd) != 3 || cmd[0] != "sh" || cmd[1] != "-c" || cmd[2] != "echo hi" {
 		t.Errorf("unexpected cmd: %v", cmd)
@@ -296,7 +302,8 @@ func TestAvailableNonDarwin(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("testing non-darwin path")
 	}
-	if Available() {
-		t.Error("non-darwin should report unavailable")
+	_, err := exec.LookPath("bwrap")
+	if Available() != (err == nil) {
+		t.Errorf("Available() = %v, bwrap err = %v", Available(), err)
 	}
 }

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -2,12 +2,12 @@
 
 package sandbox
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
 
-// Command runs the command unwrapped: no OS sandbox is implemented for this
-// platform yet (Linux bubblewrap/landlock is the next step). The permission
-// layer still gates the call.
-//
 // When spec.Mode is "enforce" and bubblewrap (bwrap) is available on PATH,
 // the command is wrapped in a bubblewrap sandbox with a profile analogous to
 // macOS Seatbelt: writes confined to WriteRoots, network denied unless
@@ -67,6 +67,9 @@ func bwrapArgs(spec Spec, sh Shell, command string) []string {
 	for _, root := range spec.WriteRoots {
 		args = append(args, "--bind", root, root)
 	}
+	for _, root := range linuxWriteDirs() {
+		args = append(args, "--bind", root, root)
+	}
 	for _, root := range spec.ForbidReadRoots {
 		args = append(args, "--tmpfs", root)
 	}
@@ -91,8 +94,45 @@ func bwrapArgsForArgs(spec Spec, args []string) []string {
 	for _, root := range spec.WriteRoots {
 		out = append(out, "--bind", root, root)
 	}
+	for _, root := range linuxWriteDirs() {
+		out = append(out, "--bind", root, root)
+	}
 	for _, root := range spec.ForbidReadRoots {
 		out = append(out, "--tmpfs", root)
 	}
 	return append(out, args...)
+}
+
+func linuxWriteDirs() []string {
+	dirs := []string{}
+	if td := os.TempDir(); td != "" && td != "/tmp" {
+		dirs = append(dirs, td)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		for _, sub := range []string{".cache", ".cargo", ".npm", "go"} {
+			dirs = append(dirs, filepath.Join(home, sub))
+		}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		abs, err := filepath.Abs(d)
+		if err != nil {
+			continue
+		}
+		if real, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = real
+		}
+		if abs == "/tmp" || seen[abs] || !dirExists(abs) {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+	return out
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }

--- a/internal/sandbox/seatbelt_other_test.go
+++ b/internal/sandbox/seatbelt_other_test.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLinuxWriteDirsSkipsMissingDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".cache"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := linuxWriteDirs()
+	if !containsPath(got, filepath.Join(home, ".cache")) {
+		t.Fatalf("existing cache dir missing from linux write dirs: %v", got)
+	}
+	for _, missing := range []string{".cargo", ".npm", "go"} {
+		if containsPath(got, filepath.Join(home, missing)) {
+			t.Fatalf("missing dir %s should not be bound: %v", missing, got)
+		}
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	absWant, err := filepath.Abs(want)
+	if err != nil {
+		return false
+	}
+	for _, p := range paths {
+		if p == absWant {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/shellsafe/shellsafe.go
+++ b/internal/shellsafe/shellsafe.go
@@ -19,7 +19,7 @@ var ReadOnlyCommands = map[string]bool{
 	"grep": true, "egrep": true, "fgrep": true, "rg": true,
 	"echo": true, "printf": true,
 	"pwd": true, "cd": true, "whoami": true, "id": true, "uname": true, "hostname": true,
-	"date": true, "env": true, "printenv": true,
+	"date": true, "printenv": true,
 	"wc": true, "sort": true, "uniq": true, "cut": true, "tr": true,
 	"stat": true, "file": true, "du": true, "df": true,
 	"ps": true, "top": true, "htop": true,


### PR DESCRIPTION
## Summary

This PR consolidates the valid hardening work from #5450 into a smaller, reviewed patch set:

- Fixes memory drift control so decayed confidence is used for stale detection without being persisted and compounded every turn.
- Preserves hand-written `MEMORY.md` content while only updating managed memory index lines.
- Narrows managed memory-index matching so ordinary Markdown links are not treated as saved-memory entries.
- Keeps Unicode memory names usable while still rejecting empty or punctuation-only slugs.
- Blocks unsafe memory `@import` paths, including absolute paths, home-relative paths, parent escapes, and symlink escapes.
- Removes `env` from read-only shell auto-approval and blocks write/execution-capable `find` predicates, including `-fprint0`.
- Backs up corrupt memory-compiler `state.json` before falling back to empty state.
- Adds a trace ID collision guard for coarse platform clocks.
- Marks manual summarize rewrites in cache diagnostics.
- Waits for foreground `parallel_tasks` workers to exit after cancellation.
- Makes Linux bubblewrap write-cache bindings skip missing directories so sandbox startup does not fail on machines without every toolchain cache.

Refs #5450.

## Consolidation notes

Kept/adapted from #5450:

- The memory drift, managed-index preservation, index regex, `env` read-only removal, `find` unsafe argument coverage, corrupt-state backup, Unicode slug, trace ID collision, summarize rewrite diagnostics, and `parallel_tasks` cancellation findings were valid.
- The Linux bubblewrap cache-dir fix was kept in intent, but adapted to bind only existing directories because `bwrap --bind` fails when the source path does not exist.
- The memory import containment fix was expanded to reject symlink escapes, not only lexical absolute or `~` paths.
- The Unicode slug fix was adapted so slug fallback remains deterministic for lookup/delete paths; empty or punctuation-only names are rejected instead of generating a random slug.

Reviewed but not adopted from #5450:

- The proposed unconditional `TruthLocked` retention was not adopted. Existing tests intentionally allow stale truth-locked nodes to lose retention priority under tight limits, and retaining all truth-locked nodes can violate `maxMemoryGraphNodes`.

## Repository Contributor Credits

- @bfxh authored #5450 and contributed the original investigation and several valid fix directions that this PR keeps or adapts.

## Cache impact

Cache-impact: low - Memory prefix bytes can change only when saved-memory content is corrected or unsafe imports are rejected; tool schemas, provider request serialization, and stable tool ordering are unchanged.
Cache-guard: `go test -count=1 ./internal/memory/... ./internal/memorycompiler/... ./internal/permission/... ./internal/sandbox/... ./internal/agent/...`, `GOOS=windows GOARCH=amd64 go test -c ./internal/sandbox`, and `git diff --check origin/main-v2...HEAD`.
System-prompt-review: PR author/Codex review verified the memory/system-prompt-sensitive changes are correctness and safety scoped and do not introduce per-turn dynamic prefix churn.

This PR does not change tool schemas, provider request serialization, or stable tool ordering. It can change the memory prefix only by preserving valid managed memory content, preventing unsafe imports, and avoiding accidental memory-index corruption; those are intended correctness and safety fixes rather than per-turn dynamic prefix changes.

## Verification

- `go test -count=1 ./internal/memory/... ./internal/memorycompiler/... ./internal/permission/... ./internal/sandbox/... ./internal/agent/...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/sandbox`
- `git diff --check origin/main-v2...HEAD`
- `go test -count=1 ./...`
