### PR TITLE
Default Windows bash sandbox to off / Windows Bash 沙箱默认关闭

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -558,7 +558,7 @@ func (a *App) restoreOrBuildTabs() {
 	_, _ = config.MigrateLegacyIfNeeded()
 	f := loadTabsFile()
 	_, _ = recoverLegacyProjectSidebarRoots(f)
-	_, _ = config.ResetOfficialProviderPricingOnUpgrade(config.UserConfigPath())
+	_, _ = config.ApplyUserConfigUpgradesOnStartup(config.UserConfigPath())
 	_, _ = config.MigrateMCPToUserConfigOnUpgrade(desktopMCPMigrationRoots(f))
 
 	// Load i18n from the first available config.

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -795,7 +795,7 @@ func (a *App) Settings() SettingsView {
 				Ask:   []string{},
 				Deny:  []string{},
 			},
-			Sandbox:                 SandboxView{Bash: "enforce", AllowWrite: []string{}, EffectiveWriteRoots: []string{}, Shell: "auto"},
+			Sandbox:                 SandboxView{Bash: config.Default().BashMode(), AllowWrite: []string{}, EffectiveWriteRoots: []string{}, Shell: "auto"},
 			Agent:                   AgentView{PlannerMaxSteps: 0, MaxSubagentDepth: agent.DefaultMaxSubagentDepth, ColdResumePrune: true, ReasoningLanguage: "auto"},
 			Bot:                     botSettingsView(config.BotConfig{}),
 			AutoPlan:                "off",
@@ -815,10 +815,7 @@ func (a *App) Settings() SettingsView {
 		}
 	}
 	ctrl := a.activeCtrl()
-	bash := cfg.Sandbox.Bash
-	if bash == "" {
-		bash = "enforce"
-	}
+	bash := cfg.BashMode()
 	shell := cfg.Tools.Shell.Prefer
 	if shell == "" {
 		shell = "auto"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -165,6 +165,9 @@ func migrateLegacyConfigForCLI() {
 	if _, err := config.MigrateLegacyIfNeeded(); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: config migration failed:", err)
 	}
+	if _, err := config.ApplyUserConfigUpgradesOnStartup(config.UserConfigPath()); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: config upgrade failed:", err)
+	}
 }
 
 func migrateMCPConfigForCLIWorkspace() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -418,7 +418,7 @@ command = "legacy-bin"
 	if err != nil {
 		t.Fatalf("read migrated user config: %v", err)
 	}
-	for _, want := range []string{`config_version = 3`, `[desktop]`, `name    = "legacy-cli"`} {
+	for _, want := range []string{`config_version = 4`, `[desktop]`, `name    = "legacy-cli"`} {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("migrated config missing %q:\n%s", want, body)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -425,6 +425,31 @@ command = "legacy-bin"
 	}
 }
 
