### PR TITLE
Fix Windows desktop session lease self-lock on model switch / 修复 Windows 桌面端切换模型会话租约自锁

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1582,7 +1582,10 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	snap := a.tabRuntimeSnapshot(tab)
 	oldSink := snap.sink
 	if oldSink != nil {
-		oldSink.setBinding(detachedRuntimeTabID(oldPath), nil)
+		// Rebind under the runtime key, matching the id cloneDetachedRuntimeTab
+		// derives — a raw path here would hash to a different detached id on
+		// Windows where keys are case-folded.
+		oldSink.setBinding(detachedRuntimeTabID(sessionRuntimeKey(oldPath)), nil)
 		oldSink.clearContext()
 	}
 	if oldCtrl.RuntimeStatus().Cancellable {
@@ -7155,6 +7158,9 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	tab.model = name
 	tab.effort = cloneStringPtr(effortOverride)
 	tab.Label = newCtrl.Label()
+	// Supersede any in-flight startup build: it would otherwise finish later,
+	// overwrite this controller, and release/steal the tab's session lease.
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {
@@ -7304,6 +7310,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
 	tab.Ready = true
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {
@@ -7429,6 +7436,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
 	tab.Ready = true
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1655,19 +1655,28 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	newCtrl.SetSessionPath(path)
 
 	a.mu.Lock()
-	if current := a.tabs[tab.ID]; current == tab {
-		tab.Ctrl = newCtrl
-		tab.sink = newSink
-		tab.SessionPath = path
-		tab.Label = newCtrl.Label()
-		tab.Ready = true
-		tab.StartupErr = ""
-		// Supersede any in-flight startup build: the session it was resuming
-		// was just destroyed, and finishing later would pass the generation
-		// check and overwrite this controller.
-		a.supersedeTabBuildLocked(tab)
-		a.saveTabsLocked()
+	if current := a.tabs[tab.ID]; current != tab {
+		a.mu.Unlock()
+		// The old session is already destroyed either way; release what this
+		// clear acquired for the replaced tab (fresh controller and its
+		// lease) so neither leaks, and still finish the old runtime teardown.
+		newCtrl.Close()
+		tab.releaseSessionLease()
+		oldCtrl.CloseAfterDestroy()
+		a.emitProjectTreeChanged()
+		return fmt.Errorf("tab %q changed while clearing the session", tab.ID)
 	}
+	tab.Ctrl = newCtrl
+	tab.sink = newSink
+	tab.SessionPath = path
+	tab.Label = newCtrl.Label()
+	tab.Ready = true
+	tab.StartupErr = ""
+	// Supersede any in-flight startup build: the session it was resuming
+	// was just destroyed, and finishing later would pass the generation
+	// check and overwrite this controller.
+	a.supersedeTabBuildLocked(tab)
+	a.saveTabsLocked()
 	a.mu.Unlock()
 	oldCtrl.CloseAfterDestroy()
 	a.emitProjectTreeChanged()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1662,6 +1662,10 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 		tab.Label = newCtrl.Label()
 		tab.Ready = true
 		tab.StartupErr = ""
+		// Supersede any in-flight startup build: the session it was resuming
+		// was just destroyed, and finishing later would pass the generation
+		// check and overwrite this controller.
+		a.supersedeTabBuildLocked(tab)
 		a.saveTabsLocked()
 	}
 	a.mu.Unlock()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3776,6 +3776,74 @@ func TestClearActiveSessionRuntimeSupersedesInFlightStartupBuild(t *testing.T) {
 	assertTabBuildSuperseded(t, app, tab, 1, buildCtx)
 }
 
+func TestClearActiveSessionRuntimeReleasesResourcesWhenTabReplaced(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "clear-runtime-replaced-tab.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+
+	oldSession := agent.NewSession("old system prompt")
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:          "tab_replaced",
+		Scope:       "global",
+		SessionPath: sessionPath,
+		model:       "old/old-model",
+		Ready:       true,
+		Ctrl:        oldCtrl,
+		disabledMCP: map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	// The tab entry now points at a replacement struct (the tab was closed and
+	// reopened while the clear ran off-lock), so the swap must not apply.
+	replacement := &WorkspaceTab{ID: tab.ID, Scope: "global"}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: replacement}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(tab.releaseSessionLease)
+
+	err := app.clearActiveSessionRuntime(tab, oldCtrl)
+	if err == nil || !strings.Contains(err.Error(), "changed while clearing") {
+		t.Fatalf("clearActiveSessionRuntime error = %v, want tab-changed error", err)
+	}
+	if replacement.Ctrl != nil {
+		t.Fatalf("replacement tab controller = %v, want untouched nil", replacement.Ctrl)
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatalf("replaced tab controller = %v, want left on the destroyed runtime", tab.Ctrl)
+	}
+	if key := tab.sessionLeaseRuntimeKey(); key != "" {
+		t.Fatalf("replaced tab still holds a session lease for %q; the fresh lease leaked", key)
+	}
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Fatalf("old session artifacts were not destroyed (stat err=%v)", err)
+	}
+}
+
 func TestDeleteProviderRejectsRunningAffectedTab(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1837,20 +1837,7 @@ func TestSetProviderKeyRebuildSupersedesInFlightStartupBuild(t *testing.T) {
 	}
 	defer tab.Ctrl.Close()
 
-	app.mu.Lock()
-	superseded := app.tabBuildSupersededLocked(tab, startupGeneration)
-	app.mu.Unlock()
-	if !superseded {
-		t.Fatal("in-flight startup build was not superseded; finishing it would overwrite the provider-key controller")
-	}
-	select {
-	case <-buildCtx.Done():
-	default:
-		t.Fatal("in-flight startup build context was not cancelled by the provider-key rebuild")
-	}
-	if tab.buildCancel != nil {
-		t.Fatal("build cancel was not cleared by the provider-key rebuild")
-	}
+	assertTabBuildSuperseded(t, app, tab, startupGeneration, buildCtx)
 }
 
 func TestSaveProviderWithKeyLeaseHeldPersistsCustomProvider(t *testing.T) {
@@ -3627,6 +3614,166 @@ func TestDeleteProviderMigratesConfigAndOpenTabs(t *testing.T) {
 	if tab.Ctrl != nil {
 		t.Fatal("tab controller should be closed and cleared when retargeted without a running app context")
 	}
+}
+
+// assertTabBuildSuperseded checks that the startup build registered before the
+// mutation (generation) can no longer install its controller and that its
+// build context was cancelled.
+func assertTabBuildSuperseded(t *testing.T, app *App, tab *WorkspaceTab, generation uint64, buildCtx context.Context) {
+	t.Helper()
+	app.mu.Lock()
+	superseded := app.tabBuildSupersededLocked(tab, generation)
+	app.mu.Unlock()
+	if !superseded {
+		t.Fatal("in-flight startup build was not superseded; finishing it would reinstall a stale controller")
+	}
+	select {
+	case <-buildCtx.Done():
+	default:
+		t.Fatal("in-flight startup build context was not cancelled")
+	}
+	if tab.buildCancel != nil {
+		t.Fatal("build cancel was not cleared")
+	}
+}
+
+func TestDeleteProviderSupersedesInFlightStartupBuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "prov-b/model-b1"
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "prov-a", Kind: "openai", BaseURL: "https://a.example.com", Model: "model-a1", APIKeyEnv: "REASONIX_TEST_KEY"},
+		{Name: "prov-b", Kind: "openai", BaseURL: "https://b.example.com", Model: "model-b1", APIKeyEnv: "REASONIX_TEST_KEY"},
+	}
+	cfg.Desktop.ProviderAccess = []string{"prov-a", "prov-b"}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	// Model the async startup build still being in flight for the affected
+	// tab: no controller yet, a live generation, a cancellable build context.
+	buildCtx, buildCancel := context.WithCancel(context.Background())
+	tab := &WorkspaceTab{
+		ID:              "tab_a",
+		Scope:           "global",
+		model:           "prov-a/model-a1",
+		buildGeneration: 1,
+		buildCancel:     buildCancel,
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.DeleteProvider("prov-a"); err != nil {
+		t.Fatalf("DeleteProvider: %v", err)
+	}
+	assertTabBuildSuperseded(t, app, tab, 1, buildCtx)
+	if tab.model != "prov-b/model-b1" {
+		t.Fatalf("tab model after delete = %q, want prov-b/model-b1", tab.model)
+	}
+}
+
+func TestRemoveBuiltInProviderAccessSupersedesInFlightStartupBuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "prov-b/model-b1"
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "deepseek", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-chat", APIKeyEnv: "REASONIX_TEST_KEY"},
+		{Name: "prov-b", Kind: "openai", BaseURL: "https://b.example.com", Model: "model-b1", APIKeyEnv: "REASONIX_TEST_KEY"},
+	}
+	cfg.Desktop.ProviderAccess = []string{"deepseek", "prov-b"}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	buildCtx, buildCancel := context.WithCancel(context.Background())
+	tab := &WorkspaceTab{
+		ID:              "tab_ds",
+		Scope:           "global",
+		model:           "deepseek/deepseek-chat",
+		buildGeneration: 1,
+		buildCancel:     buildCancel,
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.RemoveProviderAccess("deepseek"); err != nil {
+		t.Fatalf("RemoveProviderAccess: %v", err)
+	}
+	assertTabBuildSuperseded(t, app, tab, 1, buildCtx)
+	if tab.model != "prov-b/model-b1" {
+		t.Fatalf("tab model after access removal = %q, want prov-b/model-b1", tab.model)
+	}
+}
+
+func TestClearActiveSessionRuntimeSupersedesInFlightStartupBuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "clear-runtime-in-flight.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+
+	oldSession := agent.NewSession("old system prompt")
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: sessionPath, Label: "old", Sink: event.Discard})
+
+	app := NewApp()
+	// A runtime is attached while an older async build is still in flight
+	// (e.g. attached via topic activation); destroying the session must
+	// invalidate that build so it cannot resurrect the destroyed session.
+	buildCtx, buildCancel := context.WithCancel(context.Background())
+	tab := &WorkspaceTab{
+		ID:              "tab_clear",
+		Scope:           "global",
+		SessionPath:     sessionPath,
+		model:           "old/old-model",
+		Ready:           true,
+		Ctrl:            oldCtrl,
+		buildGeneration: 1,
+		buildCancel:     buildCancel,
+		disabledMCP:     map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(tab.releaseSessionLease)
+
+	if err := app.clearActiveSessionRuntime(tab, oldCtrl); err != nil {
+		t.Fatalf("clearActiveSessionRuntime: %v", err)
+	}
+	if tab.Ctrl == nil || tab.Ctrl == oldCtrl {
+		t.Fatalf("clear did not install a fresh controller (ctrl=%v)", tab.Ctrl)
+	}
+	defer tab.Ctrl.Close()
+	assertTabBuildSuperseded(t, app, tab, 1, buildCtx)
 }
 
 func TestDeleteProviderRejectsRunningAffectedTab(t *testing.T) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1781,6 +1781,78 @@ func TestSetProviderKeyLeaseHeldKeepsCurrentController(t *testing.T) {
 	}
 }
 
