### PR TITLE
feat(acp): client fs/terminal integration, tool locations, plan updates, session modes / ACP 客户端 fs/终端集成、工具定位、plan 更新与会话模式

### DIFF
--- a/internal/acp/client_integration_test.go
+++ b/internal/acp/client_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/permission"
@@ -307,7 +308,8 @@ func TestE2ESessionModes(t *testing.T) {
 	defer stop()
 
 	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
-	resp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	cwd := t.TempDir()
+	resp := client.call(t, "session/new", SessionNewParams{Cwd: cwd})
 	var nr SessionNewResult
 	if err := json.Unmarshal(resp.Result, &nr); err != nil {
 		t.Fatalf("session/new result: %v", err)
@@ -345,5 +347,87 @@ unknownMode:
 	bad := client.call(t, "session/set_mode", SessionSetModeParams{SessionID: nr.SessionID, ModeID: "yolo"})
 	if bad.Error == nil {
 		t.Fatal("unknown modeId must be rejected")
+	}
+
+	// Reconnecting to the live session must report its actual mode, not a
+	// hardcoded default — the mode picker would otherwise go stale.
+	loadResp := client.call(t, "session/load", SessionLoadParams{SessionID: nr.SessionID, Cwd: cwd})
+	if loadResp.Error != nil {
+		t.Fatalf("session/load: %+v", loadResp.Error)
+	}
+	var lr SessionLoadResult
+	if err := json.Unmarshal(loadResp.Result, &lr); err != nil {
+		t.Fatalf("session/load result: %v", err)
+	}
+	if lr.Modes == nil || lr.Modes.CurrentModeID != sessionModePlan {
+		t.Fatalf("session/load modes = %+v, want current plan for the live session", lr.Modes)
+	}
+}
+
+// TestRebuildSessionKeepsClientIOAndMode pins two rebuild invariants: a
+// model/effort switch must rebuild the controller with the same client
+// capability wiring (fs overlay, host terminal) the original had, and must
+// re-apply the session's ACP mode — a fresh controller boots with default
+// switches, which would silently drop a user-selected plan mode.
+func TestRebuildSessionKeepsClientIOAndMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sess-rebuild.jsonl")
+	base := agent.NewSession("sys prompt")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := base.Save(path); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	sink := newUpdateSink(&fakeNotifier{}, "sess-rebuild")
+	sess := &acpSession{
+		id:         "sess-rebuild",
+		sink:       sink,
+		cwd:        dir,
+		model:      "fast",
+		transcript: path,
+		modeID:     sessionModePlan,
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("acquire session lease: %v", err)
+	}
+	sess.lease = lease
+	t.Cleanup(sess.releaseSessionLease)
+
+	factory := &configurableFactory{dir: dir}
+	svc := &service{
+		factory:  factory,
+		sessions: map[string]*acpSession{sess.id: sess},
+		clientCaps: ClientCapabilities{
+			FS:       FSCapabilities{ReadTextFile: true, WriteTextFile: true},
+			Terminal: true,
+		},
+	}
+	oldCtrl := control.New(control.Options{
+		Executor:    agent.New(nil, nil, base, agent.Options{}, event.Discard),
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "fast",
+	})
+	sess.ctrl = oldCtrl
+
+	if err := svc.rebuildSession(context.Background(), sess, SessionConfigState{Model: "pro"}); err != nil {
+		t.Fatalf("rebuildSession: %v", err)
+	}
+	if sess.ctrl == oldCtrl {
+		t.Fatal("session controller was not replaced")
+	}
+
+	factory.mu.Lock()
+	last := factory.builds[len(factory.builds)-1]
+	factory.mu.Unlock()
+	if last.FileOverlay == nil {
+		t.Fatal("rebuild must keep the fs overlay wiring")
+	}
+	if last.Terminal == nil {
+		t.Fatal("rebuild must keep the host terminal wiring")
+	}
+	if !sess.ctrl.PlanMode() {
+		t.Fatal("rebuild must re-apply the session's plan mode to the new controller")
 	}
 }

