### PR TITLE
Fix duplicate rich composer input / 修复富文本输入重复显示

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -180,6 +180,20 @@ function dispatchPasteFile(textarea: HTMLTextAreaElement, file: File) {
   textarea.dispatchEvent(event);
 }
 
+function dispatchPasteText(input: HTMLElement, text: string) {
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    configurable: true,
+    value: {
+      files: [],
+      items: [],
+      types: ["text/plain"],
+      getData: (kind: string) => (kind === "text" || kind === "text/plain" ? text : ""),
+    },
+  });
+  input.dispatchEvent(event);
+}
+
 function nativeFileDropEvent(): Event {
   const drop = new window.Event("drop", { bubbles: true, cancelable: true });
   Object.defineProperty(drop, "dataTransfer", {
@@ -218,6 +232,15 @@ function richComposerTaskText(input: HTMLElement): string {
   const clone = input.cloneNode(true) as HTMLElement;
   clone.querySelectorAll("[data-invocation-id], [data-composer-caret-anchor]").forEach((node) => node.remove());
   return clone.textContent ?? "";
+}
+
+function richTextBeforeInvocation(input: HTMLElement, invocation: Element): string {
+  const range = document.createRange();
+  range.setStart(input, 0);
+  range.setEndBefore(invocation);
+  const shell = document.createElement("div");
+  shell.appendChild(range.cloneContents());
+  return richComposerTaskText(shell);
 }
 
 async function appendRichComposerInput(input: HTMLElement, text: string, composing = false) {
@@ -297,6 +320,109 @@ console.log("\ncomposer goal toggle");
   eq(calls.send.length, 0, "enabling goal mode with a draft does not send");
   eq(calls.setCollaborationMode.join(","), "goal", "enabling goal mode switches only the collaboration axis");
   eq(textarea.value, "/reviewer ship the release notes", "enabling goal mode preserves the prefixed draft text");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  mockApp({
+    Commands: async () => [
+      { name: "writing-plans", description: "Write a plan", kind: "skill" },
+      { name: "review", description: "Review the result", kind: "skill" },
+    ],
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => [],
+  });
+  const { root, calls, rerender } = await renderComposer();
+  await replaceComposerDraft(rerender, 4200, "/writing-plans");
+  await waitFor("skill menu for pasted-block offsets", () => Boolean(document.querySelector(".slashmenu")));
+  let textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render for pasted-block offsets");
+  await act(async () => {
+    textarea.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await flushTimers();
+  });
+
+  let richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  let firstToken = richInput?.querySelector(".composer-invocation-token");
+  if (!richInput || !firstToken) throw new Error("initial rich invocation did not render for pasted-block offsets");
+  const afterFirst = document.createRange();
+  afterFirst.setStartAfter(firstToken);
+  afterFirst.collapse(true);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(afterFirst);
+  const expandedText = Array.from({ length: 20 }, (_, index) => `expanded line ${index + 1}`).join("\n");
+  await act(async () => {
+    dispatchPasteText(richInput!, expandedText);
+    await flushTimers();
+  });
+  const firstLabel = document.querySelector(".composer__pasted-label")?.textContent ?? "";
+  ok(firstLabel !== "", "long rich-composer paste folds into a pasted block");
+
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("rich input disappeared after folded paste");
+  await appendRichComposerInput(richInput, " /review");
+  const afterReviewQuery = document.createRange();
+  afterReviewQuery.selectNodeContents(richInput);
+  afterReviewQuery.collapse(false);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(afterReviewQuery);
+  await act(async () => {
+    richInput!.dispatchEvent(new window.KeyboardEvent("keyup", { key: "w", bubbles: true }));
+    await flushTimers();
+  });
+  await waitFor("second skill menu after folded paste", () => Boolean(document.querySelector(".slashmenu")));
+  await act(async () => {
+    richInput!.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await flushTimers();
+  });
+
+  const expandButton = document.querySelectorAll<HTMLButtonElement>(".composer__pasted-actions button")[1];
+  if (!expandButton) throw new Error("pasted-block expand button did not render");
+  await act(async () => {
+    expandButton.click();
+    await flushTimers();
+  });
+  ok(document.querySelector(".composer__pasted-block") === null, "expanding a pasted block removes its folded control");
+
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  const tokensAfterExpand = richInput?.querySelectorAll(".composer-invocation-token");
+  const secondToken = tokensAfterExpand?.[1];
+  if (!richInput || !secondToken) throw new Error("second rich invocation disappeared after pasted-block expansion");
+  eq(richTextBeforeInvocation(richInput, secondToken), `${expandedText} `, "expanding folded text shifts the following invocation to the end of the expanded content");
+  const beforeSecond = document.createRange();
+  beforeSecond.setStartBefore(secondToken);
+  beforeSecond.collapse(true);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(beforeSecond);
+  const removedText = Array.from({ length: 20 }, (_, index) => `removed line ${index + 1}`).join("\n");
+  await act(async () => {
+    dispatchPasteText(richInput!, removedText);
+    await flushTimers();
+  });
+  const removeButton = document.querySelectorAll<HTMLButtonElement>(".composer__pasted-actions button")[2];
+  if (!removeButton) throw new Error("pasted-block remove button did not render");
+  await act(async () => {
+    removeButton.click();
+    await flushTimers();
+  });
+
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  const secondTokenAfterRemove = richInput?.querySelectorAll(".composer-invocation-token")[1];
+  if (!richInput || !secondTokenAfterRemove) throw new Error("second rich invocation disappeared after pasted-block removal");
+  eq(richTextBeforeInvocation(richInput, secondTokenAfterRemove), `${expandedText} `, "removing folded text restores the following invocation offset");
+
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("send button did not render after pasted-block replacement");
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+  eq(calls.structured[0]?.invocations[1]?.offset, expandedText.length, "trimmed structured submission keeps the normalized following invocation offset");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -214,6 +214,27 @@ function fileEntry(name: string): DirEntry {
   return { name, isDir: false };
 }
 
+function richComposerTaskText(input: HTMLElement): string {
+  const clone = input.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("[data-invocation-id], [data-composer-caret-anchor]").forEach((node) => node.remove());
+  return clone.textContent ?? "";
+}
+
+async function appendRichComposerInput(input: HTMLElement, text: string, composing = false) {
+  await act(async () => {
+    if (composing) input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    input.appendChild(document.createTextNode(text));
+    input.dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: text,
+      inputType: composing ? "insertCompositionText" : "insertText",
+      isComposing: composing,
+    }));
+    if (composing) input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+    await flushTimers();
+  });
+}
+
 async function replaceComposerDraft(rerender: RenderedComposer["rerender"], id: number, text: string) {
   await rerender({ insertRequest: { id, text, mode: "replace" } });
 }
@@ -1275,6 +1296,22 @@ console.log("\ncomposer goal toggle");
   ok(document.querySelector<HTMLElement>(".invocation-display--composer")?.style.getPropertyValue("--invocation-color") === "#d59a2f", "selected custom subagent uses its configured color");
   sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
   ok(sendButton?.disabled === true, "subagent-only invocation remains blocked until a task is entered");
+
+  const subagentInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!subagentInput) throw new Error("rich composer did not render for colored subagent");
+  await appendRichComposerInput(subagentInput, "Inspect ");
+  eq(richComposerTaskText(subagentInput), "Inspect ", "rich composer does not duplicate ordinary browser input");
+  await appendRichComposerInput(subagentInput, "仓库做了什么？", true);
+  eq(richComposerTaskText(subagentInput), "Inspect 仓库做了什么？", "rich composer does not duplicate committed IME input");
+
+  sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("composer send button did not render after subagent task input");
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+  eq(calls.send[2], "Inspect 仓库做了什么？", "subagent task is sent exactly once after rich input");
+  eq(calls.structured[2]?.input, "Inspect 仓库做了什么？", "structured subagent input contains one task copy");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -1304,6 +1304,13 @@ console.log("\ncomposer goal toggle");
   await appendRichComposerInput(subagentInput, "仓库做了什么？", true);
   eq(richComposerTaskText(subagentInput), "Inspect 仓库做了什么？", "rich composer does not duplicate committed IME input");
 
