### PR TITLE
Feat: Add Agent Teams, Subagents, Agent View, and Usage Tracking support

### DIFF
--- a/internal/agentteam/agentteam_test.go
+++ b/internal/agentteam/agentteam_test.go
@@ -1,0 +1,275 @@
+package agentteam
+
+import (
+	"testing"
+)
+
+func TestNewTeam(t *testing.T) {
+	team := NewTeam("test-team", "/workspace")
+	if team.Name() != "test-team" {
+		t.Errorf("expected name 'test-team', got %q", team.Name())
+	}
+	if team.Status() != TeamActive {
+		t.Errorf("expected status active, got %s", team.Status())
+	}
+	if team.Workspace() != "/workspace" {
+		t.Errorf("expected workspace /workspace, got %q", team.Workspace())
+	}
+}
+
+func TestTeamMembers(t *testing.T) {
+	team := NewTeam("test-team", "/workspace")
+
+	member := TeamMember{
+		ID:   "member-1",
+		Name: "Alice",
+		Role: "developer",
+	}
+
+	team.AddMember(member)
+	members := team.Members()
+	if len(members) != 1 {
+		t.Errorf("expected 1 member, got %d", len(members))
+	}
+	if members[0].Name != "Alice" {
+		t.Errorf("expected member name Alice, got %s", members[0].Name)
+	}
+
+	got, ok := team.GetMember("member-1")
+	if !ok {
+		t.Error("should find member-1")
+	}
+	if got.Role != "developer" {
+		t.Errorf("expected role developer, got %s", got.Role)
+	}
+
+	team.UpdateMemberStatus("member-1", "working")
+	got, _ = team.GetMember("member-1")
+	if got.Status != "working" {
+		t.Errorf("expected status working, got %s", got.Status)
+	}
+
+	team.RemoveMember("member-1")
+	if len(team.Members()) != 0 {
+		t.Errorf("expected 0 members after removal, got %d", len(team.Members()))
+	}
+}
+
+func TestTeamDescription(t *testing.T) {
+	team := NewTeam("test-team", "/workspace")
+	team.SetDescription("A test team")
+	if team.Description() != "A test team" {
+		t.Errorf("expected description 'A test team', got %q", team.Description())
+	}
+}
+
+func TestTeamLead(t *testing.T) {
+	team := NewTeam("test-team", "/workspace")
+	team.SetLead("lead-1")
+	if team.LeadID() != "lead-1" {
+		t.Errorf("expected lead ID 'lead-1', got %q", team.LeadID())
+	}
+}
+
+func TestTaskList(t *testing.T) {
+	tl := NewTaskList("")
+
+	id, err := tl.Create(Task{
+		Title:       "Test task",
+		Description: "A test task",
+		Priority:    5,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty task ID")
+	}
+
+	if tl.Len() != 1 {
+		t.Errorf("expected 1 task, got %d", tl.Len())
+	}
+
+	task, ok := tl.Get(id)
+	if !ok {
+		t.Fatal("should find task by ID")
+	}
+	if task.Title != "Test task" {
+		t.Errorf("expected title 'Test task', got %q", task.Title)
+	}
+	if task.Status != TaskPending {
+		t.Errorf("expected status pending, got %s", task.Status)
+	}
+
+	err = tl.Update(id, Task{Status: TaskInProgress, Assignee: "alice"})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	task, _ = tl.Get(id)
+	if task.Status != TaskInProgress {
+		t.Errorf("expected status in_progress, got %s", task.Status)
+	}
+	if task.Assignee != "alice" {
+		t.Errorf("expected assignee alice, got %s", task.Assignee)
+	}
+
+	pending := tl.ByStatus(TaskPending)
+	if len(pending) != 0 {
+		t.Errorf("expected 0 pending tasks, got %d", len(pending))
+	}
+
+	inProgress := tl.ByStatus(TaskInProgress)
+	if len(inProgress) != 1 {
+		t.Errorf("expected 1 in_progress task, got %d", len(inProgress))
+	}
+
+	byAssignee := tl.ByAssignee("alice")
+	if len(byAssignee) != 1 {
+		t.Errorf("expected 1 task for alice, got %d", len(byAssignee))
+	}
+
+	err = tl.Delete(id)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if tl.Len() != 0 {
+		t.Errorf("expected 0 tasks after delete, got %d", tl.Len())
+	}
+}
+
+func TestTaskDependencies(t *testing.T) {
+	tl := NewTaskList("")
+
+	id1, _ := tl.Create(Task{Title: "Task 1"})
+	id2, _ := tl.Create(Task{Title: "Task 2", Dependencies: []string{id1}})
+
+	task2, _ := tl.Get(id2)
+	if len(task2.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(task2.Dependencies))
+	}
+
+	claimed, ok := tl.Claim("worker-1")
+	if !ok {
+		t.Fatal("should be able to claim task 1")
+	}
+	if claimed.ID != id1 {
+		t.Errorf("expected to claim task 1 first, got %s", claimed.ID)
+	}
+
+	err := tl.Update(id1, Task{Status: TaskCompleted})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	claimed2, ok := tl.Claim("worker-2")
+	if !ok {
+		t.Fatal("should be able to claim task 2 after task 1 is done")
+	}
+	if claimed2.ID != id2 {
+		t.Errorf("expected to claim task 2, got %s", claimed2.ID)
+	}
+}
+
+func TestMailbox(t *testing.T) {
+	mb := NewMailbox("")
+
+	id, err := mb.Send("alice", "bob", "Hello", "How are you?", "chat")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty message ID")
+	}
+
+	inbox := mb.Inbox("bob")
+	if len(inbox) != 1 {
+		t.Errorf("expected 1 message in bob's inbox, got %d", len(inbox))
+	}
+	if inbox[0].Subject != "Hello" {
+		t.Errorf("expected subject 'Hello', got %q", inbox[0].Subject)
+	}
+
+	unread := mb.Unread("bob")
+	if len(unread) != 1 {
+		t.Errorf("expected 1 unread for bob, got %d", len(unread))
+	}
+
+	mb.MarkRead(id)
+	unread = mb.Unread("bob")
+	if len(unread) != 0 {
+		t.Errorf("expected 0 unread after marking read, got %d", len(unread))
+	}
+
+	_, err = mb.Broadcast("alice", "Announcement", "Team meeting at 3pm")
+	if err != nil {
+		t.Fatalf("Broadcast failed: %v", err)
+	}
+
+	inboxAll := mb.Inbox("charlie")
+	if len(inboxAll) != 1 {
+		t.Errorf("expected 1 broadcast in charlie's inbox, got %d", len(inboxAll))
+	}
+
+	count := mb.UnreadCount("bob")
+	if count != 1 {
+		t.Errorf("expected 1 unread count for bob (broadcast), got %d", count)
+	}
+
+	mb.MarkAllRead("bob")
+	count = mb.UnreadCount("bob")
+	if count != 0 {
+		t.Errorf("expected 0 unread after MarkAllRead, got %d", count)
+	}
+}
+
+func TestManager(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewManager(tmpDir)
+
+	team, err := mgr.CreateTeam("test-team", "/workspace")
+	if err != nil {
+		t.Fatalf("CreateTeam failed: %v", err)
+	}
+	if team.Name() != "test-team" {
+		t.Errorf("expected team name 'test-team', got %q", team.Name())
+	}
+
+	teams := mgr.ListTeams()
+	if len(teams) != 1 {
+		t.Errorf("expected 1 team, got %d", len(teams))
+	}
+
+	got, ok := mgr.GetTeam("test-team")
+	if !ok {
+		t.Fatal("should find test-team")
+	}
+	if got.Workspace() != "/workspace" {
+		t.Errorf("expected workspace /workspace, got %q", got.Workspace())
+	}
+
+	tl, err := mgr.GetTaskList("test-team")
+	if err != nil {
+		t.Fatalf("GetTaskList failed: %v", err)
+	}
+	if tl.Len() != 0 {
+		t.Errorf("expected 0 tasks in new team, got %d", tl.Len())
+	}
+
+	mbox, err := mgr.GetMailbox("test-team")
+	if err != nil {
+		t.Fatalf("GetMailbox failed: %v", err)
+	}
+	if mbox.UnreadCount("anyone") != 0 {
+		t.Error("expected 0 unread messages in new mailbox")
+	}
+
+	err = mgr.DeleteTeam("test-team")
+	if err != nil {
+		t.Fatalf("DeleteTeam failed: %v", err)
+	}
+	teams = mgr.ListTeams()
+	if len(teams) != 0 {
+		t.Errorf("expected 0 teams after deletion, got %d", len(teams))
+	}
+}

--- a/internal/agentteam/mailbox.go
+++ b/internal/agentteam/mailbox.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/fileutil"
 )
 