+func TestRunAppliesUserConfigUpgradesOnStartup(t *testing.T) {
+	isolateCLIConfigHome(t)
+	path := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("config_version = 2\ndefault_model = \"deepseek-flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureStdout(t, func() {
+		if rc := Run([]string{"mcp", "list"}, "test-version"); rc != 0 {
+			t.Fatalf("mcp list rc = %d, want 0", rc)
+		}
+	})
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read upgraded user config: %v", err)
+	}
+	if !strings.Contains(string(body), "config_version = 4") {
+		t.Fatalf("CLI startup should apply user config upgrades:\n%s", body)
+	}
+}
+
 func TestRunMetadataCommandsDoNotMigrateLegacyConfig(t *testing.T) {
 	isolateCLIConfigHome(t)
 	legacyPath := filepath.Join(filepath.Dir(config.UserConfigPath()), "reasonix.toml")

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -518,9 +518,7 @@ func TestResetOfficialProviderPricingOnUpgradeRunsOnce(t *testing.T) {
 
 func TestApplyUserConfigUpgradesOnStartupVersion3NonWindowsNoop(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	oldGOOS := runtimeGOOS
-	runtimeGOOS = "darwin"
-	defer func() { runtimeGOOS = oldGOOS }()
+	setRuntimeGOOS(t, "darwin")
 
 	c := &Config{
 		ConfigVersion: 3,
@@ -560,9 +558,7 @@ func TestApplyUserConfigUpgradesOnStartupVersion3NonWindowsNoop(t *testing.T) {
 
 func TestApplyUserConfigUpgradesOnStartupWindowsBashEnforceDefaultsOffOnce(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	oldGOOS := runtimeGOOS
-	runtimeGOOS = "windows"
-	defer func() { runtimeGOOS = oldGOOS }()
+	setRuntimeGOOS(t, "windows")
 
 	c := Default()
 	c.ConfigVersion = 3
@@ -605,9 +601,7 @@ func TestApplyUserConfigUpgradesOnStartupWindowsBashEnforceDefaultsOffOnce(t *te
 
 func TestApplyUserConfigUpgradesOnStartupWindowsBashOffOnlyMarksVersion(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	oldGOOS := runtimeGOOS
-	runtimeGOOS = "windows"
-	defer func() { runtimeGOOS = oldGOOS }()
+	setRuntimeGOOS(t, "windows")
 
 	c := Default()
 	c.ConfigVersion = 3

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -516,6 +516,122 @@ func TestResetOfficialProviderPricingOnUpgradeRunsOnce(t *testing.T) {
 	}
 }
 
+func TestApplyUserConfigUpgradesOnStartupVersion3NonWindowsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	oldGOOS := runtimeGOOS
+	runtimeGOOS = "darwin"
+	defer func() { runtimeGOOS = oldGOOS }()
+
+	c := &Config{
+		ConfigVersion: 3,
+		Providers: []ProviderEntry{{
+			Name:    "deepseek",
+			Kind:    "openai",
+			BaseURL: "https://api.deepseek.com",
+			Models:  []string{"deepseek-v4-flash"},
+			Prices: map[string]*provider.Pricing{
+				"deepseek-v4-flash": {CacheHit: 4, Input: 4, Output: 4, Currency: "$"},
+			},
+		}},
+	}
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	changed, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil {
+		t.Fatalf("ApplyUserConfigUpgradesOnStartup: %v", err)
+	}
+	if changed {
+		t.Fatal("v3 non-Windows config should not be rewritten by the Windows bash sandbox migration")
+	}
+	var got Config
+	if _, err := toml.DecodeFile(path, &got); err != nil {
+		t.Fatalf("decode migrated config: %v", err)
+	}
+	if got.ConfigVersion != 3 {
+		t.Fatalf("config_version = %d, want 3", got.ConfigVersion)
+	}
+	deepseek, _ := got.Provider("deepseek")
+	if p := deepseek.Prices["deepseek-v4-flash"]; p == nil || p.Output != 4 || p.Currency != "$" {
+		t.Fatalf("custom flash price = %+v, want preserved", p)
+	}
+}
+
+func TestApplyUserConfigUpgradesOnStartupWindowsBashEnforceDefaultsOffOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	oldGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = oldGOOS }()
+
+	c := Default()
+	c.ConfigVersion = 3
+	c.Sandbox.Bash = "enforce"
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	changed, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil {
+		t.Fatalf("ApplyUserConfigUpgradesOnStartup: %v", err)
+	}
+	if !changed {
+		t.Fatal("upgrade should migrate Windows bash sandbox default")
+	}
+	got := LoadForEdit(path)
+	if got.ConfigVersion != Default().ConfigVersion {
+		t.Fatalf("config_version = %d, want %d", got.ConfigVersion, Default().ConfigVersion)
+	}
+	if got.Sandbox.Bash != "off" || got.BashMode() != "off" {
+		t.Fatalf("Windows bash mode after migration = raw %q effective %q, want off/off", got.Sandbox.Bash, got.BashMode())
+	}
+
+	got.Sandbox.Bash = "enforce"
+	if err := got.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo manual enforce: %v", err)
+	}
+	changed, err = ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil {
+		t.Fatalf("second ApplyUserConfigUpgradesOnStartup: %v", err)
+	}
+	if changed {
+		t.Fatal("v4 config should not be migrated again after user re-enables enforce")
+	}
+	got = LoadForEdit(path)
+	if got.Sandbox.Bash != "enforce" || got.BashMode() != "enforce" {
+		t.Fatalf("manual Windows enforce = raw %q effective %q, want enforce/enforce", got.Sandbox.Bash, got.BashMode())
+	}
+}
+
+func TestApplyUserConfigUpgradesOnStartupWindowsBashOffOnlyMarksVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	oldGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = oldGOOS }()
+
+	c := Default()
+	c.ConfigVersion = 3
+	c.Sandbox.Bash = "off"
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	changed, err := ApplyUserConfigUpgradesOnStartup(path)
+	if err != nil {
+		t.Fatalf("ApplyUserConfigUpgradesOnStartup: %v", err)
+	}
+	if !changed {
+		t.Fatal("Windows v3 config should be marked as migrated")
+	}
+	got := LoadForEdit(path)
+	if got.ConfigVersion != Default().ConfigVersion {
+		t.Fatalf("config_version = %d, want %d", got.ConfigVersion, Default().ConfigVersion)
+	}
+	if got.Sandbox.Bash != "off" || got.BashMode() != "off" {
+		t.Fatalf("Windows bash mode after marker migration = raw %q effective %q, want off/off", got.Sandbox.Bash, got.BashMode())
+	}
+}
+
 func TestResolveModelUsesPerModelPricing(t *testing.T) {
 	c := &Config{Providers: []ProviderEntry{{
 		Name:    "deepseek",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -837,9 +837,9 @@ type SandboxConfig struct {
 	WorkspaceRoot string   `toml:"workspace_root"`
 	AllowWrite    []string `toml:"allow_write"`
 	ForbidRead    []string `toml:"forbid_read"`
-	// Bash is the OS-sandbox mode for the bash tool: "enforce" (default) jails
-	// each command when an OS sandbox is available and refuses bash otherwise;
-	// "off" runs it unconfined.
+	// Bash is the OS-sandbox mode for the bash tool: "enforce" jails each
+	// command when an OS sandbox is available and refuses bash otherwise; "off"
+	// runs it unconfined. Empty uses the platform default.
 	Bash string `toml:"bash"`
 	// Network allows network egress from inside the bash sandbox. Defaults true
 	// so module/package downloads keep working; the boundary is then writes.
@@ -910,14 +910,28 @@ func (c *Config) ForbidReadRootsForRoot(fallbackRoot string) []string {
 	return roots
 }
 
-// BashMode normalises the bash-sandbox mode: only an explicit "off" disables
-// it; empty or any other value resolves to "enforce", so the sandbox is on by
-// default and fails safe.
+// BashMode normalises the bash-sandbox mode for the current host.
 func (c *Config) BashMode() string {
-	if c.Sandbox.Bash == "off" {
+	return c.BashModeForGOOS(runtimeGOOS)
+}
+
+// BashModeForGOOS normalises the bash-sandbox mode for tests and cross-platform
+// rendering. Explicit "enforce" and "off" always win; only the empty default is
+// platform-specific.
+func (c *Config) BashModeForGOOS(goos string) string {
+	switch strings.TrimSpace(c.Sandbox.Bash) {
+	case "enforce":
+		return "enforce"
+	case "off":
 		return "off"
+	case "":
+		if goos == "windows" {
+			return "off"
+		}
+		return "enforce"
+	default:
+		return "enforce"
 	}
-	return "enforce"
 }
 
 // AgentConfig configures the harness loop. PlannerModel is optional: when set
@@ -1460,7 +1474,7 @@ const LanguagePolicy = `Reply in the same language the user is using in their mo
 // Default returns the built-in default configuration.
 func Default() *Config {
 	return &Config{
-		ConfigVersion:    3,
+		ConfigVersion:    4,
 		DefaultModel:     "deepseek-flash",
 		CredentialsStore: CredentialsStoreAuto,
 		UI:               UIConfig{Theme: "auto"},
@@ -1489,11 +1503,12 @@ func Default() *Config {
 		// resolves to allow) while `reasonix` prompts before writers. Users add
 		// deny/allow rules to harden or quiet specific tools.
 		Permissions: PermissionsConfig{Mode: "ask"},
-		// Sandbox on by default: bash is jailed (macOS), network allowed so
-		// builds/downloads work. Set bash = "off" to disable. Network=true here
-		// so an absent [sandbox] in a user's file keeps egress (zero value would
-		// wrongly deny it).
-		Sandbox: SandboxConfig{Bash: "enforce", Network: true},
+		// Sandbox uses platform defaults: macOS/Linux jail bash by default;
+		// Windows defaults bash to off because AppContainer behavior varies by
+		// host, while an explicit bash = "enforce" still enables it. Network=true
+		// here so an absent [sandbox] in a user's file keeps egress (zero value
+		// would wrongly deny it).
+		Sandbox: SandboxConfig{Network: true},
 		// LSP tools on by default, but dormant until a language server is on PATH;
 		// a missing server yields an install hint rather than an error.
 		LSP:     LSPConfig{Enabled: true},

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -443,7 +443,7 @@ command = "legacy-bin"
 		t.Fatalf("read migrated config: %v", err)
 	}
 	text := string(got)
-	for _, want := range []string{`config_version = 3`, `[desktop]`, `close_behavior = "quit"`, `name    = "legacy-v1"`} {
+	for _, want := range []string{`config_version = 4`, `[desktop]`, `close_behavior = "quit"`, `name    = "legacy-v1"`} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("migrated TOML missing %q:\n%s", want, text)
 		}

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -136,11 +136,15 @@ func longCat20Prices(models []string) map[string]*provider.Pricing {
 	return prices
 }
 
-// ResetOfficialProviderPricingOnUpgrade resets official DeepSeek prices to
-// the current built-in RMB defaults once for desktop upgrades. It intentionally
-// runs from the desktop app startup path, not every config Load(), so user edits
-// made after the upgrade are preserved.
-func ResetOfficialProviderPricingOnUpgrade(path string) (bool, error) {
+const (
+	deepSeekPricingResetConfigVersion      = 3
+	windowsBashSandboxDefaultConfigVersion = 4
+)
+
+// ApplyUserConfigUpgradesOnStartup applies one-time desktop startup migrations.
+// It intentionally runs from the desktop app startup path, not every config
+// Load(), so user edits made after the upgrade are preserved.
+func ApplyUserConfigUpgradesOnStartup(path string) (bool, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return false, nil
@@ -159,12 +163,47 @@ func ResetOfficialProviderPricingOnUpgrade(path string) (bool, error) {
 		return false, nil
 	}
 	cfg := LoadForEdit(path)
-	resetOfficialProviderPricingDefaults(cfg)
+	changed := false
+	if header.ConfigVersion < deepSeekPricingResetConfigVersion {
+		resetOfficialProviderPricingDefaults(cfg)
+		changed = true
+	}
+	if shouldMarkWindowsBashSandboxDefaultUpgrade(header.ConfigVersion) {
+		if resetWindowsBashSandboxDefaultOnUpgrade(cfg) {
+			changed = true
+		}
+		// Mark the Windows v4 migration even when the user was already on off,
+		// so a later manual enforce choice is not treated as the old template default.
+		changed = true
+	}
+	if !changed {
+		return false, nil
+	}
 	cfg.ConfigVersion = Default().ConfigVersion
 	if err := cfg.SaveTo(path); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// ResetOfficialProviderPricingOnUpgrade is retained for older call sites.
+func ResetOfficialProviderPricingOnUpgrade(path string) (bool, error) {
+	return ApplyUserConfigUpgradesOnStartup(path)
+}
+
+func shouldMarkWindowsBashSandboxDefaultUpgrade(fromVersion int) bool {
+	return runtimeGOOS == "windows" && fromVersion < windowsBashSandboxDefaultConfigVersion
+}
+
+func resetWindowsBashSandboxDefaultOnUpgrade(c *Config) bool {
+	if c == nil {
+		return false
+	}
+	if strings.TrimSpace(c.Sandbox.Bash) != "enforce" {
+		return false
+	}
+	c.Sandbox.Bash = "off"
+	return true
 }
 
 func resetOfficialProviderPricingDefaults(c *Config) {

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -141,8 +141,8 @@ const (
 	windowsBashSandboxDefaultConfigVersion = 4
 )
 
-// ApplyUserConfigUpgradesOnStartup applies one-time desktop startup migrations.
-// It intentionally runs from the desktop app startup path, not every config
+// ApplyUserConfigUpgradesOnStartup applies one-time startup migrations. It
+// intentionally runs from the desktop and CLI startup paths, not every config
 // Load(), so user edits made after the upgrade are preserved.
 func ApplyUserConfigUpgradesOnStartup(path string) (bool, error) {
 	path = strings.TrimSpace(path)
@@ -193,15 +193,14 @@ func shouldMarkWindowsBashSandboxDefaultUpgrade(fromVersion int) bool {
 	return runtimeGOOS == "windows" && fromVersion < windowsBashSandboxDefaultConfigVersion
 }
 
-func resetWindowsBashSandboxDefaultOnUpgrade(c *Config) bool {
+func resetWindowsBashSandboxDefaultOnUpgrade(c *Config) {
 	if c == nil {
-		return false
+		return
 	}
 	if strings.TrimSpace(c.Sandbox.Bash) != "enforce" {
-		return false
+		return
 	}
 	c.Sandbox.Bash = "off"
-	return true
 }
 
 func resetOfficialProviderPricingDefaults(c *Config) {

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -169,9 +169,7 @@ func ApplyUserConfigUpgradesOnStartup(path string) (bool, error) {
 		changed = true
 	}
 	if shouldMarkWindowsBashSandboxDefaultUpgrade(header.ConfigVersion) {
-		if resetWindowsBashSandboxDefaultOnUpgrade(cfg) {
-			changed = true
-		}
+		resetWindowsBashSandboxDefaultOnUpgrade(cfg)
 		// Mark the Windows v4 migration even when the user was already on off,
 		// so a later manual enforce choice is not treated as the old template default.
 		changed = true

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -1030,7 +1030,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		if len(c.Sandbox.AllowWrite) > 0 {
 			fmt.Fprintf(&b, "allow_write = %s\n", renderStringArray(c.Sandbox.AllowWrite))
 		}
-		if strings.TrimSpace(c.Sandbox.Bash) != "" || c.BashMode() != d.BashMode() {
+		// Only an explicitly set bash mode is a project delta; an empty value
+		// inherits the platform default.
+		if strings.TrimSpace(c.Sandbox.Bash) != "" {
 			fmt.Fprintf(&b, "bash = %q\n", c.BashMode())
 		}
 		if c.Sandbox.Network != d.Sandbox.Network {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -434,9 +434,10 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	b.WriteString("[sandbox]\n")
 	b.WriteString("# Confine tool blast radius. File-writers (write_file/edit_file/multi_edit/move_file)\n")
 	b.WriteString("# may only write under workspace_root (empty = current dir) and allow_write extras.\n")
-	b.WriteString("# bash = \"enforce\" (default) jails each command in an OS sandbox when\n")
-	b.WriteString("# available; without one, bash execution is refused. Set bash = \"off\" to restore\n")
-	b.WriteString("# pre-1.16 unconfined shell execution. network allows sandboxed bash egress.\n")
+	b.WriteString("# bash = \"enforce\" jails each command in an OS sandbox when available;\n")
+	b.WriteString("# without one, bash execution is refused. Empty defaults to enforce on macOS/Linux\n")
+	b.WriteString("# and off on Windows. Set bash = \"off\" to restore pre-1.16 unconfined shell execution.\n")
+	b.WriteString("# network allows sandboxed bash egress.\n")
 	if c.Sandbox.WorkspaceRoot != "" {
 		fmt.Fprintf(&b, "workspace_root = %q\n", c.Sandbox.WorkspaceRoot)
 	} else {
@@ -1029,7 +1030,7 @@ func RenderTOMLProjectDelta(c *Config) string {
 		if len(c.Sandbox.AllowWrite) > 0 {
 			fmt.Fprintf(&b, "allow_write = %s\n", renderStringArray(c.Sandbox.AllowWrite))
 		}
-		if c.BashMode() != "enforce" {
+		if strings.TrimSpace(c.Sandbox.Bash) != "" || c.BashMode() != d.BashMode() {
 			fmt.Fprintf(&b, "bash = %q\n", c.BashMode())
 		}
 		if c.Sandbox.Network != d.Sandbox.Network {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -22,6 +22,17 @@ func isolateUserConfigHome(t *testing.T) string {
 	return home
 }
 
+// setRuntimeGOOS overrides the package-level runtimeGOOS for one test. The
+// t.Setenv call is a guard: it panics if the test also uses t.Parallel, which
+// would otherwise race on the shared global.
+func setRuntimeGOOS(t *testing.T, goos string) {
+	t.Helper()
+	t.Setenv("REASONIX_TEST_GOOS", goos)
+	old := runtimeGOOS
+	runtimeGOOS = goos
+	t.Cleanup(func() { runtimeGOOS = old })
+}
+
 func expectedDefaultReasonixHome(home string) string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(home, "AppData", "Roaming", "reasonix")
@@ -1003,9 +1014,7 @@ func TestRenderTOMLDefaultStepsCommentedOut(t *testing.T) {
 
 func TestRenderTOMLWindowsSandboxDefaultAndExplicitEnforce(t *testing.T) {
 	isolateUserConfigHome(t)
-	oldGOOS := runtimeGOOS
-	runtimeGOOS = "windows"
-	defer func() { runtimeGOOS = oldGOOS }()
+	setRuntimeGOOS(t, "windows")
 
 	defaultRendered := RenderTOMLForScope(Default(), RenderScopeUser)
 	if !strings.Contains(defaultRendered, `bash    = "off"`) {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -251,8 +251,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.DefaultModel != "mimo-pro" {
 		t.Errorf("default_model = %q, want mimo-pro", got.DefaultModel)
 	}
-	if got.ConfigVersion != 3 {
-		t.Errorf("config_version = %d, want 3", got.ConfigVersion)
+	if got.ConfigVersion != 4 {
+		t.Errorf("config_version = %d, want 4", got.ConfigVersion)
 	}
 	if got.Language != "zh" {
 		t.Errorf("language = %q, want zh", got.Language)
@@ -575,7 +575,7 @@ func TestRenderTOMLCreationLayoutStyle(t *testing.T) {
 
 func TestScopedRenderPreservesLSPConfig(t *testing.T) {
 	const src = `
-config_version = 3
+config_version = 4
 default_model = "mimo"
 
 [lsp]
@@ -699,7 +699,7 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c.Desktop.CheckUpdates = boolPtr(false)
 
 	user := RenderTOMLForScope(c, RenderScopeUser)
-	for _, want := range []string{"config_version = 3", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `default_tool_approval_mode = "auto"`, `check_updates = false`, "[notifications]", "[tools.shell]"} {
+	for _, want := range []string{"config_version = 4", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `default_tool_approval_mode = "auto"`, `check_updates = false`, "[notifications]", "[tools.shell]"} {
 		if !strings.Contains(user, want) {
 			t.Fatalf("user render missing %q:\n%s", want, user)
 		}
@@ -998,6 +998,25 @@ func TestRenderTOMLDefaultStepsCommentedOut(t *testing.T) {
 				t.Errorf("default planner_max_steps should be commented out in [agent], got: %s", line)
 			}
 		}
+	}
+}
+
+func TestRenderTOMLWindowsSandboxDefaultAndExplicitEnforce(t *testing.T) {
+	isolateUserConfigHome(t)
+	oldGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = oldGOOS }()
+
+	defaultRendered := RenderTOMLForScope(Default(), RenderScopeUser)
+	if !strings.Contains(defaultRendered, `bash    = "off"`) {
+		t.Fatalf("Windows default user config should render bash off:\n%s", defaultRendered)
+	}
+
+	cfg := Default()
+	cfg.Sandbox.Bash = "enforce"
+	delta := RenderTOMLProjectDelta(cfg)
+	if !strings.Contains(delta, `bash = "enforce"`) {
+		t.Fatalf("Windows explicit enforce should be rendered as a delta:\n%s", delta)
 	}
 }
 

--- a/internal/config/sandbox_test.go
+++ b/internal/config/sandbox_test.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+func TestBashModeWindowsDefaultOffButExplicitEnforceWins(t *testing.T) {
+	cfg := Default()
+	if got := cfg.BashModeForGOOS("windows"); got != "off" {
+		t.Fatalf("empty Windows bash mode = %q, want off", got)
+	}
+
+	cfg.Sandbox.Bash = "enforce"
+	if got := cfg.BashModeForGOOS("windows"); got != "enforce" {
+		t.Fatalf("explicit Windows bash mode = %q, want enforce", got)
+	}
+
+	cfg.Sandbox.Bash = ""
+	if got := cfg.BashModeForGOOS("darwin"); got != "enforce" {
+		t.Fatalf("empty Darwin bash mode = %q, want enforce", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Default empty Bash sandbox mode to off on Windows while keeping macOS/Linux defaults enforced.
- Add a one-time Windows v3-to-v4 startup migration that rewrites old template `bash = "enforce"` to `off`, then preserves any later manual enforce choice.
- Surface the effective Bash sandbox mode in desktop settings and update config-version/rendering tests.
- Run the same one-time upgrade from CLI startup (`migrateLegacyConfigForCLI`), so Windows CLI-only users get the enforce-to-off migration without ever launching the desktop app. The upgrade is config_version-gated, so desktop and CLI never double-apply it; metadata commands (`version`/`help`) still leave the config untouched. Note: this also extends the pre-v3 DeepSeek official-pricing reset to CLI startup (previously desktop-only).
- Review cleanups: drop the dead `BashMode` comparison in the project delta render, drop the unused bool return of the migration helper, and add a `setRuntimeGOOS` test helper whose `t.Setenv` guard panics under `t.Parallel`, keeping the package-global GOOS override race-free.

## Known tradeoff

The old config template always wrote `bash = "enforce"` explicitly, so the migration cannot distinguish the template default from a deliberate pre-v4 enforce choice on Windows; both are rewritten to `off` once. Any enforce set after the migration is preserved.

## Validation

- `go test ./internal/config ./internal/cli`
- `cd desktop && go test ./...`
- `go vet ./internal/config ./internal/cli` and `GOOS=windows go build ./...` (root and desktop modules)

Cache-impact: low - config default/version and desktop/CLI startup migration only; no provider-visible prompt text, tool schema, or tool ordering changes.
Cache-guard: scripts/check-cache-impact.sh plus focused config/CLI/desktop tests listed above.
System-prompt-review: reviewed internal/config/config.go changes; DefaultSystemPrompt and LanguagePolicy text are unchanged.