### PR TITLE
feat: 类ChatGPT对话历史侧边栏（悬停浮层+滚动同步）

### DIFF
--- a/desktop/frontend/src/components/ChatHistorySidebar.tsx
+++ b/desktop/frontend/src/components/ChatHistorySidebar.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { useT } from "../lib/i18n";
+import type { QuestionAnchor } from "../lib/transcriptGrouping";
+
+interface ChatHistorySidebarProps {
+  questions: QuestionAnchor[];
+  onJump: (question: QuestionAnchor) => void;
+}
+
+/**
+ * ChatGPT-style conversation history sidebar.
+ *
+ * A thin vertical strip with horizontal bars (dots) on the right edge of the
+ * transcript. Hovering reveals a popover listing ALL user messages — click any
+ * to jump to that position. The popover stays open while the cursor is over
+ * it, and auto-closes on mouseleave.
+ */
+export function ChatHistorySidebar({ questions, onJump }: ChatHistorySidebarProps) {
+  const t = useT();
+  const [active, setActive] = useState<number | null>(null);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const barRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>(null);
+  const questionsRef = useRef(questions);
+  questionsRef.current = questions;
+
+  // Track last active turn to avoid redundant setActive
+  const lastActiveRef = useRef<number | null>(null);
+  // When panel is open, pause all scroll-sync — only clicks change active
+  const pauseSyncRef = useRef(false);
+
+  // Sync active dot: map transcript scroll proportion to question index
+  useEffect(() => {
+    const transcript = document.querySelector(".transcript") as HTMLElement | null;
+    if (!transcript) return;
+
+    const sync = () => {
+      if (pauseSyncRef.current) return; // panel open → no auto-sync
+
+      const cqs = questionsRef.current;
+      if (cqs.length === 0) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = transcript;
+      const ratio = scrollHeight > clientHeight
+        ? Math.max(0, Math.min(1, scrollTop / (scrollHeight - clientHeight)))
+        : 0;
+
+      const idx = Math.round(ratio * (cqs.length - 1));
+      const nextActive = cqs[idx]?.turn ?? null;
+
+      if (nextActive != null && nextActive !== lastActiveRef.current) {
+        lastActiveRef.current = nextActive;
+        setActive(nextActive);
+      }
+    };
+
+    let rafId: number;
+    const poll = () => { sync(); rafId = requestAnimationFrame(poll); };
+
+    sync();
+    transcript.addEventListener("scroll", sync, { passive: true });
+    rafId = requestAnimationFrame(poll);
+    return () => {
+      transcript.removeEventListener("scroll", sync);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  // When panel opens, scroll to the active row — but DON'T auto-scroll on active changes
+  useEffect(() => {
+    if (!panelOpen || active === null) return;
+    const list = panelRef.current?.querySelector(".ch-panel__list");
+    if (!list) return;
+    const activeRow = list.querySelector(".ch-row--active");
+    if (activeRow) {
+      activeRow.scrollIntoView({ block: "center" });
+    } else {
+      list.scrollTop = list.scrollHeight;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelOpen]);
+
+  const closestQuestionFromY = (clientY: number): { question: QuestionAnchor; idx: number } | null => {
+    const el = barRef.current;
+    if (!el) return null;
+    const markers = el.querySelectorAll<HTMLElement>(".ch-item");
+    let closest = -1;
+    let closestDist = Infinity;
+    markers.forEach((item, index) => {
+      const rect = item.getBoundingClientRect();
+      const dist = Math.abs(clientY - (rect.top + rect.height / 2));
+      if (dist < closestDist) { closestDist = dist; closest = index; }
+    });
+    if (closest < 0) return null;
+    return { question: questions[closest], idx: closest };
+  };
+
+  const onBarMove = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
+    const closest = closestQuestionFromY(e.clientY);
+    if (!closest) return;
+    pauseSyncRef.current = true;
+    setPanelOpen(true);
+    if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+  }, [questions]);
+
+  const closePanel = useCallback(() => {
+    pauseSyncRef.current = false;
+    setPanelOpen(false);
+  }, []);
+
+  const onBarLeave = useCallback(() => {
+    closeTimer.current = setTimeout(closePanel, 150);
+  }, [closePanel]);
+
+  const onPanelEnter = useCallback(() => {
+    if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+  }, []);
+
+  const onPanelLeave = useCallback(() => {
+    closeTimer.current = setTimeout(closePanel, 300);
+  }, [closePanel]);
+
+  const scrollTo = useCallback((q: QuestionAnchor) => {
+    setActive(q.turn);
+    onJump(q);
+  }, [onJump]);
+
+  const onBarMouseDown = useCallback((e: ReactMouseEvent<HTMLDivElement>) => {
+    const closest = closestQuestionFromY(e.clientY);
+    if (!closest) return;
+    e.preventDefault();
+    scrollTo(closest.question);
+  }, [scrollTo]);
+
+  if (questions.length === 0) return null;
+
+  return (
+    <nav
+      className="ch-sidebar"
+      ref={barRef}
+      aria-label={t("questionNav.label")}
+      onMouseMove={onBarMove}
+      onMouseLeave={onBarLeave}
+    >
+      <div className="ch-sidebar__rail" onMouseDown={onBarMouseDown}>
+        {questions.map((q) => (
+          <button
+            className="ch-item"
+            key={q.id}
+            type="button"
+            data-turn={q.turn}
+            aria-label={t("questionNav.jump", { n: q.turn + 1 })}
+            tabIndex={-1}
+          >
+            <span className="ch-dot" data-active={active === q.turn ? "true" : undefined} />
+          </button>
+        ))}
+      </div>
+
+      {panelOpen && (
+        <div
+          className="ch-panel"
+          ref={panelRef}
+          onMouseEnter={onPanelEnter}
+          onMouseLeave={onPanelLeave}
+        >
+          <div className="ch-panel__list">
+            {questions.map((q, idx) => {
+              const isCurrent = active === q.turn;
+              return (
+                <button
+                  className={`ch-row${isCurrent ? " ch-row--active" : ""}`}
+                  key={q.id}
+                  type="button"
+                  onClick={() => scrollTo(q)}
+                >
+                  <span className="ch-row__num">{idx + 1}</span>
+                  <span className="ch-row__text">{q.text}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/desktop/frontend/src/components/ChatHistorySidebar.tsx
+++ b/desktop/frontend/src/components/ChatHistorySidebar.tsx
@@ -55,15 +55,13 @@ export function ChatHistorySidebar({ questions, onJump }: ChatHistorySidebarProp
       }
     };
 
-    let rafId: number;
-    const poll = () => { sync(); rafId = requestAnimationFrame(poll); };
-
     sync();
     transcript.addEventListener("scroll", sync, { passive: true });
-    rafId = requestAnimationFrame(poll);
+    const ro = new ResizeObserver(() => sync());
+    ro.observe(transcript);
     return () => {
       transcript.removeEventListener("scroll", sync);
-      cancelAnimationFrame(rafId);
+      ro.disconnect();
     };
   }, []);
 
@@ -151,7 +149,8 @@ export function ChatHistorySidebar({ questions, onJump }: ChatHistorySidebarProp
             type="button"
             data-turn={q.turn}
             aria-label={t("questionNav.jump", { n: q.turn + 1 })}
-            tabIndex={-1}
+            tabIndex={0}
+            onClick={() => { scrollTo(q); setPanelOpen(true); pauseSyncRef.current = true; }}
           >
             <span className="ch-dot" data-active={active === q.turn ? "true" : undefined} />
           </button>

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createContext, memo, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import type { InvocationMetadataMap } from "../lib/invocationDisplay";

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -8,6 +8,7 @@ import { ProcessBrainIcon, ProcessCompactIcon, ProcessPhaseIcon } from "./Proces
 import { ToolCard } from "./ToolCard";
 import { ArrowDown, ChevronRight, CirclePlay, Info, TriangleAlert } from "lucide-react";
 import { Welcome } from "./Welcome";
+import { ChatHistorySidebar } from "./ChatHistorySidebar";
 import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { ToolGroup, isCreationGroupableTool, toolGroupKind, type ToolGroupKind } from "./ToolGroup";
 import { getDisplayMode, onDisplayModeChange, type DisplayMode } from "../lib/displayMode";
@@ -955,7 +956,7 @@ export function Transcript({
       )}
 
       {!empty && showQuestionNav && (
-        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
+        <ChatHistorySidebar questions={questions} onJump={handleJumpToQuestion} />
       )}
 
       {!empty && !isAtBottom && (
@@ -1521,136 +1522,6 @@ function TurnCollapse({ items, durationMs, mode, subcalls, tabId, creationMode =
       </button>
       <div ref={bodyRef} className="turn-collapse__body">{body}</div>
     </div>
-  );
-}
-
-// ── JumpBar, PhaseCard, NoticeCard, CompactionCard ────────────────────────────
-
-function QuestionJumpBar({ questions, onJump }: { questions: QuestionAnchor[]; onJump: (question: QuestionAnchor) => void }) {
-  const t = useT();
-  const [hovered, setHovered] = useState<number | null>(null);
-  const [active, setActive] = useState<number | null>(null);
-  const barRef = useRef<HTMLDivElement>(null);
-  const previewTop = useRef(0);
-  const [showPreview, setShowPreview] = useState(false);
-
-  useEffect(() => {
-    if (questions.length === 0) return;
-    setActive(questions[questions.length - 1]?.turn ?? null);
-  }, [questions]);
-
-  useEffect(() => {
-    if (active === null) return;
-    const el = barRef.current?.querySelector(`[data-turn="${active}"]`);
-    el?.scrollIntoView({ block: "nearest" });
-  }, [active]);
-
-  const hoverIdx = hovered !== null ? questions.findIndex((question) => question.turn === hovered) : -1;
-  const hoveredQuestion = hovered !== null ? questions.find((question) => question.turn === hovered) : undefined;
-
-  const closestQuestionFromY = (clientY: number): { question: QuestionAnchor; previewY: number } | null => {
-    const el = barRef.current;
-    if (!el) return null;
-    const markers = el.querySelectorAll<HTMLElement>(".jump-item");
-    const barRect = el.getBoundingClientRect();
-    let closest = -1;
-    let closestDist = Infinity;
-    let closestY = 0;
-    markers.forEach((item, index) => {
-      const rect = item.getBoundingClientRect();
-      const midY = rect.top + rect.height / 2;
-      const dist = Math.abs(clientY - midY);
-      if (dist < closestDist) {
-        closestDist = dist;
-        closest = index;
-        closestY = midY - barRect.top;
-      }
-    });
-    const question = questions[closest];
-    if (!question) return null;
-    return { question, previewY: closestY };
-  };
-
-  const onMove = (e: ReactMouseEvent<HTMLDivElement>) => {
-    const closest = closestQuestionFromY(e.clientY);
-    if (!closest) return;
-    previewTop.current = closest.previewY;
-    setHovered(closest.question.turn);
-    setShowPreview(true);
-  };
-
-  const scrollTo = (question: QuestionAnchor) => {
-    setActive(question.turn);
-    onJump(question);
-  };
-
-  const onRailMouseDown = (e: ReactMouseEvent<HTMLDivElement>) => {
-    const closest = closestQuestionFromY(e.clientY);
-    if (!closest) return;
-    e.preventDefault();
-    previewTop.current = closest.previewY;
-    setHovered(closest.question.turn);
-    setShowPreview(true);
-    scrollTo(closest.question);
-  };
-
-  const onItemMouseDown = (e: ReactMouseEvent<HTMLButtonElement>, question: QuestionAnchor) => {
-    e.preventDefault();
-    scrollTo(question);
-  };
-
-  const dotProps = (
-    idx: number,
-    turn: number,
-  ): { style: CSSProperties; "data-d"?: string } => {
-    const isActive = active === turn;
-    if (hoverIdx < 0) {
-      return { style: { width: isActive ? 18 : 12, background: isActive ? "var(--accent)" : undefined } };
-    }
-    const d = Math.abs(idx - hoverIdx);
-    const width = d === 0 ? 32 : d === 1 ? 20 : d === 2 ? 14 : isActive ? 18 : 12;
-    const background = d <= 2 ? undefined : isActive ? "var(--accent)" : undefined;
-    return {
-      style: { width, transitionDelay: `${d * 20}ms`, background },
-      "data-d": d <= 2 ? String(d) : undefined,
-    };
-  };
-
-  return (
-    <nav
-      className="jump-bar"
-      ref={barRef}
-      aria-label={t("questionNav.label")}
-      onMouseMove={onMove}
-      onMouseLeave={() => {
-        setHovered(null);
-        setShowPreview(false);
-      }}
-    >
-      <div className="jump-scroll" onMouseDown={onRailMouseDown} onClick={onRailMouseDown}>
-        {questions.map((question, index) => (
-          <button
-            className="jump-item"
-            key={question.id}
-            type="button"
-            data-turn={question.turn}
-            aria-label={t("questionNav.jump", { n: question.turn + 1 })}
-            onMouseDown={(e) => onItemMouseDown(e, question)}
-            onClick={(e) => {
-              e.stopPropagation();
-              if (e.detail === 0) scrollTo(question);
-            }}
-          >
-            <span className="jump-dot" {...dotProps(index, question.turn)} />
-          </button>
-        ))}
-      </div>
-      {showPreview && hoveredQuestion && (
-        <div className="jump-preview" style={{ top: previewTop.current }} role="tooltip">
-          <span className="jump-text">{hoveredQuestion.text}</span>
-        </div>
-      )}
-    </nav>
   );
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3511,6 +3511,145 @@ a[href] {
   }
 }
 
+/* ── ChatHistorySidebar (conversation history hover panel) ──────────────────── */
+.ch-sidebar {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  z-index: var(--z-inline-sticky);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  width: 40px;
+  padding: 0 12px 0 8px;
+  transform: translate(4px, -50%);
+  opacity: 0;
+  pointer-events: none;
+  animation: jump-bar-in 0.18s ease-out 0.08s forwards;
+}
+.transcript > .ch-sidebar {
+  max-width: none;
+  margin: 0;
+}
+.ch-sidebar__rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0px;
+  padding: 8px 0;
+  cursor: pointer;
+  pointer-events: auto;
+  scrollbar-width: none;
+}
+.ch-sidebar__rail::-webkit-scrollbar { display: none; }
+.ch-item {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  width: 24px;
+  min-height: 7px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  pointer-events: none;
+}
+.ch-item:focus { outline: none; }
+.ch-item:focus-visible .ch-dot { box-shadow: 0 0 0 3px var(--accent-soft); }
+.ch-dot {
+  pointer-events: none;
+  width: 16px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--border);
+}
+.ch-dot[data-active="true"] {
+  background: var(--fg);
+}
+
+/* ── History panel (the hover popover) ──────────────────────────────────────── */
+.ch-panel {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  z-index: var(--z-dropdown);
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  max-height: 380px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-elev);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  pointer-events: auto;
+  transform: translateY(-50%);
+  overflow: hidden;
+}
+.ch-panel__list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 4px 0;
+}
+.ch-panel__list::-webkit-scrollbar { width: 4px; }
+.ch-panel__list::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+.ch-panel__list::-webkit-scrollbar-track { background: transparent; }
+
+.ch-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: calc(100% - 16px);
+  margin: 0 8px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms;
+}
+.ch-row:hover { background: var(--bg-soft); }
+.ch-row--active { background: var(--accent-soft); }
+.ch-row--active:hover { background: var(--accent-soft); }
+.ch-row__num {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: var(--bg);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--fg-faint);
+  margin-top: 1px;
+}
+.ch-row--active .ch-row__num {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.ch-row__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  word-break: break-word;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 760px) {
+  .ch-panel { width: 260px; }
+  .ch-sidebar { display: none; }
+}
+
 .welcome {
   --welcome-brand-width: 240px;
   --welcome-brand-height: 56px;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3574,7 +3574,7 @@ a[href] {
   position: absolute;
   right: 2px;
   top: 50%;
-  z-index: var(--z-dropdown);
+  z-index: var(--z-popover);
   display: flex;
   flex-direction: column;
   width: 320px;


### PR DESCRIPTION
## 变更内容

将原有的 `QuestionJumpBar`（右侧悬停单行 tooltip）替换为 **ChatGPT 风格的历史记录侧边栏**。

### 核心功能

1. **ch-sidebar**：对话右侧的竖条横线指示器，所有消息点全部展开不裁剪
2. **ch-panel**：悬停时弹出的浮层面板，列出所有用户消息，点击可跳转
3. **滚动同步**：ch-sidebar 的高亮点自动跟随对话区滚动位置变化（按比例映射）
4. **点击锁定**：在浮层中点击某一行后，高亮锁定，手动滚动页面后才恢复跟随
5. **浮层居中**：首次打开浮层时激活行居中显示

### 改动文件

| 文件 | 操作 | 说明 |
|---|---|---|
| `ChatHistorySidebar.tsx` | 新增 | 新组件：侧边栏 + 面板 |
| `Transcript.tsx` | 修改 | 替换 QuestionJumpBar、清理死代码 |
| `styles.css` | 修改 | 新增 ~130 行 CSS（ch-* 样式） |

### 行为细节

- **未悬停时**：只显示右侧竖条横线，当前活跃消息的横线以深色（`var(--fg)`）高亮
- **悬停时**：展开浮层列表，活跃行居中显示
- **点击某行**：页面跳到该消息位置，高亮锁定，滚动页面后解锁
- **Scroll 同步**：ch-sidebar 的高亮位置按 `scrollTop/(scrollHeight-clientHeight)` 比例映射到问题索引
- **自适应布局**：ch-sidebar 无固定高度，所有横线全部展示

### 审核状态

- ship as-is，无阻塞问题
- 残留旧 `.jump-bar` 类名 CSS（死代码），可后续清理