+// Message 表示邮箱中的一条消息。
 type Message struct {
 	ID        string    `json:"id"`
 	From      string    `json:"from"`
@@ -24,12 +25,14 @@ type Message struct {
 	Type      string    `json:"type"`
 }
 
+// Mailbox 表示团队的消息邮箱。
 type Mailbox struct {
 	dir      string
 	mu       sync.RWMutex
 	messages []*Message
 }
 
+// NewMailbox 创建一个新的邮箱。
 func NewMailbox(dir string) *Mailbox {
 	return &Mailbox{
 		dir:      dir,
@@ -37,6 +40,7 @@ func NewMailbox(dir string) *Mailbox {
 	}
 }
 
+// LoadMailbox 从指定目录加载邮箱。
 func LoadMailbox(dir string) (*Mailbox, error) {
 	mb := NewMailbox(dir)
 	msgsPath := filepath.Join(dir, "messages.json")
@@ -85,6 +89,7 @@ func (mb *Mailbox) save() error {
 	return fileutil.ReplaceFile(tmpPath, path)
 }
 
+// Send 发送一条消息并返回消息 ID。
 func (mb *Mailbox) Send(from, to, subject, content, msgType string) (string, error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
@@ -109,6 +114,7 @@ func (mb *Mailbox) Send(from, to, subject, content, msgType string) (string, err
 	return msg.ID, nil
 }
 
+// Inbox 获取指定成员的收件箱消息列表。
 func (mb *Mailbox) Inbox(memberID string) []Message {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -125,6 +131,7 @@ func (mb *Mailbox) Inbox(memberID string) []Message {
 	return out
 }
 
+// Unread 获取指定成员的未读消息列表。
 func (mb *Mailbox) Unread(memberID string) []Message {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -141,6 +148,7 @@ func (mb *Mailbox) Unread(memberID string) []Message {
 	return out
 }
 
+// MarkRead 将指定消息标记为已读。
 func (mb *Mailbox) MarkRead(msgID string) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
@@ -153,6 +161,7 @@ func (mb *Mailbox) MarkRead(msgID string) {
 	_ = mb.save()
 }
 
+// MarkAllRead 将指定成员的所有消息标记为已读。
 func (mb *Mailbox) MarkAllRead(memberID string) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
@@ -165,6 +174,7 @@ func (mb *Mailbox) MarkAllRead(memberID string) {
 	_ = mb.save()
 }
 
+// Sent 获取指定成员发送的消息列表。
 func (mb *Mailbox) Sent(from string) []Message {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -181,6 +191,7 @@ func (mb *Mailbox) Sent(from string) []Message {
 	return out
 }
 
+// Get 根据消息 ID 获取消息的副本。
 func (mb *Mailbox) Get(msgID string) (*Message, bool) {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -194,6 +205,7 @@ func (mb *Mailbox) Get(msgID string) (*Message, bool) {
 	return nil, false
 }
 
+// UnreadCount 获取指定成员的未读消息数量。
 func (mb *Mailbox) UnreadCount(memberID string) int {
 	mb.mu.RLock()
 	defer mb.mu.RUnlock()
@@ -207,6 +219,7 @@ func (mb *Mailbox) UnreadCount(memberID string) int {
 	return count
 }
 
+// Broadcast 向所有成员广播一条消息。
 func (mb *Mailbox) Broadcast(from, subject, content string) (string, error) {
 	return mb.Send(from, "all", subject, content, "broadcast")
 }

--- a/internal/agentteam/mailbox.go
+++ b/internal/agentteam/mailbox.go
@@ -62,9 +62,7 @@ func (mb *Mailbox) save() error {
 	if err := os.MkdirAll(mb.dir, 0o755); err != nil {
 		return err
 	}
-	mb.mu.RLock()
 	data, err := json.MarshalIndent(mb.messages, "", "  ")
-	mb.mu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/internal/agentteam/mailbox.go
+++ b/internal/agentteam/mailbox.go
@@ -1,0 +1,214 @@
+package agentteam
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+type Message struct {
+	ID        string    `json:"id"`
+	From      string    `json:"from"`
+	To        string    `json:"to"`
+	Subject   string    `json:"subject"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+	Read      bool      `json:"read"`
+	Type      string    `json:"type"`
+}
+
+type Mailbox struct {
+	dir      string
+	mu       sync.RWMutex
+	messages []*Message
+}
+
+func NewMailbox(dir string) *Mailbox {
+	return &Mailbox{
+		dir:      dir,
+		messages: []*Message{},
+	}
+}
+
+func LoadMailbox(dir string) (*Mailbox, error) {
+	mb := NewMailbox(dir)
+	msgsPath := filepath.Join(dir, "messages.json")
+	data, err := os.ReadFile(msgsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return mb, nil
+		}
+		return nil, fmt.Errorf("read mailbox: %w", err)
+	}
+	var msgs []*Message
+	if err := json.Unmarshal(data, &msgs); err != nil {
+		return nil, fmt.Errorf("parse mailbox: %w", err)
+	}
+	mb.messages = msgs
+	return mb, nil
+}
+
+func (mb *Mailbox) save() error {
+	if strings.TrimSpace(mb.dir) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(mb.dir, 0o755); err != nil {
+		return err
+	}
+	mb.mu.RLock()
+	data, err := json.MarshalIndent(mb.messages, "", "  ")
+	mb.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := filepath.Join(mb.dir, "messages.json")
+	tmp, err := os.CreateTemp(mb.dir, ".mailbox-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, path)
+}
+
+func (mb *Mailbox) Send(from, to, subject, content, msgType string) (string, error) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	msg := &Message{
+		ID:        fmt.Sprintf("msg_%d", time.Now().UnixNano()),
+		From:      from,
+		To:        to,
+		Subject:   subject,
+		Content:   content,
+		CreatedAt: time.Now().UTC(),
+		Read:      false,
+		Type:      msgType,
+	}
+
+	mb.messages = append(mb.messages, msg)
+
+	if err := mb.save(); err != nil {
+		return "", err
+	}
+
+	return msg.ID, nil
+}
+
+func (mb *Mailbox) Inbox(memberID string) []Message {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	var out []Message
+	for _, msg := range mb.messages {
+		if msg.To == memberID || msg.To == "all" {
+			out = append(out, *msg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out
+}
+
+func (mb *Mailbox) Unread(memberID string) []Message {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	var out []Message
+	for _, msg := range mb.messages {
+		if !msg.Read && (msg.To == memberID || msg.To == "all") {
+			out = append(out, *msg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out
+}
+
+func (mb *Mailbox) MarkRead(msgID string) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	for _, msg := range mb.messages {
+		if msg.ID == msgID {
+			msg.Read = true
+		}
+	}
+	_ = mb.save()
+}
+
+func (mb *Mailbox) MarkAllRead(memberID string) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	for _, msg := range mb.messages {
+		if msg.To == memberID || msg.To == "all" {
+			msg.Read = true
+		}
+	}
+	_ = mb.save()
+}
+
+func (mb *Mailbox) Sent(from string) []Message {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	var out []Message
+	for _, msg := range mb.messages {
+		if msg.From == from {
+			out = append(out, *msg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out
+}
+
+func (mb *Mailbox) Get(msgID string) (*Message, bool) {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	for _, msg := range mb.messages {
+		if msg.ID == msgID {
+			copy := *msg
+			return &copy, true
+		}
+	}
+	return nil, false
+}
+
+func (mb *Mailbox) UnreadCount(memberID string) int {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	count := 0
+	for _, msg := range mb.messages {
+		if !msg.Read && (msg.To == memberID || msg.To == "all") {
+			count++
+		}
+	}
+	return count
+}
+
+func (mb *Mailbox) Broadcast(from, subject, content string) (string, error) {
+	return mb.Send(from, "all", subject, content, "broadcast")
+}

--- a/internal/agentteam/manager.go
+++ b/internal/agentteam/manager.go
@@ -8,12 +8,14 @@ import (
 	"sync"
 )
 
+// Manager 管理多个团队及其相关资源。
 type Manager struct {
 	baseDir string
 	mu      sync.RWMutex
 	teams   map[string]*Team
 }
 
+// NewManager 创建一个新的团队管理器。
 func NewManager(baseDir string) *Manager {
 	return &Manager{
 		baseDir: baseDir,
@@ -50,6 +52,7 @@ func sanitizeName(name string) string {
 	return result
 }
 
+// CreateTeam 创建一个新的团队。
 func (m *Manager) CreateTeam(name, workspace string) (*Team, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -72,6 +75,7 @@ func (m *Manager) CreateTeam(name, workspace string) (*Team, error) {
 	return team, nil
 }
 
+// GetTeam 根据名称获取团队。
 func (m *Manager) GetTeam(name string) (*Team, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -94,6 +98,7 @@ func (m *Manager) GetTeam(name string) (*Team, bool) {
 	return team, true
 }
 
+// ListTeams 列出所有团队的名称。
 func (m *Manager) ListTeams() []string {
 	teamsDir := filepath.Join(m.baseDir, "teams")
 	entries, err := os.ReadDir(teamsDir)
@@ -113,6 +118,7 @@ func (m *Manager) ListTeams() []string {
 	return names
 }
 
+// DeleteTeam 删除指定名称的团队及其所有资源。
 func (m *Manager) DeleteTeam(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -132,16 +138,19 @@ func (m *Manager) DeleteTeam(name string) error {
 	return nil
 }
 
+// GetTaskList 获取指定团队的任务列表。
 func (m *Manager) GetTaskList(teamName string) (*TaskList, error) {
 	taskDir := m.taskDir(teamName)
 	return LoadTaskList(taskDir)
 }
 
+// GetMailbox 获取指定团队的邮箱。
 func (m *Manager) GetMailbox(teamName string) (*Mailbox, error) {
 	mboxDir := m.mailboxDir(teamName)
 	return LoadMailbox(mboxDir)
 }
 
+// SaveTaskList 保存指定团队的所有任务。
 func (m *Manager) SaveTaskList(teamName string, tl *TaskList) error {
 	for _, task := range tl.List() {
 		t := task

--- a/internal/agentteam/manager.go
+++ b/internal/agentteam/manager.go
@@ -1,0 +1,152 @@
+package agentteam
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type Manager struct {
+	baseDir string
+	mu      sync.RWMutex
+	teams   map[string]*Team
+}
+
+func NewManager(baseDir string) *Manager {
+	return &Manager{
+		baseDir: baseDir,
+		teams:   map[string]*Team{},
+	}
+}
+
+func (m *Manager) teamDir(name string) string {
+	return filepath.Join(m.baseDir, "teams", sanitizeName(name))
+}
+
+func (m *Manager) taskDir(teamName string) string {
+	return filepath.Join(m.baseDir, "tasks", sanitizeName(teamName))
+}
+
+func (m *Manager) mailboxDir(teamName string) string {
+	return filepath.Join(m.baseDir, "mailboxes", sanitizeName(teamName))
+}
+
+func sanitizeName(name string) string {
+	name = strings.TrimSpace(name)
+	var sb strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			sb.WriteRune(r)
+		} else {
+			sb.WriteRune('_')
+		}
+	}
+	result := sb.String()
+	if result == "" {
+		result = "unnamed"
+	}
+	return result
+}
+
+func (m *Manager) CreateTeam(name, workspace string) (*Team, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("team name is required")
+	}
+
+	teamDir := m.teamDir(name)
+	if _, err := os.Stat(teamDir); err == nil {
+		return nil, fmt.Errorf("team %q already exists", name)
+	}
+
+	team := NewTeam(name, workspace)
+	if err := team.Save(teamDir); err != nil {
+		return nil, fmt.Errorf("save team: %w", err)
+	}
+
+	m.teams[strings.ToLower(name)] = team
+	return team, nil
+}
+
+func (m *Manager) GetTeam(name string) (*Team, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	team, ok := m.teams[strings.ToLower(name)]
+	if ok {
+		return team, true
+	}
+
+	teamDir := m.teamDir(name)
+	if _, err := os.Stat(teamDir); os.IsNotExist(err) {
+		return nil, false
+	}
+
+	team, err := LoadTeam(teamDir)
+	if err != nil {
+		return nil, false
+	}
+	m.teams[strings.ToLower(name)] = team
+	return team, true
+}
+
+func (m *Manager) ListTeams() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	teamsDir := filepath.Join(m.baseDir, "teams")
+	entries, err := os.ReadDir(teamsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return nil
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	return names
+}
+
+func (m *Manager) DeleteTeam(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.teams, strings.ToLower(name))
+
+	teamDir := m.teamDir(name)
+	taskDir := m.taskDir(name)
+	mailboxDir := m.mailboxDir(name)
+
+	for _, dir := range []string{teamDir, taskDir, mailboxDir} {
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("remove team dir %q: %w", dir, err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) GetTaskList(teamName string) (*TaskList, error) {
+	taskDir := m.taskDir(teamName)
+	return LoadTaskList(taskDir)
+}
+
+func (m *Manager) GetMailbox(teamName string) (*Mailbox, error) {
+	mboxDir := m.mailboxDir(teamName)
+	return LoadMailbox(mboxDir)
+}
+
+func (m *Manager) SaveTaskList(teamName string, tl *TaskList) error {
+	_ = teamName
+	_ = tl
+	return nil
+}

--- a/internal/agentteam/manager.go
+++ b/internal/agentteam/manager.go
@@ -95,9 +95,6 @@ func (m *Manager) GetTeam(name string) (*Team, bool) {
 }
 
 func (m *Manager) ListTeams() []string {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	teamsDir := filepath.Join(m.baseDir, "teams")
 	entries, err := os.ReadDir(teamsDir)
 	if err != nil {
@@ -146,7 +143,11 @@ func (m *Manager) GetMailbox(teamName string) (*Mailbox, error) {
 }
 
 func (m *Manager) SaveTaskList(teamName string, tl *TaskList) error {
-	_ = teamName
-	_ = tl
+	for _, task := range tl.List() {
+		t := task
+		if err := tl.SaveTask(&t); err != nil {
+			return fmt.Errorf("save task %q: %w", task.ID, err)
+		}
+	}
 	return nil
 }

--- a/internal/agentteam/task.go
+++ b/internal/agentteam/task.go
@@ -13,39 +13,48 @@ import (
 	"reasonix/internal/fileutil"
 )
 
+// TaskStatus 表示任务的状态。
 type TaskStatus string
 
 const (
-	TaskPending    TaskStatus = "pending"
+	// TaskPending 表示任务等待处理。
+	TaskPending TaskStatus = "pending"
+	// TaskInProgress 表示任务正在进行中。
 	TaskInProgress TaskStatus = "in_progress"
-	TaskCompleted  TaskStatus = "completed"
-	TaskFailed     TaskStatus = "failed"
-	TaskCancelled  TaskStatus = "cancelled"
+	// TaskCompleted 表示任务已完成。
+	TaskCompleted TaskStatus = "completed"
+	// TaskFailed 表示任务执行失败。
+	TaskFailed TaskStatus = "failed"
+	// TaskCancelled 表示任务已取消。
+	TaskCancelled TaskStatus = "cancelled"
 )
 
+// Task 表示一个任务项。
 type Task struct {
-	ID          string     `json:"id"`
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	Status      TaskStatus `json:"status"`
-	Assignee    string     `json:"assignee"`
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
-	CompletedAt *time.Time `json:"completed_at,omitempty"`
-	Dependencies []string  `json:"dependencies"`
-	Output      string     `json:"output,omitempty"`
-	Priority    int        `json:"priority"`
-	Tags        []string   `json:"tags,omitempty"`
-	lockFile    string     `json:"-"`
+	ID           string     `json:"id"`
+	Title        string     `json:"title"`
+	Description  string     `json:"description"`
+	Status       TaskStatus `json:"status"`
+	Assignee     string     `json:"assignee"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	Dependencies []string   `json:"dependencies"`
+	Output       string     `json:"output,omitempty"`
+	Priority     int        `json:"priority"`
+	Tags         []string   `json:"tags,omitempty"`
+	lockFile     string     `json:"-"`
 }
 
+// TaskList 表示任务列表，提供任务的增删改查和管理功能。
 type TaskList struct {
-	dir  string
-	mu   sync.RWMutex
+	dir   string
+	mu    sync.RWMutex
 	tasks map[string]*Task
 	order []string
 }
 
+// NewTaskList 创建一个新的任务列表。
 func NewTaskList(dir string) *TaskList {
 	return &TaskList{
 		dir:   dir,
@@ -54,6 +63,7 @@ func NewTaskList(dir string) *TaskList {
 	}
 }
 
+// LoadTaskList 从指定目录加载任务列表。
 func LoadTaskList(dir string) (*TaskList, error) {
 	tl := NewTaskList(dir)
 	entries, err := os.ReadDir(dir)
@@ -101,6 +111,7 @@ func loadTask(path string) (*Task, error) {
 	return &t, nil
 }
 
+// SaveTask 将单个任务保存到磁盘。
 func (tl *TaskList) SaveTask(t *Task) error {
 	if strings.TrimSpace(tl.dir) == "" {
 		return nil
@@ -131,6 +142,7 @@ func (tl *TaskList) SaveTask(t *Task) error {
 	return fileutil.ReplaceFile(tmpPath, path)
 }
 
+// Create 创建一个新任务并保存。
 func (tl *TaskList) Create(task Task) (string, error) {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
@@ -159,6 +171,7 @@ func (tl *TaskList) Create(task Task) (string, error) {
 	return task.ID, nil
 }
 
+// Get 根据 ID 获取任务的副本。
 func (tl *TaskList) Get(id string) (*Task, bool) {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()
@@ -170,6 +183,7 @@ func (tl *TaskList) Get(id string) (*Task, bool) {
 	return &copy, true
 }
 
+// List 返回所有任务的列表。
 func (tl *TaskList) List() []Task {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()
@@ -182,6 +196,7 @@ func (tl *TaskList) List() []Task {
 	return out
 }
 
+// Update 更新指定任务的字段。
 func (tl *TaskList) Update(id string, updates Task) error {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
@@ -224,6 +239,7 @@ func (tl *TaskList) Update(id string, updates Task) error {
 	return tl.SaveTask(t)
 }
 
+// Delete 删除指定 ID 的任务。
 func (tl *TaskList) Delete(id string) error {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
@@ -250,6 +266,7 @@ func (tl *TaskList) Delete(id string) error {
 	return nil
 }
 
+// Claim 认领一个待处理的任务并分配给指定成员。
 func (tl *TaskList) Claim(memberID string) (*Task, bool) {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
@@ -284,6 +301,7 @@ func (tl *TaskList) dependenciesSatisfied(t *Task) bool {
 	return true
 }
 
+// ByStatus 按状态筛选任务。
 func (tl *TaskList) ByStatus(status TaskStatus) []Task {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()
@@ -296,6 +314,7 @@ func (tl *TaskList) ByStatus(status TaskStatus) []Task {
 	return out
 }
 
+// ByAssignee 按负责人筛选任务。
 func (tl *TaskList) ByAssignee(memberID string) []Task {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()
@@ -308,6 +327,7 @@ func (tl *TaskList) ByAssignee(memberID string) []Task {
 	return out
 }
 
+// CountByStatus 统计指定状态的任务数量。
 func (tl *TaskList) CountByStatus(status TaskStatus) int {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()
@@ -320,6 +340,7 @@ func (tl *TaskList) CountByStatus(status TaskStatus) int {
 	return count
 }
 
+// Len 返回任务总数。
 func (tl *TaskList) Len() int {
 	tl.mu.RLock()
 	defer tl.mu.RUnlock()

--- a/internal/agentteam/task.go
+++ b/internal/agentteam/task.go
@@ -101,7 +101,7 @@ func loadTask(path string) (*Task, error) {
 	return &t, nil
 }
 
-func (tl *TaskList) saveTask(t *Task) error {
+func (tl *TaskList) SaveTask(t *Task) error {
 	if strings.TrimSpace(tl.dir) == "" {
 		return nil
 	}
@@ -152,7 +152,7 @@ func (tl *TaskList) Create(task Task) (string, error) {
 	tl.tasks[task.ID] = &task
 	tl.order = append(tl.order, task.ID)
 
-	if err := tl.saveTask(&task); err != nil {
+	if err := tl.SaveTask(&task); err != nil {
 		return "", err
 	}
 
@@ -221,7 +221,7 @@ func (tl *TaskList) Update(id string, updates Task) error {
 	}
 	t.UpdatedAt = time.Now().UTC()
 
-	return tl.saveTask(t)
+	return tl.SaveTask(t)
 }
 
 func (tl *TaskList) Delete(id string) error {
@@ -265,7 +265,7 @@ func (tl *TaskList) Claim(memberID string) (*Task, bool) {
 		t.Status = TaskInProgress
 		t.Assignee = memberID
 		t.UpdatedAt = time.Now().UTC()
-		if err := tl.saveTask(t); err != nil {
+		if err := tl.SaveTask(t); err != nil {
 			return nil, false
 		}
 		copy := *t

--- a/internal/agentteam/task.go
+++ b/internal/agentteam/task.go
@@ -1,0 +1,327 @@
+package agentteam
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+type TaskStatus string
+
+const (
+	TaskPending    TaskStatus = "pending"
+	TaskInProgress TaskStatus = "in_progress"
+	TaskCompleted  TaskStatus = "completed"
+	TaskFailed     TaskStatus = "failed"
+	TaskCancelled  TaskStatus = "cancelled"
+)
+
+type Task struct {
+	ID          string     `json:"id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Status      TaskStatus `json:"status"`
+	Assignee    string     `json:"assignee"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	Dependencies []string  `json:"dependencies"`
+	Output      string     `json:"output,omitempty"`
+	Priority    int        `json:"priority"`
+	Tags        []string   `json:"tags,omitempty"`
+	lockFile    string     `json:"-"`
+}
+
+type TaskList struct {
+	dir  string
+	mu   sync.RWMutex
+	tasks map[string]*Task
+	order []string
+}
+
+func NewTaskList(dir string) *TaskList {
+	return &TaskList{
+		dir:   dir,
+		tasks: map[string]*Task{},
+		order: []string{},
+	}
+}
+
+func LoadTaskList(dir string) (*TaskList, error) {
+	tl := NewTaskList(dir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return tl, nil
+		}
+		return nil, fmt.Errorf("read task directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		if id == "" {
+			continue
+		}
+		task, err := loadTask(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		tl.tasks[id] = task
+		tl.order = append(tl.order, id)
+	}
+	sort.Slice(tl.order, func(i, j int) bool {
+		ti := tl.tasks[tl.order[i]]
+		tj := tl.tasks[tl.order[j]]
+		if ti.Priority != tj.Priority {
+			return ti.Priority > tj.Priority
+		}
+		return ti.CreatedAt.Before(tj.CreatedAt)
+	})
+	return tl, nil
+}
+
+func loadTask(path string) (*Task, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var t Task
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (tl *TaskList) saveTask(t *Task) error {
+	if strings.TrimSpace(tl.dir) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(tl.dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := filepath.Join(tl.dir, t.ID+".json")
+	tmp, err := os.CreateTemp(tl.dir, ".task-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, path)
+}
+
+func (tl *TaskList) Create(task Task) (string, error) {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+
+	if strings.TrimSpace(task.ID) == "" {
+		task.ID = fmt.Sprintf("task_%d", time.Now().UnixNano())
+	}
+	if task.Status == "" {
+		task.Status = TaskPending
+	}
+	now := time.Now().UTC()
+	task.CreatedAt = now
+	task.UpdatedAt = now
+
+	if _, exists := tl.tasks[task.ID]; exists {
+		return "", fmt.Errorf("task %q already exists", task.ID)
+	}
+
+	tl.tasks[task.ID] = &task
+	tl.order = append(tl.order, task.ID)
+
+	if err := tl.saveTask(&task); err != nil {
+		return "", err
+	}
+
+	return task.ID, nil
+}
+
+func (tl *TaskList) Get(id string) (*Task, bool) {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	t, ok := tl.tasks[id]
+	if !ok {
+		return nil, false
+	}
+	copy := *t
+	return &copy, true
+}
+
+func (tl *TaskList) List() []Task {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	out := make([]Task, 0, len(tl.order))
+	for _, id := range tl.order {
+		if t, ok := tl.tasks[id]; ok {
+			out = append(out, *t)
+		}
+	}
+	return out
+}
+
+func (tl *TaskList) Update(id string, updates Task) error {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+
+	t, ok := tl.tasks[id]
+	if !ok {
+		return fmt.Errorf("task %q not found", id)
+	}
+
+	if updates.Title != "" {
+		t.Title = updates.Title
+	}
+	if updates.Description != "" {
+		t.Description = updates.Description
+	}
+	if updates.Status != "" {
+		t.Status = updates.Status
+		if updates.Status == TaskCompleted {
+			now := time.Now().UTC()
+			t.CompletedAt = &now
+		}
+	}
+	if updates.Assignee != "" {
+		t.Assignee = updates.Assignee
+	}
+	if updates.Output != "" {
+		t.Output = updates.Output
+	}
+	if len(updates.Dependencies) > 0 {
+		t.Dependencies = updates.Dependencies
+	}
+	if updates.Priority != 0 {
+		t.Priority = updates.Priority
+	}
+	if len(updates.Tags) > 0 {
+		t.Tags = updates.Tags
+	}
+	t.UpdatedAt = time.Now().UTC()
+
+	return tl.saveTask(t)
+}
+
+func (tl *TaskList) Delete(id string) error {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+
+	if _, ok := tl.tasks[id]; !ok {
+		return fmt.Errorf("task %q not found", id)
+	}
+
+	delete(tl.tasks, id)
+	for i, tid := range tl.order {
+		if tid == id {
+			tl.order = append(tl.order[:i], tl.order[i+1:]...)
+			break
+		}
+	}
+
+	if strings.TrimSpace(tl.dir) != "" {
+		path := filepath.Join(tl.dir, id+".json")
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (tl *TaskList) Claim(memberID string) (*Task, bool) {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+
+	for _, id := range tl.order {
+		t, ok := tl.tasks[id]
+		if !ok || t.Status != TaskPending {
+			continue
+		}
+		if !tl.dependenciesSatisfied(t) {
+			continue
+		}
+		t.Status = TaskInProgress
+		t.Assignee = memberID
+		t.UpdatedAt = time.Now().UTC()
+		if err := tl.saveTask(t); err != nil {
+			return nil, false
+		}
+		copy := *t
+		return &copy, true
+	}
+	return nil, false
+}
+
+func (tl *TaskList) dependenciesSatisfied(t *Task) bool {
+	for _, depID := range t.Dependencies {
+		dep, ok := tl.tasks[depID]
+		if !ok || dep.Status != TaskCompleted {
+			return false
+		}
+	}
+	return true
+}
+
+func (tl *TaskList) ByStatus(status TaskStatus) []Task {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	var out []Task
+	for _, id := range tl.order {
+		if t, ok := tl.tasks[id]; ok && t.Status == status {
+			out = append(out, *t)
+		}
+	}
+	return out
+}
+
+func (tl *TaskList) ByAssignee(memberID string) []Task {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	var out []Task
+	for _, id := range tl.order {
+		if t, ok := tl.tasks[id]; ok && t.Assignee == memberID {
+			out = append(out, *t)
+		}
+	}
+	return out
+}
+
+func (tl *TaskList) CountByStatus(status TaskStatus) int {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	count := 0
+	for _, t := range tl.tasks {
+		if t.Status == status {
+			count++
+		}
+	}
+	return count
+}
+
+func (tl *TaskList) Len() int {
+	tl.mu.RLock()
+	defer tl.mu.RUnlock()
+	return len(tl.tasks)
+}

--- a/internal/agentteam/team.go
+++ b/internal/agentteam/team.go
@@ -12,14 +12,19 @@ import (
 	"reasonix/internal/fileutil"
 )
 
+// TeamStatus 表示团队的状态。
 type TeamStatus string
 
 const (
-	TeamActive   TeamStatus = "active"
+	// TeamActive 表示团队处于活跃状态。
+	TeamActive TeamStatus = "active"
+	// TeamCleaning 表示团队正在清理中。
 	TeamCleaning TeamStatus = "cleaning"
-	TeamDone     TeamStatus = "done"
+	// TeamDone 表示团队已完成工作。
+	TeamDone TeamStatus = "done"
 )
 
+// TeamMember 表示团队中的一个成员。
 type TeamMember struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -31,6 +36,7 @@ type TeamMember struct {
 	JoinedAt  time.Time `json:"joined_at"`
 }
 
+// TeamConfig 表示团队的配置信息。
 type TeamConfig struct {
 	Name        string       `json:"name"`
 	LeadID      string       `json:"lead_id"`
@@ -42,12 +48,14 @@ type TeamConfig struct {
 	Description string       `json:"description"`
 }
 
+// Team 表示一个团队，包含成员管理和状态跟踪功能。
 type Team struct {
 	config TeamConfig
 	dir    string
 	mu     sync.RWMutex
 }
 
+// NewTeam 创建一个新的团队。
 func NewTeam(name, workspace string) *Team {
 	now := time.Now().UTC()
 	return &Team{
@@ -62,6 +70,7 @@ func NewTeam(name, workspace string) *Team {
 	}
 }
 
+// LoadTeam 从指定目录加载团队配置。
 func LoadTeam(dir string) (*Team, error) {
 	configPath := filepath.Join(dir, "config.json")
 	data, err := os.ReadFile(configPath)
@@ -78,6 +87,7 @@ func LoadTeam(dir string) (*Team, error) {
 	}, nil
 }
 
+// Save 将团队配置保存到指定目录。
 func (t *Team) Save(dir string) error {
 	if strings.TrimSpace(dir) == "" {
 		dir = t.dir
@@ -118,18 +128,21 @@ func (t *Team) Save(dir string) error {
 	return fileutil.ReplaceFile(tmpPath, filepath.Join(dir, "config.json"))
 }
 
+// Name 返回团队名称。
 func (t *Team) Name() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.config.Name
 }
 
+// Status 返回团队状态。
 func (t *Team) Status() TeamStatus {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.config.Status
 }
 
+// SetStatus 设置团队状态。
 func (t *Team) SetStatus(status TeamStatus) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -137,12 +150,14 @@ func (t *Team) SetStatus(status TeamStatus) {
 	t.config.UpdatedAt = time.Now().UTC()
 }
 
+// LeadID 返回团队负责人的 ID。
 func (t *Team) LeadID() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.config.LeadID
 }
 
+// SetLead 设置团队负责人。
 func (t *Team) SetLead(id string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -150,6 +165,7 @@ func (t *Team) SetLead(id string) {
 	t.config.UpdatedAt = time.Now().UTC()
 }
 
+// AddMember 添加或更新团队成员。
 func (t *Team) AddMember(member TeamMember) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -165,6 +181,7 @@ func (t *Team) AddMember(member TeamMember) {
 	t.config.UpdatedAt = time.Now().UTC()
 }
 
+// RemoveMember 从团队中移除指定 ID 的成员。
 func (t *Team) RemoveMember(id string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -178,6 +195,7 @@ func (t *Team) RemoveMember(id string) {
 	t.config.UpdatedAt = time.Now().UTC()
 }
 
+// Members 返回团队所有成员的副本。
 func (t *Team) Members() []TeamMember {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -186,6 +204,7 @@ func (t *Team) Members() []TeamMember {
 	return out
 }
 
+// GetMember 根据 ID 获取团队成员。
 func (t *Team) GetMember(id string) (TeamMember, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -197,6 +216,7 @@ func (t *Team) GetMember(id string) (TeamMember, bool) {
 	return TeamMember{}, false
 }
 
+// UpdateMemberStatus 更新指定成员的状态。
 func (t *Team) UpdateMemberStatus(id, status string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -209,18 +229,21 @@ func (t *Team) UpdateMemberStatus(id, status string) {
 	}
 }
 
+// Workspace 返回团队的工作目录路径。
 func (t *Team) Workspace() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.config.Workspace
 }
 
+// Description 返回团队描述。
 func (t *Team) Description() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.config.Description
 }
 
+// SetDescription 设置团队描述。
 func (t *Team) SetDescription(desc string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -228,6 +251,7 @@ func (t *Team) SetDescription(desc string) {
 	t.config.UpdatedAt = time.Now().UTC()
 }
 
+// Config 返回团队配置的副本。
 func (t *Team) Config() TeamConfig {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/internal/agentteam/team.go
+++ b/internal/agentteam/team.go
@@ -1,0 +1,235 @@
+package agentteam
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+type TeamStatus string
+
+const (
+	TeamActive   TeamStatus = "active"
+	TeamCleaning TeamStatus = "cleaning"
+	TeamDone     TeamStatus = "done"
+)
+
+type TeamMember struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+	AgentType string `json:"agent_type"`
+	Model    string `json:"model"`
+	Status   string `json:"status"`
+	SessionID string `json:"session_id"`
+	JoinedAt time.Time `json:"joined_at"`
+}
+
+type TeamConfig struct {
+	Name        string       `json:"name"`
+	LeadID      string       `json:"lead_id"`
+	Status      TeamStatus   `json:"status"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+	Members     []TeamMember `json:"members"`
+	Workspace   string       `json:"workspace"`
+	Description string       `json:"description"`
+}
+
+type Team struct {
+	config TeamConfig
+	dir    string
+	mu     sync.RWMutex
+}
+
+func NewTeam(name, workspace string) *Team {
+	now := time.Now().UTC()
+	return &Team{
+		config: TeamConfig{
+			Name:      name,
+			Status:    TeamActive,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Members:   []TeamMember{},
+			Workspace: workspace,
+		},
+	}
+}
+
+func LoadTeam(dir string) (*Team, error) {
+	configPath := filepath.Join(dir, "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read team config: %w", err)
+	}
+	var cfg TeamConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse team config: %w", err)
+	}
+	return &Team{
+		config: cfg,
+		dir:    dir,
+	}, nil
+}
+
+func (t *Team) Save(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		dir = t.dir
+	}
+	if strings.TrimSpace(dir) == "" {
+		return fmt.Errorf("team directory is required")
+	}
+	t.dir = dir
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	t.mu.RLock()
+	cfg := t.config
+	cfg.UpdatedAt = time.Now().UTC()
+	t.mu.RUnlock()
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, ".team-config.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, filepath.Join(dir, "config.json"))
+}
+
+func (t *Team) Name() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config.Name
+}
+
+func (t *Team) Status() TeamStatus {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config.Status
+}
+
+func (t *Team) SetStatus(status TeamStatus) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.config.Status = status
+	t.config.UpdatedAt = time.Now().UTC()
+}
+
+func (t *Team) LeadID() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config.LeadID
+}
+
+func (t *Team) SetLead(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.config.LeadID = id
+	t.config.UpdatedAt = time.Now().UTC()
+}
+
+func (t *Team) AddMember(member TeamMember) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	member.JoinedAt = time.Now().UTC()
+	for i, m := range t.config.Members {
+		if m.ID == member.ID {
+			t.config.Members[i] = member
+			t.config.UpdatedAt = time.Now().UTC()
+			return
+		}
+	}
+	t.config.Members = append(t.config.Members, member)
+	t.config.UpdatedAt = time.Now().UTC()
+}
+
+func (t *Team) RemoveMember(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	members := make([]TeamMember, 0, len(t.config.Members))
+	for _, m := range t.config.Members {
+		if m.ID != id {
+			members = append(members, m)
+		}
+	}
+	t.config.Members = members
+	t.config.UpdatedAt = time.Now().UTC()
+}
+
+func (t *Team) Members() []TeamMember {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]TeamMember, len(t.config.Members))
+	copy(out, t.config.Members)
+	return out
+}
+
+func (t *Team) GetMember(id string) (TeamMember, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, m := range t.config.Members {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return TeamMember{}, false
+}
+
+func (t *Team) UpdateMemberStatus(id, status string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i, m := range t.config.Members {
+		if m.ID == id {
+			t.config.Members[i].Status = status
+			t.config.UpdatedAt = time.Now().UTC()
+			return
+		}
+	}
+}
+
+func (t *Team) Workspace() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config.Workspace
+}
+
+func (t *Team) Description() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config.Description
+}
+
+func (t *Team) SetDescription(desc string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.config.Description = desc
+	t.config.UpdatedAt = time.Now().UTC()
+}
+
+func (t *Team) Config() TeamConfig {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.config
+}

--- a/internal/agentteam/team.go
+++ b/internal/agentteam/team.go
@@ -21,14 +21,14 @@ const (
 )
 
 type TeamMember struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Role     string `json:"role"`
-	AgentType string `json:"agent_type"`
-	Model    string `json:"model"`
-	Status   string `json:"status"`
-	SessionID string `json:"session_id"`
-	JoinedAt time.Time `json:"joined_at"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Role      string    `json:"role"`
+	AgentType string    `json:"agent_type"`
+	Model     string    `json:"model"`
+	Status    string    `json:"status"`
+	SessionID string    `json:"session_id"`
+	JoinedAt  time.Time `json:"joined_at"`
 }
 
 type TeamConfig struct {

--- a/internal/agentview/agentview_test.go
+++ b/internal/agentview/agentview_test.go
@@ -1,0 +1,137 @@
+package agentview
+
+import (
+	"testing"
+)
+
+func TestManager(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewManager(tmpDir)
+
+	info, err := mgr.Register("session-1", "Test Session", "/workspace", "deepseek-r1")
+	if err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if info.ID != "session-1" {
+		t.Errorf("expected ID 'session-1', got %q", info.ID)
+	}
+	if info.State != StateWorking {
+		t.Errorf("expected state working, got %s", info.State)
+	}
+
+	got, ok := mgr.Get("session-1")
+	if !ok {
+		t.Fatal("should find session-1")
+	}
+	if got.Name != "Test Session" {
+		t.Errorf("expected name 'Test Session', got %q", got.Name)
+	}
+
+	sessions := mgr.List()
+	if len(sessions) != 1 {
+		t.Errorf("expected 1 session, got %d", len(sessions))
+	}
+
+	mgr.UpdateState("session-1", StateCompleted)
+	got, _ = mgr.Get("session-1")
+	if got.State != StateCompleted {
+		t.Errorf("expected state completed, got %s", got.State)
+	}
+	if got.Running {
+		t.Error("completed session should not be running")
+	}
+
+	mgr.UpdateSummary("session-1", "All done!")
+	got, _ = mgr.Get("session-1")
+	if got.Summary != "All done!" {
+		t.Errorf("expected summary 'All done!', got %q", got.Summary)
+	}
+
+	mgr.Pin("session-1")
+	got, _ = mgr.Get("session-1")
+	if !got.Pinned {
+		t.Error("session should be pinned")
+	}
+
+	mgr.Unpin("session-1")
+	got, _ = mgr.Get("session-1")
+	if got.Pinned {
+		t.Error("session should not be pinned after unpin")
+	}
+
+	mgr.Rename("session-1", "New Name")
+	got, _ = mgr.Get("session-1")
+	if got.Name != "New Name" {
+		t.Errorf("expected name 'New Name', got %q", got.Name)
+	}
+
+	mgr.AddPullRequest("session-1", "PR #123")
+	got, _ = mgr.Get("session-1")
+	if len(got.PullRequests) != 1 {
+		t.Errorf("expected 1 PR, got %d", len(got.PullRequests))
+	}
+
+	completed := mgr.ByState(StateCompleted)
+	if len(completed) != 1 {
+		t.Errorf("expected 1 completed session, got %d", len(completed))
+	}
+
+	if mgr.NeedsInputCount() != 0 {
+		t.Errorf("expected 0 needs_input count, got %d", mgr.NeedsInputCount())
+	}
+
+	byWorkspace := mgr.ListByWorkspace("/workspace")
+	if len(byWorkspace) != 1 {
+		t.Errorf("expected 1 session in workspace, got %d", len(byWorkspace))
+	}
+
+	err = mgr.Remove("session-1")
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if mgr.CountByState(StateCompleted) != 0 {
+		t.Errorf("expected 0 completed after remove, got %d", mgr.CountByState(StateCompleted))
+	}
+}
+
+func TestManager_Load(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewManager(tmpDir)
+
+	_, err := mgr.Register("sess-1", "First", "/workspace", "model-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = mgr.Register("sess-2", "Second", "/other", "model-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.UpdateState("sess-1", StateNeedsInput)
+
+	mgr2 := NewManager(tmpDir)
+	err = mgr2.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	sessions := mgr2.List()
+	if len(sessions) != 2 {
+		t.Errorf("expected 2 loaded sessions, got %d", len(sessions))
+	}
+
+	if mgr2.NeedsInputCount() != 1 {
+		t.Errorf("expected 1 needs_input after load, got %d", mgr2.NeedsInputCount())
+	}
+}
+
+func TestStatePriority(t *testing.T) {
+	if statePriority(StateNeedsInput) != 0 {
+		t.Errorf("needs_input should be priority 0, got %d", statePriority(StateNeedsInput))
+	}
+	if statePriority(StateWorking) != 1 {
+		t.Errorf("working should be priority 1, got %d", statePriority(StateWorking))
+	}
+	if statePriority(StateCompleted) != 4 {
+		t.Errorf("completed should be priority 4, got %d", statePriority(StateCompleted))
+	}
+}

--- a/internal/agentview/manager.go
+++ b/internal/agentview/manager.go
@@ -13,18 +13,27 @@ import (
 	"reasonix/internal/fileutil"
 )
 
+// SessionState represents the current state of an agent session.
 type SessionState string
 
 const (
-	StateWorking   SessionState = "working"
+	// StateWorking indicates the agent is actively processing a task.
+	StateWorking SessionState = "working"
+	// StateNeedsInput indicates the agent is waiting for user input.
 	StateNeedsInput SessionState = "needs_input"
-	StateIdle      SessionState = "idle"
+	// StateIdle indicates the agent is idle and waiting for a task.
+	StateIdle SessionState = "idle"
+	// StateCompleted indicates the agent has successfully completed the task.
 	StateCompleted SessionState = "completed"
-	StateFailed    SessionState = "failed"
-	StateStopped   SessionState = "stopped"
-	StateSleeping  SessionState = "sleeping"
+	// StateFailed indicates the agent has encountered an error and failed.
+	StateFailed SessionState = "failed"
+	// StateStopped indicates the agent was stopped by the user.
+	StateStopped SessionState = "stopped"
+	// StateSleeping indicates the agent is sleeping and will wake up later.
+	StateSleeping SessionState = "sleeping"
 )
 
+// SessionInfo holds metadata about an agent session for display in the agent view.
 type SessionInfo struct {
 	ID           string       `json:"id"`
 	Name         string       `json:"name"`
@@ -41,13 +50,17 @@ type SessionInfo struct {
 	NextWakeAt   *time.Time   `json:"next_wake_at,omitempty"`
 }
 
+// Manager manages agent session information for the agent view.
+// It is thread-safe and persists session data to disk as JSON files.
 type Manager struct {
-	baseDir string
-	mu      sync.RWMutex
+	baseDir  string
+	mu       sync.RWMutex
 	sessions map[string]*SessionInfo
-	order   []string
+	order    []string
 }
 
+// NewManager creates a new Manager instance with the given base directory
+// for storing session data.
 func NewManager(baseDir string) *Manager {
 	return &Manager{
 		baseDir:  baseDir,
@@ -64,6 +77,8 @@ func (m *Manager) statePath(id string) string {
 	return filepath.Join(m.sessionsDir(), id+".json")
 }
 
+// Load reads all session files from disk into memory.
+// It returns an error if the directory cannot be read.
 func (m *Manager) Load() error {
 	dir := m.sessionsDir()
 	entries, err := os.ReadDir(dir)
@@ -164,6 +179,8 @@ func (m *Manager) save(info *SessionInfo) error {
 	return fileutil.ReplaceFile(tmpPath, path)
 }
 
+// Register creates a new session with the given parameters and saves it to disk.
+// It returns the created SessionInfo or an error if saving fails.
 func (m *Manager) Register(id, name, workspace, model string) (*SessionInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -191,6 +208,8 @@ func (m *Manager) Register(id, name, workspace, model string) (*SessionInfo, err
 	return info, nil
 }
 
+// UpdateState updates the state of the session with the given id.
+// It also updates LastActivity and sets Running to false for terminal states.
 func (m *Manager) UpdateState(id string, state SessionState) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -207,6 +226,8 @@ func (m *Manager) UpdateState(id string, state SessionState) {
 	_ = m.save(info)
 }
 
+// UpdateSummary updates the summary of the session with the given id.
+// It also updates LastActivity for the session.
 func (m *Manager) UpdateSummary(id, summary string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -220,6 +241,8 @@ func (m *Manager) UpdateSummary(id, summary string) {
 	_ = m.save(info)
 }
 
+// Get returns a copy of the session info for the given id.
+// The second return value indicates whether the session was found.
 func (m *Manager) Get(id string) (*SessionInfo, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -231,6 +254,8 @@ func (m *Manager) Get(id string) (*SessionInfo, bool) {
 	return &copy, true
 }
 
+// List returns all sessions sorted by state priority and last activity.
+// The returned slice is a copy; modifying it does not affect the manager.
 func (m *Manager) List() []SessionInfo {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -244,6 +269,8 @@ func (m *Manager) List() []SessionInfo {
 	return out
 }
 
+// ListByWorkspace returns all sessions for the given workspace.
+// The returned slice is a copy; modifying it does not affect the manager.
 func (m *Manager) ListByWorkspace(workspace string) []SessionInfo {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -257,6 +284,8 @@ func (m *Manager) ListByWorkspace(workspace string) []SessionInfo {
 	return out
 }
 
+// ByState returns all sessions with the given state.
+// The returned slice is a copy; modifying it does not affect the manager.
 func (m *Manager) ByState(state SessionState) []SessionInfo {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -270,6 +299,7 @@ func (m *Manager) ByState(state SessionState) []SessionInfo {
 	return out
 }
 
+// Pin marks the session with the given id as pinned.
 func (m *Manager) Pin(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -280,6 +310,7 @@ func (m *Manager) Pin(id string) {
 	}
 }
 
+// Unpin removes the pinned mark from the session with the given id.
 func (m *Manager) Unpin(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -290,6 +321,8 @@ func (m *Manager) Unpin(id string) {
 	}
 }
 
+// Rename changes the name of the session with the given id.
+// It also updates LastActivity for the session.
 func (m *Manager) Rename(id, newName string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -301,6 +334,8 @@ func (m *Manager) Rename(id, newName string) {
 	}
 }
 
+// Remove deletes the session with the given id from memory and disk.
+// It returns an error if the session is not found or the file cannot be deleted.
 func (m *Manager) Remove(id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -325,6 +360,7 @@ func (m *Manager) Remove(id string) error {
 	return nil
 }
 
+// CountByState returns the number of sessions with the given state.
 func (m *Manager) CountByState(state SessionState) int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -337,10 +373,13 @@ func (m *Manager) CountByState(state SessionState) int {
 	return count
 }
 
+// NeedsInputCount returns the number of sessions waiting for user input.
 func (m *Manager) NeedsInputCount() int {
 	return m.CountByState(StateNeedsInput)
 }
 
+// AddPullRequest adds a pull request reference to the session with the given id.
+// It also updates LastActivity for the session.
 func (m *Manager) AddPullRequest(id, pr string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/agentview/manager.go
+++ b/internal/agentview/manager.go
@@ -1,0 +1,353 @@
+package agentview
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+type SessionState string
+
+const (
+	StateWorking   SessionState = "working"
+	StateNeedsInput SessionState = "needs_input"
+	StateIdle      SessionState = "idle"
+	StateCompleted SessionState = "completed"
+	StateFailed    SessionState = "failed"
+	StateStopped   SessionState = "stopped"
+	StateSleeping  SessionState = "sleeping"
+)
+
+type SessionInfo struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	State        SessionState `json:"state"`
+	Summary      string       `json:"summary"`
+	LastActivity time.Time    `json:"last_activity"`
+	CreatedAt    time.Time    `json:"created_at"`
+	Workspace    string       `json:"workspace"`
+	Model        string       `json:"model"`
+	Pinned       bool         `json:"pinned"`
+	PullRequests []string     `json:"pull_requests,omitempty"`
+	Running      bool         `json:"running"`
+	LoopCount    int          `json:"loop_count,omitempty"`
+	NextWakeAt   *time.Time   `json:"next_wake_at,omitempty"`
+}
+
+type Manager struct {
+	baseDir string
+	mu      sync.RWMutex
+	sessions map[string]*SessionInfo
+	order   []string
+}
+
+func NewManager(baseDir string) *Manager {
+	return &Manager{
+		baseDir:  baseDir,
+		sessions: map[string]*SessionInfo{},
+		order:    []string{},
+	}
+}
+
+func (m *Manager) sessionsDir() string {
+	return filepath.Join(m.baseDir, "agent-view")
+}
+
+func (m *Manager) statePath(id string) string {
+	return filepath.Join(m.sessionsDir(), id+".json")
+}
+
+func (m *Manager) Load() error {
+	dir := m.sessionsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		if id == "" {
+			continue
+		}
+		info, err := loadSessionInfo(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		m.sessions[id] = info
+		m.order = append(m.order, id)
+	}
+
+	sort.Slice(m.order, func(i, j int) bool {
+		si := m.sessions[m.order[i]]
+		sj := m.sessions[m.order[j]]
+		return statePriority(si.State) < statePriority(sj.State) ||
+			(statePriority(si.State) == statePriority(sj.State) && si.LastActivity.After(sj.LastActivity))
+	})
+
+	return nil
+}
+
+func loadSessionInfo(path string) (*SessionInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var info SessionInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func statePriority(state SessionState) int {
+	switch state {
+	case StateNeedsInput:
+		return 0
+	case StateWorking:
+		return 1
+	case StateSleeping:
+		return 2
+	case StateIdle:
+		return 3
+	case StateCompleted:
+		return 4
+	case StateFailed:
+		return 5
+	case StateStopped:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func (m *Manager) save(info *SessionInfo) error {
+	dir := m.sessionsDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := m.statePath(info.ID)
+	tmp, err := os.CreateTemp(dir, ".agent-session-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, path)
+}
+
+func (m *Manager) Register(id, name, workspace, model string) (*SessionInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now().UTC()
+	info := &SessionInfo{
+		ID:           id,
+		Name:         name,
+		State:        StateWorking,
+		Summary:      "Starting...",
+		LastActivity: now,
+		CreatedAt:    now,
+		Workspace:    workspace,
+		Model:        model,
+		Running:      true,
+	}
+
+	m.sessions[id] = info
+	m.order = append(m.order, id)
+
+	if err := m.save(info); err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+func (m *Manager) UpdateState(id string, state SessionState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info, ok := m.sessions[id]
+	if !ok {
+		return
+	}
+	info.State = state
+	info.LastActivity = time.Now().UTC()
+	if state == StateCompleted || state == StateFailed || state == StateStopped {
+		info.Running = false
+	}
+	_ = m.save(info)
+}
+
+func (m *Manager) UpdateSummary(id, summary string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	info, ok := m.sessions[id]
+	if !ok {
+		return
+	}
+	info.Summary = summary
+	info.LastActivity = time.Now().UTC()
+	_ = m.save(info)
+}
+
+func (m *Manager) Get(id string) (*SessionInfo, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	info, ok := m.sessions[id]
+	if !ok {
+		return nil, false
+	}
+	copy := *info
+	return &copy, true
+}
+
+func (m *Manager) List() []SessionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]SessionInfo, 0, len(m.order))
+	for _, id := range m.order {
+		if info, ok := m.sessions[id]; ok {
+			out = append(out, *info)
+		}
+	}
+	return out
+}
+
+func (m *Manager) ListByWorkspace(workspace string) []SessionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []SessionInfo
+	for _, id := range m.order {
+		if info, ok := m.sessions[id]; ok && info.Workspace == workspace {
+			out = append(out, *info)
+		}
+	}
+	return out
+}
+
+func (m *Manager) ByState(state SessionState) []SessionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []SessionInfo
+	for _, id := range m.order {
+		if info, ok := m.sessions[id]; ok && info.State == state {
+			out = append(out, *info)
+		}
+	}
+	return out
+}
+
+func (m *Manager) Pin(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if info, ok := m.sessions[id]; ok {
+		info.Pinned = true
+		_ = m.save(info)
+	}
+}
+
+func (m *Manager) Unpin(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if info, ok := m.sessions[id]; ok {
+		info.Pinned = false
+		_ = m.save(info)
+	}
+}
+
+func (m *Manager) Rename(id, newName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if info, ok := m.sessions[id]; ok {
+		info.Name = newName
+		info.LastActivity = time.Now().UTC()
+		_ = m.save(info)
+	}
+}
+
+func (m *Manager) Remove(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.sessions[id]; !ok {
+		return fmt.Errorf("session %q not found", id)
+	}
+
+	delete(m.sessions, id)
+	for i, sid := range m.order {
+		if sid == id {
+			m.order = append(m.order[:i], m.order[i+1:]...)
+			break
+		}
+	}
+
+	path := m.statePath(id)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) CountByState(state SessionState) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, info := range m.sessions {
+		if info.State == state {
+			count++
+		}
+	}
+	return count
+}
+
+func (m *Manager) NeedsInputCount() int {
+	return m.CountByState(StateNeedsInput)
+}
+
+func (m *Manager) AddPullRequest(id, pr string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if info, ok := m.sessions[id]; ok {
+		info.PullRequests = append(info.PullRequests, pr)
+		info.LastActivity = time.Now().UTC()
+		_ = m.save(info)
+	}
+}

--- a/internal/subagentdef/definition.go
+++ b/internal/subagentdef/definition.go
@@ -5,29 +5,37 @@ import (
 	"time"
 )
 
+// SubagentDefinition describes a subagent configuration loaded from a
+// Markdown file with YAML frontmatter. It defines the subagent's name,
+// description, allowed tools, model settings, and other behavior parameters.
+// Fields marked with yaml:"-" are runtime metadata not persisted in the
+// definition file.
 type SubagentDefinition struct {
-	Name             string        `yaml:"name"`
-	Description      string        `yaml:"description"`
-	Prompt           string        `yaml:"-"`
-	Tools            []string      `yaml:"tools"`
-	DisallowedTools  []string      `yaml:"disallowed_tools"`
-	Model            string        `yaml:"model"`
-	Effort           string        `yaml:"effort"`
-	PermissionMode   string        `yaml:"permission_mode"`
-	MaxTurns         int           `yaml:"max_turns"`
-	Skills           []string      `yaml:"skills"`
-	MCPServers       []string      `yaml:"mcp_servers"`
-	Background       bool          `yaml:"background"`
-	Isolation        string        `yaml:"isolation"`
-	Color            string        `yaml:"color"`
-	Memory           string        `yaml:"memory"`
-	InitialPrompt    string        `yaml:"initial_prompt"`
-	SourceFile       string        `yaml:"-"`
-	SourceScope      string        `yaml:"-"`
-	CreatedAt        time.Time     `yaml:"-"`
-	UpdatedAt        time.Time     `yaml:"-"`
+	Name            string    `yaml:"name"`
+	Description     string    `yaml:"description"`
+	Prompt          string    `yaml:"-"`
+	Tools           []string  `yaml:"tools"`
+	DisallowedTools []string  `yaml:"disallowed_tools"`
+	Model           string    `yaml:"model"`
+	Effort          string    `yaml:"effort"`
+	PermissionMode  string    `yaml:"permission_mode"`
+	MaxTurns        int       `yaml:"max_turns"`
+	Skills          []string  `yaml:"skills"`
+	MCPServers      []string  `yaml:"mcp_servers"`
+	Background      bool      `yaml:"background"`
+	Isolation       string    `yaml:"isolation"`
+	Color           string    `yaml:"color"`
+	Memory          string    `yaml:"memory"`
+	InitialPrompt   string    `yaml:"initial_prompt"`
+	SourceFile      string    `yaml:"-"`
+	SourceScope     string    `yaml:"-"`
+	CreatedAt       time.Time `yaml:"-"`
+	UpdatedAt       time.Time `yaml:"-"`
 }
 
+// Normalize trims whitespace from all string fields and removes empty
+// entries from slice fields (tools, disallowed tools, skills, mcp servers).
+// Call this after loading a definition to ensure clean data.
 func (d *SubagentDefinition) Normalize() {
 	d.Name = strings.TrimSpace(d.Name)
 	d.Description = strings.TrimSpace(d.Description)
@@ -76,10 +84,16 @@ func (d *SubagentDefinition) Normalize() {
 	d.MCPServers = mcpServers
 }
 
+// Valid reports whether the definition has a non-empty name, which is the
+// minimum required field for a usable subagent definition.
 func (d *SubagentDefinition) Valid() bool {
 	return d.Name != ""
 }
 
+// ToolAllowed reports whether a given tool name is permitted for this
+// subagent. The check is case-insensitive. If the Tools list is empty,
+// all tools are allowed unless explicitly disallowed. DisallowedTools
+// takes precedence over the allowlist.
 func (d *SubagentDefinition) ToolAllowed(toolName string) bool {
 	toolName = strings.TrimSpace(toolName)
 	if toolName == "" {

--- a/internal/subagentdef/definition.go
+++ b/internal/subagentdef/definition.go
@@ -1,0 +1,102 @@
+package subagentdef
+
+import (
+	"strings"
+	"time"
+)
+
+type SubagentDefinition struct {
+	Name             string        `yaml:"name"`
+	Description      string        `yaml:"description"`
+	Prompt           string        `yaml:"-"`
+	Tools            []string      `yaml:"tools"`
+	DisallowedTools  []string      `yaml:"disallowed_tools"`
+	Model            string        `yaml:"model"`
+	Effort           string        `yaml:"effort"`
+	PermissionMode   string        `yaml:"permission_mode"`
+	MaxTurns         int           `yaml:"max_turns"`
+	Skills           []string      `yaml:"skills"`
+	MCPServers       []string      `yaml:"mcp_servers"`
+	Background       bool          `yaml:"background"`
+	Isolation        string        `yaml:"isolation"`
+	Color            string        `yaml:"color"`
+	Memory           string        `yaml:"memory"`
+	InitialPrompt    string        `yaml:"initial_prompt"`
+	SourceFile       string        `yaml:"-"`
+	SourceScope      string        `yaml:"-"`
+	CreatedAt        time.Time     `yaml:"-"`
+	UpdatedAt        time.Time     `yaml:"-"`
+}
+
+func (d *SubagentDefinition) Normalize() {
+	d.Name = strings.TrimSpace(d.Name)
+	d.Description = strings.TrimSpace(d.Description)
+	d.Model = strings.TrimSpace(d.Model)
+	d.Effort = strings.TrimSpace(d.Effort)
+	d.PermissionMode = strings.TrimSpace(d.PermissionMode)
+	d.Isolation = strings.TrimSpace(d.Isolation)
+	d.Color = strings.TrimSpace(d.Color)
+	d.Memory = strings.TrimSpace(d.Memory)
+	d.InitialPrompt = strings.TrimSpace(d.InitialPrompt)
+
+	tools := make([]string, 0, len(d.Tools))
+	for _, t := range d.Tools {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			tools = append(tools, t)
+		}
+	}
+	d.Tools = tools
+
+	disallowed := make([]string, 0, len(d.DisallowedTools))
+	for _, t := range d.DisallowedTools {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			disallowed = append(disallowed, t)
+		}
+	}
+	d.DisallowedTools = disallowed
+
+	skills := make([]string, 0, len(d.Skills))
+	for _, s := range d.Skills {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			skills = append(skills, s)
+		}
+	}
+	d.Skills = skills
+
+	mcpServers := make([]string, 0, len(d.MCPServers))
+	for _, s := range d.MCPServers {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			mcpServers = append(mcpServers, s)
+		}
+	}
+	d.MCPServers = mcpServers
+}
+
+func (d *SubagentDefinition) Valid() bool {
+	return d.Name != ""
+}
+
+func (d *SubagentDefinition) ToolAllowed(toolName string) bool {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return false
+	}
+	for _, t := range d.DisallowedTools {
+		if strings.EqualFold(t, toolName) {
+			return false
+		}
+	}
+	if len(d.Tools) == 0 {
+		return true
+	}
+	for _, t := range d.Tools {
+		if strings.EqualFold(t, toolName) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/subagentdef/loader.go
+++ b/internal/subagentdef/loader.go
@@ -1,0 +1,153 @@
+package subagentdef
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"reasonix/internal/frontmatter"
+)
+
+type LoadOptions struct {
+	Scope string
+}
+
+func LoadFromFile(path string, opts LoadOptions) (*SubagentDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read subagent file %q: %w", path, err)
+	}
+
+	def := &SubagentDefinition{}
+	body, err := frontmatter.Decode(string(data), def, frontmatter.DecodeOptions{KnownFields: false})
+	if err != nil {
+		return nil, fmt.Errorf("parse subagent frontmatter %q: %w", path, err)
+	}
+
+	def.Prompt = strings.TrimSpace(body)
+	def.SourceFile = path
+	def.SourceScope = opts.Scope
+
+	info, err := os.Stat(path)
+	if err == nil {
+		def.CreatedAt = info.ModTime()
+		def.UpdatedAt = info.ModTime()
+	}
+
+	def.Normalize()
+
+	if !def.Valid() {
+		return nil, fmt.Errorf("subagent definition %q is missing a name", path)
+	}
+
+	return def, nil
+}
+
+func LoadFromDirectory(dir string, opts LoadOptions) ([]*SubagentDefinition, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read subagent directory %q: %w", dir, err)
+	}
+
+	var defs []*SubagentDefinition
+	seen := map[string]bool{}
+
+	var walk func(string) error
+	walk = func(current string) error {
+		entries, err := os.ReadDir(current)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			fullPath := filepath.Join(current, entry.Name())
+			if entry.IsDir() {
+				if err := walk(fullPath); err != nil {
+					return err
+				}
+				continue
+			}
+			if !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+				continue
+			}
+			def, err := LoadFromFile(fullPath, opts)
+			if err != nil {
+				continue
+			}
+			key := strings.ToLower(def.Name)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			defs = append(defs, def)
+		}
+		return nil
+	}
+
+	_ = entries
+	if err := walk(dir); err != nil {
+		return nil, err
+	}
+
+	return defs, nil
+}
+
+func LoadFromJSON(data []byte, opts LoadOptions) (*SubagentDefinition, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func BuiltinDefinitions() []*SubagentDefinition {
+	now := time.Now()
+	return []*SubagentDefinition{
+		{
+			Name:        "explore",
+			Description: "A fast, read-only agent optimized for searching and analyzing codebases.",
+			Prompt:      "You are a code exploration agent. Your job is to quickly search and understand codebases. Use read-only tools to find files, search for patterns, and understand the code structure. Return concise, well-organized findings.",
+			Tools:       []string{"read_file", "grep", "glob", "ls", "code_index"},
+			Model:       "",
+			SourceScope: "builtin",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			Name:        "plan",
+			Description: "A research agent used for gathering context before presenting a plan.",
+			Prompt:      "You are a planning research agent. Gather context about the codebase to help plan an approach. Use read-only tools to understand the current state and constraints. Return research findings that will inform the plan.",
+			Tools:       []string{"read_file", "grep", "glob", "ls", "code_index"},
+			SourceScope: "builtin",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			Name:        "general-purpose",
+			Description: "A capable agent for complex, multi-step tasks requiring both exploration and action.",
+			Prompt:      "You are a general-purpose coding agent. Handle complex tasks that require both exploring the codebase and making changes. Work methodically and return clear results.",
+			SourceScope: "builtin",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			Name:        "code-reviewer",
+			Description: "Reviews code for quality, security, and best practices.",
+			Prompt:      "You are a senior code reviewer. Analyze the code and provide specific, actionable feedback on quality, security, performance, and best practices. Explain each issue clearly and suggest improvements.",
+			Tools:       []string{"read_file", "grep", "glob", "ls", "code_index"},
+			Color:       "#4CAF50",
+			SourceScope: "builtin",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			Name:        "debugger",
+			Description: "Debugging specialist for errors and test failures.",
+			Prompt:      "You are an expert debugger. Analyze errors, identify root causes, and provide fixes. Be methodical and verify your hypotheses.",
+			Color:       "#FF9800",
+			SourceScope: "builtin",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+	}
+}

--- a/internal/subagentdef/loader.go
+++ b/internal/subagentdef/loader.go
@@ -46,12 +46,8 @@ func LoadFromFile(path string, opts LoadOptions) (*SubagentDefinition, error) {
 }
 
 func LoadFromDirectory(dir string, opts LoadOptions) ([]*SubagentDefinition, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read subagent directory %q: %w", dir, err)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, nil
 	}
 
 	var defs []*SubagentDefinition
@@ -88,16 +84,11 @@ func LoadFromDirectory(dir string, opts LoadOptions) ([]*SubagentDefinition, err
 		return nil
 	}
 
-	_ = entries
 	if err := walk(dir); err != nil {
 		return nil, err
 	}
 
 	return defs, nil
-}
-
-func LoadFromJSON(data []byte, opts LoadOptions) (*SubagentDefinition, error) {
-	return nil, fmt.Errorf("not implemented")
 }
 
 func BuiltinDefinitions() []*SubagentDefinition {

--- a/internal/subagentdef/loader.go
+++ b/internal/subagentdef/loader.go
@@ -10,10 +10,17 @@ import (
 	"reasonix/internal/frontmatter"
 )
 
+// LoadOptions configures how subagent definitions are loaded from files
+// or directories. Scope sets the source scope used for priority-based
+// deduplication in the registry.
 type LoadOptions struct {
 	Scope string
 }
 
+// LoadFromFile loads a single subagent definition from a Markdown file with
+// YAML frontmatter. The file body after the frontmatter becomes the subagent
+// prompt. Returns an error if the file cannot be read, the frontmatter is
+// invalid, or the definition is missing a name.
 func LoadFromFile(path string, opts LoadOptions) (*SubagentDefinition, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -45,6 +52,10 @@ func LoadFromFile(path string, opts LoadOptions) (*SubagentDefinition, error) {
 	return def, nil
 }
 
+// LoadFromDirectory recursively loads all subagent definitions from .md files
+// in a directory tree. Definitions with duplicate names (case-insensitive)
+// are deduplicated, keeping the first one encountered. Returns nil (not an
+// error) if the directory does not exist.
 func LoadFromDirectory(dir string, opts LoadOptions) ([]*SubagentDefinition, error) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil, nil
@@ -91,6 +102,9 @@ func LoadFromDirectory(dir string, opts LoadOptions) ([]*SubagentDefinition, err
 	return defs, nil
 }
 
+// BuiltinDefinitions returns the list of built-in subagent definitions that
+// ship with the application. These serve as defaults and can be overridden
+// by definitions from higher-priority scopes (user, project, CLI).
 func BuiltinDefinitions() []*SubagentDefinition {
 	now := time.Now()
 	return []*SubagentDefinition{

--- a/internal/subagentdef/registry.go
+++ b/internal/subagentdef/registry.go
@@ -7,11 +7,20 @@ import (
 )
 
 const (
-	ScopeCLI       = "cli"
-	ScopeProject   = "project"
-	ScopeUser      = "user"
-	ScopePlugin    = "plugin"
-	ScopeBuiltin   = "builtin"
+	// ScopeCLI identifies subagent definitions bundled with the CLI binary
+	// itself. These have the highest priority and override all other scopes.
+	ScopeCLI = "cli"
+	// ScopeProject identifies subagent definitions from the current project's
+	// .reasonix directory (project-level overrides).
+	ScopeProject = "project"
+	// ScopeUser identifies subagent definitions from the user's home directory
+	// configuration (user-level defaults).
+	ScopeUser = "user"
+	// ScopePlugin identifies subagent definitions provided by loaded plugins.
+	ScopePlugin = "plugin"
+	// ScopeBuiltin identifies built-in subagent definitions shipped with the
+	// application. These have the lowest priority and serve as defaults.
+	ScopeBuiltin = "builtin"
 )
 
 var scopePriority = map[string]int{
@@ -22,12 +31,18 @@ var scopePriority = map[string]int{
 	ScopeBuiltin: 5,
 }
 
+// Registry is a thread-safe collection of subagent definitions with
+// priority-based deduplication. When multiple definitions share the same
+// name, the one from the higher-priority scope (lower scopePriority value)
+// wins. Definitions are looked up case-insensitively by name.
 type Registry struct {
 	mu    sync.RWMutex
 	defs  map[string]*SubagentDefinition
 	order []string
 }
 
+// NewRegistry returns an empty subagent definition registry, ready to accept
+// definitions from various sources via Add or AddAll.
 func NewRegistry() *Registry {
 	return &Registry{
 		defs:  map[string]*SubagentDefinition{},
@@ -35,6 +50,10 @@ func NewRegistry() *Registry {
 	}
 }
 
+// Add inserts a subagent definition into the registry. If a definition with
+// the same name (case-insensitive) already exists, the one from the
+// higher-priority scope is kept. Nil or invalid definitions are silently
+// ignored.
 func (r *Registry) Add(def *SubagentDefinition) {
 	if def == nil || !def.Valid() {
 		return
@@ -57,12 +76,16 @@ func (r *Registry) Add(def *SubagentDefinition) {
 	r.order = append(r.order, def.Name)
 }
 
+// AddAll adds all definitions from the slice to the registry, applying the
+// same priority-based deduplication rules as Add.
 func (r *Registry) AddAll(defs []*SubagentDefinition) {
 	for _, def := range defs {
 		r.Add(def)
 	}
 }
 
+// Get looks up a subagent definition by name (case-insensitive). The second
+// return value reports whether the definition was found.
 func (r *Registry) Get(name string) (*SubagentDefinition, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -70,6 +93,9 @@ func (r *Registry) Get(name string) (*SubagentDefinition, bool) {
 	return def, ok
 }
 
+// List returns all registered subagent definitions sorted first by scope
+// priority (CLI first, builtin last), then alphabetically by name. The
+// returned slice is a new slice; modifying it does not affect the registry.
 func (r *Registry) List() []*SubagentDefinition {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -94,6 +120,8 @@ func (r *Registry) List() []*SubagentDefinition {
 	return out
 }
 
+// Names returns the names of all registered subagent definitions sorted
+// alphabetically.
 func (r *Registry) Names() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -105,12 +133,16 @@ func (r *Registry) Names() []string {
 	return out
 }
 
+// Len returns the number of registered subagent definitions.
 func (r *Registry) Len() int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return len(r.defs)
 }
 
+// FindByDescription returns all subagent definitions whose name or
+// description (case-insensitive) contains the query string. An empty query
+// returns all definitions (same as List).
 func (r *Registry) FindByDescription(query string) []*SubagentDefinition {
 	query = strings.ToLower(strings.TrimSpace(query))
 	if query == "" {

--- a/internal/subagentdef/registry.go
+++ b/internal/subagentdef/registry.go
@@ -1,0 +1,131 @@
+package subagentdef
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	ScopeCLI       = "cli"
+	ScopeProject   = "project"
+	ScopeUser      = "user"
+	ScopePlugin    = "plugin"
+	ScopeBuiltin   = "builtin"
+)
+
+var scopePriority = map[string]int{
+	ScopeCLI:     1,
+	ScopeProject: 2,
+	ScopeUser:    3,
+	ScopePlugin:  4,
+	ScopeBuiltin: 5,
+}
+
+type Registry struct {
+	mu    sync.RWMutex
+	defs  map[string]*SubagentDefinition
+	order []string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		defs:  map[string]*SubagentDefinition{},
+		order: []string{},
+	}
+}
+
+func (r *Registry) Add(def *SubagentDefinition) {
+	if def == nil || !def.Valid() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := strings.ToLower(def.Name)
+	existing, ok := r.defs[key]
+	if ok {
+		existingPriority := scopePriority[existing.SourceScope]
+		newPriority := scopePriority[def.SourceScope]
+		if newPriority >= existingPriority {
+			return
+		}
+		r.defs[key] = def
+		return
+	}
+	r.defs[key] = def
+	r.order = append(r.order, def.Name)
+}
+
+func (r *Registry) AddAll(defs []*SubagentDefinition) {
+	for _, def := range defs {
+		r.Add(def)
+	}
+}
+
+func (r *Registry) Get(name string) (*SubagentDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	def, ok := r.defs[strings.ToLower(strings.TrimSpace(name))]
+	return def, ok
+}
+
+func (r *Registry) List() []*SubagentDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]*SubagentDefinition, 0, len(r.order))
+	for _, name := range r.order {
+		def, ok := r.defs[strings.ToLower(name)]
+		if ok {
+			out = append(out, def)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		pi := scopePriority[out[i].SourceScope]
+		pj := scopePriority[out[j].SourceScope]
+		if pi != pj {
+			return pi < pj
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	return out
+}
+
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.order))
+	for _, name := range r.order {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.defs)
+}
+
+func (r *Registry) FindByDescription(query string) []*SubagentDefinition {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return r.List()
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var matches []*SubagentDefinition
+	for _, def := range r.defs {
+		if strings.Contains(strings.ToLower(def.Name), query) ||
+			strings.Contains(strings.ToLower(def.Description), query) {
+			matches = append(matches, def)
+		}
+	}
+	return matches
+}

--- a/internal/subagentdef/subagentdef_test.go
+++ b/internal/subagentdef/subagentdef_test.go
@@ -1,0 +1,191 @@
+package subagentdef
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSubagentDefinition_Normalize(t *testing.T) {
+	def := &SubagentDefinition{
+		Name:            "  test-agent  ",
+		Description:     "  Test description  ",
+		Tools:           []string{" read_file ", " grep ", ""},
+		DisallowedTools: []string{" bash ", ""},
+	}
+	def.Normalize()
+
+	if def.Name != "test-agent" {
+		t.Errorf("expected name 'test-agent', got %q", def.Name)
+	}
+	if def.Description != "Test description" {
+		t.Errorf("expected description 'Test description', got %q", def.Description)
+	}
+	if len(def.Tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(def.Tools))
+	}
+	if def.Tools[0] != "read_file" {
+		t.Errorf("expected first tool 'read_file', got %q", def.Tools[0])
+	}
+	if len(def.DisallowedTools) != 1 {
+		t.Errorf("expected 1 disallowed tool, got %d", len(def.DisallowedTools))
+	}
+}
+
+func TestSubagentDefinition_ToolAllowed(t *testing.T) {
+	def := &SubagentDefinition{
+		Tools:           []string{"read_file", "grep", "glob"},
+		DisallowedTools: []string{"bash"},
+	}
+	def.Normalize()
+
+	if !def.ToolAllowed("read_file") {
+		t.Error("read_file should be allowed")
+	}
+	if !def.ToolAllowed("grep") {
+		t.Error("grep should be allowed")
+	}
+	if def.ToolAllowed("bash") {
+		t.Error("bash should be disallowed")
+	}
+	if def.ToolAllowed("write_file") {
+		t.Error("write_file should be disallowed (not in tools list)")
+	}
+}
+
+func TestSubagentDefinition_Valid(t *testing.T) {
+	def := &SubagentDefinition{Name: "test"}
+	if !def.Valid() {
+		t.Error("definition with name should be valid")
+	}
+
+	def2 := &SubagentDefinition{Name: ""}
+	if def2.Valid() {
+		t.Error("definition without name should not be valid")
+	}
+}
+
+func TestRegistry(t *testing.T) {
+	reg := NewRegistry()
+
+	def1 := &SubagentDefinition{Name: "agent-one", SourceScope: ScopeUser}
+	def2 := &SubagentDefinition{Name: "agent-two", SourceScope: ScopeProject}
+	def3 := &SubagentDefinition{Name: "Agent-One", SourceScope: ScopeBuiltin}
+
+	reg.Add(def1)
+	reg.Add(def2)
+	reg.Add(def3)
+
+	if reg.Len() != 2 {
+		t.Errorf("expected 2 definitions (case-insensitive dedup), got %d", reg.Len())
+	}
+
+	got, ok := reg.Get("agent-one")
+	if !ok {
+		t.Error("should find agent-one")
+	}
+	if got.SourceScope != ScopeUser {
+		t.Errorf("expected user scope (higher priority), got %s", got.SourceScope)
+	}
+
+	names := reg.Names()
+	if len(names) != 2 {
+		t.Errorf("expected 2 names, got %d", len(names))
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test-agent.md")
+	content := `---
+name: test-agent
+description: A test agent
+tools:
+  - read_file
+  - grep
+model: sonnet
+color: "#4CAF50"
+---
+
+You are a test agent.
+Do good work.
+`
+	if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	def, err := LoadFromFile(testFile, LoadOptions{Scope: ScopeUser})
+	if err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	if def.Name != "test-agent" {
+		t.Errorf("expected name 'test-agent', got %q", def.Name)
+	}
+	if def.Description != "A test agent" {
+		t.Errorf("expected description 'A test agent', got %q", def.Description)
+	}
+	if len(def.Tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(def.Tools))
+	}
+	if def.Model != "sonnet" {
+		t.Errorf("expected model 'sonnet', got %q", def.Model)
+	}
+	if def.Color != "#4CAF50" {
+		t.Errorf("expected color '#4CAF50', got %q", def.Color)
+	}
+	if def.SourceScope != ScopeUser {
+		t.Errorf("expected scope 'user', got %q", def.SourceScope)
+	}
+	if !containsString(def.Prompt, "You are a test agent.") {
+		t.Errorf("prompt should contain body text, got %q", def.Prompt)
+	}
+}
+
+func TestBuiltinDefinitions(t *testing.T) {
+	defs := BuiltinDefinitions()
+	if len(defs) == 0 {
+		t.Error("expected builtin definitions")
+	}
+
+	found := false
+	for _, def := range defs {
+		if def.Name == "explore" {
+			found = true
+			if def.SourceScope != ScopeBuiltin {
+				t.Errorf("explore should have builtin scope, got %s", def.SourceScope)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'explore' builtin agent")
+	}
+}
+
+func TestRegistry_FindByDescription(t *testing.T) {
+	reg := NewRegistry()
+	reg.Add(&SubagentDefinition{Name: "code-reviewer", Description: "Reviews code for quality and security"})
+	reg.Add(&SubagentDefinition{Name: "debugger", Description: "Debugs errors and test failures"})
+
+	results := reg.FindByDescription("code")
+	if len(results) != 1 {
+		t.Errorf("expected 1 result for 'code', got %d", len(results))
+	}
+	if results[0].Name != "code-reviewer" {
+		t.Errorf("expected code-reviewer, got %s", results[0].Name)
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tool/builtin/agent_view_tools.go
+++ b/internal/tool/builtin/agent_view_tools.go
@@ -1,0 +1,178 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"reasonix/internal/agentview"
+	"reasonix/internal/tool"
+)
+
+var (
+	agentViewMu       sync.Mutex
+	agentViewManager  *agentview.Manager
+	agentViewSession  string
+)
+
+func SetAgentViewManager(m *agentview.Manager, sessionID string) {
+	agentViewMu.Lock()
+	defer agentViewMu.Unlock()
+	agentViewManager = m
+	agentViewSession = sessionID
+}
+
+func getAgentViewContext() (*agentview.Manager, string, bool) {
+	agentViewMu.Lock()
+	defer agentViewMu.Unlock()
+	if agentViewManager == nil {
+		return nil, "", false
+	}
+	return agentViewManager, agentViewSession, true
+}
+
+func init() {
+	tool.RegisterBuiltin(agentViewListTool{})
+	tool.RegisterBuiltin(agentViewUpdateTool{})
+}
+
+type agentViewListTool struct{}
+
+func (agentViewListTool) Name() string { return "agent_view_list" }
+
+func (agentViewListTool) Description() string {
+	return "List all background agent sessions managed by agent view. Shows session state, summary, last activity, and workspace. Use this to see what other agents are working on."
+}
+
+func (agentViewListTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "state":{
+    "type":"string",
+    "description":"Optional filter: only show sessions in this state (working, needs_input, idle, completed, failed, stopped, sleeping).",
+    "enum":["working","needs_input","idle","completed","failed","stopped","sleeping"]
+  },
+  "workspace":{
+    "type":"string",
+    "description":"Optional filter: only show sessions in this workspace directory."
+  }
+}
+}`)
+}
+
+func (agentViewListTool) ReadOnly() bool { return true }
+
+func (agentViewListTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, _, ok := getAgentViewContext()
+	if !ok {
+		return "", fmt.Errorf("agent view is not available")
+	}
+
+	var p struct {
+		State     string `json:"state"`
+		Workspace string `json:"workspace"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+
+	var sessions []agentview.SessionInfo
+	if p.State != "" {
+		sessions = mgr.ByState(agentview.SessionState(p.State))
+	} else if p.Workspace != "" {
+		sessions = mgr.ListByWorkspace(p.Workspace)
+	} else {
+		sessions = mgr.List()
+	}
+
+	if len(sessions) == 0 {
+		return "No background sessions found.", nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Background sessions (%d total):\n\n", len(sessions))
+	for _, s := range sessions {
+		pinned := ""
+		if s.Pinned {
+			pinned = " [pinned]"
+		}
+		fmt.Fprintf(&sb, "• %s (%s)%s\n", s.Name, s.State, pinned)
+		fmt.Fprintf(&sb, "  ID: %s\n", s.ID)
+		if s.Summary != "" {
+			summary := s.Summary
+			if len(summary) > 100 {
+				summary = summary[:97] + "..."
+			}
+			fmt.Fprintf(&sb, "  Status: %s\n", summary)
+		}
+		fmt.Fprintf(&sb, "  Workspace: %s\n", s.Workspace)
+		if s.Model != "" {
+			fmt.Fprintf(&sb, "  Model: %s\n", s.Model)
+		}
+		fmt.Fprintf(&sb, "  Last active: %s ago\n", formatDuration(s.LastActivity))
+		if len(s.PullRequests) > 0 {
+			fmt.Fprintf(&sb, "  Pull requests: %s\n", strings.Join(s.PullRequests, ", "))
+		}
+		fmt.Fprintln(&sb)
+	}
+
+	return sb.String(), nil
+}
+
+type agentViewUpdateTool struct{}
+
+func (agentViewUpdateTool) Name() string { return "agent_view_update" }
+
+func (agentViewUpdateTool) Description() string {
+	return "Update the current session's status in agent view. Use this to update the summary text or state that appears in the agent view list."
+}
+
+func (agentViewUpdateTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "summary":{
+    "type":"string",
+    "description":"Short summary of what this session is doing or has done."
+  },
+  "state":{
+    "type":"string",
+    "description":"New state for the session.",
+    "enum":["working","needs_input","idle","completed","failed"]
+  }
+}
+}`)
+}
+
+func (agentViewUpdateTool) ReadOnly() bool { return true }
+
+func (agentViewUpdateTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, sessionID, ok := getAgentViewContext()
+	if !ok {
+		return "", fmt.Errorf("agent view is not available")
+	}
+
+	var p struct {
+		Summary string `json:"summary"`
+		State   string `json:"state"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+
+	if p.State != "" {
+		mgr.UpdateState(sessionID, agentview.SessionState(p.State))
+	}
+	if p.Summary != "" {
+		mgr.UpdateSummary(sessionID, p.Summary)
+	}
+
+	return "Session status updated.", nil
+}
+
+func formatDuration(t interface{}) string {
+	return "unknown"
+}

--- a/internal/tool/builtin/agent_view_tools.go
+++ b/internal/tool/builtin/agent_view_tools.go
@@ -12,11 +12,15 @@ import (
 )
 
 var (
-	agentViewMu       sync.Mutex
-	agentViewManager  *agentview.Manager
-	agentViewSession  string
+	agentViewMu      sync.Mutex
+	agentViewManager *agentview.Manager
+	agentViewSession string
 )
 
+// SetAgentViewManager sets the agent view manager and current session ID for
+// built-in agent view tools. The manager and session ID are used by agent view
+// tools like agent_view_list and agent_view_update to interact with background
+// agent sessions.
 func SetAgentViewManager(m *agentview.Manager, sessionID string) {
 	agentViewMu.Lock()
 	defer agentViewMu.Unlock()

--- a/internal/tool/builtin/subagent_def_tools.go
+++ b/internal/tool/builtin/subagent_def_tools.go
@@ -1,0 +1,213 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"reasonix/internal/subagentdef"
+	"reasonix/internal/tool"
+)
+
+var (
+	subagentDefMu       sync.Mutex
+	subagentDefRegistry *subagentdef.Registry
+)
+
+func SetSubagentDefRegistry(r *subagentdef.Registry) {
+	subagentDefMu.Lock()
+	defer subagentDefMu.Unlock()
+	subagentDefRegistry = r
+}
+
+func getSubagentDefRegistry() (*subagentdef.Registry, bool) {
+	subagentDefMu.Lock()
+	defer subagentDefMu.Unlock()
+	if subagentDefRegistry == nil {
+		return nil, false
+	}
+	return subagentDefRegistry, true
+}
+
+func init() {
+	tool.RegisterBuiltin(subagentListTool{})
+	tool.RegisterBuiltin(subagentGetTool{})
+}
+
+type subagentListTool struct{}
+
+func (subagentListTool) Name() string { return "subagent_list" }
+
+func (subagentListTool) Description() string {
+	return "List all available subagent definitions that can be used. Each subagent has a specific role, tool access, and model configuration. Use subagent_get to see full details for a specific subagent."
+}
+
+func (subagentListTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "query":{
+    "type":"string",
+    "description":"Optional search query to filter subagents by name or description."
+  }
+}
+}`)
+}
+
+func (subagentListTool) ReadOnly() bool { return true }
+
+func (subagentListTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	reg, ok := getSubagentDefRegistry()
+	if !ok {
+		return "", fmt.Errorf("subagent definitions not available")
+	}
+
+	var p struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+
+	var defs []*subagentdef.SubagentDefinition
+	if p.Query != "" {
+		defs = reg.FindByDescription(p.Query)
+	} else {
+		defs = reg.List()
+	}
+
+	if len(defs) == 0 {
+		return "No subagent definitions found.", nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Available subagents (%d total):\n\n", len(defs))
+	for _, def := range defs {
+		scope := def.SourceScope
+		if scope == "" {
+			scope = "unknown"
+		}
+		fmt.Fprintf(&sb, "• %s [%s]\n", def.Name, scope)
+		if def.Description != "" {
+			desc := def.Description
+			if len(desc) > 120 {
+				desc = desc[:117] + "..."
+			}
+			fmt.Fprintf(&sb, "  %s\n", desc)
+		}
+		if def.Model != "" {
+			fmt.Fprintf(&sb, "  Model: %s\n", def.Model)
+		}
+		if len(def.Tools) > 0 {
+			fmt.Fprintf(&sb, "  Tools: %d tools\n", len(def.Tools))
+		}
+		fmt.Fprintln(&sb)
+	}
+
+	return sb.String(), nil
+}
+
+type subagentGetTool struct{}
+
+func (subagentGetTool) Name() string { return "subagent_get" }
+
+func (subagentGetTool) Description() string {
+	return "Get detailed information about a specific subagent definition, including its full system prompt, tool access, model configuration, and capabilities."
+}
+
+func (subagentGetTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "name":{
+    "type":"string",
+    "description":"The name of the subagent definition to retrieve."
+  }
+},
+"required":["name"]
+}`)
+}
+
+func (subagentGetTool) ReadOnly() bool { return true }
+
+func (subagentGetTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	reg, ok := getSubagentDefRegistry()
+	if !ok {
+		return "", fmt.Errorf("subagent definitions not available")
+	}
+
+	var p struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return "", fmt.Errorf("subagent name is required")
+	}
+
+	def, ok := reg.Get(p.Name)
+	if !ok {
+		return "", fmt.Errorf("subagent %q not found", p.Name)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Subagent: %s\n", def.Name)
+	fmt.Fprintf(&sb, "Scope: %s\n", def.SourceScope)
+	if def.Description != "" {
+		fmt.Fprintf(&sb, "Description: %s\n", def.Description)
+	}
+	if def.Model != "" {
+		fmt.Fprintf(&sb, "Model: %s\n", def.Model)
+	}
+	if def.Effort != "" {
+		fmt.Fprintf(&sb, "Effort: %s\n", def.Effort)
+	}
+	if def.PermissionMode != "" {
+		fmt.Fprintf(&sb, "Permission mode: %s\n", def.PermissionMode)
+	}
+	if def.MaxTurns > 0 {
+		fmt.Fprintf(&sb, "Max turns: %d\n", def.MaxTurns)
+	}
+	if def.Isolation != "" {
+		fmt.Fprintf(&sb, "Isolation: %s\n", def.Isolation)
+	}
+	if def.Background {
+		fmt.Fprintf(&sb, "Background: yes\n")
+	}
+	if def.Color != "" {
+		fmt.Fprintf(&sb, "Color: %s\n", def.Color)
+	}
+	if len(def.Tools) > 0 {
+		fmt.Fprintf(&sb, "\nAllowed tools (%d):\n", len(def.Tools))
+		for _, t := range def.Tools {
+			fmt.Fprintf(&sb, "  • %s\n", t)
+		}
+	}
+	if len(def.DisallowedTools) > 0 {
+		fmt.Fprintf(&sb, "\nDisallowed tools (%d):\n", len(def.DisallowedTools))
+		for _, t := range def.DisallowedTools {
+			fmt.Fprintf(&sb, "  • %s\n", t)
+		}
+	}
+	if len(def.Skills) > 0 {
+		fmt.Fprintf(&sb, "\nPreloaded skills (%d):\n", len(def.Skills))
+		for _, s := range def.Skills {
+			fmt.Fprintf(&sb, "  • %s\n", s)
+		}
+	}
+	if def.Prompt != "" {
+		prompt := def.Prompt
+		if len(prompt) > 500 {
+			prompt = prompt[:497] + "..."
+		}
+		fmt.Fprintf(&sb, "\nSystem prompt:\n%s\n", prompt)
+	}
+	if def.SourceFile != "" {
+		fmt.Fprintf(&sb, "\nSource file: %s\n", def.SourceFile)
+	}
+
+	return sb.String(), nil
+}

--- a/internal/tool/builtin/team_tools.go
+++ b/internal/tool/builtin/team_tools.go
@@ -1,0 +1,528 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"reasonix/internal/agentteam"
+	"reasonix/internal/tool"
+)
+
+var (
+	teamToolMu      sync.Mutex
+	teamToolManager *agentteam.Manager
+	teamToolCurrent  string
+)
+
+func SetTeamToolManager(m *agentteam.Manager, teamName string) {
+	teamToolMu.Lock()
+	defer teamToolMu.Unlock()
+	teamToolManager = m
+	teamToolCurrent = teamName
+}
+
+func getTeamContext() (*agentteam.Manager, string, bool) {
+	teamToolMu.Lock()
+	defer teamToolMu.Unlock()
+	if teamToolManager == nil || teamToolCurrent == "" {
+		return nil, "", false
+	}
+	return teamToolManager, teamToolCurrent, true
+}
+
+func init() {
+	tool.RegisterBuiltin(sendMessageTool{})
+	tool.RegisterBuiltin(taskListTool{})
+	tool.RegisterBuiltin(taskCreateTool{})
+	tool.RegisterBuiltin(taskGetTool{})
+	tool.RegisterBuiltin(taskUpdateTool{})
+	tool.RegisterBuiltin(teamMemberListTool{})
+}
+
+type sendMessageTool struct{}
+
+func (sendMessageTool) Name() string { return "send_message" }
+
+func (sendMessageTool) Description() string {
+	return "Send a message to a teammate or all team members in the agent team. Use this to communicate with other agents working on the same team. You can send messages to specific teammates by name or broadcast to everyone."
+}
+
+func (sendMessageTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "to":{
+    "type":"string",
+    "description":"The teammate name to send the message to, or 'all' to broadcast to everyone."
+  },
+  "subject":{
+    "type":"string",
+    "description":"Short subject line for the message."
+  },
+  "content":{
+    "type":"string",
+    "description":"The message body to send."
+  },
+  "message_type":{
+    "type":"string",
+    "description":"Optional message type: 'chat', 'status_update', 'question', 'answer'. Defaults to 'chat'.",
+    "enum":["chat","status_update","question","answer"]
+  }
+},
+"required":["to","content"]
+}`)
+}
+
+func (sendMessageTool) ReadOnly() bool { return true }
+
+func (sendMessageTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	var p struct {
+		To      string `json:"to"`
+		Subject string `json:"subject"`
+		Content string `json:"content"`
+		Type    string `json:"message_type"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(p.To) == "" {
+		return "", fmt.Errorf("recipient is required")
+	}
+	if strings.TrimSpace(p.Content) == "" {
+		return "", fmt.Errorf("message content is required")
+	}
+	if p.Type == "" {
+		p.Type = "chat"
+	}
+
+	mbox, err := mgr.GetMailbox(teamName)
+	if err != nil {
+		return "", fmt.Errorf("get mailbox: %w", err)
+	}
+
+	msgID, err := mbox.Send("self", p.To, p.Subject, p.Content, p.Type)
+	if err != nil {
+		return "", fmt.Errorf("send message: %w", err)
+	}
+
+	return fmt.Sprintf("Message sent to %q (ID: %s).", p.To, msgID), nil
+}
+
+type taskListTool struct{}
+
+func (taskListTool) Name() string { return "task_list" }
+
+func (taskListTool) Description() string {
+	return "List all tasks in the shared team task list. Shows pending, in-progress, and completed tasks with their status, assignee, and dependencies."
+}
+
+func (taskListTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "status":{
+    "type":"string",
+    "description":"Optional filter: only show tasks with this status (pending, in_progress, completed, failed, cancelled).",
+    "enum":["pending","in_progress","completed","failed","cancelled"]
+  },
+  "assignee":{
+    "type":"string",
+    "description":"Optional filter: only show tasks assigned to this teammate."
+  }
+}
+}`)
+}
+
+func (taskListTool) ReadOnly() bool { return true }
+
+func (taskListTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	var p struct {
+		Status   string `json:"status"`
+		Assignee string `json:"assignee"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+
+	tl, err := mgr.GetTaskList(teamName)
+	if err != nil {
+		return "", fmt.Errorf("get task list: %w", err)
+	}
+
+	var tasks []agentteam.Task
+	if p.Status != "" {
+		tasks = tl.ByStatus(agentteam.TaskStatus(p.Status))
+	} else if p.Assignee != "" {
+		tasks = tl.ByAssignee(p.Assignee)
+	} else {
+		tasks = tl.List()
+	}
+
+	if len(tasks) == 0 {
+		return "No tasks found.", nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Team tasks (%d total):\n\n", len(tasks))
+	for _, t := range tasks {
+		assignee := t.Assignee
+		if assignee == "" {
+			assignee = "unassigned"
+		}
+		fmt.Fprintf(&sb, "[%s] %s (ID: %s)\n",
+			t.Status, t.Title, t.ID)
+		fmt.Fprintf(&sb, "  Assignee: %s\n", assignee)
+		if len(t.Dependencies) > 0 {
+			fmt.Fprintf(&sb, "  Dependencies: %s\n", strings.Join(t.Dependencies, ", "))
+		}
+		if t.Description != "" {
+			desc := t.Description
+			if len(desc) > 100 {
+				desc = desc[:97] + "..."
+			}
+			fmt.Fprintf(&sb, "  %s\n", desc)
+		}
+		fmt.Fprintln(&sb)
+	}
+
+	return sb.String(), nil
+}
+
+type taskCreateTool struct{}
+
+func (taskCreateTool) Name() string { return "task_create" }
+
+func (taskCreateTool) Description() string {
+	return "Create a new task in the shared team task list. Tasks can be claimed by teammates or assigned explicitly. Use dependencies to specify tasks that must be completed first."
+}
+
+func (taskCreateTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "title":{
+    "type":"string",
+    "description":"Short title for the task."
+  },
+  "description":{
+    "type":"string",
+    "description":"Detailed description of what needs to be done."
+  },
+  "assignee":{
+    "type":"string",
+    "description":"Optional teammate name to assign this task to. If omitted, the task is unassigned and can be claimed by anyone."
+  },
+  "dependencies":{
+    "type":"array",
+    "items":{"type":"string"},
+    "description":"Optional list of task IDs that must be completed before this task can be started."
+  },
+  "priority":{
+    "type":"integer",
+    "description":"Task priority (higher = more important). Defaults to 0.",
+    "minimum":0
+  },
+  "tags":{
+    "type":"array",
+    "items":{"type":"string"},
+    "description":"Optional tags for categorizing tasks."
+  }
+},
+"required":["title"]
+}`)
+}
+
+func (taskCreateTool) ReadOnly() bool { return true }
+
+func (taskCreateTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	var p struct {
+		Title        string   `json:"title"`
+		Description  string   `json:"description"`
+		Assignee     string   `json:"assignee"`
+		Dependencies []string `json:"dependencies"`
+		Priority     int      `json:"priority"`
+		Tags         []string `json:"tags"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(p.Title) == "" {
+		return "", fmt.Errorf("task title is required")
+	}
+
+	tl, err := mgr.GetTaskList(teamName)
+	if err != nil {
+		return "", fmt.Errorf("get task list: %w", err)
+	}
+
+	status := agentteam.TaskPending
+	if p.Assignee != "" {
+		status = agentteam.TaskInProgress
+	}
+
+	task := agentteam.Task{
+		Title:        p.Title,
+		Description:  p.Description,
+		Status:       status,
+		Assignee:     p.Assignee,
+		Dependencies: p.Dependencies,
+		Priority:     p.Priority,
+		Tags:         p.Tags,
+	}
+
+	id, err := tl.Create(task)
+	if err != nil {
+		return "", fmt.Errorf("create task: %w", err)
+	}
+
+	return fmt.Sprintf("Task created: %q (ID: %s). Status: %s.", p.Title, id, status), nil
+}
+
+type taskGetTool struct{}
+
+func (taskGetTool) Name() string { return "task_get" }
+
+func (taskGetTool) Description() string {
+	return "Get full details for a specific task by ID, including description, status, assignee, and output."
+}
+
+func (taskGetTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "task_id":{
+    "type":"string",
+    "description":"The ID of the task to retrieve."
+  }
+},
+"required":["task_id"]
+}`)
+}
+
+func (taskGetTool) ReadOnly() bool { return true }
+
+func (taskGetTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	var p struct {
+		TaskID string `json:"task_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(p.TaskID) == "" {
+		return "", fmt.Errorf("task ID is required")
+	}
+
+	tl, err := mgr.GetTaskList(teamName)
+	if err != nil {
+		return "", fmt.Errorf("get task list: %w", err)
+	}
+
+	task, ok := tl.Get(p.TaskID)
+	if !ok {
+		return "", fmt.Errorf("task %q not found", p.TaskID)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Task: %s\n", task.Title)
+	fmt.Fprintf(&sb, "ID: %s\n", task.ID)
+	fmt.Fprintf(&sb, "Status: %s\n", task.Status)
+	assignee := task.Assignee
+	if assignee == "" {
+		assignee = "unassigned"
+	}
+	fmt.Fprintf(&sb, "Assignee: %s\n", assignee)
+	fmt.Fprintf(&sb, "Created: %s\n", task.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&sb, "Updated: %s\n", task.UpdatedAt.Format("2006-01-02 15:04:05"))
+	if len(task.Dependencies) > 0 {
+		fmt.Fprintf(&sb, "Dependencies: %s\n", strings.Join(task.Dependencies, ", "))
+	}
+	if task.Priority > 0 {
+		fmt.Fprintf(&sb, "Priority: %d\n", task.Priority)
+	}
+	if len(task.Tags) > 0 {
+		fmt.Fprintf(&sb, "Tags: %s\n", strings.Join(task.Tags, ", "))
+	}
+	if task.Description != "" {
+		fmt.Fprintf(&sb, "\nDescription:\n%s\n", task.Description)
+	}
+	if task.Output != "" {
+		fmt.Fprintf(&sb, "\nOutput:\n%s\n", task.Output)
+	}
+
+	return sb.String(), nil
+}
+
+type taskUpdateTool struct{}
+
+func (taskUpdateTool) Name() string { return "task_update" }
+
+func (taskUpdateTool) Description() string {
+	return "Update a task's status, assignee, description, or output. Use this to mark tasks as complete, reassign them, or add results."
+}
+
+func (taskUpdateTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "task_id":{
+    "type":"string",
+    "description":"The ID of the task to update."
+  },
+  "status":{
+    "type":"string",
+    "description":"New status for the task.",
+    "enum":["pending","in_progress","completed","failed","cancelled"]
+  },
+  "assignee":{
+    "type":"string",
+    "description":"New assignee for the task."
+  },
+  "description":{
+    "type":"string",
+    "description":"Updated description."
+  },
+  "output":{
+    "type":"string",
+    "description":"Task results or output."
+  },
+  "title":{
+    "type":"string",
+    "description":"Updated task title."
+  }
+},
+"required":["task_id"]
+}`)
+}
+
+func (taskUpdateTool) ReadOnly() bool { return true }
+
+func (taskUpdateTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	var p struct {
+		TaskID      string `json:"task_id"`
+		Status      string `json:"status"`
+		Assignee    string `json:"assignee"`
+		Description string `json:"description"`
+		Output      string `json:"output"`
+		Title       string `json:"title"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if strings.TrimSpace(p.TaskID) == "" {
+		return "", fmt.Errorf("task ID is required")
+	}
+
+	tl, err := mgr.GetTaskList(teamName)
+	if err != nil {
+		return "", fmt.Errorf("get task list: %w", err)
+	}
+
+	updates := agentteam.Task{}
+	if p.Status != "" {
+		updates.Status = agentteam.TaskStatus(p.Status)
+	}
+	if p.Assignee != "" {
+		updates.Assignee = p.Assignee
+	}
+	if p.Description != "" {
+		updates.Description = p.Description
+	}
+	if p.Output != "" {
+		updates.Output = p.Output
+	}
+	if p.Title != "" {
+		updates.Title = p.Title
+	}
+
+	if err := tl.Update(p.TaskID, updates); err != nil {
+		return "", fmt.Errorf("update task: %w", err)
+	}
+
+	return fmt.Sprintf("Task %s updated successfully.", p.TaskID), nil
+}
+
+type teamMemberListTool struct{}
+
+func (teamMemberListTool) Name() string { return "team_member_list" }
+
+func (teamMemberListTool) Description() string {
+	return "List all teammates in the current agent team, including their names, roles, status, and model information."
+}
+
+func (teamMemberListTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{}
+}`)
+}
+
+func (teamMemberListTool) ReadOnly() bool { return true }
+
+func (teamMemberListTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	mgr, teamName, ok := getTeamContext()
+	if !ok {
+		return "", fmt.Errorf("not part of an agent team")
+	}
+
+	team, ok := mgr.GetTeam(teamName)
+	if !ok {
+		return "", fmt.Errorf("team %q not found", teamName)
+	}
+
+	members := team.Members()
+	if len(members) == 0 {
+		return "No teammates found in this team.", nil
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Team %q has %d members:\n\n", teamName, len(members))
+	for _, m := range members {
+		role := m.Role
+		if role == "" {
+			role = "teammate"
+		}
+		status := m.Status
+		if status == "" {
+			status = "active"
+		}
+		model := m.Model
+		if model == "" {
+			model = "default"
+		}
+		fmt.Fprintf(&sb, "• %s (%s)\n", m.Name, role)
+		fmt.Fprintf(&sb, "  ID: %s\n", m.ID)
+		fmt.Fprintf(&sb, "  Status: %s\n", status)
+		fmt.Fprintf(&sb, "  Model: %s\n", model)
+		fmt.Fprintln(&sb)
+	}
+
+	return sb.String(), nil
+}

--- a/internal/tool/builtin/team_tools.go
+++ b/internal/tool/builtin/team_tools.go
@@ -14,9 +14,12 @@ import (
 var (
 	teamToolMu      sync.Mutex
 	teamToolManager *agentteam.Manager
-	teamToolCurrent  string
+	teamToolCurrent string
 )
 
+// SetTeamToolManager sets the team tool manager and current team name for
+// built-in team tools. The manager and team name are used by team tools like
+// send_message, task_create, etc. to operate on the correct agent team.
 func SetTeamToolManager(m *agentteam.Manager, teamName string) {
 	teamToolMu.Lock()
 	defer teamToolMu.Unlock()

--- a/internal/tool/builtin/usage_tool.go
+++ b/internal/tool/builtin/usage_tool.go
@@ -1,0 +1,116 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"reasonix/internal/tool"
+	"reasonix/internal/usage"
+)
+
+var (
+	usageTrackerMu sync.Mutex
+	usageTracker   *usage.Tracker
+	usageSessionID string
+)
+
+func SetUsageTracker(t *usage.Tracker, sessionID string) {
+	usageTrackerMu.Lock()
+	defer usageTrackerMu.Unlock()
+	usageTracker = t
+	usageSessionID = sessionID
+}
+
+func getUsageContext() (*usage.Tracker, string, bool) {
+	usageTrackerMu.Lock()
+	defer usageTrackerMu.Unlock()
+	if usageTracker == nil {
+		return nil, "", false
+	}
+	return usageTracker, usageSessionID, true
+}
+
+func init() {
+	tool.RegisterBuiltin(usageCheckTool{})
+}
+
+type usageCheckTool struct{}
+
+func (usageCheckTool) Name() string { return "usage_check" }
+
+func (usageCheckTool) Description() string {
+	return "Check the current session's token usage and estimated cost. Shows prompt tokens, completion tokens, cache hits, total cost, and per-source breakdowns."
+}
+
+func (usageCheckTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "scope":{
+    "type":"string",
+    "description":"What to show: 'session' for current session only, 'all' for all sessions, 'summary' for total across all sessions.",
+    "enum":["session","all","summary"]
+  }
+}
+}`)
+}
+
+func (usageCheckTool) ReadOnly() bool { return true }
+
+func (usageCheckTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	tracker, sessionID, ok := getUsageContext()
+	if !ok {
+		return "", fmt.Errorf("usage tracking is not available")
+	}
+
+	var p struct {
+		Scope string `json:"scope"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Scope == "" {
+		p.Scope = "session"
+	}
+
+	switch p.Scope {
+	case "all":
+		sessions := tracker.ListRecent(20)
+		if len(sessions) == 0 {
+			return "No usage data available.", nil
+		}
+		return fmt.Sprintf("Recent sessions (%d):\n%s", len(sessions), formatRecentSessions(sessions)), nil
+
+	case "summary":
+		return tracker.Summary(), nil
+
+	default:
+		return tracker.FormatSessionUsage(sessionID), nil
+	}
+}
+
+func formatRecentSessions(sessions []usage.SessionUsage) string {
+	var result string
+	for i, s := range sessions {
+		if i > 0 {
+			result += "\n"
+		}
+		currency := s.Currency
+		if currency == "" {
+			currency = "¥"
+		}
+		result += fmt.Sprintf("  %s: %d tokens, %s%.4f (%d turns)",
+			s.SessionID[:min(20, len(s.SessionID))],
+			s.TotalTokens, currency, s.Cost, s.Turns)
+	}
+	return result
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -14,6 +14,7 @@ import (
 	"reasonix/internal/provider"
 )
 
+// SourceBreakdown tracks token usage and cost for a specific source within a session.
 type SourceBreakdown struct {
 	Source           string  `json:"source"`
 	PromptTokens     int     `json:"prompt_tokens"`
@@ -23,6 +24,7 @@ type SourceBreakdown struct {
 	Calls            int     `json:"calls"`
 }
 
+// SessionUsage holds cumulative token usage, cost, and activity data for a single session.
 type SessionUsage struct {
 	SessionID        string            `json:"session_id"`
 	PromptTokens     int               `json:"prompt_tokens"`
@@ -42,13 +44,15 @@ type SessionUsage struct {
 	CodeRemoved      int               `json:"code_removed"`
 }
 
+// Tracker manages per-session usage tracking with thread-safe access and persistent storage.
 type Tracker struct {
-	baseDir string
-	mu      sync.RWMutex
+	baseDir  string
+	mu       sync.RWMutex
 	sessions map[string]*SessionUsage
 	currency string
 }
 
+// NewTracker creates a new usage tracker that persists session data under baseDir.
 func NewTracker(baseDir string) *Tracker {
 	return &Tracker{
 		baseDir:  baseDir,
@@ -61,6 +65,7 @@ func (t *Tracker) sessionPath(id string) string {
 	return filepath.Join(t.baseDir, "usage", id+".json")
 }
 
+// LoadSession reads a session's usage data from disk. Returns nil, nil if the file does not exist.
 func (t *Tracker) LoadSession(id string) (*SessionUsage, error) {
 	path := t.sessionPath(id)
 	data, err := os.ReadFile(path)
@@ -105,6 +110,7 @@ func (t *Tracker) saveSession(su *SessionUsage) error {
 	return fileutil.ReplaceFile(tmpPath, path)
 }
 
+// Record adds a usage entry to the specified session, updating token counts, cost, and source breakdown.
 func (t *Tracker) Record(sessionID string, usage *provider.Usage, pricing *provider.Pricing, source string, model string) {
 	if usage == nil {
 		return
@@ -116,7 +122,7 @@ func (t *Tracker) Record(sessionID string, usage *provider.Usage, pricing *provi
 	su, ok := t.sessions[sessionID]
 	if !ok {
 		su = &SessionUsage{
-			SessionID:   sessionID,
+			SessionID: sessionID,
 			StartedAt: time.Now().UTC(),
 			Model:     model,
 			Currency:  t.currency,
@@ -174,6 +180,7 @@ func (t *Tracker) Record(sessionID string, usage *provider.Usage, pricing *provi
 	_ = t.saveSession(su)
 }
 
+// RecordCodeChanges tracks the number of lines added and removed during a session.
 func (t *Tracker) RecordCodeChanges(sessionID string, added, removed int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -193,6 +200,7 @@ func (t *Tracker) RecordCodeChanges(sessionID string, added, removed int) {
 	_ = t.saveSession(su)
 }
 
+// Get returns a copy of the session usage data for the given session ID, and whether it exists.
 func (t *Tracker) Get(sessionID string) (*SessionUsage, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -204,6 +212,7 @@ func (t *Tracker) Get(sessionID string) (*SessionUsage, bool) {
 	return &copy, true
 }
 
+// ListRecent returns sessions sorted by last activity, most recent first, up to the specified limit.
 func (t *Tracker) ListRecent(limit int) []SessionUsage {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -221,6 +230,7 @@ func (t *Tracker) ListRecent(limit int) []SessionUsage {
 	return sessions
 }
 
+// TotalCost returns the sum of costs across all tracked sessions.
 func (t *Tracker) TotalCost() float64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -231,6 +241,7 @@ func (t *Tracker) TotalCost() float64 {
 	return total
 }
 
+// TotalTokens returns the sum of total tokens across all tracked sessions.
 func (t *Tracker) TotalTokens() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -241,6 +252,7 @@ func (t *Tracker) TotalTokens() int {
 	return total
 }
 
+// Summary returns a human-readable summary of aggregate usage across all sessions.
 func (t *Tracker) Summary() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -276,6 +288,7 @@ func (t *Tracker) Summary() string {
 	)
 }
 
+// FormatSessionUsage returns a formatted string with detailed usage information for a single session.
 func (t *Tracker) FormatSessionUsage(id string) string {
 	su, ok := t.Get(id)
 	if !ok {

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -15,31 +15,31 @@ import (
 )
 
 type SourceBreakdown struct {
-	Source  string `json:"source"`
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	Source           string  `json:"source"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
 	Cost             float64 `json:"cost"`
 	Calls            int     `json:"calls"`
 }
 
 type SessionUsage struct {
-	SessionID        string    `json:"session_id"`
-	PromptTokens     int       `json:"prompt_tokens"`
-	CompletionTokens int       `json:"completion_tokens"`
-	TotalTokens      int       `json:"total_tokens"`
-	CacheHitTokens   int       `json:"cache_hit_tokens"`
-	CacheMissTokens  int       `json:"cache_miss_tokens"`
-	ReasoningTokens  int       `json:"reasoning_tokens"`
-	Cost             float64   `json:"cost"`
-	Currency         string    `json:"currency"`
-	Turns            int       `json:"turns"`
-	StartedAt        time.Time `json:"started_at"`
-	LastActivity      time.Time `json:"last_activity"`
-	Model            string    `json:"model"`
+	SessionID        string            `json:"session_id"`
+	PromptTokens     int               `json:"prompt_tokens"`
+	CompletionTokens int               `json:"completion_tokens"`
+	TotalTokens      int               `json:"total_tokens"`
+	CacheHitTokens   int               `json:"cache_hit_tokens"`
+	CacheMissTokens  int               `json:"cache_miss_tokens"`
+	ReasoningTokens  int               `json:"reasoning_tokens"`
+	Cost             float64           `json:"cost"`
+	Currency         string            `json:"currency"`
+	Turns            int               `json:"turns"`
+	StartedAt        time.Time         `json:"started_at"`
+	LastActivity     time.Time         `json:"last_activity"`
+	Model            string            `json:"model"`
 	Breakdown        []SourceBreakdown `json:"breakdown,omitempty"`
-	CodeAdded        int       `json:"code_added"`
-	CodeRemoved      int       `json:"code_removed"`
+	CodeAdded        int               `json:"code_added"`
+	CodeRemoved      int               `json:"code_removed"`
 }
 
 type Tracker struct {

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,0 +1,310 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+	"reasonix/internal/provider"
+)
+
+type SourceBreakdown struct {
+	Source  string `json:"source"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	Cost             float64 `json:"cost"`
+	Calls            int     `json:"calls"`
+}
+
+type SessionUsage struct {
+	SessionID        string    `json:"session_id"`
+	PromptTokens     int       `json:"prompt_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	TotalTokens      int       `json:"total_tokens"`
+	CacheHitTokens   int       `json:"cache_hit_tokens"`
+	CacheMissTokens  int       `json:"cache_miss_tokens"`
+	ReasoningTokens  int       `json:"reasoning_tokens"`
+	Cost             float64   `json:"cost"`
+	Currency         string    `json:"currency"`
+	Turns            int       `json:"turns"`
+	StartedAt        time.Time `json:"started_at"`
+	LastActivity      time.Time `json:"last_activity"`
+	Model            string    `json:"model"`
+	Breakdown        []SourceBreakdown `json:"breakdown,omitempty"`
+	CodeAdded        int       `json:"code_added"`
+	CodeRemoved      int       `json:"code_removed"`
+}
+
+type Tracker struct {
+	baseDir string
+	mu      sync.RWMutex
+	sessions map[string]*SessionUsage
+	currency string
+}
+
+func NewTracker(baseDir string) *Tracker {
+	return &Tracker{
+		baseDir:  baseDir,
+		sessions: map[string]*SessionUsage{},
+		currency: "¥",
+	}
+}
+
+func (t *Tracker) sessionPath(id string) string {
+	return filepath.Join(t.baseDir, "usage", id+".json")
+}
+
+func (t *Tracker) LoadSession(id string) (*SessionUsage, error) {
+	path := t.sessionPath(id)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var su SessionUsage
+	if err := json.Unmarshal(data, &su); err != nil {
+		return nil, err
+	}
+	return &su, nil
+}
+
+func (t *Tracker) saveSession(su *SessionUsage) error {
+	dir := filepath.Join(t.baseDir, "usage")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(su, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := t.sessionPath(su.SessionID)
+	tmp, err := os.CreateTemp(dir, ".usage-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, path)
+}
+
+func (t *Tracker) Record(sessionID string, usage *provider.Usage, pricing *provider.Pricing, source string, model string) {
+	if usage == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	su, ok := t.sessions[sessionID]
+	if !ok {
+		su = &SessionUsage{
+			SessionID:   sessionID,
+			StartedAt: time.Now().UTC(),
+			Model:     model,
+			Currency:  t.currency,
+		}
+		t.sessions[sessionID] = su
+	}
+
+	su.PromptTokens += usage.PromptTokens
+	su.CompletionTokens += usage.CompletionTokens
+	su.TotalTokens += usage.TotalTokens
+	su.CacheHitTokens += usage.CacheHitTokens
+	su.CacheMissTokens += usage.CacheMissTokens
+	su.ReasoningTokens += usage.ReasoningTokens
+	su.Turns++
+	su.LastActivity = time.Now().UTC()
+	if model != "" {
+		su.Model = model
+	}
+	if pricing != nil {
+		su.Cost += pricing.Cost(usage)
+		su.Currency = pricing.Symbol()
+	}
+
+	if source != "" {
+		found := false
+		for i := range su.Breakdown {
+			if su.Breakdown[i].Source == source {
+				su.Breakdown[i].PromptTokens += usage.PromptTokens
+				su.Breakdown[i].CompletionTokens += usage.CompletionTokens
+				su.Breakdown[i].TotalTokens += usage.TotalTokens
+				if pricing != nil {
+					su.Breakdown[i].Cost += pricing.Cost(usage)
+				}
+				su.Breakdown[i].Calls++
+				found = true
+				break
+			}
+		}
+		if !found {
+			cost := 0.0
+			if pricing != nil {
+				cost = pricing.Cost(usage)
+			}
+			su.Breakdown = append(su.Breakdown, SourceBreakdown{
+				Source:           source,
+				PromptTokens:     usage.PromptTokens,
+				CompletionTokens: usage.CompletionTokens,
+				TotalTokens:      usage.TotalTokens,
+				Cost:             cost,
+				Calls:            1,
+			})
+		}
+	}
+
+	_ = t.saveSession(su)
+}
+
+func (t *Tracker) RecordCodeChanges(sessionID string, added, removed int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	su, ok := t.sessions[sessionID]
+	if !ok {
+		su = &SessionUsage{
+			SessionID: sessionID,
+			StartedAt: time.Now().UTC(),
+			Currency:  t.currency,
+		}
+		t.sessions[sessionID] = su
+	}
+	su.CodeAdded += added
+	su.CodeRemoved += removed
+	su.LastActivity = time.Now().UTC()
+	_ = t.saveSession(su)
+}
+
+func (t *Tracker) Get(sessionID string) (*SessionUsage, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	su, ok := t.sessions[sessionID]
+	if !ok {
+		return nil, false
+	}
+	copy := *su
+	return &copy, true
+}
+
+func (t *Tracker) ListRecent(limit int) []SessionUsage {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	sessions := make([]SessionUsage, 0, len(t.sessions))
+	for _, su := range t.sessions {
+		sessions = append(sessions, *su)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].LastActivity.After(sessions[j].LastActivity)
+	})
+	if limit > 0 && len(sessions) > limit {
+		sessions = sessions[:limit]
+	}
+	return sessions
+}
+
+func (t *Tracker) TotalCost() float64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	total := 0.0
+	for _, su := range t.sessions {
+		total += su.Cost
+	}
+	return total
+}
+
+func (t *Tracker) TotalTokens() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	total := 0
+	for _, su := range t.sessions {
+		total += su.TotalTokens
+	}
+	return total
+}
+
+func (t *Tracker) Summary() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var totalPrompt, totalCompletion, totalCacheHit, totalCacheMiss int
+	var totalCost float64
+	var sessions int
+
+	for _, su := range t.sessions {
+		totalPrompt += su.PromptTokens
+		totalCompletion += su.CompletionTokens
+		totalCacheHit += su.CacheHitTokens
+		totalCacheMiss += su.CacheMissTokens
+		totalCost += su.Cost
+		sessions++
+	}
+
+	currency := t.currency
+	if len(t.sessions) > 0 {
+		for _, su := range t.sessions {
+			if su.Currency != "" {
+				currency = su.Currency
+				break
+			}
+		}
+	}
+
+	return fmt.Sprintf(
+		"Total cost: %s%.2f  Sessions: %d  Prompt: %d  Completion: %d  Cache hit: %d  Cache miss: %d",
+		currency, totalCost, sessions,
+		totalPrompt, totalCompletion,
+		totalCacheHit, totalCacheMiss,
+	)
+}
+
+func (t *Tracker) FormatSessionUsage(id string) string {
+	su, ok := t.Get(id)
+	if !ok {
+		return "No usage data for this session"
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Session: %s\n", su.SessionID)
+	fmt.Fprintf(&sb, "Total cost: %s%.4f\n", su.Currency, su.Cost)
+	fmt.Fprintf(&sb, "Prompt tokens: %d\n", su.PromptTokens)
+	fmt.Fprintf(&sb, "Completion tokens: %d\n", su.CompletionTokens)
+	fmt.Fprintf(&sb, "Total tokens: %d\n", su.TotalTokens)
+	if su.CacheHitTokens > 0 || su.CacheMissTokens > 0 {
+		fmt.Fprintf(&sb, "Cache hit: %d  Cache miss: %d\n", su.CacheHitTokens, su.CacheMissTokens)
+	}
+	if su.ReasoningTokens > 0 {
+		fmt.Fprintf(&sb, "Reasoning tokens: %d\n", su.ReasoningTokens)
+	}
+	fmt.Fprintf(&sb, "Turns: %d\n", su.Turns)
+	fmt.Fprintf(&sb, "Code changes: +%d / -%d\n", su.CodeAdded, su.CodeRemoved)
+	fmt.Fprintf(&sb, "Model: %s\n", su.Model)
+
+	if len(su.Breakdown) > 0 {
+		fmt.Fprintf(&sb, "\nBreakdown by source:\n")
+		for _, b := range su.Breakdown {
+			fmt.Fprintf(&sb, "  %s: %d tokens, %s%.4f (%d calls)\n",
+				b.Source, b.TotalTokens, su.Currency, b.Cost, b.Calls)
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,134 @@
+package usage
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestTracker(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracker := NewTracker(tmpDir)
+
+	usage1 := &provider.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		CacheHitTokens:   30,
+		CacheMissTokens:  70,
+		ReasoningTokens:  20,
+	}
+	pricing := &provider.Pricing{
+		CacheHit: 0.5,
+		Input:    1.0,
+		Output:   2.0,
+		Currency: "USD",
+	}
+
+	tracker.Record("session-1", usage1, pricing, "executor", "model-a")
+
+	su, ok := tracker.Get("session-1")
+	if !ok {
+		t.Fatal("should find session-1")
+	}
+	if su.PromptTokens != 100 {
+		t.Errorf("expected 100 prompt tokens, got %d", su.PromptTokens)
+	}
+	if su.CompletionTokens != 50 {
+		t.Errorf("expected 50 completion tokens, got %d", su.CompletionTokens)
+	}
+	if su.TotalTokens != 150 {
+		t.Errorf("expected 150 total tokens, got %d", su.TotalTokens)
+	}
+	if su.Turns != 1 {
+		t.Errorf("expected 1 turn, got %d", su.Turns)
+	}
+	if su.Currency != "$" {
+		t.Errorf("expected currency '$', got %q", su.Currency)
+	}
+	expectedCost := (30*0.5 + 70*1.0 + 50*2.0) / 1e6
+	if su.Cost != expectedCost {
+		t.Errorf("expected cost %f, got %f", expectedCost, su.Cost)
+	}
+
+	usage2 := &provider.Usage{
+		PromptTokens:     200,
+		CompletionTokens: 100,
+		TotalTokens:      300,
+		CacheHitTokens:   100,
+		CacheMissTokens:  100,
+	}
+	tracker.Record("session-1", usage2, pricing, "planner", "model-a")
+
+	su, _ = tracker.Get("session-1")
+	if su.PromptTokens != 300 {
+		t.Errorf("expected 300 prompt tokens after 2 calls, got %d", su.PromptTokens)
+	}
+	if su.Turns != 2 {
+		t.Errorf("expected 2 turns, got %d", su.Turns)
+	}
+	if len(su.Breakdown) != 2 {
+		t.Errorf("expected 2 breakdown entries, got %d", len(su.Breakdown))
+	}
+
+	tracker.RecordCodeChanges("session-1", 10, 5)
+	su, _ = tracker.Get("session-1")
+	if su.CodeAdded != 10 {
+		t.Errorf("expected 10 lines added, got %d", su.CodeAdded)
+	}
+	if su.CodeRemoved != 5 {
+		t.Errorf("expected 5 lines removed, got %d", su.CodeRemoved)
+	}
+
+	tracker.Record("session-2", usage1, pricing, "executor", "model-b")
+
+	if tracker.TotalTokens() != 600 {
+		t.Errorf("expected 600 total tokens, got %d", tracker.TotalTokens())
+	}
+
+	recent := tracker.ListRecent(10)
+	if len(recent) != 2 {
+		t.Errorf("expected 2 recent sessions, got %d", len(recent))
+	}
+
+	summary := tracker.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary")
+	}
+
+	formatted := tracker.FormatSessionUsage("session-1")
+	if formatted == "" {
+		t.Error("expected non-empty formatted usage")
+	}
+}
+
+func TestTracker_NilPricing(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracker := NewTracker(tmpDir)
+
+	usage := &provider.Usage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+	}
+
+	tracker.Record("session-1", usage, nil, "executor", "model-a")
+
+	su, ok := tracker.Get("session-1")
+	if !ok {
+		t.Fatal("should find session-1")
+	}
+	if su.Cost != 0 {
+		t.Errorf("expected 0 cost with nil pricing, got %f", su.Cost)
+	}
+}
+
+func TestTracker_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracker := NewTracker(tmpDir)
+
+	_, ok := tracker.Get("nonexistent")
+	if ok {
+		t.Error("should not find nonexistent session")
+	}
+}


### PR DESCRIPTION
Overview
This PR adds Agent Teams, Subagent Definitions, Agent View, and Usage Tracking infrastructure to DeepSeek Reasonix, inspired by Claude Code's multi-agent collaboration features.

New Packages
internal/subagentdef — Subagent Definition System
5 built-in subagents: explore, plan, general-purpose, code-reviewer, debugger
Load from Markdown files with YAML frontmatter
Registry with priority-based deduplication (cli > project > user > plugin > builtin)
internal/agentteam — Agent Team Collaboration
Team management, shared task list, mailbox
Task claiming with dependencies, priorities, tags
Inter-agent messaging with broadcasts
internal/agentview — Background Session Management
Session states: working, needs_input, idle, completed, failed, stopped
Pin, rename, PR tracking, workspace filtering
internal/usage — Usage & Cost Tracking
Token tracking with cache hit/miss, reasoning tokens
Cost estimation with multi-currency support
Per-source breakdown (executor, planner, subagent)
New Built-in Tools (11 tools)
subagent_list, subagent_get
send_message, task_list, task_create, task_get, task_update, team_member_list
usage_check
agent_view_list, agent_view_update
Design
Optional infrastructure (no breaking changes)
Follows existing patterns (atomic writes, frontmatter parsing, tool registration)
22 unit tests, all passing
Cache-impact: low — Adds new optional packages and tools; does not modify existing system prompt construction, memory prefix, or tool registration paths. New tools are registered via init() but are opt-in (only available when team/view context is set).
Cache-guard: Existing tool registration and system prompt construction are unchanged. New packages are fully isolated and do not affect provider-visible prompt surfaces. The change only adds new files, no modifications to existing cache-sensitive paths.