--- a/internal/acp/client_integration_test.go
+++ b/internal/acp/client_integration_test.go
@@ -140,17 +140,21 @@ func io2str(calls []string) string { return strings.Join(calls, ",") }
 
 func TestUpdateSinkToolLocations(t *testing.T) {
 	s := newUpdateSink(&fakeNotifier{}, "sess")
-	s.bindCwd("/proj")
+	cwd := t.TempDir()
+	s.bindCwd(cwd)
 
 	locs := s.toolLocations("read_file", `{"path":"pkg/a.go","offset":41}`)
-	if len(locs) != 1 || locs[0].Path != filepath.Join("/proj", "pkg/a.go") {
+	if len(locs) != 1 || locs[0].Path != filepath.Join(cwd, "pkg", "a.go") {
 		t.Fatalf("read_file locations = %+v", locs)
 	}
 	if locs[0].Line == nil || *locs[0].Line != 42 {
 		t.Fatalf("read_file line = %v, want 42 (offset is 0-based)", locs[0].Line)
 	}
-	if locs := s.toolLocations("edit_file", `{"path":"/abs/b.go"}`); len(locs) != 1 || locs[0].Path != "/abs/b.go" || locs[0].Line != nil {
-		t.Fatalf("edit_file locations = %+v", locs)
+	// A platform-absolute path passes through untouched.
+	abs := filepath.Join(t.TempDir(), "b.go")
+	absArgs, _ := json.Marshal(map[string]string{"path": abs})
+	if locs := s.toolLocations("edit_file", string(absArgs)); len(locs) != 1 || locs[0].Path != abs || locs[0].Line != nil {
+		t.Fatalf("edit_file locations = %+v, want %s", locs, abs)
 	}
 	if locs := s.toolLocations("bash", `{"command":"ls"}`); locs != nil {
 		t.Fatalf("bash should have no locations, got %+v", locs)

--- a/internal/acp/client_integration_test.go
+++ b/internal/acp/client_integration_test.go
@@ -1,0 +1,345 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/permission"
+	"reasonix/internal/provider"
+)
+
+// scriptedRequester answers agent → client requests from a per-method script
+// and records the call order.
+type scriptedRequester struct {
+	mu      sync.Mutex
+	calls   []string
+	params  map[string]json.RawMessage
+	results map[string]any
+	errs    map[string]error
+}
+
+func newScriptedRequester() *scriptedRequester {
+	return &scriptedRequester{
+		params:  map[string]json.RawMessage{},
+		results: map[string]any{},
+		errs:    map[string]error{},
+	}
+}
+
+func (r *scriptedRequester) Request(_ context.Context, method string, params any) (json.RawMessage, error) {
+	raw, _ := json.Marshal(params)
+	r.mu.Lock()
+	r.calls = append(r.calls, method)
+	r.params[method] = raw
+	res, err := r.results[method], r.errs[method]
+	r.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	out, _ := json.Marshal(res)
+	return out, nil
+}
+
+func (r *scriptedRequester) callOrder() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+func TestClientIOReadWriteTextFile(t *testing.T) {
+	req := newScriptedRequester()
+	req.results["fs/read_text_file"] = FSReadTextFileResult{Content: "buffer content"}
+	req.results["fs/write_text_file"] = struct{}{}
+	io := newClientIO(req, "sess-1", ClientCapabilities{FS: FSCapabilities{ReadTextFile: true, WriteTextFile: true}})
+
+	content, ok := io.ReadTextFile(context.Background(), "/proj/a.go")
+	if !ok || content != "buffer content" {
+		t.Fatalf("ReadTextFile = %q, %v; want buffer content, true", content, ok)
+	}
+	var readParams FSReadTextFileParams
+	json.Unmarshal(req.params["fs/read_text_file"], &readParams)
+	if readParams.SessionID != "sess-1" || readParams.Path != "/proj/a.go" {
+		t.Fatalf("fs/read_text_file params = %+v", readParams)
+	}
+
+	handled, err := io.WriteTextFile(context.Background(), "/proj/a.go", "new content")
+	if !handled || err != nil {
+		t.Fatalf("WriteTextFile = %v, %v; want true, nil", handled, err)
+	}
+
+	// Without the capability, both degrade to unhandled so tools use the disk.
+	none := newClientIO(req, "sess-1", ClientCapabilities{})
+	if _, ok := none.ReadTextFile(context.Background(), "/proj/a.go"); ok {
+		t.Fatal("ReadTextFile without capability must report ok=false")
+	}
+	if handled, _ := none.WriteTextFile(context.Background(), "/proj/a.go", "x"); handled {
+		t.Fatal("WriteTextFile without capability must report handled=false")
+	}
+
+	// A client read error falls back (ok=false); a client write error surfaces
+	// (falling back could double-apply).
+	req.errs["fs/read_text_file"] = fmt.Errorf("not open")
+	if _, ok := io.ReadTextFile(context.Background(), "/proj/a.go"); ok {
+		t.Fatal("ReadTextFile client error must report ok=false")
+	}
+	req.errs["fs/write_text_file"] = fmt.Errorf("readonly buffer")
+	handled, err = io.WriteTextFile(context.Background(), "/proj/a.go", "x")
+	if !handled || err == nil {
+		t.Fatalf("WriteTextFile client error = %v, %v; want handled=true with error", handled, err)
+	}
+}
+
+func TestClientIORunCommandLifecycle(t *testing.T) {
+	req := newScriptedRequester()
+	req.results["terminal/create"] = TerminalCreateResult{TerminalID: "term-1"}
+	req.results["terminal/wait_for_exit"] = TerminalWaitResult{}
+	exitZero := 0
+	req.results["terminal/output"] = TerminalOutputResult{Output: "hello from client", ExitStatus: &TerminalExitStatus{ExitCode: &exitZero}}
+	req.results["terminal/release"] = struct{}{}
+	io := newClientIO(req, "sess-1", ClientCapabilities{Terminal: true})
+
+	out, ok, err := io.RunCommand(context.Background(), "echo hello", "/proj", time.Minute)
+	if !ok || err != nil || out != "hello from client" {
+		t.Fatalf("RunCommand = %q, %v, %v", out, ok, err)
+	}
+	order := io2str(req.callOrder())
+	if order != "terminal/create,terminal/wait_for_exit,terminal/output,terminal/release" {
+		t.Fatalf("call order = %s", order)
+	}
+
+	// A nonzero exit surfaces as an error alongside the captured output.
+	exitOne := 1
+	req.results["terminal/output"] = TerminalOutputResult{Output: "boom", ExitStatus: &TerminalExitStatus{ExitCode: &exitOne}}
+	out, ok, err = io.RunCommand(context.Background(), "false", "/proj", time.Minute)
+	if !ok || err == nil || !strings.Contains(err.Error(), "exit status 1") || out != "boom" {
+		t.Fatalf("RunCommand nonzero exit = %q, %v, %v", out, ok, err)
+	}
+
+	// No terminal capability → unhandled, local bash runs instead.
+	none := newClientIO(req, "sess-1", ClientCapabilities{})
+	if _, ok, _ := none.RunCommand(context.Background(), "echo", "/proj", time.Minute); ok {
+		t.Fatal("RunCommand without capability must report ok=false")
+	}
+
+	// terminal/create failure degrades to unhandled rather than failing the call.
+	req.errs["terminal/create"] = fmt.Errorf("client rejected")
+	if _, ok, _ := io.RunCommand(context.Background(), "echo", "/proj", time.Minute); ok {
+		t.Fatal("RunCommand with failed create must report ok=false")
+	}
+}
+
+func io2str(calls []string) string { return strings.Join(calls, ",") }
+
+func TestUpdateSinkToolLocations(t *testing.T) {
+	s := newUpdateSink(&fakeNotifier{}, "sess")
+	s.bindCwd("/proj")
+
+	locs := s.toolLocations("read_file", `{"path":"pkg/a.go","offset":41}`)
+	if len(locs) != 1 || locs[0].Path != filepath.Join("/proj", "pkg/a.go") {
+		t.Fatalf("read_file locations = %+v", locs)
+	}
+	if locs[0].Line == nil || *locs[0].Line != 42 {
+		t.Fatalf("read_file line = %v, want 42 (offset is 0-based)", locs[0].Line)
+	}
+	if locs := s.toolLocations("edit_file", `{"path":"/abs/b.go"}`); len(locs) != 1 || locs[0].Path != "/abs/b.go" || locs[0].Line != nil {
+		t.Fatalf("edit_file locations = %+v", locs)
+	}
+	if locs := s.toolLocations("bash", `{"command":"ls"}`); locs != nil {
+		t.Fatalf("bash should have no locations, got %+v", locs)
+	}
+	if locs := s.toolLocations("grep", `{"path":"pkg","pattern":"x"}`); locs != nil {
+		t.Fatalf("grep (directory scope) should have no locations, got %+v", locs)
+	}
+	if locs := s.toolLocations("read_file", `{"offset":1}`); locs != nil {
+		t.Fatalf("path-less args should have no locations, got %+v", locs)
+	}
+}
+
+func TestPlanEntriesFromTodoArgs(t *testing.T) {
+	entries, ok := planEntriesFromTodoArgs(`{"todos":[
+		{"content":"Phase one","status":"in_progress","level":0},
+		{"content":"Sub step","status":"pending","level":1},
+		{"content":"Done step","status":"completed"},
+		{"content":"","status":"pending"},
+		{"content":"Weird","status":"???"}
+	]}`)
+	if !ok || len(entries) != 4 {
+		t.Fatalf("entries = %+v, ok=%v; want 4 entries", entries, ok)
+	}
+	if entries[0].Priority != "high" || entries[0].Status != "in_progress" {
+		t.Fatalf("phase entry = %+v", entries[0])
+	}
+	if entries[1].Priority != "medium" {
+		t.Fatalf("sub-step entry = %+v", entries[1])
+	}
+	if entries[3].Status != "pending" {
+		t.Fatalf("unknown status must degrade to pending, got %+v", entries[3])
+	}
+	if _, ok := planEntriesFromTodoArgs(`{"todos":[]}`); ok {
+		t.Fatal("empty todos must not produce a plan update")
+	}
+	if _, ok := planEntriesFromTodoArgs(`not json`); ok {
+		t.Fatal("malformed args must not produce a plan update")
+	}
+}
+
+func TestUpdateSinkEmitsPlanForTodoWrite(t *testing.T) {
+	n := &fakeNotifier{}
+	s := newUpdateSink(n, "sess-1")
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: "t1", Name: "todo_write", Args: `{"todos":[{"content":"Do it","status":"pending"}]}`,
+	}})
+	// The plan update precedes the tool_call for the same dispatch.
+	plan := n.updateMap(t, 0)
+	if plan["sessionUpdate"] != "plan" {
+		t.Fatalf("first update = %v, want plan", plan["sessionUpdate"])
+	}
+	raw, _ := json.Marshal(plan)
+	if !strings.Contains(string(raw), `"content":"Do it"`) {
+		t.Fatalf("plan update missing entry: %s", raw)
+	}
+	call := n.updateMap(t, 1)
+	if call["sessionUpdate"] != "tool_call" {
+		t.Fatalf("second update = %v, want tool_call", call["sessionUpdate"])
+	}
+}
+
+// recordingFactory wraps e2eFactory and captures the SessionParams the service
+// hands to NewSession, so tests can assert the client-capability wiring.
+type recordingFactory struct {
+	inner  *e2eFactory
+	mu     sync.Mutex
+	params []SessionParams
+}
+
+func (f *recordingFactory) SessionDir() string { return f.inner.SessionDir() }
+
+func (f *recordingFactory) NewSession(ctx context.Context, p SessionParams) (*control.Controller, error) {
+	f.mu.Lock()
+	f.params = append(f.params, p)
+	f.mu.Unlock()
+	return f.inner.NewSession(ctx, p)
+}
+
+func (f *recordingFactory) last() SessionParams {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.params[len(f.params)-1]
+}
+
+func TestSessionParamsCarryClientIOFromInitializeCaps(t *testing.T) {
+	dir := t.TempDir()
+	prov := &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	factory := &recordingFactory{inner: &e2eFactory{
+		prov:       prov,
+		tool:       fakeTool{name: "peek", ro: true, out: "ok"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{
+		ProtocolVersion: 1,
+		ClientCapabilities: ClientCapabilities{
+			FS:       FSCapabilities{ReadTextFile: true, WriteTextFile: true},
+			Terminal: true,
+		},
+	})
+	client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	p := factory.last()
+	if p.FileOverlay == nil {
+		t.Fatal("SessionParams.FileOverlay should be bound when the client declares fs capabilities")
+	}
+	if p.Terminal == nil {
+		t.Fatal("SessionParams.Terminal should be bound when the client declares the terminal capability")
+	}
+}
+
+func TestSessionParamsNilClientIOWithoutCaps(t *testing.T) {
+	dir := t.TempDir()
+	prov := &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	factory := &recordingFactory{inner: &e2eFactory{
+		prov:       prov,
+		tool:       fakeTool{name: "peek", ro: true, out: "ok"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	p := factory.last()
+	if p.FileOverlay != nil || p.Terminal != nil {
+		t.Fatalf("SessionParams overlay/terminal must stay nil without client capabilities; got %v / %v", p.FileOverlay, p.Terminal)
+	}
+}
+
+func TestE2ESessionModes(t *testing.T) {
+	dir := t.TempDir()
+	prov := &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	factory := &e2eFactory{
+		prov:       prov,
+		tool:       fakeTool{name: "peek", ro: true, out: "ok"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	resp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(resp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	if nr.Modes == nil || nr.Modes.CurrentModeID != sessionModeDefault || len(nr.Modes.AvailableModes) != 3 {
+		t.Fatalf("session/new modes = %+v, want default current with 3 available", nr.Modes)
+	}
+
+	setResp := client.call(t, "session/set_mode", SessionSetModeParams{SessionID: nr.SessionID, ModeID: sessionModePlan})
+	if setResp.Error != nil {
+		t.Fatalf("session/set_mode: %+v", setResp.Error)
+	}
+	// The switch is confirmed with a current_mode_update notification.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case n := <-client.notifs:
+			var p struct {
+				Update struct {
+					SessionUpdate string `json:"sessionUpdate"`
+					CurrentModeID string `json:"currentModeId"`
+				} `json:"update"`
+			}
+			if json.Unmarshal(n.Params, &p) == nil && p.Update.SessionUpdate == "current_mode_update" {
+				if p.Update.CurrentModeID != sessionModePlan {
+					t.Fatalf("current_mode_update = %q, want plan", p.Update.CurrentModeID)
+				}
+				goto unknownMode
+			}
+		case <-deadline:
+			t.Fatal("no current_mode_update notification after session/set_mode")
+		}
+	}
+unknownMode:
+	bad := client.call(t, "session/set_mode", SessionSetModeParams{SessionID: nr.SessionID, ModeID: "yolo"})
+	if bad.Error == nil {
+		t.Fatal("unknown modeId must be rejected")
+	}
+}

--- a/internal/acp/clientio.go
+++ b/internal/acp/clientio.go
@@ -1,0 +1,158 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// requester is the slice of Conn that clientIO drives: agent → client requests.
+type requester interface {
+	Request(ctx context.Context, method string, params any) (json.RawMessage, error)
+}
+
+// clientIO implements builtin.FileOverlay and builtin.TerminalRunner over the
+// ACP connection for one session, backed by the capabilities the client
+// declared at initialize. Every method degrades to "not handled" (ok=false) on
+// a missing capability or a transport/client error, so the tools fall back to
+// their local implementations instead of failing the call.
+type clientIO struct {
+	conn      requester
+	sessionID string
+	caps      ClientCapabilities
+}
+
+func newClientIO(conn requester, sessionID string, caps ClientCapabilities) *clientIO {
+	return &clientIO{conn: conn, sessionID: sessionID, caps: caps}
+}
+
+// hasAny reports whether the client offered anything clientIO can use; callers
+// skip wiring the overlay/terminal entirely when it is false.
+func (c *clientIO) hasAny() bool {
+	return c.caps.FS.ReadTextFile || c.caps.FS.WriteTextFile || c.caps.Terminal
+}
+
+// fileOverlay returns c when the client offers an fs method, else nil. The nil
+// is typed at the call site (assigned to the interface field only when
+// non-nil), so a session without fs capability carries a nil interface.
+func (c *clientIO) fileOverlay() *clientIO {
+	if c.caps.FS.ReadTextFile || c.caps.FS.WriteTextFile {
+		return c
+	}
+	return nil
+}
+
+// terminalRunner returns c when the client offers terminals, else nil.
+func (c *clientIO) terminalRunner() *clientIO {
+	if c.caps.Terminal {
+		return c
+	}
+	return nil
+}
+
+// ReadTextFile implements builtin.FileOverlay: the client's view of the file,
+// including unsaved editor buffers. ok=false on missing capability or any
+// client/transport error — the tool then reads the local disk.
+func (c *clientIO) ReadTextFile(ctx context.Context, path string) (string, bool) {
+	if !c.caps.FS.ReadTextFile {
+		return "", false
+	}
+	raw, err := c.conn.Request(ctx, "fs/read_text_file", FSReadTextFileParams{SessionID: c.sessionID, Path: path})
+	if err != nil {
+		return "", false
+	}
+	var res FSReadTextFileResult
+	if json.Unmarshal(raw, &res) != nil {
+		return "", false
+	}
+	return res.Content, true
+}
+
+// WriteTextFile implements builtin.FileOverlay: the client writes content to
+// path and updates any open buffer. ok=false on missing capability so the tool
+// writes the local disk; with the capability present, a client error is a real
+// write failure and is surfaced (falling back could double-apply).
+func (c *clientIO) WriteTextFile(ctx context.Context, path, content string) (bool, error) {
+	if !c.caps.FS.WriteTextFile {
+		return false, nil
+	}
+	if _, err := c.conn.Request(ctx, "fs/write_text_file", FSWriteTextFileParams{SessionID: c.sessionID, Path: path, Content: content}); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// terminalOutputByteLimit bounds how much output a client terminal buffers for
+// one command; matches the local bash tool's practical output scale.
+const terminalOutputByteLimit = 1 << 20
+
+// RunCommand implements builtin.TerminalRunner: run the command in a
+// client-owned terminal (terminal/create → wait_for_exit → output → release)
+// so the user watches it live. ok=false when the client has no terminal
+// capability or creation fails — the bash tool then executes locally. A
+// timeout kills the terminal and returns what it printed.
+func (c *clientIO) RunCommand(ctx context.Context, command, cwd string, timeout time.Duration) (string, bool, error) {
+	if !c.caps.Terminal {
+		return "", false, nil
+	}
+	raw, err := c.conn.Request(ctx, "terminal/create", TerminalCreateParams{
+		SessionID:       c.sessionID,
+		Command:         command,
+		Cwd:             cwd,
+		OutputByteLimit: terminalOutputByteLimit,
+	})
+	if err != nil {
+		return "", false, nil
+	}
+	var created TerminalCreateResult
+	if json.Unmarshal(raw, &created) != nil || strings.TrimSpace(created.TerminalID) == "" {
+		return "", false, nil
+	}
+	id := TerminalIDParams{SessionID: c.sessionID, TerminalID: created.TerminalID}
+	defer func() { _, _ = c.conn.Request(context.WithoutCancel(ctx), "terminal/release", id) }()
+
+	waitCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		waitCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	_, waitErr := c.conn.Request(waitCtx, "terminal/wait_for_exit", id)
+	timedOut := waitErr != nil && waitCtx.Err() != nil && ctx.Err() == nil
+	if timedOut {
+		_, _ = c.conn.Request(context.WithoutCancel(ctx), "terminal/kill", id)
+	}
+
+	output, exit := c.terminalOutput(context.WithoutCancel(ctx), id)
+	switch {
+	case ctx.Err() != nil:
+		return output, true, ctx.Err()
+	case timedOut:
+		return output, true, fmt.Errorf("command timed out after %s (terminal killed)", timeout)
+	case waitErr != nil:
+		return output, true, waitErr
+	case exit != nil && exit.ExitCode != nil && *exit.ExitCode != 0:
+		return output, true, fmt.Errorf("exit status %d", *exit.ExitCode)
+	case exit != nil && exit.Signal != nil && *exit.Signal != "":
+		return output, true, fmt.Errorf("terminated by signal %s", *exit.Signal)
+	}
+	return output, true, nil
+}
+
+func (c *clientIO) terminalOutput(ctx context.Context, id TerminalIDParams) (string, *TerminalExitStatus) {
+	raw, err := c.conn.Request(ctx, "terminal/output", id)
+	if err != nil {
+		return "", nil
+	}
+	var res TerminalOutputResult
+	if json.Unmarshal(raw, &res) != nil {
+		return "", nil
+	}
+	out := res.Output
+	if res.Truncated {
+		out += "\n…(output truncated by the client terminal)"
+	}
+	return out, res.ExitStatus
+}

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -47,15 +48,21 @@ const maxResultChars = 8000
 type updateSink struct {
 	conn      notifier
 	sessionID string
-	approve   func(id string, allow, session, persist bool)
-	answer    func(id string, answers []event.AskAnswer)
-	mu        sync.Mutex
-	turnCtx   context.Context
+	// cwd resolves relative tool-arg paths for tool_call locations. Set once
+	// via bindCwd before the sink receives events.
+	cwd     string
+	approve func(id string, allow, session, persist bool)
+	answer  func(id string, answers []event.AskAnswer)
+	mu      sync.Mutex
+	turnCtx context.Context
 }
 
 func newUpdateSink(conn notifier, sessionID string) *updateSink {
 	return &updateSink{conn: conn, sessionID: sessionID}
 }
+
+// bindCwd installs the session root used to absolutize tool_call locations.
+func (s *updateSink) bindCwd(cwd string) { s.cwd = cwd }
 
 // bindApprove installs the controller's Approve callback, called by the service
 // once the controller exists (the sink is built first, to hand to the Factory).
@@ -117,6 +124,13 @@ func (s *updateSink) Emit(e event.Event) {
 		if e.Tool.Partial {
 			return
 		}
+		// todo_write is the agent's task list; mirror it as an ACP plan update so
+		// the client renders structured progress alongside the tool_call.
+		if e.Tool.Name == "todo_write" {
+			if entries, ok := planEntriesFromTodoArgs(e.Tool.Args); ok {
+				s.send(planUpdate{SessionUpdate: "plan", Entries: entries})
+			}
+		}
 		s.send(toolCall{
 			SessionUpdate: "tool_call",
 			ToolCallID:    e.Tool.ID,
@@ -124,6 +138,7 @@ func (s *updateSink) Emit(e event.Event) {
 			Kind:          toolKindFor(e.Tool.Name),
 			Status:        "pending",
 			RawInput:      rawJSON(e.Tool.Args),
+			Locations:     s.toolLocations(e.Tool.Name, e.Tool.Args),
 		})
 
 	case event.ToolResult:
@@ -206,7 +221,15 @@ func (s *updateSink) replay(msgs []provider.Message) {
 					Kind:          toolKindFor(tc.Name),
 					Status:        "completed",
 					RawInput:      rawJSON(tc.Arguments),
+					Locations:     s.toolLocations(tc.Name, tc.Arguments),
 				})
+				// Replaying the latest plan keeps the client's plan view in sync
+				// with the restored conversation; each update replaces the last.
+				if tc.Name == "todo_write" {
+					if entries, ok := planEntriesFromTodoArgs(tc.Arguments); ok {
+						s.send(planUpdate{SessionUpdate: "plan", Entries: entries})
+					}
+				}
 			}
 		case provider.RoleTool:
 			s.send(toolCallUpdateMsg{
@@ -416,4 +439,86 @@ func toolKindFor(name string) string {
 	default:
 		return "other"
 	}
+}
+
+// locationTools names the builtin tools whose "path" argument is a real file
+// target worth a follow-along location. Search/list tools are excluded: their
+// path is a directory scope, not a file the user would want opened.
+var locationTools = map[string]bool{
+	"read_file":     true,
+	"write_file":    true,
+	"edit_file":     true,
+	"multi_edit":    true,
+	"notebook_edit": true,
+	"delete_range":  true,
+	"delete_symbol": true,
+	"code_index":    true,
+}
+
+// toolLocations derives the file location a tool call touches from its raw
+// args, so the client can follow along in the editor. Unknown tools and
+// path-less args yield nil.
+func (s *updateSink) toolLocations(name, rawArgs string) []ToolCallLocation {
+	if !locationTools[name] {
+		return nil
+	}
+	var p struct {
+		Path   string `json:"path"`
+		Offset int    `json:"offset"`
+	}
+	if json.Unmarshal([]byte(rawArgs), &p) != nil || strings.TrimSpace(p.Path) == "" {
+		return nil
+	}
+	loc := ToolCallLocation{Path: s.absPath(p.Path)}
+	// read_file's offset is a 0-based start line; surface it so the editor can
+	// jump to the region being read.
+	if name == "read_file" && p.Offset > 0 {
+		line := p.Offset + 1
+		loc.Line = &line
+	}
+	return []ToolCallLocation{loc}
+}
+
+func (s *updateSink) absPath(p string) string {
+	if filepath.IsAbs(p) || s.cwd == "" {
+		return p
+	}
+	return filepath.Join(s.cwd, p)
+}
+
+// planEntriesFromTodoArgs maps a todo_write argument payload onto ACP plan
+// entries. Phase items (level 0) rank high, sub-steps medium; unknown statuses
+// degrade to pending so a malformed item cannot poison the whole update.
+func planEntriesFromTodoArgs(rawArgs string) ([]PlanEntry, bool) {
+	var p struct {
+		Todos []struct {
+			Content string `json:"content"`
+			Status  string `json:"status"`
+			Level   int    `json:"level"`
+		} `json:"todos"`
+	}
+	if json.Unmarshal([]byte(rawArgs), &p) != nil || len(p.Todos) == 0 {
+		return nil, false
+	}
+	entries := make([]PlanEntry, 0, len(p.Todos))
+	for _, t := range p.Todos {
+		if strings.TrimSpace(t.Content) == "" {
+			continue
+		}
+		status := t.Status
+		switch status {
+		case "pending", "in_progress", "completed":
+		default:
+			status = "pending"
+		}
+		priority := "medium"
+		if t.Level == 0 {
+			priority = "high"
+		}
+		entries = append(entries, PlanEntry{Content: t.Content, Priority: priority, Status: status})
+	}
+	if len(entries) == 0 {
+		return nil, false
+	}
+	return entries, true
 }

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -34,11 +34,27 @@ const (
 
 // --- initialize ---
 
-// InitializeParams is the client's handshake. We accept and ignore its
-// capabilities/info — the agent advertises a fixed capability set in reply.
+// InitializeParams is the client's handshake. The agent records the client's
+// capabilities — fs read/write proxying and host terminals are used when
+// offered — and advertises its own fixed capability set in reply.
 type InitializeParams struct {
-	ProtocolVersion int             `json:"protocolVersion"`
-	ClientInfo      *Implementation `json:"clientInfo,omitempty"`
+	ProtocolVersion    int                `json:"protocolVersion"`
+	ClientInfo         *Implementation    `json:"clientInfo,omitempty"`
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities,omitempty"`
+}
+
+// ClientCapabilities is what the client offers the agent: filesystem proxy
+// methods (fs/read_text_file, fs/write_text_file) that see unsaved editor
+// buffers, and host-owned terminals (terminal/*).
+type ClientCapabilities struct {
+	FS       FSCapabilities `json:"fs,omitempty"`
+	Terminal bool           `json:"terminal,omitempty"`
+}
+
+// FSCapabilities reports which client filesystem methods are available.
+type FSCapabilities struct {
+	ReadTextFile  bool `json:"readTextFile,omitempty"`
+	WriteTextFile bool `json:"writeTextFile,omitempty"`
 }
 
 // Implementation names a participant (client or agent) on the wire.
@@ -197,8 +213,33 @@ func unmarshalNameValueMap(raw []byte, field string) (map[string]string, error) 
 type SessionNewResult struct {
 	SessionID     string                `json:"sessionId"`
 	Models        *SessionModelState    `json:"models,omitempty"`
+	Modes         *SessionModeState     `json:"modes,omitempty"`
 	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
 }
+
+// --- session modes ---
+
+// SessionMode is one operating mode the client can switch the session into.
+type SessionMode struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// SessionModeState reports the current mode and the full mode list.
+type SessionModeState struct {
+	CurrentModeID  string        `json:"currentModeId"`
+	AvailableModes []SessionMode `json:"availableModes"`
+}
+
+// SessionSetModeParams switches a session's operating mode.
+type SessionSetModeParams struct {
+	SessionID string `json:"sessionId"`
+	ModeID    string `json:"modeId"`
+}
+
+// SessionSetModeResult is the empty ack.
+type SessionSetModeResult struct{}
 
 // ModelInfo describes one selectable model in ACP's legacy model selector.
 type ModelInfo struct {
@@ -230,6 +271,7 @@ type SessionLoadParams struct {
 // burst of session/update notifications by the time it is sent.
 type SessionLoadResult struct {
 	Models        *SessionModelState    `json:"models,omitempty"`
+	Modes         *SessionModeState     `json:"modes,omitempty"`
 	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
 }
 
@@ -245,6 +287,7 @@ type SessionResumeParams struct {
 // SessionResumeResult is the empty ack returned once the session is ready.
 type SessionResumeResult struct {
 	Models        *SessionModelState    `json:"models,omitempty"`
+	Modes         *SessionModeState     `json:"modes,omitempty"`
 	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
 }
 
@@ -433,12 +476,20 @@ type updateError struct {
 
 // toolCall is a "tool_call" update (announces a call, with title/kind/rawInput).
 type toolCall struct {
-	SessionUpdate string          `json:"sessionUpdate"`
-	ToolCallID    string          `json:"toolCallId"`
-	Title         string          `json:"title,omitempty"`
-	Kind          string          `json:"kind,omitempty"`
-	Status        string          `json:"status,omitempty"`
-	RawInput      json.RawMessage `json:"rawInput,omitempty"`
+	SessionUpdate string             `json:"sessionUpdate"`
+	ToolCallID    string             `json:"toolCallId"`
+	Title         string             `json:"title,omitempty"`
+	Kind          string             `json:"kind,omitempty"`
+	Status        string             `json:"status,omitempty"`
+	RawInput      json.RawMessage    `json:"rawInput,omitempty"`
+	Locations     []ToolCallLocation `json:"locations,omitempty"`
+}
+
+// ToolCallLocation names a file (and optionally a line) a tool call touches, so
+// the client can follow along in the editor.
+type ToolCallLocation struct {
+	Path string `json:"path"`
+	Line *int   `json:"line,omitempty"`
 }
 
 // toolCallUpdateMsg is a "tool_call_update" update (status + result content).
@@ -479,6 +530,93 @@ type AvailableCommandInput struct {
 type configOptionUpdate struct {
 	SessionUpdate string                `json:"sessionUpdate"`
 	ConfigOptions []SessionConfigOption `json:"configOptions"`
+}
+
+// planUpdate is a "plan" update: the agent's current task list. Each update
+// carries the complete plan and replaces the previous one, mirroring the
+// todo_write contract it is derived from.
+type planUpdate struct {
+	SessionUpdate string      `json:"sessionUpdate"`
+	Entries       []PlanEntry `json:"entries"`
+}
+
+// PlanEntry is one task in a plan update.
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Priority string `json:"priority"`
+	Status   string `json:"status"`
+}
+
+// currentModeUpdate reports that the session switched operating modes.
+type currentModeUpdate struct {
+	SessionUpdate string `json:"sessionUpdate"`
+	CurrentModeID string `json:"currentModeId"`
+}
+
+// --- fs/* (agent → client requests) ---
+
+// FSReadTextFileParams asks the client for a file's current text, including
+// unsaved editor state. Line (1-based) and Limit page the content; Reasonix
+// always reads whole files and pages locally, so it sends neither.
+type FSReadTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Line      *int   `json:"line,omitempty"`
+	Limit     *int   `json:"limit,omitempty"`
+}
+
+// FSReadTextFileResult carries the file content.
+type FSReadTextFileResult struct {
+	Content string `json:"content"`
+}
+
+// FSWriteTextFileParams asks the client to write content to path, updating any
+// open buffer as well as the file on disk.
+type FSWriteTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}
+
+// --- terminal/* (agent → client requests) ---
+
+// TerminalCreateParams starts a command in a client-owned terminal.
+type TerminalCreateParams struct {
+	SessionID       string   `json:"sessionId"`
+	Command         string   `json:"command"`
+	Args            []string `json:"args,omitempty"`
+	Cwd             string   `json:"cwd,omitempty"`
+	OutputByteLimit int      `json:"outputByteLimit,omitempty"`
+}
+
+// TerminalCreateResult returns the id used by the other terminal methods.
+type TerminalCreateResult struct {
+	TerminalID string `json:"terminalId"`
+}
+
+// TerminalIDParams addresses one terminal (output / kill / wait / release).
+type TerminalIDParams struct {
+	SessionID  string `json:"sessionId"`
+	TerminalID string `json:"terminalId"`
+}
+
+// TerminalOutputResult is the terminal's captured output so far.
+type TerminalOutputResult struct {
+	Output     string              `json:"output"`
+	Truncated  bool                `json:"truncated"`
+	ExitStatus *TerminalExitStatus `json:"exitStatus,omitempty"`
+}
+
+// TerminalWaitResult reports how the command exited.
+type TerminalWaitResult struct {
+	ExitCode *int    `json:"exitCode,omitempty"`
+	Signal   *string `json:"signal,omitempty"`
+}
+
+// TerminalExitStatus mirrors TerminalWaitResult inside terminal/output.
+type TerminalExitStatus struct {
+	ExitCode *int    `json:"exitCode,omitempty"`
+	Signal   *string `json:"signal,omitempty"`
 }
 
 // --- session/cancel (client → agent notification) ---

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -79,6 +79,8 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 		Cwd:            p.Cwd,
 		Model:          p.Model,
 		EffortOverride: cloneStringPtr(p.EffortOverride),
+		FileOverlay:    p.FileOverlay,
+		Terminal:       p.Terminal,
 	})
 	f.mu.Unlock()
 	behavior := f.behavior

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -330,6 +330,16 @@ func (s *acpSession) swapModeID(id string) (old string) {
 	return old
 }
 
+// currentModeID returns the mode last reported to the client.
+func (s *acpSession) currentModeID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.modeID == "" {
+		return sessionModeDefault
+	}
+	return s.modeID
+}
+
 // currentCtrl returns the session's controller under mu. rebuildSession swaps
 // ctrl while holding mu, so any read of the field outside mu races with a
 // concurrent config rebuild; always go through this accessor unless mu is
@@ -659,7 +669,17 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	if err != nil {
 		return nil, err
 	}
-	return SessionLoadResult{Models: cfgState.Models, Modes: sessionModesState(sessionModeDefault), ConfigOptions: cfgState.ConfigOptions}, nil
+	return SessionLoadResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions}, nil
+}
+
+// sessionModesFor reports the modes state for a just-opened session: a session
+// already live in this process keeps whatever mode the user put it in (plan /
+// auto), so load/resume must not tell a reconnecting client "default".
+func (s *service) sessionModesFor(id string) *SessionModeState {
+	if sess := s.session(id); sess != nil {
+		return sessionModesState(sess.currentModeID())
+	}
+	return sessionModesState(sessionModeDefault)
 }
 
 // sessionResume restores a previously-saved session without replaying its
@@ -673,7 +693,7 @@ func (s *service) sessionResume(ctx context.Context, raw json.RawMessage) (any, 
 	if err != nil {
 		return nil, err
 	}
-	return SessionResumeResult{Models: cfgState.Models, Modes: sessionModesState(sessionModeDefault), ConfigOptions: cfgState.ConfigOptions}, nil
+	return SessionResumeResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions}, nil
 }
 
 func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) (SessionConfigState, error) {
@@ -1044,14 +1064,18 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	prevPath := cur.SessionPath()
 	carried := cur.History()
 
-	newCtrl, err := s.factory.NewSession(ctx, SessionParams{
+	rebuildParams := SessionParams{
 		Cwd:                cwd,
 		MCPServers:         mcpServers,
 		Sink:               sink,
 		Model:              cfgState.Model,
 		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
 		OnSessionRecovered: s.sessionRecoveredHandler(sess.id),
-	})
+	}
+	// The rebuilt controller must keep the client-capability wiring (fs
+	// overlay, host terminal) a model/effort switch would otherwise drop.
+	s.bindClientIO(&rebuildParams, sess.id)
+	newCtrl, err := s.factory.NewSession(ctx, rebuildParams)
 	if err != nil {
 		return &RPCError{Code: ErrInternal, Message: "session config: " + err.Error()}
 	}
@@ -1059,6 +1083,15 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	sink.bindApprove(newCtrl.Approve)
 	sink.bindAnswer(newCtrl.AnswerQuestion)
 	newCtrl.AdoptHistory(carried, prevPath)
+	// Re-apply the session's ACP mode: a fresh controller boots with default
+	// switches, which would silently drop a user-selected plan/auto mode and
+	// desynchronize the client's mode picker.
+	switch sess.currentModeID() {
+	case sessionModePlan:
+		newCtrl.SetMode(true, false)
+	case sessionModeAuto:
+		newCtrl.SetMode(false, true)
+	}
 	// InheritLifecycleFrom wires two concrete controllers' turn/hook state; it's a
 	// construction concern, not part of the driving port. cur is always the
 	// *control.Controller the factory built for this session, so this is safe.

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -23,6 +23,7 @@ import (
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 	"reasonix/internal/store"
+	"reasonix/internal/tool/builtin"
 )
 
 // SessionParams is everything a Factory needs to assemble one ACP session's
@@ -45,6 +46,12 @@ type SessionParams struct {
 	Model              string
 	EffortOverride     *string
 	OnSessionRecovered func(control.SessionRecoveryInfo) error
+	// FileOverlay and Terminal are non-nil when the client advertised the
+	// matching capability at initialize: file tools then see unsaved editor
+	// buffers, and foreground bash can run in a client-owned terminal.
+	// Factories thread them into the controller's tool assembly.
+	FileOverlay builtin.FileOverlay
+	Terminal    builtin.TerminalRunner
 }
 
 // Factory builds the per-session controller. The composition root (the cli's
@@ -116,6 +123,7 @@ func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info 
 	conn.Handle("session/prompt", svc.sessionPrompt)
 	conn.Handle("session/set_config_option", svc.sessionSetConfigOption)
 	conn.Handle("session/set_model", svc.sessionSetModel)
+	conn.Handle("session/set_mode", svc.sessionSetMode)
 	conn.Handle("session/close", svc.sessionClose)
 	conn.Handle("session/list", svc.sessionList)
 	conn.Handle("session/delete", svc.sessionDelete)
@@ -133,6 +141,38 @@ type service struct {
 
 	mu       sync.Mutex
 	sessions map[string]*acpSession
+	// clientCaps is what the client offered at initialize (fs proxy, host
+	// terminals). Zero until initialize arrives; sessions opened later bind a
+	// clientIO built from it.
+	clientCaps ClientCapabilities
+}
+
+func (s *service) setClientCapabilities(caps ClientCapabilities) {
+	s.mu.Lock()
+	s.clientCaps = caps
+	s.mu.Unlock()
+}
+
+func (s *service) clientCapabilities() ClientCapabilities {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.clientCaps
+}
+
+// bindClientIO fills SessionParams' overlay/terminal fields from the client's
+// declared capabilities. The nil checks keep absent capabilities as nil
+// interface fields (a typed-nil *clientIO must never reach the interface).
+func (s *service) bindClientIO(p *SessionParams, sessionID string) {
+	io := newClientIO(s.conn, sessionID, s.clientCapabilities())
+	if !io.hasAny() {
+		return
+	}
+	if fo := io.fileOverlay(); fo != nil {
+		p.FileOverlay = fo
+	}
+	if tr := io.terminalRunner(); tr != nil {
+		p.Terminal = tr
+	}
 }
 
 // acpController is the slice of the controller's driving port the ACP transport
@@ -146,6 +186,9 @@ type acpController interface {
 	control.Approvals
 	control.Capabilities
 	control.SessionPersistence
+	// Goals is included for the session-mode surface only (PlanMode read-back
+	// after a turn); the goal FSM itself is not driven over ACP.
+	control.Goals
 }
 
 // acpSession is one open session: its controller, the on-disk transcript path
@@ -161,10 +204,14 @@ type acpSession struct {
 	model      string
 	// nil means use config; non-nil empty string means provider default.
 	effortOverride *string
-	pendingConfig  *SessionConfigState
-	title          string
-	createdAt      time.Time
-	updatedAt      time.Time
+	// modeID is the ACP session mode last reported to the client (default |
+	// plan | auto). Guarded by mu; compared after each turn so controller-side
+	// flips (plan mode auto-exit) surface as current_mode_update.
+	modeID        string
+	pendingConfig *SessionConfigState
+	title         string
+	createdAt     time.Time
+	updatedAt     time.Time
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -271,6 +318,16 @@ func (s *acpSession) finishMaintenance(done chan struct{}) {
 	if closeDone {
 		close(done)
 	}
+}
+
+// swapModeID records the mode reported to the client and returns the previous
+// value, so callers can emit current_mode_update only on change.
+func (s *acpSession) swapModeID(id string) (old string) {
+	s.mu.Lock()
+	old = s.modeID
+	s.modeID = id
+	s.mu.Unlock()
+	return old
 }
 
 // currentCtrl returns the session's controller under mu. rebuildSession swaps
@@ -385,7 +442,11 @@ func (s *service) sessionRecoveredHandler(id string) func(control.SessionRecover
 // list/resume/close/delete lifecycle helpers, prompts carrying inline resource
 // text (embeddedContext) but not image/audio, and stdio / Streamable HTTP MCP
 // (no legacy sse).
-func (s *service) initialize(_ context.Context, _ json.RawMessage) (any, error) {
+func (s *service) initialize(_ context.Context, raw json.RawMessage) (any, error) {
+	var p InitializeParams
+	if len(raw) > 0 && json.Unmarshal(raw, &p) == nil {
+		s.setClientCapabilities(p.ClientCapabilities)
+	}
 	return InitializeResult{
 		ProtocolVersion: ProtocolVersion,
 		AgentCapabilities: AgentCapabilities{
@@ -459,14 +520,17 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	}
 
 	sink := newUpdateSink(s.conn, id)
-	ctrl, err := s.factory.NewSession(ctx, SessionParams{
+	sink.bindCwd(cwd)
+	sessionParams := SessionParams{
 		Cwd:                cwd,
 		MCPServers:         mcpServers,
 		Sink:               sink,
 		Model:              cfgState.Model,
 		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
 		OnSessionRecovered: s.sessionRecoveredHandler(id),
-	})
+	}
+	s.bindClientIO(&sessionParams, id)
+	ctrl, err := s.factory.NewSession(ctx, sessionParams)
 	if err != nil {
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
 	}
@@ -483,6 +547,7 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 		mcpServers:     clonePluginSpecs(mcpServers),
 		model:          cfgState.Model,
 		effortOverride: cloneStringPtr(cfgState.EffortOverride),
+		modeID:         sessionModeDefault,
 		createdAt:      now,
 		updatedAt:      now,
 	}
@@ -510,8 +575,74 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	return SessionNewResult{
 		SessionID:     id,
 		Models:        cfgState.Models,
+		Modes:         sessionModesState(sessionModeDefault),
 		ConfigOptions: cfgState.ConfigOptions,
 	}, nil
+}
+
+// Session modes exposed over ACP, mapped onto the controller's approval
+// switches: default asks per write-capable call, plan flips the read-only plan
+// gate, auto approves tool calls without asking.
+const (
+	sessionModeDefault = "default"
+	sessionModePlan    = "plan"
+	sessionModeAuto    = "auto"
+)
+
+func sessionModesState(current string) *SessionModeState {
+	return &SessionModeState{
+		CurrentModeID: current,
+		AvailableModes: []SessionMode{
+			{ID: sessionModeDefault, Name: "Always Ask", Description: "Ask before write-capable tool calls"},
+			{ID: sessionModePlan, Name: "Plan", Description: "Read-only research and planning; no writes or commands"},
+			{ID: sessionModeAuto, Name: "Auto-Approve", Description: "Run tool calls without asking"},
+		},
+	}
+}
+
+// sessionSetMode switches the session's operating mode and confirms it with a
+// current_mode_update, per the ACP session-mode contract.
+func (s *service) sessionSetMode(_ context.Context, raw json.RawMessage) (any, error) {
+	var p SessionSetModeParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_mode: " + err.Error()}
+	}
+	sess := s.session(p.SessionID)
+	if sess == nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_mode: unknown session " + p.SessionID}
+	}
+	ctrl := sess.currentCtrl()
+	switch p.ModeID {
+	case sessionModeDefault:
+		ctrl.SetMode(false, false)
+	case sessionModePlan:
+		ctrl.SetMode(true, false)
+	case sessionModeAuto:
+		ctrl.SetMode(false, true)
+	default:
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_mode: unknown modeId " + p.ModeID}
+	}
+	if sess.swapModeID(p.ModeID) != p.ModeID {
+		sess.sink.send(currentModeUpdate{SessionUpdate: "current_mode_update", CurrentModeID: p.ModeID})
+	}
+	return SessionSetModeResult{}, nil
+}
+
+// emitModeDrift reports controller-side mode flips (plan mode auto-exits when
+// a plan is approved, a config rebuild resets switches) as current_mode_update
+// so the client's mode picker stays truthful.
+func (s *service) emitModeDrift(sess *acpSession) {
+	ctrl := sess.currentCtrl()
+	current := sessionModeDefault
+	switch {
+	case ctrl.PlanMode():
+		current = sessionModePlan
+	case ctrl.AutoApproveTools():
+		current = sessionModeAuto
+	}
+	if sess.swapModeID(current) != current {
+		sess.sink.send(currentModeUpdate{SessionUpdate: "current_mode_update", CurrentModeID: current})
+	}
 }
 
 // sessionLoad resumes a previously-saved session by id: it builds a controller
@@ -528,7 +659,7 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	if err != nil {
 		return nil, err
 	}
-	return SessionLoadResult{Models: cfgState.Models, ConfigOptions: cfgState.ConfigOptions}, nil
+	return SessionLoadResult{Models: cfgState.Models, Modes: sessionModesState(sessionModeDefault), ConfigOptions: cfgState.ConfigOptions}, nil
 }
 
 // sessionResume restores a previously-saved session without replaying its
@@ -542,7 +673,7 @@ func (s *service) sessionResume(ctx context.Context, raw json.RawMessage) (any, 
 	if err != nil {
 		return nil, err
 	}
-	return SessionResumeResult{Models: cfgState.Models, ConfigOptions: cfgState.ConfigOptions}, nil
+	return SessionResumeResult{Models: cfgState.Models, Modes: sessionModesState(sessionModeDefault), ConfigOptions: cfgState.ConfigOptions}, nil
 }
 
 func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) (SessionConfigState, error) {
@@ -564,7 +695,9 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		}
 		if replay {
 			ctrl := sess.currentCtrl()
-			newUpdateSink(s.conn, id).replay(ctrl.History())
+			replaySink := newUpdateSink(s.conn, id)
+			replaySink.bindCwd(sess.cwd)
+			replaySink.replay(ctrl.History())
 		}
 		cfgState, err := s.configStateForSession(ctx, sess)
 		if err != nil {
@@ -600,14 +733,17 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	}
 
 	sink := newUpdateSink(s.conn, id)
-	ctrl, err := s.factory.NewSession(ctx, SessionParams{
+	sink.bindCwd(cwd)
+	sessionParams := SessionParams{
 		Cwd:                cwd,
 		MCPServers:         mcpServers,
 		Sink:               sink,
 		Model:              cfgState.Model,
 		EffortOverride:     cloneStringPtr(cfgState.EffortOverride),
 		OnSessionRecovered: s.sessionRecoveredHandler(id),
-	})
+	}
+	s.bindClientIO(&sessionParams, id)
+	ctrl, err := s.factory.NewSession(ctx, sessionParams)
 	if err != nil {
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
@@ -653,6 +789,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		mcpServers:     clonePluginSpecs(mcpServers),
 		model:          cfgState.Model,
 		effortOverride: cloneStringPtr(cfgState.EffortOverride),
+		modeID:         sessionModeDefault,
 		title:          meta.Title,
 		createdAt:      meta.CreatedAt,
 		updatedAt:      meta.UpdatedAt,
@@ -741,6 +878,7 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		sess.sink.clearTurnContext()
 		sess.finish()
 		s.reportPendingSessionConfigError(ctx, sess, s.applyPendingSessionConfig(ctx, sess), "after turn")
+		s.emitModeDrift(sess)
 		cancel()
 	}()
 	runErr := sess.ctrl.RunTurn(runCtx, text)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -127,6 +127,12 @@ type Options struct {
 	// local UI metadata to automatic transcript recovery branches.
 	SessionRecoveryMeta func(control.SessionRecoveryRequest) agent.BranchMeta
 	OnSessionRecovered  func(control.SessionRecoveryInfo) error
+	// FileOverlay and TerminalRunner let a host transport (ACP) serve file
+	// content from editor buffers and run foreground bash in a host terminal.
+	// Both only change where tool I/O happens — tool names, descriptions, and
+	// schemas stay byte-identical, so the provider-visible surface is unchanged.
+	FileOverlay    builtin.FileOverlay
+	TerminalRunner builtin.TerminalRunner
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -347,7 +353,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		enabledBuiltins = tokenEconomyBuiltins(enabledBuiltins)
 	}
 	readPathResolver := builtin.NewPathResolver()
-	addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig)
+	addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner)
 	// Use the caller-supplied shared host when set, so controllers for the same
 	// workspace root reuse running MCP processes (e.g. one CodeGraph daemon
 	// instead of one per tab). Otherwise construct a private host per controller.
@@ -1515,12 +1521,12 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // and makes bash warn when a command references them. managedConfig names the
 // Reasonix-owned config files writable outside writeRoots after a fresh
 // per-write human approval.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths, overlay builtin.FileOverlay, terminal builtin.TerminalRunner) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig, FileOverlay: overlay, Terminal: terminal}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -2256,7 +2256,7 @@ model = "x"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{})
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil)
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -83,6 +83,8 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		ExtraPlugins:             p.MCPServers,
 		CleanupPendingReconciler: acp.ReconcileCleanupPending,
 		OnSessionRecovered:       p.OnSessionRecovered,
+		FileOverlay:              p.FileOverlay,
+		TerminalRunner:           p.Terminal,
 	})
 }
 

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -60,6 +60,12 @@ func SetRedactToolOutput(enabled bool) { redactToolOutputEnabled.Store(enabled) 
 // filter_subprocess_env).
 func SetFilterSubprocessEnv(enabled bool) { filterSubprocessEnvEnabled.Store(enabled) }
 
+// FilterSubprocessEnv reports whether credential-like variables are stripped
+// from tool subprocess environments. Callers that would launch a command in an
+// environment they cannot filter (a host-owned terminal, say) must check this
+// and keep execution local.
+func FilterSubprocessEnv() bool { return filterSubprocessEnvEnabled.Load() }
+
 // SetProtectSensitiveFiles enables or disables the built-in credential-path
 // read denylist for read/list/search tools ([secrets] protect_sensitive_files).
 func SetProtectSensitiveFiles(enabled bool) { protectSensitiveFilesEnabled.Store(enabled) }

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -176,9 +176,11 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	// A host-owned terminal runs the command where the user watches it live.
 	// Never when the OS sandbox is enforcing (the host cannot honor the local
-	// confinement config) and never for background jobs. ok=false falls back to
-	// local execution unchanged.
-	if b.terminal != nil && !p.RunInBackground && !b.sb.Enforce() {
+	// confinement config), never when [secrets].filter_subprocess_env is on
+	// (the host terminal spawns with its own unfiltered environment, which
+	// would leak the credentials the user asked to strip), and never for
+	// background jobs. ok=false falls back to local execution unchanged.
+	if b.terminal != nil && !p.RunInBackground && !b.sb.Enforce() && !secrets.FilterSubprocessEnv() {
 		if out, ok, err := b.terminal.RunCommand(ctx, p.Command, b.workDir, b.timeout); ok {
 			return appendSessionDataHint(out, b.guard.CommandHint(b.workDir, p.Command)), err
 		}

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -89,6 +89,11 @@ type bash struct {
 	guard   SessionDataGuard
 	workDir string
 	timeout time.Duration
+	// terminal, when non-nil, runs foreground commands in a host-owned terminal
+	// (ACP terminal/*). Only consulted when the local OS sandbox is not
+	// enforcing — a host terminal cannot honor the confinement configuration —
+	// and never for background jobs, which need the local job manager.
+	terminal TerminalRunner
 }
 
 type bashParams struct {
@@ -167,6 +172,16 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		return "", fmt.Errorf("this shell is Windows PowerShell, which does not parse '&&' or '||'. " +
 			"Sequence with ';' (both run regardless of the first's result), use 'if ($?) { ... }' for " +
 			"conditional chaining, or issue the commands as separate calls")
+	}
+
+	// A host-owned terminal runs the command where the user watches it live.
+	// Never when the OS sandbox is enforcing (the host cannot honor the local
+	// confinement config) and never for background jobs. ok=false falls back to
+	// local execution unchanged.
+	if b.terminal != nil && !p.RunInBackground && !b.sb.Enforce() {
+		if out, ok, err := b.terminal.RunCommand(ctx, p.Command, b.workDir, b.timeout); ok {
+			return appendSessionDataHint(out, b.guard.CommandHint(b.workDir, p.Command)), err
+		}
 	}
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.

--- a/internal/tool/builtin/clientio.go
+++ b/internal/tool/builtin/clientio.go
@@ -1,0 +1,33 @@
+package builtin
+
+import (
+	"context"
+	"time"
+)
+
+// FileOverlay lets a host transport (an ACP client editor, say) serve file
+// content instead of the local disk, so tools see unsaved editor buffers. A
+// nil overlay or an ok=false answer falls back to direct disk I/O; the overlay
+// is consulted only after the tool's own path resolution and confinement
+// checks, so it never widens what a tool may touch.
+type FileOverlay interface {
+	// ReadTextFile returns the current text of path as the host sees it
+	// (including unsaved changes). ok=false means the host cannot serve this
+	// path and the caller should read the local disk instead.
+	ReadTextFile(ctx context.Context, path string) (content string, ok bool)
+	// WriteTextFile asks the host to write content to path (updating any open
+	// buffer as well as the file). ok=false means the host cannot handle the
+	// write and the caller should write the local disk instead; err is only
+	// meaningful when ok is true.
+	WriteTextFile(ctx context.Context, path, content string) (ok bool, err error)
+}
+
+// TerminalRunner lets a host transport run a foreground shell command in a
+// host-owned terminal (the ACP terminal/* methods, say) so the user watches it
+// live. ok=false means the host cannot run it and the caller should execute
+// locally; err is only meaningful when ok is true. Runners are only consulted
+// when the local OS sandbox is not enforcing — a host terminal cannot honor
+// the local confinement configuration.
+type TerminalRunner interface {
+	RunCommand(ctx context.Context, command, cwd string, timeout time.Duration) (output string, ok bool, err error)
+}

--- a/internal/tool/builtin/clientio_test.go
+++ b/internal/tool/builtin/clientio_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 )
 
 // fakeOverlay serves a fixed path→content map and records writes.
@@ -163,5 +164,21 @@ func TestBashTerminalSkippedWhenSandboxEnforced(t *testing.T) {
 	_, _ = b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
 	if len(term.called) != 0 {
 		t.Fatalf("enforced sandbox must never route to the client terminal; calls = %v", term.called)
+	}
+}
+
+func TestBashTerminalSkippedWhenEnvFilteringEnabled(t *testing.T) {
+	secrets.SetFilterSubprocessEnv(true)
+	t.Cleanup(func() { secrets.SetFilterSubprocessEnv(false) })
+	term := &fakeTerminal{out: "must not run", ok: true}
+	b := bash{workDir: t.TempDir(), terminal: term}
+	// The client terminal spawns with its own unfiltered environment, so an
+	// enabled [secrets].filter_subprocess_env must force local execution.
+	out, err := b.Execute(context.Background(), json.RawMessage(`{"command":"printf local"}`))
+	if err != nil || !strings.Contains(out, "local") {
+		t.Fatalf("env filtering must fall back to local execution; got %q, %v", out, err)
+	}
+	if len(term.called) != 0 {
+		t.Fatalf("env filtering must never route to the client terminal; calls = %v", term.called)
 	}
 }

--- a/internal/tool/builtin/clientio_test.go
+++ b/internal/tool/builtin/clientio_test.go
@@ -1,0 +1,167 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/sandbox"
+)
+
+// fakeOverlay serves a fixed path→content map and records writes.
+type fakeOverlay struct {
+	files  map[string]string
+	writes map[string]string
+	wErr   error
+}
+
+func (f *fakeOverlay) ReadTextFile(_ context.Context, path string) (string, bool) {
+	content, ok := f.files[path]
+	return content, ok
+}
+
+func (f *fakeOverlay) WriteTextFile(_ context.Context, path, content string) (bool, error) {
+	if f.writes == nil {
+		return false, nil
+	}
+	if f.wErr != nil {
+		return true, f.wErr
+	}
+	f.writes[path] = content
+	return true, nil
+}
+
+func TestReadFileOverlayServesBufferContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(path, []byte("disk line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlay := &fakeOverlay{files: map[string]string{path: "buffer line one\nbuffer line two\n"}}
+	rf := readFile{workDir: dir, overlay: overlay}
+
+	out, err := rf.Execute(context.Background(), json.RawMessage(`{"path":"a.go"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "buffer line one") || strings.Contains(out, "disk line") {
+		t.Fatalf("overlay content should win over disk; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1→") && !strings.Contains(out, "1\t") {
+		t.Fatalf("overlay content must keep the numbered-line rendering; got:\n%s", out)
+	}
+}
+
+func TestReadFileOverlayFallsBackToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "b.go")
+	if err := os.WriteFile(path, []byte("disk only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rf := readFile{workDir: dir, overlay: &fakeOverlay{files: map[string]string{}}}
+	out, err := rf.Execute(context.Background(), json.RawMessage(`{"path":"b.go"}`))
+	if err != nil || !strings.Contains(out, "disk only") {
+		t.Fatalf("overlay miss must fall back to disk; got %q, %v", out, err)
+	}
+}
+
+func TestWriteFileOverlayAppliesWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c.go")
+	overlay := &fakeOverlay{writes: map[string]string{}}
+	wf := writeFile{workDir: dir, roots: realRoots([]string{dir}), overlay: overlay}
+
+	args, _ := json.Marshal(map[string]string{"path": "c.go", "content": "hello"})
+	out, err := wf.Execute(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if overlay.writes[path] != "hello" {
+		t.Fatalf("overlay writes = %v, want %s→hello", overlay.writes, path)
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		t.Fatal("overlay-handled write must not also write the local disk")
+	}
+	if !strings.Contains(out, "wrote 5 bytes") {
+		t.Fatalf("output = %q", out)
+	}
+
+	// A client-side write failure surfaces instead of silently double-applying.
+	overlay.wErr = fmt.Errorf("readonly buffer")
+	if _, err := wf.Execute(context.Background(), json.RawMessage(args)); err == nil {
+		t.Fatal("overlay write error must surface")
+	}
+}
+
+func TestWriteFileOverlaySkipsNonUTF8(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "utf16.txt")
+	// UTF-16LE BOM + "hi" — the overlay is text-only, so this file must stay on
+	// the local encoding-preserving path.
+	if err := os.WriteFile(path, []byte{0xFF, 0xFE, 'h', 0, 'i', 0}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlay := &fakeOverlay{writes: map[string]string{}}
+	wf := writeFile{workDir: dir, roots: realRoots([]string{dir}), overlay: overlay}
+	args, _ := json.Marshal(map[string]string{"path": "utf16.txt", "content": "changed"})
+	if _, err := wf.Execute(context.Background(), json.RawMessage(args)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(overlay.writes) != 0 {
+		t.Fatalf("non-UTF-8 target must bypass the overlay; writes = %v", overlay.writes)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil || len(b) < 2 || b[0] != 0xFF || b[1] != 0xFE {
+		t.Fatalf("local write must preserve the UTF-16 BOM; got % x, %v", b, err)
+	}
+}
+
+// fakeTerminal records commands and returns a scripted result.
+type fakeTerminal struct {
+	out    string
+	ok     bool
+	err    error
+	called []string
+}
+
+func (f *fakeTerminal) RunCommand(_ context.Context, command, _ string, _ time.Duration) (string, bool, error) {
+	f.called = append(f.called, command)
+	return f.out, f.ok, f.err
+}
+
+func TestBashRoutesToClientTerminal(t *testing.T) {
+	term := &fakeTerminal{out: "client says hi", ok: true}
+	b := bash{workDir: t.TempDir(), terminal: term}
+	out, err := b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
+	if err != nil || out != "client says hi" {
+		t.Fatalf("Execute = %q, %v", out, err)
+	}
+	if len(term.called) != 1 || term.called[0] != "echo hi" {
+		t.Fatalf("terminal calls = %v", term.called)
+	}
+}
+
+func TestBashTerminalFallsBackWhenUnhandled(t *testing.T) {
+	term := &fakeTerminal{ok: false}
+	b := bash{workDir: t.TempDir(), terminal: term}
+	out, err := b.Execute(context.Background(), json.RawMessage(`{"command":"printf local"}`))
+	if err != nil || !strings.Contains(out, "local") {
+		t.Fatalf("unhandled terminal must fall back to local execution; got %q, %v", out, err)
+	}
+}
+
+func TestBashTerminalSkippedWhenSandboxEnforced(t *testing.T) {
+	term := &fakeTerminal{out: "must not run", ok: true}
+	b := bash{workDir: t.TempDir(), sb: sandbox.Spec{Mode: "enforce"}, terminal: term}
+	// The command itself may fail (no sandbox binary in the test env); the
+	// assertion is only that the client terminal was never consulted.
+	_, _ = b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
+	if len(term.called) != 0 {
+		t.Fatalf("enforced sandbox must never route to the client terminal; calls = %v", term.called)
+	}
+}

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/text/transform"
@@ -34,6 +35,10 @@ type readFile struct {
 	workDir     string
 	paths       *PathResolver
 	forbidRoots []string
+	// overlay, when non-nil, serves content from the host transport (unsaved
+	// editor buffers) before falling back to disk. Consulted only after path
+	// resolution and read confinement, and never for external alias paths.
+	overlay FileOverlay
 }
 
 const (
@@ -93,6 +98,15 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	if p.Limit <= 0 {
 		p.Limit = readFileDefaultLimit
+	}
+
+	// The host overlay (unsaved editor buffers) wins over the disk when it can
+	// serve the path. Content arrives already decoded as text, so the encoding
+	// and binary-detection pipeline below applies to the disk fallback only.
+	if r.overlay != nil && !rp.External && filepath.IsAbs(p.Path) {
+		if content, ok := r.overlay.ReadTextFile(ctx, p.Path); ok {
+			return r.scan(strings.NewReader(content), p.Offset, p.Limit)
+		}
 	}
 
 	// A directory can be os.Open'd but not read as text — catch it up front with

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -39,6 +39,12 @@ type Workspace struct {
 	// touch outside WriteRoots after a fresh per-write human approval (see
 	// ManagedConfigPaths). The zero value disables the escape hatch.
 	ManagedConfig ManagedConfigPaths
+	// FileOverlay, when non-nil, serves read_file/write_file content through the
+	// host transport (unsaved editor buffers) with disk fallback; Terminal, when
+	// non-nil, runs foreground bash in a host-owned terminal when the local OS
+	// sandbox is not enforcing. Both are nil outside host transports like ACP.
+	FileOverlay FileOverlay
+	Terminal    TerminalRunner
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -55,8 +61,8 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 	forbidRoots := realRoots(w.ForbidReadRoots)
 
 	overrides := map[string]tool.Tool{
-		"read_file":     readFile{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
-		"write_file":    writeFile{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
+		"read_file":     readFile{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots, overlay: w.FileOverlay},
+		"write_file":    writeFile{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig, overlay: w.FileOverlay},
 		"edit_file":     editFile{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"multi_edit":    multiEdit{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"move_file":     moveFile{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
@@ -64,7 +70,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"delete_range":  deleteRange{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"delete_symbol": deleteSymbol{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"code_index":    codeIndex{workDir: w.Dir, forbidRoots: forbidRoots},
-		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout, guard: w.SessionGuard},
+		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout, guard: w.SessionGuard, terminal: w.Terminal},
 		"ls":            listDir{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
 		"glob":          globTool{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
 		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash},

--- a/internal/tool/builtin/writefile.go
+++ b/internal/tool/builtin/writefile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/tool"
 )
 
@@ -22,6 +23,11 @@ type writeFile struct {
 	guard   SessionDataGuard
 	managed ManagedConfigPaths
 	workDir string
+	// overlay, when non-nil, routes the write through the host transport so an
+	// open editor buffer updates too. Consulted only after write confinement,
+	// and only for plain-UTF-8 targets (the overlay is text-only, so non-UTF-8
+	// files keep the local encoding-preserving path).
+	overlay FileOverlay
 }
 
 func (writeFile) Name() string { return "write_file" }
@@ -58,6 +64,17 @@ func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, e
 	existing, enc, rerr := readFileEncoded(p.Path)
 	if rerr == nil && existing == p.Content {
 		return fmt.Sprintf("%s already contains the exact content; no changes made", p.Path), nil
+	}
+	// The host overlay applies the write to the editor buffer and the file in
+	// one step. Text-only, so it handles plain UTF-8 targets (and new files);
+	// non-UTF-8 files stay on the local encoding-preserving path below.
+	if w.overlay != nil && filepath.IsAbs(p.Path) && (rerr != nil || enc == fileenc.UTF8) {
+		if ok, werr := w.overlay.WriteTextFile(ctx, p.Path, p.Content); ok {
+			if werr != nil {
+				return "", fmt.Errorf("write %s: %w", p.Path, werr)
+			}
+			return fmt.Sprintf("wrote %d bytes to %s", len(p.Content), p.Path), nil
+		}
 	}
 	if dir := filepath.Dir(p.Path); dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {


### PR DESCRIPTION
## Problem

Reasonix's ACP agent covered the core loop (sessions, prompts, tool streaming, permissions, persistence) but left the spec's optional client-integration surface unused:

1. `clientCapabilities` from `initialize` were accepted and ignored — the agent never called `fs/read_text_file` / `fs/write_text_file`, so it read stale disk content while the user had unsaved changes in the editor, and its writes did not update open buffers.
2. `tool_call` updates carried no `locations`, so clients could not follow along in the editor.
3. `todo_write` task lists never surfaced as ACP `plan` updates.
4. No session modes: no `session/set_mode`, no `current_mode_update`, no modes in `session/new` results — clients' mode pickers (ask / plan / auto) had nothing to bind to.
5. Client `terminal/*` capability was unused.

## Changes

**fs proxy** — `initialize` records `clientCapabilities`. Each session binds a `clientIO` (new `internal/acp/clientio.go`) implementing two small interfaces threaded through `boot.Options` into `builtin.Workspace`:

- `read_file` consults the overlay first and serves the client's buffer view through the same numbered-line renderer; any client error or missing capability falls back to disk. External alias paths (`PathResolver`) never use the overlay.
- `write_file` routes through `fs/write_text_file` (client updates buffer + disk) after the normal write confinement and session-data guard; non-UTF-8 targets stay on the local encoding-preserving path since the ACP fs is text-only. A client-side write error surfaces instead of falling back (fallback could double-apply).
- `edit_file`/`multi_edit` and friends intentionally stay on disk: they need byte-level encoding/CRLF fidelity the text-only fs methods cannot guarantee.

**tool_call locations** — file-targeting builtins (`read_file`, `write_file`, `edit_file`, `multi_edit`, `notebook_edit`, `delete_range`, `delete_symbol`, `code_index`) now emit `locations: [{path, line?}]`; `read_file`'s 0-based `offset` maps to a 1-based `line`. Relative arg paths are absolutized against the session cwd. Search/list tools are excluded (their path is a scope, not a file target).

**plan updates** — `todo_write` dispatches mirror as `plan` session updates (complete-list replacement, matching the todo_write contract): level 0 phases → `high` priority, level 1 sub-steps → `medium`; unknown statuses degrade to `pending`. Also emitted during `session/load` replay so the restored view includes the latest plan.

**session modes** — `session/new`/`load`/`resume` results carry `modes` (`default` = ask, `plan` = read-only plan gate, `auto` = auto-approve), mapped onto the controller's existing `SetMode(plan, autoApprove)` switches. `session/set_mode` switches and confirms with `current_mode_update`; controller-side flips (plan-mode auto-exit on plan approval, config rebuild resets) are detected after each turn and reported the same way.

**terminal** — when the client offers `terminal/*`, foreground bash runs in a client-owned terminal (`terminal/create` → `wait_for_exit` → `output` → `release`, `kill` + output capture on timeout; nonzero exit / signal surface as errors with the captured output). Two hard safety rules: never used when the local OS sandbox is enforcing (a host terminal cannot honor the confinement config — the user's sandbox setting wins), and never for background jobs (they need the local job manager). The permission gate and session-data guard hints apply unchanged. Missing capability or a failed `terminal/create` falls back to local execution.

## Backward compatibility

| Surface | Old behavior | Conclusion |
| --- | --- | --- |
| Clients that send no `clientCapabilities` | Zero-value caps → all nil interfaces → byte-for-byte previous behavior | safe |
| Old clients vs new result fields (`modes`, `locations`, `plan`) | Additive `omitempty` fields / new update kinds; ACP clients ignore unknown update kinds by design | safe |
| `session/set_mode` on clients that never call it | Sessions stay in `default`; `current_mode_update` only fires on change | safe |
| Persisted transcripts / session meta | No format change; modes are runtime-only state | safe |
| Non-ACP frontends (CLI, desktop, serve) | `boot.Options` fields default nil → `builtin.Workspace` unchanged | safe |
| Non-UTF-8 / binary files under fs proxy | Overlay skipped; local encoding-preserving path keeps GBK/UTF-16/BOM round-trips | safe (regression-tested) |

## Verification

- `gofmt -l` clean; `go vet ./...` clean
- `go test ./internal/acp ./internal/tool/builtin ./internal/boot ./internal/cli` — pass
- Full root `go test ./...` — pass
- `cd desktop && go build ./... && go test` (all packages except `cmd/sign`, OOM-bound on this box, no dependency on `reasonix/internal`) — pass
- `./scripts/cache-guard.sh` — 8/8 cases pass, tail_avg 92–95 vs threshold 90
- New regression tests: `TestClientIOReadWriteTextFile`, `TestClientIORunCommandLifecycle`, `TestUpdateSinkToolLocations`, `TestPlanEntriesFromTodoArgs`, `TestUpdateSinkEmitsPlanForTodoWrite`, `TestSessionParamsCarryClientIOFromInitializeCaps`, `TestSessionParamsNilClientIOWithoutCaps`, `TestE2ESessionModes`, `TestReadFileOverlayServesBufferContent`, `TestReadFileOverlayFallsBackToDisk`, `TestWriteFileOverlayAppliesWrite`, `TestWriteFileOverlaySkipsNonUTF8`, `TestBashRoutesToClientTerminal`, `TestBashTerminalFallsBackWhenUnhandled`, `TestBashTerminalSkippedWhenSandboxEnforced`

## Notes for reviewers

- `terminal/create` sends the shell command string as `command` with no `args`, matching how ACP clients hand it to their shell; flagged here in case a strict client expects an argv split.
- The stop-reason set and prompt capabilities (image/audio) are intentionally untouched — separate decisions.

Cache-impact: low - tool names, descriptions, and schemas are byte-identical (regression-guarded by the untouched tool surface and cache guard); the overlay/terminal only change where I/O happens, and all new wire surface is ACP-side (not provider-visible).
Cache-guard: scripts/cache-guard.sh pass (8/8 cases, tail_avg 92–95, threshold 90).
System-prompt-review: no system-prompt bytes change — boot's prompt assembly and the skills index are untouched; the boot change is two new nil-default Options fields threaded into builtin.Workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
