### PR TITLE
fix(desktop): handle provider key save rejection

### DIFF
--- a/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
+++ b/desktop/frontend/src/__tests__/settings-refresh-snapshot.test.tsx
@@ -39,6 +39,16 @@ function flushPromises(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  const reactPropsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+  const reactProps = reactPropsKey
+    ? (input as unknown as Record<string, { onChange?: (event: { target: HTMLInputElement; currentTarget: HTMLInputElement }) => void }>)[reactPropsKey]
+    : undefined;
+  reactProps?.onChange?.({ target: input, currentTarget: input });
+}
+
 async function waitFor(label: string, predicate: () => boolean) {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     await act(async () => {
@@ -94,6 +104,13 @@ function baseSettings(displayMode: "standard" | "compact" = "standard"): Setting
   };
 }
 
+function customProviderSettings(): SettingsView {
+  return {
+    ...baseSettings("standard"),
+    providerKinds: ["openai"],
+  };
+}
+
 console.log("\nsettings refresh snapshot");
 
 eq(providerEditorEffectiveKind(true, "anthropic", ["anthropic", "openai"]), "openai", "new custom providers ignore sorted providerKinds and default to OpenAI");
@@ -112,6 +129,7 @@ globalThis.document = dom.window.document;
 Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
 globalThis.Node = dom.window.Node;
 globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLInputElement = dom.window.HTMLInputElement;
 globalThis.Event = dom.window.Event;
 globalThis.CustomEvent = dom.window.CustomEvent;
 globalThis.KeyboardEvent = dom.window.KeyboardEvent;
@@ -220,6 +238,90 @@ ok(document.body.textContent?.includes("Settings could not be loaded.") === fals
 await act(async () => {
   retryRoot.unmount();
 });
+
+const keyRejectRootEl = document.createElement("div");
+document.body.appendChild(keyRejectRootEl);
+const keyRejectRoot = createRoot(keyRejectRootEl);
+const activeWorkError = "finish or cancel the current turn, answer pending prompts, and stop background jobs before changing provider key";
+let saveProviderCalls = 0;
+let setProviderKeyCalls = 0;
+const unhandledReasons: string[] = [];
+const onUnhandledRejection = (reason: unknown) => {
+  unhandledReasons.push(String((reason as Error)?.message ?? reason));
+};
+process.on("unhandledRejection", onUnhandledRejection);
+window.go = {
+  main: {
+    App: {
+      Settings: async () => customProviderSettings(),
+      SetProviderKey: async () => {
+        setProviderKeyCalls += 1;
+        throw new Error(activeWorkError);
+      },
+      SaveProvider: async () => {
+        saveProviderCalls += 1;
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+try {
+  await act(async () => {
+    keyRejectRoot.render(
+      <LocaleProvider>
+        <SettingsPanel
+          initialTab="models"
+          onClose={() => {}}
+          onChanged={() => {}}
+          desktopPlatform="windows"
+        />
+      </LocaleProvider>,
+    );
+    await flushPromises();
+  });
+  await waitFor("provider access tab", () => Boolean(Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.trim() === "Access")));
+  const accessButton = Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.trim() === "Access") as HTMLButtonElement | undefined;
+  if (!accessButton) throw new Error("provider access button did not render");
+  await act(async () => {
+    accessButton.click();
+    await flushPromises();
+  });
+  const customProviderButton = Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.trim() === "Custom provider") as HTMLButtonElement | undefined;
+  if (!customProviderButton) throw new Error("custom provider button did not render");
+  await act(async () => {
+    customProviderButton.click();
+    await flushPromises();
+  });
+  const editorInputs = Array.from(document.querySelectorAll(".provider-editor input.mem-input")) as HTMLInputElement[];
+  const nameInput = editorInputs[0];
+  const baseUrlInput = editorInputs.find((input) => input.placeholder.includes("base_url"));
+  const keyInput = editorInputs.find((input) => input.type === "password");
+  const modelsInput = editorInputs.find((input) => input.placeholder.includes("models"));
+  if (!nameInput || !baseUrlInput || !keyInput || !modelsInput) throw new Error("custom provider editor inputs did not render");
+  await act(async () => {
+    setInputValue(nameInput, "custom-proxy");
+    setInputValue(baseUrlInput, "https://proxy.example.com/v1");
+    setInputValue(keyInput, "sk-test");
+    setInputValue(modelsInput, "proxy-chat");
+    await flushPromises();
+  });
+  const saveButton = document.querySelector(".provider-editor .prov-card__actions .btn--primary") as HTMLButtonElement | null;
+  if (!saveButton) throw new Error("provider save button did not render");
+  await act(async () => {
+    saveButton.click();
+    await flushPromises();
+    await flushPromises();
+  });
+  ok(unhandledReasons.length === 0, "provider key save rejection is handled instead of becoming an unhandled rejection");
+  ok(document.body.textContent?.includes(activeWorkError) === true, "provider key save rejection remains visible in settings");
+  eq(setProviderKeyCalls, 1, "provider key save is attempted once");
+  eq(saveProviderCalls, 0, "provider config is not saved after rejected key update");
+} finally {
+  process.off("unhandledRejection", onUnhandledRejection);
+  await act(async () => {
+    keyRejectRoot.unmount();
+  });
+}
 dom.window.close();
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -4323,7 +4323,7 @@ function ProviderEditor({
   kinds: string[];
   busy: boolean;
   onCancel: () => void;
-  onSave: (p: ProviderView) => void;
+  onSave: (p: ProviderView) => void | Promise<void>;
   onSaveKey?: (apiKeyEnv: string, value: string) => Promise<void>;
   onClearKey?: (apiKeyEnv: string) => Promise<void>;
 }) {
@@ -4443,29 +4443,34 @@ function ProviderEditor({
     const ms = parseProviderListInput(models);
     const vms = parseProviderListInput(visionModels).filter((model) => ms.includes(model));
     const effectiveApiKeyEnv = providerApiKeyEnvForSave(name, apiKeyEnv, keyDraft);
-    if (keyDraft.trim()) await app.SetProviderKey(effectiveApiKeyEnv, keyDraft.trim());
-    onSave({
-      name: name.trim(),
-      builtIn: initial?.builtIn ?? false,
-      added: initial?.added ?? true,
-      kind: effectiveKind,
-      baseUrl: effectiveBaseUrl,
-      chatUrl: effectiveChatUrl,
-      models: ms,
-      visionModels: vms,
-      visionModelsConfigured: visionModelsConfigured || vms.length > 0,
-      default: ms[0] ?? "",
-      apiKeyEnv: effectiveApiKeyEnv,
-      modelsUrl: effectiveModelsUrl,
-      keySet: Boolean(keyDraft.trim()) || (initial?.keySet ?? false),
-      balanceUrl: balanceUrl.trim(),
-      contextWindow: Number(ctx) || 0,
-      reasoningProtocol,
-      supportedEfforts,
-      // Clear the stored default if no levels are selected; the backend's
-      // NormalizeEffort would otherwise silently ignore an unsupported value.
-      defaultEffort: supportedEfforts.length > 0 ? defaultEffort : "",
-    });
+    setFetchErr(null);
+    try {
+      if (keyDraft.trim()) await app.SetProviderKey(effectiveApiKeyEnv, keyDraft.trim());
+      await onSave({
+        name: name.trim(),
+        builtIn: initial?.builtIn ?? false,
+        added: initial?.added ?? true,
+        kind: effectiveKind,
+        baseUrl: effectiveBaseUrl,
+        chatUrl: effectiveChatUrl,
+        models: ms,
+        visionModels: vms,
+        visionModelsConfigured: visionModelsConfigured || vms.length > 0,
+        default: ms[0] ?? "",
+        apiKeyEnv: effectiveApiKeyEnv,
+        modelsUrl: effectiveModelsUrl,
+        keySet: Boolean(keyDraft.trim()) || (initial?.keySet ?? false),
+        balanceUrl: balanceUrl.trim(),
+        contextWindow: Number(ctx) || 0,
+        reasoningProtocol,
+        supportedEfforts,
+        // Clear the stored default if no levels are selected; the backend's
+        // NormalizeEffort would otherwise silently ignore an unsupported value.
+        defaultEffort: supportedEfforts.length > 0 ? defaultEffort : "",
+      });
+    } catch (e) {
+      setFetchErr(String((e as Error)?.message ?? e));
+    }
   };
 
   if (builtIn) {


### PR DESCRIPTION
## Summary

- Code-confirmed #5672 as an unhandled custom provider key-save rejection in the desktop settings provider editor.
- Catch provider key/config save failures in the editor and surface the existing inline error state instead of letting the rejection reach global crash handling.
- Add a settings regression for the custom provider add flow so rejected key updates remain visible and do not save the provider config.

Closes #5672.

## Verification

- `pnpm exec tsx src/__tests__/settings-refresh-snapshot.test.tsx`
- `pnpm run test:typecheck`
- `pnpm run typecheck`
- `git diff --check`

## Cache impact

Cache-impact: none - desktop settings UI error handling only; no provider-visible prompt, tool schema, cache prefix, or request serialization changes.
Cache-guard: `pnpm exec tsx src/__tests__/settings-refresh-snapshot.test.tsx`
System-prompt-review: N/A