### PR TITLE
Explicit planner no-op contract and executor fallback on planner failure / 规划模型 no-op 显式合约与故障回退执行模型

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1195,7 +1195,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		// Grace round guard: if we already gave the model one extra response
 		// and it still wants to call tools, stop here.
 		if graceRound {
-			return fmt.Errorf("paused after %d tool-call rounds (%s) — the work so far is saved; send another message to continue, or set %s higher or to 0 for no limit", a.maxSteps, a.maxStepsKey, a.maxStepsKey)
+			return &maxStepsPause{steps: a.maxSteps, key: a.maxStepsKey}
 		}
 
 		results := a.executeBatch(ctx, calls)
@@ -1229,7 +1229,21 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	// Only reached when a positive maxSteps guard is configured. The work so far
 	// is already in the session, so the user can just send another message to pick
 	// up where it left off.
-	return fmt.Errorf("paused after %d tool-call rounds (%s) — the work so far is saved; send another message to continue, or set %s higher or to 0 for no limit", a.maxSteps, a.maxStepsKey, a.maxStepsKey)
+	return &maxStepsPause{steps: a.maxSteps, key: a.maxStepsKey}
+}
+
+// maxStepsPause is the deliberate stop when a positive tool-call budget runs
+// out: the session already holds the completed work and the user is asked to
+// continue. It is a control-flow signal, not a provider failure — Coordinator
+// matches on it to surface the pause instead of degrading the turn to
+// executor-only.
+type maxStepsPause struct {
+	steps int
+	key   string
+}
+
+func (e *maxStepsPause) Error() string {
+	return fmt.Sprintf("paused after %d tool-call rounds (%s) — the work so far is saved; send another message to continue, or set %s higher or to 0 for no limit", e.steps, e.key, e.key)
 }
 
 func (a *Agent) emitMemoryCompilerStats(turn *memorycompiler.Turn) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -403,6 +403,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 // executor while preserving its separate session and cache prefix.
 func (c *Coordinator) planWithTools(ctx context.Context, input string) (string, error) {
 	before := c.plannerSess.Snapshot()
+	rewriteBefore := c.plannerSess.RewriteVersion()
 	if err := c.plannerAgent.Run(ctx, input); err != nil {
 		// Mirror plan()'s rollback: Run already appended the user message
 		// (and possibly partial assistant/tool rounds) to the planner
@@ -416,7 +417,18 @@ func (c *Coordinator) planWithTools(ctx context.Context, input string) (string, 
 		}
 		return "", err
 	}
-	for i := len(c.plannerSess.Messages) - 1; i >= len(before); i-- {
+	// The plan is this turn's final answer: the last non-empty assistant
+	// message appended after the pre-turn boundary. When a session rewrite
+	// landed during the turn (auto-compaction fires right after the final
+	// answer), the pre-turn length no longer maps to a boundary in the
+	// rewritten log — it can even exceed it, hiding a successfully produced
+	// plan. Rewrites keep the recent tail verbatim, so scanning the whole
+	// rewritten session from the end still finds the final answer first.
+	floor := len(before)
+	if c.plannerSess.RewriteVersion() != rewriteBefore {
+		floor = 0
+	}
+	for i := len(c.plannerSess.Messages) - 1; i >= floor; i-- {
 		m := c.plannerSess.Messages[i]
 		if m.Role == provider.RoleAssistant && strings.TrimSpace(m.Content) != "" {
 			return m.Content, nil

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,9 +28,22 @@ have enough evidence. Do not write full implementations or attempt side effects.
 Do not ask the user how to trigger the executor and do not say you are waiting
 for the executor. Output executor-ready instructions: what to do, which files or
 commands are relevant, expected blockers, and key decisions. Keep it short and
-actionable.`
+actionable.
+If your research shows the task needs no changes and no actions at all (already
+implemented, already resolved), explain that briefly and end your reply with a
+final line containing exactly [no_changes]. Never emit that marker when any
+work, verification, or follow-up remains.`
 
 const executorHandoffMarker = "Reasonix executor handoff"
+
+// plannerFallbackNotice is shown when the planner fails and the turn degrades
+// to executor-only instead of failing outright.
+const plannerFallbackNotice = "Planner failed; continuing this turn with the executor only."
+
+// noChangesMarker is the explicit no-op conclusion the planner is asked to emit
+// on its final line (see DefaultPlannerPrompt). isNoOpPlan trusts it over the
+// legacy phrase heuristics.
+const noChangesMarker = "[no_changes]"
 
 // PlannerPromptWithContext appends cache-stable standing context, such as loaded
 // REASONIX.md / AGENTS.md memory, to the planner's smaller system prompt.
@@ -208,7 +222,21 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning", Source: event.UsageSourcePlanner})
 	plan, err := c.plan(ctx, input)
 	if err != nil {
-		return fmt.Errorf("planner: %w", err)
+		// Cancellation and max-steps pauses are control flow, not planner
+		// failures: the first is the user aborting the turn, the second has
+		// saved work in the planner session and asks the user to continue.
+		// Neither may silently restart on the executor.
+		var pause *maxStepsPause
+		if ctx.Err() != nil || errors.As(err, &pause) {
+			return fmt.Errorf("planner: %w", err)
+		}
+		// A planner failure must not take down the turn: the executor is
+		// healthy and owns the full tool set, so degrade to single-model for
+		// this turn (mirroring the auto-plan classifier's fallback to the
+		// heuristic when it errors).
+		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: plannerFallbackNotice, Detail: "planner failed; running the executor without a plan: " + err.Error(), Source: event.UsageSourcePlanner})
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
+		return c.executor.Run(ctx, input)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 	if isNoOpPlan(plan) {
@@ -219,12 +247,26 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	return c.executor.Run(ctx, formatHandoff(input, plan, executorToolHandoffContext(c.executor)))
 }
 
+// isNoOpPlan reports whether the plan explicitly concludes that nothing needs
+// to change. The primary contract is the [no_changes] marker requested from the
+// planner in DefaultPlannerPrompt: on the final non-empty line it is trusted
+// as-is, so research notes above it (which may mention tests, runs, or edits
+// that already exist) cannot veto the conclusion. The legacy phrase list stays
+// as a fallback for planners that ignore the marker, but it only matches
+// conclusion positions (the first or last non-empty line) and is vetoed by
+// action verbs anywhere in the plan: a wrong skip silently drops the task,
+// while a missed skip just costs one executor round.
 func isNoOpPlan(plan string) bool {
-	lower := strings.ToLower(strings.TrimSpace(plan))
-	if lower == "" {
+	trimmed := strings.TrimSpace(plan)
+	if trimmed == "" {
 		return false
 	}
-	if containsNoOpActionTerm(lower) {
+	first := strings.ToLower(firstNonEmptyLine(trimmed))
+	last := strings.ToLower(lastNonEmptyLine(trimmed))
+	if strings.Contains(last, noChangesMarker) {
+		return true
+	}
+	if containsNoOpActionTerm(strings.ToLower(trimmed)) {
 		return false
 	}
 	noOp := []string{
@@ -239,7 +281,6 @@ func isNoOpPlan(plan string) bool {
 		"already handled",
 		"already implemented",
 		"already resolved",
-		"[no_changes]",
 		"无需改动",
 		"无需修改",
 		"无需更改",
@@ -254,20 +295,43 @@ func isNoOpPlan(plan string) bool {
 		"已经解决",
 	}
 	for _, phrase := range noOp {
-		if strings.Contains(lower, phrase) && !strings.Contains(lower, "not "+phrase) && !strings.Contains(lower, "不是"+phrase) {
-			return true
+		for _, line := range []string{first, last} {
+			if strings.Contains(line, phrase) && !strings.Contains(line, "not "+phrase) && !strings.Contains(line, "不是"+phrase) {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
 }
 
 func containsNoOpActionTerm(lower string) bool {
 	terms := []string{
 		" add ", " add docs", " add tests", " update ", " edit ", " write ",
 		" create ", " delete ", " remove ", " patch ", " refactor ", " implement ",
-		" run ", " test ", " build ", " fix ",
+		" run ", " test ", " build ", " fix ", " extend ", " verify ", " check ",
+		" investigate ",
 		"新增", "补充", "更新", "编辑", "写入", "创建", "删除", "移除",
-		"运行", "测试", "构建", "修复", "实现", "重构",
+		"运行", "测试", "构建", "修复", "实现", "重构", "扩展", "验证", "排查",
+		"检查", "调查",
 	}
 	padded := " " + lower + " "
 	for _, term := range terms {
@@ -292,6 +356,11 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 	if c.plannerAgent != nil {
 		return c.planWithTools(ctx, input)
 	}
+	// On failure, roll the just-added user message back: a dangling user turn
+	// would produce consecutive user roles on the next plan (which some
+	// providers reject), and Run's executor fallback keeps the turn alive
+	// after this error, so the planner session must stay coherent.
+	before := c.plannerSess.Snapshot()
 	c.plannerSess.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
 	ch, err := c.planner.Stream(ctx, provider.Request{
@@ -299,6 +368,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 		Temperature: provider.OptionalTemperature(c.temperature),
 	})
 	if err != nil {
+		c.plannerSess.Replace(before)
 		return "", err
 	}
 
@@ -312,6 +382,7 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 		case provider.ChunkUsage:
 			usage = chunk.Usage
 		case provider.ChunkError:
+			c.plannerSess.Replace(before)
 			return "", chunk.Err
 		}
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -249,9 +249,12 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 
 // isNoOpPlan reports whether the plan explicitly concludes that nothing needs
 // to change. The primary contract is the [no_changes] marker requested from the
-// planner in DefaultPlannerPrompt: on the final non-empty line it is trusted
-// as-is, so research notes above it (which may mention tests, runs, or edits
-// that already exist) cannot veto the conclusion. The legacy phrase list stays
+// planner in DefaultPlannerPrompt: when the final non-empty line IS the marker
+// (exactly, as the prompt asks) it is trusted as-is, so research notes above it
+// (which may mention tests, runs, or edits that already exist) cannot veto the
+// conclusion. A final line that merely mentions the marker in prose ("do not
+// emit [no_changes] because…") is not a conclusion and falls through to the
+// veto-guarded heuristics below. The legacy phrase list stays
 // as a fallback for planners that ignore the marker, but it only matches
 // conclusion positions (the first or last non-empty line) and is vetoed by
 // action verbs anywhere in the plan: a wrong skip silently drops the task,
@@ -263,7 +266,7 @@ func isNoOpPlan(plan string) bool {
 	}
 	first := strings.ToLower(firstNonEmptyLine(trimmed))
 	last := strings.ToLower(lastNonEmptyLine(trimmed))
-	if strings.Contains(last, noChangesMarker) {
+	if last == noChangesMarker {
 		return true
 	}
 	if containsNoOpActionTerm(strings.ToLower(trimmed)) {
@@ -399,16 +402,29 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 // read-only registry. That gives the planner the same tool-call contract as the
 // executor while preserving its separate session and cache prefix.
 func (c *Coordinator) planWithTools(ctx context.Context, input string) (string, error) {
-	before := len(c.plannerSess.Messages)
+	before := c.plannerSess.Snapshot()
 	if err := c.plannerAgent.Run(ctx, input); err != nil {
+		// Mirror plan()'s rollback: Run already appended the user message
+		// (and possibly partial assistant/tool rounds) to the planner
+		// session, and Coordinator.Run degrades to the executor on planner
+		// failure, so a dangling user message would produce consecutive
+		// user roles on the next plan. A max-steps pause is exempt: its
+		// saved work is what the user is asked to continue from.
+		var pause *maxStepsPause
+		if !errors.As(err, &pause) {
+			c.plannerSess.Replace(before)
+		}
 		return "", err
 	}
-	for i := len(c.plannerSess.Messages) - 1; i >= before; i-- {
+	for i := len(c.plannerSess.Messages) - 1; i >= len(before); i-- {
 		m := c.plannerSess.Messages[i]
 		if m.Role == provider.RoleAssistant && strings.TrimSpace(m.Content) != "" {
 			return m.Content, nil
 		}
 	}
+	// No usable plan came back: roll back too, so the executor-fallback turn
+	// does not leave the planner session ending in a user message.
+	c.plannerSess.Replace(before)
 	return "", fmt.Errorf("planner finished without producing a plan")
 }
 

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -1011,3 +1011,57 @@ func TestCoordinatorRunsExecutorWhenMarkerNotAlone(t *testing.T) {
 		t.Fatal("executor skipped: a final line mentioning the marker in prose was treated as a no-op conclusion")
 	}
 }
+
+// TestCoordinatorHandoffSurvivesPlannerCompaction pins the plan-scan boundary
+// against session rewrites: when the tool-enabled planner's final answer pushes
+// usage past the compaction trigger, Agent.Run rewrites and shortens the
+// planner session right after producing the plan. The pre-turn message count
+// then no longer bounds "this turn's messages" — scanning from it must not
+// hide the plan, or Coordinator.Run degrades to a raw executor turn despite a
+// successful plan.
+func TestCoordinatorHandoffSurvivesPlannerCompaction(t *testing.T) {
+	planner := &mockProvider{name: "planner", streams: [][]provider.Chunk{
+		{ // the plan, with usage past the force-compaction watermark
+			{Type: provider.ChunkText, Text: "Edit main.go and add the missing guard."},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 1900, TotalTokens: 1950}},
+			{Type: provider.ChunkDone},
+		},
+		{ // the compaction summarizer call
+			{Type: provider.ChunkText, Text: "- goal: guard work\n- pending: none"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	plannerReg := tool.NewRegistry()
+	plannerReg.Add(coordinatorTestTool{name: "read_file", readOnly: true, output: "ok"})
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	plannerSess := NewSession("planner-sys")
+	// Preset enough planner history that the fold shrinks the session to (or
+	// below) its pre-turn length, which is what strands a boundary based on
+	// the pre-turn message count.
+	filler := strings.Repeat("planner history filler. ", 150)
+	for i := 0; i < 3; i++ {
+		plannerSess.Add(provider.Message{Role: provider.RoleUser, Content: filler})
+		plannerSess.Add(provider.Message{Role: provider.RoleAssistant, Content: filler})
+	}
+	coord := NewCoordinator(planner, plannerSess, nil, plannerReg, Options{ContextWindow: 2000}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if plannerSess.RewriteVersion() == 0 {
+		t.Fatal("test setup: planner compaction did not fire, the rewrite boundary is not exercised")
+	}
+	if got := len(exec.requests); got == 0 {
+		t.Fatal("executor never ran")
+	}
+	got := lastUser(exec.requests[0])
+	if !strings.Contains(got, "Edit main.go and add the missing guard.") || !strings.Contains(got, executorHandoffMarker) {
+		t.Fatalf("executor input lost the plan handoff after planner compaction:\n%s", got)
+	}
+}

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -725,3 +725,185 @@ func TestCoordinatorSetPlanModeNilSafety(t *testing.T) {
 	c.SetPlanMode(true)  // should not panic
 	c.SetPlanMode(false) // should not panic
 }
+
+// errorProvider fails every Stream call, standing in for a down/misconfigured
+// planner provider.
+type errorProvider struct{ name string }
+
+func (e *errorProvider) Name() string { return e.name }
+
+func (e *errorProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	return nil, fmt.Errorf("provider unavailable")
+}
+
+// TestIsNoOpPlan pins the no-op conclusion contract: the [no_changes] marker on
+// the final line wins; phrase heuristics only match conclusion lines and are
+// vetoed by action verbs, so an "already implemented; extend it" plan must
+// still reach the executor.
+func TestIsNoOpPlan(t *testing.T) {
+	cases := []struct {
+		name string
+		plan string
+		want bool
+	}{
+		{"empty", "", false},
+		{"conclusion phrase single line", "No changes are needed; the current implementation already handles this.", true},
+		{"already implemented with follow-up work", "The auth flow is already implemented; extend it to cover refresh tokens.", false},
+		{"mid-plan aside is not a conclusion", "Findings:\nThis part is already handled by the retry helper.\nConfirm the desired direction with the user.", false},
+		{"explicit marker on final line", "The retry logic exists in client.go and the tests already run this path.\n[no_changes]", true},
+		{"marker mentioned before remaining work", "[no_changes] does not apply here.\nEdit main.go to add the missing guard.", false},
+		{"negated conclusion", "It is not already implemented.", false},
+		{"no-op phrase with action verb", "No changes are needed in code, but run the test suite.", false},
+		{"chinese conclusion", "无需改动,当前逻辑已经覆盖该场景。", true},
+		{"chinese follow-up work", "重试逻辑已经实现,但需要扩展覆盖刷新令牌。", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoOpPlan(tc.plan); got != tc.want {
+				t.Errorf("isNoOpPlan(%q) = %v, want %v", tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultPlannerPromptRequestsNoChangesMarker keeps the producer and parser
+// of the no-op contract in sync: isNoOpPlan trusts the marker because the
+// planner prompt asks for it.
+func TestDefaultPlannerPromptRequestsNoChangesMarker(t *testing.T) {
+	if !strings.Contains(DefaultPlannerPrompt, noChangesMarker) {
+		t.Fatalf("DefaultPlannerPrompt does not request the %s marker isNoOpPlan parses", noChangesMarker)
+	}
+}
+
+// TestCoordinatorDoesNotSkipExecutorForAlreadyImplementedPlanWithFollowUp is
+// the motivating regression: a plan acknowledging existing code while asking
+// for follow-up work must not be treated as a no-op conclusion.
+func TestCoordinatorDoesNotSkipExecutorForAlreadyImplementedPlanWithFollowUp(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "The auth flow is already implemented; extend it to cover refresh tokens."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "add refresh token support"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got == 0 {
+		t.Fatal("executor skipped: an already-implemented plan with follow-up work was treated as no-op")
+	}
+	if got := lastUser(exec.requests[0]); !strings.Contains(got, "extend it to cover refresh tokens") {
+		t.Fatalf("executor handoff missing the plan: %q", got)
+	}
+}
+
+// TestCoordinatorSkipsExecutorOnExplicitNoChangesMarker checks the marker
+// contract end to end: research prose above the marker may mention runs/tests
+// of existing code without vetoing the explicit conclusion.
+func TestCoordinatorSkipsExecutorOnExplicitNoChangesMarker(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "The retry logic exists in client.go and the tests already run this path.\n[no_changes]"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Should not run."},
+		{Type: provider.ChunkDone},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "check whether retries are covered"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 0 {
+		t.Fatalf("executor requests = %d, want skip on explicit [no_changes] marker", got)
+	}
+	messages := executor.session.Messages
+	if got := len(messages); got != 3 {
+		t.Fatalf("executor session messages = %d, want system + user + no-op assistant", got)
+	}
+	if got := messages[2].Content; !strings.Contains(got, "[no_changes]") {
+		t.Fatalf("persisted executor assistant message = %q, want the planner conclusion", got)
+	}
+}
+
+// TestCoordinatorFallsBackToExecutorWhenPlannerFails checks that a planner
+// failure degrades the turn to executor-only instead of failing it: the
+// executor gets the raw input (no handoff boilerplate), a warning notice is
+// emitted, and the planner session is rolled back so the next plan does not
+// start with consecutive user messages.
+func TestCoordinatorFallsBackToExecutorWhenPlannerFails(t *testing.T) {
+	cases := []struct {
+		name    string
+		planner provider.Provider
+	}{
+		{"stream call fails", &errorProvider{name: "planner"}},
+		{"stream emits error chunk", &mockProvider{name: "planner", chunks: []provider.Chunk{
+			{Type: provider.ChunkError, Err: fmt.Errorf("rate limited")},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+				{Type: provider.ChunkText, Text: "Done."},
+				{Type: provider.ChunkDone},
+			}}
+			var events []event.Event
+			sink := event.FuncSink(func(e event.Event) { events = append(events, e) })
+
+			executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+			plannerSess := NewSession("planner-sys")
+			coord := NewCoordinator(tc.planner, plannerSess, nil, nil, Options{}, executor, 0, sink, nil)
+
+			if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+				t.Fatalf("Run should fall back to the executor, got: %v", err)
+			}
+			if got := len(exec.requests); got != 1 {
+				t.Fatalf("executor requests = %d, want 1 fallback run", got)
+			}
+			got := lastUser(exec.requests[0])
+			if got != "fix the bug" || strings.Contains(got, "You are the executor now") {
+				t.Fatalf("fallback executor input = %q, want the raw task without handoff boilerplate", got)
+			}
+			if n := len(plannerSess.Messages); n != 1 {
+				t.Fatalf("planner session messages = %d, want rollback to system only", n)
+			}
+			var warned bool
+			for _, e := range events {
+				if e.Kind == event.Notice && e.Level == event.LevelWarn && strings.Contains(e.Text, "Planner failed") {
+					warned = true
+				}
+			}
+			if !warned {
+				t.Fatal("missing warn notice about the planner fallback")
+			}
+		})
+	}
+}
+
+// TestCoordinatorPropagatesPlannerErrorWhenTurnCancelled keeps cancellation
+// semantics: a turn the user aborted must not silently restart on the executor.
+func TestCoordinatorPropagatesPlannerErrorWhenTurnCancelled(t *testing.T) {
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Should not run."},
+		{Type: provider.ChunkDone},
+	}}
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(&errorProvider{name: "planner"}, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := coord.Run(ctx, "fix the bug")
+	if err == nil || !strings.Contains(err.Error(), "planner:") {
+		t.Fatalf("Run = %v, want propagated planner error on cancelled turn", err)
+	}
+	if got := len(exec.requests); got != 0 {
+		t.Fatalf("executor requests = %d, want none after user cancellation", got)
+	}
+}

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -751,7 +751,10 @@ func TestIsNoOpPlan(t *testing.T) {
 		{"already implemented with follow-up work", "The auth flow is already implemented; extend it to cover refresh tokens.", false},
 		{"mid-plan aside is not a conclusion", "Findings:\nThis part is already handled by the retry helper.\nConfirm the desired direction with the user.", false},
 		{"explicit marker on final line", "The retry logic exists in client.go and the tests already run this path.\n[no_changes]", true},
+		{"marker with surrounding whitespace", "Notes on the guard.\n  [no_changes]  ", true},
 		{"marker mentioned before remaining work", "[no_changes] does not apply here.\nEdit main.go to add the missing guard.", false},
+		{"final line mentions marker in prose", "The guard exists but the tests are missing.\nDo not emit [no_changes] because work remains.", false},
+		{"marker with trailing prose on final line", "[no_changes] — but confirm the flag default first.", false},
 		{"negated conclusion", "It is not already implemented.", false},
 		{"no-op phrase with action verb", "No changes are needed in code, but run the test suite.", false},
 		{"chinese conclusion", "无需改动,当前逻辑已经覆盖该场景。", true},
@@ -905,5 +908,106 @@ func TestCoordinatorPropagatesPlannerErrorWhenTurnCancelled(t *testing.T) {
 	}
 	if got := len(exec.requests); got != 0 {
 		t.Fatalf("executor requests = %d, want none after user cancellation", got)
+	}
+}
+
+// TestCoordinatorRollsBackPlannerSessionOnToolPlannerFailure covers the
+// production two-model wiring (boot passes PlannerToolRegistry, so planning
+// runs through planWithTools): when the tool-enabled planner fails, the
+// executor fallback must not leave the planner session with a dangling user
+// message or partial tool rounds — the next plan would otherwise start with
+// consecutive user roles, which some providers reject.
+func TestCoordinatorRollsBackPlannerSessionOnToolPlannerFailure(t *testing.T) {
+	cases := []struct {
+		name    string
+		planner provider.Provider
+	}{
+		{"stream call fails", &errorProvider{name: "planner"}},
+		{"fails after a tool round", &mockProvider{name: "planner", streams: [][]provider.Chunk{
+			{
+				{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "read_file", Arguments: `{"path":"main.go"}`}},
+				{Type: provider.ChunkDone},
+			},
+			{
+				{Type: provider.ChunkError, Err: fmt.Errorf("rate limited")},
+			},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+				{Type: provider.ChunkText, Text: "Done."},
+				{Type: provider.ChunkDone},
+			}}
+			plannerReg := tool.NewRegistry()
+			plannerReg.Add(coordinatorTestTool{name: "read_file", readOnly: true, output: "package main"})
+
+			executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+			plannerSess := NewSession("planner-sys")
+			coord := NewCoordinator(tc.planner, plannerSess, nil, plannerReg, Options{}, executor, 0, event.Discard, nil)
+
+			if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+				t.Fatalf("Run should fall back to the executor, got: %v", err)
+			}
+			if got := len(exec.requests); got != 1 {
+				t.Fatalf("executor requests = %d, want 1 fallback run", got)
+			}
+			if n := len(plannerSess.Messages); n != 1 {
+				t.Fatalf("planner session messages = %d, want rollback to system only", n)
+			}
+		})
+	}
+}
+
+// TestCoordinatorKeepsPlannerSessionOnMaxStepsPause pins the rollback
+// exemption: a max-steps pause is control flow whose saved work the user is
+// asked to continue from, so planWithTools must not roll the planner session
+// back to the pre-turn snapshot.
+func TestCoordinatorKeepsPlannerSessionOnMaxStepsPause(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "read_file", Arguments: `{"path":"main.go"}`}},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor"}
+	plannerReg := tool.NewRegistry()
+	plannerReg.Add(coordinatorTestTool{name: "read_file", readOnly: true, output: "package main"})
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	plannerSess := NewSession("planner-sys")
+	coord := NewCoordinator(planner, plannerSess, nil, plannerReg, Options{MaxSteps: 1}, executor, 0, event.Discard, nil)
+
+	err := coord.Run(context.Background(), "fix the bug")
+	if err == nil || !strings.Contains(err.Error(), "planner:") {
+		t.Fatalf("Run = %v, want the propagated max-steps pause", err)
+	}
+	if got := len(exec.requests); got != 0 {
+		t.Fatalf("executor requests = %d, want none on a paused planner turn", got)
+	}
+	if n := len(plannerSess.Messages); n <= 1 {
+		t.Fatalf("planner session messages = %d, want the saved work preserved for continue", n)
+	}
+}
+
+// TestCoordinatorRunsExecutorWhenMarkerNotAlone is the F2 regression: a final
+// line that mentions [no_changes] in prose is not the no-op conclusion, so the
+// executor must still run.
+func TestCoordinatorRunsExecutorWhenMarkerNotAlone(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "The guard exists but the tests are missing.\nDo not emit [no_changes] because work remains."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "add the missing tests"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got == 0 {
+		t.Fatal("executor skipped: a final line mentioning the marker in prose was treated as a no-op conclusion")
 	}
 }


### PR DESCRIPTION
## Problem

Two-model collaboration (`planner_model`) had two user-visible failure shapes:

1. **Silently dropped tasks.** `isNoOpPlan` matched no-op phrases ("already implemented", …) anywhere in the plan text, guarded only by a narrow action-verb list. A plan such as "the auth flow is already implemented; extend it to cover refresh tokens" was classified as a no-op: the executor never ran and the plan text was returned as the final answer. The `[no_changes]` marker was parsed but never requested from the planner, so the explicit contract was dead.
2. **Planner outage takes down the turn.** Any planner error (provider down, rate limit, misconfiguration) failed the whole turn with `planner: …` even though the executor — which owns the full tool set — was healthy.

## Changes

- `DefaultPlannerPrompt` now asks the planner to end a genuine no-op conclusion with a final `[no_changes]` line and never to emit it while work remains.
- `isNoOpPlan` trusts the marker on the final non-empty line; the legacy phrase list is demoted to a fallback that only matches conclusion positions (first/last non-empty line) and is vetoed by action verbs anywhere in the plan (list extended with extend/verify/check/investigate and CJK equivalents). Wrong-skip is the dangerous direction (silent task drop); missed-skip only costs one executor round.
- `Coordinator.Run` degrades to an executor-only turn (raw input, warn notice) when the planner fails, mirroring the auto-plan classifier's fallback-to-heuristic behavior. Cancellation and max-steps pauses still propagate: the pause is now a typed `maxStepsPause` with byte-identical message, so the fallback cannot swallow a deliberate "work saved, send another message" stop.
- The raw planner path rolls back its just-added user message on stream errors, so a fallback turn cannot leave the planner session with consecutive user roles (which some providers reject).

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted sessions / transcripts | No format change; no-op turns still persist user + assistant plan text | safe |
| Max-steps pause error | Typed error with byte-identical message; no caller matches on the string | safe |
| Plans from planners unaware of the marker | Phrase fallback still recognizes conclusion-line no-op plans (existing tests unchanged and passing) | safe |

## Verification

- `go vet ./internal/agent` and full `go test ./internal/agent -count=1`
- `go test ./internal/control ./internal/cli ./internal/boot -count=1`
- `cd desktop && go test ./...` (independent module)
- `./scripts/cache-guard.sh` — 8/8 cases pass, tail_avg 92–95 vs threshold 90
- New regression tests: `TestIsNoOpPlan`, `TestDefaultPlannerPromptRequestsNoChangesMarker`, `TestCoordinatorDoesNotSkipExecutorForAlreadyImplementedPlanWithFollowUp`, `TestCoordinatorSkipsExecutorOnExplicitNoChangesMarker`, `TestCoordinatorFallsBackToExecutorWhenPlannerFails`, `TestCoordinatorPropagatesPlannerErrorWhenTurnCancelled`; existing `TestCoordinatorPlannerMaxStepsUsesPlannerConfigKey` guards the pause-propagation path.

Cache-impact: DefaultPlannerPrompt bytes change → one-time planner-session prefix invalidation (planner sessions are per-conversation, low-frequency, and reset on session switch). Executor system prompt, tool schemas, and handoff structure are byte-identical; no per-turn dynamic bytes added to any stable prefix.
Cache-guard: scripts/cache-guard.sh pass (8/8 cases, tail_avg 92–95, threshold 90).
System-prompt-review: planner-only prompt addition (no-op marker instruction); executor system prompt untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)