### PR TITLE
Fix edit_file old_string drift matching / 修复 edit_file 匹配漂移

### DIFF
--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"reasonix/internal/tool"
 )
@@ -56,19 +55,21 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
 
-	old, newStr := matchLineEndings(content, p.OldString, p.NewString)
-	switch strings.Count(content, old) {
-	case 0:
-		return "", fmt.Errorf("old_string not found in %s", p.Path)
-	case 1:
+	applied := applyOldStringEdit(content, p.OldString, p.NewString, false)
+	switch {
+	case applied.applied == 1:
 		// ok
+	case applied.matches == 0:
+		return "", oldStringNotFoundError(p.Path, p.OldString, content)
 	default:
-		return "", fmt.Errorf("old_string is not unique in %s; add more surrounding context", p.Path)
+		return "", oldStringNotUniqueError(p.Path, applied.matches, false)
 	}
 
-	updated := strings.Replace(content, old, newStr, 1)
-	if err := writeFileEncoded(p.Path, updated, enc); err != nil {
+	if err := writeFileEncoded(p.Path, applied.updated, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
+	}
+	if applied.fuzzy {
+		return fmt.Sprintf("edited %s (fuzzy match)", p.Path), nil
 	}
 	return fmt.Sprintf("edited %s", p.Path), nil
 }

--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -33,11 +34,300 @@ func matchLineEndings(content, old, new string) (string, string) {
 	if strings.Contains(content, old) || !strings.Contains(content, "\r\n") {
 		return old, new
 	}
-	toCRLF := func(s string) string {
-		return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
-	}
 	if strings.Contains(content, toCRLF(old)) {
 		return toCRLF(old), toCRLF(new)
 	}
 	return old, new
+}
+
+func toCRLF(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
+}
+
+func matchReplacementLineEndings(content, replacement string) string {
+	if strings.Contains(content, "\r\n") {
+		return toCRLF(replacement)
+	}
+	return replacement
+}
+
+type editApplyResult struct {
+	updated string
+	applied int
+	matches int
+	fuzzy   bool
+}
+
+type editRange struct {
+	start int
+	end   int
+}
+
+// applyOldStringEdit is the shared edit_file/multi_edit/Preview contract. It
+// preserves the exact-match rule first, then falls back to a narrow fuzzy match
+// for the mismatches read_file commonly introduces or hides: trailing
+// whitespace, tab-vs-spaces indentation, and copied read_file line prefixes.
+// Non-replace_all edits still require exactly one match, including fuzzy
+// matches.
+func applyOldStringEdit(content, oldString, newString string, replaceAll bool) editApplyResult {
+	old, newStr := matchLineEndings(content, oldString, newString)
+	if replaceAll {
+		if count := strings.Count(content, old); count > 0 {
+			return editApplyResult{
+				updated: strings.ReplaceAll(content, old, newStr),
+				applied: count,
+				matches: count,
+			}
+		}
+		ranges := fuzzyEditRanges(content, old)
+		if len(ranges) == 0 {
+			return editApplyResult{updated: content}
+		}
+		return editApplyResult{
+			updated: replaceEditRanges(content, ranges, matchReplacementLineEndings(content, newStr)),
+			applied: len(ranges),
+			matches: len(ranges),
+			fuzzy:   true,
+		}
+	}
+
+	switch count := strings.Count(content, old); count {
+	case 0:
+		ranges := fuzzyEditRanges(content, old)
+		if len(ranges) != 1 {
+			return editApplyResult{updated: content, matches: len(ranges)}
+		}
+		return editApplyResult{
+			updated: replaceEditRanges(content, ranges, matchReplacementLineEndings(content, newStr)),
+			applied: 1,
+			matches: 1,
+			fuzzy:   true,
+		}
+	case 1:
+		return editApplyResult{
+			updated: strings.Replace(content, old, newStr, 1),
+			applied: 1,
+			matches: 1,
+		}
+	default:
+		return editApplyResult{updated: content, matches: count}
+	}
+}
+
+func oldStringNotFoundError(path, oldString, content string) error {
+	if line, text, ok := nearestContentLine(oldString, content); ok {
+		return fmt.Errorf("old_string not found in %s (nearest line %d: %q)", path, line, text)
+	}
+	return fmt.Errorf("old_string not found in %s", path)
+}
+
+func oldStringNotUniqueError(path string, matches int, replaceAllHint bool) error {
+	if replaceAllHint {
+		return fmt.Errorf("old_string is not unique in %s (%d matches); add more surrounding context or set replace_all", path, matches)
+	}
+	return fmt.Errorf("old_string is not unique in %s (%d matches); add more surrounding context", path, matches)
+}
+
+type lineSegment struct {
+	raw   string
+	start int
+	end   int
+}
+
+type fuzzyMode struct {
+	stripOldReadPrefixes bool
+	trimTrailing         bool
+	expandTabs           bool
+	trimLeading          bool
+}
+
+func fuzzyEditRanges(content, old string) []editRange {
+	if old == "" || content == "" {
+		return nil
+	}
+	contentLines := splitLineSegments(content)
+	oldLines := splitLineSegments(old)
+	if len(oldLines) == 0 || len(oldLines) > len(contentLines) {
+		return nil
+	}
+
+	oldHasReadPrefixes := allLinesHaveReadFilePrefix(oldLines)
+	modes := []fuzzyMode{
+		{trimTrailing: true},
+		{trimTrailing: true, expandTabs: true},
+	}
+	if oldHasReadPrefixes {
+		modes = append(modes,
+			fuzzyMode{stripOldReadPrefixes: true, trimTrailing: true},
+			fuzzyMode{stripOldReadPrefixes: true, trimTrailing: true, expandTabs: true},
+		)
+	}
+
+	for _, mode := range modes {
+		normOld := make([]string, len(oldLines))
+		for i, line := range oldLines {
+			normOld[i] = normalizeFuzzyLine(line.raw, lineHasNewline(line.raw), mode, mode.stripOldReadPrefixes)
+		}
+		var ranges []editRange
+		for i := 0; i <= len(contentLines)-len(oldLines); {
+			if fuzzyWindowMatches(contentLines[i:i+len(oldLines)], oldLines, normOld, mode) {
+				ranges = append(ranges, editRange{
+					start: contentLines[i].start,
+					end:   fuzzyWindowEnd(contentLines[i+len(oldLines)-1], oldLines[len(oldLines)-1]),
+				})
+				i += len(oldLines)
+				continue
+			}
+			i++
+		}
+		if len(ranges) > 0 {
+			return ranges
+		}
+	}
+	return nil
+}
+
+func fuzzyWindowMatches(contentWindow, oldLines []lineSegment, normOld []string, mode fuzzyMode) bool {
+	for i, contentLine := range contentWindow {
+		oldHasNewline := lineHasNewline(oldLines[i].raw)
+		if oldHasNewline && !lineHasNewline(contentLine.raw) {
+			return false
+		}
+		got := normalizeFuzzyLine(contentLine.raw, oldHasNewline, mode, false)
+		if got != normOld[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func splitLineSegments(s string) []lineSegment {
+	if s == "" {
+		return nil
+	}
+	var lines []lineSegment
+	start := 0
+	for i, r := range s {
+		if r == '\n' {
+			end := i + 1
+			lines = append(lines, lineSegment{raw: s[start:end], start: start, end: end})
+			start = end
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, lineSegment{raw: s[start:], start: start, end: len(s)})
+	}
+	return lines
+}
+
+func lineHasNewline(line string) bool {
+	return strings.HasSuffix(line, "\n")
+}
+
+func fuzzyWindowEnd(contentLast, oldLast lineSegment) int {
+	if lineHasNewline(oldLast.raw) || !lineHasNewline(contentLast.raw) {
+		return contentLast.end
+	}
+	end := contentLast.end - 1
+	if end > contentLast.start && contentLast.raw[len(contentLast.raw)-2] == '\r' {
+		end--
+	}
+	return end
+}
+
+func normalizeFuzzyLine(line string, includeNewline bool, mode fuzzyMode, stripReadPrefix bool) string {
+	body := strings.TrimSuffix(line, "\n")
+	if stripReadPrefix {
+		body, _ = stripReadFileLinePrefix(body)
+	}
+	if mode.trimTrailing {
+		body = strings.TrimRight(body, " \t\r")
+	}
+	if mode.expandTabs {
+		body = strings.ReplaceAll(body, "\t", "    ")
+	}
+	if mode.trimLeading {
+		body = strings.TrimLeft(body, " \t")
+	}
+	if includeNewline {
+		return body + "\n"
+	}
+	return body
+}
+
+func allLinesHaveReadFilePrefix(lines []lineSegment) bool {
+	if len(lines) == 0 {
+		return false
+	}
+	for _, line := range lines {
+		body := strings.TrimSuffix(line.raw, "\n")
+		if _, ok := stripReadFileLinePrefix(body); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func stripReadFileLinePrefix(line string) (string, bool) {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	j := i
+	for j < len(line) && line[j] >= '0' && line[j] <= '9' {
+		j++
+	}
+	if j == i || !strings.HasPrefix(line[j:], "\u2192") {
+		return line, false
+	}
+	return line[j+len("\u2192"):], true
+}
+
+func replaceEditRanges(content string, ranges []editRange, replacement string) string {
+	updated := content
+	for i := len(ranges) - 1; i >= 0; i-- {
+		r := ranges[i]
+		updated = updated[:r.start] + replacement + updated[r.end:]
+	}
+	return updated
+}
+
+func nearestContentLine(oldString, content string) (int, string, bool) {
+	oldLines := splitLineSegments(oldString)
+	if len(oldLines) == 0 {
+		return 0, "", false
+	}
+	target := strings.TrimSpace(normalizeFuzzyLine(oldLines[0].raw, false, fuzzyMode{trimTrailing: true, expandTabs: true}, true))
+	if target == "" {
+		return 0, "", false
+	}
+	bestLine := 0
+	bestScore := 0
+	bestText := ""
+	for i, line := range splitLineSegments(content) {
+		text := strings.TrimSuffix(line.raw, "\n")
+		score := commonPrefixLen(strings.TrimSpace(strings.ReplaceAll(text, "\t", "    ")), target)
+		if score > bestScore {
+			bestLine = i + 1
+			bestScore = score
+			bestText = text
+		}
+	}
+	if bestScore < 3 {
+		return 0, "", false
+	}
+	return bestLine, bestText, true
+}
+
+func commonPrefixLen(a, b string) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
 }

--- a/internal/tool/builtin/fuzzy_edit_test.go
+++ b/internal/tool/builtin/fuzzy_edit_test.go
@@ -1,0 +1,170 @@
+package builtin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEditFileFuzzyTrailingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	seed := "func main() {   \n\tfmt.Println(\"hello\")  \n}\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := (editFile{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path":       path,
+		"old_string": "func main() {\n\tfmt.Println(\"hello\")\n}",
+		"new_string": "func main() {\n\tfmt.Println(\"bye\")\n}",
+	}))
+	if err != nil {
+		t.Fatalf("edit_file: %v", err)
+	}
+	if !strings.Contains(out, "fuzzy match") {
+		t.Fatalf("output should disclose fuzzy matching, got %q", out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "func main() {\n\tfmt.Println(\"bye\")\n}\n"
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestEditFileFuzzyReadFileLinePrefixes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.txt")
+	seed := "alpha\nbeta\ngamma\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (editFile{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path":       path,
+		"old_string": "1\u2192alpha\n2\u2192beta",
+		"new_string": "ALPHA\nBETA",
+	}))
+	if err != nil {
+		t.Fatalf("edit_file: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ALPHA\nBETA\ngamma\n"
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestEditFileFuzzyCRLFPreservesLineEndings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "win.txt")
+	seed := "one   \r\ntwo   \r\nthree\r\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (editFile{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path":       path,
+		"old_string": "one\ntwo",
+		"new_string": "ONE\nTWO",
+	}))
+	if err != nil {
+		t.Fatalf("edit_file: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "ONE\r\nTWO\r\nthree\r\n"
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestEditFileFuzzyAmbiguousDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dup.txt")
+	seed := "target   \ntarget   \n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (editFile{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path":       path,
+		"old_string": "target\n",
+		"new_string": "updated\n",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "not unique") {
+		t.Fatalf("expected not-unique error, got %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != seed {
+		t.Fatalf("ambiguous fuzzy edit changed file: %q", got)
+	}
+}
+
+func TestEditFileFuzzyLeadingIndentDriftDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "indent.go")
+	seed := "func f() {\n    if ok {\n        return nil\n    }\n}\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (editFile{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path":       path,
+		"old_string": "if ok {\n    return nil\n}",
+		"new_string": "if ok {\n    return errors.New(\"nope\")\n}",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "old_string not found") {
+		t.Fatalf("expected not-found error for leading indentation drift, got %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != seed {
+		t.Fatalf("leading indentation drift changed file: %q", got)
+	}
+}
+
+func TestMultiEditFuzzyReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "list.txt")
+	seed := "item   \nitem\t\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := (multiEdit{}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"path": path,
+		"edits": []map[string]any{
+			{"old_string": "item\n", "new_string": "thing\n", "replace_all": true},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("multi_edit: %v", err)
+	}
+	if !strings.Contains(out, "2 total replacements") || !strings.Contains(out, "fuzzy match") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "thing\nthing\n"
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"reasonix/internal/tool"
 )
