### PR TITLE
Update website install options / 更新官网安装入口

### DIFF
--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -101,8 +101,8 @@ const R2_DESKTOP = `https://dl.reasonix.io/desktop-${desktopVersion}`;
 
       <h2 id="install"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></h2>
       <p><span class="l-en">Install the terminal app with one command on macOS, Linux, Windows, or WSL. <code>reasonix</code> opens the interactive TUI; <code>reasonix run</code> is the headless automation entry.</span><span class="l-zh">一条命令安装终端应用,支持 macOS、Linux、Windows 或 WSL。<code>reasonix</code> 打开交互式 TUI；<code>reasonix run</code> 用于无界面自动执行。</span></p>
-      <div class="codeblock"><button data-copy="npm i -g reasonix@next">Copy</button><span class="c"># npm (recommended · 推荐)</span>
-npm i -g reasonix@next
+      <div class="codeblock"><button data-copy="npm i -g reasonix">Copy</button><span class="c"># npm (recommended · 推荐)</span>
+npm i -g reasonix
 
 <span class="c"># Homebrew</span>
 brew install esengine/reasonix/reasonix</div>
@@ -125,7 +125,7 @@ brew install esengine/reasonix/reasonix</div>
           <li><span class="l-en">Scriptable runs through <code>reasonix run</code>, including piped input and explicit model selection.</span><span class="l-zh">可脚本化的 <code>reasonix run</code>,支持管道输入和显式模型选择。</span></li>
         </ul>
       </div>
