### PR TITLE
fix(cli): repaint wide-character input on Windows

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -1428,6 +1429,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	beforeInput := m.input.Value()
 	var ic tea.Cmd
 	m.input, ic = m.input.Update(msg)
 	cmds = append(cmds, ic)
@@ -1436,8 +1438,23 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if _, ok := msg.(tea.KeyPressMsg); ok {
 		m.updateCompletion()
 	}
+	if shouldClearWideInputChange(beforeInput, m.input.Value()) {
+		cmds = append(cmds, tea.ClearScreen)
+	}
 
 	return m, finalize(m, cmds)
+}
+
+var clearWideInputChanges = runtime.GOOS == "windows"
+
+func shouldClearWideInputChange(before, after string) bool {
+	return clearWideInputChanges &&
+		before != after &&
+		(hasWideInputCells(before) || hasWideInputCells(after))
+}
+
+func hasWideInputCells(s string) bool {
+	return s != "" && visibleWidth(s) != utf8.RuneCountInString(s)
 }
 
 // finalize drains the committed-line queue and batches the turn's commands. In

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1914,6 +1914,34 @@ func TestSessionSwitchSuppressesOneClearScreen(t *testing.T) {
 	}
 }
 
+func TestWideInputChangeRequestsClearScreen(t *testing.T) {
+	prev := clearWideInputChanges
+	clearWideInputChanges = true
+	defer func() { clearWideInputChanges = prev }()
+
+	m := newTestChatTUI()
+	m.input.SetValue("天安a")
+	m.input.SetCursorColumn(len([]rune("天安a")))
+
+	next, cmd := m.update(tea.KeyPressMsg{Code: '门', Text: "门"})
+	got := next.(chatTUI)
+	if got.input.Value() != "天安a门" {
+		t.Fatalf("wide-char insert should preserve the textarea value, got %q", got.input.Value())
+	}
+	if cmd == nil {
+		t.Fatal("wide-char input changes should request a full redraw")
+	}
+	if shouldClearWideInputChange("ascii", "ascii!") {
+		t.Fatal("single-width ASCII input should not request the wide-input redraw")
+	}
+	if !shouldClearWideInputChange("门", "") {
+		t.Fatal("removing the last wide character should request a full redraw")
+	}
+	if !shouldClearWideInputChange("a门", "a") {
+		t.Fatal("removing a wide character from mixed input should request a full redraw")
+	}
+}
+
 func TestReplayActiveBranchClearsPlanModeAndMarksSessionSwitch(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{})


### PR DESCRIPTION
## Summary

- Fixes #5717 by requesting a full TUI redraw when Windows composer edits involve wide characters, clearing stale cells left by mixed-width IME input.
- Keeps the change limited to the existing CLI textarea update path and adds focused regression coverage for inserting/removing CJK characters.
- Risk: Windows wide-character input may redraw a little more aggressively; no public API, config, schema, or provider-visible prompt behavior changes.

## Verification

- `go test ./internal/cli -run 'Test(WideInputChangeRequestsClearScreen|SessionSwitchSuppressesOneClearScreen|ApplyTextareaThemeHonorsCursorShape)' -count=1`
- `go test ./internal/cli -count=1`
- `git diff --check`
- Manual Windows 11 + Microsoft Pinyin verification was not run locally.

## Cache impact

Cache-impact: none — CLI/TUI rendering-only change; no provider-visible prompt, tool schema, or cache-sensitive request serialization changes.
Cache-guard: `go test ./internal/cli -count=1`
System-prompt-review: N/A