### PR TITLE
Harden session CAS meta ledger against torn reads and lost updates / 加固会话 CAS 元数据账本防撕裂读与丢失更新

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5084,22 +5084,33 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 			}
 		}
 
-		meta, err := agent.EnsureBranchMeta(info.Path)
+		migrated, err := func() (bool, error) {
+			// Read-modify-write on the branch-meta sidecar: hold the per-path
+			// meta lock so agent-side writers (autosave revision bumps,
+			// in-flight markers) can't interleave between the load and save
+			// below and lose their fields.
+			unlock := agent.LockSessionMetaPath(info.Path)
+			defer unlock()
+			meta, err := agent.EnsureBranchMeta(info.Path)
+			if err != nil {
+				return false, err
+			}
+			// Preserve scoped sessions only when their existing ownership matches
+			// the directory being migrated.
+			if !legacySessionMetaMatchesMigrationTarget(meta, scope, workspaceRoot) {
+				return false, nil
+			}
+			meta.Scope = scope
+			meta.WorkspaceRoot = workspaceRoot
+			meta.TopicID = topicID
+			meta.TopicTitle = title
+			return true, agent.SaveBranchMetaPreserveUpdated(info.Path, meta)
+		}()
 		if err != nil {
 			deferred = true
 			continue
 		}
