### PR TITLE
fix(ui): make every cost/cache readout match its labeled scope

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -109,6 +109,24 @@ const infoCost = contextCostDisplay({
   usage: { cost: 0, costUsd: 0, currency: "¥" },
 });
 eq(infoCost, { amount: 0.1759, currency: "$" }, "panel cost keeps the panel currency instead of state default");
+const singleRequestOnly = contextCostDisplay({
+  info: { sessionCost: 0, sessionCurrency: "", sessionCostUsd: 0 },
+  sessionCost: 0,
+  sessionCurrency: "¥",
+  usage: { cost: 0.42, costUsd: 0.42, currency: "¥" },
+});
+eq(
+  singleRequestOnly,
+  { amount: 0, currency: "¥" },
+  "a single request's cost never renders under the session-cost label",
+);
+const localAccumulated = contextCostDisplay({
+  info: { sessionCost: 0, sessionCurrency: "", sessionCostUsd: 0 },
+  sessionCost: 1.5,
+  sessionCurrency: "¥",
+  usage: { cost: 0.42, costUsd: 0.42, currency: "$" },
+});
+eq(localAccumulated, { amount: 1.5, currency: "¥" }, "locally accumulated session cost still renders");
 eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
 eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");

--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
-import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSourceRows, contextUsageRefreshKey, contextWindowStatus, formatCacheHitRate, formatMetricTokens } from "../components/ContextPanel";
+import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSessionCache, contextSourceRows, contextUsageRefreshKey, contextWindowStatus, formatCacheHitRate, formatMetricTokens } from "../components/ContextPanel";
 import { currencySymbol, formatMoney, formatMoneyLocalized } from "../lib/money";
 
 let passed = 0;
@@ -127,6 +127,41 @@ const localAccumulated = contextCostDisplay({
   usage: { cost: 0.42, costUsd: 0.42, currency: "$" },
 });
 eq(localAccumulated, { amount: 1.5, currency: "¥" }, "locally accumulated session cost still renders");
