### PR TITLE
Surface stable Memory v5 learnings as memory candidates in settings / 将 Memory v5 稳定学习成果提炼为设置页记忆候选

### DIFF
--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -513,8 +513,17 @@ func suggestionName(given, source, fallback string) string {
 // 56 chars, so two CJK-only statements (or long English statements sharing a
 // prefix) can collide — colliding Names make Store.Save overwrite the earlier
 // memory, and colliding IDs cross-wire the frontend's accepted-state map.
-// Appending a content-based hash keeps slugs unique and deterministic.
+//
+// When the ASCII slug is short enough that truncation cannot have caused a
+// collision, it is returned as-is for backward compatibility with old-version
+// candidate names. The hash suffix is only appended when the slug fell back to
+// the fallback (non-ASCII source) or when the slug hit the 56-char truncation
+// boundary.
 func stableSuggestionName(source, fallback string) string {
+	slug := asciiSlug(source)
+	if slug != "" && len(slug) < 56 {
+		return slug
+	}
 	base := suggestionName("", source, fallback)
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(source))

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -141,7 +141,7 @@ func (a *App) AcceptMemorySuggestionForTab(tabID string, in MemorySuggestion) (s
 	if desc == "" || body == "" {
 		return "", fmt.Errorf("memory suggestion requires description and body")
 	}
-	name := suggestionName(in.Name, desc, "memory-candidate")
+	name := acceptedSuggestionName(in.Name, desc)
 	return ctrl.SaveMemory(memory.Memory{
 		Name:        name,
 		Title:       oneLine(in.Title),
@@ -506,6 +506,44 @@ func suggestionName(given, source, fallback string) string {
 		return name
 	}
 	return "candidate"
+}
+
+// acceptedSuggestionName preserves the candidate name generated at suggestion
+// time. Re-running asciiSlug here would truncate back to 56 chars and strip
+// the uniqueness hash suffix, re-colliding long common-prefix candidates at
+// save time even though their generated Name/ID differed. A well-formed slug
+// is kept verbatim (memory.Store.Save's own slug pass cleans but never
+// truncates); anything else falls back to deriving from the description as
+// before.
+func acceptedSuggestionName(given, desc string) string {
+	if isWellFormedSlug(given) {
+		return given
+	}
+	return suggestionName("", desc, "memory-candidate")
+}
+
+// isWellFormedSlug reports whether s already matches asciiSlug's output shape
+// (lowercase ASCII letters/digits separated by single dashes), possibly with a
+// hash suffix beyond asciiSlug's 56-char cap.
+func isWellFormedSlug(s string) bool {
+	if s == "" || len(s) > 128 || s[0] == '-' || s[len(s)-1] == '-' {
+		return false
+	}
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			prevDash = false
+		case r == '-':
+			if prevDash {
+				return false
+			}
+			prevDash = true
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // stableSuggestionName returns a slug that is unique per source text and stable

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
 	"strings"
 	"time"
@@ -232,7 +233,7 @@ func suggestMemories(set *memory.Set, sessions []suggestionSession) []MemorySugg
 				continue
 			}
 			seen[key] = true
-			name := suggestionName("", statement, fmt.Sprintf("memory-candidate-%d", len(out)+1))
+			name := stableSuggestionName(statement, "memory-candidate")
 			title := suggestionTitle(statement, "Memory candidate")
 			typ := inferMemoryType(statement)
 			out = append(out, MemorySuggestion{
@@ -505,6 +506,19 @@ func suggestionName(given, source, fallback string) string {
 		return name
 	}
 	return "candidate"
+}
+
+// stableSuggestionName returns a slug that is unique per source text and stable
+// across suggestion refreshes. asciiSlug drops non-ASCII runes and truncates to
+// 56 chars, so two CJK-only statements (or long English statements sharing a
+// prefix) can collide — colliding Names make Store.Save overwrite the earlier
+// memory, and colliding IDs cross-wire the frontend's accepted-state map.
+// Appending a content-based hash keeps slugs unique and deterministic.
+func stableSuggestionName(source, fallback string) string {
+	base := suggestionName("", source, fallback)
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(source))
+	return fmt.Sprintf("%s-%08x", base, h.Sum32())
 }
 
 func asciiSlug(s string) string {

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -116,6 +116,9 @@ func (a *App) MemorySuggestionsForTab(tabID string) MemorySuggestionsView {
 
 	sessions := loadSuggestionSessions(sessionDir, suggestionSessionLimit)
 	view.Memories = suggestMemories(set, sessions)
+	// Stable Memory v5 execution learnings join the same candidate list and
+	// the same explicit-confirmation flow as history-derived suggestions.
+	view.Memories = append(view.Memories, suggestCompilerMemories(workspaceRoot, set, view.Memories)...)
 	view.Skills = suggestSkills(workspaceRoot, ctrl.AllSkills(), sessions)
 	return view
 }

--- a/desktop/memory_suggestions_compiler.go
+++ b/desktop/memory_suggestions_compiler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"hash/fnv"
 
 	"reasonix/internal/config"
 	"reasonix/internal/memory"
@@ -38,7 +39,7 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 			continue
 		}
 		seen[key] = true
-		name := stableSuggestionName("memory-v5 "+p.Pattern, "memory-v5-pattern")
+		name := compilerCandidateName(p.Pattern)
 		out = append(out, MemorySuggestion{
 			ID:          "memory-" + name,
 			Name:        name,
@@ -54,6 +55,16 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 		}
 	}
 	return out
+}
+
+// compilerCandidateName always appends a hash: compiler patterns are
+// inherently homogeneous (same tool + similar error prefix) so the ASCII
+// slug alone cannot distinguish them even when it is non-empty.
+func compilerCandidateName(pattern string) string {
+	base := suggestionName("", "memory-v5 "+pattern, "memory-v5-pattern")
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(pattern))
+	return fmt.Sprintf("%s-%08x", base, h.Sum32())
 }
 
 func compilerPatternStatement(pattern string) string {

--- a/desktop/memory_suggestions_compiler.go
+++ b/desktop/memory_suggestions_compiler.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"hash/fnv"
 
 	"reasonix/internal/config"
 	"reasonix/internal/memory"
@@ -39,7 +38,7 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 			continue
 		}
 		seen[key] = true
-		name := compilerCandidateName(p.Pattern)
+		name := stableSuggestionName("memory-v5 "+p.Pattern, "memory-v5-pattern")
 		out = append(out, MemorySuggestion{
 			ID:          "memory-" + name,
 			Name:        name,
@@ -55,19 +54,6 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 		}
 	}
 	return out
-}
-
-// compilerCandidateName derives a stable, unique slug for one Memory v5
-// pattern. asciiSlug drops non-ASCII runes and truncates, so patterns that
-// differ only in CJK error text (or share a long English prefix) would
-// otherwise collide on Name/ID — the frontend keys cards and accepted state
-// by ID, and Store.Save overwrites by Name. A short hash of the full pattern
-// keeps the slug unique and stable across refreshes.
-func compilerCandidateName(pattern string) string {
-	base := suggestionName("", "memory-v5 "+pattern, "memory-v5-pattern")
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(pattern))
-	return fmt.Sprintf("%s-%08x", base, h.Sum32())
 }
 
 func compilerPatternStatement(pattern string) string {

--- a/desktop/memory_suggestions_compiler.go
+++ b/desktop/memory_suggestions_compiler.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+
+	"reasonix/internal/config"
+	"reasonix/internal/memory"
+	"reasonix/internal/memorycompiler"
+)
+
+const (
+	// compilerSuggestionLimit bounds Memory v5 candidates separately from the
+	// history-derived ones so a busy history cannot crowd them out.
+	compilerSuggestionLimit = 3
+	// compilerSuggestionMinCount requires a pattern to recur across at least
+	// this many separate turns before it is stable enough to suggest.
+	compilerSuggestionMinCount = 2
+)
+
+// suggestCompilerMemories converts stable Memory v5 execution learnings into
+// memory candidates for the settings Memory page. Read-only: candidates are
+// only persisted through the regular AcceptMemorySuggestion confirmation flow.
+func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []MemorySuggestion) []MemorySuggestion {
+	rt := memorycompiler.New(config.MemoryCompilerDir(workspaceRoot))
+	if rt == nil || set == nil {
+		return nil
+	}
+	existing := existingMemoryText(set)
+	seen := map[string]bool{}
+	for _, s := range already {
+		seen[normalizeSuggestionKey(s.Description)] = true
+	}
+	var out []MemorySuggestion
+	for _, p := range rt.StableNoisePatterns(compilerSuggestionMinCount, compilerSuggestionLimit*2) {
+		statement := compilerPatternStatement(p.Pattern)
+		key := normalizeSuggestionKey(statement)
+		if key == "" || seen[key] || existingCovers(existing, key) {
+			continue
+		}
+		seen[key] = true
+		name := suggestionName("", "memory-v5 "+p.Pattern, fmt.Sprintf("memory-v5-pattern-%d", len(out)+1))
+		out = append(out, MemorySuggestion{
+			ID:          "memory-" + name,
+			Name:        name,
+			Title:       suggestionTitle(statement, "Memory v5 pattern"),
+			Description: oneLine(statement),
+			Type:        string(memory.TypeProject),
+			Body:        compilerCandidateBody(statement, p.Count),
+			Reason:      fmt.Sprintf("Memory v5 observed this failure pattern in %d separate turns", p.Count),
+			Evidence:    []string{fmt.Sprintf("memory-v5 execution traces: %s (x%d)", truncateRunes(p.Pattern, 160), p.Count)},
+		})
+		if len(out) >= compilerSuggestionLimit {
+			break
+		}
+	}
+	return out
+}
+
+func compilerPatternStatement(pattern string) string {
+	pattern = oneLine(pattern)
+	if pattern == "" {
+		return ""
+	}
+	return "Known repeated failure in this workspace: " + pattern + "."
+}
+
+func compilerCandidateBody(statement string, count int) string {
+	return statement + "\n\n" +
+		fmt.Sprintf("**Why:** Memory v5 recorded this failure pattern in %d separate execution traces for this workspace.\n", count) +
+		"**How to apply:** Address the known cause before retrying the same command; drop this memory once the failure stops reproducing.\n"
+}

