### PR TITLE
Fix desktop session workspace binding / 修复桌面会话工作区绑定

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -730,6 +730,13 @@ func (a *App) SubmitToTab(tabID, input string) error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	ctrl.SubmitDisplay(input, input)
 	return nil
 }
@@ -738,7 +745,11 @@ func (a *App) submitUserTurnToTab(tabID, input string) bool {
 	if a.tabReadOnly(tabID) {
 		return false
 	}
-	ctrl := a.ctrlByTabID(tabID)
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if ctrl == nil || a.ensureTabControllerWorkspace(tab) != nil {
+		return false
+	}
+	ctrl = tab.Ctrl
 	if ctrl == nil {
 		return false
 	}
@@ -760,6 +771,13 @@ func (a *App) RunShellForTab(tabID, command string) error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	ctrl.RunShell(command)
 	return nil
 }
@@ -778,6 +796,13 @@ func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	ctrl.SubmitDisplay(display, input)
 	return nil
 }
@@ -787,6 +812,13 @@ func (a *App) SubmitEditedDisplayToTab(tabID, display, input, original string) e
 	if tab != nil && tab.ReadOnly {
 		return readOnlyChannelErr()
 	}
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
@@ -867,6 +899,115 @@ func (a *App) snapshotTab(tab *WorkspaceTab) error {
 		return nil
 	}
 	return ctrl.Snapshot()
