### PR TITLE
fix(registry): reject whole-repo source when publishing a skill

### DIFF
--- a/workers/crash-report/src/registry/lib/validation.ts
+++ b/workers/crash-report/src/registry/lib/validation.ts
@@ -14,6 +14,32 @@ const slug = z
 
 const httpUrl = z.string().trim().url().max(500);
 
+// A GitHub source that points at a whole repo — a bare owner/repo root, or a
+// branch root with no sub-path — rather than one skill. The installsource
+// planner scans such a source recursively and pulls EVERY SKILL.md it finds, so
+// a package that claims to be a single skill must not publish one: it would
+// silently mass-install the repo's entire skill library under this package name.
+function isWholeGitHubRepoSource(source: string): boolean {
+  let raw = source.trim();
+  if (raw.startsWith("git:github.com/")) raw = `https://github.com/${raw.slice("git:github.com/".length)}`;
+  else if (/^github\.com\//i.test(raw)) raw = `https://${raw}`;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (u.hostname.toLowerCase() !== "github.com") return false;
+  const parts = u.pathname.split("/").filter(Boolean);
+  // owner/repo                       → whole repo
+  // owner/repo/tree/<branch>         → whole repo at a branch (no sub-path)
+  // owner/repo/tree/<branch>/<path…> → scoped to a path (allowed)
+  // owner/repo/blob/<branch>/<file>  → a specific file (allowed)
+  if (parts.length === 2) return true;
+  if (parts.length === 4 && parts[2].toLowerCase() === "tree") return true;
+  return false;
+}
+
 export const PublishSchema = z
   .object({
     kind: z.enum(["skill", "mcp"]),
@@ -30,7 +56,17 @@ export const PublishSchema = z
     contentHash: z.string().trim().max(128).default(""),
     riskLevel: z.string().trim().max(20).default(""),
   })
-  .strict();
+  .strict()
+  .superRefine((val, ctx) => {
+    if (val.kind === "skill" && isWholeGitHubRepoSource(val.source)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["source"],
+        message:
+          "source points at a whole GitHub repo, which installs every skill in it. Point it at one skill — e.g. https://github.com/<owner>/<repo>/tree/<branch>/skills/<name> or a raw SKILL.md URL.",
+      });
+    }
+  });
 
 export type PublishInput = z.infer<typeof PublishSchema>;
 


### PR DESCRIPTION
## What

Publishing a `kind: skill` package with a **bare GitHub repo-root** `source`
(`owner/repo`, or a branch root with no sub-path) silently mass-installs the
repo's entire skill library. This validates `source` at publish time and rejects
that shape.

## Why

For `kind: auto` a bare repo URL goes through `internal/installsource/plan.go`:
plugin detection only recognizes `reasonix-plugin.json` / `.codex-plugin/plugin.json`
(`plugin_package.go:30`), so a repo whose only manifest is `.claude-plugin/plugin.json`
falls through to `scanGitHubSkills`, which walks the whole repo and installs
**every `SKILL.md`** it finds (bounded only at 200). A package named for one
skill can thus drop dozens of unrelated skills into a user's setup, with no error.

Motivating case: a community submission `hello_world/grill-me` with
`source: https://github.com/mattpocock/skills` — that repo carries 38 `SKILL.md`
files.

## How

`PublishSchema.superRefine`: when `kind === "skill"` and `source` resolves to a
whole GitHub repo (bare `owner/repo`, or `.../tree/<branch>` with no path),
reject with a 422 and point the publisher at a single-skill source
(a `.../tree/<branch>/skills/<name>` subtree, or a raw `SKILL.md` URL). MCP kinds,
scoped/blob/raw URLs, and non-GitHub sources are unaffected.

## Test

Verified the classifier against a 13-case table (bare root, `.git` suffix,
trailing slash, branch-root, scoped subtree, blob file, `raw.githubusercontent`
host, `git:` prefix, scheme-less, non-github, non-URL, empty) plus the kind gate
(skill rejects, mcp allows) — all pass. The worker has no local test runner; the
change is a standard zod v3 refinement.

## Deploy

Merging to `main-v2` triggers `deploy-crash-worker.yml` → `wrangler deploy` to
`crash.reasonix.io`.