--- a/desktop/memory_suggestions_compiler.go
+++ b/desktop/memory_suggestions_compiler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"hash/fnv"
 
 	"reasonix/internal/config"
 	"reasonix/internal/memory"
@@ -38,7 +39,7 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 			continue
 		}
 		seen[key] = true
-		name := suggestionName("", "memory-v5 "+p.Pattern, fmt.Sprintf("memory-v5-pattern-%d", len(out)+1))
+		name := compilerCandidateName(p.Pattern)
 		out = append(out, MemorySuggestion{
 			ID:          "memory-" + name,
 			Name:        name,
@@ -54,6 +55,19 @@ func suggestCompilerMemories(workspaceRoot string, set *memory.Set, already []Me
 		}
 	}
 	return out
+}
+
+// compilerCandidateName derives a stable, unique slug for one Memory v5
+// pattern. asciiSlug drops non-ASCII runes and truncates, so patterns that
+// differ only in CJK error text (or share a long English prefix) would
+// otherwise collide on Name/ID — the frontend keys cards and accepted state
+// by ID, and Store.Save overwrites by Name. A short hash of the full pattern
+// keeps the slug unique and stable across refreshes.
+func compilerCandidateName(pattern string) string {
+	base := suggestionName("", "memory-v5 "+pattern, "memory-v5-pattern")
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(pattern))
+	return fmt.Sprintf("%s-%08x", base, h.Sum32())
 }
 
 func compilerPatternStatement(pattern string) string {

--- a/desktop/memory_suggestions_compiler_test.go
+++ b/desktop/memory_suggestions_compiler_test.go
@@ -193,3 +193,48 @@ func compilerCandidateIDs(memories []MemorySuggestion) []string {
 	}
 	return out
 }
