### PR TITLE
Match safe bash redirects in permission rules / 支持安全 Bash 重定向权限匹配

### DIFF
--- a/internal/permission/bash_decompose.go
+++ b/internal/permission/bash_decompose.go
@@ -17,8 +17,8 @@ import (
 // newlines. Quoting (single, double, backslash-escapes inside double quotes)
 // and $(...) / <(...) / >(...) / `...` command / process substitutions are
 // treated as opaque — operators inside them do NOT split the outer command.
-// File-descriptor duplication like `2>&1` is recognized (the `&` following an
-// unquoted `>` does not split).
+// File-descriptor duplication like `2>&1` and combined redirects like
+// `&>/dev/null` are recognized as redirection syntax rather than splitters.
 //
 // Known out-of-scope shapes — the parser refuses to decompose these to keep
 // downstream matching safe, so callers fall back to whole-string matching:
@@ -30,7 +30,7 @@ import (
 // Returns nil when the input has no control operator to split on, or when the
 // parser encounters one of the above out-of-scope shapes. Redirect fragments
 // (`2>/dev/null`, `> file`) are left attached to the simple command they
-// annotate; stripping those is out of scope for this pass.
+// annotate; permission matching later strips only the conservative safe subset.
 //
 // The tokenizer is hand-rolled to avoid pulling in a full shell parser (e.g.
 // `mvdan.cc/sh`) for what is otherwise a small piece of permission-layer
@@ -44,6 +44,9 @@ func DecomposeBashCommand(cmd string) []string {
 	// Malformed shell: leading control operator with nothing before it.
 	trimmed := strings.TrimLeft(cmd, " \t\n\r")
 	for _, op := range []string{"&&", "||", ";", "|", "&"} {
+		if op == "&" && strings.HasPrefix(trimmed, "&>") {
+			continue
+		}
 		if strings.HasPrefix(trimmed, op) {
 			return nil
 		}
@@ -155,6 +158,12 @@ func DecomposeBashCommand(cmd string) []string {
 			flush()
 			split = true
 		case '&':
+			// `&>` / `&>>` are combined stdout+stderr redirections, not
+			// background/control operators.
+			if i+1 < len(cmd) && cmd[i+1] == '>' {
+				buf.WriteByte(c)
+				continue
+			}
 			// `>&` (fd duplication) is not a splitter. Look at the last
 			// non-whitespace byte written to buf.
 			if lastMeaningfulByte(&buf) == '>' {

--- a/internal/permission/bash_decompose_test.go
+++ b/internal/permission/bash_decompose_test.go
@@ -76,6 +76,16 @@ func TestDecomposeBashCommand(t *testing.T) {
 			want: []string{"go test ./... 2>&1", "tee log"},
 		},
 		{
+			name: "&>/dev/null redirection is not a splitter",
+			in:   "git log &>/dev/null | head -20",
+			want: []string{"git log &>/dev/null", "head -20"},
+		},
+		{
+			name: "leading &>/dev/null redirection is not malformed",
+			in:   "&>/dev/null git log | head -20",
+			want: []string{"&>/dev/null git log", "head -20"},
+		},
+		{
 			name: "empty tail after trailing operator is dropped",
 			in:   "ls -la;",
 			want: nil, // only one non-empty segment after split
@@ -157,6 +167,7 @@ func TestPolicyDecideCompoundBash(t *testing.T) {
 		"Bash(git add:*)",
 		"Bash(git commit:*)",
 		"Bash(git push:*)",
+		"Bash(go test:*)",
 		"Bash(sudo chmod:*)",
 	}, nil, []string{
 		"Bash(rm -rf*)",
@@ -195,14 +206,29 @@ func TestPolicyDecideCompoundBash(t *testing.T) {
 			want: Allow,
 		},
 		{
-			name:    "segments carrying redirects currently miss prefix match (follow-up)",
+			name:    "segment with dev null redirect still matches prefix rule",
 			subject: `sudo chmod 644 /etc/foo 2>/dev/null || echo "chmod failed"`,
-			// bashPrefixMatches rejects subjects with shell syntax, so the
-			// `2>/dev/null` suffix on the first segment prevents it from
-			// matching Bash(sudo chmod:*). This PR intentionally scopes to
-			// pure operator decomposition; redirect stripping is left for a
-			// follow-up so the diff stays reviewable.
-			want: Ask,
+			want:    Allow,
+		},
+		{
+			name:    "segment with file redirect still misses prefix rule",
+			subject: `sudo chmod 644 /etc/foo > chmod.log || echo "chmod failed"`,
+			want:    Ask,
+		},
+		{
+			name:    "segment with fd duplication still matches prefix rule",
+			subject: `go test ./... 2>&1 | head -20`,
+			want:    Allow,
+		},
+		{
+			name:    "read-only segment with dev null redirect auto-allows",
+			subject: `git log --oneline 2>/dev/null | head -20`,
+			want:    Allow,
+		},
+		{
+			name:    "write-capable read-only-looking arg still asks after safe redirect",
+			subject: `git diff --output changes.patch 2>/dev/null | head -20`,
+			want:    Ask,
 		},
 		{
 			name:    "atomic subject with matching prefix rule still allows",

--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -12,6 +12,9 @@ import (
 // shellsafe tables (one source of truth with the plan-mode gate, #5341); the
 // argument rigor below is permission-specific.
 func isReadOnlyBashSubject(subject string) bool {
+	if normalized, ok := normalizeBashSafeRedirectsForMatch(subject); ok {
+		subject = normalized
+	}
 	base, sub, ok := shellsafe.CommandIsReadOnly(subject)
 	if !ok {
 		return false

--- a/internal/permission/bash_readonly_test.go
+++ b/internal/permission/bash_readonly_test.go
@@ -31,6 +31,10 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"git diff", true},
 		{"git show HEAD", true},
 		{"git blame main.go", true},
+		{"git log 2>/dev/null", true},
+		{"git log >/dev/null", true},
+		{"git log 2>&1", true},
+		{"git log &>/dev/null", true},
 		{"git remote", false},
 		{"git remote add origin git@example.com:x/y", false},
 		{"git config --global user.name Xinwei", false},
@@ -40,6 +44,9 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"git bundle create repo.bundle HEAD", false},
 		{"git diff --output changes.patch", false},
 		{"git show --output=changes.patch HEAD", false},
+		{"git diff --output changes.patch 2>/dev/null", false},
+		{"git log > changes.patch", false},
+		{"git log < /dev/null", false},
 
 		// Go read-only
 		{"go vet ./...", true},

--- a/internal/permission/bash_readonly_test.go
+++ b/internal/permission/bash_readonly_test.go
@@ -33,6 +33,8 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"git blame main.go", true},
 		{"git log 2>/dev/null", true},
 		{"git log >/dev/null", true},
+		{"git log >$null", true},
+		{"git log >NUL", true},
 		{"git log 2>&1", true},
 		{"git log &>/dev/null", true},
 		{"git remote", false},
@@ -46,6 +48,8 @@ func TestIsReadOnlyBashSubject(t *testing.T) {
 		{"git show --output=changes.patch HEAD", false},
 		{"git diff --output changes.patch 2>/dev/null", false},
 		{"git log > changes.patch", false},
+		{"git log >$nullish", false},
+		{"git log >nul.txt", false},
 		{"git log < /dev/null", false},
 
 		// Go read-only

--- a/internal/permission/bash_redirect.go
+++ b/internal/permission/bash_redirect.go
@@ -1,0 +1,233 @@
+package permission
+
+import "strings"
+
+// normalizeBashSafeRedirectsForMatch returns a copy of subject with redirect
+// syntax removed only when the redirect cannot write to a real file. It is used
+// for permission matching, never for execution.
+//
+// Supported safe forms are fd duplication/close (`2>&1`, `>&2`, `2>&-`,
+// `0<&1`) and output redirects to /dev/null (`>/dev/null`,
+// `2> /dev/null`, `>>/dev/null`, `&>/dev/null`, `&>>/dev/null`). Other
+// redirections are left unnormalized so the usual shell-syntax guard keeps
+// prefix/read-only matching conservative.
+func normalizeBashSafeRedirectsForMatch(subject string) (string, bool) {
+	var (
+		out        strings.Builder
+		quote      byte
+		parenDepth int
+		backtick   bool
+		tokenStart = true
+		removed    bool
+	)
+
+	write := func(c byte) {
+		out.WriteByte(c)
+		tokenStart = isBashMatchSpace(c)
+	}
+	noteRemoved := func() {
+		removed = true
+		if out.Len() > 0 && !lastByteIsHorizontalSpace(out.String()) {
+			out.WriteByte(' ')
+		}
+		tokenStart = true
+	}
+
+	for i := 0; i < len(subject); {
+		c := subject[i]
+
+		switch {
+		case quote != 0:
+			write(c)
+			i++
+			if c == '\\' && quote == '"' && i < len(subject) {
+				write(subject[i])
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		case parenDepth > 0:
+			write(c)
+			i++
+			switch c {
+			case '(':
+				parenDepth++
+			case ')':
+				parenDepth--
+			}
+			continue
+		case backtick:
+			write(c)
+			i++
+			if c == '`' {
+				backtick = false
+			}
+			continue
+		}
+
+		switch c {
+		case '\'', '"':
+			quote = c
+			write(c)
+			i++
+		case '`':
+			backtick = true
+			write(c)
+			i++
+		case '\\':
+			write(c)
+			i++
+			if i < len(subject) {
+				write(subject[i])
+				i++
+			}
+		case '$':
+			if i+1 < len(subject) && subject[i+1] == '(' {
+				parenDepth = 1
+				write(c)
+				write('(')
+				i += 2
+				continue
+			}
+			write(c)
+			i++
+		case '&':
+			if next, ok := consumeSafeBashRedirect(subject, i); ok {
+				noteRemoved()
+				i = next
+				continue
+			}
+			write(c)
+			i++
+		case '>', '<':
+			if c == '<' && i+1 < len(subject) && subject[i+1] == '(' {
+				parenDepth = 1
+				write(c)
+				write('(')
+				i += 2
+				continue
+			}
+			if c == '>' && i+1 < len(subject) && subject[i+1] == '(' {
+				parenDepth = 1
+				write(c)
+				write('(')
+				i += 2
+				continue
+			}
+			if next, ok := consumeSafeBashRedirect(subject, i); ok {
+				noteRemoved()
+				i = next
+				continue
+			}
+			return "", false
+		default:
+			if tokenStart && isBashMatchDigit(c) {
+				if next, ok := consumeSafeBashRedirect(subject, i); ok {
+					noteRemoved()
+					i = next
+					continue
+				}
+			}
+			write(c)
+			i++
+		}
+	}
+
+	if !removed {
+		return subject, true
+	}
+	return strings.TrimSpace(out.String()), true
+}
+
+func consumeSafeBashRedirect(s string, start int) (int, bool) {
+	i := start
+	for i < len(s) && isBashMatchDigit(s[i]) {
+		i++
+	}
+	if i >= len(s) {
+		return start, false
+	}
+
+	switch {
+	case strings.HasPrefix(s[i:], ">&"), strings.HasPrefix(s[i:], "<&"):
+		return consumeBashFDDup(s, i+2)
+	case strings.HasPrefix(s[i:], "&>>"):
+		return consumeBashDevNullRedirect(s, i+3)
+	case strings.HasPrefix(s[i:], "&>"):
+		return consumeBashDevNullRedirect(s, i+2)
+	case strings.HasPrefix(s[i:], ">>"):
+		return consumeBashDevNullRedirect(s, i+2)
+	case s[i] == '>':
+		return consumeBashDevNullRedirect(s, i+1)
+	default:
+		return start, false
+	}
+}
+
+func consumeBashFDDup(s string, i int) (int, bool) {
+	i = skipBashMatchHorizontalSpace(s, i)
+	if i >= len(s) {
+		return i, false
+	}
+	if s[i] == '-' {
+		next := i + 1
+		if next < len(s) && !isBashRedirectWordEnd(s[next]) {
+			return next, false
+		}
+		return next, true
+	}
+	start := i
+	for i < len(s) && isBashMatchDigit(s[i]) {
+		i++
+	}
+	if i == start {
+		return i, false
+	}
+	if i < len(s) && !isBashRedirectWordEnd(s[i]) {
+		return i, false
+	}
+	return i, true
+}
+
+func consumeBashDevNullRedirect(s string, i int) (int, bool) {
+	i = skipBashMatchHorizontalSpace(s, i)
+	const devNull = "/dev/null"
+	if !strings.HasPrefix(s[i:], devNull) {
+		return i, false
+	}
+	next := i + len(devNull)
+	if next < len(s) && !isBashRedirectWordEnd(s[next]) {
+		return next, false
+	}
+	return next, true
+}
+
+func skipBashMatchHorizontalSpace(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+func isBashRedirectWordEnd(c byte) bool {
+	return isBashMatchSpace(c) || strings.ContainsRune(";|&<>", rune(c))
+}
+
+func isBashMatchSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isBashMatchDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func lastByteIsHorizontalSpace(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[len(s)-1]
+	return c == ' ' || c == '\t'
+}

--- a/internal/permission/bash_redirect.go
+++ b/internal/permission/bash_redirect.go
@@ -7,10 +7,11 @@ import "strings"
 // for permission matching, never for execution.
 //
 // Supported safe forms are fd duplication/close (`2>&1`, `>&2`, `2>&-`,
-// `0<&1`) and output redirects to /dev/null (`>/dev/null`,
-// `2> /dev/null`, `>>/dev/null`, `&>/dev/null`, `&>>/dev/null`). Other
-// redirections are left unnormalized so the usual shell-syntax guard keeps
-// prefix/read-only matching conservative.
+// `0<&1`) and output redirects to a null sink (`>/dev/null`, `>$null`,
+// `>nul`, `2> /dev/null`, `>>/dev/null`, `&>/dev/null`, `&>>/dev/null`).
+// The shell execution layer normalizes these null-sink spellings to the actual
+// sink for the resolved shell. Other redirections are left unnormalized so the
+// usual shell-syntax guard keeps prefix/read-only matching conservative.
 func normalizeBashSafeRedirectsForMatch(subject string) (string, bool) {
 	var (
 		out        strings.Builder
@@ -155,13 +156,13 @@ func consumeSafeBashRedirect(s string, start int) (int, bool) {
 	case strings.HasPrefix(s[i:], ">&"), strings.HasPrefix(s[i:], "<&"):
 		return consumeBashFDDup(s, i+2)
 	case strings.HasPrefix(s[i:], "&>>"):
-		return consumeBashDevNullRedirect(s, i+3)
+		return consumeBashNullRedirect(s, i+3)
 	case strings.HasPrefix(s[i:], "&>"):
-		return consumeBashDevNullRedirect(s, i+2)
+		return consumeBashNullRedirect(s, i+2)
 	case strings.HasPrefix(s[i:], ">>"):
-		return consumeBashDevNullRedirect(s, i+2)
+		return consumeBashNullRedirect(s, i+2)
 	case s[i] == '>':
-		return consumeBashDevNullRedirect(s, i+1)
+		return consumeBashNullRedirect(s, i+1)
 	default:
 		return start, false
 	}
@@ -192,13 +193,30 @@ func consumeBashFDDup(s string, i int) (int, bool) {
 	return i, true
 }
 
-func consumeBashDevNullRedirect(s string, i int) (int, bool) {
+func consumeBashNullRedirect(s string, i int) (int, bool) {
 	i = skipBashMatchHorizontalSpace(s, i)
-	const devNull = "/dev/null"
-	if !strings.HasPrefix(s[i:], devNull) {
+	for _, sink := range []string{"/dev/null", "$null", "nul"} {
+		next, ok := consumeBashNullSink(s, i, sink)
+		if ok {
+			return next, true
+		}
+	}
+	return i, false
+}
+
+func consumeBashNullSink(s string, i int, sink string) (int, bool) {
+	if i+len(sink) > len(s) {
 		return i, false
 	}
-	next := i + len(devNull)
+	got := s[i : i+len(sink)]
+	if sink == "/dev/null" {
+		if got != sink {
+			return i, false
+		}
+	} else if !strings.EqualFold(got, sink) {
+		return i, false
+	}
+	next := i + len(sink)
 	if next < len(s) && !isBashRedirectWordEnd(s[next]) {
 		return next, false
 	}

--- a/internal/permission/bash_redirect_test.go
+++ b/internal/permission/bash_redirect_test.go
@@ -1,0 +1,108 @@
+package permission
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBashSafeRedirectsForMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{
+			name: "stderr to dev null",
+			in:   "git log 2>/dev/null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "stdout to dev null with space",
+			in:   "git log > /dev/null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "append to dev null",
+			in:   "git log >>/dev/null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "combined stdout stderr redirect",
+			in:   "git log &>/dev/null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "combined append redirect",
+			in:   "git log &>> /dev/null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "fd duplication",
+			in:   "git log 2>&1",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "fd duplication target must be a full word",
+			in:   "git log 2>&1rm",
+			ok:   false,
+		},
+		{
+			name: "fd close",
+			in:   "git log 2>&-",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "fd close target must be a full word",
+			in:   "git log 2>&-x",
+			ok:   false,
+		},
+		{
+			name: "file output stays unsafe",
+			in:   "git log > changes.patch",
+			ok:   false,
+		},
+		{
+			name: "dev null prefix is not enough",
+			in:   "git log >/dev/null.log",
+			ok:   false,
+		},
+		{
+			name: "input redirection remains conservative",
+			in:   "git log < /dev/null",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeBashSafeRedirectsForMatch(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.ok, got)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("normalized = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBashSafeRedirectsPreservesControlSyntax(t *testing.T) {
+	got, ok := normalizeBashSafeRedirectsForMatch("git log >/dev/null\nrm -rf /tmp/x")
+	if !ok {
+		t.Fatal("safe redirect should normalize while preserving the newline")
+	}
+	if !strings.Contains(got, "\n") {
+		t.Fatalf("normalized command lost the control newline: %q", got)
+	}
+	if !containsShellSyntax(got) {
+		t.Fatalf("normalized command should still be treated as shell syntax: %q", got)
+	}
+}

--- a/internal/permission/bash_redirect_test.go
+++ b/internal/permission/bash_redirect_test.go
@@ -43,6 +43,24 @@ func TestNormalizeBashSafeRedirectsForMatch(t *testing.T) {
 			ok:   true,
 		},
 		{
+			name: "powershell null sink",
+			in:   "git log >$null",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "powershell null sink is case-insensitive",
+			in:   "git log 2> $NULL",
+			want: "git log",
+			ok:   true,
+		},
+		{
+			name: "windows nul sink",
+			in:   "git log > NUL",
+			want: "git log",
+			ok:   true,
+		},
+		{
 			name: "fd duplication",
 			in:   "git log 2>&1",
 			want: "git log",
@@ -72,6 +90,16 @@ func TestNormalizeBashSafeRedirectsForMatch(t *testing.T) {
 		{
 			name: "dev null prefix is not enough",
 			in:   "git log >/dev/null.log",
+			ok:   false,
+		},
+		{
+			name: "powershell null prefix is not enough",
+			in:   "git log >$nullish",
+			ok:   false,
+		},
+		{
+			name: "windows nul prefix is not enough",
+			in:   "git log >nul.txt",
 			ok:   false,
 		},
 		{

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
-
-	"reasonix/internal/shellsafe"
 )
 
 // Decision is the outcome of evaluating a tool call against a Policy.
@@ -184,7 +182,7 @@ func (p Policy) decideBashSegments(readOnly bool, parts []string) Decision {
 	for _, sub := range parts {
 		segReadOnly := readOnly
 		if !segReadOnly {
-			if _, _, ok := shellsafe.CommandIsReadOnly(sub); ok {
+			if isReadOnlyBashSubject(sub) {
 				segReadOnly = true
 			}
 		}
@@ -637,6 +635,9 @@ func bashPrefixBase(pattern string) (string, bool) {
 }
 
 func bashPrefixMatches(base, subject string) bool {
+	if normalized, ok := normalizeBashSafeRedirectsForMatch(subject); ok {
+		subject = normalized
+	}
 	if containsShellSyntax(subject) {
 		return false
 	}

--- a/internal/permission/permission_extra_test.go
+++ b/internal/permission/permission_extra_test.go
@@ -199,6 +199,38 @@ func TestRememberRuleForBashUsesPrefixWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestBashPrefixRulesMatchSafeRedirectsOnly(t *testing.T) {
+	safe := []string{
+		"git log 2>/dev/null",
+		"git log 2> /dev/null",
+		"git log >/dev/null",
+		"git log >>/dev/null",
+		"git log &>/dev/null",
+		"git log 2>&1",
+		"git log >&2",
+	}
+	for _, cmd := range safe {
+		if !RuleMatchesString("Bash(git log:*)", "bash", cmd) {
+			t.Errorf("prefix rule should match safe redirect command %q", cmd)
+		}
+	}
+
+	unsafe := []string{
+		"git log > out.txt",
+		"git log 2>out.txt",
+		"git log < input.txt",
+		"git log 2>&1rm",
+		"git log >/dev/null && rm -rf /tmp/x",
+		"git log 2>&1 && rm -rf /tmp/x",
+		"git log >/dev/null\nrm -rf /tmp/x",
+	}
+	for _, cmd := range unsafe {
+		if RuleMatchesString("Bash(git log:*)", "bash", cmd) {
+			t.Errorf("prefix rule should not match unsafe shell command %q", cmd)
+		}
+	}
+}
+
 func TestRememberRuleWithFileSubjectIsToolWide(t *testing.T) {
 	// File mutation tools are remembered tool-wide so "always allow editing"
 	// covers any file, matching the session-grant behaviour.

--- a/internal/permission/permission_extra_test.go
+++ b/internal/permission/permission_extra_test.go
@@ -206,6 +206,8 @@ func TestBashPrefixRulesMatchSafeRedirectsOnly(t *testing.T) {
 		"git log >/dev/null",
 		"git log >>/dev/null",
 		"git log &>/dev/null",
+		"git log >$null",
+		"git log >NUL",
 		"git log 2>&1",
 		"git log >&2",
 	}
@@ -219,6 +221,8 @@ func TestBashPrefixRulesMatchSafeRedirectsOnly(t *testing.T) {
 		"git log > out.txt",
 		"git log 2>out.txt",
 		"git log < input.txt",
+		"git log >$nullish",
+		"git log >nul.txt",
 		"git log 2>&1rm",
 		"git log >/dev/null && rm -rf /tmp/x",
 		"git log 2>&1 && rm -rf /tmp/x",

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -226,21 +225,126 @@ func windowsPowerShellCandidates() []string {
 	return out
 }
 
-// nulRedirect matches a cmd.exe-style redirect to the "nul" device (>nul,
-// 2>nul, 1>>nul, &>nul …) where nul is a complete token. bash and PowerShell
-// treat "nul" as an ordinary filename, not the null device, so the redirect
-// would create an undeletable file named "nul" (a Windows reserved name) in the
-// working directory. #4252. Group 2 captures the trailing delimiter (RE2 has no
-// lookahead) so it can be re-emitted unchanged.
-var nulRedirect = regexp.MustCompile(`(?i)((?:\d+|&)?>>?)\s*nul([\s;&|<>)]|$)`)
+// normalizeNullRedirects rewrites null-device redirect aliases to sink
+// ("/dev/null" for bash, "$null" for PowerShell), so permission-approved
+// null-sink commands discard output under the resolved shell. It handles
+// cmd.exe-style `nul`, PowerShell `$null`, and POSIX `/dev/null` while avoiding
+// quoted/escaped text.
+func normalizeNullRedirects(command, sink string) string {
+	var (
+		out   strings.Builder
+		quote byte
+	)
+	write := func(c byte) {
+		out.WriteByte(c)
+	}
+	for i := 0; i < len(command); {
+		c := command[i]
+		if quote != 0 {
+			write(c)
+			i++
+			if c == '\\' && quote == '"' && i < len(command) {
+				write(command[i])
+				i++
+				continue
+			}
+			if c == '`' && i < len(command) {
+				write(command[i])
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			quote = c
+			write(c)
+			i++
+		case '\\', '`':
+			write(c)
+			i++
+			if i < len(command) {
+				write(command[i])
+				i++
+			}
+		default:
+			if replacement, next, ok := consumeNullRedirect(command, i, sink); ok {
+				out.WriteString(replacement)
+				i = next
+				continue
+			}
+			write(c)
+			i++
+		}
+	}
+	return out.String()
+}
 
-// normalizeNulRedirect rewrites those nul redirects to sink ("/dev/null" for
-// bash, "$null" for PowerShell), so the command discards output as intended.
-func normalizeNulRedirect(command, sink string) string {
-	return nulRedirect.ReplaceAllStringFunc(command, func(m string) string {
-		sub := nulRedirect.FindStringSubmatch(m)
-		return sub[1] + sink + sub[2]
-	})
+func consumeNullRedirect(s string, start int, sink string) (string, int, bool) {
+	i := start
+	if i >= len(s) {
+		return "", start, false
+	}
+	if s[i] == '&' {
+		i++
+		if i < len(s) && s[i] == '>' {
+			i++
+			if i < len(s) && s[i] == '>' {
+				i++
+			}
+		} else {
+			return "", start, false
+		}
+	} else {
+		for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+			i++
+		}
+		if i >= len(s) || s[i] != '>' {
+			return "", start, false
+		}
+		i++
+		if i < len(s) && s[i] == '>' {
+			i++
+		}
+	}
+	opEnd := i
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	next, ok := consumeNullSink(s, i)
+	if !ok {
+		return "", start, false
+	}
+	return s[start:opEnd] + sink, next, true
+}
+
+func consumeNullSink(s string, i int) (int, bool) {
+	for _, sink := range []string{"/dev/null", "$null", "nul"} {
+		if i+len(sink) > len(s) {
+			continue
+		}
+		got := s[i : i+len(sink)]
+		if sink == "/dev/null" {
+			if got != sink {
+				continue
+			}
+		} else if !strings.EqualFold(got, sink) {
+			continue
+		}
+		next := i + len(sink)
+		if next < len(s) && !isNullRedirectWordEnd(s[next]) {
+			return next, false
+		}
+		return next, true
+	}
+	return i, false
+}
+
+func isNullRedirectWordEnd(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || strings.ContainsRune(";&|<>)]", rune(c))
 }
 
 // argv builds the exec argv that runs command under this shell.
@@ -250,9 +354,9 @@ func (s Shell) argv(command string) []string {
 		path = s.Kind.String()
 	}
 	if s.Kind == ShellPowerShell {
-		return []string{path, "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + normalizeNulRedirect(command, "$null")}
+		return []string{path, "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + normalizeNullRedirects(command, "$null")}
 	}
-	return []string{path, "-c", normalizeNulRedirect(command, "/dev/null")}
+	return []string{path, "-c", normalizeNullRedirects(command, "/dev/null")}
 }
 
 // SupportsChaining reports whether the shell parses '&&' / '||'. bash does;

--- a/internal/sandbox/shell_nul_test.go
+++ b/internal/sandbox/shell_nul_test.go
@@ -2,41 +2,50 @@ package sandbox
 
 import "testing"
 
-func TestNormalizeNulRedirect(t *testing.T) {
+func TestNormalizeNullRedirects(t *testing.T) {
 	const bash = "/dev/null"
 	cases := []struct {
 		in, sink, want string
 	}{
 		{"echo hi 2>nul", bash, "echo hi 2>/dev/null"},
 		{"echo hi 2>nul", "$null", "echo hi 2>$null"},
+		{"echo hi 2>/dev/null", "$null", "echo hi 2>$null"},
+		{"echo hi 2>$null", bash, "echo hi 2>/dev/null"},
+		{"echo hi 2>$NULL", "$null", "echo hi 2>$null"},
 		{"build >nul 2>&1", bash, "build >/dev/null 2>&1"},
 		{"a 2>nul; b", bash, "a 2>/dev/null; b"},
 		{"go test 1>>NUL", bash, "go test 1>>/dev/null"},
 		{"x > nul", bash, "x >/dev/null"},
 		{"x >nul", "$null", "x >$null"},
 		{"probe &>nul", bash, "probe &>/dev/null"},
+		{"probe &>/dev/null", "$null", "probe &>$null"},
+		{"probe &>>$null", bash, "probe &>>/dev/null"},
 		// Not a nul redirect — leave untouched.
 		{"echo nul", bash, "echo nul"},
 		{"grep nul file.txt", bash, "grep nul file.txt"},
 		{"cat nul.txt", bash, "cat nul.txt"},
+		{"cat /dev/null.txt", "$null", "cat /dev/null.txt"},
+		{"echo '$null >nul '", bash, "echo '$null >nul '"},
+		{"echo \"quoted >/dev/null \"", "$null", "echo \"quoted >/dev/null \""},
+		{"echo \\>nul", bash, "echo \\>nul"},
 		{"run 2>&1", bash, "run 2>&1"},
 		{"rm nul", bash, "rm nul"},
 		{"echo nullish", bash, "echo nullish"},
 	}
 	for _, c := range cases {
-		if got := normalizeNulRedirect(c.in, c.sink); got != c.want {
-			t.Errorf("normalizeNulRedirect(%q, %q) = %q, want %q", c.in, c.sink, got, c.want)
+		if got := normalizeNullRedirects(c.in, c.sink); got != c.want {
+			t.Errorf("normalizeNullRedirects(%q, %q) = %q, want %q", c.in, c.sink, got, c.want)
 		}
 	}
 }
 
-func TestArgvNormalizesNulRedirect(t *testing.T) {
+func TestArgvNormalizesNullRedirects(t *testing.T) {
 	bashArgv := Shell{Kind: ShellBash, Path: "bash"}.argv("echo hi 2>nul")
 	if last := bashArgv[len(bashArgv)-1]; last != "echo hi 2>/dev/null" {
 		t.Errorf("bash argv command = %q, want nul rewritten to /dev/null", last)
 	}
-	psArgv := Shell{Kind: ShellPowerShell, Path: "powershell"}.argv("echo hi 2>nul")
+	psArgv := Shell{Kind: ShellPowerShell, Path: "powershell"}.argv("echo hi 2>/dev/null")
 	if last := psArgv[len(psArgv)-1]; last != psUTF8Prologue+"echo hi 2>$null" {
-		t.Errorf("powershell argv command = %q, want nul rewritten to $null", last)
+		t.Errorf("powershell argv command = %q, want /dev/null rewritten to $null", last)
 	}
 }


### PR DESCRIPTION
## Summary
- Follow up #5703 by normalizing only safe shell redirect syntax for permission matching: fd duplication/close and output redirects to null sinks (`/dev/null`, PowerShell `$null`, and Windows `nul`).
- Apply the normalized copy to Bash prefix rules and read-only segment classification, while the shell argv layer normalizes null-sink aliases to the actual sink for the resolved shell (Bash/Git Bash -> `/dev/null`, PowerShell -> `$null`).
- Keep real file redirects, input redirects, preserved control syntax, and quoted/escaped redirect-looking text conservative so they continue to ask/fall back or execute unchanged as data.

Refs #5703.

## Cache Impact
- None. This only changes permission-layer matching, shell null-sink argv normalization, and tests; it does not change provider prompts, tool schemas, request serialization, or compaction behavior.
- `scripts/check-cache-impact.sh ...` reported no cache-sensitive prompt/tool files changed.

## Verification
- `go test ./internal/permission/... -count=1`
- `go test ./internal/permission ./internal/control ./internal/planmode ./internal/sandbox ./internal/tool/builtin -count=1`
- `go test ./internal/environment -run 'TestRunProbesCache' -count=1 -v`
- `go vet ./...`
- `go build ./cmd/reasonix`
- `git diff --check`
- `scripts/check-cache-impact.sh internal/permission/bash_decompose.go internal/permission/bash_decompose_test.go internal/permission/bash_readonly.go internal/permission/bash_readonly_test.go internal/permission/permission.go internal/permission/permission_extra_test.go internal/permission/bash_redirect.go internal/permission/bash_redirect_test.go internal/sandbox/shell.go internal/sandbox/shell_nul_test.go`

Note: `go test ./... -count=1` was also attempted; the full suite hit the existing `internal/environment` probe-cache timeout pattern under load, while the targeted rerun of those tests passed.
