### PR TITLE
fix(slash): send unknown slash input as prompt

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1874,7 +1874,7 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 func TestSteerForTabReconcilesStaleWorkspaceBeforeIdleFallback(t *testing.T) {
 	f := newStaleWorkspaceBindingFixture(t, "steer_idle_fallback")
 
-	if err := f.app.SteerForTab(f.tab.ID, "/unknown-command"); err != nil {
+	if err := f.app.SteerForTab(f.tab.ID, "/tree"); err != nil {
 		t.Fatalf("SteerForTab: %v", err)
 	}
 	waitNotRunning(t, f.tab.Ctrl)
@@ -2009,11 +2009,12 @@ func runQuickClickWorkspaceReconcileTest(t *testing.T, layoutStyle string) {
 		name string
 		run  func() error
 	}
+	const localSlashCommand = "/tree"
 	actions := []quickAction{
-		{name: "submit", run: func() error { return f.app.SubmitToTab(f.tab.ID, "/unknown-command") }},
-		{name: "steer", run: func() error { return f.app.SteerForTab(f.tab.ID, "/unknown-command") }},
+		{name: "submit", run: func() error { return f.app.SubmitToTab(f.tab.ID, localSlashCommand) }},
+		{name: "steer", run: func() error { return f.app.SteerForTab(f.tab.ID, localSlashCommand) }},
 		{name: "compact", run: func() error { return f.app.Compact() }},
-		{name: "submit-display", run: func() error { return f.app.SubmitDisplayToTab(f.tab.ID, "/unknown display", "/unknown-command") }},
+		{name: "submit-display", run: func() error { return f.app.SubmitDisplayToTab(f.tab.ID, localSlashCommand, localSlashCommand) }},
 	}
 
 	start := make(chan struct{})

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3060,24 +3060,23 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	return tea.Batch(m.spinner.Tick, elapsedTick())
 }
 
-var slashCommandAliases = map[string]string{
-	"/exit":          "/quit",
-	"/migration":     "/migrate",
-	"/output-styles": "/output-style",
-	"/skill":         "/skills",
-}
-
 func (m *chatTUI) handlesSlashCommand(input string) bool {
 	cmd := strings.TrimSpace(strings.SplitN(input, " ", 2)[0])
-	if canonical, ok := slashCommandAliases[cmd]; ok {
-		cmd = canonical
-	}
 	for _, item := range m.slashItems() {
-		if item.label == cmd {
+		if item.matches(cmd) {
 			return true
 		}
 	}
 	return false
+}
+
+func (m *chatTUI) canonicalSlashCommand(cmd string) string {
+	for _, item := range m.slashItems() {
+		if item.matches(cmd) {
+			return item.label
+		}
+	}
+	return cmd
 }
 
 // confirmBubbleSent marks the already-echoed user bubble as really sent once a
@@ -3336,11 +3335,14 @@ func elapsedTick() tea.Cmd {
 // runSlashCommand handles "/<cmd> <args>" input. Local commands queue their
 // output to scrollback; MCP prompt / custom commands resolve to a model turn.
 func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
-	cmd := strings.TrimSpace(strings.SplitN(input, " ", 2)[0])
+	rawCmd := strings.TrimSpace(strings.SplitN(input, " ", 2)[0])
 
-	if strings.HasPrefix(cmd, "/mcp__") {
+	if strings.HasPrefix(rawCmd, "/mcp__") {
 		return m.runMCPPrompt(input)
 	}
+
+	cmd := m.canonicalSlashCommand(rawCmd)
+	args := strings.TrimSpace(strings.TrimPrefix(input, rawCmd))
 
 	switch cmd {
 	case "/compact":
@@ -3350,8 +3352,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		// card as they arrive; compactDoneMsg only handles the terminal error /
 		// snapshot once the pass returns. Any text after "/compact" is focus
 		// guidance steering what the summary keeps.
-		focus := strings.TrimSpace(strings.TrimPrefix(input, cmd))
-		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background(), focus)} }
+		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background(), args)} }
 	case "/new":
 		m.echoLocalCommand(input)
 		if err := m.ctrl.NewSession(); err != nil {
@@ -3425,7 +3426,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		if m.pendingModelSwitch != nil {
 			return m.pendingModelSwitch
 		}
-	case "/skill", "/skills":
+	case "/skills":
 		m.echoLocalCommand(input)
 		m.runSkillSubcommand(input)
 		if m.pendingModelSwitch != nil {
@@ -3456,7 +3457,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 
 	case "/paste-image":
 		return pasteClipboardImage()
-	case "/output-style", "/output-styles":
+	case "/output-style":
 		m.echoLocalCommand(input)
 		styles := outputstyle.List(outputstyle.Dirs())
 		if len(styles) == 0 {
@@ -3485,9 +3486,9 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/memory":
 		m.echoLocalCommand(input)
 		m.showMemory()
-	case "/migrate", "/migration":
+	case "/migrate":
 		m.echoLocalCommand(input)
-		migration.RunLegacyRescueCommand(strings.TrimSpace(strings.TrimPrefix(input, cmd)), event.FuncSink(func(e event.Event) {
+		migration.RunLegacyRescueCommand(args, event.FuncSink(func(e event.Event) {
 			if e.Kind == event.Notice {
 				m.notice(e.Text)
 			}
@@ -3495,22 +3496,21 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/goal":
 		return m.runGoalSubcommand(input)
 	case "/remember":
-		note := strings.TrimSpace(strings.TrimPrefix(input, cmd))
-		if note == "" {
+		if args == "" {
 			m.notice("nothing to remember")
-		} else if path, err := m.ctrl.QuickAdd(memory.ScopeProject, note); err != nil {
+		} else if path, err := m.ctrl.QuickAdd(memory.ScopeProject, args); err != nil {
 			m.notice("memory: " + err.Error())
 		} else {
 			m.notice("remembered → " + path)
 		}
-	case "/quit", "/exit":
+	case "/quit":
 		return tea.Quit
 	case "/copy":
 		return m.runCopyCommand(input)
 	case "/export":
 		m.runExportCommand(input)
 	case "/forget":
-		m.forgetMemory(strings.TrimSpace(strings.TrimPrefix(input, cmd)))
+		m.forgetMemory(args)
 	default:
 		// A custom command wins over a skill of the same name; both resolve to a turn.
 		if sent, ok := m.ctrl.CustomCommand(input); ok {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3060,66 +3060,22 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	return tea.Batch(m.spinner.Tick, elapsedTick())
 }
 
-var chatSlashCommands = map[string]struct{}{
-	"/auto-plan":          {},
-	"/branch":             {},
-	"/clear":              {},
-	"/cls":                {},
-	"/compact":            {},
-	"/copy":               {},
-	"/diff-fold":          {},
-	"/effort":             {},
-	"/exit":               {},
-	"/export":             {},
-	"/forget":             {},
-	"/goal":               {},
-	"/help":               {},
-	"/hooks":              {},
-	"/language":           {},
-	"/mcp":                {},
-	"/memory":             {},
-	"/memory-v5":          {},
-	"/migrate":            {},
-	"/migration":          {},
-	"/model":              {},
-	"/new":                {},
-	"/output-style":       {},
-	"/output-styles":      {},
-	"/paste-image":        {},
-	"/provider":           {},
-	"/quit":               {},
-	"/reasoning-language": {},
-	"/reload-cmd":         {},
-	"/remember":           {},
-	"/rename":             {},
-	"/resume":             {},
-	"/rewind":             {},
-	"/sandbox":            {},
-	"/skill":              {},
-	"/skills":             {},
-	"/switch":             {},
-	"/theme":              {},
-	"/todo":               {},
-	"/tree":               {},
-	"/verbose":            {},
+var slashCommandAliases = map[string]string{
+	"/exit":          "/quit",
+	"/migration":     "/migrate",
+	"/output-styles": "/output-style",
+	"/skill":         "/skills",
 }
 
 func (m *chatTUI) handlesSlashCommand(input string) bool {
 	cmd := strings.TrimSpace(strings.SplitN(input, " ", 2)[0])
-	if strings.HasPrefix(cmd, "/mcp__") {
-		return true
+	if canonical, ok := slashCommandAliases[cmd]; ok {
+		cmd = canonical
 	}
-	if _, ok := chatSlashCommands[cmd]; ok {
-		return true
-	}
-	if m.ctrl == nil {
-		return false
-	}
-	if _, ok := m.ctrl.CustomCommand(input); ok {
-		return true
-	}
-	if _, ok := m.ctrl.RunSkill(input); ok {
-		return true
+	for _, item := range m.slashItems() {
+		if item.label == cmd {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1214,16 +1214,17 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(m.spinner.Tick, elapsedTick())
 			}
 
-			// Slash commands run locally without going through the model. A
+			// Known slash commands run locally without going through the model. A
 			// '/'-leading line that's actually a dragged file path is an attachment,
-			// not a command, so it's rewritten to an @reference instead.
+			// not a command, so it's rewritten to an @reference instead. Unknown
+			// slash-prefixed prose falls through to the normal message path.
 			if strings.HasPrefix(line, "//") {
 				// Double-slash — common in JS comments, file:// URLs, etc.
 				// Not a command. Fall through to normal message path.
 			} else if strings.HasPrefix(line, "/") {
 				if ref, ok := control.FileRefLine(line); ok {
 					line = ref
-				} else {
+				} else if m.handlesSlashCommand(line) {
 					m.input.Reset()
 					m.pastedBlocks = nil
 					cmds = append(cmds, m.runSlashCommand(line))
@@ -3059,6 +3060,70 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	return tea.Batch(m.spinner.Tick, elapsedTick())
 }
 
+var chatSlashCommands = map[string]struct{}{
+	"/auto-plan":          {},
+	"/branch":             {},
+	"/clear":              {},
+	"/cls":                {},
+	"/compact":            {},
+	"/copy":               {},
+	"/diff-fold":          {},
+	"/effort":             {},
+	"/exit":               {},
+	"/export":             {},
+	"/forget":             {},
+	"/goal":               {},
+	"/help":               {},
+	"/hooks":              {},
+	"/language":           {},
+	"/mcp":                {},
+	"/memory":             {},
+	"/memory-v5":          {},
+	"/migrate":            {},
+	"/migration":          {},
+	"/model":              {},
+	"/new":                {},
+	"/output-style":       {},
+	"/output-styles":      {},
+	"/paste-image":        {},
+	"/provider":           {},
+	"/quit":               {},
+	"/reasoning-language": {},
+	"/reload-cmd":         {},
+	"/remember":           {},
+	"/rename":             {},
+	"/resume":             {},
+	"/rewind":             {},
+	"/sandbox":            {},
+	"/skill":              {},
+	"/skills":             {},
+	"/switch":             {},
+	"/theme":              {},
+	"/todo":               {},
+	"/tree":               {},
+	"/verbose":            {},
+}
+
+func (m *chatTUI) handlesSlashCommand(input string) bool {
+	cmd := strings.TrimSpace(strings.SplitN(input, " ", 2)[0])
+	if strings.HasPrefix(cmd, "/mcp__") {
+		return true
+	}
+	if _, ok := chatSlashCommands[cmd]; ok {
+		return true
+	}
+	if m.ctrl == nil {
+		return false
+	}
+	if _, ok := m.ctrl.CustomCommand(input); ok {
+		return true
+	}
+	if _, ok := m.ctrl.RunSkill(input); ok {
+		return true
+	}
+	return false
+}
+
 // confirmBubbleSent marks the already-echoed user bubble as really sent once a
 // turn's first response packet arrives, so Esc no longer un-sends it (it cancels
 // the stream instead). Also called defensively at turn end. A no-op once confirmed.
@@ -3498,7 +3563,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		if sent, ok := m.ctrl.RunSkill(input); ok {
 			return m.startTurn(sent, input, input)
 		}
-		m.notice(fmt.Sprintf("%s: %s", i18n.M.SlashUnknown, cmd))
+		return m.startTurn(input, input, input)
 	}
 	return nil
 }

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2227,6 +2227,11 @@ func TestHandlesSlashCommandFollowsSlashItems(t *testing.T) {
 		if !m.handlesSlashCommand(item.label + " extra") {
 			t.Fatalf("handlesSlashCommand should accept slashItems entry %q", item.label)
 		}
+		for _, alias := range item.aliases {
+			if !m.handlesSlashCommand(alias + " extra") {
+				t.Fatalf("handlesSlashCommand should accept alias %q for slashItems entry %q", alias, item.label)
+			}
+		}
 	}
 }
 
@@ -2239,6 +2244,23 @@ func TestHandlesSlashCommandAliasesAndUnknownProse(t *testing.T) {
 	}
 	if m.handlesSlashCommand("/history正常应该是这样的行为") {
 		t.Fatal("unknown slash-prefixed prose should fall through to the normal prompt path")
+	}
+}
+
+func TestCanonicalSlashCommandUsesSlashItemAliases(t *testing.T) {
+	m := newTestChatTUI()
+	for input, want := range map[string]string{
+		"/exit":          "/quit",
+		"/migration":     "/migrate",
+		"/output-styles": "/output-style",
+		"/skill":         "/skills",
+	} {
+		if got := m.canonicalSlashCommand(input); got != want {
+			t.Fatalf("canonicalSlashCommand(%q) = %q, want %q", input, got, want)
+		}
+	}
+	if got := m.canonicalSlashCommand("/history正常应该是这样的行为"); got != "/history正常应该是这样的行为" {
+		t.Fatalf("unknown slash text canonicalized to %q", got)
 	}
 }
 
@@ -2274,9 +2296,9 @@ func TestSlashMigrateFromImportsExplicitSessions(t *testing.T) {
 	}
 	m := newTestChatTUI()
 
-	input := `/migrate --from "` + filepath.Dir(legacySessions) + `"`
+	input := `/migration --from "` + filepath.Dir(legacySessions) + `"`
 	if cmd := m.runSlashCommand(input); cmd != nil {
-		t.Fatal("/migrate --from should run locally without returning a command")
+		t.Fatal("/migration --from should run locally without returning a command")
 	}
 	out := strings.Join(m.transcript, "\n")
 	for _, want := range []string{

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2221,6 +2221,27 @@ func TestUnknownSlashCommandStartsModelTurn(t *testing.T) {
 	}
 }
 
+func TestHandlesSlashCommandFollowsSlashItems(t *testing.T) {
+	m := newTestChatTUI()
+	for _, item := range m.slashItems() {
+		if !m.handlesSlashCommand(item.label + " extra") {
+			t.Fatalf("handlesSlashCommand should accept slashItems entry %q", item.label)
+		}
+	}
+}
+
+func TestHandlesSlashCommandAliasesAndUnknownProse(t *testing.T) {
+	m := newTestChatTUI()
+	for _, input := range []string{"/exit", "/migration", "/output-styles", "/skill"} {
+		if !m.handlesSlashCommand(input) {
+			t.Fatalf("handlesSlashCommand should accept alias %q", input)
+		}
+	}
+	if m.handlesSlashCommand("/history正常应该是这样的行为") {
+		t.Fatal("unknown slash-prefixed prose should fall through to the normal prompt path")
+	}
+}
+
 func TestSlashMigrateShowsProgress(t *testing.T) {
 	isolateCLIConfigHome(t)
 	m := newTestChatTUI()

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2186,6 +2186,41 @@ func TestSlashQuitExit(t *testing.T) {
 	}
 }
 
+func TestUnknownSlashCommandStartsModelTurn(t *testing.T) {
+	runner := &recordingTurnRunner{}
+	events := make(chan event.Event, 4)
+	ctrl := control.New(control.Options{
+		AutoPlan: "off",
+		Runner:   runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+		SessionDir: t.TempDir(),
+		Label:      "test",
+	})
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+
+	const input = "/history正常应该是这样的行为"
+	if cmd := m.runSlashCommand(input); cmd == nil {
+		t.Fatal("unknown slash text should start a model turn")
+	}
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Kind == event.TurnDone {
+				if len(runner.inputs) != 1 || runner.inputs[0] != input {
+					t.Fatalf("unknown slash command should be sent as a normal prompt, inputs=%q", runner.inputs)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for model turn, inputs=%q", runner.inputs)
+		}
+	}
+}
+
 func TestSlashMigrateShowsProgress(t *testing.T) {
 	isolateCLIConfigHome(t)
 	m := newTestChatTUI()

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -26,12 +26,26 @@ const (
 
 // compItem is one menu row: label shown, insert applied on accept, hint dimmed.
 // descend marks a directory entry — accepting it fills the input and re-opens
-// the menu one level deeper instead of closing.
+// the menu one level deeper instead of closing. aliases are accepted spellings
+// that are intentionally hidden from completion.
 type compItem struct {
 	label   string
 	insert  string
 	hint    string
 	descend bool
+	aliases []string
+}
+
+func (it compItem) matches(label string) bool {
+	if it.label == label {
+		return true
+	}
+	for _, alias := range it.aliases {
+		if alias == label {
+			return true
+		}
+	}
+	return false
 }
 
 // completion is the live autocomplete menu state. Empty value = inactive.
@@ -74,11 +88,11 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/mcp", insert: "/mcp", hint: i18n.M.CmdMcp},
 		{label: "/model", insert: "/model ", hint: i18n.M.CmdModel, descend: true},
 		{label: "/provider", insert: "/provider ", hint: i18n.M.CmdProvider, descend: true},
-		{label: "/skills", insert: "/skills", hint: i18n.M.CmdSkill},
+		{label: "/skills", insert: "/skills", hint: i18n.M.CmdSkill, aliases: []string{"/skill"}},
 		{label: "/reload-cmd", insert: "/reload-cmd", hint: i18n.M.CmdReloadCmd},
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
-		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
+		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle, aliases: []string{"/output-styles"}},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
 		{label: "/diff-fold", insert: "/diff-fold", hint: i18n.M.CmdDiffFold},
 		{label: "/sandbox", insert: "/sandbox", hint: i18n.M.CmdSandbox},
@@ -90,11 +104,11 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/language", insert: "/language ", hint: i18n.M.CmdLanguage, descend: true},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
-		{label: "/migrate", insert: "/migrate", hint: i18n.M.CmdMigrate},
+		{label: "/migrate", insert: "/migrate", hint: i18n.M.CmdMigrate, aliases: []string{"/migration"}},
 		{label: "/goal", insert: "/goal ", hint: i18n.M.CmdGoal, descend: true},
 		{label: "/remember", insert: "/remember ", hint: i18n.M.CmdRemember},
 		{label: "/forget", insert: "/forget ", hint: i18n.M.CmdForget},
-		{label: "/quit", insert: "/quit", hint: i18n.M.CmdQuit},
+		{label: "/quit", insert: "/quit", hint: i18n.M.CmdQuit, aliases: []string{"/exit"}},
 		{label: "/copy", insert: "/copy", hint: i18n.M.CmdCopy},
 		{label: "/export", insert: "/export", hint: i18n.M.CmdExport},
 	}

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -64,6 +64,49 @@ func TestSlashCompletionIncludesCustomCommands(t *testing.T) {
 	}
 }
 
+func TestCompItemMatchesLabelAndAliases(t *testing.T) {
+	item := compItem{label: "/skills", aliases: []string{"/skill"}}
+
+	for _, input := range []string{"/skills", "/skill"} {
+		if !item.matches(input) {
+			t.Fatalf("compItem should match %q", input)
+		}
+	}
+	if item.matches("/skillful") {
+		t.Fatal("compItem should not fuzzy-match alias-like text")
+	}
+}
+
+func TestSlashCompletionKeepsAliasesHidden(t *testing.T) {
+	m := newTestChatTUI()
+	items := m.slashItems()
+	hiddenAliases := map[string]string{
+		"/skills":       "/skill",
+		"/output-style": "/output-styles",
+		"/migrate":      "/migration",
+		"/quit":         "/exit",
+	}
+
+	for label, alias := range hiddenAliases {
+		var item compItem
+		for _, it := range items {
+			if it.label == label {
+				item = it
+				break
+			}
+		}
+		if item.label == "" {
+			t.Fatalf("slashItems missing canonical command %q", label)
+		}
+		if !item.matches(alias) {
+			t.Fatalf("slashItems entry %q should accept hidden alias %q", label, alias)
+		}
+		if hasLabel(items, alias) {
+			t.Fatalf("alias %q should not be exposed as a completion label", alias)
+		}
+	}
+}
+
 func TestCompletionClosesOnSpaceAndNonMatch(t *testing.T) {
 	m := newTestChatTUI()
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -658,8 +658,8 @@ func lastAssistantText(msgs []provider.Message) string {
 //
 // Slash commands route to the matching primitive: /compact, /new, and /clear
 // run their session op and emit a Notice; /mcp__server__prompt and custom /commands
-// resolve to a turn; an unknown slash emits a Notice. Anything else is a normal
-// turn with its @-references resolved first.
+// resolve to a turn; an unknown slash falls back to a normal turn. Anything else
+// is a normal turn with its @-references resolved first.
 func (c *Controller) Submit(input string) {
 	c.submit(input, "", "")
 }
@@ -871,7 +871,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			})
 			return
 		}
-		c.notice("unknown command: " + trimmed)
+		runRefTurn(input, display)
 	default:
 		if c.maybeAutoStartResearchGoal(input, display, editedOriginal) {
 			return

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -577,7 +577,7 @@ func TestSubmitMissingSlashPathDiagnosticStartsTurn(t *testing.T) {
 	}
 }
 
-func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
+func TestSubmitUnknownSlashCommandStartsNormalTurn(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	events := make(chan event.Event, 4)
 	c := New(Options{
@@ -588,18 +588,12 @@ func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
 		}),
 	})
 
-	c.Submit("/definitely-not-a-command")
+	const input = "/history正常应该是这样的行为"
+	c.Submit(input)
+	waitForTurnDone(t, events)
 
-	if len(runner.inputs) != 0 {
-		t.Fatalf("unknown slash command should not start a model turn, inputs=%q", runner.inputs)
-	}
-	select {
-	case e := <-events:
-		if e.Kind != event.Notice || !strings.Contains(e.Text, "unknown command: /definitely-not-a-command") {
-			t.Fatalf("event = %+v, want unknown-command notice", e)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for unknown-command notice")
+	if len(runner.inputs) != 1 || runner.inputs[0] != input {
+		t.Fatalf("unknown slash command should start a normal model turn, inputs=%q", runner.inputs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat unmatched slash-prefixed text as a normal user prompt instead of swallowing it as an unknown command.
- Keep built-in slash commands, custom commands, skills, MCP prompts, slash-path diagnostics, and file-ref handling on their existing paths.
- Add controller and TUI regression tests for `/history正常应该是这样的行为`.

Fixes #5756

## Validation
- `go test ./...`
- `cd desktop && go test . -run 'Test.*Submit|Test.*Slash|Test.*Command'`\n- `git diff --check`