+
+// TestCompilerCandidateLongPrefixNamesPersistDistinctly reproduces the review
+// finding: two patterns sharing a >56-char ASCII prefix get distinct generated
+// Name/ID (hash suffix), but the accept path used to re-run asciiSlug, which
+// truncates to 56 chars and strips the hash — so both saved to one file.
+func TestCompilerCandidateLongPrefixNamesPersistDistinctly(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	prefix := "cannot find module providing package example dot com slash very long prefix "
+	seedCompilerFailures(t, cwd, 2, prefix+"alpha")
+	seedCompilerFailures(t, cwd, 2, prefix+"beta")
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	var candidates []MemorySuggestion
+	for _, item := range view.Memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			candidates = append(candidates, item)
+		}
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidates = %+v, want both long-prefix patterns", candidates)
+	}
+	for _, c := range candidates {
+		if _, err := app.AcceptMemorySuggestion(c); err != nil {
+			t.Fatalf("AcceptMemorySuggestion(%s): %v", c.Name, err)
+		}
+	}
+	saved := store.List()
+	if len(saved) != 2 {
+		t.Fatalf("saved memories = %d, want 2 distinct files (accept path truncated the hash suffix)", len(saved))
+	}
+	if saved[0].Name == saved[1].Name {
+		t.Fatalf("saved names collided: %q", saved[0].Name)
+	}
+}

