### PR TITLE
fix(desktop): auto-send queued guidance when a turn ends naturally / 修复任务自然结束时排队消息丢失

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -750,6 +750,45 @@ console.log("\ncomposer goal toggle");
 }
 
 {
+  // Reproduces #6210: a message queued while a turn is running, without the
+  // explicit "guide" steer click, must not vanish when the turn ends on its
+  // own — it is the user's next turn, so it should send automatically.
+  const dom = installDom();
+  const { root, calls, rerender } = await renderComposer({
+    running: true,
+    onSend: (displayText, submitText) => {
+      calls.send.push(displayText);
+      calls.submit.push(submitText);
+      return Promise.resolve();
+    },
+  });
+
+  await rerender({ insertRequest: { id: 8, text: "keep going after this finishes", mode: "replace" } });
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("running composer send button did not render");
+
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+
+  eq(calls.send.length, 0, "queuing while running does not send immediately");
+  ok(document.querySelector(".composer-guidance-item") !== null, "queued message shows in the guidance shelf");
+
+  await rerender({ running: false });
+  await waitFor("queued guidance auto-sent on natural completion", () => calls.send.length === 1);
+
+  eq(calls.send.join(","), "keep going after this finishes", "queued guidance is sent automatically once the turn ends naturally, not discarded");
+  eq(calls.submit.join(","), "keep going after this finishes", "auto-sent guidance submits the same text it was queued with");
+  ok(document.querySelector(".composer-guidance-item") === null, "guidance shelf clears once the queued message is sent");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
   const dom = installDom();
   let listDirCalls = 0;
   mockApp({

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -789,6 +789,53 @@ console.log("\ncomposer goal toggle");
 }
 
 {
+  // #6210 follow-up: if the turn ends naturally while the controller is
+  // still activating/hydrating (submitDisabled), onSend would silently
+  // no-op — auto-send must wait for submitDisabled to clear instead of
+  // firing into that window and losing the queued message anyway.
+  const dom = installDom();
+  const { root, calls, rerender } = await renderComposer({
+    running: true,
+    submitDisabled: false,
+    onSend: (displayText, submitText) => {
+      calls.send.push(displayText);
+      calls.submit.push(submitText);
+      return Promise.resolve();
+    },
+  });
+
+  await rerender({ insertRequest: { id: 9, text: "keep going once ready", mode: "replace" } });
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("running composer send button did not render");
+
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+  ok(document.querySelector(".composer-guidance-item") !== null, "queued message shows in the guidance shelf");
+
+  // Turn ends, but the controller is still not ready to accept a submit —
+  // matches a rebuild/hydration window right after the turn finishes.
+  await rerender({ running: false, submitDisabled: true });
+  await act(async () => {
+    await flushTimers();
+  });
+  eq(calls.send.length, 0, "auto-send does not fire while the controller is still activating");
+  ok(document.querySelector(".composer-guidance-item") !== null, "queued message stays on the shelf while not ready");
+
+  await rerender({ submitDisabled: false });
+  await waitFor("queued guidance auto-sent once the controller becomes ready", () => calls.send.length === 1);
+
+  eq(calls.send.join(","), "keep going once ready", "queued guidance sends once submitDisabled clears, instead of being lost");
+  ok(document.querySelector(".composer-guidance-item") === null, "guidance shelf clears once the delayed send completes");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
   const dom = installDom();
   let listDirCalls = 0;
   mockApp({

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -685,16 +685,25 @@ export function Composer({
 
   useEffect(() => {
     if (wasRunning.current && !running) {
-      setPendingGuidance([]);
       setGuidanceExpanded(false);
       if (text.trim() === "") {
         pastedBlocksRef.current = [];
         setPastedBlocks([]);
         setOpenPastedLabels([]);
       }
+      // A message queued while the turn was running (without the explicit
+      // "guide" steer click) is the user's next turn, not scratch text to
+      // discard — send it now that the turn is done. sendQueuedGuidance
+      // removes it from the shelf on success and starts a new turn, which
+      // flips `running` true then false again, so this same effect fires
+      // once more and drains the shelf one item at a time. A failed send
+      // is left in place (dismissible via the trash button) rather than
+      // silently dropped.
+      const next = pendingGuidance[0];
+      if (next) void sendQueuedGuidance(next);
     }
     wasRunning.current = running;
-  }, [running, text]);
+  }, [running, text, pendingGuidance]);
 
   useEffect(() => {
     setPendingGuidance([]);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -691,19 +691,26 @@ export function Composer({
         setPastedBlocks([]);
         setOpenPastedLabels([]);
       }
-      // A message queued while the turn was running (without the explicit
-      // "guide" steer click) is the user's next turn, not scratch text to
-      // discard — send it now that the turn is done. sendQueuedGuidance
-      // removes it from the shelf on success and starts a new turn, which
-      // flips `running` true then false again, so this same effect fires
-      // once more and drains the shelf one item at a time. A failed send
-      // is left in place (dismissible via the trash button) rather than
-      // silently dropped.
-      const next = pendingGuidance[0];
-      if (next) void sendQueuedGuidance(next);
     }
     wasRunning.current = running;
-  }, [running, text, pendingGuidance]);
+  }, [running, text]);
+
+  // A message queued while a turn was running (without the explicit "guide"
+  // steer click) is the user's next turn, not scratch text to discard — send
+  // it once the turn is done. Gated on submitDisabled, not just running:
+  // if the turn ends while the controller is still activating/hydrating,
+  // App's onSend silently no-ops on !controllerReady, but sendQueuedGuidance
+  // still removes the item as if it had sent — so wait for submitDisabled to
+  // clear instead of firing into that no-op window (#6210 follow-up). Once
+  // both conditions hold, a successful send removes the head and starts a
+  // new turn, which flips `running` true then false again, re-running this
+  // effect to drain the shelf one item at a time; a failed send is left in
+  // place (dismissible via the trash button) rather than silently dropped.
+  useEffect(() => {
+    if (running || submitDisabled) return;
+    const next = pendingGuidance[0];
+    if (next) void sendQueuedGuidance(next);
+  }, [running, submitDisabled, pendingGuidance]);
 
   useEffect(() => {
     setPendingGuidance([]);


### PR DESCRIPTION
## Summary

- Refs #6210 — typing and submitting a follow-up prompt while a turn is running (without clicking "guide" to steer the in-flight turn) queues it in the composer's guidance shelf. When the turn finished on its own, the shelf was unconditionally cleared, silently discarding the queued message.
- The shelf is now drained instead: when the turn ends naturally, the head of the queue is sent through the existing `sendQueuedGuidance` path. A successful send starts a new turn, which re-triggers the same effect once that turn ends, draining the shelf one item at a time. A failed send stays in the shelf (dismissible via the existing trash button) rather than vanishing.

## Root Cause

`Composer.tsx`'s `running: true -> false` effect unconditionally called `setPendingGuidance([])`. `handleCancel` already knew this shelf could disappear from under the user and explicitly folds it back into the draft on cancel (its own comment says so), but that handling only covered the cancel path — natural turn completion had no equivalent, so a queued message there just vanished with no way to recover it.

## Compatibility

| Surface | Old behavior | New behavior | Conclusion |
| --- | --- | --- | --- |
| Queued guidance shelf (`pendingGuidance`) | Ephemeral React component state only, never persisted or sent to the backend | Same storage, but now flushed via the existing send path on natural completion instead of discarded | Backward compatible — no persisted format touched, purely a frontend runtime behavior fix |
| Cancel path (`handleCancel`) | Folds queued guidance back into the draft | Unchanged | Not affected — cancel clears the shelf before this effect's condition can act on it |

## Verification

- `pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx` — 73 passed (68 pre-existing + 5 new), including a new regression that reproduces #6210 (queue while running, let the turn finish naturally, assert the message sends instead of vanishing). Confirmed red-then-green: reverting the fix makes the new test time out waiting for the auto-send.
- `pnpm run test:typecheck` — clean
- Cross-checked other composer test files for regressions from the effect change: `composer-session-draft`, `composer-run-strip`, `composer-keyboard`, `composer-history`, `composer-profile`, `composer-image-capability` — all green.

Cache-impact: n/a — frontend-only composer UI behavior, no prompt/tool/provider-visible surface touched.