### PR TITLE
test: guard prompt-prefix byte stability at boot and desktop rebind level

### DIFF
--- a/desktop/session_prompt_bytes_test.go
+++ b/desktop/session_prompt_bytes_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -60,15 +61,38 @@ func marshalMessages(t *testing.T, msgs []provider.Message) []byte {
 	return b
 }
 
-// TestRebindKeepsRequestPrefixBytes is the desktop-level byte-stability guard
-// for the provider prefix cache: after the desktop's rebind path (load the
-// persisted transcript, swap in the freshly composed system prompt via
-// sessionWithFreshSystemPrompt, Resume on a new controller — the shape of
-// tabs.go's build/restore), the next request's leading messages must be
-// byte-identical to the request sent before the rebind. Any drift here means
-// every rebind cold-starts the conversation's provider cache at 10x miss
+// copySessionFiles clones a saved transcript (checkpoint anchor, event log,
+// meta sidecar) to an independent path, so a rebind can load the state saved
+// at that moment while the original controller keeps running and autosaving.
+func copySessionFiles(t *testing.T, from, to string) {
+	t.Helper()
+	copied := false
+	for _, suffix := range []string{"", ".events.jsonl", ".meta"} {
+		b, err := os.ReadFile(from + suffix)
+		if err != nil {
+			continue
+		}
+		if err := os.WriteFile(to+suffix, b, 0o644); err != nil {
+			t.Fatalf("copy session file %s: %v", suffix, err)
+		}
+		copied = true
+	}
+	if !copied {
+		t.Fatalf("no session files found at %s", from)
+	}
+}
+
+// TestRebindReproducesRequestBytes is the desktop-level byte-stability guard
+// for the provider prefix cache. It builds the strongest comparison available:
+// from ONE saved transcript, run the same follow-up turn twice — once on the
+// original controller (no rebind, the provider-cache-warm baseline) and once
+// after the desktop rebind path (agent.LoadSession + sessionWithFreshSystemPrompt
+// + Resume on a freshly built controller, the shape of tabs.go's restore). The
+// two requests must be byte-identical END TO END — system prompt, prior user
+// AND assistant turns, and the composed follow-up. Any divergence means a
+// desktop rebuild cold-starts the conversation's provider cache at 10x miss
 // pricing (#2945, #5614).
-func TestRebindKeepsRequestPrefixBytes(t *testing.T) {
+func TestRebindReproducesRequestBytes(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
@@ -81,43 +105,56 @@ func TestRebindKeepsRequestPrefixBytes(t *testing.T) {
 	if err := ctrl.RunTurn(context.Background(), "first question"); err != nil {
 		t.Fatalf("first turn: %v", err)
 	}
-	before := prov.lastRequestMessages(t)
-	beforeBytes := marshalMessages(t, before)
 	if err := ctrl.Snapshot(); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
+	// Freeze the after-turn-one transcript on an independent path: the
+	// baseline turn below autosaves onto the original path, and the rebind
+	// must load the state as saved at this moment.
+	rebindPath := filepath.Join(dir, "rebind.jsonl")
+	copySessionFiles(t, path, rebindPath)
 
-	// Desktop rebind: a NEW controller composes its (identical) system prompt,
-	// the persisted transcript is loaded, the fresh prompt is swapped in, and
-	// the controller resumes the session — tabs.go's restore shape.
+	// Baseline: the follow-up turn on the ORIGINAL controller — the exact
+	// request an uninterrupted (cache-warm) session would send.
+	if err := ctrl.RunTurn(context.Background(), "second question"); err != nil {
+		t.Fatalf("baseline second turn: %v", err)
+	}
+	baseline := prov.lastRequestMessages(t)
+	baselineBytes := marshalMessages(t, baseline)
+	if len(baseline) < 4 {
+		t.Fatalf("baseline request has %d messages, want system + first exchange + follow-up", len(baseline))
+	}
+
+	// Rebind from the transcript saved after turn one: a NEW controller
+	// composes its (identical) system prompt, the persisted transcript is
+	// loaded, the fresh prompt is swapped in, and the controller resumes —
+	// then sends the same follow-up.
 	prov2 := &capturingProvider{}
 	exec2 := agent.New(prov2, tool.NewRegistry(), agent.NewSession(systemPrompt), agent.Options{}, event.Discard)
-	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: systemPrompt, SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
-	loaded, err := agent.LoadSession(path)
+	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: systemPrompt, SessionDir: dir, SessionPath: rebindPath, Label: "test", Sink: event.Discard})
+	loaded, err := agent.LoadSession(rebindPath)
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), path)
+	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), rebindPath)
 
 	if err := ctrl2.RunTurn(context.Background(), "second question"); err != nil {
-		t.Fatalf("post-rebind turn: %v", err)
+		t.Fatalf("post-rebind second turn: %v", err)
 	}
