### PR TITLE
Fix session append recovery conflicts / 修复会话追加误入冲突副本

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -440,7 +440,7 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		}
 		return decision, nil
 	}
-	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, currentRevision, nextVersion) {
+	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, currentRevision, currentLedgerDigest, nextVersion) {
 		return snapshotWriteDecision{revision: currentRevision, repairLog: current.eventLogDamaged}, nil
 	}
 	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
@@ -677,7 +677,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, existingRevision int64, nextVersion uint64) bool {
+func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]byte, existingRevision int64, existingLedgerDigest string, nextVersion uint64) bool {
 	state := s.persistState(path)
 	if !state.ok || state.version > nextVersion || !bytes.Equal(existingDigest[:], state.digest[:]) {
 		return false
@@ -689,11 +689,21 @@ func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]by
 	// A disk ledger with no recorded revision is the mirror case: recorded
 	// revisions start at 1, so revision 0 means the sidecar was deleted or
 	// rebuilt by a listing-only writer after this session's save. An absent
-	// claim cannot revoke the ownership the digest+version match proves; a
-	// foreign claim (recorded revision that differs from the baseline) still
-	// does, keeping stale controllers from force-rewinding a ledger another
-	// runtime has since stamped.
-	return !state.revisionKnown || existingRevision == 0 || state.revision == existingRevision
+	// claim cannot revoke the ownership the digest+version match proves.
+	if !state.revisionKnown || existingRevision == 0 || state.revision == existingRevision {
+		return true
+	}
+	// A foreign revision stamp whose recorded digest still describes these
+	// exact bytes (a same-content heal or no-op record by another runtime)
+	// vouches for no content of its own: the transcript is byte-for-byte what
+	// this session last persisted, so rewriting it destroys nothing of
+	// theirs — at worst the conflict moves to the stamper's next divergent
+	// save, where its in-memory history forks a recovery branch as usual.
+	// A stamp that disagrees with the on-disk transcript (or a legacy stamp
+	// with no digest) keeps revoking ownership: that is the aftermath of a
+	// save whose bytes and record split, the bytes cannot be attributed, and
+	// only the conservative conflict path preserves both sides.
+	return existingLedgerDigest == digestString(existingDigest)
 }
 
 func (s *Session) persistState(path string) sessionPersistState {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -403,10 +403,16 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		// An unknown-revision baseline (meta sidecar unreadable at load) cannot
 		// vouch for revision equality; the digest/prefix checks above already
 		// vouch for the content, so only a known baseline arms the CAS check.
-		// Exact append is also safe with a stale baseline: the disk transcript is
-		// a byte-for-byte prefix of the snapshot, so the write only records the
-		// suffix at the current disk revision instead of rewriting that prefix.
-		if baseState.ok && baseState.revisionKnown && currentRevision != baseState.revision && !contentUnchanged && !exactAppend {
+		// Under an append-shaped write (at most a compatible leading-system
+		// swap) a stale revision is ledger drift — a reset sidecar, a
+		// same-content heal, or another runtime recording messages this
+		// snapshot already contains — unless the transcript was rewound.
+		// Locating the persisted baseline among the snapshot's prefixes and
+		// requiring the disk transcript to still reach it tells the two apart:
+		// drift keeps the baseline reachable, while a rewind cut below it and
+		// appending would resurrect the suffix another runtime removed.
+		if baseState.ok && baseState.revisionKnown && currentRevision != baseState.revision && !contentUnchanged &&
+			!appendCoversPersistedBaseline(next, existing, baseState.digest) {
 			return snapshotWriteDecision{}, snapshotConflict(path, existing, next, baseState.revision, currentRevision)
 		}
 		// A normalized-dirty load means LoadSession repaired the history on the
@@ -680,7 +686,14 @@ func (s *Session) ownsPersistedState(path string, existingDigest [sha256.Size]by
 	// digest+version match proves it. Requiring revision equality here would
 	// make every rewrite from such a baseline a permanent conflict, because
 	// the revision can only be re-learned by a successful save.
-	return !state.revisionKnown || state.revision == existingRevision
+	// A disk ledger with no recorded revision is the mirror case: recorded
+	// revisions start at 1, so revision 0 means the sidecar was deleted or
+	// rebuilt by a listing-only writer after this session's save. An absent
+	// claim cannot revoke the ownership the digest+version match proves; a
+	// foreign claim (recorded revision that differs from the baseline) still
+	// does, keeping stale controllers from force-rewinding a ledger another
+	// runtime has since stamped.
+	return !state.revisionKnown || existingRevision == 0 || state.revision == existingRevision
 }
 
 func (s *Session) persistState(path string) sessionPersistState {
@@ -833,6 +846,49 @@ func messagesHavePrefix(full, prefix []provider.Message) bool {
 		}
 	}
 	return true
+}
+
+// messagesPrefixDigestDepth returns the number of leading messages of msgs
+// whose storage digest equals target, or -1 when no prefix matches. The
+// digest accumulates exactly like digestAndSizeSessionMessages, so a match at
+// depth k means msgs[:k] is byte-for-byte the transcript that produced target.
+func messagesPrefixDigestDepth(msgs []provider.Message, target [sha256.Size]byte) int {
+	h := sha256.New()
+	sum := make([]byte, 0, sha256.Size)
+	for i, m := range msgs {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return -1
+		}
+		h.Write(b)
+		h.Write([]byte{'\n'})
+		sum = h.Sum(sum[:0])
+		if bytes.Equal(sum, target[:]) {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// appendCoversPersistedBaseline reports whether an append-shaped write (disk
+// transcript a prefix of next, modulo a compatible leading-system swap) still
+// covers everything this session ever persisted: the baseline digest must be
+// reachable as a prefix of the pending snapshot, and the disk transcript must
+// still extend at least to that depth. A shorter disk transcript means some
+// other runtime deliberately rewound below the baseline — appending over it
+// would resurrect the removed suffix, so the caller must conflict instead.
+func appendCoversPersistedBaseline(next, existing []provider.Message, baseDigest [sha256.Size]byte) bool {
+	depth := messagesPrefixDigestDepth(next, baseDigest)
+	if depth < 0 && len(next) > 0 && len(existing) > 0 &&
+		next[0].Role == provider.RoleSystem && existing[0].Role == provider.RoleSystem &&
+		!messagesEqualForStorage(next[0], existing[0]) {
+		// A resume that swapped the system prompt persisted its baseline with
+		// the previous system message — the one still on disk. Re-anchor the
+		// search on that message so the swap alone doesn't hide the baseline.
+		variant := append([]provider.Message{existing[0]}, next[1:]...)
+		depth = messagesPrefixDigestDepth(variant, baseDigest)
+	}
+	return depth >= 0 && len(existing) >= depth
 }
 
 func messagesHavePrefixWithCompatibleSystem(full, prefix []provider.Message) bool {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -403,7 +403,10 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		// An unknown-revision baseline (meta sidecar unreadable at load) cannot
 		// vouch for revision equality; the digest/prefix checks above already
 		// vouch for the content, so only a known baseline arms the CAS check.
-		if baseState.ok && baseState.revisionKnown && currentRevision != baseState.revision && !contentUnchanged {
+		// Exact append is also safe with a stale baseline: the disk transcript is
+		// a byte-for-byte prefix of the snapshot, so the write only records the
+		// suffix at the current disk revision instead of rewriting that prefix.
+		if baseState.ok && baseState.revisionKnown && currentRevision != baseState.revision && !contentUnchanged && !exactAppend {
 			return snapshotWriteDecision{}, snapshotConflict(path, existing, next, baseState.revision, currentRevision)
 		}
 		// A normalized-dirty load means LoadSession repaired the history on the

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -490,6 +490,130 @@ func TestSaveSnapshotAllowsExactAppendFromStaleRevisionBaseline(t *testing.T) {
 	}
 }
 
+func TestSaveSnapshotAllowsCompatibleSystemAppendFromStaleRevisionBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys v1")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	staleBaseline := s.persistState(path)
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot prefix append: %v", err)
+	}
+	prefixMeta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta prefix ok=%v err=%v", ok, err)
+	}
+
+	// A resume swapped the system prompt, then the turn appended a message —
+	// while the persistence baseline still points at the first save.
+	msgs := s.Snapshot()
+	msgs[0] = provider.Message{Role: provider.RoleSystem, Content: "sys v2"}
+	msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: "two"})
+	s.Replace(msgs)
+	s.setPersistedBaseline(path, staleBaseline.digest, staleBaseline.version, staleBaseline.revision, true)
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot compatible-system append from stale baseline: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession appended: %v", err)
+	}
+	if got := loaded.Messages[0].Content; got != "sys v2" {
+		t.Fatalf("system after compatible append = %q, want sys v2", got)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "two" {
+		t.Fatalf("tail after compatible append = %q, want two", got)
+	}
+	advancedMeta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta advanced ok=%v err=%v", ok, err)
+	}
+	if advancedMeta.Revision != prefixMeta.Revision+1 {
+		t.Fatalf("revision after compatible append = %d, want %d", advancedMeta.Revision, prefixMeta.Revision+1)
+	}
+	if matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after compatible append = %v err=%v, want none", matches, err)
+	}
+}
+
+func TestSaveSnapshotRefusesStaleBaselineAppendOverRewoundTranscript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot extend: %v", err)
+	}
+
+	// Another runtime rewinds the transcript below this session's baseline
+	// (e.g. a cancelled turn truncated the partial assistant reply).
+	other, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession other: %v", err)
+	}
+	other.Replace(other.Snapshot()[:2])
+	if err := other.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite rewind: %v", err)
+	}
+
+	// Appending from the stale baseline would resurrect the rewound suffix.
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "two"})
+	if err := s.SaveSnapshot(path); !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot over rewound transcript err = %v, want ErrSessionSnapshotConflict", err)
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession after refused append: %v", err)
+	}
+	if got := len(loaded.Messages); got != 2 {
+		t.Fatalf("messages after refused append = %d, want rewound 2", got)
+	}
+}
+
+func TestSaveRewriteAllowsOwnedRewriteAfterLedgerReset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial turn"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	// The meta sidecar (revision ledger) is lost — e.g. swept by a cleanup
+	// that deleted session-adjacent files. The transcript itself is intact.
+	if err := os.Remove(BranchMetaPath(path)); err != nil {
+		t.Fatalf("remove sidecar: %v", err)
+	}
+
+	// A cancelled turn strips the partial reply and flushes via SaveRewrite.
+	msgs := s.Snapshot()
+	s.Replace(msgs[:len(msgs)-1])
+	if err := s.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite after ledger reset: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession truncated: %v", err)
+	}
+	if got := len(loaded.Messages); got != 2 {
+		t.Fatalf("messages after owned rewrite = %d, want 2", got)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "first" {
+		t.Fatalf("tail after owned rewrite = %q, want first", got)
+	}
+	if matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after owned rewrite = %v err=%v, want none", matches, err)
+	}
+}
+
 func TestSaveSnapshotStillPersistsNormalizedRepair(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	mal := NewSession("sys")

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -697,7 +697,7 @@ func TestSaveSnapshotRejectsStalePrefixAfterSystemPromptRefresh(t *testing.T) {
 	}
 }
 
