### PR TITLE
TUI 内选中文字 → Ctrl+C → 优先走 wl-copy

### DIFF
--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -21,12 +22,18 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
-// copyToClipboard writes text through the terminal via OSC 52. That targets the
-// terminal-side clipboard in common SSH/tmux setups when the terminal permits it;
-// platform clipboard tools can instead succeed on the remote host and skip the
-// terminal clipboard path entirely.
+// copyToClipboard writes text through the platform clipboard tool (wl-copy on
+// Wayland, xclip/xsel on X11) via the atotto/clipboard library. Falls back to
+// OSC 52 when the platform tool is unavailable (e.g. remote SSH without a
+// clipboard provider). OSC 52 is not supported in all terminals (notably
+// GNOME Terminal on Wayland blocks it).
 func copyToClipboard(text string) tea.Cmd {
-	return tea.SetClipboard(text)
+	return func() tea.Msg {
+		if err := clipboard.WriteAll(text); err == nil {
+			return nil
+		}
+		return tea.SetClipboard(text)()
+	}
 }
 
 // autoScrollMsg drives one step of edge-drag scrolling while a selection is held


### PR DESCRIPTION
• TUI 内选中文字 → Ctrl+C → 走 wl-copy → Wayland 原生剪贴板写入 → ✅ 正常工作，不行再回退到osc52 • 粘贴 Ctrl+V → 不变，继续走 wl-paste → ✅ 正常工作
• 不再依赖 OSC 52，不受 GNOME Terminal/Wayland 安全策略影响

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
