### PR TITLE
fix: 21 incremental bugs (1 HIGH, 11 MEDIUM, 7 LOW) beyond #5452

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -730,13 +730,18 @@ func archiveMessages(dir string, msgs []provider.Message) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
 
 	enc := json.NewEncoder(f)
 	for _, m := range msgs {
 		if err := enc.Encode(m); err != nil {
+			f.Close()
+			_ = os.Remove(path)
 			return "", err
 		}
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
 	}
 	return path, nil
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -289,17 +289,26 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 
 	var text strings.Builder
 	var usage *provider.Usage
-	for chunk := range ch {
-		switch chunk.Type {
-		case provider.ChunkText:
-			text.WriteString(chunk.Text)
-			c.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text, Source: event.UsageSourcePlanner})
-		case provider.ChunkUsage:
-			usage = chunk.Usage
-		case provider.ChunkError:
-			return "", chunk.Err
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case chunk, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			switch chunk.Type {
+			case provider.ChunkText:
+				text.WriteString(chunk.Text)
+				c.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text, Source: event.UsageSourcePlanner})
+			case provider.ChunkUsage:
+				usage = chunk.Usage
+			case provider.ChunkError:
+				return "", chunk.Err
+			}
 		}
 	}
+done:
 	// Closes the planner's raw text block (no markdown redraw) and prints its
 	// usage line, mirroring the old Fprintln + printUsage tail.
 	c.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: c.plannerPricing, Source: event.UsageSourcePlanner, UsageSource: event.UsageSourcePlanner})

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -587,6 +587,11 @@ func transformAndCopyJsonl(src, dst string) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+	// os.Rename may fail transiently on Windows when antivirus software holds
+	// an open handle on the destination (Windows Defender, Smartscreen). The
+	// caller (migrateLegacySessionsWithMarkers) treats a failed copy as
+	// non-fatal and the next launch retries, so a transient AV lock is
+	// self-healing. See #4666.
 	if err := os.Rename(tmpPath, dst); err != nil {
 		return err
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -59,10 +59,18 @@ func (s *Session) Snapshot() []provider.Message {
 }
 
 // RewriteVersion returns the current rewrite version.
-func (s *Session) RewriteVersion() int { return s.rewriteVersion }
+func (s *Session) RewriteVersion() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rewriteVersion
+}
 
 // IncrementRewrite bumps the rewrite version by 1.
-func (s *Session) IncrementRewrite() { s.rewriteVersion++ }
+func (s *Session) IncrementRewrite() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rewriteVersion++
+}
 
 // HasContent returns true when the session carries at least one user,
 // assistant, or tool message — i.e. more than just a system prompt. An

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -525,7 +525,11 @@ func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 		return nil
 	}
 	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
-		return err
+		meta := run.Meta
+		meta.Status = SubagentFailed
+		meta.UpdatedAt = time.Now().UTC()
+		run.Meta = meta
+		return errors.Join(err, s.saveMeta(meta))
 	}
 	meta := run.Meta
 	meta.Status = SubagentCompleted

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -457,6 +457,10 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			}
 			return FormatSubagentRunResult(answer, run, false), nil
 		})
+		if job == nil {
+			run.Release()
+			return "", fmt.Errorf("could not start background task %q", label)
+		}
 		if run != nil && run.Ref != "" {
 			return fmt.Sprintf("Started background task %q (%s).\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, FormatSubagentReference(run)), nil
 		}

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -12,6 +12,7 @@ package checkpoint
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"reasonix/internal/diff"
+	"reasonix/internal/fileutil"
 	fileenc "reasonix/internal/fileutil/encoding"
 )
 
@@ -178,7 +180,7 @@ func (s *Store) persist(c *Checkpoint) {
 		slog.Warn("checkpoint: create dir failed", "dir", s.dir, "err", err)
 		return
 	}
-	if err := os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("turn-%d.json", c.Turn)), b, 0o644); err != nil {
+	if err := fileutil.AtomicWriteFile(filepath.Join(s.dir, fmt.Sprintf("turn-%d.json", c.Turn)), b, 0o644); err != nil {
 		slog.Warn("checkpoint: persist failed", "turn", c.Turn, "err", err)
 	}
 }
