### PR TITLE
fix(memorycompiler): filter tool_result evidence from user-facing citations (#5468)

### DIFF
--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -721,6 +721,9 @@ func memoryCitationsForIR(ir PlannerIR) []provider.MemoryCitation {
 		out = append(out, c)
 	}
 	for _, ref := range ir.MemoryReferences {
+		if ref.Influence == "evidence" {
+			continue // tool_result nodes are internal graph state, not user-facing
+		}
 		note := ref.Content
 		if ref.Influence != "" {
 			note = ref.Influence + ": " + note

--- a/internal/memorycompiler/runtime_test.go
+++ b/internal/memorycompiler/runtime_test.go
@@ -127,6 +127,42 @@ func TestStartTurnExposesMemoryCitations(t *testing.T) {
 	}
 }
 
+func TestMemoryCitationsHideEvidenceReferences(t *testing.T) {
+	citations := memoryCitationsForIR(PlannerIR{
+		Version:     version,
+		Goal:        "fix a bug",
+		SourceEvent: "fix a bug",
+		MemoryReferences: []MemoryRef{
+			{ID: "tool-1", Content: "bash succeeded", Quality: string(QualityHighSignal), Influence: "evidence"},
+			{ID: "mem-1", Content: "prefer focused tests", Quality: string(QualityHighSignal), Influence: "reference"},
+		},
+		Constraints: []Constraint{{Type: "avoid", Text: "repeat failed command", Source: "constraint-1"}},
+		RiskNotes:   []string{"verify before final answer"},
+	})
+
+	if len(citations) == 0 {
+		t.Fatal("expected non-evidence compiler citations to remain visible")
+	}
+	for _, c := range citations {
+		if strings.Contains(c.Note, "bash succeeded") || strings.Contains(c.Note, "evidence:") {
+			t.Fatalf("tool-result evidence citation leaked into user-facing citations: %+v", c)
+		}
+	}
+	foundReference := false
+	foundConstraint := false
+	for _, c := range citations {
+		if strings.Contains(c.Note, "reference: prefer focused tests") {
+			foundReference = true
+		}
+		if strings.Contains(c.Note, "avoid: repeat failed command") {
+			foundConstraint = true
+		}
+	}
+	if !foundReference || !foundConstraint {
+		t.Fatalf("expected reference and constraint citations to remain, got %+v", citations)
+	}
+}
+
 func TestStrategyPreconditionShortTokenMatchesOnWordBoundary(t *testing.T) {
 	// "ui" must match the real frontend keyword but not arbitrary substrings —
 	// otherwise the synthetic "Continue pursuing the active goal." turn (and any


### PR DESCRIPTION
## 修复内容

修复 #5468 — Memory v5 编译器的 tool result 证据（evidence: bash succeeded 等）每轮对话都出现在用户界面，挤占对话名称显示空间。

### 变更说明

在 memoryCitationsForIR 中过滤 Influence == evidence 的内存引用（即 tool_result 节点）。这些节点是工具执行状态的内部记录（如 bash succeeded），对用户无信息价值。内存图仍会记录 tool result 用于模型学习和约束生成，仅用户可见的引用展示被过滤。

### 验证
- go test ./internal/memorycompiler/... — 28 tests 全部通过
- go test ./internal/agent/... — 相关测试通过
- 最小改动：1 个文件，+3 行