### PR TITLE
Open workspace panel on launch / 启动时默认展开工作区

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -79,9 +79,9 @@ ok(
 );
 
 ok(
-  /const WORKSPACE_PANEL_DEFAULT_OPEN = false;/.test(layoutStoreSource) &&
+  /const WORKSPACE_PANEL_DEFAULT_OPEN = true;/.test(layoutStoreSource) &&
     /workspacePanelOpen:\s*WORKSPACE_PANEL_DEFAULT_OPEN/.test(layoutStoreSource),
-  "right dock starts collapsed on launch",
+  "right dock starts expanded on launch",
 );
 
 ok(

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -32,7 +32,7 @@ export const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
 export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 export const RIGHT_DOCK_MAX_WIDTH = 860;
-const WORKSPACE_PANEL_DEFAULT_OPEN = false;
+const WORKSPACE_PANEL_DEFAULT_OPEN = true;
 
 export function clampSidebarWidth(width: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));


### PR DESCRIPTION
## Summary

- Open the right workspace panel by default on desktop launch.
- Update the source-level regression test to lock in the expanded startup state.

## Why

The workspace panel provides direct access to context, files, and changes. Showing it on launch makes the primary desktop workflow immediately available without an extra toggle.

## User impact

The panel starts expanded on each new app launch. Users can still collapse it during the current run, and existing responsive width safeguards remain unchanged.

## Validation

- pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts (74 passed)
- pnpm exec tsc --noEmit -p tsconfig.test.json
- pnpm check:css
- git diff --check

## Backward compatibility

| Area | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted layout data | No schema change; workspace open state remains non-persisted | Compatible |
| Stored panel widths | Existing stored widths continue to load and clamp as before | Compatible |