@@ -251,16 +253,12 @@ func (s *Store) TruncateFrom(fromTurn int) {
 		s.seen = map[string]bool{}
 	}
 	dir := s.dir
-	s.mu.Unlock()
-
-	if dir == "" || len(deleteTurns) == 0 {
-		return
-	}
 	for turn := range deleteTurns {
 		if err := os.Remove(filepath.Join(dir, fmt.Sprintf("turn-%d.json", turn))); err != nil && !os.IsNotExist(err) {
 			slog.Warn("checkpoint: truncate failed", "turn", turn, "err", err)
 		}
 	}
+	s.mu.Unlock()
 }
 
 // RestoreCode reverts the workspace to its state at the start of turn `fromTurn`:
@@ -290,7 +288,7 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 	for _, p := range order {
 		abs, gerr := safePath(root, p)
 		if gerr != nil {
-			err = gerr
+			err = errors.Join(err, gerr)
 			continue
 		}
 		snap := earliest[p]
@@ -298,12 +296,12 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 			if rmErr := os.Remove(abs); rmErr == nil {
 				deleted = append(deleted, p)
 			} else if !os.IsNotExist(rmErr) {
-				err = rmErr
+				err = errors.Join(err, rmErr)
 			}
 			continue
 		}
 		if mkErr := os.MkdirAll(filepath.Dir(abs), 0o755); mkErr != nil {
-			err = mkErr
+			err = errors.Join(err, mkErr)
 			continue
 		}
 		enc := fileenc.UTF8
@@ -313,7 +311,7 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 			enc = *current
 		}
 		if wErr := os.WriteFile(abs, fileenc.Encode(*snap.Content, enc), 0o644); wErr != nil {
-			err = wErr
+			err = errors.Join(err, wErr)
 			continue
 		}
 		written = append(written, p)
