### PR TITLE
fix(memory): inject feedback memories into prompt

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -166,7 +166,7 @@ model = "x"
 	if _, err := store.Save(memory.Memory{
 		Name:        "synthesis-cache-policy",
 		Description: "Stable conclusions should be reused from memory",
-		Type:        memory.TypeFeedback,
+		Type:        memory.TypeProject,
 		Body:        "Use a synthesis cache document when expensive retrieval produced a stable conclusion.",
 	}); err != nil {
 		t.Fatalf("save memory: %v", err)

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -13,11 +13,12 @@ import (
 // UserDir are retained so the controller can resolve quick-add targets without
 // re-deriving discovery context.
 type Set struct {
-	Docs    []Source // REASONIX.md / AGENTS.md, ascending precedence
-	Store   Store    // auto-memory store (may be a zero/disabled Store)
-	Index   string   // MEMORY.md contents at load time
-	CWD     string   // project working dir used for discovery
-	UserDir string   // user config root (may be "")
+	Docs     []Source // REASONIX.md / AGENTS.md, ascending precedence
+	Store    Store    // auto-memory store (may be a zero/disabled Store)
+	Index    string   // MEMORY.md contents at load time
+	Feedback []Memory // saved feedback bodies captured at load time
+	CWD      string   // project working dir used for discovery
+	UserDir  string   // user config root (may be "")
 }
 
 // Options configures discovery. CWD defaults to "." and UserDir is the user
@@ -37,13 +38,25 @@ func Load(opts Options) *Set {
 		cwd = "."
 	}
 	store := StoreFor(opts.UserDir, cwd)
+	memories := store.List()
 	return &Set{
-		Docs:    discoverDocs(cwd, opts.UserDir),
-		Store:   store,
-		Index:   store.Index(),
-		CWD:     cwd,
-		UserDir: opts.UserDir,
+		Docs:     discoverDocs(cwd, opts.UserDir),
+		Store:    store,
+		Index:    store.Index(),
+		Feedback: feedbackMemories(memories),
+		CWD:      cwd,
+		UserDir:  opts.UserDir,
 	}
+}
+
+func feedbackMemories(memories []Memory) []Memory {
+	var out []Memory
+	for _, m := range memories {
+		if m.Type == TypeFeedback && strings.TrimSpace(m.Body) != "" {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // DocPath returns the doc-memory file a given scope writes to. To avoid splitting
@@ -77,7 +90,7 @@ func (s *Set) DocPath(scope Scope) string {
 // the base prompt byte-for-byte untouched (and the cache prefix maximal) when
 // there is no memory at all.
 func (s *Set) Empty() bool {
-	return s == nil || (len(s.Docs) == 0 && strings.TrimSpace(s.Index) == "")
+	return s == nil || (len(s.Docs) == 0 && len(s.Feedback) == 0 && strings.TrimSpace(s.Index) == "")
 }
 
 // docScopes are the scopes the panel can target for a quick-add or a new doc.
@@ -134,6 +147,14 @@ func (s *Set) Block() string {
 
 	for _, d := range s.Docs {
 		fmt.Fprintf(&b, "\n## %s (%s)\n\n%s\n", d.Path, d.Scope, strings.TrimSpace(d.Body))
+	}
+
+	if len(s.Feedback) > 0 {
+		b.WriteString("\n## Saved feedback\n\n")
+		b.WriteString("Apply these saved feedback memories as standing user guidance for this session.\n")
+		for _, m := range s.Feedback {
+			fmt.Fprintf(&b, "\n### %s\n\n%s\n", displayTitle(m.Title, m.Name), strings.TrimSpace(m.Body))
+		}
 	}
 
 	if idx := strings.TrimSpace(s.Index); idx != "" {

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -36,6 +36,45 @@ func TestComposeAppendsAfterBase(t *testing.T) {
 	}
 }
 
+func TestBlockInjectsFeedbackMemoryBodies(t *testing.T) {
+	root := t.TempDir()
+	user := filepath.Join(root, "userconfig")
+	proj := filepath.Join(root, "proj")
+	mustMkdir(t, user)
+	mustMkdir(t, filepath.Join(proj, ".git"))
+
+	set := Load(Options{CWD: proj, UserDir: user})
+	if _, err := set.Store.Save(Memory{
+		Name:        "prefer-concrete-next-action",
+		Title:       "Prefer concrete next action",
+		Description: "Reply structure preference",
+		Type:        TypeFeedback,
+		Body:        "When responding, lead with the concrete next action.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := set.Store.Save(Memory{
+		Name:        "project-background",
+		Description: "Background context",
+		Type:        TypeProject,
+		Body:        "PROJECT BACKGROUND SHOULD STAY LINKED ONLY",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	set = Load(Options{CWD: proj, UserDir: user})
+	block := set.Block()
+	if !strings.Contains(block, "When responding, lead with the concrete next action.") {
+		t.Fatalf("feedback memory body was not injected into prompt:\n%s", block)
+	}
+	if strings.Contains(block, "PROJECT BACKGROUND SHOULD STAY LINKED ONLY") {
+		t.Fatalf("non-feedback memory body should stay linked only:\n%s", block)
+	}
+	if !strings.Contains(block, "[Prefer concrete next action](prefer-concrete-next-action.md)") {
+		t.Fatalf("saved memory index entry missing:\n%s", block)
+	}
+}
+
 // TestDiscoverPrecedenceOrder checks user → ancestor → project → local ordering,
 // which puts the most specific guidance last.
 func TestDiscoverPrecedenceOrder(t *testing.T) {


### PR DESCRIPTION
Fixes #5595.

Problem:
- Saved memories of type `feedback` are only exposed through the MEMORY.md index at session start, so standing user guidance is not applied unless the model reads the linked file manually.

Change:
- Capture feedback memories during `memory.Load`.
- Inject feedback bodies as standing guidance in the Memory prompt block.
- Keep non-feedback saved memories linked-only as background context.

Cache-impact: medium - feedback memory bodies now become part of the cached Memory prompt block when saved feedback exists.
Cache-guard: `go test ./internal/memory -run TestBlockInjectsFeedbackMemoryBodies -count=1` verifies feedback bodies are injected while non-feedback bodies stay linked-only.
System-prompt-review: self-reviewed for cache prefix impact; change is limited to saved feedback guidance loaded at session start.

Verification:
- `go test ./internal/memory -run TestBlockInjectsFeedbackMemoryBodies -count=1`
- `go test ./internal/memory -count=1`
- `go test ./internal/control -run 'TestMemory|TestCompose' -count=1`\n- `git diff --check`