### PR TITLE
fix(desktop): allow deleting the current/last history session / 允许删除最后的历史对话

### DIFF
--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -268,27 +268,23 @@ export function HistoryPanel({
               startRename(target);
             },
           },
-          ...(menuSession.current
-            ? []
-            : [
-                {
-                  key: "delete",
-                  icon: <Archive size={13} />,
-                  label:
-                    menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path
-                      ? tr("history.confirmMoveToTrash")
-                      : tr("history.moveToTrash"),
-                  disabled: running,
-                  danger: menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path,
-                  onSelect: () => {
-                    if (menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path) {
-                      deleteHistorySession(menuSession);
-                    } else {
-                      setMenuConfirmTarget({ kind: "delete", path: menuSession.path });
-                    }
-                  },
-                } as ContextMenuItem,
-              ]),
+          {
+            key: "delete",
+            icon: <Archive size={13} />,
+            label:
+              menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path
+                ? tr("history.confirmMoveToTrash")
+                : tr("history.moveToTrash"),
+            disabled: running,
+            danger: menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path,
+            onSelect: () => {
+              if (menuConfirmTarget?.kind === "delete" && menuConfirmTarget.path === menuSession.path) {
+                deleteHistorySession(menuSession);
+              } else {
+                setMenuConfirmTarget({ kind: "delete", path: menuSession.path });
+              }
+            },
+          },
         ]
     : [];
   const trashBlankMenuItems: ContextMenuItem[] =
@@ -327,7 +323,7 @@ export function HistoryPanel({
     startRename(selectedSession);
   };
   const moveSelectedToTrash = () => {
-    if (!selectedSession || running || isTrash || selectedSession.current) return;
+    if (!selectedSession || running || isTrash) return;
     if (actionConfirmDelete) deleteHistorySession(selectedSession);
     else setMenuConfirmTarget({ kind: "delete", path: selectedSession.path });
   };
@@ -522,7 +518,7 @@ export function HistoryPanel({
                       <button
                         className="btn btn--small btn--danger"
                         type="button"
-                        disabled={!selectedSession || running || selectedSession.current}
+                        disabled={!selectedSession || running}
                         onClick={moveSelectedToTrash}
                       >
                         {actionConfirmDelete ? tr("history.confirmMoveToTrash") : tr("history.moveToTrash")}


### PR DESCRIPTION
The HistoryPanel frontend unconditionally blocked deletion of any session marked as "current", which made it impossible to trash the last remaining session. The backend already handles this gracefully via its fallback mechanism (creating a new blank tab when all tabs are removed), so the frontend guard was overly conservative.

Remove the `selectedSession.current` guard from the context menu, the `moveSelectedToTrash` action, and the "Move to trash" button.

## Summary
- Remove the `selectedSession.current` guard in HistoryPanel.tsx that blocked deletion of the current session. When only one session remains, it is always "current" — making the delete action unreachable.

## Verification
- Manual: create a single session, verify the trash button and context menu "Move to Trash" option are enabled and functional.
- Backend fallback confirmed: `desktop/app.go` creates a new blank tab when the last session is deleted (covered by `TestTrashTopicFallbackCreatesUnindexedBlank`).

## Cache impact
Cache-impact: none — desktop frontend only (HistoryPanel.tsx), no cache-sensitive paths touched
Cache-guard: no internal/boot, internal/tool, or internal/provider files changed
System-prompt-review: not applicable — no system prompt, memory, config, or skill index changes