### PR TITLE
Widen Windows node-eval statusline test timeout to 30s / 放宽 Windows node-eval statusline 测试超时至 30s

### DIFF
--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -55,7 +55,11 @@ func TestRunStatuslineCmdNormalizesQuotedNodeEval(t *testing.T) {
 	cmd := `node -e "\"` + script + `\""`
 	timeout := statuslineCommandTimeout
 	if runtime.GOOS == "windows" {
-		timeout = 10 * time.Second
+		// Windows CI cold-starts node.exe through Defender scanning while the
+		// rest of the module compiles and tests in parallel; a fresh toolchain
+		// (empty setup-go cache) pushes that past 10s. The production timeout
+		// is not under test here — only the quoted-eval normalization is.
+		timeout = 30 * time.Second
 	}
 
 	if got := runStatuslineCmdWithTimeout(cmd, `{"model":"deepseek"}`, timeout); got != "deepseek" {


### PR DESCRIPTION
## Summary

`TestRunStatuslineCmdNormalizesQuotedNodeEval` failed twice on #6206's windows-latest runs at exactly its 10s Windows timeout with empty output, then passed unchanged on the third attempt. Root cause is environmental: a toolchain bump empties the setup-go build cache, so node.exe cold-starts (Windows Defender scan included) while the whole module compiles and tests in parallel — pushing first-start past 10s.

The production statusline timeout (`statuslineCommandTimeout`, 2s) is not what this test verifies — only the quoted-eval normalization — so the test-only Windows ceiling widens to 30s. This was meant to ride along on #6206 but that PR merged before the commit landed, hence this follow-up.

## Verification

- `go test ./internal/cli -run TestRunStatuslineCmd -count=1` — pass (Linux)
- Failure evidence: #6206 windows-latest runs 1 and 2 (10.12s / 10.04s, both at the old ceiling); run 3 green with no code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)