### PR TITLE
Fix deferred settings rebuild after persistence / 修复持久化后热刷新延迟失败

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -122,6 +122,17 @@ type App struct {
 	// topic/workspace removal trash the same files while it is in flight.
 	sessionRemovalMu sync.Mutex
 
+	// runtimeRebuildMu serializes controller rebuilds (build + swap) across
+	// rebuildSetting, SetModelForTab, and the deferred-rebuild retry loop. Two
+	// concurrent rebuilds of the same tab both pass the tab-identity check at
+	// swap time (the tab pointer is unchanged), so the loser's controller
+	// would replace the winner's and leak it without Close.
+	runtimeRebuildMu sync.Mutex
+
+	// deferredRebuild tracks tabs whose settings were saved but whose runtime
+	// could not refresh because the session lease was held by another process.
+	deferredRebuild deferredRebuildState
+
 	// detachedSessions keeps live session runtimes whose visible tab was closed.
 	// It is process-local by design: shutdown closes every detached controller.
 	detachedSessions map[string]*WorkspaceTab
@@ -369,6 +380,7 @@ func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	installSystemQuitHook()
 	a.startTray()
+	a.enableDeferredRebuildRetry()
 
 	if cfg, err := config.Load(); err == nil && cfg.DesktopMetrics() && version != "dev" {
 		a.metrics.Store(newMetricsAggregator(config.MemoryUserDir()))
@@ -657,6 +669,7 @@ func (a *App) snapshotAllTabs() {
 
 // shutdown snapshots all tabs, saves the final window geometry, and closes tabs.
 func (a *App) shutdown(context.Context) {
+	a.stopDeferredRebuildRetry()
 	a.stopMainThreadWatchdog()
 	if a.heartbeat != nil {
 		a.heartbeat.Stop()
@@ -5813,7 +5826,15 @@ func (a *App) RemoveSkillPath(path string) error {
 // discovery, the system prompt index, and slash completions.
 func (a *App) RefreshSkills() error {
 	a.invalidateSkillRootsCache()
-	return a.rebuild()
+	if err := a.rebuild(); err != nil {
+		// The skill cache is already invalidated; refresh the runtime once the
+		// other window releases the session lease.
+		if _, ok := a.deferredRebuildWarning("skills", err); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // ReloadCommands rescans command directories and hot-swaps without restarting
@@ -6676,8 +6697,17 @@ func controllerHasActiveRuntimeWork(ctrl control.SessionAPI) bool {
 	return status.Running || status.PendingPrompt || status.BackgroundJobs > 0
 }
 
+// rebuildBusyError reports a rebuild rejected because the controller still has
+// a running turn, pending prompt, or background jobs. Typed so the
+// deferred-rebuild retry loop can keep waiting instead of giving up.
+type rebuildBusyError struct{ setting string }
+
+func (e *rebuildBusyError) Error() string {
+	return fmt.Sprintf("finish or cancel the current turn, answer pending prompts, and stop background jobs before changing %s", e.setting)
+}
+
 func rebuildControllerActiveWorkError(setting string) error {
-	return fmt.Errorf("finish or cancel the current turn, answer pending prompts, and stop background jobs before changing %s", setting)
+	return &rebuildBusyError{setting: setting}
 }
 
 type sessionLeaseBusyError struct {
@@ -6728,6 +6758,11 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if name == tab.model {
 		return nil
 	}
+	// Same build+swap shape as rebuildSetting; hold the same lock so a settings
+	// rebuild (manual or from the deferred-rebuild retry loop) and a model
+	// switch cannot interleave on one tab.
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
 		prevPath = strings.TrimSpace(tab.currentSessionPath())
@@ -6842,6 +6877,8 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if oldCtrl != nil {
 		oldCtrl.Close()
 	}
+	// The runtime now reflects the on-disk config; drop any deferred refresh.
+	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
 	return nil
 }
@@ -6886,6 +6923,11 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		}
 		return fmt.Errorf("tab %q not found", tabID)
 	}
+	// Build+swap path; serialize with the other rebuild paths (see
+	// runtimeRebuildMu). The tab==nil branch above goes through
+	// applyProviderEffortConfig → rebuildSetting, which takes the lock itself.
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
 	ctrl := a.controllerForTab(tab)
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("effort")
@@ -6904,7 +6946,8 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		return err
 	}
 	var carried []provider.Message
-	if oldCtrl := a.controllerForTab(tab); oldCtrl != nil {
+	oldCtrl := a.controllerForTab(tab)
+	if oldCtrl != nil {
 		if prevPath == "" {
 			prevPath = oldCtrl.SessionPath()
 		}
@@ -6912,7 +6955,6 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 			return err
 		}
 		carried = oldCtrl.History()
-		oldCtrl.Close()
 	}
 	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
@@ -6929,7 +6971,6 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
-		tab.releaseSessionLease()
 		return err
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
@@ -6940,8 +6981,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := tab.ensureSessionLease(path); err != nil {
 		newCtrl.Close()
-		tab.releaseSessionLease()
-		return err
+		return userFacingSessionLeaseError("effort", err)
 	}
 	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.mu.Lock()
@@ -6959,6 +6999,9 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.Ready = true
 	a.saveTabsLocked()
 	a.mu.Unlock()
+	if oldCtrl != nil {
+		oldCtrl.Close()
+	}
 	a.persistTabSessionPath(tab, path)
 	return nil
 }
@@ -6979,6 +7022,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if mode == currentTabTokenMode(tab) {
 		return nil
 	}
+	// Build+swap path; serialize with the other rebuild paths (see runtimeRebuildMu).
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
 	ctrl := a.controllerForTab(tab)
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("token mode")
@@ -7031,7 +7077,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := tab.ensureSessionLease(path); err != nil {
 		newCtrl.Close()
-		return err
+		return userFacingSessionLeaseError("token mode", err)
 	}
 	resumeWithFreshSystemPrompt(newCtrl, carried, path)
 	a.mu.Lock()
@@ -7526,8 +7572,8 @@ func (a *App) noticeForTab(tabID, text string) {
 	}
 }
 
-func (a *App) warningForActiveTab(text string) {
-	tab := a.activeTab()
+func (a *App) warnForTab(tabID, text string) {
+	tab := a.tabByID(tabID)
 	if tab != nil && tab.sink != nil {
 		tab.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7526,6 +7526,13 @@ func (a *App) noticeForTab(tabID, text string) {
 	}
 }
 
+func (a *App) warningForActiveTab(text string) {
+	tab := a.activeTab()
+	if tab != nil && tab.sink != nil {
+		tab.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
+	}
+}
+
 func (a *App) runEffortCommandForTab(tabID, input string) {
 	entry, err := a.currentProviderEntryForTab(tabID)
 	if err != nil {
@@ -8145,13 +8152,10 @@ func (a *App) ConnectKey(apiKey string) (string, error) {
 		return "", fmt.Errorf("save: %w", err)
 	}
 	if err := a.rebuildSetting("provider key"); err != nil {
-		// Key is persisted. Keep the current session usable and let a later
-		// rebuild pick up the credential.
-		slog.Warn("desktop: connect key rebuild failed", "err", err)
-		if strings.TrimSpace(warning) == "" {
-			warning = err.Error()
+		if rebuildWarning, ok := a.deferredRebuildWarning("provider key", err); ok {
+			warning = appendSettingsWarning(warning, rebuildWarning)
 		} else {
-			warning = warning + "\n" + err.Error()
+			return "", err
 		}
 	}
 	return warning, nil

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1939,6 +1939,331 @@ func TestConfigChangeLeaseHeldPersistsAndDefersRefresh(t *testing.T) {
 	}
 }
 
+func TestDeferredRebuildRetryAppliesAfterLeaseRelease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	prevInterval := deferredRebuildRetryInterval
+	deferredRebuildRetryInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deferredRebuildRetryInterval = prevInterval })
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "deferred-rebuild-retry.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(sessionPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			externalLease.Release()
+		}
+	}()
+
+	oldExec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.enableDeferredRebuildRetry()
+	t.Cleanup(app.stopDeferredRebuildRetry)
+	tab := &WorkspaceTab{
+		ID:          "tab_deferred_retry",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_deferred_retry", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if c := app.controllerForTab(tab); c != nil && c != oldCtrl {
+			c.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.SetMaxSubagentDepth(1); err != nil {
+		t.Fatalf("SetMaxSubagentDepth: %v", err)
+	}
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild was not scheduled while the lease is held")
+	}
+	if app.controllerForTab(tab) != oldCtrl {
+		t.Fatal("controller changed while the lease is still held")
+	}
+
+	externalLease.Release()
+	released = true
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !app.deferredRebuildPending(tab.ID) && app.controllerForTab(tab) != oldCtrl {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild is still pending after the lease was released")
+	}
+	if c := app.controllerForTab(tab); c == nil || c == oldCtrl {
+		t.Fatalf("controller was not rebuilt after the lease release: got %p", c)
+	}
+}
+
+func TestDeferredRebuildScheduleAfterStopIsNoop(t *testing.T) {
+	app := NewApp()
+	app.stopDeferredRebuildRetry()
+	app.scheduleDeferredRebuild("tab_x", "settings")
+	if app.deferredRebuildPending("tab_x") {
+		t.Fatal("schedule after stop should not register pending work")
+	}
+}
+
+func TestDeferredRebuildWaitsForTabToBecomeActive(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	prevInterval := deferredRebuildRetryInterval
+	deferredRebuildRetryInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deferredRebuildRetryInterval = prevInterval })
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "deferred-rebuild-inactive.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(sessionPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			externalLease.Release()
+		}
+	}()
+
+	oldExec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	otherCtrl := control.New(control.Options{Label: "other"})
+	defer otherCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.enableDeferredRebuildRetry()
+	t.Cleanup(app.stopDeferredRebuildRetry)
+	tab := &WorkspaceTab{
+		ID:          "tab_pending",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_pending", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	other := &WorkspaceTab{
+		ID:          "tab_other",
+		Scope:       "global",
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        otherCtrl,
+		sink:        &tabEventSink{tabID: "tab_other", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab, other.ID: other}
+	app.tabOrder = []string{tab.ID, other.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if c := app.controllerForTab(tab); c != nil && c != oldCtrl {
+			c.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.SetMaxSubagentDepth(1); err != nil {
+		t.Fatalf("SetMaxSubagentDepth: %v", err)
+	}
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild was not scheduled while the lease is held")
+	}
+
+	// Focus another tab, then release the lease: the retry must not rebuild
+	// while the pending tab is inactive (rebuildSettingLocked acts on the
+	// active tab), and must not touch the focused tab's runtime either.
+	app.mu.Lock()
+	app.activeTabID = other.ID
+	app.mu.Unlock()
+	externalLease.Release()
+	released = true
+
+	time.Sleep(150 * time.Millisecond)
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("pending entry was consumed while its tab was inactive")
+	}
+	if app.controllerForTab(tab) != oldCtrl {
+		t.Fatal("inactive pending tab was rebuilt")
+	}
+	if app.controllerForTab(other) != otherCtrl {
+		t.Fatal("focused tab was rebuilt by another tab's deferred retry")
+	}
+
+	// Switch back: the retry should now refresh the pending tab.
+	app.mu.Lock()
+	app.activeTabID = tab.ID
+	app.mu.Unlock()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !app.deferredRebuildPending(tab.ID) && app.controllerForTab(tab) != oldCtrl {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if app.deferredRebuildPending(tab.ID) {
+		t.Fatal("deferred rebuild still pending after its tab became active again")
+	}
+	if c := app.controllerForTab(tab); c == nil || c == oldCtrl {
+		t.Fatalf("controller was not rebuilt after tab reactivation: got %p", c)
+	}
+}
+
+func TestSetEffortForTabLeaseHeldKeepsOldControllerAlive(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:             "old",
+		Kind:             "openai",
+		BaseURL:          "https://example.invalid/v1",
+		Model:            "old-model",
+		APIKeyEnv:        "OLD_MODEL_KEY",
+		SupportedEfforts: []string{"low", "max"},
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "externally-leased-effort-switch.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(sessionPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			externalLease.Release()
+		}
+	}()
+
+	oldExec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_effort",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_effort", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if c := app.controllerForTab(tab); c != nil && c != oldCtrl {
+			c.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	err = app.SetEffortForTab(tab.ID, "max")
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("SetEffortForTab err = %v, want ErrSessionLeaseHeld", err)
+	}
+	if strings.Contains(err.Error(), sessionPath) || strings.Contains(err.Error(), "held by") {
+		t.Fatalf("SetEffortForTab surfaced raw lease details: %v", err)
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatal("tab controller changed after failed effort switch")
+	}
+
+	// The failed switch must leave the old runtime alive: after the other
+	// window releases the lease, retrying from the same tab has to succeed.
+	// (The old code closed the old controller before acquiring the lease, so
+	// this retry died on a snapshot of a closed session.)
+	externalLease.Release()
+	released = true
+	if err := app.SetEffortForTab(tab.ID, "max"); err != nil {
+		t.Fatalf("SetEffortForTab retry after lease release: %v", err)
+	}
+	if tab.Ctrl == oldCtrl {
+		t.Fatal("retry did not rebuild the controller")
+	}
+}
+
 func TestAddOfficialProviderAccessUsesDesktopLanguagePricing(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1757,12 +1757,15 @@ func TestSetProviderKeyLeaseHeldKeepsCurrentController(t *testing.T) {
 	app.tabOrder = []string{tab.ID}
 	app.activeTabID = tab.ID
 
-	_, err = app.SetProviderKey("LONGCAT_API_KEY", "sk-longcat")
-	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
-		t.Fatalf("SetProviderKey err = %v, want ErrSessionLeaseHeld", err)
+	warning, err := app.SetProviderKey("LONGCAT_API_KEY", "sk-longcat")
+	if err != nil {
+		t.Fatalf("SetProviderKey: %v", err)
 	}
-	if strings.Contains(err.Error(), sessionPath) || strings.Contains(err.Error(), "held by") {
-		t.Fatalf("SetProviderKey surfaced raw lease details: %v", err)
+	if !strings.Contains(warning, "current session could not refresh yet") || !strings.Contains(warning, "another Reasonix window") {
+		t.Fatalf("SetProviderKey warning = %q, want deferred rebuild warning", warning)
+	}
+	if strings.Contains(warning, sessionPath) || strings.Contains(warning, "held by") {
+		t.Fatalf("SetProviderKey surfaced raw lease details: %v", warning)
 	}
 	if tab.Ctrl != oldCtrl {
 		t.Fatalf("tab controller changed after failed provider-key rebuild")
@@ -1775,6 +1778,164 @@ func TestSetProviderKeyLeaseHeldKeepsCurrentController(t *testing.T) {
 	}
 	if access := providerAccessSet(config.LoadForEditWithoutCredentials(config.UserConfigPath()).Desktop.ProviderAccess); !access["longcat"] {
 		t.Fatalf("provider_access should still persist longcat after key save")
+	}
+}
+
+func TestSaveProviderWithKeyLeaseHeldPersistsCustomProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "externally-leased-custom-provider.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(sessionPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer externalLease.Release()
+
+	oldSession := agent.NewSession("old system prompt")
+	oldSession.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_custom_provider",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_custom_provider", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	warning, err := app.SaveProviderWithKey(ProviderView{
+		Name:      "proxy",
+		Kind:      "openai",
+		BaseURL:   "https://proxy.example/v1",
+		Models:    []string{"model-a", "model-b"},
+		Default:   "model-a",
+		APIKeyEnv: "PROXY_API_KEY",
+	}, "sk-proxy")
+	if err != nil {
+		t.Fatalf("SaveProviderWithKey: %v", err)
+	}
+	if !strings.Contains(warning, "current session could not refresh yet") || !strings.Contains(warning, "another Reasonix window") {
+		t.Fatalf("SaveProviderWithKey warning = %q, want deferred rebuild warning", warning)
+	}
+	if strings.Contains(warning, sessionPath) || strings.Contains(warning, "held by") {
+		t.Fatalf("SaveProviderWithKey surfaced raw lease details: %v", warning)
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatalf("tab controller changed after failed provider rebuild")
+	}
+	gotCfg := config.LoadForEditWithoutCredentials(config.UserConfigPath())
+	got, ok := gotCfg.Provider("proxy")
+	if !ok {
+		t.Fatal("custom provider was not saved")
+	}
+	if want := []string{"model-a", "model-b"}; !reflect.DeepEqual(got.ModelList(), want) {
+		t.Fatalf("custom provider models = %v, want %v", got.ModelList(), want)
+	}
+	if !providerAccessSet(gotCfg.Desktop.ProviderAccess)["proxy"] {
+		t.Fatalf("provider_access = %+v, want proxy", gotCfg.Desktop.ProviderAccess)
+	}
+	data, err := os.ReadFile(config.UserCredentialsPath())
+	if err != nil {
+		t.Fatalf("read credentials: %v", err)
+	}
+	if !strings.Contains(string(data), "PROXY_API_KEY=sk-proxy") {
+		t.Fatalf("provider key was not saved:\n%s", data)
+	}
+}
+
+func TestConfigChangeLeaseHeldPersistsAndDefersRefresh(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "externally-leased-settings.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	externalLease, err := agent.TryAcquireSessionLease(sessionPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer externalLease.Release()
+
+	oldExec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+	defer oldCtrl.Close()
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "tab_settings",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		Ready:       true,
+		model:       "old/old-model",
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "tab_settings", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.SetMaxSubagentDepth(1); err != nil {
+		t.Fatalf("SetMaxSubagentDepth should defer lease-held refresh instead of failing: %v", err)
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatalf("tab controller changed after deferred settings rebuild")
+	}
+	got := config.LoadForEditWithoutCredentials(config.UserConfigPath())
+	if got.Agent.MaxSubagentDepth != 1 {
+		t.Fatalf("saved max_subagent_depth = %d, want 1", got.Agent.MaxSubagentDepth)
 	}
 }
 

--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+// deferredRebuildRetryInterval is how often the retry loop probes a held
+// session lease. Package-level so tests can shorten it.
+var deferredRebuildRetryInterval = 2 * time.Second
+
+// deferredRebuildState tracks tabs whose settings were saved to disk but whose
+// runtime could not refresh because the session lease was held by another
+// Reasonix process. A single background loop probes the lease and replays the
+// rebuild once the other side releases it. The loop only runs after
+// enableDeferredRebuildRetry (the wails startup hook); tests that never call
+// it get the pending bookkeeping without a background goroutine.
+type deferredRebuildState struct {
+	mu      sync.Mutex
+	pending map[string]string // tab ID -> setting label for notices
+	enabled bool
+	running bool
+	stopped bool
+	stop    chan struct{}
+}
+
+// enableDeferredRebuildRetry arms the retry loop; called from startup.
+func (a *App) enableDeferredRebuildRetry() {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.enabled = true
+	a.startDeferredRebuildLoopLocked()
+}
+
+// startDeferredRebuildLoopLocked starts the loop when it is armed, idle, and
+// has work. Callers must hold d.mu.
+func (a *App) startDeferredRebuildLoopLocked() {
+	d := &a.deferredRebuild
+	if !d.enabled || d.running || d.stopped || len(d.pending) == 0 {
+		return
+	}
+	d.running = true
+	if d.stop == nil {
+		d.stop = make(chan struct{})
+	}
+	go a.deferredRebuildLoop(d.stop)
+}
+
+// scheduleDeferredRebuild records that tabID needs a runtime refresh for
+// setting and starts the retry loop if it is not running yet. Repeated calls
+// for the same tab collapse into one retry carrying the latest label.
+func (a *App) scheduleDeferredRebuild(tabID, setting string) {
+	tabID = strings.TrimSpace(tabID)
+	if tabID == "" {
+		return
+	}
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	if d.pending == nil {
+		d.pending = map[string]string{}
+	}
+	d.pending[tabID] = setting
+	a.startDeferredRebuildLoopLocked()
+}
+
+func (a *App) clearDeferredRebuild(tabID string) {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	delete(d.pending, tabID)
+	d.mu.Unlock()
+}
+
+func (a *App) deferredRebuildPending(tabID string) bool {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, ok := d.pending[tabID]
+	return ok
+}
+
+// stopDeferredRebuildRetry permanently stops the retry loop; used on shutdown
+// and by tests.
+func (a *App) stopDeferredRebuildRetry() {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	d.stopped = true
+	if d.stop != nil {
+		close(d.stop)
+	}
+}
+
+func (a *App) deferredRebuildLoop(stop <-chan struct{}) {
+	ticker := time.NewTicker(deferredRebuildRetryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			d := &a.deferredRebuild
+			d.mu.Lock()
+			d.running = false
+			d.mu.Unlock()
+			return
+		case <-ticker.C:
+		}
+		if a.deferredRebuildTickDone() {
+			return
+		}
+	}
+}
+
+// deferredRebuildTickDone runs one retry pass and reports true when the loop
+// should exit because nothing is pending anymore.
+func (a *App) deferredRebuildTickDone() bool {
+	d := &a.deferredRebuild
+	d.mu.Lock()
+	if d.stopped || len(d.pending) == 0 {
+		d.running = false
+		d.mu.Unlock()
+		return true
+	}
+	pending := make(map[string]string, len(d.pending))
+	for id, setting := range d.pending {
+		pending[id] = setting
+	}
+	d.mu.Unlock()
+
+	for tabID, setting := range pending {
+		a.retryDeferredRebuild(tabID, setting)
+	}
+	return false
+}
+
+func (a *App) retryDeferredRebuild(tabID, setting string) {
+	if a.ctx == nil {
+		return
+	}
+	tab := a.tabByID(tabID)
+	if tab == nil || tab.ID != tabID {
+		// The tab is gone; nothing left to refresh.
+		a.clearDeferredRebuild(tabID)
+		return
+	}
+	// Hold the rebuild mutex across probe + rebuild: the probe briefly acquires
+	// the session lease, and a concurrent manual rebuild's ensureSessionLease
+	// would see that probe as "held by another runtime" and spuriously defer.
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	// rebuildSettingLocked refreshes the active tab only. Wait until the user
+	// is back on this tab so we refresh the runtime the pending setting was
+	// meant for, not whichever tab happens to be focused.
+	if a.activeTab() != tab {
+		return
+	}
+	ctrl := a.controllerForTab(tab)
+	if ctrl == nil {
+		// Mid-(re)build on another path (provider retarget, workspace repair);
+		// racing a second build+swap against it is what this loop must avoid.
+		return
+	}
+	if controllerHasActiveRuntimeWork(ctrl) {
+		return
+	}
+	if !a.deferredRebuildLeaseLooksFree(tab) {
+		return
+	}
+	err := a.rebuildSettingLocked(setting)
+	if err == nil {
+		// rebuildSettingLocked already cleared the pending entry for the tab it
+		// refreshed; just announce it.
+		a.noticeForTab(tabID, fmt.Sprintf("%s applied: session refreshed after the lease was released", setting))
+		return
+	}
+	if errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return // grabbed back before we could rebuild; keep waiting
+	}
+	var busy *rebuildBusyError
+	if errors.As(err, &busy) {
+		return // a turn started meanwhile; retry once it finishes
+	}
+	// Anything else will not resolve by waiting; give up loudly instead of
+	// retrying forever.
+	a.clearDeferredRebuild(tabID)
+	slog.Warn("desktop: deferred settings rebuild failed", "setting", setting, "tab", tabID, "err", err)
+	a.warnForTab(tabID, fmt.Sprintf("%s was saved but the session could not refresh: %s", setting, err.Error()))
+}
+
+// deferredRebuildLeaseLooksFree cheaply probes whether the tab's session lease
+// could be acquired right now, without touching tab.sessionLease (only the
+// serialized rebuild paths may mutate that). The probe path can lag the
+// reconciled path the rebuild will use; a stale answer either re-defers on the
+// next tick or lets the rebuild fail back into the pending set, so a mismatch
+// only delays the retry.
+func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	path := strings.TrimSpace(tab.SessionPath)
+	a.mu.RUnlock()
+	if ctrl != nil {
+		if p := strings.TrimSpace(ctrl.SessionPath()); p != "" {
+			path = p
+		}
+	}
+	if path == "" {
+		return true // nothing to probe; let the rebuild decide
+	}
+	lease, err := agent.TryAcquireSessionLease(sessionRuntimeKey(path))
+	if err != nil {
+		var leaseErr *agent.SessionLeaseError
+		if errors.As(err, &leaseErr) && leaseErr.Info != nil && leaseErr.Info.PID == os.Getpid() {
+			if host, _ := os.Hostname(); leaseErr.Info.Hostname == host {
+				// This process (usually this very tab) holds the probed path;
+				// the blocking lease is some other path. Attempt the rebuild
+				// and let its own lease checks decide.
+				return true
+			}
+		}
+		return !errors.Is(err, agent.ErrSessionLeaseHeld)
+	}
+	lease.Release()
+	return true
+}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -4502,7 +4502,7 @@ function ProvidersSection({ s, busy, apply }: SectionProps) {
     setGroupModelDraft(group.id, null);
     try {
       await apply(async () => {
-        await app.SetProviderKey(apiKeyEnv, value);
+        await app.SaveProviderKey(apiKeyEnv, value);
         try {
           const fetched = await app.FetchProviderModels({ ...probe, apiKeyEnv });
           if (fetched.length > 0) {
@@ -4608,7 +4608,7 @@ function ProvidersSection({ s, busy, apply }: SectionProps) {
               setAdding(null);
             }}
             onResetPreset={(id) => apply(() => app.ResetProviderPresetAccess(id)).then(() => setAdding(null))}
-            onAddCustom={(pv) => apply(() => app.SaveProvider(pv)).then(() => setAdding(null))}
+            onAddCustom={(pv, key) => apply(() => key ? app.SaveProviderWithKey(pv, key) : app.SaveProvider(pv)).then(() => setAdding(null))}
           />
         )}
         {adding === null && groups.map((group) => (
@@ -4624,7 +4624,7 @@ function ProvidersSection({ s, busy, apply }: SectionProps) {
             kinds={s.providerKinds}
             onEdit={setEditing}
             onCancelEdit={() => setEditing(null)}
-            onSave={(pv) => apply(() => app.SaveProvider(pv)).then(() => {
+            onSave={(pv, key) => apply(() => key ? app.SaveProviderWithKey(pv, key) : app.SaveProvider(pv)).then(() => {
               setEditing(null);
               setGroupModelDraft(group.id, null);
             })}
@@ -4838,7 +4838,7 @@ function AddProviderPanel({
   onAddPreset: (id: string, key: string) => Promise<void>;
   onViewPresetConflict: (providerName: string) => void;
   onResetPreset: (id: string) => Promise<void>;
-  onAddCustom: (p: ProviderView) => void | Promise<void>;
+  onAddCustom: (p: ProviderView, key?: string) => void | Promise<void>;
 }) {
   const t = useT();
   const templateChoices = useMemo<ProviderTemplateChoice[]>(() => [
@@ -5053,7 +5053,7 @@ function ProviderAccessCard({
   kinds: string[];
   onEdit: (name: string) => void;
   onCancelEdit: () => void;
-  onSave: (p: ProviderView) => void | Promise<void>;
+  onSave: (p: ProviderView, key?: string) => void | Promise<void>;
   onRefresh: () => void;
   onToggleDraftModel: (model: string) => void;
   onToggleDraftVision: (model: string) => void;
@@ -5544,7 +5544,7 @@ function ProviderEditor({
   kinds: string[];
   busy: boolean;
   onCancel: () => void;
-  onSave: (p: ProviderView) => void;
+  onSave: (p: ProviderView, key?: string) => void | Promise<void>;
   onSaveKey?: (apiKeyEnv: string, value: string) => Promise<void>;
   onClearKey?: (apiKeyEnv: string) => Promise<void>;
 }) {
@@ -5621,7 +5621,7 @@ function ProviderEditor({
     try {
       const effectiveApiKeyEnv = providerApiKeyEnvForSave(name, apiKeyEnv, keyDraft);
       if (!apiKeyEnv.trim()) setApiKeyEnv(effectiveApiKeyEnv);
-      if (keyDraft.trim()) await app.SetProviderKey(effectiveApiKeyEnv, keyDraft.trim());
+      if (keyDraft.trim()) await app.SaveProviderKey(effectiveApiKeyEnv, keyDraft.trim());
       const fetched = await app.FetchProviderModels({
         name: name.trim() || t("settings.newProviderDraftName"),
         builtIn: initial?.builtIn ?? false,
@@ -5674,13 +5674,7 @@ function ProviderEditor({
     const ms = parseProviderListInput(models);
     const vms = parseProviderListInput(visionModels).filter((model) => ms.includes(model));
     const effectiveApiKeyEnv = providerApiKeyEnvForSave(name, apiKeyEnv, keyDraft);
-    try {
-      if (keyDraft.trim()) await app.SetProviderKey(effectiveApiKeyEnv, keyDraft.trim());
-    } catch (e) {
-      setFetchFallback(String((e as Error)?.message ?? e));
-      return;
-    }
-    onSave({
+    const provider: ProviderView = {
       name: name.trim(),
       builtIn: initial?.builtIn ?? false,
       added: initial?.added ?? true,
@@ -5706,7 +5700,12 @@ function ProviderEditor({
       // NormalizeEffort would otherwise silently ignore an unsupported value.
       defaultEffort: cleanedSupportedEfforts.length > 0 ? cleanDefaultEffort : "",
       modelOverrides: initial?.modelOverrides ?? [],
-    });
+    };
+    try {
+      await onSave(provider, keyDraft.trim() || undefined);
+    } catch (e) {
+      setFetchFallback(String((e as Error)?.message ?? e));
+    }
   };
 
   if (builtIn) {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -294,12 +294,14 @@ export interface AppBindings {
   SetAutoPlan(mode: string): Promise<void>;
   SetDefaultToolApprovalMode(mode: string): Promise<void>;
   SaveProvider(p: ProviderView): Promise<void>;
+  SaveProviderWithKey(p: ProviderView, key: string): Promise<string>;
   AddOfficialProviderAccess(kind: string, key: string): Promise<string>;
   AddProviderPresetAccess(id: string, key: string): Promise<string>;
   ResetProviderPresetAccess(id: string): Promise<void>;
   FetchProviderModels(p: ProviderView): Promise<string[]>;
   DeleteProvider(name: string): Promise<void>;
   RemoveProviderAccess(name: string): Promise<void>;
+  SaveProviderKey(apiKeyEnv: string, value: string): Promise<string>;
   SetProviderKey(apiKeyEnv: string, value: string): Promise<string>;
   ClearProviderKey(apiKeyEnv: string): Promise<void>;
   SetPermissionMode(mode: string): Promise<void>;
@@ -612,7 +614,7 @@ function bridgeBreadcrumb(method: string): string {
     return `model ${method}`;
   if (/^(SetDesktop|SetCloseBehavior|SetDisplayMode|SetStatusBar|SetExpandThinking|SetAutoPlan|SetDefaultToolApprovalMode|SetMemoryCompilerEnabled|SetReasoningLanguage)/.test(method))
     return `settings ${method}`;
-  if (/^(SaveProvider|AddOfficialProviderAccess|AddProviderPresetAccess|ResetProviderPresetAccess|RemoveProviderAccess|DeleteProvider|SetProviderKey|ClearProviderKey|FetchProviderModels|ConnectKey)/.test(method))
+  if (/^(SaveProvider|AddOfficialProviderAccess|AddProviderPresetAccess|ResetProviderPresetAccess|RemoveProviderAccess|DeleteProvider|SaveProviderKey|SetProviderKey|ClearProviderKey|FetchProviderModels|ConnectKey)/.test(method))
     return `provider ${method}`;
   if (/^(CheckUpdate|DownloadUpdate|InstallUpdate|ApplyUpdate|OpenDownloadPage)/.test(method)) return `update ${method}`;
   if (/^(AddMCPServer|UpdateMCPServer|RemoveMCPServer|ReconnectMCPServer|ClearMCPServerAuthentication|TrustMCPServerTool|TrustMCPServerTools|UntrustMCPServerTool|SetMCPServer)/.test(method))
@@ -2970,6 +2972,14 @@ function makeMockApp(): AppBindings {
       if (i >= 0) settings.providers[i] = p;
       else settings.providers.push(p);
     },
+    async SaveProviderWithKey(p: ProviderView, key: string) {
+      p.added = true;
+      p.keySet = Boolean(key.trim()) || p.keySet;
+      const i = settings.providers.findIndex((x) => x.name === p.name);
+      if (i >= 0) settings.providers[i] = p;
+      else settings.providers.push(p);
+      return "";
+    },
     async AddOfficialProviderAccess(kind: string, key: string) {
       const templates: Record<string, ProviderView> = {
         deepseek: { name: "deepseek", builtIn: true, added: true, kind: "openai", baseUrl: "https://api.deepseek.com", modelsUrl: "", models: ["deepseek-v4-flash", "deepseek-v4-pro"], visionModels: [], visionModelsConfigured: false, default: "deepseek-v4-flash", apiKeyEnv: "DEEPSEEK_API_KEY", keySet: !!key.trim(), balanceUrl: "https://api.deepseek.com/user/balance", contextWindow: 1_000_000, reasoningProtocol: "", thinking: "", supportedEfforts: [], defaultEffort: "" },
@@ -3031,6 +3041,12 @@ function makeMockApp(): AppBindings {
       const p = settings.providers.find((x) => x.name === name);
       if (p?.builtIn) p.added = false;
       else settings.providers = settings.providers.filter((x) => x.name !== name);
+    },
+    async SaveProviderKey(apiKeyEnv: string, _value: string) {
+      settings.providers.forEach((p) => {
+        if (p.apiKeyEnv === apiKeyEnv) p.keySet = true;
+      });
+      return "";
     },
     async SetProviderKey(apiKeyEnv: string, _value: string) {
       settings.providers.forEach((p) => {

--- a/desktop/plugin_packages_app.go
+++ b/desktop/plugin_packages_app.go
@@ -136,6 +136,9 @@ func (a *App) InstallPlugin(source string, opts PluginInstallOptions) (string, e
 	}
 	a.invalidateSkillRootsCache()
 	if rebuildErr := a.rebuild(); rebuildErr != nil {
+		if _, ok := a.deferredRebuildWarning("plugins", rebuildErr); ok {
+			return out, nil
+		}
 		return out, rebuildErr
 	}
 	return out, nil
@@ -161,7 +164,13 @@ func (a *App) RemovePlugin(name string) error {
 		return err
 	}
 	a.invalidateSkillRootsCache()
-	return a.rebuild()
+	if err := a.rebuild(); err != nil {
+		if _, ok := a.deferredRebuildWarning("plugins", err); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (a *App) SetPluginEnabled(name string, enabled bool) error {
@@ -172,7 +181,13 @@ func (a *App) SetPluginEnabled(name string, enabled bool) error {
 		return err
 	}
 	a.invalidateSkillRootsCache()
-	return a.rebuild()
+	if err := a.rebuild(); err != nil {
+		if _, ok := a.deferredRebuildWarning("plugins", err); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (a *App) UpdatePlugin(name string) (string, error) {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1156,7 +1156,13 @@ func (a *App) deferredRebuildWarning(setting string, err error) (string, bool) {
 	userErr := userFacingSessionLeaseError(setting, err)
 	warning := fmt.Sprintf("%s saved, but the current session could not refresh yet: %s", setting, userErr.Error())
 	slog.Warn("desktop: deferred settings rebuild", "setting", setting, "err", err)
-	a.warningForActiveTab(warning)
+	// Bind both the warning and the retry to the tab whose refresh failed (the
+	// rebuild acts on the active tab), so a tab switch right after the failure
+	// cannot misroute the notice or the deferred rebuild.
+	if tab := a.activeTab(); tab != nil {
+		a.warnForTab(tab.ID, warning)
+		a.scheduleDeferredRebuild(tab.ID, setting)
+	}
 	return warning, true
 }
 
@@ -1478,6 +1484,21 @@ func (a *App) rebuildSetting(setting string) error {
 	if a.ctx == nil {
 		return nil
 	}
+	// Serialize with SetModelForTab and the deferred-rebuild retry loop: two
+	// concurrent build+swap sequences on the same tab leak the first-swapped
+	// controller and double-close the old one.
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	return a.rebuildSettingLocked(setting)
+}
+
+// rebuildSettingLocked is rebuildSetting's body; callers must already hold
+// runtimeRebuildMu. The deferred-rebuild retry loop calls this directly because
+// it takes the lock across its lease probe.
+func (a *App) rebuildSettingLocked(setting string) error {
+	if a.ctx == nil {
+		return nil
+	}
 	tab := a.activeTab()
 	if tab == nil {
 		return fmt.Errorf("no active tab")
@@ -1585,6 +1606,7 @@ func (a *App) rebuildSetting(setting string) error {
 	tab.Ready = true
 	a.saveTabsLocked()
 	a.mu.Unlock()
+	a.clearDeferredRebuild(tab.ID)
 	a.emitReady(a.ctx)
 	return nil
 }
@@ -1736,7 +1758,12 @@ func (a *App) SetAutoPlan(mode string) error {
 	}
 	a.applyAutoPlanToLiveControllers(cfg.Agent.AutoPlan)
 	if desktopAutoPlanMode(cfg.Agent.AutoPlan) == "on" && strings.TrimSpace(cfg.Agent.AutoPlanClassifier) != "" {
-		return a.rebuild()
+		if err := a.rebuild(); err != nil {
+			if _, ok := a.deferredRebuildWarning("auto-plan", err); ok {
+				return nil
+			}
+			return err
+		}
 	}
 	return nil
 }
@@ -2317,7 +2344,13 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 		return err
 	}
 	if len(affected) == 0 {
-		return a.rebuild()
+		if err := a.rebuild(); err != nil {
+			if _, ok := a.deferredRebuildWarning("provider access", err); ok {
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 	for _, item := range affected {
 		if item.ctrl != nil {
@@ -2426,7 +2459,13 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 	}
 
 	if len(affected) == 0 {
-		return a.rebuild()
+		if err := a.rebuild(); err != nil {
+			if _, ok := a.deferredRebuildWarning("provider", err); ok {
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 	for _, item := range affected {
 		if item.ctrl != nil {
@@ -2600,7 +2639,15 @@ func (a *App) ReloadSettings() error {
 	if err := a.ensureActiveTabRebuildAllowed("settings"); err != nil {
 		return err
 	}
-	return a.rebuild()
+	if err := a.rebuild(); err != nil {
+		// The on-disk config already diverged from the runtime; retry the
+		// refresh once the other window releases the session lease.
+		if _, ok := a.deferredRebuildWarning("settings", err); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // SetSandbox updates the bash sandbox mode, network egress, and write roots.

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -1068,8 +1069,13 @@ func botDomainOrDefault(domain string) string {
 // keys are account-level, not per-project: writing them to the global config
 // rather than the cwd's reasonix.toml is what lets them survive a workspace switch.
 func (a *App) applyConfigChange(mutate func(*config.Config) error) error {
-	if err := a.ensureActiveTabRebuildAllowed("settings"); err != nil {
-		return err
+	_, err := a.applyConfigChangeWithWarning("settings", mutate)
+	return err
+}
+
+func (a *App) applyConfigChangeWithWarning(setting string, mutate func(*config.Config) error) (string, error) {
+	if err := a.ensureActiveTabRebuildAllowed(setting); err != nil {
+		return "", err
 	}
 	if err := func() error {
 		// Serialize the load-modify-save against other in-process config editors
@@ -1087,9 +1093,15 @@ func (a *App) applyConfigChange(mutate func(*config.Config) error) error {
 		}
 		return cfg.SaveTo(path)
 	}(); err != nil {
-		return err
+		return "", err
 	}
-	return a.rebuild()
+	if err := a.rebuildSetting(setting); err != nil {
+		if warning, ok := a.deferredRebuildWarning(setting, err); ok {
+			return warning, nil
+		}
+		return "", err
+	}
+	return "", nil
 }
 
 func (a *App) applyConfigOnly(mutate func(*config.Config) error) error {
@@ -1131,6 +1143,33 @@ func (a *App) ensureLiveControllersRuntimeMutationAllowed(setting string) error 
 		}
 	}
 	return nil
+}
+
+func (a *App) deferredRebuildWarning(setting string, err error) (string, bool) {
+	if err == nil || !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return "", false
+	}
+	setting = strings.TrimSpace(setting)
+	if setting == "" {
+		setting = "settings"
+	}
+	userErr := userFacingSessionLeaseError(setting, err)
+	warning := fmt.Sprintf("%s saved, but the current session could not refresh yet: %s", setting, userErr.Error())
+	slog.Warn("desktop: deferred settings rebuild", "setting", setting, "err", err)
+	a.warningForActiveTab(warning)
+	return warning, true
+}
+
+func appendSettingsWarning(existing, warning string) string {
+	existing = strings.TrimSpace(existing)
+	warning = strings.TrimSpace(warning)
+	if existing == "" {
+		return warning
+	}
+	if warning == "" {
+		return existing
+	}
+	return existing + "\n" + warning
 }
 
 // loadDesktopUserConfigForEdit loads the user config for a write path and
@@ -1854,60 +1893,104 @@ func providerDefaultForModels(currentDefault string, models []string) string {
 	return ""
 }
 
+func saveProviderConfig(c *config.Config, p ProviderView) error {
+	if c == nil {
+		return fmt.Errorf("config is nil")
+	}
+	e := config.ProviderEntry{Name: p.Name}
+	for i := range c.Providers {
+		if c.Providers[i].Name == p.Name {
+			e = c.Providers[i]
+			break
+		}
+	}
+	e.Name = p.Name
+	e.Kind = p.Kind
+	e.BaseURL = p.BaseURL
+	e.ChatURL = strings.TrimSpace(p.ChatURL)
+	e.ModelsURL = strings.TrimSpace(p.ModelsURL)
+	e.APIKeyEnv = p.APIKeyEnv
+	e.Headers = p.Headers
+	e.ExtraBody = p.ExtraBody
+	e.AuthHeader = p.AuthHeader
+	e.BalanceURL = strings.TrimSpace(p.BalanceURL)
+	e.ContextWindow = p.ContextWindow
+	e.ReasoningProtocol = p.ReasoningProtocol
+	e.Thinking = providerThinkingForSettings(p.Thinking)
+	e.SupportedEfforts = p.SupportedEfforts
+	e.DefaultEffort = p.DefaultEffort
+	e.Model = ""
+	e.Models = nil
+	e.Default = ""
+	e.VisionModels = nil
+	models := chatProviderModels(p.Models)
+	if len(models) > 0 {
+		e.Model = models[0] // also satisfies validateProvider's model requirement
+		e.Models = models
+		e.ModelOverrides = providerModelOverridesForSave(p.ModelOverrides, models)
+		if p.VisionModelsSet || len(p.VisionModels) > 0 {
+			e.Vision = false
+			e.VisionModels = providerVisionModels(models, p.VisionModels)
+		}
+		if len(models) > 1 {
+			e.Default = providerDefaultForModels(p.Default, models)
+		}
+	} else {
+		e.Vision = false
+		e.VisionModels = nil
+		e.ModelOverrides = nil
+	}
+	if err := c.UpsertProvider(e); err != nil {
+		return err
+	}
+	addProviderAccess(c, p.Name)
+	return nil
+}
+
 // SaveProvider adds or updates a provider. Enabled models are persisted through
 // `models` even when only one model is selected, while `model` remains populated
 // in-memory for validation/back-compat. The shared key/endpoint live on the entry.
 func (a *App) SaveProvider(p ProviderView) error {
 	return a.applyConfigChange(func(c *config.Config) error {
-		e := config.ProviderEntry{Name: p.Name}
-		for i := range c.Providers {
-			if c.Providers[i].Name == p.Name {
-				e = c.Providers[i]
-				break
-			}
-		}
-		e.Name = p.Name
-		e.Kind = p.Kind
-		e.BaseURL = p.BaseURL
-		e.ChatURL = strings.TrimSpace(p.ChatURL)
-		e.ModelsURL = strings.TrimSpace(p.ModelsURL)
-		e.APIKeyEnv = p.APIKeyEnv
-		e.Headers = p.Headers
-		e.ExtraBody = p.ExtraBody
-		e.AuthHeader = p.AuthHeader
-		e.BalanceURL = strings.TrimSpace(p.BalanceURL)
-		e.ContextWindow = p.ContextWindow
-		e.ReasoningProtocol = p.ReasoningProtocol
-		e.Thinking = providerThinkingForSettings(p.Thinking)
-		e.SupportedEfforts = p.SupportedEfforts
-		e.DefaultEffort = p.DefaultEffort
-		e.Model = ""
-		e.Models = nil
-		e.Default = ""
-		e.VisionModels = nil
-		models := chatProviderModels(p.Models)
-		if len(models) > 0 {
-			e.Model = models[0] // also satisfies validateProvider's model requirement
-			e.Models = models
-			e.ModelOverrides = providerModelOverridesForSave(p.ModelOverrides, models)
-			if p.VisionModelsSet || len(p.VisionModels) > 0 {
-				e.Vision = false
-				e.VisionModels = providerVisionModels(models, p.VisionModels)
-			}
-			if len(models) > 1 {
-				e.Default = providerDefaultForModels(p.Default, models)
-			}
-		} else {
-			e.Vision = false
-			e.VisionModels = nil
-			e.ModelOverrides = nil
-		}
-		if err := c.UpsertProvider(e); err != nil {
+		return saveProviderConfig(c, p)
+	})
+}
+
+// SaveProviderWithKey saves a custom provider and its credential as one settings
+// transaction, then rebuilds once after both are visible to the runtime.
+func (a *App) SaveProviderWithKey(p ProviderView, key string) (string, error) {
+	apiKeyEnv := strings.TrimSpace(p.APIKeyEnv)
+	if apiKeyEnv == "" {
+		return "", fmt.Errorf("this provider has no api_key_env set")
+	}
+	if err := a.ensureActiveTabRebuildAllowed("provider"); err != nil {
+		return "", err
+	}
+	warning, err := a.saveProviderCredential(apiKeyEnv, key)
+	if err != nil {
+		return "", err
+	}
+	if err := func() error {
+		unlock := config.LockUserConfigEdits()
+		defer unlock()
+		cfg, path, err := a.loadDesktopUserConfigForEdit()
+		if err != nil {
 			return err
 		}
-		addProviderAccess(c, p.Name)
-		return nil
-	})
+		if err := saveProviderConfig(cfg, p); err != nil {
+			return err
+		}
+		return cfg.SaveTo(path)
+	}(); err != nil {
+		return "", err
+	}
+	if err := a.rebuildSetting("provider"); err != nil {
+		if rebuildWarning, ok := a.deferredRebuildWarning("provider", err); ok {
+			return appendSettingsWarning(warning, rebuildWarning), nil
+		}
+		return "", err
+	}
+	return warning, nil
 }
 
 // AddOfficialProviderAccess adds one curated desktop provider template to the
@@ -1935,7 +2018,7 @@ func (a *App) AddOfficialProviderAccess(kind, key string) (string, error) {
 			return "", err
 		}
 	}
-	if err := a.applyConfigChange(func(c *config.Config) error {
+	rebuildWarning, err := a.applyConfigChangeWithWarning("provider access", func(c *config.Config) error {
 		names := make([]string, 0, len(entries))
 		for _, e := range entries {
 			if err := c.UpsertProvider(e); err != nil {
@@ -1945,10 +2028,11 @@ func (a *App) AddOfficialProviderAccess(kind, key string) (string, error) {
 		}
 		addProviderAccess(c, names...)
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return "", err
 	}
-	return keyWarning, nil
+	return appendSettingsWarning(keyWarning, rebuildWarning), nil
 }
 
 // AddProviderPresetAccess installs one editable custom-provider preset. Unlike
@@ -1991,7 +2075,7 @@ func (a *App) AddProviderPresetAccess(id, key string) (string, error) {
 			return "", err
 		}
 	}
-	if err := a.applyConfigChange(func(c *config.Config) error {
+	rebuildWarning, err := a.applyConfigChangeWithWarning("provider access", func(c *config.Config) error {
 		if existing := existingProviderNames(c, preset.Entries); len(existing) > 0 {
 			return providerPresetAlreadyAddedError(preset.ID, existing)
 		}
@@ -2004,10 +2088,11 @@ func (a *App) AddProviderPresetAccess(id, key string) (string, error) {
 		}
 		addProviderAccess(c, names...)
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return "", err
 	}
-	return keyWarning, nil
+	return appendSettingsWarning(keyWarning, rebuildWarning), nil
 }
 
 // ResetProviderPresetAccess intentionally overwrites same-name provider entries
@@ -2397,9 +2482,22 @@ func (a *App) SetProviderKey(apiKeyEnv, value string) (string, error) {
 		return "", err
 	}
 	if err := a.rebuildSetting("provider key"); err != nil {
+		if rebuildWarning, ok := a.deferredRebuildWarning("provider key", err); ok {
+			return appendSettingsWarning(warning, rebuildWarning), nil
+		}
 		return "", err
 	}
 	return warning, nil
+}
+
+// SaveProviderKey writes a provider secret without rebuilding the chat runtime.
+// It is used by settings probes that need credentials only for a model-list
+// request; explicit "save key" actions still call SetProviderKey.
+func (a *App) SaveProviderKey(apiKeyEnv, value string) (string, error) {
+	if strings.TrimSpace(apiKeyEnv) == "" {
+		return "", fmt.Errorf("this provider has no api_key_env set")
+	}
+	return a.saveProviderCredential(apiKeyEnv, value)
 }
 
 func (a *App) ensureProviderAccessForKey(apiKeyEnv string) error {
@@ -2469,7 +2567,13 @@ func (a *App) ClearProviderKey(apiKeyEnv string) error {
 	if err := removeDotEnv(apiKeyEnv); err != nil {
 		return err
 	}
-	return a.rebuildSetting("provider key")
+	if err := a.rebuildSetting("provider key"); err != nil {
+		if _, ok := a.deferredRebuildWarning("provider key", err); ok {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // SetPermissionMode sets the writer-fallback mode (ask|allow|deny).


### PR DESCRIPTION
## Summary

- defer session-lease-only rebuild failures after settings/provider/plugin persistence succeeds
- add a pure provider-key save path for model-list probes so fetching models does not rebuild the active chat runtime
- save custom providers and credentials together before one live refresh attempt

## Root cause

Several settings flows persisted durable state first, then rebuilt the active chat controller so the change became live immediately. If the active session lease was held by another runtime, the durable write had already succeeded but the UI treated the whole operation as failed. Custom provider creation also saved the key before the provider/model list, so a premature rebuild could interrupt the save flow.

## User impact

Provider keys, custom providers, model-list probes, general settings, onboarding key save, and plugin install/remove/enable operations now keep the saved state and report a deferred refresh warning instead of failing the operation when only the current session cannot hot-refresh. The current controller remains usable.

## Verification

- go test . (desktop)
- focused desktop provider/settings/plugin test subset
- npm --prefix desktop/frontend run --silent typecheck -- --pretty false
- npm --prefix desktop/frontend run --silent check:css
- git diff --check