### PR TITLE
Fix tab-scoped workspace file loading / 修复工作区文件跨会话串台

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7810,6 +7810,20 @@ func (a *App) activeWorkspaceBase() (string, error) {
 	return workspaceBaseFromRoot(a.activeWorkspaceRoot())
 }
 
+func (a *App) workspaceTargetForTab(tabID string) (string, control.SessionAPI, bool) {
+	tabID = strings.TrimSpace(tabID)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	tab := a.tabByIDLocked(tabID)
+	if tab == nil {
+		if tabID == "" {
+			return ".", nil, true
+		}
+		return "", nil, false
+	}
+	return tab.WorkspaceRoot, tab.Ctrl, true
+}
+
 func workspaceBaseFromRoot(root string) (string, error) {
 	if strings.TrimSpace(root) == "" || root == "." {
 		return os.Getwd()
@@ -7818,14 +7832,6 @@ func workspaceBaseFromRoot(root string) (string, error) {
 		root = abs
 	}
 	return filepath.Clean(root), nil
-}
-
-func (a *App) workspacePath(rel string) (string, bool, error) {
-	base, err := a.activeWorkspaceBase()
-	if err != nil {
-		return "", false, err
-	}
-	return workspacePathForBase(base, rel)
 }
 
 func workspacePathForBase(base, rel string) (string, bool, error) {
@@ -7853,12 +7859,21 @@ func workspacePathForBase(base, rel string) (string, bool, error) {
 // tab workspace. The menu navigates one level at a time, never recursively —
 // bounded for huge trees.
 func (a *App) ListDir(rel string) []DirEntry {
-	if browser := a.externalFolderRefBrowser(); browser != nil {
+	return a.ListDirForTab("", rel)
+}
+
+// ListDirForTab is the tab-scoped variant used by multi-tab frontend surfaces.
+func (a *App) ListDirForTab(tabID, rel string) []DirEntry {
+	root, ctrl, ok := a.workspaceTargetForTab(tabID)
+	if !ok {
+		return []DirEntry{}
+	}
+	if browser := externalFolderRefBrowserFromController(ctrl); browser != nil {
 		if entries, handled := browser.ListExternalFolderRefDir(rel); handled {
 			return externalFolderDirEntries(entries)
 		}
 	}
-	base, err := a.activeWorkspaceBase()
+	base, err := workspaceBaseFromRoot(root)
 	if err != nil {
 		return []DirEntry{}
 	}
@@ -7897,16 +7912,25 @@ func (a *App) ListDir(rel string) []DirEntry {
 
 // SearchFileRefs finds workspace files by basename for bare "@token" completion.
 func (a *App) SearchFileRefs(query string) []DirEntry {
-	base, err := a.activeWorkspaceBase()
+	return a.SearchFileRefsForTab("", query)
+}
+
+// SearchFileRefsForTab is the tab-scoped variant used by multi-tab frontend surfaces.
+func (a *App) SearchFileRefsForTab(tabID, query string) []DirEntry {
+	root, ctrl, ok := a.workspaceTargetForTab(tabID)
+	if !ok {
+		return []DirEntry{}
+	}
+	base, err := workspaceBaseFromRoot(root)
 	if err != nil {
-		return nil
+		return []DirEntry{}
 	}
 	results := fileref.Search(base, query, fileRefSearchLimit)
 	out := make([]DirEntry, 0, len(results))
 	for _, r := range results {
 		out = append(out, DirEntry{Name: r.Path, IsDir: r.IsDir})
 	}
-	if browser := a.externalFolderRefBrowser(); browser != nil {
+	if browser := externalFolderRefBrowserFromController(ctrl); browser != nil {
 		out = append(out, externalFolderDirEntries(browser.SearchExternalFolderRefs(query, fileRefSearchLimit))...)
 	}
 	return out
@@ -7918,11 +7942,9 @@ type externalFolderRefBrowser interface {
 	ExternalFolderRefLocalPath(tokenPath string) (path, displayPath string, ok bool)
 }
 
-func (a *App) externalFolderRefBrowser() externalFolderRefBrowser {
-	if ctrl := a.activeCtrl(); ctrl != nil {
-		if browser, ok := ctrl.(externalFolderRefBrowser); ok {
-			return browser
-		}
+func externalFolderRefBrowserFromController(ctrl control.SessionAPI) externalFolderRefBrowser {
+	if browser, ok := ctrl.(externalFolderRefBrowser); ok {
+		return browser
 	}
 	return nil
 }
@@ -7941,20 +7963,33 @@ func externalFolderDirEntries(entries []control.ExternalFolderRefEntry) []DirEnt
 	return out
 }
 
-func (a *App) workspaceOrExternalPath(rel string) (string, bool, error) {
-	if browser := a.externalFolderRefBrowser(); browser != nil {
+func (a *App) workspaceOrExternalPathForTab(tabID, rel string) (string, bool, error) {
+	root, ctrl, ok := a.workspaceTargetForTab(tabID)
+	if !ok {
+		return "", false, os.ErrNotExist
+	}
+	if browser := externalFolderRefBrowserFromController(ctrl); browser != nil {
 		if path, _, ok := browser.ExternalFolderRefLocalPath(rel); ok {
 			return path, true, nil
 		}
 	}
-	return a.workspacePath(rel)
+	base, err := workspaceBaseFromRoot(root)
+	if err != nil {
+		return "", false, err
+	}
+	return workspacePathForBase(base, rel)
 }
 
 // ReadFile returns a small text preview for a file under the current workspace
 // or a session-authorized external folder ref.
 func (a *App) ReadFile(rel string) FilePreview {
+	return a.ReadFileForTab("", rel)
+}
+
+// ReadFileForTab returns a preview resolved against the requested tab.
+func (a *App) ReadFileForTab(tabID, rel string) FilePreview {
 	out := FilePreview{Path: rel}
-	path, ok, err := a.workspaceOrExternalPath(rel)
+	path, ok, err := a.workspaceOrExternalPathForTab(tabID, rel)
 	if err != nil || !ok {
 		out.Err = "invalid path"
 		return out
@@ -8039,7 +8074,12 @@ func (a *App) ReadFile(rel string) FilePreview {
 // OpenWorkspacePath opens a workspace or authorized external-ref file/folder in
 // the OS default app.
 func (a *App) OpenWorkspacePath(rel string) error {
-	path, ok, err := a.workspaceOrExternalPath(rel)
+	return a.OpenWorkspacePathForTab("", rel)
+}
+
+// OpenWorkspacePathForTab opens a path resolved against the requested tab.
+func (a *App) OpenWorkspacePathForTab(tabID, rel string) error {
+	path, ok, err := a.workspaceOrExternalPathForTab(tabID, rel)
 	if err != nil || !ok {
 		return os.ErrInvalid
 	}
@@ -8049,7 +8089,12 @@ func (a *App) OpenWorkspacePath(rel string) error {
 // RevealWorkspacePath shows a workspace or authorized external-ref file in the
 // native file manager.
 func (a *App) RevealWorkspacePath(rel string) error {
-	path, ok, err := a.workspaceOrExternalPath(rel)
+	return a.RevealWorkspacePathForTab("", rel)
+}
+
+// RevealWorkspacePathForTab reveals a path resolved against the requested tab.
+func (a *App) RevealWorkspacePathForTab(tabID, rel string) error {
+	path, ok, err := a.workspaceOrExternalPathForTab(tabID, rel)
 	if err != nil || !ok {
 		return os.ErrInvalid
 	}

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -5136,6 +5136,56 @@ func TestFileRefsUseActiveTabWorkspaceRoot(t *testing.T) {
 	}
 }
 
+func TestFileRefsForTabIgnoreActiveParentWorkspace(t *testing.T) {
+	parentRoot := robustTempDir(t)
+	childRoot := filepath.Join(parentRoot, "child")
+	if err := os.MkdirAll(childRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentRoot, "parent-only.txt"), []byte("parent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentRoot, "shared.txt"), []byte("parent shared"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childRoot, "child-only.txt"), []byte("child"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childRoot, "shared.txt"), []byte("child shared"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"parent": {ID: "parent", Scope: "project", WorkspaceRoot: parentRoot},
+			"child":  {ID: "child", Scope: "project", WorkspaceRoot: childRoot},
+		},
+		activeTabID: "parent",
+	}
+
+	listed := app.ListDirForTab("child", "")
+	if !hasDirEntry(listed, "child-only.txt") || hasDirEntry(listed, "parent-only.txt") {
+		t.Fatalf("ListDirForTab(child) = %+v, want only child workspace entries", listed)
+	}
+	found := app.SearchFileRefsForTab("child", "child-only")
+	if !hasDirEntry(found, "child-only.txt") {
+		t.Fatalf("SearchFileRefsForTab(child) = %+v, want child-only.txt", found)
+	}
+	preview := app.ReadFileForTab("child", "shared.txt")
+	if preview.Err != "" || preview.Body != "child shared" {
+		t.Fatalf("ReadFileForTab(child) = %+v, want child workspace file", preview)
+	}
+	path, ok, err := app.workspaceOrExternalPathForTab("child", "shared.txt")
+	if err != nil || !ok || path != filepath.Join(childRoot, "shared.txt") {
+		t.Fatalf("workspaceOrExternalPathForTab(child) = (%q, %v, %v)", path, ok, err)
+	}
+
+	legacy := app.ReadFile("shared.txt")
+	if legacy.Err != "" || legacy.Body != "parent shared" {
+		t.Fatalf("ReadFile legacy active-tab behavior = %+v, want parent workspace file", legacy)
+	}
+}
+
 func TestFileRefsIncludeRegisteredExternalFolderChildren(t *testing.T) {
 	workspace := robustTempDir(t)
 	external := filepath.Join(robustTempDir(t), "Folder With Spaces")
@@ -5159,11 +5209,12 @@ func TestFileRefsIncludeRegisteredExternalFolderChildren(t *testing.T) {
 	app := &App{
 		tabs: map[string]*WorkspaceTab{
 			"project": {ID: "project", WorkspaceRoot: workspace, Ctrl: ctrl},
+			"other":   {ID: "other", WorkspaceRoot: robustTempDir(t)},
 		},
-		activeTabID: "project",
+		activeTabID: "other",
 	}
 
-	listed := app.ListDir(token + "/src/")
+	listed := app.ListDirForTab("project", token+"/src/")
 	if len(listed) != 1 ||
 		listed[0].Name != "outside.txt" ||
 		listed[0].Path != token+"/src/outside.txt" ||
@@ -5171,7 +5222,7 @@ func TestFileRefsIncludeRegisteredExternalFolderChildren(t *testing.T) {
 		t.Fatalf("ListDir external src = %+v, want outside token/display path", listed)
 	}
 
-	found := app.SearchFileRefs("outside")
+	found := app.SearchFileRefsForTab("project", "outside")
 	var externalHit *DirEntry
 	for i := range found {
 		if found[i].Path == token+"/src/outside.txt" {
@@ -5183,7 +5234,7 @@ func TestFileRefsIncludeRegisteredExternalFolderChildren(t *testing.T) {
 		t.Fatalf("SearchFileRefs external hit = %+v, all results %+v", externalHit, found)
 	}
 
-	preview := app.ReadFile(token + "/src/outside.txt")
+	preview := app.ReadFileForTab("project", token+"/src/outside.txt")
 	if preview.Err != "" || preview.Body != "outside" {
 		t.Fatalf("ReadFile external token preview = %+v, want outside file body", preview)
 	}

--- a/desktop/bound_array_contract_test.go
+++ b/desktop/bound_array_contract_test.go
@@ -23,6 +23,8 @@ func TestBoundArrayPayloadsAreNonNilBeforeStartup(t *testing.T) {
 		{"Commands", app.Commands()},
 		{"Models", app.Models()},
 		{"ListDir", app.ListDir("__missing__")},
+		{"ListDirForTab", app.ListDirForTab("missing", "")},
+		{"SearchFileRefsForTab", app.SearchFileRefsForTab("missing", "file")},
 		{"ListTabs", app.ListTabs()},
 		{"ListProjectTree", app.ListProjectTree()},
 	}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3591,6 +3591,7 @@ export default function App() {
                 key={state.approval.id}
                 approval={state.approval}
                 cwd={state.meta?.cwd}
+                tabId={activeTabId}
                 insertRequest={planRevisionInsertRequest}
                 onRevisionActiveChange={(active) => setWorkspaceInsertTarget(active ? "planRevision" : "composer")}
                 onAnswer={async (allow, session, persist) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1091,6 +1091,9 @@ export default function App() {
   const workspacePreviewActive = useLayoutStore((s) => s.workspacePreviewActive);
   const setWorkspacePreviewActive = useLayoutStore((s) => s.setWorkspacePreviewActive);
   const attentionChimeEvents = useRef(new Set<string>());
+  const workspaceScopeActiveTabRef = useRef(activeTabId);
+  const [workspaceControllerEpoch, setWorkspaceControllerEpoch] = useState(0);
+  workspaceScopeActiveTabRef.current = activeTabId;
   // Bump dockRefreshKey after each turn so WorkspacePanel/ContextPanel re-fetch
   // workspace changes, git history, and session metadata after AI tool writes.
   useEffect(() => {
@@ -1111,12 +1114,18 @@ export default function App() {
     // completes; clear that tab's keys (or all, for tab-less ready events).
     const unsubReady = onReady((readyTabId) => {
       clearAttentionChimeKeys(attentionChimeEvents.current, readyTabId);
+      if (!readyTabId || readyTabId === workspaceScopeActiveTabRef.current) {
+        setWorkspaceControllerEpoch((value) => value + 1);
+      }
     });
     // Model/effort/token-mode switches and clear-while-running replace the
     // controller WITHOUT an agent:ready — they signal runtime:rebuilt instead
     // (a ready here would trigger a full session reload the UI already did).
     const unsubRebuilt = onRuntimeRebuilt((rebuiltTabId) => {
       clearAttentionChimeKeys(attentionChimeEvents.current, rebuiltTabId);
+      if (!rebuiltTabId || rebuiltTabId === workspaceScopeActiveTabRef.current) {
+        setWorkspaceControllerEpoch((value) => value + 1);
+      }
     });
     return () => {
       unsub();
@@ -1391,6 +1400,14 @@ export default function App() {
   const composerSessionKey = useMemo(() => {
     return composerDraftKeyForTab(activeTab, activeTabId);
   }, [activeTab, activeTabId]);
+  const workspaceScopeKey = [
+    activeTabId ?? "",
+    activeTab?.sessionPath ?? "",
+    state.meta?.sessionPath ?? "",
+    state.meta?.cwd ?? "",
+    state.sessionGen,
+    workspaceControllerEpoch,
+  ].join("\u0000");
   const sidebarImDetailConnection = useMemo(
     () => sidebarImConnections.find((connection) => connection.id === sidebarImDetailConnectionId) ?? null,
     [sidebarImConnections, sidebarImDetailConnectionId],
@@ -3592,6 +3609,7 @@ export default function App() {
                 approval={state.approval}
                 cwd={state.meta?.cwd}
                 tabId={activeTabId}
+                workspaceScopeKey={workspaceScopeKey}
                 insertRequest={planRevisionInsertRequest}
                 onRevisionActiveChange={(active) => setWorkspaceInsertTarget(active ? "planRevision" : "composer")}
                 onAnswer={async (allow, session, persist) => {
@@ -3668,6 +3686,7 @@ export default function App() {
               pendingAsk={state.ask != null}
               transientDismissSignal={transientOverlayDismissSignal}
               sessionKey={composerSessionKey}
+              workspaceScopeKey={workspaceScopeKey}
               fileRefRefreshKey={composerFileRefRefreshKey}
               guidanceConsumedKey={latestGuidanceConsumed?.key}
               guidanceConsumedText={latestGuidanceConsumed?.text}
@@ -3783,6 +3802,7 @@ export default function App() {
                   open={workspacePanelRenderable}
                   tabId={activeTabId}
                   cwd={state.meta?.cwd}
+                  workspaceScopeKey={workspaceScopeKey}
                   maximized={workspacePanelMaximized}
                   panelWidth={workspacePanelRenderWidth}
                   onClose={() => setWorkspacePanel(false)}

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -199,6 +199,24 @@ ok(
   "Welcome is suppressed only until transcript history has loaded",
 );
 
+ok(
+  /const \[workspaceControllerEpoch, setWorkspaceControllerEpoch\] = useState\(0\);/.test(appSource) &&
+    /const workspaceScopeKey = \[/.test(appSource) &&
+    /activeTab\?\.sessionPath/.test(appSource) &&
+    /state\.meta\?\.sessionPath/.test(appSource) &&
+    /state\.meta\?\.cwd/.test(appSource) &&
+    /state\.sessionGen/.test(appSource) &&
+    /workspaceControllerEpoch/.test(appSource) &&
+    Array.from(appSource.matchAll(/workspaceScopeKey=\{workspaceScopeKey\}/g)).length === 3,
+  "workspace file consumers receive a session and controller scoped identity",
+);
+
+ok(
+  /const unsubReady = onReady\(\(readyTabId\) => \{[\s\S]*?setWorkspaceControllerEpoch[\s\S]*?\n    \}\);/.test(appSource) &&
+    /const unsubRebuilt = onRuntimeRebuilt\(\(rebuiltTabId\) => \{[\s\S]*?setWorkspaceControllerEpoch[\s\S]*?\n    \}\);/.test(appSource),
+  "controller ready and rebuilt events invalidate active workspace file scopes",
+);
+
 const navigationBlock = appSource.match(/const runNavigationRequest = useCallback\([\s\S]*?\n  \}, \[[^\]]*singleSurfaceLayout[^\]]*\]\);/)?.[0] ?? "";
 ok(
   /const navigationRunningRef = useRef\(false\);/.test(appSource) &&

--- a/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
+++ b/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
@@ -86,6 +86,8 @@ function mockApp(methods: Partial<AppBindings>) {
     main: {
       App: {
         ...methods,
+        ListDirForTab: methods.ListDirForTab ?? (async (_tabId: string, rel: string) => methods.ListDir?.(rel) ?? []),
+        SearchFileRefsForTab: methods.SearchFileRefsForTab ?? (async (_tabId: string, query: string) => methods.SearchFileRefs?.(query) ?? []),
       } as Partial<AppBindings> as AppBindings,
     },
   };
@@ -105,6 +107,7 @@ async function renderApproval(props: Partial<Parameters<typeof ApprovalModal>[0]
   let currentProps: Parameters<typeof ApprovalModal>[0] = {
     approval,
     cwd: "/repo",
+    tabId: "tab-a",
     onAnswer: () => undefined,
     onRevisePlan: (text) => revisions.push(text),
     onExitPlan: () => undefined,
@@ -131,9 +134,13 @@ console.log("\napproval modal file references");
 
 {
   const dom = installDom("en-US");
+  const fileScopeCalls: string[] = [];
   mockApp({
-    ListDir: async () => [{ name: "src", isDir: true }, { name: "README.md", isDir: false }],
-    SearchFileRefs: async () => [],
+    ListDirForTab: async (tabId) => {
+      fileScopeCalls.push(tabId);
+      return [{ name: "src", isDir: true }, { name: "README.md", isDir: false }];
+    },
+    SearchFileRefsForTab: async () => [],
   });
   const { root, revisions, rerender } = await renderApproval();
 
@@ -152,6 +159,7 @@ console.log("\napproval modal file references");
   await waitFor("plan revision @ text opens file suggestions", () => document.body.textContent?.includes("README.md") === true);
 
   ok(document.body.textContent?.includes("README.md") === true, "plan revision @ text opens file suggestions");
+  ok(fileScopeCalls.every((tabId) => tabId === "tab-a"), "plan revision file suggestions stay scoped to the active tab");
 
   const readmeButton = Array.from(document.querySelectorAll(".slashmenu__item")).find((button) => button.textContent?.includes("README.md")) as HTMLButtonElement | undefined;
   if (!readmeButton) throw new Error("README file suggestion did not render");

--- a/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
+++ b/desktop/frontend/src/__tests__/approval-modal-file-reference.test.tsx
@@ -491,5 +491,44 @@ console.log("\napproval modal file references");
   dom.window.close();
 }
 
+{
+  const dom = installDom("en-US");
+  const pending: Array<(entries: Array<{ name: string; isDir: boolean }>) => void> = [];
+  mockApp({
+    ListDirForTab: async () => new Promise((resolve) => pending.push(resolve)),
+    SearchFileRefsForTab: async () => [],
+  });
+  const { root, rerender } = await renderApproval({ workspaceScopeKey: "session-a" });
+
+  const reviseButton = Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("Revise plan")) as HTMLButtonElement | undefined;
+  if (!reviseButton) throw new Error("revise button did not render");
+  await act(async () => {
+    reviseButton.click();
+    await flushTimers();
+  });
+  await rerender({ insertRequest: { id: 20, text: "inspect @" } });
+  await waitFor("initial approval session scope request", () => pending.length === 1);
+  await rerender({ workspaceScopeKey: "session-b" });
+  await waitFor("next approval session scope request", () => pending.length === 2);
+
+  await act(async () => {
+    pending[1]([{ name: "current-plan-file.ts", isDir: false }]);
+    await flushTimers();
+  });
+  await waitFor("current approval session file result", () => document.body.textContent?.includes("current-plan-file.ts") === true);
+
+  await act(async () => {
+    pending[0]([{ name: "stale-plan-file.ts", isDir: false }]);
+    await flushTimers();
+  });
+  ok(document.body.textContent?.includes("current-plan-file.ts") === true, "current approval session file refs stay visible");
+  ok(document.body.textContent?.includes("stale-plan-file.ts") === false, "late approval session file refs are ignored");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -105,6 +105,7 @@ async function renderComposer(props: Partial<Parameters<typeof Composer>[0]> = {
     tokenMode: "full" as TokenMode,
     goal: "",
     cwd: "/repo",
+    tabId: "tab-a",
     modelLabel: "DeepSeek-R1",
     onSend: (displayText, submitText) => {
       calls.send.push(displayText);
@@ -838,12 +839,14 @@ console.log("\ncomposer goal toggle");
 {
   const dom = installDom();
   let listDirCalls = 0;
+  const listDirTabs: string[] = [];
   mockApp({
-    ListDir: async () => {
+    ListDirForTab: async (tabId) => {
+      listDirTabs.push(tabId);
       listDirCalls += 1;
       return listDirCalls === 1 ? [fileEntry("cached-dir.txt")] : [fileEntry("fresh-dir.txt")];
     },
-    SearchFileRefs: async () => [],
+    SearchFileRefsForTab: async () => [],
   });
   const { root, rerender } = await renderComposer();
 
@@ -855,6 +858,7 @@ console.log("\ncomposer goal toggle");
   await waitFor("@ directory revalidation call", () => listDirCalls === 2);
 
   eq(listDirCalls, 2, "@ directory cache hit still revalidates ListDir");
+  ok(listDirTabs.every((tabId) => tabId === "tab-a"), "@ directory requests stay scoped to the composer tab");
 
   await act(async () => {
     root.unmount();
@@ -866,11 +870,11 @@ console.log("\ncomposer goal toggle");
   const dom = installDom();
   let listDirCalls = 0;
   mockApp({
-    ListDir: async () => {
+    ListDirForTab: async () => {
       listDirCalls += 1;
       return listDirCalls === 1 ? [fileEntry("manual-refresh-stale.txt")] : [fileEntry("manual-refresh-fresh.txt")];
     },
-    SearchFileRefs: async () => [],
+    SearchFileRefsForTab: async () => [],
   });
   const { root, rerender } = await renderComposer({ fileRefRefreshKey: "0" });
 
@@ -895,8 +899,8 @@ console.log("\ncomposer goal toggle");
   let searchCalls = 0;
   Date.now = () => now;
   mockApp({
-    ListDir: async () => [],
-    SearchFileRefs: async () => {
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => {
       searchCalls += 1;
       return searchCalls === 1 ? [fileEntry("alpha-old.ts")] : [fileEntry("alpha-new.ts")];
     },
@@ -937,7 +941,7 @@ console.log("\ncomposer goal toggle");
   let thirdListDirResolve: ((entries: DirEntry[]) => void) | undefined;
   let listDirCalls = 0;
   mockApp({
-    ListDir: async () => {
+    ListDirForTab: async () => {
       listDirCalls += 1;
       if (listDirCalls === 1) {
         return new Promise<DirEntry[]>((resolve) => {
@@ -949,7 +953,7 @@ console.log("\ncomposer goal toggle");
         thirdListDirResolve = resolve;
       });
     },
-    SearchFileRefs: async () => [],
+    SearchFileRefsForTab: async () => [],
   });
   const { root, rerender } = await renderComposer({ fileRefRefreshKey: "0" });
 

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -990,5 +990,44 @@ console.log("\ncomposer goal toggle");
   dom.window.close();
 }
 
+{
+  const dom = installDom();
+  const pending: Array<(entries: DirEntry[]) => void> = [];
+  mockApp({
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => new Promise<DirEntry[]>((resolve) => pending.push(resolve)),
+  });
+  const { root, rerender } = await renderComposer({ workspaceScopeKey: "session-a" });
+  const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render");
+
+  await replaceComposerDraft(rerender, 501, "@current");
+  await waitFor("initial composer session scope request", () => pending.length === 1);
+  await rerender({ workspaceScopeKey: "session-b" });
+  await waitFor("next composer session scope request", () => pending.length === 2);
+  await rerender({ workspaceScopeKey: "session-a" });
+  await waitFor("revisited composer session scope request", () => pending.length === 3);
+
+  await act(async () => {
+    pending[2]([fileEntry("current-session-a.txt")]);
+    await flushTimers();
+  });
+
+  await act(async () => {
+    pending[0]([fileEntry("stale-initial-a.txt")]);
+    pending[1]([fileEntry("stale-session-b.txt")]);
+    await flushTimers();
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await flushTimers();
+  });
+
+  eq(textarea.value, "@current-session-a.txt ", "same-tab A→B→A keeps the current composer file-ref search cache");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
@@ -72,7 +72,7 @@ async function renderWorkspace(changes: WorkspaceChangesView) {
   window.go = {
     main: {
       App: {
-        ListDir: async () => [],
+        ListDirForTab: async () => [],
         WorkspaceGitHistory: async () => [],
         WorkspaceChanges: async () => changes,
       } as Partial<AppBindings> as AppBindings,
@@ -106,8 +106,8 @@ async function renderFilesWorkspace(methods: Partial<AppBindings>, props: Partia
   window.go = {
     main: {
       App: {
-        ListDir: async () => [],
-        SearchFileRefs: async () => [],
+        ListDirForTab: async () => [],
+        SearchFileRefsForTab: async () => [],
         WorkspaceGitHistory: async () => [],
         WorkspaceChanges: async () => ({ files: [], gitAvailable: true }),
         ...methods,
@@ -194,20 +194,57 @@ console.log("\nworkspace changes git errors");
 
 {
   const calls: string[] = [];
-  const listDir = async (dir: string): Promise<DirEntry[]> => {
-    calls.push(dir);
+  const listDirForTab = async (tabId: string, dir: string): Promise<DirEntry[]> => {
+    calls.push(`${tabId}:${dir}`);
     return [];
   };
   const { dom, root, rerender } = await renderFilesWorkspace(
-    { ListDir: listDir },
+    { ListDirForTab: listDirForTab },
     { fileListRequest: { id: 1, paths: ["src/app.ts"] } },
   );
 
-  await waitFor("initial referenced file dirs", () => calls.filter((dir) => dir === "src/").length === 1);
+  await waitFor("initial referenced file dirs", () => calls.filter((call) => call === "tab-a:src/").length === 1);
   await rerender({ fileListRequest: { id: 2, paths: ["src/app.ts"] } });
-  await waitFor("referenced file dirs revalidated", () => calls.filter((dir) => dir === "src/").length === 2);
+  await waitFor("referenced file dirs revalidated", () => calls.filter((call) => call === "tab-a:src/").length === 2);
 
-  ok(calls.filter((dir) => dir === "src/").length === 2, "workspace file tree revalidates cached directories for repeated file-list requests");
+  ok(calls.filter((call) => call === "tab-a:src/").length === 2, "workspace file tree revalidates cached directories for repeated file-list requests");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const pending: Array<{ tabId: string; resolve: (entries: DirEntry[]) => void }> = [];
+  const listDirForTab = (tabId: string, dir: string): Promise<DirEntry[]> => {
+    if (dir !== "") return Promise.resolve([]);
+    return new Promise((resolve) => pending.push({ tabId, resolve }));
+  };
+  const { dom, root, rerender } = await renderFilesWorkspace(
+    { ListDirForTab: listDirForTab },
+    { tabId: "parent-tab", cwd: "/repo" },
+  );
+
+  await waitFor("parent workspace request", () => pending.some((request) => request.tabId === "parent-tab"));
+  await rerender({ tabId: "child-tab", cwd: "/repo/child" });
+  await waitFor("child workspace request", () => pending.some((request) => request.tabId === "child-tab"));
+
+  await act(async () => {
+    pending.filter((request) => request.tabId === "child-tab").forEach((request) => request.resolve([
+      { name: "child-a.txt", isDir: false },
+      { name: "child-b.txt", isDir: false },
+    ]));
+    await flushPromises();
+  });
+  await waitFor("child workspace entries", () => (document.querySelector(".workspace-tree__sizer") as HTMLElement | null)?.style.height === "48px");
+
+  await act(async () => {
+    pending.filter((request) => request.tabId === "parent-tab").forEach((request) => request.resolve([{ name: "parent-only.txt", isDir: false }]));
+    await flushPromises();
+  });
+
+  ok((document.querySelector(".workspace-tree__sizer") as HTMLElement | null)?.style.height === "48px", "late parent workspace response cannot overwrite the two-row child tree");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
@@ -252,5 +252,91 @@ console.log("\nworkspace changes git errors");
   dom.window.close();
 }
 
+{
+  const pending: Array<(entries: DirEntry[]) => void> = [];
+  const listDirForTab = (_tabId: string, dir: string): Promise<DirEntry[]> => {
+    if (dir !== "") return Promise.resolve([]);
+    return new Promise((resolve) => pending.push(resolve));
+  };
+  const { dom, root, rerender } = await renderFilesWorkspace(
+    { ListDirForTab: listDirForTab },
+    { tabId: "shared-tab", cwd: "/repo", workspaceScopeKey: "session-a" },
+  );
+
+  await waitFor("initial session A workspace request", () => pending.length === 1);
+  await rerender({ workspaceScopeKey: "session-b" });
+  await waitFor("session B workspace request", () => pending.length === 2);
+  await rerender({ workspaceScopeKey: "session-a" });
+  await waitFor("revisited session A workspace request", () => pending.length === 3);
+
+  await act(async () => {
+    pending[2]([
+      { name: "current-a.txt", isDir: false },
+      { name: "current-b.txt", isDir: false },
+    ]);
+    await flushPromises();
+  });
+  await waitFor("revisited session A entries", () => (document.querySelector(".workspace-tree__sizer") as HTMLElement | null)?.style.height === "48px");
+
+  await act(async () => {
+    pending[0]([{ name: "stale-initial-a.txt", isDir: false }]);
+    pending[1]([{ name: "stale-b.txt", isDir: false }]);
+    await flushPromises();
+  });
+
+  ok(
+    (document.querySelector(".workspace-tree__sizer") as HTMLElement | null)?.style.height === "48px",
+    "same-tab A→B→A session switches reject stale workspace responses",
+  );
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const pending: Array<(changes: WorkspaceChangesView) => void> = [];
+  const workspaceChanges = (): Promise<WorkspaceChangesView> => new Promise((resolve) => pending.push(resolve));
+  const { dom, root, rerender } = await renderFilesWorkspace(
+    { WorkspaceChanges: workspaceChanges },
+    {
+      tabId: "shared-tab",
+      cwd: "/repo",
+      workspaceScopeKey: "session-a",
+      initialViewMode: "changed",
+    },
+  );
+
+  await waitFor("initial session changes request", () => pending.length === 1);
+  await rerender({ workspaceScopeKey: "session-b" });
+  await waitFor("next session changes request", () => pending.length === 2);
+
+  await act(async () => {
+    pending[1]({
+      files: [{ path: "session-b.ts", sources: ["session"] }],
+      gitAvailable: true,
+    });
+    await flushPromises();
+  });
+  await waitFor("session B changes", () => document.body.textContent?.includes("session-b.ts") === true);
+
+  await act(async () => {
+    pending[0]({
+      files: [{ path: "stale-session-a.ts", sources: ["session"] }],
+      gitAvailable: true,
+    });
+    await flushPromises();
+  });
+
+  ok(document.body.textContent?.includes("session-b.ts") === true, "current same-tab session changes stay visible");
+  ok(document.body.textContent?.includes("stale-session-a.ts") === false, "late same-tab session changes cannot overwrite the current session");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -136,6 +136,7 @@ export function ApprovalModal({
   onExitPlan,
   onStop,
   cwd,
+  tabId,
   insertRequest,
   onRevisionActiveChange,
   toolApprovalMode,
@@ -146,6 +147,7 @@ export function ApprovalModal({
   onExitPlan?: () => void;
   onStop: () => void;
   cwd?: string;
+  tabId?: string;
   insertRequest?: ComposerInsertRequest | null;
   onRevisionActiveChange?: (active: boolean) => void;
   toolApprovalMode?: ToolApprovalMode;
@@ -185,7 +187,7 @@ export function ApprovalModal({
   // the new one slides in.  GSAP fromTo on the shelf wrapper avoids the
   // jarring pop when the API cycles through 4+ pending approvals.
   const closingRef = useRef(false);
-  const fileMenu = useFileReferenceMenu(revisionText, cwd);
+  const fileMenu = useFileReferenceMenu(revisionText, cwd, tabId);
 
   const answerWithExit = (fn: () => void) => {
     if (closingRef.current) return;

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -137,6 +137,7 @@ export function ApprovalModal({
   onStop,
   cwd,
   tabId,
+  workspaceScopeKey,
   insertRequest,
   onRevisionActiveChange,
   toolApprovalMode,
@@ -148,6 +149,7 @@ export function ApprovalModal({
   onStop: () => void;
   cwd?: string;
   tabId?: string;
+  workspaceScopeKey?: string;
   insertRequest?: ComposerInsertRequest | null;
   onRevisionActiveChange?: (active: boolean) => void;
   toolApprovalMode?: ToolApprovalMode;
@@ -187,7 +189,7 @@ export function ApprovalModal({
   // the new one slides in.  GSAP fromTo on the shelf wrapper avoids the
   // jarring pop when the API cycles through 4+ pending approvals.
   const closingRef = useRef(false);
-  const fileMenu = useFileReferenceMenu(revisionText, cwd, tabId);
+  const fileMenu = useFileReferenceMenu(revisionText, cwd, tabId, workspaceScopeKey);
 
   const answerWithExit = (fn: () => void) => {
     if (closingRef.current) return;

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -843,6 +843,7 @@ export function Composer({
   const [searchEntries, setSearchEntries] = useState<DirEntry[]>([]);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
   const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
+  const fileRefTabId = tabId ?? "";
 
   const clearFileRefState = useCallback(() => {
     dirCache.current = {};
@@ -857,16 +858,15 @@ export function Composer({
     setDismissed(false);
   }, []);
 
-  // When the workspace/project changes (cwd prop), invalidate all @ mention
-  // state so the picker reloads candidates for the new project. Without this,
-  // dirCache/searchCache retain entries from the old project and the picker
-  // shows stale results (issue #3601).
-  const prevCwdRef = useRef(cwd);
+  // When the tab or workspace changes, invalidate all @ mention state so
+  // session-scoped external refs and workspace files cannot cross tabs.
+  const prevFileRefScopeRef = useRef({ tabId: fileRefTabId, cwd });
   useEffect(() => {
-    if (prevCwdRef.current === cwd) return; // skip mount — state already initial
-    prevCwdRef.current = cwd;
+    const previous = prevFileRefScopeRef.current;
+    if (previous.tabId === fileRefTabId && previous.cwd === cwd) return;
+    prevFileRefScopeRef.current = { tabId: fileRefTabId, cwd };
     clearFileRefState();
-  }, [clearFileRefState, cwd]);
+  }, [clearFileRefState, cwd, fileRefTabId]);
 
   const prevFileRefRefreshKeyRef = useRef(fileRefRefreshKey);
   useEffect(() => {
@@ -885,7 +885,7 @@ export function Composer({
     }
     let live = true;
     app
-      .ListDir(atDir)
+      .ListDirForTab(fileRefTabId, atDir)
       .then((es) => {
         const list = asArray(es);
         if (!live) return;
@@ -898,7 +898,7 @@ export function Composer({
     };
     // Re-fetch when the menu opens, the directory level changes, or the
     // workspace tree refreshes; cached data is only a fast first paint.
-  }, [atRaw === null, atDir, cwd, fileRefRefreshKey]);
+  }, [atRaw === null, atDir, cwd, fileRefRefreshKey, fileRefTabId]);
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
       setSearchEntries([]);
@@ -913,7 +913,7 @@ export function Composer({
     }
     let live = true;
     app
-      .SearchFileRefs(atFrag)
+      .SearchFileRefsForTab(fileRefTabId, atFrag)
       .then((es) => {
         const list = asArray(es);
         if (!live) return;
@@ -924,7 +924,7 @@ export function Composer({
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag, cwd, fileRefRefreshKey]);
+  }, [atRaw === null, atDir, atFrag, cwd, fileRefRefreshKey, fileRefTabId]);
   const atMatches = useMemo(
     () => {
       if (atRaw === null) return [];

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -498,6 +498,7 @@ export function Composer({
   pendingAsk = false,
   transientDismissSignal,
   sessionKey,
+  workspaceScopeKey,
   fileRefRefreshKey,
   guidanceConsumedKey,
   guidanceConsumedText,
@@ -552,6 +553,7 @@ export function Composer({
   pendingAsk?: boolean;
   transientDismissSignal?: number;
   sessionKey?: string;
+  workspaceScopeKey?: string;
   fileRefRefreshKey?: number | string;
   guidanceConsumedKey?: string;
   guidanceConsumedText?: string;
@@ -844,6 +846,7 @@ export function Composer({
   const dirCache = useRef<Record<string, DirEntry[]>>({});
   const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
   const fileRefTabId = tabId ?? "";
+  const fileRefScopeKey = workspaceScopeKey ?? `${fileRefTabId}\u0000${cwd ?? ""}`;
 
   const clearFileRefState = useCallback(() => {
     dirCache.current = {};
@@ -858,15 +861,14 @@ export function Composer({
     setDismissed(false);
   }, []);
 
-  // When the tab or workspace changes, invalidate all @ mention state so
-  // session-scoped external refs and workspace files cannot cross tabs.
-  const prevFileRefScopeRef = useRef({ tabId: fileRefTabId, cwd });
+  // Controller/session changes invalidate @ mention state even when tab and
+  // workspace identities stay the same (saved-session rebinds and rebuilds).
+  const prevFileRefScopeRef = useRef(fileRefScopeKey);
   useEffect(() => {
-    const previous = prevFileRefScopeRef.current;
-    if (previous.tabId === fileRefTabId && previous.cwd === cwd) return;
-    prevFileRefScopeRef.current = { tabId: fileRefTabId, cwd };
+    if (prevFileRefScopeRef.current === fileRefScopeKey) return;
+    prevFileRefScopeRef.current = fileRefScopeKey;
     clearFileRefState();
-  }, [clearFileRefState, cwd, fileRefTabId]);
+  }, [clearFileRefState, fileRefScopeKey]);
 
   const prevFileRefRefreshKeyRef = useRef(fileRefRefreshKey);
   useEffect(() => {
@@ -898,7 +900,7 @@ export function Composer({
     };
     // Re-fetch when the menu opens, the directory level changes, or the
     // workspace tree refreshes; cached data is only a fast first paint.
-  }, [atRaw === null, atDir, cwd, fileRefRefreshKey, fileRefTabId]);
+  }, [atRaw === null, atDir, fileRefRefreshKey, fileRefScopeKey, fileRefTabId]);
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
       setSearchEntries([]);
@@ -924,7 +926,7 @@ export function Composer({
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag, cwd, fileRefRefreshKey, fileRefTabId]);
+  }, [atRaw === null, atDir, atFrag, fileRefRefreshKey, fileRefScopeKey, fileRefTabId]);
   const atMatches = useMemo(
     () => {
       if (atRaw === null) return [];

--- a/desktop/frontend/src/components/FileReferenceMenu.tsx
+++ b/desktop/frontend/src/components/FileReferenceMenu.tsx
@@ -55,7 +55,7 @@ export function insertTextAtSelection(
   return { value: next, caret: before.length + text.length };
 }
 
-export function useFileReferenceMenu(text: string, cwd?: string) {
+export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string) {
   const token = useMemo(() => activeFileReferenceToken(text), [text]);
   const atRaw = token?.raw ?? null;
   const atDir = token?.dir ?? "";
@@ -66,18 +66,20 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
   const [dismissed, setDismissed] = useState(false);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
   const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
-  const prevCwdRef = useRef(cwd);
+  const fileRefTabId = tabId ?? "";
+  const prevFileRefScopeRef = useRef({ tabId: fileRefTabId, cwd });
 
   useEffect(() => {
-    if (prevCwdRef.current === cwd) return;
-    prevCwdRef.current = cwd;
+    const previous = prevFileRefScopeRef.current;
+    if (previous.tabId === fileRefTabId && previous.cwd === cwd) return;
+    prevFileRefScopeRef.current = { tabId: fileRefTabId, cwd };
     dirCache.current = {};
     searchCache.current = {};
     setEntries([]);
     setSearchEntries([]);
     setActive(0);
     setDismissed(false);
-  }, [cwd]);
+  }, [cwd, fileRefTabId]);
 
   useEffect(() => {
     setActive(0);
@@ -94,7 +96,7 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     }
     let live = true;
     app
-      .ListDir(atDir)
+      .ListDirForTab(fileRefTabId, atDir)
       .then((next) => {
         const list = asArray(next);
         if (!live) return;
@@ -105,7 +107,7 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, cwd]);
+  }, [atRaw === null, atDir, cwd, fileRefTabId]);
 
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
@@ -121,7 +123,7 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     }
     let live = true;
     app
-      .SearchFileRefs(atFrag)
+      .SearchFileRefsForTab(fileRefTabId, atFrag)
       .then((next) => {
         const list = asArray(next);
         if (!live) return;
@@ -132,7 +134,7 @@ export function useFileReferenceMenu(text: string, cwd?: string) {
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag, cwd]);
+  }, [atRaw === null, atDir, atFrag, cwd, fileRefTabId]);
 
   const items = useMemo(() => {
     if (atRaw === null) return [];

--- a/desktop/frontend/src/components/FileReferenceMenu.tsx
+++ b/desktop/frontend/src/components/FileReferenceMenu.tsx
@@ -55,7 +55,7 @@ export function insertTextAtSelection(
   return { value: next, caret: before.length + text.length };
 }
 
-export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string) {
+export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string, workspaceScopeKey?: string) {
   const token = useMemo(() => activeFileReferenceToken(text), [text]);
   const atRaw = token?.raw ?? null;
   const atDir = token?.dir ?? "";
@@ -67,19 +67,19 @@ export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string)
   const dirCache = useRef<Record<string, DirEntry[]>>({});
   const searchCache = useRef<Record<string, FileRefSearchCacheEntry>>({});
   const fileRefTabId = tabId ?? "";
-  const prevFileRefScopeRef = useRef({ tabId: fileRefTabId, cwd });
+  const fileRefScopeKey = workspaceScopeKey ?? `${fileRefTabId}\u0000${cwd ?? ""}`;
+  const prevFileRefScopeRef = useRef(fileRefScopeKey);
 
   useEffect(() => {
-    const previous = prevFileRefScopeRef.current;
-    if (previous.tabId === fileRefTabId && previous.cwd === cwd) return;
-    prevFileRefScopeRef.current = { tabId: fileRefTabId, cwd };
+    if (prevFileRefScopeRef.current === fileRefScopeKey) return;
+    prevFileRefScopeRef.current = fileRefScopeKey;
     dirCache.current = {};
     searchCache.current = {};
     setEntries([]);
     setSearchEntries([]);
     setActive(0);
     setDismissed(false);
-  }, [cwd, fileRefTabId]);
+  }, [fileRefScopeKey]);
 
   useEffect(() => {
     setActive(0);
@@ -107,7 +107,7 @@ export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string)
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, cwd, fileRefTabId]);
+  }, [atRaw === null, atDir, fileRefScopeKey, fileRefTabId]);
 
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
@@ -134,7 +134,7 @@ export function useFileReferenceMenu(text: string, cwd?: string, tabId?: string)
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag, cwd, fileRefTabId]);
+  }, [atRaw === null, atDir, atFrag, fileRefScopeKey, fileRefTabId]);
 
   const items = useMemo(() => {
     if (atRaw === null) return [];

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -236,6 +236,7 @@ export function WorkspacePanel({
   showViewTabs?: boolean;
 }) {
   const t = useT();
+  const workspaceTabId = tabId ?? "";
   const panelRef = useRef<HTMLElement>(null);
   const treeRef = useRef<HTMLDivElement>(null);
   const filterRef = useRef<HTMLInputElement>(null);
@@ -274,7 +275,8 @@ export function WorkspacePanel({
   const dismissedFileListRequestIdRef = useRef<number | null>(null);
   const lastChangeListRequestIdRef = useRef<number | null>(null);
   const dismissedChangeListRequestIdRef = useRef<number | null>(null);
-  const lastWorkspaceTabIdRef = useRef(tabId ?? "");
+  const currentWorkspaceTabIdRef = useRef(workspaceTabId);
+  const lastWorkspaceTabIdRef = useRef(workspaceTabId);
   const workspaceChangesRequestIdRef = useRef(0);
   const gitHistoryRequestIdRef = useRef(0);
   const commitDetailRequestIdRef = useRef(0);
@@ -283,23 +285,29 @@ export function WorkspacePanel({
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
   const pendingTreeRevealPathRef = useRef<string | null>(null);
+  currentWorkspaceTabIdRef.current = workspaceTabId;
 
   useEffect(() => {
     openDirsRef.current = openDirs;
   }, [openDirs]);
 
   const loadDir = useCallback(async (dir: string) => {
+    const requestTabId = workspaceTabId;
     const generation = dirLoadGenerationRef.current;
     const requestId = (dirLoadRequestIdsRef.current[dir] ?? 0) + 1;
     dirLoadRequestIdsRef.current[dir] = requestId;
-    const entries = await app.ListDir(dir).catch((): DirEntry[] => []);
-    if (dirLoadGenerationRef.current !== generation || dirLoadRequestIdsRef.current[dir] !== requestId) return;
+    const entries = await app.ListDirForTab(requestTabId, dir).catch((): DirEntry[] => []);
+    if (
+      currentWorkspaceTabIdRef.current !== requestTabId ||
+      dirLoadGenerationRef.current !== generation ||
+      dirLoadRequestIdsRef.current[dir] !== requestId
+    ) return;
     setEntriesByDir((prev) => ({ ...prev, [dir]: asArray(entries) }));
-  }, []);
+  }, [workspaceTabId]);
 
   const loadGitHistory = useCallback(async () => {
     const requestId = ++gitHistoryRequestIdRef.current;
-    const requestTabId = tabId ?? "";
+    const requestTabId = workspaceTabId;
     setLoadingHistory(true);
     try {
       const result = await app.WorkspaceGitHistory(requestTabId, selectedPath || "");
@@ -315,11 +323,11 @@ export function WorkspacePanel({
         setLoadingHistory(false);
       }
     }
-  }, [selectedPath, tabId]);
+  }, [selectedPath, workspaceTabId]);
 
   const loadWorkspaceChanges = useCallback(async () => {
     const requestId = ++workspaceChangesRequestIdRef.current;
-    const requestTabId = tabId ?? "";
+    const requestTabId = workspaceTabId;
     try {
       const result = await app.WorkspaceChanges(requestTabId);
       if (workspaceChangesRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
@@ -335,7 +343,7 @@ export function WorkspacePanel({
         setWorkspaceChanges({ files: [], gitAvailable: false });
       }
     }
-  }, [tabId]);
+  }, [workspaceTabId]);
 
   const toggleCommit = useCallback((hash: string) => {
     setExpandedCommit((prev) => {
@@ -349,7 +357,7 @@ export function WorkspacePanel({
     if (!open) return;
     if (expandedCommit) {
       const requestId = ++commitDetailRequestIdRef.current;
-      const requestTabId = tabId ?? "";
+      const requestTabId = workspaceTabId;
       let live = true;
       setLoadingCommit(true);
       app
@@ -376,7 +384,7 @@ export function WorkspacePanel({
       commitDetailRequestIdRef.current += 1;
       setCommitDetail(null);
     }
-  }, [expandedCommit, selectedPath, open, tabId]);
+  }, [expandedCommit, selectedPath, open, workspaceTabId]);
 
   const selectFile = useCallback(
     (path: string) => {
@@ -436,7 +444,7 @@ export function WorkspacePanel({
 
   useEffect(() => {
     if (!open) return;
-    const nextTabId = tabId ?? "";
+    const nextTabId = workspaceTabId;
     if (lastWorkspaceTabIdRef.current === nextTabId) return;
     lastWorkspaceTabIdRef.current = nextTabId;
     workspaceChangesRequestIdRef.current += 1;
@@ -456,7 +464,7 @@ export function WorkspacePanel({
       setOpenTabs([]);
       setPreview(null);
     }
-  }, [open, tabId]);
+  }, [open, workspaceTabId]);
 
   useEffect(() => {
     if (!open) return;
@@ -666,7 +674,7 @@ export function WorkspacePanel({
     let live = true;
     setLoadingPreview(true);
     app
-      .ReadFile(selectedPath)
+      .ReadFileForTab(workspaceTabId, selectedPath)
       .then((next) => {
         if (live) setPreview(next);
       })
@@ -688,7 +696,7 @@ export function WorkspacePanel({
     return () => {
       live = false;
     };
-  }, [selectedPath]);
+  }, [selectedPath, workspaceTabId]);
 
 
 
@@ -741,13 +749,13 @@ export function WorkspacePanel({
       return;
     }
     let cancelled = false;
-    app.SearchFileRefs(q).then((results) => {
+    app.SearchFileRefsForTab(workspaceTabId, q).then((results) => {
       if (!cancelled) setSearchResults(results);
     }).catch(() => {
       if (!cancelled) setSearchResults(null);
     });
     return () => { cancelled = true; };
-  }, [filter, viewMode, scopedFilePaths, open]);
+  }, [filter, viewMode, scopedFilePaths, open, workspaceTabId]);
 
   const flattened = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -1059,9 +1067,11 @@ export function WorkspacePanel({
   const addTreeFileToChat = async () => {
     if (!treeMenu || treeMenu.isDir) return;
     const target = treeMenu;
+    const requestTabId = workspaceTabId;
     setTreeMenu(null);
     try {
-      const file = await app.ReadFile(target.path);
+      const file = await app.ReadFileForTab(requestTabId, target.path);
+      if (currentWorkspaceTabIdRef.current !== requestTabId) return;
       if (file.err || file.binary || file.kind) {
         onAddToChat?.(formatWorkspaceReference(target.path, false));
         return;
@@ -1069,6 +1079,7 @@ export function WorkspacePanel({
       const suffix = file.truncated ? `\n\n${t("workspace.truncated")}` : "";
       onAddToChat?.(formatSelectionReference(target.path, file.body) + suffix);
     } catch {
+      if (currentWorkspaceTabIdRef.current !== requestTabId) return;
       onAddToChat?.(formatWorkspaceReference(target.path, false));
     }
   };
@@ -1076,7 +1087,7 @@ export function WorkspacePanel({
   const revealInFileManager = () => {
     if (!treeMenu) return;
     setTreeMenu(null);
-    void app.RevealWorkspacePath(treeMenu.path).catch(() => {});
+    void app.RevealWorkspacePathForTab(workspaceTabId, treeMenu.path).catch(() => {});
   };
 
   const renderNormalRow = (row: TreeRow) => {

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -215,6 +215,7 @@ export function WorkspacePanel({
   fileListRequest,
   changeListRequest,
   showViewTabs = true,
+  workspaceScopeKey: workspaceScopeKeyProp,
 }: {
   open: boolean;
   tabId?: string;
@@ -234,9 +235,11 @@ export function WorkspacePanel({
   fileListRequest?: WorkspaceFileListRequest | null;
   changeListRequest?: WorkspaceChangeListRequest | null;
   showViewTabs?: boolean;
+  workspaceScopeKey?: string;
 }) {
   const t = useT();
   const workspaceTabId = tabId ?? "";
+  const workspaceScopeKey = workspaceScopeKeyProp ?? `${workspaceTabId}\u0000${cwd ?? ""}`;
   const panelRef = useRef<HTMLElement>(null);
   const treeRef = useRef<HTMLDivElement>(null);
   const filterRef = useRef<HTMLInputElement>(null);
@@ -275,8 +278,8 @@ export function WorkspacePanel({
   const dismissedFileListRequestIdRef = useRef<number | null>(null);
   const lastChangeListRequestIdRef = useRef<number | null>(null);
   const dismissedChangeListRequestIdRef = useRef<number | null>(null);
-  const currentWorkspaceTabIdRef = useRef(workspaceTabId);
-  const lastWorkspaceTabIdRef = useRef(workspaceTabId);
+  const currentWorkspaceScopeKeyRef = useRef(workspaceScopeKey);
+  const lastWorkspaceScopeKeyRef = useRef(workspaceScopeKey);
   const workspaceChangesRequestIdRef = useRef(0);
   const gitHistoryRequestIdRef = useRef(0);
   const commitDetailRequestIdRef = useRef(0);
@@ -285,7 +288,7 @@ export function WorkspacePanel({
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
   const pendingTreeRevealPathRef = useRef<string | null>(null);
-  currentWorkspaceTabIdRef.current = workspaceTabId;
+  currentWorkspaceScopeKeyRef.current = workspaceScopeKey;
 
   useEffect(() => {
     openDirsRef.current = openDirs;
@@ -293,44 +296,47 @@ export function WorkspacePanel({
 
   const loadDir = useCallback(async (dir: string) => {
     const requestTabId = workspaceTabId;
+    const requestScopeKey = workspaceScopeKey;
     const generation = dirLoadGenerationRef.current;
     const requestId = (dirLoadRequestIdsRef.current[dir] ?? 0) + 1;
     dirLoadRequestIdsRef.current[dir] = requestId;
     const entries = await app.ListDirForTab(requestTabId, dir).catch((): DirEntry[] => []);
     if (
-      currentWorkspaceTabIdRef.current !== requestTabId ||
+      currentWorkspaceScopeKeyRef.current !== requestScopeKey ||
       dirLoadGenerationRef.current !== generation ||
       dirLoadRequestIdsRef.current[dir] !== requestId
     ) return;
     setEntriesByDir((prev) => ({ ...prev, [dir]: asArray(entries) }));
-  }, [workspaceTabId]);
+  }, [workspaceScopeKey, workspaceTabId]);
 
   const loadGitHistory = useCallback(async () => {
     const requestId = ++gitHistoryRequestIdRef.current;
     const requestTabId = workspaceTabId;
+    const requestScopeKey = workspaceScopeKey;
     setLoadingHistory(true);
     try {
       const result = await app.WorkspaceGitHistory(requestTabId, selectedPath || "");
-      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+      if (gitHistoryRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
         setGitHistory(result || []);
       }
     } catch (err) {
-      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+      if (gitHistoryRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
         setGitHistory([]);
       }
     } finally {
-      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+      if (gitHistoryRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
         setLoadingHistory(false);
       }
     }
-  }, [selectedPath, workspaceTabId]);
+  }, [selectedPath, workspaceScopeKey, workspaceTabId]);
 
   const loadWorkspaceChanges = useCallback(async () => {
     const requestId = ++workspaceChangesRequestIdRef.current;
     const requestTabId = workspaceTabId;
+    const requestScopeKey = workspaceScopeKey;
     try {
       const result = await app.WorkspaceChanges(requestTabId);
-      if (workspaceChangesRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+      if (workspaceChangesRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
         setWorkspaceChanges({
           files: Array.isArray(result?.files) ? result.files : [],
           gitAvailable: result?.gitAvailable !== false,
@@ -339,11 +345,11 @@ export function WorkspacePanel({
         });
       }
     } catch {
-      if (workspaceChangesRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+      if (workspaceChangesRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
         setWorkspaceChanges({ files: [], gitAvailable: false });
       }
     }
-  }, [workspaceTabId]);
+  }, [workspaceScopeKey, workspaceTabId]);
 
   const toggleCommit = useCallback((hash: string) => {
     setExpandedCommit((prev) => {
@@ -358,22 +364,23 @@ export function WorkspacePanel({
     if (expandedCommit) {
       const requestId = ++commitDetailRequestIdRef.current;
       const requestTabId = workspaceTabId;
+      const requestScopeKey = workspaceScopeKey;
       let live = true;
       setLoadingCommit(true);
       app
         .WorkspaceGitCommitDetail(requestTabId, expandedCommit, selectedPath || "")
         .then((detail) => {
-          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+          if (live && commitDetailRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
             setCommitDetail(detail);
           }
         })
         .catch(() => {
-          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+          if (live && commitDetailRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
             setCommitDetail(null);
           }
         })
         .finally(() => {
-          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+          if (live && commitDetailRequestIdRef.current === requestId && currentWorkspaceScopeKeyRef.current === requestScopeKey) {
             setLoadingCommit(false);
           }
         });
@@ -384,7 +391,7 @@ export function WorkspacePanel({
       commitDetailRequestIdRef.current += 1;
       setCommitDetail(null);
     }
-  }, [expandedCommit, selectedPath, open, workspaceTabId]);
+  }, [expandedCommit, selectedPath, open, workspaceScopeKey, workspaceTabId]);
 
   const selectFile = useCallback(
     (path: string) => {
@@ -444,9 +451,8 @@ export function WorkspacePanel({
 
   useEffect(() => {
     if (!open) return;
-    const nextTabId = workspaceTabId;
-    if (lastWorkspaceTabIdRef.current === nextTabId) return;
-    lastWorkspaceTabIdRef.current = nextTabId;
+    if (lastWorkspaceScopeKeyRef.current === workspaceScopeKey) return;
+    lastWorkspaceScopeKeyRef.current = workspaceScopeKey;
     workspaceChangesRequestIdRef.current += 1;
     gitHistoryRequestIdRef.current += 1;
     commitDetailRequestIdRef.current += 1;
@@ -464,7 +470,7 @@ export function WorkspacePanel({
       setOpenTabs([]);
       setPreview(null);
     }
-  }, [open, workspaceTabId]);
+  }, [open, viewMode, workspaceScopeKey]);
 
   useEffect(() => {
     if (!open) return;
@@ -696,7 +702,7 @@ export function WorkspacePanel({
     return () => {
       live = false;
     };
-  }, [selectedPath, workspaceTabId]);
+  }, [selectedPath, workspaceScopeKey, workspaceTabId]);
 
 
 
@@ -755,7 +761,7 @@ export function WorkspacePanel({
       if (!cancelled) setSearchResults(null);
     });
     return () => { cancelled = true; };
-  }, [filter, viewMode, scopedFilePaths, open, workspaceTabId]);
+  }, [filter, viewMode, scopedFilePaths, open, workspaceScopeKey, workspaceTabId]);
 
   const flattened = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -1068,10 +1074,11 @@ export function WorkspacePanel({
     if (!treeMenu || treeMenu.isDir) return;
     const target = treeMenu;
     const requestTabId = workspaceTabId;
+    const requestScopeKey = workspaceScopeKey;
     setTreeMenu(null);
     try {
       const file = await app.ReadFileForTab(requestTabId, target.path);
-      if (currentWorkspaceTabIdRef.current !== requestTabId) return;
+      if (currentWorkspaceScopeKeyRef.current !== requestScopeKey) return;
       if (file.err || file.binary || file.kind) {
         onAddToChat?.(formatWorkspaceReference(target.path, false));
         return;
@@ -1079,7 +1086,7 @@ export function WorkspacePanel({
       const suffix = file.truncated ? `\n\n${t("workspace.truncated")}` : "";
       onAddToChat?.(formatSelectionReference(target.path, file.body) + suffix);
     } catch {
-      if (currentWorkspaceTabIdRef.current !== requestTabId) return;
+      if (currentWorkspaceScopeKeyRef.current !== requestScopeKey) return;
       onAddToChat?.(formatWorkspaceReference(target.path, false));
     }
   };

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -238,15 +238,20 @@ export interface AppBindings {
   SetMCPServerTier(name: string, tier: string): Promise<void>;
   SlashArgs(input: string): Promise<SlashArgsResult>;
   ListDir(rel: string): Promise<DirEntry[]>;
+  ListDirForTab(tabID: string, rel: string): Promise<DirEntry[]>;
   SearchFileRefs(query: string): Promise<DirEntry[]>;
+  SearchFileRefsForTab(tabID: string, query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
+  ReadFileForTab(tabID: string, rel: string): Promise<FilePreview>;
   WorkspaceChanges(tabID: string): Promise<WorkspaceChangesView>;
   GitBranches(): Promise<string[]>;
   GitCheckout(branch: string): Promise<void>;
   WorkspaceGitHistory(tabID: string, path: string): Promise<GitCommitView[]>;
   WorkspaceGitCommitDetail(tabID: string, hash: string, path: string): Promise<GitCommitDetailView>;
   OpenWorkspacePath(rel: string): Promise<void>;
+  OpenWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   RevealWorkspacePath(rel: string): Promise<void>;
+  RevealWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
   SavePastedImage(dataUrl: string): Promise<string>;
   SaveClipboardImage(): Promise<string>;
@@ -2817,11 +2822,17 @@ function makeMockApp(): AppBindings {
       }
       return [{ name: "file.go", isDir: false }];
     },
+    async ListDirForTab(_tabID: string, rel: string) {
+      return this.ListDir(rel);
+    },
     async SearchFileRefs(query: string) {
       const q = query.toLowerCase();
       return ["desktop/frontend/src/lib/bridge.ts", "frontend/wailsjs/runtime/runtime.js", "internal/control/refs.go"]
         .filter((path) => path.split("/").pop()?.toLowerCase().includes(q))
         .map((name) => ({ name, isDir: false }));
+    },
+    async SearchFileRefsForTab(_tabID: string, query: string) {
+      return this.SearchFileRefs(query);
     },
     async ReadFile(rel: string) {
       const samples: Record<string, string> = {
@@ -2837,6 +2848,9 @@ function makeMockApp(): AppBindings {
         truncated: false,
         binary: false,
       };
+    },
+    async ReadFileForTab(_tabID: string, rel: string) {
+      return this.ReadFile(rel);
     },
     async WorkspaceChanges(_tabID: string) {
       return {
@@ -2876,8 +2890,14 @@ function makeMockApp(): AppBindings {
     async OpenWorkspacePath(rel: string) {
       console.info("mock OpenWorkspacePath", rel);
     },
+    async OpenWorkspacePathForTab(_tabID: string, rel: string) {
+      await this.OpenWorkspacePath(rel);
+    },
     async RevealWorkspacePath(rel: string) {
       console.info("mock RevealWorkspacePath", rel);
+    },
+    async RevealWorkspacePathForTab(_tabID: string, rel: string) {
+      await this.RevealWorkspacePath(rel);
     },
     async RevealPath(path: string) {
       console.info("mock RevealPath", path);


### PR DESCRIPTION
## Summary

- make workspace directory, search, preview, open, and reveal operations explicitly tab-scoped
- pass the visible tab ID through the workspace panel, composer `@` picker, and plan-revision file picker
- invalidate tab-local file caches and ignore stale async responses after rapid tab switches and same-tab session rebuilds

## Root cause

The frontend renders optimistic tab metadata before the asynchronous backend `SetActiveTab` call finishes. Workspace file APIs previously resolved paths through the backend's global active tab, so a file-tree request issued during that activation window could read the previous tab's workspace. Once that stale result arrived, no later event forced the tree to reload.

This was especially visible when one workspace was nested inside another, as reported in [Discussion #6237](https://github.com/esengine/DeepSeek-Reasonix/discussions/6237).

## User impact

The workspace tree, file search, file preview, and file-to-chat actions now remain bound to the selected session even while backend activation is still in flight. Late responses from a previously selected workspace or an earlier same-tab session generation cannot overwrite the current workspace.

## Validation

- `cd desktop && go test ./...`
- `cd desktop && go test -race . -run 'TestFileRefs|TestBoundArrayPayloads' -count=1`
- `cd desktop/frontend && pnpm test:all`
- post-rebase TypeScript typecheck and focused workspace race tests

## Compatibility

| Contract | Previous behavior | Result |
| --- | --- | --- |
| Existing Wails file methods | Resolve against the active tab | Preserved as compatibility wrappers |
| New tab-scoped Wails methods | Not available | Additive methods; missing tabs return safe empty/error results |
| Persisted session/config data | Unchanged | No migration or data-format change |
| Array JSON payloads | Expected `[]`, never `null` | New list/search methods preserve non-nil arrays |

## Follow-up

The separate composer input-lock race from #5951/#6229 is addressed by the race-safe follow-up #6293; that controller change is not part of this merged PR.
