### PR TITLE
Polish lease UX: self-heal metadata damage, sanitize errors, retire lock sidecars / 打磨租约体验:元数据损坏自愈、错误脱敏、锁侧车清理

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1582,7 +1582,10 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	snap := a.tabRuntimeSnapshot(tab)
 	oldSink := snap.sink
 	if oldSink != nil {
-		oldSink.setBinding(detachedRuntimeTabID(oldPath), nil)
+		// Rebind under the runtime key, matching the id cloneDetachedRuntimeTab
+		// derives — a raw path here would hash to a different detached id on
+		// Windows where keys are case-folded.
+		oldSink.setBinding(detachedRuntimeTabID(sessionRuntimeKey(oldPath)), nil)
 		oldSink.clearContext()
 	}
 	if oldCtrl.RuntimeStatus().Cancellable {
@@ -7155,6 +7158,9 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	tab.model = name
 	tab.effort = cloneStringPtr(effortOverride)
 	tab.Label = newCtrl.Label()
+	// Supersede any in-flight startup build: it would otherwise finish later,
+	// overwrite this controller, and release/steal the tab's session lease.
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {
@@ -7304,6 +7310,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
 	tab.Ready = true
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {
@@ -7429,6 +7436,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
 	tab.Ready = true
+	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
 	if oldCtrl != nil {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1045,6 +1045,20 @@ func (a *App) reportTabSnapshotError(tab *WorkspaceTab, action string, err error
 	if tab == nil || tab.sink == nil {
 		return
 	}
+	// Autosave fires once per turn; on a persistently failing disk that would
+	// stream a chat warning after every turn. Rate-limit the user-facing
+	// notice per tab (the slog line above always records every failure). Saves
+	// triggered by an explicit action are one-shot and always surface.
+	if action == "autosave" {
+		tab.saveMu.Lock()
+		now := time.Now()
+		if !tab.lastAutosaveWarnAt.IsZero() && now.Sub(tab.lastAutosaveWarnAt) < autosaveWarnInterval {
+			tab.saveMu.Unlock()
+			return
+		}
+		tab.lastAutosaveWarnAt = now
+		tab.saveMu.Unlock()
+	}
 	prefix := "Session autosave failed"
 	if strings.TrimSpace(action) != "" && action != "autosave" {
 		prefix = "Session save failed before " + action
@@ -1551,7 +1565,9 @@ func (a *App) ClearSession() error {
 		return err
 	}
 	if err := tab.ensureSessionLease(ctrl.SessionPath()); err != nil {
-		return err
+		// Wails bridge return: a raw lease error would carry the session path
+		// and holder id across to the frontend.
+		return userFacingSessionLeaseError("", err)
 	}
 	tab.resetTelemetry()
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
@@ -1650,7 +1666,9 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	path := agent.NewSessionPath(newCtrl.SessionDir(), newCtrl.Label())
 	if err := tab.ensureSessionLease(path); err != nil {
 		newCtrl.Close()
-		return err
+		// Surfaces through ClearSession's Wails return; keep the holder's
+		// path/pid/writer id out of it.
+		return userFacingSessionLeaseError("", err)
 	}
 	newCtrl.SetSessionPath(path)
 
@@ -6952,9 +6970,13 @@ type sessionLeaseBusyError struct {
 }
 
 func (e *sessionLeaseBusyError) Error() string {
+	// The raw SessionLeaseError text carries the session path and the
+	// holder's host-pid-writer id; every user-facing surface must render
+	// this wrapper instead. An empty setting means the failure gated opening
+	// the session itself (startup bind), not changing a setting on it.
 	setting := strings.TrimSpace(e.setting)
 	if setting == "" {
-		setting = "this setting"
+		return "this session is already open in another Reasonix window or still running in the background; close the other window or open a copy"
 	}
 	return fmt.Sprintf("this session is already open in another Reasonix window or still running in the background; close the other window or open a copy before changing %s", setting)
 }
@@ -6997,10 +7019,16 @@ func (a *App) canReclaimCurrentProcessSessionLease(tab *WorkspaceTab, path strin
 		return false
 	}
 	var leaseErr *agent.SessionLeaseError
-	if !errors.As(err, &leaseErr) || leaseErr == nil || leaseErr.Info == nil {
+	if !errors.As(err, &leaseErr) || leaseErr == nil {
 		return false
 	}
-	if leaseErr.Info.PID != os.Getpid() || leaseErr.Info.WriterID != agent.SessionWriterID() {
+	// A readable info naming a foreign runtime is respected here; reclaim
+	// would refuse it anyway. A nil Info (lease.json deleted by the user,
+	// quarantined by AV, or torn by a crash) must still attempt the reclaim:
+	// the OS lock is the arbiter there, and refusing on missing metadata
+	// wedges a session nobody actually holds as permanently busy.
+	if leaseErr.Info != nil &&
+		(leaseErr.Info.PID != os.Getpid() || leaseErr.Info.WriterID != agent.SessionWriterID()) {
 		return false
 	}
 	a.mu.RLock()

--- a/desktop/autosave_warn_test.go
+++ b/desktop/autosave_warn_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestReportTabSnapshotErrorDebouncesAutosave(t *testing.T) {
+	app := NewApp()
+	tab := &WorkspaceTab{ID: "tab_warn", sink: &tabEventSink{tabID: "tab_warn", app: app}}
+	failure := errors.New("disk unhappy")
+
+	app.reportTabSnapshotError(tab, "autosave", failure)
+	tab.saveMu.Lock()
+	first := tab.lastAutosaveWarnAt
+	tab.saveMu.Unlock()
+	if first.IsZero() {
+		t.Fatal("first autosave warning did not record its timestamp")
+	}
+
+	// Within the window: suppressed, timestamp untouched.
+	app.reportTabSnapshotError(tab, "autosave", failure)
+	tab.saveMu.Lock()
+	second := tab.lastAutosaveWarnAt
+	tab.saveMu.Unlock()
+	if !second.Equal(first) {
+		t.Fatalf("suppressed warning moved the debounce timestamp: %v -> %v", first, second)
+	}
+
+	// Window expired: warns again.
+	tab.saveMu.Lock()
+	tab.lastAutosaveWarnAt = time.Now().Add(-autosaveWarnInterval - time.Second)
+	tab.saveMu.Unlock()
+	app.reportTabSnapshotError(tab, "autosave", failure)
+	tab.saveMu.Lock()
+	third := tab.lastAutosaveWarnAt
+	tab.saveMu.Unlock()
+	if !third.After(first) {
+		t.Fatal("expired window did not re-arm the autosave warning")
+	}
+
+	// Explicit user actions are never debounced (state untouched).
+	app.reportTabSnapshotError(tab, "changing model", failure)
+	tab.saveMu.Lock()
+	fourth := tab.lastAutosaveWarnAt
+	tab.saveMu.Unlock()
+	if !fourth.Equal(third) {
+		t.Fatal("action-save warning must not consume the autosave debounce window")
+	}
+}

--- a/desktop/session_key_test.go
+++ b/desktop/session_key_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+// The lease registry folds session paths through agent.CanonicalSessionPath
+// (lowercased on Windows). Every desktop "same session" comparison must fold
+// the same way, or a lease the tab itself holds looks foreign and every
+// model/effort/token switch self-locks with the "already open in another
+// window" error (#5999, #6006, #5996).
+
+func TestSessionRuntimeKeyMatchesLeaseKey(t *testing.T) {
+	dir := t.TempDir()
+	// Mixed-case segment on every platform; on Windows the lease key folds it.
+	path := filepath.Join(dir, "Sessions-Dir", "20260705-Test.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("acquire lease: %v", err)
+	}
+	defer lease.Release()
+
+	if got, want := sessionRuntimeKey(lease.Path()), sessionRuntimeKey(path); got != want {
+		t.Fatalf("lease path key %q != session path key %q; lease reuse checks will self-lock", got, want)
+	}
+}
+
+func TestSessionRuntimeKeyIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Case-Mix", "20260705-Test.jsonl")
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		t.Fatal("empty key for non-empty path")
+	}
+	if again := sessionRuntimeKey(key); again != key {
+		t.Fatalf("sessionRuntimeKey not idempotent: %q -> %q", key, again)
+	}
+}
+
+func TestSessionRuntimeKeyFoldsCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive path identity is Windows-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sessions", "20260705-Test.jsonl")
+	upper := strings.ToUpper(path)
+	if sessionRuntimeKey(path) != sessionRuntimeKey(upper) {
+		t.Fatalf("case variants of one file produced distinct keys: %q vs %q",
+			sessionRuntimeKey(path), sessionRuntimeKey(upper))
+	}
+}
+
+func TestCanonicalTabSessionPathNormalizesOutsideSessionDir(t *testing.T) {
+	// Project-scope sessions live outside config.SessionDir(); the fallback
+	// must still clean the shape so one file cannot split into two keys.
+	dir := t.TempDir()
+	base := filepath.Join(dir, "projects", "p1", "sessions", "20260705-a.jsonl")
+	messy := filepath.Join(dir, "projects", "p1", ".", "sessions") + string(filepath.Separator) + "20260705-a.jsonl"
+	if sessionRuntimeKey(base) != sessionRuntimeKey(messy) {
+		t.Fatalf("path shape variants split keys: %q vs %q",
+			sessionRuntimeKey(base), sessionRuntimeKey(messy))
+	}
+}
+
+func TestEnsureSessionLeaseReusesHeldLease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sessions", "20260705-Reuse.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tab := &WorkspaceTab{ID: "tab_reuse"}
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	defer tab.releaseSessionLease()
+
+	acquires := 0
+	sessionLeaseAcquireHookForTest = func() { acquires++ }
+	defer func() { sessionLeaseAcquireHookForTest = nil }()
+
+	// Same path again — and the lease's own (canonical) form: both must hit
+	// the fast path instead of re-acquiring against our own registry entry.
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("re-ensure same path: %v", err)
+	}
+	if err := tab.ensureSessionLease(tab.sessionLeaseRuntimeKey()); err != nil {
+		t.Fatalf("re-ensure canonical form: %v", err)
+	}
+	if acquires != 0 {
+		t.Fatalf("expected fast-path reuse, got %d new acquires", acquires)
+	}
+}

--- a/desktop/session_key_test.go
+++ b/desktop/session_key_test.go
@@ -101,3 +101,37 @@ func TestEnsureSessionLeaseReusesHeldLease(t *testing.T) {
 		t.Fatalf("expected fast-path reuse, got %d new acquires", acquires)
 	}
 }
+
+func TestCanReclaimAllowsMissingLeaseInfo(t *testing.T) {
+	// lease.json deleted or torn: Info is nil but nothing actually holds the
+	// session. The reclaim attempt must be allowed — the OS lock arbitrates —
+	// instead of wedging the session as busy on missing metadata (#5999's
+	// fresh-install variant).
+	app := NewApp()
+	tab := &WorkspaceTab{ID: "tab_nil_info"}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	path := filepath.Join(t.TempDir(), "Sessions", "20260705-a.jsonl")
+
+	errNil := &agent.SessionLeaseError{Path: path}
+	if !app.canReclaimCurrentProcessSessionLease(tab, path, errNil) {
+		t.Fatal("nil-Info lease error must allow a reclaim attempt")
+	}
+
+	foreign := &agent.SessionLeaseError{Path: path, Info: &agent.SessionLeaseInfo{
+		SessionPath: path, WriterID: "other-host-1-deadbeef", PID: os.Getpid() + 1,
+	}}
+	if app.canReclaimCurrentProcessSessionLease(tab, path, foreign) {
+		t.Fatal("foreign-holder lease error must not allow reclaim")
+	}
+}
+
+func TestSessionLeaseBusyErrorOmitsSettingClause(t *testing.T) {
+	generic := (&sessionLeaseBusyError{}).Error()
+	if strings.Contains(generic, "before changing") {
+		t.Fatalf("empty-setting busy error still names a setting: %q", generic)
+	}
+	withSetting := (&sessionLeaseBusyError{setting: "model"}).Error()
+	if !strings.Contains(withSetting, "before changing model") {
+		t.Fatalf("setting busy error lost its clause: %q", withSetting)
+	}
+}

--- a/desktop/shared_host_test.go
+++ b/desktop/shared_host_test.go
@@ -18,7 +18,7 @@ func sharedHostRefsForTest(t *testing.T, app *App, root string) (int, bool) {
 
 func TestCloneDetachedRuntimeTabPreservesSharedHostKey(t *testing.T) {
 	tab := &WorkspaceTab{ID: "tab", SharedHostKey: "workspace-root"}
-	detached := cloneDetachedRuntimeTab(tab, "session-key")
+	detached := cloneDetachedRuntimeTab(tab, "session-key", "session-key")
 	if detached == nil {
 		t.Fatal("cloneDetachedRuntimeTab returned nil")
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -241,8 +241,14 @@ func (t *WorkspaceTab) hasActiveRuntimeWork() bool {
 	return status.Running || status.PendingPrompt || status.BackgroundJobs > 0
 }
 
+// sessionRuntimeKey is the comparison/map key for "same session" checks. It
+// layers agent.CanonicalSessionPath on top of the desktop path normalization
+// so the key matches the form held by session leases (lowercased on Windows).
+// Comparing a lease's Path() against a raw tab path without this fold made
+// every rebuild on Windows look like a foreign holder (self-lock, #5999).
+// Keys are identities only — never use them as display or file paths.
 func sessionRuntimeKey(path string) string {
-	return canonicalTabSessionPath(path)
+	return agent.CanonicalSessionPath(canonicalTabSessionPath(path))
 }
 
 var sessionLeaseAcquireHookForTest func()
@@ -426,7 +432,7 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 	}
 	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
-	tab.SessionPath = key
+	tab.SessionPath = canonicalTabSessionPath(path)
 	a.detachedSessions[key] = tab
 	a.mu.Unlock()
 	return true
@@ -437,8 +443,10 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 // ActivityStatus, disabledMCP, ...) are written under a.mu by bound methods
 // and the event sink, and the disabledMCP map read would otherwise race those
 // writers. The session lease is transferred separately by the caller through
-// the sessionLeaseMu helpers.
-func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
+// the sessionLeaseMu helpers. key is the runtime identity (map key / tab id
+// hash); path is the real session path — keys are case-folded on Windows and
+// must not leak into SessionPath, which is displayed and persisted.
+func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab {
 	if tab == nil {
 		return nil
 	}
@@ -454,7 +462,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key string) *WorkspaceTab {
 		SharedHostKey:    tab.SharedHostKey,
 		TopicID:          tab.TopicID,
 		TopicTitle:       tab.TopicTitle,
-		SessionPath:      key,
+		SessionPath:      canonicalTabSessionPath(path),
 		Ctrl:             tab.Ctrl,
 		Label:            tab.Label,
 		Ready:            tab.Ready,
@@ -494,12 +502,13 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 		a.mu.Unlock()
 		return false
 	}
-	key := sessionRuntimeKey(tab.currentSessionPath())
+	sourcePath := tab.currentSessionPath()
+	key := sessionRuntimeKey(sourcePath)
 	if key == "" {
 		a.mu.Unlock()
 		return false
 	}
-	detached := cloneDetachedRuntimeTab(tab, key)
+	detached := cloneDetachedRuntimeTab(tab, key, sourcePath)
 	if detached == nil {
 		a.mu.Unlock()
 		return false
@@ -522,7 +531,10 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	return true
 }
 
-func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.Context, app *App) {
+// applyRuntimeTab moves source's runtime (controller, sink, lease, telemetry)
+// onto target. path is the real session path for display/persistence; the
+// case-folded runtime key must never be written into SessionPath.
+func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context.Context, app *App) {
 	if target == nil || source == nil {
 		return
 	}
@@ -539,7 +551,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, key string, wailsCtx context.
 	target.Ctrl = source.Ctrl
 	target.sink = source.sink
 	target.adoptSessionLease(source.takeSessionLease())
-	target.SessionPath = key
+	target.SessionPath = canonicalTabSessionPath(path)
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
 	target.Ready = true
@@ -571,7 +583,7 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	detached := a.detachedSessions[key]
 	if detached != nil {
 		delete(a.detachedSessions, key)
-		applyRuntimeTab(tab, detached, key, wailsCtx, a)
+		applyRuntimeTab(tab, detached, path, wailsCtx, a)
 		if current := a.tabs[tab.ID]; current == tab {
 			a.saveTabsLocked()
 		}
@@ -602,7 +614,7 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	if a.activeTabID == source.ID {
 		a.activeTabID = tab.ID
 	}
-	applyRuntimeTab(tab, source, key, wailsCtx, a)
+	applyRuntimeTab(tab, source, path, wailsCtx, a)
 	a.saveTabsLocked()
 	attachedCtrl := tab.Ctrl
 	a.mu.Unlock()
@@ -2389,6 +2401,22 @@ func (a *App) tabBuildSuperseded(tab *WorkspaceTab, generation uint64) bool {
 	return a.tabBuildSupersededLocked(tab, generation)
 }
 
+// supersedeTabBuildLocked invalidates any in-flight startup build and cancels
+// its context. A synchronous rebuild (model/effort/token switch) that has
+// already installed its controller calls this so a slower blank-session build
+// cannot finish afterward, overwrite tab.Ctrl, and release or steal the
+// session lease the switch just bound. Callers must hold a.mu.
+func (a *App) supersedeTabBuildLocked(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	tab.buildGeneration++
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+		tab.buildCancel = nil
+	}
+}
+
 // abandonSupersededBuild cleans up after a build that lost tab ownership
 // mid-flight (removed tab, or a session rebind bumped the generation). It
 // releases only what THIS build acquired — its controller, its own
@@ -2752,6 +2780,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				a.emitReady(wailsCtx, tab.ID)
 				return
 			}
+			preLeaseKey := tab.sessionLeaseRuntimeKey()
 			if err := tab.ensureSessionLease(path); err != nil {
 				a.mu.Lock()
 				if a.tabBuildSupersededLocked(tab, buildGeneration) {
@@ -2762,7 +2791,10 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				tab.StartupErr = err.Error()
 				tab.Ready = true
 				hostKey := takeTabSharedHostKey(tab)
-				tab.releaseSessionLease()
+				// Release only a lease bound to THIS build's session: a failed
+				// ensure leaves any prior lease untouched, and that lease may
+				// belong to a runtime a concurrent switch just installed.
+				tab.releaseSessionLeaseForKey(sessionRuntimeKey(path))
 				a.mu.Unlock()
 				ctrl.Close()
 				if hostKey != "" {
@@ -2773,8 +2805,12 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			}
 			// Remember which lease THIS build bound: if the build is later
 			// superseded, only a lease still carrying this key may be
-			// released (see abandonSupersededBuild).
-			acquiredLeaseKey = sessionRuntimeKey(path)
+			// released (see abandonSupersededBuild). A fast-path reuse means
+			// the lease existed before this build (bound by a concurrent
+			// switch or recovery) — it is not ours to release.
+			if key := sessionRuntimeKey(path); key != preLeaseKey {
+				acquiredLeaseKey = key
+			}
 			// Re-check ownership right after the (potentially slow) lease
 			// bind: a rebind that superseded this build while ensure was in
 			// flight has already retargeted the tab, and continuing into
@@ -7017,7 +7053,15 @@ func canonicalTabSessionPath(path string) string {
 	if validPath, _, err := validateSessionPath(config.SessionDir(), path); err == nil {
 		return validPath
 	}
-	return path
+	// Project-scope sessions live outside config.SessionDir(), so validation
+	// against it always fails. Still normalize the shape: without clean+abs,
+	// the same file spelled with a different separator or a relative prefix
+	// splits into distinct runtime keys.
+	cleaned := filepath.Clean(path)
+	if abs, err := filepath.Abs(cleaned); err == nil {
+		return abs
+	}
+	return cleaned
 }
 
 func (a *App) rememberTabSessionPath(tab *WorkspaceTab, path string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -66,6 +66,10 @@ type WorkspaceTab struct {
 	saving       bool
 	saveAgain    bool
 	saveFailures int
+	// lastAutosaveWarnAt debounces the user-facing autosave-failure notice:
+	// a persistently failing disk (AV hold, full volume) otherwise emits a
+	// chat warning for every completed turn. Logs are never debounced.
+	lastAutosaveWarnAt time.Time
 
 	// closing is set under saveMu when the tab is being torn down. Once set,
 	// tabSnapshotLoop stops taking new snapshot work and CloseTab waits on
@@ -2577,7 +2581,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			a.mu.Unlock()
 			return
 		}
-		tab.StartupErr = err.Error()
+		tab.StartupErr = userFacingSessionLeaseError("", err).Error()
 		tab.Ready = true
 		tab.releaseSessionLease()
 		a.mu.Unlock()
@@ -2703,7 +2707,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			a.abandonSupersededBuild(tab, nil, rootKey, "")
 			return
 		}
-		tab.StartupErr = err.Error()
+		tab.StartupErr = userFacingSessionLeaseError("", err).Error()
 		tab.Ready = true
 		hostKey := takeTabSharedHostKey(tab)
 		tab.releaseSessionLease()
@@ -2788,7 +2792,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 					a.abandonSupersededBuild(tab, ctrl, rootKey, "")
 					return
 				}
-				tab.StartupErr = err.Error()
+				tab.StartupErr = userFacingSessionLeaseError("", err).Error()
 				tab.Ready = true
 				hostKey := takeTabSharedHostKey(tab)
 				// Release only a lease bound to THIS build's session: a failed
@@ -3158,6 +3162,10 @@ func (a *App) ctrlByTabID(tabID string) control.SessionAPI {
 
 const maxTabSnapshotFailureRetries = 2
 
+// autosaveWarnInterval rate-limits the user-facing autosave-failure notice
+// per tab; slog keeps recording every failure regardless.
+const autosaveWarnInterval = 5 * time.Minute
+
 func tabSnapshotRetryDelay(failures int) time.Duration {
 	switch {
 	case failures <= 1:
@@ -3231,7 +3239,6 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 				}
 			} else {
 				snapshotErr = err
-				a.reportTabSnapshotError(tab, "autosave", err)
 			}
 		}
 		tab.saveMu.Lock()
@@ -3248,22 +3255,36 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 			tab.saving = false
 			tab.saveCond.Broadcast()
 			tab.saveMu.Unlock()
+			if snapshotErr != nil {
+				slog.Warn("desktop: session autosave failed during teardown", "tab", tab.ID, "err", snapshotErr)
+			}
 			return
 		}
 		if tab.saveAgain {
 			tab.saveAgain = false
 			tab.saveMu.Unlock()
+			if snapshotErr != nil {
+				slog.Warn("desktop: session autosave failed; newer snapshot queued", "tab", tab.ID, "err", snapshotErr)
+			}
 			continue
 		}
 		if snapshotErr != nil && tab.saveFailures <= maxTabSnapshotFailureRetries {
 			delay := tabSnapshotRetryDelay(tab.saveFailures)
+			attempt := tab.saveFailures
 			tab.saveMu.Unlock()
+			// Retries are routine (transient AV/indexer holds); tell the user
+			// only when the whole burst gives up, not once per attempt.
+			slog.Warn("desktop: session autosave failed; retrying", "tab", tab.ID, "attempt", attempt, "err", snapshotErr)
 			time.Sleep(delay)
 			continue
 		}
+		exhausted := snapshotErr
 		tab.saving = false
 		tab.saveCond.Broadcast()
 		tab.saveMu.Unlock()
+		if exhausted != nil {
+			a.reportTabSnapshotError(tab, "autosave", exhausted)
+		}
 		return
 	}
 }
@@ -4706,7 +4727,12 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 					reason = "lease_held"
 				}
 				a.emitRuntimeEvent("session:recovery-failed", sessionRecoveryFailedEvent{Reason: reason})
