### PR TITLE
Restrict status bar to configured items / 限制状态栏仅显示配置项

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1200,15 +1200,6 @@ export default function App() {
     return currentTabTurns > 0 ? currentTabTurns : activeTopicTurns ?? 0;
   }, [activeTopicTurns, state.checkpoints.length, state.items]);
   const startupSplashHold = !activeTabId && state.meta?.ready !== true && !state.meta?.startupErr;
-  const hydrateStatusLabel = state.hydrating
-    ? state.hydrateReason === "switch-tab"
-      ? t("status.hydrateSwitch")
-      : state.hydrateReason === "resume-session"
-        ? t("status.hydrateResume")
-        : state.hydrateReason === "new-session"
-          ? t("status.hydrateNewSession")
-          : t("status.hydrateSync")
-    : undefined;
   const activeComposerProfile = activeTabId ? composerProfilesByTab[activeTabId] : undefined;
   const backendActiveComposerProfile = useMemo(() => {
     if (state.meta) {
@@ -3367,10 +3358,7 @@ export default function App() {
               context={state.context}
               usage={state.usage}
               balance={state.balance}
-              jobs={state.jobs}
               running={state.running || rewindCommitting}
-              collaborationMode={collaborationMode}
-              toolApprovalMode={toolApprovalMode}
               sessionTurns={sessionTurns}
               sessionTokens={state.sessionTokens}
               turnTokens={state.turnTotalTokens}
@@ -3383,7 +3371,6 @@ export default function App() {
               workspacePath={state.meta?.workspacePath || state.meta?.workspaceRoot || state.meta?.cwd}
               workspaceName={state.meta?.workspaceName}
               gitBranch={state.meta?.gitBranch}
-              hydrationLabel={hydrateStatusLabel}
             />
           </footer>
           )}

--- a/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
+++ b/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
@@ -25,8 +25,6 @@ function renderStatusBar(props: Partial<Parameters<typeof StatusBar>[0]> = {}): 
       <StatusBar
         context={{ used: 0, window: 0, sessionTokens: 0 }}
         running={false}
-        collaborationMode="normal"
-        toolApprovalMode="ask"
         {...props}
       />
     </LocaleProvider>,
@@ -78,6 +76,12 @@ console.log("\nstatus bar workspace");
   });
   ok(html.indexOf("feature/meta") >= 0 && html.indexOf("workspace/repo") >= 0, "workspace and git branch render as configured items");
   ok(html.indexOf("feature/meta") < html.indexOf("workspace/repo"), "workspace items follow configured order");
+}
+
+{
+  const html = renderStatusBar({ items: ["model"] });
+  ok(!html.includes("YOLO"), "status bar renders only configured status items, not mode indicators");
+  ok(!html.includes("后台作业") && !html.includes("Background jobs"), "status bar omits non-configurable job indicators");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -1,58 +1,12 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Activity, CircleDollarSign, CircleGauge, Database, Folder, GitBranch, Layers, Percent, RefreshCw, Wallet, Zap } from "lucide-react";
 import { Tooltip } from "./Tooltip";
 import { useI18n, type Translator } from "../lib/i18n";
 import { formatMoneyLocalized } from "../lib/money";
 import { normalizeStatusBarItems, type StatusBarItemId } from "../lib/statusBarItems";
-import { type BalanceInfo, type CollaborationMode, type ContextInfo, type JobView, type ToolApprovalMode, type WireUsage } from "../lib/types";
+import { type BalanceInfo, type ContextInfo, type WireUsage } from "../lib/types";
 
 type StatusBarLabelStyle = "icon" | "text";
