### PR TITLE
fix(desktop): key tab usage telemetry to its session so 会话费用 stops accumulating across sessions

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1464,6 +1464,10 @@ func (a *App) NewSession() error {
 	if err := ctrl.NewSession(); err != nil {
 		return err
 	}
+	// The rotated session starts with zero spend: without this reset the tab
+	// telemetry keeps the previous session's totals and the status bar 会话费用
+	// silently turns into an all-sessions running total (#5850).
+	tab.resetTelemetry(ctrl.SessionPath())
 	a.assignFreshSessionTopic(tab)
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
@@ -1569,7 +1573,7 @@ func (a *App) ClearSession() error {
 		// and holder id across to the frontend.
 		return userFacingSessionLeaseError("", err)
 	}
-	tab.resetTelemetry()
+	tab.resetTelemetry(ctrl.SessionPath())
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
 	return nil
@@ -1696,6 +1700,9 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
+	// Same contract as ClearSession's non-running path: the replacement
+	// session starts with zero spend.
+	tab.resetTelemetry(path)
 	oldCtrl.CloseAfterDestroy()
 	a.emitProjectTreeChanged()
 	return nil
@@ -4918,6 +4925,15 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 
 	var info ContextInfo
 	if tab != nil {
+		// Re-key first: a controller-side rotation (typed /new) may have
+		// swapped sessions without the App noticing, and the stale totals
+		// would otherwise be reported — and then persisted — under the new
+		// session (#5850).
+		if ctrl != nil {
+			if sp := ctrl.SessionPath(); sp != "" {
+				tab.syncTelemetryToSession(sp)
+			}
+		}
 		snap := tab.telemetrySnapshot()
 		info.SessionTokens = snap.Usage.TotalTokens
 		info.SessionCost = snap.Usage.SessionCost

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -83,7 +83,14 @@ type WorkspaceTab struct {
 	// readTelemetry tracks files read during this tab's session.
 	readTelemetry  []readFileRecord
 	usageTelemetry sessionUsageStats
-	telemMu        sync.Mutex
+	// telemetrySessionKey is the sessionRuntimeKey the telemetry above belongs
+	// to. Controller-side session rotations (typed /new, bot /reset) bypass the
+	// App bindings, so telemetry writers and readers re-key through
+	// syncTelemetryToSession before trusting the in-memory totals — otherwise a
+	// previous session's cost keeps accumulating under the new session and gets
+	// persisted into its sidecar (#5850).
+	telemetrySessionKey string
+	telemMu             sync.Mutex
 
 	// plannerDisplay keeps display-only planner output for the in-flight turn.
 	// The executor session remains the model-facing transcript; this sidecar
@@ -457,32 +464,34 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab 
 	tab.telemMu.Lock()
 	readTelemetry := append([]readFileRecord(nil), tab.readTelemetry...)
 	usageTelemetry := cloneSessionUsageStats(tab.usageTelemetry)
+	telemetrySessionKey := tab.telemetrySessionKey
 	tab.telemMu.Unlock()
 
 	return &WorkspaceTab{
-		ID:               detachedRuntimeTabID(key),
-		Scope:            tab.Scope,
-		WorkspaceRoot:    tab.WorkspaceRoot,
-		SharedHostKey:    tab.SharedHostKey,
-		TopicID:          tab.TopicID,
-		TopicTitle:       tab.TopicTitle,
-		SessionPath:      canonicalTabSessionPath(path),
-		Ctrl:             tab.Ctrl,
-		Label:            tab.Label,
-		Ready:            tab.Ready,
-		StartupErr:       tab.StartupErr,
-		sink:             tab.sink,
-		ActivityStatus:   tab.ActivityStatus,
-		readTelemetry:    readTelemetry,
-		usageTelemetry:   usageTelemetry,
-		model:            tab.model,
-		effort:           cloneStringPtr(tab.effort),
-		tokenMode:        tab.tokenMode,
-		mode:             tab.mode,
-		goal:             tab.goal,
-		toolApprovalMode: tab.toolApprovalMode,
-		disabledMCP:      cloneServerViewMap(tab.disabledMCP),
-		mcpOrder:         append([]string(nil), tab.mcpOrder...),
+		ID:                  detachedRuntimeTabID(key),
+		Scope:               tab.Scope,
+		WorkspaceRoot:       tab.WorkspaceRoot,
+		SharedHostKey:       tab.SharedHostKey,
+		TopicID:             tab.TopicID,
+		TopicTitle:          tab.TopicTitle,
+		SessionPath:         canonicalTabSessionPath(path),
+		Ctrl:                tab.Ctrl,
+		Label:               tab.Label,
+		Ready:               tab.Ready,
+		StartupErr:          tab.StartupErr,
+		sink:                tab.sink,
+		ActivityStatus:      tab.ActivityStatus,
+		readTelemetry:       readTelemetry,
+		usageTelemetry:      usageTelemetry,
+		telemetrySessionKey: telemetrySessionKey,
+		model:               tab.model,
+		effort:              cloneStringPtr(tab.effort),
+		tokenMode:           tab.tokenMode,
+		mode:                tab.mode,
+		goal:                tab.goal,
+		toolApprovalMode:    tab.toolApprovalMode,
+		disabledMCP:         cloneServerViewMap(tab.disabledMCP),
+		mcpOrder:            append([]string(nil), tab.mcpOrder...),
 	}
 }
 
@@ -545,6 +554,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	source.telemMu.Lock()
 	readTelemetry := append([]readFileRecord(nil), source.readTelemetry...)
 	usageTelemetry := cloneSessionUsageStats(source.usageTelemetry)
+	telemetrySessionKey := source.telemetrySessionKey
 	source.telemMu.Unlock()
 
 	if source.sink != nil {
@@ -571,6 +581,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.mcpOrder = append([]string(nil), source.mcpOrder...)
 	target.readTelemetry = readTelemetry
 	target.usageTelemetry = usageTelemetry
+	target.telemetrySessionKey = telemetrySessionKey
 }
 
 func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wailsCtx context.Context) bool {
@@ -717,10 +728,41 @@ func (t *WorkspaceTab) telemetrySnapshot() tabTelemetrySnapshot {
 	return tabTelemetrySnapshot{Version: 2, ReadFiles: records, Usage: usage}
 }
 
-func (t *WorkspaceTab) resetTelemetry() {
+func (t *WorkspaceTab) resetTelemetry(sessionPath string) {
 	t.telemMu.Lock()
 	t.readTelemetry = nil
 	t.usageTelemetry = sessionUsageStats{}
+	t.telemetrySessionKey = sessionRuntimeKey(sessionPath)
+	t.telemMu.Unlock()
+}
+
+// syncTelemetryToSession keys the in-memory telemetry to the runtime's current
+// session. When the runtime rotated to a different session underneath the tab
+// (typed /new routes through Controller.Submit and never reaches App.NewSession),
+// the previous session's totals must not bleed into the new one: swap in the
+// new session's persisted sidecar, or start from zero when none exists. The
+// sidecar is rewritten on every recorded event, so a reload never loses more
+// than the sub-second in-memory delta of an in-flight record.
+func (t *WorkspaceTab) syncTelemetryToSession(sessionPath string) {
+	key := sessionRuntimeKey(sessionPath)
+	if key == "" {
+		return
+	}
+	t.telemMu.Lock()
+	same := t.telemetrySessionKey == key
+	t.telemMu.Unlock()
+	if same {
+		return
+	}
+	// File I/O stays outside telemMu; re-check the key after reacquiring in
+	// case a concurrent sync or reset re-keyed the tab first.
+	snapshot := loadTelemetry(sessionPath + ".telemetry.json")
+	t.telemMu.Lock()
+	if t.telemetrySessionKey != key {
+		t.readTelemetry = snapshot.ReadFiles
+		t.usageTelemetry = snapshot.Usage
+		t.telemetrySessionKey = key
+	}
 	t.telemMu.Unlock()
 }
 
@@ -1168,6 +1210,13 @@ func (s *tabEventSink) recordReadTelemetry(e event.Event) {
 	truncated := e.Tool.Truncated || strings.Contains(e.Tool.Output, "truncated") ||
 		strings.Contains(e.Tool.Output, "File truncated")
 
+	sp := ""
+	if ctrl != nil {
+		sp = ctrl.SessionPath()
+	}
+	if sp != "" {
+		tab.syncTelemetryToSession(sp)
+	}
 	tab.recordReadFile(readFileRecord{
 		Path:      path,
 		Turn:      turn,
@@ -1176,10 +1225,7 @@ func (s *tabEventSink) recordReadTelemetry(e event.Event) {
 		Limit:     limit,
 		Truncated: truncated,
 	})
-	if ctrl == nil {
-		return
-	}
-	if sp := ctrl.SessionPath(); sp != "" {
+	if sp != "" {
 		_ = saveTelemetry(sp+".telemetry.json", tab.telemetrySnapshot())
 	}
 }
@@ -1188,6 +1234,9 @@ func (s *tabEventSink) recordTurnStarted() {
 	tab, sp := s.telemetryTab()
 	if tab == nil {
 		return
+	}
+	if sp != "" {
+		tab.syncTelemetryToSession(sp)
 	}
 	tab.recordTurnStarted(time.Now().UnixMilli())
 	if sp != "" {
@@ -1200,6 +1249,9 @@ func (s *tabEventSink) recordTurnDone() {
 	if tab == nil {
 		return
 	}
+	if sp != "" {
+		tab.syncTelemetryToSession(sp)
+	}
 	tab.recordTurnDone(time.Now().UnixMilli())
 	if sp != "" {
 		_ = saveTelemetry(sp+".telemetry.json", tab.telemetrySnapshot())
@@ -1210,6 +1262,9 @@ func (s *tabEventSink) recordUsageTelemetry(e event.Event) {
 	tab, sp := s.telemetryTab()
 	if tab == nil {
 		return
+	}
+	if sp != "" {
+		tab.syncTelemetryToSession(sp)
 	}
 	tab.recordUsage(e)
 	if sp != "" {
@@ -2850,14 +2905,18 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 					a.emitProjectTreeChanged()
 				}
 			}
-			// Restore existing telemetry if resuming a session.
-			telemetryPath := path + ".telemetry.json"
-			if snapshot := loadTelemetry(telemetryPath); len(snapshot.ReadFiles) > 0 || snapshot.Usage.RequestCount > 0 {
-				tab.telemMu.Lock()
-				tab.readTelemetry = snapshot.ReadFiles
-				tab.usageTelemetry = snapshot.Usage
-				tab.telemMu.Unlock()
-			}
+			// Key telemetry to the session this build binds: restore its
+			// persisted sidecar, or start from zero when none exists (fresh
+			// session, CLI-created session, pre-telemetry session). Keeping
+			// the previous session's totals here made 会话费用 accumulate
+			// across sessions and persisted the stale totals into the new
+			// session's sidecar on the next event (#5850).
+			snapshot := loadTelemetry(path + ".telemetry.json")
+			tab.telemMu.Lock()
+			tab.readTelemetry = snapshot.ReadFiles
+			tab.usageTelemetry = snapshot.Usage
+			tab.telemetrySessionKey = sessionRuntimeKey(path)
+			tab.telemMu.Unlock()
 		}
 	}
 
@@ -4804,6 +4863,28 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 			}
 		}
 		a.mu.Unlock()
+		// The fork continues the same conversation, so its cost history moves
+		// with it: re-key the in-memory telemetry from the original session to
+		// the recovery path and persist the sidecar right away. Without this
+		// the fork's sidecar stays empty until the next usage event (cost
+		// shows 0 after a restart), and the sync-by-key reload would wipe the
+		// carried totals as "another session's" numbers.
+		if tab != nil && !tab.removed {
+			origKey := sessionRuntimeKey(info.OriginalPath)
+			newKey := sessionRuntimeKey(info.RecoveryPath)
+			carried := false
+			if newKey != "" {
+				tab.telemMu.Lock()
+				if tab.telemetrySessionKey == origKey || tab.telemetrySessionKey == "" {
+					tab.telemetrySessionKey = newKey
+					carried = true
+				}
+				tab.telemMu.Unlock()
+			}
+			if carried {
+				_ = saveTelemetry(info.RecoveryPath+".telemetry.json", tab.telemetrySnapshot())
+			}
+		}
 		a.emitProjectTreeChanged()
 		a.emitRuntimeEvent("session:recovered", sessionRecoveryEvent{
 			OriginalPath:     info.OriginalPath,
@@ -6621,6 +6702,9 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 
 	info := ContextPanelInfo{ReadFiles: []readFileRecord{}, ChangedFiles: []ChangedFileInfo{}}
 	if ctrl != nil {
+		if sp := ctrl.SessionPath(); sp != "" {
+			tab.syncTelemetryToSession(sp)
+		}
 		used, window := ctrl.ContextSnapshot()
 		info.UsedTokens = used
 		info.WindowTokens = window

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -199,3 +199,201 @@ func TestContextPanelUsesLastUsageBreakdownWithTelemetryTotal(t *testing.T) {
 			panel.CacheHitTokens, panel.CacheMissTokens)
 	}
 }
+
+func costedUsageEvent() event.Event {
+	return event.Event{
+		Usage:   &provider.Usage{PromptTokens: 100, CompletionTokens: 40, TotalTokens: 140},
+		Pricing: &provider.Pricing{CacheHit: 1, Input: 2, Output: 3, Currency: "¥"},
+	}
+}
+
+func TestSyncTelemetryToSessionReKeysAcrossRotation(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.jsonl")
+	pathB := filepath.Join(dir, "b.jsonl")
+
+	tab := &WorkspaceTab{}
+	tab.syncTelemetryToSession(pathA)
+	tab.recordUsage(costedUsageEvent())
+	costA := tab.telemetrySnapshot().Usage.SessionCost
+	if costA <= 0 {
+		t.Fatalf("seed cost = %f, want positive", costA)
+	}
+	if err := saveTelemetry(pathA+".telemetry.json", tab.telemetrySnapshot()); err != nil {
+		t.Fatalf("save telemetry A: %v", err)
+	}
+
+	// Same session: in-memory totals survive.
+	tab.syncTelemetryToSession(pathA)
+	if got := tab.telemetrySnapshot().Usage.SessionCost; got != costA {
+		t.Fatalf("same-session sync cost = %f, want %f", got, costA)
+	}
+
+	// Rotation to a session without a sidecar starts from zero — the previous
+	// session's totals must not bleed over (#5850).
+	tab.syncTelemetryToSession(pathB)
+	if got := tab.telemetrySnapshot().Usage; got.SessionCost != 0 || got.TotalTokens != 0 || got.RequestCount != 0 {
+		t.Fatalf("rotated telemetry = %+v, want zeroed", got)
+	}
+
+	// Rotating back restores session A's persisted totals.
+	tab.syncTelemetryToSession(pathA)
+	if got := tab.telemetrySnapshot().Usage.SessionCost; got != costA {
+		t.Fatalf("restored cost = %f, want %f", got, costA)
+	}
+}
+
+func TestContextUsageForTabReKeysAfterControllerRotation(t *testing.T) {
+	dir := t.TempDir()
+	rotated := filepath.Join(dir, "rotated.jsonl")
+	stale := filepath.Join(dir, "stale.jsonl")
+
+	ag := agent.New(usageProvider{usage: &provider.Usage{}}, tool.NewRegistry(), agent.NewSession("system"), agent.Options{}, event.Discard)
+	tab := &WorkspaceTab{
+		ID:   "tab",
+		Ctrl: control.New(control.Options{Executor: ag, Sink: event.Discard, SessionDir: dir, SessionPath: rotated}),
+	}
+	// Telemetry still keyed to the pre-rotation session: a typed /new routes
+	// through Controller.Submit and rotates without App.NewSession running.
+	tab.syncTelemetryToSession(stale)
+	tab.recordUsage(costedUsageEvent())
+
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+	info := app.ContextUsageForTab("tab")
+	if info.SessionCost != 0 || info.SessionTokens != 0 {
+		t.Fatalf("context after rotation = cost %f tokens %d, want zeros", info.SessionCost, info.SessionTokens)
+	}
+	if got := tab.telemetrySnapshot().Usage.RequestCount; got != 0 {
+		t.Fatalf("telemetry request count after rotation = %d, want 0", got)
+	}
+}
+
+func TestNewSessionResetsTabUsageTelemetry(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessPath := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "world"})
+	exec := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{},
+		detachedSessions: map[string]*WorkspaceTab{},
+		activeTabID:      "tab",
+	}
+	tab := &WorkspaceTab{
+		ID:            "tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   sessPath,
+		Ready:         true,
+		model:         "test-model",
+		disabledMCP:   map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	tab.Ctrl = control.New(control.Options{
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: sessPath,
+		Label:       "test",
+		Sink:        tab.sink,
+	})
+	app.tabs[tab.ID] = tab
+
+	tab.syncTelemetryToSession(sessPath)
+	tab.recordUsage(costedUsageEvent())
+	if seed := tab.telemetrySnapshot().Usage.SessionCost; seed <= 0 {
+		t.Fatalf("seed cost = %f, want positive", seed)
+	}
+
+	if err := app.NewSession(); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if got := tab.telemetrySnapshot().Usage; got.SessionCost != 0 || got.RequestCount != 0 || got.TotalTokens != 0 {
+		t.Fatalf("telemetry after NewSession = %+v, want zeroed", got)
+	}
+	if info := app.ContextUsageForTab("tab"); info.SessionCost != 0 || info.SessionTokens != 0 {
+		t.Fatalf("context after NewSession = cost %f tokens %d, want zeros", info.SessionCost, info.SessionTokens)
+	}
+}
+
+func TestSnapshotConflictRecoveryCarriesTelemetryToFork(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	originalPath := filepath.Join(dir, "session.jsonl")
+	current := agent.NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(originalPath); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	staleExec := agent.New(stubProvider{}, tool.NewRegistry(), staleSess, agent.Options{}, event.Discard)
+	app := &App{
+		tabs:             map[string]*WorkspaceTab{},
+		detachedSessions: map[string]*WorkspaceTab{},
+		activeTabID:      "recovery_tab",
+	}
+	tab := &WorkspaceTab{
+		ID:            "recovery_tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   originalPath,
+		Ready:         true,
+		model:         "test-model",
+		disabledMCP:   map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	tab.Ctrl = control.New(control.Options{
+		Executor:            staleExec,
+		SessionDir:          dir,
+		SessionPath:         originalPath,
+		Label:               "test",
+		Sink:                tab.sink,
+		SessionRecoveryMeta: app.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
+	})
+	app.tabs[tab.ID] = tab
+
+	tab.syncTelemetryToSession(originalPath)
+	tab.recordUsage(costedUsageEvent())
+	want := tab.telemetrySnapshot().Usage.SessionCost
+	if want <= 0 {
+		t.Fatalf("seed cost = %f, want positive", want)
+	}
+
+	if err := tab.Ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	recoveryPath := tab.Ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath {
+		t.Fatalf("recovery path = %q, want distinct path", recoveryPath)
+	}
+
+	// The fork continues the conversation: in-memory totals carry over and a
+	// later sync against the fork path must not wipe them.
+	tab.syncTelemetryToSession(recoveryPath)
+	if got := tab.telemetrySnapshot().Usage.SessionCost; got != want {
+		t.Fatalf("carried cost = %f, want %f", got, want)
+	}
+	// The fork's sidecar was persisted at retarget time, so cost survives an
+	// app exit before the next usage event.
+	if got := loadTelemetry(recoveryPath + ".telemetry.json").Usage.SessionCost; got != want {
+		t.Fatalf("fork sidecar cost = %f, want %f", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

The per-tab usage telemetry that feeds the status bar 会话费用 / ContextPanel had no session identity, so its totals leaked across session rotations and were then **persisted into the wrong session's `.telemetry.json` sidecar**, compounding into an all-sessions running total. This is the most likely root cause of the "费用变贵 / 会话费用像是今日总和" reports in #5850 (see the comment suspecting the status bar shows a day total — no day-total metric exists; it is this carry-over) and part of the desktop-vs-CLI cost perception in #2945.

Leak paths fixed:

- `App.NewSession()` and the clear-while-running rebuild never reset tab telemetry (only `ClearSession` did), so a "new session" kept the old running total and kept adding to it.
- Rebinding a tab to a session **without** a telemetry sidecar (fresh session, CLI-created session, pre-telemetry session) kept the previous session's totals — and the next usage event saved them into the new session's sidecar, making the contamination persistent and snowballing.
- A typed `/new` routes through `Controller.Submit` → `go c.NewSession()` and rotates the session without the App layer ever noticing, so no App-side reset can cover it.
- A save-conflict recovery fork carried cost in memory but never wrote the fork's sidecar: cost showed 0 after a restart of a recovered session.

Fix: key the in-memory telemetry with the tab's `sessionRuntimeKey` and re-sync at every telemetry writer (usage / turn-start / turn-done / read-file recorders) and reader (`ContextUsageForTab`, `ContextPanel`). On a key mismatch the new session's persisted sidecar is swapped in (zero when none exists) instead of letting the old totals bleed in. `NewSession` and the clear-while-running path reset telemetry to the rotated session; the build/rebind restore is now unconditional and sets the key; recovery forks re-key the carried totals (continuation semantics) and persist the fork sidecar at retarget time; detach/attach tab clones carry the key.

No frontend changes needed: `newSession`/`resumeSession` already dispatch a local reset before refetching, and a typed `/new` self-corrects at the next `turn_done` context refresh once the backend reports correctly scoped numbers.

## Verification

- New tests: `TestSyncTelemetryToSessionReKeysAcrossRotation` (swap-out on rotation, restore on switch-back, same-key no-op), `TestContextUsageForTabReKeysAfterControllerRotation` (typed-/new shape: controller rotated, App unaware), `TestNewSessionResetsTabUsageTelemetry`, `TestSnapshotConflictRecoveryCarriesTelemetryToFork` (carried totals + fork sidecar written at retarget).
- `cd desktop && go test ./...` — full desktop suite green.
- `go test -race` over the telemetry/recovery tests — green.
- `go vet ./...` — clean.

## Cache impact

Cache-impact: none — desktop display-layer telemetry only; no provider request, system prompt, or tool schema changes.
Cache-guard: not applicable (no cache-sensitive files touched); desktop suite + race pass.
System-prompt-review: N/A

Refs #5850, #2945