### PR TITLE
fix(agent): unify sub-agent Options construction to stop config drift / 统一子代理 Options 构造点，修复配置漂移

### DIFF
--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -183,23 +183,8 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			}
 
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt), Options{
-				MaxSteps:            max,
-				Temperature:         p.taskTool.temperature,
-				Pricing:             pricing,
-				UsageSource:         event.UsageSourceSubagent,
-				Gate:                p.taskTool.gate,
-				ContextWindow:       ctxWin,
-				RecentKeep:          p.taskTool.recentKeep,
-				SoftCompactRatio:    p.taskTool.softCompactRatio,
-				ToolResultSnipRatio: p.taskTool.toolResultSnipRatio,
-				CompactRatio:        p.taskTool.compactRatio,
-				CompactForceRatio:   p.taskTool.compactForceRatio,
-				ArchiveDir:          p.taskTool.archiveDir,
-				KeepPolicy:          p.taskTool.keepPolicy,
-				SubagentDepth:       childDepth,
-				MaxSubagentDepth:    p.taskTool.maxDepth(),
-			}, nested)
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
+				p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth), nested)
 
 			if ctx.Err() != nil && runErr == nil {
 				runErr = ctx.Err()

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -123,6 +123,25 @@ func TestParallelTasksInjectsWorkspaceContextIntoChildren(t *testing.T) {
 	}
 }
 
