### PR TITLE
Bump Go toolchain to 1.26.5 for stdlib vulnerability fixes / Go 工具链升至 1.26.5 修复标准库漏洞

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -2,7 +2,7 @@ module reasonix/desktop
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 // The desktop shell is a nested module so its CGO/WebKit build never touches the
 // CLI's CGO_ENABLED=0 single-static-binary guarantee. The replace lets it import

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module reasonix
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

`govulncheck` is now failing on every PR (and would fail on `main-v2` itself): two Go standard library vulnerabilities were published that affect `go1.26.4` and are fixed in `go1.26.5`:

- **GO-2026-5856** — Encrypted Client Hello privacy leak in `crypto/tls` (reached via `internal/serve`, provider retry I/O, and the QQ bot gateway)
- **GO-2026-4970** — root escape via symlink plus trailing slash in `os.Root` (reached via `internal/control/refs.go` and `internal/autoresearch/store.go`)

CI resolves the toolchain from `go-version-file: go.mod`, so bumping the `toolchain` directive in both `go.mod` and `desktop/go.mod` moves every job to the fixed release. No code changes.

Unblocks govulncheck on all currently open PRs once they rebase or merge after this.

## Verification

- `go build ./...` on both the root module and `desktop/` with go1.26.5 — pass
- The failing checks referencing the two vuln IDs: see the govulncheck jobs on #6204 / #6205

🤖 Generated with [Claude Code](https://claude.com/claude-code)