### PR TITLE
fix(desktop): keep the Windows sidebar out of native drag regions / 避免 Windows 侧边栏触发窗口拖动

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -289,6 +289,13 @@ ok(
   "Windows classic chrome keeps a draggable rail while tabs remain clickable",
 );
 
+ok(
+  finalDeclaration(".sidebar", "--wails-draggable") === "drag" &&
+    finalDeclaration(".app--windows .sidebar", "--wails-draggable") === "no-drag" &&
+    finalDeclaration(".sidebar-resizer", "--wails-draggable") === "no-drag",
+  "Windows sidebar avoids native window drag without changing other platforms",
+);
+
 for (const selector of [
   ".layout--workbench-chrome-hidden",
   ":root[data-theme-style] .layout--workbench-chrome-hidden",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2033,8 +2033,15 @@ a[href] {
   padding: 12px 10px calc(12px + var(--statusbar-height));
   background: var(--sidebar-bg);
   border-right: 1px solid var(--border-soft);
+  --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
+}
+
+/* Windows window movement belongs to the dedicated chrome surfaces. Keep the
+   navigation sidebar and its adjacent resize handle out of the native drag path. */
+.app--windows .sidebar {
+  --wails-draggable: no-drag;
 }
 
 .app--darwin .sidebar {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2033,7 +2033,6 @@ a[href] {
   padding: 12px 10px calc(12px + var(--statusbar-height));
   background: var(--sidebar-bg);
   border-right: 1px solid var(--border-soft);
-  --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary

Prevent blank or non-control content in the Windows sidebar from entering Wails' native window-drag path, while preserving the existing sidebar drag behavior on macOS and Linux.

## Root cause

Wails v2 reads the computed `--wails-draggable` value from the mousedown target. The base `.sidebar` is a drag region, and CSS custom properties inherit, so non-control descendants in the Windows sidebar can start native window movement. The sidebar resize handle remains an explicit `no-drag` control, but a pointer miss into the adjacent sidebar must not move the whole window.

## Fix

- Preserve `.sidebar { --wails-draggable: drag; }` for macOS and Linux.
- Add `.app--windows .sidebar { --wails-draggable: no-drag; }` for the affected platform.
- Keep the dedicated title/chrome drag surfaces unchanged, including `.app-chrome`, `.topicbar`, `.workbench-dock__tools`, and the Windows classic drag rail.
- Add a regression contract covering the platform override and the sidebar resize handle.

## Relationship to #5777

The incorrect `ns-resize` cursor and distorted right/bottom window-edge hit area were a separate Wails coordinate-space issue already fixed by #5777 through `useWailsResizeFix`. This PR does not modify `resizeEdge`; its scope is limited to preventing the Windows sidebar from initiating native window movement.

## Verification

Verified on the latest `main-v2` integration tree:

- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/wails-resize-fix.test.tsx`
- `pnpm --dir desktop/frontend test`
- `git diff --check`

All checks passed.

## Compatibility and risk

| Area | Existing-data behavior | Conclusion |
| --- | --- | --- |
| Persisted desktop/session data | Not read or written | Backward compatible |
| Wails JSON contracts | Unchanged | Backward compatible |
| Provider prompt/cache surface | Unchanged | No cache impact |
| Security surface | CSS and source-level test only | No new security exposure |
