### PR TITLE
fix(session): recover stale controller transcripts

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -668,6 +668,7 @@ func (a *App) shutdown(context.Context) {
 				slog.Warn("desktop: shutdown snapshot failed", "tab", t.ID, "err", err)
 			}
 			t.Ctrl.Close()
+			t.releaseSessionLease()
 		}
 	}
 }
@@ -1435,6 +1436,9 @@ func (a *App) ClearSession() error {
 	if err := ctrl.ClearSession(); err != nil {
 		return err
 	}
+	if err := tab.ensureSessionLease(ctrl.SessionPath()); err != nil {
+		return err
+	}
 	tab.resetTelemetry()
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
@@ -1512,6 +1516,10 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
 	newCtrl.SetGoal(tab.goal)
 	path := agent.NewSessionPath(newCtrl.SessionDir(), newCtrl.Label())
+	if err := tab.ensureSessionLease(path); err != nil {
+		newCtrl.Close()
+		return err
+	}
 	newCtrl.SetSessionPath(path)
 
 	a.mu.Lock()
@@ -2413,6 +2421,7 @@ func (a *App) closeRemovedSessionRuntime(item removedSessionRuntime, closed map[
 				releasedTabs[item.tab] = true
 			}
 			a.releaseTabSharedHost(item.tab)
+			item.tab.releaseSessionLease()
 		}
 	}
 	if item.ctrl == nil {
@@ -2817,6 +2826,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		}
 	} else {
 		ctrl.Close()
+		tab.releaseSessionLease()
 	}
 
 	a.mu.Lock()
@@ -6605,9 +6615,23 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
+		tab.releaseSessionLease()
 		return err
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
+	newCtrl.EnableInteractiveApproval()
+	applyTabModeToController(newCtrl, tab.mode)
+	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
+	newCtrl.SetGoal(tab.goal)
+
+	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
+	if err := tab.ensureSessionLease(path); err != nil {
+		newCtrl.Close()
+		tab.releaseSessionLease()
+		return err
+	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
+	a.persistTabSessionPath(tab, path)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.model = name
@@ -6615,14 +6639,6 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	tab.Label = newCtrl.Label()
 	a.saveTabsLocked()
 	a.mu.Unlock()
-	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
-
-	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
-	a.persistTabSessionPath(tab, path)
 	return nil
 }
 
@@ -6709,9 +6725,22 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
+		tab.releaseSessionLease()
 		return err
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
+	newCtrl.EnableInteractiveApproval()
+	applyTabModeToController(newCtrl, tab.mode)
+	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
+	newCtrl.SetGoal(tab.goal)
+	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
+	if err := tab.ensureSessionLease(path); err != nil {
+		newCtrl.Close()
+		tab.releaseSessionLease()
+		return err
+	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
+	a.persistTabSessionPath(tab, path)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.model = modelRef
@@ -6721,13 +6750,6 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.Ready = true
 	a.saveTabsLocked()
 	a.mu.Unlock()
-	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
-	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
-	a.persistTabSessionPath(tab, path)
 	return nil
 }
 
@@ -6792,9 +6814,20 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		return err
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
+	newCtrl.EnableInteractiveApproval()
+	applyTabModeToController(newCtrl, tab.mode)
+	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
+	newCtrl.SetGoal(tab.goal)
+	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
+	if err := tab.ensureSessionLease(path); err != nil {
+		newCtrl.Close()
+		return err
+	}
+	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	if oldCtrl != nil {
 		oldCtrl.Close()
 	}
+	a.persistTabSessionPath(tab, path)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.model = modelRef
@@ -6804,13 +6837,6 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	tab.Ready = true
 	a.saveTabsLocked()
 	a.mu.Unlock()
-	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
-	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
-	a.persistTabSessionPath(tab, path)
 	return nil
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1479,6 +1479,8 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 		TokenMode:                currentTabTokenMode(tab),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		if teardownTimedOut {
@@ -6599,6 +6601,8 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		TokenMode:                currentTabTokenMode(tab),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		return err
@@ -6701,6 +6705,8 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		TokenMode:                currentTabTokenMode(tab),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		return err
@@ -6779,6 +6785,8 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		TokenMode:                mode,
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		return err

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -278,6 +279,89 @@ func TestDesktopSnapshotConflictRecoveryUpdatesTabAndProjectTree(t *testing.T) {
 	walk(nodes)
 	if !found {
 		t.Fatalf("project tree did not include recovery topic %q: %#v", tab.TopicID, nodes)
+	}
+}
+
+func TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	originalPath := filepath.Join(dir, "session.jsonl")
+	current := agent.NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(originalPath); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	recovery, err := staleSess.SaveRecoveryBranch(agent.RecoveryBranchOptions{
+		OriginalPath: originalPath,
+		BranchMeta: agent.BranchMeta{
+			Name:       agent.RecoveryBranchDefaultName,
+			Scope:      "global",
+			TopicID:    "topic_recovery",
+			TopicTitle: "Recovery",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(recovery.Path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease recovery: %v", err)
+	}
+	defer lease.Release()
+
+	staleExec := agent.New(stubProvider{}, tool.NewRegistry(), staleSess, agent.Options{}, event.Discard)
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{},
+		detachedSessions: map[string]*WorkspaceTab{},
+		activeTabID:      "recovery_tab",
+	}
+	tab := &WorkspaceTab{
+		ID:            "recovery_tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		TopicID:       "topic_original",
+		TopicTitle:    "Original",
+		SessionPath:   originalPath,
+		Ready:         true,
+		model:         "test-model",
+		disabledMCP:   map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	tab.Ctrl = control.New(control.Options{
+		Executor:            staleExec,
+		SessionDir:          dir,
+		SessionPath:         originalPath,
+		Label:               "test",
+		Sink:                tab.sink,
+		SessionRecoveryMeta: app.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
+	})
+	app.tabs[tab.ID] = tab
+
+	err = tab.Ctrl.Snapshot()
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("Snapshot err = %v, want ErrSessionLeaseHeld", err)
+	}
+	if got := tab.Ctrl.SessionPath(); got != originalPath {
+		t.Fatalf("controller session path = %q, want original %q", got, originalPath)
+	}
+	if tab.SessionPath != originalPath {
+		t.Fatalf("tab session path = %q, want original %q", tab.SessionPath, originalPath)
+	}
+	if tab.TopicID != "topic_original" {
+		t.Fatalf("tab topic ID = %q, want original topic", tab.TopicID)
 	}
 }
 

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -322,10 +322,19 @@ func TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease(t *testing.T) {
 	defer lease.Release()
 
 	staleExec := agent.New(stubProvider{}, tool.NewRegistry(), staleSess, agent.Options{}, event.Discard)
+	runtimeEvents := make(chan runtimeEventEnvelope, 4)
 	app := &App{
+		ctx:              context.Background(),
 		tabs:             map[string]*WorkspaceTab{},
 		detachedSessions: map[string]*WorkspaceTab{},
 		activeTabID:      "recovery_tab",
+	}
+	app.runtimeEvents.emit = func(ctx context.Context, name string, payload ...interface{}) {
+		runtimeEvents <- runtimeEventEnvelope{
+			ctx:     ctx,
+			name:    name,
+			payload: append([]interface{}(nil), payload...),
+		}
 	}
 	tab := &WorkspaceTab{
 		ID:            "recovery_tab",
@@ -362,6 +371,29 @@ func TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease(t *testing.T) {
 	}
 	if tab.TopicID != "topic_original" {
 		t.Fatalf("tab topic ID = %q, want original topic", tab.TopicID)
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case emitted := <-runtimeEvents:
+			if emitted.name != "session:recovery-failed" {
+				continue
+			}
+			if len(emitted.payload) != 1 {
+				t.Fatalf("session:recovery-failed payload count = %d, want 1", len(emitted.payload))
+			}
+			failed, ok := emitted.payload[0].(sessionRecoveryFailedEvent)
+			if !ok {
+				t.Fatalf("session:recovery-failed payload type = %T, want sessionRecoveryFailedEvent", emitted.payload[0])
+			}
+			if failed.Reason != "lease_held" {
+				t.Fatalf("session:recovery-failed reason = %q, want lease_held", failed.Reason)
+			}
+			return
+		case <-deadline:
+			t.Fatal("session:recovery-failed event was not emitted")
+		}
 	}
 }
 

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -173,6 +173,114 @@ func TestAutosaveFailureRetriesAndRecoversOnNextTurnDone(t *testing.T) {
 	}
 }
 
+func TestDesktopSnapshotConflictRecoveryUpdatesTabAndProjectTree(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	originalPath := filepath.Join(dir, "session.jsonl")
+	originalTopic := "topic_original"
+	if err := setTopicTitle("", originalTopic, "Original"); err != nil {
+		t.Fatalf("set original topic title: %v", err)
+	}
+	current := agent.NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(originalPath); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+	if err := agent.SaveBranchMeta(originalPath, agent.BranchMeta{
+		Scope:         "global",
+		TopicID:       originalTopic,
+		TopicTitle:    "Original",
+		Preview:       "first",
+		Turns:         2,
+		SchemaVersion: agent.BranchMetaCountsVersion,
+	}); err != nil {
+		t.Fatalf("SaveBranchMeta original: %v", err)
+	}
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	staleExec := agent.New(stubProvider{}, tool.NewRegistry(), staleSess, agent.Options{}, event.Discard)
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{},
+		detachedSessions: map[string]*WorkspaceTab{},
+		activeTabID:      "recovery_tab",
+	}
+	tab := &WorkspaceTab{
+		ID:            "recovery_tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		TopicID:       originalTopic,
+		TopicTitle:    "Original",
+		SessionPath:   originalPath,
+		Ready:         true,
+		model:         "test-model",
+		disabledMCP:   map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	tab.Ctrl = control.New(control.Options{
+		Executor:            staleExec,
+		SessionDir:          dir,
+		SessionPath:         originalPath,
+		Label:               "test",
+		Sink:                tab.sink,
+		SessionRecoveryMeta: app.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
+	})
+	app.tabs[tab.ID] = tab
+
+	if err := tab.Ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	recoveryPath := tab.Ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath {
+		t.Fatalf("recovery path = %q, want distinct path", recoveryPath)
+	}
+	if tab.SessionPath != recoveryPath {
+		t.Fatalf("tab session path = %q, want recovery path %q", tab.SessionPath, recoveryPath)
+	}
+	if tab.TopicID == "" || tab.TopicID == originalTopic {
+		t.Fatalf("tab topic ID = %q, want fresh recovery topic", tab.TopicID)
+	}
+	meta, ok, err := agent.LoadBranchMeta(recoveryPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recovery ok=%v err=%v", ok, err)
+	}
+	if !meta.Recovered || meta.TopicID != tab.TopicID || meta.TopicTitle != tab.TopicTitle {
+		t.Fatalf("recovery meta = %+v, tab topic=%q/%q", meta, tab.TopicID, tab.TopicTitle)
+	}
+	tabMeta := app.tabMeta(tab, true)
+	if !tabMeta.Recovered || tabMeta.RecoveryDigest != meta.RecoveryDigest || tabMeta.RecoveryParentID != string(meta.ParentID) {
+		t.Fatalf("tab recovery meta = %+v, want digest %q parent %q", tabMeta, meta.RecoveryDigest, meta.ParentID)
+	}
+	nodes := app.ListProjectTree()
+	found := false
+	var walk func([]ProjectNode)
+	walk = func(list []ProjectNode) {
+		for _, node := range list {
+			if node.TopicID == tab.TopicID {
+				found = true
+				if !node.Recovered || node.RecoveryDigest != meta.RecoveryDigest || node.RecoveryParentID != string(meta.ParentID) {
+					t.Fatalf("project tree recovery node = %+v, want digest %q parent %q", node, meta.RecoveryDigest, meta.ParentID)
+				}
+			}
+			walk(node.Children)
+		}
+	}
+	walk(nodes)
+	if !found {
+		t.Fatalf("project tree did not include recovery topic %q: %#v", tab.TopicID, nodes)
+	}
+}
+
 func TestSetActiveTabBlocksWhenCurrentSessionCannotPersist(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "blocked.jsonl")
 	if err := os.Mkdir(path, 0o755); err != nil {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onSessionRecovered } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged, onSessionRecovered, onSessionRecoveryFailed } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { playSuccessChime } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
@@ -2611,6 +2611,13 @@ export default function App() {
         : { durationMs: 9000 });
     });
   }, [enqueueNavigation, refreshTabMetas, showToast, t]);