@@ -90,26 +89,19 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 	// safety guarantee that makes multi_edit preferable to chained
 	// edit_file calls.
 	applied := 0
+	usedFuzzy := false
 	for i, step := range p.Edits {
 		if step.OldString == "" {
 			return "", fmt.Errorf("edit %d: old_string is required", i+1)
 		}
-		old, newStr := matchLineEndings(content, step.OldString, step.NewString)
-		if step.ReplaceAll {
-			count := strings.Count(content, old)
-			if count == 0 {
-				return "", fmt.Errorf("edit %d: old_string not found", i+1)
-			}
-			content = strings.ReplaceAll(content, old, newStr)
-			applied += count
-			continue
-		}
-		switch strings.Count(content, old) {
-		case 0:
+		result := applyOldStringEdit(content, step.OldString, step.NewString, step.ReplaceAll)
+		switch {
+		case result.applied > 0:
+			content = result.updated
+			applied += result.applied
+			usedFuzzy = usedFuzzy || result.fuzzy
+		case result.matches == 0:
 			return "", fmt.Errorf("edit %d: old_string not found", i+1)
-		case 1:
-			content = strings.Replace(content, old, newStr, 1)
-			applied++
 		default:
 			return "", fmt.Errorf("edit %d: old_string is not unique; add more surrounding context or set replace_all", i+1)
 		}
@@ -117,6 +109,9 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 
 	if err := writeFileEncoded(p.Path, content, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
+	}
+	if usedFuzzy {
+		return fmt.Sprintf("multi_edit %s: %d edits applied (%d total replacements) (fuzzy match)", p.Path, len(p.Edits), applied), nil
 	}
 	return fmt.Sprintf("multi_edit %s: %d edits applied (%d total replacements)", p.Path, len(p.Edits), applied), nil
 }

--- a/internal/tool/builtin/preview.go
+++ b/internal/tool/builtin/preview.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"reasonix/internal/diff"
 	fileenc "reasonix/internal/fileutil/encoding"
@@ -71,17 +70,17 @@ func (e editFile) Preview(args json.RawMessage) (diff.Change, error) {
 		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
 	}
 
-	switch strings.Count(content, p.OldString) {
-	case 0:
-		return diff.Change{}, fmt.Errorf("old_string not found in %s", p.Path)
-	case 1:
+	applied := applyOldStringEdit(content, p.OldString, p.NewString, false)
+	switch {
+	case applied.applied == 1:
 		// ok
+	case applied.matches == 0:
+		return diff.Change{}, oldStringNotFoundError(p.Path, p.OldString, content)
 	default:
-		return diff.Change{}, fmt.Errorf("old_string is not unique in %s; add more surrounding context", p.Path)
+		return diff.Change{}, oldStringNotUniqueError(p.Path, applied.matches, false)
 	}
 
-	updated := strings.Replace(content, p.OldString, p.NewString, 1)
-	return diff.Build(p.Path, content, updated, diff.Modify), nil
+	return diff.Build(p.Path, content, applied.updated, diff.Modify), nil
 }
 
 // Preview computes the change multi_edit would make by replaying every edit
@@ -114,18 +113,12 @@ func (m multiEdit) Preview(args json.RawMessage) (diff.Change, error) {
 		if step.OldString == "" {
 			return diff.Change{}, fmt.Errorf("edit %d: old_string is required", i+1)
 		}
-		if step.ReplaceAll {
-			if strings.Count(content, step.OldString) == 0 {
-				return diff.Change{}, fmt.Errorf("edit %d: old_string not found", i+1)
-			}
-			content = strings.ReplaceAll(content, step.OldString, step.NewString)
-			continue
-		}
-		switch strings.Count(content, step.OldString) {
-		case 0:
+		result := applyOldStringEdit(content, step.OldString, step.NewString, step.ReplaceAll)
+		switch {
+		case result.applied > 0:
+			content = result.updated
+		case result.matches == 0:
 			return diff.Change{}, fmt.Errorf("edit %d: old_string not found", i+1)
-		case 1:
-			content = strings.Replace(content, step.OldString, step.NewString, 1)
 		default:
 			return diff.Change{}, fmt.Errorf("edit %d: old_string is not unique; add more surrounding context or set replace_all", i+1)
 		}

--- a/internal/tool/builtin/preview_test.go
+++ b/internal/tool/builtin/preview_test.go
@@ -59,6 +59,14 @@ func TestPreviewMatchesExecute(t *testing.T) {
 			},
 		},
 		{
+			name: "edit_file fuzzy",
+			tool: editFile{},
+			seed: "alpha   \nbeta   \n",
+			args: func(p string) map[string]any {
+				return map[string]any{"path": p, "old_string": "alpha\nbeta", "new_string": "ALPHA\nBETA"}
+			},
+		},
+		{
 			name: "multi_edit",
 			tool: multiEdit{},
 			seed: "package old\n\nfunc old() {\n\told()\n}\n",


### PR DESCRIPTION
## Summary
- Add a shared `old_string` edit matcher used by `edit_file`, `multi_edit`, and previews.
- Keep exact matching first, then allow unique fuzzy matches for trailing whitespace, tab-vs-spaces indentation, and copied `read_file` line prefixes.
- Preserve CRLF when fuzzy matching Windows-style files and keep ambiguous fuzzy matches as errors.
- Keep leading-indentation drift as a failure so the tool does not silently move or re-indent a structurally different code block.

## Fixes / Refs
Fixes #5503
Refs #2786
Refs #3277

## Consolidation Notes
Kept/adapted:
- Adapted the focused fuzzy `old_string` matching and diagnostics direction from #3277 by @expfukck, reimplemented narrowly on current `main-v2`.

Reviewed but not adopted:
- Did not adopt #3277's encoding selector/config propagation, fault-tolerant JSON parser, rewind/UI/history changes, generated artifacts, or broad leading-indentation fuzzy matching because they are separate, broader, and cache/schema-sensitive or write-safety-sensitive surfaces.

## Repository Contributor Credits
- @expfukck contributed the prior #3277 investigation/prototype around edit robustness. This PR credits that work and adapts only the narrow `old_string` matching idea.

## Cache Impact
Cache-impact: low - Changes cache-sensitive file-tool implementation, but tool schemas, tool descriptions, provider serialization, system prompt, memory prefix, and stable tool ordering are unchanged.
Cache-guard: `go test ./internal/tool/builtin ./internal/agent`; exact matching still runs first, leading-indentation drift is covered as a no-write failure, and the fallback runs only inside file tool execution after a tool call is already selected.

## Verification
- `go test ./internal/tool/builtin ./internal/agent`
- `git diff --check`
