### PR TITLE
feat(cli): configure Reasonix terminal title / 配置 Reasonix 终端标题

### DIFF
--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -131,6 +131,7 @@ func (m *chatTUI) replayActiveBranch(title string) {
 	m.planMode = false
 	m.ctrl.SetPlanMode(false)
 	m.sessionSwitch = true
+	m.syncWindowTitle()
 
 	// Discard the previous session's transcript so the viewport only shows the
 	// newly loaded session. Without this the transcript accumulates across

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -105,6 +105,11 @@ type chatTUI struct {
 	// yoloRestoreToolApprovalMode remembers the Ask/Auto base mode that Ctrl+Y
 	// should restore after a desktop-style YOLO toggle.
 	yoloRestoreToolApprovalMode string
+	// terminalTitleItems controls which live session fields are mirrored into
+	// terminals that support OSC window/tab titles.
+	terminalTitleItems []string
+	// windowTitle is the latest rendered terminal title.
+	windowTitle string
 
 	// pendingInterject queues input typed while a turn runs; each TurnDone
 	// dequeues the front and submits it as the next turn.
@@ -344,6 +349,8 @@ type chatTUI struct {
 
 	// completion is the live autocomplete menu (slash commands; @-refs later).
 	completion completion
+	// titlePick is the modal /title manager for terminal title items.
+	titlePick *titlePicker
 	// fileSearchCache memoizes fileref.Search by query so the bounded walk runs
 	// once per @token fragment, not on every keystroke that re-renders the menu.
 	fileSearchCache map[string][]string
@@ -535,10 +542,11 @@ func newChatTUI(ctrl control.SessionAPI, missing string, eventCh chan event.Even
 	commitBuf := []string{}
 	nativeScrollback := detectTermuxTerminal()
 	renderW := transcriptContentWidth(termW, nativeScrollback)
-	return chatTUI{
+	m := chatTUI{
 		ctrl:                 ctrl,
 		label:                ctrl.Label(),
 		missing:              missing,
+		terminalTitleItems:   config.DefaultTerminalTitleItems(),
 		nativeScrollback:     nativeScrollback,
 		mouseCaptureOff:      mouseCaptureOffByDefault(),
 		input:                ti,
@@ -568,6 +576,8 @@ func newChatTUI(ctrl control.SessionAPI, missing string, eventCh chan event.Even
 		viewport:             viewport.New(viewport.WithWidth(termW)),
 		statusLineCount:      2,
 	}
+	m.syncWindowTitle()
+	return m
 }
 
 func transcriptContentWidth(termW int, nativeScrollback bool) int {
@@ -770,6 +780,7 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// height for the viewport. Use cm.width (same as boxW in View()) so the
 	// wrapping width matches what View() actually renders.
 	cm.statusLineCount = cm.computeStatusLineCount(cm.width)
+	cm.syncWindowTitle()
 	cm.viewport.SetHeight(cm.transcriptHeight())
 	// Re-feed only when the content grew or the width changed (re-wrapping is
 	// the expensive part); a bare scroll or spinner tick keeps the offset.
@@ -985,7 +996,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, finalize(m, cmds)
 		}
-		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
+		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.titlePick == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
 			m.growInputToFit()
 			m.updateCompletion()
@@ -1119,6 +1130,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The skill picker is modal while open: keys navigate it.
 		if m.skillPick != nil {
 			return m.handleSkillPickerKey(msg)
+		}
+		// The terminal title picker is modal while open: keys navigate it.
+		if m.titlePick != nil {
+			return m.handleTitlePickerKey(msg)
 		}
 		// A pending tool approval is modal: keystrokes answer it (y/a/n, Enter,
 		// Esc) rather than reaching the input.
@@ -1832,7 +1847,7 @@ func (m chatTUI) bottomRows() int {
 // reserve rows for a composer that cannot receive input, leaving a confusing
 // blank/bordered area at the bottom of the TUI.
 func (m chatTUI) hideComposer() bool {
-	if m.mcp != nil || m.clearConfirm != nil || m.mcpImport != nil || m.skillPick != nil || m.resumePick != nil || m.quickPick != nil || m.copyPick != nil || m.rewind != nil || m.pendingApproval != nil {
+	if m.mcp != nil || m.clearConfirm != nil || m.mcpImport != nil || m.skillPick != nil || m.titlePick != nil || m.resumePick != nil || m.quickPick != nil || m.copyPick != nil || m.rewind != nil || m.pendingApproval != nil {
 		return true
 	}
 	return m.chooser != nil && !m.chooser.typing
@@ -1852,6 +1867,9 @@ func (m chatTUI) renderMainManager() string {
 		return card
 	}
 	if card := m.renderClearConfirm(); card != "" {
+		return card
+	}
+	if card := m.renderTitlePicker(); card != "" {
 		return card
 	}
 	return m.renderSkillPicker()
@@ -1878,6 +1896,8 @@ func (m chatTUI) renderMainManagerFooter() string {
 		hint = "Enter confirm · y clear · n/Esc cancel"
 	case m.skillPick != nil:
 		hint = m.skillPickerFooterHint()
+	case m.titlePick != nil:
+		hint = m.titlePickerFooterHint()
 	}
 	if strings.TrimSpace(hint) == "" {
 		return ""
@@ -2700,6 +2720,8 @@ func (m chatTUI) View() tea.View {
 		status = "  " + modeTag + " · MCP"
 	case m.skillPick != nil:
 		status = "  " + modeTag + " · " + i18n.M.SkillPickerStatusLabel
+	case m.titlePick != nil:
+		status = "  " + modeTag + " · Terminal title"
 	case m.chooser != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusQuestion
 	case m.pendingApproval != nil && m.pendingApproval.Tool == planApprovalTool:
@@ -2807,6 +2829,7 @@ func (m chatTUI) View() tea.View {
 
 	if m.nativeScrollback {
 		v := tea.NewView(strings.Join(parts, "\n"))
+		v.WindowTitle = m.windowTitle
 		if !hideComposer {
 			if cur := m.input.Cursor(); cur != nil {
 				cur.X += 1
@@ -2826,6 +2849,7 @@ func (m chatTUI) View() tea.View {
 	}
 	v := tea.NewView(mainArea + "\n" + strings.Join(parts, "\n"))
 	v.AltScreen = true
+	v.WindowTitle = m.windowTitle
 	if m.mouseCaptureOff {
 		// Release the mouse to the terminal: native click-drag selection and
 		// right-click context menu work again, at the cost of the in-app
@@ -3227,6 +3251,8 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 		status += " · MCP"
 	case m.skillPick != nil:
 		status += " · " + i18n.M.SkillPickerStatusLabel
+	case m.titlePick != nil:
+		status += " · Terminal title"
 	case m.chooser != nil:
 		status += " · " + i18n.M.ChatStatusQuestion
 	case m.pendingApproval != nil && m.pendingApproval.Tool == planApprovalTool:
@@ -3789,6 +3815,9 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.showStatusDetails()
 	case "/rename":
 		m.runRenameCommand(input)
+	case "/title":
+		m.echoLocalCommand(input)
+		m.openTitlePicker()
 	case "/todo":
 		m.echoLocalCommand(input)
 		// Dismiss the pinned task list; a later todo_write brings it back.

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -55,6 +55,7 @@ func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	m.pendingApproval = nil
 	m.bubblePending = false
 	m.turnDiscarded = false
+	m.syncWindowTitle()
 	if clearTranscript {
 		m.clearTranscriptDisplay()
 		m.sessionSwitch = true

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1026,7 +1026,9 @@ func chatREPL(args []string) int {
 		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
 		m.showReasoning = cfg.UI.ShowReasoning   // /verbose persistence: start with config default
+		m.terminalTitleItems = cfg.TerminalTitleItems()
 		m.cfg = cfg
+		m.syncWindowTitle()
 	}
 
 	// /model support: a pure builder the TUI calls to rebuild on a different

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -53,6 +53,9 @@ func (m *chatTUI) runRenameCommand(input string) {
 		m.notice("rename: " + err.Error())
 		return
 	}
+	if targetPath == m.ctrl.SessionPath() {
+		m.syncWindowTitle()
+	}
 
 	m.notice(fmt.Sprintf(i18n.M.RenameDoneFmt, title))
 }

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
 )
 
 func TestRenameSessionUpdatesCustomTitle(t *testing.T) {
@@ -80,5 +82,50 @@ func TestSessionPickerLabelPrefersCustomTitle(t *testing.T) {
 	}
 	if strings.Contains(got, "My Topic Name") {
 		t.Errorf("label %q should prefer custom title over topic title", got)
+	}
+}
+
+func TestSessionWindowTitleUsesCustomTitleOnly(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "test-session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		TopicTitle: "Auto Topic",
+	}); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+	if got := sessionWindowTitle(sessionPath); got != "" {
+		t.Fatalf("sessionWindowTitle with only topic title = %q, want empty", got)
+	}
+	if err := agent.RenameSession(sessionPath, "  Custom Title  "); err != nil {
+		t.Fatalf("RenameSession failed: %v", err)
+	}
+	if got := sessionWindowTitle(sessionPath); got != "Custom Title" {
+		t.Fatalf("sessionWindowTitle = %q, want Custom Title", got)
+	}
+}
+
+func TestRenameCurrentSessionUpdatesTerminalWindowTitle(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "test-session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctrl := control.New(control.Options{
+		SessionDir:  dir,
+		SessionPath: sessionPath,
+		Label:       "test",
+	})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+
+	m.runRenameCommand("/rename aphone开发线程")
+
+	if got := m.windowTitle; got != "aphone开发线程" {
+		t.Fatalf("windowTitle = %q, want aphone开发线程", got)
+	}
+	if got := m.View().WindowTitle; got != "aphone开发线程" {
+		t.Fatalf("View().WindowTitle = %q, want aphone开发线程", got)
 	}
 }

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 )
@@ -119,6 +120,7 @@ func TestRenameCurrentSessionUpdatesTerminalWindowTitle(t *testing.T) {
 		Label:       "test",
 	})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.terminalTitleItems = []string{config.TerminalTitleSessionTitle}
 
 	m.runRenameCommand("/rename aphone开发线程")
 

--- a/internal/cli/slash_registry.go
+++ b/internal/cli/slash_registry.go
@@ -26,6 +26,7 @@ func builtinSlashSpecs() []builtinSlashSpec {
 		{name: "/cls", insert: "/cls", hint: i18n.M.CmdCls, showInHelp: true},
 		{name: "/resume", insert: "/resume ", hint: i18n.M.CmdResume, showInHelp: true},
 		{name: "/rename", insert: "/rename ", hint: i18n.M.CmdRename, showInHelp: true},
+		{name: "/title", insert: "/title", hint: i18n.M.CmdTitle, showInHelp: true},
 		{name: "/rewind", insert: "/rewind", hint: i18n.M.CmdRewind, showInHelp: true},
 		{name: "/tree", insert: "/tree", hint: i18n.M.CmdTree, showInHelp: true},
 		{name: "/branch", insert: "/branch ", hint: i18n.M.CmdBranch, showInHelp: true},

--- a/internal/cli/terminal_title.go
+++ b/internal/cli/terminal_title.go
@@ -76,6 +76,16 @@ func (m chatTUI) renderTerminalTitleItem(item string) string {
 		return sessionTerminalTitle(m.ctrl.SessionPath())
 	case config.TerminalTitleTodoProgress:
 		return terminalTitleTodoProgress(m.todoArgs)
+	case config.TerminalTitleMode:
+		return m.terminalTitleMode()
+	case config.TerminalTitleModel:
+		return m.terminalTitleModel()
+	case config.TerminalTitleEffort:
+		return m.terminalTitleEffort()
+	case config.TerminalTitleContext:
+		return m.terminalTitleContext()
+	case config.TerminalTitleBalance:
+		return strings.TrimSpace(m.balance)
 	case config.TerminalTitleAppName:
 		return "Reasonix"
 	case config.TerminalTitleProjectName:
@@ -89,6 +99,53 @@ func (m chatTUI) renderTerminalTitleItem(item string) string {
 	default:
 		return ""
 	}
+}
+
+func (m chatTUI) terminalTitleMode() string {
+	if m.ctrl == nil {
+		if m.planMode {
+			return "Plan"
+		}
+		return ""
+	}
+	return m.modeTagText()
+}
+
+func (m chatTUI) terminalTitleModel() string {
+	if ref := strings.TrimSpace(m.modelRef); ref != "" {
+		return ref
+	}
+	return strings.TrimSpace(m.label)
+}
+
+func (m chatTUI) terminalTitleEffort() string {
+	if strings.TrimSpace(m.effortLevel) == "" {
+		return ""
+	}
+	return "effort " + strings.TrimSpace(m.effortLevel)
+}
+
+func (m chatTUI) terminalTitleContext() string {
+	if m.ctrl == nil {
+		return ""
+	}
+	used, window := m.ctrl.ContextSnapshot()
+	if used == 0 || window == 0 {
+		return ""
+	}
+	pct := used * 100 / window
+	if ratio := m.ctrl.CompactRatio(); ratio > 0 && ratio < 1 {
+		threshold := int(ratio * 100)
+		left := threshold - pct
+		if left < 0 {
+			left = 0
+		}
+		if pct >= threshold {
+			return fmt.Sprintf("%s ctx %d%% compacting soon", shortTokens(used), pct)
+		}
+		return fmt.Sprintf("%s ctx %d%% %d%% to compact", shortTokens(used), pct, left)
+	}
+	return fmt.Sprintf("%s/%s ctx %d%%", shortTokens(used), shortTokens(window), pct)
 }
 
 func (m chatTUI) terminalTitleActivity() string {

--- a/internal/cli/terminal_title.go
+++ b/internal/cli/terminal_title.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+)
+
+func sessionWindowTitle(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return ""
+	}
+	return strings.TrimSpace(meta.CustomTitle)
+}
+
+func sessionTerminalTitle(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return agent.BranchID(sessionPath)
+	}
+	for _, title := range []string{meta.CustomTitle, meta.TopicTitle, meta.Name} {
+		if title = strings.TrimSpace(title); title != "" {
+			return title
+		}
+	}
+	if strings.TrimSpace(meta.ID) != "" {
+		return meta.ID
+	}
+	return agent.BranchID(sessionPath)
+}
+
+func (m *chatTUI) syncWindowTitle() {
+	if m == nil {
+		return
+	}
+	m.windowTitle = m.renderTerminalTitle()
+}
+
+func (m chatTUI) renderTerminalTitle() string {
+	items := m.terminalTitleItems
+	if len(items) == 0 {
+		items = config.DefaultTerminalTitleItems()
+	}
+	items = config.NormalizeTerminalTitleItems(items)
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		if part := m.renderTerminalTitleItem(item); part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return terminalTitleClean(strings.Join(parts, " | "))
+}
+
+func (m chatTUI) renderTerminalTitleItem(item string) string {
+	switch item {
+	case config.TerminalTitleActivity:
+		return m.terminalTitleActivity()
+	case config.TerminalTitleSessionTitle:
+		if m.ctrl == nil {
+			return ""
+		}
+		return sessionTerminalTitle(m.ctrl.SessionPath())
+	case config.TerminalTitleTodoProgress:
+		return terminalTitleTodoProgress(m.todoArgs)
+	case config.TerminalTitleAppName:
+		return "Reasonix"
+	case config.TerminalTitleProjectName:
+		return m.terminalTitleProjectName()
+	case config.TerminalTitleCurrentDir:
+		return terminalTitleCurrentDir()
+	case config.TerminalTitleRunState:
+		return m.terminalTitleRunState()
+	case config.TerminalTitleGitBranch:
+		return m.terminalTitleGitBranch()
+	default:
+		return ""
+	}
+}
+
+func (m chatTUI) terminalTitleActivity() string {
+	switch {
+	case m.pendingApproval != nil:
+		if m.pendingApproval.Tool == planApprovalTool {
+			return "Plan approval"
+		}
+		return "Action required"
+	case m.chooser != nil:
+		return "Question"
+	case m.state == tuiRunning:
+		return m.runningWorkingLine(m.cancelRequested(), false)
+	case m.modelSwitchPending:
+		return "Switching model"
+	case m.mcp != nil:
+		return "MCP"
+	case m.skillPick != nil:
+		return "Skills"
+	case m.titlePick != nil:
+		return "Terminal title"
+	case m.rewind != nil:
+		return "Rewind"
+	case m.resumePick != nil:
+		return "Resume"
+	default:
+		return ""
+	}
+}
+
+func terminalTitleTodoProgress(args string) string {
+	var p struct {
+		Todos []todoPanelTodo `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil || len(p.Todos) == 0 {
+		return ""
+	}
+	done := 0
+	for _, todo := range p.Todos {
+		if todo.Status == "completed" {
+			done++
+		}
+	}
+	return fmt.Sprintf("Tasks %d/%d", done, len(p.Todos))
+}
+
+func (m chatTUI) terminalTitleProjectName() string {
+	var root string
+	if m.ctrl != nil {
+		root = m.ctrl.WorkspaceRoot()
+	}
+	if strings.TrimSpace(root) == "" {
+		root, _ = os.Getwd()
+	}
+	root = strings.TrimRight(root, string(os.PathSeparator))
+	if root == "" {
+		return ""
+	}
+	return filepath.Base(root)
+}
+
+func terminalTitleCurrentDir() string {
+	cwd, err := os.Getwd()
+	if err != nil || strings.TrimSpace(cwd) == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		if cwd == home {
+			return "~"
+		}
+		prefix := strings.TrimRight(home, string(os.PathSeparator)) + string(os.PathSeparator)
+		if strings.HasPrefix(cwd, prefix) {
+			return "~" + string(os.PathSeparator) + strings.TrimPrefix(cwd, prefix)
+		}
+	}
+	return cwd
+}
+
+func (m chatTUI) terminalTitleRunState() string {
+	switch {
+	case m.pendingApproval != nil || m.chooser != nil:
+		return "Blocked"
+	case m.state == tuiRunning && m.cancelRequested():
+		return "Stopping"
+	case m.state == tuiRunning:
+		return "Working"
+	default:
+		return "Ready"
+	}
+}
+
+func (m chatTUI) terminalTitleGitBranch() string {
+	if strings.TrimSpace(m.gitStatus.Branch) == "" {
+		return ""
+	}
+	if m.gitStatus.Detached {
+		return "detached " + strings.TrimSpace(m.gitStatus.Branch)
+	}
+	return strings.TrimSpace(m.gitStatus.Branch)
+}
+
+func terminalTitleClean(s string) string {
+	s = ansi.Strip(s)
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+	s = strings.Join(strings.Fields(s), " ")
+	if visibleWidth(s) > 160 {
+		s = ansi.Truncate(s, 160, "…")
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/cli/title_picker.go
+++ b/internal/cli/title_picker.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/config"
+)
+
+type titlePicker struct {
+	items   []string
+	enabled map[string]bool
+	sel     int
+}
+
+type terminalTitleItemDef struct {
+	id   string
+	name string
+	desc string
+}
+
+var terminalTitleItemDefs = []terminalTitleItemDef{
+	{config.TerminalTitleActivity, "activity", "Current working, thinking, approval, or picker state"},
+	{config.TerminalTitleSessionTitle, "session-title", "Current session title from /rename or session metadata"},
+	{config.TerminalTitleTodoProgress, "todo-progress", "Latest todo_write progress, including completed lists"},
+	{config.TerminalTitleAppName, "app-name", "Reasonix app name"},
+	{config.TerminalTitleProjectName, "project-name", "Workspace root directory name"},
+	{config.TerminalTitleCurrentDir, "current-dir", "Current working directory"},
+	{config.TerminalTitleRunState, "run-state", "Ready, Working, Stopping, or Blocked"},
+	{config.TerminalTitleGitBranch, "git-branch", "Current Git branch when available"},
+}
+
+func (m *chatTUI) openTitlePicker() {
+	items := config.NormalizeTerminalTitleItems(m.terminalTitleItems)
+	enabled := map[string]bool{}
+	for _, item := range items {
+		enabled[item] = true
+	}
+	m.titlePick = &titlePicker{items: items, enabled: enabled}
+}
+
+func (m chatTUI) handleTitlePickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	p := m.titlePick
+	if p == nil {
+		return m, nil
+	}
+	switch msg.String() {
+	case "esc":
+		m.titlePick = nil
+	case "up", "k":
+		if p.sel > 0 {
+			p.sel--
+		}
+	case "down", "j":
+		if p.sel < len(terminalTitleItemDefs)-1 {
+			p.sel++
+		}
+	case " ", "space":
+		p.toggleSelected()
+	case "enter":
+		return m.saveTitlePick()
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), len(terminalTitleItemDefs)); ok {
+			p.sel = idx
+			p.toggleSelected()
+		}
+	}
+	return m, nil
+}
+
+func (p *titlePicker) toggleSelected() {
+	if p == nil || p.sel < 0 || p.sel >= len(terminalTitleItemDefs) {
+		return
+	}
+	id := terminalTitleItemDefs[p.sel].id
+	p.enabled[id] = !p.enabled[id]
+}
+
+func (p *titlePicker) selectedItems() []string {
+	if p == nil {
+		return config.DefaultTerminalTitleItems()
+	}
+	out := []string{}
+	for _, def := range terminalTitleItemDefs {
+		if p.enabled[def.id] {
+			out = append(out, def.id)
+		}
+	}
+	return out
+}
+
+func (m chatTUI) saveTitlePick() (tea.Model, tea.Cmd) {
+	items := m.titlePick.selectedItems()
+	if len(items) == 0 {
+		m.notice("title: select at least one item")
+		return m, nil
+	}
+	if err := persistTerminalTitleItems(items); err != nil {
+		m.notice("title: " + err.Error())
+		return m, nil
+	}
+	m.terminalTitleItems = items
+	if m.cfg != nil {
+		m.cfg.TerminalTitle.Items = items
+	}
+	m.titlePick = nil
+	m.syncWindowTitle()
+	m.notice(fmt.Sprintf("title: saved %s", strings.Join(items, ", ")))
+	return m, nil
+}
+
+func persistTerminalTitleItems(items []string) error {
+	path := config.UserConfigPath()
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("cannot resolve user config path")
+	}
+	unlock := config.LockUserConfigEdits()
+	defer unlock()
+	edit := config.LoadForEdit(path)
+	if err := edit.SetTerminalTitleItems(items); err != nil {
+		return err
+	}
+	return edit.SaveTo(path)
+}
+
+func (m chatTUI) renderTitlePicker() string {
+	p := m.titlePick
+	if p == nil {
+		return ""
+	}
+	w := max(viewWidth(m.width), 40)
+	return managerContentPanelStyle(w).Render(m.renderTitlePickerBody(w))
+}
+
+func (m chatTUI) renderTitlePickerBody(width int) string {
+	p := m.titlePick
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", viewHeader("Configure Terminal Title"))
+	fmt.Fprintf(&b, "%s\n\n", viewMeta("Select which items to display in the terminal title."))
+	for i, def := range terminalTitleItemDefs {
+		b.WriteString(renderTitlePickerRow(i, i == p.sel, p.enabled[def.id], def, width))
+		b.WriteByte('\n')
+	}
+	preview := m
+	preview.terminalTitleItems = p.selectedItems()
+	preview.titlePick = nil
+	previewTitle := preview.renderTerminalTitle()
+	if previewTitle == "" {
+		previewTitle = "(empty until a session title, todo, or activity is available)"
+	}
+	b.WriteByte('\n')
+	b.WriteString(viewSubhead("Preview") + "\n")
+	b.WriteString("  " + viewCompactText(previewTitle, viewBudget(width, 2)) + "\n")
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderTitlePickerRow(_ int, selected, enabled bool, def terminalTitleItemDef, width int) string {
+	prefix := "    "
+	if selected {
+		prefix = accent("  › ")
+	}
+	check := "[ ]"
+	if enabled {
+		check = "[x]"
+	}
+	name := fmt.Sprintf("%-14s", def.name)
+	used := 4 + visibleWidth(check) + 1 + visibleWidth(name) + 2
+	desc := viewMeta(viewCompactText(def.desc, viewBudget(width, used)))
+	line := fmt.Sprintf("%s%s %s  %s", prefix, check, name, desc)
+	if selected {
+		return accent(line)
+	}
+	return line
+}
+
+func (m chatTUI) titlePickerFooterHint() string {
+	if m.titlePick == nil {
+		return ""
+	}
+	return "↑/↓ move · Space toggle · Enter save · Esc close"
+}

--- a/internal/cli/title_picker.go
+++ b/internal/cli/title_picker.go
@@ -22,14 +22,19 @@ type terminalTitleItemDef struct {
 }
 
 var terminalTitleItemDefs = []terminalTitleItemDef{
-	{config.TerminalTitleActivity, "activity", "Current working, thinking, approval, or picker state"},
-	{config.TerminalTitleSessionTitle, "session-title", "Current session title from /rename or session metadata"},
-	{config.TerminalTitleTodoProgress, "todo-progress", "Latest todo_write progress, including completed lists"},
-	{config.TerminalTitleAppName, "app-name", "Reasonix app name"},
-	{config.TerminalTitleProjectName, "project-name", "Workspace root directory name"},
-	{config.TerminalTitleCurrentDir, "current-dir", "Current working directory"},
-	{config.TerminalTitleRunState, "run-state", "Ready, Working, Stopping, or Blocked"},
-	{config.TerminalTitleGitBranch, "git-branch", "Current Git branch when available"},
+	{config.TerminalTitleActivity, "live-run", "Reasonix live line: thinking seconds, cancel state, output tokens"},
+	{config.TerminalTitleSessionTitle, "session", "Title from /rename, branch metadata, or saved session id"},
+	{config.TerminalTitleTodoProgress, "todo-write", "todo_write checklist progress pinned above the composer"},
+	{config.TerminalTitleMode, "mode", "Ask/Auto/YOLO/Plan/Goal badge from the Reasonix status bar"},
+	{config.TerminalTitleModel, "model", "Active provider/model ref selected by /model"},
+	{config.TerminalTitleEffort, "effort", "Current /effort reasoning depth when the provider supports it"},
+	{config.TerminalTitleContext, "context", "Context usage plus auto-compact headroom"},
+	{config.TerminalTitleBalance, "balance", "Provider wallet balance when the model exposes a balance endpoint"},
+	{config.TerminalTitleGitBranch, "git", "Repo branch identity from the built-in Reasonix status line"},
+	{config.TerminalTitleProjectName, "workspace", "Workspace root folder owned by this controller"},
+	{config.TerminalTitleCurrentDir, "cwd", "Process working directory for this CLI session"},
+	{config.TerminalTitleAppName, "app", "Literal Reasonix marker"},
+	{config.TerminalTitleRunState, "state", "Compact Ready/Working/Stopping/Blocked state for terminals"},
 }
 
 func (m *chatTUI) openTitlePicker() {
@@ -137,8 +142,8 @@ func (m chatTUI) renderTitlePicker() string {
 func (m chatTUI) renderTitlePickerBody(width int) string {
 	p := m.titlePick
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", viewHeader("Configure Terminal Title"))
-	fmt.Fprintf(&b, "%s\n\n", viewMeta("Select which items to display in the terminal title."))
+	fmt.Fprintf(&b, "%s\n", viewHeader("Reasonix Terminal Title"))
+	fmt.Fprintf(&b, "%s\n\n", viewMeta("Pick Reasonix session/status fields to mirror into the terminal tab title."))
 	for i, def := range terminalTitleItemDefs {
 		b.WriteString(renderTitlePickerRow(i, i == p.sel, p.enabled[def.id], def, width))
 		b.WriteByte('\n')
@@ -148,7 +153,7 @@ func (m chatTUI) renderTitlePickerBody(width int) string {
 	preview.titlePick = nil
 	previewTitle := preview.renderTerminalTitle()
 	if previewTitle == "" {
-		previewTitle = "(empty until a session title, todo, or activity is available)"
+		previewTitle = "(waiting for Reasonix session or run metadata)"
 	}
 	b.WriteByte('\n')
 	b.WriteString(viewSubhead("Preview") + "\n")
@@ -165,7 +170,7 @@ func renderTitlePickerRow(_ int, selected, enabled bool, def terminalTitleItemDe
 	if enabled {
 		check = "[x]"
 	}
-	name := fmt.Sprintf("%-14s", def.name)
+	name := fmt.Sprintf("%-12s", def.name)
 	used := 4 + visibleWidth(check) + 1 + visibleWidth(name) + 2
 	desc := viewMeta(viewCompactText(def.desc, viewBudget(width, used)))
 	line := fmt.Sprintf("%s%s %s  %s", prefix, check, name, desc)

--- a/internal/cli/title_picker_test.go
+++ b/internal/cli/title_picker_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+func TestTerminalTitleIncludesRunningActivity(t *testing.T) {
+	m := newTestChatTUI()
+	m.terminalTitleItems = []string{config.TerminalTitleActivity}
+	m.state = tuiRunning
+	m.runStart = time.Now().Add(-343 * time.Second)
+	m.elapsed = 343
+	m.turnTokens = 9100
+
+	m.syncWindowTitle()
+
+	if !strings.Contains(m.windowTitle, "343") || !strings.Contains(m.windowTitle, "↓9.1K") {
+		t.Fatalf("windowTitle = %q, want elapsed seconds and output tokens", m.windowTitle)
+	}
+}
+
+func TestTerminalTitleTodoProgressKeepsCompletedList(t *testing.T) {
+	m := newTestChatTUI()
+	m.terminalTitleItems = []string{config.TerminalTitleTodoProgress}
+	m.todoArgs = `{"todos":[` +
+		`{"content":"one","status":"completed"},` +
+		`{"content":"two","status":"completed"}]}`
+
+	if got := m.renderTerminalTitle(); got != "Tasks 2/2" {
+		t.Fatalf("renderTerminalTitle = %q, want Tasks 2/2", got)
+	}
+}
+
+func TestTerminalTitleActivityPrefersActionRequired(t *testing.T) {
+	m := newTestChatTUI()
+	m.terminalTitleItems = []string{config.TerminalTitleActivity}
+	m.state = tuiRunning
+	m.elapsed = 42
+	m.turnTokens = 1200
+	m.pendingApproval = &event.Approval{Tool: "bash"}
+
+	if got := m.renderTerminalTitle(); got != "Action required" {
+		t.Fatalf("renderTerminalTitle = %q, want Action required", got)
+	}
+}
+
+func TestTitleCommandPersistsUserConfigNotProjectConfig(t *testing.T) {
+	isolateUserConfig(t)
+	projectPath := filepath.Join(mustGetwd(t), "reasonix.toml")
+	projectBody := "[terminal_title]\nitems = [\"activity\"]\n"
+	if err := os.WriteFile(projectPath, []byte(projectBody), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	m := newTestChatTUI()
+	m.terminalTitleItems = []string{config.TerminalTitleActivity}
+	m.runSlashCommand("/title")
+	if m.titlePick == nil {
+		t.Fatal("/title should open the terminal title picker")
+	}
+	m.titlePick.enabled = map[string]bool{config.TerminalTitleAppName: true}
+
+	next, _ := m.saveTitlePick()
+	updated := next.(chatTUI)
+
+	if got := updated.windowTitle; got != "Reasonix" {
+		t.Fatalf("windowTitle after save = %q, want Reasonix", got)
+	}
+	userBody, err := os.ReadFile(config.UserConfigPath())
+	if err != nil {
+		t.Fatalf("read user config: %v", err)
+	}
+	if !strings.Contains(string(userBody), `[terminal_title]`) || !strings.Contains(string(userBody), `items = ["app-name"]`) {
+		t.Fatalf("user config missing terminal title app-name:\n%s", userBody)
+	}
+	gotProject, err := os.ReadFile(projectPath)
+	if err != nil {
+		t.Fatalf("read project config: %v", err)
+	}
+	if string(gotProject) != projectBody {
+		t.Fatalf("/title should not rewrite project config:\n%s", gotProject)
+	}
+}

--- a/internal/cli/title_picker_test.go
+++ b/internal/cli/title_picker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/event"
 )
 
@@ -48,6 +49,75 @@ func TestTerminalTitleActivityPrefersActionRequired(t *testing.T) {
 
 	if got := m.renderTerminalTitle(); got != "Action required" {
 		t.Fatalf("renderTerminalTitle = %q, want Action required", got)
+	}
+}
+
+func TestDefaultTerminalTitleItemsPreferReasonixStatus(t *testing.T) {
+	got := config.DefaultTerminalTitleItems()
+	want := []string{
+		config.TerminalTitleActivity,
+		config.TerminalTitleSessionTitle,
+		config.TerminalTitleTodoProgress,
+		config.TerminalTitleMode,
+		config.TerminalTitleModel,
+		config.TerminalTitleEffort,
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("DefaultTerminalTitleItems = %v, want %v", got, want)
+	}
+}
+
+func TestTerminalTitleIncludesReasonixModeModelEffort(t *testing.T) {
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{})
+	m.ctrl.SetToolApprovalMode(control.ToolApprovalYolo)
+	m.modelRef = "deepseek/deepseek-v4-pro"
+	m.effortLevel = "max"
+	m.terminalTitleItems = []string{
+		config.TerminalTitleMode,
+		config.TerminalTitleModel,
+		config.TerminalTitleEffort,
+	}
+
+	if got := m.renderTerminalTitle(); got != "YOLO | deepseek/deepseek-v4-pro | effort max" {
+		t.Fatalf("renderTerminalTitle = %q, want Reasonix mode/model/effort", got)
+	}
+}
+
+func TestTerminalTitlePickerUsesReasonixDescriptions(t *testing.T) {
+	m := newTestChatTUI()
+	m.openTitlePicker()
+	body := m.renderTitlePickerBody(120)
+
+	for _, want := range []string{"Reasonix Terminal Title", "YOLO", "todo_write", "/model", "/effort"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("title picker body missing %q:\n%s", want, body)
+		}
+	}
+	for _, copied := range []string{"Current working, thinking", "Current thread title", "Latest task progress"} {
+		if strings.Contains(body, copied) {
+			t.Fatalf("title picker still contains copied-style wording %q:\n%s", copied, body)
+		}
+	}
+}
+
+func TestTerminalTitleAliasesRemainCompatible(t *testing.T) {
+	got := config.NormalizeTerminalTitleItems([]string{
+		"thread-title",
+		"task-progress",
+		"approval-mode",
+		"reasoning-effort",
+		"ctx",
+	})
+	want := []string{
+		config.TerminalTitleSessionTitle,
+		config.TerminalTitleTodoProgress,
+		config.TerminalTitleMode,
+		config.TerminalTitleEffort,
+		config.TerminalTitleContext,
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("NormalizeTerminalTitleItems = %v, want %v", got, want)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	Plugins          []PluginEntry       `toml:"plugins"`
 	Skills           SkillsConfig        `toml:"skills"`
 	Statusline       StatuslineConfig    `toml:"statusline"`
+	TerminalTitle    TerminalTitleConfig `toml:"terminal_title"`
 	LSP              LSPConfig           `toml:"lsp"`
 	Bot              BotConfig           `toml:"bot"`
 	Serve            ServeConfig         `toml:"serve"`
@@ -548,6 +549,110 @@ type LSPServer struct {
 // status data row. A JSON payload (model, context tokens, cwd) is fed on stdin.
 type StatuslineConfig struct {
 	Command string `toml:"command"`
+}
+
+// TerminalTitleConfig configures the terminal/Ghostty tab title shown by the
+// interactive CLI. Items are rendered in order and omitted when their value is
+// unavailable for the current session.
+type TerminalTitleConfig struct {
+	Items []string `toml:"items"`
+}
+
+const (
+	TerminalTitleActivity     = "activity"
+	TerminalTitleSessionTitle = "session-title"
+	TerminalTitleTodoProgress = "todo-progress"
+	TerminalTitleAppName      = "app-name"
+	TerminalTitleProjectName  = "project-name"
+	TerminalTitleCurrentDir   = "current-dir"
+	TerminalTitleRunState     = "run-state"
+	TerminalTitleGitBranch    = "git-branch"
+)
+
+var defaultTerminalTitleItems = []string{
+	TerminalTitleActivity,
+	TerminalTitleSessionTitle,
+	TerminalTitleTodoProgress,
+}
+
+// DefaultTerminalTitleItems returns the built-in terminal title item order.
+func DefaultTerminalTitleItems() []string {
+	return append([]string(nil), defaultTerminalTitleItems...)
+}
+
+// NormalizeTerminalTitleItems canonicalizes known item names, removes
+// duplicates, and falls back to the built-in defaults when no valid item remains.
+func NormalizeTerminalTitleItems(items []string) []string {
+	out, _ := normalizeTerminalTitleItems(items)
+	if len(out) == 0 {
+		return DefaultTerminalTitleItems()
+	}
+	return out
+}
+
+func normalizeTerminalTitleItems(items []string) ([]string, []string) {
+	out := []string{}
+	invalid := []string{}
+	seen := map[string]bool{}
+	for _, item := range items {
+		canonical := canonicalTerminalTitleItem(item)
+		if canonical == "" {
+			if strings.TrimSpace(item) != "" {
+				invalid = append(invalid, item)
+			}
+			continue
+		}
+		if seen[canonical] {
+			continue
+		}
+		seen[canonical] = true
+		out = append(out, canonical)
+	}
+	return out, invalid
+}
+
+func canonicalTerminalTitleItem(item string) string {
+	switch strings.ToLower(strings.TrimSpace(item)) {
+	case TerminalTitleActivity:
+		return TerminalTitleActivity
+	case TerminalTitleSessionTitle, "thread-title":
+		return TerminalTitleSessionTitle
+	case TerminalTitleTodoProgress, "task-progress":
+		return TerminalTitleTodoProgress
+	case TerminalTitleAppName:
+		return TerminalTitleAppName
+	case TerminalTitleProjectName:
+		return TerminalTitleProjectName
+	case TerminalTitleCurrentDir:
+		return TerminalTitleCurrentDir
+	case TerminalTitleRunState:
+		return TerminalTitleRunState
+	case TerminalTitleGitBranch:
+		return TerminalTitleGitBranch
+	default:
+		return ""
+	}
+}
+
+// TerminalTitleItems returns the effective item order for terminal titles.
+func (c *Config) TerminalTitleItems() []string {
+	if c == nil {
+		return DefaultTerminalTitleItems()
+	}
+	return NormalizeTerminalTitleItems(c.TerminalTitle.Items)
+}
+
+// SetTerminalTitleItems validates and stores the terminal title item order.
+func (c *Config) SetTerminalTitleItems(items []string) error {
+	normalized, invalid := normalizeTerminalTitleItems(items)
+	if len(normalized) == 0 {
+		return fmt.Errorf("terminal title: select at least one item")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("terminal title: unknown item %q", invalid[0])
+	}
+	c.TerminalTitle.Items = normalized
+	return nil
 }
 
 // BotConfig 控制多渠道 IM bot 消息网关。
@@ -1580,6 +1685,7 @@ func Default() *Config {
 		CredentialsStore: CredentialsStoreAuto,
 		UI:               UIConfig{Theme: "auto"},
 		Desktop:          DesktopConfig{DefaultToolApprovalMode: "auto"},
+		TerminalTitle:    TerminalTitleConfig{Items: DefaultTerminalTitleItems()},
 		Notifications: NotificationsConfig{
 			Enabled:         false,
 			TurnDone:        true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -562,6 +562,11 @@ const (
 	TerminalTitleActivity     = "activity"
 	TerminalTitleSessionTitle = "session-title"
 	TerminalTitleTodoProgress = "todo-progress"
+	TerminalTitleMode         = "mode"
+	TerminalTitleModel        = "model"
+	TerminalTitleEffort       = "effort"
+	TerminalTitleContext      = "context"
+	TerminalTitleBalance      = "balance"
 	TerminalTitleAppName      = "app-name"
 	TerminalTitleProjectName  = "project-name"
 	TerminalTitleCurrentDir   = "current-dir"
@@ -573,6 +578,9 @@ var defaultTerminalTitleItems = []string{
 	TerminalTitleActivity,
 	TerminalTitleSessionTitle,
 	TerminalTitleTodoProgress,
+	TerminalTitleMode,
+	TerminalTitleModel,
+	TerminalTitleEffort,
 }
 
 // DefaultTerminalTitleItems returns the built-in terminal title item order.
@@ -619,6 +627,16 @@ func canonicalTerminalTitleItem(item string) string {
 		return TerminalTitleSessionTitle
 	case TerminalTitleTodoProgress, "task-progress":
 		return TerminalTitleTodoProgress
+	case TerminalTitleMode, "approval-mode", "tool-approval":
+		return TerminalTitleMode
+	case TerminalTitleModel:
+		return TerminalTitleModel
+	case TerminalTitleEffort, "reasoning-effort":
+		return TerminalTitleEffort
+	case TerminalTitleContext, "ctx":
+		return TerminalTitleContext
+	case TerminalTitleBalance:
+		return TerminalTitleBalance
 	case TerminalTitleAppName:
 		return TerminalTitleAppName
 	case TerminalTitleProjectName:

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -472,6 +472,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	}
 	b.WriteString("\n")
 
+	b.WriteString("[terminal_title]\n")
+	b.WriteString("# Items shown in the terminal/Ghostty tab title. Use /title to change this interactively.\n")
+	fmt.Fprintf(&b, "items = %s\n", renderStringArray(c.TerminalTitleItems()))
+	b.WriteString("\n")
+
 	if shouldRenderBot(c, defaults, scope) {
 		b.WriteString("# Bot gateway: multi-channel IM bot for QQ, Feishu/Lark, and WeChat.\n")
 		b.WriteString("[bot]\n")
@@ -1091,6 +1096,12 @@ func RenderTOMLProjectDelta(c *Config) string {
 			fmt.Fprintf(&b, "command = %q\n", c.Statusline.Command)
 		}
 		b.WriteString("\n")
+	}
+
+	// [terminal_title]
+	if !reflect.DeepEqual(c.TerminalTitleItems(), d.TerminalTitleItems()) {
+		b.WriteString("[terminal_title]\n")
+		fmt.Fprintf(&b, "items = %s\n\n", renderStringArray(c.TerminalTitleItems()))
 	}
 
 	// [[plugins]] — always include when set; replaces all existing entries

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -239,6 +239,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Skills.ExcludedPaths = []string{"~/.agents/skills"}
 	orig.Skills.DisabledSkills = []string{"review", "explore"}
 	orig.Skills.MaxDepth = 2
+	orig.TerminalTitle.Items = []string{"app-name", "session-title", "git-branch"}
 	orig.Bot.ToolApprovalMode = "auto"
 	orig.Bot.Control = BotControlConfig{Enabled: true, Addr: "127.0.0.1:39001", TokenEnv: "BOT_CONTROL_TOKEN"}
 	orig.Bot.Feishu.OutboundMediaRoots = []string{"/tmp/reasonix-media", "/srv/shots"}
@@ -502,6 +503,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.SkillMaxDepth() != 2 {
 		t.Errorf("skills.max_depth = %d, want 2", got.SkillMaxDepth())
+	}
+	if want := []string{"app-name", "session-title", "git-branch"}; !reflect.DeepEqual(got.TerminalTitleItems(), want) {
+		t.Errorf("terminal title items = %v, want %v", got.TerminalTitleItems(), want)
 	}
 	if len(got.Plugins) != 2 {
 		t.Fatalf("plugins count = %d, want 2", len(got.Plugins))

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -207,6 +207,7 @@ type Messages struct {
 	CmdSwitchBranch     string // /switch
 	CmdResume           string // /resume
 	CmdRename           string // /rename
+	CmdTitle            string // /title
 	CmdModel            string // /model
 	CmdStatus           string // /status
 	CmdWorkMode         string // /work-mode

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -218,6 +218,7 @@ var English = Messages{
 	CmdSwitchBranch:     "switch conversation branch",
 	CmdResume:           "resume a saved session",
 	CmdRename:           "rename a session",
+	CmdTitle:            "configure terminal title",
 	CmdModel:            "switch model",
 	CmdStatus:           "show session status",
 	CmdWorkMode:         "switch work mode",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -219,6 +219,7 @@ var Chinese = Messages{
 	CmdSwitchBranch:     "切换对话分支",
 	CmdResume:           "恢复已保存的会话",
 	CmdRename:           "重命名会话",
+	CmdTitle:            "配置终端标题",
 	CmdModel:            "切换模型",
 	CmdStatus:           "显示会话状态",
 	CmdWorkMode:         "切换工作模式",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -470,6 +470,7 @@ var ChineseTraditional = Messages{
 	SlashClsDone:               "已清除畫面（LLM 上下文保留）",
 	CmdClear:                   "丟棄當前上下文",
 	CmdRename:                  "重新命名會話",
+	CmdTitle:                   "設定終端標題",
 	CmdGoal:                    "設定或清除當前目標",
 	CmdDiffFold:                "切換 diff 摺疊/展開",
 	ListMemorySaved:            "儲存的記憶",


### PR DESCRIPTION
## 中文

这个 PR 为 Reasonix TUI 增加终端窗口 / tab 标题配置能力，通过 `/title` 打开交互式选择器，并把选择写入用户配置的 `[terminal_title]`。

### 改了什么

- 新增 `/title` slash 命令，打开可勾选的 terminal title 字段选择器。
- 新增 `[terminal_title]` 配置，保存用户选择的标题字段。
- 支持 Reasonix 自身语义字段：运行状态、会话标题、todo 进度、模式、模型、effort、上下文、余额、Git、workspace、CWD、应用标识。
- `/rename` 后会同步刷新终端标题。
- 保留旧字段名兼容，例如 `thread-title` / `task-progress`。
- 复用上游集中式 slash registry，不再维护重复命令列表。

### 为什么

Reasonix 已经有会话元数据、`/rename`、`todo_write`、模型切换、effort、Plan/YOLO/Goal 模式和状态栏，但支持 OSC title 的终端无法在 tab title 中看到这些状态。这个 PR 让 Ghostty 等终端可以显示当前 Reasonix 会话身份和实时工作状态。

### 验证

- `go test -count=1 ./internal/cli -run 'TestTerminalTitle|TestTitleCommand|TestRenameCurrentSessionUpdatesTerminalWindowTitle|TestSessionWindowTitleUsesCustomTitleOnly'`
- `go test -count=1 ./internal/cli -run 'TestBuiltinSlashRegistry|TestSlashCompletion|TestRenderHelpGroupsCommands|TestSlashItemsIncludesSkills'`
- `go test -count=1 ./internal/config`
- `go test -count=1 ./internal/i18n`
- `go test -count=1 ./internal/cli`
- `make build`
- `git diff --check`

## English

This PR adds configurable terminal window/tab title support to the Reasonix TUI. Users can run `/title` to open an interactive picker, and selections are persisted under `[terminal_title]` in the user config.

### What changed

- Adds a `/title` slash command with an interactive field picker.
- Adds `[terminal_title]` config for persisted user-selected title fields.
- Supports Reasonix-native fields: run state, session title, todo progress, mode, model, effort, context, balance, Git, workspace, CWD, and app marker.
- Refreshes terminal title after `/rename`.
- Keeps compatibility aliases such as `thread-title` and `task-progress`.
- Reuses the upstream centralized slash registry instead of duplicating command lists.

### Why

Reasonix already tracks session metadata, `/rename`, `todo_write`, model switching, effort, Plan/YOLO/Goal modes, and a rich status line. Terminals with OSC title support could not mirror that state in the tab title. This makes useful Reasonix session identity and live work state visible in Ghostty and similar terminals.

### Validation

- `go test -count=1 ./internal/cli -run 'TestTerminalTitle|TestTitleCommand|TestRenameCurrentSessionUpdatesTerminalWindowTitle|TestSessionWindowTitleUsesCustomTitleOnly'`
- `go test -count=1 ./internal/cli -run 'TestBuiltinSlashRegistry|TestSlashCompletion|TestRenderHelpGroupsCommands|TestSlashItemsIncludesSkills'`
- `go test -count=1 ./internal/config`
- `go test -count=1 ./internal/i18n`
- `go test -count=1 ./internal/cli`
- `make build`
- `git diff --check`

## Cache Impact

Cache-impact: low. This changes local TUI/config title rendering only. It does not change model prompts, tool schemas, provider request shape, compaction, or cache policy.

Cache-guard: title/config tests cover field normalization, persistence, and picker descriptions.

System-prompt-review: reviewed the diff; no system prompt or agent instruction text is changed.
