### PR TITLE
Fix desktop session lease race and remaining runtime data races / 修复桌面端会话租约竞态及其余运行时数据竞态

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3782,12 +3782,8 @@ func workspaceName(path string) string {
 	return name
 }
 
-func tabWorkspaceName(tab *WorkspaceTab, cwd string) string {
-	return tabWorkspaceNameForScope(tab.Scope, cwd)
-}
-
-// tabWorkspaceNameForScope is the snapshot form: callers that already copied
-// tab.Scope under a.mu pass it directly instead of re-reading the tab.
+// tabWorkspaceNameForScope resolves the display name for a tab's workspace.
+// Callers pass tab.Scope copied under a.mu instead of re-reading the tab.
 func tabWorkspaceNameForScope(scope, cwd string) string {
 	if scope == "global" {
 		return globalProjectTitle()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2950,25 +2950,47 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	// controller can be double-closed.
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
-	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
+
+	// Validate the tab, compare session keys, invalidate any in-flight async
+	// build, and snapshot the controller in ONE a.mu critical section.
+	// runtimeRebuildMu does not cover startTabControllerBuild's goroutine, so
+	// observing ctrl == nil and bumping the generation later would leave a
+	// window where the async build passes its swap-time generation check,
+	// installs its controller after the observation, and the loaded build
+	// below silently overwrites it — leaking the runtime and its shared-host
+	// reference. Bump-before-snapshot makes the snapshot authoritative: after
+	// the bump the async build can only fall into its superseded branches,
+	// which release exactly what it acquired (abandonSupersededBuild).
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return fmt.Errorf("tab is not ready")
+	}
+	currentPath := ""
+	if tab.Ctrl != nil {
+		currentPath = strings.TrimSpace(tab.Ctrl.SessionPath())
+	}
+	if currentPath == "" {
+		currentPath = strings.TrimSpace(tab.SessionPath)
+	}
+	if sessionRuntimeKey(currentPath) == sessionRuntimeKey(sessionPath) {
+		// Same session: leave any in-flight build alone — resuming the
+		// session a build is already binding must stay a no-op.
+		a.mu.Unlock()
 		return nil
 	}
+	tab.buildGeneration++
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+		tab.buildCancel = nil
+	}
+	ctrl := tab.Ctrl
+	a.mu.Unlock()
+
 	profile := loadTabSessionProfile(sessionPath)
 
-	a.mu.RLock()
-	ctrl := tab.Ctrl
-	a.mu.RUnlock()
 	if ctrl == nil {
 		a.mu.Lock()
-		// Invalidate any in-flight startTabControllerBuild for this tab: its
-		// buildCtx is cancelled and its generation goes stale, so it can no
-		// longer swap a controller in after we retarget the session (a second
-		// swap would leak whichever controller lost).
-		tab.buildGeneration++
-		if tab.buildCancel != nil {
-			tab.buildCancel()
-			tab.buildCancel = nil
-		}
 		tab.SessionPath = sessionPath
 		applyTabSessionProfile(tab, profile)
 		tab.Ready = false
@@ -3008,13 +3030,8 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	}
 
 	a.mu.Lock()