--- a/desktop/memory_suggestions_compiler_test.go
+++ b/desktop/memory_suggestions_compiler_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/memory"
+	"reasonix/internal/memorycompiler"
+)
+
+func seedCompilerFailures(t *testing.T, workspaceRoot string, turns int, errText string) {
+	t.Helper()
+	rt := memorycompiler.New(config.MemoryCompilerDir(workspaceRoot))
+	if rt == nil {
+		t.Fatal("memory compiler dir did not resolve under isolated dirs")
+	}
+	for i := 0; i < turns; i++ {
+		_, turn := rt.StartTurn(context.Background(), "fix a bug", nil)
+		turn.RecordToolResults([]memorycompiler.ToolRecord{
+			{Name: "bash", Error: errText},
+			{Name: "bash", Error: errText},
+		})
+		turn.Finish(nil)
+	}
+}
+
+func TestMemorySuggestionsIncludeCompilerCandidates(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	seedCompilerFailures(t, cwd, 2, "cannot find module providing package foo")
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	var candidate MemorySuggestion
+	for _, item := range view.Memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			candidate = item
+			break
+		}
+	}
+	if candidate.ID == "" {
+		t.Fatalf("memories = %+v, want a memory-v5 candidate", view.Memories)
+	}
+	if candidate.Type != string(memory.TypeProject) {
+		t.Fatalf("candidate type = %q, want project", candidate.Type)
+	}
+	if !strings.Contains(candidate.Description, "cannot find module") {
+		t.Fatalf("candidate description missing pattern: %q", candidate.Description)
+	}
+	if !strings.Contains(candidate.Reason, "Memory v5") {
+		t.Fatalf("candidate reason missing provenance: %q", candidate.Reason)
+	}
+
+	path, err := app.AcceptMemorySuggestion(candidate)
+	if err != nil {
+		t.Fatalf("AcceptMemorySuggestion: %v", err)
+	}
+	if path == "" {
+		t.Fatal("AcceptMemorySuggestion returned empty path")
+	}
+	saved := store.List()
+	if len(saved) != 1 || !strings.Contains(saved[0].Body, "cannot find module") {
+		t.Fatalf("saved memories = %+v, want compiler candidate body", saved)
+	}
+
+	// Once accepted, the same pattern is covered by an existing memory and
+	// must not be suggested again.
+	again := app.MemorySuggestions()
+	for _, item := range again.Memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			t.Fatalf("accepted pattern suggested again: %+v", item)
+		}
+	}
+}
+
+func TestCompilerCandidatesRequireStablePattern(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	// A pattern seen in only one turn is not stable enough to suggest.
+	seedCompilerFailures(t, cwd, 1, "cannot find module providing package foo")
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	for _, item := range view.Memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			t.Fatalf("unstable pattern was suggested: %+v", item)
+		}
+	}
+}

--- a/desktop/memory_suggestions_compiler_test.go
+++ b/desktop/memory_suggestions_compiler_test.go
@@ -108,3 +108,88 @@ func TestCompilerCandidatesRequireStablePattern(t *testing.T) {
 		}
 	}
 }