-
-// JobsChip is the status-bar background-jobs indicator: a count that opens an
-// upward popover listing the running jobs (id · label · status), mirroring the
-// ModelSwitcher's click-to-open pattern. With no jobs it stays hidden so the
-// high-priority status metrics keep the compact left-to-right scan.
-function JobsChip({ jobs }: { jobs: JobView[] }) {
-  const { t } = useI18n();
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!open) return;
-    const closeOnOutsideClick = (event: MouseEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (wrapRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    document.addEventListener("click", closeOnOutsideClick);
-    return () => document.removeEventListener("click", closeOnOutsideClick);
-  }, [open]);
-  if (jobs.length === 0) {
-    return null;
-  }
-  return (
-    <div className="statusbar__jobswrap" ref={wrapRef}>
-      <Tooltip label={t("status.jobsTitle")}>
-        <button className="stat stat--jobs statusbar__jobs" onClick={() => setOpen((v) => !v)}>
-          <span className="stat__label">{t("status.jobsLabel")}</span>
-          <b>{jobs.length}</b>
-        </button>
-      </Tooltip>
-      {open && (
-        <div className="modelsw__menu jobsmenu" role="listbox">
-          <div className="jobsmenu__head">{t("status.jobsTitle")}</div>
-          {jobs.map((j) => (
-            <div className="jobsmenu__item" key={j.id} role="option">
-              <span className="jobsmenu__id">{j.id}</span>
-              <span className="jobsmenu__label">{j.label || j.kind}</span>
-              <span className="jobsmenu__status">{j.status}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
 
 function formatRate(hit: number, denom: number): string | null {
   if (denom <= 0) return null;
@@ -143,10 +97,7 @@ export function StatusBar({
   context,
   usage,
   balance,
-  jobs,
   running,
-  collaborationMode,
-  toolApprovalMode,
   sessionTurns,
   sessionTokens,
   turnTokens,
@@ -159,15 +110,11 @@ export function StatusBar({
   workspacePath,
   workspaceName,
   gitBranch,
-  hydrationLabel,
 }: {
   context: ContextInfo;
   usage?: WireUsage;
   balance?: BalanceInfo;
-  jobs?: JobView[];
   running: boolean;
-  collaborationMode: CollaborationMode;
-  toolApprovalMode: ToolApprovalMode;
   sessionTurns?: number;
   sessionTokens?: number;
   turnTokens?: number;
@@ -180,7 +127,6 @@ export function StatusBar({
   workspacePath?: string;
   workspaceName?: string;
   gitBranch?: string;
-  hydrationLabel?: string;
 }) {
   const { locale, t } = useI18n();
   const pct = context.window ? Math.min(100, Math.round((context.used / context.window) * 100)) : null;
@@ -189,7 +135,6 @@ export function StatusBar({
   const compactReached = pct !== null && compactPct !== null && pct >= compactPct;
   const nowPct = nowRate(usage);
   const avgPct = avgRate(usage) ?? contextAvgRate(context);
-  const jobsList = jobs ?? [];
   const turnCostLabel = formatMoneyLocalized(turnCost, currency, { locale });
   const costLabel = formatMoneyLocalized(cost, currency, { locale });
   const displayWorkspacePath = (workspacePath || workspaceName || "").trim();
@@ -200,8 +145,6 @@ export function StatusBar({
   const tokenLabel = formatTokenCount(sessionTokens);
   const turnTokenLabel = formatTokenCount(turnTokens);
   const balanceLabel = balance?.available && balance.display ? balance.display : "-";
-  const planMode = collaborationMode === "plan";
-  const goalMode = collaborationMode === "goal";
   const metricLabelStyle = labelStyle === "text" ? "text" : "icon";
   const visibleItems = normalizeStatusBarItems(items);
   const itemRenderers: Record<StatusBarItemId, ReactNode> = {
@@ -320,31 +263,8 @@ export function StatusBar({
   const renderedItems = visibleItems
     .map((id) => ({ id, node: itemRenderers[id] }))
     .filter(({ node }) => node !== null && node !== undefined && node !== false);
-  const modeIndicators = [
-    planMode ? <span className="statusbar__plan" key="plan">{t("status.plan")}</span> : null,
-    goalMode ? <span className="statusbar__plan" key="goal">{t("composer.goalMode")}</span> : null,
-    toolApprovalMode === "auto" ? (
-      <Tooltip label={t("composer.accessAutoTitle")} key="auto">
-        <span className="statusbar__yolo">{t("composer.accessAuto")}</span>
-      </Tooltip>
-    ) : null,
-    toolApprovalMode === "yolo" ? (
-      <Tooltip label={t("status.yoloTitle")} key="yolo">
-        <span className="statusbar__yolo">{t("composer.accessYolo")}</span>
-      </Tooltip>
-    ) : null,
-  ].filter(Boolean);
-
   return (
     <div className={`statusbar statusbar--${metricLabelStyle}`}>
-      {hydrationLabel && (
-        <div className="statusbar__group statusbar__group--hydrate">
-          <span className="stat statusbar__hydrate" role="status">
-            <RefreshCw size={12} />
-            <span>{hydrationLabel}</span>
-          </span>
-        </div>
-      )}
       <div className="statusbar__group statusbar__group--items">
         {renderedItems.map(({ id, node }) => (
           <span className="statusbar__item" data-statusbar-item={id} key={id}>
@@ -352,12 +272,6 @@ export function StatusBar({
           </span>
         ))}
       </div>
-      {modeIndicators.length > 0 && <div className="statusbar__group statusbar__group--modes">{modeIndicators}</div>}
-      {jobsList.length > 0 && (
-        <div className="statusbar__group statusbar__group--jobs">
-          <JobsChip jobs={jobsList} />
-        </div>
-      )}
     </div>
   );
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6058,23 +6058,6 @@ a[href] {
   background: var(--accent);
   animation: pulse 1.2s ease-in-out infinite;
 }
-.statusbar__group--hydrate {
-  max-width: 190px;
-  overflow: hidden;
-}
-.statusbar__hydrate {
-  color: var(--accent);
-  max-width: 190px;
-}
-.statusbar__hydrate svg {
-  flex: 0 0 auto;
-  animation: spin 1s linear infinite;
-}
-.statusbar__hydrate span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 @keyframes pulse {
   50% {
     opacity: 0.35;
@@ -6149,69 +6132,8 @@ a[href] {
 .statusbar__cost {
   justify-content: flex-start;
 }
-.stat--jobs,
-.statusbar__jobswrap {
-  flex: 0 0 auto;
-  justify-content: center;
-}
 .statusbar__balance {
   justify-content: flex-start;
-}
-.statusbar__jobswrap {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-}
-.statusbar__jobs {
-  --wails-draggable: no-drag;
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  font-family: inherit;
-  font-size: inherit;
-  color: var(--fg-dim);
-}
-.statusbar__jobs:hover {
-  color: var(--fg);
-}
-/* Jobs popover: reuses .modelsw__menu's elevated box; only the rows differ. */
-.jobsmenu {
-  min-width: 220px;
-}
-.jobsmenu__head {
-  padding: 2px 9px 6px;
-  font-size: var(--text-xs);
-  color: var(--fg-faint);
-}
-.jobsmenu__item {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 4px 9px;
-  font-size: var(--font-control-small);
-}
-.jobsmenu__id {
-  color: var(--accent);
-  flex-shrink: 0;
-}
-.jobsmenu__label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--fg-dim);
-}
-.jobsmenu__status {
-  color: var(--fg-faint);
-  flex-shrink: 0;
-}
-.statusbar__plan {
-  color: var(--accent);
-  letter-spacing: 0.6px;
-}
-.statusbar__yolo {
-  color: var(--mode-yolo-fg);
-  letter-spacing: 0.6px;
 }
 /* model switcher (bottom-of-window popover) */
 .modelsw {
@@ -20296,12 +20218,10 @@ a[href] {
 
 @media (max-width: 760px) {
   .statusbar__group--context,
-  .statusbar__group--jobs,
   .statusbar__item[data-statusbar-item="session_tokens"],
   .statusbar__item[data-statusbar-item="turn_tokens"],
   .statusbar__item[data-statusbar-item="session_turns"],
-  .statusbar__item[data-statusbar-item="context"],
-  .statusbar__jobswrap {
+  .statusbar__item[data-statusbar-item="context"] {
     display: none;
   }
 }
@@ -21182,8 +21102,7 @@ a[href] {
   box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
-:root[data-theme-style] .statusbar__cache b,
-:root[data-theme-style] .statusbar__plan {
+:root[data-theme-style] .statusbar__cache b {
   color: var(--accent);
 }
 


### PR DESCRIPTION
## Summary
- Restrict the desktop footer status bar to the configured status-bar item list.
- Remove non-configurable mode, hydration, and background-job indicators from the footer status bar.
- Add a focused regression assertion that configured status items do not render mode/job indicators.

## Related PR Check
- Checked open desktop/status-bar-adjacent PRs #5500 and #5502; neither changes the same StatusBar rendering contract.

## Cache Impact
- None. This only changes desktop frontend rendering and CSS; no provider request, prompt prefix, tool schema, or cache-sensitive runtime path changes.

## Verification
- `pnpm --dir desktop/frontend exec tsx src/__tests__/statusbar-workspace.test.tsx`
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend typecheck`