### PR TITLE
Harden Windows desktop update handoff / 强化 Windows 桌面端更新交接

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -36,6 +36,7 @@ Unicode true
 ####
 !include "wails_tools.nsh"
 !include "FileFunc.nsh"
+!include "LogicLib.nsh"
 
 # The version information for this two must consist of 4 parts
 VIProductVersion "${INFO_PRODUCTVERSION}.0"
@@ -76,6 +77,8 @@ ManifestDPIAware true
 Name "${INFO_PRODUCTNAME}"
 OutFile "..\..\bin\${INFO_PROJECTNAME}-${ARCH}-installer.exe" # Name of the installer's file.
 !define REASONIX_DEFAULT_INSTALLDIR "$LOCALAPPDATA\Programs\${INFO_PRODUCTNAME}"
+!define REASONIX_UPDATE_HELPER "reasonix-update-helper.exe"
+!define REASONIX_UNLOCK_RETRIES 60
 InstallDirRegKey HKCU "${UNINST_KEY}" "InstallLocation" # Reuse the previous install path on update; .onInit falls back to the default on first install.
 InstallDir "${REASONIX_DEFAULT_INSTALLDIR}" # Per-user install location (no admin rights required).
 ShowInstDetails show # This will always show the installation details.
@@ -130,14 +133,54 @@ fallback:
 done:
 FunctionEnd
 
+Function reasonix.waitForExecutableUnlock
+   IfFileExists "$INSTDIR\${PRODUCT_EXECUTABLE}" 0 done
+   StrCpy $0 0
+
+retry:
+   ClearErrors
+   FileOpen $1 "$INSTDIR\${PRODUCT_EXECUTABLE}" a
+   IfErrors locked
+   FileClose $1
+   Goto done
+
+locked:
+   IntOp $0 $0 + 1
+   IntCmp $0 ${REASONIX_UNLOCK_RETRIES} failed 0 0
+   Sleep 1000
+   Goto retry
+
+failed:
+   IfSilent silent interactive
+
+interactive:
+   MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Reasonix is still running. Close Reasonix, then click Retry to continue the installation." IDRETRY retry IDCANCEL abort
+   Goto retry
+
+silent:
+   SetErrorLevel 1618
+
+abort:
+   Abort "Reasonix is still running. Close Reasonix and run the installer again."
+
+done:
+FunctionEnd
+
 Section
     !insertmacro wails.setShellContext
 
     !insertmacro wails.webview2runtime
 
+    Call reasonix.waitForExecutableUnlock
+
     SetOutPath $INSTDIR
 
     !insertmacro wails.files
+    !if /FileExists "${REASONIX_UPDATE_HELPER}"
+    File "/oname=${REASONIX_UPDATE_HELPER}" "${REASONIX_UPDATE_HELPER}"
+    !else
+    !warning "${REASONIX_UPDATE_HELPER} was not found; Windows auto-update will fall back to installer-side waiting only."
+    !endif
 
     CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"
     CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"
@@ -155,6 +198,7 @@ Section "uninstall"
 
     ; Precision uninstall: delete main application files
     Delete "$INSTDIR\${PRODUCT_EXECUTABLE}"
+    Delete "$INSTDIR\${REASONIX_UPDATE_HELPER}"
 
     Delete "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk"
     Delete "$DESKTOP\${INFO_PRODUCTNAME}.lnk"

--- a/desktop/cmd/update-helper/args.go
+++ b/desktop/cmd/update-helper/args.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func installerCommandLine(installer, dir string) string {
+	line := fmt.Sprintf(`"%s" /S`, installer)
+	if dir != "" {
+		line += " /D=" + dir
+	}
+	return line
+}

