### PR TITLE
fix(serve): strip transient blocks from /history and /checkpoints

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -616,6 +616,9 @@ func historyMessages(msgs []provider.Message) []historyMessage {
 			}
 		}
 		hm := historyMessage{Role: string(m.Role), Content: m.Content}
+		if m.Role == provider.RoleUser {
+			hm.Content = agent.StripTransientUserBlocks(m.Content)
+		}
 		if m.Role == provider.RoleAssistant {
 			hm.Reasoning = m.ReasoningContent
 			if len(m.ToolCalls) > 0 {
@@ -989,7 +992,11 @@ func (s *Server) checkpoints(w http.ResponseWriter, _ *http.Request) {
 	raw := s.ctl().Checkpoints()
 	out := make([]cp, len(raw))
 	for i, c := range raw {
-		out[i] = cp{Turn: c.Turn, Prompt: c.Prompt, Files: len(c.Paths)}
+		out[i] = cp{
+			Turn:   c.Turn,
+			Prompt: agent.StripTransientUserBlocks(c.Prompt),
+			Files:  len(c.Paths),
+		}
 	}
 	writeJSON(w, out)
 }


### PR DESCRIPTION
## Summary

`GET /history` and `GET /checkpoints` returned raw composed user messages
containing transient XML blocks (`<reasoning-language>`,
`<response-language>`, `<memory-update>`) meant only for the model. After a
page refresh, these tags appeared in the transcript and rewind picker.

Both endpoints now strip transient blocks server-side via
`agent.StripTransientUserBlocks()`, so the inline HTML client and standalone
React client receive clean text. The CLI/TUI and desktop already handled this;
serve was the only frontend missing it.

## Verification

- `go build ./internal/serve/` — compiles clean
- `go vet ./internal/serve/` — no warnings
- `go test ./internal/serve/ -count=1` — all tests pass

## Cache impact

Cache-impact: none — `internal/serve/` is not a cache-sensitive path (only
HTTP response formatting, no system-prompt or tool-schema changes).
Cache-guard: N/A — existing test suite covers the changed code paths.
System-prompt-review: N/A