### PR TITLE
Support Claude plugin manifest installs / 支持 Claude 插件清单安装

### DIFF
--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -17,8 +17,8 @@ directory.
   `https://github.com/obra/superpowers`.
 - A GitHub branch or subdirectory URL, such as
   `https://github.com/owner/repo/tree/main/path/to/plugin`.
-- A local directory that contains `reasonix-plugin.json` or
-  `.codex-plugin/plugin.json`.
+- A local directory that contains `reasonix-plugin.json`,
+  `.codex-plugin/plugin.json`, or `.claude-plugin/plugin.json`.
 
 Preview the install plan without writing files:
 
@@ -224,8 +224,9 @@ third-party install scripts during plugin installation.
 
 ## Codex Compatibility
 
-Reasonix also reads Codex plugin manifests at `.codex-plugin/plugin.json`.
-For packages such as Superpowers and Claude-style skill packs, Reasonix maps:
+Reasonix also reads Codex plugin manifests at `.codex-plugin/plugin.json` and
+Claude Marketplace manifests at `.claude-plugin/plugin.json`. For packages such
+as Superpowers and Claude-style skill packs, Reasonix maps:
 
 - `skills` to Reasonix skill roots.
 - `hooks/session-start-codex` to the Reasonix `SessionStart` hook when present.

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -222,13 +222,19 @@ Reasonix plugins can declare `reasonix-plugin.json` at the plugin root:
 Relative paths are resolved inside the plugin root. Reasonix does not run
 third-party install scripts during plugin installation.
 
-## Codex Compatibility
+## Codex & Claude Compatibility
 
 Reasonix also reads Codex plugin manifests at `.codex-plugin/plugin.json` and
-Claude Marketplace manifests at `.claude-plugin/plugin.json`. For packages such
+Claude Marketplace manifests at `.claude-plugin/plugin.json`. Claude plugin
+capabilities Reasonix does not map yet (`commands/`, `agents/`,
+`hooks/hooks.json`, `.mcp.json`) surface as install warnings instead of being
+silently dropped; multi-plugin `marketplace.json` indexes are not supported —
+install each plugin directory individually. For packages such
 as Superpowers and Claude-style skill packs, Reasonix maps:
 
-- `skills` to Reasonix skill roots.
+- `skills` to Reasonix skill roots. A Claude manifest that declares no
+  `skills` field falls back to the conventional `skills/` (or `.claude/skills/`)
+  directory, matching Claude's own auto-discovery.
 - `hooks/session-start-codex` to the Reasonix `SessionStart` hook when present.
 - A plugin-root `CLAUDE.md` file to a built-in `SessionStart` context hook. The
   file is read directly by Reasonix, without spawning a shell command.

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -15,8 +15,8 @@ Reasonix 插件包把 skills、hooks 和 MCP servers 组织成一个可安装单
   `https://github.com/obra/superpowers`。
 - GitHub 分支或子目录 URL，例如
   `https://github.com/owner/repo/tree/main/path/to/plugin`。
-- 本地目录，目录内需要包含 `reasonix-plugin.json` 或
-  `.codex-plugin/plugin.json`。
+- 本地目录，目录内需要包含 `reasonix-plugin.json`、
+  `.codex-plugin/plugin.json` 或 `.claude-plugin/plugin.json`。
 
 只预览安装计划，不写文件：
 
@@ -206,8 +206,8 @@ Reasonix 原生插件在根目录声明 `reasonix-plugin.json`：
 
 ## Codex 兼容
 
-Reasonix 也会读取 `.codex-plugin/plugin.json`。对于 Superpowers 和 Claude 风格
-skill 包，Reasonix 会映射：
+Reasonix 也会读取 `.codex-plugin/plugin.json` 和 `.claude-plugin/plugin.json`。
+对于 Superpowers 和 Claude 风格 skill 包，Reasonix 会映射：
 
 - `skills` 到 Reasonix skill root。
 - 如果存在 `hooks/session-start-codex`，映射为 Reasonix `SessionStart` hook。

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -204,12 +204,16 @@ Reasonix 原生插件在根目录声明 `reasonix-plugin.json`：
 
 相对路径都按插件根目录解析。Reasonix 安装插件时不会执行第三方安装脚本。
 
-## Codex 兼容
+## Codex 与 Claude 兼容
 
 Reasonix 也会读取 `.codex-plugin/plugin.json` 和 `.claude-plugin/plugin.json`。
