### PR TITLE
feat(accounts): device-authorization sign-in for CLI/desktop

### DIFF
--- a/workers/accounts/README.md
+++ b/workers/accounts/README.md
@@ -15,18 +15,26 @@ src/
   app.ts              middleware + route wiring
   env.ts  types.ts  config.ts
   auth/   crypto.ts (PBKDF2 + token hashing)  cookies.ts (session cookie)
-  db/     users.ts  sessions.ts  emailTokens.ts  index.ts (repos factory)
+  db/     users.ts  sessions.ts  emailTokens.ts  deviceGrants.ts  index.ts (repos factory)
   email/  index.ts (Mailer + templates)  resend.ts  types.ts
-  http/   errors.ts  cors.ts  auth.ts (session middleware)  ratelimit.ts
+  http/   errors.ts  cors.ts  auth.ts (cookie + Bearer session)  ratelimit.ts
   lib/    validation.ts (zod)  handle.ts
-  routes/ auth.ts  me.ts  users.ts  health.ts
+  routes/ auth.ts  device.ts  me.ts  users.ts  health.ts
 ```
 
 Design notes:
 
 - **Sessions store `sha256(pepper:token)`** — the raw token only ever lives in the
-  cookie, so a DB read can't resurrect a live session. `sessions.kind` (`web`/`cli`)
-  is reserved so the future desktop/CLI device-flow login reuses this table.
+  cookie (web) or the client's credential store (CLI/desktop), so a DB read can't
+  resurrect a live session. Protected routes accept the session from the `rxid`
+  cookie or an `Authorization: Bearer <token>` header, so the same table serves
+  both surfaces (`sessions.kind` = `web` | `cli`).
+- **Device sign-in (RFC 8628-style)** lets the CLI/desktop authenticate without a
+  browser redirect: `/device/start` issues a `device_code` (polled) and a short
+  `user_code` (the human approves it on `APP_ORIGIN/device` while signed in). Only
+  the device code's peppered hash is stored; the `cli` session token is minted on
+  the winning poll (an atomic `DELETE … RETURNING` claim), so it never lands in the
+  DB. Polling isn't IP-limited — a `slow_down` hint plus the 10-minute TTL bound it.
 - **`password_hash` is nullable** on `users` so OAuth-only identities can be added
   later without a rebuild.
 - **Registration is enumeration-safe**: the response never reveals whether an email
@@ -45,7 +53,12 @@ Design notes:
 | POST   | `/auth/forgot`             | —    | `{ email }` → reset link                |
 | POST   | `/auth/reset`              | —    | `{ token, password }`                    |
 | POST   | `/auth/resend-verification`| —    | `{ email }`                              |
-| GET    | `/me`                      | ✓    | the signed-in account                   |
+| POST   | `/device/start`            | —    | CLI begins sign-in → `{ deviceCode, userCode, verificationUri, interval, expiresIn }` |
+| POST   | `/device/poll`             | —    | `{ deviceCode }` → `authorization_pending` \| `slow_down` \| `{ sessionToken, user }` |
+| GET    | `/device/info?userCode=`   | ✓    | approval screen: what a `user_code` will authorize |
+| POST   | `/device/approve`          | ✓    | `{ userCode }` — bind the pending grant to the signed-in user |
+| POST   | `/device/deny`             | ✓    | `{ userCode }` — reject the pending grant |
+| GET    | `/me`                      | ✓    | the signed-in account (cookie or Bearer) |
 | PATCH  | `/me`                      | ✓    | `{ displayName?, bio?, avatarUrl?, handle? }` |
 | POST   | `/me/password`             | ✓    | `{ currentPassword, newPassword }`      |
 | DELETE | `/me`                      | ✓    | soft-delete the account                 |

--- a/workers/accounts/migrations/0002_device_grants.sql
+++ b/workers/accounts/migrations/0002_device_grants.sql
@@ -1,0 +1,17 @@
+-- Device authorization grants (RFC 8628-style) for CLI/desktop sign-in.
+-- Apply: wrangler d1 migrations apply reasonix-accounts --local   (or --remote)
+
+CREATE TABLE IF NOT EXISTS device_grants (
+  device_code_hash TEXT    PRIMARY KEY,             -- sha256(pepper:device_code); the raw code lives only on the client
+  user_code        TEXT    NOT NULL UNIQUE,         -- canonical (no separators, upper) code the human types to approve
+  user_id          INTEGER,                          -- null until approved
+  status           TEXT    NOT NULL DEFAULT 'pending', -- pending | approved | denied
+  kind             TEXT    NOT NULL DEFAULT 'cli',   -- session kind minted on claim (web | cli)
+  user_agent       TEXT    NOT NULL DEFAULT '',
+  created_at       TEXT    NOT NULL,
+  last_polled_at   TEXT,                              -- drives the slow_down hint
+  approved_at      TEXT,
+  expires_at       TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS device_grants_user_code ON device_grants (user_code);
+CREATE INDEX IF NOT EXISTS device_grants_expires ON device_grants (expires_at);

--- a/workers/accounts/src/app.ts
+++ b/workers/accounts/src/app.ts
@@ -5,6 +5,7 @@ import { loadUser } from "./http/auth";
 import { errorHandler, notFoundHandler } from "./http/errors";
 import health from "./routes/health";
 import auth from "./routes/auth";
+import device from "./routes/device";
 import me from "./routes/me";
 import users from "./routes/users";
 
@@ -18,6 +19,7 @@ app.use("*", loadUser);
 
 app.route("/", health);
 app.route("/auth", auth);
+app.route("/device", device);
 app.route("/me", me);
 app.route("/u", users);
 

--- a/workers/accounts/src/auth/crypto.ts
+++ b/workers/accounts/src/auth/crypto.ts
@@ -63,6 +63,21 @@ export function hashToken(pepper: string, token: string): Promise<string> {
   return sha256Hex(`${pepper}:${token}`);
 }
 
+// Crockford base32 (no I/L/O/U) so a spoken or hand-typed device code has no
+// ambiguous characters.
+const USER_CODE_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+// A canonical 8-char user code for the device-authorization flow. 40 bits of
+// entropy; the pending window is tiny and short-lived and approval is
+// auth-gated + rate-limited, so guessing is impractical. `byte & 31` is unbiased
+// because 256 is an exact multiple of the 32-symbol alphabet.
+export function generateUserCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  let s = "";
+  for (const byte of bytes) s += USER_CODE_ALPHABET[byte & 31];
+  return s;
+}
+
 // A short random suffix for handle generation. Hex-encodes crypto bytes (a
 // bijection — no modulo, so no bias) and trims to length. Hex digits are all
 // valid handle characters.

--- a/workers/accounts/src/config.ts
+++ b/workers/accounts/src/config.ts
@@ -6,6 +6,10 @@ export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const VERIFY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const RESET_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// Device-authorization flow (CLI/desktop sign-in).
+export const DEVICE_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes to approve
+export const DEVICE_POLL_INTERVAL_S = 5; // client poll cadence; faster polls get slow_down
+
 // PBKDF2-HMAC-SHA256 work factor. Cloudflare Workers hard-caps PBKDF2 at 100k
 // iterations (it throws NotSupportedError above that), so this is the platform
 // ceiling. The value is embedded in each stored hash, so it can be raised later

--- a/workers/accounts/src/db/deviceGrants.ts
+++ b/workers/accounts/src/db/deviceGrants.ts
@@ -1,0 +1,157 @@
+import { generateToken, generateUserCode, hashToken } from "../auth/crypto";
+import { DEVICE_POLL_INTERVAL_S } from "../config";
+
+export type DeviceGrantStatus = "pending" | "approved" | "denied";
+export type SessionKind = "web" | "cli";
+
+export interface StartedGrant {
+  deviceCode: string;
+  userCode: string;
+  expiresAt: string;
+}
+
+export interface DeviceGrantInfo {
+  userCode: string;
+  userAgent: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface ClaimedGrant {
+  userId: number;
+  kind: SessionKind;
+  userAgent: string;
+}
+
+export type PollStatus =
+  | { kind: "pending"; slowDown: boolean }
+  | { kind: "denied" }
+  | { kind: "expired" }
+  | { kind: "not_found" };
+
+// Strip separators/whitespace and upper-case so a user code typed as "wdjb-mjht"
+// or "WDJB MJHT" matches the canonical form stored at issue time.
+export function normalizeUserCode(raw: string): string {
+  return raw.replace(/[^0-9a-zA-Z]/g, "").toUpperCase();
+}
+
+// Present a canonical code as two hyphen-separated groups for readability.
+export function formatUserCode(canonical: string): string {
+  const mid = Math.ceil(canonical.length / 2);
+  return `${canonical.slice(0, mid)}-${canonical.slice(mid)}`;
+}
+
+export class DeviceGrantRepo {
+  constructor(
+    private readonly db: D1Database,
+    private readonly pepper: string,
+  ) {}
+
+  // Issues a pending grant. Returns the raw device_code (for the client to poll)
+  // and the canonical user_code (for the human to approve); only the device
+  // code's peppered hash is stored, mirroring sessions/email tokens.
+  async start(opts: { userAgent?: string; ttlMs: number; kind?: SessionKind }): Promise<StartedGrant> {
+    const deviceCode = generateToken();
+    const deviceCodeHash = await hashToken(this.pepper, deviceCode);
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + opts.ttlMs).toISOString();
+    const userAgent = (opts.userAgent ?? "").slice(0, 256);
+    const kind: SessionKind = opts.kind ?? "cli";
+    for (let attempt = 0; ; attempt++) {
+      const userCode = generateUserCode();
+      try {
+        await this.db
+          .prepare(
+            `INSERT INTO device_grants (device_code_hash, user_code, status, kind, user_agent, created_at, expires_at)
+             VALUES (?1, ?2, 'pending', ?3, ?4, ?5, ?6)`,
+          )
+          .bind(deviceCodeHash, userCode, kind, userAgent, now.toISOString(), expiresAt)
+          .run();
+        return { deviceCode, userCode, expiresAt };
+      } catch (err) {
+        if (attempt >= 4) throw err; // exhausted user_code collision retries
+      }
+    }
+  }
+
+  // Safe display metadata for the approval screen; only a live pending grant is
+  // revealed, so an expired or already-decided code looks unknown.
+  async info(userCode: string): Promise<DeviceGrantInfo | null> {
+    const now = new Date().toISOString();
+    const row = await this.db
+      .prepare(
+        `SELECT user_code, user_agent, created_at, expires_at FROM device_grants
+         WHERE user_code = ?1 AND status = 'pending' AND expires_at > ?2`,
+      )
+      .bind(normalizeUserCode(userCode), now)
+      .first<{ user_code: string; user_agent: string; created_at: string; expires_at: string }>();
+    if (!row) return null;
+    return { userCode: row.user_code, userAgent: row.user_agent, createdAt: row.created_at, expiresAt: row.expires_at };
+  }
+
+  // Binds a pending grant to the approving user. Returns false when the code is
+  // unknown, expired, or already decided.
+  async approve(userCode: string, userId: number): Promise<boolean> {
+    const now = new Date().toISOString();
+    const row = await this.db
+      .prepare(
+        `UPDATE device_grants SET status = 'approved', user_id = ?1, approved_at = ?2
+         WHERE user_code = ?3 AND status = 'pending' AND expires_at > ?2
+         RETURNING device_code_hash`,
+      )
+      .bind(userId, now, normalizeUserCode(userCode))
+      .first<{ device_code_hash: string }>();
+    return row !== null;
+  }
+
+  async deny(userCode: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .prepare(
+        `UPDATE device_grants SET status = 'denied'
+         WHERE user_code = ?1 AND status = 'pending' AND expires_at > ?2`,
+      )
+      .bind(normalizeUserCode(userCode), now)
+      .run();
+  }
+
+  // Atomically claims an approved grant via DELETE ... RETURNING: exactly one
+  // poll wins and gets the bound user; the row is gone afterwards so a session is
+  // minted once. The caller creates the session (this repo never sees the pepper
+  // twice). A losing poll gets null and falls through to pollStatus.
+  async claim(deviceCode: string): Promise<ClaimedGrant | null> {
+    const deviceCodeHash = await hashToken(this.pepper, deviceCode);
+    const now = new Date().toISOString();
+    const row = await this.db
+      .prepare(
+        `DELETE FROM device_grants
+         WHERE device_code_hash = ?1 AND status = 'approved' AND user_id IS NOT NULL AND expires_at > ?2
+         RETURNING user_id, kind, user_agent`,
+      )
+      .bind(deviceCodeHash, now)
+      .first<{ user_id: number; kind: SessionKind; user_agent: string }>();
+    if (!row) return null;
+    return { userId: row.user_id, kind: row.kind, userAgent: row.user_agent };
+  }
+
+  // Reports why a not-yet-claimable poll isn't complete. Prunes an expired grant.
+  async pollStatus(deviceCode: string): Promise<PollStatus> {
+    const deviceCodeHash = await hashToken(this.pepper, deviceCode);
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const row = await this.db
+      .prepare(`SELECT status, expires_at, last_polled_at FROM device_grants WHERE device_code_hash = ?1`)
+      .bind(deviceCodeHash)
+      .first<{ status: DeviceGrantStatus; expires_at: string; last_polled_at: string | null }>();
+    if (!row) return { kind: "not_found" };
+    if (row.expires_at <= nowIso) {
+      await this.db.prepare("DELETE FROM device_grants WHERE device_code_hash = ?1").bind(deviceCodeHash).run();
+      return { kind: "expired" };
+    }
+    if (row.status === "denied") return { kind: "denied" };
+    const slowDown =
+      row.last_polled_at !== null && now.getTime() - new Date(row.last_polled_at).getTime() < DEVICE_POLL_INTERVAL_S * 1000;
+    await this.db.prepare("UPDATE device_grants SET last_polled_at = ?1 WHERE device_code_hash = ?2").bind(nowIso, deviceCodeHash).run();
+    return { kind: "pending", slowDown };
+  }
+}

--- a/workers/accounts/src/db/index.ts
+++ b/workers/accounts/src/db/index.ts
@@ -2,11 +2,13 @@ import type { Bindings } from "../env";
 import { UserRepo } from "./users";
 import { SessionRepo } from "./sessions";
 import { EmailTokenRepo } from "./emailTokens";
+import { DeviceGrantRepo } from "./deviceGrants";
 
 export interface Repos {
   users: UserRepo;
   sessions: SessionRepo;
   emailTokens: EmailTokenRepo;
+  deviceGrants: DeviceGrantRepo;
 }
 
 // Builds the repository layer from request bindings. The session pepper is a
@@ -17,7 +19,8 @@ export function repos(env: Bindings): Repos {
     users: new UserRepo(env.DB),
     sessions: new SessionRepo(env.DB, pepper),
     emailTokens: new EmailTokenRepo(env.DB, pepper),
+    deviceGrants: new DeviceGrantRepo(env.DB, pepper),
   };
 }
 
-export { UserRepo, SessionRepo, EmailTokenRepo };
+export { UserRepo, SessionRepo, EmailTokenRepo, DeviceGrantRepo };

--- a/workers/accounts/src/http/auth.ts
+++ b/workers/accounts/src/http/auth.ts
@@ -6,10 +6,19 @@ import { repos } from "../db";
 import { readSessionToken } from "../auth/cookies";
 import { ApiError } from "./errors";
 
-// Resolves the session cookie (if any) and stashes the user on the context.
-// Runs for every request; never rejects.
+// Non-browser clients (CLI/desktop) carry the session in an Authorization header
+// instead of the cookie.
+function readBearerToken(c: Context<AppEnv>): string | undefined {
+  const header = c.req.header("authorization");
+  if (!header) return undefined;
+  const token = /^Bearer\s+(.+)$/i.exec(header.trim())?.[1]?.trim();
+  return token || undefined;
+}
+
+// Resolves the session (cookie or Bearer token, if any) and stashes the user on
+// the context. Runs for every request; never rejects.
 export const loadUser: MiddlewareHandler<AppEnv> = async (c, next) => {
-  const token = readSessionToken(c);
+  const token = readSessionToken(c) ?? readBearerToken(c);
   let user: AccountUser | null = null;
   if (token) {
     const row = await repos(c.env).sessions.resolve(token);

--- a/workers/accounts/src/http/cors.ts
+++ b/workers/accounts/src/http/cors.ts
@@ -14,7 +14,7 @@ export const corsMiddleware: MiddlewareHandler<AppEnv> = (c, next) => {
     origin: (origin) => (allowed.includes(origin) ? origin : null),
     credentials: true,
     allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type"],
+    allowHeaders: ["Content-Type", "Authorization"],
     maxAge: 86400,
   })(c, next);
 };

--- a/workers/accounts/src/lib/validation.ts
+++ b/workers/accounts/src/lib/validation.ts
@@ -44,6 +44,12 @@ export const PasswordChangeSchema = z.object({
   newPassword: password,
 });
 
+const userCode = z.string().trim().min(4).max(20);
+
+export const DevicePollSchema = z.object({ deviceCode: z.string().min(10).max(256) });
+export const DeviceApproveSchema = z.object({ userCode });
+export const DeviceCodeQuerySchema = z.object({ userCode });
+
 function firstIssue(error: z.ZodError): string {
   const issue = error.issues[0];
   if (!issue) return "Some fields are invalid.";

--- a/workers/accounts/src/routes/device.ts
+++ b/workers/accounts/src/routes/device.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { toAccountUser } from "../types";
+import { repos } from "../db";
+import { formatUserCode } from "../db/deviceGrants";
+import { requireAuth, currentUser } from "../http/auth";
+import { authRateLimit } from "../http/ratelimit";
+import { ApiError } from "../http/errors";
+import { parseBody, parseQuery, DevicePollSchema, DeviceApproveSchema, DeviceCodeQuerySchema } from "../lib/validation";
+import { DEVICE_CODE_TTL_MS, DEVICE_POLL_INTERVAL_S } from "../config";
+
+const device = new Hono<AppEnv>();
+
+// CLI/desktop begins sign-in: get a device code to poll and a user code the
+// human types on the web to approve. Public, throttled per IP.
+device.post("/start", authRateLimit, async (c) => {
+  const { deviceCode, userCode, expiresAt } = await repos(c.env).deviceGrants.start({
+    userAgent: c.req.header("user-agent") ?? "",
+    ttlMs: DEVICE_CODE_TTL_MS,
+    kind: "cli",
+  });
+  const base = c.env.APP_ORIGIN;
+  const display = formatUserCode(userCode);
+  return c.json({
+    deviceCode,
+    userCode: display,
+    verificationUri: `${base}/device`,
+    verificationUriComplete: `${base}/device?code=${encodeURIComponent(display)}`,
+    interval: DEVICE_POLL_INTERVAL_S,
+    expiresIn: Math.floor(DEVICE_CODE_TTL_MS / 1000),
+    expiresAt,
+  });
+});
+
+// CLI/desktop polls with its device code. Not under the per-IP limiter — polling
+// is frequent by design; the slow_down hint plus the short TTL bound abuse.
+device.post("/poll", async (c) => {
+  const { deviceCode } = await parseBody(c, DevicePollSchema);
+  const { deviceGrants, sessions, users } = repos(c.env);
+
+  const claimed = await deviceGrants.claim(deviceCode);
+  if (claimed) {
+    const row = await users.byId(claimed.userId);
+    if (!row || row.status !== "active") throw new ApiError(403, "account_unavailable", "This account is not available.");
+    const token = await sessions.create(claimed.userId, { kind: claimed.kind, userAgent: claimed.userAgent });
+    return c.json({ status: "complete", sessionToken: token, user: toAccountUser(row) });
+  }
+
+  const status = await deviceGrants.pollStatus(deviceCode);
+  switch (status.kind) {
+    case "pending":
+      return c.json({ status: status.slowDown ? "slow_down" : "authorization_pending", interval: DEVICE_POLL_INTERVAL_S });
+    case "denied":
+      throw new ApiError(403, "access_denied", "The sign-in request was denied.");
+    case "expired":
+      throw new ApiError(410, "expired_token", "This sign-in request has expired. Run login again.");
+    case "not_found":
+      throw new ApiError(400, "invalid_grant", "Unknown or already-used device code.");
+  }
+});
+
+// The approval screen (signed-in web session) fetches what it's about to
+// authorize before the user confirms.
+device.get("/info", authRateLimit, requireAuth, async (c) => {
+  const { userCode } = parseQuery(c, DeviceCodeQuerySchema);
+  const grant = await repos(c.env).deviceGrants.info(userCode);
+  if (!grant) throw new ApiError(404, "invalid_user_code", "That code is invalid or has expired.");
+  return c.json({ grant: { ...grant, userCode: formatUserCode(grant.userCode) } });
+});
+
+device.post("/approve", authRateLimit, requireAuth, async (c) => {
+  const user = currentUser(c);
+  const { userCode } = await parseBody(c, DeviceApproveSchema);
+  const ok = await repos(c.env).deviceGrants.approve(userCode, user.id);
+  if (!ok) throw new ApiError(400, "invalid_user_code", "That code is invalid or has expired. Double-check it and try again.");
+  return c.json({ ok: true });
+});
+
+device.post("/deny", authRateLimit, requireAuth, async (c) => {
+  const { userCode } = await parseBody(c, DeviceApproveSchema);
+  await repos(c.env).deviceGrants.deny(userCode);
+  return c.json({ ok: true });
+});
+
+export default device;


### PR DESCRIPTION
## What

Adds browser-less sign-in to the accounts worker so the CLI and desktop can
authenticate against `id.reasonix.io`. An RFC 8628-style device authorization
flow:

- `POST /device/start` — client gets a `device_code` (to poll) + a short
  `user_code` (the human approves it on `APP_ORIGIN/device` while signed in)
- `POST /device/poll` — returns `authorization_pending` / `slow_down`, then the
  minted `cli` session on the winning claim
- `GET /device/info` · `POST /device/approve` · `POST /device/deny` — the
  signed-in approval screen (all require a web session)

Session middleware now resolves an `Authorization: Bearer <token>` in addition
to the `rxid` cookie, so the single `sessions` table serves both `web` and `cli`
kinds (the `kind` column was already reserved for this).

## Why

The worker shipped with cookie-only web login. This is the backend half of
`reasonix login`; the CLI/desktop command and the `reasonix.io/device` approval
page land on top of it.

## Design / security

- Only the device code's peppered `sha256` is stored (same posture as sessions
  and email tokens). The raw `cli` session token is created at **claim time** via
  an atomic `DELETE … RETURNING`, so it never lands in the DB and a grant is
  claimed exactly once.
- `user_code` is 8 chars of Crockford base32 (no ambiguous I/L/O/U); input is
  normalized (strip separators, upper-case) so `wdjb-mjht` / `WDJB MJHT` match.
- `/device/poll` is intentionally not IP-rate-limited (polling is frequent); a
  `slow_down` hint plus the 10-minute TTL bound it. `start`/`approve`/`deny`/`info`
  stay under the per-IP `AUTH_LIMITER`.
- New migration `0002_device_grants.sql`.

## Verification

`tsc --noEmit` clean. Full flow exercised end-to-end against `wrangler dev` + a
local D1 (`0001`+`0002` applied):

```
login → device/start (user_code 6MZE-5B5A)
poll         → authorization_pending
info(cookie) → grant {userAgent, createdAt, expiresAt}
approve      → {ok:true}
poll         → complete {sessionToken, user}
GET /me  Authorization: Bearer <sessionToken> → the user   (cli session + Bearer OK)
poll (replay) → invalid_grant                              (one-time claim)
approve "47n9 8y84" (lower-case, space) → {ok:true}        (user_code normalized)
```

## Follow-ups (not in this PR)

- `reasonix login` / `whoami` / `logout` in the CLI + a desktop Account panel
  (they store the returned token in the credential store, keyring-first).
- The `reasonix.io/device` approval page (web PR) calls `info` → `approve`.
