### PR TITLE
fix(ci): keep the repository-wide latest badge on the CLI release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -269,7 +269,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
+          # Repository-wide "latest" is reserved for the CLI line (see header);
+          # without this a desktop release published after the CLI one steals it.
+          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes --latest=false)
           [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
           gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
 


### PR DESCRIPTION
## Problem

`release-desktop.yml`'s own header says GitHub's repository-wide **latest** badge is reserved for the CLI (`v*`) line, but `gh release create` never passed `--latest=false` — so whichever line publishes second wins the badge. In the 1.17.0 cycle the desktop pipeline finished after the CLI one and `desktop-v1.17.0` stole `latest` (corrected by hand with `gh release edit v1.17.0 --latest`).

## Fix

Pin desktop stable releases to `--latest=false` so the badge stays on the `v*` line regardless of publish order. Canary is unaffected (no GitHub release), and prereleases were already excluded from `latest` by `--prerelease`.

## Verification

- `actionlint` passes.
- `gh release create --latest=false` verified against gh CLI docs; runtime path exercises on the next `desktop-v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)