+Reasonix 尚未映射的 Claude 插件能力（`commands/`、`agents/`、`hooks/hooks.json`、
+`.mcp.json`）会以安装警告的形式提示，而不是被静默丢弃；多插件的
+`marketplace.json` 索引暂不支持——请逐个安装插件目录。
 对于 Superpowers 和 Claude 风格 skill 包，Reasonix 会映射：
 
-- `skills` 到 Reasonix skill root。
+- `skills` 到 Reasonix skill root。Claude 清单若未声明 `skills` 字段，会回退到
+  约定目录 `skills/`（或 `.claude/skills/`），与 Claude 自身的自动发现一致。
 - 如果存在 `hooks/session-start-codex`，映射为 Reasonix `SessionStart` hook。
 - 插件根目录的 `CLAUDE.md` 会映射为内置的 `SessionStart` 上下文 hook。
   Reasonix 会直接读取该文件，不通过 shell 命令。

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -275,10 +275,6 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				if item.Installed.Version != "" {
 					env["REASONIX_PLUGIN_VERSION"] = item.Installed.Version
 				}
-				manifestFile := pluginpkg.NativeManifest
-				if pkg.ManifestKind == "codex" {
-					manifestFile = pluginpkg.CodexManifest
-				}
 				*out = append(*out, ResolvedHook{
 					HookConfig: HookConfig{
 						Match:       h.Match,
@@ -291,7 +287,7 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 					},
 					Event:  event,
 					Scope:  ScopePlugin,
-					Source: filepath.Join(pkg.Root, manifestFile),
+					Source: filepath.Join(pkg.Root, pluginpkg.ManifestPath(pkg.ManifestKind)),
 				})
 			}
 		}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -186,6 +186,52 @@ func TestApplyLocalCodexPluginPackage(t *testing.T) {
 	}
 }
 
