### PR TITLE
Guard session snapshots against stale overwrites / 防止旧快照覆盖会话

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2294,7 +2294,11 @@ func (a *App) prepareRemovedSessionRuntimes(removed []removedSessionRuntime) err
 			continue
 		}
 		if err := item.ctrl.Snapshot(); err != nil {
-			return err
+			if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
+				return err
+			}
+			slog.Warn("desktop: skipping stale runtime snapshot before removing session",
+				"session", item.sessionPath, "err", err)
 		}
 		item.ctrl.SetSessionPath("")
 		a.quiesceTabAutosave(item.tab)

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -34,23 +34,38 @@ type sessionPersistState struct {
 	ok      bool
 }
 
+type sessionSaveMode int
+
+const (
+	sessionSaveForce sessionSaveMode = iota
+	sessionSaveSnapshot
+	sessionSaveRewrite
+)
+
 // Save writes the session's messages to path in JSONL — one provider.Message
 // per line — so a user can resume the conversation later. The file is
 // rewritten in full on every save: chat sessions are small (kilobytes), and
 // append-only would have to be reconciled with the compaction pass that
 // mutates the middle of session.Messages.
 func (s *Session) Save(path string) error {
-	return s.save(path, false)
+	return s.save(path, sessionSaveForce)
 }
 
 // SaveSnapshot writes a normal autosave/snapshot only when doing so cannot hide
-// a newer transcript already on disk. Explicit history rewrites such as rewind
-// and cancel recovery should call Save instead.
+// a newer transcript already on disk. Explicit history rewrites such as rewind,
+// compaction, and cancel recovery should call SaveRewrite instead.
 func (s *Session) SaveSnapshot(path string) error {
-	return s.save(path, true)
+	return s.save(path, sessionSaveSnapshot)
 }
 
