### PR TITLE
fix(ci): smoke release pointers via authenticated R2 S3 API

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -367,6 +367,10 @@ jobs:
             aws s3 cp assets/ "s3://${R2_BUCKET}/latest/" --recursive --endpoint-url "$ENDPOINT"
           fi
 
+      # dl.reasonix.io serves 403 to GitHub Actions egress IPs (Cloudflare bot
+      # protection), so smoke the mirrored objects over the authenticated S3 API
+      # instead of the public edge. This verifies the mirror landed; the public
+      # edge itself is not reachable from CI and is covered by end users' traffic.
       - name: Smoke desktop release pointers
         if: env.HAS_R2 == 'true'
         env:
@@ -374,8 +378,11 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
           CHANNEL: ${{ steps.ver.outputs.channel }}
           PRERELEASE: ${{ steps.ver.outputs.prerelease }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
           set -euo pipefail
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           f=assets/latest.json
           jq -e --arg version "$VERSION" --arg prefix "https://dl.reasonix.io/${TAG}/" '
             .version == $version and
@@ -384,7 +391,8 @@ jobs:
               all(type == "string" and startswith($prefix) and (contains("/releases/latest/") | not)))
           ' "$f" >/dev/null
 
-          curl --retry 5 --retry-delay 2 -fsSL "https://dl.reasonix.io/${TAG}/latest.json" >/tmp/reasonix-desktop-tag-latest.json
+          aws s3 cp "s3://${R2_BUCKET}/${TAG}/latest.json" /tmp/reasonix-desktop-tag-latest.json --endpoint-url "$ENDPOINT"
+          jq -e --arg version "$VERSION" '.version == $version' /tmp/reasonix-desktop-tag-latest.json >/dev/null
           if [ "$CHANNEL" = "canary" ]; then
             pointer="canary"
           elif [ "$PRERELEASE" = "true" ]; then
@@ -393,12 +401,13 @@ jobs:
             pointer="latest"
           fi
           if [ -n "$pointer" ]; then
-            curl --retry 5 --retry-delay 2 -fsSL "https://dl.reasonix.io/${pointer}/latest.json" >/tmp/reasonix-desktop-pointer-latest.json
+            aws s3 cp "s3://${R2_BUCKET}/${pointer}/latest.json" /tmp/reasonix-desktop-pointer-latest.json --endpoint-url "$ENDPOINT"
             jq -e --arg version "$VERSION" '.version == $version' /tmp/reasonix-desktop-pointer-latest.json >/dev/null
           fi
 
           jq -r '.platforms[] | .url, .sig' "$f" | while IFS= read -r asset; do
-            curl --retry 5 --retry-delay 2 -fsSI "$asset" >/dev/null
+            key="${asset#https://dl.reasonix.io/}"
+            aws s3api head-object --bucket "$R2_BUCKET" --key "$key" --endpoint-url "$ENDPOINT" >/dev/null
           done
 
       - name: Attach desktop manifest to matching CLI release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
           set -euo pipefail
           case "$TAG" in
@@ -61,7 +64,18 @@ jobs:
               exit 0
               ;;
           esac
-          curl --retry 5 --retry-delay 2 -fsSL https://dl.reasonix.io/latest/latest.json -o latest.raw.json
+          if [ "$HAS_R2" != "true" ]; then
+            echo "R2 secrets not configured; skipping desktop manifest compatibility asset"
+            exit 0
+          fi
+          # dl.reasonix.io serves 403 to GitHub Actions egress IPs (Cloudflare bot
+          # protection), so read the manifest over the authenticated S3 API instead
+          # of the public edge.
+          aws configure set aws_access_key_id "${{ secrets.R2_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          aws configure set region auto
+          aws s3 cp "s3://${R2_BUCKET}/latest/latest.json" latest.raw.json \
+            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           jq '.download_page = "https://reasonix.io/#start"' latest.raw.json > latest.json
           jq -e '
             ([.platforms[] | (.url, .sig)] |


### PR DESCRIPTION
## Problem

Every stable release run goes red at the `dl.reasonix.io` curl steps: Cloudflare bot protection persistently serves 403 to GitHub Actions egress IPs (confirmed across 1.16.0 and 1.17.0 — reruns don't help). The publish itself always succeeds, but the red smoke step also **skips two real follow-up steps** in `release-desktop.yml`'s mirror job:

- *Attach desktop manifest to matching CLI release* (the `v*` release ends up missing its `latest.json` compatibility asset — the CLI-side attach step in `release.yml` fails on the same 403)
- *Refresh site to the new version* (the site keeps the old baked version)

Both had to be completed by hand for 1.17.0.

## Fix

Stop touching the public edge from CI and use the authenticated R2 S3 endpoint instead — the mirror job already has the AWS CLI configured with R2 credentials:

- **release-desktop.yml** smoke: `aws s3 cp` for the tag/pointer manifests, `aws s3api head-object` for every platform url/sig (public URL mapped back to its object key). This verifies what the job is responsible for — that the mirror landed; the public edge is unreachable from Actions by Cloudflare policy either way.
- **release.yml** compatibility asset: fetch `latest/latest.json` via S3 with the same repo-level R2 secrets, with a `HAS_R2` guard that skips cleanly when they are absent (mirrors the desktop workflow's guard).

The local manifest validation (version, download_page, URL prefixes) is unchanged.

## Verification

- `actionlint` passes on both workflows.
- Runtime path exercises on the next `v*` / `desktop-v*` tag; object keys were cross-checked against the mirror step's upload layout (`s3://$R2_BUCKET/$TAG/` and pointer dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)