### PR TITLE
fix(desktop): avoid background close without tray restore

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -391,11 +391,57 @@ func (a *App) beforeClose(ctx context.Context) bool {
 	return false
 }
 
+const backgroundCloseTrayReadyTimeout = 500 * time.Millisecond
+
 func (a *App) backgroundCloseHasRestorePath() bool {
 	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
-		return backgroundCloseHasRestorePathFor(goruntime.GOOS, false)
+		return backgroundCloseHasRestorePathFor(goruntime.GOOS, false, false)
 	}
-	return backgroundCloseHasRestorePathFor(goruntime.GOOS, a.startTray())
+	if !a.startTray() {
+		return false
+	}
+	return backgroundCloseHasRestorePathFor(goruntime.GOOS, true, a.waitForTrayReady(backgroundCloseTrayReadyTimeout))
+}
+
+func (a *App) waitForTrayReady(timeout time.Duration) bool {
+	if a.isTrayReady() {
+		return true
+	}
+	ready := a.trayReadySignal()
+	if ready == nil {
+		return false
+	}
+	if timeout <= 0 {
+		select {
+		case <-ready:
+			return a.isTrayReady()
+		default:
+			return false
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ready:
+		return a.isTrayReady()
+	case <-timer.C:
+		return a.isTrayReady()
+	}
+}
+
+func (a *App) isTrayReady() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.trayReady
+}
+
+func (a *App) trayReadySignal() <-chan struct{} {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.tray == nil {
+		return nil
+	}
+	return a.tray.ready
 }
 
 func (a *App) showMainWindow() {
@@ -442,8 +488,8 @@ func backgroundCloseUsesApplicationHide(goos string) bool {
 	return goos == "darwin"
 }
 
-func backgroundCloseHasRestorePathFor(goos string, trayStarted bool) bool {
-	return backgroundCloseUsesApplicationHide(goos) || trayStarted
+func backgroundCloseHasRestorePathFor(goos string, trayStarted, trayReady bool) bool {
+	return backgroundCloseUsesApplicationHide(goos) || (trayStarted && trayReady)
 }
 
 type backgroundRestorePlan struct {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -379,6 +379,9 @@ func (a *App) beforeClose(ctx context.Context) bool {
 		cfg = config.LoadForEdit(config.UserConfigPath())
 	}
 	if cfg.DesktopCloseBehavior() == "background" {
+		if !a.backgroundCloseHasRestorePath() {
+			return false
+		}
 		a.backgroundMaximised.Store(runtime.WindowIsMaximised(ctx))
 		a.saveWindowStateSync()
 		a.snapshotAllTabs()
@@ -386,6 +389,13 @@ func (a *App) beforeClose(ctx context.Context) bool {
 		return true
 	}
 	return false
+}
+
+func (a *App) backgroundCloseHasRestorePath() bool {
+	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
+		return backgroundCloseHasRestorePathFor(goruntime.GOOS, false)
+	}
+	return backgroundCloseHasRestorePathFor(goruntime.GOOS, a.startTray())
 }
 
 func (a *App) showMainWindow() {
@@ -430,6 +440,10 @@ func showFromBackground(ctx context.Context, wasMaximised bool) {
 
 func backgroundCloseUsesApplicationHide(goos string) bool {
 	return goos == "darwin"
+}
+
+func backgroundCloseHasRestorePathFor(goos string, trayStarted bool) bool {
+	return backgroundCloseUsesApplicationHide(goos) || trayStarted
 }
 
 type backgroundRestorePlan struct {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -475,20 +475,74 @@ func TestBackgroundCloseRequiresRestorePath(t *testing.T) {
 		name        string
 		goos        string
 		trayStarted bool
+		trayReady   bool
 		want        bool
 	}{
-		{name: "macOS restores from Dock", goos: "darwin", trayStarted: false, want: true},
-		{name: "Windows tray ready", goos: "windows", trayStarted: true, want: true},
-		{name: "Linux tray ready", goos: "linux", trayStarted: true, want: true},
-		{name: "Linux no tray", goos: "linux", trayStarted: false, want: false},
-		{name: "other Unix no tray", goos: "freebsd", trayStarted: false, want: false},
+		{name: "macOS restores from Dock", goos: "darwin", trayStarted: false, trayReady: false, want: true},
+		{name: "Windows tray ready", goos: "windows", trayStarted: true, trayReady: true, want: true},
+		{name: "Windows tray started but not ready", goos: "windows", trayStarted: true, trayReady: false, want: false},
+		{name: "Linux tray ready", goos: "linux", trayStarted: true, trayReady: true, want: true},
+		{name: "Linux tray started but not ready", goos: "linux", trayStarted: true, trayReady: false, want: false},
+		{name: "Linux no tray", goos: "linux", trayStarted: false, trayReady: false, want: false},
+		{name: "other Unix no tray", goos: "freebsd", trayStarted: false, trayReady: false, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := backgroundCloseHasRestorePathFor(tt.goos, tt.trayStarted); got != tt.want {
-				t.Fatalf("backgroundCloseHasRestorePathFor(%q, %v) = %v, want %v", tt.goos, tt.trayStarted, got, tt.want)
+			if got := backgroundCloseHasRestorePathFor(tt.goos, tt.trayStarted, tt.trayReady); got != tt.want {
+				t.Fatalf("backgroundCloseHasRestorePathFor(%q, %v, %v) = %v, want %v", tt.goos, tt.trayStarted, tt.trayReady, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBackgroundCloseReadySignalRequiresCurrentReadyState(t *testing.T) {
+	app := NewApp()
+	tray := newDesktopTray()
+	app.mu.Lock()
+	app.tray = tray
+	app.mu.Unlock()
+
+	if app.waitForTrayReady(0) {
+		t.Fatal("tray should not be ready before its ready signal")
+	}
+
+	tray.markReady()
+	if app.waitForTrayReady(0) {
+		t.Fatal("closed ready signal should not count without the current ready state")
+	}
+
+	app.mu.Lock()
+	app.trayReady = true
+	app.mu.Unlock()
+	if !app.waitForTrayReady(0) {
+		t.Fatal("ready state should be accepted after the tray is marked ready")
+	}
+
+	app.mu.Lock()
+	app.trayReady = false
+	app.mu.Unlock()
+	if app.waitForTrayReady(0) {
+		t.Fatal("stale ready signal should not count after the tray exits")
+	}
+}
+
+func TestBackgroundCloseWaitsForTrayReadySignal(t *testing.T) {
+	app := NewApp()
+	tray := newDesktopTray()
+	app.mu.Lock()
+	app.tray = tray
+	app.mu.Unlock()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		app.mu.Lock()
+		app.trayReady = true
+		app.mu.Unlock()
+		tray.markReady()
+	}()
+
+	if !app.waitForTrayReady(200 * time.Millisecond) {
+		t.Fatal("waitForTrayReady should observe the tray becoming ready")
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -470,6 +470,28 @@ func TestBackgroundCloseHideStrategyByPlatform(t *testing.T) {
 	}
 }
 
+func TestBackgroundCloseRequiresRestorePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		trayStarted bool
+		want        bool
+	}{
+		{name: "macOS restores from Dock", goos: "darwin", trayStarted: false, want: true},
+		{name: "Windows tray ready", goos: "windows", trayStarted: true, want: true},
+		{name: "Linux tray ready", goos: "linux", trayStarted: true, want: true},
+		{name: "Linux no tray", goos: "linux", trayStarted: false, want: false},
+		{name: "other Unix no tray", goos: "freebsd", trayStarted: false, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backgroundCloseHasRestorePathFor(tt.goos, tt.trayStarted); got != tt.want {
+				t.Fatalf("backgroundCloseHasRestorePathFor(%q, %v) = %v, want %v", tt.goos, tt.trayStarted, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBackgroundRestoreMaximiseStrategy(t *testing.T) {
 	tests := []struct {
 		goos      string

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -13,14 +13,14 @@ type desktopTray struct {
 	once     sync.Once
 }
 
-func (a *App) startTray() {
+func (a *App) startTray() bool {
 	if !traySupported() {
-		return
+		return false
 	}
 	a.mu.Lock()
 	if a.tray != nil {
 		a.mu.Unlock()
-		return
+		return true
 	}
 	t := &desktopTray{}
 	a.tray = t
@@ -61,6 +61,7 @@ func (a *App) startTray() {
 		a.trayReady = false
 		a.mu.Unlock()
 	})
+	return true
 }
 
 func (a *App) stopTray() {

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -7,10 +7,22 @@ import (
 )
 
 type desktopTray struct {
-	end      func()
-	openItem *systray.MenuItem
-	quitItem *systray.MenuItem
-	once     sync.Once
+	end       func()
+	openItem  *systray.MenuItem
+	quitItem  *systray.MenuItem
+	once      sync.Once
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func newDesktopTray() *desktopTray {
+	return &desktopTray{ready: make(chan struct{})}
+}
+
+func (t *desktopTray) markReady() {
+	t.readyOnce.Do(func() {
+		close(t.ready)
+	})
 }
 
 func (a *App) startTray() bool {
@@ -22,7 +34,7 @@ func (a *App) startTray() bool {
 		a.mu.Unlock()
 		return true
 	}
-	t := &desktopTray{}
+	t := newDesktopTray()
 	a.tray = t
 	a.mu.Unlock()
 
@@ -45,6 +57,7 @@ func (a *App) startTray() bool {
 		a.mu.Lock()
 		a.trayReady = true
 		a.mu.Unlock()
+		t.markReady()
 
 		a.goSafe("trayOpenLoop", func() {
 			for range t.openItem.ClickedCh {
@@ -58,7 +71,10 @@ func (a *App) startTray() bool {
 		})
 	}, func() {
 		a.mu.Lock()
-		a.trayReady = false
+		if a.tray == t {
+			a.trayReady = false
+			a.tray = nil
+		}
 		a.mu.Unlock()
 	})
 	return true


### PR DESCRIPTION
## Summary

- Code-confirmed #5492 as a desktop close-to-background path that could hide the window even when no tray restore path was available.
- Re-check/start the tray before background close on platforms that need it; if tray support is unavailable, allow the close to quit instead of leaving an unreachable background process.
- Added focused regression coverage for platform restore-path decisions.
- Closes #5492.

## Verification

- `cd desktop && go test . -run 'Test(BeforeClose|BackgroundClose|TrayMenuLabels)' -count=1`
- `gofmt -l desktop/app.go desktop/app_test.go desktop/tray.go`
- `git diff --check`

## Cache impact

Cache-impact: none; desktop window/tray lifecycle only.
Cache-guard: `cd desktop && go test . -run 'Test(BeforeClose|BackgroundClose|TrayMenuLabels)' -count=1`
System-prompt-review: N/A
