### PR TITLE
fix(cli): make --dir explicitly set workspace root instead of falling back to git-root detection

### DIFF
--- a/internal/boot/workspace_root_test.go
+++ b/internal/boot/workspace_root_test.go
@@ -1,0 +1,41 @@
+package boot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveWorkspaceRootExplicitAndGitFallback proves the --dir contract:
+// an explicit workspace root is honored even inside a git repository, while an
+// empty root still falls back to the nearest git root from the working directory.
+func TestResolveWorkspaceRootExplicitAndGitFallback(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit --dir pins the workspace root, not the git root of the repo.
+	if got := resolveWorkspaceRoot(sub); got != sub {
+		t.Fatalf("resolveWorkspaceRoot(%q) = %q, want the explicit dir", sub, got)
+	}
+
+	// No explicit root: fall back to the nearest git root from the CWD.
+	t.Chdir(sub)
+	got := resolveWorkspaceRoot("")
+	wantRoot, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolveWorkspaceRoot(%q) returned unusable path %q: %v", "", got, err)
+	}
+	if gotResolved != wantRoot {
+		t.Fatalf("resolveWorkspaceRoot(\"\") = %q, want git root %q", got, repo)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -283,6 +283,23 @@ func chdirTo(dir string) int {
 	return 0
 }
 
+// workspaceRootForDir returns the explicit project root to pin when --dir was
+// given. It runs after chdirTo has already switched into dir, so the process
+// working directory is the resolved root. An empty dir means no override (fall
+// back to git-root detection). A Getwd failure is returned rather than swallowed:
+// silently reverting to "" would re-trigger git-root/default resolution and break
+// the explicit --dir guarantee, so the caller must fail loudly instead.
+func workspaceRootForDir(dir string) (string, error) {
+	if dir == "" {
+		return "", nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve --dir workspace root: %w", err)
+	}
+	return wd, nil
+}
+
 func modelForResumePath(modelName, resumePath string, cfg *config.Config) string {
 	if strings.TrimSpace(modelName) != "" || strings.TrimSpace(resumePath) == "" {
 		return modelName
@@ -340,11 +357,10 @@ func runAgent(args []string) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
-	var workspaceRoot string
-	if *dir != "" {
-		if wd, err := os.Getwd(); err == nil {
-			workspaceRoot = wd
-		}
+	workspaceRoot, err := workspaceRootForDir(*dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 1
 	}
 	cfg, _ := config.Load()
 	configureCLIThemeFromConfigForTTYOutput()
@@ -673,11 +689,10 @@ func chatREPL(args []string) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
-	var workspaceRoot string
-	if *dir != "" {
-		if wd, err := os.Getwd(); err == nil {
-			workspaceRoot = wd
-		}
+	workspaceRoot, err := workspaceRootForDir(*dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 1
 	}
 	cfg, err := config.Load()
 	if err == nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -212,15 +212,18 @@ func configureCLIThemeFromConfigNoProbe() {
 // the agent's typed event stream — runAgent passes a TextSink that renders to
 // stdout, the TUI passes an event-channel sink so events become tea.Msgs.
 // profile selects economy|balanced|delivery (empty = balanced/full).
-func setupProfile(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string) (*control.Controller, error) {
+// workspaceRoot pins the project root explicitly (from --dir); empty falls back
+// to git-root detection.
+func setupProfile(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, workspaceRoot string) (*control.Controller, error) {
 	migrateMCPConfigForCLIWorkspace()
 	return boot.Build(ctx, boot.Options{
-		Model:      modelName,
-		MaxSteps:   maxStepsOverride,
-		RequireKey: requireKey,
-		Sink:       sink,
-		TokenMode:  profile,
-		SessionDir: resolveCLISessionDir(),
+		Model:         modelName,
+		MaxSteps:      maxStepsOverride,
+		RequireKey:    requireKey,
+		Sink:          sink,
+		TokenMode:     profile,
+		SessionDir:    resolveCLISessionDir(),
+		WorkspaceRoot: workspaceRoot,
 	})
 }
 
@@ -241,14 +244,15 @@ func resolveCLISessionDir() string {
 // setupQuietProfile is like setupProfile but suppresses plugin subprocess
 // stderr. Used during model switch inside a bubbletea session to prevent plugin
 // logs from corrupting the TUI's terminal raw mode.
-func setupQuietProfile(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string) (*control.Controller, error) {
+func setupQuietProfile(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, workspaceRoot string) (*control.Controller, error) {
 	return boot.Build(ctx, boot.Options{
-		Model:      modelName,
-		MaxSteps:   maxStepsOverride,
-		RequireKey: requireKey,
-		Sink:       sink,
-		Stderr:     io.Discard,
-		TokenMode:  profile,
+		Model:         modelName,
+		MaxSteps:      maxStepsOverride,
+		RequireKey:    requireKey,
+		Sink:          sink,
+		Stderr:        io.Discard,
+		TokenMode:     profile,
+		WorkspaceRoot: workspaceRoot,
 	})
 }
 
@@ -335,6 +339,12 @@ func runAgent(args []string) int {
 	}
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
+	}
+	var workspaceRoot string
+	if *dir != "" {
+		if wd, err := os.Getwd(); err == nil {
+			workspaceRoot = wd
+		}
 	}
 	cfg, _ := config.Load()
 	configureCLIThemeFromConfigForTTYOutput()
@@ -423,7 +433,7 @@ func runAgent(args []string) int {
 	if resumePath != "" {
 		*model = modelForResumePath(*model, resumePath, cfg)
 	}
-	ctrl, err := setupProfile(ctx, *model, *maxSteps, true, sink, profile)
+	ctrl, err := setupProfile(ctx, *model, *maxSteps, true, sink, profile, workspaceRoot)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
@@ -587,7 +597,7 @@ func runServe(args []string) int {
 			}
 		}
 	}
-	ctrl, err := setupProfile(ctx, *model, *maxSteps, true, bc, profile)
+	ctrl, err := setupProfile(ctx, *model, *maxSteps, true, bc, profile, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
@@ -663,6 +673,12 @@ func chatREPL(args []string) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
+	var workspaceRoot string
+	if *dir != "" {
+		if wd, err := os.Getwd(); err == nil {
+			workspaceRoot = wd
+		}
+	}
 	cfg, err := config.Load()
 	if err == nil {
 		configureCLIThemeWithStyle(cfg.UITheme(), cfg.UIThemeStyle())
@@ -729,7 +745,7 @@ func chatREPL(args []string) int {
 
 	var sink event.Sink = &eventSink{ch: eventCh}
 	sink = withNotifications(sink, cfg)
-	ctrl, err := setupProfile(ctx, *model, *maxSteps, false, sink, profile)
+	ctrl, err := setupProfile(ctx, *model, *maxSteps, false, sink, profile, workspaceRoot)
 	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
 		// True first run whose default model can't resolve: guide setup, then retry.
 		// With a config present, fall through to the descriptive error — re-running
@@ -738,7 +754,7 @@ func chatREPL(args []string) int {
 		if rc := interactiveSetup(defaultConfigTarget(), defaultEnvTarget()); rc != 0 {
 			return rc
 		}
-		ctrl, err = setupProfile(ctx, *model, *maxSteps, false, sink, profile)
+		ctrl, err = setupProfile(ctx, *model, *maxSteps, false, sink, profile, workspaceRoot)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -808,7 +824,7 @@ func chatREPL(args []string) int {
 	// runModelSubcommand performs the swap on the live copy. The same stable sink
 	// feeds the new controller, so events keep flowing to this TUI.
 	m.buildController = func(spec controllerBuildSpec, carry []provider.Message, resumePath string) (*control.Controller, error) {
-		c, err := setupQuietProfile(ctx, spec.ModelRef, *maxSteps, false, sink, spec.RuntimeProfile)
+		c, err := setupQuietProfile(ctx, spec.ModelRef, *maxSteps, false, sink, spec.RuntimeProfile, workspaceRoot)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/subagent.go
+++ b/internal/cli/subagent.go
@@ -19,8 +19,8 @@ import (
 	"reasonix/internal/skill"
 )
 
-var setupSubagentCommand = func(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink) (*control.Controller, error) {
-	return setupProfile(ctx, modelName, maxStepsOverride, requireKey, sink, "", "")
+var setupSubagentCommand = func(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, workspaceRoot string) (*control.Controller, error) {
+	return setupProfile(ctx, modelName, maxStepsOverride, requireKey, sink, "", workspaceRoot)
 }
 
 const subagentUsageText = `usage:
@@ -329,6 +329,11 @@ func subagentRunCommand(args []string, readOnly bool) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
+	workspaceRoot, err := workspaceRootForDir(*dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "subagent %s: %v\n", verb, err)
+		return 1
+	}
 	task := strings.TrimSpace(strings.Join(fs.Args(), " "))
 	if task == "" {
 		task = readStdin()
@@ -339,7 +344,7 @@ func subagentRunCommand(args []string, readOnly bool) int {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
-	ctrl, err := setupSubagentCommand(ctx, *model, *maxSteps, true, event.Discard)
+	ctrl, err := setupSubagentCommand(ctx, *model, *maxSteps, true, event.Discard, workspaceRoot)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "subagent %s: %v\n", verb, err)
 		return 1

--- a/internal/cli/subagent.go
+++ b/internal/cli/subagent.go
@@ -20,7 +20,7 @@ import (
 )
 
 var setupSubagentCommand = func(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink) (*control.Controller, error) {
-	return setupProfile(ctx, modelName, maxStepsOverride, requireKey, sink, "")
+	return setupProfile(ctx, modelName, maxStepsOverride, requireKey, sink, "", "")
 }
 
 const subagentUsageText = `usage:

--- a/internal/cli/subagent_test.go
+++ b/internal/cli/subagent_test.go
@@ -183,7 +183,7 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 
 	var normalCalls, readOnlyCalls int
 	var normalTask, tryTask string
-	setupSubagentCommand = func(context.Context, string, int, bool, event.Sink) (*control.Controller, error) {
+	setupSubagentCommand = func(context.Context, string, int, bool, event.Sink, string) (*control.Controller, error) {
 		return control.New(control.Options{
 			Skills: []skill.Skill{{Name: "helper", RunAs: skill.RunSubagent, Invocation: "manual", Scope: skill.ScopeGlobal}},
 			SkillRunner: func(_ context.Context, _ skill.Skill, task string, opts skill.SubagentRunOptions) (string, error) {
@@ -221,6 +221,67 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 	})
 	if strings.TrimSpace(out) != "try answer" || readOnlyCalls != 1 || tryTask != "inspect only" {
 		t.Fatalf("try output=%q readonly=%d task=%q", out, readOnlyCalls, tryTask)
+	}
+}
+
+// TestSubagentRunTryDirPinsExplicitWorkspaceRoot reproduces the reported gap:
+// a git repo at <repo>/.git with --dir pointing at a nested subdirectory must
+// pin that subdirectory as the workspace root, not widen it to the repo root
+// via git-root fallback. It drives the real chdirTo -> workspaceRootForDir ->
+// setupSubagentCommand plumbing, not just the helpers in isolation.
+func TestSubagentRunTryDirPinsExplicitWorkspaceRoot(t *testing.T) {
+	previous := setupSubagentCommand
+	t.Cleanup(func() { setupSubagentCommand = previous })
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotRoot string
+	setupSubagentCommand = func(_ context.Context, _ string, _ int, _ bool, _ event.Sink, workspaceRoot string) (*control.Controller, error) {
+		gotRoot = workspaceRoot
+		return control.New(control.Options{
+			Skills: []skill.Skill{{Name: "helper", RunAs: skill.RunSubagent, Invocation: "manual", Scope: skill.ScopeGlobal}},
+			SkillRunner: func(_ context.Context, _ skill.Skill, task string, opts skill.SubagentRunOptions) (string, error) {
+				return "run answer", nil
+			},
+			ReadOnlySkillRunner: func(_ context.Context, _ skill.Skill, task string, opts skill.SubagentRunOptions) (string, error) {
+				return "try answer", nil
+			},
+		}), nil
+	}
+
+	for _, verb := range []string{"run", "try"} {
+		gotRoot = ""
+		captureStdout(t, func() {
+			if rc := subagentCommand([]string{verb, "helper", "--dir", sub, "inspect"}); rc != 0 {
+				t.Fatalf("%s rc = %d", verb, rc)
+			}
+		})
+		want, err := filepath.EvalSymlinks(sub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := filepath.EvalSymlinks(gotRoot)
+		if err != nil {
+			t.Fatalf("subagent %s --dir: setup seam got unusable workspace root %q: %v", verb, gotRoot, err)
+		}
+		if got != want {
+			t.Fatalf("subagent %s --dir %s: setup seam workspace root = %q, want explicit dir %q (must not widen to repo root)", verb, sub, gotRoot, sub)
+		}
 	}
 }
 

--- a/internal/cli/subagent_test.go
+++ b/internal/cli/subagent_test.go
@@ -236,7 +236,6 @@ func TestSubagentRunTryDirPinsExplicitWorkspaceRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(origWD) })
 
 	repo := t.TempDir()
 	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
@@ -246,6 +245,10 @@ func TestSubagentRunTryDirPinsExplicitWorkspaceRoot(t *testing.T) {
 	if err := os.MkdirAll(sub, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
+	// Register the cwd restore after repo's t.TempDir() cleanup so it runs
+	// first (LIFO): on Windows, RemoveAll fails while cwd sits inside repo.
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
 	if err := os.Chdir(repo); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/workspace_root_test.go
+++ b/internal/cli/workspace_root_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"reasonix/internal/event"
 )
 
 // TestWorkspaceRootForDir covers the --dir plumbing: no --dir yields no override
@@ -32,5 +36,91 @@ func TestWorkspaceRootForDir(t *testing.T) {
 	}
 	if gotResolved != want {
 		t.Fatalf("workspaceRootForDir(%q) = %q, want cwd %q", dir, got, dir)
+	}
+}
+
+const minimalTestModelTOML = `
+default_model = "test-model"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`
+
+// TestSetupProfilePinsExplicitDirOverGitRoot drives the real chdirTo ->
+// workspaceRootForDir -> setupProfile -> boot.Build wiring shared by the
+// initial CLI controller (runAgent, chatREPL), not just the helpers in
+// isolation. An explicit --dir root inside a git repo must reach the built
+// controller unchanged; an empty --dir must still fall back to the nearest
+// git root. This proves the seam actually forwards the value end to end.
+func TestSetupProfilePinsExplicitDirOverGitRoot(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{repo, sub} {
+		if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(minimalTestModelTOML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit --dir: workspaceRootForDir pins sub; setupProfile must not widen
+	// it back to the repo's git root.
+	workspaceRoot, err := workspaceRootForDir(sub)
+	if err != nil {
+		t.Fatalf("workspaceRootForDir: %v", err)
+	}
+	ctrl, err := setupProfile(context.Background(), "", 0, false, event.Discard, "", workspaceRoot)
+	if err != nil {
+		t.Fatalf("setupProfile with explicit --dir: %v", err)
+	}
+	defer ctrl.Close()
+	wantSub, err := filepath.EvalSymlinks(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotSub, err := filepath.EvalSymlinks(ctrl.WorkspaceRoot())
+	if err != nil {
+		t.Fatalf("controller has unusable workspace root %q: %v", ctrl.WorkspaceRoot(), err)
+	}
+	if gotSub != wantSub {
+		t.Fatalf("setupProfile with --dir %s: controller workspace root = %q, want explicit dir (must not widen to repo root)", sub, ctrl.WorkspaceRoot())
+	}
+
+	// No --dir: still falls back to the nearest git root from the CWD (sub is
+	// still inside repo, which has the .git marker).
+	ctrlFallback, err := setupProfile(context.Background(), "", 0, false, event.Discard, "", "")
+	if err != nil {
+		t.Fatalf("setupProfile with no --dir: %v", err)
+	}
+	defer ctrlFallback.Close()
+	wantRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotRepo, err := filepath.EvalSymlinks(ctrlFallback.WorkspaceRoot())
+	if err != nil {
+		t.Fatalf("fallback controller has unusable workspace root %q: %v", ctrlFallback.WorkspaceRoot(), err)
+	}
+	if gotRepo != wantRepo {
+		t.Fatalf("setupProfile with no --dir: controller workspace root = %q, want git root %q", ctrlFallback.WorkspaceRoot(), repo)
 	}
 }

--- a/internal/cli/workspace_root_test.go
+++ b/internal/cli/workspace_root_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestWorkspaceRootForDir covers the --dir plumbing: no --dir yields no override
+// (empty, so boot falls back to git-root detection), while a --dir run returns
+// the post-chdir working directory as the explicit root. A Getwd failure surfaces
+// as an error rather than a silent empty fallback.
+func TestWorkspaceRootForDir(t *testing.T) {
+	// No --dir: no explicit override, no error.
+	if got, err := workspaceRootForDir(""); err != nil || got != "" {
+		t.Fatalf("workspaceRootForDir(\"\") = %q, %v; want \"\", nil", got, err)
+	}
+
+	// With --dir: chdirTo has already switched in, so the root is the CWD.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	got, err := workspaceRootForDir(dir)
+	if err != nil {
+		t.Fatalf("workspaceRootForDir: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("workspaceRootForDir returned unusable path %q: %v", got, err)
+	}
+	if gotResolved != want {
+		t.Fatalf("workspaceRootForDir(%q) = %q, want cwd %q", dir, got, dir)
+	}
+}


### PR DESCRIPTION
## 问题描述 / Problem

`reasonix --dir /a/b` 只做了 `os.Chdir(dir)` 切换工作目录，但 workspace root 仍被 git-root 搜索覆盖：`resolveWorkspaceRoot` 从 CWD 向上找最近的 `.git`，导致 workspace 始终是 `/a`（git 仓库根目录），而不是用户期望的 `/a/b`。

The `--dir` flag only changed the working directory (`os.Chdir`) but did **not** pass its value as the workspace root to `boot.Build`. `resolveWorkspaceRoot` still walks upward to find the nearest `.git`, so the workspace is always the git repo root.

## 改动说明 / Changes

### 1. `setup()` / `setupQuiet()` — 新增 `workspaceRoot` 参数
透传用户指定的 workspace root 到 `boot.Options.WorkspaceRoot`。

### 2. `runAgent()` / `chatREPL()` — 从 `--dir` 计算 workspaceRoot
`chdirTo(*dir)` 后用 `os.Getwd()` 获取绝对路径，传入 `setup()`。

### 3. `runServe()` — 补 `""` 参数
serve 模式无 `--dir`，传空字符串保持原行为。

### 4. `m.buildController` 闭包 — 补 `workspaceRoot` 参数
TUI 中 `/model` 切换模型时继承当前 session 的 workspace root。

### 5. `subagent run/try --dir` — 补 `workspaceRoot` 透传（review 修复）
`setupSubagentCommand` 之前固定传入空 `workspaceRoot`，`subagentRunCommand` 也没有像 `runAgent`/`chatREPL` 那样调用 `workspaceRootForDir(*dir)`。结果是 `subagent run/try --dir /a/b` 在 `/a/.git` 下仍会把 controller/工具边界回退到 `/a`，比用户指定目录更宽。现在按同一套 `chdirTo` → `workspaceRootForDir` → 显式传参模式修复，并对 `workspaceRootForDir` 的错误路径做同样的失败处理（不再静默回退到空字符串）。

## 效果 / Effect

| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| `reasonix`（无 --dir） | workspace = git root | ✅ 不变 |
| `reasonix --dir /a/b` | workspace = git root | ✅ workspace = /a/b |
| `/model` 切换模型 | workspace 可能跳回 | ✅ 保持一致 |
| `subagent run/try --dir /a/b`（`/a/.git` 下） | workspace = /a（git root，比预期宽） | ✅ workspace = /a/b |

## 验证 / Verification

- `go build ./...` ✅ 编译通过
- `go vet ./internal/cli/ ./internal/boot/` ✅ 无警告
- `gofmt -l . | grep -v '^desktop/'` ✅ 无输出
- `go test ./internal/cli ./internal/boot` ✅ 全部通过（含新增的 subagent --dir 显式 root 透传测试、初始 controller 显式 root 契约测试）
- `./scripts/cache-guard.sh` ✅ 通过

## Cache impact

Cache-impact: low - --dir (and now subagent run/try --dir) intentionally changes the "Current workspace" system-prompt line to the explicit directory instead of the git-root fallback; the value is computed once at boot/setup and stays stable for the whole session/turn, so it does not change tool schemas, tool ordering, or cache-prefix stability within a session.
Cache-guard: ran ./scripts/cache-guard.sh (TestReleaseCacheHitGuard, all cases pass, tail hit rates 92-95% >= 90% threshold) and go test ./internal/cli ./internal/boot (all pass).
System-prompt-review: Reviewed - the only prompt-visible effect is which path substitutes into the existing "Current workspace: <path>" line (explicit --dir vs. git-root fallback); no new prompt sections, no tool schema/order changes, and the value remains fixed for the session (including across /model rebuilds, which reuse the same captured workspaceRoot).
