### PR TITLE
fix(bot): 修改连接工具审批时避免全量重启 BotGateway

### DIFF
--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -242,3 +242,18 @@ func (r *desktopBotRuntime) snapshot() BotRuntimeStatusView {
 	defer r.mu.Unlock()
 	return r.status
 }
+
+// updateConnectionToolApprovalMode updates a connection's tool approval mode
+// on the running gateway without restarting. Returns true if updated, false if
+// the gateway is not running or the connection is unknown.
+func (r *desktopBotRuntime) updateConnectionToolApprovalMode(connID, mode string) bool {
+	if r.gw == nil {
+		return false
+	}
+	mode = normalizeBotConnectionToolApprovalMode(mode)
+	// Update ConnectionChannels in the internal GatewayConfig so new sessions
+	// pick up the mode. Existing sessions are updated by the gateway directly.
+	r.gw.UpdateConnectionToolApprovalMode(connID, mode)
+	return true
+}
+

--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -247,6 +247,8 @@ func (r *desktopBotRuntime) snapshot() BotRuntimeStatusView {
 // on the running gateway without restarting. Returns true if updated, false if
 // the gateway is not running or the connection is unknown.
 func (r *desktopBotRuntime) updateConnectionToolApprovalMode(connID, mode string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.gw == nil {
 		return false
 	}
@@ -256,4 +258,3 @@ func (r *desktopBotRuntime) updateConnectionToolApprovalMode(connID, mode string
 	r.gw.UpdateConnectionToolApprovalMode(connID, mode)
 	return true
 }
-

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -2604,7 +2604,7 @@ function BotsSection({ s, busy, apply, initialFocus }: BotsSectionProps) {
                         type="button"
                         className={selectedConnectionToolApprovalMode === mode ? "provider-add-segmented__item provider-add-segmented__item--active" : "provider-add-segmented__item"}
                         disabled={busy}
-                        onClick={() => void persistConnection(selectedConnection.id, { toolApprovalMode: mode as BotConnectionToolApprovalMode })}
+                        onClick={() => void app.SetBotConnectionToolApprovalMode(selectedConnection.id, mode)}
                       >
                         {t(`settings.botToolApprovalMode.${mode || "inherit"}` as DictKey)}
                       </button>

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -626,7 +626,6 @@ const BOT_TOOL_APPROVAL_MODES = ["", "ask", "auto", "yolo"] as const;
 
 type ProxyMode = (typeof PROXY_MODES)[number];
 type AutoPlanMode = (typeof AUTO_PLAN_MODES)[number];
-type BotConnectionToolApprovalMode = (typeof BOT_TOOL_APPROVAL_MODES)[number];
 
 function normalizeProxyMode(mode: string): ProxyMode {
   switch (mode) {
@@ -1787,6 +1786,11 @@ function BotsSection({ s, busy, apply, initialFocus }: BotsSectionProps) {
     setConnections((items) => items.map((item) => item.id === id ? { ...item, ...patch } : item));
   const persistConnection = (id: string, patch: Partial<BotConnectionView>) =>
     persistConnections((items) => items.map((item) => item.id === id ? { ...item, ...patch } : item));
+  const persistConnectionToolApprovalMode = (id: string, mode: string) => {
+    const normalizedMode = normalizeBotToolApprovalMode(mode, true);
+    setConnections((items) => items.map((item) => item.id === id ? { ...item, toolApprovalMode: normalizedMode } : item));
+    void apply(() => app.SetBotConnectionToolApprovalMode(id, normalizedMode));
+  };
   const updateConnectionCredential = (id: string, patch: Partial<BotConnectionView["credential"]>) =>
     setConnections((items) => items.map((item) => item.id === id ? { ...item, credential: { ...item.credential, ...patch } } : item));
   const persistConnectionCredential = (id: string, patch: Partial<BotConnectionView["credential"]>) =>
@@ -2604,7 +2608,7 @@ function BotsSection({ s, busy, apply, initialFocus }: BotsSectionProps) {
                         type="button"
                         className={selectedConnectionToolApprovalMode === mode ? "provider-add-segmented__item provider-add-segmented__item--active" : "provider-add-segmented__item"}
                         disabled={busy}
-                        onClick={() => void app.SetBotConnectionToolApprovalMode(selectedConnection.id, mode)}
+                        onClick={() => persistConnectionToolApprovalMode(selectedConnection.id, mode)}
                       >
                         {t(`settings.botToolApprovalMode.${mode || "inherit"}` as DictKey)}
                       </button>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -271,6 +271,7 @@ export interface AppBindings {
   SetSandbox(bash: string, network: boolean, workspaceRoot: string, allowWrite: string[], shell: string): Promise<void>;
   SetNetwork(n: NetworkView): Promise<void>;
   SetBotSettings(b: BotSettingsView): Promise<void>;
+  SetBotConnectionToolApprovalMode(connID: string, mode: string): Promise<void>;
   SetBotSecret(envName: string, value: string): Promise<void>;
   ClearBotSecret(envName: string): Promise<void>;
   StartBotConnectionInstall(provider: string, domain: string): Promise<BotInstallStartResult>;
@@ -2592,6 +2593,10 @@ function makeMockApp(): AppBindings {
         },
         async SetBotSettings(b: BotSettingsView) {
           settings.bot = JSON.parse(JSON.stringify(b)) as BotSettingsView;
+        },
+        async SetBotConnectionToolApprovalMode(connID, mode) {
+          const conn = settings.bot.connections.find((c) => c.id === connID);
+          if (conn) conn.toolApprovalMode = mode as any;
         },
         async SetBotSecret(envName: string, _value: string) {
           const name = envName.trim();

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -445,6 +445,7 @@ export function normalizeToolApprovalMode(
   if (normalized === "auto" || normalized === "yolo" || normalized === "ask") return normalized as ToolApprovalMode;
   if (legacyAutoApproveTools || (legacyMode && modeHasAutoApproveTools(legacyMode))) return "yolo";
   if (fallbackMode === "auto" && normalized === "") return "auto";
+  if (fallbackMode === "yolo" && normalized === "") return "yolo";
   return "ask";
 }
 

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -445,7 +445,6 @@ export function normalizeToolApprovalMode(
   if (normalized === "auto" || normalized === "yolo" || normalized === "ask") return normalized as ToolApprovalMode;
   if (legacyAutoApproveTools || (legacyMode && modeHasAutoApproveTools(legacyMode))) return "yolo";
   if (fallbackMode === "auto" && normalized === "") return "auto";
-  if (fallbackMode === "yolo" && normalized === "") return "yolo";
   return "ask";
 }
 

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -11,6 +11,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
+	"reasonix/internal/botruntime"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/provider"
@@ -908,6 +909,13 @@ func (a *App) rebuild() error {
 	a.emitReady(a.ctx)
 	ctrl.EnableInteractiveApproval()
 	applyTabModeToController(ctrl, tab.mode)
+	// applyTabModeToController only encodes plan+yolo from tab.mode.
+	// Apply the explicit toolApprovalMode (ask/auto/yolo) afterwards so
+	// "auto" is not lost — otherwise rebuild would silently downgrade
+	// auto to ask (#5424 regression).
+	if mode := strings.TrimSpace(tab.toolApprovalMode); mode != "" {
+		applyTabToolApprovalModeToController(ctrl, mode)
+	}
 	path := agent.ContinueSessionPath(prevPath, ctrl.SessionDir(), ctrl.Label())
 	if len(carried) > 0 {
 		carried = withFreshSystemPrompt(carried, systemPromptFrom(ctrl.History()))
@@ -1730,6 +1738,30 @@ func (a *App) SetBotSettings(b BotSettingsView) error {
 		a.refreshBotRuntimeAsync()
 	}
 	return err
+}
+
+// SetBotConnectionToolApprovalMode updates a single connection's tool approval
+// mode without restarting the bot gateway. Only the connection's mode field is
+// persisted; existing sessions on the running gateway are updated in-place.
+func (a *App) SetBotConnectionToolApprovalMode(connID, mode string) error {
+	mode = normalizeBotConnectionToolApprovalMode(mode)
+	err := a.applyConfigOnly(func(c *config.Config) error {
+		for i := range c.Bot.Connections {
+			if c.Bot.Connections[i].ID == connID || botruntime.ConnectionRuntimeID(c.Bot.Connections[i]) == connID {
+				c.Bot.Connections[i].ToolApprovalMode = mode
+				c.Bot.Connections[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+				return nil
+			}
+		}
+		return fmt.Errorf("connection %q not found", connID)
+	})
+	if err != nil {
+		return err
+	}
+	if a.botRuntime != nil && mode != "" {
+		a.botRuntime.updateConnectionToolApprovalMode(connID, mode)
+	}
+	return nil
 }
 
 func (a *App) SetBotSecret(envName, value string) error {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1744,12 +1744,19 @@ func (a *App) SetBotSettings(b BotSettingsView) error {
 // mode without restarting the bot gateway. Only the connection's mode field is
 // persisted; existing sessions on the running gateway are updated in-place.
 func (a *App) SetBotConnectionToolApprovalMode(connID, mode string) error {
+	connID = strings.TrimSpace(connID)
 	mode = normalizeBotConnectionToolApprovalMode(mode)
+	runtimeConnID := connID
 	err := a.applyConfigOnly(func(c *config.Config) error {
 		for i := range c.Bot.Connections {
-			if c.Bot.Connections[i].ID == connID || botruntime.ConnectionRuntimeID(c.Bot.Connections[i]) == connID {
+			candidateRuntimeID := botruntime.ConnectionRuntimeID(c.Bot.Connections[i])
+			if candidateRuntimeID == "" {
+				candidateRuntimeID = strings.TrimSpace(c.Bot.Connections[i].ID)
+			}
+			if c.Bot.Connections[i].ID == connID || candidateRuntimeID == connID {
 				c.Bot.Connections[i].ToolApprovalMode = mode
 				c.Bot.Connections[i].UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+				runtimeConnID = candidateRuntimeID
 				return nil
 			}
 		}
@@ -1758,8 +1765,8 @@ func (a *App) SetBotConnectionToolApprovalMode(connID, mode string) error {
 	if err != nil {
 		return err
 	}
-	if a.botRuntime != nil && mode != "" {
-		a.botRuntime.updateConnectionToolApprovalMode(connID, mode)
+	if a.botRuntime != nil {
+		a.botRuntime.updateConnectionToolApprovalMode(runtimeConnID, mode)
 	}
 	return nil
 }

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -1089,3 +1089,24 @@ func normalizeAskSelection(q event.AskQuestion, raw string) []string {
 	}
 	return out
 }
+
+// UpdateConnectionToolApprovalMode updates the in-memory tool approval mode for
+// a single bot connection without restarting the gateway. Existing sessions
+// are notified so the new posture takes effect immediately.
+func (gw *BotGateway) UpdateConnectionToolApprovalMode(connID, mode string) {
+	mode = normalizeBotToolApprovalMode(mode)
+	gw.mu.Lock()
+	if gw.cfg.ConnectionChannels == nil {
+		gw.cfg.ConnectionChannels = make(map[string]ChannelConfig)
+	}
+	ch := gw.cfg.ConnectionChannels[connID]
+	ch.ToolApprovalMode = mode
+	gw.cfg.ConnectionChannels[connID] = ch
+	// Update every active session that belongs to this connection.
+	for key, state := range gw.controllers {
+		if strings.HasPrefix(key, connID+":") || key == connID {
+			state.ctrl.SetToolApprovalMode(mode)
+		}
+	}
+	gw.mu.Unlock()
+}

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -97,6 +97,8 @@ type botController interface {
 type sessionState struct {
 	ctrl             botController
 	sink             *sessionEventSink
+	platform         Platform
+	connectionID     string
 	cancel           context.CancelFunc
 	pendingAsks      map[string][]event.AskQuestion
 	pendingApprovals map[string]event.Approval
@@ -857,6 +859,12 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg InboundMessage) *sessionState {
 	gw.mu.Lock()
 	if state, ok := gw.controllers[key]; ok {
+		if state.connectionID == "" {
+			state.connectionID = strings.TrimSpace(msg.ConnectionID)
+		}
+		if state.platform == "" {
+			state.platform = msg.Platform
+		}
 		state.lastActive = time.Now()
 		gw.mu.Unlock()
 		gw.logger.Info("bot session reused", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
@@ -899,11 +907,13 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		return existing
 	}
 	state := &sessionState{
-		ctrl:        ctrl,
-		sink:        sessionSink,
-		pendingAsks: make(map[string][]event.AskQuestion),
-		createdAt:   time.Now(),
-		lastActive:  time.Now(),
+		ctrl:         ctrl,
+		sink:         sessionSink,
+		platform:     msg.Platform,
+		connectionID: strings.TrimSpace(msg.ConnectionID),
+		pendingAsks:  make(map[string][]event.AskQuestion),
+		createdAt:    time.Now(),
+		lastActive:   time.Now(),
 	}
 	gw.controllers[key] = state
 	gw.mu.Unlock()
@@ -1091,10 +1101,20 @@ func normalizeAskSelection(q event.AskQuestion, raw string) []string {
 }
 
 // UpdateConnectionToolApprovalMode updates the in-memory tool approval mode for
-// a single bot connection without restarting the gateway. Existing sessions
-// are notified so the new posture takes effect immediately.
+// a single bot connection without restarting the gateway. Empty mode clears the
+// connection override, so existing sessions inherit the current gateway default.
 func (gw *BotGateway) UpdateConnectionToolApprovalMode(connID, mode string) {
-	mode = normalizeBotToolApprovalMode(mode)
+	connID = strings.TrimSpace(connID)
+	if connID == "" {
+		return
+	}
+	mode = normalizeOptionalBotToolApprovalMode(mode)
+	type controllerMode struct {
+		ctrl botController
+		mode string
+	}
+	var updates []controllerMode
+
 	gw.mu.Lock()
 	if gw.cfg.ConnectionChannels == nil {
 		gw.cfg.ConnectionChannels = make(map[string]ChannelConfig)
@@ -1103,10 +1123,22 @@ func (gw *BotGateway) UpdateConnectionToolApprovalMode(connID, mode string) {
 	ch.ToolApprovalMode = mode
 	gw.cfg.ConnectionChannels[connID] = ch
 	// Update every active session that belongs to this connection.
-	for key, state := range gw.controllers {
-		if strings.HasPrefix(key, connID+":") || key == connID {
-			state.ctrl.SetToolApprovalMode(mode)
+	for _, state := range gw.controllers {
+		if state == nil || state.ctrl == nil || strings.TrimSpace(state.connectionID) != connID {
+			continue
 		}
+		effectiveMode := mode
+		if effectiveMode == "" {
+			_, _, effectiveMode = gw.sessionOptionsForMessage(InboundMessage{
+				Platform:     state.platform,
+				ConnectionID: state.connectionID,
+			})
+		}
+		updates = append(updates, controllerMode{ctrl: state.ctrl, mode: effectiveMode})
 	}
 	gw.mu.Unlock()
+
+	for _, update := range updates {
+		update.ctrl.SetToolApprovalMode(update.mode)
+	}
 }

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -542,6 +542,81 @@ func TestGatewayYoloCommandUpdatesCurrentSessionAndConnectionDefault(t *testing.
 	}
 }
 
+func TestGatewayUpdateConnectionToolApprovalModeUpdatesHashedActiveSessions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{
+		ToolApprovalMode: "ask",
+		ConnectionChannels: map[string]ChannelConfig{
+			"feishu-lark": {ToolApprovalMode: "yolo"},
+		},
+	}, nil, logger)
+
+	msg := InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu-lark",
+		Domain:       "lark",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+	}
+	key := BuildSessionKey(msg.Session())
+	if strings.HasPrefix(key, msg.ConnectionID) {
+		t.Fatalf("test setup expected hashed key, got %q", key)
+	}
+	ctrl := control.New(control.Options{})
+	ctrl.SetToolApprovalMode(control.ToolApprovalYolo)
+	gw.controllers[key] = &sessionState{ctrl: ctrl, platform: msg.Platform, connectionID: msg.ConnectionID}
+
+	gw.UpdateConnectionToolApprovalMode("feishu-lark", control.ToolApprovalAsk)
+
+	if got := ctrl.ToolApprovalMode(); got != control.ToolApprovalAsk {
+		t.Fatalf("active session mode = %q, want ask", got)
+	}
+	if got := gw.cfg.ConnectionChannels["feishu-lark"].ToolApprovalMode; got != control.ToolApprovalAsk {
+		t.Fatalf("connection default mode = %q, want ask", got)
+	}
+}
+
+func TestGatewayUpdateConnectionToolApprovalModeInheritsGatewayDefault(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{
+		ToolApprovalMode: control.ToolApprovalAuto,
+		ConnectionChannels: map[string]ChannelConfig{
+			"feishu-lark":   {ToolApprovalMode: control.ToolApprovalYolo},
+			"feishu-feishu": {ToolApprovalMode: control.ToolApprovalYolo},
+		},
+	}, nil, logger)
+
+	larkMsg := InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu-lark",
+		Domain:       "lark",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+	}
+	larkKey := BuildSessionKey(larkMsg.Session())
+	larkCtrl := control.New(control.Options{})
+	larkCtrl.SetToolApprovalMode(control.ToolApprovalYolo)
+	gw.controllers[larkKey] = &sessionState{ctrl: larkCtrl, platform: larkMsg.Platform, connectionID: larkMsg.ConnectionID}
+
+	otherCtrl := control.New(control.Options{})
+	otherCtrl.SetToolApprovalMode(control.ToolApprovalYolo)
+	gw.controllers["other-hashed-key"] = &sessionState{ctrl: otherCtrl, platform: PlatformFeishu, connectionID: "feishu-feishu"}
+
+	gw.UpdateConnectionToolApprovalMode("feishu-lark", "")
+
+	if got := gw.cfg.ConnectionChannels["feishu-lark"].ToolApprovalMode; got != "" {
+		t.Fatalf("connection override = %q, want empty inherit", got)
+	}
+	if got := larkCtrl.ToolApprovalMode(); got != control.ToolApprovalAuto {
+		t.Fatalf("lark active session mode = %q, want inherited auto", got)
+	}
+	if got := otherCtrl.ToolApprovalMode(); got != control.ToolApprovalYolo {
+		t.Fatalf("other connection mode = %q, want unchanged yolo", got)
+	}
+}
+
 func TestGatewayModeCommandSupportsAskAutoAndStatus(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	gw := NewGateway(GatewayConfig{


### PR DESCRIPTION
## 问题

在 Settings → Bot → 连接详情中修改「工具审批」(ask/auto/yolo) 时，
SetBotSettings 会调用 refreshBotRuntimeAsync() 停掉整个 BotGateway
再重建，导致飞书 WebSocket 断连、已有 session 销毁。
此期间任何卡片动作回调都会失败，显示「目标回调服务当前未在线」。

## 修复

新增轻量路径 SetBotConnectionToolApprovalMode：

1. **internal/bot/gateway.go** — 新增 UpdateConnectionToolApprovalMode，
   直接更新内存 ConnectionChannels 的 ToolApprovalMode，
   并通知该连接下所有活跃 session 的 controller 即时生效

2. **desktop/bot_runtime_app.go** — 新增 updateConnectionToolApprovalMode，
   委托给网关的原地更新方法

3. **desktop/settings_app.go** — 新增 SetBotConnectionToolApprovalMode API，
   只保存该字段到磁盘 + 原地更新运行中网关，不触发全量重启

4. **desktop/frontend** — 桥接声明、调用处改为新 API，并通过设置面板的 apply 流程刷新本地状态与错误展示

## 评审跟进

- 活跃 bot session 记录 connection ID/platform，避免用 hashed session key 前缀匹配连接
- 选择「继承」时会清空连接级 override，并同步运行中 gateway 与已有 session
- live mode 更新读取 gateway 指针时加锁，避免与 BotGateway 重启竞态
- 新增回归测试覆盖 hashed active session 与 inherit default 两个关键契约

## 验证

- GitHub CI 全绿
- `go test ./internal/bot ./internal/botruntime` passed
- `pnpm --dir desktop/frontend build` passed

## 贡献说明

Authorship note: @ttmouse is the primary author of this PR. @SivanCola contributed as a collaborator by reviewing the implementation, fixing follow-up issues found during review, and verifying the final state.

## 关联

Closes #5424
