### PR TITLE
Reduce desktop trash fallback hydration lag / 降低桌面端删除话题后的恢复卡顿

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1546,12 +1546,16 @@ func removeDesktopSessionArtifacts(path string) error {
 type CheckpointMeta struct {
 	Turn            int      `json:"turn"`
 	Prompt          string   `json:"prompt"`
-	Files           []string `json:"files"`         // cumulative files RestoreCode would affect from this turn
+	Files           []string `json:"files"`     // stable preview of cumulative files RestoreCode would affect from this turn
+	FileCount       int      `json:"fileCount"` // full cumulative file count, including entries omitted from Files
+	FilesTruncated  bool     `json:"filesTruncated,omitempty"`
 	TurnFileCount   int      `json:"turnFileCount"` // files changed during this turn only
 	Time            int64    `json:"time"`          // unix milliseconds
 	CanCode         bool     `json:"canCode"`
 	CanConversation bool     `json:"canConversation"`
 }
+
+const checkpointFilePreviewLimit = 60
 
 // Checkpoints lists the session's rewind points, oldest first, for the rewind UI.
 func (a *App) Checkpoints() []CheckpointMeta {
@@ -1588,21 +1592,46 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 	// files RestoreCode would actually affect from this turn.
 	hasCodeAfter := false
 	codeFileSet := make(map[string]bool, len(metas)*2)
+	codeFilePreview := []string{}
 	for i := len(out) - 1; i >= 0; i-- {
 		if len(out[i].Files) > 0 {
 			hasCodeAfter = true
 		}
 		for _, f := range out[i].Files {
+			if codeFileSet[f] {
+				continue
+			}
 			codeFileSet[f] = true
+			codeFilePreview = insertCheckpointFilePreview(codeFilePreview, f, checkpointFilePreviewLimit)
 		}
 		out[i].CanCode = hasCodeAfter
-		out[i].Files = make([]string, 0, len(codeFileSet))
-		for f := range codeFileSet {
-			out[i].Files = append(out[i].Files, f)
-		}
-		sort.Strings(out[i].Files) // map iteration is unordered; keep the list stable
+		out[i].FileCount = len(codeFileSet)
+		out[i].Files = append([]string(nil), codeFilePreview...)
+		out[i].FilesTruncated = out[i].FileCount > len(out[i].Files)
 	}
 	return out
+}
+
+func insertCheckpointFilePreview(preview []string, path string, limit int) []string {
+	if limit <= 0 || path == "" {
+		return preview
+	}
+	idx := sort.SearchStrings(preview, path)
+	if idx < len(preview) && preview[idx] == path {
+		return preview
+	}
+	if len(preview) < limit {
+		preview = append(preview, "")
+		copy(preview[idx+1:], preview[idx:])
+		preview[idx] = path
+		return preview
+	}
+	if idx >= limit {
+		return preview
+	}
+	copy(preview[idx+1:], preview[idx:limit-1])
+	preview[idx] = path
+	return preview
 }
 
 // ToolResultForTab returns the full arguments and output for one tool call that

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1606,7 +1606,7 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 		}
 		out[i].CanCode = hasCodeAfter
 		out[i].FileCount = len(codeFileSet)
-		out[i].Files = append([]string(nil), codeFilePreview...)
+		out[i].Files = append([]string{}, codeFilePreview...)
 		out[i].FilesTruncated = out[i].FileCount > len(out[i].Files)
 	}
 	return out

