### PR TITLE
Fix serve HTTP auth cookies / 修复 serve HTTP 登录 Cookie

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -509,6 +509,9 @@ func runServe(args []string) int {
 	} else if srv.AuthMode() == "password" {
 		fmt.Printf("  auth: password (login at http://%s/login)\n", *addr)
 	}
+	if warning := serve.PlainHTTPAuthWarning(serveCfg, *addr); warning != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", warning)
+	}
 	// Diagnostic: check whether balance endpoint is reachable
 	if b, err := ctrl.Balance(context.Background()); err != nil {
 		fmt.Fprintf(os.Stderr, "  balance: error — %v\n", err)

--- a/internal/serve/auth.go
+++ b/internal/serve/auth.go
@@ -392,19 +392,12 @@ func (ag *authGate) loginSubmit(w http.ResponseWriter, r *http.Request) {
 
 func (ag *authGate) setAuthCookie(w http.ResponseWriter, r *http.Request, c *http.Cookie) {
 	c.Secure = ag.authCookieSecure(r)
-	// codeql[go/cookie-secure-not-set] Loopback HTTP serve must keep local browser auth usable; non-loopback HTTP still sets Secure cookies.
+	// codeql[go/cookie-secure-not-set] Secure cookies are only sent back over HTTPS; plain-HTTP serve must keep token/password auth usable.
 	http.SetCookie(w, c)
 }
 
 func (ag *authGate) authCookieSecure(r *http.Request) bool {
-	if ag.isTLS(r) {
-		return true
-	}
-	host := r.Host
-	if host == "" && r.URL != nil {
-		host = r.URL.Host
-	}
-	return !isLoopbackHost(host)
+	return ag.isTLS(r)
 }
 
 func safeRedirectTarget(raw string) string {
@@ -594,4 +587,15 @@ func isLoopbackHost(hostport string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// PlainHTTPAuthWarning reports whether serve is exposing authenticated access
+// over a non-loopback plain-HTTP listener. The listener may still be valid for a
+// trusted LAN or reverse-proxy setup, but users should see the risk explicitly.
+func PlainHTTPAuthWarning(cfg config.ServeConfig, addr string) string {
+	mode, err := NormalizeAuthMode(cfg.AuthMode)
+	if err != nil || mode == "none" || isLoopbackHost(addr) {
+		return ""
+	}
+	return "warning: authenticated serve is listening on non-loopback HTTP; use HTTPS via a trusted reverse proxy or bind to 127.0.0.1 for local-only access"
 }

--- a/internal/serve/auth_test.go
+++ b/internal/serve/auth_test.go
@@ -215,7 +215,7 @@ func TestTokenModeLoopbackCookieAllowsLocalHTTP(t *testing.T) {
 	}
 }
 
-func TestTokenModeNonLoopbackCookieIsSecure(t *testing.T) {
+func TestTokenModeNonLoopbackCookieAllowsPlainHTTP(t *testing.T) {
 	ag := newAuthGate(config.ServeConfig{AuthMode: "token", Token: "secret"})
 	ts := httptest.NewServer(ag.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -239,8 +239,8 @@ func TestTokenModeNonLoopbackCookieIsSecure(t *testing.T) {
 	if c == nil {
 		t.Fatal("token cookie missing")
 	}
-	if !c.Secure {
-		t.Fatal("non-loopback token cookie must be Secure")
+	if c.Secure {
+		t.Fatal("plain HTTP token cookie should stay usable without Secure")
 	}
 }
 
@@ -385,6 +385,49 @@ func TestPasswordModeValidLogin(t *testing.T) {
 	resp2.Body.Close()
 	if resp2.StatusCode != http.StatusOK {
 		t.Errorf("authenticated status = %d, want 200", resp2.StatusCode)
+	}
+}
+
+func TestPasswordModeNonLoopbackHTTPLoginCookieIsUsable(t *testing.T) {
+	ag := newAuthGate(config.ServeConfig{AuthMode: "password", PasswordHash: mustHash("correct")})
+	ts := httptest.NewServer(ag.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+	defer ts.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	form := url.Values{"password": {"correct"}}
+	req, _ := http.NewRequest("POST", ts.URL+"/login", strings.NewReader(form.Encode()))
+	req.Host = "192.0.2.10:8787"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	sessionCookie := findCookie(resp.Cookies(), cookieSession)
+	if sessionCookie == nil {
+		t.Fatal("session cookie missing")
+	}
+	if sessionCookie.Secure {
+		t.Fatal("plain HTTP password session cookie should stay usable without Secure")
+	}
+
+	req, _ = http.NewRequest("GET", ts.URL+"/status", nil)
+	req.Host = "192.0.2.10:8787"
+	req.AddCookie(sessionCookie)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("authenticated non-loopback status = %d, want 200", resp.StatusCode)
 	}
 }
 
@@ -675,8 +718,8 @@ func TestAuthCookieSecurePolicy(t *testing.T) {
 	}
 
 	req, _ := http.NewRequest("GET", "http://192.0.2.10:8787/", nil)
-	if !ag.authCookieSecure(req) {
-		t.Fatal("non-loopback HTTP cookies should be marked Secure")
+	if ag.authCookieSecure(req) {
+		t.Fatal("plain HTTP cookies should stay usable without Secure")
 	}
 
 	proxy := newAuthGate(config.ServeConfig{AuthMode: "token", Token: "x", BehindProxy: true})
@@ -684,6 +727,21 @@ func TestAuthCookieSecurePolicy(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	if !proxy.authCookieSecure(req) {
 		t.Fatal("trusted forwarded HTTPS should mark cookies Secure")
+	}
+}
+
+func TestPlainHTTPAuthWarning(t *testing.T) {
+	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "none"}, "0.0.0.0:8787"); got != "" {
+		t.Fatalf("none auth warning = %q, want empty", got)
+	}
+	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "password"}, "127.0.0.1:8787"); got != "" {
+		t.Fatalf("loopback warning = %q, want empty", got)
+	}
+	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "token"}, "0.0.0.0:8787"); !strings.Contains(got, "non-loopback HTTP") {
+		t.Fatalf("non-loopback warning = %q, want HTTP exposure warning", got)
+	}
+	if got := PlainHTTPAuthWarning(config.ServeConfig{AuthMode: "password"}, ":8787"); !strings.Contains(got, "non-loopback HTTP") {
+		t.Fatalf("wildcard warning = %q, want HTTP exposure warning", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keep `reasonix serve` auth cookies `Secure` only when the request is HTTPS, so LAN/plain-HTTP token and password auth can complete instead of looping back to `/login`.
- Add a startup warning when authenticated serve is exposed on a non-loopback HTTP listener.
- Cover token and password auth cookie behavior with regression tests.

Fixes #5859

## Verification
- `go test ./internal/serve -run 'Test(TokenModeNonLoopbackCookieAllowsPlainHTTP|PasswordModeNonLoopbackHTTPLoginCookieIsUsable|AuthCookieSecurePolicy|PlainHTTPAuthWarning|IsTLS)' -count=1`
- `go test ./internal/cli -run 'TestServe(RejectsUnknownAuthMode|PasswordAuthRequiresPasswordMaterial)' -count=1`
- `go test ./internal/serve ./internal/cli -count=1`
- `git diff --check`

Cache-impact: none. Serve auth cookie policy only; provider prompts, tool schemas, and request serialization are unchanged.
