### PR TITLE
Avoid blocking metadata hydration on git branch probes / 避免 git 分支探测阻塞元信息刷新

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -217,6 +217,7 @@ func TestMetaForTabIncludesWorkspaceContext(t *testing.T) {
 		t.Skip("git not installed")
 	}
 	isolateDesktopUserDirs(t)
+	resetWorkspaceGitBranchMetaCacheForTest(t)
 
 	repo := t.TempDir()
 	configuredSandboxRoot := filepath.Join(t.TempDir(), "sandbox")
@@ -265,8 +266,15 @@ func TestMetaForTabIncludesWorkspaceContext(t *testing.T) {
 	if strings.Contains(string(raw), "sandboxPath") || strings.Contains(string(raw), configuredSandboxRoot) {
 		t.Fatalf("meta should not expose configured sandbox root as sandboxPath: %s", raw)
 	}
-	if got.GitBranch != "feature/meta" {
-		t.Fatalf("gitBranch = %q, want feature/meta", got.GitBranch)
+	deadline := time.Now().Add(time.Second)
+	for {
+		if got = app.MetaForTab("tab-1"); got.GitBranch == "feature/meta" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gitBranch = %q, want feature/meta after async refresh", got.GitBranch)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -30,14 +30,17 @@ type workspaceChangeAccumulator struct {
 const workspaceGitBranchCacheTTL = 2 * time.Second
 
 type workspaceGitBranchCacheEntry struct {
-	branch  string
-	expires time.Time
+	branch     string
+	expires    time.Time
+	refreshing bool
 }
 
 var workspaceGitBranchCache = struct {
 	sync.Mutex
 	entries map[string]workspaceGitBranchCacheEntry
 }{entries: map[string]workspaceGitBranchCacheEntry{}}
+
+var workspaceGitBranchForMetaProbe = workspaceGitBranch
 
 func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
 	out := WorkspaceChangesView{Files: []WorkspaceChangeView{}, GitAvailable: true}
@@ -245,19 +248,40 @@ func workspaceRelPathFromGitStatus(repoRoot, base, path string) string {
 }
 
 // workspaceGitBranchForMeta is the cached variant used by high-frequency UI
-// metadata refreshes. Workflows that need an immediate git read, such as
-// WorkspaceChanges, should call workspaceGitBranch directly.
+// metadata refreshes. It never waits for git on the caller path: stale branch
+// metadata is less harmful than blocking tab activation or hydration. Workflows
+// that need an immediate git read, such as WorkspaceChanges, should call
+// workspaceGitBranch directly.
 func workspaceGitBranchForMeta(base string) string {
 	key := filepath.Clean(base)
 	now := time.Now()
+
 	workspaceGitBranchCache.Lock()
-	if cached, ok := workspaceGitBranchCache.entries[key]; ok && now.Before(cached.expires) {
+	if cached, ok := workspaceGitBranchCache.entries[key]; ok {
+		branch := cached.branch
+		if now.Before(cached.expires) || cached.refreshing {
+			workspaceGitBranchCache.Unlock()
+			return branch
+		}
+		cached.refreshing = true
+		workspaceGitBranchCache.entries[key] = cached
 		workspaceGitBranchCache.Unlock()
-		return cached.branch
+		go refreshWorkspaceGitBranchForMeta(key, base)
+		return branch
+	}
+
+	workspaceGitBranchCache.entries[key] = workspaceGitBranchCacheEntry{
+		expires:    now.Add(workspaceGitBranchCacheTTL),
+		refreshing: true,
 	}
 	workspaceGitBranchCache.Unlock()
 
-	branch := workspaceGitBranch(base)
+	go refreshWorkspaceGitBranchForMeta(key, base)
+	return ""
+}
+
+func refreshWorkspaceGitBranchForMeta(key, base string) {
+	branch := workspaceGitBranchForMetaProbe(base)
 
 	storeNow := time.Now()
 	workspaceGitBranchCache.Lock()
@@ -270,7 +294,6 @@ func workspaceGitBranchForMeta(base string) string {
 	}
 	workspaceGitBranchCache.entries[key] = workspaceGitBranchCacheEntry{branch: branch, expires: storeNow.Add(workspaceGitBranchCacheTTL)}
 	workspaceGitBranchCache.Unlock()
-	return branch
 }
 
 // workspaceGitBranch returns the current git branch name for the repo rooted

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -281,19 +281,25 @@ func workspaceGitBranchForMeta(base string) string {
 }
 
 func refreshWorkspaceGitBranchForMeta(key, base string) {
-	branch := workspaceGitBranchForMetaProbe(base)
-
-	storeNow := time.Now()
-	workspaceGitBranchCache.Lock()
-	if len(workspaceGitBranchCache.entries) > 256 {
-		for k, cached := range workspaceGitBranchCache.entries {
-			if storeNow.After(cached.expires) {
-				delete(workspaceGitBranchCache.entries, k)
+	branch := ""
+	// Store via defer so the refreshing flag is always cleared, even when the
+	// probe panics or exits the goroutine early; otherwise the entry would stay
+	// marked refreshing forever and never update again.
+	defer func() {
+		storeNow := time.Now()
+		workspaceGitBranchCache.Lock()
+		if len(workspaceGitBranchCache.entries) > 256 {
+			for k, cached := range workspaceGitBranchCache.entries {
+				if storeNow.After(cached.expires) {
+					delete(workspaceGitBranchCache.entries, k)
+				}
 			}
 		}
-	}
-	workspaceGitBranchCache.entries[key] = workspaceGitBranchCacheEntry{branch: branch, expires: storeNow.Add(workspaceGitBranchCacheTTL)}
-	workspaceGitBranchCache.Unlock()
+		workspaceGitBranchCache.entries[key] = workspaceGitBranchCacheEntry{branch: branch, expires: storeNow.Add(workspaceGitBranchCacheTTL)}
+		workspaceGitBranchCache.Unlock()
+	}()
+
+	branch = workspaceGitBranchForMetaProbe(base)
 }
 
 // workspaceGitBranch returns the current git branch name for the repo rooted

--- a/desktop/workspace_changes_test.go
+++ b/desktop/workspace_changes_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"testing"
+	"time"
 )
 
 func TestWorkspaceGitDisablesDaemonSpawns(t *testing.T) {
@@ -113,4 +115,96 @@ func TestWorkspaceGitBranchNonGitDirectory(t *testing.T) {
 	if got := workspaceGitBranch(t.TempDir()); got != "" {
 		t.Fatalf("branch = %q, want empty", got)
 	}
+}
+
+func TestWorkspaceGitBranchForMetaDoesNotBlockOnColdProbe(t *testing.T) {
+	resetWorkspaceGitBranchMetaCacheForTest(t)
+	origProbe := workspaceGitBranchForMetaProbe
+	started := make(chan struct{})
+	release := make(chan struct{})
+	workspaceGitBranchForMetaProbe = func(string) string {
+		close(started)
+		<-release
+		return "feature/async"
+	}
+	defer func() {
+		close(release)
+		workspaceGitBranchForMetaProbe = origProbe
+	}()
+
+	start := time.Now()
+	if got := workspaceGitBranchForMeta("/tmp/reasonix-cold-probe"); got != "" {
+		t.Fatalf("cold branch = %q, want empty while async refresh runs", got)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("cold metadata branch probe blocked for %s", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("background branch refresh did not start")
+	}
+
+	close(release)
+	release = make(chan struct{})
+	eventuallyBranchForMeta(t, "/tmp/reasonix-cold-probe", "feature/async")
+}
+
+func TestWorkspaceGitBranchForMetaReturnsStaleDuringRefresh(t *testing.T) {
+	resetWorkspaceGitBranchMetaCacheForTest(t)
+	workspaceGitBranchCache.Lock()
+	workspaceGitBranchCache.entries[filepath.Clean("/tmp/reasonix-stale-probe")] = workspaceGitBranchCacheEntry{
+		branch:  "feature/stale",
+		expires: time.Now().Add(-time.Second),
+	}
+	workspaceGitBranchCache.Unlock()
+
+	origProbe := workspaceGitBranchForMetaProbe
+	started := make(chan struct{})
+	release := make(chan struct{})
+	workspaceGitBranchForMetaProbe = func(string) string {
+		close(started)
+		<-release
+		return "feature/fresh"
+	}
+	defer func() {
+		close(release)
+		workspaceGitBranchForMetaProbe = origProbe
+	}()
+
+	start := time.Now()
+	if got := workspaceGitBranchForMeta("/tmp/reasonix-stale-probe"); got != "feature/stale" {
+		t.Fatalf("stale branch = %q, want feature/stale", got)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("stale metadata branch probe blocked for %s", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("background branch refresh did not start")
+	}
+
+	close(release)
+	release = make(chan struct{})
+	eventuallyBranchForMeta(t, "/tmp/reasonix-stale-probe", "feature/fresh")
+}
+
+func resetWorkspaceGitBranchMetaCacheForTest(t *testing.T) {
+	t.Helper()
+	workspaceGitBranchCache.Lock()
+	workspaceGitBranchCache.entries = map[string]workspaceGitBranchCacheEntry{}
+	workspaceGitBranchCache.Unlock()
+}
+
+func eventuallyBranchForMeta(t *testing.T, base, want string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := workspaceGitBranchForMeta(base); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("branch did not refresh to %q", want)
 }

--- a/desktop/workspace_changes_test.go
+++ b/desktop/workspace_changes_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 )
@@ -122,13 +123,15 @@ func TestWorkspaceGitBranchForMetaDoesNotBlockOnColdProbe(t *testing.T) {
 	origProbe := workspaceGitBranchForMetaProbe
 	started := make(chan struct{})
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProbe := func() { releaseOnce.Do(func() { close(release) }) }
 	workspaceGitBranchForMetaProbe = func(string) string {
 		close(started)
 		<-release
 		return "feature/async"
 	}
 	defer func() {
-		close(release)
+		releaseProbe()
 		workspaceGitBranchForMetaProbe = origProbe
 	}()
 
@@ -145,8 +148,7 @@ func TestWorkspaceGitBranchForMetaDoesNotBlockOnColdProbe(t *testing.T) {
 		t.Fatal("background branch refresh did not start")
 	}
 
-	close(release)
-	release = make(chan struct{})
+	releaseProbe()
 	eventuallyBranchForMeta(t, "/tmp/reasonix-cold-probe", "feature/async")
 }
 
@@ -162,13 +164,15 @@ func TestWorkspaceGitBranchForMetaReturnsStaleDuringRefresh(t *testing.T) {
 	origProbe := workspaceGitBranchForMetaProbe
 	started := make(chan struct{})
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProbe := func() { releaseOnce.Do(func() { close(release) }) }
 	workspaceGitBranchForMetaProbe = func(string) string {
 		close(started)
 		<-release
 		return "feature/fresh"
 	}
 	defer func() {
-		close(release)
+		releaseProbe()
 		workspaceGitBranchForMetaProbe = origProbe
 	}()
 
@@ -185,8 +189,7 @@ func TestWorkspaceGitBranchForMetaReturnsStaleDuringRefresh(t *testing.T) {
 		t.Fatal("background branch refresh did not start")
 	}
 
-	close(release)
-	release = make(chan struct{})
+	releaseProbe()
 	eventuallyBranchForMeta(t, "/tmp/reasonix-stale-probe", "feature/fresh")
 }
 


### PR DESCRIPTION
## Summary
- Make the desktop metadata git-branch helper return cached or stale branch data immediately instead of waiting for git on the hydration path.
- Refresh expired or missing git branch metadata in the background, while keeping WorkspaceChanges on the synchronous fresh git path.
- Update MetaForTab and workspace branch-cache tests for the async metadata contract.

## Context
This addresses one likely contributor to #5909 where `tab.hydrate meta` can take around 2s during topic activation. The PR does not close the issue because the thread contains multiple performance-lag shapes.

## Tests
- `cd desktop && go test . -count=1 -run '^(TestMetaForTabIncludesWorkspaceContext|TestWorkspaceGitBranch|TestWorkspaceGitBranchForMeta|TestWorkspaceGitDisablesDaemonSpawns)'`
- `git diff --check`
- `cd desktop && go test ./...`