### PR TITLE
fix(desktop): 弹出窗口失去焦点时不自动关闭 + 未保存编辑保护

### DIFF
--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -398,7 +398,7 @@ export function HistoryPanel({
   };
 
   return (
-    <div className="management-modal-backdrop history-modal-backdrop" data-state={status} onClick={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
+    <div className="management-modal-backdrop history-modal-backdrop" data-state={status} onMouseDown={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
       <section
         className="management-modal history-modal"
         data-state={status}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -211,7 +211,7 @@ export function SettingsPanel({
   const lazySettingsPageFallback = <div className="empty">{t("settings.loading")}</div>;
 
   return (
-    <div className="management-modal-backdrop settings-modal-backdrop" data-state={status} onClick={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
+    <div className="management-modal-backdrop settings-modal-backdrop" data-state={status} onMouseDown={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
       <div className="management-modal settings-modal" data-state={status}>
         <header className="management-modal__head settings-modal__head">
           <div className="management-modal__title settings-modal__title">{t("settings.title")}</div>

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -147,6 +147,11 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
   const dirtyRef = useRef(false);
   const startedRef = useRef(false);
 
+  // Reset dirty ref when leaving edit mode
+  useEffect(() => {
+    if (!editing) dirtyRef.current = false;
+  }, [editing]);
+
   const loadTasks = useCallback(async () => {
     setLoading(true);
     try {
@@ -873,7 +878,9 @@ function TaskEditor({
     || draft.newConversationEachRun !== initialTaskRef.current.newConversationEachRun
     || draft.notifyChannels !== initialTaskRef.current.notifyChannels
     || draft.scope !== initialTaskRef.current.scope
-    || draft.workspaceRoot !== initialTaskRef.current.workspaceRoot;
+    || draft.workspaceRoot !== initialTaskRef.current.workspaceRoot
+    || draft.timeWindowStart !== initialTaskRef.current.timeWindowStart
+    || draft.timeWindowEnd !== initialTaskRef.current.timeWindowEnd;
 
   useEffect(() => {
     onDirtyChange?.(isDirty);

--- a/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
+++ b/desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx
@@ -144,6 +144,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
   const statusFilterRef = useRef<HTMLButtonElement>(null);
   const [workspaceMap, setWorkspaceMap] = useState<Record<string, string>>({});
   const backdropRef = useRef<HTMLDivElement>(null);
+  const dirtyRef = useRef(false);
   const startedRef = useRef(false);
 
   const loadTasks = useCallback(async () => {
@@ -269,7 +270,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
 
   const handleBackdrop = useCallback(
     (e: React.MouseEvent) => {
-      if (e.target === backdropRef.current) onClose();
+      if (e.target === backdropRef.current && !dirtyRef.current) onClose();
     },
     [onClose],
   );
@@ -277,7 +278,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
   useEffect(() => {
     if (!open) return;
     const onKey = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !dirtyRef.current && !document.querySelector("[data-anchored-popover='active']")) onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -298,7 +299,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
   };
 
   return (
-    <div ref={backdropRef} className="heartbeat-backdrop" onClick={handleBackdrop}>
+    <div ref={backdropRef} className="heartbeat-backdrop" onMouseDown={handleBackdrop}>
       <div className="heartbeat-modal">
         <header className="heartbeat-modal__header">
           {editing ? (
@@ -319,7 +320,7 @@ export function HeartbeatPanel({ open, onClose, startNew, onOpenTopic }: Heartbe
         </header>
 
         {editing ? (
-          <TaskEditor key={editing.id} task={editing} onSave={handleSaveEdit} onCancel={() => setEditing(null)} onDelete={() => { handleDelete(editing.id); setEditing(null); }} />
+          <TaskEditor key={editing.id} task={editing} onSave={handleSaveEdit} onCancel={() => setEditing(null)} onDelete={() => { handleDelete(editing.id); setEditing(null); }} onDirtyChange={(d) => { dirtyRef.current = d; }} />
         ) : (
           <div className="heartbeat-modal__body">
             <div className="heartbeat-toolbar">
@@ -831,11 +832,13 @@ function TaskEditor({
   onSave,
   onCancel,
   onDelete,
+  onDirtyChange,
 }: {
   task: HeartbeatTask;
   onSave: (t: HeartbeatTask) => void;
   onCancel: () => void;
   onDelete: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const t = useT();
   const titleRef = useRef<HTMLInputElement>(null);
@@ -861,6 +864,21 @@ function TaskEditor({
   }, [projectOpen]);
 
   const [draft, setDraft] = useState(task);
+  const initialTaskRef = useRef(task);
+  const isDirty = draft.title !== initialTaskRef.current.title
+    || draft.prompt !== initialTaskRef.current.prompt
+    || draft.interval !== initialTaskRef.current.interval
+    || draft.enabled !== initialTaskRef.current.enabled
+    || draft.approvalMode !== initialTaskRef.current.approvalMode
+    || draft.newConversationEachRun !== initialTaskRef.current.newConversationEachRun
+    || draft.notifyChannels !== initialTaskRef.current.notifyChannels
+    || draft.scope !== initialTaskRef.current.scope
+    || draft.workspaceRoot !== initialTaskRef.current.workspaceRoot;
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
   const intervalBeforeCycle = useRef<string | null>(null);
   const promptRef = useRef<HTMLTextAreaElement>(null);
 
@@ -1174,7 +1192,8 @@ function TaskEditor({
         <button
           className="heartbeat-btn heartbeat-btn--primary"
           onClick={() => onSave(draft)}
-          disabled={!draft.title.trim() || !draft.prompt.trim()}
+          disabled={!draft.title.trim() || !draft.prompt.trim() || !isDirty}
+          title={!draft.title.trim() || !draft.prompt.trim() ? "请填写标题和提示词" : !isDirty ? "无修改内容" : undefined}
         >
           {isNew ? t("heartbeat.add") : t("heartbeat.save")}
         </button>


### PR DESCRIPTION
## Summary

修复 Issue #5964 — 弹出窗口（计划任务编辑器 / 设置面板 / 历史面板）在以下场景中误关闭并丢失已输入内容：

**问题 1：文本选择误关**
在弹窗输入框中 mousedown → 选中文本 → mouseup 在 backdrop（遮罩层）上时，`onClick` 事件的目标是 mouseup 位置（backdrop），触发了"点击外部关闭"逻辑。

修复：将 backdrop 关闭事件从 `onClick` 改为 `onMouseDown`，以 mousedown 位置（弹窗内部）为准判断。

**问题 2：未保存编辑保护**
在计划任务编辑器中修改内容后，点击 backdrop 或按 Escape 直接丢失所有输入。

修复：
- TaskEditor 添加 `isDirty` 脏状态追踪（比较 9 个字段）
- backdrop 点击 + Escape 均检查 dirty 状态，有未保存修改时阻止关闭
- 保存按钮在无修改时灰色禁用，带 tooltip 提示原因
- Escape 处理时检测嵌套弹出层（如 AnchoredPopover），避免误关面板

**改动文件：**
- `desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx` — 核心修复
- `desktop/frontend/src/components/SettingsPanel.tsx` — backdrop onClick→onMouseDown
- `desktop/frontend/src/components/HistoryPanel.tsx` — backdrop onClick→onMouseDown

## Verification

前端编译通过，wails build 成功生成了 arm64 二进制：

- 打开计划任务编辑器 → 编辑内容 → 点击 backdrop（遮罩层）→ 编辑器不关闭
- 编辑内容 → 按 Escape → 编辑器不关闭
- 无修改时 → 保存按钮灰色禁用，tooltip 提示"无修改内容"
- 字段未填时 → 保存按钮灰色禁用，tooltip 提示"请填写标题和提示词"
- 在编辑器中打开下拉菜单 → 按 Escape → 下拉关闭，面板不关闭
- 未编辑时 → backdrop/Escape 正常关闭面板（回归测试）

## Cache impact

Cache-impact: none — 仅修改前端 TypeScript 组件逻辑，无后端缓存敏感路径变更
Cache-guard: frontend TypeScript build passes cleanly
System-prompt-review: N/A

---

关联 Issue: #5964

此 PR 由 AI 代理（Reasonix / Claude Code）协助完成，在用户确认 diff 后提交。