### PR TITLE
Redact secret-bearing tool output / 脱敏工具输出中的密钥

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
 )
@@ -2398,9 +2399,10 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	callID := call.ID
 	cctx = tool.WithProgress(cctx, func(chunk string) {
-		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: chunk}})
+		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: secrets.Redact(chunk)}})
 	})
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
+	result = secrets.Redact(result)
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
 			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly())

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2399,10 +2399,10 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	callID := call.ID
 	cctx = tool.WithProgress(cctx, func(chunk string) {
-		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: secrets.Redact(chunk)}})
+		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: secrets.RedactToolOutput(chunk)}})
 	})
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
-	result = secrets.Redact(result)
+	result = secrets.RedactToolOutput(result)
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
 			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly())

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -202,6 +202,15 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	// stalest capture written last would then read the newer transcript it
 	// lost the race to as a bogus stale-prefix conflict.
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
+	// Durable transcripts are always redacted, independent of the live
+	// [secrets] redact_tool_output toggle. Digest consistency holds because
+	// Redact is deterministic and idempotent (see secrets.Redact): a loaded
+	// session's messages are already redacted, so re-redacting them here is a
+	// byte-for-byte no-op and the snapshot keeps its prefix relationship to
+	// the on-disk transcript — the same digest/prefix machinery that guards
+	// against bogus stale-prefix conflicts (#6083) sees identical bytes. The
+	// persisted baseline (markPersisted) is likewise recorded over the
+	// redacted form, matching what LoadSession will digest back.
 	msgs = secrets.RedactMessages(msgs)
 	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
 	if err != nil {
@@ -543,6 +552,11 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 		return RecoveryBranchInfo{}, fmt.Errorf("empty original session path")
 	}
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
+	// Same redaction contract as save(): recovery branches are durable
+	// transcripts too, and the coverage checks below compare against on-disk
+	// content that save() already redacted — comparing a raw snapshot against
+	// it would misread pure coverage as divergence and fork a bogus branch.
+	msgs = secrets.RedactMessages(msgs)
 	preview, turns := SessionPreviewFromMessages(msgs)
 	if turns == 0 {
 		return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -19,6 +19,7 @@ import (
 
 	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
+	"reasonix/internal/secrets"
 	"reasonix/internal/store"
 )
 
@@ -201,6 +202,7 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	// stalest capture written last would then read the newer transcript it
 	// lost the race to as a bogus stale-prefix conflict.
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
+	msgs = secrets.RedactMessages(msgs)
 	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
 	if err != nil {
 		return err

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -95,6 +95,64 @@ func TestSaveRedactsSecretsOnDisk(t *testing.T) {
 	}
 }
 
+// TestSaveRedactionKeepsSnapshotBaselineStable is the digest-consistency
+// contract behind redact-on-save: because Redact is idempotent, a loaded
+// (already-redacted) transcript re-saves as the exact same bytes, so
+// SaveSnapshot must take the up-to-date path — no rewrite, no revision bump,
+// and above all no bogus snapshot conflict / recovery fork (#6083's failure
+// shape). Appending after the resave must land as a plain append.
+func TestSaveRedactionKeepsSnapshotBaselineStable(t *testing.T) {
+	secret := "sk-real-secret-value-123456"
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
+	s.Add(provider.Message{
+		Role:       provider.RoleTool,
+		Name:       "bash",
+		ToolCallID: "call_1",
+		Content:    "DEEPSEEK_API_KEY=" + secret + "\n",
+	})
+
+	path := filepath.Join(t.TempDir(), "stable.jsonl")
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("first SaveSnapshot: %v", err)
+	}
+	rev1, _, err := sessionContentRevision(path)
+	if err != nil {
+		t.Fatalf("read revision: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	// Re-saving the loaded transcript re-runs RedactMessages over content that
+	// is already masked; idempotence means identical bytes and the up-to-date
+	// skip, not a conflict or a revision bump.
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("resave of loaded redacted session: %v", err)
+	}
+	rev2, _, err := sessionContentRevision(path)
+	if err != nil {
+		t.Fatalf("read revision after resave: %v", err)
+	}
+	if rev1 != rev2 {
+		t.Fatalf("no-op resave bumped revision %d -> %d; redaction broke digest stability", rev1, rev2)
+	}
+
+	// A continued conversation still append-saves cleanly on top.
+	loaded.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := loaded.SaveSnapshot(path); err != nil {
+		t.Fatalf("append snapshot after redacted round-trip: %v", err)
+	}
+	reloaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := len(reloaded.Messages); got != 4 {
+		t.Fatalf("message count after append = %d, want 4", got)
+	}
+}
+
 func TestSaveLoadLargeMessage(t *testing.T) {
 	s := NewSession("sys")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "run it"})

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -68,6 +68,33 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSaveRedactsSecretsOnDisk(t *testing.T) {
+	secret := "sk-real-secret-value-123456"
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
+	s.Add(provider.Message{
+		Role:       provider.RoleTool,
+		Name:       "bash",
+		ToolCallID: "call_1",
+		Content:    "DEEPSEEK_API_KEY=" + secret + "\n",
+	})
+
+	path := filepath.Join(t.TempDir(), "redacted.jsonl")
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved session: %v", err)
+	}
+	if strings.Contains(string(body), secret) {
+		t.Fatalf("session persisted raw secret:\n%s", body)
+	}
+	if !strings.Contains(string(body), "DEEPSEEK_API_KEY=sk-rea") {
+		t.Fatalf("session did not persist a masked credential marker:\n%s", body)
+	}
+}
+
 func TestSaveLoadLargeMessage(t *testing.T) {
 	s := NewSession("sys")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "run it"})

--- a/internal/agent/secret_redaction_test.go
+++ b/internal/agent/secret_redaction_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type secretOutputTool struct{}
+
+func (secretOutputTool) Name() string            { return "secret_output" }
+func (secretOutputTool) Description() string     { return "" }
+func (secretOutputTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (secretOutputTool) ReadOnly() bool          { return true }
+func (secretOutputTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "DEEPSEEK_API_KEY=sk-real-secret-value-123456\n", nil
+}
+
+func TestExecuteOneRedactsToolResultBeforeHistory(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(secretOutputTool{})
+	a := &Agent{tools: reg, session: NewSession("")}
+
+	outcome := a.executeOne(context.Background(), provider.ToolCall{ID: "call_1", Name: "secret_output", Arguments: `{}`})
+	if strings.Contains(outcome.output, "sk-real-secret-value-123456") {
+		t.Fatalf("tool outcome leaked raw secret:\n%s", outcome.output)
+	}
+	if !strings.Contains(outcome.output, "DEEPSEEK_API_KEY=sk-rea") {
+		t.Fatalf("tool outcome missing masked marker:\n%s", outcome.output)
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -44,6 +44,7 @@ import (
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 	"reasonix/internal/tool/builtin"
@@ -146,6 +147,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Arm the credential-protection layers from the user-global [secrets]
+	// section before any tool, hook, or plugin subprocess can spawn. Package
+	// globals are correct here because [secrets] is user-global (project
+	// reasonix.toml cannot override it), so concurrent workspaces agree.
+	secrets.SetRedactToolOutput(cfg.SecretsRedactToolOutput())
+	secrets.SetFilterSubprocessEnv(cfg.Secrets.FilterSubprocessEnv)
+	secrets.SetProtectSensitiveFiles(cfg.Secrets.ProtectSensitiveFiles)
 	modelName := opts.Model
 	if modelName == "" {
 		modelName = cfg.DefaultModel

--- a/internal/bot/project_index.go
+++ b/internal/bot/project_index.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/secrets"
 )
 
 const (
@@ -616,6 +617,7 @@ func searchBotProjectsWithRG(ctx context.Context, rg string, projects []botProje
 	}
 	args = append(args, roots...)
 	cmd := exec.CommandContext(ctx, rg, args...)
+	cmd.Env = secrets.ProcessEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -14,6 +14,9 @@ func doctorCommand(args []string, version string) int {
 	if len(args) > 0 && args[0] == "session" {
 		return doctorSessionCommand(args[1:], version)
 	}
+	if len(args) > 0 && args[0] == "redact-sessions" {
+		return doctorRedactSessionsCommand(args[1:])
+	}
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonOut := fs.Bool("json", false, "print diagnostics as JSON")
 	if err := fs.Parse(args); err != nil {
@@ -31,6 +34,68 @@ func doctorCommand(args []string, version string) int {
 		return 0
 	}
 	fmt.Print(doctor.RenderText(report))
+	return 0
+}
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	return strings.Join(*f, string(os.PathListSeparator))
+}
+
+func (f *stringListFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("empty path")
+	}
+	*f = append(*f, value)
+	return nil
+}
+
+func doctorRedactSessionsCommand(args []string) int {
+	fs := flag.NewFlagSet("doctor redact-sessions", flag.ContinueOnError)
+	var dirs stringListFlag
+	dryRun := fs.Bool("dry-run", false, "show how many session files would be redacted without writing")
+	jsonOut := fs.Bool("json", false, "print result as JSON")
+	fs.Var(&dirs, "dir", "session directory to scan; repeat to scan multiple directories")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: reasonix doctor redact-sessions [--dry-run] [--json] [--dir PATH]")
+		return 2
+	}
+	res := doctor.RedactSessions(doctor.RedactSessionsOptions{
+		Dirs:   []string(dirs),
+		DryRun: *dryRun,
+	})
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(res); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	} else {
+		action := "redacted"
+		if *dryRun {
+			action = "would redact"
+		}
+		fmt.Fprintf(os.Stdout, "session secret cleanup %s %d/%d files", action, res.FilesChanged, res.FilesScanned)
+		if res.FilesSkipped > 0 {
+			fmt.Fprintf(os.Stdout, " (%d skipped: active lease held)", res.FilesSkipped)
+		}
+		fmt.Fprintln(os.Stdout)
+	}
+	for _, msg := range res.Errors {
+		fmt.Fprintln(os.Stderr, "warning:", msg)
+	}
+	if len(res.Errors) > 0 {
+		return 1
+	}
 	return 0
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -104,3 +104,28 @@ func TestDoctorSessionCommandOutEqualsForm(t *testing.T) {
 		t.Fatalf("empty --out= rc = %d, want usage error 2", rc)
 	}
 }
+
+func TestDoctorRedactSessionsCommand(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "sk-real-secret-value-123456"
+	path := filepath.Join(dir, "abc.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"tool","content":"DEEPSEEK_API_KEY=`+secret+`"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if rc := doctorCommand([]string{"redact-sessions", "--dir", dir}, "test-version"); rc != 0 {
+			t.Fatalf("doctor redact-sessions rc = %d, want 0", rc)
+		}
+	})
+	if !strings.Contains(out, "session secret cleanup redacted 1/1 files") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("doctor redact-sessions leaked secret:\n%s", data)
+	}
+}

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -13,6 +12,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/secrets"
 )
 
 const gitStatusTimeout = 700 * time.Millisecond
@@ -76,7 +77,7 @@ func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
-	cmd.Env = append(os.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	cmd.Env = append(secrets.ProcessEnv(), "GIT_OPTIONAL_LOCKS=0")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/config/ccswitch.go
+++ b/internal/config/ccswitch.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reasonix/internal/secrets"
 	"sort"
 	"strings"
 )
@@ -137,7 +138,9 @@ func loadCCSwitchMCPDB(path string) ([]PluginEntry, error) {
 		return nil, fmt.Errorf("cc-switch import: sqlite3 not found to read %s", path)
 	}
 	query := `SELECT id, name, server_config FROM mcp_servers WHERE enabled_codex = 1 ORDER BY name, id`
