### PR TITLE
Preserve explicit zero temperature and empty tool schemas / 保留显式零温度并补齐空工具 schema

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1629,7 +1629,7 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages:    a.session.Messages,
 		Tools:       a.tools.Schemas(),
-		Temperature: a.temperature,
+		Temperature: provider.OptionalTemperature(a.temperature),
 	})
 	if err != nil {
 		return "", "", "", nil, nil, false, false, err

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -623,7 +623,7 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 			{Role: provider.RoleSystem, Content: sys},
 			{Role: provider.RoleUser, Content: renderTranscript(region)},
 		},
-		Temperature: a.temperature,
+		Temperature: provider.OptionalTemperature(a.temperature),
 	})
 	if err != nil {
 		return "", err

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -281,7 +281,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 
 	ch, err := c.planner.Stream(ctx, provider.Request{
 		Messages:    c.plannerSess.Messages,
-		Temperature: c.temperature,
+		Temperature: provider.OptionalTemperature(c.temperature),
 	})
 	if err != nil {
 		return "", err

--- a/internal/agent/task_classifier.go
+++ b/internal/agent/task_classifier.go
@@ -95,7 +95,7 @@ func (c *llmClassifier) IsTask(ctx context.Context, input string) (bool, error) 
 			{Role: provider.RoleUser, Content: "Classify: " + input},
 		},
 		MaxTokens:   10,
-		Temperature: 0.0,
+		Temperature: provider.TemperaturePtr(0),
 	}
 
 	ch, err := c.provider.Stream(ctx, req)

--- a/internal/control/auto_plan_classifier.go
+++ b/internal/control/auto_plan_classifier.go
@@ -48,7 +48,7 @@ func (c *ProviderAutoPlanClassifier) NeedsPlan(ctx context.Context, input string
 			{Role: provider.RoleSystem, Content: autoPlanClassifierPrompt},
 			{Role: provider.RoleUser, Content: fmt.Sprintf("heuristic_score=%d\n\nUSER_REQUEST:\n%s", score, input)},
 		},
