### PR TITLE
fix(desktop): broaden clipboard image MIME detection to all image/* types

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -210,11 +210,10 @@ function clipboardFiles(data: DataTransfer): File[] {
 }
 
 function clipboardHasImageHint(data: DataTransfer): boolean {
-  const imageType = (value: string) => {
-    const type = value.toLowerCase();
-    return type.startsWith("image/") || type.includes("png") || type.includes("jpeg") || type.includes("jpg") || type.includes("tiff");
-  };
-  return Array.from(data.items).some((item) => imageType(item.type)) || Array.from(data.types).some(imageType);
+  // All standard image MIME types start with "image/" — including webp, gif,
+  // bmp, svg+xml, avif which were previously missed by the substring approach.
+  const isImageType = (value: string) => value.toLowerCase().startsWith("image/");
+  return Array.from(data.items).some((item) => isImageType(item.type)) || Array.from(data.types).some(isImageType);
 }
 
 function isPasteShortcut(e: KeyboardEvent<HTMLTextAreaElement>): boolean {


### PR DESCRIPTION
Previous clipboardHasImageHint used substring matching for png/jpeg/jpg/tiff, missing webp, gif, bmp, svg+xml, avif and other standard image types. Also had overly broad matching that could false-positive on non-image types. Now uses startsWith("image/") covering all IANA image MIME types.