-func (s *Session) save(path string, protectSnapshot bool) error {
+// SaveRewrite writes an intentional non-append history rewrite only while this
+// Session still owns the current on-disk transcript baseline. It prevents a
+// stale controller from force-rewinding a newer transcript written elsewhere.
+func (s *Session) SaveRewrite(path string) error {
+	return s.save(path, sessionSaveRewrite)
+}
+
+func (s *Session) save(path string, mode sessionSaveMode) error {
 	if path == "" {
 		return fmt.Errorf("empty session path")
 	}
@@ -64,8 +79,8 @@ func (s *Session) save(path string, protectSnapshot bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
 	}
-	if protectSnapshot {
-		if err := s.checkSnapshotWrite(path, msgs, digest, version); err != nil {
+	if mode != sessionSaveForce {
+		if err := s.checkSnapshotWrite(path, msgs, digest, version, mode == sessionSaveRewrite); err != nil {
 			return err
 		}
 	}
@@ -103,7 +118,7 @@ func writeSessionMessages(path string, msgs []provider.Message) error {
 	return nil
 }
 
-func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextDigest [sha256.Size]byte, nextVersion uint64) error {
+func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextDigest [sha256.Size]byte, nextVersion uint64, allowOwnedRewrite bool) error {
 	current, err := LoadSession(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -119,15 +134,20 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 	if bytes.Equal(existingDigest[:], nextDigest[:]) || messagesHavePrefix(next, existing) || messagesHavePrefixWithCompatibleSystem(next, existing) {
 		return nil
 	}
+	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, nextVersion) {
+		return nil
+	}
 	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
 		return fmt.Errorf("%w: %s has %d messages; stale snapshot has %d",
 			ErrSessionSnapshotConflict, path, len(existing), len(next))
 	}
-	if state := s.persistState(path); state.ok && state.version <= nextVersion && bytes.Equal(existingDigest[:], state.digest[:]) {
-		return nil
-	}
 	return fmt.Errorf("%w: %s diverged on disk (%d messages) from snapshot (%d messages)",
 		ErrSessionSnapshotConflict, path, len(existing), len(next))
+}
+
+func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, nextVersion uint64) bool {
+	state := s.persistState(path)
+	return state.ok && state.version <= nextVersion && bytes.Equal(existingDigest[:], state.digest[:])
 }
 
 func (s *Session) persistState(path string) sessionPersistState {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1,14 +1,18 @@
 package agent
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/fileutil"
@@ -18,18 +22,61 @@ import (
 
 const cleanupPendingExt = ".cleanup-pending.json"
 
+var (
+	sessionSaveLocks           sync.Map
+	ErrSessionSnapshotConflict = errors.New("session snapshot conflicts with newer transcript")
+)
+
+type sessionPersistState struct {
+	path    string
+	digest  [sha256.Size]byte
+	version uint64
+	ok      bool
+}
+
 // Save writes the session's messages to path in JSONL — one provider.Message
 // per line — so a user can resume the conversation later. The file is
 // rewritten in full on every save: chat sessions are small (kilobytes), and
 // append-only would have to be reconciled with the compaction pass that
 // mutates the middle of session.Messages.
 func (s *Session) Save(path string) error {
+	return s.save(path, false)
+}
+
+// SaveSnapshot writes a normal autosave/snapshot only when doing so cannot hide
+// a newer transcript already on disk. Explicit history rewrites such as rewind
+// and cancel recovery should call Save instead.
+func (s *Session) SaveSnapshot(path string) error {
+	return s.save(path, true)
+}
+
+func (s *Session) save(path string, protectSnapshot bool) error {
 	if path == "" {
 		return fmt.Errorf("empty session path")
 	}
+	msgs, version := s.snapshotWithVersion()
+	digest, err := digestSessionMessages(msgs)
+	if err != nil {
+		return err
+	}
+	unlock := lockSessionSavePath(path)
+	defer unlock()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
 	}
+	if protectSnapshot {
+		if err := s.checkSnapshotWrite(path, msgs, digest, version); err != nil {
+			return err
+		}
+	}
+	if err := writeSessionMessages(path, msgs); err != nil {
+		return err
+	}
+	s.markPersisted(path, digest, version)
+	return nil
+}
+
+func writeSessionMessages(path string, msgs []provider.Message) error {
 	// Write to a sibling tmp file then rename, so a crash mid-write can't
 	// leave a partial JSONL that won't reload.
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".session.*.tmp")
@@ -38,7 +85,7 @@ func (s *Session) Save(path string) error {
 	}
 	tmpPath := tmp.Name()
 	enc := json.NewEncoder(tmp)
-	for _, m := range s.Snapshot() { // copy under the lock — a turn may be appending
+	for _, m := range msgs {
 		if err := enc.Encode(m); err != nil {
 			tmp.Close()
 			os.Remove(tmpPath)
@@ -54,6 +101,129 @@ func (s *Session) Save(path string) error {
 		return err
 	}
 	return nil
+}
+
+func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextDigest [sha256.Size]byte, nextVersion uint64) error {
+	current, err := LoadSession(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	existing := current.Snapshot()
+	existingDigest, err := digestSessionMessages(existing)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(existingDigest[:], nextDigest[:]) || messagesHavePrefix(next, existing) || messagesHavePrefixWithCompatibleSystem(next, existing) {
+		return nil
+	}
+	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
+		return fmt.Errorf("%w: %s has %d messages; stale snapshot has %d",
+			ErrSessionSnapshotConflict, path, len(existing), len(next))
+	}
+	if state := s.persistState(path); state.ok && state.version <= nextVersion && bytes.Equal(existingDigest[:], state.digest[:]) {
+		return nil
+	}
+	return fmt.Errorf("%w: %s diverged on disk (%d messages) from snapshot (%d messages)",
+		ErrSessionSnapshotConflict, path, len(existing), len(next))
+}
+
+func (s *Session) persistState(path string) sessionPersistState {
+	key := canonicalSessionSavePath(path)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.persisted.ok && s.persisted.path == key {
+		return s.persisted
+	}
+	return sessionPersistState{}
+}
+
+func (s *Session) markPersisted(path string, digest [sha256.Size]byte, version uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.persisted = sessionPersistState{
+		path:    canonicalSessionSavePath(path),
+		digest:  digest,
+		version: version,
+		ok:      true,
+	}
+}
+
+func digestSessionMessages(msgs []provider.Message) ([sha256.Size]byte, error) {
+	h := sha256.New()
+	for _, m := range msgs {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return [sha256.Size]byte{}, err
+		}
+		if _, err := h.Write(b); err != nil {
+			return [sha256.Size]byte{}, err
+		}
+		if _, err := h.Write([]byte{'\n'}); err != nil {
+			return [sha256.Size]byte{}, err
+		}
+	}
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+func messagesHavePrefix(full, prefix []provider.Message) bool {
+	if len(prefix) > len(full) {
+		return false
+	}
+	for i := range prefix {
+		if !messagesEqualForStorage(full[i], prefix[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func messagesHavePrefixWithCompatibleSystem(full, prefix []provider.Message) bool {
+	full = messagesWithoutLeadingSystem(full)
+	prefix = messagesWithoutLeadingSystem(prefix)
+	return messagesHavePrefix(full, prefix)
+}
+
+func messagesWithoutLeadingSystem(msgs []provider.Message) []provider.Message {
+	if len(msgs) > 0 && msgs[0].Role == provider.RoleSystem {
+		return msgs[1:]
+	}
+	return msgs
+}
+
+func messagesEqualForStorage(a, b provider.Message) bool {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
+}
+
+func lockSessionSavePath(path string) func() {
+	key := canonicalSessionSavePath(path)
+	v, _ := sessionSaveLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+func canonicalSessionSavePath(path string) string {
+	key := filepath.Clean(strings.TrimSpace(path))
+	if abs, err := filepath.Abs(key); err == nil {
+		key = abs
+	}
+	if runtime.GOOS == "windows" {
+		key = strings.ToLower(key)
+	}
+	return key
 }
 
 // LoadSession reads a JSONL file written by Save into a fresh Session value.
@@ -96,6 +266,9 @@ func LoadSession(path string) (*Session, error) {
 		s.normalizedDirty = true
 	}
 	s.Messages = normalized
+	if digest, err := digestSessionMessages(s.Messages); err == nil {
+		s.markPersisted(path, digest, s.version)
+	}
 	return s, nil
 }
 

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -199,7 +199,7 @@ func TestSaveSnapshotRejectsStalePrefixAfterSystemPromptRefresh(t *testing.T) {
 	}
 }
 
-func TestSaveSnapshotAllowsOwnedNonPrefixRewrite(t *testing.T) {
+func TestSaveSnapshotRejectsOwnedNonPrefixRewrite(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	s := NewSession("sys")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
@@ -212,8 +212,37 @@ func TestSaveSnapshotAllowsOwnedNonPrefixRewrite(t *testing.T) {
 		{Role: provider.RoleSystem, Content: "sys"},
 		{Role: provider.RoleUser, Content: "summarized first"},
 	})
-	if err := s.SaveSnapshot(path); err != nil {
-		t.Fatalf("SaveSnapshot owned rewrite: %v", err)
+	if err := s.SaveSnapshot(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot owned rewrite err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("message count after rejected snapshot rewrite = %d, want 3", got)
+	}
+	if got := loaded.Messages[2].Content; got != "one" {
+		t.Fatalf("last message after rejected snapshot rewrite = %q, want %q", got, "one")
+	}
+}
+
+func TestSaveRewriteAllowsOwnedNonPrefixRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	s.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "summarized first"},
+	})
+	if err := s.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite owned rewrite: %v", err)
 	}
 
 	loaded, err := LoadSession(path)
@@ -225,6 +254,34 @@ func TestSaveSnapshotAllowsOwnedNonPrefixRewrite(t *testing.T) {
 	}
 	if got := loaded.Messages[1].Content; got != "summarized first" {
 		t.Fatalf("rewritten content = %q, want %q", got, "summarized first")
+	}
+}
+
+func TestSaveRewriteRejectsStalePrefixOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := stale.SaveRewrite(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveRewrite stale err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 4 {
+		t.Fatalf("message count after stale rewrite = %d, want 4", got)
+	}
+	if got := loaded.Messages[3].Content; got != "second" {
+		t.Fatalf("last message after stale rewrite = %q, want %q", got, "second")
 	}
 }
 

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,6 +86,145 @@ func TestSaveLoadLargeMessage(t *testing.T) {
 	}
 	if loaded.Messages[2].Content != big {
 		t.Errorf("large content not round-tripped (got %d bytes, want %d)", len(loaded.Messages[2].Content), len(big))
+	}
+}
+
+func TestSaveSnapshotRejectsStalePrefixOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "two"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := stale.SaveSnapshot(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot stale prefix err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("message count after stale snapshot = %d, want 5", got)
+	}
+	if got := loaded.Messages[4].Content; got != "two" {
+		t.Fatalf("last message after stale snapshot = %q, want %q", got, "two")
+	}
+}
+
+func TestSaveSnapshotAllowsAppendFromDiskPrefix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	next := NewSession("sys")
+	next.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	next.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := next.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("message count after append snapshot = %d, want 3", got)
+	}
+}
+
+func TestSaveSnapshotAllowsAppendAfterSystemPromptRefresh(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("old sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	next := NewSession("new sys")
+	next.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	next.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := next.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot after system refresh: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("message count after system refresh append = %d, want 3", got)
+	}
+	if got := loaded.Messages[0].Content; got != "new sys" {
+		t.Fatalf("system prompt after refresh = %q, want %q", got, "new sys")
+	}
+}
+
+func TestSaveSnapshotRejectsStalePrefixAfterSystemPromptRefresh(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("new sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("old sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := stale.SaveSnapshot(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot stale after system refresh err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 4 {
+		t.Fatalf("message count after stale system refresh snapshot = %d, want 4", got)
+	}
+	if got := loaded.Messages[3].Content; got != "second" {
+		t.Fatalf("last message after stale system refresh snapshot = %q, want %q", got, "second")
+	}
+}
+
+func TestSaveSnapshotAllowsOwnedNonPrefixRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	s.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "summarized first"},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot owned rewrite: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 2 {
+		t.Fatalf("message count after rewrite = %d, want 2", got)
+	}
+	if got := loaded.Messages[1].Content; got != "summarized first" {
+		t.Fatalf("rewritten content = %q, want %q", got, "summarized first")
 	}
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -16,7 +16,9 @@ import (
 type Session struct {
 	mu             sync.RWMutex
 	Messages       []provider.Message
+	version        uint64
 	rewriteVersion int // bumped each time the log is rewritten (compact/fold)
+	persisted      sessionPersistState
 	// normalizedDirty is set when LoadSession repaired the history on the way in
 	// (empty tool-call names, dangling calls, truncated args, …). The repair
 	// already lives in Messages, so the next Save persists it automatically as
@@ -39,6 +41,7 @@ func (s *Session) Add(m provider.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, m)
+	s.version++
 }
 
 // Replace swaps the whole message log — used by compaction, which rewrites the
@@ -47,22 +50,37 @@ func (s *Session) Replace(msgs []provider.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = msgs
+	s.version++
 }
 
 // Snapshot returns a copy of the messages, safe to read from another goroutine
 // while a turn appends. Frontends (History, Save) use it instead of touching the
 // live slice.
 func (s *Session) Snapshot() []provider.Message {
+	msgs, _ := s.snapshotWithVersion()
+	return msgs
+}
+
+func (s *Session) snapshotWithVersion() ([]provider.Message, uint64) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return append([]provider.Message(nil), s.Messages...)
+	return append([]provider.Message(nil), s.Messages...), s.version
 }
 
 // RewriteVersion returns the current rewrite version.
-func (s *Session) RewriteVersion() int { return s.rewriteVersion }
+func (s *Session) RewriteVersion() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rewriteVersion
+}
 
 // IncrementRewrite bumps the rewrite version by 1.
