### PR TITLE
feat(plugin): qualify plugin slash commands / 插件斜杠命令使用限定名称

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5592,6 +5592,7 @@ type CommandInfo struct {
 	Description string `json:"description"`
 	Hint        string `json:"hint,omitempty"` // argument hint, if any
 	Kind        string `json:"kind"`           // "builtin" | "custom" | "mcp"
+	Plugin      string `json:"plugin,omitempty"`
 }
 
 // Commands lists the slash commands available this session — built-in actions,
@@ -5630,7 +5631,10 @@ func (a *App) Commands() []CommandInfo {
 		out = append(out, CommandInfo{Name: s.Name, Description: s.Description, Kind: "skill"})
 	}
 	for _, c := range ctrl.Commands() {
-		out = append(out, CommandInfo{Name: c.Name, Description: c.Description, Hint: c.ArgHint, Kind: "custom"})
+		if c.Hidden {
+			continue
+		}
+		out = append(out, CommandInfo{Name: c.Name, Description: c.Description, Hint: c.ArgHint, Kind: "custom", Plugin: c.Plugin})
 	}
 	if h := ctrl.Host(); h != nil {
 		for _, p := range h.Prompts() {

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -3,8 +3,9 @@ import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { MCPServersSettingsPage, PluginsSettingsPage } from "../components/CapabilitiesPanel";
+import { slashCommandKindTag } from "../components/SlashMenu";
 import type { AppBindings } from "../lib/bridge";
-import { LocaleProvider } from "../lib/i18n";
+import { LocaleProvider, t } from "../lib/i18n";
 import { mcpServerLifecycleActions, mcpServerRetryableFromAvailableList } from "../lib/mcpServerLifecycle";
 import type { Meta, PluginInstallOptions, PluginView, ServerView, TabMeta } from "../lib/types";
 
@@ -116,6 +117,11 @@ function setInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new inputEventCtor("input", { bubbles: true, data: value, inputType: "insertText" } as InputEventInit));
   input.dispatchEvent(new eventCtor("change", { bubbles: true }));
 }
+
+ok(
+  slashCommandKindTag({ name: "pwf:plan", description: "Plugin planning prompt.", kind: "custom", plugin: "pwf" }, t) === "plugin · pwf",
+  "slash menu identifies the canonical plugin command source",
+);
 
 console.log("capabilities panel MCP actions");
 
@@ -455,9 +461,20 @@ console.log("capabilities panel plugin actions");
             manifestKind: "reasonix",
             enabled: true,
             skills: 3,
+            commands: 2,
             hooks: 1,
             mcpServers: 1,
             skillDetails: [{ name: "plan", description: "Plan work before implementation.", invocation: "/plan", runAs: "inline" }],
+            commandDetails: [{
+              name: "plan",
+              description: "Plugin planning prompt.",
+              invocation: "/superpowers:plan",
+            }, {
+              name: "blocked",
+              description: "Occupied canonical command.",
+              invocation: "/superpowers:blocked",
+              shadowed: true,
+            }],
             hookDetails: [{ event: "SessionStart", contextFile: "CLAUDE.md", description: "Load startup context." }],
             mcpServerDetails: [{ name: "context", transport: "stdio", command: "node server.js" }],
           };
@@ -552,6 +569,8 @@ console.log("capabilities panel plugin actions");
   await waitFor("plugin update action", () => Boolean(findButton("Update")));
   ok(document.body.textContent?.includes("How to use") ?? false, "expanded plugin details explain how to use the plugin");
   ok(document.body.textContent?.includes("/plan") ?? false, "expanded plugin details list exported skill invocations");
+  ok(document.body.textContent?.includes("/superpowers:plan") ?? false, "plugin details show the canonical qualified invocation");
+  ok(document.body.textContent?.includes("qualified name is occupied by a user or project command") ?? false, "occupied canonical command explains the winning source");
   ok(document.body.textContent?.includes("SessionStart") ?? false, "expanded plugin details list exported hooks");
   ok(document.body.textContent?.includes("context") ?? false, "expanded plugin details list exported MCP servers");
 

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2062,8 +2062,16 @@ function PluginCommandList({ commands }: { commands: PluginCommandView[] }) {
 						<div className="cap-plugin-capability__line">
 							<span className="cap-plugin-capability__name">{command.invocation || `/${command.name}`}</span>
 							{command.argHint && <span className="cap-source-badge">{command.argHint}</span>}
+							{command.shadowed && <span className="cap-source-badge">{t("caps.pluginCommandShadowed")}</span>}
 						</div>
 						<div className="cap-plugin-capability__desc">{command.description || t("caps.pluginNoDescription")}</div>
+						{command.shadowed && (
+							<div className="cap-plugin-capability__hint">
+								{command.shadowedByPlugin
+									? t("caps.pluginCommandQualifiedOccupiedByPlugin", { plugin: command.shadowedByPlugin })
+									: t("caps.pluginCommandQualifiedOccupiedByCustom")}
+							</div>
+						)}
 					</div>
 				))}
 			</div>

--- a/desktop/frontend/src/components/SlashMenu.tsx
+++ b/desktop/frontend/src/components/SlashMenu.tsx
@@ -1,6 +1,16 @@
-import { useT } from "../lib/i18n";
+import { useT, type Translator } from "../lib/i18n";
 import type { CommandInfo } from "../lib/types";
 import { VirtualMenu } from "./VirtualMenu";
+
+export function slashCommandKindTag(command: CommandInfo, t: Translator): string {
+  if (command.plugin) {
+    return t("slash.plugin", { name: command.plugin });
+  }
+  if (command.kind === "custom") return t("slash.project");
+  if (command.kind === "mcp") return t("slash.mcp");
+  if (command.kind === "skill") return t("slash.skill");
+  return "";
+}
 
 // SlashMenu is the "/" autocomplete dropdown above the composer. Presentational:
 // the Composer owns filtering, the active index, and key handling; this renders
