### PR TITLE
Compact approval prompts

### DIFF
--- a/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
+++ b/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
@@ -196,5 +196,34 @@ console.log("\napproval modal file references");
   dom.window.close();
 }
 
+{
+  const dom = installDom();
+  mockApp({
+    ListDir: async () => [],
+    SearchFileRefs: async () => [],
+  });
+  const { root } = await renderApproval({
+    approval: {
+      id: "tool-approval",
+      tool: "bash",
+      subject: "npm run build\n\nRun the build command to verify frontend artifacts.",
+    },
+  });
+
+  const subject = document.querySelector(".approval-subject");
+  ok(subject != null, "tool approval shows its full subject by default");
+  eq(
+    subject?.textContent,
+    "npm run build\n\nRun the build command to verify frontend artifacts.",
+    "default-open tool approval keeps the complete subject visible",
+  );
+  ok(document.body.textContent?.includes("Hide") === true, "tool approval details start expanded");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -50,6 +50,7 @@ export function ApprovalModal({
   const isPlanApproval = approval.tool === "exit_plan_mode";
   const [revisionOpen, setRevisionOpen] = useState(false);
   const [revisionText, setRevisionText] = useState("");
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(() => (isPlanApproval ? 1 : 0));
   const cardRef = useRef<HTMLDivElement | null>(null);
   const shelfRef = useRef<HTMLDivElement | null>(null);
@@ -60,6 +61,9 @@ export function ApprovalModal({
   // jarring pop when the API cycles through 4+ pending approvals.
   const closingRef = useRef(false);
   const subject = approval.subject.trim();
+  const subjectSummary = subject.split(/\r?\n/).find((line) => line.trim())?.trim() ?? "";
+  const toolMeta = approval.reason?.trim() || subjectSummary || approval.tool;
+  const hasToolDetails = Boolean(approval.reason || subject);
   const fileMenu = useFileReferenceMenu(revisionText, cwd);
 
   const answerWithExit = (fn: () => void) => {
@@ -98,6 +102,7 @@ export function ApprovalModal({
     cardRef.current?.focus();
     setRevisionOpen(false);
     setRevisionText("");
+    setDetailsOpen(false);
     setSelectedIndex(isPlanApproval ? 1 : 0);
     playAttentionChime();
   }, [approval.id, isPlanApproval]);
@@ -219,6 +224,7 @@ export function ApprovalModal({
     return (
       <div ref={shelfRef}>
         <PromptShelf
+          className="prompt-shelf--compact prompt-shelf--plan-approval"
           barRef={cardRef}
           titleId="plan-approval-title"
           title={t("approval.planReady")}
@@ -280,14 +286,23 @@ export function ApprovalModal({
   return (
     <div ref={shelfRef}>
       <PromptShelf
+        className="prompt-shelf--compact prompt-shelf--tool-approval"
         barRef={cardRef}
         titleId="tool-approval-title"
         title={t("approval.toolPending")}
         badges={<PromptBadge>{approval.tool}</PromptBadge>}
+        meta={toolMeta}
         headerActions={
-          <PromptHeaderAction onClick={() => answerWithExit(onStop)} ariaLabel={t("composer.stopShort")}>
-            Esc
-          </PromptHeaderAction>
+          <>
+            {hasToolDetails && (
+              <PromptHeaderAction onClick={() => setDetailsOpen((open) => !open)}>
+                {t(detailsOpen ? "approval.hideDetails" : "approval.details")}
+              </PromptHeaderAction>
+            )}
+            <PromptHeaderAction onClick={() => answerWithExit(onStop)} ariaLabel={t("composer.stopShort")}>
+              Esc
+            </PromptHeaderAction>
+          </>
         }
         actions={
           <>
@@ -298,9 +313,13 @@ export function ApprovalModal({
           </>
         }
       >
-        {approval.reason && <div className="approval-reason">{approval.reason}</div>}
-        {subject && (
-          <pre className="approval-subject">{subject}</pre>
+        {detailsOpen && (
+          <div className="approval-details">
+            {approval.reason && <div className="approval-reason">{approval.reason}</div>}
+            {subject && (
+              <pre className="approval-subject">{subject}</pre>
+            )}
+          </div>
         )}
       </PromptShelf>
     </div>

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -48,9 +48,14 @@ export function ApprovalModal({
 }) {
   const t = useT();
   const isPlanApproval = approval.tool === "exit_plan_mode";
+  const subject = approval.subject.trim();
+  const subjectSummary = subject.split(/\r?\n/).find((line) => line.trim())?.trim() ?? "";
+  const toolMeta = approval.reason?.trim() || subjectSummary || approval.tool;
+  const hasToolDetails = Boolean(approval.reason || subject);
+  const showToolDetailsByDefault = !isPlanApproval && hasToolDetails;
   const [revisionOpen, setRevisionOpen] = useState(false);
   const [revisionText, setRevisionText] = useState("");
-  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(() => showToolDetailsByDefault);
   const [selectedIndex, setSelectedIndex] = useState(() => (isPlanApproval ? 1 : 0));
   const cardRef = useRef<HTMLDivElement | null>(null);
   const shelfRef = useRef<HTMLDivElement | null>(null);
@@ -60,10 +65,6 @@ export function ApprovalModal({
   // the new one slides in.  GSAP fromTo on the shelf wrapper avoids the
   // jarring pop when the API cycles through 4+ pending approvals.
   const closingRef = useRef(false);
-  const subject = approval.subject.trim();
-  const subjectSummary = subject.split(/\r?\n/).find((line) => line.trim())?.trim() ?? "";
-  const toolMeta = approval.reason?.trim() || subjectSummary || approval.tool;
-  const hasToolDetails = Boolean(approval.reason || subject);
   const fileMenu = useFileReferenceMenu(revisionText, cwd);
 
   const answerWithExit = (fn: () => void) => {
@@ -102,10 +103,10 @@ export function ApprovalModal({
     cardRef.current?.focus();
     setRevisionOpen(false);
     setRevisionText("");
-    setDetailsOpen(false);
+    setDetailsOpen(showToolDetailsByDefault);
     setSelectedIndex(isPlanApproval ? 1 : 0);
     playAttentionChime();
-  }, [approval.id, isPlanApproval]);
+  }, [approval.id, isPlanApproval, showToolDetailsByDefault]);
 
   const actionCount = isPlanApproval ? 3 : 4;
   const selectedIndexRef = useRef(selectedIndex);

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -22,8 +22,10 @@ export function AskCard({
   // Per-question state: selected option labels, and an optional typed answer.
   const [sel, setSel] = useState<Record<string, string[]>>({});
   const [custom, setCustom] = useState<Record<string, string>>({});
+  const [customOpen, setCustomOpen] = useState(false);
   const [active, setActive] = useState(0);
   const shelfRef = useRef<HTMLDivElement | null>(null);
+  const customInputRef = useRef<HTMLInputElement | null>(null);
   const advanceTimer = useRef<number | null>(null);
 
   const questions = ask.questions;
@@ -36,6 +38,7 @@ export function AskCard({
     shelfRef.current?.focus();
     setSel({});
     setCustom({});
+    setCustomOpen(false);
     setActive(0);
     if (advanceTimer.current != null) window.clearTimeout(advanceTimer.current);
     playAttentionChime();
@@ -66,7 +69,15 @@ export function AskCard({
     (sel[question.id]?.length ?? 0) > 0 || (custom[question.id]?.trim() ?? "") !== "";
 
   const currentAnswered = q ? answered(q) : false;
-  const showSubmitAction = q ? q.multi || Boolean(custom[q.id]?.trim()) : false;
+  const showSubmitAction = q ? q.multi || customOpen || Boolean(custom[q.id]?.trim()) : false;
+
+  useEffect(() => {
+    setCustomOpen(false);
+  }, [active]);
+
+  useEffect(() => {
+    if (customOpen) customInputRef.current?.focus();
+  }, [customOpen]);
 
   const finishOrAdvance = (nextSel = sel, nextCustom = custom) => {
     if (advanceTimer.current != null) {
@@ -89,6 +100,7 @@ export function AskCard({
 
     setCustom(nextCustom);
     setSel(nextSel);
+    setCustomOpen(false);
 
     if (!question.multi) {
       if (advanceTimer.current != null) window.clearTimeout(advanceTimer.current);
@@ -148,6 +160,7 @@ export function AskCard({
 
   return (
     <PromptShelf
+      className="prompt-shelf--compact prompt-shelf--ask"
       barRef={shelfRef}
       titleId="ask-shelf-title"
       title={t("ask.title")}
@@ -165,6 +178,9 @@ export function AskCard({
       headerActions={
         <>
           <PromptHeaderAction onClick={onDismiss}>{t("ask.justChat")}</PromptHeaderAction>
+          {!customOpen && (
+            <PromptHeaderAction onClick={() => setCustomOpen(true)}>{t("ask.customAnswer")}</PromptHeaderAction>
+          )}
           <PromptHeaderAction onClick={onStop} ariaLabel={t("composer.stopShort")}>Esc</PromptHeaderAction>
         </>
       }
@@ -213,8 +229,10 @@ export function AskCard({
         )
       }
     >
+      {customOpen && (
       <div className="ask-shelf__custom-row">
         <input
+          ref={customInputRef}
           className="ask-shelf__custom"
           placeholder={t("ask.customPlaceholder")}
           value={custom[q.id] ?? ""}
@@ -225,6 +243,7 @@ export function AskCard({
           }}
         />
       </div>
+      )}
     </PromptShelf>
   );
 }

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode, RefObject } from "react";
 
 export function PromptShelf({
+  className,
+  cardClassName,
   titleId,
   title,
   badges,
@@ -13,6 +15,8 @@ export function PromptShelf({
   barRef,
   role = "dialog",
 }: {
+  className?: string;
+  cardClassName?: string;
   titleId: string;
   title: ReactNode;
   badges?: ReactNode;
@@ -26,10 +30,10 @@ export function PromptShelf({
   role?: "dialog" | "region";
 }) {
   return (
-    <div className="prompt-shelf" aria-live="polite">
+    <div className={["prompt-shelf", className ?? ""].filter(Boolean).join(" ")} aria-live="polite">
       <div
         ref={barRef}
-        className="prompt-shelf__card"
+        className={["prompt-shelf__card", cardClassName ?? ""].filter(Boolean).join(" ")}
         role={role}
         aria-modal={role === "dialog" ? "false" : undefined}
         aria-labelledby={titleId}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -589,6 +589,7 @@ export const en = {
   "ask.hideDetails": "Hide",
   "ask.back": "Back",
   "ask.next": "Next",
+  "ask.customAnswer": "Other answer",
   "ask.customPlaceholder": "Type your own answer…",
   "ask.justChat": "Just chat",
 

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -441,6 +441,7 @@ export const zhTW: Record<DictKey, string> = {
   "ask.hideDetails": "收起",
   "ask.back": "返回",
   "ask.next": "下一步",
+  "ask.customAnswer": "其他答案",
   "ask.customPlaceholder": "輸入你自己的答案…",
   "ask.justChat": "只是聊聊",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -590,6 +590,7 @@ export const zh: Record<DictKey, string> = {
   "ask.hideDetails": "收起",
   "ask.back": "返回",
   "ask.next": "下一步",
+  "ask.customAnswer": "其它答案",
   "ask.customPlaceholder": "输入你自己的答案…",
   "ask.justChat": "只是聊聊",
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7105,6 +7105,137 @@ body > .mermaid-diagram--fullscreen {
 .ask-shelf__custom::placeholder {
   color: var(--fg-faint);
 }
+
+.prompt-shelf--compact .prompt-shelf__card {
+  gap: 6px;
+  padding: 8px 10px;
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
+  border-radius: 10px;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.06);
+}
+.prompt-shelf--compact .prompt-shelf__header {
+  align-items: center;
+  gap: 10px;
+}
+.prompt-shelf--compact .prompt-shelf__copy {
+  gap: 2px;
+}
+.prompt-shelf--compact .prompt-shelf__title {
+  align-items: center;
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+.prompt-shelf--compact .prompt-shelf__heading {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.prompt-shelf--compact .prompt-shelf__badges {
+  flex: 0 0 auto;
+}
+.prompt-shelf--compact .prompt-shelf__meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: normal;
+}
+.prompt-shelf--compact .prompt-shelf__header-actions,
+.prompt-shelf--compact .prompt-shelf__quick-actions {
+  align-items: center;
+  flex: 0 0 auto;
+}
+.prompt-shelf--compact .prompt-shelf__header-button {
+  min-height: 26px;
+  padding: 0 9px;
+}
+.prompt-shelf--compact .prompt-shelf__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.prompt-shelf--compact .prompt-action {
+  width: auto;
+  min-height: 28px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+.prompt-shelf--compact .prompt-action__key {
+  min-width: 19px;
+  height: 19px;
+  border-radius: 6px;
+}
+.prompt-shelf--compact .prompt-action__copy {
+  display: block;
+}
+.prompt-shelf--compact .prompt-action__label {
+  white-space: nowrap;
+}
+.prompt-shelf--compact .approval-details {
+  display: grid;
+  gap: 6px;
+}
+.prompt-shelf--compact .approval-reason {
+  padding: 7px 9px;
+  font-size: 11.5px;
+}
+.prompt-shelf--compact .approval-subject {
+  max-height: 118px;
+  padding: 7px 9px;
+  font-size: 11px;
+}
+.prompt-shelf--plan-approval .prompt-shelf__body {
+  margin-top: 2px;
+}
+.prompt-shelf--ask .prompt-shelf__card {
+  gap: 6px;
+}
+.prompt-shelf--ask .prompt-shelf__title {
+  flex-wrap: wrap;
+}
+.prompt-shelf--ask .prompt-shelf__header {
+  align-items: flex-start;
+}
+.prompt-shelf--ask .prompt-shelf__meta {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.prompt-shelf--ask .prompt-shelf__actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  max-height: 154px;
+  overflow: auto;
+  padding-right: 2px;
+}
+.prompt-shelf--ask .prompt-action {
+  width: 100%;
+  min-height: 42px;
+  align-items: center;
+  border-radius: 8px;
+  padding: 5px 8px;
+  white-space: normal;
+}
+.prompt-shelf--ask .prompt-action__copy {
+  display: grid;
+  gap: 1px;
+}
+.prompt-shelf--ask .prompt-action__label,
+.prompt-shelf--ask .prompt-action__desc {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.prompt-shelf--ask .ask-shelf__custom-row {
+  margin-top: 0;
+}
+.prompt-shelf--ask .ask-shelf__custom {
+  height: 30px;
+  padding: 0 9px;
+}
 .modal__plannote {
   margin: 0 0 16px;
   color: var(--fg-dim);


### PR DESCRIPTION
## Summary
- Compact tool and plan approval prompt shelves so they take less vertical chat space.
- Collapse tool command/reason details behind a Details/Hide toggle while preserving the original approval actions.
- Render ask requests as compact quick-pick lists and reveal the custom answer input only on demand.

## Verification
- pnpm check:css
- pnpm typecheck
- pnpm exec tsx src/__tests__/ask-card-layout.test.ts
- pnpm exec tsx src/__tests__/approval-modal-file-reference.test.tsx
- Browser mock checks: /approve-preview, /plan-approve-preview, /ask-preview