### PR TITLE
Stabilize desktop topic ordering metadata / 修复桌面会话排序元数据

### DIFF
--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -168,6 +168,60 @@ func TestEnsureBlankTabReusesIndexedTopicWithEmptyStub(t *testing.T) {
 	}
 }
 
+func TestEnsureBlankTabStoresCreatedAt(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	before := time.Now().UnixMilli()
+	meta, err := app.EnsureBlankTab("global", "")
+	after := time.Now().UnixMilli()
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+
+	createdAt := loadTopicCreatedAt("", meta.TopicID)
+	if createdAt < before || createdAt > after {
+		t.Fatalf("createdAt = %d, want between %d and %d", createdAt, before, after)
+	}
+
+	nodes := app.ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" || len(nodes[0].Children) != 1 {
+		t.Fatalf("project tree = %#v, want Global with one topic", nodes)
+	}
+	if got := nodes[0].Children[0].CreatedAt; got != createdAt {
+		t.Fatalf("project tree createdAt = %d, want %d", got, createdAt)
+	}
+}
+
+func TestEnsureBlankTabRepairsMissingCreatedAtForReusedTopic(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	const topicID = "topic_20260704-104018_deadbeef"
+	if err := setTopicTitleWithSource("", topicID, defaultTopicTitle, topicTitleSourceAuto); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := prependTopicInProjectsFile("", topicID, false); err != nil {
+		t.Fatalf("prepend topic: %v", err)
+	}
+	if got := loadTopicCreatedAt("", topicID); got != 0 {
+		t.Fatalf("createdAt before reuse = %d, want 0", got)
+	}
+
+	app := NewApp()
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.TopicID != topicID {
+		t.Fatalf("EnsureBlankTab topic = %q, want reused topic %q", meta.TopicID, topicID)
+	}
+
+	expected := time.Date(2026, 7, 4, 10, 40, 18, 0, time.UTC).UnixMilli()
+	if got := loadTopicCreatedAt("", topicID); got != expected {
+		t.Fatalf("repaired createdAt = %d, want %d", got, expected)
+	}
+}
+
 // EnsureBlankTab reuses an already-open project-scoped blank tab.
 
 func TestEnsureBlankTabCreatesOneBlankPerProject(t *testing.T) {

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   projectTreeReadActivityKey,
   projectTreeTopicHasUnreadActivity,
   projectTreeShouldRenderTopicActions,
+  projectTreeTopicMetaLine,
 } from "../components/ProjectTree";
 import type { ProjectNode } from "../lib/types";
 
@@ -26,6 +27,12 @@ function eq(a: unknown, b: unknown, label: string) {
 }
 
 console.log("\nproject tree runtime sessions");
+
+const testT = (key: string, vars?: Record<string, string | number>) => {
+  if (key === "history.turnOne") return `${vars?.n ?? 1} turn`;
+  if (key === "history.turnOther") return `${vars?.n ?? 0} turns`;
+  return key;
+};
 
 const tree: ProjectNode[] = [
   {
@@ -105,6 +112,29 @@ eq(
   }),
   { scope: "project", workspaceRoot: "/repo", topicId: "topic-project", sessionPath: undefined },
   "regular project topic still opens by topic",
+);
+
+eq(
+  projectTreeTopicMetaLine({
+    key: "global_topic_missing_time",
+    kind: "global_topic",
+    label: "Old empty topic",
+    topicId: "missing-time",
+  }, testT),
+  "projectTree.previously",
+  "topic with no turns and no timestamps renders previous-time fallback meta",
+);
+
+eq(
+  projectTreeTopicMetaLine({
+    key: "global_topic_recent",
+    kind: "global_topic",
+    label: "Recent blank topic",
+    topicId: "recent",
+    createdAt: Date.now(),
+  }, testT),
+  "projectTree.justNow",
+  "topic with a real recent timestamp still renders just-now meta",
 );
 
 const completedTopic: ProjectNode = {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -123,14 +123,18 @@ function topicIsActive(node: ProjectNode, activeScope?: string, activeWorkspaceR
   );
 }
 
