### PR TITLE
fix desktop Global topic index repair

### DIFF
--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -642,6 +642,41 @@ func TestEnsureBlankTabDoesNotReuseProjectTopicWithSession(t *testing.T) {
 	}
 }
 
+// EnsureBlankTab must not reuse a tombstoned topic: the reused ID would flow
+// into ensureTopicIndexed, whose intentional prepend clears the delete
+// tombstone and resurrects the topic the user removed.
+func TestEnsureBlankTabDoesNotReuseTombstonedTopic(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	// Race product on disk: deleted topic whose default title lingered in the
+	// global title map (title-only, absent from GlobalTopics, no sessions).
+	tombstonedID := "topic_tombstone_blank"
+	if err := setTopicTitle("", tombstonedID, defaultTopicTitle); err != nil {
+		t.Fatalf("set lingering title: %v", err)
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.DeletedTopics = prependUniqueString(f.DeletedTopics, tombstonedID)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+
+	meta, err := NewApp().EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.TopicID == tombstonedID {
+		t.Fatalf("EnsureBlankTab reused tombstoned topic %q", meta.TopicID)
+	}
+	f := loadProjectsFile()
+	if !containsDesktopString(f.DeletedTopics, tombstonedID) {
+		t.Fatalf("deletedTopics = %#v, tombstone must survive blank-tab creation", f.DeletedTopics)
+	}
+	if containsDesktopString(f.GlobalTopics, tombstonedID) {
+		t.Fatalf("globalTopics = %#v, tombstoned topic must not be re-indexed", f.GlobalTopics)
+	}
+}
+
 // NewSession skips the snapshot when the current tab has no real conversation content.
 
 func TestNewSessionNoopsWhenCurrentTabIsBlank(t *testing.T) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5249,6 +5249,10 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		return repairedTopicIDs
 	}
 	_ = prependTopicsInProjectsFile(workspaceRoot, migratedTopicIDs, false)
+	// Same fresh tombstone re-check as the repair pass: these are whole-map
+	// saves, so a concurrent DeleteTopic of an unrelated topic must not have
+	// its title written back by this migration batch.
+	pruneDeletedTopicEntries(topicTitles, topicSources)
 	if topicTitles != nil {
 		_ = saveTopicTitles(topicTitleRoot, topicTitles)
 	}
@@ -5261,6 +5265,27 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		markTopicMigrationDone(dir) // pass complete with nothing deferred
 	}
 	return uniqueStrings(append(repairedTopicIDs, migratedTopicIDs...))
