### PR TITLE
feat(bot): desktop god view — observe, approve, and take over any desktop session from IM / 飞书 bot 桌面上帝视角:观察、审批与显式接管

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -376,13 +376,7 @@ func NewApp() *App {
 		botInstalls:      map[string]*botInstallSession{},
 		botRuntime:       newDesktopBotRuntime(),
 	}
-	a.botBridge = newBotBridgeHub(
-		a.ListTabs,
-		a.ApproveTab,
-		a.AnswerQuestionForTab,
-		a.botRuntime.SendToAdapter,
-		slog.Default(),
-	)
+	a.botBridge = a.newBotBridge()
 	return a
 }
 
@@ -832,9 +826,19 @@ func (a *App) Submit(input string) error {
 }
 
 func (a *App) SubmitToTab(tabID, input string) error {
+	return a.submitToTab(tabID, input, false)
+}
+
+// submitToTab is the shared submit body. fromBridge marks submissions driven
+// by the IM takeover bridge; local (frontend) submissions on a taken-over tab
+// reclaim remote control first — typing locally is the grab-back gesture.
+func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
 	if a.tabIsReadOnly(tab) {
 		return readOnlyChannelErr()
+	}
+	if !fromBridge && tab != nil && a.botBridge != nil {
+		a.botBridge.reclaimFromDesktop(tab.ID)
 	}
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -829,52 +829,108 @@ func (a *App) SubmitToTab(tabID, input string) error {
 	return a.submitToTab(tabID, input, false)
 }
 
+// beginTabTurn locks the tab's foreground-turn admission gate and reserves the
+// event sink until TurnDone has completed all of its fan-out. The caller must
+// call finishTabTurnStart exactly once after invoking the controller.
+func (a *App) beginTabTurn(tabID string, reclaim bool) (*WorkspaceTab, control.SessionAPI, error) {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if a.tabIsReadOnly(tab) {
+		return nil, nil, readOnlyChannelErr()
+	}
+	if tab == nil || ctrl == nil {
+		return nil, nil, a.workspaceNotReadyErr(tab)
+	}
+	tab.turnStartMu.Lock()
+	if a.tabIsReadOnly(tab) {
+		tab.turnStartMu.Unlock()
+		return nil, nil, readOnlyChannelErr()
+	}
+	if reclaim && a.botBridge != nil {
+		a.botBridge.reclaimFromDesktop(tab.ID)
+	}
+	ctrl = a.controllerForTab(tab)
+	if ctrl == nil {
+		tab.turnStartMu.Unlock()
+		return nil, nil, a.workspaceNotReadyErr(tab)
+	}
+	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+		tab.turnStartMu.Unlock()
+		return nil, nil, err
+	}
+	ctrl = a.controllerForTab(tab)
+	if ctrl == nil {
+		tab.turnStartMu.Unlock()
+		return nil, nil, a.workspaceNotReadyErr(tab)
+	}
+	if ctrl.RuntimeStatus().Running || (tab.sink != nil && !tab.sink.tryBeginTurn()) {
+		tab.turnStartMu.Unlock()
+		return nil, nil, control.ErrTurnRunning
+	}
+	return tab, ctrl, nil
+}
+
+func (a *App) finishTabTurnStart(tab *WorkspaceTab, ctrl control.SessionAPI) bool {
+	started := ctrl != nil && ctrl.RuntimeStatus().Running
+	if !started && tab != nil && tab.sink != nil {
+		tab.sink.cancelTurnStart()
+	}
+	if tab != nil {
+		tab.turnStartMu.Unlock()
+	}
+	return started
+}
+
 // submitToTab is the shared submit body. fromBridge marks submissions driven
 // by the IM takeover bridge; local (frontend) submissions on a taken-over tab
 // reclaim remote control first — typing locally is the grab-back gesture.
 func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return readOnlyChannelErr()
-	}
-	if !fromBridge && tab != nil && a.botBridge != nil {
-		a.botBridge.reclaimFromDesktop(tab.ID)
-	}
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
+		tab, _ := a.tabAndCtrlByID(tabID)
+		if a.tabIsReadOnly(tab) {
+			return readOnlyChannelErr()
+		}
+		if tab == nil {
+			return a.workspaceNotReadyErr(tab)
+		}
+		tab.turnStartMu.Lock()
+		defer tab.turnStartMu.Unlock()
+		if !fromBridge && a.botBridge != nil {
+			a.botBridge.reclaimFromDesktop(tab.ID)
+		}
 		a.runEffortCommandForTab(tabID, trimmed)
 		return nil
 	}
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+	tab, ctrl, err := a.beginTabTurn(tabID, !fromBridge)
+	if err != nil {
 		return err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitDisplay(input, input)
+	a.finishTabTurnStart(tab, ctrl)
 	return nil
 }
 
 func (a *App) submitUserTurnToTab(tabID, input string) bool {
-	if a.tabReadOnly(tabID) {
+	return a.submitUserTurnToTabWithSink(tabID, input, nil)
+}
+
+func (a *App) submitUserTurnToTabWithSink(tabID, input string, forwarder event.Sink) bool {
+	tab, ctrl, err := a.beginTabTurn(tabID, false)
+	if err != nil {
 		return false
 	}
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if ctrl == nil || a.ensureTabControllerWorkspace(tab) != nil {
-		return false
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return false
+	var generation uint64
+	if forwarder != nil {
+		generation = tab.sink.SetBotSink(forwarder)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitUserTurn(input, input)
-	return true
+	started := a.finishTabTurnStart(tab, ctrl)
+	if !started && forwarder != nil {
+		tab.sink.clearBotSink(generation)
+	}
+	return started
 }
 
 // RunShell executes a shell command directly (bypassing the model) and streams
@@ -884,22 +940,13 @@ func (a *App) RunShell(command string) error {
 }
 
 func (a *App) RunShellForTab(tabID, command string) error {
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return readOnlyChannelErr()
-	}
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+	tab, ctrl, err := a.beginTabTurn(tabID, true)
+	if err != nil {
 		return err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.RunShell(command)
+	a.finishTabTurnStart(tab, ctrl)
 	return nil
 }
 
@@ -910,42 +957,24 @@ func (a *App) SubmitDisplay(display, input string) error {
 }
 
 func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return readOnlyChannelErr()
-	}
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+	tab, ctrl, err := a.beginTabTurn(tabID, true)
+	if err != nil {
 		return err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitDisplay(display, input)
+	a.finishTabTurnStart(tab, ctrl)
 	return nil
 }
 
 func (a *App) SubmitEditedDisplayToTab(tabID, display, input, original string) error {
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if a.tabIsReadOnly(tab) {
-		return readOnlyChannelErr()
-	}
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
-	}
-	if err := a.ensureTabControllerWorkspace(tab); err != nil {
+	tab, ctrl, err := a.beginTabTurn(tabID, true)
+	if err != nil {
 		return err
-	}
-	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
-		return a.workspaceNotReadyErr(tab)
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
 	ctrl.SubmitEditedDisplay(display, input, original)
+	a.finishTabTurnStart(tab, ctrl)
 	return nil
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -173,6 +173,10 @@ type App struct {
 	mediaTokens *mediaTokenStore
 	botInstalls map[string]*botInstallSession
 	botRuntime  *desktopBotRuntime
+	// botBridge gives the embedded bot gateway a god view over desktop
+	// sessions (/desktop commands). Set once in NewApp before any tab exists,
+	// read-only afterwards, so tabEventSink.Emit reads it without a lock.
+	botBridge *botBridgeHub
 
 	metrics atomic.Pointer[metricsAggregator] // non-nil only when desktop.metrics is opted in; swapped live by SetDesktopMetrics
 
@@ -365,13 +369,21 @@ func (a *App) workspaceMediaMiddleware() func(http.Handler) http.Handler {
 // NewApp constructs the bound object. Tabs are restored in startup from the
 // last session's desktop-tabs.json.
 func NewApp() *App {
-	return &App{
+	a := &App{
 		tabs:             map[string]*WorkspaceTab{},
 		detachedSessions: map[string]*WorkspaceTab{},
 		mediaTokens:      newMediaTokenStore(),
 		botInstalls:      map[string]*botInstallSession{},
 		botRuntime:       newDesktopBotRuntime(),
 	}
+	a.botBridge = newBotBridgeHub(
+		a.ListTabs,
+		a.ApproveTab,
+		a.AnswerQuestionForTab,
+		a.botRuntime.SendToAdapter,
+		slog.Default(),
+	)
+	return a
 }
 
 func (a *App) bootContext() context.Context {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -911,10 +911,6 @@ func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
 	return nil
 }
 
-func (a *App) submitUserTurnToTab(tabID, input string) bool {
-	return a.submitUserTurnToTabWithSink(tabID, input, nil)
-}
-
 func (a *App) submitUserTurnToTabWithSink(tabID, input string, forwarder event.Sink) bool {
 	tab, ctrl, err := a.beginTabTurn(tabID, false)
 	if err != nil {
@@ -1025,13 +1021,6 @@ func (a *App) SteerForTab(tabID, text string) error {
 	}
 	ctrl.Steer(text)
 	return nil
-}
-
-func (a *App) tabReadOnly(tabID string) bool {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	tab := a.tabByIDLocked(tabID)
-	return tab != nil && tab.ReadOnly
 }
 
 func (a *App) tabAndCtrlByID(tabID string) (*WorkspaceTab, control.SessionAPI) {

--- a/desktop/bot_bridge.go
+++ b/desktop/bot_bridge.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/bot"
+	"reasonix/internal/event"
+)
+
+// botBridgeHub 是 bot 网关对桌面端的"上帝视角"桥（bot.DesktopBridge 的实现）。
+//
+// 职责边界（刻意保持窄）：
+//   - 观察：tabEventSink.Emit 把每个桌面会话的事件旁路到 observe；hub 记录
+//     待审批/待回答项，并把审批请求、任务完成/出错推送给订阅聊天。
+//   - 遥控审批：/desktop approve|deny|answer 经 App.ApproveTab /
+//     AnswerQuestionForTab 按 tab 寻址回写。controller 侧幂等（先到者赢），
+//     桌面 UI 与远端并发应答互不干扰。
+//   - 不做：向桌面会话注入输入、抢占写 lease。将来的显式接管在
+//     bot.DesktopBridge 上扩展，底层走 internal/control 的接管端口。
+//
+// observe 跑在 controller 的事件 goroutine 上，绝不能做网络调用——通知统一
+// 进有界队列由 worker 异步发送，队列满时丢弃并告警。
+type botBridgeHub struct {
+	listTabs   func() []TabMeta
+	approveTab func(tabID, id string, allow, session, persist bool)
+	answerTab  func(tabID, id string, answers []QuestionAnswer)
+	notify     func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error)
+	logger     *slog.Logger
+
+	mu       sync.Mutex
+	watchers map[string]bot.DesktopWatchRoute
+	pending  map[string]desktopPendingPrompt
+
+	queue chan desktopBridgeNotification
+}
+
+type desktopPendingPrompt struct {
+	tabID     string
+	kind      string // "approval" | "ask"
+	tool      string
+	subject   string
+	questions []event.AskQuestion
+}
+
+// desktopBridgeNotification 是一条待推送的桌面事件。card 按订阅路由现做
+// （chat_type 因聊天而异）；text 同时是非卡片平台的完整降级文案。
+type desktopBridgeNotification struct {
+	text string
+	card func(route bot.DesktopWatchRoute) *bot.InteractiveCard
+}
+
+const (
+	botBridgeQueueSize     = 64
+	botBridgeSendTimeout   = 15 * time.Second
+	botBridgeSubjectLimit  = 200
+	botBridgePendingLimit  = 200
+	botBridgeErrTextLimit  = 300
+	botBridgePromptPreview = 500
+)
+
+func newBotBridgeHub(
+	listTabs func() []TabMeta,
+	approveTab func(tabID, id string, allow, session, persist bool),
+	answerTab func(tabID, id string, answers []QuestionAnswer),
+	notify func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error),
+	logger *slog.Logger,
+) *botBridgeHub {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &botBridgeHub{
+		listTabs:   listTabs,
+		approveTab: approveTab,
+		answerTab:  answerTab,
+		notify:     notify,
+		logger:     logger.With("component", "bot_bridge"),
+		watchers:   make(map[string]bot.DesktopWatchRoute),
+		pending:    make(map[string]desktopPendingPrompt),
+		queue:      make(chan desktopBridgeNotification, botBridgeQueueSize),
+	}
+	go h.run()
+	return h
+}
+
+// observe 接收某个桌面会话的一条事件。在 controller 事件 goroutine 上运行，
+// 只做内存记账和入队，不做任何阻塞调用。
+func (h *botBridgeHub) observe(tabID string, e event.Event) {
+	switch e.Kind {
+	case event.ApprovalRequest:
+		h.mu.Lock()
+		h.rememberPendingLocked(e.Approval.ID, desktopPendingPrompt{
+			tabID:   tabID,
+			kind:    "approval",
+			tool:    e.Approval.Tool,
+			subject: truncateForBridge(e.Approval.Subject, botBridgeSubjectLimit),
+		})
+		watching := len(h.watchers) > 0
+		h.mu.Unlock()
+		if watching {
+			h.enqueue(h.approvalNotification(tabID, e.Approval))
+		}
+	case event.AskRequest:
+		h.mu.Lock()
+		h.rememberPendingLocked(e.Ask.ID, desktopPendingPrompt{
+			tabID:     tabID,
+			kind:      "ask",
+			questions: e.Ask.Questions,
+		})
+		watching := len(h.watchers) > 0
+		h.mu.Unlock()
+		if watching {
+			h.enqueue(h.askNotification(tabID, e.Ask))
+		}
+	case event.TurnDone:
+		h.mu.Lock()
+		for id, p := range h.pending {
+			if p.tabID == tabID {
+				delete(h.pending, id)
+			}
+		}
+		watching := len(h.watchers) > 0
+		h.mu.Unlock()
+		if !watching {
+			return
+		}
+		if e.Err != nil && strings.Contains(e.Err.Error(), "context canceled") {
+			// 桌面端主动停止的任务不推送，避免正常操作变成噪音。
+			return
+		}
+		h.enqueue(h.turnDoneNotification(tabID, e.Err))
+	}
+}
+
+// rememberPendingLocked 记录待处理项；容量兜底防泄漏（正常路径 TurnDone 会清理）。
+func (h *botBridgeHub) rememberPendingLocked(id string, p desktopPendingPrompt) {
+	if strings.TrimSpace(id) == "" {
+		return
+	}
+	if len(h.pending) >= botBridgePendingLimit {
+		h.pending = make(map[string]desktopPendingPrompt)
+	}
+	h.pending[id] = p
+}
+
+func (h *botBridgeHub) enqueue(n desktopBridgeNotification) {
+	select {
+	case h.queue <- n:
+	default:
+		h.logger.Warn("desktop bridge notification queue full; dropping")
+	}
+}
+
+func (h *botBridgeHub) run() {
+	for n := range h.queue {
+		h.deliver(n)
+	}
+}
+
+func (h *botBridgeHub) deliver(n desktopBridgeNotification) {
+	h.mu.Lock()
+	routes := make([]bot.DesktopWatchRoute, 0, len(h.watchers))
+	for _, r := range h.watchers {
+		routes = append(routes, r)
+	}
+	notify := h.notify
+	h.mu.Unlock()
+	if notify == nil || len(routes) == 0 {
+		return
+	}
+	for _, route := range routes {
+		msg := bot.OutboundMessage{
+			ChatID:   route.ChatID,
+			ChatType: route.ChatType,
+			Text:     n.text,
+		}
+		if n.card != nil {
+			msg.Card = n.card(route)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), botBridgeSendTimeout)
+		if _, err := notify(ctx, route.ConnectionID, route.Domain, msg); err != nil {
+			h.logger.Warn("desktop bridge notification send failed", "platform", route.Platform, "err", err)
+		}
+		cancel()
+	}
+}
+
+// tabLabel 把 tabID 解析成人类可读的会话名。
+func (h *botBridgeHub) tabLabel(tabID string) string {
+	if h.listTabs != nil {
+		for _, t := range h.listTabs() {
+			if t.ID != tabID {
+				continue
+			}
+			if label := strings.TrimSpace(t.Label); label != "" {
+				return label
+			}
+			if title := strings.TrimSpace(t.TopicTitle); title != "" {
+				return title
+			}
+			break
+		}
+	}
+	return "(未命名会话)"
+}
+
+func (h *botBridgeHub) approvalNotification(tabID string, approval event.Approval) desktopBridgeNotification {
+	label := h.tabLabel(tabID)
+	text := fmt.Sprintf("⚠️ 桌面会话「%s」需要批准操作\n工具: %s\n操作: %s\n\nID: `%s`\n用 /desktop approve %s 批准，/desktop deny %s 拒绝。桌面端先处理则以先到者为准。",
+		label, approval.Tool, truncateForBridge(approval.Subject, botBridgeSubjectLimit), approval.ID, approval.ID, approval.ID)
+	return desktopBridgeNotification{
+		text: text,
+		card: func(route bot.DesktopWatchRoute) *bot.InteractiveCard {
+			return &bot.InteractiveCard{
+				Header: "桌面会话需要批准",
+				Elements: []bot.InteractiveCardElement{
+					{Tag: "markdown", Content: fmt.Sprintf("**会话**: %s\n\n**工具**: %s\n\n**操作**: %s\n\nID: `%s`", label, approval.Tool, truncateForBridge(approval.Subject, botBridgeSubjectLimit), approval.ID)},
+					{Tag: "action", Extra: map[string]any{
+						"actions": []map[string]any{
+							desktopCardButton("允许一次", "primary", "/desktop approve "+approval.ID, route),
+							desktopCardButton("拒绝", "danger", "/desktop deny "+approval.ID, route),
+						},
+					}},
+				},
+			}
+		},
+	}
+}
+
+func (h *botBridgeHub) askNotification(tabID string, ask event.Ask) desktopBridgeNotification {
+	label := h.tabLabel(tabID)
+	var b strings.Builder
+	fmt.Fprintf(&b, "❓ 桌面会话「%s」在等待回答:\n", label)
+	for i, q := range ask.Questions {
+		fmt.Fprintf(&b, "\n**%d. %s**\n", i+1, truncateForBridge(q.Prompt, botBridgePromptPreview))
+		for j, opt := range q.Options {
+			fmt.Fprintf(&b, "  %d. %s\n", j+1, opt.Label)
+		}
+	}
+	fmt.Fprintf(&b, "\nID: `%s`\n用 /desktop answer %s <选项编号或文本> 回答；桌面端先处理则以先到者为准。", ask.ID, ask.ID)
+	text := b.String()
+
+	var card func(route bot.DesktopWatchRoute) *bot.InteractiveCard
+	if len(ask.Questions) == 1 && len(ask.Questions[0].Options) > 0 {
+		options := ask.Questions[0].Options
+		card = func(route bot.DesktopWatchRoute) *bot.InteractiveCard {
+			actions := make([]map[string]any, 0, len(options))
+			for i, opt := range options {
+				optLabel := strings.TrimSpace(opt.Label)
+				if optLabel == "" {
+					optLabel = fmt.Sprintf("选项 %d", i+1)
+				}
+				actions = append(actions, desktopCardButton(optLabel, "primary", fmt.Sprintf("/desktop answer %s %d", ask.ID, i+1), route))
+			}
+			return &bot.InteractiveCard{
+				Header: "桌面会话在等待回答",
+				Elements: []bot.InteractiveCardElement{
+					{Tag: "markdown", Content: text},
+					{Tag: "action", Extra: map[string]any{"actions": actions}},
+				},
+			}
+		}
+	}
+	return desktopBridgeNotification{text: text, card: card}
+}
+
+func (h *botBridgeHub) turnDoneNotification(tabID string, err error) desktopBridgeNotification {
+	label := h.tabLabel(tabID)
+	if err != nil {
+		return desktopBridgeNotification{text: fmt.Sprintf("❌ 桌面会话「%s」任务出错: %s", label, truncateForBridge(err.Error(), botBridgeErrTextLimit))}
+	}
+	return desktopBridgeNotification{text: fmt.Sprintf("✅ 桌面会话「%s」任务完成。", label)}
+}
+
+func desktopCardButton(label, style, command string, route bot.DesktopWatchRoute) map[string]any {
+	return map[string]any{
+		"tag":  "button",
+		"text": map[string]string{"tag": "plain_text", "content": label},
+		"type": style,
+		"value": map[string]string{
+			"command":   command,
+			"chat_type": string(route.ChatType),
+		},
+	}
+}
+
+func truncateForBridge(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit]) + "…"
+}
+
+// ---- bot.DesktopBridge 实现 ----
+
+func (h *botBridgeHub) Sessions() []bot.DesktopSessionInfo {
+	if h.listTabs == nil {
+		return nil
+	}
+	tabs := h.listTabs()
+	out := make([]bot.DesktopSessionInfo, 0, len(tabs))
+	for _, t := range tabs {
+		out = append(out, bot.DesktopSessionInfo{
+			TabID:         t.ID,
+			Label:         t.Label,
+			Workspace:     t.WorkspaceName,
+			Topic:         t.TopicTitle,
+			Ready:         t.Ready,
+			Running:       t.Running,
+			PendingPrompt: t.PendingPrompt,
+		})
+	}
+	return out
+}
+
+func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if enable {
+		h.watchers[route.Key()] = route
+		return
+	}
+	delete(h.watchers, route.Key())
+}
+
+func (h *botBridgeHub) Watching(route bot.DesktopWatchRoute) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.watchers[route.Key()]
+	return ok
+}
+
+func (h *botBridgeHub) Approve(approvalID string, allow bool) (string, error) {
+	approvalID = strings.TrimSpace(approvalID)
+	h.mu.Lock()
+	p, ok := h.pending[approvalID]
+	if ok && p.kind == "approval" {
+		delete(h.pending, approvalID)
+	}
+	h.mu.Unlock()
+	if !ok || p.kind != "approval" {
+		return "", fmt.Errorf("未找到待处理的审批 %s（可能已在桌面端处理或已超时）。用 /desktop status 查看当前会话。", approvalID)
+	}
+	if h.approveTab == nil {
+		return "", fmt.Errorf("桌面端审批通道不可用。")
+	}
+	h.approveTab(p.tabID, approvalID, allow, false, false)
+	action := "批准"
+	if !allow {
+		action = "拒绝"
+	}
+	return fmt.Sprintf("已提交%s「%s」的操作（%s）。桌面端若已先处理，以先到者为准。", action, h.tabLabel(p.tabID), p.tool), nil
+}
+
+func (h *botBridgeHub) AskQuestions(askID string) ([]event.AskQuestion, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	p, ok := h.pending[strings.TrimSpace(askID)]
+	if !ok || p.kind != "ask" {
+		return nil, false
+	}
+	return p.questions, true
+}
+
+func (h *botBridgeHub) Answer(askID string, answers []event.AskAnswer) (string, error) {
+	askID = strings.TrimSpace(askID)
+	h.mu.Lock()
+	p, ok := h.pending[askID]
+	if ok && p.kind == "ask" {
+		delete(h.pending, askID)
+	}
+	h.mu.Unlock()
+	if !ok || p.kind != "ask" {
+		return "", fmt.Errorf("未找到待回答的提问 %s（可能已在桌面端回答或已超时）。", askID)
+	}
+	if h.answerTab == nil {
+		return "", fmt.Errorf("桌面端问答通道不可用。")
+	}
+	out := make([]QuestionAnswer, 0, len(answers))
+	for _, an := range answers {
+		out = append(out, QuestionAnswer{QuestionID: an.QuestionID, Selected: an.Selected})
+	}
+	h.answerTab(p.tabID, askID, out)
+	return fmt.Sprintf("已提交「%s」的回答。桌面端若已先处理，以先到者为准。", h.tabLabel(p.tabID)), nil
+}

