### PR TITLE
feat(desktop): unify token display format with K/M abbreviations (#5809)

### DIFF
--- a/desktop/frontend/src/__tests__/format-tokens.test.ts
+++ b/desktop/frontend/src/__tests__/format-tokens.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { formatTokens, formatOptionalTokens } from "../lib/format";
+
+describe("formatTokens", () => {
+  it("returns '-' for undefined, zero, and negative values", () => {
+    expect(formatTokens(undefined)).toBe("-");
+    expect(formatTokens(0)).toBe("-");
+    expect(formatTokens(-100)).toBe("-");
+  });
+
+  it("formats values below threshold as plain numbers", () => {
+    expect(formatTokens(1)).toBe("1");
+    expect(formatTokens(500)).toBe("500");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("abbreviates thousands with K suffix", () => {
+    expect(formatTokens(1000)).toBe("1K");
+    expect(formatTokens(1500)).toBe("1.5K");
+    expect(formatTokens(142000)).toBe("142K");
+    expect(formatTokens(999999)).toBe("1000K");
+  });
+
+  it("abbreviates millions with M suffix", () => {
+    expect(formatTokens(1_000_000)).toBe("1M");
+    expect(formatTokens(1_500_000)).toBe("1.5M");
+    expect(formatTokens(25_000_000)).toBe("25M");
+  });
+
+  it("strips trailing .0 for exact multiples", () => {
+    expect(formatTokens(1000)).toBe("1K");
+    expect(formatTokens(2000)).toBe("2K");
+    expect(formatTokens(1_000_000)).toBe("1M");
+  });
+
+  it("keeps one decimal place when needed", () => {
+    expect(formatTokens(1500)).toBe("1.5K");
+    expect(formatTokens(234000)).toBe("234K");
+    expect(formatTokens(1_230_000)).toBe("1.2M");
+  });
+
+  it("respects custom decimals option", () => {
+    expect(formatTokens(1500, { decimals: 2 })).toBe("1.5K");
+    expect(formatTokens(1555, { decimals: 2 })).toBe("1.55K");
+    expect(formatTokens(1_555_000, { decimals: 2 })).toBe("1.55M");
+  });
+
+  it("respects custom threshold option", () => {
+    expect(formatTokens(500, { threshold: 100 })).toBe("0.5K");
+    expect(formatTokens(99, { threshold: 100 })).toBe("99");
+    expect(formatTokens(100, { threshold: 100 })).toBe("0.1K");
+  });
+
+  it("returns locale-formatted string when compact is false", () => {
+    const result = formatTokens(142000, { compact: false });
+    // toLocaleString output varies by locale, but should contain digits
+    expect(result).toMatch(/142/);
+    expect(result).not.toMatch(/[KM]/);
+  });
+});
+
+describe("formatOptionalTokens", () => {
+  it("returns '-' for missing, zero, and negative values", () => {
+    expect(formatOptionalTokens(undefined)).toBe("-");
+    expect(formatOptionalTokens(null)).toBe("-");
+    expect(formatOptionalTokens(0)).toBe("-");
+    expect(formatOptionalTokens(-50)).toBe("-");
+  });
+
+  it("formats positive values identically to formatTokens", () => {
+    expect(formatOptionalTokens(1500)).toBe("1.5K");
+    expect(formatOptionalTokens(1_000_000)).toBe("1M");
+    expect(formatOptionalTokens(500)).toBe("500");
+  });
+});

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -8,6 +8,7 @@ import { app, onFilesDropped } from "../lib/bridge";
 import { canUsePromptHistory, isFnKeyEvent, promptHistoryDirectionFromEvent } from "../lib/composerKeyboard";
 import { cacheGeneration, loadOlder } from "../lib/composerHistory";
 import { SPINNER_WORDS, useI18n } from "../lib/i18n";
+import { formatTokens } from "../lib/format";
 import { detectShortcutPlatform, matchesShortcut } from "../lib/keyboardShortcuts";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
@@ -265,11 +266,6 @@ function composerAutoInputMaxHeight(): number {
 
 function loadComposerHeight(): number | null {
   return loadOptionalLayoutSize("composerHeight", clampComposerHeight);
-}
-
-function fmtTokens(n: number): string {
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
 }
 
 function fmtElapsed(ms: number): string {
@@ -2061,7 +2057,7 @@ export function Composer({
           const elapsedMs = Math.max(0, now - turnStartAt);
           const words = SPINNER_WORDS[locale];
           const word = words[Math.floor(elapsedMs / 3000) % words.length];
-          const tok = turnTokens && turnTokens > 0 ? ` · ↓ ${fmtTokens(turnTokens)} ${t("status.tokens")}` : "";
+          const tok = turnTokens && turnTokens > 0 ? ` · ↓ ${formatTokens(turnTokens)} ${t("status.tokens")}` : "";
           return `${word}… ${fmtElapsed(elapsedMs)}${tok}`;
         })()
       : null;

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -5,6 +5,7 @@ import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useI18n, type Locale, type Translator } from "../lib/i18n";
 import { formatMoneyLocalized } from "../lib/money";
+import { formatTokens, formatOptionalTokens } from "../lib/format";
 import type { DictKey } from "../locales/en";
 import type { BalanceInfo, ContextInfo, ContextPanelInfo, UsageSourceStats, WireUsage } from "../lib/types";
 
@@ -23,10 +24,6 @@ interface ContextPanelProps {
   refreshKey?: number;
 }
 
-function fmtFullTokens(n: number): string {
-  if (n <= 0) return "0";
-  return String(Math.round(n));
-}
 
 function fmtDuration(ms: number, t: Translator): string {
   if (ms <= 0) return "-";
@@ -37,10 +34,6 @@ function fmtDuration(ms: number, t: Translator): string {
   return t("context.durationMinutesSeconds", { minutes, seconds });
 }
 
-function fmtOptionalTokens(tokens?: number): string {
-  if (typeof tokens !== "number" || tokens <= 0) return "-";
-  return tokens.toLocaleString();
-}
 
 interface MetricTokenDisplay {
   display: string;
@@ -388,9 +381,9 @@ export function ContextPanel({
   const turnCostLabel = formatMoneyLocalized(turnCost, sessionCurrency, { locale, empty: "dash" });
   const sessionCostLabel = formatMoneyLocalized(cost.amount, cost.currency, { locale, empty: "dash" });
   const totalTokensTitle = totalTokensMetric.exact === "-" ? "-" : t("context.tokensValue", { value: totalTokensMetric.exact });
-  const usedLabel = fmtFullTokens(usedTokens);
-  const windowLabel = fmtFullTokens(windowTokens);
-  const compactRemainingLabel = tokensUntilCompact > 0 ? fmtFullTokens(tokensUntilCompact) : "0";
+  const usedLabel = formatTokens(usedTokens);
+  const windowLabel = formatTokens(windowTokens);
+  const compactRemainingLabel = tokensUntilCompact > 0 ? formatTokens(tokensUntilCompact) : "0";
   const compactMarkerPct = Math.max(0, Math.min(100, compactPct));
   const usageMarkerPct = Math.max(6, Math.min(94, usagePct));
   const compactLabelPct = Math.max(6, Math.min(94, compactMarkerPct));
@@ -508,7 +501,7 @@ export function ContextPanel({
           </section>
           <section className="context-panel__creation-grid" aria-label={t("context.overview")}>
             <MetricCard label={t("status.cacheLabel")} value={fmtUsageCacheRate(usage)} tone="accent" />
-            <MetricCard label={t("status.turnTokensLabel")} value={fmtOptionalTokens(turnTokens)} />
+            <MetricCard label={t("status.turnTokensLabel")} value={formatOptionalTokens(turnTokens)} />
             <MetricCard label={t("status.turnCostLabel")} value={turnCostLabel} />
             <MetricCard label={t("status.balanceLabel")} value={balanceLabel} tone="accent" />
           </section>

--- a/desktop/frontend/src/lib/format.ts
+++ b/desktop/frontend/src/lib/format.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared formatting utilities for token counts and numeric displays.
+ *
+ * Centralises the previously duplicated fmtTokens / fmtFullTokens helpers
+ * scattered across ContextPanel and Composer so every surface renders
+ * identical compact token strings (e.g. "1.5K", "2.0M").
+ */
+
+/** Options controlling how {@link formatTokens} renders a count. */
+export interface TokenFormatOptions {
+  /**
+   * When `true` (the default) large values are abbreviated with K / M suffixes.
+   * When `false` the raw locale-formatted number is returned instead.
+   */
+  compact?: boolean;
+
+  /** Maximum fractional digits kept in the abbreviated form (default `1`). */
+  decimals?: number;
+
+  /**
+   * Minimum value before the K-suffix kicks in (default `1000`).
+   * Useful for contexts that want to show plain numbers up to a higher bound.
+   */
+  threshold?: number;
+}
+
+/** Strip trailing zeros after the decimal point: "1.50" → "1.5", "1.00" → "1". */
+function stripTrailingZeros(s: string): string {
+  return s.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+}
+
+/**
+ * Format a token count for human-readable display.
+ *
+ * Behaviour:
+ *  - Returns `"-"` for missing, zero, or negative inputs.
+ *  - In compact mode (default): values >= 1 000 000 use the `M` suffix,
+ *    values >= `threshold` (default 1 000) use the `K` suffix, and smaller
+ *    values are rendered as-is.
+ *  - Trailing `.0` is stripped so `1000` becomes `"1K"` rather than `"1.0K"`.
+ *  - In non-compact mode `toLocaleString()` is used for locale-aware grouping.
+ *
+ * @example
+ *  formatTokens(1500)        // "1.5K"
+ *  formatTokens(1000)        // "1K"
+ *  formatTokens(142000)      // "142K"
+ *  formatTokens(1_500_000)   // "1.5M"
+ *  formatTokens(999)         // "999"
+ *  formatTokens(undefined)   // "-"
+ */
+export function formatTokens(tokens: number | undefined, options?: TokenFormatOptions): string {
+  if (typeof tokens !== "number" || tokens <= 0) return "-";
+
+  const { compact = true, decimals = 1, threshold = 1000 } = options ?? {};
+
+  if (!compact) {
+    return tokens.toLocaleString();
+  }
+
+  if (tokens >= 1_000_000) {
+    return `${stripTrailingZeros((tokens / 1_000_000).toFixed(decimals))}M`;
+  }
+  if (tokens >= threshold) {
+    return `${stripTrailingZeros((tokens / 1000).toFixed(decimals))}K`;
+  }
+
+  return String(tokens);
+}
+
+/**
+ * Convenience wrapper for optional token counts (session / turn totals).
+ *
+ * Delegates to {@link formatTokens} and returns `"-"` when the value is
+ * absent, zero, or negative — matching the old `fmtOptionalTokens` helper
+ * it replaces.
+ */
+export function formatOptionalTokens(tokens?: number | null, options?: TokenFormatOptions): string {
+  if (typeof tokens !== "number" || tokens <= 0) return "-";
+  return formatTokens(tokens, options);
+}


### PR DESCRIPTION
## Summary

Unifies the token count display format across all desktop UI surfaces by introducing a shared `formatTokens` utility. Addresses issue #5809.

## Problem

Multiple token formatting helpers existed independently, producing inconsistent output:

| Component | Before | Example (1500) | Example (142000) |
|---|---|---|---|
| ContextPanel | `fmtFullTokens` (round to int) | `1500` | `142000` |
| ContextPanel | `fmtOptionalTokens` (locale) | `1,500` | `142,000` |
| Composer | `fmtTokens` (lowercase k) | `1.5k` | `142.0k` |
| CLI/TUI | `%.1fK` (Go) | `1.5K` | `142.0K` |

Large token counts (e.g. `142,000`) were hard to scan at a glance, especially when working with context windows of 128K+ tokens.

## Solution

Created `src/lib/format.ts` with two exported functions:

- **`formatTokens(tokens, options?)`** — compact formatter with K/M suffixes
- **`formatOptionalTokens(tokens?, options?)`** — convenience wrapper for optional counts

### Design decisions

- **Uppercase K/M** — matches the CLI/TUI convention and SI prefix standards
- **One decimal place by default** — balances precision and readability
- **Strips trailing `.0`** — `1000` → `"1K"` not `"1.0K"`
- **Configurable threshold** — defaults to `1000` but can be overridden
- **`compact: false`** option — falls back to `toLocaleString()` for contexts that need full precision

### Format examples

| Input | Output |
|---|---|
| `999` | `999` |
| `1000` | `1K` |
| `1500` | `1.5K` |
| `142000` | `142K` |
| `1_000_000` | `1M` |
| `1_500_000` | `1.5M` |
| `undefined` | `-` |

## Changes

| File | Change |
|---|---|
| `src/lib/format.ts` | New shared utility (55 lines) |
| `src/__tests__/format-tokens.test.ts` | 11 test cases covering edge cases, options, and locale fallback |
| `src/components/ContextPanel.tsx` | Replace local `fmtFullTokens` / `fmtOptionalTokens` with shared imports |
| `src/components/Composer.tsx` | Replace local `fmtTokens` with shared `formatTokens` |

## Testing

- All 11 new unit tests pass
- TypeScript compilation clean for changed files

## Notes

- The CLI/TUI `shortTokens` in Go is intentionally left unchanged — it lives in a separate codebase layer and already uses a consistent K/M format
- The exported `formatMetricTokens` in ContextPanel is preserved as-is since it serves a different purpose (locale-aware exact display for metric cards)

Closes #5809