### PR TITLE
Support session-scoped external folder refs / 支持会话级外部文件夹引用

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5815,8 +5815,11 @@ func providerEffortTargetNames(cfg *config.Config, entry *config.ProviderEntry) 
 
 // DirEntry is one entry in the "@" file-reference menu.
 type DirEntry struct {
-	Name  string `json:"name"`
-	IsDir bool   `json:"isDir"`
+	Name        string `json:"name"`
+	Path        string `json:"path,omitempty"`
+	IsDir       bool   `json:"isDir"`
+	DisplayName string `json:"displayName,omitempty"`
+	DisplayPath string `json:"displayPath,omitempty"`
 }
 
 // FilePreview is a bounded, read-only file payload for the workspace side panel.
@@ -5980,6 +5983,11 @@ func workspacePathForBase(base, rel string) (string, bool, error) {
 // tab workspace. The menu navigates one level at a time, never recursively —
 // bounded for huge trees.
 func (a *App) ListDir(rel string) []DirEntry {
+	if browser := a.externalFolderRefBrowser(); browser != nil {
+		if entries, handled := browser.ListExternalFolderRefDir(rel); handled {
+			return externalFolderDirEntries(entries)
+		}
+	}
 	base, err := a.activeWorkspaceBase()
 	if err != nil {
 		return []DirEntry{}
@@ -6028,13 +6036,55 @@ func (a *App) SearchFileRefs(query string) []DirEntry {
 	for _, r := range results {
 		out = append(out, DirEntry{Name: r.Path, IsDir: r.IsDir})
 	}
+	if browser := a.externalFolderRefBrowser(); browser != nil {
+		out = append(out, externalFolderDirEntries(browser.SearchExternalFolderRefs(query, fileRefSearchLimit))...)
+	}
 	return out
 }
 
-// ReadFile returns a small text preview for a file under the current workspace.
+type externalFolderRefBrowser interface {
+	ListExternalFolderRefDir(tokenPath string) ([]control.ExternalFolderRefEntry, bool)
+	SearchExternalFolderRefs(query string, limit int) []control.ExternalFolderRefEntry
+	ExternalFolderRefLocalPath(tokenPath string) (path, displayPath string, ok bool)
+}
+
+func (a *App) externalFolderRefBrowser() externalFolderRefBrowser {
+	if ctrl := a.activeCtrl(); ctrl != nil {
+		if browser, ok := ctrl.(externalFolderRefBrowser); ok {
+			return browser
+		}
+	}
+	return nil
+}
+
+func externalFolderDirEntries(entries []control.ExternalFolderRefEntry) []DirEntry {
+	out := make([]DirEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, DirEntry{
+			Name:        e.Name,
+			Path:        e.Path,
+			IsDir:       e.IsDir,
+			DisplayName: e.DisplayName,
+			DisplayPath: e.DisplayPath,
+		})
+	}
+	return out
+}
+
+func (a *App) workspaceOrExternalPath(rel string) (string, bool, error) {
+	if browser := a.externalFolderRefBrowser(); browser != nil {
+		if path, _, ok := browser.ExternalFolderRefLocalPath(rel); ok {
+			return path, true, nil
+		}
+	}
+	return a.workspacePath(rel)
+}
+
+// ReadFile returns a small text preview for a file under the current workspace
+// or a session-authorized external folder ref.
 func (a *App) ReadFile(rel string) FilePreview {
 	out := FilePreview{Path: rel}
-	path, ok, err := a.workspacePath(rel)
+	path, ok, err := a.workspaceOrExternalPath(rel)
 	if err != nil || !ok {
 		out.Err = "invalid path"
 		return out
@@ -6116,18 +6166,20 @@ func (a *App) ReadFile(rel string) FilePreview {
 	return out
 }
 
-// OpenWorkspacePath opens a file or folder from the workspace in the OS default app.
+// OpenWorkspacePath opens a workspace or authorized external-ref file/folder in
+// the OS default app.
 func (a *App) OpenWorkspacePath(rel string) error {
-	path, ok, err := a.workspacePath(rel)
+	path, ok, err := a.workspaceOrExternalPath(rel)
 	if err != nil || !ok {
 		return os.ErrInvalid
 	}
 	return openWorkspacePath(path)
 }
 
-// RevealWorkspacePath shows a workspace file in the native file manager.
+// RevealWorkspacePath shows a workspace or authorized external-ref file in the
+// native file manager.
 func (a *App) RevealWorkspacePath(rel string) error {
-	path, ok, err := a.workspacePath(rel)
+	path, ok, err := a.workspaceOrExternalPath(rel)
 	if err != nil || !ok {
 		return os.ErrInvalid
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6396,18 +6396,21 @@ func (a *App) AttachmentDataURL(path string) (string, error) {
 
 // DroppedItem is one OS-dropped file resolved into a composer context entry: an
 // in-tree file becomes a workspace @reference (read in place, no copy), while an
-// image or out-of-tree file is copied into .reasonix/attachments.
+// outside directory becomes a session-scoped workspace @reference; an image or
+// out-of-tree file is copied into .reasonix/attachments.
 type DroppedItem struct {
-	Kind       string `json:"kind"` // "workspace" | "attachment"
-	Path       string `json:"path"`
-	IsDir      bool   `json:"isDir,omitempty"`
-	PreviewURL string `json:"previewUrl,omitempty"`
+	Kind        string `json:"kind"` // "workspace" | "attachment"
+	Path        string `json:"path"`
+	IsDir       bool   `json:"isDir,omitempty"`
+	DisplayPath string `json:"displayPath,omitempty"`
+	PreviewURL  string `json:"previewUrl,omitempty"`
 }
 
 // AttachDropped turns an absolute path from the native file-drop bridge into a
 // composer context entry. Images are stored as attachments so the chip shows a
-// thumbnail; other in-workspace files are referenced relatively (no copy); files
-// outside the workspace are copied into .reasonix/attachments.
+// thumbnail; in-workspace files are referenced relatively (no copy); directories
+// outside the workspace are registered as current-session folder references;
+// files outside the workspace are copied into .reasonix/attachments.
 func (a *App) AttachDropped(path string) (DroppedItem, error) {
 	var item DroppedItem
 	err := a.withActiveWorkspaceDo(func() error {
@@ -6427,7 +6430,16 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 			return nil
 		}
 		if info.IsDir() {
-			return fmt.Errorf("can only attach files from outside the workspace")
+			ctrl := a.activeCtrl()
+			if ctrl == nil {
+				return fmt.Errorf("workspace is not ready")
+			}
+			token, displayPath, err := ctrl.RegisterExternalFolderRef(path)
+			if err != nil {
+				return err
+			}
+			item = DroppedItem{Kind: "workspace", Path: token, IsDir: true, DisplayPath: displayPath}
+			return nil
 		}
 		rel, err := control.SaveAttachmentFile(path)
 		if err != nil {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2422,6 +2422,59 @@ func TestFileRefsUseActiveTabWorkspaceRoot(t *testing.T) {
 	}
 }
 
+func TestFileRefsIncludeRegisteredExternalFolderChildren(t *testing.T) {
+	workspace := robustTempDir(t)
+	external := filepath.Join(robustTempDir(t), "Folder With Spaces")
+	if err := os.MkdirAll(filepath.Join(external, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "src", "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectedExternal := external
+	if resolved, err := filepath.EvalSymlinks(external); err == nil {
+		expectedExternal = resolved
+	}
+	expectedDisplayPath := filepath.ToSlash(expectedExternal)
+
+	ctrl := &control.Controller{}
+	token, _, err := ctrl.RegisterExternalFolderRef(external)
+	if err != nil {
+		t.Fatalf("RegisterExternalFolderRef: %v", err)
+	}
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", WorkspaceRoot: workspace, Ctrl: ctrl},
+		},
+		activeTabID: "project",
+	}
+
+	listed := app.ListDir(token + "/src/")
+	if len(listed) != 1 ||
+		listed[0].Name != "outside.txt" ||
+		listed[0].Path != token+"/src/outside.txt" ||
+		listed[0].DisplayPath != expectedDisplayPath+"/src/outside.txt" {
+		t.Fatalf("ListDir external src = %+v, want outside token/display path", listed)
+	}
+
+	found := app.SearchFileRefs("outside")
+	var externalHit *DirEntry
+	for i := range found {
+		if found[i].Path == token+"/src/outside.txt" {
+			externalHit = &found[i]
+			break
+		}
+	}
+	if externalHit == nil || externalHit.DisplayName != "Folder With Spaces/src/outside.txt" || externalHit.DisplayPath != expectedDisplayPath+"/src/outside.txt" {
+		t.Fatalf("SearchFileRefs external hit = %+v, all results %+v", externalHit, found)
+	}
+
+	preview := app.ReadFile(token + "/src/outside.txt")
+	if preview.Err != "" || preview.Body != "outside" {
+		t.Fatalf("ReadFile external token preview = %+v, want outside file body", preview)
+	}
+}
+
 func TestDeleteSessionCancelsActiveRuntime(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"reasonix/internal/control"
 )
 
 const desktopTinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
@@ -223,5 +226,59 @@ func TestAttachDroppedImageStoresThumbnail(t *testing.T) {
 	}
 	if !strings.HasPrefix(got.PreviewURL, "data:image/png;base64,") {
 		t.Fatalf("preview = %q, want png data URL", got.PreviewURL)
+	}
+}
+
+func TestAttachDroppedOutsideWorkspaceDirRegistersWorkspaceRef(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "Folder With Spaces")
+	if err := os.MkdirAll(filepath.Join(outside, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "sub", "notes.txt"), []byte("notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectedOutside := outside
+	if resolved, err := filepath.EvalSymlinks(outside); err == nil {
+		expectedOutside = resolved
+	}
+	expectedDisplayPath := filepath.ToSlash(expectedOutside)
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := control.New(control.Options{WorkspaceRoot: workspace})
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", WorkspaceRoot: workspace, Ctrl: ctrl},
+		},
+		activeTabID: "project",
+	}
+
+	got, err := app.AttachDropped(outside)
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if got.Kind != "workspace" || !got.IsDir {
+		t.Fatalf("got %+v, want workspace directory ref", got)
+	}
+	if !strings.HasPrefix(got.Path, "__reasonix_external_folder/") || strings.ContainsAny(got.Path, " \t\r\n") {
+		t.Fatalf("external folder path token = %q, want whitespace-free external token", got.Path)
+	}
+	if got.DisplayPath != expectedDisplayPath {
+		t.Fatalf("display path = %q, want %q", got.DisplayPath, expectedDisplayPath)
+	}
+
+	block, errs := ctrl.ResolveScopedRefs(context.Background(), "inspect @"+got.Path+"/")
+	if len(errs) != 0 {
+		t.Fatalf("ResolveScopedRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, `<dir path="`+expectedDisplayPath+`">`) ||
+		!strings.Contains(block, "sub/") ||
+		!strings.Contains(block, "sub/notes.txt") {
+		t.Fatalf("external dropped folder should resolve as dir context:\n%s", block)
 	}
 }

--- a/desktop/frontend/src/__tests__/at-matches.test.ts
+++ b/desktop/frontend/src/__tests__/at-matches.test.ts
@@ -26,6 +26,10 @@ function entry(name: string, isDir = false): DirEntry {
   return { name, isDir };
 }
 
+function externalEntry(path: string, displayName: string): DirEntry {
+  return { name: displayName, path, displayName, isDir: false };
+}
+
 console.log("\nat-matches filter");
 
 // 1. Nested file surfaces when fragment matches an intermediate segment.
@@ -90,6 +94,27 @@ console.log("\nat-matches filter");
     ["a.ts", "b.ts", "src/c.ts"],
     "empty fragment includes every entry (legacy behavior preserved)",
   );
+}
+
+// 6. External-folder search results can match against a friendly display name
+// even when the submitted path is an opaque session token.
+{
+  const entries: DirEntry[] = [];
+  const searchEntries = [externalEntry("__reasonix_external_folder/abc/Folder/src/outside.txt", "Folder With Spaces/src/outside.txt")];
+  const got = filterAtMatches(entries, searchEntries, "spaces");
+  eq(
+    got.map((e) => e.path),
+    ["__reasonix_external_folder/abc/Folder/src/outside.txt"],
+    "external display name participates in filtering while preserving token path",
+  );
+}
+
+// 7. Dedup uses the submitted path when present.
+{
+  const entries = [externalEntry("__reasonix_external_folder/abc/Folder/src/outside.txt", "outside.txt")];
+  const searchEntries = [externalEntry("__reasonix_external_folder/abc/Folder/src/outside.txt", "Folder With Spaces/src/outside.txt")];
+  const got = filterAtMatches(entries, searchEntries, "outside");
+  eq(got.length, 1, "external entries with the same submitted path dedup to one");
 }
 
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -4,7 +4,7 @@ import { JSDOM } from "jsdom";
 import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { Composer } from "../components/Composer";
+import { Composer, composerPickFileEntry } from "../components/Composer";
 import { LocaleProvider } from "../lib/i18n";
 import { ToastProvider } from "../lib/toast";
 import type { AppBindings } from "../lib/bridge";
@@ -388,6 +388,27 @@ console.log("\ncomposer goal toggle");
     root.unmount();
   });
   dom.window.close();
+}
+
+{
+  const externalToken = "__reasonix_external_folder/mock/Folder-With-Spaces/src/outside.txt";
+  const externalDisplayPath = "/Users/example/Folder With Spaces/src/outside.txt";
+  const picked = composerPickFileEntry("ask @outside", "outside", "", {
+    name: "src/outside.txt",
+    path: externalToken,
+    isDir: false,
+    displayName: "Folder With Spaces/src/outside.txt",
+    displayPath: externalDisplayPath,
+  });
+  eq(picked.text, "ask ", "external search selection removes the token fragment from the draft");
+  eq(picked.workspaceRef?.path, externalToken, "external search selection submits the session ref token");
+  eq(picked.workspaceRef?.displayPath, externalDisplayPath, "external search selection keeps the real display path");
+
+  const localFile = composerPickFileEntry("ask @src/mai", "src/mai", "src/", { name: "main.go", isDir: false });
+  eq(localFile.text, "ask @src/main.go ", "local file selection still completes inline text");
+
+  const localDir = composerPickFileEntry("ask @sr", "sr", "", { name: "src", isDir: true });
+  eq(localDir.text, "ask @src/", "local dir selection still keeps the menu-open slash");
 }
 
 {

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -87,9 +87,11 @@ async function renderComposer(props: Partial<Parameters<typeof Composer>[0]> = {
   const root = createRoot(rootEl);
   const calls: {
     send: string[];
+    submit: (string | undefined)[];
     setCollaborationMode: CollaborationMode[];
   } = {
     send: [],
+    submit: [],
     setCollaborationMode: [],
   };
   let currentProps: Parameters<typeof Composer>[0] = {
@@ -100,8 +102,9 @@ async function renderComposer(props: Partial<Parameters<typeof Composer>[0]> = {
     goal: "",
     cwd: "/repo",
     modelLabel: "DeepSeek-R1",
-    onSend: (displayText) => {
+    onSend: (displayText, submitText) => {
       calls.send.push(displayText);
+      calls.submit.push(submitText);
     },
     onCancel: () => undefined,
     onCycleMode: () => {},
@@ -333,6 +336,53 @@ console.log("\ncomposer goal toggle");
   await waitFor("dropped file attachment", () => document.body.textContent?.includes("report.pdf") === true);
 
   ok(document.body.textContent?.includes("report.pdf") === true, "successful dropped file attach still renders the attachment");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  let droppedCallback: ((x: number, y: number, paths: string[]) => void) | undefined;
+  window.runtime = {
+    EventsOn: () => () => {},
+    BrowserOpenURL: () => {},
+    OnFileDrop: (cb) => {
+      droppedCallback = cb;
+    },
+    OnFileDropOff: () => {},
+  };
+  mockApp({
+    AttachDropped: async () => ({
+      kind: "workspace",
+      path: "__reasonix_external_folder/mock/Folder-With-Spaces",
+      isDir: true,
+      displayPath: "/Users/example/Folder With Spaces",
+    }),
+  });
+  const { root, calls, rerender } = await renderComposer();
+  await rerender({ insertRequest: { id: 4, text: "inspect", mode: "replace" } });
+  if (!droppedCallback) throw new Error("native file drop handler did not register");
+
+  await act(async () => {
+    droppedCallback?.(0, 0, ["/Users/example/Folder With Spaces"]);
+    await flushTimers();
+  });
+  await waitFor("dropped external folder chip", () => document.body.textContent?.includes("Folder With Spaces/") === true);
+
+  ok(document.body.textContent?.includes("Folder With Spaces/") === true, "dropped external folder renders as a folder context chip");
+
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("composer send button did not render");
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+
+  eq(calls.send.join(","), "inspect @/Users/example/Folder With Spaces/", "external folder display text uses the real folder path");
+  eq(calls.submit.join(","), "inspect @__reasonix_external_folder/mock/Folder-With-Spaces/", "external folder submit text uses the session ref token");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -42,6 +42,7 @@ interface AttachmentDedupKey {
 interface WorkspaceReference {
   path: string;
   isDir?: boolean;
+  displayPath?: string;
 }
 
 const LONG_PASTE_MIN_CHARS = 2000;
@@ -1118,7 +1119,7 @@ export function Composer({
         ...orderedAttachments.map((a) => `@${a.path}`),
       ].join(" ");
       const displayRefs = [
-        ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
+        ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.displayPath || ref.path, ref.isDir)),
         ...orderedAttachments.map(formatAttachmentDisplayReference),
       ].join(" ");
       const displayText = [trimmedText, displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
@@ -1226,7 +1227,7 @@ export function Composer({
         if (attachmentSeenInDraft(sourceDraftKey, key)) continue;
         const item = await app.AttachDropped(path);
         if (item.kind === "workspace") {
-          addWorkspaceReferenceToDraft(sourceDraftKey, { path: item.path, isDir: item.isDir });
+          addWorkspaceReferenceToDraft(sourceDraftKey, { path: item.path, isDir: item.isDir, displayPath: item.displayPath });
         } else {
           addAttachmentToDraft(sourceDraftKey, { path: item.path, previewUrl: item.previewUrl, displayName: baseName(path) }, key);
         }
@@ -2154,11 +2155,11 @@ export function Composer({
             <ComposerContextCard
               key={workspaceReferenceKey(ref)}
               variant="workspace"
-              tooltipLabel={formatWorkspaceReference(ref.path, ref.isDir)}
+              tooltipLabel={ref.displayPath ? formatWorkspaceReference(ref.displayPath, ref.isDir) : formatWorkspaceReference(ref.path, ref.isDir)}
               removeLabel={t("composer.removeReference")}
               onRemove={() => removeWorkspaceReference(ref)}
               folder={Boolean(ref.isDir)}
-              label={ref.isDir ? `${baseName(ref.path)}/` : baseName(ref.path)}
+              label={ref.isDir ? `${baseName(ref.displayPath || ref.path)}/` : baseName(ref.displayPath || ref.path)}
             />
           ))}
           {sessionRefs.map((ref) => (

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -39,7 +39,7 @@ interface AttachmentDedupKey {
   source: string;
 }
 
-interface WorkspaceReference {
+export interface WorkspaceReference {
   path: string;
   isDir?: boolean;
   displayPath?: string;
@@ -130,6 +130,29 @@ function sortComposerAttachments(items: Attachment[]): Attachment[] {
 
 function workspaceReferenceKey(ref: WorkspaceReference): string {
   return `${ref.isDir ? "dir" : "file"}:${ref.path}`;
+}
+
+function dirEntrySubmitPath(entry: DirEntry, atDir: string): string {
+  return entry.path || atDir + entry.name;
+}
+
+function dirEntryMenuLabel(entry: DirEntry): string {
+  return entry.displayName || entry.name;
+}
+
+export function composerPickFileEntry(
+  text: string,
+  atRaw: string | null,
+  atDir: string,
+  entry: DirEntry,
+): { text: string; workspaceRef?: WorkspaceReference } {
+  const atPos = text.length - (atRaw?.length ?? 0) - 1; // index of '@'
+  const prefix = text.slice(0, Math.max(0, atPos));
+  const refPath = dirEntrySubmitPath(entry, atDir);
+  if (entry.path || entry.displayPath) {
+    return { text: prefix, workspaceRef: { path: refPath, isDir: entry.isDir, displayPath: entry.displayPath } };
+  }
+  return { text: prefix + "@" + refPath + (entry.isDir ? "/" : " ") };
 }
 
 function emptyComposerDraft(): ComposerDraft {
@@ -1509,10 +1532,14 @@ export function Composer({
   };
 
   const pickEntry = (e: DirEntry) => {
-    const atPos = text.length - (atRaw?.length ?? 0) - 1; // index of '@'
-    const prefix = text.slice(0, atPos);
+    const picked = composerPickFileEntry(text, atRaw, atDir, e);
+    if (picked.workspaceRef) {
+      setTextCaretEnd(picked.text);
+      addWorkspaceReference(picked.workspaceRef);
+      return;
+    }
     // A directory keeps the menu open (trailing "/"); a file completes it (space).
-    setTextCaretEnd(prefix + "@" + atDir + e.name + (e.isDir ? "/" : " "));
+    setTextCaretEnd(picked.text);
   };
 
   // --- past:chats session reference ---
@@ -2079,7 +2106,7 @@ export function Composer({
           <VirtualMenu
             items={atMenuItems}
             activeIndex={active}
-            itemKey={(it) => (it.kind === "pastChats" ? "past:chats" : (it.entry.isDir ? "d:" : "f:") + it.entry.name)}
+            itemKey={(it) => (it.kind === "pastChats" ? "past:chats" : (it.entry.isDir ? "d:" : "f:") + (it.entry.path || it.entry.name))}
             renderItem={(it, i) =>
               it.kind === "pastChats" ? (
                 <button
@@ -2110,7 +2137,7 @@ export function Composer({
                     <FileText size={13} className="filemenu__icon" />
                   )}
                   <span className="slashmenu__name slashmenu__name--file">
-                    {it.entry.name}
+                    {dirEntryMenuLabel(it.entry)}
                     {it.entry.isDir ? "/" : ""}
                   </span>
                 </button>

--- a/desktop/frontend/src/lib/atMatches.ts
+++ b/desktop/frontend/src/lib/atMatches.ts
@@ -11,12 +11,20 @@
 // "index.tsx".
 //
 // Entries from the local ListDir (`entries`) and the fuzzy Search
-// (`searchEntries`) are merged with stable de-duplication keyed on
-// `entry.name` so a result that appears in both lists is shown only
-// once. The local list takes precedence (it represents the user's
-// current directory and is more immediate).
+// (`searchEntries`) are merged with stable de-duplication keyed on the
+// submitted path (`entry.path` when present, otherwise `entry.name`) so a result
+// that appears in both lists is shown only once. The local list takes
+// precedence (it represents the user's current directory and is more immediate).
 
 import type { DirEntry } from "./types";
+
+function entryKey(entry: DirEntry): string {
+  return entry.path || entry.name;
+}
+
+function searchableText(entry: DirEntry): string {
+  return [entry.name, entry.path, entry.displayName, entry.displayPath].filter(Boolean).join(" ").toLowerCase();
+}
 
 export function filterAtMatches(
   entries: readonly DirEntry[],
@@ -24,11 +32,11 @@ export function filterAtMatches(
   atFrag: string,
 ): DirEntry[] {
   const frag = atFrag.toLowerCase();
-  const local = entries.filter((e) => e.name.toLowerCase().includes(frag));
-  const seen = new Set(local.map((e) => e.name));
+  const local = entries.filter((e) => searchableText(e).includes(frag));
+  const seen = new Set(local.map(entryKey));
   const searched = searchEntries.filter((e) => {
-    if (seen.has(e.name)) return false;
-    return e.name.toLowerCase().includes(frag);
+    if (seen.has(entryKey(e))) return false;
+    return searchableText(e).includes(frag);
   });
   return [...local, ...searched];
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -2321,6 +2321,11 @@ function makeMockApp(): AppBindings {
     },
     async AttachDropped(path: string) {
       const name = path.split(/[/\\]/).filter(Boolean).pop() ?? path;
+      const hasExt = /\.\w{1,6}$/i.test(name);
+      if (!hasExt) {
+        const tokenName = name.replace(/[^\w.-]+/g, "-") || "folder";
+        return { kind: "workspace" as const, path: `__reasonix_external_folder/mock/${tokenName}`, isDir: true, displayPath: path };
+      }
       return { kind: "attachment" as const, path: `.reasonix/attachments/mock-${name}` };
     },
     async AttachmentDataURL(_path: string) {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -499,6 +499,7 @@ export interface DroppedItem {
   kind: "workspace" | "attachment";
   path: string;
   isDir?: boolean;
+  displayPath?: string;
   previewUrl?: string;
 }
 

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -492,7 +492,10 @@ export interface CommandInfo {
 
 export interface DirEntry {
   name: string;
+  path?: string;
   isDir: boolean;
+  displayName?: string;
+  displayPath?: string;
 }
 
 export interface DroppedItem {

--- a/desktop/frontend/src/lib/workspaceTreeSearch.ts
+++ b/desktop/frontend/src/lib/workspaceTreeSearch.ts
@@ -11,7 +11,7 @@ function basename(path: string): string {
 }
 
 function treeSearchPath(entry: DirEntry): string {
-  const path = entry.name.replace(/\\/g, "/");
+  const path = (entry.path || entry.name).replace(/\\/g, "/");
   if (!entry.isDir || path.endsWith("/")) return path;
   return path + "/";
 }
@@ -23,7 +23,7 @@ export function mergeWorkspaceSearchResults(rows: WorkspaceSearchRow[], results:
   for (const result of results) {
     const path = treeSearchPath(result);
     if (seen.has(path)) continue;
-    merged.push({ path, entry: { name: basename(path), isDir: result.isDir } });
+    merged.push({ path, entry: { ...result, name: result.displayName || basename(path) } });
     seen.add(path);
   }
   return merged;

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -278,7 +278,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if tokenEconomy {
 		enabledBuiltins = tokenEconomyBuiltins(enabledBuiltins)
 	}
-	addBuiltins(reg, enabledBuiltins, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec)
+	readPathResolver := builtin.NewPathResolver()
+	addBuiltins(reg, enabledBuiltins, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, readPathResolver)
 	// Use the caller-supplied shared host when set, so controllers for the same
 	// workspace root reuse running MCP processes (e.g. one CodeGraph daemon
 	// instead of one per tab). Otherwise construct a private host per controller.
@@ -1038,6 +1039,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Registry:               reg,
 		PluginCtx:              ctx,
 		WorkspaceRoot:          root,
+		ExternalFolderToolRefs: readPathResolver,
 		AutoPlan:               cfg.Agent.AutoPlan,
 		ResponseLanguage:       cfg.ResponseLanguage(),
 		ReasoningLanguage:      cfg.ReasoningLanguage(),
@@ -1344,12 +1346,12 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // instance bound to writeRoots (preserving registry order).
 // When workDir is non-empty, tools resolve relative paths against it instead of
 // the process cwd, enabling concurrent multi-project sessions.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, readPathResolver *builtin.PathResolver) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1783,7 +1783,7 @@ model = "x"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{})
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil)
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -129,6 +129,13 @@ type Controller struct {
 	// surfaced to frontends via WorkspaceRoot().
 	workspaceRoot string
 
+	// externalFolderRefs maps session-generated @ tokens to user-dropped
+	// directories outside workspaceRoot. It is intentionally per-controller:
+	// dragging a folder authorizes that folder for this chat session only, without
+	// widening scoped @ resolution to arbitrary absolute paths.
+	externalFolderRefsMu sync.RWMutex
+	externalFolderRefs   map[string]string
+
 	// checkpoints owns the snapshot-based rewind bookkeeping (the per-session
 	// store, the monotonic turn counter, and the conversation-rewind boundary map)
 	// behind its own lock, off c.mu — so a boundary read for a rewind/fork never

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -133,8 +133,9 @@ type Controller struct {
 	// directories outside workspaceRoot. It is intentionally per-controller:
 	// dragging a folder authorizes that folder for this chat session only, without
 	// widening scoped @ resolution to arbitrary absolute paths.
-	externalFolderRefsMu sync.RWMutex
-	externalFolderRefs   map[string]string
+	externalFolderRefsMu   sync.RWMutex
+	externalFolderRefs     map[string]string
+	externalFolderToolRefs externalFolderToolRefs
 
 	// checkpoints owns the snapshot-based rewind bookkeeping (the per-session
 	// store, the monotonic turn counter, and the conversation-rewind boundary map)
@@ -236,6 +237,10 @@ type MCPReadOnlyTrustResult struct {
 	Err       error
 }
 
+type externalFolderToolRefs interface {
+	RegisterReadRoot(token, root string)
+}
+
 // Options carries the already-built pieces setup assembles. Lifecycle metadata
 // lets the controller mint and rotate session files; Host/Commands are surfaced
 // to frontends that resolve MCP prompts and slash commands.
@@ -272,8 +277,9 @@ type Options struct {
 	PluginCtx context.Context
 	// WorkspaceRoot is the project root checkpoint restores are confined to ("" =
 	// no confinement). Frontends pass the cwd they launched the session in.
-	WorkspaceRoot string
-	AutoPlan      string
+	WorkspaceRoot          string
+	ExternalFolderToolRefs externalFolderToolRefs
+	AutoPlan               string
 	// ResponseLanguage controls final-answer language preference. Empty/auto
 	// means no transient injection because the stable language policy follows the
 	// current user turn.
@@ -353,6 +359,7 @@ func New(opts Options) *Controller {
 		jobs:                       opts.Jobs,
 		mcp:                        newMcpManager(opts.Host, opts.Registry, pluginCtx),
 		workspaceRoot:              opts.WorkspaceRoot,
+		externalFolderToolRefs:     opts.ExternalFolderToolRefs,
 		approval:                   newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -184,6 +184,7 @@ type Input interface {
 	ResolveRefs(ctx context.Context, line string) (block string, errs []string)
 	HasRefs(line string) bool
 	ImageInputEnabled() bool
+	RegisterExternalFolderRef(path string) (token, displayPath string, err error)
 }
 
 // Settings covers runtime session settings that don't fit a richer domain.

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -3,7 +3,9 @@ package control
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,16 +46,20 @@ const (
 
 // ref is a resolved @reference found in a submitted line.
 type ref struct {
-	kind   refKind
-	server string // refResource
-	uri    string // refResource
-	path   string // refFile
-	raw    string // the original token after '@', for labelling
+	kind        refKind
+	server      string // refResource
+	uri         string // refResource
+	path        string // refFile, relative to baseDir when baseDir is set
+	baseDir     string // refFile override for session-authorized external roots
+	displayPath string // refFile label/path exposed in the resolved context block
+	raw         string // the original token after '@', for labelling
 }
 
 // refTokenRe matches an @reference token: '@' then a run of non-space chars.
 var refTokenRe = regexp.MustCompile(`@([^\s]+)`)
 var pathLocationSuffixRe = regexp.MustCompile(`:\d+(?::\d+)?:?$`)
+
+const externalFolderRefPrefix = "__reasonix_external_folder"
 
 // parseRefTokens extracts the deduped, punctuation-trimmed tokens following '@'
 // in a line. Pure: classification (server? file?) happens in classifyRef.
@@ -103,6 +109,108 @@ func isImageAttachmentRef(token string) bool {
 	return false
 }
 
+// RegisterExternalFolderRef authorizes one dropped directory outside the
+// workspace as a structured @reference for this controller session. The returned
+// token is path-like and whitespace-free so it survives the existing @ token
+// parser even when the real directory path contains spaces or Windows drive
+// punctuation.
+func (c *Controller) RegisterExternalFolderRef(path string) (token, displayPath string, err error) {
+	if c == nil {
+		return "", "", fmt.Errorf("controller is not ready")
+	}
+	abs, err := normalizeExternalFolderRoot(path)
+	if err != nil {
+		return "", "", err
+	}
+	token = externalFolderRefToken(abs)
+	c.externalFolderRefsMu.Lock()
+	if c.externalFolderRefs == nil {
+		c.externalFolderRefs = map[string]string{}
+	}
+	c.externalFolderRefs[token] = abs
+	c.externalFolderRefsMu.Unlock()
+	return token, filepath.ToSlash(abs), nil
+}
+
+func normalizeExternalFolderRoot(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", os.ErrInvalid
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = filepath.Clean(resolved)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return abs, nil
+}
+
+func externalFolderRefToken(abs string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(abs)))
+	hash := hex.EncodeToString(sum[:])[:12]
+	name := safeExternalFolderRefComponent(filepath.Base(abs))
+	return externalFolderRefPrefix + "/" + hash + "/" + name
+}
+
+func safeExternalFolderRefComponent(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		return "folder"
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range name {
+		ok := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '.' || r == '_' || r == '-'
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), ".-")
+	if out == "" {
+		return "folder"
+	}
+	return out
+}
+
+func normalizeExternalFolderRefToken(token string) string {
+	token = strings.TrimSpace(token)
+	token = strings.TrimPrefix(token, "@")
+	token = filepath.ToSlash(token)
+	token = strings.TrimRight(token, "/")
+	return token
+}
+
+func (c *Controller) externalFolderRef(token string) (ref, bool) {
+	key := normalizeExternalFolderRefToken(token)
+	if !strings.HasPrefix(key, externalFolderRefPrefix+"/") {
+		return ref{}, false
+	}
+	c.externalFolderRefsMu.RLock()
+	abs, ok := c.externalFolderRefs[key]
+	c.externalFolderRefsMu.RUnlock()
+	if !ok {
+		return ref{}, false
+	}
+	displayPath := filepath.ToSlash(abs)
+	return ref{kind: refFile, path: ".", baseDir: abs, displayPath: displayPath, raw: token}, true
+}
+
 // detectRefs finds the @references in a line: MCP resources for connected
 // servers, and local paths that exist on disk.
 func (c *Controller) detectRefs(line string) []ref {
@@ -119,6 +227,10 @@ func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 	for _, tok := range parseRefTokens(line) {
 		if i := strings.Index(tok, ":"); i > 0 && i+1 < len(tok) && known[tok[:i]] {
 			refs = append(refs, ref{kind: refResource, server: tok[:i], uri: tok[i+1:], raw: tok})
+			continue
+		}
+		if r, ok := c.externalFolderRef(tok); ok {
+			refs = append(refs, r)
 			continue
 		}
 		if c.workspaceRoot != "" {
@@ -446,7 +558,11 @@ func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bo
 			}
 			appendRefBlock(&b, "resource", `ref="@`+r.raw+`"`, text)
 		case refFile:
-			text, isDir, err := readFileRef(r.path, c.workspaceRoot)
+			baseDir := c.workspaceRoot
+			if r.baseDir != "" {
+				baseDir = r.baseDir
+			}
+			text, isDir, err := readFileRef(r.path, baseDir)
 			if err != nil {
 				errs = append(errs, "@"+r.raw+" — "+err.Error())
 				continue
@@ -455,7 +571,11 @@ func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bo
 			if isDir {
 				tag = "dir"
 			}
-			appendRefBlock(&b, tag, `path="`+r.path+`"`, text)
+			displayPath := r.path
+			if r.displayPath != "" {
+				displayPath = r.displayPath
+			}
+			appendRefBlock(&b, tag, `path="`+displayPath+`"`, text)
 		case refImage:
 			appendRefBlock(&b, "image", `path="`+r.path+`"`, "[image attachment available at @"+r.path+"; sent as direct model image input only when the selected model supports vision. Text-only models can still use an available OCR/image/vision tool with this local path; image bytes are not inlined into prompt text.]")
 		}
@@ -509,7 +629,7 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	if info.IsDir() {
 		var b strings.Builder
 		n := 0
-		err := walkRootDir(root, rel, &b, &n, 0)
+		err := walkRootDir(root, rel, rel, &b, &n, 0)
 		if n >= maxDirEntries {
 			b.WriteString("\n…[truncated; directory has more entries]…")
 		}
@@ -633,9 +753,9 @@ func imageFileRefNote(displayPath, mime string, size int64, attached bool) strin
 }
 
 // walkRootDir walks a directory under a sandboxed *os.Root and writes each
-// entry (skipping noisy ones like .git and node_modules) into b until n hits
-// maxDirEntries.
-func walkRootDir(root *os.Root, dir string, b *strings.Builder, n *int, depth int) error {
+// entry relative to base (skipping noisy ones like .git and node_modules) into b
+// until n hits maxDirEntries.
+func walkRootDir(root *os.Root, dir, base string, b *strings.Builder, n *int, depth int) error {
 	if depth > 16 || *n >= maxDirEntries {
 		return nil
 	}
@@ -653,7 +773,11 @@ func walkRootDir(root *os.Root, dir string, b *strings.Builder, n *int, depth in
 			return nil
 		}
 		name := e.Name()
+		child := filepath.ToSlash(filepath.Join(dir, name))
 		entry := name
+		if rel, err := filepath.Rel(base, child); err == nil && filepath.IsLocal(rel) {
+			entry = filepath.ToSlash(rel)
+		}
 		if e.IsDir() {
 			switch name {
 			case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
@@ -665,8 +789,7 @@ func walkRootDir(root *os.Root, dir string, b *strings.Builder, n *int, depth in
 		b.WriteByte('\n')
 		*n++
 		if e.IsDir() {
-			child := filepath.ToSlash(filepath.Join(dir, name))
-			if err := walkRootDir(root, child, b, n, depth+1); err != nil {
+			if err := walkRootDir(root, child, base, b, n, depth+1); err != nil {
 				return err
 			}
 		}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -13,9 +13,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
+	"reasonix/internal/fileref"
 	"reasonix/internal/proc"
 )
 
@@ -53,6 +55,17 @@ type ref struct {
 	baseDir     string // refFile override for session-authorized external roots
 	displayPath string // refFile label/path exposed in the resolved context block
 	raw         string // the original token after '@', for labelling
+}
+
+// ExternalFolderRefEntry is a session-authorized entry under a dropped external
+// folder. Path is the opaque @ token path to submit; display fields are safe for
+// UI labels and transcripts.
+type ExternalFolderRefEntry struct {
+	Name        string
+	Path        string
+	DisplayName string
+	DisplayPath string
+	IsDir       bool
 }
 
 // refTokenRe matches an @reference token: '@' then a run of non-space chars.
@@ -197,18 +210,216 @@ func normalizeExternalFolderRefToken(token string) string {
 }
 
 func (c *Controller) externalFolderRef(token string) (ref, bool) {
-	key := normalizeExternalFolderRefToken(token)
-	if !strings.HasPrefix(key, externalFolderRefPrefix+"/") {
-		return ref{}, false
-	}
-	c.externalFolderRefsMu.RLock()
-	abs, ok := c.externalFolderRefs[key]
-	c.externalFolderRefsMu.RUnlock()
+	_, rel, abs, ok := c.externalFolderRefTarget(token)
 	if !ok {
 		return ref{}, false
 	}
-	displayPath := filepath.ToSlash(abs)
-	return ref{kind: refFile, path: ".", baseDir: abs, displayPath: displayPath, raw: token}, true
+	displayPath := externalFolderDisplayPath(abs, rel)
+	return ref{kind: refFile, path: rel, baseDir: abs, displayPath: displayPath, raw: token}, true
+}
+
+func (c *Controller) externalFolderRefTarget(token string) (rootToken, rel, abs string, ok bool) {
+	key := normalizeExternalFolderRefToken(token)
+	if !strings.HasPrefix(key, externalFolderRefPrefix+"/") {
+		return "", "", "", false
+	}
+	c.externalFolderRefsMu.RLock()
+	defer c.externalFolderRefsMu.RUnlock()
+	if abs, ok := c.externalFolderRefs[key]; ok {
+		return key, ".", abs, true
+	}
+	for registered, abs := range c.externalFolderRefs {
+		if !strings.HasPrefix(key, registered+"/") {
+			continue
+		}
+		sub, ok := cleanExternalFolderSubpath(strings.TrimPrefix(key, registered+"/"))
+		if !ok {
+			return "", "", "", false
+		}
+		return registered, sub, abs, true
+	}
+	return "", "", "", false
+}
+
+func cleanExternalFolderSubpath(sub string) (string, bool) {
+	sub = strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(sub)), "/")
+	if sub == "" || sub == "." {
+		return ".", true
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(sub))
+	if cleaned == "." {
+		return ".", true
+	}
+	if !filepath.IsLocal(cleaned) {
+		return "", false
+	}
+	return filepath.ToSlash(cleaned), true
+}
+
+func externalFolderDisplayPath(abs, rel string) string {
+	if rel == "" || rel == "." {
+		return filepath.ToSlash(abs)
+	}
+	return filepath.ToSlash(filepath.Join(abs, filepath.FromSlash(rel)))
+}
+
+func externalFolderDisplayName(abs, rel string) string {
+	name := filepath.Base(abs)
+	if rel != "" && rel != "." {
+		name = filepath.ToSlash(filepath.Join(name, filepath.FromSlash(rel)))
+	}
+	return name
+}
+
+// ListExternalFolderRefDir lists one directory level under a registered
+// external folder token. handled is true only when tokenPath targets a
+// registered external folder; callers can fall back to workspace listing when it
+// is false.
+func (c *Controller) ListExternalFolderRefDir(tokenPath string) (entries []ExternalFolderRefEntry, handled bool) {
+	rootToken, rel, abs, ok := c.externalFolderRefTarget(tokenPath)
+	if !ok {
+		return nil, false
+	}
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, true
+	}
+	defer root.Close()
+	info, err := root.Stat(rel)
+	if err != nil || !info.IsDir() {
+		return nil, true
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, true
+	}
+	dirEntries, err := f.ReadDir(-1)
+	f.Close()
+	if err != nil {
+		return nil, true
+	}
+	dirs, files := []ExternalFolderRefEntry{}, []ExternalFolderRefEntry{}
+	for _, e := range dirEntries {
+		name := e.Name()
+		if skipRefDirEntry(name, e.IsDir()) {
+			continue
+		}
+		childRel := name
+		if rel != "." {
+			childRel = filepath.ToSlash(filepath.Join(rel, name))
+		}
+		item := ExternalFolderRefEntry{
+			Name:        name,
+			Path:        rootToken + "/" + childRel,
+			DisplayName: name,
+			DisplayPath: externalFolderDisplayPath(abs, childRel),
+			IsDir:       e.IsDir(),
+		}
+		if e.IsDir() {
+			dirs = append(dirs, item)
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		files = append(files, item)
+	}
+	sortExternalFolderRefEntries(dirs)
+	sortExternalFolderRefEntries(files)
+	return append(dirs, files...), true
+}
+
+// SearchExternalFolderRefs finds entries under all registered external folders.
+// Returned Path values are opaque token paths, so selecting one stays within the
+// current session's authorization boundary.
+func (c *Controller) SearchExternalFolderRefs(query string, limit int) []ExternalFolderRefEntry {
+	query = strings.TrimSpace(query)
+	if limit <= 0 || len(query) < 2 || strings.ContainsAny(query, `/\`) {
+		return nil
+	}
+	c.externalFolderRefsMu.RLock()
+	roots := make([]struct {
+		token string
+		abs   string
+	}, 0, len(c.externalFolderRefs))
+	for token, abs := range c.externalFolderRefs {
+		roots = append(roots, struct {
+			token string
+			abs   string
+		}{token: token, abs: abs})
+	}
+	c.externalFolderRefsMu.RUnlock()
+	sort.Slice(roots, func(i, j int) bool {
+		return externalFolderDisplayPath(roots[i].abs, ".") < externalFolderDisplayPath(roots[j].abs, ".")
+	})
+	out := make([]ExternalFolderRefEntry, 0, limit)
+	queryLower := strings.ToLower(query)
+	for _, root := range roots {
+		if len(out) >= limit {
+			break
+		}
+		if info, err := os.Stat(root.abs); err != nil || !info.IsDir() {
+			continue
+		}
+		if strings.Contains(strings.ToLower(filepath.Base(root.abs)), queryLower) {
+			out = append(out, ExternalFolderRefEntry{
+				Name:        filepath.Base(root.abs),
+				Path:        root.token,
+				DisplayName: externalFolderDisplayName(root.abs, "."),
+				DisplayPath: externalFolderDisplayPath(root.abs, "."),
+				IsDir:       true,
+			})
+			if len(out) >= limit {
+				break
+			}
+		}
+		for _, result := range fileref.Search(root.abs, query, limit-len(out)) {
+			rel := filepath.ToSlash(result.Path)
+			out = append(out, ExternalFolderRefEntry{
+				Name:        rel,
+				Path:        root.token + "/" + rel,
+				DisplayName: externalFolderDisplayName(root.abs, rel),
+				DisplayPath: externalFolderDisplayPath(root.abs, rel),
+				IsDir:       result.IsDir,
+			})
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out
+}
+
+// ExternalFolderRefLocalPath resolves a registered external-folder token path to
+// the local filesystem path authorized for this controller session.
+func (c *Controller) ExternalFolderRefLocalPath(tokenPath string) (path, displayPath string, ok bool) {
+	_, rel, abs, ok := c.externalFolderRefTarget(tokenPath)
+	if !ok {
+		return "", "", false
+	}
+	return filepath.Join(abs, filepath.FromSlash(rel)), externalFolderDisplayPath(abs, rel), true
+}
+
+func sortExternalFolderRefEntries(entries []ExternalFolderRefEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.ToLower(entries[i].DisplayName) < strings.ToLower(entries[j].DisplayName)
+	})
+}
+
+func skipRefDirEntry(name string, isDir bool) bool {
+	switch name {
+	case ".DS_Store":
+		return true
+	}
+	if !isDir {
+		return false
+	}
+	switch name {
+	case ".git", "node_modules", "__pycache__", ".idea", ".vscode":
+		return true
+	}
+	return false
 }
 
 // detectRefs finds the @references in a line: MCP resources for connected
@@ -271,7 +482,11 @@ func (c *Controller) inputImages(line string) []string {
 	}
 	var urls []string
 	for _, r := range c.detectRefs(line) {
-		if url, err := visionRefImageDataURL(r, c.workspaceRoot); err == nil {
+		baseDir := c.workspaceRoot
+		if r.baseDir != "" {
+			baseDir = r.baseDir
+		}
+		if url, err := visionRefImageDataURL(r, baseDir); err == nil {
 			urls = append(urls, url)
 		}
 	}
@@ -778,11 +993,10 @@ func walkRootDir(root *os.Root, dir, base string, b *strings.Builder, n *int, de
 		if rel, err := filepath.Rel(base, child); err == nil && filepath.IsLocal(rel) {
 			entry = filepath.ToSlash(rel)
 		}
+		if skipRefDirEntry(name, e.IsDir()) {
+			continue
+		}
 		if e.IsDir() {
-			switch name {
-			case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
-				continue
-			}
 			entry += "/"
 		}
 		b.WriteString(entry)

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -409,14 +409,14 @@ func sortExternalFolderRefEntries(entries []ExternalFolderRefEntry) {
 
 func skipRefDirEntry(name string, isDir bool) bool {
 	switch name {
-	case ".DS_Store":
+	case ".DS_Store", "Thumbs.db":
 		return true
 	}
 	if !isDir {
 		return false
 	}
 	switch name {
-	case ".git", "node_modules", "__pycache__", ".idea", ".vscode":
+	case ".codex", ".git", ".idea", ".npm", ".pnpm-store", ".vscode", "__pycache__", "build", "dist", "node_modules":
 		return true
 	}
 	return false
@@ -809,6 +809,12 @@ func appendRefBlock(b *strings.Builder, tag, attr, body string) {
 // can't blow the context window.
 const maxDirEntries = 100
 
+const maxDirDepth = 16
+
+func directoryRefNote() string {
+	return fmt.Sprintf("[directory listing only; file contents are not inlined. Mention a listed file path to read its content. Common generated/vendor folders are skipped. Listing is capped at %d entries and %d nested levels.]", maxDirEntries, maxDirDepth)
+}
+
 // readFileRef reads an @-referenced path for injection. A directory yields a
 // recursive listing capped at maxDirEntries; a binary file (NUL in the first
 // 8 KiB) is noted rather than dumped; a large file is truncated to
@@ -843,6 +849,8 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	}
 	if info.IsDir() {
 		var b strings.Builder
+		b.WriteString(directoryRefNote())
+		b.WriteString("\n\n")
 		n := 0
 		err := walkRootDir(root, rel, rel, &b, &n, 0)
 		if n >= maxDirEntries {
@@ -892,6 +900,8 @@ func readFileRefUnscoped(path string) (content string, isDir bool, err error) {
 	}
 	if info.IsDir() {
 		var b strings.Builder
+		b.WriteString(directoryRefNote())
+		b.WriteString("\n\n")
 		n := 0
 		err := filepath.WalkDir(path, func(p string, d os.DirEntry, wErr error) error {
 			if wErr != nil {
@@ -903,11 +913,11 @@ func readFileRefUnscoped(path string) (content string, isDir bool, err error) {
 			if p == path {
 				return nil
 			}
-			if d.IsDir() {
-				switch d.Name() {
-				case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
+			if skipRefDirEntry(d.Name(), d.IsDir()) {
+				if d.IsDir() {
 					return filepath.SkipDir
 				}
+				return nil
 			}
 			rel, rErr := filepath.Rel(path, p)
 			if rErr != nil {
@@ -971,7 +981,7 @@ func imageFileRefNote(displayPath, mime string, size int64, attached bool) strin
 // entry relative to base (skipping noisy ones like .git and node_modules) into b
 // until n hits maxDirEntries.
 func walkRootDir(root *os.Root, dir, base string, b *strings.Builder, n *int, depth int) error {
-	if depth > 16 || *n >= maxDirEntries {
+	if depth > maxDirDepth || *n >= maxDirEntries {
 		return nil
 	}
 	f, err := root.Open(dir)
@@ -983,6 +993,12 @@ func walkRootDir(root *os.Root, dir, base string, b *strings.Builder, n *int, de
 	if err != nil {
 		return err
 	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsDir() != entries[j].IsDir() {
+			return entries[i].IsDir()
+		}
+		return strings.ToLower(entries[i].Name()) < strings.ToLower(entries[j].Name())
+	})
 	for _, e := range entries {
 		if *n >= maxDirEntries {
 			return nil

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -142,6 +142,9 @@ func (c *Controller) RegisterExternalFolderRef(path string) (token, displayPath 
 	}
 	c.externalFolderRefs[token] = abs
 	c.externalFolderRefsMu.Unlock()
+	if c.externalFolderToolRefs != nil {
+		c.externalFolderToolRefs.RegisterReadRoot(token, abs)
+	}
 	return token, filepath.ToSlash(abs), nil
 }
 

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -586,6 +586,75 @@ func TestRegisterExternalFolderRefResolvesScopedDir(t *testing.T) {
 		!strings.Contains(block, "sub/outside.txt") {
 		t.Fatalf("registered external folder should resolve as a dir listing:\n%s", block)
 	}
+
+	block, errs = c.ResolveScopedRefs(context.Background(), "read @"+token+"/sub/outside.txt")
+	if len(errs) != 0 {
+		t.Fatalf("ResolveScopedRefs child errors = %v", errs)
+	}
+	if !strings.Contains(block, `<file path="`+expectedDisplayPath+`/sub/outside.txt">`) ||
+		!strings.Contains(block, "outside") {
+		t.Fatalf("registered external child should resolve as file content:\n%s", block)
+	}
+
+	block, errs = c.ResolveScopedRefs(context.Background(), "escape @"+token+"/../secret.txt")
+	if block != "" || len(errs) != 0 {
+		t.Fatalf("external folder ref must not resolve escaping subpaths, block=%q errs=%v", block, errs)
+	}
+}
+
+func TestExternalFolderRefListAndSearch(t *testing.T) {
+	parent := t.TempDir()
+	external := filepath.Join(parent, "Folder With Spaces")
+	if err := os.MkdirAll(filepath.Join(external, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "src", "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(external, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "node_modules", "outside.txt"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectedExternal := external
+	if resolved, err := filepath.EvalSymlinks(external); err == nil {
+		expectedExternal = resolved
+	}
+	expectedDisplayPath := filepath.ToSlash(expectedExternal)
+
+	c := &Controller{}
+	token, _, err := c.RegisterExternalFolderRef(external)
+	if err != nil {
+		t.Fatalf("RegisterExternalFolderRef: %v", err)
+	}
+
+	rootEntries, handled := c.ListExternalFolderRefDir(token + "/")
+	if !handled {
+		t.Fatal("ListExternalFolderRefDir should handle the registered root token")
+	}
+	if len(rootEntries) != 1 || rootEntries[0].Name != "src" || !rootEntries[0].IsDir {
+		t.Fatalf("root entries = %+v, want src/ and skipped node_modules", rootEntries)
+	}
+
+	srcEntries, handled := c.ListExternalFolderRefDir(token + "/src/")
+	if !handled {
+		t.Fatal("ListExternalFolderRefDir should handle registered child dirs")
+	}
+	if len(srcEntries) != 1 ||
+		srcEntries[0].Name != "outside.txt" ||
+		srcEntries[0].Path != token+"/src/outside.txt" ||
+		srcEntries[0].DisplayPath != expectedDisplayPath+"/src/outside.txt" {
+		t.Fatalf("src entries = %+v, want outside.txt token/display path", srcEntries)
+	}
+
+	results := c.SearchExternalFolderRefs("outside", 10)
+	if len(results) != 1 ||
+		results[0].Path != token+"/src/outside.txt" ||
+		results[0].DisplayName != "Folder With Spaces/src/outside.txt" ||
+		results[0].DisplayPath != expectedDisplayPath+"/src/outside.txt" {
+		t.Fatalf("search results = %+v, want external outside.txt with token and display paths", results)
+	}
 }
 
 func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -527,6 +527,67 @@ func TestDetectRefsUsesWorkspaceRootNotProcessCWD(t *testing.T) {
 	}
 }
 
+func TestScopedRefsRequireExternalFolderRegistration(t *testing.T) {
+	workspace := t.TempDir()
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Controller{workspaceRoot: workspace}
+	block, errs := c.ResolveScopedRefs(context.Background(), "see @"+external)
+	if block != "" || len(errs) != 0 {
+		t.Fatalf("unregistered external dir should not resolve, block=%q errs=%v", block, errs)
+	}
+}
+
+func TestRegisterExternalFolderRefResolvesScopedDir(t *testing.T) {
+	workspace := t.TempDir()
+	parent := t.TempDir()
+	external := filepath.Join(parent, "Folder With Spaces")
+	if err := os.MkdirAll(filepath.Join(external, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(external, "sub", "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expectedExternal := external
+	if resolved, err := filepath.EvalSymlinks(external); err == nil {
+		expectedExternal = resolved
+	}
+	expectedDisplayPath := filepath.ToSlash(expectedExternal)
+
+	c := &Controller{workspaceRoot: workspace}
+	token, displayPath, err := c.RegisterExternalFolderRef(external)
+	if err != nil {
+		t.Fatalf("RegisterExternalFolderRef: %v", err)
+	}
+	if strings.ContainsAny(token, " \t\r\n") {
+		t.Fatalf("external folder token must be whitespace-free, got %q", token)
+	}
+	if displayPath != expectedDisplayPath {
+		t.Fatalf("display path = %q, want %q", displayPath, expectedDisplayPath)
+	}
+
+	refs := c.detectRefs("see @" + token + "/")
+	if len(refs) != 1 {
+		t.Fatalf("detectRefs registered external folder = %+v, want 1 ref", refs)
+	}
+	if refs[0].path != "." || refs[0].baseDir != expectedExternal || refs[0].displayPath != expectedDisplayPath {
+		t.Fatalf("external ref = %+v, want path '.' baseDir/displayPath for external folder", refs[0])
+	}
+
+	block, errs := c.ResolveScopedRefs(context.Background(), "see @"+token+"/")
+	if len(errs) != 0 {
+		t.Fatalf("ResolveScopedRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, `<dir path="`+expectedDisplayPath+`">`) ||
+		!strings.Contains(block, "sub/") ||
+		!strings.Contains(block, "sub/outside.txt") {
+		t.Fatalf("registered external folder should resolve as a dir listing:\n%s", block)
+	}
+}
+
 func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {
 	workspace := t.TempDir()
 	absPath := filepath.Join(workspace, "docs", "note.txt")

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -592,10 +592,14 @@ func TestRegisterExternalFolderRefResolvesScopedDir(t *testing.T) {
 	}
 	expectedDisplayPath := filepath.ToSlash(expectedExternal)
 
-	c := &Controller{workspaceRoot: workspace}
+	registrar := &recordingExternalFolderToolRefs{}
+	c := &Controller{workspaceRoot: workspace, externalFolderToolRefs: registrar}
 	token, displayPath, err := c.RegisterExternalFolderRef(external)
 	if err != nil {
 		t.Fatalf("RegisterExternalFolderRef: %v", err)
+	}
+	if registrar.token != token || registrar.root != expectedExternal {
+		t.Fatalf("tool read root registration = (%q, %q), want (%q, %q)", registrar.token, registrar.root, token, expectedExternal)
 	}
 	if strings.ContainsAny(token, " \t\r\n") {
 		t.Fatalf("external folder token must be whitespace-free, got %q", token)
@@ -636,6 +640,16 @@ func TestRegisterExternalFolderRefResolvesScopedDir(t *testing.T) {
 	if block != "" || len(errs) != 0 {
 		t.Fatalf("external folder ref must not resolve escaping subpaths, block=%q errs=%v", block, errs)
 	}
+}
+
+type recordingExternalFolderToolRefs struct {
+	token string
+	root  string
+}
+
+func (r *recordingExternalFolderToolRefs) RegisterReadRoot(token, root string) {
+	r.token = token
+	r.root = root
 }
 
 func TestExternalFolderRefListAndSearch(t *testing.T) {

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -194,12 +194,24 @@ func TestReadFileRef(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("nested"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "pkg", "noise.js"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	got, isDir, err := readFileRef(dir, "")
 	if err != nil || !isDir {
 		t.Fatalf("dir = (isDir=%v, err=%v)", isDir, err)
 	}
+	if !strings.Contains(got, "directory listing only") || !strings.Contains(got, "file contents are not inlined") {
+		t.Errorf("dir listing = %q, want a directory reference note", got)
+	}
 	if !strings.Contains(got, "hello.txt") || !strings.Contains(got, "sub/") || !strings.Contains(got, "sub/nested.txt") {
 		t.Errorf("dir listing = %q, want hello.txt, sub/, and sub/nested.txt", got)
+	}
+	if strings.Contains(got, "node_modules") || strings.Contains(got, "noise.js") {
+		t.Errorf("dir listing = %q, want generated/vendor directories skipped", got)
 	}
 
 	// Missing path: error.
@@ -366,6 +378,29 @@ func TestReadFileRefWithBaseDir(t *testing.T) {
 	}
 	if got2 != "hello" {
 		t.Errorf("got %q, want %q", got2, "hello")
+	}
+
+	if err := os.MkdirAll(filepath.Join(sub, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "src", "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sub, "dist"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "dist", "bundle.js"), []byte("generated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gotDir, isDir, err := readFileRef("proj", base)
+	if err != nil || !isDir {
+		t.Fatalf("readFileRef scoped dir = (isDir=%v, err=%v)", isDir, err)
+	}
+	if !strings.Contains(gotDir, "directory listing only") || !strings.Contains(gotDir, "src/") || !strings.Contains(gotDir, "src/main.go") {
+		t.Fatalf("scoped dir listing missing contract or nested file:\n%s", gotDir)
+	}
+	if strings.Contains(gotDir, "dist/") || strings.Contains(gotDir, "bundle.js") {
+		t.Fatalf("scoped dir listing should skip generated dirs:\n%s", gotDir)
 	}
 }
 
@@ -582,6 +617,7 @@ func TestRegisterExternalFolderRefResolvesScopedDir(t *testing.T) {
 		t.Fatalf("ResolveScopedRefs errors = %v", errs)
 	}
 	if !strings.Contains(block, `<dir path="`+expectedDisplayPath+`">`) ||
+		!strings.Contains(block, "directory listing only") ||
 		!strings.Contains(block, "sub/") ||
 		!strings.Contains(block, "sub/outside.txt") {
 		t.Fatalf("registered external folder should resolve as a dir listing:\n%s", block)

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -15,8 +15,12 @@ import (
 func init() { tool.RegisterBuiltin(globTool{}) }
 
 // globTool matches files by pattern. workDir, when non-empty, is the directory
-// a relative pattern resolves against (see resolveIn).
-type globTool struct{ workDir string }
+// a relative pattern resolves against (see resolveIn). paths resolves
+// session-scoped read aliases for external folder refs.
+type globTool struct {
+	workDir string
+	paths   *PathResolver
+}
 
 func (globTool) Name() string { return "glob" }
 
@@ -46,12 +50,14 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// simple-filename recursive-fallback check below works on the raw input
 	// — not the already-joined absolute path that always contains separators.
 	rawPattern := p.Pattern
-	p.Pattern = resolveIn(g.workDir, p.Pattern)
+	rp := resolveReadablePath(g.workDir, p.Pattern, g.paths)
+	p.Pattern = rp.Path
 	p.Pattern = filepath.FromSlash(p.Pattern) // models emit "/" (see Description); WalkDir/Match compare OS-native paths
+	displayPattern := rp.DisplayPath
 
 	// If the pattern contains **, use recursive matching via filepath.WalkDir.
 	if strings.Contains(p.Pattern, "**") {
-		return globRecursive(ctx, p.Pattern)
+		return globRecursive(ctx, p.Pattern, displayPattern, rp)
 	}
 
 	// For patterns without **, try filepath.Glob first. If no matches are
@@ -62,14 +68,19 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// resolveIn) so a workspace root doesn't mask a simple "*.go".
 	matches, err := filepath.Glob(p.Pattern)
 	if err != nil {
-		return "", fmt.Errorf("glob %q: %w", p.Pattern, err)
+		if rp.External {
+			return "", fmt.Errorf("glob %q: %s", displayPattern, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("glob %q: %w", displayPattern, err)
 	}
 	if len(matches) == 0 && !strings.ContainsAny(rawPattern, "/\\") {
-		return globRecursive(ctx, filepath.Join(g.workDir, "**", rawPattern))
+		fallback := filepath.Join(g.workDir, "**", rawPattern)
+		return globRecursive(ctx, fallback, fallback, ResolvedPath{})
 	}
 	if len(matches) == 0 {
 		return "(no matches)", nil
 	}
+	matches = displayGlobMatches(matches, rp)
 	if len(matches) > globMaxResults {
 		matches = matches[:globMaxResults]
 		return strings.Join(matches, "\n") + fmt.Sprintf("\n... (truncated at %d results)", globMaxResults), nil
@@ -81,7 +92,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 // It splits the pattern at ** to get a root prefix and a suffix to match
 // against each file path found during the walk. Accepts a context so the
 // walk can be interrupted on cancellation.
-func globRecursive(ctx context.Context, pattern string) (string, error) {
+func globRecursive(ctx context.Context, pattern, displayPattern string, rp ResolvedPath) (string, error) {
 	// Split on ** to find the root directory and the remaining pattern.
 	parts := strings.SplitN(pattern, "**", 2)
 	root := parts[0]
@@ -95,7 +106,10 @@ func globRecursive(ctx context.Context, pattern string) (string, error) {
 
 	// Check root exists.
 	if info, err := os.Stat(root); err != nil {
-		return "", fmt.Errorf("glob %q: %w", pattern, err)
+		if rp.External {
+			return "", fmt.Errorf("glob %q: %s", displayPattern, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("glob %q: %w", displayPattern, err)
 	} else if !info.IsDir() {
 		return "(no matches)", nil
 	}
@@ -142,18 +156,33 @@ func globRecursive(ctx context.Context, pattern string) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("glob %q: %w", pattern, err)
+		if rp.External {
+			return "", fmt.Errorf("glob %q: %s", displayPattern, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("glob %q: %w", displayPattern, err)
 	}
 
 	if len(matches) == 0 {
 		return "(no matches)", nil
 	}
 	sort.Strings(matches)
+	matches = displayGlobMatches(matches, rp)
 	result := strings.Join(matches, "\n")
 	if truncated {
 		result += fmt.Sprintf("\n... (truncated at %d results)", globMaxResults)
 	}
 	return result, nil
+}
+
+func displayGlobMatches(matches []string, rp ResolvedPath) []string {
+	if !rp.External {
+		return matches
+	}
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = rp.DisplayFor(m)
+	}
+	return out
 }
 
 // matchGlobSuffix checks if path matches the suffix pattern after **.

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -65,6 +65,7 @@ func init() { tool.RegisterBuiltin(grepTool{}) }
 // ripgrep binary the search delegates to instead of the native Go scanner.
 type grepTool struct {
 	workDir string
+	paths   *PathResolver
 	rg      string
 }
 
@@ -98,14 +99,15 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if p.Path == "" {
 		p.Path = "."
 	}
-	p.Path = resolveIn(g.workDir, p.Path)
+	rp := resolveReadablePath(g.workDir, p.Path, g.paths)
+	p.Path = rp.Path
 
 	to := grepTimeout(p.TimeoutSeconds)
 	ctx, cancel := context.WithTimeout(ctx, to)
 	defer cancel()
 
 	if g.rg != "" {
-		return g.runRipgrep(ctx, p.Pattern, p.Path, to)
+		return g.runRipgrep(ctx, p.Pattern, p.Path, to, rp)
 	}
 	re, err := regexp.Compile(p.Pattern)
 	if err != nil {
@@ -186,7 +188,7 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 				return nil // looks binary, skip the file
 			}
 			if re.MatchString(line) {
-				out = append(out, fmt.Sprintf("%s:%d:%s", file, ln, line))
+				out = append(out, fmt.Sprintf("%s:%d:%s", rp.DisplayFor(file), ln, line))
 				if len(out) >= grepMaxMatches {
 					truncated = true
 					return io.EOF
@@ -198,7 +200,10 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 	info, err := os.Stat(p.Path)
 	if err != nil {
-		return "", fmt.Errorf("grep %s: %w", p.Path, err)
+		if rp.External {
+			return "", fmt.Errorf("grep %s: %s", rp.DisplayPath, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("grep %s: %w", rp.DisplayPath, err)
 	}
 
 	if info.IsDir() {
@@ -235,7 +240,7 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 // runRipgrep delegates the search to ripgrep, which already emits
 // path:line:text with these flags and honors .gitignore. Output is streamed and
 // capped at grepMaxMatches so a flood of hits can't blow up memory.
-func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.Duration) (string, error) {
+func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.Duration, rp ResolvedPath) (string, error) {
 	cmd := exec.CommandContext(ctx, g.rg,
 		"--no-heading", "--line-number", "--with-filename", "--color", "never",
 		"--regexp", pattern, "--", path)
@@ -255,7 +260,7 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 	sc := bufio.NewScanner(stdout)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for sc.Scan() {
-		out = append(out, sc.Text())
+		out = append(out, displayRipgrepLine(sc.Text(), rp))
 		if len(out) >= grepMaxMatches {
 			truncated = true
 			break
@@ -271,10 +276,33 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 		// ripgrep exits 1 with no output for "no matches"; a real failure (bad
 		// pattern, unreadable path) writes a message to stderr.
 		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			if rp.External {
+				msg = rp.ErrorText(fmt.Errorf("%s", msg))
+			}
 			return "", fmt.Errorf("ripgrep: %s", msg)
 		}
 	}
 	return formatGrep(ctx, out, truncated, to), nil
+}
+
+func displayRipgrepLine(line string, rp ResolvedPath) string {
+	if !rp.External || !strings.HasPrefix(line, rp.Root) {
+		return line
+	}
+	for i := len(rp.Root); i < len(line); i++ {
+		if line[i] != ':' || i+1 >= len(line) || line[i+1] < '0' || line[i+1] > '9' {
+			continue
+		}
+		j := i + 1
+		for j < len(line) && line[j] >= '0' && line[j] <= '9' {
+			j++
+		}
+		if j >= len(line) || line[j] != ':' {
+			continue
+		}
+		return rp.DisplayFor(line[:i]) + line[i:]
+	}
+	return line
 }
 
 // SearchSpec configures the grep tool's engine. A non-empty RgPath makes grep

--- a/internal/tool/builtin/ls.go
+++ b/internal/tool/builtin/ls.go
@@ -14,8 +14,12 @@ import (
 func init() { tool.RegisterBuiltin(listDir{}) }
 
 // listDir lists a directory. workDir, when non-empty, is the directory a
-// relative path resolves against (see resolveIn).
-type listDir struct{ workDir string }
+// relative path resolves against (see resolveIn). paths resolves session-scoped
+// read aliases for external folder refs.
+type listDir struct {
+	workDir string
+	paths   *PathResolver
+}
 
 func (listDir) Name() string { return "ls" }
 
@@ -42,16 +46,20 @@ func (l listDir) Execute(ctx context.Context, args json.RawMessage) (string, err
 	if p.Path == "" {
 		p.Path = "."
 	}
-	p.Path = resolveIn(l.workDir, p.Path)
+	rp := resolveReadablePath(l.workDir, p.Path, l.paths)
+	p.Path = rp.Path
 
 	// Recursive mode: walk the whole tree depth-first.
 	if p.Recursive {
-		return l.listRecursive(p.Path)
+		return l.listRecursive(p.Path, rp)
 	}
 
 	entries, err := os.ReadDir(p.Path)
 	if err != nil {
-		return "", fmt.Errorf("ls %s: %w", p.Path, err)
+		if rp.External {
+			return "", fmt.Errorf("ls %s: %s", rp.DisplayPath, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("ls %s: %w", rp.DisplayPath, err)
 	}
 
 	var b strings.Builder
@@ -74,7 +82,7 @@ func (l listDir) Execute(ctx context.Context, args json.RawMessage) (string, err
 
 // listRecursive walks a directory tree depth-first, skipping noise dirs.
 // Depth is capped to guard against symlink loops.
-func (l listDir) listRecursive(root string) (string, error) {
+func (l listDir) listRecursive(root string, rp ResolvedPath) (string, error) {
 	var b strings.Builder
 	err := filepath.WalkDir(root, func(p string, d os.DirEntry, wErr error) error {
 		if wErr != nil {
@@ -110,7 +118,10 @@ func (l listDir) listRecursive(root string) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("ls -R %s: %w", root, err)
+		if rp.External {
+			return "", fmt.Errorf("ls -R %s: %s", rp.DisplayPath, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("ls -R %s: %w", rp.DisplayPath, err)
 	}
 	if b.Len() == 0 {
 		return "(empty directory tree)", nil

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -26,9 +26,13 @@ const (
 func init() { tool.RegisterBuiltin(readFile{}) }
 
 // readFile reads a text file. workDir, when non-empty, is the directory a
-// relative path is resolved against (see resolveIn); the zero value registered
-// at init resolves against the process working directory.
-type readFile struct{ workDir string }
+// relative path is resolved against (see resolveIn); paths maps session-scoped
+// external read aliases to local roots without changing the model-visible tool
+// schema.
+type readFile struct {
+	workDir string
+	paths   *PathResolver
+}
 
 const (
 	readFileDefaultLimit = 2000 // lines returned when limit is unset
@@ -66,7 +70,9 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if p.Path == "" {
 		return "", fmt.Errorf("path is required")
 	}
-	p.Path = resolveIn(r.workDir, p.Path)
+	rp := resolveReadablePath(r.workDir, p.Path, r.paths)
+	p.Path = rp.Path
+	displayPath := rp.DisplayPath
 	if p.Offset < 0 {
 		p.Offset = 0
 	}
@@ -78,12 +84,15 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// an actionable message (and avoid the doubled "read X: read X:" the scanner's
 	// error would otherwise produce) so the model switches to the ls tool.
 	if info, err := os.Stat(p.Path); err == nil && info.IsDir() {
-		return "", fmt.Errorf("%s is a directory, not a file — use the ls tool to list it, or read a specific file inside it", p.Path)
+		return "", fmt.Errorf("%s is a directory, not a file — use the ls tool to list it, or read a specific file inside it", displayPath)
 	}
 
 	f, err := os.Open(p.Path)
 	if err != nil {
-		return "", fmt.Errorf("read %s: %w", p.Path, err)
+		if rp.External {
+			return "", fmt.Errorf("read %s: %s", displayPath, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("read %s: %w", displayPath, err)
 	}
 	defer f.Close()
 
@@ -103,7 +112,10 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		// buffer it fully (these files are rare and usually small).
 		rest, rerr := io.ReadAll(f)
 		if rerr != nil {
-			return "", fmt.Errorf("read %s: %w", p.Path, rerr)
+			if rp.External {
+				return "", fmt.Errorf("read %s: %s", displayPath, rp.ErrorText(rerr))
+			}
+			return "", fmt.Errorf("read %s: %w", displayPath, rerr)
 		}
 		all := append(peek, rest...)
 		bom := fileenc.DetectQuick(all)
@@ -123,14 +135,20 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if k, ok := fileenc.DetectUTF16NoBOM(peek); ok {
 		rest, rerr := io.ReadAll(f)
 		if rerr != nil {
-			return "", fmt.Errorf("read %s: %w", p.Path, rerr)
+			if rp.External {
+				return "", fmt.Errorf("read %s: %s", displayPath, rp.ErrorText(rerr))
+			}
+			return "", fmt.Errorf("read %s: %w", displayPath, rerr)
 		}
 		all := append(peek, rest...)
 		return r.scan(bytes.NewReader(fileenc.Decode(all, k)), p.Offset, p.Limit)
 	}
 
 	if bytes.IndexByte(peek, 0) >= 0 {
-		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
+		if rp.External {
+			return "", fmt.Errorf("binary file %s (NUL byte detected); not shown by read_file", displayPath)
+		}
+		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", displayPath)
 	}
 
 	// Read up to a bounded sample for encoding detection, then stream the rest —

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -2,6 +2,8 @@ package builtin
 
 import (
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/netclient"
@@ -27,6 +29,7 @@ type Workspace struct {
 	BashTimeout time.Duration
 	Search      SearchSpec
 	ProxySpec   netclient.ProxySpec
+	ReadPaths   *PathResolver
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -42,7 +45,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 	roots := realRoots(writeRoots)
 
 	overrides := map[string]tool.Tool{
-		"read_file":     readFile{workDir: w.Dir},
+		"read_file":     readFile{workDir: w.Dir, paths: w.ReadPaths},
 		"write_file":    writeFile{workDir: w.Dir, roots: roots},
 		"edit_file":     editFile{workDir: w.Dir, roots: roots},
 		"multi_edit":    multiEdit{workDir: w.Dir, roots: roots},
@@ -52,9 +55,9 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"delete_symbol": deleteSymbol{workDir: w.Dir, roots: roots},
 		"code_index":    codeIndex{workDir: w.Dir},
 		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout},
-		"ls":            listDir{workDir: w.Dir},
-		"glob":          globTool{workDir: w.Dir},
-		"grep":          grepTool{workDir: w.Dir, rg: w.Search.RgPath},
+		"ls":            listDir{workDir: w.Dir, paths: w.ReadPaths},
+		"glob":          globTool{workDir: w.Dir, paths: w.ReadPaths},
+		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath},
 		"web_fetch":     webFetch{proxySpec: w.ProxySpec},
 	}
 	all := tool.Builtins()
@@ -100,6 +103,139 @@ func resolveIn(workDir, p string) string {
 		return p
 	}
 	return filepath.Join(workDir, p)
+}
+
+// PathResolver maps session-authorized token paths to local read-only roots.
+// It is intentionally used only by read tools; write tools continue to rely on
+// WriteRoots confinement and never resolve these aliases.
+type PathResolver struct {
+	mu    sync.RWMutex
+	roots map[string]string
+}
+
+// NewPathResolver returns a resolver whose root set can be updated after the
+// workspace tools have been registered.
+func NewPathResolver() *PathResolver {
+	return &PathResolver{roots: map[string]string{}}
+}
+
+// RegisterReadRoot authorizes token and all of its local subpaths to resolve
+// under root for read-only tools in this session.
+func (r *PathResolver) RegisterReadRoot(token, root string) {
+	if r == nil {
+		return
+	}
+	token = normalizeReadToken(token)
+	root = filepath.Clean(strings.TrimSpace(root))
+	if token == "" || root == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.roots == nil {
+		r.roots = map[string]string{}
+	}
+	r.roots[token] = root
+}
+
+// Resolve maps a submitted path or pattern to a local path when it begins with
+// a registered token. ok is false for ordinary workspace paths.
+func (r *PathResolver) Resolve(path string) (ResolvedPath, bool) {
+	if r == nil {
+		return ResolvedPath{}, false
+	}
+	key := normalizeReadToken(path)
+	if key == "" {
+		return ResolvedPath{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if root, ok := r.roots[key]; ok {
+		return ResolvedPath{Path: root, DisplayPath: key, Root: root, DisplayRoot: key, External: true}, true
+	}
+	for token, root := range r.roots {
+		if !strings.HasPrefix(key, token+"/") {
+			continue
+		}
+		sub, ok := cleanReadSubpath(strings.TrimPrefix(key, token+"/"))
+		if !ok {
+			return ResolvedPath{}, false
+		}
+		return ResolvedPath{
+			Path:        filepath.Join(root, filepath.FromSlash(sub)),
+			DisplayPath: token + "/" + sub,
+			Root:        root,
+			DisplayRoot: token,
+			External:    true,
+		}, true
+	}
+	return ResolvedPath{}, false
+}
+
+// ResolvedPath carries both the local path used for I/O and the token path that
+// should appear in tool output.
+type ResolvedPath struct {
+	Path        string
+	DisplayPath string
+	Root        string
+	DisplayRoot string
+	External    bool
+}
+
+func (p ResolvedPath) DisplayFor(path string) string {
+	if !p.External {
+		return path
+	}
+	rel, err := filepath.Rel(p.Root, path)
+	if err != nil || !filepath.IsLocal(rel) {
+		return path
+	}
+	if rel == "." {
+		return p.DisplayRoot
+	}
+	return filepath.ToSlash(filepath.Join(p.DisplayRoot, rel))
+}
+
+func (p ResolvedPath) ErrorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if !p.External {
+		return msg
+	}
+	return strings.ReplaceAll(msg, p.Root, p.DisplayRoot)
+}
+
+func resolveReadablePath(workDir, path string, resolver *PathResolver) ResolvedPath {
+	if rp, ok := resolver.Resolve(path); ok {
+		return rp
+	}
+	p := resolveIn(workDir, path)
+	return ResolvedPath{Path: p, DisplayPath: p, Root: p, DisplayRoot: p}
+}
+
+func normalizeReadToken(token string) string {
+	token = strings.TrimSpace(token)
+	token = strings.TrimPrefix(token, "@")
+	token = filepath.ToSlash(token)
+	token = strings.TrimRight(token, "/")
+	return token
+}
+
+func cleanReadSubpath(sub string) (string, bool) {
+	sub = strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(sub)), "/")
+	if sub == "" || sub == "." {
+		return ".", true
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(sub))
+	if cleaned == "." {
+		return ".", true
+	}
+	if !filepath.IsLocal(cleaned) {
+		return "", false
+	}
+	return filepath.ToSlash(cleaned), true
 }
 
 // vendorDirs are directory names grep and glob skip during a recursive walk:

--- a/internal/tool/builtin/workspace_test.go
+++ b/internal/tool/builtin/workspace_test.go
@@ -167,6 +167,13 @@ func TestWorkspaceToolSchemasStableAcrossRoots(t *testing.T) {
 	if strings.Contains(first, firstRoot) || strings.Contains(first, secondRoot) {
 		t.Fatalf("workspace paths must not leak into tool schemas: %s", first)
 	}
+
+	resolver := NewPathResolver()
+	resolver.RegisterReadRoot("__reasonix_external_folder/schema/root", t.TempDir())
+	withResolver := workspaceSchemasJSONWithResolver(t, firstRoot, resolver)
+	if first != withResolver {
+		t.Fatalf("workspace tool schemas should not depend on external read roots:\nfirst=%s\nwith=%s", first, withResolver)
+	}
 }
 
 // TestWorkspaceEmptyDirUnchanged confirms a zero-Dir workspace yields tools that
@@ -181,6 +188,54 @@ func TestWorkspaceEmptyDirUnchanged(t *testing.T) {
 	if resolveIn("", "foo") != "foo" {
 		t.Fatal("empty workspace should leave paths unresolved")
 	}
+}
+
+func TestWorkspaceReadToolsResolveExternalReadRoots(t *testing.T) {
+	workspace := t.TempDir()
+	external := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(external, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalFile := filepath.Join(external, "src", "outside.txt")
+	if err := os.WriteFile(externalFile, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	token := "__reasonix_external_folder/abc123/External"
+	resolver := NewPathResolver()
+	resolver.RegisterReadRoot(token, external)
+	tools := byName(Workspace{Dir: workspace, ReadPaths: resolver}.Tools("read_file", "ls", "grep", "glob"))
+
+	readOut := runTool(t, tools["read_file"], map[string]any{"path": token + "/src/outside.txt"})
+	if !strings.Contains(readOut, "1→outside") {
+		t.Fatalf("read_file external token output = %q, want file content", readOut)
+	}
+
+	lsOut := runTool(t, tools["ls"], map[string]any{"path": token + "/src"})
+	if !strings.Contains(lsOut, "outside.txt") {
+		t.Fatalf("ls external token output = %q, want outside.txt", lsOut)
+	}
+
+	grepOut := runTool(t, tools["grep"], map[string]any{"pattern": "outside", "path": token})
+	if !strings.Contains(grepOut, token+"/src/outside.txt:1:outside") {
+		t.Fatalf("grep external token output = %q, want token path hit", grepOut)
+	}
+	if strings.Contains(grepOut, filepath.ToSlash(external)) {
+		t.Fatalf("grep external token output leaked local path: %q", grepOut)
+	}
+
+	globOut := runTool(t, tools["glob"], map[string]any{"pattern": token + "/**/*.txt"})
+	if !strings.Contains(globOut, token+"/src/outside.txt") {
+		t.Fatalf("glob external token output = %q, want token path hit", globOut)
+	}
+	if strings.Contains(globOut, filepath.ToSlash(external)) {
+		t.Fatalf("glob external token output leaked local path: %q", globOut)
+	}
+
+	assertExternalToolError(t, tools["read_file"], map[string]any{"path": token + "/src/missing.txt"}, token+"/src/missing.txt", external)
+	assertExternalToolError(t, tools["ls"], map[string]any{"path": token + "/missing"}, token+"/missing", external)
+	assertExternalToolError(t, tools["grep"], map[string]any{"pattern": "outside", "path": token + "/missing"}, token+"/missing", external)
+	assertExternalToolError(t, tools["glob"], map[string]any{"pattern": token + "/missing/**/*.go"}, token+"/missing/**/*.go", external)
 }
 
 // --- helpers ---
@@ -202,9 +257,13 @@ func keys(m map[string]tool.Tool) []string {
 }
 
 func workspaceSchemasJSON(t *testing.T, dir string) string {
+	return workspaceSchemasJSONWithResolver(t, dir, nil)
+}
+
+func workspaceSchemasJSONWithResolver(t *testing.T, dir string, resolver *PathResolver) string {
 	t.Helper()
 	reg := tool.NewRegistry()
-	for _, tt := range (Workspace{Dir: dir}).Tools() {
+	for _, tt := range (Workspace{Dir: dir, ReadPaths: resolver}).Tools() {
 		reg.Add(tt)
 	}
 	b, err := json.Marshal(reg.Schemas())
@@ -212,4 +271,19 @@ func workspaceSchemasJSON(t *testing.T, dir string) string {
 		t.Fatalf("marshal schemas: %v", err)
 	}
 	return string(b)
+}
+
+func assertExternalToolError(t *testing.T, tl tool.Tool, args map[string]any, wantTokenPath, externalRoot string) {
+	t.Helper()
+	_, err := tl.Execute(context.Background(), argsJSON(t, args))
+	if err == nil {
+		t.Fatalf("%s should fail for missing external path", tl.Name())
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, wantTokenPath) {
+		t.Fatalf("%s error = %q, want token path %q", tl.Name(), msg, wantTokenPath)
+	}
+	if strings.Contains(msg, filepath.ToSlash(externalRoot)) || strings.Contains(msg, externalRoot) {
+		t.Fatalf("%s error leaked external root: %q", tl.Name(), msg)
+	}
 }


### PR DESCRIPTION
## Summary
- Register folders dropped from outside the workspace as session-scoped workspace references instead of inserting plain absolute-path text.
- Keep the Composer UI readable by showing real display paths while submitting internal ref tokens that the controller resolves for the current session.
- Support on-demand external folder subpaths: `@<external-folder-token>/sub/file` resolves to file content, nested directories can be listed, and file search/autocomplete can return registered external-folder children without exposing raw local paths as submit text.
- Make folder references explicit and bounded: directory refs inject a capped listing only, note that file contents are not inlined, skip common generated/vendor folders, and tell the model to request listed files when content is needed.
- Let read-only built-in tools (`read_file`, `ls`, `grep`, `glob`) resolve registered external-folder token paths so the agent can inspect/search authorized external children on demand without adding those folders as writable workspace roots.
- Extend workspace previews/open/reveal paths so authorized external ref search results can be inspected through the same desktop UI surfaces.

## References
Refs #5370, #5447

## Contribution Credits
- Kept/adapted: #5447 by @ttmouse identified the folder-drop regression and implemented the initial path-text insertion direction. This PR keeps that UX goal but replaces path-text insertion with a session-scoped folder-reference mechanism plus on-demand child-path resolution.
- Out of scope: the font-size/custom scaling request in #5370 remains a separate follow-up.

## Cache Impact
Cache-impact: low - touches cache-sensitive boot/tool files, but only to wire runtime path resolution for session-authorized external folder refs; no stable prompt text, model-visible tool schema, or provider request serialization changes.
Cache-guard: `go test ./internal/tool/...` includes schema-stability coverage for workspace tools with an external read resolver; `go test ./internal/boot` covers boot wiring.
System-prompt-review: reviewed in this PR; the boot change passes a runtime read-path resolver into the controller/tools and does not alter system prompt composition.

## Verification
- `go test ./internal/tool/...`
- `go test ./internal/control`
- `go test ./internal/boot`
- `go test . -run 'TestFileRefs|TestAttachDropped|TestWorkspaceRelativeIn|TestIsImageExt'` in the desktop module
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/at-matches.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-goal-toggle.test.tsx`
- `git diff --check`