--- a/desktop/bot_bridge.go
+++ b/desktop/bot_bridge.go
@@ -42,7 +42,7 @@ type botBridgeHub struct {
 	// announce 往会话 transcript 里发一条 Notice，让桌面用户看到接管状态变化。
 	announce func(tabID, text string)
 	// persistWatchers 把订阅全集回写用户配置（bot.desktop_watchers）。
-	persistWatchers func(routes []bot.DesktopWatchRoute)
+	persistWatchers func(routes []bot.DesktopWatchRoute) error
 	// takeoverChanged 通知桌面前端刷新（TabMeta.RemoteControlled 变化）。
 	takeoverChanged func()
 	logger          *slog.Logger
@@ -55,6 +55,9 @@ type botBridgeHub struct {
 	takeoverTabs map[string]string
 	// watchSeq 单调递增，标记订阅快照的新旧；persist 时用它丢弃过期写入。
 	watchSeq uint64
+	// watchPersistDirty keeps a failed local mutation authoritative in memory;
+	// a later runtime refresh must not silently restore the older disk snapshot.
+	watchPersistDirty bool
 
 	// persistMu 串行化订阅落盘，并保证只写最新快照（见 SetWatch）。
 	persistMu      sync.Mutex
@@ -107,7 +110,7 @@ type botBridgeDeps struct {
 	notify          func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error)
 	drive           func(tabID, text string, route bot.DesktopWatchRoute) error
 	announce        func(tabID, text string)
-	persistWatchers func(routes []bot.DesktopWatchRoute)
+	persistWatchers func(routes []bot.DesktopWatchRoute) error
 	takeoverChanged func()
 	logger          *slog.Logger
 }
@@ -320,12 +323,22 @@ func (h *botBridgeHub) askNotification(tabID string, ask event.Ask) desktopBridg
 		}
 	}
 	fmt.Fprintf(&b, "\nID: `%s`\n用 /desktop answer %s <选项编号或文本> 回答；桌面端先处理则以先到者为准。", ask.ID, ask.ID)
-	text := b.String()
+	privateText := b.String()
+	sharedText := fmt.Sprintf("❓ 桌面会话「%s」正在等待回答（问题详情仅在桌面端或私聊显示）。\n\nID: `%s`", label, ask.ID)
+	textFor := func(route bot.DesktopWatchRoute) string {
+		if isSharedChat(route.ChatType) {
+			return sharedText
+		}
+		return privateText
+	}
 
 	var card func(route bot.DesktopWatchRoute) *bot.InteractiveCard
 	if len(ask.Questions) == 1 && len(ask.Questions[0].Options) > 0 {
 		options := ask.Questions[0].Options
 		card = func(route bot.DesktopWatchRoute) *bot.InteractiveCard {
+			if isSharedChat(route.ChatType) {
+				return nil
+			}
 			actions := make([]map[string]any, 0, len(options))
 			for i, opt := range options {
 				optLabel := strings.TrimSpace(opt.Label)
@@ -337,13 +350,13 @@ func (h *botBridgeHub) askNotification(tabID string, ask event.Ask) desktopBridg
 			return &bot.InteractiveCard{
 				Header: "桌面会话在等待回答",
 				Elements: []bot.InteractiveCardElement{
-					{Tag: "markdown", Content: text},
+					{Tag: "markdown", Content: privateText},
 					{Tag: "action", Extra: map[string]any{"actions": actions}},
 				},
 			}
 		}
 	}
-	return desktopBridgeNotification{text: constText(text), card: card}
+	return desktopBridgeNotification{text: textFor, card: card}
 }
 
 func (h *botBridgeHub) turnDoneNotification(tabID string, err error) desktopBridgeNotification {
@@ -403,7 +416,7 @@ func (h *botBridgeHub) Sessions() []bot.DesktopSessionInfo {
 	return sessions
 }
 
-func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
+func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) error {
 	h.mu.Lock()
 	if enable {
 		h.watchers[route.Key()] = route
@@ -411,12 +424,13 @@ func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
 		delete(h.watchers, route.Key())
 	}
 	h.watchSeq++
+	h.watchPersistDirty = true
 	seq := h.watchSeq
 	routes := h.watcherRoutesLocked()
 	persist := h.persistWatchers
 	h.mu.Unlock()
 	if persist == nil {
-		return
+		return nil
 	}
 	// Serialize persists and drop stale ones: two concurrent SetWatch calls
 	// (different connections) compute snapshots under h.mu but write config
@@ -425,16 +439,37 @@ func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
 	h.persistMu.Lock()
 	defer h.persistMu.Unlock()
 	if seq <= h.lastPersistSeq {
-		return
+		return nil
+	}
+	if err := persist(routes); err != nil {
+		return err
 	}
 	h.lastPersistSeq = seq
-	persist(routes)
+	h.mu.Lock()
+	if h.watchSeq == seq {
+		h.watchPersistDirty = false
+	}
+	h.mu.Unlock()
+	return nil
 }
 
