### PR TITLE
Fix MCP tools/list startup race / 修复 MCP 工具列表启动竞态

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5269,6 +5269,7 @@ type ServerView struct {
 	Tools                int        `json:"tools"`
 	Prompts              int        `json:"prompts"`
 	Resources            int        `json:"resources"`
+	HasTools             bool       `json:"hasTools,omitempty"`
 	Error                string     `json:"error,omitempty"`
 	ToolList             []ToolView `json:"toolList,omitempty"`
 	TrustedReadOnlyTools []string   `json:"trustedReadOnlyTools,omitempty"`
@@ -5415,6 +5416,7 @@ func (a *App) mcpServersView() []ServerView {
 			view := ServerView{
 				Name: s.Name, Transport: s.Transport, Status: "connected", RuntimeState: "ready",
 				Tools: s.Tools, Prompts: s.Prompts, Resources: s.Resources,
+				HasTools: s.HasTools,
 				ToolList: pluginToolsToView(s.ToolList),
 			}
 			if p, ok := configured[s.Name]; ok {
@@ -6512,6 +6514,7 @@ func findMCPServerView(ctrl control.SessionAPI, name string) (ServerView, bool) 
 			return ServerView{
 				Name: s.Name, Transport: s.Transport, Status: "connected",
 				Tools: s.Tools, Prompts: s.Prompts, Resources: s.Resources,
+				HasTools: s.HasTools,
 				ToolList: pluginToolsToView(s.ToolList),
 			}, true
 		}

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -668,6 +668,7 @@ export interface ServerView {
   tools: number;
   prompts: number;
   resources: number;
+  hasTools?: boolean;
   error?: string;
   toolList?: MCPToolView[];
   trustedReadOnlyTools?: string[];

--- a/internal/cli/mcp_manager.go
+++ b/internal/cli/mcp_manager.go
@@ -60,6 +60,7 @@ type mcpServerView struct {
 	Tools      int
 	Prompts    int
 	Resources  int
+	HasTools   bool
 	Error      string
 	ToolList   []plugin.ToolInfo
 	AuthStatus string
@@ -315,6 +316,7 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 			v := mcpServerView{
 				Name: s.Name, Transport: fallbackText(s.Transport, "stdio"), Status: "connected",
 				Tools: s.Tools, Prompts: s.Prompts, Resources: s.Resources,
+				HasTools: s.HasTools,
 				ToolList: append([]plugin.ToolInfo(nil), s.ToolList...),
 			}
 			if p, ok := configured[s.Name]; ok {

--- a/internal/cli/mcp_manager_view.go
+++ b/internal/cli/mcp_manager_view.go
@@ -334,7 +334,7 @@ func mcpAuthLabel(v mcpServerView) string {
 
 func mcpCapabilitiesText(v mcpServerView) string {
 	var caps []string
-	if v.Tools > 0 {
+	if v.HasTools || v.Tools > 0 {
 		caps = append(caps, "tools")
 	}
 	if v.Prompts > 0 {

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -143,6 +143,12 @@ func TestRenderMCPStatusCapsLongSections(t *testing.T) {
 	}
 }
 
+func TestMCPCapabilitiesTextUsesAdvertisedTools(t *testing.T) {
+	if got := mcpCapabilitiesText(mcpServerView{HasTools: true}); got != "tools" {
+		t.Fatalf("mcpCapabilitiesText = %q, want tools", got)
+	}
+}
+
 func TestRenderMCPStatusShowsFailures(t *testing.T) {
 	got := renderMCPStatus(90,
 		nil,

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -143,7 +143,7 @@ func (s *lazySpawn) run() {
 func saveLazyCachedSchema(spec Spec, real []tool.Tool) {
 	_ = SaveCachedSchema(spec.Name, CachedSchema{
 		SpecHash:     SpecFingerprint(spec),
-		Capabilities: map[string]bool{},
+		Capabilities: map[string]bool{"tools": len(real) > 0},
 		Tools:        cacheableToolsOf(real),
 	})
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -204,6 +204,12 @@ const defaultStartConcurrency = 8
 // on than by stalling the whole session.
 const defaultStartTimeout = 5 * time.Second
 
+var advertisedToolsEmptyListRetryDelays = []time.Duration{
+	50 * time.Millisecond,
+	150 * time.Millisecond,
+	300 * time.Millisecond,
+}
+
 // ErrServerAlreadyConnected marks an attempted MCP connection whose server name
 // is already live on the host.
 var ErrServerAlreadyConnected = errors.New("plugin server already connected")
@@ -339,6 +345,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 				_ = SaveCachedSchema(spec.Name, CachedSchema{
 					SpecHash: SpecFingerprint(spec),
 					Capabilities: map[string]bool{
+						"tools":     c.hasTools,
 						"prompts":   c.hasPrompts,
 						"resources": c.hasResources,
 					},
@@ -498,6 +505,7 @@ type Client struct {
 	// Capabilities advertised by the server at initialize. prompts/list and
 	// resources/list are only called when advertised, so we never provoke a
 	// "method not found" on a tools-only server.
+	hasTools     bool
 	hasPrompts   bool
 	hasResources bool
 
@@ -543,6 +551,7 @@ type ServerStatus struct {
 	Tools     int
 	Prompts   int
 	Resources int
+	HasTools  bool
 	ToolList  []ToolInfo
 }
 
@@ -563,6 +572,7 @@ func (h *Host) Servers() []ServerStatus {
 			Name:      c.name,
 			Transport: c.transport,
 			Tools:     c.toolCount,
+			HasTools:  c.hasTools,
 		}
 		c.toolsMu.Lock()
 		s.ToolList = append([]ToolInfo(nil), c.tools...)
@@ -1084,6 +1094,7 @@ func (c *Client) initializeSession(ctx context.Context, recordCapabilities bool)
 	if err := json.Unmarshal(res, &ir); err != nil {
 		slog.Warn("plugin: parse initialize capabilities", "server", c.name, "err", err)
 	}
+	_, c.hasTools = ir.Capabilities["tools"]
 	_, c.hasPrompts = ir.Capabilities["prompts"]
 	_, c.hasResources = ir.Capabilities["resources"]
 
@@ -1118,20 +1129,33 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 		return append([]tool.Tool(nil), c.toolAdapters...), nil
 	}
 
-	res, err := c.call(ctx, "tools/list", map[string]any{})
+	out, err := c.listToolsRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
-	var out struct {
-		Tools []mcpTool `json:"tools"`
-	}
-	if err := json.Unmarshal(res, &out); err != nil {
-		return nil, fmt.Errorf("plugin %q: decode tools/list: %w", c.name, err)
+
+	// Some MCP servers start accepting requests before dynamically registered
+	// tools have been added. If the server advertised the tools capability, a
+	// first empty list may be a startup race; give it a small bounded window to
+	// settle before freezing the provider-visible tool surface for this client.
+	if c.hasTools && len(out) == 0 {
+		for _, delay := range advertisedToolsEmptyListRetryDelays {
+			if err := sleepContext(ctx, delay); err != nil {
+				return nil, err
+			}
+			out, err = c.listToolsRaw(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if len(out) > 0 {
+				break
+			}
+		}
 	}
 
-	toolInfos := make([]ToolInfo, 0, len(out.Tools))
-	tools := make([]tool.Tool, 0, len(out.Tools))
-	for _, t := range out.Tools {
+	toolInfos := make([]ToolInfo, 0, len(out))
+	tools := make([]tool.Tool, 0, len(out))
+	for _, t := range out {
 		hinted := t.Annotations != nil && t.Annotations.ReadOnlyHint
 		visibleName := t.Name
 		if c.spec.StripRawPrefix != "" {
@@ -1155,6 +1179,34 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	c.toolAdapters = append([]tool.Tool(nil), sortedTools...)
 	c.toolsListed = true
 	return append([]tool.Tool(nil), sortedTools...), nil
+}
+
+func (c *Client) listToolsRaw(ctx context.Context) ([]mcpTool, error) {
+	res, err := c.call(ctx, "tools/list", map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Tools []mcpTool `json:"tools"`
+	}
+	if err := json.Unmarshal(res, &out); err != nil {
+		return nil, fmt.Errorf("plugin %q: decode tools/list: %w", c.name, err)
+	}
+	return out.Tools, nil
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (c *Client) cachedTools() ([]tool.Tool, bool) {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -48,6 +48,40 @@ func (t *countingToolsTransport) toolsListCalls() int {
 	return t.calls
 }
 
+type sequenceToolsTransport struct {
+	mu    sync.Mutex
+	calls int
+	raws  []json.RawMessage
+}
+
+func (t *sequenceToolsTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if method != "tools/list" {
+		return json.RawMessage(`{}`), nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.calls++
+	if len(t.raws) == 0 {
+		return json.RawMessage(`{"tools":[]}`), nil
+	}
+	idx := t.calls - 1
+	if idx >= len(t.raws) {
+		idx = len(t.raws) - 1
+	}
+	return t.raws[idx], nil
+}
+
+func (t *sequenceToolsTransport) notify(ctx context.Context, method string, params any) error {
+	return nil
+}
+func (t *sequenceToolsTransport) close() {}
+
+func (t *sequenceToolsTransport) toolsListCalls() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}
+
 type deadlineRecordingTransport struct {
 	mu        sync.Mutex
 	deadline  []time.Duration
@@ -300,6 +334,34 @@ func TestHostToolsForCachesEmptyToolList(t *testing.T) {
 	}
 	if got := tr.toolsListCalls(); got != 1 {
 		t.Fatalf("empty tools/list calls = %d, want 1", got)
+	}
+}
+
+func TestClientListToolsRetriesAdvertisedEmptyToolList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tr := &sequenceToolsTransport{raws: []json.RawMessage{
+		json.RawMessage(`{"tools":[]}`),
+		json.RawMessage(`{"tools":[{"name":"echo","description":"Echo back the message.","inputSchema":{"type":"object"}}]}`),
+	}}
+	c := &Client{
+		name:      "race",
+		t:         tr,
+		spec:      Spec{Name: "race"},
+		transport: "stdio",
+		hasTools:  true,
+	}
+
+	tools, err := c.listTools(ctx)
+	if err != nil {
+		t.Fatalf("listTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name() != "mcp__race__echo" {
+		t.Fatalf("tools = %v, want mcp__race__echo", names(tools))
+	}
+	if got := tr.toolsListCalls(); got != 2 {
+		t.Fatalf("tools/list calls = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Record the MCP `tools` capability from initialize and expose it through CLI/desktop status views.
- Retry an initial empty `tools/list` response for advertised tools servers with a short bounded backoff.
- Keep empty tool lists cacheable for servers that do not advertise tools, and add regression coverage for the startup race.

Fixes #5918.

Cache-impact: low - MCP tool schemas and ordering stay deterministic; this only retries an initial empty `tools/list` for servers that advertise tools.
Cache-guard: `go test -count=1 ./internal/plugin ./internal/cli`; `go test -count=1 .` from `desktop/`; `pnpm typecheck` from `desktop/frontend/`; `git diff --check`.

## Root Cause
Some MCP servers can start accepting JSON-RPC requests before dynamically registered tools have been added. Reasonix listed tools immediately after initialize, then cached the first empty list for the lifetime of the client.

## Validation
- `go test -count=1 ./internal/plugin ./internal/cli`
- `go test -count=1 .` from `desktop/`
- `pnpm typecheck` from `desktop/frontend/` using Node v24.16.0
- `git diff --check`
