### PR TITLE
fix(plugin): pin cache-hit MCP placeholder tools for the whole session

### DIFF
--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -1,13 +1,17 @@
 // MCP placeholder tools. Background startup registers cheap placeholder entries
 // in the tool registry at boot — using the on-disk schema cache when it exists —
 // and kicks the real subprocess spawn / handshake immediately. By the time the
-// model calls a tool, the swap is usually already done.
+// model calls a tool, the connection is usually already up.
 //
-// Why the indirection: a background server still needs stable placeholder tools
-// before the real handshake finishes. Once it does finish, lazySpawn swaps the
-// placeholders for real tools through tool.Registry's own lock, so the next
-// model request sees the real schemas without waiting for another placeholder
-// Execute call.
+// Cache-hit placeholders are PINNED for the whole session: they present the
+// cached names/descriptions/schemas from boot onward and forward Execute to the
+// real tools once the handshake completes, but the registry entries themselves
+// are never replaced. The provider request's tools array is part of the cached
+// prompt prefix, so swapping in live tools mid-session — whenever the live
+// handshake differed from the cache — invalidated the whole conversation's
+// provider cache at 10x miss pricing. Live drift lands in the schema cache and
+// surfaces next session. Only the cache-miss connect stub still swaps (there
+// was nothing real to present), a one-time cost per server.
 package plugin
 
 import (
@@ -148,17 +152,33 @@ func saveLazyCachedSchema(spec Spec, real []tool.Tool) {
 	})
 }
 
-// trySwap installs the real tools into reg if the spawn is ready and the
-// swap hasn't happened. Caller must hold s.mu.
+// trySwap publishes the real tools after a successful spawn. Caller must hold
+// s.mu.
+//
+// Cache-miss placeholders (removePrefix set) genuinely swap: the single
+// "<server>__connect" stub is dropped and the real tools register under their
+// own names — a one-time tool-set change per server, unavoidable because no
+// schema existed to present earlier.
+//
+// Cache-hit placeholders do NOT touch the registry. The lazyTools already
+// carry the cached names/descriptions/schemas the model has seen since boot,
+// and Execute forwards to the real tool once ready — swapping in the live
+// tools would rewrite the request's tools array mid-session whenever the live
+// handshake differs from the cache (description tweaks, schema upgrades, new
+// tools), invalidating the provider prefix cache at 10x miss pricing. The
+// live result still lands in the schema cache (saveLazyCachedSchema), so the
+// NEXT session presents the updated surface — freshness deferred one session
+// in exchange for byte-stable tool bytes within this one, same trade the
+// environment-probe snapshot makes for the system prompt.
 func (s *lazySpawn) trySwap() {
 	if s.swapped || s.state != spawnReady {
 		return
 	}
 	if s.removePrefix != "" {
 		s.reg.RemovePrefix(s.removePrefix)
-	}
-	for _, t := range s.real {
-		s.reg.Add(t)
+		for _, t := range s.real {
+			s.reg.Add(t)
+		}
 	}
 	s.swapped = true
 }
@@ -360,7 +380,11 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 	}
 
 	var out []tool.Tool
