### PR TITLE
fix(serve): make rewind checkpoint click go directly to scope selection

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -1230,7 +1230,7 @@ function renderRewindPicker() {
     rewindCheckpoints.forEach((cp,i)=>{
       const item=el('div','rewind-picker__item'+(i===rewindSelected?' rewind-picker__item--active':''));
       item.innerHTML='<span class="rewind-picker__turn">#'+cp.turn+'</span><span class="rewind-picker__prompt">'+escHtml((cp.prompt||'').slice(0,80))+'</span><span class="rewind-picker__files">'+cp.files+' '+__('files')+'</span>';
-      item.onclick=()=>{rewindSelected=i;renderRewindPicker();};
+      item.onclick=()=>{rewindSelected=i;rewindStage=1;rewindScope=0;renderRewindPicker();};
       list.appendChild(item);
     });
     picker.appendChild(list);


### PR DESCRIPTION
## Summary

After clicking a checkpoint in the rewind picker, the dialog flashes and
reappears as the checkpoint list instead of showing the scope selection
(both / conversation / code / etc.). The issue is that the click handler
only updated the selection index without advancing to the next stage.

## Verification

- `go build ./internal/serve/` — compiles clean

## Cache impact

Cache-impact: none
Cache-guard: N/A
System-prompt-review: N/A