### PR TITLE
fix(desktop): keep final replies visible in compact transcript

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildTurnGroups, createWarmLayerState, questionTurnsById, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
+import { buildStepGroups, buildTurnGroups, createWarmLayerState, questionTurnsById, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -66,6 +66,27 @@ console.log("\ntranscript grouping contract");
   eq(groups[0].endIdx, 4, "first group end index");
   eq(groups[0].toolCount, 2, "counts top-level tools in a turn");
   eq(groups[2].assistantPreview, "answer 2", "keeps latest assistant preview for each turn");
+}
+
+{
+  const groups = buildStepGroups([
+    { kind: "user", id: "u0", text: "fix this" },
+    { kind: "assistant", id: "a1", text: "visible answer before retry", reasoning: "", streaming: false },
+    { kind: "notice", id: "s1", level: "info", text: "↪ steer" },
+    { kind: "assistant", id: "a2", text: "", reasoning: "", streaming: true },
+  ] as Item[]);
+  eq(groups[1]?.isFinal, true, "visible assistant text before a later assistant stays outside processed folds");
+}
+
+{
+  const groups = buildStepGroups([
+    { kind: "user", id: "u0", text: "use tools" },
+    { kind: "assistant", id: "a1", text: "", reasoning: "", streaming: false },
+    { kind: "tool", id: "t1", name: "read_file", args: "{}", readOnly: true, status: "done" },
+    { kind: "assistant", id: "a2", text: "final answer", reasoning: "", streaming: false },
+  ] as Item[]);
+  eq(groups[1]?.isFinal, false, "tool-only completed steps still fold in compact mode");
+  eq(groups[2]?.isFinal, true, "later visible final answer renders directly");
 }
 
 {

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, questionTurnsById, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
+import { buildStepGroups, buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, questionTurnsById, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -367,37 +367,7 @@ export function Transcript({
   // Each completed non-final step is folded into "Processed".
   const stepGroups = useMemo(() => {
     if (displayMode === "standard") return null;
-    const groups: { items: Item[]; isFinal: boolean; isComplete: boolean }[] = [];
-    let current: Item[] = [];
-
-    for (let i = hotStartIdx; i < items.length; i++) {
-      const it = items[i];
-      if (it.kind === "user") {
-        if (current.length > 0) {
-          const first = current[0];
-          const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
-          groups.push({ items: current, isFinal, isComplete: true });
-          current = [];
-        }
-        groups.push({ items: [it], isFinal: false, isComplete: true });
-        continue;
-      }
-      if (it.kind === "assistant") {
-        if (current.length > 0) {
-          groups.push({ items: current, isFinal: false, isComplete: true });
-          current = [];
-        }
-        current.push(it);
-      } else {
-        current.push(it);
-      }
-    }
-    if (current.length > 0) {
-      const first = current[0];
-      const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
-      groups.push({ items: current, isFinal, isComplete: false });
-    }
-    return groups;
+    return buildStepGroups(items, hotStartIdx);
   }, [displayMode, hotStartIdx, items]);
 
   const hotZoneNodes = useMemo<ReactNode[]>(() => {

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -11,6 +11,12 @@ export interface TurnGroup {
   endIdx: number;
 }
 
+export interface StepGroup {
+  items: Item[];
+  isFinal: boolean;
+  isComplete: boolean;
+}
+
 export type WarmLayerState = {
   sessionKey: string;
   expandedWarmTurns: ReadonlySet<number>;
@@ -119,6 +125,36 @@ export function buildTurnGroups(items: Item[]): TurnGroup[] {
     }
   }
   return groups;
+}
+
+export function buildStepGroups(items: Item[], startIdx = 0): StepGroup[] {
+  const groups: StepGroup[] = [];
+  let current: Item[] = [];
+
+  const flush = (isComplete: boolean) => {
+    if (current.length === 0) return;
+    groups.push({ items: current, isFinal: hasVisibleAssistantText(current), isComplete });
+    current = [];
+  };
+
+  for (let i = startIdx; i < items.length; i++) {
+    const it = items[i];
+    if (it.kind === "user") {
+      flush(true);
+      groups.push({ items: [it], isFinal: false, isComplete: true });
+      continue;
+    }
+    if (it.kind === "assistant") {
+      flush(true);
+    }
+    current.push(it);
+  }
+  flush(false);
+  return groups;
+}
+
+function hasVisibleAssistantText(items: Item[]): boolean {
+  return items.some((it) => it.kind === "assistant" && !it.streaming && it.text.trim() !== "");
 }
 
 export function warmPagination({ turnCount, hotTurns, pageSize, coldPage }: {


### PR DESCRIPTION
## Summary

- Code-confirmed that compact transcript grouping could fold visible assistant text into a `Processed` step when another assistant cycle followed, such as after mid-turn steer or final-answer readiness retry.
- Move compact step grouping into the existing transcript grouping helper and mark any completed group with visible assistant text as directly renderable.
- Keep tool-only completed steps folded in compact mode and add regression coverage for both paths.
- Closes #5533

## Verification

- `pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
- `pnpm --dir desktop/frontend run typecheck`
- `git diff --check`

## Cache impact

Cache-impact: none, desktop transcript rendering only; no provider prompt, tool schema, or system prompt changes.
Cache-guard: `pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
System-prompt-review: N/A