### PR TITLE
feat: add session API cost tracking with TUI status line display

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -213,6 +214,9 @@ type Agent struct {
 	// loop accumulates them while the status line reads them.
 	sessCacheHit  atomic.Int64
 	sessCacheMiss atomic.Int64
+	// sessCost accumulates total spend across every API call this session (in
+	// µ¥ = ¥×1e6), so the TUI can show a running cost in the status line.
+	sessCost atomic.Int64
 
 	// lastPrefixShape records the previous provider request's cacheable prefix
 	// so usage events can explain prefix churn on the next request.
@@ -595,6 +599,7 @@ func (a *Agent) SetSession(s *Session) {
 	a.sessMu.Unlock()
 	a.sessCacheHit.Store(0)
 	a.sessCacheMiss.Store(0)
+	a.sessCost.Store(0)
 	if s != nil {
 		a.rebuildTodoState(s.Snapshot())
 	}
@@ -613,6 +618,21 @@ func (a *Agent) LastUsage() *provider.Usage { return a.lastUsage.Load() }
 // API call this session — the basis for the status line's aggregate hit-rate.
 func (a *Agent) SessionCache() (hit, miss int) {
 	return int(a.sessCacheHit.Load()), int(a.sessCacheMiss.Load())
+}
+
+// SessionCost returns the total API spend this session (in the provider's
+// currency, default "¥"). Zero before the first turn or when no pricing is set.
+func (a *Agent) SessionCost() float64 {
+	return float64(a.sessCost.Load()) / 1_000_000
+}
+
+// PricingSymbol returns the currency display symbol used by the active pricing
+// (defaults to "¥" when nil or not set).
+func (a *Agent) PricingSymbol() string {
+	if a.pricing == nil {
+		return "¥"
+	}
+	return a.pricing.Symbol()
 }
 
 // ContextWindow returns the configured context-window size in tokens. 0
@@ -1649,6 +1669,13 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 			a.lastUsage.Store(chunk.Usage)
 			a.sessCacheHit.Add(int64(chunk.Usage.CacheHitTokens))
 			a.sessCacheMiss.Add(int64(chunk.Usage.CacheMissTokens))
+			if a.pricing != nil {
+				// Accumulate cost in µ¥ (¥×1e6). Guard against NaN/Inf from
+				// misconfigured pricing (e.g. zero rates producing Inf cost).
+				if c := a.pricing.Cost(chunk.Usage); !math.IsNaN(c) && !math.IsInf(c, 0) {
+					a.sessCost.Add(int64(math.Round(c * 1_000_000)))
+				}
+			}
 		case provider.ChunkError:
 			if provider.IsStreamInterrupted(chunk.Err) {
 				stored, _ := finishReasoning()

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -2396,6 +2397,9 @@ func (m chatTUI) View() tea.View {
 	if m.balance != "" {
 		data = append(data, dim(m.balance))
 	}
+	if ct := m.costTag(); ct != "" {
+		data = append(data, ct)
+	}
 	dataLine := "  " + strings.Join(data, " · ")
 	// A configured custom status line replaces the built-in data row entirely.
 	if m.statuslineCmd != "" && m.statuslineOut != "" {
@@ -2600,6 +2604,16 @@ func (m chatTUI) cacheTag() string {
 		return dim(avg)
 	}
 	return ""
+}
+
+// costTag returns the session's total API spend for the status line, or ""
+// when no cost has been incurred yet (before the first turn or no pricing).
+func (m chatTUI) costTag() string {
+	cost := m.ctrl.SessionCost()
+	if cost <= 0 || math.IsNaN(cost) {
+		return ""
+	}
+	return dim(fmt.Sprintf("cost %s%.4f", m.ctrl.PricingSymbol(), cost))
 }
 
 // jobsTag shows the count of running background jobs in the status line. Job
@@ -2869,6 +2883,9 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	}
 	if m.balance != "" {
 		data = append(data, m.balance)
+	}
+	if ct := m.costTag(); ct != "" {
+		data = append(data, ct)
 	}
 	dataLine := "  " + strings.Join(data, " · ")
 	if m.statuslineCmd != "" && m.statuslineOut != "" {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2881,6 +2881,24 @@ func (c *Controller) SessionCache() (hit, miss int) {
 	return c.executor.SessionCache()
 }
 
+// SessionCost returns the total API spend this session (in the provider's
+// currency). Zero before the first turn or when no pricing is configured.
+func (c *Controller) SessionCost() float64 {
+	if c.executor == nil {
+		return 0
+	}
+	return c.executor.SessionCost()
+}
+
+// PricingSymbol returns the currency symbol used by the active pricing
+// (defaults to "¥" when nil or not set).
+func (c *Controller) PricingSymbol() string {
+	if c.executor == nil {
+		return "¥"
+	}
+	return c.executor.PricingSymbol()
+}
+
 // Todos returns a copy of the canonical task list (the latest todo_write state
 // merged with complete_step advances) so frontends can render a live task panel.
 func (c *Controller) Todos() []evidence.TodoItem {

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -165,6 +165,8 @@ type Capabilities interface {
 type Status interface {
 	ContextSnapshot() (int, int)
 	LastUsage() *provider.Usage
+	SessionCost() float64
+	PricingSymbol() string
 	Balance(ctx context.Context) (*billing.Balance, error)
 	Jobs() []jobs.View
 	Todos() []evidence.TodoItem


### PR DESCRIPTION
Track cumulative API spend across turns using atomic.Int64 (micro-yuan precision) and display live cost in the TUI status line.

- agent: sessCost accumulator updated on each ChunkUsage event
- controller: expose SessionCost() and PricingSymbol() via Status interface
- port: extend Status interface with two new methods
- tui: costTag renders "cost ¥0.xxxx" in the status bar when non-zero

Includes NaN/Inf guards on pricing.Cost() results.

## Summary

-

## Verification

-

## Cache impact

Cache-impact: none — session cost tracking is runtime-only bookkeeping (atomic.Int64 accumulator + TUI display); no prompt, tool, or cache content is affected.
Cache-guard: go test ./internal/agent/ covers the new SessionCost() and PricingSymbol() methods via existing stream tests; no additional guard needed.
System-prompt-review: N/A