### PR TITLE
feat(site): account UI — sign-in, register, profile, device approval

### DIFF
--- a/site/src/layouts/Account.astro
+++ b/site/src/layouts/Account.astro
@@ -1,0 +1,36 @@
+---
+import Base from './Base.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
+const { title, description, titleEn, titleZh, wide } = Astro.props;
+---
+<Base title={title} description={description} titleEn={titleEn} titleZh={titleZh}>
+  <header class="nav auth-nav scrolled">
+    <div class="nav-inner">
+      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
+      <div class="lang-switch" role="group" aria-label="Language" style="margin-left:auto">
+        <button type="button" data-lang="en" class="active">EN</button>
+        <button type="button" data-lang="zh">中文</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="auth-main">
+    <div class={wide ? 'auth-card wide' : 'auth-card'}>
+      <slot />
+    </div>
+  </main>
+
+  <footer>
+    <div class="foot-sub" style="border-top:none">
+      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
+      <nav class="foot-links">
+        <a href={`${base}/`}><span class="l-en">Home</span><span class="l-zh">首页</span></a>
+        <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
+        <a href={repo}>GitHub</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>import '../scripts/auth.js';</script>
+</Base>

--- a/site/src/pages/account.astro
+++ b/site/src/pages/account.astro
@@ -1,0 +1,65 @@
+---
+import Account from '../layouts/Account.astro';
+---
+<Account
+  wide
+  title="Your account — Reasonix"
+  titleEn="Your account — Reasonix"
+  titleZh="我的账号 — Reasonix"
+  description="Manage your Reasonix account.">
+  <div id="account-gate" class="auth-head">
+    <p><span class="l-en">Loading your account…</span><span class="l-zh">正在加载账号…</span></p>
+  </div>
+
+  <div id="account-view" hidden>
+    <div class="acct-id">
+      <div>
+        <div id="acct-handle" class="acct-handle"></div>
+        <div id="acct-email" class="acct-email"></div>
+      </div>
+      <span id="acct-role" class="acct-role"></span>
+    </div>
+
+    <h2 class="acct-h2"><span class="l-en">Profile</span><span class="l-zh">资料</span></h2>
+    <div id="profile-msg" class="auth-msg" hidden></div>
+    <form id="profile-form" class="auth-form" novalidate>
+      <div class="field">
+        <label for="f-displayName"><span class="l-en">Display name</span><span class="l-zh">显示名</span></label>
+        <input id="f-displayName" type="text" maxlength="80" />
+      </div>
+      <div class="field">
+        <label for="f-handle"><span class="l-en">Handle</span><span class="l-zh">用户名</span></label>
+        <input id="f-handle" type="text" minlength="3" maxlength="30" />
+        <span class="hint"><span class="l-en">Your public profile lives at /u/&lt;handle&gt;.</span><span class="l-zh">你的公开主页地址是 /u/&lt;用户名&gt;。</span></span>
+      </div>
+      <div class="field">
+        <label for="f-bio"><span class="l-en">Bio</span><span class="l-zh">简介</span></label>
+        <textarea id="f-bio" rows="3" maxlength="500"></textarea>
+      </div>
+      <div class="field">
+        <label for="f-avatarUrl"><span class="l-en">Avatar URL</span><span class="l-zh">头像链接</span></label>
+        <input id="f-avatarUrl" type="url" maxlength="500" />
+      </div>
+      <button type="submit" class="btn btn-dark"><span class="l-en">Save profile</span><span class="l-zh">保存资料</span></button>
+    </form>
+
+    <h2 class="acct-h2"><span class="l-en">Password</span><span class="l-zh">密码</span></h2>
+    <div id="password-msg" class="auth-msg" hidden></div>
+    <form id="password-form" class="auth-form" novalidate>
+      <div class="field">
+        <label for="currentPassword"><span class="l-en">Current password</span><span class="l-zh">当前密码</span></label>
+        <input id="currentPassword" type="password" autocomplete="current-password" required />
+      </div>
+      <div class="field">
+        <label for="newPassword"><span class="l-en">New password</span><span class="l-zh">新密码</span></label>
+        <input id="newPassword" type="password" autocomplete="new-password" minlength="8" required />
+      </div>
+      <button type="submit" class="btn btn-ghost"><span class="l-en">Change password</span><span class="l-zh">修改密码</span></button>
+    </form>
+
+    <div class="acct-foot">
+      <button id="logout-btn" type="button" class="btn btn-ghost"><span class="l-en">Sign out</span><span class="l-zh">退出登录</span></button>
+      <button id="delete-btn" type="button" class="acct-danger"><span class="l-en">Delete account</span><span class="l-zh">注销账号</span></button>
+    </div>
+  </div>
+</Account>