-	out, err := exec.Command(sqlite, "-readonly", "-json", path, query).Output()
+	cmd := exec.Command(sqlite, "-readonly", "-json", path, query)
+	cmd.Env = secrets.ProcessEnv()
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("cc-switch import: read %s: %w", path, err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,10 +59,39 @@ type Config struct {
 	LSP              LSPConfig           `toml:"lsp"`
 	Bot              BotConfig           `toml:"bot"`
 	Serve            ServeConfig         `toml:"serve"`
+	Secrets          SecretsConfig       `toml:"secrets"`
 
 	providerSources          map[string]providerSourceScope
 	shadowedProjectProviders []ProviderEntry
 	expansionEnv             map[string]string
+}
+
+// SecretsConfig controls the credential protection layers. It is a user-global
+// setting: project reasonix.toml values are ignored (see LoadForRoot), so a
+// cloned repository cannot silently switch off redaction or opt the user into
+// workflow-breaking protections.
+type SecretsConfig struct {
+	// RedactToolOutput masks credential-shaped values in tool output before it
+	// enters model context and UI events. Nil keeps the default enabled.
+	// Session transcripts and background-job artifacts on disk are always
+	// redacted, regardless of this switch.
+	RedactToolOutput *bool `toml:"redact_tool_output"`
+	// FilterSubprocessEnv strips credential-like environment variables
+	// (*_API_KEY, *TOKEN*, *SECRET*, ...) from tool subprocesses (bash, hooks,
+	// LSP, MCP stdio). Default off: it breaks token-based workflows such as
+	// `gh`, HTTPS `git push`, and `npm publish`.
+	FilterSubprocessEnv bool `toml:"filter_subprocess_env"`
+	// ProtectSensitiveFiles makes read/list/search tools treat credential
+	// paths (.env, .git-credentials, .netrc, *.pem/*.key/*.p12/*.pfx, ~/.ssh)
+	// as invisible. Default off: output redaction already masks the values,
+	// and hiding the files breaks legitimate "edit my .env" workflows.
+	ProtectSensitiveFiles bool `toml:"protect_sensitive_files"`
+}
+
+// SecretsRedactToolOutput reports whether live tool output redaction is
+// enabled (default true).
+func (c *Config) SecretsRedactToolOutput() bool {
+	return c == nil || c.Secrets.RedactToolOutput == nil || *c.Secrets.RedactToolOutput
 }
 
 type providerSourceScope string

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -48,6 +48,14 @@ func LoadForRoot(root string) (*Config, error) {
 	globalMaxSteps := cfg.Agent.MaxSteps
 	globalPlannerMaxSteps := cfg.Agent.PlannerMaxSteps
 	globalMemoryCompiler := cfg.Agent.MemoryCompiler
+	// Deep-copy: toml.DecodeFile writes through an existing *bool rather than
+	// replacing it, so a shallow struct copy would alias the pointer and the
+	// project merge below would mutate the captured global value in place.
+	globalSecrets := cfg.Secrets
+	if cfg.Secrets.RedactToolOutput != nil {
+		v := *cfg.Secrets.RedactToolOutput
+		globalSecrets.RedactToolOutput = &v
+	}
 
 	tomlSources = append(tomlSources, projectTOML)
 	if err := mergeRuntimeTOMLFile(cfg, projectTOML); err != nil {
@@ -59,6 +67,10 @@ func LoadForRoot(root string) (*Config, error) {
 	cfg.Agent.MaxSteps = globalMaxSteps
 	cfg.Agent.PlannerMaxSteps = globalPlannerMaxSteps
 	cfg.Agent.MemoryCompiler = globalMemoryCompiler
+	// Secret protection is a user-global security control: a cloned repo's
+	// reasonix.toml must not be able to disable redaction or flip on the
+	// workflow-breaking env/path protections.
+	cfg.Secrets = globalSecrets
 	// toml.DecodeFile replaces [[plugins]] wholesale, so cfg.Plugins now holds
 	// only the last file's. Re-merge by name across all sources (later wins) so a
 	// project reasonix.toml doesn't drop the global config's MCP servers.

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -618,6 +618,30 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("\n")
 	}
 
+	// [secrets] is user/global only: LoadForRoot discards project values, so
+	// the project scope never renders it. Rendering it here is what lets a
+	// user's saved toggles survive config rewrites (WriteFile re-renders the
+	// whole file from the struct).
+	if scope != RenderScopeProject {
+		b.WriteString("[secrets]   # credential protection; user/global only, ./reasonix.toml cannot override\n")
+		if c.Secrets.RedactToolOutput != nil {
+			fmt.Fprintf(&b, "redact_tool_output = %v   # mask secret-shaped values in tool output before model context/UI; transcripts and job artifacts are always redacted on disk\n", *c.Secrets.RedactToolOutput)
+		} else {
+			b.WriteString("# redact_tool_output = true   # default on; set false only if masking breaks fixture-heavy edit workflows\n")
+		}
+		if c.Secrets.FilterSubprocessEnv {
+			b.WriteString("filter_subprocess_env = true   # strip credential-named env vars from tool/hook/LSP/MCP subprocesses\n")
+		} else {
+			b.WriteString("# filter_subprocess_env = false   # opt-in; stripping tokens breaks gh, HTTPS git push, npm publish\n")
+		}
+		if c.Secrets.ProtectSensitiveFiles {
+			b.WriteString("protect_sensitive_files = true   # hide .env/.git-credentials/key files/~/.ssh from read tools\n")
+		} else {
+			b.WriteString("# protect_sensitive_files = false   # opt-in; values are already masked by redaction even when files stay readable\n")
+		}
+		b.WriteString("\n")
+	}
+
 	b.WriteString("# External MCP servers. type: \"stdio\" (default, a subprocess) | \"http\" | \"sse\".\n")
 	b.WriteString("# ${VAR} / ${VAR:-default} are expanded from the environment in command/args/env/url/headers.\n")
 	if len(c.Plugins) == 0 {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1236,3 +1236,40 @@ func TestMigrateLegacyIfNeededSkipsWhenIsolated(t *testing.T) {
 		t.Fatalf("MigrateLegacyIfNeeded() = %+v, want nil when isolated", res)
 	}
 }
+
+// TestProjectConfigCannotOverrideSecrets pins [secrets] as a user-global
+// security control: a cloned repository's reasonix.toml must not be able to
+// switch off tool-output redaction or opt the user into subprocess env
+// stripping / sensitive-path hiding.
+func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
+	isolateUserConfigHome(t)
+	t.Setenv("REASONIX_HOME", "")
+	globalDir := filepath.Dir(UserConfigPath())
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	globalTOML := "[secrets]\nredact_tool_output = true\nfilter_subprocess_env = false\nprotect_sensitive_files = false\n"
+	if err := os.WriteFile(filepath.Join(globalDir, "config.toml"), []byte(globalTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	project := t.TempDir()
+	projectTOML := "[secrets]\nredact_tool_output = false\nfilter_subprocess_env = true\nprotect_sensitive_files = true\n"
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(projectTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot() error = %v", err)
+	}
+	if !cfg.SecretsRedactToolOutput() {
+		t.Error("project reasonix.toml disabled redact_tool_output; [secrets] must stay user-global")
+	}
+	if cfg.Secrets.FilterSubprocessEnv {
+		t.Error("project reasonix.toml enabled filter_subprocess_env; [secrets] must stay user-global")
+	}
+	if cfg.Secrets.ProtectSensitiveFiles {
+		t.Error("project reasonix.toml enabled protect_sensitive_files; [secrets] must stay user-global")
+	}
+}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1273,3 +1273,41 @@ func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
 		t.Error("project reasonix.toml enabled protect_sensitive_files; [secrets] must stay user-global")
 	}
 }
+
+// TestRenderTOMLPersistsSecretsSection pins config-save round-tripping: the
+// renderer must emit [secrets] for the user scope or every WriteFile would
+// silently drop the user's security toggles.
+func TestRenderTOMLPersistsSecretsSection(t *testing.T) {
+	cfg := Default()
+	off := false
+	cfg.Secrets.RedactToolOutput = &off
+	cfg.Secrets.FilterSubprocessEnv = true
+	cfg.Secrets.ProtectSensitiveFiles = true
+
+	out := RenderTOMLForScope(cfg, RenderScopeUser)
+	for _, want := range []string{"[secrets]", "redact_tool_output = false", "filter_subprocess_env = true", "protect_sensitive_files = true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("user-scope render missing %q:\n%s", want, out)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	back := Default()
+	if err := mergeFile(back, path); err != nil {
+		t.Fatalf("round-trip decode: %v", err)
+	}
+	if back.SecretsRedactToolOutput() {
+		t.Fatal("redact_tool_output=false lost in render round-trip")
+	}
+	if !back.Secrets.FilterSubprocessEnv || !back.Secrets.ProtectSensitiveFiles {
+		t.Fatalf("secrets toggles lost in render round-trip: %+v", back.Secrets)
+	}
+
+	// Project scope must not render the section — LoadForRoot ignores it there.
+	if proj := RenderTOMLForScope(cfg, RenderScopeProject); strings.Contains(proj, "[secrets]") {
+		t.Fatalf("project scope rendered [secrets]:\n%s", proj)
+	}
+}

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 const maxImageAttachmentBytes = 10 * 1024 * 1024
@@ -245,6 +246,7 @@ $ms = New-Object System.IO.MemoryStream
 $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
 [Convert]::ToBase64String($ms.ToArray())`
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd.Env = secrets.ProcessEnv()
 	proc.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
@@ -266,7 +268,9 @@ func saveLinuxClipboardImage() (string, error) {
 		{"wl-paste", "--type", "image/png", "--no-newline"},
 		{"xclip", "-selection", "clipboard", "-t", "image/png", "-o"},
 	} {
-		if out, err := exec.Command(c[0], c[1:]...).Output(); err == nil && len(out) > 0 {
+		cmd := exec.Command(c[0], c[1:]...)
+		cmd.Env = secrets.ProcessEnv()
+		if out, err := cmd.Output(); err == nil && len(out) > 0 {
 			return SaveImageBytes("", out)
 		}
 	}
@@ -458,7 +462,9 @@ on error errMsg
 	error errMsg
 end try
 `, abs, class)
-	if out, err := exec.Command("osascript", "-e", script).CombinedOutput(); err != nil {
+	clip := exec.Command("osascript", "-e", script)
+	clip.Env = secrets.ProcessEnv()
+	if out, err := clip.CombinedOutput(); err != nil {
 		_ = os.Remove(rel)
 		return "", fmt.Errorf("read clipboard image: %s", strings.TrimSpace(string(out)))
 	}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -19,6 +19,7 @@ import (
 
 	"reasonix/internal/fileref"
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 // maxFileRefBytes caps how much of an @-referenced file is injected into a
@@ -1124,6 +1125,7 @@ func runPDFTextCommand(name string, args []string) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), pdfExtractTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = secrets.ProcessEnv()
 	setShellKillTree(cmd)
 	cmd.WaitDelay = pdfExtractWaitDelay
 	proc.HideWindow(cmd)

--- a/internal/doctor/session_redact.go
+++ b/internal/doctor/session_redact.go
@@ -249,10 +249,9 @@ func eventLogNeedsRedaction(path string) bool {
 			Messages []provider.Message `json:"messages"`
 		}
 		if err := dec.Decode(&rec); err != nil {
-			if errors.Is(err, io.EOF) {
-				return false
-			}
-			return true
+			// EOF is a clean end; anything else is an undecodable tail whose
+			// torn bytes may hold raw secret text — compact it away.
+			return !errors.Is(err, io.EOF)
 		}
 		if messagesNeedRedaction(rec.Messages) {
 			return true

--- a/internal/doctor/session_redact.go
+++ b/internal/doctor/session_redact.go
@@ -1,6 +1,8 @@
 package doctor
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/fileutil"
+	"reasonix/internal/provider"
 	"reasonix/internal/secrets"
 	"reasonix/internal/store"
 )
@@ -31,9 +34,15 @@ type RedactSessionsResult struct {
 }
 
 // RedactSessions masks credential-shaped values already persisted in Reasonix
-// session transcripts, event logs, branch metadata previews, and background-job
-// artifacts. It is intentionally scoped to known Reasonix session directories;
-// it is not a general-purpose filesystem scrubber.
+// session transcripts, event logs, branch metadata, goal state, and
+// background-job artifacts. It is intentionally scoped to known Reasonix
+// session directories; it is not a general-purpose filesystem scrubber.
+//
+// Every JSON-bearing artifact is decoded before masking and re-encoded after:
+// running Redact over raw encoded bytes would eat the backslash of a \" escape
+// whenever a secret-shaped value abuts a quote, truncating the JSON string and
+// leaving the transcript undecodable (and the secret unmasked). Only plain-text
+// job logs are redacted as raw bytes.
 func RedactSessions(opts RedactSessionsOptions) RedactSessionsResult {
 	dirs := redactSessionDirs(opts.Dirs)
 	res := RedactSessionsResult{Dirs: dirs, DryRun: opts.DryRun}
@@ -54,19 +63,13 @@ func RedactSessions(opts RedactSessionsOptions) RedactSessionsResult {
 				res.FilesSkipped++
 				return nil
 			}
-			changed, rewritten, err := redactSessionFile(path, opts.DryRun)
+			changed, rewritten, err := redactSessionArtifact(path, opts.DryRun)
 			if err != nil {
 				res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", path, err))
 				return nil
 			}
-			if !changed {
-				return nil
-			}
-			res.FilesChanged++
+			res.FilesChanged += changed
 			res.BytesRewritten += rewritten
-			if !opts.DryRun {
-				removeDerivedSessionIndex(path)
-			}
 			return nil
 		}); err != nil {
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", dir, err))
@@ -155,41 +158,231 @@ func sessionRedactionLeaseHeld(sessionPath string) bool {
 	return false
 }
 
-func redactSessionFile(path string, dryRun bool) (changed bool, bytesRewritten int64, err error) {
+// redactSessionArtifact dispatches one candidate file to a format-aware
+// redactor and reports how many files it changed.
+func redactSessionArtifact(path string, dryRun bool) (changed int64, bytesRewritten int64, err error) {
+	name := filepath.Base(path)
+	switch {
+	case store.IsSessionTranscriptName(name), strings.HasSuffix(name, ".guardian.jsonl"):
+		return redactSessionTranscript(path, dryRun)
+	case strings.HasSuffix(name, ".events.jsonl"):
+		anchor := strings.TrimSuffix(path, ".events.jsonl") + ".jsonl"
+		if _, statErr := os.Stat(anchor); statErr == nil {
+			// The anchor's own walk entry rewrites the event log with it.
+			return 0, 0, nil
+		}
+		return redactSessionTranscript(anchor, dryRun)
+	case strings.HasSuffix(name, ".jsonl.meta"):
+		return redactBranchMeta(strings.TrimSuffix(path, ".meta"), dryRun)
+	case strings.HasSuffix(name, ".goal-state.json"):
+		return redactJSONFile(path, dryRun)
+	case strings.HasSuffix(name, ".json"):
+		return redactJSONFile(path, dryRun)
+	default:
+		// Background-job .log files are plain text: raw-byte redaction is
+		// correct there and only there.
+		return redactPlainTextFile(path, dryRun)
+	}
+}
+
+// redactSessionTranscript rewrites one session (anchor .jsonl plus its event
+// log) through the agent's own save machinery. Session.Save re-runs
+// RedactMessages on the snapshot, folds the event log into a single redacted
+// replace event, refreshes the anchor and event index, and records the
+// revision under the same cross-process file locks live sessions use — so
+// digests, the CAS ledger, and event-log replay stay coherent, and a rerun is
+// a no-op because Redact is idempotent on decoded content.
+func redactSessionTranscript(path string, dryRun bool) (int64, int64, error) {
+	s, err := agent.LoadSession(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	if !messagesNeedRedaction(s.Messages) {
+		return 0, 0, nil
+	}
+	files := int64(1)
+	eventLog := store.SessionEventLog(path)
+	if _, err := os.Stat(eventLog); err == nil {
+		files++
+	}
+	if dryRun {
+		return files, redactedEncodedSize(s.Messages), nil
+	}
+	if err := s.Save(path); err != nil {
+		return 0, 0, err
+	}
+	var rewritten int64
+	if info, err := os.Stat(path); err == nil {
+		rewritten += info.Size()
+	}
+	if info, err := os.Stat(eventLog); err == nil {
+		rewritten += info.Size()
+	}
+	return files, rewritten, nil
+}
+
+// messagesNeedRedaction reports whether RedactMessages would alter the
+// storage encoding of msgs. Comparing encoded forms (not struct equality)
+// matches exactly what a rewrite would put on disk.
+func messagesNeedRedaction(msgs []provider.Message) bool {
+	redacted := secrets.RedactMessages(msgs)
+	for i := range msgs {
+		before, errB := json.Marshal(msgs[i])
+		after, errA := json.Marshal(redacted[i])
+		if errB != nil || errA != nil || !bytes.Equal(before, after) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactedEncodedSize(msgs []provider.Message) int64 {
+	var n int64
+	for _, m := range secrets.RedactMessages(msgs) {
+		if b, err := json.Marshal(m); err == nil {
+			n += int64(len(b)) + 1
+		}
+	}
+	return n
+}
+
+// redactBranchMeta masks the free-text fields of the branch-metadata sidecar
+// (preview, titles, goal, recovery reason) through the typed load/save pair so
+// revisions, digests, and timestamps survive untouched.
+func redactBranchMeta(sessionPath string, dryRun bool) (int64, int64, error) {
+	unlock := agent.LockSessionMetaPath(sessionPath)
+	defer unlock()
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return 0, 0, err
+	}
+	changed := false
+	for _, field := range []*string{&meta.Name, &meta.TopicTitle, &meta.CustomTitle, &meta.Goal, &meta.Preview, &meta.RecoveryReason} {
+		if masked := secrets.Redact(*field); masked != *field {
+			*field = masked
+			changed = true
+		}
+	}
+	if !changed {
+		return 0, 0, nil
+	}
+	if dryRun {
+		return 1, 0, nil
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, meta); err != nil {
+		return 0, 0, err
+	}
+	var rewritten int64
+	if info, err := os.Stat(agent.BranchMetaPath(sessionPath)); err == nil {
+		rewritten = info.Size()
+	}
+	return 1, rewritten, nil
+}
+
+// redactJSONFile decodes a single-document JSON sidecar, masks every string
+// value in the tree, and re-encodes. UseNumber keeps numeric literals (large
+// IDs, timestamps) byte-faithful through the round trip. A file that does not
+// parse is reported and left untouched rather than risked with a raw rewrite.
+func redactJSONFile(path string, dryRun bool) (int64, int64, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return false, 0, err
-	}
-	if info.IsDir() {
-		return false, 0, nil
+		return 0, 0, err
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return false, 0, err
+		return 0, 0, err
 	}
-	next := []byte(secrets.Redact(string(raw)))
-	if string(raw) == string(next) {
-		return false, 0, nil
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return 0, 0, nil
 	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return 0, 0, fmt.Errorf("not valid JSON, left untouched: %w", err)
+	}
+	doc, changed := redactJSONValue(doc)
+	if !changed {
+		return 0, 0, nil
+	}
+	next, err := json.Marshal(doc)
+	if err != nil {
+		return 0, 0, err
+	}
+	next = append(next, '\n')
 	if dryRun {
-		return true, int64(len(next)), nil
+		return 1, int64(len(next)), nil
 	}
 	perm := info.Mode().Perm()
 	if perm == 0 {
 		perm = 0o600
 	}
 	if err := fileutil.AtomicWriteFile(path, next, perm); err != nil {
-		return false, 0, err
+		return 0, 0, err
 	}
-	return true, int64(len(next)), nil
+	return 1, int64(len(next)), nil
 }
 
-func removeDerivedSessionIndex(changedPath string) {
-	sessionPath := redactionSessionPath(changedPath)
-	if sessionPath == "" {
-		return
+func redactJSONValue(v any) (any, bool) {
+	switch t := v.(type) {
+	case string:
+		masked := secrets.Redact(t)
+		return masked, masked != t
+	case map[string]any:
+		changed := false
+		for key, val := range t {
+			next, ch := redactJSONValue(val)
+			if ch {
+				t[key] = next
+				changed = true
+			}
+		}
+		return t, changed
+	case []any:
+		changed := false
+		for i, val := range t {
+			next, ch := redactJSONValue(val)
+			if ch {
+				t[i] = next
+				changed = true
+			}
+		}
+		return t, changed
+	default:
+		return v, false
 	}
-	if err := os.Remove(store.SessionEventIndex(sessionPath)); err != nil && !os.IsNotExist(err) {
-		return
+}
+
+// redactPlainTextFile masks raw bytes — safe only for non-JSON artifacts
+// (background-job .log output).
+func redactPlainTextFile(path string, dryRun bool) (int64, int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, err
 	}
+	if info.IsDir() {
+		return 0, 0, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	next := []byte(secrets.Redact(string(raw)))
+	if bytes.Equal(raw, next) {
+		return 0, 0, nil
+	}
+	if dryRun {
+		return 1, int64(len(next)), nil
+	}
+	perm := info.Mode().Perm()
+	if perm == 0 {
+		perm = 0o600
+	}
+	if err := fileutil.AtomicWriteFile(path, next, perm); err != nil {
+		return 0, 0, err
+	}
+	return 1, int64(len(next)), nil
 }

--- a/internal/doctor/session_redact.go
+++ b/internal/doctor/session_redact.go
@@ -1,0 +1,195 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/fileutil"
+	"reasonix/internal/secrets"
+	"reasonix/internal/store"
+)
+
+// RedactSessionsOptions controls historical session-log redaction.
+type RedactSessionsOptions struct {
+	Dirs   []string
+	DryRun bool
+}
+
+// RedactSessionsResult summarizes a historical session-log redaction run.
+type RedactSessionsResult struct {
+	Dirs           []string `json:"dirs"`
+	FilesScanned   int64    `json:"files_scanned"`
+	FilesChanged   int64    `json:"files_changed"`
+	FilesSkipped   int64    `json:"files_skipped"`
+	BytesRewritten int64    `json:"bytes_rewritten"`
+	DryRun         bool     `json:"dry_run"`
+	Errors         []string `json:"errors,omitempty"`
+}
+
+// RedactSessions masks credential-shaped values already persisted in Reasonix
+// session transcripts, event logs, branch metadata previews, and background-job
+// artifacts. It is intentionally scoped to known Reasonix session directories;
+// it is not a general-purpose filesystem scrubber.
+func RedactSessions(opts RedactSessionsOptions) RedactSessionsResult {
+	dirs := redactSessionDirs(opts.Dirs)
+	res := RedactSessionsResult{Dirs: dirs, DryRun: opts.DryRun}
+	for _, dir := range dirs {
+		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", path, err))
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() || !redactSessionCandidate(path) {
+				return nil
+			}
+			res.FilesScanned++
+			if sessionPath := redactionSessionPath(path); sessionPath != "" && sessionRedactionLeaseHeld(sessionPath) {
+				res.FilesSkipped++
+				return nil
+			}
+			changed, rewritten, err := redactSessionFile(path, opts.DryRun)
+			if err != nil {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", path, err))
+				return nil
+			}
+			if !changed {
+				return nil
+			}
+			res.FilesChanged++
+			res.BytesRewritten += rewritten
+			if !opts.DryRun {
+				removeDerivedSessionIndex(path)
+			}
+			return nil
+		}); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", dir, err))
+		}
+	}
+	return res
+}
+
+func redactSessionDirs(in []string) []string {
+	var candidates []string
+	if len(in) > 0 {
+		candidates = append(candidates, in...)
+	} else {
+		candidates = append(candidates, sessionBundleSearchDirs()...)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, dir := range candidates {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+		dir = filepath.Clean(dir)
+		if seen[dir] {
+			continue
+		}
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			continue
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func redactSessionCandidate(path string) bool {
+	name := filepath.Base(path)
+	switch {
+	case store.IsSessionTranscriptName(name):
+		return true
+	case strings.HasSuffix(name, ".jsonl.meta"):
+		return true
+	case strings.HasSuffix(name, ".events.jsonl"):
+		return true
+	case strings.HasSuffix(name, ".guardian.jsonl"):
+		return true
+	case strings.HasSuffix(name, ".goal-state.json"):
+		return true
+	case filepath.Base(filepath.Dir(path)) != "" && strings.HasSuffix(filepath.Base(filepath.Dir(path)), ".jobs"):
+		return strings.HasSuffix(name, ".log") || strings.HasSuffix(name, ".json")
+	default:
+		return false
+	}
+}
+
+func redactionSessionPath(path string) string {
+	name := filepath.Base(path)
+	switch {
+	case store.IsSessionTranscriptName(name), strings.HasSuffix(name, ".guardian.jsonl"):
+		return path
+	case strings.HasSuffix(path, ".jsonl.meta"):
+		return strings.TrimSuffix(path, ".meta")
+	case strings.HasSuffix(path, ".events.jsonl"):
+		return strings.TrimSuffix(path, ".events.jsonl") + ".jsonl"
+	case strings.HasSuffix(path, ".goal-state.json"):
+		return strings.TrimSuffix(path, ".goal-state.json") + ".jsonl"
+	case strings.HasSuffix(filepath.Base(filepath.Dir(path)), ".jobs"):
+		return strings.TrimSuffix(filepath.Dir(path), ".jobs") + ".jsonl"
+	default:
+		return ""
+	}
+}
+
+func sessionRedactionLeaseHeld(sessionPath string) bool {
+	if agent.SessionLeaseHeld(sessionPath) {
+		return true
+	}
+	if strings.HasSuffix(sessionPath, ".guardian.jsonl") {
+		parent := strings.TrimSuffix(sessionPath, ".guardian.jsonl") + ".jsonl"
+		return agent.SessionLeaseHeld(parent)
+	}
+	return false
+}
+
+func redactSessionFile(path string, dryRun bool) (changed bool, bytesRewritten int64, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, 0, err
+	}
+	if info.IsDir() {
+		return false, 0, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, 0, err
+	}
+	next := []byte(secrets.Redact(string(raw)))
+	if string(raw) == string(next) {
+		return false, 0, nil
+	}
+	if dryRun {
+		return true, int64(len(next)), nil
+	}
+	perm := info.Mode().Perm()
+	if perm == 0 {
+		perm = 0o600
+	}
+	if err := fileutil.AtomicWriteFile(path, next, perm); err != nil {
+		return false, 0, err
+	}
+	return true, int64(len(next)), nil
+}
+
+func removeDerivedSessionIndex(changedPath string) {
+	sessionPath := redactionSessionPath(changedPath)
+	if sessionPath == "" {
+		return
+	}
+	if err := os.Remove(store.SessionEventIndex(sessionPath)); err != nil && !os.IsNotExist(err) {
+		return
+	}
+}

--- a/internal/doctor/session_redact.go
+++ b/internal/doctor/session_redact.go
@@ -3,7 +3,9 @@ package doctor
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -200,13 +202,20 @@ func redactSessionTranscript(path string, dryRun bool) (int64, int64, error) {
 		}
 		return 0, 0, err
 	}
-	if !messagesNeedRedaction(s.Messages) {
-		return 0, 0, nil
-	}
 	files := int64(1)
 	eventLog := store.SessionEventLog(path)
+	eventLogExists := false
 	if _, err := os.Stat(eventLog); err == nil {
 		files++
+		eventLogExists = true
+	}
+	// The replayed view alone is not enough: a replace event supersedes
+	// earlier records without erasing them, so a raw secret can survive in a
+	// stale event while the current messages are already clean. Scan every
+	// record; Session.Save compacts the whole log into a single clean replace
+	// event, which erases the stale bytes.
+	if !messagesNeedRedaction(s.Messages) && !(eventLogExists && eventLogNeedsRedaction(eventLog)) {
+		return 0, 0, nil
 	}
 	if dryRun {
 		return files, redactedEncodedSize(s.Messages), nil
@@ -222,6 +231,33 @@ func redactSessionTranscript(path string, dryRun bool) (int64, int64, error) {
 		rewritten += info.Size()
 	}
 	return files, rewritten, nil
+}
+
+// eventLogNeedsRedaction reports whether any event record — including ones a
+// later replace event superseded — still carries redactable message content.
+// Undecodable trailing bytes also count: a torn tail can hold raw secret text,
+// and the compaction that a rewrite performs erases it either way.
+func eventLogNeedsRedaction(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	for {
+		var rec struct {
+			Messages []provider.Message `json:"messages"`
+		}
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				return false
+			}
+			return true
+		}
+		if messagesNeedRedaction(rec.Messages) {
+			return true
+		}
+	}
 }
 
 // messagesNeedRedaction reports whether RedactMessages would alter the

--- a/internal/doctor/session_redact_test.go
+++ b/internal/doctor/session_redact_test.go
@@ -1,12 +1,14 @@
 package doctor
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/provider"
 	"reasonix/internal/store"
 )
 
@@ -40,12 +42,6 @@ func TestRedactSessionsScrubsHistoricalSessionArtifacts(t *testing.T) {
 		t.Fatalf("FilesChanged = %d, want 6", res.FilesChanged)
 	}
 	for path := range files {
-		if path == store.SessionEventIndex(sessionPath) {
-			if _, err := os.Stat(path); !os.IsNotExist(err) {
-				t.Fatalf("event index should be removed after transcript rewrite, stat err=%v", err)
-			}
-			continue
-		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
@@ -53,6 +49,95 @@ func TestRedactSessionsScrubsHistoricalSessionArtifacts(t *testing.T) {
 		if strings.Contains(string(data), secret) {
 			t.Fatalf("%s still leaked secret:\n%s", path, data)
 		}
+	}
+	// The rewrite must go through the real save machinery: the session still
+	// loads, the event log still replays, and the masked value survived.
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
+		t.Fatalf("redacted session no longer loads: %v", err)
+	}
+	if len(loaded.Messages) != 1 || !strings.Contains(loaded.Messages[0].Content, "DEEPSEEK_API_KEY=sk-rea") {
+		t.Fatalf("redacted session lost its masked content: %+v", loaded.Messages)
+	}
+}
+
+// TestRedactSessionsHandlesQuotedSecretsWithoutCorruption pins the decode-
+// before-redact contract: on disk a quoted secret is JSON-encoded with \"
+// escapes, and masking the raw bytes would eat the escape's backslash,
+// truncate the JSON string, and leave the transcript undecodable — while the
+// secret itself stayed in the clear.
+func TestRedactSessionsHandlesQuotedSecretsWithoutCorruption(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "hunter2-longer-secret-value"
+	sessionPath := filepath.Join(dir, "abc.jsonl")
+	line, err := json.Marshal(provider.Message{
+		Role:    provider.RoleTool,
+		Content: `export PASSWORD="` + secret + `"` + "\n",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sessionPath, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(res.Errors) > 0 {
+		t.Fatalf("RedactSessions errors = %v", res.Errors)
+	}
+	if res.FilesChanged != 1 {
+		t.Fatalf("FilesChanged = %d, want 1", res.FilesChanged)
+	}
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
+		t.Fatalf("redaction corrupted the transcript: %v", err)
+	}
+	if len(loaded.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(loaded.Messages))
+	}
+	if strings.Contains(loaded.Messages[0].Content, secret) {
+		t.Fatalf("quoted secret leaked: %q", loaded.Messages[0].Content)
+	}
+}
+
+// TestRedactSessionsIsNoOpOnHealthyStore pins idempotence: a store written by
+// a redacting build must survive the doctor untouched — rerunning cleanup on
+// clean sessions must never rewrite (or worse, corrupt) them.
+func TestRedactSessionsIsNoOpOnHealthyStore(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "abc.jsonl")
+	s := agent.NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
+	s.Add(provider.Message{
+		Role:       provider.RoleTool,
+		Name:       "bash",
+		ToolCallID: "call_1",
+		Content:    `export PASSWORD="hunter2-longer-secret-value"` + "\n",
+	})
+	if err := s.Save(sessionPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	before, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(res.Errors) > 0 {
+		t.Fatalf("RedactSessions errors = %v", res.Errors)
+	}
+	if res.FilesChanged != 0 {
+		t.Fatalf("healthy already-redacted store rewritten: %+v", res)
+	}
+	after, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("healthy transcript bytes changed:\nbefore: %s\nafter:  %s", before, after)
+	}
+	if _, err := agent.LoadSession(sessionPath); err != nil {
+		t.Fatalf("healthy session no longer loads: %v", err)
 	}
 }
 

--- a/internal/doctor/session_redact_test.go
+++ b/internal/doctor/session_redact_test.go
@@ -1,0 +1,105 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/store"
+)
+
+func TestRedactSessionsScrubsHistoricalSessionArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "sk-real-secret-value-123456"
+	sessionPath := filepath.Join(dir, "abc.jsonl")
+	files := map[string]string{
+		sessionPath:                                                     `{"role":"tool","content":"DEEPSEEK_API_KEY=` + secret + `"}` + "\n",
+		store.SessionEventLog(sessionPath):                              `{"schema_version":1,"type":"replace","messages":[{"role":"tool","content":"DEEPSEEK_API_KEY=` + secret + `"}]}` + "\n",
+		store.SessionMeta(sessionPath):                                  `{"id":"abc","preview":"DEEPSEEK_API_KEY=` + secret + `"}` + "\n",
+		store.SessionGoalState(sessionPath):                             `{"goal":"rotate token ` + secret + `"}` + "\n",
+		filepath.Join(store.SessionJobsDir(sessionPath), "bash-1.log"):  "DEEPSEEK_API_KEY=" + secret + "\n",
+		filepath.Join(store.SessionJobsDir(sessionPath), "bash-1.json"): `{"label":"echo DEEPSEEK_API_KEY=` + secret + `"}` + "\n",
+		store.SessionEventIndex(sessionPath):                            `{"schema_version":1}` + "\n",
+	}
+	for path, body := range files {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(res.Errors) > 0 {
+		t.Fatalf("RedactSessions errors = %v", res.Errors)
+	}
+	if res.FilesChanged != 6 {
+		t.Fatalf("FilesChanged = %d, want 6", res.FilesChanged)
+	}
+	for path := range files {
+		if path == store.SessionEventIndex(sessionPath) {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("event index should be removed after transcript rewrite, stat err=%v", err)
+			}
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(data), secret) {
+			t.Fatalf("%s still leaked secret:\n%s", path, data)
+		}
+	}
+}
+
+func TestRedactSessionsDryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "sk-real-secret-value-123456"
+	path := filepath.Join(dir, "abc.jsonl")
+	body := `{"role":"tool","content":"DEEPSEEK_API_KEY=` + secret + `"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}, DryRun: true})
+	if res.FilesChanged != 1 {
+		t.Fatalf("FilesChanged = %d, want 1", res.FilesChanged)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("dry-run modified file:\n%s", data)
+	}
+}
+
+func TestRedactSessionsSkipsLeasedSession(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "sk-real-secret-value-123456"
+	path := filepath.Join(dir, "abc.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"tool","content":"DEEPSEEK_API_KEY=`+secret+`"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if res.FilesSkipped != 1 {
+		t.Fatalf("FilesSkipped = %d, want 1", res.FilesSkipped)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), secret) {
+		t.Fatalf("leased session should not be rewritten:\n%s", data)
+	}
+}

--- a/internal/doctor/session_redact_test.go
+++ b/internal/doctor/session_redact_test.go
@@ -188,3 +188,45 @@ func TestRedactSessionsSkipsLeasedSession(t *testing.T) {
 		t.Fatalf("leased session should not be rewritten:\n%s", data)
 	}
 }
+
+// TestRedactSessionsScrubsStaleEventLogRecords pins the stale-record gap: a
+// later replace event supersedes — but does not erase — earlier records, so a
+// raw key can survive in an old event while the replayed view is already
+// clean. Cleanup must compact the log anyway, and the replayed transcript
+// (the clean current view) must be what survives.
+func TestRedactSessionsScrubsStaleEventLogRecords(t *testing.T) {
+	dir := t.TempDir()
+	const secret = "sk-real-secret-value-123456"
+	sessionPath := filepath.Join(dir, "abc.jsonl")
+	events := `{"schema_version":1,"type":"replace","messages":[{"role":"tool","content":"DEEPSEEK_API_KEY=` + secret + `"}]}` + "\n" +
+		`{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"clean"}]}` + "\n"
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"clean"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evPath := store.SessionEventLog(sessionPath)
+	if err := os.WriteFile(evPath, []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(res.Errors) > 0 {
+		t.Fatalf("RedactSessions errors = %v", res.Errors)
+	}
+	if res.FilesChanged != 2 {
+		t.Fatalf("FilesChanged = %d, want 2 (anchor + event log)", res.FilesChanged)
+	}
+	data, err := os.ReadFile(evPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("stale event log record still leaks secret:\n%s", data)
+	}
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
+		t.Fatalf("session no longer loads after compaction: %v", err)
+	}
+	if len(loaded.Messages) != 1 || loaded.Messages[0].Content != "clean" {
+		t.Fatalf("compaction lost the current replayed view: %+v", loaded.Messages)
+	}
+}

--- a/internal/environment/probe.go
+++ b/internal/environment/probe.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
 )
 
@@ -237,7 +238,7 @@ func runOne(ctx context.Context, command string, opts ProbeOptions) ProbeResult 
 	defer cancel()
 	cmd := exec.CommandContext(cmdCtx, exe, parts[1:]...)
 	if len(probe.Env) > 0 {
-		cmd.Env = append(os.Environ(), probe.Env...)
+		cmd.Env = append(secrets.ProcessEnv(), probe.Env...)
 	}
 	prepareProbeCommand(cmd)
 	var stdout, stderr bytes.Buffer

--- a/internal/environment/probe.go
+++ b/internal/environment/probe.go
@@ -237,9 +237,10 @@ func runOne(ctx context.Context, command string, opts ProbeOptions) ProbeResult 
 	cmdCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(cmdCtx, exe, parts[1:]...)
-	if len(probe.Env) > 0 {
-		cmd.Env = append(secrets.ProcessEnv(), probe.Env...)
-	}
+	// Always set the env explicitly: leaving cmd.Env nil would inherit the
+	// full process environment and bypass [secrets] filter_subprocess_env for
+	// probes that declare no extra variables of their own.
+	cmd.Env = append(secrets.ProcessEnv(), probe.Env...)
 	prepareProbeCommand(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/environment/probe_test.go
+++ b/internal/environment/probe_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"reasonix/internal/secrets"
 )
 
 func TestFormatSectionSortsAndRedacts(t *testing.T) {
@@ -351,4 +353,31 @@ func setProbeTimeoutForTest(t *testing.T, timeout time.Duration) {
 		probeTimeout = ProbeTimeout
 		probeCacheMu.Unlock()
 	})
+}
+
+func TestRunProbesFilterSubprocessEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell probe tool")
+	}
+	resetProbeCacheForTest(t, time.Unix(90, 0))
+	setProbeTimeoutForTest(t, 10*time.Second)
+	dir := t.TempDir()
+	toolPath := filepath.Join(dir, "envtool")
+	body := "#!/bin/sh\nprintf 'tok=%s' \"${REASONIX_TEST_SECRET_TOKEN:-none}\"\n"
+	if err := os.WriteFile(toolPath, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REASONIX_TEST_SECRET_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+	secrets.SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { secrets.SetFilterSubprocessEnv(false) })
+
+	results := RunProbesWithOverrides(context.Background(), []string{"envtool --version"}, map[string]string{"envtool": toolPath})
+	if len(results) != 1 || !results[0].Found {
+		t.Fatalf("probe result = %+v", results)
+	}
+	// Probes declaring no extra env of their own must still get the filtered
+	// environment, not inherit the full one.
+	if results[0].Output != "tok=none" {
+		t.Fatalf("probe leaked filtered env: output = %q", results[0].Output)
+	}
 }

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -29,6 +29,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 // Event is a point in the agent loop a hook can fire at.
@@ -547,8 +548,8 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	cmd := spawnCommand(cctx, in.Command)
 	proc.HideWindow(cmd)
 	cmd.Dir = in.Cwd
+	env := secrets.ProcessEnv()
 	if len(in.Env) > 0 {
-		env := os.Environ()
 		keys := make([]string, 0, len(in.Env))
 		for k := range in.Env {
 			keys = append(keys, k)
@@ -557,8 +558,8 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 		for _, k := range keys {
 			env = append(env, k+"="+in.Env[k])
 		}
-		cmd.Env = env
 	}
+	cmd.Env = env
 	cmd.Stdin = strings.NewReader(in.Stdin)
 	var outBuf, errBuf cappedBuffer
 	cmd.Stdout = &outBuf

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"reasonix/internal/pluginpkg"
+	"reasonix/internal/secrets"
 )
 
 func (t *installSourceTool) localPluginPackageAction(req request, root string) (action, []string, error) {
@@ -191,6 +192,7 @@ func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mod
 		}
 		args = append(args, cloneURL, tmp)
 		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Env = secrets.ProcessEnv()
 		if out, err := cmd.CombinedOutput(); err != nil {
 			_ = os.RemoveAll(tmp)
 			return "", func() {}, newErr(ErrSourceUnreadable, "git clone failed: %v: %s", err, strings.TrimSpace(string(out)))

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -47,6 +47,36 @@ func TestCompletedJobPersistsOutputAndReleasesMemory(t *testing.T) {
 	}
 }
 
+func TestJobArtifactRedactsSecrets(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+	secret := "sk-real-secret-value-123456"
+
+	j := m.StartForSession("session", "bash", "persist secret", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "DEEPSEEK_API_KEY="+secret+"\n")
+		return "Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz", nil
+	})
+	<-j.done
+
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 {
+		t.Fatalf("wait result = %+v", res)
+	}
+	if strings.Contains(res[0].Output, secret) || strings.Contains(res[0].Output, "ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("wait output leaked secret:\n%s", res[0].Output)
+	}
+
+	data, err := os.ReadFile(filepath.Join(ArtifactDir(sessionPath), j.ID+jobLogExt))
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	if strings.Contains(string(data), secret) || strings.Contains(string(data), "ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("artifact leaked secret:\n%s", data)
+	}
+}
+
 func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	first := NewManager(event.Discard)

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -77,6 +77,27 @@ func TestJobArtifactRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestJobArtifactMetadataRedactsLabel(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+	const secret = "sk-real-secret-value-123456"
+
+	j := m.StartForSession("session", "bash", "echo DEEPSEEK_API_KEY="+secret, func(context.Context, io.Writer) (string, error) {
+		return "", nil
+	})
+	<-j.done
+
+	data, err := os.ReadFile(filepath.Join(ArtifactDir(sessionPath), j.ID+jobMetaExt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("job metadata leaked label secret:\n%s", data)
+	}
+}
+
 func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	first := NewManager(event.Discard)

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -243,6 +243,7 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 // only see jobs whose owner matches the active session.
 func (m *Manager) StartForSession(parentSession, kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
 	parentSession = strings.TrimSpace(parentSession)
+	label = secrets.Redact(label)
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -25,6 +25,7 @@ import (
 
 	"reasonix/internal/event"
 	"reasonix/internal/nilutil"
+	"reasonix/internal/secrets"
 )
 
 var renamePath = os.Rename
@@ -216,12 +217,13 @@ func NewManager(sink event.Sink, opts ...Option) *Manager {
 type jobWriter struct{ j *Job }
 
 func (w jobWriter) Write(p []byte) (int, error) {
+	redacted := []byte(secrets.Redact(string(p)))
 	w.j.mu.Lock()
 	defer w.j.mu.Unlock()
 	w.j.activityAt = nowMs()
-	w.j.tail = appendTail(w.j.tail, p, defaultTailBytes)
+	w.j.tail = appendTail(w.j.tail, redacted, defaultTailBytes)
 	if w.j.artifactFile != nil {
-		if _, err := w.j.artifactFile.Write(p); err != nil {
+		if _, err := w.j.artifactFile.Write(redacted); err != nil {
 			w.j.artifactErr = err.Error()
 		}
 	}
@@ -296,6 +298,7 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		}
 		finishedAt := nowMs()
 		if result != "" {
+			result = secrets.Redact(result)
 			j.mu.Lock()
 			if j.artifactFile != nil {
 				if _, writeErr := j.artifactFile.WriteString(result); writeErr != nil {

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 // docState tracks what we last sent the server for a document, so ensureSynced
@@ -46,7 +47,7 @@ func startClient(ctx context.Context, bin string, args []string, env map[string]
 	cmd := exec.CommandContext(ctx, bin, args...)
 	proc.HideWindow(cmd)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), envSlice(env)...)
+	cmd.Env = append(secrets.ProcessEnv(), envSlice(env)...)
 	cmd.Stderr = io.Discard
 
 	stdin, err := cmd.StdinPipe()

--- a/internal/notify/sender_darwin.go
+++ b/internal/notify/sender_darwin.go
@@ -4,6 +4,7 @@ package notify
 
 import (
 	"os/exec"
+	"reasonix/internal/secrets"
 	"strings"
 )
 
@@ -16,6 +17,7 @@ func NewPlatformSender() PlatformSender { return PlatformSender{} }
 func (PlatformSender) Send(m Message) error {
 	script := `display notification "` + appleScriptString(m.Body) + `" with title "` + appleScriptString(m.Title) + `"`
 	cmd := exec.Command("osascript", "-e", script)
+	cmd.Env = secrets.ProcessEnv()
 	if err := cmd.Start(); err != nil {
 		return err
 	}

--- a/internal/notify/sender_linux.go
+++ b/internal/notify/sender_linux.go
@@ -2,7 +2,11 @@
 
 package notify
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"reasonix/internal/secrets"
+)
 
 // PlatformSender delivers notifications through the host OS.
 type PlatformSender struct{}
@@ -12,6 +16,7 @@ func NewPlatformSender() PlatformSender { return PlatformSender{} }
 
 func (PlatformSender) Send(m Message) error {
 	cmd := exec.Command("notify-send", m.Title, m.Body)
+	cmd.Env = secrets.ProcessEnv()
 	if err := cmd.Start(); err != nil {
 		return err
 	}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 const closeWaitBudget = 5 * time.Second
@@ -65,7 +66,7 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 			releaseSlot()
 		}
 	}()
-	env := mergeEnv(os.Environ(), s.Env)
+	env := mergeEnv(secrets.ProcessEnv(), s.Env)
 	exe, env, err := resolveStdioExecutable(ctx, s, env)
 	if err != nil {
 		return nil, err
@@ -349,7 +350,7 @@ func stdioShell() string {
 			if isExecutableFile(shell) {
 				return shell
 			}
-		} else if exe, ok := lookPathInEnv(shell, os.Environ()); ok {
+		} else if exe, ok := lookPathInEnv(shell, secrets.ProcessEnv()); ok {
 			return exe
 		}
 	}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -366,6 +366,9 @@ func runShellPATHCommand(parent context.Context, shell string, args []string) []
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, shell, args...)
+	// Explicit env so the login-shell probe honors [secrets]
+	// filter_subprocess_env instead of inheriting the full environment.
+	cmd.Env = secrets.ProcessEnv()
 	prepareStdioShellPATHProbe(cmd)
 	cmd.Stdin = strings.NewReader("")
 	out, _ := cmd.CombinedOutput()

--- a/internal/plugin/transport_stdio_env_test.go
+++ b/internal/plugin/transport_stdio_env_test.go
@@ -1,0 +1,24 @@
+package plugin
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/secrets"
+)
+
+func TestStdioShellPATHProbeFiltersEnvWhenEnabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell probe")
+	}
+	secrets.SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { secrets.SetFilterSubprocessEnv(false) })
+	t.Setenv("REASONIX_TEST_SECRET_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+
+	out := runShellPATHCommand(context.Background(), "/bin/sh", []string{"-c", `printf 'tok=%s' "${REASONIX_TEST_SECRET_TOKEN:-none}"`})
+	if !strings.Contains(string(out), "tok=none") {
+		t.Fatalf("stdio shell PATH probe leaked filtered env: %q", out)
+	}
+}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 )
 
 // psUTF8Prologue forces PowerShell to emit UTF-8 instead of the host's OEM code
@@ -166,6 +167,7 @@ func probeBash(path string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, path, "-c", "true")
+	cmd.Env = secrets.ProcessEnv()
 	proc.HideWindow(cmd)
 	return cmd.Run() == nil
 }

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+var (
+	secretKeyNamePattern = regexp.MustCompile(`(?i)(^|[_-])(api[_-]?key|access[_-]?key|private[_-]?key|secret|token|password|passwd|pwd)([_-]|$)`)
+	keyValuePattern      = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD|PWD)[A-Z0-9_.-]*|authorization)\b(\s*[:=]\s*)(?:Bearer\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
+	bearerTokenPattern   = regexp.MustCompile(`(?i)\bBearer\s+([A-Za-z0-9._~+/=-]{16,})`)
+	openAIKeyPattern     = regexp.MustCompile(`\b((?:sk|rk)-(?:proj-)?[A-Za-z0-9_-]{12,})\b`)
+	githubTokenPattern   = regexp.MustCompile(`\b(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b`)
+	slackTokenPattern    = regexp.MustCompile(`\b(xox[baprs]-[A-Za-z0-9-]{16,})\b`)
+	awsAccessKeyPattern  = regexp.MustCompile(`\b(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b`)
+	jwtPattern           = regexp.MustCompile(`\b(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`)
+)
+
+const redactedValue = "[redacted]"
+
+// EnvKeySensitive reports whether an environment variable name is likely to
+// carry credentials. It intentionally keys off the name, not the value, so child
+// processes do not inherit saved provider secrets by default.
+func EnvKeySensitive(key string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return false
+	}
+	return secretKeyNamePattern.MatchString(key)
+}
+
+// FilterEnv removes sensitive KEY=value assignments from an environment vector.
+func FilterEnv(env []string) []string {
+	out := env[:0]
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok || EnvKeySensitive(key) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// ProcessEnv returns the current process environment with credential-like
+// assignments removed, suitable for shell/tool subprocesses.
+func ProcessEnv() []string {
+	return FilterEnv(os.Environ())
+}
+
+// Redact masks credential-like values in text before the text enters model
+// context, UI events, durable transcripts, or diagnostic records.
+func Redact(s string) string {
+	if s == "" {
+		return s
+	}
+	s = keyValuePattern.ReplaceAllStringFunc(s, func(match string) string {
+		parts := keyValuePattern.FindStringSubmatch(match)
+		if len(parts) != 6 {
+			return redactedValue
+		}
+		key := parts[1]
+		sep := parts[2]
+		quote := parts[3]
+		value := parts[4]
+		endQuote := parts[5]
+		if strings.EqualFold(key, "authorization") {
+			return key + sep + quote + redactedValue + endQuote
+		}
+		return key + sep + quote + mask(value) + endQuote
+	})
+	s = bearerTokenPattern.ReplaceAllStringFunc(s, func(match string) string {
+		token := strings.TrimSpace(strings.TrimPrefix(match, "Bearer"))
+		if len(token) == len(match) {
+			return "Bearer " + redactedValue
+		}
+		return "Bearer " + mask(token)
+	})
+	for _, rx := range []*regexp.Regexp{openAIKeyPattern, githubTokenPattern, slackTokenPattern, awsAccessKeyPattern, jwtPattern} {
+		s = rx.ReplaceAllStringFunc(s, mask)
+	}
+	return s
+}
+
+func mask(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return redactedValue
+	}
+	if len(value) <= 12 {
+		return redactedValue
+	}
+	head := 4
+	tail := 4
+	if strings.HasPrefix(value, "sk-") || strings.HasPrefix(value, "rk-") {
+		head = 6
+	}
+	if len(value) <= head+tail {
+		return redactedValue
+	}
+	return value[:head] + strings.Repeat("*", len(value)-head-tail) + value[len(value)-tail:]
+}
+
+// RedactMessage returns a storage/model-safe copy of m with textual secret
+// surfaces masked. Images are left untouched because they are opaque data URLs.
+func RedactMessage(m provider.Message) provider.Message {
+	m.Content = Redact(m.Content)
+	m.ReasoningContent = Redact(m.ReasoningContent)
+	m.Original = Redact(m.Original)
+	for i := range m.ToolCalls {
+		m.ToolCalls[i].Arguments = Redact(m.ToolCalls[i].Arguments)
+		m.ToolCalls[i].Diff = Redact(m.ToolCalls[i].Diff)
+	}
+	for i := range m.MemoryCitations {
+		m.MemoryCitations[i].Note = Redact(m.MemoryCitations[i].Note)
+	}
+	return m
+}
+
+// RedactMessages returns a redacted copy of msgs.
+func RedactMessages(msgs []provider.Message) []provider.Message {
+	out := make([]provider.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = RedactMessage(m)
+	}
+	return out
+}

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -4,26 +4,69 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync/atomic"
 
 	"reasonix/internal/provider"
 )
 
 var (
-	secretKeyNamePattern = regexp.MustCompile(`(?i)(^|[_-])(api[_-]?key|access[_-]?key|private[_-]?key|secret|token|password|passwd|pwd)([_-]|$)`)
-	keyValuePattern      = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD|PWD)[A-Z0-9_.-]*|authorization)\b(\s*[:=]\s*)(?:Bearer\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
-	bearerTokenPattern   = regexp.MustCompile(`(?i)\bBearer\s+([A-Za-z0-9._~+/=-]{16,})`)
-	openAIKeyPattern     = regexp.MustCompile(`\b((?:sk|rk)-(?:proj-)?[A-Za-z0-9_-]{12,})\b`)
-	githubTokenPattern   = regexp.MustCompile(`\b(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b`)
-	slackTokenPattern    = regexp.MustCompile(`\b(xox[baprs]-[A-Za-z0-9-]{16,})\b`)
-	awsAccessKeyPattern  = regexp.MustCompile(`\b(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b`)
-	jwtPattern           = regexp.MustCompile(`\b(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`)
+	// secretKeyNamePattern matches environment-variable / key names that are
+	// likely to carry credentials. Bare "pwd" is intentionally excluded: it
+	// only counts with a leading separator (DB_PWD, MYSQL-PWD), so the POSIX
+	// PWD / OLDPWD working-directory variables never match.
+	secretKeyNamePattern = regexp.MustCompile(`(?i)((^|[_-])(api[_-]?key|access[_-]?key|private[_-]?key|secret|token|password|passwd)([_-]|$)|[_-]pwd([_-]|$))`)
+	// keyValuePattern mirrors secretKeyNamePattern for KEY=value / key: value
+	// text: PWD requires a prefixed separator so "PWD=/home/user" stays intact.
+	keyValuePattern     = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD)[A-Z0-9_.-]*|[A-Z0-9_.-]+[_-]PWD[A-Z0-9_.-]*|AUTHORIZATION)\b(\s*[:=]\s*)(?:Bearer\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
+	bearerTokenPattern  = regexp.MustCompile(`(?i)\bBearer\s+([A-Za-z0-9._~+/=-]{16,})`)
+	openAIKeyPattern    = regexp.MustCompile(`\b((?:sk|rk)-(?:proj-)?[A-Za-z0-9_-]{12,})\b`)
+	githubTokenPattern  = regexp.MustCompile(`\b(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b`)
+	slackTokenPattern   = regexp.MustCompile(`\b(xox[baprs]-[A-Za-z0-9-]{16,})\b`)
+	awsAccessKeyPattern = regexp.MustCompile(`\b(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b`)
+	jwtPattern          = regexp.MustCompile(`\b(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`)
 )
 
 const redactedValue = "[redacted]"
 
+// Runtime toggles for the opt-in protection layers, set once by the
+// composition root from the user-global [secrets] config section. Package
+// globals are safe here because [secrets] cannot be overridden per-project:
+// every concurrent workspace in one process shares the same user setting.
+var (
+	redactToolOutputEnabled      atomic.Bool
+	filterSubprocessEnvEnabled   atomic.Bool
+	protectSensitiveFilesEnabled atomic.Bool
+)
+
+func init() {
+	// Tool-output redaction defaults on; subprocess env filtering defaults
+	// off because it breaks legitimate token-based workflows (gh, git push
+	// over HTTPS, npm publish) and needs an explicit user opt-in.
+	redactToolOutputEnabled.Store(true)
+}
+
+// SetRedactToolOutput enables or disables masking of tool output before it
+// enters model context and UI events ([secrets] redact_tool_output). Durable
+// surfaces — session transcripts and background-job artifacts — are always
+// redacted regardless of this toggle.
+func SetRedactToolOutput(enabled bool) { redactToolOutputEnabled.Store(enabled) }
+
+// SetFilterSubprocessEnv enables or disables stripping credential-like
+// variables from tool subprocess environments ([secrets]
+// filter_subprocess_env).
+func SetFilterSubprocessEnv(enabled bool) { filterSubprocessEnvEnabled.Store(enabled) }
+
+// SetProtectSensitiveFiles enables or disables the built-in credential-path
+// read denylist for read/list/search tools ([secrets] protect_sensitive_files).
+func SetProtectSensitiveFiles(enabled bool) { protectSensitiveFilesEnabled.Store(enabled) }
+
+// ProtectSensitiveFiles reports whether the built-in credential-path read
+// denylist is active.
+func ProtectSensitiveFiles() bool { return protectSensitiveFilesEnabled.Load() }
+
 // EnvKeySensitive reports whether an environment variable name is likely to
 // carry credentials. It intentionally keys off the name, not the value, so child
-// processes do not inherit saved provider secrets by default.
+// processes do not inherit saved provider secrets when filtering is enabled.
 func EnvKeySensitive(key string) bool {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -45,14 +88,32 @@ func FilterEnv(env []string) []string {
 	return out
 }
 
-// ProcessEnv returns the current process environment with credential-like
-// assignments removed, suitable for shell/tool subprocesses.
+// ProcessEnv returns the environment for shell/tool subprocesses: the current
+// process environment as-is by default, with credential-like assignments
+// removed when the user opted into [secrets] filter_subprocess_env.
 func ProcessEnv() []string {
+	if !filterSubprocessEnvEnabled.Load() {
+		return os.Environ()
+	}
 	return FilterEnv(os.Environ())
 }
 
-// Redact masks credential-like values in text before the text enters model
-// context, UI events, durable transcripts, or diagnostic records.
+// RedactToolOutput masks credential-like values in live tool output (model
+// context, UI events) unless the user disabled [secrets] redact_tool_output.
+// Durable writers (session save, job artifacts) call Redact directly instead:
+// disk logs stay redacted even when live output is not.
+func RedactToolOutput(s string) string {
+	if !redactToolOutputEnabled.Load() {
+		return s
+	}
+	return Redact(s)
+}
+
+// Redact masks credential-like values in text before the text enters durable
+// transcripts, job artifacts, or diagnostic records. It is deterministic and
+// idempotent: redacting already-redacted text is a byte-for-byte no-op, which
+// the session save path relies on for digest stability across load/save cycles
+// (see Session.save).
 func Redact(s string) string {
 	if s == "" {
 		return s
@@ -104,23 +165,38 @@ func mask(value string) string {
 	return value[:head] + strings.Repeat("*", len(value)-head-tail) + value[len(value)-tail:]
 }
 
-// RedactMessage returns a storage/model-safe copy of m with textual secret
-// surfaces masked. Images are left untouched because they are opaque data URLs.
+// RedactMessage returns a storage-safe copy of m with textual secret surfaces
+// masked. Images are left untouched because they are opaque data URLs.
+// ToolCalls and MemoryCitations are cloned before masking: m is passed by
+// value but its slices share backing arrays with the caller, and the save
+// path hands in live session messages — writing through would silently mutate
+// the model-visible history mid-conversation and churn the prompt cache.
 func RedactMessage(m provider.Message) provider.Message {
 	m.Content = Redact(m.Content)
 	m.ReasoningContent = Redact(m.ReasoningContent)
 	m.Original = Redact(m.Original)
-	for i := range m.ToolCalls {
-		m.ToolCalls[i].Arguments = Redact(m.ToolCalls[i].Arguments)
-		m.ToolCalls[i].Diff = Redact(m.ToolCalls[i].Diff)
+	if len(m.ToolCalls) > 0 {
+		calls := make([]provider.ToolCall, len(m.ToolCalls))
+		copy(calls, m.ToolCalls)
+		for i := range calls {
+			calls[i].Arguments = Redact(calls[i].Arguments)
+			calls[i].Diff = Redact(calls[i].Diff)
+		}
+		m.ToolCalls = calls
 	}
-	for i := range m.MemoryCitations {
-		m.MemoryCitations[i].Note = Redact(m.MemoryCitations[i].Note)
+	if len(m.MemoryCitations) > 0 {
+		cites := make([]provider.MemoryCitation, len(m.MemoryCitations))
+		copy(cites, m.MemoryCitations)
+		for i := range cites {
+			cites[i].Note = Redact(cites[i].Note)
+		}
+		m.MemoryCitations = cites
 	}
 	return m
 }
 
-// RedactMessages returns a redacted copy of msgs.
+// RedactMessages returns a redacted copy of msgs. The input slice and its
+// messages are never mutated.
 func RedactMessages(msgs []provider.Message) []provider.Message {
 	out := make([]provider.Message, len(msgs))
 	for i, m := range msgs {

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -17,7 +17,11 @@ var (
 	secretKeyNamePattern = regexp.MustCompile(`(?i)((^|[_-])(api[_-]?key|access[_-]?key|private[_-]?key|secret|token|password|passwd)([_-]|$)|[_-]pwd([_-]|$))`)
 	// keyValuePattern mirrors secretKeyNamePattern for KEY=value / key: value
 	// text: PWD requires a prefixed separator so "PWD=/home/user" stays intact.
-	keyValuePattern     = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD)[A-Z0-9_.-]*|[A-Z0-9_.-]+[_-]PWD[A-Z0-9_.-]*|AUTHORIZATION)\b(\s*[:=]\s*)(?:Bearer\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
+	// The optional auth-scheme group keeps schemes like "Basic"/"Digest" out of
+	// the value capture, so the credential after the scheme word is what gets
+	// masked (an uncaptured scheme would itself be swallowed as the value,
+	// leaving the real credential in the clear right behind it).
+	keyValuePattern     = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD)[A-Z0-9_.-]*|[A-Z0-9_.-]+[_-]PWD[A-Z0-9_.-]*|AUTHORIZATION)\b(\s*[:=]\s*)((?:Bearer|Basic|Digest|Negotiate|NTLM|Token|Bot|ApiKey)\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
 	bearerTokenPattern  = regexp.MustCompile(`(?i)\bBearer\s+([A-Za-z0-9._~+/=-]{16,})`)
 	openAIKeyPattern    = regexp.MustCompile(`\b((?:sk|rk)-(?:proj-)?[A-Za-z0-9_-]{12,})\b`)
 	githubTokenPattern  = regexp.MustCompile(`\b(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b`)
@@ -120,18 +124,19 @@ func Redact(s string) string {
 	}
 	s = keyValuePattern.ReplaceAllStringFunc(s, func(match string) string {
 		parts := keyValuePattern.FindStringSubmatch(match)
-		if len(parts) != 6 {
+		if len(parts) != 7 {
 			return redactedValue
 		}
 		key := parts[1]
 		sep := parts[2]
-		quote := parts[3]
-		value := parts[4]
-		endQuote := parts[5]
+		scheme := parts[3]
+		quote := parts[4]
+		value := parts[5]
+		endQuote := parts[6]
 		if strings.EqualFold(key, "authorization") {
-			return key + sep + quote + redactedValue + endQuote
+			return key + sep + scheme + quote + redactedValue + endQuote
 		}
-		return key + sep + quote + mask(value) + endQuote
+		return key + sep + scheme + quote + mask(value) + endQuote
 	})
 	s = bearerTokenPattern.ReplaceAllStringFunc(s, func(match string) string {
 		token := strings.TrimSpace(strings.TrimPrefix(match, "Bearer"))

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -1,0 +1,48 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactMasksCommonSecretShapes(t *testing.T) {
+	in := strings.Join([]string{
+		"DEEPSEEK_API_KEY=sk-real-secret-value-123456",
+		"Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz",
+		"token xoxb-123456789012-abcdefabcdef",
+		"jwt eyJabc.def.ghi",
+	}, "\n")
+
+	got := Redact(in)
+	for _, leaked := range []string{
+		"sk-real-secret-value-123456",
+		"ghp_abcdefghijklmnopqrstuvwxyz",
+		"xoxb-123456789012-abcdefabcdef",
+		"eyJabc.def.ghi",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("secret leaked %q in:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{"DEEPSEEK_API_KEY=sk-rea", "Authorization: [redacted]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFilterEnvDropsSensitiveKeys(t *testing.T) {
+	got := FilterEnv([]string{
+		"PATH=/usr/bin",
+		"DEEPSEEK_API_KEY=sk-real-secret-value-123456",
+		"GH_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz",
+		"HOME=/tmp/home",
+	})
+	joined := strings.Join(got, "\n")
+	if strings.Contains(joined, "DEEPSEEK_API_KEY") || strings.Contains(joined, "GH_TOKEN") {
+		t.Fatalf("sensitive env survived:\n%s", joined)
+	}
+	if !strings.Contains(joined, "PATH=/usr/bin") || !strings.Contains(joined, "HOME=/tmp/home") {
+		t.Fatalf("non-sensitive env dropped:\n%s", joined)
+	}
+}

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -3,6 +3,8 @@ package secrets
 import (
 	"strings"
 	"testing"
+
+	"reasonix/internal/provider"
 )
 
 func TestRedactMasksCommonSecretShapes(t *testing.T) {
@@ -31,18 +33,131 @@ func TestRedactMasksCommonSecretShapes(t *testing.T) {
 	}
 }
 
+func TestRedactIsIdempotent(t *testing.T) {
+	// The session save path re-redacts loaded (already-redacted) transcripts;
+	// digest stability across load/save cycles requires a byte-for-byte no-op.
+	in := strings.Join([]string{
+		"DEEPSEEK_API_KEY=sk-real-secret-value-123456",
+		"Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz",
+		"DB_PWD='hunter2-swordfish'",
+		"plain text with PWD=/home/user/project untouched",
+	}, "\n")
+	once := Redact(in)
+	twice := Redact(once)
+	if once != twice {
+		t.Fatalf("Redact not idempotent:\nonce:  %q\ntwice: %q", once, twice)
+	}
+}
+
+func TestRedactLeavesWorkingDirectoryPWDAlone(t *testing.T) {
+	in := "PWD=/home/user/project\nOLDPWD=/home/user\nDB_PWD=hunter2-swordfish-123"
+	got := Redact(in)
+	if !strings.Contains(got, "PWD=/home/user/project") {
+		t.Fatalf("POSIX PWD variable was mangled:\n%s", got)
+	}
+	if !strings.Contains(got, "OLDPWD=/home/user") {
+		t.Fatalf("OLDPWD was mangled:\n%s", got)
+	}
+	if strings.Contains(got, "hunter2-swordfish-123") {
+		t.Fatalf("DB_PWD value leaked:\n%s", got)
+	}
+}
+
+func TestEnvKeySensitive(t *testing.T) {
+	sensitive := []string{"DEEPSEEK_API_KEY", "GH_TOKEN", "AWS_SECRET_ACCESS_KEY", "DB_PASSWORD", "MYSQL_PWD", "NPM_TOKEN"}
+	for _, key := range sensitive {
+		if !EnvKeySensitive(key) {
+			t.Errorf("EnvKeySensitive(%q) = false, want true", key)
+		}
+	}
+	benign := []string{"PWD", "OLDPWD", "PATH", "HOME", "LANG", "GOPATH", "TERM"}
+	for _, key := range benign {
+		if EnvKeySensitive(key) {
+			t.Errorf("EnvKeySensitive(%q) = true, want false", key)
+		}
+	}
+}
+
 func TestFilterEnvDropsSensitiveKeys(t *testing.T) {
 	got := FilterEnv([]string{
 		"PATH=/usr/bin",
 		"DEEPSEEK_API_KEY=sk-real-secret-value-123456",
 		"GH_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz",
+		"PWD=/home/user/project",
 		"HOME=/tmp/home",
 	})
 	joined := strings.Join(got, "\n")
 	if strings.Contains(joined, "DEEPSEEK_API_KEY") || strings.Contains(joined, "GH_TOKEN") {
 		t.Fatalf("sensitive env survived:\n%s", joined)
 	}
-	if !strings.Contains(joined, "PATH=/usr/bin") || !strings.Contains(joined, "HOME=/tmp/home") {
-		t.Fatalf("non-sensitive env dropped:\n%s", joined)
+	for _, want := range []string{"PATH=/usr/bin", "HOME=/tmp/home", "PWD=/home/user/project"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("non-sensitive env %q dropped:\n%s", want, joined)
+		}
+	}
+}
+
+func TestProcessEnvUnfilteredByDefault(t *testing.T) {
+	t.Setenv("REASONIX_TEST_SECRET_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+	joined := strings.Join(ProcessEnv(), "\n")
+	if !strings.Contains(joined, "REASONIX_TEST_SECRET_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("ProcessEnv filtered by default; filter_subprocess_env must be opt-in:\n%s", joined)
+	}
+
+	SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { SetFilterSubprocessEnv(false) })
+	joined = strings.Join(ProcessEnv(), "\n")
+	if strings.Contains(joined, "REASONIX_TEST_SECRET_TOKEN") {
+		t.Fatalf("ProcessEnv leaked sensitive key with filtering enabled:\n%s", joined)
+	}
+}
+
+func TestRedactToolOutputHonorsToggle(t *testing.T) {
+	const in = "DEEPSEEK_API_KEY=sk-real-secret-value-123456"
+	if got := RedactToolOutput(in); strings.Contains(got, "sk-real-secret-value-123456") {
+		t.Fatalf("tool output not redacted by default:\n%s", got)
+	}
+	SetRedactToolOutput(false)
+	t.Cleanup(func() { SetRedactToolOutput(true) })
+	if got := RedactToolOutput(in); got != in {
+		t.Fatalf("RedactToolOutput altered output with the toggle off:\n%s", got)
+	}
+	// The durable-surface entry point ignores the toggle.
+	if got := Redact(in); strings.Contains(got, "sk-real-secret-value-123456") {
+		t.Fatalf("Redact must stay active regardless of the toggle:\n%s", got)
+	}
+}
+
+func TestRedactMessagesDoesNotMutateInput(t *testing.T) {
+	const secret = "sk-real-secret-value-123456"
+	msgs := []provider.Message{
+		{
+			Role:    provider.RoleAssistant,
+			Content: "checking",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call_1", Name: "bash", Arguments: `{"command":"echo DEEPSEEK_API_KEY=` + secret + `"}`},
+			},
+			MemoryCitations: []provider.MemoryCitation{{Note: "token " + secret}},
+		},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Content: "DEEPSEEK_API_KEY=" + secret},
+	}
+
+	out := RedactMessages(msgs)
+
+	// The redacted copy must not carry the raw secret...
+	if strings.Contains(out[0].ToolCalls[0].Arguments, secret) || strings.Contains(out[1].Content, secret) {
+		t.Fatalf("redacted copy leaked secret: %+v", out)
+	}
+	// ...and the input — live session history the model still replays — must
+	// be untouched, including through the shared ToolCalls/MemoryCitations
+	// backing arrays.
+	if !strings.Contains(msgs[0].ToolCalls[0].Arguments, secret) {
+		t.Fatalf("RedactMessages mutated the caller's ToolCalls: %q", msgs[0].ToolCalls[0].Arguments)
+	}
+	if !strings.Contains(msgs[0].MemoryCitations[0].Note, secret) {
+		t.Fatalf("RedactMessages mutated the caller's MemoryCitations: %q", msgs[0].MemoryCitations[0].Note)
+	}
+	if !strings.Contains(msgs[1].Content, secret) {
+		t.Fatalf("RedactMessages mutated the caller's Content: %q", msgs[1].Content)
 	}
 }

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -26,10 +26,32 @@ func TestRedactMasksCommonSecretShapes(t *testing.T) {
 			t.Fatalf("secret leaked %q in:\n%s", leaked, got)
 		}
 	}
-	for _, want := range []string{"DEEPSEEK_API_KEY=sk-rea", "Authorization: [redacted]"} {
+	for _, want := range []string{"DEEPSEEK_API_KEY=sk-rea", "Authorization: Bearer [redacted]"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("redacted output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestRedactMasksNonBearerAuthorizationSchemes(t *testing.T) {
+	in := strings.Join([]string{
+		"Authorization: Basic dXNlcjpwYXNzd29yZA==",
+		"Proxy-Authorization: Digest username-hash-abcdef0123456789",
+		"Authorization: dXNlcjpwYXNzd29yZC1yYXc=",
+	}, "\n")
+	got := Redact(in)
+	for _, leaked := range []string{"dXNlcjpwYXNzd29yZA==", "username-hash-abcdef0123456789", "dXNlcjpwYXNzd29yZC1yYXc="} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("authorization credential leaked %q:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{"Authorization: Basic [redacted]", "Digest [redacted]", "Authorization: [redacted]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted output missing %q:\n%s", want, got)
+		}
+	}
+	if again := Redact(got); again != got {
+		t.Fatalf("authorization redaction not idempotent:\nonce:  %q\ntwice: %q", got, again)
 	}
 }
 

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/jobs"
 	"reasonix/internal/proc"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
 )
@@ -496,7 +497,7 @@ func commandPreview(cmd string) string {
 }
 
 func bashCommandEnv(ctx context.Context) []string {
-	env := os.Environ()
+	env := secrets.ProcessEnv()
 	if runtime.GOOS == "windows" {
 		return env
 	}

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -555,6 +555,9 @@ func runShellPATHCommand(parent context.Context, shell string, args []string) []
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, shell, args...)
+	// Explicit env so the login-shell probe honors [secrets]
+	// filter_subprocess_env instead of inheriting the full environment.
+	cmd.Env = secrets.ProcessEnv()
 	proc.PrepareShellPATHProbe(cmd)
 	cmd.Stdin = strings.NewReader("")
 	out, _ := cmd.CombinedOutput()

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 )
 
 func TestBashMergesLoginShellPath(t *testing.T) {
@@ -52,10 +53,15 @@ func TestBashMergesLoginShellPath(t *testing.T) {
 	}
 }
 
-func TestBashCommandEnvFiltersSensitiveKeys(t *testing.T) {
+func TestBashCommandEnvFiltersSensitiveKeysWhenEnabled(t *testing.T) {
+	secrets.SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { secrets.SetFilterSubprocessEnv(false) })
 	t.Setenv("DEEPSEEK_API_KEY", "sk-real-secret-value-123456")
 	t.Setenv("GH_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
 	t.Setenv("REASONIX_TEST_VISIBLE", "ok")
+	// PWD is the POSIX working-directory variable, not a password: the name
+	// filter must never strip it or every subprocess loses its cwd context.
+	t.Setenv("PWD", "/tmp/somewhere")
 
 	env := strings.Join(bashCommandEnv(context.Background()), "\n")
 	if strings.Contains(env, "DEEPSEEK_API_KEY") || strings.Contains(env, "GH_TOKEN") {
@@ -63,6 +69,18 @@ func TestBashCommandEnvFiltersSensitiveKeys(t *testing.T) {
 	}
 	if !strings.Contains(env, "REASONIX_TEST_VISIBLE=ok") {
 		t.Fatalf("bash env dropped non-sensitive key:\n%s", env)
+	}
+	if !strings.Contains(env, "PWD=/tmp/somewhere") {
+		t.Fatalf("bash env dropped PWD:\n%s", env)
+	}
+}
+
+func TestBashCommandEnvKeepsTokensByDefault(t *testing.T) {
+	t.Setenv("GH_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+
+	env := strings.Join(bashCommandEnv(context.Background()), "\n")
+	if !strings.Contains(env, "GH_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("bash env must inherit tokens while filter_subprocess_env is off (default):\n%s", env)
 	}
 }
 

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -52,6 +52,20 @@ func TestBashMergesLoginShellPath(t *testing.T) {
 	}
 }
 
+func TestBashCommandEnvFiltersSensitiveKeys(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "sk-real-secret-value-123456")
+	t.Setenv("GH_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+	t.Setenv("REASONIX_TEST_VISIBLE", "ok")
+
+	env := strings.Join(bashCommandEnv(context.Background()), "\n")
+	if strings.Contains(env, "DEEPSEEK_API_KEY") || strings.Contains(env, "GH_TOKEN") {
+		t.Fatalf("bash env leaked sensitive keys:\n%s", env)
+	}
+	if !strings.Contains(env, "REASONIX_TEST_VISIBLE=ok") {
+		t.Fatalf("bash env dropped non-sensitive key:\n%s", env)
+	}
+}
+
 func TestParseShellPATH(t *testing.T) {
 	const marker = "__REASONIX_BASH_PATH__="
 	cases := []struct {

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -128,3 +128,17 @@ func TestMergePathLists(t *testing.T) {
 		})
 	}
 }
+
+func TestRunShellPATHCommandFiltersEnvWhenEnabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell probe")
+	}
+	secrets.SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { secrets.SetFilterSubprocessEnv(false) })
+	t.Setenv("REASONIX_TEST_SECRET_TOKEN", "ghp_abcdefghijklmnopqrstuvwxyz")
+
+	out := runShellPATHCommand(context.Background(), "/bin/sh", []string{"-c", `printf 'tok=%s' "${REASONIX_TEST_SECRET_TOKEN:-none}"`})
+	if !strings.Contains(string(out), "tok=none") {
+		t.Fatalf("login-shell PATH probe leaked filtered env: %q", out)
+	}
+}

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -71,22 +72,43 @@ func ConfineReaders(forbidRoots []string) []tool.Tool {
 	}
 }
 
-// confineRead reports whether target is inside any forbidRoot. An empty
-// forbidRoots slice is unconfined (returns false). Callers should return a
-// result that mimics the directory appearing empty, matching
-// the tmpfs semantics the bubblewrap sandbox provides. Deny-side, so the
-// check folds case on case-insensitive platforms (see withinFold): a
-// case-variant of a forbidden path reaches the same bytes there.
+// confineRead reports whether target is inside any forbidRoot or matches
+// Reasonix's built-in sensitive credential path denylist. Callers should return
+// a result that mimics the directory appearing empty, matching the tmpfs
+// semantics the bubblewrap sandbox provides. Deny-side, so the check folds case
+// on case-insensitive platforms (see withinFold): a case-variant of a forbidden
+// path reaches the same bytes there.
 func confineRead(forbidRoots []string, target string) bool {
-	if len(forbidRoots) == 0 {
-		return false
-	}
 	abs, err := realPath(target)
 	if err != nil {
 		return false // can't resolve -> let the caller's normal error path handle it
 	}
+	if sensitiveReadPath(abs) {
+		return true
+	}
 	for _, r := range forbidRoots {
 		if withinFold(r, abs) {
+			return true
+		}
+	}
+	return false
+}
+
+func sensitiveReadPath(abs string) bool {
+	clean := filepath.Clean(abs)
+	name := strings.ToLower(filepath.Base(clean))
+	switch name {
+	case ".env", ".git-credentials", ".netrc":
+		return true
+	}
+	for _, ext := range []string{".pem", ".key", ".p12", ".pfx"} {
+		if strings.HasSuffix(name, ext) {
+			return true
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		if withinFold(filepath.Join(home, ".ssh"), clean) {
 			return true
 		}
 	}

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -10,6 +10,7 @@ import (
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/tool"
 )
 
@@ -72,18 +73,24 @@ func ConfineReaders(forbidRoots []string) []tool.Tool {
 	}
 }
 
-// confineRead reports whether target is inside any forbidRoot or matches
-// Reasonix's built-in sensitive credential path denylist. Callers should return
-// a result that mimics the directory appearing empty, matching the tmpfs
-// semantics the bubblewrap sandbox provides. Deny-side, so the check folds case
-// on case-insensitive platforms (see withinFold): a case-variant of a forbidden
+// confineRead reports whether target is inside any forbidRoot or, when the
+// user enabled [secrets] protect_sensitive_files, matches Reasonix's built-in
+// sensitive credential path denylist. An empty forbidRoots slice with the
+// denylist off is unconfined (returns false). Callers should return a result
+// that mimics the directory appearing empty, matching the tmpfs semantics the
+// bubblewrap sandbox provides. Deny-side, so the check folds case on
+// case-insensitive platforms (see withinFold): a case-variant of a forbidden
 // path reaches the same bytes there.
 func confineRead(forbidRoots []string, target string) bool {
+	protect := secrets.ProtectSensitiveFiles()
+	if len(forbidRoots) == 0 && !protect {
+		return false
+	}
 	abs, err := realPath(target)
 	if err != nil {
 		return false // can't resolve -> let the caller's normal error path handle it
 	}
-	if sensitiveReadPath(abs) {
+	if protect && sensitiveReadPath(abs) {
 		return true
 	}
 	for _, r := range forbidRoots {

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -13,6 +13,7 @@ import (
 
 	"reasonix/internal/config"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 )
 
 func TestWithin(t *testing.T) {
@@ -280,7 +281,16 @@ func TestConfineReadBlocksReadFile(t *testing.T) {
 	}
 }
 
-func TestDefaultSensitiveReadPathsAreBlocked(t *testing.T) {
+// withProtectSensitiveFiles flips the [secrets] protect_sensitive_files
+// toggle for one test and restores the default-off state afterwards.
+func withProtectSensitiveFiles(t *testing.T, enabled bool) {
+	t.Helper()
+	secrets.SetProtectSensitiveFiles(enabled)
+	t.Cleanup(func() { secrets.SetProtectSensitiveFiles(false) })
+}
+
+func TestSensitiveReadPathsAreBlockedWhenProtected(t *testing.T) {
+	withProtectSensitiveFiles(t, true)
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
 	if err := os.WriteFile(envPath, []byte("DEEPSEEK_API_KEY=sk-real-secret-value-123456\n"), 0o600); err != nil {
@@ -293,7 +303,7 @@ func TestDefaultSensitiveReadPathsAreBlocked(t *testing.T) {
 
 	for _, path := range []string{envPath, pemPath} {
 		if !confineRead(nil, path) {
-			t.Fatalf("sensitive path %s should be blocked by default", path)
+			t.Fatalf("sensitive path %s should be blocked when protection is on", path)
 		}
 		rf := readFile{}
 		_, err := rf.Execute(context.Background(), argsJSON(t, map[string]any{"path": path}))
@@ -311,7 +321,27 @@ func TestDefaultSensitiveReadPathsAreBlocked(t *testing.T) {
 	}
 }
 
-func TestGlobFiltersSensitiveMatchesByDefault(t *testing.T) {
+func TestSensitiveReadPathsAllowedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("PORT=8080\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if confineRead(nil, envPath) {
+		t.Fatalf(".env should stay readable while protect_sensitive_files is off (default)")
+	}
+	rf := readFile{}
+	out, err := rf.Execute(context.Background(), argsJSON(t, map[string]any{"path": envPath}))
+	if err != nil {
+		t.Fatalf("read_file .env with protection off: %v", err)
+	}
+	if !strings.Contains(out, "PORT=8080") {
+		t.Fatalf("read_file dropped .env content:\n%s", out)
+	}
+}
+
+func TestGlobFiltersSensitiveMatchesWhenProtected(t *testing.T) {
+	withProtectSensitiveFiles(t, true)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("SECRET_TOKEN=abc\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -280,6 +280,59 @@ func TestConfineReadBlocksReadFile(t *testing.T) {
 	}
 }
 
+func TestDefaultSensitiveReadPathsAreBlocked(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("DEEPSEEK_API_KEY=sk-real-secret-value-123456\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pemPath := filepath.Join(dir, "client.pem")
+	if err := os.WriteFile(pemPath, []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{envPath, pemPath} {
+		if !confineRead(nil, path) {
+			t.Fatalf("sensitive path %s should be blocked by default", path)
+		}
+		rf := readFile{}
+		_, err := rf.Execute(context.Background(), argsJSON(t, map[string]any{"path": path}))
+		if err == nil {
+			t.Fatalf("read_file should refuse sensitive path %s", path)
+		}
+	}
+
+	visible := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(visible, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if confineRead(nil, visible) {
+		t.Fatalf("ordinary path %s should not be blocked", visible)
+	}
+}
+
+func TestGlobFiltersSensitiveMatchesByDefault(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("SECRET_TOKEN=abc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := globTool{}
+	out, err := g.Execute(context.Background(), argsJSON(t, map[string]any{"pattern": filepath.Join(dir, "*")}))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if strings.Contains(out, ".env") {
+		t.Fatalf("glob leaked sensitive match:\n%s", out)
+	}
+	if !strings.Contains(out, "notes.txt") {
+		t.Fatalf("glob dropped ordinary match:\n%s", out)
+	}
+}
+
 // --- grep forbid-read ---
 
 func TestConfineReadBlocksGrepFile(t *testing.T) {

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 
 	"reasonix/internal/fileutil"
+	"reasonix/internal/secrets"
 	"reasonix/internal/tool"
 )
 
@@ -102,7 +103,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 }
 
 func filterForbidMatches(matches, forbidRoots []string) []string {
-	if len(matches) == 0 {
+	if len(matches) == 0 || (len(forbidRoots) == 0 && !secrets.ProtectSensitiveFiles()) {
 		return matches
 	}
 	out := matches[:0]

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -102,7 +102,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 }
 
 func filterForbidMatches(matches, forbidRoots []string) []string {
-	if len(forbidRoots) == 0 || len(matches) == 0 {
+	if len(matches) == 0 {
 		return matches
 	}
 	out := matches[:0]

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -280,12 +280,21 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.Duration, rp ResolvedPath) (string, bool, error) {
 	// Build the ripgrep argv and wrap it in the OS sandbox so forbid-read
 	// directories are invisible to the ripgrep subprocess.
-	argv, wrapped := sandbox.CommandArgs(g.sb, []string{
+	args := []string{
 		g.rg,
 		"--no-heading", "--line-number", "--with-filename", "--color", "never",
+		"--glob", "!.env",
+		"--glob", "!.git-credentials",
+		"--glob", "!.netrc",
+		"--glob", "!*.pem",
+		"--glob", "!*.key",
+		"--glob", "!*.p12",
+		"--glob", "!*.pfx",
+		"--glob", "!.ssh/**",
 		"--regexp", pattern,
 		"--", path,
-	})
+	}
+	argv, wrapped := sandbox.CommandArgs(g.sb, args)
 	if len(g.forbidRoots) > 0 && !wrapped {
 		return "", wrapped, nil
 	}

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -19,6 +19,7 @@ import (
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/proc"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/tool"
 )
 
@@ -283,17 +284,22 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 	args := []string{
 		g.rg,
 		"--no-heading", "--line-number", "--with-filename", "--color", "never",
-		"--glob", "!.env",
-		"--glob", "!.git-credentials",
-		"--glob", "!.netrc",
-		"--glob", "!*.pem",
-		"--glob", "!*.key",
-		"--glob", "!*.p12",
-		"--glob", "!*.pfx",
-		"--glob", "!.ssh/**",
-		"--regexp", pattern,
-		"--", path,
 	}
+	if secrets.ProtectSensitiveFiles() {
+		// Mirror sensitiveReadPath for the subprocess: ripgrep cannot call
+		// back into confineRead, so the denylist rides along as glob excludes.
+		args = append(args,
+			"--glob", "!.env",
+			"--glob", "!.git-credentials",
+			"--glob", "!.netrc",
+			"--glob", "!*.pem",
+			"--glob", "!*.key",
+			"--glob", "!*.p12",
+			"--glob", "!*.pfx",
+			"--glob", "!.ssh/**",
+		)
+	}
+	args = append(args, "--regexp", pattern, "--", path)
 	argv, wrapped := sandbox.CommandArgs(g.sb, args)
 	if len(g.forbidRoots) > 0 && !wrapped {
 		return "", wrapped, nil

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -306,6 +306,7 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 	}
 
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Env = secrets.ProcessEnv()
 	proc.HideWindow(cmd)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/winsandbox/sandbox_windows.go
+++ b/internal/winsandbox/sandbox_windows.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
 
 	"golang.org/x/sys/windows"
 )
@@ -1234,7 +1235,7 @@ func windowsSandboxTempRoot(spec Spec) (string, func(), error) {
 
 func windowsSandboxEnv(spec Spec, tempRoot string, env []string) []string {
 	if env == nil {
-		env = os.Environ()
+		env = secrets.ProcessEnv()
 	}
 	env = append([]string(nil), env...)
 	if tempRoot == "" {


### PR DESCRIPTION
## Summary

- Add opt-in credential-protection layers: tool-output redaction (default on), subprocess env filtering (default off), and sensitive-path hiding (default off).
- Redact session transcripts, background-job artifacts, streaming progress, and background-job labels before secrets can persist to disk or durable logs.
- Add `reasonix doctor redact-sessions` so existing local session artifacts from older builds can be dry-run audited and scrubbed without rewriting active sessions.
- Fix PWD false-positive (POSIX working-directory variable vs password suffix), RedactMessage shallow-copy bug, and SaveRecoveryBranch redaction bypass.
- Add `reasonix doctor redact-sessions [--dry-run] [--json] [--dir PATH]` to scrub secrets already persisted in historical session stores (transcripts, event logs, branch metadata, goal state, job artifacts), skipping sessions with an active lease. All JSON-bearing artifacts are decoded before masking and rewritten through the agent's own save machinery, so digests, the CAS ledger, and event-log replay stay coherent and reruns are no-ops; only plain-text job logs are redacted as raw bytes. Stale event-log records that later replace events superseded are scanned and compacted too.
- `filter_subprocess_env` covers every agent-spawned subprocess (probes, login-shell PATH probes, ripgrep, project indexing, plugin-package git, attachment converters, notifiers). Deliberately exempt: the user's `!` passthrough shell (documented escape hatch for credentialed commands), MCP-manager editor/`open` launchers (the user's own apps), and Windows kill/system utilities.
- `[secrets]` renders in the user-scope config output, so config saves preserve the toggles; Authorization schemes beyond Bearer (Basic/Digest/Negotiate/NTLM/Token/Bot) are captured so the credential after the scheme word is what gets masked.

## Changes

- **`internal/secrets`**: `Redact()` (deterministic, idempotent), `RedactToolOutput()` (toggle-aware), `ProcessEnv()` (filter when enabled), `SetRedactToolOutput/SetFilterSubprocessEnv/SetProtectSensitiveFiles` package toggles.
- **`internal/config`**: `[secrets]` section (user-global, project `reasonix.toml` cannot override): `redact_tool_output` (default true), `filter_subprocess_env` (default false), `protect_sensitive_files` (default false).
- **`internal/agent`**: `executeOne` uses `RedactToolOutput` for live surfaces; `save()` and `SaveRecoveryBranch` unconditionally redact for disk.
- **`internal/jobs`**: artifact writes and job labels unconditionally redact.
- **`internal/doctor` / `internal/cli`**: `reasonix doctor redact-sessions` scans known session storage, supports `--dry-run`, `--json`, repeated `--dir`, rewrites only known Reasonix session/job artifact files, and skips sessions with active leases.
- **`internal/tool/builtin`**: `confineRead/filterForbidMatches/runRipgrep` gate built-in denylist on `secrets.ProtectSensitiveFiles()`.
- **`internal/boot`**: arm toggles from `cfg.Secrets` before any subprocess spawns.
- **Regex fixes**: `secretKeyNamePattern` and `keyValuePattern` require `[_-]` prefix for `pwd` (so `PWD=/home/user` stays intact, `DB_PWD=hunter2` gets masked).
- **Clone-before-mutate**: `RedactMessage` deep-copies `ToolCalls`/`MemoryCitations` slices so the save path never writes through to live session state.

## Compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Session `.jsonl` / `.events.jsonl` | Cleanup keeps the same JSONL schema and masks only credential-shaped text values. | Backward-safe. |
| Session metadata / goal sidecars | Cleanup keeps the same file format and masks only credential-shaped text values. | Backward-safe. |
| Event index | Deleted only after cleanup rewrites a matching session artifact; it is derived data and can be rebuilt later. | Backward-safe. |
| Job artifacts / metadata | Cleanup keeps existing `.log` / `.json` formats and masks only credential-shaped text values. | Backward-safe. |

## Verification

- `git diff --check origin/main-v2...HEAD`
- `git diff --check`
- `go test ./...` (local all green)
- Focused coverage: `internal/secrets/redact_test.go` (idempotence, PWD preservation, toggle behavior, no-mutate contract), `internal/agent/save_test.go` (digest stability across redacted load/save cycles), `internal/tool/builtin/*_test.go` (toggle-gated protection, default-off behavior), `internal/config/render_test.go` (project cannot override `[secrets]`), `internal/doctor/session_redact_test.go` and `internal/cli/doctor_test.go` (historical cleanup, dry-run, active lease skip, CLI command), `internal/jobs/artifacts_test.go` (artifact and label redaction).

## Cache impact

Cache-impact: low — system prompt, tool schemas, and tool order unchanged; tool result bytes differ only when they carry credential shapes, and `Redact` is deterministic so re-redacting an already-masked transcript is a byte-for-byte no-op (digest stability proven in `TestSaveRedactionKeepsSnapshotBaselineStable`). The new doctor command is manually invoked cleanup and does not affect normal prompt construction.

Cache-guard: `go test ./...` plus focused regression in `internal/secrets`, `internal/agent/save_test.go`, `internal/tool/builtin`, `internal/jobs`, `internal/doctor`, and `internal/cli`.

System-prompt-review: checked — `internal/environment/probe.go` was modified (switched `os.Environ()` to `secrets.ProcessEnv()`), but this change does not alter system prompt text, tool registration, tool schema bytes/order, memory prefix, or provider request serialization. The environment probe's subprocess env is filtered only when the user explicitly enables `[secrets] filter_subprocess_env = true` (default off). With the default config the probe environment is byte-identical to before, so the cache-stable system prompt derived from probe output is unchanged; a user who opts in accepts a one-time prompt change on their own machine, equivalent to editing their environment.

Fixes #6178