-func TestSaveRewriteRejectsRevisionCASConflict(t *testing.T) {
+func TestSaveRewriteAllowsRewriteOverSameContentForeignStamp(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	base := NewSession("sys")
 	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
@@ -710,6 +710,9 @@ func TestSaveRewriteRejectsRevisionCASConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSession stale: %v", err)
 	}
+	// Another runtime healed the ledger over identical content: the revision
+	// advanced under a foreign writer id, but the recorded digest still
+	// describes the exact bytes this session loaded and owns.
 	meta, ok, err := LoadBranchMeta(path)
 	if err != nil || !ok {
 		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
@@ -724,9 +727,63 @@ func TestSaveRewriteRejectsRevisionCASConflict(t *testing.T) {
 		{Role: provider.RoleSystem, Content: "sys"},
 		{Role: provider.RoleUser, Content: "summarized first"},
 	})
+	if err := stale.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite over same-content stamp: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "summarized first" {
+		t.Fatalf("tail after owned rewrite = %q, want summarized first", got)
+	}
+	advanced, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta advanced ok=%v err=%v", ok, err)
+	}
+	if advanced.Revision != meta.Revision+1 {
+		t.Fatalf("revision after rewrite = %d, want %d", advanced.Revision, meta.Revision+1)
+	}
+	if matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after owned rewrite = %v err=%v, want none", matches, err)
+	}
+}
+
+func TestSaveRewriteRejectsForeignStampForUnattributedBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	base.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("Save base: %v", err)
+	}
+
+	stale, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession stale: %v", err)
+	}
+	// A foreign stamp whose digest disagrees with the on-disk transcript is
+	// the aftermath of a save whose bytes and record split — the transcript
+	// cannot be attributed, so the rewrite must fall to the conflict path.
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	meta.Revision++
+	meta.WriterID = "other-writer"
+	meta.ContentDigest = "0000000000000000000000000000000000000000000000000000000000000000"
+	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+		t.Fatalf("stamp foreign digest: %v", err)
+	}
+
+	stale.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "summarized first"},
+	})
 	err = stale.SaveRewrite(path)
 	if !errors.Is(err, ErrSessionSnapshotConflict) {
-		t.Fatalf("SaveRewrite revision conflict err = %v, want ErrSessionSnapshotConflict", err)
+		t.Fatalf("SaveRewrite unattributed stamp err = %v, want ErrSessionSnapshotConflict", err)
 	}
 	var conflict *SessionSnapshotConflictError
 	if !errors.As(err, &conflict) || conflict.Kind != SessionSnapshotConflictDiverged {

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -444,6 +444,52 @@ func TestSaveSnapshotSameContentByOtherRuntimeKeepsClonedBaselineWritable(t *tes
 	}
 }
 
