### PR TITLE
perf(desktop): wrap Tooltip and CopyButton with React.memo

### DIFF
--- a/desktop/frontend/src/components/CopyButton.tsx
+++ b/desktop/frontend/src/components/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { useT } from "../lib/i18n";
 
@@ -54,7 +54,7 @@ async function writeClipboardText(value: string): Promise<void> {
 // CopyButton copies text to the clipboard on click and briefly flips to a check.
 // Clipboard writes are best-effort across browser dev, Wails, and webviews, so
 // the visible acknowledgement stays tied to the user action.
-export function CopyButton({
+export const CopyButton = memo(function CopyButton({
   text,
   getText,
   className,
@@ -111,4 +111,4 @@ export function CopyButton({
       )}
     </button>
   );
-}
+});

--- a/desktop/frontend/src/components/Tooltip.tsx
+++ b/desktop/frontend/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { memo, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
 
@@ -33,7 +33,7 @@ function samePosition(
   );
 }
 
-export function Tooltip({
+export const Tooltip = memo(function Tooltip({
   label,
   children,
   side = "top",
@@ -182,4 +182,4 @@ export function Tooltip({
         )}
     </>
   );
-}
+});


### PR DESCRIPTION
Tooltip and CopyButton receive stable props but re-render on every parent update, causing unnecessary reconciliation overhead — especially during streaming where the Composer re-renders frequently. Wrapping with React.memo skips re-renders when props are shallow-equal.