### PR TITLE
fix(desktop): recover orphaned session leases on model/effort/token switches / 修复单窗口切换模型/思考力度/省 token 误报"会话已被占用"

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6934,11 +6934,10 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	if prevPath == "" {
 		prevPath = strings.TrimSpace(tab.currentSessionPath())
 	}
-	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
-		prevPath = a.reconciledSessionPathForTab(tab)
-		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
-		}
+	// Recomputing prevPath after this attach would be a dead store: it is
+	// unconditionally derived again after ensureTabControllerWorkspace below.
+	if a.controllerForTab(tab) == nil && prevPath != "" {
+		a.attachExistingSessionRuntime(tab, prevPath, a.ctx)
 	}
 	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 		return rebuildControllerActiveWorkError("effort")
@@ -7052,11 +7051,10 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if prevPath == "" {
 		prevPath = strings.TrimSpace(tab.currentSessionPath())
 	}
-	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
-		prevPath = a.reconciledSessionPathForTab(tab)
-		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
-		}
+	// Recomputing prevPath after this attach would be a dead store: it is
+	// unconditionally derived again after ensureTabControllerWorkspace below.
+	if a.controllerForTab(tab) == nil && prevPath != "" {
+		a.attachExistingSessionRuntime(tab, prevPath, a.ctx)
 	}
 	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 		return rebuildControllerActiveWorkError("token mode")

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6710,6 +6710,50 @@ func userFacingSessionLeaseError(setting string, err error) error {
 	return err
 }
 
+func (a *App) ensureTabSessionLeaseForRebuild(tab *WorkspaceTab, path, setting string) error {
+	if err := tab.ensureSessionLease(path); err != nil {
+		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
+			if lease, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
+				tab.releaseSessionLease()
+				tab.sessionLease = lease
+				return nil
+			} else {
+				err = reclaimErr
+			}
+		}
+		return userFacingSessionLeaseError(setting, err)
+	}
+	return nil
+}
+
+func (a *App) canReclaimCurrentProcessSessionLease(tab *WorkspaceTab, path string, err error) bool {
+	key := sessionRuntimeKey(path)
+	if tab == nil || key == "" || !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return false
+	}
+	var leaseErr *agent.SessionLeaseError
+	if !errors.As(err, &leaseErr) || leaseErr == nil || leaseErr.Info == nil {
+		return false
+	}
+	if leaseErr.Info.PID != os.Getpid() || leaseErr.Info.WriterID != agent.SessionWriterID() {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, candidate := range a.runtimeTabsLocked() {
+		if candidate == nil || candidate == tab {
+			continue
+		}
+		if candidate.sessionLease != nil && sessionRuntimeKey(candidate.sessionLease.Path()) == key {
+			return false
+		}
+		if candidate.Ctrl != nil && sessionRuntimeKey(candidate.currentSessionPath()) == key {
+			return false
+		}
+	}
+	return true
+}
+
 // SetModel switches the active model and carries the current conversation into the
 // new model's session, so the chat continues seamlessly and subsequent turns use
 // the new model. No-op if name is already active or the controller is down.
@@ -6782,8 +6826,8 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		if prevPath == "" {
 			prevPath = oldCtrl.SessionPath()
 		}
-		if err := tab.ensureSessionLease(prevPath); err != nil {
-			return userFacingSessionLeaseError("model", err)
+		if err := a.ensureTabSessionLeaseForRebuild(tab, prevPath, "model"); err != nil {
+			return err
 		}
 		if err := a.snapshotTabForAction(tab, "changing model"); err != nil {
 			return err
@@ -6818,9 +6862,9 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	newCtrl.SetGoal(tab.goal)
 
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if err := tab.ensureSessionLease(path); err != nil {
+	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "model"); err != nil {
 		newCtrl.Close()
-		return userFacingSessionLeaseError("model", err)
+		return err
 	}
 	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.mu.Lock()
@@ -6886,14 +6930,35 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		}
 		return fmt.Errorf("tab %q not found", tabID)
 	}
