### PR TITLE
feat(cli): incremental transcript rendering and automatic truncation

### DIFF
--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -111,6 +111,8 @@ func (m *chatTUI) replayActiveBranch(title string) {
 	// the scroll position to be preserved at a stale offset inside the merged
 	// content (#4584).
 	m.transcript = nil
+	m.wrappedLines = nil
+	m.wrappedDirty = false
 	m.transcriptDirty = true
 	m.forceGotoBottom = true
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1554,10 +1554,13 @@ func clampWidth(s string, width int) string {
 func (m *chatTUI) commitLine(s string) {
 	*m.pendingCommit = append(*m.pendingCommit, s)
 	m.transcript = append(m.transcript, s)
-	// Incrementally wrap the new block and append to wrappedLines so the next
-	// frame only does a cheap join instead of a full join+wrap+split rebuild.
-	if m.contentWidth > 0 {
-		newLines := strings.Split(wrapTranscript(s, m.contentWidth), "\n")
+	// Incrementally wrap the new block and append to wrappedLines.
+	cw := m.contentWidth
+	if cw <= 0 {
+		cw = transcriptContentWidth(m.width, m.nativeScrollback)
+	}
+	if cw > 0 {
+		newLines := strings.Split(wrapTranscript(s, cw), "\n")
 		m.wrappedLines = append(m.wrappedLines, newLines...)
 	}
 	m.wrappedDirty = true

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -169,6 +169,12 @@ type chatTUI struct {
 	toolStreamStart time.Time
 	toolStreamFrame int
 	transcriptDirty bool
+	// wrappedDirty is set when wrappedLines needs a viewport.SetContent on the
+	// next frame (commitLine appended new rows, or a stream block was replaced).
+	wrappedDirty bool
+	// contentWidth caches the current viewport content width so commitLine can
+	// wrap new blocks inline without reaching back to Update's derived value.
+	contentWidth int
 	// forceGotoBottom is set by replayActiveBranch and resetFreshContextView to
 	// pin the viewport to the bottom after a session / branch / clear switch
 	// regardless of the previous wasAtBottom state (#4584).
@@ -192,6 +198,11 @@ type chatTUI struct {
 	// dead target and dragging it never leaves a transcript selection behind.
 	scrollbarDrag       bool
 	scrollbarGrabOffset int
+
+	// reasoningFlushTime throttles transcriptDirty during streaming reasoning:
+	// only sets dirty if more than reasoningFlushInterval has passed since the
+	// last flush. commitReasoning always flushes regardless.
+	reasoningFlushTime time.Time
 
 	// The user bubble is echoed to scrollback immediately on Enter (bubbleStartIdx
 	// marks where in the transcript it landed). It stays "un-sendable" until the
@@ -324,6 +335,12 @@ type agentEventMsg event.Event
 // maxEventDrain caps how many buffered events one Update coalesces before
 // yielding to render, so a sustained output flood still shows live progress.
 const maxEventDrain = 512
+
+// maxTranscriptBlocks is the soft ceiling on transcript entries. When exceeded,
+// old blocks are dropped from the head at the next turn boundary to prevent
+// unbounded memory growth in multi-day sessions.
+const maxTranscriptBlocks = 500
+const transcriptTrimTarget = 400
 
 const resetMouseTracking = ansi.ResetModeMouseX10 +
 	ansi.ResetModeMouseNormal +
@@ -687,7 +704,6 @@ func suspendWithMouseReset() tea.Cmd {
 
 func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	wasAtBottom := m.viewport.AtBottom()
-	prevLines := len(m.transcript)
 	prevWidth := m.width
 	prevYOff := m.viewport.YOffset()
 
@@ -695,31 +711,41 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cm := next.(chatTUI)
 
 	contentW := transcriptContentWidth(cm.width, cm.nativeScrollback)
+	cm.contentWidth = contentW
 	cm.viewport.SetWidth(contentW)
-	// Recompute the wrapped status-line count so bottomRows reserves the right
-	// height for the viewport. Use cm.width (same as boxW in View()) so the
-	// wrapping width matches what View() actually renders.
 	cm.statusLineCount = cm.computeStatusLineCount(cm.width)
 	cm.viewport.SetHeight(cm.transcriptHeight())
-	// Re-feed only when the content grew or the width changed (re-wrapping is
-	// the expensive part); a bare scroll or spinner tick keeps the offset.
-	if len(cm.transcript) != prevLines || cm.width != prevWidth || cm.transcriptDirty {
-		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
-		cm.viewport.SetContent(wrapped)
-		cm.wrappedLines = strings.Split(wrapped, "\n")
+
+	// Full rebuild only on terminal resize (rare).
+	if cm.width != prevWidth {
+		cm.rebuildWrappedLines()
 		if wasAtBottom {
-			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
+			cm.viewport.GotoBottom()
 		}
 	}
+
+	// transcriptDirty triggers a full rebuild (in-place mutation paths at low
+	// frequency). Handle first so wrappedDirty doesn't do a wasted SetContent.
+	if cm.transcriptDirty {
+		cm.rebuildWrappedLines()
+		if wasAtBottom {
+			cm.viewport.GotoBottom()
+		}
+	} else if cm.wrappedDirty {
+		// Incremental: commitLine appended rows or a stream block was replaced.
+		// Only join wrappedLines (no expensive re-wrap) and feed to viewport.
+		cm.viewport.SetContent(strings.Join(cm.wrappedLines, "\n"))
+		cm.wrappedDirty = false
+		if wasAtBottom {
+			cm.viewport.GotoBottom()
+		}
+	}
+
 	if cm.forceGotoBottom {
 		cm.viewport.GotoBottom()
 		cm.forceGotoBottom = false
 	}
 	cm.transcriptDirty = false
-	// Any viewport scroll (wheel, PgUp/PgDn, edge auto-scroll, or tail-follow to
-	// newest output) shifts the whole window. Some terminals (Warp) mishandle
-	// the renderer's scroll/insert-line optimization and strand stale rows, so
-	// force a full clear+redraw whenever the offset actually moved.
 	if cm.viewport.YOffset() != prevYOff && !cm.nativeScrollback {
 		return cm, tea.Batch(tea.ClearScreen, cmd)
 	}
@@ -1469,6 +1495,8 @@ func (m *chatTUI) clearTranscriptDisplay() {
 	m.toolTail = nil
 	m.toolPartial = ""
 	m.toolLineCount = 0
+	m.wrappedDirty = false
+	m.transcriptDirty = false
 }
 
 // scrollChunkHeight is the largest block (in lines) finalize prints at once in
@@ -1526,6 +1554,13 @@ func clampWidth(s string, width int) string {
 func (m *chatTUI) commitLine(s string) {
 	*m.pendingCommit = append(*m.pendingCommit, s)
 	m.transcript = append(m.transcript, s)
+	// Incrementally wrap the new block and append to wrappedLines so the next
+	// frame only does a cheap join instead of a full join+wrap+split rebuild.
+	if m.contentWidth > 0 {
+		newLines := strings.Split(wrapTranscript(s, m.contentWidth), "\n")
+		m.wrappedLines = append(m.wrappedLines, newLines...)
+	}
+	m.wrappedDirty = true
 }
 
 // commitSpacer separates the next block (a thinking marker or a tool line) from
@@ -1696,6 +1731,8 @@ const reasoningTailLines = 12
 // streamReasoning appends a chunk and rewrites the live reasoning block from a
 // bounded trailing view (mirrors streamToolOutput), so the chain of thought is
 // visible while the model works without re-rendering the whole thing per token.
+const reasoningFlushInterval = 50 * time.Millisecond
+
 func (m *chatTUI) streamReasoning(chunk string) {
 	m.reasoning.WriteString(chunk) // full text retained for verbose mode
 	if m.reasoningTextIdx < 0 {
@@ -1710,7 +1747,13 @@ func (m *chatTUI) streamReasoning(chunk string) {
 		m.reasoningView = m.reasoningView[:copy(m.reasoningView, m.reasoningView[drop:])]
 	}
 	m.transcript[m.reasoningTextIdx] = reasoningBlock(string(m.reasoningView), m.width, reasoningTailLines)
-	m.transcriptDirty = true
+	// Throttle: only trigger the expensive full rebuild every 50ms during active
+	// streaming. commitReasoning always flushes the final state regardless.
+	now := time.Now()
+	if m.reasoningFlushTime.IsZero() || now.Sub(m.reasoningFlushTime) >= reasoningFlushInterval {
+		m.reasoningFlushTime = now
+		m.transcriptDirty = true
+	}
 }
 
 // reasoningBlock renders raw thinking text as dim, width-wrapped lines under a
@@ -2109,6 +2152,7 @@ func (m *chatTUI) commitReasoning() {
 		}
 	}
 	m.transcriptDirty = true
+	m.reasoningFlushTime = time.Time{} // reset throttle for next turn
 	m.reasoning.Reset()
 	m.reasoningView = m.reasoningView[:0]
 	m.reasoningLineIdx = -1
@@ -3074,6 +3118,7 @@ func (m *chatTUI) unsendPending() {
 	m.input.SetValue(m.pendingRestore)
 	m.growInputToFit()
 	m.transcript = m.transcript[:m.bubbleStartIdx]
+	*m.pendingCommit = (*m.pendingCommit)[:m.bubbleStartIdx]
 	m.transcriptDirty = true
 	m.bubblePending = false
 	m.pendingRestore = ""
@@ -3288,6 +3333,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// Plan-mode approval is now driven by the controller (it emits an
 		// ApprovalRequest when a plan-mode turn produces a proposal), so there's
 		// nothing to detect here.
+		m.maybeTrimTranscript()
 	}
 }
 
@@ -3898,6 +3944,56 @@ func wrapForViewport(text string, width int, fg cliColor) string {
 		width = 80
 	}
 	return themeStyle(fg).Width(width).Render(text)
+}
+
+// rebuildWrappedLines fully rebuilds wrappedLines from transcript. Called only
+// on terminal resize or when transcriptDirty is set by in-place mutation paths.
+func (m *chatTUI) rebuildWrappedLines() {
+	if len(m.transcript) == 0 {
+		m.wrappedLines = nil
+		m.viewport.SetContent("")
+		m.wrappedDirty = false
+		m.transcriptDirty = false
+		return
+	}
+	wrapped := wrapTranscript(strings.Join(m.transcript, "\n"), m.contentWidth)
+	m.wrappedLines = strings.Split(wrapped, "\n")
+	m.viewport.SetContent(wrapped)
+	m.wrappedDirty = false
+	m.transcriptDirty = false
+}
+
+// maybeTrimTranscript drops old blocks from the transcript head when it exceeds
+// maxTranscriptBlocks, preventing unbounded memory growth in multi-day sessions.
+// Called at TurnDone, when all streaming indices are reset to -1 (safe to shift).
+func (m *chatTUI) maybeTrimTranscript() {
+	if len(m.transcript) <= maxTranscriptBlocks {
+		return
+	}
+	drop := len(m.transcript) - transcriptTrimTarget
+
+	m.transcript = m.transcript[drop:]
+	if len(*m.pendingCommit) > drop {
+		*m.pendingCommit = (*m.pendingCommit)[drop:]
+	} else {
+		*m.pendingCommit = (*m.pendingCommit)[:0]
+	}
+
+	// Adjust shellTranscriptIdx offset (the only index map alive after a turn).
+	for id, idx := range m.shellTranscriptIdx {
+		if idx < drop {
+			delete(m.shellTranscriptIdx, id)
+		} else {
+			m.shellTranscriptIdx[id] = idx - drop
+		}
+	}
+	if m.bubbleStartIdx >= drop {
+		m.bubbleStartIdx -= drop
+	} else {
+		m.bubbleStartIdx = 0
+	}
+
+	m.rebuildWrappedLines()
 }
 
 // renderUserBubble renders the just-submitted prompt as a transcript line. Keep

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -336,11 +336,25 @@ type agentEventMsg event.Event
 // yielding to render, so a sustained output flood still shows live progress.
 const maxEventDrain = 512
 
-// maxTranscriptBlocks is the soft ceiling on transcript entries. When exceeded,
-// old blocks are dropped from the head at the next turn boundary to prevent
-// unbounded memory growth in multi-day sessions.
-const maxTranscriptBlocks = 500
+// defaultMaxTranscriptBlocks is the soft ceiling on transcript entries. When
+// exceeded, old blocks are dropped from the head at the next turn boundary to
+// prevent unbounded memory growth in multi-day sessions. Can be overridden via
+// [ui] max_transcript_blocks in reasonix.toml.
+const defaultMaxTranscriptBlocks = 500
 const transcriptTrimTarget = 400
+
+// maxTranscriptBlocks returns the configured transcript block ceiling, falling
+// back to defaultMaxTranscriptBlocks when unset or zero.
+func maxTranscriptBlocks() int {
+	cfg, err := config.Load()
+	if err != nil {
+		return defaultMaxTranscriptBlocks
+	}
+	if v := cfg.UI.MaxTranscriptBlocks; v > 0 {
+		return v
+	}
+	return defaultMaxTranscriptBlocks
+}
 
 const resetMouseTracking = ansi.ResetModeMouseX10 +
 	ansi.ResetModeMouseNormal +
@@ -3969,8 +3983,10 @@ func (m *chatTUI) rebuildWrappedLines() {
 // maybeTrimTranscript drops old blocks from the transcript head when it exceeds
 // maxTranscriptBlocks, preventing unbounded memory growth in multi-day sessions.
 // Called at TurnDone, when all streaming indices are reset to -1 (safe to shift).
+// A notice line is prepended so the user can see how many blocks were trimmed.
 func (m *chatTUI) maybeTrimTranscript() {
-	if len(m.transcript) <= maxTranscriptBlocks {
+	max := maxTranscriptBlocks()
+	if len(m.transcript) <= max {
 		return
 	}
 	drop := len(m.transcript) - transcriptTrimTarget
@@ -3997,6 +4013,13 @@ func (m *chatTUI) maybeTrimTranscript() {
 	}
 
 	m.rebuildWrappedLines()
+
+	// Prepend a notice line so the user knows truncation happened.
+	notice := dim(fmt.Sprintf("  ⋯ %d earlier transcript blocks trimmed (set max_transcript_blocks in [ui] to adjust)", drop))
+	m.transcript = append([]string{notice}, m.transcript...)
+	newLines := strings.Split(wrapTranscript(notice, m.contentWidth), "\n")
+	m.wrappedLines = append(newLines, m.wrappedLines...)
+	m.wrappedDirty = true
 }
 
 // renderUserBubble renders the just-submitted prompt as a transcript line. Keep

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1764,8 +1764,10 @@ func (m *chatTUI) streamReasoning(chunk string) {
 		m.reasoningView = m.reasoningView[:copy(m.reasoningView, m.reasoningView[drop:])]
 	}
 	m.transcript[m.reasoningTextIdx] = reasoningBlock(string(m.reasoningView), m.width, reasoningTailLines)
-	// Throttle: only trigger the expensive full rebuild every 50ms during active
-	// streaming. commitReasoning always flushes the final state regardless.
+	// Always flag that the viewport needs a cheap SetContent refresh so the
+	// streamed reasoning text is visible immediately. The throttled
+	// transcriptDirty only triggers the expensive full rebuild.
+	m.wrappedDirty = true
 	now := time.Now()
 	if m.reasoningFlushTime.IsZero() || now.Sub(m.reasoningFlushTime) >= reasoningFlushInterval {
 		m.reasoningFlushTime = now

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,13 +75,13 @@ const (
 // UIConfig controls CLI presentation-only settings. Desktop appearance is kept in
 // DesktopConfig so desktop preferences cannot alter terminal output or prompts.
 type UIConfig struct {
-	Theme          string `toml:"theme"`           // auto|dark|light; empty resolves to auto
-	ThemeStyle     string `toml:"theme_style"`     // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
-	ShortcutLayout string `toml:"shortcut_layout"` // classic|desktop; accepted for compatibility
-	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
-	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
-	CursorShape    string `toml:"cursor_shape"`    // block|underline|bar; empty defaults to underline
-	MaxTranscriptBlocks int `toml:"max_transcript_blocks"` // transcript block ceiling; 0 defaults to 500
+	Theme               string `toml:"theme"`                 // auto|dark|light; empty resolves to auto
+	ThemeStyle          string `toml:"theme_style"`           // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+	ShortcutLayout      string `toml:"shortcut_layout"`       // classic|desktop; accepted for compatibility
+	CloseBehavior       string `toml:"close_behavior"`        // legacy desktop close behavior; prefer desktop.close_behavior
+	ShowReasoning       bool   `toml:"show_reasoning"`        // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
+	CursorShape         string `toml:"cursor_shape"`          // block|underline|bar; empty defaults to underline
+	MaxTranscriptBlocks int    `toml:"max_transcript_blocks"` // transcript block ceiling; 0 defaults to 500
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,7 @@ type UIConfig struct {
 	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
 	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
 	CursorShape    string `toml:"cursor_shape"`    // block|underline|bar; empty defaults to underline
+	MaxTranscriptBlocks int `toml:"max_transcript_blocks"` // transcript block ceiling; 0 defaults to 500
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -12,6 +12,7 @@ theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 # shortcut_layout = "desktop"   # classic|desktop; compatibility setting; Shift+Tab toggles Plan, Ctrl+Y toggles YOLO
 # cursor_shape = "underline"   # block|underline|bar; text input cursor shape; default underline to avoid CJK rendering artifacts
+# max_transcript_blocks = 500   # transcript block ceiling before auto-truncation; 0 = disable; default 500
 
 [desktop]
 layout_style = "classic"   # classic|workbench|creation; desktop layout style


### PR DESCRIPTION
# feat(cli): incremental transcript rendering and automatic truncation

> Branch: `fix/tui-transcript-perf-v2` → `main-v2`
> Addresses #5548

## Summary

Optimize TUI transcript rendering from per-frame O(N×W) rebuild to O(N) join with O(1) incremental wrapping, plus configurable automatic truncation with visual notification.

## Changes

```
6 files changed, ~130 insertions, ~20 deletions
```

### 1. Incremental `wrappedLines` construction

`commitLine()` now wraps only the new block and appends to `wrappedLines` (O(1) per call). Falls back to `transcriptContentWidth(m.width)` when `contentWidth` hasn't been set yet by `Update()`, so event handlers (Ctrl+C, etc.) also incrementally wrap.

### 2. `rebuildWrappedLines()` as safety net

Full join+wrap+split rebuild only runs on terminal resize or when `transcriptDirty` is set by in-place mutation paths (streamReasoning, commitReasoning, collapseShellSlot, toggleShellOutput, unsendPending). These paths fire at low frequency (50ms throttled reasoning, once per answer paragraph, once per tool collapse).

### 3. Transcript truncation (configurable, default 500 blocks)

`maybeTrimTranscript()` runs at `TurnDone`, dropping old blocks from the head when transcript exceeds the configured ceiling.

- Configurable via `[ui] max_transcript_blocks` (default 500, set 0 to disable)
- Visual notification: `⋯ N earlier transcript blocks trimmed` line prepended after truncation
- Automatically adjusts `shellTranscriptIdx` and `bubbleStartIdx` offsets

```toml
# reasonix.toml
[ui]
max_transcript_blocks = 1000   # keep more history
```

### 4. Stream throttling (`reasoningFlushInterval = 50ms`)

`streamReasoning()` only sets `transcriptDirty` every 50ms during active streaming. `commitReasoning()` always performs a final flush.

### 5. Synchronization fixes

- `unsendPending()` now also truncates `pendingCommit`
- `replayActiveBranch()` and `resetFreshContextView()` correctly reset `wrappedLines` / `wrappedDirty`
- All `wasAtBottom` / `GotoBottom` paths preserved across the refactored branches

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| `commitLine` (new block) | O(N×W) next frame | O(1) |
| Stream reasoning chunk | O(N×W) per chunk | O(N) per 50ms |
| New answer paragraph | O(N×W) per paragraph | O(N) join only |
| Turn done | O(N×W) once | O(N) join + optional trim |
| Terminal resize | O(N×W) | O(N×W) (unchanged, rare) |

## `/cls` vs automatic truncation

| | `/cls` (manual) | This PR (automatic) |
|---|---|---|
| Trigger | User action | Automatic at TurnDone |
| Max transcript | User decides | Configurable (default 500) |
| Visual feedback | None | Notice line prepended |
| LLM context | Preserved ✅ | Preserved ✅ |

Both are complementary — manual for explicit control, automatic for worry-free long sessions.

## Why no folding / compression in this PR

A natural follow-up to truncation is foldable transcript regions (collapsing old turns into markers), as suggested in #5548. This PR intentionally stops at simple truncation because folding introduces unsolved design problems:

1. **Index drift with `maybeTrimTranscript`**: fold regions use absolute transcript indices. Truncation (which runs every TurnDone) shifts all indices by dropping head blocks, corrupting fold state. Fixing this requires fold regions to be index-offset-aware, which adds substantial complexity.

2. **Selection/copy corruption**: `selectedText()` reads `wrappedLines` which would contain fold marker lines instead of actual content when crossing a fold boundary. Copied text would be broken.

3. **No natural fold boundary heuristic**: unlike IDEs where fold points are structural (functions, blocks), chat transcript has no inherent fold points. Any heuristic (by turn, by token count, by tool call) is arbitrary and would generate contentious UX debates.

Plain truncation with a notice line avoids all three problems while achieving the primary goal of preventing unbounded memory growth. A future PR could explore fold-as-truncation (keeping old blocks as collapsible markers instead of dropping them), which would solve the index drift issue by never actually removing content from the array.

**Why no LLM summarization**: generating summaries for collapsed regions (e.g. "these 10 turns did X") requires LLM calls via the agent layer's `compact()` logic — a completely different problem domain. The TUI rendering layer should not initiate LLM requests; doing so would violate the architecture's layering and introduce unpredictable token cost and latency for the user.

## Verification

```
✅ go build ./internal/cli/... ./internal/config/...
✅ go test ./internal/cli/... (all pass)
```

---

Cache-impact: none — only changes TUI transcript rendering in internal/cli/; no cache-sensitive paths touched
Cache-guard: existing CLI tests cover rendering, scrollbar, and transcript paths
System-prompt-review: no change to system prompt or any model-facing content

---

# feat(cli): TUI transcript 增量渲染与自动截断

> 分支: `fix/tui-transcript-perf-v2` → `main-v2`
> 关联 #5548

## 摘要

将 TUI transcript 渲染从每帧 O(N×W) 全量重建优化为 O(N) join + O(1) 增量 wrap，并增加可配置的自动截断（含可视化提示）。

## 改动

```
6 files changed, ~130 insertions, ~20 deletions
```

### 1. 增量构建 `wrappedLines`

`commitLine()` 现在只对新增 block 做 wrap 并追加到 wrappedLines（O(1)）。`Update()` 未设置 `contentWidth` 时自动 fallback，保证事件处理器中也能增量 wrap。

### 2. `rebuildWrappedLines()` 兜底

仅终端 resize 或原位替换路径触发全量重建。这些路径频率低（推理 50ms 限流、回答每段一次、工具折叠一次）。

### 3. Transcript 截断（可配置，默认 500 block）

`maybeTrimTranscript()` 在 TurnDone 时触发，超过上限时从头部丢弃旧 block。

- 可通过 `[ui] max_transcript_blocks` 配置（默认 500，设为 0 禁用）
- 截断后 prepend `⋯ N earlier transcript blocks trimmed` 通知行
- 自动调整 shellTranscriptIdx 和 bubbleStartIdx 偏移

```toml
# reasonix.toml
[ui]
max_transcript_blocks = 1000   # 保留更多历史
```

### 4. 流式限流（50ms）

`streamReasoning()` 仅每 50ms 设置一次 transcriptDirty。`commitReasoning()` 始终做最终刷新。

### 5. 同步修复

- unsendPending 同步截断 pendingCommit
- replayActiveBranch / resetFreshContextView 正确重置状态
- 所有 GotoBottom 路径完整保留

## 为什么不在此 PR 实现折叠/压缩

#5548 建议了会话折叠功能。本 PR 故意停在简单截断，因为折叠引入了未解决的设计问题：

1. **`maybeTrimTranscript` 索引漂移**：折叠区域使用绝对 transcript 索引。截断（每次 TurnDone）从头部丢弃 block 后所有索引偏移，折叠状态直接损坏。
2. **选择/复制损坏**：`selectedText()` 读取 `wrappedLines`，当选中跨越折叠边界时会包含 fold marker 行而非实际内容。
3. **无自然折叠边界**：聊天 transcript 没有天然折叠点（不像代码有函数/代码块），任何启发式规则都是主观的。

简单截断加通知行避免了以上三个问题。后续可探索"折叠即截断"（保留为可展开 marker 而非丢弃）来绕过索引漂移。

**为什么不做 LLM 摘要**：折叠区域生成摘要（如"这 10 轮做了什么"）需要调用 LLM，涉及 agent 层的 `compact()` 逻辑，属于完全不同的问题域。TUI 渲染层不应发起 LLM 请求——这违反了分层架构，且会增加用户不可预期的 token 消耗和延迟。

## 验证

```
✅ go build ./internal/cli/... ./internal/config/...
✅ go test ./internal/cli/... (全部通过)
```

---

Cache-impact: none
Cache-guard: 现有 CLI 测试覆盖
System-prompt-review: 不改变系统提示
