### PR TITLE
Fix diagnostics null-array crash / 修复诊断页空数组崩溃

### DIFF
--- a/desktop/bound_array_contract_test.go
+++ b/desktop/bound_array_contract_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,12 @@ func TestBoundArrayPayloadsAreNonNilBeforeStartup(t *testing.T) {
 		{"ListTabs", app.ListTabs()},
 		{"ListProjectTree", app.ListProjectTree()},
 		{"AvailableSubagentTools", app.AvailableSubagentTools()},
+		{"AutoResearchList", app.AutoResearchList("missing")},
+		{"AutoResearchFindings", app.AutoResearchFindings("missing", 10)},
+		{"MCPServers", app.MCPServers()},
+		{"Plugins", app.Plugins()},
+		{"HeartbeatListTasks", app.HeartbeatListTasks()},
+		{"HeartbeatReloadTasks", app.HeartbeatReloadTasks()},
 	}
 	for _, tc := range cases {
 		assertNonNilSliceJSON(t, tc.name, tc.got)
@@ -57,6 +64,22 @@ func TestBoundArrayPayloadsAreNonNilBeforeStartup(t *testing.T) {
 		got.Bot.Allowlist.QQGroups == nil || got.Bot.Allowlist.FeishuGroups == nil || got.Bot.Allowlist.WeixinGroups == nil {
 		t.Fatalf("DesktopStartupSettings() contains nil array fields: %+v", got)
 	}
+
+	boundPayloads := []struct {
+		name string
+		got  any
+	}{
+		{"CapabilityDiagnostics", app.CapabilityDiagnostics(false)},
+		{"Capabilities", app.Capabilities()},
+		{"SkillsSettings", app.SkillsSettings()},
+		{"HistoryPage", app.HistoryPage(0, 20)},
+		{"Effort", app.Effort()},
+		{"Memory", app.Memory()},
+		{"MemorySuggestions", app.MemorySuggestions()},
+	}
+	for _, tc := range boundPayloads {
+		assertRequiredJSONSlicesNonNil(t, tc.name, reflect.ValueOf(tc.got))
+	}
 }
 
 func assertNonNilSliceJSON(t *testing.T, name string, got any) {
@@ -74,5 +97,39 @@ func assertNonNilSliceJSON(t *testing.T, name string, got any) {
 	}
 	if string(raw) == "null" {
 		t.Fatalf("%s JSON encoded as null; frontend expects []", name)
+	}
+}
+
+func assertRequiredJSONSlicesNonNil(t *testing.T, path string, value reflect.Value) {
+	t.Helper()
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return
+		}
+		value = value.Elem()
+	}
+
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array:
+		if value.Kind() == reflect.Slice && value.IsNil() {
+			t.Fatalf("%s is a nil slice; JSON contract requires []", path)
+		}
+		for i := 0; i < value.Len(); i++ {
+			assertRequiredJSONSlicesNonNil(t, path, value.Index(i))
+		}
+	case reflect.Struct:
+		typ := value.Type()
+		for i := 0; i < value.NumField(); i++ {
+			fieldType := typ.Field(i)
+			if fieldType.PkgPath != "" {
+				continue
+			}
+			jsonTag := fieldType.Tag.Get("json")
+			if jsonTag == "-" || strings.Contains(jsonTag, ",omitempty") {
+				continue
+			}
+			fieldPath := path + "." + fieldType.Name
+			assertRequiredJSONSlicesNonNil(t, fieldPath, value.Field(i))
+		}
 	}
 }

--- a/desktop/frontend/src/__tests__/diagnostics-settings.test.tsx
+++ b/desktop/frontend/src/__tests__/diagnostics-settings.test.tsx
@@ -189,4 +189,59 @@ console.log("diagnostics settings page");
   });
 }
 
+{
+  installDom();
+  window.localStorage.setItem("reasonix-lang", "en");
+
+  const nullArrays = baseReport(false) as unknown as Record<string, unknown>;
+  nullArrays.summary = {
+    errors: 0,
+    warnings: 0,
+    infos: 0,
+    instructions: 0,
+    skills: 0,
+    commands: 0,
+    hooks: 0,
+    plugins: 0,
+    mcp_servers: 0,
+  };
+  nullArrays.issues = null;
+  nullArrays.instructions = { docs: null };
+  nullArrays.skills = { roots: null, entries: null, winners: 0, shadowed: 0 };
+  nullArrays.commands = { roots: null, entries: null, winners: 0, shadowed: 0 };
+  nullArrays.hooks = { trusted_project: false, project_defines_hooks: false, sources: null, entries: null };
+  nullArrays.plugins = { packages: null };
+  nullArrays.mcp = { servers: null };
+
+  window.go = {
+    main: {
+      App: {
+        CapabilityDiagnostics: async () => nullArrays as unknown as CapabilityDiagnosticsReport,
+      } as Partial<AppBindings> as AppBindings,
+    },
+  };
+
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        LocaleProvider,
+        null,
+        React.createElement(DiagnosticsSettingsPage),
+      ),
+    );
+    await flush();
+  });
+
+  await waitFor("null arrays to render as empty", () => (rootEl.textContent || "").includes("No issues found"));
+  ok(rootEl.querySelector(".diag-summary"), "null arrays must not crash the diagnostics page");
+
+  await act(async () => {
+    root.unmount();
+  });
+}
+
 console.log("diagnostics-settings: ok");

