### PR TITLE
Stop readiness permission loops / 阻止 readiness 权限循环

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -398,6 +398,28 @@ type Agent struct {
 	stormSig   string
 	stormCount int
 
+	// blockedTurnStreak counts consecutive turns in which every tool call was
+	// blocked by the host (permission, plan mode, hook, or loop guard).
+	// stormSig catches a model fixated on one call shape; this catches a model
+	// rotating between blocked shapes — alternating tools, reordering a batch,
+	// or blockers whose text varies per attempt — which is zero progress all
+	// the same. Reset by any turn containing a non-blocked outcome and at the
+	// start of each user turn. See applyStormBreaker.
+	blockedTurnStreak int
+
+	// loopGuardArmed / loopGuardReceiptMark let final readiness stand down
+	// after a loop guard fired this user turn: once the host has told the model
+	// to stop retrying and report the blocker, demanding the receipts that the
+	// blocker prevents would restart the loop the guard just broke. The mark is
+	// the evidence-ledger receipt count from just before the guarded batch, so
+	// real progress — a successful write or command receipt landing after it —
+	// revokes the pass, while the bookkeeping the guard itself recommends
+	// (ask, todo_write, complete_step) keeps it. Host state, not message text:
+	// tool output that merely quotes "[loop guard]" must not unlock readiness.
+	// Reset at the start of each user turn. See loopGuardAllowsFinal.
+	loopGuardArmed       bool
+	loopGuardReceiptMark int
+
 	// repeatSuccessCounts tracks write-like tool calls that have already
 	// succeeded in this user turn. This catches the complementary loop shape to
 	// stormSig: a model keeps doing the same successful write, so there is no
@@ -958,6 +980,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		a.evidence.Reset()
 	}
 	a.repeatSuccessCounts = nil
+	a.blockedTurnStreak = 0
+	a.loopGuardArmed = false
+	a.loopGuardReceiptMark = 0
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
 	rawInput := input
 	memoryCompilerInput := rawInput
