### PR TITLE
feat: 集中存储项目数据，不污染项目目录 (closes #5739)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -366,7 +366,7 @@ func (a *App) startup(ctx context.Context) {
 	if cfg, err := config.Load(); err == nil {
 		if cfg.DesktopCentralizeProjectData() {
 			fn := func(workspaceRoot string) string {
-				return config.ProjectDataRoot(workspaceRoot, true)
+				return config.ProjectDotReasonixDir(workspaceRoot, true)
 			}
 			SetProjectDataRoot(fn)
 			autoresearch.SetProjectDataRootOverride(fn)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -370,6 +370,7 @@ func (a *App) startup(ctx context.Context) {
 			}
 			SetProjectDataRoot(fn)
 			autoresearch.SetProjectDataRootOverride(fn)
+			control.SetAttachmentRoot(true)
 		}
 	}
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -362,6 +362,17 @@ func (a *App) startup(ctx context.Context) {
 		a.recordSettingsMetricsSnapshot(cfg)
 	}
 
+	// Set up project data root override for centralized storage mode.
+	if cfg, err := config.Load(); err == nil {
+		if cfg.DesktopCentralizeProjectData() {
+			fn := func(workspaceRoot string) string {
+				return config.ProjectDataRoot(workspaceRoot, true)
+			}
+			SetProjectDataRoot(fn)
+			autoresearch.SetProjectDataRootOverride(fn)
+		}
+	}
+
 	a.heartbeat = newHeartbeatEngine(a)
 	a.heartbeat.Start()
 
@@ -7344,6 +7355,14 @@ func (a *App) withActiveWorkspace(fn func() (string, error)) (string, error) {
 
 func (a *App) withActiveWorkspaceDo(fn func() error) error {
 	root := a.activeWorkspaceRoot()
+	// Apply project data root override for centralized project storage so
+	// attachments are stored under the centralized .reasonix/attachments
+	// instead of creating .reasonix in the project directory.
+	if fn := projectDataRootOverride; fn != nil {
+		if r := fn(root); r != "" && r != root {
+			root = r
+		}
+	}
 	if root != "" && root != "." {
 		prev, err := os.Getwd()
 		if err != nil {

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -939,6 +939,7 @@ function normalizeSettingsView(view: SettingsView | null | undefined): SettingsV
     statusBarItems: normalizeStatusBarItems(view.statusBarItems),
     checkUpdates: view.checkUpdates !== false,
     memoryCompilerEnabled: view.memoryCompilerEnabled !== false,
+    centralizeProjectData: Boolean(view.centralizeProjectData),
   };
 }
 
@@ -1057,6 +1058,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
   const autoPlan = normalizeAutoPlan(s.autoPlan);
   const defaultToolApprovalMode = normalizeToolApprovalMode(s.defaultToolApprovalMode);
   const memoryCompilerEnabled = s.memoryCompilerEnabled !== false;
+  const centralizeProjectData = s.centralizeProjectData === true;
   const languagePref = normalizeLangPref(s.desktopLanguage);
   const desktopLayoutStyle = normalizeDesktopLayoutStyle(s.desktopLayoutStyle);
   const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
@@ -1307,6 +1309,13 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
           value={memoryCompilerEnabled}
           disabled={busy}
           onChange={(enabled) => void apply(() => app.SetMemoryCompilerEnabled(enabled))}
+        />
+      </SettingsField>
+      <SettingsField label={t("settings.centralizeProjectData")} hint={t("settings.centralizeProjectDataHint")}>
+        <ToggleSegment
+          value={centralizeProjectData}
+          disabled={busy}
+          onChange={(centralize) => void apply(() => app.SetProjectStorage(centralize))}
         />
       </SettingsField>
       <SettingsField label={t("settings.sound")} hint={t("settings.soundHint")} stacked>

--- a/desktop/frontend/src/lib/attachmentDisplay.ts
+++ b/desktop/frontend/src/lib/attachmentDisplay.ts
@@ -1,4 +1,4 @@
-const attachmentRefRe = /@(\.reasonix\/attachments\/[^\s]+)/g;
+const attachmentRefRe = /@((?:\.reasonix\/)?attachments\/[^\s]+)/g;
 const namedAttachmentRefRe = /(^|\s)@\[([^\]\r\n]+)\]\(([^)\s]+)\)/g;
 const referenceRefRe = /(^|\s)@([^\s]+)/g;
 const trailingPunctuationRe = /[.,;!?)\]}，。；！？）】]+$/;