-	if cs == nil {
+	// A snapshot with zero tools presents nothing the model could call, so it
+	// gets the same connect stub as a cache miss — otherwise the live tools
+	// would silently join the registry mid-session with no placeholder names
+	// reserved for them.
+	if cs == nil || len(cs.Tools) == 0 {
 		shared.removePrefix = ToolPrefix(spec.Name)
 		out = []tool.Tool{&lazyTool{
 			shared:   shared,

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -801,14 +801,28 @@ func TestLazyCacheHitPinsToolBytesAcrossDivergentHandshake(t *testing.T) {
 		t.Fatal("live-only tool joined the registry mid-session; it must wait for the next session")
 	}
 
-	// The refreshed cache carries the live truth for the NEXT session.
-	refreshed := waitForCachedSchema(t, spec, 5*time.Second)
-	names := map[string]bool{}
-	for _, ct := range refreshed.Tools {
-		names[ct.Name] = true
-	}
-	if !names["echo"] || !names["zed"] {
-		t.Fatalf("refreshed cache tools = %v, want live set {echo, zed}", refreshed.Tools)
+	// The refreshed cache carries the live truth for the NEXT session. The
+	// stale cache this test wrote is itself loadable, so poll until the
+	// refresh actually lands (the background save races Execute's return on
+	// slow machines) rather than accepting the first loadable snapshot.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		refreshed, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+		if ok {
+			names := map[string]bool{}
+			for _, ct := range refreshed.Tools {
+				names[ct.Name] = true
+			}
+			if names["echo"] && names["zed"] {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("refreshed cache tools = %v, want live set {echo, zed}", refreshed.Tools)
+			}
+		} else if time.Now().After(deadline) {
+			t.Fatal("cached schema never became loadable")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -146,13 +146,25 @@ func TestLazyCacheHitSyncSpawn(t *testing.T) {
 		t.Fatalf("host.ServerNames() = %v, want [mock]", names)
 	}
 
-	// After Execute, the registry entry must be the real *remoteTool, not the
-	// placeholder. Subsequent calls bypass the state machine and Execute
-	// directly. Compare via type name so this test doesn't need to import the
-	// unexported type by name.
+	// After Execute, the registry entry must STILL be the placeholder: cache-hit
+	// placeholders are pinned for the whole session so the request's tools
+	// array stays byte-identical even when the live handshake differs from the
+	// cache (see trySwap). Execution keeps forwarding to the real tool through
+	// the shared spawn state.
 	echoAfter, _ := reg.Get("mcp__mock__echo")
-	if got := fmt.Sprintf("%T", echoAfter); !strings.Contains(got, "remoteTool") {
-		t.Fatalf("post-Execute echo should be a remoteTool, got %s", got)
+	if _, isLazy := echoAfter.(*lazyTool); !isLazy {
+		t.Fatalf("post-Execute echo should remain the pinned *lazyTool, got %T", echoAfter)
+	}
+	if got := string(echoAfter.Schema()); got != gotSchema {
+		t.Fatalf("registry schema bytes changed across the handshake:\nbefore: %s\nafter:  %s", gotSchema, got)
+	}
+	// Second call goes straight through the ready state to the real tool.
+	out2, err := echoAfter.Execute(ctx, json.RawMessage(`{"msg":"again"}`))
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if out2 != "echo: again" {
+		t.Fatalf("second Execute result = %q, want %q", out2, "echo: again")
 	}
 }
 
@@ -722,5 +734,100 @@ func TestLazyToolsetCacheHitSchemaVisible(t *testing.T) {
 	// optimisation is moot.
 	if names := host.ServerNames(); len(names) != 0 {
 		t.Fatalf("Schema() must not spawn; host.ServerNames() = %v", names)
+	}
+}
+
+// registrySchemaBytes marshals the registry's full tool schemas — the exact
+// surface that feeds the provider request's tools array.
+func registrySchemaBytes(t *testing.T, reg *tool.Registry) string {
+	t.Helper()
+	b, err := json.Marshal(reg.Schemas())
+	if err != nil {
+		t.Fatalf("marshal schemas: %v", err)
+	}
+	return string(b)
+}
+
+// TestLazyCacheHitPinsToolBytesAcrossDivergentHandshake is the session
+// byte-stability guard: the cached snapshot deliberately DIFFERS from what the
+// live handshake will report (stale description/schema, and it omits one tool
+// the live server exposes). After the background spawn completes, the
+// registry's schema bytes must be identical to what the model saw at boot —
+// the divergence surfaces in the refreshed disk cache (next session), never
+// mid-session in the tools array.
+func TestLazyCacheHitPinsToolBytesAcrossDivergentHandshake(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	stale := CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools: []CachedTool{{
+			Name:        "echo",
+			Description: "STALE description from a previous session.",
+			Schema:      json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`),
+			// live handshake also exposes "zed" — absent here on purpose.
+		}},
+	}
+	if err := SaveCachedSchema(spec.Name, stale); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	cs, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+	if !ok {
+		t.Fatal("LoadCachedSchema miss after save")
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	for _, lt := range LazyToolset(spec, cs, host, reg, ctx, true) {
+		reg.Add(lt)
+	}
+	bootBytes := registrySchemaBytes(t, reg)
+
+	// Let the background handshake finish and give trySwap every chance to run.
+	waitForServer(t, host, "mock", 5*time.Second)
+	echo, _ := reg.Get("mcp__mock__echo")
+	if out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"pin"}`)); err != nil || out != "echo: pin" {
+		t.Fatalf("Execute after ready = %q, %v", out, err)
+	}
+
+	if got := registrySchemaBytes(t, reg); got != bootBytes {
+		t.Fatalf("tools array bytes changed mid-session after a divergent handshake:\nboot: %s\nnow:  %s", bootBytes, got)
+	}
+	if _, found := reg.Get("mcp__mock__zed"); found {
+		t.Fatal("live-only tool joined the registry mid-session; it must wait for the next session")
+	}
+
+	// The refreshed cache carries the live truth for the NEXT session.
+	refreshed := waitForCachedSchema(t, spec, 5*time.Second)
+	names := map[string]bool{}
+	for _, ct := range refreshed.Tools {
+		names[ct.Name] = true
+	}
+	if !names["echo"] || !names["zed"] {
+		t.Fatalf("refreshed cache tools = %v, want live set {echo, zed}", refreshed.Tools)
+	}
+}
+
+// TestLazyEmptyCachedToolsFallsBackToConnectStub: a snapshot with zero tools
+// presents nothing the model could call, so it must take the cache-miss stub
+// path instead of letting live tools join the registry mid-session unnamed.
+func TestLazyEmptyCachedToolsFallsBackToConnectStub(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	cs := &CachedSchema{SpecHash: SpecFingerprint(spec), Tools: nil}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 || tools[0].Name() != "mcp__mock__connect" {
+		t.Fatalf("empty-cache toolset = %v, want single connect stub", tools)
 	}
 }


### PR DESCRIPTION
## Summary

MCP 工具集会话内固定——"高缓存率"专项的最后一块。provider 请求的 tools 数组是缓存前缀的一部分，`cache_shape.go` 早已把会话中途的工具变化记为 `"tools"` 前缀失效（整段对话 10 倍 miss 计价冷启动）。

现状调查结论：lazy placeholder 机制其实已经完成了 90% 的工作——cache-hit 时占位符携带**完整缓存 schema**（与真实工具走同一个 `provider.CanonicalizeSchema`，无 drift 时逐字节相同），boot 时即注册。问题出在最后一步：后台握手一完成，`trySwap` 就把注册表里的占位符替换成 live 工具。**只要 live 握手与缓存有任何差异**（描述微调、schema 升级、server 新增工具），tools 数组就在会话中途改字节 → 前缀全灭。

修复（最小改动）：

- **cache-hit 占位符会话内固定**：`trySwap` 不再重写注册表。占位符从 boot 起呈现的缓存字节保持到会话结束，Execute 通过共享 spawn 状态转发到真实工具——这条转发路径本来就存在（`lazy.go` 的 spawnReady 分支），swap 从来不是功能必需的。live 差异照旧写入 schema 缓存（`saveLazyCachedSchema`），**下一个会话**呈现新表面——与 #6093 环境探测快照同一个取舍：新鲜度延迟一个会话，换会话内字节稳定。
- **cache-miss connect stub 保留 swap**：首次使用某 server 时没有任何真实 schema 可呈现，swap 是一次性成本，且后台 kick 通常赶在用户首条消息之前完成。
- **边角修复**：缓存里 0 个工具的快照现在也走 stub 路径——此前这种情况 live 工具会在会话中途无占位地加入注册表（也是漂移源）。
- 覆盖所有 `trySwap` 调用方，包括 `IsServerAlreadyConnected` 共享 host 恢复路径（修改在函数内部区分，天然覆盖）。

行为边界（review 时请关注）：live 握手**缺少**缓存中某工具时，该占位符调用报 "did not expose tool (cached schema may be stale)"——与修复前行为一致（旧 swap 同样不移除消失的 cache-hit 占位符）；live **新增**的工具本会话不可见，下会话出现。

## Verification

- 新增 `TestLazyCacheHitPinsToolBytesAcrossDivergentHandshake`：缓存故意与 live 分歧（过期描述/schema + 缺一个工具），后台握手完成并 Execute 后，注册表 `Schemas()` 字节与 boot 时**完全一致**、live-only 工具未中途加入、刷新后的磁盘缓存已含 live 真集。**反向验证**：恢复旧 swap 行为后该测试失败。
- 新增 `TestLazyEmptyCachedToolsFallsBackToConnectStub`；更新 `TestLazyCacheHitSyncSpawn`（断言从"swap 成 remoteTool"改为"占位符保留 + schema 字节不变 + 二次调用转发成功"）。
- `internal/plugin`（含 `-race`）、`internal/boot`、`internal/control`、`internal/agent`、desktop 全套（37s）全绿；`go vet` 干净。

## Cache impact

Cache-impact: high - this IS a cache-stability fix: removes the mid-session tools-array rewrite class of prefix invalidation. Tool surface may lag live server state by one session on cache-hit drift.
Cache-guard: TestLazyCacheHitPinsToolBytesAcrossDivergentHandshake asserts registry schema bytes are identical before/after a divergent handshake; reverse-verified against the old swap behavior.
System-prompt-review: N/A (tools array, not system prompt; no prompt content changes)

Refs #2945, #5614; completes the byte-stability line (#6093 system prompt, #6094 request prefix, this PR tools array).