### PR TITLE
Upgrade Memory v5 outcome signals, injected split, and learnings export / 升级 Memory v5 成败信号、注入分桶统计与 learnings 导出

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -343,6 +343,10 @@ type Agent struct {
 	// provider-visible execution contract. compact preserves the old injection.
 	memoryCompilerVerbosity string
 	compilerTurn            *memorycompiler.Turn
+	// lastCompilerOutcome is the previous finished turn's persisted outcome.
+	// The immediately following user message may retroactively downgrade it
+	// when it reports the result wrong; any turn start consumes it (one-shot).
+	lastCompilerOutcome *memorycompiler.OutcomeRef
 
 	// compilerInjectionMu bounds how often Memory v5 may replace a visible user
 	// turn with an execution contract. The runtime can still observe throttled
@@ -529,6 +533,22 @@ func (a *Agent) clearClassifierCache() {
 	if llm, ok := a.classifier.(*llmClassifier); ok && llm.cache != nil {
 		llm.cache.Clear()
 	}
+}
+
+// reviseMemoryCompilerOutcomeForFeedback retroactively downgrades the previous
+// turn's recorded success when the user's immediate follow-up reports the
+// result wrong. One-shot: only the next turn's input may revise, so a stale
+// reference can never be replayed against later conversation.
+func (a *Agent) reviseMemoryCompilerOutcomeForFeedback(rt *memorycompiler.Runtime, input string) {
+	ref := a.lastCompilerOutcome
+	a.lastCompilerOutcome = nil
+	if ref == nil || rt == nil {
+		return
+	}
+	if !memorycompiler.IsCorrectiveFeedback(input) {
+		return
+	}
+	rt.ReviseOutcomeFromFeedback(*ref, input)
 }
 
 func shouldStartMemoryCompiler(input string) bool {
@@ -990,6 +1010,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
+	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) {
+		a.reviseMemoryCompilerOutcomeForFeedback(memCompiler, memoryCompilerInput)
+	}
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) && shouldStartMemoryCompiler(memoryCompilerInput) {
 		// 使用分类器判断是否为任务
 		isTask := true // 默认为任务
@@ -1015,6 +1038,8 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				a.emitMemoryCompilerStats(turn)
 				defer func() {
 					turn.Finish(runErr)
+					ref := turn.OutcomeRef()
+					a.lastCompilerOutcome = &ref
 					if a.compilerTurn == turn {
 						a.compilerTurn = nil
 					}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -345,7 +345,10 @@ type Agent struct {
 	compilerTurn            *memorycompiler.Turn
 	// lastCompilerOutcome is the previous finished turn's persisted outcome.
 	// The immediately following user message may retroactively downgrade it
-	// when it reports the result wrong; any turn start consumes it (one-shot).
+	// when it reports the result wrong. Every non-synthetic turn start
+	// consumes it (one-shot) — even while the runtime is nil — so a ref can
+	// never survive intervening turns and be replayed after Memory v5 is
+	// re-enabled. Session switches clear it. Guarded by memoryCompilerMu.
 	lastCompilerOutcome *memorycompiler.OutcomeRef
 
 	// compilerInjectionMu bounds how often Memory v5 may replace a visible user
@@ -537,11 +540,14 @@ func (a *Agent) clearClassifierCache() {
 
 // reviseMemoryCompilerOutcomeForFeedback retroactively downgrades the previous
 // turn's recorded success when the user's immediate follow-up reports the
-// result wrong. One-shot: only the next turn's input may revise, so a stale
-// reference can never be replayed against later conversation.
+// result wrong. The ref is consumed unconditionally so it can never outlive
+// the turn that follows it; the revision itself additionally requires a live
+// runtime and corrective feedback.
 func (a *Agent) reviseMemoryCompilerOutcomeForFeedback(rt *memorycompiler.Runtime, input string) {
+	a.memoryCompilerMu.Lock()
 	ref := a.lastCompilerOutcome
 	a.lastCompilerOutcome = nil
+	a.memoryCompilerMu.Unlock()
 	if ref == nil || rt == nil {
 		return
 	}
@@ -702,6 +708,12 @@ func (a *Agent) SetSession(s *Session) {
 		a.rebuildTodoState(s.Snapshot())
 	}
 	a.resetMemoryCompilerInjectionGate()
+	// A session switch breaks the "immediately preceding turn" relationship:
+	// the next input belongs to a different conversation, so the pending
+	// outcome ref must not be revisable from it.
+	a.memoryCompilerMu.Lock()
+	a.lastCompilerOutcome = nil
+	a.memoryCompilerMu.Unlock()
 	// 清除分类缓存（会话边界）
 	a.clearClassifierCache()
 }
@@ -1010,8 +1022,11 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		memoryCompilerInput = sourceInput
 	}
 	input = a.withTurnPreferences(rawInput)
-	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) {
-		a.reviseMemoryCompilerOutcomeForFeedback(memCompiler, memoryCompilerInput)
+	// Consume the previous turn's outcome ref on every non-synthetic turn,
+	// even while the runtime is nil (/memory-v5 off): revision must only ever
+	// target the immediately preceding turn.
+	if !MemoryCompilerSkipFromContext(ctx) {
+		a.reviseMemoryCompilerOutcomeForFeedback(a.memoryCompilerRuntime(), memoryCompilerInput)
 	}
 	if memCompiler := a.memoryCompilerRuntime(); memCompiler != nil && !MemoryCompilerSkipFromContext(ctx) && shouldStartMemoryCompiler(memoryCompilerInput) {
 		// 使用分类器判断是否为任务
@@ -1039,7 +1054,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				defer func() {
 					turn.Finish(runErr)
 					ref := turn.OutcomeRef()
+					a.memoryCompilerMu.Lock()
 					a.lastCompilerOutcome = &ref
+					a.memoryCompilerMu.Unlock()
 					if a.compilerTurn == turn {
 						a.compilerTurn = nil
 					}

--- a/internal/agent/memory_feedback_e2e_test.go
+++ b/internal/agent/memory_feedback_e2e_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/memorycompiler"
+)
+
+// readCompilerStrategies decodes the persisted Memory v5 strategy counters so
+// the test can observe learning-side effects without exporting runtime state.
+func readCompilerStrategies(t *testing.T, dir string) []memorycompiler.Strategy {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var st struct {
+		Strategies []memorycompiler.Strategy `json:"strategies"`
+	}
+	if err := json.Unmarshal(b, &st); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	return st.Strategies
+}
+
+func TestCorrectiveFollowUpRevisesPreviousOutcome(t *testing.T) {
+	dir := t.TempDir()
+	rt := memorycompiler.New(dir)
+	mp := testutil.NewMock("m", testutil.Turn{Text: "done"}, testutil.Turn{Text: "sorry"})
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+
+	if err := a.Run(context.Background(), "fix a bug in the parser"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID == "bugfix-reproduce-first" && (s.Successes != 1 || s.Failures != 0) {
+			t.Fatalf("turn 1 not recorded as success: %+v", s)
+		}
+	}
+
+	if err := a.Run(context.Background(), "不对，还是报错"); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID != "bugfix-reproduce-first" {
+			continue
+		}
+		if s.Successes != 0 || s.Failures < 1 {
+			t.Fatalf("corrective follow-up did not revise turn 1 outcome: %+v", s)
+		}
+		return
+	}
+	t.Fatal("bugfix strategy missing from state")
+}
+
+func TestNeutralFollowUpDoesNotReviseOutcome(t *testing.T) {
+	dir := t.TempDir()
+	rt := memorycompiler.New(dir)
+	mp := testutil.NewMock("m", testutil.Turn{Text: "done"}, testutil.Turn{Text: "done again"})
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+
+	if err := a.Run(context.Background(), "fix a bug in the parser"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if err := a.Run(context.Background(), "fix another bug in the lexer"); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID != "bugfix-reproduce-first" {
+			continue
+		}
+		if s.Successes != 2 || s.Failures != 0 {
+			t.Fatalf("neutral follow-up moved counters: %+v", s)
+		}
+		return
+	}
+	t.Fatal("bugfix strategy missing from state")
+}

--- a/internal/agent/memory_feedback_e2e_test.go
+++ b/internal/agent/memory_feedback_e2e_test.go
@@ -29,6 +29,23 @@ func readCompilerStrategies(t *testing.T, dir string) []memorycompiler.Strategy 
 	return st.Strategies
 }
 
+// requireBugfixCounters asserts the persisted bugfix strategy's success/failure
+// counters.
+func requireBugfixCounters(t *testing.T, dir, when string, successes, failures int) {
+	t.Helper()
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID != "bugfix-reproduce-first" {
+			continue
+		}
+		if s.Successes != successes || s.Failures != failures {
+			t.Fatalf("%s: counters = %d ok / %d fail, want %d ok / %d fail (%+v)",
+				when, s.Successes, s.Failures, successes, failures, s)
+		}
+		return
+	}
+	t.Fatalf("%s: bugfix strategy missing from state", when)
+}
+
 func TestCorrectiveFollowUpRevisesPreviousOutcome(t *testing.T) {
 	dir := t.TempDir()
 	rt := memorycompiler.New(dir)
@@ -81,4 +98,71 @@ func TestNeutralFollowUpDoesNotReviseOutcome(t *testing.T) {
 		return
 	}
 	t.Fatal("bugfix strategy missing from state")
+}
+
+// TestStaleOutcomeRefNotRevisableAfterCompilerToggle covers the reviewer
+// scenario: success turn records a ref → /memory-v5 off → intervening turn →
+// on again → corrective input. The intervening turn must consume the ref even
+// though the runtime was nil, so the old trace is not downgraded.
+func TestStaleOutcomeRefNotRevisableAfterCompilerToggle(t *testing.T) {
+	dir := t.TempDir()
+	rt := memorycompiler.New(dir)
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "done"},
+		testutil.Turn{Text: "chat answer"},
+		testutil.Turn{Text: "sorry"},
+	)
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+
+	if err := a.Run(context.Background(), "fix a bug in the parser"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	requireBugfixCounters(t, dir, "after turn 1", 1, 0)
+
+	a.SetMemoryCompiler(nil) // /memory-v5 off
+	if err := a.Run(context.Background(), "tell me about the weather"); err != nil {
+		t.Fatalf("intervening turn: %v", err)
+	}
+	a.SetMemoryCompiler(memorycompiler.New(dir)) // /memory-v5 on
+
+	if err := a.Run(context.Background(), "不对，还是报错"); err != nil {
+		t.Fatalf("corrective turn: %v", err)
+	}
+	// The corrective input must not revise turn 1: its ref was consumed by the
+	// intervening turn. (The corrective turn itself may add new samples, so
+	// only assert turn 1's success survived.)
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID == "bugfix-reproduce-first" && s.Successes != 1 {
+			t.Fatalf("stale ref revised turn 1 after compiler toggle: %+v", s)
+		}
+	}
+}
+
+// TestOutcomeRefClearedOnSessionSwitch: switching sessions breaks the
+// "immediately preceding turn" relationship, so the first input of the new
+// session must not revise the old session's outcome even without intervening
+// turns.
+func TestOutcomeRefClearedOnSessionSwitch(t *testing.T) {
+	dir := t.TempDir()
+	rt := memorycompiler.New(dir)
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "done"},
+		testutil.Turn{Text: "sorry"},
+	)
+	a := New(mp, echoRegistry(), NewSession(""), Options{MemoryCompiler: rt}, event.Discard)
+
+	if err := a.Run(context.Background(), "fix a bug in the parser"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	requireBugfixCounters(t, dir, "after turn 1", 1, 0)
+
+	a.SetSession(NewSession("")) // resume/switch to another conversation
+	if err := a.Run(context.Background(), "不对，还是报错"); err != nil {
+		t.Fatalf("new-session turn: %v", err)
+	}
+	for _, s := range readCompilerStrategies(t, dir) {
+		if s.ID == "bugfix-reproduce-first" && s.Successes != 1 {
+			t.Fatalf("new session's first input revised the old session's outcome: %+v", s)
+		}
+	}
 }

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -491,7 +491,7 @@ func TestSlashArgCompletionMemoryV5(t *testing.T) {
 	if !m.completion.active || m.completion.kind != compSlashArg {
 		t.Fatalf("/memory-v5 should open arg completion: %+v", m.completion)
 	}
-	for _, want := range []string{"status", "off", "observe", "compact", "on"} {
+	for _, want := range []string{"status", "off", "observe", "compact", "on", "learnings"} {
 		if !hasLabel(m.completion.items, want) {
 			t.Fatalf("/memory-v5 completion missing %q: %v", want, labels(m.completion.items))
 		}

--- a/internal/cli/memory_v5.go
+++ b/internal/cli/memory_v5.go
@@ -5,12 +5,18 @@ import (
 	"strings"
 
 	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/memorycompiler"
 )
 
 func (m *chatTUI) runMemoryV5Command(input string) {
 	args := tokenizeArgs(input)
 	if len(args) > 2 {
-		m.notice("usage: /memory-v5 off|observe|compact|on|status")
+		m.notice("usage: /memory-v5 off|observe|compact|on|status|learnings")
+		return
+	}
+	if len(args) == 2 && strings.EqualFold(args[1], "learnings") {
+		m.notice(memoryV5LearningsText(m.ctrl))
 		return
 	}
 	if len(args) < 2 || strings.EqualFold(args[1], "status") {
@@ -19,7 +25,7 @@ func (m *chatTUI) runMemoryV5Command(input string) {
 			m.notice("memory-v5: " + err.Error())
 			return
 		}
-		m.notice(fmt.Sprintf("memory-v5: %s (usage: /memory-v5 off|observe|compact|on|status)", cliMemoryV5Mode(cfg.MemoryCompilerEnabled(), cfg.MemoryCompilerVerbosity())))
+		m.notice(fmt.Sprintf("memory-v5: %s (usage: /memory-v5 off|observe|compact|on|status|learnings)", cliMemoryV5Mode(cfg.MemoryCompilerEnabled(), cfg.MemoryCompilerVerbosity())))
 		return
 	}
 	if m.ctrl != nil && m.ctrl.Running() {
@@ -85,8 +91,26 @@ func parseCLIMemoryV5Setting(mode string) (cliMemoryV5Setting, error) {
 	case "on", "compact", "inject", "contract":
 		return cliMemoryV5Setting{enabled: true, verbosity: config.MemoryCompilerVerbosityCompact, setVerbosity: true}, nil
 	default:
-		return cliMemoryV5Setting{}, fmt.Errorf("memory-v5 %q: must be off|observe|compact|on|status", mode)
+		return cliMemoryV5Setting{}, fmt.Errorf("memory-v5 %q: must be off|observe|compact|on|status|learnings", mode)
 	}
+}
+
+// memoryV5LearningsText renders the project's learned Memory v5 state. It is a
+// read-only local view; nothing here reaches a provider.
+func memoryV5LearningsText(ctrl control.SessionAPI) string {
+	root := ""
+	if ctrl != nil {
+		root = ctrl.WorkspaceRoot()
+	}
+	rt := memorycompiler.New(config.MemoryCompilerDir(root))
+	if rt == nil {
+		return "memory-v5: no project state directory"
+	}
+	rep, ok := rt.LearningsReport(0)
+	if !ok {
+		return "memory-v5: no learned state yet"
+	}
+	return memorycompiler.FormatLearningsReport(rep)
 }
 
 func cliMemoryV5Mode(enabled bool, verbosity string) string {

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -10,6 +10,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/hook"
 	"reasonix/internal/i18n"
+	"reasonix/internal/memorycompiler"
 	"reasonix/internal/migration"
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/skill"
@@ -131,6 +132,7 @@ func memoryV5ArgItems(prior []string) []SlashItem {
 	}
 	return []SlashItem{
 		{Label: "status", Insert: "status", Hint: "show current Memory v5 state"},
+		{Label: "learnings", Insert: "learnings", Hint: "show learned strategies and patterns"},
 		{Label: "off", Insert: "off", Hint: "disable Memory v5 for future turns"},
 		{Label: "observe", Insert: "observe", Hint: "learn without injecting IR"},
 		{Label: "compact", Insert: "compact", Hint: "inject compact execution contracts"},
@@ -515,7 +517,11 @@ func (c *Controller) managementNotice(trimmed string) bool {
 
 func (c *Controller) memoryV5Notice(fields []string) {
 	if len(fields) > 2 {
-		c.notice("usage: /memory-v5 off|observe|compact|on|status")
+		c.notice("usage: /memory-v5 off|observe|compact|on|status|learnings")
+		return
+	}
+	if len(fields) == 2 && strings.EqualFold(fields[1], "learnings") {
+		c.notice(c.memoryV5LearningsText())
 		return
 	}
 	if len(fields) < 2 || strings.EqualFold(fields[1], "status") {
@@ -524,7 +530,7 @@ func (c *Controller) memoryV5Notice(fields []string) {
 			c.notice("memory-v5: " + err.Error())
 			return
 		}
-		c.notice(fmt.Sprintf("memory-v5: %s (usage: /memory-v5 off|observe|compact|on|status)", memoryV5Mode(cfg.MemoryCompilerEnabled(), cfg.MemoryCompilerVerbosity())))
+		c.notice(fmt.Sprintf("memory-v5: %s (usage: /memory-v5 off|observe|compact|on|status|learnings)", memoryV5Mode(cfg.MemoryCompilerEnabled(), cfg.MemoryCompilerVerbosity())))
 		return
 	}
 	if c.Running() {
@@ -586,8 +592,22 @@ func parseMemoryV5Setting(mode string) (memoryV5Setting, error) {
 	case "on", "compact", "inject", "contract":
 		return memoryV5Setting{enabled: true, verbosity: config.MemoryCompilerVerbosityCompact, setVerbosity: true}, nil
 	default:
-		return memoryV5Setting{}, fmt.Errorf("memory-v5 %q: must be off|observe|compact|on|status", mode)
+		return memoryV5Setting{}, fmt.Errorf("memory-v5 %q: must be off|observe|compact|on|status|learnings", mode)
 	}
+}
+
+// memoryV5LearningsText renders the project's learned Memory v5 state. It is a
+// read-only local view; nothing here reaches a provider.
+func (c *Controller) memoryV5LearningsText() string {
+	rt := memorycompiler.New(config.MemoryCompilerDir(c.workspaceRoot))
+	if rt == nil {
+		return "memory-v5: no project state directory"
+	}
+	rep, ok := rt.LearningsReport(0)
+	if !ok {
+		return "memory-v5: no learned state yet"
+	}
+	return memorycompiler.FormatLearningsReport(rep)
 }
 
 func memoryV5Mode(enabled bool, verbosity string) string {

--- a/internal/control/slash_test.go
+++ b/internal/control/slash_test.go
@@ -161,8 +161,8 @@ func TestSlashArgItems(t *testing.T) {
 	}
 	// /memory-v5
 	items, _ = SlashArgItems("/memory-v5 ", data)
-	if !has(items, "status") || !has(items, "off") || !has(items, "observe") || !has(items, "compact") || !has(items, "on") {
-		t.Errorf("/memory-v5 should offer status/off/observe/compact/on; got %v", labelsOf(items))
+	if !has(items, "status") || !has(items, "off") || !has(items, "observe") || !has(items, "compact") || !has(items, "on") || !has(items, "learnings") {
+		t.Errorf("/memory-v5 should offer status/off/observe/compact/on/learnings; got %v", labelsOf(items))
 	}
 	// /theme
 	items, _ = SlashArgItems("/theme ", data)
@@ -275,6 +275,27 @@ func TestManagementMemoryV5WritesUserConfig(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(notices, "\n"), "memory-v5 set to off") {
 		t.Fatalf("missing memory-v5 notice: %v", notices)
+	}
+}
+
+func TestManagementMemoryV5LearningsNotice(t *testing.T) {
+	isolateControlConfigHome(t)
+	var notices []string
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})})
+
+	if !c.managementNotice("/memory-v5 learnings") {
+		t.Fatal("/memory-v5 learnings was not handled")
+	}
+	joined := strings.Join(notices, "\n")
+	// A fresh controller has no learned state; either the no-state or the
+	// no-directory notice is acceptable, but it must not fall through to the
+	// usage error.
+	if !strings.Contains(joined, "memory-v5: no") {
+		t.Fatalf("missing learnings notice: %v", notices)
 	}
 }
 

--- a/internal/memorycompiler/feedback.go
+++ b/internal/memorycompiler/feedback.go
@@ -1,0 +1,166 @@
+package memorycompiler
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"reasonix/internal/fileutil"
+)
+
+// OutcomeRef identifies one finished turn's persisted outcome so the next user
+// message can retroactively revise it when the follow-up contradicts a recorded
+// success.
+type OutcomeRef struct {
+	TraceID    string
+	Strategy   string
+	Outcome    string
+	Injected   bool
+	FinishedAt time.Time
+}
+
+// OutcomeRef captures the finished turn's persisted identity. Valid only after
+// Finish; before that the outcome is empty and revision is a no-op.
+func (t *Turn) OutcomeRef() OutcomeRef {
+	if t == nil {
+		return OutcomeRef{}
+	}
+	strategy := strings.TrimSpace(t.strategy)
+	if strategy == "" {
+		strategy = classifyStrategy(t.trace.Goal)
+	}
+	return OutcomeRef{
+		TraceID:    t.trace.ID,
+		Strategy:   strategy,
+		Outcome:    t.trace.Outcome,
+		Injected:   t.trace.Injected,
+		FinishedAt: t.trace.CompletedAt,
+	}
+}
+
+// correctiveExclusions are compounds that contain a corrective phrase but do
+// not report a failed result ("不对外" exposes an API, it does not say the fix
+// was wrong). They are blanked before pattern matching.
+var correctiveExclusions = []string{"不对外", "不对称", "不对齐", "不对等"}
+
+var correctivePatterns = []string{
+	// zh
+	"不对", "不是这样", "还是错", "还是报错", "还是不行", "还是失败", "还是有问题",
+	"还是老样子", "没修好", "没有修好", "没修复", "没有修复", "没生效", "没有生效",
+	"并没有修", "修错", "改错了", "问题依旧", "问题还在", "又报错", "又出错",
+	// en
+	"still broken", "still fails", "still failing", "still errors", "still the same",
+	"not fixed", "didn't fix", "did not fix", "doesn't work", "does not work",
+	"didn't work", "did not work", "wrong fix", "that's wrong", "that is wrong",
+	"regressed", "made it worse",
+}
+
+// IsCorrectiveFeedback reports whether input reads as the user telling the
+// agent the previous result was wrong. Matching is confined to the head of the
+// message so a long new task that merely mentions an old failure deeper in its
+// body does not trigger retroactive revision.
+func IsCorrectiveFeedback(input string) bool {
+	head := strings.ToLower(strings.TrimSpace(input))
+	if head == "" {
+		return false
+	}
+	if runes := []rune(head); len(runes) > 160 {
+		head = string(runes[:160])
+	}
+	for _, ex := range correctiveExclusions {
+		head = strings.ReplaceAll(head, ex, " ")
+	}
+	for _, p := range correctivePatterns {
+		if strings.Contains(head, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReviseOutcomeFromFeedback downgrades a previously recorded outcome to failure
+// after the user's follow-up message reported the result wrong. The revision is
+// applied only when the referenced trace is still present in this runtime's
+// trace log, so a stale ref from another project directory cannot corrupt
+// strategy counters. Returns true when a revision was persisted.
+func (r *Runtime) ReviseOutcomeFromFeedback(ref OutcomeRef, feedback string) bool {
+	if r == nil || strings.TrimSpace(ref.TraceID) == "" {
+		return false
+	}
+	switch ref.Outcome {
+	case "success", "partial_success":
+	default:
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reason := "user feedback contradicted recorded outcome: " + summarizeText(firstLine(feedback), 120)
+	if !reviseTraceOutcomeInJSONL(filepath.Join(r.dir, tracesFile), ref.TraceID, "failure", reason) {
+		return false
+	}
+	st := r.loadStateLocked()
+	st.Strategies = ensureBuiltInStrategies(st.Strategies)
+	// partial_success already counted as a strategy failure, so only a
+	// recorded success moves the counters.
+	if ref.Outcome == "success" {
+		for i := range st.Strategies {
+			if st.Strategies[i].ID != ref.Strategy {
+				continue
+			}
+			if st.Strategies[i].Successes > 0 {
+				st.Strategies[i].Successes--
+			}
+			st.Strategies[i].Failures++
+			if ref.Injected {
+				if st.Strategies[i].InjectedSuccesses > 0 {
+					st.Strategies[i].InjectedSuccesses--
+				}
+				st.Strategies[i].InjectedFailures++
+			}
+			break
+		}
+	}
+	// ":revision" keeps this entry distinct from the turn's own learning
+	// (appendLearning dedupes by trace ID) and caps revisions at one per trace.
+	st.Learnings = appendLearning(st.Learnings, SystemLearning{
+		TraceID:              ref.TraceID + ":revision",
+		BadStrategies:        []string{ref.Strategy},
+		CausalFindings:       []string{"user follow-up contradicted trace " + ref.TraceID + " recorded as " + ref.Outcome},
+		CompilerImprovements: []string{"verify " + ref.Strategy + " results before reporting success; the user reported the previous result wrong"},
+		CreatedAt:            time.Now().UTC(),
+	})
+	st.UpdatedAt = time.Now().UTC()
+	return writeJSON(filepath.Join(r.dir, stateFile), st) == nil
+}
+
+func reviseTraceOutcomeInJSONL(path, traceID, outcome, reason string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	lines := bytes.Split(bytes.TrimRight(b, "\n"), []byte("\n"))
+	found := false
+	for i, ln := range lines {
+		var tr ExecutionTrace
+		if json.Unmarshal(ln, &tr) != nil || tr.ID != traceID {
+			continue
+		}
+		tr.Outcome = outcome
+		tr.FailureReason = reason
+		nb, err := json.Marshal(tr)
+		if err != nil {
+			return false
+		}
+		lines[i] = nb
+		found = true
+		break
+	}
+	if !found {
+		return false
+	}
+	out := append(bytes.Join(lines, []byte("\n")), '\n')
+	return fileutil.AtomicWriteFile(path, out, 0o600) == nil
+}

--- a/internal/memorycompiler/feedback_test.go
+++ b/internal/memorycompiler/feedback_test.go
@@ -1,0 +1,238 @@
+package memorycompiler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOutcomeForAbortedOnCancel(t *testing.T) {
+	if got := outcomeFor(nil, context.Canceled); got != "aborted" {
+		t.Fatalf("outcomeFor(canceled) = %q, want aborted", got)
+	}
+	wrapped := fmt.Errorf("run turn: %w", context.Canceled)
+	if got := outcomeFor(nil, wrapped); got != "aborted" {
+		t.Fatalf("outcomeFor(wrapped cancel) = %q, want aborted", got)
+	}
+	if got := outcomeFor(nil, fmt.Errorf("boom")); got != "failure" {
+		t.Fatalf("outcomeFor(real error) = %q, want failure", got)
+	}
+}
+
+func TestOutcomeForVerificationSignals(t *testing.T) {
+	pass := ToolRecord{Name: "bash", Args: `{"command":"go test ./internal/foo"}`}
+	fail := ToolRecord{Name: "bash", Args: `{"command":"go test ./internal/foo"}`, Error: "exit status 1"}
+	plainErr := ToolRecord{Name: "bash", Args: `{"command":"git push"}`, Error: "denied"}
+	plainOK := ToolRecord{Name: "read_file", Args: `{"path":"a.go"}`}
+
+	// A passing final verification confirms success even after earlier errors.
+	if got := outcomeFor([]ToolRecord{plainErr, pass}, nil); got != "success" {
+		t.Fatalf("passing verification after earlier error = %q, want success", got)
+	}
+	// A failing verification caps the turn at partial_success even when a
+	// later ordinary tool succeeded.
+	if got := outcomeFor([]ToolRecord{fail, plainOK}, nil); got != "partial_success" {
+		t.Fatalf("failing verification = %q, want partial_success", got)
+	}
+	// A passing verification followed by a later tool error falls back to the
+	// ordinary last-tool heuristic.
+	if got := outcomeFor([]ToolRecord{pass, plainErr}, nil); got != "partial_success" {
+		t.Fatalf("verification then error = %q, want partial_success", got)
+	}
+	// Non-verification commands keep the old behavior.
+	if got := outcomeFor([]ToolRecord{plainOK}, nil); got != "success" {
+		t.Fatalf("plain success = %q, want success", got)
+	}
+}
+
+func TestUpdateStrategyAbortedAndInjectedCounters(t *testing.T) {
+	st := updateStrategy(nil, "general", "aborted", false)
+	for _, s := range st {
+		if s.Samples() != 0 {
+			t.Fatalf("aborted outcome moved counters for %q: %+v", s.ID, s)
+		}
+	}
+	st = updateStrategy(st, "general", "success", true)
+	st = updateStrategy(st, "general", "failure", false)
+	for _, s := range st {
+		if s.ID != "general" {
+			continue
+		}
+		if s.Successes != 1 || s.Failures != 1 || s.InjectedSuccesses != 1 || s.InjectedFailures != 0 {
+			t.Fatalf("counters = %+v, want 1 success (injected), 1 failure (observed)", s)
+		}
+		return
+	}
+	t.Fatal("general strategy missing")
+}
+
+func TestAbortedTurnDoesNotMoveStrategyCounters(t *testing.T) {
+	dir := t.TempDir()
+	rt := New(dir)
+	_, turn := rt.StartTurn(context.Background(), "fix a bug", nil)
+	turn.Finish(context.Canceled)
+
+	st := readState(t, dir)
+	for _, s := range st.Strategies {
+		if s.Samples() != 0 {
+			t.Fatalf("aborted turn moved counters for %q: %+v", s.ID, s)
+		}
+	}
+}
+
+func TestIsCorrectiveFeedback(t *testing.T) {
+	positives := []string{
+		"不对，还是报错",
+		"没修好，重新看",
+		"still broken after your fix",
+		"这个改动没有生效",
+		"didn't fix the issue",
+	}
+	for _, in := range positives {
+		if !IsCorrectiveFeedback(in) {
+			t.Fatalf("IsCorrectiveFeedback(%q) = false, want true", in)
+		}
+	}
+	negatives := []string{
+		"",
+		"这个 API 不对外开放，请实现内部版本",
+		"两个面板不对称，请调整布局", // exclusion compound, not corrective
+		"修复登录页的 bug",
+		"thanks, looks good",
+		strings.Repeat("背景说明。", 40) + "上次不对的地方已经确认了", // corrective phrase beyond the head window
+	}
+	for _, in := range negatives {
+		if IsCorrectiveFeedback(in) {
+			t.Fatalf("IsCorrectiveFeedback(%q) = true, want false", in)
+		}
+	}
+}
+
+func TestReviseOutcomeFromFeedback(t *testing.T) {
+	dir := t.TempDir()
+	rt := New(dir)
+	_, turn := rt.StartTurn(context.Background(), "fix a bug", nil)
+	turn.Finish(nil) // no tools, no error → success
+	ref := turn.OutcomeRef()
+	if ref.Outcome != "success" || ref.Strategy != "bugfix-reproduce-first" {
+		t.Fatalf("unexpected ref: %+v", ref)
+	}
+
+	if !rt.ReviseOutcomeFromFeedback(ref, "不对，还是报错") {
+		t.Fatal("revision was not applied")
+	}
+
+	st := readState(t, dir)
+	for _, s := range st.Strategies {
+		if s.ID != ref.Strategy {
+			continue
+		}
+		if s.Successes != 0 || s.Failures != 1 {
+			t.Fatalf("counters not flipped: %+v", s)
+		}
+	}
+	found := false
+	for _, l := range st.Learnings {
+		if l.TraceID == ref.TraceID+":revision" && len(l.BadStrategies) > 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("revision learning missing")
+	}
+
+	b, err := os.ReadFile(filepath.Join(dir, tracesFile))
+	if err != nil {
+		t.Fatalf("read traces: %v", err)
+	}
+	revised := false
+	for _, ln := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var tr ExecutionTrace
+		if json.Unmarshal([]byte(ln), &tr) != nil || tr.ID != ref.TraceID {
+			continue
+		}
+		revised = tr.Outcome == "failure" && strings.Contains(tr.FailureReason, "user feedback contradicted")
+	}
+	if !revised {
+		t.Fatalf("trace outcome not rewritten:\n%s", b)
+	}
+
+	// A ref whose trace is not in this runtime's log must be a no-op.
+	stale := ref
+	stale.TraceID = "trace-not-there"
+	if rt.ReviseOutcomeFromFeedback(stale, "还是不行") {
+		t.Fatal("stale ref should not revise anything")
+	}
+}
+
+func TestInjectedPersistedInTraceAndStrategy(t *testing.T) {
+	dir := t.TempDir()
+	rt := New(dir)
+	// Seed learned state so the next turn compiles a useful contract.
+	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)
+	seed.RecordToolResults([]ToolRecord{
+		{Name: "bash", Error: "exit status 1"},
+		{Name: "bash", Error: "exit status 1"},
+	})
+	seed.Finish(nil)
+
+	compiled, turn := rt.StartTurn(context.Background(), "fix the bug again", nil)
+	if compiled == "" {
+		t.Fatal("expected a compiled contract from learned state")
+	}
+	turn.Finish(nil) // injection not suppressed → Injected persists
+
+	b, err := os.ReadFile(filepath.Join(dir, tracesFile))
+	if err != nil {
+		t.Fatalf("read traces: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	var last ExecutionTrace
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("unmarshal last trace: %v", err)
+	}
+	if !last.Injected {
+		t.Fatalf("last trace not marked injected: %+v", last)
+	}
+
+	st := readState(t, dir)
+	for _, s := range st.Strategies {
+		if s.ID != "bugfix-reproduce-first" {
+			continue
+		}
+		if s.InjectedSuccesses != 1 {
+			t.Fatalf("injected successes = %d, want 1 (%+v)", s.InjectedSuccesses, s)
+		}
+		return
+	}
+	t.Fatal("bugfix strategy missing")
+}
+
+func TestSuppressedInjectionNotPersistedAsInjected(t *testing.T) {
+	dir := t.TempDir()
+	rt := New(dir)
+	_, seed := rt.StartTurn(context.Background(), "fix a bug", nil)
+	seed.RecordToolResults([]ToolRecord{
+		{Name: "bash", Error: "exit status 1"},
+		{Name: "bash", Error: "exit status 1"},
+	})
+	seed.Finish(nil)
+
+	compiled, turn := rt.StartTurn(context.Background(), "fix the bug again", nil)
+	if compiled == "" {
+		t.Fatal("expected a compiled contract from learned state")
+	}
+	turn.SuppressInjection() // observe mode
+	turn.Finish(nil)
+
+	st := readState(t, dir)
+	for _, s := range st.Strategies {
+		if s.InjectedSuccesses != 0 && s.ID == "bugfix-reproduce-first" {
+			t.Fatalf("observe-mode turn counted as injected: %+v", s)
+		}
+	}
+}

--- a/internal/memorycompiler/report.go
+++ b/internal/memorycompiler/report.go
@@ -1,0 +1,134 @@
+package memorycompiler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// StrategyReport summarizes one strategy's learned outcome counters, split by
+// whether the compiled contract was provider-visible that turn.
+type StrategyReport struct {
+	ID                string
+	Description       string
+	Successes         int
+	Failures          int
+	InjectedSuccesses int
+	InjectedFailures  int
+	LastUsedAt        time.Time
+}
+
+func (s StrategyReport) samples() int         { return s.Successes + s.Failures }
+func (s StrategyReport) injectedSamples() int { return s.InjectedSuccesses + s.InjectedFailures }
+
+// LearningsReport is a read-only, human-readable snapshot of what Memory v5
+// has learned for one project. It exposes local state only; nothing here is
+// sent to a provider.
+type LearningsReport struct {
+	UpdatedAt       time.Time
+	Strategies      []StrategyReport
+	NoisePatterns   []string
+	Improvements    []string
+	Findings        []string
+	Nodes           int
+	HighSignalNodes int
+}
+
+// LearningsReport loads the project's learned state. ok is false when nothing
+// has been learned yet. maxItems bounds each list; <=0 uses a default.
+func (r *Runtime) LearningsReport(maxItems int) (LearningsReport, bool) {
+	if r == nil {
+		return LearningsReport{}, false
+	}
+	if maxItems <= 0 {
+		maxItems = 8
+	}
+	st := r.loadState()
+	rep := LearningsReport{UpdatedAt: st.UpdatedAt, Nodes: len(st.Nodes)}
+	for _, node := range st.Nodes {
+		if node.Quality == QualityHighSignal {
+			rep.HighSignalNodes++
+		}
+	}
+	for _, s := range st.Strategies {
+		if s.Samples() == 0 {
+			continue
+		}
+		rep.Strategies = append(rep.Strategies, StrategyReport{
+			ID:                s.ID,
+			Description:       s.Description,
+			Successes:         s.Successes,
+			Failures:          s.Failures,
+			InjectedSuccesses: s.InjectedSuccesses,
+			InjectedFailures:  s.InjectedFailures,
+			LastUsedAt:        s.LastUsedAt,
+		})
+	}
+	sort.Slice(rep.Strategies, func(i, j int) bool {
+		if rep.Strategies[i].samples() == rep.Strategies[j].samples() {
+			return rep.Strategies[i].ID < rep.Strategies[j].ID
+		}
+		return rep.Strategies[i].samples() > rep.Strategies[j].samples()
+	})
+	for _, ref := range sortedNoisyRefs(st.NoisyRefs) {
+		rep.NoisePatterns = append(rep.NoisePatterns, fmt.Sprintf("%s (x%d)", ref.ref, ref.count))
+	}
+	rep.NoisePatterns = limitStrings(rep.NoisePatterns, maxItems)
+	for _, l := range recentLearnings(st.Learnings, maxItems) {
+		rep.Improvements = append(rep.Improvements, l.CompilerImprovements...)
+		rep.Findings = append(rep.Findings, l.CausalFindings...)
+	}
+	rep.Improvements = limitStrings(dedupeStrings(rep.Improvements), maxItems)
+	rep.Findings = limitStrings(dedupeStrings(rep.Findings), maxItems)
+	ok := len(rep.Strategies)+len(rep.NoisePatterns)+len(rep.Improvements)+len(rep.Findings) > 0
+	return rep, ok
+}
+
+// FormatLearningsReport renders the report as plain notice text for the CLI and
+// desktop slash-command surfaces.
+func FormatLearningsReport(rep LearningsReport) string {
+	var b strings.Builder
+	b.WriteString("memory-v5 learnings")
+	if !rep.UpdatedAt.IsZero() {
+		fmt.Fprintf(&b, " (updated %s)", rep.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	}
+	if rep.Nodes > 0 {
+		fmt.Fprintf(&b, "\nmemory nodes: %d (%d high-signal)", rep.Nodes, rep.HighSignalNodes)
+	}
+	if len(rep.Strategies) > 0 {
+		b.WriteString("\nstrategies:")
+		for _, s := range rep.Strategies {
+			fmt.Fprintf(&b, "\n  %s: %s", s.ID, formatOutcomeSplit(s.Successes, s.Failures))
+			if s.injectedSamples() > 0 {
+				observedOK := s.Successes - s.InjectedSuccesses
+				observedFail := s.Failures - s.InjectedFailures
+				fmt.Fprintf(&b, " | injected %s vs observed %s",
+					formatOutcomeSplit(s.InjectedSuccesses, s.InjectedFailures),
+					formatOutcomeSplit(observedOK, observedFail))
+			}
+		}
+	}
+	writeReportList(&b, "repeated noise patterns", rep.NoisePatterns)
+	writeReportList(&b, "recent improvements", rep.Improvements)
+	writeReportList(&b, "recent findings", rep.Findings)
+	return b.String()
+}
+
+func formatOutcomeSplit(ok, fail int) string {
+	total := ok + fail
+	if total == 0 {
+		return "0 samples"
+	}
+	return fmt.Sprintf("%d ok / %d fail (%d%%)", ok, fail, int(float64(ok)/float64(total)*100+0.5))
+}
+
+func writeReportList(b *strings.Builder, title string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	b.WriteString("\n" + title + ":")
+	for _, item := range items {
+		b.WriteString("\n  - " + summarizeText(item, 160))
+	}
+}

--- a/internal/memorycompiler/report_test.go
+++ b/internal/memorycompiler/report_test.go
@@ -1,0 +1,48 @@
+package memorycompiler
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLearningsReportEmpty(t *testing.T) {
+	var nilRT *Runtime
+	if _, ok := nilRT.LearningsReport(0); ok {
+		t.Fatal("nil runtime reported learned state")
+	}
+	if _, ok := New(t.TempDir()).LearningsReport(0); ok {
+		t.Fatal("fresh dir reported learned state")
+	}
+}
+
+func TestLearningsReportAndFormat(t *testing.T) {
+	dir := t.TempDir()
+	rt := New(dir)
+	_, fail := rt.StartTurn(context.Background(), "fix a bug", nil)
+	fail.RecordToolResults([]ToolRecord{
+		{Name: "bash", Error: "exit status 1"},
+		{Name: "bash", Error: "exit status 1"},
+	})
+	fail.Finish(nil)
+	_, ok := rt.StartTurn(context.Background(), "fix another bug", nil)
+	ok.Finish(nil)
+
+	rep, hasState := rt.LearningsReport(0)
+	if !hasState {
+		t.Fatal("expected learned state")
+	}
+	if len(rep.Strategies) == 0 {
+		t.Fatalf("no strategies in report: %+v", rep)
+	}
+	if rep.Strategies[0].ID != "bugfix-reproduce-first" {
+		t.Fatalf("expected bugfix strategy first, got %q", rep.Strategies[0].ID)
+	}
+
+	text := FormatLearningsReport(rep)
+	for _, want := range []string{"memory-v5 learnings", "strategies:", "bugfix-reproduce-first", "ok / "} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted report missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/internal/memorycompiler/runtime.go
+++ b/internal/memorycompiler/runtime.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -147,6 +148,7 @@ type ExecutionTrace struct {
 	Goal                string               `json:"goal"`
 	Steps               []Step               `json:"steps,omitempty"`
 	Outcome             string               `json:"outcome"`
+	Injected            bool                 `json:"injected,omitempty"`
 	EfficiencyScore     float64              `json:"efficiency_score"`
 	MemoryEffectiveness float64              `json:"memory_effectiveness"`
 	StrategyUsed        []string             `json:"strategy_used,omitempty"`
@@ -264,6 +266,7 @@ type LearningTrace struct {
 	ID                   string               `json:"id"`
 	IRVersion            string               `json:"ir_version"`
 	Outcome              string               `json:"outcome"`
+	Injected             bool                 `json:"injected,omitempty"`
 	QualityScore         float64              `json:"quality_score"`
 	StrategyUsed         []string             `json:"strategy_used,omitempty"`
 	MemoryUsed           []string             `json:"memory_used,omitempty"`
@@ -348,13 +351,18 @@ type SystemLearning struct {
 }
 
 type Strategy struct {
-	ID            string    `json:"id"`
-	Preconditions []string  `json:"preconditions,omitempty"`
-	ExecutionPlan []Step    `json:"execution_plan,omitempty"`
-	Successes     int       `json:"successes"`
-	Failures      int       `json:"failures"`
-	LastUsedAt    time.Time `json:"last_used_at,omitempty"`
-	Description   string    `json:"description,omitempty"`
+	ID            string   `json:"id"`
+	Preconditions []string `json:"preconditions,omitempty"`
+	ExecutionPlan []Step   `json:"execution_plan,omitempty"`
+	Successes     int      `json:"successes"`
+	Failures      int      `json:"failures"`
+	// InjectedSuccesses/InjectedFailures split the counters above by whether
+	// the compiled contract was provider-visible that turn, so injected and
+	// observe-only outcomes can be compared for real lift.
+	InjectedSuccesses int       `json:"injected_successes,omitempty"`
+	InjectedFailures  int       `json:"injected_failures,omitempty"`
+	LastUsedAt        time.Time `json:"last_used_at,omitempty"`
+	Description       string    `json:"description,omitempty"`
 }
 
 func (s Strategy) Samples() int { return s.Successes + s.Failures }
@@ -1741,6 +1749,7 @@ func (t *Turn) Finish(err error) {
 		return
 	}
 	t.trace.CompletedAt = time.Now().UTC()
+	t.trace.Injected = t.metrics.Injected
 	t.trace.Outcome = outcomeFor(t.trace.ToolResults, err)
 	if err != nil {
 		t.trace.FailureReason = firstLine(err.Error())
@@ -1775,7 +1784,24 @@ func (t *Turn) Finish(err error) {
 
 func outcomeFor(records []ToolRecord, err error) string {
 	if err != nil {
+		// A user-cancelled turn says nothing about the strategy's quality;
+		// keep it out of the success/failure counters entirely.
+		if errors.Is(err, context.Canceled) {
+			return "aborted"
+		}
 		return "failure"
+	}
+	// Verification-shaped commands (tests, vet, typecheck, lint) are a stronger
+	// signal than ordinary tool errors: a final failing test run caps the turn
+	// at partial_success, and a passing one confirms success unless a later
+	// tool errored after it.
+	if rec, idx, ok := lastVerificationToolRecord(records); ok {
+		if strings.TrimSpace(rec.Error) != "" {
+			return "partial_success"
+		}
+		if !anyToolErrorAfter(records, idx) {
+			return "success"
+		}
 	}
 	if len(records) == 0 {
 		// A turn that finishes without error and without tool calls is a
@@ -1804,6 +1830,54 @@ func isPlanModeBlockedToolRecord(rec ToolRecord) bool {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(rec.Error), planModeBlockedToolError)
+}
+
+// verificationCommandMarkers identify shell commands whose exit status verifies
+// the turn's work (tests, vet, typecheck, lint, build). Matched as lowercase
+// substrings of the bash tool's raw argument JSON.
+var verificationCommandMarkers = []string{
+	"go test", "go vet", "go build", "gofmt -l", "golangci-lint",
+	"npm test", "npm run test", "pnpm test", "pnpm run test", "yarn test",
+	"vitest", "jest", "npx tsc", "tsc ", "typecheck", "type-check", "check:css",
+	"eslint", "pytest", "ruff check", "cargo test", "cargo check", "cargo build",
+	"mvn test", "gradle test", "make test", "ctest", "phpunit", "rspec",
+}
+
+func isVerificationToolRecord(rec ToolRecord) bool {
+	if rec.Blocked || !strings.EqualFold(strings.TrimSpace(rec.Name), "bash") {
+		return false
+	}
+	args := strings.ToLower(rec.Args)
+	if args == "" {
+		return false
+	}
+	for _, marker := range verificationCommandMarkers {
+		if strings.Contains(args, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func lastVerificationToolRecord(records []ToolRecord) (ToolRecord, int, bool) {
+	for i := len(records) - 1; i >= 0; i-- {
+		if isVerificationToolRecord(records[i]) {
+			return records[i], i, true
+		}
+	}
+	return ToolRecord{}, -1, false
+}
+
+func anyToolErrorAfter(records []ToolRecord, idx int) bool {
+	for i := idx + 1; i < len(records); i++ {
+		if strings.TrimSpace(records[i].Name) == "" || isPlanModeBlockedToolRecord(records[i]) {
+			continue
+		}
+		if strings.TrimSpace(records[i].Error) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func efficiencyScore(records []ToolRecord, start, end time.Time) float64 {
@@ -1861,11 +1935,17 @@ func (r *Runtime) writeTraceAndLearn(tr ExecutionTrace, strategyID string) {
 		strategyID = classifyStrategy(tr.Goal)
 	}
 	var evaluations []MutationEvaluation
-	st.Mutations, evaluations = evaluateMutations(st.Mutations, tr)
+	// Aborted turns carry no quality signal: they must not grade mutations
+	// under evaluation or move strategy success/failure counters.
+	if tr.Outcome != "aborted" {
+		st.Mutations, evaluations = evaluateMutations(st.Mutations, tr)
+	}
 	tr.MutationEvaluations = evaluations
 	now := time.Now().UTC()
 	baseline := baselineScore(st, strategyID)
-	st.Strategies = updateStrategy(st.Strategies, strategyID, tr.Outcome)
+	if tr.Outcome != "aborted" {
+		st.Strategies = updateStrategy(st.Strategies, strategyID, tr.Outcome, tr.Injected)
+	}
 	learning := analyzeTrace(tr, strategyID)
 	if hasLearning(learning) {
 		st.Learnings = appendLearning(st.Learnings, learning)
@@ -1917,6 +1997,7 @@ func executionTraceProjection(tr ExecutionTrace) ExecutionTrace {
 		Goal:                tr.Goal,
 		Steps:               append([]Step(nil), tr.Steps...),
 		Outcome:             tr.Outcome,
+		Injected:            tr.Injected,
 		EfficiencyScore:     tr.EfficiencyScore,
 		MemoryEffectiveness: tr.MemoryEffectiveness,
 		StrategyUsed:        append([]string(nil), tr.StrategyUsed...),
@@ -1943,6 +2024,7 @@ func learningTraceFor(tr ExecutionTrace, learning SystemLearning) (LearningTrace
 		ID:                   tr.ID,
 		IRVersion:            tr.IRVersion,
 		Outcome:              tr.Outcome,
+		Injected:             tr.Injected,
 		QualityScore:         traceQualityScore(tr),
 		StrategyUsed:         append([]string(nil), tr.StrategyUsed...),
 		MemoryUsed:           append([]string(nil), tr.MemoryUsed...),
@@ -2687,7 +2769,10 @@ func validMutation(m CompilerMutation) bool {
 	}
 }
 
-func updateStrategy(strategies []Strategy, id, outcome string) []Strategy {
+func updateStrategy(strategies []Strategy, id, outcome string, injected bool) []Strategy {
+	if outcome == "aborted" {
+		return strategies
+	}
 	id = strings.TrimSpace(id)
 	if id == "" {
 		id = "general"
@@ -2699,8 +2784,14 @@ func updateStrategy(strategies []Strategy, id, outcome string) []Strategy {
 		}
 		if outcome == "success" {
 			strategies[i].Successes++
+			if injected {
+				strategies[i].InjectedSuccesses++
+			}
 		} else {
 			strategies[i].Failures++
+			if injected {
+				strategies[i].InjectedFailures++
+			}
 		}
 		strategies[i].LastUsedAt = time.Now().UTC()
 		return strategies
@@ -2708,8 +2799,14 @@ func updateStrategy(strategies []Strategy, id, outcome string) []Strategy {
 	s := Strategy{ID: id, LastUsedAt: time.Now().UTC()}
 	if outcome == "success" {
 		s.Successes = 1
+		if injected {
+			s.InjectedSuccesses = 1
+		}
 	} else {
 		s.Failures = 1
+		if injected {
+			s.InjectedFailures = 1
+		}
 	}
 	return append(strategies, s)
 }


### PR DESCRIPTION
## Summary

Three local-only upgrades to the Memory v5 execution compiler, aimed at making its learning signal trustworthy and its learned state measurable and visible.

### 1. Cleaner outcome signal

- User-cancelled turns now record as `aborted`: still traced for observability, but excluded from strategy success/failure counters and mutation evaluation. Previously every cancellation counted as a strategy failure and polluted success rates.
- Verification-shaped bash commands (`go test`, `go vet`, `pnpm test`, `pytest`, `tsc`, ...) are a stronger outcome signal than the last-tool heuristic: a failing final verification caps the turn at `partial_success`; a passing one confirms `success` unless a later tool errored after it.
- When the user's immediate follow-up reports the result wrong ("不对，还是报错", "still broken", ...), the previous turn's recorded success is retroactively downgraded: strategy counters flip, the trace line in `traces.jsonl` is rewritten with the revision reason, and a revision learning is appended. The check is one-shot per turn, matched only against the head of the message (with compound-word exclusions such as 不对外/不对称), and it is a no-op when the referenced trace is not present in this runtime's trace log, so a stale ref can never corrupt another project's state.

### 2. Injected vs observed split (A/B measurability)

- `ExecutionTrace`/`LearningTrace` now persist whether the compiled contract was actually injected that turn (`injected`).
- `Strategy` counters gain `injected_successes`/`injected_failures` alongside the totals, so compact-mode lift over observe mode becomes measurable from local state instead of assumed. Suppressed (observe-mode) turns are never counted as injected.

### 3. `/memory-v5 learnings`

- New subcommand on both the CLI TUI and the shared control slash surface (desktop chat included): strategy success rates with the injected/observed split, repeated noise patterns, and recent improvements/findings. Read-only local view; nothing here reaches a provider. Completion items and usage strings updated on both surfaces.

## Verification

- `go test ./...` (root module) passes; `cd desktop && go test ./...` passes.
- `gofmt` and `go vet` clean on the touched packages.
- `./scripts/cache-guard.sh` passes (tail_avg 92–95 vs threshold 90).
- New focused regression tests:
  - aborted outcomes excluded from counters (unit + end-to-end through `Finish(context.Canceled)`);
  - verification-signal precedence over the last-tool heuristic;
  - corrective-feedback revision (runtime unit test plus agent e2e for both a corrective and a neutral follow-up, and a stale-ref no-op);
  - injected persistence and counter split, including the suppressed-injection case;
  - learnings report/format, slash completion, and notice coverage on both surfaces.

## Notes

- No provider-visible behavior change: the observe default, the compact contract format, tool schemas, and the system prompt are untouched. The `internal/agent/agent.go` change only adds a local pre-turn revision hook and outcome bookkeeping around the existing Memory v5 block.
- Deliberately not included: auto-falling back from compact to observe when measured lift is absent. That would change injection timing (provider-visible policy) and should be its own change once real A/B data exists.

Cache-impact: none - no provider-visible change; observe default, contract format, tool schemas, and system prompt untouched; only local learning state and read-only CLI/slash output changed.
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) passes; agent e2e tests additionally assert observe mode still preserves the raw user turn.
