### PR TITLE
fix(desktop): prevent file drops opening images

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -172,6 +172,24 @@ function dispatchPasteFile(textarea: HTMLTextAreaElement, file: File) {
   textarea.dispatchEvent(event);
 }
 
+function nativeFileDropEvent(): Event {
+  const drop = new window.Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(drop, "dataTransfer", {
+    configurable: true,
+    value: {
+      types: ["Files"],
+      files: [{}],
+      items: [
+        {
+          kind: "file",
+          webkitGetAsEntry: () => ({ isFile: true }),
+        },
+      ],
+    },
+  });
+  return drop;
+}
+
 async function waitFor(label: string, predicate: () => boolean) {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await act(async () => {
@@ -452,20 +470,7 @@ console.log("\ncomposer goal toggle");
   const composer = document.querySelector(".composer") as HTMLElement | null;
   if (!composer) throw new Error("composer did not render");
 
-  const drop = new window.Event("drop", { bubbles: true, cancelable: true });
-  Object.defineProperty(drop, "dataTransfer", {
-    configurable: true,
-    value: {
-      types: ["Files"],
-      files: [{}],
-      items: [
-        {
-          kind: "file",
-          webkitGetAsEntry: () => ({ isFile: true }),
-        },
-      ],
-    },
-  });
+  const drop = nativeFileDropEvent();
   await act(async () => {
     composer.dispatchEvent(drop);
     await flushTimers();
@@ -474,6 +479,25 @@ console.log("\ncomposer goal toggle");
 
   await act(async () => {
     dropNavRoot.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  const { root: dropWrapRoot } = await renderComposer();
+  const wrap = document.querySelector(".composer-wrap") as HTMLElement | null;
+  if (!wrap) throw new Error("composer wrap did not render");
+
+  const drop = nativeFileDropEvent();
+  await act(async () => {
+    wrap.dispatchEvent(drop);
+    await flushTimers();
+  });
+  ok(drop.defaultPrevented, "outer native file drop target prevents browser image navigation");
+
+  await act(async () => {
+    dropWrapRoot.unmount();
   });
   dom.window.close();
 }

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1333,7 +1333,9 @@ export function Composer({
   };
 
   const onFileDropCapture = (e: DragEvent<HTMLDivElement>) => {
-    if (hasWorkspaceReferenceDrag(e.dataTransfer) || !hasFileDrag(e.dataTransfer) || !hasPathlessFileDrop(e.dataTransfer)) return;
+    if (hasWorkspaceReferenceDrag(e.dataTransfer) || !hasFileDrag(e.dataTransfer)) return;
+    e.preventDefault();
+    if (!hasPathlessFileDrop(e.dataTransfer)) return;
     const files = Array.from(e.dataTransfer.files);
     if (files.length === 0) return;
     stopNativeFileDrop(e);


### PR DESCRIPTION
## Summary

- Prevent native file drops on the composer wrapper from falling through to WebKit's default image/document navigation.
- Keep browser-provided image/file drops and Wails native path drops on their existing attachment paths.

## Root cause

- The Wails file drop target is on `.composer-wrap`, but the browser navigation guard only covered the inner `.composer` drop handler for path-based native file drops.
- Dropping an image on the outer target could let WebKitGTK open it as top-level webview content, which matches the reported full-window image overlay and unusable chrome.

## Fix

- The shared drop capture handler now prevents the browser default for all non-workspace file drops.
- It still only stops propagation for pathless browser file drops, so Wails native path drops continue through `OnFileDrop -> AttachDropped`.

## Validation

- `cd desktop/frontend && pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx`
  - Red before the fix: new outer drop target regression check failed.
  - Green after the fix: 30 passed, 0 failed.
- `cd desktop/frontend && pnpm exec tsx src/__tests__/composer-image-capability.test.tsx`
  - 10 passed, 0 failed.
- `cd desktop/frontend && pnpm exec tsc --noEmit -p tsconfig.test.json`
- `git diff --check`

## Compatibility

- No public API, schema, config, permission, dependency, or lockfile changes.
- Existing composer attachment behavior is preserved for browser clipboard/file drops and Wails native file drops.

## Risk / rollback

- Risk is low and scoped to composer file drop event handling.
- Manual verification on Linux Mint 22.3 / WebKitGTK 2.52.3 is still recommended because the original compositor symptom is platform-specific.
- Rollback is reverting this commit.

Cache-impact: none, desktop frontend drop handling only; no provider-visible prompt/tool/cache-sensitive path changes.
Cache-guard: n/a — desktop UI event handling is outside cache-sensitive paths.
System-prompt-review: N/A

Closes #5068
