### PR TITLE
fix(cli): list fallback models in /model

### DIFF
--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -91,7 +91,7 @@ func (m *chatTUI) showModels() {
 		if !p.Configured() {
 			continue
 		}
-		for _, model := range p.ChatModelList() {
+		for _, model := range modelPickerModels(p) {
 			refs = append(refs, p.Name+"/"+model)
 		}
 	}
@@ -135,11 +135,21 @@ func modelRefs() []string {
 		if !p.Configured() {
 			continue
 		}
-		for _, model := range p.ChatModelList() {
+		for _, model := range modelPickerModels(p) {
 			out = append(out, p.Name+"/"+model)
 		}
 	}
 	return out
+}
+
+// modelPickerModels matches /provider: prefer chat-looking models, but keep a
+// configured provider selectable when the heuristic filters every model.
+func modelPickerModels(p *config.ProviderEntry) []string {
+	models := p.ChatModelList()
+	if len(models) == 0 {
+		models = p.ModelList()
+	}
+	return models
 }
 
 // providerNames returns the names of configured providers for slash completion.

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -32,6 +32,31 @@ func TestModelRefsFromConfig(t *testing.T) {
 	}
 }
 
+// TestModelRefsFallsBackToRawModelsWhenChatFilterEmpty verifies the /model
+// picker still exposes a configured provider when the chat-name heuristic
+// filters out every model. This mirrors /provider, which already falls back to
+// the raw configured model list for providers with no chat-looking entries.
+func TestModelRefsFallsBackToRawModelsWhenChatFilterEmpty(t *testing.T) {
+	isolateUserConfig(t)
+	cfg := config.Default()
+	cfg.DefaultModel = "local/custom-embedding"
+	cfg.Providers = []config.ProviderEntry{{
+		Name:    "local",
+		Kind:    "openai",
+		BaseURL: "http://127.0.0.1:11434/v1",
+		Models:  []string{"custom-embedding"},
+		Default: "custom-embedding",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("write user config: %v", err)
+	}
+
+	refs := modelRefs()
+	if len(refs) != 1 || refs[0] != "local/custom-embedding" {
+		t.Fatalf("modelRefs() = %v, want [local/custom-embedding]", refs)
+	}
+}
+
 // TestModelRefsSkipsUnconfigured verifies that with no provider keys set, the
 // picker offers nothing rather than listing models the user can't select.
 func TestModelRefsSkipsUnconfigured(t *testing.T) {


### PR DESCRIPTION
Problem:
- /model only listed models returned by ChatModelList().
- When a configured provider's model names are all filtered by the chat-name heuristic, the provider can disappear from /model list and completion even though /provider already falls back to the raw configured model list.

Change:
- Add a small /model picker helper that prefers chat-looking models and falls back to ModelList() only when the filtered list is empty.
- Use it for /model display and slash completion.

Refs #5581.

Verification:
- go test ./internal/cli -run 'TestModelRefs|TestModelArgCompletion|TestPersistModel' -count=1
- go test ./internal/cli -count=1
- go test ./internal/config -run 'TestChatModelList|TestIsLikelyChatModel|TestValidateAllowsNoAuthProvider|TestProviderConfigured' -count=1
- go test ./internal/environment -count=1
- go test ./internal/... -p 1 -count=1
- git diff --check HEAD~1..HEAD

Cache-impact: low - CLI model list/completion only; no cache accounting, storage, or token-counting behavior changes.
Cache-guard: go test ./internal/cli -run 'TestModelRefs|TestModelArgCompletion|TestPersistModel' -count=1
