### PR TITLE
fix(frontend): Reduce startup performance lag false positives

### DIFF
--- a/desktop/frontend/src/__tests__/bridge-breadcrumbs.test.ts
+++ b/desktop/frontend/src/__tests__/bridge-breadcrumbs.test.ts
@@ -1,0 +1,85 @@
+// Run: tsx src/__tests__/bridge-breadcrumbs.test.ts
+
+import { snapshotBreadcrumbs } from "../lib/breadcrumbs";
+import { app } from "../lib/bridge";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function ensureWindow() {
+  if (typeof window === "undefined") {
+    (globalThis as Record<string, unknown>).window = {} as Window & typeof globalThis;
+  }
+}
+
+function newBreadcrumbMessages(since: number, cat: string): string[] {
+  return snapshotBreadcrumbs()
+    .slice(since)
+    .filter((crumb) => crumb.cat === cat)
+    .map((crumb) => crumb.msg);
+}
+
+console.log("\nbridge breadcrumbs");
+
+const previousPerformance = (globalThis as { performance?: Performance }).performance;
+let now = 0;
+(globalThis as Record<string, unknown>).performance = { now: () => now };
+
+ensureWindow();
+const previousGo = window.go;
+window.go = {
+  main: {
+    App: {
+      async IsMainWindowMaximised() {
+        now = 42;
+        return true;
+      },
+      async CheckUpdate() {
+        now = 125;
+        throw new Error("offline");
+      },
+    } as never,
+  },
+};
+
+const successStart = snapshotBreadcrumbs().length;
+now = 10;
+await app.IsMainWindowMaximised();
+const successBridge = newBreadcrumbMessages(successStart, "bridge");
+ok(
+  successBridge.includes("window IsMainWindowMaximised") &&
+    successBridge.includes("window IsMainWindowMaximised done ms=32"),
+  "records bridge start and completion timing breadcrumbs",
+);
+
+const errorStart = snapshotBreadcrumbs().length;
+now = 100;
+try {
+  await app.CheckUpdate();
+} catch {
+  // Expected: this branch verifies the breadcrumb emitted by the proxy rejection path.
+}
+const errorBridge = newBreadcrumbMessages(errorStart, "bridge");
+const bridgeErrors = newBreadcrumbMessages(errorStart, "bridge.error");
+ok(errorBridge.includes("update CheckUpdate"), "records bridge start breadcrumb before failed calls");
+ok(bridgeErrors.includes("CheckUpdate ms=25"), "records bridge failure timing breadcrumbs");
+
+window.go = previousGo;
+if (previousPerformance) {
+  (globalThis as Record<string, unknown>).performance = previousPerformance;
+} else {
+  delete (globalThis as { performance?: Performance }).performance;
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -5,6 +5,7 @@ import {
   buildPerformancePayload,
   formatPerformanceContext,
   globalCrashReportReason,
+  installPerformancePressureMonitor,
   normalizeCrashError,
   parseReportedPerf,
   performanceLabelForReason,
@@ -150,6 +151,42 @@ eq(shouldPromptForPerformanceLabel(true, 11 * 60_000, false), false, "suppresses
 eq(shouldPromptForPerformanceLabel(false, 5 * 60_000, false), false, "respects the prompt cooldown window");
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, true), false, "never prompts while the window is hidden");
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "never prompts while unfocused");
+
+{
+  let interval: (() => void) | undefined;
+  let now = 0;
+  let promptPainted = false;
+  const previousWindow = (globalThis as any).window;
+  const previousDocument = (globalThis as any).document;
+  const previousPerformance = (globalThis as any).performance;
+  const previousPerformanceObserver = (globalThis as any).PerformanceObserver;
+  (globalThis as any).performance = { now: () => now };
+  (globalThis as any).window = {
+    runtime: {},
+    setInterval: (cb: () => void) => {
+      interval = cb;
+      return 1;
+    },
+  };
+  (globalThis as any).document = {
+    visibilityState: "visible",
+    hasFocus: () => true,
+    addEventListener: () => {},
+    getElementById: () => {
+      promptPainted = true;
+      return null;
+    },
+  };
+  (globalThis as any).PerformanceObserver = undefined;
+  installPerformancePressureMonitor();
+  now = 26_000;
+  interval?.();
+  eq(promptPainted, false, "first post-grace event-loop tick primes without reporting startup backlog");
+  (globalThis as any).window = previousWindow;
+  (globalThis as any).document = previousDocument;
+  (globalThis as any).performance = previousPerformance;
+  (globalThis as any).PerformanceObserver = previousPerformanceObserver;
+}
 
 const reportedPerf = serializeReportedPerf(new Set(["performance.lag"]), "abc123");
 eq([...parseReportedPerf(reportedPerf, "abc123")], ["performance.lag"], "round-trips reported labels for the same build");

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -637,6 +637,11 @@ function bridgeBreadcrumb(method: string): string {
   return "";
 }
 
