### PR TITLE
feat(site): community forum frontend at /community

### DIFF
--- a/site/src/layouts/Community.astro
+++ b/site/src/layouts/Community.astro
@@ -1,0 +1,56 @@
+---
+import "../styles/community.css";
+const { title, description, active } = Astro.props;
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+---
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href={canonical} />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Reasonix Community" />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="/community/"><span class="mark">R</span>Reasonix<span class="ctag">Community</span></a>
+      <nav class="nav-links">
+        <a class={active === "discussions" ? "here" : ""} href="/community/">Discussions</a>
+        <a href="/community/?category=skills">Skills</a>
+        <a href="/community/?category=show">Showcase</a>
+        <a href="/docs/">Docs ↗</a>
+      </nav>
+      <div class="nav-right">
+        <label class="nav-search"><span class="ico">⌕</span><input placeholder="Search…" disabled /></label>
+        <span id="nav-account"></span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <slot />
+  </main>
+
+  <footer class="foot">
+    <div class="foot-inner">
+      <a class="brand" href="/"><span class="mark">R</span>Reasonix</a>
+      <span>© 2026 · MIT · built to be left running.</span>
+      <nav class="links">
+        <a href="/community/guidelines/">Guidelines</a>
+        <a href="/docs/">Docs</a>
+        <a href="https://github.com/esengine/DeepSeek-Reasonix">GitHub</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>import "../scripts/community.js";</script>
+</body>
+</html>

--- a/site/src/pages/community/guidelines.astro
+++ b/site/src/pages/community/guidelines.astro
@@ -1,0 +1,14 @@
+---
+import Community from "../../layouts/Community.astro";
+---
+<Community title="Guidelines — Reasonix Community" description="How the Reasonix community forum works.">
+  <div class="wrap" style="padding:36px 32px 80px;max-width:760px">
+    <div class="crumb"><a href="/community/">Community</a><span class="sep">/</span><span>Guidelines</span></div>
+    <h1 style="font-size:32px;font-weight:600;letter-spacing:-0.02em">Community guidelines</h1>
+    <p style="margin:14px 0 28px;color:var(--ink-2);font-size:16px;line-height:1.7">A small forum works when everyone keeps it useful and kind. A few things worth knowing.</p>
+
+    <div class="side-card" style="margin-bottom:16px"><h4>Be kind &amp; on-topic</h4><p style="color:var(--ink-2);line-height:1.7">Assume good faith, search before asking, and keep threads focused. Format code in fenced <code>```</code> blocks.</p></div>
+    <div class="side-card" style="margin-bottom:16px"><h4>Trust levels</h4><p style="color:var(--ink-2);line-height:1.7">Everyone signs in with their Reasonix account. New accounts start limited — no links, a small daily post cap — and unlock more as they read and contribute. It keeps the forum spam-free without getting in real members' way.</p></div>
+    <div class="side-card"><h4>Moderation</h4><p style="color:var(--ink-2);line-height:1.7">Flag anything off — a few flags auto-hide a post for review. Moderators can restrict accounts that abuse the forum. All moderator actions are logged.</p></div>
+  </div>
+</Community>

--- a/site/src/pages/community/index.astro
+++ b/site/src/pages/community/index.astro
@@ -1,0 +1,58 @@
+---
+import Community from "../../layouts/Community.astro";
+---
+<Community title="Reasonix Community" description="Ask questions, share skills, and shape a DeepSeek-native agent." active="discussions">
+  <section class="head">
+    <div class="wrap">
+      <div class="row">
+        <div>
+          <div class="eyebrow">Reasonix Community</div>
+          <h1>Discussions</h1>
+          <p>Ask questions, share skills, and shape a DeepSeek-native agent — with the makers and other builders.</p>
+        </div>
+        <a class="btn btn-primary" href="/community/new/">✎ New topic</a>
+      </div>
+    </div>
+  </section>
+
+  <div class="wrap layout">
+    <div>
+      <div class="sec-title"><h2>Categories</h2></div>
+      <div class="cats" id="cat-list">
+        <div class="cat"><span class="ico">·</span><div><h3>Loading…</h3></div></div>
+      </div>
+
+      <div class="sec-title">
+        <div class="tabs" id="sort-tabs">
+          <button class="on" data-sort="latest">Latest</button>
+          <button data-sort="top">Top</button>
+        </div>
+      </div>
+      <div class="topics" id="topic-list">
+        <div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>
+        <div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>
+        <div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>
+      </div>
+    </div>
+
+    <aside class="side">
+      <div class="card cta">
+        <h4>Start a discussion</h4>
+        <p class="lead" id="cta-lead">Ask a question or share what you built.</p>
+        <a class="btn btn-primary" href="/community/new/">✎ New topic</a>
+      </div>
+      <div class="card">
+        <h4 style="margin-bottom:14px">Community</h4>
+        <div class="stats-grid" id="stats">
+          <div class="stat-box"><div class="n" id="s-topics">—</div><div class="l">topics</div></div>
+          <div class="stat-box"><div class="n" id="s-cats">—</div><div class="l">categories</div></div>
+        </div>
+      </div>
+      <div class="card">
+        <h4 style="margin-bottom:14px">Guidelines</h4>
+        <p class="lead">Be kind, search first, and keep code in fenced blocks. New accounts unlock links and more as they participate.</p>
+        <a class="btn btn-ghost sm" href="/community/guidelines/">Read the guidelines</a>
+      </div>
+    </aside>
+  </div>
+</Community>

--- a/site/src/pages/community/new.astro
+++ b/site/src/pages/community/new.astro
@@ -1,0 +1,28 @@
+---
+import Community from "../../layouts/Community.astro";
+---
+<Community title="New topic — Reasonix Community" description="Start a discussion on the Reasonix community forum.">
+  <div class="wrap" style="padding-top:32px;max-width:820px">
+    <div class="crumb"><a href="/community/">Community</a><span class="sep">/</span><span>New topic</span></div>
+    <h1 style="font-size:28px;font-weight:600;letter-spacing:-0.02em;margin-bottom:6px">Start a discussion</h1>
+
+    <div id="new-gate" hidden class="card cta" style="margin-top:18px">
+      <h4>Sign in to post</h4>
+      <p class="lead">You'll post with your Reasonix account. New here? Signing in creates one.</p>
+      <a class="btn btn-primary" id="gate-login" href="#">Sign in</a>
+    </div>
+
+    <div id="new-form" hidden>
+      <div class="msg error" id="new-msg" hidden></div>
+      <div class="composer">
+        <input class="title" id="f-title" placeholder="Topic title — be specific" maxlength="160" />
+        <textarea id="f-body" placeholder="Write your post… Markdown and ``` code blocks supported."></textarea>
+        <div class="foot">
+          <select id="f-category"><option value="">Choose a category…</option></select>
+          <button class="btn btn-primary" id="f-submit">Post topic</button>
+        </div>
+      </div>
+      <p class="lead" style="margin-top:14px">Please search before posting, keep it on-topic, and format code in fenced blocks. New accounts can't post links until they've participated a little.</p>
+    </div>
+  </div>
+</Community>

