### PR TITLE
Hide Windows startup probe consoles / 隐藏 Windows 启动探测终端弹窗

### DIFF
--- a/internal/environment/probe.go
+++ b/internal/environment/probe.go
@@ -14,9 +14,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 const ProbeTimeout = 2 * time.Second
+
+const probeWaitDelay = time.Second
 
 const probeCacheTTL = 5 * time.Minute
 
@@ -201,6 +205,7 @@ func runOne(ctx context.Context, command string, opts ProbeOptions) ProbeResult 
 	cmdCtx, cancel := context.WithTimeout(ctx, ProbeTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(cmdCtx, exe, parts[1:]...)
+	prepareProbeCommand(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -224,6 +229,16 @@ func runOne(ctx context.Context, command string, opts ProbeOptions) ProbeResult 
 	res.Found = true
 	res.Output = firstLine(out)
 	return res
+}
+
+func prepareProbeCommand(cmd *exec.Cmd) {
+	proc.HideWindow(cmd)
+	proc.SetProcessGroupKill(cmd)
+	cmd.Cancel = func() error {
+		proc.KillTree(cmd)
+		return nil
+	}
+	cmd.WaitDelay = probeWaitDelay
 }
 
 func sortResults(results []ProbeResult) {

--- a/internal/environment/probe_test.go
+++ b/internal/environment/probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -125,6 +126,20 @@ func TestRunProbesReportsTimeout(t *testing.T) {
 	}
 	if results[0].Error != "timeout" {
 		t.Fatalf("Error = %q, want timeout", results[0].Error)
+	}
+}
+
+func TestPrepareProbeCommandSetsCancellationBudget(t *testing.T) {
+	cmd := exec.Command("reasonix-test-probe")
+	prepareProbeCommand(cmd)
+	if cmd.Cancel == nil {
+		t.Fatal("probe command must install a cancellation hook")
+	}
+	if cmd.WaitDelay != probeWaitDelay {
+		t.Fatalf("WaitDelay = %v, want %v", cmd.WaitDelay, probeWaitDelay)
+	}
+	if runtime.GOOS == "windows" && cmd.SysProcAttr == nil {
+		t.Fatal("probe command must hide console windows on Windows")
 	}
 }
 

--- a/internal/environment/probe_windows_test.go
+++ b/internal/environment/probe_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package environment
+
+import (
+	"os/exec"
+	"testing"
+)
+
+const testCreateNoWindow = 0x08000000
+
+func TestPrepareProbeCommandHidesConsoleWindowOnWindows(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo", "hi")
+	prepareProbeCommand(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("HideWindow is false")
+	}
+	if cmd.SysProcAttr.CreationFlags&testCreateNoWindow == 0 {
+		t.Fatalf("CREATE_NO_WINDOW not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
+}


### PR DESCRIPTION
## Summary
- Hide startup environment probe child processes on Windows so GUI launches do not flash console windows.
- Add process-tree cancellation and a bounded wait for probe commands.
- Cover the probe preparation path, including a Windows CREATE_NO_WINDOW regression test.

Fixes #5655.

## Verification
- `go test ./internal/proc ./internal/environment ./internal/boot`
- Cross-compiled the Windows test package for `./internal/environment`.
- `git diff --check`
