### PR TITLE
chore(gitignore): ignore local temp/ scratch directories / 忽略本地 temp 临时目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ Thumbs.db
 /site/public/av/
 
 benchmarks/context-maintenance-e2e/run/
+
+# Local scratch
+temp/


### PR DESCRIPTION
## Summary

Add `temp/` to `.gitignore` so locally created scratch directories named `temp` (at any depth) never show up as untracked files or get committed by accident.

## Changes

- `.gitignore`: add a `# Local scratch` section with `temp/`.

## Verification

- `git check-ignore -v temp/ internal/temp/` matches the new rule.
- `git status` no longer lists local `temp` directories as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)