### PR TITLE
fix(mcp): forward MCP tool result images to vision models / 将 MCP 工具结果图片结构化传给视觉模型

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1231,11 +1231,12 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			return &maxStepsPause{steps: a.maxSteps, key: a.maxStepsKey}
 		}
 
-		results := a.executeBatch(ctx, calls)
+		results, images := a.executeBatch(ctx, calls)
 		for i, call := range calls {
 			a.session.Add(provider.Message{
 				Role:       provider.RoleTool,
 				Content:    results[i],
+				Images:     images[i],
 				ToolCallID: call.ID,
 				Name:       call.Name,
 			})
@@ -1964,8 +1965,9 @@ func (a *Agent) systemPrompt() string {
 // goroutines; unknown and writer calls run as single-call serial segments so
 // write/read ordering stays provider-ordered. ToolResult events are emitted
 // after the batch in call order, so emission stays serial even when execution
-// parallelised.
-func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []string {
+// parallelised. The second return carries each call's tool-result images (nil
+// for most calls), aligned by index with the first.
+func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) ([]string, [][]string) {
 	for _, c := range calls {
 		t, ok := a.tools.Get(c.Name)
 		ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly()}
@@ -2092,7 +2094,11 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	if !cancelled {
 		a.applyStormBreaker(calls, outcomes, results, receiptMark)
 	}
-	return results
+	images := make([][]string, len(calls))
+	for i := range outcomes {
+		images[i] = outcomes[i].images
+	}
+	return results, images
 }
 
 func (a *Agent) withPreviewFileDiffs(calls []provider.ToolCall) []provider.ToolCall {
@@ -2331,9 +2337,12 @@ func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (str
 // success) — a refused call, an unknown tool, or an execution error — so a sink
 // renders the result as failed ("⊘ name <errMsg>" / a red card) instead of OK;
 // blocked narrows that to a refusal (plan mode / permission). truncMsg is set
-// (without the "· " prefix) when the output was head+tailed.
+// (without the "· " prefix) when the output was head+tailed. images carries
+// data URLs from a tool.ImageTool result; they ride outside output so text
+// truncation can never corrupt an image payload.
 type toolOutcome struct {
 	output    string
+	images    []string
 	blocked   bool
 	errMsg    string
 	truncated bool
@@ -2488,7 +2497,14 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	cctx = tool.WithProgress(cctx, func(chunk string) {
 		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: secrets.RedactToolOutput(chunk)}})
 	})
-	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
+	var result string
+	var images []string
+	var err error
+	if it, ok := t.(tool.ImageTool); ok {
+		result, images, err = it.ExecuteWithImages(cctx, json.RawMessage(call.Arguments))
+	} else {
+		result, err = t.Execute(cctx, json.RawMessage(call.Arguments))
+	}
 	result = secrets.RedactToolOutput(result)
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
@@ -2530,7 +2546,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		a.hooks.SubagentStop(ctx, result)
 	}
 	body, truncMsg := truncateToolOutput(result)
-	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
+	return toolOutcome{output: body, images: images, truncated: truncMsg != "", truncMsg: truncMsg}
 }
 
 func (a *Agent) checkPlanModeMCPReadOnlyTrust(ctx context.Context, call provider.ToolCall, t tool.Tool) (bool, toolOutcome, bool) {

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -231,7 +231,7 @@ func TestExecuteBatchParallelReadOnly(t *testing.T) {
 	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
 
 	start := time.Now()
-	results := a.executeBatch(context.Background(), []provider.ToolCall{{Name: "a"}, {Name: "b"}, {Name: "c"}})
+	results, _ := a.executeBatch(context.Background(), []provider.ToolCall{{Name: "a"}, {Name: "b"}, {Name: "c"}})
 	elapsed := time.Since(start)
 
 	if calls != 3 {
@@ -264,7 +264,7 @@ func TestExecuteBatchSegmentsAroundWrites(t *testing.T) {
 	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
 
 	start := time.Now()
-	results := a.executeBatch(context.Background(), []provider.ToolCall{
+	results, _ := a.executeBatch(context.Background(), []provider.ToolCall{
 		{Name: "ro1"},
 		{Name: "ro2"},
 		{Name: "rw"},
@@ -302,7 +302,7 @@ func TestExecuteBatchFeedsReceiptsToCompleteStep(t *testing.T) {
 	reg.Add(completeStep)
 	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
 
-	results := a.executeBatch(context.Background(), []provider.ToolCall{
+	results, _ := a.executeBatch(context.Background(), []provider.ToolCall{
 		{Name: "bash", Arguments: `{"command":"go test ./internal/..."}`},
 		{Name: "complete_step", Arguments: `{
 			"step":"Run checks",

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -61,7 +61,7 @@ func TestStormBreakerEscalatesRepeatedFailure(t *testing.T) {
 	var last string
 	for i := 0; i < stormBreakThreshold; i++ {
 		call := provider.ToolCall{Name: "write_file", Arguments: args[i]}
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = executeBatchOutputs(a, context.Background(), []provider.ToolCall{call})[0]
 	}
 
 	if !strings.Contains(last, "[loop guard]") {
@@ -99,7 +99,7 @@ func TestStormBreakerEscalatesRepeatedBlockedPermission(t *testing.T) {
 	var last string
 	for i := 0; i < stormBreakThreshold; i++ {
 		call := provider.ToolCall{Name: "bash", Arguments: args[i]}
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = executeBatchOutputs(a, context.Background(), []provider.ToolCall{call})[0]
 	}
 
 	if !strings.Contains(last, "[loop guard]") {
@@ -133,7 +133,7 @@ func TestStormBreakerEscalatesAlternatingBlockedShapes(t *testing.T) {
 	}
 	var last string
 	for _, call := range calls {
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = executeBatchOutputs(a, context.Background(), []provider.ToolCall{call})[0]
 	}
 
 	if !strings.Contains(last, "[loop guard]") {
@@ -165,7 +165,7 @@ func TestStormBreakerBlockedStreakResetBySuccess(t *testing.T) {
 	}
 	var last string
 	for _, call := range calls {
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = executeBatchOutputs(a, context.Background(), []provider.ToolCall{call})[0]
 	}
 
 	if strings.Contains(last, "[loop guard]") {
@@ -192,7 +192,7 @@ func TestStormBreakerEscalatesRepeatedBatch(t *testing.T) {
 	}
 	var first string
 	for i := 0; i < stormBreakThreshold; i++ {
-		first = a.executeBatch(context.Background(), batch)[0]
+		first = executeBatchOutputs(a, context.Background(), batch)[0]
 	}
 
 	if !strings.Contains(first, "[loop guard]") {
@@ -222,7 +222,7 @@ func TestStormBreakerBatchResetsOnPartialSuccess(t *testing.T) {
 	}
 	var first string
 	for i := 0; i < stormBreakThreshold+2; i++ {
-		first = a.executeBatch(context.Background(), batch)[0]
+		first = executeBatchOutputs(a, context.Background(), batch)[0]
 	}
 
 	if strings.Contains(first, "[loop guard]") {
@@ -244,7 +244,7 @@ func TestStormBreakerSilentBelowThreshold(t *testing.T) {
 	call := provider.ToolCall{Name: "write_file", Arguments: `{"content":"x`}
 	var last string
 	for i := 0; i < stormBreakThreshold-1; i++ {
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = executeBatchOutputs(a, context.Background(), []provider.ToolCall{call})[0]
 	}
 
 	if strings.Contains(last, "[loop guard]") {
@@ -268,11 +268,11 @@ func TestStormBreakerResetsOnSuccess(t *testing.T) {
 	good := provider.ToolCall{Name: "read_file", Arguments: `{"path":"x"}`}
 	ctx := context.Background()
 
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 2
-	a.executeBatch(ctx, []provider.ToolCall{good})            // success → reset
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
-	last := a.executeBatch(ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 2
+	a.executeBatch(ctx, []provider.ToolCall{good})                    // success → reset
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 1
+	last := executeBatchOutputs(a, ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
 
 	if strings.Contains(last, "[loop guard]") {
 		t.Fatalf("guard should have reset after a successful turn, got: %q", last)
@@ -280,4 +280,10 @@ func TestStormBreakerResetsOnSuccess(t *testing.T) {
 	if len(*notices) != 0 {
 		t.Errorf("no notice expected when a success breaks the run, got %v", *notices)
 	}
+}
+
+// executeBatchOutputs runs the batch and returns just the model-facing outputs.
+func executeBatchOutputs(a *Agent, ctx context.Context, calls []provider.ToolCall) []string {
+	outputs, _ := a.executeBatch(ctx, calls)
+	return outputs
 }

--- a/internal/agent/toolimages_test.go
+++ b/internal/agent/toolimages_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// fakeImageTool implements tool.ImageTool: text and images travel on separate
+// channels, like an MCP remote tool returning a screenshot.
+type fakeImageTool struct {
+	text   string
+	images []string
+}
+
+func (f *fakeImageTool) Name() string            { return "shot" }
+func (f *fakeImageTool) Description() string     { return "returns a screenshot" }
+func (f *fakeImageTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (f *fakeImageTool) ReadOnly() bool          { return true }
+func (f *fakeImageTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	text, _, err := f.ExecuteWithImages(ctx, args)
+	return text, err
+}
+func (f *fakeImageTool) ExecuteWithImages(ctx context.Context, args json.RawMessage) (string, []string, error) {
+	return f.text, f.images, nil
+}
+
+// Tool-result images must reach the session message intact even when the text
+// output blows the truncation budget: the head+tail splice that trims tool text
+// would corrupt a base64 payload, so images ride outside the truncated text.
+func TestToolResultImagesBypassTruncation(t *testing.T) {
+	dataURL := "data:image/png;base64," + strings.Repeat("QUFB", 20000) // ~80KB payload, alone over the text budget
+	longText := strings.Repeat("x", maxToolOutputBytes+1024) + "[image: image/png]"
+	reg := tool.NewRegistry()
+	reg.Add(&fakeImageTool{text: longText, images: []string{dataURL}})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "shot", `{}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "take a screenshot"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var msg *provider.Message
+	for i := range a.session.Messages {
+		if a.session.Messages[i].Role == provider.RoleTool && a.session.Messages[i].Name == "shot" {
+			msg = &a.session.Messages[i]
+			break
+		}
+	}
+	if msg == nil {
+		t.Fatal("no tool message recorded for shot")
+	}
+	if len(msg.Images) != 1 || msg.Images[0] != dataURL {
+		t.Fatalf("tool message images corrupted or missing: got %d images", len(msg.Images))
+	}
+	if len(msg.Content) > maxToolOutputBytes+1024 || !strings.Contains(msg.Content, "truncated") {
+		t.Fatalf("tool text should be head+tail truncated, len=%d", len(msg.Content))
+	}
+	if strings.Contains(msg.Content, dataURL) {
+		t.Fatal("image payload must not be embedded in the tool text")
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -8,6 +8,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1328,10 +1329,18 @@ func (t *remoteTool) Schema() json.RawMessage {
 }
 
 func (t *remoteTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	text, _, err := t.ExecuteWithImages(ctx, args)
+	return text, err
+}
+
+// ExecuteWithImages implements tool.ImageTool: MCP results may carry image
+// content items, which callers with a structural image channel (the agent)
+// forward to vision models instead of relying on the text placeholders alone.
+func (t *remoteTool) ExecuteWithImages(ctx context.Context, args json.RawMessage) (string, []string, error) {
 	var argMap map[string]any
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &argMap); err != nil {
-			return "", fmt.Errorf("invalid args: %w", err)
+			return "", nil, fmt.Errorf("invalid args: %w", err)
 		}
 	}
 	res, err := t.client.call(ctx, "tools/call", map[string]any{
@@ -1339,32 +1348,97 @@ func (t *remoteTool) Execute(ctx context.Context, args json.RawMessage) (string,
 		"arguments": argMap,
 	})
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	return parseToolResult(res)
 }
 
-// parseToolResult flattens an MCP tools/call result into plain text.
-func parseToolResult(res json.RawMessage) (string, error) {
+// Tool-result images are forwarded to vision models as base64 data URLs, so
+// each item is validated and budgeted here rather than trusted from the MCP
+// server: payloads that are oversized, unparseable, beyond the per-result
+// count, or of a mime type outside the set every supported vision API accepts
+// are replaced with a text placeholder instead of poisoning the provider
+// request.
+const (
+	maxToolResultImageBytes = 4 << 20 // base64 length; stays under provider per-image and request caps
+	maxToolResultImages     = 5
+)
+
+var toolResultImageMimes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// parseToolResult flattens an MCP tools/call result into plain text plus the
+// image content items as data URLs. Every image item leaves a short placeholder
+// in the text at its position, so text-only consumers (and non-vision models)
+// still learn an image was returned.
+func parseToolResult(res json.RawMessage) (string, []string, error) {
 	var out struct {
 		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
+			Type     string `json:"type"`
+			Text     string `json:"text"`
+			Data     string `json:"data"`
+			MimeType string `json:"mimeType"`
 		} `json:"content"`
 		IsError bool `json:"isError"`
 	}
 	if err := json.Unmarshal(res, &out); err != nil {
-		return "", fmt.Errorf("decode tool result: %w", err)
+		return "", nil, fmt.Errorf("decode tool result: %w", err)
 	}
 	var sb strings.Builder
+	var images []string
 	for _, c := range out.Content {
-		if c.Type == "text" {
+		switch c.Type {
+		case "text":
 			sb.WriteString(c.Text)
+		case "image":
+			placeholder, url := toolResultImage(c.MimeType, c.Data, len(images))
+			sb.WriteString(placeholder)
+			if url != "" {
+				images = append(images, url)
+			}
 		}
 	}
 	text := sb.String()
 	if out.IsError {
-		return text, fmt.Errorf("plugin tool reported error: %s", text)
+		return text, images, fmt.Errorf("plugin tool reported error: %s", text)
 	}
-	return text, nil
+	return text, images, nil
+}
+
+// toolResultImage validates one MCP image content item and returns its text
+// placeholder plus the data URL to forward ("" when the item is dropped).
+func toolResultImage(mime, data string, kept int) (placeholder, url string) {
+	if kept >= maxToolResultImages {
+		return "[image omitted: per-result image limit reached]", ""
+	}
+	mime = strings.ToLower(strings.TrimSpace(mime))
+	if mime == "" {
+		mime = "image/png"
+	}
+	if !toolResultImageMimes[mime] {
+		return "[image omitted: unsupported type " + mime + "]", ""
+	}
+	// Some servers wrap base64 in whitespace; vision APIs reject non-canonical
+	// payloads, so normalize before validating.
+	data = strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t', ' ':
+			return -1
+		}
+		return r
+	}, data)
+	if data == "" {
+		return "[image omitted: no data]", ""
+	}
+	if len(data) > maxToolResultImageBytes {
+		return fmt.Sprintf("[image omitted: %d bytes exceeds the %d-byte limit]", len(data), maxToolResultImageBytes), ""
+	}
+	if _, err := base64.StdEncoding.DecodeString(data); err != nil {
+		return "[image omitted: invalid base64]", ""
+	}
+	return "[image: " + mime + "]", "data:" + mime + ";base64," + data
 }

--- a/internal/plugin/toolresult_image_test.go
+++ b/internal/plugin/toolresult_image_test.go
@@ -1,0 +1,135 @@
+package plugin
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func imageItem(mime, data string) string {
+	b, _ := json.Marshal(map[string]string{"type": "image", "data": data, "mimeType": mime})
+	return string(b)
+}
+
+func TestParseToolResultImageItem(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+	res := `{"content":[{"type":"text","text":"before "},` + imageItem("image/png", payload) + `,{"type":"text","text":" after"}]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if want := "before [image: image/png] after"; text != want {
+		t.Fatalf("text = %q, want %q", text, want)
+	}
+	if len(images) != 1 || images[0] != "data:image/png;base64,"+payload {
+		t.Fatalf("images = %v, want one png data URL", images)
+	}
+}
+
+func TestParseToolResultImageDefaultsToPNG(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("x"))
+	res := `{"content":[{"type":"image","data":"` + payload + `"}]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if text != "[image: image/png]" {
+		t.Fatalf("text = %q, want png placeholder", text)
+	}
+	if len(images) != 1 || !strings.HasPrefix(images[0], "data:image/png;base64,") {
+		t.Fatalf("images = %v, want png data URL", images)
+	}
+}
+
+func TestParseToolResultImageNormalizesWrappedBase64(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+	wrapped := payload[:4] + "\n" + payload[4:8] + " " + payload[8:]
+	res := `{"content":[` + imageItem("image/png", wrapped) + `]}`
+	_, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if len(images) != 1 || images[0] != "data:image/png;base64,"+payload {
+		t.Fatalf("images = %v, want whitespace stripped to %q", images, payload)
+	}
+}
+
+func TestParseToolResultImageInvalidBase64Omitted(t *testing.T) {
+	res := `{"content":[` + imageItem("image/png", "not-base64!!") + `]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want none for invalid base64", images)
+	}
+	if !strings.Contains(text, "invalid base64") {
+		t.Fatalf("text = %q, want invalid-base64 placeholder", text)
+	}
+}
+
+func TestParseToolResultImageUnsupportedMimeOmitted(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("bmp"))
+	res := `{"content":[` + imageItem("image/bmp", payload) + `]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want none for unsupported mime", images)
+	}
+	if !strings.Contains(text, "unsupported type image/bmp") {
+		t.Fatalf("text = %q, want unsupported-type placeholder", text)
+	}
+}
+
+func TestParseToolResultImageOversizedOmitted(t *testing.T) {
+	// Valid base64 alphabet, over the byte budget.
+	big := strings.Repeat("QUFB", maxToolResultImageBytes/4+1)
+	res := `{"content":[` + imageItem("image/png", big) + `]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if len(images) != 0 {
+		t.Fatalf("got %d images, want none for oversized payload", len(images))
+	}
+	if !strings.Contains(text, "exceeds") {
+		t.Fatalf("text = %q, want oversize placeholder", text)
+	}
+}
+
+func TestParseToolResultImageCountCapped(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("x"))
+	items := make([]string, 0, maxToolResultImages+1)
+	for i := 0; i < maxToolResultImages+1; i++ {
+		items = append(items, imageItem("image/png", payload))
+	}
+	res := `{"content":[` + strings.Join(items, ",") + `]}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err != nil {
+		t.Fatalf("parseToolResult: %v", err)
+	}
+	if len(images) != maxToolResultImages {
+		t.Fatalf("got %d images, want cap of %d", len(images), maxToolResultImages)
+	}
+	if !strings.Contains(text, "image limit reached") {
+		t.Fatalf("text = %q, want limit placeholder for the overflow item", text)
+	}
+}
+
+func TestParseToolResultErrorStillReturnsImages(t *testing.T) {
+	payload := base64.StdEncoding.EncodeToString([]byte("x"))
+	res := `{"content":[{"type":"text","text":"boom "},` + imageItem("image/png", payload) + `],"isError":true}`
+	text, images, err := parseToolResult(json.RawMessage(res))
+	if err == nil {
+		t.Fatal("want error for isError result")
+	}
+	if !strings.Contains(text, "boom") || !strings.Contains(text, "[image: image/png]") {
+		t.Fatalf("text = %q, want text and placeholder preserved", text)
+	}
+	if len(images) != 1 {
+		t.Fatalf("images = %v, want the image parsed even on error", images)
+	}
+}

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -270,7 +270,13 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 			if content == "" {
 				content = "(no output)" // tool_result content must be non-empty
 			}
-			appendBlocks("user", contentBlock{Type: "tool_result", ToolUseID: m.ToolCallID, Content: content})
+			block := contentBlock{Type: "tool_result", ToolUseID: m.ToolCallID, Content: content}
+			if c.vision {
+				if blocks := toolResultBlocks(content, m.Images); blocks != nil {
+					block.Content = blocks
+				}
+			}
+			appendBlocks("user", block)
 		case provider.RoleAssistant:
 			var blocks []contentBlock
 			// Replay the signed thinking block first (Anthropic requires it precede
@@ -609,7 +615,7 @@ type contentBlock struct {
 	Name         string          `json:"name,omitempty"`        // tool_use
 	Input        json.RawMessage `json:"input,omitempty"`       // tool_use
 	ToolUseID    string          `json:"tool_use_id,omitempty"` // tool_result
-	Content      string          `json:"content,omitempty"`     // tool_result
+	Content      any             `json:"content,omitempty"`     // tool_result: string, or []contentBlock when the result carries images
 	Source       *imageSource    `json:"source,omitempty"`      // image
 	CacheControl *cacheControl   `json:"cache_control,omitempty"`
 }
@@ -618,6 +624,23 @@ type imageSource struct {
 	Type      string `json:"type"` // "base64"
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`
+}
+
+// toolResultBlocks builds array content for a tool_result whose message carries
+// images: the text first, then one image block per parseable data URL. It
+// returns nil when nothing parses, so text-only results keep plain string
+// content — byte-identical serialization to previous releases.
+func toolResultBlocks(text string, images []string) []contentBlock {
+	var imgs []contentBlock
+	for _, url := range images {
+		if mt, data, ok := provider.ParseImageDataURL(url); ok {
+			imgs = append(imgs, contentBlock{Type: "image", Source: &imageSource{Type: "base64", MediaType: mt, Data: data}})
+		}
+	}
+	if imgs == nil {
+		return nil
+	}
+	return append([]contentBlock{{Type: "text", Text: text}}, imgs...)
 }
 
 type anthTool struct {

--- a/internal/provider/anthropic/image_test.go
+++ b/internal/provider/anthropic/image_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"encoding/json"
 	"testing"
 
 	"reasonix/internal/provider"
@@ -33,5 +34,76 @@ func TestBuildRequestSkipsImageBlockWithoutVision(t *testing.T) {
 	blocks := req.Messages[0].Content
 	if len(blocks) != 1 || blocks[0].Type != "text" {
 		t.Fatalf("blocks = %+v, want [text] only when vision is off", blocks)
+	}
+}
+
+// toolMessages is a paired history whose tool result carries an image: the
+// shape parseToolResult produces for an MCP screenshot tool.
+func toolMessages(images []string) []provider.Message {
+	return []provider.Message{
+		{Role: provider.RoleUser, Content: "screenshot please"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "shot", Arguments: "{}"}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "shot", Content: "[image: image/png]", Images: images},
+	}
+}
+
+func TestBuildRequestEmbedsToolResultImagesForVisionModel(t *testing.T) {
+	c := &client{model: "claude-opus-4-8", vision: true}
+	req := c.buildRequest(provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
+	last := req.Messages[len(req.Messages)-1]
+	if last.Role != "user" || len(last.Content) != 1 || last.Content[0].Type != "tool_result" {
+		t.Fatalf("last message = %+v, want a single tool_result block", last)
+	}
+	blocks, ok := last.Content[0].Content.([]contentBlock)
+	if !ok {
+		t.Fatalf("tool_result content = %T, want []contentBlock", last.Content[0].Content)
+	}
+	if len(blocks) != 2 || blocks[0].Type != "text" || blocks[1].Type != "image" {
+		t.Fatalf("tool_result blocks = %+v, want [text, image]", blocks)
+	}
+	if blocks[0].Text != "[image: image/png]" {
+		t.Fatalf("text block = %q, want the placeholder text", blocks[0].Text)
+	}
+	src := blocks[1].Source
+	if src == nil || src.Type != "base64" || src.MediaType != "image/png" || src.Data != "QUFB" {
+		t.Fatalf("image source = %+v, want base64 / image/png / QUFB", src)
+	}
+}
+
+func TestBuildRequestDropsToolResultImagesWithoutVision(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"} // vision unset
+	req := c.buildRequest(provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
+	last := req.Messages[len(req.Messages)-1]
+	if s, ok := last.Content[0].Content.(string); !ok || s != "[image: image/png]" {
+		t.Fatalf("non-vision tool_result content = %#v, want the plain placeholder string", last.Content[0].Content)
+	}
+}
+
+// A text-only tool result must keep serializing exactly as before the image
+// channel existed: plain string content, no array — the prompt-cache prefix of
+// existing sessions depends on those bytes.
+func TestBuildRequestToolResultTextOnlyKeepsStringContent(t *testing.T) {
+	c := &client{model: "claude-opus-4-8", vision: true}
+	msgs := toolMessages(nil)
+	msgs[2].Content = "plain output"
+	// Trailing user turn merges after the tool_result in the same user message
+	// and takes the cache breakpoint, so the tool_result block keeps its
+	// pre-image-channel bytes.
+	msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: "next"})
+	req := c.buildRequest(provider.Request{Messages: msgs})
+	last := req.Messages[len(req.Messages)-1]
+	if len(last.Content) != 2 || last.Content[0].Type != "tool_result" {
+		t.Fatalf("last message blocks = %+v, want [tool_result, text]", last.Content)
+	}
+	if s, ok := last.Content[0].Content.(string); !ok || s != "plain output" {
+		t.Fatalf("tool_result content = %#v, want plain string", last.Content[0].Content)
+	}
+	body, err := json.Marshal(last.Content[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"type":"tool_result","tool_use_id":"c1","content":"plain output"}`
+	if string(body) != want {
+		t.Fatalf("serialized tool_result = %s, want %s", body, want)
 	}
 }

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -68,3 +68,79 @@ func TestImageURLDetailOmittedByDefault(t *testing.T) {
 		t.Errorf("detail must be omitted when unset: %s", body)
 	}
 }
+
+// Tool-result images can't ride in the tool message itself (the OpenAI API
+// accepts only text parts under role "tool"), so buildRequest injects them as
+// a user message after the turn's full run of tool results.
+func TestBuildRequestInjectsToolImagesAsUserMessage(t *testing.T) {
+	c := &client{model: "gpt-4o", vision: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "screenshot please"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+				{ID: "c1", Name: "shot", Arguments: "{}"},
+				{ID: "c2", Name: "shot", Arguments: "{}"},
+			}},
+			{Role: provider.RoleTool, ToolCallID: "c1", Name: "shot", Content: "[image: image/png]", Images: []string{"data:image/png;base64,AAAA"}},
+			{Role: provider.RoleTool, ToolCallID: "c2", Name: "shot", Content: "no image"},
+			{Role: provider.RoleUser, Content: "and?"},
+		},
+	})
+	if len(req.Messages) != 6 {
+		t.Fatalf("got %d messages, want 6 (images injected after the tool run)", len(req.Messages))
+	}
+	for i, m := range req.Messages[2:4] {
+		if _, ok := m.Content.(string); !ok || m.Role != "tool" {
+			t.Fatalf("message %d = %+v, want tool message with plain string content", i+2, m)
+		}
+	}
+	inj := req.Messages[4]
+	if inj.Role != "user" {
+		t.Fatalf("injected message role = %q, want user between tool run and next turn", inj.Role)
+	}
+	parts, ok := inj.Content.([]chatContentPart)
+	if !ok || len(parts) != 2 || parts[0].Type != "text" || parts[1].Type != "image_url" {
+		t.Fatalf("injected content = %#v, want [text, image_url]", inj.Content)
+	}
+	if parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,AAAA" {
+		t.Fatalf("image_url = %+v, want the tool image data URL", parts[1].ImageURL)
+	}
+	if req.Messages[5].Content != "and?" {
+		t.Fatalf("trailing user message displaced: %+v", req.Messages[5])
+	}
+}
+
+func TestBuildRequestFlushesTrailingToolImages(t *testing.T) {
+	c := &client{model: "gpt-4o", vision: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "go"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "shot", Arguments: "{}"}}},
+			{Role: provider.RoleTool, ToolCallID: "c1", Name: "shot", Content: "[image: image/png]", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	last := req.Messages[len(req.Messages)-1]
+	if last.Role != "user" {
+		t.Fatalf("last message = %+v, want the injected image user message", last)
+	}
+	if _, ok := last.Content.([]chatContentPart); !ok {
+		t.Fatalf("last content = %#v, want content parts", last.Content)
+	}
+}
+
+func TestBuildRequestSkipsToolImagesWithoutVision(t *testing.T) {
+	c := &client{model: "deepseek-v4"} // vision unset
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "go"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "shot", Arguments: "{}"}}},
+			{Role: provider.RoleTool, ToolCallID: "c1", Name: "shot", Content: "[image: image/png]", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	if len(req.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3 (no injection without vision)", len(req.Messages))
+	}
+	if s, ok := req.Messages[2].Content.(string); !ok || s != "[image: image/png]" {
+		t.Fatalf("tool content = %#v, want the plain placeholder string", req.Messages[2].Content)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -452,8 +452,27 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 	// carry an assistant tool_calls turn whose results never landed, which DeepSeek
 	// rejects with a 400 ("must be followed by tool messages …").
 	src := provider.SanitizeToolPairing(req.Messages)
-	msgs := make([]chatMessage, len(src))
-	for i, m := range src {
+	msgs := make([]chatMessage, 0, len(src))
+	// Images returned by tool calls can't ride in the tool message itself — the
+	// OpenAI API accepts only text content parts under role "tool" — so they are
+	// carried by a synthetic user message injected after the turn's full run of
+	// tool results, before the next non-tool message (splitting a tool-result
+	// run would break the API's tool-call pairing validation).
+	var pendingToolImages []string
+	flushToolImages := func() {
+		if len(pendingToolImages) == 0 {
+			return
+		}
+		msgs = append(msgs, chatMessage{
+			Role:    "user",
+			Content: imageContentParts("Images returned by the preceding tool call(s):", pendingToolImages, c.visionDetail),
+		})
+		pendingToolImages = nil
+	}
+	for _, m := range src {
+		if m.Role != provider.RoleTool {
+			flushToolImages()
+		}
 		cm := chatMessage{
 			Role:       string(m.Role),
 			ToolCallID: m.ToolCallID,
@@ -487,8 +506,12 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		case m.Role != provider.RoleAssistant || len(cm.ToolCalls) == 0 || m.Content != "":
 			cm.Content = m.Content
 		}
-		msgs[i] = cm
+		msgs = append(msgs, cm)
+		if c.vision && m.Role == provider.RoleTool {
+			pendingToolImages = append(pendingToolImages, m.Images...)
+		}
 	}
+	flushToolImages()
 
 	var tools []chatTool
 	for _, t := range req.Tools {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,7 @@ const (
 type Message struct {
 	Role             Role     `json:"role"`
 	Content          string   `json:"content,omitempty"`
-	Images           []string `json:"images,omitempty"`            // data URLs (data:<mime>;base64,…); embedded only for vision-capable models
+	Images           []string `json:"images,omitempty"`            // data URLs (data:<mime>;base64,…) on user (attachments) and tool (MCP image results) messages; embedded only for vision-capable models
 	ReasoningContent string   `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
 	// ReasoningSignature is an opaque, provider-issued proof that ReasoningContent
 	// is genuine model output. Anthropic requires the signed thinking block be

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -60,6 +60,20 @@ func PreviewChange(t Tool, args json.RawMessage) (diff.Change, bool) {
 	return ch, true
 }
 
+// ImageTool is an optional capability a Tool may implement when its results can
+// carry images alongside text (e.g. an MCP tool returning a screenshot).
+// ExecuteWithImages returns the same text Execute would — including a short
+// placeholder marker where each image occurred — plus the images as data URLs
+// (data:<mime>;base64,<payload>). Callers with a structural image channel (the
+// agent stores them on the tool message, where vision-capable providers embed
+// them) use this instead of Execute; everything else falls back to Execute and
+// the placeholders alone describe the images. Keeping images out of the text
+// matters: tool output text is truncated at a fixed byte budget, which would
+// corrupt an embedded base64 payload.
+type ImageTool interface {
+	ExecuteWithImages(ctx context.Context, args json.RawMessage) (text string, images []string, err error)
+}
+
 // PlanModeClassifier is an optional capability a Tool may implement to declare
 // its stance on running during the planning phase. It is deliberately distinct
 // from ReadOnly(): a tool can be side-effect-free yet belong only to the


### PR DESCRIPTION
## Description

Fixes #6169

MCP tools that return image content items (e.g. `photoshop_get_preview`, chrome-devtools `take_screenshot`) had those items silently dropped by `parseToolResult`, so vision models never saw the image and the UI had nothing to show. This PR forwards tool result images to vision models through a structural channel instead of inlining base64 into the tool text.

### Why a structural channel

Tool output text passes through `truncateToolOutput` (32KB head+tail splice) before reaching providers. Any in-band base64 markdown larger than that — which is every real screenshot — gets spliced, and the splice notice contains no `)`, so a data-URI regex still matches across the gap and ships corrupted base64 to the API (reproduced during review of #6227: the captured "image" contained the splice notice text, which Anthropic rejects as a 400). Keeping images outside the text makes corruption structurally impossible.

### Changes

1. **`internal/tool/tool.go`** — new optional `ImageTool` capability interface (`ExecuteWithImages`), following the existing `Previewer`/`PlanModeClassifier` pattern.
2. **`internal/plugin/plugin.go`** — `parseToolResult` now returns images as data URLs alongside the text, leaving a short `[image: <mime>]` placeholder at each image's position. Each item is validated instead of trusted from the MCP server: mime whitelist (jpeg/png/gif/webp — the set every supported vision API accepts), 4MB base64 per image, 5 images per result, whitespace-normalized and decode-checked base64; anything else becomes a text placeholder rather than poisoning the request. `remoteTool` implements `ImageTool`.
3. **`internal/agent/agent.go`** — `executeOne` prefers `ExecuteWithImages` and carries the images on `toolOutcome`; the session's `RoleTool` message stores them in the existing `Message.Images` field. Text truncation applies to text only.
4. **`internal/provider/anthropic/anthropic.go`** — with vision enabled, a tool message with images builds `tool_result.content` as an array (text block + image source blocks — the API's supported shape). Text-only results keep plain string content with byte-identical serialization.
5. **`internal/provider/openai/openai.go`** — with vision enabled, tool images are injected as a synthetic user message after the turn's full run of tool results, because the OpenAI API accepts only text content parts under `role:"tool"`. Histories without tool images serialize byte-identically.

Non-vision models (e.g. DeepSeek) see only the short placeholder text — consistent with how user image attachments are already gated on `vision`.

### Backward compatibility

| Touch point | Old-data behavior | Conclusion |
| --- | --- | --- |
| `Message.Images` on tool messages (session JSON) | Field already exists with `omitempty`; old sessions deserialize with nil Images. New sessions read by an older binary: images ignored on tool messages (old providers embed user-role images only), no error. | safe |
| `contentBlock.Content` `string` → `any` (anthropic) | Request-side only, never persisted; a string value marshals byte-identically, guarded by `TestBuildRequestToolResultTextOnlyKeepsStringContent`. | safe |
| openai message loop (indexed → append + flush) | With no tool images the emitted message list is unchanged, guarded by `TestBuildRequestSkipsToolImagesWithoutVision`. | safe |
| `tool.Tool` interface | Unchanged; `ImageTool` is optional, non-implementing tools use the exact previous path. | safe |

### Relationship to #6227

Supersedes #6227 by @ttmouse — thank you for the investigation and the first implementation. Kept/adapted from it: the `parseToolResult` image-item parsing (Data/MimeType fields, png default) and the Anthropic `tool_result` array-content shape; ttmouse is credited with a commit `Co-authored-by` trailer. Reworked relative to it: images no longer round-trip through markdown text (the truncation-corruption blocker), OpenAI no longer puts `image_url` parts in tool messages (the API rejects them), and non-vision models no longer receive raw base64 text.

Follow-up (not in this PR): rendering tool-result images in the desktop transcript UI — the images are now on the session message, so the UI half of #6169 has the data it needs.

### Verification

- `go test ./internal/plugin/ ./internal/provider/... ./internal/agent/` — pass (new: 8 parseToolResult image tests, agent truncation-bypass test, 3 anthropic + 3 openai request-shape tests)
- `go test ./...` — pass
- `./scripts/cache-guard.sh` — pass (`long-tool-loop tail_avg=95 threshold=90`)
- `go vet`, `gofmt -l`, `git diff --check` — clean

---

Cache-impact: low — system prompt and tool schemas untouched; request serialization changes only when a tool message carries images (new data), guarded by byte-stability regressions for text-only histories on both providers

Cache-guard: ./scripts/cache-guard.sh — pass (tail_avg=95, threshold=90)
