### PR TITLE
fix(npm): promote stable publishes to the latest dist-tag

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -6,16 +6,17 @@ name: Release npm
 # own tag lets a prerelease ship to npm's `next` channel without touching the
 # stable Homebrew cask (and lets a stable cask ship without forcing npm to leave
 # its rc). Bump with:
-#   git tag npm-vX.Y.Z          # stable  -> publishes under `next`
+#   git tag npm-vX.Y.Z          # stable  -> publishes under `latest`
 #   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
 #   git push origin <tag>
 #
 # A manual workflow_dispatch can publish either an opt-in canary from the current
 # ref or an approved stable/next version when tag creation is restricted. Canary
 # publishes to the `canary` dist-tag (npm i reasonix@canary) and never moves
-# `next`/`latest`. build.mjs decides the dist-tag: 0.x stable is `latest`; a
-# `-canary.` build is `canary`; the 1.x line and rc prereleases are `next`. Promote
-# a 1.x stable to the default install with `npm dist-tag add reasonix@X.Y.Z latest`.
+# `next`/`latest`. build.mjs decides the dist-tag: a `-canary.` build is `canary`,
+# any other prerelease is `next`, and a stable version is `latest` (#5822 — the
+# old "promote latest by hand" rule left it pinned at 0.53.2 and downgraded
+# `npm update -g` users). The verify step below asserts the tag actually landed.
 on:
   push:
     tags: ['npm-v*']
@@ -86,3 +87,28 @@ jobs:
       - run: node npm/build.mjs "${{ steps.ver.outputs.arg }}" --publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Assert the dist-tag landed where build.mjs aimed it. This is the guard
+      # that #5822 lacked: `latest` sat on 0.53.2 for months while stables went
+      # to `next`, and nothing noticed until users got downgraded. The registry
+      # applies tags asynchronously after publish, hence the poll.
+      - name: Verify dist-tags
+        run: |
+          set -euo pipefail
+          version="${{ steps.ver.outputs.arg }}"
+          version="${version#npm-}"; version="${version#v}"
+          case "$version" in
+            *-canary.*) tag=canary ;;
+            *-*)        tag=next ;;
+            *)          tag=latest ;;
+          esac
+          for attempt in 1 2 3 4 5 6; do
+            got="$(npm view reasonix dist-tags."$tag" 2>/dev/null || true)"
+            if [ "$got" = "$version" ]; then
+              echo "dist-tag $tag -> $got"
+              exit 0
+            fi
+            echo "dist-tag $tag -> ${got:-<unset>}, want $version (attempt $attempt)"
+            sleep 10
+          done
+          echo "::error::npm dist-tag '$tag' never landed on $version"
+          exit 1

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -100,16 +100,19 @@ if (!publish) {
   process.exit(0);
 }
 
-// Three independent dist-tags: 0.x stable is the promoted default (`latest`); a
-// `-canary.` build is the opt-in tester channel (`canary`); everything else — the
-// 1.x line and rc prereleases — ships under `next`. Only a `--tag canary` publish
-// moves canary, so `next`/`latest` users never resolve a canary. Promote a 1.x
-// stable to default with a manual `npm dist-tag add reasonix@<ver> latest`.
+// Three independent dist-tags: a `-canary.` build is the opt-in tester channel
+// (`canary`); any other prerelease (rc, beta) ships under `next`; a stable
+// version is promoted to `latest` automatically. The old "0.x stable owns
+// latest" rule was a migration guard while the 1.x Go line was rc-only — once
+// 1.x went stable it left `latest` pinned at 0.53.2, silently downgrading
+// every `npm update -g` / `pnpm update -g` user back to the retired line
+// (#5822). Stable now always moves `latest`; release-npm.yml verifies the tag
+// landed after publish.
 const distTag = version.includes("-canary.")
   ? "canary"
-  : version.startsWith("0.") && !version.includes("-")
-    ? "latest"
-    : "next";
+  : version.includes("-")
+    ? "next"
+    : "latest";
 const publishArgs = ["publish", "--access", "public", "--tag", distTag];
 
 for (const sub of subPackages) {


### PR DESCRIPTION
## Problem

`latest` on npm is still pinned at **0.53.2** while every 1.x release ships under `next`/`canary`:

```
latest  →  0.53.2
canary  →  1.8.0-canary.9
next    →  1.17.1-rc.1
```

Because `npm update -g` / `pnpm update -g` resolve the `latest` tag, every global update silently **downgrades** 1.x users to a months-old, different-architecture version (#5822). The documented escape hatch — a manual `npm dist-tag add` — has never been run; manual steps get forgotten.

## Changes

- **npm/build.mjs**: the "0.x stable owns latest" rule was a migration guard for while the 1.x line was rc-only; it is now inverted into a trap. New policy: `-canary.` → `canary`, any other prerelease → `next`, **stable → `latest`**, automatically.
- **release-npm.yml**: new *Verify dist-tags* step polls the registry after publish (tags apply asynchronously) and fails the release if the tag did not land — the guard #5822 lacked.

Verified the tag mapping: `1.17.1→latest`, `1.18.0-rc.1→next`, `1.18.0-canary.5→canary`.

## Remaining ops

The backlog needs one of: push `npm-v1.17.1` to publish the current stable (the final was never published to npm — only rc.1), or a one-off `npm dist-tag add reasonix@<current stable> latest`. After that, this workflow keeps `latest` honest on every future stable. Consider also `npm deprecate reasonix@"<1.0.0"` so remaining 0.x users get a heads-up.

Refs #5822