### PR TITLE
fix(desktop): fix bot settings layout overflow in Creation style and QR setup panel / 修复创作风格下机器人设置布局溢出及扫码界面溢出

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -15657,6 +15657,7 @@ body > .mermaid-diagram--fullscreen {
   grid-template-columns: 220px minmax(0, 1fr);
   gap: 18px;
   align-items: center;
+  min-width: 0;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-elev);
@@ -15666,6 +15667,7 @@ body > .mermaid-diagram--fullscreen {
   grid-template-columns: 180px minmax(0, 1fr);
   gap: 16px;
   align-items: center;
+  min-width: 0;
   padding: 12px;
 }
 .bot-connect-panel__qr {
@@ -16966,6 +16968,14 @@ body > .mermaid-diagram--fullscreen {
   }
 }
 
+/* QR 扫码面板：在 1080px 提前切换单列，防止右侧文字/按钮溢出容器 */
+@media (max-width: 1080px) {
+  .bot-connect-panel,
+  .bot-connect-panel--phone {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 980px) {
   .settings-center {
     grid-template-columns: minmax(176px, 220px) minmax(0, 1fr);
@@ -17010,11 +17020,6 @@ body > .mermaid-diagram--fullscreen {
   .provider-access-card__actions,
   .set-rules__add {
     flex-wrap: wrap;
-  }
-
-  .bot-connect-panel,
-  .bot-connect-panel--phone {
-    grid-template-columns: 1fr;
   }
 
   .bot-simple-hero {
@@ -17242,12 +17247,6 @@ body > .mermaid-diagram--fullscreen {
   .bot-phone-connect__switch {
     justify-content: space-between;
     width: 100%;
-  }
-  .bot-connect-panel {
-    grid-template-columns: 1fr;
-  }
-  .bot-connect-panel--phone {
-    grid-template-columns: 1fr;
   }
   .bot-connection-table__header {
     display: none;
@@ -26536,6 +26535,13 @@ body > .mermaid-diagram--fullscreen {
   gap: 18px;
   padding: 10px 0;
   border-top-color: color-mix(in srgb, var(--border-soft) 72%, transparent);
+}
+
+/* 机器人详情卡片内 settings-field 不受 Creation 全局覆盖 — 保持紧凑布局（仅复位溢出相关的 grid 属性） */
+.app--creation .bot-detail-card .settings-field,
+:root[data-theme-style] .app--creation .bot-detail-card .settings-field {
+  grid-template-columns: minmax(112px, 138px) minmax(0, 1fr);
+  gap: 12px;
 }
 
 .app--creation .settings-field__label,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -26544,6 +26544,14 @@ body > .mermaid-diagram--fullscreen {
   gap: 12px;
 }
 
+@media (max-width: 980px) {
+  .app--creation .bot-detail-card .settings-field,
+  :root[data-theme-style] .app--creation .bot-detail-card .settings-field {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+}
+
 .app--creation .settings-field__label,
 :root[data-theme-style] .app--creation .settings-field__label {
   font-size: 11.5px;


### PR DESCRIPTION
Fixes #6064. Fixes #6196 .

**Summary**

This PR fixes two related layout overflow issues in the desktop settings panel:

1. **#6064 / #6196 — Bot detail card fields overflow in Creation desktop style**: Under the "Creation" desktop layout style, the global `.app--creation .settings-field` CSS rule (specificity 0,2,0) overrides `.bot-detail-card .settings-field` (specificity 0,2,0) because it appears later in the stylesheet. The Creation override sets `grid-template-columns: minmax(150px, 200px) minmax(260px, 1fr)`, which forces a 260px minimum control column that is too wide for the narrow bot detail card container, causing "Enable Bot", "Tool Approval", "Model", and "Runtime Settings" fields to overflow their card boundary.

2. **QR code setup panel right-side overflow in all desktop styles**: The `.bot-connect-panel` (and its `--phone` variant) serves as a CSS Grid item inside `.bot-channel-setup-card` but lacked `min-width: 0`, so the default `min-width: auto` prevented it from shrinking below its min-content size when the detail pane is narrow. Additionally, the two-column layout (fixed 180px QR column + fluid text column) lacked an early enough responsive breakpoint to switch to a single-column stacked layout before overflow occurs.

**Changes** (1 file: `desktop/frontend/src/styles.css`, +17 / −11 lines)

| Fix | Location | Change | Rationale |
|-----|----------|--------|-----------|
| Bot detail card overflow | `.app--creation .bot-detail-card .settings-field` (new rule, specificity 0,3,0) | Reset `grid-template-columns` to `minmax(112px, 138px) minmax(0, 1fr)` and `gap` to `12px` within Creation style | Higher specificity beats the Creation global override; only resets the two properties causing overflow, leaving `padding` and `border-top` untouched so adjacent field separators still render correctly |
| QR panel shrink | `.bot-connect-panel` + `--phone` base styles | Add `min-width: 0` | Allows the Grid item to shrink below min-content when its container is narrow |
| QR panel responsive | New `@media (max-width: 1080px)` block | `.bot-connect-panel` / `--phone` → `grid-template-columns: 1fr` | Switches to single-column stacked layout before the two-column layout overflows; consolidates previously scattered rules from 980px and 760px breakpoints |
| Cleanup | Remove from `@media (max-width: 980px)` and `(max-width: 760px)` | Delete redundant `.bot-connect-panel` collapse rules | Now covered by the single 1080px breakpoint |

**Verification**

- [x] CSS syntax and z-index token checks pass
- [x] Wails desktop build succeeds (windows/amd64)
- [x] Manual visual verification: Creation style → Settings → Bots → configured WeChat/QQ bot → fields no longer overflow the card
- [x] Manual visual verification: Classic/Workbench styles → no regression
- [x] Manual visual verification: Unconfigured bot → QR scan panel right side no longer overflows container
- [x] Manual visual verification: Responsive narrow viewport → all three styles behave correctly

**Cache-impact**

Cache-impact: none — only `desktop/frontend/src/styles.css` is touched; no cache-sensitive paths (`internal/boot/`, `internal/tool/`, `internal/provider/`, etc.) are affected.

---

**概述**

此 PR 修复了桌面设置面板中两个相关的布局溢出问题：

1. **#6064 / #6196 — "创作"桌面风格下机器人详情卡片字段溢出**：在"创作"桌面布局风格下，全局的 `.app--creation .settings-field` CSS 规则（优先级 0,2,0）因为出现在样式表更靠后的位置，覆盖了 `.bot-detail-card .settings-field`（优先级 0,2,0）。创作风格的覆盖将 `grid-template-columns` 设为 `minmax(150px, 200px) minmax(260px, 1fr)`，强制控制列最小宽度 260px，对于机器人详情卡片这种窄容器来说过宽，导致"启用机器人""工具审批""模型""运行设置"等字段超出卡片边框。

2. **所有桌面风格下扫码创建机器人界面右侧溢出**：`.bot-connect-panel`（及其 `--phone` 变体）作为 `.bot-channel-setup-card` 内的 CSS Grid 子项，缺少 `min-width: 0`，默认的 `min-width: auto` 阻止其在详情面板较窄时随容器缩窄。此外，双列布局（固定 180px 二维码列 + 弹性文字列）缺乏足够早的响应式断点，未能在溢出发生前切换为单列堆叠布局。

**改动**（1 个文件：`desktop/frontend/src/styles.css`，+17 / −11 行）

| 修复 | 位置 | 改动 | 原因 |
|------|------|------|------|
| 机器人详情卡片溢出 | `.app--creation .bot-detail-card .settings-field`（新增规则，优先级 0,3,0） | 在创作风格内将 `grid-template-columns` 复位为 `minmax(112px, 138px) minmax(0, 1fr)`，`gap` 复位为 `12px` | 更高优先级击败创作风格全局覆盖；仅复位导致溢出的两个属性，不动 `padding` 和 `border-top`，确保相邻字段分隔线正常渲染 |
| 扫码面板缩窄 | `.bot-connect-panel` + `--phone` 基础样式 | 添加 `min-width: 0` | 允许 Grid 子项在容器较窄时缩至内容最小宽度以下 |
| 扫码面板响应式 | 新增 `@media (max-width: 1080px)` 块 | `.bot-connect-panel` / `--phone` → `grid-template-columns: 1fr` | 在双列布局溢出前切换为单列堆叠布局；收拢原先分散在 980px 和 760px 断点中的重复规则 |
| 清理 | 从 `@media (max-width: 980px)` 和 `(max-width: 760px)` 中删除 | 移除冗余的 `.bot-connect-panel` 单列规则 | 现已由统一的 1080px 断点覆盖 |

**验证**

- [x] CSS 语法和 z-index token 检查通过
- [x] Wails 桌面构建成功 (windows/amd64)
- [x] 手动视觉验证：创作风格 → 设置 → 机器人 → 已配置的微信/QQ 机器人 → 字段不再超出卡片边框
- [x] 手动视觉验证：经典/工作台风格 → 无回归
- [x] 手动视觉验证：未配置机器人 → 扫码面板右侧不再溢出容器
- [x] 手动视觉验证：窄屏响应式 → 三种风格行为正确

**缓存影响**

Cache-impact: none — 仅修改了 `desktop/frontend/src/styles.css`，未触及任何缓存敏感路径（`internal/boot/`、`internal/tool/`、`internal/provider/` 等）。