### PR TITLE
fix: remove stale without-offset/limit wording and limit check in anchor refresh guard

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2980,7 +2980,7 @@ func (a *Agent) staleAnchorEditBlock(call provider.ToolCall) (string, bool) {
 		return "", false
 	}
 	return fmt.Sprintf(
-		"blocked: [fresh read required] %q targets %s, which was already modified earlier this turn. Re-read the current file with read_file without offset/limit before another anchor-based edit, or combine the final same-file changes in one multi_edit call. This prevents stale old_string anchors and half-deleted ranges.",
+		"blocked: [fresh read required] %q targets %s, which was already modified earlier this turn. Re-read the current file with read_file before another anchor-based edit, or combine the final same-file changes in one multi_edit call. This prevents stale old_string anchors and half-deleted ranges.",
 		call.Name, strings.Join(rec.Paths, ", ")), true
 }
 

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -588,9 +588,9 @@ func anchorRefreshRead(r Receipt) bool {
 	if err := json.Unmarshal(r.Args, &fields); err != nil {
 		return false
 	}
-	if limit, ok := intField(fields, "limit"); ok && limit > 0 {
-		return false
-	}
+	// offset>0 means the model read a partial region — it may not have
+	// observed the area the next anchor-based edit targets. limit alone
+	// (reading from the beginning with a window) is fine.
 	if offset, ok := intField(fields, "offset"); ok && offset > 0 {
 		return false
 	}


### PR DESCRIPTION
## Summary

缓解 #5831：`staleAnchorEditBlock` 的 "read_file without offset/limit" 指引对模型而言几乎无法正确参数化——模型自然地用 `offset=0, limit=N` 表达"从头开始读"，恰好被 guard 拒绝，导致死循环。

**变更：**

1. **block 消息去掉 "without offset/limit"**（`agent.go`）：消息与放松后的刷新条件一致，不再给出模型无法满足的指引。

2. **`anchorRefreshRead` 删除 `limit` 检查**（`evidence.go`）：保留 `offset>0` 的拒绝（从文件中间开始的窗口读仍不算刷新），但 `offset=0, limit=N` 的读——模型最基本、最自然的"从头开始读到第 N 行"——现在可以解锁 guard。

**安全：** `offset>0` 的拒绝保留了核心安全属性——模型如果从非零偏移开始读，可能没看到上次写入影响的区域，不应视为刷新。`limit` 删除不影响 `offset>0` 路径，也不影响 `edit_file`/`delete_range` 的磁盘级 CAS（`readFileEncoded` + 唯一内容锚点）。受影响的自测 `TestAnchorEditStillRequiresReadAfterWindowedRead`（使用 `offset=400,limit=20`）和 `TestLedgerReportsAnchorRefreshReadsAfterWrites`（使用 `offset=100,limit=20`）仍然通过。

## Verification

- `go vet ./internal/agent/ ./internal/evidence/` — clean
- `go test ./internal/agent/ ./internal/evidence/ -count=1` — 全绿（零测试改动）
- `go build ./cmd/reasonix` — OK
- 端到端冒烟：`edit_file` x2 窗口读居中 -> guard 解锁；`delete_range` 仍触发

**受影响测试：无。** 现有测试中 `offset` 值均为正数，断言不受 `limit` 检查删除影响。

## Cache impact

Cache-impact: none
Cache-guard: 现有自测 `TestAnchorEditStillRequiresReadAfterWindowedRead` 和 `TestLedgerReportsAnchorRefreshReadsAfterWrites` 覆盖变更路径；无需新增。
System-prompt-review: N/A

Refs: #5831