### PR TITLE
Thread turn context into planner gate, trim handoff tool block, planner-attribute no-op conclusion / 规划门槛透传回合上下文、精简 handoff 工具块、no-op 结论归因规划模型

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -70,15 +70,17 @@ type Coordinator struct {
 	sink           event.Sink
 	// shouldPlan gates the planner pass per turn; nil plans every turn. Lets a
 	// trivial, non-work turn (a question, a greeting) skip straight to the
-	// executor instead of paying a planner round on it.
-	shouldPlan func(string) bool
+	// executor instead of paying a planner round on it. The turn context is
+	// passed through so a classifier-backed gate stops with the turn instead
+	// of running out its own timeout after the user cancels.
+	shouldPlan func(context.Context, string) bool
 }
 
 // NewCoordinator wires a planner provider (with its own session) to an executor.
 // sink receives the planner's phase/text/usage events; the executor emits its
 // own events to its own sink (the CLI wires the same sink into both). A nil
 // sink is replaced with event.Discard.
-func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerPricing *provider.Pricing, plannerTools *tool.Registry, plannerOptions Options, executor *Agent, temperature float64, sink event.Sink, shouldPlan func(string) bool) *Coordinator {
+func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerPricing *provider.Pricing, plannerTools *tool.Registry, plannerOptions Options, executor *Agent, temperature float64, sink event.Sink, shouldPlan func(context.Context, string) bool) *Coordinator {
 	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
@@ -215,7 +217,7 @@ func (c *Coordinator) SetSandboxEscapeApprover(g sandbox.EscapeApprover) {
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
-	if c.shouldPlan != nil && !c.shouldPlan(input) {
+	if c.shouldPlan != nil && !c.shouldPlan(ctx, input) {
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, input)
 	}
@@ -241,7 +243,9 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 	if isNoOpPlan(plan) {
 		c.persistExecutorNoOp(ctx, input, plan)
-		c.sink.Emit(event.Event{Kind: event.Text, Text: plan})
+		// The relayed conclusion is planner text; keep its source so sinks
+		// attribute it like every other planner emission.
+		c.sink.Emit(event.Event{Kind: event.Text, Text: plan, Source: event.UsageSourcePlanner})
 		return nil
 	}
 	return c.executor.Run(ctx, formatHandoff(input, plan, executorToolHandoffContext(c.executor)))
@@ -490,6 +494,11 @@ Executor instructions:
 Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan, toolBlock)
 }
 
