### PR TITLE
feat(control): log snapshot-conflict triggers with the revision ledger

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2836,22 +2836,45 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	return nil
 }
 
+// snapshotConflictLogAttrs flattens a snapshot-conflict error into slog attrs.
+// Field reports of #6069-class "session changed on disk" spam are only
+// diagnosable when the logs say which trigger fired and what the revision
+// ledger looked like, so every recoverSnapshotConflict outcome logs these.
+func snapshotConflictLogAttrs(saveErr error, path, mode string) []any {
+	attrs := []any{"path", path, "mode", mode}
+	var conflict *agent.SessionSnapshotConflictError
+	if errors.As(saveErr, &conflict) && conflict != nil {
+		attrs = append(attrs,
+			"kind", string(conflict.Kind),
+			"disk_messages", conflict.ExistingMessages,
+			"snapshot_messages", conflict.SnapshotMessages,
+			"base_revision", conflict.BaseRevision,
+			"disk_revision", conflict.DiskRevision,
+		)
+	}
+	return attrs
+}
+
 func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, bool, error) {
 	if c.executor == nil || strings.TrimSpace(path) == "" {
 		return "", false, saveErr
 	}
+	mode := "snapshot"
+	if forceRewrite {
+		mode = "rewrite"
+	}
+	logAttrs := snapshotConflictLogAttrs(saveErr, path, mode)
 	if kind, ok := agent.SnapshotConflictKind(saveErr); ok && kind == agent.SessionSnapshotConflictStalePrefix {
 		if c.adoptDiskSession(path) {
+			slog.Warn("controller: snapshot conflict; adopted newer disk transcript", logAttrs...)
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "session changed on disk; adopted the newer transcript"})
 			return path, true, nil
 		}
 	}
 	reason := "snapshot conflict"
-	mode := "snapshot"
 	if forceRewrite {
 		reason = "rewrite conflict"
-		mode = "rewrite"
 	}
 	req := SessionRecoveryRequest{OriginalPath: path, Reason: reason, Mode: mode}
 	meta := agent.BranchMeta{}
@@ -2866,10 +2889,15 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	if err != nil {
 		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
 			if c.adoptDiskSession(path) {
+				slog.Warn("controller: snapshot conflict; recovery not needed, adopted disk transcript", logAttrs...)
 				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-					Text: "session changed on disk; adopted the newer transcript"})
+					Text: "session changed on disk; adopted the newer transcript (local changes already covered)"})
 				return path, true, nil
 			}
+			// Nothing was recovered AND the disk transcript could not be
+			// adopted: the snapshot is silently dropped. Leave a trace so
+			// "my last turns vanished" reports can be tied to this path.
+			slog.Warn("controller: snapshot conflict; recovery not needed but disk transcript could not be adopted", logAttrs...)
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("recover stale session snapshot: %w", err)
@@ -2892,6 +2920,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	c.mu.Unlock()
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
+	slog.Warn("controller: snapshot conflict; forked recovery branch",
+		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text: fmt.Sprintf("session changed on disk; unsaved local transcript was saved as recovery branch %s", agent.BranchID(info.Path))})
 	return info.Path, true, nil

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1242,6 +1242,41 @@ func TestNewSessionStartsFreshContextAndSavesTranscript(t *testing.T) {
 	}
 }
 
+func TestSnapshotConflictLogAttrsCarryRevisionLedger(t *testing.T) {
+	conflict := &agent.SessionSnapshotConflictError{
+		Path:             "/tmp/session.jsonl",
+		Kind:             agent.SessionSnapshotConflictDiverged,
+		ExistingMessages: 7,
+		SnapshotMessages: 5,
+		BaseRevision:     3,
+		DiskRevision:     9,
+	}
+	attrs := snapshotConflictLogAttrs(fmt.Errorf("save: %w", conflict), "/tmp/session.jsonl", "rewrite")
+	got := map[string]any{}
+	for i := 0; i+1 < len(attrs); i += 2 {
+		key, ok := attrs[i].(string)
+		if !ok {
+			t.Fatalf("attr key %v is not a string", attrs[i])
+		}
+		got[key] = attrs[i+1]
+	}
+	if got["mode"] != "rewrite" || got["kind"] != "diverged" {
+		t.Fatalf("attrs = %v, want mode=rewrite kind=diverged", got)
+	}
+	if got["base_revision"] != int64(3) || got["disk_revision"] != int64(9) {
+		t.Fatalf("attrs = %v, want base_revision=3 disk_revision=9", got)
+	}
+	if got["disk_messages"] != 7 || got["snapshot_messages"] != 5 {
+		t.Fatalf("attrs = %v, want disk_messages=7 snapshot_messages=5", got)
+	}
+
+	// A conflict error without the typed detail still logs path and mode.
+	plain := snapshotConflictLogAttrs(agent.ErrSessionSnapshotConflict, "/tmp/session.jsonl", "snapshot")
+	if len(plain) != 4 {
+		t.Fatalf("plain attrs = %v, want only path and mode", plain)
+	}
+}
+
 func TestNewSessionQueuesSessionStartHookContext(t *testing.T) {
 	dir := t.TempDir()
 	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)


### PR DESCRIPTION
## Summary

Field reports of frequent "session changed on disk" notices (#6069, v1.17.1) are undiagnosable today: the stale-prefix adoption and the recovery-not-needed adoption emit the **same** notice text, nothing logs which trigger fired, and the `BaseRevision`/`DiskRevision` pair that drove the conflict decision is discarded. When the next report lands, we still can't tell whether the remaining producer is a rewrite-ownership revocation, a genuine second writer, or something new.

- Log every `recoverSnapshotConflict` outcome — stale-prefix adopt, recovery-not-needed adopt, failed adoption, recovery fork — with the conflict kind, save mode (snapshot/rewrite), disk vs snapshot message counts, and the `BaseRevision`/`DiskRevision` pair extracted from `SessionSnapshotConflictError`.
- Differentiate the recovery-not-needed notice text ("adopted the newer transcript **(local changes already covered)**") so a user screenshot alone identifies the trigger.
- The recovery-not-needed path whose disk adoption fails used to return silently with the snapshot dropped; it now leaves a warning so "my last turns vanished" reports can be tied to this path.

No behavior change beyond the added logs and the one clarified notice string.

## Verification

- New test `TestSnapshotConflictLogAttrsCarryRevisionLedger` (typed conflict error → full attrs; bare sentinel error → path/mode only).
- `go test ./internal/control` full suite green; desktop snapshot-conflict recovery tests green.
- `go vet` clean.

## Cache impact

Cache-impact: none - logging and notice-text only; no save/recovery decision logic, provider request, or prompt changes.
Cache-guard: existing snapshot-conflict recovery tests (`internal/control`, desktop autosave suite) cover the touched paths; the new unit test covers attr extraction.
System-prompt-review: N/A

Refs #6069, #6054 — first step of narrowing the post-1.17.1 conflict trigger.