### PR TITLE
fix: 工作区面板展开状态重启后自动收起

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2065,10 +2065,10 @@ export default function App() {
       ({
         "--sidebar-expanded-width": `${sidebarRenderWidth}px`,
         "--chat-min-width": `${chatReservedWidth}px`,
-        "--workspace-width": `${workspacePanelRenderWidth}px`,
+        "--workspace-width": workspacePanelOpen ? `${workspacePanelRenderWidth}px` : "0px",
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
       }) as CSSProperties,
-    [chatReservedWidth, sidebarRenderWidth, workspacePanelRenderWidth],
+    [chatReservedWidth, sidebarRenderWidth, workspacePanelOpen, workspacePanelRenderWidth],
   );
 
   const setWorkspacePanel = useCallback((open: boolean) => {
@@ -3513,13 +3513,13 @@ export default function App() {
           />
         )}
 
-        {workspacePanelRenderable && (
-          <aside
-            className={[
-              "workbench-dock",
-              `workbench-dock--${rightDockMode}`,
-            ].join(" ")}
-            aria-label={t("rightDock.workbench")}
+        <aside
+          className={[
+            "workbench-dock",
+            `workbench-dock--${rightDockMode}`,
+            !workspacePanelRenderable ? "workbench-dock--collapsed" : "",
+          ].filter(Boolean).join(" ")}
+          aria-label={t("rightDock.workbench")}
           >
             <div className="workbench-dock__tools">
               <div className="workbench-dock__tabs" role="tablist" aria-label={t("rightDock.views")}>
@@ -3595,7 +3595,6 @@ export default function App() {
               )}
             </div>
           </aside>
-        )}
       </div>
 
       {histView !== null && (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -997,6 +997,12 @@ export default function App() {
 
   // Persist window geometry across launches.
   useWindowStatePersistence();
+  // Restore workspace panel state from previous session.
+  useEffect(() => {
+    app.LoadLayoutState().then((s) => {
+      if (s?.workspacePanelOpen) setWorkspacePanelOpen(true);
+    }).catch(() => {});
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   useViewportHeightVar();
   useEffect(() => {
     document.documentElement.setAttribute("data-platform", desktopPlatform);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -110,6 +110,10 @@ interface DesktopWindowState {
   maximised: boolean;
 }
 
+interface DesktopLayoutState {
+  workspacePanelOpen: boolean;
+}
+
 // AppBindings is the hand-written contract between the React app and the Go
 // kernel. It uses local types (types.ts) so components don't import generated
 // model classes. _CheckGeneratedBindings catches drift: when a Go method is
@@ -263,6 +267,8 @@ export interface AppBindings {
   SaveDoc(path: string, body: string): Promise<string>;
   SaveDocForTab(tabID: string, path: string, body: string): Promise<string>;
   DesktopStartupSettings(): Promise<DesktopStartupSettingsView>;
+  LoadLayoutState(): Promise<DesktopLayoutState>;
+  SaveLayoutState(state: DesktopLayoutState): Promise<void>;
   Settings(): Promise<SettingsView>;
   HooksSettings(scope: string): Promise<HooksSettingsView>;
   SaveHooksSettings(scope: string, hooks: HookConfigView[]): Promise<void>;
@@ -3189,6 +3195,12 @@ function makeMockApp(): AppBindings {
     },
     async SaveWindowState(_state) {
       // no-op in browser dev — no real window geometry to persist
+    },
+    async LoadLayoutState() {
+      return { workspacePanelOpen: false };
+    },
+    async SaveLayoutState(_state) {
+      // no-op in browser dev — no real layout state to persist
     },
     async ContextPanel(_tabID: string) {
       const now = Date.now();

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -33,6 +33,7 @@ export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 export const RIGHT_DOCK_MAX_WIDTH = 860;
 const WORKSPACE_PANEL_DEFAULT_OPEN = false;
+const WORKSPACE_PANEL_OPEN_KEY = "reasonix.workspacePanel.open";
 
 export function clampSidebarWidth(width: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
@@ -80,6 +81,28 @@ export function saveSidebarCollapsed(collapsed: boolean): void {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
   } catch {
     /* ignore storage failures */
+  }
+}
+
+function loadWorkspacePanelOpen(): boolean {
+  if (typeof window === "undefined") return WORKSPACE_PANEL_DEFAULT_OPEN;
+  try {
+    return window.localStorage.getItem(WORKSPACE_PANEL_OPEN_KEY) === "1";
+  } catch {
+    return WORKSPACE_PANEL_DEFAULT_OPEN;
+  }
+}
+
+export async function persistWorkspacePanelOpen(open: boolean): Promise<void> {
+  if (typeof window === "undefined") return;
+  // Best-effort localStorage fallback for fast subsequent loads, plus Go backend
+  // for durable cross-session persistence.
+  try { window.localStorage.setItem(WORKSPACE_PANEL_OPEN_KEY, open ? "1" : "0"); } catch { /* ok */ }
+  try {
+    const { app } = await import("../lib/bridge");
+    await app.SaveLayoutState({ workspacePanelOpen: open });
+  } catch {
+    /* bridge not ready yet — the subscribe will retry on next change */
   }
 }
 
@@ -140,7 +163,7 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarWidth: loadSidebarWidth(),
   rightDockTreeWidth: loadRightDockTreeWidth(),
   rightDockPreviewWidth: loadRightDockPreviewWidth(),
-  workspacePanelOpen: WORKSPACE_PANEL_DEFAULT_OPEN,
+  workspacePanelOpen: loadWorkspacePanelOpen(),
   workspacePanelMaximized: false,
   workspacePreviewActive: false,
   rightDockMode: "context",
@@ -153,3 +176,12 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   setWorkspacePreviewActive: (update) => set((s) => ({ workspacePreviewActive: applySetState(s.workspacePreviewActive, update) })),
   setRightDockMode: (update) => set((s) => ({ rightDockMode: applySetState(s.rightDockMode, update) })),
 }));
+
+// Auto-persist workspacePanelOpen — subscribe catches changes from every code path.
+if (typeof window !== "undefined") {
+  useLayoutStore.subscribe((state, prev) => {
+    if (state.workspacePanelOpen !== prev.workspacePanelOpen) {
+      persistWorkspacePanelOpen(state.workspacePanelOpen);
+    }
+  });
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1937,7 +1937,7 @@ a[href] {
   display: grid;
   justify-content: start;
   grid-template-rows: var(--app-chrome-height) minmax(0, 1fr);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
   height: 100%;
   min-height: 0;
   width: 100%;
@@ -1963,23 +1963,16 @@ a[href] {
 }
 .layout--sidebar-collapsed {
   --sidebar-width: 0px;
-  grid-template-columns: 0px minmax(0, 1fr);
-}
-.layout:not(.layout--sidebar-collapsed):not(.layout--workspace-open):not(.layout--workspace-maximized) {
-  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
 }
 .layout--workspace-open {
   --chrome-right-toggle-offset: var(--workspace-width);
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open:not(.layout--sidebar-collapsed) {
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open.layout--sidebar-collapsed {
   min-width: min(560px, 100vw);
-  grid-template-columns: 0px minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 /* Skip dock-column interpolation in creation mode. WebKit can mount the
    overview at zero inline size and fail to repaint its text on reopen. */
@@ -19164,6 +19157,15 @@ body > .mermaid-diagram--fullscreen {
 .layout--workspace-maximized .workbench-dock {
   width: auto;
   max-width: none;
+}
+
+.workbench-dock--collapsed {
+  overflow: hidden;
+  width: 0;
+  min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+  border-left: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/layout_state.go
+++ b/desktop/layout_state.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"reasonix/internal/config"
+)
+
+// DesktopLayoutState captures UI layout preferences persisted across launches.
+type DesktopLayoutState struct {
+	WorkspacePanelOpen bool `json:"workspacePanelOpen"`
+}
+
+func layoutStatePath() string {
+	return filepath.Join(config.MemoryUserDir(), "desktop-layout.json")
+}
+
+func loadLayoutState() DesktopLayoutState {
+	path := layoutStatePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DesktopLayoutState{}
+	}
+	var s DesktopLayoutState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return DesktopLayoutState{}
+	}
+	return s
+}
+
+// SaveLayoutState persists layout preferences so the next launch restores them.
+func (a *App) SaveLayoutState(state DesktopLayoutState) error {
+	path := layoutStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// LoadLayoutState returns the saved layout preferences. Never fails — returns
+// zero values when no saved state exists.
+func (a *App) LoadLayoutState() DesktopLayoutState {
+	return loadLayoutState()
+}


### PR DESCRIPTION
## 问题

桌面端右侧工作区面板展开后，退出应用再打开，工作区自动收起。

## 原因

侧边栏收起状态通过 localStorage 持久化，但工作区面板状态从未保存——每次启动硬编码为关闭。

## 修复

采用与窗口状态相同的 Go 后端文件持久化（`~/.reasonix/memory/desktop-layout.json`），加 localStorage 双写：

| 文件 | 改动 |
|------|------|
| `desktop/layout_state.go` | 新增 `LoadLayoutState` / `SaveLayoutState`，JSON 文件读写 |
| `desktop/frontend/src/store/layout.ts` | Zustand subscribe 自动监听 `workspacePanelOpen` 变化，调用 Go 后端持久化 |
| `desktop/frontend/src/App.tsx` | `useEffect` on mount 调用 `LoadLayoutState` 恢复 |
| `desktop/frontend/src/lib/bridge.ts` | 新增 `DesktopLayoutState` 接口和 mock |

## 测试

- `wails build` 编译通过
- 展开工作区 → 退出 → 重新打开 → 工作区保持展开状态