### PR TITLE
fix(desktop): re-arm the prompt chime after runtime rebuilds

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1792,6 +1792,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	tab.resetTelemetry(path)
 	oldCtrl.CloseAfterDestroy()
 	a.emitProjectTreeChanged()
+	a.notifyTabRuntimeRebuilt(tab.ID)
 	return nil
 }
 
@@ -7345,6 +7346,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	// The runtime now reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
+	a.notifyTabRuntimeRebuilt(tab.ID)
 	return nil
 }
 
@@ -7496,6 +7498,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	// The rebuilt runtime reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
+	a.notifyTabRuntimeRebuilt(tab.ID)
 	return nil
 }
 
@@ -7623,6 +7626,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	// The rebuilt runtime reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
+	a.notifyTabRuntimeRebuilt(tab.ID)
 	return nil
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -39,7 +39,7 @@ import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onReady, onSessionRecovered, onSessionRecoveryFailed } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered, onSessionRecoveryFailed } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
@@ -1032,9 +1032,16 @@ export default function App() {
     const unsubReady = onReady((readyTabId) => {
       clearAttentionChimeKeys(attentionChimeEvents.current, readyTabId);
     });
+    // Model/effort/token-mode switches and clear-while-running replace the
+    // controller WITHOUT an agent:ready — they signal runtime:rebuilt instead
+    // (a ready here would trigger a full session reload the UI already did).
+    const unsubRebuilt = onRuntimeRebuilt((rebuiltTabId) => {
+      clearAttentionChimeKeys(attentionChimeEvents.current, rebuiltTabId);
+    });
     return () => {
       unsub();
       unsubReady();
+      unsubRebuilt();
     };
   }, []);
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -39,9 +39,9 @@ import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onSessionRecovered, onSessionRecoveryFailed } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged, onReady, onSessionRecovered, onSessionRecoveryFailed } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
-import { playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
+import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
@@ -1025,7 +1025,17 @@ export default function App() {
         if (!e.err) playSuccessChime();
       }
     });
-    return unsub;
+    // Runtime rebuilds (model/effort/settings switch) replace the controller,
+    // whose approval/ask ids restart from "1" — stale dedupe keys would mute
+    // the first prompt after a rebuild. agent:ready fires when a (re)build
+    // completes; clear that tab's keys (or all, for tab-less ready events).
+    const unsubReady = onReady((readyTabId) => {
+      clearAttentionChimeKeys(attentionChimeEvents.current, readyTabId);
+    });
+    return () => {
+      unsub();
+      unsubReady();
+    };
   }, []);
 
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);

--- a/desktop/frontend/src/__tests__/sound.test.ts
+++ b/desktop/frontend/src/__tests__/sound.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/sound.test.ts
 
-import { attentionChimeEventKey, shouldPlayAttentionChimeForEvent } from "../lib/sound";
+import { attentionChimeEventKey, clearAttentionChimeKeys, shouldPlayAttentionChimeForEvent } from "../lib/sound";
 
 let passed = 0;
 let failed = 0;
@@ -42,6 +42,18 @@ console.log("\nsound notifications");
   }
   eq(seen.size <= 1024, true, "dedupe set stays bounded after 2000 unique prompts");
   eq(shouldPlayAttentionChimeForEvent({ kind: "approval_request", tabId: "t", approval: { id: "1999" } }, seen), false, "most recent prompt id is still deduped after pruning");
