### PR TITLE
ci(accounts): auto-deploy id.reasonix.io on merge to main-v2

### DIFF
--- a/.github/workflows/deploy-accounts-worker.yml
+++ b/.github/workflows/deploy-accounts-worker.yml
@@ -1,0 +1,38 @@
+name: Deploy accounts worker
+
+on:
+  push:
+    branches: [main-v2]
+    paths:
+      - 'workers/accounts/**'
+      - '.github/workflows/deploy-accounts-worker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-accounts-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: workers/accounts/pnpm-lock.yaml
+      - name: Deploy
+        working-directory: workers/accounts
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm install --frozen-lockfile
+          npx wrangler deploy

--- a/workers/accounts/README.md
+++ b/workers/accounts/README.md
@@ -88,3 +88,9 @@ wrangler deploy
 
 The `id.reasonix.io` custom domain route is declared in `wrangler.toml`; point the
 DNS/custom-domain binding at this worker in the Cloudflare dashboard on first deploy.
+
+The steps above are the one-time bootstrap. After that, every merge to `main-v2`
+that touches `workers/accounts/**` redeploys via `.github/workflows/deploy-accounts-worker.yml`
+(same pattern as the crash worker). CI does **not** run migrations or set secrets —
+apply new migrations with `pnpm db:apply:remote` and rotate secrets with `wrangler secret put`
+out of band.

--- a/workers/accounts/wrangler.toml
+++ b/workers/accounts/wrangler.toml
@@ -22,7 +22,9 @@ COOKIE_DOMAIN = ".reasonix.io"
 # "stub" logs email links to the worker console (local dev); "resend" sends real
 # mail via RESEND_API_KEY.
 EMAIL_PROVIDER = "resend"
-MAIL_FROM = "Reasonix <no-reply@reasonix.io>"
+# From-domain must match a verified Resend domain — send.reasonix.io is verified
+# (DKIM), the apex is not, and Resend rejects sends from an unverified domain.
+MAIL_FROM = "Reasonix <no-reply@send.reasonix.io>"
 # Comma-separated emails minted as admins on first sign-up.
 ADMIN_EMAILS = ""
 


### PR DESCRIPTION
## What

Adds `deploy-accounts-worker.yml` so the accounts worker (`id.reasonix.io`)
redeploys automatically on merge to `main-v2`, path-filtered to
`workers/accounts/**`. Mirrors the existing crash-worker pipeline, using the
repo's standard pnpm setup (`pnpm/action-setup@v6` + `setup-node` with pnpm
cache).

## Why

The accounts worker was added with a provisioned D1 and a full auth API but no
deploy pipeline — only the crash worker had one. Without this, `id.reasonix.io`
can't ship from CI. This is the first step of activating the account system
(web login UI, then CLI/desktop device-flow login land on top).

## Verification

- `pnpm install --frozen-lockfile` — clean, lockfile consistent (no
  `ERR_PNPM_OUTDATED_LOCKFILE`).
- `wrangler deploy --dry-run` — worker compiles (221 KiB / 45 KiB gzip); all
  bindings resolve (D1 `reasonix-accounts`, `AUTH_LIMITER` ratelimit, env vars).

## One-time bootstrap (out of band, not run by CI)

Same posture as the crash worker — CI deploys code only:

- `pnpm db:apply:remote` to apply migrations
- `wrangler secret put SESSION_PEPPER` (+ `RESEND_API_KEY` for real email)
- set `ADMIN_EMAILS` in `wrangler.toml`
- bind the `id.reasonix.io` custom domain in the Cloudflare dashboard

## ⚠️ Action needed before first green deploy

Confirm the `CLOUDFLARE_API_TOKEN` secret is scoped for **this** worker: the
`reasonix-accounts` D1 database and the `id.reasonix.io` Workers route (the
crash-worker token may only cover the crash resources).
