### PR TITLE
Fix workspace routing for subagents and bot sessions / 修复子代理与 Bot 会话工作区路由

### DIFF
--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -243,6 +243,27 @@ func TestEnsureBlankTabStartsProjectRuntimeWithCurrentWorkspacePrompt(t *testing
 	}
 }
 
+func TestBlankTabSessionPathRejectsOtherProjectWorkspace(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectA := robustTempDir(t)
+	projectB := robustTempDir(t)
+	pathA, err := createEmptySessionFile(desktopSessionDir(projectA), "test-model")
+	if err != nil {
+		t.Fatalf("create project A empty session: %v", err)
+	}
+	tab := &WorkspaceTab{
+		ID:            "blank-project-b",
+		Scope:         "project",
+		WorkspaceRoot: projectB,
+		SessionPath:   pathA,
+	}
+
+	if blankTabSessionPathHasNoContent(tab) {
+		t.Fatalf("blank tab treated session %q from project A as reusable for project B %q", pathA, projectB)
+	}
+}
+
 func TestForkKeepsProjectWorkspacePrompt(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1888,6 +1888,34 @@ func TestEnsureTabControllerWorkspaceRebuildsStaleWorkspace(t *testing.T) {
 	assertTabRebuiltToPinnedWorkspace(t, f)
 }
 
+func TestEnsureTabControllerWorkspaceWarnsWhenPinnedSessionSwitchesWorkspace(t *testing.T) {
+	f := newStaleWorkspaceBindingFixture(t, "warn_workspace_switch")
+	events := make(chan event.Event, 8)
+	f.tab.sink.SetBotSink(event.FuncSink(func(e event.Event) {
+		events <- e
+	}))
+
+	if err := f.app.ensureTabControllerWorkspace(f.tab); err != nil {
+		t.Fatalf("ensureTabControllerWorkspace: %v", err)
+	}
+	assertTabRebuiltToPinnedWorkspace(t, f)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Kind == event.Notice &&
+				e.Level == event.LevelWarn &&
+				strings.Contains(e.Text, f.projectA) &&
+				strings.Contains(e.Text, "switched tab") {
+				return
+			}
+		case <-deadline:
+			t.Fatal("did not receive workspace switch warning notice")
+		}
+	}
+}
+
 func TestSteerForTabReconcilesStaleWorkspaceBeforeIdleFallback(t *testing.T) {
 	f := newStaleWorkspaceBindingFixture(t, "steer_idle_fallback")
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2562,9 +2562,12 @@ func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding
 		a.mu.Unlock()
 		return
 	}
+	oldScope := tab.Scope
+	oldWorkspaceRoot := tab.WorkspaceRoot
 	changed := tab.Scope != scope ||
 		tab.WorkspaceRoot != workspaceRoot ||
 		canonicalTabSessionPath(tab.SessionPath) != canonicalTabSessionPath(binding.path)
+	workspaceChanged := tab.Scope != scope || tab.WorkspaceRoot != workspaceRoot
 	tab.Scope = scope
 	tab.WorkspaceRoot = workspaceRoot
 	tab.SessionPath = canonicalTabSessionPath(binding.path)
@@ -2579,7 +2582,28 @@ func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding
 	if changed && current == tab {
 		a.saveTabsLocked()
 	}
+	sink := tab.sink
 	a.mu.Unlock()
