### PR TITLE
fix(desktop): Restore session profile on switch / 修复切会话恢复权限与思考模式

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2699,11 +2699,13 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
 		return nil
 	}
+	profile := loadTabSessionProfile(sessionPath)
 
 	ctrl := tab.Ctrl
 	if ctrl == nil {
 		a.mu.Lock()
 		tab.SessionPath = sessionPath
+		applyTabSessionProfile(tab, profile)
 		tab.Ready = false
 		tab.StartupErr = ""
 		tab.ActivityStatus = ""
@@ -2721,6 +2723,9 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	}
 
 	_ = a.snapshotTab(tab) // persist writable sessions before switching the view.
+	if oldPath := a.reconciledSessionPathForTab(tab); oldPath != "" {
+		_ = saveTabSessionMeta(tab, oldPath)
+	}
 	if tab.hasActiveRuntimeWork() {
 		if !a.detachRuntimeForReplacement(tab) {
 			return fmt.Errorf("current session runtime cannot be detached")
@@ -2732,6 +2737,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	a.mu.Lock()
 	tab.Ctrl = nil
 	tab.SessionPath = sessionPath
+	applyTabSessionProfile(tab, profile)
 	tab.Ready = false
 	tab.StartupErr = ""
 	tab.ActivityStatus = ""

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 	"reasonix/internal/tool"
 )
 
@@ -896,6 +897,162 @@ func TestRebindTabToLoadedSessionPersistsAndRestoresSessionProfile(t *testing.T)
 	}
 	if got := currentTabToolApprovalMode(tab); got != control.ToolApprovalYolo {
 		t.Fatalf("rebound tool approval = %q, want yolo", got)
+	}
+}
+
+func TestCloseTabPersistsSessionProfileBeforeRemovingVisibleTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	currentPath := filepath.Join(dir, "profile.jsonl")
+	otherPath := filepath.Join(dir, "other.jsonl")
+	writeHistoryTestSession(t, currentPath, "profile prompt")
+	writeHistoryTestSession(t, otherPath, "other prompt")
+	if err := agent.SaveBranchMetaPreserveUpdated(currentPath, agent.BranchMeta{}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated current: %v", err)
+	}
+
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: currentPath, Label: "profile", Sink: event.Discard})
+	ctrl.SetMode(true, false)
+	ctrl.SetToolApprovalMode(control.ToolApprovalAuto)
+	ctrl.SetGoal("finish the review")
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:               "profile",
+		Scope:            "global",
+		WorkspaceRoot:    root,
+		SessionPath:      currentPath,
+		Ctrl:             ctrl,
+		Ready:            true,
+		tokenMode:        boot.TokenModeEconomy,
+		mode:             "plan",
+		toolApprovalMode: control.ToolApprovalAuto,
+		sink:             &tabEventSink{tabID: "profile", app: app},
+		disabledMCP:      map[string]ServerView{},
+	}
+	other := &WorkspaceTab{
+		ID:            "other",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   otherPath,
+		Ready:         true,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabs[other.ID] = other
+	app.tabOrder = []string{tab.ID, other.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.CloseTab(tab.ID); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(currentPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta current ok=%v err=%v", ok, err)
+	}
+	if meta.TokenMode != boot.TokenModeEconomy || meta.Mode != "plan" || meta.ToolApprovalMode != control.ToolApprovalAuto || meta.Goal != "finish the review" {
+		t.Fatalf("closed session profile = token:%q mode:%q approval:%q goal:%q, want economy/plan/auto/goal",
+			meta.TokenMode, meta.Mode, meta.ToolApprovalMode, meta.Goal)
+	}
+}
+
+func TestKeepOnlyVisibleTabPersistsRemovedSessionProfile(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	keepPath := filepath.Join(dir, "keep.jsonl")
+	removedPath := filepath.Join(dir, "removed.jsonl")
+	writeHistoryTestSession(t, keepPath, "keep prompt")
+	writeHistoryTestSession(t, removedPath, "removed prompt")
+	if err := agent.SaveBranchMetaPreserveUpdated(removedPath, agent.BranchMeta{}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated removed: %v", err)
+	}
+
+	removedCtrl := control.New(control.Options{SessionDir: dir, SessionPath: removedPath, Label: "removed", Sink: event.Discard})
+	removedCtrl.SetMode(true, false)
+	removedCtrl.SetToolApprovalMode(control.ToolApprovalAuto)
+	removedCtrl.SetGoal("keep this profile")
+
+	app := NewApp()
+	keep := &WorkspaceTab{
+		ID:            "keep",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   keepPath,
+		Ready:         true,
+		disabledMCP:   map[string]ServerView{},
+	}
+	removed := &WorkspaceTab{
+		ID:               "removed",
+		Scope:            "global",
+		WorkspaceRoot:    root,
+		SessionPath:      removedPath,
+		Ctrl:             removedCtrl,
+		Ready:            true,
+		tokenMode:        boot.TokenModeEconomy,
+		mode:             "plan",
+		toolApprovalMode: control.ToolApprovalAuto,
+		sink:             &tabEventSink{tabID: "removed", app: app},
+		disabledMCP:      map[string]ServerView{},
+	}
+	app.tabs[keep.ID] = keep
+	app.tabs[removed.ID] = removed
+	app.tabOrder = []string{keep.ID, removed.ID}
+	app.activeTabID = removed.ID
+
+	if _, err := app.keepOnlyVisibleTab(keep.ID); err != nil {
+		t.Fatalf("keepOnlyVisibleTab: %v", err)
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(removedPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta removed ok=%v err=%v", ok, err)
+	}
+	if meta.TokenMode != boot.TokenModeEconomy || meta.Mode != "plan" || meta.ToolApprovalMode != control.ToolApprovalAuto || meta.Goal != "keep this profile" {
+		t.Fatalf("removed session profile = token:%q mode:%q approval:%q goal:%q, want economy/plan/auto/goal",
+			meta.TokenMode, meta.Mode, meta.ToolApprovalMode, meta.Goal)
+	}
+}
+
+func TestLoadTabSessionProfileIgnoresTerminalGoalState(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	sessionPath := filepath.Join(dir, "terminal-goal.jsonl")
+	writeHistoryTestSession(t, sessionPath, "terminal prompt")
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		TokenMode:        boot.TokenModeEconomy,
+		Mode:             "plan",
+		ToolApprovalMode: control.ToolApprovalAuto,
+		Goal:             "stale terminal goal",
+	}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated: %v", err)
+	}
+	if err := os.WriteFile(store.SessionGoalState(sessionPath), []byte(`{"goal":"stale terminal goal","status":"complete"}`), 0o644); err != nil {
+		t.Fatalf("write goal state: %v", err)
+	}
+
+	profile := loadTabSessionProfile(sessionPath)
+	if profile.goal != "" {
+		t.Fatalf("loaded profile goal = %q, want terminal goal ignored", profile.goal)
+	}
+	if profile.tokenMode != boot.TokenModeEconomy || profile.mode != "plan" || profile.toolApprovalMode != control.ToolApprovalAuto {
+		t.Fatalf("loaded profile = token:%q mode:%q approval:%q, want economy/plan/auto",
+			profile.tokenMode, profile.mode, profile.toolApprovalMode)
 	}
 }
 

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/boot"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -825,6 +826,76 @@ func TestRebindTabToLoadedSessionReusesPreloadedTranscript(t *testing.T) {
 	}
 	if gotPath := app.tabs[tab.ID].Ctrl.SessionPath(); gotPath != targetPath {
 		t.Fatalf("rebound session path = %q, want %q", gotPath, targetPath)
+	}
+}
+
+func TestRebindTabToLoadedSessionPersistsAndRestoresSessionProfile(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	currentPath := filepath.Join(dir, "current.jsonl")
+	targetPath := filepath.Join(dir, "target.jsonl")
+	writeHistoryTestSession(t, currentPath, "current prompt")
+	writeHistoryTestSession(t, targetPath, "target prompt")
+	if err := agent.SaveBranchMetaPreserveUpdated(targetPath, agent.BranchMeta{
+		TokenMode:        boot.TokenModeFull,
+		Mode:             "yolo",
+		ToolApprovalMode: control.ToolApprovalYolo,
+	}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated target: %v", err)
+	}
+
+	loaded, err := agent.LoadSession(targetPath)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: currentPath, Label: "current", Sink: event.Discard})
+	ctrl.SetMode(true, false)
+	ctrl.SetToolApprovalMode(control.ToolApprovalAuto)
+	defer ctrl.Close()
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:               "tab",
+		Scope:            "global",
+		WorkspaceRoot:    root,
+		SessionPath:      currentPath,
+		Ctrl:             ctrl,
+		Ready:            true,
+		tokenMode:        boot.TokenModeEconomy,
+		mode:             "plan",
+		toolApprovalMode: control.ToolApprovalAuto,
+		sink:             &tabEventSink{tabID: "tab", app: app},
+		disabledMCP:      map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.rebindTabToLoadedSessionPath(tab, targetPath, loaded); err != nil {
+		t.Fatalf("rebindTabToLoadedSessionPath: %v", err)
+	}
+
+	currentMeta, ok, err := agent.LoadBranchMeta(currentPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta current ok=%v err=%v", ok, err)
+	}
+	if currentMeta.TokenMode != boot.TokenModeEconomy || currentMeta.Mode != "plan" || currentMeta.ToolApprovalMode != control.ToolApprovalAuto {
+		t.Fatalf("current session profile = token:%q mode:%q approval:%q, want economy/plan/auto",
+			currentMeta.TokenMode, currentMeta.Mode, currentMeta.ToolApprovalMode)
+	}
+	if got := currentTabTokenMode(tab); got != boot.TokenModeFull {
+		t.Fatalf("rebound token mode = %q, want full", got)
+	}
+	if got := currentTabMode(tab); got != "yolo" {
+		t.Fatalf("rebound mode = %q, want yolo", got)
+	}
+	if got := currentTabToolApprovalMode(tab); got != control.ToolApprovalYolo {
+		t.Fatalf("rebound tool approval = %q, want yolo", got)
 	}
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1318,18 +1318,17 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			return TabMeta{}, err
 		}
 	}