+function elapsedMs(startedAt: number): number {
+  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+  return Math.max(0, Math.round(now - startedAt));
+}
+
 export const app: AppBindings = new Proxy({} as AppBindings, {
   get(_t, prop) {
     const target = realApp() ?? getMock();
@@ -645,18 +650,26 @@ export const app: AppBindings = new Proxy({} as AppBindings, {
     return (...args: unknown[]) => {
       const method = String(prop);
       const crumb = bridgeBreadcrumb(method);
+      const startedAt = crumb ? (typeof performance !== "undefined" ? performance.now() : Date.now()) : 0;
       if (crumb) addBreadcrumb("bridge", crumb);
       try {
         const result = (v as (...a: unknown[]) => unknown).apply(target, args);
         if (result && typeof (result as Promise<unknown>).then === "function") {
-          return (result as Promise<unknown>).catch((err) => {
-            if (crumb) addBreadcrumb("bridge.error", method);
-            throw err;
-          });
+          return (result as Promise<unknown>).then(
+            (value) => {
+              if (crumb) addBreadcrumb("bridge", `${crumb} done ms=${elapsedMs(startedAt)}`);
+              return value;
+            },
+            (err) => {
+              if (crumb) addBreadcrumb("bridge.error", `${method} ms=${elapsedMs(startedAt)}`);
+              throw err;
+            },
+          );
         }
+        if (crumb) addBreadcrumb("bridge", `${crumb} done ms=${elapsedMs(startedAt)}`);
         return result;
       } catch (err) {
-        if (crumb) addBreadcrumb("bridge.error", method);
+        if (crumb) addBreadcrumb("bridge.error", `${method} ms=${elapsedMs(startedAt)}`);
         throw err;
       }
     };

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -635,6 +635,7 @@ export function installPerformancePressureMonitor() {
   const isFocused = () => typeof document === "undefined" || document.hasFocus?.() !== false;
   let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
   let expected = performance.now() + 1000;
+  let eventLoopLagPrimed = false;
 
   const pastGrace = () => performance.now() >= graceUntil;
   const inspectLongTasks = () => {
@@ -651,6 +652,7 @@ export function installPerformancePressureMonitor() {
       longTasks.length = 0;
       lagSamples.length = 0;
       expected = performance.now() + 1000;
+      eventLoopLagPrimed = false;
       if (!isHidden()) visibleSince = performance.now();
     });
   }
@@ -673,9 +675,17 @@ export function installPerformancePressureMonitor() {
 
   window.setInterval(() => {
     const now = performance.now();
+    if (!pastGrace()) {
+      expected = now + 1000;
+      return;
+    }
+    if (!eventLoopLagPrimed) {
+      expected = now + 1000;
+      eventLoopLagPrimed = true;
+      return;
+    }
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
-    if (!pastGrace()) return;
     if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused())) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();


### PR DESCRIPTION
## Summary

- reset the event-loop lag baseline during startup grace and prime the first post-grace tick so startup timer backlog does not immediately surface as `performance.lag`
- add completion/failure timing to bridge breadcrumbs so future performance reports can identify slow Wails calls such as update or window-state checks
- cover startup backlog handling and bridge timing breadcrumb text in focused frontend tests

## Verification

- `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/bridge-breadcrumbs.test.ts`
- `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/crash-reporting.test.ts`
- `corepack pnpm --dir desktop/frontend exec tsc --noEmit`
- `corepack pnpm --dir desktop/frontend exec tsc --noEmit -p tsconfig.test.json`
- `git diff --check`

## Cache impact

Cache-impact: none; frontend performance telemetry and breadcrumbs only.
Cache-guard: `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/bridge-breadcrumbs.test.ts`; `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/crash-reporting.test.ts`
System-prompt-review: N/A