### PR TITLE
Fix escaped PowerShell file hooks / 修复 PowerShell 文件 hook 转义引号

### DIFF
--- a/internal/hook/command_normalize.go
+++ b/internal/hook/command_normalize.go
@@ -58,30 +58,45 @@ func repairableNodeEvalArgs(command string) (string, string, string, bool) {
 }
 
 func normalizeEscapedPowerShellFile(command string) (string, bool) {
-	_, _, ok := repairablePowerShellFileArgs(command)
-	if !ok {
+	trimmed := strings.TrimSpace(command)
+	_, spans, ok := repairablePowerShellFileParse(trimmed)
+	if !ok || len(spans) == 0 {
 		return "", false
 	}
-	fixed := collapseEscapedShellQuotes(strings.TrimSpace(command))
-	if fixed == strings.TrimSpace(command) {
-		return "", false
+	// Replace only the escaped-quote sequences found during parsing, so
+	// well-formed sibling arguments keep their bytes verbatim.
+	var b strings.Builder
+	prev := 0
+	for _, span := range spans {
+		b.WriteString(trimmed[prev:span[0]])
+		b.WriteByte('"')
+		prev = span[1]
 	}
-	return fixed, true
+	b.WriteString(trimmed[prev:])
+	return b.String(), true
 }
 
 func repairablePowerShellFileArgs(command string) (string, []string, bool) {
-	fields, repaired, ok := parseSimpleHookCommandFields(command)
-	if !ok || len(fields) < 3 || !isPowerShellCommand(fields[0]) {
-		return "", nil, false
-	}
-	fileIdx := powerShellFileFlagIndex(fields)
-	if fileIdx < 0 || fileIdx+1 >= len(fields) {
-		return "", nil, false
-	}
-	if !powerShellFileRepairApplies(repaired, fileIdx) {
+	fields, _, ok := repairablePowerShellFileParse(command)
+	if !ok {
 		return "", nil, false
 	}
 	return fields[0], fields[1:], true
+}
+
+func repairablePowerShellFileParse(command string) ([]string, [][2]int, bool) {
+	fields, repaired, spans, ok := parseSimpleHookCommandFields(command)
+	if !ok || len(fields) < 3 || !isPowerShellCommand(fields[0]) {
+		return nil, nil, false
+	}
+	fileIdx := powerShellFileFlagIndex(fields)
+	if fileIdx < 0 || fileIdx+1 >= len(fields) {
+		return nil, nil, false
+	}
+	if !powerShellFileRepairApplies(repaired, fileIdx) {
+		return nil, nil, false
+	}
+	return fields, spans, true
 }
 
 func powerShellFileRepairApplies(repaired []bool, fileIdx int) bool {
@@ -105,10 +120,16 @@ func powerShellFileFlagIndex(fields []string) int {
 	return -1
 }
 
-func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
+func parseSimpleHookCommandFields(command string) ([]string, []bool, [][2]int, bool) {
+	// A newline is a shell command separator, not argument whitespace; leave
+	// multi-command strings alone like other compound commands.
+	if strings.ContainsAny(command, "\n\r") {
+		return nil, nil, nil, false
+	}
 	s := strings.TrimSpace(command)
 	fields := []string{}
 	repaired := []bool{}
+	spans := [][2]int{}
 	for i := 0; i < len(s); {
 		for i < len(s) && isShellWhitespace(s[i]) {
 			i++
@@ -128,13 +149,14 @@ func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
 					break
 				}
 				if isShellControl(c) {
-					return nil, nil, false
+					return nil, nil, nil, false
 				}
 				if n := escapedShellQuoteLen(s, i); n > 0 {
 					quote = '"'
 					escapedQuote = true
 					fieldStarted = true
 					fieldRepaired = true
+					spans = append(spans, [2]int{i, i + n})
 					i += n
 					continue
 				}
@@ -155,6 +177,7 @@ func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
 					quote = 0
 					escapedQuote = false
 					fieldRepaired = true
+					spans = append(spans, [2]int{i, i + n})
 					i += n
 					continue
 				}
@@ -176,10 +199,10 @@ func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
 			i++
 		}
 		if quote != 0 {
-			return nil, nil, false
+			return nil, nil, nil, false
 		}
 		if !fieldStarted {
-			return nil, nil, false
+			return nil, nil, nil, false
 		}
 		fields = append(fields, b.String())
 		repaired = append(repaired, fieldRepaired)
@@ -187,7 +210,7 @@ func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
 			i++
 		}
 	}
-	return fields, repaired, len(fields) > 0
+	return fields, repaired, spans, len(fields) > 0
 }
 
 func escapedShellQuoteLen(s string, i int) int {
@@ -202,7 +225,7 @@ func escapedShellQuoteLen(s string, i int) int {
 }
 
 func isShellWhitespace(c byte) bool {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+	return c == ' ' || c == '\t'
 }
 
 func isShellControl(c byte) bool {
@@ -221,13 +244,6 @@ func isDoubleQuoteEscapedByte(c byte) bool {
 	default:
 		return false
 	}
-}
-
-func collapseEscapedShellQuotes(s string) string {
-	for strings.Contains(s, `\"`) {
-		s = strings.ReplaceAll(s, `\"`, `"`)
-	}
-	return s
 }
 
 func normalizeEscapedNodeEval(command string) (string, bool) {

--- a/internal/hook/command_normalize.go
+++ b/internal/hook/command_normalize.go
@@ -6,15 +6,18 @@ import (
 	"reasonix/internal/shellparse"
 )
 
-// NormalizeCommand repairs a narrow class of copied JSON-escaped node -e hooks.
+// NormalizeCommand repairs narrow classes of copied JSON-escaped hook commands.
 // It is intentionally conservative: hook commands can be security controls, so
-// only a single static node -e command whose script clearly reads hook payload
-// JSON from stdin is rewritten.
+// only commands that were already malformed and match a known hook shape are
+// rewritten.
 func NormalizeCommand(command string) string {
 	if fixed, ok := normalizeStaticNodeEval(command); ok {
 		return fixed
 	}
 	if fixed, ok := normalizeEscapedNodeEval(command); ok {
+		return fixed
+	}
+	if fixed, ok := normalizeEscapedPowerShellFile(command); ok {
 		return fixed
 	}
 	return command
@@ -52,6 +55,179 @@ func repairableNodeEvalArgs(command string) (string, string, string, bool) {
 		}
 	}
 	return escapedNodeEvalArgs(command)
+}
+
+func normalizeEscapedPowerShellFile(command string) (string, bool) {
+	_, _, ok := repairablePowerShellFileArgs(command)
+	if !ok {
+		return "", false
+	}
+	fixed := collapseEscapedShellQuotes(strings.TrimSpace(command))
+	if fixed == strings.TrimSpace(command) {
+		return "", false
+	}
+	return fixed, true
+}
+
+func repairablePowerShellFileArgs(command string) (string, []string, bool) {
+	fields, repaired, ok := parseSimpleHookCommandFields(command)
+	if !ok || len(fields) < 3 || !isPowerShellCommand(fields[0]) {
+		return "", nil, false
+	}
+	fileIdx := powerShellFileFlagIndex(fields)
+	if fileIdx < 0 || fileIdx+1 >= len(fields) {
+		return "", nil, false
+	}
+	if !powerShellFileRepairApplies(repaired, fileIdx) {
+		return "", nil, false
+	}
+	return fields[0], fields[1:], true
+}
+
+func powerShellFileRepairApplies(repaired []bool, fileIdx int) bool {
+	for i, ok := range repaired {
+		if !ok {
+			continue
+		}
+		if i == 0 || i > fileIdx {
+			return true
+		}
+	}
+	return false
+}
+
+func powerShellFileFlagIndex(fields []string) int {
+	for i := 1; i < len(fields); i++ {
+		if strings.EqualFold(fields[i], "-File") {
+			return i
+		}
+	}
+	return -1
+}
+
+func parseSimpleHookCommandFields(command string) ([]string, []bool, bool) {
+	s := strings.TrimSpace(command)
+	fields := []string{}
+	repaired := []bool{}
+	for i := 0; i < len(s); {
+		for i < len(s) && isShellWhitespace(s[i]) {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+		var b strings.Builder
+		fieldStarted := false
+		fieldRepaired := false
+		var quote byte
+		escapedQuote := false
+		for i < len(s) {
+			c := s[i]
+			if quote == 0 {
+				if isShellWhitespace(c) {
+					break
+				}
+				if isShellControl(c) {
+					return nil, nil, false
+				}
+				if n := escapedShellQuoteLen(s, i); n > 0 {
+					quote = '"'
+					escapedQuote = true
+					fieldStarted = true
+					fieldRepaired = true
+					i += n
+					continue
+				}
+				if c == '"' || c == '\'' {
+					quote = c
+					escapedQuote = false
+					fieldStarted = true
+					i++
+					continue
+				}
+				b.WriteByte(c)
+				fieldStarted = true
+				i++
+				continue
+			}
+			if escapedQuote {
+				if n := escapedShellQuoteLen(s, i); n > 0 {
+					quote = 0
+					escapedQuote = false
+					fieldRepaired = true
+					i += n
+					continue
+				}
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+				i++
+				continue
+			}
+			if quote == '"' && c == '\\' && i+1 < len(s) && isDoubleQuoteEscapedByte(s[i+1]) {
+				b.WriteByte(s[i+1])
+				i += 2
+				continue
+			}
+			b.WriteByte(c)
+			i++
+		}
+		if quote != 0 {
+			return nil, nil, false
+		}
+		if !fieldStarted {
+			return nil, nil, false
+		}
+		fields = append(fields, b.String())
+		repaired = append(repaired, fieldRepaired)
+		for i < len(s) && isShellWhitespace(s[i]) {
+			i++
+		}
+	}
+	return fields, repaired, len(fields) > 0
+}
+
+func escapedShellQuoteLen(s string, i int) int {
+	j := i
+	for j < len(s) && s[j] == '\\' {
+		j++
+	}
+	if j == i || j >= len(s) || s[j] != '"' {
+		return 0
+	}
+	return j - i + 1
+}
+
+func isShellWhitespace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isShellControl(c byte) bool {
+	switch c {
+	case '&', '|', ';', '<', '>':
+		return true
+	default:
+		return false
+	}
+}
+
+func isDoubleQuoteEscapedByte(c byte) bool {
+	switch c {
+	case '"', '\\', '$', '`', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func collapseEscapedShellQuotes(s string) string {
+	for strings.Contains(s, `\"`) {
+		s = strings.ReplaceAll(s, `\"`, `"`)
+	}
+	return s
 }
 
 func normalizeEscapedNodeEval(command string) (string, bool) {
@@ -152,6 +328,14 @@ func startsLikeJSStatement(script string) bool {
 func isNodeCommand(command string) bool {
 	base := strings.ToLower(shellparse.WordBase(command))
 	return base == "node" || base == "node.exe"
+}
+
+func isPowerShellCommand(command string) bool {
+	base := strings.ToLower(command)
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	return base == "powershell" || base == "powershell.exe" || base == "pwsh" || base == "pwsh.exe"
 }
 
 func isNodeEvalFlag(flag string) bool {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -610,6 +610,9 @@ func spawnCommand(ctx context.Context, command string) *exec.Cmd {
 	if node, flag, script, ok := repairableNodeEvalArgs(command); ok {
 		return exec.CommandContext(ctx, node, flag, script)
 	}
+	if powershell, args, ok := repairablePowerShellFileArgs(command); ok {
+		return exec.CommandContext(ctx, powershell, args...)
+	}
 	if runtime.GOOS == "windows" {
 		if node, flag, script, ok := directNodeEvalArgs(command); ok {
 			return exec.CommandContext(ctx, node, flag, script)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -216,6 +216,21 @@ func TestNormalizeCommandRepairsOnlyPowerShellFileEscapedQuotes(t *testing.T) {
 			want:    `powershell -File \"C:\hooks\archive.ps1\" && echo done`,
 		},
 		{
+			name:    "multiline command is left alone",
+			command: "powershell -File \\\"C:\\hooks\\archive.ps1\\\"\necho done",
+			want:    "powershell -File \\\"C:\\hooks\\archive.ps1\\\"\necho done",
+		},
+		{
+			name:    "well formed sibling argument keeps its escaped quotes",
+			command: `powershell -File \"C:\hooks\archive.ps1\" "say \"hi\""`,
+			want:    `powershell -File "C:\hooks\archive.ps1" "say \"hi\""`,
+		},
+		{
+			name:    "single quoted sibling argument stays literal",
+			command: `powershell -File \"C:\hooks\archive.ps1\" 'keep \" literal'`,
+			want:    `powershell -File "C:\hooks\archive.ps1" 'keep \" literal'`,
+		},
+		{
 			name:    "non powershell command is left alone",
 			command: `python \"C:\hooks\archive.py\"`,
 			want:    `python \"C:\hooks\archive.py\"`,
@@ -268,6 +283,9 @@ func TestRepairablePowerShellFileArgs(t *testing.T) {
 	}
 	if _, _, ok := repairablePowerShellFileArgs(`powershell -File \"C:\hooks\archive.ps1\" && echo done`); ok {
 		t.Fatal("compound PowerShell command should not be direct-exec repaired")
+	}
+	if _, _, ok := repairablePowerShellFileArgs("powershell -File \\\"C:\\hooks\\archive.ps1\\\"\necho done"); ok {
+		t.Fatal("multiline PowerShell command should not be direct-exec repaired")
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -174,6 +174,103 @@ func TestNormalizeCommandRepairsOnlyStdinNodeEvalQuoting(t *testing.T) {
 	}
 }
 
+func TestNormalizeCommandRepairsOnlyPowerShellFileEscapedQuotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "powershell file path copied with json escaped quotes",
+			command: `powershell -File \"C:\Users\Example\.reasonix\hooks\archive-attachments.ps1\"`,
+			want:    `powershell -File "C:\Users\Example\.reasonix\hooks\archive-attachments.ps1"`,
+		},
+		{
+			name:    "pwsh file path with spaces",
+			command: `pwsh.exe -NoProfile -NonInteractive -File \"C:\Program Files\Reasonix Hooks\archive attachments.ps1\"`,
+			want:    `pwsh.exe -NoProfile -NonInteractive -File "C:\Program Files\Reasonix Hooks\archive attachments.ps1"`,
+		},
+		{
+			name:    "doubly escaped copied quotes",
+			command: `pwsh -File \\\"C:\Program Files\Reasonix Hooks\archive attachments.ps1\\\" \"arg with spaces\"`,
+			want:    `pwsh -File "C:\Program Files\Reasonix Hooks\archive attachments.ps1" "arg with spaces"`,
+		},
+		{
+			name:    "powershell executable path copied with escaped quotes",
+			command: `\"C:\Program Files\PowerShell\7\pwsh.exe\" -File \"C:\hooks\archive.ps1\"`,
+			want:    `"C:\Program Files\PowerShell\7\pwsh.exe" -File "C:\hooks\archive.ps1"`,
+		},
+		{
+			name:    "well formed file command stays unchanged",
+			command: `powershell -NoProfile -File "C:\Program Files\Reasonix Hooks\archive attachments.ps1"`,
+			want:    `powershell -NoProfile -File "C:\Program Files\Reasonix Hooks\archive attachments.ps1"`,
+		},
+		{
+			name:    "command mode may intentionally contain escaped quotes",
+			command: `powershell -Command \"Write-Output hi\"`,
+			want:    `powershell -Command \"Write-Output hi\"`,
+		},
+		{
+			name:    "compound command is left alone",
+			command: `powershell -File \"C:\hooks\archive.ps1\" && echo done`,
+			want:    `powershell -File \"C:\hooks\archive.ps1\" && echo done`,
+		},
+		{
+			name:    "non powershell command is left alone",
+			command: `python \"C:\hooks\archive.py\"`,
+			want:    `python \"C:\hooks\archive.py\"`,
+		},
+		{
+			name:    "missing file argument is left alone",
+			command: `powershell -NoProfile -File`,
+			want:    `powershell -NoProfile -File`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeCommand(tt.command); got != tt.want {
+				t.Fatalf("NormalizeCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNormalizesPowerShellFileEscapedQuotes(t *testing.T) {
+	home := t.TempDir()
+	bad := `powershell -File \"C:\Program Files\Reasonix Hooks\archive attachments.ps1\"`
+	want := `powershell -File "C:\Program Files\Reasonix Hooks\archive attachments.ps1"`
+	writeSettings(t, home, hookSettingsWithCommand(t, SessionStart, bad))
+
+	hooks := Load(LoadOptions{HomeDir: home})
+	if len(hooks) != 1 {
+		t.Fatalf("Load hooks = %+v, want one", hooks)
+	}
+	if hooks[0].Command != want {
+		t.Fatalf("loaded command = %q, want %q", hooks[0].Command, want)
+	}
+}
+
+func TestRepairablePowerShellFileArgs(t *testing.T) {
+	command := `powershell -NoProfile -NonInteractive -File \"C:\Program Files\Reasonix Hooks\archive attachments.ps1\" -Mode \"startup\"`
+	name, args, ok := repairablePowerShellFileArgs(command)
+	if !ok {
+		t.Fatalf("repairablePowerShellFileArgs(%q) ok = false, want true", command)
+	}
+	if name != "powershell" {
+		t.Fatalf("name = %q, want powershell", name)
+	}
+	wantArgs := []string{"-NoProfile", "-NonInteractive", "-File", `C:\Program Files\Reasonix Hooks\archive attachments.ps1`, "-Mode", "startup"}
+	if strings.Join(args, "\x00") != strings.Join(wantArgs, "\x00") {
+		t.Fatalf("args = %#v, want %#v", args, wantArgs)
+	}
+	if _, _, ok := repairablePowerShellFileArgs(`powershell -File "C:\hooks\archive.ps1"`); ok {
+		t.Fatal("well formed PowerShell command should keep shell execution")
+	}
+	if _, _, ok := repairablePowerShellFileArgs(`powershell -File \"C:\hooks\archive.ps1\" && echo done`); ok {
+		t.Fatal("compound PowerShell command should not be direct-exec repaired")
+	}
+}
+
 func TestLoadPermissionRequestHook(t *testing.T) {
 	home := t.TempDir()
 	writeSettings(t, home, `{"hooks":{"PermissionRequest":[{"match":"bash","command":"notify"}]}}`)


### PR DESCRIPTION
## Summary

- repair copied JSON-escaped quotes in PowerShell/pwsh `-File` hook commands during hook normalization
- add a runtime direct-argv fallback for the same malformed PowerShell `-File` shape, so in-memory hooks that bypass settings normalization are still handled
- cover escaped paths, paths with spaces, doubly escaped quotes, executable paths with spaces, and non-repair cases with regression tests

## Root Cause

Some Windows hook commands can be copied into `settings.json` with shell quotes still escaped, for example `powershell -File \"C:\\hooks\\startup.ps1\"`. When those backslashes survive into the command line, PowerShell may receive quotes as literal path characters and report an illegal path. SessionStart then surfaces a warning because lifecycle hooks are non-blocking, but the failed hook still adds noise before the first turn.

## Compatibility

| Surface | Old data behavior | Conclusion |
| --- | --- | --- |
| `settings.json` hook commands | Existing valid commands are left unchanged. Only malformed PowerShell/pwsh `-File` commands with copied escaped quotes are normalized. | Backward compatible |
| Hook execution contract | Commands still run through the platform shell by default. Only already-malformed PowerShell `-File` commands take the direct-argv repair path. | Backward compatible |
| Provider-visible prompt/tool schema | No prompt construction, model request serialization, tool schema, or hook context format changes. | No cache-visible contract change |

## Verification

- `go test ./internal/hook ./internal/shellparse`
- `cd desktop && go test ./...`