### PR TITLE
fix(control): fall back to new turn when steer target has no executor / steer 在 executor 为空时回退为新 turn

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1728,6 +1728,9 @@ func (c *Controller) Steer(text string) {
 	running := c.running
 	c.mu.Unlock()
 	if exec == nil {
+		// No executor — controller is not yet initialised or already closed.
+		// Fall back to a new turn so the user still gets a response.
+		go func() { c.SubmitDisplay(text, text) }()
 		return
 	}
 	if running {


### PR DESCRIPTION
## Summary

Fix #6340

Fixes the second bug reported in [#6340](https://github.com/esengine/DeepSeek-Reasonix/issues/6340): when the controller's executor is nil (not yet initialised or already closed), `Controller.Steer` silently dropped the steer input. The frontend had no indication the steer was lost — the user saw the guidance queue item vanish without effect.

This PR makes the `exec == nil` case consistent with the existing `!running` fallback: instead of a silent return, it calls `c.SubmitDisplay(text, text)` in a goroutine so the steer is converted into a new turn.

- `Controller.Steer` now falls back to `SubmitDisplay` when `c.executor` is nil, matching the existing "agent not running" path.
- The broader steer-queue-preservation problem (unconsumed steers lost at turn boundaries) is addressed separately by PR [#6308](https://github.com/esengine/DeepSeek-Reasonix/pull/6308), which removes the deferred `clearSteerQueue()` so pending items survive into the next turn.

## Verification

- **Steer after session close**: Start a session, then close it. During or shortly after the teardown, send a steer input. The steer should now be converted to a new turn rather than being silently lost; the user should see a response in the frontend.
- **Steer before full init**: In a freshly created session that hasn't yet fully initialized the executor, send a steer input. The input should be handled as a normal turn.
- **Normal operation**: During normal session operation, steer behavior should be unchanged — steer inputs continue to be forwarded to the executor as before.

## Cache impact

Cache-impact: none

The change is confined to the controller's `Steer` method and does not alter any caching layer, prompt, memory prefix, serialization path, or cached data.

Cache-guard: The existing CI Go build (`go build ./...`) and `go vet ./...` catch compile-time and basic static analysis errors. The `!running` fallback already exercises the same `SubmitDisplay` path, so this change reuses a proven code path. The manual verification steps above cover the interaction surface.

System-prompt-review: N/A - this is a strictly server-side control flow change. It does not modify system prompts, memory prefixes, output-style templates, or skill index behavior in any way visible to the model or provider.
