### PR TITLE
Guard DeepSeek tool-call reasoning replay / 保护 DeepSeek 工具调用 reasoning 回放

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1158,6 +1158,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		// when building the request, since re-sent reasoning is billable prompt
 		// input for no cache or coherence gain.
 		calls = a.withPreviewFileDiffs(calls)
+		if err := a.validateToolCallReasoning(calls, reasoning); err != nil {
+			return err
+		}
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,
@@ -1253,6 +1256,20 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	// is already in the session, so the user can just send another message to pick
 	// up where it left off.
 	return &maxStepsPause{steps: a.maxSteps, key: a.maxStepsKey}
+}
+
+func (a *Agent) validateToolCallReasoning(calls []provider.ToolCall, reasoning string) error {
+	if len(calls) == 0 || !provider.RequiresToolCallReasoning(a.prov) {
+		return nil
+	}
+	if strings.TrimSpace(reasoning) != "" {
+		return nil
+	}
+	return &provider.MissingToolCallReasoningError{
+		Provider:      a.prov.Name(),
+		ToolCallCount: len(calls),
+		CurrentTurn:   true,
+	}
 }
 
 // maxStepsPause is the deliberate stop when a positive tool-call budget runs
@@ -1835,7 +1852,7 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 			}
 		}
 		stored = display
-		if signature != "" {
+		if signature != "" || (len(calls) > 0 && provider.RequiresToolCallReasoning(a.prov)) {
 			stored = original
 		}
 		return stored, display

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1158,9 +1158,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		// when building the request, since re-sent reasoning is billable prompt
 		// input for no cache or coherence gain.
 		calls = a.withPreviewFileDiffs(calls)
-		if err := a.validateToolCallReasoning(calls, reasoning); err != nil {
-			return err
-		}
+		a.warnMissingToolCallReasoning(calls, reasoning)
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,
@@ -1258,18 +1256,21 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	return &maxStepsPause{steps: a.maxSteps, key: a.maxStepsKey}
 }
 
-func (a *Agent) validateToolCallReasoning(calls []provider.ToolCall, reasoning string) error {
+// warnMissingToolCallReasoning surfaces a DeepSeek thinking-mode tool_calls
+// turn that arrived without reasoning text — usually a gateway renaming or
+// dropping the reasoning field. The turn is still saved and the replay still
+// succeeds (the wire layer always emits the reasoning_content key for such
+// turns), but the model continues without its chain-of-thought context, so the
+// degradation is worth a visible warning.
+func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) {
 	if len(calls) == 0 || !provider.RequiresToolCallReasoning(a.prov) {
-		return nil
+		return
 	}
 	if strings.TrimSpace(reasoning) != "" {
-		return nil
+		return
 	}
-	return &provider.MissingToolCallReasoningError{
-		Provider:      a.prov.Name(),
-		ToolCallCount: len(calls),
-		CurrentTurn:   true,
-	}
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text: fmt.Sprintf("%s returned %d tool call(s) without reasoning_content; continuing, but thinking context is lost for this turn (is a gateway dropping the reasoning field?)", a.prov.Name(), len(calls))})
 }
 
 // maxStepsPause is the deliberate stop when a positive tool-call budget runs

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -13,6 +13,12 @@ import (
 	"reasonix/internal/tool"
 )
 
