### PR TITLE
fix(evidence): reject file-writing test-runner flags in verification classifier / 验证分类器拒绝会写文件的测试运行器参数

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1007,6 +1007,9 @@ func bashSegmentIsVerification(fields []string) bool {
 	if hasCommandArg(args, "--fix", "--write", "-w", "--update", "-u") {
 		return false
 	}
+	if hasWriteOutputFlag(args) {
+		return false
+	}
 	switch base {
 	case "go":
 		if len(args) == 0 {
@@ -1071,6 +1074,39 @@ func hasCommandArg(args []string, candidates ...string) bool {
 			if strings.EqualFold(arg, candidate) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// writeOutputFlags are test-runner and linter flags that write snapshot,
+// report, or profile files. Snapshot flags rewrite checked-in fixtures (the
+// --update/-u class rejected above); the others write explicit output paths.
+// A runner invoked with one of them changes workspace state, so the segment
+// must not count as read-only verification.
+var writeOutputFlags = map[string]bool{
+	"snapshot-update": true, // pytest-snapshot / syrupy
+	"updatesnapshot":  true, // jest --updateSnapshot via npm/yarn wrappers
+	"junitxml":        true, // pytest
+	"junit-xml":       true, // pytest / mypy
+	"junitfile":       true, // gotestsum
+	"jsonfile":        true, // gotestsum
+	"coverprofile":    true, // go test
+	"cpuprofile":      true, // go test
+	"memprofile":      true, // go test
+}
+
+func hasWriteOutputFlag(args []string) bool {
+	for _, arg := range args {
+		name := strings.TrimLeft(arg, "-")
+		if len(name) == len(arg) || name == "" {
+			continue // not a flag
+		}
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		if writeOutputFlags[strings.ToLower(name)] {
+			return true
 		}
 	}
 	return false

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1029,7 +1029,14 @@ func bashSegmentIsVerification(fields []string) bool {
 		return args[0] == "build" && !hasCommandArg(args, "-o")
 	case "git":
 		return len(args) > 1 && args[0] == "diff" && hasCommandArg(args[1:], "--check")
-	case "pytest", "py.test", "gotestsum", "staticcheck", "golangci-lint", "mypy", "tsc":
+	case "pytest", "py.test", "gotestsum", "staticcheck", "golangci-lint", "tsc":
+		return true
+	case "mypy":
+		for _, arg := range args {
+			if mypyFlagWritesReport(arg) {
+				return false
+			}
+		}
 		return true
 	case "npm", "pnpm", "yarn", "bun", "cargo":
 		if len(args) > 0 && hasCommandArg(args[:1], "test", "check", "lint", "clippy") {
@@ -1106,6 +1113,8 @@ var writeOutputFlags = map[string]bool{
 	"mutexprofile":    true, // go test
 	"testlogfile":     true, // go test binary
 	"gocoverdir":      true, // go test binary
+	"outputfile":      true, // jest/vitest --outputFile (with --json)
+	"report-log":      true, // pytest-reportlog
 }
 
 func hasWriteOutputFlag(args []string) bool {
@@ -1123,8 +1132,25 @@ func hasWriteOutputFlag(args []string) bool {
 		if writeOutputFlags[name] {
 			return true
 		}
+		// Vitest exposes dotted per-reporter forms (--outputFile.json=path).
+		if i := strings.IndexByte(name, '.'); i > 0 && writeOutputFlags[name[:i]] {
+			return true
+		}
 	}
 	return false
+}
+
+// mypyFlagWritesReport reports whether a mypy flag writes a report directory:
+// every mypy report option follows the --<type>-report DIR shape (txt, html,
+// xml, cobertura-xml, any-exprs, linecount, linecoverage, lineprecision), and
+// mypy has no read-only flag with that suffix. --junit-xml is covered by the
+// global write-output flags.
+func mypyFlagWritesReport(arg string) bool {
+	name := strings.ToLower(arg)
+	if i := strings.IndexByte(name, '='); i >= 0 {
+		name = name[:i]
+	}
+	return strings.HasPrefix(name, "--") && strings.HasSuffix(name, "-report")
 }
 
 // goTestFlagWritesFile reports whether a go test flag writes a workspace

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1015,7 +1015,15 @@ func bashSegmentIsVerification(fields []string) bool {
 		if len(args) == 0 {
 			return false
 		}
-		if args[0] == "test" || args[0] == "vet" {
+		if args[0] == "vet" {
+			return true
+		}
+		if args[0] == "test" {
+			for _, arg := range args[1:] {
+				if goTestFlagWritesFile(arg) {
+					return false
+				}
+			}
 			return true
 		}
 		return args[0] == "build" && !hasCommandArg(args, "-o")
@@ -1094,6 +1102,8 @@ var writeOutputFlags = map[string]bool{
 	"coverprofile":    true, // go test
 	"cpuprofile":      true, // go test
 	"memprofile":      true, // go test
+	"blockprofile":    true, // go test
+	"mutexprofile":    true, // go test
 }
 
 func hasWriteOutputFlag(args []string) bool {
@@ -1110,6 +1120,24 @@ func hasWriteOutputFlag(args []string) bool {
 		}
 	}
 	return false
+}
+
+// goTestFlagWritesFile reports whether a go test flag writes a workspace
+// artifact: -c/-o emit the test binary and -trace writes an execution trace.
+// These stay out of writeOutputFlags because the dash-stripped global match
+// would also hit node -c (a syntax-only check) and pytest --trace (a
+// read-only debugger flag). Go flags accept single- and double-dash forms.
+func goTestFlagWritesFile(arg string) bool {
+	name := strings.ToLower(arg)
+	if i := strings.IndexByte(name, '='); i >= 0 {
+		name = name[:i]
+	}
+	switch name {
+	case "-c", "--c", "-o", "--o", "-trace", "--trace":
+		return true
+	default:
+		return false
+	}
 }
 
 func completeStepVerificationCommands(args json.RawMessage) []string {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1104,6 +1104,8 @@ var writeOutputFlags = map[string]bool{
 	"memprofile":      true, // go test
 	"blockprofile":    true, // go test
 	"mutexprofile":    true, // go test
+	"testlogfile":     true, // go test binary
+	"gocoverdir":      true, // go test binary
 }
 
 func hasWriteOutputFlag(args []string) bool {
@@ -1115,7 +1117,10 @@ func hasWriteOutputFlag(args []string) bool {
 		if i := strings.IndexByte(name, '='); i >= 0 {
 			name = name[:i]
 		}
-		if writeOutputFlags[strings.ToLower(name)] {
+		// go test flags accept an optional test. prefix (-test.coverprofile)
+		// that the go tool passes through to the test binary.
+		name = strings.TrimPrefix(strings.ToLower(name), "test.")
+		if writeOutputFlags[name] {
 			return true
 		}
 	}
@@ -1123,17 +1128,26 @@ func hasWriteOutputFlag(args []string) bool {
 }
 
 // goTestFlagWritesFile reports whether a go test flag writes a workspace
-// artifact: -c/-o emit the test binary and -trace writes an execution trace.
-// These stay out of writeOutputFlags because the dash-stripped global match
-// would also hit node -c (a syntax-only check) and pytest --trace (a
-// read-only debugger flag). Go flags accept single- and double-dash forms.
+// artifact: -c/-o emit the test binary, -trace and the profile flags write
+// profiles, and -artifacts/-testlogfile/-gocoverdir write test outputs. The
+// short and ambiguous names stay out of writeOutputFlags because the
+// dash-stripped global match would also hit node -c (a syntax-only check)
+// and pytest --trace (a read-only debugger flag). go test flags accept
+// single- and double-dash forms and an optional test. prefix that the go
+// tool passes through to the test binary.
 func goTestFlagWritesFile(arg string) bool {
 	name := strings.ToLower(arg)
 	if i := strings.IndexByte(name, '='); i >= 0 {
 		name = name[:i]
 	}
-	switch name {
-	case "-c", "--c", "-o", "--o", "-trace", "--trace":
+	trimmed := strings.TrimLeft(name, "-")
+	if len(trimmed) == len(name) || trimmed == "" {
+		return false // not a flag
+	}
+	trimmed = strings.TrimPrefix(trimmed, "test.")
+	switch trimmed {
+	case "c", "o", "trace", "artifacts", "testlogfile", "gocoverdir",
+		"coverprofile", "cpuprofile", "memprofile", "blockprofile", "mutexprofile":
 		return true
 	default:
 		return false

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -562,6 +562,8 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "go test compile binary stays opaque", toolName: "bash", args: `{"command":"go test -c ./internal/evidence"}`, want: true},
 		{name: "go test dotted cpuprofile stays opaque", toolName: "bash", args: `{"command":"go test ./internal/evidence -test.cpuprofile=cpu.out -count=1"}`, want: true},
 		{name: "go test artifacts stays opaque", toolName: "bash", args: `{"command":"go test -artifacts ./..."}`, want: true},
+		{name: "jest output file stays opaque", toolName: "bash", args: `{"command":"npm test -- --json --outputFile=result.json"}`, want: true},
+		{name: "mypy report stays opaque", toolName: "bash", args: `{"command":"mypy --txt-report reports src/"}`, want: true},
 		{name: "plain pytest", toolName: "bash", args: `{"command":"pytest"}`},
 	}
 	for _, tt := range tests {
@@ -596,6 +598,13 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"go test -test.gocoverdir=covdir ./...",
 		"gotestsum -- -test.coverprofile=cover.out ./...",
 		"npm test -- --updateSnapshot",
+		"npm test -- --json --outputFile=result.json",
+		"yarn test --outputFile.json=result.json",
+		"pytest --report-log=log.jsonl",
+		"mypy --txt-report reports src/",
+		"mypy --html-report html src/",
+		"mypy --xml-report=reports src/",
+		"mypy --cobertura-xml-report reports src/",
 	} {
 		if bashCommandIsVerification(command) {
 			t.Fatalf("%q writes files and must not be classified as verification", command)
@@ -611,7 +620,9 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"go test -count=1 ./...",
 		"go test -test.v -test.run TestFoo ./...",
 		"pytest --trace",
+		"npm test -- --json",
 		"mypy src/",
+		"mypy --strict src/",
 	} {
 		if !bashCommandIsVerification(command) {
 			t.Fatalf("%q should remain a verification command", command)

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -557,6 +557,9 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "pytest junitxml report stays opaque", toolName: "bash", args: `{"command":"pytest --junitxml=report.xml"}`, want: true},
 		{name: "gotestsum junitfile stays opaque", toolName: "bash", args: `{"command":"gotestsum --junitfile out.xml ./..."}`, want: true},
 		{name: "go test coverprofile stays opaque", toolName: "bash", args: `{"command":"go test -coverprofile=cover.out ./..."}`, want: true},
+		{name: "go test blockprofile stays opaque", toolName: "bash", args: `{"command":"go test -blockprofile=block.out ./..."}`, want: true},
+		{name: "go test trace stays opaque", toolName: "bash", args: `{"command":"go test -trace trace.out ./..."}`, want: true},
+		{name: "go test compile binary stays opaque", toolName: "bash", args: `{"command":"go test -c ./internal/evidence"}`, want: true},
 		{name: "plain pytest", toolName: "bash", args: `{"command":"pytest"}`},
 	}
 	for _, tt := range tests {
@@ -579,6 +582,11 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"gotestsum --junitfile out.xml ./...",
 		"go test -coverprofile=cover.out ./...",
 		"go test --coverprofile cover.out ./...",
+		"go test -blockprofile=block.out ./...",
+		"go test -mutexprofile mutex.out ./...",
+		"go test -trace trace.out ./...",
+		"go test -c ./internal/evidence",
+		"go test -o evidence.test -c ./internal/evidence",
 		"npm test -- --updateSnapshot",
 	} {
 		if bashCommandIsVerification(command) {
@@ -592,6 +600,8 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"pytest",
 		"gotestsum ./...",
 		"go test -cover ./...",
+		"go test -count=1 ./...",
+		"pytest --trace",
 		"mypy src/",
 	} {
 		if !bashCommandIsVerification(command) {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -553,6 +553,11 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "formatter write", toolName: "bash", args: `{"command":"gofmt -w internal/a.go"}`, want: true},
 		{name: "file redirect", toolName: "bash", args: `{"command":"printf x > generated.txt"}`, want: true},
 		{name: "compound verification", toolName: "bash", args: `{"command":"go test ./... 2>&1 | tail -20"}`},
+		{name: "pytest snapshot update stays opaque", toolName: "bash", args: `{"command":"pytest --snapshot-update"}`, want: true},
+		{name: "pytest junitxml report stays opaque", toolName: "bash", args: `{"command":"pytest --junitxml=report.xml"}`, want: true},
+		{name: "gotestsum junitfile stays opaque", toolName: "bash", args: `{"command":"gotestsum --junitfile out.xml ./..."}`, want: true},
+		{name: "go test coverprofile stays opaque", toolName: "bash", args: `{"command":"go test -coverprofile=cover.out ./..."}`, want: true},
+		{name: "plain pytest", toolName: "bash", args: `{"command":"pytest"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -560,6 +565,38 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 				t.Fatalf("ToolCallMutates(%q, %s) = %v, want %v", tt.toolName, tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
+	// Snapshot flags rewrite checked-in fixtures and report/profile flags
+	// write explicit output paths; both must stay opaque mutations so the
+	// files they produce still require review and sign-off.
+	for _, command := range []string{
+		"pytest --snapshot-update",
+		"pytest --junitxml=report.xml",
+		"mypy --junit-xml report.xml src/",
+		"gotestsum --junitfile out.xml ./...",
+		"go test -coverprofile=cover.out ./...",
+		"go test --coverprofile cover.out ./...",
+		"npm test -- --updateSnapshot",
+	} {
+		if bashCommandIsVerification(command) {
+			t.Fatalf("%q writes files and must not be classified as verification", command)
+		}
+		if !ToolCallMutates("bash", json.RawMessage(`{"command":"`+command+`"}`), false) {
+			t.Fatalf("%q must remain an opaque mutation", command)
+		}
+	}
+	for _, command := range []string{
+		"pytest",
+		"gotestsum ./...",
+		"go test -cover ./...",
+		"mypy src/",
+	} {
+		if !bashCommandIsVerification(command) {
+			t.Fatalf("%q should remain a verification command", command)
+		}
 	}
 }
 

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -560,6 +560,8 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "go test blockprofile stays opaque", toolName: "bash", args: `{"command":"go test -blockprofile=block.out ./..."}`, want: true},
 		{name: "go test trace stays opaque", toolName: "bash", args: `{"command":"go test -trace trace.out ./..."}`, want: true},
 		{name: "go test compile binary stays opaque", toolName: "bash", args: `{"command":"go test -c ./internal/evidence"}`, want: true},
+		{name: "go test dotted cpuprofile stays opaque", toolName: "bash", args: `{"command":"go test ./internal/evidence -test.cpuprofile=cpu.out -count=1"}`, want: true},
+		{name: "go test artifacts stays opaque", toolName: "bash", args: `{"command":"go test -artifacts ./..."}`, want: true},
 		{name: "plain pytest", toolName: "bash", args: `{"command":"pytest"}`},
 	}
 	for _, tt := range tests {
@@ -587,6 +589,12 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"go test -trace trace.out ./...",
 		"go test -c ./internal/evidence",
 		"go test -o evidence.test -c ./internal/evidence",
+		"go test ./internal/evidence -test.cpuprofile=cpu.out -count=1",
+		"go test -test.trace trace.out ./...",
+		"go test -artifacts ./...",
+		"go test ./... -args -test.testlogfile=log.txt",
+		"go test -test.gocoverdir=covdir ./...",
+		"gotestsum -- -test.coverprofile=cover.out ./...",
 		"npm test -- --updateSnapshot",
 	} {
 		if bashCommandIsVerification(command) {
@@ -601,6 +609,7 @@ func TestRunnerWriteOutputFlagsCannotMasqueradeAsVerification(t *testing.T) {
 		"gotestsum ./...",
 		"go test -cover ./...",
 		"go test -count=1 ./...",
+		"go test -test.v -test.run TestFoo ./...",
 		"pytest --trace",
 		"mypy src/",
 	} {


### PR DESCRIPTION
## Summary

- Reject test-runner flags that write files in the delivery verification classifier: pytest/syrupy `--snapshot-update`, jest `--updateSnapshot` (via npm/yarn wrappers), pytest `--junitxml` / mypy `--junit-xml`, gotestsum `--junitfile`/`--jsonfile`, and `go test -coverprofile/-cpuprofile/-memprofile`.
- Match whole flag names in both `--flag=value` and space-separated forms, next to the existing `--fix`/`--write`/`-w`/`--update`/`-u` guard.
- Keep plain runner invocations (`pytest`, `gotestsum`, `go test -cover`, `mypy`) classified as verification.

## Root cause

`bashSegmentIsVerification` trusts conventional test runners unconditionally, so a runner invoked with an explicit write flag was still recorded with `Mutation=false`. Snapshot regeneration rewrites checked-in fixtures (the same class as the globally rejected `--update`/`-u`/`--fix`) and report/profile flags write explicit output paths; files produced by such runs bypassed the delivery re-review/re-verify/sign-off gate.

This is the same defect shape #6407 fixed for `node --test --test-update-snapshots` and `--test-reporter-destination`; this PR extends the fail-closed treatment to the sibling runners already in the classifier.

Intentionally out of scope: flags whose write behavior depends on invisible project config (plain `tsc` emits unless tsconfig sets `noEmit`) and build-cache artifacts (`cargo` `target/`, `__pycache__`) — rejecting those would misclassify common legitimate verification runs.

## Backward compatibility

| Surface | Old-data or existing-workflow behavior | Conclusion |
| --- | --- | --- |
| Persisted sessions and events | No fields or outcome values added; existing records deserialize unchanged | Compatible |
| Tool and provider contracts | Tool schemas, ordering, prompts, provider serialization, and request payloads unchanged | Compatible |
| Plain runner invocations | `pytest` / `gotestsum` / `go test` / `mypy` without write flags stay verification commands | Compatible |
| Runs with write flags | Now conservatively opaque mutations; the delivery gate asks for re-review/sign-off, matching how `gofmt -w` or `--fix` runs are already treated | Safer behavior |

## Related

- #6407 fixed the same shape for the `node --test` branch. The two PRs touch non-overlapping hunks and merge cleanly in either order (verified locally with a dry-run merge plus focused tests on the merged tree).

## Verification

- `go test ./internal/evidence ./internal/tool/builtin ./internal/agent -count=1`
- `env -u DEEPSEEK_API_KEY go test ./... -count=1`
- `./scripts/cache-guard.sh`
- `git diff --check`
- Dry-run merge with `refs/pull/6407/head`: clean; focused tests pass on the merged tree

Cache-impact: low - evidence classifier change only; no prompts, tool schemas, tool ordering, provider serialization, or request payload construction touched.
Cache-guard: ./scripts/cache-guard.sh passed; focused evidence tests plus root Go test suite passed.
