### PR TITLE
Fix Windows classic titlebar dragging / 修复 Windows 经典标题栏拖动

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -70,6 +70,12 @@ ok(
 );
 
 ok(
+  /const titlebarDragRail = darwinChrome \|\| platform === "windows";/.test(appChromeSource) &&
+    /\{titlebarDragRail && <span className="app-chrome__drag-rail"/.test(appChromeSource),
+  "AppChrome exposes the classic drag rail on macOS and Windows",
+);
+
+ok(
   /const WORKSPACE_PANEL_DEFAULT_OPEN = false;/.test(layoutStoreSource) &&
     /workspacePanelOpen:\s*WORKSPACE_PANEL_DEFAULT_OPEN/.test(layoutStoreSource),
   "right dock starts collapsed on launch",
@@ -275,6 +281,13 @@ for (const selector of [
     `${selector} stays fixed outside the Windows window controls`,
   );
 }
+
+ok(
+  finalDeclaration(".app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail", "--wails-draggable") === "drag" &&
+    finalDeclaration(".app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail", "right")?.includes("--windows-window-controls-safe") &&
+    finalDeclaration(".app--windows .app-chrome--native-tabs .tabbar", "--wails-draggable") === "no-drag",
+  "Windows classic chrome keeps a draggable rail while tabs remain clickable",
+);
 
 for (const selector of [
   ".layout--workbench-chrome-hidden",

--- a/desktop/frontend/src/components/AppChrome.tsx
+++ b/desktop/frontend/src/components/AppChrome.tsx
@@ -58,6 +58,7 @@ export function AppChrome({
 }: AppChromeProps) {
   const t = useT();
   const darwinChrome = platform === "darwin";
+  const titlebarDragRail = darwinChrome || platform === "windows";
   const chromeClassName = [
     "app-chrome",
     "app-chrome--tabs",
@@ -90,7 +91,7 @@ export function AppChrome({
           <span />
         </div>
       )}
-      {darwinChrome && <span className="app-chrome__drag-rail" aria-hidden="true" />}
+      {titlebarDragRail && <span className="app-chrome__drag-rail" aria-hidden="true" />}
       <button
         className={[
           "app-chrome__panel-toggle",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16931,18 +16931,28 @@ body > .mermaid-diagram--fullscreen {
   --wails-draggable: no-drag;
 }
 
-.app--darwin .app-chrome--tabs .app-chrome__drag-rail {
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail,
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail {
   display: block;
   position: absolute;
   top: 0;
-  left: calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 12px);
-  right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 20px);
   z-index: var(--z-local-handle);
   height: 10px;
   --wails-draggable: drag;
 }
 
-.app--darwin .app-chrome--tabs .app-chrome__drag-rail::before {
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail {
+  left: calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 20px);
+}
+
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail {
+  left: calc(var(--chrome-toggle-size) + 16px);
+  right: calc(var(--windows-window-controls-safe) + var(--chrome-toggle-size) + 18px);
+}
+
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail::before,
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail::before {
   content: "";
   position: absolute;
   top: 3px;
@@ -16960,11 +16970,13 @@ body > .mermaid-diagram--fullscreen {
     opacity 0.12s ease;
 }
 
-.app--darwin .app-chrome--tabs .app-chrome__drag-rail:hover::before {
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail:hover::before,
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail:hover::before {
   opacity: 0.72;
 }
 
-.app--darwin .app-chrome--tabs .app-chrome__drag-rail:active::before {
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail:active::before,
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .app-chrome__drag-rail:active::before {
   background: var(--accent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 68%, transparent);
   opacity: 0.95;


### PR DESCRIPTION
## Summary

- Render the existing classic titlebar drag rail on Windows as well as macOS.
- Scope the Windows rail to frameless classic chrome and keep it clear of native window controls.
- Add a chrome contract test that keeps the rail draggable while tabs remain clickable.

## Verification

- pnpm check:css
- pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts
- Browser DOM/CSS check with the Windows platform mock: drag rail is visible and marked `--wails-draggable: drag`; tabbar and window controls remain `no-drag`.

## Cache impact

Cache-impact: none; desktop chrome rendering only, with no provider-visible prompt, tool schema, context, or request serialization changes.
Cache-guard: N/A; not cache-sensitive. Covered by focused desktop frontend checks above.
System-prompt-review: N/A