### PR TITLE
fix（windows-desktop）: remove --wails-draggable: drag from .sidebar on Windows ——Windows 侧边栏 `--wails-draggable: drag` # 导致误触窗口拖拽

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2033,7 +2033,6 @@ a[href] {
   padding: 12px 10px calc(12px + var(--statusbar-height));
   background: var(--sidebar-bg);
   border-right: 1px solid var(--border-soft);
-  --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
 }


### PR DESCRIPTION
# Fix: Sidebar `--wails-draggable: drag` causes window move on Windows
> 修复：Windows 侧边栏 `--wails-draggable: drag` 导致误触窗口拖拽

---

## Problem / 问题表现

**English.** Two mouse-behavior bugs on the Windows desktop client:

1. **Cursor unexpectedly becomes `ns-resize`.** Hovering the sidebar triggers the window border resize cursor — the OS thinks the pointer is at the window edge.
2. **Dragging the right-edge strip moves the whole window.** The `.sidebar-resizer` (8px-wide handle) fails to intercept; the drag is treated as a title-bar grab.

**Chinese.** Windows 桌面客户端存在两个鼠标行为异常：

1. **光标异常变为 `ns-resize`。** 鼠标悬停侧边栏时触发窗口边框 resize 光标。
2. **拖拽右侧细条导致窗口整体移动。** `.sidebar-resizer` 未能拦截，拖拽被当作标题栏抓取。

---

## Root Cause / 根因分析

**English.** Line 2036 of `desktop/frontend/src/styles.css`:
```css
.sidebar {
  ...
  --wails-draggable: drag;  /* ← makes the entire sidebar a window drag handle */
}
```
In Wails v2, `--wails-draggable: drag` marks an element as an OS-level drag region — same as a title bar. The sidebar is a navigation panel with buttons and a resize handle; it should never have been a drag region.

- **Bug 1.** Windows window-manager conflicts with drag regions near borders, switching to `ns-resize` cursor.
- **Bug 2.** `.sidebar-resizer` (8px, `left: calc(sidebar-width - 4px)`) overlaps with `.sidebar` by 4px. Pointer in the overlap hits `.sidebar` (drag) instead of `.sidebar-resizer` (no-drag). Sidebar-resize becomes window-move.

**Chinese.** `desktop/frontend/src/styles.css` 第 2036 行将 `.sidebar` 标记为窗口拖拽区域。侧边栏不是标题栏，不应是拖拽区域。

- **Bug 1.** Windows 窗口管理器与靠近边框的拖拽区域冲突，光标切换为 `ns-resize`。
- **Bug 2.** `.sidebar-resizer` 与 `.sidebar` 有 4px 重叠，指针落在重叠区时触发窗口拖拽而非侧边栏缩放。

---

## Fix / 修复

**Plan: Remove the rogue drag region.** Delete one line from `.sidebar`.

```diff
 .sidebar {
   ...
   border-right: 1px solid var(--border-soft);
-  --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
 }
 ```

**Why safe:**
- Interactive children already have `--wails-draggable: no-drag` — redundant but harmless.
- Other drag regions (`.topbar`, `.app-chrome`, `.workbench-dock__tools`) remain. Title-bar drag still works.
- No test changes — existing tests cover `.app-chrome` / `.workbench-dock`, not `.sidebar`.

**修改安全：**
- 子交互元素已有 `--wails-draggable: no-drag`，冗余但无害。
- 其他拖拽区域（顶栏、chrome、dock）不变，标题栏拖拽正常。
- 无需修改测试。

---

## Verification / 验证

```bash
# 1. Build Windows desktop client
cd desktop && wails build

# 2. Manual checks after launch:
#    — Hover sidebar: cursor stays normal (no ns-resize)
#    — Drag right-edge strip: sidebar resizes, window stays
#    — Drag top title bar: window moves normally

# 3. TypeScript compilation unaffected
cd desktop/frontend && tsc --noEmit
```

---

## Files / 文件

```
modified:   desktop/frontend/src/styles.css
```

**Only this file.** Build artifacts and temporary changes are cleaned.

**仅此文件。** 构建产物和临时变更已清理。
