### PR TITLE
fix(delivery): align sign-off verification with final readiness / 修复交付验证与最终检查不一致

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2900,6 +2900,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	if a.evidence != nil {
 		cctx = evidence.WithLedger(cctx, a.evidence)
 		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot())
+		if a.deliveryProfile {
+			cctx = evidence.WithDeliveryProfile(cctx)
+		}
 	}
 	if len(a.projectChecks) > 0 {
 		cctx = instruction.WithChecks(cctx, a.projectChecks)

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -790,6 +790,7 @@ func (l *Ledger) hasSuccessfulPaths(paths []string, accept func(Receipt) bool) b
 
 type contextKey struct{}
 type sessionMessagesKey struct{}
+type deliveryProfileKey struct{}
 
 func WithLedger(ctx context.Context, ledger *Ledger) context.Context {
 	if ledger == nil {
@@ -801,6 +802,20 @@ func WithLedger(ctx context.Context, ledger *Ledger) context.Context {
 func FromContext(ctx context.Context) (*Ledger, bool) {
 	ledger, ok := ctx.Value(contextKey{}).(*Ledger)
 	return ledger, ok && ledger != nil
+}
+
+// WithDeliveryProfile marks tool execution as subject to the delivery-first
+// final-readiness contract. Tools use this only for stricter evidence validation;
+// it is ephemeral host state and is never serialized into sessions or prompts.
+func WithDeliveryProfile(ctx context.Context) context.Context {
+	return context.WithValue(ctx, deliveryProfileKey{}, true)
+}
+
+// DeliveryProfileFromContext reports whether the current tool call must produce
+// evidence that the delivery final-readiness gate can accept.
+func DeliveryProfileFromContext(ctx context.Context) bool {
+	enabled, _ := ctx.Value(deliveryProfileKey{}).(bool)
+	return enabled
 }
 
 // WithSessionMessages attaches the full conversation history so verifyStepEvidence
@@ -998,6 +1013,14 @@ func bashCommandIsVerification(command string) bool {
 	return found
 }
 
+// IsDeliveryVerificationCommand reports whether command is a host-recognized
+// verification command for delivery finalization. Keep complete_step and the
+// final-readiness gate on this single classifier so a sign-off cannot claim a
+// command that the final gate will immediately reject.
+func IsDeliveryVerificationCommand(command string) bool {
+	return bashCommandIsVerification(command)
+}
+
 func bashSegmentIsVerification(fields []string) bool {
 	if len(fields) == 0 {
 		return false
@@ -1025,6 +1048,8 @@ func bashSegmentIsVerification(fields []string) bool {
 			return true
 		}
 		return len(args) > 1 && args[0] == "run" && hasCommandArg(args[1:2], "test", "check", "lint", "typecheck")
+	case "node":
+		return nodeSegmentIsVerification(args)
 	case "make", "just":
 		return len(args) > 0 && hasCommandArg(args[:1], "test", "check", "lint", "verify", "ci")
 	case "python", "python3":
@@ -1035,6 +1060,29 @@ func bashSegmentIsVerification(fields []string) bool {
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")
 	}
 	return false
+}
+
+func nodeSegmentIsVerification(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch strings.ToLower(args[0]) {
+	case "--check", "-c":
+		// Syntax-check mode does not execute the target. Fail closed on any
+		// additional option: preload/eval/import flags could execute code before
+		// the check and turn a purported verifier into an opaque mutation.
+		for _, arg := range args[1:] {
+			if arg != "-" && strings.HasPrefix(arg, "-") {
+				return false
+			}
+		}
+		return true
+	case "--test":
+		// Match the repository's treatment of other conventional test runners.
+		return true
+	default:
+		return false
+	}
 }
 
 func bashReadOnlyCommandWrites(base, sub string, fields []string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1066,7 +1066,9 @@ func nodeSegmentIsVerification(args []string) bool {
 	if len(args) == 0 {
 		return false
 	}
-	switch strings.ToLower(args[0]) {
+	// Node CLI flags are case-sensitive: -c/--check is the syntax-only mode,
+	// while -C/--conditions executes the target with custom export conditions.
+	switch args[0] {
 	case "--check", "-c":
 		// Syntax-check mode does not execute the target. Fail closed on any
 		// additional option: preload/eval/import flags could execute code before

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1081,18 +1081,29 @@ func nodeSegmentIsVerification(args []string) bool {
 		return true
 	case "--test":
 		// Match the repository's treatment of other conventional test runners,
-		// but fail closed on test-runner flags that write files: snapshot
-		// regeneration rewrites checked-in fixtures (the --update/-u class),
-		// reporter destinations can write arbitrary paths, and rerun-failure
-		// state is created or updated across test runs.
+		// but fail closed on test-runner and Node runtime flags that write files.
 		for _, arg := range args[1:] {
-			lower := strings.ToLower(arg)
-			if lower == "--test-update-snapshots" ||
-				strings.HasPrefix(lower, "--test-reporter-destination") ||
-				strings.HasPrefix(lower, "--test-rerun-failures") {
+			if nodeTestFlagWritesFile(arg) {
 				return false
 			}
 		}
+		return true
+	default:
+		return false
+	}
+}
+
+func nodeTestFlagWritesFile(arg string) bool {
+	name := strings.ToLower(arg)
+	if i := strings.IndexByte(name, '='); i >= 0 {
+		name = name[:i]
+	}
+	switch name {
+	case "--cpu-prof", "--heap-prof", "--heapsnapshot-near-heap-limit", "--heapsnapshot-signal",
+		"--localstorage-file", "--perf-basic-prof", "--perf-basic-prof-only-functions", "--perf-prof",
+		"--prof", "--redirect-warnings", "--report-on-fatalerror", "--report-on-signal",
+		"--report-uncaught-exception", "--test-reporter-destination", "--test-rerun-failures",
+		"--test-update-snapshots", "--tls-keylog", "--trace-events-enabled":
 		return true
 	default:
 		return false

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1080,7 +1080,16 @@ func nodeSegmentIsVerification(args []string) bool {
 		}
 		return true
 	case "--test":
-		// Match the repository's treatment of other conventional test runners.
+		// Match the repository's treatment of other conventional test runners,
+		// but fail closed on test-runner flags that write files: snapshot
+		// regeneration rewrites checked-in fixtures (the --update/-u class) and
+		// reporter destinations can write arbitrary paths.
+		for _, arg := range args[1:] {
+			lower := strings.ToLower(arg)
+			if lower == "--test-update-snapshots" || strings.HasPrefix(lower, "--test-reporter-destination") {
+				return false
+			}
+		}
 		return true
 	default:
 		return false

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1082,11 +1082,14 @@ func nodeSegmentIsVerification(args []string) bool {
 	case "--test":
 		// Match the repository's treatment of other conventional test runners,
 		// but fail closed on test-runner flags that write files: snapshot
-		// regeneration rewrites checked-in fixtures (the --update/-u class) and
-		// reporter destinations can write arbitrary paths.
+		// regeneration rewrites checked-in fixtures (the --update/-u class),
+		// reporter destinations can write arbitrary paths, and rerun-failure
+		// state is created or updated across test runs.
 		for _, arg := range args[1:] {
 			lower := strings.ToLower(arg)
-			if lower == "--test-update-snapshots" || strings.HasPrefix(lower, "--test-reporter-destination") {
+			if lower == "--test-update-snapshots" ||
+				strings.HasPrefix(lower, "--test-reporter-destination") ||
+				strings.HasPrefix(lower, "--test-rerun-failures") {
 				return false
 			}
 		}

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -549,6 +549,9 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "security_review meta", toolName: "security_review", args: `{"task":"security"}`},
 		{name: "use_capability meta", toolName: "use_capability", args: `{"action":"inspect","capability_id":"mcp-server:github"}`},
 		{name: "test command", toolName: "bash", args: `{"command":"go test ./..."}`},
+		{name: "node syntax check", toolName: "bash", args: `{"command":"node --check app.js"}`},
+		{name: "node syntax check pipeline", toolName: "bash", args: `{"command":"tail -n +2 app.html | head -n 20 | node --check"}`},
+		{name: "node eval stays opaque", toolName: "bash", args: `{"command":"node -e 'console.log(1)'"}`, want: true},
 		{name: "diff review", toolName: "bash", args: `{"command":"git diff --check"}`},
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
@@ -572,6 +575,49 @@ func TestToolCallRequiresDeliveryCriteriaForExecutionCommands(t *testing.T) {
 	}
 	if !ToolCallRequiresDeliveryCriteria("bash", json.RawMessage(`{"command":"git diff --check"}`), false) {
 		t.Fatal("git diff --check is a verification command and should require acceptance criteria")
+	}
+	if !ToolCallRequiresDeliveryCriteria("bash", json.RawMessage(`{"command":"node --check app.js"}`), false) {
+		t.Fatal("node --check is a verification command and should require acceptance criteria")
+	}
+}
+
+func TestLedgerDeliverySignoffAcceptsNodeSyntaxCheckAfterMutation(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"app.js"}`), true, false))
+	mutation, ok := ledger.LatestSuccessfulMutationIndex()
+	if !ok {
+		t.Fatal("expected mutation receipt")
+	}
+	ledger.Record(ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"app.js"}`), true, true))
+	command := "node --check app.js"
+	ledger.Record(ReceiptFromToolCall("bash", json.RawMessage(`{"command":"node --check app.js"}`), true, false))
+	ledger.Record(ReceiptFromToolCall("complete_step", json.RawMessage(`{
+		"step":"Check JavaScript",
+		"result":"syntax valid",
+		"evidence":[{"kind":"verification","summary":"syntax valid","command":"node --check app.js"}]
+	}`), true, true))
+
+	if !IsDeliveryVerificationCommand(command) {
+		t.Fatal("node --check should be recognized as a delivery verification")
+	}
+	if latest, ok := ledger.LatestSuccessfulMutationIndex(); !ok || latest != mutation {
+		t.Fatalf("node --check moved latest mutation from %d to %d (ok=%v)", mutation, latest, ok)
+	}
+	if !ledger.HasSuccessfulReviewAfter(mutation) {
+		t.Fatal("expected post-mutation read to satisfy review")
+	}
+	if !ledger.HasSuccessfulDeliverySignoffAfter(mutation) {
+		t.Fatal("expected node --check to satisfy delivery sign-off")
+	}
+}
+
+func TestNodeEvalCannotMasqueradeAsDeliveryVerification(t *testing.T) {
+	command := `node -e 'require("fs").readFileSync("app.js")'`
+	if IsDeliveryVerificationCommand(command) {
+		t.Fatal("arbitrary node eval must not be recognized as delivery verification")
+	}
+	if !ToolCallMutates("bash", json.RawMessage(`{"command":"node -e 'require(\"fs\").readFileSync(\"app.js\")'"}`), false) {
+		t.Fatal("arbitrary node eval must remain an opaque mutation")
 	}
 }
 

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -556,6 +556,7 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "node test runner", toolName: "bash", args: `{"command":"node --test"}`},
 		{name: "node test snapshot update stays opaque", toolName: "bash", args: `{"command":"node --test --test-update-snapshots"}`, want: true},
 		{name: "node test reporter file stays opaque", toolName: "bash", args: `{"command":"node --test --test-reporter=junit --test-reporter-destination=result.txt"}`, want: true},
+		{name: "node test rerun state stays opaque", toolName: "bash", args: `{"command":"node --test --test-rerun-failures=state.json"}`, want: true},
 		{name: "diff review", toolName: "bash", args: `{"command":"git diff --check"}`},
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
@@ -641,13 +642,16 @@ func TestNodeTestRunnerWriteFlagsCannotMasqueradeAsDeliveryVerification(t *testi
 	if !IsDeliveryVerificationCommand("node --test") {
 		t.Fatal("plain node --test should be recognized as a delivery verification")
 	}
-	// --test-update-snapshots rewrites checked-in snapshot fixtures and
-	// --test-reporter-destination can write arbitrary paths; both must stay
+	// --test-update-snapshots rewrites checked-in snapshot fixtures,
+	// --test-reporter-destination can write arbitrary paths, and
+	// --test-rerun-failures creates or updates a state file. They must stay
 	// opaque mutations so new files still require review and sign-off.
 	for _, command := range []string{
 		"node --test --test-update-snapshots",
 		"node --test --test-reporter=junit --test-reporter-destination=result.txt",
 		"node --test --test-reporter junit --test-reporter-destination result.txt",
+		"node --test --test-rerun-failures=state.json",
+		"node --test --test-rerun-failures state.json",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Fatalf("%q writes files and must not be recognized as delivery verification", command)

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -557,6 +557,7 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "node test snapshot update stays opaque", toolName: "bash", args: `{"command":"node --test --test-update-snapshots"}`, want: true},
 		{name: "node test reporter file stays opaque", toolName: "bash", args: `{"command":"node --test --test-reporter=junit --test-reporter-destination=result.txt"}`, want: true},
 		{name: "node test rerun state stays opaque", toolName: "bash", args: `{"command":"node --test --test-rerun-failures=state.json"}`, want: true},
+		{name: "node test cpu profile stays opaque", toolName: "bash", args: `{"command":"node --test --cpu-prof"}`, want: true},
 		{name: "diff review", toolName: "bash", args: `{"command":"git diff --check"}`},
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
@@ -642,16 +643,30 @@ func TestNodeTestRunnerWriteFlagsCannotMasqueradeAsDeliveryVerification(t *testi
 	if !IsDeliveryVerificationCommand("node --test") {
 		t.Fatal("plain node --test should be recognized as a delivery verification")
 	}
-	// --test-update-snapshots rewrites checked-in snapshot fixtures,
-	// --test-reporter-destination can write arbitrary paths, and
-	// --test-rerun-failures creates or updates a state file. They must stay
-	// opaque mutations so new files still require review and sign-off.
+	// Test-runner state/report flags and Node runtime profiling/tracing flags
+	// create or update files. They must stay opaque mutations so those files
+	// still require review and sign-off.
 	for _, command := range []string{
 		"node --test --test-update-snapshots",
 		"node --test --test-reporter=junit --test-reporter-destination=result.txt",
 		"node --test --test-reporter junit --test-reporter-destination result.txt",
 		"node --test --test-rerun-failures=state.json",
 		"node --test --test-rerun-failures state.json",
+		"node --test --cpu-prof",
+		"node --test --heap-prof",
+		"node --test --heapsnapshot-near-heap-limit=1",
+		"node --test --heapsnapshot-signal=SIGUSR2",
+		"node --test --localstorage-file=localstorage.json",
+		"node --test --perf-basic-prof",
+		"node --test --perf-basic-prof-only-functions",
+		"node --test --perf-prof",
+		"node --test --prof",
+		"node --test --redirect-warnings=warnings.log",
+		"node --test --report-on-fatalerror",
+		"node --test --report-on-signal",
+		"node --test --report-uncaught-exception",
+		"node --test --tls-keylog=tls.log",
+		"node --test --trace-events-enabled",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Fatalf("%q writes files and must not be recognized as delivery verification", command)

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -552,6 +552,7 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "node syntax check", toolName: "bash", args: `{"command":"node --check app.js"}`},
 		{name: "node syntax check pipeline", toolName: "bash", args: `{"command":"tail -n +2 app.html | head -n 20 | node --check"}`},
 		{name: "node eval stays opaque", toolName: "bash", args: `{"command":"node -e 'console.log(1)'"}`, want: true},
+		{name: "node conditions flag stays opaque", toolName: "bash", args: `{"command":"node -C production server.js"}`, want: true},
 		{name: "diff review", toolName: "bash", args: `{"command":"git diff --check"}`},
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
@@ -618,6 +619,18 @@ func TestNodeEvalCannotMasqueradeAsDeliveryVerification(t *testing.T) {
 	}
 	if !ToolCallMutates("bash", json.RawMessage(`{"command":"node -e 'require(\"fs\").readFileSync(\"app.js\")'"}`), false) {
 		t.Fatal("arbitrary node eval must remain an opaque mutation")
+	}
+}
+
+func TestNodeConditionsFlagCannotMasqueradeAsDeliveryVerification(t *testing.T) {
+	// Node CLI flags are case-sensitive: -C is --conditions and executes the
+	// target script, unlike the syntax-only -c/--check.
+	command := "node -C production server.js"
+	if IsDeliveryVerificationCommand(command) {
+		t.Fatal("node -C (--conditions) executes the script and must not be recognized as delivery verification")
+	}
+	if !ToolCallMutates("bash", json.RawMessage(`{"command":"node -C production server.js"}`), false) {
+		t.Fatal("node -C (--conditions) must remain an opaque mutation")
 	}
 }
 

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -553,6 +553,9 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "node syntax check pipeline", toolName: "bash", args: `{"command":"tail -n +2 app.html | head -n 20 | node --check"}`},
 		{name: "node eval stays opaque", toolName: "bash", args: `{"command":"node -e 'console.log(1)'"}`, want: true},
 		{name: "node conditions flag stays opaque", toolName: "bash", args: `{"command":"node -C production server.js"}`, want: true},
+		{name: "node test runner", toolName: "bash", args: `{"command":"node --test"}`},
+		{name: "node test snapshot update stays opaque", toolName: "bash", args: `{"command":"node --test --test-update-snapshots"}`, want: true},
+		{name: "node test reporter file stays opaque", toolName: "bash", args: `{"command":"node --test --test-reporter=junit --test-reporter-destination=result.txt"}`, want: true},
 		{name: "diff review", toolName: "bash", args: `{"command":"git diff --check"}`},
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
@@ -631,6 +634,24 @@ func TestNodeConditionsFlagCannotMasqueradeAsDeliveryVerification(t *testing.T) 
 	}
 	if !ToolCallMutates("bash", json.RawMessage(`{"command":"node -C production server.js"}`), false) {
 		t.Fatal("node -C (--conditions) must remain an opaque mutation")
+	}
+}
+
+func TestNodeTestRunnerWriteFlagsCannotMasqueradeAsDeliveryVerification(t *testing.T) {
+	if !IsDeliveryVerificationCommand("node --test") {
+		t.Fatal("plain node --test should be recognized as a delivery verification")
+	}
+	// --test-update-snapshots rewrites checked-in snapshot fixtures and
+	// --test-reporter-destination can write arbitrary paths; both must stay
+	// opaque mutations so new files still require review and sign-off.
+	for _, command := range []string{
+		"node --test --test-update-snapshots",
+		"node --test --test-reporter=junit --test-reporter-destination=result.txt",
+		"node --test --test-reporter junit --test-reporter-destination result.txt",
+	} {
+		if IsDeliveryVerificationCommand(command) {
+			t.Fatalf("%q writes files and must not be recognized as delivery verification", command)
+		}
 	}
 }
 

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -174,6 +174,10 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 				hint := allCommandHints(ctx, ledger)
 				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful receipt — cite the command exactly as it ran in the session%s", i+1, command, hint)
 			}
+			_, deliveryHasMutation := ledger.LatestSuccessfulMutationIndex()
+			if evidence.DeliveryProfileFromContext(ctx) && deliveryHasMutation && !evidence.IsDeliveryVerificationCommand(command) {
+				return 0, 0, fmt.Errorf("evidence %d: command %q ran successfully but is not a recognized delivery verification; use a project test/check/lint command, or for JavaScript syntax use node --check <file> (a read-only extraction pipeline ending in node --check also works). Arbitrary node -e is treated as an opaque mutation", i+1, command)
+			}
 			hostVerified++
 		case "diff":
 			if len(e.Paths) == 0 {

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -181,6 +181,55 @@ func TestCompleteStepAllowsManualAsUnverified(t *testing.T) {
 	}
 }
 
+func TestCompleteStepDeliveryRejectsOpaqueEvalVerification(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("bash", json.RawMessage(`{"command":"node -e 'console.log(1)'"}`), true, false))
+	ctx := evidence.WithDeliveryProfile(evidence.WithLedger(context.Background(), ledger))
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Check JavaScript",
+		"result":"syntax valid",
+		"evidence":[{"kind":"verification","summary":"syntax valid","command":"node -e 'console.log(1)'"}]
+	}`))
+	if err == nil {
+		t.Fatal("delivery complete_step should reject a command the final gate cannot recognize")
+	}
+	for _, want := range []string{"not a recognized delivery verification", "node --check"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing recovery hint %q", err, want)
+		}
+	}
+}
+
+func TestCompleteStepDeliveryAcceptsNodeSyntaxCheck(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"app.js"}`), true, false))
+	ledger.Record(evidence.ReceiptFromToolCall("bash", json.RawMessage(`{"command":"node --check app.js"}`), true, false))
+	ctx := evidence.WithDeliveryProfile(evidence.WithLedger(context.Background(), ledger))
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"Check JavaScript",
+		"result":"syntax valid",
+		"evidence":[{"kind":"verification","summary":"syntax valid","command":"node --check app.js"}]
+	}`)); err != nil {
+		t.Fatalf("delivery complete_step rejected node --check: %v", err)
+	}
+}
+
+func TestCompleteStepDeliveryKeepsReadOnlyEvidenceCompatibility(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("bash", json.RawMessage(`{"command":"grep -n TODO app.js"}`), true, false))
+	ctx := evidence.WithDeliveryProfile(evidence.WithLedger(context.Background(), ledger))
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"Inspect JavaScript",
+		"result":"TODOs inspected",
+		"evidence":[{"kind":"verification","summary":"inspection completed","command":"grep -n TODO app.js"}]
+	}`)); err != nil {
+		t.Fatalf("read-only delivery evidence regressed: %v", err)
+	}
+}
+
 func TestCompleteStepRejectsMissingProjectCheckAfterWrite(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})


