### PR TITLE
fix(desktop): self-heal project re-add roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,53 @@ jobs:
       - name: test
         run: go test ./...
 
+  # Desktop project-root matching is case-insensitive only on Windows
+  # (sameDesktopPath folds case when os.PathSeparator is '\'), so the
+  # regression tests for that contract are named *OnWindows and can never
+  # run on the ubuntu leg above.
+  desktop-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/frontend/pnpm-lock.yaml
+
+      - name: Install Wails CLI
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+
+      # go:embed of frontend/dist needs a built frontend before the package
+      # compiles, same as the ubuntu desktop leg.
+      - name: Build frontend
+        run: |
+          wails generate module
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir frontend build
+
+      - name: test (Windows-only path semantics)
+        timeout-minutes: 10
+        run: go test . -run 'OnWindows$' -v
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3816,7 +3816,7 @@ func (a *App) ListWorkspaces() []WorkspaceMeta {
 		out = append(out, WorkspaceMeta{
 			Path:    project.Root,
 			Name:    projectDisplayName(project),
-			Current: activeRoot != "" && project.Root == activeRoot,
+			Current: activeRoot != "" && sameProjectRoot(project.Root, activeRoot),
 		})
 	}
 	return out

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2774,7 +2774,7 @@ func (a *App) openTransientBlankRuntime(scope, workspaceRoot string) error {
 			return fmt.Errorf("workspaceRoot is required")
 		}
 		saveWorkspace(workspaceRoot)