+
+// TestCompilerCandidateNamesUniqueForSimilarPatterns covers the review
+// finding: asciiSlug drops non-ASCII runes and truncates to 56 chars, so
+// patterns differing only in CJK text (or sharing a long English prefix) used
+// to collide on Name/ID — colliding IDs cross-wire the frontend's accepted
+// state and colliding Names make Store.Save overwrite the earlier memory.
+func TestCompilerCandidateNamesUniqueForSimilarPatterns(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	// Same tool, errors differ only in CJK text: identical after asciiSlug.
+	seedCompilerFailures(t, cwd, 2, "编译失败：找不到模块甲")
+	seedCompilerFailures(t, cwd, 2, "编译失败：找不到模块乙")
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	var candidates []MemorySuggestion
+	for _, item := range view.Memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			candidates = append(candidates, item)
+		}
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidates = %+v, want both CJK-only-diff patterns", candidates)
+	}
+	if candidates[0].Name == candidates[1].Name || candidates[0].ID == candidates[1].ID {
+		t.Fatalf("similar patterns collided on Name/ID: %q vs %q", candidates[0].Name, candidates[1].Name)
+	}
+
+	// Accepting both must persist two distinct memories, not overwrite one.
+	for _, c := range candidates {
+		if _, err := app.AcceptMemorySuggestion(c); err != nil {
+			t.Fatalf("AcceptMemorySuggestion(%s): %v", c.Name, err)
+		}
+	}
+	saved := store.List()
+	if len(saved) != 2 {
+		t.Fatalf("saved memories = %d (%+v), want 2 distinct files", len(saved), saved)
+	}
+}
+
+// TestCompilerCandidateNamesStableAcrossRefreshes: the hash suffix must be
+// derived from the pattern, not from ordering or randomness, so a refresh
+// keeps the same ID and the frontend's accepted-state map stays valid.
+func TestCompilerCandidateNamesStableAcrossRefreshes(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	seedCompilerFailures(t, cwd, 2, "cannot find module providing package foo")
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	first := app.MemorySuggestions()
+	second := app.MemorySuggestions()
+	firstIDs := compilerCandidateIDs(first.Memories)
+	secondIDs := compilerCandidateIDs(second.Memories)
+	if len(firstIDs) == 0 || strings.Join(firstIDs, ",") != strings.Join(secondIDs, ",") {
+		t.Fatalf("candidate IDs changed across refreshes: %v vs %v", firstIDs, secondIDs)
+	}
+}
+
+func compilerCandidateIDs(memories []MemorySuggestion) []string {
+	var out []string
+	for _, item := range memories {
+		if strings.HasPrefix(item.Name, "memory-v5-") {
+			out = append(out, item.ID)
+		}
+	}
+	return out
+}

--- a/desktop/memory_suggestions_test.go
+++ b/desktop/memory_suggestions_test.go
@@ -211,6 +211,39 @@ func writeSuggestionSession(t *testing.T, dir, name string, messages ...provider
 	}
 }
 
+// TestHistoryEnglishCandidateNameBackwardCompat: an English statement whose
+// asciiSlug is short (<56 chars) must produce the same Name as old code
+// (plain slug, no hash suffix), so an already-accepted memory under the old
+// Name is not duplicated after upgrade.
+func TestHistoryEnglishCandidateNameBackwardCompat(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	writeSuggestionSession(t, sessionDir, "en.jsonl",
+		provider.Message{Role: provider.RoleUser, Content: "Always prefer English for code comments."},
+		provider.Message{Role: provider.RoleAssistant, Content: "Got it."},
+	)
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	if len(view.Memories) == 0 {
+		t.Fatalf("no candidates")
+	}
+	// Old code: suggestionName("", statement, "memory-candidate-1") = asciiSlug(statement)
+	oldName := asciiSlug("Always prefer English for code comments.")
+	if view.Memories[0].Name != oldName {
+		t.Fatalf("Name = %q, want old-compatible %q (no hash suffix for short ASCII slugs)", view.Memories[0].Name, oldName)
+	}
+}
+
 // TestHistoryMemoryCandidateNamesUniqueForCJK: two pure-CJK statements that
 // differ in content but produce the same empty asciiSlug must still get
 // distinct Name/ID. Without the hash suffix they would both fall back to

--- a/desktop/memory_suggestions_test.go
+++ b/desktop/memory_suggestions_test.go
@@ -210,3 +210,96 @@ func writeSuggestionSession(t *testing.T, dir, name string, messages ...provider
 		t.Fatalf("save session %s: %v", name, err)
 	}
 }
