### PR TITLE
Capability routing hints for skills and MCP / 为 Skills 和 MCP 添加能力路由提示

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|hook-context)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|hook-context)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|hook-context|capability-route)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|hook-context|capability-route)>\s*\n?`)
 
 const memoryCompilerExecutionOpen = "<memory-compiler-execution>"
 

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -68,6 +68,11 @@ func TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution(t *testing.T) {
 			in:   "<hook-context event=\"SessionStart\">\nLoad conventions.\n</hook-context>\n\nship it",
 			want: "ship it",
 		},
+		{
+			name: "capability route prefix is stripped",
+			in:   "<capability-route version=\"1\">\nRelevant capabilities:\n- skill:review prefer\n</capability-route>\n\nreview this",
+			want: "review this",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -304,13 +304,6 @@ func normalizeAutoUse(raw string) AutoUse {
 	}
 }
 
-func atLeast(a, b AutoUse) AutoUse {
-	if rank(a) >= rank(b) {
-		return a
-	}
-	return b
-}
-
 func rank(a AutoUse) int {
 	switch a {
 	case AutoUseRequire:

--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -1,0 +1,325 @@
+package capability
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"reasonix/internal/skill"
+	"reasonix/internal/tool"
+)
+
+type Kind string
+
+const (
+	KindSkill   Kind = "skill"
+	KindMCPTool Kind = "mcp-tool"
+	KindTool    Kind = "tool"
+	KindSource  Kind = "source"
+)
+
+type Status string
+
+const (
+	StatusReady      Status = "ready"
+	StatusConfigured Status = "configured"
+	StatusDisabled   Status = "disabled"
+	StatusFailed     Status = "failed"
+	StatusStale      Status = "stale"
+)
+
+type AutoUse string
+
+const (
+	AutoUseOff     AutoUse = "off"
+	AutoUseSuggest AutoUse = "suggest"
+	AutoUsePrefer  AutoUse = "prefer"
+	AutoUseRequire AutoUse = "require"
+)
+
+type Entry struct {
+	ID               string
+	Kind             Kind
+	Name             string
+	Description      string
+	Source           string
+	Status           Status
+	ReadOnly         bool
+	Cost             string
+	AutoUse          AutoUse
+	Triggers         []string
+	NegativeTriggers []string
+	NeedsFreshData   bool
+	ToolName         string
+	ConnectSource    string
+	ConnectName      string
+}
+
+type RouteCandidate struct {
+	Entry  Entry
+	Policy AutoUse
+	Reason string
+}
+
+type RouteDecision struct {
+	Candidates []RouteCandidate
+}
+
+func SkillEntries(skills []skill.Skill, tools []tool.ContractEntry) []Entry {
+	toolNames := map[string]bool{}
+	for _, t := range tools {
+		toolNames[t.Name] = true
+	}
+	skillToolReady := toolNames["run_skill"] || toolNames["read_skill"] || toolNames["read_only_skill"]
+
+	out := make([]Entry, 0, len(skills))
+	for _, sk := range skills {
+		status := StatusReady
+		connectSource := ""
+		if !skillToolReady {
+			status = StatusConfigured
+			connectSource = "skills"
+		}
+		auto := normalizeAutoUse(sk.AutoUse)
+		if auto == "" && len(sk.Triggers) > 0 {
+			auto = AutoUsePrefer
+		} else if auto == "" {
+			auto = AutoUseSuggest
+		}
+		out = append(out, Entry{
+			ID:               "skill:" + sk.Name,
+			Kind:             KindSkill,
+			Name:             sk.Name,
+			Description:      sk.Description,
+			Source:           string(sk.Scope),
+			Status:           status,
+			Cost:             strings.TrimSpace(sk.Cost),
+			AutoUse:          auto,
+			Triggers:         cleanList(sk.Triggers),
+			NegativeTriggers: cleanList(sk.NegativeTriggers),
+			NeedsFreshData:   sk.NeedsFreshData,
+			ToolName:         "run_skill",
+			ConnectSource:    connectSource,
+		})
+	}
+	return out
+}
+
+func ToolEntries(tools []tool.ContractEntry) []Entry {
+	out := make([]Entry, 0, len(tools))
+	for _, t := range tools {
+		e := Entry{
+			ID:          "tool:" + t.Name,
+			Kind:        KindTool,
+			Name:        t.Name,
+			Description: strings.TrimSpace(t.Description),
+			Status:      StatusReady,
+			ReadOnly:    t.ReadOnly,
+			ToolName:    t.Name,
+		}
+		if server, raw, ok := tool.SplitMCPName(t.Name); ok {
+			e.ID = "mcp-tool:" + server + "/" + raw
+			e.Kind = KindMCPTool
+			e.Name = server + "/" + raw
+			e.Source = server
+			e.ConnectName = server
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func Route(input string, entries []Entry) RouteDecision {
+	text := normalize(input)
+	if text == "" {
+		return RouteDecision{}
+	}
+	var candidates []RouteCandidate
+	for _, e := range entries {
+		if e.Status == StatusDisabled || negativeMatch(text, e.NegativeTriggers) {
+			continue
+		}
+		if policy, reason, ok := routeEntry(text, e); ok {
+			candidates = append(candidates, RouteCandidate{Entry: e, Policy: policy, Reason: reason})
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if rank(candidates[i].Policy) != rank(candidates[j].Policy) {
+			return rank(candidates[i].Policy) > rank(candidates[j].Policy)
+		}
+		if candidates[i].Entry.Kind != candidates[j].Entry.Kind {
+			return candidates[i].Entry.Kind < candidates[j].Entry.Kind
+		}
+		return candidates[i].Entry.ID < candidates[j].Entry.ID
+	})
+	if len(candidates) > 5 {
+		candidates = candidates[:5]
+	}
+	return RouteDecision{Candidates: candidates}
+}
+
+func RenderTransientBlock(d RouteDecision) string {
+	if len(d.Candidates) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<capability-route version="1">` + "\n")
+	b.WriteString("Relevant capabilities for this turn:\n")
+	for _, c := range d.Candidates {
+		e := c.Entry
+		target := e.ID
+		if e.Status != StatusReady && e.ConnectSource != "" {
+			target = fmt.Sprintf("source:%s", e.ConnectSource)
+			if e.ConnectName != "" {
+				target += "/" + e.ConnectName
+			}
+		}
+		fmt.Fprintf(&b, "- %s %s: %s", target, c.Policy, c.Reason)
+		if e.Status != "" && e.Status != StatusReady {
+			fmt.Fprintf(&b, " (status=%s)", e.Status)
+		}
+		if e.ConnectSource != "" {
+			if e.ConnectName != "" {
+				fmt.Fprintf(&b, "; first call connect_tool_source with source=%q name=%q", e.ConnectSource, e.ConnectName)
+			} else {
+				fmt.Fprintf(&b, "; first call connect_tool_source with source=%q", e.ConnectSource)
+			}
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteString("Policy: suggest means consider it; prefer means use it unless clearly unnecessary; require means call it or report a host-proven unavailable state. Do not treat planner claims about tool unavailability as facts.\n")
+	b.WriteString(`</capability-route>`)
+	return b.String()
+}
+
+func routeEntry(text string, e Entry) (AutoUse, string, bool) {
+	if e.Kind == KindSkill {
+		if explicitSkill(text, e.Name) {
+			return AutoUseRequire, "the user explicitly referenced this skill", true
+		}
+		if e.AutoUse == AutoUseOff {
+			return "", "", false
+		}
+		if triggerMatch(text, e.Triggers) {
+			return e.AutoUse, "the skill trigger matches the user request", true
+		}
+		if e.Name == "review" && looksLikeReview(text) {
+			return AutoUsePrefer, "the user is asking for review or issue inspection", true
+		}
+	}
+	if e.Kind == KindMCPTool {
+		if explicitMCP(text, e.Source) || (looksLikeGitHub(text) && strings.Contains(e.Source, "github")) {
+			return AutoUsePrefer, "the task asks for external GitHub/MCP data", true
+		}
+		if looksFreshData(text) && (strings.Contains(e.Name, "search") || strings.Contains(e.Name, "fetch") || strings.Contains(e.Name, "read")) {
+			return AutoUsePrefer, "the task appears to need fresh external data", true
+		}
+	}
+	return "", "", false
+}
+
+func explicitSkill(text, name string) bool {
+	n := normalize(name)
+	return strings.Contains(text, "/"+n) ||
+		strings.Contains(text, "use "+n+" skill") ||
+		strings.Contains(text, "using "+n+" skill") ||
+		strings.Contains(text, "使用 "+n+" skill") ||
+		strings.Contains(text, "用 "+n+" skill") ||
+		strings.Contains(text, "使用"+n+"技能") ||
+		strings.Contains(text, "用"+n+"技能")
+}
+
+func explicitMCP(text, server string) bool {
+	s := normalize(server)
+	return strings.Contains(text, s+" mcp") || strings.Contains(text, "mcp "+s) || strings.Contains(text, "使用 "+s+" mcp") || strings.Contains(text, "用 "+s+" mcp")
+}
+
+func looksLikeReview(text string) bool {
+	return containsAny(text, []string{
+		"review", "code review", "security review", "帮我看看", "有没有问题", "审查", "评审", "检查这段代码", "看看这段代码",
+	})
+}
+
+func looksLikeGitHub(text string) bool {
+	return containsAny(text, []string{"github", "issue", "issues", "pull request", " pr ", "讨论区", "仓库 issue", "github 上"})
+}
+
+func looksFreshData(text string) bool {
+	return containsAny(text, []string{"latest", "recent", "today", "现在", "最新", "最近", "查一下", "搜索", "github"})
+}
+
+func triggerMatch(text string, triggers []string) bool {
+	for _, trig := range triggers {
+		t := normalize(trig)
+		if t != "" && strings.Contains(text, t) {
+			return true
+		}
+	}
+	return false
+}
+
+func negativeMatch(text string, triggers []string) bool {
+	return triggerMatch(text, triggers)
+}
+
+func containsAny(s string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(s, normalize(term)) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func cleanList(in []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+func normalizeAutoUse(raw string) AutoUse {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "off":
+		return AutoUseOff
+	case "suggest":
+		return AutoUseSuggest
+	case "prefer":
+		return AutoUsePrefer
+	case "require":
+		return AutoUseRequire
+	default:
+		return ""
+	}
+}
+
+func atLeast(a, b AutoUse) AutoUse {
+	if rank(a) >= rank(b) {
+		return a
+	}
+	return b
+}
+
+func rank(a AutoUse) int {
+	switch a {
+	case AutoUseRequire:
+		return 3
+	case AutoUsePrefer:
+		return 2
+	case AutoUseSuggest:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/capability/capability_test.go
+++ b/internal/capability/capability_test.go
@@ -1,0 +1,107 @@
+package capability
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/skill"
+	"reasonix/internal/tool"
+)
+
+func TestRoutePrefersReviewSkillForReviewRequest(t *testing.T) {
+	entries := SkillEntries([]skill.Skill{{
+		Name:        "review",
+		Description: "review code for bugs",
+		Scope:       skill.ScopeBuiltin,
+	}}, []tool.ContractEntry{{Name: "run_skill"}})
+
+	decision := Route("帮我看看这段代码有没有问题", entries)
+	if len(decision.Candidates) == 0 {
+		t.Fatal("Route returned no candidates")
+	}
+	got := decision.Candidates[0]
+	if got.Entry.ID != "skill:review" || got.Policy != AutoUsePrefer {
+		t.Fatalf("candidate = %+v, want review/prefer", got)
+	}
+}
+
+func TestRouteRequiresExplicitSkill(t *testing.T) {
+	entries := SkillEntries([]skill.Skill{{
+		Name:        "audit",
+		Description: "audit something",
+		Scope:       skill.ScopeProject,
+	}}, []tool.ContractEntry{{Name: "run_skill"}})
+
+	decision := Route("请使用 audit skill 检查一下", entries)
+	if len(decision.Candidates) == 0 {
+		t.Fatal("Route returned no candidates")
+	}
+	if got := decision.Candidates[0].Policy; got != AutoUseRequire {
+		t.Fatalf("policy = %s, want require", got)
+	}
+}
+
+func TestRouteRespectsSkillAutoUseMetadata(t *testing.T) {
+	entries := SkillEntries([]skill.Skill{
+		{
+			Name:        "quiet",
+			Description: "quiet skill",
+			Scope:       skill.ScopeProject,
+			Triggers:    []string{"inspect"},
+			AutoUse:     "off",
+		},
+		{
+			Name:        "gentle",
+			Description: "gentle skill",
+			Scope:       skill.ScopeProject,
+			Triggers:    []string{"inspect"},
+			AutoUse:     "suggest",
+		},
+	}, []tool.ContractEntry{{Name: "run_skill"}})
+
+	decision := Route("please inspect this", entries)
+	if len(decision.Candidates) != 1 {
+		t.Fatalf("candidates = %+v, want exactly the suggest skill", decision.Candidates)
+	}
+	if got := decision.Candidates[0]; got.Entry.ID != "skill:gentle" || got.Policy != AutoUseSuggest {
+		t.Fatalf("candidate = %+v, want gentle/suggest", got)
+	}
+}
+
+func TestRoutePrefersGitHubMCPForIssueLookup(t *testing.T) {
+	entries := ToolEntries([]tool.ContractEntry{{
+		Name:        "mcp__github__search_issues",
+		Description: "search GitHub issues",
+		ReadOnly:    true,
+	}})
+
+	decision := Route("查一下 GitHub issue 里有没有相关反馈", entries)
+	if len(decision.Candidates) == 0 {
+		t.Fatal("Route returned no candidates")
+	}
+	got := decision.Candidates[0]
+	if got.Entry.ID != "mcp-tool:github/search_issues" || got.Policy != AutoUsePrefer {
+		t.Fatalf("candidate = %+v, want github mcp/prefer", got)
+	}
+}
+
+func TestRenderTransientBlockMentionsConnectSource(t *testing.T) {
+	decision := RouteDecision{Candidates: []RouteCandidate{{
+		Entry: Entry{
+			ID:            "skill:review",
+			Kind:          KindSkill,
+			Name:          "review",
+			Status:        StatusConfigured,
+			ConnectSource: "skills",
+		},
+		Policy: AutoUsePrefer,
+		Reason: "matched",
+	}}}
+
+	block := RenderTransientBlock(decision)
+	for _, want := range []string{`<capability-route version="1">`, `source:skills`, `connect_tool_source`} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("block missing %q:\n%s", want, block)
+		}
+	}
+}

--- a/internal/control/capability.go
+++ b/internal/control/capability.go
@@ -1,0 +1,30 @@
+package control
+
+import (
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/capability"
+)
+
+func (c *Controller) withCapabilityRoute(composed, routeInput string) string {
+	if c == nil {
+		return composed
+	}
+	routeInput = strings.TrimSpace(agent.StripTransientUserBlocks(routeInput))
+	if routeInput == "" {
+		routeInput = strings.TrimSpace(agent.StripTransientUserBlocks(composed))
+	}
+	if routeInput == "" {
+		return composed
+	}
+	tools := c.ToolContractEntries()
+	entries := capability.ToolEntries(tools)
+	entries = append(entries, capability.SkillEntries(c.Skills(), tools)...)
+	decision := capability.Route(routeInput, entries)
+	block := capability.RenderTransientBlock(decision)
+	if block == "" {
+		return composed
+	}
+	return block + "\n\n" + composed
+}

--- a/internal/control/capability_test.go
+++ b/internal/control/capability_test.go
@@ -1,0 +1,60 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/skill"
+	"reasonix/internal/tool"
+)
+
+type capabilityRecordingRunner struct {
+	input string
+}
+
+func (r *capabilityRecordingRunner) Run(_ context.Context, input string) error {
+	r.input = input
+	return nil
+}
+
+type capabilityTestTool struct{ name string }
+
+func (t capabilityTestTool) Name() string { return t.name }
+func (t capabilityTestTool) Description() string {
+	return "test tool"
+}
+func (t capabilityTestTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{}}`)
+}
+func (t capabilityTestTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "ok", nil
+}
+func (t capabilityTestTool) ReadOnly() bool { return true }
+
+func TestRunInjectsCapabilityRouteForRelevantSkill(t *testing.T) {
+	runner := &capabilityRecordingRunner{}
+	reg := tool.NewRegistry()
+	reg.Add(capabilityTestTool{name: "run_skill"})
+	c := New(Options{
+		Runner: runner,
+		Skills: []skill.Skill{{
+			Name:        "review",
+			Description: "review code",
+			Scope:       skill.ScopeBuiltin,
+		}},
+		Registry: reg,
+	})
+
+	if err := c.Run(context.Background(), "帮我看看这段代码有没有问题"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(runner.input, `<capability-route version="1">`) ||
+		!strings.Contains(runner.input, "skill:review prefer") {
+		t.Fatalf("input missing capability route:\n%s", runner.input)
+	}
+	if got := StripComposePrefixes(runner.input); got != "帮我看看这段代码有没有问题" {
+		t.Fatalf("StripComposePrefixes = %q", got)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1319,6 +1319,7 @@ func (c *Controller) Run(ctx context.Context, input string) error {
 	ctx = agent.WithParentSession(ctx, parentSession)
 	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
+	rawInput := input
 	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -1334,7 +1335,7 @@ func (c *Controller) Run(ctx context.Context, input string) error {
 	}
 	c.markInFlightTurn(startMessages, true)
 	defer c.clearInFlightTurn()
-	return c.runner.Run(ctx, input)
+	return c.runner.Run(ctx, c.withCapabilityRoute(input, rawInput))
 }
 
 // Cancel aborts the in-flight turn. A goroutine blocked awaiting approval

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -102,7 +102,11 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	autoResearchTaskID := c.goals.currentAutoResearchTaskID()
 	autoResearchAcceptedBefore := c.autoResearchAcceptedEvidenceIDs(autoResearchTaskID)
 	c.appendAutoResearchHeartbeat(autoResearchTaskID, autoresearch.HeartbeatStartingTurn, "")
-	err := c.runner.Run(ctx, input)
+	modelInput := input
+	if !turn.synthetic {
+		modelInput = c.withCapabilityRoute(input, turn.raw)
+	}
+	err := c.runner.Run(ctx, modelInput)
 	if err == nil {
 		c.recordAutoResearchEvidenceFromAssistant(autoResearchTaskID, lastAssistantText(c.History()))
 		c.recordAutoResearchTurnProgress(autoResearchTaskID, autoResearchAcceptedBefore)

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -65,6 +65,13 @@ type Skill struct {
 	RunAs        RunAs  // inline | subagent
 	Model        string // optional model override for runAs=subagent (frontmatter `model:`)
 	Effort       string // optional effort for runAs=subagent (frontmatter `effort:`)
+	// Routing metadata is intentionally kept out of the cache-stable Skills
+	// index; it feeds per-turn capability hints only.
+	Triggers         []string
+	NegativeTriggers []string
+	AutoUse          string // off | suggest | prefer | require
+	NeedsFreshData   bool
+	Cost             string // low | medium | high (advisory)
 }
 
 // IsValidName reports whether name is a usable skill identifier.
@@ -484,18 +491,30 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
 		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
 		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
+		Triggers:     parseCSVFrontmatter(fm[skillFrontmatterTriggers]),
+		NegativeTriggers: parseCSVFrontmatter(
+			fm[skillFrontmatterNegativeTriggers],
+		),
+		AutoUse:        parseAutoUse(fm[skillFrontmatterAutoUse]),
+		NeedsFreshData: parseBoolFrontmatter(fm[skillFrontmatterNeedsFreshData]),
+		Cost:           parseCost(fm[skillFrontmatterCost]),
 	}, true
 }
 
 const (
-	skillFrontmatterDescription  = "description"
-	skillFrontmatterName         = "name"
-	skillFrontmatterRunAs        = "runas"
-	skillFrontmatterContext      = "context"
-	skillFrontmatterAgent        = "agent"
-	skillFrontmatterAllowedTools = "allowed-tools"
-	skillFrontmatterModel        = "model"
-	skillFrontmatterEffort       = "effort"
+	skillFrontmatterDescription      = "description"
+	skillFrontmatterName             = "name"
+	skillFrontmatterRunAs            = "runas"
+	skillFrontmatterContext          = "context"
+	skillFrontmatterAgent            = "agent"
+	skillFrontmatterAllowedTools     = "allowed-tools"
+	skillFrontmatterModel            = "model"
+	skillFrontmatterEffort           = "effort"
+	skillFrontmatterTriggers         = "triggers"
+	skillFrontmatterNegativeTriggers = "negative-triggers"
+	skillFrontmatterAutoUse          = "auto-use"
+	skillFrontmatterNeedsFreshData   = "needs-fresh-data"
+	skillFrontmatterCost             = "cost"
 )
 
 var skillMarkerFrontmatterKeys = []string{
@@ -507,6 +526,11 @@ var skillMarkerFrontmatterKeys = []string{
 	skillFrontmatterAllowedTools,
 	skillFrontmatterModel,
 	skillFrontmatterEffort,
+	skillFrontmatterTriggers,
+	skillFrontmatterNegativeTriggers,
+	skillFrontmatterAutoUse,
+	skillFrontmatterNeedsFreshData,
+	skillFrontmatterCost,
 }
 
 func hasSkillMarker(content string, fm map[string]string) bool {
@@ -694,6 +718,12 @@ func isScriptExt(ext string) bool {
 // parseAllowedTools splits a comma-separated `allowed-tools` value into trimmed,
 // non-empty tool names; nil when absent.
 func parseAllowedTools(raw string) []string {
+	return parseCSVFrontmatter(raw)
+}
+
+// parseCSVFrontmatter splits simple comma-separated frontmatter values. Full
+// YAML lists are intentionally out of scope for the existing frontmatter parser.
+func parseCSVFrontmatter(raw string) []string {
 	if strings.TrimSpace(raw) == "" {
 		return nil
 	}
@@ -704,6 +734,33 @@ func parseAllowedTools(raw string) []string {
 		}
 	}
 	return out
+}
+
+func parseAutoUse(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "off", "suggest", "prefer", "require":
+		return strings.ToLower(strings.TrimSpace(raw))
+	default:
+		return ""
+	}
+}
+
+func parseBoolFrontmatter(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "yes", "1", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseCost(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "low", "medium", "high":
+		return strings.ToLower(strings.TrimSpace(raw))
+	default:
+		return ""
+	}
 }
 
 // parseRunAs maps frontmatter to a run mode. An unknown value defaults to the

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -760,6 +760,30 @@ func TestReadOnlyIndexBlockPointsAtReadOnlySkill(t *testing.T) {
 	}
 }
 
+func TestSkillRoutingMetadataParsesButStaysOutOfIndex(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/router.md", "---\ndescription: route me\ntriggers: code review, 检查代码\nnegative-triggers: explain only\nauto-use: prefer\nneeds-fresh-data: true\ncost: low\n---\nbody")
+	sk, ok := New(Options{HomeDir: home, DisableBuiltins: true}).Read("router")
+	if !ok {
+		t.Fatal("skill not loaded")
+	}
+	if got := strings.Join(sk.Triggers, ","); got != "code review,检查代码" {
+		t.Fatalf("Triggers = %q", got)
+	}
+	if got := strings.Join(sk.NegativeTriggers, ","); got != "explain only" {
+		t.Fatalf("NegativeTriggers = %q", got)
+	}
+	if sk.AutoUse != "prefer" || !sk.NeedsFreshData || sk.Cost != "low" {
+		t.Fatalf("routing metadata = auto:%q fresh:%v cost:%q", sk.AutoUse, sk.NeedsFreshData, sk.Cost)
+	}
+	index := IndexBlock([]Skill{sk})
+	for _, forbidden := range []string{"code review", "auto-use", "needs-fresh-data"} {
+		if strings.Contains(index, forbidden) {
+			t.Fatalf("routing metadata leaked into index (%q):\n%s", forbidden, index)
+		}
+	}
+}
+
 func TestApplyIndexTruncates(t *testing.T) {
 	var skills []Skill
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
## Summary
- add a cache-safe capability router that emits per-turn `<capability-route>` hints for relevant skills and MCP tools
- parse optional skill routing metadata (`triggers`, `negative-triggers`, `auto-use`, `needs-fresh-data`, `cost`) without adding it to the stable skills index
- strip capability route blocks from previews/display text and cover controller injection with tests

## Cache / tool schema safety
- dynamic route hints are injected as transient user-turn blocks only
- stable system prompt Skills index and provider-visible tool schema order are unchanged
- Cache-impact: low - skill routing metadata parsing touches system-prompt-sensitive files, but metadata stays out of the stable Skills index and route hints are transient user-turn blocks.
- Cache-guard: `REASONIX_RELEASE_CACHE_GUARD=1 go test -p 1 ./internal/boot ./internal/agent ./internal/control ./internal/capability -run 'TestBuildDiscoversSkills|TestBuildTokenEconomyPlanModeCanConnectAllowedMCPSource|TestBuildLazyDoesNotConnectAtBoot|TestBuildFullModePreservesToolSchemas|TestStripTransientUserBlocks|TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP|TestRunInjectsCapabilityRouteForRelevantSkill|TestRoute' -count=1`
- System-prompt-review: reviewed for #5891; no stable system prompt or provider-visible tool schema change is introduced.

## Tests
- `go test ./internal/control -run TestRunInjectsCapabilityRouteForRelevantSkill -count=1`
- `go test ./internal/control -count=1`
- `go test ./internal/capability ./internal/skill -count=1`
- `go test ./internal/agent -run 'TestStripTransientUserBlocks|TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP|TestCoordinatorNudgesExecutorThatAnswersWithoutActing' -count=1`
- `REASONIX_RELEASE_CACHE_GUARD=1 go test -p 1 ./internal/boot ./internal/agent ./internal/control ./internal/capability -run 'TestBuildDiscoversSkills|TestBuildTokenEconomyPlanModeCanConnectAllowedMCPSource|TestBuildLazyDoesNotConnectAtBoot|TestBuildFullModePreservesToolSchemas|TestStripTransientUserBlocks|TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP|TestRunInjectsCapabilityRouteForRelevantSkill|TestRoute' -count=1`
- `git diff --check`
- `go test ./...`
