### PR TITLE
Fix desktop system prompt refresh / 修复桌面 system prompt 刷新

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5995,11 +5995,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	newCtrl.SetGoal(tab.goal)
 
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if len(carried) > 0 {
-		newCtrl.Resume(&agent.Session{Messages: carried}, path)
-	} else if path != "" {
-		newCtrl.SetSessionPath(path)
-	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.persistTabSessionPath(tab, path)
 	return nil
 }
@@ -6095,11 +6091,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
 	newCtrl.SetGoal(tab.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if len(carried) > 0 {
-		newCtrl.Resume(&agent.Session{Messages: carried}, path)
-	} else if path != "" {
-		newCtrl.SetSessionPath(path)
-	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.persistTabSessionPath(tab, path)
 	return nil
 }
@@ -6173,11 +6165,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
 	newCtrl.SetGoal(tab.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if len(carried) > 0 {
-		newCtrl.Resume(&agent.Session{Messages: carried}, path)
-	} else if path != "" {
-		newCtrl.SetSessionPath(path)
-	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.persistTabSessionPath(tab, path)
 	return nil
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1616,6 +1616,77 @@ func TestSetModelForTabRejectsProviderOutsideAccess(t *testing.T) {
 	}
 }
 
+func TestSetModelForTabRefreshesCarriedSystemPrompt(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "NEW_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old", "new"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+		{Name: "new", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "new-model", APIKeyEnv: "NEW_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	if err := os.MkdirAll(config.MemoryUserDir(), 0o755); err != nil {
+		t.Fatalf("mkdir memory dir: %v", err)
+	}
+	const freshRule = "Fresh global AGENTS rule for model switch"
+	if err := os.WriteFile(filepath.Join(config.MemoryUserDir(), "AGENTS.md"), []byte(freshRule), 0o644); err != nil {
+		t.Fatalf("write global AGENTS.md: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	oldSession := agent.NewSession("old system prompt without memory")
+	oldSession.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldPath := filepath.Join(dir, "old.jsonl")
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: oldPath, Label: "old", Sink: event.Discard})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_a",
+		Scope:       "global",
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_a", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	if err := app.SetModelForTab(tab.ID, "new/new-model"); err != nil {
+		t.Fatalf("SetModelForTab: %v", err)
+	}
+	history := tab.Ctrl.History()
+	if len(history) < 2 {
+		t.Fatalf("history length = %d, want system + user", len(history))
+	}
+	if history[0].Role != provider.RoleSystem {
+		t.Fatalf("first message role = %s, want system", history[0].Role)
+	}
+	if !strings.Contains(history[0].Content, freshRule) {
+		t.Fatalf("refreshed system prompt missing global AGENTS rule:\n%s", history[0].Content)
+	}
+	if history[1].Role != provider.RoleUser || history[1].Content != "hello" {
+		t.Fatalf("carried user message changed: %+v", history[1])
+	}
+}
+
 func TestSetDefaultModelRejectsProviderWithoutKey(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	t.Setenv("MIMO_API_KEY", "")

--- a/desktop/session_prompt.go
+++ b/desktop/session_prompt.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+func systemPromptFrom(messages []provider.Message) string {
+	for _, m := range messages {
+		if m.Role == provider.RoleSystem {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func withFreshSystemPrompt(messages []provider.Message, system string) []provider.Message {
+	if strings.TrimSpace(system) == "" {
+		return messages
+	}
+	out := append([]provider.Message(nil), messages...)
+	for i := range out {
+		if out[i].Role == provider.RoleSystem {
+			out[i].Content = system
+			out[i].ReasoningContent = ""
+			out[i].ReasoningSignature = ""
+			out[i].ToolCalls = nil
+			out[i].ToolCallID = ""
+			out[i].Name = ""
+			return out
+		}
+	}
+	return append([]provider.Message{{Role: provider.RoleSystem, Content: system}}, out...)
+}
+
+func sessionWithFreshSystemPrompt(session *agent.Session, system string) *agent.Session {
+	if session == nil {
+		return nil
+	}
+	messages := session.Snapshot()
+	if systemPromptFrom(messages) == "" {
+		return session
+	}
+	return &agent.Session{Messages: withFreshSystemPrompt(messages, system)}
+}
+
+func resumeWithFreshSystemPrompt(ctrl interface {
+	History() []provider.Message
+	Resume(*agent.Session, string)
+	SetSessionPath(string)
+}, messages []provider.Message, path string) {
+	if ctrl == nil {
+		return
+	}
+	if len(messages) > 0 {
+		ctrl.Resume(&agent.Session{Messages: withFreshSystemPrompt(messages, systemPromptFrom(ctrl.History()))}, path)
+		return
+	}
+	if path != "" {
+		ctrl.SetSessionPath(path)
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -927,34 +927,6 @@ func (a *App) rebuild() error {
 	return nil
 }
 
-func systemPromptFrom(messages []provider.Message) string {
-	for _, m := range messages {
-		if m.Role == provider.RoleSystem {
-			return m.Content
-		}
-	}
-	return ""
-}
-
-func withFreshSystemPrompt(messages []provider.Message, system string) []provider.Message {
-	if strings.TrimSpace(system) == "" {
-		return messages
-	}
-	out := append([]provider.Message(nil), messages...)
-	for i := range out {
-		if out[i].Role == provider.RoleSystem {
-			out[i].Content = system
-			out[i].ReasoningContent = ""
-			out[i].ReasoningSignature = ""
-			out[i].ToolCalls = nil
-			out[i].ToolCallID = ""
-			out[i].Name = ""
-			return out
-		}
-	}
-	return append([]provider.Message{{Role: provider.RoleSystem, Content: system}}, out...)
-}
-
 // SetDefaultModel sets the config default and switches the live model to it.
 func (a *App) SetDefaultModel(ref string) error {
 	tab := a.activeTab()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2195,7 +2195,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		// topicId and could pick the wrong session when one topic had multiple files.
 		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tab.SessionPath, loadedSession); ok {
 			if loaded != nil {
-				ctrl.Resume(loaded, pinnedPath)
+				ctrl.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl.History())), pinnedPath)
 			} else {
 				ctrl.SetSessionPath(pinnedPath)
 			}
@@ -2205,7 +2205,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			existingPath := findTopicSession(dir, tab.TopicID)
 			if existingPath != "" {
 				if loaded, err := loadResumableSession(existingPath); err == nil {
-					ctrl.Resume(loaded, existingPath)
+					ctrl.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl.History())), existingPath)
 					path = existingPath
 				}
 			}
@@ -5201,6 +5201,9 @@ func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTa
 		return nil, "", false
 	}
 	if preloaded.matches(path) {
+		if preloaded.Session != nil && len(preloaded.Session.Snapshot()) == 0 {
+			return nil, path, true
+		}
 		return preloaded.Session, path, true
 	}
 	loaded, err := agent.LoadSession(path)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5210,6 +5210,13 @@ func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTa
 		}
 		return nil, "", false
 	}
