### PR TITLE
fix(desktop): handle rand.Read error in newTopicID with timestamp fallback

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5143,7 +5143,10 @@ func newTabID() string {
 
 func newTopicID() string {
 	var b [8]byte
-	rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		now := time.Now().UTC()
+		return "topic_" + now.Format("20060102-150405") + "_" + fmt.Sprintf("%09d", now.Nanosecond())
+	}
 	return "topic_" + time.Now().UTC().Format("20060102-150405") + "_" + hex.EncodeToString(b[:])
 }
 


### PR DESCRIPTION
newTopicID() ignored the error return from rand.Read, producing all-zero random bytes on system entropy failure. Now falls back to nanosecond timestamp, matching the pattern used by newTabID().