### PR TITLE
fix(desktop): scope todo panel completion state / 修复待办面板跨会话完成态

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -16,7 +16,16 @@ const transpiled = ts.transpileModule(source, {
 }).outputText;
 
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
-const { shouldShowTodoPanel, todoDismissalKey } = await import(moduleUrl);
+const {
+  dismissedTodoKeyForScope,
+  scopedTodoBatchKey,
+  scopedTodoDismissalKey,
+  shouldOpenTodoPanelByDefault,
+  shouldShowTodoPanel,
+  todoBatchKey,
+  todoDismissalKey,
+  todoPanelScope,
+} = await import(moduleUrl);
 
 const completedTodos = [
   { content: "Inspect the report", status: "completed" },
@@ -42,6 +51,66 @@ assert.equal(
   false,
   "a user dismissal still hides that exact todo list",
 );
+const completedKey = todoDismissalKey(completedTodos);
+const dismissedBySession = new Set([scopedTodoDismissalKey("session:a", completedKey)]);
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:a", dismissedBySession, completedKey), completedTodos),
+  false,
+  "a completed todo dismissal hides the list in the session where it was closed",
+);
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:b", dismissedBySession, completedKey), completedTodos),
+  true,
+  "a completed todo dismissal in one session does not hide another session's list",
+);
+dismissedBySession.add(scopedTodoDismissalKey("session:b", completedKey));
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:a", dismissedBySession, completedKey), completedTodos),
+  false,
+  "closing another session's todo does not forget the first session dismissal",
+);
+assert.equal(
+  todoPanelScope({
+    activeTabId: "tab-a",
+    activeTab: {
+      id: "tab-a",
+      scope: "project",
+      workspaceRoot: "/repo",
+      topicId: "topic-a",
+      sessionPath: "/sessions/a.jsonl",
+    },
+  }),
+  "session:/sessions/a.jsonl",
+  "a restored history session uses its session path as the todo panel scope",
+);
+assert.equal(
+  todoPanelScope({
+    activeTabId: "tab-b",
+    activeTab: {
+      id: "tab-a",
+      scope: "project",
+      workspaceRoot: "/repo",
+      topicId: "topic-a",
+      sessionPath: "/sessions/a.jsonl",
+    },
+    eventChannel: "desktop-events",
+  }),
+  "tab:tab-b",
+  "a stale active-tab fallback must not scope dismissal to the previous session",
+);
+assert.equal(
+  todoPanelScope({
+    activeTabId: "tab-c",
+    activeTab: {
+      id: "tab-c",
+      scope: "project",
+      workspaceRoot: "/repo",
+      topicId: "topic-a",
+    },
+  }),
+  "tab:tab-c",
+  "an unsaved topic session uses its tab id so sibling sessions do not share todo state",
+);
 assert.equal(shouldShowTodoPanel(null, null, completedTodos), false, "no canonical todo item means no panel");
 assert.equal(shouldShowTodoPanel("todo-empty", null, []), false, "empty todo lists do not render a panel");
 
@@ -60,6 +129,36 @@ assert.notEqual(
   activeKey,
   todoDismissalKey([{ ...activeTodos[0], status: "completed" }, { ...activeTodos[1], status: "in_progress" }]),
   "real progress produces a fresh dismissal key",
+);
+assert.equal(
+  todoBatchKey(activeTodos),
+  todoBatchKey([{ ...activeTodos[0], status: "completed" }, { ...activeTodos[1], status: "in_progress" }]),
+  "status progress stays in the same todo batch",
+);
+assert.equal(
+  scopedTodoBatchKey("session:a", todoBatchKey(activeTodos)),
+  scopedTodoBatchKey("session:a", todoBatchKey([{ ...activeTodos[0], status: "completed" }, { ...activeTodos[1], status: "in_progress" }])),
+  "status progress keeps the same scoped open-state key",
+);
+assert.notEqual(
+  scopedTodoBatchKey("session:a", todoBatchKey(activeTodos)),
+  scopedTodoBatchKey("session:b", todoBatchKey(activeTodos)),
+  "the same task list in a different session gets isolated open state",
+);
+assert.notEqual(
+  todoBatchKey(activeTodos),
+  todoBatchKey([{ content: "Run a different task", status: "in_progress" }]),
+  "new task content creates a new todo batch",
+);
+assert.equal(
+  shouldOpenTodoPanelByDefault(activeTodos),
+  true,
+  "new incomplete todo batches open by default",
+);
+assert.equal(
+  shouldOpenTodoPanelByDefault(completedTodos),
+  false,
+  "completed todo batches collapse by default",
 );
 
 const iterations = 200_000;

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -59,7 +59,15 @@ import { HeartbeatPanel } from "./custom/features/heartbeat/HeartbeatPanel";
 import "./custom/features/heartbeat/heartbeat.css";
 import { CopyButton } from "./components/CopyButton";
 import { parseTodos } from "./lib/tools";
