### PR TITLE
fix(agent): stop load-time repairs from masquerading as snapshot conflicts

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -408,9 +408,40 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 	if err != nil {
 		return snapshotWriteDecision{}, err
 	}
+	// raw is the transcript as stored, before load-time normalization repaired
+	// it; it equals existing when no repair ran. The prefix checks below must
+	// be able to fall back to it: a mid-turn snapshot legitimately cuts an
+	// assistant tool call from its still-running result, normalization then
+	// fabricates a placeholder answer on load, and the live session's real
+	// result collides with that placeholder — misreading a pure append as
+	// divergence (and forking a bogus recovery branch).
+	raw, rawDigest := existing, existingDigest
+	rawDiffers := current.normalizedDirty && len(current.rawMessages) > 0
+	if rawDiffers {
+		raw = current.rawMessages
+		if rawDigest, err = digestSessionMessages(raw); err != nil {
+			return snapshotWriteDecision{}, err
+		}
+	}
 	contentUnchanged := bytes.Equal(existingDigest[:], nextDigest[:])
 	exactAppend := messagesHavePrefix(next, existing)
-	if contentUnchanged || exactAppend || messagesHavePrefixWithCompatibleSystem(next, existing) {
+	appendShaped := contentUnchanged || exactAppend || messagesHavePrefixWithCompatibleSystem(next, existing)
+	repairPending := current.normalizedDirty
+	if !appendShaped && rawDiffers {
+		rawUnchanged := bytes.Equal(rawDigest[:], nextDigest[:])
+		rawAppend := messagesHavePrefix(next, raw)
+		if rawUnchanged || rawAppend || messagesHavePrefixWithCompatibleSystem(next, raw) {
+			existing = raw
+			contentUnchanged = rawUnchanged
+			exactAppend = rawAppend
+			appendShaped = true
+			// The snapshot supersedes the repaired view — appending it lands
+			// the real tool results where the placeholders were fabricated —
+			// so no load-time repair is left to force a rewrite.
+			repairPending = false
+		}
+	}
+	if appendShaped {
 		// An unknown-revision baseline (meta sidecar unreadable at load) cannot
 		// vouch for revision equality; the digest/prefix checks above already
 		// vouch for the content, so only a known baseline arms the CAS check.
@@ -433,7 +464,7 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		// replayable prefix already matches this snapshot.
 		decision := snapshotWriteDecision{
 			revision:  currentRevision,
-			upToDate:  contentUnchanged && !current.normalizedDirty && !current.eventLogDamaged,
+			upToDate:  contentUnchanged && !repairPending && !current.eventLogDamaged,
 			repairLog: current.eventLogDamaged,
 		}
 		// A ledger digest that describes different content than the transcript
@@ -451,10 +482,20 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		}
 		return decision, nil
 	}