@@ -18,15 +28,6 @@ export function SlashMenu({
   onHover: (i: number) => void;
 }) {
   const t = useT();
-  // builtin commands get no tag; custom (project) and mcp commands are labelled.
-  const kindTag = (kind: CommandInfo["kind"]) =>
-    kind === "custom"
-      ? t("slash.project")
-      : kind === "mcp"
-        ? t("slash.mcp")
-        : kind === "skill"
-          ? t("slash.skill")
-          : "";
   return (
     <VirtualMenu
       items={items}
@@ -46,7 +47,7 @@ export function SlashMenu({
           <span className="slashmenu__name">/{c.name}</span>
           {c.hint && <span className="slashmenu__hint">{c.hint}</span>}
           <span className="slashmenu__desc">{c.description}</span>
-          {kindTag(c.kind) && <span className="slashmenu__kind">{kindTag(c.kind)}</span>}
+          {slashCommandKindTag(c, t) && <span className="slashmenu__kind">{slashCommandKindTag(c, t)}</span>}
         </button>
       )}
     />

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -588,6 +588,7 @@ export interface CommandInfo {
   description: string;
   hint?: string;
   kind: "builtin" | "custom" | "mcp" | "skill";
+  plugin?: string;
 }
 
 export interface DirEntry {
@@ -753,6 +754,8 @@ export interface PluginCommandView {
   argHint?: string;
   path?: string;
   invocation?: string;
+  shadowed?: boolean;
+  shadowedByPlugin?: string;
 }
 export interface PluginHookView {
   event: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -367,7 +367,10 @@ export const en = {
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "Browse with /skills, invoke directly, or ask for the workflow by name.",
   "caps.pluginCommandsTitle": "Commands",
-  "caps.pluginCommandsHint": "Slash-command prompt templates; type /<name> to run one.",
+  "caps.pluginCommandsHint": "Slash-command prompt templates; type /<plugin>:<name> to run one.",
+  "caps.pluginCommandShadowed": "overridden",
+  "caps.pluginCommandQualifiedOccupiedByPlugin": "Its qualified name is occupied by plugin {plugin}.",
+  "caps.pluginCommandQualifiedOccupiedByCustom": "Its qualified name is occupied by a user or project command.",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks trigger automatically on matching lifecycle events.",
   "caps.pluginMCPTitle": "MCP servers",
@@ -1880,6 +1883,7 @@ export const en = {
 
   // slash menu tags
   "slash.project": "project",
+  "slash.plugin": "plugin · {name}",
   "slash.mcp": "mcp",
   "slash.skill": "skill",
 

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -283,7 +283,10 @@ export const zhTW: Record<DictKey, string> = {
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "用 /skills 瀏覽，直接呼叫，或在對話中說出工作流名稱。",
   "caps.pluginCommandsTitle": "Commands",
-  "caps.pluginCommandsHint": "斜線命令模板，輸入 /<名稱> 即可執行。",
+  "caps.pluginCommandsHint": "斜線命令模板，輸入 /<外掛名>:<命令名> 即可執行。",
+  "caps.pluginCommandShadowed": "已覆蓋",
+  "caps.pluginCommandQualifiedOccupiedByPlugin": "該限定名稱已被外掛 {plugin} 占用。",
+  "caps.pluginCommandQualifiedOccupiedByCustom": "該限定名稱已被使用者或專案命令占用。",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks 會在匹配的生命週期事件中自動觸發。",
   "caps.pluginMCPTitle": "MCP 伺服器",
@@ -1216,6 +1219,7 @@ export const zhTW: Record<DictKey, string> = {
 
   // 斜線選單標籤
   "slash.project": "專案",
+  "slash.plugin": "外掛 · {name}",
   "slash.mcp": "mcp",
   "slash.skill": "skill",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -368,7 +368,10 @@ export const zh: Record<DictKey, string> = {
   "caps.pluginSkillsTitle": "Skills",
   "caps.pluginSkillsHint": "用 /skills 浏览，直接调用，或在对话中说出工作流名称。",
   "caps.pluginCommandsTitle": "Commands",
-  "caps.pluginCommandsHint": "斜杠命令模板，输入 /<名称> 即可运行。",
+  "caps.pluginCommandsHint": "斜杠命令模板，输入 /<插件名>:<命令名> 即可运行。",
+  "caps.pluginCommandShadowed": "已覆盖",
+  "caps.pluginCommandQualifiedOccupiedByPlugin": "该限定名称已被插件 {plugin} 占用。",
+  "caps.pluginCommandQualifiedOccupiedByCustom": "该限定名称已被用户或项目命令占用。",
   "caps.pluginHooksTitle": "Hooks",
   "caps.pluginHooksHint": "Hooks 会在匹配的生命周期事件中自动触发。",
   "caps.pluginMCPTitle": "MCP 服务器",
@@ -1882,6 +1885,7 @@ export const zh: Record<DictKey, string> = {
 
   // 斜杠菜单标签
   "slash.project": "项目",
+  "slash.plugin": "插件 · {name}",
   "slash.mcp": "mcp",
   "slash.skill": "skill",
 

--- a/desktop/plugin_packages_app.go
+++ b/desktop/plugin_packages_app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"reasonix/internal/command"
 	"reasonix/internal/config"
 	"reasonix/internal/installsource"
 	"reasonix/internal/pluginpkg"
@@ -48,11 +49,13 @@ type PluginSkillView struct {
 }
 
 type PluginCommandView struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	ArgHint     string `json:"argHint,omitempty"`
-	Path        string `json:"path,omitempty"`
-	Invocation  string `json:"invocation,omitempty"`
+	Name             string `json:"name"`
+	Description      string `json:"description,omitempty"`
+	ArgHint          string `json:"argHint,omitempty"`
+	Path             string `json:"path,omitempty"`
+	Invocation       string `json:"invocation,omitempty"`
+	Shadowed         bool   `json:"shadowed,omitempty"`
+	ShadowedByPlugin string `json:"shadowedByPlugin,omitempty"`
 }
 
 type PluginHookView struct {
@@ -75,6 +78,13 @@ func (a *App) Plugins() []PluginView {
 	if err != nil {
 		return []PluginView{{Error: err.Error()}}
 	}
+	a.mu.RLock()
+	ctrl := a.activeCtrlLocked()
+	a.mu.RUnlock()
+	var activeCommands []command.Command
+	if ctrl != nil {
+		activeCommands = ctrl.Commands()
+	}
 	out := make([]PluginView, 0, len(st.Plugins))
 	for _, p := range st.Plugins {
 		view := PluginView{
@@ -88,12 +98,33 @@ func (a *App) Plugins() []PluginView {
 		}
 		if pkg, warnings, err := pluginpkg.ParseDir(view.Root); err == nil {
 			applyPluginPackageDetails(&view, pkg, warnings)
+			decoratePluginCommandConflicts(&view, activeCommands)
 		} else {
 			view.Error = err.Error()
 		}
 		out = append(out, view)
 	}
 	return out
+}
+
+func decoratePluginCommandConflicts(view *PluginView, commands []command.Command) {
+	if view == nil || !view.Enabled || len(view.CommandDetails) == 0 || len(commands) == 0 {
+		return
+	}
+	byName := make(map[string]command.Command, len(commands))
+	for _, cmd := range commands {
+		byName[cmd.Name] = cmd
+	}
+	for i := range view.CommandDetails {
+		detail := &view.CommandDetails[i]
+		qualified := view.Name + ":" + detail.Name
+		winner, ok := byName[qualified]
+		if !ok || winner.Plugin == view.Name && winner.ShortName == detail.Name && !winner.Hidden {
+			continue
+		}
+		detail.Shadowed = true
+		detail.ShadowedByPlugin = winner.Plugin
+	}
 }
 
 func applyPluginPackageDetails(view *PluginView, pkg pluginpkg.Package, warnings []string) {
@@ -107,7 +138,7 @@ func applyPluginPackageDetails(view *PluginView, pkg pluginpkg.Package, warnings
 			Description: cmd.Description,
 			ArgHint:     cmd.ArgHint,
 			Path:        cmd.Path,
-			Invocation:  cmd.Invocation,
+			Invocation:  "/" + view.Name + ":" + cmd.Name,
 		})
 	}
 	view.SkillDetails = make([]PluginSkillView, 0, len(inv.Skills))

--- a/desktop/plugin_packages_app_test.go
+++ b/desktop/plugin_packages_app_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"reasonix/internal/command"
+)
+
+func TestDecoratePluginCommandConflicts(t *testing.T) {
+	view := PluginView{
+		Name:    "pwf",
+		Enabled: true,
+		CommandDetails: []PluginCommandView{
+			{Name: "plan", Invocation: "/pwf:plan"},
+			{Name: "status", Invocation: "/pwf:status"},
+			{Name: "new", Invocation: "/pwf:new"},
+		},
+	}
+	decoratePluginCommandConflicts(&view, []command.Command{
+		{Name: "plan", Plugin: "pwf", ShortName: "plan", Hidden: true},
+		{Name: "pwf:plan", Plugin: "pwf", ShortName: "plan"},
+		{Name: "pwf:status", Description: "explicit command"},
+	})
+
+	plan := view.CommandDetails[0]
+	if plan.Shadowed {
+		t.Fatalf("canonical plan should be available: %+v", plan)
+	}
+	if status := view.CommandDetails[1]; !status.Shadowed || status.ShadowedByPlugin != "" {
+		t.Fatalf("occupied canonical status = %+v", status)
+	}
+	if fresh := view.CommandDetails[2]; fresh.Shadowed {
+		t.Fatalf("command absent from a stale active session must not be reported as overridden: %+v", fresh)
+	}
+}
+
+func TestDecoratePluginCommandConflictNamesWinningPlugin(t *testing.T) {
+	view := PluginView{Name: "alpha", Enabled: true, CommandDetails: []PluginCommandView{{Name: "plan"}}}
+	decoratePluginCommandConflicts(&view, []command.Command{
+		{Name: "alpha:plan", Plugin: "beta", ShortName: "alpha:plan"},
+	})
+	got := view.CommandDetails[0]
+	if !got.Shadowed || got.ShadowedByPlugin != "beta" {
+		t.Fatalf("plugin conflict = %+v", got)
+	}
+}

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -84,6 +84,8 @@ reasonix plugin show superpowers
 `show` also prints the concrete capability inventory when available:
 
 - **skills** include suggested `/<skill>` invocations and descriptions.
+- **commands** include `/<plugin>:<command>` invocations, argument hints, and
+  descriptions.
 - **hooks** list lifecycle events, matchers, and commands or context files.
 - **mcpServers** list server names, transports, and launch targets.
 
@@ -187,6 +189,8 @@ The desktop settings page uses the same runtime model as the CLI:
   `/plugins show <name>` to see the same usage details from the chat surface.
 - Skills are shown with suggested direct commands such as `/plan`; they are also
   discoverable from `/skills` in a session.
+- Plugin commands are shown and invoked with package-qualified names such as
+  `/superpowers:plan`.
 - Hooks and MCP servers are listed for transparency. They do not need a manual
   "run" button: enabled hooks trigger automatically, and MCP tools are available
   through ordinary tool use.
@@ -236,12 +240,16 @@ as Superpowers and Claude-style skill packs, Reasonix maps:
   `skills` field falls back to the conventional `skills/` (or `.claude/skills/`)
   directory, matching Claude's own auto-discovery.
 - `commands/` (and `.claude/commands/`) to Reasonix custom slash commands: each
-  flat `<name>.md` prompt template becomes invocable as `/<name>`, with
-  frontmatter `description` / `argument-hint` and `$ARGUMENTS` / `$1..$N`
-  substitution honored. Plugin commands load at the lowest priority, so a
-  user- or project-authored command with the same name always wins. Native
-  `reasonix-plugin.json` manifests can declare the same thing explicitly with a
-  `"commands"` path list.
+  `<name>.md` prompt template is displayed and invoked canonically as
+  `/<plugin>:<name>`, with frontmatter `description` / `argument-hint` and
+  `$ARGUMENTS` / `$1..$N` substitution honored. An unambiguous `/<name>` remains
+  accepted as a hidden compatibility alias, but it is omitted from completion,
+  help, desktop menus, ACP command discovery, and the model-visible command
+  list. User- and project-authored commands own their short names, and no short
+  alias is created when multiple plugins export the same command name. An
+  explicit custom command can also occupy the qualified name; desktop plugin
+  details report that conflict. Native `reasonix-plugin.json` manifests can
+  declare the same thing explicitly with a `"commands"` path list.
 - `hooks/session-start-codex` to the Reasonix `SessionStart` hook when present.
 - A plugin-root `CLAUDE.md` file to a built-in `SessionStart` context hook. The
   file is read directly by Reasonix, without spawning a shell command.

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -80,6 +80,7 @@ reasonix plugin show superpowers
 如果能读取到能力明细，`show` 也会输出具体清单：
 
 - **skills** 会展示建议的 `/<skill>` 调用方式和描述。
+- **commands** 会展示 `/<插件名>:<命令名>` 调用方式、参数提示和描述。
 - **hooks** 会展示生命周期事件、matcher、命令或上下文文件。
 - **mcpServers** 会展示服务器名称、传输方式和启动目标。
 
@@ -172,6 +173,7 @@ reasonix plugin remove superpowers --yes
 - 在任意桌面会话里输入 `/plugins` 可以列出已安装插件；
   输入 `/plugins show <name>` 可以直接从聊天界面查看同一套使用详情。
 - Skills 会展示建议的直接命令，例如 `/plan`；在会话中也可以通过 `/skills` 浏览。
+- 插件命令统一以带插件名的形式展示和调用，例如 `/superpowers:plan`。
 - Hooks 和 MCP servers 作为透明能力清单展示。它们不需要单独的“运行”按钮：
   启用的 hooks 会自动触发，MCP 工具会通过普通工具调用流程可用。
 - 如果当前打开的会话没有反映插件变更，刷新插件列表并开启新会话。
@@ -215,9 +217,12 @@ Reasonix 尚未映射的 Claude 插件能力（`agents/`、`hooks/hooks.json`、
 - `skills` 到 Reasonix skill root。Claude 清单若未声明 `skills` 字段，会回退到
   约定目录 `skills/`（或 `.claude/skills/`），与 Claude 自身的自动发现一致。
 - `commands/`（以及 `.claude/commands/`）映射为 Reasonix 自定义斜杠命令：每个
-  扁平的 `<name>.md` 提示词模板都可以用 `/<name>` 直接调用，frontmatter 的
+  `<name>.md` 提示词模板统一以 `/<插件名>:<命令名>` 展示和调用，frontmatter 的
   `description` / `argument-hint` 以及 `$ARGUMENTS` / `$1..$N` 替换均生效。
-  插件命令以最低优先级加载，同名时用户或项目自定义的命令始终优先。原生
+  当短名称没有歧义时，`/<命令名>` 仍作为隐藏兼容别名接受输入，但不会出现在
+  补全、帮助、桌面菜单、ACP 命令发现或提供给模型的命令清单中。用户和项目命令
+  始终占有自己的短名称；多个插件导出同名命令时不会生成短名称别名。显式自定义
+  命令也可以占用限定名称，Desktop 插件详情会报告该冲突。原生
   `reasonix-plugin.json` 清单也可以通过 `"commands"` 路径列表显式声明。
 - 如果存在 `hooks/session-start-codex`，映射为 Reasonix `SessionStart` hook。
 - 插件根目录的 `CLAUDE.md` 会映射为内置的 `SessionStart` 上下文 hook。

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -511,12 +511,19 @@ func TestServeLifecycle(t *testing.T) {
 func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
 	factory := &commandFactory{
 		seen: make(chan string, 1),
-		commands: []command.Command{{
-			Name:        "review",
-			Description: "Review the target",
-			ArgHint:     "path",
-			Body:        "Review $1",
-		}},
+		commands: []command.Command{
+			{
+				Name:        "review",
+				Description: "Review the target",
+				ArgHint:     "path",
+				Body:        "Review $1",
+			},
+			{
+				Name:   "plan",
+				Body:   "Plan $ARGUMENTS",
+				Hidden: true,
+			},
+		},
 	}
 	client, stop := startServer(t, factory)
 	defer stop()
@@ -529,6 +536,7 @@ func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
 	}
 
 	var advertised bool
+	var hiddenAdvertised bool
 	select {
 	case n := <-client.notifs:
 		var p struct {
@@ -541,6 +549,9 @@ func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
 			t.Fatalf("available commands update: %v", err)
 		}
 		for _, cmd := range p.Update.AvailableCommands {
+			if cmd.Name == "plan" {
+				hiddenAdvertised = true
+			}
 			if p.Update.SessionUpdate == "available_commands_update" &&
 				cmd.Name == "review" &&
 				cmd.Description == "Review the target" &&
@@ -554,6 +565,9 @@ func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
 	}
 	if !advertised {
 		t.Fatal("review command was not advertised")
+	}
+	if hiddenAdvertised {
+		t.Fatal("hidden compatibility command was advertised")
 	}
 
 	promptCh := client.callAsync("session/prompt", SessionPromptParams{

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1607,6 +1607,9 @@ func availableCommandsFor(ctrl acpController) []AvailableCommand {
 	}
 	byName := map[string]AvailableCommand{}
 	for _, cmd := range ctrl.Commands() {
+		if cmd.Hidden {
+			continue
+		}
 		name := strings.TrimSpace(cmd.Name)
 		if name == "" {
 			continue

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -852,7 +852,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	// Custom slash commands (.reasonix/commands + user dir). Best-effort: a malformed
 	// file is skipped, and a load error never blocks the session.
-	cmds, _ := command.Load(config.CommandDirsForRoot(root)...)
+	cmds, _ := command.LoadRoots(config.CommandRootsForRoot(root)...)
 	addSlashCommandTool := func(includeSkills bool) {
 		// Expose loaded slash commands to the model via slash_command. In economy
 		// mode skills join this list only after the skills source is enabled.
@@ -868,6 +868,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 		}
 		for _, cmd := range cmds {
+			if cmd.Hidden {
+				continue
+			}
 			cmd := cmd
 			slashEntries = append(slashEntries, command.SlashEntry{
 				Name:        cmd.Name,

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3899,12 +3899,11 @@ func (m *chatTUI) echoLocalCommand(input string) {
 
 // commandNames renders the custom command list for /help, "" when there are none.
 func (m *chatTUI) commandNames() string {
-	if len(m.commands) == 0 {
-		return ""
-	}
-	names := make([]string, len(m.commands))
-	for i, c := range m.commands {
-		names[i] = "/" + c.Name
+	names := make([]string, 0, len(m.commands))
+	for _, c := range m.commands {
+		if !c.Hidden {
+			names = append(names, "/"+c.Name)
+		}
 	}
 	return strings.Join(names, " · ")
 }

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -101,7 +101,10 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/export", insert: "/export", hint: i18n.M.CmdExport},
 	}
 	for _, c := range m.commands {
-		items = append(items, compItem{label: "/" + c.Name, insert: "/" + c.Name + " ", hint: c.Description})
+		if c.Hidden {
+			continue
+		}
+		items = append(items, compItem{label: "/" + c.Name, insert: "/" + c.Name + " ", hint: customCommandHint(c)})
 	}
 	for _, s := range m.skills {
 		hint := s.Description

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -28,6 +28,16 @@ func writeAt(t *testing.T, dir, rel, content string) {
 	}
 }
 
+func TestCustomCommandHintIdentifiesPluginSource(t *testing.T) {
+	got := customCommandHint(command.Command{Description: "Create a plan", Plugin: "pwf", ShortName: "plan"})
+	if got != "plugin pwf · Create a plan" {
+		t.Fatalf("customCommandHint = %q", got)
+	}
+	if got := customCommandHint(command.Command{Description: "Project plan"}); got != "Project plan" {
+		t.Fatalf("project hint changed = %q", got)
+	}
+}
+
 func TestSlashCompletionFilterAndAccept(t *testing.T) {
 	m := newTestChatTUI()
 	m.input.SetValue("/co")

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -91,9 +91,23 @@ func builtinHelpItems() []compItem {
 func customHelpItems(commands []command.Command) []compItem {
 	items := make([]compItem, 0, len(commands))
 	for _, c := range commands {
-		items = append(items, compItem{label: "/" + c.Name, hint: c.Description})
+		if c.Hidden {
+			continue
+		}
+		items = append(items, compItem{label: "/" + c.Name, hint: customCommandHint(c)})
 	}
 	return items
+}
+
+func customCommandHint(c command.Command) string {
+	if c.Plugin == "" {
+		return c.Description
+	}
+	source := "plugin " + c.Plugin
+	if c.Description == "" {
+		return source
+	}
+	return source + " · " + c.Description
 }
 
 func skillHelpItems(skills []skill.Skill) []compItem {

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -231,14 +231,14 @@ func pluginShowCommand(args []string) int {
 	skills, commands, hooks, mcp := pkg.CapabilityCounts()
 	fmt.Printf("name: %s\nversion: %s\nenabled: %t\nkind: %s\nroot: %s\nsource: %s\nskills: %d\ncommands: %d\nhooks: %d\nmcpServers: %d\n",
 		p.Name, p.Version, p.Enabled, p.ManifestKind, root, p.Source, skills, commands, hooks, mcp)
-	printPluginInventory(pkg.Inventory())
+	printPluginInventory(p.Name, pkg.Inventory())
 	for _, warning := range warnings {
 		fmt.Println("warning:", warning)
 	}
 	return 0
 }
 
-func printPluginInventory(inv pluginpkg.Inventory) {
+func printPluginInventory(pluginName string, inv pluginpkg.Inventory) {
 	if len(inv.Skills) > 0 {
 		fmt.Println("usage:")
 		fmt.Println("  skills are available in interactive sessions; run /skills to browse them, or invoke a skill directly with /<name>.")
@@ -266,10 +266,7 @@ func printPluginInventory(inv pluginpkg.Inventory) {
 			if desc == "" {
 				desc = "(no description)"
 			}
-			invocation := cmd.Invocation
-			if invocation == "" {
-				invocation = "/" + cmd.Name
-			}
+			invocation := "/" + pluginName + ":" + cmd.Name
 			if cmd.ArgHint != "" {
 				fmt.Printf("  %s %s\t%s\n", invocation, cmd.ArgHint, desc)
 			} else {

--- a/internal/cli/slash_test.go
+++ b/internal/cli/slash_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestChatCommandNames(t *testing.T) {
-	m := chatTUI{commands: []command.Command{{Name: "review"}, {Name: "git:commit"}}}
+	m := chatTUI{commands: []command.Command{{Name: "review"}, {Name: "git:commit"}, {Name: "plan", Hidden: true}}}
 	if got := m.commandNames(); got != "/review · /git:commit" {
 		t.Errorf("commandNames = %q", got)
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -25,6 +25,18 @@ type Command struct {
 	ArgHint     string // from frontmatter (argument-hint)
 	Body        string // template with $ARGUMENTS / $1..$N / $$
 	Source      string // originating file path, for diagnostics
+	Plugin      string // installed plugin package name; empty for user/project commands
+	ShortName   string // original plugin command name before the package qualifier
+	Hidden      bool   // compatibility-only short alias; invocable but omitted from listings
+}
+
+// Root is one command directory and its optional plugin-package owner. Plugin
+// ownership is carried through loading so plugin commands can use stable,
+// package-qualified display names without losing unambiguous short-name
+// compatibility.
+type Root struct {
+	Path   string
+	Plugin string
 }
 
 // substRe matches the substitution tokens recognised in a command body.
@@ -55,10 +67,24 @@ func (c Command) Render(args []string) string {
 // into the returned error but don't prevent the others from loading. The result
 // is sorted by name.
 func Load(dirs ...string) ([]Command, error) {
-	byName := map[string]Command{}
-	var errs []string
+	roots := make([]Root, 0, len(dirs))
 	for _, dir := range dirs {
-		root, err := filepath.Abs(dir)
+		roots = append(roots, Root{Path: dir})
+	}
+	return LoadRoots(roots...)
+}
+
+// LoadRoots is Load with optional plugin ownership. Every plugin command is
+// exposed canonically as /<plugin>:<name>. A short /<name> compatibility alias
+// is retained only when exactly one plugin contributes that name and no user or
+// project command owns it; the alias is hidden from completion and model-visible
+// listings. An explicit command occupying the qualified name still wins.
+func LoadRoots(roots ...Root) ([]Command, error) {
+	byName := map[string]Command{}
+	pluginCommands := map[string]map[string]Command{}
+	var errs []string
+	for _, spec := range roots {
+		root, err := filepath.Abs(spec.Path)
 		if err != nil {
 			continue
 		}
@@ -77,8 +103,38 @@ func Load(dirs ...string) ([]Command, error) {
 				errs = append(errs, perr.Error())
 				return
 			}
-			byName[c.Name] = c
+			c.Plugin = strings.TrimSpace(spec.Plugin)
+			if c.Plugin == "" {
+				byName[c.Name] = c
+			} else {
+				if pluginCommands[c.Plugin] == nil {
+					pluginCommands[c.Plugin] = map[string]Command{}
+				}
+				pluginCommands[c.Plugin][c.Name] = c
+			}
 		})
+	}
+	byShortName := map[string][]Command{}
+	for plugin, commands := range pluginCommands {
+		for shortName, pluginCommand := range commands {
+			pluginCommand.ShortName = shortName
+			byShortName[shortName] = append(byShortName[shortName], pluginCommand)
+			qualified := plugin + ":" + shortName
+			if _, occupied := byName[qualified]; occupied {
+				continue
+			}
+			pluginCommand.Name = qualified
+			byName[qualified] = pluginCommand
+		}
+	}
+	for shortName, candidates := range byShortName {
+		if _, occupied := byName[shortName]; occupied || len(candidates) != 1 {
+			continue
+		}
+		compat := candidates[0]
+		compat.Name = shortName
+		compat.Hidden = true
+		byName[shortName] = compat
 	}
 	cmds := make([]Command, 0, len(byName))
 	for _, c := range byName {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -101,6 +101,88 @@ func TestLoadOverrideAndMissingDir(t *testing.T) {
 	}
 }
 
+func TestLoadRootsUsesCanonicalPluginNamesAndHiddenCompatibleShortName(t *testing.T) {
+	pluginDir := t.TempDir()
+	projectDir := t.TempDir()
+	write(t, pluginDir, "plan.md", "---\ndescription: Plugin plan\n---\nPLUGIN $ARGUMENTS")
+	write(t, pluginDir, "status.md", "PLUGIN STATUS")
+	write(t, projectDir, "plan.md", "---\ndescription: Project plan\n---\nPROJECT $ARGUMENTS")
+
+	cmds, err := LoadRoots(
+		Root{Path: pluginDir, Plugin: "planning-with-files"},
+		Root{Path: projectDir},
+	)
+	if err != nil {
+		t.Fatalf("LoadRoots: %v", err)
+	}
+	byName := map[string]Command{}
+	for _, cmd := range cmds {
+		byName[cmd.Name] = cmd
+	}
+	if got := byName["plan"]; got.Body != "PROJECT $ARGUMENTS" || got.Plugin != "" || got.ShortName != "" || got.Hidden {
+		t.Fatalf("short-name winner = %+v, want project command", got)
+	}
+	canonical, ok := byName["planning-with-files:plan"]
+	if !ok || canonical.Body != "PLUGIN $ARGUMENTS" || canonical.Plugin != "planning-with-files" || canonical.ShortName != "plan" || canonical.Hidden {
+		t.Fatalf("canonical plugin command = %+v, %v", canonical, ok)
+	}
+	if got := byName["status"]; got.Plugin != "planning-with-files" || got.ShortName != "status" || !got.Hidden {
+		t.Fatalf("short compatibility command = %+v, want hidden plugin alias", got)
+	}
+	if got := byName["planning-with-files:status"]; got.Plugin != "planning-with-files" || got.ShortName != "status" || got.Hidden {
+		t.Fatalf("canonical status command = %+v", got)
+	}
+	if got := canonical.Render([]string{"feature"}); got != "PLUGIN feature" {
+		t.Fatalf("canonical command render = %q", got)
+	}
+}
+
+func TestLoadRootsDoesNotReplaceAnExplicitQualifiedCommand(t *testing.T) {
+	pluginDir := t.TempDir()
+	projectDir := t.TempDir()
+	write(t, pluginDir, "plan.md", "PLUGIN")
+	write(t, projectDir, "plan.md", "PROJECT")
+	write(t, projectDir, "planning-with-files/plan.md", "EXPLICIT QUALIFIED")
+
+	cmds, err := LoadRoots(
+		Root{Path: pluginDir, Plugin: "planning-with-files"},
+		Root{Path: projectDir},
+	)
+	if err != nil {
+		t.Fatalf("LoadRoots: %v", err)
+	}
+	for _, cmd := range cmds {
+		if cmd.Name == "planning-with-files:plan" {
+			if cmd.Body != "EXPLICIT QUALIFIED" || cmd.Plugin != "" || cmd.ShortName != "" || cmd.Hidden {
+				t.Fatalf("explicit qualified command was replaced: %+v", cmd)
+			}
+			return
+		}
+	}
+	t.Fatal("explicit qualified command missing")
+}
+
+func TestLoadRootsOmitsAmbiguousShortPluginName(t *testing.T) {
+	alpha := t.TempDir()
+	beta := t.TempDir()
+	write(t, alpha, "plan.md", "ALPHA")
+	write(t, beta, "plan.md", "BETA")
+	cmds, err := LoadRoots(Root{Path: alpha, Plugin: "alpha"}, Root{Path: beta, Plugin: "beta"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]Command{}
+	for _, cmd := range cmds {
+		byName[cmd.Name] = cmd
+	}
+	if _, ok := byName["plan"]; ok {
+		t.Fatal("ambiguous plugin short name must not remain invocable")
+	}
+	if byName["alpha:plan"].Body != "ALPHA" || byName["beta:plan"].Body != "BETA" {
+		t.Fatalf("canonical plugin commands = %+v", cmds)
+	}
+}
+
 func names(cmds []Command) []string {
 	out := make([]string, len(cmds))
 	for i, c := range cmds {

--- a/internal/command/slashtool_test.go
+++ b/internal/command/slashtool_test.go
@@ -126,3 +126,38 @@ func TestSlashToolNameClashCommandWins(t *testing.T) {
 		t.Errorf("later entry should win the clash: %q", out)
 	}
 }
+
+func TestPluginSlashToolShowsOnlyCanonicalQualifiedName(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "plan.md", "---\ndescription: Plan work\n---\nPlan $ARGUMENTS")
+	plain, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned, err := LoadRoots(Root{Path: dir, Plugin: "pwf"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := func(cmds []Command) []SlashEntry {
+		out := make([]SlashEntry, 0, len(cmds))
+		for _, cmd := range cmds {
+			if cmd.Hidden {
+				continue
+			}
+			cmd := cmd
+			out = append(out, SlashEntry{Name: cmd.Name, Description: cmd.Description, ArgHint: cmd.ArgHint, Render: func(args []string) string { return cmd.Render(args) }})
+		}
+		return out
+	}
+	plainTool := NewSlashCommandTool(entries(plain))
+	ownedTool := NewSlashCommandTool(entries(owned))
+	if !strings.Contains(plainTool.Description(), "Available: plan.") {
+		t.Fatalf("plain tool description = %q", plainTool.Description())
+	}
+	if !strings.Contains(ownedTool.Description(), "Available: pwf:plan.") || strings.Contains(ownedTool.Description(), "Available: plan,") {
+		t.Fatalf("plugin tool should list one canonical name, got %q", ownedTool.Description())
+	}
+	if string(plainTool.Schema()) != string(ownedTool.Schema()) {
+		t.Fatal("plugin qualification must not change the slash_command schema")
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"unicode/utf8"
+
+	"reasonix/internal/command"
 )
 
 var (
@@ -468,46 +470,57 @@ func CommandDirs() []string {
 // dirs under root instead of the current working directory. Global dirs are
 // unchanged — they are always user-scoped.
 func CommandDirsForRoot(root string) []string {
+	roots := CommandRootsForRoot(root)
+	dirs := make([]string, 0, len(roots))
+	for _, spec := range roots {
+		dirs = append(dirs, spec.Path)
+	}
+	return dirs
+}
+
+// CommandRootsForRoot is the ownership-aware form of CommandDirsForRoot.
+// Plugin roots retain their package name so the loader can expose stable,
+// package-qualified command names and hidden short-name compatibility aliases.
+func CommandRootsForRoot(root string) []command.Root {
 	root = resolveRoot(root)
-	var dirs []string
-	add := func(dir string) {
-		if dir == "" {
+	var roots []command.Root
+	add := func(spec command.Root) {
+		if spec.Path == "" {
 			return
 		}
-		for _, existing := range dirs {
-			if samePath(existing, dir) {
+		for _, existing := range roots {
+			if samePath(existing.Path, spec.Path) && existing.Plugin == spec.Plugin {
 				return
 			}
 		}
-		dirs = append(dirs, dir)
+		roots = append(roots, spec)
 	}
-	// Enabled plugin packages contribute command dirs at the lowest priority,
-	// so a user- or project-authored command always wins a name clash with a
-	// plugin-shipped one.
-	for _, dir := range pluginPackageCommandDirs() {
-		add(dir)
+	// Enabled plugin packages contribute command dirs before user/project dirs,
+	// so explicit commands still win exact canonical-name clashes.
+	for _, spec := range pluginPackageCommandRoots() {
+		add(spec)
 	}
 	if dir := legacyOSSupportDir(); dir != "" {
-		add(filepath.Join(dir, "commands"))
+		add(command.Root{Path: filepath.Join(dir, "commands")})
 	}
 	for _, legacy := range legacyXDGConfigPaths() {
-		add(filepath.Join(filepath.Dir(legacy), "commands"))
+		add(command.Root{Path: filepath.Join(filepath.Dir(legacy), "commands")})
 	}
 	if home, err := osUserHomeDir(); err == nil {
 		for _, dir := range conventionSubdirsAsc(home, "commands") {
-			add(dir)
+			add(command.Root{Path: dir})
 		}
 	}
 	if dir := userConfigDir(); dir != "" {
-		add(filepath.Join(dir, "commands"))
+		add(command.Root{Path: filepath.Join(dir, "commands")})
 	}
 	if dir := userSupportDir(); dir != "" && !samePath(dir, userConfigDir()) {
-		add(filepath.Join(dir, "commands"))
+		add(command.Root{Path: filepath.Join(dir, "commands")})
 	}
 	for _, dir := range conventionSubdirsAsc(root, "commands") {
-		add(dir)
+		add(command.Root{Path: dir})
 	}
-	return dirs
+	return roots
 }
 
 // SourcePath returns the highest-priority config file that exists, or "" if none.

--- a/internal/config/plugin_packages.go
+++ b/internal/config/plugin_packages.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"reasonix/internal/command"
 	"reasonix/internal/pluginpkg"
 )
 
@@ -61,19 +62,22 @@ func mergeInstalledPluginPackages(cfg *Config, root string) []string {
 	return warnings
 }
 
-// pluginPackageCommandDirs returns the command directories contributed by
+// pluginPackageCommandRoots returns the command directories contributed by
 // enabled installed plugin packages, in deterministic (name, path) order.
-// CommandDirsForRoot places them ahead of every user/project dir so they lose
-// name clashes; LoadInstalled already filters to enabled packages.
-func pluginPackageCommandDirs() []string {
+// CommandRootsForRoot places them ahead of every user/project dir so explicit
+// commands win exact canonical-name clashes; LoadInstalled filters to enabled
+// packages.
+func pluginPackageCommandRoots() []command.Root {
 	reasonixHome := ReasonixHomeDir()
 	if strings.TrimSpace(reasonixHome) == "" {
 		return nil
 	}
 	installed, _ := pluginpkg.LoadInstalled(reasonixHome)
-	var out []string
+	var out []command.Root
 	for _, item := range installed {
-		out = append(out, item.Package.CommandRoots()...)
+		for _, root := range item.Package.CommandRoots() {
+			out = append(out, command.Root{Path: root, Plugin: item.Installed.Name})
+		}
 	}
 	return out
 }

--- a/internal/config/plugin_packages_test.go
+++ b/internal/config/plugin_packages_test.go
@@ -69,8 +69,8 @@ func writeConfigTestFile(t *testing.T, path, body string) {
 
 // TestCommandDirsIncludePluginPackageCommands pins the plugin-commands wiring:
 // an enabled plugin package's command roots join command discovery at the
-// lowest priority (first entries, since command.Load lets a later dir win),
-// and a disabled package contributes nothing.
+// before user/project entries, retaining package ownership, while a disabled
+// package contributes nothing.
 func TestCommandDirsIncludePluginPackageCommands(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("REASONIX_HOME", home)
@@ -91,6 +91,10 @@ func TestCommandDirsIncludePluginPackageCommands(t *testing.T) {
 	want := filepath.Join(root, "commands")
 	if len(dirs) == 0 || dirs[0] != want {
 		t.Fatalf("CommandDirsForRoot = %#v, want plugin commands dir first (lowest priority): %s", dirs, want)
+	}
+	roots := CommandRootsForRoot(t.TempDir())
+	if len(roots) == 0 || roots[0].Path != want || roots[0].Plugin != "pwf" {
+		t.Fatalf("CommandRootsForRoot = %#v, want plugin ownership on first root", roots)
 	}
 
 	if err := pluginpkg.SetEnabled(home, "pwf", false); err != nil {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3648,7 +3648,7 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 		return ctx.Err()
 	default:
 	}
-	cmds, loadErr := command.Load(config.CommandDirsForRoot(c.workspaceRoot)...)
+	cmds, loadErr := command.LoadRoots(config.CommandRootsForRoot(c.workspaceRoot)...)
 	cmdSkills := c.Skills()
 
 	entries := make([]command.SlashEntry, 0, len(cmdSkills)+len(cmds))
@@ -3661,6 +3661,9 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 		})
 	}
 	for _, cmd := range cmds {
+		if cmd.Hidden {
+			continue
+		}
 		cmd := cmd
 		entries = append(entries, command.SlashEntry{
 			Name:        cmd.Name,

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -4028,6 +4028,63 @@ func TestReloadCommandsSameNameAcrossDirs(t *testing.T) {
 	}
 }
 
+func TestReloadCommandsUsesCanonicalPluginNameAlongsideProjectShortName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	reasonixHome := filepath.Join(home, ".reasonix")
+	t.Setenv("REASONIX_HOME", reasonixHome)
+
+	pluginRoot := filepath.Join(reasonixHome, "plugins", "pwf")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, pluginpkg.ClaudeManifest), []byte(`{"name":"pwf"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCmdFile(t, filepath.Join(pluginRoot, "commands"), "plan", "Plugin plan", "PLUGIN $1")
+	writeCmdFile(t, filepath.Join(pluginRoot, "commands"), "status", "Plugin status", "STATUS $1")
+	if err := pluginpkg.Upsert(reasonixHome, pluginpkg.InstalledPlugin{Name: "pwf", Root: "plugins/pwf", ManifestKind: "claude", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := t.TempDir()
+	writeCmdFile(t, filepath.Join(workspace, ".reasonix", "commands"), "plan", "Project plan", "PROJECT $1")
+	c := New(Options{Sink: &typedNilControllerSink{}, Registry: tool.NewRegistry(), WorkspaceRoot: workspace})
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands: %v", err)
+	}
+
+	if got, ok := c.CustomCommand("/plan task"); !ok || got != "PROJECT task" {
+		t.Fatalf("short command = %q, %v; want project winner", got, ok)
+	}
+	if got, ok := c.CustomCommand("/pwf:plan task"); !ok || got != "PLUGIN task" {
+		t.Fatalf("qualified plugin command = %q, %v", got, ok)
+	}
+	if got, ok := c.CustomCommand("/status now"); !ok || got != "STATUS now" {
+		t.Fatalf("hidden compatible short command = %q, %v", got, ok)
+	}
+	if got, ok := c.CustomCommand("/pwf:status now"); !ok || got != "STATUS now" {
+		t.Fatalf("canonical plugin status command = %q, %v", got, ok)
+	}
+	cmds := c.Commands()
+	canonicalFound := false
+	hiddenFound := false
+	for _, cmd := range cmds {
+		if cmd.Name == "pwf:plan" && cmd.Plugin == "pwf" && cmd.ShortName == "plan" && !cmd.Hidden {
+			canonicalFound = true
+		}
+		if cmd.Name == "status" && cmd.Plugin == "pwf" && cmd.ShortName == "status" && cmd.Hidden {
+			hiddenFound = true
+		}
+	}
+	if !canonicalFound || !hiddenFound {
+		t.Fatalf("plugin command metadata missing: %+v", cmds)
+	}
+}
+
 // TestReloadCommandsEmptySet verifies that deleting all command files and
 // reloading results in an empty Commands() slice, while the slash_command tool
 // still exists in the Registry (containing only Skills).

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -475,7 +475,13 @@ func (c *Controller) managementNotice(trimmed string) bool {
 		if err := c.ReloadCommands(context.Background()); err != nil {
 			c.notice("reload-cmd: " + err.Error())
 		} else {
-			c.notice("commands reloaded (" + strconv.Itoa(len(c.Commands())) + " available)")
+			visible := 0
+			for _, cmd := range c.Commands() {
+				if !cmd.Hidden {
+					visible++
+				}
+			}
+			c.notice("commands reloaded (" + strconv.Itoa(visible) + " available)")
 		}
 	case "/hooks":
 		sub := ""

--- a/internal/pluginpkg/describe.go
+++ b/internal/pluginpkg/describe.go
@@ -84,11 +84,11 @@ func InstalledShowText(reasonixHome, name string) (string, error) {
 	fmt.Fprintf(&b, "plugin %s [%s]\n", p.Name, state)
 	fmt.Fprintf(&b, "version: %s\nkind: %s\nroot: %s\nsource: %s\ncapabilities: %d skills, %d commands, %d hooks, %d MCP servers\n", version, p.ManifestKind, filepath.Clean(root), p.Source, skills, commands, hooks, mcp)
 	if p.Enabled {
-		b.WriteString("usage: enabled plugins load into new sessions; use /skills, invoke /<skill> or /<command>, or ask naturally.\n")
+		b.WriteString("usage: enabled plugins load into new sessions; use /skills, invoke /<skill> or /<plugin>:<command>, or ask naturally.\n")
 	} else {
 		b.WriteString("usage: enable this plugin before its skills, commands, hooks, or MCP servers participate in sessions.\n")
 	}
-	appendInventoryText(&b, pkg.Inventory())
+	appendInventoryText(&b, p.Name, pkg.Inventory())
 	for _, warning := range warnings {
 		fmt.Fprintf(&b, "warning: %s\n", warning)
 	}
@@ -134,7 +134,7 @@ func pluginCapabilityText(reasonixHome string, p InstalledPlugin) string {
 	return strings.Join(parts, " / ")
 }
 
-func appendInventoryText(b *strings.Builder, inv Inventory) {
+func appendInventoryText(b *strings.Builder, pluginName string, inv Inventory) {
 	if len(inv.Commands) > 0 {
 		b.WriteString("commands:\n")
 		for _, cmd := range inv.Commands {
@@ -142,10 +142,7 @@ func appendInventoryText(b *strings.Builder, inv Inventory) {
 			if desc == "" {
 				desc = "(no description)"
 			}
-			invocation := cmd.Invocation
-			if invocation == "" {
-				invocation = "/" + cmd.Name
-			}
+			invocation := "/" + pluginName + ":" + cmd.Name
 			if cmd.ArgHint != "" {
 				fmt.Fprintf(b, "  %s %s - %s\n", invocation, cmd.ArgHint, desc)
 			} else {

--- a/internal/pluginpkg/pluginpkg_test.go
+++ b/internal/pluginpkg/pluginpkg_test.go
@@ -507,9 +507,9 @@ func TestParseClaudePluginAdoptsNestedCommands(t *testing.T) {
 // also claim "no detailed inventory available".
 func TestInventoryTextCommandsOnly(t *testing.T) {
 	var b strings.Builder
-	appendInventoryText(&b, Inventory{Commands: []CommandRef{{Name: "plan", Invocation: "/plan", Description: "plan things"}}})
+	appendInventoryText(&b, "superpowers", Inventory{Commands: []CommandRef{{Name: "plan", Invocation: "/plan", Description: "plan things"}}})
 	out := b.String()
-	if !strings.Contains(out, "commands:") || !strings.Contains(out, "/plan") {
+	if !strings.Contains(out, "commands:") || !strings.Contains(out, "/superpowers:plan") {
 		t.Fatalf("output = %q, want the commands listing", out)
 	}
 	if strings.Contains(out, "no detailed inventory available") {


### PR DESCRIPTION
## Summary

Follow-up to #6311. Plugin-provided custom slash commands now use a stable package-qualified visible name, such as `/superpowers:write-plan`, across the runtime, CLI, ACP, and Desktop.

## Behavior

- Display and expose every plugin command canonically as `/<plugin>:<command>`.
- Keep an unambiguous `/<command>` as an invocable but hidden compatibility alias.
- Let user/project commands continue to own their short names.
- Omit the short alias when multiple plugins export the same command name.
- Keep hidden aliases out of completion, help, Desktop menus, ACP discovery, reload counts, and the model-visible `slash_command` list.
- Show plugin provenance and exact qualified-name conflicts in Desktop plugin details.
- Use qualified command names in `reasonix plugin show`, `/plugins show`, and the English/Chinese documentation.

## Scope

This PR applies to plugin-provided `commands/`. Plugin skills keep their existing user-facing and internal names; package-qualified skill aliases are intentionally deferred to a separate design because they affect skill discovery, same-name resolution, and model-visible skill identifiers.

## Why

The short name alone does not identify which installed package supplied a command, and collisions can make plugin behavior surprising. A package-qualified visible name is deterministic and keeps every plugin command addressable without duplicating provider-visible entries.

## Compatibility

| Surface | Old behavior | New behavior | Conclusion |
| --- | --- | --- | --- |
| Existing short invocation | `/<command>` invoked the plugin command when it won discovery | Still accepted when unambiguous, but hidden from listings | Backward compatible |
| User/project short command | Won plugin name clashes | Still wins the short name | Preserved |
| Multiple plugins with the same command | One short name won by discovery order | Each qualified command remains visible; no ambiguous short alias | Deterministic |
| Plugin state/config | Existing package state | No persisted format change | Cross-version safe |
| Desktop JSON | No plugin source field on commands | Adds optional `plugin`/conflict fields with `omitempty` | Older payloads and clients remain safe |

## Cache impact

This intentionally changes provider-visible plugin command names once after upgrade. The visible list remains deterministic and contains exactly one entry per plugin command; compatibility aliases are filtered out, avoiding ongoing prefix churn or list doubling.

## Verification

- `./scripts/cache-guard.sh`
- `go test -race ./internal/command ./internal/config ./internal/control`
- `go test ./...`
- Desktop CI, including frontend build, vet, lint, build, and tests
- Linux, macOS, and Windows CI
- CodeQL and `govulncheck`
- Real plugin smoke test: Superpowers v5.0.7 installed in an isolated `REASONIX_HOME`; `/superpowers:write-plan` loaded, appeared in the canonical-only list, and expanded successfully, while `/write-plan` remained a hidden compatibility alias.

## Related work

- Builds on merged #6311.
- #6323 overlaps documentation, frontend types, and locale files and may require rebase ordering.

Cache-impact: low - plugin command names change once after upgrade, while ordering and visible entry count remain stable.
Cache-guard: `./scripts/cache-guard.sh` passed all cache-hit scenarios; hidden compatibility aliases are excluded from the provider-visible list.
System-prompt-review: reviewed locally; no system prompt text or tool schema changes, only deterministic slash-command entry names.
