### PR TITLE
Take session leases in CLI, ACP, and serve / CLI、ACP、serve 写绑定会话时接入会话租约

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: test
         if: runner.os == 'Windows'
+        timeout-minutes: 10
         env:
           # Run the prompt-cache prefix-stability guard (TestCacheHit*) in CI: a
           # regression there silently tanks the cache hit rate the project is

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -168,6 +168,11 @@ type acpSession struct {
 	done    chan struct{}
 	running bool
 	deleted bool
+	// lease is the session lease guarding transcript against other runtimes
+	// (a desktop window, the CLI) for the life of this session. Held from
+	// session/new / session/load and released on close/delete/teardown; config
+	// rebuilds keep the same transcript, so the lease never moves.
+	lease *agent.SessionLease
 	// maintenanceDone is non-nil while session-owned maintenance, such as an
 	// idle config rebuild, is in flight outside mu.
 	maintenanceDone chan struct{}
@@ -271,6 +276,30 @@ func (s *acpSession) currentCtrl() acpController {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.ctrl
+}
+
+// releaseSessionLease drops the session's transcript lease, if any. Idempotent.
+func (s *acpSession) releaseSessionLease() {
+	s.mu.Lock()
+	lease := s.lease
+	s.lease = nil
+	s.mu.Unlock()
+	if lease != nil {
+		lease.Release()
+	}
+}
+
+// sessionLeaseBindError maps a lease-acquisition failure to the protocol
+// error the client sees: a held session names its holder with the shared CLI
+// wording; anything else is an internal error.
+func sessionLeaseBindError(method string, err error) *RPCError {
+	if errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return &RPCError{
+			Code:    ErrInvalidRequest,
+			Message: method + ": " + control.SessionInUseMessage(err) + "; " + control.SessionLeaseCloseHint,
+		}
+	}
+	return &RPCError{Code: ErrInternal, Message: method + ": session lease: " + err.Error()}
 }
 
 // initialize advertises the agent's capability set: persisted load plus ACP v1
@@ -379,9 +408,17 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	}
 	// Pin a transcript file keyed by session id when the controller has a session
 	// dir, so every turn auto-saves there, session/prompt can hand the path back,
-	// and session/load can find it again by id across process restarts.
+	// and session/load can find it again by id across process restarts. The
+	// session lease is taken with it (defensive: the id-keyed path is brand new)
+	// so no other runtime can bind the transcript while this session lives.
 	if dir := ctrl.SessionDir(); dir != "" {
 		sess.transcript = transcriptPath(dir, id)
+		lease, err := agent.TryAcquireSessionLease(sess.transcript)
+		if err != nil {
+			ctrl.Close()
+			return nil, sessionLeaseBindError("session/new", err)
+		}
+		sess.lease = lease
 		ctrl.SetSessionPath(sess.transcript)
 	}
 
@@ -507,8 +544,17 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		ctrl.Close()
 		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
 	}
+	// Bind the transcript for writing only if no other runtime (a desktop
+	// window, the CLI) holds it; the editor should not silently double-write a
+	// session that is open elsewhere.
+	lease, leaseErr := agent.TryAcquireSessionLease(path)
+	if leaseErr != nil {
+		ctrl.Close()
+		return SessionConfigState{}, sessionLeaseBindError(method, leaseErr)
+	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
+		lease.Release()
 		ctrl.Close()
 		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
 	}
@@ -529,8 +575,10 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		title:          meta.Title,
 		createdAt:      meta.CreatedAt,
 		updatedAt:      meta.UpdatedAt,
+		lease:          lease,
 	}
 	if err := saveACPMeta(path, sess.meta()); err != nil {
+		sess.releaseSessionLease()
 		ctrl.Close()
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
@@ -856,6 +904,7 @@ func (s *service) sessionClose(_ context.Context, raw json.RawMessage) (any, err
 	if sess := s.takeSession(p.SessionID); sess != nil {
 		sess.abortAndWait()
 		sess.ctrl.Close()
+		sess.releaseSessionLease()
 	}
 	return SessionCloseResult{}, nil
 }
@@ -928,6 +977,10 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 	var delayed bool
 	if sess := s.takeSession(p.SessionID); sess != nil {
 		sess.deleteAndWait()
+		// The session is going away; drop its lease before removing files so
+		// the lease sidecars retire with the release (they are not in
+		// SessionSidecarFiles and would otherwise linger).
+		sess.releaseSessionLease()
 		path = sess.transcript
 		destroy = sess.ctrl.BeginDestroySession(path)
 		if result := destroy.Wait(); result.HasTimedOut() {
@@ -1151,6 +1204,7 @@ func (s *service) closeAll() {
 	for _, sess := range sessions {
 		sess.abortAndWait()
 		sess.currentCtrl().Close()
+		sess.releaseSessionLease()
 	}
 }
 

--- a/internal/acp/service_lease_test.go
+++ b/internal/acp/service_lease_test.go
@@ -1,0 +1,93 @@
+package acp
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/permission"
+	"reasonix/internal/provider"
+)
+
+func leaseTestFactory(dir string) *e2eFactory {
+	return &e2eFactory{
+		prov: &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+			{{Type: provider.ChunkText, Text: "unused"}, {Type: provider.ChunkDone}},
+		}},
+		tool:       fakeTool{name: "peek", ro: true, out: "unused"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}
+}
+
+// TestSessionLoadRefusedWhenLeaseHeld proves session/load returns a protocol
+// error naming the holder when the transcript is owned by another runtime
+// (a desktop window or CLI writing the same session), and does not register
+// the session.
+func TestSessionLoadRefusedWhenLeaseHeld(t *testing.T) {
+	dir := t.TempDir()
+	const id = "sess-held-lease"
+	path := transcriptPath(dir, id)
+	s := agent.NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "editor session"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	holder, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("test holder acquire: %v", err)
+	}
+	defer holder.Release()
+
+	client, stop := startServer(t, leaseTestFactory(dir))
+	defer stop()
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+
+	resp := client.call(t, "session/load", SessionLoadParams{SessionID: id, Cwd: t.TempDir()})
+	if resp.Error == nil {
+		t.Fatalf("session/load of a held session succeeded, want protocol error")
+	}
+	if !strings.Contains(resp.Error.Message, "in use by another Reasonix") {
+		t.Fatalf("session/load error = %q, want holder wording", resp.Error.Message)
+	}
+	if strings.Contains(resp.Error.Message, path) {
+		t.Fatalf("session/load error leaks the session path: %q", resp.Error.Message)
+	}
+
+	// The refused load must not have bound the session: a prompt is unknown.
+	promptResp := client.call(t, "session/prompt", SessionPromptParams{
+		SessionID: id,
+		Prompt:    []ContentBlock{{Type: "text", Text: "should not run"}},
+	})
+	if promptResp.Error == nil {
+		t.Fatalf("session/prompt after refused load succeeded, want unknown session")
+	}
+}
+
+// TestSessionCloseReleasesLease proves the lease taken by session/new is
+// released by session/close, so another runtime can bind the transcript.
+func TestSessionCloseReleasesLease(t *testing.T) {
+	dir := t.TempDir()
+	client, stop := startServer(t, leaseTestFactory(dir))
+	defer stop()
+
+	sid := openSession(t, client)
+	path := transcriptPath(dir, sid)
+
+	// Held while the session is open.
+	if lease, err := agent.TryAcquireSessionLease(path); err == nil {
+		lease.Release()
+		t.Fatalf("transcript lease not held after session/new")
+	}
+
+	resp := client.call(t, "session/close", SessionCloseParams{SessionID: sid})
+	if resp.Error != nil {
+		t.Fatalf("session/close errored: %+v", resp.Error)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("transcript lease not released by session/close: %v", err)
+	}
+	lease.Release()
+}

--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -73,12 +73,14 @@ func (m *chatTUI) runBranchCommand(input string) {
 		if _, err := m.ctrl.ForkNamed(n-1, name); err != nil {
 			return
 		}
+		m.followSessionLease()
 		m.replayActiveBranch(fmt.Sprintf("branched from turn %d", n))
 		return
 	} else {
 		if _, err := m.ctrl.Branch(name); err != nil {
 			return
 		}
+		m.followSessionLease()
 	}
 	m.showBranchTree()
 }
@@ -89,7 +91,23 @@ func (m *chatTUI) runSwitchCommand(input string) {
 		m.notice("usage: /switch <branch id|name>")
 		return
 	}
+	// Move the session lease before the controller binds the target branch for
+	// writing; a branch held by another runtime is refused here. Resolution
+	// failures fall through to SwitchBranch, which reports them as before.
+	if m.leases != nil {
+		if branches, err := m.ctrl.Branches(); err == nil {
+			if match, err := control.ResolveBranchRef(branches, ref); err == nil {
+				if err := m.rebindSessionLease(match.Path); err != nil {
+					m.notice("switch: " + sessionLeaseHeldNotice(err))
+					return
+				}
+			}
+		}
+	}
 	if _, err := m.ctrl.SwitchBranch(ref); err != nil {
+		// The switch failed after the lease already moved; re-point it at the
+		// session the controller still owns.
+		m.restoreSessionLease()
 		return
 	}
 	m.replayActiveBranch("switched branch")

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -289,6 +289,12 @@ type chatTUI struct {
 	modelRef        string
 	effortLevel     string // "" when the current provider/model has no configurable effort
 
+	// leases owns the session lease guarding the TUI's active session file (set
+	// by chatREPL; nil in tests and when persistence is disabled). Every in-TUI
+	// operation that rebinds the controller to another session file must move
+	// the lease first — see rebindSessionLease / followSessionLease.
+	leases *control.SessionLeaseKeeper
+
 	// outputStyle is the active output-style name (config agent.output_style),
 	// shown as the current entry in the /output-style listing. "" = default.
 	outputStyle string
@@ -3435,6 +3441,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashNewFailed, err))
 			return nil
 		}