--- a/site/src/pages/device.astro
+++ b/site/src/pages/device.astro
@@ -1,0 +1,34 @@
+---
+import Account from '../layouts/Account.astro';
+---
+<Account
+  title="Authorize a device — Reasonix"
+  titleEn="Authorize a device — Reasonix"
+  titleZh="授权设备 — Reasonix"
+  description="Approve a sign-in request from the Reasonix CLI or desktop app.">
+  <div id="device-gate" class="auth-head">
+    <p><span class="l-en">Checking your session…</span><span class="l-zh">正在检查登录状态…</span></p>
+  </div>
+
+  <div id="device-view" hidden>
+    <div class="auth-head">
+      <h1><span class="l-en">Authorize sign-in</span><span class="l-zh">授权登录</span></h1>
+      <p><span class="l-en">Confirm the code shown in your terminal or app.</span><span class="l-zh">请确认终端或应用里显示的验证码。</span></p>
+    </div>
+
+    <div id="device-msg" class="auth-msg" hidden></div>
+
+    <div class="field">
+      <label for="device-code"><span class="l-en">Device code</span><span class="l-zh">设备码</span></label>
+      <input id="device-code" class="device-code" type="text" autocomplete="one-time-code" spellcheck="false" placeholder="XXXX-XXXX" />
+    </div>
+    <button id="device-check" type="button" class="btn btn-ghost" style="width:100%"><span class="l-en">Continue</span><span class="l-zh">继续</span></button>
+
+    <p id="device-meta" class="device-meta" hidden></p>
+
+    <div id="device-actions" class="device-actions" hidden>
+      <button id="device-approve" type="button" class="btn btn-dark"><span class="l-en">Approve</span><span class="l-zh">批准</span></button>
+      <button id="device-deny" type="button" class="btn btn-ghost"><span class="l-en">Reject</span><span class="l-zh">拒绝</span></button>
+    </div>
+  </div>
+</Account>

