### PR TITLE
Add LongCat provider presets / 新增 LongCat 供应商预设

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -4728,6 +4728,10 @@ function providerTemplateConflictProviderName(choice: ProviderTemplateChoice): s
 
 function providerPresetDescription(preset: ProviderPresetView, t: ReturnType<typeof useT>): string {
   switch (preset.id) {
+    case "longcat-openai":
+      return t("settings.addProvider.preset.longcatOpenAIDesc");
+    case "longcat-anthropic":
+      return t("settings.addProvider.preset.longcatAnthropicDesc");
     case "kimi-cn":
       return t("settings.addProvider.preset.kimiCnDesc");
     case "kimi-global":

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -766,6 +766,7 @@ function mockPreset(id: string, label: string, description: string, keyEnv: stri
 }
 
 const mockKimiAPIModels = ["kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5"];
+const mockLongCatModels = ["LongCat-2.0"];
 const mockMiMoV25Models = ["mimo-v2.5-pro", "mimo-v2.5"];
 const mockMiniMaxModels = ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"];
 const mockGLMAPIModels = ["glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"];
@@ -784,6 +785,8 @@ const mockVercelModels = ["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-
 const mockOllamaCloudModels = ["glm-5.2", "kimi-k2.7-code", "deepseek-v4-pro", "deepseek-v4-flash", "minimax-m3", "nemotron-3-nano:30b", "qwen3-coder-next"];
 
 const mockProviderPresetTemplates: MockProviderPresetTemplate[] = [
+  mockPreset("longcat-openai", "LongCat OpenAI", "LongCat Platform OpenAI-compatible endpoint for LongCat-2.0.", "LONGCAT_API_KEY", mockProviderTemplate({ name: "longcat-openai", kind: "openai", baseUrl: "https://api.longcat.chat/openai/v1", modelsUrl: "https://api.longcat.chat/openai/v1/models", models: mockLongCatModels, default: "LongCat-2.0", apiKeyEnv: "LONGCAT_API_KEY", contextWindow: 131072, thinking: "enabled", supportedEfforts: ["enabled", "disabled"], defaultEffort: "enabled" })),
+  mockPreset("longcat-anthropic", "LongCat Anthropic", "LongCat Platform Anthropic-compatible Messages endpoint for LongCat-2.0.", "LONGCAT_API_KEY", mockProviderTemplate({ name: "longcat-anthropic", kind: "anthropic", baseUrl: "https://api.longcat.chat/anthropic", modelsUrl: "https://api.longcat.chat/anthropic/v1/models", models: mockLongCatModels, default: "LongCat-2.0", apiKeyEnv: "LONGCAT_API_KEY", authHeader: true, contextWindow: 131072, thinking: "enabled", supportedEfforts: ["enabled", "disabled"], defaultEffort: "enabled" })),
   mockPreset("kimi-cn", "Kimi CN API", "Moonshot Kimi China OpenAI-compatible API.", "KIMI_API_KEY", mockProviderTemplate({ name: "kimi-cn", kind: "openai", baseUrl: "https://api.moonshot.cn/v1", models: mockKimiAPIModels, visionModels: mockKimiAPIModels, default: "kimi-k2.7-code", apiKeyEnv: "KIMI_API_KEY", balanceUrl: "https://api.moonshot.cn/v1/users/me/balance", contextWindow: 262144, reasoningProtocol: "none" })),
   mockPreset("kimi-global", "Kimi Global API", "Moonshot Kimi international OpenAI-compatible API.", "MOONSHOT_API_KEY", mockProviderTemplate({ name: "kimi-global", kind: "openai", baseUrl: "https://api.moonshot.ai/v1", models: mockKimiAPIModels, visionModels: mockKimiAPIModels, default: "kimi-k2.7-code", apiKeyEnv: "MOONSHOT_API_KEY", balanceUrl: "https://api.moonshot.ai/v1/users/me/balance", contextWindow: 262144, reasoningProtocol: "none" })),
   mockPreset("kimi-coding-plan", "Kimi Coding Plan", "Kimi Coding Plan via its dedicated Anthropic-compatible endpoint.", "KIMI_CODING_API_KEY", mockProviderTemplate({ name: "kimi-coding-plan", kind: "anthropic", baseUrl: "https://api.kimi.com/coding/", models: ["kimi-for-coding"], visionModels: ["kimi-for-coding"], default: "kimi-for-coding", apiKeyEnv: "KIMI_CODING_API_KEY", headers: { "User-Agent": "claude-code/0.1.0" }, thinking: "adaptive", contextWindow: 262144 })),
@@ -826,7 +829,7 @@ const mockProviderPresetTemplates: MockProviderPresetTemplate[] = [
 ];
 
 function mockProviderPresetViews(): ProviderPresetView[] {
-  return mockProviderPresetTemplates.map((template) => ({
+  return [...mockProviderPresetTemplates].sort((a, b) => mockProviderPresetDisplayRank(a.id) - mockProviderPresetDisplayRank(b.id)).map((template) => ({
     id: template.id,
     label: template.label,
     description: template.description,
@@ -840,6 +843,14 @@ function mockProviderPresetViews(): ProviderPresetView[] {
     requiresKey: true,
     configured: false,
   }));
+}
+
+function mockProviderPresetDisplayRank(id: string): number {
+  if (id === "glm-cn" || id === "zai-global" || id.startsWith("glm-coding-plan-") || id.startsWith("zai-coding-plan-")) return 0;
+  if (id.startsWith("longcat-")) return 1;
+  if (id.startsWith("kimi-")) return 2;
+  if (id.startsWith("minimax-")) return 3;
+  return 4;
 }
 
 function cloneMockProviderTemplate(id: string, key: string): ProviderView | undefined {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1562,6 +1562,8 @@ export const en = {
   "settings.addProvider.customHint": "Use this for proxies, aggregators, or other OpenAI-compatible services.",
   "settings.addProvider.official.deepseek": "DeepSeek Official",
   "settings.addProvider.official.deepseekDesc": "Official API key access with DeepSeek V4 Flash / Pro.",
+  "settings.addProvider.preset.longcatOpenAIDesc": "LongCat Platform OpenAI-compatible endpoint with LongCat-2.0 default.",
+  "settings.addProvider.preset.longcatAnthropicDesc": "LongCat Platform Anthropic-compatible Messages endpoint using Bearer auth.",
   "settings.addProvider.preset.kimiCnDesc": "Kimi China API via Moonshot CN endpoint with K2 vision models.",
   "settings.addProvider.preset.kimiGlobalDesc": "Kimi international API via Moonshot global endpoint with K2 vision models.",
   "settings.addProvider.preset.kimiCodingPlanDesc": "Kimi Coding Plan via the dedicated Anthropic-compatible endpoint; not a CN/Global variant.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -970,6 +970,8 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.customHint": "適合代理、聚合平台或其它 OpenAI-compatible 服務。",
   "settings.addProvider.official.deepseek": "DeepSeek 官方",
   "settings.addProvider.official.deepseekDesc": "官方 API Key 接入，可用 DeepSeek V4 Flash / Pro。",
+  "settings.addProvider.preset.longcatOpenAIDesc": "LongCat 開放平台 OpenAI-compatible 端點，預設 LongCat-2.0。",
+  "settings.addProvider.preset.longcatAnthropicDesc": "LongCat 開放平台 Anthropic-compatible Messages 端點，使用 Bearer 認證。",
   "settings.addProvider.preset.kimiCnDesc": "Kimi 中國 API，走 Moonshot CN 端點，預置 K2 視覺模型。",
   "settings.addProvider.preset.kimiGlobalDesc": "Kimi 國際 API，走 Moonshot global 端點，預置 K2 視覺模型。",
   "settings.addProvider.preset.kimiCodingPlanDesc": "Kimi Coding Plan，走獨立 Anthropic-compatible 端點，不歸屬 CN/Global。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1564,6 +1564,8 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.customHint": "适合代理、聚合平台或其它 OpenAI-compatible 服务。",
   "settings.addProvider.official.deepseek": "DeepSeek 官方",
   "settings.addProvider.official.deepseekDesc": "官方 API Key 接入，可用 DeepSeek V4 Flash / Pro。",
+  "settings.addProvider.preset.longcatOpenAIDesc": "LongCat 开放平台 OpenAI-compatible 端点，默认 LongCat-2.0。",
+  "settings.addProvider.preset.longcatAnthropicDesc": "LongCat 开放平台 Anthropic-compatible Messages 端点，使用 Bearer 认证。",
   "settings.addProvider.preset.kimiCnDesc": "Kimi 国内 API，走 Moonshot CN 端点，预置 K2 视觉模型。",
   "settings.addProvider.preset.kimiGlobalDesc": "Kimi 国际 API，走 Moonshot global 端点，预置 K2 视觉模型。",
   "settings.addProvider.preset.kimiCodingPlanDesc": "Kimi Coding Plan，走独立 Anthropic-compatible 端点，不归属 CN/Global。",

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -81,6 +81,10 @@ func EffortCapabilityForEntry(e *ProviderEntry) EffortCapability {
 		// thinking on out of the box; "auto" means "don't override the model
 		// default" (== enabled for GLM).
 		return EffortCapability{Supported: true, Levels: []string{"auto", "enabled", "disabled"}, Default: "enabled"}
+	case isLongCatEntry(e):
+		// LongCat exposes the same binary thinking vocabulary on its
+		// OpenAI-compatible endpoint and documents no reasoning_effort depth scale.
+		return EffortCapability{Supported: true, Levels: []string{"auto", "enabled", "disabled"}, Default: "enabled"}
 	case isOllamaCloudEntry(e):
 		// Ollama Cloud accepts top-level reasoning_effort values low|medium|
 		// high|max. "none" means omit the field so the hosted model runs without
@@ -162,6 +166,19 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		// depth levels onto the nearest valid value so a stale /effort high|low
 		// still works. "off" is a retired DeepSeek level meaning "no thinking",
 		// which maps to "disabled".
+		switch level {
+		case "enabled", "disabled":
+			return level, nil
+		case "off":
+			return "disabled", nil
+		case "low", "medium", "high", "xhigh", "max":
+			return "enabled", nil
+		default:
+			return "", fmt.Errorf("usage: /effort auto|enabled|disabled")
+		}
+	case isLongCatEntry(e):
+		// LongCat's knob is binary (enabled|disabled); depth-like aliases mean
+		// thinking on, while the legacy off spellings disable it.
 		switch level {
 		case "enabled", "disabled":
 			return level, nil
@@ -312,6 +329,12 @@ func isMiniMaxEntry(e *ProviderEntry) bool {
 // entry-wrapper just gates on the openai kind.
 func isZhipuEntry(e *ProviderEntry) bool {
 	return e != nil && e.Kind == "openai" && openai.IsZhipu(e.BaseURL)
+}
+
+// isLongCatEntry reports whether the entry points at LongCat's OpenAI-compatible
+// endpoint. See openai.IsLongCat for the host-matching rule.
+func isLongCatEntry(e *ProviderEntry) bool {
+	return e != nil && e.Kind == "openai" && openai.IsLongCat(e.BaseURL)
 }
 
 // isOllamaCloudEntry reports whether the entry points at hosted Ollama Cloud,

--- a/internal/config/effort_test.go
+++ b/internal/config/effort_test.go
@@ -59,6 +59,24 @@ func TestIsZhipuEntry(t *testing.T) {
 	}
 }
 
+func TestIsLongCatEntry(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		{"https://api.longcat.chat/openai/v1", true},
+		{"https://api.longcat.chat/anthropic", true},
+		{"https://longcat.chat/openai/v1", false},
+		{"https://api.deepseek.com", false},
+		{"", false},
+	} {
+		e := &ProviderEntry{Kind: "openai", BaseURL: tc.baseURL}
+		if got := isLongCatEntry(e); got != tc.want {
+			t.Errorf("baseURL=%q: isLongCatEntry=%v, want %v", tc.baseURL, got, tc.want)
+		}
+	}
+}
+
 func TestIsOllamaCloudEntry(t *testing.T) {
 	for _, tc := range []struct {
 		baseURL string
@@ -95,6 +113,26 @@ func TestEffortCapabilityZhipu(t *testing.T) {
 	}
 	if cap.Default != "enabled" {
 		t.Errorf("default = %q, want enabled (GLM ships with thinking on)", cap.Default)
+	}
+}
+
+func TestEffortCapabilityLongCat(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.longcat.chat/openai/v1", Model: "LongCat-2.0"}
+	cap := EffortCapabilityForEntry(e)
+	if !cap.Supported {
+		t.Fatalf("LongCat entry should expose /effort, got %+v", cap)
+	}
+	wantLevels := []string{"auto", "enabled", "disabled"}
+	if len(cap.Levels) != len(wantLevels) {
+		t.Fatalf("levels = %v, want %v", cap.Levels, wantLevels)
+	}
+	for i, l := range wantLevels {
+		if cap.Levels[i] != l {
+			t.Errorf("levels[%d] = %q, want %q", i, cap.Levels[i], l)
+		}
+	}
+	if cap.Default != "enabled" {
+		t.Errorf("default = %q, want enabled", cap.Default)
 	}
 }
 
@@ -157,6 +195,34 @@ func TestNormalizeEffortZhipu(t *testing.T) {
 		// Stale values from other vendors resolve to a valid GLM level rather
 		// than failing the /effort command.
 		{"off", "disabled"}, // retired DeepSeek "no thinking"
+		{"low", "enabled"},
+		{"medium", "enabled"},
+		{"high", "enabled"},
+		{"xhigh", "enabled"},
+		{"max", "enabled"},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeEffort(e, tc.in)
+		if err != nil {
+			t.Errorf("NormalizeEffort(%q) returned error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeEffort(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeEffortLongCat(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.longcat.chat/openai/v1", Model: "LongCat-2.0"}
+	cases := []struct {
+		in, want string
+	}{
+		{"auto", ""},
+		{"enabled", "enabled"},
+		{"disabled", "disabled"},
+		{"ENABLED", "enabled"},
+		{"off", "disabled"},
 		{"low", "enabled"},
 		{"medium", "enabled"},
 		{"high", "enabled"},

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -121,6 +121,21 @@ func mimoDomesticPrices(models []string) map[string]*provider.Pricing {
 	return prices
 }
 
+func longCat20Price() *provider.Pricing {
+	return &provider.Pricing{CacheHit: 0.04, Input: 2, Output: 8, Currency: "¥"}
+}
+
+func longCat20Prices(models []string) map[string]*provider.Pricing {
+	prices := map[string]*provider.Pricing{}
+	for _, model := range models {
+		switch strings.TrimSpace(model) {
+		case "LongCat-2.0":
+			prices[model] = longCat20Price()
+		}
+	}
+	return prices
+}
+
 // ResetOfficialProviderPricingOnUpgrade resets official DeepSeek prices to
 // the current built-in RMB defaults once for desktop upgrades. It intentionally
 // runs from the desktop app startup path, not every config Load(), so user edits

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sort"
 	"strings"
 
 	"reasonix/internal/provider"
@@ -23,7 +24,11 @@ const ProviderPresetVersion = 1
 // intentionally editable after installation; they reduce setup friction without
 // turning fast-moving third-party catalogs into hard runtime dependencies.
 func CuratedProviderPresets() []ProviderPreset {
-	return cloneProviderPresets(curatedProviderPresets)
+	presets := cloneProviderPresets(curatedProviderPresets)
+	sort.SliceStable(presets, func(i, j int) bool {
+		return providerPresetDisplayRank(presets[i].ID) < providerPresetDisplayRank(presets[j].ID)
+	})
+	return presets
 }
 
 // CuratedProviderPreset returns a single provider preset by id.
@@ -37,10 +42,27 @@ func CuratedProviderPreset(id string) (ProviderPreset, bool) {
 	return ProviderPreset{}, false
 }
 
+func providerPresetDisplayRank(id string) int {
+	switch {
+	case id == "glm-cn" || id == "zai-global" || strings.HasPrefix(id, "glm-coding-plan-") || strings.HasPrefix(id, "zai-coding-plan-"):
+		return 0
+	case strings.HasPrefix(id, "longcat-"):
+		return 1
+	case strings.HasPrefix(id, "kimi-"):
+		return 2
+	case strings.HasPrefix(id, "minimax-"):
+		return 3
+	default:
+		return 4
+	}
+}
+
 var (
 	kimiAPIModels       = []string{"kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5"}
 	kimiAPIVisionModels = []string{"kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k2.6", "kimi-k2.5"}
 	kimiCodingModels    = []string{"kimi-for-coding"}
+
+	longCat20Models = []string{"LongCat-2.0"}
 
 	mimoV25Models       = []string{"mimo-v2.5-pro", "mimo-v2.5"}
 	mimoV25VisionModels = []string{"mimo-v2.5"}
@@ -74,6 +96,47 @@ var (
 )
 
 var curatedProviderPresets = []ProviderPreset{
+	{
+		ID:          "longcat-openai",
+		Label:       "LongCat OpenAI",
+		Description: "LongCat Platform OpenAI-compatible endpoint for LongCat-2.0.",
+		KeyEnv:      "LONGCAT_API_KEY",
+		Entries: []ProviderEntry{{
+			Name:             "longcat-openai",
+			Kind:             "openai",
+			BaseURL:          "https://api.longcat.chat/openai/v1",
+			ModelsURL:        "https://api.longcat.chat/openai/v1/models",
+			Models:           longCat20Models,
+			Default:          "LongCat-2.0",
+			APIKeyEnv:        "LONGCAT_API_KEY",
+			ContextWindow:    131072,
+			Prices:           longCat20Prices(longCat20Models),
+			Thinking:         "enabled",
+			SupportedEfforts: []string{"enabled", "disabled"},
+			DefaultEffort:    "enabled",
+		}},
+	},
+	{
+		ID:          "longcat-anthropic",
+		Label:       "LongCat Anthropic",
+		Description: "LongCat Platform Anthropic-compatible Messages endpoint for LongCat-2.0.",
+		KeyEnv:      "LONGCAT_API_KEY",
+		Entries: []ProviderEntry{{
+			Name:             "longcat-anthropic",
+			Kind:             "anthropic",
+			BaseURL:          "https://api.longcat.chat/anthropic",
+			ModelsURL:        "https://api.longcat.chat/anthropic/v1/models",
+			Models:           longCat20Models,
+			Default:          "LongCat-2.0",
+			APIKeyEnv:        "LONGCAT_API_KEY",
+			AuthHeader:       true,
+			Thinking:         "enabled",
+			SupportedEfforts: []string{"enabled", "disabled"},
+			DefaultEffort:    "enabled",
+			ContextWindow:    131072,
+			Prices:           longCat20Prices(longCat20Models),
+		}},
+	},
 	{
 		ID:          "kimi-cn",
 		Label:       "Kimi CN API",

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -4,6 +4,8 @@ import "testing"
 
 func TestCuratedProviderPresetsCoverRequestedProviders(t *testing.T) {
 	wantIDs := []string{
+		"longcat-openai",
+		"longcat-anthropic",
 		"kimi-cn",
 		"kimi-global",
 		"kimi-coding-plan",
@@ -73,6 +75,35 @@ func TestCuratedProviderPresetsCoverRequestedProviders(t *testing.T) {
 	}
 }
 
+func TestCuratedProviderPresetsDisplayOrder(t *testing.T) {
+	wantPrefix := []string{
+		"glm-cn",
+		"zai-global",
+		"glm-coding-plan-cn",
+		"glm-coding-plan-cn-anthropic",
+		"zai-coding-plan-global",
+		"zai-coding-plan-global-anthropic",
+		"longcat-openai",
+		"longcat-anthropic",
+		"kimi-cn",
+		"kimi-global",
+		"kimi-coding-plan",
+		"minimax-cn-api",
+		"minimax-global-api",
+		"minimax-cn-anthropic",
+		"minimax-global-anthropic",
+	}
+	got := CuratedProviderPresets()
+	if len(got) < len(wantPrefix) {
+		t.Fatalf("got %d presets, want at least %d", len(got), len(wantPrefix))
+	}
+	for i, want := range wantPrefix {
+		if got[i].ID != want {
+			t.Fatalf("preset[%d] = %q, want %q", i, got[i].ID, want)
+		}
+	}
+}
+
 func TestCuratedProviderPresetReturnsDeepCopy(t *testing.T) {
 	preset, ok := CuratedProviderPreset("minimax-cn-api")
 	if !ok {
@@ -127,6 +158,27 @@ func TestCuratedProviderPresetCapabilities(t *testing.T) {
 	}
 	if kimiPlan.Kind != "anthropic" || kimiPlan.DefaultModel() != "kimi-for-coding" || !kimiPlan.HasVisionModel("kimi-for-coding") || kimiPlan.Thinking != "adaptive" || kimiPlan.HasModel("kimi-code") {
 		t.Fatalf("kimi-coding-plan capability mismatch: %+v", kimiPlan)
+	}
+
+	longcat, ok := cfg.ResolveModel("longcat-openai/LongCat-2.0")
+	if !ok {
+		t.Fatal("longcat-openai/LongCat-2.0 did not resolve")
+	}
+	if longcat.BaseURL != "https://api.longcat.chat/openai/v1" || longcat.ModelsURL != "https://api.longcat.chat/openai/v1/models" || longcat.APIKeyEnv != "LONGCAT_API_KEY" {
+		t.Fatalf("longcat-openai endpoint/key mismatch: %+v", longcat)
+	}
+	if cap := EffortCapabilityForEntry(longcat); !cap.Supported || cap.Default != "enabled" || !containsString(cap.Levels, "disabled") {
+		t.Fatalf("longcat-openai effort capability = %+v, want enabled/disabled", cap)
+	}
+	if price := longcat.PriceForModel("LongCat-2.0"); price == nil || price.Currency != "¥" || price.Input != 2 || price.Output != 8 || price.CacheHit != 0.04 {
+		t.Fatalf("LongCat-2.0 price = %+v, want RMB discounted pricing", price)
+	}
+	longcatAnthropic, ok := cfg.Provider("longcat-anthropic")
+	if !ok {
+		t.Fatal("longcat-anthropic provider missing")
+	}
+	if longcatAnthropic.Kind != "anthropic" || longcatAnthropic.BaseURL != "https://api.longcat.chat/anthropic" || longcatAnthropic.ModelsURL != "https://api.longcat.chat/anthropic/v1/models" || !longcatAnthropic.AuthHeader || longcatAnthropic.Thinking != "enabled" {
+		t.Fatalf("longcat-anthropic capability mismatch: %+v", longcatAnthropic)
 	}
 
 	mimo, ok := cfg.Provider("mimo-api")

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -9,9 +9,10 @@
 //     requires the *signed* thinking block be replayed on the next turn when a tool
 //     call followed thinking, so Message carries ReasoningSignature alongside
 //     ReasoningContent and this provider replays the signed block on the next
-//     request. Off by default because the field is Anthropic-specific — an
-//     OpenAI-compatible gateway (e.g. DeepSeek's) would reject it. (redacted_thinking
-//     blocks are not yet captured/replayed.)
+//     request. Some Anthropic-compatible gateways such as LongCat instead use
+//     thinking.type enabled|disabled; those values are passed through without
+//     Anthropic's display/output_config fields. Off by default because the field is
+//     provider-specific. (redacted_thinking blocks are not yet captured/replayed.)
 //   - No temperature/top_p. Current Claude models (Opus 4.8/4.7) reject sampling
 //     parameters with a 400; Anthropic steers behavior via prompting instead.
 package anthropic
@@ -72,7 +73,9 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
 	keySource, _ := cfg.Extra["api_key_source"].(string)
 	thinking, _ := cfg.Extra["thinking"].(string)
+	thinking = strings.ToLower(strings.TrimSpace(thinking))
 	effort, _ := cfg.Extra["effort"].(string)
+	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)
@@ -274,7 +277,7 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 			// the tool_use it led to). Only when thinking is on and we have both the
 			// text and its signature — reasoning without a signature (e.g. from an
 			// openai-compatible provider) can't be replayed as a thinking block.
-			if c.thinking != "" && m.ReasoningContent != "" && m.ReasoningSignature != "" {
+			if c.thinking == "adaptive" && m.ReasoningContent != "" && m.ReasoningSignature != "" {
 				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: m.ReasoningContent, Signature: m.ReasoningSignature})
 			}
 			if m.Content != "" {
@@ -328,14 +331,21 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		Tools:     tools,
 		Stream:    true,
 	}
-	// Extended thinking is opt-in and Anthropic-specific (a compatible gateway like
-	// DeepSeek's would reject the field). "summarized" display streams the reasoning
-	// text; the default omits it but still emits the signature we round-trip.
-	if c.thinking == "adaptive" {
+	// Extended thinking is opt-in and provider-specific. Anthropic proper uses
+	// type=adaptive plus display/output_config. LongCat-style compatible gateways
+	// use the simpler enabled|disabled knob and do not accept output_config.
+	switch c.thinking {
+	case "adaptive":
 		r.Thinking = &thinkingConfig{Type: "adaptive", Display: "summarized"}
 		if c.effort != "" {
 			r.OutputConfig = &outputConfig{Effort: c.effort}
 		}
+	case "enabled", "disabled":
+		t := c.thinking
+		if c.effort == "enabled" || c.effort == "disabled" {
+			t = c.effort
+		}
+		r.Thinking = &thinkingConfig{Type: t}
 	}
 	return r
 }

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -252,6 +252,27 @@ func TestBuildRequestThinking(t *testing.T) {
 	}
 }
 
+func TestBuildRequestThinkingEnabledGateway(t *testing.T) {
+	c := &client{model: "LongCat-2.0", thinking: "enabled", effort: "disabled"}
+	r := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "hi"},
+			{Role: provider.RoleAssistant, Content: "ok", ReasoningContent: "signed reasoning", ReasoningSignature: "sig"},
+		},
+	})
+	if r.Thinking == nil || r.Thinking.Type != "disabled" || r.Thinking.Display != "" {
+		t.Fatalf("thinking config = %+v, want disabled without display", r.Thinking)
+	}
+	if r.OutputConfig != nil {
+		t.Fatalf("enabled/disabled gateway thinking must omit output_config: %+v", r.OutputConfig)
+	}
+	for _, block := range r.Messages[1].Content {
+		if block.Type == "thinking" {
+			t.Fatalf("enabled/disabled gateway must not replay Anthropic signed thinking blocks: %+v", r.Messages[1])
+		}
+	}
+}
+
 // TestBuildRequestThinkingOff is the default: no thinking field, and reasoning is
 // NOT replayed (even with a signature present) since the model wasn't asked to think.
 func TestBuildRequestThinkingOff(t *testing.T) {

--- a/internal/provider/openai/effort_test.go
+++ b/internal/provider/openai/effort_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -85,5 +86,40 @@ func TestReasoningProtocolOverridesEndpointHeuristic(t *testing.T) {
 	c = p.(*client)
 	if c.deepseek || c.effort != "" {
 		t.Fatalf("deepseek=%v effort=%q, want false/empty", c.deepseek, c.effort)
+	}
+}
+
+func TestLongCatThinkingUsesThinkingField(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "longcat",
+		BaseURL: "https://api.longcat.chat/openai/v1",
+		Model:   "LongCat-2.0",
+		APIKey:  "k",
+		Extra:   map[string]any{"effort": "disabled", "thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New longcat: %v", err)
+	}
+	c := p.(*client)
+	if !c.longcat || c.effort != "disabled" {
+		t.Fatalf("longcat=%v effort=%q, want true/disabled", c.longcat, c.effort)
+	}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	thinking, _ := body["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Fatalf("thinking = %#v, want disabled", body["thinking"])
+	}
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatalf("LongCat request must omit reasoning_effort: %s", b)
 	}
 }

--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -63,6 +63,13 @@ func IsZhipu(baseURL string) bool {
 		matchesVendorHost(baseURL, "z.ai", "api.z.ai")
 }
 
+// IsLongCat reports whether baseURL points at LongCat's OpenAI-compatible API.
+// LongCat uses the OpenAI chat shape, but gates thinking with thinking.type
+// enabled|disabled rather than the generic reasoning_effort field.
+func IsLongCat(baseURL string) bool {
+	return matchesVendorHost(baseURL, "longcat.chat", "api.longcat.chat")
+}
+
 // IsOllamaCloud reports whether baseURL points at Ollama Cloud's hosted
 // OpenAI-compatible endpoint. Local Ollama servers intentionally do not match:
 // the hosted API accepts the reasoning_effort=max extension, while localhost

--- a/internal/provider/openai/host_test.go
+++ b/internal/provider/openai/host_test.go
@@ -125,6 +125,25 @@ func TestIsZhipu(t *testing.T) {
 	}
 }
 
+func TestIsLongCat(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		{"https://api.longcat.chat/openai/v1", true},
+		{"https://api.longcat.chat/anthropic", true},
+		{"https://gateway.longcat.chat/openai/v1", true},
+		{"https://longcat.chat/openai/v1", false},
+		{"https://api.deepseek.com", false},
+		{"", false},
+		{"not-a-url", false},
+	} {
+		if got := IsLongCat(tc.baseURL); got != tc.want {
+			t.Errorf("IsLongCat(%q) = %v, want %v", tc.baseURL, got, tc.want)
+		}
+	}
+}
+
 func TestIsOllamaCloud(t *testing.T) {
 	for _, tc := range []struct {
 		baseURL string

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -8,6 +8,8 @@
 //     knob) instead of reasoning_effort, since M3 has no level scale.
 //   - open.bigmodel.cn / api.z.ai (Zhipu GLM) → emits thinking.type=enabled|
 //     disabled instead of reasoning_effort, which Zhipu silently ignores.
+//   - api.longcat.chat → emits thinking.type=enabled|disabled and omits
+//     reasoning_effort, matching LongCat's OpenAI-compatible API.
 //   - ollama.com → accepts hosted Ollama Cloud's reasoning_effort scale,
 //     including max, and omits the field for none/disabled.
 //   - everything else (MiMo and other OpenAI-compatible gateways) uses the
@@ -81,6 +83,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	deepseek := protocol == "deepseek" || (protocol == "" && IsDeepSeek(cfg.BaseURL))
 	minimax := protocol == "" && IsMiniMax(cfg.BaseURL)
 	zhipu := protocol == "" && IsZhipu(cfg.BaseURL)
+	longcat := protocol == "" && IsLongCat(cfg.BaseURL)
 	ollamaCloud := protocol == "" && IsOllamaCloud(cfg.BaseURL)
 	// Optional explicit `thinking` config field — a vendor-agnostic escape hatch
 	// (credit @eghrhegpe, #5063) for OpenAI-compatible providers we don't
@@ -134,6 +137,15 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		default:
 			return nil, fmt.Errorf("openai: provider %q uses Zhipu thinking; effort must be enabled or disabled", name)
 		}
+	case longcat:
+		// LongCat exposes a binary thinking knob on its OpenAI-compatible endpoint:
+		// thinking.type=enabled|disabled. It documents reasoning text via
+		// reasoning_content, but not the generic reasoning_effort scale.
+		switch effort {
+		case "", "enabled", "disabled":
+		default:
+			return nil, fmt.Errorf("openai: provider %q uses LongCat thinking; effort must be enabled or disabled", name)
+		}
 	case ollamaCloud:
 		// Hosted Ollama Cloud uses top-level reasoning_effort. "none" and the
 		// legacy/off aliases intentionally omit the field, which lets the model
@@ -177,6 +189,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		deepseek:     deepseek,
 		minimax:      minimax,
 		zhipu:        zhipu,
+		longcat:      longcat,
 		thinkingType: thinkingType,
 		vision:       vision,
 		visionDetail: visionDetail,
@@ -210,6 +223,7 @@ type client struct {
 	deepseek     bool
 	minimax      bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
 	zhipu        bool          // true for Zhipu GLM (bigmodel.cn / z.ai) — gates thinking via thinking.type, ignores reasoning_effort
+	longcat      bool          // true for LongCat — gates thinking via thinking.type, ignores reasoning_effort
 	thinkingType string        // explicit `thinking` config override (enabled|disabled); "" = no override
 	vision       bool          // model accepts image input — embed attached images as image_url parts
 	visionDetail string        // image_url detail hint (low|high); "" = auto/omit
@@ -497,6 +511,19 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		}
 		if c.thinkingType != "" {
 			t = c.thinkingType // explicit `thinking` config overrides the effort knob
+		}
+		out.Thinking = &thinkingMode{Type: t}
+		out.ReasoningEffort = ""
+	case c.longcat:
+		// LongCat's binary thinking knob: "enabled" (default, thinking on) or
+		// "disabled". The API documents reasoning_content in OpenAI responses but
+		// not reasoning_effort, so keep depth out of the request.
+		t := c.effort
+		if t == "" {
+			t = c.thinkingType
+		}
+		if t == "" {
+			t = "enabled"
 		}
 		out.Thinking = &thinkingMode{Type: t}
 		out.ReasoningEffort = ""


### PR DESCRIPTION
## Summary
- Add LongCat OpenAI-compatible and Anthropic-compatible provider presets for LongCat-2.0.
- Support LongCat thinking enabled/disabled request shaping across OpenAI and Anthropic adapters.
- Keep DeepSeek official first in Settings, then order recommended presets as GLM, LongCat, Kimi, and MiniMax.

Cache-impact: low - LongCat-specific request shaping is host/provider gated; existing provider request paths remain stable.
Cache-guard: go test ./internal/provider/openai ./internal/provider/anthropic

## Verification
- go test ./internal/config ./internal/provider/openai ./internal/provider/anthropic
- go test . -run 'Test.*Provider|Test.*Settings|Test.*Official|Test.*Preset' (desktop)
- pnpm typecheck (desktop/frontend)
- pnpm check:css (desktop/frontend)
- Browser verified Settings > Model > Access > Add model service order: DeepSeek, GLM, LongCat, Kimi, MiniMax.
