### PR TITLE
Fix ACP permission ownership / 修复 ACP 权限归属

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -251,8 +251,6 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 				allow = true
 			case OptAllowAlways:
 				allow, session = true, true
-			case OptAllowPersistent:
-				allow, session, persist = true, true, true
 			}
 		}
 	}
@@ -331,18 +329,16 @@ func (s *updateSink) requestAskQuestion(ctx context.Context, askID string, q eve
 	return label, ok
 }
 
-func approvalOptionNames(tool, subject string) (session, persistent string) {
+func approvalSessionOptionName(tool, subject string) string {
 	sessionRule := permission.SessionGrantRuleForScope(tool, subject)
-	persistentRule := permission.RememberRuleForScope(tool, subject)
-	return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
+	return "Allow " + sessionRule + " for this session"
 }
 
 func approvalOptions(tool, subject string) []PermissionOption {
-	allowSessionName, allowPersistentName := approvalOptionNames(tool, subject)
+	allowSessionName := approvalSessionOptionName(tool, subject)
 	options := []PermissionOption{
 		{OptionID: string(OptAllowOnce), Name: "Allow", Kind: OptAllowOnce},
 		{OptionID: string(OptAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
-		{OptionID: string(OptAllowPersistent), Name: allowPersistentName, Kind: OptAllowPersistent},
 		{OptionID: string(OptRejectOnce), Name: "Reject", Kind: OptRejectOnce},
 	}
 	return options

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -189,6 +189,31 @@ type approveCall struct {
 	persist bool
 }
 
+func invalidACPv1PermissionOptionKind(options []PermissionOption) (PermissionOption, bool) {
+	// ACP v1 schema only accepts these four PermissionOptionKind values. ACP hosts
+	// own cross-session persistence, so Reasonix-specific persistent approvals must
+	// not appear in session/request_permission options.
+	valid := map[PermissionOptionKind]bool{
+		OptAllowOnce:    true,
+		OptAllowAlways:  true,
+		OptRejectOnce:   true,
+		OptRejectAlways: true,
+	}
+	for _, opt := range options {
+		if !valid[opt.Kind] {
+			return opt, true
+		}
+	}
+	return PermissionOption{}, false
+}
+
+func assertACPv1PermissionOptionKinds(t *testing.T, options []PermissionOption) {
+	t.Helper()
+	if opt, ok := invalidACPv1PermissionOptionKind(options); ok {
+		t.Fatalf("permission option %q uses non-ACP-v1 kind %q", opt.OptionID, opt.Kind)
+	}
+}
+
 func TestUpdateSinkApprovalAllowAlways(t *testing.T) {
 	fn := &fakeNotifier{onReq: func(method string, params any) (json.RawMessage, error) {
 		if method != "session/request_permission" {
@@ -208,6 +233,7 @@ func TestUpdateSinkApprovalAllowAlways(t *testing.T) {
 		if p.ToolCall.ToolCallID != "gate-9" {
 			t.Errorf("toolCallId = %q, want gate-9", p.ToolCall.ToolCallID)
 		}
+		assertACPv1PermissionOptionKinds(t, p.Options)
 		res, _ := json.Marshal(PermissionRequestResult{
 			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowAlways)},
 		})
@@ -236,22 +262,30 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 		if err := json.Unmarshal(raw, &p); err != nil {
 			t.Fatalf("permission params: %v", err)
 		}
-		// Bash with a safe prefix now uses the same standard options as any
-		// other tool (allow_always / allow_persistent); the old prefix-specific
-		// OptAllowPrefix/OptPersistPrefix are gone.
-		var hasSession, hasPersistent bool
+		// ACP permission options stay within the official spec kinds, and ACP
+		// mode leaves cross-session persistence to the host.
+		assertACPv1PermissionOptionKinds(t, p.Options)
+		var hasOnce, hasSession, hasReject bool
 		for _, opt := range p.Options {
-			hasSession = hasSession || opt.OptionID == string(OptAllowAlways)
-			hasPersistent = hasPersistent || opt.OptionID == string(OptAllowPersistent)
+			switch opt.OptionID {
+			case string(OptAllowOnce):
+				hasOnce = opt.Kind == OptAllowOnce
+			case string(OptAllowAlways):
+				hasSession = opt.Kind == OptAllowAlways
+			case string(OptRejectOnce):
+				hasReject = opt.Kind == OptRejectOnce
+			default:
+				t.Fatalf("unexpected ACP permission option %+v in %+v", opt, p.Options)
+			}
 		}
-		if !hasSession || !hasPersistent {
-			t.Fatalf("options = %+v, want standard session and persistent choices", p.Options)
+		if !hasOnce || !hasSession || !hasReject {
+			t.Fatalf("options = %+v, want allow once, session, reject", p.Options)
 		}
-		if len(p.Options) != 4 {
-			t.Fatalf("options = %+v, want allow once, session, persistent, reject", p.Options)
+		if len(p.Options) != 3 {
+			t.Fatalf("options = %+v, want allow once, session, reject", p.Options)
 		}
 		res, _ := json.Marshal(PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowPersistent)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowAlways)},
 		})
 		return res, nil
 	}}
@@ -263,7 +297,7 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 
 	select {
 	case c := <-got:
-		want := approveCall{id: "10", allow: true, session: true, persist: true}
+		want := approveCall{id: "10", allow: true, session: true, persist: false}
 		if c != want {
 			t.Errorf("approve = %+v, want %+v", c, want)
 		}
@@ -328,6 +362,7 @@ func TestUpdateSinkAskRequestUsesPermissionChoices(t *testing.T) {
 		if len(p.Options) != 3 {
 			t.Fatalf("options = %+v, want two answers plus cancel", p.Options)
 		}
+		assertACPv1PermissionOptionKinds(t, p.Options)
 		if p.Options[0].Name != "Tests - Run the suite" || p.Options[0].Kind != OptAllowOnce {
 			t.Fatalf("first option = %+v", p.Options[0])
 		}

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -504,6 +504,10 @@ func TestE2EApprovalRoundTrip(t *testing.T) {
 		var pr PermissionRequestParams
 		json.Unmarshal(req.Params, &pr)
 		reqSeen <- pr
+		if _, ok := invalidACPv1PermissionOptionKind(pr.Options); ok {
+			client.replyError(req.ID, ErrInvalidParams, "Invalid params")
+			return
+		}
 		client.reply(req.ID, PermissionRequestResult{
 			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowOnce)},
 		})
@@ -522,6 +526,7 @@ func TestE2EApprovalRoundTrip(t *testing.T) {
 		if !strings.Contains(pr.ToolCall.Title, "writeit") {
 			t.Errorf("permission title = %q, want it to mention writeit", pr.ToolCall.Title)
 		}
+		assertACPv1PermissionOptionKinds(t, pr.Options)
 	case <-time.After(2 * time.Second):
 		t.Fatal("no permission request was raised")
 	}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -490,15 +490,16 @@ type SessionCancelParams struct {
 
 // --- session/request_permission (agent → client request) ---
 
-// PermissionOptionKind classifies an option for host UI styling. Matches main.
+// PermissionOptionKind classifies an option for host UI styling. It is an ACP v1
+// wire enum, so host-visible permission choices must stay within the official
+// protocol values.
 type PermissionOptionKind string
 
 const (
-	OptAllowOnce       PermissionOptionKind = "allow_once"
-	OptAllowAlways     PermissionOptionKind = "allow_always"
-	OptAllowPersistent PermissionOptionKind = "allow_persistent"
-	OptRejectOnce      PermissionOptionKind = "reject_once"
-	OptRejectAlways    PermissionOptionKind = "reject_always"
+	OptAllowOnce    PermissionOptionKind = "allow_once"
+	OptAllowAlways  PermissionOptionKind = "allow_always"
+	OptRejectOnce   PermissionOptionKind = "reject_once"
+	OptRejectAlways PermissionOptionKind = "reject_always"
 )
 
 // PermissionOption is one choice offered to the user for a permission request.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -331,6 +331,10 @@ func (c *rpcClient) reply(id *json.RawMessage, result any) {
 	c.send(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
 }
 
+func (c *rpcClient) replyError(id *json.RawMessage, code int, message string) {
+	c.send(map[string]any{"jsonrpc": "2.0", "id": id, "error": rpcError{Code: code, Message: message}})
+}
+
 func startServer(t *testing.T, factory Factory) (*rpcClient, func()) {
 	t.Helper()
 	inR, inW := io.Pipe()


### PR DESCRIPTION
## Summary
- keep ACP v1 permission option kinds inside the official wire enum so strict SDK clients accept `session/request_permission`
- remove the ACP persistent approval choice; `allow_always` now grants only the current Reasonix ACP session and host clients own cross-session persistence
- add strict-client and option-kind regression coverage so invalid permission kinds reproduce the `Invalid params` failure in tests

## Consolidation notes
- Kept/adapted from #5811 by @cyq1017: omit ACP persistent approval and keep `allow_always` session-scoped.
- Kept/adapted from #5878 by @SivanCola: strict-client regression coverage for invalid permission option kinds.
- Incorporates the ACP host/lib boundary analysis from #5775 by @morningtzh.

## Cache impact
- No provider-visible prompt, tool schema, tool ordering, or provider request serialization changes. This only changes the ACP host-facing permission request options.

## Testing
- `go test ./internal/acp`
- `go test ./internal/acp -run 'TestE2EApprovalRoundTrip|TestUpdateSinkApprovalBashPrefix|TestUpdateSinkAskRequestUsesPermissionChoices' -count=1`
- `go test ./internal/acp ./internal/permission ./internal/control`
- `go test ./...`

Fixes #5775.
Refs #5811.
Refs #5878.
Refs #5659.