### PR TITLE
fix(environment): persist probe snapshots so the prompt prefix stays byte-stable

### DIFF
--- a/desktop/session_prompt.go
+++ b/desktop/session_prompt.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"strings"
 
 	"reasonix/internal/agent"
@@ -14,6 +15,21 @@ func systemPromptFrom(messages []provider.Message) string {
 		}
 	}
 	return ""
+}
+
+// logSystemPromptSwap leaves a trace whenever a resume/rebind replaces a
+// conversation's persisted system prompt with different bytes: that swap
+// invalidates the whole conversation's provider prefix cache (misses bill at
+// 10x hits) and persists the rewrite. With probe snapshots keeping composition
+// deterministic, this should fire only on genuine config changes — if it shows
+// up in field logs without one, a new nondeterminism source crept into the
+// prompt assembly.
+func logSystemPromptSwap(persisted, fresh, path string) {
+	if persisted == "" || fresh == "" || persisted == fresh {
+		return
+	}
+	slog.Warn("desktop: resume swapped a differing system prompt; conversation prefix cache will miss",
+		"path", path, "persisted_len", len(persisted), "fresh_len", len(fresh))
 }
 
 func withFreshSystemPrompt(messages []provider.Message, system string) []provider.Message {
@@ -40,9 +56,11 @@ func sessionWithFreshSystemPrompt(session *agent.Session, system string) *agent.
 		return nil
 	}
 	messages := session.Snapshot()
-	if systemPromptFrom(messages) == "" {
+	persisted := systemPromptFrom(messages)
+	if persisted == "" {
 		return session
 	}
+	logSystemPromptSwap(persisted, system, "")
 	return session.CloneWithMessages(withFreshSystemPrompt(messages, system))
 }
 
