### PR TITLE
feat(site): bilingual community forum (EN / 中文)

### DIFF
--- a/site/src/layouts/Community.astro
+++ b/site/src/layouts/Community.astro
@@ -18,18 +18,21 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
 </head>
-<body>
+<body data-lang="en">
   <header class="nav">
     <div class="nav-inner">
-      <a class="brand" href="/community/"><span class="mark">R</span>Reasonix<span class="ctag">Community</span></a>
+      <a class="brand" href="/community/"><span class="mark">R</span>Reasonix<span class="ctag"><span class="l-en">Community</span><span class="l-zh">社区</span></span></a>
       <nav class="nav-links">
-        <a class={active === "discussions" ? "here" : ""} href="/community/">Discussions</a>
-        <a href="/community/?category=skills">Skills</a>
-        <a href="/community/?category=show">Showcase</a>
-        <a href="/docs/">Docs ↗</a>
+        <a class={active === "discussions" ? "here" : ""} href="/community/"><span class="l-en">Discussions</span><span class="l-zh">讨论</span></a>
+        <a href="/community/?category=skills"><span class="l-en">Skills</span><span class="l-zh">技能</span></a>
+        <a href="/community/?category=show"><span class="l-en">Showcase</span><span class="l-zh">展示</span></a>
+        <a href="/docs/"><span class="l-en">Docs ↗</span><span class="l-zh">文档 ↗</span></a>
       </nav>
       <div class="nav-right">
-        <label class="nav-search"><span class="ico">⌕</span><input placeholder="Search…" disabled /></label>
+        <div class="lang-switch" role="group" aria-label="Language">
+          <button type="button" data-lang="en" class="active">EN</button>
+          <button type="button" data-lang="zh">中文</button>
+        </div>
         <span id="nav-account"></span>
       </div>
     </div>
@@ -42,10 +45,10 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
   <footer class="foot">
     <div class="foot-inner">
       <a class="brand" href="/"><span class="mark">R</span>Reasonix</a>
-      <span>© 2026 · MIT · built to be left running.</span>
+      <span><span class="l-en">© 2026 · MIT · built to be left running.</span><span class="l-zh">© 2026 · MIT 许可 · 为常驻运行而生。</span></span>
       <nav class="links">
-        <a href="/community/guidelines/">Guidelines</a>
-        <a href="/docs/">Docs</a>
+        <a href="/community/guidelines/"><span class="l-en">Guidelines</span><span class="l-zh">规范</span></a>
+        <a href="/docs/"><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
         <a href="https://github.com/esengine/DeepSeek-Reasonix">GitHub</a>
       </nav>
     </div>

--- a/site/src/pages/community/guidelines.astro
+++ b/site/src/pages/community/guidelines.astro
@@ -3,12 +3,12 @@ import Community from "../../layouts/Community.astro";
 ---
 <Community title="Guidelines — Reasonix Community" description="How the Reasonix community forum works.">
   <div class="wrap" style="padding:36px 32px 80px;max-width:760px">
-    <div class="crumb"><a href="/community/">Community</a><span class="sep">/</span><span>Guidelines</span></div>
-    <h1 style="font-size:32px;font-weight:600;letter-spacing:-0.02em">Community guidelines</h1>
-    <p style="margin:14px 0 28px;color:var(--ink-2);font-size:16px;line-height:1.7">A small forum works when everyone keeps it useful and kind. A few things worth knowing.</p>
+    <div class="crumb"><a href="/community/"><span class="l-en">Community</span><span class="l-zh">社区</span></a><span class="sep">/</span><span><span class="l-en">Guidelines</span><span class="l-zh">规范</span></span></div>
+    <h1 style="font-size:32px;font-weight:600;letter-spacing:-0.02em"><span class="l-en">Community guidelines</span><span class="l-zh">社区规范</span></h1>
+    <p style="margin:14px 0 28px;color:var(--ink-2);font-size:16px;line-height:1.7"><span class="l-en">A small forum works when everyone keeps it useful and kind. A few things worth knowing.</span><span class="l-zh">一个小论坛，靠大家保持有用与友善才能运转。几点值得先了解。</span></p>
 