+  await replaceComposerDraft(rerender, 2006, "");
+  const resetSubagentInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!resetSubagentInput) throw new Error("rich composer disappeared after external text replacement");
+  eq(richComposerTaskText(resetSubagentInput), "", "external replacement can restore the initially rendered rich-composer text");
+  await appendRichComposerInput(resetSubagentInput, "Inspect ");
+  await appendRichComposerInput(resetSubagentInput, "仓库做了什么？", true);
+
   sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
   if (!sendButton) throw new Error("composer send button did not render after subagent task input");
   await act(async () => {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -2179,20 +2179,36 @@ export function Composer({
     setOpenPastedLabels((prev) => (prev.includes(label) ? prev.filter((x) => x !== label) : [...prev, label]));
   };
 
+  const replacePastedBlockLabel = (block: PastedBlock, replacement: string) => {
+    const current = textRef.current;
+    const start = current.indexOf(block.label);
+    if (start < 0) return;
+    const next = replaceInvocationTextRange(
+      current,
+      invocationsRef.current,
+      start,
+      start + block.label.length,
+      replacement,
+    );
+    textRef.current = next.text;
+    invocationsRef.current = next.invocations;
+    setText(next.text);
+    setInvocations(next.invocations);
+    setComposerSelection(next.text.length);
+  };
+
   const removePastedBlock = (block: PastedBlock) => {
-    const next = text.split(block.label).join("");
     pastedBlocksRef.current = pastedBlocksRef.current.filter((x) => x.label !== block.label);
     setPastedBlocks((prev) => prev.filter((x) => x.label !== block.label));
     setOpenPastedLabels((prev) => prev.filter((x) => x !== block.label));
-    setTextCaretEnd(next);
+    replacePastedBlockLabel(block, "");
   };
 
   const expandPastedBlock = (block: PastedBlock) => {
-    const next = text.split(block.label).join(block.text);
     pastedBlocksRef.current = pastedBlocksRef.current.filter((x) => x.label !== block.label);
     setPastedBlocks((prev) => prev.filter((x) => x.label !== block.label));
     setOpenPastedLabels((prev) => prev.filter((x) => x !== block.label));
-    setTextCaretEnd(next);
+    replacePastedBlockLabel(block, block.text);
   };
 
   useEffect(() => {

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -41,7 +41,24 @@ export type RichComposerInputHandle = {
 
 type PendingSelection = RichComposerSelection | null;
 
+type ComposerModel = {
+  text: string;
+  invocations: ComposerInvocation[];
+};
+
+type RenderedComposerModel = ComposerModel & {
+  version: number;
+};
+
 const CARET_SENTINEL = "\u00A0";
+
+function sameComposerModel(left: ComposerModel, right: ComposerModel | null): boolean {
+  if (!right || left.text !== right.text || left.invocations.length !== right.invocations.length) return false;
+  return left.invocations.every((item, index) => {
+    const candidate = right.invocations[index];
+    return item.id === candidate.id && item.offset === candidate.offset && item.command === candidate.command;
+  });
+}
 
 function modelFromDom(root: HTMLElement, known: Map<string, ComposerInvocation>) {
   let text = "";
@@ -182,6 +199,22 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
 }, ref) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const pendingSelectionRef = useRef<PendingSelection>(null);
+  // contentEditable mutates its DOM before input fires. Keep that browser-owned
+  // DOM for the matching controlled-state echo; rendering the same text again
+  // would append a duplicate node because React does not own the browser's
+  // mutation. External model changes bump the root key and rebuild a clean DOM.
+  const domModelRef = useRef<ComposerModel | null>(null);
+  const renderedModelRef = useRef<RenderedComposerModel>({ text, invocations, version: 0 });
+  const incomingModel: ComposerModel = { text, invocations };
+  if (!sameComposerModel(incomingModel, domModelRef.current) && !sameComposerModel(incomingModel, renderedModelRef.current)) {
+    renderedModelRef.current = {
+      text,
+      invocations,
+      version: renderedModelRef.current.version + 1,
+    };
+    domModelRef.current = null;
+  }
+  const renderedModel = renderedModelRef.current;
   // True between compositionstart and compositionend. While an IME is
   // composing, the browser owns the DOM text node and the selection: syncing
   // the controlled model (a re-render patches the composing text node) or
@@ -250,6 +283,7 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
     if (!root) return;
     const selection = selectionFromDom(root, known);
     const next = modelFromDom(root, known);
+    domModelRef.current = next;
     pendingSelectionRef.current = selection;
     onSelectionChange(selection, slashQueryAt(next.text, selection));
     onChange(next.text, next.invocations);
@@ -291,7 +325,7 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
       root.removeEventListener("compositionstart", start);
       root.removeEventListener("compositionend", end);
     };
-  }, []);
+  }, [renderedModel.version]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Backspace" && !event.nativeEvent.isComposing) {
@@ -314,11 +348,12 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
     onKeyDown(event);
   };
 
