### PR TITLE
fix: expand pasted blocks in displayText so AI sees full paste content

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1212,10 +1212,9 @@ export function Composer({
         ...currentWorkspaceRefs.map((ref) => formatWorkspaceReference(ref.displayPath || ref.path, ref.isDir)),
         ...orderedAttachments.map(formatAttachmentDisplayReference),
       ].join(" ");
-      const displayText = [trimmedText, displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
+      const displayText = [expandPastedBlocks(trimmedText), displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
       // PR-B: when past:chats refs are attached, prepend their formatted transcript
-      // to submitText only (displayText stays unchanged so the user still sees their
-      // original prompt in the input preview). With no refs we keep the original
+      // to submitText only (displayText now also expands pasted blocks for AI context).
       // submitText verbatim — no header, no rewording, byte-identical to pre-PR-B.
       const currentSessionRefs = sessionRefsRef.current;
       const sessionContext = currentSessionRefs.length === 0 ? "" : await buildSessionContext(currentSessionRefs);


### PR DESCRIPTION
When users paste long text (>=20 lines or >=2000 chars), the Composer folds it into a PastedBlock with a label like '[Pasted text #1]'. The submitText correctly used expandPastedBlocks() to restore the full content, but displayText (which gets stored in conversation history and sent to the model as context in subsequent turns) was not expanded — the model only saw the folded label.

This fix applies expandPastedBlocks() to displayText as well, so the full paste content (wrapped in --- Begin/End --- markers) is preserved in the conversation history.

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
