### PR TITLE
Fix desktop hydration storms / 修复桌面端会话同步风暴

### DIFF
--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -133,14 +133,17 @@ const tabD = tabMeta("tab-d");
 let backendActiveId = "tab-a";
 const historyB = deferred<HistoryMessage[]>();
 const historyD = deferred<HistoryMessage[]>();
+const contextDGate = deferred<ContextInfo>();
 const setActiveBGate = deferred<void>();
 const historyCalls: string[] = [];
+let contextDCalls = 0;
+let holdNextContextForD = false;
 let setActiveCalls = 0;
 let newSessionCalls = 0;
 const runningTabs = new Set<string>();
 const tabsById = new Map([tabA, tabB, tabC, tabD].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
-const readyHandlers: Array<() => void> = [];
+const readyHandlers: Array<(tabId?: string) => void> = [];
 
 function currentTabs(): TabMeta[] {
   return [tabA, tabB, tabC, tabD].map((tab) => ({ ...tab, active: tab.id === backendActiveId, running: runningTabs.has(tab.id) }));
@@ -149,7 +152,7 @@ function currentTabs(): TabMeta[] {
 window.runtime = {
   EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
     if (name === "agent:event") eventHandlers.push(cb as (e: WireEvent) => void);
-    if (name === "agent:ready") readyHandlers.push(cb as () => void);
+    if (name === "agent:ready") readyHandlers.push(cb as (tabId?: string) => void);
     return () => {};
   },
   BrowserOpenURL: () => {},
@@ -159,7 +162,15 @@ window.go = {
     App: {
       ListTabs: async () => currentTabs(),
       MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
-      ContextUsageForTab: async () => context,
+      ContextUsageForTab: async (tabID: string) => {
+        if (tabID === "tab-d" && holdNextContextForD) {
+          contextDCalls += 1;
+          holdNextContextForD = false;
+          return contextDGate.promise;
+        }
+        if (tabID === "tab-d") contextDCalls += 1;
+        return context;
+      },
       EffortForTab: async () => effort,
       BalanceForTab: async () => balance,
       JobsForTab: async () => jobs,
@@ -294,6 +305,7 @@ eq(controller?.activeTabId, "tab-c", "switching to a cached running tab still up
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "streaming C") ?? false, "cached running tab keeps its optimistic transcript");
 ok(!historyCalls.includes("tab-c"), "cached running tab skips history hydration");
 
+holdNextContextForD = true;
 await act(async () => {
   await controller?.openProjectTab(tabD.workspaceRoot, tabD.topicId || "");
   await flushPromises();
@@ -307,6 +319,25 @@ await act(async () => {
   await historyD.promise;
   await flushPromises();
 });
+eq(controller?.state.hydrating, false, "topic history clears visible hydration before ancillary phase 2 settles");
+await waitFor("open topic phase 2 started", () => contextDCalls === 1);
+const contextCallsBeforeReadyD = contextDCalls;
+const historyCallsBeforeReadyD = historyCalls.length;
+await act(async () => {
+  for (const handler of readyHandlers) {
+    handler("tab-b");
+    handler("tab-d");
+    handler();
+  }
+  await flushPromises();
+});
+eq(contextDCalls, contextCallsBeforeReadyD, "agent ready reuses in-flight open-topic hydration for the active tab");
+eq(historyCalls.length, historyCallsBeforeReadyD, "background ready events do not hydrate the active tab");
+await act(async () => {
+  contextDGate.resolve(context);
+  await contextDGate.promise;
+  await flushPromises();
+});
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "history D") ?? false, "topic history replaces the hydration placeholder");
 eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "topic history clears the hydration placeholder");
 
@@ -318,6 +349,18 @@ await act(async () => {
 eq(controller?.activeTabId, "tab-d", "reopening an already hydrated topic keeps it active");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "history D") ?? false, "reopened cached topic keeps its transcript");
 eq(historyCalls.length, historyCallsBeforeReopenD, "reopening an already hydrated topic skips history hydration");
+
+const contextCallsBeforeInactiveD = contextDCalls;
+await act(async () => {
+  await controller?.openProjectTab(tabD.workspaceRoot, tabD.topicId || "");
+  await controller?.switchTab("tab-a", tabA);
+  await flushPromises();
+});
+await act(async () => {
+  await flushPromises();
+  await flushPromises();
+});
+eq(contextDCalls, contextCallsBeforeInactiveD, "inactive topic skips ancillary hydration after quick tab switch");
 
 tabsById.set("tab-d", { ...tabD, sessionPath: `${tabD.workspaceRoot}/sessions/next-tab-d.jsonl` });
 const historyCallsBeforeReboundD = historyCalls.length;

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -532,9 +532,9 @@ export function onFilesDropped(cb: (paths: string[]) => void): () => void {
 
 // onReady subscribes to the agent:ready event fired when boot.Build completes.
 // The frontend re-fetches Meta/Context/History when this lands.
-export function onReady(cb: () => void): () => void {
+export function onReady(cb: (tabId?: string) => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
-    return window.runtime.EventsOn("agent:ready", () => cb());
+    return window.runtime.EventsOn("agent:ready", (tabId?: unknown) => cb(typeof tabId === "string" ? tabId : undefined));
   }
   // In dev mock, fire immediately since there's no real boot sequence.
   cb();

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1008,6 +1008,7 @@ export function useController() {
 
   const checkpointRefreshSeq = useRef(new Map<string, number>());
   const sessionLoadSeq = useRef(new Map<string, number>());
+  const sessionLoadInFlight = useRef(new Map<string, { sessionPath: string; promise: Promise<void> }>());
   const bumpSessionLoadSeq = useCallback((tabId: string): number => {
     const seq = (sessionLoadSeq.current.get(tabId) ?? 0) + 1;
     sessionLoadSeq.current.set(tabId, seq);
@@ -1034,77 +1035,108 @@ export function useController() {
     reason: HydrateReason = "startup",
     options: { skipHistory?: boolean; placeholderItems?: Item[]; preserveCachedHistory?: boolean; sessionPath?: string } = {},
   ) => {
-    const seq = bumpSessionLoadSeq(tabId);
-    const hydrateStartedAt = Date.now();
-    const skipHistory = Boolean(
-      options.skipHistory ||
-      (options.preserveCachedHistory && !reset && hasReusableCachedTranscript(statesRef.current.get(tabId), options.sessionPath)),
-    );
-    addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
-    dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: options.placeholderItems });
-    if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
-
-    const stillCurrent = () => sessionLoadCurrent(tabId, seq);
-    const noteFailure = (label: string, err: unknown) => {
-      addBreadcrumb("tab.hydrate", `${label} failed ${tabId}: ${errorMessage(err)}`);
-    };
-
-    const historyStartedAt = Date.now();
-
-    // Phase 1: dispatch fast metadata immediately so the transcript can render
-    // without waiting for slower ancillary calls (e.g. BalanceForTab network).
-    const [meta, historyPage] = await Promise.all([
-      app.MetaForTab(tabId).catch((err) => { noteFailure("meta", err); return undefined; }),
-      skipHistory
-        ? Promise.resolve(undefined)
-        : app.HistoryPageForTab(tabId, 0, HISTORY_PAGE_TURNS).catch((err) => { noteFailure("history", err); return undefined; }),
-    ]);
-
-    if (!stillCurrent()) return;
-    if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
-    if (!skipHistory && historyPage !== undefined) {
-      const messages = asArray(historyPage.messages);
-      dispatchTo(tabId, { type: "history_page", page: historyPage, mode: "replace" });
-      addBreadcrumb(
-        "tab.hydrate",
-        `history page ${tabId} messages=${messages.length} turns=${historyPage.startTurn}-${historyPage.endTurn}/${historyPage.totalTurns} ms=${Date.now() - historyStartedAt}`,
-      );
-      if (reason === "switch-tab") {
-        addBreadcrumb(
-          "tab.switch",
-          `history-done ${tabId} messages=${messages.length} turns=${historyPage.startTurn}-${historyPage.endTurn}/${historyPage.totalTurns} ms=${Date.now() - historyStartedAt}`,
-        );
-      }
-    } else if (skipHistory) {
-      const skipReason = options.skipHistory ? "cached-live-turn" : "cached-transcript";
-      addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=${skipReason}`);
-      if (reason === "switch-tab") {
-        addBreadcrumb("tab.switch", `history-done ${tabId} skipped ms=${Date.now() - historyStartedAt}`);
-      }
+    const sessionPath = (options.sessionPath ?? statesRef.current.get(tabId)?.meta?.sessionPath ?? "").trim();
+    const canJoinInFlight = !reset && !options.skipHistory;
+    const shouldTrackInFlight = !options.skipHistory;
+    if (canJoinInFlight) {
+      const existing = sessionLoadInFlight.current.get(tabId);
+      if (existing?.sessionPath === sessionPath) return existing.promise;
+    } else {
+      sessionLoadInFlight.current.delete(tabId);
     }
 
-    // Phase 2: local ancillary data. Balance is a network call and is refreshed
-    // after hydrate_done so it cannot hold the transcript loading state open.
-    // These don't block the transcript, so they're batched into one render.
-    const [effort, jobs, checkpoints, context] = await Promise.all([
-      app.EffortForTab(tabId).catch((err) => { noteFailure("effort", err); return undefined; }),
-      app.JobsForTab(tabId).catch((err) => { noteFailure("jobs", err); return undefined; }),
-      app.CheckpointsForTab(tabId).catch((err) => { noteFailure("checkpoints", err); return undefined; }),
-      app.ContextUsageForTab(tabId).catch((err) => { noteFailure("context", err); return undefined; }),
-    ]);
-    if (!stillCurrent()) return;
-    if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
-    if (jobs !== undefined) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
-    if (checkpoints !== undefined) dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
-    if (context !== undefined) dispatchTo(tabId, { type: "context", context });
+    const promise = (async () => {
+      const seq = bumpSessionLoadSeq(tabId);
+      const hydrateStartedAt = Date.now();
+      const skipHistory = Boolean(
+        options.skipHistory ||
+        (options.preserveCachedHistory && !reset && hasReusableCachedTranscript(statesRef.current.get(tabId), options.sessionPath)),
+      );
+      addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
+      dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: options.placeholderItems });
+      if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
 
-    dispatchTo(tabId, { type: "hydrate_done" });
-    addBreadcrumb("tab.hydrate", `done ${reason} ${tabId} ms=${Date.now() - hydrateStartedAt}`);
-    app.BalanceForTab(tabId)
-      .then((balance) => {
-        if (sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "balance", balance });
-      })
-      .catch((err) => { noteFailure("balance", err); });
+      const stillCurrent = () => sessionLoadCurrent(tabId, seq);
+      const noteFailure = (label: string, err: unknown) => {
+        addBreadcrumb("tab.hydrate", `${label} failed ${tabId}: ${errorMessage(err)}`);
+      };
+
+      const historyStartedAt = Date.now();
+
+      // Phase 1: dispatch fast metadata immediately so the transcript can render
+      // without waiting for slower ancillary calls (e.g. BalanceForTab network).
+      const [meta, historyPage] = await Promise.all([
+        app.MetaForTab(tabId).catch((err) => { noteFailure("meta", err); return undefined; }),
+        skipHistory
+          ? Promise.resolve(undefined)
+          : app.HistoryPageForTab(tabId, 0, HISTORY_PAGE_TURNS).catch((err) => { noteFailure("history", err); return undefined; }),
+      ]);
+
+      if (!stillCurrent()) return;
+      if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
+      if (!skipHistory && historyPage !== undefined) {
+        const messages = asArray(historyPage.messages);
+        dispatchTo(tabId, { type: "history_page", page: historyPage, mode: "replace" });
+        addBreadcrumb(
+          "tab.hydrate",
+          `history page ${tabId} messages=${messages.length} turns=${historyPage.startTurn}-${historyPage.endTurn}/${historyPage.totalTurns} ms=${Date.now() - historyStartedAt}`,
+        );
+        if (reason === "switch-tab") {
+          addBreadcrumb(
+            "tab.switch",
+            `history-done ${tabId} messages=${messages.length} turns=${historyPage.startTurn}-${historyPage.endTurn}/${historyPage.totalTurns} ms=${Date.now() - historyStartedAt}`,
+          );
+        }
+      } else if (skipHistory) {
+        const skipReason = options.skipHistory ? "cached-live-turn" : "cached-transcript";
+        addBreadcrumb("tab.hydrate", `history skipped ${tabId} reason=${skipReason}`);
+        if (reason === "switch-tab") {
+          addBreadcrumb("tab.switch", `history-done ${tabId} skipped ms=${Date.now() - historyStartedAt}`);
+        }
+      }
+
+      dispatchTo(tabId, { type: "hydrate_done" });
+      addBreadcrumb("tab.hydrate", `done ${reason} ${tabId} ms=${Date.now() - hydrateStartedAt}`);
+
+      // Phase 2: local ancillary data. It stays inside the same in-flight
+      // promise so duplicate ready/startup hydrations coalesce, but it runs
+      // after hydrate_done so slow Wails calls don't keep the visible transcript
+      // in a loading state.
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+      if (!stillCurrent()) return;
+      if (activeTabIdRef.current !== tabId && (reason === "startup" || reason === "switch-tab" || reason === "open-topic")) {
+        addBreadcrumb("tab.hydrate", `ancillary skipped inactive ${reason} ${tabId}`);
+        return;
+      }
+      const ancillaryStartedAt = Date.now();
+      const [effort, jobs, checkpoints, context] = await Promise.all([
+        app.EffortForTab(tabId).catch((err) => { noteFailure("effort", err); return undefined; }),
+        app.JobsForTab(tabId).catch((err) => { noteFailure("jobs", err); return undefined; }),
+        app.CheckpointsForTab(tabId).catch((err) => { noteFailure("checkpoints", err); return undefined; }),
+        app.ContextUsageForTab(tabId).catch((err) => { noteFailure("context", err); return undefined; }),
+      ]);
+      if (!stillCurrent()) return;
+      if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
+      if (jobs !== undefined) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
+      if (checkpoints !== undefined) dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
+      if (context !== undefined) dispatchTo(tabId, { type: "context", context });
+      addBreadcrumb("tab.hydrate", `ancillary ${reason} ${tabId} ms=${Date.now() - ancillaryStartedAt}`);
+      app.BalanceForTab(tabId)
+        .then((balance) => {
+          if (sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "balance", balance });
+        })
+        .catch((err) => { noteFailure("balance", err); });
+    })();
+    if (shouldTrackInFlight) {
+      sessionLoadInFlight.current.set(tabId, { sessionPath, promise });
+    }
+    try {
+      await promise;
+    } finally {
+      if (sessionLoadInFlight.current.get(tabId)?.promise === promise) {
+        sessionLoadInFlight.current.delete(tabId);
+      }
+    }
   }, [bumpSessionLoadSeq, dispatchTo, sessionLoadCurrent]);
 
   const loadOlderHistory = useCallback(async (tabId?: string): Promise<void> => {
@@ -1272,10 +1304,14 @@ export function useController() {
       }
     });
 
-    const offReady = onReady(() => {
-      const readyTabId = activeTabIdRef.current;
-      if (readyTabId) {
-        void loadSessionDataForTab(readyTabId, false, "startup", { preserveCachedHistory: true });
+    const offReady = onReady((readyTabId) => {
+      const activeId = activeTabIdRef.current;
+      if (readyTabId && activeId && readyTabId !== activeId) {
+        addBreadcrumb("tab.hydrate", `ready ignored ${readyTabId}`);
+        return;
+      }
+      if (activeId) {
+        void loadSessionDataForTab(activeId, false, "startup", { preserveCachedHistory: true });
         return;
       }
       void syncActiveTabFromBackend(false, true);

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -841,7 +841,7 @@ func isBackgroundJobLifecycleNotice(e event.Event) bool {
 			strings.Contains(text, " killed: "))
 }
 
-func (a *App) emitReady(ctx context.Context) {
+func (a *App) emitReady(ctx context.Context, tabID ...string) {
 	a.mu.RLock()
 	hook := a.readyHook
 	a.mu.RUnlock()
@@ -850,6 +850,10 @@ func (a *App) emitReady(ctx context.Context) {
 		return
 	}
 	if ctx != nil {
+		if len(tabID) > 0 && strings.TrimSpace(tabID[0]) != "" {
+			runtime.EventsEmit(ctx, "agent:ready", strings.TrimSpace(tabID[0]))
+			return
+		}
 		runtime.EventsEmit(ctx, "agent:ready")
 	}
 }
@@ -2048,7 +2052,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		tab.StartupErr = err.Error()
 		tab.Ready = true
 		a.mu.Unlock()
-		a.emitReady(wailsCtx)
+		a.emitReady(wailsCtx, tab.ID)
 		return
 	}
 
@@ -2156,7 +2160,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		tab.Ready = true
 		a.releaseTabSharedHost(tab)
 		a.mu.Unlock()
-		a.emitReady(wailsCtx)
+		a.emitReady(wailsCtx, tab.ID)
 		return
 	}
 	if a.tabRemovedForBuild(tab) {
@@ -2229,7 +2233,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			if a.attachExistingSessionRuntime(tab, path, wailsCtx) {
 				ctrl.Close()
 				a.releaseSharedHost(rootKey)
-				a.emitReady(wailsCtx)
+				a.emitReady(wailsCtx, tab.ID)
 				return
 			}
 		}
@@ -2248,7 +2252,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	tab.StartupErr = ""
 	keepBuildContext = true
 	a.mu.Unlock()
-	a.emitReady(wailsCtx)
+	a.emitReady(wailsCtx, tab.ID)
 }
 
 func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) {


### PR DESCRIPTION
## Summary

- Coalesce matching same-tab session hydrations so `startup` / `agent:ready` reuses an in-flight `open-topic` hydrate instead of starting a second phase-2 IPC pass.
- Scope `agent:ready` to the tab that finished building, while preserving the existing unscoped ready event for settings/global refreshes.
- Mark visible transcript hydration complete after meta/history lands, then defer ancillary effort/jobs/checkpoints/context work and skip that ancillary phase if the tab is no longer active.
- Adds regression coverage for the #5306 open-topic + ready-event overlap, background ready events, and quick switch-away from cached topics.

## Relationship

- Follow-up to #5306, which is already closed.
- Builds on @GTC2080's #5580 in-flight hydration coalescing approach and keeps the reset/session-change and live-turn skip paths independent.
- Refs #5580.

## Contributor credit

@GTC2080 authored #5580 and should be recognized as a co-contributor to this repository fix. This PR preserves and extends his in-flight hydration coalescing work, adding tab-scoped ready-event routing and inactive-tab ancillary guards on top.

## Verification

- PASS `corepack pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- PASS `corepack pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/open-topic-coalescing.test.tsx`
- PASS `corepack pnpm -C desktop/frontend --ignore-workspace exec tsc --noEmit`
- PASS `corepack pnpm -C desktop/frontend --ignore-workspace test`
- PASS `(cd desktop && go test ./...)`
- PASS `git diff --check origin/main-v2...HEAD`

## Cache impact

Cache-impact: none, desktop frontend hydration orchestration and Wails ready-event routing only; no provider-visible prompt/tool/schema serialization changes.
Cache-guard: PASS `corepack pnpm -C desktop/frontend --ignore-workspace test`
System-prompt-review: N/A
