### PR TITLE
fix(desktop): hide collapsed creation tool bodies

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -160,6 +160,16 @@ ok(
 );
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
+eq(
+  finalDeclaration(".app--creation .tool:not(.tool--open) > .tool__body", "height"),
+  "0 !important",
+  "collapsed creation tool bodies keep mounted content clipped",
+);
+eq(
+  finalDeclaration(".app--creation .tool:not(.tool--open) > .tool__body", "visibility"),
+  "hidden",
+  "collapsed creation tool bodies do not paint hidden tool text",
+);
 ok(
   /@container\s*\(max-width:\s*760px\)[\s\S]*?\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*0 1 auto[\s\S]*?width\s*:\s*fit-content[\s\S]*?max-width\s*:\s*min\(240px,\s*42vw\)[\s\S]*?\.composer-meta--has-intent-chip\s+\.composer-meta__control--model\s*\{[\s\S]*?flex\s*:\s*0 1 auto[\s\S]*?width\s*:\s*fit-content[\s\S]*?max-width\s*:\s*min\(220px,\s*38vw\)[\s\S]*?\.composer-meta__control--effort\s*\{[\s\S]*?display\s*:\s*none[\s\S]*?\.composer-meta__control--more\s*\{[\s\S]*?display\s*:\s*inline-flex/.test(styles),
   "composer compact controls activate at the capped theme width",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -26593,6 +26593,13 @@ body > .mermaid-diagram--fullscreen {
   padding-left: 0;
 }
 
+/* 收起的工具体仍挂载在 DOM 中；Creation 下给折叠态加硬隐藏，避免错误文本在 WebView2 中露出片段。 */
+.app--creation .tool:not(.tool--open) > .tool__body,
+:root[data-theme-style] .app--creation .tool:not(.tool--open) > .tool__body {
+  height: 0 !important;
+  visibility: hidden;
+}
+
 /* 限制工具头标题宽度，给右侧 meta（耗时/箭头/圆点）留出可见空间。
    Bash 等命令常超长，不限宽会把箭头和圆点挤出视野。仅 Creation 作用域。
    summary 在 Creation 下直接隐藏——它对 bash 只是"N 行"摘要，信息量低，


### PR DESCRIPTION
## Summary

- Fixes #5716 by hard-hiding collapsed Creation tool bodies so mounted args/output/error text cannot paint while the card is closed.
- Add a focused CSS contract for collapsed Creation tool bodies.

## Verification

- `pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts`
- `pnpm run check:css`
- `git diff --check`

## Cache impact

Cache-impact: none, desktop CSS-only rendering fix; no provider-visible prompt, tool schema, memory prefix, output style, or request serialization changes.
Cache-guard: `pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts`
System-prompt-review: N/A
