### PR TITLE
feat(creation): Windows 平台标题栏元素垂直对齐

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29774,15 +29774,13 @@ body > .mermaid-diagram--fullscreen {
   transform: translateY(-2px) !important;
 }
 
-/* Reduce session title font size and weight */
-.app--windows.app--creation .topicbar__title-row h1 {
+/* Reduce session title font size and weight. The rename input replaces the h1
+   while editing (App.tsx topicbarEditing), so it must carry the same size or
+   entering rename mode visibly jumps back to the 10px Creation default. */
+.app--windows.app--creation .topicbar__title-row h1,
+.app--windows.app--creation .topicbar__title-input {
   font-size: 13.5px !important;
   font-weight: 520 !important;
-}
-
-/* Align topicbar actions container (right side buttons) - but don't transform, let children handle it */
-.app--windows.app--creation .topicbar__actions {
-  /* Removed transform to avoid double-transform on chrome-btn */
 }
 
 /* Align action buttons (not chrome buttons) */
@@ -29795,4 +29793,11 @@ body > .mermaid-diagram--fullscreen {
 .app--windows.app--creation .topicbar__chrome-btn {
   transform: translateY(-2px) !important;
   align-self: center !important;
+}
+
+/* The alignment offset above owns the transform slot, which would otherwise
+   erase the .topicbar__chrome-btn--pressed { scale(0.94) } press feedback —
+   recombine both here. */
+.app--windows.app--creation .topicbar__chrome-btn.topicbar__chrome-btn--pressed {
+  transform: translateY(-2px) scale(0.94) !important;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29753,3 +29753,46 @@ body > .mermaid-diagram--fullscreen {
     min-width: 0;
   }
 }
+
+/* ============================================================================
+   Windows + Creation: Vertical alignment for titlebar elements
+   ========================================================================= */
+
+/* Align sidebar logo with Windows titlebar center line */
+.app--windows.app--creation .sidebar__brand,
+:root[data-theme-style] .app--windows.app--creation .sidebar__brand {
+  margin-top: -29px !important;
+}
+
+/* Align topicbar (replaces app-chrome in Creation mode) with Windows controls */
+.app--windows.app--creation .topicbar {
+  transform: translateY(-4px) !important;
+}
+
+/* Align topicbar identity (session title) with Windows controls */
+.app--windows.app--creation .topicbar__identity {
+  transform: translateY(-2px) !important;
+}
+
+/* Reduce session title font size and weight */
+.app--windows.app--creation .topicbar__title-row h1 {
+  font-size: 13.5px !important;
+  font-weight: 520 !important;
+}
+
+/* Align topicbar actions container (right side buttons) - but don't transform, let children handle it */
+.app--windows.app--creation .topicbar__actions {
+  /* Removed transform to avoid double-transform on chrome-btn */
+}
+
+/* Align action buttons (not chrome buttons) */
+.app--windows.app--creation .topicbar__action-btn:not(.topicbar__chrome-btn) {
+  transform: translateY(-2px) !important;
+  align-self: center !important;
+}
+
+/* Align topicbar chrome buttons separately (they're also in actions container) */
+.app--windows.app--creation .topicbar__chrome-btn {
+  transform: translateY(-2px) !important;
+  align-self: center !important;
+}


### PR DESCRIPTION
## 📋 变更说明

调整 Creation 风格在 **Windows 平台**下的标题栏元素垂直对齐，使 logo、会话标题、工具按钮与 Windows 窗口控制按钮在同一中心线上，提升视觉一致性。

## ✨ 主要改动

### 垂直对齐调整
- **Reasonix Logo**：往上调整 -29px，与标题栏中心线对齐
- **Topicbar 容器**：整体往上 -4px
- **会话标题**：往上 -2px
- **工具按钮**（复制、下载、分支、帮助、设置、面板切换）：统一往上 -2px 并垂直居中

### 视觉优化
- **会话标题字号**：15px → 13.5px
- **会话标题字重**：680 → 520（更轻盈）

## 🎯 作用域限定

**仅作用于 Windows + Creation 组合**，所有样式规则严格使用 `.app--windows.app--creation` 双重选择器限定：

✅ **生效条件**：
- Windows 平台（`.app--windows`）
- Creation 桌面风格（`.app--creation`）

❌ **不影响**：
- macOS 平台（`.app--darwin`）
- Linux 平台（`.app--linux`）
- Classic 风格
- Workbench 风格

## 📁 修改文件

- `desktop/frontend/src/styles.css` - 新增 42 行 Windows + Creation 专属样式

## ✅ 验证

- [x] `pnpm --dir desktop/frontend typecheck` 通过
- [x] 仅修改 CSS，无 TS/TSX 代码变更
- [x] 所有样式使用 `!important` 确保优先级
- [x] 选择器双重限定，确保不影响其他平台和风格
- [x] 本地 `wails dev` 测试通过

## 📸 效果预览

Windows + Creation 模式下，标题栏所有元素（logo、标题、按钮）现已垂直对齐至同一中心线，与 Windows 窗口控制按钮视觉一致。