### PR TITLE
ci(cache-impact): watch desktop session prompt swap and environment probes

### DIFF
--- a/scripts/check-cache-impact.sh
+++ b/scripts/check-cache-impact.sh
@@ -59,6 +59,7 @@ system_prompt_sensitive=()
 
 for file in "${changed_files[@]:-}"; do
   case "$file" in
+    desktop/session_prompt.go|\
     internal/agent/agent.go|\
     internal/agent/ask.go|\
     internal/agent/cache*|\
@@ -71,6 +72,7 @@ for file in "${changed_files[@]:-}"; do
     internal/command/slashtool.go|\
     internal/config/config.go|\
     internal/config/system_prompt*|\
+    internal/environment/*|\
     internal/history/tool.go|\
     internal/installsource/*|\
     internal/lsp/tool.go|\
@@ -87,10 +89,12 @@ for file in "${changed_files[@]:-}"; do
   esac
 
   case "$file" in
+    desktop/session_prompt.go|\
     internal/agent/task.go|\
     internal/boot/*|\
     internal/config/config.go|\
     internal/config/system_prompt*|\
+    internal/environment/*|\
     internal/memory/*|\
     internal/outputstyle/*|\
     internal/skill/*)


### PR DESCRIPTION
## Summary

The cache-impact gate watched only `internal/` prompt surfaces, leaving two cache-sensitive surfaces unguarded:

- `desktop/session_prompt.go` — rewrites the persisted leading system message with the freshly composed prompt on every tab resume/rebind (`sessionWithFreshSystemPrompt`). Any byte difference there invalidates the whole conversation's prefix cache and persists the rewrite; it is exactly the class of change this gate exists for, and today a PR touching it sails through with no Cache-impact note.
- `internal/environment/*` — composes the environment probe section embedded in the cached system prefix (`boot.go` prompt assembly). Probe output changes shift prefix bytes for every session on upgrade.

Both are added to the cache-sensitive list (requires `Cache-impact:` / `Cache-guard:` lines) and to the system-prompt-sensitive list (requires an explicit `System-prompt-review:` note), since both shape the provider-visible system prompt.

## Verification

- `bash -n scripts/check-cache-impact.sh`
- Scenario runs: `desktop/session_prompt.go` without the lines → fails listing the file; with lines but `System-prompt-review: N/A` → fails demanding a named review; with a named review → passes listing both files; `desktop/tabs.go` alone → "No cache-sensitive prompt/tool files changed" (no new noise for general desktop PRs).

## Cache impact

Cache-impact: none - CI gate configuration only; no runtime behavior change.
Cache-guard: scenario runs above exercise the new watchlist entries in both pass and fail directions.
System-prompt-review: N/A

Context: follow-up from the desktop-vs-CLI cost triage (#2945) — the desktop resume prompt-swap path was identified as an unguarded prefix-cache invalidation surface.