--- a/desktop/cmd/update-helper/args_test.go
+++ b/desktop/cmd/update-helper/args_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInstallerCommandLineIsSilentAndLeavesDFlagLast(t *testing.T) {
+	got := installerCommandLine(`C:\Temp\Reasonix Installer.exe`, `D:\Tools\Reasonix App`)
+	want := `"C:\Temp\Reasonix Installer.exe" /S /D=D:\Tools\Reasonix App`
+	if got != want {
+		t.Fatalf("installerCommandLine = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(got, `/D=D:\Tools\Reasonix App`) {
+		t.Fatalf("/D= must be the final unquoted NSIS token, got %q", got)
+	}
+}

--- a/desktop/cmd/update-helper/main_other.go
+++ b/desktop/cmd/update-helper/main_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "reasonix-update-helper is only used by Windows desktop builds")
+	os.Exit(2)
+}

--- a/desktop/cmd/update-helper/main_windows.go
+++ b/desktop/cmd/update-helper/main_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const parentExitTimeout = 2 * time.Minute
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	var parentPID uint
+	var installer, installDir, relaunch string
+	fs := flag.NewFlagSet("reasonix-update-helper", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.UintVar(&parentPID, "parent-pid", 0, "Reasonix process id to wait for before installing")
+	fs.StringVar(&installer, "installer", "", "verified NSIS installer path")
+	fs.StringVar(&installDir, "install-dir", "", "Reasonix installation directory")
+	fs.StringVar(&relaunch, "relaunch", "", "Reasonix executable to start after the installer succeeds")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	logger := newLogger()
+	if installer == "" {
+		logger.Print("missing --installer")
+		return 2
+	}
+	if parentPID != 0 {
+		if err := waitForProcessExit(uint32(parentPID), parentExitTimeout); err != nil {
+			logger.Printf("wait for parent process %d: %v", parentPID, err)
+			return 1
+		}
+	}
+	if err := runInstaller(installer, installDir); err != nil {
+		logger.Printf("run installer: %v", err)
+		return 1
+	}
+	if relaunch != "" {
+		if err := startRelaunch(relaunch, installDir); err != nil {
+			logger.Printf("relaunch: %v", err)
+			return 1
+		}
+	}
+	return 0
+}
+
+func newLogger() *log.Logger {
+	dir, err := os.UserCacheDir()
+	if err == nil {
+		dir = filepath.Join(dir, "Reasonix", "updates")
+		if err := os.MkdirAll(dir, 0o700); err == nil {
+			if f, err := os.OpenFile(filepath.Join(dir, "update-helper.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+				return log.New(f, "", log.LstdFlags)
+			}
+		}
+	}
+	return log.New(os.Stderr, "", log.LstdFlags)
+}
+
+func waitForProcessExit(pid uint32, timeout time.Duration) error {
+	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
+	if err != nil {
+		if err == windows.ERROR_INVALID_PARAMETER {
+			return nil
+		}
+		return err
+	}
+	defer windows.CloseHandle(h)
+	waitMS := uint32(timeout / time.Millisecond)
+	result, err := windows.WaitForSingleObject(h, waitMS)
+	if err != nil {
+		return err
+	}
+	switch result {
+	case windows.WAIT_OBJECT_0:
+		return nil
+	case uint32(windows.WAIT_TIMEOUT):
+		return fmt.Errorf("timed out after %s", timeout)
+	default:
+		return fmt.Errorf("unexpected wait result %d", result)
+	}
+}
+
+func runInstaller(installer, installDir string) error {
+	cmd := exec.Command(installer)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(installer, installDir), HideWindow: true}
+	return cmd.Run()
+}
+
+func startRelaunch(relaunch, installDir string) error {
+	cmd := exec.Command(relaunch)
+	cmd.Dir = installDir
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd.Start()
+}

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -572,19 +572,27 @@ func applyLinux(targz []byte) error {
 }
 
 func applyWindowsFile(path string) error {
-	return installerCommand(path, currentInstallDir()).Start()
+	return startWindowsUpdateHandoff(path, currentInstallDir(), currentExecutablePath())
 }
 
