### PR TITLE
ci(accounts): sync RESEND_API_KEY from repo secret on deploy

### DIFF
--- a/.github/workflows/deploy-accounts-worker.yml
+++ b/.github/workflows/deploy-accounts-worker.yml
@@ -36,3 +36,14 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           npx wrangler deploy
+      - name: Sync RESEND_API_KEY to the worker
+        working-directory: workers/accounts
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          if [ -n "$RESEND_API_KEY" ]; then
+            printf '%s' "$RESEND_API_KEY" | npx wrangler secret put RESEND_API_KEY
+          else
+            echo "RESEND_API_KEY not set in repo secrets; skipping (worker stays in stub email mode)."
+          fi

--- a/workers/accounts/README.md
+++ b/workers/accounts/README.md
@@ -91,6 +91,10 @@ DNS/custom-domain binding at this worker in the Cloudflare dashboard on first de
 
 The steps above are the one-time bootstrap. After that, every merge to `main-v2`
 that touches `workers/accounts/**` redeploys via `.github/workflows/deploy-accounts-worker.yml`
-(same pattern as the crash worker). CI does **not** run migrations or set secrets —
-apply new migrations with `pnpm db:apply:remote` and rotate secrets with `wrangler secret put`
-out of band.
+(same pattern as the crash worker). CI does **not** run migrations — apply new ones
+with `pnpm db:apply:remote` out of band.
+
+`RESEND_API_KEY` is synced to the worker on each deploy from the `RESEND_API_KEY`
+GitHub Actions repo secret (so the mail key has a single source of truth and needs
+no local wrangler auth). `SESSION_PEPPER` is not in CI — set it once with
+`wrangler secret put SESSION_PEPPER`.


### PR DESCRIPTION
Adds a deploy step that syncs the `RESEND_API_KEY` GitHub Actions repo secret into the worker via `wrangler secret put`.

## Why

The worker reads `env.RESEND_API_KEY` at runtime from Cloudflare. Storing it only as a GitHub secret does nothing — `wrangler deploy` never pushes GitHub secrets to the worker runtime — so verification/reset mail silently used the console stub (register returns 200 but no email sends). This gives the mail key one source of truth (the repo secret) and needs no local wrangler auth.

## Notes

- Guarded: a missing/empty `RESEND_API_KEY` secret just skips (stays in stub mode), never sets an empty key.
- Uses `printf %s` (no trailing newline) so the key is stored exactly.
- `SESSION_PEPPER` stays out of CI (already set once via `wrangler secret put`).
- Merging this triggers the deploy workflow, which sets the key on the live worker.