+  const renderedOrdered = sortComposerInvocations(renderedModel.invocations);
   const children: React.ReactNode[] = [];
   let cursor = 0;
-  ordered.forEach((item) => {
-    const offset = Math.max(cursor, Math.min(text.length, item.offset));
-    if (offset > cursor) children.push(text.slice(cursor, offset));
+  renderedOrdered.forEach((item) => {
+    const offset = Math.max(cursor, Math.min(renderedModel.text.length, item.offset));
+    if (offset > cursor) children.push(renderedModel.text.slice(cursor, offset));
     const invocation = invocationDisplayForCommand(item.command);
     children.push(
       <span
@@ -332,8 +367,10 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
           kind={invocation.kind}
           description={item.command.description}
           onRemove={() => {
-            pendingSelectionRef.current = { start: offset, end: offset };
-            onSelectionChange({ start: offset, end: offset }, null);
+            const current = known.get(item.id);
+            const currentOffset = current?.offset ?? offset;
+            pendingSelectionRef.current = { start: currentOffset, end: currentOffset };
+            onSelectionChange({ start: currentOffset, end: currentOffset }, null);
             onChange(text, invocations.filter((candidate) => candidate.id !== item.id));
           }}
           variant="composer"
@@ -354,10 +391,11 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
     );
     cursor = offset;
   });
-  if (cursor < text.length) children.push(text.slice(cursor));
+  if (cursor < renderedModel.text.length) children.push(renderedModel.text.slice(cursor));
 
   return (
     <div
+      key={renderedModel.version}
       id="composer-input"
       ref={rootRef}
       className="composer__rich-input"

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -206,12 +206,17 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
   const domModelRef = useRef<ComposerModel | null>(null);
   const renderedModelRef = useRef<RenderedComposerModel>({ text, invocations, version: 0 });
   const incomingModel: ComposerModel = { text, invocations };
-  if (!sameComposerModel(incomingModel, domModelRef.current) && !sameComposerModel(incomingModel, renderedModelRef.current)) {
+  // The rendered snapshot intentionally lags accepted browser echoes.
+  const acceptedModelRef = useRef<ComposerModel>(incomingModel);
+  if (sameComposerModel(incomingModel, domModelRef.current)) {
+    acceptedModelRef.current = incomingModel;
+  } else if (!sameComposerModel(incomingModel, acceptedModelRef.current)) {
     renderedModelRef.current = {
       text,
       invocations,
       version: renderedModelRef.current.version + 1,
     };
+    acceptedModelRef.current = incomingModel;
     domModelRef.current = null;
   }
   const renderedModel = renderedModelRef.current;


### PR DESCRIPTION
## Summary

- keep browser-owned `contentEditable` DOM for the matching controlled-state echo
- rebuild the rich composer DOM only for external text or invocation changes
- preserve following Skill/Subagent offsets when folded paste blocks are expanded or removed
- cover ordinary typing, Chinese IME commits, external draft replacement, folded paste replacement, and structured submission
- audit the repository for other editable DOM ownership conflicts; no sibling `contentEditable` implementation exists

This is a follow-up to the rich composer introduced by #6310. Provider-visible prompts, tool schemas, and structured invocation serialization are unchanged.

## Verification

- `pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx`
- `pnpm typecheck`
- `pnpm test:typecheck`
- `pnpm test:all`
- `pnpm build`
- `cd desktop && go test ./...`
- Chromium browser check with `/explore`, Chinese text, and continued Latin input