@@ -127,14 +127,14 @@ export function sortDisplayAttachments<T extends { kind: "image" | "file" | "fol
 }
 
 function isDisplayReference(path: string): boolean {
-  if (path.startsWith(".reasonix/attachments/")) return true;
+  if (path.startsWith(".reasonix/attachments/") || path.startsWith("attachments/")) return true;
   if (path.endsWith("/")) return true;
   if (path.includes("/")) return true;
   return attachmentExt(path) !== "";
 }
 
 function displayAttachment(path: string, name: string): DisplayAttachment {
-  if (path.startsWith(".reasonix/attachments/")) {
+  if (path.startsWith(".reasonix/attachments/") || path.startsWith("attachments/")) {
     const kind = isImageAttachmentRef(path) ? "image" : "file";
     return {
       path,

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -315,6 +315,8 @@ export interface AppBindings {
   SetDesktopMetrics(enabled: boolean): Promise<void>;
   SetMemoryCompilerEnabled(enabled: boolean): Promise<void>;
   SetExpandThinking(on: boolean): Promise<void>;
+  SetDesktopProjectStorage(centralized: boolean): Promise<void>;
+  SetProjectStorage(centralized: boolean): Promise<void>;
   MigrateDesktopPreferences(language: string, theme: string, style: string): Promise<void>;
   SetAgentParams(temperature: number, maxSteps: number, plannerMaxSteps: number, systemPrompt: string): Promise<void>;
   SetColdResumePrune(enabled: boolean): Promise<void>;
@@ -579,7 +581,7 @@ function bridgeBreadcrumb(method: string): string {
     return `turn ${method}`;
   if (/^(SetModel|SetEffort|SetTokenMode|SetDefaultModel|SetPlannerModel|SetSubagentModel|SetSubagentEffort)/.test(method))
     return `model ${method}`;
-  if (/^(SetDesktop|SetCloseBehavior|SetDisplayMode|SetStatusBar|SetExpandThinking|SetAutoPlan|SetDefaultToolApprovalMode|SetMemoryCompilerEnabled|SetReasoningLanguage)/.test(method))
+  if (/^(SetDesktop|SetCloseBehavior|SetDisplayMode|SetStatusBar|SetExpandThinking|SetDesktopProjectStorage|SetProjectStorage|SetAutoPlan|SetDefaultToolApprovalMode|SetMemoryCompilerEnabled|SetReasoningLanguage)/.test(method))
     return `settings ${method}`;
   if (/^(SaveProvider|AddOfficialProviderAccess|RemoveProviderAccess|DeleteProvider|SetProviderKey|ClearProviderKey|FetchProviderModels|ConnectKey)/.test(method))
     return `provider ${method}`;
@@ -1003,6 +1005,7 @@ function makeMockApp(): AppBindings {
     telemetry: true,
     metrics: true,
     memoryCompilerEnabled: true,
+    centralizeProjectData: false,
     configPath: "~/projects/reasonix/reasonix.toml",
     providerKinds: ["openai"],
     autoApproveTools: false,
@@ -2897,6 +2900,12 @@ function makeMockApp(): AppBindings {
           settings.memoryCompilerEnabled = enabled;
         },
         async SetExpandThinking(_on: boolean) {},
+        async SetDesktopProjectStorage(centralized: boolean) {
+          settings.centralizeProjectData = centralized;
+        },
+        async SetProjectStorage(centralize: boolean) {
+          settings.centralizeProjectData = centralize;
+        },
         async MigrateDesktopPreferences(language: string, theme: string, style: string) {
           if (!settings.desktopLanguage) settings.desktopLanguage = language === "en" || language === "zh" || language === "zh-TW" ? language : "";
           if (!settings.desktopTheme && !settings.desktopThemeStyle) {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1061,6 +1061,7 @@ export interface SettingsView {
   telemetry: boolean; // anonymous launch ping (install id + version + OS)
   metrics: boolean; // aggregate desktop metrics (anonymous signal/bucket counts)
   memoryCompilerEnabled: boolean; // Memory v5 execution compiler
+  centralizeProjectData: boolean; // true = store .reasonix in user data dir (projects stay clean)
   configPath: string;
   providerKinds: string[]; // provider implementations the kernel registered (for the kind picker)
   autoApproveTools: boolean;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -950,6 +950,8 @@ export const en = {
   "settings.autoPlan.on": "On",
   "settings.memoryCompiler": "Memory v5",
   "settings.memoryCompilerHint": "Use the execution memory compiler to generate and improve action plans from past outcomes.",
+  "settings.centralizeProjectData": "Centralized project data",
+  "settings.centralizeProjectDataHint": "Store .reasonix data in the Reasonix user data directory instead of each project folder, keeping your project directories clean.",
   "settings.agentRuntime": "Agent runtime",
   "settings.agentRuntimeHint": "Step limits use global settings only; ./reasonix.toml does not override them. 0 means unlimited.",
   "settings.executorMaxSteps": "Executor step limit",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -708,6 +708,8 @@ export const zhTW: Record<DictKey, string> = {
   "settings.autoPlan.on": "開啟",
   "settings.memoryCompiler": "Memory v5",
   "settings.memoryCompilerHint": "開啟執行型記憶編譯器，用歷史執行結果生成和優化下一步行動計畫。",
+  "settings.centralizeProjectData": "集中儲存專案數據",
+  "settings.centralizeProjectDataHint": "將 .reasonix 數據儲存到 Reasonix 用戶數據目錄，不在專案目錄下建立 .reasonix 資料夾，保持專案目錄乾淨。",
   "settings.agentRuntime": "Agent 執行",
   "settings.agentRuntimeHint": "輪數上限只認全域設定；專案裡的 ./reasonix.toml 不覆蓋。0 表示不限。",
   "settings.executorMaxSteps": "執行輪數上限",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -952,6 +952,8 @@ export const zh: Record<DictKey, string> = {
   "settings.autoPlan.on": "开启",
   "settings.memoryCompiler": "Memory v5",
   "settings.memoryCompilerHint": "开启执行型记忆编译器，用历史执行结果生成和优化下一步行动计划。",
+  "settings.centralizeProjectData": "集中存储项目数据",
+  "settings.centralizeProjectDataHint": "将 .reasonix 数据存储到 Reasonix 用户数据目录，不在项目目录下创建 .reasonix 文件夹，保持项目目录干净。",
   "settings.agentRuntime": "Agent 运行",
   "settings.agentRuntimeHint": "轮数上限只认全局设置；项目里的 ./reasonix.toml 不覆盖。0 表示不限。",
   "settings.executorMaxSteps": "执行轮数上限",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/autoresearch"
 	"reasonix/internal/boot"
 	"reasonix/internal/botruntime"
 	"reasonix/internal/config"
@@ -182,6 +183,7 @@ type SettingsView struct {
 	Metrics                 bool            `json:"metrics"`
 	MemoryCompiler          bool            `json:"memoryCompilerEnabled"`
 	ExpandThinking          bool            `json:"expandThinking"`
+	CentralizeProjectData   bool            `json:"centralizeProjectData"`
 	ConfigPath              string          `json:"configPath"`
 	// ProviderKinds lists the provider implementations the kernel actually
 	// registered (provider.Kinds()), so the editor's "kind" picker offers only
@@ -578,6 +580,7 @@ func (a *App) Settings() SettingsView {
 		Metrics:                 cfg.DesktopMetrics(),
 		MemoryCompiler:          cfg.MemoryCompilerEnabled(),
 		ExpandThinking:          cfg.Desktop.ExpandThinking,
+		CentralizeProjectData:   cfg.DesktopCentralizeProjectData(),
 		ConfigPath:              cfgPath,
 		ProviderKinds:           nonNil(provider.Kinds()),
 		AutoApproveTools:        ctrl != nil && ctrl.AutoApproveTools(),
@@ -1990,6 +1993,25 @@ func (a *App) SetDesktopMetrics(enabled bool) error {
 // the desktop. It is desktop-only and does not rebuild the controller.
 func (a *App) SetExpandThinking(on bool) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetExpandThinking(on) })
+}
+
+func (a *App) SetProjectStorage(centralize bool) error {
+	return a.applyConfigOnly(func(c *config.Config) error {
+		if err := c.SetDesktopCentralizeProjectData(centralize); err != nil {
+			return err
+		}
+		if c.DesktopCentralizeProjectData() {
+			fn := func(workspaceRoot string) string {
+				return config.ProjectDataRoot(workspaceRoot, true)
+			}
+			SetProjectDataRoot(fn)
+			autoresearch.SetProjectDataRootOverride(fn)
+		} else {
+			SetProjectDataRoot(nil)
+			autoresearch.SetProjectDataRootOverride(nil)
+		}
+		return nil
+	})
 }
 
 // MigrateDesktopPreferences imports old browser-local desktop preferences into

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2007,7 +2007,7 @@ func (a *App) SetProjectStorage(centralize bool) error {
 		}
 		if c.DesktopCentralizeProjectData() {
 			fn := func(workspaceRoot string) string {
-				return config.ProjectDataRoot(workspaceRoot, true)
+				return config.ProjectDotReasonixDir(workspaceRoot, true)
 			}
 			SetProjectDataRoot(fn)
 			autoresearch.SetProjectDataRootOverride(fn)

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2011,9 +2011,11 @@ func (a *App) SetProjectStorage(centralize bool) error {
 			}
 			SetProjectDataRoot(fn)
 			autoresearch.SetProjectDataRootOverride(fn)
+			control.SetAttachmentRoot(true)
 		} else {
 			SetProjectDataRoot(nil)
 			autoresearch.SetProjectDataRootOverride(nil)
+			control.SetAttachmentRoot(false)
 		}
 		return nil
 	})

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -922,7 +922,12 @@ func projectConfigPathForRoot(root string) string {
 	if strings.TrimSpace(root) == "" || root == "." {
 		return "reasonix.toml"
 	}
-	return filepath.Join(root, "reasonix.toml")
+	// Check if centralized project storage is active.
+	centralize := false
+	if cfg := config.LoadForEditWithoutCredentials(config.UserConfigPath()); cfg != nil {
+		centralize = cfg.DesktopCentralizeProjectData()
+	}
+	return config.ProjectConfigPath(root, centralize)
 }
 
 func sameConfigPath(a, b string) bool {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3691,48 +3691,57 @@ var (
 )
 
 // SetProjectDataRoot sets the project data root override used by topic path
-// functions. Pass nil to revert to local mode.
+// functions. The override should return the ".reasonix"-equivalent directory:
+// for local mode this is <workspaceRoot>/.reasonix, for centralized mode it is
+// the slug directory without the .reasonix suffix. Pass nil to revert to local
+// mode.
 func SetProjectDataRoot(fn func(workspaceRoot string) string) {
 	projectDataRootOverride = fn
 }
 
-func topicTitlesPath(workspaceRoot string) string {
+func topicDir(workspaceRoot string) (dir string, dotReasonix bool) {
 	if workspaceRoot == "" {
-		return filepath.Join(desktopConfigDir(), "global", topicTitlesFile)
+		return "", false
 	}
-	root := workspaceRoot
 	if fn := projectDataRootOverride; fn != nil {
 		if r := fn(workspaceRoot); r != "" {
-			root = r
+			return r, false // override already points to the .reasonix-equivalent dir
 		}
 	}
-	return filepath.Join(root, ".reasonix", topicTitlesFile)
+	return workspaceRoot, true // local mode: need to append .reasonix
+}
+
+func topicTitlesPath(workspaceRoot string) string {
+	dir, dot := topicDir(workspaceRoot)
+	if dir == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicTitlesFile)
+	}
+	if dot {
+		dir = filepath.Join(dir, ".reasonix")
+	}
+	return filepath.Join(dir, topicTitlesFile)
 }
 
 func topicTitleSourcesPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
+	dir, dot := topicDir(workspaceRoot)
+	if dir == "" {
 		return filepath.Join(desktopConfigDir(), "global", topicTitleSourcesFile)
 	}
-	root := workspaceRoot
-	if fn := projectDataRootOverride; fn != nil {
-		if r := fn(workspaceRoot); r != "" {
-			root = r
-		}
+	if dot {
+		dir = filepath.Join(dir, ".reasonix")
 	}
-	return filepath.Join(root, ".reasonix", topicTitleSourcesFile)
+	return filepath.Join(dir, topicTitleSourcesFile)
 }
 
 func topicCreatedAtsPath(workspaceRoot string) string {
-	if workspaceRoot == "" {
+	dir, dot := topicDir(workspaceRoot)
+	if dir == "" {
 		return filepath.Join(desktopConfigDir(), "global", topicCreatedAtsFile)
 	}
-	root := workspaceRoot
-	if fn := projectDataRootOverride; fn != nil {
-		if r := fn(workspaceRoot); r != "" {
-			root = r
-		}
+	if dot {
+		dir = filepath.Join(dir, ".reasonix")
 	}
-	return filepath.Join(root, ".reasonix", topicCreatedAtsFile)
+	return filepath.Join(dir, topicCreatedAtsFile)
 }
 
 const topicFileReadTimeout = 200 * time.Millisecond

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3675,34 +3675,64 @@ func removeProject(root string) error {
 
 // --- topic helpers ----------------------------------------------------------
 
-const (
+var (
 	topicTitlesFile        = "desktop-topic-titles.json"
 	topicTitleSourcesFile  = "desktop-topic-title-sources.json"
 	topicCreatedAtsFile    = "desktop-topic-created-at.json"
 	defaultTopicTitle      = "新的会话"
 	topicTitleSourceAuto   = "auto"
 	topicTitleSourceManual = "manual"
+
+	// projectDataRootOverride is set by the desktop app to redirect project data
+	// (.reasonix) to a centralized directory instead of the project root. When
+	// non-nil, topic path functions call it with the workspace root to get the
+	// effective data root. Nil = local mode (current default).
+	projectDataRootOverride func(workspaceRoot string) string
 )
+
+// SetProjectDataRoot sets the project data root override used by topic path
+// functions. Pass nil to revert to local mode.
+func SetProjectDataRoot(fn func(workspaceRoot string) string) {
+	projectDataRootOverride = fn
+}
 
 func topicTitlesPath(workspaceRoot string) string {
 	if workspaceRoot == "" {
 		return filepath.Join(desktopConfigDir(), "global", topicTitlesFile)
 	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicTitlesFile)
+	root := workspaceRoot
+	if fn := projectDataRootOverride; fn != nil {
+		if r := fn(workspaceRoot); r != "" {
+			root = r
+		}
+	}
+	return filepath.Join(root, ".reasonix", topicTitlesFile)
 }
 
 func topicTitleSourcesPath(workspaceRoot string) string {
 	if workspaceRoot == "" {
 		return filepath.Join(desktopConfigDir(), "global", topicTitleSourcesFile)
 	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicTitleSourcesFile)
+	root := workspaceRoot
+	if fn := projectDataRootOverride; fn != nil {
+		if r := fn(workspaceRoot); r != "" {
+			root = r
+		}
+	}
+	return filepath.Join(root, ".reasonix", topicTitleSourcesFile)
 }
 
 func topicCreatedAtsPath(workspaceRoot string) string {
 	if workspaceRoot == "" {
 		return filepath.Join(desktopConfigDir(), "global", topicCreatedAtsFile)
 	}
-	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
+	root := workspaceRoot
+	if fn := projectDataRootOverride; fn != nil {
+		if r := fn(workspaceRoot); r != "" {
+			root = r
+		}
+	}
+	return filepath.Join(root, ".reasonix", topicCreatedAtsFile)
 }
 
 const topicFileReadTimeout = 200 * time.Millisecond

--- a/internal/autoresearch/store.go
+++ b/internal/autoresearch/store.go
@@ -18,6 +18,17 @@ import (
 var safeTaskID = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 var explicitTaskPath = regexp.MustCompile(`\.reasonix/autoresearch/([A-Za-z0-9][A-Za-z0-9._-]*)/?`)
 
+// projectDataRootOverride redirects the autoresearch store root for centralized
+// project storage. When non-nil, it is called with the workspace root to get the
+// effective data root for .reasonix data. Set via SetProjectDataRootOverride.
+var projectDataRootOverride func(workspaceRoot string) string
+
+// SetProjectDataRootOverride sets the project data root override used by the
+// autoresearch store. Pass nil to revert to local mode (default).
+func SetProjectDataRootOverride(fn func(workspaceRoot string) string) {
+	projectDataRootOverride = fn
+}
+
 type Store struct {
 	workspaceRoot string
 	root          string
@@ -29,9 +40,15 @@ func NewStore(workspaceRoot string) *Store {
 	if resolved, err := filepath.EvalSymlinks(workspaceRoot); err == nil {
 		workspaceRoot = resolved
 	}
+	storeRoot := workspaceRoot
+	if fn := projectDataRootOverride; fn != nil {
+		if r := fn(workspaceRoot); r != "" {
+			storeRoot = r
+		}
+	}
 	return &Store{
 		workspaceRoot: workspaceRoot,
-		root:          filepath.Join(workspaceRoot, ".reasonix", "autoresearch"),
+		root:          filepath.Join(storeRoot, ".reasonix", "autoresearch"),
 		taskLocks:     map[string]*sync.Mutex{},
 	}
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1131,7 +1131,14 @@ func rememberPermissionRule(workspaceRoot, rule string) control.RememberResult {
 func rememberPermissionConfigPath(workspaceRoot string) string {
 	workspaceRoot = strings.TrimSpace(workspaceRoot)
 	if workspaceRoot != "" {
-		return filepath.Join(workspaceRoot, "reasonix.toml")
+		// Determine whether centralized project storage is active by loading
+		// the user config. This lets permission rules follow the centralize_project_data
+		// setting (saved reasonix.toml goes to user data dir instead of project root).
+		centralize := false
+		if cfg := config.LoadForEditWithoutCredentials(config.UserConfigPath()); cfg != nil {
+			centralize = cfg.DesktopCentralizeProjectData()
+		}
+		return config.ProjectConfigPath(workspaceRoot, centralize)
 	}
 	path := config.SourcePath()
 	if path == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ type DesktopConfig struct {
 	Metrics                 *bool    `toml:"metrics"`                    // aggregate desktop metrics (anonymous signal/bucket counts; no content); nil keeps the default enabled
 	ProviderAccess          []string `toml:"provider_access"`            // desktop-only list of provider entries shown in Settings > Model > Access
 	ExpandThinking          bool     `toml:"expand_thinking"`            // true = show reasoning text expanded by default; false = collapsed
+	CentralizeProjectData   bool     `toml:"centralize_project_data"`    // true = store .reasonix in user data dir; false = local (default)
 }
 
 // NotificationsConfig controls optional system notifications for CLI chat/run.
@@ -372,6 +373,16 @@ func (c *Config) DesktopCheckUpdates() bool {
 		return true
 	}
 	return *c.Desktop.CheckUpdates
+}
+
+// DesktopCentralizeProjectData reports whether project data (.reasonix) should
+// be stored centrally in the Reasonix user data directory rather than inside
+// each project directory. Default false (local storage).
+func (c *Config) DesktopCentralizeProjectData() bool {
+	if c == nil {
+		return false
+	}
+	return c.Desktop.CentralizeProjectData
 }
 
 // ColdResumePruneEnabled reports whether stale tool results are elided when a

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -320,6 +320,13 @@ func (c *Config) SetDesktopCheckUpdates(enabled bool) error {
 	return nil
 }
 
+// SetDesktopCentralizeProjectData sets whether project data (.reasonix) is stored
+// centrally in the Reasonix user data dir instead of inside the project directory.
+func (c *Config) SetDesktopCentralizeProjectData(centralize bool) error {
+	c.Desktop.CentralizeProjectData = centralize
+	return nil
+}
+
 // SetColdResumePrune toggles auto-elision of stale tool results on cold resume.
 func (c *Config) SetColdResumePrune(enabled bool) error {
 	c.Agent.ColdResumePrune = &enabled

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -302,6 +302,32 @@ func ProjectSessionDir(workspaceRoot string) string {
 	return filepath.Join(base, "projects", WorkspaceSlug(root), "sessions")
 }
 
+// ProjectConfigPath returns the path to the project's reasonix.toml config
+// file. When centralize is true, the config is stored under the Reasonix user
+// data dir (<state root>/projects/<slug>/reasonix.toml) instead of the project
+// root, keeping the project directory clean. Backward compatibility: if the
+// project already has a reasonix.toml from an older version, it is used
+// regardless of the centralize flag.
+func ProjectConfigPath(workspaceRoot string, centralize bool) string {
+	projectPath := filepath.Join(workspaceRoot, "reasonix.toml")
+	if !centralize {
+		return projectPath
+	}
+	// If the project already has a reasonix.toml, keep using it.
+	if info, err := os.Stat(projectPath); err == nil && !info.IsDir() {
+		return projectPath
+	}
+	base := MemoryUserDir()
+	root := strings.TrimSpace(workspaceRoot)
+	if base == "" || root == "" {
+		return projectPath
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", WorkspaceSlug(root), "reasonix.toml")
+}
+
 // ProjectDataRoot returns the directory root under which project-local data
 // (.reasonix, hooks, attachments) should be stored for the given workspaceRoot.
 //

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -305,9 +305,15 @@ func ProjectSessionDir(workspaceRoot string) string {
 // ProjectDotReasonixDir returns the directory that serves as the ".reasonix"
 // equivalent for a project. In local mode this is <workspaceRoot>/.reasonix.
 // In centralized mode this is <dataRoot>/projects/<slug>/ — no .reasonix
-// subdirectory, files go directly under the slug.
+// subdirectory, files go directly under the slug. Backward compatibility:
+// if the project already has a .reasonix directory from an older version,
+// it is used regardless of the centralize flag.
 func ProjectDotReasonixDir(workspaceRoot string, centralize bool) string {
 	if !centralize {
+		return filepath.Join(workspaceRoot, ".reasonix")
+	}
+	// Backward compatibility: if project already has .reasonix, keep it.
+	if info, err := os.Stat(filepath.Join(workspaceRoot, ".reasonix")); err == nil && info.IsDir() {
 		return filepath.Join(workspaceRoot, ".reasonix")
 	}
 	base := MemoryUserDir()
@@ -322,29 +328,24 @@ func ProjectDotReasonixDir(workspaceRoot string, centralize bool) string {
 }
 
 // ProjectConfigPath returns the path to the project's reasonix.toml config
-// file. When centralize is true, the config is stored under the Reasonix user
-// data dir (<state root>/projects/<slug>/reasonix.toml) instead of the project
-// root, keeping the project directory clean. Backward compatibility: if the
-// project already has a reasonix.toml from an older version, it is used
+// file. In local mode this is <workspaceRoot>/.reasonix/reasonix.toml.
+// In centralized mode this is <dataRoot>/projects/<slug>/reasonix.toml.
+// Backward compatibility: if the project has a legacy reasonix.toml at the
+// project root (from an older version), that path is returned instead,
 // regardless of the centralize flag.
 func ProjectConfigPath(workspaceRoot string, centralize bool) string {
-	projectPath := filepath.Join(workspaceRoot, "reasonix.toml")
-	if !centralize {
-		return projectPath
+	dir := ProjectDotReasonixDir(workspaceRoot, centralize)
+	path := filepath.Join(dir, "reasonix.toml")
+	// If the file already exists at the canonical location, use it.
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path
 	}
-	// If the project already has a reasonix.toml, keep using it.
-	if info, err := os.Stat(projectPath); err == nil && !info.IsDir() {
-		return projectPath
+	// Backward compatibility: check for legacy reasonix.toml at project root.
+	legacy := filepath.Join(workspaceRoot, "reasonix.toml")
+	if info, err := os.Stat(legacy); err == nil && !info.IsDir() {
+		return legacy
 	}
-	base := MemoryUserDir()
-	root := strings.TrimSpace(workspaceRoot)
-	if base == "" || root == "" {
-		return projectPath
-	}
-	if abs, err := filepath.Abs(root); err == nil {
-		root = abs
-	}
-	return filepath.Join(base, "projects", WorkspaceSlug(root), "reasonix.toml")
+	return path
 }
 
 // ProjectDataRoot returns the directory root under which project-local data

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -302,6 +302,25 @@ func ProjectSessionDir(workspaceRoot string) string {
 	return filepath.Join(base, "projects", WorkspaceSlug(root), "sessions")
 }
 
+// ProjectDotReasonixDir returns the directory that serves as the ".reasonix"
+// equivalent for a project. In local mode this is <workspaceRoot>/.reasonix.
+// In centralized mode this is <dataRoot>/projects/<slug>/ — no .reasonix
+// subdirectory, files go directly under the slug.
+func ProjectDotReasonixDir(workspaceRoot string, centralize bool) string {
+	if !centralize {
+		return filepath.Join(workspaceRoot, ".reasonix")
+	}
+	base := MemoryUserDir()
+	root := strings.TrimSpace(workspaceRoot)
+	if base == "" || root == "" {
+		return filepath.Join(workspaceRoot, ".reasonix")
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", WorkspaceSlug(root))
+}
+
 // ProjectConfigPath returns the path to the project's reasonix.toml config
 // file. When centralize is true, the config is stored under the Reasonix user
 // data dir (<state root>/projects/<slug>/reasonix.toml) instead of the project

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -313,6 +313,11 @@ func ProjectDataRoot(workspaceRoot string, centralize bool) string {
 	if !centralize {
 		return workspaceRoot
 	}
+	// If the project already has a .reasonix directory (created by an older
+	// version), keep using the project-local path for backward compatibility.
+	if info, err := os.Stat(filepath.Join(workspaceRoot, ".reasonix")); err == nil && info.IsDir() {
+		return workspaceRoot
+	}
 	base := MemoryUserDir()
 	root := strings.TrimSpace(workspaceRoot)
 	if base == "" || root == "" {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -302,6 +302,28 @@ func ProjectSessionDir(workspaceRoot string) string {
 	return filepath.Join(base, "projects", WorkspaceSlug(root), "sessions")
 }
 
+// ProjectDataRoot returns the directory root under which project-local data
+// (.reasonix, hooks, attachments) should be stored for the given workspaceRoot.
+//
+// When centralize is true, project data is stored under
+// <config root>/projects/<slug>/ so the project directory stays clean;
+// sessions and memory compiler already use this area. When false (default),
+// data is stored directly in workspaceRoot (current behaviour).
+func ProjectDataRoot(workspaceRoot string, centralize bool) string {
+	if !centralize {
+		return workspaceRoot
+	}
+	base := MemoryUserDir()
+	root := strings.TrimSpace(workspaceRoot)
+	if base == "" || root == "" {
+		return workspaceRoot
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", WorkspaceSlug(root))
+}
+
 // MemoryCompilerDir is the project-scoped state directory for the Memory v5
 // execution compiler. Empty means persistent compiler state is unavailable.
 func MemoryCompilerDir(workspaceRoot string) string {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -115,6 +115,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			fmt.Fprintf(&b, "provider_access = %s   # desktop settings: providers shown on Settings > Model > Access\n", renderStringArray(c.Desktop.ProviderAccess))
 		}
 		fmt.Fprintf(&b, "expand_thinking = %v   # desktop: show reasoning text expanded by default; false = collapsed\n", c.Desktop.ExpandThinking)
+		if c.Desktop.CentralizeProjectData {
+			b.WriteString("centralize_project_data = true   # store .reasonix data under Reasonix user data dir (keeps projects clean)\n")
+		} else {
+			b.WriteString("# centralize_project_data = true   # store .reasonix data under Reasonix user data dir (keeps projects clean)\n")
+		}
 		fmt.Fprintf(&b, "display_mode = %q   # desktop: standard|compact transcript display mode\n", c.DesktopDisplayMode())
 		b.WriteString("\n")
 

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -25,6 +25,17 @@ var attachmentPathSeq atomic.Uint64
 var attachmentNow = time.Now
 var safeAttachmentExt = regexp.MustCompile(`^\.[a-z0-9]{1,12}$`)
 
+// attachmentRootOverride redirects the attachment storage root for centralized
+// project storage. When non-empty, attachments use this absolute root directory
+// instead of <CWD>/.reasonix/attachments.
+var attachmentRootOverride string
+
+// SetAttachmentRoot sets an absolute path to use as the attachment root,
+// replacing <CWD>/.reasonix/attachments. Pass empty string to revert.
+func SetAttachmentRoot(root string) {
+	attachmentRootOverride = root
+}
+
 // SaveAttachmentDataURL stores a non-image file (dropped/pasted in the desktop
 // app, where the browser exposes bytes but not a real path) under
 // .reasonix/attachments and returns its repo-relative path for @referencing.
@@ -376,8 +387,15 @@ func rejectSymlinkComponents(path, root string) error {
 	return nil
 }
 
+func attachmentRoot() string {
+	if attachmentRootOverride != "" {
+		return filepath.Join(attachmentRootOverride, "attachments")
+	}
+	return filepath.Join(".reasonix", "attachments")
+}
+
 func ensureAttachmentRoot() error {
-	root := filepath.Join(".reasonix", "attachments")
+	root := attachmentRoot()
 	if info, err := os.Lstat(root); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("attachment directory must not be a symlink")

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -26,14 +26,14 @@ var attachmentNow = time.Now
 var safeAttachmentExt = regexp.MustCompile(`^\.[a-z0-9]{1,12}$`)
 
 // attachmentRootOverride redirects the attachment storage root for centralized
-// project storage. When non-empty, attachments use this absolute root directory
-// instead of <CWD>/.reasonix/attachments.
-var attachmentRootOverride string
+// project storage. When true, attachments are stored under <CWD>/attachments/
+// instead of <CWD>/.reasonix/attachments/.
+var attachmentRootOverride bool
 
-// SetAttachmentRoot sets an absolute path to use as the attachment root,
-// replacing <CWD>/.reasonix/attachments. Pass empty string to revert.
-func SetAttachmentRoot(root string) {
-	attachmentRootOverride = root
+// SetAttachmentRoot sets whether to use the centralized attachment root
+// (attachments/ instead of .reasonix/attachments/).
+func SetAttachmentRoot(centralized bool) {
+	attachmentRootOverride = centralized
 }
 
 // SaveAttachmentDataURL stores a non-image file (dropped/pasted in the desktop
@@ -349,9 +349,9 @@ func cleanAttachmentPath(path string) (string, error) {
 		return "", fmt.Errorf("attachment path must be relative")
 	}
 	clean := filepath.Clean(filepath.FromSlash(path))
-	root := filepath.Join(".reasonix", "attachments")
+	root := attachmentRoot()
 	if clean == "." || clean == root || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || !strings.HasPrefix(clean, root+string(filepath.Separator)) {
-		return "", fmt.Errorf("attachment path is outside .reasonix/attachments")
+		return "", fmt.Errorf("attachment path is outside %s", root)
 	}
 	if err := ensureAttachmentRoot(); err != nil {
 		return "", err
@@ -388,8 +388,8 @@ func rejectSymlinkComponents(path, root string) error {
 }
 
 func attachmentRoot() string {
-	if attachmentRootOverride != "" {
-		return filepath.Join(attachmentRootOverride, "attachments")
+	if attachmentRootOverride {
+		return "attachments"
 	}
 	return filepath.Join(".reasonix", "attachments")
 }
@@ -495,7 +495,7 @@ func createAttachmentFile(ext string) (string, *os.File, error) {
 func attachmentPath(ext string) string {
 	seq := attachmentPathSeq.Add(1)
 	name := fmt.Sprintf("clipboard-%s-%06d%s", attachmentNow().Format("20060102-150405.000000"), seq, ext)
-	return filepath.Join(".reasonix", "attachments", name)
+	return filepath.Join(attachmentRoot(), name)
 }
 
 func detectedImageMime(raw []byte) string {

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -111,7 +111,8 @@ func classifyRef(token string, known map[string]bool, exists func(string) bool) 
 }
 
 func isAttachmentRef(token string) bool {
-	return strings.HasPrefix(filepath.ToSlash(token), ".reasonix/attachments/")
+	path := filepath.ToSlash(token)
+	return strings.HasPrefix(path, ".reasonix/attachments/") || strings.HasPrefix(path, "attachments/")
 }
 
 func isImageAttachmentRef(token string) bool {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -142,9 +142,11 @@ func ProjectSettingsPath(projectRoot string) string {
 }
 
 // LoadOptions configure Load. Project hooks load only when Trusted; global hooks
-// always load.
+// always load. When SettingsRoot is set, project hooks settings are read from
+// SettingsRoot instead of ProjectRoot (used for centralized project storage).
 type LoadOptions struct {
-	ProjectRoot string
+	ProjectRoot  string
+	SettingsRoot string // optional: overrides ProjectRoot for settings.json lookup
 	HomeDir     string
 	Trusted     bool
 }
@@ -155,7 +157,11 @@ type LoadOptions struct {
 func Load(opts LoadOptions) []ResolvedHook {
 	var out []ResolvedHook
 	if opts.ProjectRoot != "" && opts.Trusted {
-		p := ProjectSettingsPath(opts.ProjectRoot)
+		settingsRoot := opts.SettingsRoot
+		if settingsRoot == "" {
+			settingsRoot = opts.ProjectRoot
+		}
+		p := ProjectSettingsPath(settingsRoot)
 		if s := readSettings(p); s != nil {
 			appendResolved(&out, s, ScopeProject, p)
 		}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -17,6 +17,7 @@ theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can
 layout_style = "classic"   # classic|workbench|creation; desktop layout style
 # theme = "auto"   # desktop only: auto|dark|light
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+# centralize_project_data = true   # store .reasonix under user data dir instead of project dirs
 
 [notifications]
 enabled = false   # system notifications for CLI chat/run; default off


### PR DESCRIPTION
在设置 General 页面添加「集中存储项目数据」开关。
开启后 .reasonix（topic 标题、hooks、附件、自动研究等）全部
存储到 Reasonix 用户数据目录下，项目目录保持干净。

- 新增 DesktopConfig.CentralizeProjectData bool 字段 (centralize_project_data)
- SettingsPanel General 页添加 ToggleSegment 开关
- 改写 topic 路径、附件 CWD、autoresearch store 以支持集中存储
- 更新 reasonix.example.toml 添加配置项说明