-				return fmt.Errorf("acquire recovery session lease: %w", err)
+				// This error propagates out through ctrl.Snapshot() into chat
+				// notices and bridge returns (reportTabSnapshotError). The raw
+				// path/holder id stayed in the slog line above; keep it out of
+				// the surfaced message.
+				return fmt.Errorf("acquire recovery session lease: %w",
+					userFacingSessionLeaseError("", err))
 			}
 		}
 		meta := info.Meta

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -909,8 +909,15 @@ func TestBuildTabControllerBlocksWhenSessionLeaseHeld(t *testing.T) {
 	if !tab.Ready {
 		t.Fatal("tab should be ready with startup error")
 	}
-	if !strings.Contains(tab.StartupErr, agent.ErrSessionLeaseHeld.Error()) {
-		t.Fatalf("startup error = %q, want lease-held error", tab.StartupErr)
+	// The surfaced startup error is the sanitized busy message: the raw lease
+	// error would leak the session path and the holder's host-pid-writer id
+	// into the topbar banner.
+	if !strings.Contains(tab.StartupErr, "already open in another Reasonix window") {
+		t.Fatalf("startup error = %q, want user-facing busy message", tab.StartupErr)
+	}
+	if strings.Contains(tab.StartupErr, agent.ErrSessionLeaseHeld.Error()) ||
+		strings.Contains(tab.StartupErr, path) {
+		t.Fatalf("startup error leaked raw lease details: %q", tab.StartupErr)
 	}
 }
 

--- a/internal/agent/canonical_path_test.go
+++ b/internal/agent/canonical_path_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalSessionPathMatchesLeaseRegistryKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Mixed-Case", "20260705-Test.jsonl")
+	if got, want := CanonicalSessionPath(path), canonicalSessionSavePath(path); got != want {
+		t.Fatalf("CanonicalSessionPath(%q) = %q, want lease key %q", path, got, want)
+	}
+}
+
+func TestCanonicalSessionPathIdempotentAndEmptySafe(t *testing.T) {
+	if got := CanonicalSessionPath(""); got != "" {
+		t.Fatalf("empty path resolved to %q; must stay empty", got)
+	}
+	if got := CanonicalSessionPath("   "); got != "" {
+		t.Fatalf("blank path resolved to %q; must stay empty", got)
+	}
+	path := filepath.Join(t.TempDir(), "A", "b.jsonl")
+	key := CanonicalSessionPath(path)
+	if again := CanonicalSessionPath(key); again != key {
+		t.Fatalf("not idempotent: %q -> %q", key, again)
+	}
+}
+
+func TestCanonicalSessionPathFoldsCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case folding is Windows-only")
+	}
+	path := filepath.Join(t.TempDir(), "Sessions", "20260705-Test.jsonl")
+	if CanonicalSessionPath(path) != CanonicalSessionPath(strings.ToUpper(path)) {
+		t.Fatal("case variants of one file produced distinct keys")
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -500,7 +501,12 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 		return RecoveryBranchInfo{}, err
 	}
 	if err := writeSessionEventIndex(recoveryPath, msgs, digest, meta.Revision); err != nil {
-		return RecoveryBranchInfo{}, err
+		// The recovery transcript (log + checkpoint) and its meta are already
+		// durable; the index is only a listing accelerator. Failing here would
+		// discard a recovery that in fact succeeded and re-run the whole
+		// conflict path on the next save.
+		slog.Warn("session: keeping recovery branch after event index write failure",
+			"path", recoveryPath, "err", err)
 	}
 	s.markPersisted(recoveryPath, digest, version, meta.Revision)
 	return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Meta: meta, Preview: preview, Turns: turns}, nil

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -813,6 +813,20 @@ func canonicalSessionSavePath(path string) string {
 	return key
 }
 
