### PR TITLE
Refresh file reference caches / 刷新文件引用缓存

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1030,6 +1030,9 @@ export default function App() {
   const rightDockMode = useLayoutStore((s) => s.rightDockMode);
   const setRightDockMode = useLayoutStore((s) => s.setRightDockMode);
   const [dockRefreshKey, setDockRefreshKey] = useState(0);
+  const [fileRefRefreshKey, setFileRefRefreshKey] = useState(0);
+  const refreshComposerFileRefs = useCallback(() => setFileRefRefreshKey((value) => value + 1), []);
+  const composerFileRefRefreshKey = `${dockRefreshKey}:${fileRefRefreshKey}`;
   const [projectRevision, setProjectRevision] = useState(0);
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);
   const [composerInsertRequest, setComposerInsertRequest] = useState<ComposerInsertRequest | null>(null);
@@ -3583,6 +3586,7 @@ export default function App() {
               retry={state.retry}
               transientDismissSignal={transientOverlayDismissSignal}
               sessionKey={composerSessionKey}
+              fileRefRefreshKey={composerFileRefRefreshKey}
               guidanceConsumedKey={latestGuidanceConsumed?.key}
               guidanceConsumedText={latestGuidanceConsumed?.text}
               guidanceQueuePreviewItems={guidanceQueueMockItems}
@@ -3701,6 +3705,7 @@ export default function App() {
                   onPreviewModeChange={handleWorkspacePreviewModeChange}
                   onAddToChat={addWorkspaceTextToComposer}
                   onRequestPanelWidth={ensureWorkspacePanelWidth}
+                  onFileTreeRefresh={refreshComposerFileRefs}
                   refreshKey={dockRefreshKey}
                   initialViewMode={rightDockMode === "changed" ? "changed" : "files"}
                   showViewTabs={false}

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -8,7 +8,7 @@ import { Composer, composerPickFileEntry } from "../components/Composer";
 import { LocaleProvider } from "../lib/i18n";
 import { ToastProvider } from "../lib/toast";
 import type { AppBindings } from "../lib/bridge";
-import type { CollaborationMode, ToolApprovalMode, TokenMode } from "../lib/types";
+import type { CollaborationMode, DirEntry, ToolApprovalMode, TokenMode } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -198,6 +198,16 @@ async function waitFor(label: string, predicate: () => boolean) {
     if (predicate()) return;
   }
   throw new Error(`timed out waiting for ${label}`);
+}
+
+type RenderedComposer = Awaited<ReturnType<typeof renderComposer>>;
+
+function fileEntry(name: string): DirEntry {
+  return { name, isDir: false };
+}
+
+async function replaceComposerDraft(rerender: RenderedComposer["rerender"], id: number, text: string) {
+  await rerender({ insertRequest: { id, text, mode: "replace" } });
 }
 
 console.log("\ncomposer goal toggle");
@@ -732,6 +742,157 @@ console.log("\ncomposer goal toggle");
   });
 
   eq(calls.send.join(","), "steer while activating", "queued guidance can be guided while controllerReady is false");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  let listDirCalls = 0;
