### PR TITLE
fix: 收起/展开工作区面板添加过渡动画

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2059,10 +2059,10 @@ export default function App() {
       ({
         "--sidebar-expanded-width": `${sidebarRenderWidth}px`,
         "--chat-min-width": `${chatReservedWidth}px`,
-        "--workspace-width": `${workspacePanelRenderWidth}px`,
+        "--workspace-width": workspacePanelOpen ? `${workspacePanelRenderWidth}px` : "0px",
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
       }) as CSSProperties,
-    [chatReservedWidth, sidebarRenderWidth, workspacePanelRenderWidth],
+    [chatReservedWidth, sidebarRenderWidth, workspacePanelOpen, workspacePanelRenderWidth],
   );
 
   const setWorkspacePanel = useCallback((open: boolean) => {
@@ -3507,13 +3507,13 @@ export default function App() {
           />
         )}
 
-        {workspacePanelRenderable && (
-          <aside
-            className={[
-              "workbench-dock",
-              `workbench-dock--${rightDockMode}`,
-            ].join(" ")}
-            aria-label={t("rightDock.workbench")}
+        <aside
+          className={[
+            "workbench-dock",
+            `workbench-dock--${rightDockMode}`,
+            !workspacePanelRenderable ? "workbench-dock--collapsed" : "",
+          ].filter(Boolean).join(" ")}
+          aria-label={t("rightDock.workbench")}
           >
             <div className="workbench-dock__tools">
               <div className="workbench-dock__tabs" role="tablist" aria-label={t("rightDock.views")}>
@@ -3589,7 +3589,6 @@ export default function App() {
               )}
             </div>
           </aside>
-        )}
       </div>
 
       {histView !== null && (

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1937,7 +1937,7 @@ a[href] {
   display: grid;
   justify-content: start;
   grid-template-rows: var(--app-chrome-height) minmax(0, 1fr);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
   height: 100%;
   min-height: 0;
   width: 100%;
@@ -1963,23 +1963,16 @@ a[href] {
 }
 .layout--sidebar-collapsed {
   --sidebar-width: 0px;
-  grid-template-columns: 0px minmax(0, 1fr);
-}
-.layout:not(.layout--sidebar-collapsed):not(.layout--workspace-open):not(.layout--workspace-maximized) {
-  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
 }
 .layout--workspace-open {
   --chrome-right-toggle-offset: var(--workspace-width);
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open:not(.layout--sidebar-collapsed) {
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open.layout--sidebar-collapsed {
   min-width: min(560px, 100vw);
-  grid-template-columns: 0px minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 /* Skip dock-column interpolation in creation mode. WebKit can mount the
    overview at zero inline size and fail to repaint its text on reopen. */
@@ -19164,6 +19157,15 @@ body > .mermaid-diagram--fullscreen {
 .layout--workspace-maximized .workbench-dock {
   width: auto;
   max-width: none;
+}
+
+.workbench-dock--collapsed {
+  overflow: hidden;
+  width: 0;
+  min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+  border-left: none;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
收起/展开工作区面板时缺少平滑过渡动画，而导航栏（sidebar）有动画。

**根因**
- 导航栏（sidebar）始终在 DOM 中，收起通过 CSS class 控制
- 工作区面板（workbench-dock）使用条件渲染 `{workspacePanelRenderable && ...}`，关闭时直接从 DOM 移除，CSS `transition: grid-template-columns` 无法对不存在的元素生效

**修复**
1. `.layout` 基础 grid 改为始终 3 列（sidebar | main | workspace），第 3 列宽度由 `--workspace-width` 变量控制
2. 关闭工作区时 `--workspace-width` 设为 `0px`，grid transition 平滑缩放到 0
3. `workbench-dock` 改为始终渲染，关闭时通过 `workbench-dock--collapsed` CSS 类视觉隐藏
4. 移除多余的 `grid-template-columns` 覆盖规则，保持一致性

**效果**
收起/展开工作区面板现在有和导航栏一样的 0.16s（Darwin 0.28s）平滑过渡动画