### PR TITLE
feat(desktop): fold workspace code selection into chat as expandable badges

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1038,6 +1038,11 @@ export default function App() {
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);
   const [composerInsertRequest, setComposerInsertRequest] = useState<ComposerInsertRequest | null>(null);
   const [planRevisionInsertRequest, setPlanRevisionInsertRequest] = useState<ComposerInsertRequest | null>(null);
+  // Monotonic id for composer insert requests. A wall-clock id (Date.now())
+  // collides when two snippets are inserted within the same millisecond, and
+  // the Composer's consumedInsertIdRef guard would then drop the second one —
+  // so rapid "add selection to chat" bursts must never share an id.
+  const insertRequestIdRef = useRef(0);
   const [workspaceInsertTarget, setWorkspaceInsertTarget] = useState<WorkspaceInsertTarget>("composer");
   const transientOverlayDismissSignal = useOverlayStore((s) => s.transientOverlayDismissSignal);
   const setTransientOverlayDismissSignal = useOverlayStore((s) => s.setTransientOverlayDismissSignal);
@@ -2143,10 +2148,19 @@ export default function App() {
 
   const addWorkspaceTextToComposer = useCallback((text: string) => {
     if (workspaceInsertTarget === "planRevision" && state.approval?.tool === "exit_plan_mode") {
-      setPlanRevisionInsertRequest({ id: Date.now(), text });
+      setPlanRevisionInsertRequest({ id: (insertRequestIdRef.current += 1), text });
       return;
     }
-    setComposerInsertRequest({ id: Date.now(), text });
+    setComposerInsertRequest({ id: (insertRequestIdRef.current += 1), text });
+  }, [state.approval?.tool, workspaceInsertTarget]);
+
+  const addWorkspaceCodeToComposer = useCallback((path: string, code: string) => {
+    const block = { path, text: code };
+    if (workspaceInsertTarget === "planRevision" && state.approval?.tool === "exit_plan_mode") {
+      setPlanRevisionInsertRequest({ id: (insertRequestIdRef.current += 1), text: "", block });
+      return;
+    }
+    setComposerInsertRequest({ id: (insertRequestIdRef.current += 1), text: "", block });
   }, [state.approval?.tool, workspaceInsertTarget]);
 
   // Coalesce tab-bar switches through the same last-click-wins scheduler that
@@ -3706,6 +3720,7 @@ export default function App() {
                   }}
                   onPreviewModeChange={handleWorkspacePreviewModeChange}
                   onAddToChat={addWorkspaceTextToComposer}
+                  onAddCodeToChat={addWorkspaceCodeToComposer}
                   onRequestPanelWidth={ensureWorkspacePanelWidth}
                   onFileTreeRefresh={refreshComposerFileRefs}
                   refreshKey={dockRefreshKey}

--- a/desktop/frontend/src/__tests__/message-pasted-blocks.test.ts
+++ b/desktop/frontend/src/__tests__/message-pasted-blocks.test.ts
@@ -25,6 +25,9 @@ for (const [label, name] of [
   ["[已粘贴文本 #2 · 31 行]", "Simplified Chinese"],
   ["[已貼上文字 #2 · 31 行]", "Traditional Chinese"],
   ["[Pasted text #2 · 31 lines]", "English"],
+  ["⟦选中 #3⟧", "Simplified Chinese selection"],
+  ["⟦選取 #3⟧", "Traditional Chinese selection"],
+  ["⟦Selection #3⟧", "English selection"],
 ] as const) {
   eq(
     parsePastedBlocks(`before\n${label}\nafter`, wrapped(label, "line 1\nline 2")),

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -63,6 +63,9 @@ const FILE_REF_SEARCH_CACHE_TTL_MS = 5000;
 type PastedBlock = {
   label: string;
   text: string;
+  // Optional descriptive text for the badge card (e.g. "foo.go · 12 行"). When
+  // set, the inline token (`label`) stays short/compact while the card shows this.
+  display?: string;
 };
 
 type PendingGuidance = {
@@ -1012,6 +1015,34 @@ export function Composer({
     });
   };
 
+  const insertCodeBlockAtCaret = (path: string, code: string) => {
+    const id = nextPasteId.current++;
+    const label = t("composer.selectionLabel", { id });
+    const display = t("composer.selectionBadge", { name: baseName(path), lines: lineCount(code) });
+    const content = `From \`${path}\`:\n\n${code}`;
+    const block: PastedBlock = { label, text: content, display };
+    const ta = taRef.current;
+    const start = ta ? (ta.selectionStart ?? text.length) : Math.min(lastSelectionRef.current.start, text.length);
+    const end = ta ? (ta.selectionEnd ?? start) : Math.min(lastSelectionRef.current.end, text.length);
+    const before = text.slice(0, start);
+    const after = text.slice(end);
+    const leading = before.length === 0 || before.endsWith(" ") || before.endsWith("\n") ? "" : " ";
+    const trailing = after.length === 0 || after.startsWith(" ") || after.startsWith("\n") ? "" : " ";
+    const inserted = leading + label + trailing;
+    const next = before + inserted + after;
+    const pos = before.length + inserted.length;
+    pastedBlocksRef.current = [...pastedBlocksRef.current, block];
+    setPastedBlocks((prev) => [...prev, block]);
+    setText(next);
+    requestAnimationFrame(() => {
+      const node = taRef.current;
+      if (!node) return;
+      node.focus();
+      node.selectionStart = node.selectionEnd = pos;
+      lastSelectionRef.current = { start: pos, end: pos };
+    });
+  };
+
   const replaceComposerText = (next: string) => {
     clearAttachments();
     setWorkspaceRefs([]);
@@ -1036,6 +1067,10 @@ export function Composer({
   useEffect(() => {
     if (!insertRequest || insertRequest.id === consumedInsertIdRef.current) return;
     consumedInsertIdRef.current = insertRequest.id;
+    if (insertRequest.block) {
+      insertCodeBlockAtCaret(insertRequest.block.path, insertRequest.block.text);
+      return;
+    }
     if (insertRequest.mode === "replace") {
       replaceComposerText(insertRequest.text);
       return;
@@ -2458,7 +2493,7 @@ export function Composer({
               <div className="composer__pasted-block" key={block.label}>
                 <div className="composer__pasted-head">
                   <FileText size={15} />
-                  <span className="composer__pasted-label">{block.label}</span>
+                  <span className="composer__pasted-label">{block.display ?? block.label}</span>
                   <div className="composer__pasted-actions">
                     <Tooltip label={t(open ? "composer.pastedHidePreview" : "composer.pastedShowPreview")}>
                       <button type="button" onClick={() => togglePastedPreview(block.label)}>

--- a/desktop/frontend/src/components/FloatingMenu.tsx
+++ b/desktop/frontend/src/components/FloatingMenu.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useMemo } from "react";
+import { createPortal } from "react-dom";
 
 const FLOATING_MENU_MARGIN = 8;
 
@@ -36,7 +37,12 @@ export function FloatingMenu({
   children: ReactNode;
 }) {
   const pos = useMemo(() => clampFloatingMenuPosition(x, y, width, estimatedHeight), [estimatedHeight, width, x, y]);
-  return (
+  if (typeof document === "undefined") return null;
+  // Portal to <body>: the menu is position:fixed, but a transformed ancestor
+  // (e.g. .workspace-preview carries a residual GSAP transform) would otherwise
+  // become its containing block and push the fixed coordinates off-screen.
+  // Rendering at the body root keeps fixed positioning relative to the viewport.
+  return createPortal(
     <div
       className={`floating-menu${className ? ` ${className}` : ""}`}
       style={{ left: pos.left, top: pos.top }}
@@ -47,7 +53,8 @@ export function FloatingMenu({
       onClick={(e) => e.stopPropagation()}
     >
       {children}
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -87,7 +87,11 @@ type PastedBlockInfo = {
   content: string;
 };
 
-const PASTE_LABEL_RE = /\[(?:已粘贴文本|已貼上文字|Pasted text) #\d+ · \d+ (?:行|lines)\]/g;
+const PASTE_LABEL_RE = /\[(?:已粘贴文本|已貼上文字|Pasted text) #\d+ · \d+ (?:行|lines)\]|⟦(?:选中|選取|Selection) #\d+⟧/g;
+// Selection tokens carry only an id; the "selected" wording is localized, so it
+// gets re-rendered in the active locale for display (the baked token stays fixed
+// in the submitted text for content matching).
+const SELECTION_LABEL_RE = /^⟦(?:选中|選取|Selection) #(\d+)⟧$/;
 
 export function parsePastedBlocks(text: string, submitText?: string): PastedBlockInfo[] {
   const labels = text.match(PASTE_LABEL_RE);
@@ -447,12 +451,14 @@ export function UserMessage({
                 return seg.content ? <div className="msg__text" key={`s${i}`}>{seg.content}</div> : null;
               }
               const expanded = Boolean(expandedPasteLabels[seg.block.label]);
+              const selMatch = SELECTION_LABEL_RE.exec(seg.block.label);
+              const shownLabel = selMatch ? t("composer.selectionLabel", { id: Number(selMatch[1]) }) : seg.block.label;
               return (
                 <div className="msg-pasted" key={seg.block.label}>
                   <div className="msg-pasted-block">
                     <div className="msg-pasted-head">
                       <FileText size={15} />
-                      <span className="msg-pasted-label">{seg.block.label}</span>
+                      <span className="msg-pasted-label">{shownLabel}</span>
                       <div className="msg-pasted-actions">
                         <Tooltip label={t(expanded ? "msg.pastedCollapseTooltip" : "msg.pastedExpandTooltip")}>
                           <button type="button" onClick={() => togglePasteExpand(seg.block.label)}>

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -147,21 +147,6 @@ function renderMediaPreview(preview: FilePreview): ReactElement | null {
   return null;
 }
 
-function fenceFor(text: string): string {
-  let longest = 0;
-  for (const match of text.matchAll(/`+/g)) {
-    longest = Math.max(longest, match[0].length);
-  }
-  return "`".repeat(Math.max(3, longest + 1));
-}
-
-function formatSelectionReference(path: string, text: string): string {
-  const body = text.replace(/\r\n|\r/g, "\n").trimEnd();
-  const fence = fenceFor(body);
-  const lang = languageFor(path);
-  return `From \`${path}\`:\n\n${fence}${lang ?? ""}\n${body}\n${fence}`;
-}
-
 function shortCwd(cwd?: string): string {
   if (!cwd) return "";
   const parts = cwd.split("/").filter(Boolean);
@@ -206,6 +191,7 @@ export function WorkspacePanel({
   onToggleMaximized,
   onPreviewModeChange,
   onAddToChat,
+  onAddCodeToChat,
   onRequestPanelWidth,
   onFileTreeRefresh,
   refreshKey,
@@ -225,6 +211,7 @@ export function WorkspacePanel({
   onToggleMaximized: () => void;
   onPreviewModeChange?: (active: boolean) => void;
   onAddToChat?: (text: string) => void;
+  onAddCodeToChat?: (path: string, code: string) => void;
   onRequestPanelWidth?: (width: number) => void;
   onFileTreeRefresh?: () => void;
   refreshKey?: number;
@@ -637,11 +624,17 @@ export function WorkspacePanel({
     const onKey = (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") close();
     };
-    window.addEventListener("click", close);
+    // Dismiss on mousedown rather than click: the trailing click a drag-selection
+    // emits would otherwise close the toolbar the instant mouseup opens it. A fresh
+    // mousedown only fires when the user starts another interaction, and FloatingMenu
+    // stops propagation so pressing its button never counts as an outside press.
+    window.addEventListener("mousedown", close);
+    window.addEventListener("scroll", close, true);
     window.addEventListener("resize", close);
     window.addEventListener("keydown", onKey);
     return () => {
-      window.removeEventListener("click", close);
+      window.removeEventListener("mousedown", close);
+      window.removeEventListener("scroll", close, true);
       window.removeEventListener("resize", close);
       window.removeEventListener("keydown", onKey);
     };
@@ -1019,9 +1012,21 @@ export function WorkspacePanel({
     setSelectionMenu({ x: event.clientX, y: event.clientY, text, path: selectedPath });
   };
 
+  // Selecting code with the mouse pops the "Add to Chat" button right away,
+  // so a snippet is one click from the composer instead of right-click →
+  // menu item. The right-click menu (openSelectionMenu) stays as a fallback.
+  const showSelectionToolbar = (event: ReactMouseEvent<HTMLDivElement>) => {
+    // Mouseup on the floating button bubbles back here; let the button handle it.
+    if ((event.target as HTMLElement | null)?.closest(".floating-menu")) return;
+    if (!selectedPath || loadingPreview || preview?.err || preview?.binary || preview?.kind) return;
+    const text = selectedTextFromPreview();
+    if (text.trim() === "") return;
+    setSelectionMenu({ x: event.clientX, y: event.clientY + 8, text, path: selectedPath });
+  };
+
   const addSelectionToChat = () => {
     if (!selectionMenu) return;
-    onAddToChat?.(formatSelectionReference(selectionMenu.path, selectionMenu.text));
+    onAddCodeToChat?.(selectionMenu.path, selectionMenu.text);
     setSelectionMenu(null);
   };
 
@@ -1066,8 +1071,8 @@ export function WorkspacePanel({
         onAddToChat?.(formatWorkspaceReference(target.path, false));
         return;
       }
-      const suffix = file.truncated ? `\n\n${t("workspace.truncated")}` : "";
-      onAddToChat?.(formatSelectionReference(target.path, file.body) + suffix);
+      const body = file.truncated ? `${file.body}\n\n${t("workspace.truncated")}` : file.body;
+      onAddCodeToChat?.(target.path, body);
     } catch {
       onAddToChat?.(formatWorkspaceReference(target.path, false));
     }
@@ -1305,6 +1310,7 @@ export function WorkspacePanel({
           className={`workspace-preview__body${codePreviewActive ? " workspace-preview__body--code" : ""}`}
           ref={previewBodyRef}
           onContextMenu={openSelectionMenu}
+          onMouseUp={showSelectionToolbar}
         >
           {viewMode === "changed" && scopedChangeRows ? (
             <div className="workspace-change-scope">

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -647,6 +647,10 @@ export interface ComposerInsertRequest {
   id: number;
   text: string;
   mode?: "insert" | "replace";
+  // When set, the composer folds this code into a removable/expandable badge
+  // (a pasted-block) at the caret instead of inserting `text` inline. The path
+  // rides in the badge label; the code expands back in place on send.
+  block?: { path: string; text: string };
 }
 
 // MCP & Skills drawer (desktop/app.go Capabilities) — the GUI counterpart to

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -484,6 +484,8 @@ export const en = {
   "composer.stop": "Stop (Esc)",
   "composer.stopShort": "Stop",
   "composer.pastedLabel": "[Pasted text #{id} · {lines} lines]",
+  "composer.selectionLabel": "⟦Selection #{id}⟧",
+  "composer.selectionBadge": "{name} · {lines} lines",
   "composer.pastedShowPreview": "Preview pasted text",
   "composer.pastedHidePreview": "Hide pasted text preview",
   "composer.pastedExpand": "Expand",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -361,6 +361,8 @@ export const zhTW: Record<DictKey, string> = {
   "composer.stop": "停止（Esc）",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已貼上文字 #{id} · {lines} 行]",
+  "composer.selectionLabel": "⟦選取 #{id}⟧",
+  "composer.selectionBadge": "{name} · {lines} 行",
   "composer.pastedShowPreview": "預覽貼上文字",
   "composer.pastedHidePreview": "收起貼上文字預覽",
   "composer.pastedExpand": "展開",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -485,6 +485,8 @@ export const zh: Record<DictKey, string> = {
   "composer.stop": "停止（Esc）",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已粘贴文本 #{id} · {lines} 行]",
+  "composer.selectionLabel": "⟦选中 #{id}⟧",
+  "composer.selectionBadge": "{name} · {lines} 行",
   "composer.pastedShowPreview": "预览粘贴文本",
   "composer.pastedHidePreview": "收起粘贴文本预览",
   "composer.pastedExpand": "展开",


### PR DESCRIPTION
## 需求

Closes #6053 —— 在工作区打开代码后,用鼠标选中一段代码即可快速添加到聊天框。

## 效果

<img width="1731" height="1241" alt="image" src="https://github.com/user-attachments/assets/8125916b-321c-4474-9f42-5754bc9f901a" />


## 做法

- 选中代码后 **mouseup 即浮现「添加到聊天」按钮**(不再只有右键菜单),一步加入。
- 片段以**紧凑徽章**落在光标处(复用现有 pasted-block 机制):可 👁 预览内容、🗑 一键删除、展开;发送时就地还原,**多段各自的内联位置与顺序保持不变**。
- `FloatingMenu` 改为 **portal 到 `document.body`**:`.workspace-preview` 带有残留的 GSAP `transform`,会成为 `position: fixed` 的包含块把浮层顶出屏幕——顺带修复了原右键菜单在工作区里的同样错位。
- 选区 / 文件树菜单改为 **mousedown + scroll 关闭**,避免拖选尾随的 click 把刚弹出的浮层瞬间关掉。
- 徽章标签**按当前语言实时渲染**(i18n),发送后的消息也随语言切换。
- composer insert 请求 id 改为**单调递增计数器**,避免同一毫秒内多段插入因去重被丢弃。
- 右键「添加整份文件内容」也统一为徽章样式。

## 测试

- `tsc --noEmit` ✅
- 前端测试套件 `pnpm test` ✅(含 `message-pasted-blocks` 新增的选中标签解析用例)
- 手动(macOS WebKit 桌面端):选中 → 浮现按钮 → 徽章(👁 预览 / 🗑 一键删);多段插在正文不同光标位置、发送保持原位;右键菜单;Esc / 滚动 / 点击别处关闭;中英切换标签随之变化。
