### PR TITLE
fix(plugin): support marketplace preflight without Windows console flashes / 支持市场预检并消除 Windows 黑框

### DIFF
--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -240,12 +240,17 @@ third-party install scripts during plugin installation.
 ## Codex & Claude Compatibility
 
 Reasonix also reads Codex plugin manifests at `.codex-plugin/plugin.json` and
-Claude Marketplace manifests at `.claude-plugin/plugin.json`. Claude plugin
+Claude plugin manifests at `.claude-plugin/plugin.json`. Claude plugin
 capabilities Reasonix does not map yet (`agents/`,
 `hooks/hooks.json`, `.mcp.json`) surface as install warnings instead of being
-silently dropped; multi-plugin `marketplace.json` indexes are not supported —
-install each plugin directory individually. For packages such
-as Superpowers and Claude-style skill packs, Reasonix maps:
+silently dropped. GitHub-hosted multi-plugin marketplaces with a
+`.claude-plugin/marketplace.json` can be installed from the repository root
+when their plugin entries use relative string sources such as
+`./plugins/example`; preview shows one action per plugin before anything is
+written. Set the optional install name to a marketplace plugin name to select
+only that entry. External/object, npm, `strict: false`, and other advanced
+marketplace source protocols are not implemented yet. For packages such as
+Superpowers and Claude-style skill packs, Reasonix maps:
 
 - `skills` to Reasonix skill roots. A Claude manifest that declares no
   `skills` field falls back to the conventional `skills/` (or `.claude/skills/`)
@@ -276,8 +281,7 @@ as Superpowers and Claude-style skill packs, Reasonix maps:
   are interpreted as seconds.
 
 Unsupported Claude hook item types are skipped with a warning. Reasonix does not
-run third-party install scripts or implement marketplace-specific install
-protocols.
+run third-party install scripts.
 
 Plugin hooks receive these environment variables:
 

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -246,11 +246,13 @@ capabilities Reasonix does not map yet (`agents/`,
 silently dropped. GitHub-hosted multi-plugin marketplaces with a
 `.claude-plugin/marketplace.json` can be installed from the repository root
 when their plugin entries use relative string sources such as
-`./plugins/example`; preview shows one action per plugin before anything is
-written. Set the optional install name to a marketplace plugin name to select
-only that entry. External/object, npm, `strict: false`, and other advanced
-marketplace source protocols are not implemented yet. For packages such as
-Superpowers and Claude-style skill packs, Reasonix maps:
+`./plugins/example` or `plugins/example`; preview shows one action per plugin
+before anything is written. Set the optional install name to a marketplace
+plugin name to select only that entry. External/object, npm, `strict: false`,
+and other advanced marketplace source protocols are not implemented yet:
+those entries are skipped with a warning during a full-marketplace install,
+and reported as an error when one of them is selected by name. For packages
+such as Superpowers and Claude-style skill packs, Reasonix maps:
 
 - `skills` to Reasonix skill roots. A Claude manifest that declares no
   `skills` field falls back to the conventional `skills/` (or `.claude/skills/`)

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -220,8 +220,11 @@ Reasonix 原生插件在根目录声明 `reasonix-plugin.json`：
 
 Reasonix 也会读取 `.codex-plugin/plugin.json` 和 `.claude-plugin/plugin.json`。
 Reasonix 尚未映射的 Claude 插件能力（`agents/`、`hooks/hooks.json`、
-`.mcp.json`）会以安装警告的形式提示，而不是被静默丢弃；多插件的
-`marketplace.json` 索引暂不支持——请逐个安装插件目录。
+`.mcp.json`）会以安装警告的形式提示，而不是被静默丢弃。GitHub 仓库若在
+`.claude-plugin/marketplace.json` 中通过 `./plugins/example` 这类相对字符串
+列出多个插件，可以直接从仓库根目录安装；预检会在写入前逐项展示安装动作。
+填写可选安装名称时，可只选择 marketplace 中的同名插件。外部/object 来源、
+npm、`strict: false` 以及其他高级 marketplace 来源协议暂未实现。
 对于 Superpowers 和 Claude 风格 skill 包，Reasonix 会映射：
 
 - `skills` 到 Reasonix skill root。Claude 清单若未声明 `skills` 字段，会回退到
@@ -245,8 +248,7 @@ Reasonix 尚未映射的 Claude 插件能力（`agents/`、`hooks/hooks.json`、
   Claude 的 `matcher` 字段会映射到 Reasonix `match`；hook 命令以插件根目录作为
   `cwd` 执行；Claude `timeout` 按秒解析。
 
-不支持的 Claude hook item type 会跳过并产生 warning。Reasonix 不会执行第三方安装脚本，
-也不会实现 marketplace 专用安装协议。
+不支持的 Claude hook item type 会跳过并产生 warning。Reasonix 不会执行第三方安装脚本。
 
 插件 hook 会收到这些环境变量：
 

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -221,10 +221,12 @@ Reasonix 原生插件在根目录声明 `reasonix-plugin.json`：
 Reasonix 也会读取 `.codex-plugin/plugin.json` 和 `.claude-plugin/plugin.json`。
 Reasonix 尚未映射的 Claude 插件能力（`agents/`、`hooks/hooks.json`、
 `.mcp.json`）会以安装警告的形式提示，而不是被静默丢弃。GitHub 仓库若在
-`.claude-plugin/marketplace.json` 中通过 `./plugins/example` 这类相对字符串
-列出多个插件，可以直接从仓库根目录安装；预检会在写入前逐项展示安装动作。
-填写可选安装名称时，可只选择 marketplace 中的同名插件。外部/object 来源、
-npm、`strict: false` 以及其他高级 marketplace 来源协议暂未实现。
+`.claude-plugin/marketplace.json` 中通过 `./plugins/example` 或
+`plugins/example` 这类相对字符串列出多个插件，可以直接从仓库根目录安装；
+预检会在写入前逐项展示安装动作。填写可选安装名称时，可只选择 marketplace
+中的同名插件。外部/object 来源、npm、`strict: false` 以及其他高级
+marketplace 来源协议暂未实现：整库安装时这类条目会跳过并给出警告，
+按名称选中这类条目时则直接报错。
 对于 Superpowers 和 Claude 风格 skill 包，Reasonix 会映射：
 
 - `skills` 到 Reasonix skill root。Claude 清单若未声明 `skills` 字段，会回退到

--- a/internal/bot/project_index.go
+++ b/internal/bot/project_index.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/proc"
 	"reasonix/internal/secrets"
 )
 