+func TestApplyLocalClaudePluginPackage(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(t.TempDir(), "ui-ux-pro-max")
+	writeFile(t, filepath.Join(src, ".claude-plugin", "plugin.json"), `{
+  "name": "ui-ux-pro-max",
+  "version": "2.6.2",
+  "description": "UI/UX design intelligence",
+  "skills": "./.claude/skills/"
+}`)
+	writeFile(t, filepath.Join(src, ".claude", "skills", "ui-ux-pro-max", "SKILL.md"), "---\nname: ui-ux-pro-max\ndescription: UI design helper\n---\nUse design rules.")
+	writeFile(t, filepath.Join(src, "CLAUDE.md"), "Use the bundled UI workflow.")
+
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	planned := execInstall(t, tl, map[string]any{
+		"source": src,
+		"kind":   "plugin",
+	})
+	if planned.Kind != "plugin" || planned.Kinds.Plugin != 1 {
+		t.Fatalf("planned = %+v, want one plugin action", planned)
+	}
+	if planned.Actions[0].Name != "ui-ux-pro-max" || planned.Actions[0].ManifestKind != "claude" || planned.Actions[0].SkillCount != 1 || planned.Actions[0].HookCount != 1 {
+		t.Fatalf("plugin action = %+v", planned.Actions[0])
+	}
+
+	done := execInstall(t, tl, map[string]any{
+		"source": src,
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if !done.OK || done.Status != "done" {
+		t.Fatalf("apply response = %+v", done)
+	}
+	statePath := filepath.Join(home, ".reasonix", "plugin-packages.json")
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("state file missing: %v", err)
+	}
+	if !strings.Contains(string(raw), `"name": "ui-ux-pro-max"`) || !strings.Contains(string(raw), `"manifestKind": "claude"`) {
+		t.Fatalf("state file = %s", raw)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".reasonix", "plugins", "ui-ux-pro-max", ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatalf("installed plugin missing: %v", err)
+	}
+}
+
 func TestApplyLocalSkillFileCopiesToProject(t *testing.T) {
 	project := t.TempDir()
 	home := t.TempDir()

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -27,7 +27,7 @@ func (t *installSourceTool) planGitHubPluginPackage(ctx context.Context, req req
 	}
 	var warnings []string
 	for _, branch := range src.branches() {
-		for _, manifestPath := range []string{pluginpkg.NativeManifest, pluginpkg.CodexManifest} {
+		for _, manifestPath := range pluginpkg.ManifestPaths() {
 			rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", src.Owner, src.Repo, branch, joinURLPath(src.Path, manifestPath))
 			body, err := t.fetchText(ctx, rawURL)
 			if err != nil {

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -363,11 +363,67 @@ func parseCodexLike(path, root, kind string, includeCodexSessionStartHook bool) 
 			}
 		}
 	}
-	warnings := applyClaudeCompatibility(root, &manifest)
+	var warnings []string
+	if kind == "claude" {
+		warnings = append(warnings, applyClaudeConventionDirs(root, &manifest)...)
+	}
+	warnings = append(warnings, applyClaudeCompatibility(root, &manifest)...)
 	if err := validateManifest(root, &manifest); err != nil {
 		return Package{}, warnings, err
 	}
 	return Package{Root: root, ManifestKind: kind, Manifest: manifest}, warnings, nil
+}
+
+// claudeConventionSkillDirs are the directories a Claude plugin loads skills
+// from BY CONVENTION — the official plugin layout auto-discovers skills/ (and
+// packs in the wild use .claude/skills/) without declaring them in
+// plugin.json, whose manifest usually carries metadata only.
+var claudeConventionSkillDirs = []string{"skills", ".claude/skills"}
+
+// claudeUnmappedCapabilities are the conventional Claude plugin surfaces
+// Reasonix does not map yet. Their presence is worth a warning: silently
+// installing a package while dropping half its capabilities reads as "install
+// succeeded" when it mostly didn't.
+var claudeUnmappedCapabilities = []string{"commands", "agents", "hooks/hooks.json", ".mcp.json"}
+
+// applyClaudeConventionDirs fills manifest.Skills from the conventional skill
+// directories when the manifest declares none (the standard Claude plugin
+// shape), and reports the conventional capabilities Reasonix cannot map.
+func applyClaudeConventionDirs(root string, manifest *Manifest) []string {
+	var warnings []string
+	if len(manifest.Skills) == 0 {
+		for _, rel := range claudeConventionSkillDirs {
+			dir := filepath.Join(root, filepath.FromSlash(rel))
+			if dirContainsSkill(dir) {
+				manifest.Skills = append(manifest.Skills, rel)
+			}
+		}
+	}
+	for _, rel := range claudeUnmappedCapabilities {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err == nil {
+			warnings = append(warnings, fmt.Sprintf("claude plugin declares %s, which Reasonix does not map yet; that capability will not be installed", rel))
+		}
+	}
+	return warnings
+}
+
+// dirContainsSkill reports whether dir holds at least one skill definition
+// (<dir>/<name>/SKILL.md), so an empty conventional directory is not adopted
+// as a skill root.
+func dirContainsSkill(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if info, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil && info.Mode().IsRegular() {
+			return true
+		}
+	}
+	return false
 }
 
 func ManifestPath(kind string) string {

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -23,6 +23,7 @@ import (
 const (
 	NativeManifest = "reasonix-plugin.json"
 	CodexManifest  = ".codex-plugin/plugin.json"
+	ClaudeManifest = ".claude-plugin/plugin.json"
 	StateFilename  = "plugin-packages.json"
 
 	claudeSettingsPath = ".claude/settings.json"
@@ -274,7 +275,10 @@ func ParseDir(root string) (Package, []string, error) {
 	if pkg, warnings, err := parseCodex(filepath.Join(root, CodexManifest), root); err == nil {
 		return pkg, warnings, nil
 	}
-	return Package{}, nil, fmt.Errorf("no %s or %s found", NativeManifest, CodexManifest)
+	if pkg, warnings, err := parseClaudePlugin(filepath.Join(root, ClaudeManifest), root); err == nil {
+		return pkg, warnings, nil
+	}
+	return Package{}, nil, fmt.Errorf("no %s, %s, or %s found", NativeManifest, CodexManifest, ClaudeManifest)
 }
 
 func parseNative(path, root string) (Package, []string, error) {
@@ -316,6 +320,14 @@ func parseNative(path, root string) (Package, []string, error) {
 }
 
 func parseCodex(path, root string) (Package, []string, error) {
+	return parseCodexLike(path, root, "codex", true)
+}
+
+func parseClaudePlugin(path, root string) (Package, []string, error) {
+	return parseCodexLike(path, root, "claude", false)
+}
+
+func parseCodexLike(path, root, kind string, includeCodexSessionStartHook bool) (Package, []string, error) {
 	var raw struct {
 		Name        string          `json:"name"`
 		Version     string          `json:"version"`
@@ -340,20 +352,39 @@ func parseCodex(path, root string) (Package, []string, error) {
 		Skills:      skills,
 	}
 	hookPath := filepath.Join(root, "hooks", "session-start-codex")
-	if info, err := os.Stat(hookPath); err == nil && info.Mode().IsRegular() {
-		manifest.Hooks = map[string][]Hook{
-			"SessionStart": {{
-				Command:     hookPath,
-				Cwd:         root,
-				Description: "Codex-compatible session start hook from " + manifest.Name,
-			}},
+	if includeCodexSessionStartHook {
+		if info, err := os.Stat(hookPath); err == nil && info.Mode().IsRegular() {
+			manifest.Hooks = map[string][]Hook{
+				"SessionStart": {{
+					Command:     hookPath,
+					Cwd:         root,
+					Description: "Codex-compatible session start hook from " + manifest.Name,
+				}},
+			}
 		}
 	}
 	warnings := applyClaudeCompatibility(root, &manifest)
 	if err := validateManifest(root, &manifest); err != nil {
 		return Package{}, warnings, err
 	}
-	return Package{Root: root, ManifestKind: "codex", Manifest: manifest}, warnings, nil
+	return Package{Root: root, ManifestKind: kind, Manifest: manifest}, warnings, nil
+}
+
+func ManifestPath(kind string) string {
+	switch kind {
+	case "reasonix":
+		return NativeManifest
+	case "codex":
+		return CodexManifest
+	case "claude":
+		return ClaudeManifest
+	default:
+		return NativeManifest
+	}
+}
+
+func ManifestPaths() []string {
+	return []string{NativeManifest, CodexManifest, ClaudeManifest}
 }
 
 func applyClaudeCompatibility(root string, manifest *Manifest) []string {

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -96,6 +96,42 @@ func TestParseCodexClaudeCompatibility(t *testing.T) {
 	}
 }
 
+func TestParseClaudePluginManifest(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{
+	  "name": "ui-ux-pro-max",
+	  "version": "2.6.2",
+	  "description": "UI/UX design intelligence",
+	  "skills": "./.claude/skills/"
+	}`)
+	writeTestFile(t, filepath.Join(root, ".claude", "skills", "ui-ux-pro-max", "SKILL.md"), "---\ndescription: UI design helper\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "CLAUDE.md"), "Use the bundled UI workflow.")
+
+	pkg, warnings, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if pkg.ManifestKind != "claude" || pkg.Manifest.Name != "ui-ux-pro-max" || pkg.Manifest.Version != "2.6.2" {
+		t.Fatalf("pkg = %+v", pkg)
+	}
+	if got := pkg.SkillRoots(); len(got) != 1 || got[0] != filepath.Join(root, ".claude", "skills") {
+		t.Fatalf("SkillRoots = %#v", got)
+	}
+	inv := pkg.Inventory()
+	if len(inv.Skills) != 1 || inv.Skills[0].Name != "ui-ux-pro-max" || inv.Skills[0].Invocation != "/ui-ux-pro-max" {
+		t.Fatalf("Inventory().Skills = %+v", inv.Skills)
+	}
+	if hooks := pkg.Manifest.Hooks["SessionStart"]; len(hooks) != 1 || hooks[0].ContextFile != "CLAUDE.md" {
+		t.Fatalf("SessionStart hooks = %+v, want CLAUDE.md context hook", hooks)
+	}
+	if ManifestPath(pkg.ManifestKind) != ClaudeManifest {
+		t.Fatalf("ManifestPath(%q) = %q, want %q", pkg.ManifestKind, ManifestPath(pkg.ManifestKind), ClaudeManifest)
+	}
+}
+
 func TestParseCodexWithoutSessionStartHookDoesNotWarn(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, CodexManifest), `{

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -219,3 +219,141 @@ func writeTestFile(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+// TestParseClaudePluginConventionSkillDirs pins the standard Claude plugin
+// shape: plugin.json carries metadata only, and skills live in the
+// conventional skills/ directory that Claude auto-discovers. Without the
+// fallback such a package installed as zero capabilities with no warning.
+func TestParseClaudePluginConventionSkillDirs(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{
+	  "name": "design-pack",
+	  "version": "1.0.0",
+	  "description": "metadata-only manifest"
+	}`)
+	writeTestFile(t, filepath.Join(root, "skills", "design-review", "SKILL.md"), "---\ndescription: review designs\n---\nbody")
+
+	pkg, warnings, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if pkg.ManifestKind != "claude" {
+		t.Fatalf("kind = %q", pkg.ManifestKind)
+	}
+	if got := pkg.SkillRoots(); len(got) != 1 || got[0] != filepath.Join(root, "skills") {
+		t.Fatalf("SkillRoots = %#v, want conventional skills dir", got)
+	}
+	if inv := pkg.Inventory(); len(inv.Skills) != 1 || inv.Skills[0].Name != "design-review" {
+		t.Fatalf("Inventory().Skills = %+v", inv.Skills)
+	}
+}
+
+func TestParseClaudePluginDotClaudeConventionDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "pack"}`)
+	writeTestFile(t, filepath.Join(root, ".claude", "skills", "helper", "SKILL.md"), "---\ndescription: helper\n---\nbody")
+
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if got := pkg.SkillRoots(); len(got) != 1 || got[0] != filepath.Join(root, ".claude", "skills") {
+		t.Fatalf("SkillRoots = %#v, want .claude/skills", got)
+	}
+}
+
+func TestParseClaudePluginIgnoresEmptyConventionDirAndExplicitSkillsWin(t *testing.T) {
+	root := t.TempDir()
+	// Empty conventional dir (no SKILL.md inside) must not be adopted.
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "empty-pack"}`)
+	if err := os.MkdirAll(filepath.Join(root, "skills", "stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if got := pkg.SkillRoots(); len(got) != 0 {
+		t.Fatalf("SkillRoots = %#v, want none for a skill-less conventional dir", got)
+	}
+
+	// Explicit skills declaration disables the fallback entirely.
+	root2 := t.TempDir()
+	writeTestFile(t, filepath.Join(root2, ClaudeManifest), `{"name": "explicit-pack", "skills": "./custom/"}`)
+	writeTestFile(t, filepath.Join(root2, "custom", "one", "SKILL.md"), "---\ndescription: one\n---\nbody")
+	writeTestFile(t, filepath.Join(root2, "skills", "two", "SKILL.md"), "---\ndescription: two\n---\nbody")
+	pkg2, _, err := ParseDir(root2)
+	if err != nil {
+		t.Fatalf("ParseDir explicit: %v", err)
+	}
+	if got := pkg2.SkillRoots(); len(got) != 1 || got[0] != filepath.Join(root2, "custom") {
+		t.Fatalf("SkillRoots = %#v, want only the declared custom dir", got)
+	}
+}
+
+func TestParseClaudePluginWarnsOnUnmappedCapabilities(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "big-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "commands", "deploy.md"), "run deploy")
+	writeTestFile(t, filepath.Join(root, "hooks", "hooks.json"), `{}`)
+	writeTestFile(t, filepath.Join(root, ".mcp.json"), `{}`)
+
+	_, warnings, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	joined := strings.Join(warnings, "\n")
+	for _, want := range []string{"commands", "hooks/hooks.json", ".mcp.json"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("warnings = %v, want mention of %s", warnings, want)
+		}
+	}
+	if strings.Contains(joined, "agents") {
+		t.Fatalf("warnings = %v, must not mention absent agents dir", warnings)
+	}
+}
+
+// TestParseClaudePluginDoesNotRegisterCodexSessionStartHook pins the security
+// boundary of the includeCodexSessionStartHook flag: a claude-kind package
+// shipping a hooks/session-start-codex file must NOT get it registered as an
+// executable SessionStart hook (that convention belongs to codex manifests).
+func TestParseClaudePluginDoesNotRegisterCodexSessionStartHook(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "sneaky-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "hooks", "session-start-codex"), "#!/bin/sh\necho pwned\n")
+
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	for _, h := range pkg.Manifest.Hooks["SessionStart"] {
+		if h.Command != "" {
+			t.Fatalf("claude package registered executable SessionStart hook: %+v", h)
+		}
+	}
+}
+
+// TestParseCodexManifestNotAffectedByClaudeFallback: the convention-dir
+// fallback is claude-only; a codex manifest without a skills field keeps its
+// existing "no skills" behavior even when a skills/ directory exists.
+func TestParseCodexManifestNotAffectedByClaudeFallback(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, CodexManifest), `{"name": "codex-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if pkg.ManifestKind != "codex" {
+		t.Fatalf("kind = %q", pkg.ManifestKind)
+	}
+	if got := pkg.SkillRoots(); len(got) != 0 {
+		t.Fatalf("SkillRoots = %#v, codex parsing must not adopt convention dirs", got)
+	}
+}


### PR DESCRIPTION
## Summary
- support `.claude-plugin/plugin.json` as a compatible plugin package manifest
- preserve existing Reasonix and Codex manifest behavior while labeling Claude manifests as `manifestKind: "claude"`
- update plugin package docs in English and Chinese

Cache-impact: low - touches install_source plugin detection only; it does not change existing provider-visible tool schemas or system prompt content.
Cache-guard: `go test ./internal/pluginpkg ./internal/installsource ./internal/hook`; full `go test ./...`; isolated install verification for `nextlevelbuilder/ui-ux-pro-max-skill`.

## Verification
- `go test ./internal/pluginpkg ./internal/installsource ./internal/hook`
- `go test ./...`
- verified `https://github.com/nextlevelbuilder/ui-ux-pro-max-skill` plans and installs successfully in an isolated Reasonix home
