### PR TITLE
Continue on recovery path when pre-rebuild snapshot conflicts / 重建前快照冲突时沿恢复分支继续写入

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7011,6 +7011,25 @@ func userFacingSessionLeaseError(setting string, err error) error {
 	return err
 }
 
+// sessionPathAfterSnapshot returns where a controller rebuild should keep
+// persisting after the old controller was snapshotted. Snapshotting is not
+// path-neutral: a snapshot conflict can recover by retargeting the controller
+// (and the tab's session lease, via handleTabSessionRecovered) to a recovery
+// branch, so a prevPath captured before the snapshot may be stale. Reusing the
+// stale path would bind the rebuilt controller — carrying the just-recovered
+// transcript — back to the original file, turning every later save into a new
+// conflict that derives yet another recovery branch. Falls back to fallback
+// when the controller is gone or persistence is disabled (empty SessionPath).
+func sessionPathAfterSnapshot(ctrl control.SessionAPI, fallback string) string {
+	if ctrl == nil {
+		return fallback
+	}
+	if path := strings.TrimSpace(ctrl.SessionPath()); path != "" {
+		return path
+	}
+	return fallback
+}
+
 func (a *App) ensureTabSessionLeaseForRebuild(tab *WorkspaceTab, path, setting string) error {
 	if err := tab.ensureSessionLease(path); err != nil {
 		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
@@ -7150,6 +7169,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		if err := a.snapshotTabForAction(tab, "changing model"); err != nil {
 			return err
 		}
+		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
 		carried = oldCtrl.History()
 	}
 
@@ -7308,6 +7328,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		if err := a.snapshotTabForAction(tab, "changing effort"); err != nil {
 			return err
 		}
+		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
 		carried = oldCtrl.History()
 	}
 	sharedHost := a.lookupSharedHost(snap.sharedHostKey)
@@ -7434,6 +7455,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		if err := a.snapshotTabForAction(tab, "changing token mode"); err != nil {
 			return err
 		}
+		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
 		carried = oldCtrl.History()
 	}
 	sharedHost := a.lookupSharedHost(snap.sharedHostKey)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -111,6 +111,19 @@ func isolateDesktopUserDirs(t *testing.T) string {
 	return home
 }
 
+func primarySessionFiles(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, ".jsonl") &&
+			!strings.HasSuffix(base, ".events.jsonl") &&
+			!strings.HasSuffix(base, ".guardian.jsonl") {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
 func setDesktopTestCredential(t *testing.T, key, value string) {
 	t.Helper()
 	if _, err := config.SetCredential(key, value); err != nil {
@@ -2705,6 +2718,108 @@ func TestSetModelForTabRefreshesCarriedSystemPrompt(t *testing.T) {
 	}
 	if history[1].Role != provider.RoleUser || history[1].Content != "hello" {
 		t.Fatalf("carried user message changed: %+v", history[1])
+	}
+}
+
+func TestSetModelForTabContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "NEW_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old", "new"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+		{Name: "new", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "new-model", APIKeyEnv: "NEW_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	originalPath := filepath.Join(dir, "model-switch-conflict.jsonl")
+	current := agent.NewSession("old system prompt")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(originalPath); err != nil {
+		t.Fatalf("save current session: %v", err)
+	}
+
+	stale := agent.NewSession("old system prompt")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	oldExec := agent.New(nil, nil, stale, agent.Options{}, event.Discard)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.runtimeEvents.emit = func(context.Context, string, ...interface{}) {}
+	tab := &WorkspaceTab{
+		ID:          "tab_recovery_model",
+		Scope:       "global",
+		SessionPath: originalPath,
+		Ready:       true,
+		model:       "old/old-model",
+		disabledMCP: map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	oldCtrl := control.New(control.Options{
+		Executor:            oldExec,
+		SessionDir:          dir,
+		SessionPath:         originalPath,
+		Label:               "old",
+		Sink:                tab.sink,
+		SessionRecoveryMeta: app.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
+	})
+	tab.Ctrl = oldCtrl
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.SetModelForTab(tab.ID, "new/new-model"); err != nil {
+		t.Fatalf("SetModelForTab: %v", err)
+	}
+	recoveryPath := tab.Ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("model switch session path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
+	}
+	if got := tab.currentSessionPath(); got != recoveryPath {
+		t.Fatalf("tab current session path = %q, want recovery path %q", got, recoveryPath)
+	}
+	if tab.sessionLease == nil || sessionRuntimeKey(tab.sessionLease.Path()) != sessionRuntimeKey(recoveryPath) {
+		t.Fatalf("tab lease path = %q, want recovery path %q", tab.sessionLeaseRuntimeKey(), recoveryPath)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after model switch = %v, want only %q", matches, recoveryPath)
+	}
+	if err := tab.Ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot after model switch recovery: %v", err)
+	}
+	matches, err = filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches after snapshot: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", matches, recoveryPath)
 	}
 }
 

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1538,6 +1538,7 @@ func (a *App) rebuildSettingLocked(setting string) error {
 		if err := a.snapshotTabForAction(tab, "rebuilding settings"); err != nil {
 			return err
 		}
+		prevPath = sessionPathAfterSnapshot(oldCtrl, prevPath)
 		carried = oldCtrl.History()
 	}
 	snap := a.tabRuntimeSnapshot(tab)

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -98,7 +98,7 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 			return behavior(ctx, sink, input, p)
 		},
 	}
