### PR TITLE
fix(memory): read listed markdown names

### DIFF
--- a/internal/memory/recall.go
+++ b/internal/memory/recall.go
@@ -196,6 +196,7 @@ func filterMemories(memories []Memory, typ Type) []Memory {
 }
 
 func readMemoryByName(store Store, name string) (Memory, bool) {
+	name = strings.TrimSuffix(strings.TrimSpace(name), ".md")
 	name = slug(name)
 	if name == "" {
 		return Memory{}, false

--- a/internal/memory/recall_test.go
+++ b/internal/memory/recall_test.go
@@ -157,6 +157,27 @@ func TestRecallToolReadsMemoryByName(t *testing.T) {
 	}
 }
 
+func TestRecallToolReadsMemoryByListedMarkdownName(t *testing.T) {
+	store := Store{Dir: t.TempDir()}
+	saveMemory(t, store, Memory{
+		Name:        "user-prefers-tabs",
+		Title:       "Prefers tabs",
+		Description: "User prefers tabs for indentation",
+		Type:        TypeUser,
+		Body:        "Use tabs unless the repository style clearly says otherwise.",
+	})
+
+	out, err := NewRecallTool(store).Execute(context.Background(), []byte(`{"operation":"read","name":"user-prefers-tabs.md"}`))
+	if err != nil {
+		t.Fatalf("Execute read with listed markdown name: %v", err)
+	}
+	for _, want := range []string{"Memory user-prefers-tabs", "type: user", "Use tabs"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("read output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestRecallToolListsAndFiltersByType(t *testing.T) {
 	store := Store{Dir: t.TempDir()}
 	saveMemory(t, store, Memory{Name: "one", Description: "project fact", Type: TypeProject, Body: "body"})


### PR DESCRIPTION
## Problem
`memory(operation="list")` renders saved memories as links like `name.md`, but `memory(operation="read", name="name.md")` slugifies the suffix and fails to find the saved memory.

## Change
Strip a trailing `.md` from memory read names before resolving the saved memory slug.

Cache-impact: low - touches the memory read resolver, but does not change the memory tool description, schema, list output, or composed system-prompt text.
Cache-guard: `go test ./internal/memory -run 'TestRecallToolSchemaIsCacheStable|TestRecallToolReadsMemoryByListedMarkdownName' -count=1`
System-prompt-review: self-reviewed; provider-visible memory tool description/schema are unchanged and covered by TestRecallToolSchemaIsCacheStable.

## Verification
- `go test ./internal/memory -run TestRecallToolReadsMemoryByListedMarkdownName -count=1`
- `go test ./internal/memory -count=1`
- `go test ./internal/memory ./internal/boot -count=1`
- `go test ./internal/memory -run 'TestRecallToolSchemaIsCacheStable|TestRecallToolReadsMemoryByListedMarkdownName' -count=1`
- `git diff --check`

Closes #5597