### PR TITLE
perf(desktop): preload MarkdownRenderer code-split chunk to avoid Suspense flash

### DIFF
--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -1,6 +1,16 @@
-import { lazy, memo, Suspense } from "react";
+import { lazy, memo, Suspense, useEffect } from "react";
 
 const MarkdownRenderer = lazy(() => import("./MarkdownRenderer"));
+
+// Preload the MarkdownRenderer code-split chunk so the first message renders
+// without a Suspense fallback flash of raw text.
+let preloaded = false;
+function preloadMarkdownRenderer() {
+  if (preloaded) return;
+  preloaded = true;
+  void import("./MarkdownRenderer");
+}
+preloadMarkdownRenderer();
 
 export const Markdown = memo(function Markdown({
   text,

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, Suspense, useEffect } from "react";
+import { lazy, memo, Suspense } from "react";
 
 const MarkdownRenderer = lazy(() => import("./MarkdownRenderer"));
 


### PR DESCRIPTION
MarkdownRenderer is code-split via React.lazy. On first render, users see a raw-text fallback flash before the chunk loads. Now preloads eagerly at module import time so the chunk is ready before the first message.