-// seedWatchers 用配置里的订阅全集重置内存态（配置是持久化的唯一事实源）。
-func (h *botBridgeHub) seedWatchers(routes []bot.DesktopWatchRoute) {
+func (h *botBridgeHub) watcherVersion() uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.watchSeq
+}
+
+// seedWatchers applies a config snapshot only if no watch command changed the
+// runtime after the config read began. Fresh external config edits still apply;
+// stale refreshes and failed local persists do not erase newer runtime state.
+func (h *botBridgeHub) seedWatchers(routes []bot.DesktopWatchRoute, expectedSeq uint64) {
+	h.persistMu.Lock()
+	defer h.persistMu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.watchSeq != expectedSeq || h.watchPersistDirty {
+		return
+	}
 	h.watchers = make(map[string]bot.DesktopWatchRoute, len(routes))
 	for _, r := range routes {
 		if strings.TrimSpace(r.ChatID) == "" {

--- a/desktop/bot_bridge.go
+++ b/desktop/bot_bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -26,15 +27,26 @@ import (
 // observe 跑在 controller 的事件 goroutine 上，绝不能做网络调用——通知统一
 // 进有界队列由 worker 异步发送，队列满时丢弃并告警。
 type botBridgeHub struct {
-	listTabs   func() []TabMeta
+	sessions   func() []bot.DesktopSessionInfo
 	approveTab func(tabID, id string, allow, session, persist bool)
 	answerTab  func(tabID, id string, answers []QuestionAnswer)
 	notify     func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error)
-	logger     *slog.Logger
+	// drive 把一条远程文本提交为 tab 的新 turn，并把该 turn 的输出转发回 route。
+	drive func(tabID, text string, route bot.DesktopWatchRoute) error
+	// announce 往会话 transcript 里发一条 Notice，让桌面用户看到接管状态变化。
+	announce func(tabID, text string)
+	// persistWatchers 把订阅全集回写用户配置（bot.desktop_watchers）。
+	persistWatchers func(routes []bot.DesktopWatchRoute)
+	// takeoverChanged 通知桌面前端刷新（TabMeta.RemoteControlled 变化）。
+	takeoverChanged func()
+	logger          *slog.Logger
 
 	mu       sync.Mutex
 	watchers map[string]bot.DesktopWatchRoute
 	pending  map[string]desktopPendingPrompt
+	// takeovers: tabID -> 驾驶该会话的聊天路由；takeoverTabs: routeKey -> tabID。
+	takeovers    map[string]bot.DesktopWatchRoute
+	takeoverTabs map[string]string
 
 	queue chan desktopBridgeNotification
 }
@@ -49,9 +61,11 @@ type desktopPendingPrompt struct {
 
 // desktopBridgeNotification 是一条待推送的桌面事件。card 按订阅路由现做
 // （chat_type 因聊天而异）；text 同时是非卡片平台的完整降级文案。
+// route 非 nil 时定向发给该聊天（不看 watch 订阅），用于接管收回等必达通知。
 type desktopBridgeNotification struct {
-	text string
-	card func(route bot.DesktopWatchRoute) *bot.InteractiveCard
+	text  string
+	card  func(route bot.DesktopWatchRoute) *bot.InteractiveCard
+	route *bot.DesktopWatchRoute
 }
 
 const (
@@ -63,25 +77,39 @@ const (
 	botBridgePromptPreview = 500
 )
 
-func newBotBridgeHub(
-	listTabs func() []TabMeta,
-	approveTab func(tabID, id string, allow, session, persist bool),
-	answerTab func(tabID, id string, answers []QuestionAnswer),
-	notify func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error),
-	logger *slog.Logger,
-) *botBridgeHub {
+// botBridgeDeps 打包 hub 对宿主(App)的全部依赖，便于测试注入。
+type botBridgeDeps struct {
+	sessions        func() []bot.DesktopSessionInfo
+	approveTab      func(tabID, id string, allow, session, persist bool)
+	answerTab       func(tabID, id string, answers []QuestionAnswer)
+	notify          func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error)
+	drive           func(tabID, text string, route bot.DesktopWatchRoute) error
+	announce        func(tabID, text string)
+	persistWatchers func(routes []bot.DesktopWatchRoute)
+	takeoverChanged func()
+	logger          *slog.Logger
+}
+
+func newBotBridgeHub(deps botBridgeDeps) *botBridgeHub {
+	logger := deps.logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 	h := &botBridgeHub{
-		listTabs:   listTabs,
-		approveTab: approveTab,
-		answerTab:  answerTab,
-		notify:     notify,
-		logger:     logger.With("component", "bot_bridge"),
-		watchers:   make(map[string]bot.DesktopWatchRoute),
-		pending:    make(map[string]desktopPendingPrompt),
-		queue:      make(chan desktopBridgeNotification, botBridgeQueueSize),
+		sessions:        deps.sessions,
+		approveTab:      deps.approveTab,
+		answerTab:       deps.answerTab,
+		notify:          deps.notify,
+		drive:           deps.drive,
+		announce:        deps.announce,
+		persistWatchers: deps.persistWatchers,
+		takeoverChanged: deps.takeoverChanged,
+		logger:          logger.With("component", "bot_bridge"),
+		watchers:        make(map[string]bot.DesktopWatchRoute),
+		pending:         make(map[string]desktopPendingPrompt),
+		takeovers:       make(map[string]bot.DesktopWatchRoute),
+		takeoverTabs:    make(map[string]string),
+		queue:           make(chan desktopBridgeNotification, botBridgeQueueSize),
 	}
 	go h.run()
 	return h
@@ -163,9 +191,11 @@ func (h *botBridgeHub) run() {
 
 func (h *botBridgeHub) deliver(n desktopBridgeNotification) {
 	h.mu.Lock()
-	routes := make([]bot.DesktopWatchRoute, 0, len(h.watchers))
-	for _, r := range h.watchers {
-		routes = append(routes, r)
+	var routes []bot.DesktopWatchRoute
+	if n.route != nil {
+		routes = []bot.DesktopWatchRoute{*n.route}
+	} else {
+		routes = h.watcherRoutesLocked()
 	}
 	notify := h.notify
 	h.mu.Unlock()
@@ -191,21 +221,27 @@ func (h *botBridgeHub) deliver(n desktopBridgeNotification) {
 
 // tabLabel 把 tabID 解析成人类可读的会话名。
 func (h *botBridgeHub) tabLabel(tabID string) string {
-	if h.listTabs != nil {
-		for _, t := range h.listTabs() {
-			if t.ID != tabID {
-				continue
-			}
-			if label := strings.TrimSpace(t.Label); label != "" {
-				return label
-			}
-			if title := strings.TrimSpace(t.TopicTitle); title != "" {
-				return title
-			}
-			break
+	if s, ok := h.sessionByTabID(tabID); ok {
+		if label := strings.TrimSpace(s.Label); label != "" {
+			return label
+		}
+		if title := strings.TrimSpace(s.Topic); title != "" {
+			return title
 		}
 	}
 	return "(未命名会话)"
+}
+
+func (h *botBridgeHub) sessionByTabID(tabID string) (bot.DesktopSessionInfo, bool) {
+	if h.sessions == nil {
+		return bot.DesktopSessionInfo{}, false
+	}
+	for _, s := range h.sessions() {
+		if s.TabID == tabID {
+			return s, true
+		}
+	}
+	return bot.DesktopSessionInfo{}, false
 }
 
 func (h *botBridgeHub) approvalNotification(tabID string, approval event.Approval) desktopBridgeNotification {
@@ -300,33 +336,47 @@ func truncateForBridge(s string, limit int) string {
 // ---- bot.DesktopBridge 实现 ----
 
 func (h *botBridgeHub) Sessions() []bot.DesktopSessionInfo {
-	if h.listTabs == nil {
+	if h.sessions == nil {
 		return nil
 	}
-	tabs := h.listTabs()
-	out := make([]bot.DesktopSessionInfo, 0, len(tabs))
-	for _, t := range tabs {
-		out = append(out, bot.DesktopSessionInfo{
-			TabID:         t.ID,
-			Label:         t.Label,
-			Workspace:     t.WorkspaceName,
-			Topic:         t.TopicTitle,
-			Ready:         t.Ready,
-			Running:       t.Running,
-			PendingPrompt: t.PendingPrompt,
-		})
-	}
-	return out
+	return h.sessions()
 }
 
 func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if enable {
 		h.watchers[route.Key()] = route
-		return
+	} else {
+		delete(h.watchers, route.Key())
 	}
-	delete(h.watchers, route.Key())
+	routes := h.watcherRoutesLocked()
+	persist := h.persistWatchers
+	h.mu.Unlock()
+	if persist != nil {
+		persist(routes)
+	}
+}
+
+// seedWatchers 用配置里的订阅全集重置内存态（配置是持久化的唯一事实源）。
+func (h *botBridgeHub) seedWatchers(routes []bot.DesktopWatchRoute) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.watchers = make(map[string]bot.DesktopWatchRoute, len(routes))
+	for _, r := range routes {
+		if strings.TrimSpace(r.ChatID) == "" {
+			continue
+		}
+		h.watchers[r.Key()] = r
+	}
+}
+
+func (h *botBridgeHub) watcherRoutesLocked() []bot.DesktopWatchRoute {
+	routes := make([]bot.DesktopWatchRoute, 0, len(h.watchers))
+	for _, r := range h.watchers {
+		routes = append(routes, r)
+	}
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Key() < routes[j].Key() })
+	return routes
 }
 
 func (h *botBridgeHub) Watching(route bot.DesktopWatchRoute) bool {
@@ -388,4 +438,141 @@ func (h *botBridgeHub) Answer(askID string, answers []event.AskAnswer) (string, 
 	}
 	h.answerTab(p.tabID, askID, out)
 	return fmt.Sprintf("已提交「%s」的回答。桌面端若已先处理，以先到者为准。", h.tabLabel(p.tabID)), nil
+}
+
+// ---- 显式接管 ----
+
+func (h *botBridgeHub) Takeover(route bot.DesktopWatchRoute, tabID string) (string, error) {
+	tabID = strings.TrimSpace(tabID)
+	session, ok := h.sessionByTabID(tabID)
+	if !ok {
+		return "", fmt.Errorf("未找到会话 %s。用 /desktop status 查看可接管的会话。", tabID)
+	}
+	if session.Detached {
+		return "", fmt.Errorf("会话「%s」在后台运行，暂不支持接管；请先在桌面端打开它。", h.tabLabel(tabID))
+	}
+	h.mu.Lock()
+	if holder, held := h.takeovers[tabID]; held && holder.Key() != route.Key() {
+		h.mu.Unlock()
+		return "", fmt.Errorf("会话「%s」已被另一个聊天接管。", h.tabLabel(tabID))
+	}
+	// 同一聊天换目标：先解除旧绑定。
+	if prev, ok := h.takeoverTabs[route.Key()]; ok && prev != tabID {
+		delete(h.takeovers, prev)
+	}
+	h.takeovers[tabID] = route
+	h.takeoverTabs[route.Key()] = tabID
+	announce := h.announce
+	changed := h.takeoverChanged
+	h.mu.Unlock()
+	if announce != nil {
+		announce(tabID, "此会话已被 IM 远程接管（bot 管理员）。在此本地发送任意消息即可收回控制。")
+	}
+	if changed != nil {
+		changed()
+	}
+	label := h.tabLabel(tabID)
+	return fmt.Sprintf("已接管「%s」。现在直接发消息即可驱动它，输出会流回本聊天；/desktop release 解除接管。桌面端本地发言会自动收回控制。", label), nil
+}
+
+func (h *botBridgeHub) Release(route bot.DesktopWatchRoute) (string, error) {
+	h.mu.Lock()
+	tabID, ok := h.takeoverTabs[route.Key()]
+	if ok {
+		delete(h.takeoverTabs, route.Key())
+		delete(h.takeovers, tabID)
+	}
+	announce := h.announce
+	changed := h.takeoverChanged
+	h.mu.Unlock()
+	if !ok {
+		return "", fmt.Errorf("本聊天当前没有接管任何桌面会话。")
+	}
+	if announce != nil {
+		announce(tabID, "IM 远程接管已解除。")
+	}
+	if changed != nil {
+		changed()
+	}
+	return fmt.Sprintf("已解除对「%s」的接管。", h.tabLabel(tabID)), nil
+}
+
+func (h *botBridgeHub) TakeoverTab(route bot.DesktopWatchRoute) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.takeoverTabs[route.Key()]
+}
+
+func (h *botBridgeHub) DriveInput(route bot.DesktopWatchRoute, text string) (string, error) {
+	h.mu.Lock()
+	tabID := h.takeoverTabs[route.Key()]
+	h.mu.Unlock()
+	if tabID == "" {
+		return "", fmt.Errorf("本聊天没有接管任何桌面会话。")
+	}
+	session, ok := h.sessionByTabID(tabID)
+	if !ok || session.Detached {
+		// 会话被关闭或转入后台：自动解除绑定，避免消息黑洞。
+		h.mu.Lock()
+		delete(h.takeoverTabs, route.Key())
+		delete(h.takeovers, tabID)
+		h.mu.Unlock()
+		if changed := h.takeoverChanged; changed != nil {
+			changed()
+		}
+		return "", fmt.Errorf("被接管的会话已关闭或转入后台，接管已自动解除。")
+	}
+	if session.Running {
+		return "", fmt.Errorf("会话「%s」正在执行中，等它完成后再发；或用 /desktop watch on 订阅完成通知。", h.tabLabel(tabID))
+	}
+	if h.drive == nil {
+		return "", fmt.Errorf("桌面端驱动通道不可用。")
+	}
+	if err := h.drive(tabID, text, route); err != nil {
+		return "", fmt.Errorf("驱动失败: %v", err)
+	}
+	return "", nil
+}
+
+// reclaimFromDesktop 在桌面用户本地提交输入时收回控制权：解除绑定并通知
+// 远端聊天。由 App.SubmitToTab 调用（bridge 自己的驱动不走这条路）。
+func (h *botBridgeHub) reclaimFromDesktop(tabID string) {
+	h.mu.Lock()
+	route, ok := h.takeovers[tabID]
+	if ok {
+		delete(h.takeovers, tabID)
+		delete(h.takeoverTabs, route.Key())
+	}
+	notify := h.notify
+	changed := h.takeoverChanged
+	h.mu.Unlock()
+	if !ok {
+		return
+	}
+	if changed != nil {
+		changed()
+	}
+	if notify == nil {
+		return
+	}
+	label := h.tabLabel(tabID)
+	// 直接入通知队列（不依赖 watch 订阅）：接管者必须知道控制权没了。
+	h.enqueue(desktopBridgeNotification{
+		text:  fmt.Sprintf("🔓 桌面端已收回会话「%s」的控制权，接管已解除。", label),
+		route: &route,
+	})
+}
+
+// remoteControlledTabs 返回当前被接管的 tabID 集合（TabMeta 标记用）。
+func (h *botBridgeHub) remoteControlledTabs() map[string]bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.takeovers) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(h.takeovers))
+	for tabID := range h.takeovers {
+		out[tabID] = true
+	}
+	return out
 }

--- a/desktop/bot_bridge.go
+++ b/desktop/bot_bridge.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -12,6 +13,11 @@ import (
 	"reasonix/internal/bot"
 	"reasonix/internal/event"
 )
+
+// errDriveBusy signals that a takeover drive could not start because the target
+// controller was already running a turn. The hub translates it into a
+// user-facing "session busy" message rather than a generic drive failure.
+var errDriveBusy = errors.New("desktop session busy")
 
 // botBridgeHub 是 bot 网关对桌面端的"上帝视角"桥（bot.DesktopBridge 的实现）。
 //
@@ -47,6 +53,12 @@ type botBridgeHub struct {
 	// takeovers: tabID -> 驾驶该会话的聊天路由；takeoverTabs: routeKey -> tabID。
 	takeovers    map[string]bot.DesktopWatchRoute
 	takeoverTabs map[string]string
+	// watchSeq 单调递增，标记订阅快照的新旧；persist 时用它丢弃过期写入。
+	watchSeq uint64
+
+	// persistMu 串行化订阅落盘，并保证只写最新快照（见 SetWatch）。
+	persistMu      sync.Mutex
+	lastPersistSeq uint64
 
 	queue chan desktopBridgeNotification
 }
@@ -59,13 +71,23 @@ type desktopPendingPrompt struct {
 	questions []event.AskQuestion
 }
 
-// desktopBridgeNotification 是一条待推送的桌面事件。card 按订阅路由现做
-// （chat_type 因聊天而异）；text 同时是非卡片平台的完整降级文案。
-// route 非 nil 时定向发给该聊天（不看 watch 订阅），用于接管收回等必达通知。
+// desktopBridgeNotification 是一条待推送的桌面事件。text 与 card 都按订阅路由
+// 现做，因此群聊(多用户)与私聊可给出不同详略——命令行/错误详情只发私聊，群里
+// 只给摘要。route 非 nil 时定向发给该聊天(不看 watch 订阅)，用于接管收回等必达通知。
 type desktopBridgeNotification struct {
-	text  string
+	text  func(route bot.DesktopWatchRoute) string
 	card  func(route bot.DesktopWatchRoute) *bot.InteractiveCard
 	route *bot.DesktopWatchRoute
+}
+
+// isSharedChat 判断一个聊天是否为多用户场景(群/话题群/服务器频道)。私聊/单聊
+// 只有操作者本人,可安全展示命令行等敏感详情。
+func isSharedChat(ct bot.ChatType) bool {
+	return ct != bot.ChatDM && ct != bot.ChatDirect
+}
+
+func constText(s string) func(bot.DesktopWatchRoute) string {
+	return func(bot.DesktopWatchRoute) string { return s }
 }
 
 const (
@@ -202,21 +224,31 @@ func (h *botBridgeHub) deliver(n desktopBridgeNotification) {
 	if notify == nil || len(routes) == 0 {
 		return
 	}
+	// Fan out per route: a single slow/hung connection must not hold the queue
+	// worker for its full timeout and back-pressure everyone else's approvals.
+	var wg sync.WaitGroup
 	for _, route := range routes {
-		msg := bot.OutboundMessage{
-			ChatID:   route.ChatID,
-			ChatType: route.ChatType,
-			Text:     n.text,
-		}
-		if n.card != nil {
-			msg.Card = n.card(route)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), botBridgeSendTimeout)
-		if _, err := notify(ctx, route.ConnectionID, route.Domain, msg); err != nil {
-			h.logger.Warn("desktop bridge notification send failed", "platform", route.Platform, "err", err)
-		}
-		cancel()
+		wg.Add(1)
+		go func(route bot.DesktopWatchRoute) {
+			defer wg.Done()
+			msg := bot.OutboundMessage{
+				ChatID:   route.ChatID,
+				ChatType: route.ChatType,
+			}
+			if n.text != nil {
+				msg.Text = n.text(route)
+			}
+			if n.card != nil {
+				msg.Card = n.card(route)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), botBridgeSendTimeout)
+			defer cancel()
+			if _, err := notify(ctx, route.ConnectionID, route.Domain, msg); err != nil {
+				h.logger.Warn("desktop bridge notification send failed", "platform", route.Platform, "err", err)
+			}
+		}(route)
 	}
+	wg.Wait()
 }
 
 // tabLabel 把 tabID 解析成人类可读的会话名。
@@ -246,15 +278,25 @@ func (h *botBridgeHub) sessionByTabID(tabID string) (bot.DesktopSessionInfo, boo
 
 func (h *botBridgeHub) approvalNotification(tabID string, approval event.Approval) desktopBridgeNotification {
 	label := h.tabLabel(tabID)
-	text := fmt.Sprintf("⚠️ 桌面会话「%s」需要批准操作\n工具: %s\n操作: %s\n\nID: `%s`\n用 /desktop approve %s 批准，/desktop deny %s 拒绝。桌面端先处理则以先到者为准。",
-		label, approval.Tool, truncateForBridge(approval.Subject, botBridgeSubjectLimit), approval.ID, approval.ID, approval.ID)
+	// The approval subject is the pending command line; only reveal it in a
+	// private chat. In a shared chat show the tool name and point the operator
+	// to the desktop / a DM instead of leaking the command to the whole group.
+	subjectFor := func(route bot.DesktopWatchRoute) string {
+		if isSharedChat(route.ChatType) {
+			return "(命令详情仅在桌面端或私聊显示)"
+		}
+		return truncateForBridge(approval.Subject, botBridgeSubjectLimit)
+	}
 	return desktopBridgeNotification{
-		text: text,
+		text: func(route bot.DesktopWatchRoute) string {
+			return fmt.Sprintf("⚠️ 桌面会话「%s」需要批准操作\n工具: %s\n操作: %s\n\nID: `%s`\n用 /desktop approve %s 批准，/desktop deny %s 拒绝。桌面端先处理则以先到者为准。",
+				label, approval.Tool, subjectFor(route), approval.ID, approval.ID, approval.ID)
+		},
 		card: func(route bot.DesktopWatchRoute) *bot.InteractiveCard {
 			return &bot.InteractiveCard{
 				Header: "桌面会话需要批准",
 				Elements: []bot.InteractiveCardElement{
-					{Tag: "markdown", Content: fmt.Sprintf("**会话**: %s\n\n**工具**: %s\n\n**操作**: %s\n\nID: `%s`", label, approval.Tool, truncateForBridge(approval.Subject, botBridgeSubjectLimit), approval.ID)},
+					{Tag: "markdown", Content: fmt.Sprintf("**会话**: %s\n\n**工具**: %s\n\n**操作**: %s\n\nID: `%s`", label, approval.Tool, subjectFor(route), approval.ID)},
 					{Tag: "action", Extra: map[string]any{
 						"actions": []map[string]any{
 							desktopCardButton("允许一次", "primary", "/desktop approve "+approval.ID, route),
@@ -301,15 +343,21 @@ func (h *botBridgeHub) askNotification(tabID string, ask event.Ask) desktopBridg
 			}
 		}
 	}
-	return desktopBridgeNotification{text: text, card: card}
+	return desktopBridgeNotification{text: constText(text), card: card}
 }
 
 func (h *botBridgeHub) turnDoneNotification(tabID string, err error) desktopBridgeNotification {
 	label := h.tabLabel(tabID)
 	if err != nil {
-		return desktopBridgeNotification{text: fmt.Sprintf("❌ 桌面会话「%s」任务出错: %s", label, truncateForBridge(err.Error(), botBridgeErrTextLimit))}
+		// Error text can contain paths/tokens; only detail it in a private chat.
+		return desktopBridgeNotification{text: func(route bot.DesktopWatchRoute) string {
+			if isSharedChat(route.ChatType) {
+				return fmt.Sprintf("❌ 桌面会话「%s」任务出错（详情见桌面端或私聊）。", label)
+			}
+			return fmt.Sprintf("❌ 桌面会话「%s」任务出错: %s", label, truncateForBridge(err.Error(), botBridgeErrTextLimit))
+		}}
 	}
-	return desktopBridgeNotification{text: fmt.Sprintf("✅ 桌面会话「%s」任务完成。", label)}
+	return desktopBridgeNotification{text: constText(fmt.Sprintf("✅ 桌面会话「%s」任务完成。", label))}
 }
 
 func desktopCardButton(label, style, command string, route bot.DesktopWatchRoute) map[string]any {
@@ -339,7 +387,20 @@ func (h *botBridgeHub) Sessions() []bot.DesktopSessionInfo {
 	if h.sessions == nil {
 		return nil
 	}
-	return h.sessions()
+	sessions := h.sessions()
+	h.mu.Lock()
+	byTab := make(map[string][]bot.DesktopPendingInfo, len(h.pending))
+	for id, p := range h.pending {
+		byTab[p.tabID] = append(byTab[p.tabID], bot.DesktopPendingInfo{ID: id, Kind: p.kind, Tool: p.tool})
+	}
+	h.mu.Unlock()
+	for i := range sessions {
+		if pend := byTab[sessions[i].TabID]; len(pend) > 0 {
+			sort.Slice(pend, func(a, b int) bool { return pend[a].ID < pend[b].ID })
+			sessions[i].Pending = pend
+		}
+	}
+	return sessions
 }
 
 func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
@@ -349,12 +410,25 @@ func (h *botBridgeHub) SetWatch(route bot.DesktopWatchRoute, enable bool) {
 	} else {
 		delete(h.watchers, route.Key())
 	}
+	h.watchSeq++
+	seq := h.watchSeq
 	routes := h.watcherRoutesLocked()
 	persist := h.persistWatchers
 	h.mu.Unlock()
-	if persist != nil {
-		persist(routes)
+	if persist == nil {
+		return
 	}
+	// Serialize persists and drop stale ones: two concurrent SetWatch calls
+	// (different connections) compute snapshots under h.mu but write config
+	// outside it, so their writes could otherwise reorder and let an older
+	// snapshot clobber a newer one, silently losing a subscription.
+	h.persistMu.Lock()
+	defer h.persistMu.Unlock()
+	if seq <= h.lastPersistSeq {
+		return
+	}
+	h.lastPersistSeq = seq
+	persist(routes)
 }
 
 // seedWatchers 用配置里的订阅全集重置内存态（配置是持久化的唯一事实源）。
@@ -444,6 +518,14 @@ func (h *botBridgeHub) Answer(askID string, answers []event.AskAnswer) (string, 
 
 func (h *botBridgeHub) Takeover(route bot.DesktopWatchRoute, tabID string) (string, error) {
 	tabID = strings.TrimSpace(tabID)
+	// DM only. In a group the binding is keyed on the group chat, so after an
+	// admin takes over, ANY allowlisted member's plain message would be diverted
+	// to drive the session — a privilege escalation past the admin gate that
+	// establishes the takeover. Restricting to DM keeps the driver identical to
+	// the operator who established it.
+	if route.ChatType != bot.ChatDM {
+		return "", fmt.Errorf("接管仅支持私聊：在群里接管会让其他成员也能驱动你的桌面会话。请在与 bot 的私聊中接管。")
+	}
 	session, ok := h.sessionByTabID(tabID)
 	if !ok {
 		return "", fmt.Errorf("未找到会话 %s。用 /desktop status 查看可接管的会话。", tabID)
@@ -456,9 +538,11 @@ func (h *botBridgeHub) Takeover(route bot.DesktopWatchRoute, tabID string) (stri
 		h.mu.Unlock()
 		return "", fmt.Errorf("会话「%s」已被另一个聊天接管。", h.tabLabel(tabID))
 	}
-	// 同一聊天换目标：先解除旧绑定。
+	// 同一聊天换目标：先解除旧绑定，并记下旧 tab 以便公告解除。
+	released := ""
 	if prev, ok := h.takeoverTabs[route.Key()]; ok && prev != tabID {
 		delete(h.takeovers, prev)
+		released = prev
 	}
 	h.takeovers[tabID] = route
 	h.takeoverTabs[route.Key()] = tabID
@@ -466,6 +550,9 @@ func (h *botBridgeHub) Takeover(route bot.DesktopWatchRoute, tabID string) (stri
 	changed := h.takeoverChanged
 	h.mu.Unlock()
 	if announce != nil {
+		if released != "" {
+			announce(released, "IM 远程接管已解除（接管方切换到了另一个会话）。")
+		}
 		announce(tabID, "此会话已被 IM 远程接管（bot 管理员）。在此本地发送任意消息即可收回控制。")
 	}
 	if changed != nil {
@@ -523,15 +610,22 @@ func (h *botBridgeHub) DriveInput(route bot.DesktopWatchRoute, text string) (str
 		return "", fmt.Errorf("被接管的会话已关闭或转入后台，接管已自动解除。")
 	}
 	if session.Running {
-		return "", fmt.Errorf("会话「%s」正在执行中，等它完成后再发；或用 /desktop watch on 订阅完成通知。", h.tabLabel(tabID))
+		return "", h.busyError(tabID)
 	}
 	if h.drive == nil {
 		return "", fmt.Errorf("桌面端驱动通道不可用。")
 	}
 	if err := h.drive(tabID, text, route); err != nil {
+		if errors.Is(err, errDriveBusy) {
+			return "", h.busyError(tabID)
+		}
 		return "", fmt.Errorf("驱动失败: %v", err)
 	}
 	return "", nil
+}
+
+func (h *botBridgeHub) busyError(tabID string) error {
+	return fmt.Errorf("会话「%s」正在执行中，等它完成后再发；或用 /desktop watch on 订阅完成通知。", h.tabLabel(tabID))
 }
 
 // reclaimFromDesktop 在桌面用户本地提交输入时收回控制权：解除绑定并通知
@@ -558,7 +652,7 @@ func (h *botBridgeHub) reclaimFromDesktop(tabID string) {
 	label := h.tabLabel(tabID)
 	// 直接入通知队列（不依赖 watch 订阅）：接管者必须知道控制权没了。
 	h.enqueue(desktopBridgeNotification{
-		text:  fmt.Sprintf("🔓 桌面端已收回会话「%s」的控制权，接管已解除。", label),
+		text:  constText(fmt.Sprintf("🔓 桌面端已收回会话「%s」的控制权，接管已解除。", label)),
 		route: &route,
 	})
 }

--- a/desktop/bot_bridge_app.go
+++ b/desktop/bot_bridge_app.go
@@ -112,28 +112,24 @@ func (a *App) bridgeAnnounce(tabID, text string) {
 // bridgeDrive 把远程文本提交为可见 tab 的新 turn，并为这一轮挂上事件转发器,
 // 让输出流回接管聊天（转发器在 TurnDone 自动卸载）。
 func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error {
-	a.mu.RLock()
-	tab := a.tabs[tabID]
-	var sink *tabEventSink
-	var ctrl control.SessionAPI
-	if tab != nil {
-		sink = tab.sink
-		ctrl = tab.Ctrl
+	tab, ctrl, err := a.beginTabTurn(tabID, false)
+	if err != nil {
+		if err == control.ErrTurnRunning {
+			return errDriveBusy
+		}
+		return err
 	}
-	a.mu.RUnlock()
-	if tab == nil || sink == nil {
-		return fmt.Errorf("会话不在前台，无法驱动")
+	if tab.sink == nil {
+		a.finishTabTurnStart(tab, nil)
+		return fmt.Errorf("会话事件通道不可用，无法驱动")
 	}
-	if a.tabIsReadOnly(tab) {
-		return fmt.Errorf("会话是只读的（外部 transcript），无法驱动")
-	}
-	// Fresh busy check (the DriveInput-side check uses a slow ListTabs snapshot).
-	// SubmitDisplay silently no-ops when the controller is already running, so if
-	// we attached the forwarder and submitted into a busy controller, the message
-	// would be dropped AND the forwarder would linger onto the next (foreign)
-	// turn. Bail before attaching.
-	if ctrl != nil && ctrl.RuntimeStatus().Running {
-		return errDriveBusy
+	// A local submission may have reclaimed the tab while this drive was waiting
+	// for the per-tab admission gate. Revalidate ownership only after the gate is
+	// held, immediately before attaching the route-specific forwarder.
+	if a.botBridge == nil || a.botBridge.TakeoverTab(route) != tabID {
+		tab.sink.cancelTurnStart()
+		tab.turnStartMu.Unlock()
+		return fmt.Errorf("接管已解除，请重新接管会话")
 	}
 	target := botForwardTarget{
 		ConnID:   route.ConnectionID,
@@ -141,17 +137,14 @@ func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error
 		ChatID:   route.ChatID,
 		ChatType: route.ChatType,
 	}
-	sink.SetBotSink(newBotEventForwarder(a.botRuntime, []botForwardTarget{target}))
-	if err := a.submitToTab(tabID, text, true); err != nil {
-		sink.SetBotSink(nil)
-		return err
-	}
+	generation := tab.sink.SetBotSink(newBotEventForwarder(a.botRuntime, []botForwardTarget{target}))
+	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.SubmitDisplay(text, text)
 	// Confirm the submit actually started a turn. If nothing is running now, the
-	// controller was busy/rotating in the tiny window after the check above and
-	// the submit no-oped — detach so a later turn's output does not leak, and
-	// report busy instead of silently swallowing the message.
-	if ctrl != nil && !ctrl.RuntimeStatus().Running {
-		sink.SetBotSink(nil)
+	// controller was rotating and the submit no-oped — detach this exact
+	// generation so a later turn's output does not leak.
+	if !a.finishTabTurnStart(tab, ctrl) {
+		tab.sink.clearBotSink(generation)
 		return errDriveBusy
 	}
 	return nil
@@ -159,8 +152,8 @@ func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error
 
 // bridgePersistWatchers 把订阅全集回写用户配置（bot.desktop_watchers），
 // 桌面重启后由 refreshBotRuntime 重新种子。
-func (a *App) bridgePersistWatchers(routes []bot.DesktopWatchRoute) {
-	err := a.applyConfigOnly(func(c *config.Config) error {
+func (a *App) bridgePersistWatchers(routes []bot.DesktopWatchRoute) error {
+	return a.applyConfigOnly(func(c *config.Config) error {
 		watchers := make([]config.BotDesktopWatcherConfig, 0, len(routes))
 		for _, r := range routes {
 			watchers = append(watchers, config.BotDesktopWatcherConfig{
@@ -174,9 +167,6 @@ func (a *App) bridgePersistWatchers(routes []bot.DesktopWatchRoute) {
 		c.Bot.DesktopWatchers = watchers
 		return nil
 	})
-	if err != nil {
-		slog.Warn("persist desktop watchers failed", "err", err)
-	}
 }
 
 func bridgeRoutesFromConfig(watchers []config.BotDesktopWatcherConfig) []bot.DesktopWatchRoute {

--- a/desktop/bot_bridge_app.go
+++ b/desktop/bot_bridge_app.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"reasonix/internal/bot"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+// 本文件是 botBridgeHub 对 App 的全部胶水：会话枚举（含后台 detached）、
+// 按 tab 寻址的审批/问答/驱动、transcript 公告、订阅持久化。
+
+func (a *App) newBotBridge() *botBridgeHub {
+	return newBotBridgeHub(botBridgeDeps{
+		sessions:        a.bridgeSessions,
+		approveTab:      a.bridgeApprove,
+		answerTab:       a.bridgeAnswer,
+		notify:          a.botRuntime.SendToAdapter,
+		drive:           a.bridgeDrive,
+		announce:        a.bridgeAnnounce,
+		persistWatchers: a.bridgePersistWatchers,
+		takeoverChanged: a.emitProjectTreeChanged,
+		logger:          slog.Default(),
+	})
+}
+
+// bridgeSessions 枚举所有 live 会话：可见 tab 用完整 TabMeta，后台 detached
+// 会话补一份轻量快照（controller 仍存活，审批/问答仍可路由）。
+func (a *App) bridgeSessions() []bot.DesktopSessionInfo {
+	tabs := a.ListTabs()
+	out := make([]bot.DesktopSessionInfo, 0, len(tabs)+4)
+	seen := make(map[string]bool, len(tabs))
+	for _, t := range tabs {
+		seen[t.ID] = true
+		out = append(out, bot.DesktopSessionInfo{
+			TabID:         t.ID,
+			Label:         t.Label,
+			Workspace:     t.WorkspaceName,
+			Topic:         t.TopicTitle,
+			Ready:         t.Ready,
+			Running:       t.Running,
+			PendingPrompt: t.PendingPrompt,
+		})
+	}
+	a.mu.RLock()
+	for _, tab := range a.detachedSessions {
+		if tab == nil || seen[tab.ID] {
+			continue
+		}
+		seen[tab.ID] = true
+		out = append(out, bot.DesktopSessionInfo{
+			TabID:    tab.ID,
+			Label:    tab.TopicTitle,
+			Topic:    tab.TopicTitle,
+			Ready:    tab.Ctrl != nil,
+			Running:  strings.TrimSpace(tab.ActivityStatus) != "",
+			Detached: true,
+		})
+	}
+	a.mu.RUnlock()
+	return out
+}
+
+// bridgeCtrlByTabID 解析可见与后台 detached 两张表（区别于 ctrlByTabID：
+// 那是前端语义，空 tabID 落到活跃 tab，且不看 detached）。
+func (a *App) bridgeCtrlByTabID(tabID string) control.SessionAPI {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if tab := a.tabByEventSinkIDLocked(tabID); tab != nil {
+		return tab.Ctrl
+	}
+	return nil
+}
+
+func (a *App) bridgeApprove(tabID, id string, allow, session, persist bool) {
+	if ctrl := a.bridgeCtrlByTabID(tabID); ctrl != nil {
+		ctrl.Approve(id, allow, session, persist)
+	}
+}
+
+func (a *App) bridgeAnswer(tabID, id string, answers []QuestionAnswer) {
+	ctrl := a.bridgeCtrlByTabID(tabID)
+	if ctrl == nil {
+		return
+	}
+	out := make([]event.AskAnswer, len(answers))
+	for i, an := range answers {
+		out[i] = event.AskAnswer{QuestionID: an.QuestionID, Selected: an.Selected}
+	}
+	ctrl.AnswerQuestion(id, out)
+}
+
+// bridgeAnnounce 往会话 transcript 发一条 Notice，桌面用户在聊天流里可见。
+func (a *App) bridgeAnnounce(tabID, text string) {
+	a.mu.RLock()
+	tab := a.tabByEventSinkIDLocked(tabID)
+	var sink *tabEventSink
+	if tab != nil {
+		sink = tab.sink
+	}
+	a.mu.RUnlock()
+	if sink == nil {
+		return
+	}
+	sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
+}
+
+// bridgeDrive 把远程文本提交为可见 tab 的新 turn，并为这一轮挂上事件转发器,
+// 让输出流回接管聊天（转发器在 TurnDone 自动卸载）。
+func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error {
+	a.mu.RLock()
+	tab := a.tabs[tabID]
+	var sink *tabEventSink
+	if tab != nil {
+		sink = tab.sink
+	}
+	a.mu.RUnlock()
+	if tab == nil || sink == nil {
+		return fmt.Errorf("会话不在前台，无法驱动")
+	}
+	if a.tabIsReadOnly(tab) {
+		return fmt.Errorf("会话是只读的（外部 transcript），无法驱动")
+	}
+	target := botForwardTarget{
+		ConnID:   route.ConnectionID,
+		Domain:   route.Domain,
+		ChatID:   route.ChatID,
+		ChatType: route.ChatType,
+	}
+	sink.SetBotSink(newBotEventForwarder(a.botRuntime, []botForwardTarget{target}))
+	if err := a.submitToTab(tabID, text, true); err != nil {
+		sink.SetBotSink(nil)
+		return err
+	}
+	return nil
+}
+
+// bridgePersistWatchers 把订阅全集回写用户配置（bot.desktop_watchers），
+// 桌面重启后由 refreshBotRuntime 重新种子。
+func (a *App) bridgePersistWatchers(routes []bot.DesktopWatchRoute) {
+	err := a.applyConfigOnly(func(c *config.Config) error {
+		watchers := make([]config.BotDesktopWatcherConfig, 0, len(routes))
+		for _, r := range routes {
+			watchers = append(watchers, config.BotDesktopWatcherConfig{
+				Platform:     string(r.Platform),
+				ConnectionID: r.ConnectionID,
+				Domain:       r.Domain,
+				ChatType:     string(r.ChatType),
+				ChatID:       r.ChatID,
+			})
+		}
+		c.Bot.DesktopWatchers = watchers
+		return nil
+	})
+	if err != nil {
+		slog.Warn("persist desktop watchers failed", "err", err)
+	}
+}
+
+func bridgeRoutesFromConfig(watchers []config.BotDesktopWatcherConfig) []bot.DesktopWatchRoute {
+	routes := make([]bot.DesktopWatchRoute, 0, len(watchers))
+	for _, w := range watchers {
+		routes = append(routes, bot.DesktopWatchRoute{
+			Platform:     bot.Platform(strings.TrimSpace(w.Platform)),
+			ConnectionID: strings.TrimSpace(w.ConnectionID),
+			Domain:       strings.TrimSpace(w.Domain),
+			ChatType:     bot.ChatType(strings.TrimSpace(w.ChatType)),
+			ChatID:       strings.TrimSpace(w.ChatID),
+		})
+	}
+	return routes
+}

--- a/desktop/bot_bridge_app.go
+++ b/desktop/bot_bridge_app.go
@@ -115,8 +115,10 @@ func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error
 	a.mu.RLock()
 	tab := a.tabs[tabID]
 	var sink *tabEventSink
+	var ctrl control.SessionAPI
 	if tab != nil {
 		sink = tab.sink
+		ctrl = tab.Ctrl
 	}
 	a.mu.RUnlock()
 	if tab == nil || sink == nil {
@@ -124,6 +126,14 @@ func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error
 	}
 	if a.tabIsReadOnly(tab) {
 		return fmt.Errorf("会话是只读的（外部 transcript），无法驱动")
+	}
+	// Fresh busy check (the DriveInput-side check uses a slow ListTabs snapshot).
+	// SubmitDisplay silently no-ops when the controller is already running, so if
+	// we attached the forwarder and submitted into a busy controller, the message
+	// would be dropped AND the forwarder would linger onto the next (foreign)
+	// turn. Bail before attaching.
+	if ctrl != nil && ctrl.RuntimeStatus().Running {
+		return errDriveBusy
 	}
 	target := botForwardTarget{
 		ConnID:   route.ConnectionID,
@@ -135,6 +145,14 @@ func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error
 	if err := a.submitToTab(tabID, text, true); err != nil {
 		sink.SetBotSink(nil)
 		return err
+	}
+	// Confirm the submit actually started a turn. If nothing is running now, the
+	// controller was busy/rotating in the tiny window after the check above and
+	// the submit no-oped — detach so a later turn's output does not leak, and
+	// report busy instead of silently swallowing the message.
+	if ctrl != nil && !ctrl.RuntimeStatus().Running {
+		sink.SetBotSink(nil)
+		return errDriveBusy
 	}
 	return nil
 }

--- a/desktop/bot_bridge_test.go
+++ b/desktop/bot_bridge_test.go
@@ -21,32 +21,72 @@ type bridgeNotifyCall struct {
 }
 
 type bridgeTestEnv struct {
-	hub      *botBridgeHub
-	notified chan bridgeNotifyCall
-	approves chan [2]string // [tabID, id+":"+allow]
-	answers  chan [2]string // [tabID, id]
+	hub       *botBridgeHub
+	notified  chan bridgeNotifyCall
+	approves  chan [2]string // [tabID, id+":"+allow]
+	answers   chan [2]string // [tabID, id]
+	driven    chan [2]string // [tabID, text]
+	announced chan [2]string // [tabID, text]
+	persisted chan []bot.DesktopWatchRoute
+	driveErr  error
+}
+
+func tabsToSessions(tabs []TabMeta) []bot.DesktopSessionInfo {
+	out := make([]bot.DesktopSessionInfo, 0, len(tabs))
+	for _, t := range tabs {
+		out = append(out, bot.DesktopSessionInfo{
+			TabID:         t.ID,
+			Label:         t.Label,
+			Workspace:     t.WorkspaceName,
+			Topic:         t.TopicTitle,
+			Ready:         t.Ready,
+			Running:       t.Running,
+			PendingPrompt: t.PendingPrompt,
+		})
+	}
+	return out
 }
 
 func newBridgeTestEnv(tabs []TabMeta) *bridgeTestEnv {
+	return newBridgeTestEnvSessions(tabsToSessions(tabs))
+}
+
+func newBridgeTestEnvSessions(sessions []bot.DesktopSessionInfo) *bridgeTestEnv {
 	env := &bridgeTestEnv{
-		notified: make(chan bridgeNotifyCall, 16),
-		approves: make(chan [2]string, 16),
-		answers:  make(chan [2]string, 16),
+		notified:  make(chan bridgeNotifyCall, 16),
+		approves:  make(chan [2]string, 16),
+		answers:   make(chan [2]string, 16),
+		driven:    make(chan [2]string, 16),
+		announced: make(chan [2]string, 16),
+		persisted: make(chan []bot.DesktopWatchRoute, 16),
 	}
-	env.hub = newBotBridgeHub(
-		func() []TabMeta { return tabs },
-		func(tabID, id string, allow, session, persist bool) {
+	env.hub = newBotBridgeHub(botBridgeDeps{
+		sessions: func() []bot.DesktopSessionInfo { return sessions },
+		approveTab: func(tabID, id string, allow, session, persist bool) {
 			env.approves <- [2]string{tabID, fmt.Sprintf("%s:%t", id, allow)}
 		},
-		func(tabID, id string, answers []QuestionAnswer) {
+		answerTab: func(tabID, id string, answers []QuestionAnswer) {
 			env.answers <- [2]string{tabID, id}
 		},
-		func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error) {
+		notify: func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error) {
 			env.notified <- bridgeNotifyCall{connectionID: connectionID, domain: domain, msg: msg}
 			return bot.SendResult{MessageID: "sent-1"}, nil
 		},
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
-	)
+		drive: func(tabID, text string, route bot.DesktopWatchRoute) error {
+			if env.driveErr != nil {
+				return env.driveErr
+			}
+			env.driven <- [2]string{tabID, text}
+			return nil
+		},
+		announce: func(tabID, text string) {
+			env.announced <- [2]string{tabID, text}
+		},
+		persistWatchers: func(routes []bot.DesktopWatchRoute) {
+			env.persisted <- routes
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
 	return env
 }
 
@@ -225,5 +265,151 @@ func TestBridgeWatchLifecycleStopsNotifications(t *testing.T) {
 	}
 
 	env.hub.observe("tab-x", event.Event{Kind: event.TurnDone})
+	env.expectNoNotification(t)
+}
+
+func TestBridgeSetWatchPersistsAndSeedRestores(t *testing.T) {
+	env := newBridgeTestEnv(nil)
+	route := testWatchRoute()
+
+	env.hub.SetWatch(route, true)
+	select {
+	case routes := <-env.persisted:
+		if len(routes) != 1 || routes[0].Key() != route.Key() {
+			t.Fatalf("persisted = %+v, want the subscribed route", routes)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SetWatch did not persist watchers")
+	}
+
+	// 模拟重启:全新 hub 从配置种子恢复。
+	env2 := newBridgeTestEnv(nil)
+	env2.hub.seedWatchers([]bot.DesktopWatchRoute{route})
+	if !env2.hub.Watching(route) {
+		t.Fatal("seeded hub should be watching the persisted route")
+	}
+	env2.hub.observe("tab-x", event.Event{Kind: event.TurnDone})
+	if call := env2.waitNotification(t); !strings.Contains(call.msg.Text, "✅") {
+		t.Fatalf("seeded watcher did not receive notifications: %q", call.msg.Text)
+	}
+}
+
+func TestBridgeApprovalRoutesToDetachedSession(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{
+		{TabID: "tab-bg", Label: "后台任务", Detached: true, Ready: true},
+	})
+
+	env.hub.observe("tab-bg", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "appr-bg", Tool: "bash"}})
+	if _, err := env.hub.Approve("appr-bg", true); err != nil {
+		t.Fatalf("Approve on detached session: %v", err)
+	}
+	select {
+	case got := <-env.approves:
+		if got[0] != "tab-bg" {
+			t.Fatalf("approve routed to %v, want tab-bg", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("detached approval was not routed")
+	}
+}
+
+func TestBridgeTakeoverLifecycle(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{
+		{TabID: "tab-1", Label: "会话一", Ready: true},
+		{TabID: "tab-bg", Label: "后台", Detached: true},
+	})
+	route := testWatchRoute()
+
+	// 后台会话拒绝接管。
+	if _, err := env.hub.Takeover(route, "tab-bg"); err == nil {
+		t.Fatal("takeover of a detached session should fail")
+	}
+
+	feedback, err := env.hub.Takeover(route, "tab-1")
+	if err != nil {
+		t.Fatalf("Takeover: %v", err)
+	}
+	if !strings.Contains(feedback, "已接管") {
+		t.Fatalf("feedback = %q", feedback)
+	}
+	if env.hub.TakeoverTab(route) != "tab-1" {
+		t.Fatalf("TakeoverTab = %q, want tab-1", env.hub.TakeoverTab(route))
+	}
+	select {
+	case got := <-env.announced:
+		if got[0] != "tab-1" || !strings.Contains(got[1], "接管") {
+			t.Fatalf("announce = %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("takeover was not announced to the desktop transcript")
+	}
+
+	// 驱动输入路由到 tab。
+	if _, err := env.hub.DriveInput(route, "跑一下测试"); err != nil {
+		t.Fatalf("DriveInput: %v", err)
+	}
+	select {
+	case got := <-env.driven:
+		if got[0] != "tab-1" || got[1] != "跑一下测试" {
+			t.Fatalf("driven = %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("drive input was not routed")
+	}
+
+	// 另一个聊天抢同一会话被拒。
+	other := route
+	other.ChatID = "chat-other"
+	if _, err := env.hub.Takeover(other, "tab-1"); err == nil {
+		t.Fatal("takeover by another chat should be rejected while held")
+	}
+
+	// 释放。
+	if _, err := env.hub.Release(route); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if env.hub.TakeoverTab(route) != "" {
+		t.Fatal("binding should be cleared after release")
+	}
+	if _, err := env.hub.Release(route); err == nil {
+		t.Fatal("second release should report no binding")
+	}
+}
+
+func TestBridgeDriveInputRejectsRunningSession(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{
+		{TabID: "tab-1", Label: "会话一", Ready: true, Running: true},
+	})
+	route := testWatchRoute()
+	if _, err := env.hub.Takeover(route, "tab-1"); err != nil {
+		t.Fatalf("Takeover: %v", err)
+	}
+	<-env.announced
+	if _, err := env.hub.DriveInput(route, "hello"); err == nil || !strings.Contains(err.Error(), "正在执行中") {
+		t.Fatalf("DriveInput on running session = %v, want busy rejection", err)
+	}
+}
+
+func TestBridgeReclaimFromDesktopNotifiesController(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{
+		{TabID: "tab-1", Label: "会话一", Ready: true},
+	})
+	route := testWatchRoute()
+	if _, err := env.hub.Takeover(route, "tab-1"); err != nil {
+		t.Fatalf("Takeover: %v", err)
+	}
+	<-env.announced
+
+	env.hub.reclaimFromDesktop("tab-1")
+	if env.hub.TakeoverTab(route) != "" {
+		t.Fatal("reclaim should clear the binding")
+	}
+	call := env.waitNotification(t)
+	if !strings.Contains(call.msg.Text, "收回") || call.msg.ChatID != route.ChatID {
+		t.Fatalf("reclaim notification = %+v", call)
+	}
+
+	// 未接管 tab 的 reclaim 是 no-op。
+	env.hub.reclaimFromDesktop("tab-1")
 	env.expectNoNotification(t)
 }

--- a/desktop/bot_bridge_test.go
+++ b/desktop/bot_bridge_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/bot"
+	"reasonix/internal/event"
+)
+
+type bridgeNotifyCall struct {
+	connectionID string
+	domain       string
+	msg          bot.OutboundMessage
+}
+
+type bridgeTestEnv struct {
+	hub      *botBridgeHub
+	notified chan bridgeNotifyCall
+	approves chan [2]string // [tabID, id+":"+allow]
+	answers  chan [2]string // [tabID, id]
+}
+
+func newBridgeTestEnv(tabs []TabMeta) *bridgeTestEnv {
+	env := &bridgeTestEnv{
+		notified: make(chan bridgeNotifyCall, 16),
+		approves: make(chan [2]string, 16),
+		answers:  make(chan [2]string, 16),
+	}
+	env.hub = newBotBridgeHub(
+		func() []TabMeta { return tabs },
+		func(tabID, id string, allow, session, persist bool) {
+			env.approves <- [2]string{tabID, fmt.Sprintf("%s:%t", id, allow)}
+		},
+		func(tabID, id string, answers []QuestionAnswer) {
+			env.answers <- [2]string{tabID, id}
+		},
+		func(ctx context.Context, connectionID, domain string, msg bot.OutboundMessage) (bot.SendResult, error) {
+			env.notified <- bridgeNotifyCall{connectionID: connectionID, domain: domain, msg: msg}
+			return bot.SendResult{MessageID: "sent-1"}, nil
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	return env
+}
+
+func (env *bridgeTestEnv) waitNotification(t *testing.T) bridgeNotifyCall {
+	t.Helper()
+	select {
+	case call := <-env.notified:
+		return call
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for bridge notification")
+		return bridgeNotifyCall{}
+	}
+}
+
+func (env *bridgeTestEnv) expectNoNotification(t *testing.T) {
+	t.Helper()
+	select {
+	case call := <-env.notified:
+		t.Fatalf("unexpected notification: %+v", call)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func testWatchRoute() bot.DesktopWatchRoute {
+	return bot.DesktopWatchRoute{
+		ConnectionID: "feishu-main",
+		Domain:       "feishu",
+		Platform:     bot.PlatformFeishu,
+		ChatType:     bot.ChatDM,
+		ChatID:       "chat-god",
+	}
+}
+
+func TestBridgeApprovalNotifiesWatchersAndRoutesApproval(t *testing.T) {
+	env := newBridgeTestEnv([]TabMeta{{ID: "tab-1", Label: "修复登录"}})
+	env.hub.SetWatch(testWatchRoute(), true)
+
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{
+		ID: "appr-1", Tool: "bash", Subject: "rm -rf build",
+	}})
+
+	call := env.waitNotification(t)
+	if call.connectionID != "feishu-main" || call.msg.ChatID != "chat-god" {
+		t.Fatalf("notification routed to %s/%s, want feishu-main/chat-god", call.connectionID, call.msg.ChatID)
+	}
+	for _, want := range []string{"修复登录", "bash", "rm -rf build", "/desktop approve appr-1"} {
+		if !strings.Contains(call.msg.Text, want) {
+			t.Fatalf("notification text = %q, want it to contain %q", call.msg.Text, want)
+		}
+	}
+	if call.msg.Card == nil {
+		t.Fatal("approval notification should carry an interactive card")
+	}
+
+	feedback, err := env.hub.Approve("appr-1", true)
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if !strings.Contains(feedback, "先到者为准") {
+		t.Fatalf("feedback = %q, want first-wins note", feedback)
+	}
+	select {
+	case got := <-env.approves:
+		if got[0] != "tab-1" || got[1] != "appr-1:true" {
+			t.Fatalf("approve routed as %v, want tab-1/appr-1:true", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("approve was not routed to the tab")
+	}
+
+	// 同一 ID 第二次应答:pending 已清,返回未找到。
+	if _, err := env.hub.Approve("appr-1", false); err == nil {
+		t.Fatal("second Approve on the same id should fail")
+	}
+}
+
+func TestBridgePendingRecordedWithoutWatchers(t *testing.T) {
+	env := newBridgeTestEnv([]TabMeta{{ID: "tab-1", Label: "会话"}})
+
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "appr-2", Tool: "bash"}})
+	env.expectNoNotification(t)
+
+	if _, err := env.hub.Approve("appr-2", false); err != nil {
+		t.Fatalf("Approve without watchers should still work: %v", err)
+	}
+	select {
+	case got := <-env.approves:
+		if got[1] != "appr-2:false" {
+			t.Fatalf("deny routed as %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deny was not routed")
+	}
+}
+
+func TestBridgeTurnDoneClearsPendingAndNotifies(t *testing.T) {
+	env := newBridgeTestEnv([]TabMeta{{ID: "tab-1", Label: "会话一"}})
+	env.hub.SetWatch(testWatchRoute(), true)
+
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "appr-3", Tool: "bash"}})
+	env.waitNotification(t)
+
+	env.hub.observe("tab-1", event.Event{Kind: event.TurnDone})
+	call := env.waitNotification(t)
+	if !strings.Contains(call.msg.Text, "✅") || !strings.Contains(call.msg.Text, "会话一") {
+		t.Fatalf("turn-done text = %q", call.msg.Text)
+	}
+
+	if _, err := env.hub.Approve("appr-3", true); err == nil {
+		t.Fatal("pending approval should be cleared by TurnDone")
+	}
+}
+
+func TestBridgeSuppressesCanceledTurnAndErrorsNotify(t *testing.T) {
+	env := newBridgeTestEnv([]TabMeta{{ID: "tab-1", Label: "会话一"}})
+	env.hub.SetWatch(testWatchRoute(), true)
+
+	env.hub.observe("tab-1", event.Event{Kind: event.TurnDone, Err: errors.New("context canceled")})
+	env.expectNoNotification(t)
+
+	env.hub.observe("tab-1", event.Event{Kind: event.TurnDone, Err: errors.New("boom")})
+	call := env.waitNotification(t)
+	if !strings.Contains(call.msg.Text, "❌") || !strings.Contains(call.msg.Text, "boom") {
+		t.Fatalf("error text = %q", call.msg.Text)
+	}
+}
+
+func TestBridgeAskAnswerRoundTrip(t *testing.T) {
+	env := newBridgeTestEnv([]TabMeta{{ID: "tab-2", Label: "问答会话"}})
+	env.hub.SetWatch(testWatchRoute(), true)
+
+	env.hub.observe("tab-2", event.Event{Kind: event.AskRequest, Ask: event.Ask{
+		ID: "ask-1",
+		Questions: []event.AskQuestion{{
+			ID:      "q1",
+			Prompt:  "选一个方案",
+			Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+		}},
+	}})
+	call := env.waitNotification(t)
+	if !strings.Contains(call.msg.Text, "/desktop answer ask-1") {
+		t.Fatalf("ask notification = %q, want answer hint", call.msg.Text)
+	}
+	if call.msg.Card == nil {
+		t.Fatal("single-choice ask should carry option buttons")
+	}
+
+	questions, ok := env.hub.AskQuestions("ask-1")
+	if !ok || len(questions) != 1 {
+		t.Fatalf("AskQuestions = %v/%v", questions, ok)
+	}
+	if _, err := env.hub.Answer("ask-1", []event.AskAnswer{{QuestionID: "q1", Selected: []string{"B"}}}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	select {
+	case got := <-env.answers:
+		if got[0] != "tab-2" || got[1] != "ask-1" {
+			t.Fatalf("answer routed as %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("answer was not routed")
+	}
+}
+
+func TestBridgeWatchLifecycleStopsNotifications(t *testing.T) {
+	env := newBridgeTestEnv(nil)
+	route := testWatchRoute()
+
+	env.hub.SetWatch(route, true)
+	if !env.hub.Watching(route) {
+		t.Fatal("route should be watching after SetWatch(true)")
+	}
+	env.hub.SetWatch(route, false)
+	if env.hub.Watching(route) {
+		t.Fatal("route should not be watching after SetWatch(false)")
+	}
+
+	env.hub.observe("tab-x", event.Event{Kind: event.TurnDone})
+	env.expectNoNotification(t)
+}

--- a/desktop/bot_bridge_test.go
+++ b/desktop/bot_bridge_test.go
@@ -21,14 +21,15 @@ type bridgeNotifyCall struct {
 }
 
 type bridgeTestEnv struct {
-	hub       *botBridgeHub
-	notified  chan bridgeNotifyCall
-	approves  chan [2]string // [tabID, id+":"+allow]
-	answers   chan [2]string // [tabID, id]
-	driven    chan [2]string // [tabID, text]
-	announced chan [2]string // [tabID, text]
-	persisted chan []bot.DesktopWatchRoute
-	driveErr  error
+	hub        *botBridgeHub
+	notified   chan bridgeNotifyCall
+	approves   chan [2]string // [tabID, id+":"+allow]
+	answers    chan [2]string // [tabID, id]
+	driven     chan [2]string // [tabID, text]
+	announced  chan [2]string // [tabID, text]
+	persisted  chan []bot.DesktopWatchRoute
+	driveErr   error
+	persistErr error
 }
 
 func tabsToSessions(tabs []TabMeta) []bot.DesktopSessionInfo {
@@ -82,8 +83,9 @@ func newBridgeTestEnvSessions(sessions []bot.DesktopSessionInfo) *bridgeTestEnv 
 		announce: func(tabID, text string) {
 			env.announced <- [2]string{tabID, text}
 		},
-		persistWatchers: func(routes []bot.DesktopWatchRoute) {
+		persistWatchers: func(routes []bot.DesktopWatchRoute) error {
 			env.persisted <- routes
+			return env.persistErr
 		},
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
@@ -206,6 +208,27 @@ func TestBridgeApprovalShowsSubjectInDM(t *testing.T) {
 	call := env.waitNotification(t)
 	if !strings.Contains(call.msg.Text, "rm -rf build") {
 		t.Fatalf("DM notification should show the command line: %q", call.msg.Text)
+	}
+}
+
+func TestBridgeAskRedactsPromptAndOptionsInGroup(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}})
+	if err := env.hub.SetWatch(testGroupRoute(), true); err != nil {
+		t.Fatalf("SetWatch: %v", err)
+	}
+	<-env.persisted
+	env.hub.observe("tab-1", event.Event{Kind: event.AskRequest, Ask: event.Ask{
+		ID: "redacted-ask",
+		Questions: []event.AskQuestion{{
+			ID: "q1", Prompt: "INTERNAL_ONLY_PROMPT", Options: []event.AskOption{{Label: "CHOICE_INTERNAL"}},
+		}},
+	}})
+	call := env.waitNotification(t)
+	if strings.Contains(call.msg.Text, "INTERNAL_ONLY_PROMPT") || strings.Contains(call.msg.Text, "CHOICE_INTERNAL") {
+		t.Fatalf("group notification leaked ask details: %q", call.msg.Text)
+	}
+	if call.msg.Card != nil {
+		t.Fatal("group ask notification must not include option buttons")
 	}
 }
 
@@ -404,13 +427,60 @@ func TestBridgeSetWatchPersistsAndSeedRestores(t *testing.T) {
 
 	// 模拟重启:全新 hub 从配置种子恢复。
 	env2 := newBridgeTestEnv(nil)
-	env2.hub.seedWatchers([]bot.DesktopWatchRoute{route})
+	env2.hub.seedWatchers([]bot.DesktopWatchRoute{route}, env2.hub.watcherVersion())
 	if !env2.hub.Watching(route) {
 		t.Fatal("seeded hub should be watching the persisted route")
 	}
 	env2.hub.observe("tab-x", event.Event{Kind: event.TurnDone})
 	if call := env2.waitNotification(t); !strings.Contains(call.msg.Text, "✅") {
 		t.Fatalf("seeded watcher did not receive notifications: %q", call.msg.Text)
+	}
+}
+
+func TestBridgeSeedDoesNotOverwriteNewerRuntimeWatch(t *testing.T) {
+	env := newBridgeTestEnv(nil)
+	route := testWatchRoute()
+	staleVersion := env.hub.watcherVersion()
+	if err := env.hub.SetWatch(route, true); err != nil {
+		t.Fatalf("SetWatch: %v", err)
+	}
+	<-env.persisted
+
+	// Simulate a runtime refresh carrying a config snapshot loaded before the
+	// watch command persisted. It must not erase the newer in-process route.
+	env.hub.seedWatchers(nil, staleVersion)
+	if !env.hub.Watching(route) {
+		t.Fatal("stale config seed overwrote the newer runtime subscription")
+	}
+}
+
+func TestBridgeSeedPreservesWatchAfterPersistFailure(t *testing.T) {
+	env := newBridgeTestEnv(nil)
+	env.persistErr = errors.New("disk unavailable")
+	route := testWatchRoute()
+	if err := env.hub.SetWatch(route, true); err == nil {
+		t.Fatal("SetWatch should report the persistence failure")
+	}
+	<-env.persisted
+
+	env.hub.seedWatchers(nil, env.hub.watcherVersion())
+	if !env.hub.Watching(route) {
+		t.Fatal("disk snapshot erased a runtime watch whose persistence failed")
+	}
+}
+
+func TestBridgeSeedAppliesFreshExternalConfig(t *testing.T) {
+	env := newBridgeTestEnv(nil)
+	route := testWatchRoute()
+	version := env.hub.watcherVersion()
+	env.hub.seedWatchers([]bot.DesktopWatchRoute{route}, version)
+	if !env.hub.Watching(route) {
+		t.Fatal("initial config seed did not apply")
+	}
+
+	env.hub.seedWatchers(nil, version)
+	if env.hub.Watching(route) {
+		t.Fatal("fresh external config update did not replace the watcher set")
 	}
 }
 

--- a/desktop/bot_bridge_test.go
+++ b/desktop/bot_bridge_test.go
@@ -120,6 +120,126 @@ func testWatchRoute() bot.DesktopWatchRoute {
 	}
 }
 
+func testGroupRoute() bot.DesktopWatchRoute {
+	r := testWatchRoute()
+	r.ChatType = bot.ChatGroup
+	r.ChatID = "group-god"
+	return r
+}
+
+func TestBridgeTakeoverRejectsGroupChat(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一", Ready: true}})
+	if _, err := env.hub.Takeover(testGroupRoute(), "tab-1"); err == nil {
+		t.Fatal("takeover from a group chat must be rejected (non-admin members could otherwise drive it)")
+	}
+	if _, err := env.hub.Takeover(testWatchRoute(), "tab-1"); err != nil {
+		t.Fatalf("DM takeover should work: %v", err)
+	}
+}
+
+func TestBridgeTakeoverSwitchAnnouncesReleaseToOldTab(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{
+		{TabID: "tab-a", Label: "A", Ready: true},
+		{TabID: "tab-b", Label: "B", Ready: true},
+	})
+	route := testWatchRoute()
+	if _, err := env.hub.Takeover(route, "tab-a"); err != nil {
+		t.Fatalf("takeover A: %v", err)
+	}
+	if got := <-env.announced; got[0] != "tab-a" {
+		t.Fatalf("first announce = %v, want tab-a takeover", got)
+	}
+	if _, err := env.hub.Takeover(route, "tab-b"); err != nil {
+		t.Fatalf("switch to B: %v", err)
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-env.announced:
+			seen[got[0]] = true
+		case <-time.After(time.Second):
+			t.Fatalf("missing announce after switch; seen=%v", seen)
+		}
+	}
+	if !seen["tab-a"] || !seen["tab-b"] {
+		t.Fatalf("switch should announce release to tab-a and takeover to tab-b; seen=%v", seen)
+	}
+}
+
+func TestBridgeDriveInputBusyReturnsBusyMessage(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一", Ready: true}})
+	route := testWatchRoute()
+	if _, err := env.hub.Takeover(route, "tab-1"); err != nil {
+		t.Fatalf("Takeover: %v", err)
+	}
+	<-env.announced
+	env.driveErr = errDriveBusy
+	_, err := env.hub.DriveInput(route, "hi")
+	if err == nil || !strings.Contains(err.Error(), "正在执行中") {
+		t.Fatalf("busy drive should surface a clean busy message, got %v", err)
+	}
+}
+
+func TestBridgeApprovalRedactsSubjectInGroup(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}})
+	env.hub.SetWatch(testGroupRoute(), true)
+	<-env.persisted
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "a1", Tool: "bash", Subject: "rm -rf /secret"}})
+	call := env.waitNotification(t)
+	if strings.Contains(call.msg.Text, "rm -rf /secret") {
+		t.Fatalf("group notification leaked the command line: %q", call.msg.Text)
+	}
+	if call.msg.Card != nil {
+		for _, el := range call.msg.Card.Elements {
+			if strings.Contains(el.Content, "rm -rf /secret") {
+				t.Fatal("group card leaked the command line")
+			}
+		}
+	}
+}
+
+func TestBridgeApprovalShowsSubjectInDM(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}})
+	env.hub.SetWatch(testWatchRoute(), true)
+	<-env.persisted
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "a1", Tool: "bash", Subject: "rm -rf build"}})
+	call := env.waitNotification(t)
+	if !strings.Contains(call.msg.Text, "rm -rf build") {
+		t.Fatalf("DM notification should show the command line: %q", call.msg.Text)
+	}
+}
+
+func TestBridgeSessionsIncludePendingIDs(t *testing.T) {
+	env := newBridgeTestEnvSessions([]bot.DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}})
+	env.hub.observe("tab-1", event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "a1", Tool: "bash"}})
+	env.hub.observe("tab-1", event.Event{Kind: event.AskRequest, Ask: event.Ask{ID: "q1", Questions: []event.AskQuestion{{ID: "x", Prompt: "?"}}}})
+	found := map[string]bool{}
+	for _, s := range env.hub.Sessions() {
+		if s.TabID != "tab-1" {
+			continue
+		}
+		for _, p := range s.Pending {
+			found[p.ID] = true
+		}
+	}
+	if !found["a1"] || !found["q1"] {
+		t.Fatalf("Sessions() should surface pending approval and ask ids; got %v", found)
+	}
+}
+
+func TestBridgePersistDropsStaleSnapshot(t *testing.T) {
+	env := newBridgeTestEnvSessions(nil)
+	// Two subscribes: the second (newer seq) must be the persisted result even
+	// though we invoke the seed-restore afterward.
+	env.hub.SetWatch(testWatchRoute(), true)
+	<-env.persisted
+	env.hub.SetWatch(testGroupRoute(), true)
+	routes := <-env.persisted
+	if len(routes) != 2 {
+		t.Fatalf("persisted routes = %d, want both subscriptions", len(routes))
+	}
+}
+
 func TestBridgeApprovalNotifiesWatchersAndRoutesApproval(t *testing.T) {
 	env := newBridgeTestEnv([]TabMeta{{ID: "tab-1", Label: "修复登录"}})
 	env.hub.SetWatch(testWatchRoute(), true)

--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -81,7 +81,13 @@ func (a *App) refreshBotRuntime() {
 		a.botRuntime.stop("error", err.Error())
 		return
 	}
-	_ = a.botRuntime.apply(a.bootContext(), cfg, globalTabWorkspaceRoot(), a.persistRemoteBotToolApprovalMode)
+	// Assign through a typed local so a nil *botBridgeHub never becomes a
+	// non-nil bot.DesktopBridge interface inside the gateway config.
+	var bridge bot.DesktopBridge
+	if a.botBridge != nil {
+		bridge = a.botBridge
+	}
+	_ = a.botRuntime.apply(a.bootContext(), cfg, globalTabWorkspaceRoot(), a.persistRemoteBotToolApprovalMode, bridge)
 }
 
 func (a *App) loadDesktopBotConfig() (*config.Config, error) {
@@ -109,7 +115,7 @@ func (a *App) BotRuntimeStatus() BotRuntimeStatusView {
 	return a.botRuntime.snapshot()
 }
 
-func (r *desktopBotRuntime) apply(parent context.Context, cfg *config.Config, workspaceRoot string, onToolApprovalModeChange func(bot.InboundMessage, string) error) error {
+func (r *desktopBotRuntime) apply(parent context.Context, cfg *config.Config, workspaceRoot string, onToolApprovalModeChange func(bot.InboundMessage, string) error, bridge bot.DesktopBridge) error {
 	if r == nil {
 		return nil
 	}
@@ -184,6 +190,7 @@ func (r *desktopBotRuntime) apply(parent context.Context, cfg *config.Config, wo
 		OnInbound:                botruntime.NewRemoteRememberer(logger),
 		OnSessionReady:           botruntime.NewSessionRemembererWithWorkspace(logger, workspaceRoot),
 		OnToolApprovalModeChange: onToolApprovalModeChange,
+		Desktop:                  bridge,
 	}
 	bindings := botruntime.AdapterBindings(cfg, plan.Enabled, nil, logger)
 	if len(bindings) == 0 {

--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -85,6 +85,9 @@ func (a *App) refreshBotRuntime() {
 	// non-nil bot.DesktopBridge interface inside the gateway config.
 	var bridge bot.DesktopBridge
 	if a.botBridge != nil {
+		// 配置是订阅的持久化事实源：每次运行时重算前重新种子，桌面重启后
+		// /desktop watch 的订阅继续生效。
+		a.botBridge.seedWatchers(bridgeRoutesFromConfig(cfg.Bot.DesktopWatchers))
 		bridge = a.botBridge
 	}
 	_ = a.botRuntime.apply(a.bootContext(), cfg, globalTabWorkspaceRoot(), a.persistRemoteBotToolApprovalMode, bridge)

--- a/desktop/bot_runtime_app.go
+++ b/desktop/bot_runtime_app.go
@@ -76,6 +76,10 @@ func (a *App) refreshBotRuntime() {
 	if a.botRuntime == nil {
 		return
 	}
+	var watcherVersion uint64
+	if a.botBridge != nil {
+		watcherVersion = a.botBridge.watcherVersion()
+	}
 	cfg, err := a.loadDesktopBotConfig()
 	if err != nil {
 		a.botRuntime.stop("error", err.Error())
@@ -87,7 +91,7 @@ func (a *App) refreshBotRuntime() {
 	if a.botBridge != nil {
 		// 配置是订阅的持久化事实源：每次运行时重算前重新种子，桌面重启后
 		// /desktop watch 的订阅继续生效。
-		a.botBridge.seedWatchers(bridgeRoutesFromConfig(cfg.Bot.DesktopWatchers))
+		a.botBridge.seedWatchers(bridgeRoutesFromConfig(cfg.Bot.DesktopWatchers), watcherVersion)
 		bridge = a.botBridge
 	}
 	_ = a.botRuntime.apply(a.bootContext(), cfg, globalTabWorkspaceRoot(), a.persistRemoteBotToolApprovalMode, bridge)

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -22,6 +22,7 @@ import (
 
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/event"
 )
 
 // ── Data model ──────────────────────────────────────────────────────────────
@@ -353,17 +354,14 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 	// session-mapped targets. The forwarder is set on the tab's event sink
 	// so AI output events are streamed to connected bot channels in
 	// real-time alongside the desktop UI.
-	botForwardAttached := false
+	var botForwarder event.Sink
 	if t.NotifyChannels != nil && *t.NotifyChannels {
-		botForwardAttached = e.attachBotForwarder(tabMeta.ID)
+		botForwarder = e.newBotForwarder(tabMeta.ID)
 	}
 
 	// Submit as a plain user turn so scheduled prompts cannot invoke desktop
 	// shell or slash-command handlers such as "!cmd", "/clear", or "/compact".
-	if !e.app.submitUserTurnToTab(tabMeta.ID, t.Prompt) {
-		if botForwardAttached {
-			e.clearBotForwarder(tabMeta.ID)
-		}
+	if !e.app.submitUserTurnToTabWithSink(tabMeta.ID, t.Prompt, botForwarder) {
 		log.Printf("[heartbeat] submit skipped for %q", t.Title)
 		return t
 	}
@@ -862,39 +860,26 @@ func (a *App) HeartbeatGenerateID() string {
 	return string(b)
 }
 
-// attachBotForwarder sets up event forwarding to connected bot channels for
-// the tab identified by tabID. It is called before submitting a heartbeat
-// prompt. If the bot runtime is not active or has no session-mapped targets
-// the call is a no-op.
-func (e *HeartbeatEngine) attachBotForwarder(tabID string) bool {
+// newBotForwarder builds event forwarding for a heartbeat turn. The caller
+// attaches it only after acquiring the tab's turn-admission gate.
+func (e *HeartbeatEngine) newBotForwarder(tabID string) event.Sink {
 	runtime := e.app.botRuntime
 	if runtime == nil || !runtime.Running() {
-		return false
+		return nil
 	}
 	cfg, err := e.app.loadDesktopBotConfig()
 	if err != nil {
 		log.Printf("[heartbeat] load config for bot forward: %v", err)
-		return false
+		return nil
 	}
 	targets := runtime.ForwardTargets(cfg)
 	if len(targets) == 0 {
-		return false // no session-mapped channels to forward to
+		return nil // no session-mapped channels to forward to
 	}
 	tab := e.app.tabByID(tabID)
 	if tab == nil || tab.sink == nil {
-		return false
+		return nil
 	}
 	log.Printf("[heartbeat] bot forwarding attached: %d target(s) for tab %s", len(targets), tabID)
-
-	forwarder := newBotEventForwarder(runtime, targets)
-	tab.sink.SetBotSink(forwarder)
-	return true
-}
-
-func (e *HeartbeatEngine) clearBotForwarder(tabID string) {
-	tab := e.app.tabByID(tabID)
-	if tab == nil || tab.sink == nil {
-		return
-	}
-	tab.sink.SetBotSink(nil)
+	return newBotEventForwarder(runtime, targets)
 }

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -85,6 +85,7 @@ func (s *heartbeatExecuteTaskCtrlStub) RuntimeStatus() control.RuntimeStatus {
 
 func (s *heartbeatExecuteTaskCtrlStub) SubmitUserTurn(input, display string) {
 	s.submitted = append(s.submitted, input)
+	s.status.Running = true
 }
 
 func (s *heartbeatExecuteTaskCtrlStub) SetToolApprovalMode(mode string) {

--- a/desktop/tab_event_sink_test.go
+++ b/desktop/tab_event_sink_test.go
@@ -20,6 +20,17 @@ func (s *closeTrackingSink) Close() {
 	s.closed.Store(true)
 }
 
+type blockingCloseTrackingSink struct {
+	closeTrackingSink
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingCloseTrackingSink) Emit(event.Event) {
+	close(s.entered)
+	<-s.release
+}
+
 func TestTabEventSinkSetBotSinkClosesPreviousSink(t *testing.T) {
 	sink := &tabEventSink{}
 	first := &closeTrackingSink{}
@@ -42,6 +53,54 @@ func TestTabEventSinkSetBotSinkClosesPreviousSink(t *testing.T) {
 	if !second.closed.Load() {
 		t.Fatal("second sink was not closed when cleared")
 	}
+}
+
+func TestTabEventSinkOldTurnDoneDoesNotClearReplacement(t *testing.T) {
+	sink := &tabEventSink{}
+	old := &blockingCloseTrackingSink{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	replacement := &closeTrackingSink{}
+
+	if !sink.tryBeginTurn() {
+		t.Fatal("failed to reserve initial turn")
+	}
+	sink.SetBotSink(old)
+	done := make(chan struct{})
+	go func() {
+		sink.Emit(event.Event{Kind: event.TurnDone})
+		close(done)
+	}()
+	select {
+	case <-old.entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("old forwarder did not receive TurnDone")
+	}
+
+	sink.SetBotSink(replacement)
+	if sink.tryBeginTurn() {
+		t.Fatal("new turn admitted before old TurnDone completed")
+	}
+	close(old.release)
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("TurnDone did not finish")
+	}
+
+	if replacement.closed.Load() {
+		t.Fatal("old TurnDone cleared the replacement forwarder")
+	}
+	got, _ := sink.botSinkSnapshot()
+	if got != replacement {
+		t.Fatalf("attached forwarder = %T, want replacement", got)
+	}
+	if !sink.tryBeginTurn() {
+		t.Fatal("next turn was not admitted after TurnDone completed")
+	}
+	sink.cancelTurnStart()
+	sink.SetBotSink(nil)
 }
 
 func TestTabEventSinkDoesNotBlockOnRuntimeEventsEmit(t *testing.T) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1448,6 +1448,7 @@ type TabMeta struct {
 	Ready             bool                     `json:"ready"`
 	Running           bool                     `json:"running"`
 	PendingPrompt     bool                     `json:"pendingPrompt,omitempty"`
+	RemoteControlled  bool                     `json:"remoteControlled,omitempty"`
 	BackgroundJobs    int                      `json:"backgroundJobs,omitempty"`
 	CancelRequested   bool                     `json:"cancelRequested,omitempty"`
 	Cancellable       bool                     `json:"cancellable"`
@@ -1521,6 +1522,9 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		m.BackgroundJobs = status.BackgroundJobs
 		m.CancelRequested = status.CancelRequested
 		m.Cancellable = status.Cancellable
+	}
+	if a.botBridge != nil {
+		m.RemoteControlled = a.botBridge.remoteControlledTabs()[tab.ID]
 	}
 	if meta, ok, err := agent.LoadBranchMeta(tab.currentSessionPath()); err == nil && ok && meta.Recovered {
 		m.Recovered = true

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -59,6 +59,7 @@ type WorkspaceTab struct {
 	buildGeneration     uint64             // identifies the current in-flight build
 	removed             bool               // set when the visible tab is pruned/closed before build completes
 	reconcileMu         sync.Mutex         // serializes stale controller workspace repair for this tab
+	turnStartMu         sync.Mutex         // serializes foreground turn admission for this tab
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
@@ -921,6 +922,8 @@ type tabEventSink struct {
 	ctx           context.Context
 	runtimeEvents asyncRuntimeEmitter
 	botSink       event.Sink // optional: when set, events are also forwarded here
+	botSinkGen    uint64
+	turnInFlight  bool // stays true through the end of TurnDone fan-out
 }
 
 type closeableEventSink interface {
@@ -946,6 +949,11 @@ func (s *tabEventSink) setBinding(tabID string, app *App) {
 }
 
 func (s *tabEventSink) Emit(e event.Event) {
+	if e.Kind == event.TurnStarted {
+		s.mu.Lock()
+		s.turnInFlight = true
+		s.mu.Unlock()
+	}
 	tabID, app := s.binding()
 	if app != nil {
 		switch e.Kind {
@@ -990,15 +998,13 @@ func (s *tabEventSink) Emit(e event.Event) {
 	// Forward event to bot channels when a bot forwarder is attached.
 	// Read the sink under the read lock so SetBotSink can safely swap it
 	// from another goroutine.
-	s.mu.RLock()
-	bs := s.botSink
-	s.mu.RUnlock()
+	bs, botSinkGen := s.botSinkSnapshot()
 	if bs != nil {
 		bs.Emit(e)
 		// Detach the forwarder after TurnDone so subsequent turns on the
 		// same tab do not keep pushing to bot channels.
 		if e.Kind == event.TurnDone {
-			s.SetBotSink(nil)
+			s.clearBotSink(botSinkGen)
 		}
 	}
 	// Unlike the transient botSink above, the bridge observes every tab for
@@ -1007,20 +1013,71 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if app != nil && app.botBridge != nil {
 		app.botBridge.observe(tabID, e)
 	}
+	if e.Kind == event.TurnDone {
+		s.mu.Lock()
+		s.turnInFlight = false
+		s.mu.Unlock()
+	}
 }
 
 // SetBotSink atomically sets or clears the bot event forwarder on this sink.
 // It is safe to call concurrently with Emit.
-func (s *tabEventSink) SetBotSink(sink event.Sink) {
+func (s *tabEventSink) SetBotSink(sink event.Sink) uint64 {
 	s.mu.Lock()
 	old := s.botSink
 	s.botSink = sink
+	s.botSinkGen++
+	generation := s.botSinkGen
 	s.mu.Unlock()
 	if old != nil && old != sink {
 		if closer, ok := old.(closeableEventSink); ok {
 			closer.Close()
 		}
 	}
+	return generation
+}
+
+func (s *tabEventSink) botSinkSnapshot() (event.Sink, uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.botSink, s.botSinkGen
+}
+
+// clearBotSink clears only the forwarder generation observed by the finishing
+// turn. A delayed TurnDone must not detach a replacement installed meanwhile.
+func (s *tabEventSink) clearBotSink(generation uint64) {
+	s.mu.Lock()
+	if s.botSinkGen != generation {
+		s.mu.Unlock()
+		return
+	}
+	old := s.botSink
+	s.botSink = nil
+	s.botSinkGen++
+	s.mu.Unlock()
+	if closer, ok := old.(closeableEventSink); ok {
+		closer.Close()
+	}
+}
+
+// tryBeginTurn reserves the tab until its TurnDone has finished fan-out. The
+// controller clears RuntimeStatus().Running before it emits TurnDone, so the
+// controller status alone leaves a window where a new turn can inherit the old
+// turn's forwarder or have its replacement cleared by the old completion.
+func (s *tabEventSink) tryBeginTurn() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.turnInFlight {
+		return false
+	}
+	s.turnInFlight = true
+	return true
+}
+
+func (s *tabEventSink) cancelTurnStart() {
+	s.mu.Lock()
+	s.turnInFlight = false
+	s.mu.Unlock()
 }
 
 func (s *tabEventSink) setContext(ctx context.Context) {
@@ -3061,16 +3118,25 @@ func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) (string, bool
 	if tab == nil {
 		return "", false
 	}
+	a.mu.RLock()
+	current := a.tabs[tab.ID]
 	path := strings.TrimSpace(tab.SessionPath)
+	ctrl := tab.Ctrl
+	scope := tab.Scope
+	workspaceRoot := tab.WorkspaceRoot
+	a.mu.RUnlock()
+	if current != tab {
+		return "", false
+	}
 	if path != "" {
 		if resolved, ok := a.reconcileTabWithSessionPath(tab, path); ok {
 			return resolved, true
 		}
 	}
-	if tab.Ctrl == nil {
+	if ctrl == nil {
 		return "", false
 	}
-	path = strings.TrimSpace(tab.Ctrl.SessionPath())
+	path = strings.TrimSpace(ctrl.SessionPath())
 	if path == "" {
 		return "", false
 	}
@@ -3078,8 +3144,8 @@ func (a *App) reconcileTabWithPinnedSessionMeta(tab *WorkspaceTab) (string, bool
 	if !ok {
 		return "", false
 	}
-	if tab.Scope == "project" && binding.scope != "project" && normalizeProjectRoot(tab.WorkspaceRoot) != "" {
-		if root, ok := safeControllerWorkspaceRoot(tab.Ctrl); ok && sameProjectRoot(root, tab.WorkspaceRoot) {
+	if scope == "project" && binding.scope != "project" && normalizeProjectRoot(workspaceRoot) != "" {
+		if root, ok := safeControllerWorkspaceRoot(ctrl); ok && sameProjectRoot(root, workspaceRoot) {
 			return "", false
 		}
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1001,6 +1001,12 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.SetBotSink(nil)
 		}
 	}
+	// Unlike the transient botSink above, the bridge observes every tab for
+	// its whole lifetime (god view: /desktop status, watch subscriptions,
+	// remote approvals). observe only does in-memory bookkeeping and queueing.
+	if app != nil && app.botBridge != nil {
+		app.botBridge.observe(tabID, e)
+	}
 }
 
 // SetBotSink atomically sets or clears the bot event forwarder on this sink.

--- a/internal/bot/desktop.go
+++ b/internal/bot/desktop.go
@@ -58,7 +58,7 @@ type DesktopBridge interface {
 	// Sessions 枚举当前所有桌面 live 会话（含后台 detached）。
 	Sessions() []DesktopSessionInfo
 	// SetWatch 订阅/退订当前聊天的桌面事件推送。
-	SetWatch(route DesktopWatchRoute, enable bool)
+	SetWatch(route DesktopWatchRoute, enable bool) error
 	// Watching 返回该聊天当前是否在订阅。
 	Watching(route DesktopWatchRoute) bool
 	// Approve 应答任意桌面会话的待审批项，返回用户可读的结果文案。
@@ -120,11 +120,15 @@ func (gw *BotGateway) handleDesktopCommand(msg InboundMessage) string {
 		route := desktopRouteFromMessage(msg)
 		switch arg {
 		case "on":
-			bridge.SetWatch(route, true)
-			return "已订阅桌面事件：审批请求、任务完成/出错会推送到本聊天。用 /desktop watch off 退订。\n注意：订阅状态保存在内存中，桌面端重启后需重新订阅。"
+			if err := bridge.SetWatch(route, true); err != nil {
+				return "已在本次运行中订阅桌面事件，但保存订阅失败；桌面端重启后可能需要重新订阅。"
+			}
+			return "已订阅桌面事件：审批请求、任务完成/出错会推送到本聊天。订阅已保存，桌面端重启后仍会生效。用 /desktop watch off 退订。"
 		case "off":
-			bridge.SetWatch(route, false)
-			return "已退订桌面事件推送。"
+			if err := bridge.SetWatch(route, false); err != nil {
+				return "已在本次运行中退订桌面事件，但保存失败；桌面端重启后订阅可能恢复。"
+			}
+			return "已退订桌面事件推送，持久化订阅也已移除。"
 		case "", "state":
 			if bridge.Watching(route) {
 				return "本聊天正在订阅桌面事件推送。用 /desktop watch off 退订。"
@@ -182,6 +186,9 @@ func (gw *BotGateway) handleDesktopCommand(msg InboundMessage) string {
 // 不经过这里（仍走 handleSlashCommand），所以 /desktop release 永远可用。
 // 返回 true 表示消息已被桌面接管通道消费。
 func (gw *BotGateway) divertToDesktopTakeover(ctx context.Context, adapter Adapter, msg InboundMessage) bool {
+	if strings.HasPrefix(strings.TrimSpace(msg.Text), "/") {
+		return false
+	}
 	bridge := gw.cfg.Desktop
 	if bridge == nil {
 		return false
@@ -189,6 +196,14 @@ func (gw *BotGateway) divertToDesktopTakeover(ctx context.Context, adapter Adapt
 	route := desktopRouteFromMessage(msg)
 	if bridge.TakeoverTab(route) == "" {
 		return false
+	}
+	// Re-check the continuing capability, not only the command that created it.
+	// A runtime refresh can revoke admin while leaving this process-local binding
+	// alive; base allowlist admission alone must not preserve takeover power.
+	if !gw.checkCommandRole(msg.Platform, msg, "admin") {
+		_, _ = bridge.Release(route)
+		_ = gw.sendText(ctx, adapter, msg, "桌面接管已解除：当前账号不再具有 bot 管理员权限。")
+		return true
 	}
 	if strings.TrimSpace(msg.Text) == "" {
 		_ = gw.sendText(ctx, adapter, msg, "接管模式暂不支持转发附件，请发送文本。")

--- a/internal/bot/desktop.go
+++ b/internal/bot/desktop.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,8 @@ type DesktopSessionInfo struct {
 	Ready         bool
 	Running       bool
 	PendingPrompt bool
+	// Detached 标记后台运行的会话（已从可见 tab 分离，controller 仍存活）。
+	Detached bool
 }
 
 // DesktopWatchRoute 标识一个订阅了桌面事件的 bot 聊天。
@@ -38,11 +41,11 @@ func (r DesktopWatchRoute) Key() string {
 // 语义约定：
 //   - 审批应答与桌面 UI 是"先到者赢"（controller 侧幂等，重复应答被静默忽略），
 //     Approve/Answer 的返回文案应体现"以先到者为准"。
-//   - 本接口刻意不包含向桌面会话注入输入或抢占写权的方法。将来的显式接管
-//     （/takeover：抢写 lease、桌面提示并可抢回）会作为独立方法在此扩展，
-//     底层依赖 internal/control 的接管端口，而不是复用 gateway 的会话机器。
+//   - 接管是"显式"的：/desktop takeover 绑定聊天与会话，桌面端会在会话
+//     transcript 里看到提示；桌面用户在该会话本地发送任意消息即自动收回
+//     控制并通知远端。接管期间桌面输入不被锁定（controller 侧先到者赢）。
 type DesktopBridge interface {
-	// Sessions 枚举当前所有桌面 live 会话。
+	// Sessions 枚举当前所有桌面 live 会话（含后台 detached）。
 	Sessions() []DesktopSessionInfo
 	// SetWatch 订阅/退订当前聊天的桌面事件推送。
 	SetWatch(route DesktopWatchRoute, enable bool)
@@ -54,6 +57,15 @@ type DesktopBridge interface {
 	AskQuestions(askID string) ([]event.AskQuestion, bool)
 	// Answer 应答任意桌面会话的待回答 ask，返回用户可读的结果文案。
 	Answer(askID string, answers []event.AskAnswer) (string, error)
+	// Takeover 把该聊天绑定为某个桌面会话的远程驾驶者，返回用户可读文案。
+	Takeover(route DesktopWatchRoute, tabID string) (string, error)
+	// Release 解除该聊天的接管绑定，返回用户可读文案。
+	Release(route DesktopWatchRoute) (string, error)
+	// TakeoverTab 返回该聊天当前接管的 tabID，未接管时为空串。
+	TakeoverTab(route DesktopWatchRoute) string
+	// DriveInput 把一条文本作为新 turn 提交到该聊天接管的桌面会话。
+	// 成功时输出会经事件转发流回聊天；返回的文案（可为空）用于即时回执。
+	DriveInput(route DesktopWatchRoute, text string) (string, error)
 }
 
 func desktopRouteFromMessage(msg InboundMessage) DesktopWatchRoute {
@@ -71,7 +83,9 @@ const desktopCommandUsage = "用法:\n" +
 	"/desktop watch on|off|status - 订阅/退订桌面事件推送(审批请求、任务完成/出错)\n" +
 	"/desktop approve <id> - 批准桌面会话的待审批操作\n" +
 	"/desktop deny <id> - 拒绝桌面会话的待审批操作\n" +
-	"/desktop answer <id> <选项编号或文本> - 回答桌面会话的提问"
+	"/desktop answer <id> <选项编号或文本> - 回答桌面会话的提问\n" +
+	"/desktop takeover <tab> - 接管桌面会话，后续消息直接驱动它\n" +
+	"/desktop release - 解除接管，回到普通 bot 会话"
 
 // handleDesktopCommand 处理 /desktop 系列命令(上帝视角：观察 + 遥控审批)。
 // 调用方已完成 admin 角色门控。
@@ -134,9 +148,51 @@ func (gw *BotGateway) handleDesktopCommand(msg InboundMessage) string {
 			return err.Error()
 		}
 		return feedback
+	case "takeover":
+		if len(fields) < 3 {
+			return desktopCommandUsage
+		}
+		feedback, err := bridge.Takeover(desktopRouteFromMessage(msg), fields[2])
+		if err != nil {
+			return err.Error()
+		}
+		return feedback
+	case "release":
+		feedback, err := bridge.Release(desktopRouteFromMessage(msg))
+		if err != nil {
+			return err.Error()
+		}
+		return feedback
 	default:
 		return desktopCommandUsage
 	}
+}
+
+// divertToDesktopTakeover 把已接管聊天的普通消息改道到桌面会话。斜杠命令
+// 不经过这里（仍走 handleSlashCommand），所以 /desktop release 永远可用。
+// 返回 true 表示消息已被桌面接管通道消费。
+func (gw *BotGateway) divertToDesktopTakeover(ctx context.Context, adapter Adapter, msg InboundMessage) bool {
+	bridge := gw.cfg.Desktop
+	if bridge == nil {
+		return false
+	}
+	route := desktopRouteFromMessage(msg)
+	if bridge.TakeoverTab(route) == "" {
+		return false
+	}
+	if strings.TrimSpace(msg.Text) == "" {
+		_ = gw.sendText(ctx, adapter, msg, "接管模式暂不支持转发附件，请发送文本。")
+		return true
+	}
+	feedback, err := bridge.DriveInput(route, msg.Text)
+	if err != nil {
+		_ = gw.sendText(ctx, adapter, msg, err.Error())
+		return true
+	}
+	if strings.TrimSpace(feedback) != "" {
+		_ = gw.sendText(ctx, adapter, msg, feedback)
+	}
+	return true
 }
 
 func formatDesktopSessions(sessions []DesktopSessionInfo) string {
@@ -162,12 +218,15 @@ func formatDesktopSessions(sessions []DesktopSessionInfo) string {
 		if label == "" {
 			label = "(未命名)"
 		}
+		if s.Detached {
+			state += "·后台"
+		}
 		fmt.Fprintf(&b, "\n- %s [%s]", label, state)
 		if ws := strings.TrimSpace(s.Workspace); ws != "" {
 			fmt.Fprintf(&b, "\n  项目: %s", ws)
 		}
 		fmt.Fprintf(&b, "\n  tab: %s", s.TabID)
 	}
-	b.WriteString("\n\n用 /desktop watch on 订阅审批与完成事件。")
+	b.WriteString("\n\n用 /desktop watch on 订阅审批与完成事件；/desktop takeover <tab> 接管某个会话。")
 	return b.String()
 }

--- a/internal/bot/desktop.go
+++ b/internal/bot/desktop.go
@@ -1,0 +1,173 @@
+package bot
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/event"
+)
+
+// DesktopSessionInfo 是一个桌面 live 会话(tab)的快照，用于 /desktop status。
+type DesktopSessionInfo struct {
+	TabID         string
+	Label         string
+	Workspace     string
+	Topic         string
+	Ready         bool
+	Running       bool
+	PendingPrompt bool
+}
+
+// DesktopWatchRoute 标识一个订阅了桌面事件的 bot 聊天。
+type DesktopWatchRoute struct {
+	ConnectionID string
+	Domain       string
+	Platform     Platform
+	ChatType     ChatType
+	ChatID       string
+}
+
+// Key 返回订阅表的稳定键。
+func (r DesktopWatchRoute) Key() string {
+	return fmt.Sprintf("%s|%s|%s|%s", r.Platform, r.ConnectionID, r.Domain, r.ChatID)
+}
+
+// DesktopBridge 由桌面端进程实现，让 bot 聊天获得对整个桌面端的上帝视角：
+// 全局会话清单、事件订阅、以及对任意桌面 live 会话的远程审批/问答。
+//
+// 语义约定：
+//   - 审批应答与桌面 UI 是"先到者赢"（controller 侧幂等，重复应答被静默忽略），
+//     Approve/Answer 的返回文案应体现"以先到者为准"。
+//   - 本接口刻意不包含向桌面会话注入输入或抢占写权的方法。将来的显式接管
+//     （/takeover：抢写 lease、桌面提示并可抢回）会作为独立方法在此扩展，
+//     底层依赖 internal/control 的接管端口，而不是复用 gateway 的会话机器。
+type DesktopBridge interface {
+	// Sessions 枚举当前所有桌面 live 会话。
+	Sessions() []DesktopSessionInfo
+	// SetWatch 订阅/退订当前聊天的桌面事件推送。
+	SetWatch(route DesktopWatchRoute, enable bool)
+	// Watching 返回该聊天当前是否在订阅。
+	Watching(route DesktopWatchRoute) bool
+	// Approve 应答任意桌面会话的待审批项，返回用户可读的结果文案。
+	Approve(approvalID string, allow bool) (string, error)
+	// AskQuestions 返回某个待回答 ask 的问题列表（用于把 IM 文本解析成选项）。
+	AskQuestions(askID string) ([]event.AskQuestion, bool)
+	// Answer 应答任意桌面会话的待回答 ask，返回用户可读的结果文案。
+	Answer(askID string, answers []event.AskAnswer) (string, error)
+}
+
+func desktopRouteFromMessage(msg InboundMessage) DesktopWatchRoute {
+	return DesktopWatchRoute{
+		ConnectionID: msg.ConnectionID,
+		Domain:       msg.Domain,
+		Platform:     msg.Platform,
+		ChatType:     msg.ChatType,
+		ChatID:       msg.ChatID,
+	}
+}
+
+const desktopCommandUsage = "用法:\n" +
+	"/desktop status - 查看桌面端所有 live 会话\n" +
+	"/desktop watch on|off|status - 订阅/退订桌面事件推送(审批请求、任务完成/出错)\n" +
+	"/desktop approve <id> - 批准桌面会话的待审批操作\n" +
+	"/desktop deny <id> - 拒绝桌面会话的待审批操作\n" +
+	"/desktop answer <id> <选项编号或文本> - 回答桌面会话的提问"
+
+// handleDesktopCommand 处理 /desktop 系列命令(上帝视角：观察 + 遥控审批)。
+// 调用方已完成 admin 角色门控。
+func (gw *BotGateway) handleDesktopCommand(msg InboundMessage) string {
+	bridge := gw.cfg.Desktop
+	if bridge == nil {
+		return "此 bot 未运行在桌面端进程内，/desktop 命令不可用。请在桌面端设置里启用 bot。"
+	}
+	fields := strings.Fields(msg.Text)
+	sub := ""
+	if len(fields) > 1 {
+		sub = strings.ToLower(fields[1])
+	}
+	switch sub {
+	case "", "status", "sessions":
+		return formatDesktopSessions(bridge.Sessions())
+	case "watch":
+		arg := ""
+		if len(fields) > 2 {
+			arg = strings.ToLower(fields[2])
+		}
+		route := desktopRouteFromMessage(msg)
+		switch arg {
+		case "on":
+			bridge.SetWatch(route, true)
+			return "已订阅桌面事件：审批请求、任务完成/出错会推送到本聊天。用 /desktop watch off 退订。\n注意：订阅状态保存在内存中，桌面端重启后需重新订阅。"
+		case "off":
+			bridge.SetWatch(route, false)
+			return "已退订桌面事件推送。"
+		case "", "state":
+			if bridge.Watching(route) {
+				return "本聊天正在订阅桌面事件推送。用 /desktop watch off 退订。"
+			}
+			return "本聊天未订阅桌面事件推送。用 /desktop watch on 订阅。"
+		default:
+			return desktopCommandUsage
+		}
+	case "approve", "deny":
+		if len(fields) < 3 {
+			return desktopCommandUsage
+		}
+		feedback, err := bridge.Approve(fields[2], sub == "approve")
+		if err != nil {
+			return err.Error()
+		}
+		return feedback
+	case "answer":
+		if len(fields) < 4 {
+			return desktopCommandUsage
+		}
+		askID := fields[2]
+		questions, ok := bridge.AskQuestions(askID)
+		if !ok {
+			return fmt.Sprintf("未找到待回答的提问 %s（可能已在桌面端回答或已超时）。", askID)
+		}
+		raw := strings.Join(fields[3:], " ")
+		answers := parseAskAnswers(questions, raw)
+		feedback, err := bridge.Answer(askID, answers)
+		if err != nil {
+			return err.Error()
+		}
+		return feedback
+	default:
+		return desktopCommandUsage
+	}
+}
+
+func formatDesktopSessions(sessions []DesktopSessionInfo) string {
+	if len(sessions) == 0 {
+		return "桌面端当前没有 live 会话。"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "桌面端 live 会话（%d 个）:\n", len(sessions))
+	for _, s := range sessions {
+		state := "空闲"
+		switch {
+		case s.PendingPrompt:
+			state = "⚠️ 等待审批/回答"
+		case s.Running:
+			state = "▶️ 执行中"
+		case !s.Ready:
+			state = "启动中"
+		}
+		label := strings.TrimSpace(s.Label)
+		if label == "" {
+			label = strings.TrimSpace(s.Topic)
+		}
+		if label == "" {
+			label = "(未命名)"
+		}
+		fmt.Fprintf(&b, "\n- %s [%s]", label, state)
+		if ws := strings.TrimSpace(s.Workspace); ws != "" {
+			fmt.Fprintf(&b, "\n  项目: %s", ws)
+		}
+		fmt.Fprintf(&b, "\n  tab: %s", s.TabID)
+	}
+	b.WriteString("\n\n用 /desktop watch on 订阅审批与完成事件。")
+	return b.String()
+}

--- a/internal/bot/desktop.go
+++ b/internal/bot/desktop.go
@@ -19,6 +19,16 @@ type DesktopSessionInfo struct {
 	PendingPrompt bool
 	// Detached 标记后台运行的会话（已从可见 tab 分离，controller 仍存活）。
 	Detached bool
+	// Pending 列出该会话当前待处理的审批/问答，便于用户在推送丢失时仍能
+	// 用 /desktop approve|answer <id> 处理。
+	Pending []DesktopPendingInfo
+}
+
+// DesktopPendingInfo 是一条待处理的审批或问答的摘要。
+type DesktopPendingInfo struct {
+	ID   string
+	Kind string // "approval" | "ask"
+	Tool string
 }
 
 // DesktopWatchRoute 标识一个订阅了桌面事件的 bot 聊天。
@@ -226,6 +236,17 @@ func formatDesktopSessions(sessions []DesktopSessionInfo) string {
 			fmt.Fprintf(&b, "\n  项目: %s", ws)
 		}
 		fmt.Fprintf(&b, "\n  tab: %s", s.TabID)
+		for _, p := range s.Pending {
+			kind := "审批"
+			if p.Kind == "ask" {
+				kind = "提问"
+			}
+			line := fmt.Sprintf("\n  待%s: %s", kind, p.ID)
+			if tool := strings.TrimSpace(p.Tool); tool != "" {
+				line += " (" + tool + ")"
+			}
+			b.WriteString(line)
+		}
 	}
 	b.WriteString("\n\n用 /desktop watch on 订阅审批与完成事件；/desktop takeover <tab> 接管某个会话。")
 	return b.String()

--- a/internal/bot/desktop_test.go
+++ b/internal/bot/desktop_test.go
@@ -19,6 +19,7 @@ type fakeDesktopBridge struct {
 	takeovers map[string]string // routeKey -> tabID
 	driven    []string
 	driveErr  error
+	watchErr  error
 }
 
 func newFakeDesktopBridge() *fakeDesktopBridge {
@@ -31,8 +32,9 @@ func newFakeDesktopBridge() *fakeDesktopBridge {
 }
 
 func (f *fakeDesktopBridge) Sessions() []DesktopSessionInfo { return f.sessions }
-func (f *fakeDesktopBridge) SetWatch(route DesktopWatchRoute, enable bool) {
+func (f *fakeDesktopBridge) SetWatch(route DesktopWatchRoute, enable bool) error {
 	f.watching[route.Key()] = enable
+	return f.watchErr
 }
 func (f *fakeDesktopBridge) Watching(route DesktopWatchRoute) bool {
 	return f.watching[route.Key()]
@@ -170,6 +172,21 @@ func TestHandleDesktopCommandWatchLifecycle(t *testing.T) {
 	}
 }
 
+func TestHandleDesktopCommandWatchReportsPersistenceFailure(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.watchErr = fmt.Errorf("disk unavailable")
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+	msg := desktopTestMessage("/desktop watch on")
+
+	got := gw.handleDesktopCommand(msg)
+	if !strings.Contains(got, "本次运行中订阅") || !strings.Contains(got, "保存订阅失败") {
+		t.Fatalf("watch persistence failure reply = %q", got)
+	}
+	if !bridge.Watching(desktopRouteFromMessage(msg)) {
+		t.Fatal("runtime subscription should remain active after persistence failure")
+	}
+}
+
 func TestHandleDesktopCommandApproveAndDeny(t *testing.T) {
 	bridge := newFakeDesktopBridge()
 	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
@@ -262,6 +279,11 @@ func TestDivertToDesktopTakeover(t *testing.T) {
 
 	route := desktopRouteFromMessage(msg)
 	bridge.takeovers[route.Key()] = "tab-1"
+	msg.Text = "/desktop status"
+	if gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
+		t.Fatal("slash commands must remain in the bot command path during takeover")
+	}
+	msg.Text = "帮我跑一下测试"
 	if !gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
 		t.Fatal("message should divert to the taken-over session")
 	}
@@ -277,5 +299,35 @@ func TestDivertToDesktopTakeover(t *testing.T) {
 	sent := adapter.sentMessages()
 	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1].Text, "正在执行中") {
 		t.Fatalf("sent = %+v, want drive error relayed to the chat", sent)
+	}
+}
+
+func TestDivertToDesktopTakeoverRevokesFormerAdmin(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.sessions = []DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}}
+	gw := &BotGateway{
+		cfg: GatewayConfig{
+			Desktop: bridge,
+			Allowlist: AllowlistConfig{Admins: map[Platform][]string{
+				PlatformFeishu: {"current-admin"},
+			}},
+		},
+		logger:        discardLogger(),
+		adapterHealth: map[string]*AdapterHealthSnapshot{},
+	}
+	adapter := newFakeAdapter(PlatformFeishu, "fake-feishu")
+	msg := desktopTestMessage("run tests")
+	route := desktopRouteFromMessage(msg)
+	bridge.takeovers[route.Key()] = "tab-1"
+
+	if !gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
+		t.Fatal("revoked takeover message should be consumed with an explanation")
+	}
+	if bridge.TakeoverTab(route) != "" || len(bridge.driven) != 0 {
+		t.Fatalf("revoked takeover remained active or drove input: tab=%q driven=%v", bridge.TakeoverTab(route), bridge.driven)
+	}
+	sent := adapter.sentMessages()
+	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1].Text, "不再具有") {
+		t.Fatalf("sent = %+v, want admin-revocation explanation", sent)
 	}
 }

--- a/internal/bot/desktop_test.go
+++ b/internal/bot/desktop_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,6 +16,9 @@ type fakeDesktopBridge struct {
 	denied    []string
 	answered  map[string][]event.AskAnswer
 	questions map[string][]event.AskQuestion
+	takeovers map[string]string // routeKey -> tabID
+	driven    []string
+	driveErr  error
 }
 
 func newFakeDesktopBridge() *fakeDesktopBridge {
@@ -22,6 +26,7 @@ func newFakeDesktopBridge() *fakeDesktopBridge {
 		watching:  make(map[string]bool),
 		answered:  make(map[string][]event.AskAnswer),
 		questions: make(map[string][]event.AskQuestion),
+		takeovers: make(map[string]string),
 	}
 }
 
@@ -50,6 +55,36 @@ func (f *fakeDesktopBridge) AskQuestions(id string) ([]event.AskQuestion, bool) 
 func (f *fakeDesktopBridge) Answer(id string, answers []event.AskAnswer) (string, error) {
 	f.answered[id] = answers
 	return "已提交回答", nil
+}
+
+func (f *fakeDesktopBridge) Takeover(route DesktopWatchRoute, tabID string) (string, error) {
+	for _, s := range f.sessions {
+		if s.TabID == tabID {
+			f.takeovers[route.Key()] = tabID
+			return "已接管", nil
+		}
+	}
+	return "", fmt.Errorf("未找到会话 %s", tabID)
+}
+
+func (f *fakeDesktopBridge) Release(route DesktopWatchRoute) (string, error) {
+	if _, ok := f.takeovers[route.Key()]; !ok {
+		return "", fmt.Errorf("本聊天当前没有接管任何桌面会话。")
+	}
+	delete(f.takeovers, route.Key())
+	return "已解除接管", nil
+}
+
+func (f *fakeDesktopBridge) TakeoverTab(route DesktopWatchRoute) string {
+	return f.takeovers[route.Key()]
+}
+
+func (f *fakeDesktopBridge) DriveInput(route DesktopWatchRoute, text string) (string, error) {
+	if f.driveErr != nil {
+		return "", f.driveErr
+	}
+	f.driven = append(f.driven, text)
+	return "", nil
 }
 
 func desktopTestMessage(text string) InboundMessage {
@@ -168,5 +203,64 @@ func TestHandleDesktopCommandAnswerParsesSelection(t *testing.T) {
 
 	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop answer ask-gone 1")); !strings.Contains(got, "未找到") {
 		t.Fatalf("missing-ask reply = %q", got)
+	}
+}
+
+func TestHandleDesktopCommandTakeoverAndRelease(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.sessions = []DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}}
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+	msg := desktopTestMessage("/desktop takeover tab-1")
+
+	if got := gw.handleDesktopCommand(msg); !strings.Contains(got, "已接管") {
+		t.Fatalf("takeover reply = %q", got)
+	}
+	route := desktopRouteFromMessage(msg)
+	if bridge.takeovers[route.Key()] != "tab-1" {
+		t.Fatalf("takeovers = %v, want route bound to tab-1", bridge.takeovers)
+	}
+
+	msg.Text = "/desktop release"
+	if got := gw.handleDesktopCommand(msg); !strings.Contains(got, "已解除") {
+		t.Fatalf("release reply = %q", got)
+	}
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop takeover missing")); !strings.Contains(got, "未找到") {
+		t.Fatalf("missing-tab reply = %q", got)
+	}
+}
+
+func TestDivertToDesktopTakeover(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.sessions = []DesktopSessionInfo{{TabID: "tab-1", Label: "会话一"}}
+	gw := &BotGateway{
+		cfg:           GatewayConfig{Desktop: bridge},
+		logger:        discardLogger(),
+		adapterHealth: map[string]*AdapterHealthSnapshot{},
+	}
+	adapter := newFakeAdapter(PlatformFeishu, "fake-feishu")
+	msg := desktopTestMessage("帮我跑一下测试")
+
+	// 未接管:不分流。
+	if gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
+		t.Fatal("message should not divert without a takeover binding")
+	}
+
+	route := desktopRouteFromMessage(msg)
+	bridge.takeovers[route.Key()] = "tab-1"
+	if !gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
+		t.Fatal("message should divert to the taken-over session")
+	}
+	if len(bridge.driven) != 1 || bridge.driven[0] != "帮我跑一下测试" {
+		t.Fatalf("driven = %v, want the plain message text", bridge.driven)
+	}
+
+	// 驱动失败:错误文案回给用户。
+	bridge.driveErr = fmt.Errorf("会话正在执行中")
+	if !gw.divertToDesktopTakeover(context.Background(), adapter, msg) {
+		t.Fatal("drive failure should still consume the message")
+	}
+	sent := adapter.sentMessages()
+	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1].Text, "正在执行中") {
+		t.Fatalf("sent = %+v, want drive error relayed to the chat", sent)
 	}
 }

--- a/internal/bot/desktop_test.go
+++ b/internal/bot/desktop_test.go
@@ -1,0 +1,172 @@
+package bot
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+type fakeDesktopBridge struct {
+	sessions  []DesktopSessionInfo
+	watching  map[string]bool
+	approved  []string
+	denied    []string
+	answered  map[string][]event.AskAnswer
+	questions map[string][]event.AskQuestion
+}
+
+func newFakeDesktopBridge() *fakeDesktopBridge {
+	return &fakeDesktopBridge{
+		watching:  make(map[string]bool),
+		answered:  make(map[string][]event.AskAnswer),
+		questions: make(map[string][]event.AskQuestion),
+	}
+}
+
+func (f *fakeDesktopBridge) Sessions() []DesktopSessionInfo { return f.sessions }
+func (f *fakeDesktopBridge) SetWatch(route DesktopWatchRoute, enable bool) {
+	f.watching[route.Key()] = enable
+}
+func (f *fakeDesktopBridge) Watching(route DesktopWatchRoute) bool {
+	return f.watching[route.Key()]
+}
+func (f *fakeDesktopBridge) Approve(id string, allow bool) (string, error) {
+	if id == "gone" {
+		return "", fmt.Errorf("未找到待处理的审批 %s", id)
+	}
+	if allow {
+		f.approved = append(f.approved, id)
+	} else {
+		f.denied = append(f.denied, id)
+	}
+	return "已提交", nil
+}
+func (f *fakeDesktopBridge) AskQuestions(id string) ([]event.AskQuestion, bool) {
+	qs, ok := f.questions[id]
+	return qs, ok
+}
+func (f *fakeDesktopBridge) Answer(id string, answers []event.AskAnswer) (string, error) {
+	f.answered[id] = answers
+	return "已提交回答", nil
+}
+
+func desktopTestMessage(text string) InboundMessage {
+	return InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu-main",
+		Domain:       "feishu",
+		ChatType:     ChatDM,
+		ChatID:       "chat-god",
+		UserID:       "admin-user",
+		Text:         text,
+	}
+}
+
+func TestHandleDesktopCommandWithoutBridge(t *testing.T) {
+	gw := &BotGateway{cfg: GatewayConfig{}}
+	got := gw.handleDesktopCommand(desktopTestMessage("/desktop status"))
+	if !strings.Contains(got, "未运行在桌面端进程内") {
+		t.Fatalf("reply = %q, want standalone-mode notice", got)
+	}
+}
+
+func TestHandleDesktopCommandStatusListsSessions(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.sessions = []DesktopSessionInfo{
+		{TabID: "tab-1", Label: "修复登录", Workspace: "blade", Running: true, Ready: true},
+		{TabID: "tab-2", Label: "", Topic: "周报", Ready: true, PendingPrompt: true},
+	}
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+
+	got := gw.handleDesktopCommand(desktopTestMessage("/desktop status"))
+	for _, want := range []string{"2 个", "修复登录", "▶️ 执行中", "周报", "⚠️ 等待审批/回答", "tab-1", "blade"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status reply = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestHandleDesktopCommandStatusEmpty(t *testing.T) {
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: newFakeDesktopBridge()}}
+	got := gw.handleDesktopCommand(desktopTestMessage("/desktop"))
+	if !strings.Contains(got, "没有 live 会话") {
+		t.Fatalf("reply = %q, want empty-sessions notice", got)
+	}
+}
+
+func TestHandleDesktopCommandWatchLifecycle(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+	msg := desktopTestMessage("/desktop watch on")
+
+	got := gw.handleDesktopCommand(msg)
+	if !strings.Contains(got, "已订阅") {
+		t.Fatalf("watch on reply = %q", got)
+	}
+	route := desktopRouteFromMessage(msg)
+	if !bridge.watching[route.Key()] {
+		t.Fatal("watch on did not subscribe the message route")
+	}
+
+	msg.Text = "/desktop watch off"
+	got = gw.handleDesktopCommand(msg)
+	if !strings.Contains(got, "已退订") {
+		t.Fatalf("watch off reply = %q", got)
+	}
+	if bridge.watching[route.Key()] {
+		t.Fatal("watch off did not unsubscribe the message route")
+	}
+}
+
+func TestHandleDesktopCommandApproveAndDeny(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop approve appr-1")); !strings.Contains(got, "已提交") {
+		t.Fatalf("approve reply = %q", got)
+	}
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop deny appr-2")); !strings.Contains(got, "已提交") {
+		t.Fatalf("deny reply = %q", got)
+	}
+	if len(bridge.approved) != 1 || bridge.approved[0] != "appr-1" {
+		t.Fatalf("approved = %v, want [appr-1]", bridge.approved)
+	}
+	if len(bridge.denied) != 1 || bridge.denied[0] != "appr-2" {
+		t.Fatalf("denied = %v, want [appr-2]", bridge.denied)
+	}
+
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop approve gone")); !strings.Contains(got, "未找到") {
+		t.Fatalf("missing-approval reply = %q", got)
+	}
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop approve")); got != desktopCommandUsage {
+		t.Fatalf("missing-arg reply = %q, want usage", got)
+	}
+}
+
+func TestHandleDesktopCommandAnswerParsesSelection(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.questions["ask-1"] = []event.AskQuestion{{
+		ID:      "q1",
+		Prompt:  "选一个",
+		Options: []event.AskOption{{Label: "方案 A"}, {Label: "方案 B"}},
+	}}
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+
+	got := gw.handleDesktopCommand(desktopTestMessage("/desktop answer ask-1 2"))
+	if !strings.Contains(got, "已提交回答") {
+		t.Fatalf("answer reply = %q", got)
+	}
+	answers := bridge.answered["ask-1"]
+	if len(answers) != 1 || answers[0].QuestionID != "q1" {
+		t.Fatalf("answers = %+v, want one answer for q1", answers)
+	}
+	if len(answers[0].Selected) != 1 || answers[0].Selected[0] != "方案 B" {
+		t.Fatalf("selected = %v, want numeric index resolved to 方案 B", answers[0].Selected)
+	}
+
+	if got := gw.handleDesktopCommand(desktopTestMessage("/desktop answer ask-gone 1")); !strings.Contains(got, "未找到") {
+		t.Fatalf("missing-ask reply = %q", got)
+	}
+}

--- a/internal/bot/desktop_test.go
+++ b/internal/bot/desktop_test.go
@@ -123,6 +123,21 @@ func TestHandleDesktopCommandStatusListsSessions(t *testing.T) {
 	}
 }
 
+func TestHandleDesktopCommandStatusListsPendingIDs(t *testing.T) {
+	bridge := newFakeDesktopBridge()
+	bridge.sessions = []DesktopSessionInfo{{
+		TabID: "tab-1", Label: "修复登录", Ready: true, PendingPrompt: true,
+		Pending: []DesktopPendingInfo{{ID: "appr-9", Kind: "approval", Tool: "bash"}},
+	}}
+	gw := &BotGateway{cfg: GatewayConfig{Desktop: bridge}}
+	got := gw.handleDesktopCommand(desktopTestMessage("/desktop status"))
+	// The pending id must be visible so a user whose push was dropped can still
+	// run /desktop approve <id>.
+	if !strings.Contains(got, "appr-9") {
+		t.Fatalf("status = %q, want it to list the pending approval id", got)
+	}
+}
+
 func TestHandleDesktopCommandStatusEmpty(t *testing.T) {
 	gw := &BotGateway{cfg: GatewayConfig{Desktop: newFakeDesktopBridge()}}
 	got := gw.handleDesktopCommand(desktopTestMessage("/desktop"))

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -59,6 +59,11 @@ type GatewayConfig struct {
 	// The gateway updates the live session and in-memory defaults first; this
 	// callback lets desktop save the chosen connection mode to user config.
 	OnToolApprovalModeChange func(InboundMessage, string) error
+	// Desktop, when the gateway is embedded in the desktop app, gives bot
+	// chats a god view over desktop sessions (/desktop commands): global
+	// status, event subscriptions, and remote approvals for any live desktop
+	// session. Nil when the gateway runs standalone (reasonix bot start).
+	Desktop DesktopBridge
 }
 
 // ChannelConfig overrides gateway defaults for one IM channel.
@@ -1285,6 +1290,15 @@ func (gw *BotGateway) handleSlashCommand(ctx context.Context, adapter Adapter, k
 		}
 		_ = gw.sendText(ctx, adapter, msg, gw.handleProjectSearchCommand(ctx, msg.Text))
 
+	case strings.HasPrefix(msg.Text, "/desktop"):
+		// God view over the embedding desktop app: listing every live desktop
+		// session and answering its approvals is strictly more power than the
+		// per-session approver role, so gate on admin.
+		if !gw.requireCommandRole(ctx, adapter, msg, "admin") {
+			return
+		}
+		_ = gw.sendText(ctx, adapter, msg, gw.handleDesktopCommand(msg))
+
 	case strings.HasPrefix(msg.Text, "/status"):
 		active := gw.sessions.ActiveCount()
 		pending := gw.sessions.PendingCount(key)
@@ -1310,6 +1324,7 @@ func (gw *BotGateway) handleSlashCommand(ctx context.Context, adapter Adapter, k
 			"/sessions search <关键词> - 搜索可 attach 的历史会话\n" +
 			"/attach session <id|关键词> - 绑定当前远端会话到已有历史会话\n" +
 			"/search all <关键词> - 跨已索引项目检索文件内容\n" +
+			"/desktop status|watch|approve|deny|answer - 桌面端上帝视角(需内嵌运行)\n" +
 			"/status - 查看状态\n" +
 			"/help - 显示帮助"
 		_ = gw.sendText(ctx, adapter, msg, help)

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -609,6 +609,13 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 		return
 	}
 
+	// 已接管桌面会话的聊天：普通消息直接驱动那个桌面会话，不进 bot 自己的
+	// 会话机器（斜杠命令仍走上面的分支，/desktop release 永远可达）。
+	if gw.divertToDesktopTakeover(ctx, binding.Adapter, msg) {
+		gw.logger.Info("bot message diverted to desktop takeover", logFields...)
+		return
+	}
+
 	cleanup := gw.addPendingReaction(ctx, binding.Platform, binding.Adapter, msg)
 
 	queueMode := gw.queueMode(key, msg)

--- a/internal/bot/session.go
+++ b/internal/bot/session.go
@@ -140,6 +140,7 @@ var slashCommands = map[string]bool{
 	"/sessions": true,
 	"/attach":   true,
 	"/search":   true,
+	"/desktop":  true,
 	"/status":   true,
 	"/help":     true,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -529,6 +529,20 @@ type BotConfig struct {
 	Weixin             WeixinBotConfig       `toml:"weixin"`
 	Routes             []BotRouteConfig      `toml:"routes"`
 	Connections        []BotConnectionConfig `toml:"connections"`
+	// DesktopWatchers persists /desktop watch subscriptions so god-view
+	// notifications survive a desktop restart. Managed by the desktop bot
+	// bridge, not the settings UI.
+	DesktopWatchers []BotDesktopWatcherConfig `toml:"desktop_watchers"`
+}
+
+// BotDesktopWatcherConfig is one bot chat subscribed to desktop events
+// (/desktop watch on).
+type BotDesktopWatcherConfig struct {
+	Platform     string `toml:"platform"`
+	ConnectionID string `toml:"connection_id"`
+	Domain       string `toml:"domain"`
+	ChatType     string `toml:"chat_type"`
+	ChatID       string `toml:"chat_id"`
 }
 
 type BotSelfUserIDs struct {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -521,6 +521,12 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 				renderBotRoute(&b, route)
 			}
 		}
+		if len(c.Bot.DesktopWatchers) > 0 {
+			for _, watcher := range c.Bot.DesktopWatchers {
+				b.WriteString("\n[[bot.desktop_watchers]]\n")
+				renderBotDesktopWatcher(&b, watcher)
+			}
+		}
 		b.WriteString("\n[bot.pairing]\n")
 		fmt.Fprintf(&b, "enabled = %v\n", c.Bot.Pairing.Enabled)
 		if c.Bot.Pairing.RequestTTLMinutes > 0 {
@@ -1611,6 +1617,24 @@ func renderBotRoute(b *strings.Builder, route BotRouteConfig) {
 	}
 	if strings.TrimSpace(route.WorkspaceRoot) != "" {
 		fmt.Fprintf(b, "workspace_root = %q\n", strings.TrimSpace(route.WorkspaceRoot))
+	}
+}
+
+func renderBotDesktopWatcher(b *strings.Builder, watcher BotDesktopWatcherConfig) {
+	if strings.TrimSpace(watcher.Platform) != "" {
+		fmt.Fprintf(b, "platform = %q\n", strings.TrimSpace(watcher.Platform))
+	}
+	if strings.TrimSpace(watcher.ConnectionID) != "" {
+		fmt.Fprintf(b, "connection_id = %q\n", strings.TrimSpace(watcher.ConnectionID))
+	}
+	if strings.TrimSpace(watcher.Domain) != "" {
+		fmt.Fprintf(b, "domain = %q\n", strings.TrimSpace(watcher.Domain))
+	}
+	if strings.TrimSpace(watcher.ChatType) != "" {
+		fmt.Fprintf(b, "chat_type = %q\n", strings.TrimSpace(watcher.ChatType))
+	}
+	if strings.TrimSpace(watcher.ChatID) != "" {
+		fmt.Fprintf(b, "chat_id = %q\n", strings.TrimSpace(watcher.ChatID))
 	}
 }
 

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -251,6 +251,13 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 		ToolApprovalMode: "ask",
 		WorkspaceRoot:    "/tmp/reasonix-route",
 	}}
+	orig.Bot.DesktopWatchers = []BotDesktopWatcherConfig{{
+		Platform:     "feishu",
+		ConnectionID: "feishu-lark",
+		Domain:       "lark",
+		ChatType:     "dm",
+		ChatID:       "oc_watcher",
+	}}
 	orig.Bot.Connections = []BotConnectionConfig{{
 		ID:               "feishu-lark",
 		Provider:         "feishu",
@@ -375,6 +382,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if len(got.Bot.Routes) != 1 || got.Bot.Routes[0].WorkspaceRoot != "/tmp/reasonix-route" || got.Bot.Routes[0].ChatID != "oc_group" {
 		t.Errorf("bot routes not preserved: %+v", got.Bot.Routes)
+	}
+	if len(got.Bot.DesktopWatchers) != 1 || got.Bot.DesktopWatchers[0].ChatID != "oc_watcher" || got.Bot.DesktopWatchers[0].Platform != "feishu" || got.Bot.DesktopWatchers[0].Domain != "lark" {
+		t.Errorf("bot desktop watchers not preserved: %+v", got.Bot.DesktopWatchers)
 	}
 	if len(got.Bot.Connections[0].SessionMappings) != 1 || got.Bot.Connections[0].SessionMappings[0].Scope != "project" || got.Bot.Connections[0].SessionMappings[0].WorkspaceRoot != "/tmp/reasonix-bot" {
 		t.Errorf("bot session mapping scope not preserved: %+v", got.Bot.Connections[0].SessionMappings)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -176,6 +176,7 @@ type Controller struct {
 	mu        sync.Mutex
 	cancel    context.CancelFunc
 	running   bool
+	finishing bool // TurnDone is still being delivered; reject a replacement turn
 	canceling bool
 	// rotating is set under mu while NewSession/ClearSession swap the executor
 	// session out. Checking running once and then swapping later leaves a
@@ -574,7 +575,7 @@ func (c *Controller) beginCheckpoint(input string) {
 // turn is already in flight.
 func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 	c.mu.Lock()
-	if c.running || c.rotating {
+	if c.running || c.finishing || c.rotating {
 		c.mu.Unlock()
 		return
 	}
@@ -593,22 +594,32 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 		defer cancel()
 		defer func() {
 			if r := recover(); r != nil {
-				c.mu.Lock()
-				c.running = false
-				c.cancel = nil
-				c.canceling = false
-				c.mu.Unlock()
-				c.sink.Emit(event.Event{Kind: event.TurnDone, Err: fmt.Errorf("internal error: %v", r)})
+				c.finishGuardedTurn(fmt.Errorf("internal error: %v", r))
 			}
 		}()
 		err := body(ctx)
-		c.mu.Lock()
-		c.running = false
-		c.cancel = nil
-		c.canceling = false
-		c.mu.Unlock()
-		c.sink.Emit(event.Event{Kind: event.TurnDone, Err: explainError(err)})
+		c.finishGuardedTurn(explainError(err))
 	}()
+}
+
+// finishGuardedTurn keeps admission closed while TurnDone is delivered. The
+// sink fan-out may detach per-turn transports; allowing a replacement turn in
+// after running=false but before that fan-out completed let the old completion
+// clear or inherit the replacement turn's transport.
+func (c *Controller) finishGuardedTurn(err error) {
+	c.mu.Lock()
+	c.running = false
+	c.finishing = true
+	c.cancel = nil
+	c.canceling = false
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		c.finishing = false
+		c.mu.Unlock()
+	}()
+	c.sink.Emit(event.Event{Kind: event.TurnDone, Err: err})
 }
 
 // Send starts a turn with an uncomposed message. The controller applies
@@ -1412,7 +1423,7 @@ func (c *Controller) Cancel() {
 func (c *Controller) Running() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.running
+	return c.running || c.finishing
 }
 
 // beginRotation claims the session-rotation gate. It fails if a turn is running
@@ -1424,7 +1435,7 @@ func (c *Controller) Running() bool {
 func (c *Controller) beginRotation() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.running {
+	if c.running || c.finishing {
 		return errTurnRunningRotation
 	}
 	if c.rotating {
@@ -1457,12 +1468,13 @@ func (c *Controller) PendingPrompt() bool {
 func (c *Controller) RuntimeStatus() RuntimeStatus {
 	c.mu.Lock()
 	running := c.running
+	active := running || c.finishing
 	canceling := c.canceling
 	c.mu.Unlock()
 	pending := c.approval.hasPending()
 	backgroundJobs := len(c.Jobs())
 	return RuntimeStatus{
-		Running:         running,
+		Running:         active,
 		PendingPrompt:   pending,
 		BackgroundJobs:  backgroundJobs,
 		CancelRequested: canceling,

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3185,6 +3185,51 @@ func TestRunGuardedPanicEmitsTurnDone(t *testing.T) {
 	}
 }
 
+func TestRunGuardedRejectsReplacementUntilTurnDoneReturns(t *testing.T) {
+	turnDoneEntered := make(chan struct{})
+	releaseTurnDone := make(chan struct{})
+	firstBodyDone := make(chan struct{})
+	secondBodyRan := make(chan struct{}, 1)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.TurnDone {
+			close(turnDoneEntered)
+			<-releaseTurnDone
+		}
+	})})
+
+	c.runGuarded(func(context.Context) error {
+		close(firstBodyDone)
+		return nil
+	})
+	<-firstBodyDone
+	select {
+	case <-turnDoneEntered:
+	case <-time.After(time.Second):
+		t.Fatal("TurnDone delivery did not start")
+	}
+	if !c.RuntimeStatus().Running {
+		t.Fatal("controller reported idle while TurnDone was still being delivered")
+	}
+	c.runGuarded(func(context.Context) error {
+		secondBodyRan <- struct{}{}
+		return nil
+	})
+	select {
+	case <-secondBodyRan:
+		t.Fatal("replacement turn started before TurnDone delivery completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseTurnDone)
+	deadline := time.Now().Add(time.Second)
+	for c.RuntimeStatus().Running && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if c.RuntimeStatus().Running {
+		t.Fatal("controller remained busy after TurnDone returned")
+	}
+}
+
 func TestRunGuardedPanicDoesNotDoubleEmitTurnDone(t *testing.T) {
 	sess := agent.NewSession("sys")
 	var count int32


### PR DESCRIPTION
## Summary

Adds an optional desktop bridge to the embedded bot gateway so administrator chats can observe, remotely approve, and explicitly take over live desktop sessions.

- `/desktop status`, `watch on|off`, `approve|deny|answer`, `takeover`, and `release` are admin-gated.
- A persistent desktop hub observes visible and detached sessions without blocking controller event delivery.
- Watch subscriptions round-trip through `[[bot.desktop_watchers]]` and survive restart.
- Explicit takeover binds one chat to one visible tab; local input reclaims control, busy or detached sessions reject remote input, and output streams through a per-turn forwarder.
- Standalone CLI bot behavior remains unchanged because `GatewayConfig.Desktop` is optional.

## Review follow-up hardening

- **Atomic turn handoff**: the controller keeps turn admission closed until `TurnDone` fan-out returns. Desktop turn starts share a per-tab admission gate, and forwarders carry generations so an old completion cannot clear a replacement.
- **Local/remote contention**: takeover ownership is revalidated after acquiring the tab gate. Local submits reclaim first; remote and heartbeat starts cannot attach a forwarder to an unrelated in-flight turn.
- **Continuing authorization**: every ordinary takeover message revalidates the admin role. Runtime revocation releases the binding and prevents further input injection.
- **Group confidentiality**: group watchers receive only the ask summary and ID. Prompt text, option labels, cards, and buttons remain limited to desktop or direct chats.
- **Subscription durability**: persistence errors are returned to `/desktop watch`, whose reply now distinguishes runtime state from saved state. Versioned config seeding prevents stale refreshes from overwriting newer or failed-to-persist runtime subscriptions while still accepting fresh external config edits.
- Slash commands are explicitly excluded from takeover diversion, keeping `/desktop release` and the normal bot command path reachable.

## Cache impact

Cache-impact: none - the config change is limited to bot-only watcher persistence and does not enter provider-visible prompts, tool schemas, or request serialization.
Cache-guard: `./scripts/cache-guard.sh` and `go test ./internal/config` cover the existing cache and config-rendering invariants.
System-prompt-review: reviewed - `internal/config/config.go` changes only the `BotConfig` section; no system-prompt construction or provider-visible state changes.

## Backward compatibility audit

| Touch point | Old-data / old-peer behavior | Conclusion |
| --- | --- | --- |
| `bot.desktop_watchers` | Missing in old configs means an empty list; old binaries ignore the unknown key | Safe |
| `TabMeta.remoteControlled` | Additive `omitempty` field | Safe |
| `GatewayConfig.Desktop` | Additive and nil for standalone bot processes | Safe |
| `SubmitToTab` and controller public ports | Existing signatures are unchanged | Safe |
| Session keys and leases | Unchanged; takeover bindings remain process-local | Safe |
| Controller status | `Running` remains true only through final `TurnDone` delivery; cancellation remains unavailable once execution itself has finished | Safe lifecycle tightening |

## Security

- God-view commands and continuing takeover capability require the bot admin role.
- Shared chats do not receive approval subjects, ask prompts, option labels, or interactive answer controls.
- Local desktop input always wins control reclamation.
- Notification and persistence failures expose sanitized user-facing text, not local paths.

## Verification

- `go test -race ./internal/control ./internal/bot`
- `cd desktop && go test -race .`
- `go vet ./internal/control ./internal/bot`
- `cd desktop && go vet .`
- Combined-tree race tests with #6272, including a synthetic merge onto the latest `main-v2`

Focused regressions cover controller admission during blocked `TurnDone`, old-forwarder generation cleanup, admin revocation, slash-command routing, group ask redaction, watcher persistence failures, stale seed rejection, fresh external config application, and the heartbeat/controller race path.

## Known limitations

Cross-process lease preemption remains out of scope. Takeover forwards text only, and frontend takeover banner UI remains a follow-up.
