### PR TITLE
fix(acp): send available_commands_update after session/new response

### DIFF
--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -20,6 +20,13 @@ const maxMessageBytes = 32 << 20 // 32 MiB
 // *RPCError; any other error becomes ErrInternal.
 type RequestHandler func(ctx context.Context, params json.RawMessage) (any, error)
 
+// responseWithAfter lets a request handler schedule work that must run only
+// after the JSON-RPC response has been written to the wire.
+type responseWithAfter interface {
+	Response() any
+	AfterResponse()
+}
+
 // NotificationHandler reacts to an inbound notification. It cannot reply, so it
 // returns nothing — errors have nowhere to go on the wire (stderr would corrupt
 // stdout, which is the JSON-RPC channel).
@@ -238,12 +245,20 @@ func (c *Conn) serveRequest(ctx context.Context, id json.RawMessage, method stri
 		c.writeError(id, code, err.Error())
 		return
 	}
+	var after func()
+	if r, ok := result.(responseWithAfter); ok {
+		result = r.Response()
+		after = r.AfterResponse
+	}
 	raw, err := json.Marshal(result)
 	if err != nil {
 		c.writeError(id, ErrInternal, "marshal result: "+err.Error())
 		return
 	}
 	_ = c.write(outbound{JSONRPC: "2.0", ID: id, Result: raw})
+	if after != nil {
+		after()
+	}
 }
 
 // resolve delivers a response to the goroutine waiting on its outbound request.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1454,5 +1455,39 @@ func TestServeUnknownMethod(t *testing.T) {
 	}
 	if resp.Error.Code != ErrMethodNotFound {
 		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrMethodNotFound)
+	}
+}
+
+func TestServeRequestRunsAfterResponseHookAfterWritingResult(t *testing.T) {
+	var buf bytes.Buffer
+	conn := NewConn(strings.NewReader(""), &buf)
+	conn.Handle("test/hook", func(context.Context, json.RawMessage) (any, error) {
+		return afterResponse{
+			result: map[string]string{"ok": "yes"},
+			after: func() {
+				_ = conn.Notify("test/notification", map[string]string{"after": "yes"})
+			},
+		}, nil
+	})
+
+	conn.serveRequest(context.Background(), json.RawMessage("1"), "test/hook", nil)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("wrote %d frames, want 2: %q", len(lines), buf.String())
+	}
+	var response frame
+	if err := json.Unmarshal([]byte(lines[0]), &response); err != nil {
+		t.Fatalf("response frame: %v", err)
+	}
+	if response.ID == nil || response.Method != "" {
+		t.Fatalf("first frame = %+v, want response", response)
+	}
+	var notification frame
+	if err := json.Unmarshal([]byte(lines[1]), &notification); err != nil {
+		t.Fatalf("notification frame: %v", err)
+	}
+	if notification.Method != "test/notification" || notification.ID != nil {
+		t.Fatalf("second frame = %+v, want notification", notification)
 	}
 }

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -170,6 +170,22 @@ type acpSession struct {
 	deleted bool
 }
 
+// afterResponse wraps a result with deferred work that runs after the
+// JSON-RPC response is written — this keeps ACP notifications (e.g.
+// available_commands_update) strictly after their matching response.
+type afterResponse struct {
+	result any
+	after  func()
+}
+
+func (r afterResponse) Response() any { return r.result }
+
+func (r afterResponse) AfterResponse() {
+	if r.after != nil {
+		r.after()
+	}
+}
+
 func (s *acpSession) begin(ctx context.Context) (context.Context, context.CancelFunc, bool) {
 	runCtx, cancel := context.WithCancel(ctx)
 	s.mu.Lock()
@@ -348,12 +364,13 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	s.mu.Lock()
 	s.sessions[id] = sess
 	s.mu.Unlock()
-	s.sendAvailableCommands(sess)
-
-	return SessionNewResult{
-		SessionID:     id,
-		Models:        cfgState.Models,
-		ConfigOptions: cfgState.ConfigOptions,
+	return afterResponse{
+		result: SessionNewResult{
+			SessionID:     id,
+			Models:        cfgState.Models,
+			ConfigOptions: cfgState.ConfigOptions,
+		},
+		after: func() { s.sendAvailableCommands(sess) },
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

sessionNew was calling `sendAvailableCommands` synchronously before returning the `SessionNewResult`, causing the `session/update` notification to reach the client before the `session/new` response. Per the [ACP spec on slash commands](https://agentclientprotocol.com/protocol/v1/slash-commands), `available_commands_update` MAY be sent 'after creating a session' — i.e. after the `session/new` response.

This broke slash commands in Zed because the client received the notification before the session was fully created and discarded it. Users would see "Available commands for reasonix: none" when typing `/explore`, `/skill`, etc.

## Fix

Introduced a `responseWithAfter` interface in `server.go` so request handlers can defer work until after the JSON-RPC response is written to the wire. `sessionNew` now returns an `afterResponse` whose `AfterResponse` hook calls `sendAvailableCommands`.

Also added `TestServeRequestRunsAfterResponseHookAfterWritingResult` verifying wire-level ordering.

### Before (wrong order)
```
Line  37: ← session/update (available_commands_update)  ← notification first!
Line 512: ← session/new response (sessionId + models)    ← response after
```

### After (correct order, matching Codex ACP behavior)
```
Line N:   ← session/new response (sessionId + models)    ← response first ✓
Line N+1: ← session/update (available_commands_update)   ← notification after ✓
```

Closes #5483