-		_ = addProject(workspaceRoot, "")
+		a.registerProjectRoot(workspaceRoot)
 		actualRoot = workspaceRoot
 	} else {
 		actualRoot = globalWorkspaceRoot()

--- a/desktop/recovery_gc.go
+++ b/desktop/recovery_gc.go
@@ -86,10 +86,11 @@ func recoveryGCDirs() []string {
 	seen := map[string]bool{}
 	var dirs []string
 	add := func(dir string) {
-		if dir == "" || seen[dir] {
+		key := projectRootKey(dir)
+		if dir == "" || seen[key] {
 			return
 		}
-		seen[dir] = true
+		seen[key] = true
 		dirs = append(dirs, dir)
 	}
 	add(desktopSessionDir(globalWorkspaceRoot()))

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1949,7 +1949,7 @@ func (a *App) blankTabMatchesTargetLocked(tab *WorkspaceTab, scope, workspaceRoo
 	if tab == nil || tab.Scope != scope {
 		return false
 	}
-	if scope == "project" && tab.WorkspaceRoot != workspaceRoot {
+	if scope == "project" && !sameProjectRoot(tab.WorkspaceRoot, workspaceRoot) {
 		return false
 	}
 	if tab.Ctrl == nil {
@@ -2051,13 +2051,8 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 	var topicIDs []string
 	if scope == "global" {
 		topicIDs = orderedTopicIDs(f.GlobalTopics, titles)
-	} else {
-		for _, project := range f.Projects {
-			if project.Root == workspaceRoot {
-				topicIDs = orderedTopicIDs(project.Topics, titles)
-				break
-			}
-		}
+	} else if i := projectIndexByRoot(f.Projects, workspaceRoot); i >= 0 {
+		topicIDs = orderedTopicIDs(f.Projects[i].Topics, titles)
 	}
 	if len(topicIDs) == 0 {
 		return ""
@@ -2077,7 +2072,7 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		if tab == nil || tab.Scope != scope || strings.TrimSpace(tab.TopicID) == "" {
 			continue
 		}
-		if scope == "project" && tab.WorkspaceRoot != workspaceRoot {
+		if scope == "project" && !sameProjectRoot(tab.WorkspaceRoot, workspaceRoot) {
 			continue
 		}
 		openTopics[tab.TopicID] = true
@@ -3090,7 +3085,9 @@ func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding
 	changed := tab.Scope != scope ||
 		tab.WorkspaceRoot != workspaceRoot ||
 		canonicalTabSessionPath(tab.SessionPath) != canonicalTabSessionPath(binding.path)
-	workspaceChanged := tab.Scope != scope || tab.WorkspaceRoot != workspaceRoot
+	// Spelling-only root updates still persist above, but an equivalent root is
+	// the same workspace — do not warn the user about a switch.
+	workspaceChanged := tab.Scope != scope || !sameProjectRoot(tab.WorkspaceRoot, workspaceRoot)
 	tab.Scope = scope
 	tab.WorkspaceRoot = workspaceRoot
 	tab.SessionPath = canonicalTabSessionPath(binding.path)
@@ -4052,7 +4049,7 @@ func prependTopicsInProjectsFileOpts(workspaceRoot string, topicIDs []string, en
 			return true, nil
 		}
 		for i, p := range f.Projects {
-			if p.Root != workspaceRoot {
+			if !sameProjectRoot(p.Root, workspaceRoot) {
 				continue
 			}
 			next := uniqueStrings(append(append([]string(nil), live...), p.Topics...))
@@ -4187,6 +4184,9 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 
 func normalizeSidebarOrder(order []string, projects []desktopProject) []string {
 	seenGlobal := false
+	// Dedupe roots against a roots-only list: out also holds the global order
+	// token, which must never be path-compared against project roots.
+	var seenRoots []string
 	out := make([]string, 0, len(order))
 	for _, value := range order {
 		value = strings.TrimSpace(value)
@@ -4203,9 +4203,10 @@ func normalizeSidebarOrder(order []string, projects []desktopProject) []string {
 			continue
 		}
 		root = projects[i].Root
-		if projectRootInList(out, root) {
+		if projectRootInList(seenRoots, root) {
 			continue
 		}
+		seenRoots = append(seenRoots, root)
 		out = append(out, root)
 	}
 	return out
@@ -5514,11 +5515,8 @@ func repairIndexedSessionTopics(dir string) []string {
 	indexedTopics := projects.GlobalTopics
 	if scope == "project" {
 		indexedTopics = nil
-		for _, p := range projects.Projects {
-			if p.Root == workspaceRoot {
-				indexedTopics = p.Topics
-				break
-			}
+		if i := projectIndexByRoot(projects.Projects, workspaceRoot); i >= 0 {
+			indexedTopics = projects.Projects[i].Topics
 		}
 	}
 	indexedSet := make(map[string]bool, len(indexedTopics))
@@ -5683,6 +5681,17 @@ func sameDesktopPath(a, b string) bool {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
+}
+
+// projectRootKey is the map-key form of a project root: cleaned, absolute,
+// and case-folded on Windows — the same key form agent.CanonicalSessionPath
+// uses for session paths, so equivalent spellings never split lookups.
+func projectRootKey(root string) string {
+	root = cleanDesktopPath(root)
+	if os.PathSeparator == '\\' {
+		return strings.ToLower(root)
+	}
+	return root
 }
 
 func restoreSessionTopicIndex(dir, sessionPath string) error {
@@ -6714,7 +6723,10 @@ func topicSummaryKey(scope, workspaceRoot, topicID string) string {
 	if scope == "global" {
 		return "global::" + topicID
 	}
-	return "project:" + workspaceRoot + ":" + topicID
+	// Producers key by the live tab's root spelling while the sidebar keys by
+	// the registry's canonical spelling; fold both so runtime status never
+	// splits across equivalent roots.
+	return "project:" + projectRootKey(workspaceRoot) + ":" + topicID
 }
 
 func projectSessionNodeKey(scope, sessionPath string) string {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1551,6 +1551,42 @@ func (a *App) ListTabs() []TabMeta {
 	return enrichTabMetas(out)
 }
 
+// syncTabWorkspaceRootSpellings repoints open project tabs at the registry's
+// canonical root spelling after a registry write may have rewritten it
+// (addProject and friends adopt the caller's spelling). Tabs, the project
+// tree, and persisted tab state then agree on a single string form of each
+// root, which the frontend compares exactly. Callers must not hold a.mu.
+func (a *App) syncTabWorkspaceRootSpellings() {
+	projects := loadProjectsFile().Projects
+	a.mu.Lock()
+	changed := false
+	for _, tab := range a.tabs {
+		if tab == nil || tab.Scope != "project" {
+			continue
+		}
+		i := projectIndexByRoot(projects, tab.WorkspaceRoot)
+		if i < 0 || tab.WorkspaceRoot == projects[i].Root {
+			continue
+		}
+		tab.WorkspaceRoot = projects[i].Root
+		changed = true
+	}
+	if changed {
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
+	if changed {
+		a.emitProjectTreeChanged()
+	}
+}
+
+// registerProjectRoot indexes workspaceRoot in the project registry and
+// realigns open tabs when the registry adopted a new spelling of the root.
+func (a *App) registerProjectRoot(workspaceRoot string) {
+	_ = addProject(workspaceRoot, "")
+	a.syncTabWorkspaceRootSpellings()
+}
+
 // OpenProjectTab builds a controller scoped to workspaceRoot and opens the
 // session selected by the given topic. Topic selection resolves to a concrete
 // session path first; the visible tab is then attached to that session runtime.
@@ -1562,7 +1598,7 @@ func (a *App) OpenProjectTab(workspaceRoot, topicID string) (TabMeta, error) {
 		workspaceRoot = abs
 	}
 	saveWorkspace(workspaceRoot)
-	_ = addProject(workspaceRoot, "")
+	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
 	return a.openTopicTab("project", workspaceRoot, topicID, sessionPath)
@@ -1579,7 +1615,7 @@ func (a *App) openProjectTabInactive(workspaceRoot, topicID string) (TabMeta, er
 	if abs, err := filepath.Abs(workspaceRoot); err == nil {
 		workspaceRoot = abs
 	}
-	_ = addProject(workspaceRoot, "")
+	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
 	return a.openTopicTabWithActivation("project", workspaceRoot, topicID, sessionPath, false)
@@ -1713,7 +1749,7 @@ func (a *App) OpenTopicSession(scope, workspaceRoot, topicID, sessionPath string
 			return TabMeta{}, fmt.Errorf("workspaceRoot is required")
 		}
 		saveWorkspace(workspaceRoot)
-		_ = addProject(workspaceRoot, "")
+		a.registerProjectRoot(workspaceRoot)
 	}
 	_, validPath, err := a.sessionDirForPath(sessionPath)
 	if err != nil {
@@ -1794,7 +1830,7 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 			workspaceRoot = abs
 		}
 		saveWorkspace(workspaceRoot)
-		_ = addProject(workspaceRoot, "")
+		a.registerProjectRoot(workspaceRoot)
 	} else {
 		workspaceRoot = ""
 		globalRoot = globalWorkspaceRoot()
@@ -3063,7 +3099,7 @@ func (a *App) applySessionBindingToTab(tab *WorkspaceTab, binding sessionBinding
 		if workspaceRoot == "" {
 			return
 		}
-		_ = addProject(workspaceRoot, "")
+		a.registerProjectRoot(workspaceRoot)
 	} else {
 		scope = "global"
 		workspaceRoot = globalTabWorkspaceRoot()
@@ -3872,10 +3908,11 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 	var roots []string
 	add := func(root string) {
 		root = normalizeProjectRoot(root)
-		if root == "" || seen[root] {
+		key := projectRootKey(root)
+		if root == "" || seen[key] {
 			return
 		}
-		seen[root] = true
+		seen[key] = true
 		roots = append(roots, root)
 	}
 	if cur := loadWorkspace(); cur != "" {
@@ -3907,16 +3944,17 @@ func recoverLegacyProjectSidebarRoots(tabs desktopTabsFile) (bool, error) {
 		for _, project := range f.Projects {
 			root := normalizeProjectRoot(project.Root)
 			if root != "" {
-				seen[root] = true
+				seen[projectRootKey(root)] = true
 			}
 		}
 
 		add := func(root string) {
 			root = normalizeProjectRoot(root)
-			if root == "" || seen[root] || !existingDirectory(root) {
+			key := projectRootKey(root)
+			if root == "" || seen[key] || !existingDirectory(root) {
 				return
 			}
-			seen[root] = true
+			seen[key] = true
 			f.Projects = append(f.Projects, desktopProject{Root: root})
 			changed = true
 		}
@@ -5862,6 +5900,7 @@ func (a *App) RenameProject(workspaceRoot, title string) error {
 	if err := renameProject(workspaceRoot, title); err != nil {
 		return err
 	}
+	a.syncTabWorkspaceRootSpellings()
 	a.emitProjectTreeChanged()
 	return nil
 }
@@ -5872,6 +5911,7 @@ func (a *App) SetProjectColor(workspaceRoot, color string) error {
 	if err := setProjectColor(workspaceRoot, color); err != nil {
 		return err
 	}
+	a.syncTabWorkspaceRootSpellings()
 	a.emitProjectTreeChanged()
 	return nil
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4114,6 +4114,36 @@ func normalizeProjectRoot(root string) string {
 	return root
 }
 
+func sameProjectRoot(a, b string) bool {
+	return sameDesktopPath(normalizeProjectRoot(a), normalizeProjectRoot(b))
+}
+
+func projectIndexByRoot(projects []desktopProject, root string) int {
+	root = normalizeProjectRoot(root)
+	if root == "" {
+		return -1
+	}
+	for i, project := range projects {
+		if sameProjectRoot(project.Root, root) {
+			return i
+		}
+	}
+	return -1
+}
+
+func projectRootInList(roots []string, root string) bool {
+	root = normalizeProjectRoot(root)
+	if root == "" {
+		return false
+	}
+	for _, candidate := range roots {
+		if sameProjectRoot(candidate, root) {
+			return true
+		}
+	}
+	return false
+}
+
 func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 	out := desktopProjectFile{
 		GlobalTitle:        strings.TrimSpace(f.GlobalTitle),
@@ -4122,7 +4152,6 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 		GlobalPinnedTopics: uniqueStrings(f.GlobalPinnedTopics),
 		DeletedTopics:      uniqueStrings(f.DeletedTopics),
 	}
-	index := map[string]int{}
 	for _, p := range f.Projects {
 		root := normalizeProjectRoot(p.Root)
 		if root == "" {
@@ -4133,7 +4162,7 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 		p.Color = normalizeProjectColor(p.Color)
 		p.Topics = uniqueStrings(p.Topics)
 		p.PinnedTopics = uniqueStrings(p.PinnedTopics)
-		if i, ok := index[root]; ok {
+		if i := projectIndexByRoot(out.Projects, root); i >= 0 {
 			if out.Projects[i].Title == "" && p.Title != "" {
 				out.Projects[i].Title = p.Title
 			}
@@ -4144,17 +4173,12 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 			out.Projects[i].PinnedTopics = uniqueStrings(append(out.Projects[i].PinnedTopics, p.PinnedTopics...))
 			continue
 		}
-		index[root] = len(out.Projects)
 		out.Projects = append(out.Projects, p)
-	}
-	projectRoots := make(map[string]bool, len(out.Projects))
-	for _, project := range out.Projects {
-		projectRoots[project.Root] = true
 	}
 	for _, root := range uniqueStrings(f.PinnedProjects) {
 		root = normalizeProjectRoot(root)
-		if root != "" && projectRoots[root] && !containsDesktopString(out.PinnedProjects, root) {
-			out.PinnedProjects = append(out.PinnedProjects, root)
+		if i := projectIndexByRoot(out.Projects, root); i >= 0 && !projectRootInList(out.PinnedProjects, out.Projects[i].Root) {
+			out.PinnedProjects = append(out.PinnedProjects, out.Projects[i].Root)
 		}
 	}
 	out.SidebarOrder = normalizeSidebarOrder(f.SidebarOrder, out.Projects)
@@ -4162,28 +4186,26 @@ func normalizeProjectsFile(f desktopProjectFile) desktopProjectFile {
 }
 
 func normalizeSidebarOrder(order []string, projects []desktopProject) []string {
-	projectRoots := make(map[string]bool, len(projects))
-	for _, project := range projects {
-		if project.Root != "" {
-			projectRoots[project.Root] = true
-		}
-	}
-	seen := make(map[string]bool, len(order))
+	seenGlobal := false
 	out := make([]string, 0, len(order))
 	for _, value := range order {
 		value = strings.TrimSpace(value)
 		if value == desktopGlobalOrderToken {
-			if !seen[value] {
-				seen[value] = true
+			if !seenGlobal {
+				seenGlobal = true
 				out = append(out, value)
 			}
 			continue
 		}
 		root := normalizeProjectRoot(value)
-		if root == "" || !projectRoots[root] || seen[root] {
+		i := projectIndexByRoot(projects, root)
+		if i < 0 {
 			continue
 		}
-		seen[root] = true
+		root = projects[i].Root
+		if projectRootInList(out, root) {
+			continue
+		}
 		out = append(out, root)
 	}
 	return out
@@ -4400,7 +4422,7 @@ func projectColor(root string) string {
 		return globalProjectColor()
 	}
 	for _, p := range loadProjectsFile().Projects {
-		if p.Root == root {
+		if sameProjectRoot(p.Root, root) {
 			return normalizeProjectColor(p.Color)
 		}
 	}
@@ -4426,11 +4448,19 @@ func addProject(root, title string) error {
 	title = strings.TrimSpace(title)
 	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
 		for i, p := range f.Projects {
-			if p.Root == root {
-				if title == "" || f.Projects[i].Title == title {
+			if sameProjectRoot(p.Root, root) {
+				changed := false
+				if f.Projects[i].Root != root {
+					f.Projects[i].Root = root
+					changed = true
+				}
+				if title != "" && f.Projects[i].Title != title {
+					f.Projects[i].Title = title
+					changed = true
+				}
+				if !changed {
 					return false, nil
 				}
-				f.Projects[i].Title = title
 				return true, nil
 			}
 		}
@@ -4451,10 +4481,11 @@ func renameProject(root, title string) error {
 			return true, nil
 		}
 		for i, p := range f.Projects {
-			if p.Root == root {
-				if f.Projects[i].Title == title {
+			if sameProjectRoot(p.Root, root) {
+				if f.Projects[i].Root == root && f.Projects[i].Title == title {
 					return false, nil
 				}
+				f.Projects[i].Root = root
 				f.Projects[i].Title = title
 				return true, nil
 			}
@@ -4476,10 +4507,11 @@ func setProjectColor(root, color string) error {
 			return true, nil
 		}
 		for i, p := range f.Projects {
-			if p.Root == root {
-				if f.Projects[i].Color == color {
+			if sameProjectRoot(p.Root, root) {
+				if f.Projects[i].Root == root && f.Projects[i].Color == color {
 					return false, nil
 				}
+				f.Projects[i].Root = root
 				f.Projects[i].Color = color
 				return true, nil
 			}
@@ -4494,7 +4526,7 @@ func removeProject(root string) error {
 	return updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
 		projects := make([]desktopProject, 0, len(f.Projects))
 		for _, p := range f.Projects {
-			if p.Root != root {
+			if !sameProjectRoot(p.Root, root) {
 				projects = append(projects, p)
 			}
 		}
@@ -5843,19 +5875,19 @@ func (a *App) SetProjectPinned(workspaceRoot string, pinned bool) error {
 		return fmt.Errorf("workspaceRoot is required")
 	}
 	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
-		found := false
-		for _, project := range f.Projects {
-			if project.Root == root {
-				found = true
-				break
-			}
-		}
-		if !found {
+		i := projectIndexByRoot(f.Projects, root)
+		if i < 0 {
 			return false, fmt.Errorf("project %q not found", root)
 		}
-		next := removeString(f.PinnedProjects, root)
+		root = f.Projects[i].Root
+		next := make([]string, 0, len(f.PinnedProjects))
+		for _, pinnedRoot := range f.PinnedProjects {
+			if !sameProjectRoot(pinnedRoot, root) {
+				next = append(next, pinnedRoot)
+			}
+		}
 		if pinned {
-			next = prependUniqueString(f.PinnedProjects, root)
+			next = prependUniqueString(next, root)
 		}
 		if sameStringList(next, f.PinnedProjects) {
 			return false, nil
@@ -5873,36 +5905,32 @@ func (a *App) SetProjectPinned(workspaceRoot string, pinned bool) error {
 // when present, the virtual Global sidebar section.
 func (a *App) ReorderProjects(workspaceRoots []string) error {
 	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
-		byRoot := make(map[string]desktopProject, len(f.Projects))
-		for _, project := range f.Projects {
-			byRoot[project.Root] = project
-		}
-		seen := make(map[string]bool, len(workspaceRoots))
+		var seenProjects []string
 		next := make([]desktopProject, 0, len(workspaceRoots))
 		sidebarOrder := make([]string, 0, len(workspaceRoots))
 		hasGlobalOrder := false
 		for _, root := range workspaceRoots {
 			root = strings.TrimSpace(root)
 			if root == desktopGlobalOrderToken {
-				if seen[root] {
+				if hasGlobalOrder {
 					return false, fmt.Errorf("duplicate global section")
 				}
-				seen[root] = true
 				hasGlobalOrder = true
 				sidebarOrder = append(sidebarOrder, root)
 				continue
 			}
 			root = normalizeProjectRoot(root)
-			project, ok := byRoot[root]
-			if !ok {
+			i := projectIndexByRoot(f.Projects, root)
+			if i < 0 {
 				return false, fmt.Errorf("project %q not found", root)
 			}
-			if seen[root] {
+			project := f.Projects[i]
+			if projectRootInList(seenProjects, project.Root) {
 				return false, fmt.Errorf("duplicate project %q", root)
 			}
-			seen[root] = true
+			seenProjects = append(seenProjects, project.Root)
 			next = append(next, project)
-			sidebarOrder = append(sidebarOrder, root)
+			sidebarOrder = append(sidebarOrder, project.Root)
 		}
 		if len(next) != len(f.Projects) {
 			return false, fmt.Errorf("project order length mismatch")

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1802,13 +1802,13 @@ func tabMatchesTopicTarget(tab *WorkspaceTab, scope, workspaceRoot, topicID stri
 	if scope == "global" {
 		return true
 	}
-	return normalizeProjectRoot(tab.WorkspaceRoot) == normalizeProjectRoot(workspaceRoot)
+	return sameProjectRoot(tab.WorkspaceRoot, workspaceRoot)
 }
 
 func tabInWorkspace(tab *WorkspaceTab, workspaceRoot string) bool {
 	return tab != nil &&
 		tab.Scope == "project" &&
-		normalizeProjectRoot(tab.WorkspaceRoot) == normalizeProjectRoot(workspaceRoot)
+		sameProjectRoot(tab.WorkspaceRoot, workspaceRoot)
 }
 
 // EnsureBlankTab activates the existing blank tab for the target scope, or
@@ -3065,7 +3065,7 @@ func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) (string, bool
 		return "", false
 	}
 	if tab.Scope == "project" && binding.scope != "project" && normalizeProjectRoot(tab.WorkspaceRoot) != "" {
-		if root, ok := safeControllerWorkspaceRoot(tab.Ctrl); ok && normalizeProjectRoot(root) == normalizeProjectRoot(tab.WorkspaceRoot) {
+		if root, ok := safeControllerWorkspaceRoot(tab.Ctrl); ok && sameProjectRoot(root, tab.WorkspaceRoot) {
 			return "", false
 		}
 	}
@@ -5693,9 +5693,9 @@ func legacySessionScopeMatchesMigrationTarget(meta agent.BranchMeta, scope, work
 	}
 	metaRoot := normalizeProjectRoot(meta.WorkspaceRoot)
 	if scope == "project" {
-		return metaRoot == "" || normalizeProjectRoot(workspaceRoot) == metaRoot
+		return metaRoot == "" || sameProjectRoot(workspaceRoot, metaRoot)
 	}
-	return metaRoot == "" || normalizeProjectRoot(globalWorkspaceRoot()) == metaRoot
+	return metaRoot == "" || sameProjectRoot(globalWorkspaceRoot(), metaRoot)
 }
 
 func cleanDesktopPath(path string) string {
@@ -7680,7 +7680,7 @@ func (a *App) knownSessionDirs() []string {
 
 func topicSessionMatchMatchesTarget(match topicSessionMatch, scope, workspaceRoot string) bool {
 	if scope == "project" {
-		return match.scope == "project" && normalizeProjectRoot(match.workspaceRoot) == normalizeProjectRoot(workspaceRoot)
+		return match.scope == "project" && sameProjectRoot(match.workspaceRoot, workspaceRoot)
 	}
 	return match.scope == "" || match.scope == "global"
 }

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -254,7 +254,10 @@ func TestProjectFileUpdatesSerializeReadModifyWrite(t *testing.T) {
 func TestNormalizeProjectsFileMergesEquivalentProjectRoots(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	projectRoot := t.TempDir()
-	equivalentRoot := filepath.Join(projectRoot, ".")
+	// A textually different spelling of the same folder. filepath.Join would
+	// clean the dot segment away and hand back the identical string, so build
+	// the spelling by hand.
+	equivalentRoot := projectRoot + string(filepath.Separator) + "."
 
 	f := normalizeProjectsFile(desktopProjectFile{
 		Projects: []desktopProject{
@@ -301,7 +304,7 @@ func TestSwitchWorkspaceReaddsRemovedProject(t *testing.T) {
 
 	app := NewApp()
 	installNoopRuntimeEvents(app)
-	if got, err := app.SwitchWorkspace(filepath.Join(projectRoot, ".")); err != nil {
+	if got, err := app.SwitchWorkspace(projectRoot + string(filepath.Separator) + "."); err != nil {
 		t.Fatalf("switch workspace: %v", err)
 	} else if got != normalizeProjectRoot(projectRoot) {
 		t.Fatalf("SwitchWorkspace root = %q, want %q", got, normalizeProjectRoot(projectRoot))
@@ -313,6 +316,108 @@ func TestSwitchWorkspaceReaddsRemovedProject(t *testing.T) {
 	}
 	if got := loadWorkspace(); got != normalizeProjectRoot(projectRoot) {
 		t.Fatalf("active workspace = %q, want %q", got, normalizeProjectRoot(projectRoot))
+	}
+}
+
+// flipPathASCIICase returns the path with the case of every ASCII letter
+// swapped — on Windows an equivalent spelling of the same folder that
+// normalizeProjectRoot cannot fold away.
+func flipPathASCIICase(t *testing.T, path string) string {
+	t.Helper()
+	flipped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r - 'a' + 'A'
+		case r >= 'A' && r <= 'Z':
+			return r - 'A' + 'a'
+		}
+		return r
+	}, path)
+	if flipped == path {
+		t.Skipf("path %q contains no ASCII letters to flip", path)
+	}
+	return flipped
+}
+
+func TestNormalizeProjectsFileFoldsRootCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive root matching only applies to Windows paths")
+	}
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	flipped := flipPathASCIICase(t, projectRoot)
+
+	f := normalizeProjectsFile(desktopProjectFile{
+		Projects: []desktopProject{
+			{Root: projectRoot, Title: "Project", Topics: []string{"topic_a"}},
+			{Root: flipped, Color: "blue", Topics: []string{"topic_b"}},
+		},
+		PinnedProjects: []string{flipped},
+		SidebarOrder:   []string{flipped, projectRoot},
+	})
+
+	if len(f.Projects) != 1 {
+		t.Fatalf("projects = %+v, want case-equivalent roots merged", f.Projects)
+	}
+	canonical := f.Projects[0].Root
+	if canonical != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("merged root = %q, want first spelling %q", canonical, normalizeProjectRoot(projectRoot))
+	}
+	if f.Projects[0].Title != "Project" || f.Projects[0].Color != "blue" {
+		t.Fatalf("merged metadata = %+v, want title and color preserved", f.Projects[0])
+	}
+	if got := f.Projects[0].Topics; len(got) != 2 || got[0] != "topic_a" || got[1] != "topic_b" {
+		t.Fatalf("merged topics = %v, want [topic_a topic_b]", got)
+	}
+	if len(f.PinnedProjects) != 1 || f.PinnedProjects[0] != canonical {
+		t.Fatalf("pinned projects = %v, want canonical root %q", f.PinnedProjects, canonical)
+	}
+	if len(f.SidebarOrder) != 1 || f.SidebarOrder[0] != canonical {
+		t.Fatalf("sidebar order = %v, want canonical root %q", f.SidebarOrder, canonical)
+	}
+}
+
+func TestProjectRootOpsFoldCaseOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive root matching only applies to Windows paths")
+	}
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	flipped := flipPathASCIICase(t, projectRoot)
+
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := addProject(flipped, ""); err != nil {
+		t.Fatalf("re-add project under flipped case: %v", err)
+	}
+	projects := loadProjectsFile().Projects
+	if len(projects) != 1 {
+		t.Fatalf("projects = %+v, want re-add under equivalent spelling to update in place", projects)
+	}
+	if projects[0].Root != normalizeProjectRoot(flipped) {
+		t.Fatalf("root = %q, want self-healed to latest spelling %q", projects[0].Root, normalizeProjectRoot(flipped))
+	}
+	if projects[0].Title != "Project" {
+		t.Fatalf("title = %q, want preserved across re-add", projects[0].Title)
+	}
+
+	if err := prependTopicInProjectsFile(projectRoot, "topic_a", true); err != nil {
+		t.Fatalf("prepend topic: %v", err)
+	}
+	projects = loadProjectsFile().Projects
+	if len(projects) != 1 {
+		t.Fatalf("projects = %+v, want topic prepend to reuse the case-equivalent entry", projects)
+	}
+	if got := projects[0].Topics; len(got) != 1 || got[0] != "topic_a" {
+		t.Fatalf("topics = %v, want [topic_a] on the merged entry", got)
+	}
+
+	if err := removeProject(projectRoot); err != nil {
+		t.Fatalf("remove project via original spelling: %v", err)
+	}
+	if got := loadProjectsFile().Projects; len(got) != 0 {
+		t.Fatalf("projects after remove = %+v, want none", got)
 	}
 }
 

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -421,6 +421,42 @@ func TestProjectRootOpsFoldCaseOnWindows(t *testing.T) {
 	}
 }
 
+func TestSyncTabWorkspaceRootSpellingsOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive root matching only applies to Windows paths")
+	}
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	flipped := flipPathASCIICase(t, projectRoot)
+
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+
+	app := NewApp()
+	installNoopRuntimeEvents(app)
+	app.tabs["tab_case"] = &WorkspaceTab{
+		ID:            "tab_case",
+		Scope:         "project",
+		WorkspaceRoot: normalizeProjectRoot(projectRoot),
+		Ready:         true,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabOrder = []string{"tab_case"}
+
+	// Re-registering under the flipped spelling self-heals the registry root;
+	// open tabs must follow so the frontend keeps comparing one string form.
+	app.registerProjectRoot(flipped)
+
+	projects := loadProjectsFile().Projects
+	if len(projects) != 1 || projects[0].Root != normalizeProjectRoot(flipped) {
+		t.Fatalf("registry projects = %+v, want single root %q", projects, normalizeProjectRoot(flipped))
+	}
+	if got := app.tabs["tab_case"].WorkspaceRoot; got != projects[0].Root {
+		t.Fatalf("tab root = %q, want registry spelling %q", got, projects[0].Root)
+	}
+}
+
 func TestDialogDefaultDirectoryFallsBackFromMissingWorkspace(t *testing.T) {
 	parent := t.TempDir()
 	missing := filepath.Join(parent, "deleted", "project")

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -251,6 +251,71 @@ func TestProjectFileUpdatesSerializeReadModifyWrite(t *testing.T) {
 	}
 }
 
+func TestNormalizeProjectsFileMergesEquivalentProjectRoots(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	equivalentRoot := filepath.Join(projectRoot, ".")
+
+	f := normalizeProjectsFile(desktopProjectFile{
+		Projects: []desktopProject{
+			{Root: projectRoot, Title: "Project", Topics: []string{"topic_a"}},
+			{Root: equivalentRoot, Color: "blue", Topics: []string{"topic_b"}, PinnedTopics: []string{"topic_b"}},
+		},
+		PinnedProjects: []string{equivalentRoot},
+		SidebarOrder:   []string{equivalentRoot, projectRoot},
+	})
+
+	if len(f.Projects) != 1 {
+		t.Fatalf("projects = %+v, want one merged project", f.Projects)
+	}
+	if f.Projects[0].Root != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("merged root = %q, want %q", f.Projects[0].Root, normalizeProjectRoot(projectRoot))
+	}
+	if f.Projects[0].Title != "Project" || f.Projects[0].Color != "blue" {
+		t.Fatalf("merged metadata = %+v, want title and color preserved", f.Projects[0])
+	}
+	if got := f.Projects[0].Topics; len(got) != 2 || got[0] != "topic_a" || got[1] != "topic_b" {
+		t.Fatalf("merged topics = %v, want [topic_a topic_b]", got)
+	}
+	if len(f.PinnedProjects) != 1 || f.PinnedProjects[0] != f.Projects[0].Root {
+		t.Fatalf("pinned projects = %v, want canonical root %q", f.PinnedProjects, f.Projects[0].Root)
+	}
+	if len(f.SidebarOrder) != 1 || f.SidebarOrder[0] != f.Projects[0].Root {
+		t.Fatalf("sidebar order = %v, want canonical root %q", f.SidebarOrder, f.Projects[0].Root)
+	}
+}
+
+func TestSwitchWorkspaceReaddsRemovedProject(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := removeProject(projectRoot); err != nil {
+		t.Fatalf("remove project: %v", err)
+	}
+	if got := loadProjectsFile().Projects; len(got) != 0 {
+		t.Fatalf("projects after remove = %+v, want none", got)
+	}
+
+	app := NewApp()
+	installNoopRuntimeEvents(app)
+	if got, err := app.SwitchWorkspace(filepath.Join(projectRoot, ".")); err != nil {
+		t.Fatalf("switch workspace: %v", err)
+	} else if got != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("SwitchWorkspace root = %q, want %q", got, normalizeProjectRoot(projectRoot))
+	}
+
+	projects := loadProjectsFile().Projects
+	if len(projects) != 1 || projects[0].Root != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("projects after re-add = %+v, want %q", projects, normalizeProjectRoot(projectRoot))
+	}
+	if got := loadWorkspace(); got != normalizeProjectRoot(projectRoot) {
+		t.Fatalf("active workspace = %q, want %q", got, normalizeProjectRoot(projectRoot))
+	}
+}
+
 func TestDialogDefaultDirectoryFallsBackFromMissingWorkspace(t *testing.T) {
 	parent := t.TempDir()
 	missing := filepath.Join(parent, "deleted", "project")

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
+	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
@@ -454,6 +455,58 @@ func TestSyncTabWorkspaceRootSpellingsOnWindows(t *testing.T) {
 	}
 	if got := app.tabs["tab_case"].WorkspaceRoot; got != projects[0].Root {
 		t.Fatalf("tab root = %q, want registry spelling %q", got, projects[0].Root)
+	}
+}
+
+func TestFindTopicSessionAfterCaseFlippedReaddOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("case-insensitive root matching only applies to Windows paths")
+	}
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	flipped := flipPathASCIICase(t, projectRoot)
+
+	// Register under original spelling.
+	if err := addProject(projectRoot, "Project"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := prependTopicInProjectsFile(projectRoot, "topic_case", true); err != nil {
+		t.Fatalf("prepend topic: %v", err)
+	}
+
+	// Write a session file with the original root spelling in its meta.
+	sessionDir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(sessionDir, "topic-case.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	if err := agent.SaveBranchMeta(sessionPath, agent.BranchMeta{
+		TopicID:       "topic_case",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("save branch meta: %v", err)
+	}
+
+	// Re-add under the flipped-case spelling — simulates Windows Explorer
+	// or a different shell returning the same folder with different case.
+	app := NewApp()
+	installNoopRuntimeEvents(app)
+	app.registerProjectRoot(flipped)
+
+	// findTopicSessionForTarget must match the session whose meta carries
+	// the original case spelling against the registry's new (flipped) root.
+	path, _ := app.findTopicSessionForTarget("project", normalizeProjectRoot(flipped), "topic_case")
+	if path == "" {
+		t.Fatal("findTopicSessionForTarget returned empty path; session with old-case root should still match")
+	}
+	if path != sessionPath {
+		t.Fatalf("findTopicSessionForTarget = %q, want %q", path, sessionPath)
 	}
 }
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -334,8 +334,16 @@ func MemoryCompilerDir(workspaceRoot string) string {
 }
 
 // WorkspaceSlug flattens an absolute workspace path into the directory name
-// used under <config root>/projects.
+// used under <config root>/projects. Windows spells the same folder with
+// varying case (drive-letter case, Explorer renames), so the slug folds case
+// there — matching agent.CanonicalSessionPath's key form — or equivalent
+// spellings of one workspace would produce distinct slug strings. Existing
+// mixed-case slug directories need no migration: NTFS resolves names
+// case-insensitively, so the folded slug opens the same directory.
 func WorkspaceSlug(absPath string) string {
+	if runtimeGOOS == "windows" {
+		absPath = strings.ToLower(absPath)
+	}
 	return strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
 }
 

--- a/internal/config/workspace_slug_test.go
+++ b/internal/config/workspace_slug_test.go
@@ -1,0 +1,30 @@
+package config
+
+import "testing"
+
+// WorkspaceSlug folds case on Windows so equivalent spellings of one
+// workspace (drive-letter case, Explorer renames) map to a single slug —
+// the same key form agent.CanonicalSessionPath uses for session paths.
+func TestWorkspaceSlugFoldsCaseOnWindows(t *testing.T) {
+	setRuntimeGOOS(t, "windows")
+	upper := WorkspaceSlug(`C:\Users\Dev\Proj`)
+	lower := WorkspaceSlug(`c:\users\dev\proj`)
+	if upper != lower {
+		t.Fatalf("WorkspaceSlug case-split on windows: %q vs %q", upper, lower)
+	}
+	if want := "c--users-dev-proj"; upper != want {
+		t.Fatalf("WorkspaceSlug = %q, want %q", upper, want)
+	}
+}
+
+// Unix paths are case-sensitive: two spellings that differ in case are two
+// different directories and must keep distinct slugs.
+func TestWorkspaceSlugPreservesCaseOffWindows(t *testing.T) {
+	setRuntimeGOOS(t, "linux")
+	if got, want := WorkspaceSlug("/Users/Dev/Proj"), "-Users-Dev-Proj"; got != want {
+		t.Fatalf("WorkspaceSlug = %q, want %q", got, want)
+	}
+	if WorkspaceSlug("/users/dev/proj") == WorkspaceSlug("/Users/Dev/Proj") {
+		t.Fatal("WorkspaceSlug folded case off windows; unix paths are case-sensitive")
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/config"
 	"reasonix/internal/frontmatter"
 )
 
@@ -77,7 +78,7 @@ func StoreFor(userDir, cwd string) Store {
 		return Store{}
 	}
 	return Store{
-		Dir:       filepath.Join(userDir, "projects", slugify(absOf(cwd)), "memory"),
+		Dir:       filepath.Join(userDir, "projects", config.WorkspaceSlug(absOf(cwd)), "memory"),
 		GlobalDir: filepath.Join(userDir, "memory", "global"),
 	}
 }
@@ -95,14 +96,6 @@ func (s Store) DirFor(t Type) string {
 
 // indexFile is the human-readable index of saved memories.
 const indexFile = "MEMORY.md"
-
-// slugify turns an absolute project path into a single filesystem-safe segment,
-// matching the auto-memory convention (path separators → '-'), e.g.
-// "/Users/me/proj" → "-Users-me-proj".
-func slugify(absPath string) string {
-	r := strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-")
-	return r.Replace(absPath)
-}
 
 // dirs returns the directories to read from, in order: GlobalDir first (shared
 // memories), then Dir (project-specific).

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -356,7 +357,13 @@ func TestStoreForSlug(t *testing.T) {
 	if strings.Count(filepath.Base(filepath.Dir(s.Dir)), "/") != 0 {
 		t.Fatalf("slug should have no separators: %s", s.Dir)
 	}
-	if !strings.Contains(s.Dir, "-Users-me-proj") {
+	// config.WorkspaceSlug folds case on Windows (equivalent spellings of one
+	// folder must share a slug); unix slugs keep the original case.
+	want := "-Users-me-proj"
+	if runtime.GOOS == "windows" {
+		want = "-users-me-proj"
+	}
+	if !strings.Contains(s.Dir, want) {
 		t.Fatalf("unexpected slug: %s", s.Dir)
 	}
 }


### PR DESCRIPTION
## Summary
- compare desktop project roots with the platform-aware path matcher
- canonicalize stale project registry entries when a project is added again
- keep project pinning and sidebar ordering resilient to equivalent root spellings
- extend the same equivalence to runtime lookups that cross spelling sources: blank-tab reuse, open-topic collection, session-binding workspace notices, topic prepend/repair, indexed blank-topic reuse, and `ListWorkspaces`' `Current` flag
- fold case in `topicSummaryKey` (same key form as `agent.CanonicalSessionPath`) so sidebar topic runtime status never splits across the tab, registry, and session-meta root spellings
- fold Windows case in `config.WorkspaceSlug` so equivalent spellings of one workspace no longer split its `projects/<slug>` session/memory state directories; `internal/memory`'s duplicate `slugify` now routes through it. No migration needed: NTFS resolves directory names case-insensitively, so the folded slug opens the same directory
- sync open project tabs to the registry's canonical root spelling after registry writes (`registerProjectRoot` / rename / color), persist the tab snapshot, and emit `project-tree:changed` — the frontend keeps comparing plain strings against a single source of truth instead of learning platform path semantics
- fold the startup-migration and recovery-GC seen maps (`desktopMCPMigrationRoots`, `recoverLegacyProjectSidebarRoots`, `recoveryGCDirs`) with `projectRootKey` so case-split roots are not scanned or appended twice
- keep the global sidebar token out of path comparisons in `normalizeSidebarOrder`
- add regression coverage: equivalent-root merging, re-adding a removed project, Windows-only case-folding tests (`*OnWindows`) including tab re-spell sync, `WorkspaceSlug` fold/preserve tests, plus a `windows-latest` desktop CI leg to run the Windows-only tests

## Root Cause
The desktop project registry used exact string equality for several root-path operations. If an existing record used an equivalent spelling of the same folder, later remove/re-add, pin, or reorder operations could miss the stale entry instead of repairing it. On Linux/macOS `normalizeProjectRoot` already collapses dot segments and trailing separators, so the reachable spelling split is Windows case differences (`filepath.Abs` does not fold case) — which is why the contract tests are Windows-only and need the new CI leg. The same key-splitting shape also affected `config.WorkspaceSlug` (persistent per-project state directories) and the frontend's exact `workspaceRoot` comparisons, both fixed here at the owner level.

## Known limitations
- macOS APFS is case-insensitive by default, but `sameDesktopPath` only folds case on Windows, so same-folder case variants can still split on macOS. This matches the existing `sameDesktopPath` semantics.
- Symlinked spellings of the same folder (e.g. `/var` vs `/private/var`) are not treated as equivalent; nothing resolves symlinks today.

## Checks
- `go test ./...` (root module, includes the `WorkspaceSlug` fold/preserve tests)
- `cd desktop && go test .`
- `cd desktop && go test . -run 'OnWindows$' -v` (runs on the new `desktop-windows` CI leg; skips elsewhere)
- `gofmt -l` / `go vet` clean on both modules
- `git diff --check`


## Cache
Cache-impact: none - internal/memory/store.go only routes the project-slug computation through config.WorkspaceSlug (deduping a copy of slugify). The slug names the on-disk memory storage directory; it is never emitted into the provider-visible system prompt, and off Windows the produced bytes are identical to before. The MEMORY.md index text that loads into the cached prefix is unchanged.
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) passed; no prompt-construction, tool-schema, or memory-index-format bytes changed.
System-prompt-review: No system-prompt surface touched - the change is a storage-path helper dedup, so the cached system-prompt prefix is byte-identical on all platforms except the Windows storage directory casing.
