### PR TITLE
fix: 工作区面板展开状态在重启后自动收起

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -129,6 +129,7 @@ import {
   saveRightDockTreeWidth,
   saveSidebarCollapsed,
   saveSidebarWidth,
+  saveWorkspacePanelOpen,
   useLayoutStore,
 } from "./store/layout";
 import { useOverlayStore } from "./store/overlays";
@@ -2015,6 +2016,7 @@ export default function App() {
         return;
       }
       setWorkspacePanelOpen(true);
+      saveWorkspacePanelOpen(true);
     },
     [closeTransientOverlays, rightDockMode, workspacePanelMaximized, workspacePanelOpen],
   );
@@ -2027,6 +2029,7 @@ export default function App() {
     setLiveWorkspacePanelRenderWidth(null);
     setWorkspacePanelMaximized(false);
     setWorkspacePanelOpen(false);
+    saveWorkspacePanelOpen(false);
   }, [closeTransientOverlays, workspacePanelOpen]);
 
   const toggleWorkspacePanel = useCallback(() => {

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -33,6 +33,7 @@ export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 export const RIGHT_DOCK_MAX_WIDTH = 860;
 const WORKSPACE_PANEL_DEFAULT_OPEN = false;
+const WORKSPACE_PANEL_OPEN_KEY = "reasonix.workspacePanel.open";
 
 export function clampSidebarWidth(width: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
@@ -78,6 +79,24 @@ export function saveSidebarCollapsed(collapsed: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+function loadWorkspacePanelOpen(): boolean {
+  if (typeof window === "undefined") return WORKSPACE_PANEL_DEFAULT_OPEN;
+  try {
+    return window.localStorage.getItem(WORKSPACE_PANEL_OPEN_KEY) === "1";
+  } catch {
+    return WORKSPACE_PANEL_DEFAULT_OPEN;
+  }
+}
+
+export function saveWorkspacePanelOpen(open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WORKSPACE_PANEL_OPEN_KEY, open ? "1" : "0");
   } catch {
     /* ignore storage failures */
   }
@@ -140,7 +159,7 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarWidth: loadSidebarWidth(),
   rightDockTreeWidth: loadRightDockTreeWidth(),
   rightDockPreviewWidth: loadRightDockPreviewWidth(),
-  workspacePanelOpen: WORKSPACE_PANEL_DEFAULT_OPEN,
+  workspacePanelOpen: loadWorkspacePanelOpen(),
   workspacePanelMaximized: false,
   workspacePreviewActive: false,
   rightDockMode: "context",


### PR DESCRIPTION
## 问题

桌面端工作区面板（右侧预览/文件树）的展开/收起状态不会持久化。每次展开工作区后退出应用，下次启动工作区又自动收起。

## 原因

侧边栏 (`sidebarCollapsed`) 通过 localStorage 持久化，但工作区面板 (`workspacePanelOpen`) 的初始值硬编码为 `false`，从未写入 localStorage。

## 修复

| 文件 | 改动 |
|------|------|
| `desktop/frontend/src/store/layout.ts` | 新增 `loadWorkspacePanelOpen()` / `saveWorkspacePanelOpen()`，初始值从 localStorage 读取 |
| `desktop/frontend/src/App.tsx` | `openWorkspacePanel` 展开时写入 `true`，`closeWorkspacePanel` 收起时写入 `false` |

存储 key：`reasonix.workspacePanel.open`

## 测试

- `wails build` 编译通过
- TypeScript 类型检查通过
- 逻辑与 `sidebarCollapsed` 持久化模式一致