### PR TITLE
# fix(desktop): make tab bar empty space draggable for window move / 使标签栏空白区域可拖拽窗口

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -18720,8 +18720,8 @@ body > .mermaid-diagram--fullscreen {
   transition: padding 0.28s cubic-bezier(0.2, 0.72, 0.2, 1);
 }
 
-.app--darwin .app-chrome--tabs .tabbar,
-.app--darwin .app-chrome--tabs .tabbar * {
+.app--darwin .app-chrome--tabs .tabbar__tab,
+.app--darwin .app-chrome--tabs .tabbar__new {
   --wails-draggable: no-drag;
 }
 
@@ -19038,10 +19038,10 @@ body > .mermaid-diagram--fullscreen {
   background: color-mix(in srgb, var(--bg-soft) 92%, var(--bg-elev));
 }
 
-.app--windows .app-chrome--native-tabs .tabbar,
-.app--linux .app-chrome--native-tabs .tabbar,
-.app--windows .app-chrome--native-tabs .tabbar *,
-.app--linux .app-chrome--native-tabs .tabbar * {
+.app--windows .app-chrome--native-tabs .tabbar__tab,
+.app--windows .app-chrome--native-tabs .tabbar__new,
+.app--linux .app-chrome--native-tabs .tabbar__tab,
+.app--linux .app-chrome--native-tabs .tabbar__new {
   --wails-draggable: no-drag;
 }
 


### PR DESCRIPTION
# fix(desktop): make tab bar empty space draggable for window move / 使标签栏空白区域可拖拽窗口

---

## 问题描述 / Problem
https://github.com/esengine/DeepSeek-Reasonix/issues/6251
**中文**：在 Windows/Linux/macOS 桌面端的"经典"模式（classic mode）下，顶栏标签区域无法通过鼠标拖拽来移动窗口。用户只能从顶栏最右侧（搜索按钮区域）拖拽窗口，左侧标签栏的空白区域（padding、标签间隙、新标签按钮周围）全部不可拖拽。

**English**: In classic mode of the desktop client on Windows/Linux/macOS, the tab bar area cannot be used to drag the window. Users can only drag from the rightmost area (around the search button), while the empty space in the tab bar (padding, gaps between tabs, area around the new-tab button) is entirely non-draggable.

---

## 根因分析 / Root Cause

**中文**：CSS 中使用了通配符选择器 `*` 将 `.tabbar` 的**所有子元素**设为 `--wails-draggable: no-drag`，导致标签栏的背景、padding 区域、flex 间隙等原本应继承 `drag` 的空间全部被覆盖为不可拖拽。

```css
/* 改动前 (Before) —— 通配符误伤全部子元素 */
.app--darwin .app-chrome--tabs .tabbar,
.app--darwin .app-chrome--tabs .tabbar * {
  --wails-draggable: no-drag;
}

.app--windows .app-chrome--native-tabs .tabbar,
.app--linux .app-chrome--native-tabs .tabbar,
.app--windows .app-chrome--native-tabs .tabbar *,
.app--linux .app-chrome--native-tabs .tabbar * {
  --wails-draggable: no-drag;
}
```

**English**: The wildcard selector `*` applied `--wails-draggable: no-drag` to **every descendant** of `.tabbar`, overriding the inherited `drag` from `.app-chrome` for all padding, gaps, and background areas.

---

## 改动 / Change

**中文**：将 `*` 通配符缩小为**只覆盖具体的交互元素**（`.tabbar__tab` 标签页、`.tabbar__new` 新标签按钮），使标签栏的背景区域自然继承父级 `.app-chrome` 的 `--wails-draggable: drag`。

```css
/* 改动后 (After) —— 仅交互元素设为 no-drag */
.app--darwin .app-chrome--tabs .tabbar__tab,
.app--darwin .app-chrome--tabs .tabbar__new {
  --wails-draggable: no-drag;
}

.app--windows .app-chrome--native-tabs .tabbar__tab,
.app--windows .app-chrome--native-tabs .tabbar__new,
.app--linux .app-chrome--native-tabs .tabbar__tab,
.app--linux .app-chrome--native-tabs .tabbar__new {
  --wails-draggable: no-drag;
}
```

**English**: Narrow the wildcard `*` to **specific interactive elements only** (`.tabbar__tab` for tabs, `.tabbar__new` for the new-tab button). The tab bar background areas inherit `--wails-draggable: drag` from `.app-chrome`.

**变更统计 / Diff**: `desktop/frontend/src/styles.css` — +6 / -6 lines (zero net change, selector replacement only)

---

## 效果 / Effect

**中文**：

| 区域 | 改动前 | 改动后 |
|------|--------|--------|
| 标签栏背景 / padding / flex 间隙 | ❌ 不可拖拽 | ✅ 可拖拽 |
| 新标签按钮 `[+]` 周围空间 | ❌ 不可拖拽 | ✅ 可拖拽 |
| 各标签页 `.tabbar__tab` 本身 | ❌ 不可拖拽（正常） | ✅ 不可拖拽（正常，可点击切换） |
| 新标签按钮 `.tabbar__new` | ❌ 不可拖拽（正常） | ✅ 不可拖拽（正常，可点击） |
| 搜索按钮 / 右面板按钮周边 | ✅ 可拖拽（未变） | ✅ 可拖拽（未变） |

**自适应行为**：可拖拽区域从最右侧标签页的右边沿延伸到搜索按钮的左边界。标签页增多时该区域自然缩短，减少时自然变长——无需额外逻辑。

**English**:

| Area | Before | After |
|------|--------|-------|
| Tab bar background / padding / flex gaps | ❌ Not draggable | ✅ Draggable |
| Space around new-tab button `[+]` | ❌ Not draggable | ✅ Draggable |
| Tab elements `.tabbar__tab` | ❌ Not draggable (correct) | ✅ Not draggable (correct, clickable) |
| New-tab button `.tabbar__new` | ❌ Not draggable (correct) | ✅ Not draggable (correct, clickable) |
| Search / right panel toggle area | ✅ Draggable (unchanged) | ✅ Draggable (unchanged) |

**Adaptive behavior**: The draggable zone spans from the right edge of the rightmost tab to the left edge of the search button. As tabs increase, this zone naturally shrinks; as tabs decrease, it grows — no extra logic needed.

---

## 平台覆盖 / Platform Coverage

**中文**：本次改动同时覆盖三个平台：

- **Windows**: `.app--windows .app-chrome--native-tabs`
- **Linux**: `.app--linux .app-chrome--native-tabs`
- **macOS**: `.app--darwin .app-chrome--tabs`

**English**: The fix covers all three platforms simultaneously.

---

## 验证 / Verification

- `wails build` — 编译通过 ✅
- 仅 CSS 选择器替换，零布局改变，零 JS 改动
- 所有按钮仍受 `.app-chrome button { --wails-draggable: no-drag }` 兜底保护
- windows desktop客户端本地编译成功，拖动正常，创建多标签页后拖动区域符合用户直觉，标签拖动调整顺序不受影响，顶部按钮功能均可正常触发，目前只有window物理机，其他的桌面端没测