### PR TITLE
fix(desktop): ignore resume lag false positives

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -143,6 +143,11 @@ eq(shouldRecordLongTaskSample(570_000, 92, 15_000, false, 20_000, false), false,
 eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag while the window is hidden");
 eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
 eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");
+eq(
+  shouldRecordEventLoopLagSample(false, 60_000, true, 3_000),
+  false,
+  "ignores event-loop lag immediately after focus resumes",
+);
 eq(shouldRecordEventLoopLagSample(false, 60_000, false), false, "ignores event-loop lag while unfocused");
 
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false), true, "prompts an unhandled label past cooldown while visible");

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -377,10 +377,11 @@ export function shouldRecordEventLoopLagSample(
   visibilityHidden: boolean,
   msSinceVisible: number,
   focused = true,
+  msSinceFocused = msSinceVisible,
 ): boolean {
   if (!focused) return false;
   if (visibilityHidden) return false;
-  return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS;
+  return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS && msSinceFocused >= VISIBILITY_RESUME_GRACE_MS;
 }
 
 export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPayload {
@@ -634,9 +635,18 @@ export function installPerformancePressureMonitor() {
   const isHidden = () => typeof document !== "undefined" && document.visibilityState === "hidden";
   const isFocused = () => typeof document === "undefined" || document.hasFocus?.() !== false;
   let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
+  let focusedSince = isFocused() ? startedAt : Number.POSITIVE_INFINITY;
   let expected = performance.now() + 1000;
 
   const pastGrace = () => performance.now() >= graceUntil;
+  const resetSamples = () => {
+    const now = performance.now();
+    longTasks.length = 0;
+    lagSamples.length = 0;
+    expected = now + 1000;
+    visibleSince = isHidden() ? Number.POSITIVE_INFINITY : now;
+    focusedSince = isFocused() ? now : Number.POSITIVE_INFINITY;
+  };
   const inspectLongTasks = () => {
     if (!pastGrace()) return;
     const summary = longTaskSummary();
@@ -647,13 +657,10 @@ export function installPerformancePressureMonitor() {
   };
 
   if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", () => {
-      longTasks.length = 0;
-      lagSamples.length = 0;
-      expected = performance.now() + 1000;
-      if (!isHidden()) visibleSince = performance.now();
-    });
+    document.addEventListener("visibilitychange", resetSamples);
   }
+  window.addEventListener("focus", resetSamples);
+  window.addEventListener("blur", resetSamples);
 
   if (typeof PerformanceObserver !== "undefined") {
     try {
@@ -676,7 +683,7 @@ export function installPerformancePressureMonitor() {
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
     if (!pastGrace()) return;
-    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused())) return;
+    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused(), now - focusedSince)) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);


### PR DESCRIPTION
## Summary

- Reset desktop performance-pressure sampling on window focus and blur, not just visibility changes.
- Require the event-loop lag monitor to pass both visibility-resume and focus-resume grace windows before prompting.
- Add regression coverage for lag samples immediately after focus resumes.
- Fixes #5909.

## Verification

- `corepack pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/crash-reporting.test.ts`
- `corepack pnpm -C desktop/frontend --ignore-workspace run test:typecheck`
- `git diff --check`

## Cache impact

Cache-impact: none - frontend performance-pressure prompt gating only; no provider-visible prompt, tool schema, MCP registration, or provider request serialization changes.
Cache-guard: `corepack pnpm -C desktop/frontend --ignore-workspace exec tsx src/__tests__/crash-reporting.test.ts`; `corepack pnpm -C desktop/frontend --ignore-workspace run test:typecheck`; `git diff --check`
System-prompt-review: N/A
