### PR TITLE
Preserve continued recovery sessions / 保留已继续的恢复会话

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2136,7 +2136,8 @@ type SessionMeta struct {
 	UserID         string `json:"userId,omitempty"`
 	ThreadID       string `json:"threadId,omitempty"`
 	SessionSource  string `json:"sessionSource,omitempty"`
-	Recovered      bool   `json:"recovered,omitempty"` // conflict-recovery copy of another session
+	Recovered      bool   `json:"recovered,omitempty"`    // created by conflict recovery, including an adopted/continued branch
+	RecoveryCopy   bool   `json:"recoveryCopy,omitempty"` // proven unchanged since recovery and safe for copy cleanup
 }
 
 type channelSessionRoute struct {
@@ -2308,6 +2309,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, 
 		TopicID:        s.TopicID,
 		TopicTitle:     s.TopicTitle,
 		Recovered:      sessionInfoIsAutomaticRecovery(s),
+		RecoveryCopy:   sessionInfoIsUnmodifiedRecoveryCopy(s),
 	}
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2137,7 +2137,7 @@ type SessionMeta struct {
 	ThreadID       string `json:"threadId,omitempty"`
 	SessionSource  string `json:"sessionSource,omitempty"`
 	Recovered      bool   `json:"recovered,omitempty"`    // created by conflict recovery, including an adopted/continued branch
-	RecoveryCopy   bool   `json:"recoveryCopy,omitempty"` // proven unchanged since recovery and safe for copy cleanup
+	RecoveryCopy   bool   `json:"recoveryCopy,omitempty"` // actual branch content is unchanged and covered by its parent
 }
 
 type channelSessionRoute struct {
@@ -2232,7 +2232,7 @@ func (a *App) ListSessions() []SessionMeta {
 		if title == "" {
 			title = titles[filepath.Base(s.Path)]
 		}
-		meta := sessionMetaFromInfo(s, title, s.Path == active, isOpen, 0)
+		meta := sessionMetaFromInfo(s, title, s.Path == active, isOpen, 0, dir)
 		if route, ok := channelRoutes[sessionRuntimeKey(s.Path)]; ok {
 			applyChannelSessionRoute(&meta, route)
 		}
@@ -2261,7 +2261,7 @@ func (a *App) ListTrashedSessions() []SessionMeta {
 			if title == "" {
 				title = titles[filepath.Base(path)]
 			}
-			out = append(out, sessionMetaFromInfo(infos[0], title, false, false, deletedAt))
+			out = append(out, sessionMetaFromInfo(infos[0], title, false, false, deletedAt, dir))
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -2292,7 +2292,7 @@ func (a *App) sessionDirForPath(path string) (string, string, error) {
 	return "", "", fmt.Errorf("session path outside known session dirs: %s", path)
 }
 
-func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, deletedAt int64) SessionMeta {
+func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, deletedAt int64, parentDir string) SessionMeta {
 	return SessionMeta{
 		Path:           s.Path,
 		Preview:        s.Preview,
@@ -2309,7 +2309,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, 
 		TopicID:        s.TopicID,
 		TopicTitle:     s.TopicTitle,
 		Recovered:      sessionInfoIsAutomaticRecovery(s),
-		RecoveryCopy:   sessionInfoIsUnmodifiedRecoveryCopy(s),
+		RecoveryCopy:   sessionInfoIsUnmodifiedRecoveryCopy(s, parentDir),
 	}
 }
 
@@ -2412,10 +2412,19 @@ func channelDisplayName(provider, domain string) string {
 // has an in-process runtime, the runtime is cancelled and removed first so
 // autosave cannot recreate or append to the deleted file later.
 func (a *App) DeleteSession(path string) error {
-	return friendlySessionFileError(a.deleteSession(path))
+	return friendlySessionFileError(a.deleteSession(path, false))
 }
 
-func (a *App) deleteSession(path string) error {
+// DeleteRecoveryCopy is the guarded bulk-cleanup path. The frontend's copy
+// marker is only a hint; the backend re-reads the branch and parent immediately
+// before changing runtime state or moving any files.
+func (a *App) DeleteRecoveryCopy(path string) error {
+	return friendlySessionFileError(a.deleteSession(path, true))
+}
+
+var errRecoveryCopyNotRedundant = errors.New("recovery session contains content not preserved by its parent")
+
+func (a *App) deleteSession(path string, requireRedundantRecovery bool) error {
 	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
@@ -2432,6 +2441,9 @@ func (a *App) deleteSession(path string) error {
 	if err := func() error {
 		a.sessionRemovalMu.Lock()
 		defer a.sessionRemovalMu.Unlock()
+		if requireRedundantRecovery && !agent.RecoveryBranchCoveredByParent(sessionPath, dir) {
+			return errRecoveryCopyNotRedundant
+		}
 
 		removed, nextFallback := a.removeSessionRuntimeBindings(dir, sessionPath)
 		fallback = nextFallback
@@ -2959,13 +2971,24 @@ func (a *App) sessionOpen(dir, sessionPath string) bool {
 // PurgeTrashedSession permanently removes a trashed session and its title/display
 // sidecars.
 func (a *App) PurgeTrashedSession(path string) error {
-	return friendlySessionFileError(a.purgeTrashedSession(path))
+	return friendlySessionFileError(a.purgeTrashedSession(path, false))
 }
 
-func (a *App) purgeTrashedSession(path string) error {
+// PurgeRecoveryCopy is the guarded permanent-cleanup path. A trashed branch is
+// rechecked against its live parent; missing, stale, or divergent data is kept.
+func (a *App) PurgeRecoveryCopy(path string) error {
+	return friendlySessionFileError(a.purgeTrashedSession(path, true))
+}
+
+func (a *App) purgeTrashedSession(path string, requireRedundantRecovery bool) error {
 	dir, err := a.trashedSessionDir(path)
 	if err != nil {
 		return err
+	}
+	a.sessionRemovalMu.Lock()
+	defer a.sessionRemovalMu.Unlock()
+	if requireRedundantRecovery && !agent.RecoveryBranchCoveredByParent(path, dir) {
+		return errRecoveryCopyNotRedundant
 	}
 	if err := purgeTrashedSessionFile(dir, path); err != nil {
 		return err

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1839,6 +1839,9 @@ func removeDesktopSessionArtifacts(path string) error {
 		return err
 	}
 	defer guard.Release()
+	if err := invalidateTopicDirMarkers(filepath.Dir(path)); err != nil {
+		return err
+	}
 	defer invalidateTopicSessionIndexForPath(path)
 	for _, p := range sessionOwnedArtifactPaths(path) {
 		if strings.TrimSpace(p) == "" {
@@ -2987,8 +2990,20 @@ func (a *App) purgeTrashedSession(path string, requireRedundantRecovery bool) er
 	}
 	a.sessionRemovalMu.Lock()
 	defer a.sessionRemovalMu.Unlock()
-	if requireRedundantRecovery && !agent.RecoveryBranchCoveredByParent(path, dir) {
-		return errRecoveryCopyNotRedundant
+	var parentGuard *agent.SessionRemovalGuard
+	if requireRedundantRecovery {
+		parentGuard, err = agent.TryAcquireRecoveryParentGuard(path, dir)
+		if err != nil {
+			switch {
+			case errors.Is(err, agent.ErrRecoveryBranchNotCovered):
+				return errRecoveryCopyNotRedundant
+			case errors.Is(err, agent.ErrSessionLeaseHeld):
+				return errSessionBusyElsewhere
+			default:
+				return err
+			}
+		}
+		defer parentGuard.Release()
 	}
 	if err := purgeTrashedSessionFile(dir, path); err != nil {
 		return err

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2827,12 +2827,13 @@ export default function App() {
       const uniquePaths = Array.from(new Set(paths));
       for (const path of uniquePaths) {
         // Best effort per path: one locked/missing file must not abandon the
-        // rest of the sweep. The final refresh reconciles whatever happened.
-        await deleteSession(path).catch(() => undefined);
+        // rest of the sweep. The guarded backend method revalidates actual
+        // branch and parent content before moving anything.
+        await app.DeleteRecoveryCopy(path).catch(() => undefined);
       }
       await refreshHistoryView();
     },
-    [state.running, deleteSession, refreshHistoryView],
+    [state.running, refreshHistoryView],
   );
   const onRenameSession = useCallback(
     async (path: string, title: string) => {
@@ -2875,6 +2876,19 @@ export default function App() {
       setHistView((cur) => (cur === null ? null : { kind: "trash", sessions: trashed }));
     },
     [purgeTrashedSession, listTrashedSessions],
+  );
+  const onPurgeRecoveryCopies = useCallback(
+    async (paths: string[]) => {
+      const uniquePaths = Array.from(new Set(paths));
+      for (const path of uniquePaths) {
+        // Permanent copy cleanup must not trust the list result: the backend
+        // rechecks the trashed transcript and its live parent for every path.
+        await app.PurgeRecoveryCopy(path).catch(() => undefined);
+      }
+      const trashed = await listTrashedSessions();
+      setHistView((cur) => (cur === null ? null : { kind: "trash", sessions: trashed }));
+    },
+    [listTrashedSessions],
   );
 
   // Workspace: open the folder chooser and switch projects. The hook resets the
@@ -3816,6 +3830,7 @@ export default function App() {
             onRestore={onRestoreTrashedSession}
             onPurge={onPurgeTrashedSession}
             onPurgeAll={onPurgeAllTrashedSessions}
+            onPurgeRecoveryCopies={onPurgeRecoveryCopies}
             onDeleteMany={onDeleteManySessions}
             onClose={closeHistory}
           />

--- a/desktop/frontend/src/__tests__/history-recovery-copies.test.tsx
+++ b/desktop/frontend/src/__tests__/history-recovery-copies.test.tsx
@@ -133,9 +133,10 @@ console.log("\nhistory panel recovery-copy bulk actions");
     kind: "history",
     sessions: [
       session({ path: "/s/normal.jsonl" }),
-      session({ path: "/s/idle-recovery-0123456789abcdef.jsonl", recovered: true }),
-      session({ path: "/s/open-recovery-0123456789abcdef.jsonl", recovered: true, open: true }),
-      session({ path: "/s/current-recovery-0123456789abcdef.jsonl", recovered: true, current: true }),
+      session({ path: "/s/continued-recovery-0123456789abcdef.jsonl", title: "continued recovery kept", recovered: true }),
+      session({ path: "/s/idle-recovery-0123456789abcdef.jsonl", recovered: true, recoveryCopy: true }),
+      session({ path: "/s/open-recovery-0123456789abcdef.jsonl", recovered: true, recoveryCopy: true, open: true }),
+      session({ path: "/s/current-recovery-0123456789abcdef.jsonl", recovered: true, recoveryCopy: true, current: true }),
     ],
     onDeleteMany: (paths: string[]) => deleted.push(paths),
     onPurgeAll: (paths: string[]) => purged.push(paths),
@@ -150,6 +151,7 @@ console.log("\nhistory panel recovery-copy bulk actions");
     if (confirm) await click(confirm);
   }
   eq(deleted, [["/s/idle-recovery-0123456789abcdef.jsonl"]], "sweep trashes only idle recovery copies");
+  ok(document.body.textContent?.includes("continued recovery kept"), "continued recovery remains in normal history");
   eq(purged, [], "history sweep never purges");
 
   await act(async () => {
@@ -165,7 +167,7 @@ console.log("\nhistory panel recovery-copy bulk actions");
     kind: "history",
     sessions: [
       session({ path: "/s/normal.jsonl" }),
-      session({ path: "/s/current-recovery-0123456789abcdef.jsonl", recovered: true, current: true }),
+      session({ path: "/s/current-recovery-0123456789abcdef.jsonl", recovered: true, recoveryCopy: true, current: true }),
     ],
     onDeleteMany: () => {},
   });
@@ -184,8 +186,9 @@ console.log("\nhistory panel recovery-copy bulk actions");
     kind: "trash",
     sessions: [
       session({ path: "/t/normal.jsonl", deletedAt: now }),
-      session({ path: "/t/a-recovery-0123456789abcdef.jsonl", deletedAt: now, recovered: true }),
-      session({ path: "/t/b-recovery-0123456789abcdef.jsonl", deletedAt: now, recovered: true }),
+      session({ path: "/t/continued-recovery-0123456789abcdef.jsonl", deletedAt: now, recovered: true }),
+      session({ path: "/t/a-recovery-0123456789abcdef.jsonl", deletedAt: now, recovered: true, recoveryCopy: true }),
+      session({ path: "/t/b-recovery-0123456789abcdef.jsonl", deletedAt: now, recovered: true, recoveryCopy: true }),
     ],
     onRestore: () => {},
     onPurge: () => {},

--- a/desktop/frontend/src/__tests__/history-recovery-copies.test.tsx
+++ b/desktop/frontend/src/__tests__/history-recovery-copies.test.tsx
@@ -140,6 +140,7 @@ console.log("\nhistory panel recovery-copy bulk actions");
     ],
     onDeleteMany: (paths: string[]) => deleted.push(paths),
     onPurgeAll: (paths: string[]) => purged.push(paths),
+    onPurgeRecoveryCopies: (paths: string[]) => purged.push(paths),
   });
 
   const sweep = findButton("Trash recovery copies");
@@ -182,6 +183,7 @@ console.log("\nhistory panel recovery-copy bulk actions");
 {
   const dom = installDom();
   const purged: string[][] = [];
+  const emptied: string[][] = [];
   const root = await renderPanel({
     kind: "trash",
     sessions: [
@@ -192,7 +194,8 @@ console.log("\nhistory panel recovery-copy bulk actions");
     ],
     onRestore: () => {},
     onPurge: () => {},
-    onPurgeAll: (paths: string[]) => purged.push(paths),
+    onPurgeAll: (paths: string[]) => emptied.push(paths),
+    onPurgeRecoveryCopies: (paths: string[]) => purged.push(paths),
   });
 
   const clear = findButton("Clear copies");
@@ -208,6 +211,7 @@ console.log("\nhistory panel recovery-copy bulk actions");
     [["/t/a-recovery-0123456789abcdef.jsonl", "/t/b-recovery-0123456789abcdef.jsonl"]],
     "clear copies purges every trashed recovery copy and nothing else",
   );
+  eq(emptied, [], "clear copies does not invoke the unguarded empty-trash action");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -146,13 +146,13 @@ export function HistoryPanel({
       return [s.title, s.preview, s.path, s.topicTitle, s.workspaceRoot].some((part) => (part ?? "").toLowerCase().includes(q));
     });
   }, [dateFilter, isTrash, query, scopeFilter, sessions, statusFilter]);
-  // Recovery copies are bulk-actionable in both views: trash purges them for
-  // good, history sweeps them into the trash. The history sweep skips copies
-  // that are current or open in a tab — an adopted copy is someone's live
-  // conversation. Counting from `sessions` (not the filtered list) keeps the
-  // sweep exhaustive even while a search or filter is active.
+  // Only branches proven unchanged since recovery are bulk-actionable. A
+  // continued recovery branch keeps `recovered` provenance for its badge, but
+  // is normal user history and must never enter copy cleanup. Counting from
+  // `sessions` (not the filtered list) keeps the sweep exhaustive even while a
+  // search or filter is active.
   const recoveryCopyPaths = useMemo(
-    () => sessions.filter((s) => s.recovered && (isTrash || (!s.current && !s.open))).map((s) => s.path),
+    () => sessions.filter((s) => s.recoveryCopy && (isTrash || (!s.current && !s.open))).map((s) => s.path),
     [isTrash, sessions],
   );
   const recoveryCopyCount = recoveryCopyPaths.length;
@@ -160,19 +160,19 @@ export function HistoryPanel({
     () =>
       isTrash
         ? filteredSessions
-        : [...filteredSessions.filter((s) => !s.recovered), ...filteredSessions.filter((s) => s.recovered)],
+        : [...filteredSessions.filter((s) => !s.recoveryCopy), ...filteredSessions.filter((s) => s.recoveryCopy)],
     [filteredSessions, isTrash],
   );
 
   // Sessions arrive newest-first; bucket consecutive ones under a day heading
   // (Today / Yesterday / a date) while preserving that order.
-  const groups: { label: string; items: SessionMeta[]; recovered: boolean }[] = [];
+  const groups: { label: string; items: SessionMeta[]; recoveryCopy: boolean }[] = [];
   for (const s of displayedSessions) {
-    const recovered = !isTrash && Boolean(s.recovered);
+    const recoveryCopy = !isTrash && Boolean(s.recoveryCopy);
     const label = dayLabel(sessionTimeForGrouping(s, isTrash));
     const last = groups[groups.length - 1];
-    if (last && last.label === label && last.recovered === recovered) last.items.push(s);
-    else groups.push({ label, items: [s], recovered });
+    if (last && last.label === label && last.recoveryCopy === recoveryCopy) last.items.push(s);
+    else groups.push({ label, items: [s], recoveryCopy });
   }
 
   useEffect(() => {
@@ -493,9 +493,9 @@ export function HistoryPanel({
               <div className="mem-empty">{tr("history.noResults")}</div>
             ) : (
               groups.map((g) => (
-                <section className="mem-section" key={`${g.recovered ? "recovered" : "normal"}-${g.label}`}>
+                <section className="mem-section" key={`${g.recoveryCopy ? "recovery-copy" : "normal"}-${g.label}`}>
                   <div className="mem-section__title hist-group__title">
-                    <span>{g.recovered ? `${tr("history.recoveryCopiesGroup")} · ${g.label}` : g.label}</span>
+                    <span>{g.recoveryCopy ? `${tr("history.recoveryCopiesGroup")} · ${g.label}` : g.label}</span>
                     <span className="hist-group__count">{g.items.length}</span>
                   </div>
                   {g.items.map((s) => {

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -28,6 +28,7 @@ export function HistoryPanel({
   onRestore,
   onPurge,
   onPurgeAll,
+  onPurgeRecoveryCopies,
   onDeleteMany,
   onClose,
 }: {
@@ -41,6 +42,7 @@ export function HistoryPanel({
   onRestore?: (path: string) => void;
   onPurge?: (path: string) => void;
   onPurgeAll?: (paths: string[]) => void;
+  onPurgeRecoveryCopies?: (paths: string[]) => void;
   onDeleteMany?: (paths: string[]) => void;
   onClose: () => void;
 }) {
@@ -146,11 +148,11 @@ export function HistoryPanel({
       return [s.title, s.preview, s.path, s.topicTitle, s.workspaceRoot].some((part) => (part ?? "").toLowerCase().includes(q));
     });
   }, [dateFilter, isTrash, query, scopeFilter, sessions, statusFilter]);
-  // Only branches proven unchanged since recovery are bulk-actionable. A
-  // continued recovery branch keeps `recovered` provenance for its badge, but
-  // is normal user history and must never enter copy cleanup. Counting from
-  // `sessions` (not the filtered list) keeps the sweep exhaustive even while a
-  // search or filter is active.
+  // Only branches whose actual content is still the fork snapshot and remains
+  // covered by the parent are bulk-actionable. A unique recovery branch keeps
+  // `recovered` provenance for its badge, but is normal user history and must
+  // never enter copy cleanup. Counting from `sessions` (not the filtered list)
+  // keeps the sweep exhaustive even while a search or filter is active.
   const recoveryCopyPaths = useMemo(
     () => sessions.filter((s) => s.recoveryCopy && (isTrash || (!s.current && !s.open))).map((s) => s.path),
     [isTrash, sessions],
@@ -256,7 +258,7 @@ export function HistoryPanel({
   const clearRecoveryCopies = () => {
     const paths = recoveryCopyPaths;
     closeHistoryMenus();
-    if (isTrash) onPurgeAll?.(paths);
+    if (isTrash) onPurgeRecoveryCopies?.(paths);
     else onDeleteMany?.(paths);
   };
   const sessionMenuItems: ContextMenuItem[] = menuSession

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1017,7 +1017,7 @@ function makeMockApp(): AppBindings {
   // Mutable so delete/rename are observable in browser dev.
   const sessions: SessionMeta[] = [
     { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, createdAt: t0 - 2 * day, lastActivityAt: t0 - 3_600_000, modTime: t0 - 3_600_000, current: true, open: true },
-    { path: "/mock/sessions/b-recovery-0123456789abcdef.jsonl", preview: "refactor the payment module", turns: 5, createdAt: t0 - 3 * day, lastActivityAt: t0 - 6 * 3_600_000, modTime: t0 - 6 * 3_600_000, current: false, open: true, recovered: true },
+    { path: "/mock/sessions/b-recovery-0123456789abcdef.jsonl", preview: "refactor the payment module", turns: 5, createdAt: t0 - 3 * day, lastActivityAt: t0 - 6 * 3_600_000, modTime: t0 - 6 * 3_600_000, current: false, open: true, recovered: true, recoveryCopy: true },
     { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, createdAt: t0 - 4 * day, lastActivityAt: t0 - day - 3_600_000, modTime: t0 - day - 3_600_000, current: false, open: false },
     { path: "/mock/sessions/d.jsonl", preview: "explain the plugin host design", turns: 3, createdAt: t0 - 5 * day, lastActivityAt: t0 - 4 * day, modTime: t0 - 4 * day, current: false, open: false },
   ];
@@ -1069,6 +1069,7 @@ function makeMockApp(): AppBindings {
       topicId: "topic_product",
       topicTitle: t("mock.trashGlobalProductTitle"),
       recovered: true,
+      recoveryCopy: true,
     },
   ];
   if (freshMock) {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -185,8 +185,10 @@ export interface AppBindings {
   OpenChannelSessionPageForTab(tabID: string, path: string, limit: number): Promise<HistoryPage>;
   PreviewSession(path: string): Promise<HistoryMessage[]>;
   DeleteSession(path: string): Promise<void>;
+  DeleteRecoveryCopy(path: string): Promise<void>;
   RestoreSession(path: string): Promise<void>;
   PurgeTrashedSession(path: string): Promise<void>;
+  PurgeRecoveryCopy(path: string): Promise<void>;
   RenameSession(path: string, title: string): Promise<void>;
   ScanPromptHistory(nonce: string): Promise<PromptHistoryResult>;
   ListWorkspaces(): Promise<WorkspaceView[]>;
@@ -2323,6 +2325,9 @@ function makeMockApp(): AppBindings {
         });
       }
     },
+    async DeleteRecoveryCopy(path: string) {
+      return this.DeleteSession(path);
+    },
     async RestoreSession(path: string) {
       const i = trashedSessions.findIndex((s) => s.path === path);
       if (i >= 0) {
@@ -2337,6 +2342,9 @@ function makeMockApp(): AppBindings {
     async PurgeTrashedSession(path: string) {
       const i = trashedSessions.findIndex((s) => s.path === path);
       if (i >= 0) trashedSessions.splice(i, 1);
+    },
+    async PurgeRecoveryCopy(path: string) {
+      return this.PurgeTrashedSession(path);
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -416,7 +416,8 @@ export interface SessionMeta {
   userId?: string;
   threadId?: string;
   sessionSource?: string;
-  recovered?: boolean; // conflict-recovery copy of another session
+  recovered?: boolean; // created by conflict recovery, including a continued branch
+  recoveryCopy?: boolean; // unchanged since recovery and safe for copy cleanup
 }
 
 // SessionReference is a session selected via @ past:chats for context injection.

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -417,7 +417,7 @@ export interface SessionMeta {
   threadId?: string;
   sessionSource?: string;
   recovered?: boolean; // created by conflict recovery, including a continued branch
-  recoveryCopy?: boolean; // unchanged since recovery and safe for copy cleanup
+  recoveryCopy?: boolean; // actual branch content is unchanged and covered by its parent
 }
 
 // SessionReference is a session selected via @ past:chats for context injection.

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ func saveSnapshotTurns(t *testing.T, path string, turns int) *agent.Session {
 func TestMergeSessionInfosCountsRecoveryActivity(t *testing.T) {
 	summaries := map[string]topicSummary{}
 	now := time.Now()
+	digest := strings.Repeat("a", 64)
 	infos := []agent.SessionInfo{
 		{
 			Path:           "/tmp/original.jsonl",
@@ -43,6 +45,8 @@ func TestMergeSessionInfosCountsRecoveryActivity(t *testing.T) {
 			Scope:          "global",
 			TopicID:        "topic-1",
 			Recovered:      true,
+			RecoveryDigest: digest,
+			ContentDigest:  digest,
 		},
 	}
 	mergeSessionInfos("/tmp", infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
@@ -60,6 +64,75 @@ func TestMergeSessionInfosCountsRecoveryActivity(t *testing.T) {
 	}
 }
 
+func TestMergeSessionInfosKeepsContinuedRecoveryVisible(t *testing.T) {
+	summaries := map[string]topicSummary{}
+	now := time.Now()
+	infos := []agent.SessionInfo{{
+		Path:           "/tmp/original-recovery-0123456789abcdef.jsonl",
+		Turns:          5,
+		LastActivityAt: now,
+		Scope:          "global",
+		TopicID:        "topic-continued",
+		Recovered:      true,
+		RecoveryDigest: "before-save",
+		ContentDigest:  "after-save",
+	}}
+
+	mergeSessionInfos("/tmp", infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
+	summary := summaries[topicSummaryKey("global", "", "topic-continued")]
+	if !summary.hasAdoptedRecovery || summary.hasRecoveryOnly {
+		t.Fatalf("summary flags = %+v, want adopted recovery only", summary)
+	}
+	if topicHiddenAsRecoveryOnly(summary, false, nil) {
+		t.Fatal("continued recovery was hidden after its tab closed")
+	}
+	if got := summary.displayTurns(); got != 5 {
+		t.Fatalf("display turns = %d, want 5", got)
+	}
+}
+
+func TestRecoveryCopyRequiresMatchingNonEmptyDigests(t *testing.T) {
+	validA := strings.Repeat("a", 64)
+	validB := strings.Repeat("b", 64)
+	cases := []struct {
+		name     string
+		recovery string
+		content  string
+		want     bool
+	}{
+		{name: "unchanged", recovery: validA, content: validA, want: true},
+		{name: "continued", recovery: validA, content: validB, want: false},
+		{name: "malformed", recovery: "same", content: "same", want: false},
+		{name: "missing content digest", recovery: validA, want: false},
+		{name: "missing recovery digest", content: validA, want: false},
+	}
+	for _, tc := range cases {
+		if got := recoveryDigestsIdentifyUnmodifiedCopy(tc.recovery, tc.content); got != tc.want {
+			t.Errorf("%s: unmodified = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSessionMetaSeparatesRecoveryProvenanceFromCleanupCopy(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	info := agent.SessionInfo{
+		Path:           "/tmp/session-recovery-0123456789abcdef.jsonl",
+		Recovered:      true,
+		RecoveryDigest: digest,
+		ContentDigest:  digest,
+	}
+	meta := sessionMetaFromInfo(info, "", false, false, 0)
+	if !meta.Recovered || !meta.RecoveryCopy {
+		t.Fatalf("unchanged recovery meta = %+v, want provenance and cleanup-copy flags", meta)
+	}
+
+	info.ContentDigest = strings.Repeat("b", 64)
+	meta = sessionMetaFromInfo(info, "", false, false, 0)
+	if !meta.Recovered || meta.RecoveryCopy {
+		t.Fatalf("continued recovery meta = %+v, want provenance without cleanup-copy flag", meta)
+	}
+}
+
 func TestTopicHiddenAsRecoveryOnly(t *testing.T) {
 	recoveryOnly := topicSummary{hasRecoveryOnly: true}
 	cases := []struct {
@@ -71,6 +144,7 @@ func TestTopicHiddenAsRecoveryOnly(t *testing.T) {
 	}{
 		{"recovery-only idle", recoveryOnly, false, nil, true},
 		{"normal session present", topicSummary{hasRecoveryOnly: true, hasNormalSession: true}, false, nil, false},
+		{"continued recovery present", topicSummary{hasRecoveryOnly: true, hasAdoptedRecovery: true}, false, nil, false},
 		{"pinned stays visible", recoveryOnly, true, nil, false},
 		{"single open runtime", recoveryOnly, false, []runtimeSessionStatus{{open: true}}, false},
 		// topicRuntimeStatus reports open/running only for single-session

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -179,6 +179,19 @@ func TestRecoveryCopyCleanupRevalidatesInBackend(t *testing.T) {
 		t.Fatalf("rejected trashed recovery branch was not preserved: %v", err)
 	}
 	coverDesktopRecoveryParent(t, purgeParent, purgeMsgs)
+	parentLease, err := agent.TryAcquireSessionLease(purgeParent)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease parent: %v", err)
+	}
+	if err := app.PurgeRecoveryCopy(purgeTrashPath); !errors.Is(err, errSessionBusyElsewhere) {
+		parentLease.Release()
+		t.Fatalf("PurgeRecoveryCopy while parent is live err = %v, want errSessionBusyElsewhere", err)
+	}
+	if _, err := os.Stat(purgeTrashPath); err != nil {
+		parentLease.Release()
+		t.Fatalf("busy-parent purge did not preserve recovery branch: %v", err)
+	}
+	parentLease.Release()
 	if err := app.PurgeRecoveryCopy(purgeTrashPath); err != nil {
 		t.Fatalf("PurgeRecoveryCopy covered branch: %v", err)
 	}

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/provider"
 	"reasonix/internal/store"
 )
@@ -26,30 +26,61 @@ func saveSnapshotTurns(t *testing.T, path string, turns int) *agent.Session {
 	return s
 }
 
+func forkDesktopRecoveryBranch(t *testing.T, dir, name string) (parentPath, branchPath string, branchMsgs []provider.Message) {
+	t.Helper()
+	parentPath = filepath.Join(dir, name+".jsonl")
+	parent := agent.NewSession("sys")
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	parent.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "disk " + name})
+	if err := parent.Save(parentPath); err != nil {
+		t.Fatalf("Save recovery parent: %v", err)
+	}
+	branch := agent.NewSession("sys")
+	branch.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	branch.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	branch.Add(provider.Message{Role: provider.RoleUser, Content: "local " + name})
+	info, err := branch.SaveRecoveryBranch(agent.RecoveryBranchOptions{OriginalPath: parentPath})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	return parentPath, info.Path, branch.Snapshot()
+}
+
+func coverDesktopRecoveryParent(t *testing.T, parentPath string, branchMsgs []provider.Message) {
+	t.Helper()
+	parent := agent.NewSession("")
+	parent.Messages = append([]provider.Message(nil), branchMsgs...)
+	parent.Add(provider.Message{Role: provider.RoleAssistant, Content: "parent kept the recovery content"})
+	if err := parent.Save(parentPath); err != nil {
+		t.Fatalf("Save covering recovery parent: %v", err)
+	}
+}
+
 func TestMergeSessionInfosCountsRecoveryActivity(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, branchPath, branchMsgs := forkDesktopRecoveryBranch(t, dir, "covered")
+	coverDesktopRecoveryParent(t, parentPath, branchMsgs)
 	summaries := map[string]topicSummary{}
 	now := time.Now()
-	digest := strings.Repeat("a", 64)
 	infos := []agent.SessionInfo{
 		{
-			Path:           "/tmp/original.jsonl",
+			Path:           parentPath,
 			Turns:          3,
 			LastActivityAt: now.Add(-time.Hour),
 			Scope:          "global",
 			TopicID:        "topic-1",
 		},
 		{
-			Path:           "/tmp/original-recovery-abc.jsonl",
+			Path:           branchPath,
 			Turns:          5,
 			LastActivityAt: now,
 			Scope:          "global",
 			TopicID:        "topic-1",
 			Recovered:      true,
-			RecoveryDigest: digest,
-			ContentDigest:  digest,
 		},
 	}
-	mergeSessionInfos("/tmp", infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
+	mergeSessionInfos(dir, infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
 	summary := summaries[topicSummaryKey("global", "", "topic-1")]
 	if !summary.hasNormalSession || !summary.hasRecoveryOnly {
 		t.Fatalf("summary flags = %+v, want both normal and recovery seen", summary)
@@ -65,20 +96,20 @@ func TestMergeSessionInfosCountsRecoveryActivity(t *testing.T) {
 }
 
 func TestMergeSessionInfosKeepsContinuedRecoveryVisible(t *testing.T) {
+	dir := t.TempDir()
+	_, branchPath, _ := forkDesktopRecoveryBranch(t, dir, "diverged")
 	summaries := map[string]topicSummary{}
 	now := time.Now()
 	infos := []agent.SessionInfo{{
-		Path:           "/tmp/original-recovery-0123456789abcdef.jsonl",
+		Path:           branchPath,
 		Turns:          5,
 		LastActivityAt: now,
 		Scope:          "global",
 		TopicID:        "topic-continued",
 		Recovered:      true,
-		RecoveryDigest: "before-save",
-		ContentDigest:  "after-save",
 	}}
 
-	mergeSessionInfos("/tmp", infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
+	mergeSessionInfos(dir, infos, map[string]string{}, map[string]agent.SessionInfo{}, map[string]string{}, summaries)
 	summary := summaries[topicSummaryKey("global", "", "topic-continued")]
 	if !summary.hasAdoptedRecovery || summary.hasRecoveryOnly {
 		t.Fatalf("summary flags = %+v, want adopted recovery only", summary)
@@ -91,45 +122,68 @@ func TestMergeSessionInfosKeepsContinuedRecoveryVisible(t *testing.T) {
 	}
 }
 
-func TestRecoveryCopyRequiresMatchingNonEmptyDigests(t *testing.T) {
-	validA := strings.Repeat("a", 64)
-	validB := strings.Repeat("b", 64)
-	cases := []struct {
-		name     string
-		recovery string
-		content  string
-		want     bool
-	}{
-		{name: "unchanged", recovery: validA, content: validA, want: true},
-		{name: "continued", recovery: validA, content: validB, want: false},
-		{name: "malformed", recovery: "same", content: "same", want: false},
-		{name: "missing content digest", recovery: validA, want: false},
-		{name: "missing recovery digest", content: validA, want: false},
+func TestSessionMetaSeparatesRecoveryProvenanceFromCleanupCopy(t *testing.T) {
+	dir := t.TempDir()
+	coveredParent, coveredBranch, coveredMsgs := forkDesktopRecoveryBranch(t, dir, "meta-covered")
+	coverDesktopRecoveryParent(t, coveredParent, coveredMsgs)
+	info := agent.SessionInfo{
+		Path:      coveredBranch,
+		Recovered: true,
 	}
-	for _, tc := range cases {
-		if got := recoveryDigestsIdentifyUnmodifiedCopy(tc.recovery, tc.content); got != tc.want {
-			t.Errorf("%s: unmodified = %v, want %v", tc.name, got, tc.want)
-		}
+	meta := sessionMetaFromInfo(info, "", false, false, 0, dir)
+	if !meta.Recovered || !meta.RecoveryCopy {
+		t.Fatalf("covered recovery meta = %+v, want provenance and cleanup-copy flags", meta)
+	}
+
+	_, divergedBranch, _ := forkDesktopRecoveryBranch(t, dir, "meta-diverged")
+	info.Path = divergedBranch
+	meta = sessionMetaFromInfo(info, "", false, false, 0, dir)
+	if !meta.Recovered || meta.RecoveryCopy {
+		t.Fatalf("diverged recovery meta = %+v, want provenance without cleanup-copy flag", meta)
 	}
 }
 
-func TestSessionMetaSeparatesRecoveryProvenanceFromCleanupCopy(t *testing.T) {
-	digest := strings.Repeat("a", 64)
-	info := agent.SessionInfo{
-		Path:           "/tmp/session-recovery-0123456789abcdef.jsonl",
-		Recovered:      true,
-		RecoveryDigest: digest,
-		ContentDigest:  digest,
+func TestRecoveryCopyCleanupRevalidatesInBackend(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	meta := sessionMetaFromInfo(info, "", false, false, 0)
-	if !meta.Recovered || !meta.RecoveryCopy {
-		t.Fatalf("unchanged recovery meta = %+v, want provenance and cleanup-copy flags", meta)
+	app := NewApp()
+
+	parentPath, branchPath, branchMsgs := forkDesktopRecoveryBranch(t, dir, "delete-guard")
+	if err := app.DeleteRecoveryCopy(branchPath); err == nil {
+		t.Fatal("DeleteRecoveryCopy accepted a branch with unique content")
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("rejected recovery branch was not preserved: %v", err)
+	}
+	coverDesktopRecoveryParent(t, parentPath, branchMsgs)
+	if err := app.DeleteRecoveryCopy(branchPath); err != nil {
+		t.Fatalf("DeleteRecoveryCopy covered branch: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(branchPath), filepath.Base(branchPath))
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("covered recovery branch was not moved to trash: %v", err)
 	}
 
-	info.ContentDigest = strings.Repeat("b", 64)
-	meta = sessionMetaFromInfo(info, "", false, false, 0)
-	if !meta.Recovered || meta.RecoveryCopy {
-		t.Fatalf("continued recovery meta = %+v, want provenance without cleanup-copy flag", meta)
+	purgeParent, purgeBranch, purgeMsgs := forkDesktopRecoveryBranch(t, dir, "purge-guard")
+	if err := app.DeleteSession(purgeBranch); err != nil {
+		t.Fatalf("DeleteSession divergent branch: %v", err)
+	}
+	purgeTrashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(purgeBranch), filepath.Base(purgeBranch))
+	if err := app.PurgeRecoveryCopy(purgeTrashPath); err == nil {
+		t.Fatal("PurgeRecoveryCopy accepted a trashed branch with unique content")
+	}
+	if _, err := os.Stat(purgeTrashPath); err != nil {
+		t.Fatalf("rejected trashed recovery branch was not preserved: %v", err)
+	}
+	coverDesktopRecoveryParent(t, purgeParent, purgeMsgs)
+	if err := app.PurgeRecoveryCopy(purgeTrashPath); err != nil {
+		t.Fatalf("PurgeRecoveryCopy covered branch: %v", err)
+	}
+	if _, err := os.Stat(purgeTrashPath); !os.IsNotExist(err) {
+		t.Fatalf("covered recovery branch survived permanent purge: %v", err)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -451,6 +451,9 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 		return err
 	}
 	defer guard.Release()
+	if err := invalidateTopicDirMarkers(dir); err != nil {
+		return err
+	}
 	itemDir := target.itemDir
 	if target.allocateUnique {
 		itemDir, err = reserveUniqueSessionTrashItemDir(dir, key)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5369,8 +5369,10 @@ var legacyMigrationMu sync.Mutex
 // It is stamped only when the pass left nothing deferred (an empty legacy
 // session that could gain content later keeps the dir unmarked), so the gate
 // never hides a session that should still be migrated.
-const topicMigrationMarker = ".topics-migrated"
-const topicIndexRepairMarker = ".topic-indexes-repaired"
+// v2 re-evaluates recovery-named sessions that v1 skipped solely by filename.
+// The old marker cannot safely suppress this one-time data-preservation pass.
+const topicMigrationMarker = ".topics-migrated-v2"
+const topicIndexRepairMarker = ".topic-indexes-repaired-v2"
 
 func topicDirMarkerDone(dir, marker string) bool {
 	dir = strings.TrimSpace(dir)
@@ -5470,7 +5472,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	// unmarked so the next render retries instead of the gate hiding it forever.
 	deferred := false
 	for _, info := range infos {
-		if sessionOrderInfoIsAutomaticRecovery(info) {
+		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info) {
 			continue
 		}
 		if strings.TrimSpace(info.TopicID) != "" {
@@ -5650,7 +5652,7 @@ func repairIndexedSessionTopics(dir string) []string {
 	sourcesChanged := false
 	deferred := false
 	for _, info := range infos {
-		if sessionOrderInfoIsAutomaticRecovery(info) {
+		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info) {
 			continue
 		}
 		topicID := strings.TrimSpace(info.TopicID)
@@ -5759,6 +5761,35 @@ func sessionInfoIsAutomaticRecovery(info agent.SessionInfo) bool {
 	return info.Recovered ||
 		strings.TrimSpace(info.RecoveryDigest) != "" ||
 		isAutomaticRecoverySessionPath(info.Path)
+}
+
+// recoveryDigestsIdentifyUnmodifiedCopy is deliberately conservative: recovery
+// provenance (a flag, digest, or filename) is not enough to authorize hiding or
+// bulk deletion. Both digests must be present and equal, proving that no save
+// has changed the recovered branch since it was forked.
+func recoveryDigestsIdentifyUnmodifiedCopy(recoveryDigest, contentDigest string) bool {
+	recoveryDigest = strings.TrimSpace(recoveryDigest)
+	contentDigest = strings.TrimSpace(contentDigest)
+	if len(recoveryDigest) != 64 || len(contentDigest) != 64 || recoveryDigest != contentDigest {
+		return false
+	}
+	for _, r := range recoveryDigest {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func sessionOrderInfoIsUnmodifiedRecoveryCopy(info agent.SessionOrderInfo) bool {
+	return sessionOrderInfoIsAutomaticRecovery(info) &&
+		recoveryDigestsIdentifyUnmodifiedCopy(info.RecoveryDigest, info.ContentDigest)
+}
+
+func sessionInfoIsUnmodifiedRecoveryCopy(info agent.SessionInfo) bool {
+	return sessionInfoIsAutomaticRecovery(info) &&
+		recoveryDigestsIdentifyUnmodifiedCopy(info.RecoveryDigest, info.ContentDigest)
 }
 
 func isAutomaticRecoverySessionPath(path string) bool {
@@ -6526,10 +6557,19 @@ func (a *App) topicTrashTargets(topicID string) ([]topicTrashTarget, error) {
 // topicSummary is used by ListProjectTree and mergeSessionInfos to track
 // per-topic turn count and last activity.
 type topicSummary struct {
-	turns            int
-	lastActivityAt   int64
-	hasNormalSession bool
-	hasRecoveryOnly  bool
+	turns                int
+	adoptedRecoveryTurns int
+	lastActivityAt       int64
+	hasNormalSession     bool
+	hasRecoveryOnly      bool
+	hasAdoptedRecovery   bool
+}
+
+func (s topicSummary) displayTurns() int {
+	if s.adoptedRecoveryTurns > s.turns {
+		return s.adoptedRecoveryTurns
+	}
+	return s.turns
 }
 
 // runtimeSessionStatus is one open or detached runtime session, as shown in
@@ -6556,7 +6596,7 @@ type runtimeSessionStatus struct {
 // reports open/running only for single-session topics, so it must not gate
 // topic existence.
 func topicHiddenAsRecoveryOnly(summary topicSummary, pinned bool, runtimeSessions []runtimeSessionStatus) bool {
-	if !summary.hasRecoveryOnly || summary.hasNormalSession || pinned {
+	if !summary.hasRecoveryOnly || summary.hasNormalSession || summary.hasAdoptedRecovery || pinned {
 		return false
 	}
 	for _, session := range runtimeSessions {
@@ -6776,7 +6816,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 				Label:          title,
 				TopicID:        id,
 				ProjectColor:   globalColor,
-				Turns:          summary.turns,
+				Turns:          summary.displayTurns(),
 				CreatedAt:      topicCreatedAtForTree(globalCreatedMap, id),
 				LastActivityAt: summary.lastActivityAt,
 				Open:           open,
@@ -6858,7 +6898,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 				Root:           p.Root,
 				TopicID:        tid,
 				ProjectColor:   p.Color,
-				Turns:          summary.turns,
+				Turns:          summary.displayTurns(),
 				CreatedAt:      topicCreatedAtForTree(createdMap, tid),
 				LastActivityAt: summary.lastActivityAt,
 				Open:           open,
@@ -7926,12 +7966,17 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		summary := topicSummaries[key]
 		lastActivityAt := info.LastActivityAt.UnixMilli()
 		if sessionInfoIsAutomaticRecovery(info) {
-			// A conflict copy duplicates its original, so its turns would
-			// double-count — but its activity is real: once a tab adopts the
-			// copy as its live transcript, all new work lands here, and
-			// skipping it would freeze the topic's recency, unread state, and
-			// time filters at the original's last save.
-			summary.hasRecoveryOnly = true
+			// An unchanged conflict copy duplicates its original, so its turns
+			// must not be added. Once its content digest diverges, however, the
+			// branch contains unique user work and must keep the topic visible.
+			if sessionInfoIsUnmodifiedRecoveryCopy(info) {
+				summary.hasRecoveryOnly = true
+			} else {
+				summary.hasAdoptedRecovery = true
+				if info.Turns > summary.adoptedRecoveryTurns {
+					summary.adoptedRecoveryTurns = info.Turns
+				}
+			}
 			if lastActivityAt > summary.lastActivityAt {
 				summary.lastActivityAt = lastActivityAt
 			}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5472,7 +5472,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	// unmarked so the next render retries instead of the gate hiding it forever.
 	deferred := false
 	for _, info := range infos {
-		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info) {
+		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info, dir) {
 			continue
 		}
 		if strings.TrimSpace(info.TopicID) != "" {
@@ -5652,7 +5652,7 @@ func repairIndexedSessionTopics(dir string) []string {
 	sourcesChanged := false
 	deferred := false
 	for _, info := range infos {
-		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info) {
+		if sessionOrderInfoIsUnmodifiedRecoveryCopy(info, dir) {
 			continue
 		}
 		topicID := strings.TrimSpace(info.TopicID)
@@ -5763,33 +5763,14 @@ func sessionInfoIsAutomaticRecovery(info agent.SessionInfo) bool {
 		isAutomaticRecoverySessionPath(info.Path)
 }
 
-// recoveryDigestsIdentifyUnmodifiedCopy is deliberately conservative: recovery
-// provenance (a flag, digest, or filename) is not enough to authorize hiding or
-// bulk deletion. Both digests must be present and equal, proving that no save
-// has changed the recovered branch since it was forked.
-func recoveryDigestsIdentifyUnmodifiedCopy(recoveryDigest, contentDigest string) bool {
-	recoveryDigest = strings.TrimSpace(recoveryDigest)
-	contentDigest = strings.TrimSpace(contentDigest)
-	if len(recoveryDigest) != 64 || len(contentDigest) != 64 || recoveryDigest != contentDigest {
-		return false
-	}
-	for _, r := range recoveryDigest {
-		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func sessionOrderInfoIsUnmodifiedRecoveryCopy(info agent.SessionOrderInfo) bool {
+func sessionOrderInfoIsUnmodifiedRecoveryCopy(info agent.SessionOrderInfo, parentDir string) bool {
 	return sessionOrderInfoIsAutomaticRecovery(info) &&
-		recoveryDigestsIdentifyUnmodifiedCopy(info.RecoveryDigest, info.ContentDigest)
+		agent.RecoveryBranchCoveredByParent(info.Path, parentDir)
 }
 
-func sessionInfoIsUnmodifiedRecoveryCopy(info agent.SessionInfo) bool {
+func sessionInfoIsUnmodifiedRecoveryCopy(info agent.SessionInfo, parentDir string) bool {
 	return sessionInfoIsAutomaticRecovery(info) &&
-		recoveryDigestsIdentifyUnmodifiedCopy(info.RecoveryDigest, info.ContentDigest)
+		agent.RecoveryBranchCoveredByParent(info.Path, parentDir)
 }
 
 func isAutomaticRecoverySessionPath(path string) bool {
@@ -7966,10 +7947,9 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		summary := topicSummaries[key]
 		lastActivityAt := info.LastActivityAt.UnixMilli()
 		if sessionInfoIsAutomaticRecovery(info) {
-			// An unchanged conflict copy duplicates its original, so its turns
-			// must not be added. Once its content digest diverges, however, the
-			// branch contains unique user work and must keep the topic visible.
-			if sessionInfoIsUnmodifiedRecoveryCopy(info) {
+			// A covered conflict copy duplicates its parent, so its turns must not
+			// be added. Any branch with unique content keeps the topic visible.
+			if sessionInfoIsUnmodifiedRecoveryCopy(info, dir) {
 				summary.hasRecoveryOnly = true
 			} else {
 				summary.hasAdoptedRecovery = true

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5374,6 +5374,20 @@ var legacyMigrationMu sync.Mutex
 const topicMigrationMarker = ".topics-migrated-v2"
 const topicIndexRepairMarker = ".topic-indexes-repaired-v2"
 
+func invalidateTopicDirMarkers(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	var errs []error
+	for _, marker := range []string{topicMigrationMarker, topicIndexRepairMarker} {
+		if err := os.Remove(filepath.Join(dir, marker)); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func topicDirMarkerDone(dir, marker string) bool {
 	dir = strings.TrimSpace(dir)
 	marker = strings.TrimSpace(marker)

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -462,7 +462,7 @@ func TestLegacySessionsMigrateIntoGlobalTopics(t *testing.T) {
 	}
 }
 
-func TestLegacyRecoverySessionsDoNotMigrateIntoTopics(t *testing.T) {
+func TestAmbiguousLegacyRecoverySessionsMigrateIntoTopics(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	dir := config.SessionDir()
@@ -471,21 +471,59 @@ func TestLegacyRecoverySessionsDoNotMigrateIntoTopics(t *testing.T) {
 	}
 	normal := writeLegacySession(t, dir, "normal.jsonl", "normal imported prompt", time.Now().Add(-2*time.Hour))
 	recovery := writeLegacySession(t, dir, "normal-recovery-0123456789abcdef.jsonl", "legacy recovery prompt", time.Now().Add(-time.Hour))
+	// Simulate an upgrade from the filename-only classifier: the v1 marker
+	// must not prevent the new conservative pass from recovering this history.
+	if err := os.WriteFile(filepath.Join(dir, ".topics-migrated"), nil, 0o644); err != nil {
+		t.Fatalf("write v1 migration marker: %v", err)
+	}
 
 	nodes := NewApp().ListProjectTree()
 	if len(nodes) != 1 || nodes[0].Kind != "global_folder" {
 		t.Fatalf("project tree = %#v, want global folder", nodes)
 	}
-	if got := len(nodes[0].Children); got != 1 {
-		t.Fatalf("global migrated topics = %d, want only the normal session: %#v", got, nodes[0].Children)
+	if got := len(nodes[0].Children); got != 2 {
+		t.Fatalf("global migrated topics = %d, want both sessions preserved: %#v", got, nodes[0].Children)
 	}
-	if got, want := nodes[0].Children[0].TopicID, legacySessionTopicID(normal); got != want {
-		t.Fatalf("migrated topic = %q, want normal session topic %q", got, want)
+	wantTopics := map[string]bool{legacySessionTopicID(normal): true, legacySessionTopicID(recovery): true}
+	for _, node := range nodes[0].Children {
+		delete(wantTopics, node.TopicID)
 	}
-	if meta, ok, err := agent.LoadBranchMeta(recovery); err != nil {
+	if len(wantTopics) != 0 {
+		t.Fatalf("migrated topics missing %v: %#v", wantTopics, nodes[0].Children)
+	}
+	if meta, ok, err := agent.LoadBranchMeta(recovery); err != nil || !ok {
 		t.Fatalf("load recovery meta: %v", err)
-	} else if ok && strings.TrimSpace(meta.TopicID) != "" {
-		t.Fatalf("legacy recovery branch was migrated into topic %q", meta.TopicID)
+	} else if strings.TrimSpace(meta.TopicID) == "" {
+		t.Fatal("ambiguous legacy recovery branch was not migrated into a visible topic")
+	}
+}
+
+func TestUnmodifiedRecoveryCopyDoesNotMigrateIntoTopics(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	recovery := writeLegacySession(t, dir, "normal-recovery-0123456789abcdef.jsonl", "unchanged recovery copy", time.Now())
+	digest := strings.Repeat("a", 64)
+	if err := agent.SaveBranchMetaPreserveUpdated(recovery, agent.BranchMeta{
+		ID:             agent.BranchID(recovery),
+		Recovered:      true,
+		RecoveryDigest: digest,
+		ContentDigest:  digest,
+	}); err != nil {
+		t.Fatalf("save recovery meta: %v", err)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || len(nodes[0].Children) != 0 {
+		t.Fatalf("unmodified recovery copy migrated into project tree: %#v", nodes)
+	}
+	if meta, ok, err := agent.LoadBranchMeta(recovery); err != nil || !ok {
+		t.Fatalf("load recovery meta: ok=%v err=%v", ok, err)
+	} else if strings.TrimSpace(meta.TopicID) != "" {
+		t.Fatalf("unmodified recovery copy was migrated into topic %q", meta.TopicID)
 	}
 }
 
@@ -509,6 +547,9 @@ func TestHistoryMarksLegacyRecoverySessionsAsRecovered(t *testing.T) {
 		}
 		if !session.Recovered {
 			t.Fatalf("history session recovered flag = false, want true: %+v", session)
+		}
+		if session.RecoveryCopy {
+			t.Fatalf("legacy filename-only recovery was marked safe for bulk cleanup: %+v", session)
 		}
 		return
 	}
@@ -535,9 +576,12 @@ func TestTrashMarksLegacyRecoverySessionsAsRecovered(t *testing.T) {
 	if !sessions[0].Recovered {
 		t.Fatalf("trashed recovery session recovered flag = false, want true: %+v", sessions[0])
 	}
+	if sessions[0].RecoveryCopy {
+		t.Fatalf("legacy filename-only recovery was marked safe for bulk purge: %+v", sessions[0])
+	}
 }
 
-func TestProjectTreeHidesAlreadyMigratedLegacyRecoveryTopic(t *testing.T) {
+func TestProjectTreeKeepsAmbiguousMigratedRecoveryTopicVisible(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
 	dir := config.SessionDir()
@@ -558,24 +602,25 @@ func TestProjectTreeHidesAlreadyMigratedLegacyRecoveryTopic(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save migrated recovery meta: %v", err)
 	}
-	if err := setTopicTitle("", topicID, "恢复分支"); err != nil {
-		t.Fatalf("set topic title: %v", err)
-	}
-	if err := prependTopicsInProjectsFile("", []string{topicID}, false); err != nil {
-		t.Fatalf("prepend topic: %v", err)
+	// A v1 repair pass skipped this recovery-named record. The v2 pass must
+	// revisit it and restore its existing topic to the sidebar index.
+	if err := os.WriteFile(filepath.Join(dir, ".topic-indexes-repaired"), nil, 0o644); err != nil {
+		t.Fatalf("write v1 repair marker: %v", err)
 	}
 
 	nodes := NewApp().ListProjectTree()
-	var walk func([]ProjectNode)
-	walk = func(list []ProjectNode) {
-		for _, node := range list {
-			if node.TopicID == topicID {
-				t.Fatalf("already-migrated recovery topic should be hidden, got node %+v", node)
+	if len(nodes) == 0 {
+		t.Fatal("project tree is empty")
+	}
+	for _, node := range nodes[0].Children {
+		if node.TopicID == topicID {
+			if node.Turns != 1 {
+				t.Fatalf("recovery topic turns = %d, want 1", node.Turns)
 			}
-			walk(node.Children)
+			return
 		}
 	}
-	walk(nodes)
+	t.Fatalf("ambiguous recovery topic should stay visible: %#v", nodes)
 }
 
 func TestTopicMigrationMarkerRescansWhenSessionFileChanges(t *testing.T) {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -505,25 +505,17 @@ func TestUnmodifiedRecoveryCopyDoesNotMigrateIntoTopics(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
-	recovery := writeLegacySession(t, dir, "normal-recovery-0123456789abcdef.jsonl", "unchanged recovery copy", time.Now())
-	digest := strings.Repeat("a", 64)
-	if err := agent.SaveBranchMetaPreserveUpdated(recovery, agent.BranchMeta{
-		ID:             agent.BranchID(recovery),
-		Recovered:      true,
-		RecoveryDigest: digest,
-		ContentDigest:  digest,
-	}); err != nil {
-		t.Fatalf("save recovery meta: %v", err)
-	}
+	parent, recovery, branchMsgs := forkDesktopRecoveryBranch(t, dir, "normal")
+	coverDesktopRecoveryParent(t, parent, branchMsgs)
 
 	nodes := NewApp().ListProjectTree()
-	if len(nodes) != 1 || len(nodes[0].Children) != 0 {
-		t.Fatalf("unmodified recovery copy migrated into project tree: %#v", nodes)
+	if len(nodes) != 1 || len(nodes[0].Children) != 1 {
+		t.Fatalf("project tree = %#v, want only the covering parent topic", nodes)
 	}
 	if meta, ok, err := agent.LoadBranchMeta(recovery); err != nil || !ok {
 		t.Fatalf("load recovery meta: ok=%v err=%v", ok, err)
 	} else if strings.TrimSpace(meta.TopicID) != "" {
-		t.Fatalf("unmodified recovery copy was migrated into topic %q", meta.TopicID)
+		t.Fatalf("parent-covered recovery copy was migrated into topic %q", meta.TopicID)
 	}
 }
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -519,6 +519,56 @@ func TestUnmodifiedRecoveryCopyDoesNotMigrateIntoTopics(t *testing.T) {
 	}
 }
 
+func TestCoveredRecoveryCopyBecomesVisibleAfterMigratedParentDeletion(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	parent, recovery, branchMsgs := forkDesktopRecoveryBranch(t, dir, "parent-delete")
+	coverDesktopRecoveryParent(t, parent, branchMsgs)
+	app := NewApp()
+
+	app.ListProjectTree()
+	for _, marker := range []string{topicMigrationMarker, topicIndexRepairMarker} {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err != nil {
+			t.Fatalf("expected %s after migration: %v", marker, err)
+		}
+	}
+	if meta, ok, err := agent.LoadBranchMeta(recovery); err != nil || !ok {
+		t.Fatalf("load skipped recovery meta: ok=%v err=%v", ok, err)
+	} else if strings.TrimSpace(meta.TopicID) != "" {
+		t.Fatalf("covered recovery copy was migrated before parent deletion: %+v", meta)
+	}
+
+	if err := app.DeleteSession(parent); err != nil {
+		t.Fatalf("DeleteSession parent: %v", err)
+	}
+	for _, marker := range []string{topicMigrationMarker, topicIndexRepairMarker} {
+		if _, err := os.Stat(filepath.Join(dir, marker)); !os.IsNotExist(err) {
+			t.Fatalf("%s survived live session deletion: %v", marker, err)
+		}
+	}
+
+	nodes := app.ListProjectTree()
+	meta, ok, err := agent.LoadBranchMeta(recovery)
+	if err != nil || !ok {
+		t.Fatalf("load recovery meta after parent deletion: ok=%v err=%v", ok, err)
+	}
+	if meta.TopicID != legacySessionTopicID(recovery) {
+		t.Fatalf("recovery topic after parent deletion = %q, want %q", meta.TopicID, legacySessionTopicID(recovery))
+	}
+	for _, root := range nodes {
+		for _, node := range root.Children {
+			if node.TopicID == meta.TopicID {
+				return
+			}
+		}
+	}
+	t.Fatalf("project tree after parent deletion = %#v, want recovery topic %q", nodes, meta.TopicID)
+}
+
 func TestHistoryMarksLegacyRecoverySessionsAsRecovered(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/agent/recovery_gc.go
+++ b/internal/agent/recovery_gc.go
@@ -34,6 +34,57 @@ func SessionLeaseHeld(path string) bool {
 	return SessionLeaseHeldByOtherRuntime(path)
 }
 
+// RecoveryBranchCoveredByParent reports whether a conflict-recovery branch
+// preserves no content that is absent from its parent. It deliberately reads
+// both transcripts instead of trusting listing sidecars: stale metadata must
+// never authorize hiding, migration skipping, bulk trash, or permanent purge.
+// Missing/corrupt metadata, a changed branch, or a missing/diverged parent are
+// all treated conservatively as not covered.
+func RecoveryBranchCoveredByParent(path, parentDir string) bool {
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok || !meta.Recovered || strings.TrimSpace(meta.RecoveryDigest) == "" {
+		return false
+	}
+	return recoveryBranchCoveredByParent(path, parentDir, meta)
+}
+
+func recoveryBranchCoveredByParent(path, parentDir string, meta BranchMeta) bool {
+	parentID := strings.TrimSpace(meta.ParentID)
+	if parentID == "" {
+		return false
+	}
+	branch, err := LoadSession(path)
+	if err != nil || branch == nil {
+		return false
+	}
+	branchMsgs := branch.Snapshot()
+	branchDigest, err := digestSessionMessages(branchMsgs)
+	if err != nil || digestString(branchDigest) != strings.TrimSpace(meta.RecoveryDigest) {
+		// Continued on (or undigestable): this is someone's conversation now.
+		return false
+	}
+	parentDir = strings.TrimSpace(parentDir)
+	if parentDir == "" {
+		parentDir = filepath.Dir(path)
+	}
+	parentPath := filepath.Join(parentDir, parentID+".jsonl")
+	if parentPath == path || !IsVisibleSession(parentPath) {
+		return false
+	}
+	parent, err := LoadSession(parentPath)
+	if err != nil || parent == nil {
+		return false
+	}
+	parentMsgs := parent.Snapshot()
+	parentDigest, err := digestSessionMessages(parentMsgs)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(parentDigest[:], branchDigest[:]) ||
+		messagesHavePrefix(parentMsgs, branchMsgs) ||
+		messagesHavePrefixWithCompatibleSystem(parentMsgs, branchMsgs)
+}
+
 // ReclaimableRecoveryBranches scans dir for conflict-recovery branches that
 // are safe to dispose of. Every condition must hold — when in doubt the branch
 // stays, because a recovery branch exists precisely to prevent data loss:
@@ -92,33 +143,7 @@ func ReclaimableRecoveryBranches(dir string, now time.Time, grace time.Duration)
 		if SessionLeaseHeld(path) {
 			continue
 		}
-		branch, err := LoadSession(path)
-		if err != nil || branch == nil {
-			continue
-		}
-		branchMsgs := branch.Snapshot()
-		branchDigest, err := digestSessionMessages(branchMsgs)
-		if err != nil || digestString(branchDigest) != meta.RecoveryDigest {
-			// Continued on (or undigestable): this is someone's conversation now.
-			continue
-		}
-		parentPath := filepath.Join(dir, meta.ParentID+".jsonl")
-		if parentPath == path || !IsVisibleSession(parentPath) {
-			continue
-		}
-		parent, err := LoadSession(parentPath)
-		if err != nil || parent == nil {
-			continue
-		}
-		parentMsgs := parent.Snapshot()
-		parentDigest, err := digestSessionMessages(parentMsgs)
-		if err != nil {
-			continue
-		}
-		covered := bytes.Equal(parentDigest[:], branchDigest[:]) ||
-			messagesHavePrefix(parentMsgs, branchMsgs) ||
-			messagesHavePrefixWithCompatibleSystem(parentMsgs, branchMsgs)
-		if !covered {
+		if !recoveryBranchCoveredByParent(path, dir, meta) {
 			continue
 		}
 		out = append(out, path)

--- a/internal/agent/recovery_gc.go
+++ b/internal/agent/recovery_gc.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,10 @@ import (
 // idle before GC may collect it. A fresh fork is part of an active conflict
 // flow — the user may be comparing it against the original right now.
 const RecoveryGCGracePeriod = 24 * time.Hour
+
+// ErrRecoveryBranchNotCovered means the branch cannot currently be proven
+// redundant with its parent. Destructive callers must preserve it.
+var ErrRecoveryBranchNotCovered = errors.New("recovery branch is not covered by its parent")
 
 // SessionLeaseHeld reports whether ANY live runtime — this process included —
 // holds the session's write lease. SessionLeaseHeldByOtherRuntime deliberately
@@ -46,6 +51,39 @@ func RecoveryBranchCoveredByParent(path, parentDir string) bool {
 		return false
 	}
 	return recoveryBranchCoveredByParent(path, parentDir, meta)
+}
+
+// TryAcquireRecoveryParentGuard verifies that a recovery branch is covered by
+// its parent while holding the parent's save and lease locks. The caller must
+// keep the returned guard until permanent deletion finishes, then Release it.
+// If the parent is open or being rewritten, acquisition fails without waiting
+// so bulk cleanup preserves the branch and can be retried later.
+func TryAcquireRecoveryParentGuard(path, parentDir string) (*SessionRemovalGuard, error) {
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok || !meta.Recovered || strings.TrimSpace(meta.RecoveryDigest) == "" {
+		return nil, ErrRecoveryBranchNotCovered
+	}
+	parentID := strings.TrimSpace(meta.ParentID)
+	if parentID == "" {
+		return nil, ErrRecoveryBranchNotCovered
+	}
+	parentDir = strings.TrimSpace(parentDir)
+	if parentDir == "" {
+		parentDir = filepath.Dir(path)
+	}
+	parentPath := filepath.Join(parentDir, parentID+".jsonl")
+	if parentPath == path || !IsVisibleSession(parentPath) {
+		return nil, ErrRecoveryBranchNotCovered
+	}
+	guard, err := TryAcquireSessionRemovalGuard(parentPath)
+	if err != nil {
+		return nil, err
+	}
+	if !recoveryBranchCoveredByParent(path, parentDir, meta) {
+		guard.Release()
+		return nil, ErrRecoveryBranchNotCovered
+	}
+	return guard, nil
 }
 
 func recoveryBranchCoveredByParent(path, parentDir string, meta BranchMeta) bool {

--- a/internal/agent/recovery_gc_test.go
+++ b/internal/agent/recovery_gc_test.go
@@ -1,12 +1,14 @@
 package agent
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 // forkRecoveryBranch builds a real conflict-recovery branch: a diverged disk
@@ -170,5 +172,58 @@ func TestRecoveryBranchCoveredByParentReadsActualContent(t *testing.T) {
 	}
 	if RecoveryBranchCoveredByParent(missingBranch, dir) {
 		t.Fatal("missing parent reported as covering its recovery branch")
+	}
+}
+
+func TestRecoveryParentGuardBlocksRewindAfterValidation(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, branchPath, branchMsgs := forkRecoveryBranch(t, dir, "rewind-race")
+	coverBranchInParent(t, parentPath, branchMsgs)
+
+	guard, err := TryAcquireRecoveryParentGuard(branchPath, dir)
+	if err != nil {
+		t.Fatalf("TryAcquireRecoveryParentGuard: %v", err)
+	}
+	// Force the dangerous ordering: coverage validation has completed, then a
+	// concurrent rewind tries to take the parent's save lock before purge. The
+	// guard must keep that lock unavailable until the caller finishes deleting
+	// the redundant branch.
+	if lock, err := tryTakeSessionLockFile(store.SessionLockFile(parentPath)); !errors.Is(err, errSessionFileLockHeld) {
+		if lock != nil {
+			lock.Unlock()
+		}
+		guard.Release()
+		t.Fatalf("parent save lock after coverage validation = %v, want errSessionFileLockHeld", err)
+	}
+	guard.Release()
+
+	parent, err := LoadSession(parentPath)
+	if err != nil {
+		t.Fatalf("LoadSession parent: %v", err)
+	}
+	parent.Messages = append([]provider.Message(nil), parent.Messages[:1]...)
+	if err := parent.SaveRewrite(parentPath); err != nil {
+		t.Fatalf("SaveRewrite after guard release: %v", err)
+	}
+	if RecoveryBranchCoveredByParent(branchPath, dir) {
+		t.Fatal("rewound parent still reported as covering the recovery branch")
+	}
+}
+
+func TestRecoveryParentGuardRefusesInFlightParentRewrite(t *testing.T) {
+	dir := t.TempDir()
+	parentPath, branchPath, branchMsgs := forkRecoveryBranch(t, dir, "rewrite-busy")
+	coverBranchInParent(t, parentPath, branchMsgs)
+
+	unlock, err := lockSessionFile(parentPath)
+	if err != nil {
+		t.Fatalf("lockSessionFile: %v", err)
+	}
+	defer unlock()
+	if guard, err := TryAcquireRecoveryParentGuard(branchPath, dir); !errors.Is(err, ErrSessionLeaseHeld) {
+		if guard != nil {
+			guard.Release()
+		}
+		t.Fatalf("guard during parent rewrite err = %v, want ErrSessionLeaseHeld", err)
 	}
 }

--- a/internal/agent/recovery_gc_test.go
+++ b/internal/agent/recovery_gc_test.go
@@ -121,3 +121,54 @@ func TestReclaimableRecoveryBranchesRespectsGraceLeaseAndMissingParent(t *testin
 		t.Fatalf("parent missing = %v err=%v, want none", got, err)
 	}
 }
+
+func TestRecoveryBranchCoveredByParentReadsActualContent(t *testing.T) {
+	dir := t.TempDir()
+
+	_, divergedBranch, _ := forkRecoveryBranch(t, dir, "diverged-proof")
+	if RecoveryBranchCoveredByParent(divergedBranch, dir) {
+		t.Fatal("diverged parent reported as covering its recovery branch")
+	}
+
+	coveredParent, coveredBranch, coveredMsgs := forkRecoveryBranch(t, dir, "covered-proof")
+	coverBranchInParent(t, coveredParent, coveredMsgs)
+	if !RecoveryBranchCoveredByParent(coveredBranch, dir) {
+		t.Fatal("parent containing the recovery transcript did not cover the branch")
+	}
+
+	// Restore the fork metadata after continuing the transcript. This models a
+	// stale sidecar that still claims content_digest == recovery_digest even
+	// though the actual branch has changed.
+	staleMeta, ok, err := LoadBranchMeta(coveredBranch)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta stale branch: ok=%v err=%v", ok, err)
+	}
+	continued, err := LoadSession(coveredBranch)
+	if err != nil {
+		t.Fatalf("LoadSession stale branch: %v", err)
+	}
+	continued.Add(provider.Message{Role: provider.RoleAssistant, Content: "continued after sidecar snapshot"})
+	if err := continued.Save(coveredBranch); err != nil {
+		t.Fatalf("Save continued branch: %v", err)
+	}
+	if err := SaveBranchMetaPreserveUpdated(coveredBranch, staleMeta); err != nil {
+		t.Fatalf("restore stale branch meta: %v", err)
+	}
+	if RecoveryBranchCoveredByParent(coveredBranch, dir) {
+		t.Fatal("stale sidecar authorized cleanup of changed branch content")
+	}
+
+	missingParent, missingBranch, missingMsgs := forkRecoveryBranch(t, dir, "missing-proof")
+	coverBranchInParent(t, missingParent, missingMsgs)
+	if !RecoveryBranchCoveredByParent(missingBranch, dir) {
+		t.Fatal("missing-parent fixture was not covered before parent removal")
+	}
+	for _, suffix := range []string{"", ".events.jsonl", ".meta"} {
+		if err := os.Remove(missingParent + suffix); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove parent artifact %s: %v", suffix, err)
+		}
+	}
+	if RecoveryBranchCoveredByParent(missingBranch, dir) {
+		t.Fatal("missing parent reported as covering its recovery branch")
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1180,6 +1180,7 @@ type SessionInfo struct {
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
+	ContentDigest  string
 	ParentID       string
 }
 
@@ -1199,6 +1200,7 @@ type SessionOrderInfo struct {
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
+	ContentDigest  string
 	ParentID       string
 	// Turns and Preview are the cached listing fields from the sidecar; SchemaVersion
 	// >= agent.BranchMetaCountsVersion means they were recorded from content and can
@@ -1715,6 +1717,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		recovered := false
 		recoveryReason := ""
 		recoveryDigest := ""
+		contentDigest := ""
 		parentID := ""
 		turns := 0
 		preview := ""
@@ -1734,6 +1737,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			recovered = meta.Recovered
 			recoveryReason = meta.RecoveryReason
 			recoveryDigest = meta.RecoveryDigest
+			contentDigest = meta.ContentDigest
 			parentID = meta.ParentID
 			turns = meta.Turns
 			preview = meta.Preview
@@ -1752,6 +1756,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			Recovered:      recovered,
 			RecoveryReason: recoveryReason,
 			RecoveryDigest: recoveryDigest,
+			ContentDigest:  contentDigest,
 			ParentID:       parentID,
 			Turns:          turns,
 			Preview:        preview,
@@ -1808,6 +1813,7 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			Recovered:      session.Recovered,
 			RecoveryReason: session.RecoveryReason,
 			RecoveryDigest: session.RecoveryDigest,
+			ContentDigest:  session.ContentDigest,
 			ParentID:       session.ParentID,
 		})
 	}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1180,7 +1180,6 @@ type SessionInfo struct {
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
-	ContentDigest  string
 	ParentID       string
 }
 
@@ -1200,7 +1199,6 @@ type SessionOrderInfo struct {
 	Recovered      bool
 	RecoveryReason string
 	RecoveryDigest string
-	ContentDigest  string
 	ParentID       string
 	// Turns and Preview are the cached listing fields from the sidecar; SchemaVersion
 	// >= agent.BranchMetaCountsVersion means they were recorded from content and can
@@ -1717,7 +1715,6 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		recovered := false
 		recoveryReason := ""
 		recoveryDigest := ""
-		contentDigest := ""
 		parentID := ""
 		turns := 0
 		preview := ""
@@ -1737,7 +1734,6 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			recovered = meta.Recovered
 			recoveryReason = meta.RecoveryReason
 			recoveryDigest = meta.RecoveryDigest
-			contentDigest = meta.ContentDigest
 			parentID = meta.ParentID
 			turns = meta.Turns
 			preview = meta.Preview
@@ -1756,7 +1752,6 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			Recovered:      recovered,
 			RecoveryReason: recoveryReason,
 			RecoveryDigest: recoveryDigest,
-			ContentDigest:  contentDigest,
 			ParentID:       parentID,
 			Turns:          turns,
 			Preview:        preview,
@@ -1813,7 +1808,6 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			Recovered:      session.Recovered,
 			RecoveryReason: session.RecoveryReason,
 			RecoveryDigest: session.RecoveryDigest,
-			ContentDigest:  session.ContentDigest,
 			ParentID:       session.ParentID,
 		})
 	}

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -2029,6 +2029,48 @@ func TestListSessionOrderIncludesEmptySessionsWithoutPreviewScan(t *testing.T) {
 	}
 }
 
+func TestSessionListingsExposeRecoveryAndContentDigests(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recovered.jsonl")
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "continued recovery"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+	}
+	meta.Recovered = true
+	meta.RecoveryDigest = strings.Repeat("a", 64)
+	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	ordered, err := ListSessionOrder(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ordered) != 1 {
+		t.Fatalf("ListSessionOrder len = %d, want 1", len(ordered))
+	}
+	if ordered[0].RecoveryDigest != meta.RecoveryDigest || ordered[0].ContentDigest != meta.ContentDigest {
+		t.Fatalf("ordered digests = recovery:%q content:%q, want recovery:%q content:%q", ordered[0].RecoveryDigest, ordered[0].ContentDigest, meta.RecoveryDigest, meta.ContentDigest)
+	}
+
+	listed, err := ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ListSessions len = %d, want 1", len(listed))
+	}
+	if listed[0].RecoveryDigest != meta.RecoveryDigest || listed[0].ContentDigest != meta.ContentDigest {
+		t.Fatalf("listed digests = recovery:%q content:%q, want recovery:%q content:%q", listed[0].RecoveryDigest, listed[0].ContentDigest, meta.RecoveryDigest, meta.ContentDigest)
+	}
+}
+
 func writeBranchMeta(t *testing.T, path string, createdAt, updatedAt time.Time) {
 	t.Helper()
 	meta := BranchMeta{

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -2029,7 +2029,7 @@ func TestListSessionOrderIncludesEmptySessionsWithoutPreviewScan(t *testing.T) {
 	}
 }
 
-func TestSessionListingsExposeRecoveryAndContentDigests(t *testing.T) {
+func TestSessionListingsExposeRecoveryMetadata(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "recovered.jsonl")
 	s := NewSession("")
@@ -2044,6 +2044,7 @@ func TestSessionListingsExposeRecoveryAndContentDigests(t *testing.T) {
 	}
 	meta.Recovered = true
 	meta.RecoveryDigest = strings.Repeat("a", 64)
+	meta.ParentID = "parent"
 	if err := SaveBranchMetaPreserveUpdated(path, meta); err != nil {
 		t.Fatal(err)
 	}
@@ -2055,8 +2056,8 @@ func TestSessionListingsExposeRecoveryAndContentDigests(t *testing.T) {
 	if len(ordered) != 1 {
 		t.Fatalf("ListSessionOrder len = %d, want 1", len(ordered))
 	}
-	if ordered[0].RecoveryDigest != meta.RecoveryDigest || ordered[0].ContentDigest != meta.ContentDigest {
-		t.Fatalf("ordered digests = recovery:%q content:%q, want recovery:%q content:%q", ordered[0].RecoveryDigest, ordered[0].ContentDigest, meta.RecoveryDigest, meta.ContentDigest)
+	if ordered[0].RecoveryDigest != meta.RecoveryDigest || ordered[0].ParentID != meta.ParentID {
+		t.Fatalf("ordered recovery metadata = digest:%q parent:%q, want digest:%q parent:%q", ordered[0].RecoveryDigest, ordered[0].ParentID, meta.RecoveryDigest, meta.ParentID)
 	}
 
 	listed, err := ListSessions(dir)
@@ -2066,8 +2067,8 @@ func TestSessionListingsExposeRecoveryAndContentDigests(t *testing.T) {
 	if len(listed) != 1 {
 		t.Fatalf("ListSessions len = %d, want 1", len(listed))
 	}
-	if listed[0].RecoveryDigest != meta.RecoveryDigest || listed[0].ContentDigest != meta.ContentDigest {
-		t.Fatalf("listed digests = recovery:%q content:%q, want recovery:%q content:%q", listed[0].RecoveryDigest, listed[0].ContentDigest, meta.RecoveryDigest, meta.ContentDigest)
+	if listed[0].RecoveryDigest != meta.RecoveryDigest || listed[0].ParentID != meta.ParentID {
+		t.Fatalf("listed recovery metadata = digest:%q parent:%q, want digest:%q parent:%q", listed[0].RecoveryDigest, listed[0].ParentID, meta.RecoveryDigest, meta.ParentID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Separate recovery provenance from cleanup eligibility with the optional `recoveryCopy` flag.
- Classify a cleanup copy only when the actual branch still matches its recovery digest and the live parent currently covers that content using the same equality/prefix/compatible-system rule as recovery GC.
- Use that shared agent-layer proof for project-tree visibility, topic migration/index repair, and History metadata.
- Revalidate actual branch and parent content in guarded backend methods before bulk trash or permanent copy purge.
- Hold the live parent's save and lease locks from permanent-purge validation through deletion; if the parent is open or being rewritten, preserve the copy and ask the caller to retry.
- Invalidate legacy topic migration/index markers before removing a live session so a formerly covered recovery branch becomes visible if its parent is later deleted.

## Root cause

The desktop treated recovery provenance as duplicate status. The first fix separated continued branches by comparing sidecar recovery/content digests, but equal sidecar digests only prove that the branch did not continue after the fork. They do not prove that the parent contains the branch tail, and stale sidecars can also disagree with the transcript.

A conflict fork can therefore have an unchanged recovery digest while preserving unique local history that diverges from the parent. Hiding or bulk-cleaning that branch would still lose access to user data.

Two follow-up races also needed closing: the parent could be rewound after coverage validation but before permanent deletion, and a completed one-shot migration marker could keep a recovery branch hidden after its parent was removed.

## User impact

Recovery branches remain normal visible history whenever their parent is missing or divergent, their transcript changed, or metadata is stale/corrupt. Only branches proven redundant from decoded transcript content enter compact grouping or copy cleanup. Bulk cleanup performs the same proof again in the backend. Permanent cleanup keeps the parent protected for the entire proof-to-delete window and refuses cleanup while that protection cannot be acquired.

## Safety and compatibility

| Contract | Behavior | Conclusion |
| --- | --- | --- |
| `BranchMeta.ContentDigest` | Remains optional for persistence, but is no longer trusted as cleanup authorization. | Conservative |
| Missing/diverged parent | `recoveryCopy` stays false; migration, visibility, trash, and purge preserve the branch. | Data preserving |
| Stale sidecar | Actual transcript digest must still equal `RecoveryDigest`; otherwise cleanup is rejected. | Data preserving |
| Concurrent parent update | Permanent purge holds the parent's save and lease locks from validation through deletion; a busy parent rejects cleanup. | Linearized and data preserving |
| Parent deleted after migration | Live-session removal invalidates migration and topic-index markers, so the next project-tree scan adopts the now-uncovered recovery branch. | History remains reachable |
| `SessionMeta.recoveryCopy` | Optional with `omitempty`; older/missing payloads become false and disable copy cleanup. | Backward compatible |
| Existing `recovered` field | Retained as provenance for badges and existing consumers. | Backward compatible |
| Session transcript format | No new transcript fields or message rewrites. | Unchanged |

## Regression coverage

- Parent covers the recovery branch.
- Parent diverges from the recovery branch.
- Parent is missing.
- Sidecar digest is stale after actual branch content changes.
- Backend bulk trash rejects unique content and accepts covered content.
- Backend permanent copy purge rejects unique content, rejects a live/busy parent while preserving trash, and accepts covered content once the parent is unlocked.
- A forced post-validation parent rewind cannot acquire the save lock until the recovery purge guard releases.
- An already-covered recovery branch is migrated into a visible topic after its migrated parent is deleted.
- Empty Trash remains separate from guarded copy cleanup.

## Verification

- `go test ./...`
- `go vet ./...`
- `cd desktop && go test .`
- `cd desktop && go vet .`
- `go test -race ./internal/agent -run 'TestRecoveryParentGuard|TestRecoveryBranchCoveredByParentReadsActualContent|TestReclaimableRecoveryBranches'`
- `cd desktop && go test -race . -run 'TestRecoveryCopyCleanupRevalidatesInBackend|TestCoveredRecoveryCopyBecomesVisibleAfterMigratedParentDeletion|TestUnmodifiedRecoveryCopyDoesNotMigrateIntoTopics|TestTrashPathsBlockedWhileLeaseHeld'`
- `cd desktop/frontend && npm test`
- `cd desktop/frontend && npm run build`
- `./scripts/check-cache-impact.sh`
- `git merge-tree --write-tree origin/main-v2 HEAD` plus the focused agent/desktop tests against that temporary merge tree.