-	// Same invalidation as the ctrl==nil branch: a stale async build must not
-	// swap over the rebound session.
-	tab.buildGeneration++
-	if tab.buildCancel != nil {
-		tab.buildCancel()
-		tab.buildCancel = nil
-	}
+	// The generation was already bumped (and any async build cancelled) in
+	// the validation section above; only retarget the tab here.
 	tab.Ctrl = nil
 	tab.SessionPath = sessionPath
 	applyTabSessionProfile(tab, profile)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -104,11 +104,16 @@ type App struct {
 
 	// mu protects the tab map, tabOrder, activeTabID, and per-tab fields that are read
 	// from bound methods. All bound methods that touch a controller use activeCtrl().
-	mu                     sync.RWMutex
-	tabs                   map[string]*WorkspaceTab
-	tabOrder               []string
-	activeTabID            string
-	readyHook              func()
+	mu          sync.RWMutex
+	tabs        map[string]*WorkspaceTab
+	tabOrder    []string
+	activeTabID string
+	readyHook   func()
+
+	// projectTreeChangedHook is test-only: set once before any concurrency
+	// starts, then read lock-free from emitProjectTreeChanged (whose callers
+	// may or may not hold a.mu, so it cannot re-lock). Never write it after
+	// startup.
 	projectTreeChangedHook func()
 
 	// singleSurfaceMu serializes open/reuse plus visible-tab pruning for the
@@ -684,15 +689,23 @@ func (a *App) shutdown(context.Context) {
 
 	a.mu.RLock()
 	tabs := a.runtimeTabsLocked()
-	a.mu.RUnlock()
+	type shutdownItem struct {
+		tab  *WorkspaceTab
+		ctrl control.SessionAPI
+	}
+	items := make([]shutdownItem, 0, len(tabs))
 	for _, t := range tabs {
 		if t.Ctrl != nil {
-			if err := a.snapshotTab(t); err != nil {
-				slog.Warn("desktop: shutdown snapshot failed", "tab", t.ID, "err", err)
-			}
-			t.Ctrl.Close()
-			t.releaseSessionLease()
+			items = append(items, shutdownItem{tab: t, ctrl: t.Ctrl})
 		}
+	}
+	a.mu.RUnlock()
+	for _, it := range items {
+		if err := a.snapshotTab(it.tab); err != nil {
+			slog.Warn("desktop: shutdown snapshot failed", "tab", it.tab.ID, "err", err)
+		}
+		it.ctrl.Close()
+		it.tab.releaseSessionLease()
 	}
 }
 
@@ -754,7 +767,7 @@ func (a *App) Submit(input string) error {
 
 func (a *App) SubmitToTab(tabID, input string) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	trimmed := strings.TrimSpace(input)
@@ -763,14 +776,14 @@ func (a *App) SubmitToTab(tabID, input string) error {
 		return nil
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitDisplay(input, input)
@@ -802,18 +815,18 @@ func (a *App) RunShell(command string) error {
 
 func (a *App) RunShellForTab(tabID, command string) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.RunShell(command)
@@ -828,18 +841,18 @@ func (a *App) SubmitDisplay(display, input string) error {
 
 func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitDisplay(display, input)
@@ -848,18 +861,18 @@ func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
 
 func (a *App) SubmitEditedDisplayToTab(tabID, display, input, original string) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitEditedDisplay(display, input, original)
@@ -898,25 +911,27 @@ func (a *App) Steer(text string) error {
 // SteerForTab sends mid-turn guidance to a specific tab's agent.
 func (a *App) SteerForTab(tabID, text string) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	ctrl.Steer(text)
 	return nil
 }
 
 func (a *App) tabReadOnly(tabID string) bool {
-	tab := a.tabByID(tabID)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	tab := a.tabByIDLocked(tabID)
 	return tab != nil && tab.ReadOnly
 }
 
@@ -924,6 +939,19 @@ func (a *App) tabAndCtrlByID(tabID string) (*WorkspaceTab, control.SessionAPI) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	tab := a.tabByIDLocked(tabID)
+	if tab == nil {
+		return nil, nil
+	}
+	return tab, tab.Ctrl
+}
+
+// activeTabAndCtrl snapshots the active tab and its controller in one locked
+// read, so callers never do a check-then-use on tab.Ctrl after the lock is
+// released (a rebuild can swap the controller in between).
+func (a *App) activeTabAndCtrl() (*WorkspaceTab, control.SessionAPI) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	tab := a.activeTabLocked()
 	if tab == nil {
 		return nil, nil
 	}
@@ -940,6 +968,39 @@ func (a *App) controllerForTab(tab *WorkspaceTab) control.SessionAPI {
 		return nil
 	}
 	return tab.Ctrl
+}
+
+// currentSessionPathFor is the locked form of tab.currentSessionPath: it
+// snapshots Ctrl/SessionPath under a.mu, then queries the controller off-lock.
+// Use it on paths that do not otherwise hold a.mu.
+func (a *App) currentSessionPathFor(tab *WorkspaceTab) string {
+	if tab == nil {
+		return ""
+	}
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	fallback := strings.TrimSpace(tab.SessionPath)
+	a.mu.RUnlock()
+	if ctrl != nil {
+		if path := strings.TrimSpace(ctrl.SessionPath()); path != "" {
+			return path
+		}
+	}
+	return fallback
+}
+
+// sessionDirForSnapshot mirrors tabSessionDir for callers that hold a
+// tabRuntimeSnapshot instead of reading the live tab.
+func sessionDirForSnapshot(s tabRuntimeSnapshot) string {
+	if s.workspaceRoot != "" {
+		return desktopSessionDir(s.workspaceRoot)
+	}
+	if s.ctrl != nil {
+		if dir := s.ctrl.SessionDir(); dir != "" {
+			return dir
+		}
+	}
+	return desktopSessionDir("")
 }
 
 func readOnlyChannelErr() error {
@@ -1138,11 +1199,15 @@ func (a *App) ApproveTab(tabID, id string, allow, session, persist bool) {
 func (a *App) ReplayPendingPrompts() {
 	a.mu.RLock()
 	tabs := a.runtimeTabsLocked()
-	a.mu.RUnlock()
+	ctrls := make([]control.SessionAPI, 0, len(tabs))
 	for _, t := range tabs {
 		if t.Ctrl != nil {
-			t.Ctrl.ReplayPendingPrompts()
+			ctrls = append(ctrls, t.Ctrl)
 		}
+	}
+	a.mu.RUnlock()
+	for _, ctrl := range ctrls {
+		ctrl.ReplayPendingPrompts()
 	}
 }
 
@@ -1309,7 +1374,7 @@ func (a *App) Compact() error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
@@ -1328,11 +1393,32 @@ func (a *App) Compact() error {
 // workspaceNotReadyErr names why a session action arrived before the tab's
 // controller existed: still starting, or failed to start. Silently returning
 // nil here swallowed the click with no feedback (#3938).
-func workspaceNotReadyErr(tab *WorkspaceTab) error {
-	if tab != nil && strings.TrimSpace(tab.StartupErr) != "" {
-		return fmt.Errorf("workspace failed to start: %s", tab.StartupErr)
+//
+// This is the bound-method form: StartupErr is written under a.mu by the
+// build goroutine while Submit-family calls race it, so read it under the
+// lock. Callers must not hold a.mu.
+func (a *App) workspaceNotReadyErr(tab *WorkspaceTab) error {
+	startupErr := ""
+	if tab != nil {
+		a.mu.RLock()
+		startupErr = tab.StartupErr
+		a.mu.RUnlock()
+	}
+	if strings.TrimSpace(startupErr) != "" {
+		return fmt.Errorf("workspace failed to start: %s", startupErr)
 	}
 	return fmt.Errorf("workspace is still starting")
+}
+
+// tabIsReadOnly reads tab.ReadOnly under a.mu; setTabReadOnly can flip it
+// concurrently with Submit-family bound calls. Callers must not hold a.mu.
+func (a *App) tabIsReadOnly(tab *WorkspaceTab) bool {
+	if tab == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return tab.ReadOnly
 }
 
 // NewSession snapshots the current conversation and rotates to a fresh one.
@@ -1341,18 +1427,18 @@ func (a *App) NewSession() error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	// Tab is already blank — just persist and skip the new-session dance.
 	if !controllerHasActiveRuntimeWork(ctrl) && !messagesHaveConversationContent(ctrl.History()) {
@@ -1374,24 +1460,21 @@ func (a *App) assignFreshSessionTopic(tab *WorkspaceTab) {
 	if tab == nil {
 		return
 	}
+	topicID := newTopicID()
+	a.mu.Lock()
 	scope := tab.Scope
 	workspaceRoot := tab.WorkspaceRoot
+	tab.TopicID = topicID
+	tab.TopicTitle = defaultTopicTitle
+	if current := a.tabs[tab.ID]; current == tab {
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
 	if strings.TrimSpace(scope) == "global" {
 		workspaceRoot = ""
 	} else {
 		workspaceRoot = normalizeProjectRoot(workspaceRoot)
 	}
-	topicID := newTopicID()
-	a.mu.Lock()
-	if current := a.tabs[tab.ID]; current == tab {
-		tab.TopicID = topicID
-		tab.TopicTitle = defaultTopicTitle
-		a.saveTabsLocked()
-	} else {
-		tab.TopicID = topicID
-		tab.TopicTitle = defaultTopicTitle
-	}
-	a.mu.Unlock()
 	// NewSession already rotated the runtime to a fresh session. If the sidebar
 	// topic index repair fails here, keep the session usable and let persisted
 	// session metadata repair the topic index later instead of surfacing a false
@@ -1401,11 +1484,23 @@ func (a *App) assignFreshSessionTopic(tab *WorkspaceTab) {
 }
 
 func (a *App) ensureTabTopicIndexedForUserTurn(tab *WorkspaceTab) {
-	if tab == nil || strings.TrimSpace(tab.TopicID) != "" {
+	if tab == nil {
+		return
+	}
+	topicID := newTopicID()
+	a.mu.Lock()
+	if strings.TrimSpace(tab.TopicID) != "" {
+		a.mu.Unlock()
 		return
 	}
 	scope := tab.Scope
 	workspaceRoot := tab.WorkspaceRoot
+	tab.TopicID = topicID
+	tab.TopicTitle = defaultTopicTitle
+	if current := a.tabs[tab.ID]; current == tab {
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
 	if strings.TrimSpace(scope) == "global" {
 		scope = "global"
 		workspaceRoot = ""
@@ -1413,29 +1508,10 @@ func (a *App) ensureTabTopicIndexedForUserTurn(tab *WorkspaceTab) {
 		scope = "project"
 		workspaceRoot = normalizeProjectRoot(workspaceRoot)
 	}
-	topicID := newTopicID()
-	a.mu.Lock()
-	if current := a.tabs[tab.ID]; current == tab {
-		if strings.TrimSpace(tab.TopicID) != "" {
-			a.mu.Unlock()
-			return
-		}
-		tab.TopicID = topicID
-		tab.TopicTitle = defaultTopicTitle
-		a.saveTabsLocked()
-	} else {
-		if strings.TrimSpace(tab.TopicID) != "" {
-			a.mu.Unlock()
-			return
-		}
-		tab.TopicID = topicID
-		tab.TopicTitle = defaultTopicTitle
-	}
-	a.mu.Unlock()
 
 	_ = ensureTopicIndexed(scope, workspaceRoot, topicID, defaultTopicTitle, topicTitleSourceAuto)
 	_ = setTopicCreatedAt(topicTitleRoot(scope, workspaceRoot), topicID, time.Now().UnixMilli())
-	a.persistTabSessionPath(tab, tab.currentSessionPath())
+	a.persistTabSessionPath(tab, a.currentSessionPathFor(tab))
 	a.emitProjectTreeChanged()
 }
 
@@ -1454,18 +1530,18 @@ func (a *App) ClearSession() error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if err := a.ensureTabControllerWorkspace(tab); err != nil {
 		return err
 	}
 	ctrl = a.controllerForTab(tab)
 	if ctrl == nil {
-		return workspaceNotReadyErr(tab)
+		return a.workspaceNotReadyErr(tab)
 	}
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return a.clearActiveSessionRuntime(tab, ctrl)
@@ -1486,6 +1562,12 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	if tab == nil || oldCtrl == nil {
 		return fmt.Errorf("workspace is still starting")
 	}
+	// This is a build+swap of the tab's controller; serialize with the other
+	// rebuild paths (see runtimeRebuildMu) so a concurrent model/effort/settings
+	// rebuild cannot interleave a second swap. Lock order:
+	// runtimeRebuildMu → sessionRemovalMu (no path acquires them in reverse).
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
 	// This path destroys the old session's files (removeDesktopSessionArtifacts);
 	// serialize with DeleteSession/TrashTopic/workspace removal so they never
 	// trash or restore the same files mid-clear.
@@ -1494,9 +1576,12 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 
 	a.reconciledSessionPathForTab(tab)
 	oldPath := oldCtrl.SessionPath()
-	oldSink := tab.sink
+	// Snapshot the tab profile under a.mu: bound methods write these fields
+	// under the lock while this rebuild runs off-lock.
+	snap := a.tabRuntimeSnapshot(tab)
+	oldSink := snap.sink
 	if oldSink != nil {
-		oldSink.tabID = detachedRuntimeTabID(oldPath)
+		oldSink.setBinding(detachedRuntimeTabID(oldPath), nil)
 		oldSink.clearContext()
 	}
 	if oldCtrl.RuntimeStatus().Cancellable {
@@ -1515,15 +1600,15 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	}
 
 	newSink := &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
-	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:                    tab.model,
+		Model:                    snap.model,
 		RequireKey:               false,
 		Sink:                     newSink,
-		WorkspaceRoot:            tab.WorkspaceRoot,
-		SessionDir:               tabSessionDir(tab),
-		EffortOverride:           cloneStringPtr(tab.effort),
-		TokenMode:                currentTabTokenMode(tab),
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
+		EffortOverride:           cloneStringPtr(snap.effort),
+		TokenMode:                snap.currentTokenMode(),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
@@ -1538,7 +1623,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 			finishDestroyHandles(destroys)
 		}
 		if oldSink != nil {
-			oldSink.tabID = tab.ID
+			oldSink.setBinding(tab.ID, nil)
 			oldSink.setContext(a.ctx)
 		}
 		return err
@@ -1555,9 +1640,9 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
 	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
+	applyTabModeToController(newCtrl, snap.mode)
+	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
+	newCtrl.SetGoal(snap.goal)
 	path := agent.NewSessionPath(newCtrl.SessionDir(), newCtrl.Label())
 	if err := tab.ensureSessionLease(path); err != nil {
 		newCtrl.Close()
@@ -1717,7 +1802,7 @@ func (a *App) Rewind(turn int, scope string) error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
@@ -1829,7 +1914,7 @@ func (a *App) SummarizeFrom(turn int) error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
@@ -1843,7 +1928,7 @@ func (a *App) SummarizeUpTo(turn int) error {
 	tab := a.activeTabLocked()
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
-	if tab != nil && tab.ReadOnly {
+	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
 	}
 	if ctrl == nil {
@@ -2725,11 +2810,10 @@ func (a *App) ResumeSessionPage(path string, limit int) (HistoryPage, error) {
 }
 
 func (a *App) ResumeSessionPageForTab(tabID, path string, limit int) (HistoryPage, error) {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
 		return HistoryPage{}, fmt.Errorf("tab is not ready")
 	}
-	ctrl := tab.Ctrl
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {
 		return HistoryPage{}, err
@@ -2751,11 +2835,10 @@ func (a *App) ResumeSessionPageForTab(tabID, path string, limit int) (HistoryPag
 // path is a runtime identity, so changing to a different path must replace the
 // tab's controller binding rather than mutating the current controller in place.
 func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
 		return []HistoryMessage{}, fmt.Errorf("tab is not ready")
 	}
-	ctrl := tab.Ctrl
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {
 		return nil, err
@@ -2777,11 +2860,10 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 }
 
 func (a *App) OpenChannelSessionForTab(tabID, path string) ([]HistoryMessage, error) {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
 		return []HistoryMessage{}, fmt.Errorf("tab is not ready")
 	}
-	ctrl := tab.Ctrl
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {
 		return nil, err
@@ -2800,11 +2882,10 @@ func (a *App) OpenChannelSessionForTab(tabID, path string) ([]HistoryMessage, er
 }
 
 func (a *App) OpenChannelSessionPageForTab(tabID, path string, limit int) (HistoryPage, error) {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
 		return HistoryPage{}, fmt.Errorf("tab is not ready")
 	}
-	ctrl := tab.Ctrl
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {
 		return HistoryPage{}, err
@@ -2861,14 +2942,33 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 			return err
 		}
 	}
+	// Session rebinding is a full detach/close/build/swap of the tab's
+	// controller — the same shape as rebuildSetting/SetModelForTab. Hold the
+	// shared rebuild mutex so a concurrent model/effort/settings rebuild of the
+	// same tab cannot interleave: without it both builds pass the swap-time
+	// identity check, the loser's controller leaks un-closed, and the old
+	// controller can be double-closed.
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
 		return nil
 	}
 	profile := loadTabSessionProfile(sessionPath)
 
+	a.mu.RLock()
 	ctrl := tab.Ctrl
+	a.mu.RUnlock()
 	if ctrl == nil {
 		a.mu.Lock()
+		// Invalidate any in-flight startTabControllerBuild for this tab: its
+		// buildCtx is cancelled and its generation goes stale, so it can no
+		// longer swap a controller in after we retarget the session (a second
+		// swap would leak whichever controller lost).
+		tab.buildGeneration++
+		if tab.buildCancel != nil {
+			tab.buildCancel()
+			tab.buildCancel = nil
+		}
 		tab.SessionPath = sessionPath
 		applyTabSessionProfile(tab, profile)
 		tab.Ready = false
@@ -2878,9 +2978,12 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		a.saveTabsLocked()
 		a.mu.Unlock()
 		a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
-		if tab.Ctrl == nil {
-			if tab.StartupErr != "" {
-				return fmt.Errorf("resume session: %s", tab.StartupErr)
+		a.mu.RLock()
+		builtCtrl, startupErr := tab.Ctrl, tab.StartupErr
+		a.mu.RUnlock()
+		if builtCtrl == nil {
+			if startupErr != "" {
+				return fmt.Errorf("resume session: %s", startupErr)
 			}
 			return fmt.Errorf("resume session: controller was not built")
 		}
@@ -2895,7 +2998,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 			return fmt.Errorf("save current session metadata before switching sessions: %w", err)
 		}
 	}
-	if tab.hasActiveRuntimeWork() {
+	if controllerHasActiveRuntimeWork(ctrl) {
 		if !a.detachRuntimeForReplacement(tab) {
 			return fmt.Errorf("current session runtime cannot be detached")
 		}
@@ -2905,6 +3008,13 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	}
 
 	a.mu.Lock()
+	// Same invalidation as the ctrl==nil branch: a stale async build must not
+	// swap over the rebound session.
+	tab.buildGeneration++
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+		tab.buildCancel = nil
+	}
 	tab.Ctrl = nil
 	tab.SessionPath = sessionPath
 	applyTabSessionProfile(tab, profile)
@@ -2916,9 +3026,12 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	a.mu.Unlock()
 
 	a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
-	if tab.Ctrl == nil {
-		if tab.StartupErr != "" {
-			return fmt.Errorf("resume session: %s", tab.StartupErr)
+	a.mu.RLock()
+	builtCtrl, startupErr := tab.Ctrl, tab.StartupErr
+	a.mu.RUnlock()
+	if builtCtrl == nil {
+		if startupErr != "" {
+			return fmt.Errorf("resume session: %s", startupErr)
 		}
 		return fmt.Errorf("resume session: controller was not built")
 	}
@@ -3670,7 +3783,13 @@ func workspaceName(path string) string {
 }
 
 func tabWorkspaceName(tab *WorkspaceTab, cwd string) string {
-	if tab.Scope == "global" {
+	return tabWorkspaceNameForScope(tab.Scope, cwd)
+}
+
+// tabWorkspaceNameForScope is the snapshot form: callers that already copied
+// tab.Scope under a.mu pass it directly instead of re-reading the tab.
+func tabWorkspaceNameForScope(scope, cwd string) string {
+	if scope == "global" {
 		return globalProjectTitle()
 	}
 	return workspaceName(cwd)
@@ -4859,15 +4978,18 @@ func (a *App) Meta() Meta {
 }
 
 func (a *App) imageInputEnabledForTab(tabID string) bool {
-	var tab *WorkspaceTab
 	a.mu.RLock()
-	tab = a.tabByIDLocked(tabID)
+	tab := a.tabByIDLocked(tabID)
+	var ref, root string
+	if tab != nil {
+		ref = tab.model
+		root = tab.WorkspaceRoot
+	}
 	a.mu.RUnlock()
 	if tab == nil {
 		return false
 	}
-	ref := tab.model
-	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
+	cfg, err := config.LoadForRoot(root)
 	if err == nil && ref == "" {
 		ref = cfg.DefaultModel
 	}
@@ -4879,28 +5001,31 @@ func (a *App) imageInputEnabledForTab(tabID string) bool {
 }
 
 func (a *App) MetaForTab(tabID string) Meta {
-	tab := a.tabByID(tabID)
+	a.mu.RLock()
+	tab := a.tabByIDLocked(tabID)
+	snap := snapshotTabRuntimeLocked(tab)
+	a.mu.RUnlock()
 	if tab == nil {
 		return Meta{EventChannel: eventChannel}
 	}
-	cwd := tab.WorkspaceRoot
+	cwd := snap.workspaceRoot
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
-	autoApproveTools := tab.Ctrl != nil && tab.Ctrl.AutoApproveTools()
-	collaborationMode := currentTabCollaborationMode(tab)
-	toolApprovalMode := currentTabToolApprovalMode(tab)
-	tokenMode := currentTabTokenMode(tab)
-	goal := currentTabGoal(tab)
-	goalStatus := currentTabGoalStatus(tab)
+	autoApproveTools := snap.ctrl != nil && snap.ctrl.AutoApproveTools()
+	collaborationMode := snap.collaborationMode()
+	toolApprovalMode := snap.currentToolApprovalMode()
+	tokenMode := snap.currentTokenMode()
+	goal := snap.currentGoal()
+	goalStatus := snap.currentGoalStatus()
 	return Meta{
-		Label:             tab.Label,
-		Ready:             tab.Ready,
-		StartupErr:        tab.StartupErr,
+		Label:             snap.label,
+		Ready:             snap.ready,
+		StartupErr:        snap.startupErr,
 		EventChannel:      eventChannel,
 		Cwd:               cwd,
 		WorkspaceRoot:     cwd,
-		WorkspaceName:     tabWorkspaceName(tab, cwd),
+		WorkspaceName:     tabWorkspaceNameForScope(snap.scope, cwd),
 		WorkspacePath:     cwd,
 		GitBranch:         workspaceGitBranchForMeta(cwd),
 		ImageInputEnabled: a.imageInputEnabledForTab(tabID),
@@ -4911,7 +5036,24 @@ func (a *App) MetaForTab(tabID string) Meta {
 		TokenMode:         tokenMode,
 		Goal:              goal,
 		GoalStatus:        goalStatus,
-		AutoResearch:      compactAutoResearch(tab),
+		AutoResearch:      compactAutoResearchFromController(snap.ctrl),
+	}
+}
+
+func compactAutoResearchFromController(ctrl control.SessionAPI) *AutoResearchCompactView {
+	if ctrl == nil {
+		return nil
+	}
+	summary, ok := ctrl.AutoResearchSummary()
+	if !ok || summary == nil || summary.TaskID == "" {
+		return nil
+	}
+	return &AutoResearchCompactView{
+		TaskID:        summary.TaskID,
+		Status:        summary.Status,
+		Iteration:     summary.Iteration,
+		PivotRequired: summary.PivotRequired,
+		StaleCount:    summary.StaleCount,
 	}
 }
 
@@ -4969,11 +5111,11 @@ func (a *App) AutoResearchCurrent() AutoResearchStatusView {
 }
 
 func (a *App) AutoResearchStatus(tabID string) AutoResearchStatusView {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
 		return AutoResearchStatusView{OpenCriteria: []AutoResearchCriterionView{}}
 	}
-	summary, ok := tab.Ctrl.AutoResearchSummary()
+	summary, ok := ctrl.AutoResearchSummary()
 	if !ok {
 		return AutoResearchStatusView{OpenCriteria: []AutoResearchCriterionView{}}
 	}
@@ -4981,11 +5123,11 @@ func (a *App) AutoResearchStatus(tabID string) AutoResearchStatusView {
 }
 
 func (a *App) AutoResearchList(tabID string) []AutoResearchStatusView {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
 		return []AutoResearchStatusView{}
 	}
-	summaries, ok := tab.Ctrl.AutoResearchList()
+	summaries, ok := ctrl.AutoResearchList()
 	if !ok {
 		return []AutoResearchStatusView{}
 	}
@@ -4997,11 +5139,11 @@ func (a *App) AutoResearchList(tabID string) []AutoResearchStatusView {
 }
 
 func (a *App) AutoResearchFindings(tabID string, limit int) []AutoResearchFindingView {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
 		return []AutoResearchFindingView{}
 	}
-	findings, ok := tab.Ctrl.AutoResearchFindings(limit)
+	findings, ok := ctrl.AutoResearchFindings(limit)
 	if !ok {
 		return []AutoResearchFindingView{}
 	}
@@ -5030,11 +5172,11 @@ func (a *App) AutoResearchOpenTask(tabID string) error {
 }
 
 func (a *App) AutoResearchRecordEvidence(tabID, criterionID string, input AutoResearchEvidenceView) error {
-	tab := a.tabByID(tabID)
-	if tab == nil || tab.Ctrl == nil {
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
 		return os.ErrInvalid
 	}
-	return tab.Ctrl.RecordAutoResearchEvidence(criterionID, control.AutoResearchEvidenceInput{
+	return ctrl.RecordAutoResearchEvidence(criterionID, control.AutoResearchEvidenceInput{
 		ID:       input.ID,
 		Kind:     input.Kind,
 		Summary:  input.Summary,
@@ -5843,14 +5985,14 @@ func (a *App) ReloadCommands() error {
 	if a.ctx == nil {
 		return nil
 	}
-	tab := a.activeTab()
-	if tab == nil || tab.Ctrl == nil {
+	_, ctrl := a.activeTabAndCtrl()
+	if ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
-	if tab.Ctrl.Running() {
+	if ctrl.Running() {
 		return fmt.Errorf("wait for the current turn to finish, then retry")
 	}
-	return tab.Ctrl.ReloadCommands(a.ctx)
+	return ctrl.ReloadCommands(a.ctx)
 }
 
 // SetSkillEnabled persists a skill toggle and rebuilds the controller so the
@@ -6052,20 +6194,20 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 
 // RemoveMCPServer disconnects a live server and drops it from config (the row's ✕).
 func (a *App) RemoveMCPServer(name string) error {
-	tab := a.activeTab()
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.activeTabAndCtrl()
+	if tab == nil || ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
-	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
-	disconnected := tab.Ctrl.DisconnectMCPServer(name)
+	disconnected := ctrl.DisconnectMCPServer(name)
 	removed, err := a.removeDesktopMCPServer(name)
 	if err != nil {
 		return err
 	}
 	if disconnected || removed {
-		if h := tab.Ctrl.Host(); h != nil {
+		if h := ctrl.Host(); h != nil {
 			h.ClearFailure(name)
 		}
 		a.mu.Lock()
@@ -6081,15 +6223,15 @@ func (a *App) RemoveMCPServer(name string) error {
 // a fresh handshake and tool re-registration), then reconnects.  Failures are
 // recorded on the Host so the UI can render them.
 func (a *App) ReconnectMCPServer(name string) error {
-	tab := a.activeTab()
-	if tab == nil || tab.Ctrl == nil {
+	tab, ctrl := a.activeTabAndCtrl()
+	if tab == nil || ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
-	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
-	tab.Ctrl.DisconnectMCPServer(name)
-	if h := tab.Ctrl.Host(); h != nil {
+	ctrl.DisconnectMCPServer(name)
+	if h := ctrl.Host(); h != nil {
 		h.ClearFailure(name)
 	}
 	_, err := a.connectConfiguredMCPServerForTab(tab, name)
@@ -6104,7 +6246,7 @@ func (a *App) ReconnectMCPServer(name string) error {
 		if p, found, cfgErr := a.desktopMCPServerForEdit(name); cfgErr == nil && found {
 			entry = p
 		}
-		recordMCPFailure(tab.Ctrl, entry, err)
+		recordMCPFailure(ctrl, entry, err)
 		return err
 	}
 	a.mu.Lock()
@@ -6226,11 +6368,19 @@ func (a *App) UntrustMCPServerTool(name, toolName string) error {
 // for this session, off disconnects it (config untouched either way — like Claude
 // Code's per-conversation enable/disable, it resets on the next session start).
 func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
-	tab := a.activeTab()
-	if tab == nil || tab.Ctrl == nil {
+	a.mu.RLock()
+	tab := a.activeTabLocked()
+	var ctrl control.SessionAPI
+	hostKey := ""
+	if tab != nil {
+		ctrl = tab.Ctrl
+		hostKey = tab.SharedHostKey
+	}
+	a.mu.RUnlock()
+	if tab == nil || ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
-	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
 	configuredEntry, hasConfiguredEntry, err := a.desktopMCPServerForEdit(name)
@@ -6246,7 +6396,7 @@ func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
 		}
 		return err
 	}
-	if s, ok := findMCPServerView(tab.Ctrl, name); ok {
+	if s, ok := findMCPServerView(ctrl, name); ok {
 		s.Status = "disabled"
 		s.Error = ""
 		a.mu.Lock()
@@ -6266,25 +6416,33 @@ func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
 		tab.mcpOrder = mergeServerOrder(tab.mcpOrder, []ServerView{s})
 		a.mu.Unlock()
 	}
-	if tab.SharedHostKey != "" {
-		tab.Ctrl.UnregisterMCPServerTools(name)
+	if hostKey != "" {
+		ctrl.UnregisterMCPServerTools(name)
 	} else {
-		tab.Ctrl.DisconnectMCPServer(name)
+		ctrl.DisconnectMCPServer(name)
 	}
 	return nil
 }
 
 func (a *App) connectConfiguredMCPServerForTab(tab *WorkspaceTab, name string) (int, error) {
-	if tab == nil || tab.Ctrl == nil {
+	a.mu.RLock()
+	var ctrl control.SessionAPI
+	root := ""
+	if tab != nil {
+		ctrl = tab.Ctrl
+		root = tab.WorkspaceRoot
+	}
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return 0, fmt.Errorf("no active session")
 	}
-	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
+	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		return 0, err
 	}
 	for _, p := range cfg.Plugins {
 		if p.Name == name {
-			return tab.Ctrl.ConnectMCPServer(p)
+			return ctrl.ConnectMCPServer(p)
 		}
 	}
 	return 0, fmt.Errorf("no configured MCP server named %q", name)
@@ -6294,8 +6452,8 @@ func (a *App) connectConfiguredMCPServerForTab(tab *WorkspaceTab, name string) (
 // retired tier field.
 func (a *App) SetMCPServerTier(name, tier string) error {
 	tier = normalizeMCPTier(tier)
-	tab := a.activeTab()
-	if tab != nil && controllerHasActiveRuntimeWork(tab.Ctrl) {
+	tab, ctrl := a.activeTabAndCtrl()
+	if tab != nil && controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
 	updated, found, err := a.desktopMCPServerForEdit(name)
@@ -6313,9 +6471,9 @@ func (a *App) SetMCPServerTier(name, tier string) error {
 	if err := a.saveDesktopMCPServer(updated); err != nil {
 		return err
 	}
-	if tab != nil && tab.Ctrl != nil && !mcpConnected(tab.Ctrl, name) {
-		if _, err := tab.Ctrl.ConnectMCPServer(updated); err != nil {
-			recordMCPFailure(tab.Ctrl, updated, err)
+	if tab != nil && ctrl != nil && !mcpConnected(ctrl, name) {
+		if _, err := ctrl.ConnectMCPServer(updated); err != nil {
+			recordMCPFailure(ctrl, updated, err)
 			return nil
 		}
 		a.mu.Lock()
@@ -6744,8 +6902,7 @@ func (a *App) ensureTabSessionLeaseForRebuild(tab *WorkspaceTab, path, setting s
 	if err := tab.ensureSessionLease(path); err != nil {
 		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
 			if lease, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
-				tab.releaseSessionLease()
-				tab.sessionLease = lease
+				tab.adoptSessionLease(lease)
 				return nil
 			} else {
 				err = reclaimErr
@@ -6774,7 +6931,7 @@ func (a *App) canReclaimCurrentProcessSessionLease(tab *WorkspaceTab, path strin
 		if candidate == nil || candidate == tab {
 			continue
 		}
-		if candidate.sessionLease != nil && sessionRuntimeKey(candidate.sessionLease.Path()) == key {
+		if candidate.sessionLeaseRuntimeKey() == key {
 			return false
 		}
 		if candidate.Ctrl != nil && sessionRuntimeKey(candidate.currentSessionPath()) == key {
@@ -6799,7 +6956,10 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if tab == nil {
 		return nil
 	}
-	if name == tab.model {
+	a.mu.RLock()
+	currentModel := tab.model
+	a.mu.RUnlock()
+	if name == currentModel {
 		return nil
 	}
 	// Same build+swap shape as rebuildSetting; hold the same lock so a settings
@@ -6809,7 +6969,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	defer a.runtimeRebuildMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	if a.controllerForTab(tab) == nil && prevPath != "" {
 		a.attachExistingSessionRuntime(tab, prevPath, a.ctx)
@@ -6822,18 +6982,22 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	}
 	prevPath = a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
 		prevPath = a.reconciledSessionPathForTab(tab)
 		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
+			prevPath = a.currentSessionPathFor(tab)
 		}
 		if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 			return rebuildControllerActiveWorkError("model")
 		}
 	}
-	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
+	// Snapshot the tab profile under a.mu: SetModeForTab/SetGoalForTab and the
+	// event sink write these fields under the lock while this rebuild runs
+	// off-lock.
+	snap := a.tabRuntimeSnapshot(tab)
+	cfg, err := config.LoadForRoot(snap.workspaceRoot)
 	if err != nil {
 		return err
 	}
@@ -6845,7 +7009,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		return fmt.Errorf("model %q is not available because provider %q is not added", name, entry.Name)
 	}
 	name = entry.Name + "/" + entry.Model
-	effortOverride := cloneStringPtr(tab.effort)
+	effortOverride := cloneStringPtr(snap.effort)
 	if effortOverride != nil {
 		normalized, err := config.NormalizeEffort(entry, config.EffortDisplay(&config.ProviderEntry{Effort: *effortOverride}))
 		if err != nil {
@@ -6872,16 +7036,16 @@ func (a *App) SetModelForTab(tabID, name string) error {
 
 	// Preserve the shared plugin host across controller rebuilds — the tab
 	// stays in the same workspace root, so MCP processes must not be restarted.
-	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
 
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
 		Model:                    name,
 		RequireKey:               false,
-		Sink:                     tab.sink,
-		WorkspaceRoot:            tab.WorkspaceRoot,
-		SessionDir:               tabSessionDir(tab),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
 		EffortOverride:           cloneStringPtr(effortOverride),
-		TokenMode:                currentTabTokenMode(tab),
+		TokenMode:                snap.currentTokenMode(),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
@@ -6892,9 +7056,9 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
 	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
+	applyTabModeToController(newCtrl, snap.mode)
+	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
+	newCtrl.SetGoal(snap.goal)
 
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "model"); err != nil {
@@ -6974,7 +7138,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	defer a.runtimeRebuildMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	// Recomputing prevPath after this attach would be a dead store: it is
 	// unconditionally derived again after ensureTabControllerWorkspace below.
@@ -6989,17 +7153,18 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	}
 	prevPath = a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
 		prevPath = a.reconciledSessionPathForTab(tab)
 		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
+			prevPath = a.currentSessionPathFor(tab)
 		}
 		if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 			return rebuildControllerActiveWorkError("effort")
 		}
 	}
+	snap := a.tabRuntimeSnapshot(tab)
 	entry, err := a.currentProviderEntryForTab(tabID)
 	if err != nil {
 		return err
@@ -7023,15 +7188,15 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		}
 		carried = oldCtrl.History()
 	}
-	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
 		Model:                    modelRef,
 		RequireKey:               false,
-		Sink:                     tab.sink,
-		WorkspaceRoot:            tab.WorkspaceRoot,
-		SessionDir:               tabSessionDir(tab),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
 		EffortOverride:           &effort,
-		TokenMode:                currentTabTokenMode(tab),
+		TokenMode:                snap.currentTokenMode(),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
@@ -7042,9 +7207,9 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
 	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
+	applyTabModeToController(newCtrl, snap.mode)
+	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
+	newCtrl.SetGoal(snap.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "effort"); err != nil {
 		newCtrl.Close()
@@ -7088,7 +7253,10 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		}
 		return fmt.Errorf("tab %q not found", tabID)
 	}
-	if mode == currentTabTokenMode(tab) {
+	a.mu.RLock()
+	currentMode := boot.NormalizeTokenMode(tab.tokenMode)
+	a.mu.RUnlock()
+	if mode == currentMode {
 		return nil
 	}
 	// Build+swap path; serialize with the other rebuild paths (see runtimeRebuildMu).
@@ -7096,7 +7264,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	defer a.runtimeRebuildMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	// Recomputing prevPath after this attach would be a dead store: it is
 	// unconditionally derived again after ensureTabControllerWorkspace below.
@@ -7111,12 +7279,12 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	}
 	prevPath = a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
 		prevPath = a.reconciledSessionPathForTab(tab)
 		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
+			prevPath = a.currentSessionPathFor(tab)
 		}
 		if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 			return rebuildControllerActiveWorkError("token mode")
@@ -7126,8 +7294,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if err != nil {
 		return err
 	}
-	if fallback && strings.TrimSpace(tab.model) != "" {
-		a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", tab.model, modelRef))
+	snap := a.tabRuntimeSnapshot(tab)
+	if fallback && strings.TrimSpace(snap.model) != "" {
+		a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", snap.model, modelRef))
 	}
 
 	var carried []provider.Message
@@ -7144,14 +7313,14 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		}
 		carried = oldCtrl.History()
 	}
-	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
 		Model:                    modelRef,
 		RequireKey:               false,
-		Sink:                     tab.sink,
-		WorkspaceRoot:            tab.WorkspaceRoot,
-		SessionDir:               tabSessionDir(tab),
-		EffortOverride:           cloneStringPtr(tab.effort),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
+		EffortOverride:           cloneStringPtr(snap.effort),
 		TokenMode:                mode,
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
@@ -7163,9 +7332,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	}
 	a.bindControllerDisplayRecorder(newCtrl)
 	newCtrl.EnableInteractiveApproval()
-	applyTabModeToController(newCtrl, tab.mode)
-	applyTabToolApprovalModeToController(newCtrl, tab.toolApprovalMode)
-	newCtrl.SetGoal(tab.goal)
+	applyTabModeToController(newCtrl, snap.mode)
+	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
+	newCtrl.SetGoal(snap.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "token mode"); err != nil {
 		newCtrl.Close()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2717,6 +2717,106 @@ func TestSetModelForTabReusesCurrentSessionLease(t *testing.T) {
 	}
 }
 
+func TestSetModelForTabWaitsForConcurrentBlankSessionLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "NEW_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old", "new"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+		{Name: "new", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "new-model", APIKeyEnv: "NEW_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "blank-model-switch-race.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write blank session: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:            "tab_blank_race",
+		Scope:         "global",
+		WorkspaceRoot: globalTabWorkspaceRoot(),
+		SessionPath:   path,
+		Ready:         true,
+		model:         "old/old-model",
+		sink:          &tabEventSink{tabID: "tab_blank_race", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	acquired := make(chan struct{})
+	releaseHook := make(chan struct{})
+	var once sync.Once
+	sessionLeaseAcquireHookForTest = func() {
+		once.Do(func() {
+			close(acquired)
+			<-releaseHook
+		})
+	}
+	t.Cleanup(func() { sessionLeaseAcquireHookForTest = nil })
+
+	buildErr := make(chan error, 1)
+	go func() {
+		buildErr <- tab.ensureSessionLease(path)
+	}()
+
+	select {
+	case <-acquired:
+	case err := <-buildErr:
+		t.Fatalf("background lease acquire returned before hook: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("background lease acquire did not start")
+	}
+
+	switchErr := make(chan error, 1)
+	go func() {
+		switchErr <- app.SetModelForTab(tab.ID, "new/new-model")
+	}()
+
+	select {
+	case err := <-switchErr:
+		t.Fatalf("SetModelForTab returned before concurrent lease was bound: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseHook)
+	if err := <-buildErr; err != nil {
+		t.Fatalf("background ensureSessionLease: %v", err)
+	}
+	if err := <-switchErr; err != nil {
+		t.Fatalf("SetModelForTab: %v", err)
+	}
+	if tab.Ctrl == nil {
+		t.Fatal("model switch did not build a controller")
+	}
+	if got := tab.model; got != "new/new-model" {
+		t.Fatalf("tab model = %q, want new/new-model", got)
+	}
+	if tab.sessionLease == nil || sessionRuntimeKey(tab.sessionLease.Path()) != sessionRuntimeKey(path) {
+		t.Fatalf("session lease path = %q, want %q", tab.currentSessionPath(), path)
+	}
+}
+
 func TestSetModelForTabLeaseHeldKeepsCurrentController(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")

--- a/desktop/bot_connection_app.go
+++ b/desktop/bot_connection_app.go
@@ -138,12 +138,19 @@ func (a *App) StartBotConnectionInstall(provider, domain string) (BotInstallStar
 
 func (a *App) PollBotConnectionInstall(installID string) (BotInstallPollResult, error) {
 	installID = strings.TrimSpace(installID)
+	// Copy the session under a.mu: overlapping polls of the same install can
+	// race the locked PollDomain upgrade below with unlocked field reads.
 	a.mu.RLock()
-	session := a.botInstalls[installID]
+	sessionPtr := a.botInstalls[installID]
+	var sessionCopy botInstallSession
+	if sessionPtr != nil {
+		sessionCopy = *sessionPtr
+	}
 	a.mu.RUnlock()
-	if session == nil {
+	if sessionPtr == nil {
 		return BotInstallPollResult{Error: "install session not found"}, nil
 	}
+	session := &sessionCopy
 	if time.Now().After(session.ExpireAt) {
 		a.deleteBotInstall(installID)
 		return BotInstallPollResult{Status: "expired", Error: "install session expired"}, nil

--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -70,8 +70,11 @@ func (a *App) refreshBotRuntimeAsync() {
 }
 
 func (a *App) refreshBotRuntime() {
+	// NewApp always pre-fills botRuntime; a nil here means a test-constructed
+	// App with no bot runtime, which must not lazily create one from a
+	// background goroutine (that would race a concurrent refresh).
 	if a.botRuntime == nil {
-		a.botRuntime = newDesktopBotRuntime()
+		return
 	}
 	cfg, err := a.loadDesktopBotConfig()
 	if err != nil {

--- a/desktop/race_regression_test.go
+++ b/desktop/race_regression_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
@@ -275,6 +277,170 @@ func TestAbandonSupersededBuildPreservesNewBuildOwnership(t *testing.T) {
 		t.Fatalf("matching-key abandon did not release the lease: %v", err)
 	}
 	lease.Release()
+}
+
+// TestRebindInvalidatesInFlightAsyncBuildBeforeSnapshot reproduces the #5968
+// review scenario: an async startTabControllerBuild is stalled right after
+// binding its session lease (holding its controller, lease, and shared-host
+// reference), a rebind to a different session starts meanwhile, and the
+// stalled build then tries to finish. The rebind must bump the generation
+// BEFORE snapshotting tab.Ctrl, so the stale build can only fall into its
+// superseded branches: the rebound controller must survive un-overwritten,
+// the stale build's lease and host reference must be released, and the
+// replacement build's ownership must stay intact.
+func TestRebindInvalidatesInFlightAsyncBuildBeforeSnapshot(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	oldPath := filepath.Join(dir, "rebind-race-old.jsonl")
+	newPath := filepath.Join(dir, "rebind-race-new.jsonl")
+	writeHistoryTestSession(t, oldPath, "old prompt")
+	writeHistoryTestSession(t, newPath, "new prompt")
+	oldKey := sessionRuntimeKey(oldPath)
+	newKey := sessionRuntimeKey(newPath)
+
+	app := NewApp()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID:            "tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   oldPath,
+		sink:          &tabEventSink{tabID: "tab", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		app.mu.RLock()
+		ctrl := tab.Ctrl
+		app.mu.RUnlock()
+		if ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	// Stall the async build inside its lease bind: at that point it already
+	// holds its controller, its lease, and its shared-host reference.
+	stalled := make(chan struct{})
+	releaseHook := make(chan struct{})
+	var once sync.Once
+	sessionLeaseAcquireHookForTest = func() {
+		once.Do(func() {
+			close(stalled)
+			<-releaseHook
+		})
+	}
+	t.Cleanup(func() { sessionLeaseAcquireHookForTest = nil })
+	t.Cleanup(func() {
+		select {
+		case <-releaseHook:
+		default:
+			close(releaseHook)
+		}
+	})
+
+	// startTabControllerBuild only backgrounds the build when a Wails context
+	// exists; expand its goroutine branch by hand so a.ctx can stay nil (the
+	// nil-ctx emit guards are what every other build test relies on too).
+	buildCtx, cancel := context.WithCancel(context.Background())
+	app.mu.Lock()
+	tab.buildGeneration++
+	generation := tab.buildGeneration
+	tab.buildCancel = cancel
+	app.mu.Unlock()
+	buildDone := make(chan struct{})
+	go func() {
+		defer close(buildDone)
+		app.buildTabControllerWithContext(tab, loadedTabSession{}, buildCtx, generation, cancel)
+	}()
+	select {
+	case <-stalled:
+	case <-time.After(15 * time.Second):
+		t.Fatal("async build did not reach the lease bind")
+	}
+
+	loaded, err := agent.LoadSession(newPath)
+	if err != nil {
+		t.Fatalf("LoadSession(new): %v", err)
+	}
+	rebindErr := make(chan error, 1)
+	go func() {
+		rebindErr <- app.rebindTabToLoadedSessionPath(tab, newPath, loaded)
+	}()
+
+	// Wait until the rebind's validation section has invalidated the async
+	// build (startTabControllerBuild set generation 1; the rebind bumps to 2)
+	// while the async build is still stalled pre-swap.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		app.mu.RLock()
+		generation := tab.buildGeneration
+		app.mu.RUnlock()
+		if generation >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("rebind did not bump the build generation")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	close(releaseHook)
+	select {
+	case err := <-rebindErr:
+		if err != nil {
+			t.Fatalf("rebindTabToLoadedSessionPath: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("rebind did not finish after releasing the stalled build")
+	}
+	select {
+	case <-buildDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("stale async build did not finish its superseded cleanup")
+	}
+
+	app.mu.RLock()
+	builtCtrl := tab.Ctrl
+	sessionPath := tab.SessionPath
+	app.mu.RUnlock()
+	if builtCtrl == nil {
+		t.Fatal("rebind left the tab without a controller")
+	}
+	if got := builtCtrl.SessionPath(); got != newPath {
+		t.Fatalf("stale async build overwrote the rebound controller: session path = %q, want %q", got, newPath)
+	}
+	if sessionPath != newPath {
+		t.Fatalf("tab.SessionPath = %q, want %q", sessionPath, newPath)
+	}
+	if got := tab.sessionLeaseRuntimeKey(); got != newKey {
+		t.Fatalf("tab lease key = %q, want the rebound session %q", got, newKey)
+	}
+	// The stale build's lease must be gone (released by its superseded
+	// cleanup or replaced by the rebound build's adopt) — the old session
+	// must be acquirable again.
+	lease, err := agent.TryAcquireSessionLease(oldKey)
+	if err != nil {
+		t.Fatalf("stale build leaked its session lease: %v", err)
+	}
+	lease.Release()
+	// Exactly one shared-host reference may remain: the rebound build's. The
+	// stale build must have released its own.
+	app.sharedHostsMu.Lock()
+	refs := 0
+	for _, entry := range app.sharedHosts {
+		refs += entry.refs
+	}
+	app.sharedHostsMu.Unlock()
+	if refs != 1 {
+		t.Fatalf("shared host refs = %d after stale-build cleanup, want 1 (the rebound build's)", refs)
+	}
 }
 
 // TestMetaForTabConcurrentWithBuildSwap polls MetaForTab (the frontend's boot

--- a/desktop/race_regression_test.go
+++ b/desktop/race_regression_test.go
@@ -185,6 +185,98 @@ func TestTabBuildSupersededByRebindGeneration(t *testing.T) {
 	}
 }
 
+// TestReleaseSessionLeaseForKeyOnlyMatchesOwnKey: superseded builds may only
+// release the lease bound to their own path; a mismatched key (the rebind's
+// replacement session) must be left untouched.
+func TestReleaseSessionLeaseForKeyOnlyMatchesOwnKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	pathA := filepath.Join(dir, "lease-key-a.jsonl")
+	pathB := filepath.Join(dir, "lease-key-b.jsonl")
+	tab := &WorkspaceTab{ID: "tab"}
+	t.Cleanup(tab.releaseSessionLease)
+	if err := tab.ensureSessionLease(pathB); err != nil {
+		t.Fatalf("ensureSessionLease: %v", err)
+	}
+
+	tab.releaseSessionLeaseForKey(sessionRuntimeKey(pathA))
+	if _, err := agent.TryAcquireSessionLease(sessionRuntimeKey(pathB)); err == nil {
+		t.Fatal("mismatched key released the tab's live lease")
+	}
+
+	tab.releaseSessionLeaseForKey(sessionRuntimeKey(pathB))
+	lease, err := agent.TryAcquireSessionLease(sessionRuntimeKey(pathB))
+	if err != nil {
+		t.Fatalf("matching key did not release the lease: %v", err)
+	}
+	lease.Release()
+}
+
+// TestAbandonSupersededBuildPreservesNewBuildOwnership reproduces the rebind
+// interleaving from the #5968 review: a stale async build cleans up after a
+// rebind's replacement build already published its own SharedHostKey and
+// session lease on the same live tab. The stale build must drop only its own
+// host reference and lease, never the tab's.
+func TestAbandonSupersededBuildPreservesNewBuildOwnership(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	oldPath := filepath.Join(dir, "superseded-old.jsonl")
+	newPath := filepath.Join(dir, "superseded-new.jsonl")
+	newKey := sessionRuntimeKey(newPath)
+
+	app := &App{tabs: map[string]*WorkspaceTab{}}
+	// The stale build and the replacement build each hold one reference on
+	// the same workspace-root host (the common same-root rebind).
+	app.acquireSharedHost("root")
+	app.acquireSharedHost("root")
+
+	tab := &WorkspaceTab{ID: "tab", SharedHostKey: "root"}
+	app.tabs["tab"] = tab
+	t.Cleanup(tab.releaseSessionLease)
+	if err := tab.ensureSessionLease(newPath); err != nil {
+		t.Fatalf("ensureSessionLease(new): %v", err)
+	}
+
+	// Stale build abandons with ITS key material: the old lease path and the
+	// root key it acquired.
+	app.abandonSupersededBuild(tab, nil, "root", sessionRuntimeKey(oldPath))
+
+	app.mu.RLock()
+	hostKey := tab.SharedHostKey
+	app.mu.RUnlock()
+	if hostKey != "root" {
+		t.Fatalf("stale build cleared the tab's SharedHostKey: %q", hostKey)
+	}
+	app.sharedHostsMu.Lock()
+	entry := app.sharedHosts["root"]
+	refs := 0
+	if entry != nil {
+		refs = entry.refs
+	}
+	app.sharedHostsMu.Unlock()
+	if refs != 1 {
+		t.Fatalf("shared host refs = %d after stale-build cleanup, want 1 (the live build's reference)", refs)
+	}
+	if got := tab.sessionLeaseRuntimeKey(); got != newKey {
+		t.Fatalf("stale build released the replacement build's lease: key = %q, want %q", got, newKey)
+	}
+
+	// Removal shape: the abandoned build's own key still on the tab is the
+	// last reference and must be released.
+	app.abandonSupersededBuild(tab, nil, "", newKey)
+	lease, err := agent.TryAcquireSessionLease(newKey)
+	if err != nil {
+		t.Fatalf("matching-key abandon did not release the lease: %v", err)
+	}
+	lease.Release()
+}
+
 // TestMetaForTabConcurrentWithBuildSwap polls MetaForTab (the frontend's boot
 // probe) while a fake build goroutine flips Ready/Label/StartupErr/model under
 // a.mu — the write pattern of buildTabControllerWithContext. Run with -race.

--- a/desktop/race_regression_test.go
+++ b/desktop/race_regression_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+// TestSessionLeaseHelpersConcurrentAccess hammers the sessionLeaseMu helpers
+// (ensure/take/adopt/release/key) from concurrent goroutines. Run with -race:
+// any residual raw access to tab.sessionLease shows up as a data race, and the
+// final acquire asserts no lease leaked through an interleaving.
+func TestSessionLeaseHelpersConcurrentAccess(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "lease-helper-hammer.jsonl")
+	key := sessionRuntimeKey(path)
+	tabA := &WorkspaceTab{ID: "a"}
+	tabB := &WorkspaceTab{ID: "b"}
+
+	const iterations = 300
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = tabA.ensureSessionLease(path)
+			_ = tabA.sessionLeaseRuntimeKey()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// The applyRuntimeTab transfer shape: move A's lease to B and back.
+			tabB.adoptSessionLease(tabA.takeSessionLease())
+			tabA.adoptSessionLease(tabB.takeSessionLease())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			tabA.releaseSessionLease()
+		}
+	}()
+	wg.Wait()
+
+	tabA.releaseSessionLease()
+	tabB.releaseSessionLease()
+	lease, err := agent.TryAcquireSessionLease(key)
+	if err != nil {
+		t.Fatalf("lease leaked through concurrent helper interleavings: %v", err)
+	}
+	lease.Release()
+}
+
+// TestDetachRuntimeForReplacementTransfersLease asserts the detach clone takes
+// lease ownership through the locked helpers and the visible tab keeps none.
+func TestDetachRuntimeForReplacementTransfersLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "detach-transfer.jsonl")
+	key := sessionRuntimeKey(path)
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", SessionPath: path}
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("ensureSessionLease: %v", err)
+	}
+	t.Cleanup(func() {
+		tab.releaseSessionLease()
+		for _, d := range app.detachedSessions {
+			d.releaseSessionLease()
+		}
+	})
+
+	if !app.detachRuntimeForReplacement(tab) {
+		t.Fatal("detachRuntimeForReplacement failed for a live tab")
+	}
+	detached := app.detachedSessions[key]
+	if detached == nil {
+		t.Fatal("detached runtime was not registered")
+	}
+	if got := detached.sessionLeaseRuntimeKey(); got != key {
+		t.Fatalf("detached clone lease key = %q, want %q", got, key)
+	}
+	if got := tab.sessionLeaseRuntimeKey(); got != "" {
+		t.Fatalf("visible tab still holds lease key %q after detach", got)
+	}
+}
+
+// TestDetachRuntimeForReplacementSkipsRemovedTab: a tab that DeleteSession /
+// CloseTab already unlinked must not be re-published into detachedSessions
+// (the "session resurrects" class, #4384).
+func TestDetachRuntimeForReplacementSkipsRemovedTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "detach-removed.jsonl")
+
+	removed := &WorkspaceTab{ID: "removed", SessionPath: path, removed: true}
+	app := &App{tabs: map[string]*WorkspaceTab{"removed": removed}}
+	if app.detachRuntimeForReplacement(removed) {
+		t.Fatal("removed tab was detached into the background registry")
+	}
+	if len(app.detachedSessions) != 0 {
+		t.Fatal("removed tab left an entry in detachedSessions")
+	}
+
+	orphan := &WorkspaceTab{ID: "orphan", SessionPath: path}
+	if app.detachRuntimeForReplacement(orphan) {
+		t.Fatal("tab absent from a.tabs was detached into the background registry")
+	}
+	if len(app.detachedSessions) != 0 {
+		t.Fatal("orphan tab left an entry in detachedSessions")
+	}
+}
+
+// TestTabEventSinkEmitConcurrentRebind: Emit keeps running on the controller
+// goroutine while detach/reattach rebinds the sink's tab routing. Run with
+// -race; before setBinding existed the tabID write raced every Emit.
+func TestTabEventSinkEmitConcurrentRebind(t *testing.T) {
+	sink := &tabEventSink{tabID: "before"}
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			sink.Emit(event.Event{Kind: event.Notice, Text: "hammer"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			sink.setBinding(fmt.Sprintf("tab-%d", i%2), nil)
+			sink.clearContext()
+		}
+	}()
+	wg.Wait()
+	if tabID, _ := sink.binding(); tabID == "" {
+		t.Fatal("sink lost its tab binding")
+	}
+}
+
+// TestTabBuildSupersededByRebindGeneration: a session rebind bumps
+// buildGeneration to strand any in-flight async build, so its swap (and every
+// mid-build field write) is rejected; synchronous rebuilds pass generation 0
+// and rely on runtimeRebuildMu instead.
+func TestTabBuildSupersededByRebindGeneration(t *testing.T) {
+	tab := &WorkspaceTab{ID: "tab"}
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+	app.mu.Lock()
+	tab.buildGeneration = 3
+	app.mu.Unlock()
+	if app.tabBuildSuperseded(tab, 3) {
+		t.Fatal("build with the current generation must not be superseded")
+	}
+	app.mu.Lock()
+	tab.buildGeneration++ // the rebind-side invalidation
+	app.mu.Unlock()
+	if !app.tabBuildSuperseded(tab, 3) {
+		t.Fatal("stale-generation build must be superseded after a rebind bump")
+	}
+	if app.tabBuildSuperseded(tab, 0) {
+		t.Fatal("synchronous rebuild (generation 0) must not be superseded by generation bumps")
+	}
+	app.mu.Lock()
+	tab.removed = true
+	app.mu.Unlock()
+	if !app.tabBuildSuperseded(tab, 0) {
+		t.Fatal("removed tab must supersede every build, including synchronous ones")
+	}
+}
+
+// TestMetaForTabConcurrentWithBuildSwap polls MetaForTab (the frontend's boot
+// probe) while a fake build goroutine flips Ready/Label/StartupErr/model under
+// a.mu — the write pattern of buildTabControllerWithContext. Run with -race.
+func TestMetaForTabConcurrentWithBuildSwap(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	tab := &WorkspaceTab{ID: "tab", Scope: "project", WorkspaceRoot: t.TempDir()}
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"tab": tab},
+		tabOrder:    []string{"tab"},
+		activeTabID: "tab",
+	}
+
+	const iterations = 100
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < iterations; i++ {
+			app.mu.Lock()
+			tab.Ready = !tab.Ready
+			tab.Label = fmt.Sprintf("model-%d", i)
+			tab.StartupErr = ""
+			tab.model = fmt.Sprintf("provider/m%d", i)
+			tab.goal = fmt.Sprintf("goal-%d", i)
+			tab.tokenMode = "full"
+			app.mu.Unlock()
+		}
+	}()
+	for i := 0; i < iterations; i++ {
+		meta := app.MetaForTab("tab")
+		if meta.EventChannel == "" {
+			t.Fatal("MetaForTab returned zero meta for a live tab")
+		}
+	}
+	<-done
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1511,12 +1511,12 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	}
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
-		prevPath = strings.TrimSpace(tab.currentSessionPath())
+		prevPath = a.currentSessionPathFor(tab)
 	}
 	if a.controllerForTab(tab) == nil && prevPath != "" && a.attachExistingSessionRuntime(tab, prevPath, a.ctx) {
 		prevPath = a.reconciledSessionPathForTab(tab)
 		if prevPath == "" {
-			prevPath = strings.TrimSpace(tab.currentSessionPath())
+			prevPath = a.currentSessionPathFor(tab)
 		}
 	}
 	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
@@ -1540,8 +1540,9 @@ func (a *App) rebuildSettingLocked(setting string) error {
 		}
 		carried = oldCtrl.History()
 	}
-	model := tab.model
-	if cfg, err := config.LoadForRoot(tab.WorkspaceRoot); err == nil {
+	snap := a.tabRuntimeSnapshot(tab)
+	model := snap.model
+	if cfg, err := config.LoadForRoot(snap.workspaceRoot); err == nil {
 		if resolved, fallback, ok := cfg.ResolveModelWithFallback(model); ok {
 			if fallback && strings.TrimSpace(model) != "" {
 				a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", model, resolved))
@@ -1549,14 +1550,14 @@ func (a *App) rebuildSettingLocked(setting string) error {
 			model = resolved
 		}
 	}
-	sharedHost := a.lookupSharedHost(tab.SharedHostKey)
+	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
 	ctrl, err := boot.Build(a.bootContext(), boot.Options{
 		Model: model, RequireKey: false,
-		Sink:                     tab.sink,
-		WorkspaceRoot:            tab.WorkspaceRoot,
-		SessionDir:               tabSessionDir(tab),
-		EffortOverride:           cloneStringPtr(tab.effort),
-		TokenMode:                currentTabTokenMode(tab),
+		Sink:                     snap.sink,
+		WorkspaceRoot:            snap.workspaceRoot,
+		SessionDir:               sessionDirForSnapshot(snap),
+		EffortOverride:           cloneStringPtr(snap.effort),
+		TokenMode:                snap.currentTokenMode(),
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
@@ -1574,12 +1575,12 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	}
 	a.bindControllerDisplayRecorder(ctrl)
 	ctrl.EnableInteractiveApproval()
-	applyTabModeToController(ctrl, tab.mode)
+	applyTabModeToController(ctrl, snap.mode)
 	// applyTabModeToController only encodes plan+yolo from tab.mode.
 	// Apply the explicit toolApprovalMode (ask/auto/yolo) afterwards so
 	// "auto" is not lost — otherwise rebuild would silently downgrade
 	// auto to ask (#5424 regression).
-	if mode := strings.TrimSpace(tab.toolApprovalMode); mode != "" {
+	if mode := strings.TrimSpace(snap.toolApprovalMode); mode != "" {
 		applyTabToolApprovalModeToController(ctrl, mode)
 	}
 	path := agent.ContinueSessionPath(prevPath, ctrl.SessionDir(), ctrl.Label())

--- a/desktop/shared_host.go
+++ b/desktop/shared_host.go
@@ -135,11 +135,18 @@ func (a *App) releaseSharedHost(root string) {
 }
 
 func (a *App) releaseTabSharedHost(tab *WorkspaceTab) {
-	if tab == nil || tab.SharedHostKey == "" {
+	if tab == nil {
 		return
 	}
-	key := tab.SharedHostKey
-	tab.SharedHostKey = ""
+	// SharedHostKey is a.mu-guarded (the build goroutine publishes it under
+	// the lock); do the take under the lock and the slow host release after.
+	// Callers must not hold a.mu.
+	a.mu.Lock()
+	key := takeTabSharedHostKey(tab)
+	a.mu.Unlock()
+	if key == "" {
+		return
+	}
 	a.releaseSharedHost(key)
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2775,6 +2775,15 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			// superseded, only a lease still carrying this key may be
 			// released (see abandonSupersededBuild).
 			acquiredLeaseKey = sessionRuntimeKey(path)
+			// Re-check ownership right after the (potentially slow) lease
+			// bind: a rebind that superseded this build while ensure was in
+			// flight has already retargeted the tab, and continuing into
+			// Resume/persistTabSessionPath would write the stale session
+			// path back onto the rebound tab.
+			if a.tabBuildSuperseded(tab, buildGeneration) {
+				a.abandonSupersededBuild(tab, ctrl, rootKey, acquiredLeaseKey)
+				return
+			}
 			if resumeSession != nil {
 				ctrl.Resume(sessionWithFreshSystemPrompt(resumeSession, systemPromptFrom(ctrl.History())), path)
 			} else {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -52,6 +52,7 @@ type WorkspaceTab struct {
 	Ready           bool               // true once boot.Build completes
 	StartupErr      string             // build error, surfaced to the frontend
 	sessionLease    *agent.SessionLease
+	sessionLeaseMu  sync.Mutex
 	sink            *tabEventSink      // routes events with this tab's ID
 	buildCancel     context.CancelFunc // cancels in-flight boot for tabs removed before Ready
 	buildGeneration uint64             // identifies the current in-flight build
@@ -244,6 +245,8 @@ func sessionRuntimeKey(path string) string {
 	return canonicalTabSessionPath(path)
 }
 
+var sessionLeaseAcquireHookForTest func()
+
 func (t *WorkspaceTab) ensureSessionLease(path string) error {
 	if t == nil || t.ReadOnly {
 		return nil
@@ -252,24 +255,39 @@ func (t *WorkspaceTab) ensureSessionLease(path string) error {
 	if key == "" {
 		return nil
 	}
+	t.sessionLeaseMu.Lock()
 	if t.sessionLease != nil && sessionRuntimeKey(t.sessionLease.Path()) == key {
+		t.sessionLeaseMu.Unlock()
 		return nil
 	}
 	lease, err := agent.TryAcquireSessionLease(key)
 	if err != nil {
+		t.sessionLeaseMu.Unlock()
 		return err
 	}
-	t.releaseSessionLease()
+	if hook := sessionLeaseAcquireHookForTest; hook != nil {
+		hook()
+	}
+	old := t.sessionLease
 	t.sessionLease = lease
+	t.sessionLeaseMu.Unlock()
+	if old != nil {
+		old.Release()
+	}
 	return nil
 }
 
 func (t *WorkspaceTab) releaseSessionLease() {
-	if t == nil || t.sessionLease == nil {
+	if t == nil {
 		return
 	}
-	t.sessionLease.Release()
+	t.sessionLeaseMu.Lock()
+	lease := t.sessionLease
 	t.sessionLease = nil
+	t.sessionLeaseMu.Unlock()
+	if lease != nil {
+		lease.Release()
+	}
 }
 
 func detachedRuntimeTabID(key string) string {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -340,6 +340,27 @@ func (t *WorkspaceTab) sessionLeaseRuntimeKey() string {
 	return sessionRuntimeKey(t.sessionLease.Path())
 }
 
+// releaseSessionLeaseForKey releases the tab's lease only when it is bound to
+// key. Superseded builds clean up with this instead of releaseSessionLease:
+// on a removed tab the keys match and the lease is released as before, but
+// when a session rebind superseded the build, the rebind's replacement build
+// holds a lease for a *different* session key (rebind early-returns on equal
+// keys), and releasing that here would strip the live session's protection.
+func (t *WorkspaceTab) releaseSessionLeaseForKey(key string) {
+	if t == nil || key == "" {
+		return
+	}
+	t.sessionLeaseMu.Lock()
+	lease := t.sessionLease
+	if lease == nil || sessionRuntimeKey(lease.Path()) != key {
+		t.sessionLeaseMu.Unlock()
+		return
+	}
+	t.sessionLease = nil
+	t.sessionLeaseMu.Unlock()
+	lease.Release()
+}
+
 func detachedRuntimeTabID(key string) string {
 	sum := sha256.Sum256([]byte(key))
 	return "detached_" + hex.EncodeToString(sum[:8])
@@ -2347,15 +2368,6 @@ func (a *App) markTabRemovedLocked(tab *WorkspaceTab) {
 	}
 }
 
-func (a *App) tabRemovedForBuild(tab *WorkspaceTab) bool {
-	if tab == nil {
-		return true
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return tab.removed || a.tabs[tab.ID] != tab
-}
-
 // tabBuildSupersededLocked reports whether an in-flight build lost ownership
 // of its tab: the tab was removed/replaced, or a session rebind bumped
 // buildGeneration to invalidate it. Generation 0 marks the synchronous
@@ -2375,6 +2387,25 @@ func (a *App) tabBuildSuperseded(tab *WorkspaceTab, generation uint64) bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.tabBuildSupersededLocked(tab, generation)
+}
+
+// abandonSupersededBuild cleans up after a build that lost tab ownership
+// mid-flight (removed tab, or a session rebind bumped the generation). It
+// releases only what THIS build acquired — its controller, its own
+// shared-host reference (rootKey), and the session lease bound to its own
+// path (leaseKey) — and never reads or clears the tab's SharedHostKey or
+// lease outright: on a live rebound tab the replacement build may already
+// have published its own key and lease there, and taking those would leak
+// the new runtime's host reference (or close a host still in use) and strip
+// the new session's lease. Callers must not hold a.mu.
+func (a *App) abandonSupersededBuild(tab *WorkspaceTab, ctrl control.SessionAPI, rootKey, leaseKey string) {
+	if ctrl != nil {
+		ctrl.Close()
+	}
+	if rootKey != "" {
+		a.releaseSharedHost(rootKey)
+	}
+	tab.releaseSessionLeaseForKey(leaseKey)
 }
 
 func (a *App) clearTabBuildCancel(tab *WorkspaceTab, generation uint64, cancel context.CancelFunc, keepContext bool) {
@@ -2640,11 +2671,8 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	if err != nil {
 		a.mu.Lock()
 		if a.tabBuildSupersededLocked(tab, buildGeneration) {
-			hostKey := takeTabSharedHostKey(tab)
 			a.mu.Unlock()
-			if hostKey != "" {
-				a.releaseSharedHost(hostKey)
-			}
+			a.abandonSupersededBuild(tab, nil, rootKey, "")
 			return
 		}
 		tab.StartupErr = err.Error()
@@ -2659,8 +2687,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		return
 	}
 	if a.tabBuildSuperseded(tab, buildGeneration) {
-		ctrl.Close()
-		a.releaseTabSharedHost(tab)
+		a.abandonSupersededBuild(tab, ctrl, rootKey, "")
 		return
 	}
 
@@ -2670,6 +2697,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	applyTabToolApprovalModeToController(ctrl, buildToolApprovalMode)
 	ctrl.SetGoal(buildGoal)
 
+	acquiredLeaseKey := ""
 	if dir := ctrl.SessionDir(); dir != "" {
 		migratedTopics := migrateLegacySessionsIntoGlobalTopics(dir)
 		if len(migratedTopics) > 0 {
@@ -2727,12 +2755,8 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			if err := tab.ensureSessionLease(path); err != nil {
 				a.mu.Lock()
 				if a.tabBuildSupersededLocked(tab, buildGeneration) {
-					hostKey := takeTabSharedHostKey(tab)
 					a.mu.Unlock()
-					ctrl.Close()
-					if hostKey != "" {
-						a.releaseSharedHost(hostKey)
-					}
+					a.abandonSupersededBuild(tab, ctrl, rootKey, "")
 					return
 				}
 				tab.StartupErr = err.Error()
@@ -2747,6 +2771,10 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				a.emitReady(wailsCtx, tab.ID)
 				return
 			}
+			// Remember which lease THIS build bound: if the build is later
+			// superseded, only a lease still carrying this key may be
+			// released (see abandonSupersededBuild).
+			acquiredLeaseKey = sessionRuntimeKey(path)
 			if resumeSession != nil {
 				ctrl.Resume(sessionWithFreshSystemPrompt(resumeSession, systemPromptFrom(ctrl.History())), path)
 			} else {
@@ -2778,9 +2806,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	a.mu.Lock()
 	if a.tabBuildSupersededLocked(tab, buildGeneration) {
 		a.mu.Unlock()
-		ctrl.Close()
-		a.releaseTabSharedHost(tab)
-		tab.releaseSessionLease()
+		a.abandonSupersededBuild(tab, ctrl, rootKey, acquiredLeaseKey)
 		return
 	}
 	tab.Ctrl = ctrl

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -290,6 +290,56 @@ func (t *WorkspaceTab) releaseSessionLease() {
 	}
 }
 
+// takeSessionLease removes and returns the tab's current lease WITHOUT
+// releasing it, so ownership can transfer to another holder. All access to
+// t.sessionLease must go through sessionLeaseMu; never read or assign the
+// field directly outside these helpers.
+func (t *WorkspaceTab) takeSessionLease() *agent.SessionLease {
+	if t == nil {
+		return nil
+	}
+	t.sessionLeaseMu.Lock()
+	lease := t.sessionLease
+	t.sessionLease = nil
+	t.sessionLeaseMu.Unlock()
+	return lease
+}
+
+// adoptSessionLease installs lease as the tab's session lease, releasing any
+// previously held lease unless it is the very same lease. A nil tab releases
+// the lease immediately so ownership is never dropped on the floor.
+func (t *WorkspaceTab) adoptSessionLease(lease *agent.SessionLease) {
+	if t == nil {
+		if lease != nil {
+			lease.Release()
+		}
+		return
+	}
+	t.sessionLeaseMu.Lock()
+	old := t.sessionLease
+	t.sessionLease = lease
+	t.sessionLeaseMu.Unlock()
+	if old != nil && old != lease {
+		old.Release()
+	}
+}
+
+// sessionLeaseRuntimeKey reports the runtime key of the currently held lease,
+// or "" when no lease is held. Safe to call while holding App.mu: the lock
+// order App.mu → sessionLeaseMu has no reverse path (the lease helpers never
+// touch App state while holding sessionLeaseMu).
+func (t *WorkspaceTab) sessionLeaseRuntimeKey() string {
+	if t == nil {
+		return ""
+	}
+	t.sessionLeaseMu.Lock()
+	defer t.sessionLeaseMu.Unlock()
+	if t.sessionLease == nil {
+		return ""
+	}
+	return sessionRuntimeKey(t.sessionLease.Path())
+}
+
 func detachedRuntimeTabID(key string) string {
 	sum := sha256.Sum256([]byte(key))
 	return "detached_" + hex.EncodeToString(sum[:8])
@@ -335,12 +385,23 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 	if tab == nil {
 		return false
 	}
-	key := sessionRuntimeKey(tab.currentSessionPath())
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	fallbackPath := strings.TrimSpace(tab.SessionPath)
+	sink := tab.sink
+	a.mu.RUnlock()
+	path := fallbackPath
+	if ctrl != nil {
+		if p := strings.TrimSpace(ctrl.SessionPath()); p != "" {
+			path = p
+		}
+	}
+	key := sessionRuntimeKey(path)
 	if key == "" {
 		return false
 	}
-	if tab.sink != nil {
-		tab.sink.clearContext()
+	if sink != nil {
+		sink.clearContext()
 	}
 	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
@@ -350,6 +411,12 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 	return true
 }
 
+// cloneDetachedRuntimeTab copies a running tab's runtime state into a fresh
+// detached tab. Callers must hold a.mu: the copied fields (Ctrl, Ready,
+// ActivityStatus, disabledMCP, ...) are written under a.mu by bound methods
+// and the event sink, and the disabledMCP map read would otherwise race those
+// writers. The session lease is transferred separately by the caller through
+// the sessionLeaseMu helpers.
 func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
 	if tab == nil {
 		return nil
@@ -371,7 +438,6 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
 		Label:            tab.Label,
 		Ready:            tab.Ready,
 		StartupErr:       tab.StartupErr,
-		sessionLease:     tab.sessionLease,
 		sink:             tab.sink,
 		ActivityStatus:   tab.ActivityStatus,
 		readTelemetry:    readTelemetry,
@@ -391,25 +457,44 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	if tab == nil {
 		return false
 	}
+	// One a.mu critical section covers the membership check, the field
+	// snapshot, the lease/sink handover, and the re-publication:
+	//   - the clone reads fields that bound methods and the event sink write
+	//     under a.mu (ActivityStatus every event, disabledMCP is a map);
+	//   - inserting the clone without re-checking a.tabs would resurrect a
+	//     runtime that DeleteSession/TrashTopic/RemoveWorkspace already
+	//     unlinked and closed (the "session resurrects" class, #4384);
+	//   - publishing before the lease/sink handover would let a concurrent
+	//     attachExistingSessionRuntime claim a half-initialized clone.
+	// The lease transfer stays deadlock-safe here: neither side holds a lease
+	// to release, so no lease I/O runs under a.mu.
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return false
+	}
 	key := sessionRuntimeKey(tab.currentSessionPath())
 	if key == "" {
+		a.mu.Unlock()
 		return false
 	}
 	detached := cloneDetachedRuntimeTab(tab, key)
 	if detached == nil {
+		a.mu.Unlock()
 		return false
 	}
-	tab.sessionLease = nil
+	// Transfer lease ownership through the locked helpers: a concurrent
+	// ensureSessionLease (blank-session boot, recovery callback) must never
+	// observe a torn pointer or have its freshly acquired lease clobbered.
+	detached.adoptSessionLease(tab.takeSessionLease())
 	if detached.sink != nil {
-		detached.sink.tabID = detached.ID
+		detached.sink.setBinding(detached.ID, nil)
 		// clearContext (locked nil + drain the queued emitter), not a bare
 		// ctx=nil: the latter both data-races s.ctx and leaves already-queued
 		// events to flush onto the rebound tab after this session is backgrounded
 		// (#5352 — stale "AI 不断输出" on the now-visible session).
 		detached.sink.clearContext()
 	}
-
-	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
 	a.detachedSessions[key] = detached
 	a.mu.Unlock()
@@ -426,18 +511,13 @@ func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.
 	source.telemMu.Unlock()
 
 	if source.sink != nil {
-		source.sink.tabID = target.ID
-		source.sink.app = app
+		source.sink.setBinding(target.ID, app)
 		source.sink.setContext(wailsCtx)
 	}
 
 	target.Ctrl = source.Ctrl
 	target.sink = source.sink
-	if target.sessionLease != source.sessionLease {
-		target.releaseSessionLease()
-	}
-	target.sessionLease = source.sessionLease
-	source.sessionLease = nil
+	target.adoptSessionLease(source.takeSessionLease())
 	target.SessionPath = key
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
@@ -474,9 +554,10 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 		if current := a.tabs[tab.ID]; current == tab {
 			a.saveTabsLocked()
 		}
+		attachedCtrl := tab.Ctrl
 		a.mu.Unlock()
-		if tab.Ctrl != nil {
-			tab.Ctrl.ReplayPendingPrompts()
+		if attachedCtrl != nil {
+			attachedCtrl.ReplayPendingPrompts()
 		}
 		return true
 	}
@@ -502,10 +583,11 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	}
 	applyRuntimeTab(tab, source, key, wailsCtx, a)
 	a.saveTabsLocked()
+	attachedCtrl := tab.Ctrl
 	a.mu.Unlock()
 
-	if tab.Ctrl != nil {
-		tab.Ctrl.ReplayPendingPrompts()
+	if attachedCtrl != nil {
+		attachedCtrl.ReplayPendingPrompts()
 	}
 	return true
 }
@@ -746,6 +828,11 @@ func (t *WorkspaceTab) takePlannerDisplayTurn() []HistoryMessage {
 
 // tabEventSink wraps a parent event.Sink and prepends a tabId to every wire
 // event so the frontend can route it to the correct tab's reducer.
+//
+// tabID and app are rebound while the controller keeps emitting when a running
+// session is detached to the background or reattached to another tab, so they
+// live under mu like ctx does (a bare field write would data-race Emit). Read
+// them via binding(), write via setBinding().
 type tabEventSink struct {
 	tabID         string
 	app           *App
@@ -759,8 +846,27 @@ type closeableEventSink interface {
 	Close()
 }
 
+// binding snapshots the sink's current tab routing under the sink lock.
+func (s *tabEventSink) binding() (string, *App) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tabID, s.app
+}
+
+// setBinding reroutes the sink to another tab. A nil app keeps the current
+// App pointer (detach/close paths only change the tab id).
+func (s *tabEventSink) setBinding(tabID string, app *App) {
+	s.mu.Lock()
+	s.tabID = tabID
+	if app != nil {
+		s.app = app
+	}
+	s.mu.Unlock()
+}
+
 func (s *tabEventSink) Emit(e event.Event) {
-	if s.app != nil {
+	tabID, app := s.binding()
+	if app != nil {
 		switch e.Kind {
 		case event.TurnStarted:
 			s.resetPlannerDisplayTurn()
@@ -770,7 +876,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 		case event.TurnDone:
 			s.recordTurnDone()
 		}
-		if m := s.app.metrics.Load(); m != nil {
+		if m := app.metrics.Load(); m != nil {
 			m.observe(e)
 			if e.Kind == event.TurnDone {
 				m.persist()
@@ -780,12 +886,12 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.flushPlannerDisplay()
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTab(e, s.tabID))
-	if s.app != nil {
+	s.emitRuntimeEvent(eventChannel, toWireTab(e, tabID))
+	if app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update {
-			changed := s.app.setTabActivityStatus(s.tabID, status)
+			changed := app.setTabActivityStatus(tabID, status)
 			if changed || isBackgroundJobLifecycleNotice(e) {
-				s.app.emitProjectTreeChanged()
+				app.emitProjectTreeChanged()
 			}
 		}
 	}
@@ -793,12 +899,12 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if e.Kind == event.ToolResult && e.Tool.Name == "read_file" && e.Tool.Err == "" {
 		s.recordReadTelemetry(e)
 	}
-	if s.app != nil {
+	if app != nil {
 		s.recordPlannerDisplay(e)
 	}
 	// Persist after each turn so a force-kill loses at most the in-flight prompt.
-	if e.Kind == event.TurnDone && s.app != nil {
-		s.app.scheduleTabSnapshot(s.tabID)
+	if e.Kind == event.TurnDone && app != nil {
+		app.scheduleTabSnapshot(tabID)
 	}
 	// Forward event to bot channels when a bot forwarder is attached.
 	// Read the sink under the read lock so SetBotSink can safely swap it
@@ -988,16 +1094,17 @@ func (a *App) emitReady(ctx context.Context, tabID ...string) {
 }
 
 func (s *tabEventSink) recordReadTelemetry(e event.Event) {
-	if s.app == nil {
+	tabID, app := s.binding()
+	if app == nil {
 		return
 	}
-	s.app.mu.RLock()
-	tab := s.app.tabByEventSinkIDLocked(s.tabID)
+	app.mu.RLock()
+	tab := app.tabByEventSinkIDLocked(tabID)
 	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
-	s.app.mu.RUnlock()
+	app.mu.RUnlock()
 	if tab == nil {
 		return
 	}
@@ -1108,12 +1215,13 @@ func (s *tabEventSink) flushPlannerDisplay() {
 }
 
 func (s *tabEventSink) eventTabAndController() (*WorkspaceTab, control.SessionAPI) {
-	if s.app == nil {
+	tabID, app := s.binding()
+	if app == nil {
 		return nil, nil
 	}
-	s.app.mu.RLock()
-	defer s.app.mu.RUnlock()
-	tab := s.app.tabByEventSinkIDLocked(s.tabID)
+	app.mu.RLock()
+	defer app.mu.RUnlock()
+	tab := app.tabByEventSinkIDLocked(tabID)
 	if tab == nil {
 		return nil, nil
 	}
@@ -1130,16 +1238,17 @@ func lastUserMessageContent(msgs []provider.Message) string {
 }
 
 func (s *tabEventSink) telemetryTab() (*WorkspaceTab, string) {
-	if s.app == nil {
+	tabID, app := s.binding()
+	if app == nil {
 		return nil, ""
 	}
-	s.app.mu.RLock()
-	tab := s.app.tabByEventSinkIDLocked(s.tabID)
+	app.mu.RLock()
+	tab := app.tabByEventSinkIDLocked(tabID)
 	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
-	s.app.mu.RUnlock()
+	app.mu.RUnlock()
 	if tab == nil {
 		return nil, ""
 	}
@@ -2012,28 +2121,34 @@ func (a *App) CloseTab(tabID string) error {
 		}
 	}
 	a.saveTabsLocked()
+	// Snapshot the teardown targets while still holding the lock: the tab is
+	// no longer reachable from a.tabs after this section, but locked writers
+	// holding stale pointers (rememberTabSessionPath, applySessionBindingToTab)
+	// can still write its fields under a.mu.
+	closeCtrl := tab.Ctrl
+	closeSink := tab.sink
 	a.mu.Unlock()
 
 	// Tear down outside the lock.
-	discardPath, discardTransientBlank := transientBlankSessionArtifactPath(tab)
-	if tab.Ctrl != nil {
-		if tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
+	discardPath, discardTransientBlank := a.transientBlankSessionArtifactPath(tab)
+	if closeCtrl != nil {
+		if controllerHasActiveRuntimeWork(closeCtrl) && a.detachSessionRuntime(tab) {
 			// Detached runtimes keep running and must keep saving: do not
 			// clear the path or drain for them.
 			return nil
 		}
-		tab.Ctrl.SetSessionPath("") // future snapshots become no-ops
-		a.quiesceTabAutosave(tab)   // wait for any in-flight snapshot to finish
-		tab.Ctrl.Cancel()
-		tab.Ctrl.Close()
+		closeCtrl.SetSessionPath("") // future snapshots become no-ops
+		a.quiesceTabAutosave(tab)    // wait for any in-flight snapshot to finish
+		closeCtrl.Cancel()
+		closeCtrl.Close()
 		// Release the shared plugin host reference. The host stays alive as
 		// long as any other tab for the same workspace root holds a reference;
 		// on the last release the host is closed and its subprocesses exit.
 		a.releaseTabSharedHost(tab)
 		tab.releaseSessionLease()
 	}
-	if tab.sink != nil {
-		tab.sink.clearContext() // stop further emissions (nil ctx -> Emit becomes no-op)
+	if closeSink != nil {
+		closeSink.clearContext() // stop further emissions (nil ctx -> Emit becomes no-op)
 	}
 	if discardTransientBlank {
 		discardTransientBlankSessionArtifacts(discardPath)
@@ -2166,8 +2281,11 @@ func (a *App) removeVisibleTabRuntime(tab *WorkspaceTab) {
 	if err := a.snapshotTab(tab); err != nil {
 		slog.Warn("desktop: snapshot before removing visible tab runtime failed", "tab", tab.ID, "err", err)
 	}
-	discardPath, discardTransientBlank := transientBlankSessionArtifactPath(tab)
-	if tab.Ctrl != nil && tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
+	discardPath, discardTransientBlank := a.transientBlankSessionArtifactPath(tab)
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	a.mu.RUnlock()
+	if ctrl != nil && controllerHasActiveRuntimeWork(ctrl) && a.detachSessionRuntime(tab) {
 		return
 	}
 	a.markTabRemoved(tab)
@@ -2177,14 +2295,26 @@ func (a *App) removeVisibleTabRuntime(tab *WorkspaceTab) {
 	}
 }
 
-func transientBlankSessionArtifactPath(tab *WorkspaceTab) (string, bool) {
-	if tab == nil || tab.ReadOnly || strings.TrimSpace(tab.TopicID) != "" || tab.hasActiveRuntimeWork() {
+// transientBlankSessionArtifactPath reports the artifact path to discard when
+// closing a still-blank tab. It snapshots the racy tab fields under a.mu and
+// keeps the file probe (sessionPathHasNoContent) outside the lock. Callers
+// must not hold a.mu.
+func (a *App) transientBlankSessionArtifactPath(tab *WorkspaceTab) (string, bool) {
+	if tab == nil {
 		return "", false
 	}
-	if strings.TrimSpace(tab.SessionPath) == "" || !blankTabSessionPathHasNoContent(tab) {
+	snap := a.tabRuntimeSnapshot(tab)
+	if snap.readOnly || strings.TrimSpace(snap.topicID) != "" || controllerHasActiveRuntimeWork(snap.ctrl) {
 		return "", false
 	}
-	path, ok := pinnedTabSessionPath(tabSessionDir(tab), tab.SessionPath)
+	if strings.TrimSpace(snap.sessionPath) == "" {
+		return "", false
+	}
+	dir := sessionDirForSnapshot(snap)
+	if !sessionPathHasNoContent(dir, snap.sessionPath) {
+		return "", false
+	}
+	path, ok := pinnedTabSessionPath(dir, snap.sessionPath)
 	if !ok {
 		return "", false
 	}
@@ -2226,6 +2356,27 @@ func (a *App) tabRemovedForBuild(tab *WorkspaceTab) bool {
 	return tab.removed || a.tabs[tab.ID] != tab
 }
 
+// tabBuildSupersededLocked reports whether an in-flight build lost ownership
+// of its tab: the tab was removed/replaced, or a session rebind bumped
+// buildGeneration to invalidate it. Generation 0 marks the synchronous
+// rebuild paths, which serialize through runtimeRebuildMu instead and are
+// never superseded by generation bumps. Callers must hold a.mu.
+func (a *App) tabBuildSupersededLocked(tab *WorkspaceTab, generation uint64) bool {
+	if tab == nil || tab.removed || a.tabs[tab.ID] != tab {
+		return true
+	}
+	return generation != 0 && tab.buildGeneration != generation
+}
+
+func (a *App) tabBuildSuperseded(tab *WorkspaceTab, generation uint64) bool {
+	if tab == nil {
+		return true
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.tabBuildSupersededLocked(tab, generation)
+}
+
 func (a *App) clearTabBuildCancel(tab *WorkspaceTab, generation uint64, cancel context.CancelFunc, keepContext bool) {
 	if cancel == nil {
 		return
@@ -2247,15 +2398,19 @@ func (a *App) closeTabRuntime(tab *WorkspaceTab) {
 	if tab == nil {
 		return
 	}
-	if tab.Ctrl != nil {
-		tab.Ctrl.SetSessionPath("") // future snapshots become no-ops
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	sink := tab.sink
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.SetSessionPath("") // future snapshots become no-ops
 		a.quiesceTabAutosave(tab)
-		tab.Ctrl.Cancel()
-		tab.Ctrl.Close()
+		ctrl.Cancel()
+		ctrl.Close()
 		a.releaseTabSharedHost(tab)
 	}
-	if tab.sink != nil {
-		tab.sink.clearContext()
+	if sink != nil {
+		sink.clearContext()
 	}
 	tab.releaseSessionLease()
 }
@@ -2329,13 +2484,25 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		a.clearTabBuildCancel(tab, buildGeneration, buildCancel, keepBuildContext)
 	}()
 	wailsCtx := a.ctx
-	if a.tabRemovedForBuild(tab) {
+	if a.tabBuildSuperseded(tab, buildGeneration) {
 		return
 	}
 
 	a.reconcileTabWithPinnedSessionMeta(tab)
 
-	root := tab.WorkspaceRoot
+	// Snapshot the identity/profile fields under a.mu before the off-lock
+	// stretch: session rebinding, recovery, and topic assignment write them
+	// under the lock while this goroutine builds.
+	a.mu.RLock()
+	tabWorkspaceRoot := tab.WorkspaceRoot
+	tabScope := tab.Scope
+	tabTopicID := tab.TopicID
+	tabSessionPath := tab.SessionPath
+	tabModel := tab.model
+	tabSink := tab.sink
+	a.mu.RUnlock()
+
+	root := tabWorkspaceRoot
 	if root == "" {
 		if wd, err := os.Getwd(); err == nil {
 			root = wd
@@ -2347,7 +2514,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		a.mu.Lock()
-		if tab.removed || a.tabs[tab.ID] != tab {
+		if a.tabBuildSupersededLocked(tab, buildGeneration) {
 			a.mu.Unlock()
 			return
 		}
@@ -2359,15 +2526,15 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		return
 	}
 
-	if a.tabRemovedForBuild(tab) {
+	if a.tabBuildSuperseded(tab, buildGeneration) {
 		return
 	}
-	if tab.sink != nil {
-		tab.sink.setContext(wailsCtx)
+	if tabSink != nil {
+		tabSink.setContext(wailsCtx)
 	}
 
 	sessionDir := desktopSessionDir(root)
-	topicID := strings.TrimSpace(tab.TopicID)
+	topicID := strings.TrimSpace(tabTopicID)
 
 	// Assign Global topics to legacy sessions in the global session dir so
 	// imported history appears in the project tree regardless of which tab
@@ -2376,10 +2543,14 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	if len(migratedGlobalTopics) > 0 {
 		a.emitProjectTreeChanged()
 	}
-	if tab.Scope == "global" && topicID == "" && len(migratedGlobalTopics) > 0 {
+	if tabScope == "global" && topicID == "" && len(migratedGlobalTopics) > 0 {
 		topicID = migratedGlobalTopics[0]
 		topicTitle := topicTitleForTab("global", "", topicID)
 		a.mu.Lock()
+		if a.tabBuildSupersededLocked(tab, buildGeneration) {
+			a.mu.Unlock()
+			return
+		}
 		if strings.TrimSpace(tab.TopicID) == "" {
 			tab.TopicID = topicID
 			tab.TopicTitle = topicTitle
@@ -2390,12 +2561,12 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		a.mu.Unlock()
 	}
 	if topicID != "" {
-		if _, dir := a.findTopicSessionForTarget(tab.Scope, tab.WorkspaceRoot, topicID); dir != "" {
+		if _, dir := a.findTopicSessionForTarget(tabScope, tabWorkspaceRoot, topicID); dir != "" {
 			sessionDir = dir
 		}
 	}
 	startupSessionPath := ""
-	if pinnedPath, ok := pinnedTabSessionPath(sessionDir, tab.SessionPath); ok {
+	if pinnedPath, ok := pinnedTabSessionPath(sessionDir, tabSessionPath); ok {
 		if !agent.IsCleanupPending(pinnedPath) {
 			startupSessionPath = pinnedPath
 		}
@@ -2403,7 +2574,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		startupSessionPath = findTopicSession(sessionDir, topicID)
 	}
 
-	model := strings.TrimSpace(tab.model)
+	model := strings.TrimSpace(tabModel)
 	if sessionModel, ok := agent.LoadSessionModel(startupSessionPath); ok {
 		config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, sessionModel)
 		if _, ok := cfg.ResolveModel(sessionModel); ok {
@@ -2416,31 +2587,42 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, model)
 	requestedModel := model
 	if resolved, fallback, ok := cfg.ResolveModelWithFallback(model); ok {
-		if fallback && strings.TrimSpace(tab.model) != "" {
+		if fallback && strings.TrimSpace(tabModel) != "" {
 			a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", requestedModel, resolved))
 		}
 		model = resolved
 	}
 
+	// Acquire a shared plugin host for this workspace root so MCP processes
+	// are launched once per root, not once per tab. SharedHostKey is an a.mu-
+	// guarded field (takeTabSharedHostKey reads it under the lock during
+	// teardown), so publish it under the lock alongside the model. Capture the
+	// tab-local runtime profile here too: bound methods (SetModeForTab,
+	// SetGoalForTab, SetEffortForTab, ...) write these under a.mu, so the
+	// off-lock boot.Build below must read a locked snapshot, not the live tab.
+	rootKey := tabWorkspaceRoot
+	if rootKey == "" {
+		rootKey = "__global__" // stable key for global workspace tabs
+	}
 	a.mu.Lock()
-	if tab.removed || a.tabs[tab.ID] != tab {
+	if a.tabBuildSupersededLocked(tab, buildGeneration) {
 		a.mu.Unlock()
 		return
 	}
 	tab.model = model
 	tab.Label = model
+	tab.SharedHostKey = rootKey
+	buildEffort := cloneStringPtr(tab.effort)
+	buildTokenMode := boot.NormalizeTokenMode(tab.tokenMode)
+	buildMode := tab.mode
+	buildToolApprovalMode := tab.toolApprovalMode
+	buildGoal := tab.goal
+	buildSink := tab.sink
 	a.saveTabsLocked()
 	a.mu.Unlock()
 
-	// Acquire a shared plugin host for this workspace root so MCP processes
-	// are launched once per root, not once per tab.
-	rootKey := tab.WorkspaceRoot
-	if rootKey == "" {
-		rootKey = "__global__" // stable key for global workspace tabs
-	}
-	tab.SharedHostKey = rootKey
 	sharedHost := a.acquireSharedHost(rootKey)
-	sink := a.desktopControllerSink(tab.sink, cfg.Notifications)
+	sink := a.desktopControllerSink(buildSink, cfg.Notifications)
 
 	ctrl, err := boot.Build(buildCtx, boot.Options{
 		Model:                    model,
@@ -2448,8 +2630,8 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		Sink:                     sink,
 		WorkspaceRoot:            root,
 		SessionDir:               sessionDir,
-		EffortOverride:           cloneStringPtr(tab.effort),
-		TokenMode:                currentTabTokenMode(tab),
+		EffortOverride:           cloneStringPtr(buildEffort),
+		TokenMode:                buildTokenMode,
 		SharedHost:               sharedHost,
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
@@ -2457,7 +2639,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	})
 	if err != nil {
 		a.mu.Lock()
-		if tab.removed || a.tabs[tab.ID] != tab {
+		if a.tabBuildSupersededLocked(tab, buildGeneration) {
 			hostKey := takeTabSharedHostKey(tab)
 			a.mu.Unlock()
 			if hostKey != "" {
@@ -2476,7 +2658,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		a.emitReady(wailsCtx, tab.ID)
 		return
 	}
-	if a.tabRemovedForBuild(tab) {
+	if a.tabBuildSuperseded(tab, buildGeneration) {
 		ctrl.Close()
 		a.releaseTabSharedHost(tab)
 		return
@@ -2484,22 +2666,33 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 
 	a.bindControllerDisplayRecorder(ctrl)
 	ctrl.EnableInteractiveApproval()
-	applyTabModeToController(ctrl, tab.mode)
-	applyTabToolApprovalModeToController(ctrl, tab.toolApprovalMode)
-	ctrl.SetGoal(tab.goal)
+	applyTabModeToController(ctrl, buildMode)
+	applyTabToolApprovalModeToController(ctrl, buildToolApprovalMode)
+	ctrl.SetGoal(buildGoal)
 
 	if dir := ctrl.SessionDir(); dir != "" {
 		migratedTopics := migrateLegacySessionsIntoGlobalTopics(dir)
 		if len(migratedTopics) > 0 {
 			a.emitProjectTreeChanged()
 		}
-		if tab.Scope == "global" && strings.TrimSpace(tab.TopicID) == "" && len(migratedTopics) > 0 {
+		// Refresh the topic/session locals under the lock: a rebind or the
+		// recovery callback may have rewritten them since the early snapshot.
+		a.mu.RLock()
+		tabTopicID = strings.TrimSpace(tab.TopicID)
+		tabSessionPath = tab.SessionPath
+		a.mu.RUnlock()
+		if tabScope == "global" && tabTopicID == "" && len(migratedTopics) > 0 {
 			topicID := migratedTopics[0]
 			topicTitle := topicTitleForTab("global", "", topicID)
 			a.mu.Lock()
-			tab.TopicID = topicID
-			tab.TopicTitle = topicTitle
-			a.saveTabsLocked()
+			if !a.tabBuildSupersededLocked(tab, buildGeneration) && strings.TrimSpace(tab.TopicID) == "" {
+				tab.TopicID = topicID
+				tab.TopicTitle = topicTitle
+				tabTopicID = topicID
+				a.saveTabsLocked()
+			} else {
+				tabTopicID = strings.TrimSpace(tab.TopicID)
+			}
 			a.mu.Unlock()
 		}
 		var path string
@@ -2507,12 +2700,12 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		// Prefer the exact session file persisted for this tab. Topic lookup is a
 		// compatibility fallback for older desktop-tabs.json files that only stored
 		// topicId and could pick the wrong session when one topic had multiple files.
-		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tab.SessionPath, loadedSession); ok {
+		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tabSessionPath, loadedSession); ok {
 			path = pinnedPath
 			resumeSession = loaded
 		}
-		if path == "" && tab.TopicID != "" {
-			existingPath := findTopicSession(dir, tab.TopicID)
+		if path == "" && tabTopicID != "" {
+			existingPath := findTopicSession(dir, tabTopicID)
 			if existingPath != "" {
 				if loaded, err := loadResumableSession(existingPath); err == nil {
 					path = existingPath
@@ -2533,7 +2726,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			}
 			if err := tab.ensureSessionLease(path); err != nil {
 				a.mu.Lock()
-				if tab.removed || a.tabs[tab.ID] != tab {
+				if a.tabBuildSupersededLocked(tab, buildGeneration) {
 					hostKey := takeTabSharedHostKey(tab)
 					a.mu.Unlock()
 					ctrl.Close()
@@ -2560,8 +2753,14 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				ctrl.SetSessionPath(path)
 			}
 			a.persistTabSessionPath(tab, path)
-			if strings.TrimSpace(tab.TopicID) != "" {
-				if err := ensureTopicIndexed(tab.Scope, tab.WorkspaceRoot, tab.TopicID, tab.TopicTitle, loadTopicTitleSource(topicTitleRoot(tab.Scope, tab.WorkspaceRoot), tab.TopicID)); err == nil {
+			a.mu.RLock()
+			indexScope := tab.Scope
+			indexRoot := tab.WorkspaceRoot
+			indexTopicID := strings.TrimSpace(tab.TopicID)
+			indexTopicTitle := tab.TopicTitle
+			a.mu.RUnlock()
+			if indexTopicID != "" {
+				if err := ensureTopicIndexed(indexScope, indexRoot, indexTopicID, indexTopicTitle, loadTopicTitleSource(topicTitleRoot(indexScope, indexRoot), indexTopicID)); err == nil {
 					a.emitProjectTreeChanged()
 				}
 			}
@@ -2577,7 +2776,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	}
 
 	a.mu.Lock()
-	if tab.removed || a.tabs[tab.ID] != tab {
+	if a.tabBuildSupersededLocked(tab, buildGeneration) {
 		a.mu.Unlock()
 		ctrl.Close()
 		a.releaseTabSharedHost(tab)
@@ -2999,29 +3198,38 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 }
 
 func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
-	if tab == nil || strings.TrimSpace(tab.TopicID) == "" || tab.Ctrl == nil {
+	if tab == nil {
 		return false
 	}
+	// Runs on the autosave goroutine; TopicID/Scope/WorkspaceRoot/Ctrl are
+	// written under a.mu by session switches and recovery.
+	a.mu.RLock()
+	topicID := strings.TrimSpace(tab.TopicID)
 	titleRoot := tab.WorkspaceRoot
 	if tab.Scope == "global" {
 		titleRoot = ""
 	}
-	if source := loadTopicTitleSource(titleRoot, tab.TopicID); source != topicTitleSourceAuto {
+	ctrl := tab.Ctrl
+	a.mu.RUnlock()
+	if topicID == "" || ctrl == nil {
 		return false
 	}
-	sessionPath := tab.Ctrl.SessionPath()
+	if source := loadTopicTitleSource(titleRoot, topicID); source != topicTitleSourceAuto {
+		return false
+	}
+	sessionPath := ctrl.SessionPath()
 	if sessionPath == "" {
 		return false
 	}
 	if sessionHasManualDisplayTitle(sessionPath) {
 		return false
 	}
-	nextTitle, updated := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath)
+	nextTitle, updated := autoTitleTopicFromSession(titleRoot, topicID, sessionPath)
 	if !updated {
 		return false
 	}
-	a.updateOpenTopicTitle(tab.TopicID, nextTitle)
-	a.updateTopicSessionTitles(tab.TopicID, nextTitle)
+	a.updateOpenTopicTitle(topicID, nextTitle)
+	a.updateTopicSessionTitles(topicID, nextTitle)
 	a.emitProjectTreeChanged()
 	return true
 }
@@ -6213,6 +6421,118 @@ func currentTabTokenMode(tab *WorkspaceTab) string {
 		return boot.TokenModeFull
 	}
 	return boot.NormalizeTokenMode(tab.tokenMode)
+}
+
+// tabRuntimeSnapshot is a consistent under-a.mu copy of the per-tab fields
+// that bound methods and rebuild paths need after releasing the lock. The
+// build/rebuild goroutines write these fields under a.mu, so lock-free reads
+// from other goroutines are data races (same class as the sessionLease race
+// fixed for #5955). Controller methods are invoked on the snapshot's ctrl
+// AFTER unlocking, never while holding a.mu.
+type tabRuntimeSnapshot struct {
+	ctrl             control.SessionAPI
+	sink             *tabEventSink
+	label            string
+	ready            bool
+	readOnly         bool
+	startupErr       string
+	scope            string
+	workspaceRoot    string
+	sessionPath      string
+	topicID          string
+	topicTitle       string
+	sharedHostKey    string
+	model            string
+	effort           *string
+	tokenMode        string
+	mode             string
+	goal             string
+	toolApprovalMode string
+}
+
+// snapshotTabRuntimeLocked copies the racy per-tab fields. Callers must hold
+// a.mu (read or write side).
+func snapshotTabRuntimeLocked(tab *WorkspaceTab) tabRuntimeSnapshot {
+	if tab == nil {
+		return tabRuntimeSnapshot{}
+	}
+	return tabRuntimeSnapshot{
+		ctrl:             tab.Ctrl,
+		sink:             tab.sink,
+		label:            tab.Label,
+		ready:            tab.Ready,
+		readOnly:         tab.ReadOnly,
+		startupErr:       tab.StartupErr,
+		scope:            tab.Scope,
+		workspaceRoot:    tab.WorkspaceRoot,
+		sessionPath:      tab.SessionPath,
+		topicID:          tab.TopicID,
+		topicTitle:       tab.TopicTitle,
+		sharedHostKey:    tab.SharedHostKey,
+		model:            tab.model,
+		effort:           cloneStringPtr(tab.effort),
+		tokenMode:        tab.tokenMode,
+		mode:             tab.mode,
+		goal:             tab.goal,
+		toolApprovalMode: tab.toolApprovalMode,
+	}
+}
+
+func (a *App) tabRuntimeSnapshot(tab *WorkspaceTab) tabRuntimeSnapshot {
+	if tab == nil {
+		return tabRuntimeSnapshot{}
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return snapshotTabRuntimeLocked(tab)
+}
+
+// Snapshot-based forms of the currentTabX helpers, for callers that already
+// hold a consistent tabRuntimeSnapshot.
+
+func (s tabRuntimeSnapshot) currentMode() string {
+	if s.ctrl != nil {
+		return tabModeFromAxes(s.ctrl.PlanMode(), s.ctrl.AutoApproveTools())
+	}
+	return normalizeTabMode(s.mode)
+}
+
+func (s tabRuntimeSnapshot) currentGoal() string {
+	if s.ctrl != nil {
+		return s.ctrl.Goal()
+	}
+	return strings.TrimSpace(s.goal)
+}
+
+func (s tabRuntimeSnapshot) currentGoalStatus() string {
+	if s.ctrl != nil {
+		return s.ctrl.GoalStatus()
+	}
+	if strings.TrimSpace(s.goal) != "" {
+		return control.GoalStatusRunning
+	}
+	return control.GoalStatusStopped
+}
+
+func (s tabRuntimeSnapshot) collaborationMode() string {
+	if tabModeHasPlan(s.currentMode()) {
+		return "plan"
+	}
+	if strings.TrimSpace(s.currentGoal()) != "" && s.currentGoalStatus() == control.GoalStatusRunning {
+		return "goal"
+	}
+	return "normal"
+}
+
+func (s tabRuntimeSnapshot) currentToolApprovalMode() string {
+	if s.ctrl != nil {
+		return s.ctrl.ToolApprovalMode()
+	}
+	return normalizeToolApprovalMode(s.toolApprovalMode)
+}
+
+func (s tabRuntimeSnapshot) currentTokenMode() string {
+	return boot.NormalizeTokenMode(s.tokenMode)
 }
 
 func persistedTabTokenMode(mode string) string {

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -401,6 +401,60 @@ func TestClearTabBuildCancelCancelsAbandonedBuildContext(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionLeaseSerializesConcurrentSameTabAcquire(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "same-tab-concurrent-lease.jsonl")
+	tab := &WorkspaceTab{ID: "tab"}
+	t.Cleanup(tab.releaseSessionLease)
+
+	acquired := make(chan struct{})
+	releaseHook := make(chan struct{})
+	var once sync.Once
+	sessionLeaseAcquireHookForTest = func() {
+		once.Do(func() {
+			close(acquired)
+			<-releaseHook
+		})
+	}
+	t.Cleanup(func() { sessionLeaseAcquireHookForTest = nil })
+
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- tab.ensureSessionLease(path)
+	}()
+
+	select {
+	case <-acquired:
+	case err := <-firstErr:
+		t.Fatalf("first ensureSessionLease returned before hook: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("first ensureSessionLease did not acquire lease")
+	}
+
+	secondErr := make(chan error, 1)
+	go func() {
+		secondErr <- tab.ensureSessionLease(path)
+	}()
+
+	select {
+	case err := <-secondErr:
+		t.Fatalf("second ensureSessionLease returned while first acquire was unbound: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseHook)
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first ensureSessionLease: %v", err)
+	}
+	if err := <-secondErr; err != nil {
+		t.Fatalf("second ensureSessionLease should reuse the tab lease: %v", err)
+	}
+}
+
 func TestAttachExistingSessionRuntimeSkipsRemovedTab(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -38,7 +38,7 @@ func (a *App) startTray() bool {
 	a.tray = t
 	a.mu.Unlock()
 
-	t.end = startDesktopTray(func() {
+	end := startDesktopTray(func() {
 		systray.SetIcon(trayIconBytes)
 		systray.SetTitle("Reasonix")
 		systray.SetTooltip("Reasonix")
@@ -51,21 +51,25 @@ func (a *App) startTray() bool {
 		systray.SetOnSecondaryTapped(nil)
 
 		labels := trayMenuLabels(a.trayLocale())
-		t.openItem = systray.AddMenuItem(labels.openTitle, labels.openTooltip)
-		t.quitItem = systray.AddMenuItem(labels.quitTitle, labels.quitTooltip)
+		openItem := systray.AddMenuItem(labels.openTitle, labels.openTooltip)
+		quitItem := systray.AddMenuItem(labels.quitTitle, labels.quitTooltip)
 
+		// Publish the menu items under a.mu: this callback runs on the systray
+		// goroutine while bound settings calls (updateTrayLocale) read them.
 		a.mu.Lock()
+		t.openItem = openItem
+		t.quitItem = quitItem
 		a.trayReady = true
 		a.mu.Unlock()
 		t.markReady()
 
 		a.goSafe("trayOpenLoop", func() {
-			for range t.openItem.ClickedCh {
+			for range openItem.ClickedCh {
 				a.showFromTray()
 			}
 		})
 		a.goSafe("trayQuitLoop", func() {
-			for range t.quitItem.ClickedCh {
+			for range quitItem.ClickedCh {
 				a.quitFromTray()
 			}
 		})
@@ -77,31 +81,43 @@ func (a *App) startTray() bool {
 		}
 		a.mu.Unlock()
 	})
+	a.mu.Lock()
+	t.end = end
+	a.mu.Unlock()
 	return true
 }
 
 func (a *App) stopTray() {
 	a.mu.RLock()
 	t := a.tray
+	var end func()
+	if t != nil {
+		end = t.end
+	}
 	a.mu.RUnlock()
-	if t == nil || t.end == nil {
+	if t == nil || end == nil {
 		return
 	}
-	t.once.Do(t.end)
+	t.once.Do(end)
 }
 
 func (a *App) updateTrayLocale(locale string) {
 	a.mu.RLock()
 	t := a.tray
+	var openItem, quitItem *systray.MenuItem
+	if t != nil {
+		openItem = t.openItem
+		quitItem = t.quitItem
+	}
 	a.mu.RUnlock()
-	if t == nil || t.openItem == nil || t.quitItem == nil {
+	if openItem == nil || quitItem == nil {
 		return
 	}
 	labels := trayMenuLabels(locale)
-	t.openItem.SetTitle(labels.openTitle)
-	t.openItem.SetTooltip(labels.openTooltip)
-	t.quitItem.SetTitle(labels.quitTitle)
-	t.quitItem.SetTooltip(labels.quitTooltip)
+	openItem.SetTitle(labels.openTitle)
+	openItem.SetTooltip(labels.openTooltip)
+	quitItem.SetTitle(labels.quitTitle)
+	quitItem.SetTooltip(labels.quitTooltip)
 }
 
 func (a *App) trayLocale() string {

--- a/internal/control/close_idempotent_test.go
+++ b/internal/control/close_idempotent_test.go
@@ -1,0 +1,41 @@
+package control
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/hook"
+)
+
+// TestCloseIsIdempotent guards the desktop tab-lifecycle contract: rebind,
+// model switch, CloseTab, and shutdown can race to Close the same controller,
+// so a duplicate Close must not re-fire SessionEnd hooks or re-run cleanup.
+func TestCloseIsIdempotent(t *testing.T) {
+	var sessionEnds atomic.Int32
+	hooks := hook.NewRunner([]hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "session-end"},
+		Event:      hook.SessionEnd,
+		Scope:      hook.ScopeGlobal,
+	}}, t.TempDir(), func(context.Context, hook.SpawnInput) hook.SpawnResult {
+		sessionEnds.Add(1)
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+	c := New(Options{Runner: &fakeTurnRunner{}, Hooks: hooks})
+	// A completed turn arms startedOnce so SessionEnd is eligible to fire.
+	if err := c.Run(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.Close()
+		close(done)
+	}()
+	c.Close()
+	<-done
+
+	if got := sessionEnds.Load(); got != 1 {
+		t.Fatalf("SessionEnd hooks fired %d times across concurrent Close calls, want 1", got)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -102,6 +102,7 @@ type Controller struct {
 	shell                             sandbox.Shell // interpreter for user-invoked "!" commands; zero = auto
 	classifier                        autoPlanClassifier
 	startedOnce                       bool                             // guards the one-shot SessionStart hook on first turn
+	closeOnce                         sync.Once                        // makes close idempotent under racing teardown paths
 	onRemember                        func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
 	onRememberMCPReadOnlyTrust        func(serverName, rawToolName string) MCPReadOnlyTrustResult
 	onRememberPlanModeReadOnlyCommand func(prefix string) PlanModeReadOnlyCommandTrustResult
@@ -3503,23 +3504,28 @@ const (
 )
 
 func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
-	c.mu.Lock()
-	started := c.startedOnce
-	c.mu.Unlock()
-	if fireSessionEnd && started {
-		c.hooks.SessionEnd(context.Background())
-	}
-	if c.jobs != nil {
-		switch jobsMode {
-		case closeJobsAsync:
-			c.jobs.CloseAsync()
-		default:
-			c.jobs.Close() // cancel any still-running background jobs
+	// Desktop tab lifecycles can race a rebind/model-switch/close on the same
+	// controller; make teardown idempotent so a duplicate Close cannot re-fire
+	// SessionEnd hooks or re-run cleanup. The first caller's jobsMode wins.
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		started := c.startedOnce
+		c.mu.Unlock()
+		if fireSessionEnd && started {
+			c.hooks.SessionEnd(context.Background())
 		}
-	}
-	if c.cleanup != nil {
-		c.cleanup()
-	}
+		if c.jobs != nil {
+			switch jobsMode {
+			case closeJobsAsync:
+				c.jobs.CloseAsync()
+			default:
+				c.jobs.Close() // cancel any still-running background jobs
+			}
+		}
+		if c.cleanup != nil {
+			c.cleanup()
+		}
+	})
 }
 
 // Jobs returns the still-running background jobs for the status bar (nil when


### PR DESCRIPTION
## Summary
- serialize per-tab session lease acquire/release so concurrent blank-session startup and model/settings rebuilds reuse the current tab lease
- keep model switching from surfacing a false "another Reasonix window" error when the same tab is still binding its lease
- extend the same fix across the remaining desktop runtime races found in a follow-up concurrency audit:
  - route the five remaining raw `sessionLease` accesses (detach clone / nil write, reattach transfer, rebuild reclaim, cross-tab probe) through locked take/adopt/key helpers, so no interleaving can leak a lease (session permanently "held") or resurrect a released one (two writers on one `.jsonl`)
  - move `tabEventSink.tabID`/`app` under the sink mutex like `ctx` (same reasoning as the #5352 clearContext fix); `Emit` snapshots the binding and detach/reattach rebinds via `setBinding`
  - run `detachRuntimeForReplacement` (field clone + lease/sink handover + membership check + re-publication) in one `a.mu` critical section, so runtimes unlinked by DeleteSession/TrashTopic cannot resurrect (#4384 class) and the `disabledMCP` map is never read lock-free while the event goroutine writes
  - serialize `rebindTabToLoadedSessionPath` and `clearActiveSessionRuntime` with `runtimeRebuildMu` like every other build+swap path, make `Controller.close` idempotent (`sync.Once`), and add build-generation guards so a session rebind strands any in-flight async build instead of double-swapping controllers
  - replace check-then-use reads in bound methods (`MetaForTab`, Submit-family readiness/read-only checks, `ReplayPendingPrompts`, shutdown, MCP toggles, AutoResearch, `ReloadCommands`) and in the build/rebuild goroutines with locked `tabRuntimeSnapshot` copies; publish/take `SharedHostKey` under `a.mu` only
  - snapshot teardown/autosave/topic-assignment reads under the lock (CloseTab, keepOnlyVisibleTab, closeTabRuntime, detachSessionRuntime, maybeAutoTitleTopic); copy bot install sessions under `a.mu`; publish tray menu items under `a.mu`; drop the unlocked bot-runtime lazy init

Fixes #5955

## Tests
- go test -race . (desktop, full suite — includes new regressions: concurrent lease-helper hammer with leak assertion, detach membership + lease transfer, sink rebind during Emit, MetaForTab vs build swap, build-generation supersession)
- go test -race ./internal/control/ (includes new concurrent double-Close regression asserting SessionEnd fires once)
- go vet + gofmt clean in both modules