+
+  useEffect(() => {
+    return onSessionRecoveryFailed((event) => {
+      const key = event.reason === "lease_held" ? "recovery.failedLease" : "recovery.failedUnavailable";
+      showToast(t(key), "error", { durationMs: 9000 });
+    });
+  }, [showToast, t]);
 
   const handleNewTab = useCallback(async () => {
     closeTransientOverlays();

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged, onSessionRecovered } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { playSuccessChime } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
@@ -2588,6 +2588,30 @@ export default function App() {
     enqueueNavigation({ kind: "blank", scope, workspaceRoot: scope === "project" ? workspaceRoot : "" }),
   [enqueueNavigation]);
 
+  useEffect(() => {
+    return onSessionRecovered((event) => {
+      const scope = event.scope === "project" ? "project" : "global";
+      const workspaceRoot = scope === "project" ? event.workspaceRoot || "" : "";
+      setProjectRevision((value) => value + 1);
+      void refreshTabMetas();
+      showToast(t("recovery.toast", { title: event.topicTitle || t("recovery.branch") }), "warn", event.topicId
+        ? {
+            actionLabel: t("recovery.open"),
+            durationMs: 9000,
+            onAction: () => {
+              void enqueueNavigation({
+                kind: "topic",
+                scope,
+                workspaceRoot,
+                topicId: event.topicId || "",
+                sessionPath: event.recoveryPath || "",
+              });
+            },
+          }
+        : { durationMs: 9000 });
+    });
+  }, [enqueueNavigation, refreshTabMetas, showToast, t]);
+
   const handleNewTab = useCallback(async () => {
     closeTransientOverlays();
     setSidebarImDetailConnectionId("");
@@ -2848,6 +2872,13 @@ export default function App() {
     : [topicbarWorkspacePath || topicbarWorkspaceLabel, topicbarImSourceLabel].filter(Boolean).join(" · ");
   const topicbarCanRename = !sidebarImDetailConnection && Boolean(activeTab?.topicId);
   const topicbarTitleEditSize = Math.min(56, Math.max(4, topicTitleDraft.length || topicbarTitle.length || 1));
+  const recoveryBannerTitle = activeTab?.recovered
+    ? [
+        activeTab.recoveryReason ? t("recovery.reason", { reason: activeTab.recoveryReason }) : "",
+        activeTab.recoveryDigest ? t("recovery.digest", { digest: activeTab.recoveryDigest.slice(0, 12) }) : "",
+        activeTab.recoveryParentId ? t("recovery.parent", { parent: activeTab.recoveryParentId }) : "",
+      ].filter(Boolean).join(" · ")
+    : "";
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
   const windowsFramelessChrome = desktopPlatform === "windows";
   const handleWindowsTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
@@ -3397,6 +3428,13 @@ export default function App() {
 
           {state.meta?.startupErr && (
             <div className="banner banner--error">{t("topbar.startupError", { msg: state.meta.startupErr })}</div>
+          )}
+
+          {activeTab?.recovered && !sidebarImDetailConnection && (
+            <div className="banner banner--recovery" title={recoveryBannerTitle || undefined}>
+              <span className="banner__badge">{t("recovery.branch")}</span>
+              <span>{t("recovery.banner")}</span>
+            </div>
           )}
 
           <UpdateBanner enabled={startupUpdateChecksEnabled === true} />

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1140,7 +1140,15 @@ export function ProjectTree({
       const imSourceLabel = imSource?.label || "";
       const imSourceTitle = imSourceLabel ? t("msg.fromIm", { source: imSourceLabel }) : "";
       const imSourcePlatform = (imSource?.platform || "im").replace(/[^a-z0-9_-]/gi, "").toLowerCase() || "im";
-      const title = [label, imSourceTitle, statusLabel, meta, exactTimeLabel].filter(Boolean).join(" · ");
+      const recovered = Boolean(node.recovered);
+      const recoveryTitle = recovered
+        ? [
+            t("recovery.branch"),
+            node.recoveryReason ? t("recovery.reason", { reason: node.recoveryReason }) : "",
+            node.recoveryDigest ? t("recovery.digest", { digest: node.recoveryDigest.slice(0, 12) }) : "",
+          ].filter(Boolean).join(" · ")
+        : "";
+      const title = [label, recoveryTitle, imSourceTitle, statusLabel, meta, exactTimeLabel].filter(Boolean).join(" · ");
       const topicMenuOpen = !isSessionNode && menuTopic === topicId;
       const pinned = Boolean(node.pinned);
       const pinLabel = t(pinned ? "projectTree.unpinTopic" : "projectTree.pinTopic");
@@ -1217,7 +1225,7 @@ export function ProjectTree({
       }
       const row = (
         <div
-          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${unread ? " project-tree__topic--unread" : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${sideTimeVisible && (timeLabel || showStatusInSide) ? " project-tree__topic--with-side" : meta ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
+          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${unread ? " project-tree__topic--unread" : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${recovered ? " project-tree__topic--recovered" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${sideTimeVisible && (timeLabel || showStatusInSide) ? " project-tree__topic--with-side" : meta ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
           style={accentStyle}
           onContextMenu={isSessionNode ? undefined : openTopicMenu}
         >
@@ -1271,6 +1279,11 @@ export function ProjectTree({
                   </span>
                 )}
                 {!compactTopics && statusLabel && <span className={`project-tree__topic-status project-tree__topic-status--${status}`}>{statusLabel}</span>}
+                {recovered && (
+                  <span className="project-tree__topic-recovery" title={recoveryTitle}>
+                    {t("recovery.badge")}
+                  </span>
+                )}
               </span>
               {!compactTopics && !creationTopics && meta && (
                 <span className="project-tree__topic-meta">
@@ -1292,6 +1305,11 @@ export function ProjectTree({
             {compactTopics && meta && (
               <span className="sr-only">
                 {meta}
+              </span>
+            )}
+            {compactTopics && recovered && (
+              <span className="sr-only">
+                {t("recovery.branch")}
               </span>
             )}
           </button>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -57,6 +57,7 @@ import type {
   QuestionAnswer,
   ServerView,
   SessionMeta,
+  SessionRecoveryEvent,
   SettingsView,
   SkillsSettingsView,
   SkillRootView,
@@ -578,6 +579,13 @@ export function onReady(cb: (tabId?: string) => void): () => void {
 export function onProjectTreeChanged(cb: () => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn("project-tree:changed", () => cb());
+  }
+  return () => {};
+}
+
+export function onSessionRecovered(cb: (payload: SessionRecoveryEvent) => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("session:recovered", (payload?: unknown) => cb((payload ?? {}) as SessionRecoveryEvent));
   }
   return () => {};
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -57,6 +57,7 @@ import type {
   QuestionAnswer,
   ServerView,
   SessionMeta,
+  SessionRecoveryFailedEvent,
   SessionRecoveryEvent,
   SettingsView,
   SkillsSettingsView,
@@ -586,6 +587,13 @@ export function onProjectTreeChanged(cb: () => void): () => void {
 export function onSessionRecovered(cb: (payload: SessionRecoveryEvent) => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn("session:recovered", (payload?: unknown) => cb((payload ?? {}) as SessionRecoveryEvent));
+  }
+  return () => {};
+}
+
+export function onSessionRecoveryFailed(cb: (payload: SessionRecoveryFailedEvent) => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("session:recovery-failed", (payload?: unknown) => cb((payload ?? {}) as SessionRecoveryFailedEvent));
   }
   return () => {};
 }

--- a/desktop/frontend/src/lib/toast.tsx
+++ b/desktop/frontend/src/lib/toast.tsx
@@ -4,11 +4,19 @@ export interface Toast {
   id: number;
   text: string;
   level: "info" | "warn" | "error";
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export interface ToastOptions {
+  actionLabel?: string;
+  onAction?: () => void;
+  durationMs?: number;
 }
 
 export interface ToastContextValue {
   toasts: Toast[];
-  showToast: (text: string, level?: Toast["level"]) => void;
+  showToast: (text: string, level?: Toast["level"], options?: ToastOptions) => void;
 }
 
 const ToastContext = createContext<ToastContextValue>({ toasts: [], showToast: () => {} });
@@ -23,13 +31,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const timers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
 
-  const showToast = useCallback((text: string, level: Toast["level"] = "info") => {
+  const showToast = useCallback((text: string, level: Toast["level"] = "info", options: ToastOptions = {}) => {
     const id = nextId++;
-    setToasts((prev) => [...prev, { id, text, level }]);
+    setToasts((prev) => [...prev, { id, text, level, actionLabel: options.actionLabel, onAction: options.onAction }]);
     const timer = setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id));
       timers.current.delete(id);
-    }, 2500);
+    }, options.durationMs ?? (options.actionLabel ? 8000 : 2500));
     timers.current.set(id, timer);
   }, []);
 
@@ -49,6 +57,19 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             {t.level === "warn" && <span className="toast__icon">⚠️</span>}
             {t.level === "error" && <span className="toast__icon">❌</span>}
             <span className="toast__text">{t.text}</span>
+            {t.actionLabel && t.onAction && (
+              <button
+                type="button"
+                className="toast__action"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  dismissToast(t.id);
+                  t.onAction?.();
+                }}
+              >
+                {t.actionLabel}
+              </button>
+            )}
           </div>
         ))}
       </div>

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -208,6 +208,10 @@ export interface TabMeta {
   goal?: string;
   goalStatus?: GoalStatus;
   autoResearch?: AutoResearchCompactView;
+  recovered?: boolean;
+  recoveryReason?: string;
+  recoveryDigest?: string;
+  recoveryParentId?: string;
   startupErr?: string;
   active: boolean;
   cwd: string;
@@ -228,6 +232,10 @@ export interface ProjectNode {
   running?: boolean;
   status?: ProjectTopicStatus;
   pinned?: boolean;
+  recovered?: boolean;
+  recoveryReason?: string;
+  recoveryDigest?: string;
+  recoveryParentId?: string;
   children?: ProjectNode[];
 }
 
@@ -237,6 +245,19 @@ export interface TopicMeta {
   id: string;
   title: string;
   createdAt: number;
+}
+
+export interface SessionRecoveryEvent {
+  originalPath?: string;
+  recoveryPath: string;
+  scope?: string;
+  workspaceRoot?: string;
+  topicId?: string;
+  topicTitle?: string;
+  recoveryReason?: string;
+  recoveryDigest?: string;
+  recoveryParentId?: string;
+  existing?: boolean;
 }
 
 export interface ContextPanelInfo {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -260,6 +260,10 @@ export interface SessionRecoveryEvent {
   existing?: boolean;
 }
 
+export interface SessionRecoveryFailedEvent {
+  reason?: "lease_held" | "lease_unavailable" | string;
+}
+
 export interface ContextPanelInfo {
   usedTokens: number;
   windowTokens: number;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -728,6 +728,16 @@ export const en = {
   "history.historySessionActions": "History session actions",
   "history.trashActions": "Trash actions",
 
+  // session recovery
+  "recovery.branch": "Recovery branch",
+  "recovery.badge": "Recovery",
+  "recovery.open": "Open recovery branch",
+  "recovery.toast": "Unsaved local changes were saved as {title}.",
+  "recovery.banner": "This session was recovered from a save conflict. Compare it with the original before continuing.",
+  "recovery.reason": "Reason: {reason}",
+  "recovery.digest": "Digest: {digest}",
+  "recovery.parent": "Parent: {parent}",
+
   // project tree
   "projectTree.workspaceTitle": "Projects",
   "projectTree.pinnedTitle": "Pinned",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -733,6 +733,8 @@ export const en = {
   "recovery.badge": "Recovery",
   "recovery.open": "Open recovery branch",
   "recovery.toast": "Unsaved local changes were saved as {title}.",
+  "recovery.failedLease": "The recovery branch is in use by another runtime, so this tab did not switch to it.",
+  "recovery.failedUnavailable": "The recovery branch could not be opened, so this tab stayed on the original session.",
   "recovery.banner": "This session was recovered from a save conflict. Compare it with the original before continuing.",
   "recovery.reason": "Reason: {reason}",
   "recovery.digest": "Digest: {digest}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -571,6 +571,16 @@ export const zhTW: Record<DictKey, string> = {
   "history.historySessionActions": "歷史會話操作",
   "history.trashActions": "回收站操作",
 
+  // 會話恢復
+  "recovery.branch": "恢復分支",
+  "recovery.badge": "恢復",
+  "recovery.open": "開啟恢復分支",
+  "recovery.toast": "未儲存的本機內容已儲存為 {title}。",
+  "recovery.banner": "目前會話來自儲存衝突恢復。繼續前建議與原會話對比。",
+  "recovery.reason": "原因：{reason}",
+  "recovery.digest": "摘要：{digest}",
+  "recovery.parent": "父會話：{parent}",
+
   // 專案樹
   "projectTree.workspaceTitle": "專案",
   "projectTree.pinnedTitle": "置頂",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -576,6 +576,8 @@ export const zhTW: Record<DictKey, string> = {
   "recovery.badge": "恢復",
   "recovery.open": "開啟恢復分支",
   "recovery.toast": "未儲存的本機內容已儲存為 {title}。",
+  "recovery.failedLease": "恢復分支被另一個執行階段占用，未切換過去。",
+  "recovery.failedUnavailable": "無法開啟恢復分支，目前標籤仍停留在原會話。",
   "recovery.banner": "目前會話來自儲存衝突恢復。繼續前建議與原會話對比。",
   "recovery.reason": "原因：{reason}",
   "recovery.digest": "摘要：{digest}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -729,6 +729,16 @@ export const zh: Record<DictKey, string> = {
   "history.historySessionActions": "历史会话操作",
   "history.trashActions": "回收站操作",
 
+  // 会话恢复
+  "recovery.branch": "恢复分支",
+  "recovery.badge": "恢复",
+  "recovery.open": "打开恢复分支",
+  "recovery.toast": "未保存的本地内容已保存为 {title}。",
+  "recovery.banner": "当前会话来自保存冲突恢复。继续前建议与原会话对比。",
+  "recovery.reason": "原因：{reason}",
+  "recovery.digest": "摘要：{digest}",
+  "recovery.parent": "父会话：{parent}",
+
   // 项目树
   "projectTree.workspaceTitle": "项目",
   "projectTree.pinnedTitle": "置顶",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -734,6 +734,8 @@ export const zh: Record<DictKey, string> = {
   "recovery.badge": "恢复",
   "recovery.open": "打开恢复分支",
   "recovery.toast": "未保存的本地内容已保存为 {title}。",
+  "recovery.failedLease": "恢复分支被另一个运行时占用，未切换过去。",
+  "recovery.failedUnavailable": "无法打开恢复分支，当前标签仍停留在原会话。",
   "recovery.banner": "当前会话来自保存冲突恢复。继续前建议与原会话对比。",
   "recovery.reason": "原因：{reason}",
   "recovery.digest": "摘要：{digest}",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2665,6 +2665,27 @@ a[href] {
   color: var(--ok);
   border-bottom: 1px solid var(--border-soft);
 }
+.banner--recovery {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: color-mix(in srgb, var(--warn) 9%, var(--bg-elev));
+  color: color-mix(in srgb, var(--warn) 72%, var(--fg));
+  border-bottom: 1px solid color-mix(in srgb, var(--warn) 22%, var(--border-soft));
+}
+.banner__badge {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warn) 13%, transparent);
+  color: color-mix(in srgb, var(--warn) 84%, var(--fg));
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+}
 .banner--update {
   display: flex;
   align-items: center;
@@ -19116,6 +19137,26 @@ body > .mermaid-diagram--fullscreen {
   color: color-mix(in srgb, var(--err) 84%, var(--fg));
 }
 
+.project-tree__topic--recovered {
+  color: color-mix(in srgb, var(--warn) 18%, var(--fg-dim));
+}
+
+.project-tree__topic-recovery {
+  flex: 0 0 auto;
+  height: 17px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  color: color-mix(in srgb, var(--warn) 82%, var(--fg));
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+}
+
 .project-tree__topic-meta {
   max-width: 100%;
   min-width: 0;
@@ -24784,6 +24825,26 @@ body > .mermaid-diagram--fullscreen {
 }
 .toast__text {
   line-height: 1.4;
+}
+.toast__action {
+  --wails-draggable: no-drag;
+  flex: 0 0 auto;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-radius: 7px;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  color: inherit;
+  padding: 0 9px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1;
+  cursor: pointer;
+}
+.toast__action:hover,
+.toast__action:focus-visible {
+  background: color-mix(in srgb, currentColor 13%, transparent);
+  outline: none;
 }
 @keyframes toast-in {
   from { opacity: 0; transform: translateY(-8px); }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1011,6 +1011,7 @@ func (a *App) rebuild() error {
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
+		tab.releaseSessionLease()
 		a.mu.Lock()
 		tab.StartupErr = err.Error()
 		tab.Ready = true
@@ -1019,15 +1020,6 @@ func (a *App) rebuild() error {
 		return err
 	}
 	a.bindControllerDisplayRecorder(ctrl)
-	a.mu.Lock()
-	tab.Ctrl = ctrl
-	tab.model = model
-	tab.Label = ctrl.Label()
-	tab.StartupErr = ""
-	tab.Ready = true
-	a.saveTabsLocked()
-	a.mu.Unlock()
-	a.emitReady(a.ctx)
 	ctrl.EnableInteractiveApproval()
 	applyTabModeToController(ctrl, tab.mode)
 	// applyTabModeToController only encodes plan+yolo from tab.mode.
@@ -1038,6 +1030,11 @@ func (a *App) rebuild() error {
 		applyTabToolApprovalModeToController(ctrl, mode)
 	}
 	path := agent.ContinueSessionPath(prevPath, ctrl.SessionDir(), ctrl.Label())
+	if err := tab.ensureSessionLease(path); err != nil {
+		ctrl.Close()
+		tab.releaseSessionLease()
+		return err
+	}
 	if len(carried) > 0 {
 		carried = withFreshSystemPrompt(carried, systemPromptFrom(ctrl.History()))
 		ctrl.Resume(&agent.Session{Messages: carried}, path)
@@ -1045,6 +1042,15 @@ func (a *App) rebuild() error {
 		ctrl.SetSessionPath(path)
 	}
 	a.persistTabSessionPath(tab, path)
+	a.mu.Lock()
+	tab.Ctrl = ctrl
+	tab.model = model
+	tab.Label = ctrl.Label()
+	tab.StartupErr = ""
+	tab.Ready = true
+	a.saveTabsLocked()
+	a.mu.Unlock()
+	a.emitReady(a.ctx)
 	return nil
 }
 

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1007,6 +1007,8 @@ func (a *App) rebuild() error {
 		TokenMode:                currentTabTokenMode(tab),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		a.mu.Lock()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -51,6 +51,7 @@ type WorkspaceTab struct {
 	Label           string             // model label (for the tab badge)
 	Ready           bool               // true once boot.Build completes
 	StartupErr      string             // build error, surfaced to the frontend
+	sessionLease    *agent.SessionLease
 	sink            *tabEventSink      // routes events with this tab's ID
 	buildCancel     context.CancelFunc // cancels in-flight boot for tabs removed before Ready
 	buildGeneration uint64             // identifies the current in-flight build
@@ -243,6 +244,34 @@ func sessionRuntimeKey(path string) string {
 	return canonicalTabSessionPath(path)
 }
 
+func (t *WorkspaceTab) ensureSessionLease(path string) error {
+	if t == nil || t.ReadOnly {
+		return nil
+	}
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		return nil
+	}
+	if t.sessionLease != nil && sessionRuntimeKey(t.sessionLease.Path()) == key {
+		return nil
+	}
+	lease, err := agent.TryAcquireSessionLease(key)
+	if err != nil {
+		return err
+	}
+	t.releaseSessionLease()
+	t.sessionLease = lease
+	return nil
+}
+
+func (t *WorkspaceTab) releaseSessionLease() {
+	if t == nil || t.sessionLease == nil {
+		return
+	}
+	t.sessionLease.Release()
+	t.sessionLease = nil
+}
+
 func detachedRuntimeTabID(key string) string {
 	sum := sha256.Sum256([]byte(key))
 	return "detached_" + hex.EncodeToString(sum[:8])
@@ -324,6 +353,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
 		Label:            tab.Label,
 		Ready:            tab.Ready,
 		StartupErr:       tab.StartupErr,
+		sessionLease:     tab.sessionLease,
 		sink:             tab.sink,
 		ActivityStatus:   tab.ActivityStatus,
 		readTelemetry:    readTelemetry,
@@ -351,6 +381,7 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	if detached == nil {
 		return false
 	}
+	tab.sessionLease = nil
 	if detached.sink != nil {
 		detached.sink.tabID = detached.ID
 		// clearContext (locked nil + drain the queued emitter), not a bare
@@ -384,6 +415,11 @@ func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.
 
 	target.Ctrl = source.Ctrl
 	target.sink = source.sink
+	if target.sessionLease != source.sessionLease {
+		target.releaseSessionLease()
+	}
+	target.sessionLease = source.sessionLease
+	source.sessionLease = nil
 	target.SessionPath = key
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
@@ -1940,6 +1976,7 @@ func (a *App) CloseTab(tabID string) error {
 		// long as any other tab for the same workspace root holds a reference;
 		// on the last release the host is closed and its subprocesses exit.
 		a.releaseTabSharedHost(tab)
+		tab.releaseSessionLease()
 	}
 	if tab.sink != nil {
 		tab.sink.clearContext() // stop further emissions (nil ctx -> Emit becomes no-op)
@@ -2118,6 +2155,7 @@ func (a *App) closeTabRuntime(tab *WorkspaceTab) {
 	if tab.sink != nil {
 		tab.sink.clearContext()
 	}
+	tab.releaseSessionLease()
 }
 
 // buildTabController assembles a controller for a tab in the background, the
@@ -2213,6 +2251,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		}
 		tab.StartupErr = err.Error()
 		tab.Ready = true
+		tab.releaseSessionLease()
 		a.mu.Unlock()
 		a.emitReady(wailsCtx, tab.ID)
 		return
@@ -2324,6 +2363,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		tab.StartupErr = err.Error()
 		tab.Ready = true
 		a.releaseTabSharedHost(tab)
+		tab.releaseSessionLease()
 		a.mu.Unlock()
 		a.emitReady(wailsCtx, tab.ID)
 		return
@@ -2355,32 +2395,56 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			a.mu.Unlock()
 		}
 		var path string
+		var resumeSession *agent.Session
 		// Prefer the exact session file persisted for this tab. Topic lookup is a
 		// compatibility fallback for older desktop-tabs.json files that only stored
 		// topicId and could pick the wrong session when one topic had multiple files.
 		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tab.SessionPath, loadedSession); ok {
-			if loaded != nil {
-				ctrl.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl.History())), pinnedPath)
-			} else {
-				ctrl.SetSessionPath(pinnedPath)
-			}
 			path = pinnedPath
+			resumeSession = loaded
 		}
 		if path == "" && tab.TopicID != "" {
 			existingPath := findTopicSession(dir, tab.TopicID)
 			if existingPath != "" {
 				if loaded, err := loadResumableSession(existingPath); err == nil {
-					ctrl.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl.History())), existingPath)
 					path = existingPath
+					resumeSession = loaded
 				}
 			}
 		}
 		if path == "" {
 			path = agent.NewSessionPath(dir, ctrl.Label())
-			ctrl.SetSessionPath(path)
 		}
 		// Write/update scope/session meta.
 		if path != "" {
+			if a.attachExistingSessionRuntime(tab, path, wailsCtx) {
+				ctrl.Close()
+				a.releaseSharedHost(rootKey)
+				a.emitReady(wailsCtx, tab.ID)
+				return
+			}
+			if err := tab.ensureSessionLease(path); err != nil {
+				a.mu.Lock()
+				if tab.removed || a.tabs[tab.ID] != tab {
+					a.mu.Unlock()
+					ctrl.Close()
+					a.releaseTabSharedHost(tab)
+					return
+				}
+				tab.StartupErr = err.Error()
+				tab.Ready = true
+				a.releaseTabSharedHost(tab)
+				tab.releaseSessionLease()
+				a.mu.Unlock()
+				ctrl.Close()
+				a.emitReady(wailsCtx, tab.ID)
+				return
+			}
+			if resumeSession != nil {
+				ctrl.Resume(sessionWithFreshSystemPrompt(resumeSession, systemPromptFrom(ctrl.History())), path)
+			} else {
+				ctrl.SetSessionPath(path)
+			}
 			a.persistTabSessionPath(tab, path)
 			if strings.TrimSpace(tab.TopicID) != "" {
 				if err := ensureTopicIndexed(tab.Scope, tab.WorkspaceRoot, tab.TopicID, tab.TopicTitle, loadTopicTitleSource(topicTitleRoot(tab.Scope, tab.WorkspaceRoot), tab.TopicID)); err == nil {
@@ -2395,12 +2459,6 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				tab.usageTelemetry = snapshot.Usage
 				tab.telemMu.Unlock()
 			}
-			if a.attachExistingSessionRuntime(tab, path, wailsCtx) {
-				ctrl.Close()
-				a.releaseSharedHost(rootKey)
-				a.emitReady(wailsCtx, tab.ID)
-				return
-			}
 		}
 	}
 
@@ -2409,6 +2467,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		a.mu.Unlock()
 		ctrl.Close()
 		a.releaseTabSharedHost(tab)
+		tab.releaseSessionLease()
 		return
 	}
 	tab.Ctrl = ctrl
@@ -3994,6 +4053,11 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 	return func(info control.SessionRecoveryInfo) {
 		if strings.TrimSpace(info.RecoveryPath) == "" {
 			return
+		}
+		if tab != nil && !tab.ReadOnly {
+			if err := tab.ensureSessionLease(info.RecoveryPath); err != nil {
+				slog.Warn("desktop: acquire recovery session lease", "path", info.RecoveryPath, "err", err)
+			}
 		}
 		meta := info.Meta
 		scope := strings.TrimSpace(meta.Scope)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4049,14 +4049,15 @@ func (a *App) tabSessionRecoveryMeta(tab *WorkspaceTab) func(control.SessionReco
 	}
 }
 
-func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionRecoveryInfo) {
-	return func(info control.SessionRecoveryInfo) {
+func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionRecoveryInfo) error {
+	return func(info control.SessionRecoveryInfo) error {
 		if strings.TrimSpace(info.RecoveryPath) == "" {
-			return
+			return nil
 		}
 		if tab != nil && !tab.ReadOnly {
 			if err := tab.ensureSessionLease(info.RecoveryPath); err != nil {
 				slog.Warn("desktop: acquire recovery session lease", "path", info.RecoveryPath, "err", err)
+				return fmt.Errorf("acquire recovery session lease: %w", err)
 			}
 		}
 		meta := info.Meta
@@ -4112,6 +4113,7 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 			Existing:         info.Existing,
 		})
 		a.invalidatePromptHistoryCache()
+		return nil
 	}
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4019,6 +4019,10 @@ type sessionRecoveryEvent struct {
 	Existing         bool   `json:"existing,omitempty"`
 }
 
+type sessionRecoveryFailedEvent struct {
+	Reason string `json:"reason,omitempty"`
+}
+
 func (a *App) tabSessionRecoveryMeta(tab *WorkspaceTab) func(control.SessionRecoveryRequest) agent.BranchMeta {
 	return func(req control.SessionRecoveryRequest) agent.BranchMeta {
 		if tab == nil {
@@ -4057,6 +4061,11 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 		if tab != nil && !tab.ReadOnly {
 			if err := tab.ensureSessionLease(info.RecoveryPath); err != nil {
 				slog.Warn("desktop: acquire recovery session lease", "path", info.RecoveryPath, "err", err)
+				reason := "lease_unavailable"
+				if errors.Is(err, agent.ErrSessionLeaseHeld) {
+					reason = "lease_held"
+				}
+				a.emitRuntimeEvent("session:recovery-failed", sessionRecoveryFailedEvent{Reason: reason})
 				return fmt.Errorf("acquire recovery session lease: %w", err)
 			}
 		}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1159,6 +1159,10 @@ type TabMeta struct {
 	Goal              string                   `json:"goal,omitempty"`
 	GoalStatus        string                   `json:"goalStatus,omitempty"`
 	AutoResearch      *AutoResearchCompactView `json:"autoResearch,omitempty"`
+	Recovered         bool                     `json:"recovered,omitempty"`
+	RecoveryReason    string                   `json:"recoveryReason,omitempty"`
+	RecoveryDigest    string                   `json:"recoveryDigest,omitempty"`
+	RecoveryParentID  string                   `json:"recoveryParentId,omitempty"`
 	StartupErr        string                   `json:"startupErr,omitempty"`
 	Active            bool                     `json:"active"`
 	Cwd               string                   `json:"cwd"`
@@ -1218,6 +1222,12 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		m.BackgroundJobs = status.BackgroundJobs
 		m.CancelRequested = status.CancelRequested
 		m.Cancellable = status.Cancellable
+	}
+	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok && meta.Recovered {
+		m.Recovered = true
+		m.RecoveryReason = meta.RecoveryReason
+		m.RecoveryDigest = meta.RecoveryDigest
+		m.RecoveryParentID = string(meta.ParentID)
 	}
 	return m
 }
@@ -2301,6 +2311,8 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		TokenMode:                currentTabTokenMode(tab),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
 		a.mu.Lock()
@@ -3924,6 +3936,121 @@ func forkTopicTitle(title string) string {
 	return base + " · 分叉"
 }
 
+func recoveryTopicTitle(title string) string {
+	base := strings.TrimSpace(title)
+	if base == "" || base == defaultTopicTitle || base == "Global" {
+		return "恢复分支"
+	}
+	if strings.HasSuffix(base, " · 恢复") {
+		return base
+	}
+	return base + " · 恢复"
+}
+
+type sessionRecoveryEvent struct {
+	OriginalPath     string `json:"originalPath,omitempty"`
+	RecoveryPath     string `json:"recoveryPath"`
+	Scope            string `json:"scope,omitempty"`
+	WorkspaceRoot    string `json:"workspaceRoot,omitempty"`
+	TopicID          string `json:"topicId,omitempty"`
+	TopicTitle       string `json:"topicTitle,omitempty"`
+	RecoveryReason   string `json:"recoveryReason,omitempty"`
+	RecoveryDigest   string `json:"recoveryDigest,omitempty"`
+	RecoveryParentID string `json:"recoveryParentId,omitempty"`
+	Existing         bool   `json:"existing,omitempty"`
+}
+
+func (a *App) tabSessionRecoveryMeta(tab *WorkspaceTab) func(control.SessionRecoveryRequest) agent.BranchMeta {
+	return func(req control.SessionRecoveryRequest) agent.BranchMeta {
+		if tab == nil {
+			return agent.BranchMeta{Name: agent.RecoveryBranchDefaultName}
+		}
+		scope := strings.TrimSpace(tab.Scope)
+		if scope != "project" {
+			scope = "global"
+		}
+		workspaceRoot := strings.TrimSpace(tab.WorkspaceRoot)
+		if scope == "global" {
+			workspaceRoot = ""
+		}
+		topicID := newTopicID()
+		topicTitle := recoveryTopicTitle(tab.TopicTitle)
+		return agent.BranchMeta{
+			Name:             agent.RecoveryBranchDefaultName,
+			Scope:            scope,
+			WorkspaceRoot:    workspaceRoot,
+			TopicID:          topicID,
+			TopicTitle:       topicTitle,
+			Model:            strings.TrimSpace(tab.model),
+			TokenMode:        persistedTabTokenMode(currentTabTokenMode(tab)),
+			Mode:             persistedTabMode(currentTabMode(tab)),
+			ToolApprovalMode: persistedToolApprovalMode(currentTabToolApprovalMode(tab)),
+			Goal:             persistedTabGoal(tab),
+		}
+	}
+}
+
+func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionRecoveryInfo) {
+	return func(info control.SessionRecoveryInfo) {
+		if strings.TrimSpace(info.RecoveryPath) == "" {
+			return
+		}
+		meta := info.Meta
+		scope := strings.TrimSpace(meta.Scope)
+		if scope != "project" {
+			scope = "global"
+		}
+		workspaceRoot := strings.TrimSpace(meta.WorkspaceRoot)
+		if scope == "global" {
+			workspaceRoot = ""
+		}
+		if strings.TrimSpace(meta.TopicID) != "" {
+			title := strings.TrimSpace(meta.TopicTitle)
+			if title == "" {
+				title = recoveryTopicTitle("")
+			}
+			_ = setTopicTitleWithSource(workspaceRoot, meta.TopicID, title, topicTitleSourceManual)
+			_ = ensureTopicIndexed(scope, workspaceRoot, meta.TopicID, title, topicTitleSourceManual)
+		}
+		invalidateTopicSessionIndexForPath(info.RecoveryPath)
+		a.mu.Lock()
+		if tab != nil && !tab.removed {
+			oldKey := sessionRuntimeKey(info.OriginalPath)
+			newKey := sessionRuntimeKey(info.RecoveryPath)
+			if oldKey != "" && newKey != "" && a.detachedSessions[oldKey] == tab {
+				delete(a.detachedSessions, oldKey)
+				a.ensureDetachedSessionsLocked()
+				a.detachedSessions[newKey] = tab
+			}
+			tab.SessionPath = canonicalTabSessionPath(info.RecoveryPath)
+			if strings.TrimSpace(meta.TopicID) != "" {
+				tab.Scope = scope
+				tab.WorkspaceRoot = workspaceRoot
+				tab.TopicID = meta.TopicID
+				tab.TopicTitle = meta.TopicTitle
+			}
+			if a.tabs[tab.ID] == tab {
+				a.saveTabsLocked()
+			}
+		}
+		a.mu.Unlock()
+		a.emitProjectTreeChanged()
+		a.emitRuntimeEvent("session:recovered", sessionRecoveryEvent{
+			OriginalPath:     info.OriginalPath,
+			RecoveryPath:     info.RecoveryPath,
+			Scope:            scope,
+			WorkspaceRoot:    workspaceRoot,
+			TopicID:          meta.TopicID,
+			TopicTitle:       meta.TopicTitle,
+			RecoveryReason:   meta.RecoveryReason,
+			RecoveryDigest:   meta.RecoveryDigest,
+			RecoveryParentID: string(meta.ParentID),
+			Existing:         info.Existing,
+		})
+		a.invalidatePromptHistoryCache()
+	}
+}
+
 func setTopicTitle(workspaceRoot, topicID, title string) error {
 	return setTopicTitleWithSource(workspaceRoot, topicID, title, topicTitleSourceManual)
 }
@@ -4055,21 +4182,25 @@ func loadTelemetry(path string) tabTelemetrySnapshot {
 // ProjectNode is one node in the sidebar project tree (a project folder or a
 // topic leaf).
 type ProjectNode struct {
-	Key            string        `json:"key"`  // stable key for React
-	Kind           string        `json:"kind"` // "project" | "topic" | "session" | "global_folder" | "global_topic" | "global_session"
-	Label          string        `json:"label"`
-	Root           string        `json:"root,omitempty"` // project workspace root
-	TopicID        string        `json:"topicId,omitempty"`
-	SessionPath    string        `json:"sessionPath,omitempty"`
-	ProjectColor   string        `json:"projectColor,omitempty"`
-	Turns          int           `json:"turns,omitempty"`
-	CreatedAt      int64         `json:"createdAt,omitempty"`
-	LastActivityAt int64         `json:"lastActivityAt,omitempty"`
-	Open           bool          `json:"open,omitempty"`
-	Running        bool          `json:"running,omitempty"`
-	Status         string        `json:"status,omitempty"`
-	Pinned         bool          `json:"pinned,omitempty"`
-	Children       []ProjectNode `json:"children,omitempty"`
+	Key              string        `json:"key"`  // stable key for React
+	Kind             string        `json:"kind"` // "project" | "topic" | "session" | "global_folder" | "global_topic" | "global_session"
+	Label            string        `json:"label"`
+	Root             string        `json:"root,omitempty"` // project workspace root
+	TopicID          string        `json:"topicId,omitempty"`
+	SessionPath      string        `json:"sessionPath,omitempty"`
+	ProjectColor     string        `json:"projectColor,omitempty"`
+	Turns            int           `json:"turns,omitempty"`
+	CreatedAt        int64         `json:"createdAt,omitempty"`
+	LastActivityAt   int64         `json:"lastActivityAt,omitempty"`
+	Open             bool          `json:"open,omitempty"`
+	Running          bool          `json:"running,omitempty"`
+	Status           string        `json:"status,omitempty"`
+	Pinned           bool          `json:"pinned,omitempty"`
+	Recovered        bool          `json:"recovered,omitempty"`
+	RecoveryReason   string        `json:"recoveryReason,omitempty"`
+	RecoveryDigest   string        `json:"recoveryDigest,omitempty"`
+	RecoveryParentID string        `json:"recoveryParentId,omitempty"`
+	Children         []ProjectNode `json:"children,omitempty"`
 }
 
 func normalizeTopicStatus(status string) string {
@@ -4991,8 +5122,12 @@ func (a *App) topicTrashTargets(topicID string) ([]topicTrashTarget, error) {
 // topicSummary is used by ListProjectTree and mergeSessionInfos to track
 // per-topic turn count and last activity.
 type topicSummary struct {
-	turns          int
-	lastActivityAt int64
+	turns            int
+	lastActivityAt   int64
+	recovered        bool
+	recoveryReason   string
+	recoveryDigest   string
+	recoveryParentID string
 }
 
 var listProjectTreeMu sync.Mutex
@@ -5008,14 +5143,18 @@ func (a *App) ListProjectTree() []ProjectNode {
 	f := loadProjectsFile()
 	out := []ProjectNode{}
 	type runtimeSessionStatus struct {
-		sessionPath    string
-		label          string
-		turns          int
-		createdAt      int64
-		lastActivityAt int64
-		open           bool
-		running        bool
-		status         string
+		sessionPath      string
+		label            string
+		turns            int
+		createdAt        int64
+		lastActivityAt   int64
+		open             bool
+		running          bool
+		status           string
+		recovered        bool
+		recoveryReason   string
+		recoveryDigest   string
+		recoveryParentID string
 	}
 	topicSummaries := map[string]topicSummary{}
 	sessionInfos := map[string]agent.SessionInfo{}
@@ -5102,14 +5241,18 @@ func (a *App) ListProjectTree() []ProjectNode {
 		}
 		running := status != "" || runtimeStatus.Running || runtimeStatus.PendingPrompt || runtimeStatus.BackgroundJobs > 0
 		runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)] = append(runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)], runtimeSessionStatus{
-			sessionPath:    sessionPath,
-			label:          label,
-			turns:          info.Turns,
-			createdAt:      unixMilliOrZero(info.CreatedAt),
-			lastActivityAt: unixMilliOrZero(info.LastActivityAt),
-			open:           open,
-			running:        running,
-			status:         status,
+			sessionPath:      sessionPath,
+			label:            label,
+			turns:            info.Turns,
+			createdAt:        unixMilliOrZero(info.CreatedAt),
+			lastActivityAt:   unixMilliOrZero(info.LastActivityAt),
+			open:             open,
+			running:          running,
+			status:           status,
+			recovered:        info.Recovered,
+			recoveryReason:   info.RecoveryReason,
+			recoveryDigest:   info.RecoveryDigest,
+			recoveryParentID: string(info.ParentID),
 		})
 	}
 	for _, tab := range a.tabs {
@@ -5150,19 +5293,23 @@ func (a *App) ListProjectTree() []ProjectNode {
 				kind = "global_session"
 			}
 			nodes = append(nodes, ProjectNode{
-				Key:            projectSessionNodeKey(scope, session.sessionPath),
-				Kind:           kind,
-				Label:          session.label,
-				Root:           workspaceRoot,
-				TopicID:        topicID,
-				SessionPath:    session.sessionPath,
-				ProjectColor:   projectColor,
-				Turns:          session.turns,
-				CreatedAt:      session.createdAt,
-				LastActivityAt: session.lastActivityAt,
-				Open:           session.open,
-				Running:        session.running,
-				Status:         session.status,
+				Key:              projectSessionNodeKey(scope, session.sessionPath),
+				Kind:             kind,
+				Label:            session.label,
+				Root:             workspaceRoot,
+				TopicID:          topicID,
+				SessionPath:      session.sessionPath,
+				ProjectColor:     projectColor,
+				Turns:            session.turns,
+				CreatedAt:        session.createdAt,
+				LastActivityAt:   session.lastActivityAt,
+				Open:             session.open,
+				Running:          session.running,
+				Status:           session.status,
+				Recovered:        session.recovered,
+				RecoveryReason:   session.recoveryReason,
+				RecoveryDigest:   session.recoveryDigest,
+				RecoveryParentID: session.recoveryParentID,
 			})
 		}
 		return nodes
@@ -5185,19 +5332,23 @@ func (a *App) ListProjectTree() []ProjectNode {
 			open, running, status := topicRuntimeStatus(topicSummaryKey("global", "", id))
 			pinned := containsDesktopString(f.GlobalPinnedTopics, id)
 			children = append(children, ProjectNode{
-				Key:            "global_topic_" + id,
-				Kind:           "global_topic",
-				Label:          title,
-				TopicID:        id,
-				ProjectColor:   globalColor,
-				Turns:          summary.turns,
-				CreatedAt:      globalCreatedMap[id],
-				LastActivityAt: summary.lastActivityAt,
-				Open:           open,
-				Running:        running,
-				Status:         status,
-				Pinned:         pinned,
-				Children:       runtimeSessionNodes("global", "", id, globalColor),
+				Key:              "global_topic_" + id,
+				Kind:             "global_topic",
+				Label:            title,
+				TopicID:          id,
+				ProjectColor:     globalColor,
+				Turns:            summary.turns,
+				CreatedAt:        globalCreatedMap[id],
+				LastActivityAt:   summary.lastActivityAt,
+				Open:             open,
+				Running:          running,
+				Status:           status,
+				Pinned:           pinned,
+				Recovered:        summary.recovered,
+				RecoveryReason:   summary.recoveryReason,
+				RecoveryDigest:   summary.recoveryDigest,
+				RecoveryParentID: summary.recoveryParentID,
+				Children:         runtimeSessionNodes("global", "", id, globalColor),
 			})
 		}
 		out = append(out, ProjectNode{
@@ -5259,20 +5410,24 @@ func (a *App) ListProjectTree() []ProjectNode {
 			open, running, status := topicRuntimeStatus(topicSummaryKey("project", p.Root, tid))
 			pinned := containsDesktopString(p.PinnedTopics, tid)
 			children = append(children, ProjectNode{
-				Key:            "topic_" + tid,
-				Kind:           "topic",
-				Label:          topicTitle,
-				Root:           p.Root,
-				TopicID:        tid,
-				ProjectColor:   p.Color,
-				Turns:          summary.turns,
-				CreatedAt:      createdMap[tid],
-				LastActivityAt: summary.lastActivityAt,
-				Open:           open,
-				Running:        running,
-				Status:         status,
-				Pinned:         pinned,
-				Children:       runtimeSessionNodes("project", p.Root, tid, p.Color),
+				Key:              "topic_" + tid,
+				Kind:             "topic",
+				Label:            topicTitle,
+				Root:             p.Root,
+				TopicID:          tid,
+				ProjectColor:     p.Color,
+				Turns:            summary.turns,
+				CreatedAt:        createdMap[tid],
+				LastActivityAt:   summary.lastActivityAt,
+				Open:             open,
+				Running:          running,
+				Status:           status,
+				Pinned:           pinned,
+				Recovered:        summary.recovered,
+				RecoveryReason:   summary.recoveryReason,
+				RecoveryDigest:   summary.recoveryDigest,
+				RecoveryParentID: summary.recoveryParentID,
+				Children:         runtimeSessionNodes("project", p.Root, tid, p.Color),
 			})
 		}
 		node.Label = title
@@ -6084,6 +6239,18 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		lastActivityAt := info.LastActivityAt.UnixMilli()
 		if lastActivityAt > summary.lastActivityAt {
 			summary.lastActivityAt = lastActivityAt
+		}
+		if info.Recovered {
+			summary.recovered = true
+			if summary.recoveryReason == "" {
+				summary.recoveryReason = info.RecoveryReason
+			}
+			if summary.recoveryDigest == "" {
+				summary.recoveryDigest = info.RecoveryDigest
+			}
+			if summary.recoveryParentID == "" {
+				summary.recoveryParentID = string(info.ParentID)
+			}
 		}
 		topicSummaries[key] = summary
 	}

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -676,6 +677,42 @@ func TestBuildTabControllerReusesOpenSessionPathRuntime(t *testing.T) {
 	}
 	if _, ok := app.tabs[oldTab.ID]; ok {
 		t.Fatal("source tab for reused runtime should be removed")
+	}
+}
+
+func TestBuildTabControllerBlocksWhenSessionLeaseHeld(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "leased.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+
+	app := NewApp()
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "leased")
+	tab.SessionPath = path
+	tab.sink = &tabEventSink{tabID: "leased", app: app}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.buildTabController(tab)
+	if tab.Ctrl != nil {
+		t.Fatalf("tab controller = %T, want nil when lease is held", tab.Ctrl)
+	}
+	if !tab.Ready {
+		t.Fatal("tab should be ready with startup error")
+	}
+	if !strings.Contains(tab.StartupErr, agent.ErrSessionLeaseHeld.Error()) {
+		t.Fatalf("startup error = %q, want lease-held error", tab.StartupErr)
 	}
 }
 

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -36,6 +36,9 @@ type BranchMeta struct {
 	Recovered        bool      `json:"recovered,omitempty"`
 	RecoveryReason   string    `json:"recovery_reason,omitempty"`
 	RecoveryDigest   string    `json:"recovery_digest,omitempty"`
+	Revision         int64     `json:"revision,omitempty"`
+	ContentDigest    string    `json:"content_digest,omitempty"`
+	WriterID         string    `json:"writer_id,omitempty"`
 	// SchemaVersion records the BranchMeta version that last wrote the listing
 	// fields (Turns/Preview) FROM the session's content. It is stamped only by the
 	// writers that actually derive those counts — Controller.snapshot's
@@ -150,6 +153,9 @@ func saveBranchMeta(sessionPath string, m BranchMeta, touchUpdated bool) error {
 	if touchUpdated || m.UpdatedAt.IsZero() {
 		m.UpdatedAt = now
 	}
+	if existing, ok, err := LoadBranchMeta(sessionPath); err == nil && ok {
+		preserveBranchMetaPersistence(&m, existing)
+	}
 	if err := os.MkdirAll(filepath.Dir(metaPath), 0o755); err != nil {
 		return err
 	}
@@ -177,6 +183,26 @@ func saveBranchMeta(sessionPath string, m BranchMeta, touchUpdated bool) error {
 		return err
 	}
 	return nil
+}
+
+func preserveBranchMetaPersistence(next *BranchMeta, existing BranchMeta) {
+	if next == nil {
+		return
+	}
+	if existing.Revision > next.Revision {
+		next.Revision = existing.Revision
+		next.ContentDigest = existing.ContentDigest
+		next.WriterID = existing.WriterID
+		return
+	}
+	if existing.Revision == next.Revision {
+		if strings.TrimSpace(next.ContentDigest) == "" {
+			next.ContentDigest = existing.ContentDigest
+		}
+		if strings.TrimSpace(next.WriterID) == "" {
+			next.WriterID = existing.WriterID
+		}
+	}
 }
 
 func EnsureBranchMeta(sessionPath string) (BranchMeta, error) {

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -33,6 +33,9 @@ type BranchMeta struct {
 	Mode             string    `json:"mode,omitempty"`
 	ToolApprovalMode string    `json:"tool_approval_mode,omitempty"`
 	Goal             string    `json:"goal,omitempty"`
+	Recovered        bool      `json:"recovered,omitempty"`
+	RecoveryReason   string    `json:"recovery_reason,omitempty"`
+	RecoveryDigest   string    `json:"recovery_digest,omitempty"`
 	// SchemaVersion records the BranchMeta version that last wrote the listing
 	// fields (Turns/Preview) FROM the session's content. It is stamped only by the
 	// writers that actually derive those counts — Controller.snapshot's

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -26,13 +27,15 @@ var (
 	sessionSaveLocks            sync.Map
 	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
 	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
+	sessionWriterID             = newSessionWriterID()
 )
 
 type sessionPersistState struct {
-	path    string
-	digest  [sha256.Size]byte
-	version uint64
-	ok      bool
+	path     string
+	digest   [sha256.Size]byte
+	version  uint64
+	revision int64
+	ok       bool
 }
 
 type sessionSaveMode int
@@ -55,6 +58,8 @@ type SessionSnapshotConflictError struct {
 	Kind             SessionSnapshotConflictKind
 	ExistingMessages int
 	SnapshotMessages int
+	BaseRevision     int64
+	DiskRevision     int64
 }
 
 func (e *SessionSnapshotConflictError) Error() string {
@@ -63,11 +68,11 @@ func (e *SessionSnapshotConflictError) Error() string {
 	}
 	switch e.Kind {
 	case SessionSnapshotConflictStalePrefix:
-		return fmt.Sprintf("%s: %s has %d messages; stale snapshot has %d",
-			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.SnapshotMessages)
+		return fmt.Sprintf("%s: %s has %d messages at revision %d; stale snapshot has %d messages from revision %d",
+			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.DiskRevision, e.SnapshotMessages, e.BaseRevision)
 	default:
-		return fmt.Sprintf("%s: %s diverged on disk (%d messages) from snapshot (%d messages)",
-			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.SnapshotMessages)
+		return fmt.Sprintf("%s: %s diverged on disk (%d messages, revision %d) from snapshot (%d messages, revision %d)",
+			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.DiskRevision, e.SnapshotMessages, e.BaseRevision)
 	}
 }
 
@@ -133,6 +138,7 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	if err != nil {
 		return err
 	}
+	baseRevision := int64(0)
 	unlock := lockSessionSavePath(path)
 	defer unlock()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -144,14 +150,24 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	}
 	defer unlockFile()
 	if mode != sessionSaveForce {
-		if err := s.checkSnapshotWrite(path, msgs, digest, version, mode == sessionSaveRewrite); err != nil {
+		revision, err := s.checkSnapshotWrite(path, msgs, digest, version, mode == sessionSaveRewrite)
+		if err != nil {
 			return err
 		}
+		baseRevision = revision
+	} else if revision, _, err := sessionContentRevision(path); err != nil {
+		return err
+	} else {
+		baseRevision = revision
 	}
 	if err := writeSessionMessages(path, msgs); err != nil {
 		return err
 	}
-	s.markPersisted(path, digest, version)
+	revision, err := recordSessionContentRevision(path, digest, baseRevision)
+	if err != nil {
+		return err
+	}
+	s.markPersisted(path, digest, version, revision)
 	return nil
 }
 
@@ -182,38 +198,65 @@ func writeSessionMessages(path string, msgs []provider.Message) error {
 	return nil
 }
 
-func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextDigest [sha256.Size]byte, nextVersion uint64, allowOwnedRewrite bool) error {
+func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextDigest [sha256.Size]byte, nextVersion uint64, allowOwnedRewrite bool) (int64, error) {
 	current, err := LoadSession(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return 0, nil
 		}
-		return err
+		return 0, err
 	}
+	currentRevision, _, err := sessionContentRevision(path)
+	if err != nil {
+		return 0, err
+	}
+	baseState := s.persistState(path)
 	existing := current.Snapshot()
 	existingDigest, err := digestSessionMessages(existing)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if bytes.Equal(existingDigest[:], nextDigest[:]) || messagesHavePrefix(next, existing) || messagesHavePrefixWithCompatibleSystem(next, existing) {
-		return nil
+		if baseState.ok && currentRevision != baseState.revision && !bytes.Equal(existingDigest[:], nextDigest[:]) {
+			return 0, snapshotConflict(path, existing, next, baseState.revision, currentRevision)
+		}
+		return currentRevision, nil
 	}
-	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, nextVersion) {
-		return nil
+	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, currentRevision, nextVersion) {
+		return currentRevision, nil
 	}
 	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
-		return &SessionSnapshotConflictError{
+		return 0, &SessionSnapshotConflictError{
 			Path:             path,
 			Kind:             SessionSnapshotConflictStalePrefix,
 			ExistingMessages: len(existing),
 			SnapshotMessages: len(next),
+			BaseRevision:     baseState.revision,
+			DiskRevision:     currentRevision,
 		}
 	}
-	return &SessionSnapshotConflictError{
+	return 0, &SessionSnapshotConflictError{
 		Path:             path,
 		Kind:             SessionSnapshotConflictDiverged,
 		ExistingMessages: len(existing),
 		SnapshotMessages: len(next),
+		BaseRevision:     baseState.revision,
+		DiskRevision:     currentRevision,
+	}
+}
+
+func snapshotConflict(path string, existing, next []provider.Message, baseRevision, diskRevision int64) error {
+	kind := SessionSnapshotConflictDiverged
+	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
+		kind = SessionSnapshotConflictStalePrefix
+	}
+	return &SessionSnapshotConflictError{
+		Path:             path,
+		Kind:             kind,
+		ExistingMessages: len(existing),
+		SnapshotMessages: len(next),
+		BaseRevision:     baseRevision,
+		DiskRevision:     diskRevision,
 	}
 }
 
@@ -231,7 +274,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	if err != nil {
 		return RecoveryBranchInfo{}, err
 	}
-	digestText := fmt.Sprintf("%x", digest[:])
+	digestText := digestString(digest)
 
 	unlockOriginal := lockSessionSavePath(originalPath)
 	unlockOriginalFile, lockErr := lockSessionFile(originalPath)
@@ -276,7 +319,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 			if err != nil {
 				return RecoveryBranchInfo{}, err
 			}
-			s.markPersisted(recoveryPath, digest, version)
+			s.markPersisted(recoveryPath, digest, version, meta.Revision)
 			return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Existing: true, Meta: meta, Preview: preview, Turns: turns}, nil
 		}
 	} else if loadErr != nil && !os.IsNotExist(loadErr) {
@@ -293,7 +336,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	if err != nil {
 		return RecoveryBranchInfo{}, err
 	}
-	s.markPersisted(recoveryPath, digest, version)
+	s.markPersisted(recoveryPath, digest, version, meta.Revision)
 	return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Meta: meta, Preview: preview, Turns: turns}, nil
 }
 
@@ -314,8 +357,22 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 	meta.Recovered = true
 	meta.RecoveryReason = firstNonEmpty(strings.TrimSpace(opts.Reason), "session snapshot conflict")
 	meta.RecoveryDigest = digest
+	if meta.Revision == 0 {
+		meta.Revision = 1
+	}
+	if strings.TrimSpace(meta.ContentDigest) == "" {
+		meta.ContentDigest = digest
+	}
+	if strings.TrimSpace(meta.WriterID) == "" {
+		meta.WriterID = SessionWriterID()
+	}
 	if err := SaveBranchMeta(path, meta); err != nil {
 		return BranchMeta{}, err
+	}
+	if stored, ok, err := LoadBranchMeta(path); err != nil {
+		return BranchMeta{}, err
+	} else if ok {
+		return stored, nil
 	}
 	return meta, nil
 }
@@ -337,9 +394,12 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, nextVersion uint64) bool {
+func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, existingRevision int64, nextVersion uint64) bool {
 	state := s.persistState(path)
-	return state.ok && state.version <= nextVersion && bytes.Equal(existingDigest[:], state.digest[:])
+	return state.ok &&
+		state.version <= nextVersion &&
+		state.revision == existingRevision &&
+		bytes.Equal(existingDigest[:], state.digest[:])
 }
 
 func (s *Session) persistState(path string) sessionPersistState {
@@ -352,15 +412,84 @@ func (s *Session) persistState(path string) sessionPersistState {
 	return sessionPersistState{}
 }
 
-func (s *Session) markPersisted(path string, digest [sha256.Size]byte, version uint64) {
+func (s *Session) markPersisted(path string, digest [sha256.Size]byte, version uint64, revision int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.persisted = sessionPersistState{
-		path:    canonicalSessionSavePath(path),
-		digest:  digest,
-		version: version,
-		ok:      true,
+		path:     canonicalSessionSavePath(path),
+		digest:   digest,
+		version:  version,
+		revision: revision,
+		ok:       true,
 	}
+}
+
+func sessionContentRevision(path string) (int64, string, error) {
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil {
+		return 0, "", nil
+	}
+	if !ok {
+		return 0, "", nil
+	}
+	return meta.Revision, strings.TrimSpace(meta.ContentDigest), nil
+}
+
+func recordSessionContentRevision(path string, digest [sha256.Size]byte, baseRevision int64) (int64, error) {
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil {
+		meta = BranchMeta{ID: BranchID(path)}
+		ok = false
+	}
+	if !ok {
+		meta = BranchMeta{ID: BranchID(path)}
+	}
+	if meta.Revision < baseRevision {
+		meta.Revision = baseRevision
+	}
+	meta.Revision++
+	meta.ContentDigest = digestString(digest)
+	meta.WriterID = SessionWriterID()
+	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+		return 0, err
+	}
+	stored, ok, err := LoadBranchMeta(path)
+	if err != nil {
+		return 0, err
+	}
+	if ok && stored.Revision > 0 {
+		return stored.Revision, nil
+	}
+	return meta.Revision, nil
+}
+
+func digestString(digest [sha256.Size]byte) string {
+	return fmt.Sprintf("%x", digest[:])
+}
+
+func SessionWriterID() string {
+	return sessionWriterID
+}
+
+func newSessionWriterID() string {
+	host, _ := os.Hostname()
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = "unknown-host"
+	}
+	host = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, host)
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return fmt.Sprintf("%s-%d-%d", host, os.Getpid(), time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%s-%d-%x", host, os.Getpid(), nonce[:])
 }
 
 func digestSessionMessages(msgs []provider.Message) ([sha256.Size]byte, error) {
@@ -479,7 +608,11 @@ func LoadSession(path string) (*Session, error) {
 	}
 	s.Messages = normalized
 	if digest, err := digestSessionMessages(s.Messages); err == nil {
-		s.markPersisted(path, digest, s.version)
+		revision := int64(0)
+		if meta, ok, metaErr := LoadBranchMeta(path); metaErr == nil && ok {
+			revision = meta.Revision
+		}
+		s.markPersisted(path, digest, s.version, revision)
 	}
 	return s, nil
 }

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -438,8 +438,7 @@ func sessionContentRevision(path string) (int64, string, error) {
 func recordSessionContentRevision(path string, digest [sha256.Size]byte, baseRevision int64) (int64, error) {
 	meta, ok, err := LoadBranchMeta(path)
 	if err != nil {
-		meta = BranchMeta{ID: BranchID(path)}
-		ok = false
+		return baseRevision, nil
 	}
 	if !ok {
 		meta = BranchMeta{ID: BranchID(path)}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -23,8 +23,9 @@ import (
 const cleanupPendingExt = ".cleanup-pending.json"
 
 var (
-	sessionSaveLocks           sync.Map
-	ErrSessionSnapshotConflict = errors.New("session snapshot conflicts with newer transcript")
+	sessionSaveLocks            sync.Map
+	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
+	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
 )
 
 type sessionPersistState struct {
@@ -41,6 +42,64 @@ const (
 	sessionSaveSnapshot
 	sessionSaveRewrite
 )
+
+type SessionSnapshotConflictKind string
+
+const (
+	SessionSnapshotConflictStalePrefix SessionSnapshotConflictKind = "stale_prefix"
+	SessionSnapshotConflictDiverged    SessionSnapshotConflictKind = "diverged"
+)
+
+type SessionSnapshotConflictError struct {
+	Path             string
+	Kind             SessionSnapshotConflictKind
+	ExistingMessages int
+	SnapshotMessages int
+}
+
+func (e *SessionSnapshotConflictError) Error() string {
+	if e == nil {
+		return ErrSessionSnapshotConflict.Error()
+	}
+	switch e.Kind {
+	case SessionSnapshotConflictStalePrefix:
+		return fmt.Sprintf("%s: %s has %d messages; stale snapshot has %d",
+			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.SnapshotMessages)
+	default:
+		return fmt.Sprintf("%s: %s diverged on disk (%d messages) from snapshot (%d messages)",
+			ErrSessionSnapshotConflict, e.Path, e.ExistingMessages, e.SnapshotMessages)
+	}
+}
+
+func (e *SessionSnapshotConflictError) Unwrap() error {
+	return ErrSessionSnapshotConflict
+}
+
+func SnapshotConflictKind(err error) (SessionSnapshotConflictKind, bool) {
+	var conflict *SessionSnapshotConflictError
+	if errors.As(err, &conflict) && conflict != nil {
+		return conflict.Kind, true
+	}
+	return "", false
+}
+
+const RecoveryBranchDefaultName = "Recovered unsaved changes from stale runtime"
+
+type RecoveryBranchOptions struct {
+	OriginalPath string
+	Name         string
+	Reason       string
+	BranchMeta   BranchMeta
+}
+
+type RecoveryBranchInfo struct {
+	Path     string
+	Digest   string
+	Existing bool
+	Meta     BranchMeta
+	Preview  string
+	Turns    int
+}
 
 // Save writes the session's messages to path in JSONL — one provider.Message
 // per line — so a user can resume the conversation later. The file is
@@ -79,6 +138,11 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create session dir: %w", err)
 	}
+	unlockFile, err := lockSessionFile(path)
+	if err != nil {
+		return fmt.Errorf("lock session file: %w", err)
+	}
+	defer unlockFile()
 	if mode != sessionSaveForce {
 		if err := s.checkSnapshotWrite(path, msgs, digest, version, mode == sessionSaveRewrite); err != nil {
 			return err
@@ -138,11 +202,139 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		return nil
 	}
 	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
-		return fmt.Errorf("%w: %s has %d messages; stale snapshot has %d",
-			ErrSessionSnapshotConflict, path, len(existing), len(next))
+		return &SessionSnapshotConflictError{
+			Path:             path,
+			Kind:             SessionSnapshotConflictStalePrefix,
+			ExistingMessages: len(existing),
+			SnapshotMessages: len(next),
+		}
 	}
-	return fmt.Errorf("%w: %s diverged on disk (%d messages) from snapshot (%d messages)",
-		ErrSessionSnapshotConflict, path, len(existing), len(next))
+	return &SessionSnapshotConflictError{
+		Path:             path,
+		Kind:             SessionSnapshotConflictDiverged,
+		ExistingMessages: len(existing),
+		SnapshotMessages: len(next),
+	}
+}
+
+func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranchInfo, error) {
+	originalPath := strings.TrimSpace(opts.OriginalPath)
+	if originalPath == "" {
+		return RecoveryBranchInfo{}, fmt.Errorf("empty original session path")
+	}
+	msgs, version := s.snapshotWithVersion()
+	preview, turns := SessionPreviewFromMessages(msgs)
+	if turns == 0 {
+		return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded
+	}
+	digest, err := digestSessionMessages(msgs)
+	if err != nil {
+		return RecoveryBranchInfo{}, err
+	}
+	digestText := fmt.Sprintf("%x", digest[:])
+
+	unlockOriginal := lockSessionSavePath(originalPath)
+	unlockOriginalFile, lockErr := lockSessionFile(originalPath)
+	if lockErr != nil {
+		unlockOriginal()
+		return RecoveryBranchInfo{}, fmt.Errorf("lock original session file: %w", lockErr)
+	}
+	current, err := LoadSession(originalPath)
+	unlockOriginalFile()
+	unlockOriginal()
+	if err != nil && !os.IsNotExist(err) {
+		return RecoveryBranchInfo{}, err
+	}
+	if err == nil && current != nil {
+		existing := current.Snapshot()
+		existingDigest, digestErr := digestSessionMessages(existing)
+		if digestErr != nil {
+			return RecoveryBranchInfo{}, digestErr
+		}
+		if bytes.Equal(existingDigest[:], digest[:]) ||
+			messagesHavePrefix(existing, msgs) ||
+			messagesHavePrefixWithCompatibleSystem(existing, msgs) {
+			return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded
+		}
+	}
+
+	recoveryPath := recoverySessionPath(originalPath, digest)
+	unlockRecovery := lockSessionSavePath(recoveryPath)
+	defer unlockRecovery()
+	unlockRecoveryFile, err := lockSessionFile(recoveryPath)
+	if err != nil {
+		return RecoveryBranchInfo{}, fmt.Errorf("lock recovery session file: %w", err)
+	}
+	defer unlockRecoveryFile()
+	if loaded, loadErr := LoadSession(recoveryPath); loadErr == nil && loaded != nil {
+		existingDigest, digestErr := digestSessionMessages(loaded.Snapshot())
+		if digestErr != nil {
+			return RecoveryBranchInfo{}, digestErr
+		}
+		if bytes.Equal(existingDigest[:], digest[:]) {
+			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText)
+			if err != nil {
+				return RecoveryBranchInfo{}, err
+			}
+			s.markPersisted(recoveryPath, digest, version)
+			return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Existing: true, Meta: meta, Preview: preview, Turns: turns}, nil
+		}
+	} else if loadErr != nil && !os.IsNotExist(loadErr) {
+		return RecoveryBranchInfo{}, loadErr
+	}
+
+	if err := os.MkdirAll(filepath.Dir(recoveryPath), 0o755); err != nil {
+		return RecoveryBranchInfo{}, fmt.Errorf("create recovery session dir: %w", err)
+	}
+	if err := writeSessionMessages(recoveryPath, msgs); err != nil {
+		return RecoveryBranchInfo{}, err
+	}
+	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText)
+	if err != nil {
+		return RecoveryBranchInfo{}, err
+	}
+	s.markPersisted(recoveryPath, digest, version)
+	return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Meta: meta, Preview: preview, Turns: turns}, nil
+}
+
+func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions, preview string, turns int, digest string) (BranchMeta, error) {
+	meta := opts.BranchMeta
+	meta.ID = BranchID(path)
+	if strings.TrimSpace(meta.Name) == "" {
+		meta.Name = firstNonEmpty(strings.TrimSpace(opts.Name), RecoveryBranchDefaultName)
+	}
+	if strings.TrimSpace(meta.ParentID) == "" {
+		meta.ParentID = BranchID(opts.OriginalPath)
+	}
+	meta.ForkTurn = -1
+	meta.ForkMessageIndex = len(s.Snapshot())
+	meta.Preview = preview
+	meta.Turns = turns
+	meta.SchemaVersion = BranchMetaCountsVersion
+	meta.Recovered = true
+	meta.RecoveryReason = firstNonEmpty(strings.TrimSpace(opts.Reason), "session snapshot conflict")
+	meta.RecoveryDigest = digest
+	if err := SaveBranchMeta(path, meta); err != nil {
+		return BranchMeta{}, err
+	}
+	return meta, nil
+}
+
+func recoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
+	parent := BranchID(originalPath)
+	if parent == "" {
+		parent = "session"
+	}
+	return filepath.Join(filepath.Dir(originalPath), fmt.Sprintf("%s-recovery-%x.jsonl", parent, digest[:8]))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, nextVersion uint64) bool {
@@ -306,6 +498,10 @@ type SessionInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
+	Recovered      bool
+	RecoveryReason string
+	RecoveryDigest string
+	ParentID       string
 }
 
 // SessionOrderInfo is the lightweight sidecar/mtime ordering record shared by
@@ -320,6 +516,10 @@ type SessionOrderInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
+	Recovered      bool
+	RecoveryReason string
+	RecoveryDigest string
+	ParentID       string
 	// Turns and Preview are the cached listing fields from the sidecar; SchemaVersion
 	// >= agent.BranchMetaCountsVersion means they were recorded from content and can
 	// be trusted (even Turns == 0). ListSessions uses them to skip the whole-file decode.
@@ -489,6 +689,10 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		workspaceRoot := ""
 		topicID := ""
 		topicTitle := ""
+		recovered := false
+		recoveryReason := ""
+		recoveryDigest := ""
+		parentID := ""
 		turns := 0
 		preview := ""
 		schemaVersion := 0
@@ -503,6 +707,10 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			workspaceRoot = meta.WorkspaceRoot
 			topicID = meta.TopicID
 			topicTitle = meta.TopicTitle
+			recovered = meta.Recovered
+			recoveryReason = meta.RecoveryReason
+			recoveryDigest = meta.RecoveryDigest
+			parentID = meta.ParentID
 			turns = meta.Turns
 			preview = meta.Preview
 			schemaVersion = meta.SchemaVersion
@@ -516,6 +724,10 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			WorkspaceRoot:  workspaceRoot,
 			TopicID:        topicID,
 			TopicTitle:     topicTitle,
+			Recovered:      recovered,
+			RecoveryReason: recoveryReason,
+			RecoveryDigest: recoveryDigest,
+			ParentID:       parentID,
 			Turns:          turns,
 			Preview:        preview,
 			SchemaVersion:  schemaVersion,
@@ -567,6 +779,10 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			WorkspaceRoot:  session.WorkspaceRoot,
 			TopicID:        session.TopicID,
 			TopicTitle:     session.TopicTitle,
+			Recovered:      session.Recovered,
+			RecoveryReason: session.RecoveryReason,
+			RecoveryDigest: session.RecoveryDigest,
+			ParentID:       session.ParentID,
 		})
 	}
 	return out, nil

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -170,6 +170,52 @@ func TestSaveSnapshotAllowsAppendAfterSystemPromptRefresh(t *testing.T) {
 	}
 }
 