@@ -618,6 +619,9 @@ func searchBotProjectsWithRG(ctx context.Context, rg string, projects []botProje
 	args = append(args, roots...)
 	cmd := exec.CommandContext(ctx, rg, args...)
 	cmd.Env = secrets.ProcessEnv()
+	// The desktop app hosts bot bridges in the GUI process; without this an
+	// rg search flashes a console window on Windows.
+	proc.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -190,6 +190,10 @@ func (t *installSourceTool) Execute(ctx context.Context, raw json.RawMessage) (s
 	if err != nil {
 		return "", err
 	}
+	// Marketplace planning may keep one temporary clone alive so apply can
+	// reuse the exact approved snapshot. Clean it on every exit path, including
+	// plan-ID mismatch or host approval denial before executeApply runs.
+	defer cleanupActionResources(actions)
 	planID := computePlanID(req, actions)
 	if len(actions) == 0 {
 		out := response{
@@ -303,6 +307,15 @@ func (t *installSourceTool) executeApply(ctx context.Context, req request, actio
 		Warnings: warnings,
 		Next:     next,
 	})
+}
+
+func cleanupActionResources(actions []action) {
+	for i := range actions {
+		if actions[i].cleanup != nil {
+			actions[i].cleanup()
+			actions[i].cleanup = nil
+		}
+	}
 }
 
 // executeUninstall handles op=uninstall. It locates the named entry in the

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1706,6 +1706,155 @@ func TestGitHubPluginPlanMatchesApply(t *testing.T) {
 	}
 }
 
+// TestGitHubClaudeMarketplacePlansAndAppliesRelativePlugins pins the desktop
+// workflow reported by users: entering a GitHub marketplace root should plan
+// each relative-path plugin, then install all approved entries from one clone.
+func TestGitHubClaudeMarketplacePlansAndAppliesRelativePlugins(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "legal-tools",
+  "owner": {"name": "Legal Team"},
+  "plugins": [
+    {"name": "beta-legal", "source": "./plugins/beta"},
+    {"name": "alpha-legal", "source": "./plugins/alpha"}
+  ]
+}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "alpha", ".claude-plugin", "plugin.json"), `{"name":"alpha-legal","version":"1.0.0"}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "alpha", "skills", "alpha", "SKILL.md"), "---\ndescription: alpha\n---\nAlpha")
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "beta", ".claude-plugin", "plugin.json"), `{"name":"beta-legal","version":"2.0.0"}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "beta", "commands", "review.md"), "---\ndescription: review\n---\nReview")
+
+	project := t.TempDir()
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: project, HomeDir: home})
+	tool := tl.(*installSourceTool)
+	cloneCalls := 0
+	cleanupCalls := 0
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		cloneCalls++
+		if source != "https://github.com/acme/legal-tools" {
+			t.Fatalf("unexpected extra clone for %q", source)
+		}
+		return marketplaceRoot, "cafe0001", func() { cleanupCalls++ }, nil
+	}
+
+	plan := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+	})
+	if !plan.OK || plan.Status != "planned" || len(plan.Actions) != 2 {
+		t.Fatalf("plan response = %+v", plan)
+	}
+	if plan.Actions[0].Name != "alpha-legal" || plan.Actions[1].Name != "beta-legal" {
+		t.Fatalf("actions = %+v, want stable marketplace-name order", plan.Actions)
+	}
+	if plan.Actions[0].Source != "https://github.com/acme/legal-tools/tree/main/plugins/alpha" ||
+		plan.Actions[1].Source != "https://github.com/acme/legal-tools/tree/main/plugins/beta" {
+		t.Fatalf("marketplace action sources = %q / %q", plan.Actions[0].Source, plan.Actions[1].Source)
+	}
+	if cloneCalls != 1 || cleanupCalls != 1 {
+		t.Fatalf("preview clone/cleanup calls = %d/%d, want 1/1", cloneCalls, cleanupCalls)
+	}
+
+	applied := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if !applied.OK || applied.Status != "done" || len(applied.Actions) != 2 {
+		t.Fatalf("apply response = %+v", applied)
+	}
+	if cloneCalls != 2 || cleanupCalls != 2 {
+		t.Fatalf("preview+apply clone/cleanup calls = %d/%d, want 2/2 (one clone per phase)", cloneCalls, cleanupCalls)
+	}
+	for _, name := range []string{"alpha-legal", "beta-legal"} {
+		if _, ok, err := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), name); err != nil || !ok {
+			t.Fatalf("installed plugin %q missing: ok=%v err=%v", name, ok, err)
+		}
+	}
+}
+
+func TestGitHubClaudeMarketplaceNameSelectsOnePlugin(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "legal-tools",
+  "plugins": [
+    {"name": "alpha-legal", "source": "./alpha"},
+    {"name": "beta-legal", "source": "./beta"}
+  ]
+}`)
+	for _, name := range []string{"alpha-legal", "beta-legal"} {
+		dir := strings.TrimSuffix(name, "-legal")
+		writeFile(t, filepath.Join(marketplaceRoot, dir, ".claude-plugin", "plugin.json"), fmt.Sprintf(`{"name":%q}`, name))
+	}
+
+	tl := NewTool(Options{ProjectRoot: t.TempDir(), HomeDir: t.TempDir()})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() {}, nil
+	}
+	plan := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+		"name":   "beta-legal",
+	})
+	if len(plan.Actions) != 1 || plan.Actions[0].Name != "beta-legal" {
+		t.Fatalf("selected plan = %+v, want only beta-legal", plan.Actions)
+	}
+}
+
+func TestGitHubClaudeMarketplaceRejectsEscapingRelativeSource(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "unsafe-tools",
+  "plugins": [{"name": "escape", "source": "./../escape"}]
+}`)
+
+	tl := NewTool(Options{ProjectRoot: t.TempDir(), HomeDir: t.TempDir()})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() {}, nil
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"source": "https://github.com/acme/unsafe-tools",
+		"kind":   "plugin",
+	})
+	_, err := tl.Execute(context.Background(), raw)
+	if err == nil || !strings.Contains(err.Error(), "escapes") {
+		t.Fatalf("error = %v, want marketplace path escape rejection", err)
+	}
+}
+
+func TestGitHubClaudeMarketplaceCleansCloneWhenApprovalIsDenied(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "one-tool",
+  "plugins": [{"name": "alpha", "source": "./alpha"}]
+}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "alpha", ".claude-plugin", "plugin.json"), `{"name":"alpha"}`)
+
+	cleanupCalls := 0
+	tl := NewTool(Options{
+		ProjectRoot: t.TempDir(),
+		HomeDir:     t.TempDir(),
+		Approval: func(actions []action) error {
+			return errors.New("not approved")
+		},
+	})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() { cleanupCalls++ }, nil
+	}
+	resp := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/one-tool",
+		"kind":   "plugin",
+		"apply":  true,
+	})
+	if resp.Status != "denied" || cleanupCalls != 1 {
+		t.Fatalf("response=%+v cleanupCalls=%d, want denied and one cleanup", resp, cleanupCalls)
+	}
+}
+
 // TestGitHubPluginApplyRefusesUnpinnableDrift pins the snapshot contract: when
 // the source resolves to a different commit than the plan approved and the
 // approved snapshot cannot be restored, apply must refuse instead of

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -1855,6 +1855,136 @@ func TestGitHubClaudeMarketplaceCleansCloneWhenApprovalIsDenied(t *testing.T) {
 	}
 }
 
