### PR TITLE
Guard anchor edits after same-turn writes / 防止同回合锚点编辑失效

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2015,6 +2015,13 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 			errMsg:  "blocked by loop guard",
 		}
 	}
+	if out, blocked := a.staleAnchorEditBlock(call); blocked {
+		return toolOutcome{
+			output:  out,
+			blocked: true,
+			errMsg:  "blocked: fresh read required",
+		}
+	}
 	if a.planMode.Load() {
 		// Translate the tool's optional plan-mode self-report into the policy's
 		// tri-state. Mirrors the t.(tool.Previewer) assertion precedent below.
@@ -2240,6 +2247,32 @@ func (a *Agent) repeatedSuccessBlock(call provider.ToolCall, t tool.Tool) (strin
 	return fmt.Sprintf(
 		"blocked: [loop guard] %q has already succeeded %d times with the same write-like arguments in this user turn. Re-running it is unlikely to help and may burn tokens or repeat file writes. Change approach: use edit_file or multi_edit for file changes, verify with a read/test command, or explain the blocker in your final answer.",
 		call.Name, count), true
+}
+
+func (a *Agent) staleAnchorEditBlock(call provider.ToolCall) (string, bool) {
+	if a.evidence == nil || !anchorBasedEditTool(call.Name) {
+		return "", false
+	}
+	rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, false)
+	if len(rec.Paths) == 0 {
+		return "", false
+	}
+	writeIndex, ok := a.evidence.LatestSuccessfulWriteIndex(rec.Paths)
+	if !ok || a.evidence.HasSuccessfulReadAfter(rec.Paths, writeIndex) {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"blocked: [fresh read required] %q targets %s, which was already modified earlier this turn. Re-read the current file with read_file before another anchor-based edit, or combine the final same-file changes in one multi_edit call. This prevents stale old_string anchors and half-deleted ranges.",
+		call.Name, strings.Join(rec.Paths, ", ")), true
+}
+
+func anchorBasedEditTool(name string) bool {
+	switch name {
+	case "edit_file", "delete_range":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *Agent) recordRepeatSuccess(call provider.ToolCall, t tool.Tool) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2258,11 +2258,11 @@ func (a *Agent) staleAnchorEditBlock(call provider.ToolCall) (string, bool) {
 		return "", false
 	}
 	writeIndex, ok := a.evidence.LatestSuccessfulWriteIndex(rec.Paths)
-	if !ok || a.evidence.HasSuccessfulReadAfter(rec.Paths, writeIndex) {
+	if !ok || a.evidence.HasSuccessfulAnchorRefreshReadAfter(rec.Paths, writeIndex) {
 		return "", false
 	}
 	return fmt.Sprintf(
-		"blocked: [fresh read required] %q targets %s, which was already modified earlier this turn. Re-read the current file with read_file before another anchor-based edit, or combine the final same-file changes in one multi_edit call. This prevents stale old_string anchors and half-deleted ranges.",
+		"blocked: [fresh read required] %q targets %s, which was already modified earlier this turn. Re-read the current file with read_file without offset/limit before another anchor-based edit, or combine the final same-file changes in one multi_edit call. This prevents stale old_string anchors and half-deleted ranges.",
 		call.Name, strings.Join(rec.Paths, ", ")), true
 }
 

--- a/internal/agent/stale_anchor_guard_test.go
+++ b/internal/agent/stale_anchor_guard_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestAnchorEditRequiresReadAfterSameTurnWrite(t *testing.T) {
+	var editCalls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "edit_file", readOnly: false, calls: &editCalls})
+
+	args := `{"path":"src/map.html","old_string":"before","new_string":"after"}`
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "edit_file", args),
+			toolCallChunk("c2", "edit_file", args),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit the map"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&editCalls); got != 1 {
+		t.Fatalf("edit_file executed %d times, want only the first call", got)
+	}
+	results := toolResults(a.session, "edit_file")
+	if len(results) != 2 {
+		t.Fatalf("tool results = %d, want 2", len(results))
+	}
+	last := results[len(results)-1]
+	for _, want := range []string{"[fresh read required]", "read_file", "multi_edit"} {
+		if !strings.Contains(last, want) {
+			t.Fatalf("blocked result should mention %q, got %q", want, last)
+		}
+	}
+}
+
+func TestAnchorEditAllowedAfterFreshRead(t *testing.T) {
+	var editCalls int32
+	var readCalls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "edit_file", readOnly: false, calls: &editCalls})
+	reg.Add(fakeTool{name: "read_file", readOnly: true, calls: &readCalls})
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "edit_file", `{"path":"src/map.html","old_string":"before","new_string":"after"}`),
+			toolCallChunk("c2", "read_file", `{"path":"src/map.html"}`),
+			toolCallChunk("c3", "edit_file", `{"path":"src/map.html","old_string":"current","new_string":"final"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit the map with a read between edits"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&readCalls); got != 1 {
+		t.Fatalf("read_file executed %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&editCalls); got != 2 {
+		t.Fatalf("edit_file executed %d times, want 2 after fresh read", got)
+	}
+	if last := lastToolResult(a.session, "edit_file"); strings.Contains(last, "[fresh read required]") {
+		t.Fatalf("fresh read should allow the second edit, got %q", last)
+	}
+}
+
+func TestMultiEditAllowedAfterSameTurnWrite(t *testing.T) {
+	var editCalls int32
+	var multiCalls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "edit_file", readOnly: false, calls: &editCalls})
+	reg.Add(fakeTool{name: "multi_edit", readOnly: false, calls: &multiCalls})
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "edit_file", `{"path":"src/map.html","old_string":"before","new_string":"after"}`),
+			toolCallChunk("c2", "multi_edit", `{"path":"src/map.html","edits":[{"old_string":"current","new_string":"final"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit the map atomically"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&editCalls); got != 1 {
+		t.Fatalf("edit_file executed %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&multiCalls); got != 1 {
+		t.Fatalf("multi_edit executed %d times, want 1", got)
+	}
+}

--- a/internal/agent/stale_anchor_guard_test.go
+++ b/internal/agent/stale_anchor_guard_test.go
@@ -77,6 +77,38 @@ func TestAnchorEditAllowedAfterFreshRead(t *testing.T) {
 	}
 }
 
+func TestAnchorEditStillRequiresReadAfterWindowedRead(t *testing.T) {
+	var editCalls int32
+	var readCalls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "edit_file", readOnly: false, calls: &editCalls})
+	reg.Add(fakeTool{name: "read_file", readOnly: true, calls: &readCalls})
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "edit_file", `{"path":"src/map.html","old_string":"before","new_string":"after"}`),
+			toolCallChunk("c2", "read_file", `{"path":"src/map.html","offset":400,"limit":20}`),
+			toolCallChunk("c3", "edit_file", `{"path":"src/map.html","old_string":"current","new_string":"final"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit the map with a narrow read between edits"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&readCalls); got != 1 {
+		t.Fatalf("read_file executed %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&editCalls); got != 1 {
+		t.Fatalf("edit_file executed %d times, want only the first call", got)
+	}
+	if last := lastToolResult(a.session, "edit_file"); !strings.Contains(last, "[fresh read required]") {
+		t.Fatalf("windowed read should not allow the second edit, got %q", last)
+	}
+}
+
 func TestMultiEditAllowedAfterSameTurnWrite(t *testing.T) {
 	var editCalls int32
 	var multiCalls int32

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -359,6 +359,35 @@ func (l *Ledger) LatestSuccessfulWriteIndex(paths []string) (int, bool) {
 	return latest, latest >= 0
 }
 
+// HasSuccessfulReadAfter reports whether any wanted path was read after the
+// given receipt index. It lets anchor-based edit tools require a fresh file view
+// after a same-turn write changed the text their anchors would match.
+func (l *Ledger) HasSuccessfulReadAfter(paths []string, after int) bool {
+	wanted := pathSet(normalizePaths(paths))
+	if l == nil || len(wanted) == 0 {
+		return false
+	}
+	start := after + 1
+	if start < 0 {
+		start = 0
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := start; i < len(l.receipts); i++ {
+		r := l.receipts[i]
+		if !r.Success || !r.Read {
+			continue
+		}
+		for _, p := range r.Paths {
+			if wanted[p] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (l *Ledger) LatestSuccessfulWriterIndex() (int, bool) {
 	if l == nil {
 		return 0, false

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -359,10 +359,11 @@ func (l *Ledger) LatestSuccessfulWriteIndex(paths []string) (int, bool) {
 	return latest, latest >= 0
 }
 
-// HasSuccessfulReadAfter reports whether any wanted path was read after the
-// given receipt index. It lets anchor-based edit tools require a fresh file view
-// after a same-turn write changed the text their anchors would match.
-func (l *Ledger) HasSuccessfulReadAfter(paths []string, after int) bool {
+// HasSuccessfulAnchorRefreshReadAfter reports whether read_file refreshed a
+// wanted path after the given receipt index. Windowed reads and grep/ls receipts
+// are deliberately not enough for same-turn anchor edits: they may have observed
+// a different region than the next old_string/delete_range anchor.
+func (l *Ledger) HasSuccessfulAnchorRefreshReadAfter(paths []string, after int) bool {
 	wanted := pathSet(normalizePaths(paths))
 	if l == nil || len(wanted) == 0 {
 		return false
@@ -376,7 +377,7 @@ func (l *Ledger) HasSuccessfulReadAfter(paths []string, after int) bool {
 	defer l.mu.Unlock()
 	for i := start; i < len(l.receipts); i++ {
 		r := l.receipts[i]
-		if !r.Success || !r.Read {
+		if !r.Success || !anchorRefreshRead(r) {
 			continue
 		}
 		for _, p := range r.Paths {
@@ -386,6 +387,23 @@ func (l *Ledger) HasSuccessfulReadAfter(paths []string, after int) bool {
 		}
 	}
 	return false
+}
+
+func anchorRefreshRead(r Receipt) bool {
+	if r.ToolName != "read_file" || !r.Read {
+		return false
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(r.Args, &fields); err != nil {
+		return false
+	}
+	if limit, ok := intField(fields, "limit"); ok && limit > 0 {
+		return false
+	}
+	if offset, ok := intField(fields, "offset"); ok && offset > 0 {
+		return false
+	}
+	return true
 }
 
 func (l *Ledger) LatestSuccessfulWriterIndex() (int, bool) {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -46,6 +46,23 @@ func TestLedgerMatchesFileReadAndWriteReceipts(t *testing.T) {
 	}
 }
 
+func TestLedgerReportsReadsAfterWrites(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(Receipt{ToolName: "write_file", Success: true, Paths: []string{`src\a.go`}, Write: true})
+	writeIndex, ok := ledger.LatestSuccessfulWriteIndex([]string{`src/a.go`})
+	if !ok {
+		t.Fatal("expected latest write index")
+	}
+	if ledger.HasSuccessfulReadAfter([]string{`src/a.go`}, writeIndex) {
+		t.Fatal("read-after-write should be false before a read")
+	}
+
+	ledger.Record(Receipt{ToolName: "read_file", Success: true, Paths: []string{`src/a.go`}, Read: true})
+	if !ledger.HasSuccessfulReadAfter([]string{`src/a.go`}, writeIndex) {
+		t.Fatal("read-after-write should be true after a successful read")
+	}
+}
+
 func TestLedgerReportsFinalReadinessReceiptsAfterWriter(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -46,19 +46,27 @@ func TestLedgerMatchesFileReadAndWriteReceipts(t *testing.T) {
 	}
 }
 
-func TestLedgerReportsReadsAfterWrites(t *testing.T) {
+func TestLedgerReportsAnchorRefreshReadsAfterWrites(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{ToolName: "write_file", Success: true, Paths: []string{`src\a.go`}, Write: true})
 	writeIndex, ok := ledger.LatestSuccessfulWriteIndex([]string{`src/a.go`})
 	if !ok {
 		t.Fatal("expected latest write index")
 	}
-	if ledger.HasSuccessfulReadAfter([]string{`src/a.go`}, writeIndex) {
+	if ledger.HasSuccessfulAnchorRefreshReadAfter([]string{`src/a.go`}, writeIndex) {
 		t.Fatal("read-after-write should be false before a read")
 	}
 
-	ledger.Record(Receipt{ToolName: "read_file", Success: true, Paths: []string{`src/a.go`}, Read: true})
-	if !ledger.HasSuccessfulReadAfter([]string{`src/a.go`}, writeIndex) {
+	ledger.Record(Receipt{ToolName: "grep", Success: true, Paths: []string{`src/a.go`}, Read: true, Args: json.RawMessage(`{"path":"src/a.go","pattern":"func"}`)})
+	if ledger.HasSuccessfulAnchorRefreshReadAfter([]string{`src/a.go`}, writeIndex) {
+		t.Fatal("grep should not refresh anchor edit state")
+	}
+	ledger.Record(Receipt{ToolName: "read_file", Success: true, Paths: []string{`src/a.go`}, Read: true, Args: json.RawMessage(`{"path":"src/a.go","offset":100,"limit":20}`)})
+	if ledger.HasSuccessfulAnchorRefreshReadAfter([]string{`src/a.go`}, writeIndex) {
+		t.Fatal("windowed read_file should not refresh anchor edit state")
+	}
+	ledger.Record(Receipt{ToolName: "read_file", Success: true, Paths: []string{`src/a.go`}, Read: true, Args: json.RawMessage(`{"path":"src/a.go"}`)})
+	if !ledger.HasSuccessfulAnchorRefreshReadAfter([]string{`src/a.go`}, writeIndex) {
 		t.Fatal("read-after-write should be true after a successful read")
 	}
 }

--- a/internal/tool/builtin/builtin_test.go
+++ b/internal/tool/builtin/builtin_test.go
@@ -192,6 +192,8 @@ func TestEditFile(t *testing.T) {
 	args := argsJSON(t, map[string]any{"path": f, "old_string": "x", "new_string": "y"})
 	if _, err := (editFile{}).Execute(context.Background(), args); err == nil {
 		t.Fatal("expected not-unique error")
+	} else if !strings.Contains(err.Error(), "repeated separator lines") {
+		t.Fatalf("not-unique error should steer away from weak anchors, got: %v", err)
 	}
 	if b, _ := os.ReadFile(f); string(b) != "x x x" {
 		t.Fatalf("file modified despite error: %q", b)

--- a/internal/tool/builtin/delete_range.go
+++ b/internal/tool/builtin/delete_range.go
@@ -104,20 +104,29 @@ func (d deleteRange) preview(args json.RawMessage) (diff.Change, error) {
 	lines := strings.Split(strings.ReplaceAll(original, "\r", ""), "\n")
 	startLine := findUniqueLine(lines, p.StartAnchor)
 	if startLine == -2 {
-		return diff.Change{}, fmt.Errorf("start_anchor is not unique in %s; add more surrounding context", p.Path)
+		return diff.Change{}, fmt.Errorf("start_anchor is not unique in %s%s; add nearby unique code, not just repeated separator lines", p.Path, lineMatchSummary(lines, p.StartAnchor, 5))
 	}
 	if startLine == -1 {
 		return diff.Change{}, fmt.Errorf("start_anchor not found in %s", p.Path)
 	}
 	endLine := findUniqueLine(lines, p.EndAnchor)
 	if endLine == -2 {
-		return diff.Change{}, fmt.Errorf("end_anchor is not unique in %s; add more surrounding context", p.Path)
+		return diff.Change{}, fmt.Errorf("end_anchor is not unique in %s%s; add nearby unique code, not just repeated separator lines", p.Path, lineMatchSummary(lines, p.EndAnchor, 5))
 	}
 	if endLine == -1 {
 		return diff.Change{}, fmt.Errorf("end_anchor not found in %s", p.Path)
 	}
 	if startLine > endLine {
 		return diff.Change{}, fmt.Errorf("start_anchor appears after end_anchor (lines %d and %d)", startLine+1, endLine+1)
+	}
+	deleteStart, deleteEnd, deletesLines, err := deletionLineInterval(startLine, endLine, inclusive, p.Path)
+	if err != nil {
+		return diff.Change{}, err
+	}
+	if deletesLines {
+		if err := validateBraceCompleteDeletion(lines, deleteStart, deleteEnd, p.Path); err != nil {
+			return diff.Change{}, err
+		}
 	}
 
 	// Build new content
@@ -157,4 +166,141 @@ func findUniqueLine(lines []string, target string) int {
 		}
 	}
 	return idx
+}
+
+func deletionLineInterval(startLine, endLine int, inclusive bool, path string) (int, int, bool, error) {
+	if inclusive {
+		return startLine, endLine, true, nil
+	}
+	if startLine == endLine {
+		return 0, 0, false, fmt.Errorf("start_anchor and end_anchor match the same line in %s; with inclusive=false there is nothing between them to delete", path)
+	}
+	start, end := startLine+1, endLine-1
+	if start > end {
+		return start, end, false, nil
+	}
+	return start, end, true, nil
+}
+
+func validateBraceCompleteDeletion(lines []string, deleteStart, deleteEnd int, path string) error {
+	for _, pair := range bracePairsByLine(lines) {
+		if pair.openLine < 0 || pair.closeLine < 0 {
+			continue
+		}
+		openDeleted := lineInRange(pair.openLine, deleteStart, deleteEnd)
+		closeDeleted := lineInRange(pair.closeLine, deleteStart, deleteEnd)
+		switch {
+		case openDeleted && !closeDeleted:
+			if pair.openLine == deleteEnd {
+				return fmt.Errorf("end_anchor in %s appears to open a code block at line %d; delete_range would delete that header but leave its closing line %d outside the range. Use an end_anchor on the block's closing line, or use edit_file/multi_edit with the full exact block", path, pair.openLine+1, pair.closeLine+1)
+			}
+			return fmt.Errorf("delete_range in %s would cut a code block: opening brace at line %d is deleted but its closing brace at line %d is kept. Choose anchors that include the whole block, or use edit_file/multi_edit with the full exact block", path, pair.openLine+1, pair.closeLine+1)
+		case !openDeleted && closeDeleted:
+			return fmt.Errorf("delete_range in %s would cut a code block: closing brace at line %d is deleted but its opening brace at line %d is kept. Choose anchors that include the whole block, or use edit_file/multi_edit with the full exact block", path, pair.closeLine+1, pair.openLine+1)
+		}
+	}
+	return nil
+}
+
+func lineInRange(line, start, end int) bool {
+	return line >= start && line <= end
+}
+
+type bracePair struct {
+	openLine  int
+	closeLine int
+}
+
+func bracePairsByLine(lines []string) []bracePair {
+	var pairs []bracePair
+	var stack []int
+	inBlockComment := false
+	var quote byte
+	escaped := false
+
+	for lineNo, line := range lines {
+		for i := 0; i < len(line); i++ {
+			c := line[i]
+			if inBlockComment {
+				if c == '*' && i+1 < len(line) && line[i+1] == '/' {
+					inBlockComment = false
+					i++
+				}
+				continue
+			}
+			if quote != 0 {
+				if escaped {
+					escaped = false
+					continue
+				}
+				if c == '\\' {
+					escaped = true
+					continue
+				}
+				if c == quote {
+					quote = 0
+				}
+				continue
+			}
+			if c == '/' && i+1 < len(line) {
+				switch line[i+1] {
+				case '/':
+					i = len(line)
+					continue
+				case '*':
+					inBlockComment = true
+					i++
+					continue
+				}
+			}
+			switch c {
+			case '\'', '"', '`':
+				quote = c
+			case '{':
+				stack = append(stack, lineNo)
+			case '}':
+				if len(stack) == 0 {
+					pairs = append(pairs, bracePair{openLine: -1, closeLine: lineNo})
+					continue
+				}
+				openLine := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				pairs = append(pairs, bracePair{openLine: openLine, closeLine: lineNo})
+			}
+		}
+		if quote == '\'' || quote == '"' {
+			quote = 0
+			escaped = false
+		}
+	}
+	for _, openLine := range stack {
+		pairs = append(pairs, bracePair{openLine: openLine, closeLine: -1})
+	}
+	return pairs
+}
+
+func lineMatchSummary(lines []string, target string, limit int) string {
+	var matches []int
+	for i, line := range lines {
+		if line == target {
+			matches = append(matches, i+1)
+		}
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(" (matching lines include ")
+	for i, line := range matches {
+		if i >= limit {
+			b.WriteString(", ...")
+			break
+		}
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(fmt.Sprint(line))
+	}
+	b.WriteString(")")
+	return b.String()
 }

--- a/internal/tool/builtin/delete_range.go
+++ b/internal/tool/builtin/delete_range.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"reasonix/internal/diff"
@@ -123,7 +124,7 @@ func (d deleteRange) preview(args json.RawMessage) (diff.Change, error) {
 	if err != nil {
 		return diff.Change{}, err
 	}
-	if deletesLines {
+	if deletesLines && shouldValidateBraceCompleteDeletion(p.Path) {
 		if err := validateBraceCompleteDeletion(lines, deleteStart, deleteEnd, p.Path); err != nil {
 			return diff.Change{}, err
 		}
@@ -180,6 +181,19 @@ func deletionLineInterval(startLine, endLine int, inclusive bool, path string) (
 		return start, end, false, nil
 	}
 	return start, end, true, nil
+}
+
+func shouldValidateBraceCompleteDeletion(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".c", ".cc", ".cjs", ".cpp", ".cs", ".css", ".cxx",
+		".go", ".h", ".hh", ".hpp", ".htm", ".html",
+		".java", ".js", ".json", ".jsonc", ".jsx", ".kt", ".kts",
+		".less", ".mjs", ".php", ".rs", ".sass", ".scss", ".svelte",
+		".swift", ".ts", ".tsx", ".vue":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateBraceCompleteDeletion(lines []string, deleteStart, deleteEnd int, path string) error {
@@ -299,7 +313,7 @@ func lineMatchSummary(lines []string, target string, limit int) string {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(fmt.Sprint(line))
+		fmt.Fprint(&b, line)
 	}
 	b.WriteString(")")
 	return b.String()

--- a/internal/tool/builtin/delete_range_test.go
+++ b/internal/tool/builtin/delete_range_test.go
@@ -103,6 +103,132 @@ func TestDeleteRangeReversed(t *testing.T) {
 	}
 }
 
+func TestDeleteRangeRejectsEndAnchorOpeningBlock(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "map.html")
+	body := strings.Join([]string{
+		"// map engine",
+		"function switchToProvinceMap() {",
+		"  redraw();",
+		"}",
+		"function highlightCurrentOnMap() {",
+		"  if (!state.mapInstance) return;",
+		"  repaint();",
+		"}",
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "// map engine", "end_anchor": "function highlightCurrentOnMap() {",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected block-opening end_anchor to be rejected")
+	}
+	for _, want := range []string{"appears to open a code block", "closing line", "edit_file/multi_edit"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != body {
+		t.Errorf("file modified despite rejected range:\n%s", got)
+	}
+}
+
+func TestDeleteRangeAllowsCompleteBraceBlock(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "map.html")
+	body := strings.Join([]string{
+		"function before() {",
+		"  keep();",
+		"}",
+		"function removeMe() {",
+		"  if (ok) {",
+		"    redraw();",
+		"  }",
+		"} // removeMe",
+		"function after() {",
+		"  keep();",
+		"}",
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "function removeMe() {", "end_anchor": "} // removeMe",
+	})
+	got, _ := os.ReadFile(f)
+	want := strings.Join([]string{
+		"function before() {",
+		"  keep();",
+		"}",
+		"function after() {",
+		"  keep();",
+		"}",
+		"",
+	}, "\n")
+	if string(got) != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestDeleteRangeRejectsClosingBraceWithoutOpening(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "map.html")
+	body := strings.Join([]string{
+		"function keepHeader() {",
+		"  removeBody();",
+		"} // keepHeader",
+		"function after() {",
+		"  keep();",
+		"}",
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "  removeBody();", "end_anchor": "} // keepHeader",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected range cutting a block close to be rejected")
+	}
+	for _, want := range []string{"would cut a code block", "closing brace", "opening brace"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != body {
+		t.Errorf("file modified despite rejected range:\n%s", got)
+	}
+}
+
+func TestDeleteRangeDuplicateAnchorReportsLines(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "dup-separator.js")
+	body := strings.Join([]string{
+		"// ═══════════════════════════════════════",
+		"const a = 1;",
+		"// ═══════════════════════════════════════",
+		"const b = 2;",
+		"// ═══════════════════════════════════════",
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "// ═══════════════════════════════════════", "end_anchor": "const b = 2;",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected duplicate anchor error")
+	}
+	for _, want := range []string{"not unique", "matching lines include 1, 3, 5", "repeated separator lines"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}
+
 func TestDeleteRangeCRLF(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "crlf.txt")
 	body := "line1\r\nline2\r\nline3\r\nline4\r\nline5\r\n"

--- a/internal/tool/builtin/delete_range_test.go
+++ b/internal/tool/builtin/delete_range_test.go
@@ -203,6 +203,33 @@ func TestDeleteRangeRejectsClosingBraceWithoutOpening(t *testing.T) {
 	}
 }
 
+func TestDeleteRangeAllowsPartialBraceDeletionInPlainText(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "notes.md")
+	body := strings.Join([]string{
+		"intro",
+		"example {",
+		"  remove this prose line",
+		"}",
+		"end",
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "example {", "end_anchor": "  remove this prose line",
+	})
+	got, _ := os.ReadFile(f)
+	want := strings.Join([]string{
+		"intro",
+		"}",
+		"end",
+		"",
+	}, "\n")
+	if string(got) != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
 func TestDeleteRangeDuplicateAnchorReportsLines(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "dup-separator.js")
 	body := strings.Join([]string{

--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -62,7 +62,7 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	case applied.matches == 0:
 		return "", oldStringNotFoundError(p.Path, p.OldString, content)
 	default:
-		return "", oldStringNotUniqueError(p.Path, applied.matches, false)
+		return "", oldStringNotUniqueError(p.Path, p.OldString, content, applied.matches, false)
 	}
 
 	if err := writeFileEncoded(p.Path, applied.updated, enc); err != nil {

--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -115,17 +115,19 @@ func applyOldStringEdit(content, oldString, newString string, replaceAll bool) e
 }
 
 func oldStringNotFoundError(path, oldString, content string) error {
+	hint := " Re-read the current file before retrying; if several related edits target the same area, combine the final replacements in one multi_edit call."
 	if line, text, ok := nearestContentLine(oldString, content); ok {
-		return fmt.Errorf("old_string not found in %s (nearest line %d: %q)", path, line, text)
+		return fmt.Errorf("old_string not found in %s (nearest line %d: %q).%s", path, line, text, hint)
 	}
-	return fmt.Errorf("old_string not found in %s", path)
+	return fmt.Errorf("old_string not found in %s.%s", path, hint)
 }
 
-func oldStringNotUniqueError(path string, matches int, replaceAllHint bool) error {
+func oldStringNotUniqueError(path, oldString, content string, matches int, replaceAllHint bool) error {
+	lineHint := oldStringMatchLineSummary(oldString, content, 5)
 	if replaceAllHint {
-		return fmt.Errorf("old_string is not unique in %s (%d matches); add more surrounding context or set replace_all", path, matches)
+		return fmt.Errorf("old_string is not unique in %s (%d matches)%s; add nearby unique code, not just repeated separator lines, or set replace_all if every match should change", path, matches, lineHint)
 	}
-	return fmt.Errorf("old_string is not unique in %s (%d matches); add more surrounding context", path, matches)
+	return fmt.Errorf("old_string is not unique in %s (%d matches)%s; add nearby unique code, not just repeated separator lines", path, matches, lineHint)
 }
 
 type lineSegment struct {
@@ -317,6 +319,51 @@ func nearestContentLine(oldString, content string) (int, string, bool) {
 		return 0, "", false
 	}
 	return bestLine, bestText, true
+}
+
+func oldStringMatchLineSummary(oldString, content string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	target := firstNonEmptyLine(oldString)
+	if target == "" {
+		return ""
+	}
+	var matches []int
+	for i, line := range splitLineSegments(content) {
+		text := strings.TrimSuffix(line.raw, "\n")
+		text = strings.TrimSuffix(text, "\r")
+		if strings.Contains(text, target) {
+			matches = append(matches, i+1)
+		}
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("; matching lines include ")
+	for i, line := range matches {
+		if i >= limit {
+			b.WriteString(", ...")
+			break
+		}
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(fmt.Sprint(line))
+	}
+	return b.String()
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range splitLineSegments(s) {
+		text := strings.TrimSpace(strings.TrimSuffix(line.raw, "\n"))
+		text = strings.TrimSuffix(text, "\r")
+		if text != "" {
+			return text
+		}
+	}
+	return ""
 }
 
 func commonPrefixLen(a, b string) int {

--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -350,7 +350,7 @@ func oldStringMatchLineSummary(oldString, content string, limit int) string {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(fmt.Sprint(line))
+		fmt.Fprint(&b, line)
 	}
 	return b.String()
 }

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -101,9 +101,9 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 			applied += result.applied
 			usedFuzzy = usedFuzzy || result.fuzzy
 		case result.matches == 0:
-			return "", fmt.Errorf("edit %d: old_string not found", i+1)
+			return "", fmt.Errorf("edit %d: %w", i+1, oldStringNotFoundError(p.Path, step.OldString, content))
 		default:
-			return "", fmt.Errorf("edit %d: old_string is not unique; add more surrounding context or set replace_all", i+1)
+			return "", fmt.Errorf("edit %d: %w", i+1, oldStringNotUniqueError(p.Path, step.OldString, content, result.matches, true))
 		}
 	}
 

--- a/internal/tool/builtin/preview.go
+++ b/internal/tool/builtin/preview.go
@@ -77,7 +77,7 @@ func (e editFile) Preview(args json.RawMessage) (diff.Change, error) {
 	case applied.matches == 0:
 		return diff.Change{}, oldStringNotFoundError(p.Path, p.OldString, content)
 	default:
-		return diff.Change{}, oldStringNotUniqueError(p.Path, applied.matches, false)
+		return diff.Change{}, oldStringNotUniqueError(p.Path, p.OldString, content, applied.matches, false)
 	}
 
 	return diff.Build(p.Path, content, applied.updated, diff.Modify), nil
@@ -118,9 +118,9 @@ func (m multiEdit) Preview(args json.RawMessage) (diff.Change, error) {
 		case result.applied > 0:
 			content = result.updated
 		case result.matches == 0:
-			return diff.Change{}, fmt.Errorf("edit %d: old_string not found", i+1)
+			return diff.Change{}, fmt.Errorf("edit %d: %w", i+1, oldStringNotFoundError(p.Path, step.OldString, content))
 		default:
-			return diff.Change{}, fmt.Errorf("edit %d: old_string is not unique; add more surrounding context or set replace_all", i+1)
+			return diff.Change{}, fmt.Errorf("edit %d: %w", i+1, oldStringNotUniqueError(p.Path, step.OldString, content, result.matches, true))
 		}
 	}
 	return diff.Build(p.Path, original, content, diff.Modify), nil

--- a/internal/tool/builtin/write_tool_test.go
+++ b/internal/tool/builtin/write_tool_test.go
@@ -265,10 +265,39 @@ func TestEditFileOldStringNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for old_string not found")
 	}
+	if !strings.Contains(err.Error(), "Re-read the current file") {
+		t.Fatalf("not-found error should include recovery hint, got: %v", err)
+	}
 	// File should be unchanged.
 	got, _ := os.ReadFile(f)
 	if string(got) != "hello world" {
 		t.Errorf("file modified despite error: %q", got)
+	}
+}
+
+func TestEditFileNotUniqueReportsMatchingLines(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "map.html")
+	separator := "    // ═══════════════════════════════════════"
+	body := strings.Join([]string{
+		separator,
+		"const a = 1;",
+		separator,
+		"const b = 2;",
+		separator,
+		"",
+	}, "\n")
+	os.WriteFile(f, []byte(body), 0o644)
+
+	_, err := editFile{}.Execute(context.Background(), argsJSON(t, map[string]any{
+		"path": f, "old_string": separator, "new_string": "// section",
+	}))
+	if err == nil {
+		t.Fatal("expected not-unique error")
+	}
+	for _, want := range []string{"not unique", "matching lines include 1, 3, 5", "repeated separator lines"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
 	}
 }
 
@@ -345,6 +374,11 @@ func TestMultiEditStepNotFound(t *testing.T) {
 	}))
 	if err == nil {
 		t.Fatal("expected error for missing edit step")
+	}
+	for _, want := range []string{"edit 2", "Re-read the current file"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("multi_edit error should mention %q, got: %v", want, err)
+		}
 	}
 	// File should be unchanged (atomicity).
 	got, _ := os.ReadFile(f)


### PR DESCRIPTION
## Summary

- block same-turn `edit_file` and `delete_range` calls on a file that was already written until the model reads the current file again
- keep `multi_edit` available as the atomic path for final same-file replacements
- validate `delete_range` against brace-pair boundaries so it cannot delete only a function header or closing brace and leave orphaned code
- improve not-found and non-unique anchor errors with recovery guidance and matching line hints

## Root Cause

Repeated anchor edits could keep using pre-edit text after an earlier successful write changed the file. Separately, `delete_range` treated start/end anchors as plain lines, so an inclusive range could cut through a brace block and leave half of a function behind. Decorative separators also produced ambiguous anchors with low-actionability errors.

## Cache

Cache-impact: low - touches cache-sensitive built-in tool runtime and model-facing tool-result/error guidance, but does not change provider-visible tool schemas, descriptions, ordering, system prompt, or provider request serialization.
Cache-guard: `go test -count=1 ./internal/evidence ./internal/agent ./internal/tool/builtin`; `go test ./...`; `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m`; `git diff --check`; static diff scan confirms no tool Schema/Description changes.

## Validation

- `go test -count=1 ./internal/evidence ./internal/agent ./internal/tool/builtin`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m`
- `git diff --check`