### PR TITLE
fix(bash): preserve wait-delay daemon sessions

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -113,7 +113,7 @@ func (b bash) resolved() sandbox.Shell {
 }
 
 func (bash) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"preserve_background_processes":{"type":"boolean","description":"After the shell command exits normally, keep any process-group members it intentionally left behind. Use only for deliberate daemonization, such as nohup/disown/setsid; cancellation and timeouts still kill the process group."}},"required":["command"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"preserve_background_processes":{"type":"boolean","description":"After the shell command exits normally, keep any process-group members it intentionally left behind. Use only for deliberate daemonization, such as nohup/disown/setsid or commands that launch persistent browser sessions like playwright-cli open; cancellation and timeouts still kill the process group."}},"required":["command"]}`)
 }
 
 // ReadOnly is false: bash's effect cannot be inferred from args (rm, curl,
@@ -168,10 +168,11 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			cmd.Stdout = out
 			cmd.Stderr = out
 			tracked, runErr := runShellProcess(cmd, shouldTrackShellProcess(sh, p.Command, p.PreserveBackgroundProcesses))
-			if shouldReapAfterRun(jobCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
+			reapAfterRun := shouldReapAfterRun(jobCtx, sh, p.Command, p.PreserveBackgroundProcesses)
+			if reapAfterRun {
 				reapShellProcess(cmd, tracked) // reap process-group stragglers the job left running (#3702)
 			}
-			return "", runErr
+			return "", normalizeBashRunError(jobCtx, runErr, !reapAfterRun)
 		})
 		return fmt.Sprintf("Started background job %q. It keeps running across turns; read new output with bash_output(job_id=%q), wait for it with wait, or stop it with kill_shell(job_id=%q).", job.ID, job.ID, job.ID), nil
 	}
@@ -200,7 +201,8 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	// server) leaves it in the process group; Wait only reaped the shell leader.
 	// Kill the group so those don't accumulate into an OOM (#3702). On cancel/
 	// timeout the command's Cancel path already did this; this covers normal exit.
-	if shouldReapAfterRun(runCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
+	reapAfterRun := shouldReapAfterRun(runCtx, sh, p.Command, p.PreserveBackgroundProcesses)
+	if reapAfterRun {
 		reapShellProcess(cmd, tracked)
 	}
 	out := buf.String()
@@ -208,6 +210,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	if errors.Is(context.Cause(runCtx), errBashTimeout) {
 		return out, fmt.Errorf("command timed out (> %s)", timeout)
 	}
+	err = normalizeBashRunError(runCtx, err, !reapAfterRun)
 	if err != nil {
 		// Non-zero exit: feed output and error back so the model can self-correct.
 		return out, fmt.Errorf("command exited: %w", err)
@@ -243,6 +246,16 @@ func (b bash) foregroundTimeout() time.Duration {
 		return 0
 	}
 	return b.timeout
+}
+
+func normalizeBashRunError(ctx context.Context, err error, keepBackgroundProcesses bool) error {
+	if err == nil {
+		return nil
+	}
+	if keepBackgroundProcesses && ctx.Err() == nil && errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return err
 }
 
 type trackedShellProcess struct {

--- a/internal/tool/builtin/bash_timeout_test.go
+++ b/internal/tool/builtin/bash_timeout_test.go
@@ -2,6 +2,8 @@ package builtin
 
 import (
 	"context"
+	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -56,6 +58,26 @@ func TestWorkspacePassesBashTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("error = %v, want timeout", err)
+	}
+}
+
+func TestNormalizeBashRunErrorPreservesWaitDelayOnlyForKeptBackgroundProcesses(t *testing.T) {
+	if got := normalizeBashRunError(context.Background(), exec.ErrWaitDelay, true); got != nil {
+		t.Fatalf("preserved ErrWaitDelay = %v, want nil", got)
+	}
+	if got := normalizeBashRunError(context.Background(), exec.ErrWaitDelay, false); !errors.Is(got, exec.ErrWaitDelay) {
+		t.Fatalf("non-preserved ErrWaitDelay = %v, want ErrWaitDelay", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := normalizeBashRunError(ctx, exec.ErrWaitDelay, true); !errors.Is(got, exec.ErrWaitDelay) {
+		t.Fatalf("cancelled preserved ErrWaitDelay = %v, want ErrWaitDelay", got)
+	}
+
+	errBoom := errors.New("boom")
+	if got := normalizeBashRunError(context.Background(), errBoom, true); !errors.Is(got, errBoom) {
+		t.Fatalf("other error = %v, want boom", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Treat `exec.ErrWaitDelay` as successful completion when bash is preserving intentional background process descendants, so commands that launch persistent sessions can return without surfacing a wait-delay error.
- Apply the same normalization to foreground and `run_in_background` bash paths while preserving timeout, cancellation, and ordinary command failures.
- Update `preserve_background_processes` guidance to cover persistent browser sessions such as `playwright-cli open`.

Fixes #5575

## Verification

- PASS `go test ./internal/tool/builtin -run 'TestNormalizeBashRunErrorPreservesWaitDelayOnlyForKeptBackgroundProcesses|TestShouldReapAfterRunHonorsExplicitPreserveOnlyOnCompletion'`
- PASS `GOOS=windows GOARCH=amd64 go test -c -o /tmp/reasonix-builtin-5575.test.exe ./internal/tool/builtin && rm -f /tmp/reasonix-builtin-5575.test.exe`
- PASS `git diff --check`

## Cache impact

Cache-impact: low, updates the bash tool schema description only; the tool schema shape and provider prompt construction are unchanged.
Cache-guard: `go test ./internal/tool/builtin -run 'TestNormalizeBashRunErrorPreservesWaitDelayOnlyForKeptBackgroundProcesses|TestShouldReapAfterRunHonorsExplicitPreserveOnlyOnCompletion'`
System-prompt-review: N/A
