### PR TITLE
fix(desktop): restore TurnActions visibility when steer sits between assistant and actions

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-process-fold.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-process-fold.test.ts
@@ -222,6 +222,25 @@ try {
   const segmentHeads = segmentDoc.querySelectorAll("button.turn-collapse__reasoning-head");
   ok(segmentHeads.length === 3, "every reasoning segment gets its own toggle");
   ok(Array.from(segmentHeads).every((head) => head.getAttribute("aria-expanded") === "true"), "reasoning segments default to expanded");
+
+  // #6393: a steer notice between the last assistant answer and TurnActions
+  // breaks the CSS sibling chain (.msg--assistant:hover + .turn-actions),
+  // hiding the copy button in creation mode because TurnActions starts with
+  // opacity:0; pointer-events:none and requires the sibling hover to reveal.
+  const steerBetweenDoc = render([
+    { kind: "user", id: "u-steer-bug", text: "do it" },
+    { kind: "assistant", id: "a-steer-bug", text: "here is the answer", reasoning: "", streaming: false, workDurationMs: 1_000 },
+    { kind: "notice", id: "n-steer-bug", level: "info", text: "↪ mid-turn steer between answer and actions" },
+  ]);
+  const turnActions = steerBetweenDoc.querySelector(".turn-actions");
+  ok(turnActions !== null, "#6393: TurnActions exists in DOM after steer");
+  ok(turnActions?.querySelector(".copybtn") !== null, "#6393: copy button exists inside TurnActions");
+  // The critical sibling-chain assertion: .turn-actions' previous sibling
+  // should be .msg--assistant for creation-mode CSS to reveal it on hover.
+  // With a steer in between, it's .steer-line instead → permanently hidden.
+  const prevSibling = turnActions?.previousElementSibling;
+  ok(prevSibling?.classList.contains("steer-line") === true, "#6393: TurnActions previous sibling is steer-line, NOT msg--assistant — CSS hover chain broken");
+  ok(prevSibling?.classList.contains("msg--assistant") === false, "#6393: CSS .msg--assistant:hover + .turn-actions will NOT match (steer-line sits between)");
 } finally {
   await server?.close();
   delete (globalThis as { localStorage?: Storage }).localStorage;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29988,10 +29988,14 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .app--creation .msg--assistant:hover + .turn-actions,
+.app--creation .steer-line:hover + .turn-actions,
+.app--creation .notice-line--delivery:hover + .turn-actions,
 .app--creation .turn-actions:hover,
 .app--creation .turn-actions:focus-within,
 .app--creation .turn-actions--open,
 :root[data-theme-style] .app--creation .msg--assistant:hover + .turn-actions,
+:root[data-theme-style] .app--creation .steer-line:hover + .turn-actions,
+:root[data-theme-style] .app--creation .notice-line--delivery:hover + .turn-actions,
 :root[data-theme-style] .app--creation .turn-actions:hover,
 :root[data-theme-style] .app--creation .turn-actions:focus-within,
 :root[data-theme-style] .app--creation .turn-actions--open {


### PR DESCRIPTION
## Before / After

| Before — steer visible, Copy/Fork/Rewind **hidden** | After — hover steer, Copy/Fork/Rewind **visible** |
|---|---|
| <img width="2400" height="1590" alt="bug-6393-before" src="https://github.com/user-attachments/assets/061934f2-a989-4c4a-ae99-1de7b2b4a946" /> | <img width="2400" height="1590" alt="bug-6393-after" src="https://github.com/user-attachments/assets/249a0f4d-55a0-4767-9b32-3fecfa033f58" /> |

## Problem

In creation mode, `.turn-actions` starts with `opacity: 0; pointer-events: none` and only becomes visible via CSS sibling hover (`.msg--assistant:hover + .turn-actions`). After #6351 refactored `partitionTurnItems` to place *all* assistant answers outside the work fold, steer and delivery notices can now render between the last assistant message and TurnActions, breaking the sibling chain. TurnActions — including the copy button — stays permanently invisible.

Fixes #6393.

## Solution

Add `.steer-line:hover + .turn-actions` and `.notice-line--delivery:hover + .turn-actions` selectors (with `:root[data-theme-style]` counterparts) to the existing creation-mode visibility rules. Zero JS changes — purely a CSS selector expansion.

## Changes

- `desktop/frontend/src/styles.css` — 4 new CSS selectors (+4 lines)
- `desktop/frontend/src/__tests__/transcript-process-fold.test.ts` — 4 assertions pinning the sibling-chain contract (+19 lines)

## Testing

```
npx tsx src/__tests__/transcript-process-fold.test.ts
# 33 passed, 0 failed — includes 4 #6393-specific assertions
```

## Notes for Reviewer

CSS-only fix — no DOM restructuring, no JS changes. The approach is intentionally minimal: if future element types also appear between `.msg--assistant` and `.turn-actions`, a follow-up should migrate to a container-based hover model (wrap outside content + TurnActions in `.turn-outside` and use `.turn-outside:hover .turn-actions`). That carries more regression risk today; this PR fixes the immediate regression with the smallest possible diff.

Cache-impact: none — stylesheet-only change, no provider/system-prompt/tool path touched.
Cache-guard: n/a — CSS change has no effect on cache-hit rate.