### PR TITLE
Fix Windows frameless titlebar controls / 修复 Windows 无边框标题栏控制

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import type { CSSProperties, KeyboardEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
 import { ShellExpandProvider, useShellExpand } from "./lib/shellExpand";
 import gsap from "gsap";
 import { useGSAP } from "@gsap/react";
@@ -10,8 +10,11 @@ import {
   Activity,
   CircleHelp,
   Command,
+  Copy as RestoreIcon,
   Download,
+  Minus,
   Search,
+  Square,
   SquarePen,
   PanelLeft,
   PanelRight,
@@ -29,6 +32,7 @@ import {
   Brain,
   Cpu,
   Palette,
+  X,
 } from "lucide-react";
 import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
@@ -195,6 +199,65 @@ const MAX_DISMISSED_TODO_KEYS = 160;
 type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string };
 type WorkspaceInsertTarget = "composer" | "planRevision";
 type DesktopPlatform = "darwin" | "windows" | "linux";
+
+function WindowsWindowControls() {
+  const [maximised, setMaximised] = useState(false);
+
+  const syncMaximised = useCallback(() => {
+    void app.IsMainWindowMaximised()
+      .then(setMaximised)
+      .catch(() => setMaximised(false));
+  }, []);
+
+  useEffect(() => {
+    syncMaximised();
+    window.addEventListener("resize", syncMaximised);
+    window.addEventListener("focus", syncMaximised);
+    return () => {
+      window.removeEventListener("resize", syncMaximised);
+      window.removeEventListener("focus", syncMaximised);
+    };
+  }, [syncMaximised]);
+
+  const toggleMaximise = useCallback(() => {
+    void app.ToggleMaximiseMainWindow()
+      .then(() => window.setTimeout(syncMaximised, 80))
+      .catch(() => undefined);
+  }, [syncMaximised]);
+
+  return (
+    <div className="windows-window-controls" aria-label="Window controls">
+      <button
+        className="windows-window-control windows-window-control--minimize"
+        type="button"
+        aria-label="Minimize window"
+        title="Minimize"
+        onClick={() => void app.MinimiseMainWindow()}
+      >
+        <Minus size={13} strokeWidth={1.9} />
+      </button>
+      <button
+        className="windows-window-control windows-window-control--maximize"
+        type="button"
+        aria-label="Maximize or restore window"
+        aria-pressed={maximised}
+        title={maximised ? "Restore" : "Maximize"}
+        onClick={toggleMaximise}
+      >
+        {maximised ? <RestoreIcon size={12} strokeWidth={1.75} /> : <Square size={11} strokeWidth={1.8} />}
+      </button>
+      <button
+        className="windows-window-control windows-window-control--close"
+        type="button"
+        aria-label="Close window"
+        title="Close"
+        onClick={() => void app.CloseMainWindow()}
+      >
+        <X size={13} strokeWidth={1.9} />
+      </button>
+    </div>
+  );
+}
 type HistoryViewState =
   | { kind: "history"; source: "scope"; filter: HistoryScopeFilter; sessions: SessionMeta[] }
   | { kind: "history"; source: "all"; sessions: SessionMeta[] }
@@ -2786,6 +2849,15 @@ export default function App() {
   const topicbarCanRename = !sidebarImDetailConnection && Boolean(activeTab?.topicId);
   const topicbarTitleEditSize = Math.min(56, Math.max(4, topicTitleDraft.length || topicbarTitle.length || 1));
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
+  const windowsFramelessChrome = desktopPlatform === "windows";
+  const handleWindowsTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    if (!windowsFramelessChrome) return;
+    const target = event.target as HTMLElement | null;
+    if (!target?.closest(".app-chrome, .topicbar, .workbench-dock__tools")) return;
+    if (target.closest("button, input, textarea, select, a, [role='button'], [role='tab'], .windows-window-controls")) return;
+    event.preventDefault();
+    void app.ToggleMaximiseMainWindow();
+  }, [windowsFramelessChrome]);
   // Creation keeps the classic sidebar/chat structure while gating chrome tweaks
   // behind its own style flag so classic/workbench remain unchanged.
   const appChromeHidden = sidebarWorkbench || sidebarCreation;
