### PR TITLE
fix(site): validate next redirects by parsed origin in auth.js / 按解析后的 origin 校验登录跳转，修复开放重定向

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,25 @@ jobs:
           version: v2.12.2
           args: --timeout=5m
 
+  # The site/ auth client has security-sensitive redirect-validation logic
+  # (safeNext) covered by node:test unit tests. Those tests use only Node
+  # builtins, so no `npm install` is needed — run them directly on every PR so
+  # a regression in redirect validation fails the build instead of shipping.
+  site:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: test
+        run: npm test
+
   govulncheck:
     runs-on: ubuntu-latest
     continue-on-error: true # informational — stdlib vulns need a Go patch release

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "prebuild": "node scripts/fetch-community.mjs",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "node --test src/scripts/*.test.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",

--- a/site/src/scripts/auth.js
+++ b/site/src/scripts/auth.js
@@ -39,7 +39,9 @@ const withBase = (p) => (import.meta.env.BASE_URL.replace(/\/$/, "") + p) || p;
 // after sign-in without opening a redirect to an arbitrary host.
 function safeNext(next) {
   if (!next) return null;
-  if (next.startsWith("/")) return next;
+  // "/" alone is same-origin; "//" or "/\" is a protocol-relative URL a browser
+  // will follow to a different host, so those must fall through to the origin check below.
+  if (next.startsWith("/") && next[1] !== "/" && next[1] !== "\\") return next;
   try {
     const u = new URL(next);
     if (u.protocol === "https:" && (u.host === "reasonix.io" || u.host.endsWith(".reasonix.io"))) return next;

--- a/site/src/scripts/auth.js
+++ b/site/src/scripts/auth.js
@@ -1,3 +1,5 @@
+import { safeNext } from "./safe-next.js";
+
 // Client for the reasonix-accounts API (id.reasonix.io). Cookie-based session,
 // so every call sends credentials; the API base is build-time configurable.
 const API = (import.meta.env.PUBLIC_ACCOUNTS_API || "https://id.reasonix.io").replace(/\/$/, "");
@@ -34,21 +36,6 @@ const $ = (id) => document.getElementById(id);
 const qp = new URLSearchParams(location.search);
 const withBase = (p) => (import.meta.env.BASE_URL.replace(/\/$/, "") + p) || p;
 
-// A `next` is honoured only if it's a same-origin path or an absolute https URL
-// under reasonix.io, so a subdomain (e.g. crash.reasonix.io) can return here
-// after sign-in without opening a redirect to an arbitrary host.
-function safeNext(next) {
-  if (!next) return null;
-  // "/" alone is same-origin; "//" or "/\" is a protocol-relative URL a browser
-  // will follow to a different host, so those must fall through to the origin check below.
-  if (next.startsWith("/") && next[1] !== "/" && next[1] !== "\\") return next;
-  try {
-    const u = new URL(next);
-    if (u.protocol === "https:" && (u.host === "reasonix.io" || u.host.endsWith(".reasonix.io"))) return next;
-  } catch {}
-  return null;
-}
-
 function msg(el, kind, text) {
   if (!el) return;
   el.className = "auth-msg " + kind;
@@ -77,7 +64,7 @@ if (loginForm) {
     busy(btn, true);
     try {
       await api("/auth/login", { method: "POST", body: { email: $("email").value.trim(), password: $("password").value } });
-      location.href = safeNext(qp.get("next")) || withBase("/account/");
+      location.href = safeNext(qp.get("next"), location.origin) || withBase("/account/");
     } catch (err) {
       msg(box, "error", err.message);
       busy(btn, false);

--- a/site/src/scripts/safe-next.js
+++ b/site/src/scripts/safe-next.js
@@ -12,6 +12,14 @@
 // "//evil.example" — a protocol-relative redirect off-site. Parsing with
 // `new URL()` first and checking the *parsed* origin/host closes that gap
 // because it uses the same normalization the browser itself applies.
+//
+// Both branches return the fully-serialized `u.href`, never a relative
+// fragment. Returning `u.pathname` would reopen the hole: dot-segment inputs
+// such as "/.//evil.example" or "/a/..//evil.example" resolve to a
+// same-origin URL whose *pathname* is "//evil.example", and handing that
+// bare pathname back to `location.href` re-parses it as a protocol-relative
+// URL to evil.example. `u.href` keeps the origin attached, so assigning it
+// can never leave reasonix.io.
 export function safeNext(next, origin) {
   if (!next) return null;
   let u;
@@ -20,7 +28,7 @@ export function safeNext(next, origin) {
   } catch {
     return null;
   }
-  if (u.origin === origin) return u.pathname + u.search + u.hash;
+  if (u.origin === origin) return u.href;
   if (u.protocol === "https:" && (u.host === "reasonix.io" || u.host.endsWith(".reasonix.io"))) return u.href;
   return null;
 }

--- a/site/src/scripts/safe-next.js
+++ b/site/src/scripts/safe-next.js
@@ -1,0 +1,26 @@
+// A post-login `next` redirect target is honoured only if it resolves — via
+// full URL parsing against the real page origin, so control characters and
+// protocol-relative tricks get the same normalization a browser applies
+// before navigating — to a same-origin path, or to an absolute https URL
+// under reasonix.io. That lets a subdomain (e.g. crash.reasonix.io) return
+// here after sign-in without opening a redirect to an arbitrary host.
+//
+// Validating a raw string prefix (e.g. checking it starts with "/") is not
+// enough: URLSearchParams decodes percent-encoding, so a value like
+// "/%09/evil.example" arrives as "/\t/evil.example", which passes a naive
+// prefix check but the URL parser strips the tab during navigation, leaving
+// "//evil.example" — a protocol-relative redirect off-site. Parsing with
+// `new URL()` first and checking the *parsed* origin/host closes that gap
+// because it uses the same normalization the browser itself applies.
+export function safeNext(next, origin) {
+  if (!next) return null;
+  let u;
+  try {
+    u = new URL(next, origin);
+  } catch {
+    return null;
+  }
+  if (u.origin === origin) return u.pathname + u.search + u.hash;
+  if (u.protocol === "https:" && (u.host === "reasonix.io" || u.host.endsWith(".reasonix.io"))) return u.href;
+  return null;
+}

--- a/site/src/scripts/safe-next.test.mjs
+++ b/site/src/scripts/safe-next.test.mjs
@@ -4,12 +4,27 @@ import { safeNext } from "./safe-next.js";
 
 const ORIGIN = "https://reasonix.io";
 
-test("same-origin path passes through", () => {
-  assert.equal(safeNext("/account/settings?x=1#y", ORIGIN), "/account/settings?x=1#y");
+// The security invariant: whatever safeNext returns, re-resolving it the way a
+// browser does when it assigns `location.href` must stay on our origin or an
+// allowed reasonix.io host. Asserting this (rather than a fixed string) catches
+// any value that looks same-origin but re-parses off-site.
+function assertLandsSomewhereSafe(returned) {
+  if (returned === null) return;
+  const landed = new URL(returned, ORIGIN);
+  const ok = landed.origin === ORIGIN || landed.host === "reasonix.io" || landed.host.endsWith(".reasonix.io");
+  assert.ok(ok, `returned ${JSON.stringify(returned)} re-resolves off-site to ${landed.href}`);
+}
+
+test("same-origin path passes through as an absolute same-origin URL", () => {
+  const got = safeNext("/account/settings?x=1#y", ORIGIN);
+  assert.equal(got, "https://reasonix.io/account/settings?x=1#y");
+  assertLandsSomewhereSafe(got);
 });
 
 test("allowed reasonix.io subdomain passes through", () => {
-  assert.equal(safeNext("https://crash.reasonix.io/x", ORIGIN), "https://crash.reasonix.io/x");
+  const got = safeNext("https://crash.reasonix.io/x", ORIGIN);
+  assert.equal(got, "https://crash.reasonix.io/x");
+  assertLandsSomewhereSafe(got);
 });
 
 test("empty/missing next", () => {
@@ -31,6 +46,18 @@ test("rejects control characters (as decoded by URLSearchParams) smuggling a pro
   // the value, e.g. "?next=/%09/evil.example" arrives as "/\t/evil.example".
   for (const c of ["\t", "\n", "\r"]) {
     assert.equal(safeNext(`/${c}/evil.example`, ORIGIN), null, JSON.stringify(c));
+  }
+});
+
+test("dot-segment inputs that normalize to a //host pathname do not escape", () => {
+  // These resolve to a same-origin URL whose pathname is "//evil.example".
+  // Returning the bare pathname would re-parse as a protocol-relative redirect;
+  // returning the absolute href keeps them on reasonix.io. Assert end to end.
+  for (const p of ["/.//evil.example", "/a/..//evil.example", "/..//evil.example", "/%2e//evil.example"]) {
+    const got = safeNext(decodeURIComponent(p), ORIGIN);
+    assert.notEqual(got, null, p);
+    assert.equal(new URL(got, ORIGIN).origin, ORIGIN, `${p} -> ${got}`);
+    assertLandsSomewhereSafe(got);
   }
 });
 

--- a/site/src/scripts/safe-next.test.mjs
+++ b/site/src/scripts/safe-next.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { safeNext } from "./safe-next.js";
+
+const ORIGIN = "https://reasonix.io";
+
+test("same-origin path passes through", () => {
+  assert.equal(safeNext("/account/settings?x=1#y", ORIGIN), "/account/settings?x=1#y");
+});
+
+test("allowed reasonix.io subdomain passes through", () => {
+  assert.equal(safeNext("https://crash.reasonix.io/x", ORIGIN), "https://crash.reasonix.io/x");
+});
+
+test("empty/missing next", () => {
+  assert.equal(safeNext("", ORIGIN), null);
+  assert.equal(safeNext(null, ORIGIN), null);
+});
+
+test("rejects a plain protocol-relative redirect", () => {
+  assert.equal(safeNext("//evil.example", ORIGIN), null);
+});
+
+test("rejects a backslash-prefixed redirect", () => {
+  assert.equal(safeNext("/\\evil.example", ORIGIN), null);
+  assert.equal(safeNext("/\\/evil.example", ORIGIN), null);
+});
+
+test("rejects control characters (as decoded by URLSearchParams) smuggling a protocol-relative redirect", () => {
+  // URLSearchParams.get() decodes %09/%0A/%0D before this function ever sees
+  // the value, e.g. "?next=/%09/evil.example" arrives as "/\t/evil.example".
+  for (const c of ["\t", "\n", "\r"]) {
+    assert.equal(safeNext(`/${c}/evil.example`, ORIGIN), null, JSON.stringify(c));
+  }
+});
+
+test("rejects an unrelated https host and non-https schemes", () => {
+  assert.equal(safeNext("https://evil.example/", ORIGIN), null);
+  assert.equal(safeNext("javascript:alert(1)", ORIGIN), null);
+});
+
+test("rejects a reasonix.io-lookalike host", () => {
+  assert.equal(safeNext("https://reasonix.io.evil.example/", ORIGIN), null);
+});


### PR DESCRIPTION
## Summary
`safeNext()` in `site/src/scripts/auth.js` validates the post-login `next`
redirect target. The original raw-string prefix check (does it start with `/`)
was bypassable in several ways, all of which send an authenticated user off-site
right after sign-in via a crafted link like
`https://reasonix.io/login?next=<payload>`:

- **Protocol-relative** — `//evil.example` and `/\evil.example` start with `/`
  but a browser resolves them to another origin.
- **Control-character smuggling** — `URLSearchParams.get()` decodes
  `?next=/%09/evil.example` to `"/\t/evil.example"`; the browser strips the tab
  during URL parsing, collapsing it to `//evil.example`.
- **Dot-segment normalization** — `/.//evil.example` and `/a/..//evil.example`
  normalize to a same-origin URL whose *pathname* is `//evil.example`, which
  re-parses as a protocol-relative redirect if handed back verbatim.

### Fix
Parse the target with `new URL(next, origin)` and validate the **parsed**
origin/host, applying the same normalization the browser uses before navigating,
instead of inspecting the raw string. Both the same-origin and the allowed
`*.reasonix.io` branches return the fully-serialized `u.href` (never a bare
pathname), so the value assigned to `location.href` always carries an origin and
cannot escape. `safeNext()` was extracted into `site/src/scripts/safe-next.js`
as a pure, DOM-free function so it is unit-testable.

Addresses CodeQL alerts `js/xss` (#204) and
`js/client-side-unvalidated-url-redirection` (#203).

## Test plan
- [x] `npm test` in `site/` — 9 `node:test` cases covering protocol-relative,
  backslash, tab/CR/LF control-char, dot-segment (`/.//`, `/a/..//`, `/..//`,
  `/%2e//`), cross-origin https, `javascript:`, and reasonix.io-lookalike hosts.
  Each accepted value is re-resolved end-to-end to assert it stays on-origin.
- [x] Added a `site` job to `.github/workflows/ci.yml` so these tests run on
  every PR (previously the site test script existed but no CI job invoked it).