-	opts := control.Options{Runner: runner, Sink: p.Sink, SessionDir: f.dir}
+	opts := control.Options{Runner: runner, Sink: p.Sink, SessionDir: f.dir, OnSessionRecovered: p.OnSessionRecovered}
 	if f.withHooks {
 		opts.Hooks = f.hookRunner()
 	}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -170,8 +170,12 @@ type acpSession struct {
 	deleted bool
 	// lease is the session lease guarding transcript against other runtimes
 	// (a desktop window, the CLI) for the life of this session. Held from
-	// session/new / session/load and released on close/delete/teardown; config
-	// rebuilds keep the same transcript, so the lease never moves.
+	// session/new / session/load and released on close/delete/teardown. Config
+	// rebuilds normally keep the same transcript; when the pre-rebuild
+	// snapshot conflicts and retargets the controller to a recovery branch,
+	// the lease keeps guarding the original transcript (the recovery file was
+	// just created by this process — following it needs OnSessionRecovered
+	// wiring, tracked as a follow-up).
 	lease *agent.SessionLease
 	// maintenanceDone is non-nil while session-owned maintenance, such as an
 	// idle config rebuild, is in flight outside mu.
@@ -766,7 +770,6 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	sess.pendingConfig = nil
 
 	cur := sess.ctrl
-	prevPath := cur.SessionPath()
 	sink := sess.sink
 	mcpServers := clonePluginSpecs(sess.mcpServers)
 	cwd := sess.cwd
@@ -783,6 +786,12 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	if err := cur.Snapshot(); err != nil {
 		return &RPCError{Code: ErrInternal, Message: "session config: snapshot before switch: " + err.Error()}
 	}
+	// Capture the adopt path and history only after Snapshot: a snapshot
+	// conflict can retarget cur to a recovery branch (or adopt the newer disk
+	// transcript), and a pre-snapshot capture would bind the rebuilt controller
+	// back to the original file, re-conflicting on every later save.
+	// SessionPath is controller-locked, so reading it off sess.mu is safe.
+	prevPath := cur.SessionPath()
 	carried := cur.History()
 
 	newCtrl, err := s.factory.NewSession(ctx, SessionParams{

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -350,6 +350,33 @@ func (s *service) sessionRecoveredHandler(id string) func(control.SessionRecover
 			old.Release()
 		}
 		_ = saveACPMeta(recoveryPath, meta)
+		// Leave a redirect on the id-keyed sidecar so restart-time lookups
+		// (session/load, session/resume, session/delete, loadMeta) resolve the
+		// id to the recovery file; without it the next process reopens the
+		// pre-recovery transcript. Always written against the id-keyed path,
+		// so resolution stays a single hop even for recovery-of-recovery.
+		if dir := s.sessionDir(); dir != "" {
+			if idPath := transcriptPath(dir, id); idPath != recoveryPath {
+				idMeta, _, err := loadACPMeta(idPath)
+				if err != nil {
+					slog.Warn("acp: load id-keyed meta for recovery redirect", "err", err)
+					idMeta = acpSessionMeta{}
+				}
+				if idMeta.SessionID == "" {
+					idMeta.SessionID = id
+				}
+				if idMeta.Cwd == "" {
+					idMeta.Cwd = meta.Cwd
+				}
+				if idMeta.CreatedAt.IsZero() {
+					idMeta.CreatedAt = meta.CreatedAt
+				}
+				idMeta.ActiveTranscript = filepath.Base(recoveryPath)
+				if err := saveACPMeta(idPath, idMeta); err != nil {
+					slog.Warn("acp: save recovery redirect", "err", err)
+				}
+			}
+		}
 		return nil
 	}
 }
@@ -549,7 +576,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	var saved acpSessionMeta
 	persistedPath := ""
 	if dir := s.sessionDir(); dir != "" {
-		persistedPath = transcriptPath(dir, id)
+		persistedPath = resolveTranscriptPath(dir, id)
 		if agent.IsCleanupPending(persistedPath) {
 			return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
 		}
@@ -593,7 +620,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		ctrl.Close()
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": persistence is disabled"}
 	}
