### PR TITLE
fix(memory): strip .md suffix in read to match list display format

### DIFF
--- a/internal/memory/recall.go
+++ b/internal/memory/recall.go
@@ -196,6 +196,7 @@ func filterMemories(memories []Memory, typ Type) []Memory {
 }
 
 func readMemoryByName(store Store, name string) (Memory, bool) {
+	name = strings.TrimSuffix(name, ".md")
 	name = slug(name)
 	if name == "" {
 		return Memory{}, false

--- a/internal/memory/recall_test.go
+++ b/internal/memory/recall_test.go
@@ -136,6 +136,32 @@ func TestRecallToolExcludesArchivedMemories(t *testing.T) {
 	}
 }
 
+func TestRecallToolReadsMemoryWithDotMdSuffix(t *testing.T) {
+	store := Store{Dir: t.TempDir()}
+	saveMemory(t, store, Memory{
+		Name:        "test-rules",
+		Title:       "Test rules",
+		Description: "Test description",
+		Type:        TypeProject,
+		Body:        "Test body.",
+	})
+
+	for _, tc := range []struct{ name, label string }{
+		{"test-rules.md", ".md suffix from list display"},
+		{"test-rules", "plain slug (backwards compat)"},
+	} {
+		out, err := NewRecallTool(store).Execute(context.Background(), []byte(`{"operation":"read","name":"`+tc.name+`"}`))
+		if err != nil {
+			t.Fatalf("[%s] Execute read(%q): %v", tc.label, tc.name, err)
+		}
+		for _, want := range []string{"Memory test-rules", "Test body"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("[%s] read output missing %q:\n%s", tc.label, want, out)
+			}
+		}
+	}
+}
+
 func TestRecallToolReadsMemoryByName(t *testing.T) {
 	store := Store{Dir: t.TempDir()}
 	saveMemory(t, store, Memory{


### PR DESCRIPTION
## Summary

`memory(list)` displays links with `.md` suffix (e.g. `[my-rules](my-rules.md)`), but `memory(read, name="my-rules.md")` fails because `slug()` converts the dot to a dash, producing `"my-rules-md"` instead of `"my-rules"`.

Fix: strip `.md` suffix in `readMemoryByName` before slug normalization, so the displayed link format works as a direct input to `memory(read)`.

## Verification

- `go test ./internal/memory/ -run TestRecallTool` — 9 tests pass (8 existing + 1 new)
- `go test ./internal/memory/... ./internal/control/...` — all pass
- `go build ./...` — clean
- `gofmt -l .` — no changes

Closes #5597

Cache-impact: low — tool schema and description unchanged; only adds input normalization in the read path.
Cache-guard: TestRecallToolReadsMemoryByName + TestRecallToolReadsMemoryWithDotMdSuffix
System-prompt-review: No schema, description, or prompt changes — only read-path input normalization. TestRecallToolSchemaIsCacheStable confirms schema stability.