### PR TITLE
Fix silent desktop session save failures / 修复桌面会话保存失败静默丢失

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -635,7 +635,9 @@ func (a *App) snapshotAllTabs() {
 	tabs := a.runtimeTabsLocked()
 	a.mu.RUnlock()
 	for _, t := range tabs {
-		_ = a.snapshotTab(t)
+		if err := a.snapshotTab(t); err != nil {
+			slog.Warn("desktop: snapshot all tabs failed", "tab", t.ID, "err", err)
+		}
 	}
 }
 
@@ -657,7 +659,9 @@ func (a *App) shutdown(context.Context) {
 	a.mu.RUnlock()
 	for _, t := range tabs {
 		if t.Ctrl != nil {
-			_ = a.snapshotTab(t)
+			if err := a.snapshotTab(t); err != nil {
+				slog.Warn("desktop: shutdown snapshot failed", "tab", t.ID, "err", err)
+			}
 			t.Ctrl.Close()
 		}
 	}
@@ -913,6 +917,43 @@ func (a *App) snapshotTab(tab *WorkspaceTab) error {
 		return nil
 	}
 	return ctrl.Snapshot()
+}
+
+func snapshotTabDirect(tab *WorkspaceTab) error {
+	if tab == nil || tab.ReadOnly || tab.Ctrl == nil {
+		return nil
+	}
+	return tab.Ctrl.Snapshot()
+}
+
+func (a *App) snapshotTabForAction(tab *WorkspaceTab, action string) error {
+	if err := a.snapshotTab(tab); err != nil {
+		a.reportTabSnapshotError(tab, action, err)
+		if strings.TrimSpace(action) == "" {
+			return fmt.Errorf("save current session: %w", err)
+		}
+		return fmt.Errorf("save current session before %s: %w", action, err)
+	}
+	return nil
+}
+
+func (a *App) reportTabSnapshotError(tab *WorkspaceTab, action string, err error) {
+	if err == nil {
+		return
+	}
+	tabID := ""
+	if tab != nil {
+		tabID = tab.ID
+	}
+	slog.Warn("desktop: session snapshot failed", "tab", tabID, "action", action, "err", err)
+	if tab == nil || tab.sink == nil {
+		return
+	}
+	prefix := "Session autosave failed"
+	if strings.TrimSpace(action) != "" && action != "autosave" {
+		prefix = "Session save failed before " + action
+	}
+	tab.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: prefix + ": " + err.Error()})
 }
 
 func (a *App) reconciledSessionPathForTab(tab *WorkspaceTab) string {
@@ -2722,9 +2763,13 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		return nil
 	}
 
