### PR TITLE
Recover legacy sidebar projects on upgrade / 升级时恢复旧版侧栏项目

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3316,24 +3316,23 @@ func migrateLegacyWorkspacesIntoProjects() {
 	if len(legacy) == 0 {
 		return
 	}
-	f := loadProjectsFile()
-	seen := make(map[string]bool, len(f.Projects)+len(legacy))
-	for _, p := range f.Projects {
-		seen[p.Root] = true
-	}
-	changed := false
-	for _, path := range legacy {
-		root := normalizeProjectRoot(path)
-		if root == "" || seen[root] {
-			continue
+	_ = updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		seen := make(map[string]bool, len(f.Projects)+len(legacy))
+		for _, p := range f.Projects {
+			seen[p.Root] = true
 		}
-		f.Projects = append(f.Projects, desktopProject{Root: root})
-		seen[root] = true
-		changed = true
-	}
-	if changed {
-		_ = saveProjectsFile(f)
-	}
+		changed := false
+		for _, path := range legacy {
+			root := normalizeProjectRoot(path)
+			if root == "" || seen[root] {
+				continue
+			}
+			f.Projects = append(f.Projects, desktopProject{Root: root})
+			seen[root] = true
+			changed = true
+		}
+		return changed, nil
+	})
 }
 
 func workspaceName(path string) string {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -525,6 +525,7 @@ func (a *App) restoreOrBuildTabs() {
 	// picked up by Load instead of falling back to built-in defaults.
 	_, _ = config.MigrateLegacyIfNeeded()
 	f := loadTabsFile()
+	_, _ = recoverLegacyProjectSidebarRoots(f)
 	_, _ = config.ResetOfficialProviderPricingOnUpgrade(config.UserConfigPath())
 	_, _ = config.MigrateMCPToUserConfigOnUpgrade(desktopMCPMigrationRoots(f))
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1554,19 +1554,7 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		a.mu.Unlock()
 		return TabMeta{}, err
 	}
-	f := loadProjectsFile()
-	if workspaceRoot == "" {
-		f.GlobalTopics = prependUniqueString(f.GlobalTopics, topicID)
-		_ = saveProjectsFile(f)
-	} else {
-		for i, p := range f.Projects {
-			if p.Root == workspaceRoot {
-				f.Projects[i].Topics = prependUniqueString(p.Topics, topicID)
-				_ = saveProjectsFile(f)
-				break
-			}
-		}
-	}
+	_ = prependTopicInProjectsFile(workspaceRoot, topicID, false)
 
 	tabID := a.newUniqueTabIDLocked()
 	created = &WorkspaceTab{
@@ -2778,6 +2766,8 @@ const tabsFileName = "desktop-tabs.json"
 const desktopGlobalOrderToken = "__global__"
 const legacyProjectSidebarRecoveryMarker = "desktop-projects-legacy-recovered"
 
+var desktopProjectsFileMu sync.Mutex
+
 type desktopProject struct {
 	Root         string   `json:"root"`
 	Title        string   `json:"title,omitempty"`
@@ -2996,40 +2986,40 @@ func recoverLegacyProjectSidebarRoots(tabs desktopTabsFile) (bool, error) {
 		return false, nil
 	}
 
-	f := loadProjectsFile()
-	seen := map[string]bool{}
-	for _, project := range f.Projects {
-		root := normalizeProjectRoot(project.Root)
-		if root != "" {
-			seen[root] = true
-		}
-	}
-
 	changed := false
-	add := func(root string) {
-		root = normalizeProjectRoot(root)
-		if root == "" || seen[root] || !existingDirectory(root) {
-			return
+	err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		seen := map[string]bool{}
+		for _, project := range f.Projects {
+			root := normalizeProjectRoot(project.Root)
+			if root != "" {
+				seen[root] = true
+			}
 		}
-		seen[root] = true
-		f.Projects = append(f.Projects, desktopProject{Root: root})
-		changed = true
-	}
-	if cur := loadWorkspace(); cur != "" {
-		add(cur)
-	}
-	for _, root := range loadWorkspaces() {
-		add(root)
-	}
-	for _, entry := range tabs.Tabs {
-		if entry.Scope == "project" {
-			add(entry.WorkspaceRoot)
+
+		add := func(root string) {
+			root = normalizeProjectRoot(root)
+			if root == "" || seen[root] || !existingDirectory(root) {
+				return
+			}
+			seen[root] = true
+			f.Projects = append(f.Projects, desktopProject{Root: root})
+			changed = true
 		}
-	}
-	if changed {
-		if err := saveProjectsFile(f); err != nil {
-			return false, err
+		if cur := loadWorkspace(); cur != "" {
+			add(cur)
 		}
+		for _, root := range loadWorkspaces() {
+			add(root)
+		}
+		for _, entry := range tabs.Tabs {
+			if entry.Scope == "project" {
+				add(entry.WorkspaceRoot)
+			}
+		}
+		return changed, nil
+	})
+	if err != nil {
+		return false, err
 	}
 	return changed, writeLegacyProjectSidebarRecoveryMarker(markerPath)
 }
@@ -3073,6 +3063,88 @@ func saveProjectsFile(f desktopProjectFile) error {
 		return err
 	}
 	return fileutil.ReplaceFile(tmp, path)
+}
+
+func updateProjectsFile(mutator func(*desktopProjectFile) (bool, error)) error {
+	desktopProjectsFileMu.Lock()
+	defer desktopProjectsFileMu.Unlock()
+
+	f := loadProjectsFile()
+	changed, err := mutator(&f)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return saveProjectsFile(f)
+}
+
+func prependTopicInProjectsFile(workspaceRoot, topicID string, ensureProject bool) error {
+	return prependTopicsInProjectsFile(workspaceRoot, []string{topicID}, ensureProject)
+}
+
+func prependTopicsInProjectsFile(workspaceRoot string, topicIDs []string, ensureProject bool) error {
+	workspaceRoot = normalizeProjectRoot(workspaceRoot)
+	topicIDs = uniqueStrings(topicIDs)
+	if len(topicIDs) == 0 {
+		return nil
+	}
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		if workspaceRoot == "" {
+			next := uniqueStrings(append(append([]string(nil), topicIDs...), f.GlobalTopics...))
+			if sameStringList(next, f.GlobalTopics) {
+				return false, nil
+			}
+			f.GlobalTopics = next
+			return true, nil
+		}
+		for i, p := range f.Projects {
+			if p.Root != workspaceRoot {
+				continue
+			}
+			next := uniqueStrings(append(append([]string(nil), topicIDs...), p.Topics...))
+			if sameStringList(next, p.Topics) {
+				return false, nil
+			}
+			f.Projects[i].Topics = next
+			return true, nil
+		}
+		if !ensureProject {
+			return false, nil
+		}
+		f.Projects = append(f.Projects, desktopProject{Root: workspaceRoot, Topics: topicIDs})
+		return true, nil
+	})
+}
+
+func removeTopicFromProjectsFile(topicID string) error {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return nil
+	}
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		changed := false
+		if next := removeString(f.GlobalTopics, topicID); !sameStringList(next, f.GlobalTopics) {
+			f.GlobalTopics = next
+			changed = true
+		}
+		if next := removeString(f.GlobalPinnedTopics, topicID); !sameStringList(next, f.GlobalPinnedTopics) {
+			f.GlobalPinnedTopics = next
+			changed = true
+		}
+		for i, p := range f.Projects {
+			if next := removeString(p.Topics, topicID); !sameStringList(next, p.Topics) {
+				f.Projects[i].Topics = next
+				changed = true
+			}
+			if next := removeString(p.PinnedTopics, topicID); !sameStringList(next, p.PinnedTopics) {
+				f.Projects[i].PinnedTopics = next
+				changed = true
+			}
+		}
+		return changed, nil
+	})
 }
 
 func normalizeProjectRoot(root string) string {
@@ -3158,6 +3230,18 @@ func normalizeSidebarOrder(order []string, projects []desktopProject) []string {
 		out = append(out, root)
 	}
 	return out
+}
+
+func sameProjectOrder(a, b []desktopProject) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Root != b[i].Root {
+			return false
+		}
+	}
+	return true
 }
 
 func uniqueStrings(values []string) []string {
@@ -3383,67 +3467,86 @@ func addProject(root, title string) error {
 		return fmt.Errorf("project root is required")
 	}
 	title = strings.TrimSpace(title)
-	f := loadProjectsFile()
-	for i, p := range f.Projects {
-		if p.Root == root {
-			if title != "" {
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		for i, p := range f.Projects {
+			if p.Root == root {
+				if title == "" || f.Projects[i].Title == title {
+					return false, nil
+				}
 				f.Projects[i].Title = title
+				return true, nil
 			}
-			return saveProjectsFile(f)
 		}
-	}
-	f.Projects = append(f.Projects, desktopProject{Root: root, Title: title})
-	return saveProjectsFile(f)
+		f.Projects = append(f.Projects, desktopProject{Root: root, Title: title})
+		return true, nil
+	})
 }
 
 func renameProject(root, title string) error {
 	title = strings.TrimSpace(title)
-	f := loadProjectsFile()
-	if strings.TrimSpace(root) == "" {
-		f.GlobalTitle = title
-		return saveProjectsFile(f)
-	}
 	root = normalizeProjectRoot(root)
-	for i, p := range f.Projects {
-		if p.Root == root {
-			f.Projects[i].Title = title
-			return saveProjectsFile(f)
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		if root == "" {
+			if f.GlobalTitle == title {
+				return false, nil
+			}
+			f.GlobalTitle = title
+			return true, nil
 		}
-	}
-	f.Projects = append(f.Projects, desktopProject{Root: root, Title: title})
-	return saveProjectsFile(f)
+		for i, p := range f.Projects {
+			if p.Root == root {
+				if f.Projects[i].Title == title {
+					return false, nil
+				}
+				f.Projects[i].Title = title
+				return true, nil
+			}
+		}
+		f.Projects = append(f.Projects, desktopProject{Root: root, Title: title})
+		return true, nil
+	})
 }
 
 func setProjectColor(root, color string) error {
 	root = normalizeProjectRoot(root)
 	color = normalizeProjectColor(color)
-	if root == "" {
-		f := loadProjectsFile()
-		f.GlobalColor = color
-		return saveProjectsFile(f)
-	}
-	f := loadProjectsFile()
-	for i, p := range f.Projects {
-		if p.Root == root {
-			f.Projects[i].Color = color
-			return saveProjectsFile(f)
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		if root == "" {
+			if f.GlobalColor == color {
+				return false, nil
+			}
+			f.GlobalColor = color
+			return true, nil
 		}
-	}
-	f.Projects = append(f.Projects, desktopProject{Root: root, Color: color})
-	return saveProjectsFile(f)
+		for i, p := range f.Projects {
+			if p.Root == root {
+				if f.Projects[i].Color == color {
+					return false, nil
+				}
+				f.Projects[i].Color = color
+				return true, nil
+			}
+		}
+		f.Projects = append(f.Projects, desktopProject{Root: root, Color: color})
+		return true, nil
+	})
 }
 
 func removeProject(root string) error {
 	root = normalizeProjectRoot(root)
-	f := loadProjectsFile()
-	projects := make([]desktopProject, 0, len(f.Projects))
-	for _, p := range f.Projects {
-		if p.Root != root {
-			projects = append(projects, p)
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		projects := make([]desktopProject, 0, len(f.Projects))
+		for _, p := range f.Projects {
+			if p.Root != root {
+				projects = append(projects, p)
+			}
 		}
-	}
-	f.Projects = projects
-	return saveProjectsFile(f)
+		if len(projects) == len(f.Projects) {
+			return false, nil
+		}
+		f.Projects = projects
+		return true, nil
+	})
 }
 
 // --- topic helpers ----------------------------------------------------------
