### PR TITLE
feat(crash-report): D1 retention purge, ingest sentinel, graceful write degradation / 崩溃统计 D1:自动清理 + 写入哨兵 + 摄入降级

### DIFF
--- a/.github/workflows/deploy-crash-worker.yml
+++ b/.github/workflows/deploy-crash-worker.yml
@@ -43,7 +43,8 @@ jobs:
           ALERT_WEBHOOK: ${{ secrets.ALERT_WEBHOOK }}
         run: |
           if [ -z "$ALERT_WEBHOOK" ]; then
-            echo "ALERT_WEBHOOK repo secret not set; sentinel alerts stay log-only."
+            echo "ALERT_WEBHOOK repo secret not set; removing any existing worker secret."
+            printf '{"ALERT_WEBHOOK":null}' | npx wrangler secret bulk
             exit 0
           fi
           printf '%s' "$ALERT_WEBHOOK" | npx wrangler secret put ALERT_WEBHOOK

--- a/.github/workflows/deploy-crash-worker.yml
+++ b/.github/workflows/deploy-crash-worker.yml
@@ -32,3 +32,18 @@ jobs:
         run: |
           npm ci
           npx wrangler deploy
+      # Mirrors the ALERT_WEBHOOK repo secret into the worker so the ingest
+      # sentinel can push alerts (see runIngestSentinel). Managed here so
+      # nobody needs local Cloudflare credentials; when the repo secret is
+      # unset the sentinel stays log-only.
+      - name: Sync alert webhook secret
+        working-directory: workers/crash-report
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ALERT_WEBHOOK: ${{ secrets.ALERT_WEBHOOK }}
+        run: |
+          if [ -z "$ALERT_WEBHOOK" ]; then
+            echo "ALERT_WEBHOOK repo secret not set; sentinel alerts stay log-only."
+            exit 0
+          fi
+          printf '%s' "$ALERT_WEBHOOK" | npx wrangler secret put ALERT_WEBHOOK

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -63,6 +63,17 @@ CREATE TABLE IF NOT EXISTS pings (
   PRIMARY KEY (date, install_id)
 );
 