+// TestGitHubClaudeMarketplaceAcceptsBarePathsAndSkipsUnsupported pins the
+// widened source subset: bare relative paths ("plugins/alpha") plan like
+// "./"-prefixed ones, while object sources, external URLs, and invalid names
+// skip with a warning instead of failing the whole plan.
+func TestGitHubClaudeMarketplaceAcceptsBarePathsAndSkipsUnsupported(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "legal-tools",
+  "metadata": {"pluginRoot": "plugins"},
+  "plugins": [
+    {"name": "alpha-legal", "source": "alpha"},
+    {"name": "beta-legal", "source": "./beta"},
+    {"name": "external", "source": "https://github.com/acme/elsewhere"},
+    {"name": "object", "source": {"source": "github", "repo": "acme/elsewhere"}},
+    {"name": "bad/name", "source": "./bad"}
+  ]
+}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "alpha", ".claude-plugin", "plugin.json"), `{"name":"alpha-legal"}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "beta", ".claude-plugin", "plugin.json"), `{"name":"beta-legal"}`)
+
+	tl := NewTool(Options{ProjectRoot: t.TempDir(), HomeDir: t.TempDir()})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() {}, nil
+	}
+	plan := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+	})
+	if !plan.OK || plan.Status != "planned" || len(plan.Actions) != 2 {
+		t.Fatalf("plan response = %+v", plan)
+	}
+	if plan.Actions[0].Name != "alpha-legal" || plan.Actions[1].Name != "beta-legal" {
+		t.Fatalf("actions = %+v, want alpha-legal and beta-legal", plan.Actions)
+	}
+	if plan.Actions[0].Source != "https://github.com/acme/legal-tools/tree/main/plugins/alpha" ||
+		plan.Actions[1].Source != "https://github.com/acme/legal-tools/tree/main/plugins/beta" {
+		t.Fatalf("action sources = %q / %q", plan.Actions[0].Source, plan.Actions[1].Source)
+	}
+	joined := strings.Join(plan.Warnings, "\n")
+	for _, fragment := range []string{
+		`"external": external source`,
+		`"object": only relative string sources`,
+		`"bad/name": not a valid plugin name`,
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("warnings %q missing skip notice %q", plan.Warnings, fragment)
+		}
+	}
+}
+
+// TestGitHubClaudeMarketplaceSelectedUnsupportedSourceFails pins the selection
+// contract: skipping is only for bulk installs — when the user names exactly
+// one plugin and its source shape is unsupported, the plan must fail loudly.
+func TestGitHubClaudeMarketplaceSelectedUnsupportedSourceFails(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "legal-tools",
+  "plugins": [
+    {"name": "alpha-legal", "source": "./alpha"},
+    {"name": "external", "source": "https://github.com/acme/elsewhere"}
+  ]
+}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "alpha", ".claude-plugin", "plugin.json"), `{"name":"alpha-legal"}`)
+
+	tl := NewTool(Options{ProjectRoot: t.TempDir(), HomeDir: t.TempDir()})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() {}, nil
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+		"name":   "external",
+	})
+	_, err := tl.Execute(context.Background(), raw)
+	if err == nil || !strings.Contains(err.Error(), "external source") {
+		t.Fatalf("error = %v, want external-source rejection for the selected plugin", err)
+	}
+}
+
+// TestGitHubClaudeMarketplacePlanIDStableAcrossPlanAndApply pins the approval
+// contract the desktop host relies on: the planId returned by the preview must
+// match the planId recomputed by the apply call, or every marketplace apply
+// with an echoed planId would be refused.
+func TestGitHubClaudeMarketplacePlanIDStableAcrossPlanAndApply(t *testing.T) {
+	marketplaceRoot := t.TempDir()
+	writeFile(t, filepath.Join(marketplaceRoot, ".claude-plugin", "marketplace.json"), `{
+  "name": "legal-tools",
+  "metadata": {"pluginRoot": "plugins"},
+  "plugins": [
+    {"name": "alpha-legal", "source": "alpha"},
+    {"name": "beta-legal", "source": "beta"}
+  ]
+}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "alpha", ".claude-plugin", "plugin.json"), `{"name":"alpha-legal"}`)
+	writeFile(t, filepath.Join(marketplaceRoot, "plugins", "beta", ".claude-plugin", "plugin.json"), `{"name":"beta-legal"}`)
+
+	home := t.TempDir()
+	tl := NewTool(Options{ProjectRoot: t.TempDir(), HomeDir: home})
+	tool := tl.(*installSourceTool)
+	tool.preparePlugin = func(ctx context.Context, source, mode string) (string, string, func(), error) {
+		return marketplaceRoot, "cafe0001", func() {}, nil
+	}
+	plan := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+	})
+	if plan.Status != "planned" || len(plan.Actions) != 2 || plan.PlanID == "" {
+		t.Fatalf("plan = %+v", plan)
+	}
+	applied := execInstall(t, tl, map[string]any{
+		"source": "https://github.com/acme/legal-tools",
+		"kind":   "plugin",
+		"apply":  true,
+		"planId": plan.PlanID,
+	})
+	if !applied.OK || applied.Status != "done" {
+		t.Fatalf("apply with echoed planId = %+v", applied)
+	}
+	if applied.PlanID != plan.PlanID {
+		t.Fatalf("plan ID drifted between plan (%s) and apply (%s)", plan.PlanID, applied.PlanID)
+	}
+	for _, name := range []string{"alpha-legal", "beta-legal"} {
+		if _, ok, err := pluginpkg.FindInstalled(filepath.Join(home, ".reasonix"), name); err != nil || !ok {
+			t.Fatalf("installed plugin %q missing: ok=%v err=%v", name, ok, err)
+		}
+	}
+}
+
 // TestGitHubPluginApplyRefusesUnpinnableDrift pins the snapshot contract: when
 // the source resolves to a different commit than the plan approved and the
 // approved snapshot cannot be restored, apply must refuse instead of

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -2,16 +2,35 @@ package installsource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
 	"reasonix/internal/pluginpkg"