+func TestSaveSnapshotRecordsRevisionAndMetaUpdatesPreserveIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := base.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta base ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 1 || meta.ContentDigest == "" || meta.WriterID == "" {
+		t.Fatalf("base persistence meta = %+v, want revision/digest/writer", meta)
+	}
+
+	if err := UpdateSessionMeta(path, "model-a", "first", 1, true); err != nil {
+		t.Fatalf("UpdateSessionMeta: %v", err)
+	}
+	refreshed, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta refreshed ok=%v err=%v", ok, err)
+	}
+	if refreshed.Revision != meta.Revision || refreshed.ContentDigest != meta.ContentDigest || refreshed.WriterID != meta.WriterID {
+		t.Fatalf("listing meta update changed persistence fields: before=%+v after=%+v", meta, refreshed)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	loaded.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append: %v", err)
+	}
+	advanced, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta advanced ok=%v err=%v", ok, err)
+	}
+	if advanced.Revision != refreshed.Revision+1 {
+		t.Fatalf("revision after append = %d, want %d", advanced.Revision, refreshed.Revision+1)
+	}
+	if advanced.ContentDigest == refreshed.ContentDigest {
+		t.Fatalf("content digest did not change after append: %q", advanced.ContentDigest)
+	}
+}
+
 func TestSaveSnapshotRejectsStalePrefixAfterSystemPromptRefresh(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	current := NewSession("new sys")
@@ -196,6 +242,55 @@ func TestSaveSnapshotRejectsStalePrefixAfterSystemPromptRefresh(t *testing.T) {
 	}
 	if got := loaded.Messages[3].Content; got != "second" {
 		t.Fatalf("last message after stale system refresh snapshot = %q, want %q", got, "second")
+	}
+}
+
+func TestSaveRewriteRejectsRevisionCASConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	base.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	stale, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession stale: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	meta.Revision++
+	meta.WriterID = "other-writer"
+	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+		t.Fatalf("bump revision: %v", err)
+	}
+
+	stale.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "summarized first"},
+	})
+	err = stale.SaveRewrite(path)
+	if !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveRewrite revision conflict err = %v, want ErrSessionSnapshotConflict", err)
+	}
+	var conflict *SessionSnapshotConflictError
+	if !errors.As(err, &conflict) || conflict.Kind != SessionSnapshotConflictDiverged {
+		t.Fatalf("conflict = %+v, want diverged revision conflict", conflict)
+	}
+	if conflict.BaseRevision != meta.Revision-1 || conflict.DiskRevision != meta.Revision {
+		t.Fatalf("conflict revisions = base %d disk %d, want %d/%d",
+			conflict.BaseRevision, conflict.DiskRevision, meta.Revision-1, meta.Revision)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "one" {
+		t.Fatalf("tail after rejected rewrite = %q, want one", got)
 	}
 }
 
