### PR TITLE
Migrate diagnostic sidecars through overlong-name reconciliation / 超长名整理时迁移诊断 sidecar

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -31,6 +31,7 @@ import (
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/store"
 	"reasonix/internal/tool"
 )
 
@@ -114,14 +115,24 @@ func isolateDesktopUserDirs(t *testing.T) string {
 func primarySessionFiles(paths []string) []string {
 	out := make([]string, 0, len(paths))
 	for _, path := range paths {
-		base := filepath.Base(path)
-		if strings.HasSuffix(base, ".jsonl") &&
-			!strings.HasSuffix(base, ".events.jsonl") &&
-			!strings.HasSuffix(base, ".guardian.jsonl") {
+		if store.IsSessionTranscriptName(filepath.Base(path)) {
 			out = append(out, path)
 		}
 	}
 	return out
+}
+
+func readConflictLogLines(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read conflict log: %v", err)
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
 }
 
 func setDesktopTestCredential(t *testing.T, key, value string) {
@@ -2341,6 +2352,137 @@ func TestSetEffortForTabLeaseHeldKeepsOldControllerAlive(t *testing.T) {
 	}
 	if tab.Ctrl == oldCtrl {
 		t.Fatal("retry did not rebuild the controller")
+	}
+}
+
+func TestSetEffortForTabReanchorsDepthCapRecoveryBranch(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:             "old",
+		Kind:             "openai",
+		BaseURL:          "https://example.invalid/v1",
+		Model:            "old-model",
+		APIKeyEnv:        "OLD_MODEL_KEY",
+		SupportedEfforts: []string{"low", "max"},
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	recoveryPath := filepath.Join(dir, "effort-switch-conflict-recovery-deadbeef.jsonl")
+	disk := agent.NewSession("old system prompt")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "disk second"})
+	if err := disk.Save(recoveryPath); err != nil {
+		t.Fatalf("save recovery branch: %v", err)
+	}
+	meta, ok, err := agent.LoadBranchMeta(recoveryPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	meta.Recovered = true
+	meta.ParentID = "effort-switch-conflict"
+	meta.RecoveryReason = "snapshot conflict"
+	meta.RecoveryDepth = agent.SessionRecoveryMaxDepth
+	if err := agent.SaveBranchMeta(recoveryPath, meta); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+
+	stale := agent.NewSession("old system prompt")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
+	oldExec := agent.New(nil, nil, stale, agent.Options{}, event.Discard)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.runtimeEvents.emit = func(context.Context, string, ...interface{}) {}
+	tab := &WorkspaceTab{
+		ID:          "tab_depth_cap_effort",
+		Scope:       "global",
+		SessionPath: recoveryPath,
+		Ready:       true,
+		model:       "old/old-model",
+		disabledMCP: map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	oldCtrl := control.New(control.Options{
+		Executor:            oldExec,
+		SessionDir:          dir,
+		SessionPath:         recoveryPath,
+		Label:               "old",
+		Sink:                tab.sink,
+		SessionRecoveryMeta: app.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
+	})
+	tab.Ctrl = oldCtrl
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+	stale.IncrementRewrite()
+
+	if err := app.SetEffortForTab(tab.ID, "max"); err != nil {
+		t.Fatalf("SetEffortForTab: %v", err)
+	}
+	if got := tab.Ctrl.SessionPath(); got != recoveryPath {
+		t.Fatalf("session path after effort switch = %q, want current recovery branch %q", got, recoveryPath)
+	}
+	if got := tab.currentSessionPath(); got != recoveryPath {
+		t.Fatalf("tab current session path = %q, want %q", got, recoveryPath)
+	}
+	if tab.sessionLease == nil || sessionRuntimeKey(tab.sessionLease.Path()) != sessionRuntimeKey(recoveryPath) {
+		t.Fatalf("tab lease path = %q, want %q", tab.sessionLeaseRuntimeKey(), recoveryPath)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after effort switch = %v, want only %q", matches, recoveryPath)
+	}
+
+	lines := readConflictLogLines(t, store.SessionConflictLog(recoveryPath))
+	if len(lines) != 1 {
+		t.Fatalf("conflict log lines = %v, want one depth-cap diagnostic", lines)
+	}
+	if !strings.Contains(lines[0], `"outcome":"recovery_depth_cap_force_saved"`) {
+		t.Fatalf("conflict diagnostic = %s, want depth-cap outcome", lines[0])
+	}
+	if strings.Contains(lines[0], dir) || strings.Contains(lines[0], recoveryPath) {
+		t.Fatalf("conflict diagnostic leaked local path: %s", lines[0])
+	}
+
+	if err := tab.Ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot after effort switch recovery: %v", err)
+	}
+	afterLines := readConflictLogLines(t, store.SessionConflictLog(recoveryPath))
+	if len(afterLines) != len(lines) {
+		t.Fatalf("follow-up snapshot appended conflict diagnostics: before=%v after=%v", lines, afterLines)
+	}
+	matches, err = filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery branches after snapshot: %v", err)
+	}
+	matches = primarySessionFiles(matches)
+	if len(matches) != 1 || matches[0] != recoveryPath {
+		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", matches, recoveryPath)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -147,6 +147,7 @@ func sessionTrashArtifacts(sessionPath, key string) []sessionTrashArtifact {
 		{src: store.SessionGoalState(sessionPath), name: stem + ".goal-state.json"},
 		{src: store.SessionEventLog(sessionPath), name: stem + ".events.jsonl"},
 		{src: store.SessionEventIndex(sessionPath), name: stem + ".event-index.json"},
+		{src: store.SessionConflictLog(sessionPath), name: stem + ".conflicts.jsonl"},
 		{src: sessionTelemetryPath(sessionPath), name: key + ".telemetry.json"},
 		{src: store.SessionCheckpointDir(sessionPath), name: stem + ".ckpt"},
 		{src: store.SessionJobsDir(sessionPath), name: stem + ".jobs"},

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -170,6 +170,8 @@ func TestDeleteSessionFile(t *testing.T) {
 	os.WriteFile(eventLogPath, []byte(`{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"event"}]}`+"\n"), 0o644)
 	eventIndexPath := store.SessionEventIndex(sessionPath)
 	os.WriteFile(eventIndexPath, []byte(`{"schema_version":1,"message_count":1}`), 0o644)
+	conflictLogPath := store.SessionConflictLog(sessionPath)
+	os.WriteFile(conflictLogPath, []byte(`{"outcome":"forked_recovery_branch"}`+"\n"), 0o644)
 	telemetryPath := sessionTelemetryPath(sessionPath)
 	os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644)
 	lockPath := store.SessionLockFile(sessionPath)
@@ -205,6 +207,7 @@ func TestDeleteSessionFile(t *testing.T) {
 	trashGoalPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.goal-state.json")
 	trashEventLogPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.events.jsonl")
 	trashEventIndexPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.event-index.json")
+	trashConflictLogPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.conflicts.jsonl")
 	trashTelemetryPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl.telemetry.json")
 	trashCkptDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.ckpt")
 	trashJobsDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jobs")
@@ -224,6 +227,9 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(eventIndexPath); !os.IsNotExist(err) {
 		t.Error("session event index should be removed from active sessions")
+	}
+	if _, err := os.Stat(conflictLogPath); !os.IsNotExist(err) {
+		t.Error("session conflict log should be removed from active sessions")
 	}
 	if _, err := os.Stat(telemetryPath); !os.IsNotExist(err) {
 		t.Error("session telemetry should be removed from active sessions")
@@ -257,6 +263,9 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(trashEventIndexPath); err != nil {
 		t.Fatalf("session event index should be in trash: %v", err)
+	}
+	if _, err := os.Stat(trashConflictLogPath); err != nil {
+		t.Fatalf("session conflict log should be in trash: %v", err)
 	}
 	if _, err := os.Stat(trashTelemetryPath); err != nil {
 		t.Fatalf("session telemetry should be in trash: %v", err)
@@ -493,6 +502,10 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	if err := os.WriteFile(eventIndexPath, []byte(`{"schema_version":1,"message_count":1}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	conflictLogPath := store.SessionConflictLog(sessionPath)
+	if err := os.WriteFile(conflictLogPath, []byte(`{"outcome":"forked_recovery_branch"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	telemetryPath := sessionTelemetryPath(sessionPath)
 	if err := os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644); err != nil {
 		t.Fatal(err)
@@ -537,6 +550,9 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(eventIndexPath); err != nil {
 		t.Fatalf("session event index should be restored: %v", err)
+	}
+	if _, err := os.Stat(conflictLogPath); err != nil {
+		t.Fatalf("session conflict log should be restored: %v", err)
 	}
 	if _, err := os.Stat(telemetryPath); err != nil {
 		t.Fatalf("session telemetry should be restored: %v", err)
@@ -835,6 +851,7 @@ func TestRemoveDesktopSessionArtifactsRemovesOwnedSidecars(t *testing.T) {
 		store.SessionGoalState(sessionPath),
 		store.SessionEventLog(sessionPath),
 		store.SessionEventIndex(sessionPath),
+		store.SessionConflictLog(sessionPath),
 		sessionTelemetryPath(sessionPath),
 		store.SessionLockFile(sessionPath),
 		store.SessionLeaseLock(sessionPath),
@@ -872,6 +889,7 @@ func TestRemoveDesktopSessionArtifactsRemovesOwnedSidecars(t *testing.T) {
 		store.SessionGoalState(sessionPath),
 		store.SessionEventLog(sessionPath),
 		store.SessionEventIndex(sessionPath),
+		store.SessionConflictLog(sessionPath),
 		sessionTelemetryPath(sessionPath),
 		store.SessionLockFile(sessionPath),
 		store.SessionLeaseLock(sessionPath),

--- a/internal/acp/session_files_test.go
+++ b/internal/acp/session_files_test.go
@@ -25,6 +25,9 @@ func TestDeleteSessionFilesSweepsEventLogAndSidecars(t *testing.T) {
 	if err := os.WriteFile(acpMetaPath(path), []byte("{}\n"), 0o644); err != nil {
 		t.Fatalf("write acp meta: %v", err)
 	}
+	if err := os.WriteFile(store.SessionConflictLog(path), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write conflict log: %v", err)
+	}
 
 	if err := deleteSessionFiles(path); err != nil {
 		t.Fatalf("deleteSessionFiles: %v", err)
@@ -35,6 +38,7 @@ func TestDeleteSessionFilesSweepsEventLogAndSidecars(t *testing.T) {
 		store.SessionMeta(path),
 		store.SessionEventLog(path),
 		store.SessionEventIndex(path),
+		store.SessionConflictLog(path),
 	} {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
 			t.Errorf("artifact survived delete: %s (err=%v)", p, err)

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1471,7 +1471,7 @@ func reconcileOverlongSessionFilenames(dir string) error {
 	renamed := map[string]string{} // old branch ID -> new branch ID
 	for _, e := range entries {
 		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, guardianSidecarSuffix) {
+		if e.IsDir() || !store.IsSessionTranscriptName(name) {
 			continue
 		}
 		if len(name) <= maxSessionBasenameBytes {
@@ -1595,6 +1595,9 @@ func migrateSessionSidecars(oldPath, newPath, newID string) error {
 	}
 	for _, pair := range [][2]string{
 		{store.SessionGoalState(oldPath), store.SessionGoalState(newPath)},
+		{store.SessionEventLog(oldPath), store.SessionEventLog(newPath)},
+		{store.SessionEventIndex(oldPath), store.SessionEventIndex(newPath)},
+		{store.SessionConflictLog(oldPath), store.SessionConflictLog(newPath)},
 		{store.SessionCheckpointDir(oldPath), store.SessionCheckpointDir(newPath)},
 		{store.SessionJobsDir(oldPath), store.SessionJobsDir(newPath)},
 	} {
@@ -1620,7 +1623,7 @@ func reparentSessionBranches(dir string, renamed map[string]string) error {
 	var errs []error
 	for _, e := range entries {
 		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, guardianSidecarSuffix) {
+		if e.IsDir() || !store.IsSessionTranscriptName(name) {
 			continue
 		}
 		if len(name)+len(".meta") > nameMaxBytes {

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 // touch sets a file's mtime to t. Used by the listing-order test so it
@@ -2009,4 +2010,60 @@ func readSessionEventsForTest(t *testing.T, path string) []sessionEventRecord {
 		out = append(out, rec)
 	}
 	return out
+}
+
+// TestReconcileOverlongMigratesDiagnosticSidecars pins two halves of one fix:
+// overlong-name reconciliation must skip .events.jsonl / .conflicts.jsonl
+// sidecars instead of renaming each into a fake session with fabricated meta,
+// and the owning transcript's rename must carry those sidecars along instead
+// of orphaning them under the retired stem.
+func TestReconcileOverlongMigratesDiagnosticSidecars(t *testing.T) {
+	dir := t.TempDir()
+	// 236-byte transcript name: past the 224 reconcile bound, while its
+	// .events.jsonl (243) and .conflicts.jsonl (246) still fit under 255 —
+	// exactly the window where the old suffix filter mistook them for
+	// overlong sessions.
+	id := strings.Repeat("s", 230)
+	oldPath := filepath.Join(dir, id+".jsonl")
+	content := `{"role":"system","content":"sys"}` + "\n" + `{"role":"user","content":"hello"}` + "\n"
+	if err := os.WriteFile(oldPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.SessionEventLog(oldPath),
+		[]byte(`{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"hello"}]}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.SessionConflictLog(oldPath),
+		[]byte(`{"outcome":"forked_recovery_branch"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReconcileSessionSidecars(dir); err != nil {
+		t.Fatalf("ReconcileSessionSidecars: %v", err)
+	}
+
+	newPath := filepath.Join(dir, recoveryParentStem(id)+".jsonl")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("renamed transcript missing: %v", err)
+	}
+	if _, err := os.Stat(store.SessionEventLog(newPath)); err != nil {
+		t.Fatalf("event log not migrated with the rename: %v", err)
+	}
+	if _, err := os.Stat(store.SessionConflictLog(newPath)); err != nil {
+		t.Fatalf("conflict log not migrated with the rename: %v", err)
+	}
+	for _, gone := range []string{oldPath, store.SessionEventLog(oldPath), store.SessionConflictLog(oldPath)} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Fatalf("%s still present under the retired stem (err=%v)", filepath.Base(gone), err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if store.IsSessionTranscriptName(e.Name()) && e.Name() != filepath.Base(newPath) {
+			t.Fatalf("reconcile fabricated an extra session from a sidecar: %s", e.Name())
+		}
+	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,6 +59,14 @@ func doctorSessionCommand(args []string, version string) int {
 			}
 			outPath = args[i]
 		default:
+			if v, ok := strings.CutPrefix(arg, "--out="); ok {
+				if v == "" {
+					fmt.Fprintln(os.Stderr, "error: --out requires a path")
+					return 2
+				}
+				outPath = v
+				continue
+			}
 			if strings.HasPrefix(arg, "-") {
 				fmt.Fprintf(os.Stderr, "error: unknown doctor session flag %s\n", arg)
 				return 2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -42,6 +42,10 @@ func doctorSessionCommand(args []string, version string) int {
 		switch arg {
 		case "-h", "--help":
 			fmt.Fprintln(os.Stdout, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+			fmt.Fprintln(os.Stdout, "")
+			fmt.Fprintln(os.Stdout, "Bundles the session transcript, persistence sidecars, conflict diagnostics,")
+			fmt.Fprintln(os.Stdout, "and the recovery parent chain into a zip for support. Unlike `reasonix doctor`,")
+			fmt.Fprintln(os.Stdout, "bundled transcripts are NOT redacted; share only with a trusted support channel.")
 			return 0
 		case "--zip":
 			// The subcommand currently writes a zip by default. Keep --zip as an
@@ -80,5 +84,6 @@ func doctorSessionCommand(args []string, version string) int {
 		return 1
 	}
 	fmt.Println(result.Path)
+	fmt.Fprintln(os.Stderr, "note: the bundle contains full session transcripts without redaction; share it only with a trusted support channel")
 	return 0
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,11 +5,15 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"reasonix/internal/doctor"
 )
 
 func doctorCommand(args []string, version string) int {
+	if len(args) > 0 && args[0] == "session" {
+		return doctorSessionCommand(args[1:], version)
+	}
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonOut := fs.Bool("json", false, "print diagnostics as JSON")
 	if err := fs.Parse(args); err != nil {
@@ -27,5 +31,54 @@ func doctorCommand(args []string, version string) int {
 		return 0
 	}
 	fmt.Print(doctor.RenderText(report))
+	return 0
+}
+
+func doctorSessionCommand(args []string, version string) int {
+	ref := ""
+	outPath := ""
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "-h", "--help":
+			fmt.Fprintln(os.Stdout, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+			return 0
+		case "--zip":
+			// The subcommand currently writes a zip by default. Keep --zip as an
+			// explicit, script-friendly marker so support replies can say exactly
+			// what to run.
+		case "--out":
+			i++
+			if i >= len(args) {
+				fmt.Fprintln(os.Stderr, "error: --out requires a path")
+				return 2
+			}
+			outPath = args[i]
+		default:
+			if strings.HasPrefix(arg, "-") {
+				fmt.Fprintf(os.Stderr, "error: unknown doctor session flag %s\n", arg)
+				return 2
+			}
+			if ref != "" {
+				fmt.Fprintln(os.Stderr, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+				return 2
+			}
+			ref = arg
+		}
+	}
+	if ref == "" {
+		fmt.Fprintln(os.Stderr, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+		return 2
+	}
+	result, err := doctor.WriteSessionBundle(doctor.SessionBundleOptions{
+		Version:    version,
+		SessionRef: ref,
+		OutputPath: outPath,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+	fmt.Println(result.Path)
 	return 0
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -80,3 +80,27 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 	return string(data)
 }
+
+func TestDoctorSessionCommandOutEqualsForm(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	sessionDir := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "abc.jsonl"), []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(t.TempDir(), "abc-diag.zip")
+	out := captureStdout(t, func() {
+		if rc := doctorCommand([]string{"session", "abc", "--out=" + outPath}, "test-version"); rc != 0 {
+			t.Fatalf("doctor session rc = %d, want 0", rc)
+		}
+	})
+	if strings.TrimSpace(out) != outPath {
+		t.Fatalf("doctor session output = %q, want %q", strings.TrimSpace(out), outPath)
+	}
+	if rc := doctorCommand([]string{"session", "abc", "--out="}, "test-version"); rc != 2 {
+		t.Fatalf("empty --out= rc = %d, want usage error 2", rc)
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -32,6 +33,30 @@ func TestRunDispatchesDoctor(t *testing.T) {
 	})
 	if !strings.Contains(out, "reasonix dispatch-version doctor") {
 		t.Fatalf("doctor output missing header:\n%s", out)
+	}
+}
+
+func TestDoctorSessionCommandWritesBundle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	sessionDir := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "abc.jsonl"), []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(t.TempDir(), "abc-diag.zip")
+	out := captureStdout(t, func() {
+		if rc := doctorCommand([]string{"session", "abc", "--zip", "--out", outPath}, "test-version"); rc != 0 {
+			t.Fatalf("doctor session rc = %d, want 0", rc)
+		}
+	})
+	if strings.TrimSpace(out) != outPath {
+		t.Fatalf("doctor session output = %q, want %q", strings.TrimSpace(out), outPath)
+	}
+	if info, err := os.Stat(outPath); err != nil || info.Size() == 0 {
+		t.Fatalf("bundle stat = %v, %v", info, err)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2932,6 +2932,8 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 		if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
 			return err
 		}
+		beforeRecoverPath := path
+		beforeRecoverSession := s
 		recoveredPath, recovered, recoverErr := c.recoverSnapshotConflict(path, err, forceRewrite)
 		if recoverErr != nil {
 			return recoverErr
@@ -2942,9 +2944,9 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 		// Adoption swaps in a freshly loaded session whose rewrite baseline
 		// adoptDiskSession already set; the version captured above belongs to
 		// the replaced session and must not be re-applied to the new one.
-		adoptedDiskSession = recoveredPath == path
 		path = recoveredPath
 		s = c.executor.Session()
+		adoptedDiskSession = recoveredPath == beforeRecoverPath && s != beforeRecoverSession
 	}
 	// Persist guardian session so the prefix cache stays warm after restart.
 	if c.guardianSess != nil {
@@ -2990,6 +2992,59 @@ func snapshotConflictLogAttrs(saveErr error, path, mode string) []any {
 	return attrs
 }
 
+type snapshotConflictDiagnostic struct {
+	At               time.Time `json:"at"`
+	BranchID         string    `json:"branch_id"`
+	Mode             string    `json:"mode"`
+	Outcome          string    `json:"outcome"`
+	Kind             string    `json:"kind,omitempty"`
+	DiskMessages     int       `json:"disk_messages,omitempty"`
+	SnapshotMessages int       `json:"snapshot_messages,omitempty"`
+	BaseRevision     int64     `json:"base_revision,omitempty"`
+	DiskRevision     int64     `json:"disk_revision,omitempty"`
+	RecoveryBranchID string    `json:"recovery_branch_id,omitempty"`
+	ExistingRecovery bool      `json:"existing_recovery,omitempty"`
+}
+
+func appendSnapshotConflictDiagnostic(path, mode, outcome string, saveErr error, recoveryPath string, existing bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	rec := snapshotConflictDiagnostic{
+		At:       time.Now(),
+		BranchID: agent.BranchID(path),
+		Mode:     mode,
+		Outcome:  outcome,
+	}
+	var conflict *agent.SessionSnapshotConflictError
+	if errors.As(saveErr, &conflict) && conflict != nil {
+		rec.Kind = string(conflict.Kind)
+		rec.DiskMessages = conflict.ExistingMessages
+		rec.SnapshotMessages = conflict.SnapshotMessages
+		rec.BaseRevision = conflict.BaseRevision
+		rec.DiskRevision = conflict.DiskRevision
+	}
+	if recoveryPath != "" {
+		rec.RecoveryBranchID = agent.BranchID(recoveryPath)
+		rec.ExistingRecovery = existing
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	logPath := store.SessionConflictLog(path)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(data, '\n'))
+}
+
 func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, bool, error) {
 	if c.executor == nil || strings.TrimSpace(path) == "" {
 		return "", false, saveErr
@@ -3001,6 +3056,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	logAttrs := snapshotConflictLogAttrs(saveErr, path, mode)
 	if kind, ok := agent.SnapshotConflictKind(saveErr); ok && kind == agent.SessionSnapshotConflictStalePrefix {
 		if c.adoptDiskSession(path) {
+			appendSnapshotConflictDiagnostic(path, mode, "adopted_newer_disk_transcript", saveErr, "", false)
 			slog.Warn("controller: snapshot conflict; adopted newer disk transcript", logAttrs...)
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "session changed on disk; adopted the newer transcript"})
@@ -3032,6 +3088,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 			if forceErr := c.executor.Session().Save(path); forceErr != nil {
 				return "", false, fmt.Errorf("recovery chain depth exceeded; force save failed: %w", forceErr)
 			}
+			appendSnapshotConflictDiagnostic(path, mode, "recovery_depth_cap_force_saved", saveErr, path, false)
 			slog.Warn("controller: snapshot conflict; recovery depth cap reached, force-saved onto current branch", logAttrs...)
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "session conflicts kept recurring; kept the transcript on the current recovery branch"})
@@ -3039,6 +3096,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 		}
 		if errors.Is(err, agent.ErrSessionRecoveryNotNeeded) {
 			if c.adoptDiskSession(path) {
+				appendSnapshotConflictDiagnostic(path, mode, "recovery_not_needed_adopted_disk_transcript", saveErr, "", false)
 				slog.Warn("controller: snapshot conflict; recovery not needed, adopted disk transcript", logAttrs...)
 				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 					Text: "session changed on disk; adopted the newer transcript (local changes already covered)"})
@@ -3047,6 +3105,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 			// Nothing was recovered AND the disk transcript could not be
 			// adopted: the snapshot is silently dropped. Leave a trace so
 			// "my last turns vanished" reports can be tied to this path.
+			appendSnapshotConflictDiagnostic(path, mode, "recovery_not_needed_adopt_failed", saveErr, "", false)
 			slog.Warn("controller: snapshot conflict; recovery not needed but disk transcript could not be adopted", logAttrs...)
 			return "", false, nil
 		}
@@ -3071,6 +3130,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
 	c.transplantInFlightTurnMarker(path, info.Path)
+	appendSnapshotConflictDiagnostic(path, mode, "forked_recovery_branch", saveErr, info.Path, info.Existing)
 	slog.Warn("controller: snapshot conflict; forked recovery branch",
 		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1741,6 +1741,7 @@ func TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch(t *testing.T)
 	exec := agent.New(nil, nil, stale, agent.Options{}, event.Discard)
 	sink := &noticeSink{}
 	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test", Sink: sink})
+	stale.IncrementRewrite()
 
 	if err := c.Snapshot(); err != nil {
 		t.Fatalf("Snapshot: %v", err)
@@ -1765,6 +1766,12 @@ func TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch(t *testing.T)
 	notices := sink.notices()
 	if len(notices) == 0 || !strings.Contains(notices[len(notices)-1], "kept the transcript on the current recovery branch") {
 		t.Fatalf("notices = %v, want depth-cap notice", notices)
+	}
+	c.mu.Lock()
+	savedRewriteVersion := c.savedRewriteVersion
+	c.mu.Unlock()
+	if savedRewriteVersion != stale.RewriteVersion() {
+		t.Fatalf("rewrite baseline after depth-cap force save = %d, want %d", savedRewriteVersion, stale.RewriteVersion())
 	}
 
 	// The force save re-anchored the baseline: the next snapshot must not

--- a/internal/control/session_artifacts_test.go
+++ b/internal/control/session_artifacts_test.go
@@ -28,6 +28,7 @@ func TestRemoveSessionArtifactsSweepsEventLogAndSidecars(t *testing.T) {
 	}
 	for _, extra := range []string{
 		store.SessionGoalState(path),
+		store.SessionConflictLog(path),
 		guardian.PathFor(path),
 		guardian.CursorPathFor(path),
 		store.SessionEventLog(guardian.PathFor(path)),
@@ -47,6 +48,7 @@ func TestRemoveSessionArtifactsSweepsEventLogAndSidecars(t *testing.T) {
 		store.SessionGoalState(path),
 		store.SessionEventLog(path),
 		store.SessionEventIndex(path),
+		store.SessionConflictLog(path),
 		guardian.PathFor(path),
 		guardian.CursorPathFor(path),
 		store.SessionEventLog(guardian.PathFor(path)),

--- a/internal/doctor/session_bundle.go
+++ b/internal/doctor/session_bundle.go
@@ -410,9 +410,8 @@ func addBundleFile(zw *zip.Writer, name, path string, info os.FileInfo) error {
 }
 
 func addBundleBytes(zw *zip.Writer, name string, data []byte, modTime time.Time) error {
-	h := &zip.FileHeader{Name: name, Method: zip.Deflate}
+	h := &zip.FileHeader{Name: name, Method: zip.Deflate, Modified: modTime}
 	h.SetMode(0o644)
-	h.SetModTime(modTime)
 	w, err := zw.CreateHeader(h)
 	if err != nil {
 		return err

--- a/internal/doctor/session_bundle.go
+++ b/internal/doctor/session_bundle.go
@@ -1,0 +1,452 @@
+package doctor
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/store"
+)
+
+const sessionBundleSchemaVersion = 1
+
+// SessionBundleOptions controls a session-conflict diagnostic zip. SessionRef
+// accepts either a branch id such as "20260706-...-recovery-abcd1234", a
+// matching .jsonl basename, or an absolute/relative transcript path.
+type SessionBundleOptions struct {
+	Version    string
+	SessionRef string
+	OutputPath string
+	Now        time.Time
+}
+
+type SessionBundleResult struct {
+	Path        string
+	SessionPath string
+	Included    []SessionBundleFile
+	Missing     []string
+}
+
+type SessionBundleManifest struct {
+	SchemaVersion int                  `json:"schema_version"`
+	GeneratedAt   time.Time            `json:"generated_at"`
+	Version       string               `json:"version"`
+	RequestedRef  string               `json:"requested_ref"`
+	SessionPath   string               `json:"session_path"`
+	Sessions      []SessionBundleEntry `json:"sessions"`
+	Included      []SessionBundleFile  `json:"included"`
+	Missing       []string             `json:"missing,omitempty"`
+}
+
+type SessionBundleEntry struct {
+	BranchID       string `json:"branch_id"`
+	Role           string `json:"role"`
+	Path           string `json:"path"`
+	ParentID       string `json:"parent_id,omitempty"`
+	Recovered      bool   `json:"recovered,omitempty"`
+	RecoveryReason string `json:"recovery_reason,omitempty"`
+	RecoveryDepth  int    `json:"recovery_depth,omitempty"`
+}
+
+type SessionBundleFile struct {
+	Role string `json:"role"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+type sessionArtifact struct {
+	role string
+	path string
+}
+
+// WriteSessionBundle writes a zip containing the selected session transcript,
+// its persistence sidecars, a redacted doctor report, and the recovery parent
+// chain discoverable through branch metadata.
+func WriteSessionBundle(opts SessionBundleOptions) (SessionBundleResult, error) {
+	ref := strings.TrimSpace(opts.SessionRef)
+	if ref == "" {
+		return SessionBundleResult{}, fmt.Errorf("session branch id or path is required")
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	sessionPath, err := resolveSessionBundlePath(ref)
+	if err != nil {
+		return SessionBundleResult{}, err
+	}
+	chain := sessionBundleChain(sessionPath)
+	outPath := strings.TrimSpace(opts.OutputPath)
+	if outPath == "" {
+		outPath = defaultSessionBundlePath(agent.BranchID(sessionPath))
+	}
+	if abs, err := filepath.Abs(outPath); err == nil {
+		outPath = abs
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return SessionBundleResult{}, err
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return SessionBundleResult{}, err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	manifest := SessionBundleManifest{
+		SchemaVersion: sessionBundleSchemaVersion,
+		GeneratedAt:   now,
+		Version:       opts.Version,
+		RequestedRef:  redactSessionBundleRef(ref),
+		SessionPath:   redactSessionBundlePath(sessionPath),
+	}
+	result := SessionBundleResult{Path: outPath, SessionPath: sessionPath}
+
+	report := Collect(Options{Version: opts.Version})
+	reportData, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		_ = zw.Close()
+		return SessionBundleResult{}, err
+	}
+	if err := addBundleBytes(zw, "doctor.json", reportData, now); err != nil {
+		_ = zw.Close()
+		return SessionBundleResult{}, err
+	}
+
+	for i, path := range chain {
+		role := "parent"
+		if i == 0 {
+			role = "requested"
+		}
+		meta, ok, metaErr := agent.LoadBranchMeta(path)
+		if metaErr != nil {
+			metaPath := store.SessionMeta(path)
+			manifest.Missing = append(manifest.Missing, redactSessionBundlePath(metaPath)+": "+redactSessionBundleError(metaErr))
+		}
+		entry := SessionBundleEntry{
+			BranchID: agent.BranchID(path),
+			Role:     role,
+			Path:     redactSessionBundlePath(path),
+		}
+		if ok {
+			entry.ParentID = meta.ParentID
+			entry.Recovered = meta.Recovered
+			entry.RecoveryReason = meta.RecoveryReason
+			entry.RecoveryDepth = meta.RecoveryDepth
+		}
+		manifest.Sessions = append(manifest.Sessions, entry)
+
+		for _, artifact := range sessionBundleArtifacts(path) {
+			info, statErr := os.Stat(artifact.path)
+			if statErr != nil {
+				if !os.IsNotExist(statErr) {
+					manifest.Missing = append(manifest.Missing, redactSessionBundlePath(artifact.path)+": "+redactSessionBundleError(statErr))
+				}
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+			zipName := filepath.ToSlash(filepath.Join("sessions", safeBundleName(agent.BranchID(path)), filepath.Base(artifact.path)))
+			if err := addBundleFile(zw, zipName, artifact.path, info); err != nil {
+				_ = zw.Close()
+				return SessionBundleResult{}, err
+			}
+			file := SessionBundleFile{
+				Role: artifact.role,
+				Name: zipName,
+				Path: redactSessionBundlePath(artifact.path),
+				Size: info.Size(),
+			}
+			manifest.Included = append(manifest.Included, file)
+			result.Included = append(result.Included, file)
+		}
+	}
+	sort.Strings(manifest.Missing)
+	result.Missing = append(result.Missing, manifest.Missing...)
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		_ = zw.Close()
+		return SessionBundleResult{}, err
+	}
+	if err := addBundleBytes(zw, "manifest.json", manifestData, now); err != nil {
+		_ = zw.Close()
+		return SessionBundleResult{}, err
+	}
+	if err := zw.Close(); err != nil {
+		return SessionBundleResult{}, err
+	}
+	return result, nil
+}
+
+func resolveSessionBundlePath(ref string) (string, error) {
+	if path, ok := existingSessionPath(ref); ok {
+		return path, nil
+	}
+	branch := sessionBundleBranchID(ref)
+	if branch == "" {
+		return "", fmt.Errorf("invalid session reference %q", ref)
+	}
+	name := branch + ".jsonl"
+	var matches []string
+	for _, dir := range sessionBundleSearchDirs() {
+		path := filepath.Join(dir, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			matches = append(matches, path)
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("session %q not found under Reasonix session directories", branch)
+	}
+	sort.Strings(matches)
+	if len(matches) > 1 {
+		redacted := make([]string, len(matches))
+		for i, match := range matches {
+			redacted[i] = redactSessionBundlePath(match)
+		}
+		return "", fmt.Errorf("session %q matched multiple files; pass an absolute path: %s", branch, strings.Join(redacted, ", "))
+	}
+	return matches[0], nil
+}
+
+func redactSessionBundleRef(ref string) string {
+	if strings.ContainsAny(ref, `/\`) {
+		return redactSessionBundlePath(ref)
+	}
+	return ref
+}
+
+func redactSessionBundlePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return path
+	}
+	root := strings.TrimSpace(config.MemoryUserDir())
+	if root != "" {
+		absRoot, rootErr := filepath.Abs(root)
+		absPath, pathErr := filepath.Abs(path)
+		if rootErr == nil && pathErr == nil {
+			if rel, err := filepath.Rel(absRoot, absPath); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				if rel == "." {
+					return "<REASONIX_HOME>"
+				}
+				return filepath.ToSlash(filepath.Join("<REASONIX_HOME>", rel))
+			}
+		}
+	}
+	return redactHome(path)
+}
+
+func redactSessionBundleError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return redactSessionBundleText(err.Error())
+}
+
+func redactSessionBundleText(text string) string {
+	if text == "" {
+		return text
+	}
+	if root := strings.TrimSpace(config.MemoryUserDir()); root != "" {
+		text = replacePathPrefix(text, root, "<REASONIX_HOME>")
+		if absRoot, err := filepath.Abs(root); err == nil {
+			text = replacePathPrefix(text, absRoot, "<REASONIX_HOME>")
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		text = replacePathPrefix(text, home, "~")
+	}
+	return text
+}
+
+func replacePathPrefix(text, old, new string) string {
+	old = strings.TrimRight(strings.TrimSpace(old), string(os.PathSeparator))
+	if old == "" {
+		return text
+	}
+	text = strings.ReplaceAll(text, old+string(os.PathSeparator), new+string(os.PathSeparator))
+	return strings.ReplaceAll(text, old, new)
+}
+
+func existingSessionPath(ref string) (string, bool) {
+	path := strings.Trim(strings.TrimSpace(ref), `"'`)
+	if path == "" {
+		return "", false
+	}
+	if !strings.HasSuffix(filepath.Base(path), ".jsonl") {
+		if candidate := path + ".jsonl"; strings.ContainsAny(path, `/\`) {
+			path = candidate
+		}
+	}
+	if !strings.HasSuffix(filepath.Base(path), ".jsonl") {
+		return "", false
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return path, true
+}
+
+func sessionBundleBranchID(ref string) string {
+	ref = strings.Trim(strings.TrimSpace(ref), `"'`)
+	base := filepath.Base(ref)
+	for _, suffix := range []string{".jsonl.meta", ".jsonl", ".meta", ".json"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	return strings.TrimSpace(base)
+}
+
+func sessionBundleSearchDirs() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(dir string) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return
+		}
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+		if seen[dir] {
+			return
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	add(config.SessionDir())
+	if cwd, err := os.Getwd(); err == nil {
+		add(config.ProjectSessionDir(cwd))
+	}
+	if root := config.MemoryUserDir(); root != "" {
+		projects := filepath.Join(root, "projects")
+		_ = filepath.WalkDir(projects, func(path string, d os.DirEntry, err error) error {
+			if err != nil || !d.IsDir() {
+				return nil
+			}
+			if d.Name() == "sessions" {
+				add(path)
+				return filepath.SkipDir
+			}
+			return nil
+		})
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sessionBundleChain(path string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for len(out) < 16 {
+		if path == "" {
+			break
+		}
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		if seen[path] {
+			break
+		}
+		seen[path] = true
+		out = append(out, path)
+		meta, ok, err := agent.LoadBranchMeta(path)
+		if err != nil || !ok || strings.TrimSpace(meta.ParentID) == "" {
+			break
+		}
+		parent := filepath.Join(filepath.Dir(path), meta.ParentID+".jsonl")
+		if info, err := os.Stat(parent); err != nil || info.IsDir() {
+			break
+		}
+		path = parent
+	}
+	return out
+}
+
+func sessionBundleArtifacts(sessionPath string) []sessionArtifact {
+	return []sessionArtifact{
+		{role: "transcript", path: sessionPath},
+		{role: "meta", path: store.SessionMeta(sessionPath)},
+		{role: "goal_state", path: store.SessionGoalState(sessionPath)},
+		{role: "events", path: store.SessionEventLog(sessionPath)},
+		{role: "event_index", path: store.SessionEventIndex(sessionPath)},
+		{role: "conflicts", path: store.SessionConflictLog(sessionPath)},
+		{role: "lease", path: store.SessionLeaseInfo(sessionPath)},
+	}
+}
+
+func addBundleFile(zw *zip.Writer, name, path string, info os.FileInfo) error {
+	h, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	h.Name = name
+	h.Method = zip.Deflate
+	w, err := zw.CreateHeader(h)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(w, f)
+	return err
+}
+
+func addBundleBytes(zw *zip.Writer, name string, data []byte, modTime time.Time) error {
+	h := &zip.FileHeader{Name: name, Method: zip.Deflate}
+	h.SetMode(0o644)
+	h.SetModTime(modTime)
+	w, err := zw.CreateHeader(h)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func defaultSessionBundlePath(branch string) string {
+	branch = safeBundleName(branch)
+	if branch == "" {
+		branch = "session"
+	}
+	return filepath.Join(os.TempDir(), "reasonix-session-"+branch+"-diag.zip")
+}
+
+func safeBundleName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+		if b.Len() >= 120 {
+			break
+		}
+	}
+	return strings.Trim(b.String(), "._-")
+}

--- a/internal/doctor/session_bundle_test.go
+++ b/internal/doctor/session_bundle_test.go
@@ -1,0 +1,143 @@
+package doctor
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/store"
+)
+
+func TestWriteSessionBundleIncludesRecoveryChain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	dir := filepath.Join(home, "projects", "workspace", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(dir, "parent-session.jsonl")
+	recovery := filepath.Join(dir, "parent-session-recovery-deadbeef.jsonl")
+	writeFile(t, parent, `{"role":"user","content":"parent"}`+"\n")
+	writeFile(t, recovery, `{"role":"user","content":"recovery"}`+"\n")
+	if err := agent.SaveBranchMeta(parent, agent.BranchMeta{ID: "parent-session"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(recovery, agent.BranchMeta{
+		ID:             "parent-session-recovery-deadbeef",
+		ParentID:       "parent-session",
+		Recovered:      true,
+		RecoveryReason: "snapshot conflict",
+		RecoveryDepth:  1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, store.SessionEventLog(recovery), `{"type":"replace"}`+"\n")
+	writeFile(t, store.SessionEventIndex(recovery), `{"log_size":19}`+"\n")
+	writeFile(t, store.SessionConflictLog(recovery), `{"outcome":"forked_recovery_branch"}`+"\n")
+	writeFile(t, store.SessionLeaseInfo(recovery), `{"pid":1234}`+"\n")
+
+	out := filepath.Join(t.TempDir(), "diag.zip")
+	got, err := WriteSessionBundle(SessionBundleOptions{
+		Version:    "test-version",
+		SessionRef: store.SessionMeta(recovery),
+		OutputPath: out,
+		Now:        time.Unix(1700000000, 0),
+	})
+	if err != nil {
+		t.Fatalf("WriteSessionBundle: %v", err)
+	}
+	if got.Path != out {
+		t.Fatalf("bundle path = %q, want %q", got.Path, out)
+	}
+	if got.SessionPath != recovery {
+		t.Fatalf("session path = %q, want %q", got.SessionPath, recovery)
+	}
+
+	files := zipFiles(t, out)
+	for _, want := range []string{
+		"doctor.json",
+		"manifest.json",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.jsonl",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.jsonl.meta",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.events.jsonl",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.event-index.json",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.conflicts.jsonl",
+		"sessions/parent-session-recovery-deadbeef/parent-session-recovery-deadbeef.jsonl.lease.json",
+		"sessions/parent-session/parent-session.jsonl",
+		"sessions/parent-session/parent-session.jsonl.meta",
+	} {
+		if _, ok := files[want]; !ok {
+			t.Fatalf("zip missing %s; entries=%v", want, keys(files))
+		}
+	}
+
+	var manifest SessionBundleManifest
+	if err := json.Unmarshal(files["manifest.json"], &manifest); err != nil {
+		t.Fatalf("manifest JSON: %v", err)
+	}
+	if strings.Contains(string(files["manifest.json"]), home) {
+		t.Fatalf("manifest leaked REASONIX_HOME path:\n%s", files["manifest.json"])
+	}
+	if manifest.Version != "test-version" {
+		t.Fatalf("manifest version = %q", manifest.Version)
+	}
+	if !strings.Contains(manifest.RequestedRef, "<REASONIX_HOME>") {
+		t.Fatalf("requested ref = %q, want redacted REASONIX_HOME path", manifest.RequestedRef)
+	}
+	if len(manifest.Sessions) != 2 {
+		t.Fatalf("manifest sessions = %+v, want recovery plus parent", manifest.Sessions)
+	}
+	if manifest.Sessions[0].BranchID != "parent-session-recovery-deadbeef" || manifest.Sessions[0].ParentID != "parent-session" {
+		t.Fatalf("recovery manifest entry = %+v", manifest.Sessions[0])
+	}
+}
+
+func writeFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func zipFiles(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	out := map[string][]byte{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[f.Name] = data
+	}
+	return out
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -432,6 +432,7 @@ Usage:
   reasonix mcp <add|remove|list|import>                 manage MCP servers in reasonix.toml
   reasonix init                                         show how to generate project memory (AGENTS.md)
   reasonix doctor [--json]                              print redacted local diagnostics
+  reasonix doctor session <branch-id> [--zip] [--out PATH]  export a session conflict diagnostic zip
   reasonix bot start|doctor|weixin-login                multi-channel IM bot gateway
   reasonix upgrade [--check] [--force]                   self-update to the latest release (also: reasonix update)
   reasonix version

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -433,6 +433,7 @@ var Chinese = Messages{
   reasonix mcp <add|remove|list|import>                 管理 reasonix.toml 里的 MCP 服务器
   reasonix init                                         查看如何生成项目记忆（AGENTS.md）
   reasonix doctor [--json]                              输出脱敏的本地诊断信息
+  reasonix doctor session <branch-id> [--zip] [--out PATH]  导出会话冲突诊断 zip
   reasonix bot start|doctor|weixin-login                多渠道 IM bot 网关
   reasonix upgrade [--check] [--force]                   自更新到最新版本（也可用：reasonix update）
   reasonix version

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -381,6 +381,7 @@ var ChineseTraditional = Messages{
   reasonix mcp <add|remove|list|import>                 管理 reasonix.toml 裡的 MCP 伺服器
   reasonix init                                         查看如何產生專案記憶（AGENTS.md）
   reasonix doctor [--json]                              輸出脫敏的本機診斷資訊
+  reasonix doctor session <branch-id> [--zip] [--out PATH]  匯出會話衝突診斷 zip
   reasonix bot start|doctor|weixin-login                多管道 IM bot 閘道
   reasonix upgrade [--check] [--force]                   自更新至最新版本（也可用：reasonix update）
   reasonix version

--- a/internal/serve/session_files_test.go
+++ b/internal/serve/session_files_test.go
@@ -22,6 +22,9 @@ func TestRemoveSessionFilesSweepsEventLogAndSidecars(t *testing.T) {
 	if err := s.SaveSnapshot(path); err != nil {
 		t.Fatalf("SaveSnapshot append: %v", err)
 	}
+	if err := os.WriteFile(store.SessionConflictLog(path), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write conflict log: %v", err)
+	}
 
 	if err := removeSessionFiles(dir, path); err != nil {
 		t.Fatalf("removeSessionFiles: %v", err)
@@ -31,6 +34,7 @@ func TestRemoveSessionFilesSweepsEventLogAndSidecars(t *testing.T) {
 		store.SessionMeta(path),
 		store.SessionEventLog(path),
 		store.SessionEventIndex(path),
+		store.SessionConflictLog(path),
 	} {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
 			t.Errorf("artifact survived delete: %s (err=%v)", p, err)

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -24,6 +24,7 @@ func IsSessionTranscriptName(name string) bool {
 	name = strings.TrimSpace(name)
 	return strings.HasSuffix(name, ".jsonl") &&
 		!strings.HasSuffix(name, ".events.jsonl") &&
+		!strings.HasSuffix(name, ".conflicts.jsonl") &&
 		!strings.HasSuffix(name, ".guardian.jsonl")
 }
 
@@ -67,6 +68,16 @@ func SessionEventIndex(sessionPath string) string {
 		return ""
 	}
 	return sessionStem(sessionPath) + ".event-index.json"
+}
+
+// SessionConflictLog is the append-only diagnostic log for snapshot conflict
+// recoveries (<id>.conflicts.jsonl). It contains revision counters and branch
+// ids, not transcript content.
+func SessionConflictLog(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".conflicts.jsonl"
 }
 
 // SessionLockFile is the advisory save lock (<id>.jsonl.lock).
@@ -121,7 +132,7 @@ func SessionCleanupPending(sessionPath string) string {
 }
 
 // SessionSidecarFiles returns every regular-file sidecar owned by a session
-// transcript: branch meta, goal state, the event log, and the event index.
+// transcript: branch meta, goal state, event/index logs, and diagnostic logs.
 // Every surface that deletes a session (desktop trash, /clear, serve, ACP)
 // must remove all of these — the event log is the authoritative transcript, so
 // leaving it behind both leaks the "deleted" conversation and lets LoadSession
@@ -137,5 +148,6 @@ func SessionSidecarFiles(sessionPath string) []string {
 		SessionGoalState(sessionPath),
 		SessionEventLog(sessionPath),
 		SessionEventIndex(sessionPath),
+		SessionConflictLog(sessionPath),
 	}
 }

--- a/internal/store/session_test.go
+++ b/internal/store/session_test.go
@@ -14,6 +14,7 @@ func TestSessionSidecarLayout(t *testing.T) {
 		{"goal-state", SessionGoalState(p), "/home/u/.reasonix/sessions/abc.goal-state.json"},
 		{"event-log", SessionEventLog(p), "/home/u/.reasonix/sessions/abc.events.jsonl"},
 		{"event-index", SessionEventIndex(p), "/home/u/.reasonix/sessions/abc.event-index.json"},
+		{"conflict-log", SessionConflictLog(p), "/home/u/.reasonix/sessions/abc.conflicts.jsonl"},
 		{"lock", SessionLockFile(p), p + ".lock"},
 		{"lease-lock", SessionLeaseLock(p), p + ".lease.lock"},
 		{"lease-info", SessionLeaseInfo(p), p + ".lease.json"},
@@ -37,6 +38,7 @@ func TestSessionSidecarEmptyPath(t *testing.T) {
 		{"goal-state", SessionGoalState},
 		{"event-log", SessionEventLog},
 		{"event-index", SessionEventIndex},
+		{"conflict-log", SessionConflictLog},
 		{"lock", SessionLockFile},
 		{"lease-lock", SessionLeaseLock},
 		{"lease-info", SessionLeaseInfo},
@@ -57,6 +59,7 @@ func TestIsSessionTranscriptName(t *testing.T) {
 	}{
 		{"session.jsonl", true},
 		{"session.events.jsonl", false},
+		{"session.conflicts.jsonl", false},
 		{"session.guardian.jsonl", false},
 		{"session.guardian.events.jsonl", false},
 		{"session.jsonl.meta", false},
@@ -78,6 +81,7 @@ func TestSessionSidecarFiles(t *testing.T) {
 		"/home/u/.reasonix/sessions/abc.goal-state.json",
 		"/home/u/.reasonix/sessions/abc.events.jsonl",
 		"/home/u/.reasonix/sessions/abc.event-index.json",
+		"/home/u/.reasonix/sessions/abc.conflicts.jsonl",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("SessionSidecarFiles = %v, want %v", got, want)


### PR DESCRIPTION
## Summary
- The overlong-name reconcile pass filtered by a bare `.jsonl` suffix, so an `.events.jsonl` or `.conflicts.jsonl` whose name crossed the 224-byte bound (owner stem between 209 and 224 bytes) was renamed into a fake session with fabricated meta, while the owning transcript's rename orphaned both logs under the retired stem. Filter with `store.IsSessionTranscriptName` and carry the event log, event index, and conflict log through `migrateSessionSidecars` like the other owned sidecars.
- `reasonix doctor session` now also accepts `--out=PATH` (equals form); empty `--out=` is a usage error.
- New regression test verified red-without-fix / green-with-fix.

**Stacked on #6120** (needs `store.SessionConflictLog` and the `doctor session` subcommand; contains its commits until it merges — review the top commit only).

## Tests
- `go test ./internal/agent ./internal/cli`
- `golangci-lint run` (clean)