### PR TITLE
fix(agent): cap recovery chain depth and force-save at the cap

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -37,9 +37,15 @@ type BranchMeta struct {
 	Recovered        bool      `json:"recovered,omitempty"`
 	RecoveryReason   string    `json:"recovery_reason,omitempty"`
 	RecoveryDigest   string    `json:"recovery_digest,omitempty"`
-	Revision         int64     `json:"revision,omitempty"`
-	ContentDigest    string    `json:"content_digest,omitempty"`
-	WriterID         string    `json:"writer_id,omitempty"`
+	// RecoveryDepth counts how many recovery forks separate this branch from a
+	// normal session (1 = forked from a normal session). SaveRecoveryBranch
+	// refuses to fork past SessionRecoveryMaxDepth so a conflict loop cannot
+	// spawn unbounded nested recovery chains (#5993 reached 8 levels). Legacy
+	// recovery metas without the field are treated as depth 1.
+	RecoveryDepth int    `json:"recovery_depth,omitempty"`
+	Revision      int64  `json:"revision,omitempty"`
+	ContentDigest string `json:"content_digest,omitempty"`
+	WriterID      string `json:"writer_id,omitempty"`
 	// SchemaVersion records the BranchMeta version that last wrote the listing
 	// fields (Turns/Preview) FROM the session's content. It is stamped only by the
 	// writers that actually derive those counts — Controller.snapshot's

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -45,9 +45,20 @@ var (
 	sessionSaveLocks            sync.Map
 	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
 	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
-	errSessionFileLockHeld      = errors.New("session file lock held")
-	sessionWriterID             = newSessionWriterID()
+	// ErrSessionRecoveryDepthExceeded refuses a recovery fork whose parent is
+	// already SessionRecoveryMaxDepth recovery forks deep. A chain that deep
+	// means saves keep conflicting on branches this runtime itself created;
+	// forking further multiplies session files without converging (#5993).
+	ErrSessionRecoveryDepthExceeded = errors.New("session recovery chain depth exceeded")
+	errSessionFileLockHeld          = errors.New("session file lock held")
+	sessionWriterID                 = newSessionWriterID()
 )
+
+// SessionRecoveryMaxDepth bounds nested recovery forks: a normal session may
+// fork a recovery branch (depth 1), which may itself fork twice more under
+// genuine repeated incidents; past that the caller should stop forking and
+// write onto the branch it already owns.
+const SessionRecoveryMaxDepth = 3
 
 type sessionPersistState struct {
 	path     string
@@ -519,6 +530,22 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 		}
 	}
 
+	// Refuse to deepen a runaway chain: forking FROM a branch that is already
+	// at the depth cap only multiplies recovery files (#5993 reached 8 nested
+	// levels). The caller falls back to force-writing the branch it owns.
+	parentDepth := 0
+	if parentMeta, ok, metaErr := LoadBranchMeta(originalPath); metaErr == nil && ok && parentMeta.Recovered {
+		parentDepth = parentMeta.RecoveryDepth
+		if parentDepth <= 0 {
+			// Legacy recovery meta predating RecoveryDepth.
+			parentDepth = 1
+		}
+	}
+	if parentDepth >= SessionRecoveryMaxDepth {
+		return RecoveryBranchInfo{}, fmt.Errorf("%w: %s is already %d recovery forks deep",
+			ErrSessionRecoveryDepthExceeded, originalPath, parentDepth)
+	}
+
 	recoveryPath := recoverySessionPath(originalPath, digest)
 	unlockRecovery := lockSessionSavePath(recoveryPath)
 	defer unlockRecovery()
@@ -533,7 +560,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 			return RecoveryBranchInfo{}, digestErr
 		}
 		if bytes.Equal(existingDigest[:], digest[:]) {
-			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText)
+			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, parentDepth+1)
 			if err != nil {
 				return RecoveryBranchInfo{}, err
 			}
@@ -562,7 +589,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	if err := writeSessionMessages(recoveryPath, msgs); err != nil {
 		return RecoveryBranchInfo{}, err
 	}
-	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText)
+	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, parentDepth+1)
 	if err != nil {
 		return RecoveryBranchInfo{}, err
 	}
@@ -578,7 +605,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Meta: meta, Preview: preview, Turns: turns}, nil
 }
 
