### PR TITLE
ci(release): catch missing stable npm tags without failing in-flight publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,3 +122,38 @@ jobs:
           done
           echo "::error::public compatibility manifest unreachable at $url"
           exit 1
+
+      # A stable CLI release must never leave the npm `latest` dist-tag behind:
+      # v1.17.5 shipped as binaries/Homebrew while npm `latest` still pointed at
+      # 0.53.2 (#5822) — every `npm update -g` user was silently downgraded to a
+      # months-old version, and nothing noticed because the npm line
+      # (release-npm.yml, `npm-vX.Y.Z` tags) is triggered independently and the
+      # stable npm tag was simply never pushed. release-npm.yml's own verify
+      # step only guards runs that happen; this guard catches the run that
+      # DIDN'T. It fails the stable CLI release when npm `latest` is older than
+      # the version being released — the fix is pushing the matching
+      # `npm-vX.Y.Z` tag (or `npm dist-tag add` for an already-published
+      # version).
+      - name: Check npm latest dist-tag freshness
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            *-*)
+              echo "prerelease $TAG — npm latest does not move on prereleases; skipping"
+              exit 0
+              ;;
+          esac
+          version="${TAG#v}"
+          got="$(npm view reasonix dist-tags.latest 2>/dev/null || true)"
+          if [ -z "$got" ]; then
+            echo "::error::could not read npm dist-tags.latest"
+            exit 1
+          fi
+          newest="$(printf '%s\n%s\n' "$got" "$version" | sort -V | tail -1)"
+          if [ "$newest" != "$got" ]; then
+            echo "::error::npm 'latest' is $got but this stable release is $version — npm users running 'npm update -g' are being downgraded. Push the npm-v$version tag (or 'npm dist-tag add reasonix@$version latest')."
+            exit 1
+          fi
+          echo "npm latest -> $got (>= $version) OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,17 +123,24 @@ jobs:
           echo "::error::public compatibility manifest unreachable at $url"
           exit 1
 
-      # A stable CLI release must never leave the npm `latest` dist-tag behind:
-      # v1.17.5 shipped as binaries/Homebrew while npm `latest` still pointed at
-      # 0.53.2 (#5822) — every `npm update -g` user was silently downgraded to a
+      # A stable CLI release must never leave the npm line behind: v1.17.5
+      # shipped as binaries/Homebrew while npm `latest` still pointed at 0.53.2
+      # (#5822) — every `npm update -g` user was silently downgraded to a
       # months-old version, and nothing noticed because the npm line
       # (release-npm.yml, `npm-vX.Y.Z` tags) is triggered independently and the
       # stable npm tag was simply never pushed. release-npm.yml's own verify
       # step only guards runs that happen; this guard catches the run that
-      # DIDN'T. It fails the stable CLI release when npm `latest` is older than
-      # the version being released — the fix is pushing the matching
-      # `npm-vX.Y.Z` tag (or `npm dist-tag add` for an already-published
-      # version).
+      # DIDN'T.
+      #
+      # Two distinct states, two responses (the runs race: both workflows wait
+      # on the release environment independently, and npm dist-tags propagate
+      # asynchronously, so "tag pushed but latest not moved yet" is a NORMAL
+      # mid-release state, not a failure):
+      #   - npm-v<version> tag missing  -> hard fail. This is the #5822 gap:
+      #     nobody pushed the npm release at all.
+      #   - tag pushed, latest lagging  -> poll briefly, then WARN and pass.
+      #     The npm run may still be awaiting its own environment approval;
+      #     release-npm.yml's verify step owns asserting the dist-tag lands.
       - name: Check npm latest dist-tag freshness
         env:
           TAG: ${{ github.ref_name }}
@@ -146,14 +153,21 @@ jobs:
               ;;
           esac
           version="${TAG#v}"
-          got="$(npm view reasonix dist-tags.latest 2>/dev/null || true)"
-          if [ -z "$got" ]; then
-            echo "::error::could not read npm dist-tags.latest"
+          if ! git ls-remote --exit-code origin "refs/tags/npm-v$version" >/dev/null; then
+            echo "::error::the npm-v$version tag was never pushed — the npm channel is being left behind and 'npm update -g' users will be downgraded to the old 'latest'. Push it: git tag npm-v$version ${TAG} && git push origin npm-v$version (or 'npm dist-tag add reasonix@$version latest' for an already-published version)."
             exit 1
           fi