@@ -1235,7 +1260,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	if !hasWriter {
 		if len(missing) > 0 {
-			if a.latestToolResultHasLoopGuard() {
+			if a.loopGuardAllowsFinal() {
 				return out
 			}
 			out.reason = strings.Join(missing, "; ")
@@ -1262,28 +1287,39 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	if len(missing) == 0 {
 		return out
 	}
-	if a.latestToolResultHasLoopGuard() {
+	if a.loopGuardAllowsFinal() {
 		return out
 	}
 	out.reason = strings.Join(missing, "; ")
 	return out
 }
 
-func (a *Agent) latestToolResultHasLoopGuard() bool {
-	if a == nil || a.session == nil {
+// armLoopGuardPass records that a loop guard fired this user turn.
+// receiptMark is the evidence-ledger receipt count from just before the
+// guarded batch ran, so a successful write or command receipt recorded after
+// it counts as real progress and revokes the pass (see loopGuardAllowsFinal).
+func (a *Agent) armLoopGuardPass(receiptMark int) {
+	a.loopGuardArmed = true
+	a.loopGuardReceiptMark = receiptMark
+}
+
+// loopGuardAllowsFinal reports whether final readiness should stand down: a
+// loop guard fired this user turn and no host-observable progress — a
+// successful write or command receipt — has landed since. In that state the
+// missing receipts are exactly what the blocker prevents, so demanding them
+// would restart the retry loop the guard just broke; the model must be free to
+// report the blocker instead. The bookkeeping the guard recommends (ask,
+// todo_write, complete_step) produces neither write nor command receipts, so
+// it keeps the pass; real progress revokes it because receipts are obtainable
+// again and readiness should resume enforcing them.
+func (a *Agent) loopGuardAllowsFinal() bool {
+	if a == nil || !a.loopGuardArmed {
 		return false
 	}
-	msgs := a.session.Snapshot()
-	for i := len(msgs) - 1; i >= 0; i-- {
-		msg := msgs[i]
-		switch msg.Role {
-		case provider.RoleTool:
-			return strings.Contains(msg.Content, "[loop guard]")
-		case provider.RoleUser:
-			return false
-		}
+	if a.evidence == nil {
+		return true
 	}
-	return false
+	return !a.evidence.HasWriteOrCommandSince(a.loopGuardReceiptMark)
 }
 
 func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
@@ -1829,6 +1865,13 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	results := make([]string, len(calls))
 	outcomes := make([]toolOutcome, len(calls))
 	durations := make([]int64, len(calls))
+	// Snapshot the receipt count before the batch runs: if a loop guard fires
+	// for this batch, successes recorded during it (a mixed batch where only one
+	// call was guard-blocked) must already count as progress against the pass.
+	receiptMark := 0
+	if a.evidence != nil {
+		receiptMark = a.evidence.Len()
+	}
 	run := func(i int) {
 		start := time.Now()
 		outcomes[i] = a.executeOne(ctx, calls[i])
@@ -1924,7 +1967,7 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 		a.compilerTurn.RecordToolResults(records)
 	}
 	if !cancelled {
-		a.applyStormBreaker(calls, outcomes, results)
+		a.applyStormBreaker(calls, outcomes, results, receiptMark)
 	}
 	return results
 }
@@ -2036,55 +2079,101 @@ const stormBreakThreshold = 3
 // no-op/write loop and should be redirected to a different tool or final answer.
 const repeatSuccessBreakThreshold = 2
 
-// applyStormBreaker detects a run of identically failing or blocked turns and,
-// past the threshold, rewrites the model-facing result (results[0]) into a
-// directive to change approach. It keys on each call's (tool, error/blocker) —
-// not its args — because a stuck model reworks the arguments cosmetically while
-// hitting the same host refusal or failure (see the stormSig field doc). A turn
-// is a fixation candidate when every one of its calls errored or was blocked.
-// Any success or different batch shape is varied work, so it resets the counter.
-// This covers both the single-call spiral and a repeated multi-call batch. The
-// hard maxSteps guard remains the ultimate backstop; this just keeps the loop
-// from burning that whole budget bouncing off the same host response.
-func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string) {
-	sig, ok := batchStormSignature(calls, outcomes)
-	if !ok {
-		a.stormSig, a.stormCount = "", 0
-		return
-	}
-	if sig != a.stormSig {
-		a.stormSig, a.stormCount = sig, 1
-		return
-	}
-	a.stormCount++
-	if a.stormCount < stormBreakThreshold {
-		return
-	}
-	subject := fmt.Sprintf("%q", calls[0].Name)
-	short := calls[0].Name
-	if len(calls) > 1 {
-		subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
-		short = fmt.Sprintf("a batch of %d calls", len(calls))
-	}
-	anyBlocked := false
+// loopGuardBlockErrMsg is the errMsg carried by a repeat-success loop-guard
+// block. applyStormBreaker matches it to arm the final-readiness loop-guard
+// pass, since that guard also invites the model to report the blocker.
+const loopGuardBlockErrMsg = "blocked by loop guard"
+
+// applyStormBreaker detects a run of zero-progress turns and, past the
+// threshold, rewrites the model-facing result (results[0]) into a directive to
+// change approach. Two detectors, because a stuck model varies its retries two
+// ways. The signature detector keys on each call's (tool, error/blocker) — not
+// its args — since a stuck model reworks the arguments cosmetically while
+// hitting the same host refusal or failure (see the stormSig field doc). The
+// streak detector counts consecutive turns in which every call was blocked,
+// regardless of shape: rotating tools, reordering a batch, or a blocker whose
+// text varies per attempt escapes the signature but is still zero progress —
+// only a host refusal (not a plain error) proves that, so the streak requires
+// blocked outcomes. Any success resets both. When a guard fires — or when a
+// call in the batch was already blocked by the per-call repeat-success guard —
+// the final-readiness loop-guard pass is armed so the model may report the
+// blocker (see loopGuardAllowsFinal). The hard maxSteps guard remains the
+// ultimate backstop; this just keeps the loop from burning that whole budget
+// bouncing off the same host refusals.
+func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) {
+	allBlocked := len(outcomes) > 0
 	for _, outcome := range outcomes {
-		if outcome.blocked {
-			anyBlocked = true
+		if !outcome.blocked {
+			allBlocked = false
 			break
 		}
 	}
-	action := "failed"
-	advice := "Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer."
-	if anyBlocked {
-		action = "been blocked or failed"
-		advice = "Change approach: do not keep retrying a blocked tool by changing the command or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
+	if allBlocked {
+		a.blockedTurnStreak++
+	} else {
+		a.blockedTurnStreak = 0
 	}
-	results[0] = outcomes[0].output + fmt.Sprintf(
-		"\n\n[loop guard] %s has now %s %d times in a row with the same host response. Re-sending it — even with the wording changed — will not help: the calls keep hitting the same outcome. %s",
-		subject, action, a.stormCount, advice)
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf(
-		"loop guard: %s hit the same host response %d× — nudging the model to change approach",
-		short, a.stormCount)})
+	for _, outcome := range outcomes {
+		if outcome.blocked && outcome.errMsg == loopGuardBlockErrMsg {
+			a.armLoopGuardPass(receiptMark)
+			break
+		}
+	}
+
+	sig, ok := batchStormSignature(calls, outcomes)
+	switch {
+	case !ok:
+		a.stormSig, a.stormCount = "", 0
+	case sig != a.stormSig:
+		a.stormSig, a.stormCount = sig, 1
+	default:
+		a.stormCount++
+	}
+	stormHit := ok && a.stormCount >= stormBreakThreshold
+	streakHit := allBlocked && a.blockedTurnStreak >= stormBreakThreshold
+	if !stormHit && !streakHit {
+		return
+	}
+
+	const blockedAdvice = "Change approach: do not keep retrying a blocked tool by changing the tool, command, or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
+	var guard, notice string
+	if stormHit {
+		subject := fmt.Sprintf("%q", calls[0].Name)
+		short := calls[0].Name
+		if len(calls) > 1 {
+			subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
+			short = fmt.Sprintf("a batch of %d calls", len(calls))
+		}
+		anyBlocked := false
+		for _, outcome := range outcomes {
+			if outcome.blocked {
+				anyBlocked = true
+				break
+			}
+		}
+		action := "failed"
+		advice := "Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer."
+		if anyBlocked {
+			action = "been blocked or failed"
+			advice = blockedAdvice
+		}
+		guard = fmt.Sprintf(
+			"[loop guard] %s has now %s %d times in a row with the same host response. Re-sending it — even with the wording changed — will not help: the calls keep hitting the same outcome. %s",
+			subject, action, a.stormCount, advice)
+		notice = fmt.Sprintf(
+			"loop guard: %s hit the same host response %d× — nudging the model to change approach",
+			short, a.stormCount)
+	} else {
+		guard = fmt.Sprintf(
+			"[loop guard] every tool call in the last %d turns has been blocked by the host (permission, plan mode, hook, or loop guard). Switching tools, reordering calls, or rewording arguments will not help while the blockers stand. %s",
+			a.blockedTurnStreak, blockedAdvice)
+		notice = fmt.Sprintf(
+			"loop guard: every tool call blocked %d turns in a row — nudging the model to change approach",
+			a.blockedTurnStreak)
+	}
+	results[0] = outcomes[0].output + "\n\n" + guard
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: notice})
+	a.armLoopGuardPass(receiptMark)
 }
 
 // batchStormSignature returns a per-turn fixation signature — each call's
@@ -2139,7 +2228,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		return toolOutcome{
 			output:  out,
 			blocked: true,
-			errMsg:  "blocked by loop guard",
+			errMsg:  loopGuardBlockErrMsg,
 		}
 	}
 	if out, blocked := a.staleAnchorEditBlock(call); blocked {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -385,15 +385,16 @@ type Agent struct {
 	compactStuck        bool
 	consecutiveCompacts int
 
-	// stormSig / stormCount track a run of turns that keep failing the same way so
-	// the loop can break a death-spiral. The signature is each call's (tool, error)
-	// in order, NOT (tool, args): a stuck model reliably reworks the arguments
-	// cosmetically (a re-worded essay, a reordered object) while the call fails
-	// identically every time — keying on args misses the loop entirely (observed
-	// live against truncated tool-call arguments). Because errors that embed their
-	// subject (e.g. "file not found: /x") differ per target, genuine varied probing
-	// does not collapse to one signature. Reset whenever a turn does anything else
-	// (a different failure shape, or any success). See applyStormBreaker.
+	// stormSig / stormCount track a run of turns that keep failing or getting
+	// blocked the same way so the loop can break a death-spiral. The signature is
+	// each call's (tool, error/blocker) in order, NOT (tool, args): a stuck model
+	// reliably reworks the arguments cosmetically (a re-worded essay, a reordered
+	// object, a different shell command) while the host returns the same refusal or
+	// failure every time — keying on args misses the loop entirely. Because errors
+	// that embed their subject (e.g. "file not found: /x") differ per target,
+	// genuine varied probing does not collapse to one signature. Reset whenever a
+	// turn does anything else (a different failure/block shape, or any success).
+	// See applyStormBreaker.
 	stormSig   string
 	stormCount int
 
@@ -1234,6 +1235,9 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	if !hasWriter {
 		if len(missing) > 0 {
+			if a.latestToolResultHasLoopGuard() {
+				return out
+			}
 			out.reason = strings.Join(missing, "; ")
 		}
 		return out
@@ -1258,8 +1262,28 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	if len(missing) == 0 {
 		return out
 	}
+	if a.latestToolResultHasLoopGuard() {
+		return out
+	}
 	out.reason = strings.Join(missing, "; ")
 	return out
+}
+
+func (a *Agent) latestToolResultHasLoopGuard() bool {
+	if a == nil || a.session == nil {
+		return false
+	}
+	msgs := a.session.Snapshot()
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := msgs[i]
+		switch msg.Role {
+		case provider.RoleTool:
+			return strings.Contains(msg.Content, "[loop guard]")
+		case provider.RoleUser:
+			return false
+		}
+	}
+	return false
 }
 
 func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
@@ -1469,7 +1493,7 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 }
 
 func finalReadinessRetryMessage(reason string) string {
-	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied. If the blocked item needs user input, a user-owned choice, or manual review, call the ask tool with concrete options and wait for its tool result; do not ask in prose, and do not claim the user answered unless an actual ask tool result or a new user message says so."
+	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run only the required tool calls, then answer when readiness is satisfied. Prefer signing off completed work with complete_step and updating todo_write from existing receipts; do not run exploratory bash commands just to satisfy readiness. If a permission, plan-mode, hook, or loop-guard block prevents the required receipt, do not keep retrying the blocked command with different wording. If the blocked item needs user input, a user-owned choice, or manual review, call the ask tool with concrete options and wait for its tool result; do not ask in prose, and do not claim the user answered unless an actual ask tool result or a new user message says so."
 }
 
 func shouldNudgeExecutorHandoff(input, answer string) bool {
@@ -2012,17 +2036,16 @@ const stormBreakThreshold = 3
 // no-op/write loop and should be redirected to a different tool or final answer.
 const repeatSuccessBreakThreshold = 2
 
-// applyStormBreaker detects a run of identically-failing turns and, past the
-// threshold, rewrites the model-facing result (results[0]) into a directive to
-// change approach. It keys on each call's (tool, error) — not its args — because a
-// stuck model reworks the arguments cosmetically while failing identically (see
-// the stormSig field doc). A turn is a fixation candidate only when every one of
-// its calls errored and none was merely blocked by plan mode / permissions (those
-// carry a clear, distinct message the model can already act on). Any success, any
-// block, or a different batch shape is varied work, so it resets the counter. This
-// covers both the single-call spiral and a repeated multi-call batch. The hard
-// maxSteps guard remains the ultimate backstop; this just keeps the loop from
-// burning that whole budget bouncing off the same failure.
+// applyStormBreaker detects a run of identically failing or blocked turns and,
+// past the threshold, rewrites the model-facing result (results[0]) into a
+// directive to change approach. It keys on each call's (tool, error/blocker) —
+// not its args — because a stuck model reworks the arguments cosmetically while
+// hitting the same host refusal or failure (see the stormSig field doc). A turn
+// is a fixation candidate when every one of its calls errored or was blocked.
+// Any success or different batch shape is varied work, so it resets the counter.
+// This covers both the single-call spiral and a repeated multi-call batch. The
+// hard maxSteps guard remains the ultimate backstop; this just keeps the loop
+// from burning that whole budget bouncing off the same host response.
 func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string) {
 	sig, ok := batchStormSignature(calls, outcomes)
 	if !ok {
@@ -2043,27 +2066,40 @@ func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutc
 		subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
 		short = fmt.Sprintf("a batch of %d calls", len(calls))
 	}
+	anyBlocked := false
+	for _, outcome := range outcomes {
+		if outcome.blocked {
+			anyBlocked = true
+			break
+		}
+	}
+	action := "failed"
+	advice := "Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer."
+	if anyBlocked {
+		action = "been blocked or failed"
+		advice = "Change approach: do not keep retrying a blocked tool by changing the command or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
+	}
 	results[0] = outcomes[0].output + fmt.Sprintf(
-		"\n\n[loop guard] %s has now failed %d times in a row with the same error. Re-sending it — even with the wording changed — will not help: the calls keep failing the same way. Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer.",
-		subject, a.stormCount)
+		"\n\n[loop guard] %s has now %s %d times in a row with the same host response. Re-sending it — even with the wording changed — will not help: the calls keep hitting the same outcome. %s",
+		subject, action, a.stormCount, advice)
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf(
-		"loop guard: %s failed %d× the same way — nudging the model to change approach",
+		"loop guard: %s hit the same host response %d× — nudging the model to change approach",
 		short, a.stormCount)})
 }
 
 // batchStormSignature returns a per-turn fixation signature — each call's
