### PR TITLE
feat(plugin): map Claude plugin commands to custom slash commands / 将 Claude 插件 commands 映射为自定义斜杠命令

### DIFF
--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -4,7 +4,7 @@ import { asArray } from "../lib/array";
 import { app, openExternal } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { mcpServerLifecycleActions, mcpServerRetryableFromAvailableList } from "../lib/mcpServerLifecycle";
-import type { CapabilitiesView, MCPServerInput, PluginHookView, PluginInstallOptions, PluginMCPServerView, PluginSkillView, PluginView, ServerView, SkillRootSkillView, SkillRootView, SkillsSettingsView, SkillView, TabMeta } from "../lib/types";
+import type { CapabilitiesView, MCPServerInput, PluginCommandView, PluginHookView, PluginInstallOptions, PluginMCPServerView, PluginSkillView, PluginView, ServerView, SkillRootSkillView, SkillRootView, SkillsSettingsView, SkillView, TabMeta } from "../lib/types";
 import { InlineConfirmButton } from "./InlineConfirmButton";
 import { ResizableDrawer } from "./ResizableDrawer";
 import { Tooltip } from "./Tooltip";
@@ -2026,9 +2026,10 @@ function PluginRow({
 function PluginUsageDetails({ plugin }: { plugin: PluginView }) {
 	const t = useT();
 	const skills = asArray(plugin.skillDetails);
+	const commands = asArray(plugin.commandDetails);
 	const hooks = asArray(plugin.hookDetails);
 	const mcps = asArray(plugin.mcpServerDetails);
-	const hasDetails = skills.length > 0 || hooks.length > 0 || mcps.length > 0;
+	const hasDetails = skills.length > 0 || commands.length > 0 || hooks.length > 0 || mcps.length > 0;
 	return (
 		<div className="cap-plugin-usage">
 			<div className="cap-plugin-usage__title">{t("caps.pluginUsageTitle")}</div>
@@ -2037,6 +2038,7 @@ function PluginUsageDetails({ plugin }: { plugin: PluginView }) {
 			</div>
 			{hasDetails ? (
 				<div className="cap-plugin-capabilities">
+					{commands.length > 0 && <PluginCommandList commands={commands} />}
 					{skills.length > 0 && <PluginSkillList skills={skills} />}
 					{hooks.length > 0 && <PluginHookList hooks={hooks} />}
 					{mcps.length > 0 && <PluginMCPList servers={mcps} />}
@@ -2044,6 +2046,27 @@ function PluginUsageDetails({ plugin }: { plugin: PluginView }) {
 			) : (
 				<div className="cap-plugin-usage__empty">{t("caps.pluginNoCapabilityDetails")}</div>
 			)}
+		</div>
+	);
+}
+
+function PluginCommandList({ commands }: { commands: PluginCommandView[] }) {
+	const t = useT();
+	return (
+		<div className="cap-plugin-capability">
+			<div className="cap-plugin-capability__head">{t("caps.pluginCommandsTitle")}</div>
+			<div className="cap-plugin-capability__hint">{t("caps.pluginCommandsHint")}</div>
+			<div className="cap-plugin-capability__list">
+				{commands.map((command) => (
+					<div className="cap-plugin-capability__item" key={`${command.name}-${command.path || command.invocation || ""}`}>
+						<div className="cap-plugin-capability__line">
+							<span className="cap-plugin-capability__name">{command.invocation || `/${command.name}`}</span>
+							{command.argHint && <span className="cap-source-badge">{command.argHint}</span>}
+						</div>
+						<div className="cap-plugin-capability__desc">{command.description || t("caps.pluginNoDescription")}</div>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }
@@ -2125,9 +2148,11 @@ function normalizePluginView(plugin: PluginView): PluginView {
 		root: plugin.root || "",
 		enabled: Boolean(plugin.enabled),
 		skills: Number.isFinite(plugin.skills) ? plugin.skills : 0,
+		commands: Number.isFinite(plugin.commands) ? plugin.commands : 0,
 		hooks: Number.isFinite(plugin.hooks) ? plugin.hooks : 0,
 		mcpServers: Number.isFinite(plugin.mcpServers) ? plugin.mcpServers : 0,
 		skillDetails: asArray(plugin.skillDetails),
+		commandDetails: asArray(plugin.commandDetails),
 		hookDetails: asArray(plugin.hookDetails),
 		mcpServerDetails: asArray(plugin.mcpServerDetails),
 		warnings: asArray(plugin.warnings),

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -730,9 +730,11 @@ export interface PluginView {
   manifestKind?: string;
   enabled: boolean;
   skills: number;
+  commands?: number;
   hooks: number;
   mcpServers: number;
   skillDetails?: PluginSkillView[];
+  commandDetails?: PluginCommandView[];
   hookDetails?: PluginHookView[];
   mcpServerDetails?: PluginMCPServerView[];
   warnings?: string[];
@@ -744,6 +746,13 @@ export interface PluginSkillView {
   path?: string;
   invocation?: string;
   runAs?: string;
+}
+export interface PluginCommandView {
+  name: string;
+  description?: string;
+  argHint?: string;
+  path?: string;
+  invocation?: string;
 }
 export interface PluginHookView {
   event: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -366,6 +366,8 @@ export const en = {
   "caps.pluginNoCapabilityDetails": "No detailed capability inventory is available for this plugin.",
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "Browse with /skills, invoke directly, or ask for the workflow by name.",
+  "caps.pluginCommandsTitle": "Commands",
+  "caps.pluginCommandsHint": "Slash-command prompt templates; type /<name> to run one.",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks trigger automatically on matching lifecycle events.",
   "caps.pluginMCPTitle": "MCP servers",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -282,6 +282,8 @@ export const zhTW: Record<DictKey, string> = {
   "caps.pluginNoCapabilityDetails": "此插件暫無可展示的能力明細。",
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "用 /skills 瀏覽，直接呼叫，或在對話中說出工作流名稱。",
+  "caps.pluginCommandsTitle": "Commands",
+  "caps.pluginCommandsHint": "斜線命令模板，輸入 /<名稱> 即可執行。",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks 會在匹配的生命週期事件中自動觸發。",
   "caps.pluginMCPTitle": "MCP 伺服器",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -367,6 +367,8 @@ export const zh: Record<DictKey, string> = {
   "caps.pluginNoCapabilityDetails": "此插件暂无可展示的能力明细。",
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "用 /skills 浏览，直接调用，或在对话中说出工作流名称。",
+  "caps.pluginCommandsTitle": "Commands",
+  "caps.pluginCommandsHint": "斜杠命令模板，输入 /<名称> 即可运行。",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks 会在匹配的生命周期事件中自动触发。",
   "caps.pluginMCPTitle": "MCP 服务器",

--- a/desktop/plugin_packages_app.go
+++ b/desktop/plugin_packages_app.go
@@ -21,9 +21,11 @@ type PluginView struct {
 	ManifestKind     string                `json:"manifestKind,omitempty"`
 	Enabled          bool                  `json:"enabled"`
 	Skills           int                   `json:"skills"`
+	Commands         int                   `json:"commands"`
 	Hooks            int                   `json:"hooks"`
 	MCPServers       int                   `json:"mcpServers"`
 	SkillDetails     []PluginSkillView     `json:"skillDetails,omitempty"`
+	CommandDetails   []PluginCommandView   `json:"commandDetails,omitempty"`
 	HookDetails      []PluginHookView      `json:"hookDetails,omitempty"`
 	MCPServerDetails []PluginMCPServerView `json:"mcpServerDetails,omitempty"`
 	Warnings         []string              `json:"warnings,omitempty"`
@@ -43,6 +45,14 @@ type PluginSkillView struct {
 	Path        string `json:"path,omitempty"`
 	Invocation  string `json:"invocation,omitempty"`
 	RunAs       string `json:"runAs,omitempty"`
+}
+
+type PluginCommandView struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	ArgHint     string `json:"argHint,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Invocation  string `json:"invocation,omitempty"`
 }
 
 type PluginHookView struct {
@@ -87,9 +97,19 @@ func (a *App) Plugins() []PluginView {
 }
 
 func applyPluginPackageDetails(view *PluginView, pkg pluginpkg.Package, warnings []string) {
-	view.Skills, view.Hooks, view.MCPServers = pkg.CapabilityCounts()
+	view.Skills, view.Commands, view.Hooks, view.MCPServers = pkg.CapabilityCounts()
 	view.Warnings = warnings
 	inv := pkg.Inventory()
+	view.CommandDetails = make([]PluginCommandView, 0, len(inv.Commands))
+	for _, cmd := range inv.Commands {
+		view.CommandDetails = append(view.CommandDetails, PluginCommandView{
+			Name:        cmd.Name,
+			Description: cmd.Description,
+			ArgHint:     cmd.ArgHint,
+			Path:        cmd.Path,
+			Invocation:  cmd.Invocation,
+		})
+	}
 	view.SkillDetails = make([]PluginSkillView, 0, len(inv.Skills))
 	for _, sk := range inv.Skills {
 		view.SkillDetails = append(view.SkillDetails, PluginSkillView{

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -226,7 +226,7 @@ third-party install scripts during plugin installation.
 
 Reasonix also reads Codex plugin manifests at `.codex-plugin/plugin.json` and
 Claude Marketplace manifests at `.claude-plugin/plugin.json`. Claude plugin
-capabilities Reasonix does not map yet (`commands/`, `agents/`,
+capabilities Reasonix does not map yet (`agents/`,
 `hooks/hooks.json`, `.mcp.json`) surface as install warnings instead of being
 silently dropped; multi-plugin `marketplace.json` indexes are not supported —
 install each plugin directory individually. For packages such
@@ -235,6 +235,13 @@ as Superpowers and Claude-style skill packs, Reasonix maps:
 - `skills` to Reasonix skill roots. A Claude manifest that declares no
   `skills` field falls back to the conventional `skills/` (or `.claude/skills/`)
   directory, matching Claude's own auto-discovery.
+- `commands/` (and `.claude/commands/`) to Reasonix custom slash commands: each
+  flat `<name>.md` prompt template becomes invocable as `/<name>`, with
+  frontmatter `description` / `argument-hint` and `$ARGUMENTS` / `$1..$N`
+  substitution honored. Plugin commands load at the lowest priority, so a
+  user- or project-authored command with the same name always wins. Native
+  `reasonix-plugin.json` manifests can declare the same thing explicitly with a
+  `"commands"` path list.
 - `hooks/session-start-codex` to the Reasonix `SessionStart` hook when present.
 - A plugin-root `CLAUDE.md` file to a built-in `SessionStart` context hook. The
   file is read directly by Reasonix, without spawning a shell command.

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -207,13 +207,18 @@ Reasonix 原生插件在根目录声明 `reasonix-plugin.json`：
 ## Codex 与 Claude 兼容
 
 Reasonix 也会读取 `.codex-plugin/plugin.json` 和 `.claude-plugin/plugin.json`。
-Reasonix 尚未映射的 Claude 插件能力（`commands/`、`agents/`、`hooks/hooks.json`、
+Reasonix 尚未映射的 Claude 插件能力（`agents/`、`hooks/hooks.json`、
 `.mcp.json`）会以安装警告的形式提示，而不是被静默丢弃；多插件的
 `marketplace.json` 索引暂不支持——请逐个安装插件目录。
 对于 Superpowers 和 Claude 风格 skill 包，Reasonix 会映射：
 
 - `skills` 到 Reasonix skill root。Claude 清单若未声明 `skills` 字段，会回退到
   约定目录 `skills/`（或 `.claude/skills/`），与 Claude 自身的自动发现一致。
+- `commands/`（以及 `.claude/commands/`）映射为 Reasonix 自定义斜杠命令：每个
+  扁平的 `<name>.md` 提示词模板都可以用 `/<name>` 直接调用，frontmatter 的
+  `description` / `argument-hint` 以及 `$ARGUMENTS` / `$1..$N` 替换均生效。
+  插件命令以最低优先级加载，同名时用户或项目自定义的命令始终优先。原生
+  `reasonix-plugin.json` 清单也可以通过 `"commands"` 路径列表显式声明。
 - 如果存在 `hooks/session-start-codex`，映射为 Reasonix `SessionStart` hook。
 - 插件根目录的 `CLAUDE.md` 会映射为内置的 `SessionStart` 上下文 hook。
   Reasonix 会直接读取该文件，不通过 shell 命令。

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -228,9 +228,9 @@ func pluginShowCommand(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	skills, hooks, mcp := pkg.CapabilityCounts()
-	fmt.Printf("name: %s\nversion: %s\nenabled: %t\nkind: %s\nroot: %s\nsource: %s\nskills: %d\nhooks: %d\nmcpServers: %d\n",
-		p.Name, p.Version, p.Enabled, p.ManifestKind, root, p.Source, skills, hooks, mcp)
+	skills, commands, hooks, mcp := pkg.CapabilityCounts()
+	fmt.Printf("name: %s\nversion: %s\nenabled: %t\nkind: %s\nroot: %s\nsource: %s\nskills: %d\ncommands: %d\nhooks: %d\nmcpServers: %d\n",
+		p.Name, p.Version, p.Enabled, p.ManifestKind, root, p.Source, skills, commands, hooks, mcp)
 	printPluginInventory(pkg.Inventory())
 	for _, warning := range warnings {
 		fmt.Println("warning:", warning)
@@ -254,6 +254,24 @@ func printPluginInventory(inv pluginpkg.Inventory) {
 			}
 			if sk.RunAs != "" {
 				fmt.Printf("  %s\t%s\t%s\n", invocation, sk.RunAs, desc)
+			} else {
+				fmt.Printf("  %s\t%s\n", invocation, desc)
+			}
+		}
+	}
+	if len(inv.Commands) > 0 {
+		fmt.Println("commands:")
+		for _, cmd := range inv.Commands {
+			desc := cmd.Description
+			if desc == "" {
+				desc = "(no description)"
+			}
+			invocation := cmd.Invocation
+			if invocation == "" {
+				invocation = "/" + cmd.Name
+			}
+			if cmd.ArgHint != "" {
+				fmt.Printf("  %s %s\t%s\n", invocation, cmd.ArgHint, desc)
 			} else {
 				fmt.Printf("  %s\t%s\n", invocation, desc)
 			}
@@ -312,6 +330,12 @@ func pluginDoctorCommand(args []string) int {
 	for _, skillRoot := range pkg.SkillRoots() {
 		if st, err := os.Stat(skillRoot); err != nil || !st.IsDir() {
 			fmt.Fprintf(os.Stderr, "missing skill root: %s\n", skillRoot)
+			return 1
+		}
+	}
+	for _, commandRoot := range pkg.CommandRoots() {
+		if st, err := os.Stat(commandRoot); err != nil || !st.IsDir() {
+			fmt.Fprintf(os.Stderr, "missing command root: %s\n", commandRoot)
 			return 1
 		}
 	}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -481,6 +481,12 @@ func CommandDirsForRoot(root string) []string {
 		}
 		dirs = append(dirs, dir)
 	}
+	// Enabled plugin packages contribute command dirs at the lowest priority,
+	// so a user- or project-authored command always wins a name clash with a
+	// plugin-shipped one.
+	for _, dir := range pluginPackageCommandDirs() {
+		add(dir)
+	}
 	if dir := legacyOSSupportDir(); dir != "" {
 		add(filepath.Join(dir, "commands"))
 	}

--- a/internal/config/plugin_packages.go
+++ b/internal/config/plugin_packages.go
@@ -61,6 +61,23 @@ func mergeInstalledPluginPackages(cfg *Config, root string) []string {
 	return warnings
 }
 
+// pluginPackageCommandDirs returns the command directories contributed by
+// enabled installed plugin packages, in deterministic (name, path) order.
+// CommandDirsForRoot places them ahead of every user/project dir so they lose
+// name clashes; LoadInstalled already filters to enabled packages.
+func pluginPackageCommandDirs() []string {
+	reasonixHome := ReasonixHomeDir()
+	if strings.TrimSpace(reasonixHome) == "" {
+		return nil
+	}
+	installed, _ := pluginpkg.LoadInstalled(reasonixHome)
+	var out []string
+	for _, item := range installed {
+		out = append(out, item.Package.CommandRoots()...)
+	}
+	return out
+}
+
 // PluginPackageOwner reports the installed plugin package that contributed an
 // MCP server. Config-authored servers with the same name win during merge and
 // therefore have no package owner.

--- a/internal/config/plugin_packages_test.go
+++ b/internal/config/plugin_packages_test.go
@@ -66,3 +66,48 @@ func writeConfigTestFile(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+// TestCommandDirsIncludePluginPackageCommands pins the plugin-commands wiring:
+// an enabled plugin package's command roots join command discovery at the
+// lowest priority (first entries, since command.Load lets a later dir win),
+// and a disabled package contributes nothing.
+func TestCommandDirsIncludePluginPackageCommands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	root := filepath.Join(home, "plugins", "pwf")
+	writeConfigTestFile(t, filepath.Join(root, pluginpkg.ClaudeManifest), `{"name": "pwf"}`)
+	writeConfigTestFile(t, filepath.Join(root, "skills", "planner", "SKILL.md"), "---\ndescription: p\n---\nbody")
+	writeConfigTestFile(t, filepath.Join(root, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan: $ARGUMENTS")
+	if err := pluginpkg.Upsert(home, pluginpkg.InstalledPlugin{
+		Name:         "pwf",
+		Root:         "plugins/pwf",
+		ManifestKind: "claude",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs := CommandDirsForRoot(t.TempDir())
+	want := filepath.Join(root, "commands")
+	if len(dirs) == 0 || dirs[0] != want {
+		t.Fatalf("CommandDirsForRoot = %#v, want plugin commands dir first (lowest priority): %s", dirs, want)
+	}
+
+	if err := pluginpkg.SetEnabled(home, "pwf", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range CommandDirsForRoot(t.TempDir()) {
+		if dir == want {
+			t.Fatalf("disabled plugin's commands dir must not join discovery: %#v", dir)
+		}
+	}
+}
+
+// TestCommandDirsWithoutPluginState keeps the no-plugin fast path intact.
+func TestCommandDirsWithoutPluginState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if dirs := CommandDirsForRoot(t.TempDir()); len(dirs) == 0 {
+		t.Fatal("CommandDirsForRoot must still return the conventional dirs")
+	}
+}

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -69,9 +69,10 @@ type installSourceTool struct {
 	approval     ApprovalFunc
 	// preparePlugin overrides plugin source preparation in tests. nil uses
 	// preparePluginSource. Plan and apply both resolve the source through the
-	// same function, so the capability set the approval covers is by
-	// construction the one that gets installed.
-	preparePlugin func(ctx context.Context, source, mode string) (string, func(), error)
+	// same function, and git sources additionally report the resolved commit,
+	// so the capability set the approval covers is by construction the one
+	// that gets installed (apply pins the approved commit on divergence).
+	preparePlugin func(ctx context.Context, source, mode string) (root, commit string, cleanup func(), err error)
 }
 
 // NewTool returns a tool.Tool that callers register with the agent's

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -67,6 +67,11 @@ type installSourceTool struct {
 	connectMCP   MCPConnector
 	onDisconnect OnDisconnectFunc
 	approval     ApprovalFunc
+	// preparePlugin overrides plugin source preparation in tests. nil uses
+	// preparePluginSource. Plan and apply both resolve the source through the
+	// same function, so the capability set the approval covers is by
+	// construction the one that gets installed.
+	preparePlugin func(ctx context.Context, source, mode string) (string, func(), error)
 }
 
 // NewTool returns a tool.Tool that callers register with the agent's

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1907,3 +1907,64 @@ func TestFailedReplaceKeepsExistingPluginInstall(t *testing.T) {
 		}
 	}
 }
+
+// TestBackupPathCannotCollideWithSiblingPlugin pins the backup-naming
+// contract: plugin names may legally contain dots, so a plugin literally
+// named "foo.pre-replace" must survive an update of plugin "foo" — the swap
+// backup must use a name no valid plugin can occupy.
+func TestBackupPathCannotCollideWithSiblingPlugin(t *testing.T) {
+	fooV1 := t.TempDir()
+	writeFile(t, filepath.Join(fooV1, ".claude-plugin", "plugin.json"), `{"name": "foo", "version": "1.0.0"}`)
+	writeFile(t, filepath.Join(fooV1, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	fooV2 := t.TempDir()
+	writeFile(t, filepath.Join(fooV2, ".claude-plugin", "plugin.json"), `{"name": "foo", "version": "2.0.0"}`)
+	writeFile(t, filepath.Join(fooV2, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan v2")
+	sibling := t.TempDir()
+	writeFile(t, filepath.Join(sibling, ".claude-plugin", "plugin.json"), `{"name": "foo.pre-replace", "version": "1.0.0"}`)
+	writeFile(t, filepath.Join(sibling, "commands", "keep.md"), "---\ndescription: keep\n---\nKeep")
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	sources := map[string]string{
+		"https://github.com/acme/foo":     fooV1,
+		"https://github.com/acme/sibling": sibling,
+	}
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return sources[source], "cafe-" + source, func() {}, nil
+	}
+
+	for _, source := range []string{"https://github.com/acme/foo", "https://github.com/acme/sibling"} {
+		resp := execInstall(t, tl, map[string]any{"source": source, "kind": "plugin", "apply": true})
+		if !resp.OK || resp.Status != "done" {
+			t.Fatalf("install %s = %+v", source, resp)
+		}
+	}
+
+	sources["https://github.com/acme/foo"] = fooV2
+	update := execInstall(t, tl, map[string]any{
+		"source":  "https://github.com/acme/foo",
+		"kind":    "plugin",
+		"apply":   true,
+		"replace": true,
+	})
+	if !update.OK || update.Status != "done" {
+		t.Fatalf("update = %+v", update)
+	}
+
+	siblingRoot := filepath.Join(home, ".reasonix", "plugins", "foo.pre-replace")
+	if _, err := os.Stat(filepath.Join(siblingRoot, "commands", "keep.md")); err != nil {
+		t.Fatalf("sibling plugin's files must survive the update of foo: %v", err)
+	}
+	if _, ok, _ := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), "foo.pre-replace"); !ok {
+		t.Fatal("sibling plugin must stay registered")
+	}
+	pkg, _, err := pluginpkg.ParseDir(filepath.Join(home, ".reasonix", "plugins", "foo"))
+	if err != nil {
+		t.Fatalf("ParseDir foo: %v", err)
+	}
+	if pkg.Manifest.Version != "2.0.0" {
+		t.Fatalf("foo version = %q, want the update applied", pkg.Manifest.Version)
+	}
+}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/pluginpkg"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
@@ -1672,8 +1673,8 @@ func TestGitHubPluginPlanMatchesApply(t *testing.T) {
 	home := t.TempDir()
 	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
 	tool := tl.(*installSourceTool)
-	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, func(), error) {
-		return src, func() {}, nil
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return src, "cafe0001", func() {}, nil
 	}
 
 	plan := execInstall(t, tl, map[string]any{
@@ -1702,5 +1703,50 @@ func TestGitHubPluginPlanMatchesApply(t *testing.T) {
 		t.Fatalf("apply counts (%d/%d/%d/%d) diverge from approved plan (%d/%d/%d/%d)",
 			got.SkillCount, got.CommandCount, got.HookCount, got.ToolCount,
 			planned.SkillCount, planned.CommandCount, planned.HookCount, planned.ToolCount)
+	}
+}
+
+// TestGitHubPluginApplyRefusesUnpinnableDrift pins the snapshot contract: when
+// the source resolves to a different commit than the plan approved and the
+// approved snapshot cannot be restored, apply must refuse instead of
+// installing content the approval never covered.
+func TestGitHubPluginApplyRefusesUnpinnableDrift(t *testing.T) {
+	tree1 := t.TempDir()
+	writeFile(t, filepath.Join(tree1, ".claude-plugin", "plugin.json"), `{"name": "pwf", "version": "1.0.0"}`)
+	writeFile(t, filepath.Join(tree1, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	tree2 := t.TempDir()
+	writeFile(t, filepath.Join(tree2, ".claude-plugin", "plugin.json"), `{"name": "pwf", "version": "1.0.1"}`)
+	writeFile(t, filepath.Join(tree2, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	writeFile(t, filepath.Join(tree2, "commands", "extra.md"), "---\ndescription: extra\n---\nExtra")
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	calls := 0
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		calls++
+		if calls == 1 {
+			return tree1, "cafe0001", func() {}, nil // plan recompute inside the apply call
+		}
+		return tree2, "cafe0002", func() {}, nil // apply resolution: source moved
+	}
+
+	resp := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/pwf",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if resp.OK || resp.Status != "failed" {
+		t.Fatalf("response = %+v, want a failed apply when the source drifted past the approved commit", resp)
+	}
+	if len(resp.Actions) != 1 || resp.Actions[0].Status != "failed" {
+		t.Fatalf("actions = %+v, want the single install action failed", resp.Actions)
+	}
+	if !strings.Contains(resp.Actions[0].Error, "approved commit cafe0001") {
+		t.Fatalf("action error = %q, want the approved-commit drift refusal", resp.Actions[0].Error)
+	}
+	if _, ok, _ := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), "pwf"); ok {
+		t.Fatal("drifted plugin must not be installed")
 	}
 }

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1832,3 +1832,78 @@ func TestCopyRefusesUnmaterializableSymlinkCommands(t *testing.T) {
 		t.Fatal("failed install must not be registered")
 	}
 }
+
+// TestFailedReplaceKeepsExistingPluginInstall pins the update-safety contract:
+// when a replace=true update fails capability verification (e.g. the new
+// version ships an unmaterializable symlink), the previously installed
+// version must survive on disk and stay registered — a failed update may
+// never leave an enabled plugin pointing at a missing or gutted root.
+func TestFailedReplaceKeepsExistingPluginInstall(t *testing.T) {
+	v1 := t.TempDir()
+	writeFile(t, filepath.Join(v1, ".claude-plugin", "plugin.json"), `{"name": "pwf", "version": "1.0.0"}`)
+	writeFile(t, filepath.Join(v1, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "evil.md"), "---\ndescription: evil\n---\nEvil")
+	v2 := t.TempDir()
+	writeFile(t, filepath.Join(v2, ".claude-plugin", "plugin.json"), `{"name": "pwf", "version": "2.0.0"}`)
+	writeFile(t, filepath.Join(v2, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	if err := os.Symlink(filepath.Join(outside, "evil.md"), filepath.Join(v2, "commands", "evil.md")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	current, commit := v1, "cafe0001"
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return current, commit, func() {}, nil
+	}
+
+	install := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/pwf",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if !install.OK || install.Status != "done" {
+		t.Fatalf("initial install = %+v", install)
+	}
+
+	current, commit = v2, "cafe0002"
+	update := execInstall(t, tl, map[string]any{
+		"source":  "https://github.com/acme/pwf",
+		"kind":    "plugin",
+		"apply":   true,
+		"replace": true,
+	})
+	if update.OK || update.Status != "failed" {
+		t.Fatalf("update = %+v, want a failed apply for the unmaterializable symlink", update)
+	}
+
+	installedRoot := filepath.Join(home, ".reasonix", "plugins", "pwf")
+	if _, err := os.Stat(filepath.Join(installedRoot, "commands", "plan.md")); err != nil {
+		t.Fatalf("previous install must survive a failed update: %v", err)
+	}
+	pkg, _, err := pluginpkg.ParseDir(installedRoot)
+	if err != nil {
+		t.Fatalf("ParseDir installed: %v", err)
+	}
+	if pkg.Manifest.Version != "1.0.0" {
+		t.Fatalf("installed version = %q, want the previous 1.0.0 kept", pkg.Manifest.Version)
+	}
+	if p, ok, _ := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), "pwf"); !ok || !p.Enabled {
+		t.Fatal("previous registration must survive a failed update")
+	}
+	if _, err := os.Stat(installedRoot + ".pre-replace"); !os.IsNotExist(err) {
+		t.Fatal("failed update must not leave a backup tree behind")
+	}
+	entries, err := os.ReadDir(filepath.Dir(installedRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".staging-") {
+			t.Fatalf("failed update must not leave staging dir %q behind", e.Name())
+		}
+	}
+}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1750,3 +1750,85 @@ func TestGitHubPluginApplyRefusesUnpinnableDrift(t *testing.T) {
 		t.Fatal("drifted plugin must not be installed")
 	}
 }
+
+// TestCopyMaterializesInRootSymlinkedCommands pins that a command alias
+// symlinked to a file inside the package survives copy-mode installs: the
+// installed tree must resolve to the same capability set the plan counted.
+func TestCopyMaterializesInRootSymlinkedCommands(t *testing.T) {
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, ".claude-plugin", "plugin.json"), `{"name": "aliases"}`)
+	writeFile(t, filepath.Join(src, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeFile(t, filepath.Join(src, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	if err := os.Symlink(filepath.Join(src, "commands", "plan.md"), filepath.Join(src, "commands", "pwf.md")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return src, "cafe0001", func() {}, nil
+	}
+
+	resp := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/aliases",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if !resp.OK || resp.Status != "done" || len(resp.Actions) != 1 {
+		t.Fatalf("response = %+v", resp)
+	}
+	if resp.Actions[0].CommandCount != 2 {
+		t.Fatalf("planned commands = %d, want 2 (alias followed)", resp.Actions[0].CommandCount)
+	}
+	installedRoot := filepath.Join(home, ".reasonix", "plugins", "aliases")
+	pkg, _, err := pluginpkg.ParseDir(installedRoot)
+	if err != nil {
+		t.Fatalf("ParseDir installed: %v", err)
+	}
+	if _, commands, _, _ := pkg.CapabilityCounts(); commands != 2 {
+		t.Fatalf("installed commands = %d, want the symlinked alias materialized", commands)
+	}
+}
+
+// TestCopyRefusesUnmaterializableSymlinkCommands pins the fail-closed path: a
+// command symlinked to a file OUTSIDE the package counts during planning but
+// cannot be materialized by copy mode, so apply must refuse (and clean up)
+// rather than silently install fewer commands than approved.
+func TestCopyRefusesUnmaterializableSymlinkCommands(t *testing.T) {
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "evil.md"), "---\ndescription: evil\n---\nEvil")
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, ".claude-plugin", "plugin.json"), `{"name": "escapes"}`)
+	writeFile(t, filepath.Join(src, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan")
+	if err := os.Symlink(filepath.Join(outside, "evil.md"), filepath.Join(src, "commands", "evil.md")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return src, "cafe0001", func() {}, nil
+	}
+
+	resp := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/escapes",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if resp.OK || resp.Status != "failed" || len(resp.Actions) != 1 || resp.Actions[0].Status != "failed" {
+		t.Fatalf("response = %+v, want a failed apply for the unmaterializable symlink", resp)
+	}
+	if !strings.Contains(resp.Actions[0].Error, "approved plan counted") {
+		t.Fatalf("action error = %q, want the capability-verification refusal", resp.Actions[0].Error)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".reasonix", "plugins", "escapes")); !os.IsNotExist(err) {
+		t.Fatal("failed install must not leave the copied tree behind")
+	}
+	if _, ok, _ := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), "escapes"); ok {
+		t.Fatal("failed install must not be registered")
+	}
+}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1655,3 +1655,52 @@ func ExampleNewTool() {
 		resp.Status, resp.Kind, resp.Kinds.Skill, resp.Kinds.MCP)
 	// Output: status=planned kind=mcp skill=0 mcp=1
 }
+
+// TestGitHubPluginPlanMatchesApply pins the approval contract: the plan the
+// user approves must describe exactly the capability set apply installs. Both
+// phases resolve the source through pluginSource, so convention-discovered
+// capabilities (skills/, commands/ — including nested namespaces) appear in
+// the plan, not only after installation.
+func TestGitHubPluginPlanMatchesApply(t *testing.T) {
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, ".claude-plugin", "plugin.json"), `{"name": "pwf", "version": "1.0.0"}`)
+	writeFile(t, filepath.Join(src, "skills", "planner", "SKILL.md"), "---\ndescription: planner\n---\nbody")
+	writeFile(t, filepath.Join(src, "commands", "plan.md"), "---\ndescription: plan\n---\nPlan: $ARGUMENTS")
+	writeFile(t, filepath.Join(src, "commands", "git", "commit.md"), "---\ndescription: commit\n---\nCommit")
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, func(), error) {
+		return src, func() {}, nil
+	}
+
+	plan := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/pwf",
+		"kind":   "plugin",
+	})
+	if !plan.OK || plan.Status != "planned" || len(plan.Actions) != 1 {
+		t.Fatalf("plan response = %+v", plan)
+	}
+	planned := plan.Actions[0]
+	if planned.SkillCount != 1 || planned.CommandCount != 2 {
+		t.Fatalf("planned counts = %d skills / %d commands, want 1/2 (plan must see convention dirs)", planned.SkillCount, planned.CommandCount)
+	}
+
+	applied := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/pwf",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if !applied.OK || applied.Status != "done" || len(applied.Actions) != 1 {
+		t.Fatalf("apply response = %+v", applied)
+	}
+	got := applied.Actions[0]
+	if got.SkillCount != planned.SkillCount || got.CommandCount != planned.CommandCount ||
+		got.HookCount != planned.HookCount || got.ToolCount != planned.ToolCount {
+		t.Fatalf("apply counts (%d/%d/%d/%d) diverge from approved plan (%d/%d/%d/%d)",
+			got.SkillCount, got.CommandCount, got.HookCount, got.ToolCount,
+			planned.SkillCount, planned.CommandCount, planned.HookCount, planned.ToolCount)
+	}
+}

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -287,9 +287,12 @@ func installCopiedPlugin(pkg pluginpkg.Package, sourceRoot, target string, repla
 	}
 	// Swap staged tree into place. The backup rename keeps the previous
 	// install restorable until the new tree has landed; both renames stay on
-	// one filesystem (same parent dir), so each is atomic.
-	backup := target + ".pre-replace"
-	_ = os.RemoveAll(backup) // stale leftover from an interrupted prior swap
+	// one filesystem (same parent dir), so each is atomic. The backup name
+	// derives from the staging dir: dot-prefixed and randomized, it can never
+	// pass IsValidName, so it cannot collide with a sibling plugin's install
+	// dir (plugin names may legally contain dots, e.g. "foo.pre-replace") and
+	// needs no pre-cleanup that could delete such a neighbor.
+	backup := staging + ".old"
 	hadOld := false
 	if _, err := os.Lstat(target); err == nil {
 		hadOld = true

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -77,7 +77,7 @@ func (t *installSourceTool) pluginPackageAction(req request, pkg pluginpkg.Packa
 	if t.reasonixHome != "" {
 		root = pluginpkg.InstallRoot(t.reasonixHome, name)
 	}
-	skills, hooks, mcp := pkg.CapabilityCounts()
+	skills, commands, hooks, mcp := pkg.CapabilityCounts()
 	a := action{
 		Kind:         "plugin",
 		Action:       "install_plugin_package",
@@ -89,12 +89,14 @@ func (t *installSourceTool) pluginPackageAction(req request, pkg pluginpkg.Packa
 		ConfigPath:   pluginpkg.StatePath(t.reasonixHome),
 		Skills:       pkg.Manifest.Skills,
 		SkillCount:   skills,
+		Commands:     pkg.Manifest.Commands,
+		CommandCount: commands,
+		ManifestKind: pkg.ManifestKind,
 		HookCount:    hooks,
 		ToolCount:    mcp,
-		ManifestKind: pkg.ManifestKind,
 		Version:      pkg.Manifest.Version,
 		RiskLevel:    RiskMedium,
-		RiskReasons:  []string{"installs a plugin package that can add skills, hooks, and MCP servers"},
+		RiskReasons:  []string{"installs a plugin package that can add skills, commands, hooks, and MCP servers"},
 	}
 	if a.Mode == "link" {
 		a.RiskReasons = append(a.RiskReasons, "links a plugin package from a mutable local directory")
@@ -167,7 +169,7 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 	act.Target = target
 	act.ManifestKind = pkg.ManifestKind
 	act.Version = pkg.Manifest.Version
-	act.SkillCount, act.HookCount, act.ToolCount = pkg.CapabilityCounts()
+	act.SkillCount, act.CommandCount, act.HookCount, act.ToolCount = pkg.CapabilityCounts()
 	return nil
 }
 

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -31,7 +31,7 @@ func (t *installSourceTool) planGitHubPluginPackage(ctx context.Context, req req
 	// capability directories (skills/, commands/) or their warnings, so it
 	// under-reports the capability set — and the plan the user approves must
 	// describe exactly what apply installs.
-	root, cleanup, err := t.pluginSource(ctx, req.Source, modeForPlugin(req.Mode))
+	root, commit, cleanup, err := t.pluginSource(ctx, req.Source, modeForPlugin(req.Mode))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,13 +42,17 @@ func (t *installSourceTool) planGitHubPluginPackage(ctx context.Context, req req
 	}
 	act := t.pluginPackageAction(req, pkg, req.Source)
 	act.Source = req.Source
+	// The commit joins the action and therefore the plan ID, so the approval
+	// fingerprints the exact snapshot; apply pins to it.
+	act.Commit = commit
 	return []action{act}, warnings, nil
 }
 
 // pluginSource resolves a plugin source to an on-disk tree. Both the plan and
 // apply phases go through this single function so their views can never
-// diverge (the P1 approval-contract guarantee).
-func (t *installSourceTool) pluginSource(ctx context.Context, source, mode string) (string, func(), error) {
+// diverge (the approval-contract guarantee); for git sources it also reports
+// the resolved commit SHA ("" for local directories).
+func (t *installSourceTool) pluginSource(ctx context.Context, source, mode string) (string, string, func(), error) {
 	if t.preparePlugin != nil {
 		return t.preparePlugin(ctx, source, mode)
 	}
@@ -113,11 +117,19 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 		return newErr(ErrInvalidManifest, "invalid plugin name %q", act.Name)
 	}
 	target := pluginpkg.InstallRoot(t.reasonixHome, act.Name)
-	sourceRoot, cleanup, err := t.pluginSource(ctx, act.Source, act.Mode)
+	sourceRoot, commit, cleanup, err := t.pluginSource(ctx, act.Source, act.Mode)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+	if act.Commit != "" && commit != act.Commit {
+		// The source moved between the approved plan and this resolution; pin
+		// the clone back to the approved snapshot so what installs is exactly
+		// what was reviewed.
+		if err := checkoutPluginCommit(ctx, sourceRoot, act.Commit); err != nil {
+			return newErr(ErrApprovalDenied, "plugin source changed since the approved plan (approved commit %s, found %s) and the approved snapshot could not be restored: %v; re-run without apply to review the new plan", act.Commit, commit, err)
+		}
+	}
 	pkg, warnings, err := pluginpkg.ParseDir(sourceRoot)
 	if err != nil {
 		return newErr(ErrInvalidManifest, "%v", err)
@@ -160,7 +172,7 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 	return nil
 }
 
-func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mode string) (string, func(), error) {
+func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mode string) (string, string, func(), error) {
 	source = strings.TrimSpace(source)
 	if strings.HasPrefix(source, "git:github.com/") {
 		source = "https://github.com/" + strings.TrimPrefix(source, "git:github.com/")
@@ -168,11 +180,11 @@ func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mod
 	if isURL(source) {
 		src, ok := parseGitHubRepoSource(source)
 		if !ok {
-			return "", func() {}, newErr(ErrUnsupportedKind, "plugin URL %q is not a GitHub repository", source)
+			return "", "", func() {}, newErr(ErrUnsupportedKind, "plugin URL %q is not a GitHub repository", source)
 		}
 		tmp, err := os.MkdirTemp("", "reasonix-plugin-*")
 		if err != nil {
-			return "", func() {}, err
+			return "", "", func() {}, err
 		}
 		cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", src.Owner, src.Repo)
 		args := []string{"clone", "--depth=1"}
@@ -184,19 +196,43 @@ func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mod
 		cmd.Env = secrets.ProcessEnv()
 		if out, err := cmd.CombinedOutput(); err != nil {
 			_ = os.RemoveAll(tmp)
-			return "", func() {}, newErr(ErrSourceUnreadable, "git clone failed: %v: %s", err, strings.TrimSpace(string(out)))
+			return "", "", func() {}, newErr(ErrSourceUnreadable, "git clone failed: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+		commit := ""
+		rev := exec.CommandContext(ctx, "git", "-C", tmp, "rev-parse", "HEAD")
+		rev.Env = secrets.ProcessEnv()
+		if out, err := rev.Output(); err == nil {
+			commit = strings.TrimSpace(string(out))
 		}
 		root := tmp
 		if src.Path != "" {
 			root = filepath.Join(tmp, filepath.FromSlash(src.Path))
 		}
-		return root, func() { _ = os.RemoveAll(tmp) }, nil
+		return root, commit, func() { _ = os.RemoveAll(tmp) }, nil
 	}
 	path := t.resolvePath(source)
 	if mode == "link" {
-		return path, func() {}, nil
+		return path, "", func() {}, nil
 	}
-	return path, func() {}, nil
+	return path, "", func() {}, nil
+}
+
+// checkoutPluginCommit pins a fresh clone to the approved commit when its HEAD
+// has moved past it. GitHub serves full-SHA fetches, so the approved snapshot
+// stays reachable after ordinary pushes; a history rewrite that discarded it
+// fails here — exactly the case where the user must re-review the plan.
+func checkoutPluginCommit(ctx context.Context, cloneRoot, commit string) error {
+	fetch := exec.CommandContext(ctx, "git", "-C", cloneRoot, "fetch", "--depth=1", "origin", commit)
+	fetch.Env = secrets.ProcessEnv()
+	if out, err := fetch.CombinedOutput(); err != nil {
+		return fmt.Errorf("fetch approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
+	}
+	co := exec.CommandContext(ctx, "git", "-C", cloneRoot, "checkout", "--detach", commit)
+	co.Env = secrets.ProcessEnv()
+	if out, err := co.CombinedOutput(); err != nil {
+		return fmt.Errorf("checkout approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func replaceCopiedPlugin(sourceRoot, target string, replace bool) error {

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -146,15 +146,7 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 			return err
 		}
 	} else {
-		if err := replaceCopiedPlugin(sourceRoot, target, req.Replace); err != nil {
-			return err
-		}
-		// Fail closed when the copied tree resolves to a different capability
-		// set than the plan the user approved — e.g. a symlink copyDir could
-		// not materialize safely. A silent gap here would install less than
-		// what was reviewed.
-		if err := verifyCopiedCapabilities(pkg, target); err != nil {
-			_ = os.RemoveAll(target)
+		if err := installCopiedPlugin(pkg, sourceRoot, target, req.Replace); err != nil {
 			return err
 		}
 	}
@@ -263,19 +255,58 @@ func checkoutPluginCommit(ctx context.Context, cloneRoot, commit string) error {
 	return nil
 }
 
-func replaceCopiedPlugin(sourceRoot, target string, replace bool) error {
-	if _, err := os.Lstat(target); err == nil {
-		if !replace {
-			return newErr(ErrAlreadyExists, "plugin package already exists at %s; retry with replace=true to update it", target)
-		}
-		if err := os.RemoveAll(target); err != nil {
-			return err
-		}
+// installCopiedPlugin copies sourceRoot into a staging directory next to
+// target, verifies the staged tree resolves to the capability set the plan
+// approved, and only then swaps it into place with a backup-protected rename.
+// Any failure before the swap — copy error, capability mismatch — leaves an
+// existing installation completely intact, so a bad update can never destroy
+// the working version it was meant to replace.
+func installCopiedPlugin(pkg pluginpkg.Package, sourceRoot, target string, replace bool) error {
+	if _, err := os.Lstat(target); err == nil && !replace {
+		return newErr(ErrAlreadyExists, "plugin package already exists at %s; retry with replace=true to update it", target)
 	}
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
 	}
-	return copyDir(sourceRoot, target)
+	staging, err := os.MkdirTemp(filepath.Dir(target), "."+filepath.Base(target)+".staging-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(staging)
+	if err := copyDir(sourceRoot, staging); err != nil {
+		return err
+	}
+	// Fail closed when the copied tree resolves to a different capability set
+	// than the plan the user approved — e.g. a symlink copyDir could not
+	// materialize safely. A silent gap here would install less than reviewed.
+	if err := verifyCopiedCapabilities(pkg, staging); err != nil {
+		return err
+	}
+	if err := os.Chmod(staging, 0o755); err != nil { // MkdirTemp creates 0700
+		return err
+	}
+	// Swap staged tree into place. The backup rename keeps the previous
+	// install restorable until the new tree has landed; both renames stay on
+	// one filesystem (same parent dir), so each is atomic.
+	backup := target + ".pre-replace"
+	_ = os.RemoveAll(backup) // stale leftover from an interrupted prior swap
+	hadOld := false
+	if _, err := os.Lstat(target); err == nil {
+		hadOld = true
+		if err := os.Rename(target, backup); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(staging, target); err != nil {
+		if hadOld {
+			_ = os.Rename(backup, target) // restore the previous install
+		}
+		return err
+	}
+	if hadOld {
+		_ = os.RemoveAll(backup)
+	}
+	return nil
 }
 
 func replaceSymlink(target, sourceRoot string, replace bool) error {

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -149,6 +149,14 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 		if err := replaceCopiedPlugin(sourceRoot, target, req.Replace); err != nil {
 			return err
 		}
+		// Fail closed when the copied tree resolves to a different capability
+		// set than the plan the user approved — e.g. a symlink copyDir could
+		// not materialize safely. A silent gap here would install less than
+		// what was reviewed.
+		if err := verifyCopiedCapabilities(pkg, target); err != nil {
+			_ = os.RemoveAll(target)
+			return err
+		}
 	}
 	installed := pluginpkg.InstalledPlugin{
 		Name:         act.Name,
@@ -215,6 +223,26 @@ func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mod
 		return path, "", func() {}, nil
 	}
 	return path, "", func() {}, nil
+}
+
+// verifyCopiedCapabilities re-parses the installed copy and requires its
+// capability counts to match the source tree the plan described. Discovery
+// follows symlinks but copy mode can only materialize links that stay inside
+// the package, so an unmaterializable link would otherwise silently install
+// fewer skills/commands than the approval covered.
+func verifyCopiedCapabilities(src pluginpkg.Package, target string) error {
+	installed, _, err := pluginpkg.ParseDir(target)
+	if err != nil {
+		return newErr(ErrInvalidManifest, "installed plugin tree failed to re-parse: %v", err)
+	}
+	ss, sc, sh, sm := src.CapabilityCounts()
+	is, ic, ih, im := installed.CapabilityCounts()
+	if ss != is || sc != ic || sh != ih || sm != im {
+		return newErr(ErrInvalidManifest,
+			"installed copy resolves to %d skills / %d commands / %d hooks / %d MCP servers but the approved plan counted %d/%d/%d/%d — the package likely uses symlinks copy mode cannot materialize safely; retry with mode=link or fix the package layout",
+			is, ic, ih, im, ss, sc, sh, sm)
+	}
+	return nil
 }
 
 // checkoutPluginCommit pins a fresh clone to the approved commit when its HEAD

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -26,46 +26,33 @@ func (t *installSourceTool) planGitHubPluginPackage(ctx context.Context, req req
 	if !ok {
 		return nil, nil, newErr(ErrUnsupportedKind, "plugin URL %q is not a GitHub repository", req.Source)
 	}
-	var warnings []string
-	for _, branch := range src.branches() {
-		for _, manifestPath := range pluginpkg.ManifestPaths() {
-			rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", src.Owner, src.Repo, branch, joinURLPath(src.Path, manifestPath))
-			body, err := t.fetchText(ctx, rawURL)
-			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("%s: %s", rawURL, err.Error()))
-				continue
-			}
-			tmp, err := os.MkdirTemp("", "reasonix-plugin-plan-*")
-			if err != nil {
-				return nil, warnings, err
-			}
-			defer os.RemoveAll(tmp)
-			if err := os.MkdirAll(filepath.Dir(filepath.Join(tmp, manifestPath)), 0o755); err != nil {
-				return nil, warnings, err
-			}
-			if err := os.WriteFile(filepath.Join(tmp, manifestPath), []byte(body), 0o644); err != nil {
-				return nil, warnings, err
-			}
-			if strings.EqualFold(manifestPath, pluginpkg.CodexManifest) {
-				if hookBody, err := t.fetchText(ctx, fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", src.Owner, src.Repo, branch, joinURLPath(src.Path, "hooks/session-start-codex"))); err == nil {
-					hookPath := filepath.Join(tmp, "hooks", "session-start-codex")
-					if mkErr := os.MkdirAll(filepath.Dir(hookPath), 0o755); mkErr == nil {
-						_ = os.WriteFile(hookPath, []byte(hookBody), 0o755)
-					}
-				}
-			}
-			pkg, pkgWarnings, err := pluginpkg.ParseDir(tmp)
-			warnings = append(warnings, pkgWarnings...)
-			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("%s: %s", rawURL, err.Error()))
-				continue
-			}
-			act := t.pluginPackageAction(req, pkg, req.Source)
-			act.Source = req.Source
-			return []action{act}, warnings, nil
-		}
+	// Plan against the same source tree apply will install (a shallow clone
+	// via pluginSource). A manifest-only fetch cannot see conventional
+	// capability directories (skills/, commands/) or their warnings, so it
+	// under-reports the capability set — and the plan the user approves must
+	// describe exactly what apply installs.
+	root, cleanup, err := t.pluginSource(ctx, req.Source, modeForPlugin(req.Mode))
+	if err != nil {
+		return nil, nil, err
 	}
-	return nil, warnings, newErr(ErrManifestMissing, "no plugin manifest found in GitHub repository %s/%s", src.Owner, src.Repo)
+	defer cleanup()
+	pkg, warnings, err := pluginpkg.ParseDir(root)
+	if err != nil {
+		return nil, warnings, newErr(ErrManifestMissing, "no plugin manifest found in GitHub repository %s/%s: %v", src.Owner, src.Repo, err)
+	}
+	act := t.pluginPackageAction(req, pkg, req.Source)
+	act.Source = req.Source
+	return []action{act}, warnings, nil
+}
+
+// pluginSource resolves a plugin source to an on-disk tree. Both the plan and
+// apply phases go through this single function so their views can never
+// diverge (the P1 approval-contract guarantee).
+func (t *installSourceTool) pluginSource(ctx context.Context, source, mode string) (string, func(), error) {
+	if t.preparePlugin != nil {
+		return t.preparePlugin(ctx, source, mode)
+	}
+	return t.preparePluginSource(ctx, source, mode)
 }
 
 func (t *installSourceTool) pluginPackageAction(req request, pkg pluginpkg.Package, source string) action {
@@ -126,7 +113,7 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 		return newErr(ErrInvalidManifest, "invalid plugin name %q", act.Name)
 	}
 	target := pluginpkg.InstallRoot(t.reasonixHome, act.Name)
-	sourceRoot, cleanup, err := t.preparePluginSource(ctx, act.Source, act.Mode)
+	sourceRoot, cleanup, err := t.pluginSource(ctx, act.Source, act.Mode)
 	if err != nil {
 		return err
 	}

--- a/internal/installsource/skill.go
+++ b/internal/installsource/skill.go
@@ -310,10 +310,19 @@ func mustRel(base, path string) string {
 
 // copyDir walks src and writes a parallel tree under dst. O_EXCL refuses to
 // overwrite a leaf; a leftover partial tree is left on disk for the user to
-// inspect (we never rm -rf). Symlinks inside src are followed once and
-// copied as the resolved file, which is what skill directories expect.
+// inspect (we never rm -rf). A symlink is materialized as its resolved
+// content only when it points at a regular file INSIDE src — discovery
+// (skills and commands) follows links, so dropping an in-tree alias would
+// install less than the plan counted. Everything else a link can be —
+// escaping the tree, broken, or a directory — is skipped, never followed:
+// the plugin-package apply path verifies capability counts after the copy,
+// so a skipped link fails the install closed instead of silently shrinking it.
 func copyDir(src, dst string) error {
 	var copied int64
+	srcRoot := src
+	if resolved, err := filepath.EvalSymlinks(src); err == nil {
+		srcRoot = resolved
+	}
 	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -329,10 +338,26 @@ func copyDir(src, dst string) error {
 			}
 			return os.MkdirAll(target, 0o755)
 		}
+		source := path
 		if !d.Type().IsRegular() {
-			return nil
+			if d.Type()&os.ModeSymlink == 0 {
+				return nil
+			}
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return nil // broken link
+			}
+			relToRoot, err := filepath.Rel(srcRoot, resolved)
+			if err != nil || relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+				return nil // escapes the tree — never follow
+			}
+			info, err := os.Stat(resolved)
+			if err != nil || !info.Mode().IsRegular() {
+				return nil // directory or otherwise unmaterializable link
+			}
+			source = resolved
 		}
-		info, err := d.Info()
+		info, err := os.Stat(source)
 		if err != nil {
 			return err
 		}
@@ -340,7 +365,7 @@ func copyDir(src, dst string) error {
 		if copied > maxSkillCopyBytes {
 			return newErr(ErrInvalidManifest, "skill directory exceeds %d bytes", maxSkillCopyBytes)
 		}
-		in, err := os.Open(path)
+		in, err := os.Open(source)
 		if err != nil {
 			return err
 		}

--- a/internal/installsource/types.go
+++ b/internal/installsource/types.go
@@ -87,6 +87,8 @@ type action struct {
 	Headers       map[string]string `json:"headers,omitempty"`
 	Skills        []string          `json:"skills,omitempty"`
 	SkillCount    int               `json:"skillCount,omitempty"`
+	Commands      []string          `json:"commands,omitempty"`
+	CommandCount  int               `json:"commandCount,omitempty"`
 	Layout        string            `json:"layout,omitempty"`        // canonical_dir|flat_compat|registered_root
 	InstallRoot   string            `json:"installRoot,omitempty"`   // skills root or registered custom root
 	CanonicalPath string            `json:"canonicalPath,omitempty"` // <skill-name>/SKILL.md when applicable

--- a/internal/installsource/types.go
+++ b/internal/installsource/types.go
@@ -89,6 +89,7 @@ type action struct {
 	SkillCount    int               `json:"skillCount,omitempty"`
 	Commands      []string          `json:"commands,omitempty"`
 	CommandCount  int               `json:"commandCount,omitempty"`
+	Commit        string            `json:"commit,omitempty"`        // resolved git snapshot the plan describes; apply pins to it
 	Layout        string            `json:"layout,omitempty"`        // canonical_dir|flat_compat|registered_root
 	InstallRoot   string            `json:"installRoot,omitempty"`   // skills root or registered custom root
 	CanonicalPath string            `json:"canonicalPath,omitempty"` // <skill-name>/SKILL.md when applicable

--- a/internal/pluginpkg/describe.go
+++ b/internal/pluginpkg/describe.go
@@ -71,7 +71,7 @@ func InstalledShowText(reasonixHome, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	skills, hooks, mcp := pkg.CapabilityCounts()
+	skills, commands, hooks, mcp := pkg.CapabilityCounts()
 	state := "disabled"
 	if p.Enabled {
 		state = "enabled"
@@ -82,11 +82,11 @@ func InstalledShowText(reasonixHome, name string) (string, error) {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "plugin %s [%s]\n", p.Name, state)
-	fmt.Fprintf(&b, "version: %s\nkind: %s\nroot: %s\nsource: %s\ncapabilities: %d skills, %d hooks, %d MCP servers\n", version, p.ManifestKind, filepath.Clean(root), p.Source, skills, hooks, mcp)
+	fmt.Fprintf(&b, "version: %s\nkind: %s\nroot: %s\nsource: %s\ncapabilities: %d skills, %d commands, %d hooks, %d MCP servers\n", version, p.ManifestKind, filepath.Clean(root), p.Source, skills, commands, hooks, mcp)
 	if p.Enabled {
-		b.WriteString("usage: enabled plugins load into new sessions; use /skills, invoke /<skill>, or ask naturally.\n")
+		b.WriteString("usage: enabled plugins load into new sessions; use /skills, invoke /<skill> or /<command>, or ask naturally.\n")
 	} else {
-		b.WriteString("usage: enable this plugin before its skills, hooks, or MCP servers participate in sessions.\n")
+		b.WriteString("usage: enable this plugin before its skills, commands, hooks, or MCP servers participate in sessions.\n")
 	}
 	appendInventoryText(&b, pkg.Inventory())
 	for _, warning := range warnings {
@@ -114,10 +114,13 @@ func pluginCapabilityText(reasonixHome string, p InstalledPlugin) string {
 	if err != nil {
 		return "invalid: " + err.Error()
 	}
-	skills, hooks, mcp := pkg.CapabilityCounts()
+	skills, commands, hooks, mcp := pkg.CapabilityCounts()
 	parts := []string{}
 	if skills > 0 {
 		parts = append(parts, fmt.Sprintf("%d skills", skills))
+	}
+	if commands > 0 {
+		parts = append(parts, fmt.Sprintf("%d commands", commands))
 	}
 	if hooks > 0 {
 		parts = append(parts, fmt.Sprintf("%d hooks", hooks))
@@ -132,6 +135,24 @@ func pluginCapabilityText(reasonixHome string, p InstalledPlugin) string {
 }
 
 func appendInventoryText(b *strings.Builder, inv Inventory) {
+	if len(inv.Commands) > 0 {
+		b.WriteString("commands:\n")
+		for _, cmd := range inv.Commands {
+			desc := oneLine(cmd.Description)
+			if desc == "" {
+				desc = "(no description)"
+			}
+			invocation := cmd.Invocation
+			if invocation == "" {
+				invocation = "/" + cmd.Name
+			}
+			if cmd.ArgHint != "" {
+				fmt.Fprintf(b, "  %s %s - %s\n", invocation, cmd.ArgHint, desc)
+			} else {
+				fmt.Fprintf(b, "  %s - %s\n", invocation, desc)
+			}
+		}
+	}
 	if len(inv.Skills) > 0 {
 		b.WriteString("skills:\n")
 		for _, sk := range inv.Skills {

--- a/internal/pluginpkg/describe.go
+++ b/internal/pluginpkg/describe.go
@@ -200,7 +200,7 @@ func appendInventoryText(b *strings.Builder, inv Inventory) {
 			fmt.Fprintf(b, "  %s [%s] - %s\n", server.Name, server.Transport, target)
 		}
 	}
-	if len(inv.Skills) == 0 && len(inv.Hooks) == 0 && len(inv.MCPServers) == 0 {
+	if len(inv.Skills) == 0 && len(inv.Commands) == 0 && len(inv.Hooks) == 0 && len(inv.MCPServers) == 0 {
 		b.WriteString("capabilities: no detailed inventory available\n")
 	}
 }

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"reasonix/internal/command"
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/frontmatter"
@@ -42,6 +43,7 @@ type Package struct {
 
 type Inventory struct {
 	Skills     []SkillRef
+	Commands   []CommandRef
 	Hooks      []HookRef
 	MCPServers []MCPServerRef
 }
@@ -52,6 +54,16 @@ type SkillRef struct {
 	Path        string
 	Invocation  string
 	RunAs       string
+}
+
+// CommandRef is one custom slash command a plugin contributes: a flat <name>.md
+// prompt template invoked as /<name> (Claude plugin commands map here 1:1).
+type CommandRef struct {
+	Name        string
+	Description string
+	ArgHint     string
+	Path        string
+	Invocation  string
 }
 
 type HookRef struct {
@@ -77,8 +89,12 @@ type Manifest struct {
 	Homepage    string
 	Repository  string
 	Skills      []string
-	Hooks       map[string][]Hook
-	MCPServers  map[string]MCPServer
+	// Commands are directories of flat <name>.md slash-command prompt templates
+	// (rendered with $ARGUMENTS/$1..$N on /<name>). Declared explicitly in a
+	// manifest or adopted from a Claude plugin's conventional commands/ dir.
+	Commands   []string
+	Hooks      map[string][]Hook
+	MCPServers map[string]MCPServer
 }
 
 type Hook struct {
@@ -290,6 +306,7 @@ func parseNative(path, root string) (Package, []string, error) {
 		Homepage    string               `json:"homepage"`
 		Repository  string               `json:"repository"`
 		Skills      json.RawMessage      `json:"skills"`
+		Commands    json.RawMessage      `json:"commands"`
 		Hooks       map[string][]Hook    `json:"hooks"`
 		MCPServers  map[string]MCPServer `json:"mcpServers"`
 	}
@@ -300,6 +317,10 @@ func parseNative(path, root string) (Package, []string, error) {
 	if err != nil {
 		return Package{}, nil, err
 	}
+	commands, err := parseSkillPaths(raw.Commands)
+	if err != nil {
+		return Package{}, nil, err
+	}
 	manifest := Manifest{
 		Name:        strings.TrimSpace(raw.Name),
 		Version:     strings.TrimSpace(raw.Version),
@@ -307,6 +328,7 @@ func parseNative(path, root string) (Package, []string, error) {
 		Homepage:    strings.TrimSpace(raw.Homepage),
 		Repository:  strings.TrimSpace(raw.Repository),
 		Skills:      skills,
+		Commands:    commands,
 		Hooks:       normalizeHooks(raw.Hooks),
 		MCPServers:  raw.MCPServers,
 	}
@@ -336,11 +358,16 @@ func parseCodexLike(path, root, kind string, includeCodexSessionStartHook bool) 
 		Homepage    string          `json:"homepage"`
 		Repository  string          `json:"repository"`
 		Skills      json.RawMessage `json:"skills"`
+		Commands    json.RawMessage `json:"commands"`
 	}
 	if err := readJSONFile(path, &raw); err != nil {
 		return Package{}, nil, err
 	}
 	skills, err := parseSkillPaths(raw.Skills)
+	if err != nil {
+		return Package{}, nil, err
+	}
+	commands, err := parseSkillPaths(raw.Commands)
 	if err != nil {
 		return Package{}, nil, err
 	}
@@ -351,6 +378,7 @@ func parseCodexLike(path, root, kind string, includeCodexSessionStartHook bool) 
 		Homepage:    strings.TrimSpace(raw.Homepage),
 		Repository:  strings.TrimSpace(raw.Repository),
 		Skills:      skills,
+		Commands:    commands,
 	}
 	hookPath := filepath.Join(root, "hooks", "session-start-codex")
 	if includeCodexSessionStartHook {
@@ -381,15 +409,25 @@ func parseCodexLike(path, root, kind string, includeCodexSessionStartHook bool) 
 // plugin.json, whose manifest usually carries metadata only.
 var claudeConventionSkillDirs = []string{"skills", ".claude/skills"}
 
+// claudeConventionCommandDirs are the directories a Claude plugin loads slash
+// commands from by convention. A command is a flat <name>.md prompt template
+// the user invokes as /<name> — exactly Reasonix's custom-command shape
+// (internal/command) — so these directories map onto Manifest.Commands and
+// join command discovery at the lowest priority. Unlike skill dirs they are
+// adopted even when the manifest declares skills explicitly, because
+// plugin.json never lists commands.
+var claudeConventionCommandDirs = []string{"commands", ".claude/commands"}
+
 // claudeUnmappedCapabilities are the conventional Claude plugin surfaces
 // Reasonix does not map yet. Their presence is worth a warning: silently
 // installing a package while dropping half its capabilities reads as "install
 // succeeded" when it mostly didn't.
-var claudeUnmappedCapabilities = []string{"commands", "agents", "hooks/hooks.json", ".mcp.json"}
+var claudeUnmappedCapabilities = []string{"agents", "hooks/hooks.json", ".mcp.json"}
 
 // applyClaudeConventionDirs fills manifest.Skills from the conventional skill
 // directories when the manifest declares none (the standard Claude plugin
-// shape), and reports the conventional capabilities Reasonix cannot map.
+// shape), adopts conventional command directories into manifest.Commands, and
+// reports the conventional capabilities Reasonix cannot map.
 func applyClaudeConventionDirs(root string, manifest *Manifest) []string {
 	var warnings []string
 	if len(manifest.Skills) == 0 {
@@ -400,12 +438,29 @@ func applyClaudeConventionDirs(root string, manifest *Manifest) []string {
 			}
 		}
 	}
+	for _, rel := range claudeConventionCommandDirs {
+		dir := filepath.Join(root, filepath.FromSlash(rel))
+		if dirContainsCommandMd(dir) && !containsPathEntry(manifest.Commands, rel) {
+			manifest.Commands = append(manifest.Commands, rel)
+		}
+	}
 	for _, rel := range claudeUnmappedCapabilities {
 		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err == nil {
 			warnings = append(warnings, fmt.Sprintf("claude plugin declares %s, which Reasonix does not map yet; that capability will not be installed", rel))
 		}
 	}
 	return warnings
+}
+
+// containsPathEntry reports whether the manifest path list already names rel
+// (slash-normalized), so convention adoption never duplicates an explicit entry.
+func containsPathEntry(paths []string, rel string) bool {
+	for _, p := range paths {
+		if filepath.ToSlash(filepath.Clean(filepath.FromSlash(p))) == rel {
+			return true
+		}
+	}
+	return false
 }
 
 // dirContainsSkill reports whether dir holds at least one skill definition
@@ -421,6 +476,29 @@ func dirContainsSkill(dir string) bool {
 			continue
 		}
 		if info, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err == nil && info.Mode().IsRegular() {
+			return true
+		}
+	}
+	return false
+}
+
+// dirContainsCommandMd reports whether dir holds at least one flat command
+// definition (<dir>/<name>.md with an installable name), so an empty
+// conventional command directory is not adopted as a command root.
+func dirContainsCommandMd(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() || !e.Type().IsRegular() {
+			continue
+		}
+		name := e.Name()
+		if !strings.EqualFold(filepath.Ext(name), ".md") {
+			continue
+		}
+		if IsValidName(strings.TrimSuffix(name, filepath.Ext(name))) {
 			return true
 		}
 	}
@@ -641,6 +719,11 @@ func validateManifest(root string, m *Manifest) error {
 			return err
 		}
 	}
+	for _, p := range m.Commands {
+		if err := validateRelativePath(p); err != nil {
+			return err
+		}
+	}
 	for event, hooks := range m.Hooks {
 		if strings.TrimSpace(event) == "" {
 			return fmt.Errorf("hook event is required")
@@ -697,8 +780,20 @@ func (p Package) SkillRoots() []string {
 	return out
 }
 
-func (p Package) CapabilityCounts() (skills, hooks, mcp int) {
+// CommandRoots returns the absolute command directories this package
+// contributes to custom slash-command discovery.
+func (p Package) CommandRoots() []string {
+	var out []string
+	for _, rel := range p.Manifest.Commands {
+		out = append(out, filepath.Join(p.Root, filepath.FromSlash(rel)))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (p Package) CapabilityCounts() (skills, commands, hooks, mcp int) {
 	skills = len(p.skillRefs())
+	commands = len(p.commandRefs())
 	for _, hs := range p.Manifest.Hooks {
 		hooks += len(hs)
 	}
@@ -709,9 +804,32 @@ func (p Package) CapabilityCounts() (skills, hooks, mcp int) {
 func (p Package) Inventory() Inventory {
 	return Inventory{
 		Skills:     p.skillRefs(),
+		Commands:   p.commandRefs(),
 		Hooks:      p.hookRefs(),
 		MCPServers: p.mcpServerRefs(),
 	}
+}
+
+// commandRefs loads the package's command dirs through the same loader the
+// runtime uses (internal/command), so names, namespacing, and frontmatter
+// semantics can never drift between the inventory and actual invocation.
+func (p Package) commandRefs() []CommandRef {
+	roots := p.CommandRoots()
+	if len(roots) == 0 {
+		return nil
+	}
+	cmds, _ := command.Load(roots...) // best-effort: malformed files are surfaced at load time elsewhere
+	out := make([]CommandRef, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, CommandRef{
+			Name:        c.Name,
+			Description: c.Description,
+			ArgHint:     c.ArgHint,
+			Path:        c.Source,
+			Invocation:  "/" + c.Name,
+		})
+	}
+	return out
 }
 
 func (p Package) skillRefs() []SkillRef {

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -483,35 +483,12 @@ func dirContainsSkill(dir string) bool {
 }
 
 // dirContainsCommandMd reports whether dir holds at least one command
-// definition (a <name>.md with an installable name stem) at any nesting depth
-// — the runtime loader (internal/command) walks namespace subdirectories like
-// commands/git/commit.md, so adoption gating must see them too. Hidden
-// directories are skipped and depth is bounded to keep adoption scans cheap.
-func dirContainsCommandMd(dir string) bool { return dirContainsCommandMdAtDepth(dir, 1) }
-
-func dirContainsCommandMdAtDepth(dir string, depth int) bool {
-	const maxCommandScanDepth = 5
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() {
-			if depth < maxCommandScanDepth && !strings.HasPrefix(name, ".") &&
-				dirContainsCommandMdAtDepth(filepath.Join(dir, name), depth+1) {
-				return true
-			}
-			continue
-		}
-		if !e.Type().IsRegular() || !strings.EqualFold(filepath.Ext(name), ".md") {
-			continue
-		}
-		if IsValidName(strings.TrimSuffix(name, filepath.Ext(name))) {
-			return true
-		}
-	}
-	return false
+// definition. It delegates to the runtime loader (internal/command), so the
+// adoption gate and what /<name> actually loads can never diverge — including
+// arbitrarily nested namespace layouts like commands/a/b/c/commit.md.
+func dirContainsCommandMd(dir string) bool {
+	cmds, _ := command.Load(dir) // best-effort: a missing dir or malformed files load nothing
+	return len(cmds) > 0
 }
 
 func ManifestPath(kind string) string {

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -482,20 +482,29 @@ func dirContainsSkill(dir string) bool {
 	return false
 }
 
-// dirContainsCommandMd reports whether dir holds at least one flat command
-// definition (<dir>/<name>.md with an installable name), so an empty
-// conventional command directory is not adopted as a command root.
-func dirContainsCommandMd(dir string) bool {
+// dirContainsCommandMd reports whether dir holds at least one command
+// definition (a <name>.md with an installable name stem) at any nesting depth
+// — the runtime loader (internal/command) walks namespace subdirectories like
+// commands/git/commit.md, so adoption gating must see them too. Hidden
+// directories are skipped and depth is bounded to keep adoption scans cheap.
+func dirContainsCommandMd(dir string) bool { return dirContainsCommandMdAtDepth(dir, 1) }
+
+func dirContainsCommandMdAtDepth(dir string, depth int) bool {
+	const maxCommandScanDepth = 5
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() || !e.Type().IsRegular() {
+		name := e.Name()
+		if e.IsDir() {
+			if depth < maxCommandScanDepth && !strings.HasPrefix(name, ".") &&
+				dirContainsCommandMdAtDepth(filepath.Join(dir, name), depth+1) {
+				return true
+			}
 			continue
 		}
-		name := e.Name()
-		if !strings.EqualFold(filepath.Ext(name), ".md") {
+		if !e.Type().IsRegular() || !strings.EqualFold(filepath.Ext(name), ".md") {
 			continue
 		}
 		if IsValidName(strings.TrimSuffix(name, filepath.Ext(name))) {

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -40,7 +40,7 @@ func TestParseCodexSuperpowersManifest(t *testing.T) {
 	if len(inv.Skills) != 1 || inv.Skills[0].Name != "plan" || inv.Skills[0].Invocation != "/plan" {
 		t.Fatalf("Inventory().Skills = %+v", inv.Skills)
 	}
-	if skills, hooks, _ := pkg.CapabilityCounts(); skills != 1 || hooks != 1 {
+	if skills, _, hooks, _ := pkg.CapabilityCounts(); skills != 1 || hooks != 1 {
 		t.Fatalf("CapabilityCounts skills=%d hooks=%d", skills, hooks)
 	}
 }
@@ -329,13 +329,111 @@ func TestParseClaudePluginWarnsOnUnmappedCapabilities(t *testing.T) {
 		t.Fatalf("ParseDir: %v", err)
 	}
 	joined := strings.Join(warnings, "\n")
-	for _, want := range []string{"commands", "hooks/hooks.json", ".mcp.json"} {
+	for _, want := range []string{"hooks/hooks.json", ".mcp.json"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("warnings = %v, want mention of %s", warnings, want)
 		}
 	}
+	// commands map to custom slash commands now — they must not warn.
+	if strings.Contains(joined, "commands") {
+		t.Fatalf("warnings = %v, must not warn about the mapped commands dir", warnings)
+	}
 	if strings.Contains(joined, "agents") {
 		t.Fatalf("warnings = %v, must not mention absent agents dir", warnings)
+	}
+}
+
+// TestParseClaudePluginMapsCommandsDir pins the commands mapping: a Claude
+// plugin's conventional commands/ dir becomes a Manifest.Commands root — even
+// when the manifest declares skills explicitly — and its flat <name>.md
+// templates surface in the inventory as /<name> invocations.
+func TestParseClaudePluginMapsCommandsDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "pwf-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "planner", "SKILL.md"), "---\ndescription: planner skill\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "commands", "plan.md"), "---\ndescription: \"Start planning\"\nargument-hint: \"[task]\"\n---\nPlan: $ARGUMENTS")
+	writeTestFile(t, filepath.Join(root, "commands", "status.md"), "Show status")
+
+	pkg, warnings, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none for a fully mapped plugin", warnings)
+	}
+	if got := pkg.CommandRoots(); len(got) != 1 || got[0] != filepath.Join(root, "commands") {
+		t.Fatalf("CommandRoots = %#v, want the conventional commands dir", got)
+	}
+	inv := pkg.Inventory()
+	if len(inv.Commands) != 2 {
+		t.Fatalf("inventory commands = %#v, want plan and status", inv.Commands)
+	}
+	byName := map[string]CommandRef{}
+	for _, c := range inv.Commands {
+		byName[c.Name] = c
+	}
+	plan, ok := byName["plan"]
+	if !ok || plan.Invocation != "/plan" || plan.Description != "Start planning" || plan.ArgHint != "[task]" {
+		t.Fatalf("plan command = %+v, want /plan with description and arg hint", plan)
+	}
+	if _, ok := byName["status"]; !ok {
+		t.Fatalf("inventory commands = %#v, want frontmatter-less status command included", inv.Commands)
+	}
+	skills, commands, hooks, mcp := pkg.CapabilityCounts()
+	if skills != 1 || commands != 2 || hooks != 0 || mcp != 0 {
+		t.Fatalf("CapabilityCounts = %d skills %d commands %d hooks %d mcp, want 1/2/0/0", skills, commands, hooks, mcp)
+	}
+
+	// Explicit skills declaration must not disable command adoption.
+	root2 := t.TempDir()
+	writeTestFile(t, filepath.Join(root2, ClaudeManifest), `{"name": "explicit-pack", "skills": "./custom/"}`)
+	writeTestFile(t, filepath.Join(root2, "custom", "one", "SKILL.md"), "---\ndescription: one\n---\nbody")
+	writeTestFile(t, filepath.Join(root2, "commands", "go.md"), "go")
+	pkg2, _, err := ParseDir(root2)
+	if err != nil {
+		t.Fatalf("ParseDir explicit: %v", err)
+	}
+	if got := pkg2.CommandRoots(); len(got) != 1 || got[0] != filepath.Join(root2, "commands") {
+		t.Fatalf("CommandRoots = %#v, want commands adopted alongside explicit skills", got)
+	}
+
+	// A docs-only commands dir (no installable <name>.md) is not adopted.
+	root3 := t.TempDir()
+	writeTestFile(t, filepath.Join(root3, ClaudeManifest), `{"name": "docs-pack"}`)
+	writeTestFile(t, filepath.Join(root3, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeTestFile(t, filepath.Join(root3, "commands", "notes.txt"), "not a command")
+	pkg3, _, err := ParseDir(root3)
+	if err != nil {
+		t.Fatalf("ParseDir docs-only: %v", err)
+	}
+	if got := pkg3.CommandRoots(); len(got) != 0 {
+		t.Fatalf("CommandRoots = %#v, want none for a commands dir without .md files", got)
+	}
+}
+
+// TestNativeManifestCommandsField pins the explicit "commands" declaration in
+// reasonix-plugin.json, including path validation.
+func TestNativeManifestCommandsField(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, NativeManifest), `{"name": "native-pack", "commands": ["cmds"]}`)
+	writeTestFile(t, filepath.Join(root, "cmds", "ship.md"), "---\ndescription: ship it\n---\nShip $1")
+
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if got := pkg.CommandRoots(); len(got) != 1 || got[0] != filepath.Join(root, "cmds") {
+		t.Fatalf("CommandRoots = %#v, want declared cmds dir", got)
+	}
+	inv := pkg.Inventory()
+	if len(inv.Commands) != 1 || inv.Commands[0].Name != "ship" {
+		t.Fatalf("inventory commands = %#v, want ship", inv.Commands)
+	}
+
+	rootBad := t.TempDir()
+	writeTestFile(t, filepath.Join(rootBad, NativeManifest), `{"name": "bad-pack", "commands": ["../escape"]}`)
+	if _, _, err := ParseDir(rootBad); err == nil {
+		t.Fatal("ParseDir must reject a commands path escaping the plugin root")
 	}
 }
 

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -516,3 +516,25 @@ func TestInventoryTextCommandsOnly(t *testing.T) {
 		t.Fatalf("output = %q, must not claim an empty inventory after listing commands", out)
 	}
 }
+
+// TestParseClaudePluginAdoptsDeeplyNestedCommands pins that adoption gating
+// shares the runtime loader's discovery semantics with no depth ceiling: a
+// plugin whose only command sits six levels deep is still adopted.
+func TestParseClaudePluginAdoptsDeeplyNestedCommands(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "deep-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "commands", "a", "b", "c", "d", "e", "commit.md"), "---\ndescription: deep commit\n---\nCommit")
+
+	pkg, _, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if got := pkg.CommandRoots(); len(got) != 1 || got[0] != filepath.Join(root, "commands") {
+		t.Fatalf("CommandRoots = %#v, want commands adopted for the deeply nested layout", got)
+	}
+	inv := pkg.Inventory()
+	if len(inv.Commands) != 1 || inv.Commands[0].Name != "a:b:c:d:e:commit" {
+		t.Fatalf("inventory commands = %#v, want the namespaced deep command", inv.Commands)
+	}
+}

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -477,3 +477,42 @@ func TestParseCodexManifestNotAffectedByClaudeFallback(t *testing.T) {
 		t.Fatalf("SkillRoots = %#v, codex parsing must not adopt convention dirs", got)
 	}
 }
+
+// TestParseClaudePluginAdoptsNestedCommands pins that namespace layouts like
+// commands/git/commit.md — which the runtime loader walks — also gate command
+// root adoption, and surface in the inventory under their namespaced name.
+func TestParseClaudePluginAdoptsNestedCommands(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ClaudeManifest), `{"name": "nested-pack"}`)
+	writeTestFile(t, filepath.Join(root, "skills", "s", "SKILL.md"), "---\ndescription: s\n---\nbody")
+	writeTestFile(t, filepath.Join(root, "commands", "git", "commit.md"), "---\ndescription: commit helper\n---\nCommit: $ARGUMENTS")
+
+	pkg, warnings, err := ParseDir(root)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if got := pkg.CommandRoots(); len(got) != 1 || got[0] != filepath.Join(root, "commands") {
+		t.Fatalf("CommandRoots = %#v, want commands adopted for nested-only layout", got)
+	}
+	inv := pkg.Inventory()
+	if len(inv.Commands) != 1 || inv.Commands[0].Name != "git:commit" || inv.Commands[0].Invocation != "/git:commit" {
+		t.Fatalf("inventory commands = %#v, want namespaced git:commit", inv.Commands)
+	}
+}
+
+// TestInventoryTextCommandsOnly pins that a commands-only inventory does not
+// also claim "no detailed inventory available".
+func TestInventoryTextCommandsOnly(t *testing.T) {
+	var b strings.Builder
+	appendInventoryText(&b, Inventory{Commands: []CommandRef{{Name: "plan", Invocation: "/plan", Description: "plan things"}}})
+	out := b.String()
+	if !strings.Contains(out, "commands:") || !strings.Contains(out, "/plan") {
+		t.Fatalf("output = %q, want the commands listing", out)
+	}
+	if strings.Contains(out, "no detailed inventory available") {
+		t.Fatalf("output = %q, must not claim an empty inventory after listing commands", out)
+	}
+}


### PR DESCRIPTION
## Description

Refs discussion #5762 (report: `planning-with-files` "won't install" while `andrej-karpathy-skills` works).

The plugin actually installed — its 6 SKILL.md variants imported — but its primary interface is `commands/` (`/plan`, `/pwf`, `/start`, `/status` + locale variants), which Reasonix dropped with a *"claude plugin declares commands, which Reasonix does not map yet"* warning. To users that reads as a failed install, and the plugin's headline feature really was missing. `andrej-karpathy-skills` is a skills-only repo, so it mapped 100% with no warning — hence the confusing contrast.

### The fix: map the capability instead of warning about it

A Claude plugin command is exactly Reasonix's existing custom slash command shape (`internal/command`): a flat `<name>.md` prompt template with frontmatter `description` / `argument-hint`, `$ARGUMENTS` / `$1..$N` substitution, and subdirectory namespacing. So this PR routes plugin commands into that existing subsystem — no new invocation machinery:

1. **`internal/pluginpkg`** — `Manifest` gains `Commands []string`. All three manifest kinds accept an explicit `"commands"` path list; Claude plugins additionally adopt the conventional `commands/` and `.claude/commands/` dirs automatically (even when the manifest declares `skills` explicitly, since `plugin.json` never lists commands). Paths are validated like skill paths (no absolute / `..` escapes). `Inventory`/`CapabilityCounts`/describe output now report commands, loaded through `internal/command` itself so inventory names can never drift from runtime behavior. `commands` is removed from the unmapped-capabilities warning list (`agents/`, `hooks/hooks.json`, `.mcp.json` still warn).
2. **`internal/config`** — `CommandDirsForRoot` prepends enabled plugin packages' command roots at the **lowest priority**: both boot and hot `ReloadCommands` pick them up automatically, plugin commands appear in slash completion and the `slash_command` tool, and a user- or project-authored command always wins a name clash.
3. **CLI / install plans** — `plugin verify` checks command roots; install plans carry `commands` / `commandCount`; `plugin show` lists commands with arg hints.
4. **Desktop** — the plugin view exposes a commands count + details, and the capabilities panel renders a Commands section (en / zh / zh-TW strings added).
5. **Docs** — EN and zh-CN plugin docs describe the mapping.

### Backward compatibility

| Touch point | Old-data behavior | Conclusion |
| --- | --- | --- |
| `Manifest.Commands` (parsed, not persisted) | Manifests without `"commands"` parse to nil; behavior identical | safe |
| `plugin-packages.json` state file | Format untouched; already-installed plugins gain commands on next parse — no reinstall needed | safe |
| `CapabilityCounts` signature (3 → 4 values) | Compile-time only; all in-repo callers updated | safe |
| `CommandDirsForRoot` | Returns the same conventional dirs plus plugin roots prepended; no plugin state → unchanged list | safe |
| Desktop `PluginView` JSON | Additive `commands` / `commandDetails` fields; older frontends ignore them | safe |
| Command name clashes | Plugin dirs load first (lowest priority) — existing user/project commands always win | safe |

### Verification

- End-to-end against `planning-with-files` v3.4.0: `reasonix plugin install` completes with **zero warnings**, reporting 6 skills + 11 commands; `plugin show` lists `/plan`, `/pwf`, `/status` … with descriptions and arg hints.
- New regressions: commands-dir adoption (incl. alongside explicit skills, and docs-only dirs not adopted), native `"commands"` manifest field + path-escape rejection, `CommandDirsForRoot` plugin wiring incl. disabled-plugin exclusion and lowest-priority ordering.
- `go test ./...` (root) and `cd desktop && go test ./...` — pass; `go vet` / `gofmt` clean.
- Frontend: `tsc --noEmit` (app + test configs), capabilities-panel test, `check:css` — pass.

Follow-up (intentionally out of scope): `agents/` and `.mcp.json` mapping still warn; the desktop install-warning copy could be localized.

---

Cache-impact: low — system prompt and tool schemas untouched; plugin commands join the `slash_command` tool and slash completion exactly like existing custom commands, so provider-visible content changes only when the user installs/removes/toggles a plugin (same class as plugin skills today), and loading order is deterministic (sorted)

Cache-guard: go test ./internal/pluginpkg/ ./internal/config/ ./internal/installsource/ ./internal/command/ — pass (covers manifest parsing, command-dir wiring incl. lowest-priority ordering, install plans, and the command loader); end-to-end install of planning-with-files v3.4.0 verified 6 skills + 11 commands with zero warnings
