### PR TITLE
fix(agent): make parallel tasks read-only

### DIFF
--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -1,23 +1,21 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
 	"reasonix/internal/event"
-	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
-// ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
-// collects all results. Each sub-task runs as a foreground sub-agent in its
+// ParallelTasksTool dispatches multiple read-only sub-agent tasks concurrently
+// and collects all results. Each sub-task runs as a foreground sub-agent in its
 // own goroutine, emitting nested events so the frontend renders independent
 // cards for each sub-task.
 type ParallelTasksTool struct {
@@ -34,7 +32,7 @@ func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasks
 func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
 
 func (p *ParallelTasksTool) Description() string {
-	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+	return "Dispatch multiple read-only sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
 }
 
 func (p *ParallelTasksTool) Schema() json.RawMessage {
@@ -62,7 +60,9 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
 }`)
 }
 
-func (p *ParallelTasksTool) ReadOnly() bool { return false }
+func (p *ParallelTasksTool) ReadOnly() bool { return true }
+
+func (p *ParallelTasksTool) PlanModeSafe() bool { return true }
 
 type parallelTaskItem struct {
 	Prompt      string   `json:"prompt"`
@@ -71,7 +71,6 @@ type parallelTaskItem struct {
 	MaxSteps    int      `json:"max_steps"`
 	Model       string   `json:"model"`
 	Effort      string   `json:"effort"`
-	DependsOn   []int    `json:"depends_on"`
 }
 
 type parallelTaskStatus string
@@ -88,7 +87,9 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	var params struct {
 		Tasks []parallelTaskItem `json:"tasks"`
 	}
-	if err := json.Unmarshal(args, &params); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(args))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&params); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
 	if len(params.Tasks) == 0 {
@@ -103,8 +104,8 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	parentID, sink, _, ok := CallContext(ctx)
 	if !ok || sink == nil {
-		// Fallback: no event sink available, use background-jobs approach.
-		return p.runAsBackgroundJobs(ctx, params.Tasks)
+		parentID = "parallel_tasks"
+		sink = event.Discard
 	}
 
 	type subResult struct {
@@ -115,63 +116,31 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	n := len(params.Tasks)
 
-	// Dependency state: remaining = number of deps not yet completed.
 	remaining := make([]int, n)
 	running := make([]bool, n)
 	done := make([]bool, n)
 	outputs := make([]string, n)
 	taskErrs := make([]error, n)
 	statuses := make([]parallelTaskStatus, n)
-	for i, t := range params.Tasks {
-		remaining[i] = len(t.DependsOn)
+	for i := range params.Tasks {
 		statuses[i] = parallelTaskPending
 	}
 
 	doneCh := make(chan subResult, n)
 	var wg sync.WaitGroup
 
-	wisdomDir, _ := os.MkdirTemp("", "parallel-wisdom-*")
-	if wisdomDir != "" {
-		defer os.RemoveAll(wisdomDir)
-	}
-	makePrompt := func(t parallelTaskItem) string {
-		var prefix strings.Builder
-		if len(t.DependsOn) > 0 && wisdomDir != "" {
-			entries, _ := os.ReadDir(wisdomDir)
-			if len(entries) > 0 {
-				fmt.Fprintf(&prefix, "Previous task results are available at %s. Read the relevant files with read_file before starting.\n\n", wisdomDir)
-			}
-		}
-		prefix.WriteString(t.Prompt)
-		return prefix.String()
-	}
 	makeLabel := func(t parallelTaskItem, idx int) string {
 		if t.Description != "" {
 			return t.Description
 		}
 		return fmt.Sprintf("task-%d", idx+1)
 	}
-	writeWisdom := func(r subResult) {
-		if wisdomDir == "" {
-			return
-		}
-		fname := filepath.Join(wisdomDir, fmt.Sprintf("task-%d.md", r.index+1))
-		switch {
-		case r.output != "":
-			summary := fmt.Sprintf("# Task %d Result\n\n%s", r.index+1, strings.TrimSpace(r.output))
-			_ = os.WriteFile(fname, []byte(summary), 0o644)
-		case r.err != nil:
-			summary := fmt.Sprintf("# Task %d Result\n\nFAILED: %s", r.index+1, r.err)
-			_ = os.WriteFile(fname, []byte(summary), 0o644)
-		}
-	}
 	startTask := func(idx int) {
 		t := params.Tasks[idx]
 		running[idx] = true
-		prompt := makePrompt(t)
 		label := makeLabel(t, idx)
 		subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
-		dispatchArgs, _ := json.Marshal(map[string]string{"prompt": prompt, "description": label})
+		dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
 		sink.Emit(event.Event{
 			Kind: event.ToolDispatch,
 			Tool: event.Tool{
@@ -185,7 +154,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			defer wg.Done()
 			nested := subSinkFor(subID, sink)
 			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
-			subReg := p.taskTool.buildSubReg(t.Tools)
+			subReg := ReadOnlySubagentToolRegistry(p.taskTool.parentReg, t.Tools)
 
 			max := t.MaxSteps
 			if max <= 0 {
@@ -203,7 +172,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			}
 
 			sess := NewSession("")
-			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
 				MaxSteps:            max,
 				Temperature:         p.taskTool.temperature,
 				Pricing:             pricing,
@@ -285,17 +254,6 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			statuses[r.index] = parallelTaskCancelled
 		default:
 			statuses[r.index] = parallelTaskFailed
-		}
-		writeWisdom(r)
-
-		for i, t := range params.Tasks {
-			if remaining[i] > 0 && !running[i] && !done[i] {
-				for _, dep := range t.DependsOn {
-					if dep == r.index {
-						remaining[i]--
-					}
-				}
-			}
 		}
 		if schedule {
 			startReady()
@@ -381,131 +339,10 @@ func formatParallelTasksAggregate(outputs []string, errs []error, statuses []par
 	return b.String()
 }
 
-// runAsBackgroundJobs is the fallback path when no event sink is available.
-func (p *ParallelTasksTool) runAsBackgroundJobs(ctx context.Context, tasks []parallelTaskItem) (string, error) {
-	jm, ok := jobs.FromContext(ctx)
-	if !ok {
-		return "", fmt.Errorf("background jobs are not available in this context")
-	}
-	session := jobs.SessionFromContext(ctx)
-
-	if err := validateParallelTaskItems(tasks); err != nil {
-		return "", err
-	}
-
-	type jobRef struct {
-		id    string
-		label string
-		idx   int
-	}
-	var refs []jobRef
-
-	for i, t := range tasks {
-		if strings.TrimSpace(t.Prompt) == "" {
-			return "", fmt.Errorf("task %d: prompt is required", i+1)
-		}
-		label := t.Description
-		if label == "" {
-			label = fmt.Sprintf("task-%d", i+1)
-		}
-
-		subArgs := map[string]interface{}{
-			"prompt":            t.Prompt,
-			"description":       label,
-			"run_in_background": true,
-		}
-		if len(t.Tools) > 0 {
-			subArgs["tools"] = t.Tools
-		}
-		if t.MaxSteps > 0 {
-			subArgs["max_steps"] = t.MaxSteps
-		}
-		if t.Model != "" {
-			subArgs["model"] = t.Model
-		}
-		if t.Effort != "" {
-			subArgs["effort"] = t.Effort
-		}
-
-		subJSON, err := json.Marshal(subArgs)
-		if err != nil {
-			return "", fmt.Errorf("task %d: marshal: %w", i+1, err)
-		}
-
-		result, err := p.taskTool.Execute(ctx, subJSON)
-		if err != nil {
-			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
-		}
-		refs = append(refs, jobRef{id: extractJobID(result), label: label, idx: i})
-		_ = result
-	}
-
-	if len(refs) == 0 {
-		return "", fmt.Errorf("no tasks were dispatched")
-	}
-
-	jobIDs := make([]string, 0, len(refs))
-	order := make(map[string]int)
-	for _, r := range refs {
-		jobIDs = append(jobIDs, r.id)
-		order[r.id] = r.idx
-	}
-
-	results := jm.WaitForSession(ctx, session, jobIDs, 0)
-	if len(results) == 0 {
-		return "No parallel task results available.", nil
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "Completed %d parallel tasks:\n", len(results))
-	for _, r := range results {
-		idx := order[r.ID]
-		label := r.ID
-		if r.Label != "" {
-			label = r.Label
-		}
-		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
-		_ = idx
-	}
-	return b.String(), nil
-}
-
 func validateParallelTaskItems(tasks []parallelTaskItem) error {
 	for i, t := range tasks {
 		if strings.TrimSpace(t.Prompt) == "" {
 			return fmt.Errorf("task %d: prompt is required", i+1)
-		}
-		for j, dep := range t.DependsOn {
-			if dep < 0 || dep >= len(tasks) {
-				return fmt.Errorf("task %d: depends_on[%d] = %d out of range (0-%d)", i+1, j, dep, len(tasks)-1)
-			}
-			if dep == i {
-				return fmt.Errorf("task %d: self-referencing depends_on", i+1)
-			}
-		}
-	}
-
-	state := make([]int, len(tasks)) // 0 = unvisited, 1 = visiting, 2 = done
-	var visit func(int) error
-	visit = func(i int) error {
-		switch state[i] {
-		case 1:
-			return fmt.Errorf("task dependency cycle detected at task %d", i+1)
-		case 2:
-			return nil
-		}
-		state[i] = 1
-		for _, dep := range tasks[i].DependsOn {
-			if err := visit(dep); err != nil {
-				return err
-			}
-		}
-		state[i] = 2
-		return nil
-	}
-	for i := range tasks {
-		if err := visit(i); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,9 +14,9 @@ import (
 	"reasonix/internal/tool"
 )
 
-func TestParallelTasksToolIsWriteCapable(t *testing.T) {
-	if (&ParallelTasksTool{}).ReadOnly() {
-		t.Fatal("parallel_tasks must be write-capable because spawned sub-agents can invoke writer tools")
+func TestParallelTasksToolIsReadOnly(t *testing.T) {
+	if !(&ParallelTasksTool{}).ReadOnly() {
+		t.Fatal("parallel_tasks must be read-only because it only dispatches read-only sub-agents")
 	}
 }
 
@@ -45,22 +46,44 @@ func TestParallelTasksValidatesAllTasksBeforeRuntimeLookup(t *testing.T) {
 	}
 }
 
-func TestParallelTasksRejectsDependencyCyclesBeforeRuntimeLookup(t *testing.T) {
+func TestParallelTasksRejectsHiddenDependencyFieldBeforeRuntimeLookup(t *testing.T) {
 	tool := &ParallelTasksTool{}
 	_, err := tool.Execute(context.Background(), json.RawMessage(`{
 		"tasks": [
 			{"prompt": "first", "depends_on": [1]},
-			{"prompt": "second", "depends_on": [0]}
+			{"prompt": "second"}
 		]
 	}`))
 	if err == nil {
-		t.Fatal("Execute returned nil error for cyclic dependencies")
+		t.Fatal("Execute returned nil error for hidden dependency field")
 	}
-	if !strings.Contains(err.Error(), "cycle") {
-		t.Fatalf("Execute error = %v, want dependency cycle validation", err)
+	if !strings.Contains(err.Error(), "depends_on") {
+		t.Fatalf("Execute error = %v, want depends_on rejection", err)
 	}
 	if strings.Contains(err.Error(), "background jobs are not available") {
-		t.Fatalf("Execute looked up background jobs before validating dependencies: %v", err)
+		t.Fatalf("Execute looked up runtime before rejecting hidden dependencies: %v", err)
+	}
+}
+
+func TestParallelTasksDoesNotExposeWriterToolsToChildren(t *testing.T) {
+	var writerCalls int32
+	parentReg := tool.NewRegistry()
+	parentReg.Add(fakeTool{name: "write_file", readOnly: false, calls: &writerCalls})
+	task := newTestTaskTool(t, writerCallingProvider{}, parentReg, "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, parentReg)
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	out, err := parallel.Execute(ctx, json.RawMessage(`{
+		"tasks": [
+			{"prompt": "try writer one"},
+			{"prompt": "try writer two"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("Execute returned error: %v\n%s", err, out)
+	}
+	if got := atomic.LoadInt32(&writerCalls); got != 0 {
+		t.Fatalf("writer tool executed %d times; parallel_tasks children must be read-only", got)
 	}
 }
 
@@ -168,6 +191,33 @@ func (promptRoutingProvider) Stream(_ context.Context, req provider.Request) (<-
 	ch <- provider.Chunk{Type: provider.ChunkDone}
 	close(ch)
 	return ch, nil
+}
+
+type writerCallingProvider struct{}
+
+func (writerCallingProvider) Name() string { return "writer-calling" }
+
+func (writerCallingProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, 2)
+	if !hasToolResult(req, "write_file") {
+		ch <- toolCallChunk("write-1", "write_file", `{"path":"x","content":"y"}`)
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "writer unavailable"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func hasToolResult(req provider.Request, name string) bool {
+	for _, m := range req.Messages {
+		if m.Role == provider.RoleTool && m.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 type stringsError string


### PR DESCRIPTION
## Summary

This PR narrows `parallel_tasks` to read-only sub-agent dispatch so concurrent subtasks cannot mutate the workspace or invoke writer tools.

## Why

`parallel_tasks` previously ran multiple sub-agents concurrently while exposing the normal writable sub-agent tool registry. That made it possible for parallel children to edit files or run write-capable tools at the same time without write-set isolation, locking, conflict detection, or merge semantics.

The tool schema also intentionally hid `depends_on`, but the runtime still parsed and honored it. That created an undocumented behavior path where callers could trigger dependency scheduling that was not part of the provider-visible contract.

## Changes

- Mark `parallel_tasks` as read-only and plan-mode safe.
- Run each child with `ReadOnlySubagentToolRegistry` instead of the writable sub-agent registry.
- Reject unknown arguments with `DisallowUnknownFields`, including hidden `depends_on`.
- Remove the hidden dependency/wisdom-file scheduling path.
- Remove the background-job fallback that could route back through writable `task` execution.
- Add regression tests for the read-only contract, hidden dependency rejection, and writer-tool isolation.

## Cache Impact

Cache-impact: medium - changes the provider-visible `parallel_tasks` tool description, so sessions started after this version may get a different cached tool-prefix entry. It does not introduce per-turn dynamic schema changes, and the JSON schema remains stable.
Cache-guard: `go test ./internal/agent -run 'TestParallelTasks'` covers schema stability, read-only classification, hidden `depends_on` rejection, and writer-tool isolation.

## Validation

- `go test ./internal/agent -run 'TestParallelTasks'`
- `go test ./internal/agent`
- `go test ./internal/control`
- `go test ./internal/...`