+	if workspaceChanged && sink != nil {
+		sink.Emit(event.Event{
+			Kind:  event.Notice,
+			Level: event.LevelWarn,
+			Text:  sessionBindingWorkspaceNotice(oldScope, oldWorkspaceRoot, scope, workspaceRoot),
+		})
+	}
+}
+
+func sessionBindingWorkspaceNotice(oldScope, oldWorkspaceRoot, scope, workspaceRoot string) string {
+	return "Session belongs to " + describeSessionBindingWorkspace(scope, workspaceRoot) +
+		"; switched tab from " + describeSessionBindingWorkspace(oldScope, oldWorkspaceRoot) +
+		" to match the saved session."
+}
+
+func describeSessionBindingWorkspace(scope, workspaceRoot string) string {
+	if strings.TrimSpace(scope) == "project" && strings.TrimSpace(workspaceRoot) != "" {
+		return fmt.Sprintf("project workspace %q", strings.TrimSpace(workspaceRoot))
+	}
+	return "global workspace"
 }
 
 func (a *App) resolveSessionBinding(sessionPath string) (sessionBinding, bool) {

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -183,7 +183,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			}
 
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt), Options{
 				MaxSteps:            max,
 				Temperature:         p.taskTool.temperature,
 				Pricing:             pricing,

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -100,6 +101,25 @@ func TestParallelTasksForegroundCompletesAndClosesWorkers(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("parallel_tasks foreground execution did not return; workers likely waited on spawnCh forever")
+	}
+}
+
+func TestParallelTasksInjectsWorkspaceContextIntoChildren(t *testing.T) {
+	workspace := t.TempDir()
+	task := NewTaskTool(promptRoutingProvider{}, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), workspace, "base-model", "base-effort")
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	out, err := parallel.Execute(ctx, json.RawMessage(`{"tasks":[{"prompt":"inspect one"},{"prompt":"inspect two"}]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Current workspace: "+strconv.Quote(workspace)) ||
+		!strings.Contains(out, `prefer "." or relative paths`) ||
+		!strings.Contains(out, "inspect one ok") ||
+		!strings.Contains(out, "inspect two ok") {
+		t.Fatalf("parallel output = %q, want child workspace context and prompt", out)
 	}
 }
 

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"reasonix/internal/event"
@@ -747,6 +748,7 @@ func (t *TaskTool) resolveSubSessionRuntime(modelRef, effort string) (provider.P
 }
 
 func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session, childDepth int) (string, error) {
+	prompt = t.withWorkspaceContext(prompt)
 	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
 		MaxSteps:            maxSteps,
 		Temperature:         t.temperature,
@@ -766,6 +768,28 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		SubagentDepth:       childDepth,
 		MaxSubagentDepth:    t.maxDepth(),
 	}, sink)
+}
+
+func (t *TaskTool) withWorkspaceContext(prompt string) string {
+	if t == nil {
+		return prompt
+	}
+	ctx := subagentWorkspaceContext(t.workspaceRoot)
+	if ctx == "" {
+		return prompt
+	}
+	return ctx + "\n\n" + prompt
+}
+
+func subagentWorkspaceContext(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return ""
+	}
+	return `<workspace-context event="SubagentWorkspace">
+Current workspace: ` + strconv.Quote(root) + `
+File tools resolve relative paths against this workspace. For project inspection, prefer "." or relative paths unless the user explicitly named another absolute path.
+</workspace-context>`
 }
 
 func FormatSubagentReference(run *SubagentRun) string {

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -49,6 +50,30 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	}
 	if got := lastUser(sub.lastReq); !strings.Contains(got, `<subagent-context event="SubagentStart">`) || !strings.HasSuffix(got, "find callers of Foo") {
 		t.Errorf("sub-agent user = %q, want SubagentStart context plus prompt", got)
+	}
+}
+
+func TestTaskToolInjectsWorkspaceContextIntoSubagentPrompt(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "answer"},
+		{Type: provider.ChunkDone},
+	}}
+	workspace := t.TempDir()
+	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), workspace, "base-model", "base-effort")
+
+	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"inspect project"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if sys := sub.lastReq.Messages[0]; sys.Role != provider.RoleSystem || sys.Content != "sys" {
+		t.Fatalf("system prompt = %+v, want original prompt", sys)
+	}
+	got := lastUser(sub.lastReq)
+	if !strings.Contains(got, `<workspace-context event="SubagentWorkspace">`) ||
+		!strings.Contains(got, "Current workspace: "+strconv.Quote(workspace)) ||
+		!strings.Contains(got, `prefer "." or relative paths`) ||
+		!strings.HasSuffix(got, "inspect project") {
+		t.Fatalf("sub-agent user = %q, want workspace context plus prompt", got)
 	}
 }
 
@@ -359,6 +384,9 @@ func TestReadOnlyTaskToolRunsEphemerallyWithReadOnlyRegistry(t *testing.T) {
 	if sys := sub.lastReq.Messages[0]; sys.Role != provider.RoleSystem || sys.Content != DefaultReadOnlyTaskSystemPrompt {
 		t.Fatalf("read_only_task system prompt = %+v, want read-only prompt", sys)
 	}
+	if got := lastUser(sub.lastReq); !strings.Contains(got, "Current workspace: ") || !strings.HasSuffix(got, "inspect callers") {
+		t.Fatalf("read_only_task user = %q, want workspace context plus prompt", got)
+	}
 
 	got := map[string]bool{}
 	for _, s := range sub.lastReq.Tools {
@@ -441,7 +469,7 @@ func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	if len(msgs) < 4 {
 		t.Fatalf("continued request messages = %+v, want prior transcript plus new task", msgs)
 	}
-	if !strings.HasSuffix(msgs[1].Content, "first task") || msgs[2].Content != "first answer" || lastUser(sub.requests[1]) != "second task" {
+	if !strings.HasSuffix(msgs[1].Content, "first task") || msgs[2].Content != "first answer" || !strings.HasSuffix(lastUser(sub.requests[1]), "second task") {
 		t.Fatalf("continued request messages = %+v, want first task/answer then second task", msgs)
 	}
 }
@@ -611,7 +639,7 @@ func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.
 		t.Fatalf("LoadSession: %v", err)
 	}
 	msgs := loaded.Snapshot()
-	if len(msgs) != 4 || !strings.HasSuffix(msgs[1].Content, "first task") || msgs[2].Content != "first answer" || msgs[3].Content != "second task" {
+	if len(msgs) != 4 || !strings.HasSuffix(msgs[1].Content, "first task") || msgs[2].Content != "first answer" || !strings.HasSuffix(msgs[3].Content, "second task") {
 		t.Fatalf("failed continuation transcript = %+v, want first task/answer plus second task", msgs)
 	}
 	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"third task","continue_from":"`+ref+`"}`)); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -48,6 +48,18 @@ type ChannelConfig struct {
 	Model            string
 	ToolApprovalMode string
 	WorkspaceRoot    string
+	SessionMappings  []SessionMapping
+}
+
+// SessionMapping is the runtime subset of a saved bot connection mapping used
+// to route a remote chat/user/thread back to its intended workspace.
+type SessionMapping struct {
+	RemoteID      string
+	ChatType      string
+	UserID        string
+	ThreadID      string
+	Scope         string
+	WorkspaceRoot string
 }
 
 // AdapterBinding attaches an adapter instance to one saved bot connection.