-	path := transcriptPath(dir, id)
+	path := resolveTranscriptPath(dir, id)
 	if path != persistedPath && agent.IsCleanupPending(path) {
 		ctrl.Close()
 		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
@@ -652,6 +679,38 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 // chat/run session files (those are addressed by a picker, not by id).
 func transcriptPath(dir, id string) string {
 	return filepath.Join(dir, id+".jsonl")
+}
+
+// resolveTranscriptPath returns the transcript file session id currently
+// lives in. That is the id-keyed path by default; after a snapshot recovery
+// moved the live session onto a recovery branch, the id-keyed sidecar carries
+// an ActiveTranscript redirect (written by sessionRecoveredHandler) that
+// load/resume/delete/meta lookups must follow, or a restart silently reopens
+// the pre-recovery transcript. The redirect is a basename, must stay inside
+// dir, and its target must exist and claim the same session id; anything else
+// falls back to the id-keyed path.
+func resolveTranscriptPath(dir, id string) string {
+	path := transcriptPath(dir, id)
+	meta, ok, err := loadACPMeta(path)
+	if err != nil || !ok {
+		return path
+	}
+	active := strings.TrimSpace(meta.ActiveTranscript)
+	if active == "" || active == filepath.Base(path) {
+		return path
+	}
+	if filepath.Base(active) != active {
+		return path
+	}
+	resolved := filepath.Join(dir, active)
+	if !sessionFileExists(resolved) {
+		return path
+	}
+	targetMeta, ok, err := loadACPMeta(resolved)
+	if err != nil || !ok || targetMeta.SessionID != id {
+		return path
+	}
+	return resolved
 }
 
 // sessionPrompt runs one turn. It flattens the prompt blocks to text and runs the
@@ -995,7 +1054,18 @@ func (s *service) sessionList(_ context.Context, raw json.RawMessage) (any, erro
 		if err != nil {
 			return nil, &RPCError{Code: ErrInternal, Message: "session/list: " + err.Error()}
 		}
+		// A recovered session has two sidecars claiming the same id: the
+		// active recovery transcript's own meta and the id-keyed redirect.
+		// Reduce to one representative per id before filtering, so the entry
+		// shown never carries the stale pre-recovery title/timestamps.
+		best := map[string]acpSessionMeta{}
 		for _, meta := range metas {
+			cur, ok := best[meta.SessionID]
+			if !ok || listMetaBeats(meta, cur) {
+				best[meta.SessionID] = meta
+			}
+		}
+		for _, meta := range best {
 			info := meta.info(nil)
 			if sessionInfoMatchesCwd(info, filterCwd) {
 				byID[info.SessionID] = info
@@ -1059,7 +1129,7 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 	}
 	if path == "" {
 		if dir := s.sessionDir(); dir != "" {
-			path = transcriptPath(dir, p.SessionID)
+			path = resolveTranscriptPath(dir, p.SessionID)
 		}
 	}
 	if path != "" && !delayed {
@@ -1068,6 +1138,17 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 		}
 		if destroy.Finish != nil {
 			destroy.Finish()
+		}
+	}
+	// A recovered session lives in two files: the recovery transcript (deleted
+	// above) and the id-keyed original holding the redirect. Remove the twin
+	// too, or it resurfaces in session/list as a ghost that delete-by-id can
+	// never reach again.
+	if dir := s.sessionDir(); dir != "" {
+		if idPath := transcriptPath(dir, p.SessionID); idPath != path {
+			if err := deleteSessionFiles(idPath); err != nil {
+				return nil, &RPCError{Code: ErrInternal, Message: "session/delete: " + err.Error()}
+			}
 		}
 	}
 	return SessionDeleteResult{}, nil
@@ -1250,7 +1331,7 @@ func (s *service) loadMeta(id string) (acpSessionMeta, bool) {
 	if dir == "" {
 		return acpSessionMeta{}, false
 	}
-	meta, ok, err := loadACPMeta(transcriptPath(dir, id))
+	meta, ok, err := loadACPMeta(resolveTranscriptPath(dir, id))
 	if err != nil {
 		return acpSessionMeta{}, false
 	}
@@ -1440,6 +1521,12 @@ type acpSessionMeta struct {
 	Title          string    `json:"title,omitempty"`
 	CreatedAt      time.Time `json:"createdAt"`
 	UpdatedAt      time.Time `json:"updatedAt"`
+	// ActiveTranscript, when set on the id-keyed sidecar, is the basename of
+	// the transcript this session currently lives in: a snapshot recovery
+	// moved the live session onto a recovery branch and left this redirect
+	// behind so restart-time lookups (resolveTranscriptPath) follow the
+	// session instead of reopening the pre-recovery file.
+	ActiveTranscript string `json:"activeTranscript,omitempty"`
 }
 
 func (m acpSessionMeta) info(extra map[string]any) SessionInfo {
@@ -1603,6 +1690,19 @@ func sessionIDFromTranscript(path string) string {
 		base = strings.TrimSuffix(base, ext)
 	}
 	return base
+}
+
+// listMetaBeats reports whether a should represent its session id in
+// session/list over b. A meta without an ActiveTranscript redirect is the
+// session's live transcript and always beats a redirect sidecar; between two
+// of the same kind the later UpdatedAt wins.
+func listMetaBeats(a, b acpSessionMeta) bool {
+	aRedirect := strings.TrimSpace(a.ActiveTranscript) != ""
+	bRedirect := strings.TrimSpace(b.ActiveTranscript) != ""
+	if aRedirect != bRedirect {
+		return !aRedirect
+	}
+	return a.UpdatedAt.After(b.UpdatedAt)
 }
 
 func sessionInfoMatchesCwd(info SessionInfo, filter string) bool {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -35,13 +35,16 @@ import (
 // Cwd roots the session's file tools and bash (built via builtin.Workspace).
 // Model and EffortOverride are optional session-local provider selectors from
 // ACP config options. MCPServers are the MCP servers the client asked the agent
-// to connect for this session.
+// to connect for this session. OnSessionRecovered is the service's bookkeeping
+// hook for automatic transcript recovery branches (see sessionRecoveredHandler);
+// factories must wire it into the controller they build.
 type SessionParams struct {
-	Cwd            string
-	MCPServers     []plugin.Spec
-	Sink           event.Sink
-	Model          string
-	EffortOverride *string
+	Cwd                string
+	MCPServers         []plugin.Spec
+	Sink               event.Sink
+	Model              string
+	EffortOverride     *string
+	OnSessionRecovered func(control.SessionRecoveryInfo) error
 }
 
 // Factory builds the per-session controller. The composition root (the cli's
@@ -170,12 +173,10 @@ type acpSession struct {
 	deleted bool
 	// lease is the session lease guarding transcript against other runtimes
 	// (a desktop window, the CLI) for the life of this session. Held from
-	// session/new / session/load and released on close/delete/teardown. Config
-	// rebuilds normally keep the same transcript; when the pre-rebuild
-	// snapshot conflicts and retargets the controller to a recovery branch,
-	// the lease keeps guarding the original transcript (the recovery file was
-	// just created by this process — following it needs OnSessionRecovered
-	// wiring, tracked as a follow-up).
+	// session/new / session/load and released on close/delete/teardown.
+	// Config rebuilds keep the same transcript; when a snapshot conflict
+	// retargets the controller to a recovery branch, sessionRecoveredHandler
+	// moves transcript and this lease to the recovery file at commit time.
 	lease *agent.SessionLease
 	// maintenanceDone is non-nil while session-owned maintenance, such as an
 	// idle config rebuild, is in flight outside mu.
@@ -306,6 +307,53 @@ func sessionLeaseBindError(method string, err error) *RPCError {
 	return &RPCError{Code: ErrInternal, Message: method + ": session lease: " + err.Error()}
 }
 
+// sessionRecoveredHandler returns the OnSessionRecovered callback wired into
+// every controller built for session id. When a snapshot conflict retargets
+// the controller to a recovery branch (turn-end autosave in persistAfterTurn,
+// or the pre-rebuild snapshot in rebuildSession), the ACP bookkeeping must
+// follow at commit time: session/prompt reports sess.transcript,
+// session/delete destroys it, and the session lease must guard the file the
+// controller actually writes. The recovery lease is acquired before the old
+// one is released so the outgoing transcript stays guarded until the new one
+// is secured; a failure aborts the recovery commit and the controller stays
+// on the original path (the next save retries).
+func (s *service) sessionRecoveredHandler(id string) func(control.SessionRecoveryInfo) error {
+	return func(info control.SessionRecoveryInfo) error {
+		recoveryPath := strings.TrimSpace(info.RecoveryPath)
+		if recoveryPath == "" {
+			return nil
+		}
+		sess := s.session(id)
+		if sess == nil {
+			return nil
+		}
+		lease, err := agent.TryAcquireSessionLease(recoveryPath)
+		if err != nil {
+			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				return fmt.Errorf("bind recovery session: %s; %s",
+					control.SessionInUseMessage(err), control.SessionLeaseCloseHint)
+			}
+			return fmt.Errorf("bind recovery session: %w", err)
+		}
+		sess.mu.Lock()
+		if sess.deleted {
+			sess.mu.Unlock()
+			lease.Release()
+			return fmt.Errorf("bind recovery session: session is deleted")
+		}
+		old := sess.lease
+		sess.lease = lease
+		sess.transcript = recoveryPath
+		meta := sess.metaLocked()
+		sess.mu.Unlock()
+		if old != nil {
+			old.Release()
+		}
+		_ = saveACPMeta(recoveryPath, meta)
+		return nil
+	}
+}
+
 // initialize advertises the agent's capability set: persisted load plus ACP v1
 // list/resume/close/delete lifecycle helpers, prompts carrying inline resource
 // text (embeddedContext) but not image/audio, and stdio / Streamable HTTP MCP
@@ -385,11 +433,12 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 
 	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:            cwd,
-		MCPServers:     mcpServers,
-		Sink:           sink,
-		Model:          cfgState.Model,
-		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
+		Cwd:                cwd,
+		MCPServers:         mcpServers,
+		Sink:               sink,
+		Model:              cfgState.Model,
+		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
+		OnSessionRecovered: s.sessionRecoveredHandler(id),
 	})
 	if err != nil {
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
@@ -525,11 +574,12 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 
 	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:            cwd,
-		MCPServers:     mcpServers,
-		Sink:           sink,
-		Model:          cfgState.Model,
-		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
+		Cwd:                cwd,
+		MCPServers:         mcpServers,
+		Sink:               sink,
+		Model:              cfgState.Model,
+		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
+		OnSessionRecovered: s.sessionRecoveredHandler(id),
 	})
 	if err != nil {
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
@@ -789,17 +839,21 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	// Capture the adopt path and history only after Snapshot: a snapshot
 	// conflict can retarget cur to a recovery branch (or adopt the newer disk
 	// transcript), and a pre-snapshot capture would bind the rebuilt controller
-	// back to the original file, re-conflicting on every later save.
+	// back to the original file, re-conflicting on every later save. When that
+	// recovery fired, sessionRecoveredHandler already moved sess.transcript
+	// and the session lease to the recovery file, so prevPath, the session
+	// bookkeeping, and the controller agree on one path here.
 	// SessionPath is controller-locked, so reading it off sess.mu is safe.
 	prevPath := cur.SessionPath()
 	carried := cur.History()
 
 	newCtrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:            cwd,
-		MCPServers:     mcpServers,
-		Sink:           sink,
-		Model:          cfgState.Model,
-		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
+		Cwd:                cwd,
+		MCPServers:         mcpServers,
+		Sink:               sink,
+		Model:              cfgState.Model,
+		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
+		OnSessionRecovered: s.sessionRecoveredHandler(sess.id),
 	})
 	if err != nil {
 		return &RPCError{Code: ErrInternal, Message: "session config: " + err.Error()}

--- a/internal/acp/switch_recovery_test.go
+++ b/internal/acp/switch_recovery_test.go
@@ -1,0 +1,89 @@
+package acp
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict is the ACP
+// twin of the desktop rebuild fix: when the pre-rebuild Snapshot hits a
+// conflict and retargets the old controller to a recovery branch, AdoptHistory
+// must bind the replacement controller to that recovery path. A pre-snapshot
+// capture bound the just-recovered transcript back to the original file, so
+// every later save re-conflicted and derived yet another recovery branch.
+func TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "acp-switch-conflict.jsonl")
+
+	disk := agent.NewSession("sys prompt")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := disk.Save(originalPath); err != nil {
+		t.Fatalf("save disk session: %v", err)
+	}
+
+	stale := agent.NewSession("sys prompt")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+
+	sink := newUpdateSink(&fakeNotifier{}, "sess-recovery")
+	sess := &acpSession{
+		id:    "sess-recovery",
+		sink:  sink,
+		cwd:   dir,
+		model: "fast",
+	}
+	oldCtrl := control.New(control.Options{
+		Executor:    agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:  dir,
+		SessionPath: originalPath,
+		Label:       "fast",
+	})
+	sess.ctrl = oldCtrl
+	svc := &service{
+		factory:  &configurableFactory{dir: dir},
+		sessions: map[string]*acpSession{sess.id: sess},
+	}
+
+	if err := svc.rebuildSession(context.Background(), sess, SessionConfigState{Model: "pro"}); err != nil {
+		t.Fatalf("rebuildSession: %v", err)
+	}
+	if sess.ctrl == oldCtrl {
+		t.Fatal("session controller was not replaced")
+	}
+
+	recoveryPath := sess.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("rebuilt session path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
+	}
+
+	// The rebuilt controller adopted the recovery file's baseline, so its next
+	// snapshot must not derive a second recovery branch.
+	if err := sess.ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot after rebuild: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches: %v", err)
+	}
+	primary := matches[:0]
+	for _, path := range matches {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, ".events.jsonl") || strings.HasSuffix(base, ".guardian.jsonl") {
+			continue
+		}
+		primary = append(primary, path)
+	}
+	if len(primary) != 1 || primary[0] != recoveryPath {
+		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", primary, recoveryPath)
+	}
+}

