### PR TITLE
Reduce desktop hydration metadata lag / 降低桌面端 hydrate 元数据卡顿

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4791,7 +4791,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 		WorkspaceRoot:     cwd,
 		WorkspaceName:     tabWorkspaceName(tab, cwd),
 		WorkspacePath:     cwd,
-		GitBranch:         workspaceGitBranch(cwd),
+		GitBranch:         workspaceGitBranchForMeta(cwd),
 		ImageInputEnabled: a.imageInputEnabledForTab(tabID),
 		AutoApproveTools:  autoApproveTools,
 		Bypass:            autoApproveTools,

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -133,9 +133,12 @@ const tabD = tabMeta("tab-d");
 const tabE = tabMeta("tab-e");
 const tabF = tabMeta("tab-f");
 const tabG = tabMeta("tab-g");
+const tabH = tabMeta("tab-h");
 let backendActiveId = "tab-a";
 const historyB = deferred<HistoryMessage[]>();
 const historyD = deferred<HistoryMessage[]>();
+let metaH = deferred<Meta>();
+let historyH = deferred<HistoryMessage[]>();
 const contextDGate = deferred<ContextInfo>();
 const setActiveBGate = deferred<void>();
 const setActiveEGate = deferred<void>();
@@ -144,12 +147,15 @@ const submitTabCGate = deferred<void>();
 const historyCalls: string[] = [];
 const cancelCalls: string[] = [];
 let contextDCalls = 0;
+let metaHCalls = 0;
 let holdNextContextForD = false;
+let holdNextMetaForH = false;
+let holdNextHistoryForH = false;
 let setActiveCalls = 0;
 let newSessionCalls = 0;
 let failSetActiveFor = "";
 const runningTabs = new Set<string>();
-const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG].map((tab) => [tab.id, tab]));
+const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG, tabH].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
 const readyHandlers: Array<(tabId?: string) => void> = [];
 
