### PR TITLE
fix(desktop): clean memory compiler titles

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1891,7 +1891,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, 
 	return SessionMeta{
 		Path:           s.Path,
 		Preview:        s.Preview,
-		Title:          title,
+		Title:          cleanStoredSessionTitle(title),
 		Turns:          s.Turns,
 		CreatedAt:      s.CreatedAt.UnixMilli(),
 		LastActivityAt: s.LastActivityAt.UnixMilli(),
@@ -1902,7 +1902,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, 
 		Scope:          s.Scope,
 		WorkspaceRoot:  s.WorkspaceRoot,
 		TopicID:        s.TopicID,
-		TopicTitle:     s.TopicTitle,
+		TopicTitle:     cleanStoredTopicTitle(s.TopicTitle),
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -58,6 +58,9 @@ func loadSessionTitles(dir string) map[string]string {
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	for key, title := range m {
+		m[key] = cleanStoredSessionTitle(title)
+	}
 	return m
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2495,7 +2495,7 @@ func sessionBindingInDir(dir, sessionPath string) (sessionBinding, bool) {
 	}
 	if hasMeta {
 		binding.topicID = strings.TrimSpace(meta.TopicID)
-		binding.topicTitle = strings.TrimSpace(meta.TopicTitle)
+		binding.topicTitle = cleanStoredTopicTitle(meta.TopicTitle)
 	}
 	if binding.scope == "project" {
 		binding.workspaceRoot = normalizeProjectRoot(binding.workspaceRoot)
@@ -2520,7 +2520,7 @@ func sessionBindingFromMeta(path string, meta agent.BranchMeta) (sessionBinding,
 		scope:         scope,
 		workspaceRoot: workspaceRoot,
 		topicID:       strings.TrimSpace(meta.TopicID),
-		topicTitle:    strings.TrimSpace(meta.TopicTitle),
+		topicTitle:    cleanStoredTopicTitle(meta.TopicTitle),
 		hasMeta:       true,
 		meta:          meta,
 	}, true
@@ -2719,7 +2719,9 @@ func topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath string) (stri
 	if topicID == "" || sessionPath == "" {
 		return "", "", false
 	}
-	storedTitle := strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID))
+	rawStoredTitle := strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID))
+	storedTitle := cleanStoredTopicTitle(rawStoredTitle)
+	storedTitleInternal := titleLooksInternal(rawStoredTitle) && storedTitle == ""
 	storedSource := strings.TrimSpace(loadTopicTitleSource(workspaceRoot, topicID))
 	if storedTitle != "" {
 		if storedSource == topicTitleSourceManual || storedTitle != defaultTopicTitle {
@@ -2738,10 +2740,10 @@ func topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath string) (stri
 		}
 	}
 
