### PR TITLE
Make parallel_tasks read-only

### DIFF
--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -1,0 +1,475 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// ParallelTasksTool dispatches multiple read-only research sub-agent tasks
+// concurrently and collects all results. Each sub-task runs as a foreground
+// sub-agent in its own goroutine, emitting nested events so the frontend renders
+// independent cards for each sub-task.
+type ParallelTasksTool struct {
+	taskTool *TaskTool
+	reg      *tool.Registry
+}
+
+// NewParallelTasksTool creates a parallel dispatch tool that reuses the given
+// TaskTool's sub-agent infrastructure.
+func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasksTool {
+	return &ParallelTasksTool{taskTool: taskTool, reg: reg}
+}
+
+func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
+
+func (p *ParallelTasksTool) Description() string {
+	return "Dispatch multiple read-only research sub-agent tasks concurrently and collect their results. Each task runs in its own read-only sub-agent in parallel. Use this for independent inspection, search, review, comparison, and synthesis; it cannot write files or mutate host state. Blocks until all complete."
+}
+
+func (p *ParallelTasksTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "tasks":{
+    "type":"array",
+    "description":"Array of sub-task descriptions to run in parallel.",
+    "items":{
+      "type":"object",
+      "properties":{
+        "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
+        "description":{"type":"string","description":"Optional short label shown in the job list."},
+        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
+        "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
+        "model":{"type":"string","description":"Optional model override."},
+        "effort":{"type":"string","description":"Optional reasoning effort override."},
+        "depends_on":{"type":"array","items":{"type":"integer"},"description":"Optional zero-based indexes of earlier tasks whose results this task should read before starting. Use for synthesis tasks that depend on prior research outputs."}
+      },
+      "required":["prompt"]
+    }
+  }
+},
+"required":["tasks"]
+}`)
+}
+
+func (p *ParallelTasksTool) ReadOnly() bool { return true }
+
+// PlanModeSafe reports true: parallel_tasks only spawns read-only research
+// sub-agents, using the same registry boundary as read_only_task.
+func (p *ParallelTasksTool) PlanModeSafe() bool { return true }
+
+type parallelTaskItem struct {
+	Prompt      string   `json:"prompt"`
+	Description string   `json:"description"`
+	Tools       []string `json:"tools"`
+	MaxSteps    int      `json:"max_steps"`
+	Model       string   `json:"model"`
+	Effort      string   `json:"effort"`
+	DependsOn   []int    `json:"depends_on"`
+}
+
+type parallelTaskStatus string
+
+const (
+	parallelTaskPending   parallelTaskStatus = "pending"
+	parallelTaskCompleted parallelTaskStatus = "completed"
+	parallelTaskFailed    parallelTaskStatus = "failed"
+	parallelTaskCancelled parallelTaskStatus = "cancelled"
+	parallelTaskSkipped   parallelTaskStatus = "skipped"
+)
+
+func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		Tasks []parallelTaskItem `json:"tasks"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if len(params.Tasks) == 0 {
+		return "", fmt.Errorf("at least one task is required")
+	}
+	if len(params.Tasks) == 1 {
+		return "", fmt.Errorf("parallel_tasks with a single task is equivalent to task; use task instead")
+	}
+	if err := validateParallelTaskItems(params.Tasks); err != nil {
+		return "", err
+	}
+
+	parentID, sink, _, ok := CallContext(ctx)
+	if !ok || sink == nil {
+		return p.runWithoutEventSink(ctx, params.Tasks)
+	}
+
+	type subResult struct {
+		index  int
+		output string
+		err    error
+	}
+
+	n := len(params.Tasks)
+
+	// Dependency state: remaining = number of deps not yet completed.
+	remaining := make([]int, n)
+	running := make([]bool, n)
+	done := make([]bool, n)
+	outputs := make([]string, n)
+	taskErrs := make([]error, n)
+	statuses := make([]parallelTaskStatus, n)
+	for i, t := range params.Tasks {
+		remaining[i] = len(t.DependsOn)
+		statuses[i] = parallelTaskPending
+	}
+
+	doneCh := make(chan subResult, n)
+	var wg sync.WaitGroup
+
+	wisdomDir, _ := os.MkdirTemp("", "parallel-wisdom-*")
+	if wisdomDir != "" {
+		defer os.RemoveAll(wisdomDir)
+	}
+	makePrompt := func(t parallelTaskItem) string {
+		var prefix strings.Builder
+		if len(t.DependsOn) > 0 && wisdomDir != "" {
+			entries, _ := os.ReadDir(wisdomDir)
+			if len(entries) > 0 {
+				fmt.Fprintf(&prefix, "Previous task results are available at %s. Read the relevant files with read_file before starting.\n\n", wisdomDir)
+			}
+		}
+		prefix.WriteString(t.Prompt)
+		return prefix.String()
+	}
+	makeLabel := func(t parallelTaskItem, idx int) string {
+		if t.Description != "" {
+			return t.Description
+		}
+		return fmt.Sprintf("task-%d", idx+1)
+	}
+	writeWisdom := func(r subResult) {
+		if wisdomDir == "" {
+			return
+		}
+		fname := filepath.Join(wisdomDir, fmt.Sprintf("task-%d.md", r.index+1))
+		switch {
+		case r.output != "":
+			summary := fmt.Sprintf("# Task %d Result\n\n%s", r.index+1, strings.TrimSpace(r.output))
+			_ = os.WriteFile(fname, []byte(summary), 0o644)
+		case r.err != nil:
+			summary := fmt.Sprintf("# Task %d Result\n\nFAILED: %s", r.index+1, r.err)
+			_ = os.WriteFile(fname, []byte(summary), 0o644)
+		}
+	}
+	startTask := func(idx int) {
+		t := params.Tasks[idx]
+		running[idx] = true
+		prompt := makePrompt(t)
+		label := makeLabel(t, idx)
+		subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
+		dispatchArgs, _ := json.Marshal(map[string]string{"prompt": prompt, "description": label})
+		sink.Emit(event.Event{
+			Kind: event.ToolDispatch,
+			Tool: event.Tool{ID: subID, ParentID: parentID, Name: "read_only_task", Args: string(dispatchArgs), ReadOnly: true},
+		})
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			output, runErr := p.runReadOnlySubtask(ctx, t, prompt, subSinkFor(subID, sink))
+			if runErr != nil {
+				errText := runErr.Error()
+				if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+					errText = "cancelled: " + errText
+				}
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "read_only_task", Err: errText, ReadOnly: true},
+				})
+				doneCh <- subResult{index: idx, err: runErr}
+				return
+			}
+			sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: subID, ParentID: parentID, Name: "read_only_task", Output: output, ReadOnly: true},
+			})
+			doneCh <- subResult{index: idx, output: output}
+		}()
+	}
+
+	startReady := func() {
+		if ctx.Err() != nil {
+			return
+		}
+		for i := range params.Tasks {
+			if remaining[i] == 0 && !running[i] && !done[i] {
+				startTask(i)
+			}
+		}
+	}
+	markCancelled := func(err error) {
+		for i := range params.Tasks {
+			if done[i] {
+				continue
+			}
+			done[i] = true
+			if running[i] {
+				statuses[i] = parallelTaskCancelled
+				taskErrs[i] = err
+				continue
+			}
+			statuses[i] = parallelTaskSkipped
+			taskErrs[i] = err
+		}
+	}
+
+	completed := 0
+	startReady()
+	processResult := func(r subResult, schedule bool) {
+		if done[r.index] {
+			return
+		}
+		completed++
+		done[r.index] = true
+		outputs[r.index] = r.output
+		taskErrs[r.index] = r.err
+		switch {
+		case r.err == nil:
+			statuses[r.index] = parallelTaskCompleted
+		case errors.Is(r.err, context.Canceled), errors.Is(r.err, context.DeadlineExceeded):
+			statuses[r.index] = parallelTaskCancelled
+		default:
+			statuses[r.index] = parallelTaskFailed
+		}
+		writeWisdom(r)
+
+		for i, t := range params.Tasks {
+			if remaining[i] > 0 && !running[i] && !done[i] {
+				for _, dep := range t.DependsOn {
+					if dep == r.index {
+						remaining[i]--
+					}
+				}
+			}
+		}
+		if schedule {
+			startReady()
+		}
+	}
+	for completed < n {
+		select {
+		case r := <-doneCh:
+			processResult(r, true)
+		case <-ctx.Done():
+			err := ctx.Err()
+		drain:
+			for {
+				select {
+				case r := <-doneCh:
+					processResult(r, false)
+				default:
+					break drain
+				}
+			}
+			markCancelled(err)
+			wg.Wait()
+			return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
+		}
+	}
+	wg.Wait()
+	if parallelTasksWereCancelled(statuses) {
+		err := ctx.Err()
+		if err == nil {
+			err = context.Canceled
+		}
+		return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
+	}
+	return formatParallelTasksAggregate(outputs, taskErrs, statuses, false), nil
+}
+
+func parallelTasksWereCancelled(statuses []parallelTaskStatus) bool {
+	for _, st := range statuses {
+		if st == parallelTaskCancelled || st == parallelTaskSkipped {
+			return true
+		}
+	}
+	return false
+}
+
+func formatParallelTasksAggregate(outputs []string, errs []error, statuses []parallelTaskStatus, cancelled bool) string {
+	n := len(statuses)
+	var b strings.Builder
+	if cancelled {
+		completed := 0
+		for _, st := range statuses {
+			if st == parallelTaskCompleted {
+				completed++
+			}
+		}
+		fmt.Fprintf(&b, "Cancelled parallel tasks after completing %d of %d tasks:\n", completed, n)
+	} else {
+		fmt.Fprintf(&b, "Completed %d parallel tasks:\n", n)
+	}
+	for i, st := range statuses {
+		fmt.Fprintf(&b, "── task-%d ──\n", i+1)
+		switch st {
+		case parallelTaskCompleted:
+			fmt.Fprintf(&b, "%s\n", strings.TrimSpace(outputs[i]))
+		case parallelTaskCancelled:
+			if errs[i] != nil {
+				fmt.Fprintf(&b, "[CANCELLED] %s\n", errs[i])
+			} else {
+				b.WriteString("[CANCELLED]\n")
+			}
+		case parallelTaskSkipped:
+			if errs[i] != nil {
+				fmt.Fprintf(&b, "[SKIPPED] cancelled before start: %s\n", errs[i])
+			} else {
+				b.WriteString("[SKIPPED] cancelled before start\n")
+			}
+		case parallelTaskFailed:
+			fmt.Fprintf(&b, "[FAILED] %s\n", errs[i])
+		default:
+			b.WriteString("[PENDING]\n")
+		}
+	}
+	return b.String()
+}
+
+func (p *ParallelTasksTool) runWithoutEventSink(ctx context.Context, tasks []parallelTaskItem) (string, error) {
+	outputs := make([]string, len(tasks))
+	errs := make([]error, len(tasks))
+	statuses := make([]parallelTaskStatus, len(tasks))
+	for i := range statuses {
+		statuses[i] = parallelTaskPending
+	}
+
+	var wg sync.WaitGroup
+	for i, t := range tasks {
+		i, t := i, t
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			outputs[i], errs[i] = p.runReadOnlySubtask(ctx, t, t.Prompt, event.Discard)
+			switch {
+			case errs[i] == nil:
+				statuses[i] = parallelTaskCompleted
+			case errors.Is(errs[i], context.Canceled), errors.Is(errs[i], context.DeadlineExceeded):
+				statuses[i] = parallelTaskCancelled
+			default:
+				statuses[i] = parallelTaskFailed
+			}
+		}()
+	}
+	wg.Wait()
+	if parallelTasksWereCancelled(statuses) {
+		err := ctx.Err()
+		if err == nil {
+			err = context.Canceled
+		}
+		return formatParallelTasksAggregate(outputs, errs, statuses, true), err
+	}
+	return formatParallelTasksAggregate(outputs, errs, statuses, false), nil
+}
+
+func (p *ParallelTasksTool) runReadOnlySubtask(ctx context.Context, t parallelTaskItem, prompt string, sink event.Sink) (string, error) {
+	modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
+	subReg := ReadOnlySubagentToolRegistry(p.taskTool.parentReg, t.Tools)
+	max := t.MaxSteps
+	if max <= 0 {
+		max = 20
+	}
+	prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
+	if err != nil {
+		return "", err
+	}
+	sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
+	output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
+		MaxSteps:          max,
+		Temperature:       p.taskTool.temperature,
+		Pricing:           pricing,
+		UsageSource:       event.UsageSourceSubagent,
+		Gate:              p.taskTool.gate,
+		ContextWindow:     ctxWin,
+		RecentKeep:        p.taskTool.recentKeep,
+		SoftCompactRatio:  p.taskTool.softCompactRatio,
+		CompactRatio:      p.taskTool.compactRatio,
+		CompactForceRatio: p.taskTool.compactForceRatio,
+		ArchiveDir:        p.taskTool.archiveDir,
+		KeepPolicy:        p.taskTool.keepPolicy,
+	}, sink)
+	if ctx.Err() != nil && runErr == nil {
+		runErr = ctx.Err()
+	}
+	return output, runErr
+}
+
+func validateParallelTaskItems(tasks []parallelTaskItem) error {
+	for i, t := range tasks {
+		if strings.TrimSpace(t.Prompt) == "" {
+			return fmt.Errorf("task %d: prompt is required", i+1)
+		}
+		for j, dep := range t.DependsOn {
+			if dep < 0 || dep >= len(tasks) {
+				return fmt.Errorf("task %d: depends_on[%d] = %d out of range (0-%d)", i+1, j, dep, len(tasks)-1)
+			}
+			if dep == i {
+				return fmt.Errorf("task %d: self-referencing depends_on", i+1)
+			}
+		}
+	}
+
+	state := make([]int, len(tasks)) // 0 = unvisited, 1 = visiting, 2 = done
+	var visit func(int) error
+	visit = func(i int) error {
+		switch state[i] {
+		case 1:
+			return fmt.Errorf("task dependency cycle detected at task %d", i+1)
+		case 2:
+			return nil
+		}
+		state[i] = 1
+		for _, dep := range tasks[i].DependsOn {
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		state[i] = 2
+		return nil
+	}
+	for i := range tasks {
+		if err := visit(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveSubagentProvider resolves a provider for a sub-agent, using the
+// TaskTool's resolver or falling back to the task tool's own provider.
+func resolveSubagentProvider(tt *TaskTool, modelRef, effortRef string) (provider.Provider, *provider.Pricing, int, error) {
+	if tt.resolveProvider != nil && (modelRef != "" || effortRef != "") {
+		return tt.resolveProvider(modelRef, effortRef)
+	}
+	// Use the task tool's own defaults.
+	return tt.prov, tt.pricing, tt.contextWindow, nil
+}
+
+func extractJobID(msg string) string {
+	quote := strings.Index(msg, `"`)
+	if quote < 0 {
+		return ""
+	}
+	end := strings.Index(msg[quote+1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return msg[quote+1 : quote+1+end]
+}

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -1,0 +1,226 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestParallelTasksToolIsReadOnly(t *testing.T) {
+	if !(&ParallelTasksTool{}).ReadOnly() {
+		t.Fatal("parallel_tasks must be read-only because it is for parallel research, not concurrent writes")
+	}
+}
+
+func TestParallelTasksSchemaExposesDependencyOrdering(t *testing.T) {
+	schema := string((&ParallelTasksTool{}).Schema())
+	if !strings.Contains(schema, "depends_on") {
+		t.Fatal("parallel_tasks schema should expose depends_on so the model can express result dependencies")
+	}
+}
+
+func TestParallelTasksUsesReadOnlySubagentRegistry(t *testing.T) {
+	prov := &recordToolsProvider{name: "sub"}
+	parentReg := tool.NewRegistry()
+	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
+	parentReg.Add(fakeTool{name: "write_file", readOnly: false})
+	parentReg.Add(fakeTool{name: "bash", readOnly: false})
+	task := newTestTaskTool(t, prov, parentReg, "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, parentReg)
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	if _, err := parallel.Execute(ctx, json.RawMessage(`{
+		"tasks": [
+			{"prompt": "inspect auth", "tools": ["read_file", "write_file", "bash"]},
+			{"prompt": "inspect sessions", "tools": ["read_file", "write_file", "bash"]}
+		]
+	}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, req := range prov.requests {
+		got := map[string]bool{}
+		for _, schema := range req.Tools {
+			got[schema.Name] = true
+		}
+		if !got["read_file"] || !got["bash"] || got["write_file"] {
+			t.Fatalf("parallel_tasks sub-agent tools = %v, want read_file and read-only bash, no write_file", got)
+		}
+	}
+}
+
+func TestParallelTasksValidatesAllTasksBeforeRuntimeLookup(t *testing.T) {
+	tool := &ParallelTasksTool{}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"tasks": [
+			{"prompt": "inspect the parser"},
+			{"prompt": "   "}
+		]
+	}`))
+	if err == nil {
+		t.Fatal("Execute returned nil error for an empty later task")
+	}
+	if !strings.Contains(err.Error(), "task 2: prompt is required") {
+		t.Fatalf("Execute error = %v, want task validation before runtime lookup", err)
+	}
+	if strings.Contains(err.Error(), "background jobs are not available") {
+		t.Fatalf("Execute looked up background jobs before validating all tasks: %v", err)
+	}
+}
+
+func TestParallelTasksRejectsDependencyCyclesBeforeRuntimeLookup(t *testing.T) {
+	tool := &ParallelTasksTool{}
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"tasks": [
+			{"prompt": "first", "depends_on": [1]},
+			{"prompt": "second", "depends_on": [0]}
+		]
+	}`))
+	if err == nil {
+		t.Fatal("Execute returned nil error for cyclic dependencies")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("Execute error = %v, want dependency cycle validation", err)
+	}
+	if strings.Contains(err.Error(), "background jobs are not available") {
+		t.Fatalf("Execute looked up background jobs before validating dependencies: %v", err)
+	}
+}
+
+func TestParallelTasksForegroundCompletesAndClosesWorkers(t *testing.T) {
+	task := newTestTaskTool(t, parallelStaticProvider{}, tool.NewRegistry(), "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	done := make(chan error, 1)
+	go func() {
+		out, err := parallel.Execute(ctx, json.RawMessage(`{
+			"tasks": [
+				{"prompt": "first"},
+				{"prompt": "second"}
+			]
+		}`))
+		if err != nil {
+			done <- err
+			return
+		}
+		if !strings.Contains(out, "Completed 2 parallel tasks") {
+			done <- stringsError("missing aggregate output: " + out)
+			return
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("parallel_tasks foreground execution did not return; workers likely waited on spawnCh forever")
+	}
+}
+
+func TestParallelTasksCancelReturnsPartialAggregate(t *testing.T) {
+	task := newTestTaskTool(t, promptRoutingProvider{}, tool.NewRegistry(), "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+
+	ctx, cancel := context.WithCancel(withCallContext(context.Background(), "parallel-call", event.Discard, nil, false))
+	defer cancel()
+	done := make(chan struct {
+		out string
+		err error
+	}, 1)
+	go func() {
+		out, err := parallel.Execute(ctx, json.RawMessage(`{
+			"tasks": [
+				{"prompt": "done child"},
+				{"prompt": "stuck child"}
+			]
+		}`))
+		done <- struct {
+			out string
+			err error
+		}{out: out, err: err}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("Execute error = %v, want context cancellation", got.err)
+		}
+		if strings.Contains(got.out, "Completed 2 parallel tasks") {
+			t.Fatalf("cancelled aggregate reported full completion:\n%s", got.out)
+		}
+		if !strings.Contains(got.out, "done child ok") {
+			t.Fatalf("cancelled aggregate lost completed child output:\n%s", got.out)
+		}
+		if !strings.Contains(strings.ToLower(got.out), "cancelled") {
+			t.Fatalf("cancelled aggregate did not mark unfinished child:\n%s", got.out)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("parallel_tasks did not return promptly after cancellation")
+	}
+}
+
+type parallelStaticProvider struct{}
+
+func (parallelStaticProvider) Name() string { return "parallel-static" }
+
+func (parallelStaticProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+type promptRoutingProvider struct{}
+
+func (promptRoutingProvider) Name() string { return "prompt-routing" }
+
+func (promptRoutingProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	if strings.Contains(lastUser(req), "stuck") {
+		ch := make(chan provider.Chunk)
+		go func() {
+			<-ctx.Done()
+			close(ch)
+		}()
+		return ch, nil
+	}
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: lastUser(req) + " ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+type stringsError string
+
+func (e stringsError) Error() string { return string(e) }
+
+type recordToolsProvider struct {
+	name     string
+	requests []provider.Request
+}
+
+func (p *recordToolsProvider) Name() string { return p.name }
+
+func (p *recordToolsProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.requests = append(p.requests, req)
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -22,8 +22,18 @@ Use the provided tools to investigate or act. Return a single final answer that 
 and self-contained — the parent will see only that answer, not your tool calls or reasoning.
 If you need to ask for clarification, fail with a precise question instead of guessing.`
 
+// DefaultReadOnlyTaskSystemPrompt steers read-only sub-agents toward isolated
+// research. They never receive writer tools, persisted transcript controls, or
+// background process controls, so their final answer is the only handoff.
+const DefaultReadOnlyTaskSystemPrompt = `You are a read-only research sub-agent invoked by a parent coding agent.
+Use only the provided read-only tools to inspect code, docs, history, and safe shell output.
+Do not attempt to write files, install capabilities, mutate memory, control long-lived
+processes, or delegate to another agent. Return a concise, self-contained final answer
+with the evidence the parent needs.`
+
 var subagentMetaTools = []string{
 	"task",
+	"parallel_tasks",
 	"run_skill",
 	"read_skill",
 	"install_skill",
@@ -38,6 +48,10 @@ var subagentJobTools = []string{
 	"wait",
 	"bash_output",
 	"kill_shell",
+}
+
+var readOnlySubagentWorkflowTools = []string{
+	"connect_tool_source",
 }
 
 const subagentToolBoundarySummary = "Recursive agent/skill tools and unsupported background job tools (wait, bash_output, kill_shell) are excluded; bash is exposed as foreground-only inside subagents."
@@ -99,6 +113,34 @@ func (b foregroundOnlyBash) Execute(ctx context.Context, args json.RawMessage) (
 }
 
 func (b foregroundOnlyBash) ReadOnly() bool { return b.inner.ReadOnly() }
+
+type readOnlyBash struct {
+	inner tool.Tool
+}
+
+func (b readOnlyBash) Name() string { return "bash" }
+
+func (b readOnlyBash) Description() string {
+	desc := strings.TrimSpace(b.inner.Description())
+	if desc == "" {
+		desc = "Execute a command in the shell and return combined stdout/stderr."
+	}
+	desc = strings.Replace(desc, "Execute a command in the shell", "Execute a foreground read-only command in the shell", 1)
+	return desc + " Only plan-mode safe read-only commands are allowed; shell operators, background execution, process preservation, and write-capable arguments are blocked."
+}
+
+func (readOnlyBash) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Read-only shell command to execute in the foreground. Must match the plan-mode safe bash policy."}},"required":["command"]}`)
+}
+
+func (b readOnlyBash) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if blocked, msg := planModeBashBlocked(args); blocked {
+		return msg, nil
+	}
+	return b.inner.Execute(ctx, args)
+}
+
+func (readOnlyBash) ReadOnly() bool { return true }
 
 // TaskTool spawns a sub-agent in its own session for a focused sub-task. The
 // sub-agent runs with a filtered tool whitelist and the same step budget shape
@@ -461,6 +503,46 @@ var plannerNonResearchTools = []string{
 func PlannerToolRegistry(parent *tool.Registry) *tool.Registry {
 	exclude := append(SubagentMetaTools(), plannerNonResearchTools...)
 	return FilterReadOnlyRegistry(parent, exclude...)
+}
+
+// ReadOnlySubagentToolRegistry returns the tool set exposed to read-only
+// sub-agents: read-only research tools plus a bash wrapper that enforces the
+// plan-mode safe command policy at execution time. Workflow/meta tools are
+// excluded even when their Tool.ReadOnly contract is true.
+func ReadOnlySubagentToolRegistry(parent *tool.Registry, names []string) *tool.Registry {
+	exclude := append(SubagentMetaTools(), subagentJobTools...)
+	exclude = append(exclude, plannerNonResearchTools...)
+	exclude = append(exclude, readOnlySubagentWorkflowTools...)
+	ex := make(map[string]bool, len(exclude))
+	for _, e := range exclude {
+		ex[e] = true
+	}
+	sub := tool.NewRegistry()
+	if parent == nil {
+		return sub
+	}
+	src := names
+	if len(src) == 0 {
+		src = parent.Names()
+	}
+	for _, name := range src {
+		if ex[name] {
+			continue
+		}
+		tl, ok := parent.Get(name)
+		if !ok {
+			continue
+		}
+		if name == "bash" {
+			sub.Add(readOnlyBash{inner: tl})
+			continue
+		}
+		if !tl.ReadOnly() {
+			continue
+		}
+		sub.Add(tl)
+	}
+	return sub
 }
 
 // FilterReadOnlyRegistry builds a sub-registry containing only tools whose


### PR DESCRIPTION
## Summary

This PR updates the `parallel_tasks` work for `main-v2` with an explicit read-only contract. In the GitHub diff the tool files appear as added because `main-v2` does not currently contain `parallel_tasks`, but the behavioral intent of this PR is not to introduce a write-capable parallel worker. The intended contract is: `parallel_tasks` is a read-only research fanout tool for parallel search, inspection, review, comparison, and synthesis.

Main changes:

- Defines `parallel_tasks` on top of `main-v2` with read-only semantics.
- Makes `parallel_tasks.ReadOnly()` return `true`.
- Adds `PlanModeSafe()` so the tool can be used safely in plan mode.
- Routes child tasks through `ReadOnlySubagentToolRegistry`, preventing inheritance of writer tools such as `write_file`, `edit_file`, `multi_edit`, and `move_file`.
- Wraps `bash` inside read-only sub-agents as read-only bash, allowing only plan-mode-safe commands.
- Exposes `depends_on` in the schema for DAG-style research flows where synthesis tasks depend on prior results.
- Adds tests for read-only classification, dependency schema exposure, read-only tool filtering, cancellation, and dependency-cycle validation.

## Why

Parallel sub-agents are useful for broad research and synthesis, but inheriting write tools by default risks conflicting concurrent edits. This PR makes the boundary explicit: `parallel_tasks` gathers evidence concurrently; it does not mutate the workspace.

## Validation

```sh
go test ./internal/agent/ -run 'TestParallelTasks' -count=1
go test ./internal/agent/ -count=1
```

Cache-impact: medium — adds the `parallel_tasks` schema on `main-v2` and establishes the read-only sub-agent boundary, causing one tool-schema prefix change for existing sessions; the schema is static afterward.
Cache-guard: `go test ./internal/agent/ -run 'TestParallelTasks' -count=1` and `go test ./internal/agent/ -count=1`