+	"reasonix/internal/proc"
 	"reasonix/internal/secrets"
 )
+
+const (
+	claudeMarketplaceManifest = ".claude-plugin/marketplace.json"
+	maxMarketplacePlugins     = 64
+)
+
+type claudeMarketplace struct {
+	Name     string `json:"name"`
+	Metadata struct {
+		PluginRoot string `json:"pluginRoot"`
+	} `json:"metadata"`
+	Plugins []struct {
+		Name   string          `json:"name"`
+		Source json.RawMessage `json:"source"`
+	} `json:"plugins"`
+}
 
 func (t *installSourceTool) localPluginPackageAction(req request, root string) (action, []string, error) {
 	pkg, warnings, err := pluginpkg.ParseDir(root)
@@ -35,17 +54,156 @@ func (t *installSourceTool) planGitHubPluginPackage(ctx context.Context, req req
 	if err != nil {
 		return nil, nil, err
 	}
-	defer cleanup()
 	pkg, warnings, err := pluginpkg.ParseDir(root)
-	if err != nil {
-		return nil, warnings, newErr(ErrManifestMissing, "no plugin manifest found in GitHub repository %s/%s: %v", src.Owner, src.Repo, err)
+	if err == nil {
+		defer cleanup()
+		act := t.pluginPackageAction(req, pkg, req.Source)
+		act.Source = req.Source
+		// The commit joins the action and therefore the plan ID, so the approval
+		// fingerprints the exact snapshot; apply pins to it.
+		act.Commit = commit
+		return []action{act}, warnings, nil
 	}
-	act := t.pluginPackageAction(req, pkg, req.Source)
-	act.Source = req.Source
-	// The commit joins the action and therefore the plan ID, so the approval
-	// fingerprints the exact snapshot; apply pins to it.
-	act.Commit = commit
-	return []action{act}, warnings, nil
+
+	actions, marketplaceWarnings, marketplaceErr := t.planClaudeMarketplace(ctx, req, src, root, commit)
+	warnings = append(warnings, marketplaceWarnings...)
+	if marketplaceErr != nil {
+		cleanup()
+		return nil, warnings, newErr(ErrManifestMissing, "no plugin manifest or supported Claude marketplace found in GitHub repository %s/%s: plugin: %v; marketplace: %v", src.Owner, src.Repo, err, marketplaceErr)
+	}
+	if req.Apply {
+		// All marketplace entries come from this one immutable clone. Reusing it
+		// keeps a 12-plugin marketplace at one clone during apply and guarantees
+		// every copied plugin is the snapshot represented by act.Commit.
+		actions[0].cleanup = cleanup
+		return actions, warnings, nil
+	}
+	cleanup()
+	return actions, warnings, nil
+}
+
+func (t *installSourceTool) planClaudeMarketplace(ctx context.Context, req request, src githubRepoSource, root, commit string) ([]action, []string, error) {
+	manifestPath := filepath.Join(root, filepath.FromSlash(claudeMarketplaceManifest))
+	body, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	var marketplace claudeMarketplace
+	if err := json.Unmarshal(body, &marketplace); err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", claudeMarketplaceManifest, err)
+	}
+	if strings.TrimSpace(marketplace.Name) == "" {
+		return nil, nil, fmt.Errorf("%s has no marketplace name", claudeMarketplaceManifest)
+	}
+	if len(marketplace.Plugins) == 0 {
+		return nil, nil, fmt.Errorf("%s contains no plugins", claudeMarketplaceManifest)
+	}
+	if len(marketplace.Plugins) > maxMarketplacePlugins {
+		return nil, nil, fmt.Errorf("%s contains %d plugins; limit is %d", claudeMarketplaceManifest, len(marketplace.Plugins), maxMarketplacePlugins)
+	}
+
+	branch := strings.TrimSpace(src.Branch)
+	if branch == "" {
+		branch = currentPluginGitBranch(ctx, root)
+	}
+	if branch == "" {
+		branch = src.branches()[0]
+	}
+
+	selected := strings.TrimSpace(req.Name)
+	foundSelected := selected == ""
+	seen := make(map[string]bool, len(marketplace.Plugins))
+	var actions []action
+	var warnings []string
+	for _, entry := range marketplace.Plugins {
+		entryName := strings.TrimSpace(entry.Name)
+		if selected != "" && entryName != selected {
+			continue
+		}
+		foundSelected = true
+		if entryName == "" {
+			warnings = append(warnings, "skipped Claude marketplace entry with an empty name")
+			continue
+		}
+		if seen[entryName] {
+			return nil, warnings, fmt.Errorf("%s contains duplicate plugin name %q", claudeMarketplaceManifest, entryName)
+		}
+		seen[entryName] = true
+
+		var source string
+		if err := json.Unmarshal(entry.Source, &source); err != nil {
+			warnings = append(warnings, fmt.Sprintf("skipped Claude marketplace plugin %q: only relative string sources are supported", entryName))
+			continue
+		}
+		rel, err := claudeMarketplaceRelativePath(marketplace.Metadata.PluginRoot, source)
+		if err != nil {
+			return nil, warnings, fmt.Errorf("plugin %q: %w", entryName, err)
+		}
+		pluginRoot := filepath.Join(root, filepath.FromSlash(rel))
+		pkg, pkgWarnings, err := pluginpkg.ParseDir(pluginRoot)
+		warnings = append(warnings, pkgWarnings...)
+		if err != nil {
+			return nil, warnings, fmt.Errorf("plugin %q at %s: %w", entryName, rel, err)
+		}
+		if pkg.Manifest.Name != entryName {
+			return nil, warnings, fmt.Errorf("marketplace plugin %q points to manifest named %q", entryName, pkg.Manifest.Name)
+		}
+
+		repoPath := joinURLPath(src.Path, rel)
+		pluginSource := fmt.Sprintf("https://github.com/%s/%s/tree/%s/%s", src.Owner, src.Repo, branch, repoPath)
+		actionReq := req
+		actionReq.Name = ""
+		act := t.pluginPackageAction(actionReq, pkg, pluginSource)
+		act.Source = pluginSource
+		act.Commit = commit
+		act.preparedRoot = pluginRoot
+		actions = append(actions, act)
+	}
+	if !foundSelected {
+		return nil, warnings, fmt.Errorf("%s does not contain plugin %q", claudeMarketplaceManifest, selected)
+	}
+	if len(actions) == 0 {
+		return nil, warnings, fmt.Errorf("%s contains no supported relative-path plugins", claudeMarketplaceManifest)
+	}
+	sort.Slice(actions, func(i, j int) bool { return actions[i].Name < actions[j].Name })
+	sort.Strings(warnings)
+	warnings = slices.Compact(warnings)
+	return actions, warnings, nil
+}
+
+func claudeMarketplaceRelativePath(pluginRoot, source string) (string, error) {
+	pluginRoot = strings.TrimSpace(pluginRoot)
+	if pluginRoot == "" {
+		pluginRoot = "."
+	}
+	fields := []struct {
+		label string
+		value string
+	}{
+		{label: "metadata.pluginRoot", value: pluginRoot},
+		{label: "source", value: strings.TrimSpace(source)},
+	}
+	for _, field := range fields {
+		if field.value != "." && field.value != "./" && !strings.HasPrefix(field.value, "./") {
+			return "", fmt.Errorf("%s %q must be a relative path beginning with ./", field.label, field.value)
+		}
+	}
+	cleanRoot := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(pluginRoot, "./")))
+	cleanSource := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(strings.TrimSpace(source), "./")))
+	rel := filepath.Clean(filepath.Join(cleanRoot, cleanSource))
+	if rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("source %q escapes or does not identify a plugin subdirectory", source)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func currentPluginGitBranch(ctx context.Context, root string) string {
+	cmd := pluginGitCommand(ctx, "-C", root, "branch", "--show-current")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // pluginSource resolves a plugin source to an on-disk tree. Both the plan and
@@ -117,9 +275,13 @@ func (t *installSourceTool) applyInstallPluginPackage(ctx context.Context, req r
 		return newErr(ErrInvalidManifest, "invalid plugin name %q", act.Name)
 	}
 	target := pluginpkg.InstallRoot(t.reasonixHome, act.Name)
-	sourceRoot, commit, cleanup, err := t.pluginSource(ctx, act.Source, act.Mode)
-	if err != nil {
-		return err
+	sourceRoot, commit, cleanup := act.preparedRoot, act.Commit, func() {}
+	if sourceRoot == "" {
+		var err error
+		sourceRoot, commit, cleanup, err = t.pluginSource(ctx, act.Source, act.Mode)
+		if err != nil {
+			return err
+		}
 	}
 	defer cleanup()
 	if act.Commit != "" && commit != act.Commit {
@@ -192,15 +354,13 @@ func (t *installSourceTool) preparePluginSource(ctx context.Context, source, mod
 			args = append(args, "--branch", src.Branch)
 		}
 		args = append(args, cloneURL, tmp)
-		cmd := exec.CommandContext(ctx, "git", args...)
-		cmd.Env = secrets.ProcessEnv()
+		cmd := pluginGitCommand(ctx, args...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			_ = os.RemoveAll(tmp)
 			return "", "", func() {}, newErr(ErrSourceUnreadable, "git clone failed: %v: %s", err, strings.TrimSpace(string(out)))
 		}
 		commit := ""
-		rev := exec.CommandContext(ctx, "git", "-C", tmp, "rev-parse", "HEAD")
-		rev.Env = secrets.ProcessEnv()
+		rev := pluginGitCommand(ctx, "-C", tmp, "rev-parse", "HEAD")
 		if out, err := rev.Output(); err == nil {
 			commit = strings.TrimSpace(string(out))
 		}
@@ -242,17 +402,22 @@ func verifyCopiedCapabilities(src pluginpkg.Package, target string) error {
 // stays reachable after ordinary pushes; a history rewrite that discarded it
 // fails here — exactly the case where the user must re-review the plan.
 func checkoutPluginCommit(ctx context.Context, cloneRoot, commit string) error {
-	fetch := exec.CommandContext(ctx, "git", "-C", cloneRoot, "fetch", "--depth=1", "origin", commit)
-	fetch.Env = secrets.ProcessEnv()
+	fetch := pluginGitCommand(ctx, "-C", cloneRoot, "fetch", "--depth=1", "origin", commit)
 	if out, err := fetch.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
 	}
-	co := exec.CommandContext(ctx, "git", "-C", cloneRoot, "checkout", "--detach", commit)
-	co.Env = secrets.ProcessEnv()
+	co := pluginGitCommand(ctx, "-C", cloneRoot, "checkout", "--detach", commit)
 	if out, err := co.CombinedOutput(); err != nil {
 		return fmt.Errorf("checkout approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func pluginGitCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = secrets.ProcessEnv()
+	proc.HideWindow(cmd)
+	return cmd
 }
 
 // installCopiedPlugin copies sourceRoot into a staging directory next to

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -125,14 +125,36 @@ func (t *installSourceTool) planClaudeMarketplace(ctx context.Context, req reque
 			warnings = append(warnings, "skipped Claude marketplace entry with an empty name")
 			continue
 		}
+		// Validate the name at plan time so a broken entry surfaces in the
+		// preview instead of failing its action mid-apply.
+		if !pluginpkg.IsValidName(entryName) {
+			if selected != "" {
+				return nil, warnings, fmt.Errorf("marketplace plugin %q is not a valid plugin name", entryName)
+			}
+			warnings = append(warnings, fmt.Sprintf("skipped Claude marketplace plugin %q: not a valid plugin name", entryName))
+			continue
+		}
 		if seen[entryName] {
 			return nil, warnings, fmt.Errorf("%s contains duplicate plugin name %q", claudeMarketplaceManifest, entryName)
 		}
 		seen[entryName] = true
 
+		// Unsupported source shapes (object sources, external URLs) skip the
+		// entry with a warning in a bulk install, but fail loudly when the
+		// user selected exactly that plugin by name.
 		var source string
 		if err := json.Unmarshal(entry.Source, &source); err != nil {
+			if selected != "" {
+				return nil, warnings, fmt.Errorf("marketplace plugin %q: only relative string sources are supported", entryName)
+			}
 			warnings = append(warnings, fmt.Sprintf("skipped Claude marketplace plugin %q: only relative string sources are supported", entryName))
+			continue
+		}
+		if marketplaceSourceIsExternal(source) {
+			if selected != "" {
+				return nil, warnings, fmt.Errorf("marketplace plugin %q: external source %q is not supported yet", entryName, source)
+			}
+			warnings = append(warnings, fmt.Sprintf("skipped Claude marketplace plugin %q: external source %q is not supported yet", entryName, source))
 			continue
 		}
 		rel, err := claudeMarketplaceRelativePath(marketplace.Metadata.PluginRoot, source)
@@ -176,25 +198,44 @@ func claudeMarketplaceRelativePath(pluginRoot, source string) (string, error) {
 	if pluginRoot == "" {
 		pluginRoot = "."
 	}
-	fields := []struct {
-		label string
-		value string
-	}{
-		{label: "metadata.pluginRoot", value: pluginRoot},
-		{label: "source", value: strings.TrimSpace(source)},
+	cleanRoot, err := cleanMarketplaceRelPath("metadata.pluginRoot", pluginRoot)
+	if err != nil {
+		return "", err
 	}
-	for _, field := range fields {
-		if field.value != "." && field.value != "./" && !strings.HasPrefix(field.value, "./") {
-			return "", fmt.Errorf("%s %q must be a relative path beginning with ./", field.label, field.value)
-		}
+	cleanSource, err := cleanMarketplaceRelPath("source", source)
+	if err != nil {
+		return "", err
 	}
-	cleanRoot := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(pluginRoot, "./")))
-	cleanSource := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(strings.TrimSpace(source), "./")))
 	rel := filepath.Clean(filepath.Join(cleanRoot, cleanSource))
-	if rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("source %q escapes or does not identify a plugin subdirectory", source)
 	}
 	return filepath.ToSlash(rel), nil
+}
+
+// cleanMarketplaceRelPath normalizes one relative-path field of a marketplace
+// entry. Real marketplaces spell paths both as "./plugins/example" and as the
+// bare "plugins/example", so both are accepted; absolute and drive-qualified
+// paths are rejected before the join so they can never re-anchor the lookup
+// outside the clone.
+func cleanMarketplaceRelPath(label, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is empty", label)
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(value, "./")))
+	if filepath.IsAbs(cleaned) || filepath.VolumeName(cleaned) != "" {
+		return "", fmt.Errorf("%s %q must be a relative path inside the marketplace repository", label, value)
+	}
+	return cleaned, nil
+}
+
+// marketplaceSourceIsExternal reports whether a string source points outside
+// the marketplace repository (a URL or scp-like git address) rather than at a
+// relative path inside it.
+func marketplaceSourceIsExternal(source string) bool {
+	source = strings.TrimSpace(source)
+	return strings.Contains(source, "://") || strings.HasPrefix(source, "git@")
 }
 
 func currentPluginGitBranch(ctx context.Context, root string) string {

--- a/internal/installsource/plugin_package_windows_test.go
+++ b/internal/installsource/plugin_package_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package installsource
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPluginGitCommandHidesConsoleWindow(t *testing.T) {
+	cmd := pluginGitCommand(context.Background(), "version")
+	if cmd.SysProcAttr == nil {
+		t.Fatal("plugin git command must set Windows process attributes")
+	}
+	const createNoWindow = 0x08000000
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 || !cmd.SysProcAttr.HideWindow {
+		t.Fatalf("plugin git command can flash a console window: %+v", cmd.SysProcAttr)
+	}
+}

--- a/internal/installsource/types.go
+++ b/internal/installsource/types.go
@@ -108,6 +108,12 @@ type action struct {
 	entry      config.PluginEntry
 	skill      skillCandidate
 	disconnect func() // optional MCP rollback; nil when not connected
+	// preparedRoot lets a multi-plugin marketplace apply reuse the exact clone
+	// that produced its approved plan instead of cloning the same repository
+	// once per plugin. cleanup is attached to one action and runs after all
+	// actions finish.
+	preparedRoot string
+	cleanup      func()
 }
 
 func actionPlanKey(a action) string {
@@ -150,6 +156,8 @@ func publicActions(in []action) []action {
 		out[i] = in[i]
 		out[i].entry = config.PluginEntry{}
 		out[i].skill = skillCandidate{}
+		out[i].preparedRoot = ""
+		out[i].cleanup = nil
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

- detect GitHub-hosted Claude marketplace roots and turn bounded relative-path entries into deterministic per-plugin install actions
- keep marketplace planning and apply on one pinned clone, validate paths and manifest names, support optional single-plugin selection, and clean temporary resources on every exit path
- route plugin Git clone/revision/fetch/checkout subprocesses through the Windows hidden-window helper so desktop preflight no longer flashes a console
- accept both `./plugins/example` and bare `plugins/example` relative sources; entries the subset cannot install (object sources, external URLs, invalid plugin names) skip with a per-entry warning during bulk installs and report a precise error when selected by name
- validate marketplace plugin names at plan time so broken entries surface in the preview instead of mid-apply
- hide the rg console window in the desktop bot project search — the one remaining bare spawn in the GUI-process path with the same console-flash shape
- pin the marketplace planId approval contract (preview planId must match the planId recomputed on apply) with a regression test
- document the supported marketplace subset in English and Chinese

## Verification

- `go test ./internal/installsource ./internal/bot ./internal/pluginpkg ./internal/proc`
- `go vet ./internal/installsource ./internal/bot ./internal/pluginpkg`
- `DEEPSEEK_API_KEY= go test ./...`
- `cd desktop && go test ./...`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/reasonix-installsource-windows.test.exe ./internal/installsource`
- `GOOS=windows GOARCH=amd64 go build ./internal/installsource ./internal/bot`
- real GitHub dry-run against `CSlawyer1985/claude-for-legal-ZH`: 12 plugin actions and 150 skills planned from one pinned commit
- isolated-home real apply against the same marketplace: all 12 plugin packages installed and registered successfully

## Cache impact

Cache-impact: low - changes `install_source` plugin discovery, desktop child-process behavior, and bot search child-process flags only; provider-visible tool schemas, system prompts, memory prefixes, and request serialization are unchanged.
Cache-guard: focused install-source/plugin-package/bot tests, full root tests, desktop tests, and Windows target compilation passed.
System-prompt-review: N/A
