### PR TITLE
fix(error): surface the provider's real reason on 402/429/5xx and 401/403 / 402/429/5xx 与 401/403 错误透出上游真实原因

### DIFF
--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
@@ -46,8 +47,9 @@ func explainError(err error) error {
 			msg = fmt.Sprintf("%s (%s)", msg, authErr.KeyEnv)
 		}
 		// Relays explain *why* auth failed in the body ("token expired", key
-		// not entitled to the model) — as diagnostic here as on APIError.
-		if reason := providerBodyReason(authErr.Body); reason != "" {
+		// not entitled to the model) — as diagnostic here as on APIError, but
+		// auth bodies also echo credentials, so scrub key material first.
+		if reason := redactAuthReason(providerBodyReason(authErr.Body)); reason != "" {
 			return fmt.Errorf("%s\n%s", msg, reason)
 		}
 		return errors.New(msg)
@@ -71,6 +73,36 @@ func apiErrorReason(e *provider.APIError) string {
 		return e.ToolContext
 	}
 	return reason + "\n" + e.ToolContext
+}
+
+// Auth failure bodies are where servers echo credentials: providers include a
+// masked tail ("Your api key: ****ae54 is invalid") and a sloppy relay can
+// reflect the full key it received. Both narrow or reveal the key, and the
+// displayed turn error can travel further than the user's terminal (bot
+// forwarding, shared screenshots).
+var (
+	// maskedFragmentRe matches a provider-masked credential and any visible
+	// prefix/suffix around the stars ("****ae54", "sk-ab****").
+	maskedFragmentRe = regexp.MustCompile(`[A-Za-z0-9._-]*\*{2,}[A-Za-z0-9._-]*`)
+	// keyTokenRe matches key-shaped runs; real keys virtually always contain a
+	// digit, which redactAuthReason requires so digit-free identifiers like
+	// "invalid_authentication_token" stay readable.
+	keyTokenRe = regexp.MustCompile(`[A-Za-z0-9_-]{16,}`)
+	digitRe    = regexp.MustCompile(`[0-9]`)
+)
+
+// redactAuthReason scrubs key material from an auth-failure reason before
+// display. Deliberately applied only to 401/403 bodies: other statuses don't
+// carry credentials, and 400 schema errors legitimately contain long
+// identifiers that this scrub would mangle.
+func redactAuthReason(s string) string {
+	s = maskedFragmentRe.ReplaceAllString(s, "****")
+	return keyTokenRe.ReplaceAllStringFunc(s, func(tok string) string {
+		if digitRe.MatchString(tok) {
+			return "****"
+		}
+		return tok
+	})
 }
 
 // providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped error

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
+	"reasonix/internal/secrets"
 )
 
 // explainError maps a provider HTTP failure to an actionable, localized message