+// CanonicalSessionPath is the identity key of a session path: cleaned,
+// absolute, and case-folded on Windows, matching the key form used by the
+// lease registry and the save-path locks. Any runtime bookkeeping that
+// compares or maps session paths (desktop tabs, detached runtimes) must use
+// this exact form, or the same file splits into distinct keys — e.g.
+// `C:\Users\...` vs the lease's lowercased `c:\users\...`. Empty input stays
+// empty instead of resolving to the working directory.
+func CanonicalSessionPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return canonicalSessionSavePath(path)
+}
+
 // LoadSession reads a saved session into a fresh Session value. New sessions
 // replay the append-only event log; legacy sessions without an event log fall
 // back to the compatibility .jsonl checkpoint. A damaged log is replayed to its

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -93,26 +93,35 @@ func TryAcquireSessionLease(path string) (*SessionLease, error) {
 }
 
 // TryReclaimCurrentProcessSessionLease re-acquires a lease whose in-process
-// owner entry was orphaned (a lease dropped without Release). It only succeeds
-// when the on-disk lease info identifies the current process AND the OS lease
-// lock is free: an active holder keeps its lock file locked, so reclaiming
-// from it fails with ErrSessionLeaseHeld without touching the holder's entry.
+// owner entry was orphaned (a lease dropped without Release). The OS lease
+// lock is the arbiter: an active holder keeps its lock file locked for the
+// whole hold, so reclaiming from one fails with ErrSessionLeaseHeld without
+// touching the holder's entry. Holding the lock proves nobody does, which
+// also covers metadata-damage states — a missing or unreadable lease info
+// (deleted by the user, quarantined by AV, torn by a crash) with a free lock
+// is a leftover, not a holder, and must not wedge the session as busy.
 func TryReclaimCurrentProcessSessionLease(path string) (*SessionLease, error) {
 	path = canonicalSessionSavePath(path)
 	info, err := LoadSessionLeaseInfo(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// The holder finished releasing between the caller's failed
-			// acquire and now; a regular acquire can win the lease cleanly.
-			return TryAcquireSessionLease(path)
+	switch {
+	case err == nil:
+		if info == nil || info.PID != os.Getpid() || info.WriterID != SessionWriterID() {
+			// A readable info naming another live runtime: never steal it.
+			// (A crashed foreign leftover is separated from a live holder by
+			// the lock probe in SessionLeaseHeldByOtherRuntime; reclaim is
+			// only for leases this process lost track of.)
+			return nil, &SessionLeaseError{Path: path, Info: info}
 		}
-		// Unreadable lease info means the holder cannot be identified, so
-		// reclaiming is unsafe. Report the lease as held rather than leaking
-		// a raw filesystem error to callers that surface it to users.
-		return nil, &SessionLeaseError{Path: path}
-	}
-	if info == nil || info.PID != os.Getpid() || info.WriterID != SessionWriterID() {
-		return nil, &SessionLeaseError{Path: path, Info: info}
+	case os.IsNotExist(err):
+		// The holder finished releasing (info removed first) or the sidecar
+		// was deleted out from under an orphaned entry. Either way the lock
+		// probe below decides; info identity has nothing left to say.
+		info = nil
+	default:
+		// Unreadable info hides the holder's identity, but the lock still
+		// tells the truth: a live holder keeps it locked. Fall through to the
+		// probe instead of wedging on metadata damage.
+		info = nil
 	}
 	unlock, err := tryLockSessionLeaseFile(path)
 	if err != nil {
@@ -203,6 +212,16 @@ func (l *SessionLease) Release() {
 		// Only remove the entry this lease owns: after a reclaim the map may
 		// already point at a newer lease for the same path.
 		sessionLeaseOwners.CompareAndDelete(l.path, l.ownerID)
+		// Best-effort retirement of the lock sidecars this session no longer
+		// needs. Historically they were left behind on every release and only
+		// swept on the next boot reconcile, so ordinary use accumulated
+		// .lock/.lease.lock files (#6014). The helpers re-take each lock
+		// non-blocking and delete it atomically with the release, so a new
+		// holder or an in-flight save simply turns this into a no-op. This
+		// must run after CompareAndDelete: the lease-lock helper skips paths
+		// the owner registry still reports as held by this process.
+		_ = removeStaleSessionLeaseLockSidecar(l.path, store.SessionLeaseLock(l.path))
+		_ = removeStaleSessionLockSidecar(l.path, store.SessionLockFile(l.path))
 	})
 }
 

--- a/internal/agent/session_lease_test.go
+++ b/internal/agent/session_lease_test.go
@@ -7,18 +7,35 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"reasonix/internal/store"
 )
 
