### PR TITLE
fix(desktop): show error state in past:chats when ListSessions fails

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -499,6 +499,7 @@ export function Composer({
   const [pastChatQuery, setPastChatQuery] = useState("");
   const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
   const [loadingPastChats, setLoadingPastChats] = useState(false);
+  const [pastChatsError, setPastChatsError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [composerPrompt, setComposerPrompt] = useState<string | null>(null);
   // Prompt history navigation (plain ↑/↓)
@@ -1542,6 +1543,7 @@ export function Composer({
     setActive(0);
     setPastChatQuery("");
     setLoadingPastChats(true);
+    setPastChatsError(false);
     try {
       const sessions = await app.ListSessions();
       // Discard stale response if workspace changed while the request was in-flight.
@@ -1558,6 +1560,7 @@ export function Composer({
     } catch {
       if (cwdRef.current !== snapshotCwd) return;
       setPastChats([]);
+      setPastChatsError(true);
     } finally {
       if (cwdRef.current === snapshotCwd) setLoadingPastChats(false);
     }
@@ -2012,6 +2015,13 @@ export function Composer({
             {loadingPastChats ? (
               <div className="slashmenu__item slashmenu__item--empty">
                 <span className="slashmenu__name">正在加载历史会话...</span>
+              </div>
+            ) : pastChatsError ? (
+              <div className="slashmenu__item slashmenu__item--empty">
+                <span className="slashmenu__name">{t("composer.pastChatsError")}</span>
+                <button className="slashmenu__retry-btn" type="button" onClick={openPastChats}>
+                  {t("composer.pastChatsRetry")}
+                </button>
               </div>
             ) : pastChats.length === 0 ? (
               <div className="slashmenu__item slashmenu__item--empty">

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -414,6 +414,8 @@ export const en = {
   "composer.shellMode": "Shell mode: prefix input with !",
   "composer.shellModeOn": "Shell mode on: click to remove !",
   "composer.stop": "Stop (Esc)",
+  "composer.pastChatsError": "Failed to load sessions",
+  "composer.pastChatsRetry": "Retry",
   "composer.stopShort": "Stop",
   "composer.pastedLabel": "[Pasted text #{id} · {lines} lines]",
   "composer.pastedShowPreview": "Preview pasted text",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -291,6 +291,8 @@ export const zhTW: Record<DictKey, string> = {
   "composer.resize": "拖動調整輸入區高度，雙擊重置",
   "composer.send": "傳送（Enter）",
   "composer.stop": "停止（Esc）",
+  "composer.pastChatsError": "載入工作階段失敗",
+  "composer.pastChatsRetry": "重試",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已貼上文字 #{id} · {lines} 行]",
   "composer.pastedShowPreview": "預覽貼上文字",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -414,6 +414,8 @@ export const zh: Record<DictKey, string> = {
   "composer.send": "发送（Enter）",
   "composer.shellMode": "Shell 模式：给输入前加 !",
   "composer.shellModeOn": "Shell 模式已开：点击移除 !",
+  "composer.pastChatsError": "加载会话失败",
+  "composer.pastChatsRetry": "重试",
   "composer.stop": "停止（Esc）",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已粘贴文本 #{id} · {lines} 行]",


### PR DESCRIPTION
When app.ListSessions() fails, pastChats was set to empty array with no error indication — users saw "No recent sessions" even on network/backend errors. Now shows localized error message with retry button.