### PR TITLE
Fix cascading session recovery / 修复会话恢复级联

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -937,12 +937,12 @@ func ReconcileSessionSidecars(dir string) error {
 		switch {
 		case strings.HasSuffix(name, sessionLeaseInfoSidecarSuffix):
 			base := filepath.Join(dir, strings.TrimSuffix(name, ".lease.json"))
-			if err := removeStaleSessionLeaseSidecar(base, sidecarPath); err != nil {
+			if err := removeStaleSessionLeaseInfoSidecar(base, sidecarPath); err != nil {
 				errs = append(errs, fmt.Errorf("%s: %w", sidecarPath, err))
 			}
 		case strings.HasSuffix(name, sessionLeaseLockSidecarSuffix):
 			base := filepath.Join(dir, strings.TrimSuffix(name, ".lease.lock"))
-			if err := removeStaleSessionLeaseSidecar(base, sidecarPath); err != nil {
+			if err := removeStaleSessionLeaseLockSidecar(base, sidecarPath); err != nil {
 				errs = append(errs, fmt.Errorf("%s: %w", sidecarPath, err))
 			}
 		case strings.HasSuffix(name, sessionLockSidecarSuffix):
@@ -960,29 +960,42 @@ func removeStaleSessionLockSidecar(basePath, sidecarPath string) error {
 	if sessionLeaseHeldLocally(basePath) || SessionLeaseHeldByOtherRuntime(basePath) {
 		return nil
 	}
-	unlock, err := tryLockSessionFile(basePath)
+	lock, err := tryTakeSessionLockFile(sidecarPath)
 	if err != nil {
 		if errors.Is(err, errSessionFileLockHeld) {
 			return nil
 		}
 		return err
 	}
-	// Unlink before releasing the flock. Dropping the lock first opens a
-	// window where a concurrent saver locks this inode, the file disappears
-	// under it, and the next opener creates a fresh inode whose "exclusive"
-	// lock the first saver cannot see. Holding the lock across the unlink
-	// narrows that to openers already parked on the old inode.
-	removeErr := os.Remove(sidecarPath)
-	if unlock != nil {
-		unlock()
-	}
-	if removeErr != nil && !os.IsNotExist(removeErr) {
-		return removeErr
-	}
-	return nil
+	// The removal is atomic with the release (unlink-under-flock on Unix,
+	// delete-disposition on the held handle on Windows), so a concurrent
+	// saver can never acquire a lock file that is being deleted under it.
+	return lock.RemoveAndUnlock()
 }
 
-func removeStaleSessionLeaseSidecar(basePath, sidecarPath string) error {
+// removeStaleSessionLeaseLockSidecar retires a leftover .lease.lock. The file
+// is the lease lock itself, so taking it non-blocking proves no runtime holds
+// the lease, and RemoveAndUnlock deletes it atomically with the release.
+func removeStaleSessionLeaseLockSidecar(basePath, sidecarPath string) error {
+	basePath = canonicalSessionSavePath(basePath)
+	if sessionLeaseHeldLocally(basePath) {
+		return nil
+	}
+	lock, err := tryTakeSessionLockFile(sidecarPath)
+	if err != nil {
+		if errors.Is(err, errSessionFileLockHeld) {
+			return nil
+		}
+		return err
+	}
+	return lock.RemoveAndUnlock()
+}
+
+// removeStaleSessionLeaseInfoSidecar retires a leftover .lease.json while
+// holding the lease lock, so no runtime can adopt the info file mid-removal.
+// The info file itself is never held open by anyone, so a plain remove under
+// the lock is safe on every platform.
+func removeStaleSessionLeaseInfoSidecar(basePath, sidecarPath string) error {
 	basePath = canonicalSessionSavePath(basePath)
 	if sessionLeaseHeldLocally(basePath) {
 		return nil
@@ -996,9 +1009,6 @@ func removeStaleSessionLeaseSidecar(basePath, sidecarPath string) error {
 			}
 			return err
 		}
-		// Same unlink-under-lock ordering as removeStaleSessionLockSidecar:
-		// while we hold the lease flock no runtime can acquire this lease, so
-		// the sidecar cannot be adopted between the check and the removal.
 		removeErr := os.Remove(sidecarPath)
 		if unlock != nil {
 			unlock()
@@ -1111,16 +1121,16 @@ func renameOverlongSession(oldPath string) (string, error) {
 	if sessionLeaseSidecarFits(oldPath) && SessionLeaseHeldByOtherRuntime(oldPath) {
 		return "", nil
 	}
-	var unlockFile func()
+	var lockFile *sessionLockFile
 	if sessionLockSidecarFits(oldPath) {
-		unlock, err := tryLockSessionFile(oldPath)
+		lock, err := tryTakeSessionLockFile(oldPath + ".lock")
 		if err != nil {
 			if errors.Is(err, errSessionFileLockHeld) {
 				return "", nil
 			}
 			return "", err
 		}
-		unlockFile = unlock
+		lockFile = lock
 	}
 	renameErr := func() error {
 		if err := os.Rename(oldPath, newPath); err != nil {
@@ -1128,13 +1138,8 @@ func renameOverlongSession(oldPath string) (string, error) {
 		}
 		return migrateSessionSidecars(oldPath, newPath, newID)
 	}()
-	// Retire the old disposable sidecars while the file lock is still held,
-	// mirroring removeStaleSessionLockSidecar's unlink-under-lock ordering.
-	if sessionLockSidecarFits(oldPath) {
-		if err := os.Remove(oldPath + ".lock"); err != nil && !os.IsNotExist(err) && renameErr == nil {
-			renameErr = err
-		}
-	}
+	// Retire the old disposable lease sidecars: any holder was ruled out
+	// above, and nothing keeps these files open, so a plain remove is safe.
 	if sessionLeaseSidecarFits(oldPath) {
 		for _, stale := range []string{oldPath + ".lease.lock", oldPath + ".lease.json"} {
 			if err := os.Remove(stale); err != nil && !os.IsNotExist(err) && renameErr == nil {
@@ -1142,8 +1147,11 @@ func renameOverlongSession(oldPath string) (string, error) {
 			}
 		}
 	}
-	if unlockFile != nil {
-		unlockFile()
+	// The old .lock goes atomically with the release of the lock we hold on it.
+	if lockFile != nil {
+		if err := lockFile.RemoveAndUnlock(); err != nil && renameErr == nil {
+			renameErr = err
+		}
 	}
 	if renameErr != nil {
 		return "", renameErr

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -15,18 +15,26 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
 	"reasonix/internal/store"
 )
 
-const cleanupPendingExt = ".cleanup-pending.json"
+const (
+	cleanupPendingExt             = ".cleanup-pending.json"
+	maxRecoveryParentStemBytes    = 80
+	sessionLockSidecarSuffix      = ".jsonl.lock"
+	sessionLeaseLockSidecarSuffix = ".jsonl.lease.lock"
+	sessionLeaseInfoSidecarSuffix = ".jsonl.lease.json"
+)
 
 var (
 	sessionSaveLocks            sync.Map
 	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
 	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
+	errSessionFileLockHeld      = errors.New("session file lock held")
 	sessionWriterID             = newSessionWriterID()
 )
 
@@ -395,11 +403,56 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 }
 
 func recoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
-	parent := BranchID(originalPath)
-	if parent == "" {
-		parent = "session"
-	}
+	parent := recoveryParentStem(BranchID(originalPath))
 	return filepath.Join(filepath.Dir(originalPath), fmt.Sprintf("%s-recovery-%x.jsonl", parent, digest[:8]))
+}
+
+func recoveryParentStem(parent string) string {
+	parent = strings.TrimSpace(parent)
+	if parent == "" {
+		return "session"
+	}
+	sum := sha256.Sum256([]byte(parent))
+	if idx := strings.Index(parent, "-recovery-"); idx >= 0 {
+		base := strings.Trim(parent[:idx], "-_. ")
+		if base == "" {
+			base = "session"
+		}
+		base = strings.Trim(truncateUTF8Bytes(base, maxRecoveryParentStemBytes), "-_. ")
+		if base == "" {
+			base = "session"
+		}
+		return fmt.Sprintf("%s-%x", base, sum[:6])
+	}
+	if len(parent) <= maxRecoveryParentStemBytes {
+		return parent
+	}
+	prefix := strings.Trim(truncateUTF8Bytes(parent, maxRecoveryParentStemBytes), "-_. ")
+	if prefix == "" {
+		prefix = "session"
+	}
+	return fmt.Sprintf("%s-%x", prefix, sum[:6])
+}
+
+func truncateUTF8Bytes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(s) <= max {
+		return s
+	}
+	used := 0
+	for i, r := range s {
+		size := utf8.RuneLen(r)
+		if size < 0 {
+			size = 1
+		}
+		if used+size > max {
+			return s[:i]
+		}
+		used += size
+	}
+	return s
 }
 
 func firstNonEmpty(values ...string) string {
@@ -819,22 +872,122 @@ func ListCleanupPending(dir string) ([]CleanupPendingInfo, error) {
 }
 
 // ReconcileCleanupPending retries physical cleanup for leftover delayed-cleanup
-// markers. It keeps going after individual cleanup errors and returns them joined.
+// markers and stale lock/lease sidecars. It keeps going after individual
+// cleanup errors and returns them joined.
 func ReconcileCleanupPending(dir string, cleanup func(CleanupPendingInfo) error) error {
+	var errs []error
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		errs = append(errs, err)
+	}
 	pending, err := ListCleanupPending(dir)
 	if err != nil {
-		return err
+		errs = append(errs, err)
+		return errors.Join(errs...)
 	}
 	if cleanup == nil {
-		return nil
+		return errors.Join(errs...)
 	}
-	var errs []error
 	for _, item := range pending {
 		if err := cleanup(item); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", item.SessionPath, err))
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// ReconcileSessionSidecars removes stale lock and lease files left beside
+// sessions by older runtimes. It never removes .jsonl transcripts; recovered
+// conversations may contain useful user history even when their names are ugly.
+func ReconcileSessionSidecars(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var errs []error
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		sidecarPath := filepath.Join(dir, name)
+		switch {
+		case strings.HasSuffix(name, sessionLeaseInfoSidecarSuffix):
+			base := filepath.Join(dir, strings.TrimSuffix(name, ".lease.json"))
+			if err := removeStaleSessionLeaseSidecar(base, sidecarPath); err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", sidecarPath, err))
+			}
+		case strings.HasSuffix(name, sessionLeaseLockSidecarSuffix):
+			base := filepath.Join(dir, strings.TrimSuffix(name, ".lease.lock"))
+			if err := removeStaleSessionLeaseSidecar(base, sidecarPath); err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", sidecarPath, err))
+			}
+		case strings.HasSuffix(name, sessionLockSidecarSuffix):
+			base := filepath.Join(dir, strings.TrimSuffix(name, ".lock"))
+			if err := removeStaleSessionLockSidecar(base, sidecarPath); err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", sidecarPath, err))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func removeStaleSessionLockSidecar(basePath, sidecarPath string) error {
+	basePath = canonicalSessionSavePath(basePath)
+	if sessionLeaseHeldLocally(basePath) || SessionLeaseHeldByOtherRuntime(basePath) {
+		return nil
+	}
+	unlock, err := tryLockSessionFile(basePath)
+	if err != nil {
+		if errors.Is(err, errSessionFileLockHeld) {
+			return nil
+		}
+		return err
+	}
+	if unlock != nil {
+		unlock()
+	}
+	if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func removeStaleSessionLeaseSidecar(basePath, sidecarPath string) error {
+	basePath = canonicalSessionSavePath(basePath)
+	if sessionLeaseHeldLocally(basePath) {
+		return nil
+	}
+	lockPath := basePath + ".lease.lock"
+	if _, err := os.Stat(lockPath); err == nil {
+		unlock, err := tryLockSessionLeaseFile(basePath)
+		if err != nil {
+			if errors.Is(err, ErrSessionLeaseHeld) {
+				return nil
+			}
+			return err
+		}
+		if unlock != nil {
+			unlock()
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func sessionLeaseHeldLocally(path string) bool {
+	_, ok := sessionLeaseOwners.Load(canonicalSessionSavePath(path))
+	return ok
 }
 
 // ListSessionOrder returns every *.jsonl session under dir in the same

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1078,8 +1078,10 @@ func reconcileOverlongSessionFilenames(dir string) error {
 		newID, err := renameOverlongSession(oldPath)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", oldPath, err))
-			continue
 		}
+		// A non-empty newID means the transcript rename landed even if some
+		// sidecar migration failed; record it so children still re-parent —
+		// this run is the only one that knows the old-to-new mapping.
 		if newID != "" {
 			renamed[BranchID(oldPath)] = newID
 		}
@@ -1132,31 +1134,38 @@ func renameOverlongSession(oldPath string) (string, error) {
 		}
 		lockFile = lock
 	}
-	renameErr := func() error {
-		if err := os.Rename(oldPath, newPath); err != nil {
-			return err
+	if err := os.Rename(oldPath, newPath); err != nil {
+		// Nothing moved: the old transcript is intact and the next
+		// reconciliation can retry, so its lock file stays in place too.
+		if lockFile != nil {
+			lockFile.Unlock()
 		}
-		return migrateSessionSidecars(oldPath, newPath, newID)
-	}()
+		return "", err
+	}
+	// The transcript is committed under its new name from here on. Sidecar
+	// migration and lock cleanup failures are reported, but the new ID is
+	// still returned so the caller re-parents children: the old name is gone,
+	// and a later run would have no way to reconstruct this mapping.
+	var errs []error
+	if err := migrateSessionSidecars(oldPath, newPath, newID); err != nil {
+		errs = append(errs, err)
+	}
 	// Retire the old disposable lease sidecars: any holder was ruled out
 	// above, and nothing keeps these files open, so a plain remove is safe.
 	if sessionLeaseSidecarFits(oldPath) {
 		for _, stale := range []string{oldPath + ".lease.lock", oldPath + ".lease.json"} {
-			if err := os.Remove(stale); err != nil && !os.IsNotExist(err) && renameErr == nil {
-				renameErr = err
+			if err := os.Remove(stale); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, err)
 			}
 		}
 	}
 	// The old .lock goes atomically with the release of the lock we hold on it.
 	if lockFile != nil {
-		if err := lockFile.RemoveAndUnlock(); err != nil && renameErr == nil {
-			renameErr = err
+		if err := lockFile.RemoveAndUnlock(); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	if renameErr != nil {
-		return "", renameErr
-	}
-	return newID, nil
+	return newID, errors.Join(errs...)
 }
 
 // migrateSessionSidecars moves the user-state sidecars of a renamed session:

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -28,6 +28,17 @@ const (
 	sessionLockSidecarSuffix      = ".jsonl.lock"
 	sessionLeaseLockSidecarSuffix = ".jsonl.lease.lock"
 	sessionLeaseInfoSidecarSuffix = ".jsonl.lease.json"
+	guardianSidecarSuffix         = ".guardian.jsonl"
+	// nameMaxBytes is the single-component filename limit shared by the
+	// filesystems Reasonix targets (APFS, ext4, NTFS all cap at 255).
+	nameMaxBytes = 255
+	// maxSessionBasenameBytes bounds transcript basenames that reconciliation
+	// leaves in place. Sidecars append up to ~16 bytes to the transcript name
+	// or its stem (".lease.lock", ".cleanup-pending.json", ".guardian.jsonl"),
+	// so 224 keeps every sidecar comfortably under nameMaxBytes with headroom
+	// for future suffixes. Names past this bound come from the pre-bounded
+	// recovery cascade and get renamed by reconcileOverlongSessionFilenames.
+	maxSessionBasenameBytes = 224
 )
 
 var (
@@ -895,22 +906,28 @@ func ReconcileCleanupPending(dir string, cleanup func(CleanupPendingInfo) error)
 	return errors.Join(errs...)
 }
 
-// ReconcileSessionSidecars removes stale lock and lease files left beside
-// sessions by older runtimes. It never removes .jsonl transcripts; recovered
-// conversations may contain useful user history even when their names are ugly.
+// ReconcileSessionSidecars renames transcripts whose filenames outgrew their
+// sidecars and removes stale lock and lease files left beside sessions by
+// older runtimes. It never removes .jsonl transcripts; recovered conversations
+// may contain useful user history even when their names are ugly.
 func ReconcileSessionSidecars(dir string) error {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
 		return nil
 	}
+	var errs []error
+	if err := reconcileOverlongSessionFilenames(dir); err != nil {
+		errs = append(errs, err)
+	}
+	// Re-list after the rename pass: it retires old names and their sidecars.
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return errors.Join(errs...)
 		}
-		return err
+		errs = append(errs, err)
+		return errors.Join(errs...)
 	}
-	var errs []error
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -950,11 +967,17 @@ func removeStaleSessionLockSidecar(basePath, sidecarPath string) error {
 		}
 		return err
 	}
+	// Unlink before releasing the flock. Dropping the lock first opens a
+	// window where a concurrent saver locks this inode, the file disappears
+	// under it, and the next opener creates a fresh inode whose "exclusive"
+	// lock the first saver cannot see. Holding the lock across the unlink
+	// narrows that to openers already parked on the old inode.
+	removeErr := os.Remove(sidecarPath)
 	if unlock != nil {
 		unlock()
 	}
-	if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
-		return err
+	if removeErr != nil && !os.IsNotExist(removeErr) {
+		return removeErr
 	}
 	return nil
 }
@@ -973,12 +996,22 @@ func removeStaleSessionLeaseSidecar(basePath, sidecarPath string) error {
 			}
 			return err
 		}
+		// Same unlink-under-lock ordering as removeStaleSessionLockSidecar:
+		// while we hold the lease flock no runtime can acquire this lease, so
+		// the sidecar cannot be adopted between the check and the removal.
+		removeErr := os.Remove(sidecarPath)
 		if unlock != nil {
 			unlock()
 		}
-	} else if err != nil && !os.IsNotExist(err) {
+		if removeErr != nil && !os.IsNotExist(removeErr) {
+			return removeErr
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
 		return err
 	}
+	// No lease lock file: holders keep it present (and locked) for their whole
+	// lifetime, so the leftover info sidecar has no owner to race with.
 	if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -988,6 +1021,202 @@ func removeStaleSessionLeaseSidecar(basePath, sidecarPath string) error {
 func sessionLeaseHeldLocally(path string) bool {
 	_, ok := sessionLeaseOwners.Load(canonicalSessionSavePath(path))
 	return ok
+}
+
+// sessionLockSidecarFits reports whether basePath's .lock sidecar name stays
+// within the filesystem's per-component limit; past it, no process can hold
+// (or ever have held) the file lock, because the lock file cannot be created.
+func sessionLockSidecarFits(basePath string) bool {
+	return len(filepath.Base(basePath))+len(".lock") <= nameMaxBytes
+}
+
+// sessionLeaseSidecarFits is the lease-file analogue of sessionLockSidecarFits.
+func sessionLeaseSidecarFits(basePath string) bool {
+	return len(filepath.Base(basePath))+len(".lease.lock") <= nameMaxBytes
+}
+
+// reconcileOverlongSessionFilenames renames transcripts whose basenames grew
+// past maxSessionBasenameBytes — the leftover shape of the pre-bounded
+// recovery cascade (#5923), where lock and lease sidecars could no longer be
+// created and the session became unsaveable. The conversation bytes are kept
+// verbatim under a bounded name derived the same way new recovery branches
+// are named; branch meta moves along with its ID rewritten, and sessions
+// pointing at the old ID are re-parented so lineage survives the rename.
+func reconcileOverlongSessionFilenames(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var errs []error
+	renamed := map[string]string{} // old branch ID -> new branch ID
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, guardianSidecarSuffix) {
+			continue
+		}
+		if len(name) <= maxSessionBasenameBytes {
+			continue
+		}
+		oldPath := filepath.Join(dir, name)
+		if IsCleanupPending(oldPath) {
+			// Being deleted; renaming would orphan the cleanup marker.
+			continue
+		}
+		newID, err := renameOverlongSession(oldPath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", oldPath, err))
+			continue
+		}
+		if newID != "" {
+			renamed[BranchID(oldPath)] = newID
+		}
+	}
+	if len(renamed) > 0 {
+		if err := reparentSessionBranches(dir, renamed); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// renameOverlongSession moves one overlong transcript to its bounded name and
+// migrates the sidecars that carry user state. It returns the new branch ID,
+// or "" when the session was skipped because a runtime may still own it.
+func renameOverlongSession(oldPath string) (string, error) {
+	oldID := BranchID(oldPath)
+	newID := recoveryParentStem(oldID)
+	if newID == oldID {
+		return "", nil
+	}
+	newPath := filepath.Join(filepath.Dir(oldPath), newID+".jsonl")
+	if _, err := os.Stat(newPath); err == nil {
+		return "", fmt.Errorf("rename target %s already exists", filepath.Base(newPath))
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	unlockOld := lockSessionSavePath(oldPath)
+	defer unlockOld()
+	unlockNew := lockSessionSavePath(newPath)
+	defer unlockNew()
+	if sessionLeaseHeldLocally(oldPath) {
+		return "", nil
+	}
+	// Names past the sidecar limit cannot have lease or lock holders in any
+	// process — the holder files themselves are uncreatable — so probing them
+	// would only manufacture ENAMETOOLONG errors and wrongly skip the exact
+	// sessions this pass exists to repair.
+	if sessionLeaseSidecarFits(oldPath) && SessionLeaseHeldByOtherRuntime(oldPath) {
+		return "", nil
+	}
+	var unlockFile func()
+	if sessionLockSidecarFits(oldPath) {
+		unlock, err := tryLockSessionFile(oldPath)
+		if err != nil {
+			if errors.Is(err, errSessionFileLockHeld) {
+				return "", nil
+			}
+			return "", err
+		}
+		unlockFile = unlock
+	}
+	renameErr := func() error {
+		if err := os.Rename(oldPath, newPath); err != nil {
+			return err
+		}
+		return migrateSessionSidecars(oldPath, newPath, newID)
+	}()
+	// Retire the old disposable sidecars while the file lock is still held,
+	// mirroring removeStaleSessionLockSidecar's unlink-under-lock ordering.
+	if sessionLockSidecarFits(oldPath) {
+		if err := os.Remove(oldPath + ".lock"); err != nil && !os.IsNotExist(err) && renameErr == nil {
+			renameErr = err
+		}
+	}
+	if sessionLeaseSidecarFits(oldPath) {
+		for _, stale := range []string{oldPath + ".lease.lock", oldPath + ".lease.json"} {
+			if err := os.Remove(stale); err != nil && !os.IsNotExist(err) && renameErr == nil {
+				renameErr = err
+			}
+		}
+	}
+	if unlockFile != nil {
+		unlockFile()
+	}
+	if renameErr != nil {
+		return "", renameErr
+	}
+	return newID, nil
+}
+
+// migrateSessionSidecars moves the user-state sidecars of a renamed session:
+// branch meta (with its ID rewritten to match the new filename), goal state,
+// and the checkpoint/job directories. Lock and lease files are disposable and
+// are removed by the caller instead.
+func migrateSessionSidecars(oldPath, newPath, newID string) error {
+	var errs []error
+	if len(filepath.Base(oldPath))+len(".meta") <= nameMaxBytes {
+		if meta, ok, err := LoadBranchMeta(oldPath); err != nil {
+			errs = append(errs, err)
+		} else if ok {
+			meta.ID = newID
+			if err := SaveBranchMetaPreserveUpdated(newPath, meta); err != nil {
+				errs = append(errs, err)
+			} else if err := os.Remove(BranchMetaPath(oldPath)); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	for _, pair := range [][2]string{
+		{store.SessionGoalState(oldPath), store.SessionGoalState(newPath)},
+		{store.SessionCheckpointDir(oldPath), store.SessionCheckpointDir(newPath)},
+		{store.SessionJobsDir(oldPath), store.SessionJobsDir(newPath)},
+	} {
+		// A source name past the filesystem limit cannot exist; renaming it
+		// would just manufacture ENAMETOOLONG instead of a clean not-exist.
+		if len(filepath.Base(pair[0])) > nameMaxBytes {
+			continue
+		}
+		if err := os.Rename(pair[0], pair[1]); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// reparentSessionBranches rewrites ParentID references from renamed branch IDs
+// to their bounded replacements so the branch tree stays connected.
+func reparentSessionBranches(dir string, renamed map[string]string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, guardianSidecarSuffix) {
+			continue
+		}
+		if len(name)+len(".meta") > nameMaxBytes {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		unlock := lockSessionSavePath(path)
+		meta, ok, err := LoadBranchMeta(path)
+		if err == nil && ok {
+			if newParent, hit := renamed[meta.ParentID]; hit && newParent != meta.ParentID {
+				meta.ParentID = newParent
+				err = SaveBranchMetaPreserveUpdated(path, meta)
+			}
+		}
+		unlock()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // ListSessionOrder returns every *.jsonl session under dir in the same

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -677,6 +677,138 @@ func TestSaveRecoveryBranchDedupesByDigest(t *testing.T) {
 	}
 }
 
+func TestSaveRecoveryBranchCompactsLongParentFilename(t *testing.T) {
+	dir := t.TempDir()
+	parentID := strings.Repeat("longparent-", 22)
+	path := filepath.Join(dir, parentID+".jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "disk"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	base := filepath.Base(info.Path)
+	if len(base) > 140 {
+		t.Fatalf("recovery basename length = %d (%q), want bounded", len(base), base)
+	}
+	for _, suffix := range []string{".lock", ".lease.lock", ".lease.json", ".meta"} {
+		if len(base+suffix) > 255 {
+			t.Fatalf("recovery sidecar basename %q length = %d, want <= 255", base+suffix, len(base+suffix))
+		}
+	}
+	meta, ok, err := LoadBranchMeta(info.Path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recovery ok=%v err=%v", ok, err)
+	}
+	if meta.ParentID != BranchID(path) {
+		t.Fatalf("recovery parent = %q, want original branch id", meta.ParentID)
+	}
+}
+
+func TestSaveRecoveryBranchDoesNotCascadeRecoveryFilename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "disk"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	local := NewSession("sys")
+	local.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	local.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	first, err := local.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("first SaveRecoveryBranch: %v", err)
+	}
+
+	recoveryDisk, err := LoadSession(first.Path)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	recoveryDisk.Add(provider.Message{Role: provider.RoleUser, Content: "disk follow-up"})
+	if err := recoveryDisk.SaveSnapshot(first.Path); err != nil {
+		t.Fatalf("SaveSnapshot recovery disk: %v", err)
+	}
+	recoveryLocal := NewSession("sys")
+	recoveryLocal.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	recoveryLocal.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	recoveryLocal.Add(provider.Message{Role: provider.RoleUser, Content: "local follow-up"})
+
+	second, err := recoveryLocal.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: first.Path})
+	if err != nil {
+		t.Fatalf("second SaveRecoveryBranch: %v", err)
+	}
+	base := filepath.Base(second.Path)
+	if count := strings.Count(base, "-recovery-"); count != 1 {
+		t.Fatalf("recovery basename = %q, contains %d recovery markers, want 1", base, count)
+	}
+	if len(base) > 140 {
+		t.Fatalf("recovery basename length = %d (%q), want bounded", len(base), base)
+	}
+}
+
+func TestReconcileSessionSidecarsRemovesUnlockedArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, sidecar := range []string{path + ".lock", path + ".lease.lock", path + ".lease.json"} {
+		if err := os.WriteFile(sidecar, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", sidecar, err)
+		}
+	}
+
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("session transcript removed: %v", err)
+	}
+	for _, sidecar := range []string{path + ".lock", path + ".lease.lock", path + ".lease.json"} {
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Fatalf("%s exists after sidecar cleanup (err=%v)", sidecar, err)
+		}
+	}
+}
+
+func TestReconcileSessionSidecarsKeepsLiveLocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := lockSessionFile(path)
+	if err != nil {
+		t.Fatalf("lockSessionFile: %v", err)
+	}
+	defer unlock()
+	lease, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars: %v", err)
+	}
+	for _, sidecar := range []string{path + ".lock", path + ".lease.lock", path + ".lease.json"} {
+		if _, err := os.Stat(sidecar); err != nil {
+			t.Fatalf("%s missing while lock is live: %v", sidecar, err)
+		}
+	}
+}
+
 // TestListSessionsOrdersByMTime makes sure the picker shows the most
 // recently used conversation first — that's what users reach for when they
 // hit `reasonix --continue`.

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -926,6 +926,58 @@ func TestReconcileSessionSidecarsRenamesOverlongSessionFiles(t *testing.T) {
 	}
 }
 
+// TestReconcileOverlongRenameStillReparentsWhenSidecarMigrationFails pins the
+// point-of-no-return contract: once the transcript rename lands, the mapping
+// must be committed — children re-parented, error surfaced as a warning —
+// because the old name is gone and no later run can reconstruct it.
+func TestReconcileOverlongRenameStillReparentsWhenSidecarMigrationFails(t *testing.T) {
+	dir := t.TempDir()
+	longID := strings.Repeat("m", 240)
+	oldPath := filepath.Join(dir, longID+".jsonl")
+	content := `{"role":"user","content":"hello"}` + "\n"
+	if err := os.WriteFile(oldPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(oldPath, BranchMeta{Name: "keep", ParentID: "root"}); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+	childPath := filepath.Join(dir, "child.jsonl")
+	if err := os.WriteFile(childPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(childPath, BranchMeta{Name: "child", ParentID: longID}); err != nil {
+		t.Fatalf("SaveBranchMeta child: %v", err)
+	}
+
+	newID := recoveryParentStem(longID)
+	newPath := filepath.Join(dir, newID+".jsonl")
+	// Sabotage the meta migration: its destination path is a directory.
+	if err := os.Mkdir(newPath+".meta", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReconcileSessionSidecars(dir); err == nil {
+		t.Fatal("expected the sabotaged meta migration to surface an error")
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("renamed transcript missing after partial failure: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old transcript still present (err=%v)", err)
+	}
+	childMeta, ok, err := LoadBranchMeta(childPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta child ok=%v err=%v", ok, err)
+	}
+	if childMeta.ParentID != newID {
+		t.Fatalf("child ParentID = %q, want %q despite sidecar failure", childMeta.ParentID, newID)
+	}
+	// The old meta stays behind as the durable copy of the un-migrated fields.
+	if _, err := os.Stat(oldPath + ".meta"); err != nil {
+		t.Fatalf("old meta lost though its migration failed: %v", err)
+	}
+}
+
 // TestListSessionsOrdersByMTime makes sure the picker shows the most
 // recently used conversation first — that's what users reach for when they
 // hit `reasonix --continue`.

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -809,6 +809,123 @@ func TestReconcileSessionSidecarsKeepsLiveLocks(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionSidecarsKeepsFlockOnlyLocks proves the file lock alone
+// protects a writer from cleanup: CLI-style savers hold the .lock flock while
+// writing without ever taking a session lease.
+func TestReconcileSessionSidecarsKeepsFlockOnlyLocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := lockSessionFile(path)
+	if err != nil {
+		t.Fatalf("lockSessionFile: %v", err)
+	}
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars: %v", err)
+	}
+	if _, err := os.Stat(path + ".lock"); err != nil {
+		t.Fatalf(".lock removed while a lock-only writer holds it: %v", err)
+	}
+	unlock()
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars after unlock: %v", err)
+	}
+	if _, err := os.Stat(path + ".lock"); !os.IsNotExist(err) {
+		t.Fatalf(".lock survived cleanup after release (err=%v)", err)
+	}
+}
+
+// TestReconcileSessionSidecarsRenamesOverlongSessionFiles covers the
+// migration for transcripts left behind by the unbounded recovery cascade
+// (#5923): names so long their lock/lease sidecars could not be created. The
+// conversation bytes must survive under a bounded name, branch meta must move
+// with its ID rewritten, and children must be re-parented onto the new ID.
+func TestReconcileSessionSidecarsRenamesOverlongSessionFiles(t *testing.T) {
+	dir := t.TempDir()
+	longID := strings.Repeat("p", 240) // 246-byte basename: .lock fits, .lease.lock does not
+	hugeID := strings.Repeat("q", 248) // 254-byte basename: no sidecar fits at all
+	oldLong := filepath.Join(dir, longID+".jsonl")
+	oldHuge := filepath.Join(dir, hugeID+".jsonl")
+	content := `{"role":"system","content":"sys"}` + "\n" + `{"role":"user","content":"hello"}` + "\n"
+	for _, p := range []string{oldLong, oldHuge} {
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(oldLong+".lock", []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(oldLong, BranchMeta{Name: "长会话", ParentID: "root-branch"}); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+	childPath := filepath.Join(dir, "child.jsonl")
+	if err := os.WriteFile(childPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(childPath, BranchMeta{Name: "child", ParentID: longID}); err != nil {
+		t.Fatalf("SaveBranchMeta child: %v", err)
+	}
+
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars: %v", err)
+	}
+
+	for _, gone := range []string{oldLong, oldHuge, oldLong + ".lock", oldLong + ".meta"} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Fatalf("%s still present after rename (err=%v)", filepath.Base(gone), err)
+		}
+	}
+	newLongID := recoveryParentStem(longID)
+	newLong := filepath.Join(dir, newLongID+".jsonl")
+	newHuge := filepath.Join(dir, recoveryParentStem(hugeID)+".jsonl")
+	for _, p := range []string{newLong, newHuge} {
+		if base := filepath.Base(p); len(base) > maxSessionBasenameBytes {
+			t.Fatalf("renamed basename %q length %d exceeds bound %d", base, len(base), maxSessionBasenameBytes)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read renamed transcript: %v", err)
+		}
+		if string(b) != content {
+			t.Fatalf("transcript content changed by rename: %q", b)
+		}
+	}
+	meta, ok, err := LoadBranchMeta(newLong)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta renamed ok=%v err=%v", ok, err)
+	}
+	if meta.ID != newLongID {
+		t.Fatalf("migrated meta ID = %q, want %q", meta.ID, newLongID)
+	}
+	if meta.Name != "长会话" || meta.ParentID != "root-branch" {
+		t.Fatalf("migrated meta lost fields: %+v", meta)
+	}
+	childMeta, ok, err := LoadBranchMeta(childPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta child ok=%v err=%v", ok, err)
+	}
+	if childMeta.ParentID != newLongID {
+		t.Fatalf("child ParentID = %q, want re-parented %q", childMeta.ParentID, newLongID)
+	}
+
+	before, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars rerun: %v", err)
+	}
+	after, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) != len(after) {
+		t.Fatalf("rerun changed the directory: before=%d entries, after=%d", len(before), len(after))
+	}
+}
+
 // TestListSessionsOrdersByMTime makes sure the picker shows the most
 // recently used conversation first — that's what users reach for when they
 // hit `reasonix --continue`.

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -24,6 +24,24 @@ func lockSessionFile(path string) (func(), error) {
 	}, nil
 }
 
+func tryLockSessionFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, errSessionFileLockHeld
+		}
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}
+
 func tryLockSessionLeaseFile(path string) (func(), error) {
 	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -24,8 +24,16 @@ func lockSessionFile(path string) (func(), error) {
 	}, nil
 }
 
