### PR TITLE
Fix npm CLI binary version injection / 修复 npm CLI 二进制版本注入

### DIFF
--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -23,6 +23,7 @@ if (!tag) {
 }
 // npm ships on its own `npm-v*` tag (release-npm.yml); also accept a bare `v*`.
 const version = tag.replace(/^(npm-)?v/, "");
+const binaryVersion = `v${version}`;
 const publish = process.argv.includes("--publish");
 
 rmSync(STAGE, { recursive: true, force: true });
@@ -42,7 +43,7 @@ for (const t of TARGETS) {
       "build",
       "-trimpath",
       "-ldflags",
-      `-s -w -X main.version=${tag}`,
+      `-s -w -X main.version=${binaryVersion}`,
       "-o",
       join(dir, "bin", exe),
       "./cmd/reasonix",


### PR DESCRIPTION
## Summary
- Inject a normalized v-prefixed semver into npm-built CLI binaries.
- Keep npm package versions derived from `npm-v*` tags unchanged.
- Fixes #5932.

## Verification
- `go test ./internal/cli -run 'TestNormalizeVersion|TestPickCLIRelease'`
- `node npm/build.mjs npm-v1.16.0-rc.1`
- `npm/.stage/cli-darwin-arm64/bin/reasonix --version && npm/.stage/cli-darwin-arm64/bin/reasonix upgrade --check --force`