### PR TITLE
Auto-refresh session titles without overriding manual names / 自动更新会话标题且尊重手动命名

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1916,7 +1916,11 @@ func (a *App) ListSessions() []SessionMeta {
 	out := make([]SessionMeta, 0, len(infos))
 	for _, s := range infos {
 		_, isOpen := open[s.Path]
-		meta := sessionMetaFromInfo(s, titles[filepath.Base(s.Path)], s.Path == active, isOpen, 0)
+		title := strings.TrimSpace(s.CustomTitle)
+		if title == "" {
+			title = titles[filepath.Base(s.Path)]
+		}
+		meta := sessionMetaFromInfo(s, title, s.Path == active, isOpen, 0)
 		if route, ok := channelRoutes[sessionRuntimeKey(s.Path)]; ok {
 			applyChannelSessionRoute(&meta, route)
 		}
@@ -1941,7 +1945,11 @@ func (a *App) ListTrashedSessions() []SessionMeta {
 				continue
 			}
 			deletedAt := trashedSessionDeletedAt(path)
-			out = append(out, sessionMetaFromInfo(infos[0], titles[filepath.Base(path)], false, false, deletedAt))
+			title := strings.TrimSpace(infos[0].CustomTitle)
+			if title == "" {
+				title = titles[filepath.Base(path)]
+			}
+			out = append(out, sessionMetaFromInfo(infos[0], title, false, false, deletedAt))
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -2627,9 +2635,19 @@ func (a *App) PurgeTrashedSession(path string) error {
 }
 
 // RenameSession sets a custom display name for a session (empty clears it back to
-// the preview). It only affects the history panel; the file on disk is unchanged.
+// the preview). The transcript file is unchanged; the canonical name lives in
+// the branch meta sidecar, with the legacy .titles.json map kept as a
+// compatibility write-through for older desktop data paths.
 func (a *App) RenameSession(path, title string) error {
-	if err := setSessionTitle(a.activeSessionDir(), path, title); err != nil {
+	dir := a.activeSessionDir()
+	sessionPath, _, err := validateSessionPath(dir, path)
+	if err != nil {
+		return err
+	}
+	if err := agent.RenameSession(sessionPath, title); err != nil {
+		return err
+	}
+	if err := setSessionTitle(dir, sessionPath, title); err != nil {
 		return err
 	}
 	a.invalidatePromptHistoryCache()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3721,6 +3721,17 @@ func TestDesktopSessionAPIsUseControllerSessionDir(t *testing.T) {
 	if err := app.RenameSession(pathA, "A title"); err != nil {
 		t.Fatalf("RenameSession in active session dir: %v", err)
 	}
+	meta, ok, err := agent.LoadBranchMeta(pathA)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after RenameSession ok=%v err=%v", ok, err)
+	}
+	if meta.CustomTitle != "A title" {
+		t.Fatalf("custom title should be written to branch meta, got %q", meta.CustomTitle)
+	}
+	sessions = app.ListSessions()
+	if len(sessions) != 1 || sessions[0].Title != "A title" {
+		t.Fatalf("ListSessions should return custom title from branch meta, got %+v", sessions)
+	}
 	if titles := loadSessionTitles(dirA); titles["a.jsonl"] != "A title" {
 		t.Fatalf("title should be written beside the active session, got %+v", titles)
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1760,6 +1760,7 @@ func resetReusableBlankTabTitle(tab *WorkspaceTab, scope, workspaceRoot string) 
 	if err := setTopicTitleWithSource(titleRoot, topicID, defaultTopicTitle, topicTitleSourceAuto); err != nil {
 		return err
 	}
+	_ = deleteTopicAutoTitleMeta(titleRoot, topicID)
 	tab.TopicTitle = defaultTopicTitle
 	return nil
 }
@@ -2899,6 +2900,9 @@ func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	if sessionPath == "" {
 		return false
 	}
+	if sessionHasManualDisplayTitle(sessionPath) {
+		return false
+	}
 	nextTitle, updated := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath)
 	if !updated {
 		return false
@@ -2913,14 +2917,90 @@ func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (stri
 	if source := loadTopicTitleSource(workspaceRoot, topicID); source != topicTitleSourceAuto {
 		return "", false
 	}
-	nextTitle := topicTitleFromSession(sessionPath)
-	if nextTitle == "" || nextTitle == loadTopicTitle(workspaceRoot, topicID) {
+	if sessionHasManualDisplayTitle(sessionPath) {
+		return "", false
+	}
+	proposal := autoTopicTitleProposalFromSession(sessionPath)
+	if proposal.Title == "" {
+		return "", false
+	}
+	if !shouldApplyAutoTopicTitle(workspaceRoot, topicID, proposal) {
+		return "", false
+	}
+	nextTitle := proposal.Title
+	if nextTitle == strings.TrimSpace(loadTopicTitle(workspaceRoot, topicID)) {
+		_ = recordTopicAutoTitleMeta(workspaceRoot, topicID, proposal)
 		return "", false
 	}
 	if err := setTopicTitleWithSource(workspaceRoot, topicID, nextTitle, topicTitleSourceAuto); err != nil {
 		return "", false
 	}
+	_ = recordTopicAutoTitleMeta(workspaceRoot, topicID, proposal)
 	return nextTitle, true
+}
+
+type autoTopicTitleProposal struct {
+	Title     string
+	Stage     int
+	UserTurns int
+	BasisHash string
+}
+
+func autoTopicTitleProposalFromSession(path string) autoTopicTitleProposal {
+	users := topicTitleUserTurnsFromSession(path)
+	if len(users) == 0 {
+		return autoTopicTitleProposal{}
+	}
+	stage := 1
+	if len(users) >= 3 {
+		stage = 3
+	}
+	basis := users
+	if len(basis) > stage {
+		basis = basis[:stage]
+	}
+	title := topicTitleFromUserTurns(basis)
+	if title == "" {
+		return autoTopicTitleProposal{}
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d\x00%s", stage, strings.Join(basis, "\x00"))))
+	return autoTopicTitleProposal{
+		Title:     title,
+		Stage:     stage,
+		UserTurns: len(users),
+		BasisHash: hex.EncodeToString(sum[:8]),
+	}
+}
+
+func shouldApplyAutoTopicTitle(workspaceRoot, topicID string, proposal autoTopicTitleProposal) bool {
+	if proposal.Stage <= 0 || proposal.BasisHash == "" {
+		return false
+	}
+	meta := loadTopicAutoTitleMeta(workspaceRoot)[topicID]
+	if meta.Stage > proposal.Stage {
+		return false
+	}
+	if meta.Stage == proposal.Stage && meta.BasisHash == proposal.BasisHash {
+		return false
+	}
+	return true
+}
+
+func sessionHasManualDisplayTitle(sessionPath string) bool {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return false
+	}
+	if meta, ok, err := agent.LoadBranchMeta(sessionPath); err == nil && ok {
+		if strings.TrimSpace(meta.CustomTitle) != "" {
+			return true
+		}
+	}
+	dir := filepath.Dir(sessionPath)
+	if dir == "." || dir == string(filepath.Separator) {
+		return false
+	}
+	return strings.TrimSpace(loadSessionTitles(dir)[filepath.Base(sessionPath)]) != ""
 }
 
 func topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath string) (string, string, bool) {
@@ -2960,25 +3040,82 @@ func topicTitleFallbackForOpen(workspaceRoot, topicID, sessionPath string) (stri
 }
 
 func topicTitleFromSession(path string) string {
+	users := topicTitleUserTurnsFromSession(path)
+	if len(users) == 0 {
+		return ""
+	}
+	return topicTitleFromText(users[0])
+}
+
+func topicTitleUserTurnsFromSession(path string) []string {
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return nil
 	}
 	defer f.Close()
 	dec := json.NewDecoder(f)
+	var users []string
 	for {
 		var msg struct {
 			Role    string `json:"role"`
 			Content string `json:"content"`
 		}
 		if err := dec.Decode(&msg); err != nil {
-			return ""
+			return users
 		}
 		if msg.Role == "user" {
 			content := control.StripComposePrefixes(agent.HandoffTask(msg.Content))
 			content = control.StripReferencedContextPrefix(content)
-			return topicTitleFromText(content)
+			if strings.TrimSpace(content) != "" {
+				users = append(users, content)
+			}
 		}
+	}
+}
+
+func topicTitleFromUserTurns(users []string) string {
+	type candidate struct {
+		title string
+		score int
+	}
+	best := candidate{score: -1}
+	for i, text := range users {
+		title := topicTitleFromText(text)
+		if title == "" || lowSignalTopicTitle(title) {
+			continue
+		}
+		runes := len([]rune(title))
+		score := runes
+		if score > 24 {
+			score = 24
+		}
+		if i == 0 {
+			score += 3
+		}
+		if runes < 5 {
+			score -= 6
+		}
+		if score > best.score {
+			best = candidate{title: title, score: score}
+		}
+	}
+	if best.title != "" {
+		return best.title
+	}
+	if len(users) > 0 {
+		return topicTitleFromText(users[0])
+	}
+	return ""
+}
+
+func lowSignalTopicTitle(title string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(title))
+	normalized = strings.Trim(normalized, " \t\r\n，。！？；：、,.!?;:\"'`“”‘’()（）[]【】")
+	switch normalized {
+	case "", "好", "好的", "好啊", "可以", "嗯", "对", "是的", "继续", "继续吧", "采纳建议", "采用建议", "收到", "明白", "ok", "okay", "yes", "yep", "go on", "continue", "thanks", "thank you":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -3799,6 +3936,7 @@ const (
 	topicTitlesFile        = "desktop-topic-titles.json"
 	topicTitleSourcesFile  = "desktop-topic-title-sources.json"
 	topicCreatedAtsFile    = "desktop-topic-created-at.json"
+	topicAutoTitlesFile    = "desktop-topic-auto-title-meta.json"
 	defaultTopicTitle      = "新的会话"
 	topicTitleSourceAuto   = "auto"
 	topicTitleSourceManual = "manual"
@@ -3823,6 +3961,13 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 		return filepath.Join(desktopConfigDir(), "global", topicCreatedAtsFile)
 	}
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
+}
+
+func topicAutoTitleMetaPath(workspaceRoot string) string {
+	if workspaceRoot == "" {
+		return filepath.Join(desktopConfigDir(), "global", topicAutoTitlesFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicAutoTitlesFile)
 }
 
 const topicFileReadTimeout = 200 * time.Millisecond
@@ -3888,6 +4033,23 @@ func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	return m
 }
 
+type topicAutoTitleMeta struct {
+	Stage     int    `json:"stage,omitempty"`
+	UserTurns int    `json:"userTurns,omitempty"`
+	BasisHash string `json:"basisHash,omitempty"`
+	UpdatedAt int64  `json:"updatedAt,omitempty"`
+}
+
+func loadTopicAutoTitleMeta(workspaceRoot string) map[string]topicAutoTitleMeta {
+	m := map[string]topicAutoTitleMeta{}
+	b, err := readFileWithTimeout(topicAutoTitleMetaPath(workspaceRoot), topicFileReadTimeout)
+	if err != nil {
+		return m
+	}
+	_ = json.Unmarshal(b, &m)
+	return m
+}
+
 func loadStringMapForUpdate(path string) (map[string]string, error) {
 	m := map[string]string{}
 	b, err := os.ReadFile(path)
@@ -3899,6 +4061,22 @@ func loadStringMapForUpdate(path string) (map[string]string, error) {
 	}
 	if err := json.Unmarshal(b, &m); err != nil || m == nil {
 		return map[string]string{}, nil
+	}
+	return m, nil
+}
+
+func loadTopicAutoTitleMetaForUpdate(workspaceRoot string) (map[string]topicAutoTitleMeta, error) {
+	m := map[string]topicAutoTitleMeta{}
+	path := topicAutoTitleMetaPath(workspaceRoot)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &m); err != nil || m == nil {
+		return map[string]topicAutoTitleMeta{}, nil
 	}
 	return m, nil
 }
@@ -3968,6 +4146,22 @@ func saveTopicCreatedAts(workspaceRoot string, m map[string]int64) error {
 		return err
 	}
 	path := topicCreatedAtsPath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return fileutil.ReplaceFile(tmp, path)
+}
+
+func saveTopicAutoTitleMeta(workspaceRoot string, m map[string]topicAutoTitleMeta) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := topicAutoTitleMetaPath(workspaceRoot)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -4177,7 +4371,48 @@ func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error
 	} else {
 		sources[topicID] = strings.TrimSpace(source)
 	}
-	return saveTopicTitleSources(workspaceRoot, sources)
+	if err := saveTopicTitleSources(workspaceRoot, sources); err != nil {
+		return err
+	}
+	if strings.TrimSpace(source) == topicTitleSourceManual ||
+		(strings.TrimSpace(source) == topicTitleSourceAuto && strings.TrimSpace(title) == defaultTopicTitle) {
+		_ = deleteTopicAutoTitleMeta(workspaceRoot, topicID)
+	}
+	return nil
+}
+
+func recordTopicAutoTitleMeta(workspaceRoot, topicID string, proposal autoTopicTitleProposal) error {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" || proposal.Stage <= 0 || proposal.BasisHash == "" {
+		return nil
+	}
+	m, err := loadTopicAutoTitleMetaForUpdate(workspaceRoot)
+	if err != nil {
+		return err
+	}
+	m[topicID] = topicAutoTitleMeta{
+		Stage:     proposal.Stage,
+		UserTurns: proposal.UserTurns,
+		BasisHash: proposal.BasisHash,
+		UpdatedAt: time.Now().UnixMilli(),
+	}
+	return saveTopicAutoTitleMeta(workspaceRoot, m)
+}
+
+func deleteTopicAutoTitleMeta(workspaceRoot, topicID string) error {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return nil
+	}
+	m, err := loadTopicAutoTitleMetaForUpdate(workspaceRoot)
+	if err != nil {
+		return err
+	}
+	if _, ok := m[topicID]; !ok {
+		return nil
+	}
+	delete(m, topicID)
+	return saveTopicAutoTitleMeta(workspaceRoot, m)
 }
 
 func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