-	_ = a.snapshotTab(tab) // persist writable sessions before switching the view.
+	if err := a.snapshotTabForAction(tab, "switching sessions"); err != nil {
+		return err
+	}
 	if oldPath := a.reconciledSessionPathForTab(tab); oldPath != "" {
-		_ = saveTabSessionMeta(tab, oldPath)
+		if err := saveTabSessionMeta(tab, oldPath); err != nil {
+			return fmt.Errorf("save current session metadata before switching sessions: %w", err)
+		}
 	}
 	if tab.hasActiveRuntimeWork() {
 		if !a.detachRuntimeForReplacement(tab) {
@@ -3345,8 +3390,10 @@ func (a *App) RemoveWorkspace(dir string) error {
 		if !tabInWorkspace(tab, dir) {
 			continue
 		}
-		if tab.Ctrl != nil && !tab.ReadOnly {
-			_ = tab.Ctrl.Snapshot()
+		if err := snapshotTabDirect(tab); err != nil {
+			a.mu.Unlock()
+			slog.Warn("desktop: snapshot before removing workspace failed", "tab", id, "workspace", dir, "err", err)
+			return fmt.Errorf("save current session before removing workspace: %w", err)
 		}
 		a.markTabRemovedLocked(tab)
 		closeTabs = append(closeTabs, tab)
@@ -6466,7 +6513,9 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		if prevPath == "" {
 			prevPath = tab.Ctrl.SessionPath()
 		}
-		_ = a.snapshotTab(tab)
+		if err := a.snapshotTabForAction(tab, "changing model"); err != nil {
+			return err
+		}
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()
 	}
@@ -6570,7 +6619,9 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		if prevPath == "" {
 			prevPath = tab.Ctrl.SessionPath()
 		}
-		_ = a.snapshotTab(tab)
+		if err := a.snapshotTabForAction(tab, "changing effort"); err != nil {
+			return err
+		}
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()
 	}
@@ -6647,7 +6698,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		if prevPath == "" {
 			prevPath = oldCtrl.SessionPath()
 		}
-		_ = a.snapshotTab(tab)
+		if err := a.snapshotTabForAction(tab, "changing token mode"); err != nil {
+			return err
+		}
 		carried = oldCtrl.History()
 	}
 	sharedHost := a.lookupSharedHost(tab.SharedHostKey)

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -49,7 +49,12 @@ func waitForFile(t *testing.T, path, want string) {
 
 func waitForAutosaveIdle(t *testing.T, tab *WorkspaceTab) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	waitForAutosaveIdleWithin(t, tab, 2*time.Second)
+}
+
+func waitForAutosaveIdleWithin(t *testing.T, tab *WorkspaceTab, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		tab.saveMu.Lock()
 		idle := !tab.saving && !tab.saveAgain
@@ -132,6 +137,91 @@ func TestScheduleSnapshotCoalesces(t *testing.T) {
 	waitForAutosaveIdle(t, tab)
 }
 
+func TestAutosaveFailureRetriesAndRecoversOnNextTurnDone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocked.jsonl")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("mkdir blocked path: %v", err)
+	}
+	a, tab := appWithTab(t, path)
+	_ = a
+
+	tab.sink.Emit(event.Event{Kind: event.TurnDone})
+	waitForAutosaveIdleWithin(t, tab, 5*time.Second)
+
+	tab.saveMu.Lock()
+	failures := tab.saveFailures
+	tab.saveMu.Unlock()
+	if failures == 0 {
+		t.Fatal("autosave failure should be recorded and retried")
+	}
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		t.Fatalf("blocked session path should still be the directory, info=%v err=%v", info, err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove blocked dir: %v", err)
+	}
+	tab.sink.Emit(event.Event{Kind: event.TurnDone})
+	waitForFile(t, path, "remember this turn")
+	waitForAutosaveIdle(t, tab)
+
+	tab.saveMu.Lock()
+	failures = tab.saveFailures
+	tab.saveMu.Unlock()
+	if failures != 0 {
+		t.Fatalf("autosave failures after recovery = %d, want 0", failures)
+	}
+}
+
+func TestSetActiveTabBlocksWhenCurrentSessionCannotPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocked.jsonl")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("mkdir blocked path: %v", err)
+	}
+	a, _ := appWithTab(t, path)
+	a.tabs["target_tab"] = &WorkspaceTab{
+		ID:          "target_tab",
+		Scope:       "global",
+		Ready:       true,
+		disabledMCP: map[string]ServerView{},
+	}
+	a.tabOrder = []string{"test_tab", "target_tab"}
+
+	err := a.SetActiveTab("target_tab")
+	if err == nil || !strings.Contains(err.Error(), "save current session before switching tabs") {
+		t.Fatalf("SetActiveTab error = %v, want persistence failure", err)
+	}
+	if a.activeTabID != "test_tab" {
+		t.Fatalf("active tab = %q, want original tab after failed save", a.activeTabID)
+	}
+}
+
+func TestRebindSessionBlocksWhenCurrentSessionCannotPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocked.jsonl")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("mkdir blocked path: %v", err)
+	}
+	a, tab := appWithTab(t, path)
+	target := filepath.Join(t.TempDir(), "target.jsonl")
+	sess := agent.NewSession("system")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "target prompt"})
+	if err := sess.Save(target); err != nil {
+		t.Fatalf("save target: %v", err)
+	}
+	loaded, err := agent.LoadSession(target)
+	if err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+
+	err = a.rebindTabToLoadedSessionPath(tab, target, loaded)
+	if err == nil || !strings.Contains(err.Error(), "save current session before switching sessions") {
+		t.Fatalf("rebind error = %v, want persistence failure", err)
+	}
+	if tab.Ctrl == nil || tab.Ctrl.SessionPath() != path {
+		t.Fatalf("tab controller/path changed after failed save: ctrl=%v path=%q", tab.Ctrl, tab.currentSessionPath())
+	}
+}
+
 // TestCloseTabNoResurrectionFromAutosave is the regression test for #4384.
 // It proves that after CloseTab returns, the per-turn autosave goroutine can no
 // longer write the session file — even when it is in flight at the moment the
