### PR TITLE
fix: fail safe when bash sandbox is unavailable

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -149,7 +149,10 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	}
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
-	argv, _ := sandbox.Command(b.sb, sh, p.Command)
+	argv, wrapped := sandbox.Command(b.sb, sh, p.Command)
+	if b.sb.Mode == "enforce" && !wrapped {
+		return "", fmt.Errorf("bash sandbox requested but unavailable on this platform; refusing to run unconfined")
+	}
 	cmdEnv := bashCommandEnv(ctx)
 
 	if p.RunInBackground {

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"reasonix/internal/config"
@@ -163,6 +164,34 @@ func TestBashSandboxConfinement(t *testing.T) {
 	}
 	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
 		t.Error("escaping write must not create the file")
+	}
+}
+
+func TestBashEnforceRejectsWhenSandboxUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bash{
+		sb: sandbox.Spec{
+			Mode:       "enforce",
+			WriteRoots: []string{t.TempDir()},
+		},
+		shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: exe},
+	}
+
+	args, _ := json.Marshal(map[string]string{"command": "ignored"})
+	out, err := b.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("bash should reject enforce mode when the OS sandbox is unavailable")
+	}
+	if !strings.Contains(err.Error(), "bash sandbox requested but unavailable") {
+		t.Fatalf("error = %q, want sandbox unavailable", err)
+	}
+	if out != "" {
+		t.Fatalf("output = %q, want no command execution", out)
 	}
 }
 


### PR DESCRIPTION
Fixes #5793.

## Summary
- refuse to execute bash when sandbox mode is enforce but the OS sandbox wrapper is unavailable
- add a regression test for the unavailable-sandbox path so commands are not run unconfined

Cache-impact: low - bash tool execution now fails closed when enforce mode cannot obtain an OS sandbox wrapper; no prompt or cache schema changes.
Cache-guard: go test ./internal/tool/builtin -run TestBashEnforceRejectsWhenSandboxUnavailable -count=1

## Verification
- go test ./internal/tool/builtin -run TestBashEnforceRejectsWhenSandboxUnavailable -count=1
- go test ./internal/tool/builtin ./internal/sandbox
- go test ./internal/...