### PR TITLE
Keep compaction on failed planner-turn rollback; marker-only no-op contract / 规划回合失败回滚保留 compaction、no-op 判定仅认 marker

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -266,72 +266,14 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 }
 
 // isNoOpPlan reports whether the plan explicitly concludes that nothing needs
-// to change. The primary contract is the [no_changes] marker requested from the
-// planner in DefaultPlannerPrompt: when the final non-empty line IS the marker
-// (exactly, as the prompt asks) it is trusted as-is, so research notes above it
-// (which may mention tests, runs, or edits that already exist) cannot veto the
-// conclusion. A final line that merely mentions the marker in prose ("do not
-// emit [no_changes] because…") is not a conclusion and falls through to the
-// veto-guarded heuristics below. The legacy phrase list stays
-// as a fallback for planners that ignore the marker, but it only matches
-// conclusion positions (the first or last non-empty line) and is vetoed by
-// action verbs anywhere in the plan: a wrong skip silently drops the task,
-// while a missed skip just costs one executor round.
+// to change: the final non-empty line is exactly the [no_changes] marker that
+// DefaultPlannerPrompt requests. The marker is trusted as-is, so research notes
+// above it (which may mention tests, runs, or edits that already exist) cannot
+// veto the conclusion. There is deliberately no phrase heuristic behind it: a
+// wrong skip silently drops the task, while a planner that ignores the marker
+// contract just costs one executor round.
 func isNoOpPlan(plan string) bool {
-	trimmed := strings.TrimSpace(plan)
-	if trimmed == "" {
-		return false
-	}
-	first := strings.ToLower(firstNonEmptyLine(trimmed))
-	last := strings.ToLower(lastNonEmptyLine(trimmed))
-	if last == noChangesMarker {
-		return true
-	}
-	if containsNoOpActionTerm(strings.ToLower(trimmed)) {
-		return false
-	}
-	noOp := []string{
-		"no changes needed",
-		"no changes are needed",
-		"no changes required",
-		"no changes are required",
-		"no action needed",
-		"no action required",
-		"nothing to change",
-		"nothing to do",
-		"already handled",
-		"already implemented",
-		"already resolved",
-		"无需改动",
-		"无需修改",
-		"无需更改",
-		"不需要修改",
-		"不需要改",
-		"不用改",
-		"不用修改",
-		"不必改动",
-		"没有需要修改",
-		"已经正确处理",
-		"已经实现",
-		"已经解决",
-	}
-	for _, phrase := range noOp {
-		for _, line := range []string{first, last} {
-			if strings.Contains(line, phrase) && !strings.Contains(line, "not "+phrase) && !strings.Contains(line, "不是"+phrase) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func firstNonEmptyLine(s string) string {
-	for _, line := range strings.Split(s, "\n") {
-		if t := strings.TrimSpace(line); t != "" {
-			return t
-		}
-	}
-	return ""
+	return strings.ToLower(lastNonEmptyLine(plan)) == noChangesMarker
 }
 
 func lastNonEmptyLine(s string) string {
@@ -342,25 +284,6 @@ func lastNonEmptyLine(s string) string {
 		}
 	}
 	return ""
-}
-
-func containsNoOpActionTerm(lower string) bool {
-	terms := []string{
-		" add ", " add docs", " add tests", " update ", " edit ", " write ",
-		" create ", " delete ", " remove ", " patch ", " refactor ", " implement ",
-		" run ", " test ", " build ", " fix ", " extend ", " verify ", " check ",
-		" investigate ",
-		"新增", "补充", "更新", "编辑", "写入", "创建", "删除", "移除",
-		"运行", "测试", "构建", "修复", "实现", "重构", "扩展", "验证", "排查",
-		"检查", "调查",
-	}
-	padded := " " + lower + " "
-	for _, term := range terms {
-		if strings.Contains(padded, term) {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan string) {
@@ -431,7 +354,7 @@ func (c *Coordinator) planWithTools(ctx context.Context, input string) (string, 
 		// saved work is what the user is asked to continue from.
 		var pause *maxStepsPause
 		if !errors.As(err, &pause) {
-			c.plannerSess.Replace(before)
+			c.rollbackPlannerTurn(before, rewriteBefore)
 		}
 		return "", err
 	}
@@ -454,8 +377,32 @@ func (c *Coordinator) planWithTools(ctx context.Context, input string) (string, 
 	}
 	// No usable plan came back: roll back too, so the executor-fallback turn
 	// does not leave the planner session ending in a user message.
-	c.plannerSess.Replace(before)
+	c.rollbackPlannerTurn(before, rewriteBefore)
 	return "", fmt.Errorf("planner finished without producing a plan")
+}
+
+// rollbackPlannerTurn discards a failed planning turn from the planner session.
+// Without a mid-turn rewrite the pre-turn snapshot is restored exactly. When
+// auto-compaction rewrote the log during the turn, restoring the snapshot would
+// also revert the compaction — wasting its summarizer call and re-growing the
+// prompt the fold just paid to shrink — so only the trailing plain user
+// messages are dropped (the dangling turn input plus any steer/nudge messages):
+// those are what would produce consecutive user roles on the next plan, while
+// completed tool rounds and the compaction digest stay coherent history.
+func (c *Coordinator) rollbackPlannerTurn(before []provider.Message, rewriteBefore int) {
+	if c.plannerSess.RewriteVersion() == rewriteBefore {
+		c.plannerSess.Replace(before)
+		return
+	}
+	msgs := c.plannerSess.Snapshot()
+	for len(msgs) > 0 {
+		last := msgs[len(msgs)-1]
+		if last.Role != provider.RoleUser || isCompactionSummary(last) {
+			break
+		}
+		msgs = msgs[:len(msgs)-1]
+	}
+	c.plannerSess.Replace(msgs)
 }
 
 func plannerSink(sink event.Sink) event.Sink {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -473,7 +473,7 @@ func TestCoordinatorNudgesMixedGuidanceAndWorkTask(t *testing.T) {
 
 func TestCoordinatorSkipsExecutorWhenPlannerConcludesNoChanges(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
-		{Type: provider.ChunkText, Text: "No changes are needed; the current implementation already handles this."},
+		{Type: provider.ChunkText, Text: "No changes are needed; the current implementation already handles this.\n[no_changes]"},
 		{Type: provider.ChunkDone},
 	}}
 	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
@@ -736,10 +736,10 @@ func (e *errorProvider) Stream(context.Context, provider.Request) (<-chan provid
 	return nil, fmt.Errorf("provider unavailable")
 }
 
-// TestIsNoOpPlan pins the no-op conclusion contract: the [no_changes] marker on
-// the final line wins; phrase heuristics only match conclusion lines and are
-// vetoed by action verbs, so an "already implemented; extend it" plan must
-// still reach the executor.
+// TestIsNoOpPlan pins the no-op conclusion contract: only a final non-empty
+// line that is exactly the [no_changes] marker skips the executor. Phrase
+// conclusions without the marker deliberately do not — a wrong skip silently
+// drops the task, a missed one costs a single executor round.
 func TestIsNoOpPlan(t *testing.T) {
 	cases := []struct {
 		name string
@@ -747,7 +747,7 @@ func TestIsNoOpPlan(t *testing.T) {
 		want bool
 	}{
 		{"empty", "", false},
-		{"conclusion phrase single line", "No changes are needed; the current implementation already handles this.", true},
+		{"conclusion phrase without marker", "No changes are needed; the current implementation already handles this.", false},
 		{"already implemented with follow-up work", "The auth flow is already implemented; extend it to cover refresh tokens.", false},
 		{"mid-plan aside is not a conclusion", "Findings:\nThis part is already handled by the retry helper.\nConfirm the desired direction with the user.", false},
 		{"explicit marker on final line", "The retry logic exists in client.go and the tests already run this path.\n[no_changes]", true},
@@ -757,7 +757,7 @@ func TestIsNoOpPlan(t *testing.T) {
 		{"marker with trailing prose on final line", "[no_changes] — but confirm the flag default first.", false},
 		{"negated conclusion", "It is not already implemented.", false},
 		{"no-op phrase with action verb", "No changes are needed in code, but run the test suite.", false},
-		{"chinese conclusion", "无需改动,当前逻辑已经覆盖该场景。", true},
+		{"chinese conclusion without marker", "无需改动,当前逻辑已经覆盖该场景。", false},
 		{"chinese follow-up work", "重试逻辑已经实现,但需要扩展覆盖刷新令牌。", false},
 	}
 	for _, tc := range cases {
@@ -1155,5 +1155,68 @@ func TestCoordinatorPassesTurnContextToPlannerGate(t *testing.T) {
 	}
 	if !sawTurnValue {
 		t.Fatal("planner gate did not receive the turn context")
+	}
+}
+
+// TestCoordinatorFailedTurnRollbackKeepsCompaction pins the rewrite-aware
+// rollback economics: when auto-compaction fires mid-turn (after a tool round)
+// and the planner THEN fails, restoring the pre-turn snapshot would revert the
+// compaction — wasting its summarizer call and re-growing the prompt. The
+// rollback must instead keep the compacted log and only drop trailing plain
+// user messages, so the next plan still starts from the folded history without
+// consecutive user roles.
+func TestCoordinatorFailedTurnRollbackKeepsCompaction(t *testing.T) {
+	planner := &mockProvider{name: "planner", streams: [][]provider.Chunk{
+		{ // tool round whose usage crosses the force-compaction watermark
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "read_file", Arguments: `{"path":"main.go"}`}},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 1900, TotalTokens: 1950}},
+			{Type: provider.ChunkDone},
+		},
+		{ // the compaction summarizer call
+			{Type: provider.ChunkText, Text: "- goal: guard work\n- pending: continue"},
+			{Type: provider.ChunkDone},
+		},
+		{ // the next planner round fails
+			{Type: provider.ChunkError, Err: fmt.Errorf("rate limited")},
+		},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	plannerReg := tool.NewRegistry()
+	plannerReg.Add(coordinatorTestTool{name: "read_file", readOnly: true, output: "package main"})
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	plannerSess := NewSession("planner-sys")
+	filler := strings.Repeat("planner history filler. ", 150)
+	for i := 0; i < 3; i++ {
+		plannerSess.Add(provider.Message{Role: provider.RoleUser, Content: filler})
+		plannerSess.Add(provider.Message{Role: provider.RoleAssistant, Content: filler})
+	}
+	coord := NewCoordinator(planner, plannerSess, nil, plannerReg, Options{ContextWindow: 2000}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+		t.Fatalf("Run should fall back to the executor, got: %v", err)
+	}
+	if got := len(exec.requests); got != 1 {
+		t.Fatalf("executor requests = %d, want 1 fallback run", got)
+	}
+	if plannerSess.RewriteVersion() == 0 {
+		t.Fatal("test setup: planner compaction did not fire, the rewrite-aware rollback is not exercised")
+	}
+	msgs := plannerSess.Snapshot()
+	var hasSummary bool
+	for _, m := range msgs {
+		if isCompactionSummary(m) {
+			hasSummary = true
+		}
+	}
+	if !hasSummary {
+		t.Fatal("rollback reverted the compaction: no compaction summary left in the planner session")
+	}
+	if last := msgs[len(msgs)-1]; last.Role == provider.RoleUser && !isCompactionSummary(last) {
+		t.Fatalf("planner session ends in a plain user message after rollback: %q", last.Content)
 	}
 }


### PR DESCRIPTION
## Summary

Two economics/robustness follow-ups on the two-model coordinator, stacked on #6193 (the first three commits are that PR; review this one by its last commit).

- **Failed-turn rollback keeps a mid-turn compaction.** `planWithTools` restores the pre-turn snapshot when the planner fails so the session cannot end in a dangling user message. But when auto-compaction had already rewritten the session during the turn, the snapshot restore also reverted the compaction — throwing away the summarizer call it paid for and re-growing the prompt the fold had just shrunk (the next turn would compact again: one wasted summarize round-trip plus an extra cache reset). The rollback is now rewrite-aware: with no rewrite it restores the snapshot exactly as before; after a rewrite it keeps the compacted log and drops only trailing plain user messages, which are what would produce consecutive user roles on the next plan. Completed tool rounds and the compaction digest remain coherent history.

- **`isNoOpPlan` trusts only the explicit `[no_changes]` contract.** The legacy phrase list ("no changes needed", "无需改动", …) plus its action-verb veto existed for planners that ignore the marker. The failure asymmetry argues against keeping it: a phrase false-positive silently drops the user's task, while a missed skip merely costs one executor round. With the marker contract in `DefaultPlannerPrompt` (#6193), the heuristics are retired — the final non-empty line must be exactly the marker.

Behavior change note: planners that conclude "no changes" in prose without emitting `[no_changes]` no longer skip the executor; the executor runs once and reaches the same conclusion. This is the safe direction of the trade.

## Cache impact

No provider-visible prompt bytes change (`isNoOpPlan` is response parsing; the rollback only affects failure-path session shape). Keeping the compaction on failed turns strictly improves prompt-size behavior. `./scripts/cache-guard.sh` passes 8/8.

## Verification

- `go test ./internal/agent -count=1` — pass
- `gofmt -l` / `go vet ./internal/agent` — clean
- New regression test `TestCoordinatorFailedTurnRollbackKeepsCompaction`: tool round crosses the force-compaction watermark, next planner round fails; asserts the compaction summary survives the rollback and the session does not end in a plain user message
- `TestIsNoOpPlan` table updated: phrase conclusions without the marker are pinned to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)