### PR TITLE
fix(agent): allow complete_step by todo index

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -620,7 +620,7 @@ func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, re
 			r.Command = stringField(fields, "command")
 		}
 		if toolName == "complete_step" {
-			r.Step = stringField(fields, "step")
+			r.Step = completeStepIdentity(fields)
 			r.StepProof = completeStepHasProof(fields)
 		}
 		if toolName == "todo_write" {
@@ -687,6 +687,25 @@ func stringField(fields map[string]json.RawMessage, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(s)
+}
+
+func completeStepIdentity(fields map[string]json.RawMessage) string {
+	if n, ok := intField(fields, "step_index"); ok && n > 0 {
+		return strconv.Itoa(n)
+	}
+	return stringField(fields, "step")
+}
+
+func intField(fields map[string]json.RawMessage, key string) (int, bool) {
+	raw, ok := fields[key]
+	if !ok {
+		return 0, false
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func stringSliceField(fields map[string]json.RawMessage, key string) []string {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -190,6 +190,21 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 	}
 }
 
+func TestReceiptFromToolCallExtractsCompleteStepIndex(t *testing.T) {
+	receipt := ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step_index":2,
+		"result":"done",
+		"evidence":[{"kind":"manual","summary":"checked"}]
+	}`), true, true)
+
+	if receipt.Step != "2" {
+		t.Fatalf("step index not extracted as step identity: %+v", receipt)
+	}
+	if !receipt.StepProof {
+		t.Fatalf("step proof not detected: %+v", receipt)
+	}
+}
+
 func TestLedgerMatchesLatestSuccessfulTodoStep(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"reasonix/internal/evidence"
@@ -51,6 +52,7 @@ func (completeStep) Schema() json.RawMessage {
 "type":"object",
 "properties":{
   "step":{"type":"string","description":"Which plan step this completes — its title or number, matching the task list."},
+  "step_index":{"type":"integer","minimum":1,"description":"Optional 1-based task-list item number. Prefer this when the step title is long or easy to mistype."},
   "result":{"type":"string","description":"What is now true or changed as a result of finishing this step."},
   "evidence":{
     "type":"array",
@@ -69,7 +71,7 @@ func (completeStep) Schema() json.RawMessage {
   },
   "notes":{"type":"string","description":"Optional caveats, follow-ups, or anything deferred."}
 },
-"required":["step","result","evidence"]
+"required":["result","evidence"]
 }`)
 }
 
@@ -85,16 +87,21 @@ func (completeStep) PlanModeSafe() bool { return false }
 
 func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Step     string         `json:"step"`
-		Result   string         `json:"result"`
-		Evidence []stepEvidence `json:"evidence"`
-		Notes    string         `json:"notes"`
+		Step      string         `json:"step"`
+		StepIndex int            `json:"step_index"`
+		Result    string         `json:"result"`
+		Evidence  []stepEvidence `json:"evidence"`
+		Notes     string         `json:"notes"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
-	if strings.TrimSpace(p.Step) == "" {
-		return "", fmt.Errorf("step is required — name the plan step you are completing")
+	step := completeStepIdentity(p.Step, p.StepIndex)
+	if step == "" {
+		return "", fmt.Errorf("step or step_index is required — name the plan step you are completing, or cite its 1-based task-list number")
+	}
+	if p.StepIndex < 0 {
+		return "", fmt.Errorf("step_index must be a positive 1-based task-list number")
 	}
 	if strings.TrimSpace(p.Result) == "" {
 		return "", fmt.Errorf("result is required — state what is now true after finishing this step")
@@ -117,7 +124,7 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	if err != nil {
 		return "", err
 	}
-	todoMatch, hasTodo, err := verifyTodoStep(ctx, p.Step)
+	todoMatch, hasTodo, err := verifyTodoStep(ctx, step)
 	if err != nil {
 		return "", err
 	}
@@ -131,14 +138,21 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	}
 	todoStatus := ""
 	if hasTodo {
-		todoStatus = fmt.Sprintf(" Todo step: todo-matched %d.", todoMatch.Index)
+		todoStatus = fmt.Sprintf(" Todo step: todo-matched %d (%q).", todoMatch.Index, todoMatch.Content)
 	}
 	projectStatus := ""
 	if projectVerified > 0 {
 		projectStatus = fmt.Sprintf(" Project checks: project checks %d.", projectVerified)
 	}
 	return fmt.Sprintf("Step %q signed off with %d evidence item(s) [%s].%s The host advanced the task list; continue with the next step.",
-		p.Step, len(p.Evidence), strings.Join(kinds, ", "), hostStatus+todoStatus+projectStatus), nil
+		step, len(p.Evidence), strings.Join(kinds, ", "), hostStatus+todoStatus+projectStatus), nil
+}
+
+func completeStepIdentity(step string, stepIndex int) string {
+	if stepIndex > 0 {
+		return strconv.Itoa(stepIndex)
+	}
+	return strings.TrimSpace(step)
 }
 
 func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified int, manualUnverified int, err error) {

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -290,6 +290,33 @@ func TestCompleteStepMatchesTodoReceipt(t *testing.T) {
 	}
 }
 
+func TestCompleteStepMatchesTodoByExplicitStepIndex(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Add parser", Status: "completed"},
+			{Content: "Wire parser", Status: "in_progress"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	out, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step_index":2,
+		"result":"parser wiring is complete",
+		"evidence":[{"kind":"manual","summary":"checked manually"}]}`))
+	if err != nil {
+		t.Fatalf("todo-backed step_index rejected: %v", err)
+	}
+	if !strings.Contains(out, "todo-matched 2") {
+		t.Fatalf("ack should mention todo index match, got %q", out)
+	}
+	if !strings.Contains(out, "Wire parser") {
+		t.Fatalf("ack should name the indexed todo, got %q", out)
+	}
+}
+
 func TestCompleteStepRejectsTodoMismatch(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{


### PR DESCRIPTION
## Summary
- allow `complete_step` to cite a todo by explicit `step_index` when the title is long or easy to mistype
- record `step_index` in the evidence ledger using the existing numeric step identity
- include the matched todo title in the sign-off acknowledgement

Fixes #5176

Cache-impact: low - Changes the built-in complete_step schema by adding optional step_index; no tools are added or removed.
Cache-guard: `go test ./internal/agent -run TestPlanModeDoesNotMutateSystemOrTools -count=1`

## Verification
- `go test ./internal/tool/builtin ./internal/evidence -run 'TestCompleteStepMatchesTodoByExplicitStepIndex|TestReceiptFromToolCallExtractsCompleteStepIndex' -count=1`
- `go test ./internal/tool/builtin ./internal/evidence ./internal/agent -count=1`
- `go test ./internal/agent -run TestPlanModeDoesNotMutateSystemOrTools -count=1`
- `go test ./...`
- `git diff --check`