### PR DESCRIPTION
## Summary

- Align complete_step verification evidence with the classifier used by the final delivery-readiness gate.
- Recognize node --check, node -c, read-only extraction pipelines ending in node --check, and node --test as delivery verification.
- Keep arbitrary node -e commands classified as opaque mutations and reject them during delivery sign-off with an actionable node --check hint.
- Preserve existing read-only delivery workflows when no mutation occurred.

## Root cause

In delivery mode, complete_step accepted any successful command as verification, while final readiness required a host-recognized verification command. A successful node -e check was therefore accepted during step completion but then treated as the latest opaque mutation, invalidating the earlier read, review, and sign-off evidence. The agent retried until the final-readiness limit and surfaced a recoverable incomplete-delivery card after the session stopped.

## Backward compatibility

| Surface | Old-data or existing-workflow behavior | Conclusion |
| --- | --- | --- |
| Persisted sessions and events | No fields or outcome values were added; existing records deserialize unchanged | Compatible |
| Tool and provider contracts | Tool schemas, ordering, prompts, provider serialization, and request payloads are unchanged | Compatible |
| Read-only delivery steps | Successful evidence remains accepted when no mutation occurred | Compatible |
| JavaScript verification | node --check and node --test can now satisfy delivery readiness; node -e remains conservatively opaque | Safer behavior |

## Verification

- go test ./internal/evidence ./internal/tool/builtin ./internal/agent -count=1
- env -u DEEPSEEK_API_KEY go test ./... -count=1
- cd desktop && go test ./... -count=1
- ./scripts/cache-guard.sh
- scripts/check-cache-impact.sh with the changed files and this PR metadata
- git diff --check

Cache-impact: low - aligns delivery evidence classification without changing prompts, tool schemas, tool ordering, provider serialization, or request payload construction.
Cache-guard: ./scripts/cache-guard.sh passed; focused evidence and complete_step tests plus root and desktop Go test suites passed.