### PR TITLE
fix(desktop): restore responsive dock-tab compression on Windows frameless / 修复 Windows 无边框窗口下右侧栏标签被遮挡的问题

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29511,3 +29511,38 @@ body > .mermaid-diagram--fullscreen {
     min-width: 0;
   }
 }
+
+/* ── Windows frameless: workbench dock tab compression ─────────────── */
+/* When the rightmost tab ("Changes") would touch the window-controls box
+   (dock ≤ 380 px  →  3 × 69 px tabs + 12 px left padding + 156 px safe
+   area), enable proportional flex-shrink.  Padding and gap use clamp()
+   with cqi units so they decrease *continuously* from 380 px down to the
+   minimum dock width — no discrete jumps.  macOS / Linux are unaffected
+   (no .app--windows-frameless class in the DOM). */
+
+@container (max-width: 380px) {
+  /* ── tabs: proportional shrink + continuous padding / gap ── */
+  :root[data-theme-style] .app--windows-frameless .workbench-dock__tab,
+  :root[data-theme-style] .app--windows-frameless.app--creation .workbench-dock__tab,
+  .app--windows-frameless.app--creation .workbench-dock__tab,
+  .app--windows-frameless .workbench-dock__tab {
+    flex: 1 1 auto;
+    min-width: 30px;
+    max-width: none;
+    /*  380 px dock → 12 px padding    300 px dock →  5 px padding  */
+    padding-left:  clamp(5px, calc(8.75 * 1cqi - 21.25px), 12px);
+    padding-right: clamp(5px, calc(8.75 * 1cqi - 21.25px), 12px);
+    /*  380 px dock →  6 px gap        300 px dock →  2 px gap      */
+    gap:           clamp(2px, calc(5 * 1cqi - 13px), 6px);
+  }
+
+  /* ── label: allow truncation once text no longer fits ── */
+  :root[data-theme-style] .app--windows-frameless .workbench-dock__tab-label,
+  :root[data-theme-style] .app--windows-frameless.app--creation .workbench-dock__tab-label,
+  .app--windows-frameless.app--creation .workbench-dock__tab-label,
+  .app--windows-frameless .workbench-dock__tab-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}


### PR DESCRIPTION
Fixes #5825 .

### Problem

On Windows frameless the custom window-controls box (138 px wide, `position: fixed; z-index: var(--z-dock)`) sits at the top-right corner.  `workbench-dock__tools` reserves `padding-right: 156 px` to prevent the three view tabs — Overview, Files, Changes — from being overlapped.  However, themed styles (`:root[data-theme-style]`) unconditionally set `flex: 0 0 auto; min-width: auto` on `.workbench-dock__tab`, preventing the tabs from shrinking when the right dock is narrow.  The existing `@container` breakpoints at 520 px and 340 px (added to collapse tabs progressively) were overridden by later themed rules with higher specificity and never took effect.

When the dock is dragged to its minimum width (300 px tree / 420 px preview) the three auto-sized tabs (~207 px total) overflow the available content area (~132 px after the 156 px safe padding), pushing the rightmost tab under the window-controls box where it is invisible and unclickable.  The same issue affects the Creation theme.

### Fix

One `@container (max-width: 380 px)` query appended **at end-of-file**, scoped entirely to `.app--windows-frameless` so macOS and Linux are unaffected.  The query:

- Enables **proportional** flex-shrink (`flex: 1 1 auto`) — wider tabs (e.g. "Overview") shrink more than narrower ones, preserving visual hierarchy.
- Uses `clamp()` with `cqi` (container-query inline-percentage) units so `padding` and `gap` decrease **continuously** from 12 px / 6 px at 380 px dock down to 5 px / 2 px at the minimum dock width — no discrete jumps, no sudden visual changes.
- Adds `overflow: hidden; text-overflow: ellipsis` to tab labels as a last resort when text genuinely no longer fits.

The 380 px breakpoint corresponds to the exact point where the rightmost tab's edge would touch the window-controls box (`3 × 69 px tabs + 12 px left padding + 156 px safe area = 379 px`).

### Verification

- Built and smoke-tested on Windows 11 in Workbench and Creation themes; tabs compress smoothly as the dock narrows and remain clickable down to the minimum dock width.
- `gofmt` ✓  `go vet ./...` ✓
- Existing test suite: `go test ./internal/tool/builtin/ ./internal/boot/` passes (2 unrelated pre-existing failures in gitignore tests).

### Diff

| File | Delta |
|------|-------|
| `desktop/frontend/src/styles.css` | +35 lines, 0 removed |

Zero existing lines modified — pure append.

Cache-impact: none — CSS-only frontend change; no Go, provider, boot, config, memory, skill, or output-style files are touched.
Cache-guard: existing UI tests (app-chrome-tabs.test.ts, typography-overflow-contract.test.ts) exercise the workbench dock selectors; the new rules are scoped to .app--windows-frameless so macOS/Linux layouts are byte-identical.

---

### 问题

Windows 无边框模式下，自定义窗口控件（138 px 宽，`position: fixed`，高 `z-index`）固定在右上角。`workbench-dock__tools` 预留了 `padding-right: 156 px` 以避免"概览 / 文件 / 改动"三个视图标签被遮挡，但主题样式（`:root[data-theme-style]`）无条件地将 `.workbench-dock__tab` 设为 `flex: 0 0 auto; min-width: auto`，阻止了标签在窄屏下收缩。原有的 `@container` 断点（520 px / 340 px）被后文中更高特异性的主题规则覆盖，从未生效。

当右侧栏收窄至最小宽度（tree 模式 300 px / preview 模式 420 px）时，三个按内容自适应的标签（总宽约 207 px）溢出仅 132 px 的内容区，最右侧的"改动"标签被推到窗口控件下方，不可见、不可点击。创作主题存在相同问题。

### 修复

在 CSS 文件末尾追加一个 `@container (max-width: 380 px)` 查询，全部用 `.app--windows-frameless` 限定，macOS / Linux 不受影响。该查询：

- 启用**按比例**的 flex-shrink（`flex: 1 1 auto`）——宽标签比窄标签收缩更多，保持视觉层次。
- 使用 `clamp()` 配合 `cqi` 单位，使 `padding` 和 `gap` **连续渐变**：380 px dock 时 12 px / 6 px，线性渐变至最小宽度时的 5 px / 2 px——无跳变，无突变感。
- 对标签文字添加 `overflow: hidden; text-overflow: ellipsis`，仅在文字确实无法容纳时显示省略号。

380 px 断点精确对应最右侧标签触碰窗口控件左边缘的瞬间（`3 × 69 px + 12 px 左内边距 + 156 px 安全区 = 379 px`）。

### 验证

- Windows 11 实机构建测试，工作台和创作主题下标签随侧栏收窄平滑压缩，缩至最小宽度仍可点击。
- `gofmt` ✓  `go vet ./...` ✓
- 现有测试套件通过（2 个无关的 gitignore 测试预存失败）。

### 改动

| 文件 | 变更 |
|------|------|
| `desktop/frontend/src/styles.css` | +35 行，0 删除 |

零行修改现有代码——纯末尾追加。

Cache-impact: none — 仅前端 CSS 变更；未触及 Go、provider、boot、config、memory、skill、output-style 任一文件。
Cache-guard: 现有 UI 测试（app-chrome-tabs.test.ts, typography-overflow-contract.test.ts）已覆盖 workbench dock 选择器；新规则由 .app--windows-frameless 限定，macOS/Linux 布局完全不变。