### PR TITLE
fix(tui): persist session via Snapshot() before tea.Quit on Ctrl+C exit paths

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1099,6 +1099,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.bubblePending {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
 				} else if m.cancelRequested() {
+					_ = m.ctrl.Snapshot()
 					m.ctrl.Cancel()
 					return m, tea.Quit
 				} else {
@@ -1130,6 +1131,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if !m.lastCtrlCAt.IsZero() && time.Since(m.lastCtrlCAt) < 1500*time.Millisecond {
+				if m.ctrl != nil {
+					_ = m.ctrl.Snapshot()
+				}
 				return m, tea.Quit
 			}
 			m.lastCtrlCAt = time.Now()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3466,6 +3466,7 @@ func (c *Controller) ReleaseResources() {
 // Close stops plugin subprocesses and releases resources. A session that ever
 // started fires SessionEnd so a teardown hook runs.
 func (c *Controller) Close() {
+	_ = c.Snapshot()
 	c.close(true, closeJobsWithGrace)
 }
 


### PR DESCRIPTION
## PR Description

```
Ctrl+C (running turn + idle double-press), Ctrl+D, exit/quit/:q, and /quit//exit all returned tea.Quit without first calling Snapshot(), causing session data loss. The SIGHUP/SIGTERM handler already does this correctly. Mirror that pattern in the two chat_tui.go Ctrl+C paths, and add a defensive Snapshot() in Controller.Close() as a safety net for all remaining exit paths.

Fixes #5879

## Summary

Three exit paths in the TUI returned `tea.Quit` without first persisting the session via `Snapshot()`. Only the SIGHUP/SIGTERM handler (`cli.go:697-704`) correctly snapshotted before quitting.

**Root cause:** `ctrl.Snapshot()` was never called on user-initiated exits.

**Changes (2 files, +5 lines):**

| File | Change |
|------|--------|
| `internal/cli/chat_tui.go:1102` | Added `_ = m.ctrl.Snapshot()` before `tea.Quit` in the `cancelRequested()` path (second Ctrl+C during a running turn) |
| `internal/cli/chat_tui.go:1133` | Added `_ = m.ctrl.Snapshot()` (with nil guard) before `tea.Quit` in the double-Ctrl+C idle path |
| `internal/control/controller.go:3469` | Added `_ = c.Snapshot()` as first line of `Close()` — defensive safety net for Ctrl+D, `exit`/`quit`/`:q`, `/quit`/`/exit`, and future regressions |

**Why this approach:**
- Mirrors the existing SIGHUP/SIGTERM handler pattern: snapshot then quit.
- Matches the existing `_ = m.ctrl.Snapshot()` call in chat_tui.go:1353 (after compaction).
- Follows REASONIX.md rule: "Add behavior to the controller, not a frontend" — the `Close()` fix benefits all three frontends.
- `Snapshot()` is idempotent with internal nil/empty guards — safe to call unconditionally.
- No new imports, API changes, or config changes.

## Verification

```bash
# go vet — clean
go vet ./internal/cli/ ./internal/control/

# go test — both pass
go test ./internal/cli/ ./internal/control/
# ok  reasonix/internal/cli      5.311s
# ok  reasonix/internal/control   (cached)

# gofmt — no unformatted files
gofmt -w . && gofmt -l .
# (no output)

# Manual testing:
# 1. Start a chat, exchange a few messages
# 2. Ctrl+C twice (idle) → verify session .jsonl was persisted
# 3. Ctrl+D → verify .jsonl persisted
# 4. Type "exit" / "quit" / ":q" → verify .jsonl persisted
# 5. Type "/quit" / "/exit" → verify .jsonl persisted
```

## Cache impact

Cache-impact: none — changes are in `internal/cli/` and `internal/control/`, which are not cache-sensitive paths (not under `internal/boot/`, `internal/tool/`, `internal/provider/`, etc.)
Cache-guard: N/A — no cache-sensitive files touched; `go vet ./internal/cli/ ./internal/control/` + `go test ./internal/cli/ ./internal/control/` pass
System-prompt-review: N/A
```