### PR TITLE
fix(desktop): empty placeholder session overwrites real session, dropping system prompt

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5203,6 +5203,13 @@ func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTa
 		}
 		return nil, "", false
 	}
+	// An empty file (0 messages) is a pre-created placeholder, not a real
+	// session to resume.  Treating it as valid would make ctrl.Resume replace
+	// the executor's live session (with system prompt) with the empty one,
+	// causing the saved transcript to lack the agent identity contract.
+	if len(loaded.Snapshot()) == 0 {
+		return nil, path, true
+	}
 	return loaded, path, true
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -77,3 +77,13 @@ func (s *Session) HasContent() bool {
 	}
 	return false
 }
+
+// HasSystemMessage reports whether the session starts with a system message,
+// which carries the agent's stable identity and behavioural contract. Sessions
+// without one are not safe to persist: when reloaded the model has no identity
+// context and falls back to its training-data defaults.
+func (s *Session) HasSystemMessage() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.Messages) > 0 && s.Messages[0].Role == provider.RoleSystem
+}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -88,6 +88,55 @@ func TestHasContentWithTool(t *testing.T) {
 	}
 }
 
+// --- Session.HasSystemMessage ---
+
+func TestHasSystemMessageWithSystem(t *testing.T) {
+	s := NewSession("system prompt")
+	if !s.HasSystemMessage() {
+		t.Error("session with system message should report HasSystemMessage true")
+	}
+}
+
+func TestHasSystemMessageWithoutSystem(t *testing.T) {
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if s.HasSystemMessage() {
+		t.Error("session without system message should report HasSystemMessage false")
+	}
+}
+
+func TestHasSystemMessageAfterReplaceWithoutSystem(t *testing.T) {
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "kept"})
+	// Replace with messages that have no system message — simulates a
+	// compact/summarise path that failed to preserve the system prompt.
+	s.Replace([]provider.Message{
+		{Role: provider.RoleUser, Content: "replaced"},
+	})
+	if s.HasContent() {
+		// HasContent returns true because the user message exists.
+		if s.HasSystemMessage() {
+			t.Error("session replaced without system message should report HasSystemMessage false")
+		}
+	} else {
+		t.Error("session with user message should have content")
+	}
+}
+
+func TestHasSystemMessageCompactedKeepsSystem(t *testing.T) {
+	// This is the healthy path: compact preserves the system message at index 0.
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "answer"})
+	s.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "summary"},
+	})
+	if !s.HasSystemMessage() {
+		t.Error("compacted session should still have system message at index 0")
+	}
+}
+
 // --- Save / LoadSession round-trip ---
 
 func TestSaveLoadSessionRoundTrip(t *testing.T) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2138,6 +2138,18 @@ func (c *Controller) snapshot(markActivity bool) error {
 		// prompt) — staying quiet here is correct, not a data-loss path.
 		return nil
 	}
+	if !s.HasSystemMessage() {
+		// The session has user/assistant/tool messages but no leading system
+		// prompt.  Persisting it would create a session file that, when
+		// reloaded, has no agent-identity contract — the model falls back to
+		// its training-data defaults, giving wrong answers to identity
+		// queries ("who are you?").  Log the anomaly so the root cause
+		// (typically an empty sysPrompt reaching NewSession) can be
+		// diagnosed, then refuse to write a corrupted transcript.
+		slog.Warn("controller: refusing to snapshot session with content but no system message",
+			"label", c.Label(), "session_dir", c.SessionDir(), "message_count", len(s.Snapshot()))
+		return nil
+	}
 	if path == "" {
 		// There IS content but nowhere to write it: this silently dropped whole
 		// bot conversations (#4414). Surface it loudly instead of returning nil


### PR DESCRIPTION
## Bug

When a new desktop tab is created, the saved session file has no system
message — the agent identity contract (Reasonix persona, AGENTS.md,
MEMORY.md) is lost.  When the session is reloaded the model has no
identity context and falls back to its training-data defaults, giving
wrong answers to identity questions.

## Root cause

In `desktop/tabs.go`:

1. `createEmptySessionFile(dir, "")` pre-creates an empty placeholder `.jsonl`
   file (0 bytes) for a new tab.
2. `buildTabControllerWithContext` builds a real session with the full
   system prompt via `boot.Build()`.
3. `loadPinnedTabSessionWithPreload` loads the placeholder via
   `LoadSession`, which returns a **non-nil** `&Session{}` with zero
   messages for an empty file (EOF is not an error).
4. Because it's non-nil, `ctrl.Resume(emptySession, path)` is called,
   which calls `executor.SetSession(emptySession)` — **replacing the
   real session with an empty one**.
5. The first turn adds a user message and `snapshot()` saves the
   session — without any system message.

## Fix

One logical line in `loadPinnedTabSessionWithPreload`: treat a
0-message session the same as a missing file (return nil), so the
caller keeps the session built by `boot.Build`.

Defensive guard in `controller.snapshot()`: refuse to persist a
session that has user/assistant/tool content but no system message,
preventing future regressions from silently producing broken transcripts.

## Verification

- `go test ./desktop -count=1` — all pass
- `go test ./internal/agent/... ./internal/control/... -count=1` — all pass
- Wails build: `wails build` — successful
- Includes `HasSystemMessage()` unit tests covering the normal,
  missing, post-Replace, and post-compaction cases