### PR TITLE
fix(agent): validate branch session ids in subagent lineage

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -382,7 +382,11 @@ func (s *SubagentStore) nearestLineageSource(requestedRef string, spec SubagentS
 }
 
 func (s *SubagentStore) sessionAncestors(current string) ([]string, error) {
-	current = strings.TrimSpace(current)
+	var err error
+	current, err = normalizeLineageSessionID(current)
+	if err != nil {
+		return nil, err
+	}
 	if current == "" {
 		return nil, nil
 	}
@@ -404,7 +408,10 @@ func (s *SubagentStore) sessionAncestors(current string) ([]string, error) {
 		if strings.TrimSpace(meta.ID) != cursor {
 			return nil, fmt.Errorf("branch metadata for session %q declares id %q", cursor, meta.ID)
 		}
-		parent := strings.TrimSpace(meta.ParentID)
+		parent, err := normalizeLineageSessionID(meta.ParentID)
+		if err != nil {
+			return nil, err
+		}
 		if parent == "" {
 			break
 		}
@@ -618,7 +625,11 @@ func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
 }
 
 func requireParentSession(spec SubagentSpec) error {
-	if strings.TrimSpace(spec.ParentSession) == "" {
+	parentSession, err := normalizeLineageSessionID(spec.ParentSession)
+	if err != nil {
+		return err
+	}
+	if parentSession == "" {
 		return fmt.Errorf("subagent transcript parent session is required")
 	}
 	return nil
@@ -656,8 +667,15 @@ func (s *SubagentStore) validateForkOwner(meta SubagentMeta, spec SubagentSpec) 
 }
 
 func (s *SubagentStore) isAncestorSession(ancestor, current string) (bool, error) {
-	ancestor = strings.TrimSpace(ancestor)
-	current = strings.TrimSpace(current)
+	var err error
+	ancestor, err = normalizeLineageSessionID(ancestor)
+	if err != nil {
+		return false, err
+	}
+	current, err = normalizeLineageSessionID(current)
+	if err != nil {
+		return false, err
+	}
 	if ancestor == "" || current == "" {
 		return false, nil
 	}
@@ -681,7 +699,10 @@ func (s *SubagentStore) isAncestorSession(ancestor, current string) (bool, error
 		if cursor == ancestor {
 			return true, nil
 		}
-		parent := strings.TrimSpace(meta.ParentID)
+		parent, err := normalizeLineageSessionID(meta.ParentID)
+		if err != nil {
+			return false, err
+		}
 		cursor = parent
 	}
 	return false, nil
@@ -754,6 +775,27 @@ func validSubagentRef(ref string) bool {
 	}
 	for _, r := range ref {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizeLineageSessionID(id string) (string, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return "", nil
+	}
+	if trimmed != id || trimmed == "." || trimmed == ".." || !validLineageSessionID(trimmed) {
+		return "", fmt.Errorf("invalid parent session identifier %q", id)
+	}
+	return trimmed, nil
+}
+
+func validLineageSessionID(id string) bool {
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
 			continue
 		}
 		return false

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -509,6 +509,111 @@ func TestSubagentStoreRejectsForkWhenLineageCannotBeProven(t *testing.T) {
 	}
 }
 
+func TestSubagentStoreRejectsUnsafeLineageSessionIDs(t *testing.T) {
+	rootDir := t.TempDir()
+	sessionDir := filepath.Join(rootDir, "sessions")
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	outsidePath := filepath.Join(rootDir, "outside.jsonl")
+	if err := SaveBranchMeta(outsidePath, BranchMeta{ID: "../outside"}); err != nil {
+		t.Fatalf("SaveBranchMeta(outside): %v", err)
+	}
+	saveTestBranchMeta(t, sessionDir, "child", "")
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "ancestors current traversal",
+			run: func() error {
+				_, err := store.sessionAncestors("../outside")
+				return err
+			},
+		},
+		{
+			name: "ancestor current traversal",
+			run: func() error {
+				_, err := store.isAncestorSession("child", "../outside")
+				return err
+			},
+		},
+		{
+			name: "ancestor target traversal",
+			run: func() error {
+				_, err := store.isAncestorSession("../outside", "child")
+				return err
+			},
+		},
+		{
+			name: "prepare parent traversal",
+			run: func() error {
+				spec := testSubagentSpec(t, "review")
+				spec.ParentSession = "../outside"
+				run, err := store.PrepareFresh(spec)
+				if run != nil {
+					run.Release()
+				}
+				return err
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requireInvalidLineageSessionID(t, tc.run())
+		})
+	}
+}
+
+func TestSubagentStoreRejectsUnsafeLineageParentIDs(t *testing.T) {
+	rootDir := t.TempDir()
+	sessionDir := filepath.Join(rootDir, "sessions")
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	outsidePath := filepath.Join(rootDir, "outside.jsonl")
+	if err := SaveBranchMeta(outsidePath, BranchMeta{ID: "../outside"}); err != nil {
+		t.Fatalf("SaveBranchMeta(outside): %v", err)
+	}
+	saveTestBranchMeta(t, sessionDir, "child", "../outside")
+
+	t.Run("ancestors parent traversal", func(t *testing.T) {
+		_, err := store.sessionAncestors("child")
+		requireInvalidLineageSessionID(t, err)
+	})
+	t.Run("ancestor parent traversal", func(t *testing.T) {
+		_, err := store.isAncestorSession("root", "child")
+		requireInvalidLineageSessionID(t, err)
+	})
+}
+
+func TestSubagentStoreLineageAllowsDottedSessionIDs(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	root := "2026.06.29-root"
+	child := "child.session-1"
+	saveTestBranchMeta(t, sessionDir, root, "")
+	saveTestBranchMeta(t, sessionDir, child, root)
+
+	ancestors, err := store.sessionAncestors(child)
+	if err != nil {
+		t.Fatalf("sessionAncestors: %v", err)
+	}
+	if len(ancestors) != 1 || ancestors[0] != root {
+		t.Fatalf("ancestors = %v, want [%s]", ancestors, root)
+	}
+	ok, err := store.isAncestorSession(root, child)
+	if err != nil {
+		t.Fatalf("isAncestorSession: %v", err)
+	}
+	if !ok {
+		t.Fatalf("isAncestorSession(%q, %q) = false, want true", root, child)
+	}
+}
+
 func TestSubagentStoreForkReleasesSourceLockAfterCopy(t *testing.T) {
 	store := NewSubagentStore(t.TempDir())
 	spec := testSubagentSpec(t, "review")
@@ -712,4 +817,11 @@ func prepareCompletedSubagentForLineageTest(t *testing.T, parentSession string) 
 	}
 	run.Release()
 	return sessionDir, store, run.Ref, spec
+}
+
+func requireInvalidLineageSessionID(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), "invalid parent session identifier") {
+		t.Fatalf("error = %v, want invalid parent session identifier", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Reject unsafe session IDs before subagent lineage code builds branch metadata paths.
- Validate current, ancestor, and parent session IDs used by `sessionAncestors`, `isAncestorSession`, and `requireParentSession`.
- Add regression coverage for path traversal-style IDs and confirm dotted session IDs remain valid.

Fixes #5551

## Verification

- `go test ./internal/agent -run TestSubagentStore -count=1`
- `go test ./internal/agent -count=1`
- `git diff --check`

## Cache impact

Cache-impact: none, this only changes agent-side session lineage ID validation and does not affect prompts, tool schemas, provider requests, memory prefix, or output styles.
Cache-guard: `go test ./internal/agent -run TestSubagentStore -count=1` covers the changed subagent lineage behavior.
System-prompt-review: N/A