+}
+
+func (a *App) reconciledSessionPathForTab(tab *WorkspaceTab) string {
+	if tab == nil {
+		return ""
+	}
+	path, _ := a.reconcileTabWithPinnedSessionMeta(tab)
+	if path == "" && tab.Ctrl != nil {
+		path = tab.Ctrl.SessionPath()
+	}
+	return path
+}
+
+func (a *App) ensureTabControllerWorkspace(tab *WorkspaceTab) error {
+	if tab == nil || tab.Ctrl == nil || tab.ReadOnly {
+		return nil
+	}
+	if tab.hasActiveRuntimeWork() {
+		return nil
+	}
+	ctrl := tab.Ctrl
+	path, hasBinding := a.reconcileTabWithPinnedSessionMeta(tab)
+	desiredRoot := strings.TrimSpace(tab.WorkspaceRoot)
+	ctrlRoot, rootOK := safeControllerWorkspaceRoot(ctrl)
+	ctrlDir, dirOK := safeControllerSessionDir(ctrl)
+	if !rootOK || !dirOK {
+		return nil
+	}
+	if !hasBinding {
+		if desiredRoot == "" || strings.TrimSpace(ctrlRoot) == "" || sameDesktopPath(ctrlRoot, desiredRoot) {
+			return nil
+		}
+	}
+	desiredDir := tabSessionDir(tab)
+	rootMatches := desiredRoot == "" || sameDesktopPath(ctrlRoot, desiredRoot)
+	dirMatches := desiredDir == "" || sameDesktopPath(ctrlDir, desiredDir)
+	if !dirMatches && path != "" {
+		if validPath, _, err := validateSessionPath(ctrlDir, path); err == nil && sessionRuntimeKey(validPath) == sessionRuntimeKey(path) {
+			dirMatches = true
+		}
+	}
+	if strings.TrimSpace(ctrlRoot) == "" && dirMatches {
+		rootMatches = true
+	}
+	if tab.Scope == "global" {
+		if strings.TrimSpace(ctrlRoot) == "" {
+			rootMatches = true
+		}
+		if sameDesktopPath(ctrlDir, config.SessionDir()) || sameDesktopPath(ctrlDir, desktopSessionDir(globalWorkspaceRoot())) {
+			dirMatches = true
+		}
+	}
+	sessionMatches := path == "" || sessionRuntimeKey(ctrl.SessionPath()) == sessionRuntimeKey(path)
+	if rootMatches && dirMatches && sessionMatches {
+		return nil
+	}
+	if err := ctrl.Snapshot(); err != nil {
+		return err
+	}
+	ctrl.Close()
+
+	a.mu.Lock()
+	if current := a.tabs[tab.ID]; current == tab {
+		tab.Ctrl = nil
+		tab.Ready = false
+		tab.StartupErr = ""
+		tab.ActivityStatus = ""
+		if tab.sink == nil {
+			tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
+		}
+		a.releaseTabSharedHost(tab)
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
+
+	a.buildTabController(tab)
+	if tab.Ctrl == nil {
+		if tab.StartupErr != "" {
+			return fmt.Errorf("workspace failed to restart with corrected root: %s", tab.StartupErr)
+		}
+		return fmt.Errorf("workspace failed to restart with corrected root")
+	}
+	return nil
+}
+
+func safeControllerWorkspaceRoot(ctrl control.SessionAPI) (root string, ok bool) {
+	if ctrl == nil {
+		return "", false
+	}
+	defer func() {
+		if recover() != nil {
+			root = ""
+			ok = false
+		}
+	}()
+	return ctrl.WorkspaceRoot(), true
+}
+
+func safeControllerSessionDir(ctrl control.SessionAPI) (dir string, ok bool) {
+	if ctrl == nil {
+		return "", false
+	}
+	defer func() {
+		if recover() != nil {
+			dir = ""
+			ok = false
+		}
+	}()
+	return ctrl.SessionDir(), true
 }
 
 // Approve answers a pending approval_request by ID: allow runs the call, session
@@ -1096,6 +1237,13 @@ func (a *App) NewSession() error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	// Tab is already blank — just persist and skip the new-session dance.
 	if !controllerHasActiveRuntimeWork(ctrl) && !messagesHaveConversationContent(ctrl.History()) {
 		a.persistTabSessionPath(tab, ctrl.SessionPath())
@@ -1163,6 +1311,13 @@ func (a *App) ClearSession() error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return a.clearActiveSessionRuntime(tab, ctrl)
 	}
@@ -1179,6 +1334,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	if tab == nil || oldCtrl == nil {
 		return fmt.Errorf("workspace is still starting")
 	}
+	a.reconciledSessionPathForTab(tab)
 	oldPath := oldCtrl.SessionPath()
 	oldSink := tab.sink
 	if oldSink != nil {
@@ -1398,6 +1554,17 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 		a.mu.RUnlock()
 		return TabMeta{}, readOnlyChannelErr()
 	}
+	a.mu.RUnlock()
+
+	if err := a.ensureTabControllerWorkspace(sourceTab); err != nil {
+		return TabMeta{}, err
+	}
+	a.mu.RLock()
+	if a.tabs[sourceTab.ID] != sourceTab || sourceTab.Ctrl == nil {
+		a.mu.RUnlock()
+		return TabMeta{}, nil
+	}
+	ctrl = sourceTab.Ctrl
 	scope := sourceTab.Scope
 	workspaceRoot := sourceTab.WorkspaceRoot
 	sourceTitle := sourceTab.TopicTitle
@@ -1545,24 +1712,42 @@ func controllerSessionDir(ctrl control.SessionAPI) string {
 
 func tabSessionDir(tab *WorkspaceTab) string {
 	if tab != nil {
+		if tab.WorkspaceRoot != "" {
+			return desktopSessionDir(tab.WorkspaceRoot)
+		}
 		if tab.Ctrl != nil {
 			if dir := tab.Ctrl.SessionDir(); dir != "" {
 				return dir
 			}
 		}
-		if tab.WorkspaceRoot != "" {
-			return desktopSessionDir(tab.WorkspaceRoot)
-		}
 	}
 	return desktopSessionDir("")
 }
 
+func tabRuntimeSessionDir(tab *WorkspaceTab) string {
+	if tab != nil && tab.Ctrl != nil {
+		if dir, ok := safeControllerSessionDir(tab.Ctrl); ok && strings.TrimSpace(dir) != "" {
+			if path := strings.TrimSpace(tab.currentSessionPath()); path != "" {
+				if _, _, err := validateSessionPath(dir, path); err == nil {
+					return dir
+				}
+			} else {
+				return dir
+			}
+		}
+	}
+	return tabSessionDir(tab)
+}
+
 func (a *App) activeSessionDir() string {
-	a.mu.RLock()
-	tab := a.activeTabLocked()
-	dir := tabSessionDir(tab)
-	a.mu.RUnlock()
-	return dir
+	tab := a.activeTab()
+	if path, ok := a.reconcileTabWithPinnedSessionMeta(tab); ok && strings.TrimSpace(path) != "" {
+		return filepath.Dir(path)
+	}
+	if tab != nil && tab.Ctrl != nil {
+		return tabRuntimeSessionDir(tab)
+	}
+	return tabSessionDir(tab)
 }
 
 // ListSessions returns the saved sessions newest-first for the history panel,
@@ -1758,7 +1943,11 @@ func (a *App) DeleteSession(path string) error {
 	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
-		return err
+		var foundErr error
+		if dir, sessionPath, foundErr = a.sessionDirForPath(path); foundErr != nil {
+			return err
+		}
+		key = filepath.Base(sessionPath)
 	}
 	if err := validateSessionTrashTarget(dir, sessionPath, key); err != nil {
 		return err
@@ -1884,7 +2073,7 @@ func (a *App) removeTopicRuntimeBindings(topicID string) ([]removedSessionRuntim
 		if tab == nil || tab.TopicID != topicID {
 			continue
 		}
-		sessionDir := tabSessionDir(tab)
+		sessionDir := tabRuntimeSessionDir(tab)
 		sessionPath := canonicalTabSessionPath(tab.currentSessionPath())
 		if len(removed) == 0 {
 			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot}
@@ -1901,7 +2090,7 @@ func (a *App) removeTopicRuntimeBindings(topicID string) ([]removedSessionRuntim
 		if tab == nil || tab.TopicID != topicID {
 			continue
 		}
-		sessionDir := tabSessionDir(tab)
+		sessionDir := tabRuntimeSessionDir(tab)
 		sessionPath := canonicalTabSessionPath(tab.currentSessionPath())
 		if len(removed) == 0 {
 			fallback = fallbackRuntimeTarget{scope: tab.Scope, workspaceRoot: tab.WorkspaceRoot}
@@ -1937,10 +2126,17 @@ func removedRuntimeFromTab(tab *WorkspaceTab, dir, sessionPath string) removedSe
 }
 
 func tabMatchesSession(tab *WorkspaceTab, dir, sessionPath string) bool {
-	if tab == nil || tabSessionDir(tab) != dir {
+	if tab == nil {
 		return false
 	}
 	currentPath, _, err := validateSessionPath(dir, tab.currentSessionPath())
+	if err == nil && currentPath == sessionPath {
+		return true
+	}
+	if tabRuntimeSessionDir(tab) != dir {
+		return false
+	}
+	currentPath, _, err = validateSessionPath(dir, tab.currentSessionPath())
 	return err == nil && currentPath == sessionPath
 }
 
@@ -2120,7 +2316,7 @@ func (a *App) beginDestroySessionJobs(dir, sessionPath string) []control.Session
 	defer a.mu.RUnlock()
 	var destroys []control.SessionDestroyHandle
 	for _, tab := range a.runtimeTabsLocked() {
-		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+		if tab == nil || tab.Ctrl == nil || tabRuntimeSessionDir(tab) != dir {
 			continue
 		}
 		destroys = append(destroys, tab.Ctrl.BeginDestroySession(sessionPath))
@@ -2194,7 +2390,7 @@ func (a *App) sessionDestroying(dir, sessionPath string) bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	for _, tab := range a.runtimeTabsLocked() {
-		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+		if tab == nil || tab.Ctrl == nil || tabRuntimeSessionDir(tab) != dir {
 			continue
 		}
 		if tab.Ctrl.IsDestroyingSession(sessionPath) {
@@ -5934,6 +6130,10 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if controllerHasActiveRuntimeWork(tab.Ctrl) {
 		return rebuildControllerActiveWorkError("model")
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	prevPath := a.reconciledSessionPathForTab(tab)
 	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
 	if err != nil {
 		return err
@@ -5957,9 +6157,10 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	}
 
 	var carried []provider.Message
-	prevPath := ""
 	if tab.Ctrl != nil {
-		prevPath = tab.Ctrl.SessionPath()
+		if prevPath == "" {
+			prevPath = tab.Ctrl.SessionPath()
+		}
 		_ = a.snapshotTab(tab)
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()
@@ -6046,6 +6247,10 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("effort")
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	prevPath := a.reconciledSessionPathForTab(tab)
 	entry, err := a.currentProviderEntryForTab(tabID)
 	if err != nil {
 		return err
@@ -6056,9 +6261,10 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		return err
 	}
 	var carried []provider.Message
-	prevPath := ""
 	if tab.Ctrl != nil {
-		prevPath = tab.Ctrl.SessionPath()
+		if prevPath == "" {
+			prevPath = tab.Ctrl.SessionPath()
+		}
 		_ = a.snapshotTab(tab)
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()
@@ -6118,6 +6324,10 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("token mode")
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	prevPath := a.reconciledSessionPathForTab(tab)
 	modelRef, fallback, err := a.resolvedModelForTab(tab)
 	if err != nil {
 		return err
@@ -6127,10 +6337,11 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	}
 
 	var carried []provider.Message
-	prevPath := ""
 	oldCtrl := tab.Ctrl
 	if oldCtrl != nil {
-		prevPath = oldCtrl.SessionPath()
+		if prevPath == "" {
+			prevPath = oldCtrl.SessionPath()
+		}
 		_ = a.snapshotTab(tab)
 		carried = oldCtrl.History()
 	}
@@ -6891,7 +7102,13 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 			return nil
 		}
 		if info.IsDir() {
-			ctrl := a.activeCtrl()
+			tab, ctrl := a.tabAndCtrlByID("")
+			if err := a.ensureTabControllerWorkspace(tab); err != nil {
+				return err
+			}
+			if tab != nil {
+				ctrl = tab.Ctrl
+			}
 			if ctrl == nil {
 				return fmt.Errorf("workspace is not ready")
 			}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6907,6 +6907,9 @@ func (a *App) runEffortCommandForTab(tabID, input string) {
 }
 
 func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, error) {
+	if tab := a.tabByID(tabID); tab != nil {
+		a.reconcileTabWithPinnedSessionMeta(tab)
+	}
 	a.mu.RLock()
 	ref := ""
 	workspaceRoot := ""

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -923,6 +923,11 @@ func (a *App) ensureTabControllerWorkspace(tab *WorkspaceTab) error {
 	if tab == nil || tab.Ctrl == nil || tab.ReadOnly {
 		return nil
 	}
+	tab.reconcileMu.Lock()
+	defer tab.reconcileMu.Unlock()
+	if tab.Ctrl == nil || tab.ReadOnly {
+		return nil
+	}
 	if tab.hasActiveRuntimeWork() {
 		return nil
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -864,6 +864,13 @@ func (a *App) SteerForTab(tabID, text string) error {
 	if ctrl == nil {
 		return workspaceNotReadyErr(tab)
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
+	}
 	ctrl.Steer(text)
 	return nil
 }
@@ -1209,6 +1216,13 @@ func (a *App) Compact() error {
 	if tab != nil && tab.ReadOnly {
 		return readOnlyChannelErr()
 	}
+	if ctrl == nil {
+		return nil
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	ctrl = tab.Ctrl
 	if ctrl == nil {
 		return nil
 	}

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1219,7 +1219,7 @@ func TestAddOfficialProviderAccessRejectsBackgroundJobsBeforeSavingKey(t *testin
 	os.Unsetenv("DEEPSEEK_API_KEY")
 
 	app := NewApp()
-	app.ctx = context.Background()
+	app.readyHook = func() {}
 	app.setTestCtrl(newBackgroundJobController(t, "provider-access-job"), "deepseek-flash/deepseek-v4-flash")
 
 	_, err := app.AddOfficialProviderAccess("deepseek", "sk-test")
@@ -1684,6 +1684,164 @@ func TestSetModelForTabRefreshesCarriedSystemPrompt(t *testing.T) {
 	}
 	if history[1].Role != provider.RoleUser || history[1].Content != "hello" {
 		t.Fatalf("carried user message changed: %+v", history[1])
+	}
+}
+
+func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "TEST_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "test/test-model"
+	cfg.Desktop.ProviderAccess = []string{"test"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "test", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "test-model", APIKeyEnv: "TEST_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+
+	topicID := "topic_rebuild_workspace"
+	topicTitle := "Rebuild workspace"
+	sessionDirA := desktopSessionDir(projectA)
+	sessionDirB := desktopSessionDir(projectB)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	if err := os.MkdirAll(sessionDirB, 0o755); err != nil {
+		t.Fatalf("mkdir project B sessions: %v", err)
+	}
+	sessionPathA := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", topicID, topicTitle, projectA, "project A prompt", time.Now())
+	sessionPathB := filepath.Join(sessionDirB, "wrong.jsonl")
+
+	oldSession := agent.NewSession("old system prompt")
+	oldSession.Add(provider.Message{Role: provider.RoleUser, Content: "carry me"})
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{
+		Executor:      oldExec,
+		SessionDir:    sessionDirB,
+		SessionPath:   sessionPathB,
+		Label:         "test/test-model",
+		ModelRef:      "test/test-model",
+		WorkspaceRoot: projectB,
+		Sink:          event.Discard,
+	})
+
+	app := NewApp()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID:            "tab_stale_workspace",
+		Scope:         "project",
+		WorkspaceRoot: projectB,
+		TopicID:       topicID,
+		TopicTitle:    topicTitle,
+		SessionPath:   sessionPathA,
+		Ready:         true,
+		model:         "test/test-model",
+		Ctrl:          oldCtrl,
+		sink:          &tabEventSink{tabID: "tab_stale_workspace", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	if err := app.ensureTabControllerWorkspace(tab); err != nil {
+		t.Fatalf("ensureTabControllerWorkspace: %v", err)
+	}
+	if tab.Ctrl == nil {
+		t.Fatal("controller was not rebuilt")
+	}
+	if tab.Ctrl == oldCtrl {
+		t.Fatal("stale controller was reused")
+	}
+	if got := normalizeProjectRoot(tab.WorkspaceRoot); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	}
+	if got := normalizeProjectRoot(tab.Ctrl.WorkspaceRoot()); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("controller workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	}
+	if !sameDesktopPath(tab.Ctrl.SessionDir(), sessionDirA) {
+		t.Fatalf("controller session dir = %q, want %q", tab.Ctrl.SessionDir(), sessionDirA)
+	}
+	if !sameDesktopPath(tab.Ctrl.SessionPath(), sessionPathA) {
+		t.Fatalf("controller session path = %q, want %q", tab.Ctrl.SessionPath(), sessionPathA)
+	}
+}
+
+func TestListSessionsUsesPinnedSessionOwnerBeforeStaleRuntimeDir(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+	sessionDirA := desktopSessionDir(projectA)
+	sessionDirB := desktopSessionDir(projectB)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	if err := os.MkdirAll(sessionDirB, 0o755); err != nil {
+		t.Fatalf("mkdir project B sessions: %v", err)
+	}
+	sessionPathA := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", "topic_project_a", "Project A topic", projectA, "project A prompt", time.Now())
+	sessionPathB := writeTopicSessionWithPrompt(t, sessionDirB, "project-b.jsonl", "topic_project_b", "Project B topic", projectB, "project B prompt", time.Now().Add(time.Minute))
+
+	app := NewApp()
+	oldCtrl := control.New(control.Options{
+		SessionDir:    sessionDirB,
+		SessionPath:   sessionPathB,
+		WorkspaceRoot: projectB,
+		Sink:          event.Discard,
+	})
+	tab := &WorkspaceTab{
+		ID:            "tab_stale_runtime_dir",
+		Scope:         "project",
+		WorkspaceRoot: projectB,
+		TopicID:       "topic_project_a",
+		TopicTitle:    "Project A topic",
+		SessionPath:   sessionPathA,
+		Ready:         true,
+		Ctrl:          oldCtrl,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(oldCtrl.Close)
+
+	sessions := app.ListSessions()
+	if len(sessions) == 0 {
+		t.Fatal("ListSessions() returned no sessions")
+	}
+	if filepath.Clean(sessions[0].Path) != filepath.Clean(sessionPathA) {
+		t.Fatalf("ListSessions()[0].Path = %q, want pinned project A session %q", sessions[0].Path, sessionPathA)
+	}
+	for _, item := range sessions {
+		if filepath.Clean(item.Path) == filepath.Clean(sessionPathB) {
+			t.Fatalf("ListSessions() included stale project B runtime session: %+v", sessions)
+		}
+	}
+	if got := normalizeProjectRoot(tab.WorkspaceRoot); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1690,13 +1691,17 @@ func TestSetModelForTabRefreshesCarriedSystemPrompt(t *testing.T) {
 type staleWorkspaceBindingFixture struct {
 	app          *App
 	tab          *WorkspaceTab
-	oldCtrl      *control.Controller
+	oldCtrl      control.SessionAPI
 	projectA     string
 	sessionDirA  string
 	sessionPathA string
 }
 
 func newStaleWorkspaceBindingFixture(t *testing.T, suffix string) staleWorkspaceBindingFixture {
+	return newStaleWorkspaceBindingFixtureWithLayout(t, suffix, "")
+}
+
+func newStaleWorkspaceBindingFixtureWithLayout(t *testing.T, suffix, layoutStyle string) staleWorkspaceBindingFixture {
 	t.Helper()
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "TEST_MODEL_KEY", "sk-test")
@@ -1706,6 +1711,11 @@ func newStaleWorkspaceBindingFixture(t *testing.T, suffix string) staleWorkspace
 	cfg.Desktop.ProviderAccess = []string{"test"}
 	cfg.Providers = []config.ProviderEntry{
 		{Name: "test", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "test-model", APIKeyEnv: "TEST_MODEL_KEY"},
+	}
+	if strings.TrimSpace(layoutStyle) != "" {
+		if err := cfg.SetDesktopLayoutStyle(layoutStyle); err != nil {
+			t.Fatalf("set desktop layout style: %v", err)
+		}
 	}
 	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
 		t.Fatalf("save config: %v", err)
@@ -1802,6 +1812,55 @@ func assertTabRebuiltToPinnedWorkspace(t *testing.T, f staleWorkspaceBindingFixt
 	}
 }
 
+type blockingSnapshotCtrl struct {
+	control.SessionAPI
+
+	firstSnapshotStarted  chan struct{}
+	secondSnapshotStarted chan struct{}
+	releaseSnapshot       chan struct{}
+	firstOnce             sync.Once
+	secondOnce            sync.Once
+	snapshotCount         atomic.Int32
+	closeCount            atomic.Int32
+}
+
+func newBlockingSnapshotCtrl(ctrl control.SessionAPI) *blockingSnapshotCtrl {
+	return &blockingSnapshotCtrl{
+		SessionAPI:            ctrl,
+		firstSnapshotStarted:  make(chan struct{}),
+		secondSnapshotStarted: make(chan struct{}),
+		releaseSnapshot:       make(chan struct{}),
+	}
+}
+
+func (c *blockingSnapshotCtrl) Snapshot() error {
+	count := c.snapshotCount.Add(1)
+	if count == 1 {
+		c.firstOnce.Do(func() { close(c.firstSnapshotStarted) })
+	} else if count == 2 {
+		c.secondOnce.Do(func() { close(c.secondSnapshotStarted) })
+	}
+	<-c.releaseSnapshot
+	if c.SessionAPI == nil {
+		return nil
+	}
+	return c.SessionAPI.Snapshot()
+}
+
+func (c *blockingSnapshotCtrl) Close() {
+	c.closeCount.Add(1)
+	if c.SessionAPI != nil {
+		c.SessionAPI.Close()
+	}
+}
+
+func (f *staleWorkspaceBindingFixture) installBlockingSnapshotController() *blockingSnapshotCtrl {
+	ctrl := newBlockingSnapshotCtrl(f.tab.Ctrl)
+	f.tab.Ctrl = ctrl
+	f.oldCtrl = ctrl
+	return ctrl
+}
+
 func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 	f := newStaleWorkspaceBindingFixture(t, "rebuild_workspace")
 
@@ -1827,6 +1886,87 @@ func TestCompactReconcilesStaleWorkspaceBeforeCompaction(t *testing.T) {
 	if err := f.app.Compact(); err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
+	assertTabRebuiltToPinnedWorkspace(t, f)
+}
+
+func TestClassicLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {
+	runQuickClickWorkspaceReconcileTest(t, "classic")
+}
+
+func TestWorkbenchLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {
+	runQuickClickWorkspaceReconcileTest(t, "workbench")
+}
+
+func TestCreationLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {
+	runQuickClickWorkspaceReconcileTest(t, "creation")
+}
+
+func runQuickClickWorkspaceReconcileTest(t *testing.T, layoutStyle string) {
+	t.Helper()
+	f := newStaleWorkspaceBindingFixtureWithLayout(t, "quick_click_"+layoutStyle, layoutStyle)
+	if got, want := f.app.singleSurfaceLayoutEnabled(), singleSurfaceLayoutStyle(layoutStyle); got != want {
+		t.Fatalf("singleSurfaceLayoutEnabled(%q) = %v, want %v", layoutStyle, got, want)
+	}
+	blockingCtrl := f.installBlockingSnapshotController()
+
+	type quickAction struct {
+		name string
+		run  func() error
+	}
+	actions := []quickAction{
+		{name: "submit", run: func() error { return f.app.SubmitToTab(f.tab.ID, "/unknown-command") }},
+		{name: "steer", run: func() error { return f.app.SteerForTab(f.tab.ID, "/unknown-command") }},
+		{name: "compact", run: func() error { return f.app.Compact() }},
+		{name: "submit-display", run: func() error { return f.app.SubmitDisplayToTab(f.tab.ID, "/unknown display", "/unknown-command") }},
+	}
+
+	start := make(chan struct{})
+	ready := make(chan struct{}, len(actions))
+	errs := make(chan error, len(actions))
+	var wg sync.WaitGroup
+	for _, action := range actions {
+		action := action
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready <- struct{}{}
+			<-start
+			if err := action.run(); err != nil {
+				errs <- fmt.Errorf("%s: %w", action.name, err)
+			}
+		}()
+	}
+	for range actions {
+		<-ready
+	}
+	close(start)
+
+	select {
+	case <-blockingCtrl.firstSnapshotStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first stale controller snapshot")
+	}
+	select {
+	case <-blockingCtrl.secondSnapshotStarted:
+		t.Fatal("workspace rebuild was not serialized: second stale snapshot started before the first rebuild finished")
+	case <-time.After(75 * time.Millisecond):
+	}
+	close(blockingCtrl.releaseSnapshot)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+	if got := blockingCtrl.snapshotCount.Load(); got != 1 {
+		t.Fatalf("stale snapshot count = %d, want 1", got)
+	}
+	if got := blockingCtrl.closeCount.Load(); got != 1 {
+		t.Fatalf("stale close count = %d, want 1", got)
+	}
+	waitNotRunning(t, f.tab.Ctrl)
 	assertTabRebuiltToPinnedWorkspace(t, f)
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1687,7 +1687,17 @@ func TestSetModelForTabRefreshesCarriedSystemPrompt(t *testing.T) {
 	}
 }
 
-func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
+type staleWorkspaceBindingFixture struct {
+	app          *App
+	tab          *WorkspaceTab
+	oldCtrl      *control.Controller
+	projectA     string
+	sessionDirA  string
+	sessionPathA string
+}
+
+func newStaleWorkspaceBindingFixture(t *testing.T, suffix string) staleWorkspaceBindingFixture {
+	t.Helper()
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "TEST_MODEL_KEY", "sk-test")
 
@@ -1710,8 +1720,8 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 		t.Fatalf("add project B: %v", err)
 	}
 
-	topicID := "topic_rebuild_workspace"
-	topicTitle := "Rebuild workspace"
+	topicID := "topic_" + suffix
+	topicTitle := "Rebuild workspace " + suffix
 	sessionDirA := desktopSessionDir(projectA)
 	sessionDirB := desktopSessionDir(projectB)
 	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
@@ -1739,7 +1749,7 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 	app := NewApp()
 	app.readyHook = func() {}
 	tab := &WorkspaceTab{
-		ID:            "tab_stale_workspace",
+		ID:            "tab_stale_workspace_" + suffix,
 		Scope:         "project",
 		WorkspaceRoot: projectB,
 		TopicID:       topicID,
@@ -1748,7 +1758,7 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 		Ready:         true,
 		model:         "test/test-model",
 		Ctrl:          oldCtrl,
-		sink:          &tabEventSink{tabID: "tab_stale_workspace", app: app},
+		sink:          &tabEventSink{tabID: "tab_stale_workspace_" + suffix, app: app},
 		disabledMCP:   map[string]ServerView{},
 	}
 	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
@@ -1760,27 +1770,64 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 		}
 	})
 
-	if err := app.ensureTabControllerWorkspace(tab); err != nil {
-		t.Fatalf("ensureTabControllerWorkspace: %v", err)
+	return staleWorkspaceBindingFixture{
+		app:          app,
+		tab:          tab,
+		oldCtrl:      oldCtrl,
+		projectA:     projectA,
+		sessionDirA:  sessionDirA,
+		sessionPathA: sessionPathA,
 	}
-	if tab.Ctrl == nil {
+}
+
+func assertTabRebuiltToPinnedWorkspace(t *testing.T, f staleWorkspaceBindingFixture) {
+	t.Helper()
+	if f.tab.Ctrl == nil {
 		t.Fatal("controller was not rebuilt")
 	}
-	if tab.Ctrl == oldCtrl {
+	if f.tab.Ctrl == f.oldCtrl {
 		t.Fatal("stale controller was reused")
 	}
-	if got := normalizeProjectRoot(tab.WorkspaceRoot); got != normalizeProjectRoot(projectA) {
-		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	if got := normalizeProjectRoot(f.tab.WorkspaceRoot); got != normalizeProjectRoot(f.projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(f.projectA))
 	}
-	if got := normalizeProjectRoot(tab.Ctrl.WorkspaceRoot()); got != normalizeProjectRoot(projectA) {
-		t.Fatalf("controller workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	if got := normalizeProjectRoot(f.tab.Ctrl.WorkspaceRoot()); got != normalizeProjectRoot(f.projectA) {
+		t.Fatalf("controller workspace root = %q, want project A %q", got, normalizeProjectRoot(f.projectA))
 	}
-	if !sameDesktopPath(tab.Ctrl.SessionDir(), sessionDirA) {
-		t.Fatalf("controller session dir = %q, want %q", tab.Ctrl.SessionDir(), sessionDirA)
+	if !sameDesktopPath(f.tab.Ctrl.SessionDir(), f.sessionDirA) {
+		t.Fatalf("controller session dir = %q, want %q", f.tab.Ctrl.SessionDir(), f.sessionDirA)
 	}
-	if !sameDesktopPath(tab.Ctrl.SessionPath(), sessionPathA) {
-		t.Fatalf("controller session path = %q, want %q", tab.Ctrl.SessionPath(), sessionPathA)
+	if !sameDesktopPath(f.tab.Ctrl.SessionPath(), f.sessionPathA) {
+		t.Fatalf("controller session path = %q, want %q", f.tab.Ctrl.SessionPath(), f.sessionPathA)
 	}
+}
+
+func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
+	f := newStaleWorkspaceBindingFixture(t, "rebuild_workspace")
+
+	if err := f.app.ensureTabControllerWorkspace(f.tab); err != nil {
+		t.Fatalf("ensureTabControllerWorkspace: %v", err)
+	}
+	assertTabRebuiltToPinnedWorkspace(t, f)
+}
+
+func TestSteerForTabReconcilesStaleWorkspaceBeforeIdleFallback(t *testing.T) {
+	f := newStaleWorkspaceBindingFixture(t, "steer_idle_fallback")
+
+	if err := f.app.SteerForTab(f.tab.ID, "/unknown-command"); err != nil {
+		t.Fatalf("SteerForTab: %v", err)
+	}
+	waitNotRunning(t, f.tab.Ctrl)
+	assertTabRebuiltToPinnedWorkspace(t, f)
+}
+
+func TestCompactReconcilesStaleWorkspaceBeforeCompaction(t *testing.T) {
+	f := newStaleWorkspaceBindingFixture(t, "compact")
+
+	if err := f.app.Compact(); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	assertTabRebuiltToPinnedWorkspace(t, f)
 }
 
 func TestListSessionsUsesPinnedSessionOwnerBeforeStaleRuntimeDir(t *testing.T) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1835,9 +1835,10 @@ func newBlockingSnapshotCtrl(ctrl control.SessionAPI) *blockingSnapshotCtrl {
 
 func (c *blockingSnapshotCtrl) Snapshot() error {
 	count := c.snapshotCount.Add(1)
-	if count == 1 {
+	switch count {
+	case 1:
 		c.firstOnce.Do(func() { close(c.firstSnapshotStarted) })
-	} else if count == 2 {
+	case 2:
 		c.secondOnce.Do(func() { close(c.secondSnapshotStarted) })
 	}
 	<-c.releaseSnapshot
@@ -1887,6 +1888,101 @@ func TestCompactReconcilesStaleWorkspaceBeforeCompaction(t *testing.T) {
 		t.Fatalf("Compact: %v", err)
 	}
 	assertTabRebuiltToPinnedWorkspace(t, f)
+}
+
+func TestEffortCommandUsesPinnedSessionOwnerBeforeStaleWorkspaceRoot(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OWNER_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "STALE_MODEL_KEY", "sk-test")
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+	ownerConfig := `default_model = "owner/owner-model"
+[[providers]]
+name = "owner"
+kind = "openai"
+base_url = "https://owner.example.invalid/v1"
+model = "owner-model"
+api_key_env = "OWNER_MODEL_KEY"
+supported_efforts = ["max"]
+default_effort = "max"
+`
+	if err := os.WriteFile(filepath.Join(projectA, "reasonix.toml"), []byte(ownerConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleConfig := `default_model = "stale/stale-model"
+[[providers]]
+name = "stale"
+kind = "openai"
+base_url = "https://stale.example.invalid/v1"
+model = "stale-model"
+api_key_env = "STALE_MODEL_KEY"
+reasoning_protocol = "none"
+`
+	if err := os.WriteFile(filepath.Join(projectB, "reasonix.toml"), []byte(staleConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	topicID := "topic_effort_owner"
+	topicTitle := "Effort owner"
+	sessionDirA := desktopSessionDir(projectA)
+	sessionDirB := desktopSessionDir(projectB)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	if err := os.MkdirAll(sessionDirB, 0o755); err != nil {
+		t.Fatalf("mkdir project B sessions: %v", err)
+	}
+	sessionPathA := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", topicID, topicTitle, projectA, "project A prompt", time.Now())
+	oldCtrl := control.New(control.Options{
+		SessionDir:    sessionDirB,
+		SessionPath:   filepath.Join(sessionDirB, "wrong.jsonl"),
+		WorkspaceRoot: projectB,
+		Sink:          event.Discard,
+	})
+
+	app := NewApp()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID:            "tab_stale_effort",
+		Scope:         "project",
+		WorkspaceRoot: projectB,
+		TopicID:       topicID,
+		TopicTitle:    topicTitle,
+		SessionPath:   sessionPathA,
+		Ready:         true,
+		Ctrl:          oldCtrl,
+		sink:          &tabEventSink{tabID: "tab_stale_effort", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	if err := app.SubmitToTab(tab.ID, "/effort max"); err != nil {
+		t.Fatalf("SubmitToTab(/effort max): %v", err)
+	}
+	waitNotRunning(t, tab.Ctrl)
+	if tab.effort == nil || *tab.effort != "max" {
+		t.Fatalf("tab effort = %#v, want max from pinned project A provider", tab.effort)
+	}
+	if got := normalizeProjectRoot(tab.WorkspaceRoot); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	}
+	if got := normalizeProjectRoot(tab.Ctrl.WorkspaceRoot()); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("controller workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	}
 }
 
 func TestClassicLayoutQuickClicksSerializeWorkspaceRebuild(t *testing.T) {

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -7,8 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/event"
 )
 
 const desktopTinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
@@ -73,6 +76,51 @@ func TestSavePastedImageUsesActiveWorkspaceRoot(t *testing.T) {
 	}
 	if !strings.HasPrefix(preview, "data:image/png;base64,") {
 		t.Fatalf("preview = %q, want png data URL", preview)
+	}
+}
+
+func TestSavePastedImageUsesPinnedSessionOwnerBeforeStaleWorkspaceRoot(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	launchRoot := t.TempDir()
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+	sessionDirA := desktopSessionDir(projectA)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	sessionPathA := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", "topic_attach_owner", "Attach owner", projectA, "project A prompt", time.Now())
+	if err := os.Chdir(launchRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"project": {ID: "project", Scope: "project", WorkspaceRoot: projectB, SessionPath: sessionPathA},
+		},
+		activeTabID: "project",
+	}
+
+	got, err := app.SavePastedImage("data:image/png;base64," + desktopTinyPNG)
+	if err != nil {
+		t.Fatalf("SavePastedImage: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectA, filepath.FromSlash(got))); err != nil {
+		t.Fatalf("pasted image should be saved under pinned session owner project A: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectB, filepath.FromSlash(got))); !os.IsNotExist(err) {
+		t.Fatalf("pasted image should not be saved under stale project B, stat err=%v", err)
+	}
+	if gotRoot := normalizeProjectRoot(app.tabs["project"].WorkspaceRoot); gotRoot != normalizeProjectRoot(projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", gotRoot, normalizeProjectRoot(projectA))
 	}
 }
 
@@ -280,5 +328,100 @@ func TestAttachDroppedOutsideWorkspaceDirRegistersWorkspaceRef(t *testing.T) {
 		!strings.Contains(block, "sub/") ||
 		!strings.Contains(block, "sub/notes.txt") {
 		t.Fatalf("external dropped folder should resolve as dir context:\n%s", block)
+	}
+}
+
+func TestAttachDroppedOutsideWorkspaceDirRegistersAfterPinnedOwnerRebuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "TEST_MODEL_KEY", "sk-test")
+	cfg := config.Default()
+	cfg.DefaultModel = "test/test-model"
+	cfg.Desktop.ProviderAccess = []string{"test"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "test", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "test-model", APIKeyEnv: "TEST_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "External")
+	if err := os.MkdirAll(filepath.Join(outside, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "sub", "notes.txt"), []byte("notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+	sessionDirA := desktopSessionDir(projectA)
+	sessionDirB := desktopSessionDir(projectB)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	if err := os.MkdirAll(sessionDirB, 0o755); err != nil {
+		t.Fatalf("mkdir project B sessions: %v", err)
+	}
+	sessionPathA := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", "topic_external_ref", "External ref", projectA, "project A prompt", time.Now())
+	sessionPathB := filepath.Join(sessionDirB, "wrong.jsonl")
+	oldCtrl := control.New(control.Options{
+		SessionDir:    sessionDirB,
+		SessionPath:   sessionPathB,
+		WorkspaceRoot: projectB,
+		Sink:          event.Discard,
+	})
+	app := NewApp()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID:            "project",
+		Scope:         "project",
+		WorkspaceRoot: projectB,
+		TopicID:       "topic_external_ref",
+		TopicTitle:    "External ref",
+		SessionPath:   sessionPathA,
+		Ready:         true,
+		model:         "test/test-model",
+		Ctrl:          oldCtrl,
+		sink:          &tabEventSink{tabID: "project", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	got, err := app.AttachDropped(outside)
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if tab.Ctrl == oldCtrl {
+		t.Fatal("stale controller was reused for external folder ref")
+	}
+	if gotRoot := normalizeProjectRoot(tab.Ctrl.WorkspaceRoot()); gotRoot != normalizeProjectRoot(projectA) {
+		t.Fatalf("controller workspace root = %q, want project A %q", gotRoot, normalizeProjectRoot(projectA))
+	}
+	resolver, ok := tab.Ctrl.(interface {
+		ResolveScopedRefs(context.Context, string) (string, []string)
+	})
+	if !ok {
+		t.Fatalf("rebuilt controller does not resolve scoped refs: %T", tab.Ctrl)
+	}
+	block, errs := resolver.ResolveScopedRefs(context.Background(), "inspect @"+got.Path+"/")
+	if len(errs) != 0 {
+		t.Fatalf("ResolveScopedRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, "sub/notes.txt") {
+		t.Fatalf("external dropped folder should resolve on rebuilt controller:\n%s", block)
 	}
 }

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -92,15 +92,20 @@ func (a *App) MemorySuggestionsForTab(tabID string) MemorySuggestionsView {
 	tab := a.tabByIDLocked(tabID)
 	var ctrl control.SessionAPI
 	workspaceRoot := ""
-	sessionDir := ""
 	if tab != nil {
 		ctrl = tab.Ctrl
 		workspaceRoot = tab.WorkspaceRoot
-		sessionDir = tabSessionDir(tab)
 	}
 	a.mu.RUnlock()
 	if ctrl == nil {
 		return view
+	}
+	sessionDir := ""
+	if path, ok := a.reconcileTabWithPinnedSessionMeta(tab); ok && strings.TrimSpace(path) != "" {
+		sessionDir = filepath.Dir(path)
+		workspaceRoot = tab.WorkspaceRoot
+	} else {
+		sessionDir = tabRuntimeSessionDir(tab)
 	}
 	set := ctrl.Memory()
 	if set == nil {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -607,11 +607,11 @@ func (a *App) applyConfigOnly(mutate func(*config.Config) error) error {
 }
 
 func (a *App) ensureActiveTabRebuildAllowed(setting string) error {
-	if a.ctx == nil {
-		return nil
-	}
 	tab := a.activeTab()
 	if tab == nil {
+		if a.ctx == nil {
+			return nil
+		}
 		return fmt.Errorf("no active tab")
 	}
 	if controllerHasActiveRuntimeWork(tab.Ctrl) {
@@ -806,10 +806,12 @@ func configDeclaresProviderAccess(path string) bool {
 }
 
 func (a *App) activeWorkspaceRoot() string {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if tab := a.activeTabLocked(); tab != nil {
-		return tab.WorkspaceRoot
+	tab := a.activeTab()
+	if tab != nil {
+		a.reconcileTabWithPinnedSessionMeta(tab)
+		if strings.TrimSpace(tab.WorkspaceRoot) != "" {
+			return tab.WorkspaceRoot
+		}
 	}
 	return "."
 }
@@ -862,10 +864,15 @@ func (a *App) rebuild() error {
 	if controllerHasActiveRuntimeWork(tab.Ctrl) {
 		return rebuildControllerActiveWorkError("settings")
 	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		return err
+	}
+	prevPath := a.reconciledSessionPathForTab(tab)
 	var carried []provider.Message
-	prevPath := ""
 	if tab.Ctrl != nil {
-		prevPath = tab.Ctrl.SessionPath()
+		if prevPath == "" {
+			prevPath = tab.Ctrl.SessionPath()
+		}
 		_ = a.snapshotTab(tab)
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2297,29 +2297,79 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	a.emitReady(wailsCtx, tab.ID)
 }
 
-func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) {
-	if tab == nil || strings.TrimSpace(tab.SessionPath) == "" {
-		return
-	}
-	path, meta, ok := a.pinnedSessionMeta(tab.SessionPath)
-	if !ok {
-		return
-	}
+type sessionBinding struct {
+	path          string
+	scope         string
+	workspaceRoot string
+	topicID       string
+	topicTitle    string
+	hasMeta       bool
+	meta          agent.BranchMeta
+}
 
-	scope := meta.DefaultScope()
-	workspaceRoot := ""
+func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) (string, bool) {
+	if tab == nil {
+		return "", false
+	}
+	path := strings.TrimSpace(tab.SessionPath)
+	if path != "" {
+		if resolved, ok := a.reconcileTabWithSessionPath(tab, path); ok {
+			return resolved, true
+		}
+	}
+	if tab.Ctrl == nil {
+		return "", false
+	}
+	path = strings.TrimSpace(tab.Ctrl.SessionPath())
+	if path == "" {
+		return "", false
+	}
+	binding, ok := a.resolveSessionBinding(path)
+	if !ok {
+		return "", false
+	}
+	if tab.Scope == "project" && binding.scope != "project" && normalizeProjectRoot(tab.WorkspaceRoot) != "" {
+		if root, ok := safeControllerWorkspaceRoot(tab.Ctrl); ok && normalizeProjectRoot(root) == normalizeProjectRoot(tab.WorkspaceRoot) {
+			return "", false
+		}
+	}
+	a.applySessionBindingToTab(tab, binding)
+	return binding.path, true
+}
+
+func (a *App) reconcileTabWithSessionPath(tab *WorkspaceTab, sessionPath string) (string, bool) {
+	if tab == nil || strings.TrimSpace(sessionPath) == "" {
+		return "", false
+	}
+	binding, ok := a.resolveSessionBinding(sessionPath)
+	if !ok {
+		return "", false
+	}
+	a.applySessionBindingToTab(tab, binding)
+	return binding.path, true
+}
+
+func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding) {
+	if tab == nil || binding.path == "" {
+		return
+	}
+	scope := binding.scope
+	workspaceRoot := binding.workspaceRoot
+	if scope == "" {
+		scope = "global"
+	}
 	if scope == "project" {
-		workspaceRoot = normalizeProjectRoot(meta.WorkspaceRoot)
+		workspaceRoot = normalizeProjectRoot(workspaceRoot)
 		if workspaceRoot == "" {
 			return
 		}
 		_ = addProject(workspaceRoot, "")
 	} else {
+		scope = "global"
 		workspaceRoot = globalTabWorkspaceRoot()
 	}
-
-	topicID := strings.TrimSpace(meta.TopicID)
-	topicTitle := strings.TrimSpace(meta.TopicTitle)
+	topicID := strings.TrimSpace(binding.topicID)
+	topicTitle := strings.TrimSpace(binding.topicTitle)
 	if topicTitle == "" && topicID != "" {
 		topicTitle = topicTitleForTab(scope, workspaceRoot, topicID)
 	}
@@ -2332,10 +2382,10 @@ func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) {
 	}
 	changed := tab.Scope != scope ||
 		tab.WorkspaceRoot != workspaceRoot ||
-		canonicalTabSessionPath(tab.SessionPath) != canonicalTabSessionPath(path)
+		canonicalTabSessionPath(tab.SessionPath) != canonicalTabSessionPath(binding.path)
 	tab.Scope = scope
 	tab.WorkspaceRoot = workspaceRoot
-	tab.SessionPath = canonicalTabSessionPath(path)
+	tab.SessionPath = canonicalTabSessionPath(binding.path)
 	if topicID != "" {
 		changed = changed || tab.TopicID != topicID
 		tab.TopicID = topicID
@@ -2350,48 +2400,105 @@ func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) {
 	a.mu.Unlock()
 }
 
-func (a *App) pinnedSessionMeta(sessionPath string) (string, agent.BranchMeta, bool) {
+func (a *App) resolveSessionBinding(sessionPath string) (sessionBinding, bool) {
 	sessionPath = strings.TrimSpace(sessionPath)
 	if sessionPath == "" {
-		return "", agent.BranchMeta{}, false
+		return sessionBinding{}, false
 	}
 	for _, dir := range a.knownSessionDirs() {
-		path, _, err := validateSessionPath(dir, sessionPath)
-		if err != nil {
-			continue
-		}
-		if meta, ok, err := agent.LoadBranchMeta(path); err == nil && ok {
-			return path, meta, true
+		if binding, ok := sessionBindingInDir(dir, sessionPath); ok {
+			return binding, true
 		}
 	}
-
 	if !filepath.IsAbs(sessionPath) {
-		return "", agent.BranchMeta{}, false
+		return sessionBinding{}, false
 	}
 	path, err := filepath.Abs(sessionPath)
 	if err != nil {
-		return "", agent.BranchMeta{}, false
+		return sessionBinding{}, false
 	}
 	meta, ok, err := agent.LoadBranchMeta(path)
 	if err != nil || !ok {
-		return "", agent.BranchMeta{}, false
+		return sessionBinding{}, false
 	}
+	for _, dir := range sessionBindingCandidateDirs(meta) {
+		if binding, ok := sessionBindingInDir(dir, path); ok {
+			return binding, true
+		}
+	}
+	return sessionBindingFromMeta(path, meta)
+}
 
-	var candidateDirs []string
+func sessionBindingCandidateDirs(meta agent.BranchMeta) []string {
 	if meta.DefaultScope() == "project" {
 		if root := normalizeProjectRoot(meta.WorkspaceRoot); root != "" {
-			candidateDirs = append(candidateDirs, desktopSessionDir(root))
+			return []string{desktopSessionDir(root)}
+		}
+		return nil
+	}
+	return []string{desktopSessionDir(globalWorkspaceRoot()), config.SessionDir()}
+}
+
+func sessionBindingInDir(dir, sessionPath string) (sessionBinding, bool) {
+	path, ok := pinnedTabSessionPath(dir, sessionPath)
+	if !ok {
+		return sessionBinding{}, false
+	}
+	meta, hasMeta, err := agent.LoadBranchMeta(path)
+	if err != nil {
+		return sessionBinding{}, false
+	}
+	scope, workspaceRoot, _, ownerOK := legacyMigrationTargetForDir(dir)
+	if !ownerOK {
+		if !hasMeta {
+			return sessionBinding{}, false
+		}
+		return sessionBindingFromMeta(path, meta)
+	}
+	if scope == "global" {
+		if !hasMeta {
+			return sessionBinding{}, false
+		}
+		return sessionBindingFromMeta(path, meta)
+	}
+	binding := sessionBinding{
+		path:          path,
+		scope:         scope,
+		workspaceRoot: workspaceRoot,
+		hasMeta:       hasMeta,
+		meta:          meta,
+	}
+	if hasMeta {
+		binding.topicID = strings.TrimSpace(meta.TopicID)
+		binding.topicTitle = strings.TrimSpace(meta.TopicTitle)
+	}
+	if binding.scope == "project" {
+		binding.workspaceRoot = normalizeProjectRoot(binding.workspaceRoot)
+	}
+	return binding, true
+}
+
+func sessionBindingFromMeta(path string, meta agent.BranchMeta) (sessionBinding, bool) {
+	scope := meta.DefaultScope()
+	workspaceRoot := ""
+	if scope == "project" {
+		workspaceRoot = normalizeProjectRoot(meta.WorkspaceRoot)
+		if workspaceRoot == "" {
+			return sessionBinding{}, false
 		}
 	} else {
-		candidateDirs = append(candidateDirs, desktopSessionDir(globalWorkspaceRoot()), config.SessionDir())
+		scope = "global"
+		workspaceRoot = globalTabWorkspaceRoot()
 	}
-	for _, dir := range candidateDirs {
-		validPath, _, err := validateSessionPath(dir, path)
-		if err == nil {
-			return validPath, meta, true
-		}
-	}
-	return "", agent.BranchMeta{}, false
+	return sessionBinding{
+		path:          path,
+		scope:         scope,
+		workspaceRoot: workspaceRoot,
+		topicID:       strings.TrimSpace(meta.TopicID),
+		topicTitle:    strings.TrimSpace(meta.TopicTitle),
+		hasMeta:       true,
+		meta:          meta,
+	}, true
 }
 
 // --- active tab helpers -----------------------------------------------------
@@ -5271,11 +5378,18 @@ func globalTabWorkspaceRoot() string {
 }
 
 func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool) {
-	return loadPinnedTabSessionWithPreload(dir, sessionPath, loadedTabSession{})
+	return loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath, loadedTabSession{}, true)
 }
 
 func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTabSession) (*agent.Session, string, bool) {
+	return loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath, preloaded, false)
+}
+
+func loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath string, preloaded loadedTabSession, allowMigrationFallback bool) (*agent.Session, string, bool) {
 	path, ok := pinnedTabSessionPath(dir, sessionPath)
+	if !ok && allowMigrationFallback {
+		path, ok = migratedPinnedTabSessionPath(dir, sessionPath)
+	}
 	if !ok {
 		return nil, "", false
 	}
@@ -5305,6 +5419,25 @@ func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTa
 	return loaded, path, true
 }
 
+func migratedPinnedTabSessionPath(dir, sessionPath string) (string, bool) {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" || dir == "" || !filepath.IsAbs(sessionPath) {
+		return "", false
+	}
+	if _, err := os.Stat(sessionPath); err == nil || !os.IsNotExist(err) {
+		return "", false
+	}
+	base := filepath.Base(sessionPath)
+	if base == "." || base == string(filepath.Separator) || !strings.HasSuffix(base, ".jsonl") {
+		return "", false
+	}
+	path, _, err := validateSessionPath(dir, filepath.Join(dir, base))
+	if err != nil {
+		return "", false
+	}
+	return path, true
+}
+
 func pinnedTabSessionPath(dir, sessionPath string) (string, bool) {
 	sessionPath = strings.TrimSpace(sessionPath)
 	if sessionPath == "" || dir == "" {
@@ -5312,6 +5445,9 @@ func pinnedTabSessionPath(dir, sessionPath string) (string, bool) {
 	}
 	path, _, err := validateSessionPath(dir, sessionPath)
 	if err != nil {
+		if filepath.IsAbs(sessionPath) {
+			return "", false
+		}
 		base := filepath.Base(sessionPath)
 		if base == "." || base == string(filepath.Separator) || !strings.HasSuffix(base, ".jsonl") {
 			return "", false
@@ -5332,8 +5468,22 @@ func saveTabSessionMeta(tab *WorkspaceTab, path string) error {
 	if err != nil {
 		return err
 	}
-	m.Scope = tab.Scope
-	m.WorkspaceRoot = tab.WorkspaceRoot
+	scope := tab.Scope
+	workspaceRoot := tab.WorkspaceRoot
+	if ownerScope, ownerRoot, _, ok := legacyMigrationTargetForDir(filepath.Dir(path)); ok {
+		if ownerScope == "project" {
+			scope = ownerScope
+			workspaceRoot = ownerRoot
+		}
+	}
+	if scope == "project" {
+		workspaceRoot = normalizeProjectRoot(workspaceRoot)
+	} else {
+		scope = "global"
+		workspaceRoot = ""
+	}
+	m.Scope = scope
+	m.WorkspaceRoot = workspaceRoot
 	m.TopicID = tab.TopicID
 	m.TopicTitle = tab.TopicTitle
 	if err := agent.SaveBranchMetaPreserveUpdated(path, m); err != nil {
@@ -5373,6 +5523,9 @@ func (a *App) persistTabSessionPath(tab *WorkspaceTab, path string) {
 	path = canonicalTabSessionPath(path)
 	if tab == nil || path == "" {
 		return
+	}
+	if reconciled, ok := a.reconcileTabWithSessionPath(tab, path); ok {
+		path = canonicalTabSessionPath(reconciled)
 	}
 	_ = saveTabSessionMeta(tab, path)
 	a.rememberTabSessionPath(tab, path)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -52,6 +52,7 @@ type WorkspaceTab struct {
 	buildCancel     context.CancelFunc // cancels in-flight boot for tabs removed before Ready
 	buildGeneration uint64             // identifies the current in-flight build
 	removed         bool               // set when the visible tab is pruned/closed before build completes
+	reconcileMu     sync.Mutex         // serializes stale controller workspace repair for this tab
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -712,6 +712,56 @@ func TestBuildTabControllerUsesPinnedSessionMetaWorkspace(t *testing.T) {
 	}
 }
 
+func TestPersistTabSessionPathUsesSessionDirOwnerBeforeSavingMeta(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	if err := addProject(projectA, "Project A"); err != nil {
+		t.Fatalf("add project A: %v", err)
+	}
+	if err := addProject(projectB, "Project B"); err != nil {
+		t.Fatalf("add project B: %v", err)
+	}
+
+	topicID := "topic_owner_before_meta"
+	topicTitle := "Owner before meta"
+	sessionDirA := desktopSessionDir(projectA)
+	if err := os.MkdirAll(sessionDirA, 0o755); err != nil {
+		t.Fatalf("mkdir project A sessions: %v", err)
+	}
+	sessionPath := writeTopicSessionWithPrompt(t, sessionDirA, "project-a.jsonl", topicID, topicTitle, projectA, "project A prompt", time.Now())
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		t.Fatalf("load branch meta: ok=%v err=%v", ok, err)
+	}
+	meta.WorkspaceRoot = projectB
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, meta); err != nil {
+		t.Fatalf("pollute branch meta: %v", err)
+	}
+
+	app := NewApp()
+	tab := app.createTabEntryWithID("project", projectB, topicID, "tab_stale_workspace")
+	tab.TopicTitle = topicTitle
+	tab.SessionPath = sessionPath
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.persistTabSessionPath(tab, sessionPath)
+
+	if got := normalizeProjectRoot(tab.WorkspaceRoot); got != normalizeProjectRoot(projectA) {
+		t.Fatalf("tab workspace root = %q, want project A %q", got, normalizeProjectRoot(projectA))
+	}
+	gotMeta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		t.Fatalf("reload branch meta: ok=%v err=%v", ok, err)
+	}
+	if gotMeta.Scope != "project" || normalizeProjectRoot(gotMeta.WorkspaceRoot) != normalizeProjectRoot(projectA) {
+		t.Fatalf("saved branch meta scope/root = %q/%q, want project/%q", gotMeta.Scope, gotMeta.WorkspaceRoot, normalizeProjectRoot(projectA))
+	}
+}
+
 func TestBuildTabControllerIgnoresStaleSessionModelWhenTabModelResolves(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	t.Setenv("REASONIX_TEST_KEY", "sk-test")
@@ -787,6 +837,19 @@ func TestLoadPinnedTabSessionFallsBackToMigratedBasename(t *testing.T) {
 	}
 	if filepath.Clean(pinnedPath) != filepath.Clean(path) {
 		t.Fatalf("pinned path = %q, want %q", pinnedPath, path)
+	}
+}
+
+func TestPinnedTabSessionPathRejectsExistingAbsolutePathOutsideDir(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	pathA := writeLegacySession(t, dirA, "same-name.jsonl", "project A", time.Now())
+	_ = writeLegacySession(t, dirB, filepath.Base(pathA), "project B", time.Now())
+
+	if got, ok := pinnedTabSessionPath(dirB, pathA); ok {
+		t.Fatalf("pinnedTabSessionPath mapped existing absolute path outside dir to %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reconcile desktop tabs against the persisted session owner before controller rebuilds, submits, shell runs, settings rebuilds, and model/effort/token switches
- prevent session meta writes and legacy basename fallback from reassigning a project session to the wrong workspace
- keep history, memory suggestions, attachments, and external folder refs aligned with the verified session owner

Fixes #5164. Related to #4256 and #4847.

## Verification
- cd desktop && go test . -count=1
- go test ./internal/control -count=1
- git diff --check
- go test ./... -count=1
