### PR TITLE
fix: send unrecognized "/" messages to AI instead of discarding them …

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -795,7 +795,8 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			})
 			return
 		}
-		c.notice("unknown command: " + trimmed)
+		c.notice("unknown command: " + trimmed + " — sending as message to AI")
+		runRefTurn(input, display)
 	default:
 		if c.maybeAutoStartResearchGoal(input, display) {
 			return

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -586,9 +586,8 @@ func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
 
 	c.Submit("/definitely-not-a-command")
 
-	if len(runner.inputs) != 0 {
-		t.Fatalf("unknown slash command should not start a model turn, inputs=%q", runner.inputs)
-	}
+	// An unknown slash command should emit a notice AND send the message to the
+	// AI as a normal turn — it might be a legitimate message starting with "/".
 	select {
 	case e := <-events:
 		if e.Kind != event.Notice || !strings.Contains(e.Text, "unknown command: /definitely-not-a-command") {
@@ -596,6 +595,10 @@ func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for unknown-command notice")
+	}
+	waitForTurnDone(t, events)
+	if len(runner.inputs) != 1 || runner.inputs[0] != "/definitely-not-a-command" {
+		t.Fatalf("unknown slash command should start a model turn, inputs=%q", runner.inputs)
 	}
 }
 


### PR DESCRIPTION
…(#5756)

Messages starting with "/" that are not recognized commands were silently discarded with "unknown command" notice. This prevented legitimate messages like "/history normally should..." from reaching the AI.

Now: unrecognized "/" messages still emit a notice ("unknown command — sending as message to AI") and fall through to the normal turn dispatch path, matching the behavior of "//" double-slash messages.

Cache-impact: none — control flow change only; no tool/prompt changes.

Cache-guard: go test ./internal/control/ -run TestSubmitUnknownSlashCommand

Fixes #5756

## Summary

-

## Verification

-
## Cache impact
Cache-impact: none — control flow change only; no tool/prompt changes.
Cache-guard: go test ./internal/control/ -run TestSubmitUnknownSlashCommand
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

Cache-impact: none, low, medium, or high, plus the reason.
