### PR TITLE
feat(registry): moderate submissions before they go live

### DIFF
--- a/site/src/pages/skills.astro
+++ b/site/src/pages/skills.astro
@@ -90,7 +90,7 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
         <div class="pub-head">
           <div>
             <h3><span class="l-en">Publish a package</span><span class="l-zh">发布一个包</span></h3>
-            <p><span class="l-en">Signed-in publishers only. Your package is namespaced to your handle: <code>@you/name</code>.</span><span class="l-zh">仅登录用户可发布。包会以你的 handle 命名:<code>@you/name</code>。</span></p>
+            <p><span class="l-en">Verified accounts only. Submissions are reviewed before they go live; your package is namespaced to your handle (<code>@you/name</code>).</span><span class="l-zh">仅已验证邮箱的账号可提交。提交后经管理员审核才会公开;包以你的 handle 命名(<code>@you/name</code>)。</span></p>
           </div>
           <button type="button" class="pub-close" id="publish-close" aria-label="Close">✕</button>
         </div>
@@ -421,7 +421,10 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
         const data = await r.json().catch(() => ({}));
         if (r.status === 401) { setMsg('Sign in at id.reasonix.io to publish.', 'err'); return; }
         if (!r.ok) { setMsg(data?.error?.message || 'Publish failed.', 'err'); return; }
-        setMsg(`Published ${data.package.slug}@${data.version}.`, 'ok');
+        const pending = data.package?.status === 'pending';
+        setMsg(pending
+          ? `Submitted ${data.package.slug} for review — an admin approves it before it goes live.`
+          : `Published ${data.package.slug}@${data.version}.`, 'ok');
         ev.target.reset();
         loadPackages(); loadFeed();
       } catch { setMsg('Registry is unreachable right now.', 'err'); }

--- a/workers/registry/seed.sql
+++ b/workers/registry/seed.sql
@@ -30,3 +30,9 @@ INSERT INTO events (type, package_id, actor_handle, summary, created_at) VALUES
 INSERT INTO events (type, package_id, actor_handle, summary, created_at)
   SELECT 'install', p.id, '', 'installed ' || p.slug, datetime('now','-' || (abs(random()) % 6) || ' days')
   FROM packages p, (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5);
+
+-- a pending submission (moderation): must stay out of the public list/detail until approved
+INSERT INTO packages
+  (kind, scope_handle, name, slug, summary, source, install_kind, tags, latest_version, status, publisher_id, created_at, updated_at)
+VALUES
+  ('skill','newbie','untested-skill','newbie/untested-skill','A freshly submitted skill awaiting review','https://example.com/untested/SKILL.md','skill','experimental','0.1.0','pending',9,datetime('now','-20 minutes'),datetime('now','-20 minutes'));

--- a/workers/registry/src/app.ts
+++ b/workers/registry/src/app.ts
@@ -5,6 +5,7 @@ import { errorHandler, notFoundHandler } from "./http/errors";
 import health from "./routes/health";
 import packages from "./routes/packages";
 import activity from "./routes/activity";
+import admin from "./routes/admin";
 
 const app = new Hono<AppEnv>();
 
@@ -16,5 +17,6 @@ app.use("*", corsMiddleware);
 app.route("/", health);
 app.route("/v1/packages", packages);
 app.route("/v1/activity", activity);
+app.route("/v1/admin", admin);
 
 export default app;

--- a/workers/registry/src/db/packages.ts
+++ b/workers/registry/src/db/packages.ts
@@ -77,8 +77,10 @@ export class PackageRepo {
     return res.results ?? [];
   }
 
