### PR TITLE
fix: prevent bash sandbox bypass on platforms without OS sandboxing (…

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -36,5 +36,5 @@ type Spec struct {
 	Shell Shell
 }
 
-// enforce reports whether the spec asks for confinement.
-func (s Spec) enforce() bool { return s.Mode == "enforce" }
+// Enforce reports whether the spec asks for confinement.
+func (s Spec) Enforce() bool { return s.Mode == "enforce" }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// --- Spec.enforce ---
+// --- Spec.Enforce ---
 
 func TestEnforce(t *testing.T) {
 	cases := []struct {
@@ -22,8 +22,8 @@ func TestEnforce(t *testing.T) {
 	}
 	for _, c := range cases {
 		s := Spec{Mode: c.mode}
-		if got := s.enforce(); got != c.want {
-			t.Errorf("Spec{%q}.enforce() = %v, want %v", c.mode, got, c.want)
+		if got := s.Enforce(); got != c.want {
+			t.Errorf("Spec{%q}.Enforce() = %v, want %v", c.mode, got, c.want)
 		}
 	}
 }
@@ -32,7 +32,7 @@ func TestEnforce(t *testing.T) {
 
 func TestSpecZeroValue(t *testing.T) {
 	var s Spec
-	if s.enforce() {
+	if s.Enforce() {
 		t.Error("zero-value Spec should not enforce")
 	}
 	if s.Network {

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -14,7 +14,7 @@ import (
 // sandbox-exec missing — a graceful fallback rather than a hard failure, since
 // the permission layer still gates the call).
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
-	if !spec.enforce() || !Available() {
+	if !spec.Enforce() || !Available() {
 		return sh.argv(command), false
 	}
 	return append([]string{"sandbox-exec", "-p", seatbeltProfile(spec)}, sh.argv(command)...), true
@@ -25,7 +25,7 @@ func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 // without shell interpretation — suitable for direct binary invocations like
 // ripgrep that don't need a shell wrapper.
 func CommandArgs(spec Spec, args []string) ([]string, bool) {
-	if !spec.enforce() || !Available() {
+	if !spec.Enforce() || !Available() {
 		return args, false
 	}
 	return append([]string{"sandbox-exec", "-p", seatbeltProfile(spec)}, args...), true

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -14,7 +14,7 @@ import (
 // spec.Network is true. When bwrap is unavailable the command runs unconfined
 // (boot and acp warn about this once at startup).
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
-	if !spec.enforce() {
+	if !spec.Enforce() {
 		return sh.argv(command), false
 	}
 	if bwrap, err := exec.LookPath("bwrap"); err == nil {
@@ -31,7 +31,7 @@ func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 // prefix without shell interpretation — suitable for direct binary invocations
 // like ripgrep that don't need a shell wrapper.
 func CommandArgs(spec Spec, args []string) ([]string, bool) {
-	if !spec.enforce() {
+	if !spec.Enforce() {
 		return args, false
 	}
 	if bwrap, err := exec.LookPath("bwrap"); err == nil {

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -142,7 +142,15 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	}
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
-	argv, _ := sandbox.Command(b.sb, sh, p.Command)
+	argv, sandboxed := sandbox.Command(b.sb, sh, p.Command)
+
+	// When OS sandbox is unavailable but enforce is requested, apply in-process
+	// write-path validation so bash cannot bypass the file-tool sandbox (#5793).
+	if !sandboxed && b.sb.Enforce() {
+		if err := checkBashWriteTargets(p.Command, sh, b.sb.WriteRoots); err != nil {
+			return "", err
+		}
+	}
 	cmdEnv := bashCommandEnv(ctx)
 
 	if p.RunInBackground {
@@ -530,6 +538,357 @@ func shellWordBase(word string) string {
 		return word[i+1:]
 	}
 	return word
+}
+
+// checkBashWriteTargets scans command for file-write patterns (redirects,
+// PowerShell cmdlets, tee, dd) and validates every detected output path against
+// writeRoots. When OS sandbox is unavailable, this in-process check prevents the
+// model from using bash to bypass the file-tool sandbox (#5793).
+//
+// It is a best-effort defence: it catches the common patterns the model learns
+// (Set-Content, Out-File, >/>> redirects) but cannot intercept writes made by a
+// sub-program the shell invokes (python -c "open(...)"). The permission layer
+// already gates the bash call itself; this guard closes the "approve once,
+// write anywhere" gap on platforms without OS sandboxing.
+func checkBashWriteTargets(command string, sh sandbox.Shell, writeRoots []string) error {
+	if len(writeRoots) == 0 {
+		return nil
+	}
+	roots := realRoots(writeRoots)
+	for _, target := range extractWriteTargets(command, sh) {
+		if err := confine(roots, target); err != nil {
+			return fmt.Errorf("bash sandbox: %w. "+
+				"Use the dedicated write tools (write_file, edit_file) to modify files — "+
+				"they respect the sandbox. To bypass, set [sandbox] bash = \"off\" in reasonix.toml.",
+				err)
+		}
+	}
+	return nil
+}
+
+// extractWriteTargets returns file paths that the command appears to write to.
+// It handles common patterns the model uses to bypass the file-tool sandbox:
+// PowerShell Set-Content/Out-File/Add-Content -Path, shell >/>> redirects,
+// tee, and dd of=. It does not parse arbitrary subcommands.
+func extractWriteTargets(command string, sh sandbox.Shell) []string {
+	var targets []string
+
+	if sh.Kind == sandbox.ShellPowerShell {
+		targets = append(targets, extractPSWriteTargets(command)...)
+	}
+
+	// Shell redirect targets: >file, >>file, 2>file, &>file, 1>file
+	targets = append(targets, extractRedirectTargets(command)...)
+
+	// tee file1 file2 ...
+	targets = append(targets, extractTeeTargets(command)...)
+
+	// dd of=file
+	targets = append(targets, extractDdTargets(command)...)
+
+	return targets
+}
+
+// extractPSWriteTargets extracts -Path and -FilePath arguments from PowerShell
+// write cmdlets (Set-Content, Out-File, Add-Content, New-Item,
+// Export-Csv, Export-Clixml).
+func extractPSWriteTargets(command string) []string {
+	writeCmdlets := []string{
+		"Set-Content", "Out-File", "Add-Content", "New-Item",
+		"Export-Csv", "Export-Clixml",
+	}
+
+	var targets []string
+	// Scan for each write cmdlet and its -Path / -FilePath argument.
+	for _, c := range writeCmdlets {
+		rest := command
+		for {
+			idx := findCmdlet(rest, c)
+			if idx < 0 {
+				break
+			}
+			// Search for -Path or -FilePath after the cmdlet name.
+			tail := rest[idx+len(c):]
+			path := extractPSPathArg(tail)
+			if path != "" {
+				targets = append(targets, path)
+			}
+			rest = rest[idx+len(c):]
+		}
+	}
+	return targets
+}
+
+// findCmdlet finds the next occurrence of cmdlet in command, returning the
+// start index or -1. It matches only when cmdlet appears as a whole word
+// (preceded by start-of-string, whitespace, or a pipe/command separator).
+func findCmdlet(command, cmdlet string) int {
+	for i := 0; i <= len(command)-len(cmdlet); i++ {
+		sub := command[i : i+len(cmdlet)]
+		if !strings.EqualFold(sub, cmdlet) {
+			continue
+		}
+		// Check that it's a whole word.
+		if i > 0 {
+			prev := command[i-1]
+			if prev != ' ' && prev != '\t' && prev != '|' && prev != ';' && prev != '\n' && prev != '&' {
+				continue
+			}
+		}
+		end := i + len(cmdlet)
+		if end < len(command) {
+			next := command[end]
+			if next != ' ' && next != '\t' && next != '\n' && next != '\r' {
+				continue
+			}
+		}
+		return i
+	}
+	return -1
+}
+
+// extractPSPathArg extracts the value of -Path or -FilePath from a PowerShell
+// cmdlet argument tail (the part of the command after the cmdlet name).
+func extractPSPathArg(tail string) string {
+	for _, flag := range []string{"-FilePath", "-Path"} {
+		if path := extractFlagValue(tail, flag); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+// extractFlagValue extracts a flag's value from a command tail. Handles
+// quoted and unquoted values, and -Flag=value / -Flag:value syntax.
+func extractFlagValue(tail, flag string) string {
+	rest := tail
+	for {
+		idx := findFlag(rest, flag)
+		if idx < 0 {
+			return ""
+		}
+		after := rest[idx+len(flag):]
+		// Handle -Flag=value or -Flag:value syntax.
+		if len(after) > 0 && (after[0] == '=' || after[0] == ':') {
+			after = after[1:]
+		}
+		after = strings.TrimLeftFunc(after, func(r rune) bool {
+			return r == ' ' || r == '\t'
+		})
+		if after == "" {
+			rest = rest[idx+len(flag):]
+			continue
+		}
+		// Quoted value.
+		if after[0] == '"' || after[0] == '\'' {
+			q := after[0]
+			end := strings.IndexByte(after[1:], q)
+			if end >= 0 {
+				return after[1 : 1+end]
+			}
+			return ""
+		}
+		// Unquoted value: take until whitespace or end.
+		end := strings.IndexFunc(after, func(r rune) bool {
+			return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == ';' || r == '|' || r == '&'
+		})
+		if end < 0 {
+			return after
+		}
+		return after[:end]
+	}
+}
+
+// findFlag finds a flag in a command string, matching only when it appears as a
+// whole flag (preceded by whitespace, semicolon, pipe, or start-of-string).
+func findFlag(s, flag string) int {
+	lower := strings.ToLower(s)
+	flagLower := strings.ToLower(flag)
+	for i := 0; i <= len(lower)-len(flagLower); i++ {
+		sub := lower[i : i+len(flagLower)]
+		if sub != flagLower {
+			continue
+		}
+		if i > 0 {
+			prev := s[i-1]
+			if prev != ' ' && prev != '\t' && prev != ';' && prev != '|' && prev != '\n' {
+				continue
+			}
+		}
+		return i
+	}
+	return -1
+}
+
+// extractRedirectTargets extracts file paths from shell redirect operators
+// (> file, >> file, 2> file, 1> file, &> file, 2>> file, etc.).
+func extractRedirectTargets(command string) []string {
+	var targets []string
+	// Scan for > (redirect) outside quoted spans.
+	var quote byte
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		if c != '>' {
+			continue
+		}
+		// Skip >> (append) — treat it the same as >.
+		if i+1 < len(command) && command[i+1] == '>' {
+			i++ // skip second >
+		}
+		// Extract the target path after >.
+		after := strings.TrimLeftFunc(command[i+1:], func(r rune) bool {
+			return r == ' ' || r == '\t'
+		})
+		if after == "" {
+			continue
+		}
+		// Skip fd passthrough (e.g., 2>&1, &>1, 1>&2) but NOT >&file which
+		// redirects both stdout+stderr to a file.
+		if after[0] == '&' {
+			if len(after) > 1 && (after[1] >= '0' && after[1] <= '9') {
+				continue // fd passthrough: >&1, >&2
+			}
+			// ">& file" or ">>& file" — consume the &, extract the path.
+			afterPath := strings.TrimLeftFunc(after[1:], func(r rune) bool {
+				return r == ' ' || r == '\t'
+			})
+			path := extractShellWord(afterPath)
+			if path != "" && !strings.HasPrefix(path, "/dev/") {
+				targets = append(targets, path)
+			}
+			continue
+		}
+		// Extract the path.
+		path := extractShellWord(after)
+		if path != "" && !strings.HasPrefix(path, "/dev/") {
+			targets = append(targets, path)
+		}
+	}
+	return targets
+}
+
+// extractShellWord returns the first shell word from s (handles quoting).
+func extractShellWord(s string) string {
+	if s == "" {
+		return ""
+	}
+	if s[0] == '"' || s[0] == '\'' {
+		q := s[0]
+		end := strings.IndexByte(s[1:], q)
+		if end >= 0 {
+			return s[1 : 1+end]
+		}
+		return s[1:] // unterminated quote — take rest
+	}
+	end := strings.IndexFunc(s, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == ';' || r == '|' || r == '&' || r == '<' || r == '>'
+	})
+	if end < 0 {
+		return s
+	}
+	return s[:end]
+}
+
+// extractTeeTargets extracts file paths from tee [file1 file2 ...].
+func extractTeeTargets(command string) []string {
+	var targets []string
+	rest := command
+	for {
+		idx := findCmdlet(rest, "tee")
+		if idx < 0 {
+			break
+		}
+		tail := rest[idx+3:] // skip "tee"
+		tail = strings.TrimLeftFunc(tail, func(r rune) bool {
+			return r == ' ' || r == '\t'
+		})
+
+		// tee accepts -a/--append flags anywhere; skip them.
+		for {
+			if strings.HasPrefix(tail, "-a ") || strings.HasPrefix(tail, "--append ") {
+				tail = tail[strings.IndexByte(tail, ' ')+1:]
+				tail = strings.TrimLeftFunc(tail, func(r rune) bool {
+					return r == ' ' || r == '\t'
+				})
+				continue
+			}
+			if tail == "-a" || tail == "--append" {
+				break // flag at end, no files follow
+			}
+			break
+		}
+
+		// Extract all file arguments (tee can write to multiple files).
+		for {
+			tail = strings.TrimSpace(tail)
+			if tail == "" {
+				break
+			}
+			word := extractShellWord(tail)
+			if word == "" {
+				break
+			}
+			if strings.HasPrefix(word, "-") {
+				// Next flag — could be -a/--append, skip and continue.
+				if word == "-a" || word == "--append" {
+					tail = tail[len(word):]
+					tail = strings.TrimSpace(tail)
+					continue
+				}
+				break // other flags end the file list
+			}
+			targets = append(targets, word)
+			tail = tail[len(word):]
+		}
+		rest = rest[idx+3:]
+	}
+	return targets
+}
+
+// extractDdTargets extracts file paths from dd of=file.
+func extractDdTargets(command string) []string {
+	var targets []string
+	rest := command
+	for {
+		idx := findCmdlet(rest, "dd")
+		if idx < 0 {
+			break
+		}
+		tail := rest[idx+2:] // skip "dd"
+		// Find of= in the arguments.
+		for {
+			eqIdx := strings.Index(strings.ToLower(tail), "of=")
+			if eqIdx < 0 {
+				break
+			}
+			valStart := eqIdx + 3
+			end := strings.IndexFunc(tail[valStart:], func(r rune) bool {
+				return r == ' ' || r == '\t' || r == '\n'
+			})
+			var val string
+			if end < 0 {
+				val = tail[valStart:]
+			} else {
+				val = tail[valStart : valStart+end]
+			}
+			if val != "" {
+				targets = append(targets, val)
+			}
+			tail = tail[valStart:]
+		}
+		rest = rest[idx+2:]
+	}
+	return targets
 }
 
 // commandPreview is a short single-line label for a background bash job, surfaced

--- a/internal/tool/builtin/bash_sandbox_test.go
+++ b/internal/tool/builtin/bash_sandbox_test.go
@@ -1,0 +1,351 @@
+package builtin
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+)
+
+func TestExtractWriteTargets_PS_SetContent(t *testing.T) {
+	targets := extractWriteTargets(
+		`Set-Content -Path "/outside/file.md" -Value $content`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/outside/file.md` {
+		t.Fatalf("got %v, want [/outside/file.md]", targets)
+	}
+}
+
+func TestExtractWriteTargets_PS_OutFile(t *testing.T) {
+	targets := extractWriteTargets(
+		`Out-File -FilePath /foo/bar.txt -InputObject $x`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/foo/bar.txt` {
+		t.Fatalf("got %v, want [/foo/bar.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_PS_AddContent(t *testing.T) {
+	targets := extractWriteTargets(
+		`Add-Content -Path "/outside/file.log" -Value "log line"`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/outside/file.log` {
+		t.Fatalf("got %v, want [/outside/file.log]", targets)
+	}
+}
+
+func TestExtractWriteTargets_PS_CaseInsensitive(t *testing.T) {
+	targets := extractWriteTargets(
+		`set-content -path "/mixed/CASE.md" -Value x`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/mixed/CASE.md` {
+		t.Fatalf("got %v, want [/mixed/CASE.md]", targets)
+	}
+}
+
+func TestExtractWriteTargets_PS_FlagEquals(t *testing.T) {
+	targets := extractWriteTargets(
+		`Set-Content -Path=/path/to/file.txt -Value x`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/path/to/file.txt` {
+		t.Fatalf("got %v, want [/path/to/file.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_ShellRedirect(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hello > /tmp/out.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/out.txt` {
+		t.Fatalf("got %v, want [/tmp/out.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_ShellAppendRedirect(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hello >> /var/log/app.log`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/var/log/app.log` {
+		t.Fatalf("got %v, want [/var/log/app.log]", targets)
+	}
+}
+
+func TestExtractWriteTargets_ShellStderrRedirect(t *testing.T) {
+	targets := extractWriteTargets(
+		`cmd 2> /tmp/err.log`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/err.log` {
+		t.Fatalf("got %v, want [/tmp/err.log]", targets)
+	}
+}
+
+func TestExtractWriteTargets_ShellRedirectFdPassthrough(t *testing.T) {
+	// 2>&1 should NOT be treated as a write target — it's fd passthrough.
+	targets := extractWriteTargets(
+		`cmd 2>&1`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 0 {
+		t.Fatalf("got %v, want [] (2>&1 is fd passthrough, not a file write)", targets)
+	}
+}
+
+func TestExtractWriteTargets_ShellDevNullIgnored(t *testing.T) {
+	targets := extractWriteTargets(
+		`cmd 2>/dev/null`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 0 {
+		t.Fatalf("got %v, want [] (/dev/null writes should be ignored)", targets)
+	}
+}
+
+func TestExtractWriteTargets_Tee(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hello | tee /tmp/tee_out.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/tee_out.txt` {
+		t.Fatalf("got %v, want [/tmp/tee_out.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_Dd(t *testing.T) {
+	targets := extractWriteTargets(
+		`dd if=/dev/zero of=/tmp/dd_out.bin bs=1024 count=1`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/dd_out.bin` {
+		t.Fatalf("got %v, want [/tmp/dd_out.bin]", targets)
+	}
+}
+
+func TestExtractWriteTargets_BashOnlyNoPS(t *testing.T) {
+	// Set-Content in a bash context (no PowerShell) — bash won't recognize it as a cmdlet.
+	targets := extractWriteTargets(
+		`Set-Content -Path /tmp/x.txt -Value hi`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	// Bash doesn't have Set-Content, but PowerShell patterns are only extracted when sh.Kind == PowerShell.
+	// However, the command might still match redirect patterns — verify none here.
+	found := false
+	for _, tgt := range targets {
+		if strings.Contains(tgt, "x.txt") {
+			found = true
+		}
+	}
+	if found {
+		t.Fatalf("should not extract PS paths in bash context, got %v", targets)
+	}
+}
+
+func TestExtractWriteTargets_Empty(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo "hello world"`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 0 {
+		t.Fatalf("got %v, want []", targets)
+	}
+}
+
+func TestExtractWriteTargets_MultipleRedirects(t *testing.T) {
+	targets := extractWriteTargets(
+		`cmd > /tmp/a.txt 2> /tmp/b.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets %v, want 2", len(targets), targets)
+	}
+}
+
+func TestCheckBashWriteTargets_PassesInRoot(t *testing.T) {
+	root := t.TempDir()
+	err := checkBashWriteTargets(
+		`echo hello > `+root+`/file.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+		[]string{root},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckBashWriteTargets_BlocksOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	err := checkBashWriteTargets(
+		`echo hello > /outside/file.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+		[]string{root},
+	)
+	if err == nil {
+		t.Fatal("expected error for path outside write roots, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside the writable roots") {
+		t.Errorf("error should mention writable roots, got: %v", err)
+	}
+}
+
+func TestCheckBashWriteTargets_BlocksRedirectOutsideRoot(t *testing.T) {
+	err := checkBashWriteTargets(
+		`echo hello > /etc/passwd`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+		[]string{`/workspace`},
+	)
+	if err == nil {
+		t.Fatal("expected error for redirect outside write roots, got nil")
+	}
+}
+
+func TestCheckBashWriteTargets_EmptyRootsAllowed(t *testing.T) {
+	err := checkBashWriteTargets(
+		`echo hello > /anywhere/file.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("empty roots should be unconfined, got: %v", err)
+	}
+}
+
+func TestExtractWriteTargets_PS_NewItem(t *testing.T) {
+	targets := extractWriteTargets(
+		`New-Item -Path "/workspace/newfile.txt" -ItemType File`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/workspace/newfile.txt` {
+		t.Fatalf("got %v, want [/workspace/newfile.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_SingleQuotedPath(t *testing.T) {
+	targets := extractWriteTargets(
+		`Set-Content -Path '/Program Files/app/config.ini' -Value x`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/Program Files/app/config.ini` {
+		t.Fatalf("got %v, want [/Program Files/app/config.ini]", targets)
+	}
+}
+
+func TestExtractWriteTargets_BashAmpersandRedirect(t *testing.T) {
+	// ">& file" redirects both stdout+stderr to file — must be caught.
+	targets := extractWriteTargets(
+		`cmd >& /tmp/out.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/out.txt` {
+		t.Fatalf("got %v, want [/tmp/out.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_BashAmpersandBothRedirect(t *testing.T) {
+	// "&> file" is equivalent to ">& file" in bash.
+	targets := extractWriteTargets(
+		`cmd &> /tmp/both.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/both.txt` {
+		t.Fatalf("got %v, want [/tmp/both.txt]", targets)
+	}
+}
+
+func TestExtractWriteTargets_FdPassthroughStillIgnored(t *testing.T) {
+	// 2>&1, 1>&2, and &> with digit are still fd passthrough.
+	targets := extractWriteTargets(
+		`cmd 2>&1 1>&2`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 0 {
+		t.Fatalf("got %v, want [] (fd passthrough should be ignored)", targets)
+	}
+}
+
+func TestExtractWriteTargets_TeeMultiFile(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hi | tee /tmp/a.txt /tmp/b.txt /tmp/c.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 3 {
+		t.Fatalf("got %d targets %v, want 3", len(targets), targets)
+	}
+	for i, want := range []string{"/tmp/a.txt", "/tmp/b.txt", "/tmp/c.txt"} {
+		if targets[i] != want {
+			t.Fatalf("targets[%d] = %q, want %q", i, targets[i], want)
+		}
+	}
+}
+
+func TestExtractWriteTargets_TeeAppend(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hi | tee -a /tmp/appended.log`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/appended.log` {
+		t.Fatalf("got %v, want [/tmp/appended.log]", targets)
+	}
+}
+
+func TestExtractWriteTargets_TeeAppendLongFlag(t *testing.T) {
+	targets := extractWriteTargets(
+		`echo hi | tee --append /tmp/appended2.log /tmp/appended3.log`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets %v, want 2", len(targets), targets)
+	}
+}
+
+func TestExtractWriteTargets_ExportCsv(t *testing.T) {
+	targets := extractWriteTargets(
+		`Get-Process | Export-Csv -Path /tmp/procs.csv`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/procs.csv` {
+		t.Fatalf("got %v, want [/tmp/procs.csv]", targets)
+	}
+}
+
+func TestExtractWriteTargets_ExportClixml(t *testing.T) {
+	targets := extractWriteTargets(
+		`Get-Process | Export-Clixml -Path /tmp/procs.xml`,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell},
+	)
+	if len(targets) != 1 || targets[0] != `/tmp/procs.xml` {
+		t.Fatalf("got %v, want [/tmp/procs.xml]", targets)
+	}
+}
+
+func TestCheckBashWriteTargets_TeeMultiFileBlocksOutside(t *testing.T) {
+	root := t.TempDir()
+	err := checkBashWriteTargets(
+		`echo hi | tee `+root+`/ok.txt /outside/bad.txt`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+		[]string{root},
+	)
+	if err == nil {
+		t.Fatal("expected error for tee with one file outside write roots, got nil")
+	}
+}
+
+func TestExtractWriteTargets_ProcessSubstitutionNotFalsePositive(t *testing.T) {
+	// >(...) is process substitution, not a file redirect — should NOT be caught.
+	targets := extractWriteTargets(
+		`diff <(ls) <(ls -la)`,
+		sandbox.Shell{Kind: sandbox.ShellBash},
+	)
+	// <(... ) are reads, >(...) are writes — but our parser only looks for `>` as
+	// a redirect operator, and `>(...)` has no space before `(`. Verify no
+	// false positive.
+	if len(targets) != 0 {
+		t.Fatalf("process substitution should not produce targets, got %v", targets)
+	}
+}


### PR DESCRIPTION
…#5793)

When the OS-level sandbox (Seatbelt/bwrap) is unavailable but enforcement is requested, apply in-process write-path validation to bash commands so the model cannot use bash to bypass the file-tool sandbox.

The parser scans for common write-intent patterns:
- PowerShell: Set-Content, Out-File, Add-Content, New-Item, Export-Csv, Export-Clixml (-Path/-FilePath)
- Shell redirects: >, >>, 2>, >& file, &> file
- tee (all file arguments, with -a/--append)
- dd of=

Detected paths are validated against WriteRoots using the same confine() function that file tools use. This is best-effort defense-in-depth: the permission layer still gates the bash call itself.

Also exported sandbox.Spec.enforce() → Enforce() for use by the builtin package.

Fixes #5793

## Summary

-

## Verification

-


## Cache impact
Cache-impact: none — the bash tool name, description, and schema are unchanged. The in-process write-path validation is runtime-only and does not affect the stable system prompt, tool contract, or prefix cache.
Cache-guard: go test ./internal/tool/builtin/ covers the bash execute path; the new bash_sandbox_test.go (31 tests) validates the sandbox detection logic across all supported patterns.
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
