### PR TITLE
fix(desktop): export PDF/image fails in WKWebView

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-virtual": "^3.14.3",
     "gsap": "^3.15.0",
     "highlight.js": "^11.10.0",
+    "html2canvas": "^1.4.1",
     "katex": "^0.17.0",
     "lucide-react": "^1.21.0",
     "mermaid": "^11.16.0",

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       highlight.js:
         specifier: ^11.10.0
         version: 11.11.1
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       katex:
         specifier: ^0.17.0
         version: 0.17.0
@@ -654,6 +657,10 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -694,6 +701,9 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -983,6 +993,10 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1434,6 +1448,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -1513,6 +1530,9 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
@@ -2070,6 +2090,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -2101,6 +2123,10 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -2469,6 +2495,11 @@ snapshots:
       - '@noble/hashes'
 
   html-url-attributes@3.0.1: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -3200,6 +3231,10 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -3286,6 +3321,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@14.0.1: {}
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1572,31 +1572,45 @@ export default function App() {
     async (format: "markdown" | "json" | "pdf" | "image") => {
       const base = safeFilename(sessionTitle);
       setTopicExportOpen(false);
+      const pickAndSave = async (
+        ext: string,
+        mime: string,
+        payload: string | Promise<string>,
+        base64Encoded: boolean,
+      ) => {
+        const path = await app.PickExportFile(`${base}.${ext}`, mime);
+        if (!path) return;
+        await app.SaveExportFile(path, await payload, base64Encoded);
+        showToast(t("topicBar.exportSuccess"), "info");
+      };
       try {
         if (format === "json") {
-          const path = await app.PickExportFile(`${base}.json`, "application/json");
-          if (path) await app.SaveExportFile(path, getSessionJson(), false);
+          await pickAndSave("json", "application/json", getSessionJson(), false);
         } else if (format === "pdf") {
-          const path = await app.PickExportFile(`${base}.pdf`, "application/pdf");
-          if (!path) return;
           const { blobToBase64, renderSessionPdfBlob } = await import("./lib/sessionExport");
-          const blob = await renderSessionPdfBlob(getSessionMarkdown(), sessionTitle);
-          await app.SaveExportFile(path, await blobToBase64(blob), true);
+          await pickAndSave(
+            "pdf",
+            "application/pdf",
+            blobToBase64(await renderSessionPdfBlob(getSessionMarkdown(), sessionTitle)),
+            true,
+          );
         } else if (format === "image") {
-          const path = await app.PickExportFile(`${base}.png`, "image/png");
-          if (!path) return;
           const { blobToBase64, renderSessionImageBlob } = await import("./lib/sessionExport");
-          const blob = await renderSessionImageBlob(getSessionMarkdown());
-          await app.SaveExportFile(path, await blobToBase64(blob), true);
+          await pickAndSave(
+            "png",
+            "image/png",
+            blobToBase64(await renderSessionImageBlob(getSessionMarkdown())),
+            true,
+          );
         } else {
-          const path = await app.PickExportFile(`${base}.md`, "text/markdown");
-          if (path) await app.SaveExportFile(path, getSessionMarkdown(), false);
+          await pickAndSave("md", "text/markdown", getSessionMarkdown(), false);
         }
       } catch (err) {
         console.error("Failed to export session", err);
+        showToast(t("topicBar.exportFailed"), "error");
       }
     },
-    [getSessionJson, getSessionMarkdown, sessionTitle],
+    [getSessionJson, getSessionMarkdown, sessionTitle, showToast, t],
   );
 
   useEffect(() => {

--- a/desktop/frontend/src/lib/sessionExport.tsx
+++ b/desktop/frontend/src/lib/sessionExport.tsx
@@ -284,52 +284,22 @@ function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality?: number)
   });
 }
 