+// leaseTestPath returns a session path in "user shape" — mixed case, exactly
+// as desktop/CLI callers pass it — plus its canonical registry key for
+// internal-state setup and assertions. Tests must feed the user shape to the
+// API under test: feeding pre-canonicalized paths is how the Windows
+// case-fold mismatch (#5999) escaped this suite. On non-Windows hosts the two
+// forms are identical; on Windows they differ and exercise the fold.
+func leaseTestPath(t *testing.T) (userPath, key string) {
+	t.Helper()
+	userPath = filepath.Join(t.TempDir(), "Sessions-Dir", "Session-Test.jsonl")
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return userPath, canonicalSessionSavePath(userPath)
+}
+
 func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "session.jsonl")
-	first, err := TryAcquireSessionLease(path)
+	userPath, _ := leaseTestPath(t)
+	first, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("first TryAcquireSessionLease: %v", err)
 	}
 	if first.Path() == "" {
 		t.Fatal("first lease path is empty")
 	}
-	info, err := LoadSessionLeaseInfo(path)
+	info, err := LoadSessionLeaseInfo(userPath)
 	if err != nil {
 		t.Fatalf("LoadSessionLeaseInfo: %v", err)
 	}
@@ -26,7 +43,7 @@ func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
 		t.Fatalf("lease info = %+v, want writer metadata", info)
 	}
 
