### PR TITLE
feat(cli): 状态栏显示本 session 累计花费

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -80,6 +80,14 @@ type chatTUI struct {
 	// events) for the live "↓N" readout in the running status line.
 	turnTokens int
 
+	// sessionCost accumulates this process's estimated spend across every priced
+	// Usage event (planner + executor + subagents + compaction), converted via each
+	// event's Pricing. Process-scoped like turnTokens, so a resumed session starts
+	// fresh rather than replaying prior spend. sessionCostSymbol holds the latest
+	// Pricing's currency symbol for display.
+	sessionCost       float64
+	sessionCostSymbol string
+
 	// balance is the last-fetched wallet-balance readout (e.g. "¥110.00"), "" when
 	// the provider declares no balance_url or a fetch failed. Refreshed async on
 	// startup and after each turn so the status line stays roughly current without
@@ -2438,6 +2446,9 @@ func (m chatTUI) View() tea.View {
 	if m.balance != "" {
 		data = append(data, dim(m.balance))
 	}
+	if ct := m.costTag(); ct != "" {
+		data = append(data, ct)
+	}
 	dataLine := "  " + strings.Join(data, " · ")
 	// A configured custom status line replaces the built-in data row entirely.
 	if m.statuslineCmd != "" && m.statuslineOut != "" {
@@ -2660,6 +2671,18 @@ func (m chatTUI) jobsTag() string {
 		return ""
 	}
 	return dim(fmt.Sprintf("⚙ %d", n))
+}
+
+// costTag shows this process's cumulative estimated spend (Σ over every priced
+// Usage event), formatted as symbol+amount to match the per-turn cost in
+// FormatUsageLine. "" until the first priced Usage arrives — providers without
+// Pricing never set sessionCost, so the tag simply stays hidden.
+func (m chatTUI) costTag() string {
+	if m.sessionCost <= 0 {
+		return ""
+	}
+	money := fmt.Sprintf("%s%.4f", m.sessionCostSymbol, m.sessionCost)
+	return dim(fmt.Sprintf(i18n.M.ChatStatusSessionCostFmt, money))
 }
 
 func (m chatTUI) modelTag() string {
@@ -2933,6 +2956,9 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	}
 	if m.balance != "" {
 		data = append(data, m.balance)
+	}
+	if ct := m.costTag(); ct != "" {
+		data = append(data, ct)
 	}
 	dataLine := "  " + strings.Join(data, " · ")
 	if m.statuslineCmd != "" && m.statuslineOut != "" {
@@ -3279,6 +3305,10 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 	case event.Usage:
 		if e.Usage != nil {
 			m.turnTokens += e.Usage.CompletionTokens
+			if e.Pricing != nil {
+				m.sessionCost += e.Pricing.Cost(e.Usage)
+				m.sessionCostSymbol = e.Pricing.Symbol()
+			}
 		}
 		if line := agent.FormatUsageLine(e.Usage, e.Pricing, e.CacheDiagnostics); line != "" {
 			m.finalizeStreamed()

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -79,6 +79,7 @@ type Messages struct {
 	ChatStatusCycleHint         string // plan-toggle shortcut hint shown when no modal prompt owns the status row
 	ChatStatusCacheNowFmt       string // cache status tag, "%s" = latest-turn hit rate with percent sign
 	ChatStatusCacheAvgFmt       string // cache status tag, "%s" = session-average hit rate with percent sign
+	ChatStatusSessionCostFmt    string // session-cumulative spend tag, "%s" = currency symbol + amount (e.g. "¥0.0123")
 	ChatStatusPlanApproval      string // shortcuts hint while a plan is pending
 	PlanApprovalPrompt          string // one-line "plan above is ready" banner shown above the input
 	ChatStatusToolApproval      string // shortcuts hint while a tool call awaits approval

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -53,6 +53,7 @@ var English = Messages{
 	ChatStatusCycleHint:         "shift+tab toggles plan · ctrl+y yolo",
 	ChatStatusCacheNowFmt:       "turn hit %s",
 	ChatStatusCacheAvgFmt:       "avg %s",
+	ChatStatusSessionCostFmt:    "spent %s",
 	ChatStatusPlanApproval:      "Enter/y approves & executes · n/Esc keeps planning · PgUp/PgDn/Ctrl+Home/End scrolls",
 	PlanApprovalPrompt:          "Plan ready above — Enter/y to approve & execute, n/Esc to keep planning",
 	ChatStatusToolApproval:      "1 approve once · 2 allow scope this session · 3/4 prefix or save when offered · n/Esc deny · Ctrl-C cancels turn",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -54,6 +54,7 @@ var Chinese = Messages{
 	ChatStatusCycleHint:         "shift+tab 切换计划 · ctrl+y yolo",
 	ChatStatusCacheNowFmt:       "本次命中 %s",
 	ChatStatusCacheAvgFmt:       "平均 %s",
+	ChatStatusSessionCostFmt:    "花费 %s",
 	ChatStatusPlanApproval:      "Enter/y 批准并执行 · n/Esc 继续规划 · PgUp/PgDn/Ctrl+Home/End 滚动",
 	PlanApprovalPrompt:          "计划已生成（见上方）— Enter/y 批准执行,n/Esc 继续规划",
 	ChatStatusToolApproval:      "1 本次允许 · 2 本会话允许此范围 · 提供时 3/4 为前缀或保存 · n/Esc 拒绝 · Ctrl-C 取消本轮",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -50,6 +50,7 @@ var ChineseTraditional = Messages{
 	ChatStatusCycleHint:         "shift+tab 循環切換",
 	ChatStatusCacheNowFmt:       "本次命中 %s",
 	ChatStatusCacheAvgFmt:       "平均 %s",
+	ChatStatusSessionCostFmt:    "花費 %s",
 	ChatStatusPlanApproval:      "Enter/y 核准並執行 · n/Esc 繼續規劃 · PgUp/PgDn 捲動",
 	PlanApprovalPrompt:          "計畫已生成（見上方）— Enter/y 核准執行,n/Esc 繼續規劃",
 	ChatStatusToolApproval:      "1 本次允許 · 2 本會話允許此範圍 · 提供時 3/4 為前綴或儲存 · n/Esc 拒絕 · Ctrl-C 取消本輪",


### PR DESCRIPTION
## 做了什么
TUI 底部状态栏(余额旁)增加「本 session 累计花费」,形如 `花费 ¥0.0123`。

## 实现
- `internal/cli/chat_tui.go`:`sessionCost`/`sessionCostSymbol` 字段;`event.Usage` 里经 `Pricing.Cost` 累加;新增 `costTag()`;`View()` 与 `computeStatusLineCount()` 两处 append。
- `internal/i18n/`:`ChatStatusSessionCostFmt`(zh「花费 %s」/ zh_tw「花費 %s」/ en「spent %s」)。

## 口径
本次运行累计(进程级),resume 不含历史;符号随 `Pricing.Symbol()`;`sessionCost≤0` 不显示。

## 效果截图

<img width="1062" height="925" alt="image" src="https://github.com/user-attachments/assets/5873e519-c95b-4348-9a47-1f18a6fe63b3" />