+
+// TestHistoryMemoryCandidateNamesUniqueForCJK: two pure-CJK statements that
+// differ in content but produce the same empty asciiSlug must still get
+// distinct Name/ID. Without the hash suffix they would both fall back to
+// "memory-candidate-<ordinal>" — but ordinals depend on iteration order and
+// wouldn't survive refresh, and Store.Save overwrites by name.
+func TestHistoryMemoryCandidateNamesUniqueForCJK(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	// Two pure-CJK "always" statements that pass extractMemoryStatement but
+	// share the exact same empty asciiSlug.
+	writeSuggestionSession(t, sessionDir, "zh-a.jsonl",
+		provider.Message{Role: provider.RoleUser, Content: "以后始终使用甲方案处理合并冲突。"},
+		provider.Message{Role: provider.RoleAssistant, Content: "好的。"},
+	)
+	writeSuggestionSession(t, sessionDir, "zh-b.jsonl",
+		provider.Message{Role: provider.RoleUser, Content: "以后始终使用乙方案处理部署回滚。"},
+		provider.Message{Role: provider.RoleAssistant, Content: "好的。"},
+	)
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	view := app.MemorySuggestions()
+	if len(view.Memories) < 2 {
+		t.Fatalf("memories = %+v, want at least 2 CJK candidates", view.Memories)
+	}
+	names := map[string]bool{}
+	ids := map[string]bool{}
+	for _, m := range view.Memories {
+		if names[m.Name] {
+			t.Fatalf("duplicate Name %q among history candidates", m.Name)
+		}
+		if ids[m.ID] {
+			t.Fatalf("duplicate ID %q among history candidates", m.ID)
+		}
+		names[m.Name] = true
+		ids[m.ID] = true
+	}
+
+	// Accept both → two distinct persisted memories.
+	for _, c := range view.Memories {
+		if _, err := app.AcceptMemorySuggestion(c); err != nil {
+			t.Fatalf("AcceptMemorySuggestion(%s): %v", c.Name, err)
+		}
+	}
+	saved := store.List()
+	if len(saved) != len(view.Memories) {
+		t.Fatalf("saved %d memories, want %d (Name collision caused overwrite)", len(saved), len(view.Memories))
+	}
+}
+
+// TestHistoryMemoryCandidateNamesStableAcrossRefreshes: the hash suffix must
+// be derived from the statement, not from iteration order or random state, so
+// a refresh keeps the same ID and the frontend's accepted-state map stays valid.
+func TestHistoryMemoryCandidateNamesStableAcrossRefreshes(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	sessionDir := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	writeSuggestionSession(t, sessionDir, "pref.jsonl",
+		provider.Message{Role: provider.RoleUser, Content: "以后请始终用中文回复，除非我明确要求英文。"},
+		provider.Message{Role: provider.RoleAssistant, Content: "好的。"},
+	)
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: store, CWD: cwd, UserDir: userDir},
+		SessionDir: sessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = cwd
+
+	first := app.MemorySuggestions()
+	second := app.MemorySuggestions()
+	if len(first.Memories) == 0 || len(first.Memories) != len(second.Memories) {
+		t.Fatalf("memories counts differ across refreshes: %d vs %d", len(first.Memories), len(second.Memories))
+	}
+	for i := range first.Memories {
+		if first.Memories[i].ID != second.Memories[i].ID || first.Memories[i].Name != second.Memories[i].Name {
+			t.Fatalf("refresh changed candidate #%d: %q/%q → %q/%q",
+				i, first.Memories[i].Name, first.Memories[i].ID,
+				second.Memories[i].Name, second.Memories[i].ID)
+		}
+	}
+}

