### PR TITLE
fix(feishu): remove pending reaction emoji after turn completes

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -570,14 +570,14 @@ func (a *adapter) sendSDKContent(ctx context.Context, msg bot.OutboundMessage, m
 	return bot.SendResult{MessageID: stringPtrValue(resp.Data.MessageId)}, nil
 }
 
-func (a *adapter) AddPendingReaction(ctx context.Context, messageID string) error {
+func (a *adapter) AddPendingReaction(ctx context.Context, messageID string) (func(), error) {
 	messageID = strings.TrimSpace(messageID)
 	if messageID == "" {
-		return nil
+		return nil, nil
 	}
 	client, err := a.sdkClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req := larkim.NewCreateMessageReactionReqBuilder().
 		MessageId(messageID).
@@ -587,15 +587,31 @@ func (a *adapter) AddPendingReaction(ctx context.Context, messageID string) erro
 		Build()
 	resp, err := client.Im.MessageReaction.Create(ctx, req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if resp == nil {
-		return fmt.Errorf("feishu reaction error: empty response")
+	if resp == nil || !resp.Success() {
+		if resp != nil {
+			return nil, fmt.Errorf("feishu reaction error: %s", feishuCodeError(resp.Code, resp.Msg))
+		}
+		return nil, fmt.Errorf("feishu reaction error: empty response")
 	}
-	if !resp.Success() {
-		return fmt.Errorf("feishu reaction error: %s", feishuCodeError(resp.Code, resp.Msg))
+	reactionID := ""
+	if resp.Data != nil && resp.Data.ReactionId != nil {
+		reactionID = *resp.Data.ReactionId
 	}
-	return nil
+	if reactionID == "" {
+		return nil, nil
+	}
+	cleanup := func() {
+		delReq := larkim.NewDeleteMessageReactionReqBuilder().
+			MessageId(messageID).
+			ReactionId(reactionID).
+			Build()
+		if _, err := client.Im.MessageReaction.Delete(context.Background(), delReq); err != nil {
+			a.logger.Warn("feishu reaction cleanup failed", "message", logHash(messageID), "err", err)
+		}
+	}
+	return cleanup, nil
 }
 
 // sendCard 发送 interactive card 消息（用于审批/问答）。

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -76,10 +76,11 @@ type BotGateway struct {
 	sessions *SessionManager
 	startErr []error
 
-	mu             sync.Mutex
-	controllers    map[string]*sessionState // session key -> active state
-	allowlist      map[Platform]map[string]bool
-	groupAllowlist map[Platform]map[string]bool
+	mu                      sync.Mutex
+	controllers             map[string]*sessionState // session key -> active state
+	pendingReactionCleanups map[string][]func()
+	allowlist               map[Platform]map[string]bool
+	groupAllowlist          map[Platform]map[string]bool
 
 	logger *slog.Logger
 }
@@ -106,7 +107,6 @@ type sessionState struct {
 	lastAskID        string
 	createdAt        time.Time
 	lastActive       time.Time
-	pendingReactionCleanups []func()
 }
 
 type sessionEventSink struct {
@@ -152,13 +152,14 @@ func NewGatewayWithAdapterBindings(cfg GatewayConfig, adapters []AdapterBinding,
 		cfg.Debounce = 1500 * time.Millisecond
 	}
 	gw := &BotGateway{
-		cfg:            cfg,
-		adapters:       normalizeAdapterBindings(adapters),
-		sessions:       NewSessionManager(cfg.Debounce),
-		controllers:    make(map[string]*sessionState),
-		allowlist:      make(map[Platform]map[string]bool),
-		groupAllowlist: make(map[Platform]map[string]bool),
-		logger:         logger.With("component", "bot_gateway"),
+		cfg:                     cfg,
+		adapters:                normalizeAdapterBindings(adapters),
+		sessions:                NewSessionManager(cfg.Debounce),
+		controllers:             make(map[string]*sessionState),
+		pendingReactionCleanups: make(map[string][]func()),
+		allowlist:               make(map[Platform]map[string]bool),
+		groupAllowlist:          make(map[Platform]map[string]bool),
+		logger:                  logger.With("component", "bot_gateway"),
 	}
 	gw.buildAllowlist()
 	return gw
@@ -358,26 +359,39 @@ func (gw *BotGateway) storeReactionCleanup(key string, cleanup func()) {
 	}
 	gw.mu.Lock()
 	defer gw.mu.Unlock()
-	if state := gw.controllers[key]; state != nil {
-		state.pendingReactionCleanups = append(state.pendingReactionCleanups, cleanup)
-	}
+	gw.pendingReactionCleanups[key] = append(gw.pendingReactionCleanups[key], cleanup)
 }
 
 func (gw *BotGateway) flushReactionCleanups(key string, cleanup func()) {
-	gw.mu.Lock()
-	state := gw.controllers[key]
-	if state != nil && len(state.pendingReactionCleanups) > 0 {
-		stored := state.pendingReactionCleanups
-		state.pendingReactionCleanups = nil
-		gw.mu.Unlock()
-		for _, c := range stored {
-			c()
-		}
-	} else {
-		gw.mu.Unlock()
-	}
+	stored := gw.takeReactionCleanups(key)
+	runReactionCleanups(stored)
 	if cleanup != nil {
 		cleanup()
+	}
+}
+
+func (gw *BotGateway) takeReactionCleanups(key string) []func() {
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	stored := gw.pendingReactionCleanups[key]
+	delete(gw.pendingReactionCleanups, key)
+	return stored
+}
+
+func runReactionCleanups(cleanups []func()) {
+	for _, cleanup := range cleanups {
+		if cleanup != nil {
+			cleanup()
+		}
+	}
+}
+
+func makeReactionCleanup(cleanups []func()) func() {
+	if len(cleanups) == 0 {
+		return nil
+	}
+	return func() {
+		runReactionCleanups(cleanups)
 	}
 }
 
@@ -812,12 +826,16 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 	defer func() {
 		// 检查是否有等待队列中的消息
 		next := gw.sessions.Release(key)
-		gw.flushReactionCleanups(key, cleanup)
 		if next != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			nextCleanup := makeReactionCleanup(gw.takeReactionCleanups(key))
 			gw.logger.Info("bot pending message released", "platform", next.Platform, "chat_type", next.ChatType, "chat", hashID(next.ChatID), "session", key[:8])
-			gw.runTurn(ctx, adapter, key, *next, nil)
+			gw.runTurn(ctx, adapter, key, *next, nextCleanup)
 			return
 		}
+		gw.flushReactionCleanups(key, cleanup)
 	}()
 
 	// 构建输入文本：群聊中在消息前加上发送者名

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -106,6 +106,7 @@ type sessionState struct {
 	lastAskID        string
 	createdAt        time.Time
 	lastActive       time.Time
+	pendingReactionCleanups []func()
 }
 
 type sessionEventSink struct {
@@ -114,7 +115,7 @@ type sessionEventSink struct {
 }
 
 type pendingReactionAdapter interface {
-	AddPendingReaction(ctx context.Context, messageID string) error
+	AddPendingReaction(ctx context.Context, messageID string) (func(), error)
 }
 
 func (s *sessionEventSink) setTarget(target event.Sink) {
@@ -324,17 +325,19 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 		return
 	}
 
-	gw.addPendingReaction(ctx, binding.Platform, binding.Adapter, msg)
+	cleanup := gw.addPendingReaction(ctx, binding.Platform, binding.Adapter, msg)
 
 	// session 并发控制
 	acquired, merged := gw.sessions.TryAcquire(key, msg)
 	if merged {
 		gw.logger.Debug("message merged to pending queue", "session", key[:8])
+		gw.storeReactionCleanup(key, cleanup)
 		return
 	}
 	if !acquired {
 		// 正在处理中且非 bypass 命令，已在 TryAcquire 中入队
 		gw.logger.Debug("session busy, queued", "session", key[:8])
+		gw.storeReactionCleanup(key, cleanup)
 		return
 	}
 
@@ -346,20 +349,52 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 	// would unblock it: the session wedges until restart (#4701, #4863, #4402).
 	// Per-session serialization is still held by the session lock (active[key]),
 	// which the deferred Release inside runTurn clears.
-	go gw.runTurn(ctx, binding.Adapter, key, msg)
+	go gw.runTurn(ctx, binding.Adapter, key, msg, cleanup)
 }
 
-func (gw *BotGateway) addPendingReaction(ctx context.Context, plat Platform, adapter Adapter, msg InboundMessage) {
-	if strings.TrimSpace(msg.MessageID) == "" {
+func (gw *BotGateway) storeReactionCleanup(key string, cleanup func()) {
+	if cleanup == nil {
 		return
+	}
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if state := gw.controllers[key]; state != nil {
+		state.pendingReactionCleanups = append(state.pendingReactionCleanups, cleanup)
+	}
+}
+
+func (gw *BotGateway) flushReactionCleanups(key string, cleanup func()) {
+	gw.mu.Lock()
+	state := gw.controllers[key]
+	if state != nil && len(state.pendingReactionCleanups) > 0 {
+		stored := state.pendingReactionCleanups
+		state.pendingReactionCleanups = nil
+		gw.mu.Unlock()
+		for _, c := range stored {
+			c()
+		}
+	} else {
+		gw.mu.Unlock()
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+func (gw *BotGateway) addPendingReaction(ctx context.Context, plat Platform, adapter Adapter, msg InboundMessage) func() {
+	if strings.TrimSpace(msg.MessageID) == "" {
+		return nil
 	}
 	reactor, ok := adapter.(pendingReactionAdapter)
 	if !ok {
-		return
+		return nil
 	}
-	if err := reactor.AddPendingReaction(ctx, msg.MessageID); err != nil {
+	cleanup, err := reactor.AddPendingReaction(ctx, msg.MessageID)
+	if err != nil {
 		gw.logger.Warn("pending reaction failed", "platform", plat, "err", err)
+		return nil
 	}
+	return cleanup
 }
 
 func (gw *BotGateway) checkAllowlist(plat Platform, msg InboundMessage) bool {
@@ -772,14 +807,15 @@ func toolApprovalModeLabel(mode string) string {
 	}
 }
 
-func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, msg InboundMessage) {
+func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, msg InboundMessage, cleanup func()) {
 	gw.logger.Info("bot turn started", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
 	defer func() {
 		// 检查是否有等待队列中的消息
 		next := gw.sessions.Release(key)
+		gw.flushReactionCleanups(key, cleanup)
 		if next != nil {
 			gw.logger.Info("bot pending message released", "platform", next.Platform, "chat_type", next.ChatType, "chat", hashID(next.ChatID), "session", key[:8])
-			gw.runTurn(ctx, adapter, key, *next)
+			gw.runTurn(ctx, adapter, key, *next, nil)
 			return
 		}
 	}()

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -105,6 +105,7 @@ func (f *blockingSendAdapter) Send(ctx context.Context, msg OutboundMessage) (Se
 type fakeReactionAdapter struct {
 	*fakeAdapter
 	reactions []string
+	cleanups  []string
 }
 
 type gatewayFakeProvider struct{}
@@ -119,9 +120,21 @@ func (gatewayFakeProvider) Stream(context.Context, provider.Request) (<-chan pro
 
 func (f *fakeReactionAdapter) AddPendingReaction(ctx context.Context, messageID string) (func(), error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.reactions = append(f.reactions, messageID)
-	return func() {}, nil
+	f.mu.Unlock()
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.cleanups = append(f.cleanups, messageID)
+	}, nil
+}
+
+func (f *fakeReactionAdapter) cleanupMessages() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.cleanups))
+	copy(out, f.cleanups)
+	return out
 }
 
 func TestFakeAdapterInterface(t *testing.T) {
@@ -754,6 +767,47 @@ func TestGatewayAddsPendingReactionWhenAdapterSupportsIt(t *testing.T) {
 
 	if len(fa.reactions) != 1 || fa.reactions[0] != "om_123" {
 		t.Fatalf("reactions = %#v, want [om_123]", fa.reactions)
+	}
+}
+
+func TestGatewayStoresQueuedReactionCleanupBeforeControllerExists(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{}, nil, logger)
+	fa := &fakeReactionAdapter{fakeAdapter: newFakeAdapter(PlatformFeishu, "fake-feishu")}
+	first := InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu-feishu",
+		Domain:       "feishu",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+		Text:         "first",
+		MessageID:    "om_first",
+	}
+	key := BuildSessionKey(first.Session())
+	if acquired, merged := gw.sessions.TryAcquire(key, first); !acquired || merged {
+		t.Fatalf("first TryAcquire = (%v, %v), want acquired without merge", acquired, merged)
+	}
+
+	queued := first
+	queued.Text = "queued"
+	queued.MessageID = "om_queued"
+	cleanup := gw.addPendingReaction(context.Background(), PlatformFeishu, fa, queued)
+	if acquired, merged := gw.sessions.TryAcquire(key, queued); acquired || !merged {
+		t.Fatalf("queued TryAcquire = (%v, %v), want merged while active", acquired, merged)
+	}
+	gw.storeReactionCleanup(key, cleanup)
+	if _, ok := gw.controllers[key]; ok {
+		t.Fatal("test setup expected no controller state yet")
+	}
+	if cleaned := fa.cleanupMessages(); len(cleaned) != 0 {
+		t.Fatalf("cleanup messages before flush = %#v, want none", cleaned)
+	}
+
+	gw.flushReactionCleanups(key, nil)
+	cleaned := fa.cleanupMessages()
+	if len(cleaned) != 1 || cleaned[0] != "om_queued" {
+		t.Fatalf("cleanup messages = %#v, want [om_queued]", cleaned)
 	}
 }
 

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -117,11 +117,11 @@ func (gatewayFakeProvider) Stream(context.Context, provider.Request) (<-chan pro
 	return ch, nil
 }
 
-func (f *fakeReactionAdapter) AddPendingReaction(ctx context.Context, messageID string) error {
+func (f *fakeReactionAdapter) AddPendingReaction(ctx context.Context, messageID string) (func(), error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reactions = append(f.reactions, messageID)
-	return nil
+	return func() {}, nil
 }
 
 func TestFakeAdapterInterface(t *testing.T) {


### PR DESCRIPTION
## Summary

The "OnIt" reaction emoji added when the bot starts processing a message was never removed. It stayed visible after the turn completed, which is confusing.

## Problem

`AddPendingReaction` in `gateway.go` added the reaction on message receipt, but there was no corresponding removal logic. The emoji persisted indefinitely.

## Fix

Changed `AddPendingReaction` to return a `func()` cleanup closure. The gateway defers this cleanup in `runTurn`, so the emoji is automatically removed when the turn finishes (success or error).

Only the Feishu adapter implements this interface. QQ and WeChat are unaffected.

Files: `internal/bot/gateway.go`, `internal/bot/feishu/feishu.go`, `internal/bot/gateway_test.go`.

## Verification

- `go test ./internal/bot/...` — 65/65 pass
- `go vet ./...` — clean
- `gofmt -l .` — no changes

## Cache impact

Cache-impact: none — `internal/bot/` is not in cache-sensitive paths.
Cache-guard: existing tests cover the changed code paths.
System-prompt-review: N/A