+func TestSetProviderKeyRebuildSupersedesInFlightStartupBuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "old",
+		Kind:      "openai",
+		BaseURL:   "https://example.invalid/v1",
+		Model:     "old-model",
+		APIKeyEnv: "OLD_MODEL_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "startup-build-in-flight.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	// Model the async startup build still being in flight: no controller yet,
+	// a live build generation, and a cancellable build context.
+	buildCtx, buildCancel := context.WithCancel(context.Background())
+	const startupGeneration = 1
+	tab := &WorkspaceTab{
+		ID:              "tab_key_rebuild",
+		Scope:           "global",
+		SessionPath:     sessionPath,
+		model:           "old/old-model",
+		buildGeneration: startupGeneration,
+		buildCancel:     buildCancel,
+		disabledMCP:     map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(tab.releaseSessionLease)
+
+	if _, err := app.SetProviderKey("OLD_MODEL_KEY", "sk-new"); err != nil {
+		t.Fatalf("SetProviderKey: %v", err)
+	}
+	if tab.Ctrl == nil {
+		t.Fatal("provider-key rebuild did not install a controller")
+	}
+	defer tab.Ctrl.Close()
+
+	app.mu.Lock()
+	superseded := app.tabBuildSupersededLocked(tab, startupGeneration)
+	app.mu.Unlock()
+	if !superseded {
+		t.Fatal("in-flight startup build was not superseded; finishing it would overwrite the provider-key controller")
+	}
+	select {
+	case <-buildCtx.Done():
+	default:
+		t.Fatal("in-flight startup build context was not cancelled by the provider-key rebuild")
+	}
+	if tab.buildCancel != nil {
+		t.Fatal("build cancel was not cleared by the provider-key rebuild")
+	}
+}
+
 func TestSaveProviderWithKeyLeaseHeldPersistsCustomProvider(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")

--- a/desktop/session_key_test.go
+++ b/desktop/session_key_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+// The lease registry folds session paths through agent.CanonicalSessionPath
+// (lowercased on Windows). Every desktop "same session" comparison must fold
+// the same way, or a lease the tab itself holds looks foreign and every
+// model/effort/token switch self-locks with the "already open in another
+// window" error (#5999, #6006, #5996).
+
+func TestSessionRuntimeKeyMatchesLeaseKey(t *testing.T) {
+	dir := t.TempDir()
+	// Mixed-case segment on every platform; on Windows the lease key folds it.
+	path := filepath.Join(dir, "Sessions-Dir", "20260705-Test.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("acquire lease: %v", err)
+	}
+	defer lease.Release()
+
+	if got, want := sessionRuntimeKey(lease.Path()), sessionRuntimeKey(path); got != want {
+		t.Fatalf("lease path key %q != session path key %q; lease reuse checks will self-lock", got, want)
+	}
+}
+
+func TestSessionRuntimeKeyIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Case-Mix", "20260705-Test.jsonl")
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		t.Fatal("empty key for non-empty path")
+	}
+	if again := sessionRuntimeKey(key); again != key {
+		t.Fatalf("sessionRuntimeKey not idempotent: %q -> %q", key, again)
+	}
+}
+
+func TestSessionRuntimeKeyFoldsCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive path identity is Windows-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sessions", "20260705-Test.jsonl")
+	upper := strings.ToUpper(path)
+	if sessionRuntimeKey(path) != sessionRuntimeKey(upper) {
+		t.Fatalf("case variants of one file produced distinct keys: %q vs %q",
+			sessionRuntimeKey(path), sessionRuntimeKey(upper))
+	}
+}
+
+func TestCanonicalTabSessionPathNormalizesOutsideSessionDir(t *testing.T) {
+	// Project-scope sessions live outside config.SessionDir(); the fallback
+	// must still clean the shape so one file cannot split into two keys.
+	dir := t.TempDir()
+	base := filepath.Join(dir, "projects", "p1", "sessions", "20260705-a.jsonl")
+	messy := filepath.Join(dir, "projects", "p1", ".", "sessions") + string(filepath.Separator) + "20260705-a.jsonl"
+	if sessionRuntimeKey(base) != sessionRuntimeKey(messy) {
+		t.Fatalf("path shape variants split keys: %q vs %q",
+			sessionRuntimeKey(base), sessionRuntimeKey(messy))
+	}
+}
+
+func TestEnsureSessionLeaseReusesHeldLease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sessions", "20260705-Reuse.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tab := &WorkspaceTab{ID: "tab_reuse"}
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	defer tab.releaseSessionLease()
+
+	acquires := 0
+	sessionLeaseAcquireHookForTest = func() { acquires++ }
+	defer func() { sessionLeaseAcquireHookForTest = nil }()
+
+	// Same path again — and the lease's own (canonical) form: both must hit
+	// the fast path instead of re-acquiring against our own registry entry.
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("re-ensure same path: %v", err)
+	}
+	if err := tab.ensureSessionLease(tab.sessionLeaseRuntimeKey()); err != nil {
+		t.Fatalf("re-ensure canonical form: %v", err)
+	}
+	if acquires != 0 {
+		t.Fatalf("expected fast-path reuse, got %d new acquires", acquires)
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2375,6 +2375,10 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 			continue
 		}
 		tab.Ctrl = nil