-function topicMetaLine(node: ProjectNode, t: Translator, compact = false): string {
+export function projectTreeTopicMetaLine(node: ProjectNode, t: Translator, compact = false): string {
   const parts: string[] = [];
   const turns = node.turns ?? 0;
   if (turns > 0) parts.push(t(turns === 1 ? "history.turnOne" : "history.turnOther", { n: turns }));
   const activityAt = node.lastActivityAt || node.createdAt || 0;
   if (activityAt) parts.push(topicActivityLabel(activityAt, t, compact));
-  if (parts.length === 0) parts.push(t("projectTree.justNow"));
+  if (parts.length === 0) parts.push(t("projectTree.previously"));
   return parts.join(" · ");
+}
+
+function topicUnknownTimeLabel(node: ProjectNode, t: Translator): string {
+  return topicActivityAt(node) ? "" : t("projectTree.previously");
 }
 
 const topicStatusLabels: Record<ProjectTopicStatus, DictKey> = {
@@ -1050,8 +1054,10 @@ export function ProjectTree({
     const filtered = tree
       .map(filterNode)
       .filter((node): node is ProjectNode => node !== null);
-    return compactTopics ? arrangeWorkbenchTree(filtered, workbenchOrganizeMode, workbenchSortMode) : filtered;
-  }, [compactTopics, query, tree, timeFilter, workbenchOrganizeMode, workbenchSortMode]);
+    if (compactTopics) return arrangeWorkbenchTree(filtered, workbenchOrganizeMode, workbenchSortMode);
+    if (creationTopics) return arrangeWorkbenchTree(filtered, "project", "updated");
+    return filtered;
+  }, [compactTopics, creationTopics, query, tree, timeFilter, workbenchOrganizeMode, workbenchSortMode]);
 
   const workbenchTreeSections = useMemo<WorkbenchTreeSections>(() => {
     if (!compactTopics) return { pinned: [], projects: visibleTree };
@@ -1128,9 +1134,9 @@ export function ProjectTree({
       const label = (node.label || node.topicId || "Untitled").replace(/^●\s*/, "");
       const activityAt = node.lastActivityAt || node.createdAt || 0;
       const sideTimeVisible = compactTopics || creationTopics;
-      const timeLabel = sideTimeVisible && activityAt ? topicActivityLabel(activityAt, t, true) : "";
+      const timeLabel = sideTimeVisible ? (activityAt ? topicActivityLabel(activityAt, t, true) : topicUnknownTimeLabel(node, t)) : "";
       const exactTimeLabel = sideTimeVisible && activityAt ? topicActivityDateLabel(activityAt) : "";
-      const meta = topicMetaLine(node, t, compactTopics);
+      const meta = projectTreeTopicMetaLine(node, t, compactTopics);
       const status = topicStatus(node);
       const statusLabel = topicStatusLabel(node, t);
       const showStatusInSide = status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job";

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -757,6 +757,7 @@ export const en = {
   "projectTree.renameProjectWorkbench": "Rename project",
   "projectTree.projectHistory": "View project history",
   "projectTree.justNow": "just now",
+  "projectTree.previously": "previously",
   "projectTree.running": "responding",
   "projectTree.status.thinking": "thinking",
   "projectTree.status.streaming": "responding",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1486,6 +1486,7 @@ export const zhTW: Record<DictKey, string> = {
   "clearContext.done": "已清空當前上下文",
   "clearContext.failed": "清空當前上下文失敗",
   "projectTree.justNow": "剛剛",
+  "projectTree.previously": "之前",
   "projectTree.running": "輸出中",
   "projectTree.status.thinking": "思考中",
   "projectTree.status.streaming": "輸出中",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -758,6 +758,7 @@ export const zh: Record<DictKey, string> = {
   "projectTree.renameProjectWorkbench": "重命名项目",
   "projectTree.projectHistory": "查看项目历史",
   "projectTree.justNow": "刚刚",
+  "projectTree.previously": "之前",
   "projectTree.running": "输出中",
   "projectTree.status.thinking": "思考中",
   "projectTree.status.streaming": "输出中",

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1593,6 +1593,13 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		// Reuse a previously-indexed but unused blank topic instead of
 		// creating a new one.  Build it inline (not via OpenProjectTab /
 		// OpenGlobalTab) so it inherits settings from the active tab.
+		if loadTopicCreatedAt(topicTitleRoot(scope, workspaceRoot), topicID) <= 0 {
+			createdAt := topicIDCreatedAt(topicID)
+			if createdAt <= 0 {
+				createdAt = time.Now().UnixMilli()
+			}
+			_ = setTopicCreatedAt(topicTitleRoot(scope, workspaceRoot), topicID, createdAt)
+		}
 		tabID := a.newUniqueTabIDLocked()
 		topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
 		created = &WorkspaceTab{
@@ -1632,7 +1639,12 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 
 	topicID := newTopicID()
 	topicTitle := defaultTopicTitle
+	createdAt := time.Now().UnixMilli()
 	if err := setTopicTitleWithSource(workspaceRoot, topicID, topicTitle, topicTitleSourceAuto); err != nil {
+		a.mu.Unlock()
+		return TabMeta{}, err
+	}
+	if err := setTopicCreatedAt(workspaceRoot, topicID, createdAt); err != nil {
 		a.mu.Unlock()
 		return TabMeta{}, err
 	}
@@ -4184,6 +4196,33 @@ func loadTopicCreatedAt(workspaceRoot, topicID string) int64 {
 	return loadTopicCreatedAts(workspaceRoot)[topicID]
 }
 
+func topicIDCreatedAt(topicID string) int64 {
+	topicID = strings.TrimSpace(topicID)
+	for _, prefix := range []string{"topic_", "legacy_"} {
+		if !strings.HasPrefix(topicID, prefix) {
+			continue
+		}
+		stamp := strings.TrimPrefix(topicID, prefix)
+		if len(stamp) < len("20060102-150405") {
+			continue
+		}
+		stamp = stamp[:len("20060102-150405")]
+		t, err := time.ParseInLocation("20060102-150405", stamp, time.UTC)
+		if err != nil {
+			continue
+		}
+		return t.UnixMilli()
+	}
+	return 0
+}
+
+func topicCreatedAtForTree(createdAts map[string]int64, topicID string) int64 {
+	if createdAt := createdAts[topicID]; createdAt > 0 {
+		return createdAt
+	}
+	return topicIDCreatedAt(topicID)
+}
+
 func topicTitleForTab(scope, workspaceRoot, topicID string) string {
 	titleRoot := topicTitleRoot(scope, workspaceRoot)
 	if title := strings.TrimSpace(loadTopicTitle(titleRoot, topicID)); title != "" {
@@ -5675,7 +5714,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 				TopicID:          id,
 				ProjectColor:     globalColor,
 				Turns:            summary.turns,
-				CreatedAt:        globalCreatedMap[id],
+				CreatedAt:        topicCreatedAtForTree(globalCreatedMap, id),
 				LastActivityAt:   summary.lastActivityAt,
 				Open:             open,
 				Running:          running,
@@ -5754,7 +5793,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 				TopicID:          tid,
 				ProjectColor:     p.Color,
 				Turns:            summary.turns,
-				CreatedAt:        createdMap[tid],
+				CreatedAt:        topicCreatedAtForTree(createdMap, tid),
 				LastActivityAt:   summary.lastActivityAt,
 				Open:             open,
 				Running:          running,

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1170,6 +1170,27 @@ func TestCreateTopicDefaultsToAutoNewSessionTitle(t *testing.T) {
 	}
 }
 
+func TestListProjectTreeFallsBackToTopicIDCreatedAt(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	const topicID = "legacy_20260606-114914_2276f13fd87c"
+	if err := setTopicTitleWithSource("", topicID, "你好，你是谁", topicTitleSourceManual); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := prependTopicInProjectsFile("", topicID, false); err != nil {
+		t.Fatalf("prepend topic: %v", err)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" || len(nodes[0].Children) != 1 {
+		t.Fatalf("project tree = %#v, want Global with one topic", nodes)
+	}
+	expected := time.Date(2026, 6, 6, 11, 49, 14, 0, time.UTC).UnixMilli()
+	if got := nodes[0].Children[0].CreatedAt; got != expected {
+		t.Fatalf("project tree createdAt = %d, want %d", got, expected)
+	}
+}
+
 func TestCreateTopicAppearsFirstInProjectTree(t *testing.T) {
 	isolateDesktopUserDirs(t)
 


### PR DESCRIPTION
## Summary
- Persist `createdAt` metadata for newly-created and reused blank desktop topics so future empty sessions sort consistently.
- Derive display `createdAt` from timestamp-shaped legacy topic IDs without mutating existing metadata files.
- Show unknown-time legacy empty topics as `previously` / `之前` instead of `just now` / `刚刚`, and sort creation-sidebar topics by recent activity.

## Verification
- `go test . -run 'TestEnsureBlankTabStoresCreatedAt|TestEnsureBlankTabRepairsMissingCreatedAtForReusedTopic|TestListProjectTreeFallsBackToTopicIDCreatedAt|TestCreateTopicDefaultsToAutoNewSessionTitle|TestCreateGlobalTopicAppearsFirstInProjectTree' -count=1` from `desktop`
- `pnpm exec tsx src/__tests__/project-tree-runtime.test.ts` from `desktop/frontend`
- `pnpm exec tsc --noEmit -p tsconfig.test.json` from `desktop/frontend`
- `git diff --check origin/main-v2...HEAD`