### PR TITLE
feat: skill/MCP registry — worker + web discovery page

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -54,6 +54,7 @@ const ld = {
       <nav class="nav-links">
         <a href="#features"><span class="l-en">Features</span><span class="l-zh">特性</span></a>
         <a href="#how"><span class="l-en">How it works</span><span class="l-zh">工作原理</span></a>
+        <a href={`${base}/skills/`}><span class="l-en">Skills</span><span class="l-zh">技能市场</span></a>
         <a href="#community"><span class="l-en">Community</span><span class="l-zh">社区</span></a>
         <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
         <a href="#start"><span class="l-en">Get started</span><span class="l-zh">快速开始</span></a>

--- a/site/src/pages/skills.astro
+++ b/site/src/pages/skills.astro
@@ -1,0 +1,433 @@
+---
+import Base from '../layouts/Base.astro';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
+const desc = "Browse, publish, and install community skills and MCP servers for Reasonix. One command to add any capability to your agent — install_source does the rest, SSRF-guarded and risk-rated.";
+---
+<Base
+  title="Reasonix — Skills & MCP registry"
+  titleEn="Reasonix — Skills & MCP registry"
+  titleZh="Reasonix — 技能与 MCP 市场"
+  description={desc}>
+
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
+      <nav class="nav-links">
+        <a href={`${base}/#features`}><span class="l-en">Features</span><span class="l-zh">特性</span></a>
+        <a href={`${base}/skills/`} class="here"><span class="l-en">Skills</span><span class="l-zh">技能市场</span></a>
+        <a href={`${base}/#community`}><span class="l-en">Community</span><span class="l-zh">社区</span></a>
+        <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
+      </nav>
+      <div class="lang-switch" role="group" aria-label="Language">
+        <button type="button" data-lang="en" class="active">EN</button>
+        <button type="button" data-lang="zh">中文</button>
+      </div>
+      <a class="btn btn-dark" id="publish-open" href="#publish"><span class="l-en">Publish</span><span class="l-zh">发布</span></a>
+    </div>
+  </header>
+
+  <main>
+  <section class="reg-head">
+    <div class="wrap">
+      <div class="sec-head split">
+        <span class="kicker"><span class="l-en">Registry</span><span class="l-zh">技能市场</span></span>
+        <h2><span class="l-en">Every skill, one <span class="em">install</span> away.</span><span class="l-zh">每个能力,一条 <span class="em">install</span> 就到手。</span></h2>
+        <p><span class="l-en">Community skills and MCP servers for your agent. The registry only stores metadata and a source pointer — installs run client-side through <code>install_source</code>, SSRF-guarded and risk-rated. Nothing executes here.</span><span class="l-zh">社区贡献的技能与 MCP 服务器。市场只存元数据与来源指针——安装在你本机经 <code>install_source</code> 执行(带 SSRF 防护与风险分级),这里不运行任何代码。</span></p>
+      </div>
+
+      <div class="reg-toolbar">
+        <div class="reg-search">
+          <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M8.5 3a5.5 5.5 0 1 0 3.4 9.8l3.6 3.7 1.4-1.4-3.7-3.6A5.5 5.5 0 0 0 8.5 3Zm0 2a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z"/></svg>
+          <input id="reg-q" type="search" autocomplete="off" placeholder="Search skills, MCP servers, tags…" aria-label="Search the registry" />
+        </div>
+        <div class="reg-tabs" data-group="kind" role="tablist">
+          <button class="active" data-kind="all" role="tab"><span class="l-en">All</span><span class="l-zh">全部</span></button>
+          <button data-kind="skill" role="tab">Skills</button>
+          <button data-kind="mcp" role="tab">MCP</button>
+        </div>
+        <div class="reg-tabs" data-group="sort" role="tablist">
+          <button class="active" data-sort="new" role="tab"><span class="l-en">New</span><span class="l-zh">最新</span></button>
+          <button data-sort="trending" role="tab"><span class="l-en">Trending</span><span class="l-zh">趋势</span></button>
+          <button data-sort="installs" role="tab"><span class="l-en">Top</span><span class="l-zh">最热</span></button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="reg-body">
+    <div class="wrap reg-cols">
+      <div class="reg-main">
+        <div id="pkg-grid" class="pkg-grid" data-state="loading" aria-live="polite">
+          <div class="pkg-skel"></div><div class="pkg-skel"></div><div class="pkg-skel"></div><div class="pkg-skel"></div>
+        </div>
+        <div id="reg-empty" class="reg-state" hidden>
+          <h3><span class="l-en">Be the first to publish.</span><span class="l-zh">来当第一个发布者。</span></h3>
+          <p><span class="l-en">No packages match yet. Ship a skill you built and it lands here for everyone.</span><span class="l-zh">还没有匹配的包。把你写的技能发上来,所有人都能一键装。</span></p>
+          <a class="btn btn-dark" href="#publish" data-publish-jump><span class="l-en">Publish a skill</span><span class="l-zh">发布一个技能</span></a>
+        </div>
+        <div id="reg-offline" class="reg-state" hidden>
+          <h3><span class="l-en">Registry is launching soon.</span><span class="l-zh">市场即将上线。</span></h3>
+          <p><span class="l-en">The registry service isn't reachable yet. Sign in to get a handle ready — your packages will be namespaced to it.</span><span class="l-zh">市场服务暂时还连不上。先登录占好你的 handle——你的包会以它作命名空间。</span></p>
+          <a class="btn btn-dark" href="https://id.reasonix.io"><span class="l-en">Sign in at id.reasonix.io</span><span class="l-zh">前往 id.reasonix.io 登录</span></a>
+        </div>
+      </div>
+
+      <aside class="reg-aside">
+        <div class="feed-card">
+          <div class="feed-head"><span class="pulse"></span><span class="l-en">Live activity</span><span class="l-zh">实时动态</span></div>
+          <ul id="feed" class="feed-list"><li class="feed-skel"></li><li class="feed-skel"></li><li class="feed-skel"></li></ul>
+          <div id="feed-empty" class="feed-empty" hidden><span class="l-en">Quiet for now — the first publish shows up here.</span><span class="l-zh">暂时安静——第一个发布会出现在这里。</span></div>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="reg-publish" id="publish" hidden>
+    <div class="wrap">
+      <div class="pub-card">
+        <div class="pub-head">
+          <div>
+            <h3><span class="l-en">Publish a package</span><span class="l-zh">发布一个包</span></h3>
+            <p><span class="l-en">Signed-in publishers only. Your package is namespaced to your handle: <code>@you/name</code>.</span><span class="l-zh">仅登录用户可发布。包会以你的 handle 命名:<code>@you/name</code>。</span></p>
+          </div>
+          <button type="button" class="pub-close" id="publish-close" aria-label="Close">✕</button>
+        </div>
+        <form id="pub-form" class="pub-form">
+          <div class="pub-row">
+            <label><span class="l-en">Kind</span><span class="l-zh">类型</span>
+              <select name="kind"><option value="skill">skill</option><option value="mcp">mcp</option></select>
+            </label>
+            <label><span class="l-en">Name</span><span class="l-zh">名称</span>
+              <input name="name" required placeholder="my-skill" pattern="[a-z0-9][a-z0-9._-]*" />
+            </label>
+            <label><span class="l-en">Version</span><span class="l-zh">版本</span>
+              <input name="version" placeholder="0.1.0" />
+            </label>
+          </div>
+          <label><span class="l-en">One-line summary</span><span class="l-zh">一句话简介</span>
+            <input name="summary" maxlength="200" placeholder="What does it do?" />
+          </label>
+          <label><span class="l-en">Source</span><span class="l-zh">来源</span>
+            <input name="source" required placeholder="https://… SKILL.md · .mcp.json · repo · package name" />
+          </label>
+          <div class="pub-row">
+            <label><span class="l-en">Repo (optional)</span><span class="l-zh">仓库(可选)</span>
+              <input name="repoUrl" placeholder="https://github.com/…" />
+            </label>
+            <label><span class="l-en">Tags (comma-separated)</span><span class="l-zh">标签(逗号分隔)</span>
+              <input name="tags" placeholder="testing, go, review" />
+            </label>
+          </div>
+          <div class="pub-actions">
+            <button type="submit" class="btn btn-dark"><span class="l-en">Publish</span><span class="l-zh">发布</span></button>
+            <span id="pub-msg" class="pub-msg" role="status"></span>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+  </main>
+
+  <footer>
+    <div class="foot-inner">
+      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
+      <span><span class="l-en">© 2026 Reasonix · MIT licensed · built to be left running.</span><span class="l-zh">© 2026 Reasonix · MIT 许可 · 为常驻运行而生。</span></span>
+      <nav class="foot-links">
+        <a href={repo}>GitHub</a>
+        <a href={`${base}/`}><span class="l-en">Home</span><span class="l-zh">首页</span></a>
+        <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
+        <a href="https://id.reasonix.io"><span class="l-en">Sign in</span><span class="l-zh">登录</span></a>
+      </nav>
+    </div>
+  </footer>
+
+  <style is:global>
+    .reg-head { padding: 128px 0 0; }
+    .reg-toolbar {
+      display: flex; flex-wrap: wrap; gap: 12px; align-items: center;
+      margin-top: 32px; padding-bottom: 4px;
+    }
+    .reg-search {
+      display: flex; align-items: center; gap: 8px; flex: 1 1 240px;
+      background: var(--bg-soft); border-radius: 999px; padding: 0 18px;
+      border: 1px solid transparent; transition: border-color .2s, background .2s;
+    }
+    .reg-search:focus-within { background: #fff; border-color: var(--line); box-shadow: var(--shadow-1); }
+    .reg-search svg { width: 18px; height: 18px; fill: var(--ink-3); flex: none; }
+    .reg-search input {
+      border: none; background: none; outline: none; width: 100%;
+      font-family: var(--font-sans); font-size: 15px; color: var(--ink); padding: 12px 0;
+    }
+    .reg-tabs { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
+    .reg-tabs button {
+      font-family: var(--font-sans); font-size: 13.5px; font-weight: 500; color: var(--ink-2);
+      background: transparent; border: none; cursor: pointer; padding: 8px 16px; border-radius: 999px;
+      transition: background .2s, color .2s, box-shadow .2s;
+    }
+    .reg-tabs button:hover { color: var(--ink); }
+    .reg-tabs button.active { background: #fff; color: var(--accent); box-shadow: var(--shadow-1); }
+
+    .reg-body { padding: 36px 0 96px; }
+    .reg-cols { display: grid; grid-template-columns: 1fr 320px; gap: 32px; align-items: start; }
+    .reg-main { min-width: 0; }
+    .pkg-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+    .pkg-grid[data-state="loading"] .pkg-skel { display: block; }
+
+    .pkg-card {
+      display: flex; flex-direction: column; gap: 12px;
+      background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+      padding: 22px; min-width: 0; transition: box-shadow .25s, border-color .25s, transform .25s;
+    }
+    .pkg-card:hover { box-shadow: var(--shadow-2); border-color: transparent; transform: translateY(-2px); }
+    .pkg-top { display: flex; align-items: center; gap: 8px; }
+    .pkg-kind { font-family: var(--font-mono); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); background: var(--accent-soft); padding: 4px 9px; border-radius: 999px; }
+    .pkg-kind.mcp { color: oklch(0.5 0.16 300); background: color-mix(in oklch, oklch(0.5 0.16 300) 9%, white); }
+    .pkg-badge { font-size: 11px; font-weight: 600; padding: 4px 9px; border-radius: 999px; }
+    .pkg-badge.verified { color: oklch(0.5 0.13 155); background: color-mix(in oklch, oklch(0.5 0.13 155) 10%, white); }
+    .pkg-badge.community { color: var(--ink-3); background: var(--bg-soft); }
+    .pkg-stars { margin-left: auto; font-size: 13px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+    .pkg-name { font-size: 17px; font-weight: 600; letter-spacing: -.01em; overflow-wrap: anywhere; }
+    .pkg-name .scope { color: var(--ink-3); font-weight: 500; }
+    .pkg-sum { font-size: 14px; line-height: 1.55; color: var(--ink-2); overflow-wrap: anywhere; }
+    .pkg-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+    .pkg-tags span { font-size: 12px; color: var(--ink-3); background: var(--bg-soft); padding: 3px 10px; border-radius: 999px; }
+    .pkg-foot { display: flex; align-items: center; gap: 12px; margin-top: 2px; }
+    .pkg-install {
+      display: inline-flex; align-items: center; gap: 10px; flex: 1; min-width: 0;
+      font-family: var(--font-mono); font-size: 12.5px; color: var(--ink);
+      background: var(--bg-soft); border-radius: 999px; padding: 8px 8px 8px 14px;
+    }
+    .pkg-install code { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .pkg-install button {
+      margin-left: auto; flex: none; font-family: var(--font-sans); font-size: 12px; font-weight: 600;
+      background: #fff; color: var(--accent); border: none; cursor: pointer; padding: 6px 13px;
+      border-radius: 999px; box-shadow: var(--shadow-1); transition: background .2s, color .2s;
+    }
+    .pkg-install button.copied { background: oklch(0.55 0.14 155); color: #fff; }
+    .pkg-meta { font-size: 12.5px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+
+    .pkg-skel, .feed-skel { display: none; border-radius: var(--radius); background: linear-gradient(100deg, var(--bg-soft) 30%, oklch(0.94 0.004 247) 50%, var(--bg-soft) 70%); background-size: 200% 100%; animation: sheen 1.2s linear infinite; }
+    .pkg-skel { height: 168px; }
+    .feed-skel { height: 44px; border-radius: 12px; margin-bottom: 10px; }
+    @keyframes sheen { to { background-position: -200% 0; } }
+
+    .reg-state { text-align: center; padding: 56px 20px; border: 1px dashed var(--line); border-radius: var(--radius); }
+    .reg-state h3 { font-size: 20px; font-weight: 600; }
+    .reg-state p { margin: 10px auto 22px; max-width: 40ch; color: var(--ink-2); font-size: 15px; line-height: 1.55; }
+
+    .reg-aside { position: sticky; top: 88px; }
+    .feed-card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px; }
+    .feed-head { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: var(--ink); margin-bottom: 14px; }
+    .pulse { width: 8px; height: 8px; border-radius: 50%; background: oklch(0.7 0.16 150); box-shadow: 0 0 0 0 oklch(0.7 0.16 150 / .5); animation: pulse 2s var(--ease) infinite; }
+    @keyframes pulse { 70%, 100% { box-shadow: 0 0 0 7px oklch(0.7 0.16 150 / 0); } }
+    .feed-list { list-style: none; display: flex; flex-direction: column; gap: 2px; }
+    .feed-item { display: flex; flex-direction: column; gap: 2px; padding: 9px 0; border-top: 1px solid var(--line); font-size: 13px; }
+    .feed-item:first-child { border-top: none; }
+    .feed-item .fx { color: var(--ink); line-height: 1.45; }
+    .feed-item .fx b { font-weight: 600; }
+    .feed-item .fx a { color: var(--accent); text-decoration: none; }
+    .feed-item .fx a:hover { text-decoration: underline; }
+    .feed-item .ft { color: var(--ink-3); font-size: 11.5px; }
+    .feed-item .ico { font-family: var(--font-mono); }
+    .feed-empty { font-size: 13px; color: var(--ink-3); line-height: 1.5; }
+
+    .reg-publish { padding: 8px 0 64px; scroll-margin-top: 88px; }
+    .pub-card { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; box-shadow: var(--shadow-2); }
+    .pub-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 20px; }
+    .pub-head h3 { font-size: 20px; font-weight: 600; }
+    .pub-head p { margin-top: 6px; color: var(--ink-2); font-size: 14px; }
+    .pub-close { background: var(--bg-soft); border: none; cursor: pointer; width: 32px; height: 32px; border-radius: 50%; color: var(--ink-2); font-size: 14px; flex: none; }
+    .pub-close:hover { color: var(--ink); }
+    .pub-form { display: flex; flex-direction: column; gap: 14px; }
+    .pub-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .pub-form label { display: flex; flex-direction: column; gap: 6px; font-size: 12.5px; font-weight: 600; color: var(--ink-2); }
+    .pub-form input, .pub-form select {
+      font-family: var(--font-sans); font-size: 14px; color: var(--ink); font-weight: 400;
+      background: var(--bg-soft); border: 1px solid transparent; border-radius: var(--radius-sm);
+      padding: 11px 14px; outline: none; transition: border-color .2s, background .2s;
+    }
+    .pub-form input:focus, .pub-form select:focus { background: #fff; border-color: var(--accent); }
+    .pub-actions { display: flex; align-items: center; gap: 16px; margin-top: 4px; }
+    .pub-msg { font-size: 13.5px; color: var(--ink-2); }
+    .pub-msg.err { color: oklch(0.55 0.18 25); }
+    .pub-msg.ok { color: oklch(0.5 0.13 155); }
+
+    @media (max-width: 900px) {
+      .reg-cols { grid-template-columns: 1fr; }
+      .reg-aside { position: static; }
+      .pkg-grid { grid-template-columns: 1fr; }
+      .pub-row { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 560px) {
+      .reg-head { padding-top: 104px; }
+      .wrap { padding: 0 20px; }
+      .reg-toolbar { gap: 10px; }
+      .reg-tabs { flex: 1 1 auto; justify-content: center; }
+      .pkg-card { padding: 18px; }
+      .pub-card { padding: 20px; }
+    }
+  </style>
+
+  <script>
+    const REGISTRY = import.meta.env.PUBLIC_REGISTRY_ORIGIN || 'https://registry.reasonix.io';
+    const state = { kind: 'all', sort: 'new', q: '' };
+
+    const grid = document.getElementById('pkg-grid');
+    const emptyEl = document.getElementById('reg-empty');
+    const offlineEl = document.getElementById('reg-offline');
+    const feedEl = document.getElementById('feed');
+    const feedEmpty = document.getElementById('feed-empty');
+
+    const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (m) => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[m]
+    ));
+
+    function show(el, on) { if (el) el.hidden = !on; }
+
+    function card(p) {
+      const kindCls = p.kind === 'mcp' ? 'pkg-kind mcp' : 'pkg-kind';
+      const badge = p.verified
+        ? '<span class="pkg-badge verified">✓ verified</span>'
+        : '<span class="pkg-badge community">community</span>';
+      const tags = (p.tags || []).slice(0, 4).map((t) => `<span>${esc(t)}</span>`).join('');
+      const stars = p.starCount > 0 ? `<span class="pkg-stars">★ ${p.starCount}</span>` : '';
+      const repo = p.repoUrl ? ` · <a href="${esc(p.repoUrl)}" target="_blank" rel="noreferrer">repo</a>` : '';
+      return `<article class="pkg-card">
+        <div class="pkg-top"><span class="${kindCls}">${esc(p.kind)}</span>${badge}${stars}</div>
+        <div class="pkg-name"><span class="scope">${esc(p.handle)}/</span>${esc(p.name)}</div>
+        <div class="pkg-sum">${esc(p.summary) || '<span style="color:var(--ink-3)">No summary.</span>'}</div>
+        ${tags ? `<div class="pkg-tags">${tags}</div>` : ''}
+        <div class="pkg-foot">
+          <span class="pkg-install" title="Install source — give it to Reasonix"><code>${esc(p.source)}</code><button data-copy="${esc(p.source)}" data-slug="${esc(p.handle)}/${esc(p.name)}">Copy</button></span>
+        </div>
+        <div class="pkg-meta">↓ ${p.installCount || 0} installs · v${esc(p.latestVersion) || '—'}${repo}</div>
+      </article>`;
+    }
+
+    function renderPackages(list) {
+      grid.removeAttribute('data-state');
+      show(offlineEl, false);
+      if (!list.length) { grid.innerHTML = ''; show(emptyEl, true); return; }
+      show(emptyEl, false);
+      grid.innerHTML = list.map(card).join('');
+    }
+
+    function renderOffline() {
+      grid.removeAttribute('data-state');
+      grid.innerHTML = '';
+      show(emptyEl, false);
+      show(offlineEl, true);
+    }
+
+    const rel = (iso) => {
+      const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+      if (s < 60) return 'just now';
+      if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+      if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+      return `${Math.floor(s / 86400)}d ago`;
+    };
+
+    function feedLine(e) {
+      const who = e.actor ? `<b>@${esc(e.actor)}</b> ` : '';
+      const link = e.slug ? `<a href="#" data-slug="${esc(e.slug)}">${esc(e.slug)}</a>` : '';
+      const verb = { publish: 'published', update: 'updated', star: 'starred', milestone: '' };
+      const ico = { publish: '↑', update: '↻', star: '★', milestone: '◎' }[e.type] || '•';
+      const text = e.type === 'milestone' ? esc(e.summary) : `${who}${verb[e.type] || e.type} ${link}`;
+      return `<li class="feed-item"><span class="fx"><span class="ico">${ico}</span> ${text}</span><span class="ft">${rel(e.createdAt)}</span></li>`;
+    }
+
+    function renderFeed(events) {
+      if (!events.length) { feedEl.innerHTML = ''; show(feedEmpty, true); return; }
+      show(feedEmpty, false);
+      feedEl.innerHTML = events.map(feedLine).join('');
+    }
+
+    async function loadPackages() {
+      const params = new URLSearchParams({ kind: state.kind, sort: state.sort, q: state.q, limit: '48' });
+      try {
+        const r = await fetch(`${REGISTRY}/v1/packages?${params}`);
+        if (!r.ok) throw new Error(String(r.status));
+        renderPackages((await r.json()).packages || []);
+      } catch { renderOffline(); }
+    }
+
+    async function loadFeed() {
+      try {
+        const r = await fetch(`${REGISTRY}/v1/activity?limit=20`);
+        if (!r.ok) throw new Error(String(r.status));
+        renderFeed((await r.json()).events || []);
+      } catch { feedEl.innerHTML = ''; show(feedEmpty, true); }
+    }
+
+    // Copy install command (cards render after page load, so delegate).
+    grid.addEventListener('click', (ev) => {
+      const btn = ev.target.closest('button[data-copy]');
+      if (!btn) return;
+      navigator.clipboard?.writeText(btn.dataset.copy);
+      btn.classList.add('copied');
+      btn.textContent = '✓';
+      setTimeout(() => { btn.classList.remove('copied'); btn.textContent = 'Copy'; }, 1400);
+      // Best-effort install ping — powers the trending rank.
+      fetch(`${REGISTRY}/v1/packages/${btn.dataset.slug}/installed`, { method: 'POST' }).catch(() => {});
+    });
+
+    // Toolbar
+    let debounce;
+    document.getElementById('reg-q').addEventListener('input', (e) => {
+      clearTimeout(debounce);
+      state.q = e.target.value.trim();
+      debounce = setTimeout(loadPackages, 220);
+    });
+    document.querySelectorAll('.reg-tabs').forEach((group) => {
+      group.addEventListener('click', (ev) => {
+        const btn = ev.target.closest('button');
+        if (!btn) return;
+        group.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (group.dataset.group === 'kind') state.kind = btn.dataset.kind;
+        else state.sort = btn.dataset.sort;
+        loadPackages();
+      });
+    });
+
+    // Publish panel
+    const publish = document.getElementById('publish');
+    const openPublish = (ev) => { if (ev) ev.preventDefault(); publish.hidden = false; publish.scrollIntoView({ behavior: 'smooth' }); };
+    document.getElementById('publish-open').addEventListener('click', openPublish);
+    document.querySelectorAll('[data-publish-jump]').forEach((el) => el.addEventListener('click', openPublish));
+    document.getElementById('publish-close').addEventListener('click', () => { publish.hidden = true; });
+    if (location.hash === '#publish') publish.hidden = false;
+
+    const msg = document.getElementById('pub-msg');
+    const setMsg = (text, cls) => { msg.textContent = text; msg.className = 'pub-msg' + (cls ? ' ' + cls : ''); };
+
+    document.getElementById('pub-form').addEventListener('submit', async (ev) => {
+      ev.preventDefault();
+      const f = new FormData(ev.target);
+      const tags = String(f.get('tags') || '').split(',').map((t) => t.trim()).filter(Boolean);
+      const body = {
+        kind: f.get('kind'), name: f.get('name'), summary: f.get('summary') || '',
+        source: f.get('source'), version: f.get('version') || '',
+        repoUrl: f.get('repoUrl') || '', tags,
+      };
+      setMsg('Publishing…');
+      try {
+        const r = await fetch(`${REGISTRY}/v1/packages`, {
+          method: 'POST', credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+        });
+        const data = await r.json().catch(() => ({}));
+        if (r.status === 401) { setMsg('Sign in at id.reasonix.io to publish.', 'err'); return; }
+        if (!r.ok) { setMsg(data?.error?.message || 'Publish failed.', 'err'); return; }
+        setMsg(`Published ${data.package.slug}@${data.version}.`, 'ok');
+        ev.target.reset();
+        loadPackages(); loadFeed();
+      } catch { setMsg('Registry is unreachable right now.', 'err'); }
+    });
+
+    loadPackages();
+    loadFeed();
+  </script>
+</Base>

--- a/workers/registry/.gitignore
+++ b/workers/registry/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+dist/

--- a/workers/registry/migrations/0001_initial.sql
+++ b/workers/registry/migrations/0001_initial.sql
@@ -1,0 +1,68 @@
+-- Reasonix registry: published skills/MCP servers, their versions, and the
+-- activity/install event log. Apply:
+--   wrangler d1 migrations apply reasonix-registry --local   (or --remote)
+
+-- One row per published capability. The registry stores only metadata and a
+-- source pointer; it never fetches or executes the content — install happens
+-- client-side through the install_source tool (SSRF-guarded, risk-rated).
+CREATE TABLE IF NOT EXISTS packages (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  kind           TEXT    NOT NULL,                    -- skill | mcp
+  scope_handle   TEXT    NOT NULL,                    -- publisher handle (namespace)
+  name           TEXT    NOT NULL,                    -- capability slug within the scope
+  slug           TEXT    NOT NULL UNIQUE,             -- '<handle>/<name>' canonical id
+  summary        TEXT    NOT NULL DEFAULT '',         -- one-liner (SKILL.md description)
+  description    TEXT    NOT NULL DEFAULT '',         -- long markdown (README)
+  source         TEXT    NOT NULL DEFAULT '',         -- what install_source pulls from
+  install_kind   TEXT    NOT NULL DEFAULT 'auto',     -- auto | skill | mcp
+  homepage       TEXT    NOT NULL DEFAULT '',
+  repo_url       TEXT    NOT NULL DEFAULT '',
+  tags           TEXT    NOT NULL DEFAULT '',         -- comma-separated
+  latest_version TEXT    NOT NULL DEFAULT '',
+  install_count  INTEGER NOT NULL DEFAULT 0,
+  star_count     INTEGER NOT NULL DEFAULT 0,
+  verified       INTEGER NOT NULL DEFAULT 0,          -- owner/admin trust badge
+  status         TEXT    NOT NULL DEFAULT 'active',   -- active | hidden | removed
+  publisher_id   INTEGER NOT NULL,                    -- accounts user id (owner)
+  created_at     TEXT    NOT NULL,
+  updated_at     TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS packages_kind ON packages (kind, status);
+CREATE INDEX IF NOT EXISTS packages_installs ON packages (install_count DESC);
+CREATE INDEX IF NOT EXISTS packages_created ON packages (created_at DESC);
+CREATE INDEX IF NOT EXISTS packages_publisher ON packages (publisher_id);
+
+-- Immutable version history: one row per published version, carrying the source
+-- snapshot and content hash so a consumer can audit provenance before install.
+CREATE TABLE IF NOT EXISTS package_versions (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  package_id   INTEGER NOT NULL,
+  version      TEXT    NOT NULL,
+  source       TEXT    NOT NULL DEFAULT '',
+  manifest     TEXT    NOT NULL DEFAULT '',           -- JSON: frontmatter / mcp config snapshot
+  content_hash TEXT    NOT NULL DEFAULT '',           -- sha256 of the source
+  risk_level   TEXT    NOT NULL DEFAULT '',           -- echoed from install_source plan
+  created_at   TEXT    NOT NULL,
+  UNIQUE (package_id, version)
+);
+CREATE INDEX IF NOT EXISTS versions_package ON package_versions (package_id, created_at DESC);
+
+-- Per-user stars, so star_count is a real de-duplicated tally.
+CREATE TABLE IF NOT EXISTS stars (
+  package_id INTEGER NOT NULL,
+  user_id    INTEGER NOT NULL,
+  created_at TEXT    NOT NULL,
+  PRIMARY KEY (package_id, user_id)
+);
+
+-- Activity log: powers the homepage live feed and the 7-day "trending" ranking.
+CREATE TABLE IF NOT EXISTS events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  type         TEXT    NOT NULL,                       -- publish | update | install | star
+  package_id   INTEGER,
+  actor_handle TEXT    NOT NULL DEFAULT '',
+  summary      TEXT    NOT NULL DEFAULT '',
+  created_at   TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS events_created ON events (created_at DESC);
+CREATE INDEX IF NOT EXISTS events_trending ON events (type, created_at);

--- a/workers/registry/package-lock.json
+++ b/workers/registry/package-lock.json
@@ -1,0 +1,1548 @@
+{
+  "name": "reasonix-registry",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reasonix-registry",
+      "dependencies": {
+        "hono": "^4.6.14",
+        "zod": "^3.25.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260601.0",
+        "typescript": "^5.8.0",
+        "wrangler": "^4.102.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260630.1.tgz",
+      "integrity": "sha512-oEVsD2NZtPAMaEvFeH2Y6N63yiFuOnPDKeAM+l8AkRbLAbFk462uWOq6/ZLn8ouY4P4coMkgsOPqcT1mkuzvzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-tar1vcQSzM+27Agrlv28BhtN1tIFKw2YHrzldEMyQJOJB/885TU8Z3oO1c/a9YOmsKABhD6I4dGFhsmXyrbK1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260630.1.tgz",
+      "integrity": "sha512-mhjIg91+ikWw5v9tY4BYO7N9vLOZBhn7EnVFvxCdxcpuUUFBKATxUYHUy1kkgYxnmiI6s93PRNbzBz1NpYQ3IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-7g0iGvMCwGct+vE3FOKXtFWMAIGHzK2Ei9oALp44gXuL4lBcs3PPJISeTp5itquW2JwS1fw4Hnq7zrT7N/dgPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260630.1.tgz",
+      "integrity": "sha512-J5KF9VF8yRpRBib/cPSuEp6iR9q3/cKgeDVhg1ZtuwpkzwnmCb+rxMF5WFLxAN8bI2x2FMG1v6o4vVFOGZ0fOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260701.1.tgz",
+      "integrity": "sha512-eGZ+PWPlu/yUxH+BJoplV45oSA709sjYFYr2kjrqSo+601qE15X4tsuZcPz1KE6Fb3ObGA9d9ZXn53n34NtyiA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260630.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260630.0.tgz",
+      "integrity": "sha512-lyRplDrSJJWVpzSSQPBSQtNmUuxScCZyOOkXFs37uSbdTfWRDDmw6DyFKVS2s1eYtA/i4u2xR/0FyPIsTl/HJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260630.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260630.1.tgz",
+      "integrity": "sha512-7M0AA4l14hmPGtzQ5YPHyXosIKI/uz3TdcPHeiFDbgb7/0c8ECVMzIaodSV5bZIVhDHL0OlzqITAdPiwAr+dTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260630.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260630.1",
+        "@cloudflare/workerd-linux-64": "1.20260630.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260630.1",
+        "@cloudflare/workerd-windows-64": "1.20260630.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.106.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.106.0.tgz",
+      "integrity": "sha512-b6EVbsvbmAUY4bUQXT3+f8oFP8x+J5rEa5z3Akeh+6vyKiN4x8+PyZ53DPpnqdxhIihhq/a00Yq5chGJ19QXBQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260630.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260630.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260630.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/workers/registry/package.json
+++ b/workers/registry/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "reasonix-registry",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "db:apply:local": "wrangler d1 migrations apply reasonix-registry --local",
+    "db:apply:remote": "wrangler d1 migrations apply reasonix-registry --remote"
+  },
+  "dependencies": {
+    "hono": "^4.6.14",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260601.0",
+    "typescript": "^5.8.0",
+    "wrangler": "^4.102.0"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
+  }
+}

--- a/workers/registry/seed.sql
+++ b/workers/registry/seed.sql
@@ -1,0 +1,32 @@
+-- Local demo data for the registry. Apply to the LOCAL D1 only:
+--   wrangler d1 execute reasonix-registry --local --file=seed.sql
+DELETE FROM events;
+DELETE FROM stars;
+DELETE FROM package_versions;
+DELETE FROM packages;
+
+INSERT INTO packages
+  (kind, scope_handle, name, slug, summary, source, install_kind, repo_url, tags, latest_version, install_count, star_count, verified, publisher_id, created_at, updated_at)
+VALUES
+  ('skill','esengine','pr-review','esengine/pr-review','Adversarial multi-pass PR review with inline findings','https://github.com/esengine/reasonix-skills/pr-review','skill','https://github.com/esengine/reasonix-skills','review,git,quality','1.2.0',428,96,1,1,datetime('now','-40 days'),datetime('now','-3 days')),
+  ('skill','esengine','go-test-gen','esengine/go-test-gen','Generate table-driven Go tests for the current package','https://github.com/esengine/reasonix-skills/go-test-gen','skill','https://github.com/esengine/reasonix-skills','go,testing','0.4.1',213,44,1,1,datetime('now','-22 days'),datetime('now','-6 days')),
+  ('mcp','sivancola','feishu-notify','sivancola/feishu-notify','Send Feishu/Lark interactive cards from your agent','https://github.com/SivanCola/feishu-mcp/.mcp.json','mcp','https://github.com/SivanCola/feishu-mcp','feishu,notify,im','0.3.0',156,31,0,2,datetime('now','-14 days'),datetime('now','-2 days')),
+  ('skill','huqiantao','commit-msg','huqiantao/commit-msg','Write conventional commit messages from the staged diff','https://raw.githubusercontent.com/HUQIANTAO/rx/main/commit-msg/SKILL.md','skill','https://github.com/HUQIANTAO/rx','git,commits','1.0.0',502,73,0,3,datetime('now','-9 days'),datetime('now','-1 day')),
+  ('mcp','community','postgres','community/postgres','Query and inspect a Postgres database over MCP','npx -y @modelcontextprotocol/server-postgres','mcp','https://github.com/modelcontextprotocol/servers','database,sql,postgres','0.6.2',89,18,0,4,datetime('now','-5 days'),datetime('now','-5 days')),
+  ('skill','gtc2080','changelog','gtc2080/changelog','Draft a CHANGELOG entry from merged PRs since the last tag','https://github.com/GTC2080/rx-skills/changelog','skill','https://github.com/GTC2080/rx-skills','release,docs','0.2.0',37,9,0,5,datetime('now','-2 days'),datetime('now','-2 days'));
+
+INSERT INTO package_versions (package_id, version, source, content_hash, risk_level, created_at)
+  SELECT id, latest_version, source, '', 'low', updated_at FROM packages;
+
+INSERT INTO events (type, package_id, actor_handle, summary, created_at)
+  SELECT 'publish', id, scope_handle, 'published ' || slug || '@' || latest_version, created_at FROM packages;
+
+INSERT INTO events (type, package_id, actor_handle, summary, created_at) VALUES
+  ((SELECT id FROM packages WHERE slug='huqiantao/commit-msg'),'milestone','huqiantao','huqiantao/commit-msg reached 500 installs',datetime('now','-6 hours')),
+  ((SELECT id FROM packages WHERE slug='esengine/pr-review'),'star','sivancola','starred esengine/pr-review',datetime('now','-3 hours')),
+  ((SELECT id FROM packages WHERE slug='gtc2080/changelog'),'publish','gtc2080','published gtc2080/changelog@0.2.0',datetime('now','-90 minutes'));
+
+-- install pings over the last week to give the trending rank something to sort on
+INSERT INTO events (type, package_id, actor_handle, summary, created_at)
+  SELECT 'install', p.id, '', 'installed ' || p.slug, datetime('now','-' || (abs(random()) % 6) || ' days')
+  FROM packages p, (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5);

--- a/workers/registry/src/app.ts
+++ b/workers/registry/src/app.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import type { AppEnv } from "./env";
+import { corsMiddleware } from "./http/cors";
+import { errorHandler, notFoundHandler } from "./http/errors";
+import health from "./routes/health";
+import packages from "./routes/packages";
+import activity from "./routes/activity";
+
+const app = new Hono<AppEnv>();
+
+app.onError(errorHandler);
+app.notFound(notFoundHandler);
+
+app.use("*", corsMiddleware);
+
+app.route("/", health);
+app.route("/v1/packages", packages);
+app.route("/v1/activity", activity);
+
+export default app;

--- a/workers/registry/src/db/events.ts
+++ b/workers/registry/src/db/events.ts
@@ -1,0 +1,44 @@
+import type { EventRow } from "../types";
+
+export type EventType = "publish" | "update" | "install" | "star" | "milestone";
+
+export interface NewEvent {
+  type: EventType;
+  packageId: number | null;
+  actorHandle: string;
+  summary: string;
+  now: string;
+}
+
+export class EventRepo {
+  constructor(private readonly db: D1Database) {}
+
+  async log(e: NewEvent): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO events (type, package_id, actor_handle, summary, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)`,
+      )
+      .bind(e.type, e.packageId, e.actorHandle, e.summary.slice(0, 200), e.now)
+      .run();
+  }
+
+  // Most-recent social activity, joined to the package slug so the feed can link
+  // back. Raw 'install' pings are excluded — they exist only to feed the trending
+  // rank; the feed surfaces publish/update/star and install-milestone events.
+  async recent(limit: number): Promise<EventRow[]> {
+    const res = await this.db
+      .prepare(
+        `SELECT e.type AS type, p.slug AS slug, e.actor_handle AS actor_handle,
+                e.summary AS summary, e.created_at AS created_at
+         FROM events e
+         LEFT JOIN packages p ON p.id = e.package_id
+         WHERE e.type IN ('publish', 'update', 'star', 'milestone')
+         ORDER BY e.created_at DESC
+         LIMIT ?1`,
+      )
+      .bind(limit)
+      .all<EventRow>();
+    return res.results ?? [];
+  }
+}

--- a/workers/registry/src/db/index.ts
+++ b/workers/registry/src/db/index.ts
@@ -1,0 +1,10 @@
+import type { Bindings } from "../env";
+import { PackageRepo } from "./packages";
+import { EventRepo } from "./events";
+
+export function repos(env: Bindings): { packages: PackageRepo; events: EventRepo } {
+  return {
+    packages: new PackageRepo(env.DB),
+    events: new EventRepo(env.DB),
+  };
+}

--- a/workers/registry/src/db/packages.ts
+++ b/workers/registry/src/db/packages.ts
@@ -1,0 +1,204 @@
+import type { PackageRow, VersionRow, RegistryUser } from "../types";
+import type { PublishInput } from "../lib/validation";
+import { ApiError } from "../http/errors";
+
+const TRENDING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface ListParams {
+  kind: "skill" | "mcp" | "all";
+  q: string;
+  sort: "new" | "trending" | "installs";
+  limit: number;
+  offset: number;
+  now: string;
+}
+
+export interface PublishResult {
+  row: PackageRow;
+  created: boolean;
+  version: string;
+}
+
+export class PackageRepo {
+  constructor(private readonly db: D1Database) {}
+
+  async list(p: ListParams): Promise<PackageRow[]> {
+    const where: string[] = ["p.status = 'active'"];
+    const binds: unknown[] = [];
+
+    if (p.kind !== "all") {
+      where.push(`p.kind = ?${binds.length + 1}`);
+      binds.push(p.kind);
+    }
+    if (p.q) {
+      const like = `%${p.q.toLowerCase()}%`;
+      const a = binds.length + 1;
+      where.push(`(lower(p.name) LIKE ?${a} OR lower(p.summary) LIKE ?${a + 1} OR lower(p.tags) LIKE ?${a + 2})`);
+      binds.push(like, like, like);
+    }
+
+    let select = "SELECT p.* FROM packages p";
+    let order: string;
+    if (p.sort === "trending") {
+      const windowStart = new Date(new Date(p.now).getTime() - TRENDING_WINDOW_MS).toISOString();
+      select = `SELECT p.*, COALESCE(e.c, 0) AS trend FROM packages p
+        LEFT JOIN (
+          SELECT package_id, COUNT(*) AS c FROM events
+          WHERE type = 'install' AND created_at > ?${binds.length + 1}
+          GROUP BY package_id
+        ) e ON e.package_id = p.id`;
+      binds.push(windowStart);
+      order = "ORDER BY trend DESC, p.install_count DESC, p.created_at DESC";
+    } else if (p.sort === "installs") {
+      order = "ORDER BY p.install_count DESC, p.created_at DESC";
+    } else {
+      order = "ORDER BY p.created_at DESC";
+    }
+
+    const sql = `${select} WHERE ${where.join(" AND ")} ${order} LIMIT ?${binds.length + 1} OFFSET ?${binds.length + 2}`;
+    binds.push(p.limit, p.offset);
+
+    const res = await this.db.prepare(sql).bind(...binds).all<PackageRow>();
+    return res.results ?? [];
+  }
+
+  async bySlug(slug: string): Promise<PackageRow | null> {
+    return this.db.prepare("SELECT * FROM packages WHERE slug = ?1").bind(slug).first<PackageRow>();
+  }
+
+  async versions(packageId: number): Promise<VersionRow[]> {
+    const res = await this.db
+      .prepare(
+        `SELECT version, source, content_hash, risk_level, created_at
+         FROM package_versions WHERE package_id = ?1 ORDER BY created_at DESC`,
+      )
+      .bind(packageId)
+      .all<VersionRow>();
+    return res.results ?? [];
+  }
+
+  // Create a new package or append a version to an owned one. Republishing an
+  // existing version is refused (409) so version history stays immutable.
+  async publish(user: RegistryUser, input: PublishInput, now: string): Promise<PublishResult> {
+    const slug = `${user.handle}/${input.name}`;
+    const existing = await this.bySlug(slug);
+
+    if (existing) {
+      if (existing.publisher_id !== user.id && user.role !== "admin") {
+        throw new ApiError(403, "not_owner", "That name belongs to another publisher.");
+      }
+      const version = input.version || nextPatch(existing.latest_version);
+      await this.insertVersion(existing.id, version, input, now);
+      await this.db
+        .prepare(
+          `UPDATE packages SET summary = ?1, description = ?2, source = ?3, install_kind = ?4,
+             homepage = ?5, repo_url = ?6, tags = ?7, latest_version = ?8, updated_at = ?9
+           WHERE id = ?10`,
+        )
+        .bind(
+          input.summary,
+          input.description,
+          input.source,
+          input.installKind,
+          input.homepage,
+          input.repoUrl,
+          input.tags.join(","),
+          version,
+          now,
+          existing.id,
+        )
+        .run();
+      const row = await this.bySlug(slug);
+      if (!row) throw new ApiError(500, "publish_failed", "Package not found after update.");
+      return { row, created: false, version };
+    }
+
+    const version = input.version || "0.1.0";
+    const inserted = await this.db
+      .prepare(
+        `INSERT INTO packages
+           (kind, scope_handle, name, slug, summary, description, source, install_kind,
+            homepage, repo_url, tags, latest_version, publisher_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
+         RETURNING id`,
+      )
+      .bind(
+        input.kind,
+        user.handle,
+        input.name,
+        slug,
+        input.summary,
+        input.description,
+        input.source,
+        input.installKind,
+        input.homepage,
+        input.repoUrl,
+        input.tags.join(","),
+        version,
+        user.id,
+        now,
+      )
+      .first<{ id: number }>();
+    if (!inserted) throw new ApiError(500, "publish_failed", "Insert returned no id.");
+    await this.insertVersion(inserted.id, version, input, now);
+    const row = await this.bySlug(slug);
+    if (!row) throw new ApiError(500, "publish_failed", "Package not found after insert.");
+    return { row, created: true, version };
+  }
+
+  private async insertVersion(packageId: number, version: string, input: PublishInput, now: string): Promise<void> {
+    const res = await this.db
+      .prepare(
+        `INSERT OR IGNORE INTO package_versions
+           (package_id, version, source, manifest, content_hash, risk_level, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+      )
+      .bind(packageId, version, input.source, input.manifest, input.contentHash, input.riskLevel, now)
+      .run();
+    if ((res.meta.changes ?? 0) === 0) {
+      throw new ApiError(409, "version_exists", `Version ${version} is already published.`);
+    }
+  }
+
+  // Best-effort install tally. Returns the new count, or null when no active
+  // package matches the slug.
+  async recordInstall(slug: string): Promise<number | null> {
+    const res = await this.db
+      .prepare("UPDATE packages SET install_count = install_count + 1 WHERE slug = ?1 AND status = 'active'")
+      .bind(slug)
+      .run();
+    if ((res.meta.changes ?? 0) === 0) return null;
+    const row = await this.bySlug(slug);
+    return row?.install_count ?? null;
+  }
+
+  // Toggle a star. Returns the resulting state, or null when the slug is unknown.
+  async toggleStar(slug: string, userId: number, now: string): Promise<{ starred: boolean; count: number } | null> {
+    const pkg = await this.bySlug(slug);
+    if (!pkg || pkg.status !== "active") return null;
+
+    const added = await this.db
+      .prepare("INSERT OR IGNORE INTO stars (package_id, user_id, created_at) VALUES (?1, ?2, ?3)")
+      .bind(pkg.id, userId, now)
+      .run();
+
+    if ((added.meta.changes ?? 0) > 0) {
+      await this.db.prepare("UPDATE packages SET star_count = star_count + 1 WHERE id = ?1").bind(pkg.id).run();
+      return { starred: true, count: pkg.star_count + 1 };
+    }
+    await this.db.prepare("DELETE FROM stars WHERE package_id = ?1 AND user_id = ?2").bind(pkg.id, userId).run();
+    await this.db
+      .prepare("UPDATE packages SET star_count = MAX(0, star_count - 1) WHERE id = ?1")
+      .bind(pkg.id)
+      .run();
+    return { starred: false, count: Math.max(0, pkg.star_count - 1) };
+  }
+}
+
+// Bump the patch component so an update without an explicit version still lands
+// as a distinct, immutable version row. Non-semver latest values restart at 0.1.0.
+function nextPatch(latest: string): string {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(latest.trim());
+  if (!m) return "0.1.0";
+  return `${m[1]}.${m[2]}.${Number(m[3]) + 1}`;
+}

--- a/workers/registry/src/env.ts
+++ b/workers/registry/src/env.ts
@@ -1,0 +1,23 @@
+import type { RegistryUser } from "./types";
+
+// Cloudflare's native rate-limit binding (configured under [[unsafe.bindings]]).
+export interface RateLimiter {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
+}
+
+export interface Bindings {
+  DB: D1Database;
+  WRITE_LIMITER?: RateLimiter;
+
+  // Plain vars (wrangler.toml [vars]).
+  ACCOUNTS_ORIGIN: string;
+  APP_ORIGIN: string;
+  ALLOWED_ORIGINS: string;
+}
+
+// Set by requireAuth on protected routes; absent on public reads.
+export interface Variables {
+  user: RegistryUser;
+}
+
+export type AppEnv = { Bindings: Bindings; Variables: Variables };

--- a/workers/registry/src/http/auth.ts
+++ b/workers/registry/src/http/auth.ts
@@ -1,0 +1,37 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { AppEnv } from "../env";
+import type { RegistryUser } from "../types";
+import { ApiError } from "./errors";
+
+// Resolve identity by asking the account service, forwarding the caller's cookie
+// and Authorization so both the web session and the CLI bearer resolve. The
+// registry never holds SESSION_PEPPER; accounts stays the sole identity authority.
+async function fetchAccountUser(c: Context<AppEnv>): Promise<RegistryUser | null> {
+  const cookie = c.req.header("cookie");
+  const authz = c.req.header("authorization");
+  if (!cookie && !authz) return null;
+
+  const headers: Record<string, string> = {};
+  if (cookie) headers["cookie"] = cookie;
+  if (authz) headers["authorization"] = authz;
+
+  const res = await fetch(`${c.env.ACCOUNTS_ORIGIN}/me`, { headers });
+  if (!res.ok) return null;
+  const body = (await res.json()) as { user?: { id?: number; handle?: string; role?: string } };
+  const u = body.user;
+  if (!u || typeof u.id !== "number" || typeof u.handle !== "string") return null;
+  return { id: u.id, handle: u.handle, role: u.role === "admin" ? "admin" : "member" };
+}
+
+// Gate for write routes. Public reads never call this, so list/detail never pay
+// the account round-trip.
+export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const user = await fetchAccountUser(c).catch(() => null);
+  if (!user) throw new ApiError(401, "unauthorized", "Sign in at id.reasonix.io to publish.");
+  c.set("user", user);
+  await next();
+};
+
+export function currentUser(c: Context<AppEnv>): RegistryUser {
+  return c.get("user");
+}

--- a/workers/registry/src/http/cors.ts
+++ b/workers/registry/src/http/cors.ts
@@ -1,0 +1,20 @@
+import type { MiddlewareHandler } from "hono";
+import { cors } from "hono/cors";
+import type { AppEnv } from "../env";
+
+// CORS with credentials: only origins listed in ALLOWED_ORIGINS get an
+// Access-Control-Allow-Origin header, and it always echoes the exact origin
+// (never "*", which is incompatible with cookies).
+export const corsMiddleware: MiddlewareHandler<AppEnv> = (c, next) => {
+  const allowed = (c.env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return cors({
+    origin: (origin) => (allowed.includes(origin) ? origin : null),
+    credentials: true,
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    maxAge: 86400,
+  })(c, next);
+};

--- a/workers/registry/src/http/errors.ts
+++ b/workers/registry/src/http/errors.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../env";
+
+// A client-safe error: the code/message pair is sent verbatim to the caller, so
+// never put internal detail in here.
+export class ApiError extends Error {
+  constructor(
+    public readonly status: ContentfulStatusCode,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export function errorHandler(err: Error, c: Context<AppEnv>): Response {
+  if (err instanceof ApiError) {
+    return c.json({ error: { code: err.code, message: err.message } }, err.status);
+  }
+  if (err instanceof SyntaxError) {
+    return c.json({ error: { code: "invalid_json", message: "Request body must be valid JSON." } }, 400);
+  }
+  if (err instanceof HTTPException) {
+    return err.getResponse();
+  }
+  console.error("unhandled error:", err);
+  return c.json({ error: { code: "internal", message: "Something went wrong." } }, 500);
+}
+
+export function notFoundHandler(c: Context<AppEnv>): Response {
+  return c.json({ error: { code: "not_found", message: "Not found." } }, 404);
+}

--- a/workers/registry/src/http/ratelimit.ts
+++ b/workers/registry/src/http/ratelimit.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../env";
+import { ApiError } from "./errors";
+
+// Per-IP throttle for write endpoints. The binding may be absent under local
+// `wrangler dev`, in which case the limiter is simply skipped.
+export const writeRateLimit: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const limiter = c.env.WRITE_LIMITER;
+  if (limiter) {
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const { success } = await limiter.limit({ key: ip });
+    if (!success) {
+      throw new ApiError(429, "rate_limited", "Too many requests. Please wait a minute and try again.");
+    }
+  }
+  await next();
+};

--- a/workers/registry/src/index.ts
+++ b/workers/registry/src/index.ts
@@ -1,0 +1,5 @@
+// Reasonix skill + MCP registry — publish, discover, and track installs for
+// reasonix.io. The Hono app is itself the Workers fetch handler.
+import app from "./app";
+
+export default app;

--- a/workers/registry/src/lib/validation.ts
+++ b/workers/registry/src/lib/validation.ts
@@ -1,0 +1,69 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../env";
+import { ApiError } from "../http/errors";
+
+// A capability slug: lowercase, 1–64 chars of [a-z0-9._-], starting and ending
+// with an alphanumeric. Matches the skill-name rules install_source enforces.
+const slug = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(/^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/, "Use 1–64 chars: letters, digits, '.', '_', '-'.")
+  .max(64);
+
+const httpUrl = z.string().trim().url().max(500);
+
+export const PublishSchema = z
+  .object({
+    kind: z.enum(["skill", "mcp"]),
+    name: slug,
+    summary: z.string().trim().max(200).default(""),
+    description: z.string().trim().max(8000).default(""),
+    source: z.string().trim().min(1).max(500),
+    installKind: z.enum(["auto", "skill", "mcp"]).default("auto"),
+    version: z.string().trim().max(40).default(""),
+    homepage: z.union([httpUrl, z.literal("")]).default(""),
+    repoUrl: z.union([httpUrl, z.literal("")]).default(""),
+    tags: z.array(z.string().trim().min(1).max(30)).max(8).default([]),
+    manifest: z.string().max(16000).default(""),
+    contentHash: z.string().trim().max(128).default(""),
+    riskLevel: z.string().trim().max(20).default(""),
+  })
+  .strict();
+
+export type PublishInput = z.infer<typeof PublishSchema>;
+
+export const ListQuerySchema = z.object({
+  kind: z.enum(["skill", "mcp", "all"]).default("all"),
+  q: z.string().trim().max(100).default(""),
+  sort: z.enum(["new", "trending", "installs"]).default("new"),
+  limit: z.coerce.number().int().min(1).max(100).default(24),
+  offset: z.coerce.number().int().min(0).max(10000).default(0),
+});
+
+function firstIssue(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) return "Some fields are invalid.";
+  const path = issue.path.join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export async function parseBody<S extends z.ZodTypeAny>(c: Context<AppEnv>, schema: S): Promise<z.infer<S>> {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    throw new ApiError(400, "invalid_json", "Request body must be valid JSON.");
+  }
+  const result = schema.safeParse(raw);
+  if (!result.success) throw new ApiError(422, "invalid_input", firstIssue(result.error));
+  return result.data;
+}
+
+export function parseQuery<S extends z.ZodTypeAny>(c: Context<AppEnv>, schema: S): z.infer<S> {
+  const params = Object.fromEntries(new URL(c.req.url).searchParams);
+  const result = schema.safeParse(params);
+  if (!result.success) throw new ApiError(422, "invalid_input", firstIssue(result.error));
+  return result.data;
+}

--- a/workers/registry/src/routes/activity.ts
+++ b/workers/registry/src/routes/activity.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../env";
+import { repos } from "../db";
+import { parseQuery } from "../lib/validation";
+
+const activity = new Hono<AppEnv>();
+
+const FeedQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(30),
+});
+
+// The homepage live feed: publish/update/star/milestone events. Raw install
+// pings are excluded here (they feed the trending rank) so the feed stays social.
+activity.get("/", async (c) => {
+  const { limit } = parseQuery(c, FeedQuerySchema);
+  const rows = await repos(c.env).events.recent(limit);
+  const events = rows.map((e) => ({
+    type: e.type,
+    slug: e.slug,
+    actor: e.actor_handle,
+    summary: e.summary,
+    createdAt: e.created_at,
+  }));
+  return c.json({ events });
+});
+
+export default activity;

--- a/workers/registry/src/routes/health.ts
+++ b/workers/registry/src/routes/health.ts
@@ -1,0 +1,8 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+
+const health = new Hono<AppEnv>();
+
+health.get("/health", (c) => c.json({ ok: true, service: "reasonix-registry" }));
+
+export default health;

--- a/workers/registry/src/routes/packages.ts
+++ b/workers/registry/src/routes/packages.ts
@@ -1,0 +1,79 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { toPackageDTO } from "../types";
+import { repos } from "../db";
+import { requireAuth, currentUser } from "../http/auth";
+import { writeRateLimit } from "../http/ratelimit";
+import { ApiError } from "../http/errors";
+import { parseBody, parseQuery, PublishSchema, ListQuerySchema } from "../lib/validation";
+
+const packages = new Hono<AppEnv>();
+
+const now = () => new Date().toISOString();
+
+// Install-count thresholds worth announcing in the activity feed.
+const MILESTONES = new Set([10, 50, 100, 500, 1000]);
+const isMilestone = (n: number) => MILESTONES.has(n) || (n >= 1000 && n % 1000 === 0);
+
+packages.get("/", async (c) => {
+  const q = parseQuery(c, ListQuerySchema);
+  const rows = await repos(c.env).packages.list({ ...q, now: now() });
+  return c.json({ packages: rows.map(toPackageDTO), limit: q.limit, offset: q.offset });
+});
+
+packages.get("/:handle/:name", async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const { packages: repo } = repos(c.env);
+  const row = await repo.bySlug(slug);
+  if (!row || row.status !== "active") throw new ApiError(404, "not_found", "No such package.");
+  const versions = await repo.versions(row.id);
+  return c.json({ package: toPackageDTO(row), versions });
+});
+
+packages.post("/", writeRateLimit, requireAuth, async (c) => {
+  const user = currentUser(c);
+  const input = await parseBody(c, PublishSchema);
+  const { packages: repo, events } = repos(c.env);
+  const { row, created, version } = await repo.publish(user, input, now());
+  await events.log({
+    type: created ? "publish" : "update",
+    packageId: row.id,
+    actorHandle: user.handle,
+    summary: `${created ? "published" : "updated"} ${row.slug}@${version}`,
+    now: now(),
+  });
+  return c.json({ package: toPackageDTO(row), created, version }, created ? 201 : 200);
+});
+
+packages.post("/:handle/:name/installed", writeRateLimit, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const { packages: repo, events } = repos(c.env);
+  const count = await repo.recordInstall(slug);
+  if (count === null) throw new ApiError(404, "not_found", "No such package.");
+  const row = await repo.bySlug(slug);
+  await events.log({ type: "install", packageId: row?.id ?? null, actorHandle: "", summary: `installed ${slug}`, now: now() });
+  if (isMilestone(count) && row) {
+    await events.log({
+      type: "milestone",
+      packageId: row.id,
+      actorHandle: row.scope_handle,
+      summary: `${slug} reached ${count} installs`,
+      now: now(),
+    });
+  }
+  return c.json({ ok: true, installCount: count });
+});
+
+packages.post("/:handle/:name/star", writeRateLimit, requireAuth, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const user = currentUser(c);
+  const { packages: repo, events } = repos(c.env);
+  const result = await repo.toggleStar(slug, user.id, now());
+  if (result === null) throw new ApiError(404, "not_found", "No such package.");
+  if (result.starred) {
+    await events.log({ type: "star", packageId: null, actorHandle: user.handle, summary: `starred ${slug}`, now: now() });
+  }
+  return c.json(result);
+});
+
+export default packages;

--- a/workers/registry/src/types.ts
+++ b/workers/registry/src/types.ts
@@ -1,0 +1,98 @@
+// The subset of an account the registry needs: identity + namespace + trust.
+export interface RegistryUser {
+  id: number;
+  handle: string;
+  role: "member" | "admin";
+}
+
+export type PackageKind = "skill" | "mcp";
+
+// A `packages` row as stored in D1.
+export interface PackageRow {
+  id: number;
+  kind: PackageKind;
+  scope_handle: string;
+  name: string;
+  slug: string;
+  summary: string;
+  description: string;
+  source: string;
+  install_kind: string;
+  homepage: string;
+  repo_url: string;
+  tags: string;
+  latest_version: string;
+  install_count: number;
+  star_count: number;
+  verified: number;
+  status: string;
+  publisher_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// The public, camel-cased view served by the API.
+export interface PackageDTO {
+  kind: PackageKind;
+  handle: string;
+  name: string;
+  slug: string;
+  summary: string;
+  description: string;
+  source: string;
+  installKind: string;
+  homepage: string;
+  repoUrl: string;
+  tags: string[];
+  latestVersion: string;
+  installCount: number;
+  starCount: number;
+  verified: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VersionRow {
+  version: string;
+  source: string;
+  content_hash: string;
+  risk_level: string;
+  created_at: string;
+}
+
+export interface EventRow {
+  type: string;
+  slug: string | null;
+  actor_handle: string;
+  summary: string;
+  created_at: string;
+}
+
+function splitTags(tags: string): string[] {
+  return tags
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+export function toPackageDTO(row: PackageRow): PackageDTO {
+  return {
+    kind: row.kind,
+    handle: row.scope_handle,
+    name: row.name,
+    slug: row.slug,
+    summary: row.summary,
+    description: row.description,
+    source: row.source,
+    installKind: row.install_kind,
+    homepage: row.homepage,
+    repoUrl: row.repo_url,
+    tags: splitTags(row.tags),
+    latestVersion: row.latest_version,
+    installCount: row.install_count,
+    starCount: row.star_count,
+    verified: row.verified === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/workers/registry/tsconfig.json
+++ b/workers/registry/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/workers/registry/wrangler.toml
+++ b/workers/registry/wrangler.toml
@@ -1,0 +1,33 @@
+# Skill + MCP registry for reasonix.io — publish, discover, and track installs.
+# Identity is delegated to the account service (id.reasonix.io); this worker
+# never holds SESSION_PEPPER. First deploy:
+#   wrangler d1 create reasonix-registry         # paste database_id below
+#   wrangler d1 migrations apply reasonix-registry --remote
+#   wrangler deploy
+name = "reasonix-registry"
+main = "src/index.ts"
+compatibility_date = "2026-06-01"
+
+routes = [{ pattern = "registry.reasonix.io", custom_domain = true }]
+
+[vars]
+# Account service that resolves the session cookie / CLI bearer to an account.
+ACCOUNTS_ORIGIN = "https://id.reasonix.io"
+# Where the web frontend lives (canonical links back to package pages).
+APP_ORIGIN = "https://reasonix.io"
+# Browsers that may call this API with credentials (comma-separated).
+ALLOWED_ORIGINS = "https://reasonix.io,https://www.reasonix.io"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "reasonix-registry"
+# Fill in after `wrangler d1 create reasonix-registry`.
+database_id = "PLACEHOLDER-run-wrangler-d1-create-reasonix-registry"
+migrations_dir = "migrations"
+
+# Per-IP throttle for writes (publish / install-ping / star).
+[[unsafe.bindings]]
+name = "WRITE_LIMITER"
+type = "ratelimit"
+namespace_id = "3001"
+simple = { limit = 30, period = 60 }


### PR DESCRIPTION
## What

Adds a discovery layer over the existing `install_source` distribution rail so the community can browse, search, and publish skills and MCP servers at **reasonix.io/skills**.

- **`workers/registry/`** — a Cloudflare Worker (Hono + D1):
  - `GET /v1/packages` — kind + text filter; sort by `new` / `trending` / `installs`
  - `GET /v1/packages/:handle/:name` — detail + versions
  - `POST /v1/packages` — publish (auth-gated)
  - `POST /v1/packages/:handle/:name/installed` — best-effort install tally → trending
  - `POST /v1/packages/:handle/:name/star`
  - `GET /v1/activity` — live feed (publish / update / star / milestone; raw installs excluded so it stays social)
- **`site/src/pages/skills.astro`** — browse / search / sort, copy install source, a compact publish form, and a live activity feed; plus a home-nav entry.

## Why

`install_source` already installs skills and MCP servers from a URL, file, `.mcp.json`, or package name — but there was no way to *discover* what exists. This is the missing front door, and a stronger daily-return engine for the community (fresh packages, trending, activity) than a quiet forum.

## Design notes

- **Never executes package content.** The registry stores only metadata and a source pointer; installs still run client-side through `install_source` (SSRF-guarded, risk-rated).
- **Identity is delegated.** Publish forwards the caller's cookie/bearer to `id.reasonix.io/me`; the worker never holds `SESSION_PEPPER`. Packages are namespaced to the publisher handle (`@handle/name`).
- **Static-site friendly.** The page client-fetches the registry at runtime (`PUBLIC_REGISTRY_ORIGIN`, default `registry.reasonix.io`), degrading to a "launching soon" state when the worker is unreachable and a "be the first to publish" state on an empty registry.

## Verified

- `workers/registry`: `npm run typecheck` clean; end-to-end smoke test against a local D1 (list / sort / trending, activity feed, seed data).
- `site`: `astro build` clean; `/skills/` renders; responsive down to mobile.

## Deploy (owner-gated — not automated)

First deploy needs Cloudflare account actions, same shape as `workers/accounts`:

```
cd workers/registry
wrangler d1 create reasonix-registry          # paste the id into wrangler.toml
wrangler d1 migrations apply reasonix-registry --remote
# add DNS: registry.reasonix.io (custom_domain)
wrangler deploy
```

Requires a CF API token with Workers Scripts + D1 + Workers Routes (same pending scope question as #5679). The registry launches empty; nothing here touches production data.