+		// Supersede any in-flight startup build: it was planned against the
+		// removed provider and would otherwise finish later, pass its
+		// generation check, and reinstall a controller for it.
+		a.supersedeTabBuildLocked(tab)
 		tab.model = fallbackRef
 		tab.Label = fallbackRef
 		tab.StartupErr = ""
@@ -2490,6 +2494,10 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 			continue
 		}
 		tab.Ctrl = nil
+		// Supersede any in-flight startup build: it was planned against the
+		// removed provider and would otherwise finish later, pass its
+		// generation check, and reinstall a controller for it.
+		a.supersedeTabBuildLocked(tab)
 		tab.model = fallbackRef
 		tab.Label = fallbackRef
 		tab.StartupErr = ""

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1605,6 +1605,9 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	tab.Label = ctrl.Label()
 	tab.StartupErr = ""
 	tab.Ready = true
+	// Supersede any in-flight startup build: it would otherwise finish later,
+	// pass its generation check, and overwrite the controller just installed.
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	a.clearDeferredRebuild(tab.ID)

--- a/desktop/shared_host_test.go
+++ b/desktop/shared_host_test.go
@@ -18,7 +18,7 @@ func sharedHostRefsForTest(t *testing.T, app *App, root string) (int, bool) {
 
 func TestCloneDetachedRuntimeTabPreservesSharedHostKey(t *testing.T) {
 	tab := &WorkspaceTab{ID: "tab", SharedHostKey: "workspace-root"}
-	detached := cloneDetachedRuntimeTab(tab, "session-key")
+	detached := cloneDetachedRuntimeTab(tab, "session-key", "session-key")
 	if detached == nil {
 		t.Fatal("cloneDetachedRuntimeTab returned nil")
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -241,8 +241,14 @@ func (t *WorkspaceTab) hasActiveRuntimeWork() bool {
 	return status.Running || status.PendingPrompt || status.BackgroundJobs > 0
 }
 
+// sessionRuntimeKey is the comparison/map key for "same session" checks. It
+// layers agent.CanonicalSessionPath on top of the desktop path normalization
+// so the key matches the form held by session leases (lowercased on Windows).
+// Comparing a lease's Path() against a raw tab path without this fold made
+// every rebuild on Windows look like a foreign holder (self-lock, #5999).
+// Keys are identities only — never use them as display or file paths.
 func sessionRuntimeKey(path string) string {
-	return canonicalTabSessionPath(path)
+	return agent.CanonicalSessionPath(canonicalTabSessionPath(path))
 }
 
 var sessionLeaseAcquireHookForTest func()
@@ -426,7 +432,7 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 	}
 	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
-	tab.SessionPath = key
+	tab.SessionPath = canonicalTabSessionPath(path)
 	a.detachedSessions[key] = tab
 	a.mu.Unlock()
 	return true
@@ -437,8 +443,10 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 // ActivityStatus, disabledMCP, ...) are written under a.mu by bound methods
 // and the event sink, and the disabledMCP map read would otherwise race those
 // writers. The session lease is transferred separately by the caller through
-// the sessionLeaseMu helpers.
-func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
+// the sessionLeaseMu helpers. key is the runtime identity (map key / tab id
+// hash); path is the real session path — keys are case-folded on Windows and
+// must not leak into SessionPath, which is displayed and persisted.
+func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab {
 	if tab == nil {
 		return nil
 	}
@@ -454,7 +462,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
 		SharedHostKey:    tab.SharedHostKey,
 		TopicID:          tab.TopicID,
 		TopicTitle:       tab.TopicTitle,
-		SessionPath:      key,
+		SessionPath:      canonicalTabSessionPath(path),
 		Ctrl:             tab.Ctrl,
 		Label:            tab.Label,
 		Ready:            tab.Ready,
@@ -494,12 +502,13 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 		a.mu.Unlock()
 		return false
 	}
-	key := sessionRuntimeKey(tab.currentSessionPath())
+	sourcePath := tab.currentSessionPath()
+	key := sessionRuntimeKey(sourcePath)
 	if key == "" {
 		a.mu.Unlock()
 		return false
 	}
-	detached := cloneDetachedRuntimeTab(tab, key)
+	detached := cloneDetachedRuntimeTab(tab, key, sourcePath)
 	if detached == nil {
 		a.mu.Unlock()
 		return false
@@ -522,7 +531,10 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	return true
 }
 
-func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.Context, app *App) {
+// applyRuntimeTab moves source's runtime (controller, sink, lease, telemetry)
+// onto target. path is the real session path for display/persistence; the
+// case-folded runtime key must never be written into SessionPath.
+func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context.Context, app *App) {
 	if target == nil || source == nil {
 		return
 	}
@@ -539,7 +551,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.
 	target.Ctrl = source.Ctrl
 	target.sink = source.sink
 	target.adoptSessionLease(source.takeSessionLease())
-	target.SessionPath = key
+	target.SessionPath = canonicalTabSessionPath(path)
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
 	target.Ready = true
@@ -571,7 +583,7 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	detached := a.detachedSessions[key]
 	if detached != nil {
 		delete(a.detachedSessions, key)
-		applyRuntimeTab(tab, detached, key, wailsCtx, a)
+		applyRuntimeTab(tab, detached, path, wailsCtx, a)
 		if current := a.tabs[tab.ID]; current == tab {
 			a.saveTabsLocked()
 		}
@@ -602,7 +614,7 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	if a.activeTabID == source.ID {
 		a.activeTabID = tab.ID
 	}
-	applyRuntimeTab(tab, source, key, wailsCtx, a)
+	applyRuntimeTab(tab, source, path, wailsCtx, a)
 	a.saveTabsLocked()
 	attachedCtrl := tab.Ctrl
 	a.mu.Unlock()
@@ -2389,6 +2401,22 @@ func (a *App) tabBuildSuperseded(tab *WorkspaceTab, generation uint64) bool {
 	return a.tabBuildSupersededLocked(tab, generation)
 }
 
+// supersedeTabBuildLocked invalidates any in-flight startup build and cancels
+// its context. A synchronous rebuild (model/effort/token switch) that has
+// already installed its controller calls this so a slower blank-session build
+// cannot finish afterward, overwrite tab.Ctrl, and release or steal the
+// session lease the switch just bound. Callers must hold a.mu.
+func (a *App) supersedeTabBuildLocked(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	tab.buildGeneration++
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+		tab.buildCancel = nil
+	}
+}
+
 // abandonSupersededBuild cleans up after a build that lost tab ownership
 // mid-flight (removed tab, or a session rebind bumped the generation). It
 // releases only what THIS build acquired — its controller, its own
@@ -2752,6 +2780,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				a.emitReady(wailsCtx, tab.ID)
 				return
 			}
+			preLeaseKey := tab.sessionLeaseRuntimeKey()
 			if err := tab.ensureSessionLease(path); err != nil {
 				a.mu.Lock()
 				if a.tabBuildSupersededLocked(tab, buildGeneration) {
@@ -2762,7 +2791,10 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				tab.StartupErr = err.Error()
 				tab.Ready = true
 				hostKey := takeTabSharedHostKey(tab)
-				tab.releaseSessionLease()
+				// Release only a lease bound to THIS build's session: a failed
+				// ensure leaves any prior lease untouched, and that lease may
+				// belong to a runtime a concurrent switch just installed.
+				tab.releaseSessionLeaseForKey(sessionRuntimeKey(path))
 				a.mu.Unlock()
 				ctrl.Close()
 				if hostKey != "" {
@@ -2773,8 +2805,12 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			}
 			// Remember which lease THIS build bound: if the build is later
 			// superseded, only a lease still carrying this key may be
-			// released (see abandonSupersededBuild).
-			acquiredLeaseKey = sessionRuntimeKey(path)
+			// released (see abandonSupersededBuild). A fast-path reuse means
+			// the lease existed before this build (bound by a concurrent
+			// switch or recovery) — it is not ours to release.
+			if key := sessionRuntimeKey(path); key != preLeaseKey {
+				acquiredLeaseKey = key
+			}
 			// Re-check ownership right after the (potentially slow) lease
 			// bind: a rebind that superseded this build while ensure was in
 			// flight has already retargeted the tab, and continuing into
@@ -7017,7 +7053,15 @@ func canonicalTabSessionPath(path string) string {
 	if validPath, _, err := validateSessionPath(config.SessionDir(), path); err == nil {
 		return validPath
 	}
-	return path
+	// Project-scope sessions live outside config.SessionDir(), so validation
+	// against it always fails. Still normalize the shape: without clean+abs,
+	// the same file spelled with a different separator or a relative prefix
+	// splits into distinct runtime keys.
+	cleaned := filepath.Clean(path)
+	if abs, err := filepath.Abs(cleaned); err == nil {
+		return abs
+	}
+	return cleaned
 }
 
 func (a *App) rememberTabSessionPath(tab *WorkspaceTab, path string) {

--- a/internal/agent/canonical_path_test.go
+++ b/internal/agent/canonical_path_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalSessionPathMatchesLeaseRegistryKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Mixed-Case", "20260705-Test.jsonl")
+	if got, want := CanonicalSessionPath(path), canonicalSessionSavePath(path); got != want {
+		t.Fatalf("CanonicalSessionPath(%q) = %q, want lease key %q", path, got, want)
+	}
+}
+
+func TestCanonicalSessionPathIdempotentAndEmptySafe(t *testing.T) {
+	if got := CanonicalSessionPath(""); got != "" {
+		t.Fatalf("empty path resolved to %q; must stay empty", got)
+	}
+	if got := CanonicalSessionPath("   "); got != "" {
+		t.Fatalf("blank path resolved to %q; must stay empty", got)
+	}
+	path := filepath.Join(t.TempDir(), "A", "b.jsonl")
+	key := CanonicalSessionPath(path)
+	if again := CanonicalSessionPath(key); again != key {
+		t.Fatalf("not idempotent: %q -> %q", key, again)
+	}
+}
+
+func TestCanonicalSessionPathFoldsCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case folding is Windows-only")
+	}
+	path := filepath.Join(t.TempDir(), "Sessions", "20260705-Test.jsonl")
+	if CanonicalSessionPath(path) != CanonicalSessionPath(strings.ToUpper(path)) {
+		t.Fatal("case variants of one file produced distinct keys")
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -813,6 +813,20 @@ func canonicalSessionSavePath(path string) string {
 	return key
 }
 
+// CanonicalSessionPath is the identity key of a session path: cleaned,
+// absolute, and case-folded on Windows, matching the key form used by the
+// lease registry and the save-path locks. Any runtime bookkeeping that
+// compares or maps session paths (desktop tabs, detached runtimes) must use
+// this exact form, or the same file splits into distinct keys — e.g.
+// `C:\Users\...` vs the lease's lowercased `c:\users\...`. Empty input stays
+// empty instead of resolving to the working directory.
+func CanonicalSessionPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return canonicalSessionSavePath(path)
+}
+
 // LoadSession reads a saved session into a fresh Session value. New sessions
 // replay the append-only event log; legacy sessions without an event log fall
 // back to the compatibility .jsonl checkpoint. A damaged log is replayed to its


### PR DESCRIPTION
## Summary

Windows desktop users could not switch model / effort / token mode / provider key even in a single window — every attempt failed with:

> this session is already open in another Reasonix window or still running in the background; close the other window or open a copy before changing model

This reproduced on fresh installs with the lease info PID pointing at the running process itself (#5999's verification), across v1.16.0–v1.17.0.

## Root cause

Two canonical forms for one session path:

- The lease registry keys sessions through `canonicalSessionSavePath` — clean + absolute + **lowercased on Windows** (`internal/agent/save.go`). `SessionLease.Path()` returns this folded form.
- Desktop's `sessionRuntimeKey` kept the raw path case (`desktop/tabs.go`).

On Windows every real session path contains uppercase segments (`C:\Users\...`), so the tab's *own* lease never compared equal to its session key. `ensureSessionLease` skipped the reuse fast path, re-acquired against the process's own in-process registry entry (`ErrSessionLeaseHeld`, with our own PID in the lease info), and the reclaim fallback then hit the tab's own live `LockFileEx` handle. Single-window self-lock, deterministic.

Two adjacent defects shared the same mismatch or surface:

- `releaseSessionLeaseForKey` never matched on Windows, so an abandoned startup build leaked a held lease (session stays busy for every window until restart).
- A startup build racing a successful model/effort/token switch could later overwrite the freshly installed controller, or release / claim the lease the switch had just bound (the switch paths never superseded in-flight builds; on non-Windows too).

## Changes

- Export `agent.CanonicalSessionPath` and layer it into `sessionRuntimeKey`, so desktop identity checks agree with the lease registry byte-for-byte; normalize the `canonicalTabSessionPath` fallback (project-scope sessions) with clean+abs so shape variants cannot split one file into two keys.
- Keep case-folded keys out of `SessionPath`: detach/attach paths (`cloneDetachedRuntimeTab`, `applyRuntimeTab`, `detachSessionRuntime`) now carry the display path separately from the runtime key; the detached sink rebind hashes the runtime key consistently.
- Startup build lease hygiene: on ensure failure release only a lease bound to this build's session (never a lease a concurrent switch installed); skip recording `acquiredLeaseKey` when the fast path merely reused an existing lease.
- `SetModelForTab` / `SetEffortForTab` / `SetTokenModeForTab` supersede any in-flight startup build (`supersedeTabBuildLocked`: generation bump + build-context cancel) inside the same critical section that installs the replacement controller.

## Tests

- New: lease/runtime key agreement (cross-platform invariant that fails on Windows before this fix), key idempotence, Windows case-folding (skipped off-Windows), project-scope fallback normalization, fast-path lease reuse without re-acquire.
- `go test ./internal/agent` (full, incl. lease suite) — pass.
- `cd desktop && go test .` (full suite) — pass; lease/switch subset with `-race` — pass.
- `GOOS=windows GOARCH=amd64 go build ./...` in both modules — clean.

## Cache impact

Cache-impact: none. Desktop runtime ownership and lease bookkeeping only; no provider-visible prompts, tool schemas, request serialization, or compaction changes.

Fixes #5999. Fixes #6006. Fixes #5989. Fixes #5990. Refs #5996.
