### PR TITLE
fix(agent): preserve late-arriving steer items across turn boundaries / 修复N组中途引导消息静默丢失问题

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -906,6 +906,7 @@ func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
 		return err
 	}
 	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.ResetSteer()
 	ctrl.SubmitDisplay(input, input)
 	a.finishTabTurnStart(tab, ctrl)
 	return nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -802,17 +802,19 @@ func (a *Agent) consumeSteer() (string, bool) {
 	return t, true
 }
 
-func (a *Agent) clearSteerQueue() {
-	a.steerMu.Lock()
-	defer a.steerMu.Unlock()
-	a.steerQueue = nil
-	a.steerConsumed = false
-}
-
 func (a *Agent) steerQueueLen() int {
 	a.steerMu.Lock()
 	defer a.steerMu.Unlock()
 	return len(a.steerQueue)
+}
+
+// ResetSteer clears all queued steer items. Call this when an explicit new
+// user turn supersedes any pending mid-turn guidance from a previous turn.
+func (a *Agent) ResetSteer() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
 }
 
 // CompactRatio returns the fraction of the window at which auto-compaction
@@ -1035,9 +1037,20 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		}
 		return 1
 	}
-	defer a.clearSteerQueue()
+	// Preserve late-arriving steer items across turn boundaries.
+	// During the turn loop, consumeSteer() drains the queue
+	// injectively. Any items queued after the last consume (e.g.
+	// during final-answer emission or just before defer cleanups)
+	// must survive into the next turn - clearing them here would
+	// silently drop user guidance that arrived near turn-end.
+	//
+	// steerConsumed is reset only when there are pending items, so
+	// the frontend's SteerConsumed poll remains accurate between
+	// turns when the queue is genuinely empty.
 	a.steerMu.Lock()
-	a.steerConsumed = false
+	if len(a.steerQueue) > 0 {
+		a.steerConsumed = false
+	}
 	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1657,6 +1657,17 @@ func (c *Controller) SteerConsumed() bool {
 	return true
 }
 
+// ResetSteer clears all queued steer items. Call this when an explicit new
+// user turn supersedes any pending mid-turn guidance from a previous turn.
+func (c *Controller) ResetSteer() {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		exec.ResetSteer()
+	}
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -61,6 +61,7 @@ type TurnControl interface {
 	Cancel()
 	Steer(text string)
 	SteerConsumed() bool
+	ResetSteer()
 	Running() bool
 	CancelRequested() bool
 	RuntimeStatus() RuntimeStatus


### PR DESCRIPTION
## Summary

Fix the steer queue (guidance queue / 引导队列) silently discarding unconsumed items at turn boundaries, and prevent stale guidance from leaking into explicitly-submitted new turns.

## Root cause

`agent.Run()` registers `defer a.clearSteerQueue()` at the top of every turn, unconditionally clearing the steer queue when the turn completes. If the user queues steer items after the agent loop's last `consumeSteer()` check but before the `defer` runs, those items are silently dropped. No event is emitted, so the frontend never knows the queue was cleared.

The code already has one guard — a `steerQueueLen() > 0` check that defers turn-end — but it only catches items that arrived before the check. Items arriving in the window between the check and the defer are lost.

## Design

### Core insight

`consumeSteer()` itself pops consumed items from the queue — it is injective. Any items remaining in the queue at turn-end are simply ones that arrived too late to be consumed. The fix has two layers:

**Layer 1: Preserve unconsumed steer**

Remove `defer a.clearSteerQueue()`. Unconsumed items survive into the next turn, where `consumeSteer()` in the agent loop picks them up naturally on the first iteration.

**Layer 2: Clear old steer on explicit new-turn submission**

Preservation alone is not enough. If the user queued "don't forget to add comments" near the end of a code-writing task, then typed a completely new prompt "make me a PPT" and pressed Enter, the model would see the stale guidance injected before the new task — a semantic mismatch.

To handle this, a new `Agent.ResetSteer()` method is added and wired through the controller. It is called only on the explicit-submission code path in `app.go`, not on the steer-to-turn conversion path:

| User action | Code path | Clears old steer? |
|---|---|---|
| "Hold" while idle → auto-convert to turn | `SteerForTab` → `ctrl.Steer(text)` | No — old guidance preserved |
| "Hold" while running → inject mid-turn | `SteerForTab` → `ctrl.Steer(text)` | N/A (enqueued, not cleared) |
| Type new prompt → press Enter | `submitToTab` → `ctrl.ResetSteer()` → `ctrl.SubmitDisplay` | Yes — old guidance cleared |
| Auto-continuation (plan mode, etc.) | controller internal → `agent.Run()` | No — old guidance preserved |

### Why `ResetSteer()` is called in `app.go`'s `submitToTab` rather than deeper

The two scenarios diverge before reaching the agent:

- `submitToTab` → `beginTabTurn` → `ctrl.SubmitDisplay(input, input)`
- `SteerForTab` → `ctrl.Steer(text)` (may internally call `SubmitDisplay`, but does not go through `app.go`'s `submitToTab`)

Placing the clear in the controller's `SubmitDisplay` would also clear steer on idle-to-turn conversions — exactly the scenario we want to preserve. Placing it in `submitToTab` precisely targets "the user typed something new and pressed Enter."

### Ancillary changes

- `steerConsumed` flag: changed from unconditional reset to `if len(a.steerQueue) > 0` conditional reset, so the frontend's `SteerConsumed()` poll does not report a false "items pending" state when the queue is genuinely empty.
- Removed the `clearSteerQueue()` helper (caller removed; would fail the `unused` linter).

## Verification

- `go test ./internal/agent/... -run "Steer|steer"` — all pass
- `go test ./internal/agent/... -count=1` — all pass
- `go test ./internal/control/... -count=1` — all pass
- `go test -run "TestSteerForTab" ./desktop/...` — passes
- `go vet ./internal/agent/... ./internal/control/...` — clean

## Related

Fixes #6238

---

Cache-impact: low — removing a deferred queue-clear at turn-end does not change the conversation prefix shape; steer injection via `consumeSteer()` in the agent loop builds the same user messages as before. The new `ResetSteer()` call in `submitToTab` only clears in-memory state before a turn starts and does not affect the provider wire format.

Cache-guard: `go test ./internal/agent/... -run "Steer|steer"` — all pass; `go test ./internal/agent/... -count=1` — all pass; `go test -run "TestSteerForTab" ./desktop/...` — passes