### PR TITLE
fix(desktop): replace hardcoded Chinese strings with i18n keys in Composer

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -2011,11 +2011,11 @@ export function Composer({
           <div className="slashmenu" role="listbox">
             {loadingPastChats ? (
               <div className="slashmenu__item slashmenu__item--empty">
-                <span className="slashmenu__name">正在加载历史会话...</span>
+                <span className="slashmenu__name">{t("composer.pastChatsLoading")}</span>
               </div>
             ) : pastChats.length === 0 ? (
               <div className="slashmenu__item slashmenu__item--empty">
-                <span className="slashmenu__name">暂无历史会话</span>
+                <span className="slashmenu__name">{t("composer.pastChatsEmpty")}</span>
               </div>
             ) : (
               <>
@@ -2024,7 +2024,7 @@ export function Composer({
                   <input
                     className="slashmenu__search"
                     type="text"
-                    placeholder="搜索历史会话…"
+                    placeholder={t("composer.pastChatsSearchPlaceholder")}
                     value={pastChatQuery}
                     autoFocus
                     onChange={(ev) => {
@@ -2036,7 +2036,7 @@ export function Composer({
                 </div>
                 {filteredPastChats.length === 0 ? (
                   <div className="slashmenu__item slashmenu__item--empty">
-                    <span className="slashmenu__name">没有匹配的历史会话</span>
+                    <span className="slashmenu__name">{t("composer.pastChatsNoMatch")}</span>
                   </div>
                 ) : (
                   filteredPastChats.map((session, i) => {
@@ -2092,7 +2092,7 @@ export function Composer({
                 setActive(0);
               }}
             >
-              <span className="slashmenu__name">← 返回文件列表</span>
+              <span className="slashmenu__name">{t("composer.pastChatsBackToList")}</span>
             </button>
           </div>
         ) : (
@@ -2196,7 +2196,7 @@ export function Composer({
                   </span>
                 </span>
               </Tooltip>
-              <Tooltip label="移除引用会话">
+              <Tooltip label={t("composer.removeSessionRef")}>
                 <button
                   type="button"
                   onClick={() => removeSessionRef(ref.path)}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -152,6 +152,14 @@ export const en = {
   "topicBar.exportPdf": "Export PDF",
   "topicBar.exportImage": "Export Image",
 
+  // past:chats
+  "composer.pastChatsLoading": "Loading sessions...",
+  "composer.pastChatsEmpty": "No recent sessions",
+  "composer.pastChatsNoMatch": "No matching sessions",
+  "composer.pastChatsBackToList": "← Back to file list",
+  "composer.pastChatsSearchPlaceholder": "Search sessions...",
+  "composer.removeSessionRef": "Remove session reference",
+
   // scope labels
   "scope.global": "Scope: Global",
   "scope.project": "Project · {name}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1201,6 +1201,14 @@ export const zhTW: Record<DictKey, string> = {
   "topicBar.command": "命令",
   "topicBar.exportPdf": "匯出 PDF",
   "topicBar.exportImage": "匯出圖片",
+
+  // past:chats
+  "composer.pastChatsLoading": "正在載入歷史工作階段...",
+  "composer.pastChatsEmpty": "暫無歷史工作階段",
+  "composer.pastChatsNoMatch": "沒有符合的工作階段",
+  "composer.pastChatsBackToList": "← 返回檔案列表",
+  "composer.pastChatsSearchPlaceholder": "搜尋工作階段...",
+  "composer.removeSessionRef": "移除引用工作階段",
   "workspace.filterReferencedFiles": "篩選依賴檔案…",
   "workspace.clearFileScope": "顯示完整檔案樹",
   "workspace.clearChangeScope": "顯示全部改動",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -153,6 +153,14 @@ export const zh: Record<DictKey, string> = {
   "topicBar.exportPdf": "导出 PDF",
   "topicBar.exportImage": "导出图片",
 
+  // past:chats
+  "composer.pastChatsLoading": "正在加载历史会话...",
+  "composer.pastChatsEmpty": "暂无历史会话",
+  "composer.pastChatsNoMatch": "没有匹配的历史会话",
+  "composer.pastChatsBackToList": "← 返回文件列表",
+  "composer.pastChatsSearchPlaceholder": "搜索历史会话...",
+  "composer.removeSessionRef": "移除引用会话",
+
   // 范围标签
   "scope.global": "范围：全局",
   "scope.project": "项目 · {name}",


### PR DESCRIPTION
Fixes 6 hardcoded Chinese strings in Composer.tsx that bypassed the i18n system.

**Changes:**
- `正在加载历史会话...` → `t("composer.pastChatsLoading")`
- `暂无历史会话` → `t("composer.pastChatsEmpty")`  
- `没有匹配的历史会话` → `t("composer.pastChatsNoMatch")`
- `← 返回文件列表` → `t("composer.pastChatsBackToList")`
- `placeholder="搜索历史会话…"` → `t("composer.pastChatsSearchPlaceholder")`
- `label="移除引用会话"` → `t("composer.removeSessionRef")`

Adds 6 new translation keys to en/zh/zh-TW locales.