### PR TITLE
fix(desktop): preserve conflicting trash sessions

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -5289,7 +5289,7 @@ func TestRestoreSessionRejectsOpenEmptyLiveStub(t *testing.T) {
 	}
 }
 
-func TestDeleteSessionValidTrashRejectsNonEmptyLive(t *testing.T) {
+func TestDeleteSessionValidTrashRenamesDifferentLiveConflict(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	dir := config.SessionDir()
@@ -5313,15 +5313,34 @@ func TestDeleteSessionValidTrashRejectsNonEmptyLive(t *testing.T) {
 	app := NewApp()
 	app.setTestCtrl(activeCtrl, "")
 
-	err := app.DeleteSession(filepath.Base(path))
-	if err == nil || !strings.Contains(err.Error(), "already exists in trash") {
-		t.Fatalf("DeleteSession conflict error = %v, want valid trash conflict", err)
+	if err := app.DeleteSession(filepath.Base(path)); err != nil {
+		t.Fatalf("DeleteSession should move different live session to a unique trash item: %v", err)
 	}
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("non-empty live session should remain: %v", err)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("live session should be moved out of active history, stat err = %v", err)
 	}
-	if _, err := os.Stat(trashPath); err != nil {
-		t.Fatalf("trash session should remain: %v", err)
+	if got, err := os.ReadFile(trashPath); err != nil || !strings.Contains(string(got), "trashed") {
+		t.Fatalf("original trash session should remain, got %q err=%v", string(got), err)
+	}
+	trashed, err := listTrashedSessionFiles(dir)
+	if err != nil {
+		t.Fatalf("list trash: %v", err)
+	}
+	var renamedPath string
+	for _, candidate := range trashed {
+		if candidate != trashPath && filepath.Base(candidate) == filepath.Base(path) {
+			renamedPath = candidate
+			break
+		}
+	}
+	if renamedPath == "" {
+		t.Fatalf("renamed trash copy not found in %#v", trashed)
+	}
+	if filepath.Base(filepath.Dir(renamedPath)) == filepath.Base(path) {
+		t.Fatalf("renamed trash copy reused fixed trash item dir: %s", renamedPath)
+	}
+	if got, err := os.ReadFile(renamedPath); err != nil || !strings.Contains(string(got), "new work") {
+		t.Fatalf("renamed trash session = %q err=%v, want live content", string(got), err)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -214,7 +214,30 @@ func reconcileDesktopTrashSessionArtifacts(dir, sessionPath, key string) error {
 	}
 	defer guard.Release()
 	itemDir := filepath.Join(sessionTrashPath(dir), key)
-	if err := os.MkdirAll(itemDir, 0o755); err != nil {
+	if info, err := os.Stat(itemDir); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("session trash target is not a directory: %s", key)
+		}
+		trashPath := filepath.Join(itemDir, key)
+		if trashInfo, err := os.Stat(trashPath); err == nil && !trashInfo.IsDir() {
+			matches, err := trashSessionMatchesLive(sessionPath, trashPath)
+			if err != nil {
+				return err
+			}
+			if !matches {
+				itemDir, err = reserveUniqueSessionTrashItemDir(dir, key)
+				if err != nil {
+					return err
+				}
+			}
+		} else if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	} else if os.IsNotExist(err) {
+		if err := os.MkdirAll(itemDir, 0o755); err != nil {
+			return err
+		}
+	} else {
 		return err
 	}
 	for _, artifact := range sessionTrashArtifacts(sessionPath, key) {
@@ -259,7 +282,10 @@ func validateSessionTrashTarget(dir, sessionPath, key string) error {
 			if removable {
 				return nil
 			}
-			return fmt.Errorf("session already exists in trash: %s", key)
+			if agent.SessionLeaseHeldByOtherRuntime(sessionPath) {
+				return errSessionBusyElsewhere
+			}
+			return nil
 		} else if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -270,37 +296,64 @@ func validateSessionTrashTarget(dir, sessionPath, key string) error {
 	return nil
 }
 
-func prepareSessionTrashTarget(dir, sessionPath, key string) (bool, error) {
+type preparedSessionTrashTarget struct {
+	shouldMove     bool
+	itemDir        string
+	allocateUnique bool
+}
+
+func prepareSessionTrashTarget(dir, sessionPath, key string) (preparedSessionTrashTarget, error) {
 	if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
-		return false, nil
+		return preparedSessionTrashTarget{}, nil
 	} else if err != nil {
-		return false, err
+		return preparedSessionTrashTarget{}, err
 	}
 	itemDir := filepath.Join(sessionTrashPath(dir), key)
 	if info, err := os.Stat(itemDir); err == nil {
 		if !info.IsDir() {
-			return false, fmt.Errorf("session trash target is not a directory: %s", key)
+			return preparedSessionTrashTarget{}, fmt.Errorf("session trash target is not a directory: %s", key)
 		}
 		trashPath := filepath.Join(itemDir, key)
 		if trashInfo, err := os.Stat(trashPath); err == nil && !trashInfo.IsDir() {
 			removable, err := liveSessionRemovableWithExistingTrash(sessionPath, trashPath)
 			if err != nil {
-				return false, err
+				return preparedSessionTrashTarget{}, err
 			}
 			if removable {
-				return false, removeDesktopSessionArtifacts(sessionPath)
+				return preparedSessionTrashTarget{}, removeDesktopSessionArtifacts(sessionPath)
 			}
-			return false, fmt.Errorf("session already exists in trash: %s", key)
+			if agent.SessionLeaseHeldByOtherRuntime(sessionPath) {
+				return preparedSessionTrashTarget{}, errSessionBusyElsewhere
+			}
+			return preparedSessionTrashTarget{shouldMove: true, allocateUnique: true}, nil
 		} else if err != nil && !os.IsNotExist(err) {
-			return false, err
+			return preparedSessionTrashTarget{}, err
 		}
 		if err := os.RemoveAll(itemDir); err != nil {
-			return false, err
+			return preparedSessionTrashTarget{}, err
 		}
 	} else if !os.IsNotExist(err) {
-		return false, err
+		return preparedSessionTrashTarget{}, err
 	}
-	return true, nil
+	return preparedSessionTrashTarget{shouldMove: true, itemDir: itemDir}, nil
+}
+
+func reserveUniqueSessionTrashItemDir(dir, key string) (string, error) {
+	root := sessionTrashPath(dir)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", err
+	}
+	stem := strings.TrimSuffix(key, ".jsonl")
+	for i := 0; i < 100; i++ {
+		name := fmt.Sprintf("%s.jsonl-deleted-%d-%02d", stem, time.Now().UnixNano(), i)
+		itemDir := filepath.Join(root, name)
+		if err := os.Mkdir(itemDir, 0o755); err == nil {
+			return itemDir, nil
+		} else if !os.IsExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("could not allocate unique trash target for session: %s", key)
 }
 
 // liveSessionRemovableWithExistingTrash reports whether a live session file may
@@ -383,11 +436,11 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 	if err := validateSessionTrashTarget(dir, sessionPath, key); err != nil {
 		return err
 	}
-	shouldMove, err := prepareSessionTrashTarget(dir, sessionPath, key)
+	target, err := prepareSessionTrashTarget(dir, sessionPath, key)
 	if err != nil {
 		return err
 	}
-	if !shouldMove {
+	if !target.shouldMove {
 		return nil
 	}
 	// Acquired after prepareSessionTrashTarget: the duplicate-trash path in
@@ -397,8 +450,13 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 		return err
 	}
 	defer guard.Release()
-	itemDir := filepath.Join(sessionTrashPath(dir), key)
-	if err := os.MkdirAll(itemDir, 0o755); err != nil {
+	itemDir := target.itemDir
+	if target.allocateUnique {
+		itemDir, err = reserveUniqueSessionTrashItemDir(dir, key)
+		if err != nil {
+			return err
+		}
+	} else if err := os.MkdirAll(itemDir, 0o755); err != nil {
 		return err
 	}
 	if beforeMove != nil {
@@ -443,17 +501,27 @@ func listTrashedSessionFiles(dir string) ([]string, error) {
 		if !e.IsDir() {
 			continue
 		}
-		key := e.Name()
-		if filepath.Ext(key) != ".jsonl" || filepath.Base(key) != key {
-			continue
+		itemDir := filepath.Join(root, e.Name())
+		keys := []string{}
+		if b, err := os.ReadFile(filepath.Join(itemDir, sessionTrashMetaFile)); err == nil {
+			var meta trashedSessionMeta
+			if json.Unmarshal(b, &meta) == nil && store.IsSessionTranscriptName(meta.Key) {
+				keys = append(keys, meta.Key)
+			}
 		}
-		path := filepath.Join(root, key, key)
-		validPath, _, _, err := validateTrashedSessionPath(dir, path)
-		if err != nil {
-			continue
+		if store.IsSessionTranscriptName(e.Name()) {
+			keys = append(keys, e.Name())
 		}
-		if info, err := os.Stat(validPath); err == nil && !info.IsDir() {
-			paths = append(paths, validPath)
+		for _, key := range keys {
+			path := filepath.Join(itemDir, key)
+			validPath, _, _, err := validateTrashedSessionPath(dir, path)
+			if err != nil {
+				continue
+			}
+			if info, err := os.Stat(validPath); err == nil && !info.IsDir() {
+				paths = append(paths, validPath)
+				break
+			}
 		}
 	}
 	return paths, nil
@@ -786,8 +854,18 @@ func validateTrashedSessionPath(dir, sessionPath string) (string, string, string
 		return "", "", "", fmt.Errorf("session path outside trash dir: %s", sessionPath)
 	}
 	parts := strings.Split(rel, string(filepath.Separator))
-	if len(parts) != 2 || parts[0] != parts[1] {
+	if len(parts) != 2 {
 		return "", "", "", fmt.Errorf("invalid trash session path: %s", sessionPath)
+	}
+	if parts[0] != parts[1] {
+		b, err := os.ReadFile(filepath.Join(root, parts[0], sessionTrashMetaFile))
+		if err != nil {
+			return "", "", "", fmt.Errorf("invalid trash session path: %s", sessionPath)
+		}
+		var meta trashedSessionMeta
+		if err := json.Unmarshal(b, &meta); err != nil || meta.Key != parts[1] {
+			return "", "", "", fmt.Errorf("invalid trash session path: %s", sessionPath)
+		}
 	}
 	if info, err := os.Lstat(absPath); err == nil {
 		if info.IsDir() {
@@ -1004,6 +1082,13 @@ func sessionDisplayKeyStillOwned(dir, key string, protected map[string]struct{})
 	trashPath := filepath.Join(sessionTrashPath(dir), key, key)
 	if info, err := os.Stat(trashPath); err == nil && !info.IsDir() {
 		return true
+	}
+	if paths, err := listTrashedSessionFiles(dir); err == nil {
+		for _, path := range paths {
+			if filepath.Base(path) == key {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/desktop/sessions_lease_guard_test.go
+++ b/desktop/sessions_lease_guard_test.go
@@ -81,7 +81,7 @@ func TestDeleteSessionKeepsDuplicateLiveSessionHeldByOtherRuntime(t *testing.T) 
 	}
 
 	err := app.DeleteSession(filepath.Base(path))
-	if err == nil || !strings.Contains(err.Error(), "session already exists in trash") {
+	if err == nil || !strings.Contains(err.Error(), errSessionBusyElsewhere.Error()) {
 		t.Fatalf("DeleteSession err = %v, want refusal while a foreign runtime holds the lease", err)
 	}
 	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != string(content) {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -579,6 +579,51 @@ func TestRestoreTrashedSessionFileWithEmptyLiveStub(t *testing.T) {
 	}
 }
 
+func TestRestoreTrashedSessionFileFromUniqueTrashItem(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "restore-unique.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"old"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("trash old: %v", err)
+	}
+	fixedTrashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(sessionPath), filepath.Base(sessionPath))
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"new"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write new live session: %v", err)
+	}
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("trash new with fixed trash conflict: %v", err)
+	}
+
+	trashed, err := listTrashedSessionFiles(dir)
+	if err != nil {
+		t.Fatalf("list trash: %v", err)
+	}
+	var uniqueTrashPath string
+	for _, candidate := range trashed {
+		if candidate != fixedTrashPath && filepath.Base(candidate) == filepath.Base(sessionPath) {
+			uniqueTrashPath = candidate
+			break
+		}
+	}
+	if uniqueTrashPath == "" {
+		t.Fatalf("unique trash path not listed, got %#v", trashed)
+	}
+	if err := restoreTrashedSessionFile(dir, uniqueTrashPath); err != nil {
+		t.Fatalf("restore unique trash item: %v", err)
+	}
+	if got, err := os.ReadFile(sessionPath); err != nil || !strings.Contains(string(got), "new") {
+		t.Fatalf("restored session = %q err=%v, want new content", string(got), err)
+	}
+	if _, err := os.Stat(filepath.Dir(uniqueTrashPath)); !os.IsNotExist(err) {
+		t.Fatalf("unique trash item should be removed after restore, stat err = %v", err)
+	}
+	if _, err := os.Stat(fixedTrashPath); err != nil {
+		t.Fatalf("original fixed trash item should remain: %v", err)
+	}
+}
+
 func TestValidateSessionTrashTargetKeepsDiscardableLiveStub(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "discardable-live.jsonl")


### PR DESCRIPTION
## Summary
- Move divergent live sessions into a unique trash item when the fixed `.trash/<key>/<key>` entry already exists.
- Keep the old fast paths for empty/duplicate live sessions, and continue refusing deletes while another runtime owns the session lease.
- Teach trash listing/path validation to resolve unique trash items through `.trash-meta.json` so restore and purge keep working.

## Root Cause
Recovery/session trash entries used the session basename as both the logical key and the storage item directory. When an older recovery copy was already in trash and the live recovery later diverged, delete refused with `session already exists in trash` to avoid overwriting either history.

## Validation
- `cd desktop && go test . -run 'TestDeleteSessionValidTrash(RenamesDifferentLiveConflict|RemovesEmptyLiveStub|RemovesDuplicateLiveSession)|TestDeleteSessionTrashConflictKeepsRuntime|TestDeleteSessionKeepsDuplicateLiveSessionHeldByOtherRuntime|TestRestoreSessionRejectsOpenEmptyLiveStub|TestRestoreTrashedSessionFileFromUniqueTrashItem' -v`
- `cd desktop && go test . -run 'TestReconcileDesktopCleanupPendingDelete(MovesArtifactsToTrash|ReusesExistingTrashDir|MovesRemainingSidecars)|TestDeleteSessionFile|TestValidateSessionTrashTargetKeepsDiscardableLiveStub|TestTrashPathsBlockedWhileLeaseHeld|TestRestoreTrashedSessionFile|TestPurgeTrashedSessionFile|TestListTrashedSessionFilesRejectsSymlinkEscape|TestTrashTopic' -v`
- `cd desktop && go test .`