+	// An empty file (0 messages) is a pre-created placeholder, not a real
+	// session to resume.  Treating it as valid would make ctrl.Resume replace
+	// the executor's live session (with system prompt) with the empty one,
+	// causing the saved transcript to lack the agent identity contract.
+	if len(loaded.Snapshot()) == 0 {
+		return nil, path, true
+	}
 	return loaded, path, true
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -77,3 +77,13 @@ func (s *Session) HasContent() bool {
 	}
 	return false
 }
+
+// HasSystemMessage reports whether the session starts with a system message,
+// which carries the agent's stable identity and behavioural contract. Sessions
+// without one are not safe to persist: when reloaded the model has no identity
+// context and falls back to its training-data defaults.
+func (s *Session) HasSystemMessage() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.Messages) > 0 && s.Messages[0].Role == provider.RoleSystem
+}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -88,6 +88,55 @@ func TestHasContentWithTool(t *testing.T) {
 	}
 }
 
+// --- Session.HasSystemMessage ---
+
+func TestHasSystemMessageWithSystem(t *testing.T) {
+	s := NewSession("system prompt")
+	if !s.HasSystemMessage() {
+		t.Error("session with system message should report HasSystemMessage true")
+	}
+}
+
+func TestHasSystemMessageWithoutSystem(t *testing.T) {
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if s.HasSystemMessage() {
+		t.Error("session without system message should report HasSystemMessage false")
+	}
+}
+
+func TestHasSystemMessageAfterReplaceWithoutSystem(t *testing.T) {
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "kept"})
+	// Replace with messages that have no system message — simulates a
+	// compact/summarise path that failed to preserve the system prompt.
+	s.Replace([]provider.Message{
+		{Role: provider.RoleUser, Content: "replaced"},
+	})
+	if s.HasContent() {
+		// HasContent returns true because the user message exists.
+		if s.HasSystemMessage() {
+			t.Error("session replaced without system message should report HasSystemMessage false")
+		}
+	} else {
+		t.Error("session with user message should have content")
+	}
+}
+
+func TestHasSystemMessageCompactedKeepsSystem(t *testing.T) {
+	// This is the healthy path: compact preserves the system message at index 0.
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "answer"})
+	s.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "summary"},
+	})
+	if !s.HasSystemMessage() {
+		t.Error("compacted session should still have system message at index 0")
+	}
+}
+
 // --- Save / LoadSession round-trip ---
 
 func TestSaveLoadSessionRoundTrip(t *testing.T) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2222,6 +2222,18 @@ func (c *Controller) snapshot(markActivity bool) error {
 		// prompt) — staying quiet here is correct, not a data-loss path.
 		return nil
 	}