--- a/site/src/pages/community/topic.astro
+++ b/site/src/pages/community/topic.astro
@@ -1,0 +1,42 @@
+---
+import Community from "../../layouts/Community.astro";
+---
+<Community title="Discussion — Reasonix Community" description="A discussion on the Reasonix community forum.">
+  <div class="wrap" style="padding-top:28px">
+    <div class="crumb">
+      <a href="/community/">Community</a><span class="sep">/</span>
+      <span id="crumb-cat">…</span><span class="sep">/</span>
+      <span id="crumb-title">Loading…</span>
+    </div>
+    <div class="thread-head">
+      <h1 id="t-title">
+        <div class="skeleton" style="border:none;padding:0"><div class="bar" style="width:70%;height:22px"></div></div>
+      </h1>
+      <div class="meta" id="t-meta"></div>
+    </div>
+  </div>
+
+  <div class="wrap thread-layout">
+    <div>
+      <div id="posts">
+        <div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>
+        <div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>
+      </div>
+
+      <div id="reply-zone"></div>
+    </div>
+
+    <aside class="side">
+      <div class="side-card">
+        <h4>Participants</h4>
+        <div class="parti" id="parti"></div>
+      </div>
+      <div class="side-card">
+        <h4>Actions</h4>
+        <div style="display:flex;flex-direction:column;gap:10px">
+          <a class="link-act" href="/community/">← Back to discussions</a>
+        </div>
+      </div>
+    </aside>
+  </div>
+</Community>

