### PR TITLE
fix(openai): support vLLM reasoning field in stream responses

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -605,9 +605,13 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 
 		delta := sr.Choices[0].Delta
-		if delta.ReasoningContent != "" {
+		reasoning := delta.ReasoningContent
+		if reasoning == "" {
+			reasoning = delta.Reasoning
+		}
+		if reasoning != "" {
 			emitted = true
-			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: delta.ReasoningContent}) {
+			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: reasoning}) {
 				return emitted, ctx.Err()
 			}
 		}
@@ -834,7 +838,8 @@ type streamResponse struct {
 	Choices []struct {
 		Delta struct {
 			Content          string         `json:"content"`
-			ReasoningContent string         `json:"reasoning_content"`
+			ReasoningContent string         `json:"reasoning_content"` // DeepSeek / OpenAI
+			Reasoning        string         `json:"reasoning"`         // vLLM fallback
 			ToolCalls        []chatToolCall `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason *string `json:"finish_reason"`

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1108,3 +1108,85 @@ func TestBuildRequestDefaultsEmptyToolParameters(t *testing.T) {
 		t.Fatalf("nil parameters should default to %s, got %s in %s", want, got, body)
 	}
 }
+
+// TestStreamReadsVLLMReasoningField verifies that vLLM-style reasoning chunks
+// (using the "reasoning" field instead of "reasoning_content") are correctly
+// parsed and emitted as ChunkReasoning.
+func TestStreamReadsVLLMReasoningField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w,
+			"data: {\"choices\":[{\"delta\":{\"reasoning\":\"let me think\"}}]}\n\n"+
+				"data: {\"choices\":[{\"delta\":{\"content\":\"the answer\"}}]}\n\n"+
+				"data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "vllm", BaseURL: srv.URL, Model: "qwen3.6-35b", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var reasoning, text string
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkReasoning:
+			reasoning += chunk.Text
+		case provider.ChunkText:
+			text += chunk.Text
+		case provider.ChunkError:
+			t.Fatalf("unexpected error: %v", chunk.Err)
+		}
+	}
+	if reasoning != "let me think" {
+		t.Errorf("reasoning = %q, want %q", reasoning, "let me think")
+	}
+	if text != "the answer" {
+		t.Errorf("text = %q, want %q", text, "the answer")
+	}
+}
+
+// TestStreamReasoningContentTakesPrecedence verifies that when both
+// "reasoning_content" and "reasoning" are present in the same delta,
+// the standard "reasoning_content" field is used (DeepSeek/OpenAI take
+// priority over vLLM's variant).
+func TestStreamReasoningContentTakesPrecedence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w,
+			"data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"standard\",\"reasoning\":\"vllm\"}}]}\n\n"+
+				"data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-reasoner", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var reasoning string
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkReasoning {
+			reasoning += chunk.Text
+		}
+	}
+	if reasoning != "standard" {
+		t.Errorf("reasoning = %q, want %q (reasoning_content should take precedence)", reasoning, "standard")
+	}
+}


### PR DESCRIPTION
<img width="1886" height="828" alt="image" src="https://github.com/user-attachments/assets/5b6d5539-77a4-48e5-a96d-aae309834e8a" />

## Summary

- 支持 vLLM 在流式响应中使用 `reasoning` 字段名作为 `reasoning_content` 的 fallback
- vLLM 将思考内容放在 `reasoning` 字段下返回，而 Reasonix 只解析了 `reasoning_content`，导致思考过程被静默丢弃
- 当两个字段同时存在时，优先使用 `reasoning_content`（DeepSeek / OpenAI 标准格式）

## Verification

- 新增 `TestStreamReadsVLLMReasoningField` — 验证 vLLM 的 reasoning 字段能被正确解析为 ChunkReasoning
- 新增 `TestStreamReasoningContentTakesPrecedence` — 验证两字段同时存在时优先使用标准字段
- `internal/provider/openai` 全部测试通过，`make build` 编译成功，`go vet` 无警告

## Cache impact

Cache-impact: none — 仅修改响应解析逻辑，不涉及请求构造或系统提示词
Cache-guard: N/A
System-prompt-review: N/A

Closes #5901