-	second, err := TryAcquireSessionLease(path)
+	second, err := TryAcquireSessionLease(userPath)
 	if !errors.Is(err, ErrSessionLeaseHeld) {
 		t.Fatalf("second TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
 	}
@@ -36,7 +53,7 @@ func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
 	}
 
 	first.Release()
-	third, err := TryAcquireSessionLease(path)
+	third, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("third TryAcquireSessionLease after release: %v", err)
 	}
@@ -44,43 +61,112 @@ func TestSessionLeaseRejectsConcurrentWriterAndReleases(t *testing.T) {
 }
 
 func TestSessionLeaseReclaimsCurrentProcessStaleOwner(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "session.jsonl")
-	path = canonicalSessionSavePath(path)
-	sessionLeaseOwners.Store(path, struct{}{})
+	userPath, key := leaseTestPath(t)
+	sessionLeaseOwners.Store(key, struct{}{})
 	t.Cleanup(func() {
-		sessionLeaseOwners.Delete(path)
-		_ = os.Remove(sessionLeaseInfoPath(path))
+		sessionLeaseOwners.Delete(key)
+		_ = os.Remove(sessionLeaseInfoPath(key))
 	})
-	if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
-		SessionPath: path,
+	if err := SaveSessionLeaseInfo(key, SessionLeaseInfo{
+		SessionPath: key,
 		WriterID:    SessionWriterID(),
 		PID:         os.Getpid(),
 		AcquiredAt:  time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("SaveSessionLeaseInfo: %v", err)
 	}
-	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+	if lease, err := TryAcquireSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
 		if lease != nil {
 			lease.Release()
 		}
 		t.Fatalf("TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
 	}
-	lease, err := TryReclaimCurrentProcessSessionLease(path)
+	lease, err := TryReclaimCurrentProcessSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryReclaimCurrentProcessSessionLease: %v", err)
 	}
 	lease.Release()
 }
 
