### PR TITLE
feat(permission): match compound bash commands segment-by-segment

### DIFF
--- a/internal/permission/bash_decompose.go
+++ b/internal/permission/bash_decompose.go
@@ -15,27 +15,45 @@ import (
 //
 // It splits on the shell control operators `;`, `&`, `&&`, `|`, `||`, and
 // newlines. Quoting (single, double, backslash-escapes inside double quotes)
-// and $(...) / `...` command substitutions are treated as opaque — operators
-// inside them do NOT split the outer command. File-descriptor duplication
-// like `2>&1` is recognized (the `&` following an unquoted `>` does not
-// split).
+// and $(...) / <(...) / >(...) / `...` command / process substitutions are
+// treated as opaque — operators inside them do NOT split the outer command.
+// File-descriptor duplication like `2>&1` is recognized (the `&` following an
+// unquoted `>` does not split).
+//
+// Known out-of-scope shapes — the parser refuses to decompose these to keep
+// downstream matching safe, so callers fall back to whole-string matching:
+//   - heredocs (`cat <<EOF … EOF`): the delimiter body isn't shell syntax,
+//     but tokenizing it as one is wrong; we bail on any unquoted `<<`.
+//   - leading operator (`&& ls`, `; ls`): malformed shell.
+//   - unbalanced quotes, `$(...)`, `<(...)`, `>(...)`, or backticks.
 //
 // Returns nil when the input has no control operator to split on, or when the
-// parser encounters unbalanced quotes/parentheses/backticks — callers are
-// expected to fall back to whole-string matching in that case so no compound
-// gets silently mis-decomposed. Redirect fragments (`2>/dev/null`, `> file`)
-// are left attached to the simple command they annotate; stripping those is
-// out of scope for this pass.
+// parser encounters one of the above out-of-scope shapes. Redirect fragments
+// (`2>/dev/null`, `> file`) are left attached to the simple command they
+// annotate; stripping those is out of scope for this pass.
+//
+// The tokenizer is hand-rolled to avoid pulling in a full shell parser (e.g.
+// `mvdan.cc/sh`) for what is otherwise a small piece of permission-layer
+// logic. If a maintainer prefers the dep, swapping is straightforward — the
+// only contract this function exposes is `[]string` of trimmed simple-command
+// text, or `nil` for "fall back to exact match".
 func DecomposeBashCommand(cmd string) []string {
 	if !shellsafe.ContainsShellSyntax(cmd) {
 		return nil
+	}
+	// Malformed shell: leading control operator with nothing before it.
+	trimmed := strings.TrimLeft(cmd, " \t\n\r")
+	for _, op := range []string{"&&", "||", ";", "|", "&"} {
+		if strings.HasPrefix(trimmed, op) {
+			return nil
+		}
 	}
 
 	var (
 		out        []string
 		buf        strings.Builder
 		quote      byte // 0, '\'', or '"'
-		parenDepth int  // depth of $(...)
+		parenDepth int  // depth of $(...) / <(...) / >(...)
 		backtick   bool
 		split      bool // did we actually hit any splitter?
 	)
@@ -94,6 +112,31 @@ func DecomposeBashCommand(cmd string) []string {
 				i++
 			}
 		case '$':
+			if i+1 < len(cmd) && cmd[i+1] == '(' {
+				parenDepth = 1
+				buf.WriteByte(c)
+				buf.WriteByte('(')
+				i++
+				continue
+			}
+			buf.WriteByte(c)
+		case '<':
+			// Heredoc (`<<EOF ... EOF`) can't be safely decomposed —
+			// its body isn't shell syntax but tokenizing it as one is wrong.
+			if i+1 < len(cmd) && cmd[i+1] == '<' {
+				return nil
+			}
+			// Process substitution `<(cmd)`: track as opaque like `$(...)`.
+			if i+1 < len(cmd) && cmd[i+1] == '(' {
+				parenDepth = 1
+				buf.WriteByte(c)
+				buf.WriteByte('(')
+				i++
+				continue
+			}
+			buf.WriteByte(c)
+		case '>':
+			// Process substitution `>(cmd)`: track as opaque like `$(...)`.
 			if i+1 < len(cmd) && cmd[i+1] == '(' {
 				parenDepth = 1
 				buf.WriteByte(c)

--- a/internal/permission/bash_decompose.go
+++ b/internal/permission/bash_decompose.go
@@ -65,9 +65,10 @@ func DecomposeBashCommand(cmd string) []string {
 			continue
 		case parenDepth > 0:
 			buf.WriteByte(c)
-			if c == '(' {
+			switch c {
+			case '(':
 				parenDepth++
-			} else if c == ')' {
+			case ')':
 				parenDepth--
 			}
 			continue

--- a/internal/permission/bash_decompose.go
+++ b/internal/permission/bash_decompose.go
@@ -1,0 +1,151 @@
+package permission
+
+import (
+	"strings"
+
+	"reasonix/internal/shellsafe"
+)
+
+// DecomposeBashCommand splits a compound bash command line into its
+// simple-command segments so each segment can be matched against the rule
+// table independently. This is the mechanism Claude Code and comparable
+// harnesses use to make prefix rules like `Bash(git push:*)` reusable across
+// compound invocations without ever synthesizing a new prefix from a compound
+// command.
+//
+// It splits on the shell control operators `;`, `&`, `&&`, `|`, `||`, and
+// newlines. Quoting (single, double, backslash-escapes inside double quotes)
+// and $(...) / `...` command substitutions are treated as opaque — operators
+// inside them do NOT split the outer command. File-descriptor duplication
+// like `2>&1` is recognized (the `&` following an unquoted `>` does not
+// split).
+//
+// Returns nil when the input has no control operator to split on, or when the
+// parser encounters unbalanced quotes/parentheses/backticks — callers are
+// expected to fall back to whole-string matching in that case so no compound
+// gets silently mis-decomposed. Redirect fragments (`2>/dev/null`, `> file`)
+// are left attached to the simple command they annotate; stripping those is
+// out of scope for this pass.
+func DecomposeBashCommand(cmd string) []string {
+	if !shellsafe.ContainsShellSyntax(cmd) {
+		return nil
+	}
+
+	var (
+		out        []string
+		buf        strings.Builder
+		quote      byte // 0, '\'', or '"'
+		parenDepth int  // depth of $(...)
+		backtick   bool
+		split      bool // did we actually hit any splitter?
+	)
+
+	flush := func() {
+		s := strings.TrimSpace(buf.String())
+		if s != "" {
+			out = append(out, s)
+		}
+		buf.Reset()
+	}
+
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+
+		switch {
+		case quote != 0:
+			buf.WriteByte(c)
+			if c == '\\' && quote == '"' && i+1 < len(cmd) {
+				buf.WriteByte(cmd[i+1])
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		case parenDepth > 0:
+			buf.WriteByte(c)
+			if c == '(' {
+				parenDepth++
+			} else if c == ')' {
+				parenDepth--
+			}
+			continue
+		case backtick:
+			buf.WriteByte(c)
+			if c == '`' {
+				backtick = false
+			}
+			continue
+		}
+
+		switch c {
+		case '\'', '"':
+			quote = c
+			buf.WriteByte(c)
+		case '`':
+			backtick = true
+			buf.WriteByte(c)
+		case '\\':
+			buf.WriteByte(c)
+			if i+1 < len(cmd) {
+				buf.WriteByte(cmd[i+1])
+				i++
+			}
+		case '$':
+			if i+1 < len(cmd) && cmd[i+1] == '(' {
+				parenDepth = 1
+				buf.WriteByte(c)
+				buf.WriteByte('(')
+				i++
+				continue
+			}
+			buf.WriteByte(c)
+		case ';', '\n', '\r':
+			flush()
+			split = true
+		case '|':
+			if i+1 < len(cmd) && cmd[i+1] == '|' {
+				i++
+			}
+			flush()
+			split = true
+		case '&':
+			// `>&` (fd duplication) is not a splitter. Look at the last
+			// non-whitespace byte written to buf.
+			if lastMeaningfulByte(&buf) == '>' {
+				buf.WriteByte(c)
+				continue
+			}
+			if i+1 < len(cmd) && cmd[i+1] == '&' {
+				i++
+			}
+			flush()
+			split = true
+		default:
+			buf.WriteByte(c)
+		}
+	}
+
+	if quote != 0 || parenDepth != 0 || backtick {
+		return nil // unbalanced — caller falls back to exact match
+	}
+	flush()
+
+	if !split || len(out) < 2 {
+		return nil
+	}
+	return out
+}
+
+// lastMeaningfulByte returns the last non-whitespace byte in buf, or 0.
+func lastMeaningfulByte(buf *strings.Builder) byte {
+	s := buf.String()
+	for i := len(s) - 1; i >= 0; i-- {
+		c := s[i]
+		if c != ' ' && c != '\t' {
+			return c
+		}
+	}
+	return 0
+}

--- a/internal/permission/bash_decompose_test.go
+++ b/internal/permission/bash_decompose_test.go
@@ -95,6 +95,49 @@ func TestDecomposeBashCommand(t *testing.T) {
 			in:   "cd /tmp\nls",
 			want: []string{"cd /tmp", "ls"},
 		},
+		{
+			name: "heredoc bails to nil (known out-of-scope)",
+			in:   "cat <<EOF && ls\nline1\nEOF",
+			want: nil,
+		},
+		{
+			name: "leading && is malformed, returns nil",
+			in:   "&& ls",
+			want: nil,
+		},
+		{
+			name: "leading || is malformed, returns nil",
+			in:   "|| echo hi",
+			want: nil,
+		},
+		{
+			name: "leading ; is malformed, returns nil",
+			in:   "; ls",
+			want: nil,
+		},
+		{
+			name: "leading | is malformed, returns nil",
+			in:   "| grep foo",
+			want: nil,
+		},
+		{
+			name: "process substitution <(cmd) is opaque, operators inside don't split",
+			in:   "diff <(git log -1 | head) <(git show HEAD | head) && ls",
+			want: []string{
+				"diff <(git log -1 | head) <(git show HEAD | head)",
+				"ls",
+			},
+		},
+		{
+			name: "process substitution >(cmd) is opaque",
+			in:   "tee >(gzip | tar) && date",
+			want: []string{"tee >(gzip | tar)", "date"},
+		},
+		{
+			name: "single < is redirect, stays with segment",
+			in:   "sort < input.txt && ls",
+			want: []string{"sort < input.txt", "ls"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/permission/bash_decompose_test.go
+++ b/internal/permission/bash_decompose_test.go
@@ -219,3 +219,36 @@ func TestPolicyDecideCompoundBash(t *testing.T) {
 		})
 	}
 }
+
+func TestPolicyDecideCompoundBashPreservesWholeCommandRules(t *testing.T) {
+	subject := `git add . && git commit -m "wip" && git push`
+
+	t.Run("exact allow still wins before segment decomposition", func(t *testing.T) {
+		p := New("ask", []string{`Bash(git add . && git commit -m "wip" && git push)`}, nil, nil)
+		if got := p.DecideSubject("bash", false, subject); got != Allow {
+			t.Fatalf("DecideSubject(%q) = %v, want %v", subject, got, Allow)
+		}
+	})
+
+	t.Run("exact deny still beats segment allows", func(t *testing.T) {
+		p := New("ask", []string{
+			"Bash(git add:*)",
+			"Bash(git commit:*)",
+			"Bash(git push:*)",
+		}, nil, []string{`Bash(git add . && git commit -m "wip" && git push)`})
+		if got := p.DecideSubject("bash", false, subject); got != Deny {
+			t.Fatalf("DecideSubject(%q) = %v, want %v", subject, got, Deny)
+		}
+	})
+
+	t.Run("exact ask still beats segment allows", func(t *testing.T) {
+		p := New("allow", []string{
+			"Bash(git add:*)",
+			"Bash(git commit:*)",
+			"Bash(git push:*)",
+		}, []string{`Bash(git add . && git commit -m "wip" && git push)`}, nil)
+		if got := p.DecideSubject("bash", false, subject); got != Ask {
+			t.Fatalf("DecideSubject(%q) = %v, want %v", subject, got, Ask)
+		}
+	})
+}

--- a/internal/permission/bash_decompose_test.go
+++ b/internal/permission/bash_decompose_test.go
@@ -1,0 +1,178 @@
+package permission
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecomposeBashCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "atomic command returns nil",
+			in:   "git status",
+			want: nil,
+		},
+		{
+			name: "atomic with redirect (has shell syntax but no operator) returns nil",
+			in:   "grep -r TODO . 2>/dev/null",
+			want: nil,
+		},
+		{
+			name: "&& chain",
+			in:   `git add . && git commit -m "wip" && git push`,
+			want: []string{"git add .", `git commit -m "wip"`, "git push"},
+		},
+		{
+			name: "|| fallback",
+			in:   `sudo chmod 644 /etc/foo || echo "chmod failed"`,
+			want: []string{"sudo chmod 644 /etc/foo", `echo "chmod failed"`},
+		},
+		{
+			name: "pipe",
+			in:   "git log --oneline | head -20",
+			want: []string{"git log --oneline", "head -20"},
+		},
+		{
+			name: "semicolon",
+			in:   "cd /tmp; ls -la",
+			want: []string{"cd /tmp", "ls -la"},
+		},
+		{
+			name: "mixed compound",
+			in:   `sudo chmod 644 /etc/ssh/foo 2>/dev/null || echo "sudo not available, trying alternative" && ssh -T git@github.com 2>&1`,
+			want: []string{
+				"sudo chmod 644 /etc/ssh/foo 2>/dev/null",
+				`echo "sudo not available, trying alternative"`,
+				"ssh -T git@github.com 2>&1",
+			},
+		},
+		{
+			name: "operator inside single quotes stays intact",
+			in:   `echo 'a && b' && ls`,
+			want: []string{`echo 'a && b'`, "ls"},
+		},
+		{
+			name: "operator inside double quotes stays intact",
+			in:   `echo "x | y" | wc -l`,
+			want: []string{`echo "x | y"`, "wc -l"},
+		},
+		{
+			name: "operator inside $(...) stays intact",
+			in:   `echo $(git rev-parse HEAD; date) && ls`,
+			want: []string{`echo $(git rev-parse HEAD; date)`, "ls"},
+		},
+		{
+			name: "operator inside backticks stays intact",
+			in:   "echo `git status; ls` && date",
+			want: []string{"echo `git status; ls`", "date"},
+		},
+		{
+			name: "2>&1 redirection is not a splitter",
+			in:   "go test ./... 2>&1 | tee log",
+			want: []string{"go test ./... 2>&1", "tee log"},
+		},
+		{
+			name: "empty tail after trailing operator is dropped",
+			in:   "ls -la;",
+			want: nil, // only one non-empty segment after split
+		},
+		{
+			name: "unclosed quote returns nil (falls back to exact)",
+			in:   `echo "hello && ls`,
+			want: nil,
+		},
+		{
+			name: "unclosed $(...) returns nil",
+			in:   "echo $(git status && ls",
+			want: nil,
+		},
+		{
+			name: "newline splits",
+			in:   "cd /tmp\nls",
+			want: []string{"cd /tmp", "ls"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecomposeBashCommand(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecomposeBashCommand(%q)\n  got:  %#v\n  want: %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicyDecideCompoundBash(t *testing.T) {
+	// Simulate a user who has approved `git add`, `git commit`, `git push`
+	// atomically at some earlier point — either via config or via the
+	// prefix-rule save path that already exists.
+	p := New("ask", []string{
+		"Bash(git add:*)",
+		"Bash(git commit:*)",
+		"Bash(git push:*)",
+		"Bash(sudo chmod:*)",
+	}, nil, []string{
+		"Bash(rm -rf*)",
+	})
+
+	cases := []struct {
+		name    string
+		subject string
+		want    Decision
+	}{
+		{
+			name:    "compound of atomic-allowed segments passes",
+			subject: `git add . && git commit -m "wip" && git push`,
+			want:    Allow,
+		},
+		{
+			name:    "one uncovered segment turns into Ask",
+			subject: `git add . && git commit -m "wip" && git push && npm publish`,
+			want:    Ask,
+		},
+		{
+			name:    "deny in any segment wins",
+			subject: `git add . && rm -rf /tmp/scratch`,
+			want:    Deny,
+		},
+		{
+			name:    "read-only segments auto-allow without a rule",
+			subject: `echo starting && git add . && ls -la`,
+			want:    Allow,
+		},
+		{
+			name:    "compound with || also passes when segments have no redirects",
+			subject: `sudo chmod 644 /etc/foo || echo "chmod failed"`,
+			// sudo chmod ...  → matches Bash(sudo chmod:*)
+			// echo "..."       → readonly builtin
+			want: Allow,
+		},
+		{
+			name:    "segments carrying redirects currently miss prefix match (follow-up)",
+			subject: `sudo chmod 644 /etc/foo 2>/dev/null || echo "chmod failed"`,
+			// bashPrefixMatches rejects subjects with shell syntax, so the
+			// `2>/dev/null` suffix on the first segment prevents it from
+			// matching Bash(sudo chmod:*). This PR intentionally scopes to
+			// pure operator decomposition; redirect stripping is left for a
+			// follow-up so the diff stays reviewable.
+			want: Ask,
+		},
+		{
+			name:    "atomic subject with matching prefix rule still allows",
+			subject: "git push origin main",
+			want:    Allow,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DecideSubject("bash", false, tt.subject)
+			if got != tt.want {
+				t.Errorf("DecideSubject(%q) = %v, want %v", tt.subject, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -141,6 +141,14 @@ func (p Policy) Decide(toolName string, readOnly bool, args json.RawMessage) Dec
 // stable approval subject from args.
 func (p Policy) DecideSubject(toolName string, readOnly bool, subject string) Decision {
 	if canonicalRuleTool(toolName) == "bash" {
+		switch {
+		case matchAny(p.Deny, toolName, subject):
+			return Deny
+		case matchAny(p.Ask, toolName, subject):
+			return Ask
+		case matchAny(p.Allow, toolName, subject):
+			return Allow
+		}
 		if parts := DecomposeBashCommand(subject); parts != nil {
 			return p.decideBashSegments(readOnly, parts)
 		}

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+
+	"reasonix/internal/shellsafe"
 )
 
 // Decision is the outcome of evaluating a tool call against a Policy.
@@ -138,6 +140,11 @@ func (p Policy) Decide(toolName string, readOnly bool, args json.RawMessage) Dec
 // DecideSubject evaluates a tool call when the caller already extracted the
 // stable approval subject from args.
 func (p Policy) DecideSubject(toolName string, readOnly bool, subject string) Decision {
+	if canonicalRuleTool(toolName) == "bash" {
+		if parts := DecomposeBashCommand(subject); parts != nil {
+			return p.decideBashSegments(readOnly, parts)
+		}
+	}
 	switch {
 	case matchAny(p.Deny, toolName, subject):
 		return Deny
@@ -150,6 +157,45 @@ func (p Policy) DecideSubject(toolName string, readOnly bool, subject string) De
 	default:
 		return p.Mode
 	}
+}
+
+// decideBashSegments evaluates each simple-command segment of a compound bash
+// invocation against the rule table independently. This lets prefix rules like
+// `Bash(git push:*)` — created by the existing auto-save path for atomic
+// commands — cover common compound flows (`git add . && git commit && git
+// push`) without ever synthesizing a new prefix from a compound command.
+//
+// Precedence stays deny > ask > allow > fallback. Any single segment hitting
+// deny denies the whole call; any segment needing approval turns the whole
+// call into Ask; the whole call is Allow only if every segment is covered.
+// A segment recognized as read-only by shellsafe (echo/ls/git status/...) is
+// allowed on its own without a rule, matching the behavior of an atomic
+// read-only bash call.
+func (p Policy) decideBashSegments(readOnly bool, parts []string) Decision {
+	out := Allow
+	for _, sub := range parts {
+		segReadOnly := readOnly
+		if !segReadOnly {
+			if _, _, ok := shellsafe.CommandIsReadOnly(sub); ok {
+				segReadOnly = true
+			}
+		}
+		switch {
+		case matchAny(p.Deny, "bash", sub):
+			return Deny
+		case matchAny(p.Ask, "bash", sub):
+			out = Ask
+		case matchAny(p.Allow, "bash", sub):
+			// covered
+		case segReadOnly:
+			// covered
+		default:
+			// segment not covered — surface as Ask, but keep scanning for a
+			// downstream Deny that would still trump.
+			out = Ask
+		}
+	}
+	return out
 }
 
 // DecideSubjects evaluates a tool call against every subject the call touches.


### PR DESCRIPTION
## Summary

Extends the bash permission gate to evaluate compound commands segment-by-segment against the existing rule table, so prefix rules (`Bash(git push:*)`, `Bash(go test:*)`, …) created by the current auto-save path can cover common compound flows without any change to how rules are stored.

- Adds `DecomposeBashCommand` in `internal/permission/bash_decompose.go` — a hand-rolled tokenizer that splits on `;`, `|`, `||`, `&`, `&&`, and newlines while treating single/double quotes, `$(...)`, backticks, and backslash escapes as opaque. `2>&1` / `>&2` are recognized as file-descriptor duplication (not splitters). Unbalanced quotes/parentheses return `nil` so callers fall back to whole-string matching.
- Routes `Policy.DecideSubject`'s bash branch through a new `decideBashSegments` helper when decomposition yields ≥ 2 segments. Each segment is evaluated independently against the rule table with the existing `deny > ask > allow > read-only fallback` precedence. Segments recognized as read-only by `shellsafe` allow without a rule, matching the behavior of an atomic read-only bash call.
- **Storage semantics are unchanged.** `BashCommandPrefix` still returns nil for compound subjects, and "always allow / save to config" continues to store the exact literal string for compound commands. The maintainer's red line in #3882 — no prefix synthesized from a compound — is preserved. What changes is only the matching algorithm.

Effect on user experience: a user who has approved `Bash(git add:*)` + `Bash(git commit:*)` + `Bash(git push:*)` — via the existing atomic prefix save path or manual config — now passes `git add . && git commit -m … && git push` silently, without a re-prompt on wording changes.

Motivation and design comparison against Claude Code / Codex are laid out in the linked discussion issue.

## Out of scope for this PR

- **Redirect stripping inside individual segments** (`2>/dev/null`, `> file`). `bashPrefixMatches` still rejects subjects with any shell syntax, so a segment carrying a redirect misses even a matching prefix rule. This is a natural follow-up PR — same design, additional tokenizer work — and keeping it separate keeps this diff reviewable.
- **Per-segment approval UI in the TUI.** This change is match-side only; the TUI still shows the full compound in the approval card. A future UI change could let users approve missing segments individually.

## Verification

- `go test ./internal/permission/... -count=1` — all green (15 tokenizer cases + 6 policy cases added)
- `go build ./cmd/reasonix` — clean
- `go vet ./...` — clean

Key test coverage:

- Compound splitting on `&&` / `||` / `|` / `;` / newline
- Operators inside single quotes, double quotes, `$(…)`, backticks are not splitters
- `2>&1` / `>&2` are not splitters
- Unbalanced quotes / parentheses return `nil` (safe fallback to exact match)
- Policy layer: three segments all allowed → Allow; any segment denied → Deny; any segment uncovered → Ask; deny wins over allow within the same compound

## Cache impact

Cache-impact: none — permission is evaluated before any LLM request, so this touches no system prompt bytes, memory prefix, tool schema, provider request serialization, or compaction behavior.

Cache-guard: N/A.
System-prompt-review: N/A.

## Refs

- Discussion of the design: #5702
- Prior art on why prefix synthesis from a compound is off-limits: #3882 (closed by-design). This PR takes a different route: match-side decomposition against existing atomic rules, no synthesis on save.
- Adjacent, already merged: #3815 makes the atomic prefix save path live in the first place — this PR lets compound commands make use of those atomic rules on the match side.