+  mockApp({
+    ListDir: async () => {
+      listDirCalls += 1;
+      return listDirCalls === 1 ? [fileEntry("cached-dir.txt")] : [fileEntry("fresh-dir.txt")];
+    },
+    SearchFileRefs: async () => [],
+  });
+  const { root, rerender } = await renderComposer();
+
+  await replaceComposerDraft(rerender, 101, "@");
+  await waitFor("initial @ directory load", () => listDirCalls === 1);
+
+  await replaceComposerDraft(rerender, 102, "");
+  await replaceComposerDraft(rerender, 103, "@");
+  await waitFor("@ directory revalidation call", () => listDirCalls === 2);
+
+  eq(listDirCalls, 2, "@ directory cache hit still revalidates ListDir");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  let listDirCalls = 0;
+  mockApp({
+    ListDir: async () => {
+      listDirCalls += 1;
+      return listDirCalls === 1 ? [fileEntry("manual-refresh-stale.txt")] : [fileEntry("manual-refresh-fresh.txt")];
+    },
+    SearchFileRefs: async () => [],
+  });
+  const { root, rerender } = await renderComposer({ fileRefRefreshKey: "0" });
+
+  await replaceComposerDraft(rerender, 201, "@");
+  await waitFor("initial @ directory load before refresh key", () => listDirCalls === 1);
+
+  await rerender({ fileRefRefreshKey: "1" });
+  await waitFor("@ directory reload after refresh key", () => listDirCalls === 2);
+
+  eq(listDirCalls, 2, "fileRefRefreshKey refreshes @ directory cache while the menu is open");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  const realDateNow = Date.now;
+  let now = 1000;
+  let searchCalls = 0;
+  Date.now = () => now;
+  mockApp({
+    ListDir: async () => [],
+    SearchFileRefs: async () => {
+      searchCalls += 1;
+      return searchCalls === 1 ? [fileEntry("alpha-old.ts")] : [fileEntry("alpha-new.ts")];
+    },
+  });
+  const { root, rerender } = await renderComposer();
+
+  try {
+    await replaceComposerDraft(rerender, 301, "@alpha");
+    await waitFor("initial @ search request", () => searchCalls === 1);
+    eq(searchCalls, 1, "@ search fetches the first query");
+
+    await replaceComposerDraft(rerender, 302, "");
+    now = 2000;
+    await replaceComposerDraft(rerender, 303, "@alpha");
+    await act(async () => {
+      await flushTimers();
+    });
+    eq(searchCalls, 1, "@ search cache is reused inside the TTL");
+
+    await replaceComposerDraft(rerender, 304, "");
+    now = 7001;
+    await replaceComposerDraft(rerender, 305, "@alpha");
+    await waitFor("expired @ search cache refresh", () => searchCalls === 2);
+    eq(searchCalls, 2, "@ search cache revalidates after the TTL");
+  } finally {
+    Date.now = realDateNow;
+  }
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  let staleListDirResolve: ((entries: DirEntry[]) => void) | undefined;
+  let thirdListDirResolve: ((entries: DirEntry[]) => void) | undefined;
+  let listDirCalls = 0;
+  mockApp({
+    ListDir: async () => {
+      listDirCalls += 1;
+      if (listDirCalls === 1) {
+        return new Promise<DirEntry[]>((resolve) => {
+          staleListDirResolve = resolve;
+        });
+      }
+      if (listDirCalls === 2) return [fileEntry("cache-live.txt")];
+      return new Promise<DirEntry[]>((resolve) => {
+        thirdListDirResolve = resolve;
+      });
+    },
+    SearchFileRefs: async () => [],
+  });
+  const { root, rerender } = await renderComposer({ fileRefRefreshKey: "0" });
+
+  const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render");
+
+  await replaceComposerDraft(rerender, 401, "@cache");
+  await waitFor("initial stale @ directory request", () => listDirCalls === 1);
+
+  await rerender({ fileRefRefreshKey: "1" });
+  await waitFor("fresh @ directory request after refresh key", () => listDirCalls === 2);
+  await act(async () => {
+    await flushTimers();
+  });
+
+  staleListDirResolve?.([fileEntry("cache-stale.txt")]);
+  await act(async () => {
+    await flushTimers();
+  });
+
+  await replaceComposerDraft(rerender, 402, "");
+  await replaceComposerDraft(rerender, 403, "@cache");
+  await waitFor("second fresh @ directory request", () => listDirCalls === 3);
+  await act(async () => {
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await flushTimers();
+  });
+  eq(textarea.value, "@cache-live.txt ", "stale @ directory request cannot repopulate cache after refresh");
+  thirdListDirResolve?.([fileEntry("cache-later.txt")]);
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
@@ -7,7 +7,7 @@ import { createRoot } from "react-dom/client";
 import { WorkspacePanel } from "../components/WorkspacePanel";
 import { LocaleProvider } from "../lib/i18n";
 import type { AppBindings } from "../lib/bridge";
