### PR TITLE
fix(agent): warn once per session on missing tool-call reasoning / 缺失思维链告警改为每会话一次

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -260,6 +260,13 @@ type Agent struct {
 	lastPrefixShape     PrefixShape
 	haveLastPrefixShape bool
 
+	// warnedMissingToolCallReasoning dedupes the missing tool-call reasoning
+	// notice: when an endpoint stops emitting reasoning it tends to do so for
+	// every following round, so the first notice carries the signal and
+	// per-round repeats only flood the transcript. Loop-owned; reset by
+	// SetSession so a swapped-in conversation warns anew.
+	warnedMissingToolCallReasoning bool
+
 	// planMode, when true, refuses any tool call whose ReadOnly() is false.
 	// The system prompt and tool list never change with the toggle so the
 	// prompt-cache prefix stays valid; the gating happens at execute time
@@ -719,6 +726,7 @@ func (a *Agent) SetSession(s *Session) {
 	a.sessMu.Unlock()
 	a.sessCacheHit.Store(0)
 	a.sessCacheMiss.Store(0)
+	a.warnedMissingToolCallReasoning = false
 	if s != nil {
 		a.rebuildTodoState(s.Snapshot())
 	}
@@ -1269,9 +1277,12 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 // warnMissingToolCallReasoning surfaces a thinking-mode tool_calls turn that
 // arrived without reasoning text only when the provider/model is expected to
 // emit it. The turn is still saved and the replay still succeeds (the wire
-// layer can conservatively emit the reasoning_content key), but models that do
+// layer always emits the reasoning_content key on such turns), but models that
 // rely on tool-call reasoning continue without their chain-of-thought context,
-// so that degradation is worth a visible warning.
+// so that degradation is worth one visible warning. Exactly one per session:
+// the shape is endpoint-conditional (observed on the official DeepSeek API as
+// well as behind gateways) and tends to repeat for every round once it starts,
+// so per-round notices bury the transcript without adding signal (#6259).
 func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) {
 	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.prov) {
 		return
@@ -1279,8 +1290,13 @@ func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasonin
 	if strings.TrimSpace(reasoning) != "" {
 		return
 	}
+	if a.warnedMissingToolCallReasoning {
+		return
+	}
+	a.warnedMissingToolCallReasoning = true
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-		Text: fmt.Sprintf("%s returned %d tool call(s) without reasoning_content; continuing, but thinking context is lost for this turn (is a gateway dropping the reasoning field?)", a.prov.Name(), len(calls))})
+		Text:   fmt.Sprintf("%s returned tool calls without reasoning_content; continuing, but thinking context is lost on such turns (shown once per session)", a.prov.Name()),
+		Detail: fmt.Sprintf("this round carried %d tool call(s) and no reasoning. Whether reasoning accompanies tool calls is endpoint-side behavior; the turn is saved and replayed with an empty reasoning_content key, which the API accepts. Later rounds with the same shape stay silent for the rest of the session.", len(calls))})
 }
 
 // maxStepsPause is the deliberate stop when a positive tool-call budget runs

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -555,14 +555,17 @@ func TestRunWellFormedToolLoopRoundTrips(t *testing.T) {
 }
 
 // TestRunWarnsAndContinuesOnMissingToolCallReasoning: a DeepSeek thinking-mode
-// tool_calls turn arriving without reasoning (gateway dropped the field) is a
-// quality degradation, not a failure — the turn is saved, the loop continues to
-// completion, and the user sees a warn notice naming the likely cause. The
-// wire layer keeps the replay valid by always serializing the reasoning_content
-// key on such turns.
+// tool_calls turn arriving without reasoning is a quality degradation, not a
+// failure — the turn is saved, the loop continues to completion, and the user
+// sees a single warn notice. Missing reasoning tends to repeat on every round
+// once it starts (endpoint-conditional behavior, seen on the official API too),
+// so later rounds with the same shape must stay silent instead of flooding the
+// transcript (#6259). The wire layer keeps the replay valid by always
+// serializing the reasoning_content key on such turns.
 func TestRunWarnsAndContinuesOnMissingToolCallReasoning(t *testing.T) {
 	mp := testutil.NewMock("deepseek-proxy",
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "echo", Arguments: `{"text":"again"}`}}},
 		testutil.Turn{Text: "done"},
 	)
 	sink := &recordSink{}