-// (name, error) in order — and ok=true only when every call errored and none was
-// merely blocked. ok=false (any success or block) means the turn made varied
-// progress, so the caller resets the counter. Keying on the error rather than the
-// args is deliberate: a stuck model reworks the arguments while failing the same
-// way, so identical-args matching would miss the loop.
+// (name, error/blocker) in order — and ok=true only when every call errored or
+// was blocked. ok=false (any success) means the turn made progress, so the
+// caller resets the counter. Keying on the host response rather than the args is
+// deliberate: a stuck model reworks the arguments while hitting the same
+// response, so identical-args matching would miss the loop.
 func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (string, bool) {
 	if len(calls) == 0 {
 		return "", false
 	}
 	var sb strings.Builder
 	for i := range calls {
-		if outcomes[i].errMsg == "" || outcomes[i].blocked {
+		if outcomes[i].errMsg == "" {
 			return "", false
 		}
 		sb.WriteString(calls[i].Name)

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -458,6 +458,66 @@ func TestFinalReadinessPermissionLoopGuardAllowsBlockedFinal(t *testing.T) {
 	}
 }
 
+// TestFinalReadinessPermissionLoopGuardAllowsBlockedFinalForBatch pins the
+// multi-call variant: the guard text lands on the batch's FIRST result, so any
+// detection keyed to the latest tool message misses it. The loop-guard pass is
+// host state and must let the model report the blocker regardless of where in
+// the batch the guard text sits.
+func TestFinalReadinessPermissionLoopGuardAllowsBlockedFinalForBatch(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("w1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("t1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature final"}, {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("b1a", "bash", `{"command":"go test ./..."}`),
+			toolCallChunk("b1b", "bash", `{"command":"go vet ./..."}`),
+			{Type: provider.ChunkDone},
+		},
+		{
+			toolCallChunk("b2a", "bash", `{"command":"git status --short"}`),
+			toolCallChunk("b2b", "bash", `{"command":"git diff --stat"}`),
+			{Type: provider.ChunkDone},
+		},
+		{
+			toolCallChunk("b3a", "bash", `{"command":"ls -la"}`),
+			toolCallChunk("b3b", "bash", `{"command":"pwd"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "blocked by permission"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{
+		Gate: &stubGate{deny: map[string]bool{"bash": true}},
+	}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit with todo, then hit batched bash permission blocks"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 6 {
+		t.Fatalf("provider calls = %d, want readiness retry, three blocked batches, then final", prov.call)
+	}
+	results := toolResults(a.session, "bash")
+	if len(results) != 2*stormBreakThreshold {
+		t.Fatalf("bash results = %d, want %d blocked attempts across three batches", len(results), 2*stormBreakThreshold)
+	}
+	if !strings.Contains(results[len(results)-2], "[loop guard]") {
+		t.Fatalf("first result of the guarded batch should carry the loop guard, got: %q", results[len(results)-2])
+	}
+	if strings.Contains(results[len(results)-1], "[loop guard]") {
+		t.Fatalf("last result of the guarded batch should stay untouched (the pass must not depend on it), got: %q", results[len(results)-1])
+	}
+}
+
 func TestTodoWriteOnlyTurnMayEndWithIncompleteTodos(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -412,6 +412,52 @@ func TestFinalReadinessStopsAfterRepeatedBlocks(t *testing.T) {
 	}
 }
 
+func TestFinalReadinessPermissionLoopGuardAllowsBlockedFinal(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("w1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("t1", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature final"}, {Type: provider.ChunkDone}},
+		{toolCallChunk("b1", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("b2", "bash", `{"command":"git status --short"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("b3", "bash", `{"command":"ls -la"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "blocked by permission"}, {Type: provider.ChunkDone}},
+	}}
+	sink, notices := warnNoticeRecorder()
+	a := New(prov, reg, NewSession(""), Options{
+		Gate: &stubGate{deny: map[string]bool{"bash": true}},
+	}, sink)
+
+	if err := a.Run(context.Background(), "edit with todo, then hit bash permission blocks"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 6 {
+		t.Fatalf("provider calls = %d, want readiness retry, three blocked bash calls, then final", prov.call)
+	}
+	if !sessionHasUserMessageContaining(a.session, "final-answer readiness") {
+		t.Fatal("missing synthetic readiness retry message")
+	}
+	if got := lastToolResult(a.session, "bash"); !strings.Contains(got, "[loop guard]") {
+		t.Fatalf("last bash result = %q, want permission loop guard", got)
+	}
+	if got := toolResults(a.session, "bash"); len(got) != stormBreakThreshold {
+		t.Fatalf("bash results = %d, want exactly %d blocked attempts", len(got), stormBreakThreshold)
+	}
+	if len(*notices) == 0 {
+		t.Fatal("loop guard should emit a user-facing warning notice")
+	}
+}
+
 func TestTodoWriteOnlyTurnMayEndWithIncompleteTodos(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -102,12 +102,9 @@ func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 func TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
-	sess := NewSession("")
-	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
-	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
-	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "blocked: denied\n\n[loop guard] bash kept hitting the same host response"})
-	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "I am blocked by permission."})
-	a := &Agent{evidence: readinessLedger(writer, todo), session: sess}
+	ledger := readinessLedger(writer, todo)
+	a := &Agent{evidence: ledger}
+	a.armLoopGuardPass(ledger.Len())
 
 	got := a.finalReadinessCheck()
 	if !got.applies {
@@ -115,6 +112,59 @@ func TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker(t *testing.T) {
 	}
 	if got.reason != "" {
 		t.Fatalf("finalReadinessCheck() reason = %q, want loop guard to allow final blocker report", got.reason)
+	}
+}
+
+// TestFinalReadinessLoopGuardPassSurvivesBookkeeping proves the exact actions
+// the loop guard recommends — ask, todo_write, complete_step — do not revoke
+// the pass: the model must be able to record the blocker and then report it.
+func TestFinalReadinessLoopGuardPassSurvivesBookkeeping(t *testing.T) {
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	ledger := readinessLedger(writer, todo)
+	a := &Agent{evidence: ledger}
+	a.armLoopGuardPass(ledger.Len())
+
+	ledger.Record(evidence.Receipt{ToolName: "ask", Success: true})
+	ledger.Record(evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}})
+	ledger.Record(evidence.Receipt{ToolName: "complete_step", Success: true, Step: "edit"})
+
+	if got := a.finalReadinessCheck(); got.reason != "" {
+		t.Fatalf("finalReadinessCheck() reason = %q, want bookkeeping after the guard to keep the pass", got.reason)
+	}
+}
+
+// TestFinalReadinessLoopGuardPassRevokedByRealProgress proves a successful
+// write or command receipt after the guard revokes the pass: receipts are
+// obtainable again, so readiness resumes enforcing them.
+func TestFinalReadinessLoopGuardPassRevokedByRealProgress(t *testing.T) {
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	ledger := readinessLedger(writer, todo)
+	a := &Agent{evidence: ledger}
+	a.armLoopGuardPass(ledger.Len())
+
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
+
+	if got := a.finalReadinessCheck(); got.reason == "" {
+		t.Fatal("finalReadinessCheck() reason empty, want real progress after the guard to revoke the pass")
+	}
+}
+
+// TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput proves the pass is host
+// state, not message text: a tool result that merely quotes "[loop guard]"
+// (a grep over this repo, a pasted transcript) must not unlock readiness.
+func TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput(t *testing.T) {
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	sess := NewSession("")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
+	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "agent.go:2082: \"[loop guard] %s has now %s %d times\""})
+	a := &Agent{evidence: readinessLedger(writer, todo), session: sess}
+
+	if got := a.finalReadinessCheck(); got.reason == "" {
+		t.Fatal("finalReadinessCheck() reason empty, want quoted loop-guard text to be ignored")
 	}
 }
 

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -6,6 +6,7 @@ import (
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/instruction"
+	"reasonix/internal/provider"
 )
 
 func readinessLedger(receipts ...evidence.Receipt) *evidence.Ledger {
@@ -98,6 +99,25 @@ func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 	}
 }
 
+func TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker(t *testing.T) {
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	sess := NewSession("")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
+	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "blocked: denied\n\n[loop guard] bash kept hitting the same host response"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "I am blocked by permission."})
+	a := &Agent{evidence: readinessLedger(writer, todo), session: sess}
+
+	got := a.finalReadinessCheck()
+	if !got.applies {
+		t.Fatalf("finalReadinessCheck() applies = false, want true audit after loop guard")
+	}
+	if got.reason != "" {
+		t.Fatalf("finalReadinessCheck() reason = %q, want loop guard to allow final blocker report", got.reason)
+	}
+}
+
 func TestFinalReadinessRetryMessageKeepsUserChoicesInteractive(t *testing.T) {
 	msg := finalReadinessRetryMessage("latest successful todo_write still has incomplete items: Ask user to review the doc: in_progress")
 	lower := strings.ToLower(msg)
@@ -106,6 +126,8 @@ func TestFinalReadinessRetryMessageKeepsUserChoicesInteractive(t *testing.T) {
 		"wait for its tool result",
 		"do not ask in prose",
 		"do not claim the user answered",
+		"do not run exploratory bash commands",
+		"do not keep retrying the blocked command",
 	} {
 		if !strings.Contains(lower, want) {
 			t.Fatalf("finalReadinessRetryMessage() missing %q:\n%s", want, msg)

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -113,6 +113,69 @@ func TestStormBreakerEscalatesRepeatedBlockedPermission(t *testing.T) {
 	}
 }
 
+// TestStormBreakerEscalatesAlternatingBlockedShapes: rotating between two
+// blocked tools defeats the signature detector (each turn resets the count),
+// but every turn is still a host refusal with zero progress. The blocked-turn
+// streak must trip the guard anyway.
+func TestStormBreakerEscalatesAlternatingBlockedShapes(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(fakeTool{name: "web_fetch", readOnly: false})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{
+		Gate: &stubGate{deny: map[string]bool{"bash": true, "web_fetch": true}},
+	}, sink)
+
+	calls := []provider.ToolCall{
+		{Name: "bash", Arguments: `{"command":"go test ./..."}`},
+		{Name: "web_fetch", Arguments: `{"url":"https://example.com"}`},
+		{Name: "bash", Arguments: `{"command":"ls"}`},
+	}
+	var last string
+	for _, call := range calls {
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+	}
+
+	if !strings.Contains(last, "[loop guard]") {
+		t.Fatalf("after %d all-blocked turns the guard should fire despite alternating tools, got: %q", stormBreakThreshold, last)
+	}
+	if !a.loopGuardArmed {
+		t.Fatal("streak guard should arm the final-readiness loop-guard pass")
+	}
+	if len(*notices) == 0 {
+		t.Errorf("streak loop guard should emit a warn notice to the user")
+	}
+}
+
+// TestStormBreakerBlockedStreakResetBySuccess: a turn that makes real progress
+// proves the model is not stuck, so the blocked-turn streak must start over.
+func TestStormBreakerBlockedStreakResetBySuccess(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	a := New(nil, reg, NewSession(""), Options{
+		Gate: &stubGate{deny: map[string]bool{"bash": true}},
+	}, event.Discard)
+
+	calls := []provider.ToolCall{
+		{Name: "bash", Arguments: `{"command":"go test ./..."}`},
+		{Name: "bash", Arguments: `{"command":"ls"}`},
+		{Name: "read_file", Arguments: `{"path":"a.go"}`},
+		{Name: "bash", Arguments: `{"command":"pwd"}`},
+	}
+	var last string
+	for _, call := range calls {
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+	}
+
+	if strings.Contains(last, "[loop guard]") {
+		t.Fatalf("a successful turn should reset the blocked streak, got: %q", last)
+	}
+	if a.blockedTurnStreak != 1 {
+		t.Fatalf("blockedTurnStreak = %d, want 1 after success reset plus one block", a.blockedTurnStreak)
+	}
+}
+
 // TestStormBreakerEscalatesRepeatedBatch: a multi-call batch that fails the same
 // way every round is just as much a death-spiral as a single call — once the whole
 // batch repeats stormBreakThreshold times, the guard must fire and name the batch.

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -78,6 +78,41 @@ func TestStormBreakerEscalatesRepeatedFailure(t *testing.T) {
 	}
 }
 
+// TestStormBreakerEscalatesRepeatedBlockedPermission covers the readiness
+// recovery failure mode where the model keeps changing bash commands after the
+// host returns the same permission denial. Blocked calls used to reset the storm
+// counter, so this loop could churn approval prompts without ever changing
+// approach.
+func TestStormBreakerEscalatesRepeatedBlockedPermission(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{
+		Gate: &stubGate{deny: map[string]bool{"bash": true}},
+	}, sink)
+
+	args := []string{
+		`{"command":"go test ./..."}`,
+		`{"command":"git status --short"}`,
+		`{"command":"ls -la"}`,
+	}
+	var last string
+	for i := 0; i < stormBreakThreshold; i++ {
+		call := provider.ToolCall{Name: "bash", Arguments: args[i]}
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+	}
+
+	if !strings.Contains(last, "[loop guard]") {
+		t.Fatalf("after %d same permission blocks the result should carry the loop guard, got: %q", stormBreakThreshold, last)
+	}
+	if !strings.Contains(last, "blocked") || !strings.Contains(last, "permission") {
+		t.Fatalf("permission loop guard should preserve blocked context, got: %q", last)
+	}
+	if len(*notices) == 0 {
+		t.Errorf("loop guard should emit a warn notice to the user")
+	}
+}
+
 // TestStormBreakerEscalatesRepeatedBatch: a multi-call batch that fails the same
 // way every round is just as much a death-spiral as a single call — once the whole
 // batch repeats stormBreakThreshold times, the guard must fire and name the batch.

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -91,6 +91,39 @@ func (l *Ledger) Record(r Receipt) {
 	l.receipts = append(l.receipts, r)
 }
 
+// Len returns the number of receipts recorded this turn, giving callers a
+// stable index to pass to the *Since matchers.
+func (l *Ledger) Len() int {
+	if l == nil {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.receipts)
+}
+
+// HasWriteOrCommandSince reports whether a successful write or command receipt
+// was recorded at or after index — host-observable progress, as opposed to
+// bookkeeping receipts (todo_write, complete_step, ask), which carry neither a
+// write flag nor a command.
+func (l *Ledger) HasWriteOrCommandSince(index int) bool {
+	if l == nil {
+		return false
+	}
+	if index < 0 {
+		index = 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := index; i < len(l.receipts); i++ {
+		r := l.receipts[i]
+		if r.Success && (r.Write || r.Command != "") {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *Ledger) HasSuccessfulCommand(command string) bool {
 	command = strings.TrimSpace(command)
 	if l == nil || command == "" {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -29,6 +29,35 @@ func TestLedgerRecordsSuccessAndFailureReceipts(t *testing.T) {
 	}
 }
 
+func TestLedgerHasWriteOrCommandSince(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(Receipt{ToolName: "todo_write", Success: true, Todos: []TodoItem{{Content: "edit", Status: "in_progress"}}})
+	ledger.Record(Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}})
+	ledger.Record(Receipt{ToolName: "bash", Success: false, Command: "go test ./..."})
+	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "edit"})
+
+	if got := ledger.Len(); got != 4 {
+		t.Fatalf("Len() = %d, want 4", got)
+	}
+	if !ledger.HasWriteOrCommandSince(0) {
+		t.Fatal("write receipt at index 1 should count from index 0")
+	}
+	if !ledger.HasWriteOrCommandSince(-1) {
+		t.Fatal("negative index should behave like 0")
+	}
+	if ledger.HasWriteOrCommandSince(2) {
+		t.Fatal("failed command and bookkeeping receipts must not count as progress")
+	}
+	ledger.Record(Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
+	if !ledger.HasWriteOrCommandSince(2) {
+		t.Fatal("successful command receipt after index should count as progress")
+	}
+	var nilLedger *Ledger
+	if nilLedger.HasWriteOrCommandSince(0) {
+		t.Fatal("nil ledger must report no progress")
+	}
+}
+
 func TestLedgerMatchesFileReadAndWriteReceipts(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{ToolName: "read_file", Success: true, Paths: []string{`internal/tool/builtin/completestep.go`}, Read: true})


### PR DESCRIPTION
## Summary
- Prevent final-readiness recovery from turning permission, plan-mode, hook, or loop-guard blocks into repeated tool-request loops.
- Extend the existing storm breaker so repeated blocked tool outcomes are counted, not just execution errors.
- Let final-readiness accept a final blocker report after a loop guard fired, tracked as host state instead of message text.
- Add a blocked-turn streak detector so rotating tools, reordering batches, or blockers whose text varies per attempt still trip the guard.

Cache-impact: low - Only recovery-turn synthetic guidance and loop-guard result text change; system prompt, tool schemas, tool ordering, provider request serialization, and compaction behavior are unchanged.
Cache-guard: scripts/check-cache-impact.sh metadata gate; `go test ./internal/agent -run 'TestFinalReadinessPermissionLoopGuardAllowsBlockedFinal|TestFinalReadinessPermissionLoopGuardAllowsBlockedFinalForBatch|TestStormBreakerEscalatesRepeatedBlockedPermission|TestStormBreakerEscalatesAlternatingBlockedShapes|TestStormBreakerBlockedStreakResetBySuccess|TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker|TestFinalReadinessLoopGuardPassSurvivesBookkeeping|TestFinalReadinessLoopGuardPassRevokedByRealProgress|TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput'`; `go test ./internal/evidence -run 'TestLedgerHasWriteOrCommandSince'`; `go test ./internal/agent ./internal/permission ./internal/control`; `go test ./...`; `git diff --check`.

## Problem and cause
After a write plus `todo_write`, final-answer readiness blocks a final response until host-observable receipts prove the work is complete. If the model tries to satisfy that by running `bash`, a permission denial, plan-mode refusal, or hook block returns a `blocked:` tool result.

The previous storm breaker ignored blocked outcomes, so each changed command or argument reset loop detection even when every attempt hit the same host refusal. In practice this could surface as repeated bash approval requests while the task never completed. After a loop guard did appear, final-readiness could still ask for receipts that could no longer be produced, causing another retry instead of letting the model report the blocker.

Review of the first iteration found three residual gaps in its "latest tool result contains `[loop guard]`" detection:
- The guard text lands on a batch's first result, but readiness only inspected the last tool message, so multi-call blocked batches never unlocked the final blocker report.
- Any tool output that merely quoted `[loop guard]` (a grep over this repo, a pasted transcript) unlocked readiness by accident.
- Following the guard's own advice (`ask`, `todo_write`, `complete_step`) made a newer tool result the latest one, revoking the pass and restarting the retry loop. Separately, a model rotating between two blocked shapes reset the signature detector every turn and never tripped the guard at all.

## Fix
- Include blocked outcomes in the storm signature, keyed by tool name and host response rather than tool arguments. Different bash commands that hit the same permission blocker now trip the loop guard; successes and different host responses remain reset points.
- Add a blocked-turn streak detector alongside the signature: three consecutive turns in which every call was blocked trip the guard regardless of tool rotation, batch order, or blocker text variance. Only host refusals count — plain errors keep legitimate varied probing untouched.
- Track the readiness loop-guard pass as host state armed by the storm breaker itself (including the per-call repeat-success guard), not by scanning message text. The pass survives the bookkeeping the guard recommends and is revoked once a successful write or command receipt lands after the guard, since receipts are then obtainable again (new `Ledger.Len` / `Ledger.HasWriteOrCommandSince`).
- Tighten the final-readiness retry instruction so the model prefers `complete_step` and `todo_write` from existing receipts and does not run exploratory bash commands just to satisfy readiness.

## Tests
- `go test ./internal/agent -run 'TestFinalReadinessPermissionLoopGuardAllowsBlockedFinal|TestFinalReadinessPermissionLoopGuardAllowsBlockedFinalForBatch|TestStormBreakerEscalatesRepeatedBlockedPermission|TestStormBreakerEscalatesAlternatingBlockedShapes|TestStormBreakerBlockedStreakResetBySuccess|TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker|TestFinalReadinessLoopGuardPassSurvivesBookkeeping|TestFinalReadinessLoopGuardPassRevokedByRealProgress|TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput'`
- `go test ./internal/evidence -run 'TestLedgerHasWriteOrCommandSince'`
- `go test ./internal/agent ./internal/permission ./internal/control`
- `go test ./...`
- `git diff --check`