+-- Single-row checkpoint used by the scheduled ingest sentinel to detect when
+-- launch totals stop advancing between runs. The worker also creates this
+-- table at runtime so existing databases need no manual migration.
+CREATE TABLE IF NOT EXISTS ingest_sentinel_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  day TEXT NOT NULL,
+  ping_count INTEGER NOT NULL,
+  open_count INTEGER NOT NULL,
+  checked_at TEXT NOT NULL
+);
+
 -- Opt-in aggregate desktop metrics: anonymous per-day (signal, bucket) counters,
 -- no content. Generic shape so a new signal is just new rows.
 CREATE TABLE IF NOT EXISTS metrics (

--- a/workers/crash-report/src/env.ts
+++ b/workers/crash-report/src/env.ts
@@ -18,4 +18,8 @@ export interface Env {
   APP_ORIGIN?: string;
   // Browsers allowed to call the registry API with credentials (comma-separated).
   ALLOWED_ORIGINS?: string;
+  // Optional incident webhook for the ingest sentinel (wrangler secret put
+  // ALERT_WEBHOOK). Feishu/Lark bot URLs get their native payload shape; any
+  // other receiver gets Slack-style {"text": ...}. Unset = log-only.
+  ALERT_WEBHOOK?: string;
 }

--- a/workers/crash-report/src/env.ts
+++ b/workers/crash-report/src/env.ts
@@ -18,8 +18,9 @@ export interface Env {
   APP_ORIGIN?: string;
   // Browsers allowed to call the registry API with credentials (comma-separated).
   ALLOWED_ORIGINS?: string;
-  // Optional incident webhook for the ingest sentinel (wrangler secret put
-  // ALERT_WEBHOOK). Feishu/Lark bot URLs get their native payload shape; any
-  // other receiver gets Slack-style {"text": ...}. Unset = log-only.
+  // Optional incident webhook for the ingest sentinel, mirrored from the
+  // GitHub repo secret of the same name by deploy-crash-worker.yml. Feishu/
+  // Lark bot URLs get their native payload shape; any other receiver gets
+  // Slack-style {"text": ...}. Unset = log-only.
   ALERT_WEBHOOK?: string;
 }

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -976,6 +976,54 @@ async function handleCommunityAction(
   return back;
 }
 
+// Time-series retention, run by the daily cron trigger. Every dashboard query
+// against the per-install tables reads at most the current window (-29 day),
+// while the aggregate `metrics` table also serves the 30d view's
+// previous-window delta (back to -59 day), so it keeps a doubled horizon.
+// `reports`/`groups` are excluded on purpose: they are the triage queue and
+// the regression baseline, are not date-partitioned, and their growth is
+// already bounded by per-group sampling. Without this purge the database
+// grows until D1's size cap, at which point every ingest write starts
+// throwing (all of /v1/ping, /v1/metrics and /v1/report 500 while reads keep
+// working — exactly the 2026-07-03 stats blackout).
+const RETENTION = [
+  { table: "pings", keepDays: 30 },
+  { table: "metrics", keepDays: 60 },
+  { table: "metric_users", keepDays: 30 },
+] as const;
+// Deletes run in rowid chunks so a run never holds one giant transaction.
+// Steady state is one expired day per table; the chunk cap is a backstop that
+// still drains ~2M rows per table per run after an ingest outage or backlog.
+const RETENTION_CHUNK_ROWS = 10_000;
+const RETENTION_MAX_CHUNKS = 200;
+
+async function purgeExpiredStatsRows(env: Env): Promise<void> {
+  for (const { table, keepDays } of RETENTION) {
+    // Keep exactly the newest `keepDays` dates: today plus keepDays-1 back,
+    // matching the `date >= date('now', '-{keepDays-1} day')` reads.
+    const cutoff = `-${keepDays - 1} day`;
+    let purged = 0;
+    try {
+      for (let i = 0; i < RETENTION_MAX_CHUNKS; i++) {
+        const res = await env.DB.prepare(
+          `DELETE FROM ${table} WHERE rowid IN (
+             SELECT rowid FROM ${table} WHERE date < date('now', ?1) LIMIT ${RETENTION_CHUNK_ROWS}
+           )`,
+        )
+          .bind(cutoff)
+          .run();
+        const changes = res.meta.changes ?? 0;
+        purged += changes;
+        if (changes < RETENTION_CHUNK_ROWS) break;
+      }
+      console.log(`retention: purged ${purged} rows from ${table} (keep ${keepDays}d)`);
+    } catch (err) {
+      // One broken table must not stop the others; the cron retries tomorrow.
+      console.error(`retention: purge failed for ${table} after ${purged} rows`, err);
+    }
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -1057,5 +1105,9 @@ export default {
       return new Response("method not allowed", { status: 405 });
     }
     return new Response("not found", { status: 404 });
+  },
+
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(purgeExpiredStatsRows(env));
   },
 };

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -1031,8 +1031,9 @@ const SENTINEL_CRON = "17 1,7,13,19 * * *";
 // shapes independently:
 //   1. canary write into `pings` (immediately deleted) — catches writes
 //      throwing, e.g. the D1 size cap, regardless of traffic;
-//   2. today's real ping count — catches ingest dying upstream of the worker
-//      (edge blocking, client regression) even while writes stay healthy.
+//   2. today's real ping and open totals compared with the previous run —
+//      catches ingest dying upstream of the worker (edge blocking, client
+//      regression) even after the UTC day already has traffic.
 // Alerts go to the optional ALERT_WEBHOOK secret; without it they still land
 // in the worker logs. While broken this fires at most 4 alerts/day.
 const CANARY_INSTALL_ID = "ffffffffffffffffffffffffffffffff";