-function loadImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error("Could not render export image"));
-    img.src = url;
-  });
-}
-
-function serializeSurface(surface: HTMLElement, width: number, height: number): string {
-  const clone = surface.cloneNode(true) as HTMLElement;
-  clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
-  clone.style.width = `${width}px`;
-  clone.style.minHeight = `${height}px`;
-  const style = document.createElement("style");
-  style.textContent = EXPORT_STYLES;
-  clone.insertBefore(style, clone.firstChild);
-  return new XMLSerializer().serializeToString(clone);
-}
-
 async function renderSurfaceToCanvas(surface: HTMLElement): Promise<HTMLCanvasElement> {
   const width = Math.max(1, Math.ceil(surface.scrollWidth || surface.getBoundingClientRect().width || EXPORT_WIDTH));
   const height = Math.max(1, Math.ceil(surface.scrollHeight || surface.getBoundingClientRect().height || 1));
   const preferredScale = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
   const scale = Math.min(preferredScale, MAX_CANVAS_SIDE / width, MAX_CANVAS_SIDE / height);
-  const canvasWidth = Math.max(1, Math.floor(width * scale));
-  const canvasHeight = Math.max(1, Math.floor(height * scale));
-  const serialized = serializeSurface(surface, width, height);
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><foreignObject width="100%" height="100%">${serialized}</foreignObject></svg>`;
-  const svgUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml;charset=utf-8" }));
 
-  try {
-    const image = await loadImage(svgUrl);
-    const canvas = document.createElement("canvas");
-    canvas.width = canvasWidth;
-    canvas.height = canvasHeight;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("Canvas is not available");
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
-    ctx.scale(scale, scale);
-    ctx.drawImage(image, 0, 0, width, height);
-    return canvas;
-  } finally {
-    URL.revokeObjectURL(svgUrl);
-  }
+  const { default: html2canvas } = await import("html2canvas");
+  return html2canvas(surface, {
+    backgroundColor: "#ffffff",
+    scale,
+    useCORS: true,
+    logging: false,
+    width,
+    height,
+    windowWidth: EXPORT_WIDTH,
+  });
 }
 
 function bytesFromString(value: string): Uint8Array {
@@ -463,6 +433,7 @@ export async function renderSessionPdfBlob(markdown: string, title: string): Pro
     const jpegBlob = await canvasToBlob(canvas, "image/jpeg", 0.92);
     const jpegBytes = new Uint8Array(await jpegBlob.arrayBuffer());
     const pdfBytes = createRasterPdf(jpegBytes, canvas.width, canvas.height, title);
+    canvas.width = canvas.height = 0;
     return new Blob([arrayBufferFromBytes(pdfBytes)], { type: "application/pdf" });
   } finally {
     disposeExport(rendered);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -151,6 +151,8 @@ export const en = {
   "topicBar.exportJson": "Export JSON",
   "topicBar.exportPdf": "Export PDF",
   "topicBar.exportImage": "Export Image",
+  "topicBar.exportSuccess": "Exported successfully",
+  "topicBar.exportFailed": "Export failed",
 
   // scope labels
   "scope.global": "Scope: Global",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1246,6 +1246,8 @@ export const zhTW: Record<DictKey, string> = {
   "topicBar.command": "命令",
   "topicBar.exportPdf": "匯出 PDF",
   "topicBar.exportImage": "匯出圖片",
+  "topicBar.exportSuccess": "匯出成功",
+  "topicBar.exportFailed": "匯出失敗",
   "workspace.filterReferencedFiles": "篩選依賴檔案…",
   "workspace.clearFileScope": "顯示完整檔案樹",
   "workspace.clearChangeScope": "顯示全部改動",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -152,6 +152,8 @@ export const zh: Record<DictKey, string> = {
   "topicBar.exportJson": "导出 JSON",
   "topicBar.exportPdf": "导出 PDF",
   "topicBar.exportImage": "导出图片",
+  "topicBar.exportSuccess": "导出成功",
+  "topicBar.exportFailed": "导出失败",
 
   // 范围标签
   "scope.global": "范围：全局",


### PR DESCRIPTION
## Problem

Desktop client's session export to PDF (and image) silently failed — after picking the save path, no file was actually generated. Markdown and JSON exports worked but gave no success/failure feedback.

Fixes #5788

## Root cause

`renderSurfaceToCanvas` in `desktop/frontend/src/lib/sessionExport.tsx` used SVG `<foreignObject>` to wrap the rendered HTML, loaded it via `<img>`, then drew to a canvas. In WKWebView (macOS Wails v2) this path taints the canvas, so `canvas.toBlob()` returns `null` and the export throws `"Could not encode export image"` — the file never gets written.

## Fix

1. **Replace foreignObject with html2canvas** — directly traverses the DOM and paints to a canvas, bypassing the WKWebView taint. Dynamically imported so it doesn't bloat the first-screen bundle.
2. **Add success/failure toast for every export format** (markdown / json / pdf / image) — previously only `console.error` on failure, no feedback on success.
3. **Refactor `exportSession`** — the 4 format branches duplicated a pick → save → toast flow; unified into a `pickAndSave(ext, mime, payload, base64Encoded)` helper.
4. **Release canvas bitmap** after PDF rasterization (`canvas.width = canvas.height = 0`) to cut peak memory on long sessions.

## Validation

- `pnpm build` passes (tsc typecheck + vite build).
- `wails build` passes.
- Manually tested export to PDF, image, markdown, and JSON — all four now produce a file and show a success toast. Long sessions with code blocks, tables, and KaTeX formulas render correctly in the exported PDF.

## Notes

- Adds one runtime dependency: `html2canvas@^1.4.1` (~48 KB gzipped, dynamically imported).
- Image export was fixed by the same change — it shares `renderSurfaceToCanvas` with PDF export.
- The original `serializeSurface`/`loadImage` helpers were deleted (no longer reachable).