--- a/desktop/frontend/src/components/DiagnosticsSettingsPage.tsx
+++ b/desktop/frontend/src/components/DiagnosticsSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ChevronDown, ChevronRight, Clipboard, Loader2, RefreshCw } from "lucide-react";
 import { app } from "../lib/bridge";
+import { asArray } from "../lib/array";
 import { useT } from "../lib/i18n";
 import type { CapabilityDiagnosticsReport, CapabilityIssue, SettingsTab } from "../lib/types";
 
@@ -32,7 +33,7 @@ export function DiagnosticsSettingsPage({
     setLoading(true);
     setError(null);
     try {
-      const next = await app.CapabilityDiagnostics(runtime);
+      const next = normalizeDiagnosticsReport(await app.CapabilityDiagnostics(runtime));
       // Last-request-wins: ignore stale responses after rapid refresh/toggle.
       if (seq !== loadSeq.current) return;
       setReport(next);
@@ -269,6 +270,31 @@ export function DiagnosticsSettingsPage({
       )}
     </div>
   );
+}
+
+function normalizeDiagnosticsReport(report: CapabilityDiagnosticsReport): CapabilityDiagnosticsReport {
+  return {
+    ...report,
+    issues: asArray(report.issues),
+    instructions: { ...report.instructions, docs: asArray(report.instructions?.docs) },
+    skills: {
+      ...report.skills,
+      roots: asArray(report.skills?.roots),
+      entries: asArray(report.skills?.entries),
+    },
+    commands: {
+      ...report.commands,
+      roots: asArray(report.commands?.roots),
+      entries: asArray(report.commands?.entries),
+    },
+    hooks: {
+      ...report.hooks,
+      sources: asArray(report.hooks?.sources),
+      entries: asArray(report.hooks?.entries),
+    },
+    plugins: { ...report.plugins, packages: asArray(report.plugins?.packages) },
+    mcp: { ...report.mcp, servers: asArray(report.mcp?.servers) },
+  };
 }
 
 function Collapsible({

--- a/desktop/frontend/src/components/SubagentsPanel.tsx
+++ b/desktop/frontend/src/components/SubagentsPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties }
 import { Check, ChevronDown } from "lucide-react";
 
 import { app } from "../lib/bridge";
+import { asArray } from "../lib/array";
 import { useT } from "../lib/i18n";
 import { PROJECT_COLOR_OPTIONS, projectColorValue, type ProjectColorKey } from "../lib/projectColors";
 import type { MCPToolView, SettingsView, SkillView, SubagentProfileInput } from "../lib/types";
@@ -79,8 +80,8 @@ export function SubagentsSettingsPage({ s, onUseInChat }: { s: SettingsView; onU
       app.SkillsSettings().catch(() => ({ skills: [], skillRoots: [] })),
       app.AvailableSubagentTools().catch(() => []),
     ]);
-    setSkills(settingsView.skills.filter((sk) => sk.runAs === "subagent"));
-    setTools(availableTools);
+    setSkills(asArray<SkillView>(settingsView?.skills).filter((sk) => sk.runAs === "subagent"));
+    setTools(asArray<MCPToolView>(availableTools));
   }, []);
   useEffect(() => { void reload(); }, [reload]);
 

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -756,7 +756,7 @@ export function WorkspacePanel({
     }
     let cancelled = false;
     app.SearchFileRefsForTab(workspaceTabId, q).then((results) => {
-      if (!cancelled) setSearchResults(results);
+      if (!cancelled) setSearchResults(asArray(results));
     }).catch(() => {
       if (!cancelled) setSearchResults(null);
     });

--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -821,7 +821,7 @@ func weeksBetween(a, b time.Time) int {
 // HeartbeatListTasks returns all heartbeat tasks.
 func (a *App) HeartbeatListTasks() []HeartbeatTask {
 	if a.heartbeat == nil {
-		return nil
+		return []HeartbeatTask{}
 	}
 	return a.heartbeat.ListTasks()
 }
@@ -829,7 +829,7 @@ func (a *App) HeartbeatListTasks() []HeartbeatTask {
 // HeartbeatReloadTasks reloads tasks from disk and returns them.
 func (a *App) HeartbeatReloadTasks() []HeartbeatTask {
 	if a.heartbeat == nil {
-		return nil
+		return []HeartbeatTask{}
 	}
 	return a.heartbeat.ReloadTasks()
 }

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -336,7 +336,7 @@ func (a *App) GitBranches() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	branches := strings.FieldsFunc(strings.TrimSpace(string(raw)), func(r rune) bool { return r == '\n' })
+	branches := append([]string{}, strings.FieldsFunc(strings.TrimSpace(string(raw)), func(r rune) bool { return r == '\n' })...)
 	return branches, nil
 }
 
@@ -388,7 +388,7 @@ func (a *App) WorkspaceGitHistory(tabID string, path string) ([]GitCommitView, e
 	}
 
 	parts := bytes.Split(raw, []byte{0})
-	var out []GitCommitView
+	out := []GitCommitView{}
 	// 4 parts per commit: hash, author, date, message
 	for i := 0; i+3 < len(parts); i += 4 {
 		out = append(out, GitCommitView{

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -1455,6 +1455,45 @@ func TestWorkspaceGitHistory(t *testing.T) {
 	}
 }
 
+func TestEmptyGitArrayResultsAreNonNil(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+
+	app := &App{}
+	branches, err := app.GitBranches()
+	if err != nil {
+		t.Fatalf("GitBranches err = %v", err)
+	}
+	if branches == nil {
+		t.Fatal("GitBranches returned nil for an unborn repository; frontend expects []")
+	}
+
+	if err := os.WriteFile("tracked.txt", []byte("content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "tracked.txt")
+	runGit(t, "commit", "-m", "initial")
+
+	history, err := app.WorkspaceGitHistory("", "never-existed.txt")
+	if err != nil {
+		t.Fatalf("WorkspaceGitHistory empty path err = %v", err)
+	}
+	if history == nil {
+		t.Fatal("WorkspaceGitHistory returned nil for a path without commits; frontend expects []")
+	}
+}
+
 func TestWorkspaceGitHistoryUsesRequestedTabWorkspace(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")

--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -53,7 +53,7 @@ func Collect(opts Options) Report {
 		cfg = config.Default()
 	}
 
-	var issues []Issue
+	issues := []Issue{}
 	if cfgErr != nil {
 		issues = append(issues, Issue{
 			Severity: "error", Code: "config.load_failed", Subsystem: "config",

--- a/internal/capdiag/collect_test.go
+++ b/internal/capdiag/collect_test.go
@@ -124,6 +124,16 @@ func TestMissingConventionDirsNoWarning(t *testing.T) {
 	r := capdiag.Collect(capdiag.Options{
 		Root: root, HomeDir: home, ReasonixHomeDir: filepath.Join(home, ".reasonix"),
 	})
+	if r.Issues == nil {
+		t.Fatal("empty issues must be a non-nil slice for JSON consumers")
+	}
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"issues":[]`) {
+		t.Fatalf("empty issues must marshal as [], got %s", raw)
+	}
 	for _, is := range r.Issues {
 		if is.Severity == "warning" && strings.Contains(strings.ToLower(is.Message), "directory") {
 			t.Fatalf("missing dir should not warn: %+v", is)


### PR DESCRIPTION
## Summary

- Prevent the Diagnostics settings page from crashing when Wails serializes empty Go slices as JSON `null`.
- Normalize nested diagnostics arrays and other direct binding consumers at the React boundary.
- Make heartbeat and Git empty-result paths return non-nil slices.
- Add backend contract tests and a production-shape frontend regression test.

## Root cause

`internal/capdiag.Collect` returned a nil `issues` slice when diagnostics found no problems. Wails serialized it as `null`, while `DiagnosticsSettingsPage` accessed `report.issues.length`. Browser mocks consistently returned arrays, so the production-only payload mismatch was not covered.

## Compatibility

| Contract | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted files and config | No persisted schema or format changes | Backward compatible |
| Wails array payloads | Existing arrays remain unchanged; empty `null` values normalize to `[]` | Backward compatible |
| Optional `omitempty` arrays | Semantics remain unchanged | Backward compatible |
| Frontend binding consumers | Accept both legacy `null` and current array payloads | Backward compatible |

## Verification

- `go test ./internal/capdiag`
- `go test ./...`
- `cd desktop && go test ./...`
- Frontend full test suite
- Frontend TypeScript typecheck
- Frontend production build
- `git diff --check`