-import { shouldShowTodoPanel, todoDismissalKey } from "./lib/todoVisibility";
+import {
+  dismissedTodoKeyForScope,
+  scopedTodoBatchKey,
+  scopedTodoDismissalKey,
+  shouldShowTodoPanel,
+  todoBatchKey,
+  todoDismissalKey,
+  todoPanelScope,
+} from "./lib/todoVisibility";
 import {
   type BotConnectionView,
   type BotRuntimeStatusView,
@@ -182,6 +190,8 @@ function normalizeDesktopLayoutStyle(style: string | undefined): DesktopLayoutSt
   return "classic";
 }
 const SHOW_CONTEXT_DOCK = true;
+const DISMISSED_TODO_STORAGE_KEY = "todoPanel:dismissedKeys";
+const MAX_DISMISSED_TODO_KEYS = 160;
 type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string };
 type WorkspaceInsertTarget = "composer" | "planRevision";
 type DesktopPlatform = "darwin" | "windows" | "linux";
@@ -230,6 +240,29 @@ type SidebarImConnectionDetailProps = {
   onOpenSettings: () => void;
   onManageAllowlist: () => void;
 };
+
+function loadDismissedTodoKeys(): Set<string> {
+  try {
+    const saved = window.localStorage.getItem(DISMISSED_TODO_STORAGE_KEY);
+    if (!saved) return new Set();
+    const parsed = JSON.parse(saved) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((value): value is string => typeof value === "string" && value.length > 0));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveDismissedTodoKeys(keys: ReadonlySet<string>): void {
+  try {
+    window.localStorage.setItem(
+      DISMISSED_TODO_STORAGE_KEY,
+      JSON.stringify(Array.from(keys).slice(-MAX_DISMISSED_TODO_KEYS)),
+    );
+  } catch {
+    /* ignore quota errors */
+  }
+}
 
 function isSidebarImConnection(connection: BotConnectionView): boolean {
   return connection.provider === "feishu" || connection.provider === "weixin";
@@ -1395,7 +1428,11 @@ export default function App() {
   // a stale local dismissal cannot hide work that still blocks final readiness;
   // completed lists collapse automatically and can then be dismissed. The
   // dismissal key is still based on stable todo content/state so history reloads
-  // do not resurrect the same finished list under a different event id.
+  // do not resurrect the same finished list under a different event id. The
+  // batch key ignores status changes so progress within the same task list does
+  // not look like a brand-new task batch. Dismissal and open state are scoped to
+  // the active session/topic/tab so different projects and sessions do not hide
+  // or reopen each other's todo panels.
   const todoEntry = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const it = state.items[i];
@@ -1407,9 +1444,30 @@ export default function App() {
   }, [state.items]);
   const todoItem = todoEntry?.item ?? null;
   const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
-  const [dismissedTodo, setDismissedTodo] = useState<string | null>(null);
+  const [dismissedTodoKeys, setDismissedTodoKeys] = useState<Set<string>>(loadDismissedTodoKeys);
   const todoKey = useMemo(() => todoDismissalKey(todos), [todos]);
+  const todoBatch = useMemo(() => todoBatchKey(todos), [todos]);
+  const todoScope = useMemo(
+    () => todoPanelScope({ activeTab, activeTabId, eventChannel: state.meta?.eventChannel }),
+    [activeTab, activeTabId, state.meta?.eventChannel],
+  );
+  const dismissedTodo = useMemo(
+    () => dismissedTodoKeyForScope(todoScope, dismissedTodoKeys, todoKey),
+    [dismissedTodoKeys, todoKey, todoScope],
+  );
+  const scopedTodoKey = useMemo(() => scopedTodoDismissalKey(todoScope, todoKey), [todoKey, todoScope]);
+  const scopedTodoBatch = useMemo(() => scopedTodoBatchKey(todoScope, todoBatch), [todoBatch, todoScope]);
   const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos);
+  const dismissTodos = useCallback(() => {
+    if (!scopedTodoKey) return;
+    setDismissedTodoKeys((current) => {
+      if (current.has(scopedTodoKey)) return current;
+      const next = new Set(current);
+      next.add(scopedTodoKey);
+      saveDismissedTodoKeys(next);
+      return next;
+    });
+  }, [scopedTodoKey]);
 
   const sessionTitle = topicTitle(activeTab);
   const sessionHasContent = state.items.length > 0 || Boolean(state.live?.text || state.live?.reasoning);
@@ -3280,7 +3338,14 @@ export default function App() {
 
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
-            {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
+            {showTodos && (
+              <TodoPanel
+                key={scopedTodoBatch}
+                stateKey={scopedTodoBatch}
+                todos={todos}
+                onDismiss={dismissTodos}
+              />
+            )}
             {rewindState && (
               <UndoRewindBanner
                 meta={{

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -1,22 +1,39 @@
 import { useEffect, useRef, useState } from "react";
 import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
+import { shouldOpenTodoPanelByDefault } from "../lib/todoVisibility";
 import { PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 
-const STORAGE_KEY = "todoPanel:open";
+const STORAGE_KEY = "todoPanel:openStates";
+const MAX_STORED_OPEN_STATES = 80;
 
-function loadOpenState(): boolean {
+function loadOpenStates(): Record<string, boolean> {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    return saved === null ? true : saved === "1";
+    if (!saved) return {};
+    const parsed = JSON.parse(saved) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const states: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "boolean") states[key] = value;
+    }
+    return states;
   } catch {
-    return true;
+    return {};
   }
 }
 
-function saveOpenState(open: boolean): void {
+function loadOpenState(stateKey: string, defaultOpen: boolean): boolean {
+  const states = loadOpenStates();
+  return Object.prototype.hasOwnProperty.call(states, stateKey) ? states[stateKey] : defaultOpen;
+}
+
+function saveOpenState(stateKey: string, open: boolean): void {
   try {
-    localStorage.setItem(STORAGE_KEY, open ? "1" : "0");
+    const entries = Object.entries(loadOpenStates()).filter(([key]) => key !== stateKey);
+    entries.push([stateKey, open]);
+    const trimmed = entries.slice(-MAX_STORED_OPEN_STATES);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(trimmed)));
   } catch {
     /* ignore quota errors */
   }
@@ -24,23 +41,35 @@ function saveOpenState(open: boolean): void {
 
 // TodoPanel is the live task list pinned just above the composer — the kernel's
 // latest todo_write call drives it, and it updates in place as the agent flips
-// items to in_progress / completed. The collapsed/expanded state is persisted
-// globally in localStorage so the user's choice sticks across sessions.
+// items to in_progress / completed. Open state follows the current todo batch:
+// new incomplete work opens by default, finished work collapses to a reviewable
+// summary, and manual expand/collapse is restored only for the same batch.
 export function TodoPanel({
+  stateKey,
   todos,
   onDismiss,
 }: {
+  stateKey: string;
   todos: Todo[];
   onDismiss: () => void;
 }) {
   const t = useT();
-  const [open, setOpen] = useState(loadOpenState);
   const currentRef = useRef<HTMLLIElement | null>(null);
 
   const done = todos.filter((t) => t.status === "completed").length;
   const current = todos.find((t) => t.status === "in_progress");
   const allDone = todos.length > 0 && done === todos.length;
   const summary = current?.activeForm || current?.content || todos[todos.length - 1]?.content || "";
+  const [open, setOpen] = useState(() => loadOpenState(stateKey, shouldOpenTodoPanelByDefault(todos)));
+  const wasAllDoneRef = useRef(allDone);
+
+  useEffect(() => {
+    if (allDone && !wasAllDoneRef.current) {
+      saveOpenState(stateKey, false);
+      setOpen(false);
+    }
+    wasAllDoneRef.current = allDone;
+  }, [allDone, stateKey]);
 
   useEffect(() => {
     if (!open) return;
@@ -58,7 +87,13 @@ export function TodoPanel({
       role="region"
       headerActions={
         <>
-          <PromptHeaderAction onClick={() => setOpen((value) => { const next = !value; saveOpenState(next); return next; })}>
+          <PromptHeaderAction
+            onClick={() => setOpen((value) => {
+              const next = !value;
+              saveOpenState(stateKey, next);
+              return next;
+            })}
+          >
             {open ? t("common.collapse") : t("common.expand")}
           </PromptHeaderAction>
           {allDone && (

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -1,5 +1,17 @@
 import type { Todo } from "./tools";
 
+export interface TodoPanelScopeInput {
+  activeTabId?: string | null;
+  activeTab?: {
+    id?: string | null;
+    scope?: string | null;
+    workspaceRoot?: string | null;
+    topicId?: string | null;
+    sessionPath?: string | null;
+  } | null;
+  eventChannel?: string | null;
+}
+
 export function todoDismissalKey(todos: Todo[]): string {
   if (todos.length === 0) return "";
   return JSON.stringify(todos.map((todo) => ({
@@ -10,6 +22,50 @@ export function todoDismissalKey(todos: Todo[]): string {
   })));
 }
 
+export function todoPanelScope({ activeTab, activeTabId, eventChannel }: TodoPanelScopeInput): string {
+  const tabId = String(activeTabId ?? "").trim();
+  const tab = !tabId || activeTab?.id === tabId ? activeTab : null;
+  const sessionPath = tab?.sessionPath?.trim();
+  if (sessionPath) return `session:${sessionPath}`;
+  if (tabId) return `tab:${tabId}`;
+  const topicId = tab?.topicId?.trim();
+  if (tab && topicId) return `topic:${tab.scope ?? ""}:${tab.workspaceRoot ?? ""}:${topicId}`;
+  const channel = String(eventChannel ?? "").trim();
+  return channel ? `event:${channel}` : "";
+}
+
+export function scopedTodoDismissalKey(scope: string | null | undefined, todoKey: string | null | undefined): string {
+  const key = String(todoKey ?? "").trim();
+  if (!key) return "";
+  const prefix = String(scope ?? "").trim();
+  return prefix ? `${prefix}\0${key}` : key;
+}
+
+export function dismissedTodoKeyForScope(
+  scope: string | null | undefined,
+  dismissedKeys: ReadonlySet<string> | null | undefined,
+  todoKey: string | null | undefined,
+): string | null {
+  const scopedKey = scopedTodoDismissalKey(scope, todoKey);
+  if (!scopedKey || !dismissedKeys?.has(scopedKey)) return null;
+  return todoKey ?? null;
+}
+
+export function todoBatchKey(todos: Todo[]): string {
+  if (todos.length === 0) return "";
+  return JSON.stringify(todos.map((todo) => ({
+    content: String(todo.content ?? ""),
+    level: typeof todo.level === "number" ? todo.level : 0,
+  })));
+}
+
+export function scopedTodoBatchKey(scope: string | null | undefined, batchKey: string | null | undefined): string {
+  const key = String(batchKey ?? "").trim();
+  if (!key) return "";
+  const prefix = String(scope ?? "").trim();
+  return prefix ? `${prefix}\0${key}` : key;
+}
+
 export function shouldShowTodoPanel(
   todoKey: string | null | undefined,
   dismissedTodoKey: string | null,
@@ -18,6 +74,10 @@ export function shouldShowTodoPanel(
   if (!todoKey || todos.length === 0) return false;
   if (hasIncompleteTodos(todos)) return true;
   return todoKey !== dismissedTodoKey;
+}
+
+export function shouldOpenTodoPanelByDefault(todos: Todo[]): boolean {
+  return hasIncompleteTodos(todos);
 }
 
 function todoStatus(status: unknown): string {


### PR DESCRIPTION
## Summary

- Scope TodoPanel dismissal and expand/collapse state by active session path, with tab fallback for unsaved sessions, so switching between projects or sessions no longer reopens or hides another session's finished todo list.
- Treat task progress as a stable todo batch: incomplete/new batches open by default, completed batches auto-collapse into a reviewable summary, and users can still expand or close the completed list.
- Persist bounded completed-dismissal and open-state records, and add regression coverage for restored sessions, stale active-tab fallbacks, unsaved tabs, cross-session dismissals, and scoped batch state.

Fixes #5062
Related: #4343, #5212

## Verification

- `node scripts/test-todo-visibility.mjs`
- `pnpm test:typecheck`
- `pnpm test`
- `pnpm build`

## Cache impact

Cache-impact: none — desktop TodoPanel visibility/localStorage state only; no provider-visible prompt, memory prefix, tool schema/order, request serialization, compaction, reasoning upload, or MCP/tooling behavior changes.
Cache-guard: focused todo visibility regression test plus full frontend typecheck, test suite, and production build.
System-prompt-review: N/A