+		m.followSessionLease()
 		// Native scrollback keeps the old transcript; mark the fork with a fresh banner.
 		m.resetFreshContextView(false)
 		m.notice(i18n.M.SlashNewDone)

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -40,6 +40,7 @@ func (m chatTUI) confirmClearContext() (tea.Model, tea.Cmd) {
 		m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashClearFailed, err))
 		return m, nil
 	}
+	m.followSessionLease()
 	m.resetFreshContextView(true)
 	m.notice(i18n.M.SlashClearDone)
 	return m, tea.ClearScreen

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -140,7 +140,7 @@ func Run(args []string, version string) int {
 
 func isDefaultInteractiveFlag(arg string) bool {
 	switch arg {
-	case "--model", "--max-steps", "--continue", "-c", "--resume", "--dangerously-skip-permissions", "--yolo", "--dir":
+	case "--model", "--max-steps", "--continue", "-c", "--resume", "--copy", "--dangerously-skip-permissions", "--yolo", "--dir":
 		return true
 	}
 	if name, _, ok := strings.Cut(arg, "="); ok && isDefaultInteractiveFlag(name) {
@@ -298,6 +298,7 @@ func runAgent(args []string) int {
 	cont := fs.Bool("continue", false, "resume the most recent saved session")
 	fs.BoolVar(cont, "c", false, "shorthand for --continue")
 	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
+	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -316,12 +317,51 @@ func runAgent(args []string) int {
 		return 2
 	}
 
-	var resumeSession *agent.Session
-	if *resume != "" {
-		var err error
-		resumeSession, err = loadResumableSession(*resume)
+	// Resolve the resume target up front so --copy and the session lease can be
+	// handled before any heavy assembly. --resume takes precedence over
+	// --continue, matching the Resume call below.
+	resumePath := strings.TrimSpace(*resume)
+	if resumePath == "" && *cont {
+		sessions, err := agent.ListSessions(resolveCLISessionDir())
+		if err != nil || len(sessions) == 0 {
+			fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
+			return 1
+		}
+		resumePath = sessions[0].Path
+	}
+	if *copySession && resumePath == "" {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "--copy requires --resume or --continue")
+		return 2
+	}
+	if *copySession {
+		copied, err := copySessionForWriting(resumePath)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		fmt.Printf("continuing in a session copy: %s\n", copied)
+		resumePath = copied
+	}
+
+	// Own the session file for the lifetime of this run so a desktop window (or
+	// another CLI) writing the same session is refused up front instead of
+	// silently double-writing. Released after the controller closes.
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	var resumeSession *agent.Session
+	if resumePath != "" {
+		var err error
+		resumeSession, err = loadResumableSession(resumePath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		if err := leases.Rebind(resumePath); err != nil {
+			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, sessionLeaseResumeRefusal(err))
+			} else {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			}
 			return 1
 		}
 	}
@@ -349,12 +389,8 @@ func runAgent(args []string) int {
 		sink = metrics
 	}
 	sink = withNotifications(sink, cfg)
-	if *resume != "" {
-		*model = modelForResumePath(*model, *resume, cfg)
-	} else if *cont {
-		if sessions, err := agent.ListSessions(resolveCLISessionDir()); err == nil && len(sessions) > 0 {
-			*model = modelForResumePath(*model, sessions[0].Path, cfg)
-		}
+	if resumePath != "" {
+		*model = modelForResumePath(*model, resumePath, cfg)
 	}
 	ctrl, err := setup(ctx, *model, *maxSteps, true, sink)
 	if err != nil {
@@ -367,23 +403,17 @@ func runAgent(args []string) int {
 	// MCP/API callers that manage their own per-project session). Takes
 	// precedence over --continue.
 	// --continue: resume the most recent saved session.
-	if *resume != "" {
-		ctrl.Resume(resumeSession, *resume)
-	} else if *cont {
-		sessions, err := agent.ListSessions(ctrl.SessionDir())
-		if err != nil || len(sessions) == 0 {
-			fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
-			return 1
-		}
-		loaded, err := agent.LoadSession(sessions[0].Path)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
-		ctrl.Resume(loaded, sessions[0].Path)
+	if resumePath != "" {
+		ctrl.Resume(resumeSession, resumePath)
 	}
 	if ctrl.SessionPath() == "" && ctrl.SessionDir() != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
+	}
+	// Fresh sessions take the lease too (defensive: the path is brand new); a
+	// resumed path is already held, making this a no-op.
+	if err := leases.Rebind(ctrl.SessionPath()); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
+		return 1
 	}
 
 	runErr := ctrl.Run(ctx, prompt)
@@ -472,12 +502,25 @@ func runServe(args []string) int {
 		return 1
 	}
 
+	// Own the active session file for the server's lifetime; the serve
+	// handlers that rebind sessions (/resume, /new, /fork) move the lease
+	// through the same keeper. Released after the controller closes.
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
 	var resumeSession *agent.Session
 	if *resume != "" {
 		var err error
 		resumeSession, err = loadResumableSession(*resume)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		if err := leases.Rebind(*resume); err != nil {
+			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
+			} else {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			}
 			return 1
 		}
 	}
@@ -504,8 +547,15 @@ func runServe(args []string) int {
 		ctrl.Resume(resumeSession, *resume)
 	}
 	ctrl.EnsureSessionPath()
+	// Fresh sessions take the lease too (defensive: the path is brand new); a
+	// resumed path is already held, making this a no-op.
+	if err := leases.Rebind(ctrl.SessionPath()); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
+		return 1
+	}
 
 	srv := serve.New(ctrl, bc, serveCfg)
+	srv.SetSessionLeases(leases)
 	fmt.Printf("reasonix serve — %s on http://%s\n", ctrl.Label(), *addr)
 	if srv.AuthMode() == "token" {
 		fmt.Printf("  auth: token\n")
@@ -545,6 +595,7 @@ func chatREPL(args []string) int {
 	cont := fs.Bool("continue", false, "resume the most recent saved session")
 	fs.BoolVar(cont, "c", false, "shorthand for --continue")
 	resume := fs.Bool("resume", false, "list saved sessions and pick one to resume")
+	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the selected session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	yolo := fs.Bool("dangerously-skip-permissions", false, "YOLO: auto-approve approval-gated tool calls this session; same runtime mode as Ctrl+Y")
 	fs.BoolVar(yolo, "yolo", false, "alias for --dangerously-skip-permissions")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
@@ -577,6 +628,36 @@ func chatREPL(args []string) int {
 			return 1
 		}
 		resumePath = sessions[0].Path
+	}
+	if *copySession && resumePath == "" {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "--copy requires --resume or --continue")
+		return 2
+	}
+	if *copySession {
+		copied, err := copySessionForWriting(resumePath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		fmt.Printf("continuing in a session copy: %s\n", copied)
+		resumePath = copied
+	}
+
+	// Own the active session file for the TUI's lifetime; in-TUI switches
+	// (/resume, /switch, /new, ...) move the lease with the active path.
+	// Refusing a held resume target up front is what keeps a desktop window
+	// and this chat from silently double-writing one transcript.
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if resumePath != "" {
+		if err := leases.Rebind(resumePath); err != nil {
+			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, sessionLeaseResumeRefusal(err))
+			} else {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			}
+			return 1
+		}
 	}
 
 	ctx := context.Background()
@@ -618,6 +699,12 @@ func chatREPL(args []string) int {
 		ctrl.Resume(loaded, resumePath)
 	}
 	ctrl.EnsureSessionPath()
+	// Fresh sessions take the lease too (defensive: the path is brand new); a
+	// resumed path is already held, making this a no-op.
+	if err := leases.Rebind(ctrl.SessionPath()); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
+		return 1
+	}
 
 	// Surface a missing-key warning inside the TUI banner so the first message
 	// failing is at least pre-announced; the user can still enter chat.
@@ -650,6 +737,7 @@ func chatREPL(args []string) int {
 	}
 
 	m := newChatTUI(ctrl, missing, eventCh, termW)
+	m.leases = leases
 	if cfg, err := config.Load(); err == nil {
 		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -350,18 +350,18 @@ func runAgent(args []string) int {
 	defer leases.Release()
 	var resumeSession *agent.Session
 	if resumePath != "" {
-		var err error
-		resumeSession, err = loadResumableSession(resumePath)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
 		if err := leases.Rebind(resumePath); err != nil {
 			if errors.Is(err, agent.ErrSessionLeaseHeld) {
 				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, sessionLeaseResumeRefusal(err))
 			} else {
 				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			}
+			return 1
+		}
+		var err error
+		resumeSession, err = loadResumableSession(resumePath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			return 1
 		}
 	}
@@ -509,18 +509,18 @@ func runServe(args []string) int {
 	defer leases.Release()
 	var resumeSession *agent.Session
 	if *resume != "" {
-		var err error
-		resumeSession, err = loadResumableSession(*resume)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
 		if err := leases.Rebind(*resume); err != nil {
 			if errors.Is(err, agent.ErrSessionLeaseHeld) {
 				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
 			} else {
 				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			}
+			return 1
+		}
+		var err error
+		resumeSession, err = loadResumableSession(*resume)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			return 1
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -266,7 +266,7 @@ func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 	if !strings.Contains(out, "Usage:") && !strings.Contains(out, "用法：") {
 		t.Fatalf("help output missing usage:\n%s", out)
 	}
-	if !strings.Contains(out, "reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>") {
+	if !strings.Contains(out, "reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] <task>") {
 		t.Fatalf("help output missing run resume flags:\n%s", out)
 	}
 }

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -65,7 +65,13 @@ func (m *chatTUI) runResumeCommand(input string) {
 		return
 	}
 	// Persist the conversation we're leaving so switching back later restores it.
+	// Snapshot before moving the lease: the outgoing session must be written
+	// while this process still owns it.
 	_ = m.ctrl.Snapshot()
+	if err := m.rebindSessionLease(target.Path); err != nil {
+		m.notice("resume: " + sessionLeaseHeldNotice(err))
+		return
+	}
 	m.ctrl.Resume(loaded, target.Path)
 	m.replayActiveBranch(i18n.M.ResumedTitle)
 }

--- a/internal/cli/resume_picker.go
+++ b/internal/cli/resume_picker.go
@@ -87,7 +87,13 @@ func (m chatTUI) applyResumePick() (tea.Model, tea.Cmd) {
 		m.notice("resume: " + err.Error())
 		return m, nil
 	}
+	// Snapshot before moving the lease: the outgoing session must be written
+	// while this process still owns it.
 	_ = m.ctrl.Snapshot()
+	if err := m.rebindSessionLease(target.Path); err != nil {
+		m.notice("resume: " + sessionLeaseHeldNotice(err))
+		return m, nil
+	}
 	m.ctrl.Resume(loaded, target.Path)
 	m.replayActiveBranch(i18n.M.ResumedTitle)
 	return m, nil

--- a/internal/cli/rewind.go
+++ b/internal/cli/rewind.go
@@ -122,6 +122,7 @@ func (m chatTUI) applyRewind() (tea.Model, tea.Cmd) {
 	switch act.kind {
 	case "fork":
 		if _, err := m.ctrl.Fork(meta.Turn); err == nil {
+			m.followSessionLease()
 			m.replayActiveBranch(fmt.Sprintf("branched from turn %d", meta.Turn+1))
 		}
 		return m, nil // the branch is a new session

--- a/internal/cli/session_lease.go
+++ b/internal/cli/session_lease.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+)
+
+// sessionLeaseResumeRefusal is the startup-time refusal for `reasonix
+// [--resume|--continue]` and `reasonix run --resume/--continue`: it names the
+// holder and offers the two ways out (close the holder, or continue in a
+// duplicated session via --copy).
+func sessionLeaseResumeRefusal(err error) string {
+	return control.SessionInUseMessage(err) +
+		"; close the other Reasonix window or process, or rerun with --copy to continue in a duplicated session"
+}
+
+// sessionLeaseHeldNotice is the in-TUI refusal for /resume and /switch, where
+// exiting to rerun with --copy is not the natural move.
+func sessionLeaseHeldNotice(err error) string {
+	return control.SessionInUseMessage(err) + "; " + control.SessionLeaseCloseHint
+}
+
+// rebindSessionLease moves the chat TUI's session lease to path before the
+// controller binds it for writing. A nil keeper (tests, persistence disabled)
+// gates nothing. On error the keeper still guards the previous session.
+func (m *chatTUI) rebindSessionLease(path string) error {
+	if m.leases == nil {
+		return nil
+	}
+	return m.leases.Rebind(path)
+}
+
+// restoreSessionLease re-points the lease at the controller's current session
+// after a switch attempt moved it but the switch itself then failed.
+// Best-effort: the old lease was released during the rebind, so in the
+// (unlikely) case another runtime grabbed it in between this stays silent and
+// the next write surfaces the conflict.
+func (m *chatTUI) restoreSessionLease() {
+	if m.leases == nil {
+		return
+	}
+	_ = m.leases.Rebind(m.ctrl.SessionPath())
+}
+
+// followSessionLease re-points the TUI's session lease at the controller's
+// current session file after an operation that rotated it to a fresh path
+// (/new, /clear, /branch, fork). A fresh path cannot be held by anyone else,
+// so failure is theoretical — but never silent.
+func (m *chatTUI) followSessionLease() {
+	if m.leases == nil {
+		return
+	}
+	if err := m.leases.Rebind(m.ctrl.SessionPath()); err != nil {
+		m.notice(sessionLeaseHeldNotice(err))
+	}
+}
+
+// copySessionForWriting duplicates the session at src into a fresh session
+// file beside it and returns the new path. It backs the --copy escape hatch:
+// when src is held by another runtime, the copy gives this process a session
+// it can own. The duplicate is written through Session.Save, so it is
+// event-log aware (authoritative event log plus .jsonl checkpoint) and starts
+// with no lease/lock sidecars of its own; src is only read. When src is being
+// written concurrently, the copy captures the transcript as of the load — an
+// append-only prefix, the same view a resume would see.
+func copySessionForWriting(src string) (string, error) {
+	loaded, err := loadResumableSession(src)
+	if err != nil {
+		return "", err
+	}
+	msgs := loaded.Snapshot()
+
+	var srcMeta agent.BranchMeta
+	if meta, ok, metaErr := agent.LoadBranchMeta(src); metaErr == nil && ok {
+		srcMeta = meta
+	}
+	label := "session"
+	if model, ok := agent.LoadSessionModel(src); ok && strings.TrimSpace(model) != "" {
+		label = model
+	}
+
+	newPath := agent.NewSessionPath(filepath.Dir(src), label)
+	copySess := agent.NewSession("")
+	copySess.Messages = msgs
+	if err := copySess.Save(newPath); err != nil {
+		return "", fmt.Errorf("copy session: %w", err)
+	}
+	preview, turns := agent.SessionPreviewFromMessages(msgs)
+	meta := agent.BranchMeta{
+		ParentID:         agent.BranchID(src),
+		ForkTurn:         -1,
+		ForkMessageIndex: len(msgs),
+		Preview:          preview,
+		Turns:            turns,
+		SchemaVersion:    agent.BranchMetaCountsVersion,
+		Model:            srcMeta.Model,
+	}
+	if title := strings.TrimSpace(firstNonEmpty(srcMeta.CustomTitle, srcMeta.TopicTitle)); title != "" {
+		meta.CustomTitle = title + " (copy)"
+	}
+	if err := agent.SaveBranchMeta(newPath, meta); err != nil {
+		return "", fmt.Errorf("copy session meta: %w", err)
+	}
+	return newPath, nil
+}

--- a/internal/cli/session_lease_test.go
+++ b/internal/cli/session_lease_test.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/store"
+)
+
+// holdSessionLease simulates another runtime owning path for the duration of
+// the test (the in-process lease registry plus the OS lock behave exactly as a
+// foreign holder for acquisition purposes).
+func holdSessionLease(t *testing.T, path string) *agent.SessionLease {
+	t.Helper()
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("test holder acquire: %v", err)
+	}
+	t.Cleanup(lease.Release)
+	return lease
+}
+
+func TestRunResumeRefusedWhenSessionLeaseHeld(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	path := filepath.Join(t.TempDir(), "held-run.jsonl")
+	saveTestSession(t, path, "held prompt")
+	holdSessionLease(t, path)
+
+	errOut := captureStderr(t, func() {
+		if rc := runAgent([]string{"--resume", path, "continue task"}); rc != 1 {
+			t.Fatalf("run --resume held rc = %d, want 1", rc)
+		}
+	})
+	if !strings.Contains(errOut, "in use by another Reasonix") {
+		t.Fatalf("run --resume held stderr = %q, want holder wording", errOut)
+	}
+	if !strings.Contains(errOut, "--copy") {
+		t.Fatalf("run --resume held stderr = %q, want --copy guidance", errOut)
+	}
+	if strings.Contains(errOut, path) {
+		t.Fatalf("run --resume held stderr leaks the session path: %q", errOut)
+	}
+}
+
+func TestRunCopyRequiresResumeTarget(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	errOut := captureStderr(t, func() {
+		if rc := runAgent([]string{"--copy", "do things"}); rc != 2 {
+			t.Fatalf("run --copy without target rc = %d, want 2", rc)
+		}
+	})
+	if !strings.Contains(errOut, "--copy requires --resume or --continue") {
+		t.Fatalf("run --copy stderr = %q, want usage error", errOut)
+	}
+}
+
+func TestRunResumeCopyContinuesInDuplicate(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "held-src.jsonl")
+	saveTestSession(t, src, "copy me")
+	srcBytes, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	holdSessionLease(t, src)
+
+	var rc int
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			rc = runAgent([]string{"--resume", src, "--copy", "continue task"})
+		})
+	})
+	// The isolated home has no provider config, so the run itself fails after
+	// the copy — but never with the lease refusal, and never touching src.
+	if rc != 1 {
+		t.Fatalf("run --resume --copy rc = %d, want 1 (setup fails in isolated home)", rc)
+	}
+	if !strings.Contains(out, "continuing in a session copy: ") {
+		t.Fatalf("stdout = %q, want session copy line", out)
+	}
+	copyPath := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(out), "continuing in a session copy:"))
+	if copyPath == "" || copyPath == src {
+		t.Fatalf("copy path = %q, want a fresh path", copyPath)
+	}
+
+	srcAfter, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(srcAfter) != string(srcBytes) {
+		t.Fatalf("source transcript was modified by --copy")
+	}
+	srcLoaded, err := agent.LoadSession(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	copyLoaded, err := agent.LoadSession(copyPath)
+	if err != nil {
+		t.Fatalf("load copy: %v", err)
+	}
+	srcMsgs, copyMsgs := srcLoaded.Snapshot(), copyLoaded.Snapshot()
+	if len(copyMsgs) != len(srcMsgs) {
+		t.Fatalf("copy has %d messages, source %d", len(copyMsgs), len(srcMsgs))
+	}
+	for i := range srcMsgs {
+		if copyMsgs[i].Role != srcMsgs[i].Role || copyMsgs[i].Content != srcMsgs[i].Content {
+			t.Fatalf("copy message %d = %+v, want %+v", i, copyMsgs[i], srcMsgs[i])
+		}
+	}
+	// The run exited: the copy's lease must be released again.
+	if _, err := os.Stat(store.SessionLeaseInfo(agent.CanonicalSessionPath(copyPath))); !os.IsNotExist(err) {
+		t.Fatalf("copy lease info after exit stat err = %v, want not exist", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(copyPath)
+	if err != nil {
+		t.Fatalf("copy lease not released after run: %v", err)
+	}
+	lease.Release()
+}
+
+func TestRunResumeReleasesLeaseOnExit(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	path := filepath.Join(t.TempDir(), "release-run.jsonl")
+	saveTestSession(t, path, "resume me")
+
+	// No provider config in the isolated home: the run fails after the lease
+	// was taken, and the deferred release must still run.
+	_ = captureStderr(t, func() {
+		if rc := runAgent([]string{"--resume", path, "continue task"}); rc != 1 {
+			t.Fatalf("run --resume rc = %d, want 1 (setup fails in isolated home)", rc)
+		}
+	})
+	if _, err := os.Stat(store.SessionLeaseInfo(agent.CanonicalSessionPath(path))); !os.IsNotExist(err) {
+		t.Fatalf("lease info after run exit stat err = %v, want not exist", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("lease not released after run exit: %v", err)
+	}
+	lease.Release()
+}
+
+func TestCopySessionForWritingDuplicatesTranscript(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.jsonl")
+	s := agent.NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "question"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "answer"})
+	if err := s.Save(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(src, agent.BranchMeta{
+		CustomTitle:   "My debugging session",
+		Model:         "deepseek/deepseek-chat",
+		SchemaVersion: agent.BranchMetaCountsVersion,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srcBytes, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copyPath, err := copySessionForWriting(src)
+	if err != nil {
+		t.Fatalf("copySessionForWriting: %v", err)
+	}
+	if filepath.Dir(copyPath) != dir {
+		t.Fatalf("copy landed in %q, want beside the source in %q", filepath.Dir(copyPath), dir)
+	}
+
+	loaded, err := agent.LoadSession(copyPath)
+	if err != nil {
+		t.Fatalf("load copy: %v", err)
+	}
+	got := loaded.Snapshot()
+	want := s.Snapshot()
+	if len(got) != len(want) {
+		t.Fatalf("copy has %d messages, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Role != want[i].Role || got[i].Content != want[i].Content {
+			t.Fatalf("copy message %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(copyPath)
+	if err != nil || !ok {
+		t.Fatalf("copy branch meta: ok=%v err=%v", ok, err)
+	}
+	if meta.ParentID != agent.BranchID(src) {
+		t.Fatalf("copy ParentID = %q, want %q", meta.ParentID, agent.BranchID(src))
+	}
+	if meta.CustomTitle != "My debugging session (copy)" {
+		t.Fatalf("copy CustomTitle = %q", meta.CustomTitle)
+	}
+	if meta.Model != "deepseek/deepseek-chat" {
+		t.Fatalf("copy Model = %q", meta.Model)
+	}
+
+	// The copy starts unowned and without lease/lock sidecars of its own.
+	for _, sidecar := range []string{
+		store.SessionLeaseInfo(agent.CanonicalSessionPath(copyPath)),
+		store.SessionLeaseLock(agent.CanonicalSessionPath(copyPath)),
+	} {
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Fatalf("copy has lease sidecar %s (err=%v)", sidecar, err)
+		}
+	}
+	// The source transcript is only read.
+	srcAfter, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(srcAfter) != string(srcBytes) {
+		t.Fatalf("source transcript was modified by the copy")
+	}
+}
+
+// chatLeaseFixture builds a TUI over a temp session dir with two saved
+// sessions: older (the active one) and newer (the /resume 1 target).
+func chatLeaseFixture(t *testing.T) (m chatTUI, active, target string) {
+	t.Helper()
+	dir := t.TempDir()
+	active = filepath.Join(dir, "a-active.jsonl")
+	target = filepath.Join(dir, "b-target.jsonl")
+	saveTestSession(t, active, "active session")
+	saveTestSession(t, target, "target session")
+	pinNewer(t, active, target)
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	m = newTestChatTUI()
+	m.width = 80
+	m.ctrl = control.New(control.Options{Executor: exec, SessionDir: dir, SessionPath: active, Label: "test"})
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	return m, active, target
+}
+
+// pinNewer gives newer a strictly later mtime than older so ListSessions
+// ordering is deterministic across filesystems with coarse mtimes.
+func pinNewer(t *testing.T, older, newer string) {
+	t.Helper()
+	info, err := os.Stat(newer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := info.ModTime().Add(-2 * time.Second)
+	if err := os.Chtimes(older, old, old); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChatResumeCommandRefusedWhenLeaseHeld(t *testing.T) {
+	m, active, target := chatLeaseFixture(t)
+	holdSessionLease(t, target)
+
+	m.runResumeCommand("/resume 1")
+
+	out := strings.Join(m.transcript, "\n")
+	if !strings.Contains(out, "in use by another Reasonix") {
+		t.Fatalf("refusal notice missing from transcript:\n%s", out)
+	}
+	if got := m.ctrl.SessionPath(); got != active {
+		t.Fatalf("session path after refused /resume = %q, want %q", got, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(active); got != want {
+		t.Fatalf("lease after refused /resume = %q, want %q", got, want)
+	}
+}
+
+func TestChatResumeCommandMovesLease(t *testing.T) {
+	m, active, target := chatLeaseFixture(t)
+
+	m.runResumeCommand("/resume 1")
+
+	if got := m.ctrl.SessionPath(); got != target {
+		t.Fatalf("session path after /resume = %q, want %q", got, target)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(target); got != want {
+		t.Fatalf("lease after /resume = %q, want %q", got, want)
+	}
+	// The lease on the session we left must be free again.
+	lease, err := agent.TryAcquireSessionLease(active)
+	if err != nil {
+		t.Fatalf("old session lease not released by /resume: %v", err)
+	}
+	lease.Release()
+}
+
+func TestChatNewSessionTakesFreshLease(t *testing.T) {
+	m, active, _ := chatLeaseFixture(t)
+
+	if cmd := m.runSlashCommand("/new"); cmd != nil {
+		t.Fatal("/new should not return a tea.Cmd")
+	}
+
+	fresh := m.ctrl.SessionPath()
+	if fresh == active {
+		t.Fatalf("/new did not rotate the session path")
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(fresh); got != want {
+		t.Fatalf("lease after /new = %q, want %q", got, want)
+	}
+	lease, err := agent.TryAcquireSessionLease(active)
+	if err != nil {
+		t.Fatalf("old session lease not released by /new: %v", err)
+	}
+	lease.Release()
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2457,6 +2457,14 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	return match, nil
 }
 
+// ResolveBranchRef resolves a /switch-style branch reference (id, unique
+// prefix, name, or path) against a branch listing, using the same matching
+// rules as SwitchBranch. Frontends use it to learn the target session path
+// before switching — e.g. to move their session lease first.
+func ResolveBranchRef(branches []agent.BranchInfo, ref string) (agent.BranchInfo, error) {
+	return resolveBranch(branches, strings.TrimSpace(ref))
+}
+
 func resolveBranch(branches []agent.BranchInfo, ref string) (agent.BranchInfo, error) {
 	refLower := strings.ToLower(ref)
 	var matches []agent.BranchInfo

--- a/internal/control/session_lease_keeper.go
+++ b/internal/control/session_lease_keeper.go
@@ -1,0 +1,116 @@
+package control
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"reasonix/internal/agent"
+)
+
+// SessionLeaseKeeper owns at most one session lease on behalf of a frontend
+// that binds session files for writing (the CLI chat/run commands, `reasonix
+// serve`, one ACP session). Desktop tabs keep their own per-tab lease
+// management; this keeper is the equivalent for the single-session surfaces:
+// it follows the active session path across resumes, forks, and fresh-session
+// rotations, holding exactly one lease at a time.
+//
+// The zero value is not ready for use; construct with NewSessionLeaseKeeper.
+type SessionLeaseKeeper struct {
+	mu    sync.Mutex
+	lease *agent.SessionLease
+}
+
+func NewSessionLeaseKeeper() *SessionLeaseKeeper {
+	return &SessionLeaseKeeper{}
+}
+
+// Rebind points the keeper at path: it acquires path's session lease and only
+// then releases the previously held one, so the outgoing session stays
+// protected until the new one is secured. Rebinding to the path already held
+// is a no-op; an empty path (session persistence disabled) just releases.
+// On failure the keeper is unchanged — the caller still holds its previous
+// lease and must not bind path for writing. A held path surfaces as an error
+// wrapping agent.ErrSessionLeaseHeld; format it with SessionInUseMessage.
+func (k *SessionLeaseKeeper) Rebind(path string) error {
+	if k == nil {
+		return nil
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if strings.TrimSpace(path) == "" {
+		k.releaseLocked()
+		return nil
+	}
+	if k.lease != nil && k.lease.Path() == agent.CanonicalSessionPath(path) {
+		return nil
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		return err
+	}
+	k.releaseLocked()
+	k.lease = lease
+	return nil
+}
+
+// Release drops the held lease, if any. Idempotent; call it on frontend
+// teardown after the controller has finished its final writes.
+func (k *SessionLeaseKeeper) Release() {
+	if k == nil {
+		return
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.releaseLocked()
+}
+
+// HeldPath reports the canonical session path the keeper currently guards,
+// or "" when it holds nothing.
+func (k *SessionLeaseKeeper) HeldPath() string {
+	if k == nil {
+		return ""
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.lease == nil {
+		return ""
+	}
+	return k.lease.Path()
+}
+
+func (k *SessionLeaseKeeper) releaseLocked() {
+	if k.lease != nil {
+		k.lease.Release()
+		k.lease = nil
+	}
+}
+
+// SessionLeaseCloseHint is the universal way out of a lease refusal, appended
+// by surfaces that have no copy escape hatch (in-TUI switches, serve, ACP).
+const SessionLeaseCloseHint = "close the other Reasonix window or process first"
+
+// SessionInUseMessage renders a lease-acquisition failure as the shared
+// operator-facing "who is holding this" line used by the CLI, serve, and ACP.
+// It names the holder from the lease info when available and degrades to a
+// generic line otherwise. The session file path is deliberately omitted — the
+// caller already knows which session it asked for.
+func SessionInUseMessage(err error) string {
+	const fallback = "this session is in use by another Reasonix window or process"
+	var leaseErr *agent.SessionLeaseError
+	if !errors.As(err, &leaseErr) || leaseErr == nil || leaseErr.Info == nil || leaseErr.Info.PID <= 0 {
+		return fallback
+	}
+	info := leaseErr.Info
+	var b strings.Builder
+	fmt.Fprintf(&b, "this session is in use by another Reasonix process (pid %d", info.PID)
+	if host := strings.TrimSpace(info.Hostname); host != "" {
+		b.WriteString(" on " + host)
+	}
+	if !info.AcquiredAt.IsZero() {
+		b.WriteString(", since " + info.AcquiredAt.Local().Format("15:04"))
+	}
+	b.WriteString(")")
+	return b.String()
+}

--- a/internal/control/session_lease_keeper_test.go
+++ b/internal/control/session_lease_keeper_test.go
@@ -1,0 +1,183 @@
+package control
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/store"
+)
+
+func TestSessionLeaseKeeperRebindMovesLease(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.jsonl")
+	b := filepath.Join(dir, "b.jsonl")
+
+	k := NewSessionLeaseKeeper()
+	defer k.Release()
+
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a): %v", err)
+	}
+	if got, want := k.HeldPath(), agent.CanonicalSessionPath(a); got != want {
+		t.Fatalf("HeldPath = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(store.SessionLeaseInfo(agent.CanonicalSessionPath(a))); err != nil {
+		t.Fatalf("lease info for a missing: %v", err)
+	}
+	// a is held: an outside acquire must fail.
+	if _, err := agent.TryAcquireSessionLease(a); !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("TryAcquireSessionLease(a) while kept = %v, want ErrSessionLeaseHeld", err)
+	}
+
+	if err := k.Rebind(b); err != nil {
+		t.Fatalf("Rebind(b): %v", err)
+	}
+	if got, want := k.HeldPath(), agent.CanonicalSessionPath(b); got != want {
+		t.Fatalf("HeldPath after rebind = %q, want %q", got, want)
+	}
+	// The old lease is released: a is acquirable again and its info is gone.
+	if _, err := os.Stat(store.SessionLeaseInfo(agent.CanonicalSessionPath(a))); !os.IsNotExist(err) {
+		t.Fatalf("lease info for a after rebind stat err = %v, want not exist", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(a)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease(a) after rebind: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseKeeperRebindSamePathIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.jsonl")
+
+	k := NewSessionLeaseKeeper()
+	defer k.Release()
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a): %v", err)
+	}
+	// Same canonical path again must not trip over the keeper's own lease.
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a) again: %v", err)
+	}
+	if got, want := k.HeldPath(), agent.CanonicalSessionPath(a); got != want {
+		t.Fatalf("HeldPath = %q, want %q", got, want)
+	}
+}
+
+func TestSessionLeaseKeeperRefusesHeldPathAndKeepsCurrent(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.jsonl")
+	b := filepath.Join(dir, "b.jsonl")
+
+	holder, err := agent.TryAcquireSessionLease(b)
+	if err != nil {
+		t.Fatalf("holder acquire: %v", err)
+	}
+	defer holder.Release()
+
+	k := NewSessionLeaseKeeper()
+	defer k.Release()
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a): %v", err)
+	}
+	err = k.Rebind(b)
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("Rebind(held b) = %v, want ErrSessionLeaseHeld", err)
+	}
+	// Failure leaves the keeper on its previous session.
+	if got, want := k.HeldPath(), agent.CanonicalSessionPath(a); got != want {
+		t.Fatalf("HeldPath after refused rebind = %q, want %q", got, want)
+	}
+}
+
+func TestSessionLeaseKeeperEmptyPathReleases(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.jsonl")
+
+	k := NewSessionLeaseKeeper()
+	defer k.Release()
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a): %v", err)
+	}
+	if err := k.Rebind(""); err != nil {
+		t.Fatalf("Rebind(empty): %v", err)
+	}
+	if got := k.HeldPath(); got != "" {
+		t.Fatalf("HeldPath after empty rebind = %q, want empty", got)
+	}
+	lease, err := agent.TryAcquireSessionLease(a)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease(a) after empty rebind: %v", err)
+	}
+	lease.Release()
+}
+
+func TestSessionLeaseKeeperReleaseRemovesLeaseInfo(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.jsonl")
+
+	k := NewSessionLeaseKeeper()
+	if err := k.Rebind(a); err != nil {
+		t.Fatalf("Rebind(a): %v", err)
+	}
+	k.Release()
+	k.Release() // idempotent
+	if _, err := os.Stat(store.SessionLeaseInfo(agent.CanonicalSessionPath(a))); !os.IsNotExist(err) {
+		t.Fatalf("lease info after Release stat err = %v, want not exist", err)
+	}
+	if got := k.HeldPath(); got != "" {
+		t.Fatalf("HeldPath after Release = %q, want empty", got)
+	}
+}
+
+func TestSessionInUseMessageNamesHolder(t *testing.T) {
+	acquired := time.Date(2026, 7, 6, 3, 4, 0, 0, time.UTC)
+	err := &agent.SessionLeaseError{
+		Path: "/tmp/x.jsonl",
+		Info: &agent.SessionLeaseInfo{
+			SessionPath: "/tmp/x.jsonl",
+			WriterID:    "writer-nonce-should-not-appear",
+			PID:         12345,
+			Hostname:    "devbox",
+			AcquiredAt:  acquired,
+		},
+	}
+	msg := SessionInUseMessage(err)
+	if !strings.Contains(msg, "another Reasonix process") {
+		t.Fatalf("message %q missing holder wording", msg)
+	}
+	if !strings.Contains(msg, "pid 12345") || !strings.Contains(msg, "on devbox") {
+		t.Fatalf("message %q missing pid/host", msg)
+	}
+	if !strings.Contains(msg, "since "+acquired.Local().Format("15:04")) {
+		t.Fatalf("message %q missing local acquire time", msg)
+	}
+	if strings.Contains(msg, "writer-nonce-should-not-appear") {
+		t.Fatalf("message %q leaks the writer id", msg)
+	}
+	if strings.Contains(msg, "/tmp/x.jsonl") {
+		t.Fatalf("message %q leaks the session path", msg)
+	}
+}
+
+func TestSessionInUseMessageFallsBackWithoutInfo(t *testing.T) {
+	for name, err := range map[string]error{
+		"nil info":   &agent.SessionLeaseError{Path: "/tmp/x.jsonl"},
+		"plain held": agent.ErrSessionLeaseHeld,
+		"zero pid":   &agent.SessionLeaseError{Info: &agent.SessionLeaseInfo{PID: 0}},
+	} {
+		msg := SessionInUseMessage(err)
+		if msg != "this session is in use by another Reasonix window or process" {
+			t.Fatalf("%s: message = %q, want generic fallback", name, msg)
+		}
+		if strings.Contains(msg, "pid "+strconv.Itoa(os.Getpid())) {
+			t.Fatalf("%s: fallback should not invent a pid: %q", name, msg)
+		}
+	}
+}

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -391,8 +391,8 @@ var English = Messages{
 	UsageBody: `reasonix — a config- and plugin-driven coding agent (multi-model)
 
 Usage:
-  reasonix [--model NAME] [-c|--continue] [--resume] [--yolo] [--dir PATH]   interactive session (multi-turn; -c resumes the latest, --resume picks one)
-  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>   run one task and exit
+  reasonix [--model NAME] [-c|--continue] [--resume] [--copy] [--yolo] [--dir PATH]   interactive session (multi-turn; -c resumes the latest, --resume picks one, --copy continues in a duplicate)
+  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] <task>   run one task and exit
   reasonix review [--base BRANCH] [--commit SHA] [--model NAME]  AI-powered code review on local diffs
   reasonix serve [--model NAME] [--addr HOST:PORT] [--auth none|token|password] [--token STR] [--password STR] [--hash-password]  serve over HTTP+SSE (with optional auth)
   reasonix acp [--model NAME]                           serve Agent Client Protocol over stdio (also: reasonix --acp)

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -392,8 +392,8 @@ var Chinese = Messages{
 	UsageBody: `reasonix — 由配置和插件驱动的 coding agent（多模型）
 
 用法：
-  reasonix [--model NAME] [-c|--continue] [--resume] [--yolo] [--dir PATH]   交互式会话（多轮；-c 恢复最近一次，--resume 选择一个）
-  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>   执行单次任务后退出
+  reasonix [--model NAME] [-c|--continue] [--resume] [--copy] [--yolo] [--dir PATH]   交互式会话（多轮；-c 恢复最近一次，--resume 选择一个，--copy 在副本中继续）
+  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] <task>   执行单次任务后退出
   reasonix review [--base BRANCH] [--commit SHA] [--model NAME]  AI 代码审查（基于本地 diff）
   reasonix serve [--model NAME] [--addr HOST:PORT] [--auth none|token|password] [--token STR] [--password STR] [--hash-password]  通过 HTTP+SSE 提供服务（支持可选认证）
   reasonix acp [--model NAME]                           通过 stdio 提供 Agent Client Protocol（也可用：reasonix --acp）

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -48,6 +49,11 @@ type Server struct {
 	titlePrice      *provider.Pricing
 	titles          *titleCache
 	auth            *authGate // nil when auth is disabled
+	// leases guards the active session file against other runtimes (a desktop
+	// window, another CLI). Wired by the serve CLI command with the keeper that
+	// already holds the startup session's lease; nil (tests, embedded use)
+	// disables lease gating.
+	leases *control.SessionLeaseKeeper
 }
 
 // New builds a Server. bc must be the controller's event sink.
@@ -69,6 +75,30 @@ func (s *Server) ctl() control.SessionAPI {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.ctrl
+}
+
+// SetSessionLeases hands the server the session-lease keeper that guards its
+// active session file. The write-binding endpoints (/resume, /new, /fork and
+// model switches that rotate the path) then move the lease along with the
+// active session and refuse to bind a session held by another runtime.
+// Call it before serving; a nil keeper leaves lease gating off.
+func (s *Server) SetSessionLeases(k *control.SessionLeaseKeeper) {
+	s.leases = k
+}
+
+// rebindSessionLease moves the server's session lease to path. A nil keeper
+// gates nothing (tests, embedded use).
+func (s *Server) rebindSessionLease(path string) error {
+	if s.leases == nil {
+		return nil
+	}
+	return s.leases.Rebind(path)
+}
+
+// sessionInUseError renders a lease refusal for HTTP clients using the shared
+// CLI wording, without the session file path.
+func sessionInUseError(err error) string {
+	return control.SessionInUseMessage(err) + "; " + control.SessionLeaseCloseHint
 }
 
 // AuthToken returns the pre-shared token when in token mode, or "" otherwise.
@@ -163,6 +193,15 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	}
 	s.ctrl = newCtrl
 	s.mu.Unlock()
+
+	// A carried conversation keeps its file (newPath == prevPath) and the lease
+	// with it; only a previously file-less session gets a fresh path here, and
+	// the lease follows it (fresh path — failure is theoretical).
+	if newPath != prevPath {
+		if err := s.rebindSessionLease(newPath); err != nil {
+			slog.Warn("serve: session lease after model switch", "err", err)
+		}
+	}
 
 	// Off-lock: tear down the old controller. Close can block up to 15s.
 	cur.Close()
@@ -511,6 +550,11 @@ func (s *Server) newSession(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Fresh path — the lease follows it; failure is theoretical but not silent.
+	if err := s.rebindSessionLease(s.ctl().SessionPath()); err != nil {
+		http.Error(w, sessionInUseError(err), http.StatusConflict)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -695,6 +739,11 @@ func (s *Server) fork(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// The controller switched to the fork (a fresh path); the lease follows it.
+	if err := s.rebindSessionLease(s.ctl().SessionPath()); err != nil {
+		http.Error(w, sessionInUseError(err), http.StatusConflict)
+		return
+	}
 	writeJSON(w, map[string]string{"path": path})
 }
 
@@ -841,12 +890,26 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session is pending cleanup", http.StatusBadRequest)
 		return
 	}
-	// Snapshot the current session before switching away.
+	// Snapshot the current session before switching away — while this process
+	// still holds its lease.
 	if err := s.ctl().Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before resume", "err", err)
 	}
+	// Refuse to bind a session another runtime is writing (a desktop window,
+	// another CLI); on success the lease now guards the resume target.
+	if err := s.rebindSessionLease(realPath); err != nil {
+		if errors.Is(err, agent.ErrSessionLeaseHeld) {
+			http.Error(w, sessionInUseError(err), http.StatusConflict)
+		} else {
+			http.Error(w, "session lease: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
 	loaded, err := agent.LoadSession(realPath)
 	if err != nil {
+		// The lease already moved to the target; re-point it at the session the
+		// controller still owns (best-effort).
+		_ = s.rebindSessionLease(s.ctl().SessionPath())
 		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -37,10 +37,17 @@ var indexHTML []byte
 // Server wires a controller to its HTTP surface. The Broadcaster must be the
 // same sink the controller was constructed with, so events reach SSE clients.
 type Server struct {
-	mu       sync.RWMutex // guards ctrl, which switchModel swaps at runtime
-	switchMu sync.Mutex   // serializes switchModel so its Snapshot/Build/Close run off s.mu
-	ctrl     control.SessionAPI
-	bc       *Broadcaster
+	mu sync.RWMutex // guards ctrl, which switchModel swaps at runtime
+	// bindMu serializes every entry point that changes the active session
+	// path — /resume, /new, /fork, and switchModel. net/http runs handlers
+	// concurrently and serve serves multiple browser tabs, so without this
+	// two interleaved rebinds can leave the controller writing one session
+	// while the lease keeper guards another (the exact split this feature
+	// exists to prevent). It also keeps switchModel's Snapshot/Build/Close
+	// off s.mu, as the narrower switchMu did before it was widened.
+	bindMu sync.Mutex
+	ctrl   control.SessionAPI
+	bc     *Broadcaster
 	// buildController builds the replacement controller during a model switch.
 	// Nil in production (switchModel falls back to boot.Build); tests inject a
 	// fake so switchModel can be exercised without real provider IO.
@@ -94,6 +101,11 @@ func (s *Server) rebindSessionLease(path string) error {
 	}
 	return s.leases.Rebind(path)
 }
+
+// resumeBindHookForTest, when set, runs inside /resume's critical sequence
+// between the lease rebind and the controller Resume. Tests use it to force
+// the interleaving bindMu exists to prevent; production never sets it.
+var resumeBindHookForTest func()
 
 // sessionInUseError renders a lease refusal for HTTP clients using the shared
 // CLI wording, without the session file path.
@@ -150,12 +162,13 @@ func (s *Server) initTitleProvider() {
 // old controller's Close (jobs.CloseWithGrace up to 15s + SessionEnd hook) — all
 // run OFF s.mu. Holding the write lock across them would wedge every HTTP handler
 // on s.ctl()'s RLock for the duration, stalling the whole serve frontend
-// (mirrors the acp rebuildSession fix and PR #5920). switchMu serializes the
-// switch itself so two switches can't interleave, preserving the old "second
-// switch waits" semantics without pinning s.mu.
+// (mirrors the acp rebuildSession fix and PR #5920). bindMu serializes the
+// switch against every other session-path-changing entry point (/resume,
+// /new, /fork), preserving the old "second switch waits" semantics without
+// pinning s.mu.
 func (s *Server) switchModel(ctx context.Context, ref string) error {
-	s.switchMu.Lock()
-	defer s.switchMu.Unlock()
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
 
 	// Snapshot the current controller under a short read of s.mu only.
 	cur := s.ctl()
@@ -180,7 +193,7 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	newPath := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	newCtrl.AdoptHistory(carried, newPath)
 
-	// Publish the swap under a short write lock. switchMu already serializes
+	// Publish the swap under a short write lock. bindMu already serializes
 	// switches — today the only writer of s.ctrl — so the identity re-check is
 	// defensive: it keeps a future controller-swapping path (or a test doing so)
 	// from being silently clobbered after the off-lock build. On a mismatch,
@@ -222,7 +235,7 @@ func (s *Server) build(ctx context.Context, ref string) (*control.Controller, er
 }
 
 // switchEffort persists a new reasoning-effort level for the active provider and
-// rebuilds via switchModel (which serializes on switchMu).
+// rebuilds via switchModel (which serializes on bindMu).
 func (s *Server) switchEffort(ctx context.Context, level string) error {
 	cur := s.ctl()
 	if cur.Running() {
@@ -546,6 +559,10 @@ func (s *Server) compact(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) newSession(w http.ResponseWriter, _ *http.Request) {
+	// Session-path-changing entry point: serialize with /resume, /fork, and
+	// switchModel so the controller and the lease keeper move together.
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
 	if err := s.ctl().NewSession(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -734,6 +751,11 @@ func (s *Server) fork(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing turn", http.StatusBadRequest)
 		return
 	}
+	// Session-path-changing critical sequence: serialize with /resume, /new,
+	// and switchModel so the controller and the lease keeper move together.
+	// Taken after body decoding so a slow client cannot hold the binding lock.
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
 	path, err := s.ctl().ForkNamed(body.Turn, body.Name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -890,6 +912,12 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session is pending cleanup", http.StatusBadRequest)
 		return
 	}
+	// Session-path-changing critical sequence: two interleaved resumes would
+	// leave the controller on one session and the lease on another; serialize
+	// with /new, /fork, and switchModel. Taken after body/path validation so a
+	// slow client cannot hold the binding lock while uploading.
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
 	// Snapshot the current session before switching away — while this process
 	// still holds its lease.
 	if err := s.ctl().Snapshot(); err != nil {
@@ -912,6 +940,9 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		_ = s.rebindSessionLease(s.ctl().SessionPath())
 		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
 		return
+	}
+	if hook := resumeBindHookForTest; hook != nil {
+		hook()
 	}
 	s.ctl().Resume(loaded, realPath)
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/serve/serve_lease_test.go
+++ b/internal/serve/serve_lease_test.go
@@ -1,0 +1,132 @@
+package serve
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+func saveServeTestSession(t *testing.T, path string) {
+	t.Helper()
+	s := agent.NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResumeRefusedWhenSessionLeaseHeld proves POST /resume refuses to bind a
+// session another runtime holds, keeps the server on its current session, and
+// reports the shared holder wording.
+func TestResumeRefusedWhenSessionLeaseHeld(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	held := filepath.Join(dir, "held.jsonl")
+	saveServeTestSession(t, active)
+	saveServeTestSession(t, held)
+
+	holder, err := agent.TryAcquireSessionLease(held)
+	if err != nil {
+		t.Fatalf("test holder acquire: %v", err)
+	}
+	defer holder.Release()
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	server.SetSessionLeases(leases)
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	body, err := json.Marshal(map[string]string{"path": held})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	respBody, _ := readAll(resp)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("held resume status = %d, want 409 (body %q)", resp.StatusCode, respBody)
+	}
+	if !strings.Contains(respBody, "in use by another Reasonix") {
+		t.Fatalf("held resume body = %q, want holder wording", respBody)
+	}
+	if strings.Contains(respBody, held) {
+		t.Fatalf("held resume body leaks the session path: %q", respBody)
+	}
+	if got := filepath.Clean(ctrl.SessionPath()); got != filepath.Clean(active) {
+		t.Fatalf("session path after refused resume = %q, want active %q", got, active)
+	}
+	if got, want := leases.HeldPath(), agent.CanonicalSessionPath(active); got != want {
+		t.Fatalf("lease after refused resume = %q, want %q", got, want)
+	}
+}
+
+// TestResumeMovesSessionLease proves a successful POST /resume releases the old
+// session's lease and holds the new one.
+func TestResumeMovesSessionLease(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	next := filepath.Join(dir, "next.jsonl")
+	saveServeTestSession(t, active)
+	saveServeTestSession(t, next)
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	server.SetSessionLeases(leases)
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	body, err := json.Marshal(map[string]string{"path": next})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	respBody, _ := readAll(resp)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("resume status = %d, want 204 (body %q)", resp.StatusCode, respBody)
+	}
+	want, err := filepath.EvalSymlinks(next)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, wantHeld := leases.HeldPath(), agent.CanonicalSessionPath(want); got != wantHeld {
+		t.Fatalf("lease after resume = %q, want %q", got, wantHeld)
+	}
+	lease, err := agent.TryAcquireSessionLease(active)
+	if err != nil {
+		t.Fatalf("old session lease not released by resume: %v", err)
+	}
+	lease.Release()
+}
+
+func readAll(resp *http.Response) (string, error) {
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	return strings.TrimSpace(string(b)), err
+}

--- a/internal/serve/serve_lease_test.go
+++ b/internal/serve/serve_lease_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -134,6 +135,44 @@ func readAll(resp *http.Response) (string, error) {
 	return strings.TrimSpace(string(b)), err
 }
 
+func postServeLeaseJSON(client *http.Client, url string, body any, want int) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Post(url, "application/json", strings.NewReader(string(payload)))
+	if err != nil {
+		return err
+	}
+	respBody, readErr := readAll(resp)
+	if readErr != nil {
+		return readErr
+	}
+	if resp.StatusCode != want {
+		return fmt.Errorf("POST %s status = %d, want %d (body %q)", url, resp.StatusCode, want, respBody)
+	}
+	return nil
+}
+
+func waitServeLeaseDone(t *testing.T, done <-chan struct{}, what string, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+func waitServeLeaseResult(t *testing.T, ch <-chan error, what string, timeout time.Duration) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out waiting for %s", what)
+	}
+}
+
 // TestConcurrentResumesKeepControllerAndLeaseAligned hammers POST /resume from
 // two goroutines bouncing between different targets and asserts the invariant
 // this PR exists for: whatever session the controller ends up writing is the
@@ -162,33 +201,46 @@ func TestConcurrentResumesKeepControllerAndLeaseAligned(t *testing.T) {
 	server.SetSessionLeases(leases)
 	srv := httptest.NewServer(server.Handler())
 	defer srv.Close()
+	client := &http.Client{Timeout: 10 * time.Second}
 
-	post := func(target string) {
-		body, _ := json.Marshal(map[string]string{"path": target})
-		resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
-		if err != nil {
-			return
-		}
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
+	post := func(target string) error {
+		return postServeLeaseJSON(client, srv.URL+"/resume", map[string]string{"path": target}, http.StatusNoContent)
 	}
 
 	const rounds = 25
 	var wg sync.WaitGroup
+	errs := make(chan error, rounds*2)
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for range rounds {
-			post(targetB)
+			if err := post(targetB); err != nil {
+				errs <- err
+				return
+			}
 		}
 	}()
 	go func() {
 		defer wg.Done()
 		for range rounds {
-			post(targetC)
+			if err := post(targetC); err != nil {
+				errs <- err
+				return
+			}
 		}
 	}()
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+		close(errs)
+	}()
+	waitServeLeaseDone(t, done, "concurrent resume posts", 20*time.Second)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
 	held := leases.HeldPath()
@@ -219,30 +271,48 @@ func TestConcurrentResumeAndForkKeepAlignment(t *testing.T) {
 	server.SetSessionLeases(leases)
 	srv := httptest.NewServer(server.Handler())
 	defer srv.Close()
+	client := &http.Client{Timeout: 10 * time.Second}
 
 	var wg sync.WaitGroup
+	errs := make(chan error, 30)
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for range 15 {
-			body, _ := json.Marshal(map[string]string{"path": target})
-			if resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body))); err == nil {
-				_, _ = io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
+			if err := postServeLeaseJSON(client, srv.URL+"/resume", map[string]string{"path": target}, http.StatusNoContent); err != nil {
+				errs <- err
+				return
 			}
 		}
 	}()
 	go func() {
 		defer wg.Done()
 		for range 15 {
-			body, _ := json.Marshal(map[string]any{"turn": 0, "name": ""})
-			if resp, err := http.Post(srv.URL+"/fork", "application/json", strings.NewReader(string(body))); err == nil {
-				_, _ = io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
+			payload, _ := json.Marshal(map[string]any{"turn": 0, "name": ""})
+			resp, err := client.Post(srv.URL+"/fork", "application/json", strings.NewReader(string(payload)))
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, readErr := readAll(resp)
+			if readErr != nil {
+				errs <- readErr
+				return
 			}
 		}
 	}()
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+		close(errs)
+	}()
+	waitServeLeaseDone(t, done, "concurrent resume/fork posts", 20*time.Second)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
 	held := leases.HeldPath()
@@ -278,6 +348,7 @@ func TestInterleavedResumesForcedThroughBindWindow(t *testing.T) {
 	server.SetSessionLeases(leases)
 	srv := httptest.NewServer(server.Handler())
 	defer srv.Close()
+	client := &http.Client{Timeout: 10 * time.Second}
 
 	entered := make(chan struct{})
 	release := make(chan struct{})
@@ -294,37 +365,57 @@ func TestInterleavedResumesForcedThroughBindWindow(t *testing.T) {
 		}
 	}
 	defer func() { resumeBindHookForTest = nil }()
+	var releaseOnce sync.Once
+	unpark := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	t.Cleanup(unpark)
 
-	post := func(target string) {
-		body, _ := json.Marshal(map[string]string{"path": target})
-		resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
-		if err != nil {
-			return
-		}
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
+	post := func(target string) error {
+		return postServeLeaseJSON(client, srv.URL+"/resume", map[string]string{"path": target}, http.StatusNoContent)
 	}
 
-	done1 := make(chan struct{})
-	go func() { defer close(done1); post(targetB) }()
-	<-entered // request 1 parked inside its bind window, lease moved to B
+	done1 := make(chan error, 1)
+	go func() { done1 <- post(targetB) }()
+	select {
+	case <-entered:
+		// Request 1 parked inside its bind window, lease moved to B.
+	case err := <-done1:
+		if err != nil {
+			t.Fatalf("first resume finished before entering bind hook: %v", err)
+		}
+		t.Fatal("first resume finished before entering bind hook")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first resume to enter bind hook")
+	}
 
-	done2 := make(chan struct{})
-	go func() { defer close(done2); post(targetC) }()
+	done2 := make(chan error, 1)
+	go func() { done2 <- post(targetC) }()
 	// Request 2 must not complete while request 1 owns the bind window.
 	select {
-	case <-done2:
+	case err := <-done2:
 		// Unpark request 1 before failing, or httptest's Close would wait the
 		// full package timeout on the parked handler.
-		close(release)
-		<-done1
+		unpark()
+		if waitErr := waitServeLeaseResult(t, done1, "first resume after failed serialization check", 5*time.Second); waitErr != nil {
+			t.Fatalf("second resume completed inside the first resume's bind window; first resume cleanup failed: %v", waitErr)
+		}
+		if err != nil {
+			t.Fatalf("second resume completed inside the first resume's bind window with error: %v", err)
+		}
 		t.Fatal("second resume completed inside the first resume's bind window")
 	case <-time.After(150 * time.Millisecond):
 	}
 
-	close(release)
-	<-done1
-	<-done2
+	unpark()
+	if err := waitServeLeaseResult(t, done1, "first resume", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitServeLeaseResult(t, done2, "second resume", 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
 
 	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
 	held := leases.HeldPath()

--- a/internal/serve/serve_lease_test.go
+++ b/internal/serve/serve_lease_test.go
@@ -7,7 +7,10 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
@@ -129,4 +132,210 @@ func readAll(resp *http.Response) (string, error) {
 	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	return strings.TrimSpace(string(b)), err
+}
+
+// TestConcurrentResumesKeepControllerAndLeaseAligned hammers POST /resume from
+// two goroutines bouncing between different targets and asserts the invariant
+// this PR exists for: whatever session the controller ends up writing is the
+// session the lease keeper guards. Without bindMu serializing the
+// snapshot→rebind→resume sequence, interleaved handlers split the two (the
+// controller on one path, the lease on another), leaving the written session
+// unprotected and a foreign one wrongly occupied.
+func TestConcurrentResumesKeepControllerAndLeaseAligned(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	targetB := filepath.Join(dir, "target-b.jsonl")
+	targetC := filepath.Join(dir, "target-c.jsonl")
+	for _, p := range []string{active, targetB, targetC} {
+		saveServeTestSession(t, p)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	defer ctrl.Close()
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	server.SetSessionLeases(leases)
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	post := func(target string) {
+		body, _ := json.Marshal(map[string]string{"path": target})
+		resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	const rounds = 25
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range rounds {
+			post(targetB)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range rounds {
+			post(targetC)
+		}
+	}()
+	wg.Wait()
+
+	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
+	held := leases.HeldPath()
+	if got != held {
+		t.Fatalf("controller/lease split after concurrent resumes:\n  controller writes %q\n  lease guards      %q", got, held)
+	}
+}
+
+// TestConcurrentResumeAndForkKeepAlignment interleaves /resume with /fork —
+// the two handlers rotate the active path through different code paths — and
+// asserts the same controller/lease alignment invariant.
+func TestConcurrentResumeAndForkKeepAlignment(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	target := filepath.Join(dir, "target.jsonl")
+	saveServeTestSession(t, active)
+	saveServeTestSession(t, target)
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	defer ctrl.Close()
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	server.SetSessionLeases(leases)
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 15 {
+			body, _ := json.Marshal(map[string]string{"path": target})
+			if resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body))); err == nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 15 {
+			body, _ := json.Marshal(map[string]any{"turn": 0, "name": ""})
+			if resp, err := http.Post(srv.URL+"/fork", "application/json", strings.NewReader(string(body))); err == nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+			}
+		}
+	}()
+	wg.Wait()
+
+	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
+	held := leases.HeldPath()
+	if got != held {
+		t.Fatalf("controller/lease split after resume×fork interleave:\n  controller writes %q\n  lease guards      %q", got, held)
+	}
+}
+
+// TestInterleavedResumesForcedThroughBindWindow deterministically forces the
+// interleaving bindMu prevents: request 1 is parked between its lease rebind
+// and its controller Resume while request 2 tries to resume a different
+// session. With bindMu, request 2 waits and both requests land aligned;
+// without it, request 2 completes inside request 1's window and request 1
+// then rebinds the controller to a session the lease no longer guards.
+func TestInterleavedResumesForcedThroughBindWindow(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	targetB := filepath.Join(dir, "target-b.jsonl")
+	targetC := filepath.Join(dir, "target-c.jsonl")
+	for _, p := range []string{active, targetB, targetC} {
+		saveServeTestSession(t, p)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	defer ctrl.Close()
+	server := New(ctrl, bc, config.ServeConfig{})
+	leases := control.NewSessionLeaseKeeper()
+	defer leases.Release()
+	if err := leases.Rebind(active); err != nil {
+		t.Fatalf("seed lease on active: %v", err)
+	}
+	server.SetSessionLeases(leases)
+	srv := httptest.NewServer(server.Handler())
+	defer srv.Close()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	// Park only the FIRST request through the hook. A sync.Once would not do:
+	// Once.Do holds an internal mutex while f runs, so the second request
+	// would block on the Once itself and accidentally reproduce bindMu's
+	// serialization even with the guard removed.
+	var first atomic.Bool
+	first.Store(true)
+	resumeBindHookForTest = func() {
+		if first.CompareAndSwap(true, false) {
+			close(entered)
+			<-release
+		}
+	}
+	defer func() { resumeBindHookForTest = nil }()
+
+	post := func(target string) {
+		body, _ := json.Marshal(map[string]string{"path": target})
+		resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	done1 := make(chan struct{})
+	go func() { defer close(done1); post(targetB) }()
+	<-entered // request 1 parked inside its bind window, lease moved to B
+
+	done2 := make(chan struct{})
+	go func() { defer close(done2); post(targetC) }()
+	// Request 2 must not complete while request 1 owns the bind window.
+	select {
+	case <-done2:
+		// Unpark request 1 before failing, or httptest's Close would wait the
+		// full package timeout on the parked handler.
+		close(release)
+		<-done1
+		t.Fatal("second resume completed inside the first resume's bind window")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(release)
+	<-done1
+	<-done2
+
+	got := agent.CanonicalSessionPath(server.ctl().SessionPath())
+	held := leases.HeldPath()
+	if got != held {
+		t.Fatalf("controller/lease split after forced interleave:\n  controller writes %q\n  lease guards      %q", got, held)
+	}
+	wantC := targetC
+	if resolved, err := filepath.EvalSymlinks(targetC); err == nil {
+		wantC = resolved // serve resolves the request path; match its form
+	}
+	if got != agent.CanonicalSessionPath(wantC) {
+		t.Fatalf("last resume should win: controller on %q, want %q", got, wantC)
+	}
 }


### PR DESCRIPTION
## Summary

Phase 2b of #6027: put the session lease where the writers are. The desktop has held leases since v1.16, but CLI `--resume`/`--continue`, the chat TUI's in-session switches, `serve`, and ACP never acquired one — leaving "desktop + CLI on the same session" as the last real silent dual-writer entrance. Until now CAS only caught it after the fact by forking recovery copies; with this PR the second writer is refused up front with a clear way out.

Per the approved UX in #6027: conflict → refuse with a holder-identity line + escape hatch; never silent double-writing, never raw lease details.

## What's new

**`control.SessionLeaseKeeper`** — a single-holder lease follower for the non-desktop frontends (one active session at a time). `Rebind` acquires the new path *before* releasing the old one, no-ops on the already-held canonical path (same canonical form as the lease registry — the #6023 lesson), releases on empty path, and on failure leaves the previous lease untouched. `control.SessionInUseMessage` renders the shared holder line:

> this session is in use by another Reasonix process (pid 12345 on HOSTNAME, since 15:04)

pid/host/time are local diagnostics on the operator's own machine; the writer id (random nonce) and the session file path are deliberately never included.

**CLI**
- `reasonix [run] --resume/--continue` on a held session fails fast before setup: holder line + "close the other Reasonix window or process, or rerun with `--copy` to continue in a duplicated session" (exit 1).
- New `--copy` flag: duplicates the resume target beside the original — written through `Session.Save` so the copy is event-log-aware, carries parent/preview/turns/model meta and a " (copy)" title suffix, and starts with no lease/lock sidecars — then continues writable on the copy. `--copy` without a resume target exits 2.
- In-TUI `/resume` and `/switch` refuse held targets and stay on the current session (holder line + close hint). The outgoing session is snapshotted *before* the lease moves; if `/switch` fails after the lease already moved, the lease is re-pointed at the session the controller still owns.
- `/new`, `/clear`, `/branch`, `/branch N`, and rewind-fork follow the controller onto their fresh paths (fresh paths cannot be held; failure is theoretical but never silent). Leases release after the controller closes on exit — verified by tests that the sidecars are gone and reacquirable.

**serve** — `POST /resume` on a held session returns **409 Conflict** with the holder line and leaves serve's state unchanged; `/new`, `/fork`, and model-switch path rotations follow their new paths. Read-only endpoints unaffected.

**ACP** — `session/new`, `session/load`, `session/resume` guard their bind; held sessions surface a protocol error with the holder line (no copy hatch — that is an editor-side decision). `session/close` / `session/delete` / close-all release; delete releases *before* removing files so no locked sidecar survives on Windows.

**Crash resilience needs no special casing**: the OS lock is the sole arbiter (kernel releases it with the process), so a dead holder's session is simply acquirable and its stale `lease.json` gets overwritten — same self-healing the desktop relies on.

## Deliberately not wired (documented for #6027 tracking)

- The bot gateway's attached-session path — its concurrent build-then-reuse flow needs desktop-style lease *handover* semantics, worth its own design round.
- Destructive-op guards for serve/ACP delete endpoints (`TryAcquireSessionRemovalGuard` exists in agent) — protection for deletes, not write-binds; separate concern.
- A TUI read-only browse mode — refusal + `--copy` covers the need without inventing a new mode.

## Tests

19 new regressions across four packages: keeper semantics (handover, canonical no-op, held-refusal keeps prior lease, empty-path release, idempotent release, holder-line content and non-leak assertions), CLI (held resume refusal with `--copy` hint and no path leak, `--copy` correctness — copy equals source transcript, source bytes untouched, copy's lease released on exit — normal resume releases on exit, TUI held-refusal / lease handover / fresh-path follow), serve (409 + unchanged state; successful resume moves the lease), ACP (held load refused and unregistered; close releases).

`go test ./internal/cli ./internal/acp ./internal/serve ./internal/control ./internal/agent` — all pass; new cases pass with `-race`; `gofmt`/`go vet` clean; `GOOS=windows GOARCH=amd64 go build ./...` clean; desktop module untouched (builds/vets clean).

## Cache impact

Cache-impact: none. CLI/serve/ACP session binding, help text, and an exported wrapper (`ResolveBranchRef`) only; no provider-visible prompts, tool schemas, request serialization, or compaction changes.

Refs #6027.
