### PR TITLE
feat(ui): add mouse_capture config option for terminal-native text selection

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -651,6 +651,9 @@ func chatREPL(args []string) int {
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
 		m.showReasoning = cfg.UI.ShowReasoning   // /verbose persistence: start with config default
 		m.cfg = cfg
+		if cfg.UI.MouseCapture != nil && !*cfg.UI.MouseCapture {
+			m.mouseCaptureOff = true
+		}
 	}
 
 	// /model support: a pure builder the TUI calls to rebuild on a different

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,8 +79,9 @@ type UIConfig struct {
 	ThemeStyle     string `toml:"theme_style"`     // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	ShortcutLayout string `toml:"shortcut_layout"` // classic|desktop; accepted for compatibility
 	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
-	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
-	CursorShape    string `toml:"cursor_shape"`    // block|underline|bar; empty defaults to underline
+	ShowReasoning  bool    `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
+	CursorShape    string  `toml:"cursor_shape"`    // block|underline|bar; empty defaults to underline
+	MouseCapture   *bool   `toml:"mouse_capture"`   // enable in-app mouse handling; nil/true = enabled, false = released to terminal (native selection works)
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -12,6 +12,10 @@ theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 # shortcut_layout = "desktop"   # classic|desktop; compatibility setting; Shift+Tab toggles Plan, Ctrl+Y toggles YOLO
 # cursor_shape = "underline"   # block|underline|bar; text input cursor shape; default underline to avoid CJK rendering artifacts
+# mouse_capture = true   # enable in-app mouse handling (transcript scrollbar drag, wheel-scroll,
+                         # drag-select). Set to false to release mouse ownership to the terminal so
+                         # native click-drag selection and the right-click context menu work again.
+                         # Useful when running inside tmux or screen.
 
 [desktop]
 layout_style = "classic"   # classic|workbench|creation; desktop layout style


### PR DESCRIPTION
## Summary

Adds a `[ui].mouse_capture` config option to `config.toml` so users can disable in-app mouse capture persistently.

When running inside terminal multiplexers like **tmux** (with `set -g mouse on`) or **screen**, the TUI captures all mouse events via `\e[?1002h` / `\e[?1006h` / `\e[?1003h` (Bubble Tea `MouseModeCellMotion`), which prevents the multiplexer from intercepting mouse drags for native text selection. The `MouseDragEnd1Pane` binding never fires.

Setting `mouse_capture = false` sets `v.MouseMode = tea.MouseModeNone` in View(), releasing mouse ownership back to the terminal so click-drag selection and the right-click context menu work normally. In-app scrollbar drag and wheel-scrolling are sacrificed while it is off.

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `MouseCapture *bool` field to `UIConfig` (`toml:"mouse_capture"`) |
| `internal/cli/cli.go` | Check `cfg.UI.MouseCapture` after model init and set `mouseCaptureOff` when explicitly `false` |
| `reasonix.example.toml` | Document the new option in the `[ui]` section |

The existing `REASONIX_DISABLE_MOUSE` env var continues to work unchanged. The `*bool` pointer type means nil/absent preserves the existing env-var-based default.

---

**Cache-impact:** low — config field addition, no prompt/tool surface change; existing env-var path already tested

**Cache-guard:** existing `mouseCaptureOffByDefault()` covers the env-var path; new config path checked by the same `mouseCaptureOff` field in View()

**System-prompt-review:** n/a — system prompt not modified; config.go change is struct-only, no prompt text