### PR TITLE
Fix quoted node eval hook autorepair / 修复 node -e hook 引号自愈

### DIFF
--- a/desktop/hooks_settings_app.go
+++ b/desktop/hooks_settings_app.go
@@ -69,6 +69,7 @@ func (a *App) SaveHooksSettingsForRoot(scope, projectRoot string, hooks []HookCo
 		if cmd == "" {
 			continue
 		}
+		cmd = hook.NormalizeCommand(cmd)
 		settings.Hooks[event] = append(settings.Hooks[event], hook.HookConfig{
 			Match:       strings.TrimSpace(h.Match),
 			Command:     cmd,

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -1137,6 +1137,30 @@ func TestSaveHooksSettingsPreservesUnknownSettingsKeys(t *testing.T) {
 	}
 }
 
+func TestSaveHooksSettingsNormalizesQuotedNodeEvalHookCommand(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	script := "const payload = JSON.parse(require('fs').readFileSync(0, 'utf8')); console.log(payload.toolName)"
+	bad := `node -e "\"` + script + `\""`
+	want := hook.NormalizeCommand(bad)
+	if want == bad {
+		t.Fatal("test command did not normalize")
+	}
+
+	app := NewApp()
+	if err := app.SaveHooksSettings("global", []HookConfigView{{
+		Event:   string(hook.PreToolUse),
+		Match:   "bash",
+		Command: bad,
+	}}); err != nil {
+		t.Fatalf("SaveHooksSettings: %v", err)
+	}
+
+	view := app.HooksSettings("global")
+	if len(view.Hooks) != 1 || view.Hooks[0].Command != want {
+		t.Fatalf("HooksSettings = %+v, want normalized command %q", view.Hooks, want)
+	}
+}
+
 func TestProjectHooksSettingsUseActiveWorkspaceRootAndTrust(t *testing.T) {
 	home := isolateDesktopUserDirs(t)
 	project := t.TempDir()

--- a/internal/agent/testutil/mock_provider.go
+++ b/internal/agent/testutil/mock_provider.go
@@ -8,6 +8,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"reasonix/internal/provider"
@@ -124,6 +125,7 @@ func (p *MockProvider) Stream(ctx context.Context, req provider.Request) (<-chan
 				ch <- provider.Chunk{Type: provider.ChunkError, Err: ctx.Err()}
 				return
 			case ch <- c:
+				runtime.Gosched()
 			}
 		}
 	}()

--- a/internal/agent/testutil/mock_provider.go
+++ b/internal/agent/testutil/mock_provider.go
@@ -8,7 +8,6 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"sync"
 
 	"reasonix/internal/provider"
@@ -125,7 +124,6 @@ func (p *MockProvider) Stream(ctx context.Context, req provider.Request) (<-chan
 				ch <- provider.Chunk{Type: provider.ChunkError, Err: ctx.Err()}
 				return
 			case ch <- c:
-				runtime.Gosched()
 			}
 		}
 	}()

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -406,7 +406,7 @@ func (m chatTUI) runStatusline() tea.Cmd {
 // keeps a slow script from stalling the UI; any failure collapses to "".
 func runStatuslineCmd(cmd, stdinPayload string) string {
 	res := hook.DefaultSpawner(context.Background(), hook.SpawnInput{
-		Command: cmd,
+		Command: hook.NormalizeCommand(cmd),
 		Stdin:   stdinPayload + "\n",
 		Timeout: 2 * time.Second,
 	})

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -42,6 +43,18 @@ func TestRunStatuslineCmd(t *testing.T) {
 	// A failing command yields an empty line, not an error.
 	if got := runStatuslineCmd(failCmd, "{}"); got != "" {
 		t.Errorf("failed command should yield empty, got %q", got)
+	}
+}
+
+func TestRunStatuslineCmdNormalizesQuotedNodeEval(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available")
+	}
+	script := "const payload = JSON.parse(require('fs').readFileSync(0, 'utf8')); console.log(payload.model)"
+	cmd := `node -e "\"` + script + `\""`
+
+	if got := runStatuslineCmd(cmd, `{"model":"deepseek"}`); got != "deepseek" {
+		t.Fatalf("normalized statusline node -e output = %q, want deepseek", got)
 	}
 }
 

--- a/internal/hook/command_normalize.go
+++ b/internal/hook/command_normalize.go
@@ -1,0 +1,202 @@
+package hook
+
+import (
+	"strings"
+
+	"reasonix/internal/shellparse"
+)
+
+// NormalizeCommand repairs a narrow class of copied JSON-escaped node -e hooks.
+// It is intentionally conservative: hook commands can be security controls, so
+// only a single static node -e command whose script clearly reads hook payload
+// JSON from stdin is rewritten.
+func NormalizeCommand(command string) string {
+	if fixed, ok := normalizeStaticNodeEval(command); ok {
+		return fixed
+	}
+	if fixed, ok := normalizeEscapedNodeEval(command); ok {
+		return fixed
+	}
+	return command
+}
+
+func normalizeStaticNodeEval(command string) (string, bool) {
+	node, flag, script, ok := repairableNodeEvalArgs(command)
+	if !ok {
+		return "", false
+	}
+	return renderNodeEvalCommand(node, flag, script), true
+}
+
+func directNodeEvalArgs(command string) (string, string, string, bool) {
+	fields, malformed := shellparse.StaticFields(command)
+	if malformed == "" && len(fields) == 3 && isNodeCommand(fields[0]) && isNodeEvalFlag(fields[1]) {
+		script, ok := repairQuotedNodeEvalScript(fields[2])
+		if ok {
+			return fields[0], fields[1], script, true
+		}
+		if isHookStdinNodeEval(fields[2]) {
+			return fields[0], fields[1], fields[2], true
+		}
+	}
+	node, flag, script, ok := escapedNodeEvalArgs(command)
+	return node, flag, script, ok
+}
+
+func repairableNodeEvalArgs(command string) (string, string, string, bool) {
+	fields, malformed := shellparse.StaticFields(command)
+	if malformed == "" && len(fields) == 3 && isNodeCommand(fields[0]) && isNodeEvalFlag(fields[1]) {
+		script, ok := repairQuotedNodeEvalScript(fields[2])
+		if ok {
+			return fields[0], fields[1], script, true
+		}
+	}
+	return escapedNodeEvalArgs(command)
+}
+
+func normalizeEscapedNodeEval(command string) (string, bool) {
+	node, flag, script, ok := escapedNodeEvalArgs(command)
+	if !ok {
+		return "", false
+	}
+	return renderNodeEvalCommand(node, flag, script), true
+}
+
+func escapedNodeEvalArgs(command string) (string, string, string, bool) {
+	command = strings.TrimSpace(command)
+	for _, prefix := range []struct {
+		raw  string
+		node string
+		flag string
+	}{
+		{raw: `node -e `, node: "node", flag: "-e"},
+		{raw: `node --eval `, node: "node", flag: "--eval"},
+		{raw: `node.exe -e `, node: "node.exe", flag: "-e"},
+		{raw: `node.exe --eval `, node: "node.exe", flag: "--eval"},
+	} {
+		rest, ok := strings.CutPrefix(command, prefix.raw)
+		if !ok {
+			continue
+		}
+		script, ok := trimEscapedQuotes(strings.TrimSpace(rest))
+		if !ok || !isHookStdinNodeEval(script) {
+			return "", "", "", false
+		}
+		return prefix.node, prefix.flag, script, true
+	}
+	return "", "", "", false
+}
+
+func repairQuotedNodeEvalScript(script string) (string, bool) {
+	for _, trim := range []func(string) (string, bool){
+		trimDoubleQuotes,
+		trimEscapedQuotes,
+		trimBackslashEscapedQuotes,
+	} {
+		if candidate, ok := trim(strings.TrimSpace(script)); ok && isHookStdinNodeEval(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func trimDoubleQuotes(s string) (string, bool) {
+	if len(s) < 2 || s[0] != '"' {
+		return "", false
+	}
+	s = strings.TrimPrefix(s, `"`)
+	s = strings.TrimSuffix(s, `"`)
+	return s, true
+}
+
+func trimEscapedQuotes(s string) (string, bool) {
+	if !strings.HasPrefix(s, `\"`) {
+		return "", false
+	}
+	s = strings.TrimPrefix(s, `\"`)
+	s = strings.TrimSuffix(s, `\"`)
+	return unescapeJSONStyleQuotes(s), true
+}
+
+func trimBackslashEscapedQuotes(s string) (string, bool) {
+	if !strings.HasPrefix(s, `\\"`) {
+		return "", false
+	}
+	s = strings.TrimPrefix(s, `\\"`)
+	s = strings.TrimSuffix(s, `\\"`)
+	return unescapeJSONStyleQuotes(s), true
+}
+
+func unescapeJSONStyleQuotes(s string) string {
+	return strings.ReplaceAll(s, `\"`, `"`)
+}
+
+func isHookStdinNodeEval(script string) bool {
+	script = strings.TrimSpace(script)
+	if script == "" {
+		return false
+	}
+	if !startsLikeJSStatement(script) {
+		return false
+	}
+	return strings.Contains(script, "JSON.parse") &&
+		(strings.Contains(script, "readFileSync(0") || strings.Contains(script, "readFileSync( 0") || strings.Contains(script, "process.stdin"))
+}
+
+func startsLikeJSStatement(script string) bool {
+	for _, prefix := range []string{
+		"const ", "const\t", "let ", "let\t", "var ", "var\t",
+		"import ", "require(", "if ", "if(", "try ", "(async ", "async ",
+	} {
+		if strings.HasPrefix(script, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNodeCommand(command string) bool {
+	base := strings.ToLower(shellparse.WordBase(command))
+	return base == "node" || base == "node.exe"
+}
+
+func isNodeEvalFlag(flag string) bool {
+	return flag == "-e" || flag == "--eval"
+}
+
+func renderNodeEvalCommand(node, flag, script string) string {
+	return shellField(node) + " " + shellField(flag) + " " + shellDoubleQuote(script)
+}
+
+func shellField(s string) string {
+	if s != "" {
+		safe := true
+		for _, r := range s {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+				r == '_' || r == '-' || r == '.' || r == '/' || r == ':' || r == '\\' {
+				continue
+			}
+			safe = false
+			break
+		}
+		if safe {
+			return s
+		}
+	}
+	return shellDoubleQuote(s)
+}
+
+func shellDoubleQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\', '"', '$', '`':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/hook/command_normalize.go
+++ b/internal/hook/command_normalize.go
@@ -101,30 +101,24 @@ func repairQuotedNodeEvalScript(script string) (string, bool) {
 }
 
 func trimDoubleQuotes(s string) (string, bool) {
-	if len(s) < 2 || s[0] != '"' {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
 		return "", false
 	}
-	s = strings.TrimPrefix(s, `"`)
-	s = strings.TrimSuffix(s, `"`)
-	return s, true
+	return s[1 : len(s)-1], true
 }
 
 func trimEscapedQuotes(s string) (string, bool) {
-	if !strings.HasPrefix(s, `\"`) {
+	if len(s) < 4 || !strings.HasPrefix(s, `\"`) || !strings.HasSuffix(s, `\"`) {
 		return "", false
 	}
-	s = strings.TrimPrefix(s, `\"`)
-	s = strings.TrimSuffix(s, `\"`)
-	return unescapeJSONStyleQuotes(s), true
+	return unescapeJSONStyleQuotes(s[2 : len(s)-2]), true
 }
 
 func trimBackslashEscapedQuotes(s string) (string, bool) {
-	if !strings.HasPrefix(s, `\\"`) {
+	if len(s) < 6 || !strings.HasPrefix(s, `\\"`) || !strings.HasSuffix(s, `\\"`) {
 		return "", false
 	}
-	s = strings.TrimPrefix(s, `\\"`)
-	s = strings.TrimSuffix(s, `\\"`)
-	return unescapeJSONStyleQuotes(s), true
+	return unescapeJSONStyleQuotes(s[3 : len(s)-3]), true
 }
 
 func unescapeJSONStyleQuotes(s string) string {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -229,6 +229,7 @@ func appendResolved(out *[]ResolvedHook, s *Settings, scope Scope, source string
 			if strings.TrimSpace(cfg.Command) == "" {
 				continue
 			}
+			cfg.Command = NormalizeCommand(cfg.Command)
 			*out = append(*out, ResolvedHook{HookConfig: cfg, Event: event, Scope: scope, Source: source})
 		}
 	}
@@ -256,6 +257,7 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				if command != "" && !h.ShellCommand && !filepath.IsAbs(command) {
 					command = filepath.Join(pkg.Root, filepath.FromSlash(command))
 				}
+				command = NormalizeCommand(command)
 				contextFile := h.ContextFile
 				if contextFile != "" && !filepath.IsAbs(contextFile) {
 					contextFile = filepath.Join(pkg.Root, filepath.FromSlash(contextFile))
@@ -546,8 +548,7 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	cctx, cancel := context.WithTimeout(ctx, in.Timeout)
 	defer cancel()
 
-	name, args := shellInvocation(in.Command)
-	cmd := exec.CommandContext(cctx, name, args...)
+	cmd := spawnCommand(cctx, in.Command)
 	proc.HideWindow(cmd)
 	cmd.Dir = in.Cwd
 	if len(in.Env) > 0 {
@@ -593,6 +594,14 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 		res.ExitCode = 0
 	}
 	return res
+}
+
+func spawnCommand(ctx context.Context, command string) *exec.Cmd {
+	if node, flag, script, ok := directNodeEvalArgs(command); ok {
+		return exec.CommandContext(ctx, node, flag, script)
+	}
+	name, args := shellInvocation(command)
+	return exec.CommandContext(ctx, name, args...)
 }
 
 func shellInvocation(command string) (string, []string) {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -596,9 +596,27 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	return res
 }
 
+// spawnCommand picks the execution vehicle for a hook command. Commands run
+// through the shell by default — that is the documented contract, and scripts
+// may rely on shell expansion ($VAR, backticks). Direct exec (no shell) is
+// used only where it is strictly better:
+//   - a command this call just repaired (its broken quoting means it never
+//     worked through a shell, so there is no expansion behavior to preserve);
+//   - on Windows, a recognized node -e stdin-hook command: `cmd /c` mangles
+//     quoted JS (&, %, nested quotes), which is the breakage this repair
+//     exists for, and cmd performs no POSIX-style $ expansion to preserve.
+//
+// POSIX commands that were already well-formed keep their shell semantics
+// verbatim — normalizeStaticNodeEval's rendering escapes $ and backticks, so
+// even repaired commands re-entering here behave identically under sh -c.
 func spawnCommand(ctx context.Context, command string) *exec.Cmd {
-	if node, flag, script, ok := directNodeEvalArgs(command); ok {
+	if node, flag, script, ok := repairableNodeEvalArgs(command); ok {
 		return exec.CommandContext(ctx, node, flag, script)
+	}
+	if runtime.GOOS == "windows" {
+		if node, flag, script, ok := directNodeEvalArgs(command); ok {
+			return exec.CommandContext(ctx, node, flag, script)
+		}
 	}
 	name, args := shellInvocation(command)
 	return exec.CommandContext(ctx, name, args...)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +35,25 @@ func writeHookTestFile(t *testing.T, path, body string) {
 	}
 }
 
+func requireNode(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available")
+	}
+}
+
 const sampleSettings = `{"hooks":{"PreToolUse":[{"match":"bash","command":"echo pre"}],"Stop":[{"command":"echo stop"}]}}`
+
+func hookSettingsWithCommand(t *testing.T, event Event, command string) string {
+	t.Helper()
+	body, err := json.Marshal(Settings{Hooks: map[Event][]HookConfig{
+		event: []HookConfig{{Match: "bash", Command: command}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
 
 func TestLoadTrustGating(t *testing.T) {
 	home := t.TempDir()
@@ -53,6 +73,104 @@ func TestLoadTrustGating(t *testing.T) {
 	}
 	if got[0].Scope != ScopeProject {
 		t.Errorf("project hooks should sort first, got %s", got[0].Scope)
+	}
+}
+
+func TestLoadNormalizesQuotedNodeEvalHooksPerProject(t *testing.T) {
+	requireNode(t)
+
+	home := t.TempDir()
+	projA := t.TempDir()
+	projB := t.TempDir()
+	script := "const payload = JSON.parse(require('fs').readFileSync(0, 'utf8')); console.log(payload.toolName)"
+	bad := `node -e "\"` + script + `\""`
+	want := NormalizeCommand(bad)
+	if want == bad {
+		t.Fatal("test command did not normalize")
+	}
+	writeSettings(t, projA, hookSettingsWithCommand(t, PreToolUse, bad))
+	writeSettings(t, projB, hookSettingsWithCommand(t, PreToolUse, bad))
+
+	for _, project := range []string{projA, projB, projB} {
+		hooks := Load(LoadOptions{HomeDir: home, ProjectRoot: project, Trusted: true})
+		if len(hooks) != 1 {
+			t.Fatalf("Load(%q) hooks = %+v, want one", project, hooks)
+		}
+		if hooks[0].Command != want {
+			t.Fatalf("Load(%q) command = %q, want %q", project, hooks[0].Command, want)
+		}
+		rep := Run(context.Background(), Payload{Event: PreToolUse, Cwd: project, ToolName: "bash"}, hooks, nil)
+		if len(rep.Outcomes) != 1 || rep.Outcomes[0].Decision != DecisionPass || rep.Outcomes[0].Stdout != "bash" {
+			t.Fatalf("normalized hook outcome = %+v, want pass with bash stdout", rep)
+		}
+	}
+}
+
+func TestNormalizeCommandRepairsOnlyStdinNodeEvalQuoting(t *testing.T) {
+	script := "const payload = JSON.parse(require('fs').readFileSync(0, 'utf8')); console.log(payload.toolName)"
+	doubleQuoteScript := `const payload = JSON.parse(require(\"fs\").readFileSync(0, \"utf8\")); console.log(payload.toolName)`
+	tests := []struct {
+		name    string
+		command string
+		repair  bool
+	}{
+		{
+			name:    "quoted script argument",
+			command: `node -e "\"` + script + `\""`,
+			repair:  true,
+		},
+		{
+			name:    "json escaped shell quotes",
+			command: `node -e \"` + script + `\"`,
+			repair:  true,
+		},
+		{
+			name:    "json escaped shell and script quotes",
+			command: `node -e \"` + doubleQuoteScript + `\"`,
+			repair:  true,
+		},
+		{
+			name:    "normal hook command",
+			command: `node -e "` + script + `"`,
+		},
+		{
+			name:    "intentional string literal",
+			command: `node -e '"hello"'`,
+		},
+		{
+			name:    "not stdin hook script",
+			command: `node -e "\"console.log(1)\""`,
+		},
+		{
+			name:    "compound command",
+			command: `node -e "\"` + script + `\"" && echo done`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeCommand(tt.command)
+			if tt.repair {
+				if got == tt.command {
+					t.Fatalf("NormalizeCommand(%q) did not repair", tt.command)
+				}
+				if strings.Contains(got, `\""`) {
+					t.Fatalf("NormalizeCommand(%q) left accidental escaped quotes in %q", tt.command, got)
+				}
+				requireNode(t)
+				r := DefaultSpawner(context.Background(), SpawnInput{
+					Command: got,
+					Stdin:   `{"toolName":"bash"}`,
+					Timeout: 2 * time.Second,
+				})
+				if r.ExitCode != 0 || r.Stdout != "bash" {
+					t.Fatalf("normalized command did not execute: command=%q result=%+v", got, r)
+				}
+				return
+			}
+			if got != tt.command {
+				t.Fatalf("NormalizeCommand(%q) = %q, want unchanged", tt.command, got)
+			}
+		})
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -581,3 +581,32 @@ func TestDefaultSpawnerOutputCap(t *testing.T) {
 		t.Errorf("captured output %d exceeds cap %d", len(r.Stdout), outputCapBytes)
 	}
 }
+
+// TestWellFormedNodeEvalKeepsShellSemantics pins the execution contract for
+// commands that never needed repair: hook commands are documented to run
+// through the shell, and existing user hooks may rely on shell expansion.
+// A well-formed node -e stdin-hook command must therefore keep $VAR expansion
+// on POSIX — only repaired commands (whose broken quoting means they never
+// worked through a shell) may take the direct-exec path.
+func TestWellFormedNodeEvalKeepsShellSemantics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cmd does not perform POSIX $ expansion; Windows intentionally direct-execs recognized node evals")
+	}
+	requireNode(t)
+	command := `node -e "const payload = JSON.parse(require('fs').readFileSync(0, 'utf8')); console.log('$HOOK_TEST_MARKER' + payload.toolName)"`
+	if got := NormalizeCommand(command); got != command {
+		t.Fatalf("well-formed command was rewritten: %q", got)
+	}
+	r := DefaultSpawner(context.Background(), SpawnInput{
+		Command: command,
+		Stdin:   `{"toolName":"bash"}`,
+		Timeout: 2 * time.Second,
+		Env:     map[string]string{"HOOK_TEST_MARKER": "expanded-"},
+	})
+	if r.ExitCode != 0 {
+		t.Fatalf("spawn failed: %+v", r)
+	}
+	if r.Stdout != "expanded-bash" {
+		t.Fatalf("stdout = %q, want %q — $VAR expansion was lost (command bypassed the shell)", r.Stdout, "expanded-bash")
+	}
+}


### PR DESCRIPTION
## Summary
- Add conservative command normalization for copied JSON-escaped `node -e` commands that read JSON payloads from stdin.
- Apply the normalization when loading hooks, when saving desktop hook settings, and before running the TUI custom statusline command.
- Cover per-project repeated hook loading, safe non-repair cases, desktop settings persistence, and TUI statusline execution.

## Tests
- `go test ./internal/cli -run 'TestRunStatuslineCmd|TestModelSwitchRefreshesCustomStatusline' -count=1`
- `go test ./internal/hook -count=1`
- `cd desktop && go test . -run 'TestSaveHooksSettings|TestProjectHooksSettings|TestTrustProjectHooks' -count=1`