-func tryLockSessionFile(path string) (func(), error) {
-	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+// sessionLockFile is a non-blocking exclusive lock on a lock file itself,
+// used by cleanup paths that may need to delete the file they locked.
+type sessionLockFile struct {
+	f *os.File
+}
+
+// tryTakeSessionLockFile opens lockPath and takes its exclusive flock without
+// blocking. A live holder surfaces as errSessionFileLockHeld.
+func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -36,10 +44,24 @@ func tryLockSessionFile(path string) (func(), error) {
 		}
 		return nil, err
 	}
-	return func() {
-		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
-		_ = f.Close()
-	}, nil
+	return &sessionLockFile{f: f}, nil
+}
+
+func (l *sessionLockFile) Unlock() {
+	_ = unix.Flock(int(l.f.Fd()), unix.LOCK_UN)
+	_ = l.f.Close()
+}
+
+// RemoveAndUnlock deletes the lock file atomically with the release: the
+// unlink happens while the flock is still held, so a waiter blocked on this
+// inode can never adopt a file that is about to disappear for everyone else.
+func (l *sessionLockFile) RemoveAndUnlock() error {
+	removeErr := os.Remove(l.f.Name())
+	l.Unlock()
+	if removeErr != nil && !os.IsNotExist(removeErr) {
+		return removeErr
+	}
+	return nil
 }
 
 func tryLockSessionLeaseFile(path string) (func(), error) {

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"errors"
 	"os"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -26,25 +27,61 @@ func lockSessionFile(path string) (func(), error) {
 	}, nil
 }
 
