### PR TITLE
fix(desktop): normalize session path case on Windows for lease matching

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
+	goruntime "runtime"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
@@ -7015,7 +7016,13 @@ func canonicalTabSessionPath(path string) string {
 		return ""
 	}
 	if validPath, _, err := validateSessionPath(config.SessionDir(), path); err == nil {
+		if goruntime.GOOS == "windows" {
+			validPath = strings.ToLower(validPath)
+		}
 		return validPath
+	}
+	if goruntime.GOOS == "windows" {
+		path = strings.ToLower(path)
 	}
 	return path
 }


### PR DESCRIPTION
## Summary

### Problems (#6006)

**中文：**
- Windows 上切换 model / effort / token mode 时，当前 tab 可能误报 session 已在另一个 Reasonix 窗口或后台进程中打开。
- 该提示即使在当前 tab 自己已经持有 session lease 的情况下也可能出现。
- 这会阻塞 v1.16 之后依赖 session runtime lease 的 controller rebuild 流程。

**English:**
- On Windows, switching model / effort / token mode can incorrectly report that the current session is already open in another Reasonix window or background process.
- The warning can appear even when the active tab itself already owns the session lease.
- This blocks controller rebuild flows that rely on session runtime leases introduced/enforced after v1.16.

### Root Causes

**中文：**
- agent 层通过 `canonicalSessionSavePath` 规范化 session path，并且在 Windows 下会转成小写。
- desktop tab 层通过 `canonicalTabSessionPath` / `sessionRuntimeKey` 做 lease key 匹配，但此前没有应用相同的 Windows 大小写规范化。
- 因此 `c:\users\...\session.jsonl` 和 `C:\Users\...\session.jsonl` 会被 desktop 层误判成不同 runtime key，导致当前 tab 尝试再次 acquire 自己已经持有的 lease。
- `agent.TryAcquireSessionLease` 随后正确返回 `ErrSessionLeaseHeld`，但 desktop 将其展示成另一个窗口/后台进程占用的用户提示。

**English:**
- The agent layer normalizes session paths via `canonicalSessionSavePath`, which lowercases on Windows.
- The desktop tab layer uses `canonicalTabSessionPath` / `sessionRuntimeKey` for lease key matching, but previously did not apply the same Windows case normalization.
- As a result, `c:\users\...\session.jsonl` and `C:\Users\...\session.jsonl` were treated as different runtime keys by the desktop layer, causing the current tab to try to re-acquire a lease it already held.
- `agent.TryAcquireSessionLease` then correctly returned `ErrSessionLeaseHeld`, but the desktop layer surfaced it as a user-facing message about another window/background process.

### Changes

**中文：**
- 在 `desktop/tabs.go` 的 import 中新增 `goruntime runtime`，避免和 Wails 的 `runtime` 包命名冲突。
- 在 `canonicalTabSessionPath` 中，当 `validateSessionPath` 成功时，Windows 下对返回的 `validPath` 执行 `strings.ToLower(validPath)`。
- 当 path 无法通过 `validateSessionPath` 校验但仍被用作 runtime key 时，Windows 下也对原始 `path` 执行 `strings.ToLower(path)`。
- 这样 `sessionRuntimeKey(path)`、`ensureSessionLease(path)`、`sessionLeaseRuntimeKey()` 等 desktop lease 比较路径会和 agent 层 `canonicalSessionSavePath` 的 Windows 规范化结果保持一致。
- 修复范围最小：不改动 lease acquire/release 行为、用户错误包装、controller rebuild 流程或 session 文件格式。

**English:**
- Added `goruntime runtime` to `desktop/tabs.go` imports to avoid colliding with the Wails `runtime` package name.
- Updated `canonicalTabSessionPath`: when `validateSessionPath(config.SessionDir(), path)` succeeds, the returned `validPath` is lowercased on Windows via `strings.ToLower(validPath)`.
- Updated the fallback branch in `canonicalTabSessionPath`: when the path cannot be validated but is still used as a runtime key, the original `path` is also lowercased on Windows via `strings.ToLower(path)`.
- This makes desktop lease comparisons through `sessionRuntimeKey(path)`, `ensureSessionLease(path)`, and `sessionLeaseRuntimeKey()` consistent with the agent layer's `canonicalSessionSavePath` normalization on Windows.
- The fix stays minimal: it does not change lease acquire/release behavior, user-facing error wrapping, controller rebuild flow, or session file format.

Fixes #6006