### PR TITLE
fix(agent): flush unconsumed steers at turn exit instead of dropping them / 回合退出时保留未消费的引导消息

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3370,11 +3370,22 @@ func newStaleWorkspaceBindingFixtureWithLayout(t *testing.T, suffix, layoutStyle
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "TEST_MODEL_KEY", "sk-test")
 
+	// Steers and idle-steer fallbacks start real provider turns (they are no
+	// longer command-interpreted), so the fixture's provider must complete
+	// instantly instead of pointing at an unreachable host — otherwise every
+	// steer leaves the controller running for the rest of the test.
+	providerStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	t.Cleanup(providerStub.Close)
+
 	cfg := config.Default()
 	cfg.DefaultModel = "test/test-model"
 	cfg.Desktop.ProviderAccess = []string{"test"}
 	cfg.Providers = []config.ProviderEntry{
-		{Name: "test", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "test-model", APIKeyEnv: "TEST_MODEL_KEY"},
+		{Name: "test", Kind: "openai", BaseURL: providerStub.URL, Model: "test-model", APIKeyEnv: "TEST_MODEL_KEY"},
 	}
 	if strings.TrimSpace(layoutStyle) != "" {
 		if err := cfg.SetDesktopLayoutStyle(layoutStyle); err != nil {
@@ -3566,7 +3577,10 @@ func TestEnsureTabControllerWorkspaceWarnsWhenPinnedSessionSwitchesWorkspace(t *
 func TestSteerForTabReconcilesStaleWorkspaceBeforeIdleFallback(t *testing.T) {
 	f := newStaleWorkspaceBindingFixture(t, "steer_idle_fallback")
 
-	if err := f.app.SteerForTab(f.tab.ID, "/unknown-command"); err != nil {
+	// The idle fallback submits the steer text verbatim as a provider turn
+	// (steers are never command-interpreted); the fixture's provider stub
+	// completes it instantly.
+	if err := f.app.SteerForTab(f.tab.ID, "steer guidance"); err != nil {
 		t.Fatalf("SteerForTab: %v", err)
 	}
 	waitNotRunning(t, f.tab.Ctrl)
@@ -3703,7 +3717,7 @@ func runQuickClickWorkspaceReconcileTest(t *testing.T, layoutStyle string) {
 	}
 	actions := []quickAction{
 		{name: "submit", run: func() error { return f.app.SubmitToTab(f.tab.ID, "/unknown-command") }},
-		{name: "steer", run: func() error { return f.app.SteerForTab(f.tab.ID, "/unknown-command") }},
+		{name: "steer", run: func() error { return f.app.SteerForTab(f.tab.ID, "steer guidance") }},
 		{name: "compact", run: func() error { return f.app.Compact() }},
 		{name: "submit-display", run: func() error { return f.app.SubmitDisplayToTab(f.tab.ID, "/unknown display", "/unknown-command") }},
 	}
@@ -3743,6 +3757,14 @@ func runQuickClickWorkspaceReconcileTest(t *testing.T, layoutStyle string) {
 	wg.Wait()
 	close(errs)
 	for err := range errs {
+		// The steer action holds a real provider turn now, so racing quick
+		// clicks may legitimately observe a busy controller. This test
+		// asserts workspace-rebuild serialization, not that every
+		// concurrent action wins the turn.
+		if strings.Contains(err.Error(), "turn already running") ||
+			strings.Contains(err.Error(), "cannot compact while a turn is running") {
+			continue
+		}
 		t.Error(err)
 	}
 	if t.Failed() {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -190,11 +190,14 @@ function emptyComposerDraft(): ComposerDraft {
   };
 }
 
+// Exact (trimmed) equality only: the consumed-steer notice carries the steer
+// text verbatim, and substring matching removed the wrong queue item when one
+// queued text contained another (#6238).
 function guidanceTextMatches(queued: string, consumed: string): boolean {
   const left = queued.trim();
   const right = consumed.trim();
   if (!left || !right) return false;
-  return left === right || left.includes(right) || right.includes(left);
+  return left === right;
 }
 
 function cloneComposerDraft(draft: ComposerDraft): ComposerDraft {
@@ -1143,8 +1146,12 @@ export function Composer({
       const idx = consumed
         ? items.findIndex((item) => guidanceTextMatches(item.submitText, consumed) || guidanceTextMatches(item.text, consumed))
         : -1;
-      const removeAt = idx >= 0 ? idx : 0;
-      return items.filter((_, index) => index !== removeAt);
+      // Only remove on a real match. Steer notices also fire for guidance this
+      // client never queued (another window, bot bridge, turn-end flush) —
+      // falling back to dropping items[0] silently deleted unrelated queued
+      // guidance (#6238).
+      if (idx < 0) return items;
+      return items.filter((_, index) => index !== idx);
     });
   }, [draftKey, guidanceDraftKey, guidanceConsumedKey, guidanceConsumedText, takeSelfDispatchedGuidance]);
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -328,6 +328,11 @@ type Agent struct {
 	steerMu       sync.Mutex
 	steerQueue    []string
 	steerConsumed bool
+	// steerRunActive is true while Run is executing. Steer only queues while
+	// it is set; once the turn's exit flush has drained the queue, later
+	// steers are rejected so the caller can deliver them as a regular turn
+	// instead of leaving them in a queue no loop will ever consume.
+	steerRunActive bool
 
 	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
 	// complete_step validate that cited evidence happened before the claim.
@@ -820,12 +825,21 @@ func SteerText(content string) (string, bool) {
 	return after, true
 }
 
-// Steer queues a message for mid-turn injection.
-func (a *Agent) Steer(text string) {
+// Steer queues a message for mid-turn injection. It reports whether an active
+// turn accepted the text; on false nothing was queued and the caller must
+// deliver it another way (typically as a new turn). Without the active check,
+// a steer landing in the window between the turn's exit flush and the
+// controller observing running=false would sit in the queue unconsumed and
+// unpersisted — invisible to both the model and history.
+func (a *Agent) Steer(text string) bool {
 	a.steerMu.Lock()
 	defer a.steerMu.Unlock()
+	if !a.steerRunActive {
+		return false
+	}
 	a.steerQueue = append(a.steerQueue, text)
 	a.steerConsumed = false
+	return true
 }
 
 // SteerConsumed returns true when the steer queue became empty after the last consume.
@@ -847,11 +861,24 @@ func (a *Agent) consumeSteer() (string, bool) {
 	return t, true
 }
 
-func (a *Agent) clearSteerQueue() {
+// flushSteerQueue ends the turn's steer intake: it drains whatever is still
+// queued and persists each entry to the session, exactly as the in-loop
+// consume would have (#6238 — a dropped steer vanished from both the model's
+// context and history). The flushed steers reach the model on the next turn;
+// the Steer event keeps the transcript honest about when they arrived.
+func (a *Agent) flushSteerQueue() {
 	a.steerMu.Lock()
-	defer a.steerMu.Unlock()
+	pending := a.steerQueue
 	a.steerQueue = nil
-	a.steerConsumed = false
+	if len(pending) > 0 {
+		a.steerConsumed = true
+	}
+	a.steerRunActive = false
+	a.steerMu.Unlock()
+	for _, text := range pending {
+		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
+		a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+	}
 }
 
 func (a *Agent) steerQueueLen() int {
@@ -1100,9 +1127,10 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		}
 		return 1
 	}
-	defer a.clearSteerQueue()
+	defer a.flushSteerQueue()
 	a.steerMu.Lock()
 	a.steerConsumed = false
+	a.steerRunActive = true
 	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -815,14 +815,46 @@ func midTurnSteerMessage(text string) string {
 // "\n" separator that midTurnSteerMessage inserts between the prefix and the
 // user text; it does not trim spaces so the history replay matches the live
 // Steer event rendering character-for-character.
+//
+// Steers are persisted through withTurnPreferences, which can prepend
+// transient language blocks (for Chinese text even in auto mode) and append
+// the delivery-runtime marker. Both are transport framing, not steer text:
+// leading blocks are skipped before matching the prefix and a trailing
+// marker is cut from the returned text, so replay recognizes steers
+// regardless of the session's language and profile settings.
 func SteerText(content string) (string, bool) {
-	after, found := strings.CutPrefix(content, MidTurnSteerPrefix)
-	if !found {
-		return "", false
+	s := content
+	for {
+		if after, found := strings.CutPrefix(s, MidTurnSteerPrefix); found {
+			// Strip only the "\n" separator, preserving the user's original text.
+			after = strings.TrimPrefix(after, "\n")
+			if trimmed, cut := strings.CutSuffix(after, "\n\n"+deliveryRuntimeMarker); cut {
+				after = trimmed
+			}
+			return after, true
+		}
+		next, ok := trimLeadingSteerWrapper(s)
+		if !ok {
+			return "", false
+		}
+		s = next
 	}
-	// Strip only the "\n" separator, preserving the user's original text.
-	after = strings.TrimPrefix(after, "\n")
-	return after, true
+}
+
+// trimLeadingSteerWrapper removes one leading transient preference block that
+// withTurnPreferences may have placed ahead of the steer prefix. It reports
+// false when content does not start with such a block.
+func trimLeadingSteerWrapper(content string) (string, bool) {
+	s := strings.TrimLeft(content, " \t\r\n")
+	for _, tag := range []string{"response-language", "reasoning-language"} {
+		if !strings.HasPrefix(s, "<"+tag+">") {
+			continue
+		}
+		if rest, ok := trimLeadingTransientBlock(s, tag); ok {
+			return rest, true
+		}
+	}
+	return content, false
 }
 
 // Steer queues a message for mid-turn injection. It reports whether an active

--- a/internal/agent/steer_flush_test.go
+++ b/internal/agent/steer_flush_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// steerThenCancelTool queues a steer while the turn is running, then cancels
+// the turn so Run exits before the loop's per-iteration consume can deliver it.
+type steerThenCancelTool struct {
+	agent     *Agent
+	cancel    context.CancelFunc
+	steerText string
+	accepted  bool
+}
+
+func (t *steerThenCancelTool) Name() string        { return "steer_then_cancel" }
+func (t *steerThenCancelTool) Description() string { return "queues a steer and cancels the turn" }
+func (t *steerThenCancelTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{}}`)
+}
+func (t *steerThenCancelTool) ReadOnly() bool { return true }
+func (t *steerThenCancelTool) Execute(context.Context, json.RawMessage) (string, error) {
+	t.accepted = t.agent.Steer(t.steerText)
+	t.cancel()
+	return "ok", nil
+}
+
+// TestRunFlushesUnconsumedSteersOnCancel proves a steer that is still queued
+// when the turn is cancelled survives into the session (history + next turn's
+// context) and emits its Steer event, instead of being silently dropped
+// (#6238: queued guidance vanished from both the model and the transcript).
+func TestRunFlushesUnconsumedSteersOnCancel(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "steer_then_cancel", Arguments: `{}`}}},
+		testutil.Turn{Text: "never reached"},
+	)
+	hijack := &steerThenCancelTool{steerText: "use plan B"}
+	reg := tool.NewRegistry()
+	reg.Add(hijack)
+	var steerEvents []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Steer {
+			steerEvents = append(steerEvents, e.Text)
+		}
+	})
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hijack.agent = a
+	hijack.cancel = cancel
+
+	err := a.Run(ctx, "go")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run should exit on the cancelled context, got %v", err)
+	}
+	if !hijack.accepted {
+		t.Fatalf("Steer during an active turn should be accepted")
+	}
+
+	var persisted []string
+	for _, m := range a.Session().Messages {
+		if m.Role != provider.RoleUser {
+			continue
+		}
+		if strings.Contains(m.Content, MidTurnSteerPrefix) {
+			persisted = append(persisted, m.Content)
+		}
+	}
+	if len(persisted) != 1 || !strings.Contains(persisted[0], "use plan B") {
+		t.Fatalf("unconsumed steer should be persisted to the session exactly once, got %v", persisted)
+	}
+	if len(steerEvents) != 1 || steerEvents[0] != "use plan B" {
+		t.Fatalf("flushed steer should emit its Steer event, got %v", steerEvents)
+	}
+	if n := a.steerQueueLen(); n != 0 {
+		t.Fatalf("steer queue should be empty after the turn, len=%d", n)
+	}
+	if a.Steer("after the turn") {
+		t.Fatalf("Steer must be rejected once the turn has exited")
+	}
+}
+
+// TestSteerRejectedWithoutActiveTurn proves a steer arriving when no turn is
+// running is rejected instead of parked in a queue no loop will consume, so
+// the controller can convert it into a regular turn.
+func TestSteerRejectedWithoutActiveTurn(t *testing.T) {
+	a := New(testutil.NewMock("m", testutil.Turn{Text: "done"}), tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	if a.Steer("early") {
+		t.Fatalf("Steer with no active turn must be rejected")
+	}
+	if n := a.steerQueueLen(); n != 0 {
+		t.Fatalf("rejected steer must not linger in the queue, len=%d", n)
+	}
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if a.Steer("between turns") {
+		t.Fatalf("Steer between turns must be rejected")
+	}
+}

--- a/internal/agent/steer_flush_test.go
+++ b/internal/agent/steer_flush_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 
 	"reasonix/internal/agent/testutil"
@@ -71,12 +70,12 @@ func TestRunFlushesUnconsumedSteersOnCancel(t *testing.T) {
 		if m.Role != provider.RoleUser {
 			continue
 		}
-		if strings.Contains(m.Content, MidTurnSteerPrefix) {
-			persisted = append(persisted, m.Content)
+		if text, ok := SteerText(m.Content); ok {
+			persisted = append(persisted, text)
 		}
 	}
-	if len(persisted) != 1 || !strings.Contains(persisted[0], "use plan B") {
-		t.Fatalf("unconsumed steer should be persisted to the session exactly once, got %v", persisted)
+	if len(persisted) != 1 || persisted[0] != "use plan B" {
+		t.Fatalf("unconsumed steer should be persisted once and round-trip through SteerText, got %v", persisted)
 	}
 	if len(steerEvents) != 1 || steerEvents[0] != "use plan B" {
 		t.Fatalf("flushed steer should emit its Steer event, got %v", steerEvents)
@@ -86,6 +85,44 @@ func TestRunFlushesUnconsumedSteersOnCancel(t *testing.T) {
 	}
 	if a.Steer("after the turn") {
 		t.Fatalf("Steer must be rejected once the turn has exited")
+	}
+}
+
+// TestSteerTextSurvivesTurnPreferenceWrapping pins replay: steers are
+// persisted through withTurnPreferences, which prepends transient language
+// blocks (for Chinese text even in auto mode, and for any text under an
+// explicit language) ahead of the steer prefix. SteerText must skip the
+// wrapping and return the user's exact original text, or replay degrades the
+// steer into a plain user message.
+func TestSteerTextSurvivesTurnPreferenceWrapping(t *testing.T) {
+	plain := New(nil, nil, NewSession(""), Options{}, event.Discard)
+	explicit := New(nil, nil, NewSession(""), Options{}, event.Discard)
+	explicit.SetReasoningLanguage("zh")
+	explicit.SetResponseLanguage("zh")
+
+	cases := []struct {
+		name  string
+		agent *Agent
+		text  string
+	}{
+		{"english auto (no blocks)", plain, "use plan B"},
+		{"chinese auto (reasoning block)", plain, "请改用方案B"},
+		{"explicit zh (both blocks)", explicit, "switch to plan B"},
+		{"exact text preserved", plain, "  spaced\ttext  "},
+	}
+	for _, tc := range cases {
+		persisted := tc.agent.withTurnPreferences(midTurnSteerMessage(tc.text))
+		got, ok := SteerText(persisted)
+		if !ok {
+			t.Fatalf("%s: SteerText failed to recognize the persisted steer (head %.80q)", tc.name, persisted)
+		}
+		if got != tc.text {
+			t.Fatalf("%s: SteerText = %q, want %q", tc.name, got, tc.text)
+		}
+	}
+
+	if _, ok := SteerText(plain.withTurnPreferences("请总结一下这个文件")); ok {
+		t.Fatalf("a wrapped ordinary user message must not be detected as a steer")
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1748,12 +1748,13 @@ func (c *Controller) Steer(text string) {
 	if exec == nil {
 		return
 	}
-	if running {
-		exec.Steer(text)
+	// exec.Steer reports false when no turn is accepting steers — either the
+	// frontend's runningRef was stale, or the turn exited between our running
+	// check and the enqueue. Convert to a new turn so the text is never
+	// silently parked in a queue no loop will consume.
+	if running && exec.Steer(text) {
 		return
 	}
-	// Agent not running — frontend's runningRef was stale.
-	// Convert to a new turn so the user gets a response.
 	go func() { c.SubmitDisplay(text, text) }()
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -637,6 +637,19 @@ const (
 // and the desktop composer already carries a workaround gating its auto-send
 // on submitDisabled rather than turn_done (Composer.tsx).
 func (c *Controller) runGuarded(body func(ctx context.Context) error) admissionResult {
+	return c.admitGuardedTurn(body, false)
+}
+
+// runGuardedOrPark admits like runGuarded but parks the body while another
+// turn is running instead of using the deliberately-silent running drop.
+// Reserved for inputs that are the user's own words (the steer fallback):
+// the FIFO drain in finishGuardedTurn delivers them the moment the current
+// turn finishes.
+func (c *Controller) runGuardedOrPark(body func(ctx context.Context) error) admissionResult {
+	return c.admitGuardedTurn(body, true)
+}
+
+func (c *Controller) admitGuardedTurn(body func(ctx context.Context) error, parkWhileRunning bool) admissionResult {
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
@@ -648,6 +661,11 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) admissionR
 		return turnDroppedRotating
 	}
 	if c.running {
+		if parkWhileRunning {
+			c.parkedTurns = append(c.parkedTurns, body)
+			c.mu.Unlock()
+			return turnParked
+		}
 		c.mu.Unlock()
 		return turnDroppedRunning
 	}
@@ -1745,17 +1763,25 @@ func (c *Controller) Steer(text string) {
 	exec := c.executor
 	running := c.running
 	c.mu.Unlock()
-	if exec == nil {
+	if running && exec != nil && exec.Steer(text) {
 		return
 	}
-	// exec.Steer reports false when no turn is accepting steers — either the
-	// frontend's runningRef was stale, or the turn exited between our running
-	// check and the enqueue. Convert to a new turn so the text is never
-	// silently parked in a queue no loop will consume.
-	if running && exec.Steer(text) {
-		return
-	}
-	go func() { c.SubmitDisplay(text, text) }()
+	// No active turn accepted the steer: the frontend's runningRef was stale,
+	// the turn exited between our running check and the enqueue, or no
+	// executor is bound yet. Deliver it as a regular turn instead.
+	c.submitSteerFallback(text)
+}
+
+// submitSteerFallback delivers steer text that no active turn accepted as a
+// regular turn. Steers are the user's own words, so admission parks the body
+// while another turn is running or finishing rather than dropping it — the
+// window between a turn's steer-queue flush and running=false would
+// otherwise lose the text silently. The text is submitted verbatim; steers
+// are never command-interpreted.
+func (c *Controller) submitSteerFallback(text string) admissionResult {
+	return c.runGuardedOrPark(func(ctx context.Context) error {
+		return c.runRefTurnWithResolverSync(ctx, text, text, text, "", c.ResolveRefs)
+	})
 }
 
 // SteerConsumed returns true when the steer queue is empty after the last consume.

--- a/internal/control/steer_fallback_test.go
+++ b/internal/control/steer_fallback_test.go
@@ -1,0 +1,87 @@
+package control
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func steerFallbackController(t *testing.T) (*Controller, *agent.Agent) {
+	t.Helper()
+	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("ok")}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	return New(Options{Runner: ag, Executor: ag, Sink: event.Discard}), ag
+}
+
+func sessionHasUserText(ag *agent.Agent, text string) bool {
+	for _, m := range ag.Session().Messages {
+		if m.Role == provider.RoleUser && strings.Contains(m.Content, text) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSteerFallbackParksWhileRunning forces the turn-exit window: the
+// controller still reports running (the previous body has not returned), but
+// the agent's steer intake is already closed, so exec.Steer rejects the text.
+// The fallback must park the steer as a turn and deliver it when the window
+// closes — runGuarded's deliberately-silent running drop would lose the
+// user's words.
+func TestSteerFallbackParksWhileRunning(t *testing.T) {
+	c, ag := steerFallbackController(t)
+
+	block := make(chan struct{})
+	started := make(chan struct{})
+	c.runGuarded(func(context.Context) error {
+		close(started)
+		<-block
+		return nil
+	})
+	<-started
+
+	c.Steer("queued while exiting")
+
+	c.mu.Lock()
+	parked := len(c.parkedTurns)
+	c.mu.Unlock()
+	if parked != 1 {
+		t.Fatalf("steer fallback should park while running, parked=%d", parked)
+	}
+
+	close(block)
+	waitIdleAdmission(t, c)
+	deadline := time.Now().Add(30 * time.Second)
+	for !sessionHasUserText(ag, "queued while exiting") {
+		if time.Now().After(deadline) {
+			t.Fatalf("parked steer was never delivered as a turn")
+		}
+		time.Sleep(time.Millisecond)
+		waitIdleAdmission(t, c)
+	}
+}
+
+// TestSteerBetweenTurnsRunsNewTurn pins the idle fallback: with no turn
+// running the executor rejects the steer, and the controller must submit it
+// as a regular turn instead of returning silently (also covers the
+// executor-rejection path a stale frontend running flag would hit).
+func TestSteerBetweenTurnsRunsNewTurn(t *testing.T) {
+	c, ag := steerFallbackController(t)
+
+	c.Steer("late steer")
+
+	deadline := time.Now().Add(30 * time.Second)
+	for !sessionHasUserText(ag, "late steer") {
+		if time.Now().After(deadline) {
+			t.Fatalf("idle steer was never delivered as a turn")
+		}
+		time.Sleep(time.Millisecond)
+		waitIdleAdmission(t, c)
+	}
+}


### PR DESCRIPTION
## Problem

#6238: guidance queued while a turn is running can vanish — neither delivered to the model nor recorded in history. #6340 reports steers being ignored.

Mechanisms confirmed in code:

1. **`Run`'s `defer a.clearSteerQueue()`** dropped every steer still queued when the turn exited on any path other than the flushed final answer — cancel, provider error, readiness failure, maxSteps pause. Persistence only happened at consume time, so a dropped steer disappeared from both the model's context and history.
2. **Turn-exit race:** a steer landing between the agent's queue teardown and the controller observing `running=false` hit `runGuarded`'s deliberately-silent running drop.
3. **Language wrapping broke steer replay:** steers are persisted through `withTurnPreferences`, which prepends `<response-language>`/`<reasoning-language>` blocks ahead of `MidTurnSteerPrefix` — for Chinese text even in auto mode. `SteerText` only matched the bare prefix, so replay degraded those steers into plain user messages (this also affected the pre-existing consume path, i.e. already-persisted sessions).
4. **Composer queue reconciliation** removed a queued guidance item on *any* consumed-steer notice: substring matching could pick the wrong item, and on no match it deleted `items[0]` unconditionally.

## Change

- **`Agent.flushSteerQueue`** replaces `clearSteerQueue` as `Run`'s exit hook: it drains the queue and persists each entry exactly as the in-loop consume would (same wrapping, same `event.Steer` emission). Flushed steers appear in the transcript as `↪` notices and reach the model on the next turn.
- **`SteerText` is wrapping-proof:** it skips leading transient language blocks and cuts a trailing delivery-runtime marker before matching the prefix, so replay recognizes steers regardless of language/profile settings — including sessions persisted before this fix.
- **`Agent.Steer` reports acceptance** and rejects text when no turn is active. `Controller.Steer` then delivers the text through **`runGuardedOrPark`**: a new admission mode that parks the turn while another is running or finishing (FIFO drain in `finishGuardedTurn`), instead of `runGuarded`'s silent running drop. This closes the turn-exit window and also converts steers with **no bound executor** into a regular turn (integrates #6350's case — thanks @JesonChou).
- **Composer:** `guidanceTextMatches` is exact trimmed equality, and reconciliation only removes an item on a real match — no more `items[0]` fallback.

Supersedes #6308 (same problem space; credited via commit trailer).

## Compatibility

| Surface | Old data behavior | Conclusion |
| --- | --- | --- |
| Session format | Flushed steers use the existing `midTurnSteerMessage` + wrapping shape; `SteerText` now also parses steers persisted by older versions under non-auto languages | Improved |
| `Controller.Steer` public signature | Unchanged (`func(text string)`) — desktop bindings and bot gateway untouched | Safe |
| `Agent.Steer` signature | `internal`-only; sole caller is `Controller.Steer`, updated here | Safe |
| `runGuarded` admission | Behavior unchanged for all existing callers; parking mode is opt-in via `runGuardedOrPark` | Safe |
| Bot bridge (`QueueModeSteer`) | Funnels through `Controller.Steer`; inherits no-drop + park fallback | Improved |
| CLI | Never enqueues steers; replay display benefits from the `SteerText` fix | Improved |

## Tests

- `internal/agent/steer_flush_test.go`: unconsumed steer at cancel is persisted once, round-trips through `SteerText`, emits its event, and later steers are rejected; `SteerText` survives `withTurnPreferences` wrapping (English auto, Chinese auto, explicit zh, exact-text preservation) and does not misdetect wrapped ordinary messages.
- New `internal/control/steer_fallback_test.go`: forces the turn-exit window (controller running, agent intake closed) — the steer parks and is delivered when the window closes; an idle steer becomes a regular turn.
- `go test ./internal/agent ./internal/control` and `-race` for both: pass. `gofmt` / `go vet`: clean. Frontend `tsc --noEmit`, `composer-run-strip` (49) and `composer-session-draft` (39): pass.
- `cd desktop && go test ./...`: pass. The stale-workspace fixtures now run against a local instantly-completing SSE provider stub (steers start real verbatim provider turns and are no longer command-interpreted), and the quick-click serialization test tolerates the busy errors racing actions can legitimately observe while a steer turn is in flight. The touched concurrency tests also pass `-race -count=5`.

Fixes #6238. Refs #6340 (the "steer sometimes ignored" half; the fold-display half is in #6351).

Cache-impact: low
Cache-guard: go test ./internal/agent -run 'FlushesUnconsumedSteers|SteerTextSurvives' && go test ./internal/control -run SteerFallback