+	profile := loadTabSessionProfile(sessionPath)
 	tab := &WorkspaceTab{
-		ID:               tabID,
-		Scope:            scope,
-		WorkspaceRoot:    actualRoot,
-		TopicID:          topicID,
-		TopicTitle:       topicTitle,
-		SessionPath:      sessionPath,
-		tokenMode:        boot.TokenModeFull,
-		mode:             "normal",
-		toolApprovalMode: control.ToolApprovalAsk,
-		disabledMCP:      map[string]ServerView{},
+		ID:            tabID,
+		Scope:         scope,
+		WorkspaceRoot: actualRoot,
+		TopicID:       topicID,
+		TopicTitle:    topicTitle,
+		SessionPath:   sessionPath,
+		disabledMCP:   map[string]ServerView{},
 	}
+	applyTabSessionProfile(tab, profile)
 	tab.sink = &tabEventSink{tabID: tabID, app: a}
 
 	a.tabs[tabID] = tab
@@ -5631,11 +5630,64 @@ func saveTabSessionMeta(tab *WorkspaceTab, path string) error {
 	m.WorkspaceRoot = workspaceRoot
 	m.TopicID = tab.TopicID
 	m.TopicTitle = tab.TopicTitle
+	m.TokenMode = persistedTabTokenMode(currentTabTokenMode(tab))
+	m.Mode = persistedTabMode(currentTabMode(tab))
+	m.ToolApprovalMode = persistedToolApprovalMode(currentTabToolApprovalMode(tab))
+	m.Goal = strings.TrimSpace(currentTabGoal(tab))
 	if err := agent.SaveBranchMetaPreserveUpdated(path, m); err != nil {
 		return err
 	}
 	invalidateTopicSessionIndexForPath(path)
 	return nil
+}
+
+type tabSessionProfile struct {
+	tokenMode        string
+	mode             string
+	toolApprovalMode string
+	goal             string
+}
+
+func defaultTabSessionProfile() tabSessionProfile {
+	return tabSessionProfile{
+		tokenMode:        boot.TokenModeFull,
+		mode:             "normal",
+		toolApprovalMode: control.ToolApprovalAsk,
+	}
+}
+
+func tabSessionProfileFromMeta(meta agent.BranchMeta) tabSessionProfile {
+	profile := defaultTabSessionProfile()
+	profile.tokenMode = boot.NormalizeTokenMode(meta.TokenMode)
+	profile.mode = normalizeTabMode(meta.Mode)
+	profile.toolApprovalMode = normalizeToolApprovalMode(meta.ToolApprovalMode)
+	if profile.toolApprovalMode == control.ToolApprovalAsk && tabModeHasAutoApproveTools(meta.Mode) {
+		profile.toolApprovalMode = control.ToolApprovalYolo
+	}
+	profile.goal = strings.TrimSpace(meta.Goal)
+	return profile
+}
+
+func loadTabSessionProfile(sessionPath string) tabSessionProfile {
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return defaultTabSessionProfile()
+	}
+	return tabSessionProfileFromMeta(meta)
+}
+
+func applyTabSessionProfile(tab *WorkspaceTab, profile tabSessionProfile) {
+	if tab == nil {
+		return
+	}
+	tab.tokenMode = boot.NormalizeTokenMode(profile.tokenMode)
+	tab.mode = normalizeTabMode(profile.mode)
+	tab.toolApprovalMode = normalizeToolApprovalMode(profile.toolApprovalMode)
+	if tab.toolApprovalMode == control.ToolApprovalAsk && tabModeHasAutoApproveTools(tab.mode) {
+		tab.toolApprovalMode = control.ToolApprovalYolo
+	}
+	tab.mode = tabModeFromAxes(tabModeHasPlan(tab.mode), tab.toolApprovalMode == control.ToolApprovalYolo)
+	tab.goal = strings.TrimSpace(profile.goal)
 }
 
 func canonicalTabSessionPath(path string) string {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -28,6 +28,7 @@ import (
 	"reasonix/internal/eventwire"
 	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 // --- WorkspaceTab -----------------------------------------------------------
@@ -1825,6 +1826,7 @@ func (a *App) CloseTab(tabID string) error {
 	if tab.Ctrl != nil && !tab.ReadOnly {
 		_ = tab.Ctrl.Snapshot()
 	}
+	saveTabSessionMetaForCurrentSession(tab)
 	if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
 		a.markTabRemovedLocked(tab)
 	}
@@ -1898,6 +1900,7 @@ func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
 		if tab.Ctrl != nil && !tab.ReadOnly {
 			_ = tab.Ctrl.Snapshot()
 		}
+		saveTabSessionMetaForCurrentSession(tab)
 		if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
 			a.markTabRemovedLocked(tab)
 		}
@@ -2896,7 +2899,7 @@ func (a *App) saveTabsCollectLocked() (string, []desktopTabEntry, string, uint64
 				Effort:           cloneStringPtr(tab.effort),
 				TokenMode:        persistedTabTokenMode(currentTabTokenMode(tab)),
 				Mode:             persistedTabMode(currentTabMode(tab)),
-				Goal:             strings.TrimSpace(currentTabGoal(tab)),
+				Goal:             persistedTabGoal(tab),
 				ToolApprovalMode: persistedToolApprovalMode(currentTabToolApprovalMode(tab)),
 			})
 		}
