### PR TITLE
Fail closed bash sandbox and make parallel tasks read-only / Bash 沙箱失败即拒绝并限制并行子任务为只读

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -453,13 +453,14 @@ edits stay in the project), resolving symlinks and `..` so a link can't tunnel
 out. `forbid_read` optionally hides sensitive directories from the agent's
 read/list/search tools; use absolute paths or `${HOME}` / `${VAR}` references,
 not `~`, because config expansion is environment-variable based. `bash` is
-itself jailed on macOS by default (`[sandbox] bash`, Seatbelt): commands may
-write only those same roots (plus temp and toolchain caches), cannot read
-configured `forbid_read` roots while the OS sandbox is active, and reach the
-network only when `[sandbox] network` is set. Other platforms fall back to
-running unconfined when no OS sandbox is available (see
+itself jailed by default when an OS sandbox is available (`[sandbox] bash`,
+Seatbelt on macOS and bubblewrap on Linux): commands may write only those same
+roots (plus temp and toolchain caches), cannot read configured `forbid_read`
+roots while the OS sandbox is active, and reach the network only when
+`[sandbox] network` is set. When no OS sandbox is available, `bash = "enforce"`
+refuses bash execution instead of running unconfined (see
 [`SPEC.md` §9](./SPEC.md#9-roadmap-not-in-current-scope) for the escape-prompt and
-Linux support still to come).
+broader OS support still to come).
 
 ## Plugins (MCP)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -644,12 +644,14 @@ by default (root = cwd), so edits stay in the project while the agent can still
 update its own global config. `forbid_read` lists directories the agent should
 not read, list, or search; entries support `${VAR}` / `${VAR:-default}` expansion
 and should be absolute, or use `${HOME}` for home-relative secrets such as
-`${HOME}/.ssh`. `bash` is itself jailed on macOS by default
-(`[sandbox] bash = "enforce"`, Seatbelt): each command runs under sandbox-exec
-allowed to write only the same roots (+ temp and toolchain caches), denied reads
-under `forbid_read`, and allowed to reach the network only when `network = true`.
-Unsupported platforms fall back to running unconfined when no OS sandbox is
-available. The escape-prompt and Linux support are Phase 1's remainder (§9).
+`${HOME}/.ssh`. `bash` is itself jailed by default when an OS sandbox is
+available (`[sandbox] bash = "enforce"`: Seatbelt on macOS, bubblewrap on
+Linux): each command is allowed to write only the same roots (+ temp and
+toolchain caches), denied reads under `forbid_read`, and allowed to reach the
+network only when `network = true`.
+When no OS sandbox is available, `bash = "enforce"` refuses bash execution
+instead of running unconfined. The escape-prompt and broader OS support are Phase
+1's remainder (§9).
 
 ## 6. Error Handling
 
@@ -676,13 +678,15 @@ available. The escape-prompt and Linux support are Phase 1's remainder (§9).
 ## 9. Roadmap (not in current scope)
 
 - Sandbox Phase 1: an OS-level jail for `bash` so commands — not just the
-  file-writer built-ins (Phase 0) — are confined to the workspace. **macOS
-  (Seatbelt via `sandbox-exec`) ships, on by default** (see §5). Remaining: (a)
-  the escape-prompt — detect a sandbox-denied failure and offer to re-run the
-  command unconfined via the permission gate (in `reasonix run`, the command just
-  fails and the model adapts), which completes the "allow inside the box, prompt
-  at its edge" model; (b) Linux (bubblewrap / landlock). Shells out to OS tooling
-  so the binary stays dependency-free; Windows is out of scope. With this in
+  file-writer built-ins (Phase 0) — are confined to the workspace. **Seatbelt on
+  macOS and bubblewrap on Linux ship, on by default when available** (see §5).
+  Remaining: (a)
+  the escape-prompt — detect sandbox-unavailable or sandbox-denied failures and
+  offer an explicit, permission-gated unconfined rerun (in `reasonix run`, the
+  command just fails and the model adapts), which completes the "allow inside the
+  box, prompt at its edge" model; (b) broader OS sandbox support beyond current
+  Seatbelt/bubblewrap hosts. Shells out to OS tooling so the binary stays
+  dependency-free. With this in
   place, "always allow" rule persistence becomes optional rather than load-bearing.
 - MCP long tail (deferred deliberately — no consumer / no foundation yet): OAuth
   2.0 + `headersHelper` auth for remote servers; the remaining `.mcp.json` scopes

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -1,23 +1,21 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
 	"reasonix/internal/event"
-	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
-// ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
-// collects all results. Each sub-task runs as a foreground sub-agent in its
+// ParallelTasksTool dispatches multiple read-only sub-agent tasks concurrently
+// and collects all results. Each sub-task runs as a foreground sub-agent in its
 // own goroutine, emitting nested events so the frontend renders independent
 // cards for each sub-task.
 type ParallelTasksTool struct {
@@ -34,7 +32,7 @@ func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasks
 func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
 
 func (p *ParallelTasksTool) Description() string {
-	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+	return "Dispatch multiple read-only sub-agent tasks concurrently and collect their results. Each task runs in its own read-only sub-agent in parallel. Blocks until all complete."
 }
 
 func (p *ParallelTasksTool) Schema() json.RawMessage {
@@ -62,7 +60,9 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
 }`)
 }
 
-func (p *ParallelTasksTool) ReadOnly() bool { return false }
+func (p *ParallelTasksTool) ReadOnly() bool { return true }
+
+func (p *ParallelTasksTool) PlanModeSafe() bool { return true }
 
 type parallelTaskItem struct {
 	Prompt      string   `json:"prompt"`
@@ -71,7 +71,6 @@ type parallelTaskItem struct {
 	MaxSteps    int      `json:"max_steps"`
 	Model       string   `json:"model"`
 	Effort      string   `json:"effort"`
-	DependsOn   []int    `json:"depends_on"`
 }
 
 type parallelTaskStatus string
@@ -88,7 +87,9 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	var params struct {
 		Tasks []parallelTaskItem `json:"tasks"`
 	}
-	if err := json.Unmarshal(args, &params); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(args))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&params); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
 	if len(params.Tasks) == 0 {
@@ -100,11 +101,14 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	if err := validateParallelTaskItems(params.Tasks); err != nil {
 		return "", err
 	}
+	if p.taskTool == nil {
+		return "", fmt.Errorf("parallel_tasks is not configured")
+	}
 
 	parentID, sink, _, ok := CallContext(ctx)
 	if !ok || sink == nil {
-		// Fallback: no event sink available, use background-jobs approach.
-		return p.runAsBackgroundJobs(ctx, params.Tasks)
+		parentID = "parallel_tasks"
+		sink = event.Discard
 	}
 
 	type subResult struct {
@@ -115,63 +119,30 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	n := len(params.Tasks)
 
-	// Dependency state: remaining = number of deps not yet completed.
-	remaining := make([]int, n)
 	running := make([]bool, n)
 	done := make([]bool, n)
 	outputs := make([]string, n)
 	taskErrs := make([]error, n)
 	statuses := make([]parallelTaskStatus, n)
-	for i, t := range params.Tasks {
-		remaining[i] = len(t.DependsOn)
+	for i := range params.Tasks {
 		statuses[i] = parallelTaskPending
 	}
 
 	doneCh := make(chan subResult, n)
 	var wg sync.WaitGroup
 
-	wisdomDir, _ := os.MkdirTemp("", "parallel-wisdom-*")
-	if wisdomDir != "" {
-		defer os.RemoveAll(wisdomDir)
-	}
-	makePrompt := func(t parallelTaskItem) string {
-		var prefix strings.Builder
-		if len(t.DependsOn) > 0 && wisdomDir != "" {
-			entries, _ := os.ReadDir(wisdomDir)
-			if len(entries) > 0 {
-				fmt.Fprintf(&prefix, "Previous task results are available at %s. Read the relevant files with read_file before starting.\n\n", wisdomDir)
-			}
-		}
-		prefix.WriteString(t.Prompt)
-		return prefix.String()
-	}
 	makeLabel := func(t parallelTaskItem, idx int) string {
 		if t.Description != "" {
 			return t.Description
 		}
 		return fmt.Sprintf("task-%d", idx+1)
 	}
-	writeWisdom := func(r subResult) {
-		if wisdomDir == "" {
-			return
-		}
-		fname := filepath.Join(wisdomDir, fmt.Sprintf("task-%d.md", r.index+1))
-		switch {
-		case r.output != "":
-			summary := fmt.Sprintf("# Task %d Result\n\n%s", r.index+1, strings.TrimSpace(r.output))
-			_ = os.WriteFile(fname, []byte(summary), 0o644)
-		case r.err != nil:
-			summary := fmt.Sprintf("# Task %d Result\n\nFAILED: %s", r.index+1, r.err)
-			_ = os.WriteFile(fname, []byte(summary), 0o644)
-		}
-	}
 	startTask := func(idx int) {
 		t := params.Tasks[idx]
 		running[idx] = true
-		prompt := makePrompt(t)
 		label := makeLabel(t, idx)
 		subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
-		dispatchArgs, _ := json.Marshal(map[string]string{"prompt": prompt, "description": label})
+		dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
 		sink.Emit(event.Event{
 			Kind: event.ToolDispatch,
 			Tool: event.Tool{
@@ -194,7 +165,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				doneCh <- subResult{index: idx, err: depthErr}
 				return
 			}
-			subReg := p.taskTool.buildSubReg(t.Tools, childDepth)
+			subReg := ReadOnlySubagentToolRegistryForDepth(p.taskTool.parentReg, t.Tools, childDepth, p.taskTool.maxDepth())
 
 			max := t.MaxSteps
 			if max <= 0 {
@@ -211,8 +182,8 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				return
 			}
 
-			sess := NewSession("")
-			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
+			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
 				MaxSteps:            max,
 				Temperature:         p.taskTool.temperature,
 				Pricing:             pricing,
@@ -253,16 +224,6 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		}()
 	}
 
-	startReady := func() {
-		if ctx.Err() != nil {
-			return
-		}
-		for i := range params.Tasks {
-			if remaining[i] == 0 && !running[i] && !done[i] {
-				startTask(i)
-			}
-		}
-	}
 	markCancelled := func(err error) {
 		for i := range params.Tasks {
 			if done[i] {
@@ -280,8 +241,10 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	}
 
 	completed := 0
-	startReady()
-	processResult := func(r subResult, schedule bool) {
+	for i := range params.Tasks {
+		startTask(i)
+	}
+	processResult := func(r subResult) {
 		if done[r.index] {
 			return
 		}
@@ -297,32 +260,18 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		default:
 			statuses[r.index] = parallelTaskFailed
 		}
-		writeWisdom(r)
-
-		for i, t := range params.Tasks {
-			if remaining[i] > 0 && !running[i] && !done[i] {
-				for _, dep := range t.DependsOn {
-					if dep == r.index {
-						remaining[i]--
-					}
-				}
-			}
-		}
-		if schedule {
-			startReady()
-		}
 	}
 	for completed < n {
 		select {
 		case r := <-doneCh:
-			processResult(r, true)
+			processResult(r)
 		case <-ctx.Done():
 			err := ctx.Err()
 		drain:
 			for {
 				select {
 				case r := <-doneCh:
-					processResult(r, false)
+					processResult(r)
 				default:
 					break drain
 				}
@@ -392,131 +341,10 @@ func formatParallelTasksAggregate(outputs []string, errs []error, statuses []par
 	return b.String()
 }
 
-// runAsBackgroundJobs is the fallback path when no event sink is available.
-func (p *ParallelTasksTool) runAsBackgroundJobs(ctx context.Context, tasks []parallelTaskItem) (string, error) {
-	jm, ok := jobs.FromContext(ctx)
-	if !ok {
-		return "", fmt.Errorf("background jobs are not available in this context")
-	}
-	session := jobs.SessionFromContext(ctx)
-
-	if err := validateParallelTaskItems(tasks); err != nil {
-		return "", err
-	}
-
-	type jobRef struct {
-		id    string
-		label string
-		idx   int
-	}
-	var refs []jobRef
-
-	for i, t := range tasks {
-		if strings.TrimSpace(t.Prompt) == "" {
-			return "", fmt.Errorf("task %d: prompt is required", i+1)
-		}
-		label := t.Description
-		if label == "" {
-			label = fmt.Sprintf("task-%d", i+1)
-		}
-
-		subArgs := map[string]interface{}{
-			"prompt":            t.Prompt,
-			"description":       label,
-			"run_in_background": true,
-		}
-		if len(t.Tools) > 0 {
-			subArgs["tools"] = t.Tools
-		}
-		if t.MaxSteps > 0 {
-			subArgs["max_steps"] = t.MaxSteps
-		}
-		if t.Model != "" {
-			subArgs["model"] = t.Model
-		}
-		if t.Effort != "" {
-			subArgs["effort"] = t.Effort
-		}
-
-		subJSON, err := json.Marshal(subArgs)
-		if err != nil {
-			return "", fmt.Errorf("task %d: marshal: %w", i+1, err)
-		}
-
-		result, err := p.taskTool.Execute(ctx, subJSON)
-		if err != nil {
-			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
-		}
-		refs = append(refs, jobRef{id: extractJobID(result), label: label, idx: i})
-		_ = result
-	}
-
-	if len(refs) == 0 {
-		return "", fmt.Errorf("no tasks were dispatched")
-	}
-
-	jobIDs := make([]string, 0, len(refs))
-	order := make(map[string]int)
-	for _, r := range refs {
-		jobIDs = append(jobIDs, r.id)
-		order[r.id] = r.idx
-	}
-
-	results := jm.WaitForSession(ctx, session, jobIDs, 0)
-	if len(results) == 0 {
-		return "No parallel task results available.", nil
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "Completed %d parallel tasks:\n", len(results))
-	for _, r := range results {
-		idx := order[r.ID]
-		label := r.ID
-		if r.Label != "" {
-			label = r.Label
-		}
-		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
-		_ = idx
-	}
-	return b.String(), nil
-}
-
 func validateParallelTaskItems(tasks []parallelTaskItem) error {
 	for i, t := range tasks {
 		if strings.TrimSpace(t.Prompt) == "" {
 			return fmt.Errorf("task %d: prompt is required", i+1)
-		}
-		for j, dep := range t.DependsOn {
-			if dep < 0 || dep >= len(tasks) {
-				return fmt.Errorf("task %d: depends_on[%d] = %d out of range (0-%d)", i+1, j, dep, len(tasks)-1)
-			}
-			if dep == i {
-				return fmt.Errorf("task %d: self-referencing depends_on", i+1)
-			}
-		}
-	}
-
-	state := make([]int, len(tasks)) // 0 = unvisited, 1 = visiting, 2 = done
-	var visit func(int) error
-	visit = func(i int) error {
-		switch state[i] {
-		case 1:
-			return fmt.Errorf("task dependency cycle detected at task %d", i+1)
-		case 2:
-			return nil
-		}
-		state[i] = 1
-		for _, dep := range tasks[i].DependsOn {
-			if err := visit(dep); err != nil {
-				return err
-			}
-		}
-		state[i] = 2
-		return nil
-	}
-	for i := range tasks {
-		if err := visit(i); err != nil {
-			return err
 		}
 	}
 	return nil
@@ -530,16 +358,4 @@ func resolveSubagentProvider(tt *TaskTool, modelRef, effortRef string) (provider
 	}
 	// Use the task tool's own defaults.
 	return tt.prov, tt.pricing, tt.contextWindow, nil
-}
-
-func extractJobID(msg string) string {
-	quote := strings.Index(msg, `"`)
-	if quote < 0 {
-		return ""
-	}
-	end := strings.Index(msg[quote+1:], `"`)
-	if end < 0 {
-		return ""
-	}
-	return msg[quote+1 : quote+1+end]
 }

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,9 +14,13 @@ import (
 	"reasonix/internal/tool"
 )
 
-func TestParallelTasksToolIsWriteCapable(t *testing.T) {
-	if (&ParallelTasksTool{}).ReadOnly() {
-		t.Fatal("parallel_tasks must be write-capable because spawned sub-agents can invoke writer tools")
+func TestParallelTasksToolIsReadOnly(t *testing.T) {
+	p := &ParallelTasksTool{}
+	if !p.ReadOnly() {
+		t.Fatal("parallel_tasks must be read-only because spawned sub-agents receive only read-only tools")
+	}
+	if !p.PlanModeSafe() {
+		t.Fatal("parallel_tasks must be plan-mode safe because spawned sub-agents receive only read-only tools")
 	}
 }
 
@@ -45,22 +50,22 @@ func TestParallelTasksValidatesAllTasksBeforeRuntimeLookup(t *testing.T) {
 	}
 }
 
-func TestParallelTasksRejectsDependencyCyclesBeforeRuntimeLookup(t *testing.T) {
+func TestParallelTasksRejectsHiddenDependencyFieldBeforeRuntimeLookup(t *testing.T) {
 	tool := &ParallelTasksTool{}
 	_, err := tool.Execute(context.Background(), json.RawMessage(`{
 		"tasks": [
 			{"prompt": "first", "depends_on": [1]},
-			{"prompt": "second", "depends_on": [0]}
+			{"prompt": "second"}
 		]
 	}`))
 	if err == nil {
-		t.Fatal("Execute returned nil error for cyclic dependencies")
+		t.Fatal("Execute returned nil error for a hidden dependency field")
 	}
-	if !strings.Contains(err.Error(), "cycle") {
-		t.Fatalf("Execute error = %v, want dependency cycle validation", err)
+	if !strings.Contains(err.Error(), "depends_on") {
+		t.Fatalf("Execute error = %v, want hidden dependency field rejection", err)
 	}
 	if strings.Contains(err.Error(), "background jobs are not available") {
-		t.Fatalf("Execute looked up background jobs before validating dependencies: %v", err)
+		t.Fatalf("Execute looked up background jobs before rejecting hidden dependencies: %v", err)
 	}
 }
 
@@ -95,6 +100,31 @@ func TestParallelTasksForegroundCompletesAndClosesWorkers(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("parallel_tasks foreground execution did not return; workers likely waited on spawnCh forever")
+	}
+}
+
+func TestParallelTasksDoesNotExposeWriterToolsToChildren(t *testing.T) {
+	var writerCalls int32
+	parentReg := tool.NewRegistry()
+	parentReg.Add(fakeTool{name: "write_file", readOnly: false, calls: &writerCalls})
+	task := newTestTaskTool(t, writerCallingProvider{}, parentReg, "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, parentReg)
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	out, err := parallel.Execute(ctx, json.RawMessage(`{
+		"tasks": [
+			{"prompt": "try writer one"},
+			{"prompt": "try writer two"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("Execute returned error: %v\n%s", err, out)
+	}
+	if got := atomic.LoadInt32(&writerCalls); got != 0 {
+		t.Fatalf("writer tool was exposed to read-only sub-agents and called %d times", got)
+	}
+	if !strings.Contains(out, "Completed 2 parallel tasks") {
+		t.Fatalf("missing aggregate output: %s", out)
 	}
 }
 
@@ -168,6 +198,33 @@ func (promptRoutingProvider) Stream(_ context.Context, req provider.Request) (<-
 	ch <- provider.Chunk{Type: provider.ChunkDone}
 	close(ch)
 	return ch, nil
+}
+
+type writerCallingProvider struct{}
+
+func (writerCallingProvider) Name() string { return "writer-calling" }
+
+func (writerCallingProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, 2)
+	if !hasToolResult(req, "write_file") {
+		ch <- toolCallChunk("write-1", "write_file", `{"path":"x","content":"y"}`)
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "writer unavailable"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func hasToolResult(req provider.Request, name string) bool {
+	for _, m := range req.Messages {
+		if m.Role == provider.RoleTool && m.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 type stringsError string

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -783,6 +783,18 @@ func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	}
 }
 
+func extractJobID(msg string) string {
+	quote := strings.Index(msg, `"`)
+	if quote < 0 {
+		return ""
+	}
+	end := strings.Index(msg[quote+1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return msg[quote+1 : quote+1+end]
+}
+
 func subagentRefFromOutput(t *testing.T, out string) string {
 	t.Helper()
 	for _, line := range strings.Split(out, "\n") {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -306,7 +306,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: cfg.WriteRootsForRoot(root), ForbidReadRoots: cfg.ForbidReadRootsForRoot(root), Network: cfg.Sandbox.Network}
 	bashSpec.Shell = shell
 	if bashSpec.Mode == "enforce" && !sandbox.Available() {
-		fmt.Fprintln(stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
+		fmt.Fprintln(stderr, "warning: bash sandbox requested but unavailable on this platform; bash execution will be refused")
 	}
 	if autoShellPrefer(cfg.Tools.Shell.Prefer) && shell.Kind == sandbox.ShellPowerShell {
 		fmt.Fprintln(stderr, "warning: bash not found on PATH; the shell tool will run commands under Windows PowerShell. Install Git for Windows or WSL to use bash, or set [tools.shell] prefer=\"powershell\" to silence this.")

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3837,7 +3837,7 @@ func (m *chatTUI) showSandboxStatus() {
 	b.WriteString("  phase 1  OS bash sandbox\n")
 	fmt.Fprintf(&b, "    bash        %s", bash)
 	if bash == "enforce" && !available {
-		b.WriteString(" (inactive: no OS sandbox on this host — bash runs unconfined)")
+		b.WriteString(" (unavailable: no OS sandbox on this host — bash execution is refused)")
 	}
 	b.WriteString("\n")
 	fmt.Fprintf(&b, "    network     %v\n", network)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -778,8 +778,8 @@ type SandboxConfig struct {
 	AllowWrite    []string `toml:"allow_write"`
 	ForbidRead    []string `toml:"forbid_read"`
 	// Bash is the OS-sandbox mode for the bash tool: "enforce" (default) jails
-	// each command, "off" runs it unconfined. Phase 1; macOS only for now, with
-	// a graceful fallback elsewhere (see internal/sandbox).
+	// each command when an OS sandbox is available and refuses bash otherwise;
+	// "off" runs it unconfined.
 	Bash string `toml:"bash"`
 	// Network allows network egress from inside the bash sandbox. Defaults true
 	// so module/package downloads keep working; the boundary is then writes.

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -425,8 +425,8 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	b.WriteString("[sandbox]\n")
 	b.WriteString("# Confine tool blast radius. File-writers (write_file/edit_file/multi_edit/move_file)\n")
 	b.WriteString("# may only write under workspace_root (empty = current dir) and allow_write extras.\n")
-	b.WriteString("# bash = \"enforce\" (default) jails each command in an OS sandbox (macOS now;\n")
-	b.WriteString("# graceful fallback elsewhere); \"off\" disables it. network allows egress.\n")
+	b.WriteString("# bash = \"enforce\" (default) jails each command in an OS sandbox when\n")
+	b.WriteString("# available; without one, bash execution is refused. \"off\" disables it. network allows egress.\n")
 	if c.Sandbox.WorkspaceRoot != "" {
 		fmt.Fprintf(&b, "workspace_root = %q\n", c.Sandbox.WorkspaceRoot)
 	} else {

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -78,8 +78,8 @@ type SandboxReport struct {
 	Network    bool     `json:"network"`
 	WriteRoots []string `json:"write_roots,omitempty"`
 	// Available is whether an OS sandbox actually backs an "enforce" request on
-	// this host (bwrap/seatbelt present). Without it "enforce" runs unconfined —
-	// e.g. always on Windows, where there is no OS sandbox.
+	// this host (bwrap/seatbelt present). Without it "enforce" refuses bash
+	// execution instead of running unconfined.
 	Available bool `json:"available"`
 }
 
@@ -237,7 +237,7 @@ func RenderText(r Report) string {
 	fmt.Fprintf(&b, "\nsandbox\n")
 	bashLine := r.Sandbox.Bash
 	if r.Sandbox.Bash == "enforce" && !r.Sandbox.Available {
-		bashLine += " (inactive: no OS sandbox on this host — bash runs unconfined)"
+		bashLine += " (unavailable: no OS sandbox on this host — bash execution is refused)"
 	}
 	fmt.Fprintf(&b, "  bash         %s\n", bashLine)
 	fmt.Fprintf(&b, "  network      %v\n", r.Sandbox.Network)

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -115,14 +115,17 @@ func TestRenderTextSurfacesWarningsUpTop(t *testing.T) {
 	}
 }
 
-func TestRenderTextFlagsInactiveSandbox(t *testing.T) {
+func TestRenderTextFlagsUnavailableSandboxAsFailClosed(t *testing.T) {
 	inactive := RenderText(Report{Sandbox: SandboxReport{Bash: "enforce", Available: false}})
-	if !strings.Contains(inactive, "inactive") {
-		t.Fatalf("enforce without an OS sandbox should be flagged inactive:\n%s", inactive)
+	if !strings.Contains(inactive, "bash execution is refused") {
+		t.Fatalf("enforce without an OS sandbox should report fail-closed bash behavior:\n%s", inactive)
+	}
+	if strings.Contains(inactive, "runs unconfined") {
+		t.Fatalf("enforce without an OS sandbox should not claim bash runs unconfined:\n%s", inactive)
 	}
 
 	active := RenderText(Report{Sandbox: SandboxReport{Bash: "enforce", Available: true}})
-	if strings.Contains(active, "inactive") {
-		t.Fatalf("enforce with an OS sandbox should not be flagged inactive:\n%s", active)
+	if strings.Contains(active, "bash execution is refused") {
+		t.Fatalf("enforce with an OS sandbox should not be flagged unavailable:\n%s", active)
 	}
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -36,5 +36,5 @@ type Spec struct {
 	Shell Shell
 }
 
-// enforce reports whether the spec asks for confinement.
-func (s Spec) enforce() bool { return s.Mode == "enforce" }
+// Enforce reports whether the spec asks for confinement.
+func (s Spec) Enforce() bool { return s.Mode == "enforce" }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// --- Spec.enforce ---
+// --- Spec.Enforce ---
 
 func TestEnforce(t *testing.T) {
 	cases := []struct {
@@ -22,8 +22,8 @@ func TestEnforce(t *testing.T) {
 	}
 	for _, c := range cases {
 		s := Spec{Mode: c.mode}
-		if got := s.enforce(); got != c.want {
-			t.Errorf("Spec{%q}.enforce() = %v, want %v", c.mode, got, c.want)
+		if got := s.Enforce(); got != c.want {
+			t.Errorf("Spec{%q}.Enforce() = %v, want %v", c.mode, got, c.want)
 		}
 	}
 }
@@ -32,7 +32,7 @@ func TestEnforce(t *testing.T) {
 
 func TestSpecZeroValue(t *testing.T) {
 	var s Spec
-	if s.enforce() {
+	if s.Enforce() {
 		t.Error("zero-value Spec should not enforce")
 	}
 	if s.Network {

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -14,7 +14,7 @@ import (
 // sandbox-exec missing — a graceful fallback rather than a hard failure, since
 // the permission layer still gates the call).
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
-	if !spec.enforce() || !Available() {
+	if !spec.Enforce() || !Available() {
 		return sh.argv(command), false
 	}
 	return append([]string{"sandbox-exec", "-p", seatbeltProfile(spec)}, sh.argv(command)...), true
@@ -25,7 +25,7 @@ func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 // without shell interpretation — suitable for direct binary invocations like
 // ripgrep that don't need a shell wrapper.
 func CommandArgs(spec Spec, args []string) ([]string, bool) {
-	if !spec.enforce() || !Available() {
+	if !spec.Enforce() || !Available() {
 		return args, false
 	}
 	return append([]string{"sandbox-exec", "-p", seatbeltProfile(spec)}, args...), true

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -10,9 +10,8 @@ import (
 
 // Command returns the argv to run `command` through sh, wrapped in sandbox-exec
 // when the spec enforces and the tool is available. The second return is whether
-// wrapping happened; false means the command runs unconfined (sandbox off, or
-// sandbox-exec missing — a graceful fallback rather than a hard failure, since
-// the permission layer still gates the call).
+// wrapping happened; false means the argv is unwrapped (sandbox off, or
+// sandbox-exec missing). Callers decide whether an unwrapped command is allowed.
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 	if !spec.Enforce() || !Available() {
 		return sh.argv(command), false

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -14,7 +14,7 @@ import (
 // spec.Network is true. When bwrap is unavailable the command runs unconfined
 // (boot and acp warn about this once at startup).
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
-	if !spec.enforce() {
+	if !spec.Enforce() {
 		return sh.argv(command), false
 	}
 	if bwrap, err := exec.LookPath("bwrap"); err == nil {
@@ -31,7 +31,7 @@ func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 // prefix without shell interpretation — suitable for direct binary invocations
 // like ripgrep that don't need a shell wrapper.
 func CommandArgs(spec Spec, args []string) ([]string, bool) {
-	if !spec.enforce() {
+	if !spec.Enforce() {
 		return args, false
 	}
 	if bwrap, err := exec.LookPath("bwrap"); err == nil {

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -11,8 +11,8 @@ import (
 // When spec.Mode is "enforce" and bubblewrap (bwrap) is available on PATH,
 // the command is wrapped in a bubblewrap sandbox with a profile analogous to
 // macOS Seatbelt: writes confined to WriteRoots, network denied unless
-// spec.Network is true. When bwrap is unavailable the command runs unconfined
-// (boot and acp warn about this once at startup).
+// spec.Network is true. When bwrap is unavailable, the argv is returned
+// unwrapped with wrapped=false so callers can decide whether to fail closed.
 func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 	if !spec.Enforce() {
 		return sh.argv(command), false
@@ -21,8 +21,8 @@ func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 		argv := append([]string{bwrap}, bwrapArgs(spec, sh, command)...)
 		return argv, true
 	}
-	// enforce requested but bwrap unavailable — boot/acp already warned at
-	// startup; fall back to unconfined (the false result signals "not sandboxed").
+	// enforce requested but bwrap unavailable — return the unwrapped argv and let
+	// callers decide whether a non-sandboxed command is acceptable.
 	return sh.argv(command), false
 }
 

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -149,7 +149,10 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	}
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
-	argv, _ := sandbox.Command(b.sb, sh, p.Command)
+	argv, wrapped := sandbox.Command(b.sb, sh, p.Command)
+	if b.sb.Enforce() && !wrapped {
+		return "", fmt.Errorf("bash sandbox requested but unavailable on this platform; refusing to run unconfined")
+	}
 	cmdEnv := bashCommandEnv(ctx)
 
 	if p.RunInBackground {

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"reasonix/internal/config"
@@ -163,6 +164,34 @@ func TestBashSandboxConfinement(t *testing.T) {
 	}
 	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
 		t.Error("escaping write must not create the file")
+	}
+}
+
+func TestBashEnforceRejectsWhenSandboxUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := bash{
+		sb: sandbox.Spec{
+			Mode:       "enforce",
+			WriteRoots: []string{t.TempDir()},
+		},
+		shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: exe},
+	}
+
+	args, _ := json.Marshal(map[string]string{"command": "ignored"})
+	out, err := b.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("bash should reject enforce mode when the OS sandbox is unavailable")
+	}
+	if !strings.Contains(err.Error(), "bash sandbox requested but unavailable") {
+		t.Fatalf("error = %q, want sandbox unavailable", err)
+	}
+	if out != "" {
+		t.Fatalf("output = %q, want no command execution", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fail closed when `bash` sandbox mode is `enforce` but the OS sandbox wrapper is unavailable, so bash does not run unconfined on Windows/Linux/macOS fallback paths.
- Keep `sandbox.Spec.Enforce()` as the public owner API for runtime callers instead of duplicating mode string checks.
- Make `parallel_tasks` read-only and plan-mode safe: children use `ReadOnlySubagentToolRegistryForDepth`, read-only sub-agent prompting, hidden `depends_on` is rejected, and the hidden dependency/wisdom-file/background fallback paths are removed.
- Align startup, TUI, doctor, config-template, and docs messaging with the new fail-closed sandbox-unavailable behavior.

Fixes #5793.

## Source PRs / Contributor Credits
- #5830 by @cyq1017: kept the fail-closed bash sandbox runtime guard and unavailable-sandbox regression coverage.
- #5839 by @myipanta: kept the root-cause direction and public `Enforce()` sandbox API; reviewed but did not keep the best-effort shell write parser because fail-closed sandbox enforcement avoids parser bypasses and preserves full sandbox semantics.
- #5709 by @CVEngineer66: kept the read-only `parallel_tasks` contract, hidden dependency rejection, writer-tool isolation, and removal of hidden dependency/background fallback behavior; reworked on latest `main-v2` to preserve current subagent depth limits.

## Cache Impact
Cache-impact: medium - `parallel_tasks` provider-visible description, read-only/plan-mode-safe contract, and read-only sub-agent prompt behavior change; tool name/schema JSON/order and provider serialization stay stable. Follow-up wording changes only touch user-facing sandbox diagnostics/docs/config comments.
Cache-guard: `go test ./internal/agent -run 'TestParallelTasks|TestPlanMode' -count=1` plus `scripts/check-cache-impact.sh` with this PR body.
System-prompt-review: SivanCola self-reviewed; the `internal/config/config.go` change is a config struct comment only and does not alter provider-visible system prompts, tool schema serialization, or request construction.

## Verification
- `go test ./internal/tool/builtin ./internal/sandbox -run 'TestBashEnforceRejectsWhenSandboxUnavailable|TestBashSandboxConfinement|TestConfine|TestNormalizeNull|TestEnforce|TestSpecZeroValue' -count=1`
- `go test ./internal/agent -run 'TestParallelTasks|TestPlanMode|TestReadOnlySubagent|TestSubagentToolRegistry|TestTaskToolBackground' -count=1`
- `go test ./internal/doctor ./internal/config ./internal/sandbox ./internal/tool/builtin -run 'TestRenderTextFlagsUnavailableSandboxAsFailClosed|TestRenderTOML|TestBashEnforceRejectsWhenSandboxUnavailable|TestBashSandboxConfinement|TestEnforce|TestSpecZeroValue|TestConfine' -count=1`
- `go test ./internal/boot -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/agent ./internal/control ./internal/tool/builtin ./internal/sandbox -count=1`
- `go build ./cmd/reasonix`
- `git diff --check`
- `scripts/check-cache-impact.sh`

Note: `go test ./... -count=1` had transient failures in `internal/diff` and `internal/environment` during the first full run; both packages passed on direct rerun.