-	if allowOwnedRewrite && s.ownsPersistedState(path, existingDigest, currentRevision, currentLedgerDigest, nextVersion) {
-		return snapshotWriteDecision{revision: currentRevision, repairLog: current.eventLogDamaged}, nil
+	if allowOwnedRewrite {
+		owned := s.ownsPersistedState(path, existingDigest, currentRevision, currentLedgerDigest, nextVersion)
+		if !owned && rawDiffers {
+			// The persisted baseline describes the bytes this session wrote, so
+			// a repaired view can never match it; ownership is judged against
+			// the raw transcript.
+			owned = s.ownsPersistedState(path, rawDigest, currentRevision, currentLedgerDigest, nextVersion)
+		}
+		if owned {
+			return snapshotWriteDecision{revision: currentRevision, repairLog: current.eventLogDamaged}, nil
+		}
 	}
-	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) {
+	if messagesHavePrefix(existing, next) || messagesHavePrefixWithCompatibleSystem(existing, next) ||
+		(rawDiffers && (messagesHavePrefix(raw, next) || messagesHavePrefixWithCompatibleSystem(raw, next))) {
 		return snapshotWriteDecision{}, &SessionSnapshotConflictError{
 			Path:             path,
 			Kind:             SessionSnapshotConflictStalePrefix,
@@ -1041,6 +1082,12 @@ func LoadSession(path string) (*Session, error) {
 	normalized := NormalizeSession(s.Messages)
 	if len(normalized) != len(s.Messages) || (len(s.Messages) > 0 && &normalized[0] != &s.Messages[0]) {
 		s.normalizedDirty = true
+		// Keep the pre-repair transcript: checkSnapshotWrite must be able to
+		// recognize a snapshot that extends the bytes actually on disk, which
+		// the repaired view no longer represents (an interrupted tool turn
+		// gets a placeholder result fabricated here that the live session
+		// answered for real).
+		s.rawMessages = msgs
 	}
 	s.Messages = normalized
 	if digest, err := digestSessionMessages(s.Messages); err == nil {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -476,7 +476,12 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		if decision.upToDate && currentLedgerDigest != "" && currentLedgerDigest != digestString(nextDigest) {
 			decision.ledgerStale = true
 		}
-		if exactAppend && !contentUnchanged && len(existing) < len(next) && !current.eventLogDamaged {
+		// An append is only chain-safe when existing measures the transcript
+		// the event log actually replays. Under a pending load-time repair the
+		// normalized view differs from the raw log, so an append event indexed
+		// against it breaks the replay chain and orphans the appended suffix;
+		// fall through to the full rewrite, which also persists the repair.
+		if exactAppend && !contentUnchanged && len(existing) < len(next) && !current.eventLogDamaged && !repairPending {
 			decision.appendOnly = true
 			decision.appendFrom = len(existing)
 		}
@@ -564,9 +569,25 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 		if digestErr != nil {
 			return RecoveryBranchInfo{}, digestErr
 		}
-		if bytes.Equal(existingDigest[:], digest[:]) ||
+		covered := bytes.Equal(existingDigest[:], digest[:]) ||
 			messagesHavePrefix(existing, msgs) ||
-			messagesHavePrefixWithCompatibleSystem(existing, msgs) {
+			messagesHavePrefixWithCompatibleSystem(existing, msgs)
+		if !covered && current.normalizedDirty && len(current.rawMessages) > 0 {
+			// Judge coverage against the pre-repair transcript too, for the
+			// same reason as checkSnapshotWrite: load-time normalization can
+			// reshape what is actually stored, and a recovery fork is only
+			// warranted when the stored bytes themselves fail to cover this
+			// snapshot.
+			raw := current.rawMessages
+			rawDigest, rawErr := digestSessionMessages(raw)
+			if rawErr != nil {
+				return RecoveryBranchInfo{}, rawErr
+			}
+			covered = bytes.Equal(rawDigest[:], digest[:]) ||
+				messagesHavePrefix(raw, msgs) ||
+				messagesHavePrefixWithCompatibleSystem(raw, msgs)
+		}
+		if covered {
 			return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded
 		}
 	}

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -144,6 +144,127 @@ func TestSaveSnapshotAllowsAppendFromDiskPrefix(t *testing.T) {
 	}
 }
 
+// TestSaveSnapshotAppendsAcrossInterruptedToolCallTail is the mid-turn autosave
+// shape from the field: a snapshot lands between an assistant tool call and its
+// still-running result, so the transcript on disk ends with a dangling call
+// that LoadSession answers with a fabricated placeholder. The live session then
+// records the real result and keeps going. The next snapshot is a pure append
+// over the bytes on disk and must land as one — not collide with the
+// placeholder, misread the turn as divergence, and fork a recovery branch.
+func TestSaveSnapshotAppendsAcrossInterruptedToolCallTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "run the build"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "Running it.",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{"cmd":"make"}`}},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("mid-turn SaveSnapshot: %v", err)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "ok"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "Build passed."})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot after tool result: %v", err)
+	}
+
+	replay, err := replaySessionEventLog(SessionEventLogPath(path))
+	if err != nil {
+		t.Fatalf("replay event log: %v", err)
+	}
+	if replay.damaged {
+		t.Fatal("event log damaged after appending over an interrupted tool tail")
+	}
+	if replay.records != 2 {
+		t.Fatalf("event log records = %d, want 2 (bootstrap replace + append)", replay.records)
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("message count after append snapshot = %d, want 5", got)
+	}
+	if got := loaded.Messages[3].Content; got != "ok" {
+		t.Fatalf("tool result after round-trip = %q, want %q", got, "ok")
+	}
+	if loaded.normalizedDirty {
+		t.Fatal("transcript still needs repair after appending the real tool result")
+	}
+}
+
+// TestSaveSnapshotUnchangedInterruptedToolCallTailIsNoOp covers the turn that
+// stays interrupted (cancel, crash recovery with nothing new in memory):
+// re-snapshotting the exact bytes on disk must be a no-op, not a stale-prefix
+// conflict against the placeholder the load-time repair fabricated.
+func TestSaveSnapshotUnchangedInterruptedToolCallTailIsNoOp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "run the build"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "Running it.",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{"cmd":"make"}`}},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("mid-turn SaveSnapshot: %v", err)
+	}
+	logBefore, err := os.ReadFile(SessionEventLogPath(path))
+	if err != nil {
+		t.Fatalf("ReadFile event log: %v", err)
+	}
+
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot unchanged: %v", err)
+	}
+	logAfter, err := os.ReadFile(SessionEventLogPath(path))
+	if err != nil {
+		t.Fatalf("ReadFile event log after no-op snapshot: %v", err)
+	}
+	if string(logBefore) != string(logAfter) {
+		t.Fatal("no-op snapshot rewrote the event log")
+	}
+	if revision, _, err := sessionContentRevision(path); err != nil || revision != 1 {
+		t.Fatalf("revision after no-op snapshot = %d (err %v), want 1", revision, err)
+	}
+}
+
+// TestSaveRewriteOwnedAcrossInterruptedToolCallTail: compaction rewrites the
+// in-memory history while the transcript on disk still ends with the dangling
+// call a mid-turn snapshot left behind. Ownership is anchored on the raw bytes
+// this session wrote; the placeholder fabricated on load must not revoke it.
+func TestSaveRewriteOwnedAcrossInterruptedToolCallTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "run the build"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "Running it.",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{"cmd":"make"}`}},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("mid-turn SaveSnapshot: %v", err)
+	}
+
+	s.Replace([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "[compacted] run the build"},
+	})
+	if err := s.SaveRewrite(path); err != nil {
+		t.Fatalf("SaveRewrite after compaction: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 2 {
+		t.Fatalf("message count after owned rewrite = %d, want 2", got)
+	}
+	if got := loaded.Messages[1].Content; got != "[compacted] run the build" {
+		t.Fatalf("compacted message after round-trip = %q", got)
+	}
+}
+
 func TestSaveSnapshotAppendsWithoutReplacingPrefixFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	base := NewSession("sys")

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -265,6 +265,86 @@ func TestSaveRewriteOwnedAcrossInterruptedToolCallTail(t *testing.T) {
 	}
 }
 
+// TestSaveSnapshotAfterDirtyResumeKeepsEventChainReplayable: a session resumed
+// from an interrupted tool tail carries the load-time repair in memory, so its
+// transcript is one message longer than what the event log replays. The next
+// snapshot must not take the append shortcut with that inflated index — the
+// chain-broken append event would be discarded on replay, silently dropping
+// the whole new turn from disk. It must fall back to a full rewrite that
+// persists the repair and the new turn together.
+func TestSaveSnapshotAfterDirtyResumeKeepsEventChainReplayable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "run the build"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "Running it.",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{"cmd":"make"}`}},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("mid-turn SaveSnapshot: %v", err)
+	}
+
+	// Crash + reopen: the resume load answers the dangling call with a
+	// placeholder, then the user runs another turn.
+	resumed, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession resume: %v", err)
+	}
+	if !resumed.normalizedDirty {
+		t.Fatal("resume load should carry a pending repair for the dangling call")
+	}
+	resumed.Add(provider.Message{Role: provider.RoleUser, Content: "try again"})
+	resumed.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := resumed.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot after dirty resume: %v", err)
+	}
+
+	replay, err := replaySessionEventLog(SessionEventLogPath(path))
+	if err != nil {
+		t.Fatalf("replay event log: %v", err)
+	}
+	if replay.damaged {
+		t.Fatal("event log chain broken by the post-resume snapshot")
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession reload: %v", err)
+	}
+	if got := len(loaded.Messages); got != 6 {
+		t.Fatalf("message count after post-resume snapshot = %d, want 6", got)
+	}
+	if got := loaded.Messages[3].ToolCallID; got != "call_1" {
+		t.Fatalf("placeholder tool result not persisted; message 3 tool_call_id = %q", got)
+	}
+	if got := loaded.Messages[5].Content; got != "done" {
+		t.Fatalf("new turn after round-trip = %q, want %q", got, "done")
+	}
+}
+
+// TestSaveRecoveryBranchNotNeededWhenRawTranscriptCoversSnapshot: the
+// recovery-needed check must also judge coverage against the pre-repair bytes.
+// Here the stored transcript equals the snapshot exactly, but normalization
+// backfills an empty tool-call name on load; that repair must not make the
+// disk look like it fails to cover the snapshot and fork a pointless recovery.
+func TestSaveRecoveryBranchNotNeededWhenRawTranscriptCoversSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "run the build"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "Running it.",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "", Arguments: `{"cmd":"make"}`}},
+	})
+	s.Add(provider.Message{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "ok"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	_, err := s.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if !errors.Is(err, ErrSessionRecoveryNotNeeded) {
+		t.Fatalf("SaveRecoveryBranch err = %v, want ErrSessionRecoveryNotNeeded", err)
+	}
+}
+
 func TestSaveSnapshotAppendsWithoutReplacingPrefixFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	base := NewSession("sys")

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -29,6 +29,12 @@ type Session struct {
 	// or corrupt and returned the replayable prefix (or the .jsonl checkpoint).
 	// The next save heals the log with a rewrite-and-compact.
 	eventLogDamaged bool
+	// rawMessages preserves the pre-normalization transcript when the load-time
+	// repairs changed it (normalizedDirty). It is only meaningful on a freshly
+	// loaded Session: checkSnapshotWrite compares a pending snapshot against
+	// what is actually on disk, and the repaired view no longer represents
+	// those bytes — a session that kept running extends the raw transcript.
+	rawMessages []provider.Message
 }
 
 // NewSession initializes a session with an optional system prompt.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3151,6 +3151,18 @@ func (c *Controller) recoverInterruptedTurn(path string) {
 		return
 	}
 	marker := meta.InFlightTurn