-func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions, preview string, turns int, digest string) (BranchMeta, error) {
+func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions, preview string, turns int, digest string, depth int) (BranchMeta, error) {
 	meta := opts.BranchMeta
 	meta.ID = BranchID(path)
 	if strings.TrimSpace(meta.Name) == "" {
@@ -595,6 +622,9 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 	meta.Recovered = true
 	meta.RecoveryReason = firstNonEmpty(strings.TrimSpace(opts.Reason), "session snapshot conflict")
 	meta.RecoveryDigest = digest
+	// Always stamped from the parent chain, never trusted from opts: callers
+	// copy tab/session meta wholesale and would carry a stale depth.
+	meta.RecoveryDepth = depth
 	if meta.Revision == 0 {
 		meta.Revision = 1
 	}

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -1025,6 +1025,86 @@ func TestSaveRecoveryBranchSkipsPureStalePrefix(t *testing.T) {
 	}
 }
 
+func divergedSessionPair(t *testing.T, dir, name string) (string, *Session) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	current := NewSession("sys")
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	current.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := current.Save(path); err != nil {
+		t.Fatalf("Save current: %v", err)
+	}
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local " + name})
+	return path, stale
+}
+
+func stampRecoveryMeta(t *testing.T, path string, depth int) {
+	t.Helper()
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	meta.Recovered = true
+	meta.RecoveryDepth = depth
+	if err := SaveBranchMeta(path, meta); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+}
+
+func TestSaveRecoveryBranchStampsAndCapsChainDepth(t *testing.T) {
+	dir := t.TempDir()
+
+	// Forking from a normal session stamps depth 1.
+	path, stale := divergedSessionPair(t, dir, "session.jsonl")
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	if info.Meta.RecoveryDepth != 1 {
+		t.Fatalf("first fork depth = %d, want 1", info.Meta.RecoveryDepth)
+	}
+
+	// Forking from a recovery branch increments the chain depth.
+	deeper, staleDeeper := divergedSessionPair(t, dir, "deeper.jsonl")
+	stampRecoveryMeta(t, deeper, 1)
+	info, err = staleDeeper.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: deeper})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch from depth 1: %v", err)
+	}
+	if info.Meta.RecoveryDepth != 2 {
+		t.Fatalf("nested fork depth = %d, want 2", info.Meta.RecoveryDepth)
+	}
+
+	// A legacy recovery meta without the depth field counts as depth 1.
+	legacy, staleLegacy := divergedSessionPair(t, dir, "legacy.jsonl")
+	stampRecoveryMeta(t, legacy, 0)
+	info, err = staleLegacy.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: legacy})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch from legacy recovery: %v", err)
+	}
+	if info.Meta.RecoveryDepth != 2 {
+		t.Fatalf("legacy nested fork depth = %d, want 2", info.Meta.RecoveryDepth)
+	}
+
+	// A parent at the cap refuses to fork deeper.
+	capped, staleCapped := divergedSessionPair(t, dir, "capped.jsonl")
+	stampRecoveryMeta(t, capped, SessionRecoveryMaxDepth)
+	if _, err := staleCapped.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: capped}); !errors.Is(err, ErrSessionRecoveryDepthExceeded) {
+		t.Fatalf("SaveRecoveryBranch at cap err = %v, want ErrSessionRecoveryDepthExceeded", err)
+	}
+	forks, err := filepath.Glob(filepath.Join(dir, "capped-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(forks) != 0 {
+		t.Fatalf("capped parent still forked: %v", forks)
+	}
+}
+
 func TestSaveRecoveryBranchDedupesByDigest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	current := NewSession("sys")

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2887,6 +2887,21 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 		BranchMeta:   meta,
 	})
 	if err != nil {
+		if errors.Is(err, agent.ErrSessionRecoveryDepthExceeded) {
+			// Saves keep conflicting on recovery branches this runtime itself
+			// created; forking again multiplies session files without
+			// converging (#5993 reached 8 nested levels). This runtime is the
+			// only writer of its own recovery branches, so force-writing the
+			// transcript back onto the current branch keeps the data and
+			// stops the chain.
+			if forceErr := c.executor.Session().Save(path); forceErr != nil {
+				return "", false, fmt.Errorf("recovery chain depth exceeded; force save failed: %w", forceErr)
+			}
+			slog.Warn("controller: snapshot conflict; recovery depth cap reached, force-saved onto current branch", logAttrs...)
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: "session conflicts kept recurring; kept the transcript on the current recovery branch"})
+			return path, true, nil
+		}
 		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
 			if c.adoptDiskSession(path) {
 				slog.Warn("controller: snapshot conflict; recovery not needed, adopted disk transcript", logAttrs...)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2836,22 +2836,45 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	return nil
 }
 