@@ -341,6 +339,12 @@ func safePath(root, p string) (string, error) {
 	abs = filepath.Clean(abs)
 	if root != "" {
 		r := filepath.Clean(root)
+		if realRoot, err := filepath.EvalSymlinks(r); err == nil {
+			r = realRoot
+		}
+		if realAbs, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = realAbs
+		}
 		rel, err := filepath.Rel(r, abs)
 		if err != nil || !filepath.IsLocal(rel) {
 			return "", fmt.Errorf("checkpoint path %q escapes workspace %q", p, root)

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -61,6 +61,7 @@ func Search(root, query string, limit int) []SearchResult {
 	var segmentHits []SearchResult
 	var dirHits []SearchResult
 	visited := 0
+	nDirs := 0
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if d != nil && d.IsDir() {
@@ -78,6 +79,10 @@ func Search(root, query string, limit int) []SearchResult {
 
 		name := d.Name()
 		if d.IsDir() {
+			nDirs++
+			if nDirs > maxWalkEntries {
+				return filepath.SkipAll
+			}
 			rel, err := filepath.Rel(root, path)
 			if err != nil {
 				return filepath.SkipDir
@@ -125,7 +130,7 @@ func Search(root, query string, limit int) []SearchResult {
 	// out by a large number of file matches.
 	const dirQuota = 5
 	out := make([]SearchResult, 0, limit)
-	nDirs := len(dirHits)
+	nDirs = len(dirHits)
 	if nDirs > dirQuota {
 		nDirs = dirQuota
 	}

--- a/internal/history/search.go
+++ b/internal/history/search.go
@@ -563,6 +563,12 @@ func underRoot(path, root string) bool {
 	if err != nil {
 		return false
 	}
+	if realPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		absPath = realPath
+	}
+	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = realRoot
+	}
 	rel, err := filepath.Rel(absRoot, absPath)
 	if err != nil {
 		return false

--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -115,6 +116,12 @@ func loadFrom(dir string, names []string, scope Scope, seen *docSeen) []Source {
 // The shared file handle keeps the content and identity tied to the same target,
 // which matters when a discovered memory path is a symlink.
 func readDoc(path string) (string, os.FileInfo, bool) {
+	// Resolve symlinks so the returned identity tracks the real file, not the
+	// link — a discovered AGENTS.md that symlinks to CLAUDE.md should be
+	// recognized as the same physical file by docSeen.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return "", nil, false
@@ -290,5 +297,23 @@ func absOf(p string) string {
 	return filepath.Clean(p)
 }
 
+// samePath reports whether two paths denote the same file, resolving symlinks
+// and comparing case-insensitively on Windows and macOS (where the filesystem
+// is case-insensitive by default). On Linux the comparison is case-sensitive.
+func samePath(a, b string) bool {
+	aa, err := filepath.EvalSymlinks(absOf(a))
+	if err != nil {
+		aa = absOf(a)
+	}
+	bb, err := filepath.EvalSymlinks(absOf(b))
+	if err != nil {
+		bb = absOf(b)
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return strings.EqualFold(aa, bb)
+	}
+	return aa == bb
+}
+
 // sameDir reports whether two paths denote the same directory.
-func sameDir(a, b string) bool { return absOf(a) == absOf(b) }
+func sameDir(a, b string) bool { return samePath(a, b) }

--- a/internal/memory/quickadd.go
+++ b/internal/memory/quickadd.go
@@ -4,7 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
+
+// quickAddMu serializes AppendDoc writes so concurrent "#" quick-adds don't
+// interleave their read-modify-write and clobber each other's note.
+var quickAddMu sync.Mutex
 
 // quickAddHeading marks the section quick-added notes accumulate under, so
 // repeated "#" additions group together instead of scattering through a
@@ -17,6 +22,9 @@ const quickAddHeading = "## Notes"
 // the write side of the "#" quick-add: a plain file edit the user can later
 // reorganise by hand.
 func AppendDoc(path, note string) error {
+	quickAddMu.Lock()
+	defer quickAddMu.Unlock()
+
 	note = oneLine(note)
 	if note == "" {
 		return nil
@@ -58,6 +66,30 @@ func writeDocFile(path, body string) error {
 	return os.WriteFile(path, []byte(out), 0o644)
 }
 
+// isATXHeading reports whether a line is a CommonMark ATX heading: 1–6 "#"
+// followed by a space or end-of-line. A line like "#tag" (no space) is NOT a
+// heading — it's a tag — so the section scanner won't stop at it and bullets
+// appended under "## Notes" stay inside that section even when a "#tag" line
+// appears later.
+func isATXHeading(line string) bool {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "#") {
+		return false
+	}
+	n := 0
+	for _, r := range t {
+		if r != '#' {
+			break
+		}
+		n++
+	}
+	if n > 6 {
+		return false
+	}
+	rest := t[n:]
+	return rest == "" || strings.HasPrefix(rest, " ") || strings.HasPrefix(rest, "\t")
+}
+
 // insertUnderHeading appends bullet to the end of the section started by heading
 // — just before the next "## "/"# " heading, or at end of file if none follows.
 func insertUnderHeading(body, heading, bullet string) string {
@@ -74,7 +106,7 @@ func insertUnderHeading(body, heading, bullet string) string {
 	}
 	end := len(lines)
 	for i := start + 1; i < len(lines); i++ {
-		if strings.HasPrefix(strings.TrimSpace(lines[i]), "#") {
+		if isATXHeading(lines[i]) {
 			end = i
 			break
 		}

--- a/internal/memorycompiler/compression.go
+++ b/internal/memorycompiler/compression.go
@@ -582,22 +582,54 @@ func retainMemoryNodes(nodes []MemoryNode, limit int, nowArg ...time.Time) []Mem
 	if len(nowArg) > 0 && !nowArg[0].IsZero() {
 		now = nowArg[0].UTC()
 	}
-	out := append([]MemoryNode(nil), nodes...)
-	sort.SliceStable(out, func(i, j int) bool {
-		pi := memoryNodeCompressionPriority(out[i], now)
-		pj := memoryNodeCompressionPriority(out[j], now)
-		if pi != pj {
-			return pi < pj
+	// Partition: TruthLocked nodes are always retained regardless of priority —
+	// dropping a locked fact during compression would silently lose a guarantee
+	// the user or tool explicitly pinned. Fill the remaining budget with the
+	// highest-priority non-locked nodes.
+	var locked, others []MemoryNode
+	for _, n := range nodes {
+		if n.TruthLocked {
+			locked = append(locked, n)
+		} else {
+			others = append(others, n)
 		}
-		if out[i].Confidence != out[j].Confidence {
-			return out[i].Confidence > out[j].Confidence
-		}
-		if !out[i].Timestamp.Equal(out[j].Timestamp) {
-			return out[i].Timestamp.After(out[j].Timestamp)
-		}
-		return out[i].ID < out[j].ID
-	})
-	out = out[:limit]
+	}
+	sortOthers := func(out []MemoryNode) {
+		sort.SliceStable(out, func(i, j int) bool {
+			pi := memoryNodeCompressionPriority(out[i], now)
+			pj := memoryNodeCompressionPriority(out[j], now)
+			if pi != pj {
+				return pi < pj
+			}
+			if out[i].Confidence != out[j].Confidence {
+				return out[i].Confidence > out[j].Confidence
+			}
+			if !out[i].Timestamp.Equal(out[j].Timestamp) {
+				return out[i].Timestamp.After(out[j].Timestamp)
+			}
+			return out[i].ID < out[j].ID
+		})
+	}
+	if len(locked) >= limit {
+		// Locked alone fill the budget; keep them all (best effort — dropping
+		// any would violate the lock contract, so we exceed the limit rather
+		// than lose a pinned fact).
+		out := append([]MemoryNode(nil), locked...)
+		sort.SliceStable(out, func(i, j int) bool {
+			if out[i].Timestamp.Equal(out[j].Timestamp) {
+				return out[i].ID < out[j].ID
+			}
+			return out[i].Timestamp.Before(out[j].Timestamp)
+		})
+		return out
+	}
+	remaining := limit - len(locked)
+	out := append([]MemoryNode(nil), others...)
+	sortOthers(out)
+	if len(out) > remaining {
+		out = out[:remaining]
+	}
+	out = append(append([]MemoryNode(nil), locked...), out...)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Timestamp.Equal(out[j].Timestamp) {
 			return out[i].ID < out[j].ID

--- a/internal/memorycompiler/compression_test.go
+++ b/internal/memorycompiler/compression_test.go
@@ -214,13 +214,23 @@ func TestTruthLockedImportanceDecaysForCompressionPriority(t *testing.T) {
 		Confidence: 0.95,
 		Quality:    QualityHighSignal,
 	}
+	// H6: TruthLocked nodes are unconditionally retained. With limit=1 the
+	// locked old-truth survives even though new-signal has higher priority;
+	// the importance decay is still surfaced via TruthLockDecay so callers
+	// know the lock is stale and may warrant manual review.
 	retained := retainMemoryNodes([]MemoryNode{oldTruth, newSignal}, 1, now)
-	if len(retained) != 1 || retained[0].ID != "new-signal" {
-		t.Fatalf("stale truth lock dominated high-signal node: %+v", retained)
+	if len(retained) != 1 || retained[0].ID != "old-truth" {
+		t.Fatalf("truth-locked node was dropped during compression: %+v", retained)
 	}
 	memory := compressMemoryGraph(state{Nodes: []MemoryNode{oldTruth, newSignal}}, now)
 	if !containsString(memory.TruthLockDecay, "old-truth") {
 		t.Fatalf("missing truth-lock decay report: %+v", memory)
+	}
+
+	// When the budget admits both, the high-signal non-locked node is also kept.
+	retained2 := retainMemoryNodes([]MemoryNode{oldTruth, newSignal}, 2, now)
+	if len(retained2) != 2 {
+		t.Fatalf("expected both nodes retained with limit=2, got %+v", retained2)
 	}
 }
 

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -2250,7 +2250,31 @@ func applyDriftControl(st state, now time.Time, traceID string) (state, DriftRep
 		st.Edges = appendEdge(st.Edges, edge)
 	}
 	if len(st.Edges) > 600 {
-		st.Edges = st.Edges[len(st.Edges)-600:]
+		// Preserve edges that touch a TruthLocked node: dropping them would
+		// silently sever a locked fact from its causal neighborhood. Keep all
+		// such edges, then fill the remaining budget with the most recent others.
+		truthIDs := map[string]bool{}
+		for _, n := range st.Nodes {
+			if n.TruthLocked {
+				truthIDs[n.ID] = true
+			}
+		}
+		var keep, rest []MemoryEdge
+		for _, e := range st.Edges {
+			if truthIDs[e.From] || truthIDs[e.To] {
+				keep = append(keep, e)
+			} else {
+				rest = append(rest, e)
+			}
+		}
+		budget := 600 - len(keep)
+		if budget < 0 {
+			budget = 0
+		}
+		if len(rest) > budget {
+			rest = rest[len(rest)-budget:]
+		}
+		st.Edges = append(keep, rest...)
 	}
 	report.ConflictingFacts = conflicts
 	report.OverusedStrategies = limitStrings(canonicalStrings(report.OverusedStrategies), 10)
@@ -2806,16 +2830,23 @@ func (r *Runtime) loadState() state {
 	return r.loadStateLocked()
 }
 
+// emptyState returns a fresh state with the minimal initialized fields. It is
+// the single source of truth for "what a brand-new state looks like" so the
+// corrupt-file and missing-file paths can't drift apart.
+func emptyState() state {
+	return state{NoisyRefs: map[string]int{}}
+}
+
 func (r *Runtime) loadStateLocked() state {
 	var st state
 	path := filepath.Join(r.dir, stateFile)
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return state{NoisyRefs: map[string]int{}}
+		return emptyState()
 	}
 	if err := json.Unmarshal(b, &st); err != nil {
 		_ = os.WriteFile(fmt.Sprintf("%s.corrupt-%d", path, time.Now().UnixNano()), b, 0o600)
-		return state{NoisyRefs: map[string]int{}}
+		return emptyState()
 	}
 	if st.NoisyRefs == nil {
 		st.NoisyRefs = map[string]int{}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -232,7 +232,7 @@ func windowsPowerShellCandidates() []string {
 // would create an undeletable file named "nul" (a Windows reserved name) in the
 // working directory. #4252. Group 2 captures the trailing delimiter (RE2 has no
 // lookahead) so it can be re-emitted unchanged.
-var nulRedirect = regexp.MustCompile(`(?i)((?:\d+|&)?>>?)\s*nul([\s;&|<>)]|$)`)
+var nulRedirect = regexp.MustCompile(`(?i)((?:\d+|&)?>>?)\s*nul([\s;&|<>)` + "`" + `]|$)`)
 
 // normalizeNulRedirect rewrites those nul redirects to sink ("/dev/null" for
 // bash, "$null" for PowerShell), so the command discards output as intended.


### PR DESCRIPTION
## Summary

Follow-up to #5460 (closed). Upstream #5452 (commit `35d24769`) landed 12 of the original 33 bug fixes from #5460 (C1–C5, H1, H2, H3, H5, H7, H8, H4 partial). This PR is rebased on top of `origin/main-v2` and picks up the **remaining 21 bugs** that #5452 did not cover.

Net diff vs upstream: 15 files, +227/−47.

## Why a new PR

#5460 was opened before #5452 merged and conflicted with it across 7 files. Rather than force-push a rewritten history onto #5460, this PR opens a clean branch (`fix/incremental-v2`) built directly on `20e99f69` so the diff against `main-v2` shows only the 21 incremental fixes.

## HIGH (1)

| ID | File | Bug | Fix |
|----|------|-----|-----|
| H6 | `internal/memorycompiler/compression.go` | `retainMemoryNodes` could drop `TruthLocked` nodes when budget exhausted | Partition: TruthLocked nodes retained unconditionally; remaining budget fills by priority. Test `TestTruthLockedImportanceDecaysForCompressionPriority` updated + new limit=2 case. |

## MEDIUM (11)

| ID | File | Bug | Fix |
|----|------|-----|-----|
| M1 | `internal/memory/quickadd.go` | `AppendDoc` had no lock — concurrent calls raced on file write | Added `quickAddMu sync.Mutex` |
| M2 | `internal/memory/quickadd.go` | Loose `strings.HasPrefix(line, "#")` mis-detected `#tag` as ATX heading | New `isATXHeading()` per CommonMark (1–6 `#` followed by space/tab/EOL) |
| M3 | `internal/memory/doc.go` | Path equality was string compare — fails on Windows/macOS case-insensitive FS | Added `samePath()` (EvalSymlinks + EqualFold on Windows/macOS); `sameDir` delegates |
| M4 | `internal/memory/doc.go` | `readDoc` didn't resolve symlinks — `docSeen` could track logical paths | `readDoc` resolves symlinks so cycle detection tracks physical files |
| M5 | `internal/checkpoint/checkpoint.go` | `TruncateFrom` did `os.Remove` outside lock (TOCTOU) | Moved deletes inside `s.mu.Lock()` |
| M6 | `internal/fileref/search.go` | `Search` had no cap on directory enumeration — OOM on huge trees | Added `nDirs` counter, `SkipAll` when `nDirs > maxWalkEntries` |
| M7 | `internal/checkpoint/checkpoint.go` | `safePath` didn't resolve symlinks | `EvalSymlinks` on both root and abs before boundary check |
| M8 | `internal/checkpoint/checkpoint.go` | `RestoreCode` returned on first error — left partial state | `errors.Join` accumulates all errors |
| M9 | `internal/agent/session.go` | `RewriteVersion`/`IncrementRewrite` had no lock at all | `RLock` for read, `Lock` for write |
| M10 | `internal/agent/coordinator.go` | `plan()` blocked on `range ch` even after `ctx.Done()` | Switched to `select` with `ctx.Done()` (uses `goto done` to break outer for) |
| M11 | `internal/agent/subagent_store.go` | `SaveCompleted` failure left `meta` as "running" forever | Mark `SubagentFailed` + `errors.Join` on save error |
| M12 | `internal/agent/task.go` | `StartForSession` could return nil job without releasing `run` slot | Added nil-check + `run.Release()` |

## LOW (7)

| ID | File | Bug | Fix |
|----|------|-----|-----|
| L1 | `internal/memorycompiler/runtime.go` | Empty-state literal duplicated | Single `emptyState()` source |
| L2 | `internal/memorycompiler/runtime.go` | `applyDriftControl` pruned edges touching stale nodes even when the other end was `TruthLocked` | Preserve edges touching TruthLocked nodes |
| L4 | `internal/sandbox/shell.go` | `nulRedirect` regex missing backtick separator | Added `` ` `` to separator class |
| L5 | `internal/checkpoint/checkpoint.go` | `persist` wrote non-atomically — crash left corrupt file | `fileutil.AtomicWriteFile` |
| L6 | `internal/history/search.go` | `underRoot` didn't resolve symlinks | `EvalSymlinks` on absPath and absRoot before `filepath.Rel` |
| L7 | `internal/agent/migrate.go` | `os.Rename` fails on Windows when target held by AV | Added Windows AV caveat comment (#4666) |
| L8 | `internal/agent/compact.go` | `archiveMessages` left orphan temp file on encode failure | Removed `defer f.Close()`; explicit Close + `os.Remove(path)` on error path |

## Intentionally NOT included

**L3** (remove dead `sed` case in `bash_readonly.go`): upstream #5452 kept the `sed` argument check as defensive code in case `sed` is ever added to the read-only table. That is the correct call — dropping it would be a regression in defensiveness. L3 is dropped from this PR.

## Testing

```
go vet ./...                          → clean
go test -race ./internal/memory/...   → ok 6.166s
go test -race ./internal/memorycompiler/... → ok 80.505s
go test -race ./internal/agent/...    → ok 74.228s
go test -race ./internal/sandbox/...  → ok 1.945s
go test -race ./internal/permission/... → ok 1.754s
go test -race ./internal/checkpoint/... → ok 2.078s
go test -race ./internal/fileref/...  → ok 1.937s
go test -race ./internal/history/...  → ok 2.314s
go test -race ./internal/diff/...     → ok 1.995s
```

## Relationship to #5450 / #5460 / #5452

- **#5450**: original 33-bug PR (closed — superseded by #5452 + this PR)
- **#5460**: second attempt, conflicted with #5452 (closing in favor of this one)
- **#5452**: upstream PR that landed 12 of the 33 bugs (C1–C5, H1, H2, H3, H5, H7, H8, H4 partial)
- **This PR**: the remaining 21 bugs, rebased on top of #5452

## Notes

- All fixes are minimal and surgical — no refactors, no style churn.
- Backwards compatible: no public API changes, no on-disk format changes.
- Follows fail-closed: deny-list additions never widen the read-only set.
