### PR TITLE
fix(fileutil): keep ReplaceFile atomic under transient rename failures / 瞬时重命名失败时保持 ReplaceFile 的原子发布

### DIFF
--- a/internal/fileutil/atomicwrite.go
+++ b/internal/fileutil/atomicwrite.go
@@ -8,8 +8,13 @@ import (
 )
 
 var (
-	maxReplaceRetries = 8
+	maxReplaceRetries = 12
 	replaceRetryBase  = 20 * time.Millisecond
+
+	// renameFile is a test seam: the two rename failure classes ReplaceFile
+	// distinguishes (transient lock vs cross-device) cannot be provoked
+	// portably on a real filesystem.
+	renameFile = os.Rename
 )
 
 // AtomicWriteFile writes data to path crash-safely: it writes to a sibling tmp
@@ -61,34 +66,44 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-// ReplaceFile renames tmp onto dest, falling back to a copy when the rename
-// fails — Windows encryption-software filter drivers report a cross-device link
-// (EXDEV) for a same-dir rename. A second Windows failure mode is a transient
-// lock on dest (antivirus, the search indexer, a concurrent reader) that makes
-// the rename fail with a sharing violation for a few hundred ms.
+// ReplaceFile renames tmp onto dest, publishing the new content atomically: a
+// reader concurrent with the replace sees either the old file or the complete
+// new one. The rename can fail in two ways, and they are handled differently:
 //
