### PR TITLE
Attribute performance reports via JS self-profiling and denoise long-task prompts / 性能报告接入采样归因并为长任务提示降噪

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -325,6 +325,19 @@ func (a *App) ensureMediaTokenStore() *mediaTokenStore {
 	return a.mediaTokens
 }
 
+// jsProfilingMiddleware opts every asset response into the JS Self-Profiling
+// document policy so the frontend performance monitor can attach sampled stacks
+// to long-task reports. Chromium WebViews (WebView2) honor it; WebKit ignores
+// both the header and the API, so the frontend degrades to unattributed reports.
+func (a *App) jsProfilingMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Document-Policy", "js-profiling")
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // workspaceMediaMiddleware returns an HTTP middleware that intercepts
 // /__reasonix_workspace_media/{token}/{filename} requests and serves the
 // corresponding workspace file. All other paths pass through to the Wails

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -1,8 +1,10 @@
 // Run: tsx src/__tests__/crash-reporting.test.ts
 
 import {
+  aggregateLongTaskProfile,
   buildCrashPayload,
   buildPerformancePayload,
+  formatLongTaskAttribution,
   formatPerformanceContext,
   globalCrashReportReason,
   installPerformancePressureMonitor,
@@ -10,12 +12,14 @@ import {
   parseReportedPerf,
   performanceLabelForReason,
   serializeReportedPerf,
+  shouldPromptForLongTasks,
   shouldRecordEventLoopLagSample,
   shouldPromptForPerformanceLabel,
   shouldReportGlobalCrashEvent,
   shouldRecordLongTaskSample,
   topFrameFromStack,
   type PerformanceSnapshot,
+  type ProfilerTrace,
 } from "../lib/crash";
 
 let passed = 0;
@@ -141,6 +145,82 @@ eq(shouldRecordLongTaskSample(60_000, 900, 15_000, true, 20_000), false, "ignore
 eq(shouldRecordLongTaskSample(23_000, 900, 15_000, false, 20_000), false, "ignores long tasks immediately after visibility resumes");
 eq(shouldRecordLongTaskSample(26_000, 900, 15_000, false, 20_000), true, "records long tasks after the visibility resume grace period");
 eq(shouldRecordLongTaskSample(570_000, 92, 15_000, false, 20_000, false), false, "ignores long tasks while unfocused");
+eq(shouldPromptForLongTasks({ count: 1, totalMs: 850, maxMs: 850 }), true, "prompts on a single 800ms+ long task");
+eq(
+  shouldPromptForLongTasks({ count: 16, totalMs: 1_584, maxMs: 237 }),
+  false,
+  "tolerates streaming-render bursts below the 3s cumulative budget",
+);
+eq(shouldPromptForLongTasks({ count: 16, totalMs: 3_100, maxMs: 237 }), true, "prompts past the 3s cumulative budget");
+eq(shouldPromptForLongTasks({ count: 2, totalMs: 3_100, maxMs: 790 }), false, "cumulative path needs at least 3 tasks");
+
+eq(formatLongTaskAttribution("self", [{ containerType: "window" }]), "", "hides the no-signal self/window attribution");
+eq(formatLongTaskAttribution("unknown", undefined), "", "hides unknown attribution");
+eq(
+  formatLongTaskAttribution("cross-origin-descendant", [{ containerType: "iframe", containerSrc: "https://embed.example" }]),
+  "cross-origin-descendant iframe:https://embed.example",
+  "surfaces cross-context culprits with their container",
+);
+
+const trace: ProfilerTrace = {
+  resources: ["wails://wails/assets/vendor-markdown.js"],
+  frames: [
+    { name: "post", resourceId: 0, line: 1, column: 130216 },
+    { name: "tick", resourceId: 0, line: 9 },
+    { name: "" },
+  ],
+  stacks: [{ frameId: 0 }, { frameId: 1, parentId: 0 }, { frameId: 2 }],
+  samples: [
+    { timestamp: 1_000, stackId: 0 },
+    { timestamp: 1_010, stackId: 0 },
+    { timestamp: 1_020, stackId: 1 },
+    { timestamp: 5_000, stackId: 0 }, // outside every long-task window
+    { timestamp: 1_030 }, // idle sample without a stack
+    { timestamp: 1_040, stackId: 2 },
+  ],
+};
+eq(
+  aggregateLongTaskProfile(trace, [{ startMs: 990, durationMs: 100 }]),
+  [
+    { label: "post (wails://wails/assets/vendor-markdown.js:1:130216)", samples: 2 },
+    { label: "tick (wails://wails/assets/vendor-markdown.js:9)", samples: 1 },
+    { label: "(anonymous)", samples: 1 },
+  ],
+  "counts leaf frames for samples inside long-task windows",
+);
+eq(aggregateLongTaskProfile(trace, []), [], "returns nothing without long-task windows");
+eq(
+  aggregateLongTaskProfile(trace, [{ startMs: 990, durationMs: 100 }], 1),
+  [{ label: "post (wails://wails/assets/vendor-markdown.js:1:130216)", samples: 2 }],
+  "caps the frame list at maxFrames",
+);
+
+const framesSnapshot: PerformanceSnapshot = {
+  ...perf,
+  longTasks: {
+    count: 1,
+    totalMs: 900,
+    maxMs: 900,
+    recent: [{ startMs: 40_000, durationMs: 900, attribution: "cross-origin-descendant" }],
+  },
+  longTaskFrames: [{ label: "post (vendor-markdown.js:1)", samples: 42 }],
+};
+eq(
+  formatPerformanceContext(framesSnapshot).includes("900ms @ 40.0s (cross-origin-descendant)"),
+  true,
+  "recent long tasks carry their attribution",
+);
+eq(
+  formatPerformanceContext(framesSnapshot).includes("long task top frames (sampled):\n  42x post (vendor-markdown.js:1)"),
+  true,
+  "formats sampled top frames into the report context",
+);
+eq(
+  formatPerformanceContext(perf).includes("long task top frames"),
+  false,
+  "omits the frames section when no profile was captured",
+);
+
 eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag while the window is hidden");
 eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
 eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -33,8 +33,9 @@ export type PerformanceSnapshot = {
     count: number;
     totalMs: number;
     maxMs: number;
-    recent: { startMs: number; durationMs: number }[];
+    recent: { startMs: number; durationMs: number; attribution?: string }[];
   };
+  longTaskFrames?: { label: string; samples: number }[];
   connection?: {
     effectiveType?: string;
     downlinkMbps?: number;
@@ -71,7 +72,24 @@ type NormalizedError = {
 type LongTaskSample = {
   startMs: number;
   durationMs: number;
+  attribution?: string;
 };
+
+// WICG JS Self-Profiling API (https://wicg.github.io/js-self-profiling/), available
+// in Chromium WebViews when the document is served with `Document-Policy: js-profiling`.
+export type ProfilerTrace = {
+  resources?: string[];
+  frames?: { name?: string; resourceId?: number; line?: number; column?: number }[];
+  stacks?: { frameId: number; parentId?: number }[];
+  samples?: { timestamp: number; stackId?: number }[];
+};
+
+type ProfilerLike = {
+  stop(): Promise<ProfilerTrace>;
+  addEventListener?: (type: string, listener: () => void) => void;
+};
+
+type ProfilerConstructor = new (options: { sampleInterval: number; maxBufferSize: number }) => ProfilerLike;
 
 type BrowserPerformanceMemory = {
   usedJSHeapSize?: number;
@@ -91,7 +109,9 @@ type BrowserNavigator = Navigator & {
 
 const LONG_TASK_WINDOW_MS = 60_000;
 const LONG_TASK_PROMPT_MS = 800;
-const LONG_TASK_TOTAL_PROMPT_MS = 1_500;
+// Streaming renders routinely accumulate ~1.5s of 70-240ms tasks per minute without
+// user-visible jank, so the cumulative prompt only fires past half of that budget spent blocked.
+const LONG_TASK_TOTAL_PROMPT_MS = 3_000;
 const EVENT_LOOP_LAG_PROMPT_MS = 1_200;
 const STARTUP_GRACE_MS = 15_000;
 const PROMPT_COOLDOWN_MS = 10 * 60_000;
@@ -102,6 +122,51 @@ const longTasks: LongTaskSample[] = [];
 const lagSamples: number[] = [];
 let performanceMonitorInstalled = false;
 let lastPerformancePromptAt = 0;
+
+// Rolling self-profiling sampler (Chromium WebViews only; requires the asset server
+// to send `Document-Policy: js-profiling`, see jsProfilingMiddleware on the Go side).
+// ~10ms native sampling; the buffer covers the same 60s window as longTasks.
+const PROFILER_SAMPLE_INTERVAL_MS = 10;
+const PROFILER_MAX_BUFFER_SAMPLES = LONG_TASK_WINDOW_MS / PROFILER_SAMPLE_INTERVAL_MS;
+let activeProfiler: ProfilerLike | null = null;
+
+function startLongTaskProfiler(): void {
+  const ProfilerCtor = (globalThis as { Profiler?: ProfilerConstructor }).Profiler;
+  if (!ProfilerCtor) return;
+  try {
+    const profiler = new ProfilerCtor({
+      sampleInterval: PROFILER_SAMPLE_INTERVAL_MS,
+      maxBufferSize: PROFILER_MAX_BUFFER_SAMPLES,
+    });
+    // A full buffer stops sampling silently; drop the stale trace and roll over.
+    profiler.addEventListener?.("samplebufferfull", () => {
+      if (activeProfiler !== profiler) return;
+      activeProfiler = null;
+      void profiler.stop().catch(() => {});
+      startLongTaskProfiler();
+    });
+    activeProfiler = profiler;
+  } catch {
+    // Document policy missing or the API is disabled in this WebView.
+    activeProfiler = null;
+  }
+}
+
+async function collectLongTaskFrames(
+  windows: { startMs: number; durationMs: number }[],
+): Promise<{ label: string; samples: number }[]> {
+  const profiler = activeProfiler;
+  if (!profiler) return [];
+  activeProfiler = null;
+  try {
+    const trace = await profiler.stop();
+    return aggregateLongTaskProfile(trace, windows);
+  } catch {
+    return [];
+  } finally {
+    startLongTaskProfiler();
+  }
+}
 
 const PERF_REPORTED_STORAGE_KEY = "reasonix:perf-reported";
 
@@ -333,12 +398,19 @@ export function formatPerformanceContext(snapshot: PerformanceSnapshot): string 
   }
   if (snapshot.longTasks) {
     const recent = snapshot.longTasks.recent
-      .map((t) => `${fmtNumber(t.durationMs)}ms @ ${fmtNumber(t.startMs / 1000, 1)}s`)
+      .map(
+        (t) =>
+          `${fmtNumber(t.durationMs)}ms @ ${fmtNumber(t.startMs / 1000, 1)}s${t.attribution ? ` (${t.attribution})` : ""}`,
+      )
       .join("; ");
     lines.push(
       `long tasks: ${snapshot.longTasks.count} in the last 60s, max ${fmtNumber(snapshot.longTasks.maxMs)}ms, total ${fmtNumber(snapshot.longTasks.totalMs)}ms`,
     );
     if (recent) lines.push(`recent long tasks: ${recent}`);
+  }
+  if (snapshot.longTaskFrames?.length) {
+    lines.push("long task top frames (sampled):");
+    for (const frame of snapshot.longTaskFrames) lines.push(`  ${frame.samples}x ${frame.label}`);
   }
   if (snapshot.connection) {
     const parts = [
@@ -371,6 +443,69 @@ export function shouldRecordLongTaskSample(
   if (!focused) return false;
   if (visibilityHidden) return false;
   return durationMs >= 50 && startMs >= graceUntilMs && startMs - visibleSinceMs >= VISIBILITY_RESUME_GRACE_MS;
+}
+
+export function shouldPromptForLongTasks(summary: { count: number; totalMs: number; maxMs: number }): boolean {
+  return summary.maxMs >= LONG_TASK_PROMPT_MS || (summary.count >= 3 && summary.totalMs >= LONG_TASK_TOTAL_PROMPT_MS);
+}
+
+type TaskAttributionLike = {
+  containerType?: string;
+  containerName?: string;
+  containerId?: string;
+  containerSrc?: string;
+};
+
+// Longtask entries carry no stacks, only a culprit descriptor ("self", "same-origin",
+// iframe container, ...). "self" and "unknown" are the expected no-signal cases, so
+// only anomalies (cross-context culprits, named containers) make it into the report.
+export function formatLongTaskAttribution(entryName?: string, attribution?: TaskAttributionLike[]): string {
+  const parts: string[] = [];
+  if (entryName && entryName !== "unknown" && entryName !== "self") parts.push(entryName);
+  const culprit = attribution?.[0];
+  if (culprit) {
+    const container = culprit.containerName || culprit.containerId || culprit.containerSrc || "";
+    const containerType = culprit.containerType && culprit.containerType !== "window" ? culprit.containerType : "";
+    const detail = [containerType, container].filter(Boolean).join(":");
+    if (detail) parts.push(detail);
+  }
+  return parts.join(" ");
+}
+
+// Self-time view of a self-profiling trace: count each sample that landed inside a
+// long-task window against its leaf frame, so the report names the code that was
+// actually on-CPU while the UI was blocked.
+export function aggregateLongTaskProfile(
+  trace: ProfilerTrace,
+  windows: { startMs: number; durationMs: number }[],
+  maxFrames = 8,
+): { label: string; samples: number }[] {
+  if (!windows.length) return [];
+  const counts = new Map<number, number>();
+  for (const sample of trace.samples ?? []) {
+    if (sample.stackId === undefined) continue;
+    const inWindow = windows.some(
+      (w) => sample.timestamp >= w.startMs && sample.timestamp <= w.startMs + w.durationMs,
+    );
+    if (!inWindow) continue;
+    const stack = trace.stacks?.[sample.stackId];
+    if (!stack) continue;
+    counts.set(stack.frameId, (counts.get(stack.frameId) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxFrames)
+    .map(([frameId, samples]) => ({ label: formatProfilerFrame(trace, frameId), samples }));
+}
+
+function formatProfilerFrame(trace: ProfilerTrace, frameId: number): string {
+  const frame = trace.frames?.[frameId];
+  if (!frame) return `frame#${frameId}`;
+  const name = frame.name || "(anonymous)";
+  const resource = frame.resourceId !== undefined ? trace.resources?.[frame.resourceId] : undefined;
+  if (!resource) return name;
+  const line = frame.line !== undefined ? `:${frame.line}${frame.column !== undefined ? `:${frame.column}` : ""}` : "";
+  return `${name} (${resource}${line})`;
 }
 
 export function shouldRecordEventLoopLagSample(
@@ -614,7 +749,21 @@ function promptPerformanceReport(reason: string, currentLagMs = 0): void {
   lastPerformancePromptAt = now;
   addBreadcrumb("performance", reason);
   const snapshot = performanceSnapshot(reason, currentLagMs);
-  paintPerformancePrompt(buildPerformancePayload(snapshot), snapshot);
+  if (!activeProfiler) {
+    paintPerformancePrompt(buildPerformancePayload(snapshot), snapshot);
+    return;
+  }
+  // Attribute samples to the blocked spans: every recorded long task, plus the lag
+  // spike itself for event-loop reports (profiler timestamps share performance.now()'s origin).
+  const windows = [...longTasks];
+  if (currentLagMs > 0) {
+    const nowMs = performance.now();
+    windows.push({ startMs: Math.max(0, nowMs - currentLagMs), durationMs: currentLagMs });
+  }
+  void collectLongTaskFrames(windows).then((frames) => {
+    if (frames.length) snapshot.longTaskFrames = frames;
+    paintPerformancePrompt(buildPerformancePayload(snapshot), snapshot);
+  });
 }
 
 function maybePromptForHeapPressure(): void {
@@ -642,10 +791,12 @@ export function installPerformancePressureMonitor() {
     if (!pastGrace()) return;
     const summary = longTaskSummary();
     if (!summary) return;
-    if (summary.maxMs >= LONG_TASK_PROMPT_MS || (summary.count >= 3 && summary.totalMs >= LONG_TASK_TOTAL_PROMPT_MS)) {
+    if (shouldPromptForLongTasks(summary)) {
       promptPerformanceReport(`long task ${fmtNumber(summary.maxMs)}ms`);
     }
   };
+
+  startLongTaskProfiler();
 
   if (typeof document !== "undefined") {
     document.addEventListener("visibilitychange", () => {
@@ -662,7 +813,15 @@ export function installPerformancePressureMonitor() {
       const observer = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
           if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil, isHidden(), visibleSince, isFocused())) continue;
-          longTasks.push({ startMs: Math.round(entry.startTime), durationMs: Math.round(entry.duration) });
+          const attribution = formatLongTaskAttribution(
+            entry.name,
+            (entry as PerformanceEntry & { attribution?: TaskAttributionLike[] }).attribution,
+          );
+          longTasks.push({
+            startMs: Math.round(entry.startTime),
+            durationMs: Math.round(entry.duration),
+            ...(attribution ? { attribution } : {}),
+          });
         }
         pruneLongTasks();
         inspectLongTasks();

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2292,7 +2292,7 @@ export const en = {
   "crash.privacyNote": "The report contains only the error text above (user names in paths removed) plus app version and OS.",
   "performanceReport.title": "Reasonix noticed a responsiveness issue",
   "performanceReport.dismiss": "Dismiss",
-  "performanceReport.privacyNote": "Before upload, the desktop scrubber removes paths and secrets. The diagnostic is intended to contain timing, memory, network state, recent breadcrumbs, app version, and OS.",
+  "performanceReport.privacyNote": "Before upload, the desktop scrubber removes paths and secrets. The diagnostic is intended to contain timing, memory, network state, sampled app function names, recent breadcrumbs, app version, and OS.",
 
   // mock / demo seed data (browser dev only)
   "mock.sessionFixLogin": "fix the login bug in auth.go",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2345,6 +2345,6 @@ export const zhTW: Record<DictKey, string> = {
   "crash.privacyNote": "報告僅包含上方錯誤文字（路徑中的使用者名稱已移除）以及應用版本和作業系統。",
   "performanceReport.title": "Reasonix 偵測到回應卡頓",
   "performanceReport.dismiss": "關閉",
-  "performanceReport.privacyNote": "上傳前桌面端會移除路徑與密鑰；診斷資訊只用於記錄耗時、記憶體、網路狀態、近期 breadcrumbs、應用版本和作業系統。",
+  "performanceReport.privacyNote": "上傳前桌面端會移除路徑與密鑰；診斷資訊只用於記錄耗時、記憶體、網路狀態、取樣到的應用函式名、近期 breadcrumbs、應用版本和作業系統。",
   "mock.topicSysException": "異常處理與恢復演練",
 };

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2294,7 +2294,7 @@ export const zh: Record<DictKey, string> = {
   "crash.privacyNote": "报告仅包含上方错误文本（路径中的用户名已移除）以及应用版本和操作系统。",
   "performanceReport.title": "Reasonix 检测到响应卡顿",
   "performanceReport.dismiss": "关闭",
-  "performanceReport.privacyNote": "上传前桌面端会移除路径与密钥；诊断信息只用于记录耗时、内存、网络状态、近期 breadcrumbs、应用版本和操作系统。",
+  "performanceReport.privacyNote": "上传前桌面端会移除路径与密钥；诊断信息只用于记录耗时、内存、网络状态、采样到的应用函数名、近期 breadcrumbs、应用版本和操作系统。",
 
   // 模拟/演示种子数据（仅浏览器开发模式）
   "mock.sessionFixLogin": "fix the login bug in auth.go",

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -140,7 +140,7 @@ func main() {
 		MinHeight: 480,
 		// Match the dark UI shell so the initial webview background doesn't flash
 		// white before CSS loads — particularly visible on WebKitGTK.
-		BackgroundColour:   &options.RGBA{R: 26, G: 26, B: 46, A: 255},
+		BackgroundColour: &options.RGBA{R: 26, G: 26, B: 46, A: 255},
 		AssetServer: &assetserver.Options{
 			Assets:     assets,
 			Middleware: assetserver.ChainMiddleware(app.jsProfilingMiddleware(), app.workspaceMediaMiddleware()),

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -141,7 +141,10 @@ func main() {
 		// Match the dark UI shell so the initial webview background doesn't flash
 		// white before CSS loads — particularly visible on WebKitGTK.
 		BackgroundColour:   &options.RGBA{R: 26, G: 26, B: 46, A: 255},
-		AssetServer:        &assetserver.Options{Assets: assets, Middleware: app.workspaceMediaMiddleware()},
+		AssetServer: &assetserver.Options{
+			Assets:     assets,
+			Middleware: assetserver.ChainMiddleware(app.jsProfilingMiddleware(), app.workspaceMediaMiddleware()),
+		},
 		OnStartup:          app.startup,
 		OnDomReady:         app.domReady,
 		OnBeforeClose:      app.beforeClose,


### PR DESCRIPTION
## Problem

Performance-pressure diagnostics dominate crash triage volume (~18k reports over 30 days across `performance.longtask` / `performance.lag` / `performance.heap`, versus 400 for the highest-volume real crash group), yet none of them carry a stack — `longtask` PerformanceObserver entries have no attribution beyond a culprit descriptor, so the reports are unactionable. Separately, the cumulative long-task rule (`>=3 tasks && >=1.5s total per 60s`) fires on routine streaming-render bursts (e.g. 16 tasks of 70–240ms), which is a large part of that volume.

## Changes

**Attribution (frontend + Go asset server)**
- Run a rolling JS Self-Profiling sampler (10ms interval, 60s buffer) while the performance monitor is installed. When a performance prompt fires, stop the profiler, keep only samples that landed inside recorded long-task windows (plus the lag spike window itself for event-loop reports), aggregate leaf frames by self-time, and append a `long task top frames (sampled)` section to the report, e.g. `42x post (wails://wails/assets/vendor-markdown.js:1:130216)`.
- Serve `Document-Policy: js-profiling` from the Wails asset server (`jsProfilingMiddleware`, chained before the workspace-media middleware). Chromium WebViews (WebView2 — the dominant platform for these reports) honor it; WebKit ignores both the header and the API, so macOS/Linux keep today's report shape.
- Record `longtask` culprit attribution on each sample, but only surface anomalies (cross-context culprits / named containers); `self`/`window` carries no signal and is omitted.
- The report privacy note now mentions sampled app function names (en / zh / zh-TW).

**Denoise**
- Raise the cumulative long-task prompt budget from 1.5s to 3s per 60s window (single-task threshold stays 800ms). The trigger is extracted as `shouldPromptForLongTasks` with direct test coverage.

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| `CrashPayload` (`schemaVersion: 2`) | Unchanged fields; new content is additive lines inside the freeform `message` string | Safe — server/message consumers see the same schema |
| `PerformanceSnapshot` | In-memory only, never persisted; new optional fields (`attribution`, `longTaskFrames`) | Safe |
| `localStorage` `reasonix:perf-reported` | Format untouched | Safe |
| Asset responses | New `Document-Policy` header; WebKit/older WebViews ignore unknown policies | Safe |
| Profiler API absent (WebKit, older WebView2) | `startLongTaskProfiler` no-ops / catches, prompt path falls back to the synchronous unattributed report | Safe |

## Verification

- `tsx src/__tests__/crash-reporting.test.ts` — 60 passed, 0 failed (new coverage: threshold boundaries incl. the 16×~100ms streaming burst staying silent, attribution formatting, trace aggregation windowing/capping, report context formatting)
- `pnpm test` (full frontend suite) — pass
- `tsc --noEmit -p tsconfig.test.json` — pass
- `cd desktop && go build ./... && go test .` — pass (rebased onto latest `main-v2`, which also touched `app.go` and the locale files)

Follow-up (separate PR): the sampled data is expected to confirm full-document markdown re-parse per streaming frame as the dominant long-task source; block-level memoization of completed markdown blocks is the planned fix.