@@ -1074,12 +1075,53 @@ async function runIngestSentinel(env: Env): Promise<void> {
     problems.push(`canary write failed: ${errText(err)}`);
   }
   try {
-    const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM pings WHERE date = date('now') AND install_id <> ?1")
+    // Auto-create the one-row checkpoint so existing databases do not need a
+    // manual migration before this worker version is deployed.
+    await env.DB.prepare(
+      `CREATE TABLE IF NOT EXISTS ingest_sentinel_state (
+         id INTEGER PRIMARY KEY CHECK (id = 1),
+         day TEXT NOT NULL,
+         ping_count INTEGER NOT NULL,
+         open_count INTEGER NOT NULL,
+         checked_at TEXT NOT NULL
+       )`,
+    ).run();
+    const row = await env.DB.prepare(
+      `SELECT date('now') AS day,
+              COUNT(*) AS ping_count,
+              COALESCE(SUM(opens), 0) AS open_count
+       FROM pings
+       WHERE date = date('now') AND install_id <> ?1`,
+    )
       .bind(CANARY_INSTALL_ID)
-      .first<{ n: number }>();
-    if (!Number(row?.n ?? 0)) problems.push("no launch pings recorded today (UTC)");
+      .first<{ day: string; ping_count: number; open_count: number }>();
+    const day = row?.day ?? "";
+    const pingCount = Number(row?.ping_count ?? 0);
+    const openCount = Number(row?.open_count ?? 0);
+    const previous = await env.DB.prepare(
+      "SELECT day, ping_count, open_count, checked_at FROM ingest_sentinel_state WHERE id = 1",
+    ).first<{ day: string; ping_count: number; open_count: number; checked_at: string }>();
+    if (!pingCount) {
+      problems.push("no launch pings recorded today (UTC)");
+    } else if (
+      previous?.day === day &&
+      pingCount <= Number(previous.ping_count) &&
+      openCount <= Number(previous.open_count)
+    ) {
+      problems.push(
+        `launch ping totals unchanged since ${previous.checked_at} UTC (${pingCount} install rows, ${openCount} opens)`,
+      );
+    }
+    await env.DB.prepare(
+      `INSERT INTO ingest_sentinel_state (id, day, ping_count, open_count, checked_at)
+       VALUES (1, ?1, ?2, ?3, datetime('now'))
+       ON CONFLICT (id) DO UPDATE SET
+         day = ?1, ping_count = ?2, open_count = ?3, checked_at = datetime('now')`,
+    )
+      .bind(day, pingCount, openCount)
+      .run();
   } catch (err) {
-    problems.push(`ping count read failed: ${errText(err)}`);
+    problems.push(`ping progress check failed: ${errText(err)}`);
   }
   if (!problems.length) return;
   const message = `crash.reasonix.io ingest sentinel: ${problems.join("; ")} — https://crash.reasonix.io/stats`;

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -1043,10 +1043,11 @@ function errText(err: unknown): string {
 
 async function sendAlert(env: Env, text: string): Promise<void> {
   if (!env.ALERT_WEBHOOK) return;
-  const feishu = env.ALERT_WEBHOOK.includes("open.feishu.cn") || env.ALERT_WEBHOOK.includes("open.larksuite.com");
-  const body = feishu ? { msg_type: "text", content: { text } } : { text };
   try {
-    const res = await fetch(env.ALERT_WEBHOOK, {
+    const webhook = new URL(env.ALERT_WEBHOOK);
+    const feishu = webhook.hostname === "open.feishu.cn" || webhook.hostname === "open.larksuite.com";
+    const body = feishu ? { msg_type: "text", content: { text } } : { text };
+    const res = await fetch(webhook.toString(), {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -297,6 +297,16 @@ async function readJSON(request: Request): Promise<unknown | Response> {
   }
 }
 
+// Ingest writes fail together when the database is unhealthy (e.g. the D1
+// size cap: every INSERT throws while reads stay fine). Surface that as a
+// deliberate 503 with a loud log instead of an opaque worker exception, so
+// `wrangler tail` / observability show the root cause and clients see a
+// retryable status.
+function storageUnavailable(op: string, err: unknown): Response {
+  console.error(`${op}: D1 write failed`, err);
+  return new Response("storage unavailable", { status: 503 });
+}
+
 async function handleReport(request: Request, env: Env): Promise<Response> {
   const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
   const { success } = await env.RATE_LIMITER.limit({ key: ip });
@@ -338,82 +348,86 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   const buildCommit = r.buildCommit ?? "";
   const channel = r.channel ?? "";
   const severity = severityForReport({ kind: r.kind, source, label, errorType, errorMessage, topFrame });
-  const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
-    .bind(fingerprint)
-    .first<{ status: string }>();
-  const regressedAt = prior?.status === "resolved" ? now : "";
+  try {
+    const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
+      .bind(fingerprint)
+      .first<{ status: string }>();
+    const regressedAt = prior?.status === "resolved" ? now : "";
 
-  await env.DB.prepare(
-    `INSERT INTO groups (
-       fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
-       status, title, source, label, error_type, top_frame, severity,
-       last_os, last_arch, last_build_commit, last_channel, last_sample_at, regressed_at
-     )
-     VALUES (?1, ?2, 1, ?3, ?3, ?4, ?4, 'open', ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?3, ?15)
-     ON CONFLICT (fingerprint) DO UPDATE SET
-       count = count + 1,
-       last_seen = ?3,
-       last_version = ?4,
-       title = ?5,
-       source = ?6,
-       label = ?7,
-       error_type = ?8,
-       top_frame = ?9,
-       last_os = ?11,
-       last_arch = ?12,
-       last_build_commit = ?13,
-       last_channel = ?14,
-       last_sample_at = ?3,
-       status = CASE WHEN status = 'resolved' THEN 'open' ELSE status END,
-       regressed_at = CASE WHEN status = 'resolved' THEN ?3 ELSE regressed_at END`,
-  )
-    .bind(fingerprint, r.kind, now, r.version, title, source, label, errorType, topFrame, severity, r.os, r.arch, buildCommit, channel, regressedAt)
-    .run();
-
-  await env.DB.prepare(
-    `INSERT INTO reports (
-       fingerprint, kind, version, os, arch, message, device, created_at,
-       source, label, error_type, error_message, top_frame, build_commit, channel,
-       language, view, breadcrumbs, component_stack, stack, occurred_at
-     )
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)`,
-  )
-    .bind(
-      fingerprint,
-      r.kind,
-      r.version,
-      r.os,
-      r.arch,
-      message,
-      JSON.stringify(r.device ?? {}),
-      now,
-      source,
-      label,
-      errorType,
-      errorMessage,
-      topFrame,
-      buildCommit,
-      channel,
-      r.language ?? "",
-      view,
-      JSON.stringify(breadcrumbs),
-      componentStack,
-      stack,
-      r.occurredAt ?? "",
+    await env.DB.prepare(
+      `INSERT INTO groups (
+         fingerprint, kind, count, first_seen, last_seen, first_version, last_version,
+         status, title, source, label, error_type, top_frame, severity,
+         last_os, last_arch, last_build_commit, last_channel, last_sample_at, regressed_at
+       )
+       VALUES (?1, ?2, 1, ?3, ?3, ?4, ?4, 'open', ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?3, ?15)
+       ON CONFLICT (fingerprint) DO UPDATE SET
+         count = count + 1,
+         last_seen = ?3,
+         last_version = ?4,
+         title = ?5,
+         source = ?6,
+         label = ?7,
+         error_type = ?8,
+         top_frame = ?9,
+         last_os = ?11,
+         last_arch = ?12,
+         last_build_commit = ?13,
+         last_channel = ?14,
+         last_sample_at = ?3,
+         status = CASE WHEN status = 'resolved' THEN 'open' ELSE status END,
+         regressed_at = CASE WHEN status = 'resolved' THEN ?3 ELSE regressed_at END`,
     )
-    .run();
+      .bind(fingerprint, r.kind, now, r.version, title, source, label, errorType, topFrame, severity, r.os, r.arch, buildCommit, channel, regressedAt)
+      .run();
 
-  await env.DB.prepare(
-    `DELETE FROM reports
-     WHERE fingerprint = ?1
-       AND id NOT IN (
-         SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id ASC LIMIT 1)
-         UNION
-         SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id DESC LIMIT ?2)
-       )`,
-  )
-    .bind(fingerprint, LATEST_SAMPLES_PER_GROUP)
-    .run();
+    await env.DB.prepare(
+      `INSERT INTO reports (
+         fingerprint, kind, version, os, arch, message, device, created_at,
+         source, label, error_type, error_message, top_frame, build_commit, channel,
+         language, view, breadcrumbs, component_stack, stack, occurred_at
+       )
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)`,
+    )
+      .bind(
+        fingerprint,
+        r.kind,
+        r.version,
+        r.os,
+        r.arch,
+        message,
+        JSON.stringify(r.device ?? {}),
+        now,
+        source,
+        label,
+        errorType,
+        errorMessage,
+        topFrame,
+        buildCommit,
+        channel,
+        r.language ?? "",
+        view,
+        JSON.stringify(breadcrumbs),
+        componentStack,
+        stack,
+        r.occurredAt ?? "",
+      )
+      .run();
+
+    await env.DB.prepare(
+      `DELETE FROM reports
+       WHERE fingerprint = ?1
+         AND id NOT IN (
+           SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id ASC LIMIT 1)
+           UNION
+           SELECT id FROM (SELECT id FROM reports WHERE fingerprint = ?1 ORDER BY id DESC LIMIT ?2)
+         )`,
+    )
+      .bind(fingerprint, LATEST_SAMPLES_PER_GROUP)
+      .run();
+  } catch (err) {
+    return storageUnavailable("report", err);
+  }
 
   return new Response("ok", { status: 202 });
 }
@@ -429,14 +443,18 @@ async function handlePing(request: Request, env: Env): Promise<Response> {
   if (!parsed.success) return new Response("bad request", { status: 400 });
   const p = parsed.data;
 
-  await env.DB.prepare(
-    `INSERT INTO pings (date, install_id, version, os, arch, os_version, opens)
-     VALUES (date('now'), ?1, ?2, ?3, ?4, ?5, 1)
-     ON CONFLICT (date, install_id) DO UPDATE SET
-       opens = opens + 1, version = ?2, os_version = ?5`,
-  )
-    .bind(p.installId, p.version, p.os, p.arch, p.osVersion ?? "")
-    .run();
+  try {
+    await env.DB.prepare(
+      `INSERT INTO pings (date, install_id, version, os, arch, os_version, opens)
+       VALUES (date('now'), ?1, ?2, ?3, ?4, ?5, 1)
+       ON CONFLICT (date, install_id) DO UPDATE SET
+         opens = opens + 1, version = ?2, os_version = ?5`,
+    )
+      .bind(p.installId, p.version, p.os, p.arch, p.osVersion ?? "")
+      .run();
+  } catch (err) {
+    return storageUnavailable("ping", err);
+  }
 
   return new Response("ok", { status: 202 });
 }
@@ -458,7 +476,11 @@ async function handleMetrics(request: Request, env: Env): Promise<Response> {
      ON CONFLICT (date, version, os, signal, bucket) DO UPDATE SET
        count = count + ?5`,
   );
-  await env.DB.batch(m.counters.map((c) => upsert.bind(m.version, m.os, c.signal, c.bucket, c.count)));
+  try {
+    await env.DB.batch(m.counters.map((c) => upsert.bind(m.version, m.os, c.signal, c.bucket, c.count)));
+  } catch (err) {
+    return storageUnavailable("metrics", err);
+  }
   if (m.installId) {
     const userUpsert = env.DB.prepare(
       `INSERT INTO metric_users (date, version, os, signal, bucket, install_id)
@@ -997,6 +1019,73 @@ const RETENTION = [
 const RETENTION_CHUNK_ROWS = 10_000;
 const RETENTION_MAX_CHUNKS = 200;
 
+// Must match the sentinel entry in wrangler.toml [triggers] exactly — the
+// scheduled handler dispatches on controller.cron; every other trigger
+// (the retention cron, manual runs) falls through to the purge.
+const SENTINEL_CRON = "17 1,7,13,19 * * *";
+
+// Ingest sentinel. The 2026-07-03 blackout went unnoticed for ten days because
+// clients swallow ping failures by design and nothing watched the write path.
+// Four times a day (hours chosen so the UTC day always has >1h of traffic;
+// ~14k DAU means a healthy hour is never empty) this probes the two failure
+// shapes independently:
+//   1. canary write into `pings` (immediately deleted) — catches writes
+//      throwing, e.g. the D1 size cap, regardless of traffic;
+//   2. today's real ping count — catches ingest dying upstream of the worker
+//      (edge blocking, client regression) even while writes stay healthy.
+// Alerts go to the optional ALERT_WEBHOOK secret; without it they still land
+// in the worker logs. While broken this fires at most 4 alerts/day.
+const CANARY_INSTALL_ID = "ffffffffffffffffffffffffffffffff";
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function sendAlert(env: Env, text: string): Promise<void> {
+  if (!env.ALERT_WEBHOOK) return;
+  const feishu = env.ALERT_WEBHOOK.includes("open.feishu.cn") || env.ALERT_WEBHOOK.includes("open.larksuite.com");
+  const body = feishu ? { msg_type: "text", content: { text } } : { text };
+  try {
+    const res = await fetch(env.ALERT_WEBHOOK, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) console.error(`alert webhook responded ${res.status}`);
+  } catch (err) {
+    console.error("alert webhook unreachable", err);
+  }
+}
+
+async function runIngestSentinel(env: Env): Promise<void> {
+  const problems: string[] = [];
+  try {
+    await env.DB.prepare(
+      `INSERT INTO pings (date, install_id, version, os, arch, opens)
+       VALUES (date('now'), ?1, 'canary', 'canary', 'canary', 0)
+       ON CONFLICT (date, install_id) DO NOTHING`,
+    )
+      .bind(CANARY_INSTALL_ID)
+      .run();
+    // Also removes any leftover canary from a run that died mid-way.
+    await env.DB.prepare("DELETE FROM pings WHERE install_id = ?1").bind(CANARY_INSTALL_ID).run();
+  } catch (err) {
+    problems.push(`canary write failed: ${errText(err)}`);
+  }
+  try {
+    const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM pings WHERE date = date('now') AND install_id <> ?1")
+      .bind(CANARY_INSTALL_ID)
+      .first<{ n: number }>();
+    if (!Number(row?.n ?? 0)) problems.push("no launch pings recorded today (UTC)");
+  } catch (err) {
+    problems.push(`ping count read failed: ${errText(err)}`);
+  }
+  if (!problems.length) return;
+  const message = `crash.reasonix.io ingest sentinel: ${problems.join("; ")} — https://crash.reasonix.io/stats`;
+  console.error(message);
+  await sendAlert(env, message);
+}
+
 async function purgeExpiredStatsRows(env: Env): Promise<void> {
   for (const { table, keepDays } of RETENTION) {
     // Keep exactly the newest `keepDays` dates: today plus keepDays-1 back,
@@ -1107,7 +1196,11 @@ export default {
     return new Response("not found", { status: 404 });
   },
 
-  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    if (controller.cron === SENTINEL_CRON) {
+      ctx.waitUntil(runIngestSentinel(env));
+      return;
+    }
     ctx.waitUntil(purgeExpiredStatsRows(env));
   },
 };

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -9,7 +9,7 @@ routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 # past the dashboard's query horizon so the D1 database plateaus instead of
 # hitting the size cap and failing every ingest write (purgeExpiredStatsRows).
 # Second entry: ingest sentinel four times a day (runIngestSentinel) — canary
-# write + today's ping count; alerts via the optional ALERT_WEBHOOK worker
+# write + checkpointed ping growth; alerts via the optional ALERT_WEBHOOK worker
 # secret, log-only when unset. The secret is mirrored from the GitHub repo
 # secret of the same name by deploy-crash-worker.yml on every deploy — set it
 # under repo Settings → Secrets → Actions, no Cloudflare login needed. The

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -5,6 +5,12 @@ compatibility_date = "2026-06-01"
 
 routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 
+# Daily retention purge (03:47 Beijing) — drops time-series rows past the
+# dashboard's query horizon so the D1 database plateaus instead of hitting the
+# size cap and failing every ingest write. See purgeExpiredStatsRows.
+[triggers]
+crons = ["47 19 * * *"]
+
 [vars]
 # Emails force-promoted to dashboard admin — the owner is never locked out even
 # if the role migration misses them.

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -9,9 +9,11 @@ routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 # past the dashboard's query horizon so the D1 database plateaus instead of
 # hitting the size cap and failing every ingest write (purgeExpiredStatsRows).
 # Second entry: ingest sentinel four times a day (runIngestSentinel) — canary
-# write + today's ping count; alerts via the optional ALERT_WEBHOOK secret
-# (`wrangler secret put ALERT_WEBHOOK`), log-only when unset. The sentinel
-# expression must stay in sync with SENTINEL_CRON in src/index.ts.
+# write + today's ping count; alerts via the optional ALERT_WEBHOOK worker
+# secret, log-only when unset. The secret is mirrored from the GitHub repo
+# secret of the same name by deploy-crash-worker.yml on every deploy — set it
+# under repo Settings → Secrets → Actions, no Cloudflare login needed. The
+# sentinel expression must stay in sync with SENTINEL_CRON in src/index.ts.
 [triggers]
 crons = ["47 19 * * *", "17 1,7,13,19 * * *"]
 

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -5,11 +5,15 @@ compatibility_date = "2026-06-01"
 
 routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 
-# Daily retention purge (03:47 Beijing) — drops time-series rows past the
-# dashboard's query horizon so the D1 database plateaus instead of hitting the
-# size cap and failing every ingest write. See purgeExpiredStatsRows.
+# First entry: daily retention purge (03:47 Beijing) — drops time-series rows
+# past the dashboard's query horizon so the D1 database plateaus instead of
+# hitting the size cap and failing every ingest write (purgeExpiredStatsRows).
+# Second entry: ingest sentinel four times a day (runIngestSentinel) — canary
+# write + today's ping count; alerts via the optional ALERT_WEBHOOK secret
+# (`wrangler secret put ALERT_WEBHOOK`), log-only when unset. The sentinel
+# expression must stay in sync with SENTINEL_CRON in src/index.ts.
 [triggers]
-crons = ["47 19 * * *"]
+crons = ["47 19 * * *", "17 1,7,13,19 * * *"]
 
 [vars]
 # Emails force-promoted to dashboard admin — the owner is never locked out even


### PR DESCRIPTION
## Problem

The `reasonix-crash` D1 database has no retention: the time-series tables (`pings`, `metrics`, and especially the per-install `metric_users`, which grows by roughly DAU x active signals rows every day) accumulate forever. On 2026-07-03 the database hit its size cap, and from that point **every ingest write threw** — `/v1/ping`, `/v1/metrics` and `/v1/report` all returned HTTP 500 (Cloudflare error 1101) while dashboard reads kept working, so `/stats` silently flatlined for ten days: clients swallow ping failures by design, the handlers surfaced raw worker exceptions, and nothing watched the write path. Capacity has been raised, but without retention the same cliff returns — and without a sentinel it would again go unnoticed.

## Commit 1 — retention purge

Daily cron (`47 19 * * *` UTC = 03:47 Beijing) purges time-series rows past the dashboard's query horizon:

| Table | Keep | Why |
| --- | --- | --- |
| `pings` | 30 days | every query reads at most `date >= date('now', '-29 day')` |
| `metric_users` | 30 days | current-window reads only (`metricUserRows`); this is the storage hog |
| `metrics` | 60 days | the 30d view's previous-window delta (`previousWindowSince(30)`) reads back to `-59 day`; the aggregate table is small, so the doubled horizon keeps the "vs previous window" badges fully populated |
| `reports` / `groups` | untouched | triage queue + regression baseline; not date-partitioned; growth already bounded by per-group sampling |

Every existing dashboard query keeps exactly the data it reads today — no view degrades. Deletes run in 10k-row `rowid` chunks (200 chunks per table per run as a backstop) so a run never holds one giant transaction; each table has its own try/catch so one broken table cannot stop the others.

## Commit 2 — ingest sentinel + graceful degradation

**Sentinel** (second cron, `17 1,7,13,19 * * *` UTC — hours picked so the UTC day always has >1h of traffic): each run probes the two failure shapes independently:

1. canary write into `pings` (deleted in the same run, plus cleanup of any leftover from a crashed run) — catches writes throwing (the size-cap shape) regardless of traffic;
2. today's real install count and total opens, compared with the previous sentinel checkpoint (canary excluded) — catches both a completely empty UTC day and intraday ingest stagnation after traffic has already started.

The one-row `ingest_sentinel_state` checkpoint is created automatically at runtime, so existing databases need no manual migration.

Problems post to the optional `ALERT_WEBHOOK` secret — Feishu/Lark URLs get their native `{msg_type, content}` payload, anything else gets Slack-style `{text}` — and always land in the worker logs. Unset secret = log-only. While broken this fires at most 4 alerts/day.

**Deploy workflow**: the deploy workflow mirrors the `ALERT_WEBHOOK` GitHub repo secret into the worker after each deploy and deletes any stale worker secret when the repo secret is unset, so configuring or revoking alerts never requires local Cloudflare credentials.

**Degradation**: the D1 writes in `/v1/ping`, `/v1/metrics` and `/v1/report` are now wrapped; a storage failure returns a deliberate `503 storage unavailable` with a contextual `console.error` instead of an opaque 500, so `wrangler tail` shows the root cause immediately. Rate-limit (429) and validation (400) behavior is unchanged; the existing tolerated `metric_users` inner failure stays tolerated.

The only schema addition is `ingest_sentinel_state`, a one-row checkpoint table. Retention still deletes only rows already invisible to every dashboard query.

| State / format | Existing-data behavior | Conclusion |
| --- | --- | --- |
| Existing D1 without `ingest_sentinel_state` | First sentinel run creates it with `CREATE TABLE IF NOT EXISTS`; no manual migration | backward-safe |
| Older worker against a database with the new table | Ignores the extra table | cross-version safe |
| Existing `pings` / `metrics` / `metric_users` rows | Current dashboard windows are preserved; only expired rows are removed | backward-safe |

## Verification

- `npm run typecheck` — clean.
- `npx wrangler deploy --dry-run` — config and bundle validate with both cron triggers.
- Retention boundary test (`wrangler d1 execute --local`): seeded rows on both sides of each cutoff, ran the exact chunked DELETEs. Survivors: `pings`/`metric_users` oldest = `-29 day`, `metrics` oldest = `-59 day`.
- End-to-end via `wrangler dev --test-scheduled`:
  - **Broken-DB injection** (no tables): valid ping → `503 storage unavailable` (not a raw exception); sentinel run logged `canary write failed … ; ping progress check failed …` with the full alert text; retention failed per-table without aborting the run.
  - **Healthy path** (schema + seed applied): valid ping → 202; sentinel run → no alert, canary row count afterwards = 0; retention cron purged exactly the out-of-horizon rows (`pings` oldest `-29 day`, `metrics` oldest `-59 day`).
- Ingest progress regression against an old-schema database containing only `pings`: first run auto-created the checkpoint and stayed silent; a second run with unchanged totals sent one alert; incrementing `opens` made the next run healthy without another alert.

## Deploy notes

- `deploy-crash-worker.yml` auto-deploys on merge; `wrangler deploy` registers both cron triggers, no manual step.
- To get pushed alerts (instead of log-only), add a repo Actions secret named `ALERT_WEBHOOK` (Settings → Secrets and variables → Actions) with a Feishu group-bot webhook URL, then let the next deploy run — the workflow mirrors it into the worker. No Cloudflare login needed.
- The first retention run also drains any rows older than the horizon left from before the outage; SQLite reuses freed pages, so the database file plateaus at the ~30-day working set instead of growing back to the cap.