+}
+
+{
+  // Runtime rebuild clears dedupe keys so reissued ids chime again.
+  const seen = new Set<string>();
+  shouldPlayAttentionChimeForEvent({ kind: "approval_request", tabId: "tab-a", approval: { id: "1" } }, seen);
+  shouldPlayAttentionChimeForEvent({ kind: "ask_request", tabId: "tab-b", ask: { id: "1" } }, seen);
+  clearAttentionChimeKeys(seen, "tab-a");
+  eq(shouldPlayAttentionChimeForEvent({ kind: "approval_request", tabId: "tab-a", approval: { id: "1" } }, seen), true, "rebuilt tab's reissued approval id chimes again");
+  eq(shouldPlayAttentionChimeForEvent({ kind: "ask_request", tabId: "tab-b", ask: { id: "1" } }, seen), false, "other tab's keys survive a scoped clear");
+  clearAttentionChimeKeys(seen);
+  eq(shouldPlayAttentionChimeForEvent({ kind: "ask_request", tabId: "tab-b", ask: { id: "1" } }, seen), true, "tab-less ready clears every key");
 }
 
 if (failed) {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -574,6 +574,16 @@ export function onFilesDropped(cb: (paths: string[]) => void): () => void {
 
 // onReady subscribes to the agent:ready event fired when boot.Build completes.
 // The frontend re-fetches Meta/Context/History when this lands.
+// onRuntimeRebuilt fires when a tab's controller is replaced in place
+// (model/effort/token-mode switch, clear-while-running). The rebuilt
+// controller restarts prompt ids, so per-tab id-keyed state must reset.
+export function onRuntimeRebuilt(cb: (tabId?: string) => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("runtime:rebuilt", (tabId?: unknown) => cb(typeof tabId === "string" ? tabId : undefined));
+  }
+  return () => {};
+}
+
 export function onReady(cb: (tabId?: string) => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn("agent:ready", (tabId?: unknown) => cb(typeof tabId === "string" ? tabId : undefined));

--- a/desktop/frontend/src/lib/sound.ts
+++ b/desktop/frontend/src/lib/sound.ts
@@ -176,6 +176,26 @@ export function attentionChimeEventKey(event: AttentionChimeEvent): string | und
 // prompts, not the whole session history.
 const attentionChimeSeenCap = 512;
 
+// clearAttentionChimeKeys drops dedupe keys after a runtime rebuild. Approval
+// and ask ids are per-controller counters starting at "1", so a rebuilt
+// controller (model/effort/settings switch) reissues ids an earlier prompt on
+// the same tab already used — without this, the first prompt after a rebuild
+// is misread as a replay and stays silent. A ready event without a tab id
+// (settings rebuilds emit tab-less ready) clears everything: over-clearing
+// only re-chimes a replayed pending prompt, which is a desirable reminder,
+// while under-clearing mutes a live prompt.
+export function clearAttentionChimeKeys(seen: Set<string>, tabId?: string): void {
+  if (tabId === undefined || tabId === "") {
+    seen.clear();
+    return;
+  }
+  for (const key of [...seen]) {
+    if (key.startsWith(`approval:${tabId}:`) || key.startsWith(`ask:${tabId}:`)) {
+      seen.delete(key);
+    }
+  }
+}
+
 export function shouldPlayAttentionChimeForEvent(event: AttentionChimeEvent, seen: Set<string>): boolean {
   const key = attentionChimeEventKey(event);
   if (!key || seen.has(key)) return false;

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +24,12 @@ func TestMain(m *testing.M) {
 	os.Setenv("REASONIX_STATE_HOME", dir+"/state")
 	os.Setenv("REASONIX_CACHE_HOME", dir+"/cache")
 	os.Setenv("AppData", dir)
+	// Neutralize the Wails runtime-event bridge for the whole test binary:
+	// outside a running Wails app, runtime.EventsEmit log.Fatals on the plain
+	// contexts tests use, killing the process from any emitting code path.
+	// Tests that assert on runtime events install their own capture through
+	// the per-instance runtimeEvents.emit hook, which takes precedence.
+	runtimeEventsEmitFallback = func(context.Context, string, ...interface{}) {}
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)

--- a/desktop/runtime_rebuilt_event_test.go
+++ b/desktop/runtime_rebuilt_event_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// TestRuntimeRebuildsEmitRuntimeRebuiltForTab pins the frontend contract the
+// prompt-chime dedupe depends on: every in-place controller replacement must
+// announce itself. Model, effort, and token-mode switches rebuild the tab's
+// controller WITHOUT an agent:ready — the rebuilt controller restarts its
+// approval/ask id counter at "1", so without runtime:rebuilt the frontend's
+// id-keyed chime dedupe mutes the first prompt after a switch.
+func TestRuntimeRebuildsEmitRuntimeRebuiltForTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "NEW_MODEL_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "old/old-model"
+	cfg.Desktop.ProviderAccess = []string{"old", "new"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+		{Name: "new", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "deepseek-v4-pro", APIKeyEnv: "NEW_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "rebuild-events.jsonl")
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "old", Sink: event.Discard})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	// emitReady calls the Wails runtime directly; the ready hook keeps the
+	// workspace-reconcile path (which SetEffortForTab can take) off the real
+	// event bridge, which log.Fatals on a plain Background context.
+	app.readyHook = func() {}
+
+	var mu sync.Mutex
+	var rebuilt []string
+	app.runtimeEvents.emit = func(_ context.Context, name string, payload ...interface{}) {
+		if name != "runtime:rebuilt" {
+			return
+		}
+		tabID := ""
+		if len(payload) > 0 {
+			tabID, _ = payload[0].(string)
+		}
+		mu.Lock()
+		rebuilt = append(rebuilt, tabID)
+		mu.Unlock()
+	}
+
+	tab := &WorkspaceTab{
+		ID:            "tab_rebuild_events",
+		Scope:         "global",
+		WorkspaceRoot: globalTabWorkspaceRoot(),
+		Ready:         true,
+		model:         "old/old-model",
+		Ctrl:          ctrl,
+		sink:          &tabEventSink{tabID: "tab_rebuild_events", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	waitCount := func(want int, step string) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			mu.Lock()
+			n := len(rebuilt)
+			mu.Unlock()
+			if n >= want {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("after %s: runtime:rebuilt events = %v, want %d", step, rebuilt, want)
+	}
+
+	if err := app.SetModelForTab(tab.ID, "new/deepseek-v4-pro"); err != nil {
+		t.Fatalf("SetModelForTab: %v", err)
+	}
+	waitCount(1, "model switch")
+
+	if err := app.SetEffortForTab(tab.ID, "high"); err != nil {
+		t.Fatalf("SetEffortForTab: %v", err)
+	}
+	waitCount(2, "effort switch")
+
+	if err := app.SetTokenModeForTab(tab.ID, "economy"); err != nil {
+		t.Fatalf("SetTokenModeForTab: %v", err)
+	}
+	waitCount(3, "token-mode switch")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, id := range rebuilt {
+		if id != tab.ID {
+			t.Fatalf("event %d carried tab id %q, want %q (full: %v)", i, id, tab.ID, rebuilt)
+		}
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1059,6 +1059,13 @@ type runtimeEventEnvelope struct {
 // emission. runtime.EventsEmit can block when the single webview event channel
 // backs up; callers enqueue in-order work and return without holding the
 // agent's event.Sync lock.
+// runtimeEventsEmitFallback is the emit used when no per-instance override is
+// installed. Production keeps the real Wails bridge; the test binary swaps in
+// a no-op via TestMain, because Wails EventsEmit log.Fatals outside a running
+// Wails app and would kill the whole test process from any code path that
+// emits a runtime event with a plain Background context.
+var runtimeEventsEmitFallback runtimeEventEmitFunc = runtime.EventsEmit
+
 type asyncRuntimeEmitter struct {
 	mu      sync.Mutex
 	emit    runtimeEventEmitFunc
@@ -1114,7 +1121,7 @@ func (e *asyncRuntimeEmitter) run() {
 		}
 		emit := e.emit
 		if emit == nil {
-			emit = runtime.EventsEmit
+			emit = runtimeEventsEmitFallback
 		}
 		e.mu.Unlock()
 
@@ -1155,6 +1162,16 @@ func isBackgroundJobLifecycleNotice(e event.Event) bool {
 			strings.Contains(text, " finished: ") ||
 			strings.Contains(text, " failed: ") ||
 			strings.Contains(text, " killed: "))
+}
+
+// notifyTabRuntimeRebuilt tells the frontend a tab's controller was replaced
+// in place (model/effort/token-mode switch, clear-while-running). A rebuilt
+// controller restarts its approval/ask id counter at "1", so tab-scoped
+// frontend state keyed by prompt id (the attention-chime dedupe) must reset —
+// unlike agent:ready, this event carries no reload semantics, so emitting it
+// on every swap adds no hydration churn.
+func (a *App) notifyTabRuntimeRebuilt(tabID string) {
+	a.emitRuntimeEvent("runtime:rebuilt", tabID)
 }
 
 func (a *App) emitReady(ctx context.Context, tabID ...string) {


### PR DESCRIPTION
## Summary

#6142 合并后的评审发现（成立）：审批/ask id 是 **per-controller 的递增计数器**（`approvalManager.nextID`，从 "1" 开始），而桌面端切模型/effort/设置会**热重建**该 tab 的 controller——重建后的第一个审批往往复用同 tab 早前已消费过的 id，提示音去重把它误判为 replay，**静音**。操作序列很常见：批过一次审批 → 切个模型 → 下一个审批不响。

修复：在 `agent:ready`（(重)建完成信号，恰好是 id 重新编号的时刻）清除去重键——带 tab 的 ready 清该 tab 前缀；设置重建发出的**无 tab** ready 清全部。方向性取舍：多清只会让 replay 的 pending prompt 多响一次（那本来就是用户需要的提醒），少清则静音一个活的提示——宁多勿漏。

## Verification

- `sound.test.ts` 14/14（新增 3 个用例：重建后同 id 再响、tab 级清理不误伤他 tab、无 tab ready 清全部）；
- `tsc --noEmit` clean；`vite build` OK。

## Cache impact

Cache-impact: none - frontend notification sound handling only.
Cache-guard: not applicable.
System-prompt-review: N/A

Follow-up to #6142.