### PR TITLE
Improve composer responsive controls / 优化输入栏响应式控件

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -161,7 +161,7 @@ ok(
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
 ok(
-  /@container\s*\(max-width:\s*760px\)[\s\S]*?\.composer-meta--has-intent-chip\s+\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*1 1 160px[\s\S]*?\.composer-meta__control--effort\s*\{[\s\S]*?display\s*:\s*none[\s\S]*?\.composer-meta__control--more\s*\{[\s\S]*?display\s*:\s*inline-flex/.test(styles),
+  /@container\s*\(max-width:\s*760px\)[\s\S]*?\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*0 1 auto[\s\S]*?width\s*:\s*fit-content[\s\S]*?max-width\s*:\s*min\(240px,\s*42vw\)[\s\S]*?\.composer-meta--has-intent-chip\s+\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*0 1 auto[\s\S]*?width\s*:\s*fit-content[\s\S]*?max-width\s*:\s*min\(220px,\s*38vw\)[\s\S]*?\.composer-meta__control--effort\s*\{[\s\S]*?display\s*:\s*none[\s\S]*?\.composer-meta__control--more\s*\{[\s\S]*?display\s*:\s*inline-flex/.test(styles),
   "composer compact controls activate at the capped theme width",
 );
 eq(finalDeclaration(".md table", "overflow-x"), "auto", "markdown tables scroll horizontally");
@@ -177,6 +177,10 @@ ok(
 ok(
   /@media\s*\(max-width:\s*760px\)[\s\S]*?\.settings-modal\s*\{[\s\S]*?width\s*:\s*100vw[\s\S]*?height\s*:\s*100vh/.test(styles),
   "settings modal only becomes fullscreen at the narrow breakpoint",
+);
+ok(
+  /@media\s*\(max-width:\s*820px\)[\s\S]*?\.app\s+\.layout[\s\S]*?grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s*!important[\s\S]*?\.app\s+\.sidebar[\s\S]*?display\s*:\s*none\s*!important[\s\S]*?\.app\s+\.chat-pane[\s\S]*?grid-column\s*:\s*1\s*!important/.test(styles),
+  "narrow workbench layout hides side panels and keeps chat single-column",
 );
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowUp, Check, Eye, FileText, Folder, Gauge, List, MessageSquare, MoreHorizontal, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
+import { ArrowUp, Check, ChevronsUpDown, Eye, FileText, Folder, Gauge, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
@@ -1880,6 +1880,9 @@ export function Composer({
   };
   const effortLevels = asArray(effort?.levels);
   const currentEffort = effort?.current || "auto";
+  const compactEffortTitle = currentEffort === "auto"
+    ? t("status.effortAutoTitle", { def: effort?.default || "auto" })
+    : `${t("status.effortTitle")}: ${currentEffort}`;
   const hasEffort = Boolean(effort?.supported && effortLevels.length > 0);
   const chooseEffortLevel = (level: string) => {
     closeMoreMenu(() => {
@@ -2441,20 +2444,21 @@ export function Composer({
             )}
             {hasEffort && (
               <div className="composer-meta__control composer-meta__control--more">
-                <Tooltip label={t("composer.moreControls")} disabled={moreMenuOpen || moreMenuClosing}>
+                <Tooltip label={compactEffortTitle} disabled={moreMenuOpen || moreMenuClosing}>
                   <button
                     ref={moreMenuAnchorRef}
                     type="button"
-                    className={`composer-more-trigger${moreMenuOpen || moreMenuClosing ? " composer-more-trigger--open" : ""}`}
+                    className={`composer-more-trigger composer-more-trigger--effort${currentEffort !== "auto" ? " composer-more-trigger--explicit" : ""}${moreMenuOpen || moreMenuClosing ? " composer-more-trigger--open" : ""}`}
                     onClick={() => (moreMenuOpen || moreMenuClosing ? closeMoreMenu() : openMoreMenu())}
                     disabled={disabled || running}
                     aria-haspopup="menu"
                     aria-expanded={moreMenuOpen && !moreMenuClosing}
-                    aria-label={t("composer.moreControls")}
-                    title={moreMenuOpen || moreMenuClosing ? undefined : t("composer.moreControls")}
+                    aria-label={compactEffortTitle}
+                    title={moreMenuOpen || moreMenuClosing ? undefined : compactEffortTitle}
                   >
-                    <MoreHorizontal size={16} />
-                    <span>{t("topicBar.more")}</span>
+                    <Gauge size={14} />
+                    <span>{currentEffort}</span>
+                    <ChevronsUpDown size={11} />
                   </button>
                 </Tooltip>
               </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5545,12 +5545,14 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .composer-meta__control--model {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  width: fit-content;
   max-width: min(380px, 50vw);
 }
 
 .composer-meta--has-intent-chip .composer-meta__control--model {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  width: fit-content;
   max-width: min(320px, 50vw);
 }
 
@@ -5764,7 +5766,12 @@ body > .mermaid-diagram--fullscreen {
   transition: border-color 0.14s, background 0.14s, color 0.14s, transform 0.14s var(--ease-out);
 }
 
+.composer-meta__control--more .tooltip-trigger {
+  width: 100%;
+}
+
 .composer-more-trigger span {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5773,6 +5780,17 @@ body > .mermaid-diagram--fullscreen {
 
 .composer-more-trigger svg {
   flex: 0 0 auto;
+}
+
+.composer-more-trigger--effort {
+  gap: 5px;
+  padding-inline: 7px;
+}
+
+.composer-more-trigger--explicit {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface-2));
 }
 
 .composer-more-trigger:hover:not(:disabled),
@@ -5956,13 +5974,15 @@ body > .mermaid-diagram--fullscreen {
   }
 
   .composer-meta__control--model {
-    flex: 1 1 160px;
-    max-width: min(320px, 50vw);
+    flex: 0 1 auto;
+    width: fit-content;
+    max-width: min(240px, 42vw);
   }
 
   .composer-meta--has-intent-chip .composer-meta__control--model {
-    flex: 1 1 160px;
-    max-width: min(320px, 50vw);
+    flex: 0 1 auto;
+    width: fit-content;
+    max-width: min(220px, 38vw);
   }
 
   .composer-meta__control--approval {
@@ -5988,9 +6008,9 @@ body > .mermaid-diagram--fullscreen {
 
   .composer-meta__control--more {
     display: inline-flex;
-    flex: 0 0 78px;
-    width: 78px;
-    max-width: 78px;
+    flex: 0 0 86px;
+    width: 86px;
+    max-width: 86px;
   }
 }
 
@@ -6000,15 +6020,25 @@ body > .mermaid-diagram--fullscreen {
     padding-inline: 8px;
   }
 
+  .composer-meta .composer-meta__params {
+    gap: 4px;
+  }
+
+  .app--creation .composer-meta .composer-meta__params,
+  :root[data-theme-style] .app--creation .composer-meta .composer-meta__params {
+    gap: 4px;
+  }
+
   .composer-meta__control--model {
-    flex: 0 0 auto;
-    max-width: 50vw;
+    flex: 1 1 50px;
+    min-width: 42px;
+    max-width: none;
   }
 
   .composer-meta__control--approval {
-    flex-basis: 148px;
-    min-width: 144px;
-    max-width: 148px;
+    flex-basis: 92px;
+    min-width: 86px;
+    max-width: 92px;
   }
 
   .composer-meta__control--effort {
@@ -6026,6 +6056,10 @@ body > .mermaid-diagram--fullscreen {
   }
 
   .composer-more-trigger span {
+    display: none;
+  }
+
+  .composer-more-trigger--effort svg:last-child {
     display: none;
   }
 
@@ -24165,6 +24199,7 @@ body > .mermaid-diagram--fullscreen {
 .app--creation .composer-meta__control--model,
 :root[data-theme-style] .app--creation .composer-meta__control--model {
   flex: 0 1 auto;
+  width: fit-content;
   margin-left: auto;
   max-width: min(280px, 34vw);
 }
@@ -26166,4 +26201,38 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .project-tree__topic-shortcut {
   background: color-mix(in srgb, var(--fg) 8%, var(--sidebar-bg, var(--bg)));
   color: var(--fg-faint);
+}
+
+@media (max-width: 820px) {
+  .app .layout,
+  :root[data-theme-style] .app .layout {
+    --chrome-left-toggle-offset: var(--chrome-left-safe-offset);
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .app--darwin .layout,
+  :root[data-theme-style] .app--darwin .layout {
+    --chrome-left-toggle-offset: 94px;
+  }
+
+  .app .sidebar,
+  :root[data-theme-style] .app .sidebar,
+  .app .sidebar-resizer,
+  :root[data-theme-style] .app .sidebar-resizer,
+  .app .workspace-panel-resizer,
+  :root[data-theme-style] .app .workspace-panel-resizer,
+  .app .context-inspector,
+  :root[data-theme-style] .app .context-inspector,
+  .app .workbench-dock,
+  :root[data-theme-style] .app .workbench-dock {
+    display: none !important;
+  }
+
+  .app .chat-pane,
+  :root[data-theme-style] .app .chat-pane,
+  .app .topicbar,
+  :root[data-theme-style] .app .topicbar {
+    grid-column: 1 !important;
+    min-width: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- Replace the compact composer overflow trigger with a compact effort control that shows the current reasoning effort directly.
- Make the model switcher width content-adaptive with compact max-width caps so short names shrink and long names ellipsize.
- Hide side panels at narrow workbench widths so the chat pane remains single-column.

## Verification
- `CI=true pnpm exec tsc --noEmit`
- `CI=true pnpm check:css`
- `CI=true pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts`
- `CI=true pnpm exec tsx src/__tests__/workspace-layout.test.ts`
- Browser verification at 920px and 760px: no horizontal overflow and no console errors.