### PR TITLE
fix(desktop): add aria-label to Composer send button for screen readers

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -2307,6 +2307,7 @@ export function Composer({
                 className="composer__btn composer__btn--send"
                 onClick={submit}
                 disabled={submitting || pendingPaste > 0 || ((!text.trim() && attachments.length === 0 && workspaceRefs.length === 0) && !(goalModeOn && !activeGoal)) || disabled || submitDisabled || readOnly}
+                aria-label={t("composer.sendAriaLabel")}
               >
                 <ArrowUp size={16} />
               </button>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -411,6 +411,7 @@ export const en = {
   "composer.removeCurrentProjectDisabled": "Current project cannot be removed",
   "composer.resize": "Drag to resize composer, double-click to reset",
   "composer.send": "Send (Enter)",
+  "composer.sendAriaLabel": "Send message",
   "composer.shellMode": "Shell mode: prefix input with !",
   "composer.shellModeOn": "Shell mode on: click to remove !",
   "composer.stop": "Stop (Esc)",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -290,6 +290,7 @@ export const zhTW: Record<DictKey, string> = {
   "composer.removeCurrentProjectDisabled": "不能移除當前專案",
   "composer.resize": "拖動調整輸入區高度，雙擊重置",
   "composer.send": "傳送（Enter）",
+  "composer.sendAriaLabel": "傳送訊息",
   "composer.stop": "停止（Esc）",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已貼上文字 #{id} · {lines} 行]",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -412,6 +412,7 @@ export const zh: Record<DictKey, string> = {
   "composer.removeCurrentProjectDisabled": "不能移除当前项目",
   "composer.resize": "拖动调整输入区高度，双击重置",
   "composer.send": "发送（Enter）",
+  "composer.sendAriaLabel": "发送消息",
   "composer.shellMode": "Shell 模式：给输入前加 !",
   "composer.shellModeOn": "Shell 模式已开：点击移除 !",
   "composer.stop": "停止（Esc）",


### PR DESCRIPTION
The send button in Composer had no aria-label, appearing as an unlabeled button to screen readers. Adds `aria-label={t("composer.sendAriaLabel")}` with locale keys in en/zh/zh-TW.