### PR TITLE
Bound lossy slugs and tail-read append-only logs / 限长有损 slug 并尾读追加日志

### DIFF
--- a/internal/autoresearch/bounded_store_test.go
+++ b/internal/autoresearch/bounded_store_test.go
@@ -1,0 +1,239 @@
+package autoresearch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDirectionFingerprintDistinguishesLongPrefixes: two directions sharing a
+// >56-char slug prefix used to collapse to one fingerprint, wrongly counting
+// the second as a repeat and inflating StaleCount toward a forced pivot.
+func TestDirectionFingerprintDistinguishesLongPrefixes(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root)
+	task, err := store.CreateTask("Long prefix fingerprints", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	prefix := "Benchmark the desktop frontend markdown rendering pipeline for "
+
+	progress, err := store.RecordDirection(task.ID, Direction{
+		Summary:             prefix + "large tables",
+		AcceptedEvidenceIDs: []string{"f1"},
+		Now:                 time.Date(2026, 7, 7, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("RecordDirection first: %v", err)
+	}
+	if progress.StaleCount != 0 {
+		t.Fatalf("first direction stale = %d, want 0", progress.StaleCount)
+	}
+
+	progress, err = store.RecordDirection(task.ID, Direction{
+		Summary:             prefix + "code blocks",
+		AcceptedEvidenceIDs: []string{"f2"},
+		Now:                 time.Date(2026, 7, 7, 10, 1, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("RecordDirection second: %v", err)
+	}
+	// A genuinely different direction with accepted evidence must not be
+	// counted as a repeat.
+	if progress.StaleCount != 0 {
+		t.Fatalf("distinct long-prefix direction treated as repeat: stale = %d, want 0", progress.StaleCount)
+	}
+
+	// An exact repeat must still be detected.
+	progress, err = store.RecordDirection(task.ID, Direction{
+		Summary:             prefix + "code blocks",
+		AcceptedEvidenceIDs: []string{"f3"},
+		Now:                 time.Date(2026, 7, 7, 10, 2, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("RecordDirection third: %v", err)
+	}
+	if progress.StaleCount != 1 {
+		t.Fatalf("exact repeat not detected: stale = %d, want 1", progress.StaleCount)
+	}
+}
+
+// TestDirectionFingerprintDistinguishesCJK: directions differing only in CJK
+// text slugify to the same string ("task") and used to collide.
+func TestDirectionFingerprintDistinguishesCJK(t *testing.T) {
+	a := directionFingerprint("评测甲方案的渲染性能")
+	b := directionFingerprint("评测乙方案的渲染性能")
+	if a == b {
+		t.Fatalf("CJK-only-diff directions share a fingerprint: %q", a)
+	}
+	if directionFingerprint("评测甲方案的渲染性能") != a {
+		t.Fatal("fingerprint is not deterministic")
+	}
+}
+
+// TestDirectionFingerprintBackwardCompatShortASCII: short ASCII summaries keep
+// the bare slug so fingerprints recorded by older versions still match.
+func TestDirectionFingerprintBackwardCompatShortASCII(t *testing.T) {
+	got := directionFingerprint("Profile markdown rendering")
+	want := slugify("Profile markdown rendering")
+	if got != want {
+		t.Fatalf("short ASCII fingerprint = %q, want legacy slug %q", got, want)
+	}
+}
+
+// TestRecordDirectionMigratesLegacyFingerprint: a directions_tried.json entry
+// written by an older version (bare truncated slug) must still match its own
+// summary on repeat, not be double-counted as a new direction.
+func TestRecordDirectionMigratesLegacyFingerprint(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root)
+	task, err := store.CreateTask("Legacy fingerprint migration", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	summary := "Benchmark the desktop frontend markdown rendering pipeline for large tables"
+
+	// Simulate a legacy entry: fingerprint from the old bare slugify.
+	dirPath := filepath.Join(task.Root, "state", "directions_tried.json")
+	legacy := []DirectionTried{{
+		Fingerprint:        slugify(summary),
+		Summary:            summary,
+		FirstSeenIteration: 1,
+		LastSeenIteration:  1,
+		Count:              1,
+	}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dirPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	progress, err := store.RecordDirection(task.ID, Direction{
+		Summary: summary,
+		Now:     time.Date(2026, 7, 7, 11, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("RecordDirection: %v", err)
+	}
+	// Repeat of the legacy direction: stale should increment (repeat + no
+	// accepted evidence), and the entry should be migrated, not duplicated.
+	if progress.StaleCount != 1 {
+		t.Fatalf("legacy repeat not detected: stale = %d, want 1", progress.StaleCount)
+	}
+	raw, err := os.ReadFile(dirPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var directions []DirectionTried
+	if err := json.Unmarshal(raw, &directions); err != nil {
+		t.Fatal(err)
+	}
+	if len(directions) != 1 {
+		t.Fatalf("directions = %+v, want single migrated entry", directions)
+	}
+	if directions[0].Count != 2 {
+		t.Fatalf("migrated count = %d, want 2", directions[0].Count)
+	}
+	if directions[0].Fingerprint != directionFingerprint(summary) {
+		t.Fatalf("entry not migrated to new fingerprint: %q", directions[0].Fingerprint)
+	}
+}
+
+// TestTailJSONLLinesMatchesFullScan: the tail reader must return exactly the
+// same entries as a full scan for every limit, including limits larger than
+// the file and files bigger than one read chunk.
+func TestTailJSONLLinesMatchesFullScan(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root)
+	task, err := store.CreateTask("Tail read equivalence", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	// Write enough heartbeats that the log exceeds one 64KiB chunk.
+	long := strings.Repeat("x", 700)
+	for i := 0; i < 150; i++ {
+		if err := store.AppendHeartbeat(task.ID, Heartbeat{
+			Status:    HeartbeatTurnDone,
+			Iteration: i + 1,
+			Message:   fmt.Sprintf("turn-%03d %s", i, long),
+			CreatedAt: time.Date(2026, 7, 7, 12, 0, i%60, 0, time.UTC),
+		}); err != nil {
+			t.Fatalf("AppendHeartbeat %d: %v", i, err)
+		}
+	}
+	all, err := store.Heartbeats(task.ID, 0)
+	if err != nil {
+		t.Fatalf("Heartbeats(0): %v", err)
+	}
+	if len(all) != 150 {
+		t.Fatalf("full scan = %d heartbeats, want 150", len(all))
+	}
+	for _, limit := range []int{1, 3, 149, 150, 500} {
+		got, err := store.Heartbeats(task.ID, limit)
+		if err != nil {
+			t.Fatalf("Heartbeats(%d): %v", limit, err)
+		}
+		want := all
+		if limit < len(all) {
+			want = all[len(all)-limit:]
+		}
+		if len(got) != len(want) {
+			t.Fatalf("Heartbeats(%d) = %d entries, want %d", limit, len(got), len(want))
+		}
+		for i := range got {
+			if got[i].Iteration != want[i].Iteration {
+				t.Fatalf("Heartbeats(%d)[%d].Iteration = %d, want %d", limit, i, got[i].Iteration, want[i].Iteration)
+			}
+		}
+	}
+	// LastHeartbeat must be the newest entry.
+	last, ok, err := store.LastHeartbeat(task.ID)
+	if err != nil || !ok {
+		t.Fatalf("LastHeartbeat: ok=%v err=%v", ok, err)
+	}
+	if last.Iteration != 150 {
+		t.Fatalf("LastHeartbeat iteration = %d, want 150", last.Iteration)
+	}
+}
+
+// TestFindingsBoundedTailMatchesFullScan mirrors the heartbeat check for the
+// findings log, which desktop views read with a limit.
+func TestFindingsBoundedTailMatchesFullScan(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root)
+	task, err := store.CreateTask("Findings tail equivalence", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	for i := 0; i < 25; i++ {
+		if err := store.AppendFinding(task.ID, Finding{
+			ID:        fmt.Sprintf("f%03d", i),
+			Kind:      FindingKindManual,
+			Summary:   fmt.Sprintf("finding %03d", i),
+			Accepted:  i%2 == 0,
+			CreatedAt: time.Date(2026, 7, 7, 13, 0, i%60, 0, time.UTC),
+		}); err != nil {
+			t.Fatalf("AppendFinding %d: %v", i, err)
+		}
+	}
+	all, err := store.Findings(task.ID, 0)
+	if err != nil {
+		t.Fatalf("Findings(0): %v", err)
+	}
+	if len(all) != 25 || all[0].ID != "f024" {
+		t.Fatalf("full scan = %d findings first %q, want 25 / f024 (newest first)", len(all), all[0].ID)
+	}
+	got, err := store.Findings(task.ID, 5)
+	if err != nil {
+		t.Fatalf("Findings(5): %v", err)
+	}
+	if len(got) != 5 || got[0].ID != "f024" || got[4].ID != "f020" {
+		t.Fatalf("Findings(5) = %+v, want newest five f024..f020", got)
+	}
+}

--- a/internal/autoresearch/store.go
+++ b/internal/autoresearch/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -260,16 +261,20 @@ func (s *Store) Findings(taskID string, limit int) ([]Finding, error) {
 		return nil, err
 	}
 	defer storeRoot.Close()
+	path := filepath.Join(taskRel, "state", "findings.jsonl")
+	// Bounded requests (the newest-N views) read only the file tail; limit 0
+	// keeps the full scan because accepted-evidence lookups need every entry.
+	lines, err := tailJSONLLines(storeRoot, path, limit)
+	if err != nil {
+		return nil, err
+	}
 	var findings []Finding
-	if err := readJSONL(storeRoot, filepath.Join(taskRel, "state", "findings.jsonl"), func(data []byte) error {
+	for _, line := range lines {
 		var f Finding
-		if err := json.Unmarshal(data, &f); err != nil {
-			return err
+		if err := json.Unmarshal(line, &f); err != nil {
+			return nil, fmt.Errorf("autoresearch: parse %s: %w", path, err)
 		}
 		findings = append(findings, f)
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 	for i, j := 0, len(findings)-1; i < j; i, j = i+1, j-1 {
 		findings[i], findings[j] = findings[j], findings[i]
@@ -307,16 +312,21 @@ func (s *Store) Heartbeats(taskID string, limit int) ([]Heartbeat, error) {
 		return nil, err
 	}
 	defer storeRoot.Close()
+	path := filepath.Join(taskRel, "logs", "heartbeat.jsonl")
+	// Bounded requests only need the file tail; heartbeat logs grow one line
+	// per turn for the life of a task, so a full scan per read is a per-turn
+	// cost that keeps rising.
+	lines, err := tailJSONLLines(storeRoot, path, limit)
+	if err != nil {
+		return nil, err
+	}
 	var heartbeats []Heartbeat
-	if err := readJSONL(storeRoot, filepath.Join(taskRel, "logs", "heartbeat.jsonl"), func(data []byte) error {
+	for _, line := range lines {
 		var h Heartbeat
-		if err := json.Unmarshal(data, &h); err != nil {
-			return err
+		if err := json.Unmarshal(line, &h); err != nil {
+			return nil, fmt.Errorf("autoresearch: parse %s: %w", path, err)
 		}
 		heartbeats = append(heartbeats, h)
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 	if limit > 0 && len(heartbeats) > limit {
 		heartbeats = heartbeats[len(heartbeats)-limit:]
@@ -366,15 +376,20 @@ func (s *Store) RecordDirection(taskID string, d Direction) (*Progress, error) {
 	if err != nil {
 		return nil, err
 	}
-	fp := slugify(d.Summary)
+	fp := directionFingerprint(d.Summary)
 	repeated := false
 	for i := range directions {
-		if directions[i].Fingerprint == fp {
-			repeated = true
-			directions[i].Count++
-			directions[i].LastSeenIteration = progress.Iteration
-			break
+		// Legacy entries carry pre-hash fingerprints; recompute from the
+		// stored summary so repeats recorded by older versions still match,
+		// then migrate the entry in place.
+		if directions[i].Fingerprint != fp && directionFingerprint(directions[i].Summary) != fp {
+			continue
 		}
+		repeated = true
+		directions[i].Fingerprint = fp
+		directions[i].Count++
+		directions[i].LastSeenIteration = progress.Iteration
+		break
 	}
 	if !repeated {
 		directions = append(directions, DirectionTried{
@@ -619,6 +634,87 @@ func readJSONL(root *os.Root, path string, each func([]byte) error) error {
 	return nil
 }
 
+// tailJSONLLines returns the last limit non-empty lines of a JSONL file in
+// file order, reading backward in fixed-size chunks so per-turn readers do not
+// rescan an append-only log that grows for the life of a task. limit <= 0
+// reads the whole file (legacy unbounded behavior).
+func tailJSONLLines(root *os.Root, path string, limit int) ([][]byte, error) {
+	if limit <= 0 {
+		var lines [][]byte
+		if err := readJSONL(root, path, func(data []byte) error {
+			line := make([]byte, len(data))
+			copy(line, data)
+			lines = append(lines, line)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return lines, nil
+	}
+	f, err := root.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("autoresearch: open %s: %w", path, err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("autoresearch: stat %s: %w", path, err)
+	}
+	const chunkSize = 64 * 1024
+	var (
+		buf []byte
+		off = info.Size()
+	)
+	for off > 0 {
+		readLen := int64(chunkSize)
+		if off < readLen {
+			readLen = off
+		}
+		off -= readLen
+		chunk := make([]byte, readLen)
+		if _, err := f.ReadAt(chunk, off); err != nil {
+			return nil, fmt.Errorf("autoresearch: read %s: %w", path, err)
+		}
+		buf = append(chunk, buf...)
+		// Stop once the buffered tail holds enough complete lines. Count
+		// newline-separated non-empty segments after the first newline (the
+		// first segment may be a partial line unless we reached offset 0).
+		if countCompleteTailLines(buf, off == 0) > limit {
+			break
+		}
+	}
+	segments := strings.Split(string(buf), "\n")
+	if off > 0 && len(segments) > 0 {
+		segments = segments[1:] // drop the leading partial line
+	}
+	var lines [][]byte
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		lines = append(lines, []byte(seg))
+	}
+	if len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+	return lines, nil
+}
+
+func countCompleteTailLines(buf []byte, atStart bool) int {
+	segments := strings.Split(string(buf), "\n")
+	if !atStart && len(segments) > 0 {
+		segments = segments[1:]
+	}
+	count := 0
+	for _, seg := range segments {
+		if strings.TrimSpace(seg) != "" {
+			count++
+		}
+	}
+	return count
+}
+
 func (s *Store) loadDirections(root *os.Root, taskRel string) ([]DirectionTried, error) {
 	path := filepath.Join(taskRel, "state", "directions_tried.json")
 	data, err := root.ReadFile(path)
@@ -711,4 +807,59 @@ func slugify(s string) string {
 		return "task"
 	}
 	return slug
+}
+
+// directionFingerprint identifies a direction for repeat detection. slugify
+// alone truncates to 56 chars and drops non-ASCII runes, so two different
+// directions sharing a long ASCII prefix (or differing only in CJK text)
+// collapsed to one fingerprint and wrongly inflated StaleCount/PivotCount on
+// long tasks. Append a hash of the full normalized text when slugify lost
+// distinguishing content (truncation or non-ASCII letters/digits); keep the
+// bare slug otherwise so fingerprints recorded by older versions still match,
+// and punctuation-only differences stay fuzzy-matched as before.
+func directionFingerprint(summary string) string {
+	slug := slugify(summary)
+	if slug == slugifyUnbounded(summary) && !containsNonASCIIWord(summary) {
+		return slug
+	}
+	normalized := strings.Join(strings.Fields(strings.ToLower(summary)), " ")
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(normalized))
+	return fmt.Sprintf("%s-%08x", slug, h.Sum32())
+}
+
+// slugifyUnbounded matches slugify without the 56-char cap, used to detect
+// whether truncation dropped content.
+func slugifyUnbounded(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		switch {
+		case r <= unicode.MaxASCII && (unicode.IsLetter(r) || unicode.IsDigit(r)):
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		return "task"
+	}
+	return slug
+}
+
+// containsNonASCIIWord reports whether s carries letters/digits that slugify
+// discards entirely (e.g. CJK), meaning distinct summaries could share a slug.
+func containsNonASCIIWord(s string) bool {
+	for _, r := range s {
+		if r > unicode.MaxASCII && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/bounded_component_test.go
+++ b/internal/config/bounded_component_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWorkspaceSlugShortPathUnchanged: existing short paths must keep their
+// exact historical slug so on-disk project directories keep resolving.
+func TestWorkspaceSlugShortPathUnchanged(t *testing.T) {
+	got := WorkspaceSlug("/Users/me/proj")
+	if got != "-Users-me-proj" {
+		t.Fatalf("WorkspaceSlug short path = %q, want -Users-me-proj", got)
+	}
+}
+
+// TestWorkspaceSlugBoundsDeepPaths: a workspace path whose flattened slug
+// exceeds the 255-byte filename component limit used to make every derived
+// directory (project sessions, MemoryCompiler, auto-memory) uncreatable with
+// ENAMETOOLONG.
+func TestWorkspaceSlugBoundsDeepPaths(t *testing.T) {
+	deep := "/data/" + strings.Repeat("deeply-nested-workspace-segment/", 12) + "proj"
+	slug := WorkspaceSlug(deep)
+	if len(slug) > 255 {
+		t.Fatalf("slug length = %d, exceeds 255-byte component limit", len(slug))
+	}
+	// Distinct deep paths must not collapse to one slug.
+	other := "/data/" + strings.Repeat("deeply-nested-workspace-segment/", 12) + "proj2"
+	if WorkspaceSlug(other) == slug {
+		t.Fatal("distinct deep paths share one slug")
+	}
+	// Deterministic across calls.
+	if WorkspaceSlug(deep) != slug {
+		t.Fatal("slug is not deterministic")
+	}
+}
+
+func TestBoundFilenameComponentRuneBoundary(t *testing.T) {
+	// A multi-byte-rune input truncated mid-rune must back off to a valid
+	// boundary, not emit invalid UTF-8 into a filename.
+	long := strings.Repeat("工作区", 100)
+	got := BoundFilenameComponent(long, 255)
+	if len(got) > 255 {
+		t.Fatalf("bounded component length = %d, want <= 255", len(got))
+	}
+	if strings.Contains(got, "�") {
+		t.Fatalf("bounded component contains replacement char: %q", got)
+	}
+}

--- a/internal/config/bounded_component_test.go
+++ b/internal/config/bounded_component_test.go
@@ -8,6 +8,7 @@ import (
 // TestWorkspaceSlugShortPathUnchanged: existing short paths must keep their
 // exact historical slug so on-disk project directories keep resolving.
 func TestWorkspaceSlugShortPathUnchanged(t *testing.T) {
+	setRuntimeGOOS(t, "linux")
 	got := WorkspaceSlug("/Users/me/proj")
 	if got != "-Users-me-proj" {
 		t.Fatalf("WorkspaceSlug short path = %q, want -Users-me-proj", got)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 )
 
 var (
@@ -344,7 +347,40 @@ func WorkspaceSlug(absPath string) string {
 	if runtimeGOOS == "windows" {
 		absPath = strings.ToLower(absPath)
 	}
-	return strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
+	slug := strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
+	return boundFilenameComponent(slug, 255)
+}
+
+// boundFilenameComponent caps a derived filename component at the common
+// per-component filesystem limit (255 bytes on ext4/APFS/NTFS). maxLen is the
+// byte budget for this component (path segments pass 255; names that gain an
+// extension pass 255 minus the extension length). Inputs at or under the
+// budget pass through byte-identical — every component that ever existed on
+// disk is under the budget, or it could not have been created — so existing
+// directories and files keep resolving. Only inputs that would previously
+// have failed with ENAMETOOLONG are truncated, with an FNV-1a hash of the
+// full input appended so distinct deep paths cannot collapse to one name.
+func boundFilenameComponent(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	budget := maxLen - 17 // room for "-" + 16 hex digits
+	prefix := s[:budget]
+	// Back off to a rune boundary so a multi-byte character is never split.
+	for len(prefix) > 0 && !utf8.ValidString(prefix) {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return fmt.Sprintf("%s-%016x", prefix, h.Sum64())
+}
+
+// BoundFilenameComponent is the exported form for sibling packages deriving
+// filename components from unbounded input. maxLen is the byte budget for the
+// component (pass 255 for a bare path segment; subtract the extension length
+// when one will be appended).
+func BoundFilenameComponent(s string, maxLen int) string {
+	return boundFilenameComponent(s, maxLen)
 }
 
 // CacheDir is the per-user cache root for derived/regenerable artefacts: MCP

--- a/internal/memory/bounded_name_test.go
+++ b/internal/memory/bounded_name_test.go
@@ -1,0 +1,41 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSaveBoundsLongNames: a memory name distilled from a long
+// title/description used to fail the write with ENAMETOOLONG because
+// slug(name)+".md" exceeded the 255-byte filename component limit.
+func TestSaveBoundsLongNames(t *testing.T) {
+	s := StoreFor(t.TempDir(), t.TempDir())
+	long := strings.Repeat("always-verify-the-desktop-session-lease-before-rebuild-", 8) + "end"
+	path, err := s.Save(Memory{Name: long, Description: "d", Type: TypeProject, Body: "b"})
+	if err != nil {
+		t.Fatalf("Save long name: %v", err)
+	}
+	if path == "" {
+		t.Fatal("Save returned empty path")
+	}
+	// Distinct long names must persist as distinct files.
+	other := strings.Repeat("always-verify-the-desktop-session-lease-before-rebuild-", 8) + "other"
+	path2, err := s.Save(Memory{Name: other, Description: "d", Type: TypeProject, Body: "b2"})
+	if err != nil {
+		t.Fatalf("Save second long name: %v", err)
+	}
+	if path2 == path {
+		t.Fatalf("distinct long names collapsed to one file: %q", path)
+	}
+	if got := s.List(); len(got) != 2 {
+		t.Fatalf("List() = %d memories, want 2", len(got))
+	}
+}
+
+// TestSlugShortNamesUnchanged: short names keep their historical slug so
+// existing memory files keep resolving after upgrade.
+func TestSlugShortNamesUnchanged(t *testing.T) {
+	if got := slug("My Setting: prefer 中文"); got != "my-setting-prefer-中文" {
+		t.Fatalf("short slug changed: %q", got)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -611,9 +611,14 @@ func splitFrontmatter(s string) (map[string]string, string) {
 // slugRe strips everything but Unicode letters and digits.
 var slugRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 
-// slug normalises a name into a kebab-case, filesystem-safe stem.
+// slug normalises a name into a kebab-case, filesystem-safe stem. The stem is
+// bounded so `<stem>.md` stays under the 255-byte filename component limit —
+// a name distilled from a long title/description previously failed the write
+// with ENAMETOOLONG. Names short enough to have ever been written are
+// returned unchanged, so existing files keep resolving.
 func slug(s string) string {
-	return strings.Trim(slugRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "-"), "-")
+	stem := strings.Trim(slugRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "-"), "-")
+	return config.BoundFilenameComponent(stem, 255-len(".md"))
 }
 
 // oneLine collapses whitespace so a description can't break the single-line

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -164,8 +164,11 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 // "foo.bar" and "foo-bar" collapse to one slug — and two colliding servers
 // sharing a file would alternately reset each other's window, so neither
 // could ever accumulate enough consecutive samples to demote. Hashing the raw
-// name into the filename gives every server its own history. Returns "" when
-// no cache dir is resolvable, which all callers treat as "skip telemetry".
+// name into the filename gives every server its own history. The slug portion
+// is bounded so the whole component stays under the 255-byte filesystem limit
+// even for very long server names — the hash carries the uniqueness, so
+// truncating the slug is safe. Returns "" when no cache dir is resolvable,
+// which all callers treat as "skip telemetry".
 func statsPath(name string) string {
 	base := config.CacheDir()
 	if base == "" {
@@ -173,7 +176,12 @@ func statsPath(name string) string {
 	}
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(name))
-	return filepath.Join(base, "mcp", fmt.Sprintf("%s-%08x.stats.json", slug(name), h.Sum32()))
+	// 255-byte component budget: slug + "-" + 8 hex digits + ".stats.json".
+	stem := slug(name)
+	if maxStem := 255 - len("-00000000.stats.json"); len(stem) > maxStem {
+		stem = stem[:maxStem]
+	}
+	return filepath.Join(base, "mcp", fmt.Sprintf("%s-%08x.stats.json", stem, h.Sum32()))
 }
 
 // legacyStatsPath is the pre-hash location, shared by every server whose name

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -44,6 +44,13 @@ type StartupStats struct {
 	Version   int       `json:"version"`
 	SamplesMs []int64   `json:"samples_ms"`
 	LastSeen  time.Time `json:"last_seen"`
+	// Name is the raw (pre-slug) server name that owns these samples. The
+	// filename slug is lossy — "foo.bar" and "foo-bar" share one file — so
+	// readers verify ownership before trusting samples, or a slow server's
+	// history could demote an unrelated healthy one. Empty on files written
+	// by older versions; those are adopted by the first writer (additive
+	// field, no version bump, so downgraded builds still read the file).
+	Name string `json:"name,omitempty"`
 }
 
 // Recommendation is the result of inspecting a plugin's recent startup
@@ -82,6 +89,12 @@ func RecordStartup(name string, dur time.Duration) error {
 		// migration path trivial as the format evolves.
 		stats = StartupStats{Version: statsVersion}
 	}
+	if stats.Name != "" && stats.Name != name {
+		// The slug collided with a different server's file. Do not mix
+		// samples across servers; start this server's window fresh.
+		stats = StartupStats{Version: statsVersion}
+	}
+	stats.Name = name
 
 	ms := dur.Milliseconds()
 	if ms < 0 {
@@ -127,6 +140,11 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 		// Either no history yet or a format we can't read — give the plugin a
 		// chance. The cost of one slow start is small compared to wrongly
 		// demoting a healthy plugin off stale data.
+		return Recommendation{}
+	}
+	if stats.Name != "" && stats.Name != name {
+		// Slug collision: these samples belong to a different server. Treat
+		// as no history rather than demote off another server's slowness.
 		return Recommendation{}
 	}
 

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -12,6 +12,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -82,16 +83,11 @@ func RecordStartup(name string, dur time.Duration) error {
 		return nil
 	}
 
-	stats := loadStats(path) // missing/corrupt → fresh zero value
+	stats := loadStatsForOwner(name) // missing/corrupt/foreign → fresh zero value
 	if stats.Version != statsVersion {
 		// Version mismatch: start over rather than try to migrate. The window
 		// is small enough that "lose 20 samples" is cheap, and it keeps the
 		// migration path trivial as the format evolves.
-		stats = StartupStats{Version: statsVersion}
-	}
-	if stats.Name != "" && stats.Name != name {
-		// The slug collided with a different server's file. Do not mix
-		// samples across servers; start this server's window fresh.
 		stats = StartupStats{Version: statsVersion}
 	}
 	stats.Name = name
@@ -135,16 +131,11 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 	if path == "" {
 		return Recommendation{}
 	}
-	stats := loadStats(path)
+	stats := loadStatsForOwner(name)
 	if stats.Version != statsVersion || len(stats.SamplesMs) == 0 {
 		// Either no history yet or a format we can't read — give the plugin a
 		// chance. The cost of one slow start is small compared to wrongly
 		// demoting a healthy plugin off stale data.
-		return Recommendation{}
-	}
-	if stats.Name != "" && stats.Name != name {
-		// Slug collision: these samples belong to a different server. Treat
-		// as no history rather than demote off another server's slowness.
 		return Recommendation{}
 	}
 
@@ -169,11 +160,27 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 }
 
 // statsPath returns the canonical path for one plugin's stats file:
-// <config.CacheDir()>/mcp/<slug>.stats.json. Shares the cache root and slug
-// rule with the schema cache so a `<plugin>.json` and `<plugin>.stats.json`
-// sit side by side under the same per-server folder. Returns "" when no cache
-// dir is resolvable, which all callers treat as "skip telemetry".
+// <config.CacheDir()>/mcp/<slug>-<hash>.stats.json. The slug alone is lossy —
+// "foo.bar" and "foo-bar" collapse to one slug — and two colliding servers
+// sharing a file would alternately reset each other's window, so neither
+// could ever accumulate enough consecutive samples to demote. Hashing the raw
+// name into the filename gives every server its own history. Returns "" when
+// no cache dir is resolvable, which all callers treat as "skip telemetry".
 func statsPath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	return filepath.Join(base, "mcp", fmt.Sprintf("%s-%08x.stats.json", slug(name), h.Sum32()))
+}
+
+// legacyStatsPath is the pre-hash location, shared by every server whose name
+// collapses to the same slug. Read-only for migration: a named legacy file is
+// adopted by its owner; a nameless one (pre-Name builds) has no provable owner
+// and is never trusted for demotion or adopted into a new window.
+func legacyStatsPath(name string) string {
 	base := config.CacheDir()
 	if base == "" {
 		return ""
@@ -200,6 +207,29 @@ func loadStats(path string) StartupStats {
 		return StartupStats{}
 	}
 	return s
+}
+
+// loadStatsForOwner reads name's history from its hashed path, falling back to
+// the shared legacy (pre-hash) file for a one-time migration. Legacy files are
+// trusted only when their recorded Name matches: a nameless legacy file
+// (written before ownership tracking) is shared by every server whose name
+// collapses to the same slug, so its samples cannot be attributed and must not
+// seed anyone's window or demote anyone.
+func loadStatsForOwner(name string) StartupStats {
+	if s := loadStats(statsPath(name)); s.Version != 0 || len(s.SamplesMs) > 0 {
+		if s.Name == "" || s.Name == name {
+			return s
+		}
+		return StartupStats{}
+	}
+	legacy := legacyStatsPath(name)
+	if legacy == "" {
+		return StartupStats{}
+	}
+	if s := loadStats(legacy); s.Name == name {
+		return s
+	}
+	return StartupStats{}
 }
 
 // writeStatsAtomic serialises s and writes it via tmpfile + os.Rename so that

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -220,3 +220,68 @@ func containsAny(s, chars string) bool {
 	}
 	return false
 }
+
+// TestStatsSlugCollisionDoesNotCrossDemote: "foo.bar" and "foo-bar" share one
+// stats file (lossy filename slug). A slow server's samples must not demote
+// the other server sharing the slug.
+func TestStatsSlugCollisionDoesNotCrossDemote(t *testing.T) {
+	withTempCache(t)
+
+	// foo.bar is chronically slow: enough consecutive over-budget samples to
+	// trigger demotion for itself.
+	for i := 0; i < defaultDemoteAfter; i++ {
+		if err := RecordStartup("foo.bar", 5*time.Second); err != nil {
+			t.Fatalf("RecordStartup foo.bar: %v", err)
+		}
+	}
+	if rec := Recommend("foo.bar", time.Second, 0); !rec.Demote {
+		t.Fatalf("foo.bar should demote on its own history: %+v", rec)
+	}
+	// foo-bar shares the slug but is a different server: it must not inherit
+	// foo.bar's slow history.
+	if rec := Recommend("foo-bar", time.Second, 0); rec.Demote {
+		t.Fatalf("foo-bar demoted off foo.bar's samples: %+v", rec)
+	}
+	// And when foo-bar starts recording, it takes over the file fresh instead
+	// of mixing samples.
+	if err := RecordStartup("foo-bar", 10*time.Millisecond); err != nil {
+		t.Fatalf("RecordStartup foo-bar: %v", err)
+	}
+	s := readStats(t, "foo-bar")
+	if s.Name != "foo-bar" || len(s.SamplesMs) != 1 {
+		t.Fatalf("stats after takeover = %+v, want fresh window owned by foo-bar", s)
+	}
+}
+
+// TestStatsLegacyFileWithoutNameAdopted: stats written by older versions have
+// no Name field; the same server keeps its history (adopted on next write)
+// and Recommend still works on it.
+func TestStatsLegacyFileWithoutNameAdopted(t *testing.T) {
+	withTempCache(t)
+
+	for i := 0; i < 3; i++ {
+		if err := RecordStartup("legacy", 100*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+	// Simulate a legacy file: strip the Name field.
+	path := statsPath("legacy")
+	s := readStats(t, "legacy")
+	s.Name = ""
+	if err := writeStatsAtomic(path, s); err != nil {
+		t.Fatalf("write legacy stats: %v", err)
+	}
+
+	// Recommend still reads the legacy file (no ownership check possible).
+	if rec := Recommend("legacy", time.Second, 0); rec.P99 == 0 {
+		t.Fatalf("legacy stats not readable: %+v", rec)
+	}
+	// The next write adopts the file without dropping history.
+	if err := RecordStartup("legacy", 100*time.Millisecond); err != nil {
+		t.Fatalf("RecordStartup after legacy: %v", err)
+	}
+	s = readStats(t, "legacy")
+	if s.Name != "legacy" || len(s.SamplesMs) != 4 {
+		t.Fatalf("legacy adoption = %+v, want name set and 4 samples kept", s)
+	}
+}

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -348,3 +348,33 @@ func TestStatsLegacyFileWithoutNameAdopted(t *testing.T) {
 		t.Fatalf("legacy adoption = %+v, want name set and 4 samples kept", s)
 	}
 }
+
+// TestStatsPathBoundedForLongNames: the hash suffix added for collision
+// safety must not push a previously-writable long slug past the 255-byte
+// filename component limit (slugs of 236-244 bytes could write
+// "<slug>.stats.json" before, but "<slug>-<hash>.stats.json" would exceed it).
+func TestStatsPathBoundedForLongNames(t *testing.T) {
+	withTempCache(t)
+
+	long := strings.Repeat("a", 240)
+	p := statsPath(long)
+	if p == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	if base := filepath.Base(p); len(base) > 255 {
+		t.Fatalf("component = %d bytes, exceeds 255 limit: %q", len(base), base)
+	}
+	// The bounded path must still be writable and readable end-to-end.
+	if err := RecordStartup(long, 100*time.Millisecond); err != nil {
+		t.Fatalf("RecordStartup long name: %v", err)
+	}
+	s := readStats(t, long)
+	if s.Name != long || len(s.SamplesMs) != 1 {
+		t.Fatalf("long-name stats = %+v, want one owned sample", s)
+	}
+	// Distinct long names sharing the truncated stem must keep distinct files.
+	other := strings.Repeat("a", 240) + "b"
+	if statsPath(other) == p {
+		t.Fatalf("distinct long names collapsed to one stats path: %q", p)
+	}
+}

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -221,41 +221,104 @@ func containsAny(s, chars string) bool {
 	return false
 }
 
-// TestStatsSlugCollisionDoesNotCrossDemote: "foo.bar" and "foo-bar" share one
-// stats file (lossy filename slug). A slow server's samples must not demote
-// the other server sharing the slug.
+// TestStatsSlugCollisionDoesNotCrossDemote: "foo.bar" and "foo-bar" collapse
+// to one slug. Each server now gets its own hash-suffixed file, so a slow
+// server's samples must not demote the other, and interleaved startups must
+// not reset each other's windows (the old shared-file ownership check made
+// each writer wipe the other's history, so neither could ever accumulate
+// enough consecutive samples to demote).
 func TestStatsSlugCollisionDoesNotCrossDemote(t *testing.T) {
 	withTempCache(t)
 
-	// foo.bar is chronically slow: enough consecutive over-budget samples to
-	// trigger demotion for itself.
+	// Interleave a chronically slow server with a healthy one sharing the slug.
 	for i := 0; i < defaultDemoteAfter; i++ {
 		if err := RecordStartup("foo.bar", 5*time.Second); err != nil {
 			t.Fatalf("RecordStartup foo.bar: %v", err)
 		}
+		if err := RecordStartup("foo-bar", 10*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup foo-bar: %v", err)
+		}
 	}
+	// Both windows must have accumulated independently despite interleaving.
+	slow := readStats(t, "foo.bar")
+	fast := readStats(t, "foo-bar")
+	if len(slow.SamplesMs) != defaultDemoteAfter || slow.Name != "foo.bar" {
+		t.Fatalf("foo.bar window = %+v, want %d samples owned by foo.bar", slow, defaultDemoteAfter)
+	}
+	if len(fast.SamplesMs) != defaultDemoteAfter || fast.Name != "foo-bar" {
+		t.Fatalf("foo-bar window = %+v, want %d samples owned by foo-bar", fast, defaultDemoteAfter)
+	}
+	// The slow server demotes on its own history; the healthy one does not.
 	if rec := Recommend("foo.bar", time.Second, 0); !rec.Demote {
 		t.Fatalf("foo.bar should demote on its own history: %+v", rec)
 	}
-	// foo-bar shares the slug but is a different server: it must not inherit
-	// foo.bar's slow history.
 	if rec := Recommend("foo-bar", time.Second, 0); rec.Demote {
 		t.Fatalf("foo-bar demoted off foo.bar's samples: %+v", rec)
 	}
-	// And when foo-bar starts recording, it takes over the file fresh instead
-	// of mixing samples.
-	if err := RecordStartup("foo-bar", 10*time.Millisecond); err != nil {
-		t.Fatalf("RecordStartup foo-bar: %v", err)
+}
+
+// TestStatsLegacyNamedFileMigrated: a pre-hash stats file whose recorded Name
+// matches is this server's own history — Recommend keeps working from it and
+// the next write carries it into the hashed path.
+func TestStatsLegacyNamedFileMigrated(t *testing.T) {
+	withTempCache(t)
+
+	legacy := StartupStats{Version: statsVersion, Name: "legacy", LastSeen: time.Now()}
+	for i := 0; i < 3; i++ {
+		legacy.SamplesMs = append(legacy.SamplesMs, 100)
 	}
-	s := readStats(t, "foo-bar")
-	if s.Name != "foo-bar" || len(s.SamplesMs) != 1 {
-		t.Fatalf("stats after takeover = %+v, want fresh window owned by foo-bar", s)
+	if err := writeStatsAtomic(legacyStatsPath("legacy"), legacy); err != nil {
+		t.Fatalf("write legacy stats: %v", err)
+	}
+
+	if rec := Recommend("legacy", time.Second, 0); rec.P99 == 0 {
+		t.Fatalf("legacy named stats not readable: %+v", rec)
+	}
+	if err := RecordStartup("legacy", 100*time.Millisecond); err != nil {
+		t.Fatalf("RecordStartup after legacy: %v", err)
+	}
+	s := readStats(t, "legacy")
+	if s.Name != "legacy" || len(s.SamplesMs) != 4 {
+		t.Fatalf("legacy migration = %+v, want name kept and 4 samples", s)
 	}
 }
 
-// TestStatsLegacyFileWithoutNameAdopted: stats written by older versions have
-// no Name field; the same server keeps its history (adopted on next write)
-// and Recommend still works on it.
+// TestStatsLegacyNamelessCollisionNotTrusted: a pre-ownership legacy file has
+// no Name, so it is shared by every server whose name collapses to the slug
+// and its samples cannot be attributed. It must not demote anyone and must
+// not seed a new window.
+func TestStatsLegacyNamelessCollisionNotTrusted(t *testing.T) {
+	withTempCache(t)
+
+	nameless := StartupStats{Version: statsVersion, LastSeen: time.Now()}
+	for i := 0; i < defaultDemoteAfter; i++ {
+		nameless.SamplesMs = append(nameless.SamplesMs, 5000) // over budget
+	}
+	if err := writeStatsAtomic(legacyStatsPath("foo.bar"), nameless); err != nil {
+		t.Fatalf("write nameless legacy stats: %v", err)
+	}
+
+	// Neither colliding server may be demoted off unattributable samples.
+	if rec := Recommend("foo.bar", time.Second, 0); rec.Demote {
+		t.Fatalf("foo.bar demoted off nameless legacy samples: %+v", rec)
+	}
+	if rec := Recommend("foo-bar", time.Second, 0); rec.Demote {
+		t.Fatalf("foo-bar demoted off nameless legacy samples: %+v", rec)
+	}
+	// A new write starts a fresh window instead of inheriting the samples.
+	if err := RecordStartup("foo.bar", 10*time.Millisecond); err != nil {
+		t.Fatalf("RecordStartup: %v", err)
+	}
+	s := readStats(t, "foo.bar")
+	if s.Name != "foo.bar" || len(s.SamplesMs) != 1 {
+		t.Fatalf("window after nameless legacy = %+v, want fresh single-sample window", s)
+	}
+}
+
+// TestStatsLegacyFileWithoutNameAdopted: a nameless file at the hashed path is
+// unambiguous — the hash pins it to exactly one server name — so its samples
+// stay usable and the next write adopts it without dropping history. (Nameless
+// files at the shared legacy path are the untrusted case, covered above.)
 func TestStatsLegacyFileWithoutNameAdopted(t *testing.T) {
 	withTempCache(t)
 


### PR DESCRIPTION
## Summary

Four related unbounded-growth / lossy-slug defects found by a sweep for "grows until truncation breaks something or performance degrades". All fixes preserve old-version user data — see the compatibility audit below.

### 1. AutoResearch direction fingerprints collide (correctness)

`slugify` truncates to 56 chars and drops non-ASCII runes, so two different directions sharing a long ASCII prefix — or differing only in CJK text (which slugs to the literal `"task"`) — collapsed to one fingerprint. `RecordDirection` then counted the second direction as a repeat, wrongly inflating `StaleCount`/`PivotCount` and pushing long tasks into premature forced pivots.

`directionFingerprint` now appends an FNV-1a hash of the normalized summary **only when slugify was lossy** (truncation or non-ASCII words). Short ASCII summaries keep the bare slug, byte-identical to fingerprints recorded by older versions. Legacy `directions_tried.json` entries are matched by recomputing the fingerprint from their stored summary and migrated in place — a legacy repeat is still detected, never double-counted.

### 2. AutoResearch bounded reads scan the whole log (performance)

`Findings`/`Heartbeats` read the entire JSONL file and then truncated to `limit`. `Summary` → `LastHeartbeat` → `Heartbeats(taskID, 1)` runs every turn, so the per-turn fixed cost grew with the life of the task. Bounded requests now tail-read backward in 64KiB chunks (`tailJSONLLines`); `limit == 0` keeps the full scan because accepted-evidence lookups need every entry. A cross-chunk equivalence test asserts tail reads return exactly what a full scan returns for every limit.

### 3. Workspace path slugs exceed the filename component limit (availability)

`config.WorkspaceSlug` and `memory.StoreFor`'s slugify flatten a full absolute path into a single directory name with no bound. A deep workspace path produced components over the 255-byte per-component filesystem limit, breaking project sessions, MemoryCompiler state, and the auto-memory store with `ENAMETOOLONG`. Components are now bounded via `BoundFilenameComponent` (truncate + FNV-1a hash of the full input, backing off to a valid UTF-8 rune boundary).

### 4. Memory name slugs and plugin stats files (availability / correctness)

- `memory.Store.Save` wrote `slug(m.Name)+".md"` with no bound; names distilled from long titles failed with `ENAMETOOLONG`. Same bounded rule, with the `.md` extension budgeted.
- Plugin startup-stats files shared a lossy filename slug across servers (`foo.bar` / `foo-bar` → one file), so one server's slow samples could demote a different healthy server — and any shared-file scheme lets interleaved startups reset each other's window so a chronically slow server never accumulates enough consecutive samples to auto-demote. `statsPath` now embeds an FNV-1a hash of the raw server name (`<slug>-<hash>.stats.json`), giving every server its own history. The pre-hash path is read-only for migration: a legacy file whose recorded `Name` matches is carried into the hashed path on the next write with history intact; a nameless legacy file (pre-ownership builds) has no provable owner, so it never feeds `Recommend` and never seeds a window — fail-open, matching the existing "missing stats → no demote" semantics. (The schema cache sharing this slug already validates `SpecHash`, so collisions there were only cache misses — unchanged.)

## Backward compatibility audit

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Direction fingerprints (short ASCII) | Bare slug kept — byte-identical to legacy fingerprints | Safe |
| Direction fingerprints (long/CJK, legacy entries) | Matched by recomputing from stored summary, migrated in place; repeat detection preserved | Safe (tested) |
| Findings/heartbeat JSONL | Read-path change only; file format untouched; `limit 0` semantics unchanged | Safe |
| Workspace slug directories | Any component that ever existed on disk is ≤255 bytes → returned byte-identical; only previously-uncreatable paths change (error → working) | Safe (tested) |
| Memory file names | Short names unchanged (incl. CJK names); long names previously failed to write, so no old files exist | Safe (tested) |
| Plugin stats files | New hashed filenames are additive (old files untouched). Named legacy files migrate on next write with samples intact; nameless legacy files are unattributable, so they are ignored rather than trusted (fail-open: no demote, one normal startup — same as missing stats). `Name` is `omitempty` with no version bump, so downgraded builds still read migrated files | Safe (tested) |

## Verification

- Root module `go test ./...` green; `cd desktop && go test ./...` green; `go vet` and `gofmt` clean on all touched packages; `go test -race ./internal/autoresearch` green; `./scripts/cache-guard.sh` passes.
- New regression tests per finding: long-prefix and CJK fingerprint distinction (legacy slug collision independently proven), legacy fingerprint migration, tail-read/full-scan equivalence across a >64KiB multi-chunk log, deep-path slug bounding + determinism + rune-boundary safety, long memory-name persistence of distinct files, interleaved colliding servers accumulating independent stats windows and demoting independently, named legacy stats migration with history intact, and nameless legacy collisions demoting nobody.

## Notes

- No provider-visible behavior change: filename generation, local log reads, and local telemetry only. Prompts, tool schemas, contract formats, and serialization are untouched.
- Also audited but deliberately unchanged: autoresearch task directory names (timestamp-prefixed + existence check), plugin schema cache (SpecHash-guarded), session recovery filenames, MemoryCompiler trace caps, guardian transcript caps.

Cache-impact: none - only local filename generation, log tail-reads, and telemetry ownership checks changed; no prompt construction, tool schema, serialization, or memory-prefix content is affected (memory index/body text is unchanged; only the on-disk file stem for previously-uncreatable long names changes).
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) passes on this head.
System-prompt-review: Maintainer reviewed and approved the memory-store change before publication. The MEMORY.md index and memory body text that load into the cached prefix are byte-identical for every name that could previously be saved; only the file stem of names that previously failed with ENAMETOOLONG changes.
