### PR TITLE
fix(openai): support Gemini thought_signature round-trip on tool calls

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -447,6 +447,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 			wire := chatToolCall{ID: tc.ID, Type: "function"}
 			wire.Function.Name = tc.Name
 			wire.Function.Arguments = tc.Arguments
+			wire.Function.ThoughtSignature = tc.ThoughtSignature
 			cm.ToolCalls = append(cm.ToolCalls, wire)
 		}
 		switch {
@@ -667,6 +668,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 				cur.Name = tc.Function.Name
 			}
 			cur.Arguments += tc.Function.Arguments
+			cur.ThoughtSignature = tc.Function.ThoughtSignature
 			// Signal the call's start the moment its name is known, so a frontend
 			// can show the tool card immediately rather than only after its
 			// (possibly large) arguments finish streaming.
@@ -852,8 +854,9 @@ type chatToolCall struct {
 	ID       string `json:"id,omitempty"`
 	Type     string `json:"type,omitempty"`
 	Function struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
+		Name             string `json:"name"`
+		Arguments        string `json:"arguments"`
+		ThoughtSignature string `json:"thought_signature,omitempty"` // Gemini support
 	} `json:"function"`
 }
 

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1108,3 +1108,110 @@ func TestBuildRequestDefaultsEmptyToolParameters(t *testing.T) {
 		t.Fatalf("nil parameters should default to %s, got %s in %s", want, got, body)
 	}
 }
+
+func TestStreamReadsGeminiThoughtSignature(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w,
+			"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_abc123\",\"type\":\"function\",\"function\":{\"name\":\"write_file\",\"arguments\":\"{\\\"path\\\":\\\"test.txt\\\"}\",\"thought_signature\":\"gemini_sig_xyz789\"}}]}}]}\n\n"+
+				"data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "gemini", BaseURL: srv.URL, Model: "gemini-3.5-flash"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ch, err := p.Stream(context.Background(), provider.Request{})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var foundToolCall bool
+	var gotSignature string
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkToolCall && chunk.ToolCall != nil {
+			foundToolCall = true
+			gotSignature = chunk.ToolCall.ThoughtSignature
+		}
+	}
+
+	if !foundToolCall {
+		t.Fatal("expected ChunkToolCall but none received")
+	}
+	if gotSignature != "gemini_sig_xyz789" {
+		t.Errorf("ThoughtSignature = %q, want %q", gotSignature, "gemini_sig_xyz789")
+	}
+}
+
+func TestBuildRequestRoundTripsGeminiThoughtSignature(t *testing.T) {
+	c := &client{
+		name:    "gemini",
+		baseURL: "https://generativelanguage.googleapis.com/v1beta",
+		model:   "gemini-3.5-flash",
+	}
+
+	req := provider.Request{
+		Messages: []provider.Message{
+			{
+				Role:    provider.RoleAssistant,
+				Content: "I'll use a tool to help you.",
+				ToolCalls: []provider.ToolCall{
+					{
+						ID:               "call_abc123",
+						Name:             "write_file",
+						Arguments:        `{"path":"test.txt"}`,
+						ThoughtSignature: "gemini_sig_xyz789",
+					},
+				},
+			},
+		},
+	}
+
+	chatReq := c.buildRequest(req)
+
+	jsonBytes, err := json.Marshal(chatReq)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	messages, ok := raw["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		t.Fatal("no messages in request")
+	}
+
+	msg, ok := messages[0].(map[string]any)
+	if !ok {
+		t.Fatal("first message is not an object")
+	}
+
+	toolCalls, ok := msg["tool_calls"].([]any)
+	if !ok || len(toolCalls) == 0 {
+		t.Fatal("no tool_calls in message")
+	}
+
+	tc, ok := toolCalls[0].(map[string]any)
+	if !ok {
+		t.Fatal("first tool_call is not an object")
+	}
+
+	fn, ok := tc["function"].(map[string]any)
+	if !ok {
+		t.Fatal("function is not an object")
+	}
+
+	sig, ok := fn["thought_signature"].(string)
+	if !ok {
+		t.Fatal("thought_signature field missing or not a string")
+	}
+	if sig != "gemini_sig_xyz789" {
+		t.Errorf("thought_signature = %q, want %q", sig, "gemini_sig_xyz789")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,12 +78,13 @@ func ParseImageDataURL(dataURL string) (mediaType, base64Data string, ok bool) {
 
 // ToolCall is a tool invocation requested by the model. Arguments is raw JSON.
 type ToolCall struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
-	Diff      string `json:"diff,omitempty"`
-	Added     int    `json:"added,omitempty"`
-	Removed   int    `json:"removed,omitempty"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Arguments        string `json:"arguments"`
+	Diff             string `json:"diff,omitempty"`
+	Added            int    `json:"added,omitempty"`
+	Removed          int    `json:"removed,omitempty"`
+	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
 // ToolSchema is a tool definition exposed to the model. Parameters is JSON Schema.


### PR DESCRIPTION
## Summary

- 支持 Gemini 的 `thought_signature` 字段在 tool call 中的解析与回传
- Gemini API 要求在使用 function calling 时，必须将 `thought_signature` 字段原样回传
- 未修复时，Gemini 3.5 flash 返回 HTTP 400 错误："Function call is missing a thought_signature in functionCall parts"

## Changes

1. 在 `provider.ToolCall` 中新增 `ThoughtSignature` 字段（`internal/provider/provider.go`）
2. 在 `chatToolCall.Function` 中新增 `ThoughtSignature` 字段（`internal/provider/openai/openai.go`）
3. 在 `readStream` 中解析 Gemini 响应里的 `thought_signature`
4. 在 `buildRequest` 中将 `thought_signature` 回传到请求中

## Verification

- 新增 `TestStreamReadsGeminiThoughtSignature` — 验证从 API 响应解析
- 新增 `TestBuildRequestRoundTripsGeminiThoughtSignature` — 验证请求中的 round-trip
- 所有现有测试通过（无回归）
- `go vet` 无警告，`gofmt` 无格式问题，`make build` 编译成功

## Cache impact

Cache-impact: none
Cache-guard: N/A
System-prompt-review: N/A

Closes #5905
