### PR TITLE
fix(skill): enforce review/security-review read-only contract at the tool boundary / 在工具边界强制 review/security-review 只读契约

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -766,7 +766,18 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if childDepth > maxSubagentDepth {
 			return "", fmt.Errorf("subagent delegation depth limit reached (max_subagent_depth=%d)", maxSubagentDepth)
 		}
-		subReg := agent.SubagentToolRegistryForDepth(reg, sk.AllowedTools, childDepth, maxSubagentDepth)
+		// A read-only skill (builtin review/security-review, or frontmatter
+		// `read-only: true`) gets its promise enforced at the tool boundary:
+		// writer tools are stripped and bash runs under the plan-mode safe
+		// command policy. Transcripts recorded against the writer-capable
+		// registry stop matching on continue_from (schema-hash check reports
+		// the mismatch).
+		var subReg *tool.Registry
+		if sk.ReadOnly {
+			subReg = agent.ReadOnlySubagentToolRegistryForDepth(reg, sk.AllowedTools, childDepth, maxSubagentDepth)
+		} else {
+			subReg = agent.SubagentToolRegistryForDepth(reg, sk.AllowedTools, childDepth, maxSubagentDepth)
+		}
 		continueFrom := strings.TrimSpace(runOpts.ContinueFrom)
 		legacyForkFrom := strings.TrimSpace(runOpts.ForkFrom)
 		if continueFrom != "" && legacyForkFrom != "" {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -584,7 +584,10 @@ model = "x"
 	}
 }
 