-// currentInstallDir is the directory of the running executable — the location a
-// Windows update must overwrite. Empty when it can't be resolved, in which case
-// the installer falls back to its own InstallDir logic.
-func currentInstallDir() string {
+func currentExecutablePath() string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
 	}
 	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
 		exe = resolved
+	}
+	return exe
+}
+
+// currentInstallDir is the directory of the running executable — the location a
+// Windows update must overwrite. Empty when it can't be resolved, in which case
+// the installer falls back to its own InstallDir logic.
+func currentInstallDir() string {
+	exe := currentExecutablePath()
+	if exe == "" {
+		return ""
 	}
 	return filepath.Dir(exe)
 }

--- a/desktop/updater_other.go
+++ b/desktop/updater_other.go
@@ -9,3 +9,7 @@ import "os/exec"
 func installerCommand(name, _ string) *exec.Cmd {
 	return exec.Command(name)
 }
+
+func startWindowsUpdateHandoff(name, dir, _ string) error {
+	return installerCommand(name, dir).Start()
+}

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -3,9 +3,11 @@
 package main
 
 import (
-	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
+	"time"
 )
 
 // installerCommand runs the NSIS updater, forcing $INSTDIR to dir via /D= so the
@@ -15,8 +17,54 @@ import (
 // C:\Users\Jane Doe\...) and NSIS would then mis-parse the target directory.
 func installerCommand(name, dir string) *exec.Cmd {
 	cmd := exec.Command(name)
-	if dir != "" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf(`"%s" /D=%s`, name, dir)}
-	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(name, dir), HideWindow: true}
 	return cmd
+}
+
+func startWindowsUpdateHandoff(installerPath, installDir, relaunchPath string) error {
+	if err := startWindowsUpdateHelper(installerPath, installDir, relaunchPath); err == nil {
+		return nil
+	}
+	return installerCommand(installerPath, installDir).Start()
+}
+
+func startWindowsUpdateHelper(installerPath, installDir, relaunchPath string) error {
+	if installDir == "" {
+		return os.ErrNotExist
+	}
+	helperPath, err := prepareWindowsUpdateHelper(installDir)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(helperPath, windowsUpdateHandoffArgs(os.Getpid(), installerPath, installDir, relaunchPath)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd.Start()
+}
+
+func prepareWindowsUpdateHelper(installDir string) (string, error) {
+	src := filepath.Join(installDir, windowsUpdateHelperFileName)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return "", err
+	}
+	dir, err := updateCacheDir()
+	if err != nil {
+		return "", err
+	}
+	cleanupWindowsUpdateHelpers(dir)
+	dst := filepath.Join(dir, "reasonix-update-helper-"+time.Now().UTC().Format("20060102150405.000000000")+".exe")
+	if err := os.WriteFile(dst, data, 0o700); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+func cleanupWindowsUpdateHelpers(dir string) {
+	matches, err := filepath.Glob(filepath.Join(dir, "reasonix-update-helper-*.exe"))
+	if err != nil {
+		return
+	}
+	for _, name := range matches {
+		_ = os.Remove(name)
+	}
 }

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const windowsUpdateHelperFileName = "reasonix-update-helper.exe"
+
 // installerCommand runs the NSIS updater, forcing $INSTDIR to dir via /D= so the
 // update overwrites the current install in place. NSIS requires /D= to be the
 // final, unquoted token taken verbatim to the end of the line, so the raw command

--- a/desktop/updater_windows_args.go
+++ b/desktop/updater_windows_args.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const windowsUpdateHelperFileName = "reasonix-update-helper.exe"
+
+func installerCommandLine(installer, dir string) string {
+	line := fmt.Sprintf(`"%s" /S`, installer)
+	if dir != "" {
+		line += " /D=" + dir
+	}
+	return line
+}
+
+func windowsUpdateHandoffArgs(parentPID int, installer, installDir, relaunch string) []string {
+	args := []string{
+		"--parent-pid", strconv.Itoa(parentPID),
+		"--installer", installer,
+	}
+	if installDir != "" {
+		args = append(args, "--install-dir", installDir)
+	}
+	if relaunch != "" {
+		args = append(args, "--relaunch", relaunch)
+	}
+	return args
+}

--- a/desktop/updater_windows_args.go
+++ b/desktop/updater_windows_args.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 )
 
