### PR TITLE
Fix ACP permission option kinds / 修复 ACP 权限选项类型

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -27,6 +27,15 @@ type notifier interface {
 // dispatch.ts (the full result still goes to the model; this is display only).
 const maxResultChars = 8000
 
+type approvalOptionID string
+
+const (
+	approvalOptionAllowOnce       approvalOptionID = "allow_once"
+	approvalOptionAllowAlways     approvalOptionID = "allow_always"
+	approvalOptionAllowPersistent approvalOptionID = "allow_persistent"
+	approvalOptionRejectOnce      approvalOptionID = "reject_once"
+)
+
 // updateSink is an event.Sink bound to one session that maps the agent's typed
 // event stream onto ACP session/update notifications. It is the v2 counterpart of
 // main's dispatchKernelEvent: where main translated kernel events, we translate
@@ -246,12 +255,12 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 	if raw, err := s.conn.Request(ctx, "session/request_permission", params); err == nil {
 		var res PermissionRequestResult
 		if json.Unmarshal(raw, &res) == nil && res.Outcome.Outcome == "selected" {
-			switch PermissionOptionKind(res.Outcome.OptionID) {
-			case OptAllowOnce:
+			switch approvalOptionID(res.Outcome.OptionID) {
+			case approvalOptionAllowOnce:
 				allow = true
-			case OptAllowAlways:
+			case approvalOptionAllowAlways:
 				allow, session = true, true
-			case OptAllowPersistent:
+			case approvalOptionAllowPersistent:
 				allow, session, persist = true, true, true
 			}
 		}
@@ -340,10 +349,10 @@ func approvalOptionNames(tool, subject string) (session, persistent string) {
 func approvalOptions(tool, subject string) []PermissionOption {
 	allowSessionName, allowPersistentName := approvalOptionNames(tool, subject)
 	options := []PermissionOption{
-		{OptionID: string(OptAllowOnce), Name: "Allow", Kind: OptAllowOnce},
-		{OptionID: string(OptAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
-		{OptionID: string(OptAllowPersistent), Name: allowPersistentName, Kind: OptAllowPersistent},
-		{OptionID: string(OptRejectOnce), Name: "Reject", Kind: OptRejectOnce},
+		{OptionID: string(approvalOptionAllowOnce), Name: "Allow", Kind: OptAllowOnce},
+		{OptionID: string(approvalOptionAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
+		{OptionID: string(approvalOptionAllowPersistent), Name: allowPersistentName, Kind: OptAllowAlways},
+		{OptionID: string(approvalOptionRejectOnce), Name: "Reject", Kind: OptRejectOnce},
 	}
 	return options
 }

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -189,6 +189,30 @@ type approveCall struct {
 	persist bool
 }
 
+func invalidACPv1PermissionOptionKind(options []PermissionOption) (PermissionOption, bool) {
+	// ACP v1 schema only accepts these four PermissionOptionKind values. Reasonix
+	// actions such as persistent approval must stay in optionId.
+	valid := map[PermissionOptionKind]bool{
+		OptAllowOnce:    true,
+		OptAllowAlways:  true,
+		OptRejectOnce:   true,
+		OptRejectAlways: true,
+	}
+	for _, opt := range options {
+		if !valid[opt.Kind] {
+			return opt, true
+		}
+	}
+	return PermissionOption{}, false
+}
+
+func assertACPv1PermissionOptionKinds(t *testing.T, options []PermissionOption) {
+	t.Helper()
+	if opt, ok := invalidACPv1PermissionOptionKind(options); ok {
+		t.Fatalf("permission option %q uses non-ACP-v1 kind %q", opt.OptionID, opt.Kind)
+	}
+}
+
 func TestUpdateSinkApprovalAllowAlways(t *testing.T) {
 	fn := &fakeNotifier{onReq: func(method string, params any) (json.RawMessage, error) {
 		if method != "session/request_permission" {
@@ -208,8 +232,9 @@ func TestUpdateSinkApprovalAllowAlways(t *testing.T) {
 		if p.ToolCall.ToolCallID != "gate-9" {
 			t.Errorf("toolCallId = %q, want gate-9", p.ToolCall.ToolCallID)
 		}
+		assertACPv1PermissionOptionKinds(t, p.Options)
 		res, _ := json.Marshal(PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowAlways)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(approvalOptionAllowAlways)},
 		})
 		return res, nil
 	}}
@@ -236,13 +261,14 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 		if err := json.Unmarshal(raw, &p); err != nil {
 			t.Fatalf("permission params: %v", err)
 		}
-		// Bash with a safe prefix now uses the same standard options as any
-		// other tool (allow_always / allow_persistent); the old prefix-specific
-		// OptAllowPrefix/OptPersistPrefix are gone.
+		// Bash with a safe prefix now uses the same standard option IDs as any
+		// other tool; Reasonix-specific persistence stays in optionId, while kind
+		// stays inside ACP v1's enum.
+		assertACPv1PermissionOptionKinds(t, p.Options)
 		var hasSession, hasPersistent bool
 		for _, opt := range p.Options {
-			hasSession = hasSession || opt.OptionID == string(OptAllowAlways)
-			hasPersistent = hasPersistent || opt.OptionID == string(OptAllowPersistent)
+			hasSession = hasSession || (opt.OptionID == string(approvalOptionAllowAlways) && opt.Kind == OptAllowAlways)
+			hasPersistent = hasPersistent || (opt.OptionID == string(approvalOptionAllowPersistent) && opt.Kind == OptAllowAlways)
 		}
 		if !hasSession || !hasPersistent {
 			t.Fatalf("options = %+v, want standard session and persistent choices", p.Options)
@@ -251,7 +277,7 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 			t.Fatalf("options = %+v, want allow once, session, persistent, reject", p.Options)
 		}
 		res, _ := json.Marshal(PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowPersistent)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(approvalOptionAllowPersistent)},
 		})
 		return res, nil
 	}}
@@ -328,6 +354,7 @@ func TestUpdateSinkAskRequestUsesPermissionChoices(t *testing.T) {
 		if len(p.Options) != 3 {
 			t.Fatalf("options = %+v, want two answers plus cancel", p.Options)
 		}
+		assertACPv1PermissionOptionKinds(t, p.Options)
 		if p.Options[0].Name != "Tests - Run the suite" || p.Options[0].Kind != OptAllowOnce {
 			t.Fatalf("first option = %+v", p.Options[0])
 		}

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -504,8 +504,12 @@ func TestE2EApprovalRoundTrip(t *testing.T) {
 		var pr PermissionRequestParams
 		json.Unmarshal(req.Params, &pr)
 		reqSeen <- pr
+		if _, ok := invalidACPv1PermissionOptionKind(pr.Options); ok {
+			client.replyError(req.ID, ErrInvalidParams, "Invalid params")
+			return
+		}
 		client.reply(req.ID, PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowOnce)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(approvalOptionAllowOnce)},
 		})
 	}()
 
@@ -522,6 +526,7 @@ func TestE2EApprovalRoundTrip(t *testing.T) {
 		if !strings.Contains(pr.ToolCall.Title, "writeit") {
 			t.Errorf("permission title = %q, want it to mention writeit", pr.ToolCall.Title)
 		}
+		assertACPv1PermissionOptionKinds(t, pr.Options)
 	case <-time.After(2 * time.Second):
 		t.Fatal("no permission request was raised")
 	}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -490,15 +490,16 @@ type SessionCancelParams struct {
 
 // --- session/request_permission (agent → client request) ---
 
-// PermissionOptionKind classifies an option for host UI styling. Matches main.
+// PermissionOptionKind classifies an option for host UI styling. It is an ACP v1
+// wire enum, so Reasonix-specific approval actions must live in optionId, not
+// here.
 type PermissionOptionKind string
 
 const (
-	OptAllowOnce       PermissionOptionKind = "allow_once"
-	OptAllowAlways     PermissionOptionKind = "allow_always"
-	OptAllowPersistent PermissionOptionKind = "allow_persistent"
-	OptRejectOnce      PermissionOptionKind = "reject_once"
-	OptRejectAlways    PermissionOptionKind = "reject_always"
+	OptAllowOnce    PermissionOptionKind = "allow_once"
+	OptAllowAlways  PermissionOptionKind = "allow_always"
+	OptRejectOnce   PermissionOptionKind = "reject_once"
+	OptRejectAlways PermissionOptionKind = "reject_always"
 )
 
 // PermissionOption is one choice offered to the user for a permission request.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -331,6 +331,10 @@ func (c *rpcClient) reply(id *json.RawMessage, result any) {
 	c.send(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
 }
 
+func (c *rpcClient) replyError(id *json.RawMessage, code int, message string) {
+	c.send(map[string]any{"jsonrpc": "2.0", "id": id, "error": rpcError{Code: code, Message: message}})
+}
+
 func startServer(t *testing.T, factory Factory) (*rpcClient, func()) {
 	t.Helper()
 	inR, inW := io.Pipe()


### PR DESCRIPTION
## Summary
- keep ACP v1 `PermissionOptionKind` limited to the official wire enum values
- move Reasonix persistent approval semantics to internal `optionId` handling while sending `kind: "allow_always"` for the persistent choice
- add strict-client coverage so invalid permission option kinds would reproduce the `Invalid params` failure instead of slipping through

## Testing
- `go test ./internal/acp`
- `go test ./internal/acp -run 'TestE2EApprovalRoundTrip|TestUpdateSinkApprovalBashPrefix|TestUpdateSinkAskRequestUsesPermissionChoices' -count=1`
- `go test ./...`

## Notes
- Addresses the ACP permission failure reported in discussion #5659.