### PR TITLE
Fix source-aware MCP removal / 修复 MCP 来源感知删除

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5659,6 +5659,7 @@ type ServerView struct {
 	AuthStatus           string     `json:"authStatus,omitempty"`
 	AuthURL              string     `json:"authUrl,omitempty"`
 	AuthConfigured       bool       `json:"authConfigured,omitempty"`
+	ManagedByPlugin      string     `json:"managedByPlugin,omitempty"`
 }
 
 type ToolView struct {
@@ -5771,11 +5772,15 @@ func (a *App) mcpServersView() []ServerView {
 	connected := map[string]bool{}
 	retainedDisabled := map[string]ServerView{}
 	configured := map[string]config.PluginEntry{}
+	managedByPlugin := map[string]string{}
 	var configuredEntries []config.PluginEntry
 	if cfg, err := config.LoadForRoot(workspaceRoot); err == nil {
 		configuredEntries = append(configuredEntries, cfg.Plugins...)
 		for _, p := range configuredEntries {
 			configured[p.Name] = p
+			if owner, ok := cfg.PluginPackageOwner(p.Name); ok {
+				managedByPlugin[p.Name] = owner
+			}
 		}
 	}
 	if h := ctrl.Host(); h != nil {
@@ -5859,6 +5864,9 @@ func (a *App) mcpServersView() []ServerView {
 		}
 	}
 	out = orderServerViews(out, order)
+	for i := range out {
+		out[i].ManagedByPlugin = managedByPlugin[out[i].Name]
+	}
 
 	a.mu.Lock()
 	if tab, ok := a.tabs[tabID]; ok {
@@ -6429,22 +6437,29 @@ func (a *App) RemoveMCPServer(name string) error {
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
-	disconnected := ctrl.DisconnectMCPServer(name)
+	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
+	if err != nil {
+		return err
+	}
+	if owner, ok := cfg.PluginPackageOwner(name); ok {
+		return fmt.Errorf("MCP server %q is managed by plugin %q; disable or remove the plugin instead", name, owner)
+	}
 	removed, err := a.removeDesktopMCPServer(name)
 	if err != nil {
 		return err
 	}
-	if disconnected || removed {
-		if h := ctrl.Host(); h != nil {
-			h.ClearFailure(name)
-		}
-		a.mu.Lock()
-		delete(tab.disabledMCP, name)
-		tab.mcpOrder = removeServerOrder(tab.mcpOrder, name)
-		a.mu.Unlock()
-		return nil
+	if !removed {
+		return fmt.Errorf("no removable MCP server named %q", name)
 	}
-	return fmt.Errorf("no MCP server named %q", name)
+	ctrl.DisconnectMCPServer(name)
+	if h := ctrl.Host(); h != nil {
+		h.ClearFailure(name)
+	}
+	a.mu.Lock()
+	delete(tab.disabledMCP, name)
+	tab.mcpOrder = removeServerOrder(tab.mcpOrder, name)
+	a.mu.Unlock()
+	return nil
 }
 
 // ReconnectMCPServer disconnects the server if it is already connected (to force
@@ -6757,33 +6772,7 @@ func (a *App) saveDesktopMCPServer(entry config.PluginEntry) error {
 }
 
 func (a *App) removeDesktopMCPServer(name string) (bool, error) {
-	removed := false
-	// Lock only the user-config load-modify-save; the project-scope removals
-	// below write project files, which this lock does not cover.
-	if err := func() error {
-		unlock := config.LockUserConfigEdits()
-		defer unlock()
-		cfg, path, err := a.loadDesktopUserConfigForEdit()
-		if err != nil {
-			return err
-		}
-		if cfg.RemovePlugin(name) {
-			removed = true
-			return cfg.SaveTo(path)
-		}
-		return nil
-	}(); err != nil {
-		return false, err
-	}
-	projectRemoved, err := a.removeProjectMCPOverride(name)
-	if err != nil {
-		return removed, err
-	}
-	mcpJSONRemoved, err := a.removeProjectMCPJSONServer(name)
-	if err != nil {
-		return removed || projectRemoved, err
-	}
-	return removed || projectRemoved || mcpJSONRemoved, nil
+	return config.RemovePluginFromSourcesForRoot(a.activeWorkspaceRoot(), name)
 }
 
 func (a *App) removeProjectMCPOverride(name string) (bool, error) {
@@ -6806,10 +6795,6 @@ func (a *App) removeProjectMCPOverride(name string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-func (a *App) removeProjectMCPJSONServer(name string) (bool, error) {
-	return config.RemoveMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), name)
 }
 
 func (a *App) desktopMCPServerOwnedByProjectMCPJSON(name string) bool {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6437,14 +6437,10 @@ func (a *App) RemoveMCPServer(name string) error {
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
 	}
-	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
-	if err != nil {
+	if err := ensureMCPServerDirectlyWritable(tab.WorkspaceRoot, name); err != nil {
 		return err
 	}
-	if owner, ok := cfg.PluginPackageOwner(name); ok {
-		return fmt.Errorf("MCP server %q is managed by plugin %q; disable or remove the plugin instead", name, owner)
-	}
-	removed, err := a.removeDesktopMCPServer(name)
+	removed, err := a.removeDesktopMCPServer(tab.WorkspaceRoot, name)
 	if err != nil {
 		return err
 	}
@@ -6502,12 +6498,15 @@ func (a *App) ReconnectMCPServer(name string) error {
 // clears the current session's cached connection failure. It does not remove the
 // server itself or try to sign the user out of the third-party browser session.
 func (a *App) ClearMCPServerAuthentication(name string) error {
-	ctrl := a.activeCtrl()
-	if ctrl == nil {
+	tab, ctrl := a.activeTabAndCtrl()
+	if tab == nil || ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
 	if controllerHasActiveRuntimeWork(ctrl) {
 		return rebuildControllerActiveWorkError("MCP server")
+	}
+	if err := ensureMCPServerDirectlyWritable(tab.WorkspaceRoot, name); err != nil {
+		return err
 	}
 	if _, _, _, err := config.ClearPluginAuthenticationInSource(name); err != nil {
 		return err
@@ -6747,8 +6746,12 @@ func (a *App) desktopMCPServerForEdit(name string) (config.PluginEntry, bool, er
 }
 
 func (a *App) saveDesktopMCPServer(entry config.PluginEntry) error {
-	if a.desktopMCPServerOwnedByProjectMCPJSON(entry.Name) {
-		_, err := config.UpsertMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), entry)
+	root := a.activeWorkspaceRoot()
+	if err := ensureMCPServerDirectlyWritable(root, entry.Name); err != nil {
+		return err
+	}
+	if a.desktopMCPServerOwnedByProjectMCPJSON(root, entry.Name) {
+		_, err := config.UpsertMCPJSONPlugin(projectMCPJSONPathForRoot(root), entry)
 		return err
 	}
 	// Lock only the user-config load-modify-save; the project-override cleanup
@@ -6767,16 +6770,27 @@ func (a *App) saveDesktopMCPServer(entry config.PluginEntry) error {
 	}(); err != nil {
 		return err
 	}
-	_, err := a.removeProjectMCPOverride(entry.Name)
+	_, err := a.removeProjectMCPOverride(root, entry.Name)
 	return err
 }
 
-func (a *App) removeDesktopMCPServer(name string) (bool, error) {
-	return config.RemovePluginFromSourcesForRoot(a.activeWorkspaceRoot(), name)
+func ensureMCPServerDirectlyWritable(root, name string) error {
+	cfg, err := config.LoadForRoot(root)
+	if err != nil {
+		return err
+	}
+	if owner, ok := cfg.PluginPackageOwner(name); ok {
+		return fmt.Errorf("MCP server %q is managed by plugin %q; disable or remove the plugin instead", name, owner)
+	}
+	return nil
 }
 
-func (a *App) removeProjectMCPOverride(name string) (bool, error) {
-	path := projectConfigPathForRoot(a.activeWorkspaceRoot())
+func (a *App) removeDesktopMCPServer(root, name string) (bool, error) {
+	return config.RemovePluginFromSourcesForRoot(root, name)
+}
+
+func (a *App) removeProjectMCPOverride(root, name string) (bool, error) {
+	path := projectConfigPathForRoot(root)
 	userPath := config.UserConfigPath()
 	if path == "" || sameConfigPath(path, userPath) {
 		return false, nil
@@ -6797,7 +6811,7 @@ func (a *App) removeProjectMCPOverride(name string) (bool, error) {
 	return true, nil
 }
 
-func (a *App) desktopMCPServerOwnedByProjectMCPJSON(name string) bool {
+func (a *App) desktopMCPServerOwnedByProjectMCPJSON(root, name string) bool {
 	if strings.TrimSpace(name) == "" {
 		return false
 	}
@@ -6809,11 +6823,11 @@ func (a *App) desktopMCPServerOwnedByProjectMCPJSON(name string) bool {
 			return false
 		}
 	}
-	projectCfg := config.LoadForEdit(projectConfigPathForRoot(a.activeWorkspaceRoot()))
+	projectCfg := config.LoadForEdit(projectConfigPathForRoot(root))
 	if _, ok := findPluginEntry(projectCfg.Plugins, name); ok {
 		return false
 	}
-	_, ok, err := config.LoadMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), name)
+	_, ok, err := config.LoadMCPJSONPlugin(projectMCPJSONPathForRoot(root), name)
 	return err == nil && ok
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6803,6 +6803,92 @@ func TestRemoveMCPServerDeletesProjectMCPJSONEntry(t *testing.T) {
 	}
 }
 
+func TestRemoveMCPServerRejectsPluginManagedServerWithoutDisconnecting(t *testing.T) {
+	home := isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	srv := desktopMCPHTTPServer(t)
+	defer srv.Close()
+	reasonixHome := filepath.Join(home, ".reasonix")
+	root := filepath.Join(reasonixHome, "plugins", "superpowers")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, pluginpkg.NativeManifest), []byte(fmt.Sprintf(`{
+  "name": "superpowers",
+  "version": "1.0.0",
+  "mcpServers": {
+    "helper": { "type": "http", "url": %q }
+  }
+}`, srv.URL)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := pluginpkg.Upsert(reasonixHome, pluginpkg.InstalledPlugin{
+		Name:         "superpowers",
+		Root:         "plugins/superpowers",
+		Version:      "1.0.0",
+		ManifestKind: "reasonix",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadForRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := findPluginEntry(cfg.Plugins, "helper")
+	if !ok {
+		t.Fatalf("plugin-managed MCP missing from config: %+v", cfg.Plugins)
+	}
+	ctrl := control.New(control.Options{Host: plugin.NewHost()})
+	defer ctrl.Close()
+	if _, err := ctrl.ConnectMCPServer(entry); err != nil {
+		t.Fatalf("connect plugin-managed MCP: %v", err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "")
+	app.activeTab().WorkspaceRoot = dir
+	err = app.RemoveMCPServer("helper")
+	if err == nil || !strings.Contains(err.Error(), "managed by plugin") || !strings.Contains(err.Error(), "superpowers") {
+		t.Fatalf("RemoveMCPServer(plugin-managed) error = %v", err)
+	}
+	if !mcpConnected(ctrl, "helper") {
+		t.Fatal("plugin-managed MCP was disconnected despite rejected removal")
+	}
+	servers := app.MCPServers()
+	if len(servers) != 1 || servers[0].Name != "helper" || servers[0].ManagedByPlugin != "superpowers" {
+		t.Fatalf("MCPServers() = %+v, want helper managed by superpowers", servers)
+	}
+}
+
+func TestRemoveMCPServerRejectsRuntimeOnlyServerWithoutDisconnecting(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	srv := desktopMCPHTTPServer(t)
+	defer srv.Close()
+	ctrl := control.New(control.Options{Host: plugin.NewHost()})
+	defer ctrl.Close()
+	if _, err := ctrl.ConnectMCPServer(config.PluginEntry{Name: "runtime-only", Type: "http", URL: srv.URL}); err != nil {
+		t.Fatalf("connect runtime-only MCP: %v", err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "")
+	app.activeTab().WorkspaceRoot = dir
+	err := app.RemoveMCPServer("runtime-only")
+	if err == nil || !strings.Contains(err.Error(), "no removable MCP server") {
+		t.Fatalf("RemoveMCPServer(runtime-only) error = %v", err)
+	}
+	if !mcpConnected(ctrl, "runtime-only") {
+		t.Fatal("runtime-only MCP was disconnected despite failed persistence removal")
+	}
+}
+
 func TestUpdateMCPServerEditsProjectMCPJSONEntry(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6858,6 +6858,18 @@ func TestRemoveMCPServerRejectsPluginManagedServerWithoutDisconnecting(t *testin
 	if !mcpConnected(ctrl, "helper") {
 		t.Fatal("plugin-managed MCP was disconnected despite rejected removal")
 	}
+	for action, actionErr := range map[string]error{
+		"trust tool": app.TrustMCPServerTool("helper", "echo"),
+		"clear auth": app.ClearMCPServerAuthentication("helper"),
+		"update":     app.UpdateMCPServer("helper", MCPServerInput{Name: "helper", Transport: "http", URL: srv.URL}),
+	} {
+		if actionErr == nil || !strings.Contains(actionErr.Error(), "managed by plugin") {
+			t.Fatalf("%s plugin-managed MCP error = %v", action, actionErr)
+		}
+	}
+	if _, found := findPluginEntry(config.LoadForEdit(config.UserConfigPath()).Plugins, "helper"); found {
+		t.Fatal("plugin-managed MCP mutation created a user-config shadow")
+	}
 	servers := app.MCPServers()
 	if len(servers) != 1 || servers[0].Name != "helper" || servers[0].ManagedByPlugin != "superpowers" {
 		t.Fatalf("MCPServers() = %+v, want helper managed by superpowers", servers)

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -245,6 +245,70 @@ console.log("capabilities panel MCP actions");
   dom.window.close();
 }
 
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const meta: Meta = { label: "test", ready: true, eventChannel: "managed-mcp-channel", cwd: "/tmp/reasonix-test", workspaceRoot: "/tmp/reasonix-test" };
+  const tabs: TabMeta[] = [{
+    id: "tab-managed-mcp",
+    scope: "project",
+    workspaceRoot: "/tmp/reasonix-test",
+    workspaceName: "reasonix-test",
+    topicId: "topic-managed-mcp",
+    topicTitle: "Managed MCP",
+    label: "Managed MCP",
+    ready: true,
+    running: false,
+    mode: "normal",
+    toolApprovalMode: "auto",
+    active: true,
+    cwd: "/tmp/reasonix-test",
+  }];
+  const servers: ServerView[] = [{
+    name: "helper",
+    transport: "http",
+    status: "connected",
+    configured: true,
+    managedByPlugin: "superpowers",
+    autoStart: true,
+    tools: 1,
+    prompts: 0,
+    resources: 0,
+  }];
+  window.go = {
+    main: {
+      App: {
+        Meta: async () => meta,
+        ListTabs: async () => tabs,
+        MCPServers: async () => servers,
+      } as Partial<AppBindings> as AppBindings,
+    },
+  };
+
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null, React.createElement(MCPServersSettingsPage)));
+    await flush();
+  });
+  await waitFor("plugin-managed MCP row", () => Boolean(document.querySelector(".cap-row__name")?.textContent?.includes("helper")));
+  ok(document.body.textContent?.includes("Managed by plugin superpowers") ?? false, "plugin-managed MCP identifies its owner");
+
+  const disclosure = document.querySelector<HTMLButtonElement>(".cap-disclosure");
+  if (!disclosure) throw new Error("missing plugin-managed MCP disclosure");
+  await act(async () => {
+    disclosure.click();
+    await flush();
+  });
+  ok(!findButton("Remove server"), "plugin-managed MCP hides the misleading remove action");
+  ok(!findButton("Edit config"), "plugin-managed MCP hides direct config editing");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log("capabilities panel plugin actions");
 
 {

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -272,10 +272,12 @@ console.log("capabilities panel MCP actions");
     status: "connected",
     configured: true,
     managedByPlugin: "superpowers",
+    authConfigured: true,
     autoStart: true,
     tools: 1,
     prompts: 0,
     resources: 0,
+    toolList: [{ name: "echo", description: "Echo input", readOnlyHint: true }],
   }];
   window.go = {
     main: {
@@ -302,6 +304,77 @@ console.log("capabilities panel MCP actions");
   });
   ok(!findButton("Remove server"), "plugin-managed MCP hides the misleading remove action");
   ok(!findButton("Edit config"), "plugin-managed MCP hides direct config editing");
+  ok(!findButton("Clear auth"), "plugin-managed MCP hides auth persistence actions");
+  ok(!findButton("Pre-trust read-only (1)"), "plugin-managed MCP hides bulk trust persistence actions");
+
+  const viewTools = findButton("View tools");
+  if (!viewTools) throw new Error("missing managed MCP View tools button");
+  await act(async () => {
+    viewTools.click();
+    await flush();
+  });
+  ok(!findButton("Pre-trust"), "plugin-managed MCP hides per-tool trust persistence actions");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const meta: Meta = { label: "test", ready: true, eventChannel: "runtime-mcp-channel", cwd: "/tmp/reasonix-test", workspaceRoot: "/tmp/reasonix-test" };
+  const tabs: TabMeta[] = [{
+    id: "tab-runtime-mcp",
+    scope: "project",
+    workspaceRoot: "/tmp/reasonix-test",
+    workspaceName: "reasonix-test",
+    topicId: "topic-runtime-mcp",
+    topicTitle: "Runtime MCP",
+    label: "Runtime MCP",
+    ready: true,
+    running: false,
+    mode: "normal",
+    toolApprovalMode: "auto",
+    active: true,
+    cwd: "/tmp/reasonix-test",
+  }];
+  const servers: ServerView[] = [{
+    name: "runtime-only",
+    transport: "stdio",
+    status: "failed",
+    configured: false,
+    autoStart: false,
+    tools: 0,
+    prompts: 0,
+    resources: 0,
+    error: "command not found",
+  }];
+  window.go = {
+    main: {
+      App: {
+        Meta: async () => meta,
+        ListTabs: async () => tabs,
+        MCPServers: async () => servers,
+      } as Partial<AppBindings> as AppBindings,
+    },
+  };
+
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null, React.createElement(MCPServersSettingsPage)));
+    await flush();
+  });
+  await waitFor("runtime-only failure details", () => Boolean(findButton("View details")));
+  const showDetails = findButton("View details");
+  if (!showDetails) throw new Error("missing runtime-only failure details button");
+  await act(async () => {
+    showDetails.click();
+    await flush();
+  });
+  ok(!findButton("Remove server"), "runtime-only MCP failure hides an action the backend cannot persist");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -820,7 +820,7 @@ function FailedServersNotice({
                 <button className="btn btn--small" onClick={() => onToggle(s.name)} aria-expanded={open}>
                   {open ? t("common.collapse") : t("caps.showLog")}
                 </button>
-                {!s.builtIn && (
+                {!s.builtIn && !s.managedByPlugin && (
                   <InlineConfirmButton
                     label={t("caps.remove")}
                     confirmLabel={t("caps.confirmRemove")}
@@ -905,6 +905,9 @@ function ServerRow({
           ? t("caps.disabledAutoStart")
           : t("caps.disabled")
         : t("caps.counts", { tools: s.tools, prompts: s.prompts, resources: s.resources });
+  if (s.managedByPlugin) {
+    sub = `${sub} · ${t("caps.managedByPlugin", { plugin: s.managedByPlugin })}`;
+  }
   if (s.authStatus === "possible" && s.status !== "failed") {
     sub = `${sub} · ${t("caps.authPossibleShort")}`;
   }
@@ -1019,7 +1022,7 @@ function ServerDetails({
 }) {
   const t = useT();
   const command = serverCommand(s);
-  const canEditConfig = s.configured && !s.builtIn;
+  const canEditConfig = s.configured && !s.builtIn && !s.managedByPlugin;
   const lifecycle = mcpServerLifecycleActions(s);
   const canConnectNow = lifecycle.canConnectNow;
   const canReconnect = lifecycle.canReconnect;
@@ -1401,7 +1404,7 @@ function failureGroupLabel(kind: FailureKind, count: number, t: ReturnType<typeo
 }
 
 function canBulkRemoveFailure(server: ServerView): boolean {
-  if (server.builtIn || !server.configured) return false;
+  if (server.builtIn || server.managedByPlugin || !server.configured) return false;
   const kind = failureKind(server);
   return kind === "missing-command" || kind === "command-unavailable";
 }

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -820,7 +820,7 @@ function FailedServersNotice({
                 <button className="btn btn--small" onClick={() => onToggle(s.name)} aria-expanded={open}>
                   {open ? t("common.collapse") : t("caps.showLog")}
                 </button>
-                {!s.builtIn && !s.managedByPlugin && (
+                {!s.builtIn && !s.managedByPlugin && s.configured && (
                   <InlineConfirmButton
                     label={t("caps.remove")}
                     confirmLabel={t("caps.confirmRemove")}
@@ -1022,16 +1022,17 @@ function ServerDetails({
 }) {
   const t = useT();
   const command = serverCommand(s);
-  const canEditConfig = s.configured && !s.builtIn && !s.managedByPlugin;
+  const canMutateConfig = s.configured && !s.builtIn && !s.managedByPlugin;
+  const canEditConfig = canMutateConfig;
   const lifecycle = mcpServerLifecycleActions(s);
   const canConnectNow = lifecycle.canConnectNow;
   const canReconnect = lifecycle.canReconnect;
   const canShowTools = s.status === "connected" && ((s.tools ?? 0) > 0 || (tools?.length ?? 0) > 0);
-  const showClearAuth = canClearAuth(s);
+  const showClearAuth = canMutateConfig && canClearAuth(s);
   const authLabel = serverAuthLabel(s, t);
   const trustedReadOnlyTools = s.trustedReadOnlyTools ?? [];
   const trustedReadOnlyToolNames = new Set(trustedReadOnlyTools);
-  const canTrustTool = s.configured && !s.builtIn;
+  const canTrustTool = canMutateConfig;
   const reportedReadOnlyToolNames = (tools ?? []).filter((tool) => tool.readOnlyHint).map((tool) => tool.name);
   const bulkTrustToolNames = reportedReadOnlyToolNames.filter((name) => !trustedReadOnlyToolNames.has(name));
   if (editing && canEditConfig) {
@@ -1439,7 +1440,7 @@ function shouldOpenAuth(s: ServerView): boolean {
 }
 
 function canClearAuth(s: ServerView): boolean {
-  if (!s.configured || s.builtIn) return false;
+  if (!s.configured || s.builtIn || s.managedByPlugin) return false;
   return Boolean(s.authConfigured || s.authStatus === "required" || s.authStatus === "possible" || isRemoteTransport(s.transport));
 }
 

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -679,6 +679,7 @@ export interface ServerView {
   authStatus?: "none" | "possible" | "required" | string;
   authUrl?: string;
   authConfigured?: boolean;
+  managedByPlugin?: string;
 }
 export interface MCPToolView {
   name: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -284,6 +284,7 @@ export const en = {
   "caps.reauthorize": "Reauthorize",
   "caps.checkCommand": "Check command",
   "caps.builtIn": "Built-in",
+  "caps.managedByPlugin": "Managed by plugin {plugin}",
   "caps.auth": "Auth",
   "caps.authRequired": "authorization required",
   "caps.authRequiredSummary": "This MCP server requires authorization before it can connect.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -200,6 +200,7 @@ export const zhTW: Record<DictKey, string> = {
   "caps.reauthorize": "重新授權",
   "caps.checkCommand": "檢查命令",
   "caps.builtIn": "內建",
+  "caps.managedByPlugin": "由外掛 {plugin} 管理",
   "caps.auth": "授權",
   "caps.authRequired": "需要授權",
   "caps.authRequiredSummary": "該 MCP 伺服器需要完成授權後才能連線。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -285,6 +285,7 @@ export const zh: Record<DictKey, string> = {
   "caps.reauthorize": "重新授权",
   "caps.checkCommand": "检查命令",
   "caps.builtIn": "内置",
+  "caps.managedByPlugin": "由插件 {plugin} 管理",
   "caps.auth": "授权",
   "caps.authRequired": "需要授权",
   "caps.authRequiredSummary": "该 MCP 服务器需要完成授权后才能连接。",

--- a/desktop/plugin_packages_app.go
+++ b/desktop/plugin_packages_app.go
@@ -156,8 +156,7 @@ func (a *App) RemovePlugin(name string) error {
 			if tab == nil || tab.Ctrl == nil {
 				return false
 			}
-			removed, _ := tab.Ctrl.RemoveMCPServer(serverName)
-			return removed
+			return tab.Ctrl.DisconnectMCPServer(serverName)
 		},
 	})
 	if _, err := tl.Execute(context.Background(), raw); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	providerSources          map[string]providerSourceScope
 	shadowedProjectProviders []ProviderEntry
 	expansionEnv             map[string]string
+	pluginPackageOwners      map[string]string
 }
 
 // SecretsConfig controls the credential protection layers. It is a user-global

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -810,6 +810,80 @@ func pluginTOMLSourcePath(name string) string {
 	return pluginTOMLSourcePathForRoot(".", name)
 }
 
+// RemovePluginFromSourcesForRoot removes an MCP server from every writable
+// config source that can contribute it for root. Removing all matching TOML
+// declarations prevents a lower-priority duplicate from reappearing after the
+// higher-priority entry is deleted; project .mcp.json is handled last.
+func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, fmt.Errorf("remove MCP server: name is required")
+	}
+
+	removeTOML := func(path string) (bool, error) {
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		cfg, err := loadForEditStrict(path, false)
+		if err != nil {
+			return false, err
+		}
+		if !cfg.RemovePlugin(name) {
+			return false, nil
+		}
+		if err := cfg.SaveTo(path); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	removed := false
+	userPaths := userConfigCandidatePaths()
+	unlock := LockUserConfigEdits()
+	for _, path := range userPaths {
+		changed, err := removeTOML(path)
+		if err != nil {
+			unlock()
+			return removed, err
+		}
+		removed = removed || changed
+	}
+	unlock()
+
+	resolvedRoot := resolveRoot(root)
+	projectTOML := "reasonix.toml"
+	if resolvedRoot != "." {
+		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
+	}
+	isUserPath := false
+	for _, path := range userPaths {
+		if samePath(path, projectTOML) {
+			isUserPath = true
+			break
+		}
+	}
+	if !isUserPath {
+		changed, err := removeTOML(projectTOML)
+		if err != nil {
+			return removed, err
+		}
+		removed = removed || changed
+	}
+
+	mcpPath := mcpJSONFile
+	if resolvedRoot != "." {
+		mcpPath = filepath.Join(resolvedRoot, mcpJSONFile)
+	}
+	changed, err := RemoveMCPJSONPlugin(mcpPath, name)
+	if err != nil {
+		return removed, err
+	}
+	return removed || changed, nil
+}
+
 // TrustPluginReadOnlyToolInSourceForRoot persists one trusted MCP read-only tool
 // into the file that owns the server for root. TOML declarations win over
 // .mcp.json, matching LoadForRoot merge precedence.

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -810,48 +812,197 @@ func pluginTOMLSourcePath(name string) string {
 	return pluginTOMLSourcePathForRoot(".", name)
 }
 
+type configSourceEdit struct {
+	path   string
+	before []byte
+	perm   os.FileMode
+	write  func() error
+}
+
+func newConfigSourceEdit(path string, write func() error) (configSourceEdit, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return configSourceEdit{}, err
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		return configSourceEdit{}, err
+	}
+	return configSourceEdit{path: path, before: before, perm: info.Mode().Perm(), write: write}, nil
+}
+
+func applyConfigSourceEdits(edits []configSourceEdit) error {
+	for i := range edits {
+		if err := edits[i].write(); err != nil {
+			var rollbackErrs []error
+			for j := i; j >= 0; j-- {
+				if rollbackErr := fileutil.AtomicWriteFile(edits[j].path, edits[j].before, edits[j].perm); rollbackErr != nil {
+					rollbackErrs = append(rollbackErrs, fmt.Errorf("restore %s: %w", edits[j].path, rollbackErr))
+				}
+			}
+			if rollbackErr := errors.Join(rollbackErrs...); rollbackErr != nil {
+				return errors.Join(err, fmt.Errorf("roll back MCP config removal: %w", rollbackErr))
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func planTOMLPluginRemoval(path, name string) (configSourceEdit, bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return configSourceEdit{}, false, nil
+		}
+		return configSourceEdit{}, false, err
+	}
+	cfg := Default()
+	if err := mergeFile(cfg, path); err != nil {
+		return configSourceEdit{}, false, err
+	}
+	normalizeConfigForEdit(cfg)
+	if !cfg.RemovePlugin(name) {
+		return configSourceEdit{}, false, nil
+	}
+	edit, err := newConfigSourceEdit(path, func() error { return cfg.SaveTo(path) })
+	return edit, err == nil, err
+}
+
+func planMCPJSONPluginRemoval(path, name string) (configSourceEdit, bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return configSourceEdit{}, false, nil
+		}
+		return configSourceEdit{}, false, err
+	}
+	root, servers, err := readMCPJSONRaw(path)
+	if err != nil {
+		return configSourceEdit{}, false, err
+	}
+	if _, ok := servers[name]; !ok {
+		return configSourceEdit{}, false, nil
+	}
+	delete(servers, name)
+	edit, err := newConfigSourceEdit(path, func() error { return writeMCPJSONServers(path, root, servers) })
+	return edit, err == nil, err
+}
+
+func planLegacyMCPDisable(path, name string) (configSourceEdit, bool, error) {
+	if strings.TrimSpace(path) == "" {
+		return configSourceEdit{}, false, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return configSourceEdit{}, false, nil
+		}
+		return configSourceEdit{}, false, err
+	}
+	data, err := fileencoding.ReadFileUTF8(path)
+	if err != nil {
+		return configSourceEdit{}, false, err
+	}
+	var root map[string]json.RawMessage
+	var view struct {
+		MCP         []string                   `json:"mcp"`
+		MCPServers  map[string]json.RawMessage `json:"mcpServers"`
+		MCPDisabled []string                   `json:"mcpDisabled"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return configSourceEdit{}, false, nil
+	}
+	if err := json.Unmarshal(data, &view); err != nil {
+		return configSourceEdit{}, false, nil
+	}
+
+	foundNamed := false
+	changed := false
+	filtered := make([]string, 0, len(view.MCP))
+	for i, raw := range view.MCP {
+		entry, ok := parseLegacyMCPSpec(raw)
+		if !ok {
+			filtered = append(filtered, raw)
+			continue
+		}
+		effectiveName := entry.Name
+		if effectiveName == "" {
+			effectiveName = anonymousMCPName(i)
+		}
+		if effectiveName != name {
+			filtered = append(filtered, raw)
+			continue
+		}
+		if entry.Name == "" {
+			changed = true
+			continue
+		}
+		foundNamed = true
+		filtered = append(filtered, raw)
+	}
+	if _, ok := view.MCPServers[name]; ok {
+		foundNamed = true
+	}
+	if foundNamed && !containsString(view.MCPDisabled, name) {
+		view.MCPDisabled = append(view.MCPDisabled, name)
+		changed = true
+	}
+	if !changed {
+		return configSourceEdit{}, false, nil
+	}
+	if len(filtered) != len(view.MCP) {
+		raw, marshalErr := json.Marshal(filtered)
+		if marshalErr != nil {
+			return configSourceEdit{}, false, marshalErr
+		}
+		root["mcp"] = raw
+	}
+	disabledRaw, err := json.Marshal(view.MCPDisabled)
+	if err != nil {
+		return configSourceEdit{}, false, err
+	}
+	root["mcpDisabled"] = disabledRaw
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return configSourceEdit{}, false, err
+	}
+	out = append(out, '\n')
+	edit, err := newConfigSourceEdit(path, func() error {
+		return fileutil.AtomicWriteFile(path, out, info.Mode().Perm())
+	})
+	return edit, err == nil, err
+}
+
 // RemovePluginFromSourcesForRoot removes an MCP server from every writable
 // config source that can contribute it for root. Removing all matching TOML
 // declarations prevents a lower-priority duplicate from reappearing after the
-// higher-priority entry is deleted; project .mcp.json is handled last.
+// higher-priority entry is deleted. Every edit is planned before the first write,
+// and legacy JSON receives a disable marker for older Reasonix versions.
 func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return false, fmt.Errorf("remove MCP server: name is required")
 	}
 
-	removeTOML := func(path string) (bool, error) {
-		if _, err := os.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		cfg, err := loadForEditStrict(path, false)
-		if err != nil {
-			return false, err
-		}
-		if !cfg.RemovePlugin(name) {
-			return false, nil
-		}
-		if err := cfg.SaveTo(path); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	removed := false
-	userPaths := userConfigCandidatePaths()
 	unlock := LockUserConfigEdits()
-	for _, path := range userPaths {
-		changed, err := removeTOML(path)
+	defer unlock()
+
+	var edits []configSourceEdit
+	planTOML := func(path string) error {
+		edit, changed, err := planTOMLPluginRemoval(path, name)
 		if err != nil {
-			unlock()
-			return removed, err
+			return err
 		}
-		removed = removed || changed
+		if changed {
+			edits = append(edits, edit)
+		}
+		return nil
 	}
-	unlock()
+	userPaths := userConfigCandidatePaths()
+	for _, path := range userPaths {
+		if err := planTOML(path); err != nil {
+			return false, err
+		}
+	}
 
 	resolvedRoot := resolveRoot(root)
 	projectTOML := "reasonix.toml"
@@ -866,22 +1017,36 @@ func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
 		}
 	}
 	if !isUserPath {
-		changed, err := removeTOML(projectTOML)
-		if err != nil {
-			return removed, err
+		if err := planTOML(projectTOML); err != nil {
+			return false, err
 		}
-		removed = removed || changed
 	}
 
 	mcpPath := mcpJSONFile
 	if resolvedRoot != "." {
 		mcpPath = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
-	changed, err := RemoveMCPJSONPlugin(mcpPath, name)
+	mcpEdit, changed, err := planMCPJSONPluginRemoval(mcpPath, name)
 	if err != nil {
-		return removed, err
+		return false, err
 	}
-	return removed || changed, nil
+	if changed {
+		edits = append(edits, mcpEdit)
+	}
+	legacyEdit, changed, err := planLegacyMCPDisable(legacyConfigPath(), name)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		edits = append(edits, legacyEdit)
+	}
+	if len(edits) == 0 {
+		return false, nil
+	}
+	if err := applyConfigSourceEdits(edits); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // TrustPluginReadOnlyToolInSourceForRoot persists one trusted MCP read-only tool

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -104,10 +104,13 @@ func LoadForRoot(root string) (*Config, error) {
 	}
 	cfg.mergeMCPJSON(entries)
 
-	// Lowest priority: the v0.x ~/.reasonix/config.json's mcpServers, so upgrading
-	// from the TypeScript line keeps MCP servers without rewriting them. Anything
-	// the v2 config or .mcp.json already declared wins on a name collision.
-	cfg.mergeMCPJSON(loadLegacyMCP(legacyConfigPath()))
+	// Lowest priority before the one-time v1.9.1 MCP migration: the v0.x
+	// ~/.reasonix/config.json's mcpServers. Once the migration marker exists, the
+	// current config is authoritative even when it is empty; reading the legacy
+	// source again would resurrect servers the user removed from current config.
+	if !mcpGlobalMigrationComplete() {
+		cfg.mergeMCPJSON(loadLegacyMCP(legacyConfigPath()))
+	}
 	_ = mergeInstalledPluginPackages(cfg, root)
 	normalizePluginCommandLines(cfg)
 	normalizeLegacyEffort(cfg)

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -685,3 +685,50 @@ func TestLoadLegacyMCP(t *testing.T) {
 		t.Errorf("empty path: got %+v, want nil", got)
 	}
 }
+
+func TestRemovePluginFromSourcesForRootRemovesEveryWritableDeclaration(t *testing.T) {
+	_, userConfig, _ := legacyHome(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(userConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{userConfig, filepath.Join(root, "reasonix.toml")} {
+		if err := os.WriteFile(path, []byte(`
+[[plugins]]
+name = "duplicate"
+command = "duplicate-mcp"
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mcpPath := filepath.Join(root, mcpJSONFile)
+	if err := os.WriteFile(mcpPath, []byte(`{
+  "mcpServers": {
+    "duplicate": { "command": "duplicate-json" },
+    "keep": { "command": "keep-json" }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := RemovePluginFromSourcesForRoot(root, "duplicate")
+	if err != nil {
+		t.Fatalf("RemovePluginFromSourcesForRoot: %v", err)
+	}
+	if !removed {
+		t.Fatal("RemovePluginFromSourcesForRoot reported no removal")
+	}
+	for _, path := range []string{userConfig, filepath.Join(root, "reasonix.toml")} {
+		for _, p := range LoadForEdit(path).Plugins {
+			if p.Name == "duplicate" {
+				t.Fatalf("duplicate MCP survived in %s: %+v", path, p)
+			}
+		}
+	}
+	if _, found, err := LoadMCPJSONPlugin(mcpPath, "duplicate"); err != nil || found {
+		t.Fatalf("duplicate .mcp.json entry survived: found=%v err=%v", found, err)
+	}
+	if _, found, err := LoadMCPJSONPlugin(mcpPath, "keep"); err != nil || !found {
+		t.Fatalf("unrelated .mcp.json entry was lost: found=%v err=%v", found, err)
+	}
+}

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -730,5 +731,69 @@ command = "duplicate-mcp"
 	}
 	if _, found, err := LoadMCPJSONPlugin(mcpPath, "keep"); err != nil || !found {
 		t.Fatalf("unrelated .mcp.json entry was lost: found=%v err=%v", found, err)
+	}
+}
+
+func TestRemovePluginFromSourcesForRootPreflightsEverySource(t *testing.T) {
+	_, userConfig, _ := legacyHome(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(userConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const original = `[[plugins]]
+name = "duplicate"
+command = "duplicate-mcp"
+`
+	if err := os.WriteFile(userConfig, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, mcpJSONFile), []byte(`{"mcpServers":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if removed, err := RemovePluginFromSourcesForRoot(root, "duplicate"); err == nil || removed {
+		t.Fatalf("RemovePluginFromSourcesForRoot = (%v, %v), want false and malformed .mcp.json error", removed, err)
+	}
+	got, err := os.ReadFile(userConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("user config changed before every source was validated:\n%s", got)
+	}
+}
+
+func TestApplyConfigSourceEditsRollsBackEarlierWrites(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.toml")
+	second := filepath.Join(dir, "second.toml")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("before\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstEdit, err := newConfigSourceEdit(first, func() error {
+		return os.WriteFile(first, []byte("after\n"), 0o600)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondEdit, err := newConfigSourceEdit(second, func() error {
+		return errors.New("publish failed")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applyConfigSourceEdits([]configSourceEdit{firstEdit, secondEdit}); err == nil {
+		t.Fatal("applyConfigSourceEdits unexpectedly succeeded")
+	}
+	for _, path := range []string{first, second} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "before\n" {
+			t.Fatalf("%s was not rolled back: %q", path, got)
+		}
 	}
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -274,6 +274,15 @@ func mcpGlobalMigrationMarkerPath() string {
 	return filepath.Join(dir, "mcp-global-migration-v1")
 }
 
+func mcpGlobalMigrationComplete() bool {
+	marker := mcpGlobalMigrationMarkerPath()
+	if marker == "" {
+		return false
+	}
+	_, err := os.Stat(marker)
+	return err == nil
+}
+
 func mcpMigrationLegacyTOMLPaths(dest, home string) []string {
 	var paths []string
 	for _, path := range legacyTOMLPaths(dest, home) {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -328,6 +328,50 @@ command = "late-bin"
 	}
 }
 
+func TestMCPMigrationMarkerMakesCurrentConfigAuthoritativeAfterRemoval(t *testing.T) {
+	src, dest, _ := legacyHome(t)
+	writeLegacy(t, src, `{
+		"mcpServers": {
+			"legacy-only": {"command": "legacy-mcp-bin"}
+		}
+	}`)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("config_version = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := MigrateMCPToUserConfigOnUpgrade(nil)
+	if err != nil {
+		t.Fatalf("MigrateMCPToUserConfigOnUpgrade: %v", err)
+	}
+	if res == nil || res.Added != 1 {
+		t.Fatalf("migration result = %+v, want one imported MCP", res)
+	}
+
+	cfg := LoadForEdit(dest)
+	if !cfg.RemovePlugin("legacy-only") {
+		t.Fatal("migrated MCP missing from current config")
+	}
+	if err := cfg.SaveTo(dest); err != nil {
+		t.Fatalf("save current config after removal: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load after removal: %v", err)
+	}
+	for _, p := range loaded.Plugins {
+		if p.Name == "legacy-only" {
+			t.Fatalf("removed MCP was resurrected from legacy config: %+v", loaded.Plugins)
+		}
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("legacy source should remain untouched: %v", err)
+	}
+}
+
 func TestMigrateMCPToUserConfigOnUpgradeDoesNotMarkEmptyScan(t *testing.T) {
 	_, _, _ = legacyHome(t)
 	res, err := MigrateMCPToUserConfigOnUpgrade(nil)

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -350,12 +350,12 @@ func TestMCPMigrationMarkerMakesCurrentConfigAuthoritativeAfterRemoval(t *testin
 		t.Fatalf("migration result = %+v, want one imported MCP", res)
 	}
 
-	cfg := LoadForEdit(dest)
-	if !cfg.RemovePlugin("legacy-only") {
-		t.Fatal("migrated MCP missing from current config")
+	removed, err := RemovePluginFromSourcesForRoot(t.TempDir(), "legacy-only")
+	if err != nil {
+		t.Fatalf("RemovePluginFromSourcesForRoot: %v", err)
 	}
-	if err := cfg.SaveTo(dest); err != nil {
-		t.Fatalf("save current config after removal: %v", err)
+	if !removed {
+		t.Fatal("RemovePluginFromSourcesForRoot reported no removal")
 	}
 
 	loaded, err := Load()
@@ -367,8 +367,15 @@ func TestMCPMigrationMarkerMakesCurrentConfigAuthoritativeAfterRemoval(t *testin
 			t.Fatalf("removed MCP was resurrected from legacy config: %+v", loaded.Plugins)
 		}
 	}
-	if _, err := os.Stat(src); err != nil {
-		t.Fatalf("legacy source should remain untouched: %v", err)
+	if got := loadLegacyMCP(src); len(got) != 0 {
+		t.Fatalf("an older runtime would resurrect the removed legacy MCP: %+v", got)
+	}
+	legacyRaw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read legacy source: %v", err)
+	}
+	if !strings.Contains(string(legacyRaw), `"legacy-only"`) || !strings.Contains(string(legacyRaw), `"mcpDisabled"`) {
+		t.Fatalf("legacy source should retain the server and add a compatibility disable marker:\n%s", legacyRaw)
 	}
 }
 

--- a/internal/config/plugin_packages.go
+++ b/internal/config/plugin_packages.go
@@ -52,9 +52,24 @@ func mergeInstalledPluginPackages(cfg *Config, root string) []string {
 				Tier:      srv.Tier,
 			}
 			cfg.Plugins = append(cfg.Plugins, entry)
+			if cfg.pluginPackageOwners == nil {
+				cfg.pluginPackageOwners = map[string]string{}
+			}
+			cfg.pluginPackageOwners[name] = item.Installed.Name
 		}
 	}
 	return warnings
+}
+
+// PluginPackageOwner reports the installed plugin package that contributed an
+// MCP server. Config-authored servers with the same name win during merge and
+// therefore have no package owner.
+func (cfg *Config) PluginPackageOwner(name string) (string, bool) {
+	if cfg == nil || len(cfg.pluginPackageOwners) == 0 {
+		return "", false
+	}
+	owner, ok := cfg.pluginPackageOwners[strings.TrimSpace(name)]
+	return owner, ok
 }
 
 func pluginPackageCommand(root, command string) string {

--- a/internal/config/plugin_packages.go
+++ b/internal/config/plugin_packages.go
@@ -64,11 +64,11 @@ func mergeInstalledPluginPackages(cfg *Config, root string) []string {
 // PluginPackageOwner reports the installed plugin package that contributed an
 // MCP server. Config-authored servers with the same name win during merge and
 // therefore have no package owner.
-func (cfg *Config) PluginPackageOwner(name string) (string, bool) {
-	if cfg == nil || len(cfg.pluginPackageOwners) == 0 {
+func (c *Config) PluginPackageOwner(name string) (string, bool) {
+	if c == nil || len(c.pluginPackageOwners) == 0 {
 		return "", false
 	}
-	owner, ok := cfg.pluginPackageOwners[strings.TrimSpace(name)]
+	owner, ok := c.pluginPackageOwners[strings.TrimSpace(name)]
 	return owner, ok
 }
 

--- a/internal/config/plugin_packages_test.go
+++ b/internal/config/plugin_packages_test.go
@@ -52,6 +52,9 @@ func TestLoadMergesInstalledPluginSkillRootsAndMCP(t *testing.T) {
 	if !found {
 		t.Fatalf("plugin MCP server missing: %#v", cfg.Plugins)
 	}
+	if owner, ok := cfg.PluginPackageOwner("helper"); !ok || owner != "superpowers" {
+		t.Fatalf("plugin MCP owner = %q, %v; want superpowers, true", owner, ok)
+	}
 }
 
 func writeConfigTestFile(t *testing.T, path, body string) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3877,28 +3877,28 @@ func (c *Controller) ConnectConfiguredMCPServer(name string) (int, error) {
 	return 0, fmt.Errorf("no configured MCP server named %q", name)
 }
 
-// RemoveMCPServer disconnects a live MCP server — its tools vanish from the next
-// turn — and removes it from the config file. It reports whether a live server was
-// disconnected; an error only when the name is neither connected nor in config (or
-// the config save fails). A server declared in .mcp.json disconnects for this
-// session but returns on the next start, since that file isn't ours to edit.
+// RemoveMCPServer removes a writable MCP configuration before disconnecting the
+// live server, so a persistence failure never produces a false-successful
+// session-only removal. MCPs contributed by an installed plugin package are
+// managed with that package and cannot be removed independently.
 func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error) {
-	disconnected = c.mcp.disconnect(name)
-	cfg, lerr := config.Load()
+	cfg, lerr := config.LoadForRoot(c.workspaceRoot)
 	if lerr != nil {
-		return disconnected, lerr
+		return false, lerr
 	}
-	inConfig := cfg.RemovePlugin(name)
-	if inConfig {
-		if !disconnected {
-			c.mcp.removeToolPrefix(name)
-		}
-		if serr := cfg.Save(); serr != nil {
-			return disconnected, serr
-		}
+	if owner, ok := cfg.PluginPackageOwner(name); ok {
+		return false, fmt.Errorf("MCP server %q is managed by plugin %q; disable or remove the plugin instead", name, owner)
 	}
-	if !disconnected && !inConfig {
-		return false, fmt.Errorf("no MCP server named %q", name)
+	removed, rerr := config.RemovePluginFromSourcesForRoot(c.workspaceRoot, name)
+	if rerr != nil {
+		return false, rerr
+	}
+	if !removed {
+		return false, fmt.Errorf("no removable MCP server named %q", name)
+	}
+	disconnected = c.mcp.disconnect(name)
+	if !disconnected {
+		c.mcp.removeToolPrefix(name)
 	}
 	return disconnected, nil
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/jobs"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
+	"reasonix/internal/pluginpkg"
 	"reasonix/internal/provider"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
@@ -2377,6 +2378,91 @@ tier = "lazy"
 	}
 	if names := c.ConfiguredMCPNames(); len(names) != 0 {
 		t.Fatalf("ConfiguredMCPNames() = %v, want empty after remove", names)
+	}
+}
+
+func TestRemoveMCPServerKeepsRuntimeOnlyToolsWhenPersistenceRemovalFails(t *testing.T) {
+	isolateControlConfigHome(t)
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__runtime_only__echo"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	if disconnected, err := c.RemoveMCPServer("runtime_only"); err == nil || disconnected || !strings.Contains(err.Error(), "no removable MCP server") {
+		t.Fatalf("RemoveMCPServer(runtime_only) = (%v, %v)", disconnected, err)
+	}
+	if _, found := reg.Get("mcp__runtime_only__echo"); !found {
+		t.Fatalf("runtime-only tool was removed despite failed persistence; names=%v", reg.Names())
+	}
+}
+
+func TestRemoveMCPServerRejectsPluginManagedTools(t *testing.T) {
+	home := isolateControlConfigHome(t)
+	reasonixHome := filepath.Join(home, ".reasonix")
+	root := filepath.Join(reasonixHome, "plugins", "superpowers")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, pluginpkg.NativeManifest), []byte(`{
+  "name": "superpowers",
+  "version": "1.0.0",
+  "mcpServers": {
+    "helper": { "command": "bin/helper" }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := pluginpkg.Upsert(reasonixHome, pluginpkg.InstalledPlugin{
+		Name:         "superpowers",
+		Root:         "plugins/superpowers",
+		Version:      "1.0.0",
+		ManifestKind: "reasonix",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__helper__echo"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+	disconnected, err := c.RemoveMCPServer("helper")
+	if err == nil || disconnected || !strings.Contains(err.Error(), "managed by plugin") || !strings.Contains(err.Error(), "superpowers") {
+		t.Fatalf("RemoveMCPServer(plugin-managed) = (%v, %v)", disconnected, err)
+	}
+	if _, found := reg.Get("mcp__helper__echo"); !found {
+		t.Fatalf("plugin-managed tool was removed despite rejected removal; names=%v", reg.Names())
+	}
+}
+
+func TestRemoveMCPServerDeletesProjectMCPJSONSource(t *testing.T) {
+	isolateControlConfigHome(t)
+	if err := os.WriteFile(".mcp.json", []byte(`{
+  "mcpServers": {
+    "mock": { "command": "mock-mcp" },
+    "keep": { "command": "keep-mcp" }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+	disconnected, err := c.RemoveMCPServer("mock")
+	if err != nil {
+		t.Fatalf("RemoveMCPServer(.mcp.json): %v", err)
+	}
+	if disconnected {
+		t.Fatal("RemoveMCPServer reported a live disconnect for an idle .mcp.json server")
+	}
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Fatalf(".mcp.json placeholder survived removal; names=%v", reg.Names())
+	}
+	raw, err := os.ReadFile(".mcp.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"mock"`) || !strings.Contains(string(raw), `"keep"`) {
+		t.Fatalf(".mcp.json removal did not preserve unrelated servers:\n%s", raw)
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2398,6 +2398,7 @@ func TestRemoveMCPServerKeepsRuntimeOnlyToolsWhenPersistenceRemovalFails(t *test
 func TestRemoveMCPServerRejectsPluginManagedTools(t *testing.T) {
 	home := isolateControlConfigHome(t)
 	reasonixHome := filepath.Join(home, ".reasonix")
+	t.Setenv("REASONIX_HOME", reasonixHome)
 	root := filepath.Join(reasonixHome, "plugins", "superpowers")
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
@@ -2430,6 +2431,12 @@ func TestRemoveMCPServerRejectsPluginManagedTools(t *testing.T) {
 	}
 	if _, found := reg.Get("mcp__helper__echo"); !found {
 		t.Fatalf("plugin-managed tool was removed despite rejected removal; names=%v", reg.Names())
+	}
+	if disconnected := c.DisconnectMCPServer("helper"); !disconnected {
+		t.Fatal("session-only disconnect should be allowed for a plugin-managed MCP")
+	}
+	if _, found := reg.Get("mcp__helper__echo"); found {
+		t.Fatalf("plugin-managed tool survived session-only disconnect; names=%v", reg.Names())
 	}
 }
 


### PR DESCRIPTION
## Summary

- make migrated current config authoritative and add a legacy `mcpDisabled` compatibility marker so older Reasonix versions cannot resurrect a removed server
- plan removals across user/project TOML, project `.mcp.json`, and legacy JSON before the first write, then roll back every committed source if a later write fails
- track installed-plugin ownership, reject direct persistent mutations of plugin-managed MCP servers, and surface ownership in the desktop UI
- preserve session-only disconnects for plugin uninstall and apply the persistence-first removal contract to both desktop and CLI/TUI paths

## Root cause

Runtime configuration merged legacy, plugin-package, TOML, and `.mcp.json` sources into one MCP list, while removal either wrote only the merged config or disconnected first. The live disconnect could therefore report success even though the owning source was unchanged, causing the server to return after restart. Multi-source removal also needed a transaction boundary: a later source failure must not leave earlier files partially edited.

Plugin-owned entries appeared directly mutable even though reinstall/reload would restore them, and plugin uninstall needs a runtime-only disconnect after package persistence has already been removed.

## User impact

Removed MCP servers now stay removed across restarts and across mixed old/new Reasonix clients. A malformed or unwritable later source cannot leave earlier configuration files partially deleted: committed edits are restored before the error is returned, and live tools remain connected. Plugin-managed servers identify their owner, reject direct persistent mutations, and still disconnect normally when their owning plugin is removed.

## Backward compatibility

| Surface | Behavior | Compatibility |
| --- | --- | --- |
| Legacy v0 MCP config | Before migration it is still imported. Removal preserves legacy entries and unknown JSON fields while adding the server name to `mcpDisabled`; anonymous legacy entries are removed from the legacy list because older readers cannot disable their synthesized names. | Safe for current and older Reasonix readers; prevents resurrection without dropping unrelated legacy data. |
| TOML and `.mcp.json` | Existing formats are unchanged. Every source is parsed before the first write; a later publish failure restores original bytes and permissions for already-touched files. | Failure-atomic across writable sources. |
| Plugin package state | Ownership remains in memory only. Persistent MCP edit/remove/auth/trust actions reject package-owned entries; session toggles and package uninstall still use runtime-only disconnects. | No persisted schema change. |
| Wails `ServerView` | Adds optional `managedByPlugin,omitempty`. Missing values retain existing frontend behavior. | Backward compatible. |
| Provider/tool schemas | No provider-visible tool names, schemas, descriptions, or ordering changed. | Cache-safe. |

## Cache impact

Cache-impact: none - the change affects MCP config persistence and desktop ownership metadata only; provider-visible prompts, tool names, schemas, descriptions, and ordering are unchanged.
Cache-guard: `./scripts/cache-guard.sh` passed all cases with tail averages 92–95 against the 90 threshold.
System-prompt-review: self-reviewed; no system prompt content or prompt assembly changed, and the `internal/config/config.go` change is in-memory MCP ownership metadata only.

## Validation

- `golangci-lint run --timeout=10m`
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `go test ./...` passed every package except load-sensitive Node hook subprocess cases that hit their 2-second timeout; `go test ./internal/hook -count=1` passed immediately in isolation
- `(cd desktop && go test ./...)`
- `go test -race ./internal/config ./internal/control`
- focused desktop race tests for MCP removal and persistent mutation paths
- frontend capability-action tests, production/test type-checks, CSS checks, and production build
- `./scripts/cache-guard.sh` (all cases passed; tail averages 92–95 against the 90 threshold)

Related: [discussion #6021](https://github.com/esengine/DeepSeek-Reasonix/discussions/6021).