-import type { WorkspaceChangesView } from "../lib/types";
+import type { DirEntry, WorkspaceChangesView } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -101,6 +101,47 @@ async function renderWorkspace(changes: WorkspaceChangesView) {
   return { dom, root };
 }
 
+async function renderFilesWorkspace(methods: Partial<AppBindings>, props: Partial<Parameters<typeof WorkspacePanel>[0]> = {}) {
+  const dom = installDom();
+  window.go = {
+    main: {
+      App: {
+        ListDir: async () => [],
+        SearchFileRefs: async () => [],
+        WorkspaceGitHistory: async () => [],
+        WorkspaceChanges: async () => ({ files: [], gitAvailable: true }),
+        ...methods,
+      } as Partial<AppBindings> as AppBindings,
+    },
+  };
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  let currentProps: Parameters<typeof WorkspacePanel>[0] = {
+    open: true,
+    tabId: "tab-a",
+    cwd: "/repo",
+    maximized: false,
+    initialViewMode: "files",
+    onClose: () => {},
+    onToggleMaximized: () => {},
+    ...props,
+  };
+  const rerender = async (nextProps: Partial<Parameters<typeof WorkspacePanel>[0]> = {}) => {
+    currentProps = { ...currentProps, ...nextProps };
+    await act(async () => {
+      root.render(
+        <LocaleProvider>
+          <WorkspacePanel {...currentProps} />
+        </LocaleProvider>,
+      );
+      await flushPromises();
+    });
+  };
+  await rerender();
+  return { dom, root, rerender };
+}
+
 console.log("\nworkspace changes git errors");
 
 {
@@ -145,6 +186,29 @@ console.log("\nworkspace changes git errors");
   await waitFor("git error warning with files", () => document.body.textContent?.includes("app.ts") === true);
   ok(document.body.textContent?.includes("Git status is unavailable for this workspace.") === true, "gitErr renders a warning");
   ok(document.body.textContent?.includes("app.ts") === true, "files still render when gitErr is present");
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const calls: string[] = [];
+  const listDir = async (dir: string): Promise<DirEntry[]> => {
+    calls.push(dir);
+    return [];
+  };
+  const { dom, root, rerender } = await renderFilesWorkspace(
+    { ListDir: listDir },
+    { fileListRequest: { id: 1, paths: ["src/app.ts"] } },
+  );
+
+  await waitFor("initial referenced file dirs", () => calls.filter((dir) => dir === "src/").length === 1);
+  await rerender({ fileListRequest: { id: 2, paths: ["src/app.ts"] } });
+  await waitFor("referenced file dirs revalidated", () => calls.filter((dir) => dir === "src/").length === 2);
+
+  ok(calls.filter((dir) => dir === "src/").length === 2, "workspace file tree revalidates cached directories for repeated file-list requests");
+
   await act(async () => {
     root.unmount();
   });

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -57,6 +57,7 @@ const PROMPT_HISTORY_PREFETCH_REMAINING = 3;
 // it; the real gap is a few ms, so keep it short or a deliberate quick second
 // Enter (submit) gets eaten too.
 const IME_CONFIRM_GRACE_MS = 100;
+const FILE_REF_SEARCH_CACHE_TTL_MS = 5000;
 
 type PastedBlock = {
   label: string;
@@ -67,6 +68,11 @@ type PendingGuidance = {
   id: number;
   text: string;
   submitText: string;
+};
+
+type FileRefSearchCacheEntry = {
+  entries: DirEntry[];
+  cachedAt: number;
 };
 
 type ComposerDraft = {
@@ -444,6 +450,7 @@ export function Composer({
   retry,
   transientDismissSignal,
   sessionKey,
+  fileRefRefreshKey,
   guidanceConsumedKey,
   guidanceConsumedText,
   guidanceQueuePreviewItems,
@@ -486,6 +493,7 @@ export function Composer({
   retry?: { attempt: number; max: number };
   transientDismissSignal?: number;
   sessionKey?: string;
+  fileRefRefreshKey?: number | string;
   guidanceConsumedKey?: string;
   guidanceConsumedText?: string;
   guidanceQueuePreviewItems?: readonly string[];
@@ -743,16 +751,9 @@ export function Composer({
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [searchEntries, setSearchEntries] = useState<DirEntry[]>([]);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
-  const searchCache = useRef<Record<string, DirEntry[]>>({});
+  const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
 
-  // When the workspace/project changes (cwd prop), invalidate all @ mention
-  // state so the picker reloads candidates for the new project. Without this,
-  // dirCache/searchCache retain entries from the old project and the picker
-  // shows stale results (issue #3601).
-  const prevCwdRef = useRef(cwd);
-  useEffect(() => {
-    if (prevCwdRef.current === cwd) return; // skip mount — state already initial
-    prevCwdRef.current = cwd;
+  const clearFileRefState = useCallback(() => {
     dirCache.current = {};
     searchCache.current = {};
     setEntries([]);
@@ -763,29 +764,50 @@ export function Composer({
     setLoadingPastChats(false);
     setActive(0);
     setDismissed(false);
-  }, [cwd]);
+  }, []);
+
+  // When the workspace/project changes (cwd prop), invalidate all @ mention
+  // state so the picker reloads candidates for the new project. Without this,
+  // dirCache/searchCache retain entries from the old project and the picker
+  // shows stale results (issue #3601).
+  const prevCwdRef = useRef(cwd);
+  useEffect(() => {
+    if (prevCwdRef.current === cwd) return; // skip mount — state already initial
+    prevCwdRef.current = cwd;
+    clearFileRefState();
+  }, [clearFileRefState, cwd]);
+
+  const prevFileRefRefreshKeyRef = useRef(fileRefRefreshKey);
+  useEffect(() => {
+    if (prevFileRefRefreshKeyRef.current === fileRefRefreshKey) return;
+    prevFileRefRefreshKeyRef.current = fileRefRefreshKey;
+    clearFileRefState();
+  }, [clearFileRefState, fileRefRefreshKey]);
 
   useEffect(() => {
     if (atRaw === null) return;
     const cached = dirCache.current[atDir];
     if (cached) {
       setEntries(cached);
-      return;
+    } else {
+      setEntries([]);
     }
     let live = true;
     app
       .ListDir(atDir)
       .then((es) => {
         const list = asArray(es);
+        if (!live) return;
         dirCache.current[atDir] = list;
-        if (live) setEntries(list);
+        setEntries(list);
       })
       .catch(() => {});
     return () => {
       live = false;
     };
-    // re-fetch when the menu opens or the directory level changes
-  }, [atRaw === null, atDir, cwd]);
+    // Re-fetch when the menu opens, the directory level changes, or the
+    // workspace tree refreshes; cached data is only a fast first paint.
+  }, [atRaw === null, atDir, cwd, fileRefRefreshKey]);
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
       setSearchEntries([]);
@@ -793,23 +815,25 @@ export function Composer({
     }
     const cached = searchCache.current[atFrag];
     if (cached) {
-      setSearchEntries(cached);
-      return;
+      setSearchEntries(cached.entries);
+      if (Date.now() - cached.cachedAt < FILE_REF_SEARCH_CACHE_TTL_MS) return;
+    } else {
+      setSearchEntries([]);
     }
-    setSearchEntries([]);
     let live = true;
     app
       .SearchFileRefs(atFrag)
       .then((es) => {
-        const list = es ?? [];
-        searchCache.current[atFrag] = list;
-        if (live) setSearchEntries(list);
+        const list = asArray(es);
+        if (!live) return;
+        searchCache.current[atFrag] = { entries: list, cachedAt: Date.now() };
+        setSearchEntries(list);
       })
       .catch(() => {});
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag, cwd]);
+  }, [atRaw === null, atDir, atFrag, cwd, fileRefRefreshKey]);
   const atMatches = useMemo(
     () => {
       if (atRaw === null) return [];

--- a/desktop/frontend/src/components/FileReferenceMenu.tsx
+++ b/desktop/frontend/src/components/FileReferenceMenu.tsx
@@ -6,6 +6,13 @@ import { app } from "../lib/bridge";
 import type { DirEntry } from "../lib/types";
 import { VirtualMenu } from "./VirtualMenu";
 
+const FILE_REF_SEARCH_CACHE_TTL_MS = 5000;
+
+type FileRefSearchCacheEntry = {
+  entries: DirEntry[];
+  cachedAt: number;
+};
+
 export function dirEntrySubmitPath(entry: DirEntry, atDir: string): string {
   return entry.path || atDir + entry.name;
 }
@@ -58,7 +65,7 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
   const [active, setActive] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
-  const searchCache = useRef<Record<string, DirEntry[]>>({});
+  const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
   const prevCwdRef = useRef(cwd);
 
   useEffect(() => {
@@ -82,15 +89,17 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     const cached = dirCache.current[atDir];
     if (cached) {
       setEntries(cached);
-      return;
+    } else {
+      setEntries([]);
     }
     let live = true;
     app
       .ListDir(atDir)
       .then((next) => {
         const list = asArray(next);
+        if (!live) return;
         dirCache.current[atDir] = list;
-        if (live) setEntries(list);
+        setEntries(list);
       })
       .catch(() => {});
     return () => {
@@ -105,17 +114,19 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     }
     const cached = searchCache.current[atFrag];
     if (cached) {
-      setSearchEntries(cached);
-      return;
+      setSearchEntries(cached.entries);
+      if (Date.now() - cached.cachedAt < FILE_REF_SEARCH_CACHE_TTL_MS) return;
+    } else {
+      setSearchEntries([]);
     }
-    setSearchEntries([]);
     let live = true;
     app
       .SearchFileRefs(atFrag)
       .then((next) => {
-        const list = next ?? [];
-        searchCache.current[atFrag] = list;
-        if (live) setSearchEntries(list);
+        const list = asArray(next);
+        if (!live) return;
+        searchCache.current[atFrag] = { entries: list, cachedAt: Date.now() };
+        setSearchEntries(list);
       })
       .catch(() => {});
     return () => {

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -24,6 +24,7 @@ import {
   Search,
   X,
 } from "lucide-react";
+import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import {
@@ -206,6 +207,7 @@ export function WorkspacePanel({
   onPreviewModeChange,
   onAddToChat,
   onRequestPanelWidth,
+  onFileTreeRefresh,
   refreshKey,
   initialViewMode = "files",
   revealPathRequest,
@@ -224,6 +226,7 @@ export function WorkspacePanel({
   onPreviewModeChange?: (active: boolean) => void;
   onAddToChat?: (text: string) => void;
   onRequestPanelWidth?: (width: number) => void;
+  onFileTreeRefresh?: () => void;
   refreshKey?: number;
   initialViewMode?: "files" | "changed";
   revealPathRequest?: WorkspaceRevealRequest | null;
@@ -275,6 +278,8 @@ export function WorkspacePanel({
   const workspaceChangesRequestIdRef = useRef(0);
   const gitHistoryRequestIdRef = useRef(0);
   const commitDetailRequestIdRef = useRef(0);
+  const dirLoadGenerationRef = useRef(0);
+  const dirLoadRequestIdsRef = useRef<Record<string, number>>({});
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
   const pendingTreeRevealPathRef = useRef<string | null>(null);
@@ -284,8 +289,12 @@ export function WorkspacePanel({
   }, [openDirs]);
 
   const loadDir = useCallback(async (dir: string) => {
-    const entries = await app.ListDir(dir).catch(() => []);
-    setEntriesByDir((prev) => ({ ...prev, [dir]: entries ?? [] }));
+    const generation = dirLoadGenerationRef.current;
+    const requestId = (dirLoadRequestIdsRef.current[dir] ?? 0) + 1;
+    dirLoadRequestIdsRef.current[dir] = requestId;
+    const entries = await app.ListDir(dir).catch((): DirEntry[] => []);
+    if (dirLoadGenerationRef.current !== generation || dirLoadRequestIdsRef.current[dir] !== requestId) return;
+    setEntriesByDir((prev) => ({ ...prev, [dir]: asArray(entries) }));
   }, []);
 
   const loadGitHistory = useCallback(async () => {
@@ -399,15 +408,15 @@ export function WorkspacePanel({
       setOpenTabs((tabs) => [...tabs.filter((tab) => tab !== path), path].slice(-WORKSPACE_MAX_PREVIEW_TABS));
       const dirs = parentDirs(path);
       setOpenDirs((prev) => new Set([...Array.from(prev), ...dirs]));
-      dirs.forEach((dir) => {
-        if (!entriesByDir[dir]) void loadDir(dir);
-      });
+      dirs.forEach((dir) => void loadDir(dir));
     },
-    [entriesByDir, loadDir, openTabs.length, panelWidth, selectedPath, treeVisible],
+    [loadDir, openTabs.length, panelWidth, selectedPath, treeVisible],
   );
 
   useEffect(() => {
     if (!open) return;
+    dirLoadGenerationRef.current += 1;
+    dirLoadRequestIdsRef.current = {};
     setEntriesByDir({});
     setOpenDirs(new Set([""]));
     setSelectedPath(null);
@@ -503,10 +512,8 @@ export function WorkspacePanel({
     setTreeMenu(null);
     const dirs = Array.from(new Set(paths.flatMap(parentDirs)));
     setOpenDirs((prev) => new Set([...Array.from(prev), ...dirs]));
-    dirs.forEach((dir) => {
-      if (!entriesByDir[dir]) void loadDir(dir);
-    });
-  }, [entriesByDir, fileListRequest, loadDir, open, scopedFilePaths, viewMode]);
+    dirs.forEach((dir) => void loadDir(dir));
+  }, [fileListRequest, loadDir, open, scopedFilePaths, viewMode]);
 
   useEffect(() => {
     if (!open || changeListRequest) return;
@@ -649,10 +656,10 @@ export function WorkspacePanel({
       void loadWorkspaceChanges();
       return;
     }
+    onFileTreeRefresh?.();
     const dirs = Array.from(openDirsRef.current);
-    setEntriesByDir({});
     dirs.forEach((dir) => void loadDir(dir));
-  }, [loadGitHistory, loadWorkspaceChanges, loadDir, viewMode]);
+  }, [loadGitHistory, loadWorkspaceChanges, loadDir, onFileTreeRefresh, viewMode]);
 
   const refreshSelected = useCallback(() => {
     if (!selectedPath) return;
@@ -698,12 +705,12 @@ export function WorkspacePanel({
           next.delete(dir);
         } else {
           next.add(dir);
-          if (!entriesByDir[dir]) void loadDir(dir);
+          void loadDir(dir);
         }
         return next;
       });
     },
-    [entriesByDir, loadDir],
+    [loadDir],
   );
 
   const breadcrumbDirs = selectedPath ? parentDirs(selectedPath) : [""];
@@ -1262,6 +1269,7 @@ export function WorkspacePanel({
                 setFilter("");
                 showTreeEvenSplit();
                 setOpenDirs((prev) => new Set([...Array.from(prev), ""]));
+                void loadDir("");
               }}
             >
               {shortCwd(cwd) || t("workspace.title")}


### PR DESCRIPTION
## Summary
- Revalidate Composer @ file reference directories while keeping cached entries for fast first paint.
- Add a short TTL for fuzzy @ file searches and invalidate Composer file-reference caches from workspace tree refreshes.
- Revalidate workspace file tree directory caches with per-directory request guards so stale responses cannot overwrite newer data.

## Tests
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-goal-toggle.test.tsx`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/workspace-changes-errors.test.tsx`
- `pnpm --dir desktop/frontend run test:typecheck`
- `git diff --check`