### PR TITLE
fix(site): correct docs sidebar active-section highlight

### DIFF
--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -116,13 +116,39 @@
   if (sideLinks.length) {
     const targets = sideLinks
       .map((a) => document.getElementById(a.getAttribute("href").slice(1)))
-      .filter(Boolean);
+      .filter(Boolean)
+      // Sidebar links are grouped editorially, so their order differs from the
+      // page order. The spy below picks the last section past the 140px line,
+      // which is only correct when targets are sorted in document order.
+      .sort((a, b) =>
+        a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1);
+    const setActive = (id) =>
+      sideLinks.forEach((a) => {
+        const on = a.getAttribute("href") === "#" + id;
+        a.classList.toggle("active", on);
+        if (on) a.setAttribute("aria-current", "true");
+        else a.removeAttribute("aria-current");
+      });
+    // While a click smooth-scrolls to a section, pin the highlight to it so it
+    // doesn't sweep through every section scrolled past on the way. scrollend
+    // releases the pin when the scroll settles — on arrival or when the user
+    // takes over (wheel, touch, keyboard, scrollbar). Browsers without
+    // scrollend just skip pinning: correct destination, no sweep suppression.
+    let pinned = null;
     const spy = () => {
+      if (pinned) return;
       let current = targets[0];
       for (const t of targets) if (t.getBoundingClientRect().top < 140) current = t;
-      sideLinks.forEach((a) =>
-        a.classList.toggle("active", current && a.getAttribute("href") === "#" + current.id));
+      if (current) setActive(current.id);
     };
+    if ("onscrollend" in window) {
+      const ids = new Set(targets.map((t) => t.id));
+      document.querySelectorAll("a[href^='#']").forEach((a) => {
+        const id = a.getAttribute("href").slice(1);
+        if (ids.has(id)) a.addEventListener("click", () => { pinned = id; setActive(id); });
+      });
+      window.addEventListener("scrollend", () => { pinned = null; spy(); }, { passive: true });
+    }
     window.addEventListener("scroll", spy, { passive: true });
     spy();
   }


### PR DESCRIPTION
## Summary

The sidebar on `/docs/` highlights the wrong section, and clicking an item makes the highlight flash through a couple of sections before it lands. Clicking "Model keys", for example, flashes "Browser UI" on the way.

Two things were going on:

1. The scrollspy collects its sections from the sidebar links, then treats the last one you've scrolled past as the current section. That only holds if the sections are in page order, but the sidebar is grouped by topic (Start / Daily use / Understand), so the order doesn't match the page. Sorting the sections by document position fixes the wrong-item part.

2. The page scrolls with `scroll-behavior: smooth`, so a click animates the scroll and the spy runs on every frame, dragging the highlight through everything it passes. The clicked section is now pinned until the scroll settles (`scrollend`), so it goes straight there. It's feature-detected, so a browser without `scrollend` just falls back to the normal behavior.

I also added `aria-current="true"` to the active link so screen readers can tell which section is current.

Only `site/src/scripts/site.js` changes.

### Before (the bug)

https://github.com/user-attachments/assets/5acced9d-abe8-48cc-9724-e3d1cbc9bf42




### After (the fix)

https://github.com/user-attachments/assets/ce475256-4e93-4e2d-a083-1e9ac42bd090


## Verification

- `node --check site/src/scripts/site.js` passes
- `npm run dev`, then clicked every sidebar item and the hero cards: the highlight lands on the right section, no flash, and follows manual scrolling
- Confirmed the fallback (no `scrollend`) still lands on the right section

## Cache impact

Cache-impact: none (docs site JS only; no prompts, tools, or provider requests touched)
Cache-guard: n/a
System-prompt-review: N/A

---

Not in this PR: the sidebar's topic grouping doesn't follow the page's section order, which is the underlying reason the spy needed sorting. Realigning them is an editorial call, so I left it out and can file a separate issue if that's wanted. The global smooth scroll also ignores `prefers-reduced-motion`, which is worth its own change.
