### PR TITLE
fix(desktop): collapse todo panel by default

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -153,12 +153,7 @@ assert.notEqual(
 assert.equal(
   shouldOpenTodoPanelByDefault(),
   false,
-  "new incomplete todo batches collapse by default",
-);
-assert.equal(
-  shouldOpenTodoPanelByDefault(),
-  false,
-  "completed todo batches collapse by default",
+  "todo batches collapse by default regardless of completion",
 );
 
 const iterations = 200_000;

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -151,12 +151,12 @@ assert.notEqual(
   "new task content creates a new todo batch",
 );
 assert.equal(
-  shouldOpenTodoPanelByDefault(activeTodos),
-  true,
-  "new incomplete todo batches open by default",
+  shouldOpenTodoPanelByDefault(),
+  false,
+  "new incomplete todo batches collapse by default",
 );
 assert.equal(
-  shouldOpenTodoPanelByDefault(completedTodos),
+  shouldOpenTodoPanelByDefault(),
   false,
   "completed todo batches collapse by default",
 );

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1699,8 +1699,9 @@ export default function App() {
   // successful top-level todo_write result; failed or still-running attempts do
   // not advance the canonical panel state. Incomplete lists are always shown so
   // a stale local dismissal cannot hide work that still blocks final readiness;
-  // completed lists collapse automatically and can then be dismissed. The
-  // dismissal key is still based on stable todo content/state so history reloads
+  // every new list starts collapsed while its header keeps showing live progress
+  // and the current task; completed lists can then be dismissed. The dismissal
+  // key is still based on stable todo content/state so history reloads
   // do not resurrect the same finished list under a different event id. The
   // batch key ignores status changes so progress within the same task list does
   // not look like a brand-new task batch. Dismissal and open state are scoped to

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -41,9 +41,9 @@ function saveOpenState(stateKey: string, open: boolean): void {
 
 // TodoPanel is the live task list pinned just above the composer — the kernel's
 // latest todo_write call drives it, and it updates in place as the agent flips
-// items to in_progress / completed. Open state follows the current todo batch:
-// new incomplete work opens by default, finished work collapses to a reviewable
-// summary, and manual expand/collapse is restored only for the same batch.
+// items to in_progress / completed. Each new todo batch starts collapsed so the
+// header can show live progress and the current task without occupying extra
+// space. Manual expand/collapse is restored only for the same batch.
 export function TodoPanel({
   stateKey,
   todos,
@@ -60,7 +60,7 @@ export function TodoPanel({
   const current = todos.find((t) => t.status === "in_progress");
   const allDone = todos.length > 0 && done === todos.length;
   const summary = current?.activeForm || current?.content || todos[todos.length - 1]?.content || "";
-  const [open, setOpen] = useState(() => loadOpenState(stateKey, shouldOpenTodoPanelByDefault(todos)));
+  const [open, setOpen] = useState(() => loadOpenState(stateKey, shouldOpenTodoPanelByDefault()));
   const wasAllDoneRef = useRef(allDone);
 
   useEffect(() => {

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -76,8 +76,8 @@ export function shouldShowTodoPanel(
   return todoKey !== dismissedTodoKey;
 }
 
-export function shouldOpenTodoPanelByDefault(todos: Todo[]): boolean {
-  return hasIncompleteTodos(todos);
+export function shouldOpenTodoPanelByDefault(): boolean {
+  return false;
 }
 
 function todoStatus(status: unknown): string {


### PR DESCRIPTION
## Summary

- start each new desktop todo batch collapsed
- keep the completed/total badge and current in-progress task visible in the collapsed header
- preserve manual expand/collapse state within the same todo batch
- update the todo visibility regression contract

## Why

The live todo list previously opened automatically whenever incomplete work arrived, which occupied extra composer space. The compact header already contains the useful at-a-glance state, so incomplete batches should remain collapsed until the user explicitly expands them.

## Validation

- `pnpm test:todo-visibility`
- `pnpm build`
- browser mock `/todo-preview`: verified the initial header shows `1/3` and the current task with zero rendered todo rows; expanding shows all three rows without changing the header summary

## Compatibility

No persisted data format, Wails contract, provider request, or prompt construction changed. Existing manually saved open state remains scoped to and honored for the same todo batch.