### PR TITLE
ci(release): smoke the public update paths after publishing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -412,6 +412,53 @@ jobs:
             aws s3api head-object --bucket "$R2_BUCKET" --key "$key" --endpoint-url "$ENDPOINT" >/dev/null
           done
 
+      # Best-effort probe of the release gateway — the updater's second
+      # manifest source — over the same public edge and Go client UA end users
+      # hit. A 403 here is the known Cloudflare bot-protection gap (#6005:
+      # datacenter/proxy egress gets blocked before the worker runs) and must
+      # not fail the release until a WAF skip rule for /v1/desktop/releases/*
+      # lands; it is surfaced as a warning so the run shows whether the edge
+      # is open. Anything else unexpected (404, 5xx, wrong version) means the
+      # gateway route or pointer regressed and fails hard.
+      - name: Probe public release gateway
+        if: env.HAS_R2 == 'true'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          CHANNEL: ${{ steps.ver.outputs.channel }}
+          PRERELEASE: ${{ steps.ver.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if [ "$PRERELEASE" = "true" ]; then
+            echo "prerelease — no pointer moved; skipping gateway probe"
+            exit 0
+          fi
+          chan="stable"
+          [ "$CHANNEL" = "canary" ] && chan="canary"
+          url="https://crash.reasonix.io/v1/desktop/releases/${chan}/latest.json"
+          # curl already prints 000 for a transport failure; || true keeps -e
+          # from killing the step so the case below can route it.
+          code="$(curl -sS -A "Go-http-client/2.0" -o /tmp/gateway-latest.json -w '%{http_code}' "$url" || true)"
+          case "$code" in
+            200)
+              if jq -e --arg version "$VERSION" '.version == $version' /tmp/gateway-latest.json >/dev/null; then
+                echo "gateway serves $VERSION on $chan"
+              else
+                echo "::error::gateway responded 200 but serves $(jq -r '.version // "<none>"' /tmp/gateway-latest.json), want $VERSION — stale or wrong pointer"
+                exit 1
+              fi
+              ;;
+            403)
+              echo "::warning::gateway returned 403 to CI egress — known bot-protection gap (#6005), not failing the release"
+              ;;
+            000|"")
+              echo "::warning::gateway unreachable from CI (transport error), not failing the release"
+              ;;
+            *)
+              echo "::error::gateway returned $code for $url — route or pointer regression"
+              exit 1
+              ;;
+          esac
+
       - name: Attach desktop manifest to matching CLI release
         if: env.HAS_R2 == 'true' && steps.ver.outputs.channel != 'canary' && steps.ver.outputs.prerelease != 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,40 @@ jobs:
               all(type == "string" and startswith("https://dl.reasonix.io/") and (contains("/releases/latest/") | not)))
           ' latest.json >/dev/null
           gh release upload "$TAG" latest.json --clobber
+
+      # The compatibility asset exists for pre-v1.16 desktop updaters that
+      # still poll GitHub's repository-wide latest URL — so verify it exactly
+      # the way those clients fetch it: anonymously, over the public edge, with
+      # a Go client UA. Unlike dl.reasonix.io (whose bot protection 403s
+      # Actions egress — see the R2 note above), GitHub serves its own runners,
+      # so this can hard-fail. #5826/#5858 shipped a broken update check for
+      # weeks precisely because nothing exercised the public path. Retries
+      # cover the release CDN propagating the freshly uploaded asset.
+      - name: Smoke public compatibility manifest
+        env:
+          TAG: ${{ github.ref_name }}
+          HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            *-*)
+              echo "prerelease $TAG — no compatibility asset uploaded; skipping"
+              exit 0
+              ;;
+          esac
+          if [ "$HAS_R2" != "true" ]; then
+            echo "R2 secrets not configured; no compatibility asset uploaded; skipping"
+            exit 0
+          fi
+          url="https://github.com/${{ github.repository }}/releases/latest/download/latest.json"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -fsSL -A "Go-http-client/2.0" -o /tmp/compat-latest.json "$url"; then
+              jq -e '(.version | type == "string") and (.platforms | type == "object")' /tmp/compat-latest.json >/dev/null
+              echo "public compatibility manifest OK (desktop version $(jq -r .version /tmp/compat-latest.json))"
+              exit 0
+            fi
+            echo "attempt $attempt failed; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::public compatibility manifest unreachable at $url"
+          exit 1


### PR DESCRIPTION
## Problem

The release smoke checks verify artifacts over the **authenticated** R2 S3 API (necessarily — dl.reasonix.io bot-blocks Actions egress), which means no release step ever exercises what end users' updaters actually reach. That blind spot is how #5826/#5858 (manifest 404) shipped broken for weeks, and why #6005 (gateway 403) was only visible in user reports.

## Changes

- **release.yml** — after uploading the desktop-manifest compatibility asset, fetch it back **anonymously with a Go client UA** via `releases/latest/download/latest.json`: the exact path pre-v1.16 updaters poll. GitHub serves its own runners (no bot wall), so this asserts hard; retries cover release-CDN propagation. Skips cleanly on prereleases / missing R2 secrets, mirroring the upload step's guards.
- **release-desktop.yml** — probe the release gateway (`crash.reasonix.io/v1/desktop/releases/<channel>/latest.json`) the same way:
  - `200` must serve exactly the just-released version (stale pointer ⇒ fail),
  - `403` is the known bot-protection gap (#6005) → `::warning` only, so releases aren't blocked until a WAF skip rule for that path lands — at which point this can be tightened to a hard assert,
  - `404`/`5xx`/transport anomalies ⇒ routing or pointer regression ⇒ fail.

Both workflows pass YAML validation; the probe handles curl's `000` transport-failure code explicitly.

Refs #5826, #5858, #6005