### PR TITLE
feat(desktop): add custom DPI zoom via WebView2 ZoomFactor

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3519,6 +3519,7 @@ export default function App() {
             initialTab={settingsTarget}
             initialFocus={settingsFocus ?? undefined}
             agentRunning={state.running}
+            desktopPlatform={desktopPlatform}
             onClose={() => {
               setSettingsFocus(null);
               setSettingsTarget(null);

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -58,6 +58,7 @@ import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "skills", "memory", "hooks", "shortcuts", "permissions", "sandbox", "network", "appearance", "updates"];
 export type SettingsInitialFocus = { target: "bot-allowlist"; connectionId?: string };
+type DesktopPlatform = "darwin" | "windows" | "linux";
 
 const MCPServersSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.MCPServersSettingsPage })));
 const SkillsSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.SkillsSettingsPage })));
@@ -73,12 +74,14 @@ export function SettingsPanel({
   initialTab,
   initialFocus,
   agentRunning = false,
+  desktopPlatform,
 }: {
   onClose: () => void;
   onChanged: (settings?: SettingsView | null) => void;
   initialTab?: SettingsTab;
   initialFocus?: SettingsInitialFocus;
   agentRunning?: boolean;
+  desktopPlatform: DesktopPlatform;
 }) {
   const t = useT();
   const [s, setS] = useState<SettingsView | null>(null);
@@ -222,6 +225,7 @@ export function SettingsPanel({
                       theme={theme}
                       themeStyle={themeStyle}
                       textSize={textSize}
+                      showDisplayZoom={desktopPlatform === "windows"}
                       zoomPct={zoomPct}
                       fontFamily={fontFamily}
                       monoFontFamily={monoFontFamily}
@@ -5205,6 +5209,7 @@ function AppearanceSection({
   theme,
   themeStyle,
   textSize,
+  showDisplayZoom,
   zoomPct,
   fontFamily,
   monoFontFamily,
@@ -5222,6 +5227,7 @@ function AppearanceSection({
   theme: Theme;
   themeStyle: ThemeStyle;
   textSize: TextSize;
+  showDisplayZoom: boolean;
   zoomPct: number;
   fontFamily: FontFamily;
   monoFontFamily: MonoFontFamily;
@@ -5302,35 +5308,37 @@ function AppearanceSection({
           ))}
         </div>
       </SettingsField>
-      <SettingsField label={t("settings.displayZoom")}>
-        <div className="zoom-slider-wrap">
-          <div className="zoom-slider__value">{zoomPct}%</div>
-          <div className="zoom-slider-row">
-            <span className="zoom-slider__label">50%</span>
-            <div className="slider-track">
-              <div className="slider-track__bg" />
-              <div
-                className="slider-track__fill"
-                style={{ width: `calc(${((zoomPct - 50) / 150) * 100}% + 15px)` }}
-              />
-              <div className="slider-thumb" style={{ left: `${((zoomPct - 50) / 150) * 100}%` }}>
-                <div className="slider-thumb__left" />
-                <div className="slider-thumb__mid" />
-                <div className="slider-thumb__right" />
+      {showDisplayZoom && (
+        <SettingsField label={t("settings.displayZoom")}>
+          <div className="zoom-slider-wrap">
+            <div className="zoom-slider__value">{zoomPct}%</div>
+            <div className="zoom-slider-row">
+              <span className="zoom-slider__label">50%</span>
+              <div className="slider-track">
+                <div className="slider-track__bg" />
+                <div
+                  className="slider-track__fill"
+                  style={{ width: `calc(${((zoomPct - 50) / 150) * 100}% + 15px)` }}
+                />
+                <div className="slider-thumb" style={{ left: `${((zoomPct - 50) / 150) * 100}%` }}>
+                  <div className="slider-thumb__left" />
+                  <div className="slider-thumb__mid" />
+                  <div className="slider-thumb__right" />
+                </div>
+                <input
+                  type="range"
+                  min={50}
+                  max={200}
+                  step={5}
+                  value={zoomPct}
+                  onChange={(e) => onRestartZoom(Number(e.target.value) / 100)}
+                />
               </div>
-              <input
-                type="range"
-                min={50}
-                max={200}
-                step={5}
-                value={zoomPct}
-                onChange={(e) => onRestartZoom(Number(e.target.value) / 100)}
-              />
+              <span className="zoom-slider__label">200%</span>
             </div>
-            <span className="zoom-slider__label">200%</span>
           </div>
-        </div>
-      </SettingsField>
+        </SettingsField>
+      )}
       <SettingsField label={t("settings.fontFamily")}>
         <div className="set-seg">
           {availableFontFamilies.map((font) => (

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -245,11 +245,17 @@ export function SettingsPanel({
                         applyTextSize(size);
                         setTextSizeState(size);
                       }}
-                      onRestartZoom={(zoom) => {
+                      onRestartZoom={async (zoom) => {
                         const snapped = snapZoom(zoom);
-                        saveRestartZoom(snapped);
-                        setZoomPct(zoomToPercent(snapped));
-                        void app.SetDesktopZoomFactor(snapped);
+                        setErr(null);
+                        setWarning(null);
+                        try {
+                          await app.SetDesktopZoomFactor(snapped);
+                          saveRestartZoom(snapped);
+                          setZoomPct(zoomToPercent(snapped));
+                        } catch (e) {
+                          setErr(String((e as Error)?.message ?? e));
+                        }
                       }}
                       onFontFamily={(font) => {
                         applyFontFamily(font);
@@ -5236,7 +5242,7 @@ function AppearanceSection({
   onTheme: (t: Theme) => void;
   onThemeStyle: (style: ThemeStyle) => void;
   onTextSize: (size: TextSize) => void;
-  onRestartZoom: (zoom: ZoomLevel) => void;
+  onRestartZoom: (zoom: ZoomLevel) => Promise<void>;
   onFontFamily: (font: FontFamily) => void;
   onMonoFontFamily: (font: MonoFontFamily) => void;
   onCustomFontNameChange: (name: string) => void;
@@ -5331,7 +5337,7 @@ function AppearanceSection({
                   max={200}
                   step={5}
                   value={zoomPct}
-                  onChange={(e) => onRestartZoom(Number(e.target.value) / 100)}
+                  onChange={(e) => { void onRestartZoom(Number(e.target.value) / 100); }}
                 />
               </div>
               <span className="zoom-slider__label">200%</span>

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import {
   type ThemeStyle,
 } from "../lib/theme";
 import { TEXT_SIZES, applyTextSize, getTextSize, type TextSize } from "../lib/textSize";
+import { snapZoom, zoomToPercent, saveRestartZoom, getRestartZoom, type ZoomLevel } from "../lib/dpiScale";
 import {
   applyFontFamily,
   applyMonoFontFamily,
@@ -89,6 +90,7 @@ export function SettingsPanel({
   const [theme, setThemeState] = useState<Theme>(getTheme());
   const [themeStyle, setThemeStyleState] = useState<ThemeStyle>(() => getThemeStyle(getTheme()));
   const [textSize, setTextSizeState] = useState<TextSize>(getTextSize());
+  const [zoomPct, setZoomPct] = useState<number>(zoomToPercent(getRestartZoom()));
   const [fontFamily, setFontFamilyState] = useState<FontFamily>(getFontFamily());
   const [monoFontFamily, setMonoFontFamilyState] = useState<MonoFontFamily>(getMonoFontFamily());
   const [customFontName, setCustomFontNameState] = useState<string>(getCustomFontName());
@@ -220,6 +222,7 @@ export function SettingsPanel({
                       theme={theme}
                       themeStyle={themeStyle}
                       textSize={textSize}
+                      zoomPct={zoomPct}
                       fontFamily={fontFamily}
                       monoFontFamily={monoFontFamily}
                       customFontName={customFontName}
@@ -237,6 +240,12 @@ export function SettingsPanel({
                       onTextSize={(size) => {
                         applyTextSize(size);
                         setTextSizeState(size);
+                      }}
+                      onRestartZoom={(zoom) => {
+                        const snapped = snapZoom(zoom);
+                        saveRestartZoom(snapped);
+                        setZoomPct(zoomToPercent(snapped));
+                        void app.SetDesktopZoomFactor(snapped);
                       }}
                       onFontFamily={(font) => {
                         applyFontFamily(font);
@@ -5196,6 +5205,7 @@ function AppearanceSection({
   theme,
   themeStyle,
   textSize,
+  zoomPct,
   fontFamily,
   monoFontFamily,
   customFontName,
@@ -5203,6 +5213,7 @@ function AppearanceSection({
   onTheme,
   onThemeStyle,
   onTextSize,
+  onRestartZoom,
   onFontFamily,
   onMonoFontFamily,
   onCustomFontNameChange,
@@ -5211,6 +5222,7 @@ function AppearanceSection({
   theme: Theme;
   themeStyle: ThemeStyle;
   textSize: TextSize;
+  zoomPct: number;
   fontFamily: FontFamily;
   monoFontFamily: MonoFontFamily;
   customFontName: string;
@@ -5218,6 +5230,7 @@ function AppearanceSection({
   onTheme: (t: Theme) => void;
   onThemeStyle: (style: ThemeStyle) => void;
   onTextSize: (size: TextSize) => void;
+  onRestartZoom: (zoom: ZoomLevel) => void;
   onFontFamily: (font: FontFamily) => void;
   onMonoFontFamily: (font: MonoFontFamily) => void;
   onCustomFontNameChange: (name: string) => void;
@@ -5287,6 +5300,35 @@ function AppearanceSection({
               {textSizeName(size, t)}
             </button>
           ))}
+        </div>
+      </SettingsField>
+      <SettingsField label={t("settings.displayZoom")}>
+        <div className="zoom-slider-wrap">
+          <div className="zoom-slider__value">{zoomPct}%</div>
+          <div className="zoom-slider-row">
+            <span className="zoom-slider__label">50%</span>
+            <div className="slider-track">
+              <div className="slider-track__bg" />
+              <div
+                className="slider-track__fill"
+                style={{ width: `calc(${((zoomPct - 50) / 150) * 100}% + 15px)` }}
+              />
+              <div className="slider-thumb" style={{ left: `${((zoomPct - 50) / 150) * 100}%` }}>
+                <div className="slider-thumb__left" />
+                <div className="slider-thumb__mid" />
+                <div className="slider-thumb__right" />
+              </div>
+              <input
+                type="range"
+                min={50}
+                max={200}
+                step={5}
+                value={zoomPct}
+                onChange={(e) => onRestartZoom(Number(e.target.value) / 100)}
+              />
+            </div>
+            <span className="zoom-slider__label">200%</span>
+          </div>
         </div>
       </SettingsField>
       <SettingsField label={t("settings.fontFamily")}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -294,6 +294,9 @@ export interface AppBindings {
   SetDesktopLanguage(lang: string): Promise<void>;
   SetDesktopAppearance(theme: string, style: string): Promise<void>;
   SetDesktopLayoutStyle(style: string): Promise<void>;
+  SetDesktopZoomFactor(factor: number): Promise<void>;
+  GetDesktopZoomFactor(): Promise<number>;
+  RestartApplication(): Promise<void>;
   SetDesktopCheckUpdates(enabled: boolean): Promise<void>;
   SetDesktopTelemetry(enabled: boolean): Promise<void>;
   SetDesktopMetrics(enabled: boolean): Promise<void>;
@@ -2763,6 +2766,15 @@ function makeMockApp(): AppBindings {
         },
         async SetDesktopLayoutStyle(style: string) {
           settings.desktopLayoutStyle = style === "workbench" || style === "creation" ? style : "classic";
+        },
+        async SetDesktopZoomFactor(_factor: number) {
+          // no-op in mock; in production this writes desktop-zoom.json via Go
+        },
+        async GetDesktopZoomFactor() {
+          return 1.0; // default in mock
+        },
+        async RestartApplication() {
+          // no-op in mock
         },
         async SetDesktopCheckUpdates(enabled: boolean) {
           settings.checkUpdates = enabled;

--- a/desktop/frontend/src/lib/dpiScale.ts
+++ b/desktop/frontend/src/lib/dpiScale.ts
@@ -1,0 +1,79 @@
+/**
+ * DPI zoom scale service.
+ *
+ * Uses the WebView2 ZoomFactor (Go side) for reliable, layout-safe zooming.
+ * The frontend only saves the user's preference and lets the Go binding persist
+ * it to desktop-zoom.json; on next startup main.go reads the file and applies
+ * ZoomFactor to the WebView2 window options.
+ *
+ * Range: 0.50 – 2.00 (50% – 200%), step 0.05.
+ */
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 2.0;
+export const ZOOM_STEP = 0.05;
+
+export type ZoomLevel = number; // 0.5 – 2.0
+
+export const DEFAULT_ZOOM: ZoomLevel = 1.0;
+
+const ZOOM_KEY = "reasonix-zoom-restart";
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+/** Snap a number to the nearest valid step within [MIN, MAX]. */
+export function snapZoom(value: number): ZoomLevel {
+  const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+  const steps = Math.round((clamped - MIN_ZOOM) / ZOOM_STEP);
+  return parseFloat((MIN_ZOOM + steps * ZOOM_STEP).toFixed(2));
+}
+
+/** Convert a zoom value (0.5-2.0) to a percentage integer (50-200). */
+export function zoomToPercent(zoom: ZoomLevel): number {
+  return Math.round(zoom * 100);
+}
+
+/** Convert a percentage integer (50-200) back to a zoom value (0.5-2.0). */
+export function percentToZoom(pct: number): ZoomLevel {
+  return snapZoom(pct / 100);
+}
+
+function readZoom(fallback: ZoomLevel): ZoomLevel {
+  const stored = typeof localStorage !== "undefined" ? localStorage.getItem(ZOOM_KEY) : null;
+  if (stored === null) return fallback;
+  const parsed = parseFloat(stored);
+  if (isNaN(parsed)) return fallback;
+  return snapZoom(parsed);
+}
+
+function writeZoom(value: ZoomLevel): void {
+  try {
+    localStorage.setItem(ZOOM_KEY, String(value));
+  } catch {
+    /* private mode / no storage */
+  }
+}
+
+// ─── public API ─────────────────────────────────────────────────────
+
+/** Read the saved zoom level that will be applied on next restart. */
+export function getRestartZoom(): ZoomLevel {
+  return readZoom(DEFAULT_ZOOM);
+}
+
+/**
+ * Save a zoom factor that will be picked up by Go on next startup and
+ * applied as the WebView2 `ZoomFactor`. Takes effect after the app is
+ * restarted (no layout issues — ZoomFactor is engine-level).
+ */
+export function saveRestartZoom(userZoom: ZoomLevel): void {
+  writeZoom(snapZoom(userZoom));
+}
+
+/**
+ * Init: no-op for zoom (the Go-side ZoomFactor is applied at WebView2
+ * creation time).
+ */
+export function initDpiScale(): void {
+  /* zoom is handled entirely by the Go side (ZoomFactor) */
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1288,6 +1288,7 @@ export const en = {
   "settings.textSizeLarge": "Large",
   "settings.textSizeXLarge": "Extra large",
   "settings.textSizeXXLarge": "Huge",
+  "settings.displayZoom": "Display zoom (restart required)",
   "settings.fontFamily": "Interface font",
   "settings.fontFamilySystem": "System",
   "settings.fontFamilyYaHei": "YaHei",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -799,6 +799,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.textSizeLarge": "大",
   "settings.textSizeXLarge": "特大",
   "settings.textSizeXXLarge": "超大",
+  "settings.displayZoom": "顯示縮放（需重啟生效）",
   "settings.fontFamily": "介面字型",
   "settings.fontFamilySystem": "系統預設",
   "settings.fontFamilyYaHei": "微軟正黑體",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1290,6 +1290,7 @@ export const zh: Record<DictKey, string> = {
   "settings.textSizeLarge": "大",
   "settings.textSizeXLarge": "特大",
   "settings.textSizeXXLarge": "超大",
+  "settings.displayZoom": "显示缩放（需重启生效）",
   "settings.fontFamily": "界面字体",
   "settings.fontFamilySystem": "系统默认",
   "settings.fontFamilyYaHei": "微软雅黑",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -13513,6 +13513,130 @@ body > .mermaid-diagram--fullscreen {
   color: var(--accent);
   font-weight: 650;
 }
+
+/* ─── Zoom slider ──────────────────────────────────── */
+.zoom-slider-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.zoom-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+}
+
+.zoom-slider__label {
+  font-size: var(--font-control-small);
+  color: var(--fg-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* 百分比值 — 居中在轨道上方 */
+.zoom-slider__value {
+  font-size: var(--font-control-small);
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1;
+  text-align: center;
+  width: 100%;
+}
+
+/* 让 label 在 settings-field 网格中靠下对齐 */
+.settings-field:has(.zoom-slider-wrap) {
+  align-items: end;
+}
+
+/* 轨道容器 */
+.slider-track {
+  position: relative;
+  flex: 1;
+  width: 100%;
+  height: 20px;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;
+}
+
+/* 轨道背景 */
+.slider-track__bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 10px;
+  background: var(--bg-elev-2);
+  overflow: hidden;
+}
+
+/* 填充 — 两端圆角，右侧半圆收口 */
+.slider-track__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  border-radius: 10px;
+  background: var(--accent);
+  max-width: 100%;  /* 防止超出轨道 */
+}
+
+/* 胶囊滑块 — 外包 1px 主题色边框 */
+.slider-thumb {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 28px;
+  height: 18px;
+  pointer-events: none;
+  z-index: var(--z-local-raised);
+  box-shadow: 0 0 0 1px var(--accent);
+  border-radius: 10px;
+}
+
+.slider-thumb__left {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 9px;
+  height: 18px;
+  background: #fff;
+  border-radius: 9px 0 0 9px;
+}
+.slider-thumb__mid {
+  position: absolute;
+  left: 9px;
+  top: 0;
+  width: 10px;
+  height: 18px;
+  background: #fff;
+}
+.slider-thumb__right {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 9px;
+  height: 18px;
+  background: #fff;
+  border-radius: 0 9px 9px 0;
+}
+
+/* 透明 input range — 事件捕获 */
+.slider-track input[type="range"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  z-index: var(--z-local-handle);
+  margin: 0;
+}
 .bot-channel-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -150,7 +150,6 @@ func main() {
 			// Follow the OS theme so the title bar matches light/dark system
 			// preference instead of being locked to dark.
 			Theme:                windows.SystemDefault,
-			IsZoomControlEnabled: true,
 			ZoomFactor:           zoomFactor,
 			WebviewGpuIsDisabled: windowsWebview2GPUDisabled(),
 		},

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -102,6 +102,12 @@ func main() {
 		}
 	}
 
+	// Restore saved desktop zoom factor (WebView2 ZoomFactor), or default to 1.0.
+	zoomFactor := 1.0
+	if zf, ok := loadZoomFactor(); ok && zf > 0 {
+		zoomFactor = zf
+	}
+
 	err := wails.Run(&options.App{
 		Title:     "Reasonix",
 		Width:     width,
@@ -144,6 +150,8 @@ func main() {
 			// Follow the OS theme so the title bar matches light/dark system
 			// preference instead of being locked to dark.
 			Theme:                windows.SystemDefault,
+			IsZoomControlEnabled: true,
+			ZoomFactor:           zoomFactor,
 			WebviewGpuIsDisabled: windowsWebview2GPUDisabled(),
 		},
 		Linux: &linux.Options{

--- a/desktop/zoom_factor.go
+++ b/desktop/zoom_factor.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"reasonix/internal/config"
+)
+
+// DesktopZoomFactor persists the user's WebView2 zoom factor preference across
+// restarts. The frontend writes it; main.go reads it before wails.Run() to set
+// the Windows ZoomFactor option.
+type DesktopZoomFactor struct {
+	ZoomFactor float64 `json:"zoomFactor"`
+}
+
+func zoomFactorPath() string {
+	return filepath.Join(config.MemoryUserDir(), "desktop-zoom.json")
+}
+
+// loadZoomFactor reads the saved zoom factor. The bool is false when no saved
+// value exists (first launch, missing file, corrupt JSON). Callers should fall
+// back to 1.0 (no zoom) in that case.
+func loadZoomFactor() (float64, bool) {
+	path := zoomFactorPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	var zf DesktopZoomFactor
+	if err := json.Unmarshal(data, &zf); err != nil {
+		return 0, false
+	}
+	if zf.ZoomFactor < 0.5 || zf.ZoomFactor > 2.0 {
+		return 0, false
+	}
+	return zf.ZoomFactor, true
+}
+
+// GetDesktopZoomFactor returns the currently persisted restart zoom factor,
+// or 1.0 if none is saved.
+func (a *App) GetDesktopZoomFactor() float64 {
+	zf, ok := loadZoomFactor()
+	if !ok {
+		return 1.0
+	}
+	return zf
+}
+
+// SetDesktopZoomFactor persists a zoom factor for the next launch. The value
+// is clamped to [0.5, 2.0] (50% – 200%) for safety.
+func (a *App) SetDesktopZoomFactor(factor float64) error {
+	if factor < 0.5 {
+		factor = 0.5
+	}
+	if factor > 2.0 {
+		factor = 2.0
+	}
+	path := zoomFactorPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(DesktopZoomFactor{ZoomFactor: factor})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// RestartApplication saves the zoom and restarts the whole process so the new
+// ZoomFactor takes effect in the WebView2 window options.
+func (a *App) RestartApplication() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, os.Args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}


### PR DESCRIPTION
# Reasonix Desktop — Custom DPI Zoom Slider

> **分支:** `dpi-zoom-restart`
> **基于:** `main-v2` (上游主干)
> **PR 目标:** 增加用户自定义 DPI 缩放功能，通过 WebView2 ZoomFactor 实现引擎级缩放

---

## 概述

为 Reasonix Desktop 添加一个**用户自定义 DPI 缩放倍率**功能，让 UI 缩放不再完全跟随 Windows 系统全局 DPI，而是允许用户在 50%~200% 范围内以 5% 步进自定义缩放值。

缩放通过 **WebView2 `ZoomFactor`** 引擎级实现，与 CSS 无关，不会破坏 `100vh` 布局，系统 DPI 变化时也能正确跟随。

---

## 变更清单

### 新建文件

| 文件 | 说明 |
|---|---|
| `desktop/zoom_factor.go` (87行) | ZoomFactor 持久化：`loadZoomFactor()`、`SetDesktopZoomFactor()`、`GetDesktopZoomFactor()`、`RestartApplication()` |
| `desktop/frontend/src/lib/dpiScale.ts` (79行) | 前端缩放服务：`snapZoom()`、`zoomToPercent()`、`saveRestartZoom()`、`getRestartZoom()` |

### 修改文件

| 文件 | 变更 |
|---|---|
| `desktop/main.go` | 启动时读取 `desktop-zoom.json`，设置 `ZoomFactor`（保持 WebView2 原生快捷缩放关闭） |
| `desktop/frontend/src/components/SettingsPanel.tsx` | Appearance 区域新增缩放滑块 UI（导入 dpiScale、zoomPct 状态、onRestartZoom 处理器） |
| `desktop/frontend/src/lib/bridge.ts` | 添加 `SetDesktopZoomFactor` / `GetDesktopZoomFactor` / `RestartApplication` 接口声明 + mock |
| `desktop/frontend/src/styles.css` | 完整滑块组件样式（轨道、填充条、胶囊 thumb、z-index 变量） |
| `desktop/frontend/src/locales/en.ts` | 添加 `settings.displayZoom` 键 |
| `desktop/frontend/src/locales/zh.ts` | 添加 `"显示缩放（需重启生效）"` |
| `desktop/frontend/src/locales/zh-TW.ts` | 添加 `"顯示縮放（需重啟生效）"` |

---

## 实现架构

```
                    ┌──────────────────────────────────────┐
                    │  SettingsPanel (Appearance 分页)     │
                    │  滑块 UI ←→ zoomPct 状态              │
                    └──────────────────┬───────────────────┘
                                       │ onRestartZoom(zoom)
                                       ▼
                    ┌──────────────────────────────────────┐
                    │  dpiScale.ts                         │
                    │  saveRestartZoom() → localStorage    │
                    │  + app.SetDesktopZoomFactor()        │
                    └──────────────────┬───────────────────┘
                                       ▼
                    ┌──────────────────────────────────────┐
                    │  zoom_factor.go (Go binding)         │
                    │  SetDesktopZoomFactor()              │
                    │  → 写入 desktop-zoom.json            │
                    └──────────────────┬───────────────────┘
                                       │ 下次启动
                                       ▼
                    ┌──────────────────────────────────────┐
                    │  main.go                             │
                    │  loadZoomFactor() → ZoomFactor       │
                    │  → WebView2 引擎级缩放，无布局问题     │
                    └──────────────────────────────────────┘
```

---

## 用户界面

<img width="2560" height="1504" alt="PixPin_2026-06-30_17-28-56" src="https://github.com/user-attachments/assets/91cf69fd-fe9b-44ed-9eb6-445d769108f5" />



- **轨道条**: 20px 高，10px 圆角，`var(--bg-elev-2)` 背景
- **填充条**: 从左侧到「胶囊中心+16px」，右侧半圆收口（r=10），`var(--accent)` 色
- **胶囊滑块**: 白色，左半圆9px + 矩形10px + 右半圆9px，外带 1px `var(--accent)` 边框
- **百分比值**: 轨道上方居中显示
- **范围**: 50%~200%，5% 步进

---

## 使用方式

1. 打开 设置 → 外观
2. 拖动「显示缩放（需重启生效）」滑块
3. 关闭客户端，重新打开
4. WebView2 ZoomFactor 生效，整个 UI 等比缩放

---

## 测试验证

- [x] 设置缩放值后关闭重开，UI 按指定倍率缩放
- [x] 系统 DPI 变化时，缩放跟随正确（无布局错乱）
- [x] 未设置时默认为 100%，行为与原版一致
- [x] 滑块上下限 50%~200%，步进 5%
- [x] 多显示器拖拽（正常缩放）


<img width="1200" height="2608" alt="PixPin_2026-06-30_17-26-54" src="https://github.com/user-attachments/assets/35b2091b-f22a-4369-b4ee-0c5feeae2760" />
<img width="2560" height="1600" alt="PixPin_2026-06-30_17-27-27" src="https://github.com/user-attachments/assets/3fce9a15-f98c-4d19-a65b-7bb53bc9de17" />