@@ -571,23 +574,54 @@ func TestRunWarnsAndContinuesOnMissingToolCallReasoning(t *testing.T) {
 	if err := a.Run(context.Background(), "go"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	var savedToolTurn bool
+	var savedToolTurns int
 	for _, m := range a.Session().Messages {
 		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
-			savedToolTurn = true
+			savedToolTurns++
 		}
 	}
-	if !savedToolTurn {
-		t.Fatalf("tool-call turn should be saved despite missing reasoning, session=%+v", a.Session().Messages)
+	if savedToolTurns != 2 {
+		t.Fatalf("tool-call turns saved = %d, want 2 despite missing reasoning, session=%+v", savedToolTurns, a.Session().Messages)
 	}
-	var warned bool
+	var warns int
 	for _, e := range sink.kinds(event.Notice) {
 		if e.Level == event.LevelWarn && strings.Contains(e.Text, "without reasoning_content") {
-			warned = true
+			warns++
 		}
 	}
-	if !warned {
-		t.Fatal("missing-reasoning tool_calls turn should emit a warn notice")
+	if warns != 1 {
+		t.Fatalf("missing-reasoning warn notices = %d, want exactly 1 (first round warns, repeats stay silent)", warns)
+	}
+}
+
+// TestSetSessionRearmsMissingToolCallReasoningWarn: the once-per-session dedupe
+// is scoped to the conversation — swapping in a different session (resume/new)
+// must re-arm the notice so the fresh conversation still gets its one warning.
+func TestSetSessionRearmsMissingToolCallReasoningWarn(t *testing.T) {
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "done"},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "done again"},
+	)
+	sink := &recordSink{}
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{}, sink)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	a.SetSession(NewSession(""))
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	var warns int
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Level == event.LevelWarn && strings.Contains(e.Text, "without reasoning_content") {
+			warns++
+		}
+	}
+	if warns != 2 {
+		t.Fatalf("warn notices across two sessions = %d, want 2 (SetSession re-arms the dedupe)", warns)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Emit the "returned tool calls without reasoning_content" warn notice **once per session** instead of once per tool round; later rounds with the same shape stay silent. `SetSession` re-arms the dedupe so a resumed or swapped-in conversation still gets its one warning.
- Reword the notice: drop the "(is a gateway dropping the reasoning field?)" guess — the shape is now confirmed on the official DeepSeek endpoint as well (#6259, #6333), so pointing at gateways sends affected users down the wrong path. The impact explanation (thinking context lost; the turn is replayed with an empty `reasoning_content` key, which the API accepts) moves into the notice detail.

## Background
Users on the official `deepseek-v4-pro` endpoint report this warning repeating every round for whole agent runs (#6259 with several +1s, #6333; #6173 is the same family behind a litellm gateway). Live multi-round captures against the official API (thinking enabled, `reasoning_effort: high`, streaming tool loop, empty-reasoning replay on prior turns) show reasoning present on every round from an overseas vantage, while affected users see it absent on every round — the behavior is endpoint/path-conditional and, once it starts, tends to repeat for the rest of the run. A per-round notice therefore adds no signal after the first and buries the transcript (reported screenshots show 10+ identical cards in a single run).

The wire-level guard from #6217 (always serialize the `reasoning_content` key on DeepSeek `tool_calls` turns) keeps these sessions fully functional; the remaining product issue is notice spam, which this PR addresses. The upstream missing-reasoning behavior itself stays tracked in the referenced issues.

## Behavior
| scenario | before | after |
| --- | --- | --- |
| first tool round missing reasoning | warn notice | warn notice (text notes once-per-session; detail explains impact) |
| subsequent missing-reasoning rounds | warn notice per round | silent |
| rounds where reasoning is present | no notice | no notice (unchanged) |
| `SetSession` (resume / conversation swap) | — | dedupe re-armed; the new conversation warns once again |

## Cache impact
Cache-impact: none - notice emission dedupe only; no provider-visible request bytes, tool schemas, ordering, or serialization change.
Cache-guard: go test ./internal/agent (full package, includes the DeepSeek reasoning replay round-trip tests); provider serialization untouched.

## Verification
- `go test ./internal/agent -count=1` — full package green, including the updated `TestRunWarnsAndContinuesOnMissingToolCallReasoning` (two missing-reasoning rounds → exactly one warn, both tool turns still saved) and the new `TestSetSessionRearmsMissingToolCallReasoningWarn`
- `gofmt -l` / `go vet ./internal/agent` clean
- Repo sweep: no remaining references to the old notice text

Refs #6259 #6333 #6173
