### PR TITLE
fix(desktop): add accent colour underline to active tab / 选中tab底部增加主题色条

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -115,6 +115,30 @@ ok(
 );
 
 ok(
+  finalDeclaration(":root[data-theme-style] .tabbar__tab--active", "box-shadow")?.includes(
+    "inset 0 -2px 0 var(--project-accent, var(--accent))",
+  ),
+  "active themed tab carries the project-accent underline",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .tabbar__tab--active:focus-visible", "box-shadow")?.includes(
+    "inset 0 -2px 0 var(--project-accent, var(--accent))",
+  ) &&
+    finalDeclaration(":root[data-theme-style] .tabbar__tab--active:focus-visible", "box-shadow")?.includes(
+      "0 0 0 3px var(--accent-soft)",
+    ),
+  "keyboard focus on the active tab keeps both the focus ring and the accent underline",
+);
+
+ok(
+  matchingBlocks(".app--darwin .app-chrome--tabs .tabbar__tab--active").every(
+    (block) => !block.includes("inset 0 2px"),
+  ),
+  "macOS active tab declares no dead top-edge accent (the themed bottom-edge layer owns it)",
+);
+
+ok(
   /workbenchChrome \? \(\s*<span className="app-chrome__spacer" aria-hidden="true" \/>/s.test(appChromeSource),
   "AppChrome workbench branch skips the tab strip",
 );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -19782,7 +19782,9 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
   background: var(--chat-bg);
   border-color: var(--border-soft);
-  box-shadow: 0 -1px 0 color-mix(in srgb, var(--fg) 5%, transparent);
+  box-shadow:
+    0 -1px 0 color-mix(in srgb, var(--fg) 5%, transparent),
+    inset 0 2px 0 var(--project-accent, var(--accent));
 }
 
 .app--darwin .app-chrome--tabs .tabbar__tab-label {
@@ -20005,13 +20007,16 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
   border-color: var(--border);
   background: var(--bg-elev);
-  box-shadow: 0 1px 0 color-mix(in srgb, #fff 45%, transparent);
+  box-shadow:
+    0 1px 0 color-mix(in srgb, #fff 45%, transparent),
+    inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 .app--linux .app-chrome--native-tabs .tabbar__tab--active {
   color: var(--fg);
   border-color: color-mix(in srgb, var(--border-soft) 70%, transparent);
   background: color-mix(in srgb, var(--bg-elev) 78%, transparent);
+  box-shadow: inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 .app--windows .app-chrome--native-tabs .tabbar__tab:active,
@@ -20507,7 +20512,9 @@ body > .mermaid-diagram--fullscreen {
 .tabbar__tab--active {
   color: var(--fg);
   background: var(--chat-bg);
-  box-shadow: inset 0 -1px 0 var(--chat-bg);
+  box-shadow:
+    inset 0 -1px 0 var(--chat-bg),
+    inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 @media (max-width: 980px) {
@@ -23308,7 +23315,7 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
   border-color: var(--border);
   background: var(--bg-elev);
-  box-shadow: none;
+  box-shadow: inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 .app--darwin .app-chrome--tabs .tabbar__new,
@@ -24112,7 +24119,9 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .tabbar__tab--active {
   color: var(--fg);
   background: var(--surface-2);
-  box-shadow: var(--app-graphite-shadow);
+  box-shadow:
+    var(--app-graphite-shadow),
+    inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 :root[data-theme-style] .tabbar__tab:focus {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -19782,9 +19782,7 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
   background: var(--chat-bg);
   border-color: var(--border-soft);
-  box-shadow:
-    0 -1px 0 color-mix(in srgb, var(--fg) 5%, transparent),
-    inset 0 2px 0 var(--project-accent, var(--accent));
+  box-shadow: 0 -1px 0 color-mix(in srgb, var(--fg) 5%, transparent);
 }
 
 .app--darwin .app-chrome--tabs .tabbar__tab-label {
@@ -24130,6 +24128,13 @@ body > .mermaid-diagram--fullscreen {
 
 :root[data-theme-style] .tabbar__tab:focus-visible {
   box-shadow: 0 0 0 3px var(--accent-soft), var(--app-graphite-shadow);
+}
+
+:root[data-theme-style] .tabbar__tab--active:focus-visible {
+  box-shadow:
+    0 0 0 3px var(--accent-soft),
+    var(--app-graphite-shadow),
+    inset 0 -2px 0 var(--project-accent, var(--accent));
 }
 
 :root[data-theme-style] .tabbar__tab-label {


### PR DESCRIPTION
## Summary

Fix #6391

Add a 2px accent-coloured underline to the active tab using `box-shadow: inset`, making the selected tab immediately distinguishable from inactive ones. Uses `var(--project-accent, var(--accent))` to respect per-project accent colours.

`::after` pseudo-elements were avoided because `.tabbar__tab--drop-after::after` already occupies the `::after` slot for the drag-drop indicator.

- **macOS**: accent bar at bottom edge — the always-on `[data-theme-style]` layer flattens the tab and owns the accent, so it renders like the other platforms
- **Windows / Linux native-tabs**: accent bar at bottom edge (`inset 0 -2px`)
- **Classic mode** (base `.tabbar__tab--active`): accent bar at bottom edge
- **workspace-tabs-bar**: accent bar at bottom edge
- **`[data-theme-style]`** creation mode: accent bar at bottom edge, composed with existing graphite shadow

> Maintainer note: `applyTheme` always sets `data-theme-style`, so the `[data-theme-style]` rule wins on every platform and renders the accent as a uniform bottom-edge marker. The earlier macOS top-edge (`inset 0 2px`) declaration never applied and has been reverted to its base box-shadow in a follow-up commit; a `.tabbar__tab--active:focus-visible` rule was also added so keyboard focus keeps the active marker.

## Verification

- **Active tab indicator**: Open multiple tabs. The active tab shows a 2px accent-coloured underline. Switch between tabs — the underline moves to the newly selected tab.
- **Theme switching**: Cycle through the 6 built-in themes. The underline colour changes to match the current theme's accent.
- **Project colours**: Open tabs from different projects with custom accent colours. Each tab's underline uses its project's colour.
- **Drag-drop**: Drag a tab to reorder. The drop indicator (vertical accent line) and the active underline do not interfere.
- **macOS styling**: macOS active tabs keep their original border and chat-bg background; the accent renders as a subtle bottom line through the themed layer.

## Cache impact

Cache-impact: none — pure CSS, no model/provider/serialization path touched.
Cache-guard: `pnpm --dir desktop/frontend build` passes; 77/77 frontend CSS contract tests pass.
System-prompt-review: N/A — strictly client-side CSS, no prompt or memory prefix changed.

## Result

<img width="575" height="63" alt="QQ_1783936613609" src="https://github.com/user-attachments/assets/5c2efefd-640d-4db3-8315-b17ca3b8c032" />