-		// Preserve scoped sessions only when their existing ownership matches
-		// the directory being migrated.
-		if !legacySessionMetaMatchesMigrationTarget(meta, scope, workspaceRoot) {
-			continue
-		}
-		meta.Scope = scope
-		meta.WorkspaceRoot = workspaceRoot
-		meta.TopicID = topicID
-		meta.TopicTitle = title
-		if err := agent.SaveBranchMetaPreserveUpdated(info.Path, meta); err != nil {
-			deferred = true
+		if !migrated {
 			continue
 		}
 		if topicTitles == nil {
@@ -5199,7 +5210,22 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 		return err
 	}
 	if !ok || strings.TrimSpace(meta.TopicID) == "" {
+		// The migration pass takes per-session meta locks itself, so it must
+		// run outside the lock taken below.
 		migrateLegacySessionsIntoGlobalTopics(dir)
+		return nil
+	}
+
+	// Read-modify-write on the branch-meta sidecar: re-read and save under the
+	// per-path meta lock so a concurrent save's revision bump can't land in
+	// between and get rolled back by the write at the end.
+	unlock := agent.LockSessionMetaPath(sessionPath)
+	defer unlock()
+	meta, ok, err = agent.LoadBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	if !ok || strings.TrimSpace(meta.TopicID) == "" {
 		return nil
 	}
 
@@ -5551,12 +5577,19 @@ func (a *App) updateTopicSessionTitles(topicID, title string) {
 	}
 	for _, dir := range a.knownSessionDirs() {
 		for _, match := range topicSessionMatches(dir, topicID) {
+			// Read-modify-write on the branch-meta sidecar: hold the per-path
+			// meta lock so a concurrent save's revision bump can't land between
+			// the load and save below and get rolled back by this write.
+			unlock := agent.LockSessionMetaPath(match.path)
 			meta, ok, err := agent.LoadBranchMeta(match.path)
 			if err != nil || !ok {
+				unlock()
 				continue
 			}
 			meta.TopicTitle = title
-			if err := agent.SaveBranchMetaPreserveUpdated(match.path, meta); err == nil {
+			err = agent.SaveBranchMetaPreserveUpdated(match.path, meta)
+			unlock()
+			if err == nil {
 				invalidateTopicSessionIndex(dir)
 			}
 		}

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -131,6 +131,32 @@ func LoadBranchMeta(sessionPath string) (BranchMeta, bool, error) {
 	return m, true, nil
 }
 
+// branchMetaReadBackoffs paces the re-reads of a branch-meta sidecar that
+// failed to load. On Windows fileutil.ReplaceFile can fall back to a
+// non-atomic in-place copy, so a concurrent reader may catch the sidecar
+// half-written (an open/read error or truncated JSON). Those tears heal in
+// milliseconds; a few short retries separate them from real corruption.
+var branchMetaReadBackoffs = []time.Duration{20 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond}
+
+// loadBranchMetaRetry reads the branch-meta sidecar like LoadBranchMeta but
+// retries transient failures (I/O errors and undecodable JSON) before giving
+// up. A missing sidecar is a legitimate state — a session that has never
+// recorded meta — and returns ok=false immediately without retrying.
+func loadBranchMetaRetry(sessionPath string) (BranchMeta, bool, error) {
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		meta, ok, err := LoadBranchMeta(sessionPath)
+		if err == nil {
+			return meta, ok, nil
+		}
+		lastErr = err
+		if attempt >= len(branchMetaReadBackoffs) {
+			return BranchMeta{}, false, lastErr
+		}
+		time.Sleep(branchMetaReadBackoffs[attempt])
+	}
+}
+
 func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 	return saveBranchMeta(sessionPath, m, true)
 }
@@ -335,6 +361,11 @@ func RenameSession(sessionPath string, title string) error {
 	if sessionPath == "" {
 		return fmt.Errorf("empty session path")
 	}
+	// Read-modify-write on the sidecar: hold the per-path meta lock so a
+	// concurrent save (recordSessionContentRevision) can't have its Revision
+	// bump clobbered by a stale read-back here.
+	unlock := lockSessionSavePath(sessionPath)
+	defer unlock()
 	m, err := EnsureBranchMeta(sessionPath)
 	if err != nil {
 		return err

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,7 +54,14 @@ type sessionPersistState struct {
 	digest   [sha256.Size]byte
 	version  uint64
 	revision int64
-	ok       bool
+	// revisionKnown marks revision as a real ledger value. It is false when
+	// the baseline was established while the meta sidecar was unreadable
+	// (torn or corrupt): the session must still open, but revision 0 must not
+	// pose as a baseline or every honest on-disk revision would read as a
+	// stale-runtime conflict. CAS checks fall back to digest+version until a
+	// successful save re-learns the revision.
+	revisionKnown bool
+	ok            bool
 }
 
 type sessionSaveMode int
@@ -160,11 +168,6 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	if path == "" {
 		return fmt.Errorf("empty session path")
 	}
-	msgs, version := s.snapshotWithVersion()
-	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
-	if err != nil {
-		return err
-	}
 	baseRevision := int64(0)
 	unlock := lockSessionSavePath(path)
 	defer unlock()
@@ -176,6 +179,16 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 		return fmt.Errorf("lock session file: %w", err)
 	}
 	defer unlockFile()
+	// Capture the snapshot only while holding the save locks. Concurrent
+	// in-process savers (turn-end snapshot, periodic autosave, shutdown
+	// snapshot) that captured before locking could land out of order: the
+	// stalest capture written last would then read the newer transcript it
+	// lost the race to as a bogus stale-prefix conflict.
+	msgs, version := s.snapshotWithVersion()
+	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
+	if err != nil {
+		return err
+	}
 	probe, err := probeSessionEventLog(path)
 	if err != nil {
 		return err
@@ -232,7 +245,12 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 				return err
 			}
 			if err := writeSessionEventIndex(path, msgs, digest, revision); err != nil {
-				return err
+				// The event index is only a listing accelerator; the transcript
+				// and its revision are already durable above. Failing the save
+				// here would skip markPersisted and leave the in-memory baseline
+				// behind the disk state it just wrote, misreading the next save
+				// as a stale-runtime conflict.
+				slog.Warn("session: keeping save after event index write failure", "path", path, "err", err)
 			}
 			s.markPersisted(path, digest, version, revision)
 			return nil
@@ -291,7 +309,9 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	}
 	if probe.native {
 		if err := writeSessionEventIndex(path, msgs, digest, revision); err != nil {
-			return err
+			// See the append path above: index loss must not fail a save whose
+			// transcript and revision already landed.
+			slog.Warn("session: keeping save after event index write failure", "path", path, "err", err)
 		}
 	}
 	s.markPersisted(path, digest, version, revision)
@@ -354,7 +374,10 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 	contentUnchanged := bytes.Equal(existingDigest[:], nextDigest[:])
 	exactAppend := messagesHavePrefix(next, existing)
 	if contentUnchanged || exactAppend || messagesHavePrefixWithCompatibleSystem(next, existing) {
-		if baseState.ok && currentRevision != baseState.revision && !contentUnchanged {
+		// An unknown-revision baseline (meta sidecar unreadable at load) cannot
+		// vouch for revision equality; the digest/prefix checks above already
+		// vouch for the content, so only a known baseline arms the CAS check.
+		if baseState.ok && baseState.revisionKnown && currentRevision != baseState.revision && !contentUnchanged {
 			return snapshotWriteDecision{}, snapshotConflict(path, existing, next, baseState.revision, currentRevision)
 		}
 		// A normalized-dirty load means LoadSession repaired the history on the
@@ -607,10 +630,14 @@ func firstNonEmpty(values ...string) string {
 
 func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, existingRevision int64, nextVersion uint64) bool {
 	state := s.persistState(path)
-	return state.ok &&
-		state.version <= nextVersion &&
-		state.revision == existingRevision &&
-		bytes.Equal(existingDigest[:], state.digest[:])
+	if !state.ok || state.version > nextVersion || !bytes.Equal(existingDigest[:], state.digest[:]) {
+		return false
+	}
+	// An unknown-revision baseline still owns the transcript it loaded — the
+	// digest+version match proves it. Requiring revision equality here would
+	// make every rewrite from such a baseline a permanent conflict, because
+	// the revision can only be re-learned by a successful save.
+	return !state.revisionKnown || state.revision == existingRevision
 }
 
 func (s *Session) persistState(path string) sessionPersistState {
@@ -624,21 +651,39 @@ func (s *Session) persistState(path string) sessionPersistState {
 }
 
 func (s *Session) markPersisted(path string, digest [sha256.Size]byte, version uint64, revision int64) {
+	s.setPersistedBaseline(path, digest, version, revision, true)
+}
+
+// markPersistedRevisionUnknown records a baseline whose ledger revision could
+// not be learned because the meta sidecar was unreadable. The digest and
+// version still anchor ownership checks; revision-based CAS stays disarmed
+// until a successful save records the real revision via markPersisted.
+func (s *Session) markPersistedRevisionUnknown(path string, digest [sha256.Size]byte, version uint64) {
+	s.setPersistedBaseline(path, digest, version, 0, false)
+}
+
+func (s *Session) setPersistedBaseline(path string, digest [sha256.Size]byte, version uint64, revision int64, revisionKnown bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.persisted = sessionPersistState{
-		path:     canonicalSessionSavePath(path),
-		digest:   digest,
-		version:  version,
-		revision: revision,
-		ok:       true,
+		path:          canonicalSessionSavePath(path),
+		digest:        digest,
+		version:       version,
+		revision:      revision,
+		revisionKnown: revisionKnown,
+		ok:            true,
 	}
 }
 
+// sessionContentRevision reads the CAS ledger (revision + content digest) from
+// the branch-meta sidecar. A missing sidecar is revision 0 — a session that
+// has never recorded one. An unreadable sidecar is an error: reporting it as
+// revision 0 would desync every runtime baseline from the ledger and turn the
+// next honest save into a bogus conflict (and a recovery branch).
 func sessionContentRevision(path string) (int64, string, error) {
-	meta, ok, err := LoadBranchMeta(path)
+	meta, ok, err := loadBranchMetaRetry(path)
 	if err != nil {
-		return 0, "", nil
+		return 0, "", err
 	}
 	if !ok {
 		return 0, "", nil
@@ -647,9 +692,12 @@ func sessionContentRevision(path string) (int64, string, error) {
 }
 
 func recordSessionContentRevision(path string, digest [sha256.Size]byte, baseRevision int64) (int64, error) {
-	meta, ok, err := LoadBranchMeta(path)
+	meta, ok, err := loadBranchMetaRetry(path)
 	if err != nil {
-		return baseRevision, nil
+		// Fail the save instead of rebuilding the ledger from a bad read: the
+		// transcript bytes already landed, so a later save (autosave retry)
+		// can bump the revision once the sidecar reads cleanly again.
+		return 0, err
 	}
 	if !ok {
 		meta = BranchMeta{ID: BranchID(path)}
@@ -663,7 +711,7 @@ func recordSessionContentRevision(path string, digest [sha256.Size]byte, baseRev
 	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
 		return 0, err
 	}
-	stored, ok, err := LoadBranchMeta(path)
+	stored, ok, err := loadBranchMetaRetry(path)
 	if err != nil {
 		return 0, err
 	}
@@ -841,11 +889,21 @@ func LoadSession(path string) (*Session, error) {
 	}
 	s.Messages = normalized
 	if digest, err := digestSessionMessages(s.Messages); err == nil {
-		revision := int64(0)
-		if meta, ok, metaErr := LoadBranchMeta(path); metaErr == nil && ok {
-			revision = meta.Revision
+		if meta, ok, metaErr := loadBranchMetaRetry(path); metaErr != nil {
+			// The sidecar exists but is unreadable even after retries (torn or
+			// corrupt). The session must still open, but revision 0 must not
+			// pose as a real baseline: the next save would misread the honest
+			// on-disk revision as another runtime's write and fork a recovery
+			// branch. Anchor the baseline on digest+version only until a
+			// successful save re-learns the revision.
+			s.markPersistedRevisionUnknown(path, digest, s.version)
+		} else {
+			revision := int64(0)
+			if ok {
+				revision = meta.Revision
+			}
+			s.markPersisted(path, digest, s.version, revision)
 		}
-		s.markPersisted(path, digest, s.version, revision)
 	}
 	return s, nil
 }

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -81,6 +81,11 @@ type snapshotWriteDecision struct {
 	// a lost suffix, or nothing decodable): the safe write shape is a full
 	// rewrite that also compacts the log back to a healthy single event.
 	repairLog bool
+	// ledgerStale is set when the on-disk transcript already matches the
+	// snapshot but the meta ledger still describes older content — the
+	// aftermath of a save whose bytes landed and whose revision record then
+	// failed. The up-to-date path must heal the ledger instead of skipping it.
+	ledgerStale bool
 }
 
 type SessionSnapshotConflictKind string
@@ -215,6 +220,27 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 			// other runtime resumed on this file and turning their next
 			// legitimate save into a stale-runtime conflict. Skip the write and
 			// adopt the current on-disk revision as this session's baseline.
+			if decision.ledgerStale {
+				// ...unless the ledger never learned about this transcript: a
+				// prior save landed its bytes and then failed to record the
+				// revision. Same-content retries are exactly the "later save"
+				// that failure deferred to, and skipping here would strand the
+				// ledger on the old digest forever. Record now, reproducing
+				// the state the interrupted save would have left.
+				revision, err := recordSessionContentRevision(path, digest, decision.revision)
+				if err != nil {
+					return err
+				}
+				if probe.native {
+					if err := writeSessionEventIndex(path, msgs, digest, revision); err != nil {
+						// See the append path below: index loss must not fail a
+						// save whose transcript and revision already landed.
+						slog.Warn("session: keeping save after event index write failure", "path", path, "err", err)
+					}
+				}
+				s.markPersisted(path, digest, version, revision)
+				return nil
+			}
 			s.markPersisted(path, digest, version, decision.revision)
 			return nil
 		}
@@ -361,7 +387,7 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		}
 		return snapshotWriteDecision{}, err
 	}
-	currentRevision, _, err := sessionContentRevision(path)
+	currentRevision, currentLedgerDigest, err := sessionContentRevision(path)
 	if err != nil {
 		return snapshotWriteDecision{}, err
 	}
@@ -389,6 +415,15 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 			revision:  currentRevision,
 			upToDate:  contentUnchanged && !current.normalizedDirty && !current.eventLogDamaged,
 			repairLog: current.eventLogDamaged,
+		}
+		// A ledger digest that describes different content than the transcript
+		// on disk is the aftermath of a save whose bytes landed and whose
+		// revision record then failed (crash or fail-closed record between the
+		// two writes). Only a non-empty mismatch counts: a missing sidecar or
+		// a legacy one without a digest is a legitimate state, and stamping it
+		// here would bump revisions other runtimes still hold as baselines.
+		if decision.upToDate && currentLedgerDigest != "" && currentLedgerDigest != digestString(nextDigest) {
+			decision.ledgerStale = true
 		}
 		if exactAppend && !contentUnchanged && len(existing) < len(next) && !current.eventLogDamaged {
 			decision.appendOnly = true
@@ -695,8 +730,10 @@ func recordSessionContentRevision(path string, digest [sha256.Size]byte, baseRev
 	meta, ok, err := loadBranchMetaRetry(path)
 	if err != nil {
 		// Fail the save instead of rebuilding the ledger from a bad read: the
-		// transcript bytes already landed, so a later save (autosave retry)
-		// can bump the revision once the sidecar reads cleanly again.
+		// transcript bytes already landed, so a later save can record the
+		// revision once the sidecar reads cleanly again — a content-bearing
+		// save lands here again, and a same-content retry heals through the
+		// up-to-date ledgerStale path in save().
 		return 0, err
 	}
 	if !ok {

--- a/internal/agent/session_meta_ledger_test.go
+++ b/internal/agent/session_meta_ledger_test.go
@@ -1,0 +1,491 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// shrinkMetaReadBackoffs keeps corrupt-sidecar tests fast. Only the pacing of
+// the torn-read retries changes; the retry-then-fail semantics stay intact.
+func shrinkMetaReadBackoffs(t *testing.T) {
+	t.Helper()
+	old := branchMetaReadBackoffs
+	branchMetaReadBackoffs = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { branchMetaReadBackoffs = old })
+}
+
+func assertNoRecoveryBranches(t *testing.T, sessionPath string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(sessionPath), "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("unexpected recovery branches: %v", matches)
+	}
+}
+
+// A meta sidecar that exists but cannot be parsed must fail the save instead
+// of being silently treated as revision 0 — the desync that used to fork
+// bogus recovery branches. The unreadable ledger must also survive untouched
+// so a healed read can pick up the real revision.
+func TestSaveFailsClosedOnCorruptMetaLedger(t *testing.T) {
+	shrinkMetaReadBackoffs(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	good, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read good meta: %v", err)
+	}
+	corrupt := []byte("{ torn json")
+	if err := os.WriteFile(metaPath, corrupt, 0o644); err != nil {
+		t.Fatalf("corrupt meta: %v", err)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	saveErr := s.SaveSnapshot(path)
+	if saveErr == nil {
+		t.Fatal("SaveSnapshot with corrupt meta ledger succeeded, want error")
+	}
+	if errors.Is(saveErr, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot with corrupt meta misread as conflict: %v", saveErr)
+	}
+	assertNoRecoveryBranches(t, path)
+	if b, err := os.ReadFile(metaPath); err != nil || string(b) != string(corrupt) {
+		t.Fatalf("failed save rewrote the unreadable ledger: err=%v content=%q", err, b)
+	}
+	onDisk, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession after failed save: %v", err)
+	}
+	if got := len(onDisk.Messages); got != 2 {
+		t.Fatalf("failed save changed transcript: %d messages, want 2", got)
+	}
+
+	// Once the sidecar reads cleanly again the same session saves normally.
+	if err := os.WriteFile(metaPath, good, 0o644); err != nil {
+		t.Fatalf("restore meta: %v", err)
+	}
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot after meta repair: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after repair ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 2 {
+		t.Fatalf("revision after repaired save = %d, want 2", meta.Revision)
+	}
+}
+
+// An unreadable meta sidecar at load time must not stop the session from
+// opening, and the revision-0 placeholder must not arm the CAS check: once
+// the sidecar reads cleanly again, appends save without a bogus conflict.
+func TestLoadSessionWithUnreadableMetaStillOpensAndAppends(t *testing.T) {
+	shrinkMetaReadBackoffs(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	seed := NewSession("sys")
+	seed.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	seed.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := seed.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot seed: %v", err)
+	}
+	good, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read good meta: %v", err)
+	}
+	if err := os.WriteFile(metaPath, []byte("{ torn json"), 0o644); err != nil {
+		t.Fatalf("corrupt meta: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession with unreadable meta: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("loaded %d messages, want 3", got)
+	}
+	if !loaded.persisted.ok {
+		t.Fatal("load must still establish a persistence baseline")
+	}
+	if loaded.persisted.revisionKnown {
+		t.Fatal("baseline built without a readable ledger must be revision-unknown")
+	}
+
+	// The tear heals (another runtime's write completes / the corruption was
+	// transient): the on-disk revision is an honest 1 against this runtime's
+	// unknown baseline. The append must not be misread as a stale runtime.
+	if err := os.WriteFile(metaPath, good, 0o644); err != nil {
+		t.Fatalf("restore meta: %v", err)
+	}
+	loaded.Add(provider.Message{Role: provider.RoleUser, Content: "next"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append after unreadable-meta load: %v", err)
+	}
+	assertNoRecoveryBranches(t, path)
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after append ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 2 {
+		t.Fatalf("revision after append = %d, want 2", meta.Revision)
+	}
+	if !loaded.persisted.revisionKnown {
+		t.Fatal("successful save must re-learn the revision baseline")
+	}
+
+	// With the baseline re-learned, revision CAS is armed again.
+	loaded.Add(provider.Message{Role: provider.RoleAssistant, Content: "reply"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot second append: %v", err)
+	}
+}
+
+// Compaction-style rewrites from a revision-unknown baseline must fall back to
+// digest+version ownership instead of failing the revision equality check.
+func TestSaveRewriteWithUnreadableMetaBaselineOwnsByDigest(t *testing.T) {
+	shrinkMetaReadBackoffs(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	seed := NewSession("sys")
+	seed.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	seed.Add(provider.Message{Role: provider.RoleAssistant, Content: "a long detailed answer"})
+	if err := seed.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot seed: %v", err)
+	}
+	good, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read good meta: %v", err)
+	}
+	if err := os.WriteFile(metaPath, []byte("{ torn json"), 0o644); err != nil {
+		t.Fatalf("corrupt meta: %v", err)
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession with unreadable meta: %v", err)
+	}
+	if err := os.WriteFile(metaPath, good, 0o644); err != nil {
+		t.Fatalf("restore meta: %v", err)
+	}
+
+	rewritten := loaded.Snapshot()
+	rewritten[len(rewritten)-1].Content = "compacted"
+	loaded.Replace(rewritten)
+	if err := loaded.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite from unknown-revision baseline: %v", err)
+	}
+	assertNoRecoveryBranches(t, path)
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after rewrite ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 2 {
+		t.Fatalf("revision after rewrite = %d, want 2", meta.Revision)
+	}
+	reloaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession after rewrite: %v", err)
+	}
+	if got := reloaded.Messages[len(reloaded.Messages)-1].Content; got != "compacted" {
+		t.Fatalf("rewrite tail = %q, want compacted", got)
+	}
+}
+
+// A missing sidecar is not damage: it is the legitimate revision-0 state of a
+// session that never recorded one, and must keep arming the CAS baseline.
+func TestMissingMetaRemainsKnownZeroRevisionBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	if err := os.Remove(BranchMetaPath(path)); err != nil {
+		t.Fatalf("remove meta: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession without meta: %v", err)
+	}
+	if !loaded.persisted.ok || !loaded.persisted.revisionKnown || loaded.persisted.revision != 0 {
+		t.Fatalf("missing meta baseline = %+v, want known revision 0", loaded.persisted)
+	}
+	loaded.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append without meta: %v", err)
+	}
+	assertNoRecoveryBranches(t, path)
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recreated ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 1 {
+		t.Fatalf("recreated revision = %d, want 1", meta.Revision)
+	}
+}
+
+// Losing the event index (a listing accelerator, never read by LoadSession)
+// must not fail a save whose transcript and revision already landed, and must
+// not leave the baseline behind disk where the next save reads as a conflict.
+func TestSaveSnapshotToleratesEventIndexWriteFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	// Squat a directory on the index path so every index write must fail.
+	if err := os.MkdirAll(SessionEventIndexPath(path), 0o755); err != nil {
+		t.Fatalf("pre-create index dir: %v", err)
+	}
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot with failing event index = %v, want nil", err)
+	}
+	first, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta first ok=%v err=%v", ok, err)
+	}
+	if first.Revision != 1 {
+		t.Fatalf("first revision = %d, want 1", first.Revision)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("second SaveSnapshot = %v, want nil (baseline must advance despite index failure)", err)
+	}
+	second, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta second ok=%v err=%v", ok, err)
+	}
+	if second.Revision != 2 {
+		t.Fatalf("second revision = %d, want 2", second.Revision)
+	}
+	assertNoRecoveryBranches(t, path)
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("loaded %d messages, want 3", got)
+	}
+	if info, err := os.Stat(SessionEventIndexPath(path)); err != nil || !info.IsDir() {
+		t.Fatalf("fixture broke: index path no longer a directory (err=%v)", err)
+	}
+}
+
+// Meta-only writers (rename, model stamp) racing content saves must never
+// roll the revision ledger backwards or manufacture conflicts.
+func TestSessionMetaConcurrentWritersKeepRevisionMonotonic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "turn 0"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot seed: %v", err)
+	}
+	if err := RenameSession(path, "seed-title"); err != nil {
+		t.Fatalf("RenameSession seed: %v", err)
+	}
+	if err := SetBranchModelPreserveUpdated(path, "prov/model-seed"); err != nil {
+		t.Fatalf("SetBranchModelPreserveUpdated seed: %v", err)
+	}
+
+	const saves = 25
+	stop := make(chan struct{})
+	var stopOnce sync.Once
+	stopAll := func() { stopOnce.Do(func() { close(stop) }) }
+	var wg sync.WaitGroup
+	defer func() {
+		stopAll()
+		wg.Wait()
+	}()
+	metaErrCh := make(chan error, 2)
+	var regressed atomic.Bool
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := RenameSession(path, fmt.Sprintf("title-%d", i)); err != nil {
+				select {
+				case metaErrCh <- err:
+				default:
+				}
+				return
+			}
+			if err := SetBranchModelPreserveUpdated(path, fmt.Sprintf("prov/model-%d", i)); err != nil {
+				select {
+				case metaErrCh <- err:
+				default:
+				}
+				return
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		last := int64(0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if meta, ok, err := LoadBranchMeta(path); err == nil && ok {
+				if meta.Revision < last {
+					regressed.Store(true)
+					return
+				}
+				last = meta.Revision
+			}
+		}
+	}()
+
+	for i := 1; i <= saves; i++ {
+		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("turn %d", i)})
+		if err := s.SaveSnapshot(path); err != nil {
+			t.Fatalf("SaveSnapshot %d under meta-writer hammer: %v", i, err)
+		}
+	}
+	stopAll()
+	wg.Wait()
+	close(metaErrCh)
+	for err := range metaErrCh {
+		t.Fatalf("meta writer error: %v", err)
+	}
+	if regressed.Load() {
+		t.Fatal("meta revision regressed while meta-only writers raced saves")
+	}
+
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta final ok=%v err=%v", ok, err)
+	}
+	if want := int64(saves + 1); meta.Revision != want {
+		t.Fatalf("final revision = %d, want %d", meta.Revision, want)
+	}
+	digest, err := digestSessionMessages(s.Snapshot())
+	if err != nil {
+		t.Fatalf("digest final content: %v", err)
+	}
+	if meta.ContentDigest != digestString(digest) {
+		t.Fatalf("final content digest = %q, want %q", meta.ContentDigest, digestString(digest))
+	}
+	if meta.CustomTitle == "" || meta.Model == "" {
+		t.Fatalf("meta-only fields lost under hammer: %+v", meta)
+	}
+	assertNoRecoveryBranches(t, path)
+}
+
+// A saver that blocks on the save lock must persist whatever the session
+// holds when it finally enters the critical section, not a stale capture from
+// when it was scheduled — the out-of-order landing that used to surface as
+// "session changed on disk" adoptions between the turn-end snapshot, periodic
+// autosave, and shutdown snapshot.
+func TestSaveSnapshotCapturesContentUnderSaveLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "turn 0"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot seed: %v", err)
+	}
+
+	unlock := lockSessionSavePath(path)
+	done := make(chan error, 1)
+	go func() { done <- s.SaveSnapshot(path) }()
+	// Let the saver reach the save lock, then grow the session while it waits.
+	time.Sleep(50 * time.Millisecond)
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "added while saver waited"})
+	unlock()
+	if err := <-done; err != nil {
+		t.Fatalf("SaveSnapshot after lock release: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 3 {
+		t.Fatalf("saved %d messages, want 3 (snapshot must be captured under the save lock)", got)
+	}
+	assertNoRecoveryBranches(t, path)
+}
+
+// Multiple in-process savers of one session (turn-end snapshot, periodic
+// autosave, shutdown snapshot) must never conflict with each other: the
+// snapshot is captured under the save lock, so a stale pre-lock capture can
+// no longer land after a newer one.
+func TestConcurrentSnapshotSaversNeverConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "turn 0"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot seed: %v", err)
+	}
+
+	const adds = 30
+	stop := make(chan struct{})
+	errCh := make(chan error, 64)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				if err := s.SaveSnapshot(path); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+				}
+				select {
+				case <-stop:
+					return
+				default:
+				}
+			}
+		}()
+	}
+	for i := 1; i <= adds; i++ {
+		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("turn %d", i)})
+		time.Sleep(time.Millisecond)
+	}
+	close(stop)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if errors.Is(err, ErrSessionSnapshotConflict) {
+			t.Fatalf("concurrent snapshot savers conflicted: %v", err)
+		}
+		t.Errorf("concurrent snapshot saver error: %v", err)
+	}
+
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("final SaveSnapshot: %v", err)
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got, want := len(loaded.Messages), adds+2; got != want {
+		t.Fatalf("final message count = %d, want %d", got, want)
+	}
+	assertNoRecoveryBranches(t, path)
+}

