### PR TITLE
fix(desktop): prevent permission rule chip from overflowing rightward…

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -13398,6 +13398,9 @@ body > .mermaid-diagram--fullscreen {
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 6px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .set-rule__x {
   border: none;
@@ -15069,12 +15072,6 @@ body > .mermaid-diagram--fullscreen {
   .settings-page--form .set-rules-grid,
   .set-rules-grid {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
-  }
-
-  .set-rule {
-    max-width: 100%;
-    overflow-wrap: anywhere;
-    white-space: normal;
   }
 
   .set-rules__add .mem-input {


### PR DESCRIPTION
### Bug
细粒度规则列表（deny/ask/allow）中输入长命令时，`.set-rule` chip 向右无限扩展，
将「✕」删除按钮推出设置面板外。纯中文正常，长拉丁字符/命令溢出。

### Root Cause
文本换行限制（`max-width:100%; overflow-wrap:anywhere; white-space:normal`）
仅写在 `@media (max-width: 980px)` 内，桌面宽屏下不生效。

### Fix
- 将三个换行属性提升到全局 `.set-rule` base 定义
- 从 `@media (max-width: 980px)` 中删除重复规则

### Verification
- `wails build` 编译通过
- 实测长命令正常向下换行，✕ 按钮始终可见


修复前
<img width="2560" height="1528" alt="PixPin_2026-07-01_00-11-12" src="https://github.com/user-attachments/assets/416a29c6-5ae5-4ba7-adad-f4377510725a" />

修复后
<img width="2560" height="1600" alt="PixPin_2026-07-01_00-10-53" src="https://github.com/user-attachments/assets/4f82f057-1249-4960-af08-26625f117e89" />