-func (s *Session) IncrementRewrite() { s.rewriteVersion++ }
+func (s *Session) IncrementRewrite() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rewriteVersion++
+	s.version++
+}
 
 // HasContent returns true when the session carries at least one user,
 // assistant, or tool message — i.e. more than just a system prompt. An

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2523,7 +2523,7 @@ func (c *Controller) maybeColdResumePrune(path string) {
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
 		"resumed after %s idle (provider cache expired) — elided %d stale tool results to cheapen the cold restart",
 		time.Since(last).Round(time.Minute), st.Results)})
-	if err := c.Snapshot(); err != nil {
+	if err := c.SnapshotRewrite(); err != nil {
 		slog.Warn("controller: post-prune snapshot", "err", err)
 	}
 }
@@ -2613,7 +2613,7 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	}
 	var err error
 	if forceRewrite {
-		err = s.Save(path)
+		err = s.SaveRewrite(path)
 	} else {
 		err = s.SaveSnapshot(path)
 	}
@@ -2743,16 +2743,16 @@ func (c *Controller) replaceSessionAfterCancel(msgs []provider.Message) {
 	// the in_progress items written by the cancelled turn.
 	c.executor.RebuildTodoState()
 	// The mid-turn autosave may have already written a partial transcript to
-	// disk.  snapshotActivityIfChanged skips the write when messageCount()
-	// returns to startMessages, so force a flush here to overwrite the stale
-	// file.  We call Session.Save directly to cover the edge case where the
-	// strip leaves only a system message (HasContent() == false), which would
-	// cause snapshot() to return early without writing.
+	// disk. snapshotActivityIfChanged skips the write when messageCount()
+	// returns to startMessages, so flush the cleaned transcript here. SaveRewrite
+	// still checks that this controller owns the current on-disk baseline before
+	// overwriting it, and also covers the edge case where the strip leaves only a
+	// system message (HasContent() == false).
 	c.mu.Lock()
 	path := c.sessionPath
 	c.mu.Unlock()
 	if path != "" {
-		if err := c.executor.Session().Save(path); err != nil {
+		if err := c.executor.Session().SaveRewrite(path); err != nil {
 			slog.Warn("controller: post-cancel transcript flush", "err", err)
 		}
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -761,7 +761,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 				c.notice("compaction failed: " + err.Error())
 			} else {
 				c.notice("compacted")
-				if err := c.Snapshot(); err != nil {
+				if err := c.SnapshotRewrite(); err != nil {
 					slog.Warn("controller: snapshot after compact", "err", err)
 				}
 			}
@@ -2149,7 +2149,7 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 		}
 		s.Messages = s.Messages[:boundary]
 		c.checkpoints.truncateFrom(turn) // renumber future turns from here; later turns are gone
-		if err := c.Snapshot(); err != nil {
+		if err := c.SnapshotRewrite(); err != nil {
 			slog.Warn("controller: snapshot after rewind", "err", err)
 		}
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -2439,7 +2439,7 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 	// the turn counter monotonic so new turns don't collide with the store) —
 	// conversation rewind degrades to "unavailable" until fresh turns rebuild them.
 	c.checkpoints.clearBounds()
-	if err := c.Snapshot(); err != nil {
+	if err := c.SnapshotRewrite(); err != nil {
 		slog.Warn("controller: post-summarize snapshot", "err", err)
 	}
 	return nil
@@ -2534,7 +2534,7 @@ func (c *Controller) maybeColdResumePrune(path string) {
 // path, so a misconfigured deployment surfaces instead of dropping data.
 // Called after every turn so a crash loses at most one in-flight prompt.
 func (c *Controller) Snapshot() error {
-	return c.snapshot(false)
+	return c.snapshot(false, false)
 }
 
 // SnapshotActivity writes the active conversation and marks the session as
@@ -2542,7 +2542,14 @@ func (c *Controller) Snapshot() error {
 // transcript; switch/close snapshots should call Snapshot so they do not reorder
 // recent-session pickers.
 func (c *Controller) SnapshotActivity() error {
-	return c.snapshot(true)
+	return c.snapshot(true, false)
+}
+
+// SnapshotRewrite persists an intentional history rewrite, such as rewind or
+// manual compaction. Ordinary autosave paths should use Snapshot so stale
+// controllers cannot overwrite a newer transcript.
+func (c *Controller) SnapshotRewrite() error {
+	return c.snapshot(false, true)
 }
 
 // midTurnSnapshotInterval is atomic (nanoseconds) so a test shrinking it
@@ -2563,14 +2570,14 @@ func (c *Controller) autosaveWhileRunning(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			if err := c.snapshot(false); err != nil {
+			if err := c.snapshot(false, false); err != nil {
 				slog.Warn("controller: mid-turn snapshot", "err", err)
 			}
 		}
 	}
 }
 
-func (c *Controller) snapshot(markActivity bool) error {
+func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	c.mu.Lock()
 	path := c.sessionPath
 	modelRef := c.modelRef
@@ -2604,7 +2611,13 @@ func (c *Controller) snapshot(markActivity bool) error {
 			"label", c.Label(), "session_dir", c.SessionDir())
 		return errNoSessionPath
 	}
-	if err := s.Save(path); err != nil {
+	var err error
+	if forceRewrite {
+		err = s.Save(path)
+	} else {
+		err = s.SaveSnapshot(path)
+	}
+	if err != nil {
 		return err
 	}
 	// Persist guardian session so the prefix cache stays warm after restart.
@@ -2673,7 +2686,7 @@ func (c *Controller) recoverInterruptedTurn(path string) {
 		} else {
 			c.stripTurnMessagesAfter(marker.StartMessageIndex)
 		}
-		if err := c.snapshot(false); err != nil {
+		if err := c.snapshot(false, true); err != nil {
 			slog.Warn("controller: post-interrupted-turn snapshot", "err", err)
 		}
 	}

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -646,6 +646,86 @@ func TestSnapshotRejectsStaleControllerOverwrite(t *testing.T) {
 	}
 }
 
+func TestSnapshotRewriteRejectsStaleControllerOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "two"})
+	currentExec := agent.New(nil, nil, currentSess, agent.Options{}, event.Discard)
+	current := New(Options{Executor: currentExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := current.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity current: %v", err)
+	}
+
+	staleSess.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "summarized first"},
+	})
+	if err := stale.SnapshotRewrite(); !errors.Is(err, agent.ErrSessionSnapshotConflict) {
+		t.Fatalf("SnapshotRewrite stale err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("message count after stale rewrite = %d, want 5", got)
+	}
+	if got := loaded.Messages[4].Content; got != "two" {
+		t.Fatalf("last message after stale rewrite = %q, want %q", got, "two")
+	}
+}
+
+func TestCancelFlushRejectsStaleControllerOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "partial"})
+	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "two"})
+	currentExec := agent.New(nil, nil, currentSess, agent.Options{}, event.Discard)
+	current := New(Options{Executor: currentExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := current.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity current: %v", err)
+	}
+
+	stale.replaceSessionAfterCancel([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "first"},
+	})
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("message count after stale cancel flush = %d, want 5", got)
+	}
+	if got := loaded.Messages[4].Content; got != "two" {
+		t.Fatalf("last message after stale cancel flush = %q, want %q", got, "two")
+	}
+}
+
 func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -605,6 +606,43 @@ func TestSnapshotDoesNotRefreshSessionActivity(t *testing.T) {
 	}
 	if second.Model != "provider/model-a" {
 		t.Fatalf("snapshot model = %q, want provider/model-a", second.Model)
+	}
+}
+
+func TestSnapshotRejectsStaleControllerOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "two"})
+	currentExec := agent.New(nil, nil, currentSess, agent.Options{}, event.Discard)
+	current := New(Options{Executor: currentExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := current.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity current: %v", err)
+	}
+
+	if err := stale.Snapshot(); !errors.Is(err, agent.ErrSessionSnapshotConflict) {
+		t.Fatalf("Snapshot stale err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("message count after stale snapshot = %d, want 5", got)
+	}
+	if got := loaded.Messages[4].Content; got != "two" {
+		t.Fatalf("last message after stale snapshot = %q, want %q", got, "two")
 	}
 }
 


### PR DESCRIPTION
Closes #5783.

## Summary

- Add protected session save modes for normal snapshots and intentional history rewrites.
- Reject stale controller snapshots that would overwrite a newer transcript already persisted on disk.
- Allow explicit rewrites (`compact`, rewind, cold-resume pruning, interrupted-turn/cancel recovery) only when the controller still owns the current on-disk transcript baseline.
- Let desktop session removal skip stale runtime snapshots while preserving the newer on-disk transcript for trash/removal flows.

## Root cause

Normal controller snapshots rewrote the whole JSONL file. If an older tab/runtime still held a shorter in-memory session for the same session path, a later autosave or tab close could replace the newer JSONL with that stale snapshot, making messages appear to roll back or disappear.

## Validation

- `go test ./internal/agent ./internal/control`
- `cd desktop && go test .`
- `git diff --check`
- `go test ./internal/environment -run TestRunProbesUsesOverridePathAndFirstLine -count=1`

Note: `go test ./...` was also attempted; the only failure was the same intermittent `internal/environment` probe timeout, and the focused probe test passed when rerun separately.
