### PR TITLE
fix(desktop): show fallback UI in ErrorBoundary instead of blank screen

### DIFF
--- a/desktop/frontend/src/components/ErrorBoundary.tsx
+++ b/desktop/frontend/src/components/ErrorBoundary.tsx
@@ -13,6 +13,20 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, { crashed:
   }
 
   render() {
-    return this.state.crashed ? null : this.props.children;
+    if (this.state.crashed) {
+      return (
+        <div className="error-boundary-fallback" role="alert">
+          <p className="error-boundary-fallback__message">Something went wrong rendering this section.</p>
+          <button
+            className="error-boundary-fallback__retry"
+            type="button"
+            onClick={() => this.setState({ crashed: false })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
   }
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2503,6 +2503,35 @@ a[href] {
   background: var(--chat-bg);
 }
 
+/* ── error boundary fallback ─────────────────────────────────────────────── */
+.error-boundary-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 16px;
+  color: var(--fg-dim);
+  text-align: center;
+}
+.error-boundary-fallback__message {
+  margin: 0;
+  font-size: 13px;
+}
+.error-boundary-fallback__retry {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-elev);
+  color: var(--fg);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.error-boundary-fallback__retry:hover {
+  background: var(--bg-elev-2);
+}
+
 /* ── top bar (drag region) ───────────────────────────────────────────────── */
 .topbar {
   position: relative;


### PR DESCRIPTION
Currently ErrorBoundary renders null when a child crashes, leaving users with a completely blank area and no recovery path. This PR adds a fallback card with a "Try again" button.

**Before:** `return this.state.crashed ? null : this.props.children;`
**After:** Renders a fallback `<div role="alert">` with error message and retry button that resets error state.