### PR TITLE
fix(sandbox): hide Windows sandbox consoles and fail lock waits fast

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -513,8 +513,12 @@ executable as a hidden helper, and both the CLI and the desktop app embed that
 helper entry point — if enforce is requested in a build that lacks it, bash
 refuses with a clear error instead of returning empty output. A command that
 queues behind another sandboxed command on the same workspace prints a
-one-line "waiting for another sandboxed command" notice (wait cap
-`WINDOWS_SANDBOX_LOCK_MS`, default 10 minutes). If sandboxed commands fail
+one-line "waiting for another sandboxed command" notice that names the holding
+command and its PID when known. A foreground command gives up after 1 minute
+with the same holder detail (a queued turn should fail fast, not hang);
+background jobs wait up to 10 minutes, and `WINDOWS_SANDBOX_LOCK_MS` overrides
+both. Stop the named command first; raising the wait cap only makes later
+commands wait longer. If sandboxed commands fail
 only under Git-for-Windows/MSYS2 bash, try `[tools.shell] prefer =
 "powershell"` — the MSYS runtime is fragile under a low-integrity token. Run
 `reasonix doctor` to see the resolved shell, sandbox availability, and whether

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -411,8 +411,11 @@ low-integrity token 下，除配置的 root 外它仍能写入 Windows 对任何
 Windows 沙盒排障：沙盒会把 Reasonix 可执行文件自身以隐藏 helper 方式重新拉起，
 CLI 与桌面端都内置了这个 helper 入口——若某个构建缺少入口而又请求 enforce，
 bash 会以明确报错拒绝执行，而不是返回空输出。同一 workspace 上排队等待另一条
-沙盒命令时会打印一行“waiting for another sandboxed command”提示（等待上限
-`WINDOWS_SANDBOX_LOCK_MS`，默认 10 分钟）。如果只有 Git-for-Windows/MSYS2 bash
+沙盒命令时会打印一行“waiting for another sandboxed command”提示，并在可识别时
+标出持锁命令及其 PID。前台命令排队 1 分钟后即失败并给出同样的持锁信息（被挡住
+的回合应尽快报错，而不是挂住）；后台任务最多等 10 分钟，`WINDOWS_SANDBOX_LOCK_MS`
+可同时覆盖两者。应先停止提示中点名的命令；调大等待上限只会让后续命令等更久。
+如果只有 Git-for-Windows/MSYS2 bash
 下的沙盒命令失败，可试 `[tools.shell] prefer = "powershell"`——MSYS 运行时在
 low-integrity token 下较脆弱。运行 `reasonix doctor` 可查看解析到的 shell、沙盒
 可用性，以及项目 `reasonix.toml` 是否固定了 `[sandbox]`（项目文件优先级高于

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"runtime"
 	"sync/atomic"
+	"time"
 )
 
 // WindowsHelperCommand is an internal CLI subcommand used only by the Windows
@@ -83,6 +84,13 @@ type Spec struct {
 	// Path) means the tool resolves one itself; the composition root sets it from
 	// [tools.shell] so the configured choice rides along with the spec.
 	Shell Shell
+	// WindowsLockWait bounds how long a Windows-sandboxed run may queue behind
+	// another sandboxed command on the same workspace before failing with a
+	// clear error naming the holder. Zero uses the short interactive default (a
+	// blocked foreground command should fail fast, not hang its turn); the bash
+	// tool passes a longer budget for background jobs, which nobody is blocked
+	// on. Other platforms ignore it. WINDOWS_SANDBOX_LOCK_MS overrides both.
+	WindowsLockWait time.Duration
 }
 
 // Enforce reports whether the spec asks for confinement.

