### PR TITLE
Anchor Chinese reasoning language from raw prompts / 从原始提问锚定中文思考语言

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1037,7 +1037,7 @@ export const en = {
   "settings.coldResumePrune.on": "On",
   "settings.coldResumePrune.off": "Off",
   "settings.reasoningLanguage": "Thinking language",
-  "settings.reasoningLanguageHint": "Affects visible reasoning only. Auto follows the conversation language without injecting a language instruction.",
+  "settings.reasoningLanguageHint": "Affects visible reasoning only. Auto anchors clear Chinese prompts; referenced context is ignored.",
   "settings.reasoningLanguage.auto": "Auto",
   "settings.reasoningLanguage.zh": "中文",
   "settings.reasoningLanguage.en": "English",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -795,7 +795,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.coldResumePrune.on": "開",
   "settings.coldResumePrune.off": "關",
   "settings.reasoningLanguage": "思考語言",
-  "settings.reasoningLanguageHint": "只影響可見思考過程。自動跟隨對話語言，不額外注入語言指令。",
+  "settings.reasoningLanguageHint": "只影響可見思考過程。自動在原始提問明顯為中文時錨定中文，引用內容不參與判斷。",
   "settings.reasoningLanguage.auto": "自動",
   "settings.reasoningLanguage.zh": "中文",
   "settings.reasoningLanguage.en": "English",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1039,7 +1039,7 @@ export const zh: Record<DictKey, string> = {
   "settings.coldResumePrune.on": "开",
   "settings.coldResumePrune.off": "关",
   "settings.reasoningLanguage": "思考语言",
-  "settings.reasoningLanguageHint": "只影响可见思考过程。自动跟随对话语言，不额外注入语言指令。",
+  "settings.reasoningLanguageHint": "只影响可见思考过程。自动在原始提问明显为中文时锚定中文，引用内容不参与判断。",
   "settings.reasoningLanguage.auto": "自动",
   "settings.reasoningLanguage.zh": "中文",
   "settings.reasoningLanguage.en": "English",

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -800,7 +800,7 @@ func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
 	}
 
 	userComposed := userCtrl.Compose("hi")
-	if !strings.Contains(userComposed, "Simplified Chinese") {
+	if !strings.Contains(userComposed, "简体中文") {
 		t.Fatalf("user-level tab Compose = %q, want zh reasoning language", userComposed)
 	}
 	projectComposed := projectCtrl.Compose("hi")

--- a/docs/REASONING_LANGUAGE.md
+++ b/docs/REASONING_LANGUAGE.md
@@ -19,7 +19,9 @@ explicit without changing the stable system prompt or tool definitions.
 
 The setting is intentionally small:
 
-- `auto` follows the conversation language and injects no extra instruction.
+- `auto` anchors visible reasoning to Chinese when the raw user prompt is
+  clearly Chinese, ignoring injected reference context such as `@file` contents;
+  English and ambiguous turns add no extra instruction.
 - `zh` asks visible reasoning to prefer Simplified Chinese.
 - `en` asks visible reasoning to prefer English.
 
@@ -89,11 +91,15 @@ argument.
 
 ## Cache Behavior
 
-`auto` is the cache-friendliest choice. It injects nothing and relies on the
-existing stable language policy.
+`auto` is still cache-friendly. When the raw user prompt clearly looks Chinese,
+Reasonix adds the same small transient `<reasoning-language>` block for that
+turn; English and ambiguous turns inject nothing and rely on the existing stable
+language policy. Injected reference context such as `@file` contents is ignored
+for this auto decision.
 
-When set to `zh` or `en`, Reasonix adds a small transient
-`<reasoning-language>` block to the user turn. It does not change:
+When set to `zh` or `en`, Reasonix always adds a small transient
+`<reasoning-language>` block to the user turn. In all modes, this does not
+change:
 
 - the system prompt
 - tool schema bytes or ordering

--- a/docs/REASONING_LANGUAGE.zh-CN.md
+++ b/docs/REASONING_LANGUAGE.zh-CN.md
@@ -14,7 +14,7 @@
 
 取值只有三种：
 
-- `auto`：跟随当前对话语言，不额外注入语言指令。
+- `auto`：用户原始提问明显为中文时锚定中文，并忽略 `@file` 等注入的引用内容；英文或不确定时不额外注入语言指令。
 - `zh`：可见思考过程优先使用简体中文。
 - `en`：可见思考过程优先使用英文。
 
@@ -79,9 +79,9 @@ reasoning_language = "auto" # auto|zh|en
 
 ## 缓存影响
 
-`auto` 对缓存最友好。它不会注入任何额外内容，只复用已有的稳定语言策略。
+`auto` 仍然对缓存友好。用户原始提问明显是中文时，Reasonix 会为这一轮加入同样很小的 `<reasoning-language>` 临时 block；英文或信号不明确时不注入，只复用已有的稳定语言策略。`@file` 等注入的引用内容不会参与这个自动判断。
 
-当设置为 `zh` 或 `en` 时，Reasonix 会把一个很小的 `<reasoning-language>` 临时 block 放进本次 user turn。它不会改变：
+当设置为 `zh` 或 `en` 时，Reasonix 总是会把一个很小的 `<reasoning-language>` 临时 block 放进本次 user turn。所有模式下，它都不会改变：
 
 - system prompt
 - 工具 schema 的字节或顺序

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -58,7 +58,7 @@ func TestRunPrefixesReasoningLanguageOnSyntheticRetry(t *testing.T) {
 	}
 	for i, req := range prov.requests {
 		got := lastUser(req)
-		if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") {
+		if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") {
 			t.Fatalf("request %d last user = %q, want reasoning-language prefix", i, got)
 		}
 	}

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"unicode"
 )
 
 type reasoningLanguageContextKey struct{}