+
+console.log("\ncontext panel session cache scope");
+
+eq(
+  contextSessionCache(
+    { sessionCacheHitTokens: 900, sessionCacheMissTokens: 100 },
+    { cacheHitTokens: 800, cacheMissTokens: 200 },
+    { sessionCacheHitTokens: 700, sessionCacheMissTokens: 300 },
+  ),
+  { hit: 900, miss: 100 },
+  "all-sources panel telemetry beats executor-only wire counters",
+);
+eq(
+  contextSessionCache(
+    { sessionCacheHitTokens: 0, sessionCacheMissTokens: 0 },
+    { cacheHitTokens: 800, cacheMissTokens: 200 },
+    { sessionCacheHitTokens: 700, sessionCacheMissTokens: 300 },
+  ),
+  { hit: 800, miss: 200 },
+  "ContextInfo telemetry is the second all-sources choice",
+);
+eq(
+  contextSessionCache(
+    { sessionCacheHitTokens: 0, sessionCacheMissTokens: 0 },
+    { cacheHitTokens: 0, cacheMissTokens: 0 },
+    { sessionCacheHitTokens: 700, sessionCacheMissTokens: 300 },
+  ),
+  { hit: 700, miss: 300 },
+  "executor-only wire counters only bridge the pre-refresh gap",
+);
+eq(
+  contextSessionCache(null, undefined, undefined),
+  { hit: 0, miss: 0 },
+  "no data renders as empty, not NaN",
+);
 eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
 eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -126,20 +126,17 @@ export function contextCostDisplay({
   sessionCurrency?: string;
   usage?: Pick<WireUsage, "cost" | "costUsd" | "currency">;
 }): { amount: number; currency?: string } {
+  // Session-scoped sources only: this value renders under the 会话费用 label,
+  // and falling back to a single request's usage.cost silently displayed one
+  // turn's spend as the whole session's. usage now contributes currency only.
   if (info?.sessionCost && info.sessionCost > 0) {
     return { amount: info.sessionCost, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
   }
   if (sessionCost && sessionCost > 0) {
     return { amount: sessionCost, currency: sessionCurrency || info?.sessionCurrency || usage?.currency };
   }
-  if (usage?.cost && usage.cost > 0) {
-    return { amount: usage.cost, currency: usage.currency || sessionCurrency || info?.sessionCurrency };
-  }
   if (info?.sessionCostUsd && info.sessionCostUsd > 0) {
     return { amount: info.sessionCostUsd, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
-  }
-  if (usage?.costUsd && usage.costUsd > 0) {
-    return { amount: usage.costUsd, currency: usage.currency || sessionCurrency || info?.sessionCurrency };
   }
   return { amount: 0, currency: info?.sessionCurrency || sessionCurrency || usage?.currency };
 }

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -141,6 +141,25 @@ export function contextCostDisplay({
   return { amount: 0, currency: info?.sessionCurrency || sessionCurrency || usage?.currency };
 }
 
+// contextSessionCache picks the session-cumulative cache hit/miss pair for the
+// panel's session average. All-sources telemetry (panel info, then ContextInfo)
+// wins over the wire session counters, which the Go agent scopes to the
+// executor only — the same preference StatusBar applies — and the pair always
+// comes from a single source so the computed rate never mixes scopes.
+export function contextSessionCache(
+  info?: Pick<ContextPanelInfo, "sessionCacheHitTokens" | "sessionCacheMissTokens"> | null,
+  context?: Pick<ContextInfo, "cacheHitTokens" | "cacheMissTokens">,
+  usage?: Pick<WireUsage, "sessionCacheHitTokens" | "sessionCacheMissTokens">,
+): { hit: number; miss: number } {
+  const infoHit = info?.sessionCacheHitTokens ?? 0;
+  const infoMiss = info?.sessionCacheMissTokens ?? 0;
+  if (infoHit + infoMiss > 0) return { hit: infoHit, miss: infoMiss };
+  const ctxHit = context?.cacheHitTokens ?? 0;
+  const ctxMiss = context?.cacheMissTokens ?? 0;
+  if (ctxHit + ctxMiss > 0) return { hit: ctxHit, miss: ctxMiss };
+  return { hit: usage?.sessionCacheHitTokens ?? 0, miss: usage?.sessionCacheMissTokens ?? 0 };
+}
+
 interface ContextBreakdown {
   promptTokens: number;
   completionTokens: number;
@@ -351,11 +370,12 @@ export function ContextPanel({
         ? usage.totalTokens
         : promptTokens + completionTokens;
   const reasoningTokens = usage?.reasoningTokens ?? info?.reasoningTokens ?? 0;
-  // Session-cumulative values for the top summary.
-  // Prefer usage.sessionCacheHitTokens — it is the session-cumulative value from
-  // the Go agent (includes background tasks) and arrives with every usage event.
-  const sessionCacheHit = usage?.sessionCacheHitTokens ?? info?.sessionCacheHitTokens ?? context?.cacheHitTokens ?? 0;
-  const sessionCacheMiss = usage?.sessionCacheMissTokens ?? info?.sessionCacheMissTokens ?? context?.cacheMissTokens ?? 0;
+  // Session-cumulative cache tokens for the top summary: all-sources telemetry
+  // first (matching the session cost and per-source rows in this panel — the
+  // wire session counters are executor-only), with the live counters bridging
+  // only a fresh session's first turn before the telemetry refresh. Hit and
+  // miss come as a pair from one source so the rate cannot mix scopes.
+  const { hit: sessionCacheHit, miss: sessionCacheMiss } = contextSessionCache(info, context, usage);
   const totalTokensMetric = formatMetricTokens(totalTokens, locale);
   const cost = contextCostDisplay({ info, sessionCost, sessionCurrency, usage });
   const sourceUsageRows = contextSourceRows(info, sessionCurrency);

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -22,9 +22,10 @@ function nowRate(u?: WireUsage): string | null {
 }
 
 // avgRate is the SESSION-AGGREGATE cache-hit % — Σhit/Σ(hit+miss) across every
-// turn — the steadier, cost-oriented number that matches the legacy dashboard.
-// On a non-compacting DeepSeek session it trails nowRate (early cold-start turns
-// drag the average down); it overtakes only when compaction craters single turns.
+// turn — but scoped to the EXECUTOR agent only: the wire session counters come
+// from the main agent and exclude subagent/planner/auxiliary requests. It is
+// only the pre-first-refresh fallback; the authoritative all-sources number is
+// contextAvgRate below, so the "session average" label reports one scope.
 function avgRate(u?: WireUsage): string | null {
   if (!u) return null;
   const denom = u.sessionCacheHitTokens + u.sessionCacheMissTokens;
@@ -32,8 +33,10 @@ function avgRate(u?: WireUsage): string | null {
 }
 
 // contextAvgRate computes the session-aggregate cache-hit % from ContextInfo
-// cache tokens (loaded from persisted telemetry on session resume). Used as a
-// fallback when no live WireUsage is available yet.
+// cache tokens — the tab telemetry that accumulates ALL request sources
+// (executor, subagents, planner, auxiliary calls), refreshed at turn
+// boundaries. Preferred over avgRate: it matches the 会话费用 tooltip's
+// "includes main model, subagents and auxiliary calls" scope.
 function contextAvgRate(ctx: ContextInfo): string | null {
   const hit = ctx.cacheHitTokens ?? 0;
   const miss = ctx.cacheMissTokens ?? 0;
@@ -186,7 +189,9 @@ export function StatusBar({
   const compactNear = pct !== null && compactPct !== null && pct >= Math.max(0, compactPct - 10);
   const compactReached = pct !== null && compactPct !== null && pct >= compactPct;
   const nowPct = nowRate(usage);
-  const avgPct = avgRate(usage) ?? contextAvgRate(context);
+  // All-sources telemetry first; the executor-only live counters only bridge
+  // the gap before the first ContextInfo refresh of a fresh session.
+  const avgPct = contextAvgRate(context) ?? avgRate(usage);
   const turnCostLabel = formatMoneyLocalized(turnCost, currency, { locale });
   const costLabel = formatMoneyLocalized(cost, currency, { locale });
   const displayWorkspacePath = (workspacePath || workspaceName || "").trim();

--- a/internal/cli/cache_tag_test.go
+++ b/internal/cli/cache_tag_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+// cacheTagCtrl stubs the two SessionAPI reads cacheTag performs; every other
+// method panics via the embedded nil interface, which is exactly what we want
+// from a focused status-line test.
+type cacheTagCtrl struct {
+	control.SessionAPI
+	last      *provider.Usage
+	hit, miss int
+}
+
+func (s cacheTagCtrl) LastUsage() *provider.Usage { return s.last }
+func (s cacheTagCtrl) SessionCache() (int, int)   { return s.hit, s.miss }
+
+func TestCacheTagHiddenWhenProviderReportsNoCacheFields(t *testing.T) {
+	// A provider without prompt-cache support reports prompt tokens but no
+	// cache hit/miss fields. Falling back to PromptTokens as the denominator
+	// used to paint a bogus "turn hit 0.00%"; the tag must stay empty instead.
+	m := chatTUI{ctrl: cacheTagCtrl{last: &provider.Usage{PromptTokens: 1000}}}
+	if got := m.cacheTag(); got != "" {
+		t.Fatalf("cacheTag with no cache fields = %q, want empty", got)
+	}
+}
+
+func TestCacheTagShowsRealZeroHit(t *testing.T) {
+	// A genuine full miss (provider reports the fields, hit is zero) is
+	// informative and must still render.
+	m := chatTUI{ctrl: cacheTagCtrl{last: &provider.Usage{PromptTokens: 1000, CacheMissTokens: 1000}}}
+	if got := m.cacheTag(); !strings.Contains(got, "0.00%") {
+		t.Fatalf("cacheTag with a real full miss = %q, want 0.00%% rendered", got)
+	}
+}
+
+func TestCacheTagRendersHitRateAndSessionAverage(t *testing.T) {
+	m := chatTUI{ctrl: cacheTagCtrl{
+		last: &provider.Usage{CacheHitTokens: 80, CacheMissTokens: 20},
+		hit:  700, miss: 300,
+	}}
+	got := m.cacheTag()
+	if !strings.Contains(got, "80.00%") {
+		t.Fatalf("cacheTag = %q, want turn rate 80.00%%", got)
+	}
+	if !strings.Contains(got, "70.00%") {
+		t.Fatalf("cacheTag = %q, want session average 70.00%%", got)
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2678,11 +2678,10 @@ func cacheRateLabel(format string, hit, denom int) string {
 func (m chatTUI) cacheTag() string {
 	now := ""
 	if u := m.ctrl.LastUsage(); u != nil {
-		d := u.CacheHitTokens + u.CacheMissTokens
-		if d == 0 {
-			d = u.PromptTokens
-		}
-		now = cacheRateLabel(i18n.M.ChatStatusCacheNowFmt, u.CacheHitTokens, d)
+		// Only render when the provider actually reports cache token fields:
+		// falling back to PromptTokens as the denominator painted a bogus
+		// "turn hit 0.00%" for providers with no prompt-cache support.
+		now = cacheRateLabel(i18n.M.ChatStatusCacheNowFmt, u.CacheHitTokens, u.CacheHitTokens+u.CacheMissTokens)
 	}
 	avg := ""
 	if hit, miss := m.ctrl.SessionCache(); hit+miss > 0 {

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -499,7 +499,7 @@ const __T = {
     'model': 'Model',
     'total_tokens': 'Total Tokens',
     'cache_hit_rate': 'Cache Hit Rate',
-    'total_cost': 'Total Cost',
+    'total_cost': 'Session Cost',
     'context_usage': 'Context Usage',
 
     'connected': 'Connected',
@@ -602,7 +602,7 @@ const __T = {
     'model': '模型',
     'total_tokens': '总 Token',
     'cache_hit_rate': '缓存命中率',
-    'total_cost': '总费用',
+    'total_cost': '会话费用',
     'context_usage': '上下文用量',
 
     'connected': '已连接',
@@ -1165,7 +1165,7 @@ function loadSessions(){
       const title=s.title||name.replace(/^\w+-/,'').replace(/T/,' ').replace(/[-_]/g,' ').slice(0,30);
       const meta=s.turns?s.turns+' turns':'';
 	      item.innerHTML='<svg class="session-item__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg><div class="session-item__body"><div class="session-item__title">'+escHtml(title)+'</div><div class="session-item__meta">'+escHtml(meta)+'</div></div><button type="button" class="session-del" data-name="'+escAttr(s.name)+'" title="'+escAttr(__('delete_confirm'))+'">&times;</button>';
-      item.onclick=()=>{if(running||s.current)return;post('/resume',{path:s.path}).then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';todosDismissed=false;loadSessions();setTimeout(()=>fetch('/history').then(r=>r.json()).then(msgs=>{renderHistoryMessages(msgs);fetchTodos();}),300);});};
+      item.onclick=()=>{if(running||s.current)return;post('/resume',{path:s.path}).then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';todosDismissed=false;resetCumulativeStats();loadSessions();setTimeout(()=>fetch('/history').then(r=>r.json()).then(msgs=>{renderHistoryMessages(msgs);fetchTodos();}),300);});};
       list.appendChild(item);
     });
   }).catch(()=>{const list=$('#session-list');if(list)list.innerHTML='<div style="padding:10px;color:var(--muted-2);font-size:12px">'+__('error_loading')+'</div>';});
@@ -1318,7 +1318,7 @@ $('#btn-plan').onclick=()=>void setPlan(!planMode);
 $('#btn-bypass').onclick=()=>void toggleYolo();
 $('#btn-goal').onclick=()=>toggleGoalMode();
 $('#goal-chip').onclick=()=>toggleGoalMode();
-$('#btn-new').onclick=()=>{if(running)return;post('/new').then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';todosState=[];todosDismissed=false;renderTodoPanel();loadSessions();});};
+$('#btn-new').onclick=()=>{if(running)return;post('/new').then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';todosState=[];todosDismissed=false;renderTodoPanel();resetCumulativeStats();loadSessions();});};
 $('#btn-compact').onclick=()=>{if(!running)post('/compact');};
 $('#btn-rewind').onclick=()=>openRewindPicker();
 $('#btn-tree').onclick=()=>{post('/submit',{input:'/tree'});};
@@ -1333,7 +1333,11 @@ overlay.onclick=()=>closeSidebar();
 document.addEventListener('keydown',e=>{if(e.key==='Escape'&&sidebar.classList.contains('sidebar--open'))closeSidebar();});
 
 // ── cumulative stats ──
+// Session-scoped counters accumulated while this page is open. They reset on
+// session rotation (/new, /resume) so the stats card labeled "session cost"
+// never quietly turns into an all-sessions running total.
 let cumulativeTokens=0, cumulativeCost=0, cumulativeCacheHit=0, cumulativeCacheMiss=0;
+function resetCumulativeStats(){cumulativeTokens=0;cumulativeCost=0;cumulativeCacheHit=0;cumulativeCacheMiss=0;}
 function openStats(){
   const modal=$('#stats-modal');
   if(!modal)return;
@@ -1346,7 +1350,9 @@ function openStats(){
     const hit=cumulativeCacheHit||s.cacheHit||0, miss=cumulativeCacheMiss||s.cacheMiss||0;
     const rate=hit+miss>0?Math.round(hit/(hit+miss)*100)+'%':'0%';
     $('#stats-cache-rate').textContent=rate;
-    const cost=cumulativeCost||s.lastUsage?.cost||0;
+    // No single-request fallback here: rendering lastUsage.cost (one turn)
+    // under the session-cost label displayed one turn's spend as the session's.
+    const cost=cumulativeCost;
     $('#stats-total-cost').textContent=cost>0?fmtMoney(cost,s.lastUsage?.currency):'-';
     $('#stats-balance').textContent=s.balance?.display||'-';
     if(s.window){const pct=Math.min(100,Math.round(s.used/s.window*100));$('#stats-ctx-fill').style.width=pct+'%';$('#stats-ctx-used').textContent=fmtTok(s.used)+' tok';$('#stats-ctx-window').textContent=fmtTok(s.window)+' tok';}


### PR DESCRIPTION
## Summary

费用显示清理线的收尾（#6075 修掉了主污染源；这个 PR 打包剩余的四个口径错位），全部是"标签声称的口径 ≠ 实际显示的数"的问题：

1. **Desktop 状态栏「平均命中」口径静默切换**：实时值来自 wire 会话计数器（仅 executor 主模型），fallback 却来自 tab 遥测（全部请求来源）——同一个标签在两种口径间跳变。现在优先全来源遥测（与「会话费用」tooltip 声称的"包含主模型、子代理和辅助调用"一致），executor-only 实时值仅在新会话首轮刷新前兜底。
2. **CLI 状态行对无缓存字段的 provider 显示 "本次命中 0.00%"**：旧逻辑在 hit+miss 为 0 时用 PromptTokens 充当分母。现在缓存字段缺席时隐藏该指标；真实的全 miss（字段存在、hit 为 0）仍照常显示 0.00%。
3. **serve Web UI「总费用」跨会话累计且有单请求兜底**：计数器自页面加载起累计、`/new`/`/resume` 后继续滚，且空值时退到单请求的 `lastUsage.cost`。现在会话轮换时重置计数器、删除单请求兜底、卡片改标为「会话费用/Session Cost」。
4. **Desktop ContextPanel 会话费用兜底链**可能把单请求的 `usage.cost` 渲染在「会话费用」标签下；移除单请求分支（usage 仅贡献货币符号）。

## Verification

- New: `TestCacheTagHiddenWhenProviderReportsNoCacheFields` / `TestCacheTagShowsRealZeroHit` / `TestCacheTagRendersHitRateAndSessionAverage`（CLI）；context-panel 测试新增"单请求费用不得渲染在会话标签下"与"本地累计仍渲染"两个用例。
- `go test ./internal/cli ./internal/serve` green；frontend `tsc --noEmit` clean；`context-panel-breakdown`（40 pass）与 `statusbar-workspace`（13 pass）测试通过；serve 内联 JS 语法解析验证通过。

## Cache impact

Cache-impact: none - display-layer only; no provider request, prompt, or tool schema changes.
Cache-guard: not applicable (no cache-sensitive files); UI test suites above cover the change.
System-prompt-review: N/A

Refs #5850 (关闭这条线的最后一批), #2945.