@@ -2800,11 +2872,13 @@ export default function App() {
     <ShellExpandProvider>
     <ShellHotkeys />
     <TextSizeHotkeys />
-    <div
-      ref={appRef}
-      className={[
+      <div
+        ref={appRef}
+        onDoubleClickCapture={handleWindowsTitlebarDoubleClick}
+        className={[
         "app",
         `app--${desktopPlatform}`,
+        windowsFramelessChrome ? "app--windows-frameless" : "",
         browserPreviewChrome ? "app--browser-preview" : "",
         sidebarWorkbench ? "app--workbench" : "",
         sidebarCreation ? "app--creation" : "",
@@ -3661,6 +3735,7 @@ export default function App() {
       <HeartbeatPanel open={heartbeatOpen} onClose={() => setHeartbeatOpen(false)} onOpenTopic={(scope, workspaceRoot, topicId) => {
         void handleOpenTopic(scope, workspaceRoot, topicId);
       }} />
+      {windowsFramelessChrome && <WindowsWindowControls />}
     </div>
     </ShellExpandProvider>
   );

--- a/desktop/frontend/src/components/AppChrome.tsx
+++ b/desktop/frontend/src/components/AppChrome.tsx
@@ -1,4 +1,4 @@
-import { Minus, PanelLeft, PanelRight, Search, Square, X } from "lucide-react";
+import { PanelLeft, PanelRight, Search } from "lucide-react";
 import { TabBar } from "./TabBar";
 import type { TabMeta } from "../lib/types";
 import { useT } from "../lib/i18n";
@@ -58,14 +58,12 @@ export function AppChrome({
 }: AppChromeProps) {
   const t = useT();
   const darwinChrome = platform === "darwin";
-  const showWindowsPreviewControls = browserPreviewChrome && platform === "windows";
   const chromeClassName = [
     "app-chrome",
     "app-chrome--tabs",
     darwinChrome ? "app-chrome--darwin-tabs" : "app-chrome--native-tabs",
     workbenchChrome ? "app-chrome--workbench" : "",
     !darwinChrome ? "app-chrome--identityless" : "",
-    showWindowsPreviewControls ? "app-chrome--preview-window-controls" : "",
     `app-chrome--platform-${platform}`,
   ].filter(Boolean).join(" ");
   const tabBar = (
@@ -193,19 +191,6 @@ export function AppChrome({
         >
           <PanelRight size={16} />
         </button>
-      )}
-      {showWindowsPreviewControls && (
-        <div className="app-chrome__window-controls app-chrome__window-controls--windows" aria-hidden="true">
-          <span className="app-chrome__window-control app-chrome__window-control--minimize">
-            <Minus size={12} strokeWidth={1.9} />
-          </span>
-          <span className="app-chrome__window-control app-chrome__window-control--maximize">
-            <Square size={10} strokeWidth={1.8} />
-          </span>
-          <span className="app-chrome__window-control app-chrome__window-control--close">
-            <X size={12} strokeWidth={1.9} />
-          </span>
-        </div>
       )}
     </header>
   );

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -118,6 +118,10 @@ interface DesktopWindowState {
 // to AppBindings, then run `pnpm typecheck` to verify.
 export interface AppBindings {
   Platform(): Promise<string>;
+  MinimiseMainWindow(): Promise<void>;
+  ToggleMaximiseMainWindow(): Promise<void>;
+  IsMainWindowMaximised(): Promise<boolean>;
+  CloseMainWindow(): Promise<void>;
   // ── Heartbeat ──
   HeartbeatListTasks(): Promise<unknown>;
   HeartbeatReloadTasks(): Promise<unknown>;
@@ -584,6 +588,7 @@ function bridgeBreadcrumb(method: string): string {
     return `mcp ${method}`;
   if (/^(AddSkillPath|RemoveSkillPath|RefreshSkills|SetSkillEnabled|AcceptSkillSuggestion)/.test(method))
     return `skill ${method}`;
+  if (/^(MinimiseMainWindow|ToggleMaximiseMainWindow|IsMainWindowMaximised|CloseMainWindow)$/.test(method)) return `window ${method}`;
   if (/^(OpenProjectTab|OpenGlobalTab|OpenTopicSession|EnsureBlankTab|ActivateTopic|EnsureBlankSurface|SetActiveTab|CloseTab|ReorderTabs|CreateTopic|RenameTopic|DeleteTopic|TrashTopic|RenameProject|RemoveWorkspace|SwitchWorkspace|PickWorkspace)/.test(method))
     return `nav ${method}`;
   return "";
@@ -1455,6 +1460,18 @@ function makeMockApp(): AppBindings {
     }
   };
   return {
+    async MinimiseMainWindow() {
+      console.info("mock MinimiseMainWindow");
+    },
+    async ToggleMaximiseMainWindow() {
+      console.info("mock ToggleMaximiseMainWindow");
+    },
+    async IsMainWindowMaximised() {
+      return false;
+    },
+    async CloseMainWindow() {
+      console.info("mock CloseMainWindow");
+    },
     async Platform() {
       const override = browserPlatformOverride();
       if (override) return override;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16645,7 +16645,6 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .app-chrome {
-  --windows-preview-controls-width: 138px;
   grid-row: 1;
   grid-column: 1 / -1;
   position: relative;
@@ -16818,37 +16817,53 @@ body > .mermaid-diagram--fullscreen {
   }
 }
 
-.app-chrome__window-controls {
-  position: absolute;
+.windows-window-controls {
+  position: fixed;
   top: 0;
   right: 0;
-  z-index: var(--z-local-raised);
-  height: 100%;
+  z-index: var(--z-dock);
+  width: var(--windows-window-controls-width, 138px);
+  height: var(--windows-window-controls-height, 48px);
   display: flex;
   align-items: stretch;
   justify-content: flex-end;
+  color: var(--fg-dim);
+  background: var(--bg-elev);
+  border-left: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  box-shadow: -12px 0 18px -18px color-mix(in srgb, var(--fg) 46%, transparent);
+  pointer-events: auto;
+  user-select: none;
   --wails-draggable: no-drag;
 }
 
-.app-chrome__window-control {
-  width: 46px;
+.windows-window-control {
+  flex: 0 0 var(--windows-window-control-width, 46px);
+  width: var(--windows-window-control-width, 46px);
+  min-width: var(--windows-window-control-width, 46px);
   height: 100%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--fg-dim);
+  border: 0;
+  border-radius: 0;
   background: transparent;
+  color: inherit;
   transition:
-    background 0.12s ease,
-    color 0.12s ease;
+    background var(--dur-fast),
+    color var(--dur-fast);
+  --wails-draggable: no-drag;
 }
 
-.app-chrome__window-control:hover {
+.windows-window-control:hover,
+.windows-window-control:focus-visible {
   color: var(--fg);
-  background: color-mix(in srgb, var(--fg-faint) 12%, transparent);
+  background: color-mix(in srgb, var(--fg-faint) 13%, transparent);
+  outline: none;
 }
 
-.app-chrome__window-control--close:hover {
+.windows-window-control--close:hover,
+.windows-window-control--close:focus-visible {
   color: #fff;
   background: #c42b1c;
 }
@@ -17163,10 +17178,6 @@ body > .mermaid-diagram--fullscreen {
     linear-gradient(180deg, color-mix(in srgb, var(--bg-soft) 88%, var(--bg-elev)), var(--bg-soft));
 }
 
-.app--browser-preview.app--windows .app-chrome--native-tabs {
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--windows-preview-controls-width) + 48px);
-}
-
 .app--linux .app-chrome--native-tabs {
   background: color-mix(in srgb, var(--bg-soft) 92%, var(--bg-elev));
 }
@@ -17217,10 +17228,6 @@ body > .mermaid-diagram--fullscreen {
   right: 8px;
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
-}
-
-.app--browser-preview.app--windows .app-chrome--native-tabs .app-chrome__panel-toggle--right {
-  right: calc(var(--windows-preview-controls-width) + 8px);
 }
 
 .app--windows .app-chrome--native-tabs .app-chrome__panel-toggle::before,
@@ -21207,10 +21214,6 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .app--windows .app-chrome--native-tabs {
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--bg-elev) 94%, #fff), var(--bg-elev));
-}
-
-:root[data-theme-style] .app--browser-preview.app--windows .app-chrome--native-tabs {
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--windows-preview-controls-width) + 48px);
 }
 
 :root[data-theme-style] .app--linux .app-chrome--native-tabs {
@@ -27608,6 +27611,50 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .project-tree__topic-shortcut {
   background: color-mix(in srgb, var(--fg) 8%, var(--sidebar-bg, var(--bg)));
   color: var(--fg-faint);
+}
+
+.app--windows-frameless {
+  --windows-window-controls-width: 138px;
+  --windows-window-control-width: 46px;
+  --windows-window-controls-gap: 18px;
+  --windows-window-controls-safe: calc(var(--windows-window-controls-width) + var(--windows-window-controls-gap));
+  --windows-window-controls-height: 48px;
+}
+
+.app--windows-frameless.app--workbench {
+  --windows-window-controls-height: 40px;
+}
+
+.app--windows-frameless:not(.app--workbench):not(.app--creation) {
+  --windows-window-controls-height: 38px;
+}
+
+:root[data-theme-style] .app--windows-frameless:not(.app--workbench):not(.app--creation) {
+  --windows-window-controls-height: 46px;
+}
+
+.app--windows-frameless.app--creation {
+  --windows-window-controls-height: 56px;
+}
+
+.app--windows-frameless .app-chrome--native-tabs,
+:root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs {
+  padding-right: calc(var(--chrome-right-toggle-offset) + var(--windows-window-controls-safe));
+}
+
+.app--windows-frameless .topicbar,
+:root[data-theme-style] .app--windows-frameless .topicbar {
+  padding-right: var(--windows-window-controls-safe);
+}
+
+.app--windows-frameless .workbench-dock__tools,
+:root[data-theme-style] .app--windows-frameless .workbench-dock__tools {
+  padding-right: var(--windows-window-controls-safe);
+}
+
+.app--windows-frameless .workbench-dock__tabs,
+:root[data-theme-style] .app--windows-frameless .workbench-dock__tabs {
+  max-width: calc(100% - 4px);
 }
 
 @media (max-width: 820px) {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -10,6 +10,7 @@ import (
 	"embed"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/wailsapp/wails/v2"
@@ -112,6 +113,7 @@ func main() {
 		Title:     "Reasonix",
 		Width:     width,
 		Height:    height,
+		Frameless: goruntime.GOOS == "windows",
 		MinWidth:  760,
 		MinHeight: 480,
 		// Match the dark UI shell so the initial webview background doesn't flash

--- a/desktop/window_controls.go
+++ b/desktop/window_controls.go
@@ -1,0 +1,41 @@
+package main
+
+import "github.com/wailsapp/wails/v2/pkg/runtime"
+
+// MinimiseMainWindow backs the Windows frameless titlebar controls.
+func (a *App) MinimiseMainWindow() {
+	if a.ctx == nil {
+		return
+	}
+	runtime.WindowMinimise(a.ctx)
+}
+
+// ToggleMaximiseMainWindow backs the Windows frameless titlebar controls.
+func (a *App) ToggleMaximiseMainWindow() {
+	if a.ctx == nil {
+		return
+	}
+	runtime.WindowToggleMaximise(a.ctx)
+}
+
+// IsMainWindowMaximised reports the native maximise state for the Windows
+// frameless titlebar controls.
+func (a *App) IsMainWindowMaximised() bool {
+	if a.ctx == nil {
+		return false
+	}
+	return runtime.WindowIsMaximised(a.ctx)
+}
+
+// CloseMainWindow preserves Reasonix's configured close behavior for the
+// Windows frameless titlebar close button.
+func (a *App) CloseMainWindow() {
+	if a.ctx == nil {
+		return
+	}
+	if a.beforeClose(a.ctx) {
+		return
+	}
+	a.forceQuit.Store(true)
+	runtime.Quit(a.ctx)
+}


### PR DESCRIPTION
## Summary
- Enable frameless mode only for the Windows desktop shell.
- Add custom Windows minimize, maximize/restore, and close controls that preserve Reasonix close behavior.
- Reserve a dedicated system-control zone across classic, workbench, and creation layouts so workspace controls do not collide with the titlebar controls.
- Add maximize-state icon switching and double-click maximize/restore on draggable titlebar regions.

## Verification
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend typecheck`
- `go test ./...` from `desktop/`

Closes #5696