### PR TITLE
fix(serve): deduplicate tool card on partial dispatch + align card width

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -95,7 +95,7 @@ input,textarea{font:inherit;color:inherit}
 @keyframes blink{to{visibility:hidden}}
 
 /* card (v1 pattern) */
-.card{background:var(--card);border-radius:var(--radius-lg);overflow:hidden;font-size:14px;box-shadow:var(--shadow-sm);margin:8px auto;transition:border-color .18s ease}
+.card{background:var(--card);border-radius:var(--radius-lg);overflow:hidden;font-size:14px;box-shadow:var(--shadow-sm);margin:8px auto;max-width:760px;transition:border-color .18s ease}
 .card-head{display:grid;grid-template-columns:auto minmax(0,1fr) auto auto;align-items:center;gap:8px;padding:7px 12px;font-size:13px;color:var(--fg-2);cursor:pointer;user-select:none;background:var(--card);transition:background .18s ease}
 .card-head:hover{background:var(--card-hover)}
 .card-head .ico{width:18px;height:18px;border-radius:5px;display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--fg-2);flex-shrink:0;font-size:10px}

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -1066,7 +1066,9 @@ function copyText(text) {
   return Promise.resolve(false);
 }
 function renderToolDispatch(tool) {
-  hideWelcome(); const card=el('div','card'); card.id='tool-'+tool.id; card.dataset.open='false'; card.dataset.tone='accent';
+  hideWelcome(); let card=toolCards[tool.id];
+  if(!card){card=el('div','card');card.id='tool-'+tool.id;}else{card.innerHTML='';}
+  card.dataset.open='false'; card.dataset.tone='accent';
   card.dataset.startedAt=String(Date.now());
   const head=el('div','card-head');
   const summary=toolArgsSummary(tool.args);


### PR DESCRIPTION
## Summary

Two fixes in `internal/serve/index.html`:

1. **Tool card width alignment** — Added `max-width: 760px` to `.card` so tool cards match `.msg` width instead of stretching full container width.

2. **Duplicate tool card on partial→full dispatch** — The backend emits `tool_dispatch` twice for the same tool call: first with `{partial: true}` (name only, no args), then with full args. The original code created a new card each time and overwrote `toolCards[tool.id]`, leaving the first card stuck in loading state forever. Now `renderToolDispatch` reuses the existing card element (clears `innerHTML` and repopulates) when a dispatch for the same `tool.id` arrives, preventing duplicates.

## Verification
| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/70edd5ef-0f91-4432-90ee-d1cd150a97fd) | ![](https://github.com/user-attachments/assets/53729e9f-7d6e-4744-b41b-3c7c5a17f827) |


- Manually tested: running `ls` or `read_file` produces exactly one card per tool call, no leftover spinning card
- Card width now matches chat message width
