### PR TITLE
fix(tool): hint escaped Windows paths

### DIFF
--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -94,7 +94,7 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 		Notes     string         `json:"notes"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
-		return "", fmt.Errorf("invalid args: %w", err)
+		return "", fmt.Errorf("invalid args: %w%s", err, windowsPathJSONHint(args))
 	}
 	step := completeStepIdentity(p.Step, p.StepIndex)
 	if step == "" {
@@ -153,6 +153,20 @@ func completeStepIdentity(step string, stepIndex int) string {
 		return strconv.Itoa(stepIndex)
 	}
 	return strings.TrimSpace(step)
+}
+
+func windowsPathJSONHint(args json.RawMessage) string {
+	for i := 0; i+3 < len(args); i++ {
+		if !isASCIIAlpha(args[i]) || args[i+1] != ':' || args[i+2] != '\\' || args[i+3] == '\\' {
+			continue
+		}
+		return `; escape Windows path backslashes in JSON strings, e.g. "D:\\work\\task.md"`
+	}
+	return ""
+}
+
+func isASCIIAlpha(b byte) bool {
+	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z')
 }
 
 func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified int, manualUnverified int, err error) {

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -66,6 +66,19 @@ func TestCompleteStepRejectsEmptyEvidenceSummary(t *testing.T) {
 	}
 }
 
+func TestCompleteStepHintsUnescapedWindowsPathJSON(t *testing.T) {
+	_, err := completeStep{}.Execute(context.Background(),
+		json.RawMessage(`{"step":"x","result":"y","evidence":[{"kind":"files","summary":"checked","paths":["D:\work\task.md"]}]}`))
+	if err == nil {
+		t.Fatal("raw Windows paths should still be invalid JSON")
+	}
+	for _, want := range []string{"escape Windows path backslashes", `D:\\work\\task.md`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should hint %q, got %v", want, err)
+		}
+	}
+}
+
 func TestCompleteStepAccepts(t *testing.T) {
 	out, err := completeStep{}.Execute(context.Background(), json.RawMessage(`{
 		"step":"Add the parser",


### PR DESCRIPTION
Addresses one part of #5562.

Problem:
complete_step rejects raw Windows paths such as D:\work\task.md as invalid JSON, but the error did not explain how to recover.

Change:
Add a focused invalid-JSON hint when complete_step args look like an unescaped Windows drive path, showing the escaped form D:\\work\\task.md.

Cache-impact: low - complete_step error hint only; no cache accounting, cache storage, or token-counting behavior changes.
Cache-guard: go test ./internal/tool/builtin -run TestCompleteStepHintsUnescapedWindowsPathJSON -count=1

Verification:
- go test ./internal/tool/builtin -run TestCompleteStepHintsUnescapedWindowsPathJSON -count=1
- go test ./internal/tool/builtin -run "TestCompleteStep|TestTodoInventory" -count=1
- go test ./internal/tool/builtin -count=1
- go test ./internal/tool/... -count=1
- go test ./...
- git diff --check