### PR TITLE
Default custom providers to OpenAI / 自定义供应商默认使用 OpenAI 协议

### DIFF
--- a/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
+++ b/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
@@ -4,7 +4,7 @@ import { JSDOM } from "jsdom";
 import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { SettingsPanel } from "../components/SettingsPanel";
+import { SettingsPanel, providerEditorEffectiveKind } from "../components/SettingsPanel";
 import { LocaleProvider } from "../lib/i18n";
 import type { AppBindings } from "../lib/bridge";
 import type { SettingsView } from "../lib/types";
@@ -90,6 +90,9 @@ function baseSettings(displayMode: "standard" | "compact" = "standard"): Setting
 }
 
 console.log("\nsettings refresh snapshot");
+
+eq(providerEditorEffectiveKind(true, "anthropic", ["anthropic", "openai"]), "openai", "new custom providers ignore sorted providerKinds and default to OpenAI");
+eq(providerEditorEffectiveKind(false, "anthropic", ["anthropic", "openai"]), "anthropic", "existing providers preserve their stored kind");
 
 const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
   pretendToBeVisual: true,

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -650,6 +650,10 @@ function normalizeReasoningProtocol(protocol: string | undefined): string {
   return REASONING_PROTOCOLS.includes(protocol ?? "") ? protocol ?? "" : "";
 }
 
+export function providerEditorEffectiveKind(isNewCustomProvider: boolean, kind: string, kinds: string[]): string {
+  return isNewCustomProvider ? "openai" : (kind.trim() || kinds[0] || "openai");
+}
+
 function normalizeReasoningLanguage(lang: string | undefined): string {
   const v = String(lang ?? "").trim().toLowerCase();
   return v === "zh" || v === "en" ? v : "auto";
@@ -4287,7 +4291,7 @@ function ProviderEditor({
 }) {
   const t = useT();
   const [name, setName] = useState(initial?.name ?? "");
-  const [kind, setKind] = useState(initial?.kind ?? kinds[0] ?? "openai");
+  const [kind, setKind] = useState(initial?.kind ?? "openai");
   const [baseUrl, setBaseUrl] = useState(initial?.baseUrl ?? "");
   const [models, setModels] = useState((initial?.models ?? []).join(", "));
   const [visionModels, setVisionModels] = useState((initial?.visionModels ?? []).join(", "));
@@ -4311,6 +4315,7 @@ function ProviderEditor({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const builtIn = initial?.builtIn ?? false;
   const isNewCustomProvider = !initial;
+  const effectiveKind = providerEditorEffectiveKind(isNewCustomProvider, kind, kinds);
 
   // Offer the kinds the kernel actually registered; if the stored kind is a
   // legacy/unknown one, keep it as an option so editing doesn't silently change it.
@@ -4357,7 +4362,7 @@ function ProviderEditor({
         name: name.trim() || t("settings.newProviderDraftName"),
         builtIn: initial?.builtIn ?? false,
         added: initial?.added ?? true,
-        kind: kind.trim() || kinds[0] || "openai",
+        kind: effectiveKind,
         baseUrl: baseUrl.trim(),
         modelsUrl,
         models: [],
@@ -4398,7 +4403,7 @@ function ProviderEditor({
       name: name.trim(),
       builtIn: initial?.builtIn ?? false,
       added: initial?.added ?? true,
-      kind: kind.trim() || kinds[0] || "openai",
+      kind: effectiveKind,
       baseUrl: baseUrl.trim(),
       models: ms,
       visionModels: vms,


### PR DESCRIPTION
## Summary
- Default new custom provider entries to the OpenAI-compatible kind instead of the first sorted registered provider kind.
- Reuse the resolved kind for model fetch and save payloads so the read-only OpenAI-compatible UI matches the saved config.
- Add regression coverage for the registered-kind order where `anthropic` sorts before `openai`, while preserving existing providers' stored kind.

Fixes #5013.
Partially addresses the custom-provider protocol consistency part of #3788.

## Repository contributors
- @xinyiming via #4963 independently identified the same custom-provider default-kind issue and proposed defaulting new custom providers to OpenAI. This PR carries that fix direction on the current `main-v2` base and adds regression coverage.

## Verification
- `pnpm --dir desktop/frontend exec tsx src/__tests__/settings-refresh-snapshot.test.tsx`
- `pnpm --dir desktop/frontend test:typecheck`
- `pnpm --dir desktop/frontend typecheck`
- `git diff --check`
