### PR TITLE
fix(agent): 判断 edit_file/multi_edit 的 "not found" / "not unique" 错误，预先处理再发给模型auto-annotate edit_file/multi_edit anchor errors with current file context

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2551,6 +2553,19 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		if !json.Valid([]byte(call.Arguments)) {
 			detail = strings.TrimRight(detail, "\n") + "\nThe arguments were not valid JSON. Re-emit them exactly per this schema:\n" + string(t.Schema())
 		}
+		// Retry-annotate for edit_file / multi_edit: when the edit fails because
+		// old_string was not found or was ambiguous, the file may have changed since
+		// the model last read it. Append the current file state so the model can
+		// re-send matching anchors without needing a separate read_file call.
+		// Use the provider-specific anchor-edit level: Aggressive providers (DeepSeek)
+		// get auto-annotation on every error; Default providers get it only for
+		// "not found" / "not unique" errors.
+		level := provider.AnchorEditStrictness(a.prov)
+		if isEditFileAnchorError(call.Name, err, level) {
+			if fileCtx := readFileContext(json.RawMessage(call.Arguments)); fileCtx != "" {
+				detail = strings.TrimRight(detail, "\n") + "\n\nThe file may have changed since you last read it. Here is its current state around the region you tried to edit:\n" + fileCtx
+			}
+		}
 		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, detail))
 		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg}
 	}
@@ -2563,6 +2578,53 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	body, truncMsg := truncateToolOutput(result)
 	return toolOutcome{output: body, images: images, truncated: truncMsg != "", truncMsg: truncMsg}
