### PR TITLE
Real-time Token Statistics Floating Bar / 实时 Token 统计悬浮窗

### DIFF
--- a/PR_STATS_BAR.md
+++ b/PR_STATS_BAR.md
@@ -1,0 +1,212 @@
+# PR: Real-time Token Statistics Floating Bar / 实时 Token 统计悬浮窗
+
+> **Branch:** `feature/stats-bar`
+> **Base:** `main-v2`
+> **Author:** Reasonix Admin
+
+---
+
+## Overview / 概述
+
+This PR adds a real-time token statistics display to the desktop chat interface, showing input tokens (cache miss), cache hit tokens, output tokens, tokens-per-second, and elapsed time — both during streaming (in the Composer stop button area) and after completion (alongside the fork/summary/rewind action buttons). Stats are persisted across session switches and application restarts.
+
+本 PR 为桌面客户端聊天界面增加了实时 Token 统计显示功能：输入 Token（未命中缓存）、缓存命中 Token、输出 Token、生成速度（tok/s）和耗时。流式过程中显示在 Composer 停止按钮区域，对话完成后显示在分叉/总结/回溯按钮旁。统计数据跨会话切换和应用重启持久化。
+
+---
+
+## Changes Summary / 变更总览
+
+| File / 文件 | Type / 类型 | Description / 描述 |
+|------------|-------------|-------------------|
+| `desktop/frontend/src/components/StatsBar.tsx` | **NEW** | `LiveStatsContext` provider for streaming stats data |
+| `desktop/frontend/src/components/Message.tsx` | MODIFIED | TurnActions stats box, timestamp format, assistant timestamps |
+| `desktop/frontend/src/components/Transcript.tsx` | MODIFIED | Track usage/userCreatedAt, pass to TurnActions |
+| `desktop/frontend/src/components/Composer.tsx` | MODIFIED | Real-time stats in stop button area |
+| `desktop/frontend/src/App.tsx` | MODIFIED | Pass accumulated state to Composer/Transcript |
+| `desktop/frontend/src/styles.css` | MODIFIED | Styles for stats components |
+| `desktop/frontend/src/lib/useController.ts` | MODIFIED | Global accumulators, item types, event handling |
+| `desktop/frontend/src/lib/types.ts` | MODIFIED | `HistoryMessage.usage` field |
+| `internal/provider/provider.go` | MODIFIED | `Message.Usage` field, `Usage` JSON tags, `Message.CreatedAt` |
+| `internal/agent/agent.go` | MODIFIED | Pass `Usage` + `CreatedAt` on `session.Add` |
+| `desktop/app.go` | MODIFIED | `HistoryMessage.Usage` + `CreatedAt`, load-time copying |
+
+---
+
+## Detailed Changes / 详细变更
+
+### 1. StatsBar.tsx (New File / 新文件)
+
+**Purpose / 用途:** Provides `LiveStatsContext` which carries streaming state (usage, turnStartAt, running) to child components. Used by `Transcript.tsx` to share real-time usage data with the hot zone.
+
+**Exports / 导出:**
+- `LiveStats` — Interface with `usage?: WireUsage`, `turnStartAt?: number`, `running: boolean`
+- `LiveStatsContext` — React context for consuming live stats data
+
+---
+
+### 2. Message.tsx — TurnActions Stats Box / 对话操作栏统计框
+
+**Purpose / 用途:** Adds a token statistics box to the right of the fork/summary/rewind action buttons after a turn completes.
+
+**New functions / 新函数:**
+- `fmtTurnToken(n)` — Format token count (1.2K, 3.4M, etc.)
+- `fmtTurnElapsed(userCreatedAt)` — Compute elapsed seconds from user message timestamp (`Date.now() - userCreatedAt`)
+- `fmtTurnTps(tokens, userCreatedAt)` — Compute real tokens-per-second from output tokens and elapsed time
+
+**Changes / 改动:**
+- Added `usage` and `userCreatedAt` props to `TurnActions`
+- Replaced fake TPS (`completionTokens / 5`) with real computation from timestamps
+- Changed `formatMessageTime` from `HH:MM` to `HH:MM:SS`
+- Added timestamp display to `AssistantMessage` (via `item.createdAt`)
+
+---
+
+### 3. Composer.tsx — Stop Button Area Stats / 停止按钮区域统计
+
+**Purpose / 用途:** Displays real-time token statistics while the model is generating.
+
+**Changes / 改动:**
+- Added `turnCacheHitTokens` and `turnCacheMissTokens` props
+- Display input miss (`cacheMissTokens`) instead of total input (`promptTokens`)
+- TPS updates every second via `useTick(running)`
+
+---
+
+### 4. useController.ts — State Accumulators / 状态累加器
+
+**Purpose / 用途:** Core state management for per-turn and global token accumulation.
+
+**New state fields / 新增状态字段:**
+
+| Field / 字段 | Description / 说明 |
+|-------------|-------------------|
+| `turnPromptTokens` | Per-turn accumulated prompt tokens (deprecated, replaced by global deltas) |
+| `turnCacheHitTokens` | Per-turn accumulated cache hit tokens |
+| `turnCacheMissTokens` | Per-turn accumulated cache miss tokens |
+| `globalTokens` | Total tokens across entire session (never reset) |
+| `globalCacheHitTokens` | Total cache hit tokens across entire session |
+| `globalCacheMissTokens` | Total cache miss tokens across entire session |
+| `turnStartGlobalTokens` | Snapshot of `globalTokens` at turn start (for computing turn delta) |
+| `turnStartGlobalCacheHit` | Snapshot of `globalCacheHitTokens` at turn start |
+| `turnStartGlobalCacheMiss` | Snapshot of `globalCacheMissTokens` at turn start |
+
+**Key event handlers / 关键事件处理:**
+
+| Event / 事件 | Logic / 逻辑 |
+|-------------|-------------|
+| `turn_started` | Snapshot global accumulators, reset per-turn accumulators; update previous turn's item with final delta |
+| `usage` | Update global accumulators from `e.usage`; set `item.usage` with accumulated values |
+| `turn_done` | Update last assistant item with final turn delta from global accumulators (catches background calls) |
+| `message` | Set `item.usage` with accumulated turn delta |
+
+**Item types / 消息类型:**
+- `assistant` item: added `createdAt?: number` and `usage?: WireUsage`
+
+**History loading / 历史加载:**
+- `historyMessagesToItems`: copies `m.usage` to assistant items for persistence
+
+---
+
+### 5. provider.go & agent.go — Go Backend Persistence / Go 后端持久化
+
+**provider.go:**
+- `Message.Usage *Usage` — Store per-message token telemetry
+- `Usage` struct: added `json:` tags (`promptTokens`, `completionTokens`, etc.) matching frontend `WireUsage`
+- `Message.CreatedAt int64` — Unix millisecond timestamp for persistence
+
+**agent.go:**
+- `session.Add(provider.Message{..., Usage: usage, CreatedAt: time.Now().UnixMilli()})` for:
+  - User messages
+  - Assistant messages (main path)
+  - Assistant messages (error recovery path)
+
+---
+
+### 6. app.go — History Conversion / 历史消息转换
+
+**HistoryMessage struct:**
+- Added `Usage *provider.Usage` — persisted per-turn token data
+- Added `CreatedAt int64` — per-message timestamp
+
+**Key functions / 关键函数:**
+
+| Function / 函数 | Change / 改动 |
+|----------------|--------------|
+| `historyMessagesWithPlannerDisplaysAndLookups` | Copies `m.Usage` and `m.CreatedAt` to `HistoryMessage` |
+| `previewSessionMessages` | Falls back from event-format to provider.Message format, preserving usage |
+| `previewEventSessionMessages` | Captures `usage` events, attaches to preceding `model.final` |
+
+---
+
+### 7. Transcript.tsx — Usage/UserCreatedAt Capture / 数据捕获
+
+**Purpose / 用途:** Captures `item.usage` and `item.createdAt` from assistant and user items respectively, passing them to `TurnActions` for display.
+
+**Changes / 改动:**
+- Hot zone `useMemo`: tracks `actionUsage`, `actionUserCreatedAt`
+- `WarmTurnItems`: tracks `actionUsage`, `actionUserCreatedAt`
+- Both pass `usage` and `userCreatedAt` as props to `TurnActions`
+- Provides `LiveStatsContext` for streaming data
+
+---
+
+### 8. types.ts — TypeScript Types / 类型定义
+
+```ts
+export interface HistoryMessage {
+  // ... existing fields ...
+  usage?: WireUsage;  // NEW: persisted per-turn token telemetry
+}
+```
+
+---
+
+### 9. styles.css — Component Styles / 组件样式
+
+**New styles / 新样式:**
+
+| Selector / 选择器 | Purpose / 用途 |
+|------------------|---------------|
+| `.turn-actions__stats` | Stats box in TurnActions area |
+| `.turn-actions__stats-icon` | Icon sizing for stats |
+| `.composer-runstatus__stat` | Stat indicator in stop button area |
+| `.composer-runstatus__stat-icon` | Icon sizing for stop area stats |
+| `.msg--assistant` | Added `position: relative` for stats bar anchoring |
+
+---
+
+## Key Design Decisions / 关键设计决策
+
+### Why global accumulators + turn-start snapshots? / 为什么使用全局累加器 + 轮次快照？
+
+Using global accumulators (never reset) with turn-start snapshots ensures:
+- Background API calls (e.g., title generation) that happen after `turn_done` are still counted in the session total
+- Per-turn deltas are computed at the START of the next turn, catching all events including post-turn processes
+- The `turn_done` handler also computes the delta for the last turn (no subsequent `turn_started`)
+
+### How is persistence achieved? / 如何实现持久化？
+
+1. `agent.go` stores `Usage` + `CreatedAt` in `provider.Message` via `session.Add()`
+2. `agent.Session.Save()` writes messages as JSONL to `.jsonl` files
+3. `agent.LoadSession()` reads them back
+4. `historyMessagesWithPlannerDisplaysAndLookups` copies `Usage` + `CreatedAt` to `HistoryMessage`
+5. Frontend `historyMessagesToItems` creates items with `usage` + `createdAt`
+
+### Why `cacheMissTokens` instead of `promptTokens` for input display? / 为什么输入显示用 cacheMissTokens 而非 promptTokens？
+
+`promptTokens` = total input (cache hit + cache miss). Since cache hit tokens are displayed separately, showing total input would double-count. `cacheMissTokens` represents the actual uncached input that was charged.
+
+---
+
+## Testing / 测试
+
+- TypeScript: `pnpm run typecheck` — ✅ zero errors
+- CSS: `pnpm run check:css` — ✅ syntax + z-index tokens passed
+- Go: `go build ./...` — ✅ compiles
+- Full build: `wails build` — ✅ production build succeeded
+
+---
+
+## PR Link / PR 链接
+
+https://github.com/SauronSkywalker/DeepSeek-Reasonix/pull/new/feature/stats-bar

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3416,6 +3416,8 @@ type HistoryMessage struct {
 	Messages           int                       `json:"messages,omitempty"`
 	Summary            string                    `json:"summary,omitempty"`
 	Archive            string                    `json:"archive,omitempty"`
+	Usage              *provider.Usage           `json:"usage,omitempty"`
+	CreatedAt          int64                     `json:"createdAt,omitempty"`
 }
 
 type HistoryToolCall struct {
@@ -3663,7 +3665,10 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		hm := HistoryMessage{Role: string(m.Role), Content: content, CheckpointTurn: checkpointTurn, Reasoning: reasoning}
+		hm := HistoryMessage{Role: string(m.Role), Content: content, CheckpointTurn: checkpointTurn, Reasoning: reasoning, CreatedAt: m.CreatedAt}
+		if m.Role == provider.RoleAssistant {
+			hm.Usage = m.Usage
+		}
 		if m.Role == provider.RoleAssistant && len(m.MemoryCitations) > 0 {
 			hm.MemoryCitations = append([]provider.MemoryCitation(nil), m.MemoryCitations...)
 		}
@@ -4131,12 +4136,13 @@ func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return historyMessagesWithPlannerDisplays(
+	msgs := historyMessagesWithPlannerDisplays(
 		loaded.Snapshot(),
 		sessionDisplayResolver(sessionDir, sessionPath),
 		sessionPlannerDisplayTurns(sessionDir, sessionPath),
 		nil,
-	), nil
+	)
+	return msgs, nil
 }
 
 func previewSessionPage(sessionDir, path string, beforeTurn, limit int) (HistoryPage, error) {
@@ -4191,6 +4197,7 @@ type previewEventRecord struct {
 	Messages         int                       `json:"messages"`
 	Summary          string                    `json:"summary"`
 	Archive          string                    `json:"archive"`
+	Usage            *provider.Usage           `json:"usage,omitempty"`
 }
 
 type previewToolCall struct {
@@ -4221,6 +4228,7 @@ func previewEventSessionMessages(path string) ([]HistoryMessage, bool, error) {
 	out := []HistoryMessage{}
 	toolName := map[string]string{}
 	sawEvent := false
+	var pendingUsage *provider.Usage
 	for {
 		var rec previewEventRecord
 		if err := dec.Decode(&rec); err != nil {
@@ -4247,6 +4255,11 @@ func previewEventSessionMessages(path string) ([]HistoryMessage, bool, error) {
 			}
 		case "model.final":
 			hm := HistoryMessage{Role: "assistant", Content: rec.Content, Reasoning: firstNonEmpty(rec.Reasoning, rec.ReasoningContent)}
+			// Attach any pending usage from a preceding usage event
+			if pendingUsage != nil {
+				hm.Usage = pendingUsage
+				pendingUsage = nil
+			}
 			if len(rec.MemoryCitations) > 0 {
 				hm.MemoryCitations = append([]provider.MemoryCitation(nil), rec.MemoryCitations...)
 			}
@@ -4295,6 +4308,10 @@ func previewEventSessionMessages(path string) ([]HistoryMessage, bool, error) {
 				Summary:  c.Summary,
 				Archive:  c.Archive,
 			})
+		case "usage":
+			if rec.Usage != nil {
+				pendingUsage = rec.Usage
+			}
 		}
 	}
 	return out, sawEvent, nil

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3274,6 +3274,8 @@ export default function App() {
                 olderHistoryCount={state.historyStartTurn}
                 loadingOlderHistory={state.historyOlderLoading}
                 onLoadOlderHistory={() => activeTabId && loadOlderHistory(activeTabId)}
+                usage={state.usage}
+                turnStartAt={state.turnStartAt}
               />
             )}
           </main>
@@ -3369,6 +3371,9 @@ export default function App() {
               ready={controllerReady}
               turnStartAt={state.turnStartAt}
               turnTokens={state.turnTokens}
+              turnCacheHitTokens={state.turnCacheHitTokens}
+              turnCacheMissTokens={state.turnCacheMissTokens}
+              usage={state.usage}
               retry={state.retry}
               transientDismissSignal={transientOverlayDismissSignal}
               sessionKey={composerSessionKey}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowUp, Check, ChevronsUpDown, Eye, FileText, Folder, Gauge, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
+import { ArrowUp, Check, ChevronsUpDown, Database, Eye, FileText, Folder, Gauge, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X, Zap } from "lucide-react";
 import { asArray } from "../lib/array";
 import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
@@ -12,7 +12,7 @@ import { detectShortcutPlatform, matchesShortcut } from "../lib/keyboardShortcut
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
 import { useToast } from "../lib/toast";
-import { type CollaborationMode, type CommandInfo, type ComposerInsertRequest, type DirEntry, type EffortInfo, type HistoryMessage, type Mode, type PromptHistoryEntry, type SessionMeta, type SessionReference, type SlashArgItem, type SlashArgsResult, type TokenMode, type ToolApprovalMode } from "../lib/types";
+import { type CollaborationMode, type CommandInfo, type ComposerInsertRequest, type DirEntry, type EffortInfo, type HistoryMessage, type Mode, type PromptHistoryEntry, type SessionMeta, type SessionReference, type SlashArgItem, type SlashArgsResult, type TokenMode, type ToolApprovalMode, type WireUsage } from "../lib/types";
 import {
   formatWorkspaceReference,
   parseWorkspaceReference,
@@ -428,6 +428,9 @@ export function Composer({
   ready,
   turnStartAt,
   turnTokens,
+  usage,
+  turnCacheHitTokens,
+  turnCacheMissTokens,
   retry,
   transientDismissSignal,
   sessionKey,
@@ -467,6 +470,9 @@ export function Composer({
   ready?: boolean;
   turnStartAt?: number;
   turnTokens?: number;
+  usage?: WireUsage;
+  turnCacheHitTokens?: number;
+  turnCacheMissTokens?: number;
   retry?: { attempt: number; max: number };
   transientDismissSignal?: number;
   sessionKey?: string;
@@ -2176,6 +2182,27 @@ export function Composer({
           <div className="composer-runstatus" role="status" aria-live="polite">
             <span className="composer-runstatus__dot" />
             <span className="composer-runstatus__text">{runActivity}</span>
+            {usage?.cacheMissTokens ? (
+              <span className="composer-runstatus__stat" title="Input miss">
+                <ArrowUp size={9} className="composer-runstatus__stat-icon" />
+                {fmtTokens(turnCacheMissTokens ?? usage.cacheMissTokens)}
+              </span>
+            ) : null}
+            {usage?.cacheHitTokens ? (
+              <span className="composer-runstatus__stat" title="Cache hit">
+                <Database size={9} className="composer-runstatus__stat-icon" />
+                {fmtTokens(turnCacheHitTokens ?? usage.cacheHitTokens)}
+              </span>
+            ) : null}
+            {running && turnStartAt && turnTokens ? (
+              <span className="composer-runstatus__stat composer-runstatus__stat--tps" title="Tokens per second">
+                <Zap size={9} className="composer-runstatus__stat-icon" />
+                {(() => {
+                  const elapsedSec = Math.max(0, Date.now() - turnStartAt) / 1000;
+                  return elapsedSec > 0 ? `${Math.round(turnTokens / elapsedSec * 10) / 10} tok/s` : "—";
+                })()}
+              </span>
+            ) : null}
             <Tooltip label={t("composer.stop")}>
               <button className="composer-runstatus__stop" type="button" onClick={handleCancel}>
                 <Square size={10} fill="currentColor" />

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
-import { BrainCircuit, ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
+import { ArrowDown, ArrowUp, BrainCircuit, ChevronDown, ChevronRight, Clock, Database, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText, Zap } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon } from "./ProcessCard";
@@ -16,7 +16,7 @@ import { displayReasoningText } from "../lib/reasoningDisplay";
 import { stripMemoryCompilerExecution } from "../lib/memoryCompilerDisplay";
 import { visibleTranscriptMemoryCitations } from "../lib/memoryCitationVisibility";
 import type { Item, MessageActionScope } from "../lib/useController";
-import type { CheckpointMeta, MemoryCitation } from "../lib/types";
+import type { CheckpointMeta, MemoryCitation, WireUsage } from "../lib/types";
 
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
 export type TurnActionMenu = "summary" | "rewind";
@@ -142,7 +142,8 @@ function messageDate(value?: number): Date {
 function formatMessageTime(date: Date): string {
   const hours = String(date.getHours()).padStart(2, "0");
   const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${hours}:${minutes}`;
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
 }
 
 export function UserMessage({
@@ -419,6 +420,8 @@ export function TurnActions({
   actionPending = false,
   rewindDisabled = false,
   hoverMenus = false,
+  usage,
+  userCreatedAt,
 }: {
   text: string;
   turn?: number;
@@ -429,6 +432,8 @@ export function TurnActions({
   actionPending?: boolean;
   rewindDisabled?: boolean;
   hoverMenus?: boolean;
+  usage?: WireUsage;
+  userCreatedAt?: number;
 }) {
   const t = useT();
   const [confirmScope, setConfirmScope] = useState<MessageActionScope | null>(null);
@@ -618,8 +623,51 @@ export function TurnActions({
           </div>
         </>
       )}
+      {usage && (usage.promptTokens || usage.completionTokens || usage.cacheHitTokens || usage.cacheMissTokens) ? (
+        <span className="turn-actions__stats" title={`Input miss ${usage.cacheMissTokens} · Cache hit ${usage.cacheHitTokens ?? 0} · Output ${usage.completionTokens ?? 0}`}>
+          <ArrowUp size={11} className="turn-actions__stats-icon" />
+          <span>{fmtTurnToken(usage.cacheMissTokens)}</span>
+          <Database size={11} className="turn-actions__stats-icon" />
+          <span>{fmtTurnToken(usage.cacheHitTokens ?? 0)}</span>
+          <ArrowDown size={11} className="turn-actions__stats-icon" />
+          <span>{fmtTurnToken(usage.completionTokens ?? 0)}</span>
+          {usage.completionTokens > 0 && userCreatedAt ? (
+            <>
+              <Zap size={11} className="turn-actions__stats-icon" />
+              <span>{fmtTurnTps(usage.completionTokens, userCreatedAt)} tok/s</span>
+              <Clock size={11} className="turn-actions__stats-icon" />
+              <span>{fmtTurnElapsed(userCreatedAt)}s</span>
+            </>
+          ) : null}
+        </span>
+      ) : null}
     </div>
   );
+}
+
+/** Format a token count for the turn-actions stats display. */
+function fmtTurnToken(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+/** Compute elapsed seconds from user message createdAt to now. */
+function fmtTurnElapsed(userCreatedAt: number): string {
+  const ms = Date.now() - userCreatedAt;
+  const sec = Math.round(ms / 1000);
+  if (sec < 60) return String(sec);
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/** Compute tokens-per-second from output tokens and user message timestamp. */
+function fmtTurnTps(tokens: number, userCreatedAt: number): string {
+  const ms = Date.now() - userCreatedAt;
+  const sec = ms / 1000;
+  if (sec <= 0) return "—";
+  return (tokens / sec).toFixed(1);
 }
 
 export const AssistantMessage = memo(function AssistantMessage({
@@ -718,6 +766,11 @@ export const AssistantMessage = memo(function AssistantMessage({
         </div>
       )}
       <MemoryCitations citations={item.memoryCitations} />
+      {item.createdAt && (
+        <time className="msg-meta__time" dateTime={new Date(item.createdAt).toISOString()} title={new Date(item.createdAt).toLocaleString()}>
+          {formatMessageTime(new Date(item.createdAt))}
+        </time>
+      )}
     </div>
   );
 });

--- a/desktop/frontend/src/components/StatsBar.tsx
+++ b/desktop/frontend/src/components/StatsBar.tsx
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import type { WireUsage } from "../lib/types";
+
+// ── LiveStats context ──────────────────────────────────────────────────────
+
+export interface LiveStats {
+  usage?: WireUsage;
+  turnStartAt?: number;
+  running: boolean;
+}
+
+export const LiveStatsContext = createContext<LiveStats>({
+  running: false,
+});

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,6 +1,8 @@
 import { createContext, memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
+import { LiveStatsContext } from "./StatsBar";
+import type { WireUsage } from "../lib/types";
 import { useT } from "../lib/i18n";
 import { AssistantMessage, TurnActions, UserMessage } from "./Message";
 import { ProcessCompactIcon, ProcessPhaseIcon } from "./ProcessCard";
@@ -99,6 +101,8 @@ export function Transcript({
   olderHistoryCount = 0,
   loadingOlderHistory = false,
   onLoadOlderHistory,
+  usage,
+  turnStartAt,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -122,6 +126,8 @@ export function Transcript({
   olderHistoryCount?: number;
   loadingOlderHistory?: boolean;
   onLoadOlderHistory?: () => void;
+  usage?: WireUsage;
+  turnStartAt?: number;
 }) {
   const t = useT();
   const {
@@ -375,6 +381,8 @@ export function Transcript({
     let actionText = "";
     let actionReady = false;
     let activeTurn: number | undefined;
+    let actionUsage: WireUsage | undefined;
+    let actionUserCreatedAt: number | undefined;
     const pushTurnActions = () => {
       if (activeTurn == null || !actionReady || actionText.trim() === "") return;
       const turn = activeTurn;
@@ -384,6 +392,8 @@ export function Transcript({
           key={`ta-${turn}`}
           text={actionText}
           turn={turn}
+          usage={actionUsage}
+          userCreatedAt={actionUserCreatedAt}
           openMenu={openMenu}
           onOpenMenu={(menu) => setOpenAction(menu ? { turn, menu } : null)}
           checkpoint={checkpointsByTurn.get(turn)}
@@ -398,6 +408,8 @@ export function Transcript({
       );
       actionText = "";
       actionReady = false;
+      actionUsage = undefined;
+      actionUserCreatedAt = undefined;
     };
 
     // Compact mode: step-based rendering
@@ -433,6 +445,7 @@ export function Transcript({
           const tn = userTurn.get(first.id);
           const checkpoint = tn == null ? undefined : checkpointsByTurn.get(tn);
           activeTurn = tn;
+          actionUserCreatedAt = first.createdAt;
           out.push(
             <UserMessage
               key={first.id}
@@ -502,6 +515,7 @@ export function Transcript({
           if (!it.streaming && it.text.trim() !== "") {
             actionText = it.text;
             actionReady = true;
+            actionUsage = (it as { usage?: WireUsage }).usage;
           }
         }
       }
@@ -554,6 +568,7 @@ export function Transcript({
             const tn = userTurn.get(it.id);
             const checkpoint = tn == null ? undefined : checkpointsByTurn.get(tn);
             activeTurn = tn;
+            actionUserCreatedAt = it.createdAt;
             out.push(
               <UserMessage
                 key={it.id}
@@ -575,6 +590,7 @@ export function Transcript({
             if (!it.streaming && it.text.trim() !== "") {
               actionText = it.text;
               actionReady = true;
+              actionUsage = (it as { usage?: WireUsage }).usage;
             }
             break;
           case "tool":
@@ -609,6 +625,7 @@ export function Transcript({
         {empty && !hydrating && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
 
         <LiveStreamContext.Provider value={live}>
+          <LiveStatsContext.Provider value={{ usage, turnStartAt, running: !!running }}>
           {hasOlderHistory && (
             <button
               type="button"
@@ -649,6 +666,7 @@ export function Transcript({
           <div ref={entranceRef}>
             {hotZoneNodes}
           </div>
+          </LiveStatsContext.Provider>
         </LiveStreamContext.Provider>
       </div>
 
@@ -841,6 +859,8 @@ function WarmTurnItems({
   let actionText = "";
   let actionReady = false;
   let activeTurn: number | undefined;
+  let actionUsage: WireUsage | undefined;
+  let actionUserCreatedAt: number | undefined;
   const pushTurnActions = () => {
     if (activeTurn == null || !actionReady || actionText.trim() === "") return;
     const turn = activeTurn;
@@ -850,6 +870,8 @@ function WarmTurnItems({
         key={`ta-${turn}`}
         text={actionText}
         turn={turn}
+        usage={actionUsage}
+        userCreatedAt={actionUserCreatedAt}
         openMenu={openMenu}
         onOpenMenu={(menu) => setOpenAction(menu ? { turn, menu } : null)}
         checkpoint={checkpoints.get(turn)}
@@ -905,9 +927,11 @@ function WarmTurnItems({
     switch (it.kind) {
       case "user": {
         pushTurnActions();
+        actionUsage = undefined;
         const tn = userTurnMap.get(it.id);
         const checkpoint = tn == null ? undefined : checkpoints.get(tn);
         activeTurn = tn;
+        actionUserCreatedAt = it.createdAt;
         nodes.push(
           <UserMessage
             key={it.id}
@@ -928,6 +952,7 @@ function WarmTurnItems({
         if (!it.streaming && it.text.trim() !== "") {
           actionText = it.text;
           actionReady = true;
+          actionUsage = (it as { usage?: WireUsage }).usage;
         }
         break;
       }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -315,6 +315,7 @@ export interface HistoryMessage {
   messages?: number;
   summary?: string;
   archive?: string;
+  usage?: WireUsage;
 }
 
 export interface HistoryToolCall {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -48,7 +48,7 @@ const HISTORY_PAGE_TURNS = 60;
 
 export type Item =
   | { kind: "user"; id: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number }
-  | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; reasoningComplete?: boolean; memoryCitations?: MemoryCitation[] }
+  | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; createdAt?: number; reasoningComplete?: boolean; memoryCitations?: MemoryCitation[]; usage?: WireUsage }
   | { kind: "phase"; id: string; text: string }
   | { kind: "notice"; id: string; level: "info" | "warn"; text: string }
   | {
@@ -115,9 +115,21 @@ interface State {
   pendingUser?: string;
   discardTurn?: boolean;
   turnStartAt: number;
+  // Per-turn accumulators (reset each turn)
   turnTokens: number;
+  // Global accumulators (never reset, track entire session)
+  globalTokens: number;
+  globalCacheHitTokens: number;
+  globalCacheMissTokens: number;
+  // Turn-start baselines for computing per-turn contribution
+  turnStartGlobalTokens: number;
+  turnStartGlobalCacheHit: number;
+  turnStartGlobalCacheMiss: number;
   turnTotalTokens: number;
   turnCost: number;
+  turnPromptTokens: number;
+  turnCacheHitTokens: number;
+  turnCacheMissTokens: number;
   sessionTokens: number;
   sessionCost: number;
   sessionCurrency: string;
@@ -145,8 +157,17 @@ export const initialState: State = {
   backendActivationPending: false,
   turnStartAt: 0,
   turnTokens: 0,
+  globalTokens: 0,
+  globalCacheHitTokens: 0,
+  globalCacheMissTokens: 0,
+  turnStartGlobalTokens: 0,
+  turnStartGlobalCacheHit: 0,
+  turnStartGlobalCacheMiss: 0,
   turnTotalTokens: 0,
   turnCost: 0,
+  turnPromptTokens: 0,
+  turnCacheHitTokens: 0,
+  turnCacheMissTokens: 0,
   sessionTokens: 0,
   sessionCost: 0,
   sessionCurrency: "¥",
@@ -413,6 +434,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           reasoning: m.reasoning ?? "",
           streaming: false,
           memoryCitations: memoryCitations.length > 0 ? memoryCitations : undefined,
+          usage: m.usage,
         });
         seq++;
       }
@@ -581,8 +603,35 @@ function applyEvent(s: State, e: WireEvent): State {
       // the first text/reasoning token.
       let cur: State = s;
       if (cur.pendingUser !== undefined) cur = flushPendingUser(cur);
-      const { items, id, seq } = ensureAssistant(cur);
-      return { ...cur, items, currentAssistant: id, seq, live: { id, text: "", reasoning: "", reasoningComplete: false }, running: true, turnActive: true, pendingPrompt: false, cancelRequested: false, cancellable: true, turnStartAt: Date.now(), turnTokens: 0, turnTotalTokens: 0, turnCost: 0 };
+      // Compute previous turn's contribution from global accumulators
+      const turnContribution_tokens = (cur.globalTokens ?? 0) - (cur.turnStartGlobalTokens ?? 0);
+      const turnContribution_cacheHit = (cur.globalCacheHitTokens ?? 0) - (cur.turnStartGlobalCacheHit ?? 0);
+      const turnContribution_cacheMiss = (cur.globalCacheMissTokens ?? 0) - (cur.turnStartGlobalCacheMiss ?? 0);
+      // Update the last assistant item with the computed turn contribution
+      let items = cur.items;
+      if ((turnContribution_tokens > 0 || turnContribution_cacheHit > 0 || turnContribution_cacheMiss > 0) && cur.turnStartGlobalTokens !== undefined) {
+        for (let i = cur.items.length - 1; i >= 0; i--) {
+          const it = cur.items[i];
+          if (it.kind === "assistant") {
+            items = cur.items.map((item, idx) =>
+              idx === i
+                ? { ...item, usage: {
+                    promptTokens: turnContribution_tokens,
+                    completionTokens: turnContribution_tokens,
+                    totalTokens: turnContribution_tokens,
+                    cacheHitTokens: turnContribution_cacheHit,
+                    cacheMissTokens: turnContribution_cacheMiss,
+                    sessionCacheHitTokens: cur.usage?.sessionCacheHitTokens ?? 0,
+                    sessionCacheMissTokens: cur.usage?.sessionCacheMissTokens ?? 0,
+                  } }
+                : item,
+            );
+            break;
+          }
+        }
+      }
+      const stateWithItems: State = { ...cur, items }; const { items: ensuredItems, id, seq } = ensureAssistant(stateWithItems);
+      return { ...cur, items: ensuredItems, currentAssistant: id, seq, live: { id, text: "", reasoning: "", reasoningComplete: false }, running: true, turnActive: true, pendingPrompt: false, cancelRequested: false, cancellable: true, turnStartAt: Date.now(), turnTokens: 0, turnTotalTokens: 0, turnCost: 0, turnPromptTokens: 0, turnCacheHitTokens: 0, turnCacheMissTokens: 0, turnStartGlobalTokens: cur.globalTokens ?? 0, turnStartGlobalCacheHit: cur.globalCacheHitTokens ?? 0, turnStartGlobalCacheMiss: cur.globalCacheMissTokens ?? 0 };
     }
     case "text":
     case "reasoning": {
@@ -620,6 +669,16 @@ function applyEvent(s: State, e: WireEvent): State {
                 reasoning,
                 streaming: false,
                 memoryCitations: memoryCitations.length > 0 ? memoryCitations : undefined,
+                usage: {
+                  promptTokens: (s.globalTokens ?? 0) - (s.turnStartGlobalTokens ?? 0),
+                  completionTokens: (s.globalTokens ?? 0) - (s.turnStartGlobalTokens ?? 0),
+                  totalTokens: (s.globalTokens ?? 0) - (s.turnStartGlobalTokens ?? 0),
+                  cacheHitTokens: (s.globalCacheHitTokens ?? 0) - (s.turnStartGlobalCacheHit ?? 0),
+                  cacheMissTokens: (s.globalCacheMissTokens ?? 0) - (s.turnStartGlobalCacheMiss ?? 0),
+                  sessionCacheHitTokens: s.usage?.sessionCacheHitTokens ?? 0,
+                  sessionCacheMissTokens: s.usage?.sessionCacheMissTokens ?? 0,
+                },
+                createdAt: it.createdAt ?? Date.now(),
               };
             })()
           : it,
@@ -694,7 +753,39 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, items: next };
     }
     case "usage": {
-      if (!countsTowardCurrentTurn(s)) return s;
+      // Always accumulate global counters (even after turn_done, e.g. title events)
+      const gTokens = (s.globalTokens ?? 0) + (e.usage?.completionTokens ?? 0);
+      const gCacheHit = (s.globalCacheHitTokens ?? 0) + (e.usage?.cacheHitTokens ?? 0);
+      const gCacheMiss = (s.globalCacheMissTokens ?? 0) + (e.usage?.cacheMissTokens ?? 0);
+      if (!countsTowardCurrentTurn(s)) {
+        // Update the last assistant item with post-turn events (title generation, etc.)
+        const turnDiff_tokens = gTokens - (s.turnStartGlobalTokens ?? 0);
+        const turnDiff_cacheHit = gCacheHit - (s.turnStartGlobalCacheHit ?? 0);
+        const turnDiff_cacheMiss = gCacheMiss - (s.turnStartGlobalCacheMiss ?? 0);
+        let postItems = s.items;
+        if (turnDiff_tokens > 0 || turnDiff_cacheHit > 0 || turnDiff_cacheMiss > 0) {
+          for (let i = s.items.length - 1; i >= 0; i--) {
+            const it = s.items[i];
+            if (it.kind === "assistant") {
+              postItems = s.items.map((item, idx) =>
+                idx === i
+                  ? { ...item, usage: {
+                      promptTokens: turnDiff_tokens,
+                      completionTokens: turnDiff_tokens,
+                      totalTokens: turnDiff_tokens,
+                      cacheHitTokens: turnDiff_cacheHit,
+                      cacheMissTokens: turnDiff_cacheMiss,
+                      sessionCacheHitTokens: s.usage?.sessionCacheHitTokens ?? 0,
+                      sessionCacheMissTokens: s.usage?.sessionCacheMissTokens ?? 0,
+                    } }
+                  : item,
+              );
+              break;
+            }
+          }
+        }
+        return { ...s, items: postItems, globalTokens: gTokens, globalCacheHitTokens: gCacheHit, globalCacheMissTokens: gCacheMiss };
+      }
       const updateContextGauge = updatesContextGauge(e.usage);
       const used = e.usage && s.context.window && updateContextGauge ? e.usage.promptTokens : s.context.used;
       const turnTokens = s.turnTokens + (e.usage?.completionTokens ?? 0);
@@ -705,8 +796,27 @@ function applyEvent(s: State, e: WireEvent): State {
       const turnCost = s.turnCost + usageCost;
       const sessionCost = s.sessionCost + usageCost;
       const sessionCurrency = e.usage?.currency || s.sessionCurrency || "¥";
+      const turnPromptTokens = s.turnPromptTokens + (e.usage?.promptTokens ?? 0);
+      const turnCacheHitTokens = s.turnCacheHitTokens + (e.usage?.cacheHitTokens ?? 0);
+      const turnCacheMissTokens = s.turnCacheMissTokens + (e.usage?.cacheMissTokens ?? 0);
       const usage = updateContextGauge ? e.usage : s.usage;
-      return { ...s, usage, context: { ...s.context, used, sessionTokens }, turnTokens, turnTotalTokens, turnCost, sessionTokens, sessionCost, sessionCurrency };
+      // Also attach usage/createdAt to the current assistant item so it persists after streaming
+      const items = s.currentAssistant != null
+        ? s.items.map((it) =>
+            it.kind === "assistant" && it.id === s.currentAssistant && !it.usage
+              ? { ...it, usage: {
+                  promptTokens: gTokens - (s.turnStartGlobalTokens ?? 0),
+                  completionTokens: gTokens - (s.turnStartGlobalTokens ?? 0),
+                  totalTokens: gTokens - (s.turnStartGlobalTokens ?? 0),
+                  cacheHitTokens: gCacheHit - (s.turnStartGlobalCacheHit ?? 0),
+                  cacheMissTokens: gCacheMiss - (s.turnStartGlobalCacheMiss ?? 0),
+                  sessionCacheHitTokens: s.usage?.sessionCacheHitTokens ?? 0,
+                  sessionCacheMissTokens: s.usage?.sessionCacheMissTokens ?? 0,
+                }, createdAt: it.createdAt ?? Date.now() }
+              : it,
+          )
+        : s.items;
+      return { ...s, items, usage, context: { ...s.context, used, sessionTokens }, turnTokens, turnTotalTokens, turnCost, turnPromptTokens, turnCacheHitTokens, turnCacheMissTokens, sessionTokens, sessionCost, sessionCurrency, globalTokens: gTokens, globalCacheHitTokens: gCacheHit, globalCacheMissTokens: gCacheMiss };
     }
     case "notice":
       return { ...s, running: s.turnActive ? s.running : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: e.level ?? "info", text: e.text ?? "" }] };
@@ -744,12 +854,38 @@ function applyEvent(s: State, e: WireEvent): State {
     case "turn_done": {
       if (s.pendingUser !== undefined) s = flushPendingUser(s);
       const finalized = s.items.map((it) => {
-        if (it.kind === "assistant" && s.live && it.id === s.live.id) return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false };
-        if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false };
+        if (it.kind === "assistant" && s.live && it.id === s.live.id) return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false, createdAt: it.createdAt ?? Date.now() };
+        if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false, createdAt: it.createdAt ?? Date.now() };
         if (it.kind === "tool" && it.status === "running") return { ...it, status: "stopped" as const };
         return it;
       });
       let items: Item[] = e.err ? [...finalized, { kind: "notice", id: `e${s.seq}`, level: "warn", text: e.err }] : finalized;
+      // Update the last assistant item's usage with the final turn contribution
+      // from global accumulators (catches background events like title gen).
+      const turnDelta = (s.globalTokens ?? 0) - (s.turnStartGlobalTokens ?? 0);
+      const turnCacheHitDelta = (s.globalCacheHitTokens ?? 0) - (s.turnStartGlobalCacheHit ?? 0);
+      const turnCacheMissDelta = (s.globalCacheMissTokens ?? 0) - (s.turnStartGlobalCacheMiss ?? 0);
+      if (turnDelta > 0 && s.turnStartGlobalTokens !== undefined) {
+        for (let i = items.length - 1; i >= 0; i--) {
+          const it = items[i];
+          if (it.kind === "assistant") {
+            items = items.map((item, idx) =>
+              idx === i
+                ? { ...item, usage: {
+                    promptTokens: turnDelta,
+                    completionTokens: turnDelta,
+                    totalTokens: turnDelta,
+                    cacheHitTokens: turnCacheHitDelta,
+                    cacheMissTokens: turnCacheMissDelta,
+                    sessionCacheHitTokens: s.usage?.sessionCacheHitTokens ?? 0,
+                    sessionCacheMissTokens: s.usage?.sessionCacheMissTokens ?? 0,
+                  } }
+                : item,
+            );
+            break;
+          }
+        }
+      }
       // Plan approval can arrive before turn_done on some Wails event paths.
       // Keep that gate visible instead of clearing the only UI that can answer it.
       const keepPlanApproval = s.approval?.tool === "exit_plan_mode";
@@ -788,6 +924,9 @@ export function reducer(s: State, a: Action): State {
         turnTokens: 0,
         turnTotalTokens: 0,
         turnCost: 0,
+        turnPromptTokens: 0,
+        turnCacheHitTokens: 0,
+        turnCacheMissTokens: 0,
         pendingUser: a.text,
         discardTurn: false,
       };
@@ -831,8 +970,8 @@ export function reducer(s: State, a: Action): State {
         };
       }
       const finalized = s.items.map((it) => {
-        if (it.kind === "assistant" && s.live && it.id === s.live.id) return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false };
-        if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false };
+        if (it.kind === "assistant" && s.live && it.id === s.live.id) return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false, createdAt: it.createdAt ?? Date.now() };
+        if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false, createdAt: it.createdAt ?? Date.now() };
         if (it.kind === "tool" && it.status === "running") return { ...it, status: "stopped" as const };
         return it;
       });

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4013,6 +4013,7 @@ a[href] {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  position: relative; /* anchor for .stats-bar */
 }
 .msg--process-only {
   margin-top: 6px;
@@ -4798,6 +4799,41 @@ body > .mermaid-diagram--fullscreen {
   user-select: text;
   -webkit-user-select: text;
 }
+
+/* ── Stats Bar (streaming token telemetry) ──────────────────────────────── */
+.stats-bar {
+  position: absolute;
+  bottom: 2px;
+  left: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 1px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 80%, transparent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 10px;
+  color: var(--fg-muted, var(--fg-dim));
+  opacity: 0.75;
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+  z-index: var(--z-local-raised);
+}
+
+.stats-bar__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  line-height: 1;
+}
+
+.stats-bar__icon {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+}
+
 .turn-actions {
   display: flex;
   align-items: center;
@@ -4845,6 +4881,29 @@ body > .mermaid-diagram--fullscreen {
   bottom: calc(100% + 5px);
   right: auto;
   left: 0;
+}
+
+/* ── Turn-actions stats box ────────────────────────────────────────────── */
+.turn-actions__stats {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 24px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  color: var(--fg-faint);
+  border-radius: 6px;
+  padding: 3px 7px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.turn-actions__stats-icon {
+  width: 11px;
+  height: 11px;
+  opacity: 0.7;
 }
 
 /* ── diff ────────────────────────────────────────────────────────────────── */
@@ -15522,6 +15581,22 @@ body > .mermaid-diagram--fullscreen {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
+}
+
+.composer-runstatus__stat {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.composer-runstatus__stat-icon {
+  width: 9px;
+  height: 9px;
 }
 
 .composer-runstatus__stop {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
+
 )
 
 // maxToolOutputBytes caps a single tool result before it goes into the model's
@@ -908,7 +909,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			}
 		}
 	}
-	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
+	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx), CreatedAt: time.Now().UnixMilli()})
 
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0
@@ -944,6 +945,8 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 						ReasoningContent:   reasoning,
 						ReasoningSignature: signature,
 						MemoryCitations:    a.memoryCitations(),
+						Usage:              usage,
+						CreatedAt:          time.Now().UnixMilli(),
 					})
 				}
 				a.session.Add(provider.Message{
@@ -982,6 +985,8 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			ReasoningSignature: signature,
 			ToolCalls:          calls,
 			MemoryCitations:    a.memoryCitations(),
+			Usage:              usage,
+			CreatedAt:          time.Now().UnixMilli(),
 		})
 
 		if len(calls) == 0 {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,6 +44,8 @@ type Message struct {
 	MemoryCitations    []MemoryCitation `json:"memoryCitations,omitempty"` // local UI metadata; provider requests ignore it
 	Edited             bool             `json:"edited,omitempty"`          // local UI metadata; provider requests ignore it
 	Original           string           `json:"original,omitempty"`        // user prompt before inline edit
+	Usage              *Usage           `json:"usage,omitempty"`           // per-turn token telemetry
+	CreatedAt          int64            `json:"createdAt,omitempty"`        // unix milliseconds
 }
 
 // MemoryCitation is local display metadata for memories that influenced an
@@ -466,13 +468,13 @@ const (
 // the model's last reported choices[0].finish_reason so the agent can surface
 // abnormal terminations ("length", "content_filter", "repetition_truncation").
 type Usage struct {
-	PromptTokens     int
-	CompletionTokens int
-	TotalTokens      int
-	CacheHitTokens   int    // prompt tokens served from cache
-	CacheMissTokens  int    // prompt tokens not cached
-	ReasoningTokens  int    // subset of CompletionTokens spent on chain-of-thought
-	FinishReason     string // "stop", "tool_calls", "length", "content_filter", "repetition_truncation", …
+	PromptTokens     int    `json:"promptTokens"`
+	CompletionTokens int    `json:"completionTokens"`
+	TotalTokens      int    `json:"totalTokens"`
+	CacheHitTokens   int    `json:"cacheHitTokens"`
+	CacheMissTokens  int    `json:"cacheMissTokens"`
+	ReasoningTokens  int    `json:"reasoningTokens,omitempty"`
+	FinishReason     string `json:"finishReason,omitempty"`
 }
 
 // Pricing is a provider's per-1M-token rates, used to estimate spend. Currency


### PR DESCRIPTION
# PR: Real-time Token Statistics Floating Bar / 实时 Token 统计悬浮窗

> **Branch:** `feature/stats-bar`
> **Base:** `main-v2`
> **Author:** Reasonix Admin

---

## Overview / 概述

This PR adds a real-time token statistics display to the desktop chat interface, showing input tokens (cache miss), cache hit tokens, output tokens, tokens-per-second, and elapsed time — both during streaming (in the Composer stop button area) and after completion (alongside the fork/summary/rewind action buttons). Stats are persisted across session switches and application restarts.

本 PR 为桌面客户端聊天界面增加了实时 Token 统计显示功能：输入 Token（未命中缓存）、缓存命中 Token、输出 Token、生成速度（tok/s）和耗时。流式过程中显示在 Composer 停止按钮区域，对话完成后显示在分叉/总结/回溯按钮旁。统计数据跨会话切换和应用重启持久化。

---

## Changes Summary / 变更总览

| File / 文件 | Type / 类型 | Description / 描述 |
|------------|-------------|-------------------|
| `desktop/frontend/src/components/StatsBar.tsx` | **NEW** | `LiveStatsContext` provider for streaming stats data |
| `desktop/frontend/src/components/Message.tsx` | MODIFIED | TurnActions stats box, timestamp format, assistant timestamps |
| `desktop/frontend/src/components/Transcript.tsx` | MODIFIED | Track usage/userCreatedAt, pass to TurnActions |
| `desktop/frontend/src/components/Composer.tsx` | MODIFIED | Real-time stats in stop button area |
| `desktop/frontend/src/App.tsx` | MODIFIED | Pass accumulated state to Composer/Transcript |
| `desktop/frontend/src/styles.css` | MODIFIED | Styles for stats components |
| `desktop/frontend/src/lib/useController.ts` | MODIFIED | Global accumulators, item types, event handling |
| `desktop/frontend/src/lib/types.ts` | MODIFIED | `HistoryMessage.usage` field |
| `internal/provider/provider.go` | MODIFIED | `Message.Usage` field, `Usage` JSON tags, `Message.CreatedAt` |
| `internal/agent/agent.go` | MODIFIED | Pass `Usage` + `CreatedAt` on `session.Add` |
| `desktop/app.go` | MODIFIED | `HistoryMessage.Usage` + `CreatedAt`, load-time copying |

---

## Detailed Changes / 详细变更

### 1. StatsBar.tsx (New File / 新文件)

**Purpose / 用途:** Provides `LiveStatsContext` which carries streaming state (usage, turnStartAt, running) to child components. Used by `Transcript.tsx` to share real-time usage data with the hot zone.

**Exports / 导出:**
- `LiveStats` — Interface with `usage?: WireUsage`, `turnStartAt?: number`, `running: boolean`
- `LiveStatsContext` — React context for consuming live stats data

---

### 2. Message.tsx — TurnActions Stats Box / 对话操作栏统计框

**Purpose / 用途:** Adds a token statistics box to the right of the fork/summary/rewind action buttons after a turn completes.

**New functions / 新函数:**
- `fmtTurnToken(n)` — Format token count (1.2K, 3.4M, etc.)
- `fmtTurnElapsed(userCreatedAt)` — Compute elapsed seconds from user message timestamp (`Date.now() - userCreatedAt`)
- `fmtTurnTps(tokens, userCreatedAt)` — Compute real tokens-per-second from output tokens and elapsed time

**Changes / 改动:**
- Added `usage` and `userCreatedAt` props to `TurnActions`
- Replaced fake TPS (`completionTokens / 5`) with real computation from timestamps
- Changed `formatMessageTime` from `HH:MM` to `HH:MM:SS`
- Added timestamp display to `AssistantMessage` (via `item.createdAt`)

---

### 3. Composer.tsx — Stop Button Area Stats / 停止按钮区域统计

**Purpose / 用途:** Displays real-time token statistics while the model is generating.

**Changes / 改动:**
- Added `turnCacheHitTokens` and `turnCacheMissTokens` props
- Display input miss (`cacheMissTokens`) instead of total input (`promptTokens`)
- TPS updates every second via `useTick(running)`

---

### 4. useController.ts — State Accumulators / 状态累加器

**Purpose / 用途:** Core state management for per-turn and global token accumulation.

**New state fields / 新增状态字段:**

| Field / 字段 | Description / 说明 |
|-------------|-------------------|
| `turnPromptTokens` | Per-turn accumulated prompt tokens (deprecated, replaced by global deltas) |
| `turnCacheHitTokens` | Per-turn accumulated cache hit tokens |
| `turnCacheMissTokens` | Per-turn accumulated cache miss tokens |
| `globalTokens` | Total tokens across entire session (never reset) |
| `globalCacheHitTokens` | Total cache hit tokens across entire session |
| `globalCacheMissTokens` | Total cache miss tokens across entire session |
| `turnStartGlobalTokens` | Snapshot of `globalTokens` at turn start (for computing turn delta) |
| `turnStartGlobalCacheHit` | Snapshot of `globalCacheHitTokens` at turn start |
| `turnStartGlobalCacheMiss` | Snapshot of `globalCacheMissTokens` at turn start |

**Key event handlers / 关键事件处理:**

| Event / 事件 | Logic / 逻辑 |
|-------------|-------------|
| `turn_started` | Snapshot global accumulators, reset per-turn accumulators; update previous turn's item with final delta |
| `usage` | Update global accumulators from `e.usage`; set `item.usage` with accumulated values |
| `turn_done` | Update last assistant item with final turn delta from global accumulators (catches background calls) |
| `message` | Set `item.usage` with accumulated turn delta |

**Item types / 消息类型:**
- `assistant` item: added `createdAt?: number` and `usage?: WireUsage`

**History loading / 历史加载:**
- `historyMessagesToItems`: copies `m.usage` to assistant items for persistence

---

### 5. provider.go & agent.go — Go Backend Persistence / Go 后端持久化

**provider.go:**
- `Message.Usage *Usage` — Store per-message token telemetry
- `Usage` struct: added `json:` tags (`promptTokens`, `completionTokens`, etc.) matching frontend `WireUsage`
- `Message.CreatedAt int64` — Unix millisecond timestamp for persistence

**agent.go:**
- `session.Add(provider.Message{..., Usage: usage, CreatedAt: time.Now().UnixMilli()})` for:
  - User messages
  - Assistant messages (main path)
  - Assistant messages (error recovery path)

---

### 6. app.go — History Conversion / 历史消息转换

**HistoryMessage struct:**
- Added `Usage *provider.Usage` — persisted per-turn token data
- Added `CreatedAt int64` — per-message timestamp

**Key functions / 关键函数:**

| Function / 函数 | Change / 改动 |
|----------------|--------------|
| `historyMessagesWithPlannerDisplaysAndLookups` | Copies `m.Usage` and `m.CreatedAt` to `HistoryMessage` |
| `previewSessionMessages` | Falls back from event-format to provider.Message format, preserving usage |
| `previewEventSessionMessages` | Captures `usage` events, attaches to preceding `model.final` |

---

### 7. Transcript.tsx — Usage/UserCreatedAt Capture / 数据捕获

**Purpose / 用途:** Captures `item.usage` and `item.createdAt` from assistant and user items respectively, passing them to `TurnActions` for display.

**Changes / 改动:**
- Hot zone `useMemo`: tracks `actionUsage`, `actionUserCreatedAt`
- `WarmTurnItems`: tracks `actionUsage`, `actionUserCreatedAt`
- Both pass `usage` and `userCreatedAt` as props to `TurnActions`
- Provides `LiveStatsContext` for streaming data

---

### 8. types.ts — TypeScript Types / 类型定义

```ts
export interface HistoryMessage {
  // ... existing fields ...
  usage?: WireUsage;  // NEW: persisted per-turn token telemetry
}
```

---

### 9. styles.css — Component Styles / 组件样式

**New styles / 新样式:**

| Selector / 选择器 | Purpose / 用途 |
|------------------|---------------|
| `.turn-actions__stats` | Stats box in TurnActions area |
| `.turn-actions__stats-icon` | Icon sizing for stats |
| `.composer-runstatus__stat` | Stat indicator in stop button area |
| `.composer-runstatus__stat-icon` | Icon sizing for stop area stats |
| `.msg--assistant` | Added `position: relative` for stats bar anchoring |

---

## Key Design Decisions / 关键设计决策

### Why global accumulators + turn-start snapshots? / 为什么使用全局累加器 + 轮次快照？

Using global accumulators (never reset) with turn-start snapshots ensures:
- Background API calls (e.g., title generation) that happen after `turn_done` are still counted in the session total
- Per-turn deltas are computed at the START of the next turn, catching all events including post-turn processes
- The `turn_done` handler also computes the delta for the last turn (no subsequent `turn_started`)

### How is persistence achieved? / 如何实现持久化？

1. `agent.go` stores `Usage` + `CreatedAt` in `provider.Message` via `session.Add()`
2. `agent.Session.Save()` writes messages as JSONL to `.jsonl` files
3. `agent.LoadSession()` reads them back
4. `historyMessagesWithPlannerDisplaysAndLookups` copies `Usage` + `CreatedAt` to `HistoryMessage`
5. Frontend `historyMessagesToItems` creates items with `usage` + `createdAt`

### Why `cacheMissTokens` instead of `promptTokens` for input display? / 为什么输入显示用 cacheMissTokens 而非 promptTokens？

`promptTokens` = total input (cache hit + cache miss). Since cache hit tokens are displayed separately, showing total input would double-count. `cacheMissTokens` represents the actual uncached input that was charged.

---

## Testing / 测试

- TypeScript: `pnpm run typecheck` — ✅ zero errors
- CSS: `pnpm run check:css` — ✅ syntax + z-index tokens passed
- Go: `go build ./...` — ✅ compiles
- Full build: `wails build` — ✅ production build succeeded

---

## PR Link / PR 链接

https://github.com/SauronSkywalker/DeepSeek-Reasonix/pull/new/feature/stats-bar


实时数据样例
<img width="2560" height="1504" alt="PixPin_2026-07-01_16-40-46" src="https://github.com/user-attachments/assets/46fd4843-f9f1-4336-b27a-d919e6605dbb" />

多轮会话数据
<img width="2560" height="1504" alt="PixPin_2026-07-01_16-44-28" src="https://github.com/user-attachments/assets/218cc1bd-af4a-47f2-8a36-45597dd70e11" />
<img width="2560" height="1504" alt="PixPin_2026-07-01_16-45-02" src="https://github.com/user-attachments/assets/fa190502-3479-45bc-a966-467b8c4244b6" />