+func TestSaveSnapshotAllowsExactAppendFromStaleRevisionBaseline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot base: %v", err)
+	}
+	staleBaseline := s.persistState(path)
+
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot prefix append: %v", err)
+	}
+	prefixMeta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta prefix ok=%v err=%v", ok, err)
+	}
+	if prefixMeta.Revision == staleBaseline.revision {
+		t.Fatalf("prefix revision did not advance: %d", prefixMeta.Revision)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "two"})
+	s.setPersistedBaseline(path, staleBaseline.digest, staleBaseline.version, staleBaseline.revision, true)
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot exact append from stale revision baseline: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession appended: %v", err)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "two" {
+		t.Fatalf("tail after stale-baseline append = %q, want two", got)
+	}
+	advancedMeta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta advanced ok=%v err=%v", ok, err)
+	}
+	if advancedMeta.Revision != prefixMeta.Revision+1 {
+		t.Fatalf("revision after stale-baseline append = %d, want %d", advancedMeta.Revision, prefixMeta.Revision+1)
+	}
+	if matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("recovery branches after stale-baseline append = %v err=%v, want none", matches, err)
+	}
+}
+
 func TestSaveSnapshotStillPersistsNormalizedRepair(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	mal := NewSession("sys")


### PR DESCRIPTION
## TL;DR / 摘要

会话保存的 CAS 检查在若干「内容其实安全」的场景下误判为陈旧运行时冲突,把正常的追加/重写保存分叉成冲突副本(recovery branch)。本 PR 以内容证据(digest 相等、前缀关系、基线可达性)放行这些保存,同时封住一个复活孔,并对所有「字节无法归属」的场景保留保守冲突。

## Problem

A runtime whose in-memory revision baseline went stale for benign reasons — meta sidecar deleted or rebuilt, a same-content ledger heal by a mirror runtime, another runtime recording messages the snapshot already contains — had its next save misread as a stale-runtime conflict. User-visible symptom: a routine turn (e.g. asking the AI to delete local files) suddenly forks a 冲突副本 recovery branch; a cancelled turn's truncation could silently fail to stick.

## Changes

1. **7f94919 — allow exact append from a stale revision baseline.** An append-only write records only the suffix at the current disk revision; it cannot destroy disk content.
2. **895972d — anchor stale-baseline saves to the persisted baseline.** Replaces the blanket exact-append exemption with a reachability guard: the persisted baseline digest must be locatable among the pending snapshot's incremental prefix digests (re-anchored on the disk system message when a resume swapped the prompt), and the disk transcript must still reach that depth.
   - extends the exemption to compatible-system appends (resume swapped the leading system prompt, then a routine append forked a spurious recovery branch)
   - closes the gap the first commit opened: an append over a transcript another runtime deliberately rewound below the baseline conflicts again instead of resurrecting the removed suffix
   - `ownsPersistedState`: an absent revision ledger (recorded revisions start at 1, so disk revision 0 means the sidecar was deleted or rebuilt by a listing-only writer) no longer revokes the rewrite ownership the digest+version match proves — cancel-turn truncations and compaction rewrites survive a swept sidecar
3. **f4591d7 — a same-content foreign stamp keeps rewrite ownership.** When the baseline digest, the on-disk transcript digest, and the ledger's recorded digest all describe the same bytes, a foreign revision stamp (same-content heal) is bookkeeping over content this session owns. Rewriting destroys nothing of the stamper's; at worst the conflict relocates to the stamper's next divergent save, which forks from its own in-memory history — no content-loss path opens.

## Deliberately kept conservative (still conflicts)

- **Unattributable bytes**: a ledger digest that disagrees with the on-disk transcript is the aftermath of a save whose bytes landed but whose revision record failed. Event records carry a writer id, but it is per-process (shared by all sessions in one process), so the bytes cannot be safely attributed — the conflict path is the only thing preserving them. Follow-up idea: per-session writer identity in event records would make this case fixable.
- **True divergence**: two runtimes writing different message sequences still fork a recovery branch — correct protection, unchanged.
- **Asymmetric leading-system shapes / in-memory history replaced outside the rewrite channel**: kept conservative (parity with main); reachable only through pathological flows the controller already guards.

## Safety argument

- Every newly-allowed write is proven content-safe at the byte level and decided under the save file locks (no check-to-write race).
- `appendFrom` derives from the disk transcript, not the baseline, so dual runtimes sharing generation never duplicate messages.
- Sidecar writes keep `preserveBranchMetaPersistence` revision monotonicity; event replay does not consume event revisions (reload verified in tests after a ledger reset).

## Tests

- New/updated regression tests: stale-baseline exact append, compatible-system append from stale baseline, refusal over an externally rewound transcript, owned rewrite after ledger reset, rewrite over a same-content foreign stamp, refusal of an unattributed foreign stamp.
- `go test ./internal/agent ./internal/control -count=1`
- `gofmt` / `go vet` / `go build ./...`