-		Temperature: 0,
+		Temperature: provider.TemperaturePtr(0),
 		MaxTokens:   80,
 	})
 	if err != nil {

--- a/internal/control/auto_plan_classifier_test.go
+++ b/internal/control/auto_plan_classifier_test.go
@@ -41,8 +41,8 @@ func TestProviderAutoPlanClassifierParsesJSON(t *testing.T) {
 	if len(p.req.Messages) != 2 || p.req.Messages[0].Role != provider.RoleSystem {
 		t.Fatalf("request messages = %+v", p.req.Messages)
 	}
-	if p.req.MaxTokens != 80 || p.req.Temperature != 0 {
-		t.Fatalf("request limits = max %d temp %v, want 80/0", p.req.MaxTokens, p.req.Temperature)
+	if p.req.MaxTokens != 80 || p.req.Temperature == nil || *p.req.Temperature != 0 {
+		t.Fatalf("request limits = max %d temp %v, want 80/ptr(0)", p.req.MaxTokens, p.req.Temperature)
 	}
 	if !strings.Contains(p.req.Messages[1].Content, "heuristic_score=1") {
 		t.Fatalf("user message missing score: %q", p.req.Messages[1].Content)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -419,9 +419,13 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 
 	var tools []chatTool
 	for _, t := range req.Tools {
+		parameters := t.Parameters
+		if len(parameters) == 0 {
+			parameters = provider.CanonicalizeSchema(nil)
+		}
 		tools = append(tools, chatTool{
 			Type:     "function",
-			Function: chatFunction{Name: t.Name, Description: t.Description, Parameters: t.Parameters},
+			Function: chatFunction{Name: t.Name, Description: t.Description, Parameters: parameters},
 		})
 	}
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -706,7 +706,7 @@ type chatRequest struct {
 	Tools           []chatTool     `json:"tools,omitempty"`
 	Stream          bool           `json:"stream"`
 	StreamOptions   *streamOptions `json:"stream_options,omitempty"`
-	Temperature     float64        `json:"temperature,omitempty"`
+	Temperature     *float64       `json:"temperature,omitempty"`
 	MaxTokens       int            `json:"max_tokens,omitempty"`
 	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
 	Thinking        *thinkingMode  `json:"thinking,omitempty"`

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1008,7 +1008,7 @@ func TestBuildRequestOmitsResponseOnlyToolCallIndex(t *testing.T) {
 	}
 }
 
-func TestBuildRequestOmitsEmptyToolDescriptionAndParameters(t *testing.T) {
+func TestBuildRequestDefaultsEmptyToolParameters(t *testing.T) {
 	c := &client{name: "x", model: "m", baseURL: "https://api.example.com/v1"}
 	req := provider.Request{
 		Tools: []provider.ToolSchema{{Name: "noargs"}},
@@ -1035,7 +1035,7 @@ func TestBuildRequestOmitsEmptyToolDescriptionAndParameters(t *testing.T) {
 	if _, ok := fn["description"]; ok {
 		t.Fatalf("empty description should be omitted: %s", body)
 	}
-	if _, ok := fn["parameters"]; ok {
-		t.Fatalf("nil parameters should be omitted: %s", body)
+	if got, want := string(fn["parameters"]), `{"type":"object"}`; got != want {
+		t.Fatalf("nil parameters should default to %s, got %s in %s", want, got, body)
 	}
 }

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -536,6 +536,39 @@ func TestBuildRequestForwardsReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestBuildRequestTemperatureSerialization(t *testing.T) {
+	c := &client{model: "m"}
+
+	omitted := c.buildRequest(provider.Request{})
+	if omitted.Temperature != nil {
+		t.Fatalf("unset request temperature = %v, want nil", omitted.Temperature)
+	}
+	b, err := json.Marshal(omitted)
+	if err != nil {
+		t.Fatalf("marshal omitted: %v", err)
+	}
+	if strings.Contains(string(b), "temperature") {
+		t.Fatalf("unset temperature must be omitted from payload: %s", b)
+	}
+
+	zero := c.buildRequest(provider.Request{Temperature: provider.TemperaturePtr(0)})
+	if zero.Temperature == nil || *zero.Temperature != 0 {
+		t.Fatalf("zero request temperature = %v, want ptr(0)", zero.Temperature)
+	}
+	b, err = json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if !strings.Contains(string(b), `"temperature":0`) {
+		t.Fatalf("explicit zero temperature must be serialized: %s", b)
+	}
+
+	nonzero := c.buildRequest(provider.Request{Temperature: provider.TemperaturePtr(0.25)})
+	if nonzero.Temperature == nil || *nonzero.Temperature != 0.25 {
+		t.Fatalf("nonzero request temperature = %v, want ptr(0.25)", nonzero.Temperature)
+	}
+}
+
 func TestBuildRequestDeepSeekThinking(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
@@ -555,6 +588,23 @@ func TestBuildRequestDeepSeekThinking(t *testing.T) {
 				t.Fatalf("ReasoningEffort = %q, want %q", req.ReasoningEffort, tc.wantReasoning)
 			}
 		})
+	}
+}
+
+func TestBuildRequestDeepSeekPreservesCallerTemperature(t *testing.T) {
+	c := &client{model: "deepseek-v4", deepseek: true, effort: "high"}
+
+	omitted := c.buildRequest(provider.Request{})
+	if omitted.Temperature != nil {
+		t.Fatalf("DeepSeek default temperature = %v, want omitted", omitted.Temperature)
+	}
+
+	zero := c.buildRequest(provider.Request{Temperature: provider.TemperaturePtr(0)})
+	if zero.Temperature == nil || *zero.Temperature != 0 {
+		t.Fatalf("DeepSeek explicit zero temperature = %v, want ptr(0)", zero.Temperature)
+	}
+	if zero.Thinking == nil || zero.Thinking.Type != "enabled" {
+		t.Fatalf("DeepSeek thinking = %+v, want enabled", zero.Thinking)
 	}
 }
 

--- a/internal/provider/openai/realcache_test.go
+++ b/internal/provider/openai/realcache_test.go
@@ -48,7 +48,7 @@ func TestRealDeepSeekCacheProbe(t *testing.T) {
 	send := func(msgs []provider.Message) (probeResult, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
-		ch, err := p.Stream(ctx, provider.Request{Messages: msgs, Temperature: 0, MaxTokens: 16})
+		ch, err := p.Stream(ctx, provider.Request{Messages: msgs, Temperature: provider.TemperaturePtr(0), MaxTokens: 16})
 		if err != nil {
 			return probeResult{}, err
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -97,8 +97,22 @@ type ToolSchema struct {
 type Request struct {
 	Messages    []Message
 	Tools       []ToolSchema
-	Temperature float64
+	Temperature *float64 // nil = omit; non-nil = send the value, including 0
 	MaxTokens   int
+}
+
+// TemperaturePtr wraps v in a pointer so callers that explicitly want a
+// specific temperature, including 0 for deterministic output, can distinguish
+// that intent from "not set, use the provider default".
+func TemperaturePtr(v float64) *float64 { return &v }
+
+// OptionalTemperature returns nil when v is zero, matching the historical
+// config behavior where 0 meant "not configured", and a pointer otherwise.
+func OptionalTemperature(v float64) *float64 {
+	if v == 0 {
+		return nil
+	}
+	return &v
 }
 
 // interruptedToolResult stands in for a tool result that never landed — an

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -900,7 +900,7 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 			{Role: provider.RoleSystem, Content: titlePrompt},
 			{Role: provider.RoleUser, Content: firstMsg},
 		},
-		Temperature: 0,
+		Temperature: provider.TemperaturePtr(0),
 		MaxTokens:   20,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Preserve explicit `temperature: 0` in OpenAI-compatible request payloads by making `provider.Request.Temperature` optional.
- Keep default/configured-zero agent temperature behavior unchanged by omitting the field unless the caller explicitly asks for a value.
- Default empty OpenAI-compatible tool `parameters` to a valid empty object schema instead of omitting the field.
- Add regression coverage for omitted, explicit-zero, and non-zero temperature serialization, DeepSeek request construction, and empty tool parameter fallback.

## #5048 contribution credit

Adopted from #5048 by @SEPURI-SAI-KRISHNA:

- Identified that `float64` plus `json:"omitempty"` silently dropped explicit `temperature: 0`.
- Proposed separating “not set” from “explicit value” with `*float64` temperature requests.
- Added the `TemperaturePtr` and `OptionalTemperature` helper shape.
- Updated deterministic callers such as auto-plan classification and title generation to request explicit zero temperature.
- Preserved regular agent/configured-zero behavior by omitting temperature when zero means “use provider default”.

Reviewed but not adopted from #5048:

- The DeepSeek-specific override to force every DeepSeek request to `temperature=1`. This PR keeps temperature caller-controlled/default-omitted so generic DeepSeek and OpenAI-compatible behavior is not regressed.

Contributor credit: @SEPURI-SAI-KRISHNA is included as a commit co-author for the adapted #5048 work.

## Cache impact

Cache-impact: low. This changes provider request serialization only for calls that explicitly set a temperature value, including explicit zero, and for tools whose schema is empty. Default agent requests still omit temperature through `OptionalTemperature`, existing non-empty tool schemas are unchanged, and this PR does not change system prompts, tool order, or stable prompt prefix content.

Cache-guard: added provider serialization tests for omitted vs explicit-zero payloads, DeepSeek caller-temperature preservation, and empty OpenAI-compatible tool parameter fallback.

## Verification

- `git diff --check`
- `go test ./internal/provider/openai -run 'TestBuildRequestDefaultsEmptyToolParameters|TestBuildRequestContentNullForAssistantToolCalls|TestBuildRequestTemperatureSerialization|TestBuildRequestDeepSeekPreservesCallerTemperature' -count=1 -v`
- `go test ./internal/provider/openai -count=1`
- `go test ./internal/provider/openai ./internal/control ./internal/agent ./internal/serve -count=1`
- `go test ./... -p 1 -count=1`
