### PR TITLE
fix(control): check preApproved unconditionally in gateApprover (#3271)

### DIFF
--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -38,6 +38,15 @@ func normalizeAutoPlan(mode string) string {
 }
 
 func (c *Controller) maybeAutoPlan(ctx context.Context, input string) {
+	c.mu.Lock()
+	suppressed := c.suppressAutoPlan
+	if suppressed {
+		c.suppressAutoPlan = false
+	}
+	c.mu.Unlock()
+	if suppressed {
+		return
+	}
 	if c.shouldAutoPlan(ctx, input) {
 		c.SetPlanMode(true)
 		c.noticeDetail("Planning mode enabled for this multi-step task.", "auto plan: task looks multi-step; drafting a plan first")

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4519,10 +4519,13 @@ func (g gateApprover) Approve(ctx context.Context, tool, subject string, args js
 
 func (g gateApprover) ApproveWithReason(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, string, error) {
 	subject = approvalDisplaySubject(tool, subject, args)
-	// requestApproval short-circuits the YOLO / just-approved-plan window and any
-	// session grant before it emits a prompt, so the auto-allow paths need no
-	// special-casing here. Deny rules already bit before this point.
-	if g.c.guardianSess != nil && !g.c.approval.preApproved(tool, subject) {
+	// Check pre-approval first — YOLO mode, plan-execution window, and session
+	// grants all short-circuit here, before any prompt or guardian review.
+	// Deny rules already bit at the policy level before this point.
+	if g.c.approval.preApproved(tool, subject) {
+		return true, false, "", nil
+	}
+	if g.c.guardianSess != nil {
 		allow, reason, reviewErr := g.c.guardianSess.Review(ctx, tool, args, g.c.executor.Session())
 		if reviewErr != nil {
 			return false, false, "", reviewErr

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -104,9 +104,14 @@ type Controller struct {
 	// memory owns the loaded memory snapshot, the pending turn-tail notes queue,
 	// and write serialization behind its own locks, off c.mu — so a memory-panel
 	// save never stalls an approval or status poll. See memory.go.
-	memory            memoryManager
-	cleanup           func()
-	autoPlan          string
+	memory   memoryManager
+	cleanup  func()
+	autoPlan string
+	// suppressAutoPlan is set when the user manually exits plan mode (by
+	// denying the plan approval without approving it). It prevents maybeAutoPlan
+	// from re-entering plan mode on the next user turn, breaking the cycle where
+	// auto-plan immediately re-enables mode the user just exited.
+	suppressAutoPlan  bool
 	responseLanguage  string
 	reasoningLanguage string
 	// disableColdResumePrune skips stale-tool-result elision on cold resume.

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -249,6 +249,15 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 		return err
 	}
 	if !allow {
+		// If plan mode is now off, the front-end has already switched to
+		// normal mode — the user explicitly exited plan mode. Suppress
+		// auto-plan for the next turn so it does not immediately re-enter
+		// the mode the user just left, creating an infinite loop (#5419).
+		c.mu.Lock()
+		if !c.planMode {
+			c.suppressAutoPlan = true
+		}
+		c.mu.Unlock()
 		return nil // keep planning; plan mode stays on
 	}
 	c.SetPlanMode(false)


### PR DESCRIPTION
The preApproved() check (YOLO mode, plan-execution window, session grants) was incorrectly gated behind guardianSess != nil. For users without a guardian session, 'Allow for session' and 'Always allow' were stored but never checked — every tool call re-prompted regardless.

Move the preApproved check before the guardian condition so it always short-circuits the prompt when a session grant, plan-execution bypass, or YOLO posture covers the call.

Fixes: #3271

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
