### PR TITLE
fix auto approval for compound bash / 修复复合 bash 自动审批

### DIFF
--- a/internal/permission/bash_decompose_test.go
+++ b/internal/permission/bash_decompose_test.go
@@ -246,6 +246,40 @@ func TestPolicyDecideCompoundBash(t *testing.T) {
 	}
 }
 
+func TestPolicyDecideCompoundBashUsesWriterFallback(t *testing.T) {
+	command := `$file = Get-ChildItem -Path "D:\fixtures\reports" -Filter "*sample*.txt" | Select-Object -First 1; python -c "import sys; f=open(sys.argv[1], 'r', encoding='utf-8'); print(f.read()[:10000]); f.close()" $file.FullName`
+
+	cases := []struct {
+		name string
+		mode string
+		want Decision
+	}{
+		{
+			name: "auto writer fallback allows uncovered compound bash segments",
+			mode: "allow",
+			want: Allow,
+		},
+		{
+			name: "ask writer fallback still prompts for uncovered compound bash segments",
+			mode: "ask",
+			want: Ask,
+		},
+		{
+			name: "deny writer fallback still blocks uncovered compound bash segments",
+			mode: "deny",
+			want: Deny,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New(tt.mode, nil, nil, nil)
+			if got := p.DecideSubject("bash", false, command); got != tt.want {
+				t.Fatalf("DecideSubject(mode=%q) = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPolicyDecideCompoundBashPreservesWholeCommandRules(t *testing.T) {
 	subject := `git add . && git commit -m "wip" && git push`
 

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -175,7 +175,8 @@ func (p Policy) DecideSubject(toolName string, readOnly bool, subject string) De
 //
 // Precedence stays deny > ask > allow > fallback. Any single segment hitting
 // deny denies the whole call; any segment needing approval turns the whole
-// call into Ask; the whole call is Allow only if every segment is covered.
+// call into Ask; the whole call is Allow only if every segment is covered or
+// writer fallback allows uncovered segments.
 // A segment recognized as read-only by shellsafe (echo/ls/git status/...) is
 // allowed on its own without a rule, matching the behavior of an atomic
 // read-only bash call.
@@ -198,9 +199,16 @@ func (p Policy) decideBashSegments(readOnly bool, parts []string) Decision {
 		case segReadOnly:
 			// covered
 		default:
-			// segment not covered — surface as Ask, but keep scanning for a
-			// downstream Deny that would still trump.
-			out = Ask
+			// Segment not covered by a rule or read-only classification: apply
+			// the same writer fallback used for atomic bash commands.
+			switch p.Mode {
+			case Deny:
+				return Deny
+			case Ask:
+				out = Ask
+			default:
+				// covered by fallback allow
+			}
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary

- Make compound bash segment fallback honor the permission policy mode.
- Prevent Auto approval from prompting on uncovered compound bash segments when writer fallback is allow.
- Add regression coverage for a PowerShell-style pipeline/semicolon command across allow, ask, and deny modes.

## Root Cause

Compound bash commands are decomposed into simple-command segments. Uncovered segments previously forced Ask directly instead of applying the same writer fallback used by atomic bash commands, so Auto approval could still show a bash approval prompt.

## Tests

- go test ./internal/permission
- go test ./internal/control
