### PR TITLE
test(jobs): guard migration notice capture

### DIFF
--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -258,10 +258,13 @@ func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
 	if err := os.WriteFile(ArtifactDir(sessionPath), []byte("not a dir"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	var noticesMu sync.Mutex
 	var notices []string
 	m := NewManager(event.FuncSink(func(e event.Event) {
 		if e.Kind == event.Notice {
+			noticesMu.Lock()
 			notices = append(notices, e.Text)
+			noticesMu.Unlock()
 		}
 	}))
 	defer m.Close()
@@ -276,8 +279,11 @@ func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
 	if len(res) != 1 || !strings.Contains(res[0].Output, "job artifact incomplete: migration:") {
 		t.Fatalf("wait after migration failure = %+v, want artifact error", res)
 	}
+	noticesMu.Lock()
+	seenNotices := append([]string(nil), notices...)
+	noticesMu.Unlock()
 	found := false
-	for _, notice := range notices {
+	for _, notice := range seenNotices {
 		if strings.Contains(notice, "job artifact migration failed") {
 			found = true
 			break


### PR DESCRIPTION
Problem:
- The jobs migration-failure test captures notice events in a plain slice.
- Job completion and migration-failure notices can be emitted from different goroutines, so `go test -race` can report a test-local data race while appending/reading that slice.

Change:
- Guard the test notice capture with a mutex.
- Snapshot the captured notices before asserting on them.

Verification:
- go test -race ./internal/jobs -run TestSetActiveSessionPathReportsMigrationFailure -count=20
- go test -race ./internal/jobs -run TestSetActiveSessionPathReportsMigrationFailure -count=50
- go test -race ./internal/jobs -count=1
- go test ./internal/jobs -count=1
- git diff --check HEAD~1..HEAD

Cache-impact: none - test-only synchronization in internal/jobs; no runtime cache accounting, storage, or token-counting behavior changes.
Cache-guard: go test -race ./internal/jobs -run TestSetActiveSessionPathReportsMigrationFailure -count=20