### PR TITLE
Develop/reasonix desktop integration

### DIFF
--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -118,6 +118,7 @@ func (r *desktopBotRuntime) apply(parent context.Context, cfg *config.Config, wo
 		OnInbound:                botruntime.NewRemoteRememberer(logger),
 		OnSessionReady:           botruntime.NewSessionRemembererWithWorkspace(logger, workspaceRoot),
 		OnToolApprovalModeChange: onToolApprovalModeChange,
+		Plugins:                  cfg.AutoStartPlugins(),
 	}
 	bindings := botruntime.AdapterBindings(cfg, plan.Enabled, nil, logger)
 	if len(bindings) == 0 {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1,4 +1,4 @@
-// Package boot assembles a ready-to-drive control.Controller from configuration:
+﻿// Package boot assembles a ready-to-drive control.Controller from configuration:
 // it loads config, resolves the model(s), builds the tool registry (built-ins +
 // plugins), wires the permission gate, and constructs the executor — optionally
 // wrapping it in a two-model Coordinator. It is the one place that turns "what the
@@ -101,6 +101,8 @@ type Options struct {
 	// SessionDir overrides where persisted chat transcripts are written. When
 	// empty, the shared CLI/global session directory is used.
 	SessionDir string
+	// SystemPromptOverride replaces the default Reasonix base prompt entirely.
+	SystemPromptOverride string
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -186,6 +188,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 
 	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
+	if opts.SystemPromptOverride != "" {
+		sysPrompt = opts.SystemPromptOverride
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -54,6 +54,7 @@ type ChannelConfig struct {
 	Model            string
 	ToolApprovalMode string
 	WorkspaceRoot    string
+	SystemPrompt     string
 }
 
 // AdapterBinding attaches an adapter instance to one saved bot connection.
@@ -356,6 +357,44 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 	}
 
 	gw.runTurn(ctx, binding.Adapter, key, msg)
+
+	// turn 完成后，drain msgCh 中同 session 的消息，注入历史上下文
+	gw.drainSameSessionMsg(ctx, key, binding, msg.Platform)
+}
+
+// drainSameSessionMsg 在 turn 完成后，清空 msgCh 中同 session 的排队消息，
+// 将它们注入 session 历史作为上下文（不触发 AI 回复）。
+func (gw *BotGateway) drainSameSessionMsg(ctx context.Context, key string, binding AdapterBinding, plat Platform) {
+	// 非阻塞读取 msgCh，收集同 session 的消息
+	var skipped []string
+	msgCh := binding.Adapter.Messages()
+	for {
+		select {
+		case next := <-msgCh:
+			nextKey := BuildSessionKey(next.Session())
+			if nextKey == key {
+				if next.Text != "" {
+					skipped = append(skipped, next.Text)
+				}
+				continue
+			}
+			// 不同 session 的消息放不回去了... 直接丢弃（容错）
+			gw.logger.Warn("dropped cross-session message due to drain", "session", key[:8], "other_session", nextKey[:8])
+		default:
+			// 通道空，结束
+			if len(skipped) > 0 {
+				merged := strings.Join(skipped, "\n")
+				gw.mu.Lock()
+				state := gw.controllers[key]
+				gw.mu.Unlock()
+				if state != nil && state.ctrl != nil {
+					state.ctrl.AddUserMessage(merged)
+					gw.logger.Info("injected skipped messages into session history", "session", key[:8], "count", len(skipped), "chars", len(merged))
+				}
+			}
+			return
+		}
+	}
 }
 
 func (gw *BotGateway) addPendingReaction(ctx context.Context, plat Platform, adapter Adapter, msg InboundMessage) {
@@ -784,6 +823,11 @@ func toolApprovalModeLabel(mode string) string {
 func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, msg InboundMessage) {
 	gw.logger.Info("bot turn started", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
 	defer func() {
+		if r := recover(); r != nil {
+			gw.logger.Error("turn panicked", "session", key[:8], "recover", r)
+			gw.sessions.ForceRelease(key)
+			return
+		}
 		// 检查是否有等待队列中的消息
 		next := gw.sessions.Release(key)
 		if next != nil {
@@ -841,8 +885,9 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 	state.sink.setTarget(sink)
 	defer state.sink.setTarget(nil)
 
-	// 创建带取消的 context
-	turnCtx, cancel := context.WithCancel(ctx)
+	// 创建带取消和超时的 context
+	turnTimeout := 120 * time.Second
+	turnCtx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
 
 	gw.mu.Lock()
@@ -880,6 +925,15 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	gw.logger.Info("bot session creating", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "model", model, "workspace_set", strings.TrimSpace(workspaceRoot) != "", "tool_approval_mode", normalizeBotToolApprovalMode(toolApprovalMode))
 	// convert configured plugins to plugin specs for boot
 	pluginSpecs := boot.PluginSpecs(gw.cfg.Plugins)
+	// 解析 system prompt：优先使用 per-platform 通道配置
+	sysPrompt := gw.cfg.SystemPrompt
+	if ch, ok := gw.cfg.Channels[msg.Platform]; ok && ch.SystemPrompt != "" {
+		sysPrompt = ch.SystemPrompt
+	} else if connCh, ok := gw.cfg.ConnectionChannels[msg.ConnectionID]; ok && connCh.SystemPrompt != "" {
+		sysPrompt = connCh.SystemPrompt
+	}
+	gw.logger.Info("bot system prompt resolved", "platform", msg.Platform, "connection", msg.ConnectionID, "has_channel", gw.cfg.Channels[msg.Platform].SystemPrompt != "", "sysprompt_len", len(sysPrompt))
+
 	ctrl, err := boot.Build(ctx, boot.Options{
 		Model:         model,
 		MaxSteps:      gw.cfg.MaxSteps,
@@ -887,7 +941,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		Sink:          sessionSink,
 		WorkspaceRoot: workspaceRoot,
 		SessionDir:    botSessionDir(workspaceRoot),
-		SystemPromptOverride: gw.cfg.SystemPrompt,
+		SystemPromptOverride: sysPrompt,
 		ExtraPlugins:  pluginSpecs,
 	})
 	if err != nil {

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -1,10 +1,16 @@
-package bot
+﻿package bot
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +43,9 @@ type GatewayConfig struct {
 	// The gateway updates the live session and in-memory defaults first; this
 	// callback lets desktop save the chosen connection mode to user config.
 	OnToolApprovalModeChange func(InboundMessage, string) error
+	// Plugins are MCP servers to load into bot sessions, mirroring the
+	// desktop/CLI plugin system so bot sessions have the same tools.
+	Plugins []config.PluginEntry
 }
 
 // ChannelConfig overrides gateway defaults for one IM channel.
@@ -320,6 +329,29 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 		// 正在处理中且非 bypass 命令，已在 TryAcquire 中入队
 		gw.logger.Debug("session busy, queued", "session", key[:8])
 		return
+	}
+
+	// download media for AI context
+	if len(msg.MediaURLs) > 0 {
+		mediaDir := filepath.Join(os.TempDir(), "reasonix-bot-media")
+		os.MkdirAll(mediaDir, 0755)
+		var mediaRefs []string
+		for _, mediaURL := range msg.MediaURLs {
+			localPath, err := gw.downloadMedia(ctx, mediaURL, mediaDir)
+			if err != nil {
+				gw.logger.Warn("media download failed", "url", hashID(mediaURL), "err", err)
+				continue
+			}
+			mediaRefs = append(mediaRefs, localPath)
+		}
+		if len(mediaRefs) > 0 {
+			prefix := "[File](" + strings.Join(mediaRefs, ", ") + ")"
+			if msg.Text != "" {
+				msg.Text = prefix + " " + msg.Text
+			} else {
+				msg.Text = prefix
+			}
+		}
 	}
 
 	gw.runTurn(ctx, binding.Adapter, key, msg)
@@ -772,9 +804,7 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 		_ = gw.sendText(ctx, adapter, msg, "内部错误：无法创建会话。")
 		return
 	}
-	gw.rememberSessionReady(msg, state.ctrl)
-
-	// 发送"正在输入"状态
+		// 发送"正在输入"状态
 	_ = adapter.SendTyping(ctx, msg.ChatID)
 
 	// 创建事件渲染 sink
@@ -825,6 +855,9 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 	sink.Emit(event.Event{Kind: event.TurnDone, Err: err})
 	if err != nil {
 		gw.logger.Warn("turn error", "session", key[:8], "err", err)
+		// 离线降级：AI 不可用时发送 fallback 回复
+		fallbackText := "抱歉，我的大脑暂时不在线（AI 服务不可用）。请稍后再试。"
+		gw.sendText(ctx, adapter, msg, fallbackText)
 		return
 	}
 	gw.logger.Info("bot turn completed", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
@@ -844,6 +877,8 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	sessionSink := &sessionEventSink{}
 	model, workspaceRoot, toolApprovalMode := gw.sessionOptionsForMessage(msg)
 	gw.logger.Info("bot session creating", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "model", model, "workspace_set", strings.TrimSpace(workspaceRoot) != "", "tool_approval_mode", normalizeBotToolApprovalMode(toolApprovalMode))
+	// convert configured plugins to plugin specs for boot
+	pluginSpecs := boot.PluginSpecs(gw.cfg.Plugins)
 	ctrl, err := boot.Build(ctx, boot.Options{
 		Model:         model,
 		MaxSteps:      gw.cfg.MaxSteps,
@@ -851,6 +886,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		Sink:          sessionSink,
 		WorkspaceRoot: workspaceRoot,
 		SessionDir:    botSessionDir(workspaceRoot),
+		ExtraPlugins:  pluginSpecs,
 	})
 	if err != nil {
 		gw.logger.Error("build controller failed", "err", err)
@@ -858,7 +894,24 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	}
 	ctrl.EnableInteractiveApproval()
 	ctrl.SetToolApprovalMode(toolApprovalMode)
-	ensureControllerSessionPath(ctrl)
+	// 使用持久化 session 文件（按 user key，不按时间戳），保证断开后能接续
+	sessionDir := ctrl.SessionDir()
+	if sessionDir != "" {
+		persistentPath := botPersistentSessionPath(sessionDir, key)
+		ctrl.SetSessionPath(persistentPath)
+	}
+
+	// 接续历史会话：bot 会话使用固定文件，断开后重连能读到历史
+	if sessionPath := ctrl.SessionPath(); sessionPath != "" {
+		if loaded, err := agent.LoadSession(sessionPath); err == nil {
+			if loaded.HasContent() {
+				ctrl.Resume(loaded, sessionPath)
+				gw.logger.Info("bot session resumed", "path", sessionPath, "messages", len(loaded.Snapshot()))
+			}
+		} else if !os.IsNotExist(err) {
+			gw.logger.Warn("bot session load failed", "path", sessionPath, "err", err)
+		}
+	}
 
 	gw.mu.Lock()
 	gw.controllers[key] = &sessionState{
@@ -872,7 +925,13 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	gw.mu.Unlock()
 
 	gw.logger.Info("bot session created", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
+gw.rememberSessionReady(msg, ctrl)
 	return state
+}
+
+func botPersistentSessionPath(sessionDir, sessionKey string) string {
+	h := sha256.Sum256([]byte(sessionKey))
+	return filepath.Join(sessionDir, "bot-"+hex.EncodeToString(h[:8])+".jsonl")
 }
 
 func ensureControllerSessionPath(ctrl *control.Controller) {
@@ -985,6 +1044,56 @@ func (gw *BotGateway) sendText(ctx context.Context, adapter Adapter, msg Inbound
 	}
 	gw.logger.Info("bot send completed", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "reply_to", hashID(msg.MessageID), "message", hashID(result.MessageID))
 	return err
+}
+
+// downloadMedia downloads a media file to local disk.
+func (gw *BotGateway) downloadMedia(ctx context.Context, url string, dir string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("create download request: %w", err)
+	}
+	downloadCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req = req.WithContext(downloadCtx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("download error %d", resp.StatusCode)
+	}
+
+	ext := ".dat"
+	ct := resp.Header.Get("Content-Type")
+	if strings.Contains(ct, "image/jpeg") || strings.Contains(ct, "image/jpg") {
+		ext = ".jpg"
+	} else if strings.Contains(ct, "image/png") {
+		ext = ".png"
+	} else if strings.Contains(ct, "image/gif") {
+		ext = ".gif"
+	} else if strings.Contains(ct, "image/webp") {
+		ext = ".webp"
+	}
+
+	h := sha256.Sum256([]byte(url + time.Now().String()))
+	filename := "media-" + hex.EncodeToString(h[:8]) + ext
+	localPath := filepath.Join(dir, filename)
+
+	out, err := os.Create(localPath)
+	if err != nil {
+		return "", fmt.Errorf("create local file: %w", err)
+	}
+	defer out.Close()
+
+	written, err := io.Copy(out, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("save file: %w", err)
+	}
+	gw.logger.Info("media downloaded", "path", localPath, "bytes", written, "type", ct)
+	return localPath, nil
 }
 
 func parseAskAnswers(questions []event.AskQuestion, raw string) []event.AskAnswer {

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -34,6 +34,7 @@ type GatewayConfig struct {
 	Allowlist          AllowlistConfig
 	Enabled            map[Platform]bool
 	Debounce           time.Duration
+	SystemPrompt       string
 	OnInbound          func(InboundMessage)
 	// OnSessionReady notifies the host after the bot has created or reused the
 	// controller for an inbound remote. Hosts may persist the concrete session ID
@@ -886,6 +887,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		Sink:          sessionSink,
 		WorkspaceRoot: workspaceRoot,
 		SessionDir:    botSessionDir(workspaceRoot),
+		SystemPromptOverride: gw.cfg.SystemPrompt,
 		ExtraPlugins:  pluginSpecs,
 	})
 	if err != nil {

--- a/internal/bot/napcat/adapter.go
+++ b/internal/bot/napcat/adapter.go
@@ -1,0 +1,179 @@
+package napcat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"reasonix/internal/bot"
+	"github.com/gorilla/websocket"
+)
+
+type adapter struct {
+	platform bot.Platform
+	logger   *slog.Logger
+	msgCh    chan bot.InboundMessage
+	wsURL    string
+	httpURL  string
+	mu       sync.Mutex
+	conn     *websocket.Conn
+}
+
+type onebotMsg struct {
+	PostType string          `json:"post_type"`
+	MsgType  string          `json:"message_type"`
+	UserID   int64           `json:"user_id"`
+	GroupID  int64           `json:"group_id,omitempty"`
+	Message  json.RawMessage `json:"message"`
+	RawMsg   string          `json:"raw_message"`
+	MsgID    int64           `json:"message_id"`
+}
+
+func NewAdapter(logger *slog.Logger) bot.Adapter {
+	return &adapter{
+		platform: bot.PlatformNapCat,
+		logger:   logger.With("adapter", "napcat"),
+		msgCh:    make(chan bot.InboundMessage, 64),
+		wsURL:    "ws://127.0.0.1:3001",
+		httpURL:  "http://127.0.0.1:3000",
+	}
+}
+
+func (a *adapter) Name() string             { return "napcat" }
+func (a *adapter) Platform() bot.Platform   { return a.platform }
+
+func (a *adapter) Start(ctx context.Context) error {
+	a.logger.Info("connecting to NapCat")
+	c, _, err := websocket.DefaultDialer.Dial(a.wsURL, nil)
+	if err != nil {
+		return fmt.Errorf("napcat ws: %w", err)
+	}
+	a.mu.Lock()
+	a.conn = c
+	a.mu.Unlock()
+	go a.readLoop(ctx, c)
+	return nil
+}
+
+func (a *adapter) Stop() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.conn != nil {
+		return a.conn.Close()
+	}
+	return nil
+}
+
+func (a *adapter) Messages() <-chan bot.InboundMessage { return a.msgCh }
+
+func (a *adapter) readLoop(ctx context.Context, conn *websocket.Conn) {
+	defer conn.Close()
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			a.logger.Warn("ws error", "err", err)
+			return
+		}
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			continue
+		}
+		if raw["post_type"] != "message" {
+			continue
+		}
+		var msg onebotMsg
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		text := extractText(msg.Message)
+		if text == "" {
+			continue
+		}
+		inbound := bot.InboundMessage{
+			Platform:     a.platform,
+			ConnectionID: "napcat-main",
+			Domain:       "napcat",
+			Text:         text,
+			MessageID:    fmt.Sprintf("%d", msg.MsgID),
+			UserID:       fmt.Sprintf("%d", msg.UserID),
+			ChatType:     bot.ChatDM,
+			ChatID:       fmt.Sprintf("%d", msg.UserID),
+		}
+		if msg.GroupID != 0 {
+			inbound.ChatType = bot.ChatGroup
+			inbound.ChatID = fmt.Sprintf("%d", msg.GroupID)
+		}
+		select {
+		case a.msgCh <- inbound:
+		default:
+		}
+	}
+}
+
+func (a *adapter) Send(ctx context.Context, msg bot.OutboundMessage) (bot.SendResult, error) {
+	segments := []map[string]interface{}{}
+	for _, p := range msg.MediaURLs {
+		segments = append(segments, map[string]interface{}{
+			"type": "image",
+			"data": map[string]string{"file": p},
+		})
+	}
+	if msg.Text != "" {
+		segments = append(segments, map[string]interface{}{
+			"type": "text",
+			"data": map[string]string{"text": msg.Text},
+		})
+	}
+	payload := map[string]interface{}{"message": segments}
+	if msg.ChatType == bot.ChatGroup {
+		var gid int64
+		fmt.Sscanf(msg.ChatID, "%d", &gid)
+		payload["group_id"] = gid
+	} else {
+		var uid int64
+		fmt.Sscanf(msg.ChatID, "%d", &uid)
+		payload["user_id"] = uid
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(a.httpURL+"/send_msg", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return bot.SendResult{}, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	var result struct {
+		Status string `json:"status"`
+		MsgID  int64  `json:"message_id"`
+	}
+	json.Unmarshal(respBody, &result)
+	return bot.SendResult{MessageID: fmt.Sprintf("%d", result.MsgID)}, nil
+}
+
+func (a *adapter) SendTyping(ctx context.Context, chatID string) error { return nil }
+
+func extractText(raw json.RawMessage) string {
+	var arr []map[string]interface{}
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		var text string
+		for _, seg := range arr {
+			if seg["type"] == "text" {
+				if data, ok := seg["data"].(map[string]interface{}); ok {
+					if t, ok := data["text"].(string); ok {
+						text += t
+					}
+				}
+			}
+		}
+		return text
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return ""
+}

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -1,4 +1,4 @@
-package qq
+﻿package qq
 
 import (
 	"bytes"
@@ -9,7 +9,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"mime/multipart"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -77,21 +79,32 @@ type properties struct {
 	Device  string `json:"$device"`
 }
 
+// dispatchAttachment QQ 消息中的附件（图片/文件）。
+type dispatchAttachment struct {
+	URL         string `json:"url"`
+	ContentType string `json:"content_type"`
+	Filename    string `json:"filename,omitempty"`
+	Size        int    `json:"size,omitempty"`
+	Height      int    `json:"height,omitempty"`
+	Width       int    `json:"width,omitempty"`
+}
+
 type dispatchEvent struct {
-	ID        string `json:"id"`
-	Type      string `json:"type"`
-	Content   string `json:"content"`
-	Timestamp string `json:"timestamp"`
-	Author    struct {
+	ID          string               `json:"id"`
+	Type        string               `json:"type"`
+	Content     string               `json:"content"`
+	Timestamp   string               `json:"timestamp"`
+	Author      struct {
 		ID           string `json:"id"`
 		UserOpenID   string `json:"user_openid"`
 		MemberOpenID string `json:"member_openid"`
 		UnionOpenID  string `json:"union_openid"`
 		Username     string `json:"username"`
 	} `json:"author"`
-	ChannelID   string `json:"channel_id"`
-	GuildID     string `json:"guild_id"`
-	GroupOpenID string `json:"group_openid"`
+	ChannelID        string               `json:"channel_id"`
+	GuildID          string               `json:"guild_id"`
+	GroupOpenID      string               `json:"group_openid"`
+	Attachments      []dispatchAttachment `json:"attachments,omitempty"`
 }
 
 // wsClient 管理 QQ WebSocket 连接。
@@ -464,12 +477,21 @@ func (a *adapter) handleDispatch(msg gatewayPayload) {
 		return
 	}
 
+	// 解析附件（图片/文件）到 MediaURLs
+	var mediaURLs []string
+	for _, att := range evt.Attachments {
+		if att.URL != "" {
+			mediaURLs = append(mediaURLs, att.URL)
+		}
+	}
+
 	ib := bot.InboundMessage{
 		Platform:  bot.PlatformQQ,
 		UserID:    qqAuthorID(evt),
 		UserName:  evt.Author.Username,
 		Text:      evt.Content,
 		MessageID: evt.ID,
+		MediaURLs: mediaURLs,
 	}
 
 	switch msg.T {
@@ -514,6 +536,24 @@ func qqAuthorID(evt dispatchEvent) string {
 
 // sendMessage 使用 QQ REST API 发送消息。
 func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot.SendResult, error) {
+	// 如果有媒体附件，上传并发送图片
+	if len(msg.MediaURLs) > 0 {
+		for _, mediaPath := range msg.MediaURLs {
+			seq := a.nextMessageSeq(msg.ReplyToMsgID)
+			fileInfo, err := a.uploadQQMedia(ctx, mediaPath, msg.ChatID, msg.ChatType)
+			if err != nil {
+				a.logger.Warn("qq media upload failed", "path", mediaPath, "err", err)
+				continue
+			}
+			result, err := a.sendImageMessage(ctx, msg, fileInfo, seq)
+			if err != nil {
+				a.logger.Warn("qq image send failed", "err", err)
+				continue
+			}
+			return result, nil
+		}
+		// 所有媒体发送失败时降级到文本
+	}
 	text := normalizeQQMarkdownReply(msg.Text)
 	chunks := splitQQMessage(text, qqMaxChunkBytes)
 	if len(chunks) == 0 {
@@ -555,6 +595,80 @@ func (a *adapter) sendPlainMessageChunk(ctx context.Context, msg bot.OutboundMes
 		"content":  text,
 		"msg_type": 0,
 	}, seq)
+}
+
+// uploadQQMedia 上传文件到 QQ 媒体服务器，返回 file_info。
+func (a *adapter) uploadQQMedia(ctx context.Context, filePath string, chatID string, chatType bot.ChatType) (string, error) {
+	base := a.apiBaseURL()
+	var uploadURL string
+	switch chatType {
+	case bot.ChatGroup:
+		uploadURL = fmt.Sprintf("%s/v2/groups/%s/files", base, url.PathEscape(chatID))
+	default:
+		uploadURL = fmt.Sprintf("%s/v2/users/%s/files", base, url.PathEscape(chatID))
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open media file: %w", err)
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return "", fmt.Errorf("copy file: %w", err)
+	}
+	writer.Close()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, &buf)
+	if err != nil {
+		return "", fmt.Errorf("create upload request: %w", err)
+	}
+
+	token, err := a.getAccessToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "QQBot "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-Union-Appid", a.appID())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("qq upload error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		FileUUID string `json:"file_uuid"`
+		FileInfo string `json:"file_info"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode upload response: %w", err)
+	}
+	if result.FileInfo == "" {
+		result.FileInfo = result.FileUUID
+	}
+	return result.FileInfo, nil
+}
+
+// sendImageMessage 发送图片消息（msg_type: 7）。
+func (a *adapter) sendImageMessage(ctx context.Context, msg bot.OutboundMessage, fileInfo string, seq int) (bot.SendResult, error) {
+	payload := map[string]any{
+		"msg_type": 7,
+		"media":    map[string]string{"file_info": fileInfo},
+	}
+	return a.sendMessagePayload(ctx, msg, payload, seq)
 }
 
 func (a *adapter) sendMessageChunk(ctx context.Context, msg bot.OutboundMessage, text string, seq int) (bot.SendResult, error) {

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -536,18 +537,25 @@ func qqAuthorID(evt dispatchEvent) string {
 
 // sendMessage 使用 QQ REST API 发送消息。
 func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot.SendResult, error) {
-	// 如果有媒体附件，上传并发送图片
+	// 如果有媒体附件，上传并发送
 	if len(msg.MediaURLs) > 0 {
 		for _, mediaPath := range msg.MediaURLs {
 			seq := a.nextMessageSeq(msg.ReplyToMsgID)
-			fileInfo, err := a.uploadQQMedia(ctx, mediaPath, msg.ChatID, msg.ChatType)
+			fileType := detectQQFileType(mediaPath)
+			fileInfo, err := a.uploadQQMedia(ctx, mediaPath, msg.ChatID, msg.ChatType, fileType)
 			if err != nil {
 				a.logger.Warn("qq media upload failed", "path", mediaPath, "err", err)
-				continue
+				// fallback: 尝试 URL 方式上传
+				a.logger.Info("qq trying URL upload fallback", "path", mediaPath)
+				fileInfo, err = a.uploadQQMediaByURL(ctx, mediaPath, msg.ChatID, msg.ChatType, fileType)
+				if err != nil {
+					a.logger.Warn("qq URL upload also failed", "path", mediaPath, "err", err)
+					continue
+				}
 			}
-			result, err := a.sendImageMessage(ctx, msg, fileInfo, seq)
+			result, err := a.sendMediaMessage(ctx, msg, fileInfo, seq)
 			if err != nil {
-				a.logger.Warn("qq image send failed", "err", err)
+				a.logger.Warn("qq media send failed", "err", err)
 				continue
 			}
 			return result, nil
@@ -566,6 +574,7 @@ func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot
 		a.logger.Warn("qq passive reply truncated", "chat_type", msg.ChatType, "chunks", originalChunkCount, "limit", len(chunks))
 	}
 	var last bot.SendResult
+	var anySent bool
 	for _, chunk := range chunks {
 		seq := a.nextMessageSeq(msg.ReplyToMsgID)
 		var result bot.SendResult
@@ -581,11 +590,15 @@ func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot
 			result, err = a.sendPlainMessageChunk(ctx, msg, chunk, a.nextMessageSeq(msg.ReplyToMsgID))
 		}
 		if err != nil {
-			a.logger.Error("qq message send failed", "chat_type", msg.ChatType, "err", err)
-			return last, err
+			a.logger.Error("qq message chunk send failed, skipping", "chat_type", msg.ChatType, "err", err)
+			continue
 		}
+		anySent = true
 		a.logger.Info("qq message sent", "chat_type", msg.ChatType, "message_id_set", strings.TrimSpace(result.MessageID) != "")
 		last = result
+	}
+	if !anySent {
+		return last, fmt.Errorf("all message chunks failed to send")
 	}
 	return last, nil
 }
@@ -597,8 +610,24 @@ func (a *adapter) sendPlainMessageChunk(ctx context.Context, msg bot.OutboundMes
 	}, seq)
 }
 
+// detectQQFileType 根据文件扩展名返回 QQ file_type：
+// 1=图片, 2=视频, 3=语音, 4=文件
+func detectQQFileType(path string) int {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp":
+		return 1
+	case ".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv":
+		return 2
+	case ".mp3", ".wav", ".wma", ".aac", ".flac", ".ogg", ".amr":
+		return 3 // 语音
+	default:
+		return 4 // 文件/文档（pdf, doc, zip, txt等）
+	}
+}
+
 // uploadQQMedia 上传文件到 QQ 媒体服务器，返回 file_info。
-func (a *adapter) uploadQQMedia(ctx context.Context, filePath string, chatID string, chatType bot.ChatType) (string, error) {
+func (a *adapter) uploadQQMedia(ctx context.Context, filePath string, chatID string, chatType bot.ChatType, fileType int) (string, error) {
 	base := a.apiBaseURL()
 	var uploadURL string
 	switch chatType {
@@ -623,6 +652,8 @@ func (a *adapter) uploadQQMedia(ctx context.Context, filePath string, chatID str
 	if _, err := io.Copy(part, file); err != nil {
 		return "", fmt.Errorf("copy file: %w", err)
 	}
+	writer.WriteField("file_type", strconv.Itoa(fileType))
+	writer.WriteField("srv_send_msg", "false")
 	writer.Close()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, &buf)
@@ -662,8 +693,129 @@ func (a *adapter) uploadQQMedia(ctx context.Context, filePath string, chatID str
 	return result.FileInfo, nil
 }
 
-// sendImageMessage 发送图片消息（msg_type: 7）。
-func (a *adapter) sendImageMessage(ctx context.Context, msg bot.OutboundMessage, fileInfo string, seq int) (bot.SendResult, error) {
+// uploadQQMediaByURL 通过 URL 方式上传文件（作为 multipart 上传失败的 fallback）。
+func (a *adapter) uploadQQMediaByURL(ctx context.Context, filePath string, chatID string, chatType bot.ChatType, fileType int) (string, error) {
+	base := a.apiBaseURL()
+	var uploadURL string
+	if chatType == bot.ChatGroup {
+		uploadURL = fmt.Sprintf("%s/v2/groups/%s/files", base, url.PathEscape(chatID))
+	} else {
+		uploadURL = fmt.Sprintf("%s/v2/users/%s/files", base, url.PathEscape(chatID))
+	}
+
+	token, err := a.getAccessToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get token: %w", err)
+	}
+
+	// 判断文件路径是本地文件还是 URL
+	var fileURL string
+	if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
+		fileURL = filePath
+	} else {
+		// 本地文件：尝试 base64 上传
+		return a.uploadQQMediaBase64(ctx, filePath, chatID, chatType, fileType)
+	}
+
+	payload := map[string]any{
+		"file_type":    fileType,
+		"url":          fileURL,
+		"srv_send_msg": false,
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("create URL upload request: %w", err)
+	}
+	req.Header.Set("Authorization", "QQBot "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("URL upload request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("qq URL upload error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		FileUUID string `json:"file_uuid"`
+		FileInfo string `json:"file_info"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode URL upload response: %w", err)
+	}
+	fi := result.FileInfo
+	if fi == "" {
+		fi = result.FileUUID
+	}
+	return fi, nil
+}
+
+// uploadQQMediaBase64 通过 base64 数据上传本地文件到 QQ 媒体服务器。
+func (a *adapter) uploadQQMediaBase64(ctx context.Context, filePath string, chatID string, chatType bot.ChatType, fileType int) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read file for base64 upload: %w", err)
+	}
+	b64 := base64.StdEncoding.EncodeToString(data)
+	a.logger.Info("qq base64 upload attempt", "path", filePath, "size", len(data))
+
+	base := a.apiBaseURL()
+	var uploadURL string
+	if chatType == bot.ChatGroup {
+		uploadURL = fmt.Sprintf("%s/v2/groups/%s/files", base, url.PathEscape(chatID))
+	} else {
+		uploadURL = fmt.Sprintf("%s/v2/users/%s/files", base, url.PathEscape(chatID))
+	}
+
+	token, err := a.getAccessToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get token: %w", err)
+	}
+
+	payload := map[string]any{
+		"file_type":    fileType,
+		"file_data":    b64,
+		"srv_send_msg": false,
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("create base64 upload request: %w", err)
+	}
+	req.Header.Set("Authorization", "QQBot "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("base64 upload request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("qq base64 upload error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		FileUUID string `json:"file_uuid"`
+		FileInfo string `json:"file_info"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode base64 upload response: %w", err)
+	}
+	fi := result.FileInfo
+	if fi == "" {
+		fi = result.FileUUID
+	}
+	a.logger.Info("qq base64 upload success", "path", filePath)
+	return fi, nil
+}
+
+// sendMediaMessage 发送媒体消息（msg_type: 7，支持图片/视频/文件/音频）。
+func (a *adapter) sendMediaMessage(ctx context.Context, msg bot.OutboundMessage, fileInfo string, seq int) (bot.SendResult, error) {
 	payload := map[string]any{
 		"msg_type": 7,
 		"media":    map[string]string{"file_info": fileInfo},

--- a/internal/bot/render.go
+++ b/internal/bot/render.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -214,18 +216,77 @@ func (s *renderSink) flushPrefix(idx int) {
 		s.lastFlush = time.Now()
 		return
 	}
+
+	// 解析 [图片:路径] 标记，提取图片路径到 MediaURLs
+	cleanText, mediaURLs := extractImageRefs(text)
+
 	_ = s.send(OutboundMessage{
 		ConnectionID: s.connID,
 		Domain:       s.domain,
 		ChatID:       s.chatID,
 		ChatType:     s.chatType,
-		Text:         text,
+		Text:         cleanText,
+		MediaURLs:    mediaURLs,
 		ReplyToMsgID: s.replyTo,
 	})
 	remaining := raw[idx:]
 	s.buf.Reset()
 	s.buf.WriteString(remaining)
 	s.lastFlush = time.Now()
+}
+
+// extractImageRefs 从文本中提取 [图片:路径] 标记，返回清理后的文本和有效的图片路径列表。
+func extractImageRefs(text string) (string, []string) {
+	const prefix = "[图片:"
+	const suffix = "]"
+
+	var clean strings.Builder
+	var paths []string
+	remaining := text
+
+	for {
+		start := strings.Index(remaining, prefix)
+		if start < 0 {
+			clean.WriteString(remaining)
+			break
+		}
+		clean.WriteString(remaining[:start])
+		afterPrefix := start + len(prefix)
+		end := strings.Index(remaining[afterPrefix:], suffix)
+		if end < 0 {
+			clean.WriteString(remaining[start:])
+			break
+		}
+		path := strings.TrimSpace(remaining[afterPrefix : afterPrefix+end])
+
+		if path != "" {
+			// URL paths go directly (no file check needed)
+			if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+				paths = append(paths, path)
+				slog.Debug("extractImageRefs found image URL", "url", path)
+			} else {
+				absPath, err := filepath.Abs(path)
+				if err == nil {
+					if info, statErr := os.Stat(absPath); statErr == nil && !info.IsDir() {
+						paths = append(paths, absPath)
+						slog.Debug("extractImageRefs found image", "path", absPath, "size", info.Size())
+					} else {
+						slog.Warn("extractImageRefs file not found or is dir", "path", absPath, "err", statErr)
+					}
+				} else {
+					slog.Warn("extractImageRefs abs failed", "path", path, "err", err)
+				}
+			}
+		} else {
+			slog.Debug("extractImageRefs empty path in marker")
+		}
+
+		remaining = remaining[afterPrefix+end+len(suffix):]
+		// 吃掉后面的空格
+		remaining = strings.TrimLeft(remaining, " ")
+	}
+
+	return strings.TrimSpace(clean.String()), paths
 }
 
 func (s *renderSink) sendProgress(text string, force bool) {

--- a/internal/bot/types.go
+++ b/internal/bot/types.go
@@ -1,4 +1,4 @@
-// Package bot 实现 Reasonix 多渠道 IM bot 消息网关，支持 QQ、飞书、微信。
+﻿// Package bot 实现 Reasonix 多渠道 IM bot 消息网关，支持 QQ、飞书、微信。
 // 架构参考 Hermes Agent 的 gateway/adapter/session 模式。
 package bot
 
@@ -10,6 +10,7 @@ type Platform string
 const (
 	PlatformQQ     Platform = "qq"
 	PlatformFeishu Platform = "feishu"
+	PlatformNapCat Platform = "napcat"
 	PlatformWeixin Platform = "weixin"
 )
 

--- a/internal/bot/weixin/weixin.go
+++ b/internal/bot/weixin/weixin.go
@@ -474,13 +474,22 @@ func (a *adapter) handleIlinkMessage(m ilinkMessage) {
 		if item.Type == weixinItemText {
 			continue
 		}
+		// dump full item for debugging
+		if item.Type != weixinItemText {
+			if jsonStr, jsonErr := json.Marshal(item); jsonErr == nil {
+				a.logger.Info("weixin non-text item", "type", item.Type, "raw", string(jsonStr))
+			}
+		}
 		if item.ImageItem.URL != "" {
 			mediaURLs = append(mediaURLs, item.ImageItem.URL)
 		}
 	}
+	if len(mediaURLs) > 0 {
+		a.logger.Info("weixin image received", "count", len(mediaURLs), "urls", mediaURLs)
+	}
 	// 只有纯文本才跳过，有图片时即使 text 为空也要继续
 	if text == "" && len(mediaURLs) == 0 {
-		a.logger.Info("weixin message ignored", "reason", "empty_text", "from", logHash(m.FromUserID), "message", logHash(string(m.MessageID)))
+		a.logger.Info("weixin message ignored", "reason", "empty_text", "from", logHash(m.FromUserID), "message", logHash(string(m.MessageID)), "msg_type", m.MsgType, "item_count", len(m.ItemList))
 		return
 	}
 	chatType, chatID := guessIlinkChat(m, a.accountID())

--- a/internal/bot/weixin/weixin.go
+++ b/internal/bot/weixin/weixin.go
@@ -1,4 +1,4 @@
-// Package weixin 实现微信 iLink Bot 适配器。
+﻿// Package weixin 实现微信 iLink Bot 适配器。
 // 参考 Hermes Agent 的 weixin adapter：
 // - getupdates 长轮询
 // - sendmessage / sendtyping
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,6 +77,12 @@ type ilinkMessage struct {
 		TextItem struct {
 			Text string `json:"text"`
 		} `json:"text_item"`
+		ImageItem struct {
+			URL      string `json:"url"`
+			MD5      string `json:"md5,omitempty"`
+			FileName string `json:"file_name,omitempty"`
+			Size     int    `json:"size,omitempty"`
+		} `json:"image_item"`
 	} `json:"item_list"`
 }
 
@@ -461,7 +468,18 @@ func (a *adapter) handleIlinkMessage(m ilinkMessage) {
 		return
 	}
 	text := extractIlinkText(m.ItemList)
-	if text == "" {
+	// extract images from non-text items
+	var mediaURLs []string
+	for _, item := range m.ItemList {
+		if item.Type == weixinItemText {
+			continue
+		}
+		if item.ImageItem.URL != "" {
+			mediaURLs = append(mediaURLs, item.ImageItem.URL)
+		}
+	}
+	// 只有纯文本才跳过，有图片时即使 text 为空也要继续
+	if text == "" && len(mediaURLs) == 0 {
 		a.logger.Info("weixin message ignored", "reason", "empty_text", "from", logHash(m.FromUserID), "message", logHash(string(m.MessageID)))
 		return
 	}
@@ -481,6 +499,7 @@ func (a *adapter) handleIlinkMessage(m ilinkMessage) {
 		UserName:  m.FromUserID,
 		Text:      text,
 		MessageID: string(m.MessageID),
+		MediaURLs: mediaURLs,
 	}
 	select {
 	case a.msgCh <- ib:
@@ -503,6 +522,12 @@ func extractIlinkText(items []struct {
 	TextItem struct {
 		Text string `json:"text"`
 	} `json:"text_item"`
+	ImageItem struct {
+		URL      string `json:"url"`
+		MD5      string `json:"md5,omitempty"`
+		FileName string `json:"file_name,omitempty"`
+		Size     int    `json:"size,omitempty"`
+	} `json:"image_item"`
 }) string {
 	var out []string
 	for _, item := range items {
@@ -551,6 +576,99 @@ func firstNonEmptyString(vals ...string) string {
 	return ""
 }
 
+// uploadWeixinMedia 上传文件到微信媒体服务器，返回可访问的 URL。
+func (a *adapter) uploadWeixinMedia(ctx context.Context, filePath string) (string, error) {
+	tok := a.token()
+	if tok == "" {
+		return "", a.tokenMissingError()
+	}
+
+	// 1. 获取上传 URL
+	getURL := a.apiBase() + uploadMediaPath
+	req, err := http.NewRequestWithContext(ctx, "POST", getURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create getuploadurl request: %w", err)
+	}
+	setIlinkHeaders(req, tok, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("getuploadurl request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var uploadResp struct {
+		Ret       int    `json:"ret"`
+		Errcode   int    `json:"errcode"`
+		Errmsg    string `json:"errmsg"`
+		UploadURL string `json:"url"`
+		MediaID   string `json:"media_id"`
+	}
+	if err := json.Unmarshal(respBody, &uploadResp); err != nil {
+		return "", fmt.Errorf("decode getuploadurl response: %w", err)
+	}
+	if uploadResp.Ret != 0 || uploadResp.Errcode != 0 {
+		return "", fmt.Errorf("getuploadurl error ret=%d errcode=%d: %s", uploadResp.Ret, uploadResp.Errcode, uploadResp.Errmsg)
+	}
+
+	uploadURL := uploadResp.UploadURL
+	if uploadURL == "" {
+		return "", fmt.Errorf("getuploadurl returned empty url")
+	}
+
+	// 2. 上传文件
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open media file: %w", err)
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return "", fmt.Errorf("copy file: %w", err)
+	}
+	writer.Close()
+
+	uploadReq, err := http.NewRequestWithContext(ctx, "POST", uploadURL, &buf)
+	if err != nil {
+		return "", fmt.Errorf("create upload request: %w", err)
+	}
+	uploadReq.Header.Set("Content-Type", writer.FormDataContentType())
+
+	uploadResp2, err := http.DefaultClient.Do(uploadReq)
+	if err != nil {
+		return "", fmt.Errorf("upload file request: %w", err)
+	}
+	defer uploadResp2.Body.Close()
+
+	uploadBody, _ := io.ReadAll(uploadResp2.Body)
+	if uploadResp2.StatusCode >= 400 {
+		return "", fmt.Errorf("upload file error %d: %s", uploadResp2.StatusCode, string(uploadBody))
+	}
+
+	// 返回媒体 URL
+	var uploadResult struct {
+		URL     string `json:"url"`
+		MediaID string `json:"media_id"`
+	}
+	if err := json.Unmarshal(uploadBody, &uploadResult); err == nil {
+		if uploadResult.URL != "" {
+			return uploadResult.URL, nil
+		}
+		if uploadResult.MediaID != "" {
+			return uploadResult.MediaID, nil
+		}
+	}
+
+	return strings.TrimSpace(string(uploadBody)), nil
+}
+
 // sendMessage 使用微信 iLink sendmessage API 发送消息。
 func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot.SendResult, error) {
 	tok := a.token()
@@ -560,6 +678,49 @@ func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot
 
 	url := a.apiBase() + sendMessagePath
 
+	// 构造消息 item_list
+	var itemList []map[string]interface{}
+
+	// 如果有媒体附件（图片），先上传
+	if len(msg.MediaURLs) > 0 {
+		for _, mediaPath := range msg.MediaURLs {
+			mediaURL, err := a.uploadWeixinMedia(ctx, mediaPath)
+			if err != nil {
+				a.logger.Warn("weixin media upload failed", "path", mediaPath, "err", err)
+				continue
+			}
+			// detect media type from file extension
+			ext := strings.ToLower(filepath.Ext(mediaPath))
+			if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".gif" || ext == ".webp" || ext == ".bmp" {
+				itemList = append(itemList, map[string]interface{}{
+					"type":       3,
+					"image_item": map[string]string{"url": mediaURL},
+				})
+			} else {
+				// non-image: send as file item (type 4)
+				itemList = append(itemList, map[string]interface{}{
+					"type":       4,
+					"file_item": map[string]interface{}{"url": mediaURL, "name": filepath.Base(mediaPath)},
+				})
+			}
+		}
+	}
+
+	// 文本内容
+	if msg.Text != "" {
+		itemList = append(itemList, map[string]interface{}{
+			"type":      weixinItemText,
+			"text_item": map[string]string{"text": msg.Text},
+		})
+	}
+
+	// 如果没有有效内容，发空文本
+	if len(itemList) == 0 {
+		itemList = []map[string]interface{}{
+			{"type": weixinItemText, "text_item": map[string]string{"text": ""}},
+		}
+	}
+
 	payload := map[string]interface{}{
 		"base_info": map[string]string{"channel_version": ilinkChannelVersion},
 		"msg": map[string]interface{}{
@@ -568,9 +729,7 @@ func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot
 			"client_id":     fmt.Sprintf("reasonix-%d", time.Now().UnixNano()),
 			"message_type":  weixinMsgTypeBot,
 			"message_state": weixinMsgStateDone,
-			"item_list": []map[string]interface{}{
-				{"type": weixinItemText, "text_item": map[string]string{"text": msg.Text}},
-			},
+			"item_list":     itemList,
 		},
 	}
 	if contextToken := a.contextToken(msg.ChatID); contextToken != "" {

--- a/internal/botruntime/runtime.go
+++ b/internal/botruntime/runtime.go
@@ -132,7 +132,10 @@ func ChannelConfigs(connections []config.BotConnectionConfig, includeModel bool,
 		if value := normalizeToolApprovalMode(conn.ToolApprovalMode); value != "" {
 			channel.ToolApprovalMode = value
 		}
-		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" {
+		if value := strings.TrimSpace(conn.SystemPrompt); value != "" {
+			channel.SystemPrompt = value
+		}
+		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" || channel.SystemPrompt != "" {
 			out[plat] = channel
 		}
 	}
@@ -165,7 +168,10 @@ func ConnectionChannelConfigs(connections []config.BotConnectionConfig, includeM
 		if value := normalizeToolApprovalMode(conn.ToolApprovalMode); value != "" {
 			channel.ToolApprovalMode = value
 		}
-		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" {
+		if value := strings.TrimSpace(conn.SystemPrompt); value != "" {
+			channel.SystemPrompt = value
+		}
+		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" || channel.SystemPrompt != "" {
 			out[id] = channel
 		}
 	}

--- a/internal/botruntime/runtime.go
+++ b/internal/botruntime/runtime.go
@@ -1,4 +1,4 @@
-package botruntime
+﻿package botruntime
 
 import (
 	"log/slog"
@@ -8,6 +8,7 @@ import (
 
 	"reasonix/internal/bot"
 	"reasonix/internal/bot/feishu"
+	"reasonix/internal/bot/napcat"
 	"reasonix/internal/bot/qq"
 	"reasonix/internal/bot/weixin"
 	"reasonix/internal/config"
@@ -117,7 +118,7 @@ func ChannelConfigs(connections []config.BotConnectionConfig, includeModel bool,
 		}
 		plat := bot.Platform(strings.TrimSpace(conn.Provider))
 		switch plat {
-		case bot.PlatformQQ, bot.PlatformFeishu, bot.PlatformWeixin:
+		case bot.PlatformQQ, bot.PlatformFeishu, bot.PlatformWeixin, bot.PlatformNapCat:
 		default:
 			continue
 		}
@@ -229,6 +230,9 @@ func AdapterBindings(cfg *config.Config, enabled map[bot.Platform]bool, feishuDo
 			bindings = append(bindings, bot.AdapterBinding{ID: id, Domain: strings.TrimSpace(conn.Domain), Platform: platform, Adapter: weixin.New(weixinCfg, logger)})
 			hasConnection[platform] = true
 		}
+	}
+	if enabled[bot.PlatformNapCat] {
+		bindings = append(bindings, bot.AdapterBinding{ID: string(bot.PlatformNapCat), Platform: bot.PlatformNapCat, Adapter: napcat.NewAdapter(logger)})
 	}
 	if enabled[bot.PlatformQQ] && !hasConnection[bot.PlatformQQ] {
 		bindings = append(bindings, bot.AdapterBinding{ID: string(bot.PlatformQQ), Platform: bot.PlatformQQ, Adapter: qq.New(cfg.Bot.QQ, logger)})

--- a/internal/cli/bot.go
+++ b/internal/cli/bot.go
@@ -81,6 +81,15 @@ func botStart(args []string, version string) int {
 
 	requestedChannels := splitBotChannels(*channels)
 	enabledPlatforms, unknownChannels := botruntime.EnabledPlatforms(cfg, requestedChannels)
+	// force enable requested channels even if disabled in config (for CLI-only channels)
+	for _, ch := range requestedChannels {
+		if plat := bot.Platform(strings.TrimSpace(ch)); plat != "" {
+			// Also add platforms that are missing OR disabled
+			if enabled, ok := enabledPlatforms[plat]; !ok || !enabled {
+				enabledPlatforms[plat] = true
+			}
+		}
+	}
 	for _, ch := range unknownChannels {
 		fmt.Fprintf(os.Stderr, "warning: unknown channel %q\n", ch)
 	}
@@ -102,6 +111,7 @@ func botStart(args []string, version string) int {
 		WorkspaceRoot:      workspaceRoot,
 		Channels:           botruntime.ChannelConfigs(cfg.Bot.Connections, *model == "", *dir == ""),
 		ConnectionChannels: botruntime.ConnectionChannelConfigs(cfg.Bot.Connections, *model == "", *dir == ""),
+
 		Enabled:            enabledPlatforms,
 		Allowlist: bot.AllowlistConfig{
 			Enabled:  cfg.Bot.Allowlist.Enabled,
@@ -122,6 +132,25 @@ func botStart(args []string, version string) int {
 		OnInbound:      rememberInboundRemote,
 		OnSessionReady: botruntime.NewSessionRemembererWithWorkspace(logger, workspaceRoot),
 	}
+	// per-platform SystemPrompt from legacy [bot.qq] / [bot.weixin]
+	if gwCfg.Channels == nil {
+		gwCfg.Channels = make(map[bot.Platform]bot.ChannelConfig)
+	}
+	// per-platform SystemPrompt: fill if missing or empty in channels
+	fillPlatPrompt := func(plat bot.Platform, prompt string) {
+		if prompt == "" {
+			return
+		}
+		ch, ok := gwCfg.Channels[plat]
+		if !ok {
+			gwCfg.Channels[plat] = bot.ChannelConfig{SystemPrompt: prompt}
+		} else if ch.SystemPrompt == "" {
+			ch.SystemPrompt = prompt
+			gwCfg.Channels[plat] = ch
+		}
+	}
+	fillPlatPrompt(bot.PlatformQQ, cfg.Bot.QQ.SystemPrompt)
+	fillPlatPrompt(bot.PlatformWeixin, cfg.Bot.Weixin.SystemPrompt)
 
 	feishuDomains := botruntime.RequestedFeishuDomains(requestedChannels)
 	gw := bot.NewGatewayWithAdapterBindings(gwCfg, botruntime.AdapterBindings(cfg, enabledPlatforms, feishuDomains, logger), logger)

--- a/internal/cli/bot.go
+++ b/internal/cli/bot.go
@@ -1,4 +1,4 @@
-package cli
+﻿package cli
 
 import (
 	"context"
@@ -116,6 +116,7 @@ func botStart(args []string, version string) int {
 				bot.PlatformWeixin: cfg.Bot.Allowlist.WeixinGroups,
 			},
 		},
+		SystemPrompt:      cfg.Bot.SystemPrompt,
 		Debounce:       time.Duration(cfg.Bot.DebounceMs) * time.Millisecond,
 		OnInbound:      rememberInboundRemote,
 		OnSessionReady: botruntime.NewSessionRemembererWithWorkspace(logger, workspaceRoot),

--- a/internal/cli/bot.go
+++ b/internal/cli/bot.go
@@ -48,6 +48,7 @@ func botStart(args []string, version string) int {
 	channels := fs.String("channels", "", "启用的平台，逗号分隔：qq,feishu,lark,weixin")
 	dir := fs.String("dir", "", "工作目录")
 	model := fs.String("model", "", "模型名（空则用 default_model）")
+	force := fs.Bool("force", false, "ignore [bot] enabled check")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -62,8 +63,8 @@ func botStart(args []string, version string) int {
 		return 1
 	}
 
-	if !cfg.Bot.Enabled {
-		fmt.Fprintln(os.Stderr, "error: bot is not enabled in config — set [bot] enabled = true")
+	if !cfg.Bot.Enabled && !*force {
+		fmt.Fprintln(os.Stderr, "error: bot is not enabled in config — set [bot] enabled = true, or use --force")
 		return 1
 	}
 	if !cfg.Bot.Allowlist.AllowAll && (!cfg.Bot.Allowlist.Enabled || botruntime.AllowlistUserCount(cfg.Bot.Allowlist) == 0) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -402,6 +402,7 @@ type StatuslineConfig struct {
 // BotConfig 控制多渠道 IM bot 消息网关。
 type BotConfig struct {
 	Enabled          bool                  `toml:"enabled"`
+	SystemPrompt     string                `toml:"system_prompt"`
 	Model            string                `toml:"model"` // 用于 bot 的模型名，空则用 default_model
 	ToolApprovalMode string                `toml:"tool_approval_mode"`
 	MaxSteps         int                   `toml:"max_steps"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -431,13 +431,15 @@ type QQBotConfig struct {
 	Enabled      bool   `toml:"enabled"`
 	AppID        string `toml:"app_id"`
 	AppSecretEnv string `toml:"app_secret_env"` // 环境变量名，如 QQ_BOT_APP_SECRET
-	Sandbox      bool   `toml:"sandbox"`        // true 使用 QQ 沙箱 API / gateway
+	SystemPrompt string `toml:"system_prompt"`
+	Sandbox      bool   `toml:"sandbox"` // true 使用 QQ 沙箱 API / gateway
 }
 
 // FeishuBotConfig 飞书自建应用 Bot 配置。
 type FeishuBotConfig struct {
 	Enabled           bool   `toml:"enabled"`
-	Domain            string `toml:"domain"` // feishu（默认）| lark
+	Domain            string `toml:"domain"`             // feishu（默认）| lark
+	SystemPrompt      string `toml:"system_prompt"`
 	AppID             string `toml:"app_id"`
 	AppSecretEnv      string `toml:"app_secret_env"`     // 如 FEISHU_BOT_APP_SECRET
 	VerificationToken string `toml:"verification_token"` // 事件订阅验证 token
@@ -448,10 +450,11 @@ type FeishuBotConfig struct {
 
 // WeixinBotConfig 微信 iLink Bot 配置。
 type WeixinBotConfig struct {
-	Enabled   bool   `toml:"enabled"`
-	AccountID string `toml:"account_id"`
-	TokenEnv  string `toml:"token_env"` // 环境变量名，如 WEIXIN_BOT_TOKEN
-	APIBase   string `toml:"api_base"`  // iLink API base URL
+	Enabled      bool   `toml:"enabled"`
+	AccountID    string `toml:"account_id"`
+	TokenEnv     string `toml:"token_env"`     // 环境变量名，如 WEIXIN_BOT_TOKEN
+	SystemPrompt string `toml:"system_prompt"`
+	APIBase      string `toml:"api_base"` // iLink API base URL
 }
 
 // BotConnectionConfig is the desktop-friendly connection record for IM bot
@@ -468,6 +471,7 @@ type BotConnectionConfig struct {
 	Model            string                        `toml:"model"`
 	ToolApprovalMode string                        `toml:"tool_approval_mode"`
 	WorkspaceRoot    string                        `toml:"workspace_root"`
+	SystemPrompt     string                        `toml:"system_prompt"`
 	Credential       BotConnectionCredential       `toml:"credential"`
 	SessionMappings  []BotConnectionSessionMapping `toml:"session_mappings"`
 	LastError        string                        `toml:"last_error"`

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -424,6 +424,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		fmt.Fprintf(&b, "app_id = %q\n", c.Bot.QQ.AppID)
 		fmt.Fprintf(&b, "app_secret_env = %q\n", c.Bot.QQ.AppSecretEnv)
 		fmt.Fprintf(&b, "sandbox = %v\n", c.Bot.QQ.Sandbox)
+		if c.Bot.QQ.SystemPrompt != "" {
+			b.WriteString("system_prompt = \"\"\"\n")
+			b.WriteString(c.Bot.QQ.SystemPrompt)
+			b.WriteString("\n\"\"\"\n")
+		}
 		b.WriteString("\n[bot.feishu]\n")
 		fmt.Fprintf(&b, "enabled = %v\n", c.Bot.Feishu.Enabled)
 		fmt.Fprintf(&b, "app_id = %q\n", c.Bot.Feishu.AppID)
@@ -438,6 +443,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		fmt.Fprintf(&b, "account_id = %q\n", c.Bot.Weixin.AccountID)
 		fmt.Fprintf(&b, "token_env = %q\n", c.Bot.Weixin.TokenEnv)
 		fmt.Fprintf(&b, "api_base = %q\n", c.Bot.Weixin.APIBase)
+		if c.Bot.Weixin.SystemPrompt != "" {
+			b.WriteString("system_prompt = \"\"\"\n")
+			b.WriteString(c.Bot.Weixin.SystemPrompt)
+			b.WriteString("\n\"\"\"\n")
+		}
 		for _, conn := range c.Bot.Connections {
 			b.WriteString("\n[[bot.connections]]\n")
 			fmt.Fprintf(&b, "id = %q\n", conn.ID)
@@ -454,6 +464,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			}
 			if conn.WorkspaceRoot != "" {
 				fmt.Fprintf(&b, "workspace_root = %q\n", conn.WorkspaceRoot)
+			}
+			if conn.SystemPrompt != "" {
+				b.WriteString("system_prompt = \"\"\"\n")
+				b.WriteString(conn.SystemPrompt)
+				b.WriteString("\n\"\"\"\n")
 			}
 			if conn.LastError != "" {
 				fmt.Fprintf(&b, "last_error = %q\n", conn.LastError)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1327,6 +1327,21 @@ func (c *Controller) SteerConsumed() bool {
 	return true
 }
 
+// AddUserMessage 向对话历史中插入一条用户消息，不触发 AI 回复。
+func (c *Controller) AddUserMessage(content string) {
+	c.mu.Lock()
+	exec := c.executor
+	if exec == nil {
+		c.mu.Unlock()
+		return
+	}
+	sess := exec.Session()
+	c.mu.Unlock()
+	if sess != nil {
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: content})
+	}
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.


### PR DESCRIPTION
## Summary

-feat(bot): QQ Bot 发图/发文件、per-platform system prompt、消息抢占、上传 fallback 链

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
