### PR TITLE
fix(crash-report): stabilize community review table and add one-click copy

### DIFF
--- a/workers/crash-report/src/community.ts
+++ b/workers/crash-report/src/community.ts
@@ -36,6 +36,33 @@ function sourceLinks(pkg: PackageRow): string {
   return links.join(" · ");
 }
 
+// One paste-ready block of everything a reviewer needs: the install pointer,
+// provenance links, and README. The manifest snapshot lives on package_versions,
+// not here — source/repo_url are what actually carry the reviewable content.
+function reviewBlob(pkg: PackageRow): string {
+  return [
+    `Skill submission — ${pkg.slug}`,
+    `kind: ${pkg.kind}`,
+    `status: ${pkg.status}`,
+    `publisher: @${pkg.scope_handle}`,
+    `version: ${pkg.latest_version || "—"}`,
+    `submitted: ${pkg.created_at}`,
+    `install_kind: ${pkg.install_kind}`,
+    `source: ${pkg.source || "—"}`,
+    `repo_url: ${pkg.repo_url || "—"}`,
+    `homepage: ${pkg.homepage || "—"}`,
+    `tags: ${pkg.tags || "—"}`,
+    `summary: ${pkg.summary || "—"}`,
+    ``,
+    `--- description (README) ---`,
+    pkg.description || "(none)",
+  ].join("\n");
+}
+
+function copyButton(pkg: PackageRow): string {
+  return `<button type="button" class="btn ghost sm copy-btn" data-copy="${esc(reviewBlob(pkg))}"><span class="copy-label">Copy for review</span></button>`;
+}
+
 export function renderCommunity(viewer: User, packages: PackageRow[], status: string): string {
   const tabs = STATUS_TABS.map(
     (t) => `<a class="filter-tab${t.key === status ? " active" : ""}" href="/community?status=${t.key}">${t.label}</a>`,
@@ -51,7 +78,7 @@ export function renderCommunity(viewer: User, packages: PackageRow[], status: st
 <td>@${esc(p.scope_handle)}</td>
 <td class="n">${esc(p.latest_version || "—")} · ${p.install_count} inst · ${p.star_count}★</td>
 <td class="n">${esc(p.created_at.slice(0, 10))}</td>
-<td><div class="actions">${rowActions(p, status)}</div>${links ? `<div class="muted">${links}</div>` : ""}</td>
+<td><div class="actions">${rowActions(p, status)}</div><div class="rowlinks">${copyButton(p)}${links ? `<span class="muted">${links}</span>` : ""}</div></td>
 </tr>`;
         })
         .join("")
@@ -61,7 +88,7 @@ export function renderCommunity(viewer: User, packages: PackageRow[], status: st
     "community",
     `<h1>Community</h1><p class="sub">Review user-published skills and MCP servers — approve to publish, verify to badge, hide to take down</p>
 <div class="filter-tabs">${tabs}</div>
-<div class="card full"><table><thead><tr><th>package</th><th>kind</th><th>publisher</th><th>version · installs · stars</th><th>submitted</th><th></th></tr></thead>
+<div class="card full"><table class="reg-table"><colgroup><col class="c-pkg"><col class="c-kind"><col class="c-pub"><col class="c-ver"><col class="c-sub"><col class="c-act"></colgroup><thead><tr><th>package</th><th>kind</th><th>publisher</th><th>version · installs · stars</th><th>submitted</th><th></th></tr></thead>
 <tbody>${rows}</tbody></table></div>`,
     userNav(viewer),
   );

--- a/workers/crash-report/src/shell.ts
+++ b/workers/crash-report/src/shell.ts
@@ -105,6 +105,10 @@ th{text-align:left;color:var(--ink-3);font-weight:500;font-size:12.5px;padding:0
 td{padding:8px 14px 8px 0;border-top:1px solid var(--line);vertical-align:middle}
 td.n{font-family:var(--mono);font-size:13px}
 td.summary{max-width:480px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:var(--mono);font-size:12.5px}
+.reg-table{table-layout:fixed}
+.reg-table .c-pkg{width:32%}.reg-table .c-kind{width:8%}.reg-table .c-pub{width:14%}
+.reg-table .c-ver{width:16%}.reg-table .c-sub{width:10%}.reg-table .c-act{width:20%}
+.rowlinks{display:flex;align-items:center;flex-wrap:wrap;gap:8px;margin-top:6px}
 .muted{color:var(--ink-3)}
 p.summary{font-family:var(--mono);font-size:14px;margin:2px 0 6px;word-break:break-word}
 a.fp{font-family:var(--mono);font-size:13px;color:var(--accent);text-decoration:none}


### PR DESCRIPTION
## What

Two improvements to the Community moderation console (`workers/crash-report`):

**1. Fix the review table layout.** The table relied on the browser's auto
table-layout, so a long summary in the first column starved the meta columns —
`version · installs · stars` and the submitted date were wrapping
character-by-character. Switched it to `table-layout: fixed` with explicit
column widths (new `.reg-table` class + `<colgroup>`), so no column is squeezed
below its content.

**2. Add a per-row "Copy for review" button.** One click copies the whole
submission (kind, source, repo_url, homepage, tags, summary, README) to the
clipboard, so a reviewer can hand a pending skill/MCP off for review without
hand-copying each field. Reuses the existing `[data-copy]` handler and
`.copy-btn` copied/failed feedback already in `shell.ts`.

## Notes

- The `manifest` snapshot lives on `package_versions` (frontmatter only), so it
  is intentionally not in the copy blob; `source` / `repo_url` are the pointers
  to the actual reviewable content.
- The copy blob is HTML-attribute-escaped via `esc()`; verified round-trip
  (quotes, `<`, `&`, newlines all survive) with no attribute break-out.

## Deploy

Merging to `main-v2` triggers `deploy-crash-worker.yml` → `wrangler deploy` to
`crash.reasonix.io`.

## Test

Rendered the real CSS + table markup in a standalone page and confirmed the
meta columns no longer wrap per-character and the copy button copies the full
submission intact.
