### PR TITLE
fix(release): keep desktop as repository latest

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -9,7 +9,7 @@ name: Release desktop
 # runner per platform. Artifacts are minisign-signed (MINISIGN_* secrets), a
 # latest.json manifest is generated, and everything is published to a GitHub
 # release and mirrored to R2 (the updater reads R2 first, then the crash worker
-# release gateway; GitHub's repository-wide "latest" is reserved for the CLI line).
+# release gateway; stable desktop releases own GitHub's repository-wide "latest").
 #
 # The same build/sign/manifest pipeline serves two channels. A `desktop-v*` tag
 # (or manual stable dispatch) publishes a GitHub release and moves R2's latest/
@@ -269,10 +269,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Repository-wide "latest" is reserved for the CLI line (see header);
-          # without this a desktop release published after the CLI one steals it.
-          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes --latest=false)
-          [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
+          # Keep the repository homepage focused on the installable desktop app;
+          # the CLI release line is configured not to claim repository-wide latest.
+          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
+          if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then
+            args+=(--prerelease --latest=false)
+          else
+            args+=(--latest)
+          fi
           gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
 
       - name: Upload canary dist for mirror

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
     name: archives + checksums + homebrew tap
     needs: cache-guard
     runs-on: ubuntu-latest
-    # CLI stable release (archives + GitHub release + Homebrew cask). Gated on the
+    # CLI stable release (archives + GitHub release + Homebrew cask). It does not
+    # claim GitHub's repository-wide Latest badge; that belongs to desktop so the
+    # repository homepage points users at the installable app. Gated on the
     # `release` environment so only esengine can approve it going public.
     environment: release
     steps:
@@ -84,12 +86,13 @@ jobs:
           gh release upload "$TAG" latest.json --clobber
 
       # The compatibility asset exists for pre-v1.16 desktop updaters that
-      # still poll GitHub's repository-wide latest URL — so verify it exactly
-      # the way those clients fetch it: anonymously, over the public edge, with
-      # a Go client UA. Unlike dl.reasonix.io (whose bot protection 403s
-      # Actions egress — see the R2 note above), GitHub serves its own runners,
-      # so this can hard-fail. #5826/#5858 shipped a broken update check for
-      # weeks precisely because nothing exercised the public path. Retries
+      # still poll GitHub's repository-wide latest URL. Desktop releases now
+      # own that Latest badge, but this check still exercises the public fallback
+      # path exactly the way those clients fetch it: anonymously, over the public
+      # edge, with a Go client UA. Unlike dl.reasonix.io (whose bot protection
+      # 403s Actions egress — see the R2 note above), GitHub serves its own
+      # runners, so this can hard-fail. #5826/#5858 shipped a broken update check
+      # for weeks precisely because nothing exercised the public path. Retries
       # cover the release CDN propagating the freshly uploaded asset.
       - name: Smoke public compatibility manifest
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,4 +58,5 @@ homebrew_casks:
 
 release:
   prerelease: auto
+  make_latest: false
   name_template: "Reasonix CLI {{ .Tag }}"

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -119,9 +119,10 @@ Desktop releases ride their own tag namespace, `desktop-v<semver>` (plain `v*`
 tags are the CLI release). Pushing one triggers `.github/workflows/release-desktop.yml`,
 which builds on a native runner per platform (Wails can't cross-compile a
 CGO/WebKit binary), packages each artifact, signs it with minisign, generates a
-`latest.json` manifest, publishes a GitHub release, mirrors everything to R2,
-and attaches the current desktop manifest to the matching CLI release for old
-clients that still ask GitHub's repository-wide `latest` release for it.
+`latest.json` manifest, publishes a GitHub release, marks the desktop release as
+GitHub's repository-wide `Latest`, mirrors everything to R2, and attaches the
+current desktop manifest to the matching CLI release for old clients that still
+ask GitHub's repository-wide `latest` release for it.
 The Linux artifact links against WebKitGTK 4.1 (`-tags webkit2_41`), so it needs
 `libwebkit2gtk-4.1-0` at runtime — present by default on Ubuntu 22.04+, Fedora 40+.
 
@@ -133,8 +134,8 @@ The app checks `latest.json` on startup (R2 first, then the
 `crash.reasonix.io` desktop release gateway) and shows an update banner when a
 newer version is published; **Settings → Software update** has a manual check.
 The gateway resolves only the desktop `desktop-v*` release line and never uses
-GitHub's repository-wide `/releases/latest` shortcut, because plain `v*` tags are
-the CLI release line. Self-update behavior by platform:
+GitHub's repository-wide `/releases/latest` shortcut, so updater behavior does
+not depend on homepage badge semantics. Self-update behavior by platform:
 
 - **Linux / Windows** — download, verify the minisign signature, then update in
   place: Linux replaces the binary and relaunches; Windows runs the per-user NSIS

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -93,13 +93,12 @@ func appWithTab(t *testing.T, path string) (*App, *WorkspaceTab) {
 // nil sink ctx (no webview) must not disable persistence.
 func TestTurnDonePersistsSession(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
-	_ = path
-	a, tab := appWithTab(t, path)
+	_, tab := appWithTab(t, path)
 
 	tab.sink.Emit(event.Event{Kind: event.TurnDone})
 
 	waitForFile(t, path, "remember this turn")
-	_ = a
+	waitForAutosaveIdle(t, tab)
 }
 
 // TestNonTurnDoneDoesNotPersist confirms only TurnDone triggers a save, so the

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -37,10 +37,9 @@ import (
 // Manifest endpoints — R2 CDN first (fast, especially in CN), then the crash
 // worker release gateway, then GitHub as the stable channel's last resort. The
 // build channel picks the rolling pointer so a canary build polls the canary
-// line and a stable build polls latest; the two never cross. The gateway
-// deliberately avoids GitHub's repository-wide /releases/latest shortcut
-// because CLI tags (v*) and desktop tags (desktop-v*) are separate release
-// lines in the same repo.
+// line and a stable build polls latest; the two never cross. The gateway still
+// avoids GitHub's repository-wide /releases/latest shortcut so the app is not
+// coupled to GitHub's homepage badge semantics.
 const (
 	r2Base             = "https://dl.reasonix.io"
 	releaseGatewayBase = "https://crash.reasonix.io/v1/desktop/releases"
@@ -51,11 +50,10 @@ const (
 // githubManifestFallback is the stable channel's last-resort manifest source.
 // dl.reasonix.io and crash.reasonix.io share one Cloudflare zone, so bot
 // protection that 403s a user's egress IP takes out both first-party endpoints
-// at once (#6005); GitHub is separate infrastructure. The URL is safe despite
-// the repository-wide /releases/latest caveat above: release.yml pins the
-// repo-wide latest badge to the CLI line and attaches a desktop-manifest mirror
-// to every stable CLI release ("desktop manifest compatibility asset"), so this
-// asset is always the desktop manifest. Canary has no GitHub release, so its
+// at once (#6005); GitHub is separate infrastructure. Stable desktop releases
+// own the repo-wide latest badge and publish latest.json directly, while
+// release.yml also keeps a desktop-manifest mirror attached to stable CLI
+// releases for older publishing windows. Canary has no GitHub release, so its
 // chain stays two-deep.
 const githubManifestFallback = "https://github.com/esengine/DeepSeek-Reasonix/releases/latest/download/latest.json"
 

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -102,9 +102,9 @@ func TestChannelSelectsDistinctPointers(t *testing.T) {
 		t.Errorf("stable fallback = %q, want the release gateway", stable[1])
 	}
 	// GitHub is stable's explicit last resort only (#6005: both first-party
-	// endpoints share one Cloudflare zone). release.yml pins the desktop
-	// manifest mirror to the repo-wide latest release, which is what makes this
-	// URL safe; no other slot may lean on repository-wide latest.
+	// endpoints share one Cloudflare zone). Stable desktop releases own the
+	// repo-wide latest release and carry latest.json directly; no other slot may
+	// lean on repository-wide latest.
 	if len(stable) != 3 || stable[2] != githubManifestFallback {
 		t.Errorf("stable endpoints = %q, want the GitHub compatibility manifest last", stable)
 	}


### PR DESCRIPTION
## Summary
- mark stable desktop releases as GitHub repository `Latest`
- configure GoReleaser CLI releases with `make_latest: false` so CLI cannot steal the homepage release card if it finishes later
- update desktop updater/release docs to match the new ownership of repository-wide latest

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".goreleaser.yaml"); YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/release-desktop.yml"); puts "yaml ok"'`
- `git diff --check`
- `cd desktop && go test .`
