### PR TITLE
fix(feishu): switch to Interactive Card JSON 2.0 for proper markdown rendering

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -557,6 +557,29 @@ func (a *adapter) sendSDKContent(ctx context.Context, msg bot.OutboundMessage, m
 	if err != nil {
 		return bot.SendResult{}, err
 	}
+
+	replyTo := strings.TrimSpace(msg.ReplyToMsgID)
+	if replyTo != "" {
+		req := larkim.NewReplyMessageReqBuilder().
+			MessageId(replyTo).
+			Body(larkim.NewReplyMessageReqBodyBuilder().Content(content).MsgType(msgType).Build()).
+			Build()
+		resp, err := client.Im.Message.Reply(ctx, req)
+		if err != nil {
+			return bot.SendResult{}, err
+		}
+		if resp == nil {
+			return bot.SendResult{}, fmt.Errorf("feishu reply error: empty response")
+		}
+		if !resp.Success() {
+			return bot.SendResult{}, fmt.Errorf("feishu reply error: %s", feishuCodeError(resp.Code, resp.Msg))
+		}
+		if resp.Data == nil {
+			return bot.SendResult{}, nil
+		}
+		return bot.SendResult{MessageID: stringPtrValue(resp.Data.MessageId)}, nil
+	}
+
 	chatID := strings.TrimSpace(msg.ChatID)
 	if chatID == "" {
 		return bot.SendResult{}, fmt.Errorf("feishu chat_id is empty")

--- a/internal/bot/feishu/feishu_test.go
+++ b/internal/bot/feishu/feishu_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"reasonix/internal/bot"
 	"reasonix/internal/config"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 )
 
@@ -372,5 +374,122 @@ func TestBuildMarkdownCard(t *testing.T) {
 	}
 	if payload.Body.Elements[0].Content != "hello [docs](https://example.com)" {
 		t.Fatalf("content = %q, want original markdown", payload.Body.Elements[0].Content)
+	}
+}
+
+// mockHTTPClient implements larkcore.HttpClient for testing, recording all requests.
+type mockHTTPClient struct {
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	m.requests = append(m.requests, req)
+	m.mu.Unlock()
+
+	// Handle OAuth token request (first call for any API)
+	if strings.Contains(req.URL.Path, "/auth/v3/tenant_access_token/internal") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"tenant_access_token":"mock-token","expire":3600}`)),
+		}, nil
+	}
+
+	// Handle message API request
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"code":0,"data":{"message_id":"mock-msg-id"}}`)),
+	}, nil
+}
+
+func (m *mockHTTPClient) lastRequestURL() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := len(m.requests) - 1; i >= 0; i-- {
+		if !strings.Contains(m.requests[i].URL.Path, "/auth/") {
+			return m.requests[i].URL.String()
+		}
+	}
+	return ""
+}
+
+func TestSendWithReplyToMsgID(t *testing.T) {
+	mock := &mockHTTPClient{}
+	cfg := config.FeishuBotConfig{
+		AppID:        "cli-test",
+		AppSecretEnv: "FEISHU_REPLY_TEST_SECRET",
+	}
+	t.Setenv("FEISHU_REPLY_TEST_SECRET", "test-secret")
+
+	a := &adapter{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	// Inject a pre-built client with mock HTTP client so sdkClient returns it.
+	a.client = lark.NewClient(cfg.AppID, "test-secret",
+		lark.WithHttpClient(mock),
+		lark.WithOpenBaseUrl("https://test.feishu.cn"),
+	)
+
+	// With ReplyToMsgID set — should use ReplyMessage API
+	_, err := a.Send(context.Background(), bot.OutboundMessage{
+		ChatID:       "chat-1",
+		Text:         "hello **bold**",
+		ReplyToMsgID: "msg-123",
+	})
+	if err != nil {
+		t.Fatalf("Send with ReplyToMsgID failed: %v", err)
+	}
+
+	lastURL := mock.lastRequestURL()
+	if lastURL == "" {
+		t.Fatal("no message API request was made")
+	}
+	if !strings.Contains(lastURL, "/messages/msg-123/reply") {
+		t.Fatalf("expected ReplyMessage API path containing /messages/msg-123/reply, got: %s", lastURL)
+	}
+}
+
+func TestSendWithoutReplyToMsgID(t *testing.T) {
+	mock := &mockHTTPClient{}
+	cfg := config.FeishuBotConfig{
+		AppID:        "cli-test",
+		AppSecretEnv: "FEISHU_NO_REPLY_TEST_SECRET",
+	}
+	t.Setenv("FEISHU_NO_REPLY_TEST_SECRET", "test-secret")
+
+	a := &adapter{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	a.client = lark.NewClient(cfg.AppID, "test-secret",
+		lark.WithHttpClient(mock),
+		lark.WithOpenBaseUrl("https://test.feishu.cn"),
+	)
+
+	// Without ReplyToMsgID — should use CreateMessage API
+	_, err := a.Send(context.Background(), bot.OutboundMessage{
+		ChatID: "chat-1",
+		Text:   "hello",
+	})
+	if err != nil {
+		t.Fatalf("Send without ReplyToMsgID failed: %v", err)
+	}
+
+	lastURL := mock.lastRequestURL()
+	if lastURL == "" {
+		t.Fatal("no message API request was made")
+	}
+	if !strings.Contains(lastURL, "/messages?") {
+		t.Fatalf("expected CreateMessage API path containing /messages?..., got: %s", lastURL)
+	}
+	if strings.Contains(lastURL, "/reply") {
+		t.Fatalf("expected CreateMessage API path, got ReplyMessage path: %s", lastURL)
+	}
+	if !strings.Contains(lastURL, "receive_id_type=chat_id") {
+		t.Fatalf("expected CreateMessage API to have receive_id_type=chat_id query param, got: %s", lastURL)
 	}
 }


### PR DESCRIPTION
## Summary

Fix Feishu/Lark bot reply markdown rendering by switching to Interactive Card JSON 2.0, while preserving ReplyMessage API for proper reply/thread semantics.

## Problem

1. **Markdown lost in rendering** — The previous markdown-to-post conversion (`SimpleMarkdownToPost` from the Lark SDK) only supported `[links](url)` and `<at>` tags. Bold, italic, inline code, code blocks, and headings were all displayed as raw markdown syntax.

2. **ReplyMessage API was removed** — The first iteration dropped `ReplyMessage` in favor of `CreateMessage` to avoid the platform-level quote prefix (`Reply @user: original message…`), but this broke reply/thread semantics in group and topic conversations.

## Fix

- **Preserve ReplyMessage API** — `sendSDKContent` now uses `ReplyMessage` API when `ReplyToMsgID` is set, and `CreateMessage` when it is empty. This keeps reply/thread semantics intact while fixing markdown rendering. The `ReplyInThread` field is left at its default (not set) to match current thread behavior.

- **Switch to Interactive Card JSON 2.0** — `sendMessage` builds a JSON 2.0 card with a `markdown` element via `buildMarkdownCard`, sending with `MsgTypeInteractive`. This gives native CommonMark rendering (bold, italic, inline code, code blocks, headings, etc.) with no custom markdown parser needed.

- **Card size limit fallback** — if the card exceeds Feishu 30KB body limit (error codes 11310/11325), the adapter automatically retries as plain text.

- **Updated test** — `TestBuildMarkdownCard` validates the new card format. Added `TestSendWithReplyToMsgID` and `TestSendWithoutReplyToMsgID` to prove `ReplyToMsgID` is not dropped.

## Future consideration

In direct messages (DM), the platform-level reply quote prefix (`Reply @user: …`) is unnecessary since both parties already know the context. A future improvement could differentiate: suppress the reply prefix in DMs (use `CreateMessage`) while preserving it in group chats (use `ReplyMessage`). This would give cleaner DM output without sacrificing group-thread semantics.

## Verification

- `go test ./internal/bot/...` — all pass
- `go vet ./internal/bot/...` — clean
- `gofmt -l internal/bot/feishu/` — clean

## Cache impact

Cache-impact: none — `internal/bot/` is not in cache-sensitive paths.
Cache-guard: existing tests cover the changed code paths.
System-prompt-review: N/A