+type toolCallReasoningRequiredProvider struct {
+	*testutil.MockProvider
+}
+
+func (p toolCallReasoningRequiredProvider) RequiresToolCallReasoning() bool { return true }
+
 func echoRegistry() *tool.Registry {
 	reg := tool.NewRegistry()
 	reg.Add(echoTool{})
@@ -521,6 +527,59 @@ func TestRunWellFormedToolLoopRoundTrips(t *testing.T) {
 	before := len(msgs)
 	if after := len(provider.SanitizeToolPairing(msgs)); after != before {
 		t.Errorf("repair mutated a well-formed session: %d -> %d", before, after)
+	}
+}
+
+func TestRunRejectsRequiredToolCallsWithoutReasoning(t *testing.T) {
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+	)
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{}, event.Discard)
+
+	err := a.Run(context.Background(), "go")
+	var missing *provider.MissingToolCallReasoningError
+	if !errors.As(err, &missing) || !missing.CurrentTurn {
+		t.Fatalf("Run error = %T %v, want current-turn MissingToolCallReasoningError", err, err)
+	}
+	for _, m := range a.Session().Messages {
+		if m.Role == provider.RoleAssistant || m.Role == provider.RoleTool {
+			t.Fatalf("invalid tool-call turn should not be saved, session=%+v", a.Session().Messages)
+		}
+	}
+}
+
+func TestRunPreservesOriginalRequiredToolCallReasoningAcrossHook(t *testing.T) {
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{
+			Reasoning: "original reasoning",
+			ToolCalls: []provider.ToolCall{{
+				ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`,
+			}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	h := &stubHooks{hasPostLLM: true, postLLMOut: "translated display"}
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{Hooks: h}, event.Discard)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(reqs))
+	}
+	var toolCallAssistant provider.Message
+	for _, m := range reqs[1].Messages {
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
+			toolCallAssistant = m
+			break
+		}
+	}
+	if toolCallAssistant.ReasoningContent != "original reasoning" {
+		t.Fatalf("tool-call reasoning = %q, want original provider reasoning", toolCallAssistant.ReasoningContent)
+	}
+	if toolCallAssistant.ReasoningContent == "translated display" {
+		t.Fatal("translated display text leaked into provider-visible tool-call reasoning")
 	}
 }
 

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -530,21 +530,40 @@ func TestRunWellFormedToolLoopRoundTrips(t *testing.T) {
 	}
 }
 
-func TestRunRejectsRequiredToolCallsWithoutReasoning(t *testing.T) {
+// TestRunWarnsAndContinuesOnMissingToolCallReasoning: a DeepSeek thinking-mode
+// tool_calls turn arriving without reasoning (gateway dropped the field) is a
+// quality degradation, not a failure — the turn is saved, the loop continues to
+// completion, and the user sees a warn notice naming the likely cause. The
+// wire layer keeps the replay valid by always serializing the reasoning_content
+// key on such turns.
+func TestRunWarnsAndContinuesOnMissingToolCallReasoning(t *testing.T) {
 	mp := testutil.NewMock("deepseek-proxy",
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "done"},
 	)
-	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{}, event.Discard)
+	sink := &recordSink{}
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{}, sink)
 
-	err := a.Run(context.Background(), "go")
-	var missing *provider.MissingToolCallReasoningError
-	if !errors.As(err, &missing) || !missing.CurrentTurn {
-		t.Fatalf("Run error = %T %v, want current-turn MissingToolCallReasoningError", err, err)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
+	var savedToolTurn bool
 	for _, m := range a.Session().Messages {
-		if m.Role == provider.RoleAssistant || m.Role == provider.RoleTool {
-			t.Fatalf("invalid tool-call turn should not be saved, session=%+v", a.Session().Messages)
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
+			savedToolTurn = true
 		}
+	}
+	if !savedToolTurn {
+		t.Fatalf("tool-call turn should be saved despite missing reasoning, session=%+v", a.Session().Messages)
+	}
+	var warned bool
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Level == event.LevelWarn && strings.Contains(e.Text, "without reasoning_content") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatal("missing-reasoning tool_calls turn should emit a warn notice")
 	}
 }
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -447,9 +447,15 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		// validates turns after the last user message, but emitting the field on
 		// every tool_calls turn is uniform and verified accepted — so always send
 		// it (empty included) rather than fail the request when reasoning was lost
-		// upstream (e.g. a gateway renamed the field).
+		// upstream (e.g. a gateway renamed the field). With thinking disabled the
+		// API tolerates every shape, so keep the exact pre-fix bytes there: send
+		// the key only when a thinking-mode round left reasoning in the history
+		// (dropping it would invalidate the prompt-cache prefix of mixed
+		// thinking-on→off sessions for no gain).
 		if c.deepseek && m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
-			cm.ReasoningContent = &m.ReasoningContent
+			if c.RequiresToolCallReasoning() || m.ReasoningContent != "" {
+				cm.ReasoningContent = &m.ReasoningContent
+			}
 		}
 		for _, tc := range m.ToolCalls {
 			wire := chatToolCall{ID: tc.ID, Type: "function"}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -234,6 +234,10 @@ type client struct {
 
 func (c *client) Name() string { return c.name }
 
+func (c *client) RequiresToolCallReasoning() bool {
+	return c != nil && c.deepseek && c.thinkingType != "disabled"
+}
+
 func (c *client) sendOpts() provider.SendOptions {
 	return provider.SendOptions{
 		Provider:   c.name,
@@ -342,6 +346,9 @@ var bufPool = sync.Pool{
 }
 
 func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	if err := c.validateToolCallReasoning(req.Messages); err != nil {
+		return nil, err
+	}
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	if err := json.NewEncoder(buf).Encode(c.buildRequest(req)); err != nil {
@@ -423,6 +430,22 @@ func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Ch
 	case out <- chunk:
 		return true
 	}
+}
+
+func (c *client) validateToolCallReasoning(messages []provider.Message) error {
+	if !c.RequiresToolCallReasoning() {
+		return nil
+	}
+	for i, m := range provider.SanitizeToolPairing(messages) {
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 && strings.TrimSpace(m.ReasoningContent) == "" {
+			return &provider.MissingToolCallReasoningError{
+				Provider:      c.name,
+				MessageIndex:  i,
+				ToolCallCount: len(m.ToolCalls),
+			}
+		}
+	}
+	return nil
 }
 
 func (c *client) buildRequest(req provider.Request) chatRequest {
@@ -632,9 +655,13 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 
 		delta := sr.Choices[0].Delta
-		if delta.ReasoningContent != "" {
+		reasoningDelta := delta.ReasoningContent
+		if reasoningDelta == "" {
+			reasoningDelta = delta.Reasoning
+		}
+		if reasoningDelta != "" {
 			emitted = true
-			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: delta.ReasoningContent}) {
+			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: reasoningDelta}) {
 				return emitted, ctx.Err()
 			}
 		}
@@ -862,6 +889,7 @@ type streamResponse struct {
 		Delta struct {
 			Content          string         `json:"content"`
 			ReasoningContent string         `json:"reasoning_content"`
+			Reasoning        string         `json:"reasoning"`
 			ToolCalls        []chatToolCall `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason *string `json:"finish_reason"`

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -346,9 +346,6 @@ var bufPool = sync.Pool{
 }
 
 func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
-	if err := c.validateToolCallReasoning(req.Messages); err != nil {
-		return nil, err
-	}
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	if err := json.NewEncoder(buf).Encode(c.buildRequest(req)); err != nil {
@@ -432,22 +429,6 @@ func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Ch
 	}
 }
 
-func (c *client) validateToolCallReasoning(messages []provider.Message) error {
-	if !c.RequiresToolCallReasoning() {
-		return nil
-	}
-	for i, m := range provider.SanitizeToolPairing(messages) {
-		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 && strings.TrimSpace(m.ReasoningContent) == "" {
-			return &provider.MissingToolCallReasoningError{
-				Provider:      c.name,
-				MessageIndex:  i,
-				ToolCallCount: len(m.ToolCalls),
-			}
-		}
-	}
-	return nil
-}
-
 func (c *client) buildRequest(req provider.Request) chatRequest {
 	// Repair tool-call pairing before sending: an interrupted/resumed history can
 	// carry an assistant tool_calls turn whose results never landed, which DeepSeek
@@ -460,11 +441,15 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 			ToolCallID: m.ToolCallID,
 			Name:       m.Name,
 		}
-		// DeepSeek thinking mode 400s a tool_calls turn whose reasoning_content was
-		// dropped on a cache-miss replay ("reasoning_content … must be passed back"),
-		// so round it back — but only on the turn that carries the tool calls.
+		// DeepSeek thinking mode 400s an assistant tool_calls turn whose
+		// reasoning_content KEY is absent from the request JSON ("reasoning_content
+		// … must be passed back"). The API accepts an empty string, and only
+		// validates turns after the last user message, but emitting the field on
+		// every tool_calls turn is uniform and verified accepted — so always send
+		// it (empty included) rather than fail the request when reasoning was lost
+		// upstream (e.g. a gateway renamed the field).
 		if c.deepseek && m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
-			cm.ReasoningContent = m.ReasoningContent
+			cm.ReasoningContent = &m.ReasoningContent
 		}
 		for _, tc := range m.ToolCalls {
 			wire := chatToolCall{ID: tc.ID, Type: "function"}
@@ -834,8 +819,12 @@ type chatMessage struct {
 	// serializes as null (nil here); a string for every other text message
 	// (empty included — null is rejected by some backends for a tool message);
 	// and a []chatContentPart array for a vision user turn carrying images.
-	Content          any            `json:"content"`
-	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	Content any `json:"content"`
+	// A pointer so the field can serialize as an empty string: DeepSeek thinking
+	// mode requires the reasoning_content key to be PRESENT on assistant
+	// tool_calls turns (an empty value passes; a missing key 400s), while every
+	// other message must keep omitting it.
+	ReasoningContent *string        `json:"reasoning_content,omitempty"`
 	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string         `json:"tool_call_id,omitempty"`
 	Name             string         `json:"name,omitempty"`

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -949,6 +949,107 @@ func TestNewReadsEffortFromConfig(t *testing.T) {
 	}
 }
 
+func TestStreamReadsReasoningFallbackField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"reasoning":"vllm thinking","content":"answer"}}]}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "vllm", BaseURL: srv.URL, Model: "qwen", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var reasoning, text strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkReasoning:
+			reasoning.WriteString(chunk.Text)
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkError:
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	if reasoning.String() != "vllm thinking" {
+		t.Fatalf("reasoning = %q, want vLLM fallback field", reasoning.String())
+	}
+	if text.String() != "answer" {
+		t.Fatalf("text = %q, want answer", text.String())
+	}
+}
+
+func TestStreamReasoningContentTakesPrecedenceOverFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"reasoning_content":"standard","reasoning":"fallback"}}]}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "vllm", BaseURL: srv.URL, Model: "qwen", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var reasoning strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkReasoning:
+			reasoning.WriteString(chunk.Text)
+		case provider.ChunkError:
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	if reasoning.String() != "standard" {
+		t.Fatalf("reasoning = %q, want reasoning_content precedence", reasoning.String())
+	}
+}
+
+func TestStreamRejectsDeepSeekToolCallsWithoutReasoningBeforeHTTP(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{
+		Name:    "deepseek-proxy",
+		BaseURL: srv.URL,
+		Model:   "deepseek-v4-pro",
+		APIKey:  "k",
+		Extra:   map[string]any{"reasoning_protocol": "deepseek"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "inspect"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+				ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`,
+			}}},
+			{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+		},
+	})
+	var missing *provider.MissingToolCallReasoningError
+	if !errors.As(err, &missing) {
+		t.Fatalf("Stream error = %T %v, want MissingToolCallReasoningError", err, err)
+	}
+	if requests != 0 {
+		t.Fatalf("invalid DeepSeek history should fail locally, server saw %d request(s)", requests)
+	}
+}
+
 // TestBuildRequestPreservesEmptyIDToolResults proves a multi-tool turn whose
 // calls carry no id (some OpenAI-compatible gateways omit it, sending only the
 // index) keeps every tool result through buildRequest. SanitizeToolPairing keys

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -821,8 +821,12 @@ func TestNewThinkingConfigParsing(t *testing.T) {
 }
 
 // TestBuildRequestDeepSeekDisabled covers both user-facing ways to turn
-// DeepSeek thinking off. Either input must route to thinking.type=disabled and
-// drop reasoning_effort.
+// DeepSeek thinking off. Either input must route to thinking.type=disabled,
+// drop reasoning_effort, and keep the pre-fix tool-call history bytes: a
+// tool_calls turn with no reasoning omits the reasoning_content key entirely
+// (only thinking mode requires it), while reasoning left over from a
+// thinking-mode round still round-trips so the prompt-cache prefix of a mixed
+// thinking-on→off session stays stable.
 func TestBuildRequestDeepSeekDisabled(t *testing.T) {
 	base := provider.Config{Name: "ds", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4", APIKey: "k"}
 	for _, tc := range []struct {
@@ -839,12 +843,30 @@ func TestBuildRequestDeepSeekDisabled(t *testing.T) {
 			if err != nil {
 				t.Fatalf("New(%v): %v", tc.extra, err)
 			}
-			req := p.(*client).buildRequest(provider.Request{})
+			req := p.(*client).buildRequest(provider.Request{
+				Messages: []provider.Message{
+					{Role: provider.RoleUser, Content: "inspect"},
+					{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+						ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`,
+					}}},
+					{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+					{Role: provider.RoleAssistant, ReasoningContent: "from a thinking round", ToolCalls: []provider.ToolCall{{
+						ID: "call_2", Name: "read_file", Arguments: `{"path":"go.mod"}`,
+					}}},
+					{Role: provider.RoleTool, ToolCallID: "call_2", Name: "read_file", Content: "module demo"},
+				},
+			})
 			if req.Thinking == nil || req.Thinking.Type != "disabled" {
 				t.Fatalf("Thinking = %+v, want disabled", req.Thinking)
 			}
 			if req.ReasoningEffort != "" {
 				t.Fatalf("disabled DeepSeek must not send reasoning_effort, got %q", req.ReasoningEffort)
+			}
+			if rc := req.Messages[1].ReasoningContent; rc != nil {
+				t.Fatalf("disabled mode must omit reasoning_content on a reasoning-less tool_calls turn, got %q", *rc)
+			}
+			if rc := req.Messages[3].ReasoningContent; rc == nil || *rc != "from a thinking round" {
+				t.Fatalf("disabled mode must keep round-tripping thinking-round reasoning, got %v", rc)
 			}
 		})
 	}

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1014,17 +1014,17 @@ func TestStreamReasoningContentTakesPrecedenceOverFallback(t *testing.T) {
 	}
 }
 
