### PR TITLE
fix(bash): preserve session launchers after WaitDelay

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -113,7 +113,7 @@ func (b bash) resolved() sandbox.Shell {
 }
 
 func (bash) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"preserve_background_processes":{"type":"boolean","description":"After the shell command exits normally, keep any process-group members it intentionally left behind. Use only for deliberate daemonization, such as nohup/disown/setsid; cancellation and timeouts still kill the process group."}},"required":["command"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"preserve_background_processes":{"type":"boolean","description":"After the shell command exits normally, keep any process-group members it intentionally left behind. Use only for deliberate daemonization, browser/GUI/session launchers such as playwright-cli open, or nohup/disown/setsid; cancellation and timeouts still kill the process group."}},"required":["command"]}`)
 }
 
 // ReadOnly is false: bash's effect cannot be inferred from args (rm, curl,
@@ -171,7 +171,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			if shouldReapAfterRun(jobCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
 				reapShellProcess(cmd, tracked) // reap process-group stragglers the job left running (#3702)
 			}
-			return "", runErr
+			return "", normalizeBashRunError(jobCtx, runErr, p.PreserveBackgroundProcesses)
 		})
 		return fmt.Sprintf("Started background job %q. It keeps running across turns; read new output with bash_output(job_id=%q), wait for it with wait, or stop it with kill_shell(job_id=%q).", job.ID, job.ID, job.ID), nil
 	}
@@ -203,6 +203,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	if shouldReapAfterRun(runCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
 		reapShellProcess(cmd, tracked)
 	}
+	err = normalizeBashRunError(runCtx, err, p.PreserveBackgroundProcesses)
 	out := buf.String()
 
 	if errors.Is(context.Cause(runCtx), errBashTimeout) {
@@ -213,6 +214,13 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		return out, fmt.Errorf("command exited: %w", err)
 	}
 	return out, nil
+}
+
+func normalizeBashRunError(ctx context.Context, err error, preserveBackgroundProcesses bool) error {
+	if preserveBackgroundProcesses && ctx.Err() == nil && errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return err
 }
 
 func shouldReapAfterRun(ctx context.Context, sh sandbox.Shell, command string, preserveBackgroundProcesses bool) bool {

--- a/internal/tool/builtin/bash_timeout_test.go
+++ b/internal/tool/builtin/bash_timeout_test.go
@@ -2,6 +2,8 @@ package builtin
 
 import (
 	"context"
+	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -56,6 +58,21 @@ func TestWorkspacePassesBashTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("error = %v, want timeout", err)
+	}
+}
+
+func TestNormalizeBashRunErrorAllowsPreservedWaitDelay(t *testing.T) {
+	if err := normalizeBashRunError(context.Background(), exec.ErrWaitDelay, true); err != nil {
+		t.Fatalf("preserved post-exit WaitDelay should be ignored, got %v", err)
+	}
+	if err := normalizeBashRunError(context.Background(), exec.ErrWaitDelay, false); !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("ordinary WaitDelay should remain visible, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := normalizeBashRunError(ctx, exec.ErrWaitDelay, true); !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("cancelled WaitDelay should remain visible, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Treat `exec.ErrWaitDelay` as success when `preserve_background_processes=true` and the shell context has not been cancelled, so intentionally preserved browser/GUI/session launchers are not reported as failed after their parent shell exits.
- Mention browser/GUI/session launchers such as `playwright-cli open` in the existing `preserve_background_processes` schema description.
- Add regression coverage that preserves post-exit WaitDelay while keeping ordinary and cancelled WaitDelay errors visible.

Fixes #5575

## Verification

- `go test ./internal/tool/builtin -run 'TestNormalizeBashRunErrorAllowsPreservedWaitDelay|TestBashForegroundTimeoutConfig|TestBashExplicitZeroTimeoutDoesNotCapForeground|TestWorkspacePassesBashTimeout' -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/reasonix-builtin-windows.test ./internal/tool/builtin`
- `go test ./internal/tool -run TestBuiltinToolContractDocumentation -count=1`
- `git diff --check`

## Cache impact

Cache-impact: low; updates the provider-visible Bash tool schema description for `preserve_background_processes`, but does not change system prompts, memory prefixes, provider request serialization, or tool names.
Cache-guard: `go test ./internal/tool -run TestBuiltinToolContractDocumentation -count=1`
System-prompt-review: N/A
