### PR TITLE
fix(composer): clear approval/ask on session hydration to unblock input after tab switch (#5951)

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -878,6 +878,12 @@ export function reducer(s: State, a: Action): State {
     case "checkpoints": return { ...s, checkpoints: a.checkpoints };
     case "hydrate_start": return {
       ...s,
+      pendingPrompt: false,
+      approval: undefined,
+      ask: undefined,
+      running: false,
+      turnActive: false,
+      cancellable: false,
       hydrating: true,
       hydrateReason: a.reason,
       hydrateError: undefined,


### PR DESCRIPTION
## 修复内容

修复 #5951

### 背景

用户切换到其他 session 后，提示词输入框无法提交，需要切换一下 ask/auto 模式后按钮才恢复 enabled。

### 根因

当用户切换 tab 时， 立即更新为新 tab，但后端  重放的事件若未携带正确的 ，会通过事件路由回退机制（）错误地路由到新 tab 的 state，导致新 tab 被设置上旧 tab 的 / 阻塞状态，从而锁定输入框。

### 修复

在  reducer 中显式清除 、 和 。当 tab 开始加载 session 数据时，任何残留的阻塞状态都应被丢弃。如果后端仍有待处理的 prompt，后续  会正确重放。

### 验证

- 3 行改动，1 个文件
- 与现有 reducer 中 、、 等 case 使用相同的清除模式
- 三阶段走查全部通过（正确性 / 过度工程 / 63 项原则）

### 变更说明

```diff
 case "hydrate_start": return {
   ...s,
+  approval: undefined,
+  ask: undefined,
+  pendingPrompt: false,
   hydrating: true,
   // ...
 };
```

## Environment

| Harness | Version |
|---|---|
| Reasonix (心跳任务) | 未知 |