### PR TITLE
Show unread topic attention dots / 显示未读会话提醒点

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   projectTreeShouldSuppressOpenForRename,
   projectTreeReadActivityKey,
   projectTreeTopicHasUnreadActivity,
+  projectTreeShouldRenderTopicActions,
 } from "../components/ProjectTree";
 import type { ProjectNode } from "../lib/types";
 
@@ -138,6 +139,24 @@ eq(
   projectTreeTopicHasUnreadActivity({ ...completedTopic, status: "streaming", running: true }, { [completedTopicKey]: 1000 }, "project", "/repo", "other-topic"),
   false,
   "running topic keeps runtime status instead of completed-unread attention",
+);
+
+eq(
+  projectTreeShouldRenderTopicActions(false, true, false),
+  true,
+  "read workbench topic renders hover actions",
+);
+
+eq(
+  projectTreeShouldRenderTopicActions(false, true, true),
+  false,
+  "unread workbench topic omits hover actions from the keyboard tab order",
+);
+
+eq(
+  projectTreeShouldRenderTopicActions(true, true, false),
+  false,
+  "runtime session rows do not render topic hover actions",
 );
 
 eq(

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -6,6 +6,8 @@ import {
   activeSessionAncestorKeys,
   projectTreeTopicOpenRequest,
   projectTreeShouldSuppressOpenForRename,
+  projectTreeReadActivityKey,
+  projectTreeTopicHasUnreadActivity,
 } from "../components/ProjectTree";
 import type { ProjectNode } from "../lib/types";
 
@@ -102,6 +104,40 @@ eq(
   }),
   { scope: "project", workspaceRoot: "/repo", topicId: "topic-project", sessionPath: undefined },
   "regular project topic still opens by topic",