@@ -184,6 +274,34 @@ func TestCloseTabNoResurrectionFromAutosave(t *testing.T) {
 	// can write either.
 	if got := doomedTab.Ctrl.SessionPath(); got != "" {
 		t.Fatalf("controller session path = %q after CloseTab, want empty so snapshots no-op", got)
+	}
+}
+
+func TestCloseTabBlocksWhenSessionCannotPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocked.jsonl")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("mkdir blocked path: %v", err)
+	}
+	a, tab := appWithTab(t, path)
+	survivor := &WorkspaceTab{
+		ID:          "survivor_tab",
+		Scope:       "global",
+		Ready:       true,
+		disabledMCP: map[string]ServerView{},
+	}
+	survivor.sink = &tabEventSink{tabID: survivor.ID, app: a}
+	a.tabs[survivor.ID] = survivor
+	a.tabOrder = []string{tab.ID, survivor.ID}
+
+	err := a.CloseTab(tab.ID)
+	if err == nil || !strings.Contains(err.Error(), "save current session before closing tab") {
+		t.Fatalf("CloseTab error = %v, want persistence failure", err)
+	}
+	if _, ok := a.tabs[tab.ID]; !ok {
+		t.Fatal("tab was removed even though its session could not be saved")
+	}
+	if tab.Ctrl == nil || tab.Ctrl.SessionPath() != path {
+		t.Fatalf("tab controller/path changed after failed close: ctrl=%v path=%q", tab.Ctrl, tab.currentSessionPath())
 	}
 }
 

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -141,6 +141,7 @@ let contextDCalls = 0;
 let holdNextContextForD = false;
 let setActiveCalls = 0;
 let newSessionCalls = 0;