--- a/site/src/pages/forgot.astro
+++ b/site/src/pages/forgot.astro
@@ -1,0 +1,28 @@
+---
+import Account from '../layouts/Account.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<Account
+  title="Reset password — Reasonix"
+  titleEn="Reset password — Reasonix"
+  titleZh="找回密码 — Reasonix"
+  description="Reset your Reasonix account password.">
+  <div class="auth-head">
+    <h1><span class="l-en">Reset your password</span><span class="l-zh">找回密码</span></h1>
+    <p><span class="l-en">We'll email you a link to set a new one.</span><span class="l-zh">我们会给你发一封重置链接邮件。</span></p>
+  </div>
+
+  <div id="forgot-msg" class="auth-msg" hidden></div>
+
+  <form id="forgot-form" class="auth-form" novalidate>
+    <div class="field">
+      <label for="email"><span class="l-en">Email</span><span class="l-zh">邮箱</span></label>
+      <input id="email" name="email" type="email" autocomplete="email" required />
+    </div>
+    <button type="submit" class="btn btn-dark"><span class="l-en">Send reset link</span><span class="l-zh">发送重置链接</span></button>
+  </form>
+
+  <p class="auth-alt">
+    <a href={`${base}/login/`}><span class="l-en">Back to sign in</span><span class="l-zh">返回登录</span></a>
+  </p>
+</Account>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,6 +62,7 @@ const ld = {
         <button type="button" data-lang="en" class="active">EN</button>
         <button type="button" data-lang="zh">中文</button>
       </div>
+      <a class="btn btn-ghost" href={`${base}/login/`}><span class="l-en">Sign in</span><span class="l-zh">登录</span></a>
       <a class="btn btn-dark" href="#start"><span class="l-en">Install</span><span class="l-zh">安装</span></a>
     </div>
   </header>

--- a/site/src/pages/login.astro
+++ b/site/src/pages/login.astro
@@ -1,0 +1,36 @@
+---
+import Account from '../layouts/Account.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<Account
+  title="Sign in — Reasonix"
+  titleEn="Sign in — Reasonix"
+  titleZh="登录 — Reasonix"
+  description="Sign in to your Reasonix account.">
+  <div class="auth-head">
+    <h1><span class="l-en">Welcome back</span><span class="l-zh">欢迎回来</span></h1>
+    <p><span class="l-en">Sign in to your Reasonix account.</span><span class="l-zh">登录你的 Reasonix 账号。</span></p>
+  </div>
+
+  <div id="login-msg" class="auth-msg" hidden></div>
+
+  <form id="login-form" class="auth-form" novalidate>
+    <div class="field">
+      <label for="email"><span class="l-en">Email</span><span class="l-zh">邮箱</span></label>
+      <input id="email" name="email" type="email" autocomplete="email" required />
+    </div>
+    <div class="field">
+      <div class="auth-row">
+        <label for="password"><span class="l-en">Password</span><span class="l-zh">密码</span></label>
+        <a class="auth-small" href={`${base}/forgot/`}><span class="l-en">Forgot?</span><span class="l-zh">忘记密码？</span></a>
+      </div>
+      <input id="password" name="password" type="password" autocomplete="current-password" required />
+    </div>
+    <button type="submit" class="btn btn-dark"><span class="l-en">Sign in</span><span class="l-zh">登录</span></button>
+  </form>
+
+  <p class="auth-alt">
+    <span class="l-en">New to Reasonix? <a href={`${base}/register/`}>Create an account</a></span>
+    <span class="l-zh">还没有账号？<a href={`${base}/register/`}>注册一个</a></span>
+  </p>
+</Account>

--- a/site/src/pages/register.astro
+++ b/site/src/pages/register.astro
@@ -1,0 +1,38 @@
+---
+import Account from '../layouts/Account.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<Account
+  title="Create account — Reasonix"
+  titleEn="Create account — Reasonix"
+  titleZh="注册 — Reasonix"
+  description="Create your Reasonix account.">
+  <div class="auth-head">
+    <h1><span class="l-en">Create your account</span><span class="l-zh">创建账号</span></h1>
+    <p><span class="l-en">Join the Reasonix community.</span><span class="l-zh">加入 Reasonix 社区。</span></p>
+  </div>
+
+  <div id="register-msg" class="auth-msg" hidden></div>
+
+  <form id="register-form" class="auth-form" novalidate>
+    <div class="field">
+      <label for="displayName"><span class="l-en">Display name</span><span class="l-zh">显示名</span> <span class="hint">(<span class="l-en">optional</span><span class="l-zh">可选</span>)</span></label>
+      <input id="displayName" name="displayName" type="text" autocomplete="nickname" maxlength="80" />
+    </div>
+    <div class="field">
+      <label for="email"><span class="l-en">Email</span><span class="l-zh">邮箱</span></label>
+      <input id="email" name="email" type="email" autocomplete="email" required />
+    </div>
+    <div class="field">
+      <label for="password"><span class="l-en">Password</span><span class="l-zh">密码</span></label>
+      <input id="password" name="password" type="password" autocomplete="new-password" minlength="8" required />
+      <span class="hint"><span class="l-en">At least 8 characters.</span><span class="l-zh">至少 8 个字符。</span></span>
+    </div>
+    <button type="submit" class="btn btn-dark"><span class="l-en">Create account</span><span class="l-zh">注册</span></button>
+  </form>
+
+  <p class="auth-alt">
+    <span class="l-en">Already have an account? <a href={`${base}/login/`}>Sign in</a></span>
+    <span class="l-zh">已有账号？<a href={`${base}/login/`}>登录</a></span>
+  </p>
+</Account>

--- a/site/src/pages/reset.astro
+++ b/site/src/pages/reset.astro
@@ -1,0 +1,33 @@
+---
+import Account from '../layouts/Account.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<Account
+  title="Set a new password — Reasonix"
+  titleEn="Set a new password — Reasonix"
+  titleZh="设置新密码 — Reasonix"
+  description="Choose a new password for your Reasonix account.">
+  <div class="auth-head">
+    <h1><span class="l-en">Set a new password</span><span class="l-zh">设置新密码</span></h1>
+    <p><span class="l-en">Choose a password you haven't used before.</span><span class="l-zh">请设置一个新密码。</span></p>
+  </div>
+
+  <div id="reset-msg" class="auth-msg" hidden></div>
+
+  <form id="reset-form" class="auth-form" novalidate>
+    <div class="field">
+      <label for="password"><span class="l-en">New password</span><span class="l-zh">新密码</span></label>
+      <input id="password" name="password" type="password" autocomplete="new-password" minlength="8" required />
+      <span class="hint"><span class="l-en">At least 8 characters.</span><span class="l-zh">至少 8 个字符。</span></span>
+    </div>
+    <div class="field">
+      <label for="confirm"><span class="l-en">Confirm password</span><span class="l-zh">确认密码</span></label>
+      <input id="confirm" name="confirm" type="password" autocomplete="new-password" minlength="8" required />
+    </div>
+    <button type="submit" class="btn btn-dark"><span class="l-en">Update password</span><span class="l-zh">更新密码</span></button>
+  </form>
+
+  <p class="auth-alt">
+    <a href={`${base}/login/`}><span class="l-en">Back to sign in</span><span class="l-zh">返回登录</span></a>
+  </p>
+</Account>

--- a/site/src/scripts/auth.js
+++ b/site/src/scripts/auth.js
@@ -1,0 +1,290 @@
+// Client for the reasonix-accounts API (id.reasonix.io). Cookie-based session,
+// so every call sends credentials; the API base is build-time configurable.
+const API = (import.meta.env.PUBLIC_ACCOUNTS_API || "https://id.reasonix.io").replace(/\/$/, "");
+
+async function api(path, { method = "GET", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    credentials: "include",
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data = null;
+  try { data = await res.json(); } catch {}
+  if (!res.ok) {
+    const err = new Error(data?.error?.message || "Something went wrong. Please try again.");
+    err.code = data?.error?.code;
+    err.status = res.status;
+    throw err;
+  }
+  return data;
+}
+
+const $ = (id) => document.getElementById(id);
+const qp = new URLSearchParams(location.search);
+const withBase = (p) => (import.meta.env.BASE_URL.replace(/\/$/, "") + p) || p;
+
+function msg(el, kind, text) {
+  if (!el) return;
+  el.className = "auth-msg " + kind;
+  el.textContent = text;
+  el.hidden = false;
+}
+function clearMsg(el) { if (el) el.hidden = true; }
+
+function busy(btn, on) {
+  if (!btn) return;
+  btn.disabled = on;
+  btn.classList.toggle("loading", on);
+}
+
+// login — POST /auth/login, then continue to ?next or /account.
+const loginForm = $("login-form");
+if (loginForm) {
+  const box = $("login-msg");
+  const verified = qp.get("verified");
+  if (verified === "1") msg(box, "ok", "Email confirmed. Sign in to continue.");
+  else if (verified === "0") msg(box, "error", "That confirmation link was invalid or has expired.");
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(box);
+    const btn = loginForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      await api("/auth/login", { method: "POST", body: { email: $("email").value.trim(), password: $("password").value } });
+      const next = qp.get("next");
+      location.href = next && next.startsWith("/") ? next : withBase("/account/");
+    } catch (err) {
+      msg(box, "error", err.message);
+      busy(btn, false);
+    }
+  });
+}
+
+// register — enumeration-safe: the API returns the same message either way.
+const registerForm = $("register-form");
+if (registerForm) {
+  const box = $("register-msg");
+  registerForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(box);
+    const btn = registerForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      const out = await api("/auth/register", {
+        method: "POST",
+        body: {
+          email: $("email").value.trim(),
+          password: $("password").value,
+          displayName: $("displayName").value.trim() || undefined,
+        },
+      });
+      msg(box, "ok", out?.message || "Check your inbox to confirm your account.");
+      registerForm.reset();
+    } catch (err) {
+      msg(box, "error", err.message);
+    } finally {
+      busy(btn, false);
+    }
+  });
+}
+
+// forgot — always a generic success (never reveals whether the email exists).
+const forgotForm = $("forgot-form");
+if (forgotForm) {
+  const box = $("forgot-msg");
+  forgotForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(box);
+    const btn = forgotForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      const out = await api("/auth/forgot", { method: "POST", body: { email: $("email").value.trim() } });
+      msg(box, "ok", out?.message || "If that account exists, a reset link is on its way.");
+      forgotForm.reset();
+    } catch (err) {
+      msg(box, "error", err.message);
+    } finally {
+      busy(btn, false);
+    }
+  });
+}
+
+// reset — token comes from the emailed link.
+const resetForm = $("reset-form");
+if (resetForm) {
+  const box = $("reset-msg");
+  const token = qp.get("token") || "";
+  if (!token) {
+    msg(box, "error", "This reset link is incomplete. Request a new one.");
+    resetForm.querySelectorAll("input, button").forEach((el) => (el.disabled = true));
+  }
+  resetForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(box);
+    const password = $("password").value;
+    if (password !== $("confirm").value) {
+      msg(box, "error", "The two passwords don't match.");
+      return;
+    }
+    const btn = resetForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      await api("/auth/reset", { method: "POST", body: { token, password } });
+      msg(box, "ok", "Password updated. You can sign in now.");
+      resetForm.reset();
+      resetForm.querySelectorAll("input, button").forEach((el) => (el.disabled = true));
+    } catch (err) {
+      msg(box, "error", err.message);
+      busy(btn, false);
+    }
+  });
+}
+
+// account — profile view/edit, password change, sign out, delete.
+const accountView = $("account-view");
+if (accountView) {
+  const gate = $("account-gate");
+  const fill = (user) => {
+    $("acct-handle").textContent = "@" + user.handle;
+    $("acct-email").textContent = user.email + (user.emailVerified ? "" : " · unconfirmed");
+    $("acct-role").textContent = user.role;
+    $("f-displayName").value = user.displayName || "";
+    $("f-handle").value = user.handle || "";
+    $("f-bio").value = user.bio || "";
+    $("f-avatarUrl").value = user.avatarUrl || "";
+    accountView.hidden = false;
+    if (gate) gate.hidden = true;
+  };
+
+  api("/me")
+    .then((d) => fill(d.user))
+    .catch((err) => {
+      if (err.status === 401) location.href = withBase("/login/?next=/account/");
+      else if (gate) msg(gate, "error", err.message);
+    });
+
+  const profileForm = $("profile-form");
+  const pBox = $("profile-msg");
+  profileForm?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(pBox);
+    const btn = profileForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      const d = await api("/me", {
+        method: "PATCH",
+        body: {
+          displayName: $("f-displayName").value.trim(),
+          handle: $("f-handle").value.trim().toLowerCase(),
+          bio: $("f-bio").value.trim(),
+          avatarUrl: $("f-avatarUrl").value.trim(),
+        },
+      });
+      fill(d.user);
+      msg(pBox, "ok", "Profile saved.");
+    } catch (err) {
+      msg(pBox, "error", err.message);
+    } finally {
+      busy(btn, false);
+    }
+  });
+
+  const passwordForm = $("password-form");
+  const pwBox = $("password-msg");
+  passwordForm?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    clearMsg(pwBox);
+    const btn = passwordForm.querySelector("button[type=submit]");
+    busy(btn, true);
+    try {
+      await api("/me/password", {
+        method: "POST",
+        body: { currentPassword: $("currentPassword").value, newPassword: $("newPassword").value },
+      });
+      passwordForm.reset();
+      msg(pwBox, "ok", "Password changed.");
+    } catch (err) {
+      msg(pwBox, "error", err.message);
+    } finally {
+      busy(btn, false);
+    }
+  });
+
+  $("logout-btn")?.addEventListener("click", async () => {
+    try { await api("/auth/logout", { method: "POST" }); } catch {}
+    location.href = withBase("/login/");
+  });
+
+  $("delete-btn")?.addEventListener("click", async () => {
+    if (!confirm("Delete your account? This cannot be undone.")) return;
+    try {
+      await api("/me", { method: "DELETE" });
+      location.href = withBase("/");
+    } catch (err) {
+      msg(pBox, "error", err.message);
+    }
+  });
+}
+
+// device — the human-facing half of the CLI/desktop device-authorization flow.
+const deviceView = $("device-view");
+if (deviceView) {
+  const gate = $("device-gate");
+  const box = $("device-msg");
+  const codeInput = $("device-code");
+  const meta = $("device-meta");
+  const actions = $("device-actions");
+  const preset = qp.get("code");
+  if (preset && codeInput) codeInput.value = preset;
+
+  const showGrant = async () => {
+    clearMsg(box);
+    if (meta) meta.hidden = true;
+    if (actions) actions.hidden = true;
+    const code = codeInput.value.trim();
+    if (!code) { msg(box, "error", "Enter the code shown in your terminal."); return; }
+    try {
+      const d = await api("/device/info?userCode=" + encodeURIComponent(code));
+      if (meta) {
+        meta.textContent = `Requested by ${d.grant.userAgent || "a device"}`;
+        meta.hidden = false;
+      }
+      if (actions) actions.hidden = false;
+    } catch (err) {
+      msg(box, "error", err.message);
+    }
+  };
+
+  const decide = async (path, okText) => {
+    clearMsg(box);
+    const code = codeInput.value.trim();
+    actions?.querySelectorAll("button").forEach((b) => (b.disabled = true));
+    try {
+      await api(path, { method: "POST", body: { userCode: code } });
+      msg(box, "ok", okText);
+      if (meta) meta.hidden = true;
+      if (actions) actions.hidden = true;
+      codeInput.disabled = true;
+    } catch (err) {
+      msg(box, "error", err.message);
+      actions?.querySelectorAll("button").forEach((b) => (b.disabled = false));
+    }
+  };
+
+  api("/me")
+    .then(() => {
+      deviceView.hidden = false;
+      if (gate) gate.hidden = true;
+      $("device-check")?.addEventListener("click", showGrant);
+      $("device-approve")?.addEventListener("click", () => decide("/device/approve", "Approved. Return to your terminal — you're signed in."));
+      $("device-deny")?.addEventListener("click", () => decide("/device/deny", "The sign-in request was rejected."));
+      if (preset) showGrant();
+    })
+    .catch((err) => {
+      if (err.status === 401) {
+        const next = "/device/" + (preset ? "?code=" + encodeURIComponent(preset) : "");
+        location.href = withBase("/login/?next=" + encodeURIComponent(next));
+      } else if (gate) msg(gate, "error", err.message);
+    });
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -739,3 +739,64 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .hero { padding-top: 130px; }
   section { padding-top: 100px; }
 }