--- a/internal/sandbox/seatbelt_windows.go
+++ b/internal/sandbox/seatbelt_windows.go
@@ -123,5 +123,6 @@ func convertWindowsSandboxSpec(spec Spec, writable bool) winsandbox.Spec {
 		Network:         spec.Network,
 		Writable:        writable,
 		TempPrefix:      "reasonix-sandbox-",
+		LockWait:        spec.WindowsLockWait,
 	}
 }

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -27,6 +27,12 @@ import (
 
 const (
 	bashWaitDelay = 5 * time.Second
+	// windowsBackgroundSandboxLockWait is the Windows sandbox root-lock wait
+	// budget for background jobs. A detached job blocks nobody while it queues,
+	// so it keeps the patient wait; a foreground command uses the sandbox's
+	// short default and fails fast with the lock holder named instead of
+	// hanging the whole turn.
+	windowsBackgroundSandboxLockWait = 10 * time.Minute
 )
 
 var errBashTimeout = errors.New("bash foreground timeout")
@@ -161,7 +167,11 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	}
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
-	argv, wrapped := bashSandboxCommand(b.sb, sh, p.Command)
+	sbSpec := b.sb
+	if p.RunInBackground {
+		sbSpec.WindowsLockWait = windowsBackgroundSandboxLockWait
+	}
+	argv, wrapped := bashSandboxCommand(sbSpec, sh, p.Command)
 	if b.sb.Enforce() && bashSandboxEscapeSessionAllowed(ctx, p.Command, args) {
 		argv = unconfinedShellArgv(sh, p.Command)
 		wrapped = false

--- a/internal/tool/builtin/bash_sandbox_lockwait_test.go
+++ b/internal/tool/builtin/bash_sandbox_lockwait_test.go
@@ -1,0 +1,58 @@
+package builtin
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/jobs"
+	"reasonix/internal/sandbox"
+)
+
+// A foreground bash command keeps the Windows sandbox's short lock wait so a
+// queued turn fails fast with the holder named; a background job blocks nobody
+// while it queues, so it opts into the patient wait instead of dying while
+// another sandboxed command holds the workspace.
+func TestBashSandboxLockWaitForegroundVsBackground(t *testing.T) {
+	sh := sandbox.ResolveShell("", "", nil)
+	var mu sync.Mutex
+	var waits []time.Duration
+	oldCommand := bashSandboxCommand
+	bashSandboxCommand = func(spec sandbox.Spec, sh sandbox.Shell, command string) ([]string, bool) {
+		mu.Lock()
+		waits = append(waits, spec.WindowsLockWait)
+		mu.Unlock()
+		return unconfinedShellArgv(sh, command), false
+	}
+	defer func() { bashSandboxCommand = oldCommand }()
+
+	if _, err := (bash{shell: sh}).Execute(context.Background(), argsJSON(t, map[string]any{
+		"command": echoForShell(sh, "fg"),
+	})); err != nil {
+		t.Fatalf("foreground bash: %v", err)
+	}
+
+	m := jobs.NewManager(event.Discard)
+	defer m.Close()
+	ctx := jobs.WithManager(context.Background(), m)
+	if _, err := (bash{shell: sh}).Execute(ctx, argsJSON(t, map[string]any{
+		"command":           echoForShell(sh, "bg"),
+		"run_in_background": true,
+	})); err != nil {
+		t.Fatalf("background bash: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(waits) != 2 {
+		t.Fatalf("sandbox wraps = %d, want 2", len(waits))
+	}
+	if waits[0] != 0 {
+		t.Fatalf("foreground WindowsLockWait = %s, want 0 (the short interactive default)", waits[0])
+	}
+	if waits[1] != windowsBackgroundSandboxLockWait {
+		t.Fatalf("background WindowsLockWait = %s, want %s", waits[1], windowsBackgroundSandboxLockWait)
+	}
+}

--- a/internal/winsandbox/README.md
+++ b/internal/winsandbox/README.md
@@ -43,7 +43,12 @@ integrity label and restoring them afterward, so two runs touching the same root
 must not overlap. Each run takes a per-root named mutex (session-local
 namespace) for its whole lifetime; runs on disjoint roots proceed in parallel,
 runs on a shared root serialize. A crashed holder never deadlocks the next run
-because the OS marks its mutex abandoned.
+because the OS marks its mutex abandoned. The holder records its PID and a
+command preview next to each lock, so a queued run's notice and timeout error
+name what is blocking it. The queue wait defaults to 1 minute (an interactive
+command should fail fast with the holder named, not hang); a caller whose run
+nobody is blocked on — a background job — passes a longer `Spec.LockWait`
+budget.
 
 A writable run stamps a Low integrity label across its writable subtree and adds
 a deny ACE (including the current user's SID) for each forbid-read root. Both are
@@ -59,7 +64,7 @@ user out of a forbid-read path such as `~/.ssh`.
 | --- | --- |
 | `WINDOWS_SANDBOX_WAIT_MS` | Max wall-clock a sandboxed child may run before it is killed. |
 | `WINDOWS_SANDBOX_ICACLS_TIMEOUT_MS` | `icacls` timeout. Recursive (`/T`) operations default to a much larger ceiling than flat ones because they walk the whole subtree; this overrides both. |
-| `WINDOWS_SANDBOX_LOCK_MS` | Max wall-clock to wait for a busy per-root lock before failing with a clear error instead of hanging. |
+| `WINDOWS_SANDBOX_LOCK_MS` | Max wall-clock to wait for a busy per-root lock before failing with a clear error instead of hanging. Overrides both defaults (1 minute interactive, 10 minutes for background bash jobs); stop the command named in the error before raising this. |
 
 ## Network Semantics
 

--- a/internal/winsandbox/coordination_windows.go
+++ b/internal/winsandbox/coordination_windows.go
@@ -44,10 +44,11 @@ import (
 // Trade-off: a long-running sandboxed command (including a background job)
 // holds its root's lock for its whole lifetime, so other sandboxed commands on
 // the same root queue behind it. That is the price of a mutation-based sandbox;
-// the alternative is boundary corruption. The wait is bounded
-// (WINDOWS_SANDBOX_LOCK_MS) so a stuck holder surfaces as a clear error instead
-// of an indefinite hang.
-const defaultWindowsRootLockTimeout = 10 * time.Minute
+// the alternative is boundary corruption. The wait is bounded (a short
+// interactive default, a longer Spec.LockWait budget for background jobs,
+// WINDOWS_SANDBOX_LOCK_MS overriding both — see lockinfo.go) so a stuck holder
+// surfaces as a clear error naming the holding command instead of an
+// indefinite hang.
 
 // stillActiveExitCode is STILL_ACTIVE: GetExitCodeProcess reports it while a
 // process is running. Used to tell a live marker-owner from a dead one.
@@ -64,23 +65,18 @@ const stillActiveExitCode = 259
 // the mutex.
 type windowsRootLock struct {
 	handles []windows.Handle
+	names   []string
 	pinned  bool
-}
-
-func windowsRootLockTimeout() time.Duration {
-	if raw := os.Getenv("WINDOWS_SANDBOX_LOCK_MS"); raw != "" {
-		if ms, err := strconv.ParseUint(raw, 10, 63); err == nil && ms > 0 {
-			return time.Duration(ms) * time.Millisecond
-		}
-	}
-	return defaultWindowsRootLockTimeout
 }
 
 // lockWindowsRoots serializes access to every distinct root in roots. The
 // returned lock must be released once the run's grants have been cleaned up.
 // notice, when non-nil, receives a one-line message if acquisition has to
 // queue behind another run for more than windowsRootLockNoticeAfter.
-func lockWindowsRoots(roots []string, notice io.Writer) (*windowsRootLock, error) {
+// holderLabel is this run's command preview, recorded so a queued command can
+// name what is blocking it; lockWait is the caller's wait budget (see
+// windowsRootLockTimeout).
+func lockWindowsRoots(roots []string, notice io.Writer, holderLabel string, lockWait time.Duration) (*windowsRootLock, error) {
 	names := windowsRootLockNames(roots)
 	if len(names) == 0 {
 		return &windowsRootLock{}, nil
@@ -90,7 +86,7 @@ func lockWindowsRoots(roots []string, notice io.Writer) (*windowsRootLock, error
 	// mutex is owned by, and released from, the same OS thread.
 	runtime.LockOSThread()
 	lock.pinned = true
-	timeout := windowsRootLockTimeout()
+	timeout := windowsRootLockTimeout(lockWait)
 	for _, name := range names {
 		h, err := acquireNamedMutex(name, timeout, notice)
 		if err != nil {
@@ -98,6 +94,8 @@ func lockWindowsRoots(roots []string, notice io.Writer) (*windowsRootLock, error
 			return nil, err
 		}
 		lock.handles = append(lock.handles, h)
+		lock.names = append(lock.names, name)
+		writeWindowsLockHolder(name, holderLabel)
 	}
 	return lock, nil
 }
@@ -111,10 +109,14 @@ func (l *windowsRootLock) release() {
 		if h == 0 {
 			continue
 		}
+		// Drop the holder record before releasing the mutex so the next owner
+		// never races its own record against ours.
+		removeWindowsLockHolder(l.names[i])
 		_ = windows.ReleaseMutex(h)
 		_ = windows.CloseHandle(h)
 	}
 	l.handles = nil
+	l.names = nil
 	if l.pinned {
 		runtime.UnlockOSThread()
 		l.pinned = false
@@ -182,7 +184,10 @@ func acquireNamedMutex(name string, timeout time.Duration, notice io.Writer) (wi
 			waited += slice
 			if timeout > 0 && waited >= timeout {
 				_ = windows.CloseHandle(h)
-				return 0, fmt.Errorf("timed out waiting for sandbox lock %q after %s", name, timeout)
+				if holder := describeWindowsLockHolder(name); holder != "" {
+					return 0, fmt.Errorf("timed out waiting for sandbox lock %q after %s (%s; stop that command or set WINDOWS_SANDBOX_LOCK_MS higher)", name, timeout, holder)
+				}
+				return 0, fmt.Errorf("timed out waiting for sandbox lock %q after %s (stop the earlier sandboxed command or set WINDOWS_SANDBOX_LOCK_MS higher)", name, timeout)
 			}
 			if !noticed && notice != nil {
 				noticed = true
@@ -190,7 +195,11 @@ func acquireNamedMutex(name string, timeout time.Duration, notice io.Writer) (wi
 				if timeout > 0 {
 					limit = timeout.String()
 				}
-				fmt.Fprintf(notice, "windows sandbox: waiting for another sandboxed command on this workspace to finish (lock wait limit %s; set WINDOWS_SANDBOX_LOCK_MS to adjust)\n", limit)
+				if holder := describeWindowsLockHolder(name); holder != "" {
+					fmt.Fprintf(notice, "windows sandbox: waiting for another sandboxed command on this workspace to finish (%s; lock wait limit %s; stop that command or set WINDOWS_SANDBOX_LOCK_MS to adjust)\n", holder, limit)
+				} else {
+					fmt.Fprintf(notice, "windows sandbox: waiting for another sandboxed command on this workspace to finish (lock wait limit %s; stop the earlier background/long-running command or set WINDOWS_SANDBOX_LOCK_MS to adjust)\n", limit)
+				}
 			}
 		default:
 			_ = windows.CloseHandle(h)
@@ -200,6 +209,46 @@ func acquireNamedMutex(name string, timeout time.Duration, notice io.Writer) (wi
 			return 0, fmt.Errorf("wait for sandbox lock %q returned %#x", name, event)
 		}
 	}
+}
+
+// Lock-holder records live under the same user-shared %TEMP% as the residue
+// markers, one file per root digest. All operations are best-effort: the record
+// is diagnostic, so a write or read failure must never affect the run.
+func windowsLockHolderDir() string {
+	return filepath.Join(os.TempDir(), "windows-sandbox-lockholders")
+}
+
+func windowsLockHolderPath(mutexName string) string {
+	return filepath.Join(windowsLockHolderDir(), lockHolderFileName(mutexName))
+}
+
+func writeWindowsLockHolder(mutexName, label string) {
+	if err := os.MkdirAll(windowsLockHolderDir(), 0o700); err != nil {
+		return
+	}
+	rec := lockHolderRecord{pid: os.Getpid(), startUnixMS: time.Now().UnixMilli(), label: label}
+	_ = os.WriteFile(windowsLockHolderPath(mutexName), []byte(formatLockHolderRecord(rec)), 0o600)
+}
+
+func removeWindowsLockHolder(mutexName string) {
+	_ = os.Remove(windowsLockHolderPath(mutexName))
+}
+
+// describeWindowsLockHolder names the run currently holding mutexName, or ""
+// when no trustworthy record exists. A record whose PID is dead is a crash
+// leftover (the OS already released the abandoned mutex); it is skipped, not
+// deleted, because removal here could race the file the next live holder just
+// wrote — the next acquire overwrites it anyway.
+func describeWindowsLockHolder(mutexName string) string {
+	data, err := os.ReadFile(windowsLockHolderPath(mutexName))
+	if err != nil {
+		return ""
+	}
+	rec, ok := parseLockHolderRecord(string(data))
+	if !ok || !windowsProcessAlive(strconv.Itoa(rec.pid)) {
+		return ""
+	}
+	return describeLockHolder(rec, time.Now())
 }
 
 // windowsMutatedRoots is the set of paths a run edits ACLs on: its writable

--- a/internal/winsandbox/coordination_windows_test.go
+++ b/internal/winsandbox/coordination_windows_test.go
@@ -38,7 +38,7 @@ func TestWindowsRootLockQueueEmitsNotice(t *testing.T) {
 	// Long enough for the contender to sit through one full silent slice
 	// (windowsRootLockNoticeAfter) and emit the queue notice before timing out.
 	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "5000")
-	held, err := lockWindowsRoots([]string{root}, nil)
+	held, err := lockWindowsRoots([]string{root}, nil, "", 0)
 	if err != nil {
 		t.Fatalf("hold lock: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestWindowsRootLockQueueEmitsNotice(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		lock, err := lockWindowsRoots([]string{root}, &notice)
+		lock, err := lockWindowsRoots([]string{root}, &notice, "", 0)
 		if err == nil {
 			lock.release()
 		}
@@ -68,6 +68,56 @@ func TestWindowsRootLockQueueEmitsNotice(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatal("contender never finished after release")
+	}
+}
+
+// A held root lock records its holder (pid + command label); a queued
+// contender's notice names that command so the user knows what to stop, and
+// release removes the record again.
+func TestWindowsRootLockHolderRecordedAndCleared(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "5000")
+	held, err := lockWindowsRoots([]string{root}, nil, "npm run dev", 0)
+	if err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	name := windowsRootLockNames([]string{root})[0]
+	data, err := os.ReadFile(windowsLockHolderPath(name))
+	if err != nil {
+		t.Fatalf("holder record not written: %v", err)
+	}
+	rec, ok := parseLockHolderRecord(string(data))
+	if !ok || rec.pid != os.Getpid() || rec.label != "npm run dev" {
+		t.Fatalf("holder record = %+v ok=%v, want this process with label", rec, ok)
+	}
+
+	var notice lockNoticeBuffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lock, err := lockWindowsRoots([]string{root}, &notice, "", 0)
+		if err == nil {
+			lock.release()
+		}
+	}()
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(notice.String(), `held by "npm run dev"`) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !strings.Contains(notice.String(), `held by "npm run dev"`) {
+		t.Fatalf("queued notice never named the holder; got %q", notice.String())
+	}
+	held.release()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("contender never finished after release")
+	}
+	if pathExists(windowsLockHolderPath(name)) {
+		t.Fatal("holder record not removed after release")
 	}
 }
 
@@ -103,14 +153,14 @@ func TestWindowsRootLockSerializesSameRoot(t *testing.T) {
 	// the first releases. Use a short timeout so a regression fails fast.
 	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "2000")
 
-	first, err := lockWindowsRoots([]string{root}, nil)
+	first, err := lockWindowsRoots([]string{root}, nil, "", 0)
 	if err != nil {
 		t.Fatalf("first lock: %v", err)
 	}
 
 	acquired := make(chan *windowsRootLock, 1)
 	go func() {
-		second, err := lockWindowsRoots([]string{root}, nil)
+		second, err := lockWindowsRoots([]string{root}, nil, "", 0)
 		if err != nil {
 			acquired <- nil
 			return
@@ -140,7 +190,7 @@ func TestWindowsRootLockSerializesSameRoot(t *testing.T) {
 func TestWindowsRootLockTimesOutWhenHeld(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "300")
-	held, err := lockWindowsRoots([]string{root}, nil)
+	held, err := lockWindowsRoots([]string{root}, nil, "", 0)
 	if err != nil {
 		t.Fatalf("hold lock: %v", err)
 	}
@@ -157,7 +207,7 @@ func TestWindowsRootLockTimesOutWhenHeld(t *testing.T) {
 	done := make(chan result, 1)
 	go func() {
 		start := time.Now()
-		lock, err := lockWindowsRoots([]string{root}, nil)
+		lock, err := lockWindowsRoots([]string{root}, nil, "", 0)
 		if lock != nil {
 			lock.release()
 		}
@@ -186,7 +236,7 @@ func TestWindowsRootLockMultiRootNoSelfDeadlock(t *testing.T) {
 	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "2000")
 	// Acquiring multiple roots in one call must not deadlock regardless of the
 	// order the caller passes them, because names are sorted internally.
-	lock, err := lockWindowsRoots([]string{b, a, b}, nil)
+	lock, err := lockWindowsRoots([]string{b, a, b}, nil, "", 0)
 	if err != nil {
 		t.Fatalf("multi-root lock: %v", err)
 	}

--- a/internal/winsandbox/lockinfo.go
+++ b/internal/winsandbox/lockinfo.go
@@ -1,0 +1,126 @@
+package winsandbox
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// The per-root lock serializes whole sandboxed runs (see the package comment in
+// coordination_windows.go). An interactive command queued behind a long-running
+// holder should fail fast with the holder named rather than hang its turn, so
+// the default wait is short; a caller whose run nobody is blocked on (a
+// background job) passes a longer budget via Spec.LockWait.
+const defaultWindowsRootLockTimeout = time.Minute
+
+// windowsRootLockTimeout resolves one run's lock wait budget: the explicit
+// WINDOWS_SANDBOX_LOCK_MS override wins, then the caller's Spec.LockWait, then
+// the short interactive default.
+func windowsRootLockTimeout(specWait time.Duration) time.Duration {
+	if raw := os.Getenv("WINDOWS_SANDBOX_LOCK_MS"); raw != "" {
+		if ms, err := strconv.ParseUint(raw, 10, 63); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	if specWait > 0 {
+		return specWait
+	}
+	return defaultWindowsRootLockTimeout
+}
+
+// A lock-holder record names the run currently holding one root lock so a
+// queued command can tell the user what to stop. It is diagnostic only: written
+// best-effort after the mutex is acquired, removed before it is released, and
+// validated against a live PID on read, so a stale file left by a crash (the OS
+// releases the abandoned mutex itself) is ignored and overwritten by the next
+// holder of the same root. One line: "<pid>\t<start-unix-ms>\t<label>" — tabs
+// separate the fields because the label is sanitized to never contain one.
+type lockHolderRecord struct {
+	pid         int
+	startUnixMS int64
+	label       string
+}
+
+func formatLockHolderRecord(rec lockHolderRecord) string {
+	return strconv.Itoa(rec.pid) + "\t" + strconv.FormatInt(rec.startUnixMS, 10) + "\t" + rec.label + "\n"
+}
+
+func parseLockHolderRecord(data string) (lockHolderRecord, bool) {
+	line, _, _ := strings.Cut(data, "\n")
+	line = strings.TrimRight(line, "\r")
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) != 3 {
+		return lockHolderRecord{}, false
+	}
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil || pid <= 0 {
+		return lockHolderRecord{}, false
+	}
+	start, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || start <= 0 {
+		return lockHolderRecord{}, false
+	}
+	return lockHolderRecord{pid: pid, startUnixMS: start, label: parts[2]}, true
+}
+
+// lockHolderLabelMaxRunes keeps the record one readable error-message line
+// while leaving room for the shell's absolute path ahead of the user command.
+const lockHolderLabelMaxRunes = 120
+
+// lockHolderLabel renders argv as a one-line command preview for the holder
+// record: control characters (including the record's tab separator) become
+// spaces and long commands are truncated.
+func lockHolderLabel(argv []string) string {
+	label := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, strings.Join(argv, " "))
+	label = strings.TrimSpace(label)
+	if r := []rune(label); len(r) > lockHolderLabelMaxRunes {
+		return string(r[:lockHolderLabelMaxRunes]) + "…"
+	}
+	return label
+}
+
+// describeLockHolder renders a record for the queue notice / timeout error,
+// e.g. `held by "npm run dev", pid 1234, running 25m`.
+func describeLockHolder(rec lockHolderRecord, now time.Time) string {
+	running := lockHolderRunningFor(now.Sub(time.UnixMilli(rec.startUnixMS)))
+	if rec.label == "" {
+		return fmt.Sprintf("held by pid %d, running %s", rec.pid, running)
+	}
+	return fmt.Sprintf("held by %q, pid %d, running %s", rec.label, rec.pid, running)
+}
+
+// lockHolderRunningFor formats an elapsed runtime at the precision a human
+// needs to pick what to stop ("25m", not "25m3.021s"). Clock skew between the
+// holder's and the waiter's reads clamps to 0s instead of going negative.
+func lockHolderRunningFor(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		if d < 0 {
+			d = 0
+		}
+		return strconv.Itoa(int(d.Seconds())) + "s"
+	case d < time.Hour:
+		return strconv.Itoa(int(d.Minutes())) + "m"
+	default:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
+	}
+}
+
+// lockHolderFileName maps a root's mutex name (`Local\windows-sandbox.<hex>`)
+// to its holder file, keyed by the same root digest so holder and mutex can
+// never pair up differently.
+func lockHolderFileName(mutexName string) string {
+	digest := mutexName
+	if i := strings.LastIndexByte(digest, '.'); i >= 0 {
+		digest = digest[i+1:]
+	}
+	return digest + ".txt"
+}

--- a/internal/winsandbox/lockinfo_test.go
+++ b/internal/winsandbox/lockinfo_test.go
@@ -1,0 +1,118 @@
+package winsandbox
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWindowsRootLockTimeoutPrecedence(t *testing.T) {
+	// The explicit env override wins, then the caller's per-run budget, then the
+	// short interactive default.
+	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "")
+	if got := windowsRootLockTimeout(0); got != defaultWindowsRootLockTimeout {
+		t.Fatalf("default = %s, want %s", got, defaultWindowsRootLockTimeout)
+	}
+	if got := windowsRootLockTimeout(10 * time.Minute); got != 10*time.Minute {
+		t.Fatalf("spec budget = %s, want 10m", got)
+	}
+	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "1234")
+	if got := windowsRootLockTimeout(10 * time.Minute); got != 1234*time.Millisecond {
+		t.Fatalf("env override = %s, want 1.234s", got)
+	}
+	// A malformed override falls back instead of hanging or failing.
+	t.Setenv("WINDOWS_SANDBOX_LOCK_MS", "not-a-number")
+	if got := windowsRootLockTimeout(0); got != defaultWindowsRootLockTimeout {
+		t.Fatalf("malformed env = %s, want %s", got, defaultWindowsRootLockTimeout)
+	}
+}
+
+func TestLockHolderRecordRoundTrip(t *testing.T) {
+	rec := lockHolderRecord{pid: 1234, startUnixMS: 1_700_000_000_000, label: `npm run dev`}
+	got, ok := parseLockHolderRecord(formatLockHolderRecord(rec))
+	if !ok || got != rec {
+		t.Fatalf("round trip = %+v ok=%v, want %+v", got, ok, rec)
+	}
+	// A label containing spaces survives; tabs never occur (sanitized on write).
+	rec.label = "cmd /c echo ok"
+	if got, ok := parseLockHolderRecord(formatLockHolderRecord(rec)); !ok || got != rec {
+		t.Fatalf("spaced label round trip = %+v ok=%v", got, ok)
+	}
+}
+
+func TestLockHolderRecordRejectsMalformed(t *testing.T) {
+	for _, data := range []string{
+		"",
+		"garbage",
+		"12\t34",         // missing label field
+		"0\t123\tcmd",    // pid 0 is never a real holder
+		"-1\t123\tcmd",   // negative pid
+		"nope\t123\tcmd", // non-numeric pid
+		"12\tnope\tcmd",  // non-numeric start
+		"12\t0\tcmd",     // zero start time
+		"12 34 cmd",      // wrong separator
+	} {
+		if rec, ok := parseLockHolderRecord(data); ok {
+			t.Fatalf("parse(%q) = %+v, want rejection", data, rec)
+		}
+	}
+	// Only the first line counts; a trailing partial write cannot corrupt it.
+	rec, ok := parseLockHolderRecord("12\t34\tcmd\ntrailing garbage")
+	if !ok || rec.label != "cmd" {
+		t.Fatalf("multi-line parse = %+v ok=%v, want first line only", rec, ok)
+	}
+}
+
+func TestLockHolderLabelSanitizesAndTruncates(t *testing.T) {
+	got := lockHolderLabel([]string{"pwsh", "-Command", "npm\trun\ndev"})
+	if strings.ContainsAny(got, "\t\n\r") {
+		t.Fatalf("label %q still contains control characters", got)
+	}
+	if got != "pwsh -Command npm run dev" {
+		t.Fatalf("label = %q", got)
+	}
+	long := lockHolderLabel([]string{strings.Repeat("x", 500)})
+	if r := []rune(long); len(r) > lockHolderLabelMaxRunes+1 {
+		t.Fatalf("label not truncated: %d runes", len(r))
+	}
+	if !strings.HasSuffix(long, "…") {
+		t.Fatalf("truncated label %q missing ellipsis", long)
+	}
+}
+
+func TestDescribeLockHolder(t *testing.T) {
+	start := time.UnixMilli(1_700_000_000_000)
+	rec := lockHolderRecord{pid: 1234, startUnixMS: start.UnixMilli(), label: "npm run dev"}
+	if got := describeLockHolder(rec, start.Add(25*time.Minute)); got != `held by "npm run dev", pid 1234, running 25m` {
+		t.Fatalf("describe = %q", got)
+	}
+	rec.label = ""
+	if got := describeLockHolder(rec, start.Add(3*time.Second)); got != "held by pid 1234, running 3s" {
+		t.Fatalf("describe without label = %q", got)
+	}
+}
+
+func TestLockHolderRunningFor(t *testing.T) {
+	for _, tc := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{-5 * time.Second, "0s"}, // clock skew clamps, never negative
+		{12 * time.Second, "12s"},
+		{90 * time.Second, "1m"},
+		{25 * time.Minute, "25m"},
+		{2*time.Hour + 5*time.Minute, "2h05m"},
+	} {
+		if got := lockHolderRunningFor(tc.d); got != tc.want {
+			t.Fatalf("runningFor(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestLockHolderFileNameMatchesMutexDigest(t *testing.T) {
+	// The holder file is keyed by the same root digest as the mutex name, so the
+	// two can never pair up differently.
+	if got := lockHolderFileName(`Local\windows-sandbox.deadbeef00112233`); got != "deadbeef00112233.txt" {
+		t.Fatalf("holder file = %q, want digest-keyed name", got)
+	}
+}

--- a/internal/winsandbox/sandbox.go
+++ b/internal/winsandbox/sandbox.go
@@ -3,6 +3,7 @@ package winsandbox
 import (
 	"errors"
 	"os"
+	"time"
 )
 
 // ErrUnsupported is returned when the package is used on a non-Windows host or
@@ -23,6 +24,12 @@ type Spec struct {
 	Network         bool
 	Writable        bool
 	TempPrefix      string
+	// LockWait bounds how long this run may queue behind another sandboxed
+	// command holding the same per-root lock before failing with a clear
+	// error. Zero uses the short interactive default; callers whose run
+	// nobody is blocked on (background jobs) pass a longer budget.
+	// WINDOWS_SANDBOX_LOCK_MS overrides both.
+	LockWait time.Duration
 }
 
 // RunOptions carries process IO and environment overrides.

--- a/internal/winsandbox/sandbox_windows.go
+++ b/internal/winsandbox/sandbox_windows.go
@@ -20,12 +20,15 @@ import (
 	"time"
 	"unsafe"
 
+	"reasonix/internal/proc"
+
 	"golang.org/x/sys/windows"
 )
 
 const (
 	procThreadAttributeSecurityCapabilities = 0x00020009
 	startupFlagsUseStdHandles               = windows.STARTF_USESTDHANDLES
+	startupFlagsHiddenWindow                = startupFlagsUseStdHandles | windows.STARTF_USESHOWWINDOW
 	hresultAlreadyExists                    = 0x800700b7
 	allApplicationPackagesSID               = "S-1-15-2-1"
 	allRestrictedApplicationPackagesSID     = "S-1-15-2-2"
@@ -83,7 +86,7 @@ func runWindowsSandboxed(spec Spec, argv []string, opts RunOptions) (int, error)
 	}
 	// Serialize against concurrent runs touching the same roots and clear any
 	// deny residue left by a crashed run before we mutate ACLs.
-	lock, err := lockWindowsRoots(windowsMutatedRootsForRun(spec, argv[0]), lockWaitNotice(opts))
+	lock, err := lockWindowsRoots(windowsMutatedRootsForRun(spec, argv[0]), lockWaitNotice(opts), lockHolderLabel(argv), spec.LockWait)
 	if err != nil {
 		return 0, err
 	}
@@ -163,7 +166,7 @@ func runWindowsRestrictedSandboxed(spec Spec, argv []string, opts RunOptions) (i
 	}
 	// Serialize against concurrent runs touching the same roots and clear any
 	// deny residue left by a crashed run before we mutate ACLs.
-	lock, err := lockWindowsRoots(windowsMutatedRootsForRun(spec, argv[0]), lockWaitNotice(opts))
+	lock, err := lockWindowsRoots(windowsMutatedRootsForRun(spec, argv[0]), lockWaitNotice(opts), lockHolderLabel(argv), spec.LockWait)
 	if err != nil {
 		return 0, err
 	}
@@ -415,15 +418,9 @@ func startRestrictedTokenProcess(token windows.Token, argv []string, env []strin
 		}
 	}
 
-	si := windows.StartupInfoEx{}
-	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
-	si.StartupInfo.Flags = startupFlagsUseStdHandles
-	si.StartupInfo.StdInput = handles[0]
-	si.StartupInfo.StdOutput = handles[1]
-	si.StartupInfo.StdErr = handles[2]
-	si.ProcThreadAttributeList = attrList.List()
+	si := windowsSandboxStartupInfo(handles, attrList)
 
-	flags := uint32(windows.CREATE_UNICODE_ENVIRONMENT | windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_SUSPENDED)
+	flags := windowsSandboxProcessCreationFlags()
 	if err := windows.CreateProcessAsUser(token, appName, cmdLine, nil, nil, true, flags, envp, cwd, &si.StartupInfo, &pi); err != nil {
 		return pi, fmt.Errorf("create restricted process: %w", err)
 	}
@@ -487,19 +484,34 @@ func startAppContainerProcess(ac *appContainerLaunch, argv []string, env []strin
 		}
 	}
 
-	si := windows.StartupInfoEx{}
-	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
-	si.StartupInfo.Flags = startupFlagsUseStdHandles
-	si.StartupInfo.StdInput = handles[0]
-	si.StartupInfo.StdOutput = handles[1]
-	si.StartupInfo.StdErr = handles[2]
-	si.ProcThreadAttributeList = attrList.List()
+	si := windowsSandboxStartupInfo(handles, attrList)
 
-	flags := uint32(windows.CREATE_UNICODE_ENVIRONMENT | windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_SUSPENDED)
+	flags := windowsSandboxProcessCreationFlags()
 	if err := windows.CreateProcess(appName, cmdLine, nil, nil, true, flags, envp, cwd, &si.StartupInfo, &pi); err != nil {
 		return pi, fmt.Errorf("create appcontainer process: %w", err)
 	}
 	return pi, nil
+}
+
+func windowsSandboxStartupInfo(handles [3]windows.Handle, attrList *windows.ProcThreadAttributeListContainer) windows.StartupInfoEx {
+	si := windows.StartupInfoEx{}
+	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
+	si.StartupInfo.Flags = startupFlagsHiddenWindow
+	si.StartupInfo.ShowWindow = uint16(windows.SW_HIDE)
+	si.StartupInfo.StdInput = handles[0]
+	si.StartupInfo.StdOutput = handles[1]
+	si.StartupInfo.StdErr = handles[2]
+	if attrList != nil {
+		si.ProcThreadAttributeList = attrList.List()
+	}
+	return si
+}
+
+func windowsSandboxProcessCreationFlags() uint32 {
+	return uint32(windows.CREATE_UNICODE_ENVIRONMENT |
+		windows.EXTENDED_STARTUPINFO_PRESENT |
+		windows.CREATE_SUSPENDED |
+		windows.CREATE_NO_WINDOW)
 }
 
 func resolveWindowsExecutable(name string) (string, error) {
@@ -1037,7 +1049,7 @@ func icacls(root string, args ...string) error {
 	all := append([]string{root}, args...)
 	ctx, cancel := context.WithTimeout(context.Background(), icaclsTimeoutForArgs(args))
 	defer cancel()
-	cmd := exec.CommandContext(ctx, systemRootTool("icacls.exe"), all...)
+	cmd := hiddenWindowsSystemCommandContext(ctx, "icacls.exe", all...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -1054,7 +1066,7 @@ func icacls(root string, args ...string) error {
 		return nil
 	case <-ctx.Done():
 		if cmd.Process != nil {
-			_ = exec.Command(systemRootTool("taskkill.exe"), "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+			_ = hiddenWindowsSystemCommand("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
 			_ = cmd.Process.Kill()
 		}
 		select {
@@ -1066,6 +1078,18 @@ func icacls(root string, args ...string) error {
 		}
 		return fmt.Errorf("icacls %q %s: timed out", root, strings.Join(args, " "))
 	}
+}
+
+func hiddenWindowsSystemCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, systemRootTool(name), args...)
+	proc.HideWindow(cmd)
+	return cmd
+}
+
+func hiddenWindowsSystemCommand(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(systemRootTool(name), args...)
+	proc.HideWindow(cmd)
+	return cmd
 }
 
 func setLowIntegrity(root string) error {

--- a/internal/winsandbox/sandbox_windows_test.go
+++ b/internal/winsandbox/sandbox_windows_test.go
@@ -3,6 +3,7 @@
 package winsandbox
 
 import (
+	"context"
 	"net"
 	"os"
 	"os/exec"
@@ -78,6 +79,59 @@ func TestWindowsUniqueNonZeroHandles(t *testing.T) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("handles = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestWindowsSandboxProcessCreationFlagsHideConsole(t *testing.T) {
+	flags := windowsSandboxProcessCreationFlags()
+	for _, want := range []uint32{
+		windows.CREATE_UNICODE_ENVIRONMENT,
+		windows.EXTENDED_STARTUPINFO_PRESENT,
+		windows.CREATE_SUSPENDED,
+		windows.CREATE_NO_WINDOW,
+	} {
+		if flags&want == 0 {
+			t.Fatalf("process creation flags %#x missing %#x", flags, want)
+		}
+	}
+}
+
+func TestWindowsSandboxStartupInfoHidesWindowAndKeepsStdHandles(t *testing.T) {
+	handles := [3]windows.Handle{11, 12, 13}
+	si := windowsSandboxStartupInfo(handles, nil)
+	if si.StartupInfo.Cb == 0 {
+		t.Fatal("startup info size was not initialized")
+	}
+	if si.StartupInfo.Flags&windows.STARTF_USESTDHANDLES == 0 {
+		t.Fatalf("startup flags %#x missing STARTF_USESTDHANDLES", si.StartupInfo.Flags)
+	}
+	if si.StartupInfo.Flags&windows.STARTF_USESHOWWINDOW == 0 {
+		t.Fatalf("startup flags %#x missing STARTF_USESHOWWINDOW", si.StartupInfo.Flags)
+	}
+	if si.StartupInfo.ShowWindow != windows.SW_HIDE {
+		t.Fatalf("ShowWindow = %d, want SW_HIDE", si.StartupInfo.ShowWindow)
+	}
+	if si.StartupInfo.StdInput != handles[0] || si.StartupInfo.StdOutput != handles[1] || si.StartupInfo.StdErr != handles[2] {
+		t.Fatalf("std handles = (%v,%v,%v), want %v", si.StartupInfo.StdInput, si.StartupInfo.StdOutput, si.StartupInfo.StdErr, handles)
+	}
+}
+
+func TestWindowsSandboxSystemCommandsAreHidden(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for _, cmd := range []*exec.Cmd{
+		hiddenWindowsSystemCommandContext(ctx, "icacls.exe", `C:\work`, "/C"),
+		hiddenWindowsSystemCommand("taskkill.exe", "/?"),
+	} {
+		if cmd.SysProcAttr == nil {
+			t.Fatal("system command SysProcAttr is nil")
+		}
+		if !cmd.SysProcAttr.HideWindow {
+			t.Fatal("system command did not set HideWindow")
+		}
+		if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+			t.Fatalf("system command creation flags %#x missing CREATE_NO_WINDOW", cmd.SysProcAttr.CreationFlags)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Users on the new native Windows sandbox path (1.17.x) reported two issues (with screenshots):

1. Black console windows flashing / lingering over the desktop — one titled `npm run dev`, one titled `C:\Windows\System32\icacls...`.
2. `windows sandbox: waiting for another sandboxed command on this workspace to finish (lock wait limit 10m0s; set WINDOWS_SANDBOX_LOCK_MS to adjust)` — a long-running dev server holds the per-root lock for its whole lifetime, so every later sandboxed command silently queues for 10 minutes and then fails with a message that suggests the wrong fix (raising the cap only makes later commands wait longer).

## Changes

**Hide sandbox child consoles.** The Win32 `CreateProcess*` launch paths (restricted token + AppContainer) and the internal `icacls.exe`/`taskkill.exe` invocations now start with `CREATE_NO_WINDOW` + `STARTF_USESHOWWINDOW`/`SW_HIDE`, matching what `proc.HideWindow` already does for ordinary `exec.Cmd`. Startup-info and creation-flag construction is factored into shared helpers so the two launch paths cannot drift.

**Name the lock holder.** Each acquired root lock records its holder (pid, start time, command preview) in a best-effort sidecar file keyed by the same root digest as the mutex. The 2-second queue notice and the timeout error now say e.g. `held by "npm run dev", pid 1234, running 25m; stop that command or set WINDOWS_SANDBOX_LOCK_MS to adjust`. Records are validated against a live PID on read, so crash leftovers are ignored (the OS already releases the abandoned mutex).

**Fail fast in the foreground.** The interactive lock-wait default drops from 10 minutes to 1 minute — a blocked foreground command now surfaces the holder-named error quickly and flows into the existing sandbox escape-approval path instead of hanging the turn. Background bash jobs (which nobody is blocked on) keep the patient 10-minute wait via a new `Spec.LockWait` budget threaded through the helper payload. `WINDOWS_SANDBOX_LOCK_MS` still overrides both. The security model is unchanged: no automatic escape, whole-run serialization stays.

Docs (EN/zh-CN guides, winsandbox README) updated to match.

## Tests

- New portable tests for holder-record round-trip/rejection, label sanitizing, holder description, and wait-budget precedence (run on any host).
- New Windows-only tests: hidden-window creation flags/startup info, hidden system commands, holder record lifecycle + holder-named queue notice.
- `bash` tool test asserting foreground uses the short default and `run_in_background` opts into the 10-minute budget.

## Verification

- `go test ./internal/winsandbox ./internal/sandbox ./internal/tool/builtin ./internal/proc` ✅
- `GOOS=windows GOARCH=amd64 go test -c` for winsandbox / sandbox / builtin ✅
- `go build ./...`, `cd desktop && go test .`, `git diff --check` ✅
- Windows-only tests are compile-verified here (macOS dev host); they need a Windows CI run, and the black-window fix should be eyeballed once on a Windows desktop build.

Cache-impact: none - WindowsLockWait only changes internal Windows bash execution timing; tool schema/order and provider-visible prompt bytes are unchanged.
Cache-guard: go test ./internal/tool/builtin -run TestBashSandboxLockWaitForegroundVsBackground