-  // Create a new package or append a version to an owned one. Republishing an
-  // existing version is refused (409) so version history stays immutable.
+  // Create a new package or append a version to an owned one. New packages from
+  // non-admins land as 'pending' (hidden until an admin approves); versions of an
+  // already-approved package stay live. Republishing an existing version is
+  // refused (409) so version history stays immutable.
   async publish(user: RegistryUser, input: PublishInput, now: string): Promise<PublishResult> {
     const slug = `${user.handle}/${input.name}`;
     const existing = await this.bySlug(slug);
@@ -114,12 +116,13 @@ export class PackageRepo {
     }
 
     const version = input.version || "0.1.0";
+    const status = user.role === "admin" ? "active" : "pending";
     const inserted = await this.db
       .prepare(
         `INSERT INTO packages
            (kind, scope_handle, name, slug, summary, description, source, install_kind,
-            homepage, repo_url, tags, latest_version, publisher_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
+            homepage, repo_url, tags, latest_version, status, publisher_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
          RETURNING id`,
       )
       .bind(
@@ -135,6 +138,7 @@ export class PackageRepo {
         input.repoUrl,
         input.tags.join(","),
         version,
+        status,
         user.id,
         now,
       )
@@ -192,6 +196,35 @@ export class PackageRepo {
       .bind(pkg.id)
       .run();
     return { starred: false, count: Math.max(0, pkg.star_count - 1) };
+  }
+
+  // Admin: packages awaiting (or past) review, newest first.
+  async listByStatus(status: string, limit: number): Promise<PackageRow[]> {
+    const res = await this.db
+      .prepare("SELECT * FROM packages WHERE status = ?1 ORDER BY created_at DESC LIMIT ?2")
+      .bind(status, limit)
+      .all<PackageRow>();
+    return res.results ?? [];
+  }
+
+  // Admin: move a package between statuses (approve → active, reject, hide).
+  async setStatus(slug: string, status: string, now: string): Promise<PackageRow | null> {
+    const res = await this.db
+      .prepare("UPDATE packages SET status = ?1, updated_at = ?2 WHERE slug = ?3")
+      .bind(status, now, slug)
+      .run();
+    if ((res.meta.changes ?? 0) === 0) return null;
+    return this.bySlug(slug);
+  }
+
+  // Admin: grant or revoke the verified trust badge.
+  async setVerified(slug: string, verified: boolean, now: string): Promise<PackageRow | null> {
+    const res = await this.db
+      .prepare("UPDATE packages SET verified = ?1, updated_at = ?2 WHERE slug = ?3")
+      .bind(verified ? 1 : 0, now, slug)
+      .run();
+    if ((res.meta.changes ?? 0) === 0) return null;
+    return this.bySlug(slug);
   }
 }
 

--- a/workers/registry/src/http/auth.ts
+++ b/workers/registry/src/http/auth.ts
@@ -17,10 +17,17 @@ async function fetchAccountUser(c: Context<AppEnv>): Promise<RegistryUser | null
 
   const res = await fetch(`${c.env.ACCOUNTS_ORIGIN}/me`, { headers });
   if (!res.ok) return null;
-  const body = (await res.json()) as { user?: { id?: number; handle?: string; role?: string } };
+  const body = (await res.json()) as {
+    user?: { id?: number; handle?: string; role?: string; emailVerified?: boolean };
+  };
   const u = body.user;
   if (!u || typeof u.id !== "number" || typeof u.handle !== "string") return null;
-  return { id: u.id, handle: u.handle, role: u.role === "admin" ? "admin" : "member" };
+  return {
+    id: u.id,
+    handle: u.handle,
+    role: u.role === "admin" ? "admin" : "member",
+    emailVerified: u.emailVerified === true,
+  };
 }
 
 // Gate for write routes. Public reads never call this, so list/detail never pay
@@ -28,6 +35,15 @@ async function fetchAccountUser(c: Context<AppEnv>): Promise<RegistryUser | null
 export const requireAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   const user = await fetchAccountUser(c).catch(() => null);
   if (!user) throw new ApiError(401, "unauthorized", "Sign in at id.reasonix.io to publish.");
+  c.set("user", user);
+  await next();
+};
+
+// Gate for moderation routes: a resolved account with the admin role.
+export const requireAdmin: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const user = await fetchAccountUser(c).catch(() => null);
+  if (!user) throw new ApiError(401, "unauthorized", "Sign in at id.reasonix.io.");
+  if (user.role !== "admin") throw new ApiError(403, "forbidden", "Admins only.");
   c.set("user", user);
   await next();
 };

--- a/workers/registry/src/routes/admin.ts
+++ b/workers/registry/src/routes/admin.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { toPackageDTO } from "../types";
+import { repos } from "../db";
+import { requireAdmin } from "../http/auth";
+import { writeRateLimit } from "../http/ratelimit";
+import { ApiError } from "../http/errors";
+
+const admin = new Hono<AppEnv>();
+
+const now = () => new Date().toISOString();
+
+admin.use("*", requireAdmin);
+
+// Review queue. ?status defaults to pending; also accepts rejected/hidden/active.
+admin.get("/packages", async (c) => {
+  const status = new URL(c.req.url).searchParams.get("status") || "pending";
+  const rows = await repos(c.env).packages.listByStatus(status, 200);
+  return c.json({ packages: rows.map(toPackageDTO) });
+});
+
+// Approve a pending package → live. Its publish event is emitted here (on first
+// approval), so the activity feed only ever announces public packages.
+admin.post("/packages/:handle/:name/approve", writeRateLimit, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const { packages: repo, events } = repos(c.env);
+  const before = await repo.bySlug(slug);
+  if (!before) throw new ApiError(404, "not_found", "No such package.");
+  const row = await repo.setStatus(slug, "active", now());
+  if (!row) throw new ApiError(404, "not_found", "No such package.");
+  if (before.status !== "active") {
+    await events.log({
+      type: "publish",
+      packageId: row.id,
+      actorHandle: row.scope_handle,
+      summary: `published ${row.slug}@${row.latest_version}`,
+      now: now(),
+    });
+  }
+  return c.json({ package: toPackageDTO(row) });
+});
+
+admin.post("/packages/:handle/:name/reject", writeRateLimit, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const row = await repos(c.env).packages.setStatus(slug, "rejected", now());
+  if (!row) throw new ApiError(404, "not_found", "No such package.");
+  return c.json({ package: toPackageDTO(row) });
+});
+
+// Take a previously-approved package back down.
+admin.post("/packages/:handle/:name/hide", writeRateLimit, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const row = await repos(c.env).packages.setStatus(slug, "hidden", now());
+  if (!row) throw new ApiError(404, "not_found", "No such package.");
+  return c.json({ package: toPackageDTO(row) });
+});
+
+// Grant or revoke the verified badge. Body {verified:false} revokes; default grants.
+admin.post("/packages/:handle/:name/verify", writeRateLimit, async (c) => {
+  const slug = `${c.req.param("handle")}/${c.req.param("name")}`;
+  const body = (await c.req.json().catch(() => ({}))) as { verified?: boolean };
+  const row = await repos(c.env).packages.setVerified(slug, body.verified !== false, now());
+  if (!row) throw new ApiError(404, "not_found", "No such package.");
+  return c.json({ package: toPackageDTO(row) });
+});
+
+export default admin;