-          newest="$(printf '%s\n%s\n' "$got" "$version" | sort -V | tail -1)"
-          if [ "$newest" != "$got" ]; then
-            echo "::error::npm 'latest' is $got but this stable release is $version — npm users running 'npm update -g' are being downgraded. Push the npm-v$version tag (or 'npm dist-tag add reasonix@$version latest')."
-            exit 1
-          fi
-          echo "npm latest -> $got (>= $version) OK"
+          for attempt in 1 2 3 4 5 6; do
+            got="$(npm view reasonix dist-tags.latest 2>/dev/null || true)"
+            if [ -n "$got" ]; then
+              newest="$(printf '%s\n%s\n' "$got" "$version" | sort -V | tail -1)"
+              if [ "$newest" = "$got" ]; then
+                echo "npm latest -> $got (>= $version) OK"
+                exit 0
+              fi
+            fi
+            echo "npm latest -> ${got:-<unreadable>}, want >= $version (attempt $attempt)"
+            sleep 10
+          done
+          echo "::warning::npm-v$version is pushed but npm 'latest' is still ${got:-<unreadable>} — the npm publish run is likely awaiting release-environment approval or still propagating. Approve/monitor the release-npm run; its verify step asserts the dist-tag lands."
+          exit 0

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -11,7 +11,7 @@ changed and how to move over.
 | Language | TypeScript / Node | Go |
 | Branch | [`v1`](https://github.com/esengine/DeepSeek-Reasonix/tree/v1) (maintenance only) | `main-v2` (default, active) |
 | Versions | `0.x` (up to v0.54.x) | `1.0.0`+ |
-| Install | `npm i -g reasonix` (the `latest` tag, stays on `0.x`) | `npm i -g reasonix@next` — `latest` deliberately stays on `0.x`; or a release archive / `go build` |
+| Install | `npm i -g reasonix@0.53.2` (pin a `0.x` version) | `npm i -g reasonix` — `latest` points at the current `1.x` stable; or a release archive / `go build` |
 | Code intelligence | embedding semantic search + tree-sitter symbols | LSP-assisted code reading plus grep/read_file/glob; semantic index is not yet ported |
 
 "v1" and "v2" are **codebase generations**, not semver: the v1 line never reached
@@ -23,18 +23,17 @@ changed and how to move over.
 same way esbuild/biome ship native binaries via npm). The binary itself is a
 standalone Go executable; npm is only the installer, not a runtime dependency.
 
