### PR TITLE
fix(acp): MCPServerSpec.Headers 兼容 ACP 官方 [{name,value}] 数组形状

### DIFF
--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -121,29 +121,57 @@ type SessionNewParams struct {
 
 // MCPServerSpec describes one MCP server the client asks the agent to connect.
 type MCPServerSpec struct {
-	Name    string            `json:"name"`
-	Type    string            `json:"type,omitempty"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     MCPEnv            `json:"env,omitempty"`
-	URL     string            `json:"url,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	Name    string     `json:"name"`
+	Type    string     `json:"type,omitempty"`
+	Command string     `json:"command,omitempty"`
+	Args    []string   `json:"args,omitempty"`
+	Env     MCPEnv     `json:"env,omitempty"`
+	URL     string     `json:"url,omitempty"`
+	Headers MCPHeaders `json:"headers,omitempty"`
 }
 
 // MCPEnv accepts ACP's official EnvVariable[] shape while still accepting the
 // older map shape that Reasonix v1 clients used.
 type MCPEnv map[string]string
 
-// EnvVariable is one official ACP MCP environment variable entry.
+// MCPHeaders accepts ACP's official HTTPHeader[] shape while still accepting
+// the older map shape that Reasonix v1 clients used. The official spec
+// (https://agentclientprotocol.com) ships HTTP/SSE MCP headers as an array of
+// {name,value} objects, even when empty.
+type MCPHeaders map[string]string
+
+// EnvVariable is one official ACP MCP environment variable entry. The same
+// {name,value} shape is also used by HTTP/SSE headers in the ACP spec, so we
+// reuse it as the parse target for [MCPHeaders] too.
 type EnvVariable struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
 func (e *MCPEnv) UnmarshalJSON(raw []byte) error {
-	if strings.TrimSpace(string(raw)) == "" || strings.TrimSpace(string(raw)) == "null" {
-		*e = nil
-		return nil
+	out, err := unmarshalNameValueMap(raw, "env")
+	if err != nil {
+		return err
+	}
+	*e = out
+	return nil
+}
+
+func (h *MCPHeaders) UnmarshalJSON(raw []byte) error {
+	out, err := unmarshalNameValueMap(raw, "headers")
+	if err != nil {
+		return err
+	}
+	*h = out
+	return nil
+}
+
+// unmarshalNameValueMap parses ACP's official [{name,value}, ...] array shape
+// or the legacy {name: value, ...} map shape into a map. field names the JSON
+// field for error messages.
+func unmarshalNameValueMap(raw []byte, field string) (map[string]string, error) {
+	if s := strings.TrimSpace(string(raw)); s == "" || s == "null" {
+		return nil, nil
 	}
 
 	var vars []EnvVariable
@@ -151,20 +179,18 @@ func (e *MCPEnv) UnmarshalJSON(raw []byte) error {
 		out := make(map[string]string, len(vars))
 		for i, v := range vars {
 			if strings.TrimSpace(v.Name) == "" {
-				return fmt.Errorf("env[%d].name is required", i)
+				return nil, fmt.Errorf("%s[%d].name is required", field, i)
 			}
 			out[v.Name] = v.Value
 		}
-		*e = out
-		return nil
+		return out, nil
 	}
 
 	var legacy map[string]string
 	if err := json.Unmarshal(raw, &legacy); err == nil {
-		*e = legacy
-		return nil
+		return legacy, nil
 	}
-	return fmt.Errorf("env must be an array of {name,value} objects")
+	return nil, fmt.Errorf("%s must be an array of {name,value} objects", field)
 }
 
 // SessionNewResult returns the opaque id used to address the session thereafter.

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -142,7 +142,7 @@ func TestMcpSpecsNil(t *testing.T) {
 func TestMcpSpecsConversion(t *testing.T) {
 	in := []MCPServerSpec{
 		{Name: "search", Command: "search-mcp", Args: []string{"--stdio"}, Env: MCPEnv{"HOME": "/tmp"}},
-		{Name: "remote", Type: "http", URL: "https://mcp.example.test", Headers: map[string]string{"Authorization": "Bearer token"}},
+		{Name: "remote", Type: "http", URL: "https://mcp.example.test", Headers: MCPHeaders{"Authorization": "Bearer token"}},
 	}
 	got, err := mcpSpecs(in, "/workspace")
 	if err != nil {
@@ -191,6 +191,67 @@ func TestMCPEnvAcceptsOfficialArrayShape(t *testing.T) {
 	}
 	if got[0].Env["HOME"] != "/tmp" || got[0].Env["EMPTY"] != "" {
 		t.Fatalf("env = %v, want HOME and EMPTY from official array", got[0].Env)
+	}
+}
+
+func TestMCPHeadersAcceptsOfficialArrayShape(t *testing.T) {
+	var p SessionNewParams
+	raw := []byte(`{
+		"cwd":"/tmp",
+		"mcpServers":[{
+			"name":"remote",
+			"type":"http",
+			"url":"https://mcp.example.test",
+			"headers":[{"name":"Authorization","value":"Bearer token"},{"name":"X-Trace","value":""}]
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal official headers array: %v", err)
+	}
+	got, err := mcpSpecs(p.MCPServers, p.Cwd)
+	if err != nil {
+		t.Fatalf("mcpSpecs: %v", err)
+	}
+	if got[0].Headers["Authorization"] != "Bearer token" || got[0].Headers["X-Trace"] != "" {
+		t.Fatalf("headers = %v, want Authorization and X-Trace from official array", got[0].Headers)
+	}
+}
+
+func TestMCPHeadersAcceptsEmptyArray(t *testing.T) {
+	var p SessionNewParams
+	raw := []byte(`{
+		"cwd":"/tmp",
+		"mcpServers":[{
+			"name":"remote",
+			"type":"http",
+			"url":"https://mcp.example.test",
+			"headers":[]
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal empty headers array (paseo-shape): %v", err)
+	}
+	if len(p.MCPServers[0].Headers) != 0 {
+		t.Fatalf("headers = %v, want empty", p.MCPServers[0].Headers)
+	}
+}
+
+func TestMCPHeadersAcceptsLegacyMap(t *testing.T) {
+	var p SessionNewParams
+	raw := []byte(`{
+		"cwd":"/tmp",
+		"mcpServers":[{
+			"name":"remote",
+			"type":"http",
+			"url":"https://mcp.example.test",
+			"headers":{"Authorization":"Bearer token"}
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal legacy headers map: %v", err)
+	}
+	if p.MCPServers[0].Headers["Authorization"] != "Bearer token" {
+		t.Fatalf("headers = %v, want legacy-map value", p.MCPServers[0].Headers)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `MCPServerSpec.Headers` 之前声明的是 `map[string]string`，导致任何按 ACP 官方 spec 实现的客户端（如 Paseo `@getpaseo/server` v0.1.100）发的 `session/new` 会被直接拒绝：
    ```
    json: cannot unmarshal array into Go struct field MCPServerSpec.mcpServers.headers of type map[string]string
    ```
- ACP 规范要求 HTTP/SSE MCP server 的 `headers` 字段是 `[{name, value}, ...]` 数组——见 https://agentclientprotocol.com 。Paseo 即使没配自定义 header 也会发空数组 `"headers": []`，触发上面这个错。
- 同 struct 里的 `Env` 字段早就用自定义类型 `MCPEnv` + `UnmarshalJSON` 解决了完全一样的问题（同时兼容官方数组形状与旧版 map 形状）。本 PR 给 `Headers` 加上对应的 `MCPHeaders` 类型，并把 `Env` 已有的 unmarshal 逻辑抽成共享的 `unmarshalNameValueMap` 助手，两个字段共享一份实现。
- 旧 wire format 完全不受影响：`TestMcpSpecsConversion`（legacy map）和 `TestMCPEnvAcceptsOfficialArrayShape`（官方数组）原样通过。下游 `service.go:1555` 的 `mapString(m.Headers)` 调用因为 `MCPHeaders` 底层仍是 map，无需改动。

Closes #5553

## Verification

- `go test ./internal/acp/... -count=1` 全绿
- `go build ./cmd/reasonix` 干净通过
- e2e 探针：拿打过补丁的 binary 跑 `reasonix acp`，通过 stdio 喂入 `initialize` + Paseo 实际形状的 `session/new`（`"headers": []`），`session/new` 现在返回正常 result（之前直接 unmarshal 失败）
- 新增 3 个测试：
    - `TestMCPHeadersAcceptsOfficialArrayShape`——官方 `[{name,value}, ...]`
    - `TestMCPHeadersAcceptsEmptyArray`——空数组 `[]`（即 Paseo 实际触发本 bug 的形状）
    - `TestMCPHeadersAcceptsLegacyMap`——旧 `{"k": "v"}` map 形状回归

## Cache impact

Cache-impact: none — 仅改 ACP 请求体的反序列化，不影响 provider prompt prefix、memory prefix、tool schema 或任何 cache-stable 输入
Cache-guard: N/A
System-prompt-review: N/A
