### PR TITLE
Fix stalled bash cancel waits / 修复 bash 取消后等待卡死

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -167,7 +167,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			cmd.WaitDelay = bashWaitDelay
 			cmd.Stdout = out
 			cmd.Stderr = out
-			tracked, runErr := runShellProcess(cmd, shouldTrackShellProcess(sh, p.Command, p.PreserveBackgroundProcesses))
+			tracked, runErr := runShellProcess(jobCtx, cmd, shouldTrackShellProcess(sh, p.Command, p.PreserveBackgroundProcesses))
 			if shouldReapAfterRun(jobCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
 				reapShellProcess(cmd, tracked) // reap process-group stragglers the job left running (#3702)
 			}
@@ -195,7 +195,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	}
 	cmd.Stdout = w
 	cmd.Stderr = w
-	tracked, err := runShellProcess(cmd, shouldTrackShellProcess(sh, p.Command, p.PreserveBackgroundProcesses))
+	tracked, err := runShellProcess(runCtx, cmd, shouldTrackShellProcess(sh, p.Command, p.PreserveBackgroundProcesses))
 	// A foreground command that spawned a lingering child (e.g. `bazel run`'s
 	// server) leaves it in the process group; Wait only reaped the shell leader.
 	// Kill the group so those don't accumulate into an OOM (#3702). On cancel/
@@ -267,7 +267,7 @@ func shouldTrackShellProcess(sh sandbox.Shell, command string, preserveBackgroun
 	return sh.Kind != sandbox.ShellBash || !hasExplicitBackgroundKeepalive(command)
 }
 