+}
+
+// pruneDeletedTopicEntries drops tombstoned topics from scan-built title and
+// source maps just before they are persisted, re-reading DeletedTopics so a
+// DeleteTopic that landed after the scan snapshot wins. The maps are loaded
+// whole at scan start and saved whole at the end; without this re-check the
+// save would write the deleted topic's stale entries back, and a title-map
+// entry alone resurrects a topic in the sidebar (orderedTopicIDs lists topics
+// that exist only in the title map). Returns the tombstone list so callers can
+// filter their returned topic-ID slices against the same snapshot.
+func pruneDeletedTopicEntries(maps ...map[string]string) []string {
+	deleted := loadProjectsFile().DeletedTopics
+	if len(deleted) == 0 {
+		return nil
+	}
+	for _, m := range maps {
+		for _, id := range deleted {
+			delete(m, id)
+		}
+	}
+	return deleted
 }
 
 func repairIndexedSessionTopics(dir string) []string {
@@ -5353,6 +5378,26 @@ func repairIndexedSessionTopics(dir string) []string {
 		if strings.TrimSpace(topicSources[topicID]) == "" {
 			topicSources[topicID] = topicTitleSourceManual
 			sourcesChanged = true
+		}
+	}
+	if len(repairedTopicIDs) > 0 {
+		// Re-check tombstones right before persisting: a DeleteTopic landing
+		// after the scan snapshot must win. The prepend re-filters under the
+		// projects-file lock; the whole-map title/source saves and the
+		// returned IDs (callers bind blank Global tabs to the first entry)
+		// need the same fresh read.
+		if deletedNow := pruneDeletedTopicEntries(topicTitles, topicSources); len(deletedNow) > 0 {
+			deletedSet := make(map[string]bool, len(deletedNow))
+			for _, id := range deletedNow {
+				deletedSet[id] = true
+			}
+			live := repairedTopicIDs[:0]
+			for _, id := range repairedTopicIDs {
+				if !deletedSet[id] {
+					live = append(live, id)
+				}
+			}
+			repairedTopicIDs = live
 		}
 	}
 	if len(repairedTopicIDs) > 0 {
@@ -6174,6 +6219,14 @@ func (a *App) ListProjectTree() []ProjectNode {
 		migrateLegacySessionsIntoGlobalTopics(dir)
 	}
 	f := loadProjectsFile()
+	// Render-side tombstone guard: a deleted topic whose title survived a racy
+	// whole-map save would otherwise reappear via the orderedTopicIDs title-map
+	// fallback. The tombstone is authoritative until an intentional
+	// single-topic write (create/restore/tab indexing) clears it.
+	deletedTopicSet := make(map[string]bool, len(f.DeletedTopics))
+	for _, id := range f.DeletedTopics {
+		deletedTopicSet[id] = true
+	}
 	out := []ProjectNode{}
 	topicSummaries := map[string]topicSummary{}
 	sessionInfos := map[string]agent.SessionInfo{}
@@ -6346,6 +6399,9 @@ func (a *App) ListProjectTree() []ProjectNode {
 		globalTopicIDs := pinnedTopicIDs(orderedTopicIDs(f.GlobalTopics, globalTitleMap), f.GlobalPinnedTopics)
 		children := make([]ProjectNode, 0, len(globalTopicIDs))
 		for _, id := range globalTopicIDs {
+			if deletedTopicSet[id] {
+				continue
+			}
 			title := globalTitleMap[id]
 			summaryKey := topicSummaryKey("global", "", id)
 			summary := topicSummaries[summaryKey]
@@ -6421,6 +6477,9 @@ func (a *App) ListProjectTree() []ProjectNode {
 
 		children := make([]ProjectNode, 0, len(topicIDs))
 		for _, tid := range topicIDs {
+			if deletedTopicSet[tid] {
+				continue
+			}
 			topicTitle := strings.TrimSpace(titleMap[tid])
 			if topicTitle == "" {
 				topicTitle = defaultTopicTitle

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3568,6 +3568,7 @@ type desktopProjectFile struct {
 	GlobalColor        string           `json:"globalColor,omitempty"`
 	GlobalTopics       []string         `json:"globalTopics,omitempty"`
 	GlobalPinnedTopics []string         `json:"globalPinnedTopics,omitempty"`
+	DeletedTopics      []string         `json:"deletedTopics,omitempty"`
 	PinnedProjects     []string         `json:"pinnedProjects,omitempty"`
 	SidebarOrder       []string         `json:"sidebarOrder,omitempty"`
 	Projects           []desktopProject `json:"projects"`
@@ -3915,6 +3916,10 @@ func removeTopicFromProjectsFile(topicID string) error {
 			f.GlobalPinnedTopics = next
 			changed = true
 		}
+		if next := prependUniqueString(f.DeletedTopics, topicID); !sameStringList(next, f.DeletedTopics) {
+			f.DeletedTopics = next
+			changed = true
+		}
 		for i, p := range f.Projects {
 			if next := removeString(p.Topics, topicID); !sameStringList(next, p.Topics) {
 				f.Projects[i].Topics = next
@@ -3926,6 +3931,21 @@ func removeTopicFromProjectsFile(topicID string) error {
 			}
 		}
 		return changed, nil
+	})
+}
+
+func unmarkTopicDeleted(topicID string) error {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return nil
+	}
+	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		next := removeString(f.DeletedTopics, topicID)
+		if sameStringList(next, f.DeletedTopics) {
+			return false, nil
+		}
+		f.DeletedTopics = next
+		return true, nil
 	})
 }
 
@@ -3946,6 +3966,7 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 		GlobalColor:        normalizeProjectColor(f.GlobalColor),
 		GlobalTopics:       uniqueStrings(f.GlobalTopics),
 		GlobalPinnedTopics: uniqueStrings(f.GlobalPinnedTopics),
+		DeletedTopics:      uniqueStrings(f.DeletedTopics),
 	}
 	index := map[string]int{}
 	for _, p := range f.Projects {
@@ -5022,13 +5043,15 @@ var legacyMigrationMu sync.Mutex
 // session that could gain content later keeps the dir unmarked), so the gate
 // never hides a session that should still be migrated.
 const topicMigrationMarker = ".topics-migrated"
+const topicIndexRepairMarker = ".topic-indexes-repaired"
 
-func topicMigrationDone(dir string) bool {
+func topicDirMarkerDone(dir, marker string) bool {
 	dir = strings.TrimSpace(dir)
-	if dir == "" {
+	marker = strings.TrimSpace(marker)
+	if dir == "" || marker == "" {
 		return false
 	}
-	markerInfo, err := os.Stat(filepath.Join(dir, topicMigrationMarker))
+	markerInfo, err := os.Stat(filepath.Join(dir, marker))
 	if err != nil {
 		return false
 	}
@@ -5056,25 +5079,43 @@ func topicMigrationDone(dir string) bool {
 	return true
 }
 
-func markTopicMigrationDone(dir string) {
+func topicMigrationDone(dir string) bool {
+	return topicDirMarkerDone(dir, topicMigrationMarker)
+}
+
+func topicIndexRepairDone(dir string) bool {
+	return topicDirMarkerDone(dir, topicIndexRepairMarker)
+}
+
+func markTopicDirMarkerDone(dir, marker string) {
 	dir = strings.TrimSpace(dir)
-	if dir == "" {
+	marker = strings.TrimSpace(marker)
+	if dir == "" || marker == "" {
 		return
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return
 	}
-	_ = os.WriteFile(filepath.Join(dir, topicMigrationMarker), nil, 0o644)
+	_ = os.WriteFile(filepath.Join(dir, marker), nil, 0o644)
+}
+
+func markTopicMigrationDone(dir string) {
+	markTopicDirMarkerDone(dir, topicMigrationMarker)
+}
+
+func markTopicIndexRepairDone(dir string) {
+	markTopicDirMarkerDone(dir, topicIndexRepairMarker)
 }
 
 func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
+	repairedTopicIDs := repairIndexedSessionTopics(dir)
 	// One-shot per dir: once the migration pass has completed, skip the full
 	// per-render session scan entirely.
 	if topicMigrationDone(dir) {
-		return nil
+		return repairedTopicIDs
 	}
 	scope, workspaceRoot, topicTitleRoot, ok := legacyMigrationTargetForDir(dir)
 	if !ok {
@@ -5186,7 +5227,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		if !deferred {
 			markTopicMigrationDone(dir) // nothing left to migrate — gate future scans
 		}
-		return nil
+		return repairedTopicIDs
 	}
 	_ = prependTopicsInProjectsFile(workspaceRoot, migratedTopicIDs, false)
 	if topicTitles != nil {
@@ -5200,7 +5241,109 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if !deferred {
 		markTopicMigrationDone(dir) // pass complete with nothing deferred
 	}
-	return migratedTopicIDs
+	return uniqueStrings(append(repairedTopicIDs, migratedTopicIDs...))
+}
+
+func repairIndexedSessionTopics(dir string) []string {
+	if strings.TrimSpace(dir) == "" || topicIndexRepairDone(dir) {
+		return nil
+	}
+	scope, workspaceRoot, topicTitleRoot, ok := legacyMigrationTargetForDir(dir)
+	if !ok {
+		return nil
+	}
+	legacyMigrationMu.Lock()
+	defer legacyMigrationMu.Unlock()
+	if topicIndexRepairDone(dir) {
+		return nil
+	}
+	infos, err := agent.ListSessionOrder(dir)
+	if err != nil {
+		return nil
+	}
+
+	topicTitles, err := loadTopicTitlesForUpdate(topicTitleRoot)
+	if err != nil {
+		return nil
+	}
+	topicSources, err := loadTopicTitleSourcesForUpdate(topicTitleRoot)
+	if err != nil {
+		return nil
+	}
+	deletedTopics := loadProjectsFile().DeletedTopics
+	var repairedTopicIDs []string
+	titlesChanged := false
+	sourcesChanged := false
+	deferred := false
+	for _, info := range infos {
+		topicID := strings.TrimSpace(info.TopicID)
+		if topicID == "" {
+			continue
+		}
+		meta, ok, err := agent.LoadBranchMeta(info.Path)
+		if err != nil {
+			deferred = true
+			continue
+		}
+		if !ok || strings.TrimSpace(meta.TopicID) == "" {
+			continue
+		}
+		if containsDesktopString(deletedTopics, topicID) {
+			continue
+		}
+		if !legacySessionScopeMatchesMigrationTarget(meta, scope, workspaceRoot) {
+			continue
+		}
+		repairedTopicIDs = append(repairedTopicIDs, topicID)
+		if strings.TrimSpace(topicTitles[topicID]) == "" {
+			title := indexedSessionTopicTitle(dir, info, meta)
+			if title == "" {
+				title = defaultTopicTitle
+			}
+			topicTitles[topicID] = title
+			titlesChanged = true
+		}
+		if strings.TrimSpace(topicSources[topicID]) == "" {
+			topicSources[topicID] = topicTitleSourceManual
+			sourcesChanged = true
+		}
+	}
+	if len(repairedTopicIDs) > 0 {
+		if err := prependTopicsInProjectsFile(workspaceRoot, repairedTopicIDs, false); err != nil {
+			deferred = true
+		}
+		if titlesChanged {
+			if err := saveTopicTitles(topicTitleRoot, topicTitles); err != nil {
+				deferred = true
+			}
+		}
+		if sourcesChanged {
+			if err := saveTopicTitleSources(topicTitleRoot, topicSources); err != nil {
+				deferred = true
+			}
+		}
+		if !deferred {
+			projectSessionCache.invalidate()
+		}
+	}
+	if !deferred {
+		markTopicIndexRepairDone(dir)
+		return uniqueStrings(repairedTopicIDs)
+	}
+	return nil
+}
+
+func indexedSessionTopicTitle(dir string, info agent.SessionOrderInfo, meta agent.BranchMeta) string {
+	if title := topicTitleFromText(meta.TopicTitle); title != "" {
+		return title
+	}
+	if title := topicTitleFromText(info.TopicTitle); title != "" {
+		return title
+	}
+	if title := topicTitleFromText(loadSessionTitles(dir)[filepath.Base(info.Path)]); title != "" {
+		return title
+	}
+	return topicTitleFromText(info.Preview)
 }
 
 func legacyMigrationTargetForDir(dir string) (scope, workspaceRoot, topicTitleRoot string, ok bool) {
@@ -5223,6 +5366,10 @@ func legacySessionMetaMatchesMigrationTarget(meta agent.BranchMeta, scope, works
 	if strings.TrimSpace(meta.TopicID) != "" {
 		return false
 	}
+	return legacySessionScopeMatchesMigrationTarget(meta, scope, workspaceRoot)
+}
+
+func legacySessionScopeMatchesMigrationTarget(meta agent.BranchMeta, scope, workspaceRoot string) bool {
 	metaScope := strings.TrimSpace(meta.Scope)
 	if metaScope != "" && metaScope != scope {
 		return false
@@ -5322,6 +5469,9 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 	}
 	meta.TopicID = topicID
 	meta.TopicTitle = title
+	if err := unmarkTopicDeleted(topicID); err != nil {
+		return err
+	}
 	if err := prependTopicInProjectsFile(workspaceRoot, topicID, scope == "project"); err != nil {
 		return err
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3864,20 +3864,54 @@ func updateProjectsFile(mutator func(*desktopProjectFile) (bool, error)) error {
 }
 
 func prependTopicInProjectsFile(workspaceRoot, topicID string, ensureProject bool) error {
-	return prependTopicsInProjectsFile(workspaceRoot, []string{topicID}, ensureProject)
+	// Single-topic prepends are intentional writes (topic creation, a live tab
+	// indexing its session, restore from trash): they clear any delete
+	// tombstone so the topic fully returns instead of landing in a half-state
+	// where only its title resurfaces.
+	return prependTopicsInProjectsFileOpts(workspaceRoot, []string{topicID}, ensureProject, false)
 }
 
 func prependTopicsInProjectsFile(workspaceRoot string, topicIDs []string, ensureProject bool) error {
+	// Batch prepends come from the legacy migration and index-repair scans:
+	// they must respect delete tombstones so a scan never resurrects a topic
+	// the user removed.
+	return prependTopicsInProjectsFileOpts(workspaceRoot, topicIDs, ensureProject, true)
+}
+
+func prependTopicsInProjectsFileOpts(workspaceRoot string, topicIDs []string, ensureProject, respectTombstones bool) error {
 	workspaceRoot = normalizeProjectRoot(workspaceRoot)
 	topicIDs = uniqueStrings(topicIDs)
 	if len(topicIDs) == 0 {
 		return nil
 	}
 	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
-		if workspaceRoot == "" {
-			next := uniqueStrings(append(append([]string(nil), topicIDs...), f.GlobalTopics...))
-			if sameStringList(next, f.GlobalTopics) {
+		// Tombstones are checked under the projects-file lock: a DeleteTopic
+		// that lands between a scan reading DeletedTopics and this write must
+		// not be resurrected by the stale batch.
+		live := topicIDs
+		changed := false
+		if respectTombstones {
+			live = make([]string, 0, len(topicIDs))
+			for _, id := range topicIDs {
+				if !containsDesktopString(f.DeletedTopics, id) {
+					live = append(live, id)
+				}
+			}
+			if len(live) == 0 {
 				return false, nil
+			}
+		} else {
+			for _, id := range topicIDs {
+				if next := removeString(f.DeletedTopics, id); !sameStringList(next, f.DeletedTopics) {
+					f.DeletedTopics = next
+					changed = true
+				}
+			}
+		}
+		if workspaceRoot == "" {
+			next := uniqueStrings(append(append([]string(nil), live...), f.GlobalTopics...))
+			if sameStringList(next, f.GlobalTopics) {
+				return changed, nil
 			}
 			f.GlobalTopics = next
 			return true, nil
@@ -3886,17 +3920,17 @@ func prependTopicsInProjectsFile(workspaceRoot string, topicIDs []string, ensure
 			if p.Root != workspaceRoot {
 				continue
 			}
-			next := uniqueStrings(append(append([]string(nil), topicIDs...), p.Topics...))
+			next := uniqueStrings(append(append([]string(nil), live...), p.Topics...))
 			if sameStringList(next, p.Topics) {
-				return false, nil
+				return changed, nil
 			}
 			f.Projects[i].Topics = next
 			return true, nil
 		}
 		if !ensureProject {
-			return false, nil
+			return changed, nil
 		}
-		f.Projects = append(f.Projects, desktopProject{Root: workspaceRoot, Topics: topicIDs})
+		f.Projects = append(f.Projects, desktopProject{Root: workspaceRoot, Topics: live})
 		return true, nil
 	})
 }
@@ -3931,21 +3965,6 @@ func removeTopicFromProjectsFile(topicID string) error {
 			}
 		}
 		return changed, nil
-	})
-}
-
-func unmarkTopicDeleted(topicID string) error {
-	topicID = strings.TrimSpace(topicID)
-	if topicID == "" {
-		return nil
-	}
-	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
-		next := removeString(f.DeletedTopics, topicID)
-		if sameStringList(next, f.DeletedTopics) {
-			return false, nil
-		}
-		f.DeletedTopics = next
-		return true, nil
 	})
 }
 
@@ -5270,8 +5289,30 @@ func repairIndexedSessionTopics(dir string) []string {
 	if err != nil {
 		return nil
 	}
-	deletedTopics := loadProjectsFile().DeletedTopics
+	projects := loadProjectsFile()
+	deletedTopics := projects.DeletedTopics
+	// Repair only topics missing from the sidebar index. Skipping topics that
+	// are already listed and titled keeps steady-state rescans write-free:
+	// otherwise every rescan (any session activity invalidates the marker)
+	// would prepend the full topic list back in most-recently-active order,
+	// reordering the user's sidebar and handing already-visible topics to the
+	// blank-tab binding in the migration callers.
+	indexedTopics := projects.GlobalTopics
+	if scope == "project" {
+		indexedTopics = nil
+		for _, p := range projects.Projects {
+			if p.Root == workspaceRoot {
+				indexedTopics = p.Topics
+				break
+			}
+		}
+	}
+	indexedSet := make(map[string]bool, len(indexedTopics))
+	for _, id := range indexedTopics {
+		indexedSet[id] = true
+	}
 	var repairedTopicIDs []string
+	var sessionTitles map[string]string
 	titlesChanged := false
 	sourcesChanged := false
 	deferred := false
@@ -5279,6 +5320,9 @@ func repairIndexedSessionTopics(dir string) []string {
 		topicID := strings.TrimSpace(info.TopicID)
 		if topicID == "" {
 			continue
+		}
+		if indexedSet[topicID] && strings.TrimSpace(topicTitles[topicID]) != "" {
+			continue // fully indexed already — nothing to repair, skip the meta read
 		}
 		meta, ok, err := agent.LoadBranchMeta(info.Path)
 		if err != nil {
@@ -5296,7 +5340,10 @@ func repairIndexedSessionTopics(dir string) []string {
 		}
 		repairedTopicIDs = append(repairedTopicIDs, topicID)
 		if strings.TrimSpace(topicTitles[topicID]) == "" {
-			title := indexedSessionTopicTitle(dir, info, meta)
+			if sessionTitles == nil {
+				sessionTitles = loadSessionTitles(dir)
+			}
+			title := indexedSessionTopicTitle(sessionTitles, info, meta)
 			if title == "" {
 				title = defaultTopicTitle
 			}
@@ -5333,14 +5380,14 @@ func repairIndexedSessionTopics(dir string) []string {
 	return nil
 }
 
-func indexedSessionTopicTitle(dir string, info agent.SessionOrderInfo, meta agent.BranchMeta) string {
+func indexedSessionTopicTitle(sessionTitles map[string]string, info agent.SessionOrderInfo, meta agent.BranchMeta) string {
 	if title := topicTitleFromText(meta.TopicTitle); title != "" {
 		return title
 	}
 	if title := topicTitleFromText(info.TopicTitle); title != "" {
 		return title
 	}
-	if title := topicTitleFromText(loadSessionTitles(dir)[filepath.Base(info.Path)]); title != "" {
+	if title := topicTitleFromText(sessionTitles[filepath.Base(info.Path)]); title != "" {
 		return title
 	}
 	return topicTitleFromText(info.Preview)
@@ -5469,9 +5516,6 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 	}
 	meta.TopicID = topicID
 	meta.TopicTitle = title
-	if err := unmarkTopicDeleted(topicID); err != nil {
-		return err
-	}
 	if err := prependTopicInProjectsFile(workspaceRoot, topicID, scope == "project"); err != nil {
 		return err
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1969,6 +1969,15 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 	if len(topicIDs) == 0 {
 		return ""
 	}
+	// Blank-tab reuse is an automatic write path: the reused ID flows into
+	// ensureTopicIndexed, whose intentional single-topic prepend clears delete
+	// tombstones. Picking a tombstoned topic here (its default title can
+	// linger title-only after a delete raced a scan save) would therefore
+	// fully resurrect a topic the user removed — skip them.
+	deletedTopics := make(map[string]bool, len(f.DeletedTopics))
+	for _, id := range f.DeletedTopics {
+		deletedTopics[id] = true
+	}
 
 	openTopics := map[string]bool{}
 	for _, tab := range a.tabs {
@@ -2002,7 +2011,7 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		addSessionIndex(desktopSessionDir(globalWorkspaceRoot()))
 	}
 	for _, topicID := range topicIDs {
-		if openTopics[topicID] {
+		if deletedTopics[topicID] || openTopics[topicID] {
 			continue
 		}
 		if topicTitleForTab(scope, workspaceRoot, topicID) != defaultTopicTitle {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -708,6 +708,116 @@ func TestBatchPrependRespectsTombstoneWrittenAfterScanSnapshot(t *testing.T) {
 	}
 }
 
+func TestTombstonedTitleOnlyTopicStaysHiddenInProjectTree(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := addProject(t.TempDir(), "Existing project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	// Control: a legitimate title-only topic (not in GlobalTopics) must keep
+	// rendering through the orderedTopicIDs title-map fallback.
+	controlID := "topic_control_visible"
+	if err := setTopicTitle("", controlID, "正常话题"); err != nil {
+		t.Fatalf("set control title: %v", err)
+	}
+	// Race product: DeleteTopic landed, but a stale whole-map save wrote the
+	// topic's title back — tombstoned, absent from GlobalTopics, title present.
+	tombstonedID := "legacy_raced_000000000009"
+	if err := setTopicTitle("", tombstonedID, "被删除的话题"); err != nil {
+		t.Fatalf("set stale title: %v", err)
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.DeletedTopics = prependUniqueString(f.DeletedTopics, tombstonedID)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	var global *ProjectNode
+	for i := range nodes {
+		if nodes[i].Kind == "global_folder" {
+			global = &nodes[i]
+			break
+		}
+	}
+	if global == nil {
+		t.Fatalf("project tree = %#v, want Global folder", nodes)
+	}
+	seen := map[string]bool{}
+	for _, c := range global.Children {
+		seen[c.TopicID] = true
+	}
+	if seen[tombstonedID] {
+		t.Fatalf("global children = %#v, tombstoned title-only topic %q must stay hidden", global.Children, tombstonedID)
+	}
+	if !seen[controlID] {
+		t.Fatalf("global children = %#v, legitimate title-only topic %q should still render", global.Children, controlID)
+	}
+}
+
+func TestRepairPassPrunesStaleTitleOfDeletedTopic(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := addProject(t.TempDir(), "Existing project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	// Stale race product on disk: tombstoned topic whose title lingers in the
+	// global title map. The next repair pass that saves the whole map must
+	// prune it instead of persisting it again.
+	tombstonedID := "legacy_raced_000000000010"
+	if err := setTopicTitle("", tombstonedID, "被删除的话题"); err != nil {
+		t.Fatalf("set stale title: %v", err)
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.DeletedTopics = prependUniqueString(f.DeletedTopics, tombstonedID)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+
+	sessionPath := writeLegacySession(t, dir, "desktop-prune.jsonl", "needs repair", time.Now().Add(-time.Hour))
+	repairID := "legacy_desktop-prune_1234"
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		ID:         agent.BranchID(sessionPath),
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		UpdatedAt:  time.Now().Add(-time.Hour),
+		Scope:      "global",
+		TopicID:    repairID,
+		TopicTitle: "待修复话题",
+		Turns:      1,
+		Preview:    "needs repair",
+	}); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+	markTopicMigrationDone(dir)
+
+	if repaired := migrateLegacySessionsIntoGlobalTopics(dir); len(repaired) != 1 || repaired[0] != repairID {
+		t.Fatalf("repaired topics = %#v, want %q", repaired, repairID)
+	}
+	if got := loadTopicTitle("", tombstonedID); got != "" {
+		t.Fatalf("stale title = %q, repair save should prune the tombstoned entry", got)
+	}
+	if got := loadTopicTitle("", repairID); got != "待修复话题" {
+		t.Fatalf("repaired title = %q, want 待修复话题", got)
+	}
+	f := loadProjectsFile()
+	if containsDesktopString(f.GlobalTopics, tombstonedID) {
+		t.Fatalf("globalTopics = %#v, tombstoned topic must stay out", f.GlobalTopics)
+	}
+	if !containsDesktopString(f.GlobalTopics, repairID) {
+		t.Fatalf("globalTopics = %#v, want repaired topic %q", f.GlobalTopics, repairID)
+	}
+}
+
 func TestTopicMigrationDefersEmptyLegacySession(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -491,6 +491,112 @@ func TestTopicMigrationMarkerRescansWhenSessionFileChanges(t *testing.T) {
 	}
 }
 
+func TestProjectTreeRepairsIndexedGlobalTopicsAfterMigrationMarker(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := addProject(t.TempDir(), "Existing project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	sessionPath := writeLegacySession(t, dir, "desktop-legacy.jsonl", "who are you", time.Now().Add(-time.Hour))
+	topicID := "legacy_desktop-legacy_1234"
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		ID:         agent.BranchID(sessionPath),
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		UpdatedAt:  time.Now().Add(-time.Hour),
+		Scope:      "global",
+		TopicID:    topicID,
+		TopicTitle: "你是谁",
+		Turns:      1,
+		Preview:    "who are you",
+	}); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+	markTopicMigrationDone(dir)
+
+	repaired := migrateLegacySessionsIntoGlobalTopics(dir)
+	if len(repaired) != 1 || repaired[0] != topicID {
+		t.Fatalf("repaired topics = %#v, want %q", repaired, topicID)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	var global *ProjectNode
+	for i := range nodes {
+		if nodes[i].Kind == "global_folder" {
+			global = &nodes[i]
+			break
+		}
+	}
+	if global == nil {
+		t.Fatalf("project tree = %#v, want repaired Global folder", nodes)
+	}
+	if len(global.Children) != 1 || global.Children[0].TopicID != topicID || global.Children[0].Label != "你是谁" {
+		t.Fatalf("global children = %#v, want repaired topic %q with preserved title", global.Children, topicID)
+	}
+	f := loadProjectsFile()
+	if !containsDesktopString(f.GlobalTopics, topicID) {
+		t.Fatalf("globalTopics = %#v, want %q", f.GlobalTopics, topicID)
+	}
+	if got := loadTopicTitle("", topicID); got != "你是谁" {
+		t.Fatalf("global topic title = %q, want 你是谁", got)
+	}
+}
+
+func TestDeletedRepairedGlobalTopicIsNotAutoRestored(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := addProject(t.TempDir(), "Existing project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	sessionPath := writeLegacySession(t, dir, "desktop-delete.jsonl", "delete repaired topic", time.Now().Add(-time.Hour))
+	topicID := "legacy_desktop-delete_1234"
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		ID:         agent.BranchID(sessionPath),
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		UpdatedAt:  time.Now().Add(-time.Hour),
+		Scope:      "global",
+		TopicID:    topicID,
+		TopicTitle: "临时 Global",
+		Turns:      1,
+		Preview:    "delete repaired topic",
+	}); err != nil {
+		t.Fatalf("save meta: %v", err)
+	}
+	markTopicMigrationDone(dir)
+	if repaired := migrateLegacySessionsIntoGlobalTopics(dir); len(repaired) != 1 || repaired[0] != topicID {
+		t.Fatalf("initial repaired topics = %#v, want %q", repaired, topicID)
+	}
+	if err := NewApp().DeleteTopic(topicID); err != nil {
+		t.Fatalf("delete repaired topic: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	later := time.Now()
+	if err := os.Chtimes(sessionPath, later, later); err != nil {
+		t.Fatalf("touch session after delete: %v", err)
+	}
+	if repaired := migrateLegacySessionsIntoGlobalTopics(dir); len(repaired) != 0 {
+		t.Fatalf("deleted repaired topic was restored: %#v", repaired)
+	}
+	f := loadProjectsFile()
+	if containsDesktopString(f.GlobalTopics, topicID) {
+		t.Fatalf("globalTopics = %#v, deleted topic %q should stay removed", f.GlobalTopics, topicID)
+	}
+	if got := loadTopicTitle("", topicID); got != "" {
+		t.Fatalf("global topic title = %q, want deleted", got)
+	}
+	if !containsDesktopString(f.DeletedTopics, topicID) {
+		t.Fatalf("deletedTopics = %#v, want tombstone for %q", f.DeletedTopics, topicID)
+	}
+}
+
 func TestTopicMigrationDefersEmptyLegacySession(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -597,6 +597,117 @@ func TestDeletedRepairedGlobalTopicIsNotAutoRestored(t *testing.T) {
 	}
 }
 
+func TestRepairRescanKeepsIndexedTopicsUntouched(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	if err := addProject(t.TempDir(), "Existing project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	writeIndexedSession := func(name, topicID, title string, at time.Time) string {
+		p := writeLegacySession(t, dir, name, "prompt "+title, at)
+		if err := agent.SaveBranchMetaPreserveUpdated(p, agent.BranchMeta{
+			ID:         agent.BranchID(p),
+			CreatedAt:  at.Add(-time.Hour),
+			UpdatedAt:  at,
+			Scope:      "global",
+			TopicID:    topicID,
+			TopicTitle: title,
+			Turns:      1,
+			Preview:    "prompt " + title,
+		}); err != nil {
+			t.Fatalf("save meta %s: %v", name, err)
+		}
+		if err := os.Chtimes(p, at, at); err != nil {
+			t.Fatalf("chtimes %s: %v", name, err)
+		}
+		return p
+	}
+	now := time.Now()
+	olderPath := writeIndexedSession("older.jsonl", "legacy_older_000000000001", "旧话题", now.Add(-3*time.Hour))
+	writeIndexedSession("newer.jsonl", "legacy_newer_000000000002", "新话题", now.Add(-time.Hour))
+	markTopicMigrationDone(dir)
+
+	// First pass repairs both missing topics.
+	if repaired := migrateLegacySessionsIntoGlobalTopics(dir); len(repaired) != 2 {
+		t.Fatalf("initial repaired topics = %#v, want 2 entries", repaired)
+	}
+	before := loadProjectsFile()
+	projPath := filepath.Join(desktopConfigDir(), desktopProjectsFile)
+	statBefore, err := os.Stat(projPath)
+	if err != nil {
+		t.Fatalf("stat projects file: %v", err)
+	}
+
+	// Ordinary session activity invalidates the repair marker; the rescan must
+	// not reorder the indexed topics, rewrite the projects file, or report the
+	// already-visible topics as repaired (the callers bind blank Global tabs
+	// to repaired[0]).
+	time.Sleep(10 * time.Millisecond)
+	later := time.Now()
+	if err := os.Chtimes(olderPath, later, later); err != nil {
+		t.Fatalf("touch session: %v", err)
+	}
+	if repaired := migrateLegacySessionsIntoGlobalTopics(dir); len(repaired) != 0 {
+		t.Fatalf("steady-state rescan reported repairs: %#v", repaired)
+	}
+	after := loadProjectsFile()
+	if !sameStringList(before.GlobalTopics, after.GlobalTopics) {
+		t.Fatalf("rescan reordered globalTopics: before=%v after=%v", before.GlobalTopics, after.GlobalTopics)
+	}
+	statAfter, err := os.Stat(projPath)
+	if err != nil {
+		t.Fatalf("stat projects file: %v", err)
+	}
+	if !statAfter.ModTime().Equal(statBefore.ModTime()) {
+		t.Fatalf("steady-state rescan rewrote the projects file")
+	}
+}
+
+func TestBatchPrependRespectsTombstoneWrittenAfterScanSnapshot(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	topicID := "legacy_race_000000000001"
+	// Simulate a DeleteTopic landing between a repair scan's DeletedTopics
+	// snapshot and its batch write: the tombstone exists by the time the
+	// prepend runs, so the batch must drop the topic instead of resurrecting it.
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.DeletedTopics = prependUniqueString(f.DeletedTopics, topicID)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed tombstone: %v", err)
+	}
+	if err := prependTopicsInProjectsFile("", []string{topicID, "legacy_live_000000000002"}, false); err != nil {
+		t.Fatalf("batch prepend: %v", err)
+	}
+	f := loadProjectsFile()
+	if containsDesktopString(f.GlobalTopics, topicID) {
+		t.Fatalf("globalTopics = %#v, tombstoned topic %q must not be batch-prepended", f.GlobalTopics, topicID)
+	}
+	if !containsDesktopString(f.GlobalTopics, "legacy_live_000000000002") {
+		t.Fatalf("globalTopics = %#v, live topic should still be prepended", f.GlobalTopics)
+	}
+	if !containsDesktopString(f.DeletedTopics, topicID) {
+		t.Fatalf("deletedTopics = %#v, tombstone should survive a batch prepend", f.DeletedTopics)
+	}
+
+	// Intentional single-topic writes (create/restore/tab indexing) clear the
+	// tombstone and bring the topic back in the same projects-file transaction.
+	if err := prependTopicInProjectsFile("", topicID, false); err != nil {
+		t.Fatalf("single prepend: %v", err)
+	}
+	f = loadProjectsFile()
+	if !containsDesktopString(f.GlobalTopics, topicID) {
+		t.Fatalf("globalTopics = %#v, single prepend should restore %q", f.GlobalTopics, topicID)
+	}
+	if containsDesktopString(f.DeletedTopics, topicID) {
+		t.Fatalf("deletedTopics = %#v, single prepend should clear the tombstone", f.DeletedTopics)
+	}
+}
+
 func TestTopicMigrationDefersEmptyLegacySession(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()


### PR DESCRIPTION
## Summary
- repair desktop project-tree indexes for legacy Global sessions whose session metadata already has a topic ID but whose sidebar topic index is missing
- preserve explicit topic deletion by recording deleted topic tombstones so repaired Global topics do not reappear after the user removes them
- add regression coverage for the repaired Global topic path and the delete-does-not-resurrect behavior

## Root cause
Some upgraded desktop states can contain Global session metadata with `topic_id` and `topic_title` already set, while `desktop-projects.json` and the Global topic title index are missing the matching topic entries. The legacy migration skipped those sessions because they already had topic metadata, leaving the sidebar with no Global section when another project existed.

## Validation
- `go test . -run 'Test(ProjectTreeRepairsIndexedGlobalTopicsAfterMigrationMarker|DeletedRepairedGlobalTopicIsNotAutoRestored|RestoreGlobalTopicSessionReindexesProjectTree|RestoreProjectTopicSessionReindexesProjectTree|TrashTopicMovesRelatedSessionsToTrash|DeleteTopicKeepsSessionHistory)'`

Note: a full desktop package run currently hits an existing TempDir cleanup failure in `TestTurnDonePersistsSession`, unrelated to this topic-index change.