-func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
-	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-	sessionLeaseOwners.Store(path, struct{}{})
+func TestSessionLeaseReclaimsOrphanedEntryWithoutInfo(t *testing.T) {
+	// An orphaned in-process entry whose lease.json was deleted out from
+	// under it (manual cleanup, AV quarantine). Nothing actually holds the
+	// session — the OS lock is free — so reclaim must recover instead of
+	// wedging every rebuild as busy. Before the lock-arbiter rework this
+	// deadlocked: reclaim fell back to a plain acquire, which re-hit the
+	// orphaned map entry forever.
+	userPath, key := leaseTestPath(t)
+	sessionLeaseOwners.Store(key, uint64(1<<61))
+	t.Cleanup(func() { sessionLeaseOwners.Delete(key) })
+
+	if lease, err := TryAcquireSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryAcquireSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+	lease, err := TryReclaimCurrentProcessSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("TryReclaimCurrentProcessSessionLease without info: %v", err)
+	}
+	if _, err := LoadSessionLeaseInfo(userPath); err != nil {
+		t.Fatalf("reclaim should have rewritten lease info, load err = %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseReclaimsOrphanedEntryWithCorruptInfo(t *testing.T) {
+	// Same as above but the sidecar is torn (empty/undecodable) rather than
+	// missing: identity is unreadable, the lock is free, reclaim must win.
+	userPath, key := leaseTestPath(t)
+	sessionLeaseOwners.Store(key, uint64(1<<61))
 	t.Cleanup(func() {
-		sessionLeaseOwners.Delete(path)
-		_ = os.Remove(sessionLeaseInfoPath(path))
+		sessionLeaseOwners.Delete(key)
+		_ = os.Remove(sessionLeaseInfoPath(key))
 	})
-	if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
-		SessionPath: path,
+	if err := os.WriteFile(sessionLeaseInfoPath(key), []byte("{torn"), 0o644); err != nil {
+		t.Fatalf("write corrupt lease info: %v", err)
+	}
+
+	lease, err := TryReclaimCurrentProcessSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("TryReclaimCurrentProcessSessionLease with corrupt info: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseReclaimRefusesForeignInfo(t *testing.T) {
+	// A readable info naming another runtime is never stolen by reclaim,
+	// even with the lock free — that separation belongs to
+	// SessionLeaseHeldByOtherRuntime's cleanup, not to reclaim.
+	userPath, key := leaseTestPath(t)
+	if err := SaveSessionLeaseInfo(key, SessionLeaseInfo{
+		SessionPath: key,
+		WriterID:    "other-host-1234-deadbeef",
+		PID:         os.Getpid() + 1,
+		AcquiredAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionLeaseInfo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(key)) })
+
+	if lease, err := TryReclaimCurrentProcessSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
+		if lease != nil {
+			lease.Release()
+		}
+		t.Fatalf("TryReclaimCurrentProcessSessionLease err = %v, want ErrSessionLeaseHeld", err)
+	}
+}
+
+func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
+	userPath, key := leaseTestPath(t)
+	sessionLeaseOwners.Store(key, struct{}{})
+	t.Cleanup(func() {
+		sessionLeaseOwners.Delete(key)
+		_ = os.Remove(sessionLeaseInfoPath(key))
+	})
+	if err := SaveSessionLeaseInfo(key, SessionLeaseInfo{
+		SessionPath: key,
 		WriterID:    SessionWriterID(),
 		PID:         os.Getpid(),
 		AcquiredAt:  time.Now().UTC(),
@@ -97,7 +183,7 @@ func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			if lease, err := TryReclaimCurrentProcessSessionLease(path); err == nil && lease != nil {
+			if lease, err := TryReclaimCurrentProcessSessionLease(userPath); err == nil && lease != nil {
 				leases <- lease
 			}
 		}()
@@ -114,17 +200,17 @@ func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
 		t.Fatalf("concurrent reclaim produced %d leases, want exactly 1", len(won))
 	}
 	// The losers must not have evicted the winner's owner entry.
-	if _, ok := sessionLeaseOwners.Load(path); !ok {
+	if _, ok := sessionLeaseOwners.Load(key); !ok {
 		t.Fatal("winner's owner entry was evicted by a failed concurrent reclaim")
 	}
-	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+	if lease, err := TryAcquireSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
 		if lease != nil {
 			lease.Release()
 		}
 		t.Fatalf("TryAcquireSessionLease while reclaimed lease is held err = %v, want ErrSessionLeaseHeld", err)
 	}
 	won[0].Release()
-	lease, err := TryAcquireSessionLease(path)
+	lease, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryAcquireSessionLease after release: %v", err)
 	}