+let failSetActiveFor = "";
 const runningTabs = new Set<string>();
 const tabsById = new Map([tabA, tabB, tabC, tabD].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
@@ -198,6 +199,7 @@ window.go = {
       SetActiveTab: async (tabID: string) => {
         setActiveCalls += 1;
         if (tabID === "tab-b") await setActiveBGate.promise;
+        if (tabID === failSetActiveFor) throw new Error("persist failed");
         backendActiveId = tabID;
       },
       SubmitToTab: async (tabID: string) => {
@@ -276,6 +278,17 @@ await act(async () => {
 eq(controller?.activeTabId, "tab-a", "late history for another tab does not change the active tab");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "cached A") ?? false, "late history for another tab does not overwrite the active transcript");
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "late B") ?? false), "late history stays scoped to its tab state");
+
+failSetActiveFor = "tab-b";
+const historyCallsBeforeFailedSwitch = historyCalls.length;
+await act(async () => {
+  await controller?.switchTab("tab-b", tabB);
+  await flushPromises();
+});
+eq(controller?.activeTabId, "tab-a", "failed backend tab switch reverts to the previous active tab");
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "cached A") ?? false, "failed backend tab switch keeps the previous transcript visible");
+eq(historyCalls.length, historyCallsBeforeFailedSwitch, "failed backend tab switch does not hydrate the rejected target");
+failSetActiveFor = "";
 
 await act(async () => {
   for (const handler of eventHandlers) handler({ kind: "phase", text: "Planner is thinking", tabId: "tab-a" });

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1738,6 +1738,7 @@ export function useController() {
   // Tab management: switch preserves per-tab state; open creates it.
   const switchTab = useCallback(async (tabId: string, optimisticTab?: TabMeta): Promise<TabMeta[] | undefined> => {
     const startedAt = Date.now();
+    const previousTabId = activeTabIdRef.current;
     const targetSessionPath = optimisticTab?.sessionPath ?? statesRef.current.get(tabId)?.meta?.sessionPath;
     const preserveCachedHistory = hasReusableCachedTranscript(statesRef.current.get(tabId), targetSessionPath);
     addBreadcrumb("tab.switch", `click ${tabId}`);
@@ -1758,6 +1759,11 @@ export function useController() {
       .catch((err) => {
         dispatchTo(tabId, { type: "backend_activation_done" });
         dispatchTo(tabId, { type: "hydrate_error", reason: "switch-tab", error: errorMessage(err) });
+        if (previousTabId && activeTabIdRef.current === tabId) {
+          setActiveTabId(previousTabId);
+          activeTabIdRef.current = previousTabId;
+          addBreadcrumb("tab.switch", `set-active-failed-reverted ${tabId} -> ${previousTabId} ms=${Date.now() - startedAt}`);
+        }
         return false;
       });
     trackBackendActivation(tabId, backendActivation);

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -873,7 +874,9 @@ func (a *App) rebuild() error {
 		if prevPath == "" {
 			prevPath = tab.Ctrl.SessionPath()
 		}
-		_ = a.snapshotTab(tab)
+		if err := a.snapshotTabForAction(tab, "rebuilding settings"); err != nil {
+			return err
+		}
 		carried = tab.Ctrl.History()
 		tab.Ctrl.Close()
 	}
@@ -1408,6 +1411,14 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 			return err
 		}
 	}
+	for _, item := range affected {
+		if item.ctrl != nil && !item.readOnly {
+			if err := item.ctrl.Snapshot(); err != nil {
+				slog.Warn("desktop: snapshot before removing provider access failed", "tab", item.id, "provider", name, "err", err)
+				return fmt.Errorf("save current session before removing provider access: %w", err)
+			}
+		}
+	}
 	retargetProviderReferences(cfg, name, fallbackRef)
 	removeProviderAccess(cfg, name)
 	if err := cfg.SaveTo(path); err != nil {
@@ -1418,9 +1429,6 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 	}
 	for _, item := range affected {
 		if item.ctrl != nil {
-			if !item.readOnly {
-				_ = item.ctrl.Snapshot()
-			}
 			item.ctrl.Close()
 		}
 	}
@@ -1491,6 +1499,14 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 			return err
 		}
 	}
+	for _, item := range affected {
+		if item.ctrl != nil && !item.readOnly {
+			if err := item.ctrl.Snapshot(); err != nil {
+				slog.Warn("desktop: snapshot before deleting provider failed", "tab", item.id, "provider", name, "err", err)
+				return fmt.Errorf("save current session before deleting provider: %w", err)
+			}
+		}
+	}
 	if err := cfg.RemoveProvider(name); err != nil {
 		return err
 	}
@@ -1504,9 +1520,6 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 	}
 	for _, item := range affected {
 		if item.ctrl != nil {
-			if !item.readOnly {
-				_ = item.ctrl.Snapshot()
-			}
 			item.ctrl.Close()
 		}
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -59,9 +59,10 @@ type WorkspaceTab struct {
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
 	// Per-turn autosave per tab.
-	saveMu    sync.Mutex
-	saving    bool
-	saveAgain bool
+	saveMu       sync.Mutex
+	saving       bool
+	saveAgain    bool
+	saveFailures int
 
 	// closing is set under saveMu when the tab is being torn down. Once set,
 	// tabSnapshotLoop stops taking new snapshot work and CloseTab waits on
@@ -1761,6 +1762,21 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 // SetActiveTab switches the frontend's active tab. A no-op when tabID is
 // already active or unknown.
 func (a *App) SetActiveTab(tabID string) error {
+	a.mu.RLock()
+	_, ok := a.tabs[tabID]
+	active := a.tabs[a.activeTabID]
+	alreadyActive := a.activeTabID == tabID
+	a.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("tab %q not found", tabID)
+	}
+	if alreadyActive {
+		return nil
+	}
+	if err := a.snapshotTabForAction(active, "switching tabs"); err != nil {
+		return err
+	}
+
 	a.mu.Lock()
 	if _, ok := a.tabs[tabID]; !ok {
 		a.mu.Unlock()
@@ -1823,10 +1839,16 @@ func (a *App) CloseTab(tabID string) error {
 	// This closes a race window with DeleteSession: if Snapshot runs
 	// after delete(a.tabs, tabID), a concurrent DeleteSession can delete
 	// the session files, and the deferred Snapshot recreates them.
-	if tab.Ctrl != nil && !tab.ReadOnly {
-		_ = tab.Ctrl.Snapshot()
+	if err := snapshotTabDirect(tab); err != nil {
+		a.mu.Unlock()
+		slog.Warn("desktop: snapshot before closing tab failed", "tab", tabID, "err", err)
+		return fmt.Errorf("save current session before closing tab: %w", err)
 	}
-	saveTabSessionMetaForCurrentSession(tab)
+	if err := saveTabSessionMetaForCurrentSession(tab); err != nil {
+		a.mu.Unlock()
+		slog.Warn("desktop: session metadata before closing tab failed", "tab", tabID, "err", err)
+		return fmt.Errorf("save current session metadata before closing tab: %w", err)
+	}
 	if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
 		a.markTabRemovedLocked(tab)
 	}
@@ -1897,10 +1919,16 @@ func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
 		if id == tabID {
 			continue
 		}
-		if tab.Ctrl != nil && !tab.ReadOnly {
-			_ = tab.Ctrl.Snapshot()
+		if err := snapshotTabDirect(tab); err != nil {
+			a.mu.Unlock()
+			slog.Warn("desktop: snapshot before pruning hidden tab failed", "tab", id, "err", err)
+			return TabMeta{}, fmt.Errorf("save current session before switching tabs: %w", err)
 		}
-		saveTabSessionMetaForCurrentSession(tab)
+		if err := saveTabSessionMetaForCurrentSession(tab); err != nil {
+			a.mu.Unlock()
+			slog.Warn("desktop: session metadata before pruning hidden tab failed", "tab", id, "err", err)
+			return TabMeta{}, fmt.Errorf("save current session metadata before switching tabs: %w", err)
+		}
 		if tab.Ctrl == nil || !tab.hasActiveRuntimeWork() {
 			a.markTabRemovedLocked(tab)
 		}
@@ -1952,8 +1980,8 @@ func (a *App) removeVisibleTabRuntime(tab *WorkspaceTab) {
 	if tab == nil {
 		return
 	}
-	if tab.Ctrl != nil && !tab.ReadOnly {
-		_ = tab.Ctrl.Snapshot()
+	if err := a.snapshotTab(tab); err != nil {
+		slog.Warn("desktop: snapshot before removing visible tab runtime failed", "tab", tab.ID, "err", err)
 	}
 	discardPath, discardTransientBlank := transientBlankSessionArtifactPath(tab)
 	if tab.Ctrl != nil && tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
@@ -2591,6 +2619,19 @@ func (a *App) ctrlByTabID(tabID string) control.SessionAPI {
 
 // --- autosave per tab -------------------------------------------------------
 
+const maxTabSnapshotFailureRetries = 2
+
+func tabSnapshotRetryDelay(failures int) time.Duration {
+	switch {
+	case failures <= 1:
+		return 100 * time.Millisecond
+	case failures == 2:
+		return 250 * time.Millisecond
+	default:
+		return 500 * time.Millisecond
+	}
+}
+
 func (a *App) scheduleTabSnapshot(tabID string) {
 	a.mu.RLock()
 	tab := a.tabByEventSinkIDLocked(tabID)
@@ -2610,6 +2651,7 @@ func (a *App) scheduleTabSnapshot(tabID string) {
 		return
 	}
 	tab.saving = true
+	tab.saveFailures = 0
 	go a.tabSnapshotLoop(tab)
 }
 
@@ -2641,6 +2683,7 @@ func (a *App) quiesceTabAutosave(tab *WorkspaceTab) {
 func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 	defer a.recoverToPending("tabSnapshotLoop")
 	for {
+		var snapshotErr error
 		a.mu.RLock()
 		ctrl := tab.Ctrl
 		a.mu.RUnlock()
@@ -2649,11 +2692,19 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 				if !a.maybeAutoTitleTopic(tab) {
 					a.emitProjectTreeChanged()
 				}
+			} else {
+				snapshotErr = err
+				a.reportTabSnapshotError(tab, "autosave", err)
 			}
 		}
 		tab.saveMu.Lock()
 		if tab.saveCond == nil {
 			tab.saveCond = sync.NewCond(&tab.saveMu)
+		}
+		if snapshotErr == nil {
+			tab.saveFailures = 0
+		} else {
+			tab.saveFailures++
 		}
 		if tab.closing {
 			// Tab is being torn down: stop without picking up saveAgain work.
@@ -2665,6 +2716,12 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 		if tab.saveAgain {
 			tab.saveAgain = false
 			tab.saveMu.Unlock()
+			continue
+		}
+		if snapshotErr != nil && tab.saveFailures <= maxTabSnapshotFailureRetries {
+			delay := tabSnapshotRetryDelay(tab.saveFailures)
+			tab.saveMu.Unlock()
+			time.Sleep(delay)
 			continue
 		}
 		tab.saving = false
@@ -5664,18 +5721,18 @@ func tabSessionMetaPathForCurrentSession(tab *WorkspaceTab) string {
 	return ""
 }
 
-func saveTabSessionMetaForCurrentSession(tab *WorkspaceTab) {
+func saveTabSessionMetaForCurrentSession(tab *WorkspaceTab) error {
 	if tab == nil || tab.ReadOnly {
-		return
+		return nil
 	}
 	if _, discard := transientBlankSessionArtifactPath(tab); discard {
-		return
+		return nil
 	}
 	path := tabSessionMetaPathForCurrentSession(tab)
 	if path == "" {
-		return
+		return nil
 	}
-	_ = saveTabSessionMeta(tab, path)
+	return saveTabSessionMeta(tab, path)
 }
 
 type tabSessionProfile struct {


### PR DESCRIPTION
## Summary
- Report and retry desktop session snapshot failures instead of silently ending autosave.
- Block tab/session/workspace/settings/model replacement actions when the current session cannot be persisted.
- Revert optimistic frontend tab activation if the backend rejects activation after a save failure.

Fixes #5730.

## Testing
- `go test .` in `desktop`
- `pnpm exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- `pnpm exec tsc --noEmit -p tsconfig.test.json`