--- a/desktop/checkpoints_cancode_test.go
+++ b/desktop/checkpoints_cancode_test.go
@@ -77,4 +77,51 @@ func TestCheckpointsCanCodePropagatesToEarlierTurns(t *testing.T) {
 	if len(metas[0].Files) != 1 || metas[0].Files[0] != "a.txt" {
 		t.Fatalf("turn 0 cumulative files = %#v, want [a.txt]", metas[0].Files)
 	}
+	if metas[0].FileCount != 1 || metas[0].FilesTruncated {
+		t.Fatalf("turn 0 file summary = count %d truncated %v, want count 1 truncated false", metas[0].FileCount, metas[0].FilesTruncated)
+	}
+}
+
+func TestCheckpointsForTabLimitsCumulativeFilePreview(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "s.jsonl")
+	ckptDir := sessionPath[:len(sessionPath)-len(".jsonl")] + ".ckpt"
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "old"
+	files := make([]checkpoint.FileSnap, 0, checkpointFilePreviewLimit+5)
+	for i := 0; i < checkpointFilePreviewLimit+5; i++ {
+		files = append(files, checkpoint.FileSnap{Path: "file-" + strconv.Itoa(1000+i) + ".txt", Content: &content})
+	}
+	now := time.Now()
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{Turn: 0, Time: now, Prompt: "before edits", MsgIndex: 0})
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{Turn: 1, Time: now, Prompt: "edit many files", MsgIndex: 2, Files: files})
+
+	ag := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: ag, SessionDir: dir, Label: "test"})
+	ctrl.SetSessionPath(sessionPath)
+
+	app := &App{}
+	app.setTestCtrl(ctrl, "test")
+
+	metas := app.CheckpointsForTab("test")
+	if len(metas) != 2 {
+		t.Fatalf("checkpoints = %d, want 2", len(metas))
+	}
+	if metas[0].FileCount != checkpointFilePreviewLimit+5 {
+		t.Fatalf("turn 0 cumulative file count = %d, want %d", metas[0].FileCount, checkpointFilePreviewLimit+5)
+	}
+	if len(metas[0].Files) != checkpointFilePreviewLimit {
+		t.Fatalf("turn 0 preview files = %d, want %d", len(metas[0].Files), checkpointFilePreviewLimit)
+	}
+	if !metas[0].FilesTruncated {
+		t.Fatal("turn 0 should mark file preview as truncated")
+	}
+	if metas[0].TurnFileCount != 0 {
+		t.Fatalf("turn 0 file count = %d, want 0 for this turn", metas[0].TurnFileCount)
+	}
+	if metas[1].TurnFileCount != checkpointFilePreviewLimit+5 {
+		t.Fatalf("turn 1 file count = %d, want %d", metas[1].TurnFileCount, checkpointFilePreviewLimit+5)
+	}
 }

--- a/desktop/checkpoints_cancode_test.go
+++ b/desktop/checkpoints_cancode_test.go
@@ -25,6 +25,28 @@ func seedCheckpoint(t *testing.T, ckptDir string, c checkpoint.Checkpoint) {
 	}
 }
 
