### PR TITLE
fix(config): fall back to user default_model when a project override is unresolvable / 项目 default_model 失效时回退到用户全局默认模型

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -228,6 +228,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	migration.MigrateLegacyMemorySources(sink)
 	migration.MigrateLegacySessionSources(sink)
+	if ignored := cfg.IgnoredProjectDefaultModel(); ignored != "" {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "Ignored the project config's default_model.", Detail: fmt.Sprintf("./reasonix.toml sets default_model = %q but no configured provider serves it; using %q from your user config instead. Edit or remove that default_model line to silence this notice.", ignored, cfg.DefaultModel)})
+	}
 
 	// A resolvable model whose API key env is unset would otherwise build fine
 	// (RequireKey is false so the UI stays reachable) and then fail silently on the

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -44,6 +44,50 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildNoticesProjectDefaultModelFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeFile(t, home, "config.toml", `
+default_model = "deepseek-pro"
+
+[[providers]]
+name = "deepseek-pro"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "deepseek-v4-pro"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "deepseek-flash"
+`)
+
+	var notices []event.Event
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should fall back to the user default model: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, notice := range notices {
+		if notice.Level == event.LevelWarn &&
+			notice.Text == "Ignored the project config's default_model." &&
+			strings.Contains(notice.Detail, `default_model = "deepseek-flash"`) &&
+			strings.Contains(notice.Detail, `using "deepseek-pro"`) {
+			return
+		}
+	}
+	t.Fatalf("expected a warning naming the ignored project model and user fallback; got %v", notices)
+}
+
 func TestBuildMigratesLegacyBareMimoModelOverride(t *testing.T) {
 	dir := robustTempDir(t)
 	t.Chdir(dir)

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -14,8 +14,11 @@ import (
 // TestBuildUnknownModelErrorIsActionable: a default_model that doesn't resolve
 // (e.g. a stale preset name after [[providers]] replaced the built-in presets) must
 // fail with a message that names the model, lists what IS configured, and hints
-// at the [[providers]] trap — not a silent empty model.
+// at the [[providers]] trap — not a silent empty model. This contract holds when
+// the project file is the only config, so isolate REASONIX_HOME: a user-global
+// config with an explicit default_model would instead rescue the boot (#4218).
 func TestBuildUnknownModelErrorIsActionable(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	dir := robustTempDir(t)
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,11 +62,22 @@ type Config struct {
 	Serve            ServeConfig         `toml:"serve"`
 	Secrets          SecretsConfig       `toml:"secrets"`
 
-	providerSources          map[string]providerSourceScope
-	shadowedProjectProviders []ProviderEntry
-	expansionEnv             map[string]string
-	pluginPackageOwners      map[string]string
-	pluginPackageSkillOwners map[string][]string
+	providerSources            map[string]providerSourceScope
+	shadowedProjectProviders   []ProviderEntry
+	ignoredProjectDefaultModel string
+	expansionEnv               map[string]string
+	pluginPackageOwners        map[string]string
+	pluginPackageSkillOwners   map[string][]string
+}
+
+// IgnoredProjectDefaultModel returns the project reasonix.toml default_model
+// that LoadForRoot ignored because no configured provider serves it (see
+// restoreUnresolvableProjectDefaultModel), or "" when none was ignored.
+func (c *Config) IgnoredProjectDefaultModel() string {
+	if c == nil {
+		return ""
+	}
+	return c.ignoredProjectDefaultModel
 }
 
 // SecretsConfig controls the credential protection layers. It is a user-global

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -58,15 +58,18 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	}
 
 	var tomlSources []string
+	userDefaultModelExplicit := false
 	if uc := userConfigLoadPath(); uc != "" {
 		tomlSources = append(tomlSources, uc)
 		if err := mergeTOML(cfg, uc); err != nil {
 			return nil, err
 		}
+		userDefaultModelExplicit = tomlFileDefinesKey(uc, "default_model")
 	}
 	globalMaxSteps := cfg.Agent.MaxSteps
 	globalPlannerMaxSteps := cfg.Agent.PlannerMaxSteps
 	globalMemoryCompiler := cfg.Agent.MemoryCompiler
+	userDefaultModel := cfg.DefaultModel
 	// Deep-copy: TOML decoding writes through an existing *bool rather than
 	// replacing it, so a shallow struct copy would alias the pointer and the
 	// project merge below would mutate the captured global value in place.
@@ -145,6 +148,9 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	backfillDeepSeekOfficialPrices(cfg)
 	normalizeEffortConfig(cfg)
 	backfillDeepSeekPro(cfg)
+	if userDefaultModelExplicit {
+		restoreUnresolvableProjectDefaultModel(cfg, userDefaultModel)
+	}
 	cfg.Agent.AutoPlan = userAutoPlanMode()
 	cfg.CredentialsStore = credentialsStoreMode()
 	cfg.setExpansionEnv(expansionEnv)
@@ -184,6 +190,48 @@ func userAutoPlanMode() string {
 	default:
 		return "off"
 	}
+}
+
+// restoreUnresolvableProjectDefaultModel falls back to the user/global
+// default_model when a project reasonix.toml overrides it with a reference no
+// configured provider serves (#4218). Pre-v1.11 persistence paths (e.g. the
+// "always allow" writer) full-rendered ./reasonix.toml and pinned the built-in
+// default_model ("deepseek-flash") into it; once the user's [[providers]]
+// replaced the built-in presets, that stale name resolved to nothing and boot
+// hard-failed in every launch from that folder. In-memory only — the project
+// file is untouched, and a project override that does resolve still wins. The
+// ignored value is kept so boot can surface a notice.
+//
+// Callers must only invoke this when the user config explicitly defines
+// default_model: falling back to the built-in default would silently mask a
+// broken ref when the project file is the user's only config, and that case
+// must keep the actionable boot error (TestBuildUnknownModelErrorIsActionable).
+func restoreUnresolvableProjectDefaultModel(c *Config, userDefault string) {
+	if c == nil {
+		return
+	}
+	if c.DefaultModel == userDefault {
+		return
+	}
+	if _, ok := c.ResolveModel(c.DefaultModel); ok {
+		return
+	}
+	if _, ok := c.ResolveModel(userDefault); !ok {
+		return
+	}
+	c.ignoredProjectDefaultModel = c.DefaultModel
+	c.DefaultModel = userDefault
+}
+
+// tomlFileDefinesKey reports whether the TOML file at path explicitly defines
+// the given top-level key. Missing or unparseable files report false.
+func tomlFileDefinesKey(path string, key ...string) bool {
+	var f Config
+	meta, err := decodeTOMLFile(path, &f)
+	if err != nil {
+		return false
+	}
+	return meta.IsDefined(key...)
 }
 
 // backfillDeepSeekPro restores deepseek-pro for configs the pre-fix setup wizard

--- a/internal/config/load_project_default_test.go
+++ b/internal/config/load_project_default_test.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeProjectDefaultTestConfig(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// #4218: pre-v1.11 persistence paths full-rendered ./reasonix.toml and pinned
+// the built-in default_model ("deepseek-flash") into it. Once the user's
+// [[providers]] replaced the built-in presets, that stale name resolved to
+// nothing and every launch from that folder failed. The load must fall back to
+// the user/global default_model instead.
+func TestLoadForRoot_UnresolvableProjectDefaultModelFallsBackToUserDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeProjectDefaultTestConfig(t, home, "config.toml", `default_model = "deepseek-pro"
+
+[[providers]]
+name        = "deepseek-pro"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-pro"
+api_key_env = "DEEPSEEK_API_KEY"
+`)
+
+	project := t.TempDir()
+	writeProjectDefaultTestConfig(t, project, "reasonix.toml", `default_model = "deepseek-flash"
+
+[permissions]
+allow = ["Bash(go test*)"]
+`)
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if cfg.DefaultModel != "deepseek-pro" {
+		t.Fatalf("DefaultModel = %q, want fallback to user default %q", cfg.DefaultModel, "deepseek-pro")
+	}
+	if got := cfg.IgnoredProjectDefaultModel(); got != "deepseek-flash" {
+		t.Fatalf("IgnoredProjectDefaultModel() = %q, want %q", got, "deepseek-flash")
+	}
+	if _, ok := cfg.ResolveModel(cfg.DefaultModel); !ok {
+		t.Fatalf("ResolveModel(%q) failed after fallback", cfg.DefaultModel)
+	}
+}
+
+// A project default_model that does resolve is a legitimate override and must
+// keep winning over the user config.
+func TestLoadForRoot_ResolvableProjectDefaultModelStillWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeProjectDefaultTestConfig(t, home, "config.toml", `default_model = "deepseek-pro"
+
+[[providers]]
+name        = "deepseek-pro"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-pro"
+api_key_env = "DEEPSEEK_API_KEY"
+
+[[providers]]
+name        = "local"
+kind        = "openai"
+base_url    = "http://127.0.0.1:8080/v1"
+model       = "local-model"
+`)
+
+	project := t.TempDir()
+	writeProjectDefaultTestConfig(t, project, "reasonix.toml", `default_model = "local"
+`)
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if cfg.DefaultModel != "local" {
+		t.Fatalf("DefaultModel = %q, want project override %q kept", cfg.DefaultModel, "local")
+	}
+	if got := cfg.IgnoredProjectDefaultModel(); got != "" {
+		t.Fatalf("IgnoredProjectDefaultModel() = %q, want empty", got)
+	}
+}
+
+// When neither the project override nor the user default resolves, keep the
+// project value so the existing boot error names what the user actually wrote.
+func TestLoadForRoot_ProjectDefaultModelKeptWhenUserDefaultUnresolvable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeProjectDefaultTestConfig(t, home, "config.toml", `default_model = "gone-too"
+
+[[providers]]
+name        = "deepseek-pro"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-pro"
+api_key_env = "DEEPSEEK_API_KEY"
+`)
+
+	project := t.TempDir()
+	writeProjectDefaultTestConfig(t, project, "reasonix.toml", `default_model = "gone"
+`)
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if cfg.DefaultModel != "gone" {
+		t.Fatalf("DefaultModel = %q, want project value %q kept", cfg.DefaultModel, "gone")
+	}
+	if got := cfg.IgnoredProjectDefaultModel(); got != "" {
+		t.Fatalf("IgnoredProjectDefaultModel() = %q, want empty", got)
+	}
+}
+
+// When the project file is the user's only config, a broken default_model must
+// keep failing loudly at boot instead of silently substituting the built-in
+// default (see boot.TestBuildUnknownModelErrorIsActionable): no fallback fires
+// because no user config explicitly defines default_model.
+func TestLoadForRoot_NoUserConfigKeepsBrokenProjectDefaultModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	project := t.TempDir()
+	writeProjectDefaultTestConfig(t, project, "reasonix.toml", `default_model = "legacy-missing"
+
+[[providers]]
+name        = "deepseek-flash"
+kind        = "openai"
+base_url    = "https://example.invalid"
+model       = "deepseek-v4-flash"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if cfg.DefaultModel != "legacy-missing" {
+		t.Fatalf("DefaultModel = %q, want broken project value %q kept", cfg.DefaultModel, "legacy-missing")
+	}
+	if got := cfg.IgnoredProjectDefaultModel(); got != "" {
+		t.Fatalf("IgnoredProjectDefaultModel() = %q, want empty", got)
+	}
+}
+
+// No project override: the user default is untouched and nothing is reported
+// as ignored, even when the user default itself is stale.
+func TestLoadForRoot_NoProjectOverrideLeavesUserDefaultAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeProjectDefaultTestConfig(t, home, "config.toml", `default_model = "deepseek-pro"
+
+[[providers]]
+name        = "deepseek-pro"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-pro"
+api_key_env = "DEEPSEEK_API_KEY"
+`)
+
+	project := t.TempDir()
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if cfg.DefaultModel != "deepseek-pro" {
+		t.Fatalf("DefaultModel = %q, want %q", cfg.DefaultModel, "deepseek-pro")
+	}
+	if got := cfg.IgnoredProjectDefaultModel(); got != "" {
+		t.Fatalf("IgnoredProjectDefaultModel() = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Fixes #4218.

## Problem

Launching in certain project folders always fails with:

```
unknown model "deepseek-flash" (configured: deepseek-pro); note: defining [[providers]] replaces the built-in presets, so add a [[providers]] entry for it or use a configured name, or run `reasonix setup` to reconfigure
```

and only re-running `reasonix setup` gets the user back in — until it happens again in the next folder.

## Root cause

Three pieces combine:

1. **Poisoned project files (historical writer bug).** Pre-v1.11 persistence paths — e.g. the v1.6.0 "always allow" writer (`rememberPermissionRule` → `LoadForEdit(<project>/reasonix.toml)` → `SaveTo`) — full-rendered `./reasonix.toml` from `Default()` and pinned the built-in `default_model = "deepseek-flash"` into project folders. The writer was fixed in 2419ca27 (`WritePermissionsSection` writes only the `[permissions]` section), but poisoned files already on disk remain.
2. **Preset replacement.** Once any TOML source defines `[[providers]]`, the built-in presets (`deepseek-flash` / `deepseek-pro`) are replaced wholesale (`mergeTOMLProviders`). The v1.6.0 setup wizard wrote only the providers the user selected, so a Pro-only user has no entry that can resolve `"deepseek-flash"`.
3. **No recovery at load.** `loadForRoot` lets the project `default_model` override the user-global one with no resolvability check (unlike `MaxSteps` / `Secrets`, which are protected), so `boot.Build` hard-fails on every launch from that folder. `retargetDesktopOfficialRef` can rescue the legacy name but only when `desktop.provider_access` includes `deepseek`, which never applies to CLI-only users; 2129bb05 protects serve mode only.

Reproduced on current `main-v2` (e430190d): a project file with `default_model = "deepseek-flash"` plus a Pro-only user config still fails with the exact reported message.

## Fix

`LoadForRoot` now falls back to the user-global `default_model` when a project override resolves to no configured provider, and `boot.Build` emits a warn notice naming the ignored value. Deliberately narrow:

- Fires only when the user config **explicitly defines** `default_model` (checked via TOML metadata), so a project-only config with a broken ref keeps the existing actionable boot error.
- In-memory only — the project file is never rewritten.
- A project override that does resolve still wins, unchanged.
- Runs after all provider normalizers, so legacy refs those normalizers can already rescue stay rescued.

`TestBuildUnknownModelErrorIsActionable` now isolates `REASONIX_HOME` to make its "project file is the only config" precondition explicit instead of depending on the machine's real user config.

## Compatibility

| Touch point | Old-data behavior | Conclusion |
| --- | --- | --- |
| Project `reasonix.toml` with stale `default_model` + explicit user default | hard boot error on every launch | now boots on the user default + warn notice; file untouched |
| Project `reasonix.toml` with resolvable `default_model` | overrides user config | unchanged |
| Project-only config (no user `config.toml`) with broken ref | actionable boot error | unchanged (fallback gated on explicit user `default_model`) |
| User config without `default_model` | built-in default applies | unchanged (no fallback) |
| Serve mode | explicit user-global model (2129bb05) | unchanged |
| Config file formats on disk | — | no write paths changed; new struct field is unexported/in-memory |

## Verification

- New regression tests in `internal/config/load_project_default_test.go`: fallback fires for the #4218 shape; resolvable project override still wins; kept when the user default is also unresolvable; project-only broken config keeps the hard error; no-override case untouched.
- `go test ./...` (root module) — pass.
- `cd desktop && go test ./...` — pass.
- `./scripts/cache-guard.sh` — pass (no provider-visible surface changes; the fallback only affects configs that previously could not boot at all).

Cache-impact: none - only changes model fallback for configurations that previously failed to boot; provider-visible prompt and tool schemas are unchanged.
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) passed; focused boot/config tests passed.
System-prompt-review: Reviewed; boot only emits a local warning event and does not alter system-prompt construction or provider-visible prefix bytes.