### PR TITLE
Auto-copy mouse selection + mouse-capture toggle / 拖拽选中自动复制 + 鼠标接管开关

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -302,7 +302,8 @@ Chat and transcript shortcuts:
 | `Ctrl+L` or `/cls` | Clears only the visible transcript | The LLM context, session file, tools, memory, and plugins stay loaded. Use `/clear` when you want to discard the conversation context. |
 | `Esc` | Backs out of the current action | It un-sends a just-submitted turn before any reply, cancels a running turn, or clears non-empty input. |
 | Double `Esc` on an empty idle composer | Opens the rewind picker | Same entry point as `/rewind`. |
-| Transcript text selection | Copies transcript text | The full-screen TUI enables mouse reporting, so drag in the transcript to select text in-app, then press `Ctrl+C`, `Super+C`, `Meta+C`, or right-click the active selection to copy it. |
+| Transcript text selection | Copies transcript text | The full-screen TUI enables mouse reporting, so drag in the transcript to select text in-app; releasing the mouse copies it automatically, and `Ctrl+C`/`Super+C`/`Meta+C` or right-clicking the active selection copy it again. |
+| `/mouse` | Toggles in-app mouse capture | Off hands the mouse back to your terminal, restoring its native click-drag selection and right-click context menu, at the cost of in-app drag-select, the transcript scrollbar, and wheel-scroll. Set `REASONIX_DISABLE_MOUSE=1` to start every session with it off. |
 | `Ctrl+C` | Copies, cancels, clears, or quits | Copies an active transcript selection first. Otherwise it cancels a running turn, clears non-empty input, or quits on a second empty-composer press. |
 | `Ctrl+D` | Quits the TUI | Immediate quit. |
 | `Ctrl+V`, `Ctrl+Shift+V`, `Meta+V`, or `Super+V` | Pastes clipboard content | The CLI tries an image first, then falls back to text or file references. |

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -52,6 +52,13 @@ type chatTUI struct {
 	// nativeScrollback keeps Termux out of alt-screen mode so taps still focus
 	// the textarea and raise the soft keyboard.
 	nativeScrollback bool
+	// mouseCaptureOff releases mouse ownership back to the terminal (View() sets
+	// tea.MouseModeNone instead of MouseModeCellMotion) so its native
+	// click-drag selection and right-click context menu work again. Toggled by
+	// "/mouse" or REASONIX_DISABLE_MOUSE at startup; trades away in-app
+	// drag-select, the transcript scrollbar, and wheel-scroll while it's on,
+	// since the terminal no longer forwards those events to Reasonix.
+	mouseCaptureOff bool
 
 	input   textarea.Model
 	spinner spinner.Model
@@ -196,6 +203,13 @@ type chatTUI struct {
 	// dead target and dragging it never leaves a transcript selection behind.
 	scrollbarDrag       bool
 	scrollbarGrabOffset int
+	// copyNoticeText is a transient "copied to clipboard" hint shown on the status
+	// line after a mouse-drag, right-click, or Ctrl+C selection copy; "" when none
+	// is showing. copyNoticeSeq guards its expiry tick so an older copy's timer
+	// can't clear a newer notice — each copy bumps the sequence and only a tick
+	// carrying the current sequence clears the text.
+	copyNoticeText string
+	copyNoticeSeq  int
 
 	// The user bubble is echoed to scrollback immediately on Enter (bubbleStartIdx
 	// marks where in the transcript it landed). It stays "un-sendable" until the
@@ -484,6 +498,7 @@ func newChatTUI(ctrl control.SessionAPI, missing string, eventCh chan event.Even
 		label:                ctrl.Label(),
 		missing:              missing,
 		nativeScrollback:     nativeScrollback,
+		mouseCaptureOff:      mouseCaptureOffByDefault(),
 		input:                ti,
 		spinner:              sp,
 		submittedInputCursor: -1,
@@ -518,6 +533,15 @@ func transcriptContentWidth(termW int, nativeScrollback bool) int {
 		termW-- // reserve the last column for the transcript scrollbar
 	}
 	return max(termW, 1)
+}
+
+// mouseCaptureOffByDefault lets a user opt out of in-app mouse capture for
+// every run (e.g. a terminal/multiplexer combo where the native right-click
+// menu and click-drag selection matter more than the scrollbar and
+// wheel-scroll) without having to type "/mouse" each session.
+func mouseCaptureOffByDefault() bool {
+	v := strings.TrimSpace(os.Getenv("REASONIX_DISABLE_MOUSE"))
+	return v != "" && v != "0"
 }
 
 func configureChatTextarea(ti *textarea.Model) {
@@ -775,7 +799,8 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Button == tea.MouseRight && m.sel.active && !m.sel.empty() {
 			text := m.selectedText()
 			m.sel = selection{}
-			return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
+			cmds = append(cmds, m.copySelectionWithNotice(text))
+			return m, finalize(m, cmds)
 		}
 		if msg.Button == tea.MouseLeft && m.inScrollbar(msg.X, msg.Y) {
 			m.sel = selection{}
@@ -844,9 +869,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, autoScrollTick()
 
 	case tea.MouseReleaseMsg:
-		// Release finalizes the selection; the highlight stays on as the visual
-		// "what's selected" cue and a right-click copies it. A plain click (no
-		// drag) clears any prior selection.
+		// Release finalizes the selection: a real drag auto-copies it (native
+		// terminal convention), while the highlight stays on as the visual
+		// "what's selected" cue and a right-click can still re-copy it. A plain
+		// click (no drag) clears any prior selection.
 		if m.scrollbarDrag {
 			m.dragScrollbar(msg.Y)
 			m.scrollbarDrag = false
@@ -854,10 +880,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.autoScroll = 0 // stop edge auto-scroll
-		if msg.Button == tea.MouseLeft && m.sel.active && m.sel.empty() {
-			m.sel = selection{}
+		if msg.Button == tea.MouseLeft && m.sel.active {
+			if m.sel.empty() {
+				m.sel = selection{}
+			} else {
+				cmds = append(cmds, m.copySelectionWithNotice(m.selectedText()))
+			}
 		}
-		return m, nil
+		return m, finalize(m, cmds)
 
 	case tea.PasteMsg:
 		if m.state != tuiRunning && m.attachPastedImages(msg.Content) {
@@ -1063,7 +1093,8 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.sel = sel
 					text := m.selectedText()
 					m.sel = selection{}
-					return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
+					cmds = append(cmds, m.copySelectionWithNotice(text))
+					return m, finalize(m, cmds)
 				}
 				if m.bubblePending {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
@@ -1087,7 +1118,8 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.sel = sel // restore so selectedText() can read it
 				text := m.selectedText()
 				m.sel = selection{}
-				return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
+				cmds = append(cmds, m.copySelectionWithNotice(text))
+				return m, finalize(m, cmds)
 			}
 			// No selection: if the composer has text, a single press clears it
 			// (like Esc); on an empty composer a double-press within 1.5s quits.
@@ -1411,6 +1443,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.growInputToFit()
 			m.updateCompletion()
 			return m, finalize(m, cmds)
+		}
+
+	case copyNoticeExpireMsg:
+		if msg.seq == m.copyNoticeSeq {
+			m.copyNoticeText = ""
 		}
 
 	case elapsedTickMsg:
@@ -2356,6 +2393,8 @@ func (m chatTUI) View() tea.View {
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusToolApproval
+	case m.copyNoticeText != "":
+		status = "  " + modeTag + " · " + green(m.copyNoticeText)
 	case cancelRequested:
 		status = "  " + modeTag + " · " + i18n.M.CtrlCQuitHint
 	case shellMode:
@@ -2370,6 +2409,9 @@ func (m chatTUI) View() tea.View {
 	}
 	if gt := m.gitTag(); gt != "" {
 		status += " · " + gt
+	}
+	if mt := m.mouseTag(); mt != "" {
+		status += " · " + mt
 	}
 	// The spinning "thinking…" indicator is its own line ABOVE the input box (shown
 	// only while a turn runs); the status/data rows stay below. This mirrors Claude
@@ -2488,7 +2530,14 @@ func (m chatTUI) View() tea.View {
 	}
 	v := tea.NewView(mainArea + "\n" + strings.Join(parts, "\n"))
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeCellMotion // wheel scrolls the transcript; text selection is handled in-app
+	if m.mouseCaptureOff {
+		// Release the mouse to the terminal: native click-drag selection and
+		// right-click context menu work again, at the cost of the in-app
+		// scrollbar, wheel-scroll, and drag-select while it's off.
+		v.MouseMode = tea.MouseModeNone
+	} else {
+		v.MouseMode = tea.MouseModeCellMotion // wheel scrolls the transcript; text selection is handled in-app
+	}
 	// Anchor the real terminal cursor at the textarea's insertion point only when
 	// the composer is visible. input.Cursor() is relative to the textarea; offset
 	// by the viewport height + rows above + the box's top border row (+1 column
@@ -2629,6 +2678,16 @@ func (m chatTUI) effortTag() string {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("#2563eb")).Bold(true).Render(body)
 	}
 	return dim(body)
+}
+
+// mouseTag is a persistent status-line marker while mouseCaptureOff is on, so
+// the loss of in-app scrollbar/wheel-scroll/drag-select reads as a deliberate
+// state rather than a bug the user has to guess at.
+func (m chatTUI) mouseTag() string {
+	if !m.mouseCaptureOff {
+		return ""
+	}
+	return dim(i18n.M.MouseCaptureTag)
 }
 
 // shortTokens prints token counts compactly: 1_500 → "1.5K", 142_000 → "142.0K", 1_000_000 → "1.0M".
@@ -2837,6 +2896,8 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 		status += " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status += " · " + i18n.M.ChatStatusToolApproval
+	case m.copyNoticeText != "":
+		status += " · " + m.copyNoticeText
 	case cancelRequested:
 		status += " · " + i18n.M.CtrlCQuitHint
 	case shellMode:
@@ -2851,6 +2912,9 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	}
 	if gt := m.gitTag(); gt != "" {
 		status += " · " + gt
+	}
+	if mt := m.mouseTag(); mt != "" {
+		status += " · " + mt
 	}
 
 	// Replicate the data line from View().
@@ -3018,6 +3082,24 @@ func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 		m.notice("verbose on — thinking text will be shown")
 	} else {
 		m.notice("verbose off — thinking text will stay collapsed")
+	}
+}
+
+// toggleMouseCapture flips whether Reasonix owns the mouse. It's session-only
+// (unlike /verbose, this accommodates the terminal/multiplexer at hand rather
+// than recording a lasting preference) — mirrors nativeScrollback, which is
+// likewise never persisted to config. Clears any in-app selection/scrollbar
+// drag in flight so a stale one can't be found mid-gesture once the terminal
+// starts intercepting the events that would have finished it.
+func (m *chatTUI) toggleMouseCapture() {
+	m.mouseCaptureOff = !m.mouseCaptureOff
+	m.sel = selection{}
+	m.scrollbarDrag = false
+	m.autoScroll = 0
+	if m.mouseCaptureOff {
+		m.notice(i18n.M.MouseCaptureOffHint)
+	} else {
+		m.notice(i18n.M.MouseCaptureOnHint)
 	}
 }
 
@@ -3363,6 +3445,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.notice(i18n.M.SlashTodoCleared)
 	case "/verbose":
 		m.toggleVerboseReasoning(true)
+	case "/mouse":
+		m.toggleMouseCapture()
 	case "/sandbox":
 		m.echoLocalCommand(input)
 		m.showSandboxStatus()

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1119,6 +1119,138 @@ func TestTranscriptScrollbarClickAndDrag(t *testing.T) {
 	}
 }
 
