### PR TITLE
feat(desktop): add collapsible topic bar and compact composer

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import {
   Brain,
   Cpu,
   Palette,
+  ChevronDown,
 } from "lucide-react";
 import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
@@ -121,6 +122,7 @@ import {
   saveRightDockTreeWidth,
   saveSidebarCollapsed,
   saveSidebarWidth,
+  saveTopicbarCollapsed,
   useLayoutStore,
 } from "./store/layout";
 import { useOverlayStore } from "./store/overlays";
@@ -871,6 +873,8 @@ export default function App() {
   const [sidebarImDetailConnectionId, setSidebarImDetailConnectionId] = useState("");
   const sidebarCollapsed = useLayoutStore((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useLayoutStore((s) => s.setSidebarCollapsed);
+  const topicbarCollapsed = useLayoutStore((s) => s.topicbarCollapsed);
+  const setTopicbarCollapsed = useLayoutStore((s) => s.setTopicbarCollapsed);
   const heartbeatOpen = useOverlayStore((s) => s.heartbeatOpen);
   const setHeartbeatOpen = useOverlayStore((s) => s.setHeartbeatOpen);
   type TimeFilter = "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
@@ -1754,6 +1758,12 @@ export default function App() {
     setSidebarCollapsed(nextCollapsed);
     saveSidebarCollapsed(nextCollapsed);
   }, [anchorAppScrollToChat, closeTransientOverlays, pulseSidebarToggle, sidebarCollapsed]);
+
+  const toggleTopicbarCollapsed = useCallback(() => {
+    const next = !topicbarCollapsed;
+    setTopicbarCollapsed(next);
+    saveTopicbarCollapsed(next);
+  }, [topicbarCollapsed]);
 
   const sidebarWidthClamp = desktopLayoutStyle === "creation" ? clampCreationSidebarWidth : clampSidebarWidth;
   const sidebarRenderWidth = liveSidebarWidth ?? sidebarWidth;
@@ -3023,7 +3033,7 @@ export default function App() {
 
         <section className={`chat-pane${sidebarCreation && !sessionHasContent ? " chat-pane--creation-empty" : ""}`}>
           <>
-          <header className="topicbar">
+          <header className={`topicbar${topicbarCollapsed ? " topicbar--collapsed" : ""}`}>
             {workbenchChromeHidden && (
               <Tooltip label={sidebarToggleTitle}>
                 <button
@@ -3106,6 +3116,16 @@ export default function App() {
               )}
             </div>
             <div className="topicbar__spacer" />
+            <Tooltip label={topicbarCollapsed ? t("topicBar.expand") : t("topicBar.collapse")}>
+              <button
+                className={`topicbar__collapse-btn${topicbarCollapsed ? " topicbar__collapse-btn--collapsed" : ""}`}
+                type="button"
+                onClick={toggleTopicbarCollapsed}
+                aria-label={topicbarCollapsed ? t("topicBar.expand") : t("topicBar.collapse")}
+              >
+                <ChevronDown size={14} />
+              </button>
+            </Tooltip>
             <div className="topicbar__actions">
               {workbenchChromeHidden && (
                 <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -48,7 +48,7 @@ export interface WorkspaceReference {
 
 const LONG_PASTE_MIN_CHARS = 2000;
 const LONG_PASTE_MIN_LINES = 20;
-const COMPOSER_MIN_HEIGHT = 104;
+const COMPOSER_MIN_HEIGHT = 64;
 const COMPOSER_MAX_HEIGHT = 360;
 const COMPOSER_MAX_VIEWPORT_RATIO = 0.4;
 const COMPOSER_AUTO_RESERVED_HEIGHT = 58;
@@ -1412,7 +1412,8 @@ export function Composer({
   }, []);
 
   const measureTextareaAutoHeight = useCallback(() => {
-    if (composerHeight !== null) {
+    // Fixed at a size above minimum → lock, no auto-growth.
+    if (composerHeight !== null && composerHeight > COMPOSER_MIN_HEIGHT) {
       setTextareaAutoHeight(null);
       setTextareaAutoOverflow(false);
       return;
@@ -1425,8 +1426,21 @@ export function Composer({
     const nextHeight = Math.min(node.scrollHeight, maxHeight);
     const nextOverflow = node.scrollHeight > maxHeight + 1;
     node.style.height = previousHeight;
-    setTextareaAutoHeight((current) => (current === nextHeight ? current : nextHeight));
-    setTextareaAutoOverflow((current) => (current === nextOverflow ? current : nextOverflow));
+
+    if (composerHeight === null) {
+      // Pure auto mode: the textarea floats freely via textareaAutoHeight.
+      setTextareaAutoHeight((current) => (current === nextHeight ? current : nextHeight));
+      setTextareaAutoOverflow((current) => (current === nextOverflow ? current : nextOverflow));
+    } else {
+      // Dragged to minimum height: grow the card to match content.
+      const cardEl = composerCardRef.current;
+      if (!cardEl) return;
+      const currentCardHeight = cardEl.getBoundingClientRect().height;
+      const currentTextareaHeight = node.getBoundingClientRect().height;
+      const chromeHeight = currentCardHeight - currentTextareaHeight;
+      const newCardHeight = Math.max(COMPOSER_MIN_HEIGHT, Math.min(nextHeight + chromeHeight, composerMaxHeight()));
+      setComposerHeight((current) => (current === newCardHeight ? current : newCardHeight));
+    }
   }, [composerHeight]);
 
   useLayoutEffect(() => {
@@ -1434,7 +1448,7 @@ export function Composer({
   }, [text, measureTextareaAutoHeight]);
 
   useEffect(() => {
-    if (composerHeight !== null) return;
+    if (composerHeight !== null && composerHeight > COMPOSER_MIN_HEIGHT) return;
     let frame = 0;
     const update = () => {
       if (frame) window.cancelAnimationFrame(frame);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -151,6 +151,8 @@ export const en = {
   "topicBar.exportJson": "Export JSON",
   "topicBar.exportPdf": "Export PDF",
   "topicBar.exportImage": "Export Image",
+  "topicBar.collapse": "Collapse topic bar",
+  "topicBar.expand": "Expand topic bar",
 
   // scope labels
   "scope.global": "Scope: Global",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1201,6 +1201,8 @@ export const zhTW: Record<DictKey, string> = {
   "topicBar.command": "命令",
   "topicBar.exportPdf": "匯出 PDF",
   "topicBar.exportImage": "匯出圖片",
+  "topicBar.collapse": "收起標題欄",
+  "topicBar.expand": "展開標題欄",
   "workspace.filterReferencedFiles": "篩選依賴檔案…",
   "workspace.clearFileScope": "顯示完整檔案樹",
   "workspace.clearChangeScope": "顯示全部改動",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -152,6 +152,8 @@ export const zh: Record<DictKey, string> = {
   "topicBar.exportJson": "导出 JSON",
   "topicBar.exportPdf": "导出 PDF",
   "topicBar.exportImage": "导出图片",
+  "topicBar.collapse": "收起标题栏",
+  "topicBar.expand": "展开标题栏",
 
   // 范围标签
   "scope.global": "范围：全局",

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -19,6 +19,7 @@ import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { applySetState } from "./setState";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
+const TOPICBAR_COLLAPSED_KEY = "reasonix.topicbar.collapsed";
 const SIDEBAR_DEFAULT_WIDTH = 264;
 export const SIDEBAR_MIN_WIDTH = 264;
 export const CREATION_SIDEBAR_MIN_WIDTH = 236;
@@ -83,6 +84,24 @@ export function saveSidebarCollapsed(collapsed: boolean): void {
   }
 }
 
+function loadTopicbarCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(TOPICBAR_COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveTopicbarCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TOPICBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
 function loadSidebarWidth(): number {
   return loadLayoutSize("sidebarWidthGraphite", defaultSidebarWidth(), clampStoredSidebarWidth);
 }
@@ -119,6 +138,7 @@ export type RightDockMode = "context" | "files" | "changed";
 export type LayoutState = {
   sidebarCollapsed: boolean;
   sidebarWidth: number;
+  topicbarCollapsed: boolean;
   rightDockTreeWidth: number;
   rightDockPreviewWidth: number;
   workspacePanelOpen: boolean;
@@ -127,6 +147,7 @@ export type LayoutState = {
   rightDockMode: RightDockMode;
   setSidebarCollapsed: (collapsed: boolean) => void;
   setSidebarWidth: (width: number) => void;
+  setTopicbarCollapsed: (collapsed: boolean) => void;
   setRightDockTreeWidth: (width: number) => void;
   setRightDockPreviewWidth: (width: number) => void;
   setWorkspacePanelOpen: Dispatch<SetStateAction<boolean>>;
@@ -138,6 +159,7 @@ export type LayoutState = {
 export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarCollapsed: loadSidebarCollapsed(),
   sidebarWidth: loadSidebarWidth(),
+  topicbarCollapsed: loadTopicbarCollapsed(),
   rightDockTreeWidth: loadRightDockTreeWidth(),
   rightDockPreviewWidth: loadRightDockPreviewWidth(),
   workspacePanelOpen: WORKSPACE_PANEL_DEFAULT_OPEN,
@@ -146,6 +168,7 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   rightDockMode: "context",
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
+  setTopicbarCollapsed: (collapsed) => set({ topicbarCollapsed: collapsed }),
   setRightDockTreeWidth: (width) => set({ rightDockTreeWidth: width }),
   setRightDockPreviewWidth: (width) => set({ rightDockPreviewWidth: width }),
   setWorkspacePanelOpen: (update) => set((s) => ({ workspacePanelOpen: applySetState(s.workspacePanelOpen, update) })),

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4888,7 +4888,7 @@ a[href] {
   flex: 0 0 auto;
   border-top: 1px solid var(--border-soft);
   background: var(--chat-bg);
-  padding: 12px 32px 10px;
+  padding: 8px 24px 6px;
 }
 
 /* ── undo-rewind banner (above composer after a rewind) ─────────────── */
@@ -5955,7 +5955,7 @@ a[href] {
 
 .statusbar {
   max-width: var(--maxw);
-  margin: 7px auto 0;
+  margin: 4px auto 0;
   display: flex;
   align-items: center;
   gap: 0;
@@ -16885,6 +16885,57 @@ a[href] {
 
 .topicbar__spacer {
   display: none;
+}
+
+/* ── topicbar collapse ──────────────────────────────────────────────────── */
+.topicbar--collapsed {
+  min-height: 30px;
+  padding: 2px 18px;
+  gap: 8px;
+  overflow: hidden;
+}
+.topicbar--collapsed .topicbar__title-row h1 {
+  font-size: 13px; /* smaller title when collapsed */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topicbar--collapsed .topicbar__title-row .topicbar__icon-btn {
+  display: none; /* hide rename pencil */
+}
+.topicbar--collapsed .topicbar__title-edit {
+  display: none; /* hide rename input */
+}
+.topicbar--collapsed .topicbar__title-button {
+  font-size: 13px;
+}
+.topicbar--collapsed .topicbar__subtitle {
+  display: none;
+}
+.topicbar--collapsed .topicbar__actions {
+  display: none;
+}
+.topicbar__collapse-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--fg-faint);
+  cursor: pointer;
+  --wails-draggable: no-drag;
+  transition: color 0.12s, background 0.12s, transform 0.16s ease;
+}
+.topicbar__collapse-btn:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg-faint) 10%, transparent);
+}
+.topicbar__collapse-btn--collapsed {
+  transform: rotate(-90deg);
 }
 
 .topicbar__actions {


### PR DESCRIPTION
## Summary

This PR adds a collapsible topic bar and improves the composer auto-height behavior for a more polished desktop experience.

### Changes

#### 1. Collapsible topic bar
- Adds a collapse/expand toggle button to the topic bar (chevron icon between spacer and action buttons)
- When collapsed: hides action buttons, subtitles, rename controls, and shrinks to 30px — freeing vertical space for the chat area
- Collapse state persists in localStorage via the Zustand layout store
- Smooth 160ms rotation animation on the chevron button
- Full i18n support: en ("Collapse topic bar" / "Expand topic bar"), zh ("收起标题栏" / "展开标题栏"), zh-TW ("收起標題欄" / "展開標題欄")

#### 2. Composer auto-height improvements
- Reduces minimum composer height from 104px to 64px for a more compact default
- When the composer is dragged to its minimum height, it now auto-grows to fit content (previously it would lock and clip)
- When explicitly resized above the minimum, the height stays locked as before

#### 3. CSS polish
- Tighter footer padding: `12px 32px 10px` → `8px 24px 6px`
- Reduced statusbar top margin: `7px` → `4px`
- More vertical space for chat content

### Files changed
| File | Change |
|------|--------|
| `store/layout.ts` | Add topicbar collapse state, load/save helpers |
| `App.tsx` | Wire collapse button, toggle handler, ChevronDown import |
| `styles.css` | Collapse states, button styles, footer/statusbar polish |
| `Composer.tsx` | Reduce min height, auto-grow at minimum |
| `en.ts`, `zh.ts`, `zh-TW.ts` | Collapse/expand translation keys |