### PR TITLE
Point skills page at the live registry API (crash worker)

### DIFF
--- a/site/src/pages/skills.astro
+++ b/site/src/pages/skills.astro
@@ -309,7 +309,7 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
 
   <script>
     import { currentAccount, accountLogout } from '../scripts/auth.js';
-    const REGISTRY = import.meta.env.PUBLIC_REGISTRY_ORIGIN || 'https://registry.reasonix.io';
+    const REGISTRY = import.meta.env.PUBLIC_REGISTRY_ORIGIN || 'https://crash.reasonix.io';
     const state = { kind: 'all', sort: 'new', q: '' };
     let currentUser = null;
 


### PR DESCRIPTION
Points the public skills/MCP discovery page at the live registry API.

`registry.reasonix.io` was never provisioned. After #5834 folded the registry into the crash worker, the API serves from `crash.reasonix.io`. This changes the `skills.astro` default so browse/search/publish light up on next site deploy. `PUBLIC_REGISTRY_ORIGIN` still overrides, so pointing a dedicated `registry.reasonix.io` custom domain at the worker later is a one-env-var switch.

CORS already allows `reasonix.io` (the worker's `ALLOWED_ORIGINS`), so the cross-origin fetch + credentialed admin calls work. Verified with a local `astro build` (14 pages, skills bundle now targets `crash.reasonix.io/v1/packages`).
