### PR TITLE
 fix(serve): deduplicate tool card on partial dispatch + align card width

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -825,7 +825,9 @@ function finalizeMsg() { if(currentMsg){const c=currentMsg.querySelector('.curso
 
 // ── tool cards (v1 pattern) ──
 function renderToolDispatch(tool) {
-  hideWelcome(); const card=el('div','card'); card.id='tool-'+tool.id; card.dataset.open='false'; card.dataset.tone='accent';
+  hideWelcome(); let card=toolCards[tool.id];
+  if(!card){card=el('div','card');card.id='tool-'+tool.id;}else{card.innerHTML='';}
+  card.dataset.open='false'; card.dataset.tone='accent';
   const head=el('div','card-head');
   head.innerHTML='<span class="ico spin"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10" stroke-dasharray="60" stroke-dashoffset="20"/></svg></span><span class="name">'+escHtml(tool.name)+'</span>'+(tool.args?'<span class="subject">'+escHtml(tool.args.slice(0,80))+'</span>':'')+'<span class="grow"></span><span class="chev"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></span>';
   const body=el('div','card-body'); body.style.display='none';

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -89,7 +89,7 @@ input,textarea{font:inherit;color:inherit}
 @keyframes blink{to{visibility:hidden}}
 
 /* card (v1 pattern) */
-.card{background:var(--card);border-radius:var(--radius-lg);overflow:hidden;font-size:14px;box-shadow:var(--shadow-sm);margin:8px auto;transition:border-color .18s ease}
+.card{background:var(--card);border-radius:var(--radius-lg);overflow:hidden;font-size:14px;box-shadow:var(--shadow-sm);margin:8px auto;max-width:760px;transition:border-color .18s ease}
 .card-head{display:flex;align-items:center;gap:8px;padding:7px 12px;font-size:13px;color:var(--fg-2);cursor:pointer;user-select:none;background:var(--card);transition:background .18s ease}
 .card-head:hover{background:var(--card-hover)}
 .card-head .ico{width:18px;height:18px;border-radius:5px;display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--fg-2);flex-shrink:0;font-size:10px}


### PR DESCRIPTION
## Summary

Two fixes in `internal/serve/index.html`:

1. **Tool card width alignment** — Added `max-width: 760px` to `.card` so tool cards match `.msg` width instead of stretching full container width.

2. **Duplicate tool card on partial→full dispatch** — The backend emits `tool_dispatch` twice for the same tool call: first with `{partial: true}` (name only, no args), then with full args. The original code created a new card each time and overwrote `toolCards[tool.id]`, leaving the first card stuck in loading state forever. Now `renderToolDispatch` reuses the existing card element (clears `innerHTML` and repopulates) when a dispatch for the same `tool.id` arrives, preventing duplicates.

## Verification
| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/58bc8a4d-0a61-4912-b265-f44461bba34d) | ![](https://github.com/user-attachments/assets/0397dfbf-8f67-4801-bd97-18d6a6c9a366) |
- Manually tested: running `ls` or `read_file` produces exactly one card per tool call, no leftover spinning card
- Card width now matches chat message width
