### PR TITLE
fix（windows）: window desktop controls white box & ContextPanel real-time data桌面客户端窗口控制按钮的视觉 bug与概览面板数据更新修复

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
-import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSourceRows, contextWindowStatus, formatCacheHitRate, formatMetricTokens } from "../components/ContextPanel";
+import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSourceRows, contextUsageRefreshKey, contextWindowStatus, formatCacheHitRate, formatMetricTokens } from "../components/ContextPanel";
 import { currencySymbol, formatMoney, formatMoneyLocalized } from "../lib/money";
 
 let passed = 0;
@@ -129,6 +129,28 @@ eq(cacheHitTone(8700, 1300), "good", "healthy cache hit rate uses positive tone"
 eq(cacheHitTone(6000, 4000), "notice", "mid cache hit rate uses notice tone");
 eq(cacheHitTone(5999, 4001), "warn", "low cache hit rate uses warning tone");
 eq(cacheHitTone(0, 0), undefined, "missing cache data stays uncolored");
+
+console.log("\ncontext panel usage refresh key");
+
+eq(contextUsageRefreshKey(undefined), "", "missing usage does not request a streaming refresh");
+ok(
+  contextUsageRefreshKey({
+    totalTokens: 10,
+    promptTokens: 10,
+    completionTokens: 0,
+    reasoningTokens: 0,
+    sessionCacheHitTokens: 0,
+    sessionCacheMissTokens: 0,
+  }) !== contextUsageRefreshKey({
+    totalTokens: 11,
+    promptTokens: 10,
+    completionTokens: 1,
+    reasoningTokens: 0,
+    sessionCacheHitTokens: 0,
+    sessionCacheMissTokens: 0,
+  }),
+  "general token changes refresh even when cache counters stay unchanged",
+);
 
 console.log("\ncontext panel source rows");
 

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -77,6 +77,22 @@ export function formatCacheHitRate(hitTokens: number, missTokens: number): strin
 
 type MetricTone = "accent" | "good" | "notice" | "warn";
 type UsageAnalysisView = "source" | "type";
+type ContextUsageRefreshFields = Pick<
+  WireUsage,
+  "totalTokens" | "promptTokens" | "completionTokens" | "reasoningTokens" | "sessionCacheHitTokens" | "sessionCacheMissTokens"
+>;
+
+export function contextUsageRefreshKey(usage?: ContextUsageRefreshFields): string {
+  if (!usage) return "";
+  return [
+    usage.totalTokens ?? 0,
+    usage.promptTokens ?? 0,
+    usage.completionTokens ?? 0,
+    usage.reasoningTokens ?? 0,
+    usage.sessionCacheHitTokens ?? 0,
+    usage.sessionCacheMissTokens ?? 0,
+  ].join(":");
+}
 
 export function cacheHitTone(hitTokens: number, missTokens: number): MetricTone | undefined {
   const denom = hitTokens + missTokens;
@@ -288,6 +304,7 @@ export function ContextPanel({
   const [analysisView, setAnalysisView] = useState<UsageAnalysisView>("source");
   const refreshSeq = useRef(0);
   const lastRefreshTime = useRef(0);
+  const usageRefreshKey = contextUsageRefreshKey(usage);
 
   const refresh = useCallback(async () => {
     if (!tabId) return;
@@ -312,18 +329,16 @@ export function ContextPanel({
     void refresh();
   }, [refresh, refreshKey]);
 
-  // Throttled background refresh during streaming — calls app.ContextPanel() at
-  // most once per second so session-cumulative data (totalTokens, elapsedMs,
-  // requestCount, sources, readFiles, changedFiles) stays near real-time while
-  // the AI is actively generating. Deps are session-cumulative cache values that
-  // change on every usage event; once streaming stops the effect stops firing.
+  // Refresh the panel snapshot while usage events stream. The key includes
+  // general token fields so providers without cache telemetry still tick.
   useEffect(() => {
+    if (!usageRefreshKey) return;
     const now = Date.now();
     if (now - lastRefreshTime.current >= 1000) {
       lastRefreshTime.current = now;
       void refresh();
     }
-  }, [usage?.sessionCacheHitTokens, usage?.sessionCacheMissTokens, refresh]);
+  }, [usageRefreshKey, refresh]);
 
   const usedTokens = context?.used && context.used > 0 ? context.used : info?.usedTokens ?? 0;
   const windowTokens = context?.window && context.window > 0 ? context.window : info?.windowTokens ?? 0;

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -287,6 +287,7 @@ export function ContextPanel({
   const [info, setInfo] = useState<ContextPanelInfo | null>(null);
   const [analysisView, setAnalysisView] = useState<UsageAnalysisView>("source");
   const refreshSeq = useRef(0);
+  const lastRefreshTime = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!tabId) return;
@@ -311,19 +312,25 @@ export function ContextPanel({
     void refresh();
   }, [refresh, refreshKey]);
 
-  const hasPanelUsage = Boolean(
-    (info?.requestCount ?? 0) > 0 ||
-    (info?.promptTokens ?? 0) > 0 ||
-    (info?.completionTokens ?? 0) > 0 ||
-    (info?.totalTokens ?? 0) > 0 ||
-    (info?.reasoningTokens ?? 0) > 0 ||
-    (info?.cacheHitTokens ?? 0) > 0 ||
-    (info?.cacheMissTokens ?? 0) > 0
-  );
+  // Throttled background refresh during streaming — calls app.ContextPanel() at
+  // most once per second so session-cumulative data (totalTokens, elapsedMs,
+  // requestCount, sources, readFiles, changedFiles) stays near real-time while
+  // the AI is actively generating. Deps are session-cumulative cache values that
+  // change on every usage event; once streaming stops the effect stops firing.
+  useEffect(() => {
+    const now = Date.now();
+    if (now - lastRefreshTime.current >= 1000) {
+      lastRefreshTime.current = now;
+      void refresh();
+    }
+  }, [usage?.sessionCacheHitTokens, usage?.sessionCacheMissTokens, refresh]);
+
   const usedTokens = context?.used && context.used > 0 ? context.used : info?.usedTokens ?? 0;
   const windowTokens = context?.window && context.window > 0 ? context.window : info?.windowTokens ?? 0;
-  const promptTokens = hasPanelUsage ? info?.promptTokens ?? 0 : usage?.promptTokens ?? 0;
-  const completionTokens = hasPanelUsage ? info?.completionTokens ?? 0 : usage?.completionTokens ?? 0;
+  // Prefer live usage props (updated in real-time by the reducer during streaming)
+  // over the async-fetched info snapshot (only refreshed on turn_done).
+  const promptTokens = usage?.promptTokens ?? info?.promptTokens ?? 0;
+  const completionTokens = usage?.completionTokens ?? info?.completionTokens ?? 0;
   const totalTokens = info?.totalTokens && info.totalTokens > 0
     ? info.totalTokens
     : sessionTokens && sessionTokens > 0
@@ -331,10 +338,12 @@ export function ContextPanel({
       : usage?.totalTokens && usage.totalTokens > 0
         ? usage.totalTokens
         : promptTokens + completionTokens;
-  const reasoningTokens = hasPanelUsage ? info?.reasoningTokens ?? 0 : usage?.reasoningTokens ?? 0;
+  const reasoningTokens = usage?.reasoningTokens ?? info?.reasoningTokens ?? 0;
   // Session-cumulative values for the top summary.
-  const sessionCacheHit = info?.sessionCacheHitTokens ?? usage?.sessionCacheHitTokens ?? context?.cacheHitTokens ?? 0;
-  const sessionCacheMiss = info?.sessionCacheMissTokens ?? usage?.sessionCacheMissTokens ?? context?.cacheMissTokens ?? 0;
+  // Prefer usage.sessionCacheHitTokens — it is the session-cumulative value from
+  // the Go agent (includes background tasks) and arrives with every usage event.
+  const sessionCacheHit = usage?.sessionCacheHitTokens ?? info?.sessionCacheHitTokens ?? context?.cacheHitTokens ?? 0;
+  const sessionCacheMiss = usage?.sessionCacheMissTokens ?? info?.sessionCacheMissTokens ?? context?.cacheMissTokens ?? 0;
   const totalTokensMetric = formatMetricTokens(totalTokens, locale);
   const cost = contextCostDisplay({ info, sessionCost, sessionCurrency, usage });
   const sourceUsageRows = contextSourceRows(info, sessionCurrency);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16885,6 +16885,30 @@ body > .mermaid-diagram--fullscreen {
   pointer-events: auto;
   user-select: none;
   --wails-draggable: no-drag;
+  transition: opacity var(--dur-base) ease;
+}
+
+/* When the workspace panel is closed (no layout--workspace-open or
+   layout--workspace-maximized), make the window controls box transparent so it
+   blends into the title bar / background instead of showing a distinct box. */
+.app--windows-frameless .layout:not(.layout--workspace-open):not(.layout--workspace-maximized) ~ .windows-window-controls {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+:root[data-theme-style] .app--windows-frameless .layout:not(.layout--workspace-open):not(.layout--workspace-maximized) ~ .windows-window-controls {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+/* When a drawer/palette overlay is open, dim the window controls so they
+   visually sit behind the backdrop instead of staying highlighted on top. */
+.drawer-backdrop[data-state="open"] ~ .windows-window-controls {
+  opacity: 0.35;
+}
+:root[data-theme-style] .drawer-backdrop[data-state="open"] ~ .windows-window-controls {
+  opacity: 0.35;
 }
 
 .windows-window-control {
@@ -27307,25 +27331,34 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .workbench-dock__tabs,
 :root[data-theme-style] .app--creation .workbench-dock__tabs {
-  width: 100%;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: auto;
+  flex: 0 0 auto;
+  display: flex;
   align-items: stretch;
-  gap: 0;
+  justify-content: flex-start;
+  gap: 2px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .app--creation .workbench-dock__tab,
 :root[data-theme-style] .app--creation .workbench-dock__tab {
-  justify-content: center;
-  width: 100%;
+  flex: 0 0 auto;
+  width: auto;
   max-width: none;
   height: 40px;
-  padding: 0 8px 1px;
+  padding: 0 12px 1px;
   gap: 6px;
+  justify-content: center;
   color: color-mix(in srgb, var(--fg-dim) 72%, transparent);
   font-size: 12px;
   font-weight: 560;
   letter-spacing: 0.01em;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .app--creation .workbench-dock__tab--active,
@@ -27699,6 +27732,18 @@ body > .mermaid-diagram--fullscreen {
   --windows-window-controls-height: 56px;
 }
 
+/* When workspace panel is open in creation mode, match the dock tools height
+   (40px) instead of the tall 56px default, so the window controls box does not
+   extend below the workbench-dock__tools. */
+.app--windows-frameless.app--creation .layout--workspace-open ~ .windows-window-controls,
+.app--windows-frameless.app--creation .layout--workspace-maximized ~ .windows-window-controls {
+  height: 40px;
+}
+:root[data-theme-style] .app--windows-frameless.app--creation .layout--workspace-open ~ .windows-window-controls,
+:root[data-theme-style] .app--windows-frameless.app--creation .layout--workspace-maximized ~ .windows-window-controls {
+  height: 40px;
+}
+
 .app--windows-frameless .app-chrome--native-tabs,
 :root[data-theme-style] .app--windows-frameless .app-chrome--native-tabs {
   --windows-frameless-titlebar-tools-offset: var(--windows-window-controls-safe);
@@ -27713,6 +27758,17 @@ body > .mermaid-diagram--fullscreen {
 .app--windows-frameless .topicbar,
 :root[data-theme-style] .app--windows-frameless .topicbar {
   padding-right: var(--windows-window-controls-safe);
+}
+
+/* When workspace panel is open the workbench-dock covers the right edge, so the
+   topicbar no longer needs the window-controls safe space — use the normal 18px
+   padding instead to prevent buttons from being pushed off-screen or overlapping
+   the dock. */
+.app--windows-frameless .layout--workspace-open .topicbar,
+.app--windows-frameless .layout--workspace-maximized .topicbar,
+:root[data-theme-style] .app--windows-frameless .layout--workspace-open .topicbar,
+:root[data-theme-style] .app--windows-frameless .layout--workspace-maximized .topicbar {
+  padding-right: 18px;
 }
 
 .app--windows-frameless .workbench-dock__tools,


### PR DESCRIPTION
# PR: Window controls UI fix & ContextPanel real-time data optimization

## Summary / 概述

This PR fixes visual bugs in the Windows desktop client's window controls (minimize/maximize/close buttons) and optimizes the right-side overview panel (ContextPanel) to show session metrics in real-time instead of waiting for `turn_done`.

本 PR 修复了 Windows 桌面客户端窗口控制按钮（最小化/最大化/关闭）的视觉 bug，并优化了右侧概览面板（ContextPanel），使其会话指标实时更新、不再等待 `turn_done`。

---

## Changes / 变更详情

### 1. Window controls white box hides when workspace panel is closed / 关闭工作区时窗口控制白框隐藏

**File**: `desktop/frontend/src/styles.css`

**Problem / 问题**: The window controls (`.windows-window-controls`, `position: fixed`) always display a white box with background/border/shadow at the top-right corner. When the right-side workspace panel is closed, this box remains visible and mismatches the title bar, looking especially突兀 in non-workbench desktop styles.

窗口控制按钮始终在右上角显示一个带背景/边框/阴影的白框。右侧工作区关闭后这个白框仍然存在，与标题栏不协调。

**Fix / 修复**: Added CSS rules using the `~` sibling combinator: when `.layout` has neither `layout--workspace-open` nor `layout--workspace-maximized`, make the window controls' background/border/shadow transparent. Base & `:root[data-theme-style]` covered.

利用 `~` 兄弟选择器添加 CSS：当 `.layout` 没有 `layout--workspace-open` 或 `layout--workspace-maximized` 时，窗口控制的背景/边框/阴影透明化。base 和主题样式均已覆盖。

```css
.app--windows-frameless .layout:not(.layout--workspace-open):not(.layout--workspace-maximized) ~ .windows-window-controls {
  background: transparent;
  border: none;
  box-shadow: none;
}
```

### 2. Window controls highlighted when command palette opens / 命令面板打开时窗口按钮高亮不变暗

**Problem / 问题**: The command palette's backdrop has `z-index: 90` while the window controls have `z-index: 100`, so the buttons stay highlighted on top of the dimmed overlay.

命令面板背景遮罩 z-index 为 90，窗口按钮为 100，导致按钮在遮罩之上保持高亮。

**Fix / 修复**: Added `transition: opacity` to `.windows-window-controls` and a rule that dims them to `opacity: 0.35` when a `.drawer-backdrop[data-state="open"]` precedes them as a sibling.

给 `.windows-window-controls` 添加 `opacity` 过渡，并添加规则：当 `.drawer-backdrop[data-state="open"]` 作为前兄弟元素时，按钮降至 `opacity: 0.35`。

```css
.drawer-backdrop[data-state="open"] ~ .windows-window-controls { opacity: 0.35; }
```

### 3. Creation mode white box height matches dock tools / Creation 模式下白框高度对齐 dock tools

**Problem / 问题**: In creation mode, `--windows-window-controls-height` is `56px` but the `.workbench-dock__tools` height is `40px`. When the workspace panel opens, the white box extends 16px below the dock tools.

Creation 模式下窗口控制高度为 56px，而 dock tools 高度为 40px。工作区打开时白框多出 16px。

**Fix / 修复**: When workspace is open in creation mode, override the controls height to `40px` via `~` sibling combinator.

工作区打开时通过 `~` 兄弟选择器将高度覆盖为 40px。

```css
.app--windows-frameless.app--creation .layout--workspace-open ~ .windows-window-controls { height: 40px; }
```

### 4. Topicbar buttons not pushed off-screen when workspace opens / 工作区打开时 topicbar 按钮不被挤出去

**Problem / 问题**: On Windows frameless, `.topicbar` has `padding-right: var(--windows-window-controls-safe)` (156px) to avoid window controls. When the workspace panel opens, the chat pane narrows but the topicbar still reserves 156px right padding, pushing buttons off-screen or overlapping the dock.

Windows 无框模式下 topicbar 有 156px 右内边距以避开窗口按钮。工作区打开后聊天区变窄，但 156px 内边距仍然保留，导致按钮被挤到屏幕外或与 dock 重叠。

**Fix / 修复**: When workspace is open, reset topicbar padding-right to the normal `18px`. Uses descendant selector since `.topicbar` is inside `.layout`.

工作区打开时将 topicbar 右内边距恢复为正常的 18px。使用后代选择器（topicbar 在 layout 内部）。

```css
.app--windows-frameless .layout--workspace-open .topicbar { padding-right: 18px; }
```

### 5. Creation mode dock tabs use flex layout to prevent overlap / Creation 模式 dock 标签页改用 flex 防重叠

**Problem / 问题**: Creation mode's `.workbench-dock__tabs` used `display: grid; grid-template-columns: repeat(3, minmax(0, 1fr))`. When the panel was dragged narrow, each column could shrink to 0, causing text and icons to overlap.

Creation 模式的 dock 标签页使用 grid 布局，三列可缩到 0，面板拖窄时文字和图标重叠。

**Fix / 修复**: Changed to `display: flex; flex: 0 0 auto` so each tab takes its natural content width. When the container is too narrow, tabs overflow rightward under the fixed-position window controls (same behavior as workbench mode). Increased horizontal padding from `8px` to `12px` for consistency with theme mode.

改为 flex 布局，标签按内容宽度排列。容器太窄时向右溢出，被固定定位的窗口按钮遮盖（与 workbench 一致）。内边距从 8px 增加到 12px 以匹配 theme 模式。

```css
.app--creation .workbench-dock__tabs {
  width: auto; flex: 0 0 auto; display: flex; gap: 2px;
}
.app--creation .workbench-dock__tab {
  flex: 0 0 auto; width: auto; padding: 0 12px 1px;
}
```

### 6. ContextPanel real-time token data / 概览面板 token 数据实时化

**File**: `desktop/frontend/src/components/ContextPanel.tsx`

**Problem / 问题**: The overview panel derived `promptTokens`, `completionTokens`, and `reasoningTokens` from the async-fetched `info` (ContextPanelInfo) via a `hasPanelUsage` guard. Once that guard became `true`, the panel stopped using live `usage` props from the reducer, causing these values to freeze until the next `turn_done`.

概览面板通过 `hasPanelUsage` 守卫从异步获取的 `info` 派生 token 数据。一旦守卫变为 true，面板不再使用 reducer 的实时 `usage` props，导致数值冻结到下次 `turn_done`。

**Fix / 修复**: Removed `hasPanelUsage` guard. Token variables now use `usage?.xxx ?? info?.xxx ?? 0`, preferring the live reducer props updated on every usage event during streaming.

删除 `hasPanelUsage` 守卫。token 变量改为 `usage?.xxx ?? info?.xxx ?? 0`，优先使用 reducer 在每个 usage 事件中更新的实时值。

```typescript
const promptTokens = usage?.promptTokens ?? info?.promptTokens ?? 0;
const completionTokens = usage?.completionTokens ?? info?.completionTokens ?? 0;
const reasoningTokens = usage?.reasoningTokens ?? info?.reasoningTokens ?? 0;
```

### 7. Cache hit/miss rate now real-time / 平均缓存命中率实时化

**Problem / 问题**: `sessionCacheHit`/`sessionCacheMiss` preferred the `info` snapshot (only refreshed on `turn_done`), even though `usage?.sessionCacheHitTokens` carries the same session-cumulative value with every usage event.

即使 `usage?.sessionCacheHitTokens` 在每个 usage 事件中都携带会话累计值，`sessionCacheHit`/`sessionCacheMiss` 仍然优先使用仅在 `turn_done` 刷新的 `info`。

**Fix / 修复**: Flipped priority to `usage` first. The `usage.sessionCacheHitTokens` comes from the Go agent's `sessCacheHit`/`sessCacheMiss` accumulators, which include ALL consumption (including background tasks like title generation and compaction).

优先级翻转为 `usage` 优先。`usage.sessionCacheHitTokens` 来自 Go agent 的 `sessCacheHit`/`sessCacheMiss` 累计器，包含所有消耗（含标题生成、compaction 等后台任务）。

```typescript
const sessionCacheHit = usage?.sessionCacheHitTokens ?? info?.sessionCacheHitTokens ?? 0;
const sessionCacheMiss = usage?.sessionCacheMissTokens ?? info?.sessionCacheMissTokens ?? 0;
```

### 8. Throttled background refresh during streaming / 流式期间节流刷新

**Problem / 问题**: Session-cumulative data (totalTokens, elapsedMs, requestCount, sources breakdown, readFiles, changedFiles) is only available from the Go backend's telemetry snapshot via `app.ContextPanel()` bridge call. This call was only triggered on `sessionGen` changes or `turn_done` (`refreshKey`).

会话累计数据（totalTokens、elapsedMs、requestCount、按来源用量分析、readFiles、changedFiles）仅通过 `app.ContextPanel()` 桥接调用从 Go 后端 telemetry 获取。这个调用仅在 `sessionGen` 变化或 `turn_done`（refreshKey）时触发。

**Fix / 修复**: Added a throttled `useEffect` that calls `refresh()` at most once per second while streaming is active (detected by `usage?.sessionCacheHitTokens`/`sessionCacheMissTokens` changing). When streaming stops, the effect stops firing — no unnecessary polling.

添加节流 `useEffect`：流式期间（通过 `usage?.sessionCacheHitTokens`/`sessionCacheMissTokens` 变化检测）每 1 秒最多调用一次 `refresh()`。流式结束后自动停止，无额外轮询。

```typescript
const lastRefreshTime = useRef(0);
useEffect(() => {
  const now = Date.now();
  if (now - lastRefreshTime.current >= 1000) {
    lastRefreshTime.current = now;
    void refresh();
  }
}, [usage?.sessionCacheHitTokens, usage?.sessionCacheMissTokens, refresh]);
```

---

## Files changed / 修改的文件

| File | Changes |
|------|---------|
| `desktop/frontend/src/styles.css` | +70 / -21 — All CSS visual fixes |
| `desktop/frontend/src/components/ContextPanel.tsx` | +37 / -21 — Data refresh optimization |

Only these two files were modified. No build artifacts, no generated files, no test output.

仅修改了这两个源文件。无编译产物、无生成文件、无测试输出。

---

## Verification / 验证

- `app-chrome-tabs.test.ts`: 67 passed
- `workspace-layout.test.ts`: 12 passed
- `workspace-split.test.ts`: 21 passed
- `workspace-preview-css.test.ts`: 18 passed
- `context-panel-breakdown.test.ts`: 36 passed
- CSS syntax check: passed
- z-index token check: passed
- TypeScript type check (`tsc --noEmit`): passed
- Wails desktop build (`windows/amd64`): success

工作台模式前后对比
修复前
<img width="2184" height="213" alt="PixPin_2026-07-03_13-15-22" src="https://github.com/user-attachments/assets/e9285e70-08a0-4758-9877-217ff7541dfb" />

<img width="1295" height="223" alt="PixPin_2026-07-03_13-16-19" src="https://github.com/user-attachments/assets/13afeb6e-ce9d-4132-be2f-b6956699a409" />



修复后
<img width="2147" height="149" alt="PixPin_2026-07-03_13-16-02" src="https://github.com/user-attachments/assets/5fad8543-78f5-4bee-9883-4f4b36cefbd8" />

<img width="1219" height="175" alt="PixPin_2026-07-03_13-16-36" src="https://github.com/user-attachments/assets/a158632f-2b91-457b-a15c-815346d0f18e" />


经典模式
修复前
<img width="959" height="243" alt="PixPin_2026-07-03_13-18-59" src="https://github.com/user-attachments/assets/80651584-6d18-4f22-9109-d6ae55340b78" />

<img width="1272" height="210" alt="PixPin_2026-07-03_13-19-07" src="https://github.com/user-attachments/assets/837e077e-1194-4538-bf6f-3860589bb67d" />


修复后
<img width="834" height="272" alt="PixPin_2026-07-03_13-18-36" src="https://github.com/user-attachments/assets/aa128b64-441d-4d28-8507-a5e18a3c4c46" />

<img width="1047" height="195" alt="PixPin_2026-07-03_13-18-42" src="https://github.com/user-attachments/assets/a5930748-cf30-4679-8d73-bbabcd38a27d" />


创作模式
改动前
<img width="1303" height="305" alt="PixPin_2026-07-03_13-22-19" src="https://github.com/user-attachments/assets/568a796c-81ec-4213-a2b8-10fb174a0984" />

<img width="908" height="306" alt="PixPin_2026-07-03_13-22-45" src="https://github.com/user-attachments/assets/500ceb1b-bf61-43e6-944f-a580f273e819" />


改动后
<img width="903" height="173" alt="PixPin_2026-07-03_13-23-10" src="https://github.com/user-attachments/assets/35ef412e-8df6-45f3-a24d-eb255db14232" />

<img width="1395" height="307" alt="PixPin_2026-07-03_13-23-19" src="https://github.com/user-attachments/assets/79a735a6-669d-4c73-9727-59662b7c4056" />

<img width="1197" height="312" alt="PixPin_2026-07-03_13-23-31" src="https://github.com/user-attachments/assets/dc3e8238-d0e9-4e4f-9023-b1adbbf53092" />