--- a/internal/memorycompiler/candidates.go
+++ b/internal/memorycompiler/candidates.go
@@ -1,0 +1,36 @@
+package memorycompiler
+
+// StableNoisePattern is a failure pattern Memory v5 observed across at least
+// minCount separate turns, stable enough to surface as a durable memory
+// candidate for explicit user confirmation.
+type StableNoisePattern struct {
+	Pattern string
+	Count   int
+}
+
+// StableNoisePatterns returns repeated failure patterns ordered by how often
+// they recurred. Read-only: it never mutates compiler state. minCount < 1
+// defaults to 1; maxItems <= 0 uses a default.
+func (r *Runtime) StableNoisePatterns(minCount, maxItems int) []StableNoisePattern {
+	if r == nil {
+		return nil
+	}
+	if minCount < 1 {
+		minCount = 1
+	}
+	if maxItems <= 0 {
+		maxItems = 8
+	}
+	st := r.loadState()
+	var out []StableNoisePattern
+	for _, ref := range sortedNoisyRefs(st.NoisyRefs) {
+		if ref.count < minCount {
+			continue
+		}
+		out = append(out, StableNoisePattern{Pattern: ref.ref, Count: ref.count})
+		if len(out) >= maxItems {
+			break
+		}
+	}
+	return out
+}

--- a/internal/memorycompiler/candidates_test.go
+++ b/internal/memorycompiler/candidates_test.go
@@ -1,0 +1,60 @@
+package memorycompiler
+
+import (
+	"context"
+	"testing"
+)
+
+func seedRepeatedFailure(t *testing.T, rt *Runtime, turns int, errText string) {
+	t.Helper()
+	for i := 0; i < turns; i++ {
+		_, turn := rt.StartTurn(context.Background(), "fix a bug", nil)
+		turn.RecordToolResults([]ToolRecord{
+			{Name: "bash", Error: errText},
+			{Name: "bash", Error: errText},
+		})
+		turn.Finish(nil)
+	}
+}
+
+func TestStableNoisePatternsRequireMinCount(t *testing.T) {
+	rt := New(t.TempDir())
+	seedRepeatedFailure(t, rt, 1, "cannot find module providing package foo")
+
+	if got := rt.StableNoisePatterns(2, 0); len(got) != 0 {
+		t.Fatalf("single-turn pattern should not be stable yet: %+v", got)
+	}
+
+	seedRepeatedFailure(t, rt, 1, "cannot find module providing package foo")
+	got := rt.StableNoisePatterns(2, 0)
+	if len(got) != 1 {
+		t.Fatalf("patterns = %+v, want exactly one stable pattern", got)
+	}
+	if got[0].Count != 2 || got[0].Pattern != "bash repeated error: cannot find module providing package foo" {
+		t.Fatalf("unexpected stable pattern: %+v", got[0])
+	}
+}
+
+func TestStableNoisePatternsNilAndEmpty(t *testing.T) {
+	var nilRT *Runtime
+	if got := nilRT.StableNoisePatterns(1, 0); got != nil {
+		t.Fatalf("nil runtime returned patterns: %+v", got)
+	}
+	if got := New(t.TempDir()).StableNoisePatterns(1, 0); len(got) != 0 {
+		t.Fatalf("fresh dir returned patterns: %+v", got)
+	}
+}
+
+func TestStableNoisePatternsOrderedAndBounded(t *testing.T) {
+	rt := New(t.TempDir())
+	seedRepeatedFailure(t, rt, 3, "error alpha")
+	seedRepeatedFailure(t, rt, 2, "error beta")
+
+	got := rt.StableNoisePatterns(2, 1)
+	if len(got) != 1 {
+		t.Fatalf("patterns = %+v, want maxItems to bound the list", got)
+	}
+	if got[0].Count != 3 {
+		t.Fatalf("expected the most frequent pattern first: %+v", got[0])
+	}
+}


### PR DESCRIPTION
## Summary

Memory v5 already learns repeated failure patterns per workspace (`NoisyRefs`), but they were buried in `state.json` where nobody sees them. This PR bridges the stable ones into the settings Memory page's existing candidate-suggestions flow, so learned execution patterns can be promoted into durable saved memories — with explicit user confirmation, matching how history-derived suggestions already work.

### What changed

