### PR TITLE
Fix MiMo legacy tuple tool schemas / 修复 MiMo 旧版元组工具 Schema

### DIFF
--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -57,7 +57,14 @@ func requestErrorReason(e *provider.APIError) string {
 	if e.Status != 400 && e.Status != 422 {
 		return ""
 	}
-	return providerBodyReason(e.Body)
+	reason := providerBodyReason(e.Body)
+	if e.ToolContext == "" {
+		return reason
+	}
+	if reason == "" {
+		return e.ToolContext
+	}
+	return reason + "\n" + e.ToolContext
 }
 
 // providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped error

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -53,6 +53,18 @@ func TestExplainError(t *testing.T) {
 		t.Errorf("400 should append the provider reason from a JSON body, got %q", jsonBody.Error())
 	}
 
+	toolSchema := explainError(&provider.APIError{
+		Provider:    "mimo",
+		Status:      400,
+		Body:        `{"error":{"message":"Tool 197 function has invalid 'parameters' schema"}}`,
+		ToolContext: `Provider tool 197 maps to Reasonix tool "mcp__files__search" (MCP server "files", tool "search").`,
+	})
+	for _, want := range []string{"invalid 'parameters' schema", `MCP server "files"`} {
+		if !strings.Contains(toolSchema.Error(), want) {
+			t.Errorf("400 tool schema error = %q, want %q", toolSchema.Error(), want)
+		}
+	}
+
 	rawBody := explainError(&provider.APIError{Provider: "deepseek", Status: 422, Body: "some unparseable detail"})
 	if !strings.Contains(rawBody.Error(), "some unparseable detail") {
 		t.Errorf("422 should fall back to the raw body, got %q", rawBody.Error())

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -108,6 +108,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		thinking:    thinking,
 		effort:      effort,
 		vision:      vision,
+		mimo:        provider.IsMiMoEndpoint(root),
 		headers:     cleanCustomHeaders(headers),
 		authHeader:  authHeader,
 		http:        httpClient, // no overall timeout; lifecycle is ctx-driven
@@ -130,6 +131,7 @@ type client struct {
 	thinking    string // "adaptive" enables extended thinking; "" = off (config-driven)
 	effort      string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
 	vision      bool   // model accepts image input — embed attached images as base64 image blocks
+	mimo        bool   // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
 	headers     map[string]string
 	authHeader  bool // send Authorization: Bearer instead of Anthropic's x-api-key header
 	http        *http.Client
@@ -217,7 +219,7 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	}
 	resp, err := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
 	if err != nil {
-		return nil, err
+		return nil, provider.AnnotateToolSchemaError(err, req.Tools)
 	}
 	c.authed.Store(true)
 
@@ -305,6 +307,9 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		schema := t.Parameters
 		if len(schema) == 0 {
 			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		if c.mimo {
+			schema = provider.NormalizeLegacyTupleItemsForDraft202012(schema)
 		}
 		tools = append(tools, anthTool{Name: t.Name, Description: t.Description, InputSchema: schema})
 	}

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -95,6 +96,67 @@ func TestBuildRequestNoSystem(t *testing.T) {
 	// A tool with no schema gets a minimal valid object schema.
 	if string(r.Tools[0].InputSchema) != `{"type":"object","properties":{}}` {
 		t.Fatalf("empty schema not defaulted: %s", r.Tools[0].InputSchema)
+	}
+}
+
+func TestStreamAnnotatesIndexedToolSchemaError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Tool 1 function has invalid 'parameters' schema"}}`))
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "mimo-anthropic", BaseURL: srv.URL, Model: "mimo-v2.5-pro", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Tools: []provider.ToolSchema{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)},
+			{Name: "mcp__files__search", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) || !strings.Contains(apiErr.ToolContext, `MCP server "files"`) {
+		t.Fatalf("Stream error = %v, want MCP tool source context", err)
+	}
+}
+
+func TestBuildRequestScopesLegacyTupleMigrationToMiMo(t *testing.T) {
+	legacy := json.RawMessage(`{"type":"object","properties":{"pair":{"type":"array","items":[{"type":"string"},{"type":"number"}]}}}`)
+	req := provider.Request{Tools: []provider.ToolSchema{{Name: "tuple", Parameters: legacy}}}
+
+	mimo := (&client{mimo: true}).buildRequest(req)
+	if got := string(mimo.Tools[0].InputSchema); !strings.Contains(got, `"prefixItems"`) || strings.Contains(got, `"items":[`) {
+		t.Fatalf("MiMo parameters = %s, want Draft 2020-12 tuple keywords", got)
+	}
+
+	other := (&client{}).buildRequest(req)
+	if got := string(other.Tools[0].InputSchema); got != string(legacy) {
+		t.Fatalf("non-MiMo parameters changed:\n got: %s\nwant: %s", got, legacy)
+	}
+}
+
+func TestNewDetectsMiMoSchemaDialect(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		{"https://api.xiaomimimo.com/anthropic", true},
+		{"https://token-plan-cn.xiaomimimo.com/anthropic", true},
+		{"https://token-plan-sgp.xiaomimimo.com/anthropic", true},
+		{"https://token-plan-ams.xiaomimimo.com/anthropic", true},
+		{"https://api.anthropic.com", false},
+		{"https://api.minimaxi.com/anthropic", false},
+	} {
+		p, err := New(provider.Config{Name: "test", BaseURL: tc.baseURL, Model: "model"})
+		if err != nil {
+			t.Fatalf("New(%q): %v", tc.baseURL, err)
+		}
+		if got := p.(*client).mimo; got != tc.want {
+			t.Errorf("New(%q).mimo = %v, want %v", tc.baseURL, got, tc.want)
+		}
 	}
 }
 

--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -3,6 +3,8 @@ package openai
 import (
 	"net/url"
 	"strings"
+
+	"reasonix/internal/provider"
 )
 
 // matchesVendorHost reports whether baseURL points at one of the canonical
