### PR TITLE
Honor external edits to heartbeat-tasks.json / 心跳任务文件的外部编辑不再丢失

### DIFF
--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -57,6 +57,7 @@ type heartbeatConfig struct {
 type HeartbeatEngine struct {
 	mu            sync.Mutex
 	tasks         []HeartbeatTask
+	cfgMod        time.Time                        // config-file mtime as of the engine's last read/write (external-edit probe)
 	pendingTopics map[string]heartbeatPendingTopic // in-memory retry/in-flight safety for NewConversationEachRun
 	done          chan struct{}
 	running       bool
@@ -99,6 +100,28 @@ func (e *HeartbeatEngine) loadTasks() []HeartbeatTask {
 	return cfg.Tasks
 }
 
+// noteConfigModLocked records the config file's current mtime so the tick
+// external-edit probe does not re-read a file the engine itself just wrote.
+func (e *HeartbeatEngine) noteConfigModLocked() {
+	if info, err := os.Stat(e.configPath()); err == nil {
+		e.cfgMod = info.ModTime()
+	}
+}
+
+// adoptExternalEditsLocked re-reads the config when its mtime moved since the
+// engine last touched the file: heartbeat-tasks.json is documented as human-
+// and AI-editable, so an external edit should be scheduled by the next tick
+// rather than waiting for a manual Refresh or an app restart.
+func (e *HeartbeatEngine) adoptExternalEditsLocked() {
+	info, err := os.Stat(e.configPath())
+	if err != nil || info.ModTime().Equal(e.cfgMod) {
+		return
+	}
+	e.cfgMod = info.ModTime()
+	e.tasks = e.loadTasks()
+	e.prunePendingTopicsLocked(e.tasks)
+}
+
 // saveTasks writes tasks to disk atomically.
 func (e *HeartbeatEngine) saveTasks(tasks []HeartbeatTask) error {
 	if tasks == nil {
@@ -129,6 +152,7 @@ func (e *HeartbeatEngine) Start() {
 		return
 	}
 	e.tasks = e.loadTasks()
+	e.noteConfigModLocked()
 	e.running = true
 	go e.loop()
 	log.Printf("[heartbeat] engine started (%d tasks)", len(e.tasks))
@@ -160,10 +184,12 @@ func (e *HeartbeatEngine) loop() {
 }
 
 // tick checks every enabled task and runs those whose interval has elapsed.
-// It merges results (topicId, lastRunAt) rather than replacing the full list,
-// so concurrent HeartbeatSaveTasks edits are not lost.
+// It first adopts any external edit to the config file (human/AI-editable),
+// then merges results (topicId, lastRunAt) rather than replacing the full
+// list, so concurrent HeartbeatSaveTasks edits are not lost.
 func (e *HeartbeatEngine) tick() {
 	e.mu.Lock()
+	e.adoptExternalEditsLocked()
 	tasks := append([]HeartbeatTask(nil), e.tasks...)
 	e.mu.Unlock()
 
@@ -374,6 +400,7 @@ func (e *HeartbeatEngine) ReloadTasks() []HeartbeatTask {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.tasks = e.loadTasks()
+	e.noteConfigModLocked()
 	e.prunePendingTopicsLocked(e.tasks)
 	out := make([]HeartbeatTask, len(e.tasks))
 	copy(out, e.tasks)
@@ -386,7 +413,9 @@ func (e *HeartbeatEngine) ReplaceTasks(tasks []HeartbeatTask) error {
 	defer e.mu.Unlock()
 	e.tasks = tasks
 	e.prunePendingTopicsLocked(tasks)
-	return e.saveTasks(tasks)
+	err := e.saveTasks(tasks)
+	e.noteConfigModLocked()
+	return err
 }
 
 func (e *HeartbeatEngine) prunePendingTopicsLocked(tasks []HeartbeatTask) {
@@ -431,7 +460,18 @@ func (e *HeartbeatEngine) mergeRunUpdatesLocked(updates map[string]HeartbeatTask
 	if len(updates) == 0 {
 		return
 	}
-	tasks := append([]HeartbeatTask(nil), e.tasks...)
+	// Rebase onto the on-disk list before the full-list save: the config file
+	// is documented as human- and AI-editable, so an external edit may have
+	// landed after the in-memory snapshot this tick ran from. The engine owns
+	// only the run-state fields (TopicID, LastRunAt, CreatedAt backfill);
+	// task definitions added, edited, or deleted externally are adopted from
+	// disk, so the save below can never silently roll an external edit back.
+	tasks := e.loadTasks()
+	if tasks == nil {
+		// Missing or unreadable file: fall back to the in-memory list so the
+		// run state still lands (the historical behavior).
+		tasks = append([]HeartbeatTask(nil), e.tasks...)
+	}
 	for i := range tasks {
 		update, ok := updates[tasks[i].ID]
 		if !ok {
@@ -448,7 +488,9 @@ func (e *HeartbeatEngine) mergeRunUpdatesLocked(updates map[string]HeartbeatTask
 		}
 	}
 	e.tasks = tasks
+	e.prunePendingTopicsLocked(tasks)
 	_ = e.saveTasks(tasks)
+	e.noteConfigModLocked()
 }
 
 // parseInterval converts a string like "5m", "1h", "30s" to time.Duration.

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -360,5 +361,75 @@ func TestHeartbeatInactiveOpenDoesNotChangeActiveTab(t *testing.T) {
 	}
 	if meta.ID != "heartbeat" || meta.Active {
 		t.Fatalf("inactive open meta = %+v, want heartbeat and inactive", meta)
+	}
+}
+
+func TestHeartbeatMergeRunUpdatesAdoptsExternalFileEdits(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	engine := &HeartbeatEngine{
+		tasks: []HeartbeatTask{
+			{ID: "a", Title: "stale title", Prompt: "stale", Interval: "1h", Enabled: true},
+		},
+	}
+	// An external editor (the documented human/AI flow) rewrote the file after
+	// the engine's in-memory snapshot: task a was edited and task b was added.
+	external := []HeartbeatTask{
+		{ID: "a", Title: "edited externally", Prompt: "new prompt", Interval: "2h", Enabled: true},
+		{ID: "b", Title: "added externally", Prompt: "hello", Interval: "1h", Enabled: false},
+	}
+	if err := engine.saveTasks(external); err != nil {
+		t.Fatalf("seed external file: %v", err)
+	}
+
+	engine.mergeRunUpdatesLocked(map[string]HeartbeatTask{
+		"a": {ID: "a", TopicID: "topic-a", LastRunAt: 4242},
+	})
+
+	if len(engine.tasks) != 2 {
+		t.Fatalf("tasks len = %d, want 2 (external addition adopted): %+v", len(engine.tasks), engine.tasks)
+	}
+	got := engine.tasks[0]
+	if got.Title != "edited externally" || got.Prompt != "new prompt" || got.Interval != "2h" {
+		t.Fatalf("external edit was rolled back by the run-state save: %+v", got)
+	}
+	if got.TopicID != "topic-a" || got.LastRunAt != 4242 {
+		t.Fatalf("run state was not merged onto the disk copy: %+v", got)
+	}
+	// The full-list save must have preserved the externally added task on disk.
+	onDisk := engine.loadTasks()
+	if len(onDisk) != 2 || onDisk[1].ID != "b" || onDisk[1].Title != "added externally" {
+		t.Fatalf("externally added task was lost on save: %+v", onDisk)
+	}
+}
+
+func TestHeartbeatTickAdoptsExternalFileEdits(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	engine := newHeartbeatEngine(nil)
+	if err := engine.saveTasks([]HeartbeatTask{{ID: "a", Title: "A", Interval: "1h", Enabled: false}}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	engine.mu.Lock()
+	engine.tasks = engine.loadTasks()
+	engine.noteConfigModLocked()
+	engine.mu.Unlock()
+
+	// External edit lands after the engine last touched the file. Force the
+	// mtime forward so coarse filesystem timestamps cannot make this flaky.
+	if err := engine.saveTasks([]HeartbeatTask{
+		{ID: "a", Title: "A", Interval: "1h", Enabled: false},
+		{ID: "b", Title: "added externally", Interval: "1h", Enabled: false},
+	}); err != nil {
+		t.Fatalf("external edit: %v", err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(engine.configPath(), future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	engine.tick() // disabled tasks only: adoption runs, nothing executes
+
+	tasks := engine.ListTasks()
+	if len(tasks) != 2 || tasks[1].ID != "b" {
+		t.Fatalf("tick did not adopt the external edit: %+v", tasks)
 	}
 }


### PR DESCRIPTION
## Summary

`heartbeat-tasks.json` is documented as human- and **AI-editable** (the file header in `desktop/heartbeat.go` and the heartbeat panel tip: "AI agents can also edit heartbeat-tasks.json"), but the engine only half-honored that contract:

- it loaded the file **once at startup** and scheduled from the in-memory copy, so an externally added task never ran until a manual Refresh or an app restart, and
- every run-state save (`mergeRunUpdatesLocked` persists the **full list** after a task fires) was based on that stale in-memory copy, so it **silently rolled back** external additions/edits/deletions — the same "my write didn't take" shape the session-data guard (#6123) exists to prevent, except here the product explicitly invites the edit.

## Changes

- `mergeRunUpdatesLocked` rebases onto the **on-disk** list before its full-list save. The engine owns only the run-state fields (`TopicID`, `LastRunAt`, `CreatedAt` backfill); task definitions added, edited, or deleted externally are adopted from disk, so the save can no longer roll an external edit back. A missing/unreadable file falls back to the in-memory list (historical behavior, and what the existing concurrent-edit test pins).
- `tick()` probes the config file's mtime and adopts external edits before scheduling, so an agent-added task runs on the next 30s tick instead of waiting for Refresh/restart. The engine records the mtime after its own writes (`Start`/`ReloadTasks`/`ReplaceTasks`/merge) so it does not re-read files it just wrote.
- `ReplaceTasks` (the UI panel save) keeps its whole-list semantics: saving what the panel shows is the user's explicit intent.

New regressions: external edit + addition survive a run-state save (in memory and on disk), and a tick adopts an externally added task (mtime forced forward so coarse filesystem timestamps cannot flake).

## Validation

- `cd desktop && go test .` (heartbeat suite incl. the 2 new regressions) and full `go test ./...` — green
- `go vet .` / `gofmt` — clean
- Existing `TestHeartbeatMergeRunUpdatesPreservesConcurrentEditsAndDeletes` still passes unchanged (missing-file fallback preserves its semantics)

Follow-up to the review discussion on #6123 (the guard correctly stopped hard-blocking this file; this PR makes the advertised editability actually work).