-    <div class="side-card" style="margin-bottom:16px"><h4>Be kind &amp; on-topic</h4><p style="color:var(--ink-2);line-height:1.7">Assume good faith, search before asking, and keep threads focused. Format code in fenced <code>```</code> blocks.</p></div>
-    <div class="side-card" style="margin-bottom:16px"><h4>Trust levels</h4><p style="color:var(--ink-2);line-height:1.7">Everyone signs in with their Reasonix account. New accounts start limited — no links, a small daily post cap — and unlock more as they read and contribute. It keeps the forum spam-free without getting in real members' way.</p></div>
-    <div class="side-card"><h4>Moderation</h4><p style="color:var(--ink-2);line-height:1.7">Flag anything off — a few flags auto-hide a post for review. Moderators can restrict accounts that abuse the forum. All moderator actions are logged.</p></div>
+    <div class="side-card" style="margin-bottom:16px"><h4><span class="l-en">Be kind &amp; on-topic</span><span class="l-zh">友善、切题</span></h4><p style="color:var(--ink-2);line-height:1.7"><span class="l-en">Assume good faith, search before asking, and keep threads focused. Format code in fenced <code>```</code> blocks.</span><span class="l-zh">与人为善、提问前先搜索、保持话题聚焦。代码请放进 <code>```</code> 围栏块。</span></p></div>
+    <div class="side-card" style="margin-bottom:16px"><h4><span class="l-en">Trust levels</span><span class="l-zh">信任等级</span></h4><p style="color:var(--ink-2);line-height:1.7"><span class="l-en">Everyone signs in with their Reasonix account. New accounts start limited — no links, a small daily post cap — and unlock more as they read and contribute. It keeps the forum spam-free without getting in real members' way.</span><span class="l-zh">所有人用 Reasonix 账号登录。新账号有限制——不能发链接、每日发帖上限较低——随着阅读与贡献逐步解锁。既挡住广告，又不妨碍真实成员。</span></p></div>
+    <div class="side-card"><h4><span class="l-en">Moderation</span><span class="l-zh">审核</span></h4><p style="color:var(--ink-2);line-height:1.7"><span class="l-en">Flag anything off — a few flags auto-hide a post for review. Moderators can restrict accounts that abuse the forum. All moderator actions are logged.</span><span class="l-zh">发现不妥就举报——几次举报会自动隐藏帖子待审。版主可限制滥用论坛的账号。所有版主操作都有记录。</span></p></div>
   </div>
 </Community>

--- a/site/src/pages/community/index.astro
+++ b/site/src/pages/community/index.astro
@@ -6,26 +6,26 @@ import Community from "../../layouts/Community.astro";
     <div class="wrap">
       <div class="row">
         <div>
-          <div class="eyebrow">Reasonix Community</div>
-          <h1>Discussions</h1>
-          <p>Ask questions, share skills, and shape a DeepSeek-native agent — with the makers and other builders.</p>
+          <div class="eyebrow"><span class="l-en">Reasonix Community</span><span class="l-zh">Reasonix 社区</span></div>
+          <h1><span class="l-en">Discussions</span><span class="l-zh">讨论区</span></h1>
+          <p><span class="l-en">Ask questions, share skills, and shape a DeepSeek-native agent — with the makers and other builders.</span><span class="l-zh">提问、分享技能、一起打磨这个 DeepSeek 原生 Agent —— 和作者及其他构建者。</span></p>
         </div>
-        <a class="btn btn-primary" href="/community/new/">✎ New topic</a>
+        <a class="btn btn-primary" href="/community/new/"><span class="l-en">✎ New topic</span><span class="l-zh">✎ 发起话题</span></a>
       </div>
     </div>
   </section>
 
   <div class="wrap layout">
     <div>
-      <div class="sec-title"><h2>Categories</h2></div>
+      <div class="sec-title"><h2><span class="l-en">Categories</span><span class="l-zh">分区</span></h2></div>
       <div class="cats" id="cat-list">
-        <div class="cat"><span class="ico">·</span><div><h3>Loading…</h3></div></div>
+        <div class="cat"><span class="ico">·</span><div><h3><span class="l-en">Loading…</span><span class="l-zh">加载中…</span></h3></div></div>
       </div>
 
       <div class="sec-title">
         <div class="tabs" id="sort-tabs">
-          <button class="on" data-sort="latest">Latest</button>
-          <button data-sort="top">Top</button>
+          <button class="on" data-sort="latest"><span class="l-en">Latest</span><span class="l-zh">最新</span></button>
+          <button data-sort="top"><span class="l-en">Top</span><span class="l-zh">热门</span></button>
         </div>
       </div>
       <div class="topics" id="topic-list">
@@ -37,21 +37,21 @@ import Community from "../../layouts/Community.astro";
 
     <aside class="side">
       <div class="card cta">
-        <h4>Start a discussion</h4>
-        <p class="lead" id="cta-lead">Ask a question or share what you built.</p>
-        <a class="btn btn-primary" href="/community/new/">✎ New topic</a>
+        <h4><span class="l-en">Start a discussion</span><span class="l-zh">发起讨论</span></h4>
+        <p class="lead"><span class="l-en">Ask a question or share what you built.</span><span class="l-zh">提个问题，或分享你做的东西。</span></p>
+        <a class="btn btn-primary" href="/community/new/"><span class="l-en">✎ New topic</span><span class="l-zh">✎ 发起话题</span></a>
       </div>
       <div class="card">
-        <h4 style="margin-bottom:14px">Community</h4>
+        <h4 style="margin-bottom:14px"><span class="l-en">Community</span><span class="l-zh">社区</span></h4>
         <div class="stats-grid" id="stats">
-          <div class="stat-box"><div class="n" id="s-topics">—</div><div class="l">topics</div></div>
-          <div class="stat-box"><div class="n" id="s-cats">—</div><div class="l">categories</div></div>
+          <div class="stat-box"><div class="n" id="s-topics">—</div><div class="l"><span class="l-en">topics</span><span class="l-zh">话题</span></div></div>
+          <div class="stat-box"><div class="n" id="s-cats">—</div><div class="l"><span class="l-en">categories</span><span class="l-zh">分区</span></div></div>
         </div>
       </div>
       <div class="card">
-        <h4 style="margin-bottom:14px">Guidelines</h4>
-        <p class="lead">Be kind, search first, and keep code in fenced blocks. New accounts unlock links and more as they participate.</p>
-        <a class="btn btn-ghost sm" href="/community/guidelines/">Read the guidelines</a>
+        <h4 style="margin-bottom:14px"><span class="l-en">Guidelines</span><span class="l-zh">社区规范</span></h4>
+        <p class="lead"><span class="l-en">Be kind, search first, and keep code in fenced blocks. New accounts unlock links and more as they participate.</span><span class="l-zh">友善、先搜索、代码放进围栏块。新账号随参与逐步解锁发链接等权限。</span></p>
+        <a class="btn btn-ghost sm" href="/community/guidelines/"><span class="l-en">Read the guidelines</span><span class="l-zh">阅读规范</span></a>
       </div>
     </aside>
   </div>

--- a/site/src/pages/community/new.astro
+++ b/site/src/pages/community/new.astro
@@ -3,26 +3,26 @@ import Community from "../../layouts/Community.astro";
 ---
 <Community title="New topic — Reasonix Community" description="Start a discussion on the Reasonix community forum.">
   <div class="wrap" style="padding-top:32px;max-width:820px">
-    <div class="crumb"><a href="/community/">Community</a><span class="sep">/</span><span>New topic</span></div>
-    <h1 style="font-size:28px;font-weight:600;letter-spacing:-0.02em;margin-bottom:6px">Start a discussion</h1>
+    <div class="crumb"><a href="/community/">Community</a><span class="sep">/</span><span><span class="l-en">New topic</span><span class="l-zh">发起话题</span></span></div>
+    <h1 style="font-size:28px;font-weight:600;letter-spacing:-0.02em;margin-bottom:6px"><span class="l-en">Start a discussion</span><span class="l-zh">发起讨论</span></h1>
 
     <div id="new-gate" hidden class="card cta" style="margin-top:18px">
-      <h4>Sign in to post</h4>
-      <p class="lead">You'll post with your Reasonix account. New here? Signing in creates one.</p>
-      <a class="btn btn-primary" id="gate-login" href="#">Sign in</a>
+      <h4><span class="l-en">Sign in to post</span><span class="l-zh">登录后发帖</span></h4>
+      <p class="lead"><span class="l-en">You'll post with your Reasonix account. New here? Signing in creates one.</span><span class="l-zh">用你的 Reasonix 账号发帖。还没有账号？登录即创建。</span></p>
+      <a class="btn btn-primary" id="gate-login" href="#"><span class="l-en">Sign in</span><span class="l-zh">登录</span></a>
     </div>
 
     <div id="new-form" hidden>
       <div class="msg error" id="new-msg" hidden></div>
       <div class="composer">
-        <input class="title" id="f-title" placeholder="Topic title — be specific" maxlength="160" />
-        <textarea id="f-body" placeholder="Write your post… Markdown and ``` code blocks supported."></textarea>
+        <input class="title" id="f-title" maxlength="160" data-ph-en="Topic title — be specific" data-ph-zh="话题标题 —— 尽量具体" />
+        <textarea id="f-body" data-ph-en="Write your post… Markdown and ``` code blocks supported." data-ph-zh="写下内容… 支持 Markdown 和 ``` 代码块。"></textarea>
         <div class="foot">