- `internal/memorycompiler/candidates.go`: new read-only `StableNoisePatterns(minCount, maxItems)` accessor returning failure patterns that recurred across at least `minCount` separate turns, ordered by frequency. Never mutates compiler state; nil-runtime and fresh-state safe.
- `desktop/memory_suggestions_compiler.go`: `suggestCompilerMemories` converts stable patterns (≥2 turns) into project-typed `MemorySuggestion` candidates with provenance (reason names Memory v5 and the recurrence count; evidence cites the execution traces), deduplicated against history-derived suggestions and existing saved memories, capped at 3 so they cannot crowd out history candidates.
- `desktop/memory_suggestions.go`: appends compiler candidates to `MemorySuggestionsView.Memories`.

### Review hardening (post-initial-review commits)

- **Unique candidate names** (`43b147e4f`): `asciiSlug` drops non-ASCII runes and truncates to 56 chars, so patterns differing only in CJK error text collided on Name/ID — colliding IDs cross-wire the frontend's React keys and accepted-state map, and colliding Names make `Store.Save` overwrite the earlier memory. Compiler candidate names now append an FNV-1a hash of the full pattern, unique per content and stable across refreshes.
- **Same-shape sweep for history candidates** (`8b0492525`): history-derived candidates from `suggestMemories` had the same collision for pure-CJK statements (empty slug → ordinal fallback names that depend on iteration order). Extracted a shared `stableSuggestionName` helper; both candidate sources now produce content-hashed, refresh-stable names when the plain slug is collision-prone.
- **Backward-compatible names for ASCII-safe candidates** (`78133b1a2`): history candidates whose ASCII slug is non-empty and under the 56-char truncation boundary keep the plain slug — byte-identical to old-version names — so a memory accepted under the old name is not re-suggested or duplicated after upgrade. The hash suffix applies only where the old format was demonstrably broken (CJK-only statements, truncation-boundary slugs, and compiler patterns, which are inherently homogeneous).
- **Preserve generated names through the accept path** (`0403d1d1a`): `AcceptMemorySuggestion` re-derived the name via `suggestionName(in.Name, ...)`, whose `asciiSlug` pass truncates to 56 chars and strips the hash suffix — two long-common-prefix candidates got distinct generated Name/ID but collapsed to one file at save time. Accept now keeps a well-formed generated slug verbatim (`isWellFormedSlug`, up to 128 chars); malformed/empty names still fall back to deriving from the description. `memory.Store.Save`'s own slug pass remains the final validator (cleans but never truncates), and `safeJoin` still guards path construction.

### Deliberately unchanged

- Candidates persist only through the regular `AcceptMemorySuggestion` confirmation flow — nothing is written automatically. Once accepted, the pattern is covered by an existing memory and stops being suggested.
- No frontend changes: candidates render through the existing suggestion card (which already shows reason and evidence), so no i18n keys were needed.
- Unstable patterns (seen in only one turn) are never suggested.

## Backward compatibility audit

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| `state.json` / trace files | Read-only access via existing structs; no format change in this PR | Safe |
| Accepted-memory files (old names) | `existingCovers` dedupes by body content, not name — memories saved under old-format names still suppress re-suggestion | Safe |
| History candidate names (short ASCII slug) | Byte-identical to old format (no hash suffix) | Safe |
| History candidate names (pure-CJK / truncated) | Format changes from unstable ordinal to content hash; old format was broken (collisions, refresh-unstable IDs) | Intentional fix |
| Accept path with old-format names | `isWellFormedSlug` keeps short ASCII slugs verbatim, same as before | Safe |

## Verification

- `go test ./internal/...` (root module) and `go test ./...` in `desktop/` pass; `go vet` and `gofmt` clean on both modules.
- New focused tests:
  - `internal/memorycompiler`: min-count threshold, frequency ordering, maxItems bound, nil/fresh-state safety.
  - `desktop`: end-to-end candidate surfacing → accept → persisted body → no re-suggestion after acceptance; unstable single-turn patterns are not suggested.
  - Collision regressions (each red on the commit before its fix): CJK-only-diff compiler patterns persist as two files; pure-CJK history statements get distinct Name/ID; >56-char common-prefix compiler patterns accept into two distinct files; candidate IDs stable across refreshes; English candidate names byte-compatible with old format.

## Notes

- No provider-visible behavior change: purely local state reads plus desktop suggestion data. Tool schemas, prompts, contract format, and injection behavior are untouched.
- Independent of #6160 (Memory v5 outcome-signal upgrades, already merged); no file overlap with current `main-v2`.
