### PR TITLE
fix(desktop): disable "Summarize after this" on the last message

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-grouping.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-grouping.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { buildStepGroups, buildTurnGroups, createWarmLayerState, questionTurnsById, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
+import { buildStepGroups, buildTurnGroups, createWarmLayerState, lastQuestionTurn, questionTurnsById, warmColdPageForTurn, warmLayerForSession, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination } from "../lib/transcriptGrouping";
 import type { Item } from "../lib/useController";
 
 let passed = 0;
@@ -105,6 +105,22 @@ console.log("\ntranscript grouping contract");
   eq(backendTurns.get("u0"), 0, "uses backend checkpoint turn zero when present");
   eq(backendTurns.get("u2"), 3, "uses non-contiguous backend checkpoint turn");
   ok(!backendTurns.has("u1"), "does not mix visible ordinal fallback into authoritative checkpoint sessions");
+  eq(lastQuestionTurn([
+    { id: "u0", text: "first", turn: 0 },
+    { id: "u1", text: "second", turn: 1 },
+  ], visibleTurns), 1, "last question turn follows visible ordinal fallback");
+  eq(lastQuestionTurn([
+    { id: "u0", text: "first", turn: 0, checkpointTurn: 0 },
+    { id: "u1", text: "live without server stamp yet", turn: 1 },
+    { id: "u2", text: "after hidden synthetic", turn: 2, checkpointTurn: 3 },
+  ], backendTurns), 3, "last question turn follows non-contiguous backend turn");
+
+  const pagedTurns = questionTurnsById([
+    { id: "u-recent", text: "recent prompt", turn: 0, checkpointTurn: 1060 },
+  ]);
+  eq(lastQuestionTurn([
+    { id: "u-recent", text: "recent prompt", turn: 0, checkpointTurn: 1060 },
+  ], pagedTurns), 1060, "last question turn supports paged history windows");
 }
 
 {

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -557,6 +557,7 @@ export function TurnActions({
   actionPending = false,
   rewindDisabled = false,
   hoverMenus = false,
+  isLastTurn = false,
 }: {
   text: string;
   turn?: number;
@@ -567,6 +568,8 @@ export function TurnActions({
   actionPending?: boolean;
   rewindDisabled?: boolean;
   hoverMenus?: boolean;
+  /** true when this is the last user turn — disables "summarize after" */
+  isLastTurn?: boolean;
 }) {
   const t = useT();
   const [confirmScope, setConfirmScope] = useState<MessageActionScope | null>(null);
@@ -576,6 +579,9 @@ export function TurnActions({
     if (!checkpoint) return t("rewind.disabledNoCheckpoint");
     if ((scope === "fork" || scope === "summ-from" || scope === "conversation") && !checkpoint.canConversation) {
       return t("rewind.disabledNoBoundary");
+    }
+    if (scope === "summ-from" && isLastTurn) {
+      return t("rewind.disabledNoLater");
     }
     if (scope === "summ-upto") {
       if (!checkpoint.canConversation) return t("rewind.disabledNoBoundary");

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -373,6 +373,7 @@ export function Transcript({
 
   const hotZoneNodes = useMemo<ReactNode[]>(() => {
     const out: ReactNode[] = [];
+    const maxTurn = questions.length - 1;
     let actionText = "";
     let actionReady = false;
     let activeTurn: number | undefined;
@@ -391,6 +392,7 @@ export function Transcript({
           actionPending={actionPending}
           rewindDisabled={rewindDisabled}
           hoverMenus={actionHoverMenus}
+          isLastTurn={turn === maxTurn}
           onRewind={(targetTurn, scope) => {
             onRewind?.(targetTurn, scope);
             setOpenAction(null);
@@ -594,7 +596,7 @@ export function Transcript({
       if (!running) pushTurnActions();
     }
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode, questions.length]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -774,6 +776,7 @@ const WarmZone = memo(function WarmZone({
               onEdit={warmOnEdit}
               tabId={tabId}
               creationMode={creationMode}
+              totalTurns={turnGroups.length}
             />
           </WarmTurnCard>,
         );
@@ -821,6 +824,7 @@ function WarmTurnItems({
   onEdit,
   tabId,
   creationMode = false,
+  totalTurns = 0,
 }: {
   startIdx: number;
   endIdx: number;
@@ -837,8 +841,11 @@ function WarmTurnItems({
   onEdit?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   tabId?: string;
   creationMode?: boolean;
+  /** total number of user turns in the conversation */
+  totalTurns?: number;
 }) {
   const nodes: React.ReactNode[] = [];
+  const maxTurn = totalTurns - 1;
   let actionText = "";
   let actionReady = false;
   let activeTurn: number | undefined;
@@ -857,6 +864,7 @@ function WarmTurnItems({
         actionPending={actionPending}
         rewindDisabled={rewindDisabled}
         hoverMenus={actionHoverMenus}
+        isLastTurn={turn === maxTurn}
         onRewind={(targetTurn, scope) => {
           onRewind?.(targetTurn, scope);
           setOpenAction(null);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -14,7 +14,7 @@ import { isReadOnlyTool } from "../lib/useController";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { useEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useScrollManager } from "../lib/useScrollManager";
-import { buildStepGroups, buildTurnGroups, compactQuestionText, createWarmLayerState, questionAnchorId, questionTurnsById, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
+import { buildStepGroups, buildTurnGroups, compactQuestionText, createWarmLayerState, lastQuestionTurn, questionAnchorId, questionTurnsById, scrollVersion, warmColdPageForTurn, warmLayerWithColdPageAtLeast, warmLayerWithExpandedTurn, warmLayerWithNextColdPage, warmPagination, warmUserPreview, type QuestionAnchor, type TurnGroup, type WarmLayerState } from "../lib/transcriptGrouping";
 import { appendTurnActionCopyText } from "../lib/turnActionCopy";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
@@ -315,6 +315,7 @@ export function Transcript({
   }, [openAction]);
 
   const userTurn = useMemo(() => questionTurnsById(questions), [questions]);
+  const lastTurn = useMemo(() => lastQuestionTurn(questions, userTurn), [questions, userTurn]);
   const checkpointsByTurn = useMemo(() => new Map(checkpoints.map((checkpoint) => [checkpoint.turn, checkpoint])), [checkpoints]);
 
   // ── JumpBar integration ───────────────────────────────────────────────────
@@ -373,7 +374,6 @@ export function Transcript({
 
   const hotZoneNodes = useMemo<ReactNode[]>(() => {
     const out: ReactNode[] = [];
-    const maxTurn = questions.length - 1;
     let actionText = "";
     let actionReady = false;
     let activeTurn: number | undefined;
@@ -392,7 +392,7 @@ export function Transcript({
           actionPending={actionPending}
           rewindDisabled={rewindDisabled}
           hoverMenus={actionHoverMenus}
-          isLastTurn={turn === maxTurn}
+          isLastTurn={turn === lastTurn}
           onRewind={(targetTurn, scope) => {
             onRewind?.(targetTurn, scope);
             setOpenAction(null);
@@ -596,7 +596,7 @@ export function Transcript({
       if (!running) pushTurnActions();
     }
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode, questions.length]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode, lastTurn]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -634,6 +634,7 @@ export function Transcript({
               warmSubcalls={subcallsByParent}
               warmUserTurn={userTurn}
               warmCheckpoints={checkpointsByTurn}
+              warmLastTurn={lastTurn}
               warmOpenAction={openAction}
               warmActionPending={actionPending}
               warmRewindDisabled={rewindDisabled}
@@ -689,6 +690,7 @@ const WarmZone = memo(function WarmZone({
   warmSubcalls,
   warmUserTurn,
   warmCheckpoints,
+  warmLastTurn,
   warmOpenAction,
   warmActionPending,
   warmRewindDisabled,
@@ -711,6 +713,7 @@ const WarmZone = memo(function WarmZone({
   warmSubcalls: ReadonlyMap<string, ToolItem[]>;
   warmUserTurn: ReadonlyMap<string, number>;
   warmCheckpoints: ReadonlyMap<number, CheckpointMeta>;
+  warmLastTurn?: number;
   warmOpenAction: OpenTurnAction | null;
   warmActionPending: boolean;
   warmRewindDisabled: boolean;
@@ -776,7 +779,7 @@ const WarmZone = memo(function WarmZone({
               onEdit={warmOnEdit}
               tabId={tabId}
               creationMode={creationMode}
-              totalTurns={turnGroups.length}
+              lastTurn={warmLastTurn}
             />
           </WarmTurnCard>,
         );
@@ -824,7 +827,7 @@ function WarmTurnItems({
   onEdit,
   tabId,
   creationMode = false,
-  totalTurns = 0,
+  lastTurn,
 }: {
   startIdx: number;
   endIdx: number;
@@ -841,11 +844,9 @@ function WarmTurnItems({
   onEdit?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   tabId?: string;
   creationMode?: boolean;
-  /** total number of user turns in the conversation */
-  totalTurns?: number;
+  lastTurn?: number;
 }) {
   const nodes: React.ReactNode[] = [];
-  const maxTurn = totalTurns - 1;
   let actionText = "";
   let actionReady = false;
   let activeTurn: number | undefined;
@@ -864,7 +865,7 @@ function WarmTurnItems({
         actionPending={actionPending}
         rewindDisabled={rewindDisabled}
         hoverMenus={actionHoverMenus}
-        isLastTurn={turn === maxTurn}
+        isLastTurn={turn === lastTurn}
         onRewind={(targetTurn, scope) => {
           onRewind?.(targetTurn, scope);
           setOpenAction(null);

--- a/desktop/frontend/src/lib/transcriptGrouping.ts
+++ b/desktop/frontend/src/lib/transcriptGrouping.ts
@@ -74,6 +74,14 @@ export function questionTurnsById(questions: QuestionAnchor[]): Map<string, numb
   return turns;
 }
 
+export function lastQuestionTurn(questions: readonly QuestionAnchor[], turns: ReadonlyMap<string, number>): number | undefined {
+  for (let i = questions.length - 1; i >= 0; i -= 1) {
+    const turn = turns.get(questions[i].id);
+    if (turn != null) return turn;
+  }
+  return undefined;
+}
+
 export function scrollVersion(items: Item[]): string {
   return items
     .map((it) => {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1819,6 +1819,7 @@ export const en = {
   "rewind.disabledNoBoundary": "Conversation boundary is unavailable for this message",
   "rewind.disabledNoCode": "No code changes were captured after this message",
   "rewind.disabledNoEarlier": "There is nothing before this message to summarize",
+  "rewind.disabledNoLater": "There is nothing after this message to summarize",
   "rewind.filesChanged": "{count} files",
   "rewind.turnFiles": "{count} this turn",
   "rewind.both": "Rewind code and conversation",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1164,6 +1164,7 @@ export const zhTW: Record<DictKey, string> = {
   "rewind.disabledNoBoundary": "這條訊息的會話邊界不可用",
   "rewind.disabledNoCode": "這條訊息之後沒有捕獲到程式碼變更",
   "rewind.disabledNoEarlier": "這條訊息之前沒有可總結內容",
+  "rewind.disabledNoLater": "這條訊息之後沒有可總結內容",
   "rewind.filesChanged": "{count} 個檔案",
   "rewind.turnFiles": "本輪 {count} 個",
   "rewind.both": "回滾程式碼和對話",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1821,6 +1821,7 @@ export const zh: Record<DictKey, string> = {
   "rewind.disabledNoBoundary": "这条消息的会话边界不可用",
   "rewind.disabledNoCode": "这条消息之后没有捕获到代码改动",
   "rewind.disabledNoEarlier": "这条消息之前没有可总结内容",
+  "rewind.disabledNoLater": "这条消息之后没有可总结内容",
   "rewind.filesChanged": "{count} 个文件",
   "rewind.turnFiles": "本轮 {count} 个",
   "rewind.both": "回滚代码和对话",


### PR DESCRIPTION
## Problem

The "Summarize after this" button (summ-from) is enabled on the last user message, but there is nothing after it to summarize. This is inconsistent with the existing behavior that correctly disables "Summarize before this" on the first message (turn <= 0).

**Issue:** #5744

## Root Cause

`Message.tsx:574-589` — `actionDisabledReason("summ-from")` checks `canConversation` but does not check whether the current turn is the last turn.

## Changes

| File | Change |
|------|--------|
| `Message.tsx` | Add `isLastTurn` prop to `TurnActions`; check it in `actionDisabledReason` for `summ-from` |
| `Transcript.tsx` | Pass `isLastTurn={turn === maxTurn}` from hot zone and warm zone rendering |
| `en.ts` | Add `rewind.disabledNoLater` key |
| `zh.ts` | Add `rewind.disabledNoLater` key |
| `zh-TW.ts` | Add `rewind.disabledNoLater` key |

## Testing

- TypeScript compiles with no new errors
- The disable logic mirrors the existing `summ-upto` check on turn 0
- Manual verification: "Summarize after this" should be greyed out on the last message with tooltip "There is nothing after this message to summarize"