### PR TITLE
Detect macOS main-thread hangs / 检测 macOS 主线程卡死

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -136,6 +136,8 @@ type App struct {
 	backgroundMaximised atomic.Bool
 	trayReady           bool
 	tray                *desktopTray
+	hangWatchdogMu      sync.Mutex
+	hangWatchdogCancel  context.CancelFunc
 
 	mediaTokens *mediaTokenStore
 	botInstalls map[string]*botInstallSession
@@ -366,6 +368,7 @@ func (a *App) startup(ctx context.Context) {
 		a.metrics.Store(newMetricsAggregator(config.MemoryUserDir()))
 		a.recordSettingsMetricsSnapshot(cfg)
 	}
+	a.startMainThreadWatchdog()
 
 	a.heartbeat = newHeartbeatEngine(a)
 	a.heartbeat.Start()
@@ -648,6 +651,7 @@ func (a *App) snapshotAllTabs() {
 
 // shutdown snapshots all tabs, saves the final window geometry, and closes tabs.
 func (a *App) shutdown(context.Context) {
+	a.stopMainThreadWatchdog()
 	if a.heartbeat != nil {
 		a.heartbeat.Stop()
 	}

--- a/desktop/crash_pending.go
+++ b/desktop/crash_pending.go
@@ -46,15 +46,24 @@ func writePendingCrash(site string, r any, stack []byte) {
 	report.Stack = sanitizeCrashText(stackText, maxCrashStackBytes)
 	report.TopFrame = topFrameFromStack(report.Stack)
 	report.Message = msg
+	_ = writePendingReport(report, true)
+}
+
+func writePendingReport(report crashReport, overwrite bool) bool {
 	body, err := json.Marshal(report)
 	if err != nil {
-		return
+		return false
 	}
 	path := pendingCrashPath()
-	if os.MkdirAll(filepath.Dir(path), 0o755) != nil {
-		return
+	if !overwrite {
+		if _, err := os.Stat(path); err == nil {
+			return false
+		}
 	}
-	_ = os.WriteFile(path, body, 0o644)
+	if os.MkdirAll(filepath.Dir(path), 0o755) != nil {
+		return false
+	}
+	return os.WriteFile(path, body, 0o644) == nil
 }
 
 func (a *App) goSafe(site string, fn func()) {

--- a/desktop/crash_pending.go
+++ b/desktop/crash_pending.go
@@ -55,15 +55,23 @@ func writePendingReport(report crashReport, overwrite bool) bool {
 		return false
 	}
 	path := pendingCrashPath()
-	if !overwrite {
-		if _, err := os.Stat(path); err == nil {
-			return false
-		}
-	}
 	if os.MkdirAll(filepath.Dir(path), 0o755) != nil {
 		return false
 	}
-	return os.WriteFile(path, body, 0o644) == nil
+	if overwrite {
+		return os.WriteFile(path, body, 0o644) == nil
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	n, err := f.Write(body)
+	if err != nil || n != len(body) {
+		_ = os.Remove(path)
+		return false
+	}
+	return true
 }
 
 func (a *App) goSafe(site string, fn func()) {

--- a/desktop/crash_pending_test.go
+++ b/desktop/crash_pending_test.go
@@ -67,6 +67,30 @@ func TestWritePendingCrashCaps(t *testing.T) {
 	}
 }
 
+func TestWritePendingReportCanAvoidOverwritingExistingCrash(t *testing.T) {
+	t.Cleanup(func() { os.Remove(pendingCrashPath()) })
+	writePendingCrash("panic", "boom", []byte("stack"))
+	before, ok := readPending(t)
+	if !ok {
+		t.Fatal("expected initial pending crash")
+	}
+
+	hang := baseCrashReport("performance")
+	hang.Source = "native.watchdog"
+	hang.Label = "mac.main_thread.hang"
+	hang.Message = "hang"
+	if writePendingReport(hang, false) {
+		t.Fatal("writePendingReport overwrite=false should not replace existing report")
+	}
+	after, ok := readPending(t)
+	if !ok {
+		t.Fatal("expected pending crash after skipped write")
+	}
+	if after.Label != before.Label || after.Message != before.Message {
+		t.Fatalf("pending crash was overwritten: before=%+v after=%+v", before, after)
+	}
+}
+
 func TestWritePendingCrashScrubsSensitiveText(t *testing.T) {
 	t.Cleanup(func() { os.Remove(pendingCrashPath()) })
 	apiKey := "sk-proj-" + "abcdefghijklmnopqrstuvwxyz1234567890"

--- a/desktop/crash_pending_test.go
+++ b/desktop/crash_pending_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -88,6 +89,42 @@ func TestWritePendingReportCanAvoidOverwritingExistingCrash(t *testing.T) {
 	}
 	if after.Label != before.Label || after.Message != before.Message {
 		t.Fatalf("pending crash was overwritten: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestWritePendingReportNonOverwriteAllowsOneConcurrentWriter(t *testing.T) {
+	t.Cleanup(func() { os.Remove(pendingCrashPath()) })
+	const writers = 32
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	var done sync.WaitGroup
+	var successes atomic.Int32
+
+	for i := 0; i < writers; i++ {
+		ready.Add(1)
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			report := baseCrashReport("performance")
+			report.Source = "native.watchdog"
+			report.Label = "mac.main_thread.hang"
+			report.Message = strings.Repeat("hang", 1024)
+			ready.Done()
+			<-start
+			if writePendingReport(report, false) {
+				successes.Add(1)
+			}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+
+	if got := successes.Load(); got != 1 {
+		t.Fatalf("successful non-overwrite writers = %d, want 1", got)
+	}
+	if _, ok := readPending(t); !ok {
+		t.Fatal("expected one pending report")
 	}
 }
 

--- a/desktop/hang_watchdog.go
+++ b/desktop/hang_watchdog.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	mainThreadHeartbeatInterval = time.Second
+	mainThreadHangThreshold     = 12 * time.Second
+	mainThreadHangCheckInterval = 2 * time.Second
+	mainThreadSleepSkip         = 30 * time.Second
+)
+
+var (
+	mainThreadLastHeartbeat atomic.Int64
+	mainThreadHangReported  atomic.Bool
+)
+
+func recordMainThreadHeartbeat(t time.Time) {
+	mainThreadLastHeartbeat.Store(t.UnixNano())
+}
+
+func (a *App) startMainThreadWatchdog() {
+	if !mainThreadWatchdogSupported() {
+		return
+	}
+	a.hangWatchdogMu.Lock()
+	if a.hangWatchdogCancel != nil {
+		a.hangWatchdogMu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.hangWatchdogCancel = cancel
+	mainThreadHangReported.Store(false)
+	recordMainThreadHeartbeat(time.Now())
+	startNativeMainThreadHeartbeat(uint64(mainThreadHeartbeatInterval / time.Millisecond))
+	a.hangWatchdogMu.Unlock()
+
+	a.goSafe("mainThreadHangWatchdog", func() {
+		a.watchMainThreadHeartbeat(ctx)
+	})
+}
+
+func (a *App) stopMainThreadWatchdog() {
+	if !mainThreadWatchdogSupported() {
+		return
+	}
+	a.hangWatchdogMu.Lock()
+	cancel := a.hangWatchdogCancel
+	a.hangWatchdogCancel = nil
+	a.hangWatchdogMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	stopNativeMainThreadHeartbeat()
+}
+
+func (a *App) watchMainThreadHeartbeat(ctx context.Context) {
+	ticker := time.NewTicker(mainThreadHangCheckInterval)
+	defer ticker.Stop()
+	lastCheck := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if now.Sub(lastCheck) > mainThreadSleepSkip {
+				lastCheck = now
+				continue
+			}
+			lastCheck = now
+			lastUnix := mainThreadLastHeartbeat.Load()
+			if lastUnix <= 0 {
+				continue
+			}
+			last := time.Unix(0, lastUnix)
+			if now.Sub(last) < mainThreadHangThreshold {
+				continue
+			}
+			if mainThreadHangReported.CompareAndSwap(false, true) {
+				a.recordMainThreadHang(now.Sub(last), last, now)
+			}
+		}
+	}
+}
+
+func (a *App) recordMainThreadHang(age time.Duration, lastHeartbeat, observedAt time.Time) {
+	report := mainThreadHangReport(age, lastHeartbeat, observedAt)
+	wrote := writePendingReport(report, false)
+	if m := a.metrics.Load(); m != nil {
+		m.inc("desktop_hang", "main_thread")
+		m.inc("desktop_hang_age", hangAgeBucket(age))
+		m.persist()
+	}
+	slog.Warn("desktop: mac main thread heartbeat stalled",
+		"age", age.Round(time.Millisecond).String(),
+		"lastHeartbeat", lastHeartbeat.Format(time.RFC3339),
+		"pendingReport", wrote,
+	)
+}
+
+func mainThreadHangReport(age time.Duration, lastHeartbeat, observedAt time.Time) crashReport {
+	age = age.Round(time.Second)
+	message := fmt.Sprintf(`[mac.main_thread.hang]
+
+Reasonix detected that the macOS main-thread heartbeat stopped for %s.
+
+--- watchdog context ---
+last heartbeat: %s
+observed at: %s
+threshold: %s
+bucket: %s
+
+--- native runtime context ---
+%s`,
+		age,
+		lastHeartbeat.UTC().Format(time.RFC3339),
+		observedAt.UTC().Format(time.RFC3339),
+		mainThreadHangThreshold,
+		hangAgeBucket(age),
+		nativeResourceContext(),
+	)
+	report := baseCrashReport("performance")
+	report.SchemaVersion = 2
+	report.Source = "native.watchdog"
+	report.Label = "mac.main_thread.hang"
+	report.ErrorType = "MacMainThreadHang"
+	report.ErrorMessage = sanitizeCrashText("macOS main thread heartbeat stopped; AppKit/Wails run loop may be blocked.", maxCrashFieldBytes)
+	report.TopFrame = "mac.main_thread.heartbeat"
+	report.OccurredAt = observedAt.UTC().Format(time.RFC3339)
+	report.Message = sanitizeCrashText(message, maxCrashDetailBytes)
+	return report
+}
+
+func hangAgeBucket(age time.Duration) string {
+	seconds := age.Seconds()
+	switch {
+	case seconds < 15:
+		return "s_10_15"
+	case seconds < 30:
+		return "s_15_30"
+	case seconds < 60:
+		return "s_30_60"
+	case seconds < 300:
+		return "m_1_5"
+	default:
+		return "m_5_plus"
+	}
+}

--- a/desktop/hang_watchdog.go
+++ b/desktop/hang_watchdog.go
@@ -16,12 +16,32 @@ const (
 )
 
 var (
-	mainThreadLastHeartbeat atomic.Int64
-	mainThreadHangReported  atomic.Bool
+	mainThreadClockBase            = time.Now()
+	mainThreadLastHeartbeatElapsed atomic.Int64
+	mainThreadLastHeartbeatWall    atomic.Int64
+	mainThreadHangReported         atomic.Bool
 )
 
 func recordMainThreadHeartbeat(t time.Time) {
-	mainThreadLastHeartbeat.Store(t.UnixNano())
+	elapsed := t.Sub(mainThreadClockBase)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	mainThreadLastHeartbeatElapsed.Store(int64(elapsed))
+	mainThreadLastHeartbeatWall.Store(t.UnixNano())
+}
+
+func mainThreadHeartbeatAge(now time.Time) (time.Duration, time.Time, bool) {
+	lastElapsed := time.Duration(mainThreadLastHeartbeatElapsed.Load())
+	lastWall := mainThreadLastHeartbeatWall.Load()
+	if lastWall <= 0 {
+		return 0, time.Time{}, false
+	}
+	age := now.Sub(mainThreadClockBase) - lastElapsed
+	if age < 0 {
+		age = 0
+	}
+	return age, time.Unix(0, lastWall), true
 }
 
 func (a *App) startMainThreadWatchdog() {
@@ -73,16 +93,15 @@ func (a *App) watchMainThreadHeartbeat(ctx context.Context) {
 				continue
 			}
 			lastCheck = now
-			lastUnix := mainThreadLastHeartbeat.Load()
-			if lastUnix <= 0 {
+			age, last, ok := mainThreadHeartbeatAge(now)
+			if !ok {
 				continue
 			}
-			last := time.Unix(0, lastUnix)
-			if now.Sub(last) < mainThreadHangThreshold {
+			if age < mainThreadHangThreshold {
 				continue
 			}
 			if mainThreadHangReported.CompareAndSwap(false, true) {
-				a.recordMainThreadHang(now.Sub(last), last, now)
+				a.recordMainThreadHang(age, last, now)
 			}
 		}
 	}

--- a/desktop/hang_watchdog_darwin.go
+++ b/desktop/hang_watchdog_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package main
+
+/*
+#include <stdint.h>
+#include <dispatch/dispatch.h>
+
+extern void reasonixDesktopMainHeartbeat(void);
+
+static dispatch_source_t reasonix_main_heartbeat_timer;
+
+static void reasonix_main_heartbeat_handler(void *ctx) {
+	reasonixDesktopMainHeartbeat();
+}
+
+static void reasonix_start_main_heartbeat(uint64_t interval_ms) {
+	if (reasonix_main_heartbeat_timer != NULL) {
+		return;
+	}
+	reasonix_main_heartbeat_timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+	dispatch_set_context(reasonix_main_heartbeat_timer, NULL);
+	dispatch_source_set_event_handler_f(reasonix_main_heartbeat_timer, reasonix_main_heartbeat_handler);
+	dispatch_source_set_timer(reasonix_main_heartbeat_timer, dispatch_time(DISPATCH_TIME_NOW, 0), interval_ms * NSEC_PER_MSEC, 100 * NSEC_PER_MSEC);
+	dispatch_resume(reasonix_main_heartbeat_timer);
+}
+
+static void reasonix_stop_main_heartbeat(void) {
+	if (reasonix_main_heartbeat_timer == NULL) {
+		return;
+	}
+	dispatch_source_cancel(reasonix_main_heartbeat_timer);
+	reasonix_main_heartbeat_timer = NULL;
+}
+*/
+import "C"
+
+import "time"
+
+func mainThreadWatchdogSupported() bool {
+	return true
+}
+
+func startNativeMainThreadHeartbeat(intervalMS uint64) {
+	C.reasonix_start_main_heartbeat(C.uint64_t(intervalMS))
+}
+
+func stopNativeMainThreadHeartbeat() {
+	C.reasonix_stop_main_heartbeat()
+}
+
+//export reasonixDesktopMainHeartbeat
+func reasonixDesktopMainHeartbeat() {
+	recordMainThreadHeartbeat(time.Now())
+}

--- a/desktop/hang_watchdog_other.go
+++ b/desktop/hang_watchdog_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package main
+
+func mainThreadWatchdogSupported() bool {
+	return false
+}
+
+func startNativeMainThreadHeartbeat(uint64) {}
+
+func stopNativeMainThreadHeartbeat() {}

--- a/desktop/hang_watchdog_test.go
+++ b/desktop/hang_watchdog_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/config"
+)
+
+func TestHangAgeBucket(t *testing.T) {
+	cases := []struct {
+		age  time.Duration
+		want string
+	}{
+		{12 * time.Second, "s_10_15"},
+		{16 * time.Second, "s_15_30"},
+		{45 * time.Second, "s_30_60"},
+		{2 * time.Minute, "m_1_5"},
+		{10 * time.Minute, "m_5_plus"},
+	}
+	for _, c := range cases {
+		if got := hangAgeBucket(c.age); got != c.want {
+			t.Errorf("hangAgeBucket(%s) = %q, want %q", c.age, got, c.want)
+		}
+	}
+}
+
+func TestMainThreadHangReportIsStructuredPerformanceReport(t *testing.T) {
+	last := time.Date(2026, 7, 4, 9, 19, 11, 0, time.UTC)
+	observed := last.Add(16 * time.Second)
+
+	r := mainThreadHangReport(16*time.Second, last, observed)
+
+	if r.Kind != "performance" || r.Source != "native.watchdog" || r.Label != "mac.main_thread.hang" {
+		t.Fatalf("unexpected report identity: %+v", r)
+	}
+	if r.SchemaVersion != 2 || r.ErrorType != "MacMainThreadHang" || r.TopFrame == "" || r.OccurredAt == "" {
+		t.Fatalf("structured fields missing: %+v", r)
+	}
+	for _, want := range []string{"Reasonix detected", "last heartbeat:", "bucket: s_15_30", "goroutines:"} {
+		if !strings.Contains(r.Message, want) {
+			t.Fatalf("hang report message missing %q:\n%s", want, r.Message)
+		}
+	}
+}
+
+func TestRecordMainThreadHangWritesPendingReportAndMetrics(t *testing.T) {
+	t.Cleanup(func() {
+		os.Remove(pendingCrashPath())
+		os.Remove(filepath.Join(config.MemoryUserDir(), metricsPendingFile))
+	})
+	app := NewApp()
+	app.metrics.Store(newMetricsAggregator(config.MemoryUserDir()))
+
+	last := time.Now().Add(-20 * time.Second)
+	app.recordMainThreadHang(20*time.Second, last, time.Now())
+
+	r, ok := readPending(t)
+	if !ok {
+		t.Fatal("expected pending hang report")
+	}
+	if r.Kind != "performance" || r.Source != "native.watchdog" || r.Label != "mac.main_thread.hang" {
+		t.Fatalf("pending report = %+v", r)
+	}
+	c := readCounters(filepath.Join(config.MemoryUserDir(), metricsPendingFile))
+	if got := c["desktop_hang"]["main_thread"]; got != 1 {
+		t.Fatalf("desktop_hang/main_thread = %d, want 1", got)
+	}
+	if got := c["desktop_hang_age"]["s_15_30"]; got != 1 {
+		t.Fatalf("desktop_hang_age/s_15_30 = %d, want 1", got)
+	}
+}

--- a/desktop/hang_watchdog_test.go
+++ b/desktop/hang_watchdog_test.go
@@ -47,6 +47,30 @@ func TestMainThreadHangReportIsStructuredPerformanceReport(t *testing.T) {
 	}
 }
 
+func TestMainThreadHeartbeatAgeIgnoresWallClockJump(t *testing.T) {
+	oldBase := mainThreadClockBase
+	oldElapsed := mainThreadLastHeartbeatElapsed.Load()
+	oldWall := mainThreadLastHeartbeatWall.Load()
+	t.Cleanup(func() {
+		mainThreadClockBase = oldBase
+		mainThreadLastHeartbeatElapsed.Store(oldElapsed)
+		mainThreadLastHeartbeatWall.Store(oldWall)
+	})
+
+	base := time.Now()
+	mainThreadClockBase = base
+	mainThreadLastHeartbeatElapsed.Store(int64(time.Second))
+	mainThreadLastHeartbeatWall.Store(base.Add(-time.Hour).UnixNano())
+
+	age, _, ok := mainThreadHeartbeatAge(base.Add(2 * time.Second))
+	if !ok {
+		t.Fatal("expected heartbeat age")
+	}
+	if age != time.Second {
+		t.Fatalf("age = %s, want monotonic elapsed 1s despite wall-clock jump", age)
+	}
+}
+
 func TestRecordMainThreadHangWritesPendingReportAndMetrics(t *testing.T) {
 	t.Cleanup(func() {
 		os.Remove(pendingCrashPath())

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -89,6 +89,8 @@ const METRIC_SIGNALS = [
   "updater_error",
   "compaction",
   "turns",
+  "desktop_hang",
+  "desktop_hang_age",
   "client_surface",
   "client_version",
   "settings_language",

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -175,6 +175,8 @@ const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
   updater_error: { en: "Updater errors", zh: "更新器错误" },
   compaction: { en: "Compactions", zh: "压缩" },
   turns: { en: "Turns", zh: "轮次" },
+  desktop_hang: { en: "Desktop hangs", zh: "桌面卡死" },
+  desktop_hang_age: { en: "Desktop hang age", zh: "桌面卡死时长" },
   client_surface: { en: "Client surface", zh: "客户端形态" },
   client_version: { en: "Client version", zh: "客户端版本" },
   settings_language: { en: "Settings: language", zh: "设置：语言" },
@@ -211,7 +213,18 @@ const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
   settings_bot_connection_approval: { en: "Bot: connection approval", zh: "机器人：连接审批" },
 };
 
-const AGENT_METRIC_SIGNALS = ["finish_reason", "empty_final", "provider_error", "cache_hit", "tool_error", "updater_error", "compaction", "turns"];
+const AGENT_METRIC_SIGNALS = [
+  "finish_reason",
+  "empty_final",
+  "provider_error",
+  "cache_hit",
+  "tool_error",
+  "updater_error",
+  "compaction",
+  "turns",
+  "desktop_hang",
+  "desktop_hang_age",
+];
 const DEFAULT_OPEN_SETTING_GROUPS = new Set(["Client", "Models", "Providers"]);
 
 const SETTINGS_METRIC_GROUPS: { en: string; zh: string; signals: string[] }[] = [
@@ -342,6 +355,12 @@ function healthLevel(kind: "cache" | "rate", value: number | null): "good" | "wa
   return "bad";
 }
 
+function countHealthLevel(value: number): "good" | "warn" | "bad" {
+  if (value <= 0) return "good";
+  if (value <= 2) return "warn";
+  return "bad";
+}
+
 function levelText(level: "good" | "warn" | "bad" | "unknown"): string {
   if (level === "good") return i18n("Good", "健康");
   if (level === "warn") return i18n("Watch", "关注");
@@ -372,6 +391,8 @@ function agentHealth(rows: MetricRow[], previousRows: MetricRow[]): string {
   if (!rows.length) return `<div class="empty">${i18n("No agent health metrics yet", "暂无运行健康指标")}</div>`;
   const cache = cacheHitRate(rows);
   const prevCache = cacheHitRate(previousRows);
+  const desktopHangs = sumMetric(rows, "desktop_hang");
+  const prevDesktopHangs = sumMetric(previousRows, "desktop_hang");
   const rateCard = (signal: string, en: string, zh: string) => {
     const value = ratioPer100(rows, signal);
     const prev = ratioPer100(previousRows, signal);
@@ -395,6 +416,13 @@ ${rateCard("provider_error", "Provider errors", "Provider 错误")}
 ${rateCard("tool_error", "Tool errors", "工具错误")}
 ${rateCard("empty_final", "Empty final guard", "空回复拦截")}
 ${rateCard("compaction", "Compactions", "压缩")}
+${healthCard(
+  { en: "Desktop hangs", zh: "桌面卡死" },
+  String(desktopHangs),
+  countHealthLevel(desktopHangs),
+  healthDeltaHTML(deltaLabel(desktopHangs, prevDesktopHangs)),
+  healthDetailHTML(rows, "desktop_hang_age"),
+)}
 </div>`;
 }
 
@@ -531,7 +559,10 @@ export function renderStats(
   const cache = cacheHitRate(agentMetrics);
   const providerRate = ratioPer100(agentMetrics, "provider_error");
   const toolRate = ratioPer100(agentMetrics, "tool_error");
-  const healthWatchCount = [healthLevel("cache", cache), healthLevel("rate", providerRate), healthLevel("rate", toolRate)].filter((v) => v === "warn" || v === "bad").length;
+  const desktopHangs = sumMetric(agentMetrics, "desktop_hang");
+  const healthWatchCount =
+    [healthLevel("cache", cache), healthLevel("rate", providerRate), healthLevel("rate", toolRate)].filter((v) => v === "warn" || v === "bad").length +
+    (desktopHangs > 0 ? 1 : 0);
   const modulePath = (module: StatsModule) => (module === "usage" ? "/stats" : `/stats/${module}`);
   const filterQS = (patch: Record<string, string>, module: StatsModule = activeModule) => {
     const params = new URLSearchParams();
@@ -578,7 +609,7 @@ ${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionSha
 ${statCard({ en: "Open reports", zh: "未处理报告" }, String(data.overview.openReports), i18n("needs triage", "需要分诊"), filterQS({}, "diagnostics"), overviewTone)}
 ${statCard({ en: "New in latest", zh: "最新新增" }, String(data.overview.newLatestReports), i18n("first seen on latest", "首次出现在最新版"), filterQS({}, "diagnostics"), data.overview.newLatestReports ? "warn" : "good")}
 ${statCard({ en: "Regressions", zh: "回归问题" }, String(data.overview.regressedReports), i18n("previously resolved", "曾经解决后复现"), filterQS({}, "diagnostics"), data.overview.regressedReports ? "bad" : "good")}
-${statCard({ en: "Agent health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", i18nHTML(`${pct(cache)} cache · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 provider`, `${pct(cache)} 缓存 · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 Provider`), filterQS({}, "health"), healthWatchCount ? "warn" : "good")}
+${statCard({ en: "Agent health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", i18nHTML(`${pct(cache)} cache · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 provider · ${desktopHangs} hangs`, `${pct(cache)} 缓存 · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 Provider · ${desktopHangs} 次卡死`), filterQS({}, "health"), healthWatchCount ? "warn" : "good")}
 </section>`;
   const pageOverview = activeModule === "usage" ? overview : "";
   const dashboardNav = `<nav class="site-nav" aria-label="Stats navigation">


### PR DESCRIPTION
## Summary
- Add a macOS main-thread heartbeat watchdog that writes a pending `performance` diagnostic when the AppKit/Wails main queue stops ticking.
- Record anonymous aggregate `desktop_hang` and `desktop_hang_age` metrics through the existing desktop metrics flush.
- Surface desktop hang counts and age buckets in the crash stats health dashboard.

## Root Cause
A macOS hang stackshot can show Reasonix's main thread parked in the Go runtime instead of `RunMainLoop`, leaving the AppKit event loop unable to service UI events. The previous diagnostics pipeline captured Go panics and frontend reports but had no native-shell hang signal.

## Impact
- Next-launch telemetry can upload one structured native watchdog report without overwriting a pending Go panic.
- Opt-in metrics users contribute aggregate hang counts to `/stats/health`.
- Non-macOS builds keep a no-op watchdog.

## Verification
- `go test ./...` from `desktop`
- `npm run typecheck` from `workers/crash-report`
- `git diff --check`