@@ -3753,19 +3856,7 @@ func ensureTopicIndexed(scope, workspaceRoot, topicID, title, source string) err
 	if err := setTopicTitleWithSource(workspaceRoot, topicID, title, source); err != nil {
 		return err
 	}
-	f := loadProjectsFile()
-	if workspaceRoot == "" {
-		f.GlobalTopics = prependUniqueString(f.GlobalTopics, topicID)
-		return saveProjectsFile(f)
-	}
-	for i, p := range f.Projects {
-		if p.Root == workspaceRoot {
-			f.Projects[i].Topics = prependUniqueString(p.Topics, topicID)
-			return saveProjectsFile(f)
-		}
-	}
-	f.Projects = append(f.Projects, desktopProject{Root: workspaceRoot, Topics: []string{topicID}})
-	return saveProjectsFile(f)
+	return prependTopicInProjectsFile(workspaceRoot, topicID, true)
 }
 
 // --- telemetry --------------------------------------------------------------
@@ -4043,19 +4134,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		}
 		return nil
 	}
-	f := loadProjectsFile()
-	if scope == "global" {
-		f.GlobalTopics = uniqueStrings(append(migratedTopicIDs, f.GlobalTopics...))
-	} else {
-		// Find the project entry and add topics.
-		for i, p := range f.Projects {
-			if p.Root == workspaceRoot {
-				f.Projects[i].Topics = uniqueStrings(append(migratedTopicIDs, f.Projects[i].Topics...))
-				break
-			}
-		}
-	}
-	_ = saveProjectsFile(f)
+	_ = prependTopicsInProjectsFile(workspaceRoot, migratedTopicIDs, false)
 	if topicTitles != nil {
 		_ = saveTopicTitles(topicTitleRoot, topicTitles)
 	}