-	ctrl := a.controllerForTab(tab)
-	if controllerHasActiveRuntimeWork(ctrl) {
+	prevPath := a.reconciledSessionPathForTab(tab)
+	if prevPath == "" {
+		prevPath = strings.TrimSpace(tab.currentSessionPath())
+	}
+	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
+		prevPath = a.reconciledSessionPathForTab(tab)
+		if prevPath == "" {
+			prevPath = strings.TrimSpace(tab.currentSessionPath())
+		}
+	}
+	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 		return rebuildControllerActiveWorkError("effort")
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
-	prevPath := a.reconciledSessionPathForTab(tab)
+	prevPath = a.reconciledSessionPathForTab(tab)
+	if prevPath == "" {
+		prevPath = strings.TrimSpace(tab.currentSessionPath())
+	}
+	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
+		prevPath = a.reconciledSessionPathForTab(tab)
+		if prevPath == "" {
+			prevPath = strings.TrimSpace(tab.currentSessionPath())
+		}
+		if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
+			return rebuildControllerActiveWorkError("effort")
+		}
+	}
 	entry, err := a.currentProviderEntryForTab(tabID)
 	if err != nil {
 		return err
@@ -6904,15 +6969,18 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		return err
 	}
 	var carried []provider.Message
-	if oldCtrl := a.controllerForTab(tab); oldCtrl != nil {
+	oldCtrl := a.controllerForTab(tab)
+	if oldCtrl != nil {
 		if prevPath == "" {
 			prevPath = oldCtrl.SessionPath()
+		}
+		if err := a.ensureTabSessionLeaseForRebuild(tab, prevPath, "effort"); err != nil {
+			return err
 		}
 		if err := a.snapshotTabForAction(tab, "changing effort"); err != nil {
 			return err
 		}
 		carried = oldCtrl.History()
-		oldCtrl.Close()
 	}
 	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
@@ -6929,7 +6997,6 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
-		tab.releaseSessionLease()
 		return err
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
@@ -6938,9 +7005,8 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
 	newCtrl.SetGoal(tab.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if err := tab.ensureSessionLease(path); err != nil {
+	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "effort"); err != nil {
 		newCtrl.Close()
-		tab.releaseSessionLease()
 		return err
 	}
 	resumeWithFreshSystemPrompt(newCtrl, carried, path)
@@ -6959,6 +7025,9 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.Ready = true
 	a.saveTabsLocked()
 	a.mu.Unlock()
+	if oldCtrl != nil {
+		oldCtrl.Close()
+	}
 	a.persistTabSessionPath(tab, path)
 	return nil
 }
@@ -6979,14 +7048,35 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if mode == currentTabTokenMode(tab) {
 		return nil
 	}
-	ctrl := a.controllerForTab(tab)
-	if controllerHasActiveRuntimeWork(ctrl) {
+	prevPath := a.reconciledSessionPathForTab(tab)
+	if prevPath == "" {
+		prevPath = strings.TrimSpace(tab.currentSessionPath())
+	}
+	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
+		prevPath = a.reconciledSessionPathForTab(tab)
+		if prevPath == "" {
+			prevPath = strings.TrimSpace(tab.currentSessionPath())
+		}
+	}
+	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 		return rebuildControllerActiveWorkError("token mode")
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
-	prevPath := a.reconciledSessionPathForTab(tab)
+	prevPath = a.reconciledSessionPathForTab(tab)
+	if prevPath == "" {
+		prevPath = strings.TrimSpace(tab.currentSessionPath())
+	}
+	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
+		prevPath = a.reconciledSessionPathForTab(tab)
+		if prevPath == "" {
+			prevPath = strings.TrimSpace(tab.currentSessionPath())
+		}
+		if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
+			return rebuildControllerActiveWorkError("token mode")
+		}
+	}
 	modelRef, fallback, err := a.resolvedModelForTab(tab)
 	if err != nil {
 		return err
@@ -7000,6 +7090,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if oldCtrl != nil {
 		if prevPath == "" {
 			prevPath = oldCtrl.SessionPath()
+		}
+		if err := a.ensureTabSessionLeaseForRebuild(tab, prevPath, "token mode"); err != nil {
+			return err
 		}
 		if err := a.snapshotTabForAction(tab, "changing token mode"); err != nil {
 			return err
@@ -7029,7 +7122,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
 	newCtrl.SetGoal(tab.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
-	if err := tab.ensureSessionLease(path); err != nil {
+	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "token mode"); err != nil {
 		newCtrl.Close()
 		return err
 	}

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3343,6 +3343,136 @@ func TestSetTokenModeRebuildsController(t *testing.T) {
 	}
 }
 
+func TestSetTokenModeReusesCurrentSessionLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	session := agent.NewSession("old system prompt")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	exec := agent.New(nil, nil, session, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "leased-token-mode-switch.jsonl")
+	oldCtrl := control.New(control.Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "old", Sink: event.Discard})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_a",
+		Scope:       "global",
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_a", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("ensureSessionLease: %v", err)
+	}
+	if err := app.SetTokenModeForTab(tab.ID, "economy"); err != nil {
+		t.Fatalf("SetTokenModeForTab: %v", err)
+	}
+	if tab.Ctrl == nil || tab.Ctrl == oldCtrl {
+		t.Fatalf("tab controller was not rebuilt")
+	}
+	if got := currentTabTokenMode(tab); got != "economy" {
+		t.Fatalf("token mode = %q, want economy", got)
+	}
+	if tab.sessionLease == nil || sessionRuntimeKey(tab.sessionLease.Path()) != sessionRuntimeKey(path) {
+		t.Fatalf("session lease path = %q, want %q", tab.currentSessionPath(), path)
+	}
+	history := tab.Ctrl.History()
+	if len(history) < 2 || history[1].Role != provider.RoleUser || history[1].Content != "hello" {
+		t.Fatalf("carried history = %+v, want original user message", history)
+	}
+}
+
+func TestSetTokenModeLeaseHeldKeepsCurrentController(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "externally-leased-token-mode-switch.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer externalLease.Release()
+
+	session := agent.NewSession("old system prompt")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	exec := agent.New(nil, nil, session, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_a",
+		Scope:       "global",
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_a", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	err = app.SetTokenModeForTab(tab.ID, "economy")
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("SetTokenModeForTab err = %v, want ErrSessionLeaseHeld", err)
+	}
+	if strings.Contains(err.Error(), path) || strings.Contains(err.Error(), "held by") {
+		t.Fatalf("SetTokenModeForTab surfaced raw lease details: %v", err)
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatalf("tab controller changed after failed switch")
+	}
+	if got := currentTabTokenMode(tab); got != "full" {
+		t.Fatalf("token mode = %q, want full", got)
+	}
+}
+
 func TestSetTokenModeMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
