### PR TITLE
fix: update manifest URL uses wrong repo name (reasonix → DeepSeek-Re…

### DIFF
--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -166,8 +166,8 @@ func signFiles(files []string) error {
 // release tag used in download URLs (e.g. "desktop-v1.1.0").
 func genManifest(dir, version, tag string) error {
 	repo := os.Getenv("GITHUB_REPOSITORY")
-	if repo == "" {
-		repo = "esengine/reasonix"
+	if repo == "" || repo == "esengine/reasonix" {
+		repo = "esengine/DeepSeek-Reasonix"
 	}
 	m := update.Manifest{
 		Version:      version,

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -92,7 +92,7 @@ func TestGenManifest(t *testing.T) {
 	if !ok {
 		t.Fatal("windows-amd64 missing")
 	}
-	wantURL := "https://github.com/esengine/reasonix/releases/download/desktop-v1.2.0/Reasonix-windows-amd64-installer.exe"
+	wantURL := "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.2.0/Reasonix-windows-amd64-installer.exe"
 	if win.URL != wantURL {
 		t.Fatalf("windows url = %q, want %q", win.URL, wantURL)
 	}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -2847,7 +2847,7 @@ function makeMockApp(): AppBindings {
     },
     async OpenDownloadPage() {
       if (typeof window !== "undefined") {
-        window.open("https://github.com/esengine/reasonix/releases/latest", "_blank", "noopener");
+        window.open("https://github.com/esengine/DeepSeek-Reasonix/releases/latest", "_blank", "noopener");
       }
     },
     // Dev seam: drives the overlay flow in the browser until ConnectKey sets the

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -38,7 +38,7 @@ import (
 // the canary line and a stable build polls latest; the two never cross.
 const (
 	r2Base         = "https://dl.reasonix.io"
-	ghReleasesBase = "https://github.com/esengine/reasonix/releases"
+	ghReleasesBase = "https://github.com/esengine/DeepSeek-Reasonix/releases"
 	httpTimeout    = 15 * time.Second
 )
 


### PR DESCRIPTION
…asonix) (#5826)

The auto-updater fetches the manifest from
  github.com/esengine/reasonix/releases/.../latest.json
but the actual repo is esengine/DeepSeek-Reasonix, causing a 404.

Cache-impact: none — updater URL, not in the model/tool path.

Cache-guard: existing updater tests cover manifest fetch; URL constant change is covered by TestReleaseAssetURL in main_test.go.

Fixes #5826

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
