### PR TITLE
Parse Bash redirects in repeat guard / 用 Bash AST 识别 repeat guard 重定向

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,6 +11,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"mvdan.cc/sh/v3/syntax"
+
 	"reasonix/internal/diff"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
@@ -21,6 +23,7 @@ import (
 	"reasonix/internal/nilutil"
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
+	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
 )
 
@@ -2441,6 +2444,9 @@ func canonicalToolArgs(raw string) string {
 }
 
 func normalizeShellCommand(command string) string {
+	if fields, malformed := shellparse.StaticFields(command); malformed == "" && len(fields) > 0 {
+		return strings.Join(fields, " ")
+	}
 	return strings.Join(strings.Fields(command), " ")
 }
 
@@ -2476,6 +2482,78 @@ func shellPythonOpenWrites(lower string) bool {
 }
 
 func hasShellWriteRedirect(command string) bool {
+	file, err := shellparse.ParseBash(command)
+	if err == nil {
+		hasWrite := false
+		syntax.Walk(file, func(node syntax.Node) bool {
+			redir, ok := node.(*syntax.Redirect)
+			if !ok {
+				return true
+			}
+			if bashRedirectWritesFile(command, redir) {
+				hasWrite = true
+				return false
+			}
+			return true
+		})
+		return hasWrite
+	}
+	return hasShellWriteRedirectFallback(command)
+}
+
+func bashRedirectWritesFile(source string, redir *syntax.Redirect) bool {
+	if redir == nil {
+		return false
+	}
+	switch redir.Op {
+	case syntax.RdrOut, syntax.AppOut, syntax.RdrClob, syntax.AppClob,
+		syntax.RdrAll, syntax.RdrAllClob, syntax.AppAll, syntax.AppAllClob,
+		syntax.RdrInOut:
+		return !redirectWordIsNullSink(source, redir.Word)
+	default:
+		return false
+	}
+}
+
+func redirectWordIsNullSink(source string, word *syntax.Word) bool {
+	if word == nil {
+		return false
+	}
+	if value, ok := shellparse.StaticWord(word); ok {
+		if isNullSinkWord(strings.TrimSpace(value)) {
+			return true
+		}
+	}
+	value := strings.TrimSpace(redirectWordSource(source, word))
+	if isNullSinkWord(value) {
+		return true
+	}
+	if len(value) >= 2 && ((value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"')) {
+		return isNullSinkWord(value[1 : len(value)-1])
+	}
+	return false
+}
+
+func isNullSinkWord(value string) bool {
+	if value == "/dev/null" {
+		return true
+	}
+	return strings.EqualFold(value, "$null") || strings.EqualFold(value, "nul")
+}
+
+func redirectWordSource(source string, word *syntax.Word) string {
+	if word == nil || !word.Pos().IsValid() || !word.End().IsValid() {
+		return ""
+	}
+	start := int(word.Pos().Offset())
+	end := int(word.End().Offset())
+	if start < 0 || end < start || end > len(source) {
+		return ""
+	}
+	return source[start:end]
+}
+
+func hasShellWriteRedirectFallback(command string) bool {
 	var quote rune
 	var prev rune
 	for _, r := range command {

--- a/internal/agent/repeat_guard_test.go
+++ b/internal/agent/repeat_guard_test.go
@@ -64,6 +64,91 @@ func TestRepeatGuardAllowsRepeatedNonWritingBashCommand(t *testing.T) {
 	}
 }
 
+func TestRepeatGuardBashWriteRedirectDetectionUsesAST(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{
+			name: "stdout file redirect",
+			cmd:  "printf hi > prompt.txt",
+			want: true,
+		},
+		{
+			name: "stderr file redirect",
+			cmd:  "printf hi 2>err.log",
+			want: true,
+		},
+		{
+			name: "append redirect",
+			cmd:  "printf hi >> prompt.txt",
+			want: true,
+		},
+		{
+			name: "combined redirect",
+			cmd:  "printf hi &> prompt.txt",
+			want: true,
+		},
+		{
+			name: "read write redirect",
+			cmd:  "cat <> prompt.txt",
+			want: true,
+		},
+		{
+			name: "null sink redirect",
+			cmd:  "printf hi >/dev/null",
+			want: false,
+		},
+		{
+			name: "powershell null sink spelling",
+			cmd:  "printf hi >$null",
+			want: false,
+		},
+		{
+			name: "windows nul sink spelling",
+			cmd:  "printf hi >NUL",
+			want: false,
+		},
+		{
+			name: "fd duplication",
+			cmd:  "printf hi 2>&1",
+			want: false,
+		},
+		{
+			name: "quoted redirect text",
+			cmd:  `printf '%s\n' 'a > b'`,
+			want: false,
+		},
+		{
+			name: "heredoc body redirect text",
+			cmd:  "cat <<'EOF'\n> prompt.txt\nEOF",
+			want: false,
+		},
+		{
+			name: "heredoc with file redirect",
+			cmd:  "cat <<'EOF' > prompt.txt\nbody\nEOF",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShellFileWriteCommand(tt.cmd); got != tt.want {
+				t.Fatalf("isShellFileWriteCommand(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepeatGuardNormalizesStaticBashFields(t *testing.T) {
+	singleQuoted := normalizeShellCommand(`printf '%s\n' 'hello world'`)
+	doubleQuoted := normalizeShellCommand(`printf "%s\n" "hello world"`)
+	if singleQuoted != doubleQuoted {
+		t.Fatalf("normalized quote styles differ:\n single: %q\n double: %q", singleQuoted, doubleQuoted)
+	}
+}
+
 func TestRepeatGuardAllowsTwoRepeatedWriterSuccesses(t *testing.T) {
 	var calls int32
 	reg := tool.NewRegistry()


### PR DESCRIPTION
## Summary
- Use the Bash AST to classify write-like redirects for the bash repeat guard.
- Preserve existing PowerShell/Python write heuristics while excluding fd duplication, heredoc body text, and null sinks from Bash redirect matches.
- Add regression coverage for redirect operators, heredocs, null sinks, and static Bash command normalization.

Related to #5624 and follow-up to #5876.

Cache-impact: low - touches agent repeat-guard logic after tool success; it does not change provider prompt text, tool schemas, tool ordering, or request serialization.
Cache-guard: `go test ./internal/agent -count=1`; `go test ./... -p 1 -count=1`

## Tests
- `go test ./internal/agent -count=1`
- `(cd desktop && go test . -run TestDesktopE2EBlocksRepeatedSuccessfulBashFileWrite -count=1)`
- `go test ./... -p 1 -count=1`
- `git diff --check origin/main-v2...HEAD`