-	after := prov2.lastRequestMessages(t)
-	if len(after) <= len(before) {
-		t.Fatalf("post-rebind request has %d messages, want more than the %d sent before rebind", len(after), len(before))
-	}
-	prefixBytes := marshalMessages(t, after[:len(before)])
-	if string(prefixBytes) != string(beforeBytes) {
-		t.Fatalf("rebind changed the request prefix bytes — the provider prefix cache is invalidated:\nbefore: %s\nafter:  %s", beforeBytes, prefixBytes)
+	rebound := prov2.lastRequestMessages(t)
+	reboundBytes := marshalMessages(t, rebound)
+	if string(reboundBytes) != string(baselineBytes) {
+		t.Fatalf("rebind changed the request bytes — the provider prefix cache is invalidated:\nbaseline: %s\nrebound:  %s", baselineBytes, reboundBytes)
 	}
 }
 
 // TestRebindWithDriftedPromptBreaksRequestPrefix pins the failure mode the
 // guard above protects against: when the freshly composed prompt differs from
 // the one the transcript was recorded with, the swap rewrites the first
-// message and the request prefix diverges. If a future change moves the swap
-// policy to keep the persisted prompt for resumed conversations, this test
-// should be updated to assert the prefix survives instead.
+// message and the request diverges from the no-rebind baseline. If a future
+// change moves the swap policy to keep the persisted prompt for resumed
+// conversations, this test should be updated to assert the bytes survive
+// instead.
 func TestRebindWithDriftedPromptBreaksRequestPrefix(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := t.TempDir()
@@ -129,28 +166,33 @@ func TestRebindWithDriftedPromptBreaksRequestPrefix(t *testing.T) {
 	if err := ctrl.RunTurn(context.Background(), "first question"); err != nil {
 		t.Fatalf("first turn: %v", err)
 	}
-	before := prov.lastRequestMessages(t)
-	beforeBytes := marshalMessages(t, before)
 	if err := ctrl.Snapshot(); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
+	rebindPath := filepath.Join(dir, "rebind.jsonl")
+	copySessionFiles(t, path, rebindPath)
+	if err := ctrl.RunTurn(context.Background(), "second question"); err != nil {
+		t.Fatalf("baseline second turn: %v", err)
+	}
+	baseline := prov.lastRequestMessages(t)
+	baselineBytes := marshalMessages(t, baseline)
 
 	prov2 := &capturingProvider{}
 	exec2 := agent.New(prov2, tool.NewRegistry(), agent.NewSession("SYSPROMPT v2 drifted"), agent.Options{}, event.Discard)
-	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: "SYSPROMPT v2 drifted", SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
-	loaded, err := agent.LoadSession(path)
+	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: "SYSPROMPT v2 drifted", SessionDir: dir, SessionPath: rebindPath, Label: "test", Sink: event.Discard})
+	loaded, err := agent.LoadSession(rebindPath)
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), path)
+	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), rebindPath)
 	if err := ctrl2.RunTurn(context.Background(), "second question"); err != nil {
 		t.Fatalf("post-rebind turn: %v", err)
 	}