-          <select id="f-category"><option value="">Choose a category…</option></select>
-          <button class="btn btn-primary" id="f-submit">Post topic</button>
+          <select id="f-category"><option value="" data-l-en="Choose a category…" data-l-zh="选择分区…">Choose a category…</option></select>
+          <button class="btn btn-primary" id="f-submit"><span class="l-en">Post topic</span><span class="l-zh">发布话题</span></button>
         </div>
       </div>
-      <p class="lead" style="margin-top:14px">Please search before posting, keep it on-topic, and format code in fenced blocks. New accounts can't post links until they've participated a little.</p>
+      <p class="lead" style="margin-top:14px"><span class="l-en">Please search before posting, keep it on-topic, and format code in fenced blocks. New accounts can't post links until they've participated a little.</span><span class="l-zh">发帖前请先搜索、保持切题、代码放进围栏块。新账号需参与一段时间后才能发链接。</span></p>
     </div>
   </div>
 </Community>

--- a/site/src/pages/community/topic.astro
+++ b/site/src/pages/community/topic.astro
@@ -4,9 +4,9 @@ import Community from "../../layouts/Community.astro";
 <Community title="Discussion — Reasonix Community" description="A discussion on the Reasonix community forum.">
   <div class="wrap" style="padding-top:28px">
     <div class="crumb">
