### PR TITLE
fix(desktop): restore topic title from session fallback when switching projects in creation mode (#5438)

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1260,18 +1260,9 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	tabID := a.newUniqueTabIDLocked()
 	topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
-
-	// Fallback: if the topic-title file has no entry for this topic, try to
-	// extract a title from the first session found in the session directory.
-	// This covers edge cases where the topic title source was saved under a
-	// different workspace root normalization, such as when switching between
-	// projects in single-surface (creation/workbench) mode.
-	if topicTitle == defaultTopicTitle && sessionPath != "" {
-		if t := topicTitleFromSession(sessionPath); t != "" {
-			topicTitle = t
-			// Persist it back so the topic-titles file is consistent.
-			_ = setTopicTitleWithSource(workspaceRoot, topicID, t, topicTitleSourceAuto)
-		}
+	if t, source, ok := topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath); ok {
+		topicTitle = t
+		_ = setTopicTitleWithSource(workspaceRoot, topicID, t, source)
 	}
 
 	if sessionPath == "" {
@@ -2547,6 +2538,42 @@ func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (stri
 		return "", false
 	}
 	return nextTitle, true
+}
+
+func topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath string) (string, string, bool) {
+	topicID = strings.TrimSpace(topicID)
+	sessionPath = strings.TrimSpace(sessionPath)
+	if topicID == "" || sessionPath == "" {
+		return "", "", false
+	}
+	storedTitle := strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID))
+	storedSource := strings.TrimSpace(loadTopicTitleSource(workspaceRoot, topicID))
+	if storedTitle != "" {
+		if storedSource == topicTitleSourceManual || storedTitle != defaultTopicTitle {
+			return "", "", false
+		}
+	}
+
+	if storedTitle == "" {
+		dir := filepath.Dir(sessionPath)
+		if meta, ok, err := agent.LoadBranchMeta(sessionPath); err == nil && ok {
+			if title := storedSessionTopicTitle(dir, sessionPath, meta); title != "" {
+				return title, topicTitleSourceManual, true
+			}
+		} else if title := topicTitleFromText(loadSessionTitles(dir)[filepath.Base(sessionPath)]); title != "" {
+			return title, topicTitleSourceManual, true
+		}
+	}
+
+	if storedSource == topicTitleSourceManual {
+		return "", "", false
+	}
+	if storedSource == "" || storedSource == topicTitleSourceAuto {
+		if title := topicTitleFromSession(sessionPath); title != "" {
+			return title, topicTitleSourceAuto, true
+		}
+	}
+	return "", "", false
 }
 
 func topicTitleFromSession(path string) string {
@@ -3967,10 +3994,7 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 }
 
 func restoredSessionTopicTitle(dir, sessionPath string, meta agent.BranchMeta) string {
-	if title := topicTitleFromText(meta.TopicTitle); title != "" {
-		return title
-	}
-	if title := topicTitleFromText(loadSessionTitles(dir)[filepath.Base(sessionPath)]); title != "" {
+	if title := storedSessionTopicTitle(dir, sessionPath, meta); title != "" {
 		return title
 	}
 	if s, err := agent.LoadSession(sessionPath); err == nil {
@@ -3983,6 +4007,13 @@ func restoredSessionTopicTitle(dir, sessionPath string, meta agent.BranchMeta) s
 		}
 	}
 	return ""
+}
+
+func storedSessionTopicTitle(dir, sessionPath string, meta agent.BranchMeta) string {
+	if title := topicTitleFromText(meta.TopicTitle); title != "" {
+		return title
+	}
+	return topicTitleFromText(loadSessionTitles(dir)[filepath.Base(sessionPath)])
 }
 
 func legacySessionTopicID(path string) string {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1260,6 +1260,20 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	tabID := a.newUniqueTabIDLocked()
 	topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
+
+	// Fallback: if the topic-title file has no entry for this topic, try to
+	// extract a title from the first session found in the session directory.
+	// This covers edge cases where the topic title source was saved under a
+	// different workspace root normalization, such as when switching between
+	// projects in single-surface (creation/workbench) mode.
+	if topicTitle == defaultTopicTitle && sessionPath != "" {
+		if t := topicTitleFromSession(sessionPath); t != "" {
+			topicTitle = t
+			// Persist it back so the topic-titles file is consistent.
+			_ = setTopicTitleWithSource(workspaceRoot, topicID, t, topicTitleSourceAuto)
+		}
+	}
+
 	if sessionPath == "" {
 		var err error
 		sessionPath, err = createEmptySessionFile(desktopSessionDir(actualRoot), "")

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1322,6 +1322,120 @@ func TestRenameTopicRecreatesDeletedProjectTitleIndexFromSessionMeta(t *testing.
 	}
 }
 
+func TestOpenProjectTabRecoversMissingTopicTitleFromSessionMeta(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := robustTempDir(t)
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "旧标题")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeTopicSessionWithPrompt(t, dir, "stored-meta.jsonl", topic.ID, "用户保存标题", projectRoot, "first prompt should not win", time.Now())
+	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
+		t.Fatalf("remove topic titles: %v", err)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("precondition title source = %q, want manual", got)
+	}
+
+	meta, err := app.OpenProjectTab(projectRoot, topic.ID)
+	if err != nil {
+		t.Fatalf("open project tab: %v", err)
+	}
+	tab := waitForTabReady(t, app, meta.ID)
+	if got := filepath.Clean(tab.Ctrl.SessionPath()); got != filepath.Clean(sessionPath) {
+		t.Fatalf("opened session path = %q, want %q", got, sessionPath)
+	}
+	if got := meta.TopicTitle; got != "用户保存标题" {
+		t.Fatalf("opened topic title = %q, want 用户保存标题", got)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != "用户保存标题" {
+		t.Fatalf("stored topic title = %q, want 用户保存标题", got)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("title source = %q, want manual", got)
+	}
+}
+
+func TestOpenProjectTabRecoversMissingTopicTitleFromSessionTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := robustTempDir(t)
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "旧标题")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeTopicSessionWithPrompt(t, dir, "stored-session-title.jsonl", topic.ID, "", projectRoot, "first prompt should not win", time.Now())
+	if err := setSessionTitle(dir, sessionPath, "历史手动标题"); err != nil {
+		t.Fatalf("set session title: %v", err)
+	}
+	if err := os.Remove(topicTitlesPath(projectRoot)); err != nil {
+		t.Fatalf("remove topic titles: %v", err)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("precondition title source = %q, want manual", got)
+	}
+
+	meta, err := app.OpenProjectTab(projectRoot, topic.ID)
+	if err != nil {
+		t.Fatalf("open project tab: %v", err)
+	}
+	waitForTabReady(t, app, meta.ID)
+	if got := meta.TopicTitle; got != "历史手动标题" {
+		t.Fatalf("opened topic title = %q, want 历史手动标题", got)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != "历史手动标题" {
+		t.Fatalf("stored topic title = %q, want 历史手动标题", got)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("title source = %q, want manual", got)
+	}
+}
+
+func TestOpenProjectTabPreservesManualDefaultTopicTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := robustTempDir(t)
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := app.RenameTopic(topic.ID, defaultTopicTitle); err != nil {
+		t.Fatalf("rename topic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	writeTopicSessionWithPrompt(t, dir, "manual-default.jsonl", topic.ID, defaultTopicTitle, projectRoot, "first prompt should not replace manual default", time.Now())
+
+	meta, err := app.OpenProjectTab(projectRoot, topic.ID)
+	if err != nil {
+		t.Fatalf("open project tab: %v", err)
+	}
+	waitForTabReady(t, app, meta.ID)
+	if got := meta.TopicTitle; got != defaultTopicTitle {
+		t.Fatalf("opened topic title = %q, want %q", got, defaultTopicTitle)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != defaultTopicTitle {
+		t.Fatalf("stored topic title = %q, want %q", got, defaultTopicTitle)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("title source = %q, want manual", got)
+	}
+}
+
 func TestEnsureTopicIndexedPreservesGlobalAutoTitleSource(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -234,7 +234,13 @@ func (c *client) streamWithReconnect(ctx context.Context, resp *http.Response, n
 			return
 		}
 		if !provider.IsConnReset(err) {
-			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
+			// Use a fresh context for the final error chunk: the caller's ctx
+			// may already be cancelled (e.g. TestStreamCancelDoesNotReconnect),
+			// and sendChunk's second select would race <-ctx.Done() against the
+			// channel send, dropping the message ~50% of the time.  The output
+			// channel is unbuffered-when-full but has cap 1 and the reader is
+			// waiting, so background context is safe.
+			sendChunk(context.Background(), out, provider.Chunk{Type: provider.ChunkError, Err: err})
 			return
 		}
 		if emitted {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -234,13 +234,7 @@ func (c *client) streamWithReconnect(ctx context.Context, resp *http.Response, n
 			return
 		}
 		if !provider.IsConnReset(err) {
-			// Use a fresh context for the final error chunk: the caller's ctx
-			// may already be cancelled (e.g. TestStreamCancelDoesNotReconnect),
-			// and sendChunk's second select would race <-ctx.Done() against the
-			// channel send, dropping the message ~50% of the time.  The output
-			// channel is unbuffered-when-full but has cap 1 and the reader is
-			// waiting, so background context is safe.
-			sendChunk(context.Background(), out, provider.Chunk{Type: provider.ChunkError, Err: err})
+			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
 			return
 		}
 		if emitted {


### PR DESCRIPTION
## 修复内容

Fixes #5438

在创作模式（单表面布局）下切换项目时，`keepOnlyVisibleTab` 会移除先前可见 tab；切换回来重新打开 topic 时，如果 `desktop-topic-titles.json` 缺少该 topic 的标题条目，标题会退回默认的 `新的会话`。

### 变更说明

- 在 `openTopicTabWithActivation` 的 topic 打开路径中改用受保护的 fallback：
  - 已有手动 topic 标题不会被自动标题覆盖，即使手动标题文本正好是 `新的会话`
  - topic title index 缺失时，优先从 session `.jsonl.meta` 的 `BranchMeta.TopicTitle` 恢复
  - 如果 desktop session title sidecar 中有用户手动会话标题，也优先恢复
  - 只有恢复不到已保存标题且 source 允许自动标题时，才从首条 user message 生成 fallback
- 移除了本 PR 中混入的 OpenAI stream cancel 改动，使最终 diff 聚焦 #5438。
- 新增回归测试覆盖 session meta 恢复、desktop session title sidecar 恢复、手动默认标题保护。

### 验证

- `cd desktop && go test . -run 'TestOpenProjectTab(RecoversMissingTopicTitleFromSessionMeta|RecoversMissingTopicTitleFromSessionTitle|PreservesManualDefaultTopicTitle)$'`
- `cd desktop && go test ./...`
- `go test ./internal/provider/openai/...`
- `git diff --check`

---
Cache-impact: low - desktop topic title persistence/recovery only; no prompt, tool schema, provider request serialization, compaction, or reasoning upload changes.
Cache-guard: not required for provider-visible cache shape; covered by desktop regression tests above.