+// TestParallelTasksInheritLanguagePreferencesFromContext pins parallel children
+// to the same transient language injection the task tool applies: both the
+// response- and reasoning-language blocks must reach each child's user turn.
+func TestParallelTasksInheritLanguagePreferencesFromContext(t *testing.T) {
+	task := newTestTaskTool(t, promptRoutingProvider{}, tool.NewRegistry(), "sys", "", "", nil)
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+	ctx = WithResponseLanguagePreference(ctx, "zh")
+	ctx = WithReasoningLanguagePreference(ctx, "zh")
+
+	out, err := parallel.Execute(ctx, json.RawMessage(`{"tasks":[{"prompt":"inspect one"},{"prompt":"inspect two"}]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "<response-language>") || !strings.Contains(out, "<reasoning-language>") {
+		t.Fatalf("parallel output = %q, want response/reasoning language blocks injected into child prompts", out)
+	}
+}
+
 func TestParallelTasksDoesNotExposeWriterToolsToChildren(t *testing.T) {
 	var writerCalls int32
 	parentReg := tool.NewRegistry()

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -522,6 +522,8 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	if continueFrom != "" && legacyForkFrom != "" {
 		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
 	}
+	// A task tool wired without a transcript store is a caller bug: fail loudly
+	// instead of silently dropping persistence (contract pinned since #3586).
 	if t.transcripts == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
@@ -749,7 +751,15 @@ func (t *TaskTool) resolveSubSessionRuntime(modelRef, effort string) (provider.P
 
 func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session, childDepth int) (string, error) {
 	prompt = t.withWorkspaceContext(prompt)
-	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
+	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, t.subagentOptions(ctx, maxSteps, pricing, ctxWin, childDepth), sink)
+}
+
+// subagentOptions is the single construction point for the run options every
+// sub-agent spawned through this tool shares (task, read_only_task, and
+// parallel_tasks children). Compaction, language preferences, and depth limits
+// must stay uniform across those paths — add new fields here, not at call sites.
+func (t *TaskTool) subagentOptions(ctx context.Context, maxSteps int, pricing *provider.Pricing, ctxWin, childDepth int) Options {
+	return Options{
 		MaxSteps:            maxSteps,
 		Temperature:         t.temperature,
 		Pricing:             pricing,
@@ -767,7 +777,7 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		ReasoningLanguage:   ReasoningLanguageFromContext(ctx),
 		SubagentDepth:       childDepth,
 		MaxSubagentDepth:    t.maxDepth(),
-	}, sink)
+	}
 }
 
 func (t *TaskTool) withWorkspaceContext(prompt string) string {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -687,6 +687,31 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// subagent skills run ephemerally with the same registry boundary as
 	// read_only_task, so they cannot write, install, mutate memory, resume/fork
 	// transcripts, or delegate further.
+	//
+	// subagentSkillOptions is the single construction point for skill sub-agent
+	// run options, so the read-only and writer-capable runners cannot drift on
+	// compaction or language settings — add new fields here, not per runner.
+	subagentSkillOptions := func(sctx context.Context, steps int, price *provider.Pricing, ctxWin, childDepth int) agent.Options {
+		return agent.Options{
+			MaxSteps:            steps,
+			Temperature:         cfg.Agent.Temperature,
+			Pricing:             price,
+			UsageSource:         event.UsageSourceSubagent,
+			Gate:                headlessGate,
+			ContextWindow:       ctxWin,
+			RecentKeep:          cfg.Agent.RecentKeep,
+			SoftCompactRatio:    cfg.Agent.SoftCompactRatio,
+			ToolResultSnipRatio: cfg.Agent.ToolResultSnipRatio,
+			CompactRatio:        cfg.Agent.CompactRatio,
+			CompactForceRatio:   cfg.Agent.CompactForceRatio,
+			ArchiveDir:          config.ArchiveDir(),
+			KeepPolicy:          keepPolicy,
+			ResponseLanguage:    agent.ResponseLanguageFromContext(sctx),
+			ReasoningLanguage:   agent.ReasoningLanguageFromContext(sctx),
+			SubagentDepth:       childDepth,
+			MaxSubagentDepth:    maxSubagentDepth,
+		}
+	}
 	readOnlySkillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
 		if strings.TrimSpace(runOpts.ContinueFrom) != "" || strings.TrimSpace(runOpts.ForkFrom) != "" {
 			return "", fmt.Errorf("read_only_skill does not support continue_from/fork_from")
@@ -717,24 +742,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 		}
 		sysPrompt := agent.DefaultReadOnlyTaskSystemPrompt + "\n\nSkill instructions:\n" + sk.Body
-		return agent.RunSubAgentWithSession(sctx, prov, subReg, agent.NewSession(sysPrompt), task, agent.Options{
-			MaxSteps:            steps,
-			Temperature:         cfg.Agent.Temperature,
-			Pricing:             price,
-			UsageSource:         event.UsageSourceSubagent,
-			Gate:                headlessGate,
-			ContextWindow:       ctxWin,
-			RecentKeep:          cfg.Agent.RecentKeep,
-			SoftCompactRatio:    cfg.Agent.SoftCompactRatio,
-			ToolResultSnipRatio: cfg.Agent.ToolResultSnipRatio,
-			CompactRatio:        cfg.Agent.CompactRatio,
-			CompactForceRatio:   cfg.Agent.CompactForceRatio,
-			ArchiveDir:          config.ArchiveDir(),
-			KeepPolicy:          keepPolicy,
-			ReasoningLanguage:   agent.ReasoningLanguageFromContext(sctx),
-			SubagentDepth:       childDepth,
-			MaxSubagentDepth:    maxSubagentDepth,
-		}, agent.NestedSink(sctx, event.Discard))
+		return agent.RunSubAgentWithSession(sctx, prov, subReg, agent.NewSession(sysPrompt), task,
+			subagentSkillOptions(sctx, steps, price, ctxWin, childDepth), agent.NestedSink(sctx, event.Discard))
 	}
 	// Writer-capable subagent skills reuse the sub-agent machinery via this
 	// runner: an isolated loop with the skill body as system prompt, a tool set
@@ -807,20 +816,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				steps = 5
 			}
 		}
-		answer, err := agent.RunSubAgentWithSession(sctx, prov, subReg, run.Session, task, agent.Options{
-			MaxSteps:          steps,
-			Temperature:       cfg.Agent.Temperature,
-			Pricing:           price,
-			UsageSource:       event.UsageSourceSubagent,
-			Gate:              headlessGate,
-			ContextWindow:     ctxWin,
-			RecentKeep:        cfg.Agent.RecentKeep,
-			ArchiveDir:        config.ArchiveDir(),
-			KeepPolicy:        keepPolicy,
-			ReasoningLanguage: agent.ReasoningLanguageFromContext(sctx),
-			SubagentDepth:     childDepth,
-			MaxSubagentDepth:  maxSubagentDepth,
-		}, agent.NestedSink(sctx, event.Discard))
+		answer, err := agent.RunSubAgentWithSession(sctx, prov, subReg, run.Session, task,
+			subagentSkillOptions(sctx, steps, price, ctxWin, childDepth), agent.NestedSink(sctx, event.Discard))
 		if err != nil {
 			return "", errors.Join(err, subagentStore.SaveFailed(run))
 		}


### PR DESCRIPTION
## Problem

Sub-agent run options were constructed by five hand-rolled `agent.Options` literals (task, read_only_task, parallel_tasks children, and the two skill runners in boot). They had drifted apart, with user-visible consequences:

1. **Compaction config silently ignored for writer-capable skill sub-agents.** The `skillRunner` in `internal/boot/boot.go` (the execution path for explore/research/review/security_review and `run_skill`) dropped `SoftCompactRatio`, `ToolResultSnipRatio`, `CompactRatio`, and `CompactForceRatio`, so user-configured compaction ratios fell back to defaults on that path only.
2. **Language preferences not inherited.** Both skill runners dropped `ResponseLanguage`, and `parallel_tasks` children dropped both `ResponseLanguage` and `ReasoningLanguage` — a user with a configured Chinese response preference got Chinese from `task` sub-agents but potentially English from skill sub-agents and parallel children.

## Changes

Remove the structural root cause instead of patching each literal:

- `internal/agent/task.go`: add `TaskTool.subagentOptions()` as the single construction point shared by the `task`, `read_only_task`, and `parallel_tasks` child paths.
- `internal/boot/boot.go`: add the `subagentSkillOptions` closure shared by the read-only and writer-capable skill runners (net −24 lines).
- Pin language inheritance with `TestParallelTasksInheritLanguagePreferencesFromContext`.
- Document the deliberate loud-failure contract in `prepareTranscriptRun` for a missing transcript store (pinned by #3586 / `TestTaskToolRequiresTranscriptStore`) so a future "alignment" pass does not relax it by mistake.

No behavior other than the drifted fields changes: system prompts, tool registries, gates, and sink wiring are untouched.

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted formats (state, transcripts, config) | No serialization or schema change; `Options` is in-memory only | safe |
| Sub-agent `continue_from` contract | System-prompt hash, tool set, schema hash, model/effort inputs all unchanged; old transcripts continue/resume as before | safe |
| Skill sub-agent compaction | Now honors configured ratios like the `task` path; zero-value configs behave as before | safe |

## Verification

- `gofmt -l` clean; `go vet ./internal/agent/... ./internal/boot/...` clean
- Focused: `go test ./internal/agent ./internal/boot ./internal/skill ./internal/cli` — all pass
- Full root module `go test ./...` — pass
- Desktop independent module: `cd desktop && go build ./... && go test` (all packages except `cmd/sign`, which OOMs on the 3.8 GB CI-adjacent box and has zero dependency on `reasonix/internal`) — pass
- `./scripts/cache-guard.sh` — 8/8 cases pass, tail_avg 92–95 vs threshold 90
- New regression test: `TestParallelTasksInheritLanguagePreferencesFromContext`

Cache-impact: low - only sub-agent session construction changes; parent-session prefix bytes and tool schemas are byte-identical. Language blocks enter child user turns via the existing per-run injection (append-only); skill sub-agents now honor configured compaction ratios, matching the long-standing `task` behavior.
Cache-guard: scripts/cache-guard.sh pass (8/8 cases, tail_avg 92–95, threshold 90).
System-prompt-review: sub-agent system prompt bytes (DefaultReadOnlyTaskSystemPrompt + skill-body concatenation) are unchanged — refactor touches run-Options construction only; reviewed in-PR against the five prior literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