@@ -172,7 +178,14 @@ window.go = {
   main: {
     App: {
       ListTabs: async () => currentTabs(),
-      MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
+      MetaForTab: async (tabID: string) => {
+        if (tabID === "tab-h" && holdNextMetaForH) {
+          metaHCalls += 1;
+          holdNextMetaForH = false;
+          return metaH.promise;
+        }
+        return metaFor(tabsById.get(tabID) ?? tabA);
+      },
       ContextUsageForTab: async (tabID: string) => {
         if (tabID === "tab-d" && holdNextContextForD) {
           contextDCalls += 1;
@@ -191,6 +204,12 @@ window.go = {
         if (tabID === "tab-b") return historyB.promise;
         if (tabID === "tab-d") return historyD.promise;
         if (tabID === "tab-e") return [userMessage("fork E")];
+        if (tabID === "tab-g") return [userMessage("history G")];
+        if (tabID === "tab-h" && holdNextHistoryForH) {
+          holdNextHistoryForH = false;
+          return historyH.promise;
+        }
+        if (tabID === "tab-h") return [userMessage("history H")];
         return [userMessage("cached A")];
       },
       HistoryPageForTab: async (tabID: string) => {
@@ -198,9 +217,15 @@ window.go = {
         return { messages, startTurn: 0, endTurn: messages.filter((message) => message.role === "user").length, totalTurns: messages.filter((message) => message.role === "user").length, hasOlder: false };
       },
       HistoryCheckpointTurnsForTab: async () => [],
-      OpenProjectTab: async () => {
-        backendActiveId = "tab-d";
-        return { ...(tabsById.get("tab-d") ?? tabD), active: true };
+      OpenProjectTab: async (workspaceRoot: string, topicId: string) => {
+        const target = Array.from(tabsById.values()).find((tab) => tab.workspaceRoot === workspaceRoot && tab.topicId === topicId) ?? tabD;
+        backendActiveId = target.id;
+        return { ...target, active: true };
+      },
+      ActivateTopic: async (_scope: string, workspaceRoot: string, topicId: string) => {
+        const target = Array.from(tabsById.values()).find((tab) => tab.workspaceRoot === workspaceRoot && tab.topicId === topicId) ?? tabG;
+        backendActiveId = target.id;
+        return { ...target, active: true };
       },
       NewSession: async () => {
         newSessionCalls += 1;
@@ -508,6 +533,70 @@ await act(async () => {
   await flushPromises();
 });
 eq(historyCalls.length, historyCallsBeforeReboundD + 1, "rebound topic reloads history when session path changes");
+
+metaH = deferred<Meta>();
+holdNextMetaForH = true;
+const historyCallsBeforeSlowMeta = historyCalls.length;
+await act(async () => {
+  await controller?.openProjectTab(tabH.workspaceRoot, tabH.topicId || "");
+  await flushPromises();
+});
+await waitFor("slow meta tab hydrates history", () =>
+  controller?.activeTabId === "tab-h" &&
+  controller.state.hydrating === false &&
+  (controller.state.items.some((item) => item.kind === "user" && item.text === "history H") ?? false) &&
+  metaHCalls === 1
+);
+eq(historyCalls.length, historyCallsBeforeSlowMeta + 1, "slow MetaForTab does not delay the history request");
+eq(controller?.state.meta?.label, "model-tab-h", "slow MetaForTab leaves optimistic metadata visible while history hydrates");
+await act(async () => {
+  metaH.resolve({ ...metaFor(tabH), label: "fresh-model-tab-h" });
+  await metaH.promise;
+  await flushPromises();
+});
+await waitFor("slow meta refresh applies", () => controller?.state.meta?.label === "fresh-model-tab-h");
+
+metaH = deferred<Meta>();
+const metaHCallsBeforeStale = metaHCalls;
+holdNextMetaForH = true;
+await act(async () => {
+  await controller?.openProjectTab(tabH.workspaceRoot, tabH.topicId || "");
+  await flushPromises();
+});
+await waitFor("slow meta pending before single-surface navigation", () => metaHCalls === metaHCallsBeforeStale + 1);
+await act(async () => {
+  await controller?.activateTopic("project", tabG.workspaceRoot, tabG.topicId || "");
+  await flushPromises();
+});
+await waitFor("single-surface activation replaces visible tab", () =>
+  controller?.activeTabId === "tab-g" &&
+  (controller.state.items.some((item) => item.kind === "user" && item.text === "history G") ?? false)
+);
+await act(async () => {
+  metaH.resolve({ ...metaFor(tabH), label: "stale-model-tab-h" });
+  await metaH.promise;
+  await flushPromises();
+});
+historyH = deferred<HistoryMessage[]>();
+holdNextHistoryForH = true;
+await act(async () => {
+  await controller?.openProjectTab(tabH.workspaceRoot, tabH.topicId || "");
+  await flushPromises();
+});
+await waitFor("reopened tab-h treats stale late meta as discarded", () =>
+  controller?.activeTabId === "tab-h" &&
+  controller.state.hydrating === true &&
+  (controller.state.hydratePlaceholderItems?.some((item) => item.kind === "user" && item.text === "history G") ?? false)
+);
+await act(async () => {
+  historyH.resolve([userMessage("history H after stale meta")]);
+  await historyH.promise;
+  await flushPromises();
+});
+await waitFor("reopened tab-h finishes after stale meta discard", () =>
+  controller?.state.hydrating === false &&
+  (controller.state.items.some((item) => item.kind === "user" && item.text === "history H after stale meta") ?? false)
+);
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1073,23 +1073,31 @@ export function useController() {
       if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
 
       const stillCurrent = () => sessionLoadCurrent(tabId, seq);
+      const requiresVisibleTab = reason === "startup" || reason === "switch-tab" || reason === "open-topic";
+      const stillVisible = () => !requiresVisibleTab || activeTabIdRef.current === tabId;
       const noteFailure = (label: string, err: unknown) => {
         addBreadcrumb("tab.hydrate", `${label} failed ${tabId}: ${errorMessage(err)}`);
       };
 
-      const historyStartedAt = Date.now();
+      const loadTimed = async <T,>(label: string, load: () => Promise<T>): Promise<T | undefined> => {
+        const startedAt = Date.now();
+        addBreadcrumb("tab.hydrate", `${label} start ${reason} ${tabId}`);
+        try {
+          const value = await load();
+          addBreadcrumb("tab.hydrate", `${label} done ${reason} ${tabId} ms=${Date.now() - startedAt}`);
+          return value;
+        } catch (err) {
+          noteFailure(label, err);
+          return undefined;
+        }
+      };
 
-      // Phase 1: dispatch fast metadata immediately so the transcript can render
-      // without waiting for slower ancillary calls (e.g. BalanceForTab network).
-      const [meta, historyPage] = await Promise.all([
-        app.MetaForTab(tabId).catch((err) => { noteFailure("meta", err); return undefined; }),
-        skipHistory
-          ? Promise.resolve(undefined)
-          : app.HistoryPageForTab(tabId, 0, HISTORY_PAGE_TURNS).catch((err) => { noteFailure("history", err); return undefined; }),
-      ]);
+      const historyStartedAt = Date.now();
+      const historyPage = skipHistory
+        ? undefined
+        : await loadTimed("history", () => app.HistoryPageForTab(tabId, 0, HISTORY_PAGE_TURNS));
 
       if (!stillCurrent()) return;
-      if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
       if (!skipHistory && historyPage !== undefined) {
         const messages = asArray(historyPage.messages);
         dispatchTo(tabId, { type: "history_page", page: historyPage, mode: "replace" });
@@ -1120,21 +1128,20 @@ export function useController() {
       // in a loading state.
       await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
       if (!stillCurrent()) return;
-      if (activeTabIdRef.current !== tabId && (reason === "startup" || reason === "switch-tab" || reason === "open-topic")) {
+      if (!stillVisible()) {
         addBreadcrumb("tab.hydrate", `ancillary skipped inactive ${reason} ${tabId}`);
         return;
       }
+      const meta = await loadTimed("meta", () => app.MetaForTab(tabId));
+      if (!stillCurrent()) return;
+      if (!stillVisible()) {
+        addBreadcrumb("tab.hydrate", `meta ignored inactive ${reason} ${tabId}`);
+        return;
+      }
+      if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
       const ancillaryStartedAt = Date.now();
       const loadAncillary = async <T,>(label: string, load: () => Promise<T>): Promise<T | undefined> => {
-        const startedAt = Date.now();
-        try {
-          const value = await load();
-          addBreadcrumb("tab.hydrate", `ancillary ${label} ${reason} ${tabId} ms=${Date.now() - startedAt}`);
-          return value;
-        } catch (err) {
-          noteFailure(label, err);
-          return undefined;
-        }
+        return loadTimed(`ancillary ${label}`, load);
       };
       const [effort, jobs, context] = await Promise.all([
         loadAncillary("effort", () => app.EffortForTab(tabId)),
@@ -1142,22 +1149,30 @@ export function useController() {
         loadAncillary("context", () => app.ContextUsageForTab(tabId)),
       ]);
       if (!stillCurrent()) return;
+      if (!stillVisible()) {
+        addBreadcrumb("tab.hydrate", `ancillary ignored inactive ${reason} ${tabId}`);
+        return;
+      }
       if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
       if (jobs !== undefined) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
       if (context !== undefined) dispatchTo(tabId, { type: "context", context });
       await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
       if (!stillCurrent()) return;
-      if (activeTabIdRef.current !== tabId && (reason === "startup" || reason === "switch-tab" || reason === "open-topic")) {
+      if (!stillVisible()) {
         addBreadcrumb("tab.hydrate", `checkpoints skipped inactive ${reason} ${tabId}`);
         return;
       }
       const checkpoints = await loadAncillary("checkpoints", () => app.CheckpointsForTab(tabId));
       if (!stillCurrent()) return;
+      if (!stillVisible()) {
+        addBreadcrumb("tab.hydrate", `checkpoints ignored inactive ${reason} ${tabId}`);
+        return;
+      }
       if (checkpoints !== undefined) dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
       addBreadcrumb("tab.hydrate", `ancillary ${reason} ${tabId} ms=${Date.now() - ancillaryStartedAt}`);
       app.BalanceForTab(tabId)
         .then((balance) => {
-          if (sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "balance", balance });
+          if (sessionLoadCurrent(tabId, seq) && stillVisible()) dispatchTo(tabId, { type: "balance", balance });
         })
         .catch((err) => { noteFailure("balance", err); });
     })();

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1206,7 +1206,7 @@ type TabMeta struct {
 
 func enrichTabMeta(meta TabMeta) TabMeta {
 	if meta.Active {
-		meta.GitBranch = workspaceGitBranch(meta.WorkspaceRoot)
+		meta.GitBranch = workspaceGitBranchForMeta(meta.WorkspaceRoot)
 	}
 	return meta
 }
@@ -1214,7 +1214,7 @@ func enrichTabMeta(meta TabMeta) TabMeta {
 func enrichTabMetas(metas []TabMeta) []TabMeta {
 	for i := range metas {
 		if metas[i].Active {
-			metas[i].GitBranch = workspaceGitBranch(metas[i].WorkspaceRoot)
+			metas[i].GitBranch = workspaceGitBranchForMeta(metas[i].WorkspaceRoot)
 		}
 	}
 	return metas

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/control"
@@ -25,6 +26,18 @@ type workspaceChangeAccumulator struct {
 	hasSession bool
 	hasGit     bool
 }
+
+const workspaceGitBranchCacheTTL = 2 * time.Second
+
+type workspaceGitBranchCacheEntry struct {
+	branch  string
+	expires time.Time
+}
+
+var workspaceGitBranchCache = struct {
+	sync.Mutex
+	entries map[string]workspaceGitBranchCacheEntry
+}{entries: map[string]workspaceGitBranchCacheEntry{}}
 
 func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
 	out := WorkspaceChangesView{Files: []WorkspaceChangeView{}, GitAvailable: true}
@@ -223,6 +236,35 @@ func workspaceRelPathFromGitStatus(repoRoot, base, path string) string {
 		path = filepath.Join(repoRoot, filepath.FromSlash(path))
 	}
 	return normalizeWorkspaceRelPath(base, path)
+}
+
+// workspaceGitBranchForMeta is the cached variant used by high-frequency UI
+// metadata refreshes. Workflows that need an immediate git read, such as
+// WorkspaceChanges, should call workspaceGitBranch directly.
+func workspaceGitBranchForMeta(base string) string {
+	key := filepath.Clean(base)
+	now := time.Now()
+	workspaceGitBranchCache.Lock()
+	if cached, ok := workspaceGitBranchCache.entries[key]; ok && now.Before(cached.expires) {
+		workspaceGitBranchCache.Unlock()
+		return cached.branch
+	}
+	workspaceGitBranchCache.Unlock()
+
+	branch := workspaceGitBranch(base)
+
+	storeNow := time.Now()
+	workspaceGitBranchCache.Lock()
+	if len(workspaceGitBranchCache.entries) > 256 {
+		for k, cached := range workspaceGitBranchCache.entries {
+			if storeNow.After(cached.expires) {
+				delete(workspaceGitBranchCache.entries, k)
+			}
+		}
+	}
+	workspaceGitBranchCache.entries[key] = workspaceGitBranchCacheEntry{branch: branch, expires: storeNow.Add(workspaceGitBranchCacheTTL)}
+	workspaceGitBranchCache.Unlock()
+	return branch
 }
 
 // workspaceGitBranch returns the current git branch name for the repo rooted

--- a/desktop/workspace_changes_test.go
+++ b/desktop/workspace_changes_test.go
@@ -45,6 +45,36 @@ func TestWorkspaceGitBranch(t *testing.T) {
 	}
 }
 
+func TestWorkspaceGitBranchReflectsImmediateCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	repo := t.TempDir()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "init")
+	runGit(t, "checkout", "-b", "feature/one")
+
+	if got := workspaceGitBranch(repo); got != "feature/one" {
+		t.Fatalf("branch before checkout = %q, want feature/one", got)
+	}
+	runGit(t, "checkout", "-b", "feature/two")
+	if got := workspaceGitBranch(repo); got != "feature/two" {
+		t.Fatalf("branch after checkout = %q, want feature/two", got)
+	}
+}
+
 func TestWorkspaceGitBranchDetachedHead(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")


### PR DESCRIPTION
Refs #5909

## Summary
- Let transcript/history hydration complete before slower MetaForTab and ancillary Wails calls, with timed breadcrumbs for each hydration phase.
- Ignore phase-2 metadata, ancillary, checkpoint, and balance late results once the visible tab changes, preventing stale single-surface hydrations from recreating pruned tab state.
- Cache git branch lookups only for high-frequency metadata refreshes while keeping WorkspaceChanges on an uncached git read.

## Verification
- `corepack pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- `(cd desktop && go test . -count=1 -run '^(TestWorkspaceGitBranch|TestWorkspaceGitBranchReflectsImmediateCheckout|TestWorkspaceGitBranchDetachedHead|TestWorkspaceGitBranchNonGitDirectory|TestMetaForTabReportsWorkspaceGitBranch|TestMetaForTabLeavesGitBranchEmptyOutsideGit|TestWorkspaceChangesGitBranchDetachedHead|TestWorkspaceChanges)$')`
- `git diff --check origin/main-v2...HEAD`

Not run locally: full frontend `tsc --noEmit`; the local command did not complete in this environment.
