### PR TITLE
fix(desktop): make session trash tolerate missing artifacts

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -650,11 +650,18 @@ func sourcePathMissing(src string) bool {
 	return os.IsNotExist(err)
 }
 
+// copyPathFn is a seam for tests to simulate a source vanishing mid-copy.
+var copyPathFn = copyPath
+
 // copyAndRemove recursively copies src to dst, then removes src. Used as a
 // fallback when os.Rename fails (cross-device or Windows file-lock races).
 func copyAndRemove(src, dst string) error {
-	if err := copyPath(src, dst); err != nil {
+	if err := copyPathFn(src, dst); err != nil {
 		if sourcePathMissing(src) {
+			// The source vanished mid-copy; drop the partial destination so
+			// the trash never keeps a truncated artifact that a later restore
+			// would resurrect as a corrupted transcript.
+			_ = os.RemoveAll(dst)
 			return nil
 		}
 		return err

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -612,6 +612,8 @@ func movePathIfExists(src, dst string) error {
 	// Try os.Rename first — it's atomic and fast when it works.
 	if err := os.Rename(src, dst); err == nil {
 		return nil
+	} else if sourcePathMissing(src) {
+		return nil
 	} else if !isRenameCrossDeviceOrBusy(err) {
 		return err
 	}
@@ -640,10 +642,21 @@ func isRenameCrossDeviceOrBusy(err error) bool {
 	return false
 }
 
+func sourcePathMissing(src string) bool {
+	if strings.TrimSpace(src) == "" {
+		return true
+	}
+	_, err := os.Lstat(src)
+	return os.IsNotExist(err)
+}
+
 // copyAndRemove recursively copies src to dst, then removes src. Used as a
 // fallback when os.Rename fails (cross-device or Windows file-lock races).
 func copyAndRemove(src, dst string) error {
 	if err := copyPath(src, dst); err != nil {
+		if sourcePathMissing(src) {
+			return nil
+		}
 		return err
 	}
 	// On Windows, wait briefly for any file handle release.
@@ -654,6 +667,9 @@ func copyAndRemove(src, dst string) error {
 func copyPath(src, dst string) error {
 	info, err := os.Lstat(src)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	mode := info.Mode()
@@ -675,6 +691,10 @@ func copyDir(src, dst string, mode os.FileMode) error {
 	}
 	entries, err := os.ReadDir(src)
 	if err != nil {
+		if os.IsNotExist(err) {
+			_ = os.RemoveAll(dst)
+			return nil
+		}
 		return err
 	}
 	for _, e := range entries {
@@ -691,6 +711,9 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	// Open source file.
 	in, err := os.Open(src)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	// Create destination file.
@@ -716,6 +739,9 @@ func copyFile(src, dst string, mode os.FileMode) error {
 func copySymlink(src, dst string) error {
 	target, err := os.Readlink(src)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	return os.Symlink(target, dst)

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -967,6 +968,59 @@ func TestCopyFallbackTreatsMissingSourceAsAlreadyMoved(t *testing.T) {
 	}
 	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
 		t.Fatalf("copy missing dir should not leave an empty target, stat err = %v", err)
+	}
+}
+
+func TestCopyFallbackRemovesPartialTargetWhenSourceVanishesMidCopy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("session transcript"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	restore := copyPathFn
+	copyPathFn = func(copySrc, copyDst string) error {
+		// Simulate the source vanishing mid-copy: a truncated destination has
+		// already been written when the copy fails.
+		if err := os.WriteFile(copyDst, []byte("session tra"), 0o644); err != nil {
+			t.Fatalf("write partial destination: %v", err)
+		}
+		if err := os.Remove(copySrc); err != nil {
+			t.Fatalf("remove source: %v", err)
+		}
+		return errors.New("simulated read failure")
+	}
+	t.Cleanup(func() { copyPathFn = restore })
+
+	if err := copyAndRemove(src, dst); err != nil {
+		t.Fatalf("copyAndRemove should treat vanished source as already moved: %v", err)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("partial destination should be removed, stat err = %v", err)
+	}
+}
+
+func TestCopyFallbackKeepsErrorWhenSourceStillExists(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("session transcript"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	restore := copyPathFn
+	simulated := errors.New("simulated copy failure")
+	copyPathFn = func(copySrc, copyDst string) error {
+		return simulated
+	}
+	t.Cleanup(func() { copyPathFn = restore })
+
+	if err := copyAndRemove(src, dst); !errors.Is(err, simulated) {
+		t.Fatalf("copyAndRemove error = %v, want simulated copy failure", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source should be untouched on real copy failure: %v", err)
 	}
 }
 

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -955,6 +955,21 @@ func TestMovePathIfExistsCopyFallback(t *testing.T) {
 	}
 }
 
+func TestCopyFallbackTreatsMissingSourceAsAlreadyMoved(t *testing.T) {
+	dir := t.TempDir()
+	if err := copyAndRemove(filepath.Join(dir, "missing.txt"), filepath.Join(dir, "dst.txt")); err != nil {
+		t.Fatalf("copy missing source: %v", err)
+	}
+
+	dstDir := filepath.Join(dir, "dst-dir")
+	if err := copyDir(filepath.Join(dir, "missing-dir"), dstDir, 0o755); err != nil {
+		t.Fatalf("copy missing dir: %v", err)
+	}
+	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
+		t.Fatalf("copy missing dir should not leave an empty target, stat err = %v", err)
+	}
+}
+
 func TestCopyAndRemoveDirectory(t *testing.T) {
 	dir := t.TempDir()
 	srcDir := filepath.Join(dir, "src")

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -2100,6 +2100,54 @@ func TestTrashTopicMovesRelatedSessionsToTrash(t *testing.T) {
 	}
 }
 
+func TestTrashTopicRemovesStaleMissingSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_missing_trash"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Missing trash"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	missingPath := filepath.Join(dir, "already-gone.jsonl")
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"stale": {
+				ID:            "stale",
+				Scope:         "project",
+				WorkspaceRoot: projectRoot,
+				TopicID:       topicID,
+				TopicTitle:    "Missing trash",
+				SessionPath:   missingPath,
+				Ready:         true,
+				disabledMCP:   map[string]ServerView{},
+			},
+			"other": {ID: "other", Scope: "project", WorkspaceRoot: projectRoot, TopicID: "other", Ready: true},
+		},
+		tabOrder:    []string{"stale", "other"},
+		activeTabID: "stale",
+	}
+
+	if err := app.TrashTopic(topicID); err != nil {
+		t.Fatalf("TrashTopic should remove stale missing session: %v", err)
+	}
+	if got := loadTopicTitle(projectRoot, topicID); got != "" {
+		t.Fatalf("topic title should be removed, got %q", got)
+	}
+	if _, ok := app.tabs["stale"]; ok {
+		t.Fatalf("stale tab should be removed")
+	}
+	if got := app.activeTabID; got != "other" {
+		t.Fatalf("active tab = %q, want other", got)
+	}
+}
+
 func TestRestoreGlobalTopicSessionReindexesProjectTree(t *testing.T) {
 	isolateDesktopUserDirs(t)
 


### PR DESCRIPTION
## Summary

- Fix desktop topic/session trash cleanup when a session transcript or sidecar disappears before or during the move. Previously this could surface the raw Windows error `The system cannot find the path specified` and leave the sidebar topic feeling stuck.
- Make trash cleanup idempotent: if the source path is already gone, treat that artifact as already removed and continue moving any remaining artifacts. Real blocking errors, such as inaccessible destinations or busy live sessions, still propagate.
- When the source vanishes mid-copy, drop the partially written destination before treating the artifact as already moved, so the trash never keeps a truncated transcript that a later restore would resurrect. Real copy failures still propagate and leave the source untouched.
- Add regression coverage for copy fallback missing-source races, for removing a stale topic whose session path no longer exists, and for partial-destination cleanup when the source vanishes mid-copy.

## Verification

- `cd desktop && go test . -run "Test(MovePathIfExistsCopyFallback|CopyFallbackTreatsMissingSourceAsAlreadyMoved|CopyFallbackRemovesPartialTargetWhenSourceVanishesMidCopy|CopyFallbackKeepsErrorWhenSourceStillExists|TrashTopicRemovesStaleMissingSession|TrashTopicMovesRelatedSessionsToTrash|TrashTopicValidTrashRemovesEmptyLiveStub)"`
- `cd desktop && go test . -run "Test(DeleteSessionFile|MovePathIfExists|CopyAndRemove|CopyFallback|TrashTopic|Restore.*Session|PurgeTrashedSession)"`
- `cd desktop && go test .`
- `git diff --check`

## Cache impact

Cache-impact: none, desktop session cleanup only; this does not change provider-visible prompts, tool schemas, request serialization, or model context construction.
Cache-guard: `cd desktop && go test .` plus focused session trash regression tests listed above.
System-prompt-review: N/A
