### PR TITLE
feat(creation): 统一右侧面板与 Windows 控制框背景色

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -27693,9 +27693,7 @@ body > .mermaid-diagram--fullscreen {
   --project-tree-row-radius: 9px;
   padding: 38px 12px 14px;
   border-right: 0;
-  background:
-    radial-gradient(110% 70% at 18% 0%, color-mix(in srgb, var(--accent) 5%, transparent) 0%, transparent 52%),
-    color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
 }
 
 .app--creation .sidebar__brand,
@@ -29228,6 +29226,22 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .app--creation .workbench-dock,
+:root[data-theme-style] .app--creation .workbench-dock {
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+}
+
+.app--creation .workbench-dock .workspace-panel,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-panel,
+.app--creation .workbench-dock .workspace-files,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-files,
+.app--creation .workbench-dock .workspace-preview,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-preview,
+.app--creation .workbench-dock .workspace-preview__body,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-preview__body {
+  background: transparent;
+}
+
+.app--creation .workbench-dock,
 .app--creation .workbench-dock * {
   scrollbar-width: none;
 }
@@ -29776,4 +29790,13 @@ body > .mermaid-diagram--fullscreen {
    recombine both here. */
 .app--windows.app--creation .topicbar__chrome-btn.topicbar__chrome-btn--pressed {
   transform: translateY(-2px) scale(0.94) !important;
+}
+
+/* Windows 控制框在 Creation 下默认用 --bg-elev（近纯白），与右侧 workbench-dock
+   的统一底色（sidebar-bg 88%）有明显色差。改用相同底色，让控制框与右侧面板连成一片。 */
+.app--windows.app--creation .windows-window-controls,
+:root[data-theme-style] .app--windows.app--creation .windows-window-controls {
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+  border-left-color: transparent;
+  box-shadow: none;
 }


### PR DESCRIPTION
## 改动内容

在创作域（Creation 桌面风格）下优化了 UI 的整体背景色统一度。

此前 Creation 浅色/暗色下右侧面板与左侧会话列表存在明显色差：
- 右侧 `workbench-dock`（文件/改动视图）沿用 `--workspace-files-bg`，其内部 `workspace-panel` / `workspace-files` / `workspace-preview` 又被主题规则叠成 `--bg-elev`（近纯白），与左侧 `sidebar` 的 `sidebar-bg 88%` 底色不一致。
- Windows 窗口控制框（最小化/最大化/关闭所在区域）用 `--bg-elev`，在标题栏形成一块明显偏白的方框。

## 修改

全部限定在 `.app--creation` 作用域内，**不影响 classic / workbench 两种风格**：

- `workbench-dock` 背景改用与左侧 `sidebar` 相同的 `color-mix(sidebar-bg 88%, transparent)`。
- 其内部 `workspace-panel` / `workspace-files` / `workspace-preview` / `workspace-preview__body` 背景置为 `transparent`，让统一底色透出（修复文件视图右侧仍为白色的问题）。
- Windows 控制框（`.app--windows.app--creation`）背景匹配同一底色，去掉左边框与阴影，与右侧面板连成一片。
- 顺带移除左侧 `sidebar` 左上角一层未使用的淡 accent 径向渐变，与右侧保持一致的纯色。

## 测试

- `pnpm --dir desktop/frontend typecheck` 通过。
- `wails dev` 实测：Creation 浅色下左右面板与 Windows 控制框已统一为同一底色，文件视图 / 改动视图均无残留白块。
- 自检 classic / workbench：所有规则均带 `.app--creation` 前缀，两种风格表现不变。