+	if interruptedTurnContinuedOnRecoveryBranch(path, marker) {
+		// The "interrupted" turn did not die with a runtime: a recovery branch
+		// forked off this session after the marker was set, so the turn kept
+		// running (and completing) there. Runtimes predating the marker
+		// transplant in recoverSnapshotConflict left the marker behind on the
+		// forked-from branch; stripping now would truncate a transcript the
+		// completed turn already superseded. Clear the stale marker instead.
+		if err := agent.ClearSessionInFlightTurn(path); err != nil {
+			slog.Warn("controller: clear fork-orphaned in-flight turn", "err", err)
+		}
+		return
+	}
 	msgs := c.executor.Session().Snapshot()
 	changed := marker.StartMessageIndex >= 0 && len(msgs) > marker.StartMessageIndex
 	if changed {
@@ -3166,6 +3178,31 @@ func (c *Controller) recoverInterruptedTurn(path string) {
 	if err := agent.ClearSessionInFlightTurn(path); err != nil {
 		slog.Warn("controller: clear stale in-flight turn", "err", err)
 	}
+}
+
+// interruptedTurnContinuedOnRecoveryBranch reports whether a recovery branch
+// forked off path after its in-flight-turn marker was set. Markers only exist
+// while a turn runs and recovery forks happen on saves, so a child recovery
+// branch younger than the marker means the marked turn itself moved there —
+// the marker is a leftover from a runtime that switched paths mid-turn, not a
+// crashed turn whose partial tail needs stripping. A marker without a start
+// time is treated as continued whenever any recovery child exists: erring
+// toward keeping messages is the data-safe direction.
+func interruptedTurnContinuedOnRecoveryBranch(path string, marker *agent.InFlightTurnMeta) bool {
+	if marker == nil {
+		return false
+	}
+	branches, err := agent.ListBranches(filepath.Dir(path))
+	if err != nil {
+		return false
+	}
+	id := agent.BranchID(path)
+	for _, b := range branches {
+		if b.Recovered && b.ParentID == id && b.CreatedAt.After(marker.StartedAt) {
+			return true
+		}
+	}
+	return false
 }
 
 // stripTurnMessagesAfter truncates the executor's session to keep only messages

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3062,6 +3062,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	c.mu.Unlock()
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
+	c.transplantInFlightTurnMarker(path, info.Path)
 	slog.Warn("controller: snapshot conflict; forked recovery branch",
 		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
@@ -3106,6 +3107,35 @@ func (c *Controller) clearInFlightTurn() {
 	}
 	if err := agent.ClearSessionInFlightTurn(path); err != nil {
 		slog.Warn("controller: clear in-flight turn", "err", err)
+	}
+}
+
+// transplantInFlightTurnMarker moves a pending in-flight-turn marker from the
+// session path a recovery fork abandoned onto the branch the turn continues
+// on. Left behind, the stale marker would fire recoverInterruptedTurn on the
+// next open of the original branch and strip messages from a turn that in
+// fact kept running on the recovery branch; missing from the recovery branch,
+// a crash before turn end would leave its partial tail unmarked.
+func (c *Controller) transplantInFlightTurnMarker(fromPath, toPath string) {
+	if strings.TrimSpace(fromPath) == "" || strings.TrimSpace(toPath) == "" || fromPath == toPath {
+		return
+	}
+	meta, ok, err := agent.LoadBranchMeta(fromPath)
+	if err != nil || !ok || meta.InFlightTurn == nil {
+		if err != nil {
+			slog.Warn("controller: load in-flight turn marker for transplant", "path", fromPath, "err", err)
+		}
+		return
+	}
+	marker := meta.InFlightTurn
+	if err := agent.MarkSessionInFlightTurn(toPath, marker.StartMessageIndex, marker.PreserveUser); err != nil {
+		// Keep the original marker: a turn boundary on the wrong branch beats
+		// no boundary anywhere if the runtime dies before the turn completes.
+		slog.Warn("controller: transplant in-flight turn marker", "path", toPath, "err", err)
+		return
+	}
+	if err := agent.ClearSessionInFlightTurn(fromPath); err != nil {
+		slog.Warn("controller: clear in-flight turn marker on forked-from branch", "path", fromPath, "err", err)
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -754,6 +754,91 @@ func TestSnapshotConflictRecoveryTransplantsInFlightTurnMarker(t *testing.T) {
 	}
 }
 
+// TestRecoverInterruptedTurnSparesTurnContinuedOnRecoveryBranch covers the
+// legacy leftovers of the marker transplant: runtimes predating it forked a
+// recovery branch mid-turn and left the in-flight marker on the original
+// branch. Opening the original must clear the stale marker without stripping
+// a turn that in fact kept running on the recovery branch.
+func TestRecoverInterruptedTurnSparesTurnContinuedOnRecoveryBranch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	orig := agent.NewSession("sys")
+	orig.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	orig.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial"})
+	if err := orig.Save(path); err != nil {
+		t.Fatalf("Save original: %v", err)
+	}
+	if err := agent.MarkSessionInFlightTurn(path, 1, true); err != nil {
+		t.Fatalf("MarkSessionInFlightTurn: %v", err)
+	}
+	// A legacy runtime forked the running turn onto a recovery branch and
+	// left the marker behind on the original.
+	forked := agent.NewSession("sys")
+	forked.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	forked.Add(provider.Message{Role: provider.RoleAssistant, Content: "continued elsewhere"})
+	if _, err := forked.SaveRecoveryBranch(agent.RecoveryBranchOptions{OriginalPath: path}); err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	exec := agent.New(nil, nil, loaded, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	c.recoverInterruptedTurn(path)
+
+	if got := c.executor.Session().Len(); got != 3 {
+		t.Fatalf("message count after reopening forked-from branch = %d, want 3 (turn stripped despite recovery child)", got)
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if meta.InFlightTurn != nil {
+		t.Fatal("fork-orphaned in-flight marker not cleared")
+	}
+}
+
+// TestRecoverInterruptedTurnStripsGenuineCrash pins the crash-recovery
+// behavior the recovery-child guard must not swallow: with no recovery branch
+// in sight, an in-flight marker means the runtime died mid-turn and the
+// partial tail is stripped (preserving the user prompt).
+func TestRecoverInterruptedTurnStripsGenuineCrash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	orig := agent.NewSession("sys")
+	orig.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	orig.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial"})
+	if err := orig.Save(path); err != nil {
+		t.Fatalf("Save original: %v", err)
+	}
+	if err := agent.MarkSessionInFlightTurn(path, 1, true); err != nil {
+		t.Fatalf("MarkSessionInFlightTurn: %v", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	exec := agent.New(nil, nil, loaded, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	c.recoverInterruptedTurn(path)
+
+	if got := c.executor.Session().Len(); got != 2 {
+		t.Fatalf("message count after crash recovery = %d, want 2 (sys + preserved user prompt)", got)
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if meta.InFlightTurn != nil {
+		t.Fatal("in-flight marker not cleared after crash recovery")
+	}
+}
+
 func TestSnapshotRewriteRecoversStaleControllerTranscript(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -696,6 +696,64 @@ func TestSnapshotRecoversDivergedControllerTranscript(t *testing.T) {
 	}
 }
 
+// TestSnapshotConflictRecoveryTransplantsInFlightTurnMarker: when a snapshot
+// conflict forks the running turn onto a recovery branch, the in-flight-turn
+// marker must move with it. Left on the original branch, the stale marker
+// makes the next open of that branch strip messages from a turn that in fact
+// kept running (and completed) on the recovery branch.
+func TestSnapshotConflictRecoveryTransplantsInFlightTurnMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	staleSess := agent.NewSession("sys")
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	currentSess := agent.NewSession("sys")
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	currentSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	currentExec := agent.New(nil, nil, currentSess, agent.Options{}, event.Discard)
+	current := New(Options{Executor: currentExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := current.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity current: %v", err)
+	}
+
+	// The stale runtime had a foreground turn running when the conflict fired.
+	if err := agent.MarkSessionInFlightTurn(path, 2, true); err != nil {
+		t.Fatalf("MarkSessionInFlightTurn: %v", err)
+	}
+
+	if err := stale.Snapshot(); err != nil {
+		t.Fatalf("Snapshot stale diverged: %v", err)
+	}
+	recoveryPath := stale.SessionPath()
+	if recoveryPath == path || recoveryPath == "" {
+		t.Fatalf("stale session path after recovery = %q, want recovery path", recoveryPath)
+	}
+
+	origMeta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta original ok=%v err=%v", ok, err)
+	}
+	if origMeta.InFlightTurn != nil {
+		t.Fatal("in-flight turn marker left on the forked-from branch; reopening it would strip the turn")
+	}
+	recMeta, ok, err := agent.LoadBranchMeta(recoveryPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta recovery ok=%v err=%v", ok, err)
+	}
+	if recMeta.InFlightTurn == nil {
+		t.Fatal("in-flight turn marker not transplanted to the recovery branch")
+	}
+	if recMeta.InFlightTurn.StartMessageIndex != 2 || !recMeta.InFlightTurn.PreserveUser {
+		t.Fatalf("transplanted marker = %+v, want start index 2 with preserve_user", recMeta.InFlightTurn)
+	}
+}
+
 func TestSnapshotRewriteRecoversStaleControllerTranscript(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")


### PR DESCRIPTION
## Field incident

A session running on latest `main-v2` (dce3b3a70) forked a "conflict copy" 30 seconds after its first mid-turn autosave, with **no second runtime involved** (same `writer_id`/pid throughout):

- 17:59:02 first 30s mid-turn snapshot bootstraps the event log: **21 messages**, revision 1. The transcript tail is an assistant message whose tool call was still running — a legitimately dangling call.
- 17:59:32 next autosave: memory holds 34 messages whose **first 21 are byte-identical to disk** (verified by per-message JSON hashing), i.e. a pure append — yet it was rejected as `diverged` and forked `…-recovery-748ca7f3…`.

Root cause: `checkSnapshotWrite` compares the pending snapshot against `LoadSession`'s view of disk, and load-time normalization had already fabricated a placeholder result for the dangling call (`sessionToolResults`). The live session's **real** tool result collides positionally with the placeholder, both prefix checks fail, and a pure append misreads as divergence. Any tool-heavy turn whose tool outlives the 30s autosave interval reproduces this deterministically.

## Fixes (one per commit, same root cause family)

1. **`checkSnapshotWrite` falls back to the raw transcript** (09ce7df43). `LoadSession` now preserves the pre-repair messages when normalization changed them; append shape, owned-rewrite ownership, and conflict-kind classification retry against the bytes actually on disk before declaring conflict. The mid-turn compaction rewrite variant (ownership revoked by the repaired digest) is covered by the same fallback.
2. **Dirty-resume saves no longer take the append shortcut** (a1fecd3aa). `appendFrom` was measured against the normalized view while the event log replays the raw transcript; the chain-broken append event was silently discarded on the next load, **dropping the whole post-resume turn from disk** despite a successful save. A pending repair now falls through to the full rewrite, which persists the repair and the new turn together. Same commit: `SaveRecoveryBranch`'s "recovery not needed" coverage check gets the same raw fallback.
3. **Recovery forks transplant the in-flight turn marker** (7932bc1e4). The marker written at turn start stayed on the forked-from path; turn end cleared the (absent) marker on the recovery path. The next open of the original branch fired `recoverInterruptedTurn` against a turn that had completed on the recovery branch, stripping the transcript back to the turn boundary and force-saving the truncation.
4. **Fork-orphaned markers self-heal on open** (1437d5a24). Every fork made by an older runtime already left such a marker behind. A recovery child whose `parent_id` is this session and whose `created_at` postdates the marker means the marked turn moved rather than died: clear the marker, keep the messages. A genuine crash (no such child) strips exactly as before. This is the migration path for existing users — no manual cleanup needed.

## Tests

10 regression tests across `internal/agent` and `internal/control`; each was verified to FAIL with its fix stashed and PASS with it applied. Full `go test ./...`, `go vet`, `gofmt` clean.

## Related

#6074, #6080, #6082 fixed the revision-CAS/ledger-drift/adoption conflict sources; this covers the normalization-induced ones they don't reach.