### PR TITLE
fix(desktop): readPref() now reads from localStorage for locale persistence

### DIFF
--- a/desktop/frontend/src/lib/i18n.tsx
+++ b/desktop/frontend/src/lib/i18n.tsx
@@ -58,7 +58,12 @@ export function detectLocale(pref: LangPref): Locale {
 }
 
 function readPref(): LangPref {
-  return "";
+  try {
+    const v = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    return normalizeLangPref(v);
+  } catch {
+    return "";
+  }
 }
 
 export function normalizeLangPref(v: unknown): LangPref {


### PR DESCRIPTION
readPref() always returned "" (auto-detect from OS), causing user-set language preferences to be lost on restart. Now reads from localStorage using the same key as readLegacyLangPref().

**Fix:** `readPref()` now actually reads from localStorage instead of returning a stub.