### PR TITLE
fix(desktop): use private DBus connection in traySupported()

### DIFF
--- a/desktop/tray_supported_unix.go
+++ b/desktop/tray_supported_unix.go
@@ -5,18 +5,11 @@ package main
 import "github.com/godbus/dbus/v5"
 
 func traySupported() bool {
-	// SessionBusPrivate() returns a private connection rather than the shared
-	// singleton from SessionBus(). Closing a shared singleton connection can
-	// interfere with other DBus users in the same process.
-	conn, err := dbus.SessionBusPrivate()
+	// SessionBus() returns a shared singleton connection — do NOT close it.
+	// Closing the shared connection can interfere with other DBus consumers
+	// (notifications, portal dialogs) in the same process.
+	conn, err := dbus.SessionBus()
 	if err != nil {
-		return false
-	}
-	defer conn.Close()
-	if err := conn.Auth(); err != nil {
-		return false
-	}
-	if err := conn.Hello(); err != nil {
 		return false
 	}
 	obj := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")

--- a/desktop/tray_supported_unix.go
+++ b/desktop/tray_supported_unix.go
@@ -5,11 +5,20 @@ package main
 import "github.com/godbus/dbus/v5"
 
 func traySupported() bool {
-	conn, err := dbus.SessionBus()
+	// SessionBusPrivate() returns a private connection rather than the shared
+	// singleton from SessionBus(). Closing a shared singleton connection can
+	// interfere with other DBus users in the same process.
+	conn, err := dbus.SessionBusPrivate()
 	if err != nil {
 		return false
 	}
 	defer conn.Close()
+	if err := conn.Auth(); err != nil {
+		return false
+	}
+	if err := conn.Hello(); err != nil {
+		return false
+	}
 	obj := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
 	var owner string
 	return obj.Call("org.freedesktop.DBus.GetNameOwner", 0, "org.kde.StatusNotifierWatcher").Store(&owner) == nil && owner != ""


### PR DESCRIPTION
SessionBus() returns a shared singleton — closing it can interfere with other DBus users in the process. Switch to SessionBusPrivate() which creates an independent connection that can be safely closed with Auth() and Hello().