+// snapshotConflictLogAttrs flattens a snapshot-conflict error into slog attrs.
+// Field reports of #6069-class "session changed on disk" spam are only
+// diagnosable when the logs say which trigger fired and what the revision
+// ledger looked like, so every recoverSnapshotConflict outcome logs these.
+func snapshotConflictLogAttrs(saveErr error, path, mode string) []any {
+	attrs := []any{"path", path, "mode", mode}
+	var conflict *agent.SessionSnapshotConflictError
+	if errors.As(saveErr, &conflict) && conflict != nil {
+		attrs = append(attrs,
+			"kind", string(conflict.Kind),
+			"disk_messages", conflict.ExistingMessages,
+			"snapshot_messages", conflict.SnapshotMessages,
+			"base_revision", conflict.BaseRevision,
+			"disk_revision", conflict.DiskRevision,
+		)
+	}
+	return attrs
+}
+
 func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, bool, error) {
 	if c.executor == nil || strings.TrimSpace(path) == "" {
 		return "", false, saveErr
 	}
+	mode := "snapshot"
+	if forceRewrite {
+		mode = "rewrite"
+	}
+	logAttrs := snapshotConflictLogAttrs(saveErr, path, mode)
 	if kind, ok := agent.SnapshotConflictKind(saveErr); ok && kind == agent.SessionSnapshotConflictStalePrefix {
 		if c.adoptDiskSession(path) {
+			slog.Warn("controller: snapshot conflict; adopted newer disk transcript", logAttrs...)
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "session changed on disk; adopted the newer transcript"})
 			return path, true, nil
 		}
 	}
 	reason := "snapshot conflict"
-	mode := "snapshot"
 	if forceRewrite {
 		reason = "rewrite conflict"
-		mode = "rewrite"
 	}
 	req := SessionRecoveryRequest{OriginalPath: path, Reason: reason, Mode: mode}
 	meta := agent.BranchMeta{}
@@ -2866,10 +2889,15 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	if err != nil {
 		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
 			if c.adoptDiskSession(path) {
+				slog.Warn("controller: snapshot conflict; recovery not needed, adopted disk transcript", logAttrs...)
 				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-					Text: "session changed on disk; adopted the newer transcript"})
+					Text: "session changed on disk; adopted the newer transcript (local changes already covered)"})
 				return path, true, nil
 			}
+			// Nothing was recovered AND the disk transcript could not be
+			// adopted: the snapshot is silently dropped. Leave a trace so
+			// "my last turns vanished" reports can be tied to this path.
+			slog.Warn("controller: snapshot conflict; recovery not needed but disk transcript could not be adopted", logAttrs...)
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("recover stale session snapshot: %w", err)
@@ -2892,6 +2920,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	c.mu.Unlock()
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
+	slog.Warn("controller: snapshot conflict; forked recovery branch",
+		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text: fmt.Sprintf("session changed on disk; unsaved local transcript was saved as recovery branch %s", agent.BranchID(info.Path))})
 	return info.Path, true, nil

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1242,6 +1242,41 @@ func TestNewSessionStartsFreshContextAndSavesTranscript(t *testing.T) {
 	}
 }
 
+func TestSnapshotConflictLogAttrsCarryRevisionLedger(t *testing.T) {
+	conflict := &agent.SessionSnapshotConflictError{
+		Path:             "/tmp/session.jsonl",
+		Kind:             agent.SessionSnapshotConflictDiverged,
+		ExistingMessages: 7,
+		SnapshotMessages: 5,
+		BaseRevision:     3,
+		DiskRevision:     9,
+	}
+	attrs := snapshotConflictLogAttrs(fmt.Errorf("save: %w", conflict), "/tmp/session.jsonl", "rewrite")
+	got := map[string]any{}
+	for i := 0; i+1 < len(attrs); i += 2 {
+		key, ok := attrs[i].(string)
+		if !ok {
+			t.Fatalf("attr key %v is not a string", attrs[i])
+		}
+		got[key] = attrs[i+1]
+	}
+	if got["mode"] != "rewrite" || got["kind"] != "diverged" {
+		t.Fatalf("attrs = %v, want mode=rewrite kind=diverged", got)
+	}
+	if got["base_revision"] != int64(3) || got["disk_revision"] != int64(9) {
+		t.Fatalf("attrs = %v, want base_revision=3 disk_revision=9", got)
+	}
+	if got["disk_messages"] != 7 || got["snapshot_messages"] != 5 {
+		t.Fatalf("attrs = %v, want disk_messages=7 snapshot_messages=5", got)
+	}
+
+	// A conflict error without the typed detail still logs path and mode.
+	plain := snapshotConflictLogAttrs(agent.ErrSessionSnapshotConflict, "/tmp/session.jsonl", "snapshot")
+	if len(plain) != 4 {
+		t.Fatalf("plain attrs = %v, want only path and mode", plain)
+	}
+}
+
 func TestNewSessionQueuesSessionStartHookContext(t *testing.T) {
 	dir := t.TempDir()
 	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1277,6 +1277,93 @@ func TestSnapshotConflictLogAttrsCarryRevisionLedger(t *testing.T) {
 	}
 }
 
