### PR TITLE
fix(browser): prevent duplicate tool dispatch cards by updating existing card

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -825,7 +825,26 @@ function finalizeMsg() { if(currentMsg){const c=currentMsg.querySelector('.curso
 
 // ── tool cards (v1 pattern) ──
 function renderToolDispatch(tool) {
-  hideWelcome(); const card=el('div','card'); card.id='tool-'+tool.id; card.dataset.open='false'; card.dataset.tone='accent';
+  hideWelcome();
+  // Check if a card already exists for this tool (from a partial dispatch while
+  // arguments were still streaming). If so, update its subject with args that
+  // weren't available yet, instead of creating a duplicate card.
+  const existing=toolCards[tool.id];
+  if(existing){
+    if(tool.args){
+      let subject=existing.querySelector('.subject');
+      if(!subject){
+        subject=document.createElement('span');
+        subject.className='subject';
+        const name=existing.querySelector('.name');
+        const grow=existing.querySelector('.grow');
+        if(name&&grow)name.parentNode.insertBefore(subject,grow);
+      }
+      subject.textContent=tool.args.slice(0,80);
+    }
+    scrollDown(); return;
+  }
+  const card=el('div','card'); card.id='tool-'+tool.id; card.dataset.open='false'; card.dataset.tone='accent';
   const head=el('div','card-head');
   head.innerHTML='<span class="ico spin"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10" stroke-dasharray="60" stroke-dashoffset="20"/></svg></span><span class="name">'+escHtml(tool.name)+'</span>'+(tool.args?'<span class="subject">'+escHtml(tool.args.slice(0,80))+'</span>':'')+'<span class="grow"></span><span class="chev"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg></span>';
   const body=el('div','card-body'); body.style.display='none';


### PR DESCRIPTION
## Summary

### Problem
The backend emits two tool_dispatch events per tool call — a partial one (while arguments stream) and a full one (after they complete). The frontend always created a new DOM card for each, so the second dispatch created a duplicate card while the first card with its spinner remained orphaned in the DOM.

### Fix
Added a deduplication check at the top of renderToolDispatch: if toolCards[tool.id] already exists (from the partial dispatch), update the existing card's subject line with any args the full dispatch carries, then return without creating a new card. The spinner stays spinning until renderToolResult replaces it with the checkmark.

The Go backend already had a comment (agent.go line 1705-1706) saying "the frontend merges by ID" — now it actually does.

## Verification
- Visual validation on Chrome and Firefox: tool dispatch during streaming now correctly shows one card, updated in-place as arguments arrive.
- No regressions: the early-return path calls `scrollDown()` same as the original path.
- No XSS: the subject update uses `.textContent`, not `innerHTML`.
- Null-safe: `tool.args` is guarded before `.slice(0,80)`; DOM children (`name`, `grow`) are null-checked before insertion.
- All three call sites (SSE event at line 1078, history replay at lines 1154/1164) already pass `args` as a string (`|| ''`), so the `.slice` call is safe.