@@ -132,24 +218,24 @@ func TestSessionLeaseConcurrentReclaimSingleWinner(t *testing.T) {
 }
 
 func TestSessionLeaseReclaimRefusesActiveHolder(t *testing.T) {
-	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-	holder, err := TryAcquireSessionLease(path)
+	userPath, key := leaseTestPath(t)
+	holder, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryAcquireSessionLease: %v", err)
 	}
 	defer holder.Release()
 
-	if lease, err := TryReclaimCurrentProcessSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+	if lease, err := TryReclaimCurrentProcessSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
 		if lease != nil {
 			lease.Release()
 		}
 		t.Fatalf("TryReclaimCurrentProcessSessionLease err = %v, want ErrSessionLeaseHeld", err)
 	}
 	// The failed reclaim must leave the holder's owner entry intact.
-	if _, ok := sessionLeaseOwners.Load(path); !ok {
+	if _, ok := sessionLeaseOwners.Load(key); !ok {
 		t.Fatal("active holder's owner entry was evicted by a failed reclaim")
 	}
-	if lease, err := TryAcquireSessionLease(path); !errors.Is(err, ErrSessionLeaseHeld) {
+	if lease, err := TryAcquireSessionLease(userPath); !errors.Is(err, ErrSessionLeaseHeld) {
 		if lease != nil {
 			lease.Release()
 		}
@@ -158,16 +244,17 @@ func TestSessionLeaseReclaimRefusesActiveHolder(t *testing.T) {
 }
 
 func TestSessionLeaseReclaimAfterHolderReleased(t *testing.T) {
-	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-	holder, err := TryAcquireSessionLease(path)
+	userPath, _ := leaseTestPath(t)
+	holder, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryAcquireSessionLease: %v", err)
 	}
 	holder.Release()
 
 	// The holder released between the caller's failed acquire and the
-	// reclaim: the lease info file is gone and a plain acquire must win.
-	lease, err := TryReclaimCurrentProcessSessionLease(path)
+	// reclaim: the lease info file is gone and the lock is free, so the
+	// reclaim must win the lease cleanly.
+	lease, err := TryReclaimCurrentProcessSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryReclaimCurrentProcessSessionLease after release: %v", err)
 	}
@@ -175,96 +262,126 @@ func TestSessionLeaseReclaimAfterHolderReleased(t *testing.T) {
 }
 
 func TestSessionLeaseStaleReleaseKeepsNewOwnerEntry(t *testing.T) {
-	path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-	stale, err := TryAcquireSessionLease(path)
+	userPath, key := leaseTestPath(t)
+	stale, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("TryAcquireSessionLease: %v", err)
 	}
 	// Simulate a reclaim that took over the entry while the stale lease was
 	// still alive: the map now names a different owner.
-	sessionLeaseOwners.Store(path, uint64(1<<62))
-	t.Cleanup(func() { sessionLeaseOwners.Delete(path) })
+	sessionLeaseOwners.Store(key, uint64(1<<62))
+	t.Cleanup(func() { sessionLeaseOwners.Delete(key) })
 
 	stale.Release()
-	if _, ok := sessionLeaseOwners.Load(path); !ok {
+	if _, ok := sessionLeaseOwners.Load(key); !ok {
 		t.Fatal("stale Release evicted the new owner's entry")
 	}
 }
 
 func TestSessionLeaseHeldByOtherRuntime(t *testing.T) {
 	t.Run("no lease", func(t *testing.T) {
-		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-		if SessionLeaseHeldByOtherRuntime(path) {
+		userPath, _ := leaseTestPath(t)
+		if SessionLeaseHeldByOtherRuntime(userPath) {
 			t.Fatal("unheld session reported as held by another runtime")
 		}
 	})
 	t.Run("held by this process", func(t *testing.T) {
-		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-		lease, err := TryAcquireSessionLease(path)
+		userPath, _ := leaseTestPath(t)
+		lease, err := TryAcquireSessionLease(userPath)
 		if err != nil {
 			t.Fatalf("TryAcquireSessionLease: %v", err)
 		}
 		defer lease.Release()
-		if SessionLeaseHeldByOtherRuntime(path) {
+		if SessionLeaseHeldByOtherRuntime(userPath) {
 			t.Fatal("own lease reported as held by another runtime")
 		}
 	})
 	t.Run("foreign info with live lock", func(t *testing.T) {
-		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		unlock, err := tryLockSessionLeaseFile(path)
+		userPath, key := leaseTestPath(t)
+		unlock, err := tryLockSessionLeaseFile(key)
 		if err != nil {
 			t.Fatalf("tryLockSessionLeaseFile: %v", err)
 		}
 		defer unlock()
-		if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
-			SessionPath: path,
+		if err := SaveSessionLeaseInfo(key, SessionLeaseInfo{
+			SessionPath: key,
 			WriterID:    "other-host-1234-deadbeef",
 			PID:         os.Getpid() + 1,
 			AcquiredAt:  time.Now().UTC(),
 		}); err != nil {
 			t.Fatalf("SaveSessionLeaseInfo: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(path)) })
-		if !SessionLeaseHeldByOtherRuntime(path) {
+		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(key)) })
+		if !SessionLeaseHeldByOtherRuntime(userPath) {
 			t.Fatal("foreign-held session not reported as held by another runtime")
 		}
 	})
 	t.Run("foreign info from crashed process", func(t *testing.T) {
-		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-		if err := SaveSessionLeaseInfo(path, SessionLeaseInfo{
-			SessionPath: path,
+		userPath, key := leaseTestPath(t)
+		if err := SaveSessionLeaseInfo(key, SessionLeaseInfo{
+			SessionPath: key,
 			WriterID:    "other-host-1234-deadbeef",
 			PID:         os.Getpid() + 1,
 			AcquiredAt:  time.Now().UTC(),
 		}); err != nil {
 			t.Fatalf("SaveSessionLeaseInfo: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(path)) })
+		t.Cleanup(func() { _ = os.Remove(sessionLeaseInfoPath(key)) })
 		// Info file left behind but the lock is free: the holder crashed, so
 		// the session is not considered held.
-		if SessionLeaseHeldByOtherRuntime(path) {
+		if SessionLeaseHeldByOtherRuntime(userPath) {
 			t.Fatal("crashed holder's leftover info reported as held")
 		}
-		if _, err := os.Stat(sessionLeaseInfoPath(path)); !os.IsNotExist(err) {
+		if _, err := os.Stat(sessionLeaseInfoPath(key)); !os.IsNotExist(err) {
 			t.Fatalf("crashed holder's leftover info should be removed, stat err = %v", err)
 		}
 	})
 	t.Run("corrupt info from crashed process", func(t *testing.T) {
-		path := canonicalSessionSavePath(filepath.Join(t.TempDir(), "session.jsonl"))
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		if err := os.WriteFile(sessionLeaseInfoPath(path), nil, 0o644); err != nil {
+		userPath, key := leaseTestPath(t)
+		if err := os.WriteFile(sessionLeaseInfoPath(key), nil, 0o644); err != nil {
 			t.Fatalf("write corrupt lease info: %v", err)
 		}
-		if SessionLeaseHeldByOtherRuntime(path) {
+		if SessionLeaseHeldByOtherRuntime(userPath) {
 			t.Fatal("corrupt crashed holder info reported as held")
 		}
-		if _, err := os.Stat(sessionLeaseInfoPath(path)); !os.IsNotExist(err) {
+		if _, err := os.Stat(sessionLeaseInfoPath(key)); !os.IsNotExist(err) {
 			t.Fatalf("corrupt lease info should be removed, stat err = %v", err)
 		}
 	})
+}
+
+func TestSessionLeaseReleaseRetiresLockSidecars(t *testing.T) {
+	userPath, key := leaseTestPath(t)
+	lease, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	leaseLock := store.SessionLeaseLock(key)
+	if _, err := os.Stat(leaseLock); err != nil {
+		t.Fatalf("lease lock should exist while held: %v", err)
+	}
+	lease.Release()
+	if _, err := os.Stat(leaseLock); !os.IsNotExist(err) {
+		t.Fatalf("lease lock should be retired on release, stat err = %v", err)
+	}
+	if _, err := os.Stat(store.SessionLockFile(key)); !os.IsNotExist(err) {
+		t.Fatalf("save lock should be retired on release, stat err = %v", err)
+	}
+
+	// A release racing a live successor must not strip the successor's lock.
+	first, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("reacquire: %v", err)
+	}
+	second, err := TryAcquireSessionLease(userPath)
+	if !errors.Is(err, ErrSessionLeaseHeld) {
+		if second != nil {
+			second.Release()
+		}
+		t.Fatalf("second acquire err = %v, want ErrSessionLeaseHeld", err)
+	}
+	if _, err := os.Stat(leaseLock); err != nil {
+		t.Fatalf("holder's lease lock must survive a failed acquire: %v", err)
+	}
+	first.Release()
 }


### PR DESCRIPTION
## Summary

Follow-up polish on the lease/CAS stack after the #6023 / #6025 hotfixes. Those two PRs fixed the deterministic root causes; this one closes the remaining ways a healthy single-window session could still present as busy, leak holder details into the UI, or litter the session directory — the secondary irritants reported across the same incident issues.

**Stacked on #6023** (branched from it; merge #6023 first and this PR reduces to one commit).

## Changes

### 1. Lease reclaim self-heals metadata damage

`TryReclaimCurrentProcessSessionLease` now arbitrates on the OS lock alone. A missing or unreadable `lease.json` (deleted by the user, quarantined by AV, torn by a crash) with a free lock is a leftover, not a holder. Previously an orphaned in-process registry entry whose info file disappeared could **never** be reclaimed — the fallback acquire re-hit the orphaned entry forever, wedging every rebuild as busy. The desktop gate (`canReclaimCurrentProcessSessionLease`) mirrors this: nil lease info now allows the reclaim attempt (the OS lock arbitrates), while a readable info naming a foreign runtime is still refused.

### 2. Raw lease errors can no longer reach the UI

The raw `SessionLeaseError` text carries the session path and the holder's `host-pid-writer` id (seen verbatim in #5990). Audited every surface end-to-end and sanitized the three that still leaked:

- **Startup bind failures** — `tab.StartupErr` feeds the topbar error banner and the polled tab metas; all three assignment sites now render the user-facing busy message.
- **`ClearSession` bridge returns** (both the direct path and `clearActiveSessionRuntime`).
- **Recovery-lease callback** — its error propagates through `ctrl.Snapshot()` into chat notices and bridge returns; the surfaced message is now sanitized while the raw details stay in `slog`.

The busy message also drops its dangling "before changing this setting" clause when no setting applies. Trash/delete paths, deferred rebuilds, and serve/ACP were audited and confirmed clean (serve/ACP never touch leases).

### 3. Lock sidecars retire on release instead of accumulating

`SessionLease.Release` now retires `.lock` / `.lease.lock` through the existing atomic take-then-remove helpers — non-blocking, and a no-op against any live holder or in-flight save, preserving the delete-atomic-with-release invariant. Previously the sidecars were only swept on the next boot reconcile, so ordinary use accumulated lock files (#6014 reported 5 of them alongside the recovery pile-up).

### 4. Autosave failure warnings stop streaming

A persistently failing disk (AV hold, full volume) used to emit a chat warning for **every attempt of every turn** (up to 3 per burst, unbounded across turns). Now: retries are slog-only, the user notice fires once when a burst gives up, and at most once per 5 minutes per tab. Explicit action saves keep immediate feedback; every failure is still logged.

### 5. Recovery branches tolerate index write failures

`SaveRecoveryBranch` no longer fails after the recovery transcript and meta are already durable just because the event-index (a listing accelerator) could not be written — matching the two save() call sites hardened in #6025.

### 6. Lease test suite feeds user-shape paths

The suite previously passed pre-canonicalized paths to the APIs under test — the exact pattern that let the Windows case-fold mismatch (#5999) escape it. A `leaseTestPath` helper now feeds mixed-case user-shape paths to every API call (identical off-Windows, exercises the fold on Windows), with internal-state setup keeping canonical keys. New regressions: orphan-without-info reclaim, corrupt-info reclaim, foreign-info refusal, sidecar retirement on release (including the racing-successor guard), StartupErr sanitization, and the autosave warning debounce.

## Tests

- `go test ./internal/agent` full (+ lease/canonical subset with `-race`) — pass.
- `cd desktop && go test .` full suite — pass (one pre-existing assertion updated: it required the raw lease text in `StartupErr`, i.e. it had codified the leak; it now asserts the sanitized message and the absence of raw details).
- `GOOS=windows GOARCH=amd64` builds clean in both modules; `gofmt` clean.

## Cache impact

Cache-impact: none. Desktop runtime ownership, error presentation, sidecar lifecycle, and tests only; no provider-visible prompts, tool schemas, request serialization, or compaction changes.

Refs #6014 #5999 #6027 (Phase-1 groundwork for the write-protection convergence proposal).
