### PR TITLE
test: add YOLO regression test for remember/forget forced approval (#…

### DIFF
--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -211,6 +211,22 @@ func TestToolApprovalModeAutoForcesMemoryAskRules(t *testing.T) {
 	}
 }
 
+func TestToolApprovalModeYoloForcesMemoryAskRules(t *testing.T) {
+	c := New(Options{})
+	c.SetToolApprovalMode(ToolApprovalYolo)
+
+	gate := c.newInteractiveGate()
+	for _, toolName := range []string{"remember", "forget"} {
+		if got := gate.Policy.Decide(toolName, false, json.RawMessage(`{}`)); got != permission.Ask {
+			t.Fatalf("%s under yolo mode = %v, want ask", toolName, got)
+		}
+	}
+	// Verify that regular tools ARE auto-allowed in YOLO (sanity check).
+	if got := gate.Policy.Decide("bash", false, json.RawMessage(`{"command":"go test ./..."}`)); got != permission.Allow {
+		t.Fatalf("regular tool under yolo mode = %v, want allow", got)
+	}
+}
+
 func TestToolApprovalModeAutoDrainsPendingFallbackApproval(t *testing.T) {
 	approvalRequests := make(chan event.Approval, 1)
 	c := New(Options{


### PR DESCRIPTION
…5753)

The protection for remember/forget tools already exists on main-v2 (requiresFreshApprovalTool + policy.Ask rules in newInteractiveGate), but only Auto mode had a dedicated test. This adds an equivalent test for YOLO/full-access mode to prevent regression.

Cache-impact: none — test-only change.

Cache-guard: go test ./internal/control/ -run "TestToolApprovalModeYoloForcesMemoryAskRules"

Refs: #5753

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