-	after := prov2.lastRequestMessages(t)
-	if len(after) <= len(before) {
-		t.Fatalf("post-rebind request has %d messages, want more than %d", len(after), len(before))
+	rebound := prov2.lastRequestMessages(t)
+	if string(marshalMessages(t, rebound)) == string(baselineBytes) {
+		t.Fatal("drifted prompt unexpectedly reproduced the baseline request — the swap policy changed; update these guards")
 	}
-	if string(marshalMessages(t, after[:len(before)])) == string(beforeBytes) {
-		t.Fatal("drifted prompt unexpectedly kept the request prefix — the swap policy changed; update these guards")
+	if len(rebound) == 0 || rebound[0].Content == baseline[0].Content {
+		t.Fatalf("drift should surface in the leading system message; got %q", rebound[0].Content)
 	}
 }

--- a/desktop/session_prompt_bytes_test.go
+++ b/desktop/session_prompt_bytes_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// capturingProvider records the exact message list of every request it
+// receives, marshaled at capture time, so tests can compare request bytes.
+type capturingProvider struct {
+	mu       sync.Mutex
+	requests [][]byte
+}
+
+func (p *capturingProvider) Name() string { return "capturing" }
+
+func (p *capturingProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	b, err := json.Marshal(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	p.requests = append(p.requests, b)
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk, 1)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	close(ch)
+	return ch, nil
+}
+
+func (p *capturingProvider) lastRequestMessages(t *testing.T) []provider.Message {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.requests) == 0 {
+		t.Fatal("provider captured no requests")
+	}
+	var msgs []provider.Message
+	if err := json.Unmarshal(p.requests[len(p.requests)-1], &msgs); err != nil {
+		t.Fatalf("unmarshal captured request: %v", err)
+	}
+	return msgs
+}
+
+func marshalMessages(t *testing.T, msgs []provider.Message) []byte {
+	t.Helper()
+	b, err := json.Marshal(msgs)
+	if err != nil {
+		t.Fatalf("marshal messages: %v", err)
+	}
+	return b
+}
+
+// TestRebindKeepsRequestPrefixBytes is the desktop-level byte-stability guard
+// for the provider prefix cache: after the desktop's rebind path (load the
+// persisted transcript, swap in the freshly composed system prompt via
+// sessionWithFreshSystemPrompt, Resume on a new controller — the shape of
+// tabs.go's build/restore), the next request's leading messages must be
+// byte-identical to the request sent before the rebind. Any drift here means
+// every rebind cold-starts the conversation's provider cache at 10x miss
+// pricing (#2945, #5614).
+func TestRebindKeepsRequestPrefixBytes(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	const systemPrompt = "SYSPROMPT stable bytes"
+
+	prov := &capturingProvider{}
+	exec := agent.New(prov, tool.NewRegistry(), agent.NewSession(systemPrompt), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Runner: exec, Executor: exec, SystemPrompt: systemPrompt, SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
+
+	if err := ctrl.RunTurn(context.Background(), "first question"); err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	before := prov.lastRequestMessages(t)
+	beforeBytes := marshalMessages(t, before)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	// Desktop rebind: a NEW controller composes its (identical) system prompt,
+	// the persisted transcript is loaded, the fresh prompt is swapped in, and
+	// the controller resumes the session — tabs.go's restore shape.
+	prov2 := &capturingProvider{}
+	exec2 := agent.New(prov2, tool.NewRegistry(), agent.NewSession(systemPrompt), agent.Options{}, event.Discard)
+	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: systemPrompt, SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), path)
+
+	if err := ctrl2.RunTurn(context.Background(), "second question"); err != nil {
+		t.Fatalf("post-rebind turn: %v", err)
+	}
+	after := prov2.lastRequestMessages(t)
+	if len(after) <= len(before) {
+		t.Fatalf("post-rebind request has %d messages, want more than the %d sent before rebind", len(after), len(before))
+	}
+	prefixBytes := marshalMessages(t, after[:len(before)])
+	if string(prefixBytes) != string(beforeBytes) {
+		t.Fatalf("rebind changed the request prefix bytes — the provider prefix cache is invalidated:\nbefore: %s\nafter:  %s", beforeBytes, prefixBytes)
+	}
+}
+
+// TestRebindWithDriftedPromptBreaksRequestPrefix pins the failure mode the
+// guard above protects against: when the freshly composed prompt differs from
+// the one the transcript was recorded with, the swap rewrites the first
+// message and the request prefix diverges. If a future change moves the swap
+// policy to keep the persisted prompt for resumed conversations, this test
+// should be updated to assert the prefix survives instead.
+func TestRebindWithDriftedPromptBreaksRequestPrefix(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	prov := &capturingProvider{}
+	exec := agent.New(prov, tool.NewRegistry(), agent.NewSession("SYSPROMPT v1"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Runner: exec, Executor: exec, SystemPrompt: "SYSPROMPT v1", SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
+	if err := ctrl.RunTurn(context.Background(), "first question"); err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	before := prov.lastRequestMessages(t)
+	beforeBytes := marshalMessages(t, before)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	prov2 := &capturingProvider{}
+	exec2 := agent.New(prov2, tool.NewRegistry(), agent.NewSession("SYSPROMPT v2 drifted"), agent.Options{}, event.Discard)
+	ctrl2 := control.New(control.Options{Runner: exec2, Executor: exec2, SystemPrompt: "SYSPROMPT v2 drifted", SessionDir: dir, SessionPath: path, Label: "test", Sink: event.Discard})
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	ctrl2.Resume(sessionWithFreshSystemPrompt(loaded, systemPromptFrom(ctrl2.History())), path)
+	if err := ctrl2.RunTurn(context.Background(), "second question"); err != nil {
+		t.Fatalf("post-rebind turn: %v", err)
+	}
+	after := prov2.lastRequestMessages(t)
+	if len(after) <= len(before) {
+		t.Fatalf("post-rebind request has %d messages, want more than %d", len(after), len(before))
+	}
+	if string(marshalMessages(t, after[:len(before)])) == string(beforeBytes) {
+		t.Fatal("drifted prompt unexpectedly kept the request prefix — the swap policy changed; update these guards")
+	}
+}

--- a/internal/boot/prompt_stability_test.go
+++ b/internal/boot/prompt_stability_test.go
@@ -1,0 +1,85 @@
+package boot
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestBuildComposesByteStableSystemPrompt is the boot-level byte-stability
+// guard: two Builds over the same workspace and config must compose the exact
+// same system prompt. The system prompt is the provider-cached prefix of every
+// request in every session — any byte of nondeterminism here (probe flaps,
+// unsorted iteration, time-dependent content) cold-starts the provider cache
+// for the whole machine, which is precisely the "desktop costs more" class
+// (#2945). Environment probes are covered cross-process by the persisted
+// snapshot tests in internal/environment; this test pins the rest of the
+// composition (memory, skills index, output style, workspace line, policies).
+func TestBuildComposesByteStableSystemPrompt(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE SYSTEM PROMPT"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+	writeFile(t, dir, "REASONIX.md", "Project rule: keep the prompt prefix stable.")
+
+	first, err := Build(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("first Build: %v", err)
+	}
+	firstPrompt := systemMessage(first.History())
+	first.Close()
+	if strings.TrimSpace(firstPrompt) == "" {
+		t.Fatal("first Build composed an empty system prompt")
+	}
+
+	second, err := Build(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("second Build: %v", err)
+	}
+	secondPrompt := systemMessage(second.History())
+	second.Close()
+
+	if firstPrompt != secondPrompt {
+		t.Fatalf("system prompt is not byte-stable across identical Builds:\nfirst  (%d bytes)\nsecond (%d bytes)\nfirst diff site: %q",
+			len(firstPrompt), len(secondPrompt), firstDivergence(firstPrompt, secondPrompt))
+	}
+}
+
+// firstDivergence returns a small window around the first differing byte so a
+// failure names the drifting prompt section instead of dumping both prompts.
+func firstDivergence(a, b string) string {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	i := 0
+	for i < limit && a[i] == b[i] {
+		i++
+	}
+	start := i - 40
+	if start < 0 {
+		start = 0
+	}
+	endA := i + 40
+	if endA > len(a) {
+		endA = len(a)
+	}
+	endB := i + 40
+	if endB > len(b) {
+		endB = len(b)
+	}
+	return "..." + a[start:endA] + "... vs ..." + b[start:endB] + "..."
+}


### PR DESCRIPTION
## Summary

治本工程收尾：给 provider 前缀缓存加最终防线测试，补上 desktop 成本排查时确认的两个 CI 盲区——此前没有任何测试验证 (a) prompt 组装是确定性的、(b) desktop rebind 路径保持请求字节不变。

- **`TestBuildComposesByteStableSystemPrompt`** (internal/boot): two `Build`s over the same workspace/config must compose **byte-identical** system prompts. On failure it prints a window around the first diverging byte, so the drifting prompt section is named directly instead of dumping both prompts. Probe stability across processes is already covered by the persisted-snapshot tests from #6093; this pins the rest of the composition (memory compose, skills index, output style, workspace line, policies) against future nondeterminism.
- **`TestRebindKeepsRequestPrefixBytes`** (desktop): drives the real desktop rebind shape — `agent.LoadSession` + `sessionWithFreshSystemPrompt` + `Resume` on a freshly built controller — with a request-capturing provider, and asserts the next turn's leading request messages are **byte-identical** to the request sent before the rebind. This is the prefix-cache invariant itself: if it holds, a desktop rebuild costs zero cache misses.
- **`TestRebindWithDriftedPromptBreaksRequestPrefix`** pins the failure mode the guard exists for: a drifted fresh prompt rewrites the first message and the prefix diverges. If the swap policy ever changes to keep the persisted prompt for resumed conversations, this test flips and forces a conscious update of both guards.

Tests only — no production code changes.

## Verification

- `go test ./internal/boot` (16s) and full desktop suite (39s) green; `go vet` clean.
- Negative control built in: the drifted-prompt test demonstrates the capture-and-compare method detects prefix divergence.

## Cache impact

Cache-impact: none - test-only change; adds the guards that future cache-sensitive changes will be caught by.
Cache-guard: this PR IS the guard — boot-level composition determinism plus desktop rebind request-prefix byte equality.
System-prompt-review: requested from @SivanCola — test-only change (internal/boot/* glob matches the new test file); no provider-visible content changes, the new test pins existing composition bytes.

Refs #2945, #5614; builds on #6093.