-func TestStreamRejectsDeepSeekToolCallsWithoutReasoningBeforeHTTP(t *testing.T) {
-	var requests int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		w.WriteHeader(http.StatusTeapot)
-	}))
-	defer srv.Close()
-
+// TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls proves the wire
+// contract verified against the live API: DeepSeek thinking mode 400s an
+// assistant tool_calls turn whose reasoning_content KEY is missing from the
+// request JSON, but accepts an empty string. A turn whose reasoning was lost
+// upstream (gateway renamed/dropped the field, legacy session, model switch)
+// must therefore still serialize the key — while plain assistant text turns
+// keep omitting it.
+func TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek-proxy",
-		BaseURL: srv.URL,
+		BaseURL: "https://api.deepseek.com",
 		Model:   "deepseek-v4-pro",
 		APIKey:  "k",
 		Extra:   map[string]any{"reasoning_protocol": "deepseek"},
@@ -1032,21 +1032,66 @@ func TestStreamRejectsDeepSeekToolCallsWithoutReasoningBeforeHTTP(t *testing.T) 
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	_, err = p.Stream(context.Background(), provider.Request{
+	body, err := json.Marshal(p.(*client).buildRequest(provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "inspect"},
 			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
 				ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`,
 			}}},
 			{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+			{Role: provider.RoleAssistant, Content: "plain text turn"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var req struct {
+		Messages []map[string]json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if len(req.Messages) != 4 {
+		t.Fatalf("messages = %d, want 4", len(req.Messages))
+	}
+	rc, ok := req.Messages[1]["reasoning_content"]
+	if !ok {
+		t.Fatal("tool_calls turn with lost reasoning must still serialize the reasoning_content key")
+	}
+	if string(rc) != `""` {
+		t.Fatalf("reasoning_content = %s, want empty string", rc)
+	}
+	if _, ok := req.Messages[3]["reasoning_content"]; ok {
+		t.Fatal("plain assistant text turn must keep omitting reasoning_content")
+	}
+}
+
+// TestBuildRequestRoundTripsDeepSeekToolCallReasoning keeps the healthy-path
+// bytes intact: when the session has the provider-issued reasoning, it is
+// replayed verbatim on the tool_calls turn.
+func TestBuildRequestRoundTripsDeepSeekToolCallReasoning(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "deepseek-proxy",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v4-pro",
+		APIKey:  "k",
+		Extra:   map[string]any{"reasoning_protocol": "deepseek"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	out := p.(*client).buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "inspect"},
+			{Role: provider.RoleAssistant, ReasoningContent: "read main.go first", ToolCalls: []provider.ToolCall{{
+				ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`,
+			}}},
+			{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
 		},
 	})