+	if !s.HasSystemMessage() {
+		// The session has user/assistant/tool messages but no leading system
+		// prompt.  Persisting it would create a session file that, when
+		// reloaded, has no agent-identity contract — the model falls back to
+		// its training-data defaults, giving wrong answers to identity
+		// queries ("who are you?").  Log the anomaly so the root cause
+		// (typically an empty sysPrompt reaching NewSession) can be
+		// diagnosed, then refuse to write a corrupted transcript.
+		slog.Warn("controller: refusing to snapshot session with content but no system message",
+			"label", c.Label(), "session_dir", c.SessionDir(), "message_count", len(s.Snapshot()))
+		return nil
+	}
 	if path == "" {
 		// There IS content but nowhere to write it: this silently dropped whole
 		// bot conversations (#4414). Surface it loudly instead of returning nil


### PR DESCRIPTION
## Summary
- absorb @drafish's #5538 empty-placeholder session guard so blank desktop session files cannot replace the boot-built system prompt
- refresh carried history with the newly built system prompt when desktop model, effort, or token mode changes
- refresh existing system messages when pinned/topic sessions are restored, while leaving legacy user-only transcripts visible as-is
- add regression coverage for global AGENTS.md surviving a desktop model switch

## Fixes
Fixes #5618
Refs #5538

## Co-created Contributions / 共创贡献
- Kept/adapted from #5538 by @drafish: empty placeholder sessions are treated as non-resumable, `HasSystemMessage()` guards prevent persisting content without the agent identity/system contract, and focused agent/control coverage is preserved.
- Added in this branch: shared desktop system-prompt refresh helpers plus model/effort/token-mode rebuild and pinned/topic restore integration.

## CLI Impact
- Normal CLI sessions are unchanged: CLI boot still creates sessions from the resolved system prompt, so the first message remains the system message.
- The shared `Controller.Snapshot()` guard also applies to CLI only for malformed resumed sessions that already contain user/assistant/tool messages without a leading system message; those transcripts are refused for persistence instead of being written back corrupted.
- Desktop-only prompt refresh helpers are not imported by CLI and do not change CLI per-turn prompts or provider prefix cache behavior.

## Cache Impact
- System prompt bytes can change at explicit desktop rebuild/resume boundaries only: model, effort, token mode, settings rebuild, or tab restore.
- No per-turn prompt mutation, tool schema/order, or provider request serialization changes.

## Verification
- `go test ./internal/agent/... ./internal/control/... -count=1`
- `go test ./internal/cli/... -count=1`
- `cd desktop && go test . -run 'Test(SetModelForTabRefreshesCarriedSystemPrompt|WithFreshSystemPrompt)' -count=1`
- `cd desktop && go test . -run 'Test(SetModelForTabRefreshesCarriedSystemPrompt|ResumeSessionForTabTargetsSpecifiedTab|ResumeSessionForTabDetachesRunningRuntimeForDifferentSessionPath|RebindTabToLoadedSessionReusesPreloadedTranscript|OpenGlobalTabResolvesTopicToLatestSessionRuntime|BuildTabControllerRestoresPinnedSessionBeforeTopicFallback|BuildTabControllerUsesPinnedSessionMetaWorkspace|OpenProjectTabResolvesProjectSessionFromLegacyDir)' -count=1`
- `cd desktop && go test . -count=1`
- `git diff --check origin/main-v2..HEAD`