+// executorToolHandoffContext counters planner "tool unavailable" hallucinations
+// in the handoff. MCP tools are the surface planners actually mis-report (the
+// planner registry filters them away), so the block is only emitted when the
+// executor carries MCP tools; the built-in tool list would just restate the
+// schema already attached to the request and pay its tokens every planned turn.
 func executorToolHandoffContext(a *Agent) string {
 	if a == nil || a.tools == nil {
 		return ""
@@ -510,15 +519,13 @@ func executorToolHandoffContext(a *Agent) string {
 			mcpNames = append(mcpNames, name)
 		}
 	}
-	if len(toolNames) == 0 {
+	if len(mcpNames) == 0 {
 		return ""
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "- The executor request includes the full tool schema (%d tools). Tool names include: %s.", len(toolNames), boundedToolNames(toolNames, 24))
-	if len(mcpNames) > 0 {
-		fmt.Fprintf(&b, "\n- MCP tools are already registered for the executor in this request (%d MCP tools). MCP tool names include: %s.", len(mcpNames), boundedToolNames(mcpNames, 16))
-	}
+	fmt.Fprintf(&b, "- The executor request includes the full tool schema (%d tools).", len(toolNames))
+	fmt.Fprintf(&b, "\n- MCP tools are already registered for the executor in this request (%d MCP tools). MCP tool names include: %s.", len(mcpNames), boundedToolNames(mcpNames, 16))
 	return b.String()
 }
 

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -113,7 +113,7 @@ func TestCoordinatorSkipsPlannerForTrivialTurn(t *testing.T) {
 
 	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
 	plannerSess := NewSession("planner-sys")
-	coord := NewCoordinator(planner, plannerSess, nil, nil, Options{}, executor, 0, event.Discard, func(string) bool { return false })
+	coord := NewCoordinator(planner, plannerSess, nil, nil, Options{}, executor, 0, event.Discard, func(context.Context, string) bool { return false })
 
 	if err := coord.Run(context.Background(), "what does this function do?"); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -1063,5 +1063,97 @@ func TestCoordinatorHandoffSurvivesPlannerCompaction(t *testing.T) {
 	got := lastUser(exec.requests[0])
 	if !strings.Contains(got, "Edit main.go and add the missing guard.") || !strings.Contains(got, executorHandoffMarker) {
 		t.Fatalf("executor input lost the plan handoff after planner compaction:\n%s", got)
+	}
+}
+
+// TestCoordinatorNoOpConclusionAttributedToPlanner pins the event source on the
+// relayed no-op conclusion: it is planner text and must not be attributed to
+// the executor by sinks that key styling/usage off Source.
+func TestCoordinatorNoOpConclusionAttributedToPlanner(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "The guard already exists in parser.go.\n[no_changes]"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor"}
+	var events []event.Event
+	sink := event.FuncSink(func(e event.Event) { events = append(events, e) })
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, sink, nil)
+
+	if err := coord.Run(context.Background(), "check the parser guard"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var conclusion *event.Event
+	for i := range events {
+		if events[i].Kind == event.Text && strings.Contains(events[i].Text, "[no_changes]") {
+			conclusion = &events[i]
+		}
+	}
+	if conclusion == nil {
+		t.Fatal("no-op conclusion text event not emitted")
+	}
+	if conclusion.Source != event.UsageSourcePlanner {
+		t.Fatalf("no-op conclusion Source = %q, want planner attribution", conclusion.Source)
+	}
+}
+
+// TestCoordinatorHandoffOmitsToolContextWithoutMCPTools checks that the handoff
+// does not restate the built-in tool schema: the tool-context block exists to
+// counter planner claims about MCP availability and is dropped entirely when
+// the executor carries no MCP tools.
+func TestCoordinatorHandoffOmitsToolContextWithoutMCPTools(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Edit main.go and add the missing guard."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	execReg := tool.NewRegistry()
+	execReg.Add(coordinatorTestTool{name: "write_file", readOnly: false, output: "ok"})
+	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "fix the missing guard"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := lastUser(exec.requests[0])
+	for _, unwanted := range []string{"Executor tool context", "Tool names include"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("handoff restates built-in tool schema (%q):\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "Edit main.go") {
+		t.Fatalf("handoff missing the plan: %q", got)
+	}
+}
+
+// TestCoordinatorPassesTurnContextToPlannerGate pins the C2 contract: the gate
+// receives the live turn context, so a classifier-backed gate is cancelled
+// with the turn instead of running out its own timeout.
+func TestCoordinatorPassesTurnContextToPlannerGate(t *testing.T) {
+	type gateCtxKey struct{}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "It does X."},
+		{Type: provider.ChunkDone},
+	}}
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+
+	var sawTurnValue bool
+	gate := func(ctx context.Context, _ string) bool {
+		sawTurnValue = ctx.Value(gateCtxKey{}) != nil
+		return false
+	}
+	coord := NewCoordinator(&mockProvider{name: "planner"}, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, gate)
+
+	ctx := context.WithValue(context.Background(), gateCtxKey{}, "turn")
+	if err := coord.Run(ctx, "what does this do?"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !sawTurnValue {
+		t.Fatal("planner gate did not receive the turn context")
 	}
 }

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -286,17 +286,22 @@ var docsAndIssueTerms = []string{
 	"需求", "产品文档", "接口文档", "方案", "规划",
 }
 
-func NewPlannerGate(classifier AutoPlanClassifier) func(string) bool {
+// NewPlannerGate builds the per-turn planner gate for two-model mode. The turn
+// context is threaded into the classifier call so a cancelled turn stops the
+// borderline check immediately instead of letting it run out its own timeout.
+func NewPlannerGate(classifier AutoPlanClassifier) func(context.Context, string) bool {
 	if nilutil.IsNil(classifier) {
-		return TaskWarrantsPlanner
+		return func(_ context.Context, input string) bool {
+			return TaskWarrantsPlanner(input)
+		}
 	}
-	return func(input string) bool {
+	return func(ctx context.Context, input string) bool {
 		if !TaskWarrantsPlanner(input) {
 			return false
 		}
 		score := autoPlanScore(input)
 		if score <= 2 {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
 			needsPlan, _, err := classifier.NeedsPlan(ctx, input, score)
 			if err == nil {

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -119,29 +119,51 @@ func TestNewPlannerGateNilClassifierFallback(t *testing.T) {
 	if gate == nil {
 		t.Fatal("NewPlannerGate(nil) returned nil")
 	}
-	if got := gate("what is this?"); got {
+	if got := gate(context.Background(), "what is this?"); got {
 		t.Error("nil classifier gate should skip low-risk questions")
 	}
-	if got := gate("fix the bug"); !got {
+	if got := gate(context.Background(), "fix the bug"); !got {
 		t.Error("nil classifier gate should plan work requests")
 	}
 }
 
 func TestNewPlannerGateWithClassifier(t *testing.T) {
 	gate := NewPlannerGate(&mockAutoPlanClassifier{needsPlan: false})
-	if got := gate("fix the bug"); got {
+	if got := gate(context.Background(), "fix the bug"); got {
 		t.Error("classifier said no plan, gate should return false")
 	}
 
 	gate = NewPlannerGate(&mockAutoPlanClassifier{needsPlan: true})
-	if got := gate("fix the bug"); !got {
+	if got := gate(context.Background(), "fix the bug"); !got {
 		t.Error("classifier said plan, gate should return true")
 	}
 }
 
 func TestNewPlannerGateClassifierFailureFallsBackToPlanning(t *testing.T) {
 	gate := NewPlannerGate(&mockAutoPlanClassifier{err: errors.New("bad json")})
-	if got := gate("fix the bug"); !got {
+	if got := gate(context.Background(), "fix the bug"); !got {
 		t.Error("classifier failure should fall back to planning for work requests")
+	}
+}
+
+type ctxCapturingClassifier struct{ sawTurnValue bool }
+
+func (c *ctxCapturingClassifier) NeedsPlan(ctx context.Context, _ string, _ int) (bool, string, error) {
+	c.sawTurnValue = ctx.Value(plannerGateTestCtxKey{}) != nil
+	return false, "", nil
+}
+
+type plannerGateTestCtxKey struct{}
+
+// TestNewPlannerGateThreadsTurnContextIntoClassifier pins that the borderline
+// classifier call derives from the turn context (so user cancellation stops it)
+// rather than from context.Background().
+func TestNewPlannerGateThreadsTurnContextIntoClassifier(t *testing.T) {
+	cls := &ctxCapturingClassifier{}
+	gate := NewPlannerGate(cls)
+	ctx := context.WithValue(context.Background(), plannerGateTestCtxKey{}, "turn")
+	gate(ctx, "fix the bug")
+	if !cls.sawTurnValue {
+		t.Fatal("classifier context does not derive from the turn context")
 	}
 }


### PR DESCRIPTION
## Summary

Three follow-ups on the two-model coordinator, stacked on #6193 (the first three commits here are that PR; review this PR by its last commit or wait for #6193 to merge, after which this rebases to a clean single-commit diff).

- **Planner gate receives the turn context.** A classifier-backed gate (`NewPlannerGate`) derived its 3s borderline-classification timeout from `context.Background()`, so a user-cancelled turn left the classifier call running until its own timeout. The gate signature becomes `func(context.Context, string) bool` and the classifier timeout now derives from the turn context.
- **No-op conclusion attributed to the planner.** The relayed `[no_changes]` conclusion is planner text; it now carries `Source: UsageSourcePlanner` so sinks that key styling/usage off `Source` do not attribute it to the executor.
- **Handoff tool-context block trimmed.** The block exists to counter planner "tool unavailable" hallucinations about MCP tools (the planner registry filters them away). It is now emitted only when the executor carries MCP tools, and the built-in tool name list — which restated the schema already attached to the request, paying its tokens on every planned turn — is dropped.

## Cache impact

No stable-prefix bytes change. The trimmed tool block lives in the per-turn handoff user message, not in any cached prefix; system prompts, tool schemas, and message ordering are untouched. `./scripts/cache-guard.sh` passes 8/8 (tail_avg 92–95).

## Verification

- `go test ./internal/agent ./internal/control -count=1` — pass
- `gofmt -l` / `go vet` on both packages — clean
- New regression tests: `TestCoordinatorPassesTurnContextToPlannerGate`, `TestNewPlannerGateThreadsTurnContextIntoClassifier`, `TestCoordinatorNoOpConclusionAttributedToPlanner`, `TestCoordinatorHandoffOmitsToolContextWithoutMCPTools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)