### PR TITLE
fix: allow block comment prompts

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1249,8 +1249,8 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Slash commands run locally without going through the model. A
 			// '/'-leading line that's actually a dragged file path is an attachment,
 			// not a command, so it's rewritten to an @reference instead.
-			if strings.HasPrefix(line, "//") {
-				// Double-slash — common in JS comments, file:// URLs, etc.
+			if control.SlashCodeCommentLine(line) {
+				// Slash-prefixed code comments are prompt text, not commands.
 				// Not a command. Fall through to normal message path.
 			} else if strings.HasPrefix(line, "/") {
 				if ref, ok := control.FileRefLine(line); ok {

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2249,6 +2249,56 @@ func TestPasteFoldExpandOnSubmit(t *testing.T) {
 	}
 }
 
+func TestSlashCodeCommentSubmitStartsTurn(t *testing.T) {
+	for _, input := range []string{
+		"// explain this",
+		"/**\n * 阿明\n */",
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := &recordingTurnRunner{}
+			events := make(chan event.Event, 8)
+			ctrl := control.New(control.Options{
+				AutoPlan: "off",
+				Runner:   r,
+				Sink:     event.FuncSink(func(e event.Event) { events <- e }),
+			})
+			m := newTestChatTUI()
+			m.ctrl = ctrl
+			m.input.SetValue(input)
+
+			model, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			m = model.(chatTUI)
+			waitForCLIEvent(t, events, event.TurnDone)
+
+			if len(r.inputs) != 1 || r.inputs[0] != input {
+				t.Fatalf("slash code comment should start a model turn, inputs=%q", r.inputs)
+			}
+		})
+	}
+}
+
+func TestUnknownSlashCommandDoesNotStartTurn(t *testing.T) {
+	r := &recordingTurnRunner{}
+	ctrl := control.New(control.Options{
+		AutoPlan: "off",
+		Runner:   r,
+		Sink:     event.FuncSink(func(event.Event) {}),
+	})
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	m.input.SetValue("/definitely-not-a-command")
+
+	model, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = model.(chatTUI)
+
+	if len(r.inputs) != 0 {
+		t.Fatalf("unknown slash command should not start a model turn, inputs=%q", r.inputs)
+	}
+	if got := strings.Join(m.transcript, "\n"); !strings.Contains(got, "unknown command") {
+		t.Fatalf("unknown slash command should be reported in transcript, got:\n%s", got)
+	}
+}
+
 func TestPasteMsgFoldsBeforeTextareaConsumesNewlines(t *testing.T) {
 	m := newTestChatTUI()
 	model, _ := m.Update(tea.PasteMsg{Content: "1\n2\n3\n4\n5"})

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -794,9 +794,8 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			}
 			return runGoalLoop(ctx, sent, sent, display)
 		})
-	case strings.HasPrefix(trimmed, "//"):
-		// Double-slash — not a command. Common in code snippets (JS
-		// comments, file:// URLs). Run as a normal turn.
+	case strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*"):
+		// Slash-prefixed code comments are prompt text, not slash commands.
 		runRefTurn(input, display)
 	case strings.HasPrefix(trimmed, "/"):
 		if ref, ok := FileRefLine(trimmed); ok {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -794,7 +794,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			}
 			return runGoalLoop(ctx, sent, sent, display)
 		})
-	case strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*"):
+	case SlashCodeCommentLine(trimmed):
 		// Slash-prefixed code comments are prompt text, not slash commands.
 		runRefTurn(input, display)
 	case strings.HasPrefix(trimmed, "/"):

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -643,6 +643,26 @@ func TestSubmitMissingSlashPathDiagnosticStartsTurn(t *testing.T) {
 	}
 }
 
+func TestSubmitBlockCommentPrefixStartsTurn(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		AutoPlan: "off",
+		Runner:   runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+	})
+
+	input := "/**\n * 阿明\n */"
+	c.Submit(input)
+	waitForTurnDone(t, events)
+
+	if len(runner.inputs) != 1 || runner.inputs[0] != input {
+		t.Fatalf("block comment prefix should start a model turn, inputs=%q", runner.inputs)
+	}
+}
+
 func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	events := make(chan event.Event, 4)

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -644,6 +644,13 @@ func FileRefLine(line string) (string, bool) {
 	return "@" + p, true
 }
 
+// SlashCodeCommentLine reports whether a slash-prefixed line is ordinary source
+// text rather than a Reasonix slash command.
+func SlashCodeCommentLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*")
+}
+
 // SlashPathLineRef reports whether a slash-prefixed line starts with a local file
 // path, including common compiler-location suffixes like ":12" or ":12:34".
 // It returns an @reference for the file so diagnostics that begin with an

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -33,6 +33,26 @@ func TestFileRefLine(t *testing.T) {
 	}
 }
 
+func TestSlashCodeCommentLine(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{"// explain this", true},
+		{"  /* explain this */", true},
+		{"/**\n * explain this\n */", true},
+		{"/compact", false},
+		{"/mcp__server__prompt", false},
+		{"/missing/Foo.kt:12: error", false},
+		{"hello", false},
+	}
+	for _, c := range cases {
+		if got := SlashCodeCommentLine(c.line); got != c.want {
+			t.Errorf("SlashCodeCommentLine(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}
+
 func TestParseRefTokens(t *testing.T) {
 	cases := []struct {
 		line string


### PR DESCRIPTION
## Summary

- Treat slash-prefixed code comments (`//` and `/*`, including `/**`) as ordinary prompt text instead of slash commands.
- Add regression coverage for a `/**` prompt so it starts a model turn while unknown slash commands still stay guarded.
- Refs https://github.com/esengine/DeepSeek-Reasonix/issues/5836#issuecomment-4873837039

## Verification

- `go test ./internal/control -run 'TestSubmitBlockCommentPrefixStartsTurn|TestSubmitUnknownSlashCommandStillReportsNotice'`
- `git diff --check`

## Cache impact

Cache-impact: none - this only changes slash-command classification for literal comment text; no system prompt, memory prefix, or cached context shape changes.
Cache-guard: `go test ./internal/control -run 'TestSubmitBlockCommentPrefixStartsTurn|TestSubmitUnknownSlashCommandStillReportsNotice'`
System-prompt-review: N/A
