### PR TITLE
fix:Support provider extra_body

### DIFF
--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -443,6 +443,7 @@ func TestSaveProviderPreservesHiddenProviderFields(t *testing.T) {
 		Thinking:     "adaptive",
 		Effort:       "high",
 		VisionDetail: "low",
+		ExtraBody:    map[string]any{"enable_thinking": true},
 		NoProxy:      true,
 	}}
 	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
@@ -484,6 +485,9 @@ func TestSaveProviderPreservesHiddenProviderFields(t *testing.T) {
 	}
 	if got.VisionDetail != "low" {
 		t.Fatalf("vision_detail = %q, want low", got.VisionDetail)
+	}
+	if got.ExtraBody["enable_thinking"] != true {
+		t.Fatalf("extra_body = %+v, want enable_thinking=true", got.ExtraBody)
 	}
 	if !got.NoProxy {
 		t.Fatal("no_proxy = false, want preserved true")

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -117,6 +117,11 @@ complete chat request URL, set `chat_url`; Reasonix will use it directly and wil
 not append `/chat/completions`. If model discovery needs a separate address, set
 `models_url`.
 
+If a gateway requires vendor-specific top-level request body fields, set
+`extra_body`, for example `extra_body = { enable_thinking = true }`. These values
+are merged into the OpenAI-compatible chat JSON request body without allowing
+core fields such as `model`, `messages`, `tools`, or `stream` to be overridden.
+
 ## Global `.env`
 
 `<Reasonix home>/.env` is the single runtime source for provider API keys saved

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -226,6 +226,22 @@ model list manually.
 **Full URL** still uses the OpenAI-compatible chat request body. It does not
 switch the request schema to the OpenAI Responses API.
 
+Some OpenAI-compatible gateways require non-standard top-level request body
+fields. Add them with `extra_body` on the provider entry:
+
+```toml
+[[providers]]
+name        = "spark"
+kind        = "openai"
+base_url    = "https://maas-coding-api.cn-huabei-1.xf-yun.com/v2"
+models      = ["xopglm52"]
+api_key_env = "SPARK_API_KEY"
+extra_body  = { enable_thinking = true }
+```
+
+`extra_body` is merged into the chat JSON request body. Reasonix keeps core
+fields such as `model`, `messages`, `tools`, and `stream` under its own control.
+
 ## Keyboard shortcuts
 
 Shortcuts are documented by client because users usually look for the keys that

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1360,6 +1360,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"reasoning_protocol": config.ReasoningProtocolForEntry(e),
 			"chat_url":           e.ChatURL,
 			"headers":            e.Headers,
+			"extra_body":         e.ExtraBody,
 			"proxy_spec":         proxy,
 			"vision":             config.EffectiveVision(e),
 			"vision_detail":      e.VisionDetail,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -971,7 +971,8 @@ type ProviderEntry struct {
 	ModelsURL      string            `toml:"models_url"` // auto-fetch models from this URL on startup
 	Default        string            `toml:"default"`    // default model when Models is set (else Models[0])
 	APIKeyEnv      string            `toml:"api_key_env"`
-	Headers        map[string]string `toml:"headers"` // optional extra HTTP headers for OpenAI-compatible gateways; secrets should stay in api_key_env.
+	Headers        map[string]string `toml:"headers"`    // optional extra HTTP headers for OpenAI-compatible gateways; secrets should stay in api_key_env.
+	ExtraBody      map[string]any    `toml:"extra_body"` // optional extra top-level JSON request body fields for OpenAI-compatible gateways.
 	resolvedAPIKey string
 	resolvedSource CredentialSource
 	BalanceURL     string                       `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -294,6 +294,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			if len(p.Headers) > 0 {
 				fmt.Fprintf(&b, "headers     = %s   # extra static request headers; keep secrets in api_key_env\n", renderStringMap(p.Headers))
 			}
+			if len(p.ExtraBody) > 0 {
+				fmt.Fprintf(&b, "extra_body  = %s   # extra top-level JSON request body fields for compatible gateways\n", renderAnyMap(p.ExtraBody))
+			}
 			if p.BalanceURL != "" {
 				fmt.Fprintf(&b, "balance_url = %q   # optional; wallet-balance endpoint shown in the status bar\n", p.BalanceURL)
 			}
@@ -778,6 +781,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 			if len(p.Headers) > 0 {
 				fmt.Fprintf(&b, "headers     = %s\n", renderStringMap(p.Headers))
 			}
+			if len(p.ExtraBody) > 0 {
+				fmt.Fprintf(&b, "extra_body  = %s\n", renderAnyMap(p.ExtraBody))
+			}
 			if p.BalanceURL != "" {
 				fmt.Fprintf(&b, "balance_url = %q\n", p.BalanceURL)
 			}
@@ -1193,6 +1199,86 @@ func renderStringMap(m map[string]string) string {
 	}
 	b.WriteString(" }")
 	return b.String()
+}
+
+func renderAnyMap(m map[string]any) string {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		if _, ok := renderAnyValue(v); ok {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("{ ")
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		value, _ := renderAnyValue(m[k])
+		fmt.Fprintf(&b, "%s = %s", strconv.Quote(k), value)
+	}
+	b.WriteString(" }")
+	return b.String()
+}
+
+func renderAnyValue(v any) (string, bool) {
+	switch x := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		return strconv.Quote(x), true
+	case bool:
+		if x {
+			return "true", true
+		}
+		return "false", true
+	case int:
+		return strconv.Itoa(x), true
+	case int8:
+		return strconv.FormatInt(int64(x), 10), true
+	case int16:
+		return strconv.FormatInt(int64(x), 10), true
+	case int32:
+		return strconv.FormatInt(int64(x), 10), true
+	case int64:
+		return strconv.FormatInt(x, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(x), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(x), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(x), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10), true
+	case uint64:
+		return strconv.FormatUint(x, 10), true
+	case float32:
+		return formatFloat(float64(x)), true
+	case float64:
+		return formatFloat(x), true
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, item := range x {
+			part, ok := renderAnyValue(item)
+			if !ok {
+				return "", false
+			}
+			parts = append(parts, part)
+		}
+		return "[" + strings.Join(parts, ", ") + "]", true
+	case []string:
+		return renderStringArray(x), true
+	case map[string]any:
+		return renderAnyMap(x), true
+	case map[string]string:
+		return renderStringMap(x), true
+	default:
+		return "", false
+	}
 }
 
 func renderModelOverrides(m map[string]ProviderModelOverride) string {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -841,6 +841,13 @@ func TestRenderTOMLRoundTripsProviderHeadersAndModelOverrides(t *testing.T) {
 			"HTTP-Referer": "https://app.example",
 			"X-Title":      "Reasonix",
 		},
+		ExtraBody: map[string]any{
+			"enable_thinking": true,
+			"top_p":           0.8,
+			"metadata": map[string]any{
+				"mode": "fast",
+			},
+		},
 		ModelOverrides: map[string]ProviderModelOverride{
 			"deepseek-v4-flash": {
 				ReasoningProtocol: ReasoningProtocolDeepSeek,
@@ -854,6 +861,9 @@ func TestRenderTOMLRoundTripsProviderHeadersAndModelOverrides(t *testing.T) {
 	rendered := RenderTOML(orig)
 	if !strings.Contains(rendered, `headers     = { HTTP-Referer = "https://app.example", X-Title = "Reasonix" }`) {
 		t.Fatalf("rendered TOML missing headers:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `extra_body`) || !strings.Contains(rendered, `"enable_thinking" = true`) {
+		t.Fatalf("rendered TOML missing extra_body:\n%s", rendered)
 	}
 	if !strings.Contains(rendered, `model_overrides`) || !strings.Contains(rendered, `reasoning_protocol = "deepseek"`) {
 		t.Fatalf("rendered TOML missing model overrides:\n%s", rendered)
@@ -869,6 +879,13 @@ func TestRenderTOMLRoundTripsProviderHeadersAndModelOverrides(t *testing.T) {
 	}
 	if p.Headers["HTTP-Referer"] != "https://app.example" || p.Headers["X-Title"] != "Reasonix" {
 		t.Fatalf("headers after round trip = %+v", p.Headers)
+	}
+	if p.ExtraBody["enable_thinking"] != true || p.ExtraBody["top_p"] != 0.8 {
+		t.Fatalf("extra_body after round trip = %+v", p.ExtraBody)
+	}
+	metadata, ok := p.ExtraBody["metadata"].(map[string]any)
+	if !ok || metadata["mode"] != "fast" {
+		t.Fatalf("extra_body metadata after round trip = %+v", p.ExtraBody["metadata"])
 	}
 	ov := p.ModelOverrides["deepseek-v4-flash"]
 	if ov.ReasoningProtocol != ReasoningProtocolDeepSeek || !reflect.DeepEqual(ov.SupportedEfforts, []string{"high", "max"}) || ov.DefaultEffort != "high" || ov.Vision == nil || *ov.Vision {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -65,6 +65,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	chatURL, _ := cfg.Extra["chat_url"].(string)
 	chatURL = normalizeChatURL(cfg.BaseURL, chatURL)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
+	extraBody, _ := cfg.Extra["extra_body"].(map[string]any)
 	vision, _ := cfg.Extra["vision"].(bool)
 	visionDetail, _ := cfg.Extra["vision_detail"].(string)
 	visionDetail = strings.ToLower(strings.TrimSpace(visionDetail))
@@ -121,6 +122,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
 		chatURL:      chatURL,
 		headers:      cleanCustomHeaders(headers),
+		extraBody:    cleanExtraBody(extraBody),
 		model:        cfg.Model,
 		deepseek:     deepseek,
 		minimax:      minimax,
@@ -150,6 +152,7 @@ type client struct {
 	baseURL      string
 	chatURL      string
 	headers      map[string]string
+	extraBody    map[string]any
 	model        string
 	http         *http.Client
 	deepseek     bool
@@ -211,6 +214,33 @@ func cleanCustomHeaders(in map[string]string) map[string]string {
 func applyCustomHeaders(h http.Header, headers map[string]string) {
 	for name, value := range cleanCustomHeaders(headers) {
 		h.Set(name, value)
+	}
+}
+
+func cleanExtraBody(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for rawName, value := range in {
+		name := strings.TrimSpace(rawName)
+		if name == "" || reservedExtraBodyField(name) {
+			continue
+		}
+		out[name] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func reservedExtraBodyField(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "model", "messages", "tools", "stream", "stream_options", "temperature", "max_tokens", "reasoning_effort", "thinking":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -367,6 +397,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		Temperature:     req.Temperature,
 		MaxTokens:       req.MaxTokens,
 		ReasoningEffort: c.effort,
+		ExtraBody:       c.extraBody,
 	}
 	switch {
 	case c.deepseek:
@@ -619,6 +650,28 @@ type chatRequest struct {
 	MaxTokens       int            `json:"max_tokens,omitempty"`
 	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
 	Thinking        *thinkingMode  `json:"thinking,omitempty"`
+	ExtraBody       map[string]any `json:"-"`
+}
+
+func (r chatRequest) MarshalJSON() ([]byte, error) {
+	type wire chatRequest
+	baseReq := wire(r)
+	baseReq.ExtraBody = nil
+	raw, err := json.Marshal(baseReq)
+	if err != nil {
+		return nil, err
+	}
+	if len(r.ExtraBody) == 0 {
+		return raw, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, err
+	}
+	for key, value := range cleanExtraBody(r.ExtraBody) {
+		body[key] = value
+	}
+	return json.Marshal(body)
 }
 
 type thinkingMode struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -225,6 +225,64 @@ func TestStreamSendsCustomHeaders(t *testing.T) {
 	}
 }
 
+func TestStreamSendsExtraBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if req["enable_thinking"] != true {
+			http.Error(w, "extra enable_thinking missing", http.StatusBadRequest)
+			return
+		}
+		if got, ok := req["top_p"].(float64); !ok || got != 0.7 {
+			http.Error(w, "extra top_p missing", http.StatusBadRequest)
+			return
+		}
+		if req["model"] != "model-a" || req["stream"] != true {
+			http.Error(w, "reserved fields were overwritten", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{
+		Name:    "custom",
+		BaseURL: srv.URL,
+		Model:   "model-a",
+		APIKey:  "real-key",
+		Extra: map[string]any{"extra_body": map[string]any{
+			"enable_thinking": true,
+			"top_p":           0.7,
+			"model":           "wrong",
+			"stream":          false,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+}
+
 // TestBuildRequestAlwaysSerializesContent guards the DeepSeek 400 regression:
 // DeepSeek rejects a message missing the `content` field, so every message must
 // serialize one. A pure tool_calls assistant turn carries null (OpenAI-spec,


### PR DESCRIPTION
﻿## Summary

- Add `extra_body` to `[[providers]]` so OpenAI-compatible gateways can receive vendor-specific top-level JSON request body fields.
- Merge `extra_body` into chat completion requests while keeping Reasonix-owned protocol fields such as `model`, `messages`, `tools`, and `stream` protected.
- Preserve `extra_body` through config rendering and desktop provider saves, and document the config shape.

Fixes #5804

## Validation

- `go test ./internal/provider/openai ./internal/config ./internal/boot`
- `cd desktop && go test . -run TestSaveProviderPreservesHiddenProviderFields`
- `git diff --check`

Note: `cd desktop && go test .` still has unrelated environment/platform failures in hooks trust and skill-root tests on this Windows workspace; the targeted desktop provider-save regression passes.
