### PR TITLE
Fix workspace code preview scrolling / 修复工作区代码预览滚动

### DIFF
--- a/desktop/frontend/src/__tests__/workspace-preview-css.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-preview-css.test.ts
@@ -70,6 +70,9 @@ eq(
 );
 eq(finalDeclaration(".workspace-preview__body--code .workspace-note", "flex"), "0 0 auto", "code truncation note keeps its own row");
 eq(finalDeclaration(".workspace-preview__body--code .code-block", "display"), "flex", "code block fills the preview viewport");
+eq(finalDeclaration(".workspace-preview__body--code .code-block__wrap", "display"), "flex", "code wrapper keeps the preview viewport height");
+eq(finalDeclaration(".workspace-preview__body--code .code-block__wrap", "flex"), "1 1 auto", "code wrapper participates in the preview flex height");
+eq(finalDeclaration(".workspace-preview__body--code .code-block__wrap", "min-height"), "0", "code wrapper can shrink around the scrollable code viewport");
 eq(finalDeclaration(".workspace-preview__body--code .code", "overflow"), "auto", "code viewport owns horizontal and vertical scrolling");
 eq(finalDeclaration(".workspace-preview__body--code .code", "min-height"), "0", "code viewport can shrink inside the preview pane");
 eq(finalDeclaration(".workspace-preview__body--code .code", "margin"), "0", "code viewport scrollbar sits at the visible pane bottom");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7735,6 +7735,14 @@ body > .mermaid-diagram--fullscreen {
   width: 100%;
   max-width: none;
 }
+.workspace-preview__body--code .code-block__wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  width: 100%;
+  max-width: none;
+}
 .workspace-preview__body--code .code {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Fix the workspace code preview flex chain so the `CodeViewer` wrapper can shrink inside the preview pane.
- Keep the `.code` viewport responsible for scrolling and add CSS regression coverage for the wrapper.

## Root Cause
`HljsCode` wraps the `<pre>` in `.code-block__wrap` for copy button positioning. The workspace code-preview CSS made `.code-block` and `.code` flex children, but the wrapper kept its content height, so code previews could grow beyond the hidden outer pane instead of scrolling.

## Validation
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/workspace-preview-css.test.ts`
- Browser check: code preview viewport scrolls while Markdown continues to use the outer preview scroller.

Fixes #5727