### PR TITLE
Harden delivery-mode review protocol, gating, and streaming liveness / 加固交付模式 review 协议、门槛判定与流式活性

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3839,6 +3839,7 @@ export default function App() {
               turnWaitAccumMs={state.turnWaitAccumMs}
               promptWaitStartedAt={state.promptWaitStartedAt}
               turnTokens={state.turnTokens}
+              turnArgChars={state.turnArgChars}
               retry={state.retry}
               suspendedByDecision={Boolean(decisionSurface)}
               transientDismissSignal={transientOverlayDismissSignal}
@@ -3954,6 +3955,7 @@ export default function App() {
                   balance={state.balance}
                   sessionGen={state.sessionGen}
                   refreshKey={dockRefreshKey}
+                  usageSeq={state.usageSeq}
                 />
               ) : (
                 <WorkspacePanel

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -1,0 +1,81 @@
+// Run: tsx src/__tests__/use-controller-stream-progress.test.ts
+//
+// Covers the delivery-mode liveness fixes:
+// 1. Partial tool dispatches upsert a running card (instead of being dropped)
+//    and carry streaming argChars progress.
+// 2. usageSeq bumps on every usage event regardless of source, so the right
+//    panel keeps refreshing during sub-agent runs.
+// 3. A mid-turn context snapshot reporting used=0 does not collapse a gauge
+//    that already shows real usage.
+
+import { initialState, reducer } from "../lib/useController";
+import type { WireEvent } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+function ev(s: typeof initialState, e: WireEvent) {
+  return reducer(s, { type: "event", e });
+}
+
+// --- 1. partial dispatch upserts a running card with argChars ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "write_file", readOnly: false, partial: true } } as WireEvent);
+  const card = s.items.find((it) => it.kind === "tool" && it.id === "c1");
+  eq(Boolean(card), true, "partial dispatch creates a running tool card");
+  eq(card?.kind === "tool" ? card.status : "", "running", "partial card is running");
+  eq(card?.kind === "tool" ? card.args : "x", "", "partial card has no args yet");
+
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "write_file", readOnly: false, partial: true, argChars: 8192 } } as WireEvent);
+  const card2 = s.items.find((it) => it.kind === "tool" && it.id === "c1");
+  eq(card2?.kind === "tool" ? card2.argChars : 0, 8192, "arg progress updates the card");
+  eq(s.turnArgChars, 8192, "turnArgChars mirrors streaming progress");
+
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "write_file", args: '{"path":"a"}', readOnly: false } } as WireEvent);
+  const card3 = s.items.find((it) => it.kind === "tool" && it.id === "c1");
+  eq(card3?.kind === "tool" ? card3.args : "", '{"path":"a"}', "full dispatch merges args into the same card");
+  eq(card3?.kind === "tool" ? card3.argChars : 1, undefined, "full dispatch clears argChars");
+  eq(
+    s.items.filter((it) => it.kind === "tool" && it.id === "c1").length,
+    1,
+    "partial + full dispatch never duplicate the card",
+  );
+
+  s = ev(s, { kind: "usage", usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150, cacheHitTokens: 0, cacheMissTokens: 0 } } as WireEvent);
+  eq(s.turnArgChars, 0, "usage event resets the streaming estimate");
+}
+
+// --- 2. usageSeq bumps for every source ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  s = ev(s, { kind: "usage", usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15, cacheHitTokens: 0, cacheMissTokens: 0 } } as WireEvent);
+  eq(s.usageSeq, 1, "executor usage bumps usageSeq");
+  s = ev(s, { kind: "usage", usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15, cacheHitTokens: 0, cacheMissTokens: 0, source: "subagent" } } as WireEvent);
+  eq(s.usageSeq, 2, "subagent usage bumps usageSeq");
+  eq(s.usage?.source ?? "", "", "subagent usage does not replace executor gauge usage");
+}
+
+// --- 3. context no-regress guard while a turn runs ---
+{
+  let s = { ...initialState, running: true, turnActive: true, context: { used: 14000, window: 1000000, sessionTokens: 20000 } };
+  s = reducer(s, { type: "context", context: { used: 0, window: 1000000, sessionTokens: 20000 } } as never);
+  eq(s.context.used, 14000, "mid-turn used=0 snapshot keeps last known fill");
+
+  let idle = { ...initialState, context: { used: 14000, window: 1000000, sessionTokens: 20000 } };
+  idle = reducer(idle, { type: "context", context: { used: 0, window: 1000000, sessionTokens: 0 } } as never);
+  eq(idle.context.used, 0, "idle used=0 snapshot applies (genuine reset)");
+}
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -56,6 +56,21 @@ function ev(s: typeof initialState, e: WireEvent) {
   eq(s.turnArgChars, 0, "usage event resets the streaming estimate");
 }
 
