### PR TITLE
Clear stale MCP failure after removal / 删除 MCP 后清理残留失败状态

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5702,6 +5702,9 @@ func (a *App) RemoveMCPServer(name string) error {
 		return err
 	}
 	if disconnected || removed {
+		if h := tab.Ctrl.Host(); h != nil {
+			h.ClearFailure(name)
+		}
 		a.mu.Lock()
 		delete(tab.disabledMCP, name)
 		tab.mcpOrder = removeServerOrder(tab.mcpOrder, name)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -4484,6 +4484,45 @@ args = ["serve"]
 	}
 }
 
+func TestRemoveMCPServerClearsRecordedStartupFailure(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
+[[plugins]]
+name = "broken"
+command = "reasonix-missing-mcp-binary"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{Host: plugin.NewHost()}), "")
+	defer app.activeCtrl().Close()
+	recordMCPFailure(app.activeCtrl(), config.PluginEntry{
+		Name:    "broken",
+		Command: "reasonix-missing-mcp-binary",
+	}, errors.New("connect: missing binary"))
+
+	view := app.Capabilities()
+	if len(view.Servers) != 1 || view.Servers[0].Name != "broken" || view.Servers[0].Status != "failed" {
+		t.Fatalf("Capabilities before remove = %+v, want broken failed", view.Servers)
+	}
+
+	if err := app.RemoveMCPServer("broken"); err != nil {
+		t.Fatalf("RemoveMCPServer(broken): %v", err)
+	}
+	if mcpFailed(app.activeCtrl(), "broken") {
+		t.Fatalf("Host.Failures() still contains broken after remove: %+v", app.activeCtrl().Host().Failures())
+	}
+	view = app.Capabilities()
+	for _, s := range view.Servers {
+		if s.Name == "broken" {
+			t.Fatalf("Capabilities after remove still contains broken: %+v", view.Servers)
+		}
+	}
+}
+
 func TestRemoveMCPServerDeletesProjectMCPJSONEntry(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)


### PR DESCRIPTION
## Summary
- Clear a stale MCP startup failure after the desktop remove action succeeds.
- Cover the failed-startup removal path so the MCP list no longer keeps showing a removed failed server until restart.

## Contributor credit
- Credits @cyq1017 for the equivalent failed-MCP removal mechanism in #5190; this PR carries that contribution as a commit co-author.

## Verification
- `cd desktop && go test .`

Fixes #5651
Fixes #5189
Refs #5190
