### PR TITLE
[codex] expose serve workspace status and dir handling

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -338,8 +338,12 @@ func runServe(args []string) int {
 	maxSteps := fs.Int("max-steps", 0, "max tool-call rounds (0 = use config/default)")
 	addr := fs.String("addr", "127.0.0.1:8787", "listen address")
 	resume := fs.String("resume", "", "resume a saved session file")
+	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	if rc := chdirTo(*dir); rc != 0 {
+		return rc
 	}
 
 	ctx := context.Background()

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -811,6 +811,8 @@ func (s *Server) status(w http.ResponseWriter, r *http.Request) {
 		"goal":             s.ctl().Goal(),
 		"goalStatus":       s.ctl().GoalStatus(),
 		"cwd":              s.ctl().SessionDir(),
+		"workspaceRoot":    s.ctl().WorkspaceRoot(),
+		"sessionDir":       s.ctl().SessionDir(),
 		"used":             used,
 		"window":           window,
 		"cacheHit":         hit,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -99,9 +99,11 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	carried := cur.History()
 
 	newCtrl, err := boot.Build(ctx, boot.Options{
-		Model:  ref,
-		Sink:   s.bc,
-		Stderr: os.Stderr,
+		Model:         ref,
+		WorkspaceRoot: cur.WorkspaceRoot(),
+		SessionDir:    cur.SessionDir(),
+		Sink:          s.bc,
+		Stderr:        os.Stderr,
 	})
 	if err != nil {
 		return fmt.Errorf("switch model: %w", err)


### PR DESCRIPTION
## Summary
- add `serve --dir` for explicit project-root startup
- expose `workspaceRoot` and `sessionDir` in `/status` while preserving legacy `cwd`
- preserve `workspaceRoot`/`sessionDir` when `/model` or `/effort` rebuilds the controller

## Validation
- `go build ./cmd/reasonix`
- `go test ./internal/control ./internal/boot`
- targeted `go test ./internal/serve` cases
- manual `/status` validation before and after `/model` and `/effort`
- real bridge MCP submit with `model`/`effort` keeps project `sessionDir`

## Known unrelated failure
- `go test ./internal/serve` still fails `TestServeIndexPagePassesLanguagePreferenceToClient`.
- This is pre-existing and unrelated to workspace/session handling.