+}
+
+// isEditFileAnchorError reports whether the tool and its error suggest a stale
+// anchor that could be resolved by showing the current file state.
+// When level is Aggressive, every error from edit_file/multi_edit triggers
+// annotation; when Default, only "not found" / "not unique" errors do.
+func isEditFileAnchorError(name string, err error, level provider.AnchorEditLevel) bool {
+	if name != "edit_file" && name != "multi_edit" {
+		return false
+	}
+	if level == provider.AnchorEditAggressive {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "not unique")
+}
+
+// readFileContext tries to extract a "path" from the call's JSON args and
+// return the file's current first 80 lines. Returns "" when the path can't
+// be extracted or the file can't be read (the original error stands alone).
+func readFileContext(args json.RawMessage) string {
+	var p struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil || p.Path == "" {
+		return ""
+	}
+	// Resolve relative paths the same way edit_file/multi_edit's resolveIn
+	// would: convert to an absolute path so the file is found regardless of
+	// the agent's working directory.
+	resolved := p.Path
+	if !filepath.IsAbs(resolved) {
+		abs, err := filepath.Abs(resolved)
+		if err == nil {
+			resolved = abs
+		}
+	}
+	content, err := os.ReadFile(resolved)
+	if err != nil {
+		return ""
+	}
+	lines := strings.SplitN(string(content), "\n", 81)
+	if len(lines) > 80 {
+		lines = lines[:80]
+	}
+	return "file: " + resolved + "\n" + strings.Join(lines, "\n")
 }
 
 func (a *Agent) checkPlanModeMCPReadOnlyTrust(ctx context.Context, call provider.ToolCall, t tool.Tool) (bool, toolOutcome, bool) {

--- a/internal/agent/edit_retry_test.go
+++ b/internal/agent/edit_retry_test.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestIsEditFileAnchorError verifies that isEditFileAnchorError correctly
+// identifies retryable edit_file / multi_edit errors with Default level.
+func TestIsEditFileAnchorError(t *testing.T) {
+	level := provider.AnchorEditDefault
+	tests := []struct {
+		name string
+		tool string
+		err  string
+		want bool
+	}{
+		{"edit_file not found", "edit_file", `old_string not found in "foo.go"`, true},
+		{"edit_file not unique", "edit_file", `old_string is not unique in "foo.go"`, true},
+		{"multi_edit not found", "multi_edit", "edit 1: old_string not found", true},
+		{"multi_edit not unique", "multi_edit", "edit 2: old_string is not unique", true},
+		{"edit_file write error", "edit_file", "write foo.go: permission denied", false},
+		{"edit_file read error", "edit_file", "read foo.go: no such file", false},
+		{"bash error", "bash", "old_string not found", false},
+		{"write_file error", "write_file", "old_string not found", false},
+		{"multi_edit not found variant", "multi_edit", `edit 1: old_string not found in "main.go"`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &editFileErrorStub{msg: tt.err}
+			if got := isEditFileAnchorError(tt.tool, err, level); got != tt.want {
+				t.Errorf("isEditFileAnchorError(%q, %q, Default) = %v, want %v",
+					tt.tool, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsEditFileAnchorErrorAggressive verifies that with Aggressive level,
+// every edit_file/multi_edit error triggers annotation, including write
+// and read errors that would not trigger at Default level.
+func TestIsEditFileAnchorErrorAggressive(t *testing.T) {
+	level := provider.AnchorEditAggressive
+	tests := []struct {
+		name string
+		tool string
+		err  string
+		want bool
+	}{
+		{"edit_file not found", "edit_file", `old_string not found`, true},
+		{"edit_file write error", "edit_file", "write foo.go: permission denied", true},
+		{"edit_file read error", "edit_file", "read foo.go: no such file", true},
+		{"multi_edit any error", "multi_edit", "edit 3: some unexpected error", true},
+		{"bash error ignores aggressive", "bash", "old_string not found", false},
+		{"write_file error ignores aggressive", "write_file", "permission denied", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &editFileErrorStub{msg: tt.err}
+			if got := isEditFileAnchorError(tt.tool, err, level); got != tt.want {
+				t.Errorf("isEditFileAnchorError(%q, %q, Aggressive) = %v, want %v",
+					tt.tool, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// editFileErrorStub is a minimal error that lets us test isEditFileAnchorError
+// without constructing the actual fmt.Errorf messages from editfile.go.
+type editFileErrorStub struct{ msg string }
+
+func (e *editFileErrorStub) Error() string { return e.msg }
+
+func TestReadFileContext(t *testing.T) {
+	// Create a temp file with known content.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.go")
+	content := `package main
+
+func foo() {
+	fmt.Println("hello")
+}
+
+func bar() {
+	fmt.Println("world")
+}
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test: readFileContext returns file contents for a valid absolute path.
+	pathOK := filepath.ToSlash(path)
+	args := `{"path":"` + pathOK + `"}`
+	ctx := readFileContext([]byte(args))
+	if ctx == "" {
+		t.Fatal("readFileContext returned empty string for valid absolute path")
+	}
+
+	// Test: relative path is resolved correctly (the real bug from #6337).
+	// Change to the temp dir so a relative path points there.
+	oldDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(oldDir) })
+	args = `{"path":"test.go"}`
+	ctx = readFileContext([]byte(args))
+	if ctx == "" {
+		t.Fatal("readFileContext returned empty string for valid relative path")
+	}
+
+	// Test: missing path returns empty.
+	ctx = readFileContext([]byte(`{}`))
+	if ctx != "" {
+		t.Errorf("expected empty for missing path, got %q", ctx)
+	}
+
+	// Test: invalid JSON returns empty.
+	ctx = readFileContext([]byte(`not-json`))
+	if ctx != "" {
+		t.Errorf("expected empty for invalid JSON, got %q", ctx)
+	}
+
+	// Test: non-existent file returns empty (doesn't crash).
+	args = `{"path":"/nonexistent/file.go"}`
+	ctx = readFileContext([]byte(args))
+	if ctx != "" {
+		t.Errorf("expected empty for non-existent file, got %q", ctx)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -244,6 +244,16 @@ func (c *client) WarnOnMissingToolCallReasoning() bool {
 	return c.RequiresToolCallReasoning() && expectsDeepSeekToolCallReasoning(c.model)
 }
 
+// AnchorEditStrictness returns Aggressive for DeepSeek models (known to
+// have anchor-accuracy issues with edit_file/multi_edit in long-context
+// sessions) and Default for others.
+func (c *client) AnchorEditStrictness() provider.AnchorEditLevel {
+	if c == nil || !c.deepseek {
+		return provider.AnchorEditDefault
+	}
+	return provider.AnchorEditAggressive
+}
+
 func expectsDeepSeekToolCallReasoning(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if !strings.Contains(model, "deepseek") || strings.Contains(model, "flash") {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -662,6 +662,40 @@ func WarnOnMissingToolCallReasoning(p Provider) bool {
 	return RequiresToolCallReasoning(p)
 }
 
+// AnchorEditLevel controls how aggressively the agent should auto-annotate
+// edit_file/multi_edit anchor errors with the current file context.
+type AnchorEditLevel int
+
+const (
+	// AnchorEditDefault uses the default strategy: auto-annotate on the
+	// first "not found" / "not unique" error. Safest for all models.
+	AnchorEditDefault AnchorEditLevel = iota
+	// AnchorEditAggressive auto-annotates every edit tool call's error,
+	// even for non-anchor errors like write permission failures. Produces
+	// more noise but can help models that frequently misreport anchors.
+	AnchorEditAggressive
+)
+
+// AnchorEditPolicy is optionally implemented by providers whose models
+// have known difficulty with edit_file/multi_edit anchor accuracy.
+// The default (interface not implemented) is AnchorEditDefault.
+type AnchorEditPolicy interface {
+	AnchorEditStrictness() AnchorEditLevel
+}
+
+// AnchorEditStrictness reports how aggressively the agent should
+// annotate edit-file anchor errors for provider p.
+func AnchorEditStrictness(p Provider) AnchorEditLevel {
+	if nilutil.IsNil(p) {
+		return AnchorEditDefault
+	}
+	policy, ok := p.(AnchorEditPolicy)
+	if !ok {
+		return AnchorEditDefault
+	}
+	return policy.AnchorEditStrictness()
+}
+
 // Config is a resolved provider instance configuration.
 type Config struct {
 	Name    string         // instance name, e.g. "deepseek"


### PR DESCRIPTION
When edit_file or multi_edit fails with 'not found' or 'not unique', the file content may have changed since the model last read it. Before returning the error, read the current file and append its first 80 lines as context, so the model can re-send matching anchors without needing a separate read_file call.
好，先关闭 #6339，然后修复 #6338 的路径解析 bug。

变更包括：

| 改动 | 说明 |
|------|------|
| `isEditFileAnchorError` | 判断 `edit_file`/`multi_edit` 的 `"not found"` / `"not unique"` 错误 |
| `readFileContext` | 从 tool call args 中提取 `path`，用 `filepath.Abs` 解析相对路径后读前 80 行 |
| executeOne 锚点注入 | 在错误返回前自动附加当前文件内容 + 提示模型重试 |
| 测试覆盖 | 9 种锚点错误检测 + 4 种路径场景（含相对路径 ← 这是之前的 bug）|

**已关闭 PR #6339**（prompt 层面的改动边际价值低，且已有错误提示覆盖了这个场景）。
**Cache-impact:** low — only affects error messages (not system prompt or tool schema)
**Cache-guard:** existing — tool schemas unchanged, only runtime error enrichment

**Closes:** #6337