--- a/internal/acp/switch_recovery_test.go
+++ b/internal/acp/switch_recovery_test.go
@@ -2,6 +2,9 @@ package acp
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -196,5 +199,151 @@ func TestACPPersistAfterTurnMovesBookkeepingToRecoveryPath(t *testing.T) {
 	}
 	if primary := primaryRecoveryFiles(t, dir); len(primary) != 1 || primary[0] != recoveryPath {
 		t.Fatalf("recovery branches after second autosave = %v, want only %q", primary, recoveryPath)
+	}
+}
+
+// recoverACPSessionAndRestart drives an autosave recovery for session id in
+// dir, then simulates a process restart: the live session's lease is released,
+// its controller closed, and a fresh service (empty session registry, same
+// session dir) is returned alongside the original and recovery paths.
+func recoverACPSessionAndRestart(t *testing.T, dir, id string) (originalPath, recoveryPath string, restarted *service) {
+	t.Helper()
+	originalPath = transcriptPath(dir, id)
+	stale := divergedACPSession(t, originalPath)
+
+	svc := &service{
+		factory:  &configurableFactory{dir: dir},
+		sessions: map[string]*acpSession{},
+	}
+	sess := &acpSession{
+		id:         id,
+		sink:       newUpdateSink(&fakeNotifier{}, id),
+		cwd:        dir,
+		model:      "fast",
+		title:      "recovered title",
+		transcript: originalPath,
+	}
+	lease, err := agent.TryAcquireSessionLease(originalPath)
+	if err != nil {
+		t.Fatalf("acquire original session lease: %v", err)
+	}
+	sess.lease = lease
+	svc.sessions[id] = sess
+	ctrl := control.New(control.Options{
+		Executor:           agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:         dir,
+		SessionPath:        originalPath,
+		Label:              "fast",
+		OnSessionRecovered: svc.sessionRecoveredHandler(id),
+	})
+	sess.ctrl = ctrl
+
+	sess.persistAfterTurn("hello")
+	recoveryPath = ctrl.SessionPath()
+	assertACPSessionOnRecoveryPath(t, sess, originalPath, recoveryPath)
+
+	sess.releaseSessionLease()
+	ctrl.Close()
+	restarted = &service{
+		conn:     NewConn(strings.NewReader(""), io.Discard),
+		factory:  &configurableFactory{dir: dir},
+		sessions: map[string]*acpSession{},
+	}
+	return originalPath, recoveryPath, restarted
+}
+
+// TestACPLoadAfterRestartFollowsRecoveryTranscript covers the restart half of
+// the recovery move: session/load and session/resume resolve the session id to
+// the transcript the session actually lives in. Without the id-keyed redirect,
+// a restart reopened the pre-recovery file and the user's recovered work
+// silently vanished from ACP's view.
+func TestACPLoadAfterRestartFollowsRecoveryTranscript(t *testing.T) {
+	dir := t.TempDir()
+	id := "sess-restart"
+	originalPath, recoveryPath, svc := recoverACPSessionAndRestart(t, dir, id)
+
+	if _, err := svc.openExistingSession(context.Background(), "session/load", id, dir, nil, false); err != nil {
+		t.Fatalf("openExistingSession after restart: %v", err)
+	}
+	loaded := svc.session(id)
+	if loaded == nil {
+		t.Fatal("session not registered after load")
+	}
+	t.Cleanup(func() {
+		loaded.releaseSessionLease()
+		loaded.ctrl.Close()
+	})
+	assertACPSessionOnRecoveryPath(t, loaded, originalPath, recoveryPath)
+	if got := loaded.ctrl.SessionPath(); got != recoveryPath {
+		t.Fatalf("loaded controller session path = %q, want recovery path %q", got, recoveryPath)
+	}
+	// The test factory's controller has no executor, so prove the content via
+	// the transcript ACP now points at: it must hold the recovered local line,
+	// not the pre-recovery disk line.
+	resumed, err := agent.LoadSession(loaded.transcript)
+	if err != nil {
+		t.Fatalf("load resolved transcript: %v", err)
+	}
+	msgs := resumed.Snapshot()
+	if len(msgs) == 0 {
+		t.Fatal("resolved transcript is empty")
+	}
+	if got := msgs[len(msgs)-1].Content; got != "local second" {
+		t.Fatalf("resolved transcript last message = %q, want recovered local transcript (%q)", got, "local second")
+	}
+}
+
+// TestACPDeleteAfterRestartRemovesRecoveryAndIDKeyedFiles: session/delete on a
+// non-live recovered session must remove both the recovery transcript (the
+// session's live file) and the id-keyed original, or the survivor resurfaces
+// in session/list as a ghost that can never be deleted by id.
+func TestACPDeleteAfterRestartRemovesRecoveryAndIDKeyedFiles(t *testing.T) {
+	dir := t.TempDir()
+	id := "sess-del"
+	originalPath, recoveryPath, svc := recoverACPSessionAndRestart(t, dir, id)
+
+	raw, err := json.Marshal(SessionDeleteParams{SessionID: id})
+	if err != nil {
+		t.Fatalf("marshal delete params: %v", err)
+	}
+	if _, err := svc.sessionDelete(context.Background(), raw); err != nil {
+		t.Fatalf("sessionDelete after restart: %v", err)
+	}
+	for _, path := range []string{originalPath, recoveryPath, acpMetaPath(originalPath), acpMetaPath(recoveryPath)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s should be removed by session/delete, stat err = %v", path, err)
+		}
+	}
+	res, err := svc.sessionList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("sessionList after delete: %v", err)
+	}
+	if sessions := res.(SessionListResult).Sessions; len(sessions) != 0 {
+		t.Fatalf("session list after delete = %#v, want empty", sessions)
+	}
+}
+
+// TestACPSessionListAfterRecoveryShowsSingleActiveEntry: after a recovery the
+// id-keyed sidecar becomes a redirect, and session/list must present exactly
+// one entry for the id, backed by the active recovery transcript's metadata
+// (the live title), never the stale pre-recovery sidecar.
+func TestACPSessionListAfterRecoveryShowsSingleActiveEntry(t *testing.T) {
+	dir := t.TempDir()
+	id := "sess-list"
+	_, _, svc := recoverACPSessionAndRestart(t, dir, id)
+
+	res, err := svc.sessionList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("sessionList after recovery: %v", err)
+	}
+	sessions := res.(SessionListResult).Sessions
+	if len(sessions) != 1 {
+		t.Fatalf("session list after recovery = %#v, want exactly one entry", sessions)
+	}
+	if sessions[0].SessionID != id {
+		t.Fatalf("session list entry id = %q, want %q", sessions[0].SessionID, id)
+	}
+	if sessions[0].Title != "recovered title" {
+		t.Fatalf("session list entry title = %q, want the active transcript's title %q", sessions[0].Title, "recovered title")
 	}
 }