--- a/internal/agent/session_meta_ledger_test.go
+++ b/internal/agent/session_meta_ledger_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -486,6 +487,166 @@ func TestConcurrentSnapshotSaversNeverConflict(t *testing.T) {
 	}
 	if got, want := len(loaded.Messages), adds+2; got != want {
 		t.Fatalf("final message count = %d, want %d", got, want)
+	}
+	assertNoRecoveryBranches(t, path)
+}
+
+// A save that lands its transcript bytes and then fails to record the
+// revision (fail-closed record, or a crash between the two writes) leaves the
+// ledger describing older content. The next save of the same snapshot takes
+// the up-to-date path and must heal the ledger — record the revision and
+// digest the interrupted save deferred — instead of skipping it forever.
+func TestSameContentSaveHealsStaleLedgerDigest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	staleMeta, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read base meta: %v", err)
+	}
+
+	// Land new content, then rewind the sidecar to the pre-append ledger:
+	// the exact on-disk aftermath of an append whose revision record failed.
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append: %v", err)
+	}
+	if err := os.WriteFile(metaPath, staleMeta, 0o644); err != nil {
+		t.Fatalf("rewind meta: %v", err)
+	}
+
+	// Any runtime resuming this file now pairs the landed transcript with the
+	// stale revision — the post-crash shape.
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession on stale ledger: %v", err)
+	}
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("same-content SaveSnapshot: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after heal ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 2 {
+		t.Fatalf("healed revision = %d, want 2", meta.Revision)
+	}
+	digest, err := digestSessionMessages(loaded.Snapshot())
+	if err != nil {
+		t.Fatalf("digest current messages: %v", err)
+	}
+	if meta.ContentDigest != digestString(digest) {
+		t.Fatalf("healed digest = %s, want %s", meta.ContentDigest, digestString(digest))
+	}
+	assertNoRecoveryBranches(t, path)
+
+	// The healed baseline keeps working: the next append saves cleanly.
+	loaded.Add(provider.Message{Role: provider.RoleUser, Content: "two"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("append after heal: %v", err)
+	}
+	after, _, err := LoadBranchMeta(path)
+	if err != nil {
+		t.Fatalf("LoadBranchMeta after append: %v", err)
+	}
+	if after.Revision != 3 {
+		t.Fatalf("revision after post-heal append = %d, want 3", after.Revision)
+	}
+	assertNoRecoveryBranches(t, path)
+}
+
+// The surviving in-process saver — whose baseline never advanced because the
+// failed save returned before markPersisted — heals through the same
+// up-to-date path on its autosave retry of the identical snapshot.
+func TestSameContentRetryHealsLedgerForSurvivingSaver(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	staleMeta, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read base meta: %v", err)
+	}
+	baseline := s.persistState(path)
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot append: %v", err)
+	}
+	// Rewind the sidecar and the in-memory baseline to the mid-save failure
+	// state: bytes landed, record failed, markPersisted never ran.
+	if err := os.WriteFile(metaPath, staleMeta, 0o644); err != nil {
+		t.Fatalf("rewind meta: %v", err)
+	}
+	s.setPersistedBaseline(path, baseline.digest, baseline.version, baseline.revision, true)
+
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("autosave retry: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta after heal ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 2 {
+		t.Fatalf("healed revision = %d, want 2", meta.Revision)
+	}
+	assertNoRecoveryBranches(t, path)
+}
+
+// A legacy sidecar that predates content digests is not a stale ledger: the
+// up-to-date path must leave it untouched rather than bump a revision other
+// runtimes still hold as their baseline.
+func TestUpToDateSaveLeavesDigestlessLegacyMetaAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	metaPath := BranchMetaPath(path)
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	// Strip the digest by editing the raw sidecar: the save helpers back-fill
+	// an empty digest from the existing meta, exactly like real legacy files
+	// acquired one only through a content-bearing save.
+	raw, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("decode meta: %v", err)
+	}
+	delete(fields, "content_digest")
+	stripped, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("encode meta: %v", err)
+	}
+	if err := os.WriteFile(metaPath, stripped, 0o644); err != nil {
+		t.Fatalf("write legacy meta: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession legacy meta: %v", err)
+	}
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("same-content SaveSnapshot: %v", err)
+	}
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if meta.Revision != 1 {
+		t.Fatalf("legacy revision = %d, want 1 (no gratuitous bump)", meta.Revision)
+	}
+	if meta.ContentDigest != "" {
+		t.Fatalf("legacy digest = %q, want empty (untouched)", meta.ContentDigest)
 	}
 	assertNoRecoveryBranches(t, path)
 }


