### PR TITLE
fix(tool): list V5 event session turns

### DIFF
--- a/internal/tool/sessiontool/sessiontool.go
+++ b/internal/tool/sessiontool/sessiontool.go
@@ -1,6 +1,6 @@
 // Package sessiontool provides list_sessions and read_session tools that let
 // the AI discover and read past conversation sessions, enabling cross-session
-// AI context sharing. The tools reuse agent.ListSessionOrder, agent.LoadSession,
+// AI context sharing. The tools reuse agent.ListSessions, agent.LoadSession,
 // and agent.IsCleanupPending — the same infrastructure used by the history
 // tool and session picker — to avoid duplicating session-file logic.
 package sessiontool
@@ -40,24 +40,23 @@ func (t *listSessionsTool) Schema() json.RawMessage {
 }
 
 func (t *listSessionsTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
-	ordered, err := agent.ListSessionOrder(t.sessionDir)
+	sessions, err := agent.ListSessions(t.sessionDir)
 	if err != nil {
 		return "", fmt.Errorf("list_sessions: %w", err)
 	}
-	if len(ordered) == 0 {
+	if len(sessions) == 0 {
 		return "No sessions found.\n", nil
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "# Saved Sessions (%d total)\n\n", len(ordered))
+	fmt.Fprintf(&b, "# Saved Sessions (%d total)\n\n", len(sessions))
 	b.WriteString("| # | Timestamp | Model | Turns | Preview | File\n")
 	b.WriteString("|---|-----------|-------|-------|-----------------|-----\n")
-	for i, s := range ordered {
+	for i, s := range sessions {
 		ts := s.LastActivityAt.Format("2006-01-02 15:04")
 		model := modelFromPath(s.Path)
-		preview, turns := agent.SessionPreview(s.Path)
 		fmt.Fprintf(&b, "| %d | %s | %s | %d | %s | `%s`\n",
-			i+1, ts, model, turns, preview, filepath.Base(s.Path))
+			i+1, ts, model, s.Turns, s.Preview, filepath.Base(s.Path))
 	}
 	b.WriteString("\nUse `read_session` with the filename under \"File\" to view the session.\n")
 	return b.String(), nil

--- a/internal/tool/sessiontool/sessiontool_test.go
+++ b/internal/tool/sessiontool/sessiontool_test.go
@@ -3,6 +3,7 @@ package sessiontool
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -106,6 +107,32 @@ func TestListSessions_SingleSession(t *testing.T) {
 	}
 	if !strings.Contains(out, "1 turn") && !strings.Contains(out, "| 1 |") {
 		t.Errorf("expected turn count in output, got: %s", out)
+	}
+}
+
+func TestListSessions_UsesSidecarCountsForV5EventBackedSession(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "20260708-120000.000000000-deepseek-chat.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty checkpoint: %v", err)
+	}
+	if err := agent.SaveBranchMeta(sessionPath, agent.BranchMeta{
+		ID:            agent.BranchID(sessionPath),
+		Preview:       "cached V5 prompt",
+		Turns:         8,
+		SchemaVersion: agent.BranchMetaCountsVersion,
+	}); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+
+	tool := NewListSessionsTool(dir)
+	out := runTool(t, tool, map[string]any{})
+
+	if !strings.Contains(out, "| 8 |") {
+		t.Fatalf("expected sidecar turn count in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "cached V5 prompt") {
+		t.Fatalf("expected sidecar preview in output, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Problem:
- list_sessions decoded V5 event-backed sessions from the empty checkpoint file, so sessions with sidecar counts could show turns=0 and no preview.

Change:
- Reuse agent.ListSessions for list_sessions output so the tool uses the same sidecar-backed turns/preview path as resume/history.
- Add regression coverage for an empty checkpoint with counts-aware branch metadata.

Cache-impact: low - list_sessions now reads the existing ListSessions metadata path; this does not change cache schema or write behavior.
Cache-guard: go test ./internal/tool/sessiontool -count=1

Verification:
- go test ./internal/tool/sessiontool -count=1
- go test ./internal/agent -run TestListSessions|TestSessionPreviewFromMessages|TestLoadSessionUserMessagesSeesEventLogTurns -count=1