+);
+
+const completedTopic: ProjectNode = {
+  key: "topic_complete",
+  kind: "topic",
+  label: "Completed",
+  root: "/repo",
+  topicId: "topic-complete",
+  lastActivityAt: 2000,
+};
+const completedTopicKey = projectTreeReadActivityKey(completedTopic) ?? "";
+
+eq(
+  projectTreeTopicHasUnreadActivity(completedTopic, { [completedTopicKey]: 1000 }, "project", "/repo", "other-topic"),
+  true,
+  "completed inactive topic with newer activity shows unread attention",
+);
+
+eq(
+  projectTreeTopicHasUnreadActivity(completedTopic, { [completedTopicKey]: 2000 }, "project", "/repo", "other-topic"),
+  false,
+  "completed topic stops showing unread attention once opened at its latest activity",
+);
+
+eq(
+  projectTreeTopicHasUnreadActivity(completedTopic, { [completedTopicKey]: 1000 }, "project", "/repo", "topic-complete"),
+  false,
+  "active topic does not show unread attention",
+);
+
+eq(
+  projectTreeTopicHasUnreadActivity({ ...completedTopic, status: "streaming", running: true }, { [completedTopicKey]: 1000 }, "project", "/repo", "other-topic"),
+  false,
+  "running topic keeps runtime status instead of completed-unread attention",
 );
 
 eq(

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -192,6 +192,10 @@ export function projectTreeTopicHasUnreadActivity(
   return Boolean(key && activityAt > 0 && (readActivity[key] ?? 0) < activityAt);
 }
 
+export function projectTreeShouldRenderTopicActions(isSessionNode: boolean, compactTopics: boolean, unread: boolean): boolean {
+  return !isSessionNode && compactTopics && !unread;
+}
+
 function topicActivityLabel(ms: number, t: Translator, compact = false): string {
   if (ms <= 0) return "";
   const delta = Date.now() - ms;
@@ -1292,7 +1296,7 @@ export function ProjectTree({
             )}
           </button>
           {unread && <span className="project-tree__topic-unread-dot" aria-hidden="true" />}
-          {!isSessionNode && compactTopics && (
+          {projectTreeShouldRenderTopicActions(isSessionNode, compactTopics, unread) && (
             <span className="project-tree__topic-actions" aria-label={t("projectTree.topicActions")}>
               <Tooltip label={pinLabel} side="top" className="project-tree__topic-action-slot">
                 <button

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -159,6 +159,39 @@ function topicStatusLabel(node: ProjectNode, t: Translator): string {
   return status ? t(topicStatusLabels[status]) : "";
 }
 
+function topicActivityAt(node: ProjectNode): number {
+  return node.lastActivityAt || node.createdAt || 0;
+}
+
+export function projectTreeReadActivityKey(node: ProjectNode): string | null {
+  const request = projectTreeTopicOpenRequest(node);
+  if (!request?.topicId) return null;
+  return [
+    request.scope,
+    request.workspaceRoot,
+    request.topicId,
+    request.sessionPath ?? "",
+  ].join("\u001f");
+}
+
+type ProjectTreeReadActivity = Record<string, number>;
+
+export function projectTreeTopicHasUnreadActivity(
+  node: ProjectNode,
+  readActivity: ProjectTreeReadActivity,
+  activeScope?: string,
+  activeWorkspaceRoot?: string,
+  activeTopicId?: string,
+  activeSessionPath?: string,
+): boolean {
+  if (!isTopicNode(node) && !isRuntimeSessionNode(node)) return false;
+  if (topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) return false;
+  if (topicStatus(node) !== "") return false;
+  const key = projectTreeReadActivityKey(node);
+  const activityAt = topicActivityAt(node);
+  return Boolean(key && activityAt > 0 && (readActivity[key] ?? 0) < activityAt);
+}
+
 function topicActivityLabel(ms: number, t: Translator, compact = false): string {
   if (ms <= 0) return "";
   const delta = Date.now() - ms;
@@ -226,6 +259,31 @@ type WorkbenchTreeSections = {
 const GLOBAL_PROJECT_ORDER_KEY = "__global__";
 const WORKBENCH_ORGANIZE_KEY = "projectTree:workbenchOrganize";
 const WORKBENCH_SORT_KEY = "projectTree:workbenchSort";
+const READ_ACTIVITY_KEY = "projectTree:readActivity";
+const READ_ACTIVITY_INIT_KEY = "projectTree:readActivityInitialized";
+
+function loadReadActivity(): ProjectTreeReadActivity {
+  try {
+    const raw = localStorage.getItem(READ_ACTIVITY_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const out: ProjectTreeReadActivity = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function saveReadActivity(readActivity: ProjectTreeReadActivity) {
+  try {
+    localStorage.setItem(READ_ACTIVITY_KEY, JSON.stringify(readActivity));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
 
 function loadWorkbenchOrganizeMode(): WorkbenchOrganizeMode {
   try {
@@ -497,6 +555,7 @@ export function ProjectTree({
   const [workbenchHeaderMenu, setWorkbenchHeaderMenu] = useState<WorkbenchHeaderMenu>(null);
   const [workbenchOrganizeMode, setWorkbenchOrganizeMode] = useState<WorkbenchOrganizeMode>(loadWorkbenchOrganizeMode);
   const [workbenchSortMode, setWorkbenchSortMode] = useState<WorkbenchSortMode>(loadWorkbenchSortMode);
+  const [readActivity, setReadActivity] = useState<ProjectTreeReadActivity>(loadReadActivity);
   const filterRef = useRef<HTMLDivElement>(null);
   const filterTriggerRef = useRef<HTMLButtonElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -561,6 +620,67 @@ export function ProjectTree({
   useEffect(() => {
     void refresh();
   }, [refresh, refreshSignal]);
+
+  const markNodeRead = useCallback((node: ProjectNode) => {
+    const key = projectTreeReadActivityKey(node);
+    const activityAt = topicActivityAt(node);
+    if (!key || activityAt <= 0) return;
+    setReadActivity((prev) => {
+      if ((prev[key] ?? 0) >= activityAt) return prev;
+      const next = { ...prev, [key]: activityAt };
+      saveReadActivity(next);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (tree.length === 0) return;
+    try {
+      if (localStorage.getItem(READ_ACTIVITY_INIT_KEY)) return;
+    } catch {
+      return;
+    }
+    const baseline: ProjectTreeReadActivity = {};
+    const collectBaseline = (nodes: ProjectNode[]) => {
+      for (const node of nodes) {
+        if ((isTopicNode(node) || isRuntimeSessionNode(node)) && topicStatus(node) === "") {
+          const key = projectTreeReadActivityKey(node);
+          const activityAt = topicActivityAt(node);
+          if (key && activityAt > 0) baseline[key] = Math.max(baseline[key] ?? 0, activityAt);
+        }
+        collectBaseline(asArray(node.children));
+      }
+    };
+    collectBaseline(tree);
+    try {
+      localStorage.setItem(READ_ACTIVITY_INIT_KEY, "1");
+    } catch {
+      /* localStorage unavailable */
+    }
+    if (Object.keys(baseline).length === 0) return;
+    setReadActivity((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const [key, value] of Object.entries(baseline)) {
+        if ((next[key] ?? 0) >= value) continue;
+        next[key] = value;
+        changed = true;
+      }
+      if (!changed) return prev;
+      saveReadActivity(next);
+      return next;
+    });
+  }, [tree]);
+
+  useEffect(() => {
+    const markActive = (nodes: ProjectNode[]) => {
+      for (const node of nodes) {
+        if (topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) markNodeRead(node);
+        markActive(asArray(node.children));
+      }
+    };
+    markActive(tree);
+  }, [activeScope, activeSessionPath, activeTopicId, activeWorkspaceRoot, markNodeRead, tree]);
 
   useEffect(() => {
     try {
@@ -1010,6 +1130,7 @@ export function ProjectTree({
       const status = topicStatus(node);
       const statusLabel = topicStatusLabel(node, t);
       const showStatusInSide = status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job";
+      const unread = projectTreeTopicHasUnreadActivity(node, readActivity, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
       const topicId = node.topicId ?? "";
       const imSource = scope === "global" && topicId ? imTopicSources[topicId] : undefined;
       const imSourceLabel = imSource?.label || "";
@@ -1092,7 +1213,7 @@ export function ProjectTree({
       }
       const row = (
         <div
-          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${sideTimeVisible && (timeLabel || showStatusInSide) ? " project-tree__topic--with-side" : meta ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
+          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${unread ? " project-tree__topic--unread" : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${sideTimeVisible && (timeLabel || showStatusInSide) ? " project-tree__topic--with-side" : meta ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
           style={accentStyle}
           onContextMenu={isSessionNode ? undefined : openTopicMenu}
         >
@@ -1112,6 +1233,7 @@ export function ProjectTree({
               }
               const timer = setTimeout(() => {
                 if (clickTimerRef.current?.timer === timer) clickTimerRef.current = null;
+                markNodeRead(node);
                 onOpenTopic(openRequest.scope, openRequest.workspaceRoot, openRequest.topicId, openRequest.sessionPath);
               }, 200);
               clickTimerRef.current = { ...nextClick, timer };
@@ -1169,6 +1291,7 @@ export function ProjectTree({
               </span>
             )}
           </button>
+          {unread && <span className="project-tree__topic-unread-dot" aria-hidden="true" />}
           {!isSessionNode && compactTopics && (
             <span className="project-tree__topic-actions" aria-label={t("projectTree.topicActions")}>
               <Tooltip label={pinLabel} side="top" className="project-tree__topic-action-slot">

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24224,12 +24224,6 @@ body > .mermaid-diagram--fullscreen {
   transform: translateY(-50%) translateX(0);
 }
 
-.sidebar--workbench .project-tree__topic--unread:hover .project-tree__topic-actions,
-.sidebar--workbench .project-tree__topic--unread:focus-within .project-tree__topic-actions {
-  opacity: 0;
-  pointer-events: none;
-}
-
 .sidebar--workbench .project-tree__topic:hover .project-tree__topic-side,
 .sidebar--workbench .project-tree__topic:focus-within .project-tree__topic-side,
 .sidebar--workbench .project-tree__topic--menu-open .project-tree__topic-side,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24156,6 +24156,28 @@ body > .mermaid-diagram--fullscreen {
   opacity: 0.78;
 }
 
+.sidebar--workbench .project-tree__topic-unread-dot,
+.app--creation .project-tree__topic-unread-dot {
+  position: absolute;
+  top: 50%;
+  right: 18px;
+  z-index: var(--z-local-raised);
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border-radius: 999px;
+  background: var(--accent-blue, #2f8cff);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue, #2f8cff) 16%, transparent);
+  opacity: 1;
+  pointer-events: none;
+  transform: translateY(-50%) scale(1);
+  transition: opacity var(--dur-fast), transform var(--dur-fast);
+}
+
+.app--creation .project-tree__topic-unread-dot {
+  right: 10px;
+}
+
 .sidebar--workbench .project-tree__topic-state--thinking,
 .sidebar--workbench .project-tree__topic-state--streaming {
   border: 2px solid color-mix(in srgb, currentColor 26%, transparent);
@@ -24202,11 +24224,24 @@ body > .mermaid-diagram--fullscreen {
   transform: translateY(-50%) translateX(0);
 }
 
+.sidebar--workbench .project-tree__topic--unread:hover .project-tree__topic-actions,
+.sidebar--workbench .project-tree__topic--unread:focus-within .project-tree__topic-actions {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .sidebar--workbench .project-tree__topic:hover .project-tree__topic-side,
 .sidebar--workbench .project-tree__topic:focus-within .project-tree__topic-side,
-.sidebar--workbench .project-tree__topic--menu-open .project-tree__topic-side {
+.sidebar--workbench .project-tree__topic--menu-open .project-tree__topic-side,
+.sidebar--workbench .project-tree__topic--unread .project-tree__topic-side {
   opacity: 0;
   transform: translateX(-3px);
+}
+
+.app--creation .project-tree__topic--unread .project-tree__topic-side,
+.app--creation .project-tree__topic--unread:hover .project-tree__topic-side,
+.app--creation .project-tree__topic--unread:focus-within .project-tree__topic-side {
+  opacity: 0;
 }
 
 .sidebar--workbench .project-tree__topic-action-slot {
@@ -26021,6 +26056,7 @@ body > .mermaid-diagram--fullscreen {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 6px;
   min-width: 38px;
   color: color-mix(in srgb, var(--fg-faint) 76%, transparent);
   font-size: 11px;


### PR DESCRIPTION
## Summary
- Track read activity for project-tree topics locally and mark opened or active topics as read.
- Show a persistent blue attention dot for completed inactive topics with newer activity, while keeping runtime statuses separate.
- Keep unread rows from showing pin/archive hover actions until the topic is opened, and add regression coverage for the unread rules.

## Verification
- `pnpm --dir desktop/frontend run check:css`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/project-tree-runtime.test.ts`
- `pnpm --dir desktop/frontend exec tsc --noEmit`
- Browser preview verified the unread dot remains visible without hover and clears after opening the topic.
