### PR TITLE
fix: route desktop updater via release gateway

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -8,7 +8,8 @@ name: Release desktop
 # Wails cannot cross-compile a CGO/WebKit binary, so build/ fans out to one native
 # runner per platform. Artifacts are minisign-signed (MINISIGN_* secrets), a
 # latest.json manifest is generated, and everything is published to a GitHub
-# release and mirrored to R2 (the updater reads R2 first, GitHub as fallback).
+# release and mirrored to R2 (the updater reads R2 first, then the crash worker
+# release gateway; GitHub's repository-wide "latest" is reserved for the CLI line).
 #
 # The same build/sign/manifest pipeline serves two channels. A `desktop-v*` tag
 # (or manual stable dispatch) publishes a GitHub release and moves R2's latest/
@@ -260,9 +261,9 @@ jobs:
         working-directory: desktop
         run: go run ./cmd/sign manifest ../dist "${{ steps.ver.outputs.version }}" "${{ steps.ver.outputs.tag }}"
 
-      # Canary is R2-only and never appears on the GitHub releases page; the mirror
-      # job picks up the signed dist via the canary-dist artifact below. Stable
-      # publishes a GitHub release as usual.
+      # Canary never appears on the GitHub releases page; the mirror job picks up
+      # the signed dist via the canary-dist artifact below. Stable publishes a
+      # GitHub release as usual.
       - name: Publish GitHub release
         if: steps.ver.outputs.channel != 'canary'
         env:
@@ -285,7 +286,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read # gh release download
+      contents: write # gh release download + compatibility manifest upload
       actions: write # dispatch pages.yml to re-bake the site version
     # Skip cleanly when R2 isn't configured; GitHub release still works as fallback.
     if: ${{ github.repository_owner == 'esengine' }}
@@ -364,6 +365,53 @@ jobs:
             echo "prerelease — leaving R2 latest/ untouched"
           else
             aws s3 cp assets/ "s3://${R2_BUCKET}/latest/" --recursive --endpoint-url "$ENDPOINT"