-      <a href="/community/">Community</a><span class="sep">/</span>
+      <a href="/community/"><span class="l-en">Community</span><span class="l-zh">社区</span></a><span class="sep">/</span>
       <span id="crumb-cat">…</span><span class="sep">/</span>
-      <span id="crumb-title">Loading…</span>
+      <span id="crumb-title"><span class="l-en">Loading…</span><span class="l-zh">加载中…</span></span>
     </div>
     <div class="thread-head">
       <h1 id="t-title">
@@ -28,13 +28,13 @@ import Community from "../../layouts/Community.astro";
 
     <aside class="side">
       <div class="side-card">
-        <h4>Participants</h4>
+        <h4><span class="l-en">Participants</span><span class="l-zh">参与者</span></h4>
         <div class="parti" id="parti"></div>
       </div>
       <div class="side-card">
-        <h4>Actions</h4>
+        <h4><span class="l-en">Actions</span><span class="l-zh">操作</span></h4>
         <div style="display:flex;flex-direction:column;gap:10px">
-          <a class="link-act" href="/community/">← Back to discussions</a>
+          <a class="link-act" href="/community/"><span class="l-en">← Back to discussions</span><span class="l-zh">← 返回讨论区</span></a>
         </div>
       </div>
     </aside>

--- a/site/src/scripts/community.js
+++ b/site/src/scripts/community.js
@@ -1,10 +1,36 @@
 // Reasonix Community client. Renders the forum from the forum.reasonix.io API and
 // gates posting on the shared id.reasonix.io session (cookie sent cross-subdomain).
+// Bilingual like the rest of the site: static labels via .l-en/.l-zh spans that the
+// shared `reasonix-lang` choice toggles; plain-text strings pick the current lang.
 const FORUM = (import.meta.env.PUBLIC_FORUM_API || "https://forum.reasonix.io").replace(/\/$/, "");
 const ACCOUNTS = (import.meta.env.PUBLIC_ACCOUNTS_API || "https://id.reasonix.io").replace(/\/$/, "");
 
 const el = (id) => document.getElementById(id);
 const qp = new URLSearchParams(location.search);