-func runShellProcess(cmd *exec.Cmd, track bool) (*trackedShellProcess, error) {
+func runShellProcess(ctx context.Context, cmd *exec.Cmd, track bool) (*trackedShellProcess, error) {
 	if !track {
 		setKillTree(cmd)
 		return nil, cmd.Run()
@@ -283,7 +283,28 @@ func runShellProcess(cmd *exec.Cmd, track bool) (*trackedShellProcess, error) {
 		return tracked, err
 	}
 	tracked.setJob(job)
-	return tracked, cmd.Wait()
+	return tracked, waitForTrackedShellProcess(ctx, tracked, cmd.Wait, bashWaitDelay+time.Second)
+}
+
+func waitForTrackedShellProcess(ctx context.Context, tracked *trackedShellProcess, wait func() error, grace time.Duration) error {
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- wait() }()
+
+	select {
+	case err := <-waitCh:
+		return err
+	case <-ctx.Done():
+	}
+
+	tracked.kill()
+	// If the shell's Wait path is wedged on a held pipe or a platform-specific
+	// process-tree edge, do not keep the foreground turn hostage after Stop.
+	select {
+	case <-waitCh:
+		return context.Cause(ctx)
+	case <-time.After(grace):
+		return context.Cause(ctx)
+	}
 }
 
 func reapShellProcess(cmd *exec.Cmd, tracked *trackedShellProcess) {

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -300,11 +300,39 @@ func waitForTrackedShellProcess(ctx context.Context, tracked *trackedShellProces
 	// If the shell's Wait path is wedged on a held pipe or a platform-specific
 	// process-tree edge, do not keep the foreground turn hostage after Stop.
 	select {
-	case <-waitCh:
-		return context.Cause(ctx)
+	case err := <-waitCh:
+		return canceledShellWaitError{cause: context.Cause(ctx), waitErr: err}
 	case <-time.After(grace):
 		return context.Cause(ctx)
 	}
+}
+
+type canceledShellWaitError struct {
+	cause   error
+	waitErr error
+}
+
+func (e canceledShellWaitError) Error() string {
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	if e.waitErr != nil {
+		return e.waitErr.Error()
+	}
+	return "shell wait canceled"
+}
+
+func (e canceledShellWaitError) Unwrap() []error {
+	if e.cause != nil && e.waitErr != nil {
+		return []error{e.cause, e.waitErr}
+	}
+	if e.cause != nil {
+		return []error{e.cause}
+	}
+	if e.waitErr != nil {
+		return []error{e.waitErr}
+	}
+	return nil
 }
 
 func reapShellProcess(cmd *exec.Cmd, tracked *trackedShellProcess) {

--- a/internal/tool/builtin/bash_timeout_test.go
+++ b/internal/tool/builtin/bash_timeout_test.go
@@ -76,6 +76,31 @@ func TestNormalizeBashRunErrorAllowsPreservedWaitDelay(t *testing.T) {
 	}
 }
 
+func TestWaitForTrackedShellProcessReturnsWhenWaitStallsAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tracked := &trackedShellProcess{}
+	releaseWait := make(chan struct{})
+	defer close(releaseWait)
+
+	start := time.Now()
+	err := waitForTrackedShellProcess(ctx, tracked, func() error {
+		<-releaseWait
+		return nil
+	}, 20*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("cancelled stalled wait returned too slowly: %v", elapsed)
+	}
+	if !tracked.killed {
+		t.Fatal("tracked process was not marked killed")
+	}
+}
+
 func longSleepCommand(sh sandbox.Shell) string {
 	if sh.Kind == sandbox.ShellPowerShell {
 		return "Start-Sleep -Seconds 2"

--- a/internal/tool/builtin/bash_timeout_test.go
+++ b/internal/tool/builtin/bash_timeout_test.go
@@ -101,6 +101,62 @@ func TestWaitForTrackedShellProcessReturnsWhenWaitStallsAfterCancel(t *testing.T
 	}
 }
 
+func TestWaitForTrackedShellProcessKeepsWaitErrorAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	tracked := &trackedShellProcess{}
+	waitStarted := make(chan struct{})
+	releaseWait := make(chan struct{})
+	errWait := errors.New("wait failed after cancel")
+	done := make(chan error, 1)
+
+	go func() {
+		done <- waitForTrackedShellProcess(ctx, tracked, func() error {
+			close(waitStarted)
+			<-releaseWait
+			return errWait
+		}, time.Second)
+	}()
+
+	<-waitStarted
+	cancel()
+	waitUntilTrackedShellKilled(t, tracked)
+	close(releaseWait)
+
+	select {
+	case err := <-done:
+		if err.Error() != context.Canceled.Error() {
+			t.Fatalf("error text = %q, want %q", err.Error(), context.Canceled.Error())
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+		if !errors.Is(err, errWait) {
+			t.Fatalf("error = %v, want wrapped wait error %v", err, errWait)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cancelled shell wait")
+	}
+}
+
+func waitUntilTrackedShellKilled(t *testing.T, tracked *trackedShellProcess) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		tracked.mu.Lock()
+		killed := tracked.killed
+		tracked.mu.Unlock()
+		if killed {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for tracked shell kill")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
 func longSleepCommand(sh sandbox.Shell) string {
 	if sh.Kind == sandbox.ShellPowerShell {
 		return "Start-Sleep -Seconds 2"


### PR DESCRIPTION
## Summary
- Pass the active context into tracked bash process waiting.
- Kill the tracked process tree again on cancellation and bound the post-cancel `Wait` grace period.
- Preserve the underlying `Wait` error for debugging while keeping cancellation/timeout as the user-facing error.
- Add regression tests for a stalled `Wait` after cancellation and for preserving the post-cancel `Wait` error.

## Why
Some stop/cancel reports can leave the foreground turn waiting even after the child process tree has been killed. A likely failure mode is `cmd.Wait()` staying wedged on a held pipe or a platform-specific process-tree edge, so the UI never gets completion back and the user has to restart.

## Verification
- `git diff --check`
- Not run locally: `go test ./internal/tool/builtin ./internal/proc` because this local environment does not have `go`/`gofmt` installed.
- GitHub Actions will run CI/CodeQL on the updated PR head.

## Cache
Cache-impact: low - touches the builtin bash execution path, but does not change provider-visible tool names, descriptions, schemas, ordering, prompt construction, or request serialization.
Cache-guard: Existing guard rationale: the diff only changes post-cancel process waiting behavior and regression tests; CI covers gofmt, vet, lint, race, and platform tests.