### PR TITLE
style(creation): 打磨创作输入框发送按钮与模式切换条

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24436,6 +24436,28 @@ body > .mermaid-diagram--fullscreen {
   transform: none;
 }
 
+:root[data-theme="dark"][data-theme-style] .app--creation .composer__btn--send {
+  background: color-mix(in srgb, var(--accent) 56%, var(--bg-elev) 44%);
+  color: color-mix(in srgb, #fff 88%, var(--accent) 12%);
+  box-shadow: 0 3px 8px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+:root[data-theme="dark"][data-theme-style] .app--creation .composer__btn--send:not(:disabled):hover {
+  background: color-mix(in srgb, var(--accent) 64%, var(--bg-elev) 36%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme-style]:not([data-theme]) .app--creation .composer__btn--send {
+    background: color-mix(in srgb, var(--accent) 56%, var(--bg-elev) 44%);
+    color: color-mix(in srgb, #fff 88%, var(--accent) 12%);
+    box-shadow: 0 3px 8px color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+
+  :root[data-theme-style]:not([data-theme]) .app--creation .composer__btn--send:not(:disabled):hover {
+    background: color-mix(in srgb, var(--accent) 64%, var(--bg-elev) 36%);
+  }
+}
+
 .app--creation .composer__btn--send svg,
 :root[data-theme-style] .app--creation .composer__btn--send svg {
   width: 14px;
@@ -24534,28 +24556,15 @@ body > .mermaid-diagram--fullscreen {
   height: 28px;
   grid-template-columns: repeat(3, var(--creation-mode-cell));
   padding: 2px;
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
 }
 
 .app--creation .composer-modebar__thumb,
 :root[data-theme-style] .app--creation .composer-modebar__thumb {
-  left: 4px;
-  width: 24px;
-  border-color: color-mix(in srgb, #3b82f6 28%, transparent);
-  background: color-mix(in srgb, #3b82f6 34%, transparent);
-  box-shadow: none;
-  transform: translateX(calc(var(--composer-modebar-index) * var(--creation-mode-cell)));
-}
-
-.app--creation .composer-modebar--approval[data-mode="auto"] .composer-modebar__thumb,
-:root[data-theme-style] .app--creation .composer-modebar--approval[data-mode="auto"] .composer-modebar__thumb {
-  border-color: color-mix(in srgb, #22c55e 28%, transparent);
-  background: color-mix(in srgb, #22c55e 34%, transparent);
-}
-
-.app--creation .composer-modebar--approval[data-mode="yolo"] .composer-modebar__thumb,
-:root[data-theme-style] .app--creation .composer-modebar--approval[data-mode="yolo"] .composer-modebar__thumb {
-  border-color: color-mix(in srgb, #f97316 30%, transparent);
-  background: color-mix(in srgb, #f97316 36%, transparent);
+  display: none;
 }
 
 .app--creation .composer-modebar__item,
@@ -24565,6 +24574,31 @@ body > .mermaid-diagram--fullscreen {
   width: 24px;
   height: 24px;
   padding: 0;
+  color: color-mix(in srgb, var(--fg-faint) 82%, transparent);
+}
+
+.app--creation .composer-modebar__item:hover:not(:disabled),
+.app--creation .composer-modebar__item:focus-visible,
+:root[data-theme-style] .app--creation .composer-modebar__item:hover:not(:disabled),
+:root[data-theme-style] .app--creation .composer-modebar__item:focus-visible {
+  color: color-mix(in srgb, var(--fg-muted) 86%, var(--accent));
+  transform: none;
+}
+
+.app--creation .composer-modebar__item--active,
+:root[data-theme-style] .app--creation .composer-modebar__item--active {
+  color: #3b82f6;
+  transform: scale(1.16);
+}
+
+.app--creation .composer-modebar__item--auto.composer-modebar__item--active,
+:root[data-theme-style] .app--creation .composer-modebar__item--auto.composer-modebar__item--active {
+  color: #22c55e;
+}
+
+.app--creation .composer-modebar__item--yolo.composer-modebar__item--active,
+:root[data-theme-style] .app--creation .composer-modebar__item--yolo.composer-modebar__item--active {
+  color: #f97316;
 }
 
 .app--creation .composer-modebar__item span,
@@ -24576,6 +24610,13 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .app--creation .composer-modebar__item svg {
   width: 13px;
   height: 13px;
+  transition: transform 0.16s var(--ease-out), color 0.16s var(--ease-out);
+}
+
+.app--creation .composer-modebar__item--active svg,
+:root[data-theme-style] .app--creation .composer-modebar__item--active svg {
+  transform: scale(1.08);
+  stroke-width: 2.15;
 }
 
 .app--creation .composer-meta .modelsw__trigger,
@@ -24594,6 +24635,11 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .composer-meta .modelsw__kind,
 :root[data-theme-style] .app--creation .composer-meta .modelsw__kind {
+  display: none;
+}
+
+.app--creation .composer-meta .modelsw__trigger svg:not(.modelsw__kind),
+:root[data-theme-style] .app--creation .composer-meta .modelsw__trigger svg:not(.modelsw__kind) {
   display: none;
 }
 


### PR DESCRIPTION
## 改动内容

延续 PR #5065 的 Creation 视觉迭代，本次打磨创作输入框（composer）控件，全部限定在 `.app--creation` 作用域，不影响 classic / workbench。

### 1. 暗色主题发送按钮（`.composer__btn--send`）
- 暗色下用 accent 与 `--bg-elev` 混色作背景（56% accent + 44% bg-elev），文字用白主色
- 加一层 accent 色调的柔和投影
- hover 时 accent 占比提升到 64%
- 同时覆盖「显式 dark」和「跟随系统 prefers-color-scheme: dark」两条路径

### 2. 模式切换条（`.composer-modebar`）
- 移除原来的滑块 thumb（`.composer-modebar__thumb { display: none }`），连同 auto/yolo 的 thumb 着色规则一并删除
- 改用图标激活态表达当前模式：
  - 激活项 `.composer-modebar__item--active` 放大 1.16 倍、svg 放大 1.08 倍 + 描边加粗到 2.15
  - 按模式着色：默认蓝（#3b82f6）、auto 绿（#22c55e）、yolo 橙（#f97316）
  - 非激活项用 `--fg-faint` 淡化，hover/focus 轻微提色，不再有 transform 位移
- modebar 容器去掉边框/背景/阴影，`overflow: visible`，让图标放大不被裁切
- 图标加 0.16s 的 transform/color 过渡，切换更顺滑

### 3. 模型选择器（`.modelsw__trigger`）
- 隐藏触发器里多余的 svg（保留 `.modelsw__kind` 类型标识）

## 校验
- `pnpm --dir desktop/frontend typecheck` 通过
- 改动仅 `desktop/frontend/src/styles.css`，纯 CSS，全部限定 `.app--creation` 作用域
- classic / workbench 表现不受影响

## 备注
基于最新 main-v2（`8b1e5c87`）新建分支，与已合并的 #5065 独立。