-	var missing *provider.MissingToolCallReasoningError
-	if !errors.As(err, &missing) {
-		t.Fatalf("Stream error = %T %v, want MissingToolCallReasoningError", err, err)
-	}
-	if requests != 0 {
-		t.Fatalf("invalid DeepSeek history should fail locally, server saw %d request(s)", requests)
+	got := out.Messages[1].ReasoningContent
+	if got == nil || *got != "read main.go first" {
+		t.Fatalf("reasoning_content = %v, want provider-issued reasoning round-tripped", got)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -617,6 +617,51 @@ type Provider interface {
 	Stream(ctx context.Context, req Request) (<-chan Chunk, error)
 }
 
+// ToolCallReasoningPolicy is optionally implemented by providers whose protocol
+// requires assistant tool_calls turns to replay the provider-issued reasoning
+// block. Most providers leave this unset; callers must treat it as false.
+type ToolCallReasoningPolicy interface {
+	RequiresToolCallReasoning() bool
+}
+
+// RequiresToolCallReasoning reports whether p requires assistant tool_calls
+// turns to carry reasoning_content when replayed in history.
+func RequiresToolCallReasoning(p Provider) bool {
+	if nilutil.IsNil(p) {
+		return false
+	}
+	policy, ok := p.(ToolCallReasoningPolicy)
+	return ok && policy.RequiresToolCallReasoning()
+}
+
+// MissingToolCallReasoningError is returned before sending a known-invalid
+// DeepSeek thinking-mode request: the session contains, or the current turn
+// produced, an assistant tool_calls message whose reasoning_content was dropped.
+type MissingToolCallReasoningError struct {
+	Provider      string
+	MessageIndex  int
+	ToolCallCount int
+	CurrentTurn   bool
+}
+
+func (e *MissingToolCallReasoningError) Error() string {
+	prov := strings.TrimSpace(e.Provider)
+	if prov == "" {
+		prov = "provider"
+	}
+	count := e.ToolCallCount
+	if count <= 0 {
+		count = 1
+	}
+	if e.CurrentTurn {
+		return fmt.Sprintf("%s returned an assistant tool_calls turn with %d tool call(s) but no reasoning_content; DeepSeek thinking mode requires reasoning_content to be passed back, so the invalid turn was not saved", prov, count)
+	}
+	if e.MessageIndex >= 0 {
+		return fmt.Sprintf("%s cannot replay messages[%d]: assistant tool_calls has %d tool call(s) but no reasoning_content; repair or compact this session before continuing", prov, e.MessageIndex, count)
+	}
+	return fmt.Sprintf("%s cannot replay assistant tool_calls without reasoning_content; repair or compact this session before continuing", prov)
+}
+
 // Config is a resolved provider instance configuration.
 type Config struct {
 	Name    string         // instance name, e.g. "deepseek"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -618,48 +618,25 @@ type Provider interface {
 }
 
 // ToolCallReasoningPolicy is optionally implemented by providers whose protocol
-// requires assistant tool_calls turns to replay the provider-issued reasoning
-// block. Most providers leave this unset; callers must treat it as false.
+// replays the provider-issued reasoning block on assistant tool_calls turns
+// (DeepSeek thinking mode). The agent uses it to archive the original reasoning
+// text on those turns (a display-translated copy must not round-trip to the
+// API) and to warn when a turn arrives with none — the request still succeeds
+// because the wire layer always emits the reasoning_content key for such turns,
+// but the model loses its chain-of-thought context. Most providers leave this
+// unset; callers must treat it as false.
 type ToolCallReasoningPolicy interface {
 	RequiresToolCallReasoning() bool
 }
 
-// RequiresToolCallReasoning reports whether p requires assistant tool_calls
-// turns to carry reasoning_content when replayed in history.
+// RequiresToolCallReasoning reports whether p replays reasoning_content on
+// assistant tool_calls turns sent back in history.
 func RequiresToolCallReasoning(p Provider) bool {
 	if nilutil.IsNil(p) {
 		return false
 	}
 	policy, ok := p.(ToolCallReasoningPolicy)
 	return ok && policy.RequiresToolCallReasoning()
-}
-
-// MissingToolCallReasoningError is returned before sending a known-invalid
-// DeepSeek thinking-mode request: the session contains, or the current turn
-// produced, an assistant tool_calls message whose reasoning_content was dropped.
-type MissingToolCallReasoningError struct {
-	Provider      string
-	MessageIndex  int
-	ToolCallCount int
-	CurrentTurn   bool
-}
-
-func (e *MissingToolCallReasoningError) Error() string {
-	prov := strings.TrimSpace(e.Provider)
-	if prov == "" {
-		prov = "provider"
-	}
-	count := e.ToolCallCount
-	if count <= 0 {
-		count = 1
-	}
-	if e.CurrentTurn {
-		return fmt.Sprintf("%s returned an assistant tool_calls turn with %d tool call(s) but no reasoning_content; DeepSeek thinking mode requires reasoning_content to be passed back, so the invalid turn was not saved", prov, count)
-	}
-	if e.MessageIndex >= 0 {
-		return fmt.Sprintf("%s cannot replay messages[%d]: assistant tool_calls has %d tool call(s) but no reasoning_content; repair or compact this session before continuing", prov, e.MessageIndex, count)
-	}
-	return fmt.Sprintf("%s cannot replay assistant tool_calls without reasoning_content; repair or compact this session before continuing", prov)
 }
 
 // Config is a resolved provider instance configuration.


### PR DESCRIPTION
## Summary
- Always serialize the `reasoning_content` key (empty string included) on DeepSeek assistant `tool_calls` turns, so a turn whose reasoning was lost upstream still replays successfully.
- Parse OpenAI-compatible `delta.reasoning` as a fallback for reasoning deltas, so real reasoning is not lost in the first place.
- Emit a warn notice (instead of failing) when a DeepSeek thinking-mode `tool_calls` turn arrives without reasoning, and archive the original (untranslated) reasoning on those turns across PostLLMCall display hooks.

## Root cause
Some OpenAI-compatible gateways expose thinking text as `reasoning` instead of `reasoning_content`. When Reasonix lost that field, replaying the assistant `tool_calls` turn omitted the `reasoning_content` key (`omitempty`), which DeepSeek thinking mode rejects with HTTP 400 ("The `reasoning_content` in the thinking mode must be passed back to the API") — permanently poisoning the session.

Live-API experiments against `deepseek-v4-pro` established the exact contract:

| history shape | result |
| --- | --- |
| current-round `tool_calls` turn, key absent | 400 |
| current-round, key present but empty `""` | 200 |
| current-round, placeholder/real text | 200 |
| previous-round (before last user msg), key absent | 200 |
| multi-step current round, first step key absent | 400 |

So the key's presence is what matters, empty passes, and only turns after the last user message are validated. The fix makes `chatMessage.ReasoningContent` a pointer and always emits the key on DeepSeek `tool_calls` turns — every replay is valid (existing poisoned sessions recover on upgrade), no reasoning text is fabricated, and no local hard-fail is needed. An earlier revision of this PR hard-failed on missing reasoning across the whole history; the experiments showed that was stricter than the API (it would block model-switch-into-DeepSeek and thinking off→on sessions the API accepts), so it was replaced by this wire-level repair.

## Cache impact
Cache-impact: low - no system prompt, tool schema, or serialization-order change. Healthy sessions serialize byte-identically (reasoning present → same value; other messages keep omitting the key). Turns that previously omitted the key only ever produced a 400, so emitting `""` there cannot regress a working cache prefix. Plain assistant turns still drop response-only reasoning; only DeepSeek tool-call history keeps provider-required reasoning.
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) plus go test ./internal/provider ./internal/provider/openai ./internal/agent

Fixes #6216

## Verification
- `go test ./internal/provider ./internal/provider/openai` — includes new serialization-contract tests (`TestBuildRequestAlwaysSendsReasoningKeyOnDeepSeekToolCalls`, `TestBuildRequestRoundTripsDeepSeekToolCallReasoning`)
- `go test ./internal/agent` — includes `TestRunWarnsAndContinuesOnMissingToolCallReasoning` and the hook round-trip test
- `./scripts/cache-guard.sh`
- Live end-to-end: the rewritten client replayed a reasoning-less `tool_calls` history against the real DeepSeek API and completed normally (the exact scenario that 400s on main)
- `gofmt` / `go vet` / `git diff --check`

## Attribution
The `delta.reasoning` stream fallback matches the approach independently proposed in #5930 by @dailingtao and #5904 by @FightZhanAng; both are credited with commit-level `Co-authored-by:` trailers on this branch. If this PR merges first, those PRs are superseded by the fallback portion of this change.