-	if storedSource == topicTitleSourceManual {
+	if storedSource == topicTitleSourceManual && !storedTitleInternal {
 		return "", "", false
 	}
-	if storedSource == "" || storedSource == topicTitleSourceAuto {
+	if storedSource == "" || storedSource == topicTitleSourceAuto || storedTitleInternal {
 		if title := topicTitleFromSession(sessionPath); title != "" {
 			return title, topicTitleSourceAuto, true
 		}
@@ -2765,14 +2767,58 @@ func topicTitleFromSession(path string) string {
 			return ""
 		}
 		if msg.Role == "user" {
-			content := control.StripComposePrefixes(agent.HandoffTask(msg.Content))
+			content := agent.UserPreviewText(msg.Content)
 			content = control.StripReferencedContextPrefix(content)
 			return topicTitleFromText(content)
 		}
 	}
 }
 
+func memoryCompilerTitleText(text string) (string, bool) {
+	if !titleLooksInternal(text) {
+		return "", false
+	}
+	cleaned := strings.TrimSpace(agent.UserPreviewText(text))
+	if cleaned == "" || titleLooksInternal(cleaned) {
+		return "", true
+	}
+	return cleaned, true
+}
+
+func titleLooksInternal(text string) bool {
+	return strings.Contains(text, "<memory-compiler") ||
+		strings.Contains(text, `"type":"memory_v5_execution_contract"`) ||
+		strings.Contains(text, `"type": "memory_v5_execution_contract"`)
+}
+
+func cleanStoredSessionTitle(text string) string {
+	if cleaned, ok := memoryCompilerTitleText(text); ok {
+		return cleaned
+	}
+	return strings.TrimSpace(text)
+}
+
+func cleanStoredTopicTitle(text string) string {
+	if cleaned, ok := memoryCompilerTitleText(text); ok {
+		return topicTitleFromText(cleaned)
+	}
+	return strings.TrimSpace(text)
+}
+
+func topicTreeTitle(title, preview string) string {
+	if title := cleanStoredTopicTitle(title); title != "" {
+		return title
+	}
+	if title := topicTitleFromText(preview); title != "" {
+		return title
+	}
+	return defaultTopicTitle
+}
+
 func topicTitleFromText(text string) string {
+	if cleaned, ok := memoryCompilerTitleText(text); ok {
+		text = cleaned
+	}
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return ""
@@ -3782,7 +3828,7 @@ func loadTopicCreatedAt(workspaceRoot, topicID string) int64 {
 
 func topicTitleForTab(scope, workspaceRoot, topicID string) string {
 	titleRoot := topicTitleRoot(scope, workspaceRoot)
-	if title := strings.TrimSpace(loadTopicTitle(titleRoot, topicID)); title != "" {
+	if title := cleanStoredTopicTitle(loadTopicTitle(titleRoot, topicID)); title != "" {
 		return title
 	}
 	if scope == "global" {
@@ -4878,6 +4924,7 @@ func (a *App) topicTrashTargets(topicID string) ([]topicTrashTarget, error) {
 type topicSummary struct {
 	turns          int
 	lastActivityAt int64
+	preview        string
 }
 
 var listProjectTreeMu sync.Mutex
@@ -5065,8 +5112,8 @@ func (a *App) ListProjectTree() []ProjectNode {
 		globalTopicIDs := pinnedTopicIDs(orderedTopicIDs(f.GlobalTopics, globalTitleMap), f.GlobalPinnedTopics)
 		children := make([]ProjectNode, 0, len(globalTopicIDs))
 		for _, id := range globalTopicIDs {
-			title := globalTitleMap[id]
 			summary := topicSummaries[topicSummaryKey("global", "", id)]
+			title := topicTreeTitle(globalTitleMap[id], summary.preview)
 			open, running, status := topicRuntimeStatus(topicSummaryKey("global", "", id))
 			pinned := containsDesktopString(f.GlobalPinnedTopics, id)
 			children = append(children, ProjectNode{
@@ -5136,11 +5183,8 @@ func (a *App) ListProjectTree() []ProjectNode {
 
 		children := make([]ProjectNode, 0, len(topicIDs))
 		for _, tid := range topicIDs {
-			topicTitle := strings.TrimSpace(titleMap[tid])
-			if topicTitle == "" {
-				topicTitle = defaultTopicTitle
-			}
 			summary := topicSummaries[topicSummaryKey("project", p.Root, tid)]
+			topicTitle := topicTreeTitle(titleMap[tid], summary.preview)
 			open, running, status := topicRuntimeStatus(topicSummaryKey("project", p.Root, tid))
 			pinned := containsDesktopString(p.PinnedTopics, tid)
 			children = append(children, ProjectNode{
@@ -5182,7 +5226,7 @@ func projectSessionNodeKey(scope, sessionPath string) string {
 }
 
 func runtimeSessionTreeLabel(tab *WorkspaceTab, info agent.SessionInfo, title string) string {
-	if title = strings.TrimSpace(title); title != "" {
+	if title = cleanStoredSessionTitle(title); title != "" {
 		return title
 	}
 	if preview := topicTitleFromText(info.Preview); preview != "" {
@@ -5969,6 +6013,9 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		lastActivityAt := info.LastActivityAt.UnixMilli()
 		if lastActivityAt > summary.lastActivityAt {
 			summary.lastActivityAt = lastActivityAt
+			summary.preview = info.Preview
+		} else if summary.preview == "" {
+			summary.preview = info.Preview
 		}
 		topicSummaries[key] = summary
 	}

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1544,6 +1544,87 @@ func TestAutoTitleTopicFromFirstUserMessage(t *testing.T) {
 	}
 }
 
+func TestAutoTitleTopicUnwrapsMemoryCompilerContract(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topic, err := NewApp().CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	prompt := historyMemoryCompilerContract(t, "测试用例设计")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":`+strconv.Quote(prompt)+`}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	if !updated {
+		t.Fatal("auto title should update")
+	}
+	if title != "测试用例设计" {
+		t.Fatalf("generated title = %q", title)
+	}
+}
+
+func TestProjectTreeFallsBackFromInternalTopicTitleToSessionPreview(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_memory_title"
+	rawTitle := "<memory-compiler-e"
+	if err := setTopicTitleWithSource(projectRoot, topicID, rawTitle, topicTitleSourceManual); err != nil {
+		t.Fatalf("set stale topic title: %v", err)
+	}
+	if err := prependTopicInProjectsFile(projectRoot, topicID, true); err != nil {
+		t.Fatalf("index topic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeTopicSessionWithPrompt(t, dir, "memory-title.jsonl", topicID, rawTitle, projectRoot, "测试用例设计", time.Now())
+
+	title, source, ok := topicTitleFallbackForOpen(projectRoot, topicID, sessionPath)
+	if !ok || title != "测试用例设计" || source != topicTitleSourceAuto {
+		t.Fatalf("fallback title=(%q,%q,%v), want 测试用例设计 auto true", title, source, ok)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || len(nodes[0].Children) != 1 {
+		t.Fatalf("project tree = %#v, want one project with one topic", nodes)
+	}
+	if got := nodes[0].Children[0].Label; got != "测试用例设计" {
+		t.Fatalf("tree title = %q, want 测试用例设计", got)
+	}
+}
+
+func TestSessionMetaCleansMemoryCompilerTitles(t *testing.T) {
+	rawTitle := historyMemoryCompilerContract(t, "测试用例设计")
+	now := time.Now()
+	meta := sessionMetaFromInfo(agent.SessionInfo{
+		Path:           filepath.Join(t.TempDir(), "memory-title.jsonl"),
+		Preview:        "测试用例设计",
+		Turns:          1,
+		CreatedAt:      now,
+		LastActivityAt: now,
+		TopicTitle:     rawTitle,
+	}, rawTitle, false, false, 0)
+
+	if meta.Title != "测试用例设计" {
+		t.Fatalf("session title = %q, want 测试用例设计", meta.Title)
+	}
+	if meta.TopicTitle != "测试用例设计" {
+		t.Fatalf("topic title = %q, want 测试用例设计", meta.TopicTitle)
+	}
+
+	plainTitle := "explain memory_v5_execution_contract"
+	plain := sessionMetaFromInfo(agent.SessionInfo{TopicTitle: plainTitle}, plainTitle, false, false, 0)
+	if plain.Title != plainTitle || plain.TopicTitle != plainTitle {
+		t.Fatalf("plain title cleaned to (%q,%q), want %q", plain.Title, plain.TopicTitle, plainTitle)
+	}
+}
+
 func TestAutoTitleTopicStripsReasoningLanguagePrefix(t *testing.T) {
 	isolateDesktopUserDirs(t)
 


### PR DESCRIPTION
## Summary

- Clean persisted desktop session/topic titles that contain Memory v5 execution contracts before showing them in history, tabs, and the project tree.
- Fall back to the topic's latest session preview when an older persisted title only contains an unrecoverable internal fragment.
- Cover auto-title, project tree fallback, and SessionMeta title cleaning with regression tests.

## Root cause

- Memory compiler execution contracts can survive in older persisted desktop title sidecars/metadata.
- Desktop UI preferred those title fields over the already-clean session preview, so upgraded users could still see `<memory-compiler...` as a title.

## Implementation

- Reuse existing `agent.UserPreviewText` to unwrap complete memory compiler titles.
- Treat unrecoverable internal title fragments as empty and use the existing preview-derived topic-title fallback.
- Preserve normal manual titles and the manual default-title behavior.

## Validation

- `cd desktop && go test .`
- `git diff --check`

## Compatibility

- No public API, schema, config, permission, dependency, or file format changes.
- Display-only cleanup for desktop persisted title metadata.

## Risk / rollback

- Low risk; reverting this commit restores the previous title display behavior.

Closes #5666

Cache-impact: none, desktop title display/metadata cleanup only; no provider-visible prompt, tool schema, or request serialization changes.
Cache-guard: `cd desktop && go test .`
System-prompt-review: N/A