### PR TITLE
feat(skills): UI设计师 add design-ui inline skill for DESIGN.md-based UI generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,12 @@ node_modules/
 .pnpm-store/
 .npm/
 
-# Project-local Reasonix state; keep the checked-in review command.
+# Project-local Reasonix state; keep the checked-in review command and skills.
 /.reasonix/*
 !/.reasonix/commands/
 !/.reasonix/commands/review.md
+!/.reasonix/skills/
+!/.reasonix/skills/design-ui/
 
 # CodeGraph per-project index (rebuilt locally; never committed)
 .codegraph/

--- a/.reasonix/skills/design-ui/SKILL.md
+++ b/.reasonix/skills/design-ui/SKILL.md
@@ -1,58 +1,58 @@
 ---
 name: design-ui
-description: Generate UI code matching a DESIGN.md design system — load tokens, build components, verify
+description: 根据 DESIGN.md 设计系统生成 UI 代码 — 加载令牌、构建组件、验证
 ---
 
-# Design UI — generate UI code from DESIGN.md
+# Design UI — 从 DESIGN.md 生成 UI 代码
 
-Your task: generate UI code (HTML/CSS, React, or the framework specified) that follows the design system defined in the project's DESIGN.md.
+你的任务：生成符合项目 DESIGN.md 设计系统的 UI 代码（HTML/CSS、React 或指定的框架）。
 
-## How it works
+## 工作流程
 
-1. **Find the DESIGN.md** — look in these locations in order:
+1. **找到 DESIGN.md** — 按顺序查找：
    - `.reasonix/DESIGN.md`
    - `./DESIGN.md`
-   - Any file ending with `DESIGN.md` in the project root
-   
-   If none exists, offer to create one by downloading from [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) using `web_fetch`.
+   - 项目根目录下任何以 `DESIGN.md` 结尾的文件
 
-2. **Read the DESIGN.md** — use `@DESIGN.md` or `read_file` to load the full file. Pay attention to:
-   - Color palette (semantic names + hex values)
-   - Typography scale (font families, sizes, weights)
-   - Spacing/rounded tokens
-   - Component definitions (buttons, cards, inputs, nav)
-   - Do's and Don'ts (design guardrails)
+   如果都没有，用 `web_fetch` 从 [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) 下载一个。
 
-3. **Classify the request** — is the user asking for:
-   - A single page/component? → build it directly
-   - A full site? → identify pages, plan the component tree first
-   - Just a design exploration? → generate a preview HTML
+2. **读取 DESIGN.md** — 用 `@DESIGN.md` 或 `read_file` 加载完整文件。重点关注：
+   - 色板（语义名称 + 十六进制值）
+   - 字体层级（字族、字号、字重）
+   - 间距/圆角令牌
+   - 组件定义（按钮、卡片、输入框、导航）
+   - 注意事项（设计红线）
 
-4. **Generate the code** — produce production-ready UI that:
-   - Uses the exact hex values from DESIGN.md's color palette
-   - Follows the typography hierarchy (display-xl → caption)
-   - Applies the spacing scale and border radius tokens
-   - Mirrors the component definitions (button shapes, card styles)
-   - Respects every "Don't" rule in the DESIGN.md
+3. **判断需求** — 用户在问：
+   - 单个页面/组件？→ 直接构建
+   - 完整站点？→ 先规划页面结构，再构建组件树
+   - 只是设计探索？→ 生成预览 HTML
 
-5. **Write to files** — use `write_file` to create:
-   - `ui/index.html` or the appropriate framework files
-   - Include a `<link>` to the CSS or inline styles
+4. **生成代码** — 产出可用于生产环境的 UI：
+   - 使用 DESIGN.md 色板中的精确十六进制值
+   - 遵循字体层级（display-xl → caption）
+   - 应用间距刻度和圆角令牌
+   - 匹配组件定义（按钮形状、卡片样式）
+   - 遵守每条 "Don't" 规则
 
-6. **Verify** — if a browser/build tool is available, offer to verify visually.
+5. **写入文件** — 用 `write_file` 创建：
+   - `ui/index.html` 或对应框架的文件
+   - 包含 CSS 链接或内联样式
 
-## Design constraints
+6. **验证** — 如果有浏览器/构建工具可用，提供视觉验证。
 
-- Every color MUST come from the DESIGN.md palette — never invent hex values
-- Component shapes MUST match the `components:` section tokens
-- Typography MUST use the defined `typography` scale tokens
-- If DESIGN.md says "Don't", don't do it
-- Use CSS custom properties (--color-primary, --spacing-lg) to map DESIGN.md tokens to runtime values so the relationship is explicit
+## 设计约束
 
-## Arguments format
+- 每个颜色**必须**来自 DESIGN.md 色板 — 绝不凭空造十六进制值
+- 组件形状**必须**匹配 `components:` 节的令牌
+- 字体**必须**使用定义的 `typography` 层级令牌
+- 如果 DESIGN.md 说 "Don't"，就别做
+- 用 CSS 自定义属性（`--color-primary`、`--spacing-lg`）映射 DESIGN.md 令牌到运行时值，使映射关系显式可追溯
+
+## 参数格式
 
 ```
-design-ui arguments: "<description of what to build>, design=<path-to-design.md>"
+design-ui arguments: "<要构建的内容描述>, design=<design.md路径>"
 ```
 
-If `design` is omitted, search PROJECT_ROOT/DESIGN.md then .reasonix/DESIGN.md.
+如果不传 `design`，默认搜索 `PROJECT_ROOT/DESIGN.md` 然后是 `.reasonix/DESIGN.md`。

--- a/.reasonix/skills/design-ui/SKILL.md
+++ b/.reasonix/skills/design-ui/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: design-ui
+description: Generate UI code matching a DESIGN.md design system — load tokens, build components, verify
+---
+
+# Design UI — generate UI code from DESIGN.md
+
+Your task: generate UI code (HTML/CSS, React, or the framework specified) that follows the design system defined in the project's DESIGN.md.
+
+## How it works
+
+1. **Find the DESIGN.md** — look in these locations in order:
+   - `.reasonix/DESIGN.md`
+   - `./DESIGN.md`
+   - Any file ending with `DESIGN.md` in the project root
+   
+   If none exists, offer to create one by downloading from [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) using `web_fetch`.
+
+2. **Read the DESIGN.md** — use `@DESIGN.md` or `read_file` to load the full file. Pay attention to:
+   - Color palette (semantic names + hex values)
+   - Typography scale (font families, sizes, weights)
+   - Spacing/rounded tokens
+   - Component definitions (buttons, cards, inputs, nav)
+   - Do's and Don'ts (design guardrails)
+
+3. **Classify the request** — is the user asking for:
+   - A single page/component? → build it directly
+   - A full site? → identify pages, plan the component tree first
+   - Just a design exploration? → generate a preview HTML
+
+4. **Generate the code** — produce production-ready UI that:
+   - Uses the exact hex values from DESIGN.md's color palette
+   - Follows the typography hierarchy (display-xl → caption)
+   - Applies the spacing scale and border radius tokens
+   - Mirrors the component definitions (button shapes, card styles)
+   - Respects every "Don't" rule in the DESIGN.md
+
+5. **Write to files** — use `write_file` to create:
+   - `ui/index.html` or the appropriate framework files
+   - Include a `<link>` to the CSS or inline styles
+
+6. **Verify** — if a browser/build tool is available, offer to verify visually.
+
+## Design constraints
+
+- Every color MUST come from the DESIGN.md palette — never invent hex values
+- Component shapes MUST match the `components:` section tokens
+- Typography MUST use the defined `typography` scale tokens
+- If DESIGN.md says "Don't", don't do it
+- Use CSS custom properties (--color-primary, --spacing-lg) to map DESIGN.md tokens to runtime values so the relationship is explicit
+
+## Arguments format
+
+```
+design-ui arguments: "<description of what to build>, design=<path-to-design.md>"
+```
+
+If `design` is omitted, search PROJECT_ROOT/DESIGN.md then .reasonix/DESIGN.md.


### PR DESCRIPTION
# 做了什么
从 upstream/main-v2 拉取最新代码，创建 feat/design-ui-skill 分支，编写了一个完整的 design-ui inline skill。

# 怎么用
在当前项目已有 DESIGN.md 的情况下：
- run_skill({name: "design-ui", arguments: "build a login page"})
或直接：
- /design-ui build a pricing page with 3 tiers

# 没有 DESIGN.md？
先下载一个
- web_fetch https://raw.githubusercontent.com/VoltAgent/awesome-design-md/main/design-md/vercel/DESIGN.md
保存为 .reasonix/DESIGN.md，再运行上面的命令

# skill 做了什么
- 找 DESIGN.md — 自动发现 .reasonix/DESIGN.md 或 ./DESIGN.md
- 读设计令牌 — 提取色板、字体、间距、圆角、组件定义
- 生成 UI 代码 — 用精确的 hex 值、字体栈、token 映射，不凭空造颜色
- 守设计红线 — 严格遵守 DESIGN.md 里的 "Don't" 规则
- 映射到 CSS — 用 --color-primary、--spacing-lg 等 CSS 变量暴露 token

## Summary

Add a `design-ui` inline skill that integrates the [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) ecosystem (93.9k stars) with Reasonix. DESIGN.md is a markdown design system document (analogous to AGENTS.md but for UI) that defines color palettes, typography scales, spacing tokens, and component shapes extracted from real brand websites.

## How it works

```
run_skill({name: "design-ui", arguments: "build a pricing page, design=./DESIGN.md"})
\# or just:  /design-ui build a login page
\# or with @DESIGN.md auto-load
```

The skill:
1. Finds and loads the project's DESIGN.md (from `.reasonix/DESIGN.md` or `./DESIGN.md`)
2. If no DESIGN.md exists, offers to download one from awesome-design-md
3. Generates UI code using the exact tokens (hex colors, font stacks, spacing, component shapes)
4. Maps DESIGN.md tokens to CSS custom properties for runtime traceability
5. Respects every 'Do not' guardrail from the design system

## Files

- `.reasonix/skills/design-ui/SKILL.md` — the inline playbook
- `.gitignore` — un-ignore `!/.reasonix/skills/` and `!/.reasonix/skills/design-ui/`

Cache-impact: none — skill body is an isolated file, not in system prompt prefix
Cache-guard: N/A — no cache-sensitive paths modified