### PR TITLE
fix: prevent session data loss from non-atomic writes and silent corr…

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -84,6 +84,11 @@ func saveSessionTitles(dir string, m map[string]string) error {
 		os.Remove(tmpPath)
 		return err
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpPath)
 		return err
@@ -842,6 +847,11 @@ func saveSessionDisplays(dir string, m sessionDisplayMap) error {
 	}
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		return err

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -45,6 +45,11 @@ func (s *Session) Save(path string) error {
 			return fmt.Errorf("encode message: %w", err)
 		}
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("fsync session tmp: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpPath)
 		return err
@@ -359,6 +364,26 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			_ = UpdateSessionMeta(session.Path, "", preview, turns, false)
 		}
 		if turns == 0 {
+			// A non-empty file that previewSession couldn't extract any user
+			// turns from may be corrupted. Attempt LoadSession to distinguish
+			// "genuinely empty" from "corrupted beyond decoding" (#5794).
+			if fi, err := os.Stat(session.Path); err == nil && fi.Size() > 0 {
+				if _, loadErr := LoadSession(session.Path); loadErr != nil {
+					out = append(out, SessionInfo{
+						Path:           session.Path,
+						CreatedAt:      session.CreatedAt,
+						LastActivityAt: session.LastActivityAt,
+						ModTime:        session.ModTime,
+						Preview:        "⚠️ Session may be corrupted — check " + filepath.Base(session.Path),
+						Turns:          1, // non-zero so it appears in the sidebar
+						Scope:          session.Scope,
+						WorkspaceRoot:  session.WorkspaceRoot,
+						TopicID:        session.TopicID,
+						TopicTitle:     session.TopicTitle,
+					})
+					continue
+				}
+			}
 			// Never had user interaction — an empty conversation that should not
 			// appear in the history panel or the resume picker.
 			continue

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -240,6 +240,51 @@ func TestListSessionsSkipsNonJSONL(t *testing.T) {
 	}
 }
 
+func TestListSessionsShowsCorruptedSession(t *testing.T) {
+	dir := t.TempDir()
+	corrupted := filepath.Join(dir, "corrupted.jsonl")
+	// A non-empty file that is not valid JSONL — e.g., truncated mid-write.
+	if err := os.WriteFile(corrupted, []byte(`{"role":"user","content":[`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a sidecar with turns=0 (recorded as authoritative). ListSessions
+	// trusts the sidecar count, sees 0 turns, then discovers the file is
+	// non-empty and unloadable → shows it with a corruption warning (#5794).
+	_ = UpdateSessionMeta(corrupted, "", "", 0, false)
+
+	sessions, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("corrupted session should be visible, got %d sessions", len(sessions))
+	}
+	if sessions[0].Turns != 1 {
+		t.Errorf("corrupted session should have non-zero turns to appear in sidebar, got %d", sessions[0].Turns)
+	}
+	if !strings.Contains(sessions[0].Preview, "corrupted") {
+		t.Errorf("preview should indicate corruption, got %q", sessions[0].Preview)
+	}
+}
+
+func TestListSessionsSkipsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a sidecar so the file is picked up.
+	_ = UpdateSessionMeta(empty, "", "", 0, false)
+
+	sessions, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("empty (0-byte) files should still be skipped, got %d sessions", len(sessions))
+	}
+}
+
 // --- previewSession ---
 
 func TestPreviewSession(t *testing.T) {

--- a/internal/fileutil/atomicwrite.go
+++ b/internal/fileutil/atomicwrite.go
@@ -94,12 +94,35 @@ func copyOnto(tmp, dest string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(dest, data, info.Mode().Perm()); err != nil {
+	// Write to a sibling temp file, fsync, then rename atomically — never
+	// truncate the destination directly with os.WriteFile, which would leave
+	// a corrupted/empty file on crash or power loss (#5794).
+	tmp2, err := os.CreateTemp(filepath.Dir(dest), ".atomic-copy-*.tmp")
+	if err != nil {
 		return err
 	}
-	// WriteFile keeps an existing dest's mode, so re-apply tmp's mode to match
-	// what the rename would have done (a 0600 config tmp must not widen to 0644).
-	_ = os.Chmod(dest, info.Mode().Perm())
+	tmp2Path := tmp2.Name()
+	cleanup := func() { tmp2.Close(); os.Remove(tmp2Path) }
+	if _, err := tmp2.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp2.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp2.Close(); err != nil {
+		os.Remove(tmp2Path)
+		return err
+	}
+	if err := os.Chmod(tmp2Path, info.Mode().Perm()); err != nil {
+		os.Remove(tmp2Path)
+		return err
+	}
+	if err := os.Rename(tmp2Path, dest); err != nil {
+		os.Remove(tmp2Path)
+		return err
+	}
 	_ = os.Remove(tmp)
 	return nil
 }


### PR DESCRIPTION
…uption (#5794)

Three data-loss vectors fixed:

1. copyOnto in ReplaceFile now writes to a sibling temp file, fsyncs, then renames atomically — never truncates the destination directly with os.WriteFile, which could leave a corrupted file on crash or power loss. This path is hit frequently on Windows when antivirus or search indexer briefly locks the destination.

2. Session.Save and saveSessionTitles/saveSessionDisplays now call tmp.Sync() before Close(), matching the AtomicWriteFile pattern. Without fsync, the OS may not flush the temp file to disk before the rename, leaving a truncated file on crash.

3. ListSessions now shows corrupted sessions (non-empty file that fails LoadSession) with a "⚠️ Session may be corrupted" warning in the sidebar, instead of silently hiding them.

Cache-impact: none — session persistence layer; no tool/agent/prompt changes. The write path changes are runtime-only and invisible to the model and prefix cache.

Cache-guard: go test ./internal/agent/ covers ListSessions behavior; the new TestListSessionsShowsCorruptedSession and
TestListSessionsSkipsEmptyFile validate the corruption-detection path.

Fixes #5794

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