--- a/workers/registry/src/routes/packages.ts
+++ b/workers/registry/src/routes/packages.ts
@@ -32,16 +32,23 @@ packages.get("/:handle/:name", async (c) => {
 
 packages.post("/", writeRateLimit, requireAuth, async (c) => {
   const user = currentUser(c);
+  if (!user.emailVerified) {
+    throw new ApiError(403, "email_unverified", "Verify your email at id.reasonix.io before publishing.");
+  }
   const input = await parseBody(c, PublishSchema);
   const { packages: repo, events } = repos(c.env);
   const { row, created, version } = await repo.publish(user, input, now());
-  await events.log({
-    type: created ? "publish" : "update",
-    packageId: row.id,
-    actorHandle: user.handle,
-    summary: `${created ? "published" : "updated"} ${row.slug}@${version}`,
-    now: now(),
-  });
+  // Announce only what is public. A pending submission waits for an admin to
+  // approve it before it surfaces in the feed or the listing.
+  if (row.status === "active") {
+    await events.log({
+      type: created ? "publish" : "update",
+      packageId: row.id,
+      actorHandle: user.handle,
+      summary: `${created ? "published" : "updated"} ${row.slug}@${version}`,
+      now: now(),
+    });
+  }
   return c.json({ package: toPackageDTO(row), created, version }, created ? 201 : 200);
 });
 

--- a/workers/registry/src/types.ts
+++ b/workers/registry/src/types.ts
@@ -3,6 +3,7 @@ export interface RegistryUser {
   id: number;
   handle: string;
   role: "member" | "admin";
+  emailVerified: boolean;
 }
 
 export type PackageKind = "skill" | "mcp";
@@ -48,6 +49,7 @@ export interface PackageDTO {
   installCount: number;
   starCount: number;
   verified: boolean;
+  status: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -92,6 +94,7 @@ export function toPackageDTO(row: PackageRow): PackageDTO {
     installCount: row.install_count,
     starCount: row.star_count,
     verified: row.verified === 1,
+    status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };


### PR DESCRIPTION
## What

Tightens who can publish to the registry (#5725), moving to a review model.

- **Verified email required** — publishing rejects accounts that haven't confirmed their email.
- **Submissions are moderated** — a non-admin's new package lands as `pending` and stays out of the listing, detail endpoint, and activity feed until an admin approves it. Versions of an already-approved package stay live; admins publish straight to `active`.
- **Admin review endpoints** (`/v1/admin`, admin-role gated):
  - `GET /v1/admin/packages?status=pending` — the review queue
  - `POST /v1/admin/packages/:handle/:name/approve` — publish it (emits the publish event on first approval)
  - `POST .../reject` · `POST .../hide` — reject / take down
  - `POST .../verify` — grant or revoke the verified badge (the column previously had no way to be set)

## Why

Before this, any signed-in account — including one with an unverified email — could publish immediately, with no moderation. For a registry that distributes pointers to *executable* skills / MCP servers, that surface was too open. This gates publishing behind email verification + admin review, while keeping the namespacing and client-side install approval that were already there.

## Verified

- `npm run typecheck` clean; `astro build` clean.
- Local D1 smoke test: a seeded `pending` package is absent from `GET /v1/packages`, its detail returns 404, and `GET /v1/admin/packages` returns 401 without an admin session.

## Notes

- The publish → pending path relies on `id.reasonix.io/me` returning `emailVerified` (it does); the account service stays the sole identity authority.
- No schema migration — `status` already existed; new submissions just default to `pending` in code.