-func tryLockSessionFile(path string) (func(), error) {
-	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+// sessionLockFile is a non-blocking exclusive lock on a lock file itself,
+// used by cleanup paths that may need to delete the file they locked.
+type sessionLockFile struct {
+	f          *os.File
+	overlapped windows.Overlapped
+}
+
+// tryTakeSessionLockFile opens lockPath and takes its exclusive LockFileEx
+// region without blocking. A live holder surfaces as errSessionFileLockHeld.
+func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}
-	handle := windows.Handle(f.Fd())
-	var overlapped windows.Overlapped
+	l := &sessionLockFile{f: f}
 	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
-	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
+	if err := windows.LockFileEx(windows.Handle(f.Fd()), flags, 0, 1, 0, &l.overlapped); err != nil {
 		_ = f.Close()
 		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
 			return nil, errSessionFileLockHeld
 		}
 		return nil, err
 	}
-	return func() {
-		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
-		_ = f.Close()
-	}, nil
+	return l, nil
+}
+
+func (l *sessionLockFile) Unlock() {
+	handle := windows.Handle(l.f.Fd())
+	_ = windows.UnlockFileEx(handle, 0, 1, 0, &l.overlapped)
+	_ = l.f.Close()
+}
+
+// RemoveAndUnlock deletes the lock file atomically with the release. Windows
+// refuses a path-based delete of a file this process still holds open — the
+// deleter's implicit open collides with our handle's granted access — so the
+// removal is expressed on the held handle instead: mark the delete
+// disposition, then unlock and close. The name dies with the handle, leaving
+// no window where another process could adopt a lock file that is already
+// doomed.
+func (l *sessionLockFile) RemoveAndUnlock() error {
+	handle := windows.Handle(l.f.Fd())
+	// FILE_DISPOSITION_INFO with its BOOLEAN widened to a full word.
+	info := struct{ DeleteFile uint32 }{DeleteFile: 1}
+	dispErr := windows.SetFileInformationByHandle(handle, windows.FileDispositionInfo,
+		(*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)))
+	l.Unlock()
+	if dispErr != nil {
+		// Delete disposition unsupported (exotic filesystem): fall back to a
+		// path-based remove after the release. A short adoption window beats
+		// leaving the sidecar behind forever.
+		if err := os.Remove(l.f.Name()); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 func tryLockSessionLeaseFile(path string) (func(), error) {

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -26,6 +26,27 @@ func lockSessionFile(path string) (func(), error) {
 	}, nil
 }
 
+func tryLockSessionFile(path string) (func(), error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, errSessionFileLockHeld
+		}
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+		_ = f.Close()
+	}, nil
+}
+
 func tryLockSessionLeaseFile(path string) (func(), error) {
 	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"errors"
 	"os"
+	"sync/atomic"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -30,21 +31,43 @@ func lockSessionFile(path string) (func(), error) {
 // sessionLockFile is a non-blocking exclusive lock on a lock file itself,
 // used by cleanup paths that may need to delete the file they locked.
 type sessionLockFile struct {
-	f          *os.File
+	handle     windows.Handle
+	path       string
 	overlapped windows.Overlapped
 }
 
+// sessionLockDispositionFallbacks counts RemoveAndUnlock calls that could not
+// delete through the held handle and fell back to a path-based remove. The
+// fallback reopens the cleanup-vs-saver window, so tests pin it at zero.
+var sessionLockDispositionFallbacks atomic.Int64
+
 // tryTakeSessionLockFile opens lockPath and takes its exclusive LockFileEx
 // region without blocking. A live holder surfaces as errSessionFileLockHeld.
+//
+// The handle asks for DELETE access up front: FileDispositionInfo requires it,
+// and requesting it at open time keeps RemoveAndUnlock's deletion on the very
+// handle that owns the lock. A sharing violation here means some process has
+// the file open through Go's default share mode (which excludes DELETE) — for
+// a lock file that is the same answer as losing the LockFileEx race.
 func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	pathp, err := windows.UTF16PtrFromString(lockPath)
 	if err != nil {
 		return nil, err
 	}
-	l := &sessionLockFile{f: f}
+	handle, err := windows.CreateFile(pathp,
+		windows.GENERIC_READ|windows.GENERIC_WRITE|windows.DELETE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil, windows.OPEN_ALWAYS, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, errSessionFileLockHeld
+		}
+		return nil, err
+	}
+	l := &sessionLockFile{handle: handle, path: lockPath}
 	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
-	if err := windows.LockFileEx(windows.Handle(f.Fd()), flags, 0, 1, 0, &l.overlapped); err != nil {
-		_ = f.Close()
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &l.overlapped); err != nil {
+		_ = windows.CloseHandle(handle)
 		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
 			return nil, errSessionFileLockHeld
 		}
@@ -54,30 +77,28 @@ func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
 }
 
 func (l *sessionLockFile) Unlock() {
-	handle := windows.Handle(l.f.Fd())
-	_ = windows.UnlockFileEx(handle, 0, 1, 0, &l.overlapped)
-	_ = l.f.Close()
+	_ = windows.UnlockFileEx(l.handle, 0, 1, 0, &l.overlapped)
+	_ = windows.CloseHandle(l.handle)
 }
 
 // RemoveAndUnlock deletes the lock file atomically with the release. Windows