-      <div class="callout"><span class="ico">!</span><span><span class="l-en">To install the legacy <strong>0.x</strong> version, run <code>npm i -g reasonix@latest</code>. The commands above, Homebrew, and desktop/release downloads install Reasonix 1.x; the current desktop download build is <strong>v<span class="rxv">{goVer}</span></strong>.</span><span class="l-zh">如需安装 legacy <strong>0.x</strong> 版本,命令是: <code>npm i -g reasonix@latest</code>。上方命令、Homebrew 与桌面端/Release 下载对应 Reasonix 1.x；当前桌面端下载构建为 <strong>v<span class="rxv">{goVer}</span></strong>。</span></span></div>
+      <div class="callout"><span class="ico">!</span><span><span class="l-en">To install the legacy <strong>0.x</strong> version, pin it explicitly with <code>npm i -g reasonix@0.53.2</code>. The commands above, Homebrew, and desktop/release downloads install Reasonix 1.x; the current desktop download build is <strong>v<span class="rxv">{goVer}</span></strong>.</span><span class="l-zh">如需安装 legacy <strong>0.x</strong> 版本,请显式 pin: <code>npm i -g reasonix@0.53.2</code>。上方命令、Homebrew 与桌面端/Release 下载对应 Reasonix 1.x；当前桌面端下载构建为 <strong>v<span class="rxv">{goVer}</span></strong>。</span></span></div>
 
       <h2 id="desktop"><span class="l-en">Desktop app</span><span class="l-zh">桌面端</span></h2>
       <div class="desktop-panel">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -78,15 +78,22 @@ const ld = {
         <span class="l-zh"><span class="grad">DeepSeek</span> 原生的<br />终端编码 Agent。</span>
       </h1>
       <p class="sub reveal" style="--d:0.12s">
-        <span class="l-en">The loop is append-only, aligned to DeepSeek's byte-stable prefix cache — so long sessions hold <b>90%+ cache hit</b> and input-token cost collapses to <b>~1/5</b>. Terminal-first, with a local browser UI when you want one.</span>
-        <span class="l-zh">运行循环 append-only,对齐 DeepSeek 字节稳定的 prefix-cache —— 长会话缓存命中 <b>90%+</b>,输入 token 成本降到 <b>约 1/5</b>。终端优先,需要时也可启动本地浏览器 UI。</span>
+        <span class="l-en">The loop is append-only, aligned to DeepSeek's byte-stable prefix cache — so long sessions hold <b>90%+ cache hit</b> and input-token cost collapses to <b>~1/5</b>. Use the same engine from the CLI/TUI, desktop app, or local browser UI.</span>
+        <span class="l-zh">运行循环 append-only,对齐 DeepSeek 字节稳定的 prefix-cache —— 长会话缓存命中 <b>90%+</b>,输入 token 成本降到 <b>约 1/5</b>。CLI/TUI、桌面端和本地浏览器 UI 共用同一引擎。</span>
       </p>
-      <div class="hero-cta reveal" style="--d:0.18s">
-        <a class="btn btn-dark" data-os-dl data-goto="desktop" href="#start"><span class="l-en">Download for <span class="os-name">macOS</span></span><span class="l-zh">下载 <span class="os-name">macOS</span> 版</span></a>
-        <span class="install"><span class="ps1">$</span>npm i -g reasonix@next<button data-copy="npm i -g reasonix@next">Copy</button></span>
-        <a class="btn btn-ghost" href="#how"><span class="l-en">How it works ↓</span><span class="l-zh">工作原理 ↓</span></a>
+      <div class="hero-install reveal" style="--d:0.18s" aria-label="Reasonix install options">
+        <div class="install-option install-option--desktop">
+          <span class="install-kicker"><span class="l-en">Desktop app</span><span class="l-zh">桌面端</span></span>
+          <strong><span class="l-en">Visual workspace for sessions, settings, approvals, and updates.</span><span class="l-zh">可视化管理会话、设置、审批与自动更新。</span></strong>
+          <a class="btn btn-dark" data-os-dl data-goto="desktop" href="#start"><span class="l-en">Download desktop</span><span class="l-zh">下载桌面版</span></a>
+        </div>
+        <div class="install-option install-option--cli">
+          <span class="install-kicker"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></span>
+          <strong><span class="l-en">Terminal-native agent with the same local Reasonix engine.</span><span class="l-zh">终端原生入口,使用同一套本地 Reasonix 引擎。</span></strong>
+          <span class="install"><span class="ps1">$</span>npm i -g reasonix<button data-copy="npm i -g reasonix">Copy</button></span>
+        </div>
       </div>
-      <div class="also reveal" style="--d:0.22s"><span class="l-en">Also via <a href="#start" data-goto="brew">Homebrew</a> and <a href="#start" data-goto="desktop">desktop apps</a> · run <code>reasonix serve</code> for the browser UI</span><span class="l-zh">也可通过 <a href="#start" data-goto="brew">Homebrew</a> 与<a href="#start" data-goto="desktop">桌面端</a>安装 · 运行 <code>reasonix serve</code> 打开浏览器 UI</span></div>
+      <div class="also reveal" style="--d:0.22s"><span class="l-en">Prefer package managers? Use <a href="#start" data-goto="brew">Homebrew</a>. Need a local browser UI? Run <code>reasonix serve</code>.</span><span class="l-zh">偏好包管理器? 可用 <a href="#start" data-goto="brew">Homebrew</a>。需要本地浏览器 UI? 运行 <code>reasonix serve</code>。</span></div>
 
       <div class="term-stage reveal" style="--d:0.26s">
         <div class="fig"><span class="l-en">fig. 01 — a live session, cache still warm</span><span class="l-zh">图 01 —— 一场实时会话,缓存依然温热</span></div>
@@ -189,7 +196,7 @@ const ld = {
           <span class="num">01</span>
           <h3><span class="l-en">Install</span><span class="l-zh">安装</span></h3>
           <p><span class="l-en">One command. macOS, Linux, Windows, and WSL.</span><span class="l-zh">一条命令,支持 macOS、Linux、Windows 与 WSL。</span></p>
-          <code>npm i -g reasonix@next</code>
+          <code>npm i -g reasonix</code>
         </div>
         <div class="step reveal" style="--d:0.08s">
           <span class="num">02</span>
@@ -265,20 +272,20 @@ const ld = {
       </div>
 
       <div class="dl-pane active" data-pane="npm">
-        <span class="install"><span class="ps1">$</span>npm i -g reasonix@next<button data-copy="npm i -g reasonix@next">Copy</button></span>
+        <span class="install"><span class="ps1">$</span>npm i -g reasonix<button data-copy="npm i -g reasonix">Copy</button></span>
         <div class="chan">
           <div class="chan-row rec">
-            <code>npm i -g reasonix@next</code><span class="v">v<span class="rxv">{goVer}</span></span>
-            <span class="s"><span class="l-en">Go rewrite · one binary · no Node · actively developed</span><span class="l-zh">Go 重写 · 单二进制 · 无需 Node · 主力开发中</span></span>
+            <code>npm i -g reasonix</code><span class="v">v<span class="rxv">{goVer}</span></span>
+            <span class="s"><span class="l-en">Stable 1.x · one binary · no Node · actively developed</span><span class="l-zh">稳定 1.x · 单二进制 · 无需 Node · 主力开发中</span></span>
             <span class="chan-badge"><span class="l-en">recommended</span><span class="l-zh">推荐</span></span>
           </div>
           <div class="chan-row">
-            <code>npm i -g reasonix</code><span class="v">v0.53</span>
+            <code>npm i -g reasonix@0.53.2</code><span class="v">v0.53.2</span>
             <span class="s"><span class="l-en">deprecated 0.x line · no longer maintained</span><span class="l-zh">已废弃的 0.x 线 · 不再维护</span></span>
             <span class="chan-badge pre"><span class="l-en">deprecated</span><span class="l-zh">已废弃</span></span>
           </div>
         </div>
-        <div class="dl-note"><span class="l-en">macOS / Linux / Windows / WSL · the <span class="mono">latest</span> tag is pinned at v0.53 — always install from <span class="mono">@next</span> · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> release notes →</a></span><span class="l-zh">macOS / Linux / Windows / WSL · <span class="mono">latest</span> 标签固定在 v0.53——请始终通过 <span class="mono">@next</span> 安装 · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> 更新说明 →</a></span></div>
+        <div class="dl-note"><span class="l-en">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> tracks the current 1.x stable · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> release notes →</a></span><span class="l-zh">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> 指向当前 1.x 稳定版 · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> 更新说明 →</a></span></div>
       </div>
 
       <div class="dl-pane" data-pane="brew">
@@ -344,7 +351,7 @@ const ld = {
     </div>
     <div class="foot-sub">
       <span><span class="l-en">Engineered around DeepSeek's prefix cache.</span><span class="l-zh">围绕 DeepSeek 前缀缓存而设计。</span></span>
-      <span class="ver">v<span class="rxv">{goVer}</span> · @next</span>
+      <span class="ver">v<span class="rxv">{goVer}</span> · stable</span>
     </div>
   </footer>
 </Base>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -127,22 +127,72 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 }
 .hero .sub b { color: var(--ink); font-weight: 600; }
 
-.hero-cta { margin-top: 40px; display: flex; align-items: center; justify-content: center; gap: 14px; flex-wrap: wrap; }
+.hero-install {
+  --hero-action-height: 48px;
+  --hero-action-width: 160px;
+  width: min(850px, 100%); margin: 40px auto 0;
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px;
+}
+.install-option {
+  display: grid; align-content: start; justify-items: start; gap: 12px;
+  min-height: 172px; padding: 20px;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--bg-soft) 68%, white);
+  text-align: left;
+}
+.install-option--desktop {
+  background: linear-gradient(180deg, color-mix(in oklch, var(--accent) 11%, white), #fff 78%);
+  border-color: color-mix(in oklch, var(--accent) 22%, var(--line));
+}
+.install-kicker {
+  display: inline-flex; align-items: center; gap: 7px;
+  min-height: 16px; line-height: 16px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--accent);
+}
+.install-kicker::before {
+  content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--accent);
+}
+.install-option strong {
+  max-width: 330px; font-size: 15px; line-height: 1.45;
+  font-weight: 600; color: var(--ink);
+}
+.install-option .btn { align-self: end; margin-top: auto; }
+.hero-install .btn,
+.hero-install .install button {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: var(--hero-action-width); height: var(--hero-action-height);
+  padding: 0 22px; box-sizing: border-box;
+  font-size: 15px; font-weight: 600; line-height: 1;
+}
+.install-option .install { align-self: end; margin-top: auto; max-width: 100%; }
 
 .install {
-  display: inline-flex; align-items: center; gap: 14px;
+  display: inline-flex; align-items: center; gap: 14px; min-width: 0;
   font-family: var(--font-mono); font-size: 14px; color: var(--ink);
   background: var(--bg-soft); border-radius: 999px;
   padding: 12px 10px 12px 22px;
+  white-space: nowrap;
 }
 .install .ps1 { color: var(--accent); user-select: none; }
 .install button {
+  flex: none;
   font-family: var(--font-sans); font-size: 13px; font-weight: 600;
   background: #fff; color: var(--accent); border: none; cursor: pointer;
   padding: 7px 16px; border-radius: 999px; box-shadow: var(--shadow-1);
   transition: background 0.2s, color 0.2s, box-shadow 0.2s;
 }
 .install button:hover { box-shadow: var(--shadow-2); }