@@ -81,24 +83,42 @@ func apiErrorReason(e *provider.APIError) string {
 // displayed turn error can travel further than the user's terminal (bot
 // forwarding, shared screenshots).
 var (
-	// maskedFragmentRe matches a provider-masked credential and any visible
-	// prefix/suffix around the stars ("****ae54", "sk-ab****").
+	// maskedFragmentRe matches a partially masked credential and any visible
+	// prefix/suffix around the stars ("****ae54", "sk-ab****") — including the
+	// head/tail remnants secrets.Redact's own mask leaves behind. For auth
+	// display even the remnant narrows the key, so the whole run collapses.
 	maskedFragmentRe = regexp.MustCompile(`[A-Za-z0-9._-]*\*{2,}[A-Za-z0-9._-]*`)
-	// keyTokenRe matches key-shaped runs; real keys virtually always contain a
-	// digit, which redactAuthReason requires so digit-free identifiers like
-	// "invalid_authentication_token" stay readable.
+	// credContextRe masks any long value that follows a credential word.
+	// secrets.Redact's KEY=value rule only matches API_KEY/APIKEY-style names;
+	// providers write prose forms like "api key: <value>", where the value must
+	// go regardless of its composition.
+	credContextRe = regexp.MustCompile(`(?i)\b(api[ _-]?key|access[ _-]?key|secret|token|authorization|bearer|credential)s?\b(['"]?\s*[:=]?\s*['"]?)([A-Za-z0-9._~+/-]{12,})`)
+	// keyTokenRe matches key-shaped runs for the no-context fallback; a run is
+	// treated as a credential when it carries a digit or mixed case, so
+	// single-case digit-free identifiers like "invalid_authentication_token"
+	// stay readable.
 	keyTokenRe = regexp.MustCompile(`[A-Za-z0-9_-]{16,}`)
 	digitRe    = regexp.MustCompile(`[0-9]`)
 )
 
 // redactAuthReason scrubs key material from an auth-failure reason before
-// display. Deliberately applied only to 401/403 bodies: other statuses don't
-// carry credentials, and 400 schema errors legitimately contain long
-// identifiers that this scrub would mangle.
+// display, in layers: secrets.Redact for known key shapes (sk-/rk- prefixes,
+// Bearer, JWT, KEY=value forms), the credential-context rule for prose forms,
+// full collapse of masked fragments, then the key-shaped-token fallback. The
+// residual blind spot is a long single-case digit-free token with no context
+// word — indistinguishable from an identifier. Deliberately applied only to
+// 401/403 bodies: other statuses don't carry credentials, and 400 schema
+// errors legitimately contain long identifiers that this scrub would mangle.
 func redactAuthReason(s string) string {
+	if s == "" {
+		return s
+	}
+	s = secrets.Redact(s)
+	s = credContextRe.ReplaceAllString(s, "${1}${2}****")
 	s = maskedFragmentRe.ReplaceAllString(s, "****")
 	return keyTokenRe.ReplaceAllStringFunc(s, func(tok string) string {
-		if digitRe.MatchString(tok) {
+		mixedCase := strings.ToLower(tok) != tok && strings.ToUpper(tok) != tok
+		if digitRe.MatchString(tok) || mixedCase {
 			return "****"
 		}
 		return tok

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -39,11 +39,16 @@ func explainError(err error) error {
 		if authErr.HasKey {
 			msg = i18n.M.ProviderErrAuthRejected
 		}
-		if authErr.KeyEnv != "" {
-			if authErr.KeySource != "" {
-				return fmt.Errorf("%s (%s from %s)", msg, authErr.KeyEnv, authErr.KeySource)
-			}
-			return fmt.Errorf("%s (%s)", msg, authErr.KeyEnv)
+		switch {
+		case authErr.KeyEnv != "" && authErr.KeySource != "":
+			msg = fmt.Sprintf("%s (%s from %s)", msg, authErr.KeyEnv, authErr.KeySource)
+		case authErr.KeyEnv != "":
+			msg = fmt.Sprintf("%s (%s)", msg, authErr.KeyEnv)
+		}
+		// Relays explain *why* auth failed in the body ("token expired", key
+		// not entitled to the model) — as diagnostic here as on APIError.
+		if reason := providerBodyReason(authErr.Body); reason != "" {
+			return fmt.Errorf("%s\n%s", msg, reason)
 		}
 		return errors.New(msg)
 	}

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -28,7 +28,7 @@ func explainError(err error) error {
 		if msg == "" {
 			return err
 		}
-		if reason := requestErrorReason(apiErr); reason != "" {
+		if reason := apiErrorReason(apiErr); reason != "" {
 			return fmt.Errorf("%s\n%s", msg, reason)
 		}
 		return errors.New(msg)
@@ -50,13 +50,14 @@ func explainError(err error) error {
 	return err
 }
 
-// requestErrorReason returns the provider's verbatim reason for request-shaped
-// 4xx (400/422) — the localized line names the category, the body names the
-// actual cause (context-length exceeded, unpaired tool_calls). Empty otherwise.
-func requestErrorReason(e *provider.APIError) string {
-	if e.Status != 400 && e.Status != 422 {
-		return ""
-	}
+// apiErrorReason returns the provider's verbatim reason for a failed request —
+// the localized line names the category, the body names the actual cause
+// (context-length exceeded, unpaired tool_calls, a relay's "no available
+// channel"). Every mapped status surfaces its body, not just the
+// request-shaped 4xx: relay gateways wrap the real failure — dead upstream
+// channel, unsupported tools, exhausted quota — in a 402/429/5xx body, and
+// without it those errors are undiagnosable from the category line alone.
+func apiErrorReason(e *provider.APIError) string {
 	reason := providerBodyReason(e.Body)
 	if e.ToolContext == "" {
 		return reason

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -48,6 +48,14 @@ func TestExplainError(t *testing.T) {
 		}
 	}
 
+	authEcho := explainError(&provider.AuthError{Provider: "deepseek", KeyEnv: "DEEPSEEK_API_KEY", Status: 401, HasKey: true, Body: `{"error":{"message":"Authentication Fails, Your api key: ****ae54 is invalid"}}`})
+	if !strings.Contains(authEcho.Error(), "Authentication Fails") {
+		t.Errorf("401 should keep the readable reason, got %q", authEcho.Error())
+	}
+	if strings.Contains(authEcho.Error(), "ae54") {
+		t.Errorf("401 must not surface the masked key tail, got %q", authEcho.Error())
+	}
+
 	for _, status := range []int{400, 422, 429, 500, 503} {
 		got := explainError(&provider.APIError{Provider: "p", Status: status})
 		if got.Error() == "" || got.Error() == (&provider.APIError{Provider: "p", Status: status}).Error() {
@@ -113,5 +121,21 @@ func TestExplainError(t *testing.T) {
 	plain := errors.New("some other failure")
 	if explainError(plain) != plain {
 		t.Error("unknown errors should pass through unchanged")
+	}
+}
+
+func TestRedactAuthReason(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"masked tail", "Your api key: ****ae54 is invalid", "Your api key: **** is invalid"},
+		{"masked prefix form", "key sk-ab**** was rejected", "key **** was rejected"},
+		{"full key echoed by a relay", "Invalid key sk-proj-abc123def456ghi789 provided", "Invalid key **** provided"},
+		{"digit-free identifier survives", "code: invalid_authentication_token", "code: invalid_authentication_token"},
+		{"short tokens survive", "token expired at gateway", "token expired at gateway"},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		if got := redactAuthReason(c.in); got != c.want {
+			t.Errorf("%s: redactAuthReason(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
 	}
 }

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -129,7 +129,12 @@ func TestRedactAuthReason(t *testing.T) {
 		{"masked tail", "Your api key: ****ae54 is invalid", "Your api key: **** is invalid"},
 		{"masked prefix form", "key sk-ab**** was rejected", "key **** was rejected"},
 		{"full key echoed by a relay", "Invalid key sk-proj-abc123def456ghi789 provided", "Invalid key **** provided"},
+		{"digit-free sk key via secrets.Redact", "api key: sk-proj-abcdefghijklmnop is invalid", "api key: **** is invalid"},
+		{"digit-free value after credential word", "api key: relaykey_abcdefghijklmn rejected", "api key: **** rejected"},
+		{"bearer value collapses fully", "Bearer abc.def-ghijklmnopqrs rejected", "Bearer **** rejected"},
+		{"mixed-case token without context", "rejected AbCdEfGhIjKlMnOpQr", "rejected ****"},
 		{"digit-free identifier survives", "code: invalid_authentication_token", "code: invalid_authentication_token"},
+		{"all-caps code survives", "code INVALID_AUTHENTICATION_TOKEN", "code INVALID_AUTHENTICATION_TOKEN"},
 		{"short tokens survive", "token expired at gateway", "token expired at gateway"},
 		{"empty", "", ""},
 	}

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -41,6 +41,13 @@ func TestExplainError(t *testing.T) {
 		t.Errorf("401 should name the key source: %q", sourced.Error())
 	}
 
+	authBody := explainError(&provider.AuthError{Provider: "relay", KeyEnv: "RELAY_API_KEY", Status: 401, HasKey: true, Body: `{"error":{"message":"令牌已过期","type":"new_api_error"}}`})
+	for _, want := range []string{i18n.M.ProviderErrAuthRejected, "RELAY_API_KEY", "令牌已过期"} {
+		if !strings.Contains(authBody.Error(), want) {
+			t.Errorf("401 with a body = %q, want it to contain %q", authBody.Error(), want)
+		}
+	}
+
 	for _, status := range []int{400, 422, 429, 500, 503} {
 		got := explainError(&provider.APIError{Provider: "p", Status: status})
 		if got.Error() == "" || got.Error() == (&provider.APIError{Provider: "p", Status: status}).Error() {

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -16,8 +16,8 @@ func TestExplainError(t *testing.T) {
 	}
 
 	bal := explainError(&provider.APIError{Provider: "deepseek", Status: 402, Body: "Insufficient Balance"})
-	if bal.Error() != i18n.M.ProviderErrInsufficientBalance {
-		t.Errorf("402 = %q, want the insufficient-balance message", bal.Error())
+	if !strings.Contains(bal.Error(), i18n.M.ProviderErrInsufficientBalance) || !strings.Contains(bal.Error(), "Insufficient Balance") {
+		t.Errorf("402 = %q, want the insufficient-balance message plus the provider body", bal.Error())
 	}
 
 	auth := explainError(&provider.AuthError{Provider: "deepseek", KeyEnv: "DEEPSEEK_API_KEY", Status: 401})
@@ -70,9 +70,27 @@ func TestExplainError(t *testing.T) {
 		t.Errorf("422 should fall back to the raw body, got %q", rawBody.Error())
 	}
 
-	noLeak := explainError(&provider.APIError{Provider: "deepseek", Status: 429, Body: `{"error":{"message":"slow down"}}`})
-	if noLeak.Error() != i18n.M.ProviderErrRateLimited {
-		t.Errorf("429 body must not leak into the message, got %q", noLeak.Error())
+	rate := explainError(&provider.APIError{Provider: "deepseek", Status: 429, Body: `{"error":{"message":"slow down"}}`})
+	if !strings.Contains(rate.Error(), i18n.M.ProviderErrRateLimited) || !strings.Contains(rate.Error(), "slow down") {
+		t.Errorf("429 should append the provider reason, got %q", rate.Error())
+	}
+
+	// Relay gateways (one-api/new-api style) wrap the real failure — dead
+	// upstream channel, unsupported tools, exhausted quota — in a 5xx JSON
+	// body; the category line alone made those undiagnosable.
+	relay := explainError(&provider.APIError{Provider: "relay", Status: 500, Body: `{"error":{"message":"no available channel for model claude-fable-5 in group default","type":"new_api_error"}}`})
+	if !strings.Contains(relay.Error(), i18n.M.ProviderErrServer) || !strings.Contains(relay.Error(), "no available channel") {
+		t.Errorf("500 should append the provider reason from a JSON body, got %q", relay.Error())
+	}
+
+	busy := explainError(&provider.APIError{Provider: "relay", Status: 503, Body: "upstream unavailable"})
+	if !strings.Contains(busy.Error(), i18n.M.ProviderErrServerBusy) || !strings.Contains(busy.Error(), "upstream unavailable") {
+		t.Errorf("503 should fall back to the raw body, got %q", busy.Error())
+	}
+
+	bare := explainError(&provider.APIError{Provider: "relay", Status: 500})
+	if bare.Error() != i18n.M.ProviderErrServer {
+		t.Errorf("500 without a body = %q, want exactly the localized message", bare.Error())
 	}
 
 	interrupted := explainError(&provider.StreamInterruptedError{Err: io.ErrUnexpectedEOF})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -673,15 +673,18 @@ type Config struct {
 
 // AuthError reports that a provider rejected the API key (HTTP 401/403). Its
 // message is already user-facing and actionable — it names the provider and,
-// when known, the environment variable the key comes from — so the CLI can
-// surface it verbatim instead of dumping a raw status body. Providers should
-// return this (rather than a generic status error) for auth failures.
+// when known, the environment variable the key comes from — and it carries the
+// server's own reason as Body, because relay gateways explain *why* the key was
+// rejected ("token expired", key not entitled to the model) in the response
+// body. Providers should return this (rather than a generic status error) for
+// auth failures.
 type AuthError struct {
 	Provider  string // the provider instance name, e.g. "deepseek"
 	KeyEnv    string // the api_key_env the key is read from, when known
 	KeySource string // human-readable source of KeyEnv, when known
 	Status    int    // the HTTP status (401 or 403)
 	HasKey    bool   // a non-empty key was sent — the server rejected it, vs. no key configured at all
+	Body      string // trimmed response-body snippet, the server's verbatim reason when it gave one
 }
 
 func (e *AuthError) Error() string {
@@ -692,8 +695,12 @@ func (e *AuthError) Error() string {
 	if e.KeySource != "" {
 		key += " from " + e.KeySource
 	}
-	return fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
+	s := fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
 		e.Provider, e.Status, key)
+	if e.Body != "" {
+		s += "; server said: " + e.Body
+	}
+	return s
 }
 
 // Factory builds a Provider from a resolved Config.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -676,8 +676,11 @@ type Config struct {
 // when known, the environment variable the key comes from — and it carries the
 // server's own reason as Body, because relay gateways explain *why* the key was
 // rejected ("token expired", key not entitled to the model) in the response
-// body. Providers should return this (rather than a generic status error) for
-// auth failures.
+// body. Body is deliberately NOT part of Error(): servers echo masked key
+// fragments in auth bodies, and the ambient error string flows into logs,
+// status lines, and traces where key material must never propagate. Display
+// layers that want the reason read Body and extract it themselves. Providers
+// should return this (rather than a generic status error) for auth failures.
 type AuthError struct {
 	Provider  string // the provider instance name, e.g. "deepseek"
 	KeyEnv    string // the api_key_env the key is read from, when known
@@ -695,12 +698,8 @@ func (e *AuthError) Error() string {
 	if e.KeySource != "" {
 		key += " from " + e.KeySource
 	}
-	s := fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
+	return fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
 		e.Provider, e.Status, key)
-	if e.Body != "" {
-		s += "; server said: " + e.Body
-	}
-	return s
 }
 
 // Factory builds a Provider from a resolved Config.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -354,6 +354,18 @@ func TestAuthErrorWithKeyEnv(t *testing.T) {
 	}
 }
 
+func TestAuthErrorWithBody(t *testing.T) {
+	e := &AuthError{Provider: "relay", Status: 401, Body: `{"error":{"message":"token expired"}}`}
+	msg := e.Error()
+	if !contains(msg, "server said:") || !contains(msg, "token expired") {
+		t.Errorf("AuthError.Error() should carry the server's reason: %s", msg)
+	}
+	bare := &AuthError{Provider: "relay", Status: 401}
+	if contains(bare.Error(), "server said:") {
+		t.Errorf("AuthError without a body should not mention a server reason: %s", bare.Error())
+	}
+}
+
 func TestAuthErrorWithoutKeyEnv(t *testing.T) {
 	e := &AuthError{Provider: "openai", Status: 403}
 	msg := e.Error()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -354,15 +354,16 @@ func TestAuthErrorWithKeyEnv(t *testing.T) {
 	}
 }
 
-func TestAuthErrorWithBody(t *testing.T) {
-	e := &AuthError{Provider: "relay", Status: 401, Body: `{"error":{"message":"token expired"}}`}
-	msg := e.Error()
-	if !contains(msg, "server said:") || !contains(msg, "token expired") {
-		t.Errorf("AuthError.Error() should carry the server's reason: %s", msg)
+func TestAuthErrorBodyStaysOutOfError(t *testing.T) {
+	// Body carries the server's reason for display layers to extract, but it
+	// must never leak into Error(): servers echo masked key fragments in auth
+	// bodies, and the ambient string flows into logs and traces.
+	e := &AuthError{Provider: "relay", Status: 401, Body: `{"error":{"message":"Your api key: ****ae54 has expired"}}`}
+	if e.Body == "" {
+		t.Fatal("Body should carry the server's reason")
 	}
-	bare := &AuthError{Provider: "relay", Status: 401}
-	if contains(bare.Error(), "server said:") {
-		t.Errorf("AuthError without a body should not mention a server reason: %s", bare.Error())
+	if msg := e.Error(); contains(msg, "ae54") || contains(msg, "{") {
+		t.Errorf("AuthError.Error() must not include body content: %s", msg)
 	}
 }
 

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -201,7 +201,7 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			authErr := &AuthError{Provider: opts.Provider, KeyEnv: opts.KeyEnv, KeySource: opts.KeySource, Status: resp.StatusCode, HasKey: opts.KeyPresent}
+			authErr := &AuthError{Provider: opts.Provider, KeyEnv: opts.KeyEnv, KeySource: opts.KeySource, Status: resp.StatusCode, HasKey: opts.KeyPresent, Body: strings.TrimSpace(string(msg))}
 			if opts.RetryAuth && authRetries < maxAuthRetries {
 				authRetries++
 				lastErr = authErr

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -122,6 +122,9 @@ func TestSendWithRetryAuthError(t *testing.T) {
 	if !errors.As(err, &authErr) || authErr.KeyEnv != "DEEPSEEK_API_KEY" {
 		t.Errorf("want *AuthError naming the key env, got %v", err)
 	}
+	if authErr != nil && authErr.Body != "body" {
+		t.Errorf("AuthError should carry the response body, got %q", authErr.Body)
+	}
 }
 
 func TestSendWithRetryRetriesTransientAuthForKnownKey(t *testing.T) {


### PR DESCRIPTION
## Problem

A user configured a relay gateway (both a `kind = "anthropic"` and a `kind = "openai"` entry) and every request failed with only:

> Server error (HTTP 500): the provider hit an internal fault. Retried with backoff; if it keeps failing, try again later.

Relay gateways (one-api/new-api style) wrap the real cause — dead upstream channel, unsupported tools, exhausted quota, expired token — in the response body of a 402/429/5xx or 401/403. Reasonix already reads that body (`SendWithRetry` keeps a 4 KB snippet) but the display layer discarded it for every status except the request-shaped 4xx:

- `explainError` appended `providerBodyReason` only for 400/422 (`internal/control/errmsg.go`); 402/429/500/503 collapsed to the bare localized category line.
- `AuthError` had no body field at all (`internal/provider/retry.go`), so 401/403 reasons ("token expired") were dropped at the provider layer.

With no verbatim reason anywhere (and no wire-level debug log), these failures were undiagnosable from Reasonix output alone, while other clients showed the relay's reason.

## Fix

- `internal/control/errmsg.go`: drop the 400/422 guard in the (renamed) `apiErrorReason` — every status that maps to a localized line now appends the body reason (JSON `error.message` extraction, clamped to 800 runes). `ToolContext` composition is preserved.
- `internal/provider/provider.go` / `retry.go`: add `AuthError.Body`, populate it from the already-read snippet, keep the body out of `AuthError.Error()` so ambient error strings/logs never include auth response content, and surface a redacted body reason through `explainError`'s auth branch.

Output is byte-identical whenever the server returned no body. Statuses with no localized mapping (404/502/529, …) already pass through `APIError.Error()` with the body attached; mid-stream SSE `error` events already surface the upstream message — so all four error paths now carry the provider's reason.

Note: this deliberately flips the "429 body must not leak" pin from f920da10 — that commit scoped body surfacing to the request-shaped 4xx as a first step, not for privacy reasons, and the 429/5xx body is as diagnostic as the 400/422 one.

## Tests

- 500 relay-style JSON body → localized line + reason; 503 raw-body fallback; bare 500 stays exactly the localized line.
- 402/429 now append the body (existing assertions flipped accordingly).
- `AuthError` carries the response body through `SendWithRetry`; `AuthError.Error()` deliberately keeps that body out of ambient error strings; `explainError` shows a relay's 401 reason alongside the key-env hint after redacting key echoes.

## Verification

- `go test ./internal/provider/ ./internal/control/ -count=1` — ok
- `go vet ./...`, `gofmt -l internal/` — clean

Cache-impact: none - response/error path only; no provider-visible request bytes change
Cache-guard: go test ./internal/provider/ ./internal/control/ (error-path regressions: TestExplainError, TestRedactAuthReason, TestSendWithRetryAuthError, TestAuthErrorBodyStaysOutOfError)