### PR TITLE
Add MCP get command / 添加 MCP get 命令

### DIFF
--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -298,6 +298,10 @@ func looksSensitiveMCPKey(key string) bool {
 	return false
 }
 
+func looksSensitiveMCPQueryKey(key string) bool {
+	return strings.EqualFold(strings.TrimSpace(key), "key") || looksSensitiveMCPKey(key)
+}
+
 func looksSensitiveMCPValue(value string) bool {
 	lower := strings.ToLower(value)
 	for _, needle := range []string{"access_token", "id_token", "refresh_token", "api_key", "api-key", "apikey", "bearer "} {
@@ -323,7 +327,7 @@ func redactMCPURL(raw string) string {
 	q := u.Query()
 	changed := false
 	for key := range q {
-		if looksSensitiveMCPKey(key) {
+		if looksSensitiveMCPQueryKey(key) {
 			q.Set(key, "<redacted>")
 			changed = true
 		}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"reasonix/internal/config"
@@ -160,6 +162,8 @@ func mcpCommand(args []string) int {
 		return mcpList()
 	case "add":
 		return mcpAddCLI(args[1:])
+	case "get":
+		return mcpGetCLI(args[1:])
 	case "remove", "rm":
 		return mcpRemoveCLI(args[1:])
 	case "import":
@@ -214,6 +218,123 @@ func mcpList() int {
 	return 0
 }
 
+func mcpGetCLI(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: reasonix mcp get <name>")
+		return 2
+	}
+	name := args[0]
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	for _, p := range cfg.Plugins {
+		if p.Name != name {
+			continue
+		}
+		printMCPEntry(p)
+		return 0
+	}
+	fmt.Fprintf(os.Stderr, "no MCP server named %q in config\n", name)
+	return 1
+}
+
+func printMCPEntry(p config.PluginEntry) {
+	typ := p.Type
+	if typ == "" {
+		typ = "stdio"
+	}
+	fmt.Printf("name: %s\n", p.Name)
+	fmt.Printf("type: %s\n", typ)
+	if typ == "stdio" {
+		fmt.Printf("command: %s\n", p.Command)
+		if len(p.Args) > 0 {
+			fmt.Printf("args: %s\n", strings.Join(p.Args, "\n      "))
+		}
+		if len(p.Env) > 0 {
+			fmt.Println("env:")
+			for _, k := range sortedMapKeys(p.Env) {
+				fmt.Printf("  %s=%s\n", k, redactMCPConfigValue(k, p.Env[k]))
+			}
+		}
+	} else {
+		fmt.Printf("url: %s\n", redactMCPURL(p.URL))
+		if len(p.Headers) > 0 {
+			fmt.Println("headers:")
+			for _, k := range sortedMapKeys(p.Headers) {
+				fmt.Printf("  %s=%s\n", k, redactMCPConfigValue(k, p.Headers[k]))
+			}
+		}
+	}
+	if !p.ShouldAutoStart() {
+		fmt.Println("auto_start: false")
+	}
+}
+
+func sortedMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func redactMCPConfigValue(key, value string) string {
+	if looksSensitiveMCPKey(key) || looksSensitiveMCPValue(value) {
+		return "<redacted>"
+	}
+	return value
+}
+
+func looksSensitiveMCPKey(key string) bool {
+	lower := strings.ToLower(strings.TrimSpace(key))
+	for _, needle := range []string{"auth", "token", "secret", "credential", "api_key", "api-key", "apikey", "cookie"} {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksSensitiveMCPValue(value string) bool {
+	lower := strings.ToLower(value)
+	for _, needle := range []string{"access_token", "id_token", "refresh_token", "api_key", "api-key", "apikey", "bearer "} {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactMCPURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return raw
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil || u == nil {
+		if looksSensitiveMCPValue(raw) {
+			return "<redacted>"
+		}
+		return raw
+	}
+	q := u.Query()
+	changed := false
+	for key := range q {
+		if looksSensitiveMCPKey(key) {
+			q.Set(key, "<redacted>")
+			changed = true
+		}
+	}
+	if !changed {
+		return raw
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
 func mcpAddCLI(args []string) int {
 	entry, err := parseMCPAdd(args)
 	if err != nil {
@@ -265,6 +386,7 @@ func mcpUsage() {
 
 Usage:
   reasonix mcp list
+  reasonix mcp get <name>
   reasonix mcp add <name> <command> [args...]        stdio server
   reasonix mcp add <name> --http <url> [--header K=V] remote (Streamable HTTP)
   reasonix mcp add <name> --sse  <url>               remote (legacy SSE)

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -159,7 +159,7 @@ func TestMCPGetRedactsRemoteAuthMaterial(t *testing.T) {
 	_ = captureStdout(t, func() {
 		if rc := Run([]string{
 			"mcp", "add", "stripe",
-			"--http", "https://mcp.example.test/mcp?access_token=abc&workspace=main",
+			"--http", "https://mcp.example.test/mcp?access_token=abc&key=xyz&workspace=main",
 			"--header", "Authorization=Bearer abc",
 		}, "test-version"); rc != 0 {
 			t.Fatalf("mcp add remote rc = %d, want 0", rc)
@@ -175,13 +175,14 @@ func TestMCPGetRedactsRemoteAuthMaterial(t *testing.T) {
 		"type: http",
 		"workspace=main",
 		"access_token=%3Credacted%3E",
+		"key=%3Credacted%3E",
 		"Authorization=<redacted>",
 	} {
 		if !strings.Contains(getOut, want) {
 			t.Fatalf("mcp get remote output missing %q:\n%s", want, getOut)
 		}
 	}
-	if strings.Contains(getOut, "Bearer abc") || strings.Contains(getOut, "access_token=abc") {
+	if strings.Contains(getOut, "Bearer abc") || strings.Contains(getOut, "access_token=abc") || strings.Contains(getOut, "key=xyz") {
 		t.Fatalf("mcp get leaked remote auth material:\n%s", getOut)
 	}
 }

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -100,6 +100,92 @@ func TestTokenizeArgs(t *testing.T) {
 	}
 }
 
+func TestMCPGetOpenDesignStyleInstall(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	addOut := captureStdout(t, func() {
+		if rc := Run([]string{
+			"mcp", "add", "open-design",
+			"--env", "OD_DAEMON_URL=http://127.0.0.1:7456",
+			"--env", "OPEN_DESIGN_TOKEN=placeholder-value",
+			"node", "open-design-mcp.js", "--stdio",
+		}, "test-version"); rc != 0 {
+			t.Fatalf("mcp add rc = %d, want 0", rc)
+		}
+	})
+	if !strings.Contains(addOut, `added MCP server "open-design"`) {
+		t.Fatalf("mcp add output = %q", addOut)
+	}
+
+	getOut := captureStdout(t, func() {
+		if rc := Run([]string{"mcp", "get", "open-design"}, "test-version"); rc != 0 {
+			t.Fatalf("mcp get rc = %d, want 0", rc)
+		}
+	})
+	for _, want := range []string{
+		"name: open-design",
+		"type: stdio",
+		"command: node",
+		"args: open-design-mcp.js",
+		"      --stdio",
+		"OD_DAEMON_URL=http://127.0.0.1:7456",
+		"OPEN_DESIGN_TOKEN=<redacted>",
+	} {
+		if !strings.Contains(getOut, want) {
+			t.Fatalf("mcp get output missing %q:\n%s", want, getOut)
+		}
+	}
+	if strings.Contains(getOut, "placeholder-value") {
+		t.Fatalf("mcp get leaked sensitive env value:\n%s", getOut)
+	}
+}
+
+func TestMCPGetMissingServerFails(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	errOut := captureStderr(t, func() {
+		if rc := Run([]string{"mcp", "get", "open-design"}, "test-version"); rc != 1 {
+			t.Fatalf("mcp get missing rc = %d, want 1", rc)
+		}
+	})
+	if !strings.Contains(errOut, `no MCP server named "open-design"`) {
+		t.Fatalf("mcp get missing stderr = %q", errOut)
+	}
+}
+
+func TestMCPGetRedactsRemoteAuthMaterial(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	_ = captureStdout(t, func() {
+		if rc := Run([]string{
+			"mcp", "add", "stripe",
+			"--http", "https://mcp.example.test/mcp?access_token=abc&workspace=main",
+			"--header", "Authorization=Bearer abc",
+		}, "test-version"); rc != 0 {
+			t.Fatalf("mcp add remote rc = %d, want 0", rc)
+		}
+	})
+
+	getOut := captureStdout(t, func() {
+		if rc := Run([]string{"mcp", "get", "stripe"}, "test-version"); rc != 0 {
+			t.Fatalf("mcp get remote rc = %d, want 0", rc)
+		}
+	})
+	for _, want := range []string{
+		"type: http",
+		"workspace=main",
+		"access_token=%3Credacted%3E",
+		"Authorization=<redacted>",
+	} {
+		if !strings.Contains(getOut, want) {
+			t.Fatalf("mcp get remote output missing %q:\n%s", want, getOut)
+		}
+	}
+	if strings.Contains(getOut, "Bearer abc") || strings.Contains(getOut, "access_token=abc") {
+		t.Fatalf("mcp get leaked remote auth material:\n%s", getOut)
+	}
+}
+
 func TestRenderMCPStatusGroupsAndCompactsResources(t *testing.T) {
 	longURI := "file:///Users/example/project/docs/really/deep/path/with/a/very/long/resource-name.md"
 	got := renderMCPStatus(110,

--- a/internal/provider/openai/reconnect_test.go
+++ b/internal/provider/openai/reconnect_test.go
@@ -118,8 +118,11 @@ func TestStreamCancelDoesNotReconnect(t *testing.T) {
 			got = chunk.Err
 		}
 	}
-	if !errors.Is(got, context.Canceled) {
-		t.Fatalf("stream error = %v, want context.Canceled", got)
+	// Depending on whether the server close or the client watchdog observes
+	// cancellation first, the stream may close silently or surface cancellation.
+	// The contract guarded here is that cancellation never triggers a replay.
+	if got != nil && !errors.Is(got, context.Canceled) {
+		t.Fatalf("stream error = %v, want nil or context.Canceled", got)
 	}
 	if reqs.Load() != 1 {
 		t.Fatalf("cancelled stream reconnected; server saw %d requests, want 1", reqs.Load())


### PR DESCRIPTION
## Summary
- add `reasonix mcp get <name>` for idempotent MCP server lookup
- print stdio and remote MCP server details in a stable human-readable form
- redact auth-like env, header, and URL query values from `mcp get` output

## Why
Open Design-style CLI installers commonly use `add/remove/get` to manage MCP registrations. Reasonix already had `mcp add`, `mcp list`, and `mcp remove`; this fills the missing lookup command so external installers can safely detect an existing server without editing Reasonix config directly.

## Compatibility
| Area | Old data behavior | Conclusion |
| --- | --- | --- |
| Existing `config.toml` / `reasonix.toml` `[[plugins]]` | Loaded through the existing config path; no schema changes | Backward compatible |
| Existing MCP add/list/remove commands | Command names and behavior unchanged | Backward compatible |
| Missing MCP server lookup | New `mcp get <name>` exits non-zero instead of mutating config | Additive behavior |

## Validation
- `go test ./internal/cli -run 'TestMCPGet|TestParseMCPAdd|TestTokenizeArgs'`
- `go test ./internal/config -run 'TestLoadMCPJSON|TestMCPJSON|TestLoadMergesMCPJSON|TestMergeMCPJSONPrecedence'`
- `go test ./...`
- Built a temporary Reasonix binary and verified an Open Design-style `mcp add open-design -> mcp get open-design -> mcp remove open-design -> mcp get open-design` flow with isolated Reasonix config.

Cache-impact: none - test-only OpenAI stream cancellation assertion; provider-visible request serialization and stable prefix are unchanged.
Cache-guard: go test -race ./internal/provider/openai -run TestStreamCancelDoesNotReconnect -count=100; go test -race ./internal/provider/openai