+
+let lang = "en";
+const L = (en, zh) => `<span class="l-en">${en}</span><span class="l-zh">${zh}</span>`;
+const t = (en, zh) => (lang === "zh" ? zh : en);
+
+function applyLangText() {
+  const attr = lang === "zh" ? "zh" : "en";
+  document.querySelectorAll("[data-ph-en]").forEach((n) => { n.placeholder = n.getAttribute(`data-ph-${attr}`); });
+  document.querySelectorAll("[data-l-en]").forEach((n) => { n.textContent = n.getAttribute(`data-l-${attr}`); });
+}
+function setLang(l) {
+  lang = l;
+  document.body.dataset.lang = l;
+  document.documentElement.lang = l === "zh" ? "zh-CN" : "en";
+  document.querySelectorAll(".lang-switch button").forEach((b) => b.classList.toggle("active", b.dataset.lang === l));
+  try { localStorage.setItem("reasonix-lang", l); } catch {}
+  applyLangText();
+}
+function initLang() {
+  let saved = "";
+  try { saved = localStorage.getItem("reasonix-lang") || ""; } catch {}
+  setLang(saved || ((navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en"));
+  document.querySelectorAll(".lang-switch button").forEach((b) => b.addEventListener("click", () => setLang(b.dataset.lang)));
+}
 
 async function api(base, path, opts = {}) {
   const res = await fetch(base + path, {
@@ -25,25 +51,62 @@ async function api(base, path, opts = {}) {
 }
 const forum = (p, o) => api(FORUM, p, o);
 
+// Anti-spam / gate errors are localized by code; unknown codes fall back to the
+// server message.
+const ERR = {
+  email_unverified: ["Confirm your email address before posting.", "发帖前请先验证你的邮箱。"],
+  links_restricted: ["New members can't post links yet — participate a little to unlock.", "新成员暂时不能发链接——参与一段时间后解锁。"],
+  insufficient_trust: ["You don't have access to post in this category yet.", "你还没有在此分区发帖的权限。"],
+  silenced: ["Your account is temporarily restricted from posting.", "你的账号暂时被限制发帖。"],
+  rate_limited: ["You're posting too fast — take a short break.", "发帖太快了——稍微歇一会儿。"],
+  daily_limit: ["You've hit today's posting limit for your trust level.", "你已达到当前信任等级的每日发帖上限。"],
+  closed: ["This topic is closed to new replies.", "该话题已关闭，不能再回复。"],
+  unauthorized: ["Sign in to continue.", "请先登录。"],
+};
+const errText = (err) => (ERR[err.code] ? t(ERR[err.code][0], ERR[err.code][1]) : err.message);
+
+const CATS = {
+  announcements: ["Announcements", "公告"],
+  help: ["Help & Support", "帮助与支持"],
+  skills: ["Skills & Plugins", "技能与插件"],
+  show: ["Show & Tell", "作品展示"],
+  feedback: ["Feedback & Ideas", "反馈与建议"],
+};
+const CATDESC = {
+  announcements: ["Releases, roadmap, and community news.", "版本发布、路线图与社区动态。"],
+  help: ["Stuck on setup, config, or cache behavior? Ask here.", "安装、配置或缓存问题？在这里提问。"],
+  skills: ["Share, request, and review community skills and MCP servers.", "分享、求助、评审社区技能与 MCP 服务。"],
+  show: ["Built something with Reasonix? Show the community.", "用 Reasonix 做了东西？来给社区看看。"],
+  feedback: ["Feature requests and product feedback.", "功能建议与产品反馈。"],
+};
+const catName = (slug, apiName) => (CATS[slug] ? L(CATS[slug][0], CATS[slug][1]) : esc(apiName));
+const catText = (slug, apiName) => (CATS[slug] ? t(CATS[slug][0], CATS[slug][1]) : apiName);
+const ROLES = { admin: ["admin", "管理员"], moderator: ["moderator", "版主"] };
+
 function esc(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
-const AV = ["a", "b", "c", "d", "e"];
+const AV_GRAD = [
+  "var(--accent),var(--violet)",
+  "var(--ok),oklch(0.62 0.15 200)",
+  "var(--warm),var(--rose)",
+  "var(--violet),var(--rose)",
+  "oklch(0.6 0.15 200),var(--accent)",
+];
 function avatar(handle, size = "") {
   const h = handle || "?";
   let n = 0;
-  for (const ch of h) n = (n + ch.charCodeAt(0)) % AV.length;
+  for (const ch of h) n = (n + ch.charCodeAt(0)) % AV_GRAD.length;
   const initials = h.replace(/[^a-zA-Z0-9]/g, "").slice(0, 2).toUpperCase() || "?";
-  return `<span class="av ${size}" style="background:linear-gradient(140deg,var(--accent),var(--violet))" data-c="${AV[n]}">${esc(initials)}</span>`;
+  return `<span class="av ${size}" style="background:linear-gradient(140deg,${AV_GRAD[n]})">${esc(initials)}</span>`;
 }
 function ago(iso) {
   if (!iso) return "";
   const s = Math.max(1, (Date.now() - new Date(iso).getTime()) / 1000);
-  const u = [[86400, "d"], [3600, "h"], [60, "m"]];
-  for (const [sec, l] of u) if (s >= sec) return Math.floor(s / sec) + l + " ago";
-  return "just now";
+  const u = [[86400, "d", "天"], [3600, "h", "小时"], [60, "m", "分钟"]];
+  for (const [sec, en, zh] of u) if (s >= sec) { const v = Math.floor(s / sec); return L(`${v}${en} ago`, `${v}${zh}前`); }
+  return L("just now", "刚刚");
 }
-// Minimal, safe markdown: escape first, then fences, inline code, paragraphs.
 function md(body) {
   const parts = esc(body).split(/```/);
   let out = "";
@@ -65,12 +128,12 @@ async function loadAccount() {
   if (slot) {
     slot.innerHTML = account
       ? `<a href="/account/" title="${esc(account.email)}">${avatar(account.handle)}</a>`
-      : `<a class="btn btn-ghost sm" href="${loginUrl()}">Sign in</a>`;
+      : `<a class="btn btn-ghost sm" href="${loginUrl()}">${L("Sign in", "登录")}</a>`;
   }
 }
 
 /* ── home ─────────────────────────────────────────── */
-async function renderHome() {
+function renderHome() {
   const catBox = el("cat-list");
   const topicBox = el("topic-list");
   const category = qp.get("category") || "";
@@ -82,10 +145,10 @@ async function renderHome() {
     catBox.innerHTML = cats.map((c) => `
       <a class="cat" href="/community/?category=${esc(c.slug)}">
         <span class="ico">${CAT_ICONS[c.slug] || "💬"}</span>
-        <div><h3>${esc(c.name)}</h3><p>${esc(c.description)}</p>
-        <div class="meta">${c.topicCount || 0} topics${c.lastActivity ? " · " + ago(c.lastActivity) : ""}</div></div>
+        <div><h3>${catName(c.slug, c.name)}</h3><p>${CATDESC[c.slug] ? L(CATDESC[c.slug][0], CATDESC[c.slug][1]) : esc(c.description)}</p>
+        <div class="meta">${c.topicCount || 0} ${L("topics", "话题")}${c.lastActivity ? " · " + ago(c.lastActivity) : ""}</div></div>
       </a>`).join("");
-  }).catch(() => { catBox.innerHTML = `<div class="empty">Couldn't load categories.</div>`; });
+  }).catch(() => { catBox.innerHTML = `<div class="empty">${L("Couldn't load categories.", "无法加载分区。")}</div>`; });
 
   const loadTopics = (sort) => {
     topicBox.innerHTML = `<div class="skeleton"><div class="bar"></div><div class="bar short"></div></div>`.repeat(3);
@@ -93,22 +156,22 @@ async function renderHome() {
     if (category) q.set("category", category);
     if (sort) q.set("sort", sort);
     forum("/topics?" + q).then((d) => {
-      if (!d.topics.length) { topicBox.innerHTML = `<div class="empty">No topics yet — <a class="tag" href="/community/new/">start the first one</a>.</div>`; return; }
-      topicBox.innerHTML = d.topics.map((t) => `
+      if (!d.topics.length) { topicBox.innerHTML = `<div class="empty">${L("No topics yet —", "还没有话题 ——")} <a class="tag" href="/community/new/">${L("start the first one", "来发第一个")}</a>.</div>`; return; }
+      topicBox.innerHTML = d.topics.map((tp) => `
         <div class="topic">
-          ${avatar(t.author.split("@")[0])}
+          ${avatar(tp.author.split("@")[0])}
           <div class="main">
             <div class="title">
-              ${t.pinned ? '<span class="badge pinned">📌 Pinned</span>' : ""}
-              ${t.status === "solved" ? '<span class="badge solved">✓ Solved</span>' : ""}
-              <a href="/community/topic/?id=${t.id}">${esc(t.title)}</a>
+              ${tp.pinned ? `<span class="badge pinned">📌 ${L("Pinned", "置顶")}</span>` : ""}
+              ${tp.status === "solved" ? `<span class="badge solved">✓ ${L("Solved", "已解决")}</span>` : ""}
+              <a href="/community/topic/?id=${tp.id}">${esc(tp.title)}</a>
             </div>
-            <div class="sub"><span class="cat-tag">${esc(t.categoryName)}</span> <span class="who">${esc(t.author.split("@")[0])}</span> · ${ago(t.createdAt)}</div>
+            <div class="sub"><span class="cat-tag">${catName(tp.category, tp.categoryName)}</span> <span class="who">${esc(tp.author.split("@")[0])}</span> · ${ago(tp.createdAt)}</div>
           </div>
-          <div class="stat"><div class="n">${t.replyCount}</div><div class="l">replies</div></div>
-          <div class="last">${ago(t.lastPostAt)}</div>
+          <div class="stat"><div class="n">${tp.replyCount}</div><div class="l">${L("replies", "回复")}</div></div>
+          <div class="last">${ago(tp.lastPostAt)}</div>
         </div>`).join("");
-    }).catch(() => { topicBox.innerHTML = `<div class="empty">Couldn't load discussions.</div>`; });
+    }).catch(() => { topicBox.innerHTML = `<div class="empty">${L("Couldn't load discussions.", "无法加载讨论。")}</div>`; });
   };
   loadTopics("latest");
 
@@ -121,41 +184,42 @@ async function renderHome() {
 }
 
 /* ── thread ───────────────────────────────────────── */
+let firstPostId = 0;
 function postHtml(p, topic) {
   const answer = topic.acceptedPostId && topic.acceptedPostId === p.id;
   const cls = answer ? "post answer" : p.id === firstPostId ? "post op" : "post";
-  const role = p.role && p.role !== "member" ? `<span class="badge role ${esc(p.role)}">${esc(p.role)}</span>` : "";
+  const roleWord = ROLES[p.role] ? L(ROLES[p.role][0], ROLES[p.role][1]) : "";
+  const role = roleWord ? `<span class="badge role ${esc(p.role)}">${roleWord}</span>` : "";
   return `<article class="${cls}">
     ${avatar(p.handle || p.author.split("@")[0], "lg")}
     <div>
-      ${answer ? '<div class="answer-flag">✓ Accepted answer</div>' : ""}
+      ${answer ? `<div class="answer-flag">✓ ${L("Accepted answer", "已采纳回答")}</div>` : ""}
       <div class="who"><span class="name">${esc(p.handle || p.author.split("@")[0])}</span>${role}<span class="when">${ago(p.createdAt)}</span></div>
       <div class="body">${md(p.body)}</div>
       <div class="actions">
         <button class="react" data-like="${p.id}">👍 <span>${p.likeCount || 0}</span></button>
-        <button class="link-act" data-flag="${p.id}">Report</button>
+        <button class="link-act" data-flag="${p.id}">${L("Report", "举报")}</button>
       </div>
     </div>
   </article>`;
 }
-let firstPostId = 0;
 
 async function renderThread() {
   const id = Number(qp.get("id"));
   if (!id) { location.href = "/community/"; return; }
   let data;
   try { data = await forum(`/topics/${id}`); }
-  catch { el("posts").innerHTML = `<div class="empty">That discussion doesn't exist or was removed.</div>`; return; }
+  catch { el("posts").innerHTML = `<div class="empty">${L("That discussion doesn't exist or was removed.", "该讨论不存在或已被移除。")}</div>`; return; }
   const { topic, posts } = data;
   firstPostId = posts[0]?.id || 0;
 
-  document.title = `${topic.title} — Reasonix Community`;
-  el("crumb-cat").textContent = topic.category;
+  document.title = `${topic.title} — ${t("Reasonix Community", "Reasonix 社区")}`;
+  el("crumb-cat").textContent = catText(topic.category, topic.category);
   el("crumb-title").textContent = topic.title;
   el("t-title").textContent = topic.title;
   el("t-meta").innerHTML =
-    `${topic.status === "solved" ? '<span class="badge solved">✓ Solved</span>' : ""}
-     <span>${topic.replyCount} replies · ${topic.viewCount} views · started ${ago(topic.createdAt)}</span>`;
+    `${topic.status === "solved" ? `<span class="badge solved">✓ ${L("Solved", "已解决")}</span>` : ""}
+     <span>${topic.replyCount} ${L("replies", "回复")} · ${topic.viewCount} ${L("views", "浏览")} · ${L("started", "发起于")} ${ago(topic.createdAt)}</span>`;
   el("posts").innerHTML = posts.map((p) => postHtml(p, topic)).join("");
 
   const seen = new Set();
@@ -164,23 +228,24 @@ async function renderThread() {
   el("posts").addEventListener("click", async (e) => {
     const flag = e.target.closest("[data-flag]");
     if (flag && account) {
-      if (!confirm("Report this post as spam or abuse?")) return;
-      try { await forum(`/posts/${flag.dataset.flag}/flags`, { method: "POST", body: { reason: "spam" } }); flag.textContent = "Reported ✓"; flag.disabled = true; }
-      catch (err) { alert(err.message); }
+      if (!confirm(t("Report this post as spam or abuse?", "举报该帖为垃圾/滥用内容？"))) return;
+      try { await forum(`/posts/${flag.dataset.flag}/flags`, { method: "POST", body: { reason: "spam" } }); flag.innerHTML = L("Reported ✓", "已举报 ✓"); flag.disabled = true; }
+      catch (err) { alert(errText(err)); }
     } else if (flag) { location.href = loginUrl(); }
   });
 
   const zone = el("reply-zone");
   if (!account) {
-    zone.innerHTML = `<div class="composer"><div class="gate"><p>Sign in with your Reasonix account to reply.</p><a class="btn btn-primary" href="${loginUrl()}">Sign in</a></div></div>`;
+    zone.innerHTML = `<div class="composer"><div class="gate"><p>${L("Sign in with your Reasonix account to reply.", "用你的 Reasonix 账号登录后回复。")}</p><a class="btn btn-primary" href="${loginUrl()}">${L("Sign in", "登录")}</a></div></div>`;
     return;
   }
   zone.innerHTML = `
     <div class="msg error" id="reply-msg" hidden></div>
     <div class="composer">
-      <textarea id="reply-body" placeholder="Write a reply… Markdown and \`\`\` code blocks supported."></textarea>
-      <div class="foot"><span class="hint">Signed in as <b>${esc(account.handle)}</b></span><button class="btn btn-primary" id="reply-submit">Post reply</button></div>
+      <textarea id="reply-body" data-ph-en="Write a reply… Markdown and \`\`\` code blocks supported." data-ph-zh="写下回复… 支持 Markdown 和 \`\`\` 代码块。"></textarea>
+      <div class="foot"><span class="hint">${L("Signed in as", "已登录")} <b>${esc(account.handle)}</b></span><button class="btn btn-primary" id="reply-submit">${L("Post reply", "发布回复")}</button></div>
     </div>`;
+  applyLangText();
   el("reply-submit").addEventListener("click", async () => {
     const body = el("reply-body").value.trim();
     const msg = el("reply-msg");
@@ -191,7 +256,7 @@ async function renderThread() {
       await forum(`/topics/${id}/posts`, { method: "POST", body: { body } });
       location.reload();
     } catch (err) {
-      msg.textContent = err.message; msg.hidden = false;
+      msg.textContent = errText(err); msg.hidden = false;
       el("reply-submit").disabled = false;
     }
   });
@@ -210,12 +275,16 @@ async function renderNew() {
     const { categories } = await forum("/categories");
     for (const c of categories) {
       const o = document.createElement("option");
-      o.value = c.id; o.textContent = c.name;
+      o.value = c.id;
+      o.setAttribute("data-l-en", CATS[c.slug] ? CATS[c.slug][0] : c.name);
+      o.setAttribute("data-l-zh", CATS[c.slug] ? CATS[c.slug][1] : c.name);
+      o.textContent = catText(c.slug, c.name);
       sel.appendChild(o);
     }
     const pre = qp.get("category");
     if (pre) { const m = categories.find((c) => c.slug === pre); if (m) sel.value = m.id; }
   } catch {}
+  applyLangText();
 
   el("f-submit").addEventListener("click", async () => {
     const msg = el("new-msg");
@@ -223,20 +292,21 @@ async function renderNew() {
     const categoryId = Number(sel.value);
     const title = el("f-title").value.trim();
     const body = el("f-body").value.trim();
-    if (!categoryId) { msg.textContent = "Choose a category."; msg.hidden = false; return; }
-    if (title.length < 6 || body.length < 10) { msg.textContent = "Add a title (6+ chars) and a bit more detail (10+ chars)."; msg.hidden = false; return; }
+    if (!categoryId) { msg.textContent = t("Choose a category.", "请选择一个分区。"); msg.hidden = false; return; }
+    if (title.length < 6 || body.length < 10) { msg.textContent = t("Add a title (6+ chars) and a bit more detail (10+ chars).", "标题至少 6 个字符，正文至少 10 个字符。"); msg.hidden = false; return; }
     el("f-submit").disabled = true;
     try {
       const { topic } = await forum("/topics", { method: "POST", body: { categoryId, title, body } });
       location.href = `/community/topic/?id=${topic.id}`;
     } catch (err) {
-      msg.textContent = err.message; msg.hidden = false;
+      msg.textContent = errText(err); msg.hidden = false;
       el("f-submit").disabled = false;
     }
   });
 }
 
 (async function () {
+  initLang();
   await loadAccount();
   if (el("topic-list")) renderHome();
   else if (el("posts")) renderThread();

--- a/site/src/styles/community.css
+++ b/site/src/styles/community.css
@@ -37,6 +37,14 @@ a { color: inherit; text-decoration: none; }
 .wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
 [hidden] { display: none !important; }
 
+/* bilingual toggle — mirrors the main site (shared reasonix-lang choice) */
+body[data-lang="en"] .l-zh { display: none !important; }
+body[data-lang="zh"] .l-en { display: none !important; }
+.lang-switch { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
+.lang-switch button { font-family: var(--font-sans); font-size: 12.5px; font-weight: 500; color: var(--ink-2); background: transparent; border: none; cursor: pointer; padding: 6px 12px; border-radius: 999px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
+.lang-switch button:hover { color: var(--ink); }
+.lang-switch button.active { background: #fff; color: var(--accent); box-shadow: var(--shadow-1); }
+
 .nav { position: sticky; top: 0; z-index: 50; background: oklch(1 0 0 / 0.86); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); border-bottom: 1px solid var(--line); }
 .nav-inner { display: flex; align-items: center; gap: 20px; height: 64px; max-width: 1180px; margin: 0 auto; padding: 0 32px; }
 .brand { display: flex; align-items: center; gap: 10px; font-weight: 600; font-size: 17px; letter-spacing: -0.01em; }


### PR DESCRIPTION
The /community pages were English-only while the rest of the site is bilingual. Adds the same EN/中文 toggle:

- Lang switch in the community nav; `.l-en`/`.l-zh` spans for all static chrome (matching the main site's mechanism + shared `reasonix-lang` localStorage key, so the choice carries over).
- `community.js` renders dynamic labels (category names, relative times, counts, badges, empty/error states) as toggled bilingual spans, and localizes the anti-spam/gate errors by code.
- `astro build` clean (13 pages); built HTML + JS bundle carry the Chinese strings.