@@ -336,6 +431,9 @@ func TestSaveRecoveryBranchPersistsDivergedSnapshot(t *testing.T) {
 	}
 	if meta.RecoveryDigest == "" || meta.SchemaVersion != BranchMetaCountsVersion {
 		t.Fatalf("recovery digest/schema = %q/%d", meta.RecoveryDigest, meta.SchemaVersion)
+	}
+	if meta.Revision != 1 || meta.ContentDigest != meta.RecoveryDigest || meta.WriterID == "" {
+		t.Fatalf("recovery persistence meta = %+v, want revision/content digest/writer", meta)
 	}
 }
 

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -285,6 +285,103 @@ func TestSaveRewriteRejectsStalePrefixOverwrite(t *testing.T) {
 	}
 }
 
+func TestSaveRecoveryBranchPersistsDivergedSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	if err := stale.SaveSnapshot(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot stale err = %v, want ErrSessionSnapshotConflict", err)
+	}
+
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	if info.Path == "" || info.Path == path {
+		t.Fatalf("recovery path = %q, want distinct path", info.Path)
+	}
+	if info.Turns != 2 || info.Preview != "first" {
+		t.Fatalf("recovery preview/turns = %q/%d, want first/2", info.Preview, info.Turns)
+	}
+	recovered, err := LoadSession(info.Path)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	if got := recovered.Messages[len(recovered.Messages)-1].Content; got != "local second" {
+		t.Fatalf("recovery tail = %q, want local second", got)
+	}
+	original, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession original: %v", err)
+	}
+	if got := original.Messages[len(original.Messages)-1].Content; got != "disk second" {
+		t.Fatalf("original tail = %q, want disk second", got)
+	}
+	meta, ok, err := LoadBranchMeta(info.Path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recovery ok=%v err=%v", ok, err)
+	}
+	if !meta.Recovered || meta.ParentID != BranchID(path) || meta.Name != RecoveryBranchDefaultName {
+		t.Fatalf("recovery meta = %+v, want recovered parent/name", meta)
+	}
+	if meta.RecoveryDigest == "" || meta.SchemaVersion != BranchMetaCountsVersion {
+		t.Fatalf("recovery digest/schema = %q/%d", meta.RecoveryDigest, meta.SchemaVersion)
+	}
+}
+
+func TestSaveRecoveryBranchSkipsPureStalePrefix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if _, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path}); !errors.Is(err, ErrSessionRecoveryNotNeeded) {
+		t.Fatalf("SaveRecoveryBranch stale prefix err = %v, want ErrSessionRecoveryNotNeeded", err)
+	}
+}
+
+func TestSaveRecoveryBranchDedupesByDigest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "disk"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	first, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("first SaveRecoveryBranch: %v", err)
+	}
+	second, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("second SaveRecoveryBranch: %v", err)
+	}
+	if second.Path != first.Path || !second.Existing {
+		t.Fatalf("second recovery = %+v, want existing same path %q", second, first.Path)
+	}
+}
+
 // TestListSessionsOrdersByMTime makes sure the picker shows the most
 // recently used conversation first — that's what users reach for when they
 // hit `reasonix --continue`.

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+var ErrSessionLeaseHeld = errors.New("session lease held by another runtime")
+
+var sessionLeaseOwners sync.Map
+
+type SessionLeaseInfo struct {
+	SessionPath string    `json:"session_path"`
+	WriterID    string    `json:"writer_id"`
+	PID         int       `json:"pid"`
+	Hostname    string    `json:"hostname,omitempty"`
+	AcquiredAt  time.Time `json:"acquired_at"`
+}
+
+type SessionLeaseError struct {
+	Path string
+	Info *SessionLeaseInfo
+}
+
+func (e *SessionLeaseError) Error() string {
+	if e == nil {
+		return ErrSessionLeaseHeld.Error()
+	}
+	if e.Info != nil && e.Info.WriterID != "" {
+		return fmt.Sprintf("%s: %s is held by %s", ErrSessionLeaseHeld, e.Path, e.Info.WriterID)
+	}
+	return fmt.Sprintf("%s: %s", ErrSessionLeaseHeld, e.Path)
+}
+
+func (e *SessionLeaseError) Unwrap() error {
+	return ErrSessionLeaseHeld
+}
+
+type SessionLease struct {
+	path   string
+	unlock func()
+	once   sync.Once
+}
+
+func TryAcquireSessionLease(path string) (*SessionLease, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("empty session path")
+	}
+	path = canonicalSessionSavePath(path)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	if _, loaded := sessionLeaseOwners.LoadOrStore(path, struct{}{}); loaded {
+		info, _ := LoadSessionLeaseInfo(path)
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	unlock, err := tryLockSessionLeaseFile(path)
+	if err != nil {
+		sessionLeaseOwners.Delete(path)
+		if errors.Is(err, ErrSessionLeaseHeld) {
+			info, _ := LoadSessionLeaseInfo(path)
+			return nil, &SessionLeaseError{Path: path, Info: info}
+		}
+		return nil, err
+	}
+	lease := &SessionLease{path: path, unlock: unlock}
+	if err := SaveSessionLeaseInfo(path, newSessionLeaseInfo(path)); err != nil {
+		lease.Release()
+		return nil, err
+	}
+	return lease, nil
+}
+
+func (l *SessionLease) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+func (l *SessionLease) Release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		_ = os.Remove(sessionLeaseInfoPath(l.path))
+		if l.unlock != nil {
+			l.unlock()
+		}
+		sessionLeaseOwners.Delete(l.path)
+	})
+}
+
+func newSessionLeaseInfo(path string) SessionLeaseInfo {
+	host, _ := os.Hostname()
+	return SessionLeaseInfo{
+		SessionPath: path,
+		WriterID:    SessionWriterID(),
+		PID:         os.Getpid(),
+		Hostname:    host,
+		AcquiredAt:  time.Now().UTC(),
+	}
+}
+
+func LoadSessionLeaseInfo(path string) (*SessionLeaseInfo, error) {
+	b, err := os.ReadFile(sessionLeaseInfoPath(path))
+	if err != nil {
+		return nil, err
+	}
+	var info SessionLeaseInfo
+	if err := json.Unmarshal(b, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func SaveSessionLeaseInfo(path string, info SessionLeaseInfo) error {
+	leasePath := sessionLeaseInfoPath(path)
+	if err := os.MkdirAll(filepath.Dir(leasePath), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(leasePath), ".lease.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := fileutil.ReplaceFile(tmpPath, leasePath); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func sessionLeaseInfoPath(path string) string {
+	return canonicalSessionSavePath(path) + ".lease.json"
+}

--- a/internal/agent/session_lease_test.go
+++ b/internal/agent/session_lease_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	first, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("first TryAcquireSessionLease: %v", err)
+	}
+	if first.Path() == "" {
+		t.Fatal("first lease path is empty")
+	}
+	info, err := LoadSessionLeaseInfo(path)
+	if err != nil {
+		t.Fatalf("LoadSessionLeaseInfo: %v", err)
+	}
+	if info.WriterID == "" || info.PID == 0 || info.SessionPath == "" {
+		t.Fatalf("lease info = %+v, want writer metadata", info)
+	}
+
+	second, err := TryAcquireSessionLease(path)
+	if !errors.Is(err, ErrSessionLeaseHeld) {
+		t.Fatalf("second TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+	if second != nil {
+		second.Release()
+		t.Fatal("second lease unexpectedly acquired")
+	}
+
+	first.Release()
+	third, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("third TryAcquireSessionLease after release: %v", err)
+	}
+	third.Release()
+}

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -15,6 +16,24 @@ func lockSessionFile(path string) (func(), error) {
 	}
 	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
 		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
+func tryLockSessionLeaseFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, ErrSessionLeaseHeld
+		}
 		return nil, err
 	}
 	return func() {

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockSessionFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -17,6 +18,27 @@ func lockSessionFile(path string) (func(), error) {
 	var overlapped windows.Overlapped
 	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
 		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+		_ = f.Close()
+	}, nil
+}
+
+func tryLockSessionLeaseFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, ErrSessionLeaseHeld
+		}
 		return nil, err
 	}
 	return func() {

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockSessionFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -124,7 +124,7 @@ type Options struct {
 	// SessionRecoveryMeta and OnSessionRecovered let richer frontends attach
 	// local UI metadata to automatic transcript recovery branches.
 	SessionRecoveryMeta func(control.SessionRecoveryRequest) agent.BranchMeta
-	OnSessionRecovered  func(control.SessionRecoveryInfo)
+	OnSessionRecovered  func(control.SessionRecoveryInfo) error
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -121,6 +121,10 @@ type Options struct {
 	// terminal. Headless/bot frontends pass a positive value so an unanswered
 	// prompt can't wedge the session indefinitely (#4626, #4402).
 	ApprovalTimeout time.Duration
+	// SessionRecoveryMeta and OnSessionRecovered let richer frontends attach
+	// local UI metadata to automatic transcript recovery branches.
+	SessionRecoveryMeta func(control.SessionRecoveryRequest) agent.BranchMeta
+	OnSessionRecovered  func(control.SessionRecoveryInfo)
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -1094,6 +1098,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		OnRememberMCPReadOnlyTrust: func(serverName, rawToolName string) control.MCPReadOnlyTrustResult {
 			return rememberMCPReadOnlyTrust(root, serverName, rawToolName)
 		},
+		SessionRecoveryMeta: opts.SessionRecoveryMeta,
+		OnSessionRecovered:  opts.OnSessionRecovered,
 	}
 	// Guardian: when guardian_model is configured, spawn an LLM safety reviewer
 	// that can auto-allow safe Ask decisions and annotate risky ones before

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -104,7 +104,7 @@ type Controller struct {
 	onRemember                 func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
 	onRememberMCPReadOnlyTrust func(serverName, rawToolName string) MCPReadOnlyTrustResult
 	sessionRecoveryMeta        func(SessionRecoveryRequest) agent.BranchMeta
-	onSessionRecovered         func(SessionRecoveryInfo)
+	onSessionRecovered         func(SessionRecoveryInfo) error
 
 	// balanceURL/balanceKey target the active provider's optional wallet-balance
 	// endpoint (empty when the provider declares none). Captured at build so a
@@ -340,8 +340,8 @@ type Options struct {
 	// an automatic recovery branch before it is written.
 	SessionRecoveryMeta func(SessionRecoveryRequest) agent.BranchMeta
 	// OnSessionRecovered is called after a stale runtime's transcript has been
-	// saved as a recovery branch.
-	OnSessionRecovered func(SessionRecoveryInfo)
+	// saved as a recovery branch, before the controller commits to that branch.
+	OnSessionRecovered func(SessionRecoveryInfo) error
 	// PlanModeAllowedTools names extra custom tools the plan-mode policy may treat
 	// as read-only. Known blocked tools and unsafe bash still lose.
 	PlanModeAllowedTools []string
@@ -2711,21 +2711,24 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 		}
 		return "", false, fmt.Errorf("recover stale session snapshot: %w", err)
 	}
+	recoveryInfo := SessionRecoveryInfo{
+		OriginalPath: path,
+		RecoveryPath: info.Path,
+		Existing:     info.Existing,
+		Reason:       reason,
+		Meta:         info.Meta,
+	}
+	if c.onSessionRecovered != nil {
+		if err := c.onSessionRecovered(recoveryInfo); err != nil {
+			return "", false, fmt.Errorf("commit recovered session: %w", err)
+		}
+	}
 	c.mu.Lock()
 	c.sessionPath = info.Path
 	c.guardianPath = guardian.PathFor(info.Path)
 	c.mu.Unlock()
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
-	if c.onSessionRecovered != nil {
-		c.onSessionRecovered(SessionRecoveryInfo{
-			OriginalPath: path,
-			RecoveryPath: info.Path,
-			Existing:     info.Existing,
-			Reason:       reason,
-			Meta:         info.Meta,
-		})
-	}
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text: fmt.Sprintf("session changed on disk; unsaved local transcript was saved as recovery branch %s", agent.BranchID(info.Path))})
 	return info.Path, true, nil

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -103,6 +103,8 @@ type Controller struct {
 	startedOnce                bool                             // guards the one-shot SessionStart hook on first turn
 	onRemember                 func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
 	onRememberMCPReadOnlyTrust func(serverName, rawToolName string) MCPReadOnlyTrustResult
+	sessionRecoveryMeta        func(SessionRecoveryRequest) agent.BranchMeta
+	onSessionRecovered         func(SessionRecoveryInfo)
 
 	// balanceURL/balanceKey target the active provider's optional wallet-balance
 	// endpoint (empty when the provider declares none). Captured at build so a
@@ -253,6 +255,20 @@ type MCPReadOnlyTrustResult struct {
 	Err       error
 }
 
+type SessionRecoveryRequest struct {
+	OriginalPath string
+	Reason       string
+	Mode         string
+}
+
+type SessionRecoveryInfo struct {
+	OriginalPath string
+	RecoveryPath string
+	Existing     bool
+	Reason       string
+	Meta         agent.BranchMeta
+}
+
 type externalFolderToolRefs interface {
 	RegisterReadRoot(token, root string)
 }
@@ -320,6 +336,12 @@ type Options struct {
 	// read-only when the user chooses "always allow" from the plan-mode trust
 	// prompt.
 	OnRememberMCPReadOnlyTrust func(serverName, rawToolName string) MCPReadOnlyTrustResult
+	// SessionRecoveryMeta lets a frontend attach scope/topic/profile metadata to
+	// an automatic recovery branch before it is written.
+	SessionRecoveryMeta func(SessionRecoveryRequest) agent.BranchMeta
+	// OnSessionRecovered is called after a stale runtime's transcript has been
+	// saved as a recovery branch.
+	OnSessionRecovered func(SessionRecoveryInfo)
 	// PlanModeAllowedTools names extra custom tools the plan-mode policy may treat
 	// as read-only. Known blocked tools and unsafe bash still lose.
 	PlanModeAllowedTools []string
@@ -369,6 +391,8 @@ func New(opts Options) *Controller {
 		classifier:                 classifier,
 		onRemember:                 opts.OnRemember,
 		onRememberMCPReadOnlyTrust: opts.OnRememberMCPReadOnlyTrust,
+		sessionRecoveryMeta:        opts.SessionRecoveryMeta,
+		onSessionRecovered:         opts.OnSessionRecovered,
 		balanceURL:                 opts.BalanceURL,
 		balanceKey:                 opts.BalanceKey,
 		balanceClient:              opts.BalanceClient,
@@ -2617,7 +2641,18 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 		err = s.SaveSnapshot(path)
 	}
 	if err != nil {
-		return err
+		if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
+			return err
+		}
+		recoveredPath, recovered, recoverErr := c.recoverSnapshotConflict(path, err, forceRewrite)
+		if recoverErr != nil {
+			return recoverErr
+		}
+		if !recovered {
+			return nil
+		}
+		path = recoveredPath
+		s = c.executor.Session()
 	}
 	// Persist guardian session so the prefix cache stays warm after restart.
 	if c.guardianSess != nil {
@@ -2636,6 +2671,76 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	// EnsureBranchMeta / SetBranchModel / TouchBranchMeta sequence.
 	preview, turns := agent.SessionPreviewFromMessages(s.Snapshot())
 	return agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity)
+}
+
+func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, bool, error) {
+	if c.executor == nil || strings.TrimSpace(path) == "" {
+		return "", false, saveErr
+	}
+	if kind, ok := agent.SnapshotConflictKind(saveErr); ok && kind == agent.SessionSnapshotConflictStalePrefix {
+		if c.adoptDiskSession(path) {
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: "session changed on disk; adopted the newer transcript"})
+			return path, true, nil
+		}
+	}
+	reason := "snapshot conflict"
+	mode := "snapshot"
+	if forceRewrite {
+		reason = "rewrite conflict"
+		mode = "rewrite"
+	}
+	req := SessionRecoveryRequest{OriginalPath: path, Reason: reason, Mode: mode}
+	meta := agent.BranchMeta{}
+	if c.sessionRecoveryMeta != nil {
+		meta = c.sessionRecoveryMeta(req)
+	}
+	info, err := c.executor.Session().SaveRecoveryBranch(agent.RecoveryBranchOptions{
+		OriginalPath: path,
+		Reason:       reason,
+		BranchMeta:   meta,
+	})
+	if err != nil {
+		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
+			if c.adoptDiskSession(path) {
+				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+					Text: "session changed on disk; adopted the newer transcript"})
+				return path, true, nil
+			}
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("recover stale session snapshot: %w", err)
+	}
+	c.mu.Lock()
+	c.sessionPath = info.Path
+	c.guardianPath = guardian.PathFor(info.Path)
+	c.mu.Unlock()
+	c.setActiveJobSession(info.Path)
+	c.rebindCheckpoints(info.Path)
+	if c.onSessionRecovered != nil {
+		c.onSessionRecovered(SessionRecoveryInfo{
+			OriginalPath: path,
+			RecoveryPath: info.Path,
+			Existing:     info.Existing,
+			Reason:       reason,
+			Meta:         info.Meta,
+		})
+	}
+	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text: fmt.Sprintf("session changed on disk; unsaved local transcript was saved as recovery branch %s", agent.BranchID(info.Path))})
+	return info.Path, true, nil
+}
+
+func (c *Controller) adoptDiskSession(path string) bool {
+	loaded, err := agent.LoadSession(path)
+	if err != nil || loaded == nil {
+		return false
+	}
+	c.executor.SetSession(loaded)
+	c.ResetPlannerSession()
+	c.rebindCheckpoints(path)
+	c.setActiveJobSession(path)
+	return true
 }
 
 func (c *Controller) messageCount() int {
@@ -2752,7 +2857,13 @@ func (c *Controller) replaceSessionAfterCancel(msgs []provider.Message) {
 	c.mu.Unlock()
 	if path != "" {
 		if err := c.executor.Session().SaveRewrite(path); err != nil {
-			slog.Warn("controller: post-cancel transcript flush", "err", err)
+			if errors.Is(err, agent.ErrSessionSnapshotConflict) {
+				if _, _, recoverErr := c.recoverSnapshotConflict(path, err, true); recoverErr != nil {
+					slog.Warn("controller: post-cancel transcript recovery", "err", recoverErr)
+				}
+			} else {
+				slog.Warn("controller: post-cancel transcript flush", "err", err)
+			}
 		}
 	}
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,7 +3,6 @@ package control
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -609,7 +608,7 @@ func TestSnapshotDoesNotRefreshSessionActivity(t *testing.T) {
 	}
 }
 
-func TestSnapshotRejectsStaleControllerOverwrite(t *testing.T) {
+func TestSnapshotAdoptsNewerDiskForPureStalePrefix(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 
@@ -630,8 +629,8 @@ func TestSnapshotRejectsStaleControllerOverwrite(t *testing.T) {
 		t.Fatalf("SnapshotActivity current: %v", err)
 	}
 
-	if err := stale.Snapshot(); !errors.Is(err, agent.ErrSessionSnapshotConflict) {
-		t.Fatalf("Snapshot stale err = %v, want ErrSessionSnapshotConflict", err)
+	if err := stale.Snapshot(); err != nil {
+		t.Fatalf("Snapshot stale prefix: %v", err)
 	}
 
 	loaded, err := agent.LoadSession(path)
@@ -644,9 +643,56 @@ func TestSnapshotRejectsStaleControllerOverwrite(t *testing.T) {
 	if got := loaded.Messages[4].Content; got != "two" {
 		t.Fatalf("last message after stale snapshot = %q, want %q", got, "two")
 	}
+	if got := len(stale.executor.Session().Snapshot()); got != 5 {
+		t.Fatalf("stale controller adopted message count = %d, want 5", got)
+	}
 }
 
-func TestSnapshotRewriteRejectsStaleControllerOverwrite(t *testing.T) {
+func TestSnapshotRecoversDivergedControllerTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	currentExec := agent.New(nil, nil, currentSess, agent.Options{}, event.Discard)
+	current := New(Options{Executor: currentExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := current.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity current: %v", err)
+	}
+
+	if err := stale.Snapshot(); err != nil {
+		t.Fatalf("Snapshot stale diverged: %v", err)
+	}
+	recoveryPath := stale.SessionPath()
+	if recoveryPath == path || recoveryPath == "" {
+		t.Fatalf("stale session path after recovery = %q, want recovery path", recoveryPath)
+	}
+	recovered, err := agent.LoadSession(recoveryPath)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	if got := recovered.Messages[len(recovered.Messages)-1].Content; got != "local second" {
+		t.Fatalf("recovery tail = %q, want local second", got)
+	}
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession original: %v", err)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "disk second" {
+		t.Fatalf("original tail = %q, want disk second", got)
+	}
+}
+
+func TestSnapshotRewriteRecoversStaleControllerTranscript(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 
@@ -671,8 +717,8 @@ func TestSnapshotRewriteRejectsStaleControllerOverwrite(t *testing.T) {
 		{Role: provider.RoleSystem, Content: "sys"},
 		{Role: provider.RoleUser, Content: "summarized first"},
 	})
-	if err := stale.SnapshotRewrite(); !errors.Is(err, agent.ErrSessionSnapshotConflict) {
-		t.Fatalf("SnapshotRewrite stale err = %v, want ErrSessionSnapshotConflict", err)
+	if err := stale.SnapshotRewrite(); err != nil {
+		t.Fatalf("SnapshotRewrite stale: %v", err)
 	}
 
 	loaded, err := agent.LoadSession(path)
@@ -684,6 +730,24 @@ func TestSnapshotRewriteRejectsStaleControllerOverwrite(t *testing.T) {
 	}
 	if got := loaded.Messages[4].Content; got != "two" {
 		t.Fatalf("last message after stale rewrite = %q, want %q", got, "two")
+	}
+	recoveryPath := stale.SessionPath()
+	if recoveryPath == path || recoveryPath == "" {
+		t.Fatalf("stale session path after rewrite recovery = %q, want recovery path", recoveryPath)
+	}
+	recovered, err := agent.LoadSession(recoveryPath)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	if got := recovered.Messages[1].Content; got != "summarized first" {
+		t.Fatalf("recovery content = %q, want summarized first", got)
+	}
+	meta, ok, err := agent.LoadBranchMeta(recoveryPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recovery ok=%v err=%v", ok, err)
+	}
+	if !meta.Recovered || meta.ParentID != agent.BranchID(path) {
+		t.Fatalf("recovery meta = %+v, want recovered parent", meta)
 	}
 }
 


### PR DESCRIPTION
## Summary

- save divergent stale controller transcripts into deterministic recovery branch sessions instead of dropping local-only turns or auto-merging unsafe JSONL histories
- add persistent transcript revision/CAS metadata (`revision`, `content_digest`, `writer_id`) so snapshot/rewrite saves only commit from the controller's recorded disk baseline, while listing/meta updates preserve those persistence fields
- add long-lived runtime leases with an in-process owner registry plus Unix `flock` / Windows `LockFileEx` lease files, and wire desktop tab build/rebind/close/recovery paths so one writable runtime owns a session path
- keep pure stale-prefix conflicts adopting the newer disk transcript, and surface recovery sessions in desktop tabs/project tree with recovery metadata, warning toast action, sidebar badge, and recovery banner

Refs #5783

## Verification

- `go test -count=1 ./internal/agent`
- `go test -count=1 ./internal/control ./internal/boot`
- `cd desktop && go test -count=1 .`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/project-tree-runtime.test.ts`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/agent -o "<tmp>/agent.test.exe"`
- `GOOS=linux GOARCH=amd64 go test -c ./internal/agent -o "<tmp>/agent.test"`
- `git diff --check`

## Cache impact

Cache-impact: none; this changes session persistence/recovery, sidecar metadata, and desktop runtime ownership, not provider-visible prompts, model input shaping, tool schemas, or cache key behavior.
Cache-guard: `go test -count=1 ./internal/agent`; `go test -count=1 ./internal/control ./internal/boot`; `cd desktop && go test -count=1 .`; `pnpm --dir desktop/frontend typecheck`; `pnpm --dir desktop/frontend check:css`; `pnpm --dir desktop/frontend exec tsx src/__tests__/project-tree-runtime.test.ts`; `GOOS=windows GOARCH=amd64 go test -c ./internal/agent -o "<tmp>/agent.test.exe"`; `GOOS=linux GOARCH=amd64 go test -c ./internal/agent -o "<tmp>/agent.test"`.
System-prompt-review: no provider-visible system prompt, memory prefix, output style, skill index, or tool schema behavior changes.
