### PR TITLE
Harden desktop topic IDs and tray probing / 加固桌面 topic ID 与托盘探测

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5156,7 +5156,10 @@ func newTabID() string {
 
 func newTopicID() string {
 	var b [8]byte
-	rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		now := time.Now().UTC()
+		return "topic_" + now.Format("20060102-150405") + "_" + fmt.Sprintf("%09d", now.Nanosecond())
+	}
 	return "topic_" + time.Now().UTC().Format("20060102-150405") + "_" + hex.EncodeToString(b[:])
 }
 

--- a/desktop/tray_supported_unix.go
+++ b/desktop/tray_supported_unix.go
@@ -9,7 +9,8 @@ func traySupported() bool {
 	if err != nil {
 		return false
 	}
-	defer conn.Close()
+	// SessionBus returns a shared singleton connection. Do not close it here:
+	// other desktop integrations in this process may still be using it.
 	obj := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
 	var owner string
 	return obj.Call("org.freedesktop.DBus.GetNameOwner", 0, "org.kde.StatusNotifierWatcher").Store(&owner) == nil && owner != ""


### PR DESCRIPTION
## Summary
- Handle `crypto/rand.Read` failures in `newTopicID` with a timestamp fallback consistent with `newTabID`.
- Stop closing the shared Linux DBus session connection while probing tray support.

## Source PR consolidation
Kept/adapted:
- #5509 by @HUQIANTAO: kept the `rand.Read` fallback idea and applied it on the latest `main-v2`.
- #5524 by @HUQIANTAO: kept the final shared-`SessionBus` lifecycle fix, not the intermediate private-bus variant.

Reviewed but not adopted in this non-frontend maintenance PR:
- Frontend-scoped and intentionally excluded from this branch: #5502, #5505, #5506, #5507, #5508, #5513, #5515, #5516, #5517, #5518, #5519, #5521, #5523, #5526.
- Non-frontend items not adopted: #5510 (random map eviction did not match the stated oldest-entry policy), #5511 (the new emitter context was not wired into the emitter), #5514 (comment-only after reverting the behavior change, with a failing cache-impact check), #5520 (counter added without a consumer), #5525 (comment-only), #5527 (comment-only lifecycle note not needed for this maintenance pass).

## Cache impact
- None. This does not change provider-visible prompts, tool schemas, request serialization, MCP registration, memory prefix, or compaction behavior.

## Verification
- `git diff --check`
- `cd desktop && go test ./...`