@@ -99,6 +111,9 @@ type sessionState struct {
 	sink             *sessionEventSink
 	platform         Platform
 	connectionID     string
+	model            string
+	workspaceRoot    string
+	toolApprovalMode string
 	cancel           context.CancelFunc
 	pendingAsks      map[string][]event.AskQuestion
 	pendingApprovals map[string]event.Approval
@@ -106,6 +121,12 @@ type sessionState struct {
 	lastAskID        string
 	createdAt        time.Time
 	lastActive       time.Time
+}
+
+type sessionRuntimeProfile struct {
+	model            string
+	workspaceRoot    string
+	toolApprovalMode string
 }
 
 type sessionEventSink struct {
@@ -857,32 +878,37 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 }
 
 func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg InboundMessage) *sessionState {
+	profile := gw.sessionProfileForMessage(msg)
+	var stale *sessionState
 	gw.mu.Lock()
 	if state, ok := gw.controllers[key]; ok {
-		if state.connectionID == "" {
-			state.connectionID = strings.TrimSpace(msg.ConnectionID)
+		if !sessionStateMatchesRuntime(state, profile) {
+			delete(gw.controllers, key)
+			stale = state
+			gw.mu.Unlock()
+			closeBotSessionState(stale)
+			gw.logger.Warn("bot session runtime changed; rebuilding", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "old_workspace_set", strings.TrimSpace(stale.workspaceRoot) != "", "new_workspace_set", profile.workspaceRoot != "", "old_model", stale.model, "new_model", profile.model)
+		} else {
+			updateSessionStateRuntime(state, msg, profile)
+			gw.mu.Unlock()
+			safeBotSetToolApprovalMode(state.ctrl, profile.toolApprovalMode)
+			gw.logger.Info("bot session reused", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
+			return state
 		}
-		if state.platform == "" {
-			state.platform = msg.Platform
-		}
-		state.lastActive = time.Now()
+	} else {
 		gw.mu.Unlock()
-		gw.logger.Info("bot session reused", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
-		return state
 	}
-	gw.mu.Unlock()
 
 	// 创建新 Controller
 	sessionSink := &sessionEventSink{}
-	model, workspaceRoot, toolApprovalMode := gw.sessionOptionsForMessage(msg)
-	gw.logger.Info("bot session creating", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "model", model, "workspace_set", strings.TrimSpace(workspaceRoot) != "", "tool_approval_mode", normalizeBotToolApprovalMode(toolApprovalMode))
+	gw.logger.Info("bot session creating", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "model", profile.model, "workspace_set", profile.workspaceRoot != "", "tool_approval_mode", profile.toolApprovalMode)
 	ctrl, err := boot.Build(ctx, boot.Options{
-		Model:           model,
+		Model:           profile.model,
 		MaxSteps:        gw.cfg.MaxSteps,
 		RequireKey:      true,
 		Sink:            sessionSink,
-		WorkspaceRoot:   workspaceRoot,
-		SessionDir:      botSessionDir(workspaceRoot),
+		WorkspaceRoot:   profile.workspaceRoot,
+		SessionDir:      botSessionDir(profile.workspaceRoot),
 		ApprovalTimeout: gw.approvalTimeout(),
 	})
 	if err != nil {
@@ -890,36 +916,124 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		return nil
 	}
 	ctrl.EnableInteractiveApproval()
-	ctrl.SetToolApprovalMode(toolApprovalMode)
+	ctrl.SetToolApprovalMode(profile.toolApprovalMode)
 	ctrl.EnsureSessionPath()
 
+	var replace *sessionState
 	gw.mu.Lock()
 	// Re-check under the lock: while we were off-lock in boot.Build, a second
 	// message for the same key may have built and registered its own session.
-	// The first writer wins; close the controller we just built (releasing its
-	// jobs/plugin host) and reuse the existing one, so a near-simultaneous pair
-	// of opening messages can't leak a controller.
+	// Reuse it only when it still targets this message's runtime profile.
 	if existing, ok := gw.controllers[key]; ok {
-		existing.lastActive = time.Now()
-		gw.mu.Unlock()
-		ctrl.Close()
-		gw.logger.Info("bot session built concurrently; discarding duplicate", "platform", msg.Platform, "chat", hashID(msg.ChatID), "session", key[:8])
-		return existing
+		if sessionStateMatchesRuntime(existing, profile) {
+			updateSessionStateRuntime(existing, msg, profile)
+			gw.mu.Unlock()
+			ctrl.Close()
+			safeBotSetToolApprovalMode(existing.ctrl, profile.toolApprovalMode)
+			gw.logger.Info("bot session built concurrently; discarding duplicate", "platform", msg.Platform, "chat", hashID(msg.ChatID), "session", key[:8])
+			return existing
+		}
+		delete(gw.controllers, key)
+		replace = existing
 	}
 	state := &sessionState{
-		ctrl:         ctrl,
-		sink:         sessionSink,
-		platform:     msg.Platform,
-		connectionID: strings.TrimSpace(msg.ConnectionID),
-		pendingAsks:  make(map[string][]event.AskQuestion),
-		createdAt:    time.Now(),
-		lastActive:   time.Now(),
+		ctrl:             ctrl,
+		sink:             sessionSink,
+		platform:         msg.Platform,
+		connectionID:     strings.TrimSpace(msg.ConnectionID),
+		model:            profile.model,
+		workspaceRoot:    profile.workspaceRoot,
+		toolApprovalMode: profile.toolApprovalMode,
+		pendingAsks:      make(map[string][]event.AskQuestion),
+		createdAt:        time.Now(),
+		lastActive:       time.Now(),
 	}
 	gw.controllers[key] = state
 	gw.mu.Unlock()
+	closeBotSessionState(replace)
 
 	gw.logger.Info("bot session created", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
 	return state
+}
+
+func updateSessionStateRuntime(state *sessionState, msg InboundMessage, profile sessionRuntimeProfile) {
+	if state == nil {
+		return
+	}
+	if state.connectionID == "" {
+		state.connectionID = strings.TrimSpace(msg.ConnectionID)
+	}
+	if state.platform == "" {
+		state.platform = msg.Platform
+	}
+	state.model = profile.model
+	state.workspaceRoot = profile.workspaceRoot
+	state.toolApprovalMode = profile.toolApprovalMode
+	state.lastActive = time.Now()
+}
+
+func closeBotSessionState(state *sessionState) {
+	if state == nil {
+		return
+	}
+	if state.cancel != nil {
+		state.cancel()
+	}
+	if state.ctrl != nil {
+		state.ctrl.Close()
+	}
+}
+
+func (gw *BotGateway) sessionProfileForMessage(msg InboundMessage) sessionRuntimeProfile {
+	model, workspaceRoot, toolApprovalMode := gw.sessionOptionsForMessage(msg)
+	return sessionRuntimeProfile{
+		model:            strings.TrimSpace(model),
+		workspaceRoot:    strings.TrimSpace(workspaceRoot),
+		toolApprovalMode: normalizeBotToolApprovalMode(toolApprovalMode),
+	}
+}
+
+func sessionStateMatchesRuntime(state *sessionState, profile sessionRuntimeProfile) bool {
+	if state == nil || state.ctrl == nil {
+		return false
+	}
+	if stateModel := strings.TrimSpace(state.model); stateModel != "" && profile.model != "" && stateModel != profile.model {
+		return false
+	}
+	stateRoot := strings.TrimSpace(state.workspaceRoot)
+	wantRoot := strings.TrimSpace(profile.workspaceRoot)
+	if stateRoot == "" {
+		root, ok := safeBotControllerWorkspaceRoot(state.ctrl)
+		if ok {
+			stateRoot = strings.TrimSpace(root)
+		} else if wantRoot != "" {
+			return false
+		}
+	}
+	return stateRoot == wantRoot
+}
+
+func safeBotControllerWorkspaceRoot(ctrl botController) (root string, ok bool) {
+	if ctrl == nil {
+		return "", false
+	}
+	defer func() {
+		if recover() != nil {
+			root = ""
+			ok = false
+		}
+	}()
+	return ctrl.WorkspaceRoot(), true
+}
+
+func safeBotSetToolApprovalMode(ctrl botController, mode string) {
+	if ctrl == nil {
+		return
+	}
+	defer func() {
+		_ = recover()
+	}()
+	ctrl.SetToolApprovalMode(mode)
 }
 
 // defaultBotApprovalTimeout caps how long a bot session waits for a remote
@@ -976,37 +1090,91 @@ func (gw *BotGateway) sessionOptionsForMessage(msg InboundMessage) (model string
 	model = gw.cfg.Model
 	workspaceRoot = gw.cfg.WorkspaceRoot
 	toolApprovalMode = normalizeBotToolApprovalMode(gw.cfg.ToolApprovalMode)
+	var mappings []SessionMapping
 	if gw.cfg.ConnectionChannels != nil && msg.ConnectionID != "" {
 		if channel, ok := gw.cfg.ConnectionChannels[msg.ConnectionID]; ok {
-			if value := strings.TrimSpace(channel.Model); value != "" {
-				model = value
-			}
-			if value := strings.TrimSpace(channel.WorkspaceRoot); value != "" {
-				workspaceRoot = value
-			}
-			if value := normalizeOptionalBotToolApprovalMode(channel.ToolApprovalMode); value != "" {
-				toolApprovalMode = value
+			applyBotChannelOptions(channel, &model, &workspaceRoot, &toolApprovalMode)
+			mappings = channel.SessionMappings
+			if mapping, ok := matchingSessionMapping(mappings, msg); ok {
+				workspaceRoot = workspaceRootForSessionMapping(mapping, workspaceRoot)
 			}
 			return model, workspaceRoot, toolApprovalMode
 		}
 	}
-	if gw.cfg.Channels == nil {
-		return model, workspaceRoot, toolApprovalMode
+	if gw.cfg.Channels != nil {
+		if channel, ok := gw.cfg.Channels[msg.Platform]; ok {
+			applyBotChannelOptions(channel, &model, &workspaceRoot, &toolApprovalMode)
+			mappings = channel.SessionMappings
+		}
 	}
-	channel, ok := gw.cfg.Channels[msg.Platform]
-	if !ok {
-		return model, workspaceRoot, toolApprovalMode
-	}
-	if value := strings.TrimSpace(channel.Model); value != "" {
-		model = value
-	}
-	if value := strings.TrimSpace(channel.WorkspaceRoot); value != "" {
-		workspaceRoot = value
-	}
-	if value := normalizeOptionalBotToolApprovalMode(channel.ToolApprovalMode); value != "" {
-		toolApprovalMode = value
+	if mapping, ok := matchingSessionMapping(mappings, msg); ok {
+		workspaceRoot = workspaceRootForSessionMapping(mapping, workspaceRoot)
 	}
 	return model, workspaceRoot, toolApprovalMode
+}
+
+func applyBotChannelOptions(channel ChannelConfig, model *string, workspaceRoot *string, toolApprovalMode *string) {
+	if value := strings.TrimSpace(channel.Model); value != "" {
+		*model = value
+	}
+	if value := strings.TrimSpace(channel.WorkspaceRoot); value != "" {
+		*workspaceRoot = value
+	}
+	if value := normalizeOptionalBotToolApprovalMode(channel.ToolApprovalMode); value != "" {
+		*toolApprovalMode = value
+	}
+}
+
+func matchingSessionMapping(mappings []SessionMapping, msg InboundMessage) (SessionMapping, bool) {
+	for i := range mappings {
+		if sessionMappingMatches(mappings[i], msg) {
+			return mappings[i], true
+		}
+	}
+	return SessionMapping{}, false
+}
+
+func sessionMappingMatches(mapping SessionMapping, msg InboundMessage) bool {
+	if strings.TrimSpace(mapping.RemoteID) != strings.TrimSpace(msg.ChatID) {
+		return false
+	}
+	chatType, userID, threadID := sessionMappingIdentity(msg)
+	mappingChatType := strings.TrimSpace(mapping.ChatType)
+	if mappingChatType == "" {
+		return chatType == ""
+	}
+	if mappingChatType != chatType {
+		return false
+	}
+	if strings.TrimSpace(mapping.UserID) != userID {
+		return false
+	}
+	return strings.TrimSpace(mapping.ThreadID) == threadID
+}
+
+func sessionMappingIdentity(msg InboundMessage) (chatType string, userID string, threadID string) {
+	switch msg.ChatType {
+	case ChatGroup, ChatGuild:
+		chatType = string(msg.ChatType)
+		userID = strings.TrimSpace(msg.UserID)
+	case ChatThread:
+		chatType = string(msg.ChatType)
+		threadID = strings.TrimSpace(msg.ThreadID)
+		if threadID == "" {
+			threadID = strings.TrimSpace(msg.ChatID)
+		}
+	}
+	return chatType, userID, threadID
+}
+
+func workspaceRootForSessionMapping(mapping SessionMapping, fallback string) string {
+	if root := strings.TrimSpace(mapping.WorkspaceRoot); root != "" {
+		return root
+	}
+	if strings.EqualFold(strings.TrimSpace(mapping.Scope), "global") {
+		return ""
+	}
+	return fallback
 }
 
 func normalizeBotToolApprovalMode(mode string) string {

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -815,6 +815,84 @@ func TestGatewaySessionOptionsPreferConnectionOverride(t *testing.T) {
 	}
 }
 
+func TestGatewaySessionOptionsPreferConnectionSessionMappingWorkspace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{
+		Model:         "global-model",
+		WorkspaceRoot: "/global",
+		ConnectionChannels: map[string]ChannelConfig{
+			"weixin-main": {
+				WorkspaceRoot: "/connection",
+				SessionMappings: []SessionMapping{
+					{RemoteID: "group-1", ChatType: string(ChatGroup), UserID: "other", Scope: "project", WorkspaceRoot: "/other"},
+					{RemoteID: "group-1", ChatType: string(ChatGroup), UserID: "user-1", Scope: "project", WorkspaceRoot: "/mapped"},
+				},
+			},
+		},
+	}, nil, logger)
+
+	model, root, mode := gw.sessionOptionsForMessage(InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-main",
+		ChatType:     ChatGroup,
+		ChatID:       "group-1",
+		UserID:       "user-1",
+	})
+	if model != "global-model" || root != "/mapped" || mode != "ask" {
+		t.Fatalf("mapped options = %q,%q,%q; want global model, mapped workspace, ask", model, root, mode)
+	}
+
+	_, root, _ = gw.sessionOptionsForMessage(InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-main",
+		ChatType:     ChatGroup,
+		ChatID:       "group-1",
+		UserID:       "new-user",
+	})
+	if root != "/connection" {
+		t.Fatalf("unmapped group user workspace = %q, want connection default", root)
+	}
+}
+
+func TestGatewaySessionOptionsAllowSessionMappingGlobalWorkspace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{
+		WorkspaceRoot: "/global-default",
+		ConnectionChannels: map[string]ChannelConfig{
+			"weixin-main": {
+				WorkspaceRoot:   "/connection",
+				SessionMappings: []SessionMapping{{RemoteID: "dm-1", Scope: "global"}},
+			},
+		},
+	}, nil, logger)
+
+	_, root, _ := gw.sessionOptionsForMessage(InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-main",
+		ChatType:     ChatDM,
+		ChatID:       "dm-1",
+	})
+	if root != "" {
+		t.Fatalf("global mapping workspace = %q, want empty global workspace", root)
+	}
+}
+
+func TestSessionStateMatchesRuntimeRejectsWorkspaceOrModelMismatch(t *testing.T) {
+	ctrl := control.New(control.Options{WorkspaceRoot: "/old"})
+	defer ctrl.Close()
+	state := &sessionState{ctrl: ctrl, model: "model-a"}
+
+	if !sessionStateMatchesRuntime(state, sessionRuntimeProfile{model: "model-a", workspaceRoot: "/old"}) {
+		t.Fatal("session should match the controller workspace and model")
+	}
+	if sessionStateMatchesRuntime(state, sessionRuntimeProfile{model: "model-a", workspaceRoot: "/new"}) {
+		t.Fatal("session matched a different workspace root")
+	}
+	if sessionStateMatchesRuntime(state, sessionRuntimeProfile{model: "model-b", workspaceRoot: "/old"}) {
+		t.Fatal("session matched a different model")
+	}
+}
+
 func TestBotSessionDirUsesProjectWorkspaceRoot(t *testing.T) {
 	root := t.TempDir()
 	got := botSessionDir(root)

--- a/internal/botruntime/runtime.go
+++ b/internal/botruntime/runtime.go
@@ -161,16 +161,35 @@ func ConnectionChannelConfigs(connections []config.BotConnectionConfig, includeM
 		}
 		if includeWorkspaceRoot {
 			channel.WorkspaceRoot = strings.TrimSpace(conn.WorkspaceRoot)
+			channel.SessionMappings = botSessionMappings(conn.SessionMappings)
 		}
 		if value := normalizeToolApprovalMode(conn.ToolApprovalMode); value != "" {
 			channel.ToolApprovalMode = value
 		}
-		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" {
+		if channel.Model != "" || channel.WorkspaceRoot != "" || channel.ToolApprovalMode != "" || len(channel.SessionMappings) > 0 {
 			out[id] = channel
 		}
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+func botSessionMappings(mappings []config.BotConnectionSessionMapping) []bot.SessionMapping {
+	if len(mappings) == 0 {
+		return nil
+	}
+	out := make([]bot.SessionMapping, 0, len(mappings))
+	for _, mapping := range mappings {
+		out = append(out, bot.SessionMapping{
+			RemoteID:      strings.TrimSpace(mapping.RemoteID),
+			ChatType:      strings.TrimSpace(mapping.ChatType),
+			UserID:        strings.TrimSpace(mapping.UserID),
+			ThreadID:      strings.TrimSpace(mapping.ThreadID),
+			Scope:         strings.TrimSpace(mapping.Scope),
+			WorkspaceRoot: strings.TrimSpace(mapping.WorkspaceRoot),
+		})
 	}
 	return out
 }

--- a/internal/botruntime/runtime_test.go
+++ b/internal/botruntime/runtime_test.go
@@ -353,6 +353,44 @@ func TestConnectionChannelConfigsPreserveToolApprovalMode(t *testing.T) {
 	}
 }
 
