### PR TITLE
fix(acp): omit persistent permission option

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -251,8 +251,6 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 				allow = true
 			case OptAllowAlways:
 				allow, session = true, true
-			case OptAllowPersistent:
-				allow, session, persist = true, true, true
 			}
 		}
 	}
@@ -331,18 +329,16 @@ func (s *updateSink) requestAskQuestion(ctx context.Context, askID string, q eve
 	return label, ok
 }
 
-func approvalOptionNames(tool, subject string) (session, persistent string) {
+func approvalSessionOptionName(tool, subject string) string {
 	sessionRule := permission.SessionGrantRuleForScope(tool, subject)
-	persistentRule := permission.RememberRuleForScope(tool, subject)
-	return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
+	return "Allow " + sessionRule + " for this session"
 }
 
 func approvalOptions(tool, subject string) []PermissionOption {
-	allowSessionName, allowPersistentName := approvalOptionNames(tool, subject)
+	allowSessionName := approvalSessionOptionName(tool, subject)
 	options := []PermissionOption{
 		{OptionID: string(OptAllowOnce), Name: "Allow", Kind: OptAllowOnce},
 		{OptionID: string(OptAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
-		{OptionID: string(OptAllowPersistent), Name: allowPersistentName, Kind: OptAllowPersistent},
 		{OptionID: string(OptRejectOnce), Name: "Reject", Kind: OptRejectOnce},
 	}
 	return options

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -236,22 +236,28 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 		if err := json.Unmarshal(raw, &p); err != nil {
 			t.Fatalf("permission params: %v", err)
 		}
-		// Bash with a safe prefix now uses the same standard options as any
-		// other tool (allow_always / allow_persistent); the old prefix-specific
-		// OptAllowPrefix/OptPersistPrefix are gone.
-		var hasSession, hasPersistent bool
+		// ACP permission options must stay within the official spec kinds.
+		var hasOnce, hasSession, hasReject bool
 		for _, opt := range p.Options {
-			hasSession = hasSession || opt.OptionID == string(OptAllowAlways)
-			hasPersistent = hasPersistent || opt.OptionID == string(OptAllowPersistent)
+			switch opt.Kind {
+			case OptAllowOnce:
+				hasOnce = true
+			case OptAllowAlways:
+				hasSession = true
+			case OptRejectOnce:
+				hasReject = true
+			default:
+				t.Fatalf("unexpected ACP permission option kind %q in %+v", opt.Kind, p.Options)
+			}
 		}
-		if !hasSession || !hasPersistent {
-			t.Fatalf("options = %+v, want standard session and persistent choices", p.Options)
+		if !hasOnce || !hasSession || !hasReject {
+			t.Fatalf("options = %+v, want allow once, session, reject", p.Options)
 		}
-		if len(p.Options) != 4 {
-			t.Fatalf("options = %+v, want allow once, session, persistent, reject", p.Options)
+		if len(p.Options) != 3 {
+			t.Fatalf("options = %+v, want allow once, session, reject", p.Options)
 		}
 		res, _ := json.Marshal(PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowPersistent)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowAlways)},
 		})
 		return res, nil
 	}}
@@ -263,7 +269,7 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 
 	select {
 	case c := <-got:
-		want := approveCall{id: "10", allow: true, session: true, persist: true}
+		want := approveCall{id: "10", allow: true, session: true, persist: false}
 		if c != want {
 			t.Errorf("approve = %+v, want %+v", c, want)
 		}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -490,15 +490,15 @@ type SessionCancelParams struct {
 
 // --- session/request_permission (agent → client request) ---
 
-// PermissionOptionKind classifies an option for host UI styling. Matches main.
+// PermissionOptionKind classifies an option for host UI styling. Keep this to
+// the official ACP kinds so strict clients can validate request params.
 type PermissionOptionKind string
 
 const (
-	OptAllowOnce       PermissionOptionKind = "allow_once"
-	OptAllowAlways     PermissionOptionKind = "allow_always"
-	OptAllowPersistent PermissionOptionKind = "allow_persistent"
-	OptRejectOnce      PermissionOptionKind = "reject_once"
-	OptRejectAlways    PermissionOptionKind = "reject_always"
+	OptAllowOnce    PermissionOptionKind = "allow_once"
+	OptAllowAlways  PermissionOptionKind = "allow_always"
+	OptRejectOnce   PermissionOptionKind = "reject_once"
+	OptRejectAlways PermissionOptionKind = "reject_always"
 )
 
 // PermissionOption is one choice offered to the user for a permission request.


### PR DESCRIPTION
Fixes #5775.

## Problem
ACP `session/request_permission` options currently include `allow_persistent`, which is not part of the official ACP option kind set. Selecting it also lets an ACP host request a persistent Reasonix config write, which crosses the host/library boundary for this mode.

## Change
- Offer only `allow_once`, `allow_always`, and `reject_once` for ACP approval requests.
- Keep `allow_always` as a session-scoped approval instead of a persistent config write.
- Update the ACP dispatch regression test to reject non-spec option kinds and assert `persist=false`.

## Verification
- `go test ./internal/acp ./internal/permission -count=1`
- `git diff --check origin/main-v2...HEAD`
- Diff-only secret keyword scan