-const windowsUpdateHelperFileName = "reasonix-update-helper.exe"
-
 func installerCommandLine(installer, dir string) string {
 	line := fmt.Sprintf(`"%s" /S`, installer)
 	if dir != "" {

--- a/desktop/updater_windows_test.go
+++ b/desktop/updater_windows_test.go
@@ -10,7 +10,7 @@ func TestInstallerCommandPassesUnquotedDFlagLast(t *testing.T) {
 		t.Fatal("expected a raw command line forcing the install dir")
 	}
 	got := cmd.SysProcAttr.CmdLine
-	want := `"C:\Temp\reasonix-update-1.exe" /D=D:\Tools\Reasonix App`
+	want := `"C:\Temp\reasonix-update-1.exe" /S /D=D:\Tools\Reasonix App`
 	if got != want {
 		t.Fatalf("CmdLine = %q, want %q", got, want)
 	}
@@ -18,7 +18,12 @@ func TestInstallerCommandPassesUnquotedDFlagLast(t *testing.T) {
 
 func TestInstallerCommandWithoutDirSkipsDFlag(t *testing.T) {
 	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, "")
-	if cmd.SysProcAttr != nil {
-		t.Fatalf("no dir should leave NSIS InstallDir logic intact, got CmdLine %q", cmd.SysProcAttr.CmdLine)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected a raw command line for silent updater installs")
+	}
+	got := cmd.SysProcAttr.CmdLine
+	want := `"C:\Temp\reasonix-update-1.exe" /S`
+	if got != want {
+		t.Fatalf("CmdLine = %q, want %q", got, want)
 	}
 }

--- a/desktop/windows_update_handoff_test.go
+++ b/desktop/windows_update_handoff_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInstallerCommandLineIsSilentAndKeepsDFlagLast(t *testing.T) {
+	got := installerCommandLine(`C:\Temp\Reasonix Installer.exe`, `D:\Tools\Reasonix App`)
+	want := `"C:\Temp\Reasonix Installer.exe" /S /D=D:\Tools\Reasonix App`
+	if got != want {
+		t.Fatalf("installerCommandLine = %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(got, `/D=D:\Tools\Reasonix App`) {
+		t.Fatalf("/D= must be the final unquoted NSIS token, got %q", got)
+	}
+}
+
+func TestWindowsUpdateHandoffArgsCarryParentInstallAndRelaunch(t *testing.T) {
+	got := windowsUpdateHandoffArgs(
+		4242,
+		`C:\Users\Jane Doe\AppData\Local\Reasonix\updates\Reasonix-windows-amd64-installer.exe`,
+		`D:\Tools\Reasonix App`,
+		`D:\Tools\Reasonix App\reasonix-desktop.exe`,
+	)
+	want := []string{
+		"--parent-pid", "4242",
+		"--installer", `C:\Users\Jane Doe\AppData\Local\Reasonix\updates\Reasonix-windows-amd64-installer.exe`,
+		"--install-dir", `D:\Tools\Reasonix App`,
+		"--relaunch", `D:\Tools\Reasonix App\reasonix-desktop.exe`,
+	}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestWindowsInstallerScriptWaitsBeforeCopyingExecutable(t *testing.T) {
+	data, err := os.ReadFile("build/windows/installer/project.nsi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		`!define REASONIX_UPDATE_HELPER "reasonix-update-helper.exe"`,
+		"Function reasonix.waitForExecutableUnlock",
+		`FileOpen $1 "$INSTDIR\${PRODUCT_EXECUTABLE}" a`,
+		"SetErrorLevel 1618",
+		"Call reasonix.waitForExecutableUnlock",
+		`File "/oname=${REASONIX_UPDATE_HELPER}" "${REASONIX_UPDATE_HELPER}"`,
+		`Delete "$INSTDIR\${REASONIX_UPDATE_HELPER}"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("project.nsi missing %q", want)
+		}
+	}
+	wait := strings.Index(script, "Call reasonix.waitForExecutableUnlock")
+	copyFiles := strings.Index(script, "!insertmacro wails.files")
+	if wait < 0 || copyFiles < 0 || wait > copyFiles {
+		t.Fatalf("installer must wait for the running exe to unlock before wails.files (wait=%d copy=%d)", wait, copyFiles)
+	}
+}
+
+func TestDesktopBuildScriptCompilesAndPackagesWindowsUpdateHelper(t *testing.T) {
+	data, err := os.ReadFile("../scripts/desktop-build.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		`UPDATE_HELPER="reasonix-update-helper.exe"`,
+		`GOOS=windows GOARCH="$arch" go build`,
+		`./cmd/update-helper`,
+		`build/windows/installer/$UPDATE_HELPER`,
+		`cp "$helper" "$staging/$UPDATE_HELPER"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("desktop-build.sh missing %q", want)
+		}
+	}
+}

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -41,6 +41,12 @@ node -e 'const fs=require("fs"),f="wails.json",j=JSON.parse(fs.readFileSync(f,"u
 # NSIS installer is Windows-only (Wails requires a single windows target for -nsis).
 ldflags="-X main.version=$VERSION -X main.channel=$CHANNEL"
 [ "$os" = "darwin" ] && [ "${HAS_APPLE_CERT:-}" = "true" ] && ldflags="$ldflags -X main.macSelfUpdate=true"
+UPDATE_HELPER="reasonix-update-helper.exe"
+if [ "$os" = windows ]; then
+	echo "==> go build Windows update helper"
+	GOOS=windows GOARCH="$arch" go build -trimpath -ldflags="-s -w" \
+		-o "build/windows/installer/$UPDATE_HELPER" ./cmd/update-helper
+fi
 build_args=(-clean -platform "$PLATFORM" -ldflags "$ldflags")
 [ "$os" = windows ] && build_args+=(-nsis -webview2 embed)
 # Link cgo against WebKitGTK 4.1: 4.0 (libwebkit2gtk-4.0.so.37) is gone on
@@ -134,6 +140,10 @@ windows)
 	[ -n "$portable" ] || { echo "no portable Windows exe found in build/bin" >&2; exit 1; }
 	staging=$(mktemp -d)
 	cp "$portable" "$staging/${APPNAME}.exe"
+	helper="build/windows/installer/$UPDATE_HELPER"
+	if [ -f "$helper" ]; then
+		cp "$helper" "$staging/$UPDATE_HELPER"
+	fi
 	src_win=$(cygpath -w "$staging/${APPNAME}.exe")
 	zip_win=$(cygpath -w "$ROOT/dist/${APPNAME}-windows-${arch}.zip")
 	powershell.exe -NoProfile -Command "Compress-Archive -Force -LiteralPath '$src_win' -DestinationPath '$zip_win'"


### PR DESCRIPTION
## Summary
- add a small Windows update helper that waits for the running Reasonix process to exit before launching the verified NSIS installer
- make Windows updater launches silent and preserve the unquoted final /D= install-dir token required by NSIS
- make the NSIS installer wait for the existing executable to unlock before copying files, covering updates started by older builds and manual installer runs
- package the helper into Windows installer and portable builds

## Root cause
Windows auto-update could start the installer before the old reasonix-desktop.exe process had fully exited. NSIS then tried to overwrite a locked executable and showed `Error opening file for writing`, as reported in #5919.

## Validation
- `bash -n scripts/desktop-build.sh`
- `go test ./cmd/update-helper`
- `go test ./...` from `desktop/`
- Windows update helper cross-compiled successfully for `windows/amd64` and `windows/arm64`
- root `go test ./...`
- `git diff --check`

Fixes #5919