### PR TITLE
fix(desktop): cancel pending clipboard image paste timer on any key press

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1672,6 +1672,9 @@ export function Composer({
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Cancel any pending native clipboard image paste timer on any key press,
+    // preventing an image path from being inserted after user-typed text.
+    clearNativeClipboardPasteTimer();
     const composing = isImeKeyEvent(e, composingRef.current, lastCompositionEndAt.current);
     const native = e.nativeEvent as globalThis.KeyboardEvent & {
       keyCode?: number;


### PR DESCRIPTION
The native clipboard image paste timer (160ms after Ctrl+V) only had clearNativeClipboardPasteTimer() called on paste shortcuts. If the user started typing within 160ms of pasting, the async image attachment would still fire and could insert an image path after typed text. Now clears the timer on every keydown.