### PR DESCRIPTION
## Summary

Windows users on v1.16.x–v1.17.0 hit recurring bogus "save conflict" warnings during normal single-window chats — every app start could fork another recovery branch, accumulating dozens of `*-recovery-*.jsonl` files and sidecars (#6014: 24 recovery files; #5998, #6003, and the "session changed on disk; adopted the newer transcript" loop in #5996).

The transcript CAS itself (from #5856) is sound as a goal; this PR hardens its ledger so it can no longer manufacture conflicts out of transient Windows filesystem behavior. It deliberately does not redesign the mechanism (kept minimal for a hotfix).

## Root causes

The CAS ledger (`Revision`/`ContentDigest` in the `.jsonl.meta` sidecar) was maintained without protection:

1. **Unreadable ledger silently became revision 0.** `sessionContentRevision` swallowed read errors into `(0, nil)`; `LoadSession` did the same when establishing the baseline; `recordSessionContentRevision` swallowed them into "don't write the ledger at all". On Windows a sidecar read can fail transiently (AV/indexer handles; `fileutil.ReplaceFile`'s non-atomic `copyOnto` fallback tears readers). Any of these desynced baseline vs. ledger, and the next honest save misread as a foreign write → Diverged → recovery branch. This is the "triggers on every app start" shape.
2. **Unlocked read-modify-write rolled the ledger back.** `RenameSession`, topic-title propagation (`updateTopicSessionTitles`, runs after autosaves), legacy topic migration, and `restoreSessionTopicIndex` load→mutate→save meta without `LockSessionMetaPath`; a concurrent save's revision bump landing in that window was overwritten with the stale value. The write-side window is amplified to ~720ms by `ReplaceFile`'s retry ladder on Windows.
3. **Index write failure stranded the baseline.** `save()` returned an error after the transcript and revision were already durable if `writeSessionEventIndex` failed (AV-held handle), skipping `markPersisted` — baseline behind disk → next save conflicts.
4. **Snapshots were captured before locking.** Concurrent in-process savers (turn-end, periodic autosave, desktop TurnDone) could land out of order; the stalest capture then read the newer transcript as a stale-prefix conflict, producing the repeated "adopted the newer transcript" notices.

## Changes

- `loadBranchMetaRetry`: short backoff (20/50/100ms) over I/O and JSON-decode failures, separating Windows torn reads from real corruption; missing sidecar stays an immediate legitimate `ok=false`.
- `sessionContentRevision` / `recordSessionContentRevision` now fail the save on a persistently unreadable ledger instead of fabricating revision 0 / silently skipping the bump. The transcript bytes are already durable; the autosave retry heals once the sidecar reads cleanly.
- `LoadSession` with an unreadable sidecar still opens the session but records a **revision-unknown baseline** (`sessionPersistState.revisionKnown`): revision-based CAS is disarmed (content digest/prefix checks still catch real divergence), and ownership checks (`ownsPersistedState`) anchor on digest+version so owned rewrites (compaction) don't become permanent conflicts. A missing sidecar remains a known revision-0 baseline; a successful save re-learns the real revision.
- The four unlocked meta RMW paths now hold the per-path meta lock for the whole load→mutate→save cycle (the legacy-migration pass runs outside the caller's lock — it takes its own per-session locks).
- `writeSessionEventIndex` failures downgrade to a warning at both save() call sites; the index is a listing accelerator and must not strand the baseline.
- `save()` captures the snapshot under the save locks, eliminating out-of-order captures (lock-order audited: `saveLock → Session.mu` is the pre-existing order; no reverse path exists).

## Tests

New regression suite (`session_meta_ledger_test.go`, all `-race`):

- Corrupt ledger → save fails closed, no recovery branch, ledger untouched; heals after repair.
- Unreadable-meta load → session opens, appends don't conflict, owned rewrite (`SaveRewrite`) proceeds via digest+version ownership. Reverting the fix reproduces the original bogus `diverged … from snapshot revision 0` error.
- Missing meta stays a known zero baseline (behavior unchanged).
- Event-index path pre-created as a directory → save still succeeds and the baseline advances.
- Concurrent SaveSnapshot × RenameSession/SetBranchModel hammer: revision stays monotonic, no conflicts.
- Deterministic under-lock capture test (fails with the old pre-lock capture) plus a concurrent-savers zero-conflict stress.

Full suites: `go test ./internal/agent -race`, `./internal/control`, `desktop go test .` — all pass; `GOOS=windows GOARCH=amd64` builds clean in both modules.

## Cache impact

Cache-impact: none. Session persistence, sidecar bookkeeping, and lock scope only; no provider-visible prompts, tool schemas, request serialization, or compaction changes.

Fixes #6014. Fixes #5998. Fixes #5996. Refs #6003 (the recovery-branch loop; its bash-sandbox half is tracked by #5937).
