### PR TITLE
Fix TUI session recovery lease tracking / 修复 TUI 会话恢复 lease 跟随

### DIFF
--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -12,6 +12,7 @@ import (
 
 func (m *chatTUI) showBranchTree() {
 	branches, err := m.ctrl.Branches()
+	m.followSessionLease()
 	if err != nil {
 		m.notice("tree: " + err.Error())
 		return
@@ -71,6 +72,7 @@ func (m *chatTUI) runBranchCommand(input string) {
 		return
 	} else if fromTurn {
 		if _, err := m.ctrl.ForkNamed(n-1, name); err != nil {
+			m.followSessionLease()
 			return
 		}
 		m.followSessionLease()
@@ -78,6 +80,7 @@ func (m *chatTUI) runBranchCommand(input string) {
 		return
 	} else {
 		if _, err := m.ctrl.Branch(name); err != nil {
+			m.followSessionLease()
 			return
 		}
 		m.followSessionLease()
@@ -96,12 +99,15 @@ func (m *chatTUI) runSwitchCommand(input string) {
 	// failures fall through to SwitchBranch, which reports them as before.
 	if m.leases != nil {
 		if branches, err := m.ctrl.Branches(); err == nil {
+			m.followSessionLease()
 			if match, err := control.ResolveBranchRef(branches, ref); err == nil {
 				if err := m.rebindSessionLease(match.Path); err != nil {
 					m.notice("switch: " + sessionLeaseHeldNotice(err))
 					return
 				}
 			}
+		} else {
+			m.followSessionLease()
 		}
 	}
 	if _, err := m.ctrl.SwitchBranch(ref); err != nil {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -365,6 +365,11 @@ const resetMouseTracking = ansi.ResetModeMouseX10 +
 // snapshots on success.
 type compactDoneMsg struct{ err error }
 
+// tuiShutdownMsg asks the live TUI model to persist its current controller and
+// quit. It is injected from the signal handler so shutdown does not snapshot a
+// stale controller captured before an in-TUI rebuild.
+type tuiShutdownMsg struct{}
+
 // elapsedTickMsg fires once a second while a turn runs, driving the "thinking
 // Ns" counter in the status line.
 type elapsedTickMsg struct{}
@@ -1364,7 +1369,15 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashCompactFailed, msg.err))
 		} else {
 			_ = m.ctrl.Snapshot()
+			m.followSessionLease()
 		}
+
+	case tuiShutdownMsg:
+		if m.ctrl != nil {
+			_ = m.ctrl.Snapshot()
+			m.followSessionLease()
+		}
+		return m, tea.Quit
 
 	case modelSwitchMsg:
 		m.modelSwitchPending = false

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1384,7 +1384,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingModelSwitch = nil
 		if msg.err != nil {
 			m.notice("model: " + msg.err.Error())
-			// Build failed — no old controller to retire.
+			// Build failed — no old controller to retire. The kept controller
+			// may still have been retargeted to a recovery branch by the
+			// pre-switch snapshot, so the lease must follow it.
+			m.followSessionLease()
 		} else {
 			m.ctrl = msg.ctrl
 			m.label = msg.label

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -796,8 +796,7 @@ func chatREPL(args []string) int {
 	signal.Notify(hangup, syscall.SIGHUP, syscall.SIGTERM)
 	go func() {
 		for range hangup {
-			_ = ctrl.Snapshot()
-			p.Quit()
+			p.Send(tuiShutdownMsg{})
 		}
 	}()
 	final, runErr := p.Run()

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -262,6 +262,9 @@ func (m *chatTUI) branchArgItems(val string) ([]compItem, int, bool) {
 		return nil, from, true
 	}
 	branches, err := m.ctrl.Branches()
+	// Branches snapshots first, which can retarget the controller to a
+	// recovery branch; keep the lease on whatever the controller now owns.
+	m.followSessionLease()
 	if err != nil {
 		return nil, from, true
 	}

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -90,6 +90,14 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 	// controller back to the original file, re-conflicting on every later save.
 	carried := m.ctrl.History()
 	prevPath := m.ctrl.SessionPath()
+	// Move the lease before the rebuilt controller binds prevPath for writing
+	// (AdoptHistory resumes there): after a snapshot retarget the lease still
+	// guards the old path, and the async build must not open an unguarded
+	// writer on the recovery branch.
+	if err := m.rebindSessionLease(prevPath); err != nil {
+		m.notice("effort: " + sessionLeaseHeldNotice(err))
+		return nil
+	}
 	oldCtrl := m.ctrl
 	build := m.buildController
 	m.modelSwitchPending = true

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -46,6 +46,14 @@ func (m *chatTUI) runModelSubcommand(input string) {
 	// controller back to the original file, re-conflicting on every later save.
 	carried := m.ctrl.History()
 	prevPath := m.ctrl.SessionPath()
+	// Move the lease before the rebuilt controller binds prevPath for writing
+	// (AdoptHistory resumes there): after a snapshot retarget the lease still
+	// guards the old path, and the async build must not open an unguarded
+	// writer on the recovery branch.
+	if err := m.rebindSessionLease(prevPath); err != nil {
+		m.notice("model: " + sessionLeaseHeldNotice(err))
+		return
+	}
 	m.notice(fmt.Sprintf(i18n.M.ModelSwitchingFmt, ref))
 
 	// Capture old controller for cleanup after the async build succeeds.

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -68,6 +68,7 @@ func (m *chatTUI) runResumeCommand(input string) {
 	// Snapshot before moving the lease: the outgoing session must be written
 	// while this process still owns it.
 	_ = m.ctrl.Snapshot()
+	m.followSessionLease()
 	if err := m.rebindSessionLease(target.Path); err != nil {
 		m.notice("resume: " + sessionLeaseHeldNotice(err))
 		return

--- a/internal/cli/resume_picker.go
+++ b/internal/cli/resume_picker.go
@@ -90,6 +90,7 @@ func (m chatTUI) applyResumePick() (tea.Model, tea.Cmd) {
 	// Snapshot before moving the lease: the outgoing session must be written
 	// while this process still owns it.
 	_ = m.ctrl.Snapshot()
+	m.followSessionLease()
 	if err := m.rebindSessionLease(target.Path); err != nil {
 		m.notice("resume: " + sessionLeaseHeldNotice(err))
 		return m, nil

--- a/internal/cli/skill_hooks.go
+++ b/internal/cli/skill_hooks.go
@@ -174,11 +174,14 @@ func (m *chatTUI) scheduleSkillSessionRefresh(reason, notice string) bool {
 		m.notice("cannot refresh skills while a turn is running")
 		return false
 	}
-	carried := m.ctrl.History()
-	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {
 		slog.Warn(reason+": snapshot failed", "err", err)
 	}
+	// Snapshot can retarget the controller to a recovery branch. Carry the
+	// post-snapshot path so the rebuild does not bind recovered history back to
+	// the stale original transcript.
+	carried := m.ctrl.History()
+	prevPath := m.ctrl.SessionPath()
 	if notice != "" {
 		m.notice(notice)
 	}

--- a/internal/cli/skill_hooks.go
+++ b/internal/cli/skill_hooks.go
@@ -182,6 +182,14 @@ func (m *chatTUI) scheduleSkillSessionRefresh(reason, notice string) bool {
 	// the stale original transcript.
 	carried := m.ctrl.History()
 	prevPath := m.ctrl.SessionPath()
+	// Move the lease before the rebuilt controller binds prevPath for writing
+	// (AdoptHistory resumes there): after a snapshot retarget the lease still
+	// guards the old path, and the async build must not open an unguarded
+	// writer on the recovery branch.
+	if err := m.rebindSessionLease(prevPath); err != nil {
+		m.notice(reason + ": " + sessionLeaseHeldNotice(err))
+		return false
+	}
 	if notice != "" {
 		m.notice(notice)
 	}

--- a/internal/cli/switch_recovery_test.go
+++ b/internal/cli/switch_recovery_test.go
@@ -263,6 +263,71 @@ func TestShutdownMessageSnapshotsCurrentController(t *testing.T) {
 	}
 }
 
+// TestBranchCompletionKeepsLeaseOnRecoveryPathAfterSnapshotConflict covers the
+// /switch tab-completion path: listing branches snapshots the session, which
+// can retarget the controller to a recovery branch even though no switch runs.
+func TestBranchCompletionKeepsLeaseOnRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "completion-active-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+
+	if _, _, ok := m.branchArgItems("/switch "); !ok {
+		t.Fatal("branchArgItems did not handle /switch completion")
+	}
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after completion snapshot = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after completion snapshot = %q, want recovery path %q", got, want)
+	}
+}
+
+// TestModelSwitchFailureKeepsLeaseOnRecoveryPathAfterSnapshotConflict covers
+// the rebuild-failure branch: the pre-switch snapshot can retarget the kept
+// controller to a recovery branch, and a failed build must not leave the lease
+// on the stale original path.
+func TestModelSwitchFailureKeepsLeaseOnRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	isolateUserConfig(t)
+	dir := t.TempDir()
+	active := filepath.Join(dir, "model-switch-failure-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.modelRef = "old/old-model"
+	m.buildController = func(string, []provider.Message, string) (*control.Controller, error) {
+		return nil, fmt.Errorf("build failed")
+	}
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+
+	m.runModelSubcommand("/model deepseek-flash/deepseek-v4-flash")
+	if m.pendingModelSwitch == nil {
+		t.Fatal("runModelSubcommand did not queue a model switch")
+	}
+	next, _ := m.Update(m.pendingModelSwitch())
+	m = next.(chatTUI)
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after failed switch = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after failed switch = %q, want recovery path %q", got, want)
+	}
+}
+
 func resumeIndexForPath(t *testing.T, dir, path string) int {
 	t.Helper()
 	for i, session := range recentSessions(dir) {

--- a/internal/cli/switch_recovery_test.go
+++ b/internal/cli/switch_recovery_test.go
@@ -328,6 +328,110 @@ func TestModelSwitchFailureKeepsLeaseOnRecoveryPathAfterSnapshotConflict(t *test
 	}
 }
 
+// TestModelSwitchMovesLeaseToRecoveryPathBeforeRebuild pins the lease-before-
+// bind order: the rebuilt controller resumes prevPath for writing inside
+// buildController, so the lease must already guard the retargeted path when
+// the build starts, not only after modelSwitchMsg lands.
+func TestModelSwitchMovesLeaseToRecoveryPathBeforeRebuild(t *testing.T) {
+	isolateUserConfig(t)
+	dir := t.TempDir()
+	active := filepath.Join(dir, "model-switch-lease-order.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.modelRef = "old/old-model"
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+	var heldAtBuild string
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
+		heldAtBuild = m.leases.HeldPath()
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	m.runModelSubcommand("/model deepseek-flash/deepseek-v4-flash")
+	if m.pendingModelSwitch == nil {
+		t.Fatal("runModelSubcommand did not queue a model switch")
+	}
+	m.pendingModelSwitch()
+
+	assertLeaseHeldRecoveryPathAtBuild(t, &m, active, heldAtBuild)
+}
+
+// TestEffortSwitchMovesLeaseToRecoveryPathBeforeRebuild covers the same
+// lease-before-bind order for the /effort rebuild path.
+func TestEffortSwitchMovesLeaseToRecoveryPathBeforeRebuild(t *testing.T) {
+	isolateUserConfig(t)
+	dir := t.TempDir()
+	active := filepath.Join(dir, "effort-switch-lease-order.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+	var heldAtBuild string
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
+		heldAtBuild = m.leases.HeldPath()
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	cmd := m.runEffortCommand("/effort max")
+	if cmd == nil {
+		t.Fatal("runEffortCommand did not queue a rebuild")
+	}
+	cmd()
+
+	assertLeaseHeldRecoveryPathAtBuild(t, &m, active, heldAtBuild)
+}
+
+// TestSkillRefreshMovesLeaseToRecoveryPathBeforeRebuild covers the same
+// lease-before-bind order for the TUI skill rebuild path.
+func TestSkillRefreshMovesLeaseToRecoveryPathBeforeRebuild(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "skill-refresh-lease-order.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+	var heldAtBuild string
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
+		heldAtBuild = m.leases.HeldPath()
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	if !m.scheduleSkillSessionRefresh("skill refresh", "") {
+		t.Fatal("scheduleSkillSessionRefresh did not queue a rebuild")
+	}
+	m.pendingModelSwitch()
+
+	assertLeaseHeldRecoveryPathAtBuild(t, &m, active, heldAtBuild)
+}
+
+// assertLeaseHeldRecoveryPathAtBuild verifies that the snapshot retargeted the
+// controller to a recovery branch and that the lease already guarded that
+// branch when buildController ran.
+func assertLeaseHeldRecoveryPathAtBuild(t *testing.T, m *chatTUI, active, heldAtBuild string) {
+	t.Helper()
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after switch snapshot = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if want := agent.CanonicalSessionPath(recoveryPath); heldAtBuild != want {
+		t.Fatalf("lease when build started = %q, want recovery path %q", heldAtBuild, want)
+	}
+}
+
 func resumeIndexForPath(t *testing.T, dir, path string) int {
 	t.Helper()
 	for i, session := range recentSessions(dir) {

--- a/internal/cli/switch_recovery_test.go
+++ b/internal/cli/switch_recovery_test.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
@@ -97,4 +100,176 @@ func TestEffortSwitchCarriesRecoveryPathAfterSnapshotConflict(t *testing.T) {
 	if got := m.ctrl.SessionPath(); got != gotResumePath {
 		t.Fatalf("old controller session path = %q, want recovery path %q", got, gotResumePath)
 	}
+}
+
+// TestSkillRefreshCarriesRecoveryPathAfterSnapshotConflict covers the TUI skill
+// rebuild path, which also snapshots then rebuilds the controller in place.
+func TestSkillRefreshCarriesRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "skill-refresh-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, originalPath)
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+	var gotResumePath string
+	m.buildController = func(_ string, _ []provider.Message, resumePath string) (*control.Controller, error) {
+		gotResumePath = resumePath
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	if !m.scheduleSkillSessionRefresh("skill refresh", "") {
+		t.Fatal("scheduleSkillSessionRefresh did not queue a rebuild")
+	}
+	m.pendingModelSwitch()
+
+	if gotResumePath == "" || gotResumePath == originalPath || !strings.Contains(filepath.Base(gotResumePath), "-recovery-") {
+		t.Fatalf("resume path = %q, want recovery path distinct from %q", gotResumePath, originalPath)
+	}
+	if got := m.ctrl.SessionPath(); got != gotResumePath {
+		t.Fatalf("old controller session path = %q, want recovery path %q", got, gotResumePath)
+	}
+}
+
+func TestResumeCommandKeepsLeaseOnRecoveryPathWhenTargetHeld(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "resume-active-conflict.jsonl")
+	target := filepath.Join(dir, "resume-target.jsonl")
+	saveTestSession(t, target, "target session")
+
+	m := newTestChatTUI()
+	m.width = 80
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+	holdSessionLease(t, target)
+
+	m.runResumeCommand(fmt.Sprintf("/resume %d", resumeIndexForPath(t, dir, target)))
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || recoveryPath == target || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after refused resume = %q, want recovery path distinct from active %q and target %q", recoveryPath, active, target)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after refused resume = %q, want recovery path %q", got, want)
+	}
+}
+
+func TestResumePickerKeepsLeaseOnRecoveryPathWhenTargetHeld(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "resume-picker-active-conflict.jsonl")
+	target := filepath.Join(dir, "resume-picker-target.jsonl")
+	saveTestSession(t, target, "target session")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.resumePick = &resumePicker{sessions: []agent.SessionInfo{{Path: target}}, sel: 0}
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+	holdSessionLease(t, target)
+
+	next, _ := m.applyResumePick()
+	m = next.(chatTUI)
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || recoveryPath == target || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after refused picker resume = %q, want recovery path distinct from active %q and target %q", recoveryPath, active, target)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after refused picker resume = %q, want recovery path %q", got, want)
+	}
+}
+
+func TestCompactDoneKeepsLeaseOnRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "compact-active-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+
+	next, _ := m.Update(compactDoneMsg{})
+	m = next.(chatTUI)
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after compact snapshot = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after compact snapshot = %q, want recovery path %q", got, want)
+	}
+}
+
+func TestBranchTreeKeepsLeaseOnRecoveryPathAfterSnapshotConflict(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "tree-active-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.width = 80
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+
+	m.showBranchTree()
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after tree snapshot = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after tree snapshot = %q, want recovery path %q", got, want)
+	}
+}
+
+func TestShutdownMessageSnapshotsCurrentController(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "shutdown-active-conflict.jsonl")
+
+	m := newTestChatTUI()
+	m.ctrl = divergedSessionController(t, dir, active)
+	m.leases = control.NewSessionLeaseKeeper()
+	t.Cleanup(m.leases.Release)
+	if err := m.leases.Rebind(active); err != nil {
+		t.Fatalf("seed active lease: %v", err)
+	}
+
+	next, cmd := m.Update(tuiShutdownMsg{})
+	m = next.(chatTUI)
+	if cmd == nil {
+		t.Fatal("shutdown message should return tea.Quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("shutdown command = %T, want tea.QuitMsg", msg)
+	}
+
+	recoveryPath := m.ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == active || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("session path after shutdown snapshot = %q, want recovery path distinct from active %q", recoveryPath, active)
+	}
+	if got, want := m.leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after shutdown snapshot = %q, want recovery path %q", got, want)
+	}
+}
+
+func resumeIndexForPath(t *testing.T, dir, path string) int {
+	t.Helper()
+	for i, session := range recentSessions(dir) {
+		if session.Path == path {
+			return i + 1
+		}
+	}
+	t.Fatalf("session %q not found in recent sessions", path)
+	return 0
 }


### PR DESCRIPTION
## Summary
- rebuild `/skills refresh` from the post-snapshot history and session path so a snapshot recovery branch is not rebound back to the stale transcript
- keep the TUI session lease aligned after snapshot-capable `/resume`, resume picker, `/compact`, `/tree`, `/branch`, and `/switch` paths
- route SIGHUP/SIGTERM through the live TUI model so shutdown snapshots the current controller after in-TUI rebuilds
- follow the lease after `/switch` tab-completion lists branches (the listing snapshots and can retarget to a recovery branch), and after a failed model/effort/skill rebuild whose pre-switch snapshot already retargeted the kept controller
- move the lease onto the post-snapshot path before the `/model`, `/effort`, and skills-refresh rebuild fires: `AdoptHistory` binds that path for writing inside the async build, so the lease must lead the bind (matching the `/resume` and `/switch` order), and a refused lease now aborts the switch

Cache-impact: none - CLI TUI session ownership only; no prompt construction, tool schema, or provider serialization changes.
Cache-guard: `go test ./internal/cli` covers the changed TUI recovery paths; `git diff --check` passed.

## Compatibility
| Area | Old-data behavior | Conclusion |
| --- | --- | --- |
| Session transcript format | No file format or schema changes | Backward compatible |
| Session lease sidecars | Existing lease files remain readable; the TUI only rebinds to the controller's current recovery path after snapshot retargeting | Backward compatible |
| Provider prompts and tool schemas | No prompt construction, tool schema, or provider serialization changes | No cache impact expected |

## Testing
- `go test ./internal/cli`
- `git diff --check`
- `cd desktop && go test . -run 'TestDesktopSnapshotConflictRecovery(Update|Requires)|TestSet(Model|Effort)ForTab(ContinuesRecoveryPathAfterSnapshotConflict|ReanchorsDepthCapRecoveryBranch)|TestSnapshotConflictRecoveryCarriesTelemetryToFork'`
- `cd desktop && go test . -run 'Test(SetModelForTab|SetEffortForTab|SetTokenMode)(LeaseHeld|Reuses|Continues|Reanchors)|TestResumeSessionForTab|TestCloseTab|TestDesktopSnapshotConflictRecovery'`