--- a/site/src/scripts/community.js
+++ b/site/src/scripts/community.js
@@ -1,0 +1,244 @@
+// Reasonix Community client. Renders the forum from the forum.reasonix.io API and
+// gates posting on the shared id.reasonix.io session (cookie sent cross-subdomain).
+const FORUM = (import.meta.env.PUBLIC_FORUM_API || "https://forum.reasonix.io").replace(/\/$/, "");
+const ACCOUNTS = (import.meta.env.PUBLIC_ACCOUNTS_API || "https://id.reasonix.io").replace(/\/$/, "");
+
+const el = (id) => document.getElementById(id);
+const qp = new URLSearchParams(location.search);
+
+async function api(base, path, opts = {}) {
+  const res = await fetch(base + path, {
+    method: opts.method || "GET",
+    credentials: "include",
+    headers: opts.body ? { "content-type": "application/json" } : undefined,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  let data = null;
+  try { data = await res.json(); } catch {}
+  if (!res.ok) {
+    const err = new Error(data?.error?.message || "Something went wrong.");
+    err.code = data?.error?.code;
+    err.status = res.status;
+    throw err;
+  }
+  return data;
+}
+const forum = (p, o) => api(FORUM, p, o);
+
+function esc(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+const AV = ["a", "b", "c", "d", "e"];
+function avatar(handle, size = "") {
+  const h = handle || "?";
+  let n = 0;
+  for (const ch of h) n = (n + ch.charCodeAt(0)) % AV.length;
+  const initials = h.replace(/[^a-zA-Z0-9]/g, "").slice(0, 2).toUpperCase() || "?";
+  return `<span class="av ${size}" style="background:linear-gradient(140deg,var(--accent),var(--violet))" data-c="${AV[n]}">${esc(initials)}</span>`;
+}
+function ago(iso) {
+  if (!iso) return "";
+  const s = Math.max(1, (Date.now() - new Date(iso).getTime()) / 1000);
+  const u = [[86400, "d"], [3600, "h"], [60, "m"]];
+  for (const [sec, l] of u) if (s >= sec) return Math.floor(s / sec) + l + " ago";
+  return "just now";
+}
+// Minimal, safe markdown: escape first, then fences, inline code, paragraphs.
+function md(body) {
+  const parts = esc(body).split(/```/);
+  let out = "";
+  parts.forEach((chunk, i) => {
+    if (i % 2 === 1) { out += `<pre>${chunk.replace(/^\n/, "")}</pre>`; return; }
+    const paras = chunk.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+    out += paras.map((p) => `<p>${p.replace(/`([^`]+)`/g, "<code>$1</code>").replace(/\n/g, "<br>")}</p>`).join("");
+  });
+  return out || "<p></p>";
+}
+
+const CAT_ICONS = { announcements: "📣", help: "🛟", skills: "🧩", show: "✨", feedback: "💡" };
+const loginUrl = () => `/login/?next=${encodeURIComponent(location.pathname + location.search)}`;
+
+let account = null;
+async function loadAccount() {
+  try { account = (await api(ACCOUNTS, "/me")).user; } catch { account = null; }
+  const slot = el("nav-account");
+  if (slot) {
+    slot.innerHTML = account
+      ? `<a href="/account/" title="${esc(account.email)}">${avatar(account.handle)}</a>`
+      : `<a class="btn btn-ghost sm" href="${loginUrl()}">Sign in</a>`;
+  }
+}
+
+/* ── home ─────────────────────────────────────────── */
+async function renderHome() {
+  const catBox = el("cat-list");
+  const topicBox = el("topic-list");
+  const category = qp.get("category") || "";
+
+  forum("/categories").then((d) => {
+    const cats = d.categories;
+    if (el("s-cats")) el("s-cats").textContent = cats.length;
+    if (el("s-topics")) el("s-topics").textContent = cats.reduce((a, c) => a + (c.topicCount || 0), 0);
+    catBox.innerHTML = cats.map((c) => `
+      <a class="cat" href="/community/?category=${esc(c.slug)}">
+        <span class="ico">${CAT_ICONS[c.slug] || "💬"}</span>
+        <div><h3>${esc(c.name)}</h3><p>${esc(c.description)}</p>
+        <div class="meta">${c.topicCount || 0} topics${c.lastActivity ? " · " + ago(c.lastActivity) : ""}</div></div>
+      </a>`).join("");
+  }).catch(() => { catBox.innerHTML = `<div class="empty">Couldn't load categories.</div>`; });
+
+  const loadTopics = (sort) => {
+    topicBox.innerHTML = `<div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>`.repeat(3);
+    const q = new URLSearchParams();
+    if (category) q.set("category", category);
+    if (sort) q.set("sort", sort);
+    forum("/topics?" + q).then((d) => {
+      if (!d.topics.length) { topicBox.innerHTML = `<div class="empty">No topics yet — <a class="tag" href="/community/new/">start the first one</a>.</div>`; return; }
+      topicBox.innerHTML = d.topics.map((t) => `
+        <div class="topic">
+          ${avatar(t.author.split("@")[0])}
+          <div class="main">
+            <div class="title">
+              ${t.pinned ? '<span class="badge pinned">📌 Pinned</span>' : ""}
+              ${t.status === "solved" ? '<span class="badge solved">✓ Solved</span>' : ""}
+              <a href="/community/topic/?id=${t.id}">${esc(t.title)}</a>
+            </div>
+            <div class="sub"><span class="cat-tag">${esc(t.categoryName)}</span> <span class="who">${esc(t.author.split("@")[0])}</span> · ${ago(t.createdAt)}</div>
+          </div>
+          <div class="stat"><div class="n">${t.replyCount}</div><div class="l">replies</div></div>
+          <div class="last">${ago(t.lastPostAt)}</div>
+        </div>`).join("");
+    }).catch(() => { topicBox.innerHTML = `<div class="empty">Couldn't load discussions.</div>`; });
+  };
+  loadTopics("latest");
+
+  el("sort-tabs")?.addEventListener("click", (e) => {
+    const b = e.target.closest("button[data-sort]");
+    if (!b) return;
+    el("sort-tabs").querySelectorAll("button").forEach((x) => x.classList.toggle("on", x === b));
+    loadTopics(b.dataset.sort);
+  });
+}
+
+/* ── thread ───────────────────────────────────────── */
+function postHtml(p, topic) {
+  const answer = topic.acceptedPostId && topic.acceptedPostId === p.id;
+  const cls = answer ? "post answer" : p.id === firstPostId ? "post op" : "post";
+  const role = p.role && p.role !== "member" ? `<span class="badge role ${esc(p.role)}">${esc(p.role)}</span>` : "";
+  return `<article class="${cls}">
+    ${avatar(p.handle || p.author.split("@")[0], "lg")}
+    <div>
+      ${answer ? '<div class="answer-flag">✓ Accepted answer</div>' : ""}
+      <div class="who"><span class="name">${esc(p.handle || p.author.split("@")[0])}</span>${role}<span class="when">${ago(p.createdAt)}</span></div>
+      <div class="body">${md(p.body)}</div>
+      <div class="actions">
+        <button class="react" data-like="${p.id}">👍 <span>${p.likeCount || 0}</span></button>
+        <button class="link-act" data-flag="${p.id}">Report</button>
+      </div>
+    </div>
+  </article>`;
+}
+let firstPostId = 0;
+
+async function renderThread() {
+  const id = Number(qp.get("id"));
+  if (!id) { location.href = "/community/"; return; }
+  let data;
+  try { data = await forum(`/topics/${id}`); }
+  catch { el("posts").innerHTML = `<div class="empty">That discussion doesn't exist or was removed.</div>`; return; }
+  const { topic, posts } = data;
+  firstPostId = posts[0]?.id || 0;
+
+  document.title = `${topic.title} — Reasonix Community`;
+  el("crumb-cat").textContent = topic.category;
+  el("crumb-title").textContent = topic.title;
+  el("t-title").textContent = topic.title;
+  el("t-meta").innerHTML =
+    `${topic.status === "solved" ? '<span class="badge solved">✓ Solved</span>' : ""}
+     <span>${topic.replyCount} replies · ${topic.viewCount} views · started ${ago(topic.createdAt)}</span>`;
+  el("posts").innerHTML = posts.map((p) => postHtml(p, topic)).join("");
+
+  const seen = new Set();
+  el("parti").innerHTML = posts.filter((p) => !seen.has(p.author) && seen.add(p.author)).slice(0, 8).map((p) => avatar(p.handle || p.author.split("@")[0])).join("");
+
+  el("posts").addEventListener("click", async (e) => {
+    const flag = e.target.closest("[data-flag]");
+    if (flag && account) {
+      if (!confirm("Report this post as spam or abuse?")) return;
+      try { await forum(`/posts/${flag.dataset.flag}/flags`, { method: "POST", body: { reason: "spam" } }); flag.textContent = "Reported ✓"; flag.disabled = true; }
+      catch (err) { alert(err.message); }
+    } else if (flag) { location.href = loginUrl(); }
+  });
+
+  const zone = el("reply-zone");
+  if (!account) {
+    zone.innerHTML = `<div class="composer"><div class="gate"><p>Sign in with your Reasonix account to reply.</p><a class="btn btn-primary" href="${loginUrl()}">Sign in</a></div></div>`;
+    return;
+  }
+  zone.innerHTML = `
+    <div class="msg error" id="reply-msg" hidden></div>
+    <div class="composer">
+      <textarea id="reply-body" placeholder="Write a reply… Markdown and \`\`\` code blocks supported."></textarea>
+      <div class="foot"><span class="hint">Signed in as <b>${esc(account.handle)}</b></span><button class="btn btn-primary" id="reply-submit">Post reply</button></div>
+    </div>`;
+  el("reply-submit").addEventListener("click", async () => {
+    const body = el("reply-body").value.trim();
+    const msg = el("reply-msg");
+    msg.hidden = true;
+    if (body.length < 2) return;
+    el("reply-submit").disabled = true;
+    try {
+      await forum(`/topics/${id}/posts`, { method: "POST", body: { body } });
+      location.reload();
+    } catch (err) {
+      msg.textContent = err.message; msg.hidden = false;
+      el("reply-submit").disabled = false;
+    }
+  });
+}
+
+/* ── new topic ────────────────────────────────────── */
+async function renderNew() {
+  if (!account) {
+    el("new-gate").hidden = false;
+    el("gate-login").href = loginUrl();
+    return;
+  }
+  el("new-form").hidden = false;
+  const sel = el("f-category");
+  try {
+    const { categories } = await forum("/categories");
+    for (const c of categories) {
+      const o = document.createElement("option");
+      o.value = c.id; o.textContent = c.name;
+      sel.appendChild(o);
+    }
+    const pre = qp.get("category");
+    if (pre) { const m = categories.find((c) => c.slug === pre); if (m) sel.value = m.id; }
+  } catch {}
+
+  el("f-submit").addEventListener("click", async () => {
+    const msg = el("new-msg");
+    msg.hidden = true;
+    const categoryId = Number(sel.value);
+    const title = el("f-title").value.trim();
+    const body = el("f-body").value.trim();
+    if (!categoryId) { msg.textContent = "Choose a category."; msg.hidden = false; return; }
+    if (title.length < 6 || body.length < 10) { msg.textContent = "Add a title (6+ chars) and a bit more detail (10+ chars)."; msg.hidden = false; return; }
+    el("f-submit").disabled = true;
+    try {
+      const { topic } = await forum("/topics", { method: "POST", body: { categoryId, title, body } });
+      location.href = `/community/topic/?id=${topic.id}`;
+    } catch (err) {
+      msg.textContent = err.message; msg.hidden = false;
+      el("f-submit").disabled = false;
+    }
+  });
+}
+
+(async function () {
+  await loadAccount();
+  if (el("topic-list")) renderHome();
+  else if (el("posts")) renderThread();
+  else if (el("new-form")) renderNew();
+})();

--- a/site/src/styles/community.css
+++ b/site/src/styles/community.css
@@ -1,0 +1,193 @@
+/* Reasonix Community — self-hosted fonts + the reasonix.io token values, so the
+   forum shares the site's visual language without depending on its marketing CSS. */
+@import "@fontsource-variable/outfit";
+@import "@fontsource-variable/jetbrains-mono";
+
+:root {
+  --accent: oklch(0.55 0.17 257);
+  --accent-deep: oklch(0.48 0.17 257);
+  --accent-soft: color-mix(in oklch, var(--accent) 8%, white);
+  --accent-line: color-mix(in oklch, var(--accent) 26%, transparent);
+  --bg: #ffffff;
+  --bg-soft: oklch(0.977 0.0025 247);
+  --ink: oklch(0.25 0.006 260);
+  --ink-2: oklch(0.47 0.008 260);
+  --ink-3: oklch(0.62 0.008 260);
+  --line: oklch(0.925 0.004 247);
+  --ok: oklch(0.6 0.14 155);
+  --ok-soft: color-mix(in oklch, var(--ok) 12%, white);
+  --err: oklch(0.5 0.19 25);
+  --warm: oklch(0.72 0.13 66);
+  --violet: oklch(0.58 0.17 300);
+  --rose: oklch(0.62 0.19 15);
+  --radius: 20px;
+  --radius-sm: 12px;
+  --shadow-1: 0 1px 2px oklch(0.4 0.02 260 / 0.16), 0 1px 3px 1px oklch(0.4 0.02 260 / 0.07);
+  --shadow-2: 0 2px 6px oklch(0.4 0.02 260 / 0.12), 0 12px 30px -6px oklch(0.4 0.02 260 / 0.18);
+  --font-sans: "Outfit Variable", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "JetBrains Mono Variable", "SF Mono", Menlo, monospace;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { font-family: var(--font-sans); background: var(--bg); color: var(--ink); -webkit-font-smoothing: antialiased; line-height: 1.5; }
+a { color: inherit; text-decoration: none; }
+::selection { background: oklch(0.88 0.05 257); }
+.wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
+[hidden] { display: none !important; }
+
+.nav { position: sticky; top: 0; z-index: 50; background: oklch(1 0 0 / 0.86); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); border-bottom: 1px solid var(--line); }
+.nav-inner { display: flex; align-items: center; gap: 20px; height: 64px; max-width: 1180px; margin: 0 auto; padding: 0 32px; }
+.brand { display: flex; align-items: center; gap: 10px; font-weight: 600; font-size: 17px; letter-spacing: -0.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center; background: linear-gradient(140deg, var(--accent), var(--violet)); color: #fff; font-weight: 700; font-size: 15px; }
+.brand .ctag { font-size: 12px; font-weight: 600; color: var(--accent); background: var(--accent-soft); padding: 3px 9px; border-radius: 999px; }
+.nav-links { display: flex; gap: 4px; margin-left: 12px; }
+.nav-links a { color: var(--ink-2); font-size: 14.5px; font-weight: 500; padding: 8px 14px; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+.nav-links a:hover { color: var(--ink); background: var(--bg-soft); }
+.nav-links a.here { color: var(--accent); background: var(--accent-soft); }
+.nav-right { margin-left: auto; display: flex; align-items: center; gap: 12px; }
+.nav-search { display: flex; align-items: center; gap: 8px; background: var(--bg-soft); border: 1px solid transparent; border-radius: 999px; padding: 8px 14px; width: 220px; transition: border-color 0.2s, background 0.2s, box-shadow 0.2s; }
+.nav-search:focus-within { background: #fff; border-color: var(--accent-line); box-shadow: 0 0 0 4px var(--accent-soft); }
+.nav-search input { border: none; outline: none; background: none; font-family: var(--font-sans); font-size: 14px; color: var(--ink); width: 100%; }
+.nav-search .ico { color: var(--ink-3); }
+
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--font-sans); font-size: 14.5px; font-weight: 600; white-space: nowrap; padding: 10px 20px; border-radius: 999px; border: none; cursor: pointer; transition: background 0.2s, box-shadow 0.25s, color 0.2s, border-color 0.2s, transform 0.15s var(--ease); }
+.btn:active { transform: translateY(1px); }
+.btn-primary { background: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-deep); box-shadow: var(--shadow-1); }
+.btn-ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
+.btn-ghost:hover { background: var(--accent-soft); border-color: transparent; }
+.btn.sm { padding: 7px 14px; font-size: 13px; }
+.btn[disabled] { opacity: 0.55; pointer-events: none; }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.av { flex: none; display: grid; place-items: center; border-radius: 50%; width: 40px; height: 40px; font-size: 14px; font-weight: 600; color: #fff; border: 2px solid #fff; box-shadow: var(--shadow-1); overflow: hidden; }
+.av.sm { width: 28px; height: 28px; font-size: 11px; border-width: 1.5px; }
+.av.lg { width: 52px; height: 52px; font-size: 18px; }
+
+.badge { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; font-weight: 600; padding: 3px 9px; border-radius: 999px; }
+.badge.solved { color: var(--ok); background: var(--ok-soft); }
+.badge.pinned { color: var(--accent); background: var(--accent-soft); }
+.badge.role { color: var(--ink-3); background: var(--bg-soft); box-shadow: inset 0 0 0 1px var(--line); }
+.badge.role.staff, .badge.role.admin, .badge.role.moderator { color: var(--accent); background: var(--accent-soft); box-shadow: none; }
+.tag { font-size: 12px; font-weight: 500; color: var(--ink-2); background: var(--bg-soft); padding: 4px 11px; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+a.tag:hover { color: var(--accent); background: var(--accent-soft); }
+.cat-tag { font-size: 11.5px; font-weight: 600; padding: 2px 9px; border-radius: 999px; color: var(--accent); background: var(--accent-soft); }
+
+.head { padding: 40px 0 28px; border-bottom: 1px solid var(--line); background: linear-gradient(180deg, var(--accent-soft), #fff 76%); }
+.head .row { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
+.head .eyebrow { font-size: 13px; font-weight: 600; color: var(--accent); }
+.head h1 { font-size: clamp(30px, 4vw, 42px); font-weight: 600; letter-spacing: -0.02em; margin-top: 8px; }
+.head p { margin-top: 10px; font-size: 16px; color: var(--ink-2); max-width: 46ch; }
+
+.layout { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 32px; padding: 32px 0 80px; align-items: start; }
+.side { position: sticky; top: 88px; display: flex; flex-direction: column; gap: 18px; }
+.sec-title { display: flex; align-items: center; justify-content: space-between; margin: 4px 2px 14px; }
+.sec-title h2 { font-size: 15px; font-weight: 600; }
+.tabs { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
+.tabs button { font-family: var(--font-sans); font-size: 13.5px; font-weight: 500; color: var(--ink-2); background: none; border: none; cursor: pointer; padding: 7px 15px; border-radius: 999px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
+.tabs button.on { background: #fff; color: var(--accent); box-shadow: var(--shadow-1); }
+.tabs button:hover:not(.on) { color: var(--ink); }
+
+.cats { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 34px; }
+.cat { display: flex; gap: 14px; align-items: flex-start; background: var(--bg-soft); border-radius: var(--radius-sm); padding: 18px; transition: box-shadow 0.3s, transform 0.3s var(--ease), background 0.3s; }
+.cat:hover { background: #fff; box-shadow: var(--shadow-2); transform: translateY(-2px); }
+.cat .ico { width: 42px; height: 42px; border-radius: 12px; flex: none; display: grid; place-items: center; font-size: 20px; background: var(--accent-soft); }
+.cat h3 { font-size: 15.5px; font-weight: 600; }
+.cat p { font-size: 13px; color: var(--ink-2); margin-top: 3px; }
+.cat .meta { font-size: 12px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 9px; }
+
+.topics { border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; background: #fff; }
+.topic { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 16px; padding: 16px 20px; border-bottom: 1px solid var(--line); transition: background 0.18s; }
+.topic:last-child { border-bottom: none; }
+.topic:hover { background: var(--bg-soft); }
+.topic .main { min-width: 0; }
+.topic .title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.topic .title a { font-size: 15.5px; font-weight: 600; color: var(--ink); }
+.topic:hover .title a { color: var(--accent); }
+.topic .sub { display: flex; align-items: center; gap: 8px; margin-top: 6px; font-size: 12.5px; color: var(--ink-3); flex-wrap: wrap; }
+.topic .sub .who { color: var(--ink-2); font-weight: 500; }
+.topic .stat { text-align: center; min-width: 52px; }
+.topic .stat .n { font-size: 15px; font-weight: 600; font-family: var(--font-mono); }
+.topic .stat .l { font-size: 11px; color: var(--ink-3); }
+.topic .last { min-width: 96px; text-align: right; font-size: 12px; color: var(--ink-3); }
+
+.card { background: var(--bg-soft); border-radius: var(--radius-sm); padding: 20px; }
+.card.cta { background: linear-gradient(160deg, var(--accent-soft), #fff 82%); border: 1px solid var(--accent-line); }
+.card h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 6px; }
+.card .lead { font-size: 13px; color: var(--ink-2); line-height: 1.55; margin-bottom: 14px; }
+.card .btn { width: 100%; }
+.stats-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.stat-box .n { font-size: 22px; font-weight: 700; font-family: var(--font-mono); letter-spacing: -0.02em; }
+.stat-box .n .dot { color: var(--ok); }
+.stat-box .l { font-size: 12px; color: var(--ink-3); }
+.tagcloud { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.empty { padding: 40px 20px; text-align: center; color: var(--ink-3); font-size: 14px; }
+.skeleton { padding: 16px 20px; border-bottom: 1px solid var(--line); }
+.skeleton .bar { height: 12px; border-radius: 6px; background: linear-gradient(90deg, var(--bg-soft), oklch(0.95 0.003 247), var(--bg-soft)); background-size: 200% 100%; animation: sk 1.3s linear infinite; }
+.skeleton .bar.short { width: 40%; margin-top: 8px; }
+@keyframes sk { to { background-position: -200% 0; } }
+.msg { margin: 16px 0; font-size: 13.5px; border-radius: var(--radius-sm); padding: 11px 14px; }
+.msg.error { color: var(--err); background: color-mix(in oklch, var(--err) 9%, white); }
+.msg.ok { color: var(--ok); background: var(--ok-soft); }
+
+/* thread */
+.crumb { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--ink-3); margin-bottom: 14px; }
+.crumb a:hover { color: var(--accent); }
+.crumb .sep { opacity: 0.5; }
+.thread-head h1 { font-size: clamp(24px, 3vw, 32px); font-weight: 600; letter-spacing: -0.02em; line-height: 1.2; }
+.thread-head .meta { display: flex; align-items: center; gap: 10px; margin-top: 14px; flex-wrap: wrap; font-size: 13px; color: var(--ink-3); }
+.thread-layout { display: grid; grid-template-columns: minmax(0, 1fr) 260px; gap: 32px; padding: 24px 0 80px; align-items: start; }
+.post { display: grid; grid-template-columns: 52px minmax(0, 1fr); gap: 16px; padding: 24px 0; border-top: 1px solid var(--line); }
+.post:first-child { border-top: none; }
+.post.op { background: linear-gradient(180deg, var(--accent-soft), transparent 40%); border-radius: var(--radius); padding: 24px; margin: 0 -24px 4px; }
+.post.answer { background: var(--ok-soft); border: 1px solid color-mix(in oklch, var(--ok) 28%, transparent); border-radius: var(--radius); padding: 22px 24px; margin: 8px -24px; }
+.post .who { display: flex; align-items: center; gap: 9px; margin-bottom: 8px; }
+.post .who .name { font-size: 14.5px; font-weight: 600; }
+.post .who .when { font-size: 12px; color: var(--ink-3); }
+.post .answer-flag { display: flex; align-items: center; gap: 7px; font-size: 12.5px; font-weight: 600; color: var(--ok); margin-bottom: 10px; }
+.post .body { font-size: 15px; color: var(--ink); line-height: 1.7; overflow-wrap: anywhere; }
+.post .body p { margin: 0 0 12px; }
+.post .body p:last-child { margin-bottom: 0; }
+.post .body code { font-family: var(--font-mono); font-size: 13px; background: var(--bg-soft); padding: 2px 7px; border-radius: 6px; }
+.post .body pre { background: oklch(0.25 0.006 260); color: oklch(0.9 0.004 260); border-radius: var(--radius-sm); padding: 16px 18px; overflow-x: auto; font-family: var(--font-mono); font-size: 13px; line-height: 1.7; margin: 4px 0 12px; }
+.post .actions { display: flex; align-items: center; gap: 6px; margin-top: 16px; }
+.react { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-sans); font-size: 13px; font-weight: 500; color: var(--ink-2); background: var(--bg-soft); border: 1px solid transparent; border-radius: 999px; padding: 6px 13px; cursor: pointer; transition: background 0.2s, border-color 0.2s, color 0.2s; }
+.react:hover { border-color: var(--accent-line); color: var(--accent); }
+.react.on { background: var(--accent-soft); color: var(--accent); }
+.link-act { font-size: 13px; font-weight: 500; color: var(--ink-3); padding: 6px 10px; border-radius: 999px; cursor: pointer; background: none; border: none; font-family: var(--font-sans); }
+.link-act:hover { color: var(--accent); background: var(--accent-soft); }
+
+.composer { border: 1px solid var(--line); border-radius: var(--radius); padding: 8px; margin-top: 24px; background: #fff; transition: border-color 0.2s, box-shadow 0.2s; }
+.composer:focus-within { border-color: var(--accent-line); box-shadow: 0 0 0 4px var(--accent-soft); }
+.composer input.title { width: 100%; border: none; outline: none; padding: 12px 14px 4px; font-family: var(--font-sans); font-size: 18px; font-weight: 600; color: var(--ink); background: none; }
+.composer textarea { width: 100%; border: none; outline: none; resize: vertical; min-height: 96px; padding: 12px 14px; font-family: var(--font-sans); font-size: 15px; color: var(--ink); background: none; line-height: 1.6; }
+.composer .foot { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px 6px; gap: 12px; flex-wrap: wrap; }
+.composer .foot .hint { font-size: 12px; color: var(--ink-3); }
+.composer select { font-family: var(--font-sans); font-size: 13px; color: var(--ink-2); background: var(--bg-soft); border: none; border-radius: 999px; padding: 8px 12px; cursor: pointer; }
+.gate { text-align: center; padding: 22px; }
+.gate p { font-size: 14px; color: var(--ink-2); margin-bottom: 14px; }
+
+.side-card { background: var(--bg-soft); border-radius: var(--radius-sm); padding: 18px 20px; }
+.side-card h4 { font-size: 13px; font-weight: 600; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px; }
+.parti { display: flex; }
+.parti .av { margin-left: -8px; }
+.parti .av:first-child { margin-left: 0; }
+
+.foot { border-top: 1px solid var(--line); }
+.foot-inner { max-width: 1180px; margin: 0 auto; padding: 28px 32px; display: flex; align-items: center; gap: 20px; flex-wrap: wrap; font-size: 13.5px; color: var(--ink-3); }
+.foot-inner .links { display: flex; gap: 4px; margin-left: auto; flex-wrap: wrap; }
+.foot-inner .links a { padding: 6px 12px; border-radius: 999px; color: var(--ink-2); font-weight: 500; transition: background 0.2s, color 0.2s; }
+.foot-inner .links a:hover { background: var(--bg-soft); color: var(--ink); }
+
+@media (max-width: 940px) {
+  .layout, .thread-layout { grid-template-columns: 1fr; }
+  .side { position: static; }
+  .cats { grid-template-columns: 1fr; }
+  .nav-links, .nav-search { display: none; }
+  .topic { grid-template-columns: auto minmax(0, 1fr); }
+  .topic .stat, .topic .last { display: none; }
+  .wrap { padding: 0 20px; }
+}


### PR DESCRIPTION
The community forum frontend, built on the approved design and unified into the
main site.

## What's here

Astro pages at **reasonix.io/community** — one site, one design system, one deploy
(`pages.yml`):

- `/community/` — discussions home: categories + latest/top topics
- `/community/topic/?id=` — thread view: posts, accepted-answer highlight, reply
- `/community/new/` — start a topic (category + composer)
- `/community/guidelines/` — how the forum works

They're **client-rendered against the `forum.reasonix.io` API** and gated on the
**shared `id.reasonix.io` session** — the `rxid` cookie is sent cross-subdomain, so
there's no second login and nothing extra to deploy. Same client-fetch pattern as
the account pages.

## Anti-spam surfaces in the UI

The composer only appears when signed in; the API's gate errors are shown inline
(verify email, "new members can't post links yet", rate/daily limits). Report
buttons post flags (which auto-hide at the threshold server-side).

## Design

Reuses the reasonix.io token values with **self-hosted fonts** (`@fontsource`, no
CDN) — same oklch accent, radii, shadows, pill buttons — so the forum looks native
to the site. Skeletons + empty/error states on every async surface; responsive.

## Verification

- `astro build` clean — 13 pages (4 new under /community).
- API field contract confirmed against a local forum worker (`/topics`,
  `/topics/:id` return exactly what the client reads).
- Pages serve with the right containers; the client bundle bakes the default
  `forum.reasonix.io` base and honours a `PUBLIC_FORUM_API` override.
- Browser click-through not run here (no browser driver); the underlying API was
  verified end-to-end in the forum PR.

## Depends on

The forum API going live: PR (forum foundation) + `wrangler d1 create reasonix-forum`
+ schema/seed + deploy. Until then these pages render against the (not-yet-live)
`forum.reasonix.io`.