@@ -55,7 +73,9 @@ func resumeWithFreshSystemPrompt(ctrl interface {
 		return
 	}
 	if len(messages) > 0 {
-		next := withFreshSystemPrompt(messages, systemPromptFrom(ctrl.History()))
+		fresh := systemPromptFrom(ctrl.History())
+		logSystemPromptSwap(systemPromptFrom(messages), fresh, path)
+		next := withFreshSystemPrompt(messages, fresh)
 		if path != "" {
 			if loaded, err := agent.LoadSession(path); err == nil && loaded != nil {
 				if resumed, ok := loaded.CloneWithMessagesIfCompatible(next); ok {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -264,6 +264,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			environment.RunProbesWithOptions(ctx, environment.DefaultProbes(), environment.ProbeOptions{
 				Overrides: cfg.Environment.Tools,
 				DenyRoots: []string{root},
+				// Persist probe results across restarts: the section below sits
+				// inside the provider-cached prompt prefix, and re-observing
+				// per boot let transient probe flaps (timeouts, PATH drift)
+				// rewrite the prefix and cold-start every session's cache.
+				SnapshotDir: config.CacheDir(),
 			}),
 			runtime.GOOS+"/"+runtime.GOARCH,
 			shellLabel,

--- a/internal/environment/probe.go
+++ b/internal/environment/probe.go
@@ -57,6 +57,15 @@ type ProbeResult struct {
 type ProbeOptions struct {
 	Overrides map[string]string
 	DenyRoots []string
+	// SnapshotDir, when set, persists probe results across process restarts
+	// (one snapshot per fingerprint under SnapshotDir/environment). A snapshot
+	// younger than probeSnapshotTTL is served without re-probing, and a
+	// refresh merges transient failures against the previous snapshot — both
+	// keep the rendered environment section byte-stable so the cached
+	// system-prompt prefix survives rebuilds. Empty disables persistence.
+	// The directory is host state, never model-visible, so it stays out of
+	// the probe fingerprint.
+	SnapshotDir string
 }
 
 func DefaultProbes() []string {
@@ -93,7 +102,22 @@ func RunProbesWithOptions(ctx context.Context, commands []string, opts ProbeOpti
 		<-call.done
 		return cloneProbeResults(call.results)
 	}
+	// A fresh persisted snapshot substitutes for a live run entirely: rebuilds
+	// and app relaunches within the TTL render the exact bytes the sessions on
+	// this machine were recorded with, so the provider prefix cache survives.
+	snapshot, hasSnapshot := loadProbeSnapshot(opts.SnapshotDir, key)
+	if hasSnapshot && now.Sub(snapshot.StoredAt) < probeSnapshotTTL {
+		finishProbe(key, snapshot.Results, now)
+		return cloneProbeResults(snapshot.Results)
+	}
 	results := runProbesUncached(ctx, commands, opts)
+	if hasSnapshot {
+		// Even an expired snapshot anchors the flap merge: transient failures
+		// (timeout, nonzero exit) keep the previous successful observation so
+		// a slow tool cannot rewrite the prompt prefix.
+		results = mergeProbeSnapshot(snapshot.Results, results)
+	}
+	saveProbeSnapshot(opts.SnapshotDir, key, results, now)
 	finishProbe(key, results, probeNow())
 	return cloneProbeResults(results)
 }

--- a/internal/environment/snapshot.go
+++ b/internal/environment/snapshot.go
@@ -1,0 +1,141 @@
+package environment
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+// Probe snapshots persist across process restarts so the environment section —
+// which sits inside the provider-cached system-prompt prefix — stays
+// byte-stable between rebuilds and relaunches. Live probes are point-in-time
+// observations: a 2s timeout flips a slow tool between "found" and "timeout",
+// a GUI-launched desktop resolves a different PATH than a login shell, a cold
+// docker daemon reports an exit error. Re-observing on every rebuild rewrote
+// the prefix and invalidated every session's provider cache (10x miss pricing)
+// for no user-visible reason. Persisting one snapshot per probe fingerprint
+// under the shared cache root keeps rebuilds — and the CLI and desktop on the
+// same machine — on identical bytes until the snapshot ages out.
+const probeSnapshotTTL = 24 * time.Hour
+
+const probeSnapshotVersion = 1
+
+type probeSnapshot struct {
+	Version     int           `json:"version"`
+	Fingerprint string        `json:"fingerprint"`
+	StoredAt    time.Time     `json:"stored_at"`
+	Results     []ProbeResult `json:"results"`
+}
+
+func probeSnapshotPath(dir, fingerprint string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(fingerprint))
+	return filepath.Join(dir, "environment", fmt.Sprintf("probes-%x.json", sum[:8]))
+}
+
+// loadProbeSnapshot returns the persisted snapshot for fingerprint, however
+// stale. Callers decide whether it is fresh enough to serve directly or only
+// usable as the flap-merge reference.
+func loadProbeSnapshot(dir, fingerprint string) (probeSnapshot, bool) {
+	path := probeSnapshotPath(dir, fingerprint)
+	if path == "" {
+		return probeSnapshot{}, false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return probeSnapshot{}, false
+	}
+	var snap probeSnapshot
+	if err := json.Unmarshal(b, &snap); err != nil {
+		return probeSnapshot{}, false
+	}
+	if snap.Version != probeSnapshotVersion || snap.Fingerprint != fingerprint {
+		return probeSnapshot{}, false
+	}
+	return snap, true
+}
+
+func saveProbeSnapshot(dir, fingerprint string, results []ProbeResult, now time.Time) {
+	path := probeSnapshotPath(dir, fingerprint)
+	if path == "" {
+		return
+	}
+	b, err := json.Marshal(probeSnapshot{
+		Version:     probeSnapshotVersion,
+		Fingerprint: fingerprint,
+		StoredAt:    now,
+		Results:     results,
+	})
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".probes.*.tmp")
+	if err != nil {
+		return
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return
+	}
+	if err := fileutil.ReplaceFile(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+	}
+}
+
+// transientProbeFailure reports whether a probe result describes a failure
+// that says nothing definitive about whether the tool exists: a timeout (slow
+// first run, cold daemon) or a nonzero exit (daemon down, transient state).
+// "not found" and "not trusted" are definitive — the binary is gone from PATH
+// or rejected by policy — and must be adopted, not papered over.
+func transientProbeFailure(r ProbeResult) bool {
+	if r.Found {
+		return false
+	}
+	return r.Error == "timeout" || strings.HasPrefix(r.Error, "exit ")
+}
+
+// mergeProbeSnapshot overlays fresh results onto the previous snapshot's:
+// a fresh transient failure keeps the previous successful observation for the
+// same probe, so a slow or flaky tool cannot flip the rendered environment
+// section — and with it the whole cached prompt prefix — between rebuilds.
+// Definitive results (found, not found, not trusted) always win.
+func mergeProbeSnapshot(previous, fresh []ProbeResult) []ProbeResult {
+	if len(previous) == 0 {
+		return fresh
+	}
+	prevByCommand := make(map[string]ProbeResult, len(previous))
+	for _, r := range previous {
+		if r.Found {
+			prevByCommand[r.Command] = r
+		}
+	}
+	merged := append([]ProbeResult(nil), fresh...)
+	for i, r := range merged {
+		if !transientProbeFailure(r) {
+			continue
+		}
+		if prev, ok := prevByCommand[r.Command]; ok {
+			merged[i] = prev
+		}
+	}
+	sortResults(merged)
+	return merged
+}

--- a/internal/environment/snapshot_test.go
+++ b/internal/environment/snapshot_test.go
@@ -1,0 +1,144 @@
+package environment
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestProbeSnapshotServesAcrossRestartsWithoutReprobing(t *testing.T) {
+	resetProbeCacheForTest(t, time.Unix(1000, 0))
+	dir := t.TempDir()
+	snapDir := t.TempDir()
+	toolPath := writeProbeTool(t, filepath.Join(dir, "snaptool"), "snaptool 1.0")
+	opts := ProbeOptions{Overrides: map[string]string{"snaptool": toolPath}, SnapshotDir: snapDir}
+	commands := []string{"snaptool --version"}
+
+	first := RunProbesWithOptions(context.Background(), commands, opts)
+	if len(first) != 1 || !first[0].Found || first[0].Output != "snaptool 1.0" {
+		t.Fatalf("first run = %+v, want found snaptool 1.0", first)
+	}
+	sectionBefore := FormatSection(first, "test/os", "/bin/sh", nil)
+
+	// Simulate a process restart: in-memory cache gone, and the tool binary
+	// gone too — a live probe would now say "not found". The persisted
+	// snapshot must answer instead, byte-identically.
+	resetProbeCacheForTest(t, time.Unix(2000, 0))
+	if err := os.Remove(toolPath); err != nil {
+		t.Fatalf("remove tool: %v", err)
+	}
+	second := RunProbesWithOptions(context.Background(), commands, opts)
+	if len(second) != 1 || !second[0].Found || second[0].Output != "snaptool 1.0" {
+		t.Fatalf("post-restart run = %+v, want snapshot-served snaptool 1.0", second)
+	}
+	if sectionAfter := FormatSection(second, "test/os", "/bin/sh", nil); sectionAfter != sectionBefore {
+		t.Fatalf("environment section changed across restart:\nbefore: %s\nafter:  %s", sectionBefore, sectionAfter)
+	}
+}
+
+func TestProbeSnapshotExpiresAndAdoptsDefinitiveChanges(t *testing.T) {
+	resetProbeCacheForTest(t, time.Unix(1000, 0))
+	dir := t.TempDir()
+	snapDir := t.TempDir()
+	toolPath := writeProbeTool(t, filepath.Join(dir, "exptool"), "exptool 1.0")
+	opts := ProbeOptions{Overrides: map[string]string{"exptool": toolPath}, SnapshotDir: snapDir}
+	commands := []string{"exptool --version"}
+
+	if first := RunProbesWithOptions(context.Background(), commands, opts); !first[0].Found {
+		t.Fatalf("first run = %+v, want found", first)
+	}
+
+	// Past the snapshot TTL a live probe runs again; a definitive change (the
+	// tool now reports a new version) is adopted and re-persisted.
+	resetProbeCacheForTest(t, time.Unix(1000, 0).Add(probeSnapshotTTL+time.Hour))
+	writeProbeTool(t, filepath.Join(dir, "exptool"), "exptool 2.0")
+	second := RunProbesWithOptions(context.Background(), commands, opts)
+	if !second[0].Found || second[0].Output != "exptool 2.0" {
+		t.Fatalf("post-TTL run = %+v, want refreshed exptool 2.0", second)
+	}
+
+	// The refreshed snapshot serves the new bytes across the next restart.
+	resetProbeCacheForTest(t, time.Unix(1000, 0).Add(probeSnapshotTTL+2*time.Hour))
+	if err := os.Remove(toolPath); err != nil {
+		t.Fatalf("remove tool: %v", err)
+	}
+	third := RunProbesWithOptions(context.Background(), commands, opts)
+	if !third[0].Found || third[0].Output != "exptool 2.0" {
+		t.Fatalf("post-refresh restart = %+v, want snapshot-served exptool 2.0", third)
+	}
+}
+
+func TestProbeSnapshotKeepsFoundOverTransientFailure(t *testing.T) {
+	resetProbeCacheForTest(t, time.Unix(1000, 0))
+	dir := t.TempDir()
+	snapDir := t.TempDir()
+	toolPath := writeProbeTool(t, filepath.Join(dir, "flaptool"), "flaptool 1.0")
+	opts := ProbeOptions{Overrides: map[string]string{"flaptool": toolPath}, SnapshotDir: snapDir}
+	commands := []string{"flaptool --version"}
+
+	if first := RunProbesWithOptions(context.Background(), commands, opts); !first[0].Found {
+		t.Fatalf("first run = %+v, want found", first)
+	}
+
+	// Past the TTL the live probe fails transiently (nonzero exit): the merge
+	// keeps the previous successful observation so the rendered section — and
+	// with it the cached prompt prefix — does not flap. Overwrite the tool in
+	// place so the fingerprint (command + override path) stays identical to
+	// the snapshot's.
+	resetProbeCacheForTest(t, time.Unix(1000, 0).Add(probeSnapshotTTL+time.Hour))
+	if err := os.Remove(toolPath); err != nil {
+		t.Fatalf("remove tool: %v", err)
+	}
+	body := "#!/bin/sh\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		body = "@exit /b 1\r\n"
+	}
+	if err := os.WriteFile(toolPath, []byte(body), 0o755); err != nil {
+		t.Fatalf("write failing tool: %v", err)
+	}
+	second := RunProbesWithOptions(context.Background(), commands, opts)
+	if !second[0].Found || second[0].Output != "flaptool 1.0" {
+		t.Fatalf("transient failure run = %+v, want previous found result kept", second)
+	}
+
+	// A definitive "not found" (override pointing at a missing binary) is
+	// adopted — genuinely uninstalled tools must not be resurrected forever.
+	resetProbeCacheForTest(t, time.Unix(1000, 0).Add(2*probeSnapshotTTL+2*time.Hour))
+	if err := os.Remove(toolPath); err != nil {
+		t.Fatalf("remove tool: %v", err)
+	}
+	third := RunProbesWithOptions(context.Background(), commands, opts)
+	if third[0].Found || third[0].Error != "not found" {
+		t.Fatalf("definitive removal run = %+v, want not found adopted", third)
+	}
+}
+
+func TestMergeProbeSnapshotOnlyOverlaysTransientFailures(t *testing.T) {
+	previous := []ProbeResult{
+		{Command: "go version", Binary: "go", Found: true, Output: "go1.24"},
+		{Command: "docker --version", Binary: "docker", Found: true, Output: "Docker 27"},
+		{Command: "node --version", Binary: "node", Found: true, Output: "v22"},
+	}
+	fresh := []ProbeResult{
+		{Command: "go version", Binary: "go", Error: "timeout"},
+		{Command: "docker --version", Binary: "docker", Error: "exit exit status 1"},
+		{Command: "node --version", Binary: "node", Error: "not found"},
+	}
+	merged := mergeProbeSnapshot(previous, fresh)
+	byCommand := map[string]ProbeResult{}
+	for _, r := range merged {
+		byCommand[r.Command] = r
+	}
+	if r := byCommand["go version"]; !r.Found || r.Output != "go1.24" {
+		t.Fatalf("timeout overlay = %+v, want previous found kept", r)
+	}
+	if r := byCommand["docker --version"]; !r.Found || r.Output != "Docker 27" {
+		t.Fatalf("exit overlay = %+v, want previous found kept", r)
+	}
+	if r := byCommand["node --version"]; r.Found || r.Error != "not found" {
+		t.Fatalf("not-found overlay = %+v, want definitive result adopted", r)
+	}
+}


### PR DESCRIPTION
## Summary

治本工程第一步：消除系统提示词前缀里最大的不确定性来源。

The environment section sits inside the provider-cached system-prompt prefix, but probe results were **point-in-time observations** with only a 5-minute in-memory cache. Between process restarts and rebuilds they drift for reasons invisible to the user: a 2s timeout flips a slow tool between `found` and `timeout`; a GUI-launched desktop resolves a different PATH than a login shell (so the CLI and desktop compose *different* prompts on the same machine); a cold docker daemon reports an exit error. Every flip rewrites the prefix, and the desktop's fresh-system-prompt swap (`sessionWithFreshSystemPrompt`) then propagates the drifted prompt onto every resumed session — a whole-conversation cache miss at 10x miss pricing **plus a persisted rewrite**. This is the main mechanism identified behind "desktop costs more than CLI" (#2945, and the Desktop-vs-CLI comparison in #5850's comments).

Changes:

- **Persisted probe snapshots** (`ProbeOptions.SnapshotDir`, opt-in; boot passes `config.CacheDir()`): one snapshot per probe fingerprint under `<cache>/environment/`. A snapshot younger than 24h serves without re-probing, so rebuilds, relaunches, and both surfaces on one machine render identical environment bytes. 24h aligns with the controller's `cacheColdAfter`: past a day idle the provider cache is dead anyway, so a refresh at that point costs nothing extra.
- **Flap merge on refresh**: transient failures (`timeout`, `exit …`) keep the previous successful observation for the same probe; definitive results (`found`, `not found`, `not trusted`) always win, so genuinely uninstalled tools still drop out of the section.
- **Desktop swap observability**: resume/rebind now logs when it swaps a system prompt whose bytes differ from the persisted one. With deterministic composition this should fire only on genuine config changes — a field log without one points at a new nondeterminism source.

Not in this PR (follow-ups): shell resolution (`sandbox.ResolveShell`) is also PATH-dependent but config-driven and rarely flaps; a swap-policy change for resumed sessions (keep the recorded prompt vs adopt the fresh one) is a product decision left untouched.

## Verification

- New tests: `TestProbeSnapshotServesAcrossRestartsWithoutReprobing` (snapshot serves byte-identical `FormatSection` output across a simulated restart even after the tool binary disappears), `TestProbeSnapshotExpiresAndAdoptsDefinitiveChanges` (post-TTL refresh adopts a real version change and re-persists), `TestProbeSnapshotKeepsFoundOverTransientFailure` (exit-failure keeps last-good; definitive `not found` adopted), `TestMergeProbeSnapshotOnlyOverlaysTransientFailures`.
- Full suites green: `internal/environment` (+`-race`), `internal/boot` (25s), `internal/cli`, desktop (53s). `go vet` clean.
- `REASONIX_RELEASE_CACHE_GUARD=1 go test ./internal/agent -run TestReleaseCacheHitGuard` green.

## Cache impact

Cache-impact: high - this PR is itself a cache-stability fix: it removes the probe-drift class of prompt-prefix invalidation. No prompt content changes when tools are stable; the section can now be up to 24h stale relative to live tool state.
Cache-guard: new snapshot byte-stability tests above (restart-identical FormatSection assertion) plus TestReleaseCacheHitGuard run locally.
System-prompt-review: requested from @SivanCola — model-visible policy change to sign off: (1) the environment section may lag live tool state by up to 24h (new installs appear on the next refresh); (2) a transiently failing tool keeps its last-good version line until a definitive change. Both trade freshness for prefix stability.

Refs #2945, #5850, #5614.