### PR TITLE
fix(desktop): surface actionable errors when session cleanup hits a blocked file

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2288,6 +2288,10 @@ func channelDisplayName(provider, domain string) string {
 // has an in-process runtime, the runtime is cancelled and removed first so
 // autosave cannot recreate or append to the deleted file later.
 func (a *App) DeleteSession(path string) error {
+	return friendlySessionFileError(a.deleteSession(path))
+}
+
+func (a *App) deleteSession(path string) error {
 	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
@@ -2769,6 +2773,10 @@ func (a *App) activeSessionPath(dir string) string {
 
 // RestoreSession moves a trashed session back into the saved-session list.
 func (a *App) RestoreSession(path string) error {
+	return friendlySessionFileError(a.restoreSession(path))
+}
+
+func (a *App) restoreSession(path string) error {
 	dir, err := a.trashedSessionDir(path)
 	if err != nil {
 		return err
@@ -2827,6 +2835,10 @@ func (a *App) sessionOpen(dir, sessionPath string) bool {
 // PurgeTrashedSession permanently removes a trashed session and its title/display
 // sidecars.
 func (a *App) PurgeTrashedSession(path string) error {
+	return friendlySessionFileError(a.purgeTrashedSession(path))
+}
+
+func (a *App) purgeTrashedSession(path string) error {
 	dir, err := a.trashedSessionDir(path)
 	if err != nil {
 		return err

--- a/desktop/session_errors.go
+++ b/desktop/session_errors.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"syscall"
+)
+
+// Sanitized errors surfaced when a destructive or restore session operation
+// hits a real filesystem blocker. Like errSessionBusyElsewhere, they
+// intentionally carry no path, so raw OS error text never reaches the UI.
+var (
+	errSessionFileLocked       = errors.New("a session file is temporarily locked by another program (often antivirus or sync tools) — wait a moment and retry")
+	errSessionFileAccessDenied = errors.New("access to a session file was denied — close programs that may be using it or check folder permissions, then retry")
+	errSessionDiskFull         = errors.New("not enough disk space to finish the operation — free some space and retry")
+)
+
+// friendlySessionFileError rewrites raw OS-level filesystem errors from the
+// session trash/restore/purge flows (e.g. a Windows sharing violation while a
+// scanner holds a transcript) into the actionable, path-free errors above.
+// The original error is logged so diagnostics keep the path and errno.
+// Unrecognized errors — including already-sanitized ones like
+// errSessionBusyElsewhere — pass through unchanged.
+func friendlySessionFileError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return err
+	}
+	friendly := err
+	switch {
+	case isFileInUseErrno(errno):
+		friendly = errSessionFileLocked
+	case isAccessDeniedErrno(errno):
+		friendly = errSessionFileAccessDenied
+	case isDiskFullErrno(errno):
+		friendly = errSessionDiskFull
+	default:
+		return err
+	}
+	slog.Warn("desktop: session file operation blocked", "err", err)
+	return friendly
+}

--- a/desktop/session_errors.go
+++ b/desktop/session_errors.go
@@ -29,7 +29,7 @@ func friendlySessionFileError(err error) error {
 	if !errors.As(err, &errno) {
 		return err
 	}
-	friendly := err
+	var friendly error
 	switch {
 	case isFileInUseErrno(errno):
 		friendly = errSessionFileLocked

--- a/desktop/session_errors_test.go
+++ b/desktop/session_errors_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Platform errnos for the blocked-file classes. Windows values follow the
+// isRenameCrossDeviceOrBusy convention of naming the raw code inline.
+func blockedFileErrnos(t *testing.T) (inUse, accessDenied, diskFull syscall.Errno) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return 32, 5, 112 // ERROR_SHARING_VIOLATION, ERROR_ACCESS_DENIED, ERROR_DISK_FULL
+	}
+	return syscall.EBUSY, syscall.EACCES, syscall.ENOSPC
+}
+
+func TestFriendlySessionFileErrorMapsBlockedFileErrors(t *testing.T) {
+	inUse, accessDenied, diskFull := blockedFileErrnos(t)
+	secret := "/very/secret/session.jsonl"
+
+	cases := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "rename sharing violation",
+			err:  &os.LinkError{Op: "rename", Old: secret, New: secret + ".trash", Err: inUse},
+			want: errSessionFileLocked,
+		},
+		{
+			name: "remove access denied",
+			err:  &os.PathError{Op: "remove", Path: secret, Err: accessDenied},
+			want: errSessionFileAccessDenied,
+		},
+		{
+			name: "write disk full",
+			err:  &os.PathError{Op: "write", Path: secret, Err: diskFull},
+			want: errSessionDiskFull,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := friendlySessionFileError(tc.err)
+			if got != tc.want {
+				t.Fatalf("friendlySessionFileError() = %v, want %v", got, tc.want)
+			}
+			if strings.Contains(got.Error(), secret) {
+				t.Fatalf("sanitized error leaks the path: %v", got)
+			}
+		})
+	}
+}
+
+func TestFriendlySessionFileErrorPassesThroughOtherErrors(t *testing.T) {
+	if err := friendlySessionFileError(nil); err != nil {
+		t.Fatalf("nil should stay nil, got %v", err)
+	}
+	plain := errors.New("plain failure")
+	if got := friendlySessionFileError(plain); got != plain {
+		t.Fatalf("plain error rewritten to %v", got)
+	}
+	if got := friendlySessionFileError(errSessionBusyElsewhere); got != errSessionBusyElsewhere {
+		t.Fatalf("sanitized busy error rewritten to %v", got)
+	}
+	notExist := &os.PathError{Op: "lstat", Path: "gone.jsonl", Err: syscall.ENOENT}
+	if got := friendlySessionFileError(notExist); got != error(notExist) {
+		t.Fatalf("not-exist error rewritten to %v", got)
+	}
+}

--- a/desktop/session_errors_unix.go
+++ b/desktop/session_errors_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func isFileInUseErrno(errno syscall.Errno) bool {
+	return errno == syscall.EBUSY || errno == syscall.ETXTBSY
+}
+
+func isAccessDeniedErrno(errno syscall.Errno) bool {
+	return errno == syscall.EACCES || errno == syscall.EPERM
+}
+
+func isDiskFullErrno(errno syscall.Errno) bool {
+	return errno == syscall.ENOSPC || errno == syscall.EDQUOT
+}

--- a/desktop/session_errors_windows.go
+++ b/desktop/session_errors_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func isFileInUseErrno(errno syscall.Errno) bool {
+	return errno == windows.ERROR_SHARING_VIOLATION || errno == windows.ERROR_LOCK_VIOLATION
+}
+
+func isAccessDeniedErrno(errno syscall.Errno) bool {
+	return errno == windows.ERROR_ACCESS_DENIED
+}
+
+func isDiskFullErrno(errno syscall.Errno) bool {
+	return errno == windows.ERROR_DISK_FULL || errno == windows.ERROR_HANDLE_DISK_FULL
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6015,6 +6015,10 @@ func (a *App) emitRuntimeEvent(name string, payload ...interface{}) {
 
 // DeleteTopic removes a topic and its title metadata.
 func (a *App) DeleteTopic(topicID string) error {
+	return friendlySessionFileError(a.deleteTopic(topicID))
+}
+
+func (a *App) deleteTopic(topicID string) error {
 	f := loadProjectsFile()
 	found := false
 	for _, p := range f.Projects {
@@ -6120,6 +6124,10 @@ func (a *App) SetTopicPinned(topicID string, pinned bool) error {
 // cancelled and detached from the app first, so their autosave/jobs cannot
 // recreate state after the topic is gone.
 func (a *App) TrashTopic(topicID string) error {
+	return friendlySessionFileError(a.trashTopic(topicID))
+}
+
+func (a *App) trashTopic(topicID string) error {
 	if strings.TrimSpace(topicID) == "" {
 		return fmt.Errorf("topicID is required")
 	}
@@ -6169,7 +6177,7 @@ func (a *App) TrashTopic(topicID string) error {
 				}
 			}
 		}
-		return a.DeleteTopic(topicID)
+		return a.deleteTopic(topicID)
 	}(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Follow-up to #6085. That PR made session trash tolerate missing artifacts; this one covers the *remaining* real blockers: raw OS errors — Windows sharing violations while antivirus/sync tools hold a transcript, access denied, disk full — previously reached the UI toast verbatim (e.g. `The process cannot access the file because it is being used by another process.`).
- Add `friendlySessionFileError`, which classifies OS-level errnos (platform-specific: sharing/lock violation, access denied, disk full on Windows; `EBUSY`/`ETXTBSY`, `EACCES`/`EPERM`, `ENOSPC`/`EDQUOT` elsewhere) and rewrites them into sanitized, path-free messages with retry guidance, following the `errSessionBusyElsewhere` precedent. The original error is logged via `slog.Warn` so diagnostics keep the path and errno.
- Wire it at the UI-facing App entry points — `TrashTopic`, `DeleteTopic`, `DeleteSession`, `RestoreSession`, `PurgeTrashedSession` — via thin exported wrappers. Unrecognized errors (validation errors, already-sanitized busy errors, not-exist) pass through unchanged.
- Add unit coverage: each blocked-file class maps to its sanitized message and never leaks the path; nil, plain, busy, and not-exist errors pass through untouched.

## Verification

- `cd desktop && go test . -run "TestFriendlySessionFileError"`
- `cd desktop && go test .`
- `cd desktop && GOOS=windows GOARCH=amd64 go build .`
- `git diff --check`

## Cache impact

Cache-impact: none, desktop UI error surfacing only; this does not change provider-visible prompts, tool schemas, request serialization, or model context construction.
Cache-guard: `cd desktop && go test .` plus the focused `TestFriendlySessionFileError` tests listed above.
System-prompt-review: N/A