+
+/* account / auth pages */
+.auth-nav { background: oklch(1 0 0 / 0.92); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: 0 1px 0 var(--line); }
+.auth-main { min-height: 100vh; display: grid; place-items: center; padding: 116px 24px 72px; }
+.auth-card {
+  width: 100%; max-width: 420px;
+  background: var(--card); border-radius: var(--radius);
+  box-shadow: var(--shadow-2); padding: 42px 40px 36px;
+}
+.auth-card.wide { max-width: 560px; }
+.auth-head { text-align: center; }
+.auth-head h1 { font-size: 26px; font-weight: 600; letter-spacing: -0.02em; }
+.auth-head p { margin-top: 10px; font-size: 15px; line-height: 1.6; color: var(--ink-2); }
+.auth-form { display: flex; flex-direction: column; gap: 16px; margin-top: 24px; }
+.field { display: flex; flex-direction: column; gap: 7px; text-align: left; }
+.field label { font-size: 13px; font-weight: 600; color: var(--ink-2); }
+.field .hint { font-size: 12px; font-weight: 400; color: var(--ink-3); }
+.field input, .field textarea {
+  width: 100%; font-family: var(--font-sans); font-size: 15px; color: var(--ink);
+  background: var(--bg-soft); border: 1px solid transparent; border-radius: var(--radius-sm);
+  padding: 12px 14px; resize: vertical;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.field input:focus, .field textarea:focus {
+  outline: none; background: #fff;
+  border-color: color-mix(in oklch, var(--accent) 45%, var(--line));
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.field input:disabled, .field textarea:disabled { opacity: 0.55; }
+.auth-form .btn { width: 100%; margin-top: 4px; }
+.btn[disabled], .btn.loading { opacity: 0.55; pointer-events: none; }
+.auth-row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.auth-small { font-size: 12.5px; color: var(--accent); text-decoration: none; font-weight: 500; }
+.auth-small:hover { text-decoration: underline; }
+.auth-msg { margin-top: 20px; font-size: 13.5px; line-height: 1.55; border-radius: var(--radius-sm); padding: 11px 14px; text-align: left; }
+.auth-msg.error { background: color-mix(in oklch, oklch(0.63 0.21 25) 10%, white); color: oklch(0.5 0.19 25); }
+.auth-msg.ok { background: color-mix(in oklch, oklch(0.65 0.16 155) 13%, white); color: oklch(0.44 0.12 155); }
+.auth-alt { margin-top: 24px; text-align: center; font-size: 14px; color: var(--ink-3); }
+.auth-alt a { color: var(--accent); text-decoration: none; font-weight: 500; }
+.auth-alt a:hover { text-decoration: underline; }
+
+.acct-id { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding-bottom: 8px; }
+.acct-handle { font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
+.acct-email { margin-top: 3px; font-size: 13.5px; color: var(--ink-3); }
+.acct-role {
+  font-family: var(--font-mono); font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--accent); background: var(--accent-soft); padding: 5px 12px; border-radius: 999px;
+}
+.acct-h2 {
+  font-size: 15px; font-weight: 600; color: var(--ink);
+  margin: 30px 0 4px; padding-top: 24px; border-top: 1px solid var(--line);
+}
+.acct-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 34px; padding-top: 22px; border-top: 1px solid var(--line); }
+.acct-foot .btn { width: auto; margin: 0; }
+.acct-danger { font-family: var(--font-sans); font-size: 14px; font-weight: 500; color: oklch(0.55 0.19 25); background: none; border: none; cursor: pointer; padding: 8px 4px; }
+.acct-danger:hover { text-decoration: underline; }
+
+.device-code { font-family: var(--font-mono); font-size: 20px; letter-spacing: 0.16em; text-transform: uppercase; text-align: center; }
+.device-meta { margin-top: 16px; text-align: center; font-size: 13.5px; color: var(--ink-2); }
+.device-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 18px; }
+.device-actions .btn { width: 100%; margin: 0; }


