### PR TITLE
fix(prompt): guide model to re-read file before retrying edit_file/multi_edit

### DIFF
--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -24,11 +24,11 @@ type editFile struct {
 func (editFile) Name() string { return "edit_file" }
 
 func (editFile) Description() string {
-	return "Replace an exact string in a file with another. old_string must occur exactly once; add surrounding context to disambiguate. Use for targeted edits instead of rewriting the whole file."
+	return "Replace an exact string in a file with another. old_string must occur exactly once; add surrounding context to disambiguate. Use for targeted edits instead of rewriting the whole file. If this tool fails with 'old_string not found', first re-read the file with read_file — its content may have changed since you last read it — then retry with the correct text."
 }
 
 func (editFile) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"old_string":{"type":"string","description":"Exact text to replace (must be unique in the file)"},"new_string":{"type":"string","description":"Replacement text (may be empty to delete)"}},"required":["path","old_string","new_string"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"File path"},"old_string":{"type":"string","description":"Exact text to replace (must be unique in the file). If the edit fails with 'not found', re-read the file first — the content may have changed since you last read it."},"new_string":{"type":"string","description":"Replacement text (may be empty to delete)"}},"required":["path","old_string","new_string"]}`)
 }
 
 func (editFile) ReadOnly() bool { return false }

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -34,7 +34,7 @@ type editStep struct {
 func (multiEdit) Name() string { return "multi_edit" }
 
 func (multiEdit) Description() string {
-	return "Apply a list of edits to a single file atomically: each edit runs against the result of the previous one, all in memory; the file is rewritten only if every edit succeeds. Cheaper and safer than chaining edit_file calls — a failure in step 3 leaves the file untouched instead of half-edited."
+	return "Apply a list of edits to a single file atomically: each edit runs against the result of the previous one, all in memory; the file is rewritten only if every edit succeeds. Cheaper and safer than chaining edit_file calls — a failure in step 3 leaves the file untouched instead of half-edited. If any step fails with 'old_string not found', first re-read the file with read_file — its content may have changed since you last read it — then retry with the correct text."
 }
 
 func (multiEdit) Schema() json.RawMessage {
@@ -49,7 +49,7 @@ func (multiEdit) Schema() json.RawMessage {
     "items":{
       "type":"object",
       "properties":{
-        "old_string":{"type":"string","description":"Exact text to find. Without replace_all, must match exactly once."},
+        "old_string":{"type":"string","description":"Exact text to find. Without replace_all, must match exactly once. If the edit fails with 'not found', re-read the file first — the content may have changed since you last read it."},
         "new_string":{"type":"string","description":"Replacement text (empty deletes)."},
         "replace_all":{"type":"boolean","description":"Replace every occurrence instead of requiring uniqueness."}
       },


### PR DESCRIPTION
Add instruction to edit_file and multi_edit descriptions and schema documentation: if 'old_string not found', first re-read the file with read_file — the content may have changed since last read — then retry.

**Cache-impact:** medium — changes tool descriptions and schema documentation strings, which are part of the system prompt prefix
**Cache-guard:** existing — tool schema changes are caught by cache-hit regression tests
**System-prompt-review:** nudge only — schema descriptions are parameter documentation, not behavioral logic

**Also addresses:** #6337