+          fi
+
+      - name: Smoke desktop release pointers
+        if: env.HAS_R2 == 'true'
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          CHANNEL: ${{ steps.ver.outputs.channel }}
+          PRERELEASE: ${{ steps.ver.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          f=assets/latest.json
+          jq -e --arg version "$VERSION" --arg prefix "https://dl.reasonix.io/${TAG}/" '
+            .version == $version and
+            .download_page == "https://reasonix.io/#start" and
+            ([.platforms[] | (.url, .sig)] |
+              all(type == "string" and startswith($prefix) and (contains("/releases/latest/") | not)))
+          ' "$f" >/dev/null
+
+          curl --retry 5 --retry-delay 2 -fsSL "https://dl.reasonix.io/${TAG}/latest.json" >/tmp/reasonix-desktop-tag-latest.json
+          if [ "$CHANNEL" = "canary" ]; then
+            pointer="canary"
+          elif [ "$PRERELEASE" = "true" ]; then
+            pointer=""
+          else
+            pointer="latest"
+          fi
+          if [ -n "$pointer" ]; then
+            curl --retry 5 --retry-delay 2 -fsSL "https://dl.reasonix.io/${pointer}/latest.json" >/tmp/reasonix-desktop-pointer-latest.json
+            jq -e --arg version "$VERSION" '.version == $version' /tmp/reasonix-desktop-pointer-latest.json >/dev/null
+          fi
+
+          jq -r '.platforms[] | .url, .sig' "$f" | while IFS= read -r asset; do
+            curl --retry 5 --retry-delay 2 -fsSI "$asset" >/dev/null
+          done
+
+      - name: Attach desktop manifest to matching CLI release
+        if: env.HAS_R2 == 'true' && steps.ver.outputs.channel != 'canary' && steps.ver.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release upload "$VERSION" assets/latest.json --clobber
+          else
+            echo "CLI release $VERSION does not exist yet; release.yml will attach the compatibility latest.json when it publishes."
           fi
 
       # Stable release moved R2 latest/ — rebuild the site so its build-time baked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Attach desktop manifest compatibility asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            *-*)
+              echo "prerelease $TAG — GitHub latest does not move here; skipping desktop manifest compatibility asset"
+              exit 0
+              ;;
+          esac
+          curl --retry 5 --retry-delay 2 -fsSL https://dl.reasonix.io/latest/latest.json -o latest.raw.json
+          jq '.download_page = "https://reasonix.io/#start"' latest.raw.json > latest.json
+          jq -e '
+            ([.platforms[] | (.url, .sig)] |
+              all(type == "string" and startswith("https://dl.reasonix.io/") and (contains("/releases/latest/") | not)))
+          ' latest.json >/dev/null
+          gh release upload "$TAG" latest.json --clobber

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -101,7 +101,9 @@ Desktop releases ride their own tag namespace, `desktop-v<semver>` (plain `v*`
 tags are the CLI release). Pushing one triggers `.github/workflows/release-desktop.yml`,
 which builds on a native runner per platform (Wails can't cross-compile a
 CGO/WebKit binary), packages each artifact, signs it with minisign, generates a
-`latest.json` manifest, publishes a GitHub release, and mirrors everything to R2.
+`latest.json` manifest, publishes a GitHub release, mirrors everything to R2,
+and attaches the current desktop manifest to the matching CLI release for old
+clients that still ask GitHub's repository-wide `latest` release for it.
 The Linux artifact links against WebKitGTK 4.1 (`-tags webkit2_41`), so it needs
 `libwebkit2gtk-4.1-0` at runtime — present by default on Ubuntu 22.04+, Fedora 40+.
 
@@ -109,9 +111,12 @@ The Linux artifact links against WebKitGTK 4.1 (`-tags webkit2_41`), so it needs
 git tag desktop-v1.1.0 && git push origin desktop-v1.1.0
 ```
 
-The app checks `latest.json` on startup (R2 first, GitHub as fallback) and shows
-an update banner when a newer version is published; **Settings → Software update**
-has a manual check. Self-update behavior by platform:
+The app checks `latest.json` on startup (R2 first, then the
+`crash.reasonix.io` desktop release gateway) and shows an update banner when a
+newer version is published; **Settings → Software update** has a manual check.
+The gateway resolves only the desktop `desktop-v*` release line and never uses
+GitHub's repository-wide `/releases/latest` shortcut, because plain `v*` tags are
+the CLI release line. Self-update behavior by platform:
 
 - **Linux / Windows** — download, verify the minisign signature, then update in
   place: Linux replaces the binary and relaunches; Windows runs the per-user NSIS

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -166,12 +166,12 @@ func signFiles(files []string) error {
 // release tag used in download URLs (e.g. "desktop-v1.1.0").
 func genManifest(dir, version, tag string) error {
 	repo := os.Getenv("GITHUB_REPOSITORY")
-	if repo == "" {
-		repo = "esengine/reasonix"
+	if repo == "" || repo == "esengine/reasonix" {
+		repo = "esengine/DeepSeek-Reasonix"
 	}
 	m := update.Manifest{
 		Version:      version,
-		DownloadPage: fmt.Sprintf("https://github.com/%s/releases/latest", repo),
+		DownloadPage: "https://reasonix.io/#start",
 		Platforms:    map[string]update.Asset{},
 	}
 	entries, err := os.ReadDir(dir)

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -85,6 +85,9 @@ func TestGenManifest(t *testing.T) {
 	if m.Version != "v1.2.0" {
 		t.Fatalf("version = %q, want v1.2.0", m.Version)
 	}
+	if m.DownloadPage != "https://reasonix.io/#start" {
+		t.Fatalf("download_page = %q, want official install page", m.DownloadPage)
+	}
 	if len(m.Platforms) != 5 {
 		t.Fatalf("want 5 platforms, got %d: %v", len(m.Platforms), m.Platforms)
 	}
@@ -92,7 +95,7 @@ func TestGenManifest(t *testing.T) {
 	if !ok {
 		t.Fatal("windows-amd64 missing")
 	}
-	wantURL := "https://github.com/esengine/reasonix/releases/download/desktop-v1.2.0/Reasonix-windows-amd64-installer.exe"
+	wantURL := "https://github.com/esengine/DeepSeek-Reasonix/releases/download/desktop-v1.2.0/Reasonix-windows-amd64-installer.exe"
 	if win.URL != wantURL {
 		t.Fatalf("windows url = %q, want %q", win.URL, wantURL)
 	}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -3044,7 +3044,7 @@ function makeMockApp(): AppBindings {
     },
     async OpenDownloadPage() {
       if (typeof window !== "undefined") {
-        window.open("https://github.com/esengine/reasonix/releases/latest", "_blank", "noopener");
+        window.open("https://reasonix.io/#start", "_blank", "noopener");
       }
     },
     // Dev seam: drives the overlay flow in the browser until ConnectKey sets the

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1698,7 +1698,7 @@ export const en = {
   "settings.telemetryLabel": "Anonymous usage ping",
   "settings.telemetryHint": "On launch, send a random install id plus version and OS to count active installs, and — if the app crashed on a previous run — resend that crash report. Never includes conversations, keys, or file contents.",
   "settings.metricsLabel": "Share aggregate quality metrics",
-  "settings.metricsHint": "On by default. Sends anonymous turn-end counts, settings preference snapshots, and Memory v5 aggregate buckets such as injection on/off, size buckets, IR count buckets, and memory graph size buckets. Includes the random install id used to de-duplicate DAU. Buckets may include normalized custom provider and model names — never conversations, prompts, keys, paths, base URLs, memory text, tool outputs, or file contents.",
+  "settings.metricsHint": "On by default. Sends anonymous turn-end counts, updater error categories, settings preference snapshots, and Memory v5 aggregate buckets such as injection on/off, size buckets, IR count buckets, and memory graph size buckets. Includes the random install id used to de-duplicate DAU. Buckets may include normalized custom provider and model names — never conversations, prompts, keys, paths, base URLs, memory text, tool outputs, or file contents.",
   "updater.currentVersion": "Current version: {v}",
   "updater.channelLabel": "Update channel: {channel}",
   "updater.checkButton": "Check for updates",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1819,7 +1819,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.telemetryLabel": "匿名啟動統計",
   "settings.telemetryHint": "啟動時傳送隨機安裝 ID、版本號和作業系統用於統計活躍安裝量；若上次執行發生崩潰，則在本次啟動補發該崩潰報告。絕不包含對話、金鑰或檔案內容。",
   "settings.metricsLabel": "共享聚合品質指標",
-  "settings.metricsHint": "預設開啟。傳送匿名的輪次結束統計、設定偏好快照，以及 Memory v5 聚合桶，例如是否注入、大小桶、IR 數量桶和記憶圖規模桶。包含用於 DAU 去重的隨機安裝 ID。Bucket 可能包含正規化後的自訂 Provider 名和模型名——絕不包含對話、提示詞、金鑰、路徑、base URL、記憶正文、工具輸出或檔案內容。",
+  "settings.metricsHint": "預設開啟。傳送匿名的輪次結束統計、更新器錯誤類別、設定偏好快照，以及 Memory v5 聚合桶，例如是否注入、大小桶、IR 數量桶和記憶圖規模桶。包含用於 DAU 去重的隨機安裝 ID。Bucket 可能包含正規化後的自訂 Provider 名和模型名——絕不包含對話、提示詞、金鑰、路徑、base URL、記憶正文、工具輸出或檔案內容。",
   "context.windowTitle": "上下文視窗",
   "context.windowStatusHealthy": "上下文充足",
   "context.windowStatusWatch": "即將壓縮",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1700,7 +1700,7 @@ export const zh: Record<DictKey, string> = {
   "settings.telemetryLabel": "匿名启动统计",
   "settings.telemetryHint": "启动时发送随机安装 ID、版本号和操作系统用于统计活跃安装量；若上次运行发生崩溃，则在本次启动补发该崩溃报告。绝不包含对话、密钥或文件内容。",
   "settings.metricsLabel": "共享聚合质量指标",
-  "settings.metricsHint": "默认开启。发送匿名的轮次结束统计、设置偏好快照，以及 Memory v5 聚合桶，例如是否注入、大小桶、IR 数量桶和记忆图规模桶。包含用于 DAU 去重的随机安装 ID。Bucket 可能包含归一化后的自定义 Provider 名和模型名——绝不包含对话、提示词、密钥、路径、base URL、记忆正文、工具输出或文件内容。",
+  "settings.metricsHint": "默认开启。发送匿名的轮次结束统计、更新器错误类别、设置偏好快照，以及 Memory v5 聚合桶，例如是否注入、大小桶、IR 数量桶和记忆图规模桶。包含用于 DAU 去重的随机安装 ID。Bucket 可能包含归一化后的自定义 Provider 名和模型名——绝不包含对话、提示词、密钥、路径、base URL、记忆正文、工具输出或文件内容。",
   "updater.currentVersion": "当前版本：{v}",
   "updater.channelLabel": "更新渠道：{channel}",
   "updater.checkButton": "检查更新",

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -33,36 +33,38 @@ import (
 // has no Wails dependency so the logic is unit-tested directly; updater_app.go is
 // the thin Wails binding that wires these into App methods and progress events.
 
-// Manifest endpoints — R2 CDN first (fast, especially in CN), GitHub releases as
-// fallback. The build channel picks the rolling pointer so a canary build polls
-// the canary line and a stable build polls latest; the two never cross.
+// Manifest endpoints — R2 CDN first (fast, especially in CN), then the crash
+// worker release gateway. The build channel picks the rolling pointer so a
+// canary build polls the canary line and a stable build polls latest; the two
+// never cross. The gateway deliberately avoids GitHub's repository-wide
+// /releases/latest shortcut because CLI tags (v*) and desktop tags (desktop-v*)
+// are separate release lines in the same repo.
 const (
-	r2Base         = "https://dl.reasonix.io"
-	ghReleasesBase = "https://github.com/esengine/reasonix/releases"
-	httpTimeout    = 15 * time.Second
+	r2Base             = "https://dl.reasonix.io"
+	releaseGatewayBase = "https://crash.reasonix.io/v1/desktop/releases"
+	downloadPageURL    = "https://reasonix.io/#start"
+	httpTimeout        = 15 * time.Second
 )
 
 // manifestEndpoints returns the primary (R2) then fallback (GitHub) manifest URLs
 // for the running build's channel.
 func manifestEndpoints() []string {
 	if channel == "canary" {
-		// Canary publishes only to R2 (no GitHub release), so there is no
-		// GitHub fallback for this channel.
-		return []string{r2Base + "/canary/latest.json"}
+		return []string{
+			r2Base + "/canary/latest.json",
+			releaseGatewayBase + "/canary/latest.json",
+		}
 	}
 	return []string{
 		r2Base + "/latest/latest.json",
-		ghReleasesBase + "/latest/download/latest.json",
+		releaseGatewayBase + "/stable/latest.json",
 	}
 }
 
 // downloadPage is the human-facing releases page shown when self-update is
 // unavailable (macOS) or the manifest omits its own link.
 func downloadPage() string {
-	if channel == "canary" {
-		return ghReleasesBase // lists pre-releases too
-	}
-	return ghReleasesBase + "/latest"
+	return downloadPageURL
 }
 
 // UpdateInfo is the CheckUpdate result that drives the frontend's update banner.

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -27,6 +27,7 @@ func (a *App) Version() string { return version }
 func (a *App) CheckUpdate() (*UpdateInfo, error) {
 	c, err := httpClient()
 	if err != nil {
+		a.recordUpdateError(err)
 		return &UpdateInfo{
 			Current:       version,
 			Channel:       channel,
@@ -41,6 +42,7 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 	defer cancel()
 	m, err := fetchManifest(ctx, c)
 	if err != nil {
+		a.recordUpdateError(err)
 		return &UpdateInfo{
 			Current:       version,
 			Channel:       channel,
@@ -55,7 +57,7 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 	return &info, nil
 }
 
-// OpenDownloadPage opens the releases page in the browser — the macOS manual-update
+// OpenDownloadPage opens the install page in the browser — the macOS manual-update
 // path and a fallback link elsewhere.
 func (a *App) OpenDownloadPage() {
 	page := downloadPage()
@@ -208,6 +210,16 @@ func (a *App) emitProgress(phase string, received, total int64, errMsg string) {
 
 // failUpdate emits an error progress event and returns the error to the caller.
 func (a *App) failUpdate(err error) error {
+	a.recordUpdateError(err)
 	a.emitProgress("error", 0, 0, err.Error())
 	return err
+}
+
+func (a *App) recordUpdateError(err error) {
+	if err == nil || version == "dev" {
+		return
+	}
+	if m := a.metrics.Load(); m != nil {
+		m.inc("updater_error", errorClass(err.Error()))
+	}
 }

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -98,6 +98,14 @@ func TestChannelSelectsDistinctPointers(t *testing.T) {
 	if !strings.Contains(stable[0], "/latest/latest.json") {
 		t.Errorf("stable primary = %q, want the latest/ pointer", stable[0])
 	}
+	if stable[1] != releaseGatewayBase+"/stable/latest.json" {
+		t.Errorf("stable fallback = %q, want the release gateway", stable[1])
+	}
+	for _, u := range append(stable, canary...) {
+		if strings.Contains(u, "/releases/latest") {
+			t.Errorf("manifest endpoint uses GitHub's repository-wide latest release: %q", u)
+		}
+	}
 	for _, u := range canary {
 		if strings.Contains(u, "/latest/") {
 			t.Errorf("canary endpoint hits the stable latest/ pointer: %q", u)
@@ -106,8 +114,11 @@ func TestChannelSelectsDistinctPointers(t *testing.T) {
 	if !strings.Contains(canary[0], "/canary/latest.json") {
 		t.Errorf("canary primary = %q, want the canary/ pointer", canary[0])
 	}
-	if downloadPage() == (ghReleasesBase + "/latest") {
-		t.Error("canary download page should not be the stable latest releases page")
+	if canary[1] != releaseGatewayBase+"/canary/latest.json" {
+		t.Errorf("canary fallback = %q, want the release gateway", canary[1])
+	}
+	if strings.Contains(downloadPage(), "/releases/latest") {
+		t.Errorf("download page should not use GitHub's repository-wide latest release: %q", downloadPage())
 	}
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,7 +18,7 @@ provides the pre-release buffer instead of a long-lived branch.
 | Surface | Stable | Pre-release buffer |
 |---|---|---|
 | npm | `latest` (0.x), `next` (1.x) | `canary` (`npm i reasonix@canary`) |
-| Desktop | R2 `latest/` pointer | R2 `canary/` pointer (R2-only — never on the GitHub releases page) |
+| Desktop | R2 `latest/` pointer + release gateway | R2 `canary/` pointer + release gateway proxy (never on the GitHub releases page) |
 
 A canary build is isolated: it **never** moves `latest` / `next` / desktop `latest/`.
 Testers opt in explicitly. (Desktop builds carry `-X main.channel=canary`; npm versions
@@ -68,8 +68,13 @@ the `release` environment deployment.
 - Canary version numbers use the workflow `run_number`, so the desktop and CLI canary
   numbers differ (e.g. `canary.11` vs `canary.2`). Only monotonicity per channel matters.
 - A stable `-rc` tag (e.g. `npm-v1.4.0-rc.1`) still ships under `next`, not `canary`.
-- Desktop in-app updates use R2 first. Stable has a GitHub release fallback; canary is
-  R2-only and never appears on the GitHub releases page.
+- Desktop in-app updates use R2 first, then the `crash.reasonix.io` desktop release
+  gateway. The gateway resolves the `desktop-v*` release line directly and never uses
+  GitHub's repository-wide `/releases/latest`, because plain `v*` tags are the CLI
+  release line. Stable CLI releases also carry a compatibility `latest.json` asset so
+  older desktop builds that still use GitHub `latest` do not 404.
+- Canary uses R2 plus the same gateway proxy for the `canary/` pointer; it never
+  appears on the GitHub releases page.
 - Windows and Linux apply downloaded, minisign-verified artifacts in place. macOS
   applies in-app only for Developer ID signed and notarized builds; ad-hoc/local
   builds fall back to the download page.

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,17 +207,17 @@ reasonix"><span data-en>Copy</span><span data-zh>复制</span></button><pre><spa
   </div>
   <div class="panel" data-panel="desk">
     <div class="dls">
-      <a class="dl" href="https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/Reasonix-darwin-arm64.zip" download>
+      <a class="dl" href="https://dl.reasonix.io/latest/Reasonix-darwin-arm64.zip" download>
         <span class="os">macOS</span><span class="fn">Reasonix-darwin-arm64.zip</span><span class="ar" data-en>universal · Intel + Apple Silicon</span><span class="ar" data-zh>通用 · Intel + Apple Silicon</span><span class="go">↓</span>
       </a>
-      <a class="dl" href="https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/Reasonix-windows-amd64-installer.exe" download>
+      <a class="dl" href="https://dl.reasonix.io/latest/Reasonix-windows-amd64-installer.exe" download>
         <span class="os">Windows</span><span class="fn">Reasonix-windows-amd64-installer.exe</span><span class="ar" data-en>installer · x64</span><span class="ar" data-zh>安装器 · x64</span><span class="go">↓</span>
       </a>
-      <a class="dl" href="https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/Reasonix-linux-amd64.tar.gz" download>
+      <a class="dl" href="https://dl.reasonix.io/latest/Reasonix-linux-amd64.tar.gz" download>
         <span class="os">Linux</span><span class="fn">Reasonix-linux-amd64.tar.gz</span><span class="ar" data-en>x64</span><span class="ar" data-zh>x64</span><span class="go">↓</span>
       </a>
     </div>
-    <p class="undertext"><span data-en>Served from the R2 CDN (fast worldwide). Or browse <a href="https://github.com/esengine/DeepSeek-Reasonix/releases/latest">all releases on GitHub</a>.</span><span data-zh>经 R2 CDN 分发(全球加速)。或在 <a href="https://github.com/esengine/DeepSeek-Reasonix/releases/latest">GitHub releases</a> 浏览全部。</span></p>
+    <p class="undertext"><span data-en>Served from the R2 CDN (fast worldwide). Or browse <a href="https://github.com/esengine/DeepSeek-Reasonix/releases">all releases on GitHub</a>.</span><span data-zh>经 R2 CDN 分发(全球加速)。或在 <a href="https://github.com/esengine/DeepSeek-Reasonix/releases">GitHub releases</a> 浏览全部。</span></p>
   </div>
 </section>
 
@@ -258,7 +258,7 @@ reasonix"><span data-en>Copy</span><span data-zh>复制</span></button><pre><spa
       <a href="https://github.com/esengine/DeepSeek-Reasonix">GitHub</a>
       <a href="https://www.npmjs.com/package/reasonix">npm</a>
       <a href="https://platform.deepseek.com" target="_blank" rel="noreferrer">DeepSeek</a>
-      <a href="https://github.com/esengine/DeepSeek-Reasonix/releases/latest"><span data-en>Releases</span><span data-zh>下载</span></a>
+      <a href="https://github.com/esengine/DeepSeek-Reasonix/releases"><span data-en>Releases</span><span data-zh>下载</span></a>
     </div>
   </div>
 </footer>

--- a/workers/crash-report/src/desktop_release.ts
+++ b/workers/crash-report/src/desktop_release.ts
@@ -1,0 +1,100 @@
+const R2_BASE = "https://dl.reasonix.io";
+const GITHUB_RELEASES_API = "https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases?per_page=30";
+
+type ReleaseChannel = "stable" | "canary";
+
+type GitHubAsset = {
+  name?: string;
+  browser_download_url?: string;
+};
+
+type GitHubRelease = {
+  tag_name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: GitHubAsset[];
+};
+
+function manifestPointer(channel: ReleaseChannel): string {
+  return channel === "canary" ? `${R2_BASE}/canary/latest.json` : `${R2_BASE}/latest/latest.json`;
+}
+
+function gatewayHeaders(source: string): HeadersInit {
+  return {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "public, max-age=60",
+    "x-reasonix-release-source": source,
+  };
+}
+
+function isManifestJSON(text: string): boolean {
+  try {
+    const data = JSON.parse(text) as { version?: unknown; platforms?: unknown };
+    return typeof data.version === "string" && Boolean(data.platforms) && typeof data.platforms === "object";
+  } catch {
+    return false;
+  }
+}
+
+async function fetchManifestText(url: string, source: string): Promise<Response | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        accept: "application/json",
+        "user-agent": "reasonix-release-gateway",
+      },
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    if (!isManifestJSON(text)) return null;
+    return new Response(text, { status: 200, headers: gatewayHeaders(source) });
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLatestDesktopManifestFromGitHub(): Promise<Response | null> {
+  try {
+    const list = await fetch(GITHUB_RELEASES_API, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "reasonix-release-gateway",
+      },
+    });
+    if (!list.ok) return null;
+
+    const releases = (await list.json()) as GitHubRelease[];
+    const latestDesktop = releases.find(
+      (r) =>
+        !r.draft &&
+        !r.prerelease &&
+        typeof r.tag_name === "string" &&
+        /^desktop-v\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?$/.test(r.tag_name),
+    );
+    const manifest = latestDesktop?.assets?.find((a) => a.name === "latest.json" && a.browser_download_url);
+    if (!manifest?.browser_download_url) return null;
+    return fetchManifestText(manifest.browser_download_url, "github-desktop-release");
+  } catch {
+    return null;
+  }
+}
+
+export async function handleDesktopReleaseManifest(channel: ReleaseChannel): Promise<Response> {
+  const r2 = await fetchManifestText(manifestPointer(channel), `r2-${channel}`);
+  if (r2) return r2;
+
+  if (channel === "stable") {
+    const github = await fetchLatestDesktopManifestFromGitHub();
+    if (github) return github;
+  }
+
+  return new Response(JSON.stringify({ error: "desktop release manifest unavailable", channel }) + "\n", {
+    status: 502,
+    headers: gatewayHeaders("unavailable"),
+  });
+}
+
+export function desktopReleaseChannel(path: string): ReleaseChannel | null {
+  const match = path.match(/^\/v1\/desktop\/releases\/(stable|canary)\/latest\.json$/);
+  return (match?.[1] as ReleaseChannel | undefined) ?? null;
+}

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -22,6 +22,7 @@ import type { Bindings as RegistryBindings } from "./registry/env";
 import { PackageRepo } from "./registry/db/packages";
 import { EventRepo } from "./registry/db/events";
 import { renderCommunity } from "./community";
+import { desktopReleaseChannel, handleDesktopReleaseManifest } from "./desktop_release";
 
 const MAX_BODY_BYTES = 96 * 1024;
 const LATEST_SAMPLES_PER_GROUP = 5;
@@ -85,6 +86,7 @@ const METRIC_SIGNALS = [
   "provider_error",
   "cache_hit",
   "tool_error",
+  "updater_error",
   "compaction",
   "turns",
   "client_surface",
@@ -978,6 +980,9 @@ export default {
     const path = url.pathname;
     const method = request.method;
 
+    const desktopRelease = desktopReleaseChannel(path);
+    if (desktopRelease && method === "GET") return handleDesktopReleaseManifest(desktopRelease);
+
     if (path === "/v1/report" && method === "POST") return handleReport(request, env);
     if (path === "/v1/ping" && method === "POST") return handlePing(request, env);
     if (path === "/v1/metrics" && method === "POST") return handleMetrics(request, env);
@@ -1038,6 +1043,7 @@ export default {
       path === "/v1/report" ||
       path === "/v1/ping" ||
       path === "/v1/metrics" ||
+      desktopReleaseChannel(path) ||
       path === "/login" ||
       path === "/register" ||
       path === "/logout" ||

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -172,6 +172,7 @@ const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
   provider_error: { en: "Provider errors", zh: "Provider 错误" },
   cache_hit: { en: "Cache hit rate", zh: "缓存命中率" },
   tool_error: { en: "Tool errors", zh: "工具错误" },
+  updater_error: { en: "Updater errors", zh: "更新器错误" },
   compaction: { en: "Compactions", zh: "压缩" },
   turns: { en: "Turns", zh: "轮次" },
   client_surface: { en: "Client surface", zh: "客户端形态" },
@@ -210,7 +211,7 @@ const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
   settings_bot_connection_approval: { en: "Bot: connection approval", zh: "机器人：连接审批" },
 };
 
-const AGENT_METRIC_SIGNALS = ["finish_reason", "empty_final", "provider_error", "cache_hit", "tool_error", "compaction", "turns"];
+const AGENT_METRIC_SIGNALS = ["finish_reason", "empty_final", "provider_error", "cache_hit", "tool_error", "updater_error", "compaction", "turns"];
 const DEFAULT_OPEN_SETTING_GROUPS = new Set(["Client", "Models", "Providers"]);
 
 const SETTINGS_METRIC_GROUPS: { en: string; zh: string; signals: string[] }[] = [


### PR DESCRIPTION
## Summary
- Route desktop updater manifest lookup through the R2 stable/canary pointer first, then through a `crash.reasonix.io` desktop release gateway.
- Add `GET /v1/desktop/releases/{stable,canary}/latest.json` to the crash worker. Stable fallback resolves the latest `desktop-v*` GitHub release instead of using the repository-wide `/releases/latest` shortcut.
- Normalize generated desktop manifests and manual download links to the official install page, and attach a compatibility `latest.json` asset to matching CLI releases for older desktop clients.
- Add anonymous `updater_error` metric buckets and show them in crash stats so update-path failures can be monitored after release.
- Update desktop release docs and static download links to match the R2 + gateway contract.

## Issue And Related PR
Fixes #5826.

Supersedes #5843. Thanks @myipanta for identifying the updater manifest 404 and the stale repository URL path; this PR keeps that repository correction and expands the fix to the full desktop release-line contract.

## Cache Impact
Cache-impact: none. This changes updater, release, crash-worker, stats, and documentation paths only; it does not touch provider-visible prompts, tool schemas, or model request serialization.

Cache-guard: GitHub `cache-impact` check passed.

## Verification
- `cd desktop && go test ./cmd/sign .`
- `npm --prefix workers/crash-report run typecheck`
- `pnpm --dir desktop/frontend typecheck`
- `git diff --check`
- GitHub PR checks passed for #5865.
