### PR TITLE
fix(desktop): make inline reasoning blocks individually collapsible / 内联推理块支持独立折叠

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -80,6 +80,10 @@ const LiveAssistantMessage = memo(function LiveAssistantMessage({
 function InlineAssistantReasoning({ item }: { item: AssistantItem }) {
   const t = useT();
   const live = useContext(LiveStreamContext);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(true);
+  const userOverridden = useRef(false);
+
   const shown = live && live.id === item.id
     ? {
         reasoning: live.reasoning,
@@ -94,14 +98,36 @@ function InlineAssistantReasoning({ item }: { item: AssistantItem }) {
     truncateStreaming: true,
   });
   const running = shown.streaming && !shown.reasoningComplete;
+
+  useGSAPCollapse(bodyRef, open);
+
+  // Auto-open when reasoning is running so the user sees live progress;
+  // respect a manual toggle to prevent flicker.
+  useEffect(() => {
+    if (running && !userOverridden.current) {
+      setOpen(true);
+    }
+  }, [running]);
+
+  const toggle = () => {
+    userOverridden.current = true;
+    setOpen((v) => !v);
+  };
+
   return (
     <div className="turn-collapse__reasoning-phase">
-      <div className="turn-collapse__reasoning-head" data-running={running ? "" : undefined}>
+      <button
+        type="button"
+        className="turn-collapse__reasoning-head"
+        data-running={running ? "" : undefined}
+        onClick={toggle}
+        aria-expanded={open}
+      >
         <ProcessBrainIcon size={12} />
         <span>{running ? t("msg.thinkingRunning") : t("msg.thinking")}</span>
-        <ChevronRight className="reasoning__chevron reasoning__chevron--open" size={12} />
-      </div>
-      <div className="turn-collapse__inline-reasoning">{visibleReasoning}</div>
+        <ChevronRight className={`reasoning__chevron${open ? " reasoning__chevron--open" : ""}`} size={12} />
+      </button>
+      <div ref={bodyRef} className="turn-collapse__inline-reasoning">{visibleReasoning}</div>
     </div>
   );
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4213,10 +4213,21 @@ a[href] {
   align-items: center;
   gap: 6px;
   min-height: 24px;
+  padding: 2px 7px;
+  border: none;
+  background: none;
+  cursor: pointer;
   color: var(--fg-faint);
   font-size: 13px;
   font-weight: 560;
   line-height: 1.4;
+  border-radius: 6px;
+  -webkit-app-region: no-drag;
+}
+
+.turn-collapse__reasoning-head:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
 }
 
 .turn-collapse__reasoning-head > svg:first-child {
@@ -4316,7 +4327,8 @@ a[href] {
   color: var(--fg-faint);
 }
 .tool__head[data-running]:hover,
-.reasoning__head[data-running]:hover {
+.reasoning__head[data-running]:hover,
+.turn-collapse__reasoning-head[data-running]:hover {
   animation-play-state: paused;
   background: none;
   color: var(--fg);
@@ -4324,7 +4336,8 @@ a[href] {
 .tool__head[data-running]:hover .tool__chevron,
 .tool__head[data-running]:hover .tool__duration,
 .reasoning__head[data-running]:hover svg,
-.reasoning__head[data-running]:hover .reasoning__meta {
+.reasoning__head[data-running]:hover .reasoning__meta,
+.turn-collapse__reasoning-head[data-running]:hover svg {
   color: var(--fg);
 }
 @keyframes shimmer-sweep {
@@ -28834,7 +28847,9 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .app--creation .reasoning__head,
-:root[data-theme-style] .app--creation .reasoning__head {
+.app--creation .turn-collapse__reasoning-head,
+:root[data-theme-style] .app--creation .reasoning__head,
+:root[data-theme-style] .app--creation .turn-collapse__reasoning-head {
   gap: 4px;
   padding: 0;
   color: color-mix(in srgb, var(--fg-dim) 72%, transparent);


### PR DESCRIPTION
## Summary

Fix #6340

Fixes the first bug reported in [#6340](https://github.com/esengine/DeepSeek-Reasonix/issues/6340): inline reasoning blocks inside turn-collapse were not individually collapsible. This PR adds a per-block toggle driven by GSAP height animation and proper auto-open / manual-override state tracking.

- Each `InlineAssistantReasoning` block now has its own collapse toggle, with the heading rendered as a `<button type="button">` and annotated with `aria-expanded`.
- When reasoning is actively streaming, the block auto-opens so the user sees live progress. A `userOverridden` ref prevents subsequent streaming updates from fighting a manual close - no flicker.
- Collapsed headings get hover feedback (`color` + tinted background). Shimmer sweep pauses on hover and the gradient background resets, matching the existing `.reasoning__head` behavior.
- Creation-mode alignment: `.turn-collapse__reasoning-head` now inherits `padding: 0` under `.app--creation`, keeping it flush with tool heads.
- The collapse animation uses the existing `useGSAPCollapse` hook. The target `<div>` is always rendered (never conditionally unmounted) so that the hook can measure and animate `scrollHeight` correctly in both directions.

## Verification

- **Manual toggle**: Open a response that includes reasoning. Click the reasoning head - the body should collapse/expand with a smooth GSAP height tween. Toggle several times to confirm no animation loss or layout jump.
- **Streaming auto-open**: Trigger a generation request with reasoning. While the reasoning stream is running, the block stays open. Manually collapse it; incoming tokens should not force it back open.
- **Shimmer hover**: Hover the reasoning head during streaming. The sweep animation pauses and the gradient background clears. Move the cursor away - animation resumes.
- **Creation mode**: Switch to creation mode and verify the reasoning head sits left-aligned with tool heads (no extra padding).

## Cache impact

Cache-impact: none

The change is confined to the frontend rendering layer (`Transcript.tsx` + `styles.css`). It does not alter how reasoning text is serialized, stored, indexed, or retrieved from any in-memory or on-disk cache. No provider-visible prompt or memory prefix is touched.

Cache-guard: No dedicated component-level tests exist for `InlineAssistantReasoning`. The CI desktop leg (`pnpm --dir frontend build`) catches TypeScript and bundling errors on every push and serves as the automated guard. The manual verification steps above cover the interaction surface.

System-prompt-review: N/A - this is a strictly client-side UI change. It does not modify system prompts, memory prefixes, output-style templates, or skill index behavior in any way visible to the model or provider.