### PR TITLE
fix(desktop): preserve auto light theme styles / 修复桌面端自动浅色主题样式

### DIFF
--- a/desktop/frontend/src/__tests__/theme-auto-background.test.ts
+++ b/desktop/frontend/src/__tests__/theme-auto-background.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const themeSource = readFileSync(resolve(testDir, "../lib/theme.ts"), "utf8");
+const stylesSource = readFileSync(resolve(testDir, "../styles.css"), "utf8");
 
 let passed = 0;
 let failed = 0;
@@ -18,6 +19,24 @@ function ok(value: boolean, label: string) {
     process.stdout.write(`  FAIL  ${label}\n`);
     failed += 1;
   }
+}
+
+function blockAfter(source: string, needle: string, after = 0): string {
+  const selectorIndex = source.indexOf(needle, after);
+  if (selectorIndex < 0) return "";
+  const open = source.indexOf("{", selectorIndex);
+  if (open < 0) return "";
+
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, index);
+    }
+  }
+  return "";
 }
 
 console.log("\ntheme auto native background contract");
@@ -53,6 +72,46 @@ ok(
 ok(
   themeSource.includes("if (autoThemeMediaQuery || typeof window"),
   "reapplying auto does not register duplicate listeners",
+);
+
+const workbenchRefreshIndex = stylesSource.indexOf("Native Workbench refresh");
+const workbenchSource = workbenchRefreshIndex >= 0 ? stylesSource.slice(workbenchRefreshIndex) : "";
+const workbenchLightBlock = blockAfter(workbenchSource, ':root[data-theme="light"]');
+const workbenchAutoLightMediaIndex = workbenchSource.indexOf("@media (prefers-color-scheme: light)");
+const workbenchAutoLightBlock = blockAfter(workbenchSource, ":root:not([data-theme])", workbenchAutoLightMediaIndex);
+
+ok(workbenchRefreshIndex >= 0, "styles include the native workbench theme refresh section");
+ok(workbenchAutoLightMediaIndex >= 0, "workbench refresh has an auto-mode light media override");
+ok(
+  workbenchLightBlock.includes("--bg: #e9edf3;") && workbenchAutoLightBlock.includes("--bg: #e9edf3;"),
+  "auto light mode keeps the workbench light background after late root overrides",
+);
+ok(
+  workbenchLightBlock.includes("--fg: #121722;") && workbenchAutoLightBlock.includes("--fg: #121722;"),
+  "auto light mode keeps the workbench light foreground after late root overrides",
+);
+ok(
+  workbenchLightBlock.includes("--workspace-files-bg: #f1f4f8;") &&
+    workbenchAutoLightBlock.includes("--workspace-files-bg: #f1f4f8;"),
+  "auto light mode keeps workbench panel surfaces aligned with forced light mode",
+);
+
+const creationAssistantLightRule = ':root[data-theme="light"] .app--creation .msg--assistant .msg__body';
+const creationAssistantAutoLightRule = ':root:not([data-theme]) .app--creation .msg--assistant .msg__body';
+const creationAssistantLightIndex = stylesSource.indexOf(creationAssistantLightRule);
+const creationAssistantAutoLightIndex = stylesSource.indexOf(creationAssistantAutoLightRule);
+const creationAssistantLightBlock = blockAfter(stylesSource, creationAssistantLightRule);
+const creationAssistantAutoLightBlock = blockAfter(stylesSource, creationAssistantAutoLightRule);
+
+ok(creationAssistantLightIndex >= 0, "creation assistant text has an explicit light-mode color adjustment");
+ok(
+  creationAssistantAutoLightIndex > creationAssistantLightIndex,
+  "creation assistant text mirrors the light-mode color adjustment for auto light mode",
+);
+ok(
+  creationAssistantLightBlock.includes("color-mix(in srgb, var(--fg) 90%, var(--bg))") &&
+    creationAssistantAutoLightBlock.includes("color-mix(in srgb, var(--fg) 90%, var(--bg))"),
+  "creation assistant auto light text color matches forced light mode",
 );
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -22412,6 +22412,27 @@ body > .mermaid-diagram--fullscreen {
   --fg-faint: #8791a1;
 }
 
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --bg: #e9edf3;
+    --bg-soft: #f0f3f8;
+    --bg-elev: #ffffff;
+    --bg-elev-2: #eef2f7;
+    --sidebar-bg: #f3f6fa;
+    --sidebar-hover: #e7edf5;
+    --sidebar-active: color-mix(in srgb, var(--accent) 9%, #ffffff);
+    --chat-bg: #f8fafc;
+    --workspace-preview-bg: #f8fafc;
+    --workspace-files-bg: #f1f4f8;
+    --workspace-files-hover: #e8edf5;
+    --border: #d5dde8;
+    --border-soft: #e3e9f1;
+    --fg: #121722;
+    --fg-dim: #4d5666;
+    --fg-faint: #8791a1;
+  }
+}
+
 .layout {
   --chat-min-width: 700px;
   --topicbar-height: 58px;
@@ -28319,6 +28340,12 @@ body > .mermaid-diagram--fullscreen {
 
 :root[data-theme="light"] .app--creation .msg--assistant .msg__body {
   color: color-mix(in srgb, var(--fg) 90%, var(--bg));
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) .app--creation .msg--assistant .msg__body {
+    color: color-mix(in srgb, var(--fg) 90%, var(--bg));
+  }
 }
 
 .app--creation .md,


### PR DESCRIPTION
## Summary

- Preserve auto light-mode Workbench desktop tokens after the late native Workbench refresh overrides.
- Mirror the Creation assistant body light-mode color adjustment for auto light mode.
- Extend the desktop theme regression test to cover both contracts.

## Verification

- `npm run check:css`
- `npx tsx src/__tests__/theme-auto-background.test.ts`

## Compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted config/session/state files | Not changed | Backward compatible |
| Wails JSON contracts | Not changed | Backward compatible |
| Provider-visible prompts/tool schemas | Not changed | No cache-stability risk |

## Cache impact

Cache-impact: none; frontend CSS/test-only desktop appearance change.
Cache-guard: `npm run check:css`; `npx tsx src/__tests__/theme-auto-background.test.ts`
System-prompt-review: N/A