### PR TITLE
fix(desktop): prevent double-click race on topic archive (#6312)

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -571,6 +571,7 @@ export function ProjectTree({
   const visibleTopicsCollectorRef = useRef<TopicShortcutEntry[]>([]);
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
+  const trashingRef = useRef(false);
   const clickTimerRef = useRef<ProjectTreePendingTopicOpen | null>(null);
   useEffect(() => {
     return () => {
@@ -931,6 +932,8 @@ export function ProjectTree({
   };
 
   const trashTopic = async (topicId: string) => {
+    if (trashingRef.current) return;
+    trashingRef.current = true;
     try {
       await app.TrashTopic(topicId);
       setMenuTopic(null);
@@ -940,6 +943,8 @@ export function ProjectTree({
       await onTopicsChanged?.();
     } catch (err) {
       showToast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      trashingRef.current = false;
     }
   };
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5224,6 +5224,9 @@ func deleteTopicCreatedAt(workspaceRoot, topicID string) {
 	if err != nil {
 		return
 	}
+	if _, ok := created[topicID]; !ok {
+		return
+	}
 	delete(created, topicID)
 	_ = saveTopicCreatedAts(workspaceRoot, created)
 }
@@ -6319,56 +6322,40 @@ func (a *App) DeleteTopic(topicID string) error {
 }
 
 func (a *App) deleteTopic(topicID string) error {
+	// Deletion converges on the fully-deleted state instead of keying the
+	// whole cleanup on the title entry: a retry after a partial failure (or a
+	// concurrent duplicate delete) may find the title already gone while the
+	// sources map, created-at entry, sidebar index, or tombstone still need
+	// cleanup, so every step checks its own leftovers.
 	f := loadProjectsFile()
-	found := false
+	roots := make([]string, 0, len(f.Projects)+1)
 	for _, p := range f.Projects {
-		m, err := loadTopicTitlesForUpdate(p.Root)
+		roots = append(roots, p.Root)
+	}
+	roots = append(roots, "")
+	for _, root := range roots {
+		titles, err := loadTopicTitlesForUpdate(root)
 		if err != nil {
 			return err
 		}
-		if _, ok := m[topicID]; ok {
-			delete(m, topicID)
-			if err := saveTopicTitles(p.Root, m); err != nil {
+		if _, ok := titles[topicID]; ok {
+			delete(titles, topicID)
+			if err := saveTopicTitles(root, titles); err != nil {
 				return err
 			}
-			sources, err := loadTopicTitleSourcesForUpdate(p.Root)
-			if err != nil {
-				return err
-			}
-			delete(sources, topicID)
-			if err := saveTopicTitleSources(p.Root, sources); err != nil {
-				return err
-			}
-			deleteTopicCreatedAt(p.Root, topicID)
-			found = true
-			break
 		}
-	}
-	if !found {
-		m, err := loadTopicTitlesForUpdate("")
+		sources, err := loadTopicTitleSourcesForUpdate(root)
 		if err != nil {
 			return err
 		}
-		if _, ok := m[topicID]; ok {
-			delete(m, topicID)
-			if err := saveTopicTitles("", m); err != nil {
-				return err
-			}
-			sources, err := loadTopicTitleSourcesForUpdate("")
-			if err != nil {
-				return err
-			}
+		if _, ok := sources[topicID]; ok {
 			delete(sources, topicID)
-			if err := saveTopicTitleSources("", sources); err != nil {
+			if err := saveTopicTitleSources(root, sources); err != nil {
 				return err
 			}
-			deleteTopicCreatedAt("", topicID)
-			found = true
 		}
-	}
-	if !found {
-		// Topic already removed (e.g. concurrent trash) — idempotent, not an error.
-		return nil
+		deleteTopicCreatedAt(root, topicID)
+		_ = deleteTopicAutoTitleMeta(root, topicID)
 	}
 	if err := removeTopicFromProjectsFile(topicID); err != nil {
 		return err

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6367,7 +6367,8 @@ func (a *App) deleteTopic(topicID string) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("topic %q not found", topicID)
+		// Topic already removed (e.g. concurrent trash) — idempotent, not an error.
+		return nil
 	}
 	if err := removeTopicFromProjectsFile(topicID); err != nil {
 		return err

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6327,18 +6327,38 @@ func (a *App) deleteTopic(topicID string) error {
 	// concurrent duplicate delete) may find the title already gone while the
 	// sources map, created-at entry, sidebar index, or tombstone still need
 	// cleanup, so every step checks its own leftovers.
+	//
+	// Detailed cleanup is limited to roots that can actually hold the topic:
+	// roots whose sidebar index lists it, plus any root whose title map
+	// contains it. The title probe tolerates read errors on unindexed roots
+	// so unreadable metadata in an unrelated project cannot abort the
+	// deletion, while roots known to hold the topic still fail hard instead
+	// of being half-cleaned silently.
 	f := loadProjectsFile()
+	indexed := map[string]bool{
+		"": containsDesktopString(f.GlobalTopics, topicID) ||
+			containsDesktopString(f.GlobalPinnedTopics, topicID),
+	}
 	roots := make([]string, 0, len(f.Projects)+1)
 	for _, p := range f.Projects {
 		roots = append(roots, p.Root)
+		indexed[p.Root] = containsDesktopString(p.Topics, topicID) ||
+			containsDesktopString(p.PinnedTopics, topicID)
 	}
 	roots = append(roots, "")
 	for _, root := range roots {
 		titles, err := loadTopicTitlesForUpdate(root)
 		if err != nil {
-			return err
+			if indexed[root] {
+				return err
+			}
+			continue
 		}
-		if _, ok := titles[topicID]; ok {
+		_, hasTitle := titles[topicID]
+		if !hasTitle && !indexed[root] {
+			continue
+		}
+		if hasTitle {
 			delete(titles, topicID)
 			if err := saveTopicTitles(root, titles); err != nil {
 				return err

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5219,16 +5219,16 @@ func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
 	return saveTopicCreatedAts(workspaceRoot, created)
 }
 
-func deleteTopicCreatedAt(workspaceRoot, topicID string) {
+func deleteTopicCreatedAt(workspaceRoot, topicID string) error {
 	created, err := loadTopicCreatedAtsForUpdate(workspaceRoot)
 	if err != nil {
-		return
+		return err
 	}
 	if _, ok := created[topicID]; !ok {
-		return
+		return nil
 	}
 	delete(created, topicID)
-	_ = saveTopicCreatedAts(workspaceRoot, created)
+	return saveTopicCreatedAts(workspaceRoot, created)
 }
 
 // topicIndexMu serializes recovery writes to desktop-projects.json and topic
@@ -6372,8 +6372,12 @@ func (a *App) deleteTopic(topicID string) error {
 				return err
 			}
 		}
-		deleteTopicCreatedAt(root, topicID)
-		_ = deleteTopicAutoTitleMeta(root, topicID)
+		if err := deleteTopicCreatedAt(root, topicID); err != nil {
+			return err
+		}
+		if err := deleteTopicAutoTitleMeta(root, topicID); err != nil {
+			return err
+		}
 		if hasTitle {
 			delete(titles, topicID)
 			if err := saveTopicTitles(root, titles); err != nil {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6358,12 +6358,10 @@ func (a *App) deleteTopic(topicID string) error {
 		if !hasTitle && !indexed[root] {
 			continue
 		}
-		if hasTitle {
-			delete(titles, topicID)
-			if err := saveTopicTitles(root, titles); err != nil {
-				return err
-			}
-		}
+		// Fallible cleanup runs before the title entry is removed: for a
+		// title-map-only topic the title is the only locator that makes this
+		// root a candidate again, so it must survive a failed attempt and be
+		// deleted last.
 		sources, err := loadTopicTitleSourcesForUpdate(root)
 		if err != nil {
 			return err
@@ -6376,6 +6374,12 @@ func (a *App) deleteTopic(topicID string) error {
 		}
 		deleteTopicCreatedAt(root, topicID)
 		_ = deleteTopicAutoTitleMeta(root, topicID)
+		if hasTitle {
+			delete(titles, topicID)
+			if err := saveTopicTitles(root, titles); err != nil {
+				return err
+			}
+		}
 	}
 	if err := removeTopicFromProjectsFile(topicID); err != nil {
 		return err

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -357,6 +357,116 @@ func TestDeleteTopicClearsPinnedTopic(t *testing.T) {
 	}
 }
 
+func assertTopicFullyDeleted(t *testing.T, projectRoot, topicID string) {
+	t.Helper()
+	if got := loadTopicTitle(projectRoot, topicID); got != "" {
+		t.Fatalf("topic title = %q, want deleted", got)
+	}
+	if got := loadTopicTitleSources(projectRoot); got[topicID] != "" {
+		t.Fatalf("title source = %q, want deleted (all sources: %v)", got[topicID], got)
+	}
+	if got := loadTopicCreatedAts(projectRoot); got[topicID] != 0 {
+		t.Fatalf("created-at = %d, want deleted (all created: %v)", got[topicID], got)
+	}
+	f := loadProjectsFile()
+	if len(f.Projects) != 1 {
+		t.Fatalf("projects len = %d, want 1", len(f.Projects))
+	}
+	if containsDesktopString(f.Projects[0].Topics, topicID) {
+		t.Fatalf("project topics = %#v, %q should be removed", f.Projects[0].Topics, topicID)
+	}
+	if !containsDesktopString(f.DeletedTopics, topicID) {
+		t.Fatalf("deletedTopics = %#v, want tombstone for %q", f.DeletedTopics, topicID)
+	}
+}
+
+func TestDeleteTopicRetryAfterPartialFailureCompletesCleanup(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_partial_delete"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Doomed"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := setTopicCreatedAt(projectRoot, topicID, 4242); err != nil {
+		t.Fatalf("set created-at: %v", err)
+	}
+	if err := prependTopicInProjectsFile(projectRoot, topicID, false); err != nil {
+		t.Fatalf("index topic: %v", err)
+	}
+
+	// Inject a failure between the title removal and the rest of the cleanup:
+	// swapping the title-sources file for a directory makes its load fail
+	// right after the title entry is already gone.
+	sourcesPath := topicTitleSourcesPath(projectRoot)
+	backupPath := sourcesPath + ".bak"
+	if err := os.Rename(sourcesPath, backupPath); err != nil {
+		t.Fatalf("stash title sources: %v", err)
+	}
+	if err := os.Mkdir(sourcesPath, 0o755); err != nil {
+		t.Fatalf("block title sources: %v", err)
+	}
+
+	app := NewApp()
+	if err := app.DeleteTopic(topicID); err == nil {
+		t.Fatalf("delete with failing title-sources load should report an error")
+	}
+	if got := loadTopicTitle(projectRoot, topicID); got != "" {
+		t.Fatalf("first attempt should have removed the title, got %q", got)
+	}
+
+	// Heal the fault and retry: the retry must finish the remaining cleanup
+	// instead of treating the missing title entry as an already-finished
+	// deletion.
+	if err := os.Remove(sourcesPath); err != nil {
+		t.Fatalf("unblock title sources: %v", err)
+	}
+	if err := os.Rename(backupPath, sourcesPath); err != nil {
+		t.Fatalf("restore title sources: %v", err)
+	}
+	if err := app.DeleteTopic(topicID); err != nil {
+		t.Fatalf("retry delete: %v", err)
+	}
+	assertTopicFullyDeleted(t, projectRoot, topicID)
+}
+
+func TestDeleteTopicWithoutTitleEntryStillRemovesIndexAndTombstones(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_leftover_delete"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Doomed"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := setTopicCreatedAt(projectRoot, topicID, 4242); err != nil {
+		t.Fatalf("set created-at: %v", err)
+	}
+	if err := prependTopicInProjectsFile(projectRoot, topicID, false); err != nil {
+		t.Fatalf("index topic: %v", err)
+	}
+	// Strip just the title entry to mimic an interrupted earlier deletion:
+	// sources, created-at, and the sidebar index survived it.
+	titles, err := loadTopicTitlesForUpdate(projectRoot)
+	if err != nil {
+		t.Fatalf("load titles: %v", err)
+	}
+	delete(titles, topicID)
+	if err := saveTopicTitles(projectRoot, titles); err != nil {
+		t.Fatalf("save titles: %v", err)
+	}
+
+	if err := NewApp().DeleteTopic(topicID); err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+	assertTopicFullyDeleted(t, projectRoot, topicID)
+}
+
 func TestRenameProjectUpdatesSidebarTitle(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -369,11 +369,12 @@ func assertTopicFullyDeleted(t *testing.T, projectRoot, topicID string) {
 		t.Fatalf("created-at = %d, want deleted (all created: %v)", got[topicID], got)
 	}
 	f := loadProjectsFile()
-	if len(f.Projects) != 1 {
-		t.Fatalf("projects len = %d, want 1", len(f.Projects))
+	i := projectIndexByRoot(f.Projects, projectRoot)
+	if i < 0 {
+		t.Fatalf("projects = %#v, want entry for %q", f.Projects, projectRoot)
 	}
-	if containsDesktopString(f.Projects[0].Topics, topicID) {
-		t.Fatalf("project topics = %#v, %q should be removed", f.Projects[0].Topics, topicID)
+	if containsDesktopString(f.Projects[i].Topics, topicID) {
+		t.Fatalf("project topics = %#v, %q should be removed", f.Projects[i].Topics, topicID)
 	}
 	if !containsDesktopString(f.DeletedTopics, topicID) {
 		t.Fatalf("deletedTopics = %#v, want tombstone for %q", f.DeletedTopics, topicID)
@@ -465,6 +466,59 @@ func TestDeleteTopicWithoutTitleEntryStillRemovesIndexAndTombstones(t *testing.T
 		t.Fatalf("delete topic: %v", err)
 	}
 	assertTopicFullyDeleted(t, projectRoot, topicID)
+}
+
+func TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	// The broken project is added first so the cleanup sweep meets it before
+	// reaching the target root.
+	brokenRoot := t.TempDir()
+	targetRoot := t.TempDir()
+	topicID := "topic_target_delete"
+	if err := addProject(brokenRoot, ""); err != nil {
+		t.Fatalf("add broken project: %v", err)
+	}
+	if err := addProject(targetRoot, ""); err != nil {
+		t.Fatalf("add target project: %v", err)
+	}
+	if err := setTopicTitle(brokenRoot, "topic_unrelated", "Unrelated"); err != nil {
+		t.Fatalf("set unrelated topic title: %v", err)
+	}
+	if err := setTopicTitle(targetRoot, topicID, "Doomed"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := setTopicCreatedAt(targetRoot, topicID, 4242); err != nil {
+		t.Fatalf("set created-at: %v", err)
+	}
+	if err := prependTopicInProjectsFile(targetRoot, topicID, false); err != nil {
+		t.Fatalf("index topic: %v", err)
+	}
+
+	// Make the unrelated project's title metadata unreadable: deleting the
+	// target topic must skip over it instead of aborting half-way.
+	for _, path := range []string{topicTitlesPath(brokenRoot), topicTitleSourcesPath(brokenRoot)} {
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("remove %s: %v", path, err)
+		}
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatalf("block %s: %v", path, err)
+		}
+	}
+
+	if err := NewApp().DeleteTopic(topicID); err != nil {
+		t.Fatalf("delete topic with unrelated broken project: %v", err)
+	}
+	assertTopicFullyDeleted(t, targetRoot, topicID)
+
+	// The broken project's own sidebar index must be untouched.
+	f := loadProjectsFile()
+	if i := projectIndexByRoot(f.Projects, brokenRoot); i < 0 {
+		t.Fatalf("projects = %#v, want entry for broken root", f.Projects)
+	}
+	if containsDesktopString(f.DeletedTopics, "topic_unrelated") {
+		t.Fatalf("deletedTopics = %#v, unrelated topic must not be tombstoned", f.DeletedTopics)
+	}
 }
 
 func TestRenameProjectUpdatesSidebarTitle(t *testing.T) {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -368,6 +368,11 @@ func assertTopicFullyDeleted(t *testing.T, projectRoot, topicID string) {
 	if got := loadTopicCreatedAts(projectRoot); got[topicID] != 0 {
 		t.Fatalf("created-at = %d, want deleted (all created: %v)", got[topicID], got)
 	}
+	if got := loadTopicAutoTitleMeta(projectRoot); got != nil {
+		if meta, ok := got[topicID]; ok {
+			t.Fatalf("auto-title meta = %+v, want deleted (all auto-title meta: %v)", meta, got)
+		}
+	}
 	f := loadProjectsFile()
 	i := projectIndexByRoot(f.Projects, projectRoot)
 	if i < 0 {
@@ -399,9 +404,8 @@ func TestDeleteTopicRetryAfterPartialFailureCompletesCleanup(t *testing.T) {
 		t.Fatalf("index topic: %v", err)
 	}
 
-	// Inject a failure between the title removal and the rest of the cleanup:
-	// swapping the title-sources file for a directory makes its load fail
-	// right after the title entry is already gone.
+	// Inject a failure before title removal: swapping the title-sources file
+	// for a directory makes its load fail while the title locator is intact.
 	sourcesPath := topicTitleSourcesPath(projectRoot)
 	backupPath := sourcesPath + ".bak"
 	if err := os.Rename(sourcesPath, backupPath); err != nil {
@@ -513,6 +517,67 @@ func TestDeleteTopicTitleOnlyRetryAfterSourceFailureCompletesCleanup(t *testing.
 		t.Fatalf("retry delete: %v", err)
 	}
 	assertTopicFullyDeleted(t, projectRoot, topicID)
+}
+
+func TestDeleteTopicTitleOnlyRetryAfterSecondaryMetadataFailureCompletesCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(string) string
+	}{
+		{name: "created-at", path: topicCreatedAtsPath},
+		{name: "auto-title-meta", path: topicAutoTitleMetaPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateDesktopUserDirs(t)
+
+			projectRoot := t.TempDir()
+			topicID := "topic_title_only_" + strings.ReplaceAll(tt.name, "-", "_")
+			if err := addProject(projectRoot, ""); err != nil {
+				t.Fatalf("add project: %v", err)
+			}
+			if err := setTopicTitle(projectRoot, topicID, "Doomed"); err != nil {
+				t.Fatalf("set topic title: %v", err)
+			}
+			if err := setTopicCreatedAt(projectRoot, topicID, 4242); err != nil {
+				t.Fatalf("set created-at: %v", err)
+			}
+			if err := recordTopicAutoTitleMeta(projectRoot, topicID, autoTopicTitleProposal{
+				Stage: 1, UserTurns: 1, BasisHash: "review-basis",
+			}); err != nil {
+				t.Fatalf("record auto-title meta: %v", err)
+			}
+
+			blockedPath := tt.path(projectRoot)
+			backupPath := blockedPath + ".bak"
+			if err := os.Rename(blockedPath, backupPath); err != nil {
+				t.Fatalf("stash %s: %v", tt.name, err)
+			}
+			if err := os.Mkdir(blockedPath, 0o755); err != nil {
+				t.Fatalf("block %s: %v", tt.name, err)
+			}
+
+			app := NewApp()
+			if err := app.DeleteTopic(topicID); err == nil {
+				t.Fatalf("delete with failing %s cleanup should report an error", tt.name)
+			}
+			if got := loadTopicTitle(projectRoot, topicID); got != "Doomed" {
+				t.Fatalf("failed attempt must keep the title as the root locator, got %q", got)
+			}
+
+			if err := os.Remove(blockedPath); err != nil {
+				t.Fatalf("unblock %s: %v", tt.name, err)
+			}
+			if err := os.Rename(backupPath, blockedPath); err != nil {
+				t.Fatalf("restore %s: %v", tt.name, err)
+			}
+			if err := app.DeleteTopic(topicID); err != nil {
+				t.Fatalf("retry delete after %s failure: %v", tt.name, err)
+			}
+			assertTopicFullyDeleted(t, projectRoot, topicID)
+		})
+	}
 }
 
 func TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage(t *testing.T) {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -415,12 +415,12 @@ func TestDeleteTopicRetryAfterPartialFailureCompletesCleanup(t *testing.T) {
 	if err := app.DeleteTopic(topicID); err == nil {
 		t.Fatalf("delete with failing title-sources load should report an error")
 	}
-	if got := loadTopicTitle(projectRoot, topicID); got != "" {
-		t.Fatalf("first attempt should have removed the title, got %q", got)
+	if got := loadTopicTitle(projectRoot, topicID); got != "Doomed" {
+		t.Fatalf("failed attempt must keep the title as the root locator, got %q", got)
 	}
 
 	// Heal the fault and retry: the retry must finish the remaining cleanup
-	// instead of treating the missing title entry as an already-finished
+	// instead of treating a partially-deleted topic as an already-finished
 	// deletion.
 	if err := os.Remove(sourcesPath); err != nil {
 		t.Fatalf("unblock title sources: %v", err)
@@ -464,6 +464,53 @@ func TestDeleteTopicWithoutTitleEntryStillRemovesIndexAndTombstones(t *testing.T
 
 	if err := NewApp().DeleteTopic(topicID); err != nil {
 		t.Fatalf("delete topic: %v", err)
+	}
+	assertTopicFullyDeleted(t, projectRoot, topicID)
+}
+
+func TestDeleteTopicTitleOnlyRetryAfterSourceFailureCompletesCleanup(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_title_only_delete"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	// No prependTopicInProjectsFile: the topic renders purely through the
+	// orderedTopicIDs title-map fallback, so the title entry is the only
+	// locator a retry can use.
+	if err := setTopicTitle(projectRoot, topicID, "Doomed"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	if err := setTopicCreatedAt(projectRoot, topicID, 4242); err != nil {
+		t.Fatalf("set created-at: %v", err)
+	}
+
+	sourcesPath := topicTitleSourcesPath(projectRoot)
+	backupPath := sourcesPath + ".bak"
+	if err := os.Rename(sourcesPath, backupPath); err != nil {
+		t.Fatalf("stash title sources: %v", err)
+	}
+	if err := os.Mkdir(sourcesPath, 0o755); err != nil {
+		t.Fatalf("block title sources: %v", err)
+	}
+
+	app := NewApp()
+	if err := app.DeleteTopic(topicID); err == nil {
+		t.Fatalf("delete with failing title-sources load should report an error")
+	}
+	if got := loadTopicTitle(projectRoot, topicID); got != "Doomed" {
+		t.Fatalf("failed attempt must keep the title as the root locator, got %q", got)
+	}
+
+	if err := os.Remove(sourcesPath); err != nil {
+		t.Fatalf("unblock title sources: %v", err)
+	}
+	if err := os.Rename(backupPath, sourcesPath); err != nil {
+		t.Fatalf("restore title sources: %v", err)
+	}
+	if err := app.DeleteTopic(topicID); err != nil {
+		t.Fatalf("retry delete: %v", err)
 	}
 	assertTopicFullyDeleted(t, projectRoot, topicID)
 }


### PR DESCRIPTION
Two-layer defense against the archive double-click race that caused 'topic not found' errors, rendering loops, and session corruption:

1. Frontend (ProjectTree.tsx): add trashingRef guard — subsequent clicks are silently ignored while a trash operation is in flight, using the same pattern as creatingRef for topic creation.

2. Backend (tabs.go): make deleteTopic idempotent — when the topic is already removed (e.g. by a concurrent trash), return nil instead of an error. The desired end state is already achieved.

Closes #6312

## Summary

- Frontend: `trashingRef` guard in `ProjectTree.tsx` ignores repeat clicks while a trash operation is in flight.
- Backend: `deleteTopic` treats an already-removed topic as success instead of an error, and converges on the fully-deleted state — a retry after a partial failure finishes the remaining cleanup (title sources, created-at, auto-title meta, sidebar index, delete tombstone) instead of returning success early.
- Cleanup is scoped to candidate roots (sidebar index hit or title-map hit), so unreadable metadata in an unrelated project cannot abort deleting a topic that lives elsewhere; roots that actually hold the topic still fail hard.
- Within each root the fallible cleanup runs first and the title entry is deleted last, so a failed attempt always leaves a locator behind and title-map-only topics stay retryable.
- Created-at and auto-title-meta cleanup errors are propagated before title removal, preventing secondary metadata from being stranded behind a false success.

## Verification

- `cd desktop && go test ./...` — full desktop module green.
- `cd desktop && go test -race -run 'Topic' .` — green.
- New regression tests: `TestDeleteTopicRetryAfterPartialFailureCompletesCleanup` (fault-injected first attempt, retry must finish cleanup), `TestDeleteTopicWithoutTitleEntryStillRemovesIndexAndTombstones` (leftover state converges), `TestDeleteTopicIgnoresUnrelatedProjectMetadataDamage` (broken unrelated project must not block deletion), `TestDeleteTopicTitleOnlyRetryAfterSourceFailureCompletesCleanup` (title-map-only topic keeps its locator across a failed attempt), `TestDeleteTopicTitleOnlyRetryAfterSecondaryMetadataFailureCompletesCleanup` (created-at and auto-title-meta failures preserve the locator and retry cleanly). Each fails against the pre-fix code and passes with it.
- Frontend typecheck / test typecheck / CSS checks and the project-tree runtime suite covered by CI on the PR head.

## Cache impact

Cache-impact: none — desktop sidebar metadata cleanup only; no provider-visible prompt, tool schema, or serialization surface is touched.
Cache-guard: not applicable (no provider-visible change).
System-prompt-review: N/A