-// refuses a path-based delete of a file this process still holds open — the
-// deleter's implicit open collides with our handle's granted access — so the
+// refuses a path-based delete of a file this process still holds open, so the
 // removal is expressed on the held handle instead: mark the delete
 // disposition, then unlock and close. The name dies with the handle, leaving
 // no window where another process could adopt a lock file that is already
 // doomed.
 func (l *sessionLockFile) RemoveAndUnlock() error {
-	handle := windows.Handle(l.f.Fd())
 	// FILE_DISPOSITION_INFO with its BOOLEAN widened to a full word.
 	info := struct{ DeleteFile uint32 }{DeleteFile: 1}
-	dispErr := windows.SetFileInformationByHandle(handle, windows.FileDispositionInfo,
+	dispErr := windows.SetFileInformationByHandle(l.handle, windows.FileDispositionInfo,
 		(*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)))
 	l.Unlock()
 	if dispErr != nil {
 		// Delete disposition unsupported (exotic filesystem): fall back to a
 		// path-based remove after the release. A short adoption window beats
 		// leaving the sidecar behind forever.
-		if err := os.Remove(l.f.Name()); err != nil && !os.IsNotExist(err) {
+		sessionLockDispositionFallbacks.Add(1)
+		if err := os.Remove(l.path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}
@@ -87,6 +108,12 @@ func (l *sessionLockFile) RemoveAndUnlock() error {
 func tryLockSessionLeaseFile(path string) (func(), error) {
 	f, err := os.OpenFile(path+".lease.lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		// Cleanup holds lease lock files with DELETE access for a moment;
+		// Go's default share mode cannot coexist with that, so the open
+		// itself reports the file busy. Same retryable answer as a held lock.
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, ErrSessionLeaseHeld
+		}
 		return nil, err
 	}
 	handle := windows.Handle(f.Fd())

--- a/internal/agent/session_lock_windows_test.go
+++ b/internal/agent/session_lock_windows_test.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveAndUnlockDeletesViaDispositionNotFallback pins the Windows delete
+// path: the lock handle must carry DELETE access so the disposition call
+// succeeds and the TOCTOU-free branch is the one actually taken. A fallback
+// means the handle was opened without DELETE and the cleanup-vs-saver window
+// is silently back.
+func TestRemoveAndUnlockDeletesViaDispositionNotFallback(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "session.jsonl.lock")
+	before := sessionLockDispositionFallbacks.Load()
+	lock, err := tryTakeSessionLockFile(lockPath)
+	if err != nil {
+		t.Fatalf("tryTakeSessionLockFile: %v", err)
+	}
+	if err := lock.RemoveAndUnlock(); err != nil {
+		t.Fatalf("RemoveAndUnlock: %v", err)
+	}
+	if got := sessionLockDispositionFallbacks.Load(); got != before {
+		t.Fatalf("delete disposition fell back to path removal (%d -> %d); lock handle lacks DELETE access", before, got)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock file still present after RemoveAndUnlock (err=%v)", err)
+	}
+}
+
+// TestTryTakeSessionLockFileTreatsOpenHandleAsHeld pins the sharing-violation
+// mapping: a plain Go open (no DELETE sharing) must read as "held", not as an
+// error, because reconcile treats held lock files as live and skips them.
+func TestTryTakeSessionLockFileTreatsOpenHandleAsHeld(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "session.jsonl.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := tryTakeSessionLockFile(lockPath); !errors.Is(err, errSessionFileLockHeld) {
+		t.Fatalf("tryTakeSessionLockFile with plain open handle = %v, want errSessionFileLockHeld", err)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -171,6 +171,10 @@ type Controller struct {
 	autosaveWG  sync.WaitGroup
 	planMode    bool
 	sessionPath string
+	// savedRewriteVersion is the session rewrite generation that has been
+	// durably persisted for sessionPath. Auto-compaction rewrites history inside
+	// a normal turn; the next autosave must use SaveRewrite, not SaveSnapshot.
+	savedRewriteVersion int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 
@@ -428,6 +432,7 @@ func New(opts Options) *Controller {
 	cmdsInit := opts.Commands
 	c.commands.Store(&cmdsInit)
 	if c.executor != nil {
+		c.savedRewriteVersion = c.executor.Session().RewriteVersion()
 		c.executor.SetPreEditHook(func(ch diff.Change) {
 			c.checkpoints.snapshot(ch)
 		})
@@ -2033,6 +2038,7 @@ func (c *Controller) NewSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.markSessionRewritePersisted(c.executor.Session())
 	if c.guardianSess != nil {
 		c.guardianSess.Reset()
 	}
@@ -2081,6 +2087,7 @@ func (c *Controller) ClearSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.markSessionRewritePersisted(c.executor.Session())
 	if c.guardianSess != nil {
 		c.guardianSess.Reset()
 	}
@@ -2296,6 +2303,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	}
 	if switchToFork {
 		c.executor.SetSession(sess)
+		c.markSessionRewritePersisted(sess)
 		c.ResetPlannerSession()
 		c.mu.Lock()
 		c.sessionPath = newPath
@@ -2369,6 +2377,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		return "", c.rewindFail(err)
 	}
 	c.executor.SetSession(sess)
+	c.markSessionRewritePersisted(sess)
 	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = newPath
@@ -2423,6 +2432,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	}
 	if c.executor != nil {
 		c.executor.SetSession(loaded)
+		c.markSessionRewritePersisted(loaded)
 	}
 	c.ResetPlannerSession()
 	c.mu.Lock()
@@ -2521,6 +2531,7 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 func (c *Controller) Resume(s *agent.Session, path string) {
 	if c.executor != nil {
 		c.executor.SetSession(s)
+		c.markSessionRewritePersisted(s)
 	}
 	c.ResetPlannerSession()
 	c.mu.Lock()
@@ -2623,6 +2634,27 @@ func (c *Controller) SnapshotRewrite() error {
 	return c.snapshot(false, true)
 }
 
+func (c *Controller) snapshotShouldRewrite(s *agent.Session, forceRewrite bool) bool {
+	if forceRewrite || s == nil {
+		return forceRewrite
+	}
+	rewriteVersion := s.RewriteVersion()
+	c.mu.Lock()
+	saved := c.savedRewriteVersion
+	c.mu.Unlock()
+	return rewriteVersion > saved
+}
+
+func (c *Controller) markSessionRewritePersisted(s *agent.Session) {
+	if s == nil {
+		return
+	}
+	rewriteVersion := s.RewriteVersion()
+	c.mu.Lock()
+	c.savedRewriteVersion = rewriteVersion
+	c.mu.Unlock()
+}
+
 // midTurnSnapshotInterval is atomic (nanoseconds) so a test shrinking it
 // cannot race a previous test's still-parking autosave goroutine.
 var midTurnSnapshotInterval atomic.Int64
@@ -2682,6 +2714,7 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 			"label", c.Label(), "session_dir", c.SessionDir())
 		return errNoSessionPath
 	}
+	forceRewrite = c.snapshotShouldRewrite(s, forceRewrite)
 	var err error
 	if forceRewrite {
 		err = s.SaveRewrite(path)
@@ -2718,7 +2751,11 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	// like SetBranchModelPreserveUpdated. The single write subsumes the old
 	// EnsureBranchMeta / SetBranchModel / TouchBranchMeta sequence.
 	preview, turns := agent.SessionPreviewFromMessages(s.Snapshot())
-	return agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity)
+	if err := agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity); err != nil {
+		return err
+	}
+	c.markSessionRewritePersisted(s)
+	return nil
 }
 
 func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, bool, error) {
@@ -2788,6 +2825,7 @@ func (c *Controller) adoptDiskSession(path string) bool {
 		return false
 	}
 	c.executor.SetSession(loaded)
+	c.markSessionRewritePersisted(loaded)
 	c.ResetPlannerSession()
 	c.rebindCheckpoints(path)
 	c.setActiveJobSession(path)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2634,17 +2634,33 @@ func (c *Controller) SnapshotRewrite() error {
 	return c.snapshot(false, true)
 }
 
-func (c *Controller) snapshotShouldRewrite(s *agent.Session, forceRewrite bool) bool {
-	if forceRewrite || s == nil {
-		return forceRewrite
+// snapshotRewriteDecision reports whether the next save must be an owned
+// rewrite, and returns the rewrite version the decision was based on. After a
+// successful save the caller records that same captured version via
+// markSessionRewriteVersionPersisted: re-reading RewriteVersion() after the
+// write would let a compaction that landed mid-save be recorded as persisted
+// when it never reached disk, turning the next autosave into a spurious
+// snapshot conflict and a recovery branch.
+func (c *Controller) snapshotRewriteDecision(s *agent.Session, forceRewrite bool) (bool, int) {
+	if s == nil {
+		return forceRewrite, 0
 	}
 	rewriteVersion := s.RewriteVersion()
+	if forceRewrite {
+		return true, rewriteVersion
+	}
 	c.mu.Lock()
 	saved := c.savedRewriteVersion
 	c.mu.Unlock()
-	return rewriteVersion > saved
+	return rewriteVersion > saved, rewriteVersion
 }
 
+// markSessionRewritePersisted resets the persisted-rewrite baseline to s's
+// current rewrite version. Only session-swap paths (new/clear/fork/branch/
+// switch/resume/adopt) may use it: they install a session whose in-memory
+// history is exactly what disk holds, so its current version is persisted by
+// construction. Save paths must record their captured decision version via
+// markSessionRewriteVersionPersisted instead.
 func (c *Controller) markSessionRewritePersisted(s *agent.Session) {
 	if s == nil {
 		return
@@ -2652,6 +2668,23 @@ func (c *Controller) markSessionRewritePersisted(s *agent.Session) {
 	rewriteVersion := s.RewriteVersion()
 	c.mu.Lock()
 	c.savedRewriteVersion = rewriteVersion
+	c.mu.Unlock()
+}
+
+// markSessionRewriteVersionPersisted records version as durably saved for s.
+// It never lowers the baseline (a concurrent save may have persisted a newer
+// rewrite already), and it leaves the counter alone when s is no longer the
+// executor's session: the swap that raced this save owns the baseline now,
+// and an old session's version leaking onto a fresh session could exceed that
+// session's own rewrite version, making its next compaction look persisted.
+func (c *Controller) markSessionRewriteVersionPersisted(s *agent.Session, version int) {
+	if s == nil || c.executor == nil || c.executor.Session() != s {
+		return
+	}
+	c.mu.Lock()
+	if version > c.savedRewriteVersion {
+		c.savedRewriteVersion = version
+	}
 	c.mu.Unlock()
 }
 
@@ -2714,13 +2747,24 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 			"label", c.Label(), "session_dir", c.SessionDir())
 		return errNoSessionPath
 	}
-	forceRewrite = c.snapshotShouldRewrite(s, forceRewrite)
+	forceRewrite, rewriteVersion := c.snapshotRewriteDecision(s, forceRewrite)
 	var err error
 	if forceRewrite {
 		err = s.SaveRewrite(path)
 	} else {
 		err = s.SaveSnapshot(path)
+		if errors.Is(err, agent.ErrSessionSnapshotConflict) {
+			// The no-rewrite decision may already be stale: auto-compaction
+			// can rewrite history between the decision and the write. Re-decide
+			// and retry once as an owned rewrite before treating the failure as
+			// a real cross-runtime conflict.
+			if retry, retryVersion := c.snapshotRewriteDecision(s, false); retry {
+				forceRewrite, rewriteVersion = true, retryVersion
+				err = s.SaveRewrite(path)
+			}
+		}
 	}
+	adoptedDiskSession := false
 	if err != nil {
 		if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
 			return err
@@ -2732,6 +2776,10 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 		if !recovered {
 			return nil
 		}
+		// Adoption swaps in a freshly loaded session whose rewrite baseline
+		// adoptDiskSession already set; the version captured above belongs to
+		// the replaced session and must not be re-applied to the new one.
+		adoptedDiskSession = recoveredPath == path
 		path = recoveredPath
 		s = c.executor.Session()
 	}
@@ -2754,7 +2802,9 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	if err := agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity); err != nil {
 		return err
 	}
-	c.markSessionRewritePersisted(s)
+	if !adoptedDiskSession {
+		c.markSessionRewriteVersionPersisted(s, rewriteVersion)
+	}
 	return nil
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -752,6 +752,116 @@ func TestSnapshotRewriteRecoversStaleControllerTranscript(t *testing.T) {
 	}
 }
 
+func TestSnapshotActivityPersistsOwnedCompactionRewrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := sess.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	exec := agent.New(nil, nil, loaded, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	// A mid-turn autosave can persist the pre-compaction prefix. Auto-compaction
+	// then rewrites older history inside the same turn; the final activity
+	// snapshot must persist that owned rewrite in place instead of branching.
+	loaded.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("Snapshot pre-compaction: %v", err)
+	}
+	loaded.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "<compaction-summary>\nSummary of earlier conversation: first -> one\n</compaction-summary>"},
+		{Role: provider.RoleUser, Content: "second"},
+	})
+	loaded.IncrementRewrite()
+
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity after compaction: %v", err)
+	}
+	if got := c.SessionPath(); got != path {
+		t.Fatalf("session path after owned compaction = %q, want original %q", got, path)
+	}
+	reloaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession rewritten: %v", err)
+	}
+	if got := len(reloaded.Messages); got != 3 {
+		t.Fatalf("message count after compaction rewrite = %d, want 3: %+v", got, reloaded.Messages)
+	}
+	if got := reloaded.Messages[1].Content; !strings.Contains(got, "compaction-summary") {
+		t.Fatalf("compaction summary was not persisted: %+v", reloaded.Messages)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after owned compaction rewrite = %v err=%v, want none", matches, err)
+	}
+}
+
+func TestRecoveryBranchPersistsLaterOwnedCompactionRewrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "disk"})
+	if err := currentSess.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	localSess := agent.NewSession("sys")
+	localSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	localSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	localExec := agent.New(nil, nil, localSess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: localExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("Snapshot initial recovery: %v", err)
+	}
+	recoveryPath := c.SessionPath()
+	if recoveryPath == "" || recoveryPath == path {
+		t.Fatalf("recovery path = %q, want distinct path", recoveryPath)
+	}
+
+	localSess.Add(provider.Message{Role: provider.RoleUser, Content: "continue"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("Snapshot recovery append: %v", err)
+	}
+	localSess.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "<compaction-summary>\nSummary of recovery branch work: first -> local\n</compaction-summary>"},
+		{Role: provider.RoleUser, Content: "continue"},
+	})
+	localSess.IncrementRewrite()
+
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity recovery compaction: %v", err)
+	}
+	if got := c.SessionPath(); got != recoveryPath {
+		t.Fatalf("session path after recovery compaction = %q, want recovery %q", got, recoveryPath)
+	}
+	reloaded, err := agent.LoadSession(recoveryPath)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	if got := len(reloaded.Messages); got != 3 {
+		t.Fatalf("message count after recovery compaction = %d, want 3: %+v", got, reloaded.Messages)
+	}
+	if got := reloaded.Messages[1].Content; !strings.Contains(got, "compaction-summary") {
+		t.Fatalf("recovery compaction summary was not persisted: %+v", reloaded.Messages)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("nested recovery branches after owned recovery compaction = %v err=%v, want none", matches, err)
+	}
+}
+
 func TestAdoptHistoryPreservesRewriteBaseline(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -859,6 +860,174 @@ func TestRecoveryBranchPersistsLaterOwnedCompactionRewrite(t *testing.T) {
 	}
 	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
 		t.Fatalf("nested recovery branches after owned recovery compaction = %v err=%v, want none", matches, err)
+	}
+}
+
+// TestSnapshotConflictAdoptionResetsRewriteBaseline guards the baseline
+// handoff on the adopt path: adopting a newer on-disk transcript installs a
+// freshly loaded session, and the replaced session's rewrite version must not
+// leak onto it. A leaked (higher) baseline would make the adopted session's
+// own compactions look already persisted, so the next autosave would take the
+// snapshot path, conflict, and fork a spurious recovery branch.
+func TestSnapshotConflictAdoptionResetsRewriteBaseline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	base := agent.NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+	stale, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession stale: %v", err)
+	}
+	other, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession other: %v", err)
+	}
+	other.Add(provider.Message{Role: provider.RoleAssistant, Content: "newer"})
+	if err := other.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot other: %v", err)
+	}
+
+	exec := agent.New(nil, nil, stale, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	// Rewrites the stale controller never persisted before it noticed the
+	// newer transcript; adoption must discard this counter with the session.
+	for i := 0; i < 3; i++ {
+		stale.IncrementRewrite()
+	}
+
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("Snapshot adopt: %v", err)
+	}
+	if got := c.SessionPath(); got != path {
+		t.Fatalf("session path after adoption = %q, want original %q", got, path)
+	}
+	adopted := exec.Session()
+	if adopted == stale {
+		t.Fatal("expected adoption to replace the stale session")
+	}
+	readBaseline := func() int {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.savedRewriteVersion
+	}
+	if got, want := readBaseline(), adopted.RewriteVersion(); got != want {
+		t.Fatalf("rewrite baseline after adoption = %d, want adopted session's %d", got, want)
+	}
+
+	// The adopted session's first compaction must persist in place.
+	msgs := adopted.Snapshot()
+	adopted.Replace([]provider.Message{
+		msgs[0],
+		{Role: provider.RoleUser, Content: "<compaction-summary>\nfirst -> newer\n</compaction-summary>"},
+	})
+	adopted.IncrementRewrite()
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity after adopted compaction: %v", err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after adopted compaction = %v err=%v, want none", matches, err)
+	}
+	reloaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession rewritten: %v", err)
+	}
+	if got := len(reloaded.Messages); got != 2 {
+		t.Fatalf("message count after adopted compaction = %d, want 2: %+v", got, reloaded.Messages)
+	}
+}
+
+// TestMarkSessionRewriteVersionPersistedGuards pins the two properties that
+// keep the persisted-rewrite baseline safe under races: it never moves
+// backwards, and a session that is no longer the executor's cannot write its
+// version onto the counter of the session that replaced it.
+func TestMarkSessionRewriteVersionPersistedGuards(t *testing.T) {
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: t.TempDir(), Label: "test"})
+	readBaseline := func() int {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.savedRewriteVersion
+	}
+
+	c.markSessionRewriteVersionPersisted(sess, 2)
+	if got := readBaseline(); got != 2 {
+		t.Fatalf("baseline after mark(2) = %d, want 2", got)
+	}
+	c.markSessionRewriteVersionPersisted(sess, 1)
+	if got := readBaseline(); got != 2 {
+		t.Fatalf("baseline lowered to %d by mark(1), want it kept at 2", got)
+	}
+	foreign := agent.NewSession("sys")
+	c.markSessionRewriteVersionPersisted(foreign, 9)
+	if got := readBaseline(); got != 2 {
+		t.Fatalf("baseline = %d after foreign-session mark, want 2", got)
+	}
+}
+
+// TestConcurrentCompactionAndAutosaveNeverBranch drives the real shape of the
+// bug: a mid-turn autosave goroutine saving while the turn goroutine compacts.
+// Whatever the interleaving, an owned single-process session must never fork a
+// recovery branch — the decision/mark pipeline in snapshot() has to capture
+// the rewrite version it actually persisted, and retry as an owned rewrite
+// when a compaction slips in between.
+func TestConcurrentCompactionAndAutosaveNeverBranch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "turn-0"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("initial snapshot: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Errors surface as recovery branches, asserted below.
+				_ = c.SnapshotActivity()
+			}
+		}
+	}()
+	for i := 1; i <= 40; i++ {
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("turn-%d", i)})
+		if i%4 == 0 {
+			msgs := sess.Snapshot()
+			sess.Replace([]provider.Message{
+				msgs[0],
+				{Role: provider.RoleUser, Content: fmt.Sprintf("<compaction-summary>\nrounds through %d\n</compaction-summary>", i)},
+				msgs[len(msgs)-1],
+			})
+			sess.IncrementRewrite()
+		}
+	}
+	close(stop)
+	wg.Wait()
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatalf("final snapshot: %v", err)
+	}
+
+	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("compaction racing autosave created recovery branches: %v err=%v", matches, err)
+	}
+	reloaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession final: %v", err)
+	}
+	if got, want := len(reloaded.Messages), sess.Len(); got != want {
+		t.Fatalf("persisted %d messages, memory has %d", got, want)
 	}
 }
 

