### PR TITLE
fix(agent): share child step-budget rule with parallel_tasks and keep read_skill at depth cap / 统一 parallel_tasks 子任务步数预算并在深度封顶时保留 read_skill

### DIFF
--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -48,7 +48,7 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
         "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
         "description":{"type":"string","description":"Optional short label shown in the job list."},
         "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
-        "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
+        "max_steps":{"type":"integer","description":"Optional max tool-call rounds. Defaults to half the parent agent's step budget (minimum 5), same as task.","minimum":1},
         "model":{"type":"string","description":"Optional model override."},
         "effort":{"type":"string","description":"Optional reasoning effort override."}
       },
@@ -167,10 +167,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			}
 			subReg := ReadOnlySubagentToolRegistryForDepth(p.taskTool.parentReg, t.Tools, childDepth, p.taskTool.maxDepth())
 
-			max := t.MaxSteps
-			if max <= 0 {
-				max = 20
-			}
+			max := p.taskTool.childMaxSteps(t.MaxSteps)
 
 			prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
 			if err != nil {

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -269,3 +269,29 @@ func hasToolResult(req provider.Request, name string) bool {
 type stringsError string
 
 func (e stringsError) Error() string { return string(e) }
+
+// TestChildMaxStepsSharedDefault pins the single step-budget rule shared by
+// task, read_only_task, and parallel_tasks children: explicit request wins,
+// a finite parent yields half its budget (min 5), an unbounded parent yields
+// an unbounded child. parallel_tasks used to hardcode 20 instead.
+func TestChildMaxStepsSharedDefault(t *testing.T) {
+	cases := []struct {
+		name      string
+		parent    int
+		requested int
+		want      int
+	}{
+		{"explicit request wins", 30, 7, 7},
+		{"finite parent halves", 30, 0, 15},
+		{"half is floored at 5", 8, 0, 5},
+		{"unbounded parent stays unbounded", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &TaskTool{maxSteps: tc.parent}
+			if got := task.childMaxSteps(tc.requested); got != tc.want {
+				t.Fatalf("childMaxSteps(parent=%d, requested=%d) = %d, want %d", tc.parent, tc.requested, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agent/subagent_registry_test.go
+++ b/internal/agent/subagent_registry_test.go
@@ -66,7 +66,6 @@ func TestSubagentToolRegistryFiltersUnavailableToolsAndWrapsBash(t *testing.T) {
 		"parallel_tasks",
 		"run_skill",
 		"read_only_skill",
-		"read_skill",
 		"install_skill",
 		"install_source",
 		"explore",
@@ -83,6 +82,9 @@ func TestSubagentToolRegistryFiltersUnavailableToolsAndWrapsBash(t *testing.T) {
 	}
 	if _, ok := sub.Get("read_file"); !ok {
 		t.Fatalf("subagent registry should keep read_file; got %v", sub.Names())
+	}
+	if _, ok := sub.Get("read_skill"); !ok {
+		t.Fatalf("depth-capped subagent registry should keep read_skill (it renders text, it cannot recurse); got %v", sub.Names())
 	}
 	bash, ok := sub.Get("bash")
 	if !ok {
@@ -173,10 +175,13 @@ func TestReadOnlySubagentToolRegistryAllowsOnlyReadOnlyDelegationBeforeDepthLimi
 	}
 
 	secondLayer := ReadOnlySubagentToolRegistryForDepth(parent, nil, 2, 2)
-	for _, hidden := range []string{"task", "run_skill", "read_only_task", "read_only_skill", "read_skill", "explore", "write_file"} {
+	for _, hidden := range []string{"task", "run_skill", "read_only_task", "read_only_skill", "explore", "write_file"} {
 		if _, ok := secondLayer.Get(hidden); ok {
 			t.Fatalf("depth-limited read-only registry should hide %q; got %v", hidden, secondLayer.Names())
 		}
+	}
+	if _, ok := secondLayer.Get("read_skill"); !ok {
+		t.Fatalf("depth-limited read-only registry should keep read_skill (it renders text, it cannot recurse); got %v", secondLayer.Names())
 	}
 }
 

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -38,12 +38,14 @@ const subagentStartContext = `<subagent-context event="SubagentStart">
 Before acting, check the available skills and tools. If a relevant skill is available, invoke it before continuing. Delegate to another sub-agent only when the task genuinely benefits from isolated context and the delegation tool is available.
 </subagent-context>`
 
+// read_skill is deliberately not listed: it renders playbook text inline and
+// cannot recurse, so depth-capped sub-agents keep it and can still read
+// playbooks even when they can no longer delegate.
 var subagentRecursiveTools = []string{
 	"task",
 	"read_only_task",
 	"run_skill",
 	"read_only_skill",
-	"read_skill",
 	"explore",
 	"research",
 	"review",
@@ -72,8 +74,12 @@ const subagentToolBoundarySummary = "Recursive agent/skill tools are exposed onl
 // from the parent registry unless a future call site deliberately opts into a
 // different boundary. They can spawn or author more agent work, so excluding them
 // preserves one layer of delegation without adding a spawn-count cap.
+// read_skill stays listed here so the guardian and planner surfaces, which
+// exclude these names, keep their provider-visible tool sets byte-identical —
+// only the sub-agent depth cap deliberately stopped stripping it.
 func SubagentMetaTools() []string {
 	out := append([]string(nil), subagentRecursiveTools...)
+	out = append(out, "read_skill")
 	out = append(out, subagentAlwaysHiddenTools...)
 	return out
 }
@@ -366,13 +372,7 @@ func (r *ReadOnlyTaskTool) Execute(ctx context.Context, args json.RawMessage) (s
 		return "", fmt.Errorf("prompt is required")
 	}
 
-	maxSteps := p.MaxSteps
-	if maxSteps <= 0 && r.task.maxSteps > 0 {
-		maxSteps = r.task.maxSteps / 2
-		if maxSteps < 5 {
-			maxSteps = 5
-		}
-	}
+	maxSteps := r.task.childMaxSteps(p.MaxSteps)
 
 	childDepth, err := r.task.nextSubagentDepth(ctx)
 	if err != nil {
@@ -388,6 +388,27 @@ func (r *ReadOnlyTaskTool) Execute(ctx context.Context, args json.RawMessage) (s
 		return "", fmt.Errorf("read-only sub-agent profile: %w", err)
 	}
 	return r.task.runSubSession(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, prov, pricing, ctxWin, NewSession(DefaultReadOnlyTaskSystemPrompt), childDepth)
+}
+
+// childMaxSteps resolves a sub-agent's step budget. An explicit request wins.
+// Otherwise mirror the parent: a finite parent caps the child at half its
+// budget (min 5) so a delegated sub-task stays shorter than the whole turn; an
+// unbounded parent yields an unbounded child (it shares the parent's ctx, so
+// cancelling the turn stops it, and it compacts its own context — the same
+// bounds the parent has). Shared by task, read_only_task, and parallel_tasks
+// children so the default cannot drift per call site.
+func (t *TaskTool) childMaxSteps(requested int) int {
+	if requested > 0 {
+		return requested
+	}
+	if t.maxSteps <= 0 {
+		return 0
+	}
+	half := t.maxSteps / 2
+	if half < 5 {
+		half = 5
+	}
+	return half
 }
 
 func (t *TaskTool) effectiveProfile(model, effort string) (string, string) {
@@ -421,20 +442,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		return "", fmt.Errorf("prompt is required")
 	}
 
-	maxSteps := p.MaxSteps
-	if maxSteps <= 0 {
-		// No explicit cap from the caller: mirror the parent. A finite parent caps
-		// the sub-agent at half its budget (min 5) so a delegated sub-task stays
-		// shorter than the whole turn; an unbounded parent yields an unbounded
-		// sub-agent. The sub-agent shares the parent's ctx, so cancelling the turn
-		// stops it, and it compacts its own context — the same bounds the parent has.
-		if t.maxSteps > 0 {
-			maxSteps = t.maxSteps / 2
-			if maxSteps < 5 {
-				maxSteps = 5
-			}
-		}
-	}
+	maxSteps := t.childMaxSteps(p.MaxSteps)
 
 	childDepth, err := t.nextSubagentDepth(ctx)
 	if err != nil {


### PR DESCRIPTION
## Problem

Two sub-agent boundary inconsistencies reported during the #6198 review:

1. **`parallel_tasks` children hardcoded `max_steps=20`**, while `task` and `read_only_task` children default to half the parent's step budget (min 5). A parent with a small budget spawned parallel children with a larger one; a parent with a large budget starved them. The schema also documented no default at all.
2. **Depth-capped sub-agents lost `read_skill`.** `subagentRecursiveTools` listed it, but `read_skill` renders playbook text inline and cannot recurse — a sub-agent at the delegation depth limit could not even read a skill playbook.

## Changes

- `internal/agent/task.go`: extract `TaskTool.childMaxSteps()` as the single step-budget rule (explicit request wins; finite parent → half its budget, min 5; unbounded parent → unbounded child), now shared by `task`, `read_only_task`, and `parallel_tasks` children. Same drift-killing shape as #6198's `subagentOptions()`.
- `internal/agent/parallel_tasks.go`: children use the shared rule; the `max_steps` schema description now states the default.
- `subagentRecursiveTools` no longer lists `read_skill`, so both the writer and read-only sub-agent registries keep it at the depth cap. `SubagentMetaTools()` still excludes it explicitly, so the guardian and planner tool surfaces stay byte-identical.

## Backward compatibility

| Surface | Old behavior | New behavior | Conclusion |
| --- | --- | --- | --- |
| `parallel_tasks` child with explicit `max_steps` | honored | honored (unchanged) | safe |
| `parallel_tasks` child default, finite parent budget | always 20 | half parent budget (min 5), same as `task` | intended change; bounded both directions |
| `parallel_tasks` child default, unbounded parent | 20 | unbounded, same as `task` children; still cancelled with the turn and compacts its own context | intended consistency; noted here explicitly |
| Depth-capped sub-agents | no `read_skill` | `read_skill` available (read-only text render) | strict superset, no writer capability added |
| Guardian / planner registries | exclude `read_skill` | unchanged (explicit exclusion kept) | safe, byte-identical |
| Persisted formats | — | no serialization change | safe |

## Verification

- `gofmt -l` clean; `go vet ./internal/agent/...`
- `go test ./internal/agent ./internal/boot ./internal/control ./internal/skill ./internal/cli` — pass
- Full root `go test ./...` — pass
- `cd desktop && go build ./... && go test` (all packages except `cmd/sign`, OOM-bound on this box, no dependency on `reasonix/internal`) — pass
- `./scripts/cache-guard.sh` — 8/8 cases pass, tail_avg 92–95 vs threshold 90
- New regression tests: `TestChildMaxStepsSharedDefault`; updated `TestSubagentToolRegistryFiltersUnavailableToolsAndWrapsBash` and `TestReadOnlySubagentToolRegistryAllowsOnlyReadOnlyDelegationBeforeDepthLimit` to pin `read_skill` present at the depth cap

Cache-impact: low - the parallel_tasks `max_steps` schema description changes, a one-time parent-prefix invalidation on upgrade for sessions with that tool enabled (schema is stable within a session). Guardian and planner tool surfaces are byte-identical via the explicit SubagentMetaTools exclusion; child sub-agent sessions gain read_skill only at the depth cap.
Cache-guard: scripts/cache-guard.sh pass (8/8 cases, tail_avg 92–95, threshold 90).
System-prompt-review: no system-prompt bytes change — skill bodies and system prompts untouched; the only provider-visible byte change is the parallel_tasks max_steps schema description documented under Cache-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