+.hero-install .install {
+  height: var(--hero-action-height);
+  padding: 0 0 0 22px;
+}
+.hero-install .install button {
+  background: var(--accent); color: #fff; box-shadow: none;
+}
+.hero-install .install button:hover {
+  background: var(--accent-deep); box-shadow: var(--shadow-1);
+}
 .install button.copied { background: oklch(0.55 0.14 155); color: #fff; }
 
 .also { margin-top: 22px; font-size: 14px; color: var(--ink-3); }
@@ -836,12 +886,23 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .dl-help button { justify-self: start; }
   .cache-panel { padding: 36px 24px; }
   .hero { padding-top: 130px; }
+  .hero-install { grid-template-columns: 1fr; max-width: 560px; }
+  .install-option { min-height: 0; }
   section { padding-top: 100px; }
 }
 
 @media (max-width: 640px) {
   .docs-path-grid { grid-template-columns: 1fr; }
   .docs-main h1 { font-size: 34px; }
+  .hero-install { --hero-action-width: 100%; }
+  .install-option { padding: 18px; }
+  .hero-install .install {
+    height: auto;
+    width: 100%; flex-wrap: wrap; justify-content: space-between;
+    gap: 12px; padding: 14px;
+    border-radius: 24px;
+  }
+  .hero-install .install button { flex-basis: 100%; }
 }
 
 /* account / auth pages */


### PR DESCRIPTION
## Summary

- Update the website install command from `npm i -g reasonix@next` to the stable `npm i -g reasonix` path.
- Redesign the home hero install area so desktop and CLI/TUI are presented as two equal first-class options.
- Rename the desktop CTA to "Download desktop" / "下载桌面版" and align the hero desktop/download and CLI copy button sizing.
- Clarify legacy 0.x installation with an explicit `reasonix@0.53.2` pin.

## Why

The previous hero could make the product feel terminal-only, and the npm guidance still pointed users at the `next` dist tag even though the stable 1.x path now uses `latest`.

## Validation

- `npm exec astro build`
- `git diff --check`
- Browser check on the local site: the hero desktop CTA and CLI Copy button both render at 160x48 with matching typography, radius, color, and vertical alignment; non-hero copy buttons keep their lighter secondary treatment.