### PR TITLE
fix(tui): add regression test verifying viewport auto-follows streaming answer (#5456)

### DIFF
--- a/internal/cli/auto_scroll_test.go
+++ b/internal/cli/auto_scroll_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestAutoFollowStreamingAnswerAtBottom(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	// Start with a small terminal. WindowSizeMsg also commits the TUI banner.
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+
+	// Add content to overflow the viewport (banner + 40 notice lines).
+	for i := 0; i < 40; i++ {
+		cur = adv(cur, agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"}))
+	}
+
+	// Should be at bottom after filling content
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("expected at bottom after filling content, YOffset=%d", cur.viewport.YOffset())
+	}
+
+	// Now simulate streaming text while at bottom
+	cur = adv(cur, agentEventMsg(event.Event{Kind: event.Text, Text: "This is a streamed response paragraph.\n\n"}))
+
+	// Should still be at bottom after streaming new content
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("expected at bottom after streaming text at bottom, YOffset=%d", cur.viewport.YOffset())
+	}
+
+	// More streaming content
+	cur = adv(cur, agentEventMsg(event.Event{Kind: event.Text, Text: "More streamed content with wrapping.\n\n"}))
+
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("expected at bottom after more streaming, YOffset=%d", cur.viewport.YOffset())
+	}
+}


### PR DESCRIPTION
## 修复内容

为 Issue #5456 添加回归测试，验证视口在流式输出时自动跟随。

### 变更说明
- 新增  — 
- 测试序列：填充溢出内容 → 触发流式 event.Text → 验证视口始终保持在底部
- 补充了现有  的逆命题

### 验证
- go test ./internal/cli/ 全部通过
- 三种代码走查全部通过（内置 review / ponytail-review / pr-review）
- 最小改动：仅新增一个测试文件（46 行）