+// --- 1b. partial dispatch without an ID never creates an orphan card ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  // OpenAI-compatible streams can surface the name before the call ID.
+  s = ev(s, { kind: "tool_dispatch", tool: { name: "write_file", readOnly: false, partial: true, argChars: 2048 } } as WireEvent);
+  eq(s.items.filter((it) => it.kind === "tool").length, 0, "id-less partial creates no card");
+  eq(s.turnArgChars, 2048, "id-less partial still counts streaming progress");
+
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "write_file", readOnly: false, partial: true, argChars: 4096 } } as WireEvent);
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "write_file", args: '{"path":"a"}', readOnly: false } } as WireEvent);
+  eq(s.items.filter((it) => it.kind === "tool").length, 1, "late ID yields exactly one card, no orphan");
+  const only = s.items.find((it) => it.kind === "tool");
+  eq(only?.kind === "tool" ? only.id : "", "c1", "surviving card carries the real call ID");
+}
+
 // --- 2. usageSeq bumps for every source ---
 {
   let s = { ...initialState, running: true, turnActive: true };

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -546,6 +546,7 @@ export function Composer({
   turnWaitAccumMs = 0,
   promptWaitStartedAt,
   turnTokens,
+  turnArgChars = 0,
   retry,
   suspendedByDecision = false,
   pendingApprovalLabel,
@@ -606,6 +607,10 @@ export function Composer({
   turnWaitAccumMs?: number;
   promptWaitStartedAt?: number;
   turnTokens?: number;
+  // Streaming tool-call argument chars (no usage event yet) — folded into the
+  // pill as an estimated-token tail so a long write_file body reads as
+  // progress, not a stall.
+  turnArgChars?: number;
   retry?: { attempt: number; max: number };
   // True while a footer decision surface (approval / ask / clear context) owns
   // the UI. Pauses the model-work ticker without rendering a "waiting approval"
@@ -2895,7 +2900,8 @@ export function Composer({
         const elapsedMs = Math.max(0, now - turnStartAt - waitAccumMs);
         const words = SPINNER_WORDS[locale];
         const word = words[Math.floor(elapsedMs / 3000) % words.length];
-        const tok = turnTokens && turnTokens > 0 ? ` · ↓ ${fmtTokens(turnTokens)} ${t("status.tokens")}` : "";
+        const liveTokens = (turnTokens ?? 0) + Math.round((turnArgChars ?? 0) / 4);
+        const tok = liveTokens > 0 ? ` · ↓ ${fmtTokens(liveTokens)} ${t("status.tokens")}` : "";
         return `${word}… ${fmtElapsed(elapsedMs)}${tok}`;
       })()
     : null;

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -21,6 +21,10 @@ interface ContextPanelProps {
   balance?: BalanceInfo;
   sessionGen?: number;
   refreshKey?: number;
+  // Monotonic counter bumped by EVERY usage event (executor and subagent).
+  // The executor-gated `usage` prop freezes during sub-agent runs, which used
+  // to pin 会话指标/用量分析 for minutes; this keeps the snapshot ticking.
+  usageSeq?: number;
 }
 
 function fmtFullTokens(n: number): string {
@@ -314,6 +318,7 @@ export function ContextPanel({
   balance,
   sessionGen,
   refreshKey,
+  usageSeq,
 }: ContextPanelProps) {
   const { locale, t } = useI18n();
   const [info, setInfo] = useState<ContextPanelInfo | null>(null);
@@ -345,16 +350,18 @@ export function ContextPanel({
     void refresh();
   }, [refresh, refreshKey]);
 
-  // Refresh the panel snapshot while usage events stream. The key includes
-  // general token fields so providers without cache telemetry still tick.
+  // Refresh the panel snapshot while usage events stream — from any source:
+  // usageSeq covers sub-agent/title requests the executor-gated usage prop
+  // never reflects, and usageRefreshKey keeps ticking for providers whose
+  // events lack a seq. Throttled to once per second.
   useEffect(() => {
-    if (!usageRefreshKey) return;
+    if (!usageRefreshKey && !usageSeq) return;
     const now = Date.now();
     if (now - lastRefreshTime.current >= 1000) {
       lastRefreshTime.current = now;
       void refresh();
     }
-  }, [usageRefreshKey, refresh]);
+  }, [usageRefreshKey, usageSeq, refresh]);
 
   const usedTokens = context?.used && context.used > 0 ? context.used : info?.usedTokens ?? 0;
   const windowTokens = context?.window && context.window > 0 ? context.window : info?.windowTokens ?? 0;

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -32,6 +32,11 @@ function formatToolDuration(ms?: number): string {
   return `${Math.round(ms)} ms`;
 }
 
+function formatArgChars(chars: number): string {
+  if (chars >= 1000) return `${(chars / 1000).toFixed(1)}k`;
+  return String(chars);
+}
+
 function normalizeErrorText(text: string): string {
   return text.replace(/\r\n/g, "\n").trim();
 }
@@ -153,7 +158,13 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
     item.readOnly && !hasNested && item.status !== "error" && item.status !== "stopped";
 
   const duration = item.status === "running" ? "" : formatToolDuration(item.durationMs);
-  const summary = item.status === "running" ? "" : item.summary || summarizeFileDiff(item.fileDiff) || (item.error ? errorSummary : archivedWithoutFullData ? "" : summarize(item.name, effectiveArgs, displayOutput, item.error));
+  // While the model is still streaming this call's arguments (partial
+  // dispatch), show the received volume as the live subject so a long
+  // write_file body reads as progress instead of a silent stall.
+  const streamingArgs = item.status === "running" && !item.args && (item.argChars ?? 0) > 0
+    ? t("tool.receivingArgs", { chars: formatArgChars(item.argChars ?? 0) })
+    : "";
+  const summary = item.status === "running" ? streamingArgs : item.summary || summarizeFileDiff(item.fileDiff) || (item.error ? errorSummary : archivedWithoutFullData ? "" : summarize(item.name, effectiveArgs, displayOutput, item.error));
 
   // GSAP-driven collapse/expand for tool body
   const toolBodyRef = useRef<HTMLDivElement>(null);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface WireTool {
   truncated?: boolean;
   durationMs?: number;
   partial?: boolean; // an early dispatch (name only) — a full one with args follows
+  argChars?: number; // partial only: cumulative argument chars streamed so far
   parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
   diff?: string;
   added?: number;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -88,6 +88,7 @@ export type Item =
       isShell?: boolean; // true for !-prefix shell commands (controls default expand)
       parentId?: string; // a sub-agent call nests under the `task` call with this id
       profile?: { model?: string; effort?: string }; // subagent model/effort from tool event
+      argChars?: number; // args still streaming from the model: cumulative chars received
     };
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
@@ -143,12 +144,21 @@ interface State {
   turnTokens: number;
   turnTotalTokens: number;
   turnCost: number;
+  // Cumulative argument characters of the tool call currently streaming its
+  // args (partial dispatch progress). Folded into the composer pill as an
+  // estimated-token tail; cleared when the round's usage arrives (which then
+  // includes those tokens for real) and on turn start.
+  turnArgChars: number;
   sessionTokens: number;
   sessionCost: number;
   sessionCurrency: string;
   retry?: { attempt: number; max: number };
   seq: number;
   sessionGen: number;
+  // Monotonic count of usage events from ANY source (executor, subagent,
+  // title…). Drives right-panel snapshot refreshes so sub-agent activity keeps
+  // the session metrics live; state.usage stays executor-gated for the gauge.
+  usageSeq: number;
 }
 
 export const initialState: State = {
@@ -173,11 +183,13 @@ export const initialState: State = {
   turnTokens: 0,
   turnTotalTokens: 0,
   turnCost: 0,
+  turnArgChars: 0,
   sessionTokens: 0,
   sessionCost: 0,
   sessionCurrency: "¥",
   seq: 0,
   sessionGen: 0,
+  usageSeq: 0,
 };
 
 function usageTotalTokens(usage?: WireUsage): number {
@@ -646,7 +658,7 @@ function endPromptWaitIfIdle(s: State, now = Date.now()): State {
   return endPromptWait(s, now);
 }
 
-function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnWaitAccumMs" | "promptWaitStartedAt" | "turnTokens" | "turnTotalTokens" | "turnCost"> {
+function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnWaitAccumMs" | "promptWaitStartedAt" | "turnTokens" | "turnTotalTokens" | "turnCost" | "turnArgChars"> {
   return {
     turnStartAt: now,
     turnWaitAccumMs: 0,
@@ -654,6 +666,7 @@ function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnWai
     turnTokens: 0,
     turnTotalTokens: 0,
     turnCost: 0,
+    turnArgChars: 0,
   };
 }
 
@@ -769,11 +782,31 @@ function applyEvent(s: State, e: WireEvent): State {
     case "tool_dispatch": {
       const t = e.tool;
       if (!t) return s;
-      // Skip partial dispatches (name-only, no args yet) — the full dispatch
-      // with complete args follows from executeBatch. Waiting for the full
-      // dispatch means the tool card appears with name + subject at once,
-      // avoiding a "name → command" visual jump.
-      if (t.partial) return s;
+      // A partial dispatch (args still streaming from the model) upserts a
+      // lightweight "receiving" card immediately. Dropping it entirely — the
+      // old behavior — left a 30KB write_file body streaming for a minute with
+      // zero visible activity, indistinguishable from a hang. The full
+      // dispatch that follows merges by ID and fills in args/summary.
+      if (t.partial) {
+        const id = t.id || `tool${s.seq}`;
+        const turnArgChars = t.argChars && t.argChars > 0 ? t.argChars : s.turnArgChars;
+        const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === id);
+        if (idx >= 0) {
+          const next = [...s.items];
+          const it = next[idx];
+          if (it.kind === "tool" && it.status === "running" && !it.args) {
+            next[idx] = { ...it, argChars: t.argChars || it.argChars };
+            return { ...s, items: next, turnArgChars };
+          }
+          return { ...s, turnArgChars };
+        }
+        return {
+          ...s,
+          turnArgChars,
+          seq: s.seq + 1,
+          items: [...s.items, { kind: "tool", id, name: t.name, args: "", readOnly: t.readOnly, status: "running", argChars: t.argChars || undefined, parentId: t.parentId }],
+        };
+      }
       const id = t.id || `tool${s.seq}`;
       const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === id);
       if (idx >= 0) {
@@ -783,7 +816,7 @@ function applyEvent(s: State, e: WireEvent): State {
           const args = t.args ? t.args : it.args;
           const fileDiff = fileDiffFromWire(t);
           const summary = summarizeFileDiff(fileDiff) || summarize(t.name, args) || (t.name === it.name && args === it.args ? it.summary : undefined);
-          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, profile: t.profile ?? it.profile, summary, fileDiff };
+          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, profile: t.profile ?? it.profile, summary, fileDiff, argChars: undefined };
         }
         return { ...s, items: next };
       }
@@ -846,7 +879,9 @@ function applyEvent(s: State, e: WireEvent): State {
       const sessionCost = s.sessionCost + usageCost;
       const sessionCurrency = e.usage?.currency || s.sessionCurrency || "¥";
       const usage = updateContextGauge ? e.usage : s.usage;
-      return { ...s, usage, context: { ...s.context, used, sessionTokens }, turnTokens, turnTotalTokens, turnCost, sessionTokens, sessionCost, sessionCurrency };
+      // The completed round's usage now accounts for the streamed tool-call
+      // arguments, so drop the live estimate rather than double-count it.
+      return { ...s, usage, context: { ...s.context, used, sessionTokens }, turnTokens, turnTotalTokens, turnCost, turnArgChars: 0, sessionTokens, sessionCost, sessionCurrency, usageSeq: s.usageSeq + 1 };
     }
     case "notice":
       return appendNoticeToState(s, e.level ?? "info", e.text ?? "", e.detail, e.code);
@@ -1088,7 +1123,17 @@ export function reducer(s: State, a: Action): State {
         ? a.context.sessionCost
         : s.sessionCost;
       const sessionCurrency = a.context.sessionCurrency || s.sessionCurrency;
-      return { ...s, context: a.context, sessionTokens, sessionCost, sessionCurrency };
+      // Mid-turn snapshot refreshes can race a rebuilt executor whose
+      // LastUsage is still nil: the backend then reports used=0 for a session
+      // that visibly holds tokens, and the gauge collapses to "0/1M" until the
+      // next executor usage arrives. Keep the last known fill while a turn is
+      // live; genuine resets flow through the "reset" action or land when the
+      // session is idle.
+      const context =
+        a.context.used === 0 && s.context.used > 0 && (s.running || s.turnActive) && a.context.window === s.context.window
+          ? { ...a.context, used: s.context.used }
+          : a.context;
+      return { ...s, context, sessionTokens, sessionCost, sessionCurrency };
     }
     case "balance": return { ...s, balance: a.balance };
     case "effort": return { ...s, effort: a.effort };

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -788,8 +788,14 @@ function applyEvent(s: State, e: WireEvent): State {
       // zero visible activity, indistinguishable from a hang. The full
       // dispatch that follows merges by ID and fills in args/summary.
       if (t.partial) {
-        const id = t.id || `tool${s.seq}`;
         const turnArgChars = t.argChars && t.argChars > 0 ? t.argChars : s.turnArgChars;
+        // Some OpenAI-compatible streams surface the call name before its ID.
+        // Without a stable ID the card could never be merged with the full
+        // dispatch (a synthetic `tool${seq}` id would orphan it as a forever-
+        // running duplicate), so count the progress but wait for the ID before
+        // creating the card.
+        if (!t.id) return { ...s, turnArgChars };
+        const id = t.id;
         const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === id);
         if (idx >= 0) {
           const next = [...s.items];

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2145,6 +2145,7 @@ export const en = {
   "tool.stepOne": "{n} step",
   "tool.stepOther": "{n} steps",
   "tool.error": "error",
+  "tool.receivingArgs": "receiving arguments ↓ {chars}…",
   "tool.errorReceiptMismatch": "verification command has no matching successful receipt",
   "tool.truncated": "output truncated",
   "tool.showAllLines": "show all {n} lines",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1410,6 +1410,7 @@ export const zhTW: Record<DictKey, string> = {
   "tool.stepOne": "{n} 步",
   "tool.stepOther": "{n} 步",
   "tool.error": "錯誤",
+  "tool.receivingArgs": "接收參數中 ↓ {chars}…",
   "tool.errorReceiptMismatch": "證據命令沒有匹配的成功執行記錄",
   "tool.truncated": "輸出已截斷",
   "tool.showAllLines": "顯示全部 {n} 行",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2147,6 +2147,7 @@ export const zh: Record<DictKey, string> = {
   "tool.stepOne": "{n} 步",
   "tool.stepOther": "{n} 步",
   "tool.error": "错误",
+  "tool.receivingArgs": "接收参数中 ↓ {chars}…",
   "tool.errorReceiptMismatch": "证据命令没有匹配的成功执行记录",
   "tool.truncated": "输出已截断",
   "tool.showAllLines": "显示全部 {n} 行",

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -380,5 +381,32 @@ func TestTopicTitleUserTurnsSeesEventLogTurns(t *testing.T) {
 	users := topicTitleUserTurnsFromSession(path)
 	if len(users) != 3 {
 		t.Fatalf("user turns = %d, want 3 (≥3-turn title upgrade depends on this)", len(users))
+	}
+}
+
+func TestTopicTitleUserTurnsSkipHostFraming(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := agent.NewSession("sys")
+	// Delivery-mode first turn: user text with the trailing runtime marker.
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "你是谁？\n\n<delivery-runtime>\nThis session is in delivery-first mode.\n</delivery-runtime>"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "reply"})
+	// Host-injected readiness nudge, persisted as role user.
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: x"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "reply"})
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "帮我写一个魂斗罗游戏"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	users := topicTitleUserTurnsFromSession(path)
+	if len(users) != 2 {
+		t.Fatalf("user turns = %d, want 2 (readiness nudge must not count)", len(users))
+	}
+	if users[0] != "你是谁？" {
+		t.Fatalf("first turn = %q, want the marker stripped", users[0])
+	}
+	if title := topicTitleFromText(users[0]); strings.Contains(title, "<delivery") || strings.Contains(title, "delivery-run") {
+		t.Fatalf("title = %q, delivery marker leaked", title)
 	}
 }

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -389,7 +389,9 @@ func TestTopicTitleUserTurnsSkipHostFraming(t *testing.T) {
 	path := filepath.Join(dir, "session.jsonl")
 	s := agent.NewSession("sys")
 	// Delivery-mode first turn: user text with the trailing runtime marker.
-	s.Add(provider.Message{Role: provider.RoleUser, Content: "你是谁？\n\n<delivery-runtime>\nThis session is in delivery-first mode.\n</delivery-runtime>"})
+	// Built from the exported constant — the preview strip is byte-exact, so a
+	// paraphrased marker would (correctly) not be stripped.
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "你是谁？\n\n" + agent.DeliveryRuntimeMarker})
 	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "reply"})
 	// Host-injected readiness nudge, persisted as role user.
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: x"})

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3724,6 +3724,13 @@ func topicTitleUserTurnsFromSession(path string) []string {
 	}
 	var users []string
 	for _, msg := range msgs {
+		// Host-injected synthetic turns (readiness nudges, recovery retries) and
+		// mid-turn steers are persisted as role "user" but are not user-authored:
+		// counting them inflated userTurns past the stage-3 threshold and let
+		// "Host final-answer readiness check failed…" become a topic title.
+		if !agent.IsUserAuthoredTurn(msg.Text) {
+			continue
+		}
 		content := control.StripComposePrefixes(agent.HandoffTask(msg.Text))
 		content = control.StripReferencedContextPrefix(content)
 		if strings.TrimSpace(content) != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -37,6 +38,13 @@ import (
 const maxToolOutputBytes = 32 * 1024
 
 const maxFinalReadinessBlocks = 3
+
+// maxFinalReadinessBlocksWithProgress is the hard cap on readiness retries when
+// the model keeps producing new host-observable receipts between blocks. A
+// converging turn (edit → verify → review still catching up to the latest
+// mutation) deserves more nudges than a stuck one; a turn that stalls with no
+// new receipts still fails at maxFinalReadinessBlocks.
+const maxFinalReadinessBlocksWithProgress = 6
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 3
 const maxExecutorHandoffNudges = 1
@@ -373,6 +381,12 @@ type Agent struct {
 	deliveryCriteriaEstablished bool
 	deliveryTaskExpected        bool
 	deliveryMutationExpected    bool
+
+	// preserveEvidenceOnce makes the next Run keep the turn evidence ledger
+	// instead of resetting it. RunSubAgentWithSession sets it before a
+	// review_report completion nudge so the retry can cite the read receipts
+	// the subagent already earned; consumed (cleared) by that Run.
+	preserveEvidenceOnce bool
 
 	// capabilityLedger tracks require/prefer outcomes for this user turn only.
 	// Never serialized into prompts or session state.
@@ -1174,12 +1188,20 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	a.steerConsumed = false
 	a.steerRunActive = true
 	a.steerMu.Unlock()
-	if a.evidence != nil {
+	if a.evidence != nil && !a.preserveEvidenceOnce {
 		a.evidence.Reset()
 	}
+	a.preserveEvidenceOnce = false
 	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria()
-	a.deliveryTaskExpected = deliveryTaskNeedsEvidence(rawInput)
-	a.deliveryMutationExpected = deliveryTaskNeedsMutation(rawInput)
+	// Classify delivery expectations from the user's task text only. Host
+	// framing (subagent/workspace context blocks, the delivery-runtime marker)
+	// contains incidental action verbs — "file tools resolve relative paths"
+	// once classified every workspace-wrapped subagent prompt as a mutation
+	// request and deadlocked read-only subagents on a state change they are
+	// not allowed to make.
+	classifierInput := classifierTaskText(rawInput)
+	a.deliveryTaskExpected = deliveryTaskNeedsEvidence(classifierInput)
+	a.deliveryMutationExpected = deliveryTaskNeedsMutation(classifierInput) && registryHasWriterTools(a.tools)
 	a.repeatSuccessCounts = nil
 	a.blockedTurnStreak = 0
 	a.loopGuardArmed = false
@@ -1238,6 +1260,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
 
 	finalReadinessBlocks := 0
+	readinessReceiptMark := -1
 	emptyFinalBlocks := 0
 	handoffNudges := 0
 	usedAnyTool := false
@@ -1317,9 +1340,20 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		if len(calls) == 0 {
 			readiness := a.finalReadinessCheck()
 			if readiness.reason != "" {
+				// A block only counts against the base budget when the model made
+				// no host-observable progress since the previous block. A turn that
+				// keeps earning receipts (fix → verify → review the newest edit) is
+				// converging and gets extra nudges up to the hard cap; a stalled
+				// turn still fails after maxFinalReadinessBlocks.
+				progressed := readinessReceiptMark >= 0 && a.evidence != nil && a.evidence.Len() > readinessReceiptMark
+				if a.evidence != nil {
+					readinessReceiptMark = a.evidence.Len()
+				}
 				finalReadinessBlocks++
+				exhausted := finalReadinessBlocks >= maxFinalReadinessBlocksWithProgress ||
+					(finalReadinessBlocks >= maxFinalReadinessBlocks && !progressed)
 				result := evidence.ReadinessBlocked
-				if finalReadinessBlocks >= maxFinalReadinessBlocks {
+				if exhausted {
 					result = evidence.ReadinessErrored
 					event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
 					return &FinalReadinessError{Attempts: finalReadinessBlocks, Reason: readiness.reason}
@@ -1700,6 +1734,46 @@ func (a *Agent) hasIncompleteCanonicalCriteria() bool {
 	a.todoMu.Lock()
 	defer a.todoMu.Unlock()
 	return len(a.todoState) > 0 && len(evidence.IncompleteTodos(a.todoState)) > 0
+}
+
+// reClassifierHostBlock matches the host-generated framing blocks prepended to
+// sub-agent prompts (subagent start context, workspace context). They are
+// transport framing, not task text, and must not feed intent classification.
+var reClassifierHostBlock = regexp.MustCompile(`^\s*<(subagent-context|workspace-context)\b[^>]*>[\s\S]*?</(subagent-context|workspace-context)>\s*`)
+
+// classifierTaskText reduces a raw Run input to the task text the delivery
+// classifiers should judge: leading transient/user-preference blocks, host
+// subagent framing blocks, and the trailing delivery-runtime marker are all
+// host transport, not user intent.
+func classifierTaskText(input string) string {
+	s := StripTransientUserBlocks(input)
+	for {
+		next := reClassifierHostBlock.ReplaceAllString(s, "")
+		if next == s {
+			break
+		}
+		s = next
+	}
+	if trimmed, cut := strings.CutSuffix(strings.TrimSpace(s), deliveryRuntimeMarker); cut {
+		s = trimmed
+	}
+	return strings.TrimSpace(s)
+}
+
+// registryHasWriterTools reports whether any registered tool can mutate state.
+// A strictly read-only registry (read_only_task / read_only_skill subagents)
+// can never satisfy a "state change required" delivery expectation, so that
+// expectation must not be armed for it.
+func registryHasWriterTools(reg *tool.Registry) bool {
+	if reg == nil {
+		return false
+	}
+	for _, name := range reg.Names() {
+		if t, ok := reg.Get(name); ok && !t.ReadOnly() {
+			return true
+		}
+	}
+	return false
 }
 
 func deliveryTaskNeedsEvidence(input string) bool {
@@ -2098,6 +2172,7 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 	var calls []provider.ToolCall
 	var usage *provider.Usage
 	var partialToolStarted bool
+	var lastArgProgress time.Time
 	finishReasoning := func() (stored, display string) {
 		original := reasoning.String()
 		display = original
@@ -2159,6 +2234,18 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 			if tc := chunk.ToolCall; tc != nil {
 				a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
 					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true,
+				}})
+			}
+		case provider.ChunkToolCallArgsDelta:
+			partialToolStarted = true
+			// Liveness ticks while a large argument payload streams: re-emit the
+			// partial dispatch with the cumulative size (time-throttled) so the
+			// UI can show progress instead of a dead counter for the duration of
+			// a 30KB write_file body.
+			if tc := chunk.ToolCall; tc != nil && time.Since(lastArgProgress) >= 250*time.Millisecond {
+				lastArgProgress = time.Now()
+				a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true, ArgChars: chunk.ArgChars,
 				}})
 			}
 		case provider.ChunkToolCall:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -50,7 +50,12 @@ const maxExecutorHandoffNudges = 1
 const memoryCompilerInjectionMax = 5
 const memoryCompilerInjectionCooldown = 30 * time.Second
 
-const deliveryRuntimeMarker = `<delivery-runtime>
+// DeliveryRuntimeMarker is the delivery-mode contract block appended to user
+// turns (withTurnPreferences). Exported as the single source of truth for the
+// byte-exact suffix strip in preview derivation and for cross-package tests;
+// its text is cache-frozen — changing it breaks steer replay matching and the
+// prefix stability of every live delivery session.
+const DeliveryRuntimeMarker = `<delivery-runtime>
 This session is in delivery-first mode. Before any state-changing tool call,
 establish concrete, verifiable acceptance criteria with todo_write. After the
 change, inspect the result, run relevant verification, and sign off each step
@@ -758,7 +763,7 @@ func (a *Agent) withTurnPreferences(input string) string {
 	}
 	input = WithReasoningLanguage(input, lang)
 	if a.deliveryProfile && !strings.Contains(input, "<delivery-runtime>") {
-		input = strings.TrimSpace(input) + "\n\n" + deliveryRuntimeMarker
+		input = strings.TrimSpace(input) + "\n\n" + DeliveryRuntimeMarker
 	}
 	return input
 }
@@ -856,7 +861,7 @@ func SteerText(content string) (string, bool) {
 		if after, found := strings.CutPrefix(s, MidTurnSteerPrefix); found {
 			// Strip only the "\n" separator, preserving the user's original text.
 			after = strings.TrimPrefix(after, "\n")
-			if trimmed, cut := strings.CutSuffix(after, "\n\n"+deliveryRuntimeMarker); cut {
+			if trimmed, cut := strings.CutSuffix(after, "\n\n"+DeliveryRuntimeMarker); cut {
 				after = trimmed
 			}
 			return after, true

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -381,6 +380,11 @@ type Agent struct {
 	deliveryCriteriaEstablished bool
 	deliveryTaskExpected        bool
 	deliveryMutationExpected    bool
+
+	// classifierTaskText is the host-trusted task text for delivery intent
+	// classification, set by sub-agent spawners whose Run input carries host
+	// framing. Empty means classify the raw input verbatim.
+	classifierTaskText string
 
 	// preserveEvidenceOnce makes the next Run keep the turn evidence ledger
 	// instead of resetting it. RunSubAgentWithSession sets it before a
@@ -1006,6 +1010,13 @@ type Options struct {
 	// final answer. It changes host control flow, not tool schemas.
 	DeliveryProfile bool
 
+	// ClassifierTaskText, when non-empty, is the pristine task text delivery
+	// intent classification should judge instead of the raw Run input. Sub-agent
+	// spawners set it before prepending host framing (subagent/workspace context,
+	// review contracts) so framing verbs cannot arm expectations and user input
+	// dressed up as framing cannot disarm them.
+	ClassifierTaskText string
+
 	// CapabilityLedger is the optional turn-scoped capability route ledger for
 	// Delivery require/prefer gates. Nil disables capability gates.
 	CapabilityLedger *capability.Ledger
@@ -1129,6 +1140,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		evidence:                 evidence.NewLedger(),
 		projectChecks:            append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		deliveryProfile:          opts.DeliveryProfile,
+		classifierTaskText:       opts.ClassifierTaskText,
 		capabilityLedger:         opts.CapabilityLedger,
 		capabilityAudit:          opts.CapabilityAudit,
 		contextWindow:            opts.ContextWindow,
@@ -1193,13 +1205,18 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	}
 	a.preserveEvidenceOnce = false
 	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria()
-	// Classify delivery expectations from the user's task text only. Host
-	// framing (subagent/workspace context blocks, the delivery-runtime marker)
-	// contains incidental action verbs — "file tools resolve relative paths"
-	// once classified every workspace-wrapped subagent prompt as a mutation
-	// request and deadlocked read-only subagents on a state change they are
-	// not allowed to make.
-	classifierInput := classifierTaskText(rawInput)
+	// Classify delivery expectations from the task text. Sub-agent spawners
+	// pass the pristine task through Options.ClassifierTaskText (a trusted
+	// host channel) because their Run input carries host framing whose
+	// incidental verbs — "file tools resolve relative paths" — once classified
+	// every workspace-wrapped subagent prompt as a mutation request and
+	// deadlocked read-only subagents. Without the override the raw input is
+	// classified verbatim: stripping user-controllable markup here would let
+	// input dressed up as host framing disarm the delivery gates.
+	classifierInput := a.classifierTaskText
+	if strings.TrimSpace(classifierInput) == "" {
+		classifierInput = rawInput
+	}
 	a.deliveryTaskExpected = deliveryTaskNeedsEvidence(classifierInput)
 	a.deliveryMutationExpected = deliveryTaskNeedsMutation(classifierInput) && registryHasWriterTools(a.tools)
 	a.repeatSuccessCounts = nil
@@ -1734,30 +1751,6 @@ func (a *Agent) hasIncompleteCanonicalCriteria() bool {
 	a.todoMu.Lock()
 	defer a.todoMu.Unlock()
 	return len(a.todoState) > 0 && len(evidence.IncompleteTodos(a.todoState)) > 0
-}
-
-// reClassifierHostBlock matches the host-generated framing blocks prepended to
-// sub-agent prompts (subagent start context, workspace context). They are
-// transport framing, not task text, and must not feed intent classification.
-var reClassifierHostBlock = regexp.MustCompile(`^\s*<(subagent-context|workspace-context)\b[^>]*>[\s\S]*?</(subagent-context|workspace-context)>\s*`)
-
-// classifierTaskText reduces a raw Run input to the task text the delivery
-// classifiers should judge: leading transient/user-preference blocks, host
-// subagent framing blocks, and the trailing delivery-runtime marker are all
-// host transport, not user intent.
-func classifierTaskText(input string) string {
-	s := StripTransientUserBlocks(input)
-	for {
-		next := reClassifierHostBlock.ReplaceAllString(s, "")
-		if next == s {
-			break
-		}
-		s = next
-	}
-	if trimmed, cut := strings.CutSuffix(strings.TrimSpace(s), deliveryRuntimeMarker); cut {
-		s = trimmed
-	}
-	return strings.TrimSpace(s)
 }
 
 // registryHasWriterTools reports whether any registered tool can mutate state.

--- a/internal/agent/capability_gate.go
+++ b/internal/agent/capability_gate.go
@@ -219,7 +219,7 @@ func (a *Agent) deliveryReviewGateFailure() string {
 			return "structured review reported blocking findings; fix them and re-run review"
 		}
 		if !ok {
-			return "medium-risk changes require a successful review (run the review skill and submit review_report) after the latest mutation" + reviewCoverageHint(paths)
+			return "medium-risk changes require a successful review after the latest mutation (run the review skill; its subagent submits review_report)" + reviewCoverageHint(paths)
 		}
 		if report != nil {
 			a.pendingReviewWarnings = append(a.pendingReviewWarnings, report.WarningSummaries()...)

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// fakeReadFileTool is a minimal read-only tool whose successful calls produce
+// Read receipts with an extractable path, like the real read_file.
+type fakeReadFileTool struct{}
+
+func (fakeReadFileTool) Name() string            { return "read_file" }
+func (fakeReadFileTool) Description() string     { return "fake read" }
+func (fakeReadFileTool) ReadOnly() bool          { return true }
+func (fakeReadFileTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (fakeReadFileTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "contents", nil
+}
+
+// fakeWriterTool is registered (never called) so a registry counts as
+// writer-capable for delivery mutation expectations.
+type fakeWriterTool struct{}
+
+func (fakeWriterTool) Name() string            { return "fake_write" }
+func (fakeWriterTool) Description() string     { return "fake write" }
+func (fakeWriterTool) ReadOnly() bool          { return false }
+func (fakeWriterTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (fakeWriterTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "wrote", nil
+}
+
+// legacyWorkspaceContext reproduces the pre-fix host framing whose incidental
+// "resolve" classified every wrapped subagent prompt as a mutation request.
+const legacyWorkspaceContext = `<workspace-context event="SubagentWorkspace">
+Current workspace: "/w"
+File tools resolve relative paths against this workspace. For project inspection, prefer "." or relative paths unless the user explicitly named another absolute path.
+</workspace-context>`
+
+func TestClassifierTaskTextStripsHostFraming(t *testing.T) {
+	reviewPrompt := "Review the file /w/contra.html — bugfixes were applied. Report what is FIXED and what still has issues."
+	assembled := subagentStartContext + "\n\n" + legacyWorkspaceContext + "\n\n" + reviewPrompt
+
+	if got := classifierTaskText(assembled); got != reviewPrompt {
+		t.Fatalf("classifierTaskText did not reduce to the task text:\n%q", got)
+	}
+	if deliveryTaskNeedsMutation(classifierTaskText(assembled)) {
+		t.Fatal("host framing must not classify a review prompt as a mutation request")
+	}
+	// Real mutation intent in the task text still classifies as mutation.
+	fix := subagentStartContext + "\n\n" + legacyWorkspaceContext + "\n\nfix the crash in parser.go"
+	if !deliveryTaskNeedsMutation(classifierTaskText(fix)) {
+		t.Fatal("stripping framing must not erase genuine mutation intent")
+	}
+	// The delivery-runtime suffix is framing too.
+	if deliveryTaskNeedsMutation(classifierTaskText("你是谁？\n\n" + deliveryRuntimeMarker)) {
+		t.Fatal("delivery-runtime marker must not classify as mutation intent")
+	}
+}
+
+func TestReadOnlyRegistryDisarmsMutationExpectation(t *testing.T) {
+	roReg := tool.NewRegistry()
+	roReg.Add(fakeReadFileTool{})
+	if registryHasWriterTools(roReg) {
+		t.Fatal("read-only registry misreported writer tools")
+	}
+	writerReg := tool.NewRegistry()
+	writerReg.Add(fakeReadFileTool{})
+	writerReg.Add(fakeWriterTool{})
+	if !registryHasWriterTools(writerReg) {
+		t.Fatal("writer registry not detected")
+	}
+
+	// End-to-end: a read-only delivery subagent given a mutation-worded prompt
+	// must not deadlock on "the request requires a state change". The scripted
+	// sub reads a file (host-observable work) and answers.
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("1", "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "reviewed; two issues found"}, {Type: provider.ChunkDone}},
+	}}
+	sub := New(prov, roReg, NewSession("sys"), Options{DeliveryProfile: true}, event.Discard)
+	if err := sub.Run(context.Background(), "fix review: verify the fixes in a.go were applied"); err != nil {
+		t.Fatalf("read-only delivery subagent deadlocked: %v", err)
+	}
+	if sub.deliveryMutationExpected {
+		t.Fatal("mutation expectation armed on a read-only registry")
+	}
+}
+
+func TestRunSubAgentReviewReportNudgeRecovers(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	AttachReviewReportTool(reg)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		// Run 1: reads the file, then finishes with prose only — no report.
+		{toolCallChunk("1", "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "verdict: pass, no issues"}, {Type: provider.ChunkDone}},
+		// Nudge run: submits the typed report citing the run-1 read, then answers.
+		{toolCallChunk("2", "review_report", `{"kind":"review","verdict":"pass","reviewed_paths":["a.go"]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "review_report submitted: pass"}, {Type: provider.ChunkDone}},
+	}}
+	sess := NewSession("sys")
+	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess, "review a.go",
+		Options{RequireReviewReportKind: evidence.ReviewKindReview}, event.Discard)
+	if err != nil {
+		t.Fatalf("nudge recovery failed: %v", err)
+	}
+	if !strings.Contains(answer, "pass") {
+		t.Fatalf("unexpected final answer %q", answer)
+	}
+	if !sessionHasUserMessageContaining(sess, "Call review_report now") {
+		t.Fatal("expected the host completion nudge in the subagent session")
+	}
+	// The report cited a path read in run 1 — only possible because the nudge
+	// run preserved the evidence ledger instead of resetting it.
+	if got := lastToolResult(sess, "review_report"); !strings.Contains(got, "review_report accepted") {
+		t.Fatalf("review_report result = %q", got)
+	}
+}
+
+func TestRunSubAgentReviewReportExhaustionNamesRecovery(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	AttachReviewReportTool(reg)
+	dir := t.TempDir()
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "looks fine"}, {Type: provider.ChunkDone}},
+	}}
+	sess := NewSession("sys")
+	_, err := RunSubAgentWithSession(context.Background(), prov, reg, sess, "review it",
+		Options{RequireReviewReportKind: evidence.ReviewKindReview, ArchiveDir: dir}, event.Discard)
+	if err == nil {
+		t.Fatal("expected failure when the report never arrives")
+	}
+	for _, want := range []string{"review_report", "host nudges", "re-run the review skill", "parent has no review_report tool"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	// The failed transcript is dumped for diagnosis.
+	matches, globErr := filepath.Glob(filepath.Join(dir, "subagent-report-failures", "review-*.jsonl"))
+	if globErr != nil || len(matches) != 1 {
+		t.Fatalf("expected one dumped transcript, got %v (%v)", matches, globErr)
+	}
+	if data, readErr := os.ReadFile(matches[0]); readErr != nil || !strings.Contains(string(data), "looks fine") {
+		t.Fatalf("dump unreadable or incomplete: %v", readErr)
+	}
+}
+
+func TestFinalReadinessBudgetExtendsOnlyWithProgress(t *testing.T) {
+	newReg := func() *tool.Registry {
+		reg := tool.NewRegistry()
+		reg.Add(fakeReadFileTool{})
+		reg.Add(fakeWriterTool{}) // writer-capable registry keeps mutation expected
+		return reg
+	}
+	finalText := []provider.Chunk{{Type: provider.ChunkText, Text: "done, all fixed"}, {Type: provider.ChunkDone}}
+	readCall := func(id string) []provider.Chunk {
+		return []provider.Chunk{toolCallChunk(id, "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}}
+	}
+
+	// Stalled: the model answers text-only every round — no new receipts, so
+	// the base budget (3) applies unchanged.
+	stalled := &scriptedProvider{name: "p", turns: [][]provider.Chunk{finalText}}
+	a := New(stalled, newReg(), NewSession("sys"), Options{DeliveryProfile: true}, event.Discard)
+	err := a.Run(context.Background(), "fix the crash in a.go")
+	var readinessErr *FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("expected FinalReadinessError, got %v", err)
+	}
+	if readinessErr.Attempts != maxFinalReadinessBlocks {
+		t.Fatalf("stalled attempts = %d, want %d", readinessErr.Attempts, maxFinalReadinessBlocks)
+	}
+
+	// Converging: the model earns a receipt between blocks every time, so the
+	// budget extends to the hard cap instead of failing at 3.
+	converging := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		finalText,                // block 1
+		readCall("1"), finalText, // progress → block 2
+		readCall("2"), finalText, // progress → block 3 (old code failed here)
+		readCall("3"), finalText, // progress → block 4
+		readCall("4"), finalText, // progress → block 5
+		readCall("5"), finalText, // progress → block 6 → hard cap
+	}}
+	a2 := New(converging, newReg(), NewSession("sys"), Options{DeliveryProfile: true}, event.Discard)
+	err2 := a2.Run(context.Background(), "fix the crash in a.go")
+	var readinessErr2 *FinalReadinessError
+	if !errors.As(err2, &readinessErr2) {
+		t.Fatalf("expected FinalReadinessError, got %v", err2)
+	}
+	if readinessErr2.Attempts != maxFinalReadinessBlocksWithProgress {
+		t.Fatalf("converging attempts = %d, want %d", readinessErr2.Attempts, maxFinalReadinessBlocksWithProgress)
+	}
+}
+
+func TestPreviewStripsDeliveryMarkerAndSyntheticTurns(t *testing.T) {
+	first := "你是谁？\n\n" + deliveryRuntimeMarker
+	if got := UserPreviewText(first); got != "你是谁？" {
+		t.Fatalf("UserPreviewText kept framing: %q", got)
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: first},
+		{Role: provider.RoleAssistant, Content: "hi"},
+		{Role: provider.RoleUser, Content: finalReadinessRetryMessage("missing receipts") + "\n\n" + deliveryRuntimeMarker},
+		{Role: provider.RoleUser, Content: MidTurnSteerPrefix + "\nslow down"},
+		{Role: provider.RoleUser, Content: "帮我写一个魂斗罗游戏\n\n" + deliveryRuntimeMarker},
+	}
+	preview, turns := SessionPreviewFromMessages(msgs)
+	if preview != "你是谁？" {
+		t.Fatalf("preview = %q", preview)
+	}
+	if turns != 2 {
+		t.Fatalf("turns = %d, want 2 (synthetic + steer excluded)", turns)
+	}
+	if !IsSyntheticUserText(finalReadinessRetryMessage("x")) {
+		t.Fatal("readiness retry not detected as synthetic")
+	}
+}

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -226,7 +226,7 @@ func TestFinalReadinessBudgetExtendsOnlyWithProgress(t *testing.T) {
 }
 
 func TestPreviewStripsDeliveryMarkerAndSyntheticTurns(t *testing.T) {
-	first := "你是谁？\n\n" + deliveryRuntimeMarker
+	first := "你是谁？\n\n" + DeliveryRuntimeMarker
 	if got := UserPreviewText(first); got != "你是谁？" {
 		t.Fatalf("UserPreviewText kept framing: %q", got)
 	}
@@ -241,9 +241,9 @@ func TestPreviewStripsDeliveryMarkerAndSyntheticTurns(t *testing.T) {
 		{Role: provider.RoleSystem, Content: "sys"},
 		{Role: provider.RoleUser, Content: first},
 		{Role: provider.RoleAssistant, Content: "hi"},
-		{Role: provider.RoleUser, Content: finalReadinessRetryMessage("missing receipts") + "\n\n" + deliveryRuntimeMarker},
+		{Role: provider.RoleUser, Content: finalReadinessRetryMessage("missing receipts") + "\n\n" + DeliveryRuntimeMarker},
 		{Role: provider.RoleUser, Content: MidTurnSteerPrefix + "\nslow down"},
-		{Role: provider.RoleUser, Content: "帮我写一个魂斗罗游戏\n\n" + deliveryRuntimeMarker},
+		{Role: provider.RoleUser, Content: "帮我写一个魂斗罗游戏\n\n" + DeliveryRuntimeMarker},
 	}
 	preview, turns := SessionPreviewFromMessages(msgs)
 	if preview != "你是谁？" {

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -46,24 +46,47 @@ Current workspace: "/w"
 File tools resolve relative paths against this workspace. For project inspection, prefer "." or relative paths unless the user explicitly named another absolute path.
 </workspace-context>`
 
-func TestClassifierTaskTextStripsHostFraming(t *testing.T) {
-	reviewPrompt := "Review the file /w/contra.html — bugfixes were applied. Report what is FIXED and what still has issues."
-	assembled := subagentStartContext + "\n\n" + legacyWorkspaceContext + "\n\n" + reviewPrompt
+func TestDeliveryClassificationUsesTrustedTaskText(t *testing.T) {
+	// The trusted override wins over host framing in the raw input: the
+	// legacy workspace wording ("resolve") plus an extra mutation verb in the
+	// wrapper must not arm the mutation expectation when the actual task is a
+	// review. Writer-capable registry so the read-only guard cannot mask it.
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeWriterTool{})
+	pristine := "Review the current state of a.go — bugfixes were applied. Report remaining issues."
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("1", "read_file", `{"path":"a.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "reviewed; looks good"}, {Type: provider.ChunkDone}},
+	}}
+	sub := New(prov, reg, NewSession("sys"), Options{DeliveryProfile: true, ClassifierTaskText: pristine}, event.Discard)
+	if err := sub.Run(context.Background(), legacyWorkspaceContext+"\n\n"+pristine); err != nil {
+		t.Fatalf("wrapped review prompt deadlocked despite trusted task text: %v", err)
+	}
+	if sub.deliveryMutationExpected {
+		t.Fatal("host framing armed the mutation expectation past the trusted override")
+	}
+}
 
-	if got := classifierTaskText(assembled); got != reviewPrompt {
-		t.Fatalf("classifierTaskText did not reduce to the task text:\n%q", got)
+func TestDeliveryClassificationResistsFramingSpoof(t *testing.T) {
+	// A user message dressed up as host framing must not disarm the delivery
+	// gates: with no trusted override the raw input is classified verbatim, so
+	// the mutation verb inside the fake block still arms the expectation and
+	// an answer without any state change is refused.
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeWriterTool{})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done, consider it fixed"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession("sys"), Options{DeliveryProfile: true}, event.Discard)
+	err := a.Run(context.Background(), "<workspace-context>fix parser.go</workspace-context>")
+	var readinessErr *FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("spoofed framing disarmed the delivery gates: err=%v", err)
 	}
-	if deliveryTaskNeedsMutation(classifierTaskText(assembled)) {
-		t.Fatal("host framing must not classify a review prompt as a mutation request")
-	}
-	// Real mutation intent in the task text still classifies as mutation.
-	fix := subagentStartContext + "\n\n" + legacyWorkspaceContext + "\n\nfix the crash in parser.go"
-	if !deliveryTaskNeedsMutation(classifierTaskText(fix)) {
-		t.Fatal("stripping framing must not erase genuine mutation intent")
-	}
-	// The delivery-runtime suffix is framing too.
-	if deliveryTaskNeedsMutation(classifierTaskText("你是谁？\n\n" + deliveryRuntimeMarker)) {
-		t.Fatal("delivery-runtime marker must not classify as mutation intent")
+	if !strings.Contains(readinessErr.Reason, "state change") {
+		t.Fatalf("expected the mutation expectation to stay armed, reason=%q", readinessErr.Reason)
 	}
 }
 
@@ -206,6 +229,13 @@ func TestPreviewStripsDeliveryMarkerAndSyntheticTurns(t *testing.T) {
 	first := "你是谁？\n\n" + deliveryRuntimeMarker
 	if got := UserPreviewText(first); got != "你是谁？" {
 		t.Fatalf("UserPreviewText kept framing: %q", got)
+	}
+	// A literal <delivery-runtime> mention inside user prose is not the host
+	// suffix: nothing may be cut. (The agent never appends the marker when the
+	// input already mentions the tag, so this content carries no host suffix.)
+	inline := "Explain this literal: <delivery-runtime>example</delivery-runtime> and keep this sentence"
+	if got := UserPreviewText(inline); got != inline {
+		t.Fatalf("inline delivery-runtime mention was mangled: %q", got)
 	}
 	msgs := []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -180,8 +180,13 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			}
 
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
+			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth)
+			// Same contract as runSubSession: capture the pristine task before
+			// host framing is prepended so delivery intent classification judges
+			// the task, not the wrapper.
+			opts.ClassifierTaskText = t.Prompt
 			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
-				p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth), nested)
+				opts, nested)
 
 			if ctx.Err() != nil && runErr == nil {
 				runErr = ctx.Err()

--- a/internal/agent/parallel_tasks_test.go
+++ b/internal/agent/parallel_tasks_test.go
@@ -123,6 +123,35 @@ func TestParallelTasksInjectsWorkspaceContextIntoChildren(t *testing.T) {
 	}
 }
 
+// TestParallelTasksDeliveryClassifiesPristinePrompt pins the trusted
+// classifier channel on the parallel_tasks path: delivery intent must be
+// judged from the child's pristine prompt, not the workspace-wrapped text.
+// The wrapper is long enough that the IsTask length fallback classifies it as
+// a task; without ClassifierTaskText a plain conversational child ("Who are
+// you?") would be required to produce work receipts it has no reason to earn
+// and would exhaust final-answer readiness instead of answering.
+func TestParallelTasksDeliveryClassifiesPristinePrompt(t *testing.T) {
+	workspace := t.TempDir()
+	task := NewTaskTool(promptRoutingProvider{}, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), workspace, "base-model", "base-effort").
+		WithDeliveryProfile(true)
+	parallel := NewParallelTasksTool(task, tool.NewRegistry())
+	ctx := withCallContext(context.Background(), "parallel-call", event.Discard, nil, false)
+
+	out, err := parallel.Execute(ctx, json.RawMessage(`{"tasks":[{"prompt":"Who are you?"},{"prompt":"Nice to meet you"}]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, "readiness") {
+		t.Fatalf("delivery readiness leaked into a conversational parallel child: %q", out)
+	}
+	// The echo provider replays the child's full user turn; both children must
+	// have answered (their prompts echo back with the trailing " ok").
+	if !strings.Contains(out, "Who are you?") || !strings.Contains(out, "Nice to meet you") || strings.Count(out, " ok") < 2 {
+		t.Fatalf("parallel output = %q, want both children's answers", out)
+	}
+}
+
 // TestParallelTasksInheritLanguagePreferencesFromContext pins parallel children
 // to the same transient language injection the task tool applies: both the
 // response- and reasoning-language blocks must reach each child's user turn.

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -9,7 +9,7 @@ import (
 var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)>\s*\n?`)
 
 // stripTrailingDeliveryRuntime removes the exact delivery-runtime marker the
-// agent appends to user turns in delivery mode (agent.go deliveryRuntimeMarker).
+// agent appends to user turns in delivery mode (agent.go DeliveryRuntimeMarker).
 // Unlike the prefix blocks it trails the user text, so preview/title derivation
 // needs a suffix cut — leaving it produced session titles like
 // "你是谁？ <delivery-run…". The cut is byte-exact rather than a regex: a lazy
@@ -19,7 +19,7 @@ var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|rea
 // so user messages discussing it carry no host suffix at all.)
 func stripTrailingDeliveryRuntime(s string) string {
 	trimmed := strings.TrimRight(s, " \t\r\n")
-	if cut, ok := strings.CutSuffix(trimmed, deliveryRuntimeMarker); ok {
+	if cut, ok := strings.CutSuffix(trimmed, DeliveryRuntimeMarker); ok {
 		return strings.TrimRight(cut, " \t\r\n")
 	}
 	return s

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -8,6 +8,13 @@ import (
 
 var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)>\s*\n?`)
 
+// reTrailingDeliveryRuntime matches the delivery-runtime marker the agent
+// appends to user turns in delivery mode (agent.go deliveryRuntimeMarker).
+// Unlike the prefix blocks above it trails the user text, so preview/title
+// derivation needs a suffix cut — leaving it produced session titles like
+// "你是谁？ <delivery-run…".
+var reTrailingDeliveryRuntime = regexp.MustCompile(`(?s)\s*<delivery-runtime>.*?</delivery-runtime>\s*$`)
+
 const memoryCompilerExecutionOpen = "<memory-compiler-execution>"
 
 var reMemoryCompilerExecution = regexp.MustCompile(`(?s)<memory-compiler-execution>\s*(.*?)\s*</memory-compiler-execution>`)
@@ -42,6 +49,7 @@ func StripTransientUserBlocks(content string) string {
 		}
 		s = next
 	}
+	s = reTrailingDeliveryRuntime.ReplaceAllString(s, "")
 	return strings.TrimLeft(s, " \t\r\n")
 }
 
@@ -109,4 +117,54 @@ func UserPreviewText(content string) string {
 	s = HandoffTask(s)
 	s = StripTransientUserBlocks(s)
 	return strings.TrimSpace(s)
+}
+
+// SyntheticUserPrefixes lists the openings of host-injected user-role messages
+// (readiness retries, stream recovery, goal-loop nudges, compaction folds).
+// They are persisted with role "user" for provider-contract reasons but are not
+// user-authored: previews, titles, and user-turn counts must skip them, and the
+// chat UI never renders them as user bubbles. Keep in sync with the injection
+// sites in internal/agent/agent.go, internal/agent/compact.go, and
+// internal/control (plan approval, goal loop).
+var SyntheticUserPrefixes = []string{
+	"Plan approved — plan mode is off",
+	"Host final-answer readiness check failed",
+	"You are already in the executor phase",
+	"The previous assistant response was interrupted while a tool call",
+	"The previous assistant response was interrupted during streaming",
+	"The previous assistant response was interrupted before visible",
+	"The previous assistant response finished without any visible answer",
+	"<compaction-summary>",
+	"Summary of the later conversation (compacted from here on):",
+	"Summary of earlier conversation (compacted up to here):",
+	"Continue pursuing the active goal",
+	"The agent signaled goal completion and all tasks are marked done.",
+	"Goal signaled complete but issues remain:",
+	"No tool calls in recent turns.",
+}
+
+// IsSyntheticUserText reports whether a persisted user-role message is a
+// host-injected synthetic turn rather than user-authored input.
+func IsSyntheticUserText(content string) bool {
+	trimmed := strings.TrimSpace(StripTransientUserBlocks(content))
+	for _, prefix := range SyntheticUserPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsUserAuthoredTurn reports whether a persisted user-role message counts as a
+// visible user turn: not a host-injected synthetic message and not a mid-turn
+// steer. Preview/title/turn-count derivations share this so a delivery
+// readiness nudge can never become a session title or inflate turn counts.
+func IsUserAuthoredTurn(content string) bool {
+	if IsSyntheticUserText(content) {
+		return false
+	}
+	if _, isSteer := SteerText(content); isSteer {
+		return false
+	}
+	return true
 }

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -8,12 +8,22 @@ import (
 
 var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)>\s*\n?`)
 
-// reTrailingDeliveryRuntime matches the delivery-runtime marker the agent
-// appends to user turns in delivery mode (agent.go deliveryRuntimeMarker).
-// Unlike the prefix blocks above it trails the user text, so preview/title
-// derivation needs a suffix cut — leaving it produced session titles like
-// "你是谁？ <delivery-run…".
-var reTrailingDeliveryRuntime = regexp.MustCompile(`(?s)\s*<delivery-runtime>.*?</delivery-runtime>\s*$`)
+// stripTrailingDeliveryRuntime removes the exact delivery-runtime marker the
+// agent appends to user turns in delivery mode (agent.go deliveryRuntimeMarker).
+// Unlike the prefix blocks it trails the user text, so preview/title derivation
+// needs a suffix cut — leaving it produced session titles like
+// "你是谁？ <delivery-run…". The cut is byte-exact rather than a regex: a lazy
+// pattern anchored at $ would swallow user prose between a literal
+// "<delivery-runtime>" mention in the text and the real marker at the end.
+// (The agent never appends the marker when the input already mentions the tag,
+// so user messages discussing it carry no host suffix at all.)
+func stripTrailingDeliveryRuntime(s string) string {
+	trimmed := strings.TrimRight(s, " \t\r\n")
+	if cut, ok := strings.CutSuffix(trimmed, deliveryRuntimeMarker); ok {
+		return strings.TrimRight(cut, " \t\r\n")
+	}
+	return s
+}
 
 const memoryCompilerExecutionOpen = "<memory-compiler-execution>"
 
@@ -49,7 +59,7 @@ func StripTransientUserBlocks(content string) string {
 		}
 		s = next
 	}
-	s = reTrailingDeliveryRuntime.ReplaceAllString(s, "")
+	s = stripTrailingDeliveryRuntime(s)
 	return strings.TrimLeft(s, " \t\r\n")
 }
 

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1829,7 +1829,7 @@ func SessionPreviewFromMessages(msgs []provider.Message) (string, int) {
 	first := ""
 	turns := 0
 	for _, m := range msgs {
-		if m.Role == provider.RoleUser {
+		if m.Role == provider.RoleUser && IsUserAuthoredTurn(m.Content) {
 			turns++
 			if first == "" {
 				first = truncatePreview(UserPreviewText(m.Content))
@@ -1850,7 +1850,7 @@ func previewSession(path string) (string, int) {
 	first := ""
 	turns := 0
 	for _, m := range msgs {
-		if m.Role == provider.RoleUser {
+		if m.Role == provider.RoleUser && IsUserAuthoredTurn(m.Content) {
 			turns++
 			if first == "" {
 				first = truncatePreview(UserPreviewText(m.Content))

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
@@ -832,9 +835,12 @@ func subagentWorkspaceContext(root string) string {
 	if root == "" {
 		return ""
 	}
+	// Wording note: avoid incidental action verbs ("resolve", "fix", …) in this
+	// host framing — it is prepended to every sub-agent prompt and must never
+	// read as task intent (see classifierTaskText, which also strips it).
 	return `<workspace-context event="SubagentWorkspace">
 Current workspace: ` + strconv.Quote(root) + `
-File tools resolve relative paths against this workspace. For project inspection, prefer "." or relative paths unless the user explicitly named another absolute path.
+File tools interpret relative paths against this workspace. For project inspection, prefer "." or relative paths unless the user explicitly named another absolute path.
 </workspace-context>`
 }
 
@@ -877,6 +883,27 @@ func GuardSubagentHostDecisionText(answer string) string {
 	return tool.GuardSubagentHostDecisionText(answer)
 }
 
+// maxReviewReportNudges bounds the in-session completion nudges sent to a
+// review subagent that finished without submitting review_report. Each nudge is
+// one cheap continuation request on the same (cached) subagent session — far
+// cheaper than discarding the run and re-reviewing from scratch.
+const maxReviewReportNudges = 2
+
+// reviewReportTaskContract is appended to the task prompt of a review subagent
+// whose run must end with a typed report. The skill body describes how to
+// review; this states the non-negotiable submission protocol.
+func reviewReportTaskContract(kind evidence.ReviewKind) string {
+	return fmt.Sprintf(`<review-report-contract event="SubagentReviewReport">
+Before your final answer you MUST call the review_report tool exactly once with kind=%q, your verdict (pass | warn | block), reviewed_paths listing only files you actually read this run, and your findings. The host discards a review run that ends without a successful review_report call — your prose summary alone does not count.
+</review-report-contract>`, string(kind))
+}
+
+// reviewReportNudgePrompt asks an already-finished review subagent to submit
+// the missing typed report without redoing the review.
+func reviewReportNudgePrompt(kind evidence.ReviewKind) string {
+	return fmt.Sprintf("You finished the review without calling the review_report tool, so the host cannot accept the run yet. Do not redo the review. Call review_report now with kind=%q, your verdict (pass | warn | block), reviewed_paths listing only the files you actually read in this conversation, and the findings you already reported. Then restate your final verdict in one sentence.", string(kind))
+}
+
 // RunSubAgentWithSession continues an existing sub-agent session with prompt and
 // returns the latest final assistant answer. Fresh sub-agents pass a newly-created
 // session; continued sub-agents pass a loaded transcript session.
@@ -890,21 +917,38 @@ func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *to
 	if opts.SubagentDepth > 0 && isFreshSubagentSession(sess) {
 		prompt = subagentStartContext + "\n\n" + prompt
 	}
+	if kind := opts.RequireReviewReportKind; kind != "" {
+		prompt = prompt + "\n\n" + reviewReportTaskContract(kind)
+	}
 	sub := New(prov, reg, sess, opts, sink)
 	if err := sub.Run(ctx, prompt); err != nil {
 		// Still merge any partial child evidence so parent gates see real writes.
 		mergeChildEvidence(ctx, sub)
 		return "", fmt.Errorf("sub-agent: %w", err)
 	}
-	mergeChildEvidence(ctx, sub)
 	// Review/security subagents must hand back a typed report the parent's
 	// delivery gate can verify; prose alone would leave the gate demanding a
-	// review forever with no way to tell why it never arrives.
+	// review forever with no way to tell why it never arrives. A run that
+	// finished without the report gets bounded completion nudges on the same
+	// session (evidence preserved, so review_report can still cite the reads it
+	// already earned) before the whole run is declared failed.
 	if kind := opts.RequireReviewReportKind; kind != "" {
+		nudges := 0
+		for !sub.HasSuccessfulReviewReport(kind) && nudges < maxReviewReportNudges {
+			nudges++
+			sub.preserveEvidenceOnce = true
+			if err := sub.Run(ctx, reviewReportNudgePrompt(kind)); err != nil {
+				mergeChildEvidence(ctx, sub)
+				return "", fmt.Errorf("sub-agent: %w", err)
+			}
+		}
 		if !sub.HasSuccessfulReviewReport(kind) {
-			return "", fmt.Errorf("%s subagent finished without submitting review_report (kind=%s); re-run it and call review_report with the host-read paths before finishing", kind, kind)
+			mergeChildEvidence(ctx, sub)
+			dumpRef := dumpFailedSubagentSession(opts.ArchiveDir, string(kind), sess)
+			return "", fmt.Errorf("%s subagent finished without submitting review_report (kind=%s) even after %d host nudges; the report must be submitted by the review subagent itself (the parent has no review_report tool) — re-run the review skill%s", kind, kind, nudges, dumpRef)
 		}
 	}
+	mergeChildEvidence(ctx, sub)
 	// Walk the session backwards for the last assistant message with content —
 	// that's the sub-agent's final answer. Intermediate assistant messages with
 	// tool_calls but no text don't count.
@@ -915,6 +959,33 @@ func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *to
 		}
 	}
 	return "", fmt.Errorf("sub-agent finished without producing a final answer")
+}
+
+// dumpFailedSubagentSession best-effort persists a failed report-required
+// subagent transcript for post-hoc diagnosis (read-only skill subagents are
+// otherwise ephemeral, so a protocol failure leaves no trace). Returns a
+// human-readable suffix naming the dump, or "" when disabled/failed.
+func dumpFailedSubagentSession(archiveDir, kind string, sess *Session) string {
+	if strings.TrimSpace(archiveDir) == "" || sess == nil {
+		return ""
+	}
+	dir := filepath.Join(archiveDir, "subagent-report-failures")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return ""
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%s-%d.jsonl", kind, time.Now().UnixNano()))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, m := range sess.Messages {
+		if err := enc.Encode(m); err != nil {
+			return ""
+		}
+	}
+	return "; transcript dumped to " + path
 }
 
 // mergeChildEvidence folds a sub-agent's real receipts into the parent ledger

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -788,8 +788,12 @@ func (t *TaskTool) resolveSubSessionRuntime(modelRef, effort string) (provider.P
 }
 
 func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session, childDepth int) (string, error) {
+	opts := t.subagentOptions(ctx, maxSteps, pricing, ctxWin, childDepth)
+	// Capture the pristine task before host framing is prepended: delivery
+	// intent classification must judge the task, not the wrapper.
+	opts.ClassifierTaskText = prompt
 	prompt = t.withWorkspaceContext(prompt)
-	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, t.subagentOptions(ctx, maxSteps, pricing, ctxWin, childDepth), sink)
+	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, opts, sink)
 }
 
 // subagentOptions is the single construction point for the run options every
@@ -913,6 +917,12 @@ func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *to
 	}
 	if opts.SubagentDepth > 0 {
 		ctx = WithSubagentDepth(ctx, opts.SubagentDepth)
+	}
+	// Callers that wrap the prompt themselves (runSubSession) set
+	// ClassifierTaskText before wrapping; for everyone else the prompt is
+	// still pristine here, so capture it before host framing is prepended.
+	if strings.TrimSpace(opts.ClassifierTaskText) == "" {
+		opts.ClassifierTaskText = prompt
 	}
 	if opts.SubagentDepth > 0 && isFreshSubagentSession(sess) {
 		prompt = subagentStartContext + "\n\n" + prompt

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -120,39 +120,13 @@ func StripReferencedContextPrefix(content string) string {
 // approval, stream recovery, readiness retry, etc.). These should not be shown
 // in the chat UI.
 func IsSyntheticUserMessage(content string) bool {
-	trimmed := strings.TrimSpace(agent.StripTransientUserBlocks(content))
-	if trimmed == planApprovedMessage {
+	if trimmed := strings.TrimSpace(agent.StripTransientUserBlocks(content)); trimmed == planApprovedMessage {
 		return true
 	}
-	for _, prefix := range syntheticPrefixes {
-		if strings.HasPrefix(trimmed, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-// syntheticPrefixes must be kept in sync with the synthetic user messages
-// injected by the controller (planApprovedMessage, goal loop turns), agent loop
-// (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
-// executorHandoffRetryMessage in internal/agent/agent.go), and compaction
-// folds (internal/agent/compact.go), which store summaries as user-role
-// messages the chat UI must never render as user bubbles (#3653).
-var syntheticPrefixes = []string{
-	"Plan approved — plan mode is off",
-	"Host final-answer readiness check failed",
-	"You are already in the executor phase",
-	"The previous assistant response was interrupted while a tool call",
-	"The previous assistant response was interrupted during streaming",
-	"The previous assistant response was interrupted before visible",
-	"The previous assistant response finished without any visible answer",
-	"<compaction-summary>",
-	"Summary of the later conversation (compacted from here on):",
-	"Summary of earlier conversation (compacted up to here):",
-	"Continue pursuing the active goal",
-	"The agent signaled goal completion and all tasks are marked done.",
-	"Goal signaled complete but issues remain:",
-	"No tool calls in recent turns.",
+	// The prefix list lives in internal/agent (agent.SyntheticUserPrefixes) so
+	// preview/title/turn-count derivations there share the exact same filter
+	// (#3653).
+	return agent.IsSyntheticUserText(content)
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -131,6 +131,10 @@ type Tool struct {
 	// Args still streaming) so a frontend can show the card immediately; a second,
 	// full ToolDispatch (Partial false, Args set) follows when the call completes.
 	Partial bool
+	// ArgChars is the cumulative argument characters received so far for a
+	// Partial dispatch — a liveness signal while a large payload streams. Zero
+	// on the initial start dispatch and on full dispatches.
+	ArgChars int
 	// ParentID, when set, is the ID of the tool call that spawned this one — a
 	// sub-agent's calls carry the parent `task` call's ID so a frontend can nest
 	// them under it. Empty for top-level calls.

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -48,6 +48,7 @@ func ToWire(e event.Event) Event {
 			Output: e.Tool.Output, Err: e.Tool.Err,
 			ReadOnly: e.Tool.ReadOnly, Truncated: e.Tool.Truncated,
 			DurationMs: e.Tool.DurationMs, Partial: e.Tool.Partial,
+			ArgChars: e.Tool.ArgChars,
 			ParentID: e.Tool.ParentID,
 			Diff:     e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
 		}
@@ -209,6 +210,7 @@ type Tool struct {
 	Truncated  bool     `json:"truncated,omitempty"`
 	DurationMs int64    `json:"durationMs,omitempty"`
 	Partial    bool     `json:"partial,omitempty"`
+	ArgChars   int      `json:"argChars,omitempty"`
 	ParentID   string   `json:"parentId,omitempty"`
 	Diff       string   `json:"diff,omitempty"`
 	Added      int      `json:"added,omitempty"`

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -413,6 +413,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	}
 
 	tools := map[int]*provider.ToolCall{} // tool_use blocks, keyed by content index
+	argBuckets := map[int]int{}           // last emitted 2KB progress bucket per block
 	var inTok, outTok, cacheCreate, cacheRead int
 	var stopReason string
 	haveUsage := false
@@ -484,6 +485,14 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 			case "input_json_delta":
 				if tc := tools[ev.Index]; tc != nil {
 					tc.Arguments += ev.Delta.PartialJSON
+					// Progress ticks for large streaming argument payloads, one
+					// per 2KB bucket (see the openai provider for rationale).
+					if bucket := len(tc.Arguments) / 2048; bucket > argBuckets[ev.Index] {
+						argBuckets[ev.Index] = bucket
+						if !send(provider.Chunk{Type: provider.ChunkToolCallArgsDelta, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}, ArgChars: len(tc.Arguments)}) {
+							return
+						}
+					}
 				}
 			}
 		case "content_block_stop":

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -646,6 +646,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 	acc := map[int]*provider.ToolCall{}
 	started := map[int]bool{}
+	argBucket := map[int]int{}
 	var order []int
 	var lastFinishReason string
 	var sawDone bool
@@ -739,6 +740,18 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 				emitted = true
 				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: cur.ID, Name: cur.Name}}) {
 					return emitted, ctx.Err()
+				}
+			}
+			// Progress ticks while a large argument payload streams (a 30KB
+			// write_file body can take a minute-plus): one chunk per 2KB bucket
+			// so the consumer can show liveness without per-delta spam.
+			if started[tc.Index] {
+				if bucket := len(cur.Arguments) / 2048; bucket > argBucket[tc.Index] {
+					argBucket[tc.Index] = bucket
+					emitted = true
+					if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCallArgsDelta, ToolCall: &provider.ToolCall{ID: cur.ID, Name: cur.Name}, ArgChars: len(cur.Arguments)}) {
+						return emitted, ctx.Err()
+					}
 				}
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -464,13 +464,14 @@ func idDistinct(calls []ToolCall) bool {
 type ChunkType int
 
 const (
-	ChunkText          ChunkType = iota // text delta
-	ChunkReasoning                      // thinking-mode reasoning delta (before the visible answer)
-	ChunkToolCallStart                  // a tool call has begun (ToolCall: ID+Name; args still streaming)
-	ChunkToolCall                       // one complete tool call
-	ChunkUsage                          // token usage for the completion
-	ChunkDone                           // completion finished normally
-	ChunkError                          // an error occurred
+	ChunkText              ChunkType = iota // text delta
+	ChunkReasoning                          // thinking-mode reasoning delta (before the visible answer)
+	ChunkToolCallStart                      // a tool call has begun (ToolCall: ID+Name; args still streaming)
+	ChunkToolCallArgsDelta                  // progress while a call's arguments stream (ToolCall: ID+Name; ArgChars: cumulative)
+	ChunkToolCall                           // one complete tool call
+	ChunkUsage                              // token usage for the completion
+	ChunkDone                               // completion finished normally
+	ChunkError                              // an error occurred
 )
 
 // Usage reports token accounting for a completion. Cache hit/miss come from
@@ -576,7 +577,8 @@ type Chunk struct {
 	Type      ChunkType
 	Text      string    // ChunkText, ChunkReasoning
 	Signature string    // ChunkReasoning: opaque proof for the reasoning (Anthropic thinking signature), when issued
-	ToolCall  *ToolCall // ChunkToolCallStart (ID+Name only), ChunkToolCall (complete)
+	ToolCall  *ToolCall // ChunkToolCallStart (ID+Name only), ChunkToolCallArgsDelta (ID+Name), ChunkToolCall (complete)
+	ArgChars  int       // ChunkToolCallArgsDelta: cumulative argument characters received for this call
 	Usage     *Usage    // ChunkUsage
 	Err       error     // ChunkError
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -453,7 +453,7 @@ func TestRoleConstants(t *testing.T) {
 // --- ChunkType constants ---
 
 func TestChunkTypeConstants(t *testing.T) {
-	types := []ChunkType{ChunkText, ChunkReasoning, ChunkToolCallStart, ChunkToolCall, ChunkUsage, ChunkDone, ChunkError}
+	types := []ChunkType{ChunkText, ChunkReasoning, ChunkToolCallStart, ChunkToolCallArgsDelta, ChunkToolCall, ChunkUsage, ChunkDone, ChunkError}
 	for i, ct := range types {
 		if int(ct) != i {
 			t.Errorf("ChunkType %d: got %d", i, int(ct))


### PR DESCRIPTION
## Summary

Delivery-mode hardening derived from a full-workflow field trace: a 16-minute screen recording of a delivery-first session ("write a Contra game") cross-checked against the session's persisted event log. The trace surfaced one protocol failure loop that consumed roughly half the turn's wall time and tokens, one classifier bug that deadlocked read-only sub-agents, a title/metadata leak, and three streaming/telemetry UI gaps. Each fix below is backed by a regression test.

### 1. review_report protocol hardening (`internal/agent/task.go`)

A delivery review subagent that finished without calling `review_report` used to discard the entire run with an error telling the parent to "call review_report" — a tool only the subagent has. Now:

- The task prompt of a report-required subagent carries an explicit submission contract (`reviewReportTaskContract`).
- A finished-but-reportless run gets up to 2 completion nudges **on the same subagent session**, with the evidence ledger preserved (`preserveEvidenceOnce`) so the late report can still cite the reads the run already earned. One cheap cached continuation instead of a full re-review.
- On exhaustion, the error names the actual recovery ("re-run the review skill; the parent has no review_report tool") and dumps the failed transcript to `<archive>/subagent-report-failures/` for diagnosis (read-only skill subagents are otherwise ephemeral).

### 2. Delivery intent classification (`internal/agent/agent.go`)

`deliveryTaskNeedsMutation` classified the *whole* Run input, including host framing. The workspace-context boilerplate contained "File tools **resolve** relative paths…", so every workspace-wrapped subagent prompt classified as a mutation request; a read-only subagent then hit `final-answer readiness failed 3 times: the request requires a state change` — a gate it can never satisfy. Now:

- Sub-agent spawners pass the pristine task text through `Options.ClassifierTaskText` (a host-trusted channel captured before any wrapping); top-level turns are classified verbatim — no user-controllable pattern stripping (see review follow-up).
- `deliveryMutationExpected` is only armed when the registry actually has writer tools (`registryHasWriterTools`).
- The boilerplate wording avoids incidental action verbs (resolve → interpret) as defense in depth.

### 3. Progress-aware final-readiness budget (`internal/agent/agent.go`)

The readiness retry budget was a flat 3. A turn that keeps earning new host-observable receipts between blocks (fix → verify → re-review catching up to the latest mutation) is converging, not stalling — it now gets extended nudges up to a hard cap of 6. A stalled turn (no new receipts) still fails at 3. This removes the observed "model says done, banner says delivery incomplete" ending for converging turns while keeping the fail-fast bound.

### 4. Title/preview hygiene (`internal/agent/preview.go`, `save.go`, `internal/control/input.go`, `desktop/tabs.go`)

Delivery sessions were titled "你是谁？ \<delivery-run…": the trailing `<delivery-runtime>` marker survived preview derivation (the transient-block regex is prefix-anchored), and host-injected readiness nudges (persisted as `role:user`) counted as user turns for auto-title staging — in one observed case a readiness error became a topic title verbatim. Now:

- `StripTransientUserBlocks` also cuts the trailing delivery-runtime block.
- The synthetic-user prefix list moved to `agent.SyntheticUserPrefixes`; `agent.IsUserAuthoredTurn` (synthetic + steer filter) is shared by session previews, meta turn counts, and desktop topic auto-titles; `control.IsSyntheticUserMessage` delegates to it.
- Polluted auto-titles self-heal on next derivation (basis hash changes, same stage).

### 5. Tool-argument streaming liveness (`internal/provider/*`, `internal/agent/agent.go`, `internal/event*`, frontend)

A 30KB `write_file` body streamed for ~80s with zero UI movement: providers only emitted complete tool calls, and the frontend deliberately dropped partial dispatches. Now:

- openai/anthropic providers emit `ChunkToolCallArgsDelta` (one per 2KB bucket) while a call's arguments stream.
- The agent re-emits throttled (250ms) partial `ToolDispatch` events carrying cumulative `ArgChars`.
- The desktop upserts a live "receiving arguments ↓ 12.3k…" tool card for partial dispatches (merging with the full dispatch by ID), and the composer pill folds streamed arg chars into its token estimate (cleared when the round's usage arrives, so nothing double-counts).

### 6. Right-panel freshness + context-gauge guard (frontend)

- `usageSeq` increments on usage events from **any** source, so 会话指标/用量分析 keep refreshing during sub-agent runs (the executor-gated `usage` state still owns the context gauge semantics).
- A mid-turn context snapshot racing a rebuilt executor (`LastUsage() == nil` → used=0) no longer collapses the gauge to 0/1M while a turn is live; idle resets still apply.

## Compatibility audit

| Surface | Old data behavior | Conclusion |
| --- | --- | --- |
| `event.Tool.ArgChars` / wire `argChars` (omitempty) | Absent in old events; old frontends ignore unknown field, new frontend tolerates absence | Safe |
| `provider.ChunkType` enum insertion | In-memory only, never persisted or serialized | Safe |
| Session `.jsonl` / event-log format | Unchanged | Safe |
| `.jsonl.meta` `preview`/`turns` | Same fields; values now exclude host framing/synthetic turns (display-only, recomputed on next autosave) | Safe |
| Desktop topic auto-title meta (`stage`/`basisHash`) | Stage guard is monotonic; cleaned basis re-applies at equal stage via basisHash change | Safe (rare stage-inflated titles keep old text until more real turns arrive) |
| Subagent failure dumps | New additive directory under archive | Safe |
| `SteerText` / delivery marker replay | Marker text untouched; steer suffix-cut logic untouched | Safe |

## Cache and prompt-surface review

Cache-impact: the stable prompt prefix is untouched — no system prompt, tool schema, or request serialization changes; the new chunk type and events are response-parsing/UI-side only. The review contract and completion nudges do add provider-visible user-turn content, but only inside fresh per-run subagent sessions, so no cached prefix is invalidated; `deliveryRuntimeMarker` is byte-identical.
Cache-guard: `./scripts/cache-guard.sh` pass (tail_avg 92/95/95 vs threshold 90); `go test ./internal/provider ./internal/agent` green.
System-prompt-review: reviewed by SivanCola in-session — no system prompt text changed (`DefaultTaskSystemPrompt` / `DefaultReadOnlyTaskSystemPrompt` byte-identical); `task.go` changes are per-run subagent task framing (workspace-context wording, review_report contract) verified cache-neutral by the cache guard above.

## Verification

- Root module: `go test ./...` green (includes 6 new regression tests in `internal/agent/delivery_hardening_test.go`: framing-immune classification, read-only disarm end-to-end, report nudge recovery with preserved evidence, exhaustion error + transcript dump, progress-aware budget 3-vs-6, preview/synthetic filtering).
- Desktop module: `cd desktop && go test ./...` green (includes new `TestTopicTitleUserTurnsSkipHostFraming`).
- Frontend: `pnpm typecheck`, `check:css`, full `test:all` — 0 failures (includes new `use-controller-stream-progress.test.ts`, 14 assertions: partial-card upsert/merge, argChars flow, usageSeq, context no-regress guard).
- `./scripts/cache-guard.sh` pass.

## Review follow-up (`e3052d3ce`)

Addressed three P2 review findings:

1. **Trusted classifier channel** — delivery intent classification no longer pattern-strips host framing from the raw input (input dressed up as `<workspace-context>` could disarm the gates). Sub-agent spawners pass the pristine task via `Options.ClassifierTaskText`, captured before any wrapping; top-level turns are classified verbatim (pre-PR trust boundary restored). Spoof-resistance test added.
2. **Exact delivery-marker cut** — the trailing `<delivery-runtime>` strip is a byte-exact `CutSuffix` of the host marker; the previous lazy `$`-anchored regex could swallow user prose between a literal marker mention and the real suffix. Inline-mention preservation test added.
3. **ID-less partial dispatches** — a partial dispatch whose call ID has not arrived yet no longer creates a synthetic-id card the full dispatch can never merge with (orphaned forever-running duplicate); arg progress still feeds the pill and the card appears once the real ID arrives. Orphan regression test added.