@@ -54,12 +55,119 @@ func ResponseLanguageBlock(lang string) string {
 func ReasoningLanguageBlock(lang string) string {
 	switch NormalizeReasoningLanguage(lang) {
 	case "zh":
-		return "<reasoning-language>\nVisible reasoning/thinking text preference: use Simplified Chinese when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
+		return "<reasoning-language>\n可见推理/思考文本偏好：当模型服务暴露可见推理或思考文本时，请使用简体中文。代码、标识符、文件路径、shell 命令和未翻译的技术术语保持原文。此偏好不会覆盖用户对最终回答语言的明确要求。\n</reasoning-language>"
 	case "en":
 		return "<reasoning-language>\nVisible reasoning/thinking text preference: use English when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
 	default:
 		return ""
 	}
+}
+
+// ResolveReasoningLanguage returns the concrete visible-reasoning language for
+// a turn. Explicit zh/en settings win; auto anchors clear Chinese user prompts
+// and otherwise stays provider-default to preserve the historical no-injection
+// behaviour for English and ambiguous turns.
+func ResolveReasoningLanguage(lang, source string) string {
+	mode := NormalizeReasoningLanguage(lang)
+	if mode != "auto" {
+		return mode
+	}
+	return InferReasoningLanguageFromText(source)
+}
+
+// InferReasoningLanguageFromText conservatively detects Chinese user-authored
+// turns for auto reasoning-language mode. It strips Reasonix-injected context
+// wrappers first so large @file payloads or transient XML blocks do not drown
+// out the user's actual prompt. English and ambiguous turns intentionally return
+// auto, preserving the old no-extra-instruction behaviour.
+func InferReasoningLanguageFromText(source string) string {
+	source = reasoningLanguageSourceText(source)
+	if source == "" {
+		return "auto"
+	}
+	han, cjkPunct := reasoningLanguageScriptCounts(source)
+	switch {
+	case han >= 4:
+		return "zh"
+	case han >= 2 && (cjkPunct > 0 || hasChineseReasoningCue(source)):
+		return "zh"
+	default:
+		return "auto"
+	}
+}
+
+func reasoningLanguageSourceText(source string) string {
+	s := strings.TrimSpace(StripTransientUserBlocks(source))
+	const preamble = "Referenced context:"
+	if !strings.HasPrefix(s, preamble) {
+		return s
+	}
+	s = strings.TrimSpace(s[len(preamble):])
+	for {
+		s = strings.TrimSpace(s)
+		if s == "" || !strings.HasPrefix(s, "<") {
+			return s
+		}
+		tagEnd := strings.IndexAny(s, " >\t\r\n")
+		if tagEnd <= 1 {
+			return s
+		}
+		tag := s[1:tagEnd]
+		switch tag {
+		case "file", "dir", "resource", "image":
+			closeTag := "</" + tag + ">"
+			i := strings.Index(s, closeTag)
+			if i < 0 {
+				return s
+			}
+			s = strings.TrimSpace(s[i+len(closeTag):])
+		default:
+			return s
+		}
+	}
+}
+
+func reasoningLanguageScriptCounts(source string) (han, cjkPunct int) {
+	for _, r := range source {
+		switch {
+		case unicode.In(r, unicode.Han):
+			han++
+		case isCJKPunctuation(r):
+			cjkPunct++
+		}
+	}
+	return han, cjkPunct
+}
+
+func isCJKPunctuation(r rune) bool {
+	switch {
+	case r >= 0x3000 && r <= 0x303F:
+		return true
+	case r >= 0xFF00 && r <= 0xFFEF:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasChineseReasoningCue(source string) bool {
+	for _, cue := range chineseReasoningLanguageCues {
+		if strings.Contains(source, cue) {
+			return true
+		}
+	}
+	return false
+}
+
+var chineseReasoningLanguageCues = []string{
+	"你好", "请", "帮我", "帮忙", "看看", "看下", "解释", "说明", "总结", "分析",
+	"修复", "实现", "优化", "排查", "处理", "继续", "为什么", "怎么",
+	"是否", "能否", "支持", "设置", "中文", "思考", "问题", "报错",
+	"代码", "文件", "这个", "那个",
+}
+
+func reasoningLanguageBlockForSource(lang, source string) string {
+	return ReasoningLanguageBlock(ResolveReasoningLanguage(lang, source))
 }
 
 // WithResponseLanguage prefixes content with the transient response-language
@@ -77,7 +185,15 @@ func WithResponseLanguage(content, lang string) string {
 // block. User-authored mentions of the tag later in the prompt must not suppress
 // the configured preference.
 func WithReasoningLanguage(content, lang string) string {
-	block := ReasoningLanguageBlock(lang)
+	return WithReasoningLanguageForSource(content, lang, content)
+}
+
+// WithReasoningLanguageForSource prefixes content using source as the language
+// signal for auto mode. Callers that expand @references should pass the raw
+// user prompt as source so referenced English code or logs do not override the
+// user's actual conversation language.
+func WithReasoningLanguageForSource(content, lang, source string) string {
+	block := reasoningLanguageBlockForSource(lang, source)
 	if block == "" || hasLeadingInjectedBlock(content, "reasoning-language") {
 		return content
 	}

--- a/internal/agent/reasoning_language_test.go
+++ b/internal/agent/reasoning_language_test.go
@@ -26,7 +26,7 @@ func TestWithResponseLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 	userMention := "explain why <reasoning-language> appears in this file"
 	got := WithReasoningLanguage(userMention, "zh")
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, userMention) {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, userMention) {
 		t.Fatalf("WithReasoningLanguage should prefix user-authored tag mentions, got %q", got)
 	}
 
@@ -38,5 +38,34 @@ func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 	withLeadingMemory := "<memory-update>\nRemember this.\n</memory-update>\n\n" + alreadyPrefixed
 	if got := WithReasoningLanguage(withLeadingMemory, "zh"); got != withLeadingMemory {
 		t.Fatalf("WithReasoningLanguage duplicated a reasoning block after leading transient context:\n got %q\nwant %q", got, withLeadingMemory)
+	}
+}
+
+func TestWithReasoningLanguageAutoInfersFromSource(t *testing.T) {
+	chinese := WithReasoningLanguage("解释 AuthHandler 的 panic", "auto")
+	if !strings.HasPrefix(chinese, "<reasoning-language>") || !strings.Contains(chinese, "简体中文") {
+		t.Fatalf("auto reasoning language should infer Chinese, got %q", chinese)
+	}
+
+	english := WithReasoningLanguage("explain this module", "auto")
+	if english != "explain this module" {
+		t.Fatalf("auto reasoning language should keep English prompts unwrapped, got %q", english)
+	}
+
+	short := WithReasoningLanguage("hi", "auto")
+	if short != "hi" {
+		t.Fatalf("short ambiguous auto prompt should not be wrapped, got %q", short)
+	}
+}
+
+func TestWithReasoningLanguageAutoUsesRawSourceOverReferencedContext(t *testing.T) {
+	expanded := "Referenced context:\n\n<file path=\"auth.go\">\npackage main\nfunc AuthHandler() error { return errors.New(\"not authorized\") }\n</file>\n\n解释 @auth.go 的报错"
+
+	got := WithReasoningLanguageForSource(expanded, "auto", "解释 @auth.go 的报错")
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") {
+		t.Fatalf("auto reasoning language should use raw source over referenced context, got %q", got)
+	}
+	if strings.Contains(got, "use English") {
+		t.Fatalf("referenced English code should not make auto prefer English:\n%s", got)
 	}
 }

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -110,7 +110,7 @@ func TestTaskToolInheritsReasoningLanguageFromContext(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	got := lastUser(sub.lastReq)
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "inspect auth") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "inspect auth") {
 		t.Fatalf("sub-agent user = %q, want reasoning-language-prefixed prompt", got)
 	}
 }

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1368,7 +1368,7 @@ func TestAutoPlanCommandPersistsAndUpdatesController(t *testing.T) {
 	input := "实现 GitHub issue #2395：\n- 新增配置项\n- 自动判断复杂任务\n- 补测试和文档"
 	ctrl.Send(input)
 	waitForCLIEvent(t, events, event.TurnDone)
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], control.PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), control.PlanModeMarker) {
 		t.Fatalf("/auto-plan on should affect current controller, inputs=%q", runner.inputs)
 	}
 }