-func TestBuildSubagentSkillGetsForegroundOnlyBash(t *testing.T) {
+// TestBuildReviewSubagentSkillEnforcesReadOnlyBash pins the review builtin's
+// read-only contract at the tool boundary: its sub-agent gets the plan-mode
+// safe bash wrapper, not the writer-capable foreground bash.
+func TestBuildReviewSubagentSkillEnforcesReadOnlyBash(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)
 	t.Chdir(dir)
@@ -633,10 +636,99 @@ model = "x"
 		}
 	}
 	if !requestHasTool(subReq, "bash") {
-		t.Fatalf("skill subagent request should keep foreground bash; tools=%v", toolSchemaNames(subReq.Tools))
+		t.Fatalf("skill subagent request should keep bash; tools=%v", toolSchemaNames(subReq.Tools))
 	}
 	if requestToolSchemaContains(subReq, "bash", "run_in_background") {
 		t.Fatalf("skill subagent bash schema should not include run_in_background")
+	}
+	if !requestToolDescriptionContains(subReq, "bash", "Only plan-mode safe read-only commands are allowed") {
+		t.Fatalf("review subagent bash must advertise the plan-mode safe read-only policy; got %q", requestToolDescription(subReq, "bash"))
+	}
+}
+
+func requestToolDescription(req provider.Request, name string) string {
+	for _, schema := range req.Tools {
+		if schema.Name == name {
+			return schema.Description
+		}
+	}
+	return ""
+}
+
+func requestToolDescriptionContains(req provider.Request, name, want string) bool {
+	return strings.Contains(requestToolDescription(req, name), want)
+}
+
+// TestBuildRunSkillSubagentRegistryHonorsReadOnlyFlag proves the registry split
+// for user-defined subagent skills: a plain skill keeps writer tools and the
+// foreground-only bash, while a `read-only: true` skill is stripped to research
+// tools plus the plan-mode safe bash.
+func TestBuildRunSkillSubagentRegistryHonorsReadOnlyFlag(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootTokenProfileTestProvider()
+	prov := testutil.NewMock("run-skill-readonly",
+		testutil.Turn{ToolCalls: []provider.ToolCall{
+			{ID: "w-1", Name: "run_skill", Arguments: `{"name":"wskill","arguments":"write things"}`},
+		}},
+		testutil.Turn{Text: "writer sub done"},
+		testutil.Turn{ToolCalls: []provider.ToolCall{
+			{ID: "ro-1", Name: "run_skill", Arguments: `{"name":"roskill","arguments":"inspect things"}`},
+		}},
+		testutil.Turn{Text: "read-only sub done"},
+		testutil.Turn{Text: "done"},
+	)
+	setBootTokenProfileTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+`)
+	writeFile(t, dir, ".reasonix/skills/wskill.md",
+		"---\ndescription: writer skill\nrunAs: subagent\nallowed-tools: bash, read_file, write_file\n---\nwriter body")
+	writeFile(t, dir, ".reasonix/skills/roskill.md",
+		"---\ndescription: read-only skill\nrunAs: subagent\nallowed-tools: bash, read_file, write_file\nread-only: true\n---\nread-only body")
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "run both skills"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.Requests()
+	if len(reqs) != 5 {
+		t.Fatalf("provider requests = %d, want 5 (parent, writer sub, parent, read-only sub, parent)", len(reqs))
+	}
+	writerReq, roReq := reqs[1], reqs[3]
+
+	if !requestHasTool(writerReq, "write_file") {
+		t.Fatalf("writer skill subagent should keep write_file; tools=%v", toolSchemaNames(writerReq.Tools))
+	}
+	if !requestToolDescriptionContains(writerReq, "bash", "Background execution is unavailable inside subagents") {
+		t.Fatalf("writer skill subagent bash should be the foreground-only wrapper; got %q", requestToolDescription(writerReq, "bash"))
+	}
+	if requestToolDescriptionContains(writerReq, "bash", "Only plan-mode safe read-only commands are allowed") {
+		t.Fatalf("writer skill subagent bash must not be the read-only wrapper; got %q", requestToolDescription(writerReq, "bash"))
+	}
+
+	if requestHasTool(roReq, "write_file") {
+		t.Fatalf("read-only skill subagent must strip write_file; tools=%v", toolSchemaNames(roReq.Tools))
+	}
+	if !requestHasTool(roReq, "read_file") {
+		t.Fatalf("read-only skill subagent should keep read_file; tools=%v", toolSchemaNames(roReq.Tools))
+	}
+	if !requestToolDescriptionContains(roReq, "bash", "Only plan-mode safe read-only commands are allowed") {
+		t.Fatalf("read-only skill subagent bash must be the plan-mode safe wrapper; got %q", requestToolDescription(roReq, "bash"))
 	}
 }
 

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -86,6 +86,11 @@ func reviewCommand(args []string) int {
 
 	// 7. Run the review subagent.
 	ctx := context.Background()
+	// Deliberately minimal Options: this one-shot CLI path has no gate, no
+	// compaction, and no session, unlike the in-session sub-agent paths built
+	// through TaskTool.subagentOptions / boot's subagentSkillOptions. If a new
+	// Options field becomes load-bearing for sub-agents, decide explicitly
+	// whether this path needs it too.
 	result, err := agent.RunSubAgentWithSession(ctx, prov, reg, agent.NewSession(reviewSk.Body), task, agent.Options{
 		MaxSteps:      12,
 		Temperature:   cfg.Agent.Temperature,
@@ -111,12 +116,17 @@ func buildReviewSubagentRegistry(reviewSk skill.Skill, cfg *config.Config) *tool
 			parentReg.Add(tl)
 		}
 	}
-	// Keep review bash unconfined as before (read-oriented skill), but attach
-	// the session-data guard so commands touching Reasonix's own state warn the
-	// same way the boot-assembled bash does.
+	// Attach the session-data guard so commands touching Reasonix's own state
+	// warn the same way the boot-assembled bash does.
 	if _, ok := parentReg.Get("bash"); ok {
 		guard := builtin.NewSessionDataGuard(config.MemoryUserDir(), cfg.AllowWriteRoots())
 		parentReg.Add(builtin.ConfineBash(sandbox.Spec{}, guard))
+	}
+	if reviewSk.ReadOnly {
+		// The built-in review skill declares read-only; enforce it here exactly
+		// like the in-session runner does (writer tools stripped, bash under the
+		// plan-mode safe policy) so `reasonix review` is not a writable backdoor.
+		return agent.ReadOnlySubagentToolRegistry(parentReg, reviewSk.AllowedTools)
 	}
 	return agent.SubagentToolRegistry(parentReg, reviewSk.AllowedTools)
 }

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -66,3 +66,29 @@ func TestBuildReviewSubagentRegistryUsesForegroundOnlyBash(t *testing.T) {
 		t.Fatalf("review subagent background bash should return a clear error, got %v", err)
 	}
 }
+
+// TestBuildReviewSubagentRegistryEnforcesReadOnlySkill pins the CLI path of the
+// review read-only contract: `reasonix review` runs the same builtin skill as
+// the in-session review tool, so its bash must enforce the plan-mode safe
+// policy instead of trusting the prompt's "stay read-only" promise.
+func TestBuildReviewSubagentRegistryEnforcesReadOnlySkill(t *testing.T) {
+	reg := buildReviewSubagentRegistry(skill.Skill{
+		ReadOnly:     true,
+		AllowedTools: []string{"bash", "read_file", "task"},
+	}, config.Default())
+
+	if _, ok := reg.Get("task"); ok {
+		t.Fatalf("read-only review registry should hide task; got %v", reg.Names())
+	}
+	bash, ok := reg.Get("bash")
+	if !ok {
+		t.Fatalf("read-only review registry should keep bash; got %v", reg.Names())
+	}
+	if !bash.ReadOnly() {
+		t.Fatal("read-only review bash wrapper must report ReadOnly")
+	}
+	out, err := bash.Execute(context.Background(), json.RawMessage(`{"command":"rm -rf tmp"}`))
+	if err != nil || !strings.HasPrefix(out, "blocked:") {
+		t.Fatalf("write-capable command should be blocked as tool output, got %q, %v", out, err)
+	}
+}

--- a/internal/skill/builtins.go
+++ b/internal/skill/builtins.go
@@ -326,6 +326,7 @@ func builtinSkills() []Skill {
 			Path:         "(builtin)",
 			RunAs:        RunSubagent,
 			AllowedTools: append([]string(nil), reviewTools...),
+			ReadOnly:     true,
 		},
 		{
 			Name:         "security-review",
@@ -335,6 +336,7 @@ func builtinSkills() []Skill {
 			Path:         "(builtin)",
 			RunAs:        RunSubagent,
 			AllowedTools: append([]string(nil), reviewTools...),
+			ReadOnly:     true,
 		},
 		{
 			Name:        "test",

--- a/internal/skill/builtins_test.go
+++ b/internal/skill/builtins_test.go
@@ -24,6 +24,27 @@ func (t builtinTestTool) Execute(context.Context, json.RawMessage) (string, erro
 }
 func (t builtinTestTool) ReadOnly() bool { return t.readOnly }
 
+// TestBuiltinReviewSkillsDeclareReadOnly pins the tool-boundary contract behind
+// the review/security-review "Read-only" promise: runners select the read-only
+// subagent registry from this flag, so losing it silently re-opens writer bash.
+func TestBuiltinReviewSkillsDeclareReadOnly(t *testing.T) {
+	want := map[string]bool{
+		"explore":         false,
+		"research":        false,
+		"review":          true,
+		"security-review": true,
+	}
+	for _, sk := range builtinSkills() {
+		expected, tracked := want[sk.Name]
+		if !tracked {
+			continue
+		}
+		if sk.ReadOnly != expected {
+			t.Errorf("builtin %q ReadOnly = %v, want %v", sk.Name, sk.ReadOnly, expected)
+		}
+	}
+}
+
 func TestCodeGraphReadToolsRequireKnownNameAndReadOnly(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(builtinTestTool{name: "mcp__codegraph__symbols", readOnly: true})

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -65,6 +65,11 @@ type Skill struct {
 	RunAs        RunAs  // inline | subagent
 	Model        string // optional model override for runAs=subagent (frontmatter `model:`)
 	Effort       string // optional effort for runAs=subagent (frontmatter `effort:`)
+	// ReadOnly, when true, runs a subagent skill against the read-only tool
+	// registry: writer tools are stripped and bash enforces the plan-mode safe
+	// command policy at execution time (frontmatter `read-only:`). This is a
+	// tool-boundary contract, not a prompt promise.
+	ReadOnly bool
 	// Routing metadata is intentionally kept out of the cache-stable Skills
 	// index; it feeds per-turn capability hints only.
 	Triggers         []string
@@ -493,6 +498,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
 		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
 		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
+		ReadOnly:     parseBoolFrontmatter(fm[skillFrontmatterReadOnly]),
 		Triggers:     parseCSVFrontmatter(fm[skillFrontmatterTriggers]),
 		NegativeTriggers: parseCSVFrontmatter(
 			fm[skillFrontmatterNegativeTriggers],
@@ -512,6 +518,7 @@ const (
 	skillFrontmatterAllowedTools     = "allowed-tools"
 	skillFrontmatterModel            = "model"
 	skillFrontmatterEffort           = "effort"
+	skillFrontmatterReadOnly         = "read-only"
 	skillFrontmatterTriggers         = "triggers"
 	skillFrontmatterNegativeTriggers = "negative-triggers"
 	skillFrontmatterAutoUse          = "auto-use"
@@ -528,6 +535,7 @@ var skillMarkerFrontmatterKeys = []string{
 	skillFrontmatterAllowedTools,
 	skillFrontmatterModel,
 	skillFrontmatterEffort,
+	skillFrontmatterReadOnly,
 	skillFrontmatterTriggers,
 	skillFrontmatterNegativeTriggers,
 	skillFrontmatterAutoUse,

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -323,7 +323,7 @@ func TestExcludedPathsHideConventionRoots(t *testing.T) {
 func TestFrontmatterFields(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/sub.md",
-		"---\ndescription: a sub\nrunAs: subagent\nallowed-tools: read_file, grep\nmodel: deepseek-pro\n---\nbody")
+		"---\ndescription: a sub\nrunAs: subagent\nallowed-tools: read_file, grep\nmodel: deepseek-pro\nread-only: true\n---\nbody")
 	writeSkill(t, home, ".reasonix/skills/fork.md", "---\ndescription: f\ncontext: fork\n---\nbody")
 	writeSkill(t, home, ".reasonix/skills/plain.md", "---\ndescription: p\n---\nbody")
 
@@ -338,11 +338,17 @@ func TestFrontmatterFields(t *testing.T) {
 	if sub.Model != "deepseek-pro" {
 		t.Errorf("model mis-parsed: %q", sub.Model)
 	}
+	if !sub.ReadOnly {
+		t.Error("read-only: true not parsed")
+	}
 	if fork, _ := st.Read("fork"); fork.RunAs != RunSubagent {
 		t.Error("context: fork should imply subagent")
 	}
 	if plain, _ := st.Read("plain"); plain.RunAs != RunInline {
 		t.Error("default runAs should be inline")
+	}
+	if plain, _ := st.Read("plain"); plain.ReadOnly {
+		t.Error("read-only should default to false when the key is absent")
 	}
 }
 


### PR DESCRIPTION
## Problem

The builtin `review` and `security-review` sub-agents say "Stay read-only" in their prompt bodies, but the promise had no mechanism behind it: both ran through the writer-capable skill runner, so their `bash` was the foreground-only wrapper — happy to execute `git commit`, `rm`, or any other mutating command if the model drifted off its instructions. The `reasonix review` CLI path had the same gap.

## Changes

- **`Skill.ReadOnly`** (new frontmatter key `read-only:`): a subagent skill can declare that its tool boundary must be read-only. Set on the builtin `review` and `security-review` skills; user-authored skills can opt in with the same key.
- **`internal/boot/boot.go`**: `skillRunner` selects `ReadOnlySubagentToolRegistryForDepth` for read-only skills — writer tools are stripped and `bash` enforces the plan-mode safe command policy at execution time (the same wrapper `read_only_task` children already use). Transcript persistence and `continue_from` keep working for new runs.
- **`internal/cli/review.go`**: `reasonix review` applies the same enforcement, so the CLI is not a writable backdoor around the in-session contract. Also documents the deliberately minimal one-shot `Options` construction next to the shared `subagentOptions` / `subagentSkillOptions` builders (follow-up noted in #6198).

Deliberately unchanged: the dedicated `review` / `security_review` wrapper tools keep `ReadOnly() == false`, so the parent-side tool surface (plan mode, read-only parent contexts) stays byte-identical; whether to expose them there is a separate product decision.

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Skill files without `read-only:` | Frontmatter key absent → `ReadOnly=false` → exact previous behavior | safe |
| `continue_from` on old review/security-review transcripts | Tool schema hash no longer matches; fails with the existing explicit error ("uses different tool schemas") instead of silently changing capability mid-transcript — approved trade-off of this change | safe (loud, documented) |
| Skills index / persisted formats | Index rendering, state, and config formats untouched; `ReadOnly` is not serialized anywhere | safe |
| explore/research builtins | `ReadOnly=false` (they never had bash); registries unchanged | safe |

## Verification

- `gofmt -l` clean; `go vet` over skill/boot/cli/agent
- `go test ./internal/skill ./internal/cli ./internal/boot ./internal/agent` — pass
- Full root `go test ./...` — pass
- `cd desktop && go build ./... && go test` (all packages except `cmd/sign`, OOM-bound on this box, no dependency on `reasonix/internal`) — pass
- `./scripts/cache-guard.sh` — 8/8 cases pass, tail_avg 92–95 vs threshold 90
- New regression tests: `TestBuiltinReviewSkillsDeclareReadOnly`, `TestBuildReviewSubagentSkillEnforcesReadOnlyBash` (repurposed from the foreground-bash pin), `TestBuildRunSkillSubagentRegistryHonorsReadOnlyFlag` (writer skill keeps writer bash + write_file; `read-only: true` skill gets plan-mode safe bash, write_file stripped), `TestBuildReviewSubagentRegistryEnforcesReadOnlySkill` (CLI path), frontmatter parse assertions in `TestFrontmatterFields`

Cache-impact: low - parent-session prefix and parent-visible tool schemas are byte-identical (wrapper tools unchanged). Only the review/security-review child sessions see a different bash schema; that is the point of the change and invalidates only their own transcripts' continue_from with a clear error.
Cache-guard: scripts/cache-guard.sh pass (8/8 cases, tail_avg 92–95, threshold 90).
System-prompt-review: no system-prompt bytes change — skill bodies, DefaultReadOnlyTaskSystemPrompt, and the skills index rendering are untouched; the change is tool-registry selection only, reviewed against both runner paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