@@ -4202,6 +4332,49 @@ func TestDeleteSessionValidTrashRemovesEmptyLiveStub(t *testing.T) {
 	}
 	if _, err := os.Stat(trashPath); err != nil {
 		t.Fatalf("existing trash should remain authoritative: %v", err)
+	}
+}
+
+func TestDeleteSessionValidTrashRemovesDuplicateLiveSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "duplicate-recovery.jsonl")
+	content := []byte(`{"role":"user","content":"same recovery"}` + "\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write live session: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(path), filepath.Base(path))
+	if err := os.MkdirAll(filepath.Dir(trashPath), 0o755); err != nil {
+		t.Fatalf("create trash dir: %v", err)
+	}
+	if err := os.WriteFile(trashPath, content, 0o644); err != nil {
+		t.Fatalf("write trash session: %v", err)
+	}
+
+	activePath := filepath.Join(dir, "active.jsonl")
+	if err := os.WriteFile(activePath, []byte(`{"role":"user","content":"active"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write active session: %v", err)
+	}
+	activeCtrl := control.New(control.Options{SessionDir: dir, SessionPath: activePath, Label: "active"})
+	defer activeCtrl.Close()
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"active": {ID: "active", Scope: "global", Ctrl: activeCtrl, Ready: true}},
+		activeTabID: "active",
+		tabOrder:    []string{"active"},
+	}
+
+	if err := app.DeleteSession(filepath.Base(path)); err != nil {
+		t.Fatalf("DeleteSession should remove duplicate live session: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("duplicate live session should be removed, stat err = %v", err)
+	}
+	if got, err := os.ReadFile(trashPath); err != nil || string(got) != string(content) {
+		t.Fatalf("existing trash should remain authoritative, got %q err=%v", string(got), err)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -216,11 +216,11 @@ func validateSessionTrashTarget(dir, sessionPath, key string) error {
 		}
 		trashPath := filepath.Join(itemDir, key)
 		if trashInfo, err := os.Stat(trashPath); err == nil && !trashInfo.IsDir() {
-			discardable, err := liveSessionDiscardable(sessionPath)
+			removable, err := liveSessionRemovableWithExistingTrash(sessionPath, trashPath)
 			if err != nil {
 				return err
 			}
-			if discardable {
+			if removable {
 				return nil
 			}
 			return fmt.Errorf("session already exists in trash: %s", key)
@@ -247,11 +247,11 @@ func prepareSessionTrashTarget(dir, sessionPath, key string) (bool, error) {
 		}
 		trashPath := filepath.Join(itemDir, key)
 		if trashInfo, err := os.Stat(trashPath); err == nil && !trashInfo.IsDir() {
-			discardable, err := liveSessionDiscardable(sessionPath)
+			removable, err := liveSessionRemovableWithExistingTrash(sessionPath, trashPath)
 			if err != nil {
 				return false, err
 			}
-			if discardable {
+			if removable {
 				return false, removeDesktopSessionArtifacts(sessionPath)
 			}
 			return false, fmt.Errorf("session already exists in trash: %s", key)
@@ -265,6 +265,29 @@ func prepareSessionTrashTarget(dir, sessionPath, key string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// liveSessionRemovableWithExistingTrash reports whether a live session file may
+// be removed even though a trash copy already exists under the same key: the
+// live file must be discardable (empty stub) or byte-identical to the trash
+// copy, and no other runtime may hold its session lease — another process could
+// be mid-write, and removing the file would silently drop its next save.
+func liveSessionRemovableWithExistingTrash(sessionPath, trashPath string) (bool, error) {
+	discardable, err := liveSessionDiscardable(sessionPath)
+	if err != nil {
+		return false, err
+	}
+	duplicate := false
+	if !discardable {
+		duplicate, err = trashSessionMatchesLive(sessionPath, trashPath)
+		if err != nil {
+			return false, err
+		}
+	}
+	if !discardable && !duplicate {
+		return false, nil
+	}
+	return !agent.SessionLeaseHeldByOtherRuntime(sessionPath), nil
 }
 
 func liveSessionDiscardable(sessionPath string) (bool, error) {
@@ -289,6 +312,21 @@ func liveSessionDiscardable(sessionPath string) (bool, error) {
 		return false, nil
 	}
 	return !session.HasContent(), nil
+}
+
+func trashSessionMatchesLive(sessionPath, trashPath string) (bool, error) {
+	live, err := os.ReadFile(sessionPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	trashed, err := os.ReadFile(trashPath)
+	if err != nil {
+		return false, err
+	}
+	return string(live) == string(trashed), nil
 }
 
 func sessionFileHasConversationContent(sessionPath string) bool {

--- a/desktop/sessions_lease_guard_test.go
+++ b/desktop/sessions_lease_guard_test.go
@@ -1,0 +1,90 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+)
+
+// simulateForeignSessionLeaseHolder holds path's lease the way another process
+// would: the on-disk info names a foreign writer and a raw flock on a separate
+// fd keeps the lock file locked without registering in this process's
+// in-process lease bookkeeping (flock excludes other fds even within one
+// process, so this faithfully mimics a foreign holder).
+func simulateForeignSessionLeaseHolder(t *testing.T, path string) {
+	t.Helper()
+	if err := agent.SaveSessionLeaseInfo(path, agent.SessionLeaseInfo{
+		SessionPath: path,
+		WriterID:    "other-host-4242-cafebabe",
+		PID:         os.Getpid() + 1,
+		AcquiredAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionLeaseInfo: %v", err)
+	}
+	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lease lock: %v", err)
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		t.Fatalf("flock lease lock: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+		_ = os.Remove(path + ".lease.lock")
+		_ = os.Remove(path + ".lease.json")
+	})
+}
+
+func TestDeleteSessionKeepsDuplicateLiveSessionHeldByOtherRuntime(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "duplicate-foreign-held.jsonl")
+	content := []byte(`{"role":"user","content":"same recovery"}` + "\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write live session: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(path), filepath.Base(path))
+	if err := os.MkdirAll(filepath.Dir(trashPath), 0o755); err != nil {
+		t.Fatalf("create trash dir: %v", err)
+	}
+	if err := os.WriteFile(trashPath, content, 0o644); err != nil {
+		t.Fatalf("write trash session: %v", err)
+	}
+	simulateForeignSessionLeaseHolder(t, path)
+
+	activePath := filepath.Join(dir, "active.jsonl")
+	if err := os.WriteFile(activePath, []byte(`{"role":"user","content":"active"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write active session: %v", err)
+	}
+	activeCtrl := control.New(control.Options{SessionDir: dir, SessionPath: activePath, Label: "active"})
+	defer activeCtrl.Close()
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"active": {ID: "active", Scope: "global", Ctrl: activeCtrl, Ready: true}},
+		activeTabID: "active",
+		tabOrder:    []string{"active"},
+	}
+
+	err := app.DeleteSession(filepath.Base(path))
+	if err == nil || !strings.Contains(err.Error(), "session already exists in trash") {
+		t.Fatalf("DeleteSession err = %v, want refusal while a foreign runtime holds the lease", err)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != string(content) {
+		t.Fatalf("live session must stay intact, got %q err=%v", string(got), readErr)
+	}
+}

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"reasonix/internal/fileutil"
@@ -15,7 +16,16 @@ import (
 
 var ErrSessionLeaseHeld = errors.New("session lease held by another runtime")
 
-var sessionLeaseOwners sync.Map
+// sessionLeaseOwners maps the canonical session path to the owning lease's
+// unique id (from sessionLeaseSeq). Storing an identity instead of a bare
+// sentinel lets Release and the acquire/reclaim failure paths use
+// CompareAndDelete, so a racing caller can never evict an entry it does not
+// own. Ids stay unique for the process lifetime, so a stale lease released
+// after its entry was reclaimed cannot delete the new owner's entry either.
+var (
+	sessionLeaseOwners sync.Map
+	sessionLeaseSeq    atomic.Uint64
+)
 
 type SessionLeaseInfo struct {
 	SessionPath string    `json:"session_path"`
@@ -45,9 +55,10 @@ func (e *SessionLeaseError) Unwrap() error {
 }
 
 type SessionLease struct {
-	path   string
-	unlock func()
-	once   sync.Once
+	path    string
+	ownerID uint64
+	unlock  func()
+	once    sync.Once
 }
 
 func TryAcquireSessionLease(path string) (*SessionLease, error) {
@@ -58,25 +69,105 @@ func TryAcquireSessionLease(path string) (*SessionLease, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	if _, loaded := sessionLeaseOwners.LoadOrStore(path, struct{}{}); loaded {
+	ownerID := sessionLeaseSeq.Add(1)
+	if _, loaded := sessionLeaseOwners.LoadOrStore(path, ownerID); loaded {
 		info, _ := LoadSessionLeaseInfo(path)
 		return nil, &SessionLeaseError{Path: path, Info: info}
 	}
 	unlock, err := tryLockSessionLeaseFile(path)
 	if err != nil {
-		sessionLeaseOwners.Delete(path)
+		sessionLeaseOwners.CompareAndDelete(path, ownerID)
 		if errors.Is(err, ErrSessionLeaseHeld) {
 			info, _ := LoadSessionLeaseInfo(path)
 			return nil, &SessionLeaseError{Path: path, Info: info}
 		}
 		return nil, err
 	}
-	lease := &SessionLease{path: path, unlock: unlock}
+	lease := &SessionLease{path: path, ownerID: ownerID, unlock: unlock}
 	if err := SaveSessionLeaseInfo(path, newSessionLeaseInfo(path)); err != nil {
 		lease.Release()
 		return nil, err
 	}
 	return lease, nil
+}
+
+// TryReclaimCurrentProcessSessionLease re-acquires a lease whose in-process
+// owner entry was orphaned (a lease dropped without Release). It only succeeds
+// when the on-disk lease info identifies the current process AND the OS lease
+// lock is free: an active holder keeps its lock file locked, so reclaiming
+// from it fails with ErrSessionLeaseHeld without touching the holder's entry.
+func TryReclaimCurrentProcessSessionLease(path string) (*SessionLease, error) {
+	path = canonicalSessionSavePath(path)
+	info, err := LoadSessionLeaseInfo(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// The holder finished releasing between the caller's failed
+			// acquire and now; a regular acquire can win the lease cleanly.
+			return TryAcquireSessionLease(path)
+		}
+		// Unreadable lease info means the holder cannot be identified, so
+		// reclaiming is unsafe. Report the lease as held rather than leaking
+		// a raw filesystem error to callers that surface it to users.
+		return nil, &SessionLeaseError{Path: path}
+	}
+	if info == nil || info.PID != os.Getpid() || info.WriterID != SessionWriterID() {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	unlock, err := tryLockSessionLeaseFile(path)
+	if err != nil {
+		if errors.Is(err, ErrSessionLeaseHeld) {
+			return nil, &SessionLeaseError{Path: path, Info: info}
+		}
+		return nil, err
+	}
+	// Holding the OS lock proves no live lease owns this path right now, so
+	// overwriting the stale owner entry is safe; concurrent reclaimers fail
+	// the lock above and never reach this store, and a stale lease released
+	// later misses its CompareAndDelete against the new owner id.
+	ownerID := sessionLeaseSeq.Add(1)
+	lease := &SessionLease{path: path, ownerID: ownerID, unlock: unlock}
+	sessionLeaseOwners.Store(path, ownerID)
+	if err := SaveSessionLeaseInfo(path, newSessionLeaseInfo(path)); err != nil {
+		lease.Release()
+		return nil, err
+	}
+	return lease, nil
+}
+
+// SessionLeaseHeldByOtherRuntime reports whether path's session lease is held
+// by a live runtime other than the calling process. Callers use it to keep
+// destructive operations away from sessions another process may be writing;
+// leases held by this process report false because callers tear their own
+// runtimes down before acting. The lock file is only probed when a foreign
+// lease info file exists, so the common uncontended case never touches the
+// lock; a probe cannot steal a live lease because holders keep the lock held
+// for their whole lifetime.
+func SessionLeaseHeldByOtherRuntime(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	path = canonicalSessionSavePath(path)
+	if _, ok := sessionLeaseOwners.Load(path); ok {
+		// Held by this process; no need to touch the lock file.
+		return false
+	}
+	info, err := LoadSessionLeaseInfo(path)
+	if err != nil {
+		// No info file means no holder: live holders keep it present for
+		// their whole hold. An unreadable one hides the holder's identity,
+		// so err on the side of treating the session as busy.
+		return !os.IsNotExist(err)
+	}
+	if info != nil && info.PID == os.Getpid() && info.WriterID == SessionWriterID() {
+		return false
+	}
+	unlock, err := tryLockSessionLeaseFile(path)
+	if err == nil {
+		// Foreign info but a free lock: leftover from a crashed process.
+		unlock()
+		return false
+	}
+	return true
 }
 
 func (l *SessionLease) Path() string {
@@ -95,7 +186,9 @@ func (l *SessionLease) Release() {
 		if l.unlock != nil {
 			l.unlock()
 		}
-		sessionLeaseOwners.Delete(l.path)
+		// Only remove the entry this lease owns: after a reclaim the map may
+		// already point at a newer lease for the same path.
+		sessionLeaseOwners.CompareAndDelete(l.path, l.ownerID)
 	})
 }
 

--- a/internal/agent/session_lease_test.go
+++ b/internal/agent/session_lease_test.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
@@ -38,4 +41,212 @@ func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
 		t.Fatalf("third TryAcquireSessionLease after release: %v", err)
 	}
 	third.Release()
+}
+
+func TestSessionLeaseReclaimsCurrentProcessStaleOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	path = canonicalSessionSavePath(path)
+	sessionLeaseOwners.Store(path, struct{}{})
+	t.Cleanup(func() {
+		sessionLeaseOwners.Delete(path)
+		_ = os.Remove(sessionLeaseInfoPath(path))
+	})
+	if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
+		SessionPath: path,
+		WriterID:    SessionWriterID(),
+		PID:         os.Getpid(),
+		AcquiredAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionLeaseInfo: %v", err)
+	}
+	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+	lease, err := TryReclaimCurrentProcessSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryReclaimCurrentProcessSessionLease: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
+	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+	sessionLeaseOwners.Store(path, struct{}{})
+	t.Cleanup(func() {
+		sessionLeaseOwners.Delete(path)
+		_ = os.Remove(sessionLeaseInfoPath(path))
+	})
+	if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
+		SessionPath: path,
+		WriterID:    SessionWriterID(),
+		PID:         os.Getpid(),
+		AcquiredAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionLeaseInfo: %v", err)
+	}
+
+	const attempts = 16
+	var wg sync.WaitGroup
+	leases := make(chan *SessionLease, attempts)
+	start := make(chan struct{})
+	for range attempts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if lease, err := TryReclaimCurrentProcessSessionLease(path); err == nil && lease != nil {
+				leases <- lease
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(leases)
+
+	var won []*SessionLease
+	for lease := range leases {
+		won = append(won, lease)
+	}
+	if len(won) != 1 {
+		t.Fatalf("concurrent reclaim produced %d leases, want exactly 1", len(won))
+	}
+	// The losers must not have evicted the winner's owner entry.
+	if _, ok := sessionLeaseOwners.Load(path); !ok {
+		t.Fatal("winner's owner entry was evicted by a failed concurrent reclaim")
+	}
+	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryAcquireSessionLease while reclaimed lease is held err = %v, want ErrSessionLeaseHeld", err)
+	}
+	won[0].Release()
+	lease, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease after release: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseReclaimRefusesActiveHolder(t *testing.T) {
+	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+	holder, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer holder.Release()
+
+	if lease, err := TryReclaimCurrentProcessSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryReclaimCurrentProcessSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+	// The failed reclaim must leave the holder's owner entry intact.
+	if _, ok := sessionLeaseOwners.Load(path); !ok {
+		t.Fatal("active holder's owner entry was evicted by a failed reclaim")
+	}
+	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+}
+
+func TestSessionLeaseReclaimAfterHolderReleased(t *testing.T) {
+	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+	holder, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	holder.Release()
+
+	// The holder released between the caller's failed acquire and the
+	// reclaim: the lease info file is gone and a plain acquire must win.
+	lease, err := TryReclaimCurrentProcessSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryReclaimCurrentProcessSessionLease after release: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseStaleReleaseKeepsNewOwnerEntry(t *testing.T) {
+	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+	stale, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	// Simulate a reclaim that took over the entry while the stale lease was
+	// still alive: the map now names a different owner.
+	sessionLeaseOwners.Store(path, uint64(1<<62))
+	t.Cleanup(func() { sessionLeaseOwners.Delete(path) })
+
+	stale.Release()
+	if _, ok := sessionLeaseOwners.Load(path); !ok {
+		t.Fatal("stale Release evicted the new owner's entry")
+	}
+}
+
+func TestSessionLeaseHeldByOtherRuntime(t *testing.T) {
+	t.Run("no lease", func(t *testing.T) {
+		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+		if SessionLeaseHeldByOtherRuntime(path) {
+			t.Fatal("unheld session reported as held by another runtime")
+		}
+	})
+	t.Run("held by this process", func(t *testing.T) {
+		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+		lease, err := TryAcquireSessionLease(path)
+		if err != nil {
+			t.Fatalf("TryAcquireSessionLease: %v", err)
+		}
+		defer lease.Release()
+		if SessionLeaseHeldByOtherRuntime(path) {
+			t.Fatal("own lease reported as held by another runtime")
+		}
+	})
+	t.Run("foreign info with live lock", func(t *testing.T) {
+		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		unlock, err := tryLockSessionLeaseFile(path)
+		if err != nil {
+			t.Fatalf("tryLockSessionLeaseFile: %v", err)
+		}
+		defer unlock()
+		if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
+			SessionPath: path,
+			WriterID:    "other-host-1234-deadbeef",
+			PID:         os.Getpid() + 1,
+			AcquiredAt:  time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("SaveSessionLeaseInfo: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(path)) })
+		if !SessionLeaseHeldByOtherRuntime(path) {
+			t.Fatal("foreign-held session not reported as held by another runtime")
+		}
+	})
+	t.Run("foreign info from crashed process", func(t *testing.T) {
+		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
+		if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
+			SessionPath: path,
+			WriterID:    "other-host-1234-deadbeef",
+			PID:         os.Getpid() + 1,
+			AcquiredAt:  time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("SaveSessionLeaseInfo: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(path)) })
+		// Info file left behind but the lock is free: the holder crashed, so
+		// the session is not considered held.
+		if SessionLeaseHeldByOtherRuntime(path) {
+			t.Fatal("crashed holder's leftover info reported as held")
+		}
+	})
 }


### PR DESCRIPTION
## Problem

In a single-window session (typically a recovered session after an interrupted turn), switching model failed with:

> this session is already open in another Reasonix window or still running in the background; close the other window or open a copy before changing model

even though no other window existed. Switching effort / token mode on the same session leaked the raw lease error to the UI, including the session file path and writer id (`session lease held by another runtime: <path> is held by <host>-<pid>-<writer>`).

## Root cause

1. An interrupted runtime can orphan the in-process lease owner entry (`sessionLeaseOwners`): the entry stays around while nothing actually writes the session, so every controller rebuild (model/effort/token switch) is blocked by the process's own sentinel.
2. `SetEffortForTab` / `SetTokenModeForTab` had a bare `return err` on the lease acquire path, surfacing the raw `SessionLeaseError` text.
3. `SetEffortForTab` closed the old controller before building the replacement, so a failed switch left the tab without a usable controller.

## Changes

**`internal/agent` (lease kernel)**

- `sessionLeaseOwners` now stores a unique per-lease id and all removals use `CompareAndDelete`, so acquire-failure paths and stale releases can only remove their own entry — a racing reclaim can no longer evict a live holder's sentinel.
- New `TryReclaimCurrentProcessSessionLease` takes the OS lease lock *first*: an active holder keeps the lock held for its whole lifetime, so reclaiming from it fails with `ErrSessionLeaseHeld` without touching its entry; only a truly orphaned entry (lock free + lease info naming this process) is taken over.
- If the lease info vanished because the holder just finished releasing, reclaim falls back to a plain acquire instead of surfacing a raw filesystem error; unreadable info reports as a held lease.
- New `SessionLeaseHeldByOtherRuntime` distinguishes a live foreign holder from a crashed-process leftover, without touching the lock file in the uncontended case.

**`desktop` (switch flows + delete)**

- All three rebuild flows (`SetModelForTab` / `SetEffortForTab` / `SetTokenModeForTab`) go through `ensureTabSessionLeaseForRebuild`, which reclaims a same-process orphaned lease only when no other tab or detached runtime uses the session, and always maps lease conflicts to the user-facing busy error.
- Effort and token-mode paths now attach an existing detached runtime before rebuilding, mirroring the model switch.
- The old controller is closed only after the replacement is fully installed; build failures keep the tab's lease, so a failed switch leaves the current session usable for chat.
- Deleting a live session that is byte-identical to its existing trash copy is now allowed (recovered-session duplicates), but refused while **another runtime** holds the session lease, so a foreign window's next save cannot be silently dropped; empty-stub removal gets the same guard.

## Concurrency safety

- Mutual exclusion stays anchored on the OS file lock (flock / LockFileEx, held for the lease lifetime); the in-process map is a fast-fail layer that now carries owner identity.
- Adversarial regression tests: a 16-goroutine concurrent reclaim yields exactly one winner and preserves the winner's owner entry; reclaim against an active holder fails and leaves the holder intact; a stale `Release` after takeover cannot evict the new owner.

## Tests

- `go test ./internal/agent` (plus `-race`), `go test ./desktop` (full suite; lease/switch/delete subset with `-race`), root `go test ./...` — all green.
- New coverage: concurrent reclaim single winner, reclaim vs active holder, reclaim after holder release, stale-release identity, `SessionLeaseHeldByOtherRuntime` truth table (unheld / this process / live foreign / crashed leftover), duplicate-trash delete allowed when unheld and refused while a foreign runtime holds the lease (real flock), model/effort/token switch lease-reuse and external-conflict paths.
