### PR TITLE
fix(desktop): keep prompt gates scoped during tab switches

### DIFF
--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -134,6 +134,7 @@ const tabE = tabMeta("tab-e");
 const tabF = tabMeta("tab-f");
 const tabG = tabMeta("tab-g");
 const tabH = tabMeta("tab-h");
+const tabI = tabMeta("tab-i", { running: true, pendingPrompt: true, cancellable: true });
 let backendActiveId = "tab-a";
 const historyB = deferred<HistoryMessage[]>();
 const historyD = deferred<HistoryMessage[]>();
@@ -153,9 +154,10 @@ let holdNextMetaForH = false;
 let holdNextHistoryForH = false;
 let setActiveCalls = 0;
 let newSessionCalls = 0;
+let replayPendingPromptCalls = 0;
 let failSetActiveFor = "";
 const runningTabs = new Set<string>();
-const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG, tabH].map((tab) => [tab.id, tab]));
+const tabsById = new Map([tabA, tabB, tabC, tabD, tabE, tabF, tabG, tabH, tabI].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
 const readyHandlers: Array<(tabId?: string) => void> = [];
 
@@ -236,7 +238,18 @@ window.go = {
         runningTabs.add("tab-e");
         return { ...tabE, active: true, running: true };
       },
-      ReplayPendingPrompts: async () => {},
+      ReplayPendingPrompts: async () => {
+        replayPendingPromptCalls += 1;
+        const active = tabsById.get(backendActiveId);
+        if (!active?.pendingPrompt) return;
+        for (const handler of eventHandlers) {
+          handler({
+            kind: "approval_request",
+            tabId: backendActiveId,
+            approval: { id: `pending-${backendActiveId}`, tool: "bash", subject: `pending ${backendActiveId}` },
+          });
+        }
+      },
       SetActiveTab: async (tabID: string) => {
         setActiveCalls += 1;
         if (tabID === "tab-b") await setActiveBGate.promise;
@@ -278,6 +291,13 @@ await act(async () => {
 });
 await waitFor("initial active tab", () => controller?.activeTabId === "tab-a" && controller.state.items.length === 1);
 
+await act(async () => {
+  for (const handler of eventHandlers) {
+    handler({ kind: "approval_request", tabId: "tab-b", approval: { id: "stale-tab-b", tool: "bash", subject: "stale tab B" } });
+  }
+  await flushPromises();
+});
+
 let switchToB: Promise<TabMeta[] | undefined> | undefined;
 await act(async () => {
   switchToB = controller?.switchTab("tab-b", tabB);
@@ -291,6 +311,17 @@ eq(controller?.state.items.length, 0, "uncached target tab does not keep the pre
 eq(controller?.state.hydrating, true, "target tab shows lightweight hydration state while backend activation is pending");
 eq(controller?.state.backendActivationPending, true, "target tab gates unscoped actions while backend activation is pending");
 ok(!historyCalls.includes("tab-b"), "HistoryForTab is not requested before SetActiveTab completes");
+eq(controller?.state.approval?.id, undefined, "tab activation clears a stale approval already stored on the target tab");
+eq(controller?.state.running, false, "tab activation clears the stale prompt lifecycle before backend status arrives");
+
+await act(async () => {
+  for (const handler of eventHandlers) {
+    handler({ kind: "approval_request", approval: { id: "old-backend-approval", tool: "bash", subject: "old backend approval" } });
+  }
+  await flushPromises();
+});
+eq(controller?.state.approval?.id, undefined, "tab-less events stay with the confirmed backend tab during optimistic activation");
+eq(controller?.state.running, false, "tab-less old-backend prompts cannot lock the optimistic target tab");
 
 let newSessionWhileSwitching: Promise<void> | undefined;
 await act(async () => {
@@ -372,6 +403,25 @@ await act(async () => {
   await flushPromises();
 });
 await waitFor("tab-a restored after backend-running switch", () => controller?.activeTabId === "tab-a" && controller.state.items.some((item) => item.kind === "user" && item.text === "cached A"));
+
+runningTabs.add("tab-i");
+const replayCallsBeforePendingSwitch = replayPendingPromptCalls;
+await act(async () => {
+  await controller?.switchTab("tab-i", tabI);
+  await flushPromises();
+});
+eq(controller?.activeTabId, "tab-i", "switching to a prompt-blocked tab activates the requested tab");
+ok(replayPendingPromptCalls > replayCallsBeforePendingSwitch, "pending backend prompts are replayed after tab activation");
+eq(controller?.state.approval?.id, "pending-tab-i", "a genuine pending approval survives the later hydration start");
+eq(controller?.state.running, true, "a genuine pending approval keeps the target tab running");
+tabsById.set("tab-i", { ...tabI, pendingPrompt: false, running: false, cancellable: false });
+runningTabs.delete("tab-i");
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-i" });
+  await controller?.switchTab("tab-a", tabA);
+  await flushPromises();
+});
+await waitFor("tab-a restored after pending-prompt switch", () => controller?.activeTabId === "tab-a" && controller.state.items.some((item) => item.kind === "user" && item.text === "cached A"));
 
 let switchToF: Promise<TabMeta[] | undefined> | undefined;
 await act(async () => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -966,7 +966,20 @@ export function reducer(s: State, a: Action): State {
       ? { ...s, hydrating: false, hydrateReason: undefined, hydrateError: undefined, hydrateHistoryLoaded: undefined, hydratePlaceholderItems: undefined }
       : s;
     case "hydrate_error": return { ...s, hydrating: false, hydrateReason: a.reason, hydrateError: a.error, hydrateHistoryLoaded: undefined, hydratePlaceholderItems: undefined };
-    case "backend_activation_start": return s.backendActivationPending ? s : { ...s, backendActivationPending: true };
+    case "backend_activation_start": return {
+      ...s,
+      // The target tab may contain a prompt event that was routed there while
+      // frontend selection was ahead of backend activation. Reset that
+      // uncertain lifecycle first; optimistic backend metadata is applied
+      // immediately afterwards and restores a genuinely running target.
+      backendActivationPending: true,
+      pendingPrompt: false,
+      approval: undefined,
+      ask: undefined,
+      running: false,
+      turnActive: false,
+      cancellable: false,
+    };
     case "backend_activation_done": return s.backendActivationPending ? { ...s, backendActivationPending: false } : s;
     case "message_action_start": return { ...s, messageAction: a.action };
     case "message_action_done": return { ...s, messageAction: undefined };
@@ -1690,7 +1703,11 @@ export function useController() {
       for (const { tabId, e } of batch) dispatchTo(tabId, { type: "event", e });
     });
     const off = onEvent((e) => {
-      const targetTabId = e.tabId || activeTabIdRef.current;
+      // Untagged compatibility events belong to the tab that the backend has
+      // actually activated, not the frontend's optimistic selection. During a
+      // slow SetActiveTab these can differ, and routing to the optimistic tab
+      // leaks the previous session's approval/ask gate into the new composer.
+      const targetTabId = e.tabId || backendActiveTabIdRef.current || activeTabIdRef.current;
       if (!targetTabId) return;
       if (
         e.kind === "turn_started" ||


### PR DESCRIPTION
## Summary

- route legacy controller events without `tabId` to the backend-confirmed tab while frontend tab selection is optimistic
- clear uncertain approval/ask lifecycle state at backend activation start, before applying authoritative target-tab metadata
- preserve a genuinely running target tab and replayed pending approvals through the later hydration step
- add race regressions for slow tab activation, stale target prompts, tab-less old-session events, and genuine pending prompt replay

## Root cause

The frontend selects a tab optimistically before asynchronous `SetActiveTab` completes. During that window, `activeTabIdRef` points to the new frontend tab while the backend is still emitting compatibility events for the previous tab.

Events without an explicit `tabId` were routed through `activeTabIdRef`, so an approval/ask event from the old backend session could be stored on the newly selected session. That stale prompt gate disabled the new composer and looked like the input was permanently locked.

## Why this implementation

A blanket reset in `hydrate_start` can erase valid state: backend activation may already have restored a running/cancellable target or replayed a genuine pending prompt before later history hydration begins.

This change resets only the uncertain lifecycle at activation start, then lets authoritative target metadata and prompt replay restore genuine state. Untagged events remain attached to the backend-confirmed tab until activation finishes.

## Validation

- `pnpm exec tsc --noEmit -p tsconfig.test.json`
- `tab-switch-hydration.test.tsx`: 69 passed
- controller lifecycle suites: 114 passed
- post-integration workspace/composer/approval/navigation suites: 203 passed
- full frontend suite passed under a runtime compatible with CI's Node version
- `git diff --check`

## Attribution

This is a race-safe follow-up to #6229 and incorporates the diagnosis and scenario contributed by @ttmouse. The commit includes a `Co-authored-by` trailer.

Follow-up to #6281.

Fixes #5951