--- a/internal/environment/probe.go
+++ b/internal/environment/probe.go
@@ -27,6 +27,8 @@ const probeCacheTTL = 5 * time.Minute
 
 const maxRenderedTools = 24
 
+var probeTimeout = ProbeTimeout
+
 type probeCacheEntry struct {
 	storedAt time.Time
 	results  []ProbeResult
@@ -207,7 +209,7 @@ func runOne(ctx context.Context, command string, opts ProbeOptions) ProbeResult 
 		res.Error = "not trusted"
 		return res
 	}
-	cmdCtx, cancel := context.WithTimeout(ctx, ProbeTimeout)
+	cmdCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(cmdCtx, exe, parts[1:]...)
 	if len(probe.Env) > 0 {

--- a/internal/environment/probe_test.go
+++ b/internal/environment/probe_test.go
@@ -151,6 +151,7 @@ func TestRunProbesRejectsDeniedPathHit(t *testing.T) {
 }
 
 func TestRunProbesReportsTimeout(t *testing.T) {
+	setProbeTimeoutForTest(t, 200*time.Millisecond)
 	dir := t.TempDir()
 	toolPath := filepath.Join(dir, "slowtool")
 	body := "#!/bin/sh\nsleep 3\n"
@@ -269,6 +270,7 @@ func TestFormatSectionLimitsToolOutput(t *testing.T) {
 
 func writeProbeTool(t *testing.T, path, output string) string {
 	t.Helper()
+	setProbeTimeoutForTest(t, 10*time.Second)
 	body := "#!/bin/sh\nprintf '%s\\n'\n"
 	body = fmt.Sprintf(body, strings.ReplaceAll(output, "'", "'\\''"))
 	if runtime.GOOS == "windows" {
@@ -285,6 +287,7 @@ func writeProbeTool(t *testing.T, path, output string) string {
 
 func writeEnvProbeTool(t *testing.T, path string) string {
 	t.Helper()
+	setProbeTimeoutForTest(t, 10*time.Second)
 	body := "#!/bin/sh\nprintf '%s\\n' \"$REASONIX_PROBE_ENV\"\n"
 	if runtime.GOOS == "windows" {
 		if !strings.HasSuffix(path, ".bat") {
@@ -300,6 +303,7 @@ func writeEnvProbeTool(t *testing.T, path string) string {
 
 func writeStderrProbeTool(t *testing.T, path, output string) string {
 	t.Helper()
+	setProbeTimeoutForTest(t, 10*time.Second)
 	body := "#!/bin/sh\nprintf '%s\\n' >&2\n"
 	body = fmt.Sprintf(body, strings.ReplaceAll(output, "'", "'\\''"))
 	if runtime.GOOS == "windows" {
@@ -326,6 +330,7 @@ func resetProbeCacheForTest(t *testing.T, now time.Time) {
 		probeCache = map[string]probeCacheEntry{}
 		probeInflightCalls = map[string]*probeInflight{}
 		probeNow = time.Now
+		probeTimeout = ProbeTimeout
 		probeCacheMu.Unlock()
 	})
 }
@@ -334,4 +339,16 @@ func setProbeNowForTest(now time.Time) {
 	probeCacheMu.Lock()
 	probeNow = func() time.Time { return now }
 	probeCacheMu.Unlock()
+}
+
+func setProbeTimeoutForTest(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	probeCacheMu.Lock()
+	probeTimeout = timeout
+	probeCacheMu.Unlock()
+	t.Cleanup(func() {
+		probeCacheMu.Lock()
+		probeTimeout = ProbeTimeout
+		probeCacheMu.Unlock()
+	})
 }


### PR DESCRIPTION
## Summary
- Preserve the controller's persisted rewrite baseline so owned compaction rewrites save in place instead of creating recovery branches.
- Bound recovery branch filenames and prevent recovery-on-recovery names from cascading.
- Clean stale session lock and lease sidecars during cleanup reconciliation while leaving recovered transcript files intact.
- Stabilize environment probe tests under full-suite load without changing the product probe timeout.

## Test Plan
- `go test ./internal/agent ./internal/control ./internal/environment`
- `go test ./...`
- `cd desktop && go test . -run 'TestDesktopSnapshotConflictRecoveryUpdatesTabAndProjectTree|TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease|TestConfigChangeLeaseHeldPersistsAndDefersRefresh|TestDeferredRebuildRetryAppliesAfterLeaseRelease|TestSetEffortForTabLeaseHeldKeepsOldControllerAlive'`
- `cd desktop && go test .`

Refs #5923.