### PR TITLE
Recover startup session lease retries / 恢复启动会话锁重试

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -523,6 +523,7 @@ func (a *App) tabsRestoredSignal() <-chan struct{} {
 func (a *App) showMainWindow() {
 	if a.ctx != nil {
 		showFromBackground(a.ctx, a.backgroundMaximised.Swap(false))
+		a.kickDeferredRebuildRetry()
 	}
 }
 
@@ -990,12 +991,23 @@ func (a *App) tabReadOnly(tabID string) bool {
 
 func (a *App) tabAndCtrlByID(tabID string) (*WorkspaceTab, control.SessionAPI) {
 	a.mu.RLock()
-	defer a.mu.RUnlock()
 	tab := a.tabByIDLocked(tabID)
 	if tab == nil {
+		a.mu.RUnlock()
 		return nil, nil
 	}
-	return tab, tab.Ctrl
+	ctrl := tab.Ctrl
+	retryStartup := ctrl == nil && tab.StartupErrLeaseHeld
+	a.mu.RUnlock()
+	if retryStartup && a.tryRecoverStartupLeaseHeldTab(tab) {
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+		if a.tabs[tab.ID] != tab {
+			return nil, nil
+		}
+		return tab, tab.Ctrl
+	}
+	return tab, ctrl
 }
 
 // activeTabAndCtrl snapshots the active tab and its controller in one locked
@@ -1192,7 +1204,7 @@ func (a *App) ensureTabControllerWorkspace(tab *WorkspaceTab) error {
 	if current := a.tabs[tab.ID]; current == tab {
 		tab.Ctrl = nil
 		tab.Ready = false
-		tab.StartupErr = ""
+		clearTabStartupError(tab)
 		tab.ActivityStatus = ""
 		if tab.sink == nil {
 			tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
@@ -1767,7 +1779,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	tab.SessionPath = path
 	tab.Label = newCtrl.Label()
 	tab.Ready = true
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	tab.goal = ""
 	// Supersede any in-flight startup build: the session it was resuming
 	// was just destroyed, and finishing later would pass the generation
@@ -3143,7 +3155,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		tab.SessionPath = sessionPath
 		applyTabSessionProfile(tab, profile)
 		tab.Ready = false
-		tab.StartupErr = ""
+		clearTabStartupError(tab)
 		tab.ActivityStatus = ""
 		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 		a.saveTabsLocked()
@@ -3185,7 +3197,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	tab.SessionPath = sessionPath
 	applyTabSessionProfile(tab, profile)
 	tab.Ready = false
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	tab.ActivityStatus = ""
 	tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 	a.saveTabsLocked()
@@ -7473,7 +7485,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	tab.model = modelRef
 	tab.effort = &effort
 	tab.Label = newCtrl.Label()
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	tab.Ready = true
 	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
@@ -7600,7 +7612,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	tab.model = modelRef
 	tab.tokenMode = mode
 	tab.Label = newCtrl.Label()
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	tab.Ready = true
 	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2137,6 +2137,7 @@ func TestDeferredRebuildRetryAppliesAfterLeaseRelease(t *testing.T) {
 		sink:        &tabEventSink{tabID: "tab_deferred_retry", app: app},
 		disabledMCP: map[string]ServerView{},
 	}
+	installNoopRuntimeEvents(app, tab.sink)
 	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
 	app.tabOrder = []string{tab.ID}
 	app.activeTabID = tab.ID
@@ -2247,6 +2248,7 @@ func TestDeferredRebuildWaitsForTabToBecomeActive(t *testing.T) {
 		sink:        &tabEventSink{tabID: "tab_pending", app: app},
 		disabledMCP: map[string]ServerView{},
 	}
+	installNoopRuntimeEvents(app, tab.sink)
 	other := &WorkspaceTab{
 		ID:          "tab_other",
 		Scope:       "global",

--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,18 +11,22 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/control"
 )
 
 // deferredRebuildRetryInterval is how often the retry loop probes a held
 // session lease. Package-level so tests can shorten it.
 var deferredRebuildRetryInterval = 2 * time.Second
 
+const deferredStartupBuildLabel = "__startup__"
+
 // deferredRebuildState tracks tabs whose settings were saved to disk but whose
-// runtime could not refresh because the session lease was held by another
-// Reasonix process. A single background loop probes the lease and replays the
-// rebuild once the other side releases it. The loop only runs after
-// enableDeferredRebuildRetry (the wails startup hook); tests that never call
-// it get the pending bookkeeping without a background goroutine.
+// runtime could not refresh, plus tabs whose initial startup failed, because
+// the session lease was held by another Reasonix process. A single background
+// loop probes the lease and replays the rebuild once the other side releases
+// it. The loop only runs after enableDeferredRebuildRetry (the wails startup
+// hook); tests that never call it get the pending bookkeeping without a
+// background goroutine.
 type deferredRebuildState struct {
 	mu      sync.Mutex
 	pending map[string]string // tab ID -> setting label for notices
@@ -73,6 +78,14 @@ func (a *App) scheduleDeferredRebuild(tabID, setting string) {
 	}
 	d.pending[tabID] = setting
 	a.startDeferredRebuildLoopLocked()
+}
+
+func (a *App) scheduleDeferredStartupBuild(tabID string) {
+	a.scheduleDeferredRebuild(tabID, deferredStartupBuildLabel)
+}
+
+func isDeferredStartupBuild(setting string) bool {
+	return setting == deferredStartupBuildLabel
 }
 
 func (a *App) clearDeferredRebuild(tabID string) {
@@ -127,10 +140,16 @@ func (a *App) deferredRebuildLoop(stop <-chan struct{}) {
 // deferredRebuildTickDone runs one retry pass and reports true when the loop
 // should exit because nothing is pending anymore.
 func (a *App) deferredRebuildTickDone() bool {
+	return a.deferredRebuildTick(true)
+}
+
+func (a *App) deferredRebuildTick(markIdle bool) bool {
 	d := &a.deferredRebuild
 	d.mu.Lock()
 	if d.stopped || len(d.pending) == 0 {
-		d.running = false
+		if markIdle {
+			d.running = false
+		}
 		d.mu.Unlock()
 		return true
 	}
@@ -146,6 +165,15 @@ func (a *App) deferredRebuildTickDone() bool {
 	return false
 }
 
+func (a *App) kickDeferredRebuildRetry() {
+	if a.ctx == nil {
+		return
+	}
+	a.goSafe("deferredRebuildKick", func() {
+		_ = a.deferredRebuildTick(false)
+	})
+}
+
 func (a *App) retryDeferredRebuild(tabID, setting string) {
 	if a.ctx == nil {
 		return
@@ -154,6 +182,10 @@ func (a *App) retryDeferredRebuild(tabID, setting string) {
 	if tab == nil || tab.ID != tabID {
 		// The tab is gone; nothing left to refresh.
 		a.clearDeferredRebuild(tabID)
+		return
+	}
+	if isDeferredStartupBuild(setting) {
+		a.retryDeferredStartupBuild(tabID, tab)
 		return
 	}
 	// Hold the rebuild mutex across probe + rebuild: the probe briefly acquires
@@ -198,6 +230,121 @@ func (a *App) retryDeferredRebuild(tabID, setting string) {
 	a.clearDeferredRebuild(tabID)
 	slog.Warn("desktop: deferred settings rebuild failed", "setting", setting, "tab", tabID, "err", err)
 	a.warnForTab(tabID, fmt.Sprintf("%s was saved but the session could not refresh: %s", setting, err.Error()))
+}
+
+func (a *App) retryDeferredStartupBuild(tabID string, tab *WorkspaceTab) {
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	if !a.tabHasRetryableStartupLeaseError(tab) {
+		a.clearDeferredRebuild(tabID)
+		return
+	}
+	if !a.deferredRebuildLeaseLooksFree(tab) {
+		return
+	}
+	err := a.rebuildStartupTabLocked(tab)
+	if err == nil {
+		a.clearDeferredRebuild(tabID)
+		return
+	}
+	if errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return
+	}
+	a.clearDeferredRebuild(tabID)
+	slog.Warn("desktop: deferred session startup failed", "tab", tabID, "err", err)
+}
+
+func (a *App) tabHasRetryableStartupLeaseError(tab *WorkspaceTab) bool {
+	if tab == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.tabs[tab.ID] == tab && !tab.removed && tab.Ctrl == nil && tab.StartupErrLeaseHeld
+}
+
+func (a *App) rebuildStartupTabLocked(tab *WorkspaceTab) error {
+	buildCtx, cancel := context.WithCancel(a.bootContext())
+	a.mu.Lock()
+	if tab == nil || a.tabs[tab.ID] != tab || tab.removed {
+		a.mu.Unlock()
+		cancel()
+		return nil
+	}
+	if tab.Ctrl != nil {
+		a.mu.Unlock()
+		cancel()
+		return nil
+	}
+	if !tab.StartupErrLeaseHeld {
+		a.mu.Unlock()
+		cancel()
+		return nil
+	}
+	tab.buildGeneration++
+	generation := tab.buildGeneration
+	if tab.buildCancel != nil {
+		tab.buildCancel()
+	}
+	tab.buildCancel = cancel
+	tab.Ready = false
+	clearTabStartupError(tab)
+	tab.ActivityStatus = ""
+	if tab.sink == nil {
+		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
+	}
+	a.saveTabsLocked()
+	a.mu.Unlock()
+
+	a.buildTabControllerWithContext(tab, loadedTabSession{}, buildCtx, generation, cancel)
+
+	a.mu.RLock()
+	stillCurrent := false
+	var ctrl control.SessionAPI
+	startupErr := ""
+	leaseHeld := false
+	if tab != nil {
+		stillCurrent = a.tabs[tab.ID] == tab && !tab.removed
+		ctrl = tab.Ctrl
+		startupErr = tab.StartupErr
+		leaseHeld = tab.StartupErrLeaseHeld
+	}
+	a.mu.RUnlock()
+	if !stillCurrent || ctrl != nil {
+		return nil
+	}
+	if leaseHeld {
+		return agent.ErrSessionLeaseHeld
+	}
+	if strings.TrimSpace(startupErr) != "" {
+		return fmt.Errorf("session startup: %s", startupErr)
+	}
+	return fmt.Errorf("session startup: controller was not built")
+}
+
+func (a *App) tryRecoverStartupLeaseHeldTab(tab *WorkspaceTab) bool {
+	if a.ctx == nil || !a.tabHasRetryableStartupLeaseError(tab) {
+		return false
+	}
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+	if !a.tabHasRetryableStartupLeaseError(tab) {
+		return a.controllerForTab(tab) != nil
+	}
+	if !a.deferredRebuildLeaseLooksFree(tab) {
+		return false
+	}
+	err := a.rebuildStartupTabLocked(tab)
+	if err == nil {
+		a.clearDeferredRebuild(tab.ID)
+		return a.controllerForTab(tab) != nil
+	}
+	if errors.Is(err, agent.ErrSessionLeaseHeld) {
+		a.scheduleDeferredStartupBuild(tab.ID)
+	} else {
+		a.clearDeferredRebuild(tab.ID)
+	}
+	return false
 }
 
 // deferredRebuildLeaseLooksFree cheaply probes whether the tab's session lease

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1563,10 +1563,14 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	})
 	if err != nil {
 		if oldCtrl == nil {
+			leaseHeld := false
 			a.mu.Lock()
-			tab.StartupErr = err.Error()
+			leaseHeld = setTabStartupError(tab, err)
 			tab.Ready = true
 			a.mu.Unlock()
+			if leaseHeld {
+				a.scheduleDeferredStartupBuild(tab.ID)
+			}
 			a.emitReady(a.ctx)
 		}
 		return err
@@ -1601,7 +1605,7 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	tab.Ctrl = ctrl
 	tab.model = model
 	tab.Label = ctrl.Label()
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	tab.Ready = true
 	// Supersede any in-flight startup build: it would otherwise finish later,
 	// pass its generation check, and overwrite the controller just installed.
@@ -2379,7 +2383,7 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 		a.supersedeTabBuildLocked(tab)
 		tab.model = fallbackRef
 		tab.Label = fallbackRef
-		tab.StartupErr = ""
+		clearTabStartupError(tab)
 		tab.Ready = a.ctx == nil
 		if a.ctx != nil {
 			rebuildTabs = append(rebuildTabs, tab)
@@ -2498,7 +2502,7 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 		a.supersedeTabBuildLocked(tab)
 		tab.model = fallbackRef
 		tab.Label = fallbackRef
-		tab.StartupErr = ""
+		clearTabStartupError(tab)
 		tab.Ready = a.ctx == nil
 		if a.ctx != nil {
 			rebuildTabs = append(rebuildTabs, tab)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -39,25 +39,26 @@ import (
 // memory, permissions) scoped to a workspace root, so multiple projects and
 // topics can be active concurrently without interfering.
 type WorkspaceTab struct {
-	ID              string             // stable random id
-	Scope           string             // "project" | "global"
-	WorkspaceRoot   string             // project root dir (empty for global)
-	SharedHostKey   string             // opaque key for the shared plugin host (set by buildTabController)
-	TopicID         string             // topic within the project
-	TopicTitle      string             // display title
-	SessionPath     string             // exact .jsonl file this tab continues
-	ReadOnly        bool               // true for external channel transcripts opened for browsing
-	Ctrl            control.SessionAPI // nil while booting / on error
-	Label           string             // model label (for the tab badge)
-	Ready           bool               // true once boot.Build completes
-	StartupErr      string             // build error, surfaced to the frontend
-	sessionLease    *agent.SessionLease
-	sessionLeaseMu  sync.Mutex
-	sink            *tabEventSink      // routes events with this tab's ID
-	buildCancel     context.CancelFunc // cancels in-flight boot for tabs removed before Ready
-	buildGeneration uint64             // identifies the current in-flight build
-	removed         bool               // set when the visible tab is pruned/closed before build completes
-	reconcileMu     sync.Mutex         // serializes stale controller workspace repair for this tab
+	ID                  string             // stable random id
+	Scope               string             // "project" | "global"
+	WorkspaceRoot       string             // project root dir (empty for global)
+	SharedHostKey       string             // opaque key for the shared plugin host (set by buildTabController)
+	TopicID             string             // topic within the project
+	TopicTitle          string             // display title
+	SessionPath         string             // exact .jsonl file this tab continues
+	ReadOnly            bool               // true for external channel transcripts opened for browsing
+	Ctrl                control.SessionAPI // nil while booting / on error
+	Label               string             // model label (for the tab badge)
+	Ready               bool               // true once boot.Build completes
+	StartupErr          string             // build error, surfaced to the frontend
+	StartupErrLeaseHeld bool               // true when StartupErr can be retried after a session lease releases
+	sessionLease        *agent.SessionLease
+	sessionLeaseMu      sync.Mutex
+	sink                *tabEventSink      // routes events with this tab's ID
+	buildCancel         context.CancelFunc // cancels in-flight boot for tabs removed before Ready
+	buildGeneration     uint64             // identifies the current in-flight build
+	removed             bool               // set when the visible tab is pruned/closed before build completes
+	reconcileMu         sync.Mutex         // serializes stale controller workspace repair for this tab
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
@@ -479,6 +480,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab 
 		Label:               tab.Label,
 		Ready:               tab.Ready,
 		StartupErr:          tab.StartupErr,
+		StartupErrLeaseHeld: tab.StartupErrLeaseHeld,
 		sink:                tab.sink,
 		ActivityStatus:      tab.ActivityStatus,
 		readTelemetry:       readTelemetry,
@@ -569,7 +571,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
 	target.Ready = true
-	target.StartupErr = ""
+	clearTabStartupError(target)
 	target.ActivityStatus = source.ActivityStatus
 	target.model = source.model
 	target.effort = cloneStringPtr(source.effort)
@@ -2604,6 +2606,23 @@ func (a *App) desktopControllerSink(inner event.Sink, cfg config.NotificationsCo
 	return notify.NewSink(inner, sender, cfg)
 }
 
+func setTabStartupError(tab *WorkspaceTab, err error) bool {
+	if tab == nil {
+		return false
+	}
+	tab.StartupErr = userFacingSessionLeaseError("", err).Error()
+	tab.StartupErrLeaseHeld = errors.Is(err, agent.ErrSessionLeaseHeld)
+	return tab.StartupErrLeaseHeld
+}
+
+func clearTabStartupError(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	tab.StartupErr = ""
+	tab.StartupErrLeaseHeld = false
+}
+
 func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loadedTabSession, buildCtx context.Context, buildGeneration uint64, buildCancel context.CancelFunc) {
 	defer a.recoverToPending("buildTabController")
 	keepBuildContext := false
@@ -2640,15 +2659,19 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	_ = config.MigrateLegacyCredentialsForRoot(root)
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
+		leaseHeld := false
 		a.mu.Lock()
 		if a.tabBuildSupersededLocked(tab, buildGeneration) {
 			a.mu.Unlock()
 			return
 		}
-		tab.StartupErr = userFacingSessionLeaseError("", err).Error()
+		leaseHeld = setTabStartupError(tab, err)
 		tab.Ready = true
 		tab.releaseSessionLease()
 		a.mu.Unlock()
+		if leaseHeld {
+			a.scheduleDeferredStartupBuild(tab.ID)
+		}
 		a.emitReady(wailsCtx, tab.ID)
 		return
 	}
@@ -2765,19 +2788,23 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
 	})
 	if err != nil {
+		leaseHeld := false
 		a.mu.Lock()
 		if a.tabBuildSupersededLocked(tab, buildGeneration) {
 			a.mu.Unlock()
 			a.abandonSupersededBuild(tab, nil, rootKey, "")
 			return
 		}
-		tab.StartupErr = userFacingSessionLeaseError("", err).Error()
+		leaseHeld = setTabStartupError(tab, err)
 		tab.Ready = true
 		hostKey := takeTabSharedHostKey(tab)
 		tab.releaseSessionLease()
 		a.mu.Unlock()
 		if hostKey != "" {
 			a.releaseSharedHost(hostKey)
+		}
+		if leaseHeld {
+			a.scheduleDeferredStartupBuild(tab.ID)
 		}
 		a.emitReady(wailsCtx, tab.ID)
 		return
@@ -2850,13 +2877,14 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 			}
 			preLeaseKey := tab.sessionLeaseRuntimeKey()
 			if err := tab.ensureSessionLease(path); err != nil {
+				leaseHeld := false
 				a.mu.Lock()
 				if a.tabBuildSupersededLocked(tab, buildGeneration) {
 					a.mu.Unlock()
 					a.abandonSupersededBuild(tab, ctrl, rootKey, "")
 					return
 				}
-				tab.StartupErr = userFacingSessionLeaseError("", err).Error()
+				leaseHeld = setTabStartupError(tab, err)
 				tab.Ready = true
 				hostKey := takeTabSharedHostKey(tab)
 				// Release only a lease bound to THIS build's session: a failed
@@ -2867,6 +2895,9 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				ctrl.Close()
 				if hostKey != "" {
 					a.releaseSharedHost(hostKey)
+				}
+				if leaseHeld {
+					a.scheduleDeferredStartupBuild(tab.ID)
 				}
 				a.emitReady(wailsCtx, tab.ID)
 				return
@@ -2929,7 +2960,7 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	tab.Ctrl = ctrl
 	tab.Label = ctrl.Label()
 	tab.Ready = true
-	tab.StartupErr = ""
+	clearTabStartupError(tab)
 	keepBuildContext = true
 	a.mu.Unlock()
 	a.emitReady(wailsCtx, tab.ID)

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -32,6 +32,18 @@ func testAppWithOrderedTabs(t *testing.T, active string, ids ...string) *App {
 	return &App{tabs: tabs, tabOrder: append([]string(nil), ids...), activeTabID: active}
 }
 
+func installNoopRuntimeEvents(app *App, sinks ...*tabEventSink) {
+	emit := func(context.Context, string, ...interface{}) {}
+	if app != nil {
+		app.runtimeEvents.emit = emit
+	}
+	for _, sink := range sinks {
+		if sink != nil {
+			sink.runtimeEvents.emit = emit
+		}
+	}
+}
+
 func tabIDs(tabs []TabMeta) []string {
 	ids := make([]string, 0, len(tabs))
 	for _, tab := range tabs {
@@ -918,6 +930,142 @@ func TestBuildTabControllerBlocksWhenSessionLeaseHeld(t *testing.T) {
 	if strings.Contains(tab.StartupErr, agent.ErrSessionLeaseHeld.Error()) ||
 		strings.Contains(tab.StartupErr, path) {
 		t.Fatalf("startup error leaked raw lease details: %q", tab.StartupErr)
+	}
+}
+
+func TestDeferredStartupRetryBuildsAfterLeaseRelease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	prevInterval := deferredRebuildRetryInterval
+	deferredRebuildRetryInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deferredRebuildRetryInterval = prevInterval })
+
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "startup-retry.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			lease.Release()
+		}
+	})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.enableDeferredRebuildRetry()
+	t.Cleanup(app.stopDeferredRebuildRetry)
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "startup_retry")
+	tab.SessionPath = path
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	installNoopRuntimeEvents(app, tab.sink)
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if ctrl := app.controllerForTab(tab); ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	app.buildTabController(tab)
+	if tab.Ctrl != nil {
+		t.Fatalf("controller = %T, want nil while external lease is held", tab.Ctrl)
+	}
+	if !tab.StartupErrLeaseHeld {
+		t.Fatalf("startup retry flag = false, startup err = %q", tab.StartupErr)
+	}
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("startup retry was not scheduled while the lease was held")
+	}
+
+	lease.Release()
+	released = true
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !app.deferredRebuildPending(tab.ID) && app.controllerForTab(tab) != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if app.deferredRebuildPending(tab.ID) {
+		t.Fatal("startup retry is still pending after the lease was released")
+	}
+	if ctrl := app.controllerForTab(tab); ctrl == nil {
+		t.Fatal("controller was not rebuilt after the lease was released")
+	}
+	if tab.StartupErr != "" || tab.StartupErrLeaseHeld {
+		t.Fatalf("startup error after retry = %q retryable=%v, want cleared", tab.StartupErr, tab.StartupErrLeaseHeld)
+	}
+}
+
+func TestTabAndCtrlByIDRecoversStartupLeaseBeforeAction(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "startup-before-action.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			lease.Release()
+		}
+	})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "startup_action")
+	tab.SessionPath = path
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	installNoopRuntimeEvents(app, tab.sink)
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if ctrl := app.controllerForTab(tab); ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	app.buildTabController(tab)
+	if !tab.StartupErrLeaseHeld {
+		t.Fatalf("startup retry flag = false, startup err = %q", tab.StartupErr)
+	}
+	lease.Release()
+	released = true
+
+	gotTab, ctrl := app.tabAndCtrlByID(tab.ID)
+	if gotTab != tab {
+		t.Fatalf("tabAndCtrlByID tab = %p, want %p", gotTab, tab)
+	}
+	if ctrl == nil {
+		t.Fatal("tabAndCtrlByID did not rebuild the controller before returning")
+	}
+	if app.deferredRebuildPending(tab.ID) {
+		t.Fatal("startup retry remained pending after synchronous recovery")
+	}
+	if tab.StartupErr != "" || tab.StartupErrLeaseHeld {
+		t.Fatalf("startup error after synchronous recovery = %q retryable=%v, want cleared", tab.StartupErr, tab.StartupErrLeaseHeld)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Retry desktop tab startup when a saved session lease is still held by another Reasonix process and later becomes available.
- Reuse the deferred rebuild loop for startup lease recovery and kick it when the app window is shown again.
- Retry synchronously before tab actions so send and terminal paths can recover instead of leaving a stale startup error banner.

## Tests
- cd desktop && go test -run 'TestBuildTabControllerBlocksWhenSessionLeaseHeld|TestDeferredStartupRetryBuildsAfterLeaseRelease|TestTabAndCtrlByIDRecoversStartupLeaseBeforeAction|TestDeferredRebuildRetryAppliesAfterLeaseRelease|TestDeferredRebuildWaitsForTabToBecomeActive|TestConfigChangeLeaseHeldPersistsAndDefersRefresh|LeaseHeld|RecoveryFailed' .\n- cd desktop && go test -short .\n- go test ./internal/agent\n- git diff --check\n- cd desktop && wails build