@@ -4165,33 +4244,16 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 		return err
 	}
 
-	f := loadProjectsFile()
 	if scope == "global" {
-		f.GlobalTopics = prependUniqueString(f.GlobalTopics, topicID)
 		meta.Scope = "global"
 		meta.WorkspaceRoot = ""
 	} else {
-		found := false
-		for i, p := range f.Projects {
-			if p.Root != workspaceRoot {
-				continue
-			}
-			f.Projects[i].Topics = prependUniqueString(p.Topics, topicID)
-			found = true
-			break
-		}
-		if !found {
-			f.Projects = append(f.Projects, desktopProject{
-				Root:   workspaceRoot,
-				Topics: []string{topicID},
-			})
-		}
 		meta.Scope = "project"
 		meta.WorkspaceRoot = workspaceRoot
 	}
 	meta.TopicID = topicID
 	meta.TopicTitle = title
-	if err := saveProjectsFile(f); err != nil {
+	if err := prependTopicInProjectsFile(workspaceRoot, topicID, scope == "project"); err != nil {
 		return err
 	}
 	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, meta); err != nil {
@@ -4274,7 +4336,6 @@ func (a *App) CreateTopic(scope, workspaceRoot, title string) (TopicMeta, error)
 		if abs, err := filepath.Abs(workspaceRoot); err == nil {
 			workspaceRoot = abs
 		}
-		_ = addProject(workspaceRoot, "")
 	}
 	if err := setTopicTitleWithSource(workspaceRoot, topicID, trimmedTitle, titleSource); err != nil {
 		return TopicMeta{}, err
@@ -4284,19 +4345,7 @@ func (a *App) CreateTopic(scope, workspaceRoot, title string) (TopicMeta, error)
 	}
 	// New topics should appear first in their project/global group so the item
 	// just created is immediately visible and selected in the sidebar.
