### PR TITLE
Strip active-goal from user previews / 从用户预览中剥离 active-goal

### DIFF
--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -88,6 +88,25 @@ func TestHistoryMessagesDoNotReplayMemoryCompilerContract(t *testing.T) {
 	assertNoHistoryMemoryContract(t, got[0].Content)
 }
 
+func TestHistoryMessagesStripActiveGoalFromVisibleUserContent(t *testing.T) {
+	raw := "<active-goal>\nship the approval redesign\n</active-goal>\n\ncontinue implementation"
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: raw},
+		{Role: provider.RoleAssistant, Content: "done"},
+	}
+
+	got := historyMessages(msgs, control.StripComposePrefixes)
+	if len(got) != 2 {
+		t.Fatalf("history length = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Content != "continue implementation" {
+		t.Fatalf("visible user content = %q, want active-goal stripped", got[0].Content)
+	}
+	if strings.Contains(got[0].Content, "<active-goal>") || strings.Contains(got[0].Content, "ship the approval redesign") {
+		t.Fatalf("active-goal leaked into visible history content: %+v", got[0])
+	}
+}
+
 func TestHistoryMessagesCarryCheckpointTurnsAcrossHiddenSyntheticUsers(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|hook-context)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|hook-context)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context)>\s*\n?`)
 
 const memoryCompilerExecutionOpen = "<memory-compiler-execution>"
 

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -68,6 +68,18 @@ func TestStripTransientUserBlocksUnwrapsMemoryCompilerExecution(t *testing.T) {
 			in:   "<hook-context event=\"SessionStart\">\nLoad conventions.\n</hook-context>\n\nship it",
 			want: "ship it",
 		},
+		{
+			name: "active goal prefix is stripped",
+			in:   "<active-goal>\nFix all bugs\n</active-goal>\n\nfix the auth bug",
+			want: "fix the auth bug",
+		},
+		{
+			name: "active goal after other transient prefixes is stripped",
+			in: "<reasoning-language>\nuse Chinese\n</reasoning-language>\n\n" +
+				"<memory-update>\n- note\n</memory-update>\n\n" +
+				"<active-goal>\nDo X\n</active-goal>\n\nhelp me",
+			want: "help me",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Strip `<active-goal>` transient blocks from persisted user-message preview/display text.
- Keep the existing Memory v5 contract unwrapping and other transient block stripping intact.
- Add regression coverage for standalone and stacked `active-goal` prefixes, plus the Desktop history-visible user content path.

Fixes #4464

## Consolidation

- Adapts the useful fix from #4513 by @myipanta onto the current `main-v2` preview code, which now also handles response-language, hook-context, and Memory v5 contract unwrapping.

## Cache impact

Cache-impact: none — this only changes user-facing preview/display cleanup for persisted user messages. It does not change provider-visible prompt construction, system prompts, tool schemas, provider serialization, compaction, or reasoning upload behavior.

## Verification

- `go test ./internal/agent -run 'TestStripTransientUserBlocks|TestUserPreviewText|TestSessionPreviewFromMessages' -count=1`
- `go test ./internal/control -run 'TestStripComposePrefixes|TestComposeIncludesActiveGoal' -count=1`
- `cd desktop && go test . -run 'TestHistoryMessagesStripActiveGoalFromVisibleUserContent|TestHistoryMessagesDoNotReplayMemoryCompilerContract' -count=1`
- `cd desktop && go test . -run 'TestHistoryMessages' -count=1`
- `go test ./internal/agent ./internal/control -count=1`
- `git diff --check`