### PR TITLE
fix(cli): 修复 Windows 上 chooser 自由文本模式下宽字符输入的重绘问题

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -981,10 +981,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.input.Reset()
 					return m, finalize(m, cmds)
 				}
+				beforeInput := m.input.Value()
 				var ic tea.Cmd
 				m.input, ic = m.input.Update(msg)
 				cmds = append(cmds, ic)
 				m.growInputToFit()
+				if shouldClearWideInputChange(beforeInput, m.input.Value()) {
+					cmds = append(cmds, tea.ClearScreen)
+				}
 				return m, finalize(m, cmds)
 			}
 			return m.handleChooserKey(msg)

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2078,6 +2078,36 @@ func TestWideInputChangeRequestsClearScreen(t *testing.T) {
 	}
 }
 
+func TestChooserFreeTextWideInputChangeRequestsClearScreen(t *testing.T) {
+	prev := clearWideInputChanges
+	clearWideInputChanges = true
+	defer func() { clearWideInputChanges = prev }()
+
+	m := newTestChatTUI()
+	m.chooser = newChooser(event.Ask{
+		ID: "ask-1",
+		Questions: []event.AskQuestion{{
+			ID:     "q1",
+			Prompt: "Pick one",
+			Options: []event.AskOption{{
+				Label: "Option A",
+			}},
+		}},
+	})
+	m.chooser.typing = true
+	m.input.SetValue("天安a")
+	m.input.SetCursorColumn(len([]rune("天安a")))
+
+	next, cmd := m.update(tea.KeyPressMsg{Code: '门', Text: "门"})
+	got := next.(chatTUI)
+	if got.input.Value() != "天安a门" {
+		t.Fatalf("chooser free-text input should preserve the textarea value, got %q", got.input.Value())
+	}
+	if cmd == nil {
+		t.Fatal("chooser free-text wide-char input changes should request a full redraw")
+	}
+}
+
 func TestReplayActiveBranchClearsPlanModeAndMarksSessionSwitch(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{})


### PR DESCRIPTION
c146456d 添加的宽字符重绘修复（tea.ClearScreen）仅覆盖了
chatTUI.update() 底部的主输入路径。chooser 的 "Type something" 自由文本模式有自己的输入处理分支，该分支提前返回，完全绕过了
这一检查。

在 typing 分支中捕获 beforeInput，并应用相同的
shouldClearWideInputChange/tea.ClearScreen 逻辑，从而使输入到 自定义 Ask 答案中的中文、日文及其他宽字符也能在 Windows 上触发
完整的终端重绘。

修复 https://github.com/esengine/DeepSeek-Reasonix/issues/6368

│ fix(cli): repaint wide-character input in chooser free-text mode on Windows
│
│ The wide-character repaint fix (tea.ClearScreen) added in c146456d only
│ covered the normal input path at the bottom of chatTUI.update(). The
│ chooser's "Type something" free-text mode has its own input-handling
│ branch that returns early, bypassing that check entirely.
│
│ Capture beforeInput in the typing branch and apply the same
│ shouldClearWideInputChange/tea.ClearScreen logic there, so Chinese,
│ Japanese, and other wide characters typed into a custom Ask answer
│ also trigger a full terminal repaint on Windows.
│
│ Fixes #6368

## Summary
https://github.com/esengine/DeepSeek-Reasonix/issues/6368 中提及到在tui模式下触发ask时，如果选择了“自己输入”，则此时的录入模式仍旧出现“中英字符混排渲染问题”。本次pr基于c146456d 的提交进行了类似的修复。

*再次感谢c146456d 的作者！*

## Verification
1. 执行 `go build -o bin/reasonix.exe ./cmd/reasonix` 编译出可执行文件
2. 打开reasonix，并输入 “请你向我提出1个问题，给出2个选项，并支持我自己输入” ，触发ask场景（以下补充一个gif验证过程）

<img width="1858" height="887" alt="fix" src="https://github.com/user-attachments/assets/a50dde07-f74f-4381-a18e-cf3fb583f1d8" />


## Cache impact

Cache-impact: none - CLI TUI repaint only; no provider-visible prompt, tool schema, or request serialization changes.
Cache-guard: `go test ./internal/cli -run 'Test(WideInputChangeRequestsClearScreen|ChooserFreeTextWideInputChangeRequestsClearScreen)$'`; `go test ./internal/cli`
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.