+type noticeSink struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *noticeSink) Emit(e event.Event) {
+	s.mu.Lock()
+	s.events = append(s.events, e)
+	s.mu.Unlock()
+}
+
+func (s *noticeSink) notices() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, e := range s.events {
+		if e.Kind == event.Notice {
+			out = append(out, e.Text)
+		}
+	}
+	return out
+}
+
+func TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	disk := agent.NewSession("sys")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := disk.Save(path); err != nil {
+		t.Fatalf("Save disk: %v", err)
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	meta.Recovered = true
+	meta.RecoveryDepth = agent.SessionRecoveryMaxDepth
+	if err := agent.SaveBranchMeta(path, meta); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+
+	stale := agent.NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	exec := agent.New(nil, nil, stale, agent.Options{}, event.Discard)
+	sink := &noticeSink{}
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test", Sink: sink})
+
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := c.SessionPath(); got != path {
+		t.Fatalf("session path = %q, want unchanged %q (no new fork)", got, path)
+	}
+	forks, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(forks) != 0 {
+		t.Fatalf("depth cap still forked: %v", forks)
+	}
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := loaded.Messages[len(loaded.Messages)-1].Content; got != "local second" {
+		t.Fatalf("disk tail = %q, want force-saved local transcript", got)
+	}
+	notices := sink.notices()
+	if len(notices) == 0 || !strings.Contains(notices[len(notices)-1], "kept the transcript on the current recovery branch") {
+		t.Fatalf("notices = %v, want depth-cap notice", notices)
+	}
+
+	// The force save re-anchored the baseline: the next snapshot must not
+	// conflict again.
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "answer"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatalf("follow-up Snapshot: %v", err)
+	}
+	if got := sink.notices(); len(got) != len(notices) {
+		t.Fatalf("follow-up snapshot emitted more notices: %v", got)
+	}
+}
+
 func TestNewSessionQueuesSessionStartHookContext(t *testing.T) {
 	dir := t.TempDir()
 	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)


### PR DESCRIPTION
## Summary

Defense-in-depth for the #5993 class: a save-conflict loop used to fork recovery branches from recovery branches without bound — the report reached **8 nested levels**, each fork polluting the session list. The conflict triggers behind that loop are fixed (1.17.x + #6063), but nothing prevents a future regression from spawning chains again: `BranchMeta.Recovered` was display-only and `SaveRecoveryBranch` never looked at the parent's recovery state.

- Stamp `BranchMeta.RecoveryDepth` on every recovery fork (parent depth + 1; legacy recovery metas without the field count as depth 1). Always derived from the parent chain, never trusted from the caller's meta, which copies tab/session meta wholesale.
- `SaveRecoveryBranch` refuses to fork a parent already at `SessionRecoveryMaxDepth` (3) with a typed `ErrSessionRecoveryDepthExceeded`.
- At the cap, `recoverSnapshotConflict` **force-saves the transcript onto the current branch** instead of forking: this runtime is the only writer of the recovery branches it created (recovery paths are digest-derived; identical snapshots dedupe to `Existing`), so the force write keeps the data, re-anchors the persistence baseline so the next snapshot does not re-conflict, and stops the file proliferation. A warn log (with the conflict's revision ledger) plus a distinct notice make the condition visible instead of silent.

Semantic choice worth reviewing: at the cap the fallback prefers *keeping the in-memory transcript* (force write over the runtime's own recovery branch) over adopting whatever is on disk — recovery exists to prevent data loss, and the branch has no other legitimate writer.

> Stacked on #6080 (`fix/snapshot-conflict-trigger-telemetry`) — merge that first; this PR's controller change builds on its `logAttrs` instrumentation and will narrow to a single commit once #6080 lands.

## Verification

- `TestSaveRecoveryBranchStampsAndCapsChainDepth`: depth 1 stamped on first fork; nested fork increments to 2; legacy `Recovered` meta treated as depth 1; parent at cap refuses with the typed error and creates no file.
- `TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch`: diverged conflict at a depth-capped path → `Snapshot()` succeeds, no `*-recovery-*.jsonl` created, disk holds the local transcript, depth-cap notice emitted, and the follow-up snapshot does not re-conflict.
- Full suites green: `internal/agent`, `internal/control`, `internal/cli`, `internal/serve`, `internal/acp`, desktop (55s). `go vet` clean.

## Cache impact

Cache-impact: none - session persistence/recovery only; no provider request, system prompt, or tool schema changes.
Cache-guard: not applicable (no watchlist files); recovery-path suites above cover the change.
System-prompt-review: N/A

Refs #5993, #6054.