--- a/internal/acp/switch_recovery_test.go
+++ b/internal/acp/switch_recovery_test.go
@@ -12,21 +12,17 @@ import (
 	"reasonix/internal/provider"
 )
 
-// TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict is the ACP
-// twin of the desktop rebuild fix: when the pre-rebuild Snapshot hits a
-// conflict and retargets the old controller to a recovery branch, AdoptHistory
-// must bind the replacement controller to that recovery path. A pre-snapshot
-// capture bound the just-recovered transcript back to the original file, so
-// every later save re-conflicted and derived yet another recovery branch.
-func TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
-	dir := t.TempDir()
-	originalPath := filepath.Join(dir, "acp-switch-conflict.jsonl")
-
+// divergedACPSession writes a transcript to path whose on-disk content has
+// diverged from the returned in-memory session, so the next Snapshot on a
+// controller holding the stale session hits a conflict and retargets to a
+// recovery branch.
+func divergedACPSession(t *testing.T, path string) *agent.Session {
+	t.Helper()
 	disk := agent.NewSession("sys prompt")
 	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
 	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
 	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
-	if err := disk.Save(originalPath); err != nil {
+	if err := disk.Save(path); err != nil {
 		t.Fatalf("save disk session: %v", err)
 	}
 
@@ -34,43 +30,14 @@ func TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict(t *testing.
 	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
 	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
 	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	return stale
+}
 
-	sink := newUpdateSink(&fakeNotifier{}, "sess-recovery")
-	sess := &acpSession{
-		id:    "sess-recovery",
-		sink:  sink,
-		cwd:   dir,
-		model: "fast",
-	}
-	oldCtrl := control.New(control.Options{
-		Executor:    agent.New(nil, nil, stale, agent.Options{}, event.Discard),
-		SessionDir:  dir,
-		SessionPath: originalPath,
-		Label:       "fast",
-	})
-	sess.ctrl = oldCtrl
-	svc := &service{
-		factory:  &configurableFactory{dir: dir},
-		sessions: map[string]*acpSession{sess.id: sess},
-	}
-
-	if err := svc.rebuildSession(context.Background(), sess, SessionConfigState{Model: "pro"}); err != nil {
-		t.Fatalf("rebuildSession: %v", err)
-	}
-	if sess.ctrl == oldCtrl {
-		t.Fatal("session controller was not replaced")
-	}
-
-	recoveryPath := sess.ctrl.SessionPath()
-	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
-		t.Fatalf("rebuilt session path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
-	}
-
-	// The rebuilt controller adopted the recovery file's baseline, so its next
-	// snapshot must not derive a second recovery branch.
-	if err := sess.ctrl.Snapshot(); err != nil {
-		t.Fatalf("Snapshot after rebuild: %v", err)
-	}
+// primaryRecoveryFiles filters a recovery-branch glob down to primary session
+// transcripts, dropping the .events.jsonl / .guardian.jsonl sidecars that the
+// *-recovery-*.jsonl pattern also matches.
+func primaryRecoveryFiles(t *testing.T, dir string) []string {
+	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
 	if err != nil {
 		t.Fatalf("glob recovery branches: %v", err)
@@ -83,7 +50,151 @@ func TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict(t *testing.
 		}
 		primary = append(primary, path)
 	}
-	if len(primary) != 1 || primary[0] != recoveryPath {
+	return primary
+}
+
+func assertACPSessionOnRecoveryPath(t *testing.T, sess *acpSession, originalPath, recoveryPath string) {
+	t.Helper()
+	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
+	}
+	sess.mu.Lock()
+	transcript := sess.transcript
+	lease := sess.lease
+	sess.mu.Unlock()
+	if transcript != recoveryPath {
+		t.Fatalf("session transcript = %q, want recovery path %q", transcript, recoveryPath)
+	}
+	if lease == nil || lease.Path() != agent.CanonicalSessionPath(recoveryPath) {
+		got := ""
+		if lease != nil {
+			got = lease.Path()
+		}
+		t.Fatalf("session lease path = %q, want recovery path %q", got, recoveryPath)
+	}
+	// The original transcript's lease must have been released by the move so
+	// another runtime can bind it.
+	orig, err := agent.TryAcquireSessionLease(originalPath)
+	if err != nil {
+		t.Fatalf("original transcript lease should be free after recovery move: %v", err)
+	}
+	orig.Release()
+}
+
+// TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict is the ACP
+// twin of the desktop rebuild fix: when the pre-rebuild Snapshot hits a
+// conflict and retargets the old controller to a recovery branch, the session
+// bookkeeping must follow at commit time (sessionRecoveredHandler moves
+// sess.transcript and the lease), and AdoptHistory must bind the replacement
+// controller to that recovery path. A pre-snapshot capture bound the
+// just-recovered transcript back to the original file, so every later save
+// re-conflicted and derived yet another recovery branch.
+func TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "acp-switch-conflict.jsonl")
+	stale := divergedACPSession(t, originalPath)
+
+	sink := newUpdateSink(&fakeNotifier{}, "sess-recovery")
+	sess := &acpSession{
+		id:         "sess-recovery",
+		sink:       sink,
+		cwd:        dir,
+		model:      "fast",
+		transcript: originalPath,
+	}
+	lease, err := agent.TryAcquireSessionLease(originalPath)
+	if err != nil {
+		t.Fatalf("acquire original session lease: %v", err)
+	}
+	sess.lease = lease
+	t.Cleanup(sess.releaseSessionLease)
+
+	svc := &service{
+		factory:  &configurableFactory{dir: dir},
+		sessions: map[string]*acpSession{sess.id: sess},
+	}
+	oldCtrl := control.New(control.Options{
+		Executor:           agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:         dir,
+		SessionPath:        originalPath,
+		Label:              "fast",
+		OnSessionRecovered: svc.sessionRecoveredHandler(sess.id),
+	})
+	sess.ctrl = oldCtrl
+
+	if err := svc.rebuildSession(context.Background(), sess, SessionConfigState{Model: "pro"}); err != nil {
+		t.Fatalf("rebuildSession: %v", err)
+	}
+	if sess.ctrl == oldCtrl {
+		t.Fatal("session controller was not replaced")
+	}
+
+	recoveryPath := sess.ctrl.SessionPath()
+	assertACPSessionOnRecoveryPath(t, sess, originalPath, recoveryPath)
+
+	// The rebuilt controller adopted the recovery file's baseline, so its next
+	// snapshot must not derive a second recovery branch.
+	if err := sess.ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot after rebuild: %v", err)
+	}
+	if primary := primaryRecoveryFiles(t, dir); len(primary) != 1 || primary[0] != recoveryPath {
 		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", primary, recoveryPath)
+	}
+}
+
+// TestACPPersistAfterTurnMovesBookkeepingToRecoveryPath covers the autosave
+// path: a turn-end Snapshot in persistAfterTurn that recovers onto a recovery
+// branch must move sess.transcript and the session lease with the controller,
+// so session/prompt reports the live file, session/delete destroys it, and the
+// recovery transcript stays lease-guarded against other runtimes.
+func TestACPPersistAfterTurnMovesBookkeepingToRecoveryPath(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "acp-autosave-conflict.jsonl")
+	stale := divergedACPSession(t, originalPath)
+
+	sink := newUpdateSink(&fakeNotifier{}, "sess-autosave")
+	sess := &acpSession{
+		id:         "sess-autosave",
+		sink:       sink,
+		cwd:        dir,
+		model:      "fast",
+		transcript: originalPath,
+	}
+	lease, err := agent.TryAcquireSessionLease(originalPath)
+	if err != nil {
+		t.Fatalf("acquire original session lease: %v", err)
+	}
+	sess.lease = lease
+	t.Cleanup(sess.releaseSessionLease)
+
+	svc := &service{
+		factory:  &configurableFactory{dir: dir},
+		sessions: map[string]*acpSession{sess.id: sess},
+	}
+	ctrl := control.New(control.Options{
+		Executor:           agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:         dir,
+		SessionPath:        originalPath,
+		Label:              "fast",
+		OnSessionRecovered: svc.sessionRecoveredHandler(sess.id),
+	})
+	sess.ctrl = ctrl
+	t.Cleanup(ctrl.Close)
+
+	sess.persistAfterTurn("hello")
+
+	recoveryPath := ctrl.SessionPath()
+	assertACPSessionOnRecoveryPath(t, sess, originalPath, recoveryPath)
+	if primary := primaryRecoveryFiles(t, dir); len(primary) != 1 || primary[0] != recoveryPath {
+		t.Fatalf("recovery branches after autosave = %v, want only %q", primary, recoveryPath)
+	}
+	// The next turn-end autosave writes the recovery file the session now
+	// owns; it must not derive a second recovery branch.
+	sess.persistAfterTurn("again")
+	if got := ctrl.SessionPath(); got != recoveryPath {
+		t.Fatalf("controller session path after second autosave = %q, want %q", got, recoveryPath)
+	}
+	if primary := primaryRecoveryFiles(t, dir); len(primary) != 1 || primary[0] != recoveryPath {
+		t.Fatalf("recovery branches after second autosave = %v, want only %q", primary, recoveryPath)
 	}
 }

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -82,6 +82,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		WorkspaceRoot:            root,
 		ExtraPlugins:             p.MCPServers,
 		CleanupPendingReconciler: acp.ReconcileCleanupPending,
