### PR TITLE
Fix Windows classic titlebar tool positioning / 修复 Windows 经典标题栏工具定位

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -253,6 +253,30 @@ for (const selector of [
 }
 
 for (const selector of [
+  ".app--windows-frameless .app-chrome--native-tabs",
+  ":root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs",
+]) {
+  const paddingRight = finalDeclaration(selector, "padding-right") ?? "";
+  ok(
+    finalDeclaration(selector, "--windows-frameless-titlebar-tools-offset") === "var(--windows-window-controls-safe)" &&
+      paddingRight.includes("--windows-frameless-titlebar-tools-offset") &&
+      paddingRight.includes("--chrome-panel-control-size") &&
+      !paddingRight.includes("--chrome-right-toggle-offset"),
+    `${selector} keeps titlebar tools fixed beside the Windows controls`,
+  );
+}
+
+for (const selector of [
+  ".app--windows-frameless .app-chrome--native-tabs .app-chrome__panel-toggle--right",
+  ":root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs .app-chrome__panel-toggle--right",
+]) {
+  ok(
+    finalDeclaration(selector, "right") === "calc(var(--windows-frameless-titlebar-tools-offset) + 8px)",
+    `${selector} stays fixed outside the Windows window controls`,
+  );
+}
+
+for (const selector of [
   ".layout--workbench-chrome-hidden",
   ":root[data-theme-style] .layout--workbench-chrome-hidden",
 ]) {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -27647,7 +27647,13 @@ body > .mermaid-diagram--fullscreen {
 
 .app--windows-frameless .app-chrome--native-tabs,
 :root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs {
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--windows-window-controls-safe));
+  --windows-frameless-titlebar-tools-offset: var(--windows-window-controls-safe);
+  padding-right: calc(var(--windows-frameless-titlebar-tools-offset) + var(--chrome-panel-control-size, 30px) + 18px);
+}
+
+.app--windows-frameless .app-chrome--native-tabs .app-chrome__panel-toggle--right,
+:root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs .app-chrome__panel-toggle--right {
+  right: calc(var(--windows-frameless-titlebar-tools-offset) + 8px);
 }
 
 .app--windows-frameless .topicbar,


### PR DESCRIPTION
## Summary
- Keep the classic Windows titlebar search button and right dock toggle fixed beside the native window controls.
- Reserve a stable titlebar tool slot without coupling it to the right dock width.
- Add an AppChrome regression check for the Windows frameless selector contract.

## Root Cause
The Windows frameless app chrome reused the right dock offset when reserving titlebar space, so the search and toggle controls shifted when the right dock opened and could collide with the native window control area.

## Verification
- `pnpm check:css`
- `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts`
- Browser DOM check in the classic Windows preview: collapsed and expanded right dock states kept the search/toggle positions unchanged and non-overlapping with the native window controls.