### PR DESCRIPTION
## What

The web frontend for the accounts service. Astro pages on `reasonix.io` that
consume the `id.reasonix.io` JSON API:

- **`/login`** — sign in; shows the post-verification `?verified` banner and
  honours `?next=` redirects
- **`/register`** — create an account (enumeration-safe messaging)
- **`/forgot`** · **`/reset`** — password reset by email link
- **`/account`** — gated: profile edit (display name, handle, bio, avatar),
  password change, sign out, delete
- **`/device`** — the human half of the CLI/desktop device flow: enter the code
  shown in the terminal, review what's being authorized, approve or reject
- A **Sign in** link in the main nav

## Design

Reuses the site's existing design tokens (`global.css` `:root` vars) — no new
palette, same pill buttons / radii / shadows / fonts. All copy is bilingual
(`.l-en` / `.l-zh`) like the rest of the site; the language switch and nav chrome
come from the shared `Account` layout. Interactive states (hover / focus-visible
/ disabled / loading) and inline error + success messaging are wired on every
form.

## Config

The API base is build-time configurable via `PUBLIC_ACCOUNTS_API` and defaults to
`https://id.reasonix.io`. The worker already lists `reasonix.io` in
`ALLOWED_ORIGINS` with `COOKIE_DOMAIN=.reasonix.io`, so the credentialed cookie
flow works in production with no worker change.

## Verification

- `astro build` clean — 9 pages generated (6 new + existing).
- Built HTML carries the expected forms/fields (`#login-form`, `#device-view`,
  `#profile-form`, …); the JS bundle bakes the default base `id.reasonix.io`, and
  a `PUBLIC_ACCOUNTS_API` override bakes through.
- The underlying API was proven end-to-end in the device-flow PR (register →
  login → device approve → poll complete → Bearer `/me`).
- Browser click-through E2E not run here (no browser driver in CI); the pages are
  static + client-fetch, and the API contract is already verified.

Site auto-deploys via `pages.yml` on merge to `main-v2`. Best reviewed after the
accounts worker is live (deploy PR) so the flow is clickable end-to-end.