+		OnSessionRecovered:       p.OnSessionRecovered,
 	})
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1381,6 +1381,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.oldCtrl != nil {
 				m.oldControllers = append(m.oldControllers, msg.oldCtrl)
 			}
+			// The lease follows the controller's session file. Normally a
+			// no-op (a carried conversation keeps its file); it moves when
+			// the pre-switch snapshot recovered onto a recovery branch — a
+			// fresh file created by this process, so failure is theoretical.
+			m.followSessionLease()
 			m.notice(fmt.Sprintf(i18n.M.ModelSwitchedFmt, m.label))
 			cmds = append(cmds, fetchBalance(m.ctrl))
 			if c := m.runStatusline(); c != nil {

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -81,11 +81,15 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 		display = "auto"
 	}
 	m.notice(fmt.Sprintf("setting effort for %s to %s…", entry.Name, display))
-	carried := m.ctrl.History()
-	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {
 		m.notice("effort: snapshot: " + err.Error())
 	}
+	// Capture the resume path and history only after Snapshot: a snapshot
+	// conflict can retarget the controller to a recovery branch (or adopt the
+	// newer disk transcript), and a pre-snapshot capture would bind the rebuilt
+	// controller back to the original file, re-conflicting on every later save.
+	carried := m.ctrl.History()
+	prevPath := m.ctrl.SessionPath()
 	oldCtrl := m.ctrl
 	build := m.buildController
 	m.modelSwitchPending = true

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -37,11 +37,15 @@ func (m *chatTUI) runModelSubcommand(input string) {
 	// default. Mirrors the pattern used by /theme (persistTheme), /effort, and
 	// /language.
 	m.persistModel(ref)
-	carried := m.ctrl.History()
-	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {
 		m.notice("model: snapshot failed: " + err.Error())
 	}
+	// Capture the resume path and history only after Snapshot: a snapshot
+	// conflict can retarget the controller to a recovery branch (or adopt the
+	// newer disk transcript), and a pre-snapshot capture would bind the rebuilt
+	// controller back to the original file, re-conflicting on every later save.
+	carried := m.ctrl.History()
+	prevPath := m.ctrl.SessionPath()
 	m.notice(fmt.Sprintf(i18n.M.ModelSwitchingFmt, ref))
 
 	// Capture old controller for cleanup after the async build succeeds.

--- a/internal/cli/switch_recovery_test.go
+++ b/internal/cli/switch_recovery_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// divergedSessionController builds a controller whose in-memory transcript has
+// diverged from what path holds on disk, so its next Snapshot hits a conflict
+// and retargets the controller to a recovery branch.
+func divergedSessionController(t *testing.T, dir, path string) *control.Controller {
+	t.Helper()
+	disk := agent.NewSession("sys prompt")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := disk.Save(path); err != nil {
+		t.Fatalf("save disk session: %v", err)
+	}
+
+	stale := agent.NewSession("sys prompt")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	return control.New(control.Options{
+		Executor:    agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "deepseek-flash",
+	})
+}
+
+// TestModelSwitchCarriesRecoveryPathAfterSnapshotConflict is the TUI /model
+// twin of the desktop rebuild fix: when the pre-switch Snapshot retargets the
+// controller to a recovery branch, the resume path handed to buildController
+// must be that recovery path. A pre-snapshot capture bound the just-recovered
+// transcript back to the original file, re-conflicting on every later save.
+func TestModelSwitchCarriesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	isolateUserConfig(t)
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "model-switch-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, originalPath)
+	m.modelRef = "old/old-model"
+	var gotResumePath string
+	m.buildController = func(_ string, _ []provider.Message, resumePath string) (*control.Controller, error) {
+		gotResumePath = resumePath
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	m.runModelSubcommand("/model deepseek-flash/deepseek-v4-flash")
+	if m.pendingModelSwitch == nil {
+		t.Fatal("runModelSubcommand did not queue a model switch")
+	}
+	m.pendingModelSwitch()
+
+	if gotResumePath == "" || gotResumePath == originalPath || !strings.Contains(filepath.Base(gotResumePath), "-recovery-") {
+		t.Fatalf("resume path = %q, want recovery path distinct from %q", gotResumePath, originalPath)
+	}
+	if got := m.ctrl.SessionPath(); got != gotResumePath {
+		t.Fatalf("old controller session path = %q, want recovery path %q", got, gotResumePath)
+	}
+}
+
+// TestEffortSwitchCarriesRecoveryPathAfterSnapshotConflict covers the same
+// contract for the TUI /effort rebuild path.
+func TestEffortSwitchCarriesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	isolateUserConfig(t)
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "effort-switch-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, originalPath)
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+	var gotResumePath string
+	m.buildController = func(_ string, _ []provider.Message, resumePath string) (*control.Controller, error) {
+		gotResumePath = resumePath
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	cmd := m.runEffortCommand("/effort max")
+	if cmd == nil {
+		t.Fatal("runEffortCommand did not queue a rebuild")
+	}
+	cmd()
+
+	if gotResumePath == "" || gotResumePath == originalPath || !strings.Contains(filepath.Base(gotResumePath), "-recovery-") {
+		t.Fatalf("resume path = %q, want recovery path distinct from %q", gotResumePath, originalPath)
+	}
+	if got := m.ctrl.SessionPath(); got != gotResumePath {
+		t.Fatalf("old controller session path = %q, want recovery path %q", got, gotResumePath)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -175,13 +175,17 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	if cur.Running() {
 		return fmt.Errorf("cannot switch model while a turn is running")
 	}
-	prevPath := cur.SessionPath()
 
 	// Off-lock: snapshot, carry history, and build the replacement. None of these
 	// touch s.mu, so concurrent handlers keep reading the live controller.
 	if err := cur.Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before model switch", "err", err)
 	}
+	// Capture the continue path and history only after Snapshot: a snapshot
+	// conflict can retarget cur to a recovery branch (or adopt the newer disk
+	// transcript), and a pre-snapshot capture would bind the rebuilt controller
+	// back to the original file, re-conflicting on every later save.
+	prevPath := cur.SessionPath()
 	carried := cur.History()
 
 	newCtrl, err := s.build(ctx, ref)
@@ -207,13 +211,13 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.ctrl = newCtrl
 	s.mu.Unlock()
 
-	// A carried conversation keeps its file (newPath == prevPath) and the lease
-	// with it; only a previously file-less session gets a fresh path here, and
-	// the lease follows it (fresh path — failure is theoretical).
-	if newPath != prevPath {
-		if err := s.rebindSessionLease(newPath); err != nil {
-			slog.Warn("serve: session lease after model switch", "err", err)
-		}
+	// The lease follows the active session file. Rebind is a no-op for the
+	// common carried case (newPath == held path); it moves when a previously
+	// file-less session got a fresh path here, or when the pre-switch snapshot
+	// recovered onto a recovery branch. Both targets are fresh files created
+	// by this process, so failure is theoretical.
+	if err := s.rebindSessionLease(newPath); err != nil {
+		slog.Warn("serve: session lease after model switch", "err", err)
 	}
 
 	// Off-lock: tear down the old controller. Close can block up to 15s.

--- a/internal/serve/switch_recovery_test.go
+++ b/internal/serve/switch_recovery_test.go
@@ -1,0 +1,110 @@
+package serve
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// primarySessionFiles filters a recovery-branch glob down to primary session
+// transcripts, dropping the .events.jsonl / .guardian.jsonl sidecars that the
+// *-recovery-*.jsonl pattern also matches.
+func primarySessionFiles(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, ".jsonl") &&
+			!strings.HasSuffix(base, ".events.jsonl") &&
+			!strings.HasSuffix(base, ".guardian.jsonl") {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+// TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict is the serve twin
+// of the desktop rebuild fix: when the pre-switch Snapshot hits a conflict and
+// retargets the old controller to a recovery branch, the rebuilt controller
+// must continue on that recovery path. Capturing prevPath before Snapshot
+// bound the just-recovered transcript back to the original file, so every
+// later save re-conflicted and derived yet another recovery branch.
+func TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "switch-conflict.jsonl")
+
+	disk := agent.NewSession("sys prompt")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := disk.Save(originalPath); err != nil {
+		t.Fatalf("save disk session: %v", err)
+	}
+
+	stale := agent.NewSession("sys prompt")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+
+	bc := NewBroadcaster()
+	old := control.New(control.Options{
+		Executor:    agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:  dir,
+		SessionPath: originalPath,
+		Label:       "old",
+		Sink:        bc,
+	})
+	s := &Server{ctrl: old, bc: bc}
+
+	var built *control.Controller
+	s.buildController = func(_ context.Context, _ string) (*control.Controller, error) {
+		built = control.New(control.Options{
+			Executor:   agent.New(nil, nil, agent.NewSession("sys prompt"), agent.Options{}, event.Discard),
+			SessionDir: dir,
+			Label:      "new",
+			Sink:       bc,
+		})
+		return built, nil
+	}
+
+	if err := s.switchModel(context.Background(), "next-model"); err != nil {
+		t.Fatalf("switchModel: %v", err)
+	}
+
+	recoveryPath := built.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("switched session path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
+	}
+	if s.ctl() != built {
+		t.Fatal("switchModel did not publish the rebuilt controller")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after switch = %v, want only %q", matches, recoveryPath)
+	}
+
+	// The rebuilt controller adopted the recovery file's baseline, so its next
+	// snapshot must not derive a second recovery branch.
+	if err := built.Snapshot(); err != nil {
+		t.Fatalf("Snapshot after switch: %v", err)
+	}
+	matches, err = filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches after snapshot: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", matches, recoveryPath)
+	}
+}


### PR DESCRIPTION
## Problem

Every controller rebuild surface captured the session path **before** snapshotting the old controller:

- desktop: model / effort / token-mode / settings switches (`prevPath` cached before `snapshotTabForAction`)
- serve: `switchModel` (`prevPath := cur.SessionPath()` before `cur.Snapshot()`)
- CLI TUI: `/model` and `/effort` (`prevPath` before `m.ctrl.Snapshot()`)
- ACP: `rebuildSession` (`prevPath` captured inside the `sess.mu` critical section, before `Snapshot`)

A snapshot conflict can retarget the controller to a **recovery branch** (`recoverSnapshotConflict` rewrites `c.sessionPath`). With the stale pre-snapshot path, the rebuilt controller bound the just-recovered transcript back to the original file. Its baseline never matched that file again, so **every later save re-conflicted and derived yet another recovery branch** — the "recovery keeps popping up / recovery looks like it did nothing / recovery file cannot be deleted" loop reported from the Windows desktop build (switch model → write script → endless `session changed on disk ... saved as recovery branch`).

## Fix

**Commit 1 — capture the continue/resume/adopt path after `Snapshot()`** so a rebuild keeps writing whatever file the snapshot just committed to:

- `desktop/app.go` gains `sessionPathAfterSnapshot(ctrl, fallback)`; all four desktop rebuild paths re-read the old controller's path after the snapshot. The recovery callback already moves the tab lease, so the later `ensureTabSessionLeaseForRebuild(recovery path)` is a same-key no-op.
- serve / CLI / ACP move the `prevPath` + `History()` capture below the `Snapshot()` call. This also aligns `carried` across surfaces: after an `adoptDiskSession` recovery the rebuilt controller now carries the adopted transcript instead of the stale prefix.
- Lease follow-up on the single-session surfaces (rebased on #6034, now on latest `main-v2`): serve's `switchModel` now always rebinds the lease keeper to the final path (no-op when unchanged), and the TUI's model-switch handler calls `followSessionLease()`.

**Commit 2 — ACP session bookkeeping follows the recovery at commit time** (review finding: with commit 1 alone, `sess.transcript` and `sess.lease` stayed on the original file, so `session/prompt` reported a stale transcriptPath, `session/delete` destroyed the wrong file, and the live recovery transcript was written unleased):

- `control`'s `OnSessionRecovered` hook is wired through `SessionParams` and the acp factory into every controller the service builds — the same ownership pattern the desktop uses.
- `sessionRecoveredHandler` acquires the recovery lease **before** releasing the original (Rebind order), moves `sess.transcript`, and saves ACP meta against the recovery file; a lease failure aborts the recovery commit so the controller stays on the original path.
- This covers **both** recovery triggers: the turn-end autosave in `persistAfterTurn` and the pre-rebuild snapshot in `rebuildSession`.

**Commit 3 — ACP session ids resolve to the recovery transcript after restart** (review finding: with commit 2 alone, persisted lookups still treated `transcriptPath(dir, id)` as canonical, so a restart reopened the pre-recovery file, non-live `session/delete` removed the original while the recovery lingered as an undeletable orphan, and `session/list` could surface the stale sidecar):

- When a recovery commits, `sessionRecoveredHandler` leaves an `ActiveTranscript` redirect on the **id-keyed** sidecar — always written against the id-keyed path, so resolution stays a single hop even for recovery-of-recovery.
- `resolveTranscriptPath` follows the redirect only after validating it stays inside the session dir, exists, and claims the same session id; `session/load`, `session/resume`, `loadMeta`, and the non-live delete fallback all resolve through it.
- `session/delete` also removes the id-keyed twin, so neither file resurfaces in `session/list` as a ghost; the list reduces the two sidecars claiming one id to the active transcript's metadata.

## Regression tests

Each red without its fix (verified by reverting the production change / unwiring the handler):

| Surface | Test |
|---|---|
| desktop | `TestSetModelForTabContinuesRecoveryPathAfterSnapshotConflict` |
| serve | `TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict` |
| CLI `/model` | `TestModelSwitchCarriesRecoveryPathAfterSnapshotConflict` |
| CLI `/effort` | `TestEffortSwitchCarriesRecoveryPathAfterSnapshotConflict` |
| ACP rebuild | `TestACPRebuildSessionContinuesRecoveryPathAfterSnapshotConflict` (also asserts transcript + lease moved, original lease released) |
| ACP autosave | `TestACPPersistAfterTurnMovesBookkeepingToRecoveryPath` |
| ACP restart load | `TestACPLoadAfterRestartFollowsRecoveryTranscript` |
| ACP restart delete | `TestACPDeleteAfterRestartRemovesRecoveryAndIDKeyedFiles` |
| ACP list | `TestACPSessionListAfterRecoveryShowsSingleActiveEntry` |

Each asserts the controller lands on the recovery path **and** follow-up saves do not derive a second recovery branch (sidecar-filtered glob stays at exactly one).

## Verification

- `go test ./internal/serve ./internal/acp ./internal/cli` — ok
- `cd desktop && go test .` — ok (full suite)
- `go test -race` on the new tests plus the #6034 lease suites and the acp snapshot-lock tests — ok
- `gofmt` clean

## Remaining follow-up

serve and the CLI TUI keep their `SessionLeaseKeeper` on the original path when a **mid-session autosave** (not a rebuild) recovers — pre-existing shape, healed by the next path-changing action on those surfaces; tracked separately.

## 中文摘要

所有 controller 重建路径都在 snapshot **之前**缓存会话路径;快照冲突会把 controller 重定向到恢复分支,旧路径把"刚恢复的 transcript"重新绑回原文件,之后每次保存都再次冲突、再派生新的恢复分支——即 Windows 桌面端反馈的"反复出现恢复分支、恢复像没生效、恢复会话删不掉"死循环。

提交 1:统一把路径与携带历史的捕获移到 `Snapshot()` **之后**;桌面新增 `sessionPathAfterSnapshot` 供四条重建路径复用;serve/TUI 切换后跟随租约到最终路径。提交 2(评审发现):ACP 通过 `OnSessionRecovered` 接线,在恢复提交时同步移动 `sess.transcript` 与会话租约(先取新租约再释放旧租约),覆盖轮末自动保存与重建前快照两条触发路径,修复 `session/prompt` 返回过期路径、`session/delete` 删错文件、恢复文件无租约保护的问题。提交 3(第二轮评审发现):ACP 会话 id 在重启后经 id 键 sidecar 上的 `ActiveTranscript` 重定向解析到恢复文件——load/resume/loadMeta/delete 全部跟随,delete 同时清理 id 键孪生文件,list 归并为活跃 transcript 的元数据。九个回归测试,其中八个验证过"无修复必红"(list 测试守护新引入的重定向 sidecar 状态)。