+// TestMouseDragReleaseAutoCopies verifies that releasing the mouse after a
+// left-drag over the transcript copies the selection to the clipboard
+// automatically (native terminal convention), keeps the selection highlighted
+// so a follow-up right-click can still re-copy it, and arms the transient
+// "copied to clipboard" status-line notice.
+func TestMouseDragReleaseAutoCopies(t *testing.T) {
+	m := newTestChatTUI()
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 0}, head: selPos{line: 0, col: 5}}
+
+	out, cmd := m.Update(tea.MouseReleaseMsg{Button: tea.MouseLeft})
+	m2, ok := out.(chatTUI)
+	if !ok {
+		t.Fatalf("Update returned %T, want chatTUI", out)
+	}
+
+	if cmd == nil {
+		t.Fatal("release after a real drag should return a cmd (clipboard copy + notice)")
+	}
+	if !m2.sel.active {
+		t.Error("selection should stay highlighted after auto-copy so right-click can re-copy it")
+	}
+	if m2.copyNoticeText == "" {
+		t.Error("release after a real drag should arm the copied-to-clipboard notice")
+	}
+}
+
+// TestMousePlainClickReleaseDoesNotCopy verifies that a plain click (no drag,
+// empty selection) does not copy an empty string to the clipboard or show the
+// copied notice — only clears the zero-width selection, as before.
+func TestMousePlainClickReleaseDoesNotCopy(t *testing.T) {
+	m := newTestChatTUI()
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	at := selPos{line: 0, col: 3}
+	m.sel = selection{active: true, anchor: at, head: at} // empty: anchor == head
+
+	out, _ := m.Update(tea.MouseReleaseMsg{Button: tea.MouseLeft})
+	m2, ok := out.(chatTUI)
+	if !ok {
+		t.Fatalf("Update returned %T, want chatTUI", out)
+	}
+
+	if m2.sel.active {
+		t.Error("a plain click (empty selection) should be cleared on release")
+	}
+	if m2.copyNoticeText != "" {
+		t.Error("a plain click (empty selection) must not arm the copied-to-clipboard notice")
+	}
+}
+
+// TestCopyNoticeExpires verifies the copied-to-clipboard notice clears itself
+// once its own expiry tick fires, and that a stale tick from an earlier copy
+// (superseded by a newer one) does not clear the newer notice.
+func TestCopyNoticeExpires(t *testing.T) {
+	m := newTestChatTUI()
+	m.copyNoticeText = i18n.M.MouseCopiedHint
+	m.copyNoticeSeq = 2
+
+	// A stale tick from a prior (superseded) copy must not clear the current notice.
+	out, _ := m.Update(copyNoticeExpireMsg{seq: 1})
+	m2 := out.(chatTUI)
+	if m2.copyNoticeText == "" {
+		t.Fatal("a stale expiry tick must not clear a newer notice")
+	}
+
+	// The current tick clears it.
+	out, _ = m2.Update(copyNoticeExpireMsg{seq: 2})
+	m3 := out.(chatTUI)
+	if m3.copyNoticeText != "" {
+		t.Fatal("the matching expiry tick should clear the notice")
+	}
+}
+
+// TestToggleMouseCaptureFlipsModeAndClearsGestures proves "/mouse" flips
+// mouseCaptureOff, shows the matching on/off notice, and drops any in-flight
+// selection/scrollbar drag so a stale gesture can't be found mid-drag once the
+// terminal starts intercepting the events that would have finished it.
+func TestToggleMouseCaptureFlipsModeAndClearsGestures(t *testing.T) {
+	m := newTestChatTUI()
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 0}, head: selPos{line: 0, col: 5}}
+	m.scrollbarDrag = true
+	m.autoScroll = 1
+
+	m.toggleMouseCapture()
+	if !m.mouseCaptureOff {
+		t.Fatal("first toggle should turn mouse capture off")
+	}
+	if m.sel.active || m.scrollbarDrag || m.autoScroll != 0 {
+		t.Fatal("toggling mouse capture should clear any in-flight selection/drag")
+	}
+	if got := (*m.pendingCommit)[len(*m.pendingCommit)-1]; !strings.Contains(got, i18n.M.MouseCaptureOffHint) {
+		t.Fatalf("notice = %q, want it to contain %q", got, i18n.M.MouseCaptureOffHint)
+	}
+
+	m.toggleMouseCapture()
+	if m.mouseCaptureOff {
+		t.Fatal("second toggle should turn mouse capture back on")
+	}
+	if got := (*m.pendingCommit)[len(*m.pendingCommit)-1]; !strings.Contains(got, i18n.M.MouseCaptureOnHint) {
+		t.Fatalf("notice = %q, want it to contain %q", got, i18n.M.MouseCaptureOnHint)
+	}
+}
+
+// TestViewMouseModeFollowsCapture proves View() requests MouseModeNone (so
+// the terminal's native right-click menu and click-drag selection work) while
+// mouseCaptureOff is set, and MouseModeCellMotion (in-app selection/scrollbar/
+// wheel-scroll) otherwise.
+func TestViewMouseModeFollowsCapture(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 60)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
+	m = m0.(chatTUI)
+
+	if got := m.View().MouseMode; got != tea.MouseModeCellMotion {
+		t.Fatalf("MouseMode with capture on = %v, want MouseModeCellMotion", got)
+	}
+
+	m.mouseCaptureOff = true
+	if got := m.View().MouseMode; got != tea.MouseModeNone {
+		t.Fatalf("MouseMode with capture off = %v, want MouseModeNone", got)
+	}
+	// Status line wraps at this width, so check the unwrapped tag rather than
+	// the rendered (possibly line-broken) View() content.
+	if got := m.mouseTag(); !strings.Contains(ansi.Strip(got), i18n.M.MouseCaptureTag) {
+		t.Fatalf("mouseTag() = %q, want it to contain %q", got, i18n.M.MouseCaptureTag)
+	}
+}
+
 func TestEchoLocalCommandAddsTranscriptMarker(t *testing.T) {
 	m := newTestChatTUI()
 	m.echoLocalCommand("  /tree  ")

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -80,6 +80,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
+		{label: "/mouse", insert: "/mouse", hint: i18n.M.CmdMouse},
 		{label: "/diff-fold", insert: "/diff-fold", hint: i18n.M.CmdDiffFold},
 		{label: "/sandbox", insert: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/effort", insert: "/effort ", hint: i18n.M.CmdEffort, descend: true},

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -539,7 +539,8 @@ func TestFuzzyFilterSlashSubsequence(t *testing.T) {
 
 // TestFuzzyFilterSlashPrefixFirst proves prefix hits rank ahead of
 // subsequence-only hits, matching the menu behavior we want: typing "/mo"
-// should put /model at the top, not buried after non-prefix matches.
+// should put /model and /mouse (both true "/mo" prefixes) at the top, not
+// buried after non-prefix matches.
 func TestFuzzyFilterSlashPrefixFirst(t *testing.T) {
 	m := newTestChatTUI()
 	m.input.SetValue("/mo")
@@ -548,15 +549,17 @@ func TestFuzzyFilterSlashPrefixFirst(t *testing.T) {
 	if !m.completion.active {
 		t.Fatal("menu should open for /mo")
 	}
-	// /model is the only built-in whose label starts with /mo.
-	if len(m.completion.items) == 0 || m.completion.items[0].label != "/model" {
-		t.Fatalf("prefix hit /model should rank first, got %v", labels(m.completion.items))
+	// /model and /mouse are the only built-ins whose label starts with /mo;
+	// slashItems() declares /model first, and the filter is stable, so it
+	// leads.
+	if len(m.completion.items) < 2 || m.completion.items[0].label != "/model" || m.completion.items[1].label != "/mouse" {
+		t.Fatalf("prefix hits /model, /mouse should rank first in declaration order, got %v", labels(m.completion.items))
 	}
 	// Any other built-ins in the list are subsequence-only matches and must
 	// therefore NOT be prefix hits of /mo.
-	for _, it := range m.completion.items[1:] {
+	for _, it := range m.completion.items[2:] {
 		if strings.HasPrefix(it.label, "/mo") {
-			t.Errorf("%q should not appear after /model (it is a prefix hit too)", it.label)
+			t.Errorf("%q should not appear after the /mo prefix hits", it.label)
 		}
 	}
 }

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -76,6 +76,7 @@ func builtinHelpItems() []compItem {
 		{label: "/diff-fold", hint: i18n.M.CmdDiffFold},
 		{label: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/verbose", hint: i18n.M.CmdVerbose},
+		{label: "/mouse", hint: i18n.M.CmdMouse},
 		{label: "/language", hint: i18n.M.CmdLanguage},
 		{label: "/auto-plan", hint: i18n.M.CmdAutoPlan},
 		{label: "/reasoning-language", hint: i18n.M.CmdReasonLang},

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -7,6 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/i18n"
 )
 
 // wrapTranscript wraps the joined transcript to width for the viewport, keeping
@@ -27,6 +29,28 @@ func wrapTranscript(s string, width int) string {
 // terminal clipboard path entirely.
 func copyToClipboard(text string) tea.Cmd {
 	return tea.SetClipboard(text)
+}
+
+// copyNoticeTTL is how long the "copied to clipboard" status-line hint stays
+// visible after a selection copy (mouse drag, right-click, or Ctrl+C) before
+// copyNoticeExpireMsg clears it.
+const copyNoticeTTL = 1500 * time.Millisecond
+
+// copyNoticeExpireMsg clears the transient copy notice — but only if seq still
+// matches m.copyNoticeSeq, so an older copy's timer can't stomp a newer notice
+// (e.g. drag-copy immediately followed by a right-click re-copy).
+type copyNoticeExpireMsg struct{ seq int }
+
+// copySelectionWithNotice copies text to the clipboard and arms the status-line
+// "copied to clipboard" hint, bumping copyNoticeSeq so any in-flight expiry tick
+// from a prior copy is superseded rather than racing this one.
+func (m *chatTUI) copySelectionWithNotice(text string) tea.Cmd {
+	m.copyNoticeSeq++
+	seq := m.copyNoticeSeq
+	m.copyNoticeText = i18n.M.MouseCopiedHint
+	return tea.Batch(copyToClipboard(text), tea.Tick(copyNoticeTTL, func(time.Time) tea.Msg {
+		return copyNoticeExpireMsg{seq: seq}
+	}))
 }
 
 // autoScrollMsg drives one step of edge-drag scrolling while a selection is held

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -128,23 +128,27 @@ type Messages struct {
 	CompactionManual  string // trigger label: user ran /compact
 
 	// chat TUI slash commands.
-	SlashCompactDone   string // "/compact" succeeded
-	SlashCompactFailed string // "/compact" errored, prefixed before the underlying error
-	SlashNewDone       string // "/new" succeeded
-	SlashNewFailed     string // "/new" errored
-	SlashClearPrompt   string // "/clear" destructive confirmation prompt
-	SlashClearDone     string // "/clear" succeeded
-	SlashClearFailed   string // "/clear" errored
-	SlashClsDone       string // "/cls" succeeded
-	SlashTodoCleared   string // "/todo" dismissed the pinned task list
-	SlashUnavailable   string // the command is configured off (no callback wired)
-	SlashUnknown       string // shown when the user types an unrecognised "/cmd"
-	SlashHelp          string // listed commands
-	SlashPromptEmpty   string // an MCP prompt returned no text to send
-	SlashMCPNone       string // /mcp when no MCP servers are connected
-	CtrlCQuitHint      string // shown on first Ctrl+C while idle; second press exits
-	CompHintSlash      string // key hint footer under the slash-command menu
-	CompHintFile       string // key hint footer under the @ file/resource menu
+	SlashCompactDone    string // "/compact" succeeded
+	SlashCompactFailed  string // "/compact" errored, prefixed before the underlying error
+	SlashNewDone        string // "/new" succeeded
+	SlashNewFailed      string // "/new" errored
+	SlashClearPrompt    string // "/clear" destructive confirmation prompt
+	SlashClearDone      string // "/clear" succeeded
+	SlashClearFailed    string // "/clear" errored
+	SlashClsDone        string // "/cls" succeeded
+	SlashTodoCleared    string // "/todo" dismissed the pinned task list
+	SlashUnavailable    string // the command is configured off (no callback wired)
+	SlashUnknown        string // shown when the user types an unrecognised "/cmd"
+	SlashHelp           string // listed commands
+	SlashPromptEmpty    string // an MCP prompt returned no text to send
+	SlashMCPNone        string // /mcp when no MCP servers are connected
+	CtrlCQuitHint       string // shown on first Ctrl+C while idle; second press exits
+	CompHintSlash       string // key hint footer under the slash-command menu
+	CompHintFile        string // key hint footer under the @ file/resource menu
+	MouseCopiedHint     string // transient status-line hint after a mouse/Ctrl+C selection copy
+	MouseCaptureOnHint  string // "/mouse" turned in-app mouse handling back on
+	MouseCaptureOffHint string // "/mouse" released mouse capture to the terminal
+	MouseCaptureTag     string // persistent status-line marker while mouse capture is off
 
 	// shell execution (! prefix).
 	ShellExecEmpty      string // bare "!" with no command
@@ -182,6 +186,7 @@ type Messages struct {
 	CmdDiffFold         string // /diff-fold
 	CmdSandbox          string // /sandbox
 	CmdEffort           string // /effort
+	CmdMouse            string // /mouse
 	CmdAutoPlan         string // /auto-plan
 	CmdReasonLang       string // /reasoning-language
 	CmdMemoryV5         string // /memory-v5

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -159,6 +159,10 @@ var English = Messages{
 	CtrlCQuitHint:                "press Ctrl+C again to quit",
 	CompHintSlash:                "↑/↓ move · Tab/Enter select · Esc close",
 	CompHintFile:                 "↑/↓ move · Tab/Enter open folder or pick file · Esc close",
+	MouseCopiedHint:              "copied to clipboard",
+	MouseCaptureOnHint:           "mouse capture on — in-app drag-select/scrollbar/wheel active",
+	MouseCaptureOffHint:          "mouse capture off — your terminal now handles selection and right-click",
+	MouseCaptureTag:              "native mouse",
 
 	ShellExecEmpty:      "usage: !<command>  (e.g. !ls -la)",
 	ShellExecFailedFmt:  "shell command failed: %v",
@@ -193,6 +197,7 @@ var English = Messages{
 	CmdDiffFold:         "toggle diff fold/expand",
 	CmdSandbox:          "show sandbox status",
 	CmdEffort:           "set reasoning effort",
+	CmdMouse:            "toggle in-app mouse capture (off = native terminal selection/right-click)",
 	CmdAutoPlan:         "configure automatic plan mode",
 	CmdReasonLang:       "set visible reasoning language",
 	CmdMemoryV5:         "toggle Memory v5",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -160,6 +160,10 @@ var Chinese = Messages{
 	CtrlCQuitHint:                "再按一次 Ctrl+C 退出",
 	CompHintSlash:                "↑/↓ 移动 · Tab/Enter 选中 · Esc 关闭",
 	CompHintFile:                 "↑/↓ 移动 · Tab/Enter 进入文件夹或选中文件 · Esc 关闭",
+	MouseCopiedHint:              "已复制到剪贴板",
+	MouseCaptureOnHint:           "鼠标接管已开启 — 应用内拖拽选中/滚动条/滚轮生效",
+	MouseCaptureOffHint:          "鼠标接管已关闭 — 由终端原生处理选中和右键菜单",
+	MouseCaptureTag:              "终端原生鼠标",
 
 	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
 	ShellExecFailedFmt:  "Shell 命令执行失败：%v",
@@ -194,6 +198,7 @@ var Chinese = Messages{
 	CmdDiffFold:         "切换 diff 折叠/展开",
 	CmdSandbox:          "查看沙箱状态",
 	CmdEffort:           "设置推理强度",
+	CmdMouse:            "切换鼠标接管（关闭后由终端原生处理选中/右键）",
 	CmdAutoPlan:         "配置自动计划模式",
 	CmdReasonLang:       "设置可见思考语言",
 	CmdMemoryV5:         "切换 Memory v5",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -150,6 +150,10 @@ var ChineseTraditional = Messages{
 	CtrlCQuitHint:                "再按一次 Ctrl+C 退出",
 	CompHintSlash:                "↑/↓ 移動 · Tab/Enter 選中 · Esc 關閉",
 	CompHintFile:                 "↑/↓ 移動 · Tab/Enter 進入資料夾或選中檔案 · Esc 關閉",
+	MouseCopiedHint:              "已複製到剪貼簿",
+	MouseCaptureOnHint:           "滑鼠接管已開啟 — 應用內拖拽選取/捲軸/滾輪生效",
+	MouseCaptureOffHint:          "滑鼠接管已關閉 — 由終端原生處理選取與右鍵選單",
+	MouseCaptureTag:              "終端原生滑鼠",
 
 	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
 	ShellExecFailedFmt:  "Shell 命令執行失敗：%v",
@@ -180,6 +184,7 @@ var ChineseTraditional = Messages{
 	CmdReloadCmd:        "重載自定義命令",
 	CmdSandbox:          "檢視沙箱狀態",
 	CmdEffort:           "設定推理強度",
+	CmdMouse:            "切換滑鼠接管（關閉後由終端原生處理選取/右鍵）",
 	CmdAutoPlan:         "設定自動計畫模式",
 	CmdReasonLang:       "設定可見思考語言",
 	CmdMemoryV5:         "切換 Memory v5",


### PR DESCRIPTION
## Summary

- Releasing a left-drag selection in the TUI transcript now copies it to the clipboard automatically, matching native terminal behavior (and Claude Code's fullscreen-rendering mode). The selection stays highlighted afterward so right-click can still re-copy it.
- A transient "copied to clipboard" status-line notice (auto-clears after ~1.5s, does not write into scrollback) now covers the mouse-drag, right-click, and Ctrl+C selection-copy paths consistently.
- Added `/mouse` to release mouse capture back to the terminal on demand. With it off, the terminal's native click-drag selection and right-click context menu work again, at the cost of in-app drag-select, the transcript scrollbar, and wheel-scroll while it's off (mouse capture is all-or-nothing at the terminal-protocol level). `REASONIX_DISABLE_MOUSE=1` starts every session with it off.
- Updated `docs/GUIDE.md` and all four i18n locales (en/zh/zh-TW + base) accordingly.

Related: #2862 ("鼠标左键拖拽选中文本后应自动复制到系统剪贴板").

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/cli/... ./internal/i18n/...`
- [x] `go test ./internal/cli/... ./internal/i18n/...` (existing suite + new tests: `TestMouseDragReleaseAutoCopies`, `TestMousePlainClickReleaseDoesNotCopy`, `TestCopyNoticeExpires`, `TestToggleMouseCaptureFlipsModeAndClearsGestures`, `TestViewMouseModeFollowsCapture`)
- [x] Updated `TestFuzzyFilterSlashPrefixFirst` for the new `/model`/`/mouse` shared "/mo" prefix