+func assertCheckpointFilesEncodeAsArray(t *testing.T, metas []CheckpointMeta) {
+	t.Helper()
+	raw, err := json.Marshal(metas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload []struct {
+		Files json.RawMessage `json:"files"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for i, item := range payload {
+		if string(item.Files) == "null" {
+			t.Fatalf("checkpoint %d files encoded as null; frontend expects []", i)
+		}
+		if len(item.Files) == 0 || item.Files[0] != '[' {
+			t.Fatalf("checkpoint %d files encoded as %s, want JSON array", i, item.Files)
+		}
+	}
+}
+
 // TestCheckpointsCanCodePropagatesToEarlierTurns covers #3438: RestoreCode(turn)
 // reverts files touched in that turn or any later one, so a turn with no file
 // changes of its own can still rewind code when a later turn changed files. The
@@ -80,6 +102,10 @@ func TestCheckpointsCanCodePropagatesToEarlierTurns(t *testing.T) {
 	if metas[0].FileCount != 1 || metas[0].FilesTruncated {
 		t.Fatalf("turn 0 file summary = count %d truncated %v, want count 1 truncated false", metas[0].FileCount, metas[0].FilesTruncated)
 	}
+	if len(metas[2].Files) != 0 {
+		t.Fatalf("turn 2 cumulative files = %#v, want empty", metas[2].Files)
+	}
+	assertCheckpointFilesEncodeAsArray(t, metas)
 }
 
 func TestCheckpointsForTabLimitsCumulativeFilePreview(t *testing.T) {
@@ -124,4 +150,5 @@ func TestCheckpointsForTabLimitsCumulativeFilePreview(t *testing.T) {
 	if metas[1].TurnFileCount != checkpointFilePreviewLimit+5 {
 		t.Fatalf("turn 1 file count = %d, want %d", metas[1].TurnFileCount, checkpointFilePreviewLimit+5)
 	}
+	assertCheckpointFilesEncodeAsArray(t, metas)
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2769,7 +2769,7 @@ export default function App() {
     setProjectRevision((value) => value + 1);
     const tabs = await refreshTabMetas();
     if (activeTabId && !tabs.some((tab) => tab.id === activeTabId)) {
-      await syncActiveTab(true);
+      await syncActiveTab(false);
     }
   }, [activeTabId, refreshTabMetas, syncActiveTab]);
 

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -279,6 +279,21 @@ eq(controller?.activeTabId, "tab-a", "late history for another tab does not chan
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "cached A") ?? false, "late history for another tab does not overwrite the active transcript");
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "late B") ?? false), "late history stays scoped to its tab state");
 
+const historyCallsBeforeFallbackSync = historyCalls.length;
+backendActiveId = "tab-b";
+await act(async () => {
+  await controller?.syncActiveTab(false);
+  await flushPromises();
+});
+eq(controller?.activeTabId, "tab-b", "backend fallback sync activates the backend-selected cached tab");
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "late B") ?? false, "backend fallback sync keeps the cached transcript");
+eq(historyCalls.length, historyCallsBeforeFallbackSync, "backend fallback sync preserves cached history instead of reloading it");
+await act(async () => {
+  await controller?.switchTab("tab-a", tabA);
+  await flushPromises();
+});
+await waitFor("tab-a restored after fallback sync", () => controller?.activeTabId === "tab-a" && controller.state.items.some((item) => item.kind === "user" && item.text === "cached A"));
+
 failSetActiveFor = "tab-b";
 const historyCallsBeforeFailedSwitch = historyCalls.length;
 await act(async () => {

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -483,9 +483,9 @@ export function TurnActions({
     }
   };
   const actionMeta = (scope: MessageActionScope): string => {
-    if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
-      const total = checkpoint.files.length;
-      const turnCount = checkpoint.turnFileCount ?? 0;
+    const total = checkpoint?.fileCount ?? checkpoint?.files?.length ?? 0;
+    if ((scope === "code" || scope === "both") && total > 0) {
+      const turnCount = checkpoint?.turnFileCount ?? 0;
       if (turnCount > 0 && turnCount < total) {
         return `${t("rewind.filesChanged", { count: total })} (${t("rewind.turnFiles", { count: turnCount })})`;
       }
@@ -496,12 +496,16 @@ export function TurnActions({
   const actionTooltipLabel = (scope: MessageActionScope) => {
     const reason = actionDisabledReason(scope);
     if (reason) return <span>{reason}</span>;
-    if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
+    const files = checkpoint?.files ?? [];
+    const total = checkpoint?.fileCount ?? files.length;
+    if ((scope === "code" || scope === "both") && total > 0) {
+      const hidden = Math.max(0, total - files.length);
       return (
         <div className="rewind__files-tooltip">
-          {checkpoint.files.map((file) => (
+          {files.map((file) => (
             <div key={file}>{file.split(/[/\\]/).pop() || file}</div>
           ))}
+          {hidden > 0 && <div>+{hidden}</div>}
         </div>
       );
     }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1843,7 +1843,7 @@ function makeMockApp(): AppBindings {
         async ClearSession() {},
     async Checkpoints() {
       return [
-        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], turnFileCount: 1, time: Date.now() - 30_000, canCode: true, canConversation: true },
+        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], fileCount: 1, turnFileCount: 1, time: Date.now() - 30_000, canCode: true, canConversation: true },
       ];
     },
     async CheckpointsForTab() {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -356,6 +356,8 @@ export interface CheckpointMeta {
   turn: number;
   prompt: string;
   files: string[];
+  fileCount?: number;
+  filesTruncated?: boolean;
   turnFileCount?: number;
   time: number; // unix ms
   canCode?: boolean;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -43,6 +43,9 @@ export type LiveStream = { id: string; text: string; reasoning: string; reasonin
 export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversation" | "code" | "both";
 export type MessageActionState = { turn: number; scope: MessageActionScope };
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup";
+type SyncActiveTabOptions = {
+  preserveCachedHistory?: boolean;
+};
 
 const HISTORY_PAGE_TURNS = 60;
 
@@ -1109,17 +1112,35 @@ export function useController() {
         return;
       }
       const ancillaryStartedAt = Date.now();
-      const [effort, jobs, checkpoints, context] = await Promise.all([
-        app.EffortForTab(tabId).catch((err) => { noteFailure("effort", err); return undefined; }),
-        app.JobsForTab(tabId).catch((err) => { noteFailure("jobs", err); return undefined; }),
-        app.CheckpointsForTab(tabId).catch((err) => { noteFailure("checkpoints", err); return undefined; }),
-        app.ContextUsageForTab(tabId).catch((err) => { noteFailure("context", err); return undefined; }),
+      const loadAncillary = async <T,>(label: string, load: () => Promise<T>): Promise<T | undefined> => {
+        const startedAt = Date.now();
+        try {
+          const value = await load();
+          addBreadcrumb("tab.hydrate", `ancillary ${label} ${reason} ${tabId} ms=${Date.now() - startedAt}`);
+          return value;
+        } catch (err) {
+          noteFailure(label, err);
+          return undefined;
+        }
+      };
+      const [effort, jobs, context] = await Promise.all([
+        loadAncillary("effort", () => app.EffortForTab(tabId)),
+        loadAncillary("jobs", () => app.JobsForTab(tabId)),
+        loadAncillary("context", () => app.ContextUsageForTab(tabId)),
       ]);
       if (!stillCurrent()) return;
       if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
       if (jobs !== undefined) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
-      if (checkpoints !== undefined) dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
       if (context !== undefined) dispatchTo(tabId, { type: "context", context });
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+      if (!stillCurrent()) return;
+      if (activeTabIdRef.current !== tabId && (reason === "startup" || reason === "switch-tab" || reason === "open-topic")) {
+        addBreadcrumb("tab.hydrate", `checkpoints skipped inactive ${reason} ${tabId}`);
+        return;
+      }
+      const checkpoints = await loadAncillary("checkpoints", () => app.CheckpointsForTab(tabId));
+      if (!stillCurrent()) return;
+      if (checkpoints !== undefined) dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
       addBreadcrumb("tab.hydrate", `ancillary ${reason} ${tabId} ms=${Date.now() - ancillaryStartedAt}`);
       app.BalanceForTab(tabId)
         .then((balance) => {
@@ -1180,7 +1201,7 @@ export function useController() {
     }
   }, []);
 
-  const syncActiveTabFromBackend = useCallback(async (reset = false, guard = false): Promise<string | undefined> => {
+  const syncActiveTabFromBackend = useCallback(async (reset = false, guard = false, options: SyncActiveTabOptions = {}): Promise<string | undefined> => {
     const active = await activeTabFromBackend();
     if (!active) return undefined;
     // When guard is true, skip if the frontend already settled on a
@@ -1194,7 +1215,11 @@ export function useController() {
     activeTabIdRef.current = active.id;
     confirmBackendActiveTab(active.id);
     dispatchTo(active.id, { type: "optimistic_meta", meta: metaFromTab(active, statesRef.current.get(active.id)?.meta) });
-    await loadSessionDataForTab(active.id, reset, "startup");
+    const preserveCachedHistory = options.preserveCachedHistory ?? !reset;
+    await loadSessionDataForTab(active.id, reset, "startup", {
+      preserveCachedHistory,
+      sessionPath: active.sessionPath,
+    });
     return active.id;
   }, [activeTabFromBackend, confirmBackendActiveTab, dispatchTo, loadSessionDataForTab]);
 
@@ -1885,7 +1910,7 @@ export function useController() {
       await app.CloseTab(tabId);
       statesRef.current.delete(tabId);
       bump();
-      if (tabId === activeTabId) await syncActiveTabFromBackend(true);
+      if (tabId === activeTabId) await syncActiveTabFromBackend(false);
     } catch { /* ignore */ }
   }, [activeTabId, bump, syncActiveTabFromBackend]);
 


### PR DESCRIPTION
## Summary

- Preserve cached transcripts when topic/tab removal falls back to an already-hydrated desktop tab, avoiding a forced startup history reload after `TrashTopic` / close-tab fallback.
- Split phase-2 hydration so effort/jobs/context land before checkpoint metadata, add per-call breadcrumbs, and skip checkpoint refresh when the tab becomes inactive.
- Keep rewind behavior intact while reducing checkpoint payload size: checkpoint metadata now sends the full affected-file count plus a bounded stable preview instead of every cumulative file path.

## Relationship

- Addresses the remaining Desktop performance paths reported in #5306, especially the v1.14.1 payload where `TrashTopic` was followed by `startup` hydration and a long `ancillary startup` phase.
- Builds on #5355 and #5619 by addressing the remaining fallback-sync and checkpoint-payload costs after the warm/cold pagination and hydration-storm fixes.

## Contributor credit

@July-X should be recognized as a co-contributor to this repository fix. Thanks to @July-X for opening #5306 and continuing to provide versioned performance payloads and reproduction details that made the remaining `TrashTopic` / ancillary hydration path visible.

## Verification

- PASS `pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- PASS `pnpm -C desktop/frontend --ignore-workspace exec tsc --noEmit`
- PASS `(cd desktop && go test . -run 'TestCheckpoints(CanCodePropagatesToEarlierTurns|ForTabLimitsCumulativeFilePreview)$')`
- PASS `pnpm -C desktop/frontend --ignore-workspace run test`
- PASS `pnpm -C desktop/frontend --ignore-workspace run build`
- PASS `(cd desktop && go test ./...)`
- PASS `git diff --check origin/main-v2...HEAD`

## Cache impact

Cache-impact: none, desktop frontend hydration orchestration and Wails checkpoint metadata only; no provider-visible prompt/tool/schema serialization changes.
Cache-guard: PASS `pnpm -C desktop/frontend --ignore-workspace run test`
System-prompt-review: N/A