@@ -4845,6 +5080,9 @@ func (a *App) ReorderProjects(workspaceRoots []string) error {
 // RenameTopic updates a topic's display title.
 func (a *App) RenameTopic(topicID, title string) error {
 	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		trimmed = defaultTopicTitle
+	}
 	// Find which workspace this topic belongs to by scanning all project topic titles.
 	f := loadProjectsFile()
 	for _, p := range f.Projects {
@@ -6327,7 +6565,11 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		sessionKey := sessionRuntimeKey(info.Path)
 		if sessionKey != "" {
 			sessionInfos[sessionKey] = info
-			sessionTitles[sessionKey] = titles[filepath.Base(info.Path)]
+			title := strings.TrimSpace(info.CustomTitle)
+			if title == "" {
+				title = titles[filepath.Base(info.Path)]
+			}
+			sessionTitles[sessionKey] = title
 		}
 		if strings.TrimSpace(info.TopicID) == "" {
 			continue

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1567,6 +1567,53 @@ func TestAutoTitleTopicStripsReasoningLanguagePrefix(t *testing.T) {
 	}
 }
 
+func TestAutoTitleTopicRefreshesOnThirdUserTurn(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topic, err := NewApp().CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	firstTurn := strings.Join([]string{
+		`{"role":"user","content":"帮我看看"}`,
+		`{"role":"assistant","content":"可以"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(sessionPath, []byte(firstTurn), 0o644); err != nil {
+		t.Fatalf("write first session: %v", err)
+	}
+
+	title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	if !updated || title != "帮我看看" {
+		t.Fatalf("first auto title = %q updated=%v, want 帮我看看/true", title, updated)
+	}
+
+	thirdTurn := strings.Join([]string{
+		`{"role":"user","content":"帮我看看"}`,
+		`{"role":"assistant","content":"可以"}`,
+		`{"role":"user","content":"继续"}`,
+		`{"role":"assistant","content":"继续分析"}`,
+		`{"role":"user","content":"实现自动更新会话标题"}`,
+		`{"role":"assistant","content":"已实现"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(sessionPath, []byte(thirdTurn), 0o644); err != nil {
+		t.Fatalf("write third session: %v", err)
+	}
+
+	title, updated = autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	if !updated || title != "实现自动更新会话标题" {
+		t.Fatalf("third-turn auto title = %q updated=%v, want 实现自动更新会话标题/true", title, updated)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != "实现自动更新会话标题" {
+		t.Fatalf("stored title = %q, want 实现自动更新会话标题", got)
+	}
+	meta := loadTopicAutoTitleMeta(projectRoot)[topic.ID]
+	if meta.Stage != 3 {
+		t.Fatalf("auto title stage = %d, want 3", meta.Stage)
+	}
+}
+
 func TestAutoTitleDoesNotOverrideManualTopicTitle(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
@@ -1589,6 +1636,50 @@ func TestAutoTitleDoesNotOverrideManualTopicTitle(t *testing.T) {
 	}
 	if got := loadTopicTitle(projectRoot, topic.ID); got != "手动标题" {
 		t.Fatalf("stored title = %q, want 手动标题", got)
+	}
+}
+
+func TestAutoTitleDoesNotOverrideManualSessionTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topic, err := NewApp().CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"讲讲这个代码库的架构"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{CustomTitle: "手动会话标题"}); err != nil {
+		t.Fatalf("save branch meta: %v", err)
+	}
+
+	if title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath); updated || title != "" {
+		t.Fatalf("manual session title should not auto-update, title=%q updated=%v", title, updated)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != defaultTopicTitle {
+		t.Fatalf("stored title = %q, want default title", got)
+	}
+}
+
+func TestRenameTopicBlankKeepsManualTitleSource(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := app.RenameTopic(topic.ID, "   "); err != nil {
+		t.Fatalf("rename blank topic: %v", err)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != defaultTopicTitle {
+		t.Fatalf("stored title = %q, want %q", got, defaultTopicTitle)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("title source = %q, want manual", got)
 	}
 }
 

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -28,6 +28,7 @@ type BranchMeta struct {
 	WorkspaceRoot    string    `json:"workspace_root,omitempty"`
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
+	CustomTitle      string    `json:"custom_title,omitempty"`
 	Model            string    `json:"model,omitempty"`
 	TokenMode        string    `json:"token_mode,omitempty"`
 	Mode             string    `json:"mode,omitempty"`
@@ -317,9 +318,10 @@ func ListBranches(dir string) ([]BranchInfo, error) {
 	return out, nil
 }
 
-// RenameSession updates the TopicTitle in the session's .jsonl.meta sidecar
-// file. If no meta file exists yet, one is created. This is used by the
-// /rename CLI command and desktop UI to give sessions human-readable names.
+// RenameSession updates the user-chosen display title in the session's
+// .jsonl.meta sidecar file. If no meta file exists yet, one is created. The
+// topic title remains a separate grouping label, so explicit session names do
+// not fight topic auto-titling.
 func RenameSession(sessionPath string, title string) error {
 	if sessionPath == "" {
 		return fmt.Errorf("empty session path")
@@ -328,8 +330,8 @@ func RenameSession(sessionPath string, title string) error {
 	if err != nil {
 		return err
 	}
-	m.TopicTitle = title
-	return SaveBranchMeta(sessionPath, m)
+	m.CustomTitle = strings.TrimSpace(title)
+	return SaveBranchMetaPreserveUpdated(sessionPath, m)
 }
 
 // LoadSessionModel reads the canonical provider/model ref saved beside a

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -630,6 +630,7 @@ type SessionInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
+	CustomTitle    string
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
@@ -648,6 +649,7 @@ type SessionOrderInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
+	CustomTitle    string
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
@@ -821,6 +823,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		workspaceRoot := ""
 		topicID := ""
 		topicTitle := ""
+		customTitle := ""
 		recovered := false
 		recoveryReason := ""
 		recoveryDigest := ""
@@ -839,6 +842,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			workspaceRoot = meta.WorkspaceRoot
 			topicID = meta.TopicID
 			topicTitle = meta.TopicTitle
+			customTitle = meta.CustomTitle
 			recovered = meta.Recovered
 			recoveryReason = meta.RecoveryReason
 			recoveryDigest = meta.RecoveryDigest
@@ -856,6 +860,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			WorkspaceRoot:  workspaceRoot,
 			TopicID:        topicID,
 			TopicTitle:     topicTitle,
+			CustomTitle:    customTitle,
 			Recovered:      recovered,
 			RecoveryReason: recoveryReason,
 			RecoveryDigest: recoveryDigest,
@@ -911,6 +916,7 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			WorkspaceRoot:  session.WorkspaceRoot,
 			TopicID:        session.TopicID,
 			TopicTitle:     session.TopicTitle,
+			CustomTitle:    session.CustomTitle,
 			Recovered:      session.Recovered,
 			RecoveryReason: session.RecoveryReason,
 			RecoveryDigest: session.RecoveryDigest,

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -517,6 +517,39 @@ func TestListSessionsOrdersByMTime(t *testing.T) {
 	}
 }
 
+func TestListSessionsIncludesCustomTitle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "named.jsonl")
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first user prompt"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMetaPreserveUpdated(path, BranchMeta{
+		TopicTitle:    "Topic title",
+		CustomTitle:   "Custom session title",
+		Preview:       "first user prompt",
+		Turns:         1,
+		SchemaVersion: BranchMetaCountsVersion,
+	}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated: %v", err)
+	}
+
+	got, err := ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].CustomTitle != "Custom session title" {
+		t.Fatalf("custom title = %q, want Custom session title", got[0].CustomTitle)
+	}
+	if got[0].TopicTitle != "Topic title" {
+		t.Fatalf("topic title = %q, want Topic title", got[0].TopicTitle)
+	}
+}
+
 func TestListSessionsSkipsCleanupPending(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pending.jsonl")

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -4,16 +4,26 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 )
 
-func TestRenameSessionUpdatesTopicTitle(t *testing.T) {
+func TestRenameSessionUpdatesCustomTitle(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "test-session.jsonl")
 	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+	updatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		TopicTitle: "Topic",
+		CreatedAt:  updatedAt.Add(-time.Hour),
+		UpdatedAt:  updatedAt,
+	}); err != nil {
+		t.Fatalf("seed meta: %v", err)
 	}
 	if err := agent.RenameSession(sessionPath, "My Test Title"); err != nil {
 		t.Fatalf("RenameSession failed: %v", err)
@@ -24,43 +34,51 @@ func TestRenameSessionUpdatesTopicTitle(t *testing.T) {
 		t.Fatalf("reading meta: %v", err)
 	}
 	var m struct {
-		TopicTitle string `json:"topic_title"`
+		TopicTitle  string `json:"topic_title"`
+		CustomTitle string `json:"custom_title"`
 	}
 	if err := json.Unmarshal(raw, &m); err != nil {
 		t.Fatalf("decoding meta: %v", err)
 	}
-	if m.TopicTitle != "My Test Title" {
-		t.Errorf("topic_title = %q, want %q", m.TopicTitle, "My Test Title")
+	if m.CustomTitle != "My Test Title" {
+		t.Errorf("custom_title = %q, want %q", m.CustomTitle, "My Test Title")
+	}
+	if m.TopicTitle != "Topic" {
+		t.Errorf("topic_title = %q, want preserved Topic", m.TopicTitle)
+	}
+	stored, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after rename ok=%v err=%v", ok, err)
+	}
+	if !stored.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("updated_at changed after rename: got %s want %s", stored.UpdatedAt, updatedAt)
 	}
 	if err := agent.RenameSession(sessionPath, "Updated Title"); err != nil {
 		t.Fatalf("second rename failed: %v", err)
 	}
 	raw, _ = os.ReadFile(metaPath)
 	json.Unmarshal(raw, &m)
-	if m.TopicTitle != "Updated Title" {
-		t.Errorf("topic_title after second rename = %q, want %q", m.TopicTitle, "Updated Title")
+	if m.CustomTitle != "Updated Title" {
+		t.Errorf("custom_title after second rename = %q, want %q", m.CustomTitle, "Updated Title")
+	}
+	if m.TopicTitle != "Topic" {
+		t.Errorf("topic_title after second rename = %q, want preserved Topic", m.TopicTitle)
 	}
 }
 
-func TestSessionPickerLabelShowsTopicTitle(t *testing.T) {
+func TestSessionPickerLabelPrefersCustomTitle(t *testing.T) {
 	s := agent.SessionInfo{Turns: 5, Preview: "first user message here", TopicTitle: ""}
 	got := sessionPickerLabel(s)
 	if got == "" {
 		t.Fatal("empty label")
 	}
-	s.TopicTitle = "My Custom Name"
+	s.TopicTitle = "My Topic Name"
+	s.CustomTitle = "My Custom Name"
 	got = sessionPickerLabel(s)
-	if got == "" {
-		t.Fatal("empty label after setting TopicTitle")
+	if !strings.Contains(got, "My Custom Name") {
+		t.Errorf("label %q should contain custom title", got)
 	}
-	found := false
-	for _, ch := range got {
-		if ch == 'M' {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("label %q should contain topic title", got)
+	if strings.Contains(got, "My Topic Name") {
+		t.Errorf("label %q should prefer custom title over topic title", got)
 	}
 }

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -113,14 +113,16 @@ func (m *chatTUI) resumeArgItems(val string) ([]compItem, int, bool) {
 	return out, from, true
 }
 
-// sessionSummary is the "N turns · project · topicTitle/first message" line
-// shared by the /resume list and its argument completion.
-// When a TopicTitle is set (via /rename or desktop), it is shown instead of
-// the raw preview so the user can identify sessions at a glance.
+// sessionSummary is the "N turns · display title" line shared by the /resume
+// list and its argument completion. Explicit session renames win, then topic
+// titles, then the raw preview so the user can identify sessions at a glance.
 func sessionSummary(s agent.SessionInfo) string {
-	preview := s.Preview
-	if s.TopicTitle != "" {
+	preview := s.CustomTitle
+	if preview == "" {
 		preview = s.TopicTitle
+	}
+	if preview == "" {
+		preview = s.Preview
 	}
 	if preview == "" {
 		preview = "(no user message yet)"

--- a/internal/cli/resume_picker.go
+++ b/internal/cli/resume_picker.go
@@ -112,12 +112,15 @@ func (m chatTUI) renderResumePicker() string {
 	return choicePanelStyle.Width(w).Render(b.String())
 }
 
-// sessionPickerLabel is the "N turns · topicTitle/first message" line, truncated to fit.
-// When a TopicTitle is set (via /rename or desktop), it is shown instead of the raw preview.
+// sessionPickerLabel is the "N turns · display title" line, truncated to fit.
+// Explicit session renames win, then topic titles, then the raw preview.
 func sessionPickerLabel(s agent.SessionInfo) string {
-	preview := s.Preview
-	if s.TopicTitle != "" {
+	preview := s.CustomTitle
+	if preview == "" {
 		preview = s.TopicTitle
+	}
+	if preview == "" {
+		preview = s.Preview
 	}
 	if preview == "" {
 		preview = "(no user message yet)"


### PR DESCRIPTION
Summary:
- Store explicit session renames in branch meta custom_title and prefer them in desktop/CLI listings.
- Auto-refresh topic titles after the first and third user turns while skipping manually renamed topics or sessions.
- Persist auto-title metadata so autosave does not repeatedly rewrite titles, and keep blank manual topic renames locked as manual.

Tests:
- go test . -count=1 (desktop)
- go test ./internal/agent ./internal/cli -count=1
- pnpm --dir desktop/frontend exec tsx src/__tests__/session-title-contract.test.ts