### PR TITLE
fix(desktop): include completion tokens in context gauge total (#5283)

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -51,6 +51,23 @@ eq(
 );
 eq(Math.round(mock.otherPct), 33, "donut endpoint follows used/window percent");
 
+const issue5283 = contextBreakdown(6888, 1_000_000, 6840, 48, 48);
+eq(
+  {
+    promptTokens: issue5283.promptTokens,
+    completionTokens: issue5283.completionTokens,
+    reasoningTokens: issue5283.reasoningTokens,
+    otherTokens: issue5283.otherTokens,
+  },
+  {
+    promptTokens: 6840,
+    completionTokens: 0,
+    reasoningTokens: 48,
+    otherTokens: 0,
+  },
+  "prompt tokens are not scaled down when used context includes completion tokens",
+);
+
 const oversized = contextBreakdown(61_000, 1_000_000, 1_622_277, 12_049, 3_217);
 eq(
   oversized.promptTokens + oversized.completionTokens + oversized.reasoningTokens + oversized.otherTokens,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2292,8 +2292,10 @@ func (c *Controller) History() []provider.Message {
 	return c.executor.Session().Snapshot() // copy — a turn may be appending concurrently
 }
 
-// ContextSnapshot returns (promptTokens, contextWindow) from the most recent
+// ContextSnapshot returns (usedTokens, contextWindow) from the most recent
 // turn. Both zero means no data yet — a gauge hides itself.
+// usedTokens is promptTokens + completionTokens so the GUI breakdown and
+// gauge reflect the full token usage, not just the prompt fill.
 func (c *Controller) ContextSnapshot() (int, int) {
 	if c.executor == nil {
 		return 0, 0
@@ -2302,7 +2304,7 @@ func (c *Controller) ContextSnapshot() (int, int) {
 	if u == nil {
 		return 0, c.executor.ContextWindow()
 	}
-	return u.PromptTokens, c.executor.ContextWindow()
+	return u.PromptTokens + u.CompletionTokens, c.executor.ContextWindow()
 }
 
 // CompactRatio returns the auto-compaction threshold as a fraction of the window

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -79,6 +79,30 @@ func (r cancelingRunner) Run(_ context.Context, _ string) error {
 	return nil
 }
 
+func TestContextSnapshotIncludesCompletionTokens(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{{
+		{Type: provider.ChunkText, Text: "ok"},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{
+			PromptTokens:     6840,
+			CompletionTokens: 48,
+			TotalTokens:      6888,
+			ReasoningTokens:  48,
+		}},
+		{Type: provider.ChunkDone},
+	}}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{ContextWindow: 1_000_000}, event.Discard)
+	c := New(Options{Runner: ag, Executor: ag})
+
+	if err := c.Run(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	used, window := c.ContextSnapshot()
+	if used != 6888 || window != 1_000_000 {
+		t.Fatalf("ContextSnapshot() = (%d, %d), want (6888, 1000000)", used, window)
+	}
+}
+
 type fakeControlTool struct{ name string }
 
 func (t fakeControlTool) Name() string { return t.name }


### PR DESCRIPTION
## Summary

Fixes #5283 by making `ContextSnapshot()` report the current turn total used tokens as `promptTokens + completionTokens`, so the Desktop context-window gauge and breakdown no longer scale the prompt segment down when completion/reasoning tokens are present.

## Changes

- Update `internal/control.Controller.ContextSnapshot()` from prompt-only usage to total prompt + completion usage.
- Add a controller regression test for the reported `6840 prompt + 48 completion/reasoning = 6888 used` case.
- Add a frontend context-panel regression test to ensure prompt tokens are not scaled down for the #5283 token breakdown.

## Verification

- `go test ./internal/control` passed
- `go test ./internal/control ./internal/cli ./internal/serve` passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/context-panel-breakdown.test.ts` passed, 19/19
- `git diff --check` passed

## Scope

- 3 files changed: `internal/control/controller.go`, `internal/control/controller_test.go`, and `desktop/frontend/src/__tests__/context-panel-breakdown.test.ts`.

## Cache Impact

- No provider request serialization, system prompt, tool schema, memory prefix, or compaction behavior changes.

## Cache Guard

- Not applicable; this PR changes controller/UI telemetry reporting and regression tests only.
