### PR TITLE
Add real-page notice preview mock

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -162,8 +162,7 @@ import { composerDraftKeyForTab } from "./lib/composerDraftKey";
 import logoWordmark from "./assets/logo-wordmark.svg";
 
 function noticePreviewMockEnabled(): boolean {
-  if (typeof window === "undefined") return false;
-  const value = new URLSearchParams(window.location.search).get("mock")?.trim().toLowerCase();
+  const value = browserMockScenarioParam();
   return value === "notice" || value === "notices" || value === "notice-preview";
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import { useToast } from "./lib/toast";
 import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
-import { useController, type Item, type LiveStream } from "./lib/useController";
+import { localizedBackendNoticeText, useController, type Item, type LiveStream } from "./lib/useController";
 import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
@@ -160,6 +160,84 @@ import { useGlobalShortcut } from "./lib/keyboardShortcuts";
 import { topicShortcutIndexFromEvent, useTopicShortcuts, type TopicShortcutEntry } from "./lib/topicShortcuts";
 import { composerDraftKeyForTab } from "./lib/composerDraftKey";
 import logoWordmark from "./assets/logo-wordmark.svg";
+
+function noticePreviewMockEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  const value = new URLSearchParams(window.location.search).get("mock")?.trim().toLowerCase();
+  return value === "notice" || value === "notices" || value === "notice-preview";
+}
+
+function noticePreviewItems(): Item[] {
+  const notice = (index: number, level: "info" | "warn", text: string, detail: string): Item => ({
+    kind: "notice",
+    id: `notice-preview-${index}`,
+    level,
+    text: localizedBackendNoticeText(text),
+    detail,
+  });
+  return [
+    notice(0, "info", "Task status needs one more check; asking the assistant to finish or explain what is blocking it.", "final-answer readiness blocked: latest successful todo_write still has incomplete items: UI spinner in_progress, settings persistence pending"),
+    notice(1, "info", "No visible answer was produced; asking the assistant to respond again.", "empty final answer blocked: qwen3.7-plus returned no visible answer text (finish=stop, reasoning=2314 chars); retrying"),
+    notice(2, "info", "The assistant answered before taking action; asking it to use the required tools.", "executor handoff: assistant produced a proposal before running required repository commands; nudged to execute"),
+    notice(3, "info", "Tool round limit reached; asking the assistant to summarize progress.", "tool budget reached after 128 tool calls; requesting a progress summary before continuing"),
+    notice(4, "info", "The assistant is stuck retrying a blocked action; asking it to change approach.", "loop guard: repeated command failure matched the same stderr signature across 3 attempts"),
+    notice(5, "info", "Context is getting large; preserving cache until cleanup is needed.", "context window 82% full; deferred cleanup to preserve reusable prompt cache"),
+    notice(6, "info", "Context cleanup skipped for now.", "cleanup skipped: recent turn included unresolved user approval state"),
+    notice(7, "info", "Automatic context cleanup paused because the context window is too small.", "configured compact threshold exceeds current model context window; auto cleanup paused for this model"),
+    notice(8, "info", "Context was compacted without a generated summary.", "compaction completed after upstream summary generation returned empty content; retained transcript checkpoint"),
+    notice(9, "info", "Planning mode enabled for this multi-step task.", "auto plan detector matched implementation task with repository edits and verification steps"),
+    notice(10, "info", "Plan detection requested a plan.", "plan detector confidence=0.83; task includes multiple dependent UI/backend changes"),
+    notice(11, "info", "Plan detection was uncertain; using the fallback planner heuristic.", "plan detector confidence=0.48; fallback heuristic selected because files and tests are involved"),
+    notice(12, "info", "Goal is not ready to complete yet; continuing the remaining work.", "goal completion check found pending validation: desktop/frontend typecheck"),
+    notice(13, "info", "Goal still has unfinished task state; continuing the remaining work.", "active goal has open task state: implement preview, verify browser, report result"),
+    notice(14, "warn", "AutoResearch status update failed.", "autoresearch task completion update failed: write .reasonix/autoresearch/task-42/state/task_spec.json: permission denied"),
+    notice(15, "warn", "AutoResearch task marked blocked.", "autoresearch task blocked: task-42\nreason: missing accepted verification evidence after three turns"),
+    notice(16, "warn", "background export failed: needs attention", "background export failed: session archive upload returned 503 after 3 retries"),
+    notice(17, "warn", "Job artifact migration failed.", "artifact migration failed for job job_123: checksum mismatch while moving output.zip"),
+    notice(18, "warn", "Background job teardown timed out.", "job job_123 did not stop within 10s; process is still marked running by the supervisor"),
+    notice(19, "warn", "Some plan-mode tool settings were ignored.", "plan-mode tool settings ignored: unsupported tool allowlist entry \"browser.screenshot\""),
+    notice(20, "warn", "Some plan-mode command settings were ignored.", "plan-mode command settings ignored: invalid read-only prefix \"npm && test\""),
+    notice(21, "warn", "Config migration did not complete.", "config migration failed at providers.defaultModel: unknown provider reference \"old/deepseek\""),
+    notice(22, "warn", "Selected model is missing its API key.", "selected model deepseek/deepseek-v4-pro requires DEEPSEEK_API_KEY, but no key is configured"),
+    notice(23, "warn", "An MCP server failed to start.", "mcp server \"github\" failed to start: command not found: mcp-server-github"),
+    notice(24, "warn", "Some MCP servers failed to start; run /mcp for details.", "mcp startup failures: github(command not found), linear(authentication expired)"),
+    notice(25, "warn", "Guardian was disabled because its model was not found.", "guardian model \"glm-5-guard\" is not present in the configured provider catalog"),
+    notice(26, "warn", "Guardian was disabled because it could not start.", "guardian startup failed: provider returned 401 unauthorized"),
+  ];
+}
+
+function NoticePreviewPanel({ detailsLabel }: { detailsLabel: string }) {
+  return (
+    <div
+      style={{
+        flex: "1 1 auto",
+        minHeight: 0,
+        overflow: "auto",
+        padding: "44px 24px 128px",
+      }}
+    >
+      <div style={{ maxWidth: 920, margin: "0 auto" }}>
+        {noticePreviewItems().map((item) => {
+          if (item.kind !== "notice") return null;
+          return (
+            <div key={item.id} className={`notice-line notice-line--${item.level}`} data-entrance="true">
+              <span className="notice-line__icon">{item.level === "warn" ? "⚠ " : "ℹ "}</span>
+              <span className="notice-line__text">
+                {item.text}
+                {item.detail ? (
+                  <details className="notice-line__details">
+                    <summary>{detailsLabel}</summary>
+                    <pre>{item.detail}</pre>
+                  </details>
+                ) : null}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 const HistoryPanel = lazy(() => import("./components/HistoryPanel").then((module) => ({ default: module.HistoryPanel })));
 const SettingsPanel = lazy(() => import("./components/SettingsPanel").then((module) => ({ default: module.SettingsPanel })));
@@ -2290,7 +2368,6 @@ export default function App() {
     if (!rewindState) return transcriptItems;
     return transcriptItems.slice(0, rewindState.boundaryIdx).filter((it) => it.kind !== "compaction");
   }, [transcriptItems, rewindState]);
-
   const latestGuidanceConsumed = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const item = state.items[i];
@@ -3444,6 +3521,8 @@ export default function App() {
                 onManageAllowlist={() => openBotAllowlistSettings(sidebarImDetailConnection.connectionId)}
                 onOpenSession={() => void openSidebarImConnectionSession(sidebarImDetailConnection)}
               />
+            ) : noticePreviewMockEnabled() ? (
+              <NoticePreviewPanel detailsLabel={t("notice.details")} />
             ) : (
               <Transcript
                 items={displayItems}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -221,15 +221,15 @@ function NoticePreviewPanel({ detailsLabel }: { detailsLabel: string }) {
           return (
             <div key={item.id} className={`notice-line notice-line--${item.level}`} data-entrance="true">
               <span className="notice-line__icon">{item.level === "warn" ? "⚠ " : "ℹ "}</span>
-              <span className="notice-line__text">
+              <div className="notice-line__text">
                 {item.text}
                 {item.detail ? (
                   <details className="notice-line__details">
                     <summary>{detailsLabel}</summary>
-                    <pre>{item.detail}</pre>
+                    <div>{item.detail}</div>
                   </details>
                 ) : null}
-              </span>
+              </div>
             </div>
           );
         })}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -729,13 +729,14 @@ function browserPlatformOverride(): "darwin" | "windows" | "linux" | "" {
   return value === "darwin" || value === "windows" || value === "linux" ? value : "";
 }
 
-function mockScenario(): "demo" | "fresh" | "running" | "guidance" | "sandbox_escape" {
+function mockScenario(): "demo" | "fresh" | "running" | "guidance" | "sandbox_escape" | "notice" {
   if (typeof window === "undefined") return "demo";
   const value = new URLSearchParams(window.location.search).get("mock")?.trim().toLowerCase();
   if (value === "fresh" || value === "empty" || value === "first-run") return "fresh";
   if (value === "guidance" || value === "guide" || value === "steer") return "guidance";
   if (value === "running" || value === "busy" || value === "streaming") return "running";
   if (value === "sandbox_escape" || value === "sandbox-escape" || value === "sandboxescape") return "sandbox_escape";
+  if (value === "notice" || value === "notices" || value === "notice-preview") return "notice";
   return "demo";
 }
 
@@ -884,6 +885,7 @@ function makeMockApp(): AppBindings {
   const guidanceMock = scenario === "guidance";
   const runningMock = scenario === "running" || guidanceMock;
   const sandboxEscapeMock = scenario === "sandbox_escape";
+  const noticePreviewMock = scenario === "notice";
   const mockAttachmentDataURLs = new Map<string, string>();
   let cancelled = false;
   let pendingAskPreview = false;
@@ -1412,8 +1414,17 @@ function makeMockApp(): AppBindings {
     });
     return out;
   };
+  const noticePreviewHistory = (): HistoryMessage[] => [
+    { role: "user", content: "在真实聊天页面里预览 compact notice 的展示效果。" },
+    {
+      role: "assistant",
+      content: "下面是同一套 Transcript 渲染出来的提示。信息类提示更低调，诊断细节默认折叠；需要用户处理的失败仍保留警告样式。展开任意“详情”可以看到完整诊断文本。",
+    },
+  ];
 	  const mockTopicHistory = (topicId: string): HistoryMessage[] => {
 	    switch (topicId) {
+      case "topic_notice_preview":
+        return noticePreviewHistory();
       case "topic_product":
         return [
           {
@@ -1567,7 +1578,28 @@ function makeMockApp(): AppBindings {
     setMockTabRunning(currentMockTurnTabId(), false);
     emit({ kind: "turn_done" });
   };
-  let mockTabs: TabMeta[] = freshMock ? [
+  let mockTabs: TabMeta[] = noticePreviewMock ? [
+    {
+      id: "tab_notice_preview",
+      scope: "project",
+      workspaceRoot: "~/projects/reasonix",
+      workspaceName: "reasonix",
+      workspacePath: "~/projects/reasonix",
+      gitBranch: "codex/compact-chat-notices-i18n",
+      topicId: "topic_notice_preview",
+      topicTitle: "Compact notice preview",
+      projectColor: "green",
+      label: "DeepSeek-R1",
+      ready: true,
+      running: false,
+      mode: "normal",
+      collaborationMode: "normal",
+      toolApprovalMode: "ask",
+      tokenMode: "full",
+      active: true,
+      cwd: "~/projects/reasonix",
+    },
+  ] : freshMock ? [
     {
       id: "tab_global",
       scope: "global",

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1414,17 +1414,8 @@ function makeMockApp(): AppBindings {
     });
     return out;
   };
-  const noticePreviewHistory = (): HistoryMessage[] => [
-    { role: "user", content: "在真实聊天页面里预览 compact notice 的展示效果。" },
-    {
-      role: "assistant",
-      content: "下面是同一套 Transcript 渲染出来的提示。信息类提示更低调，诊断细节默认折叠；需要用户处理的失败仍保留警告样式。展开任意“详情”可以看到完整诊断文本。",
-    },
-  ];
 	  const mockTopicHistory = (topicId: string): HistoryMessage[] => {
 	    switch (topicId) {
-      case "topic_notice_preview":
-        return noticePreviewHistory();
       case "topic_product":
         return [
           {


### PR DESCRIPTION
## Summary
- add a browser-dev `?mock=notice` scenario/tab in the desktop frontend bridge
- render compact backend notices inside the real chat page using the existing notice-line styles
- keep the preview scoped to browser mock URLs and outside the normal transcript path to avoid UI overlap

## Test
- cd desktop/frontend && npm run typecheck
- cd desktop/frontend && npx tsx src/__tests__/use-controller-meta.test.ts
- cd desktop/frontend && npm run check:css

## Cache impact
Cache-impact: none, browser-only mock preview for desktop frontend notices; no provider-visible prompt, tool schema, memory prefix, or runtime cache behavior changes.
Cache-guard: frontend typecheck, focused controller notice test, CSS checks, plus GitHub cache-impact guard.