@@ -1417,7 +1417,7 @@ func TestReasoningLanguageCommandPersistsAndUpdatesController(t *testing.T) {
 		t.Fatalf("saved config missing reasoning_language=zh:\n%s", body)
 	}
 	composed := ctrl.Compose("hello")
-	if !strings.HasPrefix(composed, "<reasoning-language>") || !strings.Contains(composed, "Simplified Chinese") {
+	if !strings.HasPrefix(composed, "<reasoning-language>") || !strings.Contains(composed, "简体中文") {
 		t.Fatalf("/reasoning-language zh should affect current controller, got %q", composed)
 	}
 }

--- a/internal/control/auto_plan_e2e_test.go
+++ b/internal/control/auto_plan_e2e_test.go
@@ -85,7 +85,7 @@ func TestAutoPlanGateEndToEnd(t *testing.T) {
 	}
 
 	msgs := ag.Session().Messages
-	if got := firstUserMessage(msgs); !strings.HasPrefix(got, PlanModeMarker) {
+	if got := agent.StripTransientUserBlocks(firstUserMessage(msgs)); !strings.HasPrefix(got, PlanModeMarker) {
 		t.Fatalf("first model input = %q, want the auto-plan marker prefixed", got)
 	}
 	if c.PlanMode() {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2216,7 +2216,7 @@ func TestApprovedPlanAutoApproveEndsWithExecutionTurn(t *testing.T) {
 	// The plan approval auto-approves writers for the execution turn only. A later
 	// turn does not inherit it, and "继续" carries no special meaning — Compose must
 	// not inject any marker, and the next writer falls back to per-tool approval.
-	if got := c.Compose("继续"); got != "继续" {
+	if got := c.Compose("继续"); StripComposePrefixes(got) != "继续" {
 		t.Fatalf("a paused approved plan must not marker-prefix the next turn, got %q", got)
 	}
 	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
@@ -2265,7 +2265,7 @@ func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
 	if err := c.runTurn(context.Background(), "plan this"); err != nil {
 		t.Fatal(err)
 	}
-	if got := c.Compose("先别继续"); got != "先别继续" {
+	if got := c.Compose("先别继续"); StripComposePrefixes(got) != "先别继续" {
 		t.Fatalf("non-continuation input should not be marker-prefixed, got %q", got)
 	}
 

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -151,10 +151,10 @@ var syntheticPrefixes = []string{
 // returning the message to actually send to the model. The frontend keeps
 // showing the raw text as the user bubble.
 func (c *Controller) Compose(text string) string {
-	return c.compose(text, true)
+	return c.compose(text, text, true)
 }
 
-func (c *Controller) compose(text string, includeHookContext bool) string {
+func (c *Controller) compose(text, source string, includeHookContext bool) string {
 	c.mu.Lock()
 	plan := c.planMode
 	responseLanguage := c.responseLanguage
@@ -174,7 +174,7 @@ func (c *Controller) compose(text string, includeHookContext bool) string {
 		text = PlanModeMarker + "\n\n" + text
 	}
 	text = agent.WithResponseLanguage(text, responseLanguage)
-	text = agent.WithReasoningLanguage(text, reasoningLanguage)
+	text = agent.WithReasoningLanguageForSource(text, reasoningLanguage, source)
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
 	// so it takes effect now without invalidating the prompt cache. It folds into
@@ -327,7 +327,7 @@ func (c *Controller) ComposeSynthetic(text string) string {
 	lang := c.reasoningLanguage
 	c.mu.Unlock()
 	text = agent.WithResponseLanguage(text, responseLang)
-	return agent.WithReasoningLanguage(text, lang)
+	return agent.WithReasoningLanguageForSource(text, lang, text)
 }
 
 func activeGoalBlock(goal string, researchMode GoalResearchMode) string {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -148,11 +148,17 @@ func TestComposeReasoningLanguagePreference(t *testing.T) {
 
 	zh := New(Options{ReasoningLanguage: "zh"})
 	got := zh.Compose("hi")
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "hi") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "hi") {
 		t.Fatalf("zh reasoning language should ride the user turn, got %q", got)
 	}
 	if stripped := StripComposePrefixes(got); stripped != "hi" {
 		t.Fatalf("StripComposePrefixes = %q, want hi", stripped)
+	}
+
+	autoZh := New(Options{ReasoningLanguage: "auto"})
+	got = autoZh.Compose("解释 AuthHandler 的 panic")
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "解释 AuthHandler 的 panic") {
+		t.Fatalf("auto reasoning language should infer Chinese from the user prompt, got %q", got)
 	}
 }
 
@@ -183,7 +189,7 @@ func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
 	}
 	got := runner.inputs[0]
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "hi") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "hi") {
 		t.Fatalf("headless Run should compose the reasoning language preference, got %q", got)
 	}
 }
@@ -225,7 +231,7 @@ func TestSyntheticComposeDoesNotDrainSessionStartHookContext(t *testing.T) {
 	c := New(Options{})
 	c.enqueueHookContexts([]string{"Load once."})
 
-	if got := c.compose("synthetic", false); strings.Contains(got, "<hook-context") {
+	if got := c.compose("synthetic", "synthetic", false); strings.Contains(got, "<hook-context") {
 		t.Fatalf("synthetic compose should not inject hook context: %q", got)
 	}
 	got := c.Compose("real")
@@ -299,7 +305,7 @@ func TestComposeSyntheticReasoningLanguagePreference(t *testing.T) {
 	c := New(Options{ReasoningLanguage: "zh"})
 
 	got := c.ComposeSynthetic(planApprovedMessage)
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, planApprovedMessage) {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, planApprovedMessage) {
 		t.Fatalf("ComposeSynthetic should prefix reasoning language, got %q", got)
 	}
 	if !IsSyntheticUserMessage(got) {
@@ -770,7 +776,7 @@ func TestRunTurnAutoPlanComplexTask(t *testing.T) {
 	if err := c.runTurn(context.Background(), input); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("complex task should auto-enter plan mode, inputs=%q", runner.inputs)
 	}
 	if !c.PlanMode() {
@@ -788,7 +794,7 @@ func TestRunTurnAutoPlanSkipsSimpleQuestion(t *testing.T) {
 	if err := c.runTurn(context.Background(), "解释一下这个函数做什么？"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("simple question should not auto-plan: inputs=%q", runner.inputs)
 	}
 	if c.PlanMode() {
@@ -804,7 +810,7 @@ func TestRunTurnAutoPlanOff(t *testing.T) {
 	if err := c.runTurn(context.Background(), input); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || runner.inputs[0] != input {
+	if len(runner.inputs) != 1 || StripComposePrefixes(runner.inputs[0]) != input {
 		t.Fatalf("auto_plan=off should compose verbatim, inputs=%q", runner.inputs)
 	}
 	if c.PlanMode() {
@@ -821,7 +827,7 @@ func TestSetAutoPlanAffectsNextTurn(t *testing.T) {
 	if err := c.runTurn(context.Background(), input); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("SetAutoPlan should affect next turn, inputs=%q", runner.inputs)
 	}
 }
@@ -834,7 +840,7 @@ func TestRunTurnAutoPlanClassifierBorderlineTrue(t *testing.T) {
 	if err := c.runTurn(context.Background(), "实现一个小的配置入口"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("classifier true should auto-plan, inputs=%q", runner.inputs)
 	}
 	if classifier.calls != 1 {
@@ -850,7 +856,7 @@ func TestRunTurnAutoPlanClassifierBorderlineFalse(t *testing.T) {
 	if err := c.runTurn(context.Background(), "实现一个小的配置入口"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("classifier false should skip auto-plan, inputs=%q", runner.inputs)
 	}
 	if c.PlanMode() {
@@ -869,7 +875,7 @@ func TestRunTurnAutoPlanClassifierFallback(t *testing.T) {
 	if err := c.runTurn(context.Background(), "实现 README 文档更新"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("score 2 should fall back to heuristic auto-plan, inputs=%q", runner.inputs)
 	}
 	if classifier.calls != 1 {
@@ -885,7 +891,7 @@ func TestRunTurnAutoPlanTypedNilClassifierFallsBack(t *testing.T) {
 	if err := c.runTurn(context.Background(), "实现 README 文档更新"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if len(runner.inputs) != 1 || !strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("typed nil classifier should fall back to heuristic auto-plan, inputs=%q", runner.inputs)
 	}
 }
@@ -903,7 +909,7 @@ func TestRunTurnAutoPlanScoresRawPromptNotResolvedRefs(t *testing.T) {
 	if len(runner.inputs) != 1 {
 		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
 	}
-	if strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+	if strings.HasPrefix(agent.StripTransientUserBlocks(runner.inputs[0]), PlanModeMarker) {
 		t.Fatalf("resolved context should not trigger auto-plan when raw prompt is simple: %q", runner.inputs[0])
 	}
 	if c.PlanMode() {

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -67,7 +67,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	} else {
 		ctx = agent.WithMemoryCompilerSourceInput(ctx, turn.raw)
 	}
-	input := c.compose(turn.input, !turn.synthetic)
+	input := c.compose(turn.input, turn.raw, !turn.synthetic)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	defer c.recordDisplayForNewUser(startMessages, turn.display)

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -301,6 +301,41 @@ func TestTurnOrchestratorRefTurnRecordsVisibleDisplay(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorAutoReasoningLanguageUsesRawPromptForRefTurns(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "auth.go"), []byte("package main\nfunc AuthHandler() error { return errors.New(\"not authorized\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeTurnRunner{}
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		WorkspaceRoot: root,
+		Runner:        runner,
+		AutoPlan:      "off",
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+	})
+
+	const visible = "解释 @auth.go 的报错"
+	c.runRefTurn(visible, visible)
+	waitForTurnDone(t, events)
+
+	if len(runner.inputs) != 1 {
+		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
+	}
+	got := runner.inputs[0]
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") {
+		t.Fatalf("auto reasoning language should anchor Chinese before referenced context, got %q", got)
+	}
+	if !strings.Contains(got, "Referenced context:") || !strings.Contains(got, "AuthHandler") {
+		t.Fatalf("ref context missing from model input: %q", got)
+	}
+	if strings.Contains(got, "use English") {
+		t.Fatalf("English referenced file content should not win over raw Chinese prompt:\n%s", got)
+	}
+}
+
 func TestTurnOrchestratorCheckpointBoundaryPrecedesUserMessage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -71,7 +71,7 @@ func TestAutoApproveToolsStillAutoPlansAndRequiresPlanApproval(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("approved plan did not continue into execution")
 	}
-	if got := firstUserMessage(ag.Session().Messages); !strings.HasPrefix(got, PlanModeMarker) {
+	if got := agent.StripTransientUserBlocks(firstUserMessage(ag.Session().Messages)); !strings.HasPrefix(got, PlanModeMarker) {
 		t.Fatalf("first model input = %q, want the auto-plan marker prefixed", got)
 	}
 	if c.PlanMode() {


### PR DESCRIPTION
## Summary

- Write the explicit `zh` visible-reasoning preference in Chinese so the language anchor is not drowned out by English context.
- Make `auto` anchor visible reasoning to Chinese only when the raw user prompt is clearly Chinese; English and ambiguous prompts keep the previous no-extra-instruction behavior.
- Pass the raw user prompt into turn composition so injected `@file` / referenced context does not decide the reasoning language.
- Update Desktop copy and bilingual docs, plus regression coverage for auto mode, referenced-context turns, plan-mode assertions, subagents, retries, and CLI/Desktop propagation.

## Issue and PR relationships

Fixes #4875
Fixes #5885
Refs #4520

## Consolidation notes

- Kept/adapted #4933 by @liaoyl830: that PR identified that the `zh` reasoning-language instruction should itself be written in Chinese so it is not drowned out by English referenced files. This PR keeps that mechanism and extends it with raw-prompt auto detection and referenced-context exclusion.
- Reviewed but not folded in #4513 by @myipanta: active-goal transient block stripping is related transient-message hygiene, but it affects transcript display rather than reasoning-language selection, so it should remain a separate focused fix.

## Cache impact

Cache-impact: low — the change keeps language preferences in transient user-turn context. It does not change the stable system prompt, memory prefix, tool schemas, tool ordering, provider request serialization, compaction, MCP/tool registration, or reasoning_content upload behavior.

Cache-guard: `auto` still injects nothing for English and ambiguous prompts. It only adds the existing small `<reasoning-language>` block when the raw user prompt clearly looks Chinese, and ignores injected reference context for that decision.

System-prompt-review: reviewed; no stable system prompt or tool schema bytes change.

## Verification

- `go test ./internal/agent -run 'TestWithReasoningLanguage|TestRunPrefixesReasoningLanguage|TestTaskToolInheritsReasoningLanguage|TestPreviewSessionStripsTransientReasoningLanguageBlock' -count=1`
- `go test ./internal/control -run 'TestComposeReasoningLanguage|TestRunComposesReasoningLanguage|TestComposeSyntheticReasoningLanguage|TestTurnOrchestratorAutoReasoningLanguage|TestTurnOrchestratorRefTurnRecordsVisibleDisplay' -count=1`
- `go test ./internal/cli -run 'TestReasoningLanguageCommand' -count=1`
- `cd desktop && go test . -run 'TestSetReasoningLanguageUpdatesLiveTabControllers|TestSetDesktopLanguage' -count=1`
- `go test ./internal/control ./internal/cli -count=1`
- `go test ./internal/agent ./internal/control ./internal/cli ./internal/boot -count=1` (initial combined run hit an intermittent `TestLoadGitStatus` environment failure in `internal/cli`; rerunning `go test ./internal/cli -count=1` passed)
- `cd desktop && go test . -count=1`
- `git diff --check`