-	f := loadProjectsFile()
-	if workspaceRoot == "" {
-		f.GlobalTopics = prependUniqueString(f.GlobalTopics, topicID)
-		_ = saveProjectsFile(f)
-	} else {
-		for i, p := range f.Projects {
-			if p.Root == workspaceRoot {
-				f.Projects[i].Topics = prependUniqueString(p.Topics, topicID)
-				_ = saveProjectsFile(f)
-				break
-			}
-		}
-	}
+	_ = prependTopicInProjectsFile(workspaceRoot, topicID, workspaceRoot != "")
 	a.emitProjectTreeChanged()
 	return TopicMeta{ID: topicID, Title: trimmedTitle, CreatedAt: createdAt}, nil
 }
@@ -4328,23 +4377,27 @@ func (a *App) SetProjectPinned(workspaceRoot string, pinned bool) error {
 	if root == "" {
 		return fmt.Errorf("workspaceRoot is required")
 	}
-	f := loadProjectsFile()
-	found := false
-	for _, project := range f.Projects {
-		if project.Root == root {
-			found = true
-			break
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		found := false
+		for _, project := range f.Projects {
+			if project.Root == root {
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		return fmt.Errorf("project %q not found", root)
-	}
-	if pinned {
-		f.PinnedProjects = prependUniqueString(f.PinnedProjects, root)
-	} else {
-		f.PinnedProjects = removeString(f.PinnedProjects, root)
-	}
-	if err := saveProjectsFile(f); err != nil {
+		if !found {
+			return false, fmt.Errorf("project %q not found", root)
+		}
+		next := removeString(f.PinnedProjects, root)
+		if pinned {
+			next = prependUniqueString(f.PinnedProjects, root)
+		}
+		if sameStringList(next, f.PinnedProjects) {
+			return false, nil
+		}
+		f.PinnedProjects = next
+		return true, nil
+	}); err != nil {
 		return err
 	}
 	a.emitProjectTreeChanged()
@@ -4354,48 +4407,56 @@ func (a *App) SetProjectPinned(workspaceRoot string, pinned bool) error {
 // ReorderProjects persists the user-defined order of project folders and,
 // when present, the virtual Global sidebar section.
 func (a *App) ReorderProjects(workspaceRoots []string) error {
-	f := loadProjectsFile()
-	byRoot := make(map[string]desktopProject, len(f.Projects))
-	for _, project := range f.Projects {
-		byRoot[project.Root] = project
-	}
-	seen := make(map[string]bool, len(workspaceRoots))
-	next := make([]desktopProject, 0, len(workspaceRoots))
-	sidebarOrder := make([]string, 0, len(workspaceRoots))
-	hasGlobalOrder := false
-	for _, root := range workspaceRoots {
-		root = strings.TrimSpace(root)
-		if root == desktopGlobalOrderToken {
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		byRoot := make(map[string]desktopProject, len(f.Projects))
+		for _, project := range f.Projects {
+			byRoot[project.Root] = project
+		}
+		seen := make(map[string]bool, len(workspaceRoots))
+		next := make([]desktopProject, 0, len(workspaceRoots))
+		sidebarOrder := make([]string, 0, len(workspaceRoots))
+		hasGlobalOrder := false
+		for _, root := range workspaceRoots {
+			root = strings.TrimSpace(root)
+			if root == desktopGlobalOrderToken {
+				if seen[root] {
+					return false, fmt.Errorf("duplicate global section")
+				}
+				seen[root] = true
+				hasGlobalOrder = true
+				sidebarOrder = append(sidebarOrder, root)
+				continue
+			}
+			root = normalizeProjectRoot(root)
+			project, ok := byRoot[root]
+			if !ok {
+				return false, fmt.Errorf("project %q not found", root)
+			}
 			if seen[root] {
-				return fmt.Errorf("duplicate global section")
+				return false, fmt.Errorf("duplicate project %q", root)
 			}
 			seen[root] = true
-			hasGlobalOrder = true
+			next = append(next, project)
 			sidebarOrder = append(sidebarOrder, root)
-			continue
 		}
-		root = normalizeProjectRoot(root)
-		project, ok := byRoot[root]
-		if !ok {
-			return fmt.Errorf("project %q not found", root)
+		if len(next) != len(f.Projects) {
+			return false, fmt.Errorf("project order length mismatch")
 		}
-		if seen[root] {
-			return fmt.Errorf("duplicate project %q", root)
+		changed := !sameProjectOrder(next, f.Projects)
+		f.Projects = next
+		if hasGlobalOrder {
+			if !sameStringList(sidebarOrder, f.SidebarOrder) {
+				changed = true
+			}
+			f.SidebarOrder = sidebarOrder
+		} else {
+			if len(f.SidebarOrder) > 0 {
+				changed = true
+			}
+			f.SidebarOrder = nil
 		}
-		seen[root] = true
-		next = append(next, project)
-		sidebarOrder = append(sidebarOrder, root)
-	}
-	if len(next) != len(f.Projects) {
-		return fmt.Errorf("project order length mismatch")
-	}
-	f.Projects = next
-	if hasGlobalOrder {
-		f.SidebarOrder = sidebarOrder
-	} else {
-		f.SidebarOrder = nil
-	}
-	if err := saveProjectsFile(f); err != nil {
+		return changed, nil
+	}); err != nil {
 		return err
 	}
 	a.emitProjectTreeChanged()
@@ -4590,26 +4651,15 @@ func (a *App) DeleteTopic(topicID string) error {
 				return err
 			}
 			deleteTopicCreatedAt("", topicID)
-			f.GlobalTopics = removeString(f.GlobalTopics, topicID)
-			f.GlobalPinnedTopics = removeString(f.GlobalPinnedTopics, topicID)
 			found = true
 		}
 	}
 	if !found {
 		return fmt.Errorf("topic %q not found", topicID)
 	}
-	// Remove from project topic list.
-	f.GlobalPinnedTopics = removeString(f.GlobalPinnedTopics, topicID)
-	for i, p := range f.Projects {
-		for j, tid := range p.Topics {
-			if tid == topicID {
-				f.Projects[i].Topics = append(f.Projects[i].Topics[:j], f.Projects[i].Topics[j+1:]...)
-				break
-			}
-		}
-		f.Projects[i].PinnedTopics = removeString(f.Projects[i].PinnedTopics, topicID)
+	if err := removeTopicFromProjectsFile(topicID); err != nil {
+		return err
 	}
-	_ = saveProjectsFile(f)
 	a.emitProjectTreeChanged()
 	return nil
 }
@@ -4621,33 +4671,36 @@ func (a *App) SetTopicPinned(topicID string, pinned bool) error {
 	if topicID == "" {
 		return fmt.Errorf("topicID is required")
 	}
-	f := loadProjectsFile()
-	for i, p := range f.Projects {
-		m := loadTopicTitles(p.Root)
-		if _, ok := m[topicID]; !ok && !containsDesktopString(p.Topics, topicID) {
-			continue
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		for i, p := range f.Projects {
+			m := loadTopicTitles(p.Root)
+			if _, ok := m[topicID]; !ok && !containsDesktopString(p.Topics, topicID) {
+				continue
+			}
+			next := removeString(f.Projects[i].PinnedTopics, topicID)
+			if pinned {
+				next = prependUniqueString(f.Projects[i].PinnedTopics, topicID)
+			}
+			if sameStringList(next, f.Projects[i].PinnedTopics) {
+				return false, nil
+			}
+			f.Projects[i].PinnedTopics = next
+			return true, nil
 		}
+		globalTitles := loadTopicTitles("")
+		if _, ok := globalTitles[topicID]; !ok && !containsDesktopString(f.GlobalTopics, topicID) {
+			return false, fmt.Errorf("topic %q not found", topicID)
+		}
+		next := removeString(f.GlobalPinnedTopics, topicID)
 		if pinned {
-			f.Projects[i].PinnedTopics = prependUniqueString(f.Projects[i].PinnedTopics, topicID)
-		} else {
-			f.Projects[i].PinnedTopics = removeString(f.Projects[i].PinnedTopics, topicID)
+			next = prependUniqueString(f.GlobalPinnedTopics, topicID)
 		}
-		if err := saveProjectsFile(f); err != nil {
-			return err
+		if sameStringList(next, f.GlobalPinnedTopics) {
+			return false, nil
 		}
-		a.emitProjectTreeChanged()
-		return nil
-	}
-	globalTitles := loadTopicTitles("")
-	if _, ok := globalTitles[topicID]; !ok && !containsDesktopString(f.GlobalTopics, topicID) {
-		return fmt.Errorf("topic %q not found", topicID)
-	}
-	if pinned {
-		f.GlobalPinnedTopics = prependUniqueString(f.GlobalPinnedTopics, topicID)
-	} else {
-		f.GlobalPinnedTopics = removeString(f.GlobalPinnedTopics, topicID)
-	}
-	if err := saveProjectsFile(f); err != nil {
+		f.GlobalPinnedTopics = next
+		return true, nil
+	}); err != nil {
 		return err
 	}
 	a.emitProjectTreeChanged()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2776,6 +2776,7 @@ func topicTitleFromText(text string) string {
 const desktopProjectsFile = "desktop-projects.json"
 const tabsFileName = "desktop-tabs.json"
 const desktopGlobalOrderToken = "__global__"
+const legacyProjectSidebarRecoveryMarker = "desktop-projects-legacy-recovered"
 
 type desktopProject struct {
 	Root         string   `json:"root"`
@@ -2987,6 +2988,62 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 		add(project.Root)
 	}
 	return roots
+}
+
+func recoverLegacyProjectSidebarRoots(tabs desktopTabsFile) (bool, error) {
+	markerPath := filepath.Join(desktopConfigDir(), legacyProjectSidebarRecoveryMarker)
+	if _, err := os.Stat(markerPath); err == nil {
+		return false, nil
+	}
+
+	f := loadProjectsFile()
+	seen := map[string]bool{}
+	for _, project := range f.Projects {
+		root := normalizeProjectRoot(project.Root)
+		if root != "" {
+			seen[root] = true
+		}
+	}
+
+	changed := false
+	add := func(root string) {
+		root = normalizeProjectRoot(root)
+		if root == "" || seen[root] || !existingDirectory(root) {
+			return
+		}
+		seen[root] = true
+		f.Projects = append(f.Projects, desktopProject{Root: root})
+		changed = true
+	}
+	if cur := loadWorkspace(); cur != "" {
+		add(cur)
+	}
+	for _, root := range loadWorkspaces() {
+		add(root)
+	}
+	for _, entry := range tabs.Tabs {
+		if entry.Scope == "project" {
+			add(entry.WorkspaceRoot)
+		}
+	}
+	if changed {
+		if err := saveProjectsFile(f); err != nil {
+			return false, err
+		}
+	}
+	return changed, writeLegacyProjectSidebarRecoveryMarker(markerPath)
+}
+
+func existingDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func writeLegacyProjectSidebarRecoveryMarker(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte("ok\n"), 0o644)
 }
 
 func loadProjectsFile() desktopProjectFile {

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -187,6 +187,70 @@ func TestRecoverLegacyProjectSidebarRootsPreservesUpgradeProjects(t *testing.T) 
 	}
 }
 
+func TestProjectFileUpdatesSerializeReadModifyWrite(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	active := t.TempDir()
+	added := t.TempDir()
+
+	if err := saveProjectsFile(desktopProjectFile{Projects: []desktopProject{{Root: active, Title: "Active"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	updateErr := make(chan error, 1)
+	go func() {
+		updateErr <- updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+			close(entered)
+			<-release
+			for i, project := range f.Projects {
+				if project.Root == normalizeProjectRoot(active) {
+					f.Projects[i].Title = "Active edited"
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+	}()
+	<-entered
+
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- addProject(added, "Added")
+	}()
+	select {
+	case err := <-addErr:
+		t.Fatalf("addProject completed while another project update was in progress: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(release)
+	if err := <-updateErr; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-addErr; err != nil {
+		t.Fatal(err)
+	}
+
+	projects := loadProjectsFile().Projects
+	if len(projects) != 2 {
+		t.Fatalf("project count = %d, want 2: %+v", len(projects), projects)
+	}
+	if projects[0].Root != normalizeProjectRoot(active) || projects[0].Title != "Active edited" {
+		t.Fatalf("active project was not preserved with edited title: %+v", projects)
+	}
+	if projects[1].Root != normalizeProjectRoot(added) || projects[1].Title != "Added" {
+		t.Fatalf("concurrent project add was lost: %+v", projects)
+	}
+
+	if err := addProject(active, ""); err != nil {
+		t.Fatal(err)
+	}
+	projects = loadProjectsFile().Projects
+	if len(projects) != 2 || projects[1].Root != normalizeProjectRoot(added) {
+		t.Fatalf("no-op addProject overwrote the added project: %+v", projects)
+	}
+}
+
 func TestDialogDefaultDirectoryFallsBackFromMissingWorkspace(t *testing.T) {
 	parent := t.TempDir()
 	missing := filepath.Join(parent, "deleted", "project")

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -110,6 +110,83 @@ func TestDesktopMCPMigrationRootsIncludesLegacyWorkspaces(t *testing.T) {
 	}
 }
 
+func TestRecoverLegacyProjectSidebarRootsPreservesUpgradeProjects(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	existing := t.TempDir()
+	active := t.TempDir()
+	legacy := t.TempDir()
+	tabRoot := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	if err := saveProjectsFile(desktopProjectFile{Projects: []desktopProject{{Root: existing, Title: "Existing"}}}); err != nil {
+		t.Fatal(err)
+	}
+	saveWorkspace(active)
+	if err := os.MkdirAll(filepath.Dir(workspaceListPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal([]string{legacy, active, missing, legacy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workspaceListPath(), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tabs := desktopTabsFile{
+		Tabs: []desktopTabEntry{
+			{Scope: "project", WorkspaceRoot: tabRoot},
+			{Scope: "project", WorkspaceRoot: missing},
+			{Scope: "global"},
+		},
+	}
+	changed, err := recoverLegacyProjectSidebarRoots(tabs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("recoverLegacyProjectSidebarRoots should add missing legacy projects")
+	}
+
+	projects := loadProjectsFile().Projects
+	want := []string{
+		normalizeProjectRoot(existing),
+		normalizeProjectRoot(active),
+		normalizeProjectRoot(legacy),
+		normalizeProjectRoot(tabRoot),
+	}
+	if len(projects) != len(want) {
+		t.Fatalf("project count = %d, want %d: %+v", len(projects), len(want), projects)
+	}
+	for i, root := range want {
+		if projects[i].Root != root {
+			t.Fatalf("projects[%d].Root = %q, want %q; projects=%+v", i, projects[i].Root, root, projects)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(desktopConfigDir(), legacyProjectSidebarRecoveryMarker)); err != nil {
+		t.Fatalf("recovery marker was not written: %v", err)
+	}
+
+	if err := removeProject(legacy); err != nil {
+		t.Fatal(err)
+	}
+	changed, err = recoverLegacyProjectSidebarRoots(tabs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("recovery should be one-shot after the marker is written")
+	}
+	for _, project := range loadProjectsFile().Projects {
+		if project.Root == normalizeProjectRoot(legacy) {
+			t.Fatalf("removed legacy project was restored after marker: %+v", loadProjectsFile().Projects)
+		}
+		if project.Root == normalizeProjectRoot(missing) {
+			t.Fatalf("missing legacy project should not be restored: %+v", loadProjectsFile().Projects)
+		}
+	}
+}
+
 func TestDialogDefaultDirectoryFallsBackFromMissingWorkspace(t *testing.T) {
 	parent := t.TempDir()
 	missing := filepath.Join(parent, "deleted", "project")


### PR DESCRIPTION
## Summary
- Recover legacy project roots into `desktop-projects.json` once during desktop startup.
- Serialize all runtime read-modify-write updates to `desktop-projects.json` through a single project-index update helper.
- Make no-op project ensures avoid writing stale project snapshots, so adding a project back to the sidebar is not lost by later activity in another project.
- Keep duplicate/missing legacy roots from polluting the upgrade recovery and keep the recovery one-shot so removed projects are not restored repeatedly.

## Why
Users upgrading from 1.13.x to 1.14.x can end up with fewer project folders visible in the sidebar when the newer project index does not include legacy workspace roots. A second failure mode can remove a manually restored project again: one project action can read an older `desktop-projects.json` snapshot, another action adds a project, and the first action then writes the stale snapshot back.

This PR preserves the workspace/session binding fixes while making legacy project roots visible again and preventing stale project-index writes from dropping manually restored folders.

## Verification
- `git diff --check`
- `cd desktop && go test . -run 'TestProjectFileUpdatesSerializeReadModifyWrite|TestRecoverLegacyProjectSidebarRootsPreservesUpgradeProjects|TestDesktopMCPMigrationRootsIncludesLegacyWorkspaces|TestSaveWorkspaceOnlyRemembersLastWorkspace' -count=1`
- `cd desktop && go test . -run 'TestListProjectTree|TestSwitchWorkspaceRegistersDefaultTopicInProjectTree|TestSingleSurfaceTabsFile|TestProjectFileUpdatesSerializeReadModifyWrite|TestRecoverLegacyProjectSidebarRootsPreservesUpgradeProjects' -count=1`
- `cd desktop && go test .`
