### PR TITLE
docs(memorycompiler): document runtimeLocks non-eviction as intentional design

### DIFF
--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -42,6 +42,13 @@ const (
 	staleConfidenceThreshold  = 0.2
 )
 
+// runtimeLocks maps cleaned project directory paths to per-directory mutexes
+// so concurrent writes to the same project's memory state are serialised.
+// Entries are intentionally never deleted: each entry is a single *sync.Mutex
+// (lightweight), and the number of unique project directories visited during
+// a process lifetime is bounded in practice. If a future use case requires
+// cleanup, iterate over the map and remove entries whose Runtime instances
+// have been garbage-collected — but that adds complexity for negligible gain.
 var runtimeLocks sync.Map
 
 // Runtime owns one project's Memory v5 state.


### PR DESCRIPTION
runtimeLocks sync.Map entries are never deleted — each is a lightweight *sync.Mutex and the number of unique project directories is bounded in practice. Documents this as an intentional trade-off to prevent future readers from misidentifying it as a leak.