### PR TITLE
fix(desktop): order runtime:rebuilt ahead of the rebuilt controller's events

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1792,7 +1792,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	tab.resetTelemetry(path)
 	oldCtrl.CloseAfterDestroy()
 	a.emitProjectTreeChanged()
-	a.notifyTabRuntimeRebuilt(tab.ID)
+	a.notifyTabRuntimeRebuilt(tab)
 	return nil
 }
 
@@ -7346,7 +7346,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	// The runtime now reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
-	a.notifyTabRuntimeRebuilt(tab.ID)
+	a.notifyTabRuntimeRebuilt(tab)
 	return nil
 }
 
@@ -7498,7 +7498,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	// The rebuilt runtime reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
-	a.notifyTabRuntimeRebuilt(tab.ID)
+	a.notifyTabRuntimeRebuilt(tab)
 	return nil
 }
 
@@ -7626,7 +7626,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	// The rebuilt runtime reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
-	a.notifyTabRuntimeRebuilt(tab.ID)
+	a.notifyTabRuntimeRebuilt(tab)
 	return nil
 }
 

--- a/desktop/runtime_rebuilt_event_test.go
+++ b/desktop/runtime_rebuilt_event_test.go
@@ -56,7 +56,17 @@ func TestRuntimeRebuildsEmitRuntimeRebuiltForTab(t *testing.T) {
 
 	var mu sync.Mutex
 	var rebuilt []string
-	app.runtimeEvents.emit = func(_ context.Context, name string, payload ...interface{}) {
+	// The App-level queue must stay silent: ordering against the tab's agent
+	// events only holds when the notice rides the tab sink's own queue, so a
+	// notice showing up here means the routing regressed to the fallback.
+	app.runtimeEvents.emit = func(_ context.Context, name string, _ ...interface{}) {
+		if name == "runtime:rebuilt" {
+			mu.Lock()
+			rebuilt = append(rebuilt, "VIA-APP-QUEUE")
+			mu.Unlock()
+		}
+	}
+	sinkEmit := func(_ context.Context, name string, payload ...interface{}) {
 		if name != "runtime:rebuilt" {
 			return
 		}
@@ -76,9 +86,10 @@ func TestRuntimeRebuildsEmitRuntimeRebuiltForTab(t *testing.T) {
 		Ready:         true,
 		model:         "old/old-model",
 		Ctrl:          ctrl,
-		sink:          &tabEventSink{tabID: "tab_rebuild_events", app: app},
+		sink:          &tabEventSink{tabID: "tab_rebuild_events", app: app, ctx: context.Background()},
 		disabledMCP:   map[string]ServerView{},
 	}
+	tab.sink.runtimeEvents.emit = sinkEmit
 	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
 	app.tabOrder = []string{tab.ID}
 	app.activeTabID = tab.ID
@@ -123,6 +134,9 @@ func TestRuntimeRebuildsEmitRuntimeRebuiltForTab(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	for i, id := range rebuilt {
+		if id == "VIA-APP-QUEUE" {
+			t.Fatalf("event %d took the App-level fallback queue; it must ride the tab sink queue so it orders before the rebuilt controller's agent events (full: %v)", i, rebuilt)
+		}
 		if id != tab.ID {
 			t.Fatalf("event %d carried tab id %q, want %q (full: %v)", i, id, tab.ID, rebuilt)
 		}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1170,7 +1170,26 @@ func isBackgroundJobLifecycleNotice(e event.Event) bool {
 // frontend state keyed by prompt id (the attention-chime dedupe) must reset —
 // unlike agent:ready, this event carries no reload semantics, so emitting it
 // on every swap adds no hydration churn.
-func (a *App) notifyTabRuntimeRebuilt(tabID string) {
+//
+// Ordering matters: the reset must reach the frontend BEFORE the rebuilt
+// controller's first approval/ask event, or the stale key still mutes it. The
+// tab's agent events ride the tab sink's own async queue, so the notice goes
+// through THAT queue — same lane, FIFO, guaranteed to arrive first. The
+// App-level queue is only the fallback when the sink cannot deliver (no sink,
+// or its webview context is cleared); it cannot order against sink traffic,
+// but an unordered notice still beats none.
+func (a *App) notifyTabRuntimeRebuilt(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	a.mu.RLock()
+	sink := tab.sink
+	tabID := tab.ID
+	a.mu.RUnlock()
+	if sink != nil && sink.context() != nil {
+		sink.emitRuntimeEvent("runtime:rebuilt", tabID)
+		return
+	}
 	a.emitRuntimeEvent("runtime:rebuilt", tabID)
 }
 


### PR DESCRIPTION
## Summary

#6146 合并后的评审发现（成立）：`runtime:rebuilt` 走 **App 级**异步事件队列，而 agent 事件（approval_request/ask_request）走**每个 tab sink 自己的**队列——两条队列各自的 goroutine 独立排空，之间没有任何 happens-before。重建后的控制器若很快发出第一个审批，它可能抢在清理通知之前到达前端，旧去重键仍然把提示音静音——竞态窗口实际很窄（审批需要一轮用户+模型往返，队列排空是亚毫秒级），但结构上真实存在。

修复（采纳评审建议）：把通知改走 **tab sink 的队列**。重建路径把同一个 sink 交给新控制器（model/effort/token 切换用 `snap.sink`，clear-while-running 用刚换上的 `tab.sink`），因此单队列 FIFO 从结构上保证清理通知先于重建后控制器的任何 agent 事件到达前端。App 级队列仅作兜底（sink 为空或 webview context 已清）——无序但聊胜于无。

## Verification

- `TestRuntimeRebuildsEmitRuntimeRebuiltForTab` 升级：通过 **sink 的 emitter** 捕获，任何通知漏到 App 级队列即失败（`VIA-APP-QUEUE` 哨兵）。**反向验证**：还原旧路由后三次切换全部被哨兵抓住、测试恰在该断言失败。
- 全套 desktop 测试绿（41.4s）；`go vet` 干净。前端零改动（仍订阅同一事件名）。

## Cache impact

Cache-impact: none - desktop event routing only.
Cache-guard: not applicable.
System-prompt-review: N/A

Follow-up to #6146.