### PR TITLE
fix(desktop): skip blank topics whose session lease is foreign-held / 修复新建对话复用外部持锁的空白会话

### DIFF
--- a/desktop/sessions_lease_guard_test.go
+++ b/desktop/sessions_lease_guard_test.go
@@ -88,3 +88,50 @@ func TestDeleteSessionKeepsDuplicateLiveSessionHeldByOtherRuntime(t *testing.T) 
 		t.Fatalf("live session must stay intact, got %q err=%v", string(got), readErr)
 	}
 }
+
+// TestEnsureBlankTabSkipsIndexedTopicHeldByForeignRuntime reproduces #6028:
+// a blank topic whose session lease is still held by another runtime (a
+// lingering background/tray-hidden instance, or a leftover from a crash) must
+// not be handed back to a "new conversation" click. Reusing it would collide
+// the new tab with that holder, so every lease-gated switch (effort, model,
+// token mode) would fail as "open in another Reasonix window" no matter how
+// many times the user retries — because it keeps re-picking the same stuck
+// topic instead of ever landing on a fresh one.
+func TestEnsureBlankTabSkipsIndexedTopicHeldByForeignRuntime(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	stuckTopic, err := app.CreateTopic("global", "", "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	globalRoot := globalWorkspaceRoot()
+	dir := desktopSessionDir(globalRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	stubPath := filepath.Join(dir, "stuck-blank-stub.jsonl")
+	if err := os.WriteFile(stubPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty stub: %v", err)
+	}
+	now := time.Now()
+	if err := agent.SaveBranchMetaPreserveUpdated(stubPath, agent.BranchMeta{
+		CreatedAt:     now.Add(-time.Minute),
+		UpdatedAt:     now,
+		Scope:         "global",
+		WorkspaceRoot: globalRoot,
+		TopicID:       stuckTopic.ID,
+		TopicTitle:    defaultTopicTitle,
+	}); err != nil {
+		t.Fatalf("save branch meta: %v", err)
+	}
+	simulateForeignSessionLeaseHolder(t, stubPath)
+
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.TopicID == stuckTopic.ID {
+		t.Fatalf("EnsureBlankTab reused topic %q even though its session is held by another runtime", stuckTopic.ID)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2142,13 +2142,17 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 			continue
 		}
 		hasSession := false
+		leaseHeld := false
 		for _, index := range sessionIndexes {
 			if topicSessionIndexHasContentTopic(index, topicID) {
 				hasSession = true
 				break
 			}
+			if topicSessionIndexHasForeignLeaseTopic(index, topicID) {
+				leaseHeld = true
+			}
 		}
-		if hasSession {
+		if hasSession || leaseHeld {
 			continue
 		}
 		return topicID
@@ -7984,6 +7988,25 @@ func topicSessionIndexHasContentTopic(index topicSessionDirIndex, topicID string
 	matches := index.byTopic[strings.TrimSpace(topicID)]
 	for _, match := range matches {
 		if sessionFileHasConversationContent(match.path) {
+			return true
+		}
+	}
+	return false
+}
+
+// topicSessionIndexHasForeignLeaseTopic reports whether any session file
+// indexed under topicID is currently lease-held by a runtime other than this
+// process. A blank topic can still be lease-held — its session lease keeper
+// keeps a leftover blank tab's lease alive across a hide-to-tray close, and a
+// stale-but-live holder blocks a genuinely new session from ever settling on
+// this path. Reusing it anyway would make the "new" tab collide with that
+// holder: every lease-gated switch (effort/model/token mode) would fail as if
+// a foreign window owned it, and creating another "new" conversation would
+// keep re-picking the same stuck topic (#6028, #6109).
+func topicSessionIndexHasForeignLeaseTopic(index topicSessionDirIndex, topicID string) bool {
+	matches := index.byTopic[strings.TrimSpace(topicID)]
+	for _, match := range matches {
+		if agent.SessionLeaseHeldByOtherRuntime(match.path) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- `EnsureBlankTab`'s indexed-topic reuse (`indexedBlankTopicIDLocked`) picks a blank topic from disk to reuse for "new conversation" instead of piling up empty sessions. It only checked whether the candidate was open in a tab of *this* process — not whether its session file's lease was still held by *another* runtime (a tray-hidden background instance, or a leftover from a crash).
- Add `topicSessionIndexHasForeignLeaseTopic`, checked alongside the existing content check, so a candidate topic whose session is genuinely lease-held elsewhere is skipped instead of handed back to the new tab.

## Root Cause

Refs #6028, #6109 — very likely the same underlying defect surfacing as two different symptoms:

- #6109: a new session's `topic_id` gets silently reused from an existing "0-turn empty session" instead of getting a fresh one.
- #6028: after that reuse, the new tab collides with whatever runtime already holds that topic's session lease. Every lease-gated switch (reasoning effort / model / token-saver mode) then fails with "this session is open in another Reasonix window or running in the background," and it doesn't matter how many times the user retries "new conversation" — `indexedBlankTopicIDLocked` deterministically re-picks the same stuck topic, since nothing in the selection ever consulted lease state.

Traced via `internal/agent/session_lease.go` (`SessionLeaseHeldByOtherRuntime`, which the effort/model/token-mode switch path already calls through `ensureSessionLease`) and `desktop/tabs.go` (`EnsureBlankTab` → `indexedBlankTopicIDLocked`).

## Compatibility

| Surface | Old behavior | New behavior | Conclusion |
| --- | --- | --- | --- |
| Blank-topic reuse selection | Picks the first indexed blank topic not open in a current tab, regardless of lease state | Same, plus skips candidates whose session is lease-held by another runtime | Backward compatible — only changes which topic gets picked when one is genuinely foreign-held; unaffected in the common case (no foreign holder) |
| Persisted data (topics index, session files, lease sidecars) | — | — | No format change; this is a runtime selection-logic fix only |

## Verification

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `git diff --check` — clean
- `cd desktop && go build ./... && go test ./...` — all green
- New regression `TestEnsureBlankTabSkipsIndexedTopicHeldByForeignRuntime` confirmed red-then-green: fails without the fix (reused the foreign-held topic), passes with it.