@@ -49,7 +51,7 @@ func IsMiniMax(baseURL string) bool {
 // MiMo follows the OpenAI chat shape but authenticates with an `api-key` header
 // instead of the usual Authorization bearer header.
 func IsMiMo(baseURL string) bool {
-	return matchesVendorHost(baseURL, "xiaomimimo.com", "api.xiaomimimo.com")
+	return provider.IsMiMoEndpoint(baseURL)
 }
 
 // IsZhipu reports whether baseURL points at Zhipu's OpenAI-compatible endpoint

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -190,6 +190,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		minimax:      minimax,
 		zhipu:        zhipu,
 		longcat:      longcat,
+		mimo:         IsMiMo(cfg.BaseURL),
 		thinkingType: thinkingType,
 		vision:       vision,
 		visionDetail: visionDetail,
@@ -224,6 +225,7 @@ type client struct {
 	minimax      bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
 	zhipu        bool          // true for Zhipu GLM (bigmodel.cn / z.ai) — gates thinking via thinking.type, ignores reasoning_effort
 	longcat      bool          // true for LongCat — gates thinking via thinking.type, ignores reasoning_effort
+	mimo         bool          // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
 	thinkingType string        // explicit `thinking` config override (enabled|disabled); "" = no override
 	vision       bool          // model accepts image input — embed attached images as image_url parts
 	visionDetail string        // image_url detail hint (low|high); "" = auto/omit
@@ -387,7 +389,7 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	}
 	resp, err := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
 	if err != nil {
-		return nil, err
+		return nil, provider.AnnotateToolSchemaError(err, req.Tools)
 	}
 	c.authed.Store(true)
 
@@ -518,6 +520,9 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		parameters := t.Parameters
 		if len(parameters) == 0 {
 			parameters = provider.CanonicalizeSchema(nil)
+		}
+		if c.mimo {
+			parameters = provider.NormalizeLegacyTupleItemsForDraft202012(parameters)
 		}
 		tools = append(tools, chatTool{
 			Type:     "function",

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -90,6 +90,45 @@ func TestStreamInsufficientBalance(t *testing.T) {
 	}
 }
 
+func TestStreamAnnotatesIndexedToolSchemaError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Tool 1 function has invalid 'parameters' schema"}}`))
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "mimo", BaseURL: srv.URL, Model: "mimo-v2.5-pro", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Tools: []provider.ToolSchema{
+			{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)},
+			{Name: "mcp__files__search", Parameters: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) || !strings.Contains(apiErr.ToolContext, `MCP server "files"`) {
+		t.Fatalf("Stream error = %v, want MCP tool source context", err)
+	}
+}
+
+func TestBuildRequestScopesLegacyTupleMigrationToMiMo(t *testing.T) {
+	legacy := json.RawMessage(`{"type":"object","properties":{"pair":{"type":"array","items":[{"type":"string"},{"type":"number"}]}}}`)
+	req := provider.Request{Tools: []provider.ToolSchema{{Name: "tuple", Parameters: legacy}}}
+
+	mimo := (&client{mimo: true}).buildRequest(req)
+	if got := string(mimo.Tools[0].Function.Parameters); !strings.Contains(got, `"prefixItems"`) || strings.Contains(got, `"items":[`) {
+		t.Fatalf("MiMo parameters = %s, want Draft 2020-12 tuple keywords", got)
+	}
+
+	other := (&client{}).buildRequest(req)
+	if got := string(other.Tools[0].Function.Parameters); got != string(legacy) {
+		t.Fatalf("non-MiMo parameters changed:\n got: %s\nwant: %s", got, legacy)
+	}
+}
+
 // TestStreamAuthError verifies a 401 surfaces as an actionable *provider.AuthError
 // (naming the provider and its key env var) rather than a raw status body.
 func TestStreamAuthError(t *testing.T) {
@@ -245,6 +284,9 @@ func TestStreamUsesMiMoAPIKeyHeader(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	c := p.(*client)
+	if !c.mimo {
+		t.Fatal("official MiMo endpoint did not enable the Draft 2020-12 schema adapter")
+	}
 	c.chatURL = srv.URL
 
 	ch, err := p.Stream(context.Background(), provider.Request{

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -67,16 +67,23 @@ func retryNotifyFromContext(ctx context.Context) RetryNotify {
 // carries the code so the display layer can map it to an actionable, localized
 // message; Body is a trimmed snippet of the response.
 type APIError struct {
-	Provider string
-	Status   int
-	Body     string
+	Provider    string
+	Status      int
+	Body        string
+	ToolContext string // resolved Reasonix/MCP identity for provider-indexed tool schema errors
 }
 
 func (e *APIError) Error() string {
+	var base string
 	if e.Body == "" {
-		return fmt.Sprintf("%s: status %d", e.Provider, e.Status)
+		base = fmt.Sprintf("%s: status %d", e.Provider, e.Status)
+	} else {
+		base = fmt.Sprintf("%s: status %d: %s", e.Provider, e.Status, e.Body)
 	}
-	return fmt.Sprintf("%s: status %d: %s", e.Provider, e.Status, e.Body)
+	if e.ToolContext != "" {
+		return base + "\n" + e.ToolContext
+	}
+	return base
 }
 
 // RetryableStatus reports whether a backoff can plausibly recover from status s:

--- a/internal/provider/schema_canonicalize_test.go
+++ b/internal/provider/schema_canonicalize_test.go
@@ -146,10 +146,12 @@ func TestNormalizeLegacyTupleItemsPreservesExistingPrefixItems(t *testing.T) {
 }
 
 func TestNormalizeLegacyTupleItemsPreservesModernArrayItems(t *testing.T) {
+	// Modern object-form items need no rewrite, so the input bytes come back
+	// exactly — not a reserialized (key-sorted) copy, which would perturb the
+	// canonical bytes the registry produced once.
 	raw := json.RawMessage(`{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"number"}]}}`)
-	want := `{"items":{"anyOf":[{"type":"string"},{"type":"number"}]},"type":"array"}`
-	if got := string(NormalizeLegacyTupleItemsForDraft202012(raw)); got != want {
-		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want unchanged modern items %s", got, want)
+	if got := string(NormalizeLegacyTupleItemsForDraft202012(raw)); got != string(raw) {
+		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want the input bytes unchanged %s", got, raw)
 	}
 }
 

--- a/internal/provider/schema_canonicalize_test.go
+++ b/internal/provider/schema_canonicalize_test.go
@@ -86,3 +86,77 @@ func TestCanonicalizeSchemaPreservesDependentRequiredPropertyName(t *testing.T) 
 		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
 	}
 }
+
+func TestNormalizeLegacyTupleItemsForDraft202012(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"pair":{
+				"type":"array",
+				"items":[{"type":"string"},{"type":"number"}],
+				"additionalItems":false
+			}
+		}
+	}`)
+
+	got := string(NormalizeLegacyTupleItemsForDraft202012(raw))
+	want := `{"properties":{"pair":{"items":false,"prefixItems":[{"type":"string"},{"type":"number"}],"type":"array"}},"type":"object"}`
+	if got != want {
+		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want %s", got, want)
+	}
+	if again := string(NormalizeLegacyTupleItemsForDraft202012(json.RawMessage(got))); again != got {
+		t.Fatalf("tuple migration is not idempotent:\n first: %s\nsecond: %s", got, again)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsForDraft202012Nested(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"$defs":{
+			"value":{
+				"anyOf":[
+					{"type":"string"},
+					{"type":"array","items":[{"type":"string"},{"type":"number"}]}
+				]
+			}
+		},
+		"properties":{"value":{"$ref":"#/$defs/value"}}
+	}`)
+
+	got := string(NormalizeLegacyTupleItemsForDraft202012(raw))
+	want := `{"$defs":{"value":{"anyOf":[{"type":"string"},{"prefixItems":[{"type":"string"},{"type":"number"}],"type":"array"}]}},"properties":{"value":{"$ref":"#/$defs/value"}},"type":"object"}`
+	if got != want {
+		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want %s", got, want)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsPreservesExistingPrefixItems(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"array",
+		"prefixItems":[{"type":"boolean"}],
+		"items":[{"type":"string"}],
+		"additionalItems":{"type":"number"}
+	}`)
+
+	got := string(NormalizeLegacyTupleItemsForDraft202012(raw))
+	want := `{"items":{"type":"number"},"prefixItems":[{"type":"boolean"}],"type":"array"}`
+	if got != want {
+		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want %s", got, want)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsPreservesModernArrayItems(t *testing.T) {
+	raw := json.RawMessage(`{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"number"}]}}`)
+	want := `{"items":{"anyOf":[{"type":"string"},{"type":"number"}]},"type":"array"}`
+	if got := string(NormalizeLegacyTupleItemsForDraft202012(raw)); got != want {
+		t.Fatalf("NormalizeLegacyTupleItemsForDraft202012() = %s, want unchanged modern items %s", got, want)
+	}
+}
+
+func TestCanonicalizeSchemaPreservesLegacyTupleItems(t *testing.T) {
+	raw := json.RawMessage(`{"type":"object","properties":{"pair":{"type":"array","items":[{"type":"string"},{"type":"number"}],"additionalItems":false}}}`)
+	want := `{"properties":{"pair":{"additionalItems":false,"items":[{"type":"string"},{"type":"number"}],"type":"array"}},"type":"object"}`
+	if got := string(CanonicalizeSchema(raw)); got != want {
+		t.Fatalf("CanonicalizeSchema() = %s, want provider-neutral bytes %s", got, want)
+	}
+}

--- a/internal/provider/schema_dialect.go
+++ b/internal/provider/schema_dialect.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"strings"
-	"sync"
 )
 
 // IsMiMoEndpoint reports whether rawURL points at an official Xiaomi MiMo API
@@ -20,21 +19,18 @@ func IsMiMoEndpoint(rawURL string) bool {
 	return host != "xiaomimimo.com" && strings.HasSuffix(host, ".xiaomimimo.com")
 }
 
-// normalizedSchemaCache memoizes NormalizeLegacyTupleItemsForDraft202012
-// results keyed by the input bytes. Tool schemas come from the registry's
-// one-time canonicalization and are byte-stable across turns, while the MiMo
-// builders call the normalizer for every tool on every request — without the
-// memo each turn re-parses the full tool surface (~hundreds of schemas). The
-// cache is bounded by the set of distinct schemas seen and the function is
-// pure, so process-wide sharing is safe and deterministic.
-var normalizedSchemaCache sync.Map // string -> json.RawMessage
-
 // NormalizeLegacyTupleItemsForDraft202012 rewrites only the pre-2020-12 tuple
 // keywords in a JSON Schema. It is intentionally separate from
 // CanonicalizeSchema: provider implementations must opt in only after the target
 // endpoint's schema dialect is known, so other vendors keep their original tool
 // schema bytes and cache prefixes. A schema that needs no rewrite is returned
 // with its input bytes unchanged, byte for byte.
+//
+// There is deliberately no memoization: MCP schemas are externally supplied
+// bytes, and a process-global cache keyed by them would accumulate without
+// bound across projects, sessions, and server reconnects in a long-lived
+// desktop process. The lexical gate below keeps the common no-op case at zero
+// parses, and the rare legacy-tuple schema is cheap to re-convert per request.
 func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
 		return raw
@@ -44,21 +40,18 @@ func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessag
 	if !bytes.Contains(raw, []byte(`"items"`)) {
 		return raw
 	}
-	if cached, ok := normalizedSchemaCache.Load(string(raw)); ok {
-		return cached.(json.RawMessage)
-	}
 	var schema any
 	if err := json.Unmarshal(raw, &schema); err != nil {
 		return raw
 	}
-	result := raw
-	if normalizeDraft202012Schema(schema) {
-		if out, err := json.Marshal(schema); err == nil {
-			result = json.RawMessage(out)
-		}
+	if !normalizeDraft202012Schema(schema) {
+		return raw
 	}
-	normalizedSchemaCache.Store(string(raw), result)
-	return result
+	out, err := json.Marshal(schema)
+	if err != nil {
+		return raw
+	}
+	return json.RawMessage(out)
 }
 
 // normalizeDraft202012Schema rewrites legacy tuple keywords in place and
@@ -72,6 +65,19 @@ func normalizeDraft202012Schema(value any) bool {
 	schema, ok := value.(map[string]any)
 	if !ok {
 		return false
+	}
+	// Classify the resource's own dialect BEFORE touching anything: for an
+	// unknown/custom $schema this code cannot know whether the dialect defines
+	// 2020-12 tuple semantics, and a partial rewrite (keywords converted,
+	// declaration kept) would be self-contradictory in the other direction.
+	// JSON Schema requires processors to switch modes per dialect or leave the
+	// resource alone — so the whole custom resource, subtree included, stays
+	// untouched. Known legacy drafts and 2020-12 itself (where array-form
+	// items is simply malformed input worth repairing) proceed.
+	if decl, ok := schema["$schema"].(string); ok {
+		if !isLegacyJSONSchemaDialect(decl) && !isDraft202012Dialect(decl) {
+			return false
+		}
 	}
 	changed := false
 
@@ -142,13 +148,11 @@ func normalizeDraft202012Schema(value any) bool {
 }
 
 // isLegacyJSONSchemaDialect reports whether decl names a pre-2020-12 JSON
-// Schema dialect. Unknown or custom dialect URIs are left untouched — this
-// normalizer only understands the official drafts' tuple semantics.
+// Schema dialect. Unknown or custom dialect URIs make the whole resource
+// off-limits — this normalizer only understands the official drafts' tuple
+// semantics.
 func isLegacyJSONSchemaDialect(decl string) bool {
-	d := strings.TrimSuffix(strings.TrimSpace(decl), "#")
-	d = strings.TrimPrefix(d, "http://")
-	d = strings.TrimPrefix(d, "https://")
-	switch d {
+	switch normalizeDialectURI(decl) {
 	case "json-schema.org/schema",
 		"json-schema.org/draft-03/schema",
 		"json-schema.org/draft-04/schema",
@@ -158,6 +162,17 @@ func isLegacyJSONSchemaDialect(decl string) bool {
 		return true
 	}
 	return false
+}
+
+// isDraft202012Dialect reports whether decl names the 2020-12 dialect itself.
+func isDraft202012Dialect(decl string) bool {
+	return normalizeDialectURI(decl) == "json-schema.org/draft/2020-12/schema"
+}
+
+func normalizeDialectURI(decl string) string {
+	d := strings.TrimSuffix(strings.TrimSpace(decl), "#")
+	d = strings.TrimPrefix(d, "http://")
+	return strings.TrimPrefix(d, "https://")
 }
 
 func isSchemaObjectOrBool(value any) bool {

--- a/internal/provider/schema_dialect.go
+++ b/internal/provider/schema_dialect.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 // IsMiMoEndpoint reports whether rawURL points at an official Xiaomi MiMo API
@@ -18,44 +20,76 @@ func IsMiMoEndpoint(rawURL string) bool {
 	return host != "xiaomimimo.com" && strings.HasSuffix(host, ".xiaomimimo.com")
 }
 
+// normalizedSchemaCache memoizes NormalizeLegacyTupleItemsForDraft202012
+// results keyed by the input bytes. Tool schemas come from the registry's
+// one-time canonicalization and are byte-stable across turns, while the MiMo
+// builders call the normalizer for every tool on every request — without the
+// memo each turn re-parses the full tool surface (~hundreds of schemas). The
+// cache is bounded by the set of distinct schemas seen and the function is
+// pure, so process-wide sharing is safe and deterministic.
+var normalizedSchemaCache sync.Map // string -> json.RawMessage
+
 // NormalizeLegacyTupleItemsForDraft202012 rewrites only the pre-2020-12 tuple
 // keywords in a JSON Schema. It is intentionally separate from
 // CanonicalizeSchema: provider implementations must opt in only after the target
 // endpoint's schema dialect is known, so other vendors keep their original tool
-// schema bytes and cache prefixes.
+// schema bytes and cache prefixes. A schema that needs no rewrite is returned
+// with its input bytes unchanged, byte for byte.
 func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
 		return raw
+	}
+	// Legacy tuple syntax cannot exist without an "items" keyword; the common
+	// no-op case skips even the parse.
+	if !bytes.Contains(raw, []byte(`"items"`)) {
+		return raw
+	}
+	if cached, ok := normalizedSchemaCache.Load(string(raw)); ok {
+		return cached.(json.RawMessage)
 	}
 	var schema any
 	if err := json.Unmarshal(raw, &schema); err != nil {
 		return raw
 	}
-	normalizeDraft202012Schema(schema)
-	out, err := json.Marshal(schema)
-	if err != nil {
-		return raw
+	result := raw
+	if normalizeDraft202012Schema(schema) {
+		if out, err := json.Marshal(schema); err == nil {
+			result = json.RawMessage(out)
+		}
 	}
-	return json.RawMessage(out)
+	normalizedSchemaCache.Store(string(raw), result)
+	return result
 }
 
-func normalizeDraft202012Schema(value any) {
+// normalizeDraft202012Schema rewrites legacy tuple keywords in place and
+// reports whether anything changed. When a schema resource — an object
+// carrying its own $schema declaration — saw a conversion anywhere in its
+// subtree, an old-draft declaration is updated to 2020-12: leaving it would
+// make the output self-contradictory (an older dialect declared over
+// prefixItems / 2020-12 items), and MCP consumers may then apply the wrong
+// tuple semantics.
+func normalizeDraft202012Schema(value any) bool {
 	schema, ok := value.(map[string]any)
 	if !ok {
-		return
+		return false
 	}
+	changed := false
 
 	for _, keyword := range []string{
 		"additionalItems", "additionalProperties", "contains", "contentSchema",
 		"else", "if", "items", "not", "propertyNames", "then",
 		"unevaluatedItems", "unevaluatedProperties",
 	} {
-		normalizeDraft202012Schema(schema[keyword])
+		if normalizeDraft202012Schema(schema[keyword]) {
+			changed = true
+		}
 	}
 	for _, keyword := range []string{"allOf", "anyOf", "oneOf", "prefixItems"} {
 		if children, ok := schema[keyword].([]any); ok {
 			for _, child := range children {
-				normalizeDraft202012Schema(child)
+				if normalizeDraft202012Schema(child) {
+					changed = true
+				}
 			}
 		}
 	}
@@ -64,38 +98,66 @@ func normalizeDraft202012Schema(value any) {
 	} {
 		if children, ok := schema[keyword].(map[string]any); ok {
 			for _, child := range children {
-				normalizeDraft202012Schema(child)
+				if normalizeDraft202012Schema(child) {
+					changed = true
+				}
 			}
 		}
 	}
 	if dependencies, ok := schema["dependencies"].(map[string]any); ok {
 		for _, child := range dependencies {
+			if normalizeDraft202012Schema(child) {
+				changed = true
+			}
+		}
+	}
+
+	if legacyItems, ok := schema["items"].([]any); ok {
+		for _, child := range legacyItems {
 			normalizeDraft202012Schema(child)
 		}
-	}
-
-	legacyItems, ok := schema["items"].([]any)
-	if !ok {
-		return
-	}
-	for _, child := range legacyItems {
-		normalizeDraft202012Schema(child)
-	}
-
-	delete(schema, "items")
-	if len(legacyItems) > 0 {
-		// Keep an explicit 2020-12 prefix if a malformed mixed-dialect schema
-		// contains both forms.
-		if _, exists := schema["prefixItems"]; !exists {
-			schema["prefixItems"] = legacyItems
+		changed = true
+		delete(schema, "items")
+		if len(legacyItems) > 0 {
+			// Keep an explicit 2020-12 prefix if a malformed mixed-dialect schema
+			// contains both forms.
+			if _, exists := schema["prefixItems"]; !exists {
+				schema["prefixItems"] = legacyItems
+			}
+		}
+		if additional, exists := schema["additionalItems"]; exists {
+			delete(schema, "additionalItems")
+			if isSchemaObjectOrBool(additional) {
+				schema["items"] = additional
+			}
 		}
 	}
-	if additional, exists := schema["additionalItems"]; exists {
-		delete(schema, "additionalItems")
-		if isSchemaObjectOrBool(additional) {
-			schema["items"] = additional
+
+	if changed {
+		if decl, ok := schema["$schema"].(string); ok && isLegacyJSONSchemaDialect(decl) {
+			schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
 		}
 	}
+	return changed
+}
+
+// isLegacyJSONSchemaDialect reports whether decl names a pre-2020-12 JSON
+// Schema dialect. Unknown or custom dialect URIs are left untouched — this
+// normalizer only understands the official drafts' tuple semantics.
+func isLegacyJSONSchemaDialect(decl string) bool {
+	d := strings.TrimSuffix(strings.TrimSpace(decl), "#")
+	d = strings.TrimPrefix(d, "http://")
+	d = strings.TrimPrefix(d, "https://")
+	switch d {
+	case "json-schema.org/schema",
+		"json-schema.org/draft-03/schema",
+		"json-schema.org/draft-04/schema",
+		"json-schema.org/draft-06/schema",
+		"json-schema.org/draft-07/schema",
+		"json-schema.org/draft/2019-09/schema":
+		return true
+	}
+	return false
 }
 
 func isSchemaObjectOrBool(value any) bool {

--- a/internal/provider/schema_dialect.go
+++ b/internal/provider/schema_dialect.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// IsMiMoEndpoint reports whether rawURL points at an official Xiaomi MiMo API
+// host, including the regional token-plan subdomains. The bare apex is rejected
+// because it is not an API endpoint.
+func IsMiMoEndpoint(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host != "xiaomimimo.com" && strings.HasSuffix(host, ".xiaomimimo.com")
+}
+
+// NormalizeLegacyTupleItemsForDraft202012 rewrites only the pre-2020-12 tuple
+// keywords in a JSON Schema. It is intentionally separate from
+// CanonicalizeSchema: provider implementations must opt in only after the target
+// endpoint's schema dialect is known, so other vendors keep their original tool
+// schema bytes and cache prefixes.
+func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var schema any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return raw
+	}
+	normalizeDraft202012Schema(schema)
+	out, err := json.Marshal(schema)
+	if err != nil {
+		return raw
+	}
+	return json.RawMessage(out)
+}
+
+func normalizeDraft202012Schema(value any) {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+
+	for _, keyword := range []string{
+		"additionalItems", "additionalProperties", "contains", "contentSchema",
+		"else", "if", "items", "not", "propertyNames", "then",
+		"unevaluatedItems", "unevaluatedProperties",
+	} {
+		normalizeDraft202012Schema(schema[keyword])
+	}
+	for _, keyword := range []string{"allOf", "anyOf", "oneOf", "prefixItems"} {
+		if children, ok := schema[keyword].([]any); ok {
+			for _, child := range children {
+				normalizeDraft202012Schema(child)
+			}
+		}
+	}
+	for _, keyword := range []string{
+		"$defs", "definitions", "dependentSchemas", "patternProperties", "properties",
+	} {
+		if children, ok := schema[keyword].(map[string]any); ok {
+			for _, child := range children {
+				normalizeDraft202012Schema(child)
+			}
+		}
+	}
+	if dependencies, ok := schema["dependencies"].(map[string]any); ok {
+		for _, child := range dependencies {
+			normalizeDraft202012Schema(child)
+		}
+	}
+
+	legacyItems, ok := schema["items"].([]any)
+	if !ok {
+		return
+	}
+	for _, child := range legacyItems {
+		normalizeDraft202012Schema(child)
+	}
+
+	delete(schema, "items")
+	if len(legacyItems) > 0 {
+		// Keep an explicit 2020-12 prefix if a malformed mixed-dialect schema
+		// contains both forms.
+		if _, exists := schema["prefixItems"]; !exists {
+			schema["prefixItems"] = legacyItems
+		}
+	}
+	if additional, exists := schema["additionalItems"]; exists {
+		delete(schema, "additionalItems")
+		if isSchemaObjectOrBool(additional) {
+			schema["items"] = additional
+		}
+	}
+}
+
+func isSchemaObjectOrBool(value any) bool {
+	switch value.(type) {
+	case map[string]any, bool:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/provider/schema_dialect.go
+++ b/internal/provider/schema_dialect.go
@@ -44,7 +44,7 @@ func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessag
 	if err := json.Unmarshal(raw, &schema); err != nil {
 		return raw
 	}
-	if !normalizeDraft202012Schema(schema) {
+	if _, documentChanged := normalizeDraft202012Schema(schema); !documentChanged {
 		return raw
 	}
 	out, err := json.Marshal(schema)
@@ -54,17 +54,22 @@ func NormalizeLegacyTupleItemsForDraft202012(raw json.RawMessage) json.RawMessag
 	return json.RawMessage(out)
 }
 
-// normalizeDraft202012Schema rewrites legacy tuple keywords in place and
-// reports whether anything changed. When a schema resource — an object
-// carrying its own $schema declaration — saw a conversion anywhere in its
-// subtree, an old-draft declaration is updated to 2020-12: leaving it would
-// make the output self-contradictory (an older dialect declared over
-// prefixItems / 2020-12 items), and MCP consumers may then apply the wrong
-// tuple semantics.
-func normalizeDraft202012Schema(value any) bool {
+// normalizeDraft202012Schema rewrites legacy tuple keywords in place. It
+// returns two signals: resourceChanged reports conversions that belong to the
+// CALLER's schema resource (the node itself plus descendants up to the next
+// $schema boundary), documentChanged reports conversions anywhere in the
+// subtree and drives reserialization.
+//
+// The distinction is what keeps dialect updates inside their own resource: an
+// object carrying its own $schema is an independent schema resource, so its
+// conversions update its own old-draft declaration and then stop — they must
+// not mark the parent as changed, or a 2019-09 parent embedding a converting
+// 2020-12 $defs resource would have its untouched declaration "upgraded" and
+// the semantics of unrelated parent keywords silently changed.
+func normalizeDraft202012Schema(value any) (resourceChanged, documentChanged bool) {
 	schema, ok := value.(map[string]any)
 	if !ok {
-		return false
+		return false, false
 	}
 	// Classify the resource's own dialect BEFORE touching anything: for an
 	// unknown/custom $schema this code cannot know whether the dialect defines
@@ -74,28 +79,29 @@ func normalizeDraft202012Schema(value any) bool {
 	// resource alone — so the whole custom resource, subtree included, stays
 	// untouched. Known legacy drafts and 2020-12 itself (where array-form
 	// items is simply malformed input worth repairing) proceed.
-	if decl, ok := schema["$schema"].(string); ok {
-		if !isLegacyJSONSchemaDialect(decl) && !isDraft202012Dialect(decl) {
-			return false
-		}
+	decl, hasDecl := schema["$schema"].(string)
+	if hasDecl && !isLegacyJSONSchemaDialect(decl) && !isDraft202012Dialect(decl) {
+		return false, false
 	}
-	changed := false
+	changed := false // within this resource, up to nested $schema boundaries
+	doc := false
+	visit := func(child any) {
+		childResource, childDocument := normalizeDraft202012Schema(child)
+		changed = changed || childResource
+		doc = doc || childDocument
+	}
 
 	for _, keyword := range []string{
 		"additionalItems", "additionalProperties", "contains", "contentSchema",
 		"else", "if", "items", "not", "propertyNames", "then",
 		"unevaluatedItems", "unevaluatedProperties",
 	} {
-		if normalizeDraft202012Schema(schema[keyword]) {
-			changed = true
-		}
+		visit(schema[keyword])
 	}
 	for _, keyword := range []string{"allOf", "anyOf", "oneOf", "prefixItems"} {
 		if children, ok := schema[keyword].([]any); ok {
 			for _, child := range children {
-				if normalizeDraft202012Schema(child) {
-					changed = true
-				}
+				visit(child)
 			}
 		}
 	}
@@ -104,23 +110,19 @@ func normalizeDraft202012Schema(value any) bool {
 	} {
 		if children, ok := schema[keyword].(map[string]any); ok {
 			for _, child := range children {
-				if normalizeDraft202012Schema(child) {
-					changed = true
-				}
+				visit(child)
 			}
 		}
 	}
 	if dependencies, ok := schema["dependencies"].(map[string]any); ok {
 		for _, child := range dependencies {
-			if normalizeDraft202012Schema(child) {
-				changed = true
-			}
+			visit(child)
 		}
 	}
 
 	if legacyItems, ok := schema["items"].([]any); ok {
 		for _, child := range legacyItems {
-			normalizeDraft202012Schema(child)
+			visit(child)
 		}
 		changed = true
 		delete(schema, "items")
@@ -140,11 +142,17 @@ func normalizeDraft202012Schema(value any) bool {
 	}
 
 	if changed {
-		if decl, ok := schema["$schema"].(string); ok && isLegacyJSONSchemaDialect(decl) {
+		doc = true
+		if hasDecl && isLegacyJSONSchemaDialect(decl) {
 			schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
 		}
 	}
-	return changed
+	if hasDecl {
+		// Resource boundary: this resource's changes (and its declaration
+		// update) are settled here and must not leak into the parent.
+		return false, doc
+	}
+	return changed, doc
 }
 
 // isLegacyJSONSchemaDialect reports whether decl names a pre-2020-12 JSON

--- a/internal/provider/schema_dialect_test.go
+++ b/internal/provider/schema_dialect_test.go
@@ -96,13 +96,47 @@ func TestNormalizeLegacyTupleItemsLeavesUnconvertedDialectAlone(t *testing.T) {
 }
 
 func TestNormalizeLegacyTupleItemsLeavesUnknownDialectAlone(t *testing.T) {
+	// An unknown dialect may define its own tuple semantics; a partial rewrite
+	// (keywords converted, declaration kept) would be self-contradictory, so
+	// the whole resource comes back byte-identical.
 	raw := json.RawMessage(`{"$schema":"https://example.com/custom-dialect","type":"array","items":[{"type":"string"}]}`)
+	if got := NormalizeLegacyTupleItemsForDraft202012(raw); string(got) != string(raw) {
+		t.Fatalf("custom-dialect resource was rewritten:\n in: %s\nout: %s", raw, got)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsSkipsNestedUnknownDialectResource(t *testing.T) {
+	// The custom-dialect embedded resource stays untouched while a sibling in
+	// the (default 2020-12) enclosing schema still converts.
+	raw := json.RawMessage(`{"type":"object","$defs":{"custom":{"$schema":"https://example.com/custom-dialect","type":"array","items":[{"type":"string"}]},"pair":{"type":"array","items":[{"type":"number"}]}}}`)
 	var schema map[string]any
 	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got := schema["$schema"]; got != "https://example.com/custom-dialect" {
-		t.Fatalf("$schema = %v, custom dialects must not be rewritten", got)
+	defs := schema["$defs"].(map[string]any)
+	custom := defs["custom"].(map[string]any)
+	if _, ok := custom["items"].([]any); !ok {
+		t.Fatalf("custom resource's tuple items were rewritten: %v", custom)
+	}
+	if _, exists := custom["prefixItems"]; exists {
+		t.Fatalf("custom resource gained prefixItems: %v", custom)
+	}
+	pair := defs["pair"].(map[string]any)
+	if _, ok := pair["prefixItems"].([]any); !ok {
+		t.Fatalf("sibling resource was not converted: %v", pair)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsRepairsExplicit202012(t *testing.T) {
+	// Array-form items under an explicit 2020-12 declaration is malformed
+	// input; repairing it keeps the declaration as-is.
+	raw := json.RawMessage(`{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"array","items":[{"type":"string"}]}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := schema["$schema"]; got != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("$schema = %v, want 2020-12 kept", got)
 	}
 	if _, ok := schema["prefixItems"].([]any); !ok {
 		t.Fatalf("prefixItems missing: %v", schema)
@@ -118,12 +152,13 @@ func TestNormalizeLegacyTupleItemsCanonicalByteFastPath(t *testing.T) {
 		t.Fatal("schema without items must return the input bytes unchanged")
 	}
 
-	// Memoized conversion: repeated calls yield identical bytes.
+	// Conversion is deterministic across calls (no process-global cache holds
+	// externally supplied schema bytes).
 	tuple := json.RawMessage(`{"type":"array","items":[{"type":"string"}]}`)
 	first := NormalizeLegacyTupleItemsForDraft202012(tuple)
 	second := NormalizeLegacyTupleItemsForDraft202012(tuple)
 	if string(first) != string(second) {
-		t.Fatalf("memoized conversion diverged:\n1: %s\n2: %s", first, second)
+		t.Fatalf("conversion diverged:\n1: %s\n2: %s", first, second)
 	}
 	if string(first) == string(tuple) {
 		t.Fatalf("tuple schema was not converted: %s", first)

--- a/internal/provider/schema_dialect_test.go
+++ b/internal/provider/schema_dialect_test.go
@@ -52,3 +52,80 @@ func TestNormalizeLegacyTupleItemsDoesNotRewriteSchemaExamples(t *testing.T) {
 		t.Fatalf("schema default gained prefixItems: %s", got)
 	}
 }
+
+func TestNormalizeLegacyTupleItemsUpdatesRootDialect(t *testing.T) {
+	raw := json.RawMessage(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":[{"type":"string"},{"type":"number"}]}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := schema["$schema"]; got != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("$schema = %v, want 2020-12 after tuple conversion (old declaration would misread prefixItems)", got)
+	}
+	if _, ok := schema["prefixItems"].([]any); !ok {
+		t.Fatalf("prefixItems missing: %v", schema)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsUpdatesNestedResourceDialect(t *testing.T) {
+	raw := json.RawMessage(`{"type":"object","$defs":{"pair":{"$schema":"https://json-schema.org/draft/2019-09/schema","type":"array","items":[{"type":"string"}]}}}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, exists := schema["$schema"]; exists {
+		t.Fatalf("root gained a $schema it never declared: %v", schema)
+	}
+	pair := schema["$defs"].(map[string]any)["pair"].(map[string]any)
+	if got := pair["$schema"]; got != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("nested resource $schema = %v, want 2020-12", got)
+	}
+	if _, ok := pair["prefixItems"].([]any); !ok {
+		t.Fatalf("nested prefixItems missing: %v", pair)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsLeavesUnconvertedDialectAlone(t *testing.T) {
+	// No legacy tuple anywhere: the declared old dialect stays, and the exact
+	// input bytes come back (no reserialization).
+	raw := json.RawMessage(`{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"xs":{"type":"array","items":{"type":"string"}}}}`)
+	got := NormalizeLegacyTupleItemsForDraft202012(raw)
+	if string(got) != string(raw) {
+		t.Fatalf("unchanged schema was rewritten:\n in: %s\nout: %s", raw, got)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsLeavesUnknownDialectAlone(t *testing.T) {
+	raw := json.RawMessage(`{"$schema":"https://example.com/custom-dialect","type":"array","items":[{"type":"string"}]}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := schema["$schema"]; got != "https://example.com/custom-dialect" {
+		t.Fatalf("$schema = %v, custom dialects must not be rewritten", got)
+	}
+	if _, ok := schema["prefixItems"].([]any); !ok {
+		t.Fatalf("prefixItems missing: %v", schema)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsCanonicalByteFastPath(t *testing.T) {
+	// No "items" keyword at all: the very same backing bytes come back with no
+	// parse — the per-turn cost for the common tool surface must stay zero.
+	raw := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	got := NormalizeLegacyTupleItemsForDraft202012(raw)
+	if len(got) == 0 || &got[0] != &raw[0] {
+		t.Fatal("schema without items must return the input bytes unchanged")
+	}
+
+	// Memoized conversion: repeated calls yield identical bytes.
+	tuple := json.RawMessage(`{"type":"array","items":[{"type":"string"}]}`)
+	first := NormalizeLegacyTupleItemsForDraft202012(tuple)
+	second := NormalizeLegacyTupleItemsForDraft202012(tuple)
+	if string(first) != string(second) {
+		t.Fatalf("memoized conversion diverged:\n1: %s\n2: %s", first, second)
+	}
+	if string(first) == string(tuple) {
+		t.Fatalf("tuple schema was not converted: %s", first)
+	}
+}

--- a/internal/provider/schema_dialect_test.go
+++ b/internal/provider/schema_dialect_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsMiMoEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		url  string
+		want bool
+	}{
+		{"https://api.xiaomimimo.com/v1", true},
+		{"https://api.xiaomimimo.com/anthropic", true},
+		{"https://token-plan-cn.xiaomimimo.com/v1", true},
+		{"https://token-plan-sgp.xiaomimimo.com/anthropic", true},
+		{"https://token-plan-ams.xiaomimimo.com/v1", true},
+		{"https://xiaomimimo.com/v1", false},
+		{"https://api.deepseek.com", false},
+		{"https://xiaomimimo.com.example.org", false},
+		{"", false},
+		{"not-a-url", false},
+	} {
+		if got := IsMiMoEndpoint(tc.url); got != tc.want {
+			t.Errorf("IsMiMoEndpoint(%q) = %v, want %v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeLegacyTupleItemsDoesNotRewriteSchemaExamples(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"value":{
+				"type":"object",
+				"default":{"items":["first","second"]}
+			}
+		}
+	}`)
+	got := NormalizeLegacyTupleItemsForDraft202012(raw)
+	var schema map[string]any
+	if err := json.Unmarshal(got, &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	properties := schema["properties"].(map[string]any)
+	value := properties["value"].(map[string]any)
+	defaultValue := value["default"].(map[string]any)
+	if _, ok := defaultValue["items"].([]any); !ok {
+		t.Fatalf("schema default was rewritten: %s", got)
+	}
+	if _, exists := defaultValue["prefixItems"]; exists {
+		t.Fatalf("schema default gained prefixItems: %s", got)
+	}
+}

--- a/internal/provider/schema_dialect_test.go
+++ b/internal/provider/schema_dialect_test.go
@@ -164,3 +164,39 @@ func TestNormalizeLegacyTupleItemsCanonicalByteFastPath(t *testing.T) {
 		t.Fatalf("tuple schema was not converted: %s", first)
 	}
 }
+
+func TestNormalizeLegacyTupleItemsKeepsParentDialectAcrossResourceBoundary(t *testing.T) {
+	// The nested $defs entry is an independent schema resource (it carries its
+	// own $schema). Its conversion must reserialize the document but must NOT
+	// upgrade the parent's untouched 2019-09 declaration — the parent's other
+	// keywords were written for 2019-09 semantics.
+	raw := json.RawMessage(`{"$schema":"https://json-schema.org/draft/2019-09/schema","$defs":{"pair":{"$schema":"https://json-schema.org/draft/2020-12/schema","items":[{"type":"string"}]}}}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := schema["$schema"]; got != "https://json-schema.org/draft/2019-09/schema" {
+		t.Fatalf("parent dialect changed across nested schema-resource boundary: %v", got)
+	}
+	pair := schema["$defs"].(map[string]any)["pair"].(map[string]any)
+	if got := pair["$schema"]; got != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("nested resource $schema = %v, want 2020-12 kept", got)
+	}
+	if _, ok := pair["prefixItems"].([]any); !ok {
+		t.Fatalf("nested resource was not converted: %v", pair)
+	}
+}
+
+func TestNormalizeLegacyTupleItemsUpdatesParentForOwnResourceChanges(t *testing.T) {
+	// Contrast case: the converting subschema declares no $schema of its own,
+	// so it belongs to the parent's resource and the parent's legacy dialect
+	// must be updated.
+	raw := json.RawMessage(`{"$schema":"https://json-schema.org/draft/2019-09/schema","$defs":{"pair":{"type":"array","items":[{"type":"string"}]}}}`)
+	var schema map[string]any
+	if err := json.Unmarshal(NormalizeLegacyTupleItemsForDraft202012(raw), &schema); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := schema["$schema"]; got != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("parent dialect = %v, want 2020-12 for a conversion inside its own resource", got)
+	}
+}

--- a/internal/provider/schema_error.go
+++ b/internal/provider/schema_error.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var providerToolIndexPattern = regexp.MustCompile(`(?i)\btool\s+(\d+)\s+function\b`)
+
+// AnnotateToolSchemaError resolves provider messages such as "Tool 197 function
+// has invalid 'parameters' schema" back to the stable Reasonix tool identity.
+// MCP tool names carry their source server in mcp__<server>__<tool> form, so the
+// resulting diagnostic tells users which integration supplied the bad schema.
+func AnnotateToolSchemaError(err error, tools []ToolSchema) error {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || (apiErr.Status != 400 && apiErr.Status != 422) {
+		return err
+	}
+	match := providerToolIndexPattern.FindStringSubmatch(apiErr.Body)
+	if len(match) != 2 {
+		return err
+	}
+	index, parseErr := strconv.Atoi(match[1])
+	if parseErr != nil || index < 0 || index >= len(tools) {
+		return err
+	}
+
+	tool := tools[index]
+	context := fmt.Sprintf("Provider tool %d maps to Reasonix tool %q.", index, tool.Name)
+	if server, rawName, ok := splitMCPToolName(tool.Name); ok {
+		context = fmt.Sprintf("Provider tool %d maps to Reasonix tool %q (MCP server %q, tool %q).", index, tool.Name, server, rawName)
+	}
+	annotated := *apiErr
+	annotated.ToolContext = context
+	return &annotated
+}
+
+func splitMCPToolName(name string) (server, tool string, ok bool) {
+	const prefix = "mcp__"
+	if !strings.HasPrefix(name, prefix) {
+		return "", "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(name, prefix), "__", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/internal/provider/schema_error_test.go
+++ b/internal/provider/schema_error_test.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAnnotateToolSchemaErrorNamesMCPSource(t *testing.T) {
+	err := &APIError{
+		Provider: "mimo",
+		Status:   400,
+		Body:     `{"error":{"message":"Tool 1 function has invalid 'parameters' schema"}}`,
+	}
+	tools := []ToolSchema{
+		{Name: "read_file"},
+		{Name: "mcp__filesystem__search"},
+	}
+
+	got := AnnotateToolSchemaError(err, tools)
+	var apiErr *APIError
+	if !errors.As(got, &apiErr) {
+		t.Fatalf("AnnotateToolSchemaError() = %T, want *APIError", got)
+	}
+	for _, want := range []string{`Reasonix tool "mcp__filesystem__search"`, `MCP server "filesystem"`, `tool "search"`} {
+		if !strings.Contains(apiErr.ToolContext, want) {
+			t.Errorf("ToolContext = %q, want %q", apiErr.ToolContext, want)
+		}
+	}
+}
+
+func TestAnnotateToolSchemaErrorLeavesUnrelatedErrorsUnchanged(t *testing.T) {
+	tests := []error{
+		errors.New("network down"),
+		&APIError{Provider: "mimo", Status: 429, Body: "Tool 0 function failed"},
+		&APIError{Provider: "mimo", Status: 400, Body: "other bad request"},
+		&APIError{Provider: "mimo", Status: 400, Body: "Tool 9 function has invalid schema"},
+	}
+	tools := []ToolSchema{{Name: "read_file"}}
+	for _, err := range tests {
+		if got := AnnotateToolSchemaError(err, tools); got != err {
+			t.Errorf("AnnotateToolSchemaError(%v) changed unrelated error to %v", err, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- adapt legacy Draft 7 tuple schemas to Draft 2020-12 only at Xiaomi MiMo's OpenAI- and Anthropic-compatible wire boundaries
- preserve provider-neutral registry schemas and non-MiMo request bytes
- enrich indexed provider schema failures with the Reasonix tool name and MCP server/tool identity

## Root cause

Some MCP servers still expose tuple arrays as `items: [schema, ...]`. MiMo validates function parameters with the Draft 2020-12 metaschema, where tuple entries belong under `prefixItems`, so one legacy tool could reject the entire chat request with HTTP 400. Applying that migration in the shared registry would risk breaking providers that accept the older dialect or a smaller JSON Schema subset, so this change scopes the rewrite to confirmed MiMo endpoints.

## User impact

MiMo API and regional token-plan presets can chat with affected MCP tool sets through both supported protocols. Other provider presets keep their existing tool schema bytes. If a provider still reports an indexed schema error, the message now identifies the corresponding Reasonix tool and MCP source.

## Verification

- `go test ./...`
- `go vet ./...`
- `./scripts/cache-guard.sh`
- `git diff --check`

Cache-impact: low - only MiMo requests containing legacy tuple schemas receive different provider-visible tool bytes; non-MiMo prefixes remain unchanged.
Cache-guard: `./scripts/cache-guard.sh` passed all scenarios with tail averages of 92-95% against the 90% threshold.