+func TestConnectionChannelConfigsCarrySessionMappingsOnlyPerConnection(t *testing.T) {
+	connections := []config.BotConnectionConfig{
+		{
+			ID:            "weixin-weixin",
+			Provider:      "weixin",
+			Domain:        "weixin",
+			Enabled:       true,
+			WorkspaceRoot: "/connection",
+			SessionMappings: []config.BotConnectionSessionMapping{{
+				RemoteID:      "wx-group-1",
+				ChatType:      string(bot.ChatGroup),
+				UserID:        "wx-user-1",
+				Scope:         "project",
+				WorkspaceRoot: "/mapped",
+			}},
+		},
+	}
+
+	byConnection := ConnectionChannelConfigs(connections, true, true)
+	mappings := byConnection["weixin-weixin"].SessionMappings
+	if len(mappings) != 1 {
+		t.Fatalf("connection mappings = %+v, want one mapping", mappings)
+	}
+	if got := mappings[0]; got.RemoteID != "wx-group-1" || got.ChatType != string(bot.ChatGroup) || got.UserID != "wx-user-1" || got.WorkspaceRoot != "/mapped" {
+		t.Fatalf("connection mapping = %+v, want copied routing fields", got)
+	}
+
+	byPlatform := ChannelConfigs(connections, true, true)
+	if got := byPlatform[bot.PlatformWeixin].SessionMappings; len(got) != 0 {
+		t.Fatalf("platform mappings = %+v, want none to avoid cross-connection routing", got)
+	}
+
+	noWorkspace := ConnectionChannelConfigs(connections, true, false)
+	if got := noWorkspace["weixin-weixin"].SessionMappings; len(got) != 0 {
+		t.Fatalf("connection mappings with includeWorkspaceRoot=false = %+v, want none", got)
+	}
+}
+
 func isolateUserConfig(t *testing.T) {
 	t.Helper()
 	home := t.TempDir()


### PR DESCRIPTION
## Summary
- Inject the active workspace into task, read_only_task, and parallel_tasks child prompts so subagents prefer relative paths in the intended workspace.
- Route bot sessions through connection-level session_mappings and rebuild stale controllers when the desired runtime profile changes.
- Surface a desktop warning when an existing session binding switches a tab to the saved session workspace, with regression coverage for cross-project blank-tab reuse.

## Cache impact
Cache-impact: low - Workspace context is injected into child user turns only; stable system prompts and tool schemas are unchanged.
Cache-guard: ./scripts/cache-guard.sh
System-prompt-review: Reviewed; no stable system prompt text is changed, and the task.go change only prefixes subagent user prompts at execution time.

## Verification
- `go test -p 1 ./...`
- `(cd desktop && go test ./...)`
- `go test ./internal/bot ./internal/botruntime`
- `go test ./internal/agent`
- `./scripts/cache-guard.sh`
- `git diff --check`
