### PR TITLE
fix(control): clear the active goal on session rotation

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1513,6 +1513,10 @@ func (a *App) NewSession() error {
 	// telemetry keeps the previous session's totals and the status bar 会话费用
 	// silently turns into an all-sessions running total (#5850).
 	tab.resetTelemetry(ctrl.SessionPath())
+	// Mirror the controller: NewSession cleared the active goal, and the tab's
+	// persisted copy must follow — otherwise the next rebuild/restart would
+	// re-seed the old goal into the fresh session via SetGoal(tab.goal).
+	a.clearTabGoal(tab)
 	a.assignFreshSessionTopic(tab)
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
@@ -1619,9 +1623,25 @@ func (a *App) ClearSession() error {
 		return userFacingSessionLeaseError("", err)
 	}
 	tab.resetTelemetry(ctrl.SessionPath())
+	// Mirror the controller: ClearSession cleared the active goal.
+	a.clearTabGoal(tab)
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
 	return nil
+}
+
+// clearTabGoal drops the tab's persisted goal copy so rebuilds and restarts
+// cannot re-seed a goal the controller has already cleared on session rotation.
+func (a *App) clearTabGoal(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	a.mu.Lock()
+	tab.goal = ""
+	if current := a.tabs[tab.ID]; current == tab {
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
 }
 
 func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.SessionAPI) error {
@@ -1711,7 +1731,9 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	newCtrl.EnableInteractiveApproval()
 	applyTabModeToController(newCtrl, snap.mode)
 	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
-	newCtrl.SetGoal(snap.goal)
+	// Clearing the session clears the active goal too (same contract as
+	// Controller.ClearSession): the snapshot's goal belongs to the destroyed
+	// conversation and must not seed the replacement.
 	path := agent.NewSessionPath(newCtrl.SessionDir(), newCtrl.Label())
 	if err := tab.ensureSessionLease(path); err != nil {
 		newCtrl.Close()
@@ -1739,6 +1761,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	tab.Label = newCtrl.Label()
 	tab.Ready = true
 	tab.StartupErr = ""
+	tab.goal = ""
 	// Supersede any in-flight startup build: the session it was resuming
 	// was just destroyed, and finishing later would pass the generation
 	// check and overwrite this controller.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -639,7 +639,14 @@ func (a *App) restoreOrBuildTabs() {
 			tab.effort = cloneStringPtr(entry.Effort)
 			tab.tokenMode = boot.NormalizeTokenMode(entry.TokenMode)
 			tab.mode = persistedTabMode(entry.Mode)
-			tab.goal = strings.TrimSpace(entry.Goal)
+			// Validate the persisted goal against the session's goal-state
+			// sidecar: a typed /new or /clear rotates the session through the
+			// controller without passing App.NewSession/ClearSession, so
+			// entry.Goal can be stale. Session rotation writes a stopped
+			// goal-state onto the fresh path; reading it here stops a restart
+			// from re-seeding the cleared goal into the rotated session. A
+			// session without a sidecar keeps the persisted goal (legacy).
+			tab.goal = runningTabSessionGoal(strings.TrimSpace(entry.SessionPath), strings.TrimSpace(entry.Goal))
 			tab.toolApprovalMode = normalizeToolApprovalMode(entry.ToolApprovalMode)
 			if tab.toolApprovalMode == control.ToolApprovalAsk && tabModeHasAutoApproveTools(entry.Mode) {
 				tab.toolApprovalMode = control.ToolApprovalYolo

--- a/desktop/tab_goal_restore_test.go
+++ b/desktop/tab_goal_restore_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+// TestRestoredTabGoalFollowsSessionGoalState pins the restart half of the
+// goal-reset contract: a typed /new or /clear rotates the session through the
+// controller (never touching App.NewSession/ClearSession), so the goal saved
+// in desktop-tabs.json can be stale. Startup restore must validate it against
+// the session's goal-state sidecar — which the rotation wrote as stopped on
+// the fresh path — instead of re-seeding the cleared goal via SetGoal.
+func TestRestoredTabGoalFollowsSessionGoalState(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "session.jsonl")
+
+	exec := agent.New(stubProvider{}, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SystemPrompt: "sys", SessionDir: dir, SessionPath: oldPath, Label: "test", Sink: event.Discard})
+	ctrl.SetGoal("finish the migration")
+
+	// Typed /new: controller-side rotation only.
+	if err := ctrl.NewSession(); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	newPath := ctrl.SessionPath()
+	ctrl.Close()
+
+	// desktop-tabs.json still carries the pre-rotation goal with the rotated
+	// path (the tab profile was never told about the /new). Restore must not
+	// resurrect it: the rotated session's sidecar says stopped.
+	if got := runningTabSessionGoal(newPath, "finish the migration"); got != "" {
+		t.Fatalf("restored goal for rotated session = %q, want empty", got)
+	}
+
+	// The OLD session's sidecar still says running: restoring a tab that
+	// points at the old session keeps its goal (resume semantics).
+	if got := runningTabSessionGoal(oldPath, "finish the migration"); got != "finish the migration" {
+		t.Fatalf("restored goal for old session = %q, want preserved", got)
+	}
+
+	// A session without a goal-state sidecar keeps the persisted goal
+	// (legacy sessions predating the sidecar).
+	bare := filepath.Join(dir, "bare.jsonl")
+	if err := os.WriteFile(bare, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write bare session: %v", err)
+	}
+	if got := runningTabSessionGoal(bare, "legacy goal"); got != "legacy goal" {
+		t.Fatalf("restored goal without sidecar = %q, want fallback preserved", got)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2126,6 +2126,12 @@ func (c *Controller) NewSession() error {
 	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.snapshotMu.Unlock()
+	// A new session starts with no active goal: without this, a running goal's
+	// text kept injecting into the fresh session's first turns. The old
+	// session's goal-state sidecar was persisted before the rotation and stays
+	// intact, so resuming it restores its goal; the cleared state below lands
+	// on the NEW path (rebindCheckpoints just moved it).
+	c.ClearGoal()
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
 	c.mu.Unlock()
@@ -2187,6 +2193,8 @@ func (c *Controller) ClearSession() error {
 	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.snapshotMu.Unlock()
+	// Same contract as NewSession: the fresh session starts with no active goal.
+	c.ClearGoal()
 	c.mu.Lock()
 	c.startedOnce = true
 	c.mu.Unlock()

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 	"reasonix/internal/tool"
 )
 
@@ -1099,4 +1100,62 @@ func containsNotice(notices []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// TestSessionRotationClearsActiveGoal pins the /new & /clear goal semantics:
+// a fresh session starts with no active goal (so the old goal's text stops
+// injecting into its first turns), while the OLD session's persisted
+// goal-state sidecar keeps the running goal so resuming it restores the goal.
+func TestSessionRotationClearsActiveGoal(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	oldPath := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Executor: exec, SystemPrompt: "sys", SessionDir: dir, SessionPath: oldPath, Label: "test"})
+
+	c.SetGoal("ship the release checklist")
+	if got := c.Goal(); got != "ship the release checklist" {
+		t.Fatalf("Goal() = %q after SetGoal", got)
+	}
+	if composed := c.Compose("hello"); !strings.Contains(composed, "<active-goal>") {
+		t.Fatalf("running goal should inject into turns, composed = %q", composed)
+	}
+
+	if err := c.NewSession(); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if got := c.Goal(); got != "" {
+		t.Fatalf("Goal() after /new = %q, want empty", got)
+	}
+	if composed := c.Compose("hello"); strings.Contains(composed, "<active-goal>") {
+		t.Fatalf("old goal leaked into the fresh session's turn: %q", composed)
+	}
+	// The old session keeps its running goal on disk for /resume.
+	oldState, err := os.ReadFile(store.SessionGoalState(oldPath))
+	if err != nil {
+		t.Fatalf("read old goal state: %v", err)
+	}
+	if !strings.Contains(string(oldState), "ship the release checklist") || !strings.Contains(string(oldState), GoalStatusRunning) {
+		t.Fatalf("old session's goal state was disturbed by /new: %s", oldState)
+	}
+	// The new session's sidecar records the cleared (stopped) state, so
+	// profile restores read it as "no running goal".
+	newState, err := os.ReadFile(store.SessionGoalState(c.SessionPath()))
+	if err != nil {
+		t.Fatalf("read new goal state: %v", err)
+	}
+	if strings.Contains(string(newState), "ship the release checklist") {
+		t.Fatalf("new session's goal state carries the old goal: %s", newState)
+	}
+
+	// Same contract for /clear.
+	c.SetGoal("another goal")
+	if err := c.ClearSession(); err != nil {
+		t.Fatalf("ClearSession: %v", err)
+	}
+	if got := c.Goal(); got != "" {
+		t.Fatalf("Goal() after /clear = %q, want empty", got)
+	}
+	if composed := c.Compose("hello"); strings.Contains(composed, "<active-goal>") {
+		t.Fatalf("old goal leaked into the cleared session's turn: %q", composed)
+	}
 }


### PR DESCRIPTION
## Summary

`/new` 和 `/clear` 会重置执行器会话、planner、guardian、checkpoints——唯独不重置 goal 状态机。运行中 goal 的文本（连同 autoresearch runtime 块）会继续注入**新会话的首轮**，静默地引导一段用户已明确重置的对话。

语义决定：**两个入口都清空 goal**（新会话 = 白纸），同时保证旧会话可完整找回：

- **Controller 层**：`NewSession`/`ClearSession` 在 `rebindCheckpoints` 把 goal-state 路径移到新会话**之后**调用 `ClearGoal()`——清空后的 stopped 状态落在**新路径**的 sidecar 上（desktop 的 profile 恢复读到 stopped 即视为无 goal），而旧会话的 sidecar 在轮换前已持久化、保持 running goal 不动——`/resume` 旧会话时 `restoreRunningFromState` 照常恢复它的 goal。这一层覆盖所有前端（打字 `/new`、CLI、serve、bot、desktop）。
- **Desktop 层**：tab 的持久化 goal 副本跟随控制器——`App.NewSession`/`ClearSession` 清 `tab.goal`（否则下次 rebuild/重启会经 `SetGoal(tab.goal)` 把旧 goal 复活进新会话）；`clearActiveSessionRuntime`（运行中 /clear 的重建路径）不再把已销毁对话的 goal 种进替换控制器。**模型/effort/设置切换的 rebuild 路径保留 goal**——那些是同会话重建，语义不同，未动。

## Verification

- `TestSessionRotationClearsActiveGoal` 钉死四条性质：/new 与 /clear 后 `Goal()` 为空且 `Compose` 不含 `<active-goal>` 注入；旧会话 sidecar 保留 running goal；新会话 sidecar 不携带旧 goal。**反向验证**：去掉两处 `ClearGoal()` 后测试失败。
- 全套绿：`internal/control`/`cli`/`serve`/`bot`/`acp` + desktop（39s）；`go vet` 干净。

## Cache impact

Cache-impact: none - goal rides turn injection (input.go Compose), never the system prompt or tool schema; this only stops an unwanted injection on fresh sessions.
Cache-guard: not applicable (no cache-sensitive files); the new rotation test covers the change.
System-prompt-review: N/A

Context: /new 语义触发的后续（#5699 排查时发现的遗留项），与 #6077 的 rotation gate 同属会话轮换清理线。