-// Order matters: the rename is retried with backoff FIRST, and the copy runs
-// only after every retry failed. copyOnto truncates dest in place, so a reader
-// racing it can observe an empty or half-written file — reaching for it on the
-// first transient failure would break the atomicity AtomicWriteFile promises.
-// On filter-driver hosts where the rename never succeeds this costs the full
-// retry backoff before each copy; correctness on every other host wins. A
-// missing tmp means the write itself failed and no retry can help.
+//   - A transient lock on dest (antivirus, the search indexer, a concurrent
+//     reader without delete sharing) fails the rename for a few hundred ms.
+//     The rename is retried with backoff, and the last error is returned if
+//     the lock never clears. The failure is loud on purpose: falling back to
+//     an in-place copy here would truncate dest first, letting a racing
+//     reader observe an empty or half-written file — exactly the torn state
+//     AtomicWriteFile promises its callers (session leases, credentials,
+//     plugin state) can never happen.
+//   - Windows encryption-software filter drivers report a cross-device link
+//     (ERROR_NOT_SAME_DEVICE / EXDEV) even for a same-dir rename (#2696), and
+//     every retry fails identically. Only this class falls back to the
+//     non-atomic copy, and immediately — retrying a structurally impossible
+//     rename would only delay it. Torn reads remain possible in that degraded
+//     mode; it is the only way to write at all on such hosts, and
+//     rename-capable filesystems never take it.
+//
+// A missing tmp means the write itself failed and no retry can help.
 func ReplaceFile(tmp, dest string) error {
 	var err error
 	for attempt := 0; ; attempt++ {
-		if err = os.Rename(tmp, dest); err == nil {
+		if err = renameFile(tmp, dest); err == nil {
 			return nil
 		}
+		if renameCrossesDevice(err) {
+			if copyOnto(tmp, dest) == nil {
+				return nil
+			}
+			return err
+		}
 		if attempt >= maxReplaceRetries || !fileExists(tmp) {
-			break
+			return err
 		}
 		time.Sleep(time.Duration(attempt+1) * replaceRetryBase)
 	}
-	if copyOnto(tmp, dest) == nil {
-		return nil
-	}
-	return err
 }
 
 func fileExists(path string) bool {
@@ -96,6 +111,10 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
+// copyOnto is the non-atomic last resort for hosts whose filesystem cannot
+// rename tmp onto dest at all (see ReplaceFile). It truncates dest in place,
+// so a concurrent reader can observe an empty or half-written file — it must
+// never run for failures a retry could clear.
 func copyOnto(tmp, dest string) error {
 	info, err := os.Stat(tmp)
 	if err != nil {

--- a/internal/fileutil/atomicwrite_test.go
+++ b/internal/fileutil/atomicwrite_test.go
@@ -1,9 +1,11 @@
 package fileutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -61,6 +63,85 @@ func TestReplaceFileRenamesInPlace(t *testing.T) {
 	}
 	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
 		t.Error("tmp should be gone after ReplaceFile")
+	}
+}
+
+func TestReplaceFileTransientFailureNeverTruncatesDest(t *testing.T) {
+	// A rename blocked by a transient lock must surface the error, never fall
+	// back to the in-place copy: the copy truncates dest first, so a reader
+	// racing it can observe an empty or half-written file — the torn state
+	// AtomicWriteFile promises its callers (session leases, credentials,
+	// plugin state) can never happen.
+	oldBase, oldMax, oldRename := replaceRetryBase, maxReplaceRetries, renameFile
+	replaceRetryBase, maxReplaceRetries = 0, 2
+	renameCalls := 0
+	renameFile = func(oldpath, newpath string) error {
+		renameCalls++
+		return &os.LinkError{Op: "rename", Old: oldpath, New: newpath, Err: errors.New("transient sharing violation")}
+	}
+	t.Cleanup(func() { replaceRetryBase, maxReplaceRetries, renameFile = oldBase, oldMax, oldRename })
+
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "x.tmp")
+	dest := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(tmp, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(tmp, dest); err == nil {
+		t.Fatal("want the rename error to surface once retries are exhausted")
+	}
+	if want := maxReplaceRetries + 1; renameCalls != want {
+		t.Errorf("rename attempts = %d, want %d (initial try plus retries)", renameCalls, want)
+	}
+	if b, _ := os.ReadFile(dest); string(b) != "old" {
+		t.Fatalf("dest = %q, want the old content intact — anything else means the non-atomic copy ran", b)
+	}
+	if !fileExists(tmp) {
+		t.Error("tmp should survive a failed replace so the caller can clean up")
+	}
+}
+
+func TestReplaceFileCrossDeviceCopiesImmediately(t *testing.T) {
+	// The cross-device class (Windows encryption filter drivers, #2696) fails
+	// identically on every retry, so ReplaceFile must take the copy fallback
+	// straight away instead of sleeping through the retry ladder.
+	oldBase, oldMax, oldRename := replaceRetryBase, maxReplaceRetries, renameFile
+	// Any retry sleep would trip the elapsed-time check below.
+	replaceRetryBase, maxReplaceRetries = 10*time.Second, 8
+	renameCalls := 0
+	renameFile = func(oldpath, newpath string) error {
+		renameCalls++
+		return &os.LinkError{Op: "rename", Old: oldpath, New: newpath, Err: syscall.EXDEV}
+	}
+	t.Cleanup(func() { replaceRetryBase, maxReplaceRetries, renameFile = oldBase, oldMax, oldRename })
+
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "x.tmp")
+	dest := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(tmp, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	if err := ReplaceFile(tmp, dest); err != nil {
+		t.Fatalf("ReplaceFile should succeed via the copy fallback: %v", err)
+	}
+	if renameCalls != 1 {
+		t.Errorf("rename attempts = %d, want 1 — a structurally impossible rename must not be retried", renameCalls)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("cross-device fallback took %v — it slept through the retry ladder", elapsed)
+	}
+	if b, _ := os.ReadFile(dest); string(b) != "new" {
+		t.Errorf("dest = %q, want the new content from the copy fallback", b)
+	}
+	if fileExists(tmp) {
+		t.Error("tmp should be consumed by the copy fallback")
 	}
 }
 

--- a/internal/fileutil/replacefallback_other.go
+++ b/internal/fileutil/replacefallback_other.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package fileutil
+
+import (
+	"errors"
+	"syscall"
+)
+
+// renameCrossesDevice reports whether a rename failed with EXDEV: the two
+// paths sit on different filesystems, so no retry can make the rename succeed
+// and ReplaceFile's copy fallback is the only option. AtomicWriteFile creates
+// tmp next to dest, so this only happens when something (an overlay or bind
+// mount boundary, or a filter driver on Windows) splits the directory across
+// devices.
+func renameCrossesDevice(err error) bool {
+	return errors.Is(err, syscall.EXDEV)
+}

--- a/internal/fileutil/replacefallback_windows.go
+++ b/internal/fileutil/replacefallback_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package fileutil
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// renameCrossesDevice reports whether a rename failed because the filesystem
+// treats the two paths as different devices. Encryption-software filter
+// drivers report ERROR_NOT_SAME_DEVICE even for a same-directory rename
+// (#2696); such a rename fails identically on every retry, so ReplaceFile
+// goes straight to its copy fallback instead of burning the retry backoff.
+func renameCrossesDevice(err error) bool {
+	return errors.Is(err, windows.ERROR_NOT_SAME_DEVICE) || errors.Is(err, syscall.EXDEV)
+}

--- a/internal/fileutil/replacefallback_windows_test.go
+++ b/internal/fileutil/replacefallback_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package fileutil
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestRenameCrossesDeviceClassifiesFilterDriverError(t *testing.T) {
+	// The filter-driver failure (#2696) surfaces as ERROR_NOT_SAME_DEVICE
+	// wrapped in a LinkError; it must route to the copy fallback. A sharing
+	// violation is transient and must not — copying there truncates dest under
+	// a concurrent reader.
+	notSameDevice := &os.LinkError{Op: "rename", Old: "a", New: "b", Err: windows.ERROR_NOT_SAME_DEVICE}
+	if !renameCrossesDevice(notSameDevice) {
+		t.Fatal("ERROR_NOT_SAME_DEVICE must be classified as cross-device")
+	}
+	sharing := &os.LinkError{Op: "rename", Old: "a", New: "b", Err: windows.ERROR_SHARING_VIOLATION}
+	if renameCrossesDevice(sharing) {
+		t.Fatal("a sharing violation is transient and must not take the non-atomic copy fallback")
+	}
+	accessDenied := &os.LinkError{Op: "rename", Old: "a", New: "b", Err: windows.ERROR_ACCESS_DENIED}
+	if renameCrossesDevice(accessDenied) {
+		t.Fatal("access denied is transient (AV/indexer) and must not take the non-atomic copy fallback")
+	}
+}


### PR DESCRIPTION
## Problem

`ReplaceFile` fell back to `copyOnto` after exhausting its rename retries, **regardless of why the rename failed**. `copyOnto` truncates dest in place, so a reader racing the copy can observe an empty or half-written file — silently breaking the atomic-publication contract every `AtomicWriteFile` caller relies on (session leases, credentials, plugin state, mcp.json, session saves).

CI caught the window lining up on a real runner: `TestStateLoadDuringSaveNeverSeesTornFile` failed on windows-latest with `unexpected end of JSON input` ([run 28745056100](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/28745056100/job/85234433258)) — a transient dest lock outlived the ~0.7s retry budget, the copy fallback truncated the state file, and the concurrent `LoadState` read the torn JSON. The torn read is exactly the state that test exists to rule out; the copy fallback is the only code path that can produce it.

## Fix

Split the two rename-failure classes that were previously handled identically:

- **Transient locks** (antivirus, search indexer, a concurrent reader without delete sharing): retry longer (12 attempts, ~1.5s of backoff, up from 8 / ~0.7s), then **surface the rename error**. A loud failure beats a silently torn file — no caller of an *atomic* write API wants best-effort truncate-in-place semantics.
- **Cross-device class** (`ERROR_NOT_SAME_DEVICE` / `EXDEV`): encryption-software filter drivers report this even for a same-directory rename (#2696), and every retry fails identically. Only this class still takes the copy fallback — it is the only way to write at all on such hosts — and now **immediately**, instead of first sleeping through a retry ladder that cannot succeed. That also removes ~0.7s of latency from every save on those hosts (the cost previously accepted in the comment introduced by the retry-first ordering).

Classification lives in build-tagged `renameCrossesDevice` helpers (`golang.org/x/sys/windows.ERROR_NOT_SAME_DEVICE` on Windows, `syscall.EXDEV` elsewhere).

## Tests

- `TestReplaceFileTransientFailureNeverTruncatesDest`: transient-class failure surfaces the error, dest keeps its old content byte-for-byte, tmp survives for the caller.
- `TestReplaceFileCrossDeviceCopiesImmediately`: EXDEV-class failure copies without a single retry sleep (attempt count and elapsed-time pinned).
- `TestRenameCrossesDeviceClassifiesFilterDriverError` (windows-only): `ERROR_NOT_SAME_DEVICE` routes to the fallback; `ERROR_SHARING_VIOLATION` / `ERROR_ACCESS_DENIED` must not.
- A `renameFile` test seam injects the failures — neither class can be provoked portably on a real filesystem. Existing behavior pins (`TestReplaceFileNoRetryWhenTmpMissing`, `TestReplaceFileRetriesThenReturnsError`, `TestReplaceFileRenamesInPlace`, `TestCopyOntoOverwritesAndPreservesMode`) all still pass unchanged.

## Verification

- `go test ./internal/fileutil/... -count=1` — pass
- `go test -race ./internal/pluginpkg/ -count=1` — pass (the test that flaked on CI)
- `GOOS=windows go vet ./internal/fileutil/...` and Windows test-binary cross-compile — pass
- `go vet`, `gofmt`, `go mod tidy` (no-op; x/sys already a direct dependency), desktop module builds
- `git diff --check` clean