@@ -5633,12 +5636,46 @@ func saveTabSessionMeta(tab *WorkspaceTab, path string) error {
 	m.TokenMode = persistedTabTokenMode(currentTabTokenMode(tab))
 	m.Mode = persistedTabMode(currentTabMode(tab))
 	m.ToolApprovalMode = persistedToolApprovalMode(currentTabToolApprovalMode(tab))
-	m.Goal = strings.TrimSpace(currentTabGoal(tab))
+	m.Goal = persistedTabGoal(tab)
 	if err := agent.SaveBranchMetaPreserveUpdated(path, m); err != nil {
 		return err
 	}
 	invalidateTopicSessionIndexForPath(path)
 	return nil
+}
+
+func tabSessionMetaPathForCurrentSession(tab *WorkspaceTab) string {
+	if tab == nil {
+		return ""
+	}
+	path := strings.TrimSpace(tab.currentSessionPath())
+	if path == "" {
+		return ""
+	}
+	for _, dir := range []string{tabRuntimeSessionDir(tab), tabSessionDir(tab)} {
+		if resolved, ok := pinnedTabSessionPath(dir, path); ok {
+			return resolved
+		}
+	}
+	path = canonicalTabSessionPath(path)
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return ""
+}
+
+func saveTabSessionMetaForCurrentSession(tab *WorkspaceTab) {
+	if tab == nil || tab.ReadOnly {
+		return
+	}
+	if _, discard := transientBlankSessionArtifactPath(tab); discard {
+		return
+	}
+	path := tabSessionMetaPathForCurrentSession(tab)
+	if path == "" {
+		return
+	}
+	_ = saveTabSessionMeta(tab, path)
 }
 
 type tabSessionProfile struct {
@@ -5656,7 +5693,7 @@ func defaultTabSessionProfile() tabSessionProfile {
 	}
 }
 
-func tabSessionProfileFromMeta(meta agent.BranchMeta) tabSessionProfile {
+func tabSessionProfileFromMeta(sessionPath string, meta agent.BranchMeta) tabSessionProfile {
 	profile := defaultTabSessionProfile()
 	profile.tokenMode = boot.NormalizeTokenMode(meta.TokenMode)
 	profile.mode = normalizeTabMode(meta.Mode)
@@ -5664,7 +5701,7 @@ func tabSessionProfileFromMeta(meta agent.BranchMeta) tabSessionProfile {
 	if profile.toolApprovalMode == control.ToolApprovalAsk && tabModeHasAutoApproveTools(meta.Mode) {
 		profile.toolApprovalMode = control.ToolApprovalYolo
 	}
-	profile.goal = strings.TrimSpace(meta.Goal)
+	profile.goal = runningTabSessionGoal(sessionPath, meta.Goal)
 	return profile
 }
 
@@ -5673,7 +5710,7 @@ func loadTabSessionProfile(sessionPath string) tabSessionProfile {
 	if err != nil || !ok {
 		return defaultTabSessionProfile()
 	}
-	return tabSessionProfileFromMeta(meta)
+	return tabSessionProfileFromMeta(sessionPath, meta)
 }
 
 func applyTabSessionProfile(tab *WorkspaceTab, profile tabSessionProfile) {
@@ -5688,6 +5725,45 @@ func applyTabSessionProfile(tab *WorkspaceTab, profile tabSessionProfile) {
 	}
 	tab.mode = tabModeFromAxes(tabModeHasPlan(tab.mode), tab.toolApprovalMode == control.ToolApprovalYolo)
 	tab.goal = strings.TrimSpace(profile.goal)
+}
+
+func persistedTabGoal(tab *WorkspaceTab) string {
+	goal := strings.TrimSpace(currentTabGoal(tab))
+	if goal == "" || currentTabGoalStatus(tab) != control.GoalStatusRunning {
+		return ""
+	}
+	return goal
+}
+
+type tabSessionGoalState struct {
+	Goal   string `json:"goal,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+func runningTabSessionGoal(sessionPath, fallback string) string {
+	fallback = strings.TrimSpace(fallback)
+	if fallback == "" {
+		return ""
+	}
+	data, err := os.ReadFile(store.SessionGoalState(sessionPath))
+	if err != nil {
+		return fallback
+	}
+	var state tabSessionGoalState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fallback
+	}
+	switch state.Status {
+	case control.GoalStatusRunning:
+		if goal := strings.TrimSpace(state.Goal); goal != "" {
+			return goal
+		}
+		return fallback
+	case "", control.GoalStatusStopped:
+		return ""
+	default:
+		return ""
+	}
 }
 
 func canonicalTabSessionPath(path string) string {

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -29,6 +29,10 @@ type BranchMeta struct {
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
 	Model            string    `json:"model,omitempty"`
+	TokenMode        string    `json:"token_mode,omitempty"`
+	Mode             string    `json:"mode,omitempty"`
+	ToolApprovalMode string    `json:"tool_approval_mode,omitempty"`
+	Goal             string    `json:"goal,omitempty"`
 	// SchemaVersion records the BranchMeta version that last wrote the listing
 	// fields (Turns/Preview) FROM the session's content. It is stamped only by the
 	// writers that actually derive those counts — Controller.snapshot's


### PR DESCRIPTION
## Summary

- Persist per-session desktop profile fields in session metadata: token mode, collaboration/tool mode, tool approval mode, and goal.
- Restore those fields when opening or rebinding to a saved session so switching across projects or history entries keeps that session's own permissions and thinking profile.
- Add a regression test for rebinding from one saved session to another while preserving the old session profile and applying the target profile.

## Verification

- `go test ./internal/agent`
- `cd desktop && go test .`

## Cache impact

Cache-impact: none, desktop session metadata and controller restore behavior only; no provider-visible prompt, tool schema, or request serialization changes.
Cache-guard: `go test ./internal/agent`; `cd desktop && go test .`
System-prompt-review: N/A