### PR TITLE
fix(desktop): skip onboarding when any provider credential is stored

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7223,7 +7223,12 @@ func (a *App) ConfirmAction(req NativeConfirmRequest) (bool, error) {
 }
 
 func (a *App) NeedsOnboarding() bool {
-	return !config.CredentialStored(onboardingKeyEnv)
+	if config.CredentialStored(onboardingKeyEnv) {
+		return false
+	}
+	// If the user has configured any custom provider (or any other credential
+	// stored in Reasonix's global .env), skip the first-run DeepSeek gate.
+	return !config.AnyCredentialStored()
 }
 
 // ConnectKey validates apiKey against the balance endpoint, persists it to

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -143,6 +143,26 @@ func TestNeedsOnboardingTreatsBlankSavedKeyAsMissing(t *testing.T) {
 	}
 }
 
+func TestNeedsOnboardingSkipsWhenCustomProviderKeyStored(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	// No DEEPSEEK_API_KEY stored — simulate a user who only has a custom provider.
+	setDesktopTestCredential(t, "OPENAI_API_KEY", "sk-custom")
+
+	app := NewApp()
+	if app.NeedsOnboarding() {
+		t.Fatal("NeedsOnboarding should return false when any credential (e.g. custom provider) is stored")
+	}
+}
+
+func TestNeedsOnboardingRequiresKeyWhenCredentialsFileMissing(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	// No credentials file at all — onboarding should still be required.
+	app := NewApp()
+	if !app.NeedsOnboarding() {
+		t.Fatal("NeedsOnboarding should require a key when no credentials file exists")
+	}
+}
+
 func providerNamesFromView(providers []ProviderView) []string {
 	out := make([]string, 0, len(providers))
 	for _, p := range providers {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -278,6 +278,18 @@ func CredentialStored(key string) bool {
 	return envFileHasValue(UserCredentialsPath(), key)
 }
 
+// AnyCredentialStored reports whether Reasonix's global credentials file
+// contains at least one non-empty credential. The desktop onboarding gate
+// uses this to avoid re-prompting users who already have a custom provider
+// (or any other provider) configured — not just the default DeepSeek key.
+func AnyCredentialStored() bool {
+	path := UserCredentialsPath()
+	if path == "" {
+		return false
+	}
+	return envFileHasAnyValue(path)
+}
+
 func credentialCurrentStoreHasKey(key string) bool {
 	key = strings.TrimSpace(key)
 	if key == "" {

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -152,6 +152,37 @@ func readDotEnvFileMap(path string, allow func(string) bool) map[string]string {
 	return out
 }
 
+// envFileHasAnyValue reports whether path contains at least one non-empty,
+// non-comment KEY=value assignment. Used by AnyCredentialStored to decide
+// whether the user has configured *any* provider key (not just DeepSeek).
+func envFileHasAnyValue(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if strings.Trim(strings.TrimSpace(val), `"'`) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func envFileValue(path, wantKey string) (string, bool) {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## 问题

桌面端每次启动都会弹出「连接 Reasonix」Onboarding 窗口，要求输入 DeepSeek API key，即使用户已经通过「设置 → 模型 → 访问」配置了自定义供应端（如 OpenAI 兼容接口）。

## 根因

`NeedsOnboarding()` 只检查 `DEEPSEEK_API_KEY` 是否存储在 Reasonix 全局 `.env` 中（`desktop/app.go:7225-7227`）。自定义供应端的 API key 使用不同的环境变量名（如 `OPENAI_API_KEY`），因此检查始终返回 `true`，每次启动都弹窗。

## 修复

1. 在 `internal/config/dotenv.go` 添加 `envFileHasAnyValue()` —— 扫描凭证文件是否有任何非空条目
2. 在 `internal/config/credentials.go` 添加 `AnyCredentialStored()` —— 公开 API
3. 修改 `NeedsOnboarding()`：先检查 `DEEPSEEK_API_KEY`（快路径），若不存在则检查是否有任何其他凭证

## 测试

- `TestNeedsOnboardingIgnoresInheritedEnv` —— 保持原有行为
- `TestNeedsOnboardingTreatsBlankSavedKeyAsMissing` —— 保持原有行为
- `TestNeedsOnboardingSkipsWhenCustomProviderKeyStored` —— **新增**：验证自定义供应端 key 也能跳过 onboarding
- `TestNeedsOnboardingRequiresKeyWhenCredentialsFileMissing` —— **新增**：验证无凭证文件时仍需 onboarding