### PR TITLE
refactor(i18n): extract DeepSeek provider description to i18n messages

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1325,7 +1325,7 @@ type providerFamily struct {
 func familyOf(name string) providerFamily {
 	switch {
 	case strings.HasPrefix(name, "deepseek"):
-		return providerFamily{key: "deepseek", name: "DeepSeek", desc: "fast & cheap, plus a stronger Pro SKU"}
+		return providerFamily{key: "deepseek", name: "DeepSeek", desc: i18n.M.DeepSeekProviderDesc}
 	default:
 		return providerFamily{key: name, name: name}
 	}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -342,6 +342,9 @@ type Messages struct {
 	APIKeyAlreadySetFmt        string // "reusing existing value for %s"
 	APIKeyResetPromptFmt       string // "Re-enter %s?"
 
+	// DeepSeek provider
+	DeepSeekProviderDesc string // "fast & cheap, plus a stronger Pro SKU"
+
 	// custom provider
 	CustomProviderLabel  string // "Custom Model"
 	CustomProviderDesc   string // "Add third-party OpenAI compatible model"

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -304,6 +304,9 @@ var English = Messages{
 	APIKeyAlreadySetFmt:        "reusing existing value for %s",
 	APIKeyResetPromptFmt:       "Re-enter %s?",
 
+	// DeepSeek provider
+	DeepSeekProviderDesc: "fast & cheap, plus a stronger Pro SKU",
+
 	// custom provider
 	CustomProviderLabel:  "Custom Model",
 	CustomProviderDesc:   "Add third-party OpenAI compatible model",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -305,6 +305,9 @@ var Chinese = Messages{
 	APIKeyAlreadySetFmt:        "复用已设置的 %s",
 	APIKeyResetPromptFmt:       "重新输入 %s？",
 
+	// DeepSeek provider
+	DeepSeekProviderDesc: "快速且便宜，另有更强的 Pro 型号",
+
 	// custom provider
 	CustomProviderLabel:  "自定义模型",
 	CustomProviderDesc:   "添加第三方 OpenAI 兼容模型",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -285,6 +285,9 @@ var ChineseTraditional = Messages{
 	APIKeyAlreadySetFmt:        "復用已設定的 %s",
 	APIKeyResetPromptFmt:       "重新輸入 %s？",
 
+	// DeepSeek provider
+	DeepSeekProviderDesc: "快速且便宜，另有更強的 Pro 型號",
+
 	// custom provider
 	CustomProviderLabel:  "自訂模型",
 	CustomProviderDesc:   "新增第三方 OpenAI 相容模型",


### PR DESCRIPTION
## Summary

The `familyOf` function in `internal/cli/cli.go` had a hardcoded English description `"fast & cheap, plus a stronger Pro SKU"` for the DeepSeek provider family in the setup wizard, while every other provider description (`CustomProviderDesc`, `AnthropicProviderDesc`) already used `i18n.M`. This PR moves it into the Messages catalog so it localizes with the rest of the wizard UI.

## Verification

- [x] `go vet ./...` passes
- [x] `gofmt -l .` shows no changes
