### PR TITLE
fix(agent): dedupe reasoning language context

### DIFF
--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -236,6 +236,18 @@ func hasLeadingInjectedBlock(content, target string) bool {
 			if !ok {
 				return false
 			}
+		case strings.HasPrefix(s, "<active-goal>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "active-goal")
+			if !ok {
+				return false
+			}
+		case strings.HasPrefix(s, "<capability-route"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "capability-route")
+			if !ok {
+				return false
+			}
 		default:
 			return false
 		}

--- a/internal/agent/reasoning_language_test.go
+++ b/internal/agent/reasoning_language_test.go
@@ -39,6 +39,16 @@ func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 	if got := WithReasoningLanguage(withLeadingMemory, "zh"); got != withLeadingMemory {
 		t.Fatalf("WithReasoningLanguage duplicated a reasoning block after leading transient context:\n got %q\nwant %q", got, withLeadingMemory)
 	}
+
+	withGoalContext := "<active-goal>\nfinish the current goal\n</active-goal>\n\n" + alreadyPrefixed
+	if got := WithReasoningLanguage(withGoalContext, "zh"); got != withGoalContext {
+		t.Fatalf("WithReasoningLanguage duplicated a reasoning block after active goal context:\n got %q\nwant %q", got, withGoalContext)
+	}
+
+	withCapabilityContext := "<capability-route version=\"1\">\nroute: code\n</capability-route>\n\n" + alreadyPrefixed
+	if got := WithReasoningLanguage(withCapabilityContext, "zh"); got != withCapabilityContext {
+		t.Fatalf("WithReasoningLanguage duplicated a reasoning block after capability route context:\n got %q\nwant %q", got, withCapabilityContext)
+	}
 }
 
 func TestWithReasoningLanguageAutoInfersFromSource(t *testing.T) {


### PR DESCRIPTION
## Summary

Avoid adding a second `<reasoning-language>` block when turn context such as `<active-goal>` or `<capability-route>` already precedes an injected reasoning language preference.

Refs #6090.

## Tests

- `go test ./internal/agent -run TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock -count=1`
- `go test ./internal/agent ./internal/control -count=1`
- `go test ./internal/... -count=1`
- `git diff --check HEAD~1..HEAD`