### PR TITLE
test: Assert stale hydrate metadata is ignored

### DIFF
--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -577,6 +577,8 @@ await act(async () => {
   await metaH.promise;
   await flushPromises();
 });
+eq(controller?.activeTabId, "tab-g", "late meta from a replaced tab does not switch the visible tab");
+ok(controller?.state.meta?.label !== "stale-model-tab-h", "late meta from a replaced tab does not overwrite visible metadata");
 historyH = deferred<HistoryMessage[]>();
 holdNextHistoryForH = true;
 await act(async () => {


### PR DESCRIPTION
## Summary

- Add explicit regression assertions that late `MetaForTab` results from a replaced tab do not switch the visible tab or overwrite visible metadata.
- Strengthen the hydrate performance regression coverage related to #5909 after the main hydrate decoupling work already landed on `main-v2`.

## Verification

- `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- `corepack pnpm --dir desktop/frontend exec tsc --noEmit`
- `corepack pnpm --dir desktop/frontend exec tsc --noEmit -p tsconfig.test.json`
- `git diff --check origin/main-v2..HEAD`

## Cache impact

Cache-impact: none, frontend-only test coverage for hydrate state handling.
Cache-guard: `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/tab-switch-hydration.test.tsx`
System-prompt-review: N/A