### PR TITLE
feat(desktop): garbage-collect redundant recovery branches to trash

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -111,6 +111,14 @@ type App struct {
 	activeTabID string
 	readyHook   func()
 
+	// tabsRestored is closed when restoreOrBuildTabs has finished populating
+	// a.tabs from desktop-tabs.json (or built the first-launch tab). Startup
+	// work that inspects "which sessions are open" or persists the tab list
+	// (recovery GC's DeleteSession does both) must wait on it: running against
+	// the pre-restore empty tab map would treat every saved tab's session as
+	// closed and could overwrite desktop-tabs.json with an empty snapshot.
+	tabsRestored chan struct{}
+
 	// projectTreeChangedHook is test-only: set once before any concurrency
 	// starts, then read lock-free from emitProjectTreeChanged (whose callers
 	// may or may not hold a.mu, so it cannot re-lock). Never write it after
@@ -397,11 +405,16 @@ func (a *App) startup(ctx context.Context) {
 	a.heartbeat = newHeartbeatEngine(a)
 	a.heartbeat.Start()
 
+	a.mu.Lock()
+	a.tabsRestored = make(chan struct{})
+	a.mu.Unlock()
 	go a.restoreOrBuildTabs()
 	a.goSafe("refreshBotRuntime", a.refreshBotRuntime)
 	a.goSafe("sendStartupPing", a.sendStartupPing)
 	a.goSafe("flushMetrics", a.flushMetrics)
 	a.goSafe("flushPendingCrash", a.flushPendingCrash)
+	// After restoreOrBuildTabs is launched: the GC's first sweep waits on
+	// tabsRestored so it never observes the pre-restore empty tab map.
 	a.startRecoveryGC()
 }
 
@@ -479,6 +492,34 @@ func (a *App) trayReadySignal() <-chan struct{} {
 	return a.tray.ready
 }
 
+// markTabsRestored closes the tabsRestored gate exactly once. Safe when the
+// channel was never created (tests that drive App without startup).
+func (a *App) markTabsRestored() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.tabsRestored == nil {
+		return
+	}
+	select {
+	case <-a.tabsRestored:
+	default:
+		close(a.tabsRestored)
+	}
+}
+
+// tabsRestoredSignal returns a channel closed once tab restore has completed.
+// When startup never armed the gate (tests), it reports already-restored.
+func (a *App) tabsRestoredSignal() <-chan struct{} {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.tabsRestored == nil {
+		closed := make(chan struct{})
+		close(closed)
+		return closed
+	}
+	return a.tabsRestored
+}
+
 func (a *App) showMainWindow() {
 	if a.ctx != nil {
 		showFromBackground(a.ctx, a.backgroundMaximised.Swap(false))
@@ -547,6 +588,9 @@ func backgroundRestoreShouldMaximise(goos string, wasMaximised bool) bool {
 // default Global tab on first launch.
 func (a *App) restoreOrBuildTabs() {
 	defer a.recoverToPending("restoreOrBuildTabs")
+	// Unblock startup work gated on the restore (recovery GC) no matter how
+	// this returns — including the recover path above.
+	defer a.markTabsRestored()
 	// Reap any orphaned codegraph processes from a previous crash or older
 	// version that leaked them, so they don't accumulate across restarts.
 	a.reapOrphanCodeGraph()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -402,6 +402,7 @@ func (a *App) startup(ctx context.Context) {
 	a.goSafe("sendStartupPing", a.sendStartupPing)
 	a.goSafe("flushMetrics", a.flushMetrics)
 	a.goSafe("flushPendingCrash", a.flushPendingCrash)
+	a.startRecoveryGC()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {

--- a/desktop/recovery_gc.go
+++ b/desktop/recovery_gc.go
@@ -13,10 +13,19 @@ import (
 // so a low frequency is plenty and keeps the disk scan off the hot path.
 const recoveryGCInterval = 6 * time.Hour
 
-// startRecoveryGC kicks an immediate sweep, then repeats on an interval until
-// the app context is cancelled.
+// startRecoveryGC waits for tab restore to complete, runs one sweep, then
+// repeats on an interval until the app context is cancelled. The wait is
+// load-bearing: restoreOrBuildTabs populates a.tabs asynchronously, and a
+// sweep against the pre-restore empty tab map would see every saved tab's
+// session as closed — and DeleteSession's tab-list persistence would then
+// overwrite desktop-tabs.json with that empty snapshot.
 func (a *App) startRecoveryGC() {
 	a.goSafe("recoveryGC", func() {
+		select {
+		case <-a.tabsRestoredSignal():
+		case <-a.ctx.Done():
+			return
+		}
 		a.sweepReclaimableRecoveryBranches()
 		ticker := time.NewTicker(recoveryGCInterval)
 		defer ticker.Stop()

--- a/desktop/recovery_gc.go
+++ b/desktop/recovery_gc.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"log/slog"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+)
+
+// recoveryGCInterval bounds how often the background sweep repeats after the
+// startup run. Recovery branches accumulate slowly (only on a save conflict),
+// so a low frequency is plenty and keeps the disk scan off the hot path.
+const recoveryGCInterval = 6 * time.Hour
+
+// startRecoveryGC kicks an immediate sweep, then repeats on an interval until
+// the app context is cancelled.
+func (a *App) startRecoveryGC() {
+	a.goSafe("recoveryGC", func() {
+		a.sweepReclaimableRecoveryBranches()
+		ticker := time.NewTicker(recoveryGCInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-a.ctx.Done():
+				return
+			case <-ticker.C:
+				a.sweepReclaimableRecoveryBranches()
+			}
+		}
+	})
+}
+
+// sweepReclaimableRecoveryBranches trashes conflict-recovery branches that
+// preserve nothing unique (their content is covered by a still-present parent
+// session), were never continued on, sat idle past the grace period, and are
+// not held by any runtime. Trashing — never hard deletion — keeps every swept
+// branch recoverable from the session trash. Returns how many were reclaimed.
+func (a *App) sweepReclaimableRecoveryBranches() int {
+	return a.reclaimRecoveryBranchesIn(recoveryGCDirs(), time.Now())
+}
+
+func (a *App) reclaimRecoveryBranchesIn(dirs []string, now time.Time) int {
+	reclaimed := 0
+	for _, dir := range dirs {
+		reclaimable, err := agent.ReclaimableRecoveryBranches(dir, now, agent.RecoveryGCGracePeriod)
+		if err != nil {
+			slog.Warn("desktop: scan reclaimable recovery branches", "dir", dir, "err", err)
+			continue
+		}
+		for _, path := range reclaimable {
+			// Re-check liveness right before disposal: the scan is a snapshot,
+			// and the user may have opened the branch since. DeleteSession then
+			// runs the full removal path (removal guard, runtime unbinding,
+			// trash move), so even a miss here lands in the recoverable trash.
+			if agent.SessionLeaseHeld(path) || a.sessionOpenInAnyTab(path) {
+				continue
+			}
+			if err := a.DeleteSession(path); err != nil {
+				slog.Warn("desktop: trash reclaimed recovery branch", "path", path, "err", err)
+				continue
+			}
+			reclaimed++
+		}
+	}
+	if reclaimed > 0 {
+		slog.Info("desktop: moved redundant recovery branches to the session trash", "count", reclaimed)
+		a.emitProjectTreeChanged()
+	}
+	return reclaimed
+}
+
+// recoveryGCDirs returns every session directory the desktop lists sessions
+// from: the global desktop and legacy shared dirs plus each saved project's
+// session dirs, deduplicated.
+func recoveryGCDirs() []string {
+	seen := map[string]bool{}
+	var dirs []string
+	add := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
+	}
+	add(desktopSessionDir(globalWorkspaceRoot()))
+	add(config.SessionDir())
+	for _, project := range loadProjectsFile().Projects {
+		if root := normalizeProjectRoot(project.Root); root != "" {
+			add(desktopSessionDir(root))
+			add(config.ProjectSessionDir(root))
+		}
+	}
+	return dirs
+}
+
+// sessionOpenInAnyTab reports whether any tab's current session is path.
+// Lease checks cover live runtimes; this additionally covers tabs that hold a
+// session without a lease (read-only channel views).
+func (a *App) sessionOpenInAnyTab(path string) bool {
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, tab := range a.tabs {
+		if tab == nil {
+			continue
+		}
+		if sessionRuntimeKey(tab.currentSessionPath()) == key {
+			return true
+		}
+	}
+	return false
+}

--- a/desktop/recovery_gc_test.go
+++ b/desktop/recovery_gc_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -88,4 +89,67 @@ func TestRecoveryGCSkipsBranchOpenInTab(t *testing.T) {
 	if _, err := os.Stat(branchPath); err != nil {
 		t.Fatalf("open branch must be untouched: %v", err)
 	}
+}
+
+// TestRecoveryGCFirstSweepWaitsForTabRestore forces the startup race the
+// review caught: a saved recovery tab exists in desktop-tabs.json but a.tabs
+// has not been populated yet. The GC's first sweep must wait for the restore
+// gate — sweeping early would judge the branch "not open in any tab" and
+// DeleteSession would persist the pre-restore (empty) tab list over the
+// user's saved one.
+func TestRecoveryGCFirstSweepWaitsForTabRestore(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	_, branchPath := forkCoveredRecoveryBranch(t, dir, "startup")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	app := &App{
+		ctx:          ctx,
+		tabs:         map[string]*WorkspaceTab{},
+		tabsRestored: make(chan struct{}),
+	}
+
+	swept := make(chan int, 1)
+	go func() {
+		select {
+		case <-app.tabsRestoredSignal():
+		case <-ctx.Done():
+			swept <- -1
+			return
+		}
+		swept <- app.reclaimRecoveryBranchesIn([]string{dir}, time.Now().Add(48*time.Hour))
+	}()
+
+	// Gate still closed: the sweep must not have run — the branch is intact.
+	select {
+	case n := <-swept:
+		t.Fatalf("sweep ran before tab restore completed (reclaimed=%d)", n)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("branch touched before restore completed: %v", err)
+	}
+
+	// Restore lands the saved tab holding the branch, then opens the gate:
+	// the sweep runs and must skip the now-open branch.
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", SessionPath: branchPath, Ready: true}
+	app.mu.Lock()
+	app.tabs["tab"] = tab
+	app.mu.Unlock()
+	app.markTabsRestored()
+
+	if n := <-swept; n != 0 {
+		t.Fatalf("post-restore sweep reclaimed = %d, want 0 (branch is open in a restored tab)", n)
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("restored tab's branch must be untouched: %v", err)
+	}
+
+	// markTabsRestored is idempotent (restore + recover paths may both fire).
+	app.markTabsRestored()
 }

--- a/desktop/recovery_gc_test.go
+++ b/desktop/recovery_gc_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+// forkCoveredRecoveryBranch builds the reclaimable shape in dir: a conflict
+// fork whose parent went on to contain everything the fork preserved.
+func forkCoveredRecoveryBranch(t *testing.T, dir, name string) (parentPath, branchPath string) {
+	t.Helper()
+	parentPath = filepath.Join(dir, name+".jsonl")
+	disk := agent.NewSession("sys")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk " + name})
+	if err := disk.Save(parentPath); err != nil {
+		t.Fatalf("Save parent: %v", err)
+	}
+	stale := agent.NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local " + name})
+	info, err := stale.SaveRecoveryBranch(agent.RecoveryBranchOptions{OriginalPath: parentPath})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	covering := agent.NewSession("")
+	covering.Messages = append([]provider.Message(nil), stale.Snapshot()...)
+	covering.Add(provider.Message{Role: provider.RoleAssistant, Content: "answered after recovery"})
+	if err := covering.Save(parentPath); err != nil {
+		t.Fatalf("Save covering parent: %v", err)
+	}
+	return parentPath, info.Path
+}
+
+func TestRecoveryGCTrashesCoveredForkAndKeepsParent(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	parentPath, branchPath := forkCoveredRecoveryBranch(t, dir, "session")
+
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	if got := app.reclaimRecoveryBranchesIn([]string{dir}, time.Now().Add(48*time.Hour)); got != 1 {
+		t.Fatalf("reclaimed = %d, want 1", got)
+	}
+
+	if _, err := os.Stat(branchPath); !os.IsNotExist(err) {
+		t.Fatalf("reclaimed branch still present at %s (err=%v)", branchPath, err)
+	}
+	key := filepath.Base(branchPath)
+	trashPath := filepath.Join(dir, sessionTrashDir, key, key)
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("reclaimed branch should be in trash: %v", err)
+	}
+	if _, err := os.Stat(parentPath); err != nil {
+		t.Fatalf("parent session must be untouched: %v", err)
+	}
+
+	// A second sweep is a no-op: nothing left to reclaim.
+	if got := app.reclaimRecoveryBranchesIn([]string{dir}, time.Now().Add(48*time.Hour)); got != 0 {
+		t.Fatalf("second sweep reclaimed = %d, want 0", got)
+	}
+}
+
+func TestRecoveryGCSkipsBranchOpenInTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	_, branchPath := forkCoveredRecoveryBranch(t, dir, "open")
+
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", SessionPath: branchPath, Ready: true}
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+	if got := app.reclaimRecoveryBranchesIn([]string{dir}, time.Now().Add(48*time.Hour)); got != 0 {
+		t.Fatalf("reclaimed = %d, want 0 while the branch is open in a tab", got)
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("open branch must be untouched: %v", err)
+	}
+}

--- a/internal/agent/recovery_gc.go
+++ b/internal/agent/recovery_gc.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Recovery-branch garbage collection. Conflict recovery forks a copy of the
+// in-memory transcript whenever a save conflicts (#5993); the triggers are
+// fixed, but every fork that ever happened still sits in the session list
+// until the user trashes it by hand. Most of them preserve nothing: the
+// original session went on to contain everything the fork saved. Those — and
+// only those — are safe to reclaim automatically.
+
+// RecoveryGCGracePeriod is how long a reclaimable recovery branch must sit
+// idle before GC may collect it. A fresh fork is part of an active conflict
+// flow — the user may be comparing it against the original right now.
+const RecoveryGCGracePeriod = 24 * time.Hour
+
+// SessionLeaseHeld reports whether ANY live runtime — this process included —
+// holds the session's write lease. SessionLeaseHeldByOtherRuntime deliberately
+// answers false for the current process; GC needs the stricter question, since
+// a branch open in one of our own tabs is just as much in use.
+func SessionLeaseHeld(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if _, ok := sessionLeaseOwners.Load(canonicalSessionSavePath(path)); ok {
+		return true
+	}
+	return SessionLeaseHeldByOtherRuntime(path)
+}
+
+// ReclaimableRecoveryBranches scans dir for conflict-recovery branches that
+// are safe to dispose of. Every condition must hold — when in doubt the branch
+// stays, because a recovery branch exists precisely to prevent data loss:
+//
+//  1. The branch meta says Recovered and records the fork digest.
+//  2. The transcript still matches that fork digest: the branch was never
+//     continued on. A single follow-up turn disqualifies it permanently.
+//  3. The parent transcript (meta.ParentID, same directory) exists and covers
+//     the branch content — equal digest, or the branch is a strict prefix
+//     (allowing a compatible leading-system swap). These are the same checks
+//     SaveRecoveryBranch uses to declare a recovery not needed in the first
+//     place, so "covered" here means the fork preserves nothing unique.
+//  4. No live runtime holds the branch's session lease.
+//  5. The branch has been idle for at least grace.
+//
+// It returns candidate paths only; disposal (trash, delete) is caller policy.
+func ReclaimableRecoveryBranches(dir string, now time.Time, grace time.Duration) ([]string, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") || strings.HasSuffix(e.Name(), ".events.jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if !IsVisibleSession(path) {
+			continue
+		}
+		meta, ok, err := LoadBranchMeta(path)
+		if err != nil || !ok || !meta.Recovered || strings.TrimSpace(meta.RecoveryDigest) == "" {
+			continue
+		}
+		if strings.TrimSpace(meta.ParentID) == "" {
+			continue
+		}
+		idleSince := meta.UpdatedAt
+		if idleSince.IsZero() {
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			idleSince = info.ModTime()
+		}
+		if now.Sub(idleSince) < grace {
+			continue
+		}
+		if SessionLeaseHeld(path) {
+			continue
+		}
+		branch, err := LoadSession(path)
+		if err != nil || branch == nil {
+			continue
+		}
+		branchMsgs := branch.Snapshot()
+		branchDigest, err := digestSessionMessages(branchMsgs)
+		if err != nil || digestString(branchDigest) != meta.RecoveryDigest {
+			// Continued on (or undigestable): this is someone's conversation now.
+			continue
+		}
+		parentPath := filepath.Join(dir, meta.ParentID+".jsonl")
+		if parentPath == path || !IsVisibleSession(parentPath) {
+			continue
+		}
+		parent, err := LoadSession(parentPath)
+		if err != nil || parent == nil {
+			continue
+		}
+		parentMsgs := parent.Snapshot()
+		parentDigest, err := digestSessionMessages(parentMsgs)
+		if err != nil {
+			continue
+		}
+		covered := bytes.Equal(parentDigest[:], branchDigest[:]) ||
+			messagesHavePrefix(parentMsgs, branchMsgs) ||
+			messagesHavePrefixWithCompatibleSystem(parentMsgs, branchMsgs)
+		if !covered {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out, nil
+}

--- a/internal/agent/recovery_gc_test.go
+++ b/internal/agent/recovery_gc_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// forkRecoveryBranch builds a real conflict-recovery branch: a diverged disk
+// parent plus a stale in-memory session, forked through SaveRecoveryBranch —
+// the exact artifacts GC will meet in the field.
+func forkRecoveryBranch(t *testing.T, dir, name string) (parentPath, branchPath string, branchMsgs []provider.Message) {
+	t.Helper()
+	parentPath = filepath.Join(dir, name+".jsonl")
+	disk := NewSession("sys")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk " + name})
+	if err := disk.Save(parentPath); err != nil {
+		t.Fatalf("Save parent: %v", err)
+	}
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local " + name})
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: parentPath})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	return parentPath, info.Path, stale.Snapshot()
+}
+
+// coverBranchInParent rewrites the parent so it contains the branch's content
+// plus later turns — the "original session went on and kept everything the
+// fork preserved" shape that makes the fork redundant.
+func coverBranchInParent(t *testing.T, parentPath string, branchMsgs []provider.Message) {
+	t.Helper()
+	merged := NewSession("")
+	merged.Messages = append([]provider.Message(nil), branchMsgs...)
+	merged.Add(provider.Message{Role: provider.RoleAssistant, Content: "answered after recovery"})
+	if err := merged.Save(parentPath); err != nil {
+		t.Fatalf("Save covering parent: %v", err)
+	}
+}
+
+func TestReclaimableRecoveryBranchesCollectsOnlyCoveredIdleForks(t *testing.T) {
+	dir := t.TempDir()
+	later := time.Now().Add(48 * time.Hour)
+
+	// Covered + idle + unleased: reclaimable.
+	_, covered, coveredMsgs := forkRecoveryBranch(t, dir, "covered")
+	coverBranchInParent(t, filepath.Join(dir, "covered.jsonl"), coveredMsgs)
+
+	// Diverged parent: the fork holds turns that exist nowhere else — kept.
+	forkRecoveryBranch(t, dir, "diverged")
+
+	// Continued on: one follow-up turn on the branch disqualifies it forever.
+	continuedParent, continuedBranch, continuedMsgs := forkRecoveryBranch(t, dir, "continued")
+	coverBranchInParent(t, continuedParent, continuedMsgs)
+	cont, err := LoadSession(continuedBranch)
+	if err != nil {
+		t.Fatalf("LoadSession continued branch: %v", err)
+	}
+	cont.Add(provider.Message{Role: provider.RoleAssistant, Content: "user kept chatting here"})
+	if err := cont.Save(continuedBranch); err != nil {
+		t.Fatalf("Save continued branch: %v", err)
+	}
+
+	got, err := ReclaimableRecoveryBranches(dir, later, RecoveryGCGracePeriod)
+	if err != nil {
+		t.Fatalf("ReclaimableRecoveryBranches: %v", err)
+	}
+	if len(got) != 1 || got[0] != covered {
+		t.Fatalf("reclaimable = %v, want only %q", got, covered)
+	}
+}
+
+func TestReclaimableRecoveryBranchesRespectsGraceLeaseAndMissingParent(t *testing.T) {
+	dir := t.TempDir()
+	later := time.Now().Add(48 * time.Hour)
+
+	parentPath, branchPath, branchMsgs := forkRecoveryBranch(t, dir, "guarded")
+	coverBranchInParent(t, parentPath, branchMsgs)
+
+	// Fresh fork inside the grace window: kept.
+	if got, err := ReclaimableRecoveryBranches(dir, time.Now(), RecoveryGCGracePeriod); err != nil || len(got) != 0 {
+		t.Fatalf("within grace = %v err=%v, want none", got, err)
+	}
+
+	// Lease held (by this very process): kept.
+	lease, err := TryAcquireSessionLease(branchPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	if !SessionLeaseHeld(branchPath) {
+		t.Fatal("SessionLeaseHeld = false while this process holds the lease")
+	}
+	if got, err := ReclaimableRecoveryBranches(dir, later, RecoveryGCGracePeriod); err != nil || len(got) != 0 {
+		t.Fatalf("with lease held = %v err=%v, want none", got, err)
+	}
+	lease.Release()
+	if SessionLeaseHeld(branchPath) {
+		t.Fatal("SessionLeaseHeld = true after release")
+	}
+
+	// Released + idle: reclaimable now.
+	if got, err := ReclaimableRecoveryBranches(dir, later, RecoveryGCGracePeriod); err != nil || len(got) != 1 || got[0] != branchPath {
+		t.Fatalf("after release = %v err=%v, want %q", got, err, branchPath)
+	}
+
+	// Parent gone: content is no longer covered anywhere — kept.
+	for _, suffix := range []string{"", ".events.jsonl", ".meta"} {
+		if err := os.Remove(parentPath + suffix); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove parent artifact %s: %v", suffix, err)
+		}
+	}
+	if got, err := ReclaimableRecoveryBranches(dir, later, RecoveryGCGracePeriod); err != nil || len(got) != 0 {
+		t.Fatalf("parent missing = %v err=%v, want none", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

补上 #5993 的最后半截：冲突触发源已在 1.17.x 修复,但历史上产生的每一个恢复分支仍堆在会话列表里,只能手动清理(该 issue 明确抱怨的"会话列表被大量 recovery 文件污染")。

**清理策略(保守优先——recovery 分支的存在意义就是防数据丢失,宁可漏收不可误删)**:

`agent.ReclaimableRecoveryBranches` 仅当**全部**条件成立才判定可回收:

1. meta 标记 `Recovered` 且记录了 fork 时的内容摘要;
2. 当前 transcript 仍与该摘要一致——**从未被续聊过**(用户在分支上多聊一轮即永久豁免);
3. 父会话(`meta.ParentID`,同目录)仍存在且**覆盖**分支内容(摘要相等,或分支是父的前缀、允许兼容的 system 消息替换)——与 `SaveRecoveryBranch` 判定"无需恢复"用的是同一组检查,即该分支未保留任何独有内容;
4. 无任何运行时持有该分支的会话租约(新增 `agent.SessionLeaseHeld`,含本进程——`SessionLeaseHeldByOtherRuntime` 对本进程故意返回 false,GC 需要更严的问法);
5. 空闲超过 24h 宽限期(新 fork 属于进行中的冲突流程,用户可能正在对比)。

**处置方式**:desktop 启动时 + 每 6 小时后台扫描所有会话目录(全局 + legacy 共享 + 每个已保存项目),处置前**再次**核查租约与"是否在某个 tab 打开"(扫描是快照,期间用户可能打开了分支),然后走完整的 `DeleteSession` 流程——**移入可恢复的会话回收站,绝不硬删**;即使启发式对某个分支误判,用户也能从回收站找回。

## Verification

- Agent 层:`TestReclaimableRecoveryBranchesCollectsOnlyCoveredIdleForks`(covered 回收 / diverged 保留 / 续聊过保留)与 `TestReclaimableRecoveryBranchesRespectsGraceLeaseAndMissingParent`(宽限期内保留、租约持有保留并验证 `SessionLeaseHeld` 本进程语义、释放后回收、父缺失保留)。fixtures 通过真实的 `SaveRecoveryBranch` 冲突流程构造。
- Desktop 层:`TestRecoveryGCTrashesCoveredForkAndKeepsParent`(回收进回收站、父会话不动、二次扫描零回收)与 `TestRecoveryGCSkipsBranchOpenInTab`。
- **反向验证**:临时移除"父覆盖"守卫后,diverged 分支(内容仅存于此)被误判可回收、测试恰在该处失败——数据丢失守卫真实生效。
- `go test ./internal/agent`(19.7s)与完整 desktop 套件(40.8s)全绿;`-race` 覆盖 GC/租约路径;`go vet` 干净。

## Cache impact

Cache-impact: none - session file lifecycle only; no provider request, prompt, or tool schema changes.
Cache-guard: not applicable (no cache-sensitive files); suites above cover the change.
System-prompt-review: N/A

Refs #5993(收尾其"列表污染"部分), #6054.