-**`npm i -g reasonix` deliberately still installs `0.x`.** A bare install — and
-`npx reasonix`, and 0.53's own `update` — follows npm's `latest` tag, which we
-keep pinned to the `0.x` line so existing users aren't pulled into the rewrite
-without asking. v1.x (Go) ships under the `next` tag; opt in explicitly:
+**`npm i -g reasonix` installs the current `1.x` stable.** npm's `latest` tag
+moved to the Go line with `1.17.5` — the earlier "`latest` stays pinned to
+`0.x`" migration guard silently downgraded `npm update -g` users once 1.x went
+stable (#5822), so it was retired. Release candidates still ship under the
+`next` tag; `0.x` stays installable by pinning:
 
 ```sh
-npm i -g reasonix@next     # or pin a version: reasonix@1.1.0
-reasonix
+npm i -g reasonix          # current 1.x stable
+npm i -g reasonix@next     # release candidate, when one is ahead of stable
+npm i -g reasonix@0.53.2   # pin the legacy TS build
 ```
-
-`latest` will stay on `0.x` for the foreseeable future, so installing or
-updating v2 always means `@next` (or a pinned `1.x`).
 
 Prebuilt archives (`reasonix-<os>-<arch>.tar.gz` / `.zip`) and the desktop
 installer are attached to each GitHub release. These are a **separate channel**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,7 +17,7 @@ provides the pre-release buffer instead of a long-lived branch.
 
 | Surface | Stable | Pre-release buffer |
 |---|---|---|
-| npm | `latest` (0.x), `next` (1.x) | `canary` (`npm i reasonix@canary`) |
+| npm | `latest` (current 1.x stable) | `next` (rc), `canary` (`npm i reasonix@canary`) |
 | Desktop | R2 `latest/` pointer + release gateway | R2 `canary/` pointer + release gateway proxy (never on the GitHub releases page) |
 
 A canary build is isolated: it **never** moves `latest` / `next` / desktop `latest/`.
@@ -53,15 +53,16 @@ the `release` environment deployment.
 5. **Ship stable** when the canary is clean — push the three tags:
    ```sh
    git tag v1.4.0         && git push origin v1.4.0          # CLI binaries + Homebrew
-   git tag npm-v1.4.0     && git push origin npm-v1.4.0      # npm -> next
+   git tag npm-v1.4.0     && git push origin npm-v1.4.0      # npm -> latest
    git tag desktop-v1.4.0 && git push origin desktop-v1.4.0  # desktop -> R2 latest/
    ```
    Each stable run **waits for esengine to approve the `release` environment** before publishing.
-6. **Promote to default install** (optional, when 1.x should become the bare `npm i` target):
-   ```sh
-   npm dist-tag add reasonix@1.4.0 latest
-   ```
-7. **Next cycle** — the canary rolls on toward `1.5.0`.
+   A stable `npm-v*` publish moves the `latest` dist-tag automatically (build.mjs)
+   and release-npm.yml verifies it landed. **Do not skip the npm tag**: the stable
+   CLI release (release.yml) fails when npm `latest` lags behind the version being
+   released — that guard exists because 1.0.0–1.17.5 shipped without stable npm
+   tags and `npm update -g` silently downgraded users to 0.53.2 (#5822).
+6. **Next cycle** — the canary rolls on toward `1.5.0`.
 
 ## Notes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,9 +59,11 @@ the `release` environment deployment.
    Each stable run **waits for esengine to approve the `release` environment** before publishing.
    A stable `npm-v*` publish moves the `latest` dist-tag automatically (build.mjs)
    and release-npm.yml verifies it landed. **Do not skip the npm tag**: the stable
-   CLI release (release.yml) fails when npm `latest` lags behind the version being
-   released — that guard exists because 1.0.0–1.17.5 shipped without stable npm
-   tags and `npm update -g` silently downgraded users to 0.53.2 (#5822).
+   CLI release (release.yml) fails when the matching `npm-v*` tag was never pushed
+   — that guard exists because 1.0.0–1.17.5 shipped without stable npm tags and
+   `npm update -g` silently downgraded users to 0.53.2 (#5822). A pushed tag whose
+   publish is still awaiting approval only warns; release-npm.yml's verify step
+   owns asserting the dist-tag lands.
 6. **Next cycle** — the canary rolls on toward `1.5.0`.
 
 ## Notes


### PR DESCRIPTION
## Summary

#5822 的流程性根因修复。排查结论：

- npm `latest` 卡在 0.53.2 的直接原因：**1.0.0 到 1.17.5 从未发过一个稳定版 npm tag**——所有 `npm-v*` tag 全是 `-rc.1`，按 build.mjs 的规则发到 `next`。`latest` 不是"没被 promote"，是稳定版 npm 发布这一步在发版流程里整个缺失。
- 此前为 #5822 加的两道防线都防不住这个：build.mjs 的自动 dist-tag 规则和 release-npm.yml 的 verify 步骤**只对发生了的 run 生效**——npm tag 根本没推，run 就不存在。

**立即止血（已执行）**：推了 `npm-v1.17.5` tag（指向与 `v1.17.5` 相同的 commit `221a764`），release-npm.yml 走 build.mjs 的稳定版路径，已发布 1.17.5 并把 `latest` 从 0.53.2 移过去；workflow 自带的 verify 步骤已断言 tag 落位。

**流程防线（本 PR）**：在稳定版 CLI 发布（release.yml，`v*` 非预发布）末尾加 npm 渠道守门：

- 先检查匹配的 `npm-v<version>` tag 是否存在；不存在时 hard fail，并给出补救命令。这覆盖 #5822 的真正缺口：稳定版 npm tag 根本没推，release-npm.yml 的 verify run 不会发生。
- 如果 `npm-v<version>` tag 已推，但 npm `latest` 仍低于本次版本，则短轮询后只 warning 放行。这个状态可能只是 npm workflow 仍在等待 `release` environment 审批、发布中，或 registry dist-tag 尚未传播；最终落位由 release-npm.yml 自己的 verify step 断言。
- 预发布跳过；`latest` 等于或高于本次 tag 则通过。

## Verification

- YAML 解析通过；本地验证了 tag 缺失分支会失败，tag 已存在时 stale/equal/newer 三种 dist-tag 比较行为符合预期。
- `npm view reasonix dist-tags` 已显示 `latest: 1.17.5`；止血发布完成。

## Cache impact

Cache-impact: none - release workflow only; no runtime code.
Cache-guard: not applicable.
System-prompt-review: N/A

Fixes #5822.