### PR TITLE
Clean up bot session mappings on delete / 删除 Bot 会话时清理映射

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -32,6 +32,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/billing"
 	"reasonix/internal/boot"
+	"reasonix/internal/botruntime"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -1774,6 +1775,9 @@ func (a *App) DeleteSession(path string) error {
 		}
 	}
 	a.closeRemainingRemovedSessionRuntimesAfterDestroy(removed, closedRemoved)
+	if err := botruntime.ForgetAutoSessionMappingsForPath(sessionPath); err != nil {
+		slog.Warn("desktop: failed to clear auto bot session mapping", "err", err)
+	}
 	if fallback.needs {
 		fallback = a.sessionDeleteFallbackTarget(fallback)
 		if err := a.openFallbackRuntime(fallback); err != nil {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3208,6 +3208,52 @@ func TestListSessionsMarksAutoBotSessionAsChannel(t *testing.T) {
 	}
 }
 
+func TestDeleteSessionClearsAutoBotSessionMapping(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "bot-channel.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"from channel"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	other := filepath.Join(dir, "other-channel.jsonl")
+	cfg := config.Default()
+	cfg.Bot.Connections = []config.BotConnectionConfig{{
+		ID: "weixin-weixin", Provider: "weixin", Domain: "weixin", Label: "微信", Enabled: true, Status: "connected",
+		SessionMappings: []config.BotConnectionSessionMapping{
+			{RemoteID: "remove-auto", SessionID: "path:" + path, SessionSource: "auto"},
+			{RemoteID: "keep-explicit", SessionID: "path:" + path},
+			{RemoteID: "keep-other-auto", SessionID: "path:" + other, SessionSource: "auto"},
+		},
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "active.jsonl"), Label: "test"})
+	app.setTestCtrl(ctrl, "")
+	defer app.activeCtrl().Close()
+
+	if err := app.DeleteSession(path); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	got := config.LoadForEdit(config.UserConfigPath())
+	mappings := got.Bot.Connections[0].SessionMappings
+	if len(mappings) != 2 {
+		t.Fatalf("session mappings = %+v, want explicit and other auto mappings preserved", mappings)
+	}
+	for _, mapping := range mappings {
+		if mapping.RemoteID == "remove-auto" {
+			t.Fatalf("deleted session auto mapping was preserved: %+v", mappings)
+		}
+	}
+}
+
 func TestOpenChannelSessionForTabIsReadOnly(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/botruntime/runtime.go
+++ b/internal/botruntime/runtime.go
@@ -2,6 +2,7 @@ package botruntime
 
 import (
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -334,6 +335,45 @@ func RememberInboundSessionWorkspace(msg bot.InboundMessage, sessionID string, w
 	return rememberInbound(msg, strings.TrimSpace(sessionID), strings.TrimSpace(workspaceRoot))
 }
 
+func ForgetAutoSessionMappingsForPath(sessionPath string) error {
+	target := normalizedBotSessionPath(sessionPath)
+	if target == "" {
+		return nil
+	}
+	userPath := config.UserConfigPath()
+	if strings.TrimSpace(userPath) == "" {
+		return nil
+	}
+	rememberPersistMu.Lock()
+	defer rememberPersistMu.Unlock()
+
+	cfg := config.LoadForEdit(userPath)
+	now := time.Now().UTC().Format(time.RFC3339)
+	changed := false
+	for i := range cfg.Bot.Connections {
+		conn := &cfg.Bot.Connections[i]
+		next := conn.SessionMappings[:0]
+		removed := false
+		for _, mapping := range conn.SessionMappings {
+			if strings.TrimSpace(mapping.SessionSource) == "auto" && normalizedBotSessionPath(mapping.SessionID) == target {
+				removed = true
+				continue
+			}
+			next = append(next, mapping)
+		}
+		if !removed {
+			continue
+		}
+		conn.SessionMappings = next
+		conn.UpdatedAt = now
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return cfg.SaveTo(userPath)
+}
+
 func rememberInbound(msg bot.InboundMessage, sessionID string, actualWorkspaceRoot string) error {
 	userPath := config.UserConfigPath()
 	platform := msg.Platform
@@ -454,6 +494,23 @@ func botSessionSource(sessionID string) string {
 		return ""
 	}
 	return "auto"
+}
+
+func normalizedBotSessionPath(sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(sessionID), "path:") {
+		sessionID = strings.TrimSpace(sessionID[5:])
+	}
+	if sessionID == "" {
+		return ""
+	}
+	if !(strings.HasSuffix(sessionID, ".jsonl") || strings.Contains(sessionID, "/") || strings.Contains(sessionID, `\`) || strings.HasPrefix(sessionID, "~")) {
+		return ""
+	}
+	return filepath.Clean(sessionID)
 }
 
 func connectionMatchesInbound(conn config.BotConnectionConfig, msg bot.InboundMessage) bool {

--- a/internal/botruntime/runtime_test.go
+++ b/internal/botruntime/runtime_test.go
@@ -287,6 +287,48 @@ func TestRememberInboundSessionUpdatesAutoMappingTarget(t *testing.T) {
 	}
 }
 
+func TestForgetAutoSessionMappingsForPathRemovesOnlyAutoPathTargets(t *testing.T) {
+	isolateUserConfig(t)
+	target := filepath.Join(t.TempDir(), "bot-channel.jsonl")
+	other := filepath.Join(t.TempDir(), "other-channel.jsonl")
+	cfg := config.Default()
+	cfg.Bot.Connections = []config.BotConnectionConfig{{
+		ID: "weixin-weixin", Provider: "weixin", Domain: "weixin", Label: "微信", Enabled: true, Status: "connected",
+		SessionMappings: []config.BotConnectionSessionMapping{
+			{RemoteID: "remove-path-prefix", SessionID: "path:" + target, SessionSource: "auto"},
+			{RemoteID: "remove-raw-path", SessionID: target, SessionSource: "auto"},
+			{RemoteID: "keep-explicit-path", SessionID: "path:" + target},
+			{RemoteID: "keep-other-auto", SessionID: "path:" + other, SessionSource: "auto"},
+			{RemoteID: "keep-topic-auto", SessionID: "topic:bot-topic", SessionSource: "auto"},
+		},
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	if err := ForgetAutoSessionMappingsForPath(target); err != nil {
+		t.Fatalf("forget auto session mappings: %v", err)
+	}
+
+	got := config.LoadForEdit(config.UserConfigPath())
+	mappings := got.Bot.Connections[0].SessionMappings
+	if len(mappings) != 3 {
+		t.Fatalf("mappings = %+v, want three preserved mappings", mappings)
+	}
+	remotes := map[string]bool{}
+	for _, mapping := range mappings {
+		remotes[mapping.RemoteID] = true
+	}
+	for _, remote := range []string{"keep-explicit-path", "keep-other-auto", "keep-topic-auto"} {
+		if !remotes[remote] {
+			t.Fatalf("mapping %q was not preserved: %+v", remote, mappings)
+		}
+	}
+	if got.Bot.Connections[0].UpdatedAt == "" {
+		t.Fatalf("connection UpdatedAt was not refreshed")
+	}
+}
+
 func TestConnectionChannelConfigsPreserveToolApprovalMode(t *testing.T) {
 	connections := []config.BotConnectionConfig{
 		{ID: "feishu-feishu", Provider: "feishu", Domain: "feishu", Enabled: true, ToolApprovalMode: "auto"},


### PR DESCRIPTION
## Summary
- Remove auto-created bot session mappings when the corresponding desktop session is deleted.
- Preserve explicit/manual bot mappings while cleaning only `SessionSource == "auto"` path targets.
- Add regression coverage for botruntime cleanup and desktop `DeleteSession`.

Fixes #5155

## Cache Impact
- No provider request serialization, prompt-prefix, tool schema, or compaction behavior changes.

## Verification
- `go test ./internal/botruntime`
- `go test .` from the `desktop` module
