### PR TITLE
fix(agent): stop delivery sub-agent readiness failure cascade / 修复交付模式子 agent readiness 失败级联

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1212,6 +1212,29 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		a.evidence.Reset()
 	}
 	a.preserveEvidenceOnce = false
+	// Re-lease this session's background-job mutations that no turn has
+	// committed yet. The Reset above just wiped any lease a failed or
+	// cancelled turn held (its ledger is gone), and a process restart starts
+	// from an empty ledger too — in both cases the job manager still marks the
+	// job's evidence uncommitted. Without re-injecting it here, a turn that
+	// never re-issues wait/bash_output (the model has no reason to if it
+	// doesn't know a mutation is still pending) would ship the background
+	// change without the final-readiness gate ever seeing it. Plan-mode turns
+	// skip this like collectBackgroundEvidence does: writers are blocked, so
+	// arming delivery sign-off demands here would deadlock the turn.
+	if a.evidence != nil && a.jobs != nil && !a.planMode.Load() {
+		session := jobs.SessionFromContext(ctx)
+		for _, jobID := range a.jobs.PendingEvidenceJobIDsForSession(session) {
+			summary, ready := a.jobs.TryLeaseEvidenceForSession(session, jobID)
+			if !ready {
+				continue
+			}
+			if !a.evidence.NoteBackgroundLease(session, jobID) {
+				continue
+			}
+			a.evidence.MergeChild(summary)
+		}
+	}
 	// Commit background-job evidence leases only after this turn delivers.
 	// wait/bash_output merge a finished background writer's receipts into the
 	// ledger provisionally; if the turn reaches a final answer (runErr == nil)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2463,9 +2463,10 @@ type toolCallBatch struct {
 // partitionToolCalls keeps provider order while letting contiguous known
 // read-only tools run together. Unknown and writer tools are single-call serial
 // batches so they cannot reorder around reads or produce surprising errors.
-// complete_step and todo_write are read-only but never join a parallel run: they
-// read the turn's evidence ledger, so every prior call's receipt must be recorded
-// before they run.
+// complete_step and todo_write read the turn's evidence ledger. wait and
+// bash_output can merge a background task's receipts into that ledger. These
+// evidence-sensitive tools never join a parallel run, so provider order stays
+// receipt order.
 func partitionToolCalls(r *tool.Registry, calls []provider.ToolCall) []toolCallBatch {
 	var batches []toolCallBatch
 	for i := 0; i < len(calls); {
@@ -2485,7 +2486,8 @@ func partitionToolCalls(r *tool.Registry, calls []provider.ToolCall) []toolCallB
 }
 
 func parallelisable(r *tool.Registry, name string) bool {
-	if name == "complete_step" || name == "todo_write" {
+	switch name {
+	case "complete_step", "todo_write", "wait", "bash_output":
 		return false
 	}
 	t, ok := r.Get(name)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1212,6 +1212,20 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		a.evidence.Reset()
 	}
 	a.preserveEvidenceOnce = false
+	// Commit background-job evidence leases only after this turn delivers.
+	// wait/bash_output merge a finished background writer's receipts into the
+	// ledger provisionally; if the turn reaches a final answer (runErr == nil)
+	// the delivery gates have verified and reviewed those mutations, so the
+	// job's evidence can be permanently drained. A failed or cancelled turn
+	// leaves the lease uncommitted so the next turn re-collects it.
+	defer func() {
+		if runErr != nil || a.evidence == nil || a.jobs == nil {
+			return
+		}
+		for _, lease := range a.evidence.BackgroundLeases() {
+			a.jobs.CommitEvidenceForSession(lease.Session, lease.JobID)
+		}
+	}()
 	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria()
 	// Classify delivery expectations from the task text. Sub-agent spawners
 	// pass the pristine task through Options.ClassifierTaskText (a trusted

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -100,7 +100,10 @@ type callContext struct {
 // withCallContext stamps ctx with the executing call's ID, the agent's sink, and
 // the asker. executeOne sets this before every Execute; `task` reads it (via
 // CallContext) to nest sub-agent events, and `ask` reads the asker to prompt.
+// The plan-mode flag is mirrored onto the leaf planmode key so tools that must
+// not import this package (for example internal/tool/builtin) can still read it.
 func withCallContext(ctx context.Context, parentID string, sink event.Sink, asker Asker, planMode bool) context.Context {
+	ctx = planmode.WithActive(ctx, planMode)
 	return context.WithValue(ctx, callContextKey{}, callContext{parentID: parentID, sink: sink, asker: asker, planMode: planMode})
 }
 

--- a/internal/agent/capability_gate.go
+++ b/internal/agent/capability_gate.go
@@ -194,6 +194,16 @@ func (a *Agent) deliveryReviewGateFailure() string {
 	if a == nil || !a.deliveryProfile || a.evidence == nil {
 		return ""
 	}
+	if a.subagentDepth > 0 {
+		// Structured review is the parent's contract. A child's mutation
+		// receipts merge into the parent ledger (mergeChildEvidence), so the
+		// parent cannot final-answer without review coverage of those writes.
+		// Demanding review_report inside a depth-capped sub-agent — which may
+		// not even have the review tools — wedges the child against a gate it
+		// cannot satisfy. The light post-mutation review (read the touched
+		// file or run git diff/status) still applies via finalReadinessCheck.
+		return ""
+	}
 	mutation, ok := a.evidence.LatestSuccessfulMutationIndex()
 	if !ok {
 		return ""

--- a/internal/agent/capability_gate_test.go
+++ b/internal/agent/capability_gate_test.go
@@ -23,10 +23,8 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
 	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
 
-	// A path-less bash write classifies Medium: one structured review is
-	// required, with the recovery guidance for identifying the changed files.
 	got := a.deliveryReviewGateFailure()
-	for _, want := range []string{"medium-risk", "git status --short", "git diff", "mutation did not report file paths"} {
+	for _, want := range []string{"high-risk", "git status --short", "git diff", "mutation did not report file paths"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("review gate = %q, want %q", got, want)
 		}
@@ -41,8 +39,19 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 		"reviewed_paths":["internal/agent/agent.go"],
 		"findings":[]
 	}`)})
+	got = a.deliveryReviewGateFailure()
+	if !strings.Contains(got, "security_review") || !strings.Contains(got, "mutation did not report file paths") {
+		t.Fatalf("security review gate = %q, want opaque-mutation recovery guidance", got)
+	}
+
+	ledger.Record(evidence.Receipt{ToolName: "review_report", Success: true, Args: json.RawMessage(`{
+		"kind":"security",
+		"verdict":"pass",
+		"reviewed_paths":["internal/agent/agent.go"],
+		"findings":[]
+	}`)})
 	if got := a.deliveryReviewGateFailure(); got != "" {
-		t.Fatalf("review gate = %q after review report, want ready (opaque is medium, not high)", got)
+		t.Fatalf("review gate = %q after both reports, want ready", got)
 	}
 }
 

--- a/internal/agent/capability_gate_test.go
+++ b/internal/agent/capability_gate_test.go
@@ -23,8 +23,10 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
 	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
 
+	// A path-less bash write classifies Medium: one structured review is
+	// required, with the recovery guidance for identifying the changed files.
 	got := a.deliveryReviewGateFailure()
-	for _, want := range []string{"git status --short", "git diff", "mutation did not report file paths"} {
+	for _, want := range []string{"medium-risk", "git status --short", "git diff", "mutation did not report file paths"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("review gate = %q, want %q", got, want)
 		}
@@ -39,18 +41,59 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 		"reviewed_paths":["internal/agent/agent.go"],
 		"findings":[]
 	}`)})
-	got = a.deliveryReviewGateFailure()
-	if !strings.Contains(got, "security_review") || !strings.Contains(got, "mutation did not report file paths") {
-		t.Fatalf("security review gate = %q, want opaque-mutation recovery guidance", got)
+	if got := a.deliveryReviewGateFailure(); got != "" {
+		t.Fatalf("review gate = %q after review report, want ready (opaque is medium, not high)", got)
+	}
+}
+
+func TestDeliveryReviewGateHighRiskStillRequiresSecurityReview(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"internal/permission/gate.go"}`), true, false))
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "review", readOnly: true})
+	reg.Add(fakeTool{name: "security_review", readOnly: true})
+	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
+
+	if got := a.deliveryReviewGateFailure(); !strings.Contains(got, "high-risk") {
+		t.Fatalf("review gate = %q, want high-risk review demand", got)
+	}
+
+	ledger.Record(evidence.Receipt{ToolName: "review_report", Success: true, Args: json.RawMessage(`{
+		"kind":"review",
+		"verdict":"pass",
+		"reviewed_paths":["internal/permission/gate.go"],
+		"findings":[]
+	}`)})
+	if got := a.deliveryReviewGateFailure(); !strings.Contains(got, "security_review") {
+		t.Fatalf("security review gate = %q, want security_review demand", got)
 	}
 
 	ledger.Record(evidence.Receipt{ToolName: "review_report", Success: true, Args: json.RawMessage(`{
 		"kind":"security",
 		"verdict":"pass",
-		"reviewed_paths":["internal/agent/agent.go"],
+		"reviewed_paths":["internal/permission/gate.go"],
 		"findings":[]
 	}`)})
 	if got := a.deliveryReviewGateFailure(); got != "" {
 		t.Fatalf("review gate = %q after both reports, want ready", got)
+	}
+}
+
+func TestDeliveryReviewGateDefersToParentInSubagents(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"internal/permission/gate.go"}`), true, false))
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "review", readOnly: true})
+	reg.Add(fakeTool{name: "security_review", readOnly: true})
+	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg, subagentDepth: 1}
+
+	// Inside a sub-agent the structured-review contract belongs to the parent,
+	// which receives the child's mutation receipts via mergeChildEvidence. The
+	// child must not wedge against a review_report demand it may be unable to
+	// satisfy.
+	if got := a.deliveryReviewGateFailure(); got != "" {
+		t.Fatalf("subagent review gate = %q, want deferred to parent", got)
 	}
 }

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -179,6 +179,55 @@ func TestRunSubAgentReviewReportExhaustionNamesRecovery(t *testing.T) {
 	}
 }
 
+func TestRunSubAgentSalvagesReadinessExhaustedWork(t *testing.T) {
+	// The child performs a real mutation, then keeps answering without the
+	// delivery sign-off receipts until the readiness budget is exhausted. Its
+	// work is on disk, so the run must degrade to an explicitly unverified
+	// answer instead of a hard failure that tricks the parent into spawning
+	// repair tasks for changes that already landed.
+	reg := evidenceRegistry()
+	finalText := []provider.Chunk{{Type: provider.ChunkText, Text: "done, explanations added"}, {Type: provider.ChunkDone}}
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("criteria", "todo_write", `{"todos":[{"content":"Add explanations","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("write", "write_file", `{"path":"qa/bank.md"}`), {Type: provider.ChunkDone}},
+		finalText, // block 1 — complete_step/verification receipts missing
+		finalText, // block 2 — no new receipts, stalled
+		finalText, // block 3 — budget exhausted
+	}}
+	sess := NewSession("sys")
+	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+		"add explanations to the question bank", Options{DeliveryProfile: true, SubagentDepth: 1}, event.Discard)
+	if err != nil {
+		t.Fatalf("readiness exhaustion with real work must salvage, got err: %v", err)
+	}
+	for _, want := range []string{"[unverified]", "done, explanations added", "already on disk"} {
+		if !strings.Contains(answer, want) {
+			t.Fatalf("salvaged answer %q missing %q", answer, want)
+		}
+	}
+}
+
+func TestRunSubAgentReadinessFailureWithoutMutationStillFails(t *testing.T) {
+	// An unbacked "done" claim keeps failing: with a mutation expected and no
+	// successful mutation receipt, salvage must not launder the claim into an
+	// unverified answer.
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeWriterTool{})
+	finalText := []provider.Chunk{{Type: provider.ChunkText, Text: "done, all fixed"}, {Type: provider.ChunkDone}}
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{finalText, finalText, finalText}}
+	sess := NewSession("sys")
+	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+		"fix the crash in a.go", Options{DeliveryProfile: true, SubagentDepth: 1}, event.Discard)
+	var readinessErr *FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("expected wrapped FinalReadinessError, got %v", err)
+	}
+	if answer != "" {
+		t.Fatalf("mutation-less readiness failure must not salvage, got %q", answer)
+	}
+}
+
 func TestFinalReadinessBudgetExtendsOnlyWithProgress(t *testing.T) {
 	newReg := func() *tool.Registry {
 		reg := tool.NewRegistry()

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -218,6 +218,25 @@ func TestPartitionToolCallsTodoWriteSerial(t *testing.T) {
 	}
 }
 
+func TestPartitionToolCallsBackgroundCollectorsSerial(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	reg.Add(fakeTool{name: "wait", readOnly: true})
+	reg.Add(fakeTool{name: "bash_output", readOnly: true})
+
+	calls := []provider.ToolCall{{Name: "read_file"}, {Name: "wait"}, {Name: "bash_output"}, {Name: "read_file"}}
+	got := partitionToolCalls(reg, calls)
+	want := []toolCallBatch{
+		{start: 0, end: 1, parallel: true},
+		{start: 1, end: 2},
+		{start: 2, end: 3},
+		{start: 3, end: 4, parallel: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("partitionToolCalls = %+v, want %+v", got, want)
+	}
+}
+
 // TestExecuteBatchParallelReadOnly checks that three 80ms read-only calls
 // complete in well under 3×80ms — the wall-clock proof of true parallelism.
 func TestExecuteBatchParallelReadOnly(t *testing.T) {

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -718,3 +718,21 @@ func TestPlanModeOff_AllToolsAllowed(t *testing.T) {
 		t.Error("bash should not be blocked when plan mode is off")
 	}
 }
+
+func TestCallContextMirrorsPlanModeOntoLeafKey(t *testing.T) {
+	// Leaf-package tools (internal/tool/builtin) read plan mode via
+	// planmode.Active because importing this package would cycle. The call
+	// context constructor is the single production writer of both flags, so
+	// this pins them in lockstep.
+	on := withCallContext(context.Background(), "c", event.Discard, nil, true)
+	if !PlanModeFromContext(on) || !planmode.Active(on) {
+		t.Fatal("plan-mode flags disagree for an active planning call")
+	}
+	off := withCallContext(context.Background(), "c", event.Discard, nil, false)
+	if PlanModeFromContext(off) || planmode.Active(off) {
+		t.Fatal("plan-mode flags disagree for a normal call")
+	}
+	if !planmode.Active(WithToolCallContext(context.Background(), "c", event.Discard, nil, true)) {
+		t.Fatal("exported host-initiated wrapper lost the leaf plan-mode flag")
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -79,25 +79,8 @@ const subagentToolBoundarySummary = "Recursive agent/skill tools are exposed onl
 // so a wide fan-out risks conflicting concurrent writes — and feeds the failure
 // cascade where every "needs attention" notice tempts the model into spawning
 // yet more repair tasks. Further sub-tasks can run in the foreground, or start
-// once a running job is collected with wait. The check is advisory (read then
-// start), not atomic; tool rounds are serialized per turn, so at worst a race
-// overshoots by one.
+// once a running job is collected with wait.
 const maxConcurrentBackgroundTasks = 3
-
-// runningBackgroundTasks counts this session's still-running background task
-// jobs. Other job kinds (background bash) do not count against the task cap.
-func runningBackgroundTasks(jm *jobs.Manager, parentSession string) int {
-	if jm == nil {
-		return 0
-	}
-	n := 0
-	for _, v := range jm.RunningForSession(parentSession) {
-		if v.Kind == "task" {
-			n++
-		}
-	}
-	return n
-}
 
 // AlwaysHiddenSubagentTools returns the tool names excluded from every
 // subagent's registry regardless of an explicit allowlist or delegation
@@ -528,12 +511,14 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			}
 			return "", fmt.Errorf("background execution is not available in this context")
 		}
-		if running := runningBackgroundTasks(jm, jobs.SessionFromContext(ctx)); running >= maxConcurrentBackgroundTasks {
+		releaseStart, running, ok := jm.ReserveStartForSession(jobs.SessionFromContext(ctx), "task", maxConcurrentBackgroundTasks)
+		if !ok {
 			if run != nil {
 				run.Release()
 			}
 			return "", fmt.Errorf("%d background tasks are already running for this session (limit %d); collect their results with wait — or run this sub-task in the foreground — before starting more", running, maxConcurrentBackgroundTasks)
 		}
+		defer releaseStart()
 		nested := subSinkFor(parentID, parent)
 		label := p.Description
 		if label == "" {
@@ -545,8 +530,13 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 				return "", err
 			}
 		}
+		parentSession := ParentSession(ctx)
+		backgroundEvidence := evidence.NewLedger()
 		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (result string, err error) {
+			jobCtx = WithParentSession(jobCtx, parentSession)
+			jobCtx = evidence.WithLedger(jobCtx, backgroundEvidence)
 			defer run.Release()
+			defer func() { jobs.PublishEvidence(jobCtx, backgroundEvidence.Summary()) }()
 			defer func() {
 				if r := recover(); r != nil {
 					panicErr := fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
@@ -563,6 +553,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			}
 			return FormatSubagentRunResult(answer, run, false), nil
 		})
+		releaseStart()
 		if run != nil && run.Ref != "" {
 			return fmt.Sprintf("Started background task %q (%s).\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, FormatSubagentReference(run)), nil
 		}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -74,6 +74,31 @@ var readOnlySubagentWorkflowTools = []string{
 
 const subagentToolBoundarySummary = "Recursive agent/skill tools are exposed only while max_subagent_depth leaves another delegation layer; unsupported background job tools (parallel_tasks, wait, bash_output, kill_shell) are excluded; bash is exposed as foreground-only inside subagents."
 
+// maxConcurrentBackgroundTasks bounds writer-capable background sub-agents per
+// session. They all mutate the same workspace (there is no worktree isolation),
+// so a wide fan-out risks conflicting concurrent writes — and feeds the failure
+// cascade where every "needs attention" notice tempts the model into spawning
+// yet more repair tasks. Further sub-tasks can run in the foreground, or start
+// once a running job is collected with wait. The check is advisory (read then
+// start), not atomic; tool rounds are serialized per turn, so at worst a race
+// overshoots by one.
+const maxConcurrentBackgroundTasks = 3
+
+// runningBackgroundTasks counts this session's still-running background task
+// jobs. Other job kinds (background bash) do not count against the task cap.
+func runningBackgroundTasks(jm *jobs.Manager, parentSession string) int {
+	if jm == nil {
+		return 0
+	}
+	n := 0
+	for _, v := range jm.RunningForSession(parentSession) {
+		if v.Kind == "task" {
+			n++
+		}
+	}
+	return n
+}
+
 // AlwaysHiddenSubagentTools returns the tool names excluded from every
 // subagent's registry regardless of an explicit allowlist or delegation
 // depth (unlike subagentRecursiveTools, which depends on remaining depth).
@@ -502,6 +527,12 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 				run.Release()
 			}
 			return "", fmt.Errorf("background execution is not available in this context")
+		}
+		if running := runningBackgroundTasks(jm, jobs.SessionFromContext(ctx)); running >= maxConcurrentBackgroundTasks {
+			if run != nil {
+				run.Release()
+			}
+			return "", fmt.Errorf("%d background tasks are already running for this session (limit %d); collect their results with wait — or run this sub-task in the foreground — before starting more", running, maxConcurrentBackgroundTasks)
 		}
 		nested := subSinkFor(parentID, parent)
 		label := p.Description
@@ -934,6 +965,9 @@ func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *to
 	if err := sub.Run(ctx, prompt); err != nil {
 		// Still merge any partial child evidence so parent gates see real writes.
 		mergeChildEvidence(ctx, sub)
+		if answer, ok := salvageReadinessExhaustedAnswer(sub, sess, opts, err); ok {
+			return answer, nil
+		}
 		return "", fmt.Errorf("sub-agent: %w", err)
 	}
 	// Review/security subagents must hand back a typed report the parent's
@@ -959,16 +993,62 @@ func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *to
 		}
 	}
 	mergeChildEvidence(ctx, sub)
-	// Walk the session backwards for the last assistant message with content —
-	// that's the sub-agent's final answer. Intermediate assistant messages with
-	// tool_calls but no text don't count.
+	if answer := latestAssistantAnswer(sess); answer != "" {
+		return answer, nil
+	}
+	return "", fmt.Errorf("sub-agent finished without producing a final answer")
+}
+
+// latestAssistantAnswer walks the session backwards for the last assistant
+// message with content — that's the sub-agent's final answer. Intermediate
+// assistant messages with tool_calls but no text don't count.
+func latestAssistantAnswer(sess *Session) string {
+	if sess == nil {
+		return ""
+	}
 	for i := len(sess.Messages) - 1; i >= 0; i-- {
 		m := sess.Messages[i]
 		if m.Role == provider.RoleAssistant && strings.TrimSpace(m.Content) != "" {
-			return m.Content, nil
+			return m.Content
 		}
 	}
-	return "", fmt.Errorf("sub-agent finished without producing a final answer")
+	return ""
+}
+
+// salvageReadinessExhaustedAnswer degrades a sub-agent's readiness exhaustion
+// from a hard failure to an explicitly unverified result. The gate exists to
+// stop unverified *claims*, not to discard finished *work*: when the child has
+// a real successful mutation on disk and a visible answer, failing the whole
+// run makes the parent believe the work is broken and spawn repair tasks for
+// changes that already landed — the failure cascade users see as a wall of
+// "background task failed" notices. The child's receipts were already merged
+// into the parent ledger, so the parent's own delivery gates still require
+// verification and review of those writes before it can final-answer.
+//
+// Salvage is refused when the child produced no successful mutation (an
+// unbacked "done" claim must keep failing, e.g. a spoofed or lazy run) and for
+// report-required review sub-agents, whose contract is the typed review_report
+// rather than prose.
+func salvageReadinessExhaustedAnswer(sub *Agent, sess *Session, opts Options, err error) (string, bool) {
+	var readinessErr *FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		return "", false
+	}
+	if opts.RequireReviewReportKind != "" {
+		return "", false
+	}
+	if sub == nil || !sub.EvidenceSummary().HasMutation() {
+		return "", false
+	}
+	answer := latestAssistantAnswer(sess)
+	if answer == "" {
+		return "", false
+	}
+	return "[unverified] The sub-agent finished its work but exhausted the host delivery sign-off checks before reporting (" +
+		readinessErr.Reason +
+		"). Its successful writes are already on disk and its receipts were merged into this turn's evidence. " +
+		"Inspect the diff and run the relevant checks before relying on the result below; do not re-run or \"fix\" the same work without first checking what already changed.\n\nSub-agent answer:\n" +
+		answer, true
 }
 
 // dumpFailedSubagentSession best-effort persists a failed report-required

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -1002,6 +1002,95 @@ func TestBackgroundEvidenceCommittedWhenTurnDelivers(t *testing.T) {
 	}
 }
 
+// TestFailedTurnBackgroundMutationForcesReadinessOnNextRunWithoutWait extends
+// TestBackgroundEvidenceNotCommittedWhenTurnFails: after the first turn collects
+// a background mutation via wait but fails to sign it off, Run's Reset wipes the
+// per-turn ledger before the second turn starts. Without re-injecting the still
+// uncommitted mutation, a second turn that never calls wait/bash_output again
+// would sail through final-readiness having never seen it. Run must re-lease it
+// automatically so the gate still blocks.
+func TestFailedTurnBackgroundMutationForcesReadinessOnNextRunWithoutWait(t *testing.T) {
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	jobID := startTerminalBackgroundMutation(t, jm, "parent-session", "qa/bank.md")
+
+	reg := evidenceRegistry()
+	waitBuiltin(t, reg)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("w", "wait", `{"job_ids":["`+jobID+`"]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}}, // no sign-off
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+		// Second Run: the model never calls wait/bash_output again.
+		{{Type: provider.ChunkText, Text: "sure, here you go"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "sure, here you go"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "sure, here you go"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true, Jobs: jm}, event.Discard)
+	ctx := jobs.WithManager(WithParentSession(context.Background(), "parent-session"), jm)
+	ctx = jobs.WithSession(ctx, "parent-session")
+
+	var readiness *FinalReadinessError
+	if err := a.Run(ctx, "collect and finish the background task"); !errors.As(err, &readiness) {
+		t.Fatalf("first turn = %v, want readiness exhaustion on the uncollected sign-off", err)
+	}
+	if leased := jm.LeaseEvidenceForSession("parent-session", jobID); !leased.HasMutation() {
+		t.Fatalf("first failed turn consumed the background evidence: %+v", leased)
+	}
+
+	readiness = nil
+	if err := a.Run(ctx, "never mind, just answer directly"); !errors.As(err, &readiness) {
+		t.Fatalf("second turn (no wait call) = %v, want readiness exhaustion on the still-pending mutation", err)
+	}
+	if leased := jm.LeaseEvidenceForSession("parent-session", jobID); !leased.HasMutation() {
+		t.Fatalf("second failed turn consumed the background evidence: %+v", leased)
+	}
+}
+
+// TestRestartRecoversPendingBackgroundMutationForcesReadinessWithoutWait mirrors
+// the same guarantee across a process restart: a background task mutates and
+// finishes while no turn is collecting it, the process exits before any turn
+// commits (or even leases) that evidence, and a fresh Manager + Agent pair —
+// standing in for the restarted process — must still see it and enforce
+// final-readiness on the very first turn, with no wait/bash_output call at all.
+func TestRestartRecoversPendingBackgroundMutationForcesReadinessWithoutWait(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	first := jobs.NewManager(event.Discard)
+	first.SetActiveSessionPath("parent-session", sessionPath)
+	j := first.StartForSession("parent-session", "task", "bg writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		jobs.PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Write: true, Mutation: true, Paths: []string{"qa/bank.md"},
+		}}})
+		return "background answer", nil
+	})
+	if res := first.WaitForSession(context.Background(), "parent-session", []string{j.ID}, 5); len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background job = %+v, want done", res)
+	}
+	first.Close() // the process exits before any turn ever leased this evidence
+
+	second := jobs.NewManager(event.Discard)
+	defer second.Close()
+	second.SetActiveSessionPath("parent-session", sessionPath)
+
+	reg := evidenceRegistry()
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true, Jobs: second}, event.Discard)
+	ctx := jobs.WithManager(WithParentSession(context.Background(), "parent-session"), second)
+	ctx = jobs.WithSession(ctx, "parent-session")
+
+	var readiness *FinalReadinessError
+	if err := a.Run(ctx, "what's the status?"); !errors.As(err, &readiness) {
+		t.Fatalf("post-restart turn = %v, want readiness exhaustion on the recovered mutation", err)
+	}
+	if leased := second.LeaseEvidenceForSession("parent-session", j.ID); !leased.HasMutation() {
+		t.Fatalf("recovered evidence lost after the failed post-restart turn: %+v", leased)
+	}
+}
+
 func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "answer"},

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
@@ -858,6 +859,54 @@ func TestTaskToolBackgroundCapRefusesFanOut(t *testing.T) {
 	}
 	if res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5); len(res) != 1 || res[0].Status != jobs.Done {
 		t.Fatalf("post-drain job = %+v, want done", res)
+	}
+}
+
+func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
+	reg := evidenceRegistry()
+	finalText := []provider.Chunk{{Type: provider.ChunkText, Text: "done, explanations added"}, {Type: provider.ChunkDone}}
+	sub := &scriptedProvider{name: "sub", turns: [][]provider.Chunk{
+		{toolCallChunk("criteria", "todo_write", `{"todos":[{"content":"Add explanations","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("write", "write_file", `{"path":"qa/bank.md"}`), {Type: provider.ChunkDone}},
+		finalText,
+		finalText,
+		finalText,
+	}}
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort").
+		WithDeliveryProfile(true)
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	parentLedger := evidence.NewLedger()
+	ctx := testTaskContext()
+	ctx = jobs.WithSession(ctx, "parent-session")
+	ctx = jobs.WithManager(ctx, jm)
+	ctx = evidence.WithLedger(ctx, parentLedger)
+
+	out, err := task.Execute(ctx, []byte(`{"prompt":"add explanations to the question bank","run_in_background":true}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	jobID := extractJobID(out)
+	res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5)
+	if len(res) != 1 || res[0].Status != jobs.Done || !strings.Contains(res[0].Output, "[unverified]") {
+		t.Fatalf("background salvage = %+v, want done unverified result", res)
+	}
+	if parentLedger.Summary().HasMutation() {
+		t.Fatal("background goroutine wrote directly into the parent turn ledger")
+	}
+
+	summary := jm.TakeEvidenceForSession("parent-session", jobID)
+	if !summary.HasMutation() {
+		t.Fatal("terminal background task did not publish its mutation evidence")
+	}
+	paths := summary.MutationPaths()
+	if len(paths) != 1 || paths[0] != "qa/bank.md" {
+		t.Fatalf("background mutation paths = %v, want qa/bank.md", paths)
+	}
+	if second := jm.TakeEvidenceForSession("parent-session", jobID); len(second.Receipts) != 0 {
+		t.Fatalf("background evidence was collectible twice: %+v", second)
 	}
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -897,7 +897,7 @@ func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
 		t.Fatal("background goroutine wrote directly into the parent turn ledger")
 	}
 
-	summary := jm.TakeEvidenceForSession("parent-session", jobID)
+	summary := jm.LeaseEvidenceForSession("parent-session", jobID)
 	if !summary.HasMutation() {
 		t.Fatal("terminal background task did not publish its mutation evidence")
 	}
@@ -905,8 +905,100 @@ func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
 	if len(paths) != 1 || filepath.ToSlash(paths[0]) != "qa/bank.md" {
 		t.Fatalf("background mutation paths = %v, want qa/bank.md", paths)
 	}
-	if second := jm.TakeEvidenceForSession("parent-session", jobID); len(second.Receipts) != 0 {
-		t.Fatalf("background evidence was collectible twice: %+v", second)
+	// Lease does not consume: the evidence stays available until the collecting
+	// turn commits, so a cancelled/errored turn can re-collect it.
+	if again := jm.LeaseEvidenceForSession("parent-session", jobID); !again.HasMutation() {
+		t.Fatalf("lease consumed background evidence without a commit: %+v", again)
+	}
+	jm.CommitEvidenceForSession("parent-session", jobID)
+	if after := jm.LeaseEvidenceForSession("parent-session", jobID); len(after.Receipts) != 0 {
+		t.Fatalf("committed background evidence still leasable: %+v", after)
+	}
+}
+
+// startTerminalBackgroundMutation registers a background task job that publishes
+// one mutation and returns after it reaches a terminal state, ready to collect.
+func startTerminalBackgroundMutation(t *testing.T, jm *jobs.Manager, session, path string) string {
+	t.Helper()
+	j := jm.StartForSession(session, "task", "bg writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		jobs.PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Write: true, Mutation: true, Paths: []string{path},
+		}}})
+		return "background answer", nil
+	})
+	if res := jm.WaitForSession(context.Background(), session, []string{j.ID}, 5); len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background job = %+v, want done", res)
+	}
+	return j.ID
+}
+
+func waitBuiltin(t *testing.T, reg *tool.Registry) {
+	t.Helper()
+	wait, ok := tool.LookupBuiltin("wait")
+	if !ok {
+		t.Fatal("wait builtin not registered")
+	}
+	reg.Add(wait)
+}
+
+func TestBackgroundEvidenceNotCommittedWhenTurnFails(t *testing.T) {
+	// The delivery turn collects a background writer's mutation via wait, then
+	// fails to sign it off, exhausting readiness. Because the turn never
+	// delivered, the lease must not be committed: the mutation stays collectable
+	// so the next turn can review it instead of shipping it unreviewed.
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	jobID := startTerminalBackgroundMutation(t, jm, "parent-session", "qa/bank.md")
+
+	reg := evidenceRegistry()
+	waitBuiltin(t, reg)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("w", "wait", `{"job_ids":["`+jobID+`"]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}}, // no sign-off
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "all set"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true, Jobs: jm}, event.Discard)
+	ctx := jobs.WithManager(WithParentSession(context.Background(), "parent-session"), jm)
+	ctx = jobs.WithSession(ctx, "parent-session")
+
+	err := a.Run(ctx, "collect and finish the background task")
+	var readiness *FinalReadinessError
+	if !errors.As(err, &readiness) {
+		t.Fatalf("turn = %v, want readiness exhaustion on the uncollected sign-off", err)
+	}
+	// The failed turn must not have consumed the evidence.
+	if leased := jm.LeaseEvidenceForSession("parent-session", jobID); !leased.HasMutation() {
+		t.Fatalf("failed delivery turn consumed the background evidence: %+v", leased)
+	}
+}
+
+func TestBackgroundEvidenceCommittedWhenTurnDelivers(t *testing.T) {
+	// A successful turn that collected a background writer's mutation commits the
+	// lease, permanently draining the job's evidence so a later re-poll does not
+	// re-demand review of work already delivered.
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	jobID := startTerminalBackgroundMutation(t, jm, "parent-session", "notes.txt")
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	waitBuiltin(t, reg)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("w", "wait", `{"job_ids":["`+jobID+`"]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "collected the result"}, {Type: provider.ChunkDone}},
+	}}
+	// No delivery profile: the turn succeeds immediately after collecting, so the
+	// commit-on-success hook fires without a full sign-off script.
+	a := New(prov, reg, NewSession(""), Options{Jobs: jm}, event.Discard)
+	ctx := jobs.WithManager(WithParentSession(context.Background(), "parent-session"), jm)
+	ctx = jobs.WithSession(ctx, "parent-session")
+
+	if err := a.Run(ctx, "collect the background task"); err != nil {
+		t.Fatalf("delivering turn failed: %v", err)
+	}
+	if leased := jm.LeaseEvidenceForSession("parent-session", jobID); len(leased.Receipts) != 0 {
+		t.Fatalf("delivered turn did not commit the background lease: %+v", leased)
 	}
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -800,6 +801,63 @@ func TestTaskToolBackgroundAncestorContinuationIncludesForkGuidance(t *testing.T
 		!strings.Contains(res[0].Output, "The requested ref resolves to an ancestor conversation transcript") ||
 		!strings.Contains(res[0].Output, "Final answer:\nchild background answer") {
 		t.Fatalf("job output = %q, want copied ref guidance and final answer", res[0].Output)
+	}
+}
+
+func TestTaskToolBackgroundCapRefusesFanOut(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "background answer"},
+		{Type: provider.ChunkDone},
+	}}
+	store := NewSubagentStore(t.TempDir())
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctx := testTaskContext()
+	ctx = jobs.WithSession(ctx, "parent-session")
+	ctx = jobs.WithManager(ctx, jm)
+
+	// Saturate the cap with still-running task jobs owned by this session.
+	release := make(chan struct{})
+	var ids []string
+	for i := 0; i < maxConcurrentBackgroundTasks; i++ {
+		j := jm.StartForSession("parent-session", "task", "busy", func(jctx context.Context, _ io.Writer) (string, error) {
+			select {
+			case <-release:
+			case <-jctx.Done():
+			}
+			return "ok", nil
+		})
+		ids = append(ids, j.ID)
+	}
+
+	if _, err := task.Execute(ctx, []byte(`{"prompt":"one more","run_in_background":true}`)); err == nil ||
+		!strings.Contains(err.Error(), "limit") || !strings.Contains(err.Error(), "wait") {
+		t.Fatalf("Execute over cap = %v, want background task limit refusal", err)
+	}
+
+	// Foreground execution is not capped.
+	if out, err := task.Execute(ctx, []byte(`{"prompt":"foreground task"}`)); err != nil || !strings.Contains(out, "background answer") {
+		t.Fatalf("foreground Execute = %q, %v; want uncapped foreground run", out, err)
+	}
+
+	// Collecting the running jobs frees the cap.
+	close(release)
+	jm.WaitForSession(context.Background(), "parent-session", ids, 5)
+	out, err := task.Execute(ctx, []byte(`{"prompt":"after drain","run_in_background":true}`))
+	if err != nil {
+		t.Fatalf("Execute after drain: %v", err)
+	}
+	jobID := extractJobID(out)
+	if jobID == "" {
+		t.Fatalf("no background job id in output:\n%s", out)
+	}
+	if res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5); len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("post-drain job = %+v, want done", res)
 	}
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -902,7 +902,7 @@ func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
 		t.Fatal("terminal background task did not publish its mutation evidence")
 	}
 	paths := summary.MutationPaths()
-	if len(paths) != 1 || paths[0] != "qa/bank.md" {
+	if len(paths) != 1 || filepath.ToSlash(paths[0]) != "qa/bank.md" {
 		t.Fatalf("background mutation paths = %v, want qa/bank.md", paths)
 	}
 	if second := jm.TakeEvidenceForSession("parent-session", jobID); len(second.Receipts) != 0 {

--- a/internal/evidence/child_test.go
+++ b/internal/evidence/child_test.go
@@ -65,14 +65,12 @@ func TestClassifyMutationRisk(t *testing.T) {
 		t.Fatalf("auth risk = %s, want high", got)
 	}
 
-	// A path-less bash write cannot be scored by path but is usually a routine
-	// content edit: it warrants review (medium), not the security_review
-	// protocol that High demands.
+	// A path-less bash write cannot be scored by path, so it remains high risk.
 	opaque := []Receipt{
 		{ToolName: "bash", Success: true, Mutation: true, Command: "some-unknown-writer"},
 	}
-	if got := ClassifyMutationRisk(opaque, 0); got != RiskMedium {
-		t.Fatalf("opaque risk = %s, want medium", got)
+	if got := ClassifyMutationRisk(opaque, 0); got != RiskHigh {
+		t.Fatalf("opaque risk = %s, want high", got)
 	}
 
 	// Privileged/opaque tools keep escalating to High even without paths.

--- a/internal/evidence/child_test.go
+++ b/internal/evidence/child_test.go
@@ -65,11 +65,31 @@ func TestClassifyMutationRisk(t *testing.T) {
 		t.Fatalf("auth risk = %s, want high", got)
 	}
 
+	// A path-less bash write cannot be scored by path but is usually a routine
+	// content edit: it warrants review (medium), not the security_review
+	// protocol that High demands.
 	opaque := []Receipt{
 		{ToolName: "bash", Success: true, Mutation: true, Command: "some-unknown-writer"},
 	}
-	if got := ClassifyMutationRisk(opaque, 0); got != RiskHigh {
-		t.Fatalf("opaque risk = %s, want high", got)
+	if got := ClassifyMutationRisk(opaque, 0); got != RiskMedium {
+		t.Fatalf("opaque risk = %s, want medium", got)
+	}
+
+	// Privileged/opaque tools keep escalating to High even without paths.
+	opaquePrivileged := []Receipt{
+		{ToolName: "mcp__srv__write", Success: true, Mutation: true},
+	}
+	if got := ClassifyMutationRisk(opaquePrivileged, 0); got != RiskHigh {
+		t.Fatalf("privileged opaque risk = %s, want high", got)
+	}
+
+	// An opaque write alongside a security-sensitive path still classifies High.
+	opaqueHighPath := []Receipt{
+		{ToolName: "bash", Success: true, Mutation: true},
+		ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"internal/permission/gate.go"}`), true, false),
+	}
+	if got := ClassifyMutationRisk(opaqueHighPath, 0); got != RiskHigh {
+		t.Fatalf("opaque+auth risk = %s, want high", got)
 	}
 }
 

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -56,15 +56,25 @@ type Receipt struct {
 	OutputBytes int `json:"output_bytes,omitempty"`
 }
 
+// BackgroundLease identifies a background job whose evidence was provisionally
+// merged into the current turn's ledger. The host commits these leases only
+// after the turn passes its delivery gates, so a failed turn leaves the job's
+// evidence collectable again.
+type BackgroundLease struct {
+	Session string
+	JobID   string
+}
+
 // Ledger stores the receipts available to complete_step for the current turn.
 type Ledger struct {
-	mu       sync.Mutex
-	receipts []Receipt
+	mu               sync.Mutex
+	receipts         []Receipt
+	backgroundLeases []BackgroundLease
 }
 
 func NewLedger() *Ledger { return &Ledger{} }
 
-// Reset clears receipts between user turns.
+// Reset clears receipts and background leases between user turns.
 func (l *Ledger) Reset() {
 	if l == nil {
 		return
@@ -72,6 +82,42 @@ func (l *Ledger) Reset() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.receipts = nil
+	l.backgroundLeases = nil
+}
+
+// NoteBackgroundLease records that a background job's evidence was merged into
+// this turn. It returns false when the job was already noted this turn so the
+// caller can skip a duplicate merge — collection is idempotent within a turn,
+// while a fresh turn (after Reset) leases again.
+func (l *Ledger) NoteBackgroundLease(session, jobID string) bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, lease := range l.backgroundLeases {
+		if lease.Session == session && lease.JobID == jobID {
+			return false
+		}
+	}
+	l.backgroundLeases = append(l.backgroundLeases, BackgroundLease{Session: session, JobID: jobID})
+	return true
+}
+
+// BackgroundLeases returns the background jobs merged into this turn, for the
+// host to commit once the turn's delivery gates pass.
+func (l *Ledger) BackgroundLeases() []BackgroundLease {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.backgroundLeases) == 0 {
+		return nil
+	}
+	out := make([]BackgroundLease, len(l.backgroundLeases))
+	copy(out, l.backgroundLeases)
+	return out
 }
 
 // Record appends a receipt. Failed receipts are retained for auditability but

--- a/internal/evidence/risk.go
+++ b/internal/evidence/risk.go
@@ -33,11 +33,8 @@ var highRiskToolHints = []string{
 
 // ClassifyMutationRisk scores the change set after the latest mutation.
 // Low: docs/tests/i18n/pure presentation only, with no opaque writes.
-// Medium: ordinary production code, limited multi-file edits, or path-less
-// (opaque) mutations from ordinary tools — a bash edit that reports no paths
-// cannot be scored by path, but it is usually a routine content change that
-// warrants review, not the full security_review protocol.
-// High: security-sensitive surfaces, privileged/opaque tools, or 10+ paths.
+// Medium: ordinary production code or limited multi-file edits.
+// High: security-sensitive surfaces, opaque mutations, or 10+ paths.
 func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 	start := after + 1
 	if start < 0 {
@@ -85,6 +82,12 @@ func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 			}
 		}
 	}
+	if opaque {
+		return RiskHigh
+	}
+	if len(paths) == 0 {
+		return RiskLow
+	}
 	if len(paths) >= 10 {
 		return RiskHigh
 	}
@@ -96,17 +99,6 @@ func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 			onlyLow = false
 			hasProd = true
 		}
-	}
-	if opaque {
-		// Path-less writes from ordinary tools cannot prove they are low risk,
-		// so they always warrant a review — but privileged surfaces already
-		// returned High above via toolLooksHighRisk, and blanket-escalating
-		// every bash content edit to High forces the security_review protocol
-		// onto routine changes.
-		return RiskMedium
-	}
-	if len(paths) == 0 {
-		return RiskLow
 	}
 	if onlyLow && !hasProd {
 		return RiskLow

--- a/internal/evidence/risk.go
+++ b/internal/evidence/risk.go
@@ -33,8 +33,11 @@ var highRiskToolHints = []string{
 
 // ClassifyMutationRisk scores the change set after the latest mutation.
 // Low: docs/tests/i18n/pure presentation only, with no opaque writes.
-// Medium: ordinary production code or limited multi-file edits.
-// High: security-sensitive surfaces, opaque mutations, or 10+ paths.
+// Medium: ordinary production code, limited multi-file edits, or path-less
+// (opaque) mutations from ordinary tools — a bash edit that reports no paths
+// cannot be scored by path, but it is usually a routine content change that
+// warrants review, not the full security_review protocol.
+// High: security-sensitive surfaces, privileged/opaque tools, or 10+ paths.
 func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 	start := after + 1
 	if start < 0 {
@@ -82,12 +85,6 @@ func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 			}
 		}
 	}
-	if opaque {
-		return RiskHigh
-	}
-	if len(paths) == 0 {
-		return RiskLow
-	}
 	if len(paths) >= 10 {
 		return RiskHigh
 	}
@@ -99,6 +96,17 @@ func ClassifyMutationRisk(receipts []Receipt, after int) RiskLevel {
 			onlyLow = false
 			hasProd = true
 		}
+	}
+	if opaque {
+		// Path-less writes from ordinary tools cannot prove they are low risk,
+		// so they always warrant a review — but privileged surfaces already
+		// returned High above via toolLooksHighRisk, and blanket-escalating
+		// every bash content edit to High forces the security_review protocol
+		// onto routine changes.
+		return RiskMedium
+	}
+	if len(paths) == 0 {
+		return RiskLow
 	}
 	if onlyLow && !hasProd {
 		return RiskLow

--- a/internal/jobs/artifacts.go
+++ b/internal/jobs/artifacts.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	jobLogExt        = ".log"
-	jobMetaExt       = ".json"
-	defaultTailBytes = 64 * 1024
+	jobLogExt                       = ".log"
+	jobMetaExt                      = ".json"
+	defaultTailBytes                = 64 * 1024
+	mutationEvidenceVersion         = 1
+	recoveredBackgroundTaskToolName = "background_task_recovery"
 )
 
 // ArtifactDir returns the sidecar directory for a persistent session transcript.
@@ -33,16 +35,26 @@ func RemoveArtifacts(sessionPath string) error {
 }
 
 type artifactMeta struct {
-	ID               string `json:"id"`
-	Kind             string `json:"kind"`
-	Label            string `json:"label,omitempty"`
-	SessionID        string `json:"sessionId,omitempty"`
-	Status           Status `json:"status"`
-	StartedAt        int64  `json:"startedAt"`
-	FinishedAt       int64  `json:"finishedAt,omitempty"`
-	ArtifactComplete bool   `json:"artifactComplete"`
-	ArtifactError    string `json:"artifactError,omitempty"`
-	LogPath          string `json:"logPath,omitempty"`
+	ID                      string                    `json:"id"`
+	Kind                    string                    `json:"kind"`
+	Label                   string                    `json:"label,omitempty"`
+	SessionID               string                    `json:"sessionId,omitempty"`
+	Status                  Status                    `json:"status"`
+	StartedAt               int64                     `json:"startedAt"`
+	FinishedAt              int64                     `json:"finishedAt,omitempty"`
+	ArtifactComplete        bool                      `json:"artifactComplete"`
+	ArtifactError           string                    `json:"artifactError,omitempty"`
+	LogPath                 string                    `json:"logPath,omitempty"`
+	MutationEvidenceVersion int                       `json:"mutationEvidenceVersion,omitempty"`
+	MutationEvidence        *artifactMutationEvidence `json:"mutationEvidence,omitempty"`
+}
+
+// artifactMutationEvidence deliberately excludes receipt args, commands, and
+// review contents. After a restart the parent must re-inspect and re-verify the
+// recovered mutation rather than trusting stale child sign-off evidence.
+type artifactMutationEvidence struct {
+	Risk  string   `json:"risk"`
+	Paths []string `json:"paths,omitempty"`
 }
 
 func writeMeta(path string, meta artifactMeta) error {

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -121,7 +121,7 @@ func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 	if got := second.WaitForSession(context.Background(), "session", nil, 1); len(got) != 0 {
 		t.Fatalf("wait without ids should ignore restored completed artifacts, got %+v", got)
 	}
-	if got := second.TakeEvidenceForSession("session", j.ID); len(got.Receipts) != 0 {
+	if got := second.LeaseEvidenceForSession("session", j.ID); len(got.Receipts) != 0 {
 		t.Fatalf("mutation-free task restored mutation evidence: %+v", got)
 	}
 
@@ -180,7 +180,7 @@ func TestTaskMutationEvidencePersistsWithoutSensitiveReceiptData(t *testing.T) {
 	second := NewManager(event.Discard)
 	defer second.Close()
 	second.SetActiveSessionPath("session", sessionPath)
-	summary := second.TakeEvidenceForSession("session", j.ID)
+	summary := second.LeaseEvidenceForSession("session", j.ID)
 	if len(summary.Receipts) != 1 {
 		t.Fatalf("restored evidence = %+v, want one synthetic mutation", summary)
 	}
@@ -204,17 +204,23 @@ func TestTaskMutationEvidencePersistsWithoutSensitiveReceiptData(t *testing.T) {
 	if got := ledger.MutationRiskAfter(mutation); got != evidence.RiskMedium {
 		t.Fatalf("restored mutation risk = %s, want medium", got)
 	}
-	if secondTake := second.TakeEvidenceForSession("session", j.ID); len(secondTake.Receipts) != 0 {
-		t.Fatalf("restored evidence was collectible twice: %+v", secondTake)
+	// Lease does not consume: the receipts stay available until the collecting
+	// turn commits. Only then is the persisted summary drained.
+	if again := second.LeaseEvidenceForSession("session", j.ID); len(again.Receipts) != 1 {
+		t.Fatalf("restored evidence not re-leasable before commit: %+v", again)
+	}
+	second.CommitEvidenceForSession("session", j.ID)
+	if afterCommit := second.LeaseEvidenceForSession("session", j.ID); len(afterCommit.Receipts) != 0 {
+		t.Fatalf("committed evidence still leasable: %+v", afterCommit)
 	}
 
-	// The tombstone take drains the persisted copy as well — a further restart
-	// must not offer the same mutation a third time.
+	// The commit drained the persisted copy too — a further restart must not
+	// offer the same mutation again.
 	third := NewManager(event.Discard)
 	defer third.Close()
 	third.SetActiveSessionPath("session", sessionPath)
-	if thirdTake := third.TakeEvidenceForSession("session", j.ID); len(thirdTake.Receipts) != 0 {
-		t.Fatalf("restored evidence resurrected after a second restart: %+v", thirdTake)
+	if thirdLease := third.LeaseEvidenceForSession("session", j.ID); len(thirdLease.Receipts) != 0 {
+		t.Fatalf("committed evidence resurrected after restart: %+v", thirdLease)
 	}
 }
 
@@ -239,11 +245,13 @@ func TestHighRiskTaskMutationEvidenceRestoresAsOpaque(t *testing.T) {
 	}
 }
 
-func TestLegacyTaskArtifactRecoversNoEvidence(t *testing.T) {
-	// A pre-feature artifact (no mutationEvidenceVersion) never published child
-	// receipts, so recovery must not synthesize a mutation: doing so would
-	// retroactively demand inspection and review for work no collecting turn
-	// ever saw under the new contract.
+func TestLegacyTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T) {
+	// A pre-feature artifact (no mutationEvidenceVersion) proves only that the
+	// mutation state was never recorded — not that the task made no changes. A
+	// legacy background writer task collected after upgrade could carry real,
+	// unreviewed edits, so recovery must be conservative: an opaque RiskHigh
+	// mutation that forces fresh inspection and review rather than silently
+	// skipping it.
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	dir := ArtifactDir(sessionPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -265,8 +273,15 @@ func TestLegacyTaskArtifactRecoversNoEvidence(t *testing.T) {
 	m := NewManager(event.Discard)
 	defer m.Close()
 	m.SetActiveSessionPath("session", sessionPath)
-	if summary := m.TakeEvidenceForSession("session", "task-1"); len(summary.Receipts) != 0 {
-		t.Fatalf("legacy task evidence = %+v, want none", summary)
+	summary := m.LeaseEvidenceForSession("session", "task-1")
+	if len(summary.Receipts) != 1 || !summary.HasMutation() || len(summary.MutationPaths()) != 0 {
+		t.Fatalf("legacy task evidence = %+v, want one opaque mutation", summary)
+	}
+	ledger := evidence.NewLedger()
+	ledger.MergeChild(summary)
+	mutation, ok := ledger.LatestSuccessfulMutationIndex()
+	if !ok || ledger.MutationRiskAfter(mutation) != evidence.RiskHigh {
+		t.Fatalf("legacy task mutation was not recovered conservatively: %+v", ledger.Summary())
 	}
 }
 
@@ -290,10 +305,12 @@ func TestFutureVersionTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T)
 	}
 }
 
-func TestTakenEvidenceDoesNotResurrectAfterRestart(t *testing.T) {
-	// Collecting a task's evidence drains the persisted copy too: a restart
-	// must not resurrect receipts for a re-polled job id and re-arm review
-	// demands for work the collecting turn already handled.
+func TestLeasedEvidenceResurrectsUntilCommitted(t *testing.T) {
+	// Collection is provisional. A lease that is never committed — the
+	// collecting turn was cancelled, errored, or the process exited before
+	// delivery — must leave the mutation recoverable after a restart, so a
+	// background change can never ship unreviewed. Only a commit drains the
+	// persisted copy.
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	first := NewManager(event.Discard)
 	first.SetActiveSessionPath("session", sessionPath)
@@ -304,8 +321,9 @@ func TestTakenEvidenceDoesNotResurrectAfterRestart(t *testing.T) {
 		return "done", nil
 	})
 	<-j.done
-	if taken := first.TakeEvidenceForSession("session", j.ID); !taken.HasMutation() {
-		t.Fatalf("live take = %+v, want the published mutation", taken)
+	// Lease without committing (the turn never delivered), then restart.
+	if leased := first.LeaseEvidenceForSession("session", j.ID); !leased.HasMutation() {
+		t.Fatalf("live lease = %+v, want the published mutation", leased)
 	}
 	first.Close()
 
@@ -313,15 +331,24 @@ func TestTakenEvidenceDoesNotResurrectAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(data), `"mutationEvidence"`) {
-		t.Fatalf("drained meta still carries mutation evidence:\n%s", data)
+	if !strings.Contains(string(data), `"mutationEvidence"`) {
+		t.Fatalf("uncommitted lease drained the persisted mutation summary:\n%s", data)
 	}
 
 	second := NewManager(event.Discard)
 	defer second.Close()
 	second.SetActiveSessionPath("session", sessionPath)
-	if summary := second.TakeEvidenceForSession("session", j.ID); len(summary.Receipts) != 0 {
-		t.Fatalf("collected evidence resurrected after restart: %+v", summary)
+	if summary := second.LeaseEvidenceForSession("session", j.ID); !summary.HasMutation() {
+		t.Fatalf("uncommitted evidence lost after restart: %+v", summary)
+	}
+	// Committing after the restart drains it; a further restart offers nothing.
+	second.CommitEvidenceForSession("session", j.ID)
+	second.Close()
+	third := NewManager(event.Discard)
+	defer third.Close()
+	third.SetActiveSessionPath("session", sessionPath)
+	if summary := third.LeaseEvidenceForSession("session", j.ID); len(summary.Receipts) != 0 {
+		t.Fatalf("committed evidence resurrected after restart: %+v", summary)
 	}
 }
 

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -207,6 +207,15 @@ func TestTaskMutationEvidencePersistsWithoutSensitiveReceiptData(t *testing.T) {
 	if secondTake := second.TakeEvidenceForSession("session", j.ID); len(secondTake.Receipts) != 0 {
 		t.Fatalf("restored evidence was collectible twice: %+v", secondTake)
 	}
+
+	// The tombstone take drains the persisted copy as well — a further restart
+	// must not offer the same mutation a third time.
+	third := NewManager(event.Discard)
+	defer third.Close()
+	third.SetActiveSessionPath("session", sessionPath)
+	if thirdTake := third.TakeEvidenceForSession("session", j.ID); len(thirdTake.Receipts) != 0 {
+		t.Fatalf("restored evidence resurrected after a second restart: %+v", thirdTake)
+	}
 }
 
 func TestHighRiskTaskMutationEvidenceRestoresAsOpaque(t *testing.T) {
@@ -230,7 +239,11 @@ func TestHighRiskTaskMutationEvidenceRestoresAsOpaque(t *testing.T) {
 	}
 }
 
-func TestLegacyTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T) {
+func TestLegacyTaskArtifactRecoversNoEvidence(t *testing.T) {
+	// A pre-feature artifact (no mutationEvidenceVersion) never published child
+	// receipts, so recovery must not synthesize a mutation: doing so would
+	// retroactively demand inspection and review for work no collecting turn
+	// ever saw under the new contract.
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	dir := ArtifactDir(sessionPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -252,15 +265,63 @@ func TestLegacyTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T) {
 	m := NewManager(event.Discard)
 	defer m.Close()
 	m.SetActiveSessionPath("session", sessionPath)
-	summary := m.TakeEvidenceForSession("session", "task-1")
+	if summary := m.TakeEvidenceForSession("session", "task-1"); len(summary.Receipts) != 0 {
+		t.Fatalf("legacy task evidence = %+v, want none", summary)
+	}
+}
+
+func TestFutureVersionTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T) {
+	// A meta written by a newer build (unknown non-zero version) may contain
+	// real evidence in a shape this build cannot parse: recover it as an opaque
+	// mutation so downgrade coexistence cannot skip review.
+	meta := artifactMeta{
+		Kind:                    "task",
+		MutationEvidenceVersion: mutationEvidenceVersion + 1,
+	}
+	summary := mutationEvidenceFromArtifact(meta)
 	if len(summary.Receipts) != 1 || !summary.HasMutation() || len(summary.MutationPaths()) != 0 {
-		t.Fatalf("legacy task evidence = %+v, want one opaque mutation", summary)
+		t.Fatalf("future-version evidence = %+v, want one opaque mutation", summary)
 	}
 	ledger := evidence.NewLedger()
 	ledger.MergeChild(summary)
 	mutation, ok := ledger.LatestSuccessfulMutationIndex()
 	if !ok || ledger.MutationRiskAfter(mutation) != evidence.RiskHigh {
-		t.Fatalf("legacy task mutation was not recovered conservatively: %+v", ledger.Summary())
+		t.Fatalf("future-version mutation was not recovered conservatively: %+v", ledger.Summary())
+	}
+}
+
+func TestTakenEvidenceDoesNotResurrectAfterRestart(t *testing.T) {
+	// Collecting a task's evidence drains the persisted copy too: a restart
+	// must not resurrect receipts for a re-polled job id and re-arm review
+	// demands for work the collecting turn already handled.
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	first := NewManager(event.Discard)
+	first.SetActiveSessionPath("session", sessionPath)
+	j := first.StartForSession("session", "task", "writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Write: true, Mutation: true, Paths: []string{"changed.go"},
+		}}})
+		return "done", nil
+	})
+	<-j.done
+	if taken := first.TakeEvidenceForSession("session", j.ID); !taken.HasMutation() {
+		t.Fatalf("live take = %+v, want the published mutation", taken)
+	}
+	first.Close()
+
+	data, err := os.ReadFile(filepath.Join(ArtifactDir(sessionPath), j.ID+jobMetaExt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"mutationEvidence"`) {
+		t.Fatalf("drained meta still carries mutation evidence:\n%s", data)
+	}
+
+	second := NewManager(event.Discard)
+	defer second.Close()
+	second.SetActiveSessionPath("session", sessionPath)
+	if summary := second.TakeEvidenceForSession("session", j.ID); len(summary.Receipts) != 0 {
+		t.Fatalf("collected evidence resurrected after restart: %+v", summary)
 	}
 }
 

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 )
 
 func TestCompletedJobPersistsOutputAndReleasesMemory(t *testing.T) {
@@ -119,6 +121,9 @@ func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 	if got := second.WaitForSession(context.Background(), "session", nil, 1); len(got) != 0 {
 		t.Fatalf("wait without ids should ignore restored completed artifacts, got %+v", got)
 	}
+	if got := second.TakeEvidenceForSession("session", j.ID); len(got.Receipts) != 0 {
+		t.Fatalf("mutation-free task restored mutation evidence: %+v", got)
+	}
 
 	next := second.StartForSession("session", "bash", "next", func(context.Context, io.Writer) (string, error) {
 		return "", nil
@@ -126,6 +131,136 @@ func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 	<-next.done
 	if next.ID == j.ID {
 		t.Fatalf("new job reused restored id %q", next.ID)
+	}
+}
+
+func TestTaskMutationEvidencePersistsWithoutSensitiveReceiptData(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	first := NewManager(event.Discard)
+	first.SetActiveSessionPath("session", sessionPath)
+	const secret = "private-receipt-value-123456"
+	j := first.StartForSession("session", "task", "writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{
+			{
+				ToolName: "write_file",
+				Args:     json.RawMessage(`{"path":"internal/agent/task.go","content":"` + secret + `"}`),
+				Success:  true,
+				Write:    true,
+				Mutation: true,
+				Paths:    []string{"internal/agent/task.go"},
+			},
+			{
+				ToolName: "bash",
+				Success:  true,
+				Command:  "go test ./... --token=" + secret,
+			},
+		}})
+		return "persisted answer", nil
+	})
+	<-j.done
+	first.Close()
+
+	metaPath := filepath.Join(ArtifactDir(sessionPath), j.ID+jobMetaExt)
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, leaked := range []string{secret, "content", "go test ./..."} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("job metadata persisted sensitive receipt data %q:\n%s", leaked, text)
+		}
+	}
+	for _, want := range []string{`"mutationEvidenceVersion": 1`, `"risk": "medium"`, `"internal/agent/task.go"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("job metadata missing %q:\n%s", want, text)
+		}
+	}
+
+	second := NewManager(event.Discard)
+	defer second.Close()
+	second.SetActiveSessionPath("session", sessionPath)
+	summary := second.TakeEvidenceForSession("session", j.ID)
+	if len(summary.Receipts) != 1 {
+		t.Fatalf("restored evidence = %+v, want one synthetic mutation", summary)
+	}
+	receipt := summary.Receipts[0]
+	if !receipt.Success || !receipt.Mutation || !receipt.Write || receipt.ToolName != recoveredBackgroundTaskToolName {
+		t.Fatalf("restored receipt = %+v, want successful recovered mutation", receipt)
+	}
+	if len(receipt.Paths) != 1 || filepath.ToSlash(receipt.Paths[0]) != "internal/agent/task.go" {
+		t.Fatalf("restored paths = %v, want internal/agent/task.go", receipt.Paths)
+	}
+	if len(receipt.Args) != 0 || receipt.Command != "" || receipt.Read {
+		t.Fatalf("restored receipt retained stale sign-off data: %+v", receipt)
+	}
+
+	ledger := evidence.NewLedger()
+	ledger.MergeChild(summary)
+	mutation, ok := ledger.LatestSuccessfulMutationIndex()
+	if !ok || ledger.HasSuccessfulReviewAfter(mutation) || ledger.HasSuccessfulVerificationCommand() {
+		t.Fatalf("restored evidence bypassed fresh review/verification: %+v", ledger.Summary())
+	}
+	if got := ledger.MutationRiskAfter(mutation); got != evidence.RiskMedium {
+		t.Fatalf("restored mutation risk = %s, want medium", got)
+	}
+	if secondTake := second.TakeEvidenceForSession("session", j.ID); len(secondTake.Receipts) != 0 {
+		t.Fatalf("restored evidence was collectible twice: %+v", secondTake)
+	}
+}
+
+func TestHighRiskTaskMutationEvidenceRestoresAsOpaque(t *testing.T) {
+	meta := artifactMeta{
+		Kind:                    "task",
+		MutationEvidenceVersion: mutationEvidenceVersion,
+		MutationEvidence: &artifactMutationEvidence{
+			Risk:  string(evidence.RiskHigh),
+			Paths: []string{"ordinary-looking.go"},
+		},
+	}
+	summary := mutationEvidenceFromArtifact(meta)
+	if len(summary.Receipts) != 1 || len(summary.Receipts[0].Paths) != 0 {
+		t.Fatalf("high-risk restored evidence = %+v, want opaque mutation", summary)
+	}
+	ledger := evidence.NewLedger()
+	ledger.MergeChild(summary)
+	mutation, ok := ledger.LatestSuccessfulMutationIndex()
+	if !ok || ledger.MutationRiskAfter(mutation) != evidence.RiskHigh {
+		t.Fatalf("high-risk mutation was downgraded during recovery: %+v", ledger.Summary())
+	}
+}
+
+func TestLegacyTaskArtifactRecoversAsOpaqueHighRiskMutation(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	dir := ArtifactDir(sessionPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task-1"+jobLogExt), []byte("legacy answer"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMeta(filepath.Join(dir, "task-1"+jobMetaExt), artifactMeta{
+		ID:               "task-1",
+		Kind:             "task",
+		Status:           Done,
+		ArtifactComplete: true,
+		LogPath:          "task-1" + jobLogExt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+	summary := m.TakeEvidenceForSession("session", "task-1")
+	if len(summary.Receipts) != 1 || !summary.HasMutation() || len(summary.MutationPaths()) != 0 {
+		t.Fatalf("legacy task evidence = %+v, want one opaque mutation", summary)
+	}
+	ledger := evidence.NewLedger()
+	ledger.MergeChild(summary)
+	mutation, ok := ledger.LatestSuccessfulMutationIndex()
+	if !ok || ledger.MutationRiskAfter(mutation) != evidence.RiskHigh {
+		t.Fatalf("legacy task mutation was not recovered conservatively: %+v", ledger.Summary())
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/secrets"
 )
@@ -129,6 +130,9 @@ type Job struct {
 	artifactComplete bool
 	artifactErr      string
 	tombstone        bool
+
+	evidence      evidence.ChildEvidenceSummary
+	evidenceTaken bool
 }
 
 // Manager is the session's background-job table. It is safe for concurrent use.
@@ -148,6 +152,7 @@ type Manager struct {
 	artifactDirs map[string]string
 	loaded       map[string]bool
 	tempRoot     string
+	reservations map[string]int
 
 	stalledWarning time.Duration
 	teardownGrace  time.Duration
@@ -200,6 +205,7 @@ func NewManager(sink event.Sink, opts ...Option) *Manager {
 		jobs:          map[string]*Job{},
 		destroying:    map[string]bool{},
 		artifactDirs:  map[string]string{},
+		reservations:  map[string]int{},
 		loaded:        map[string]bool{},
 		tempRoot:      tempRoot,
 		teardownGrace: DefaultTeardownGrace,
@@ -266,6 +272,8 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		artifactComplete: artifactErr == "",
 		artifactErr:      artifactErr,
 	}
+	ctx = WithSession(ctx, parentSession)
+	ctx = context.WithValue(ctx, jobCtxKey{}, j)
 	key := jobKey(parentSession, id)
 	m.jobs[key] = j
 	m.order = append(m.order, key)
@@ -813,6 +821,50 @@ func (m *Manager) RunningForSession(parentSession string) []View {
 		j.mu.Unlock()
 	}
 	return out
+}
+
+// ReserveStartForSession atomically reserves capacity for a job start. The
+// caller must release the reservation after StartForSession has registered the
+// job (or when setup fails). Running jobs and in-flight start reservations both
+// count toward limit, so concurrent callers cannot overshoot it.
+func (m *Manager) ReserveStartForSession(parentSession, kind string, limit int) (release func(), running int, ok bool) {
+	if limit <= 0 {
+		return func() {}, 0, true
+	}
+	parentSession = strings.TrimSpace(parentSession)
+	key := jobKey(parentSession, kind)
+	m.mu.Lock()
+	for _, jobKey := range m.order {
+		j := m.jobs[jobKey]
+		if j == nil || !sessionMatches(parentSession, j.SessionID) || j.Kind != kind {
+			continue
+		}
+		select {
+		case <-j.done:
+		default:
+			running++
+		}
+	}
+	running += m.reservations[key]
+	if running >= limit {
+		m.mu.Unlock()
+		return func() {}, running, false
+	}
+	m.reservations[key]++
+	m.mu.Unlock()
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			m.mu.Lock()
+			m.reservations[key]--
+			if m.reservations[key] == 0 {
+				delete(m.reservations, key)
+			}
+			m.mu.Unlock()
+		})
+	}
+	return release, running, true
 }
 
 // HasUnfinishedForSession reports whether parentSession owns any job whose
@@ -1484,6 +1536,7 @@ func jobKey(parentSession, id string) string {
 
 type ctxKey struct{}
 type sessionCtxKey struct{}
+type jobCtxKey struct{}
 
 // WithManager stamps ctx with the job manager so tools can reach it via
 // FromContext. The agent sets this on every tool call's context.
@@ -1509,4 +1562,41 @@ func WithSession(ctx context.Context, parentSession string) context.Context {
 func SessionFromContext(ctx context.Context) string {
 	session, _ := ctx.Value(sessionCtxKey{}).(string)
 	return strings.TrimSpace(session)
+}
+
+// PublishEvidence attaches a background agent's host-observed receipts to its
+// job. The receipts stay independent of the parent turn ledger until the
+// parent collects the terminal result with wait or bash_output.
+func PublishEvidence(ctx context.Context, summary evidence.ChildEvidenceSummary) {
+	j, _ := ctx.Value(jobCtxKey{}).(*Job)
+	if j == nil || len(summary.Receipts) == 0 {
+		return
+	}
+	j.mu.Lock()
+	j.evidence.Receipts = append(j.evidence.Receipts, summary.Receipts...)
+	j.mu.Unlock()
+}
+
+// TakeEvidenceForSession returns a terminal job's evidence exactly once. This
+// prevents repeated wait/bash_output calls from duplicating receipts in the
+// collecting turn's ledger.
+func (m *Manager) TakeEvidenceForSession(parentSession, id string) evidence.ChildEvidenceSummary {
+	j := m.get(parentSession, id)
+	if j == nil {
+		return evidence.ChildEvidenceSummary{}
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	select {
+	case <-j.done:
+	default:
+		return evidence.ChildEvidenceSummary{}
+	}
+	if j.evidenceTaken {
+		return evidence.ChildEvidenceSummary{}
+	}
+	j.evidenceTaken = true
+	out := make([]evidence.Receipt, len(j.evidence.Receipts))
+	copy(out, j.evidence.Receipts)
+	return evidence.ChildEvidenceSummary{Receipts: out}
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -1664,23 +1664,74 @@ func PublishEvidence(ctx context.Context, summary evidence.ChildEvidenceSummary)
 // committed job returns empty so a re-poll after successful delivery does not
 // re-demand review.
 func (m *Manager) LeaseEvidenceForSession(parentSession, id string) evidence.ChildEvidenceSummary {
+	summary, _ := m.tryLeaseEvidenceForSession(parentSession, id)
+	return summary
+}
+
+// TryLeaseEvidenceForSession is LeaseEvidenceForSession plus a ready flag that
+// separates "terminal evidence available" (possibly empty — a committed job or
+// one with no mutations) from "not ready to lease yet": unknown job, still
+// running, or killed but its run goroutine has not yet flushed PublishEvidence
+// and closed done. KillForSession flips status to Killed synchronously, well
+// before the goroutine actually returns, so a bash_output poll that lands in
+// that window must not treat the empty read as final. Callers that record a
+// lease (collectBackgroundEvidence) must gate on ready so they never note a
+// lease before the evidence exists — noting it early would let a later commit
+// drain evidence nobody ever merged or reviewed.
+func (m *Manager) TryLeaseEvidenceForSession(parentSession, id string) (evidence.ChildEvidenceSummary, bool) {
+	return m.tryLeaseEvidenceForSession(parentSession, id)
+}
+
+func (m *Manager) tryLeaseEvidenceForSession(parentSession, id string) (evidence.ChildEvidenceSummary, bool) {
 	j := m.get(parentSession, id)
 	if j == nil {
-		return evidence.ChildEvidenceSummary{}
+		return evidence.ChildEvidenceSummary{}, false
 	}
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	select {
 	case <-j.done:
 	default:
-		return evidence.ChildEvidenceSummary{}
+		return evidence.ChildEvidenceSummary{}, false
 	}
 	if j.evidenceCommitted {
-		return evidence.ChildEvidenceSummary{}
+		return evidence.ChildEvidenceSummary{}, true
 	}
 	out := make([]evidence.Receipt, len(j.evidence.Receipts))
 	copy(out, j.evidence.Receipts)
-	return evidence.ChildEvidenceSummary{Receipts: out}
+	return evidence.ChildEvidenceSummary{Receipts: out}, true
+}
+
+// PendingEvidenceJobIDsForSession returns the IDs of parentSession's terminal
+// jobs that carry uncommitted mutation evidence — a prior turn leased it but
+// never delivered (the turn failed or was cancelled, and the next turn's Reset
+// wiped it from the per-turn ledger), or the process restarted before any turn
+// collected it at all. The agent re-leases these at the start of every turn so
+// a turn that never calls wait/bash_output still surfaces the pending mutation
+// to its final-readiness checks instead of silently shipping it unreviewed.
+func (m *Manager) PendingEvidenceJobIDsForSession(parentSession string) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var ids []string
+	for _, key := range m.order {
+		j := m.jobs[key]
+		if j == nil || !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		j.mu.Lock()
+		terminal := false
+		select {
+		case <-j.done:
+			terminal = true
+		default:
+		}
+		pending := terminal && !j.evidenceCommitted && len(j.evidence.Receipts) > 0
+		j.mu.Unlock()
+		if pending {
+			ids = append(ids, j.ID)
+		}
+	}
+	return ids
 }
 
 // CommitEvidenceForSession permanently consumes a terminal job's evidence after

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -131,8 +131,8 @@ type Job struct {
 	artifactErr      string
 	tombstone        bool
 
-	evidence      evidence.ChildEvidenceSummary
-	evidenceTaken bool
+	evidence          evidence.ChildEvidenceSummary
+	evidenceCommitted bool
 }
 
 // Manager is the session's background-job table. It is safe for concurrent use.
@@ -449,21 +449,21 @@ func mutationEvidenceFromArtifact(meta artifactMeta) evidence.ChildEvidenceSumma
 	if meta.Kind != "task" {
 		return evidence.ChildEvidenceSummary{}
 	}
-	if meta.MutationEvidenceVersion == 0 {
-		// Legacy artifact from before mutation evidence was persisted: that
-		// flow never published child receipts, so there is nothing to recover.
-		// Synthesizing a mutation here would retroactively demand inspection
-		// and review for work no collecting turn ever saw — pure burden with
-		// no safety gain over the old behavior.
-		return evidence.ChildEvidenceSummary{}
-	}
 	if meta.MutationEvidenceVersion != mutationEvidenceVersion {
-		// A newer build persisted a shape this one cannot parse. Assume the
-		// worst (an opaque mutation) so downgrade coexistence on a shared
-		// state directory cannot skip review.
+		// Any version this build cannot parse — a pre-feature artifact
+		// (version 0) or one written by a newer build — is treated as an
+		// opaque mutation. A missing summary only proves the mutation state
+		// was not recorded, not that the task made no changes: a legacy
+		// background writer task collected after upgrade could carry real,
+		// unreviewed edits. Recovering it as opaque RiskHigh forces fresh
+		// inspection and review rather than silently skipping it, and keeps
+		// downgrade coexistence on a shared state directory conservative.
 		return opaqueRecoveredTaskMutation()
 	}
 	if meta.MutationEvidence == nil {
+		// Same-version artifact with no summary: this build DID record the
+		// mutation state and found none, so there is genuinely nothing to
+		// recover.
 		return evidence.ChildEvidenceSummary{}
 	}
 
@@ -1653,10 +1653,17 @@ func PublishEvidence(ctx context.Context, summary evidence.ChildEvidenceSummary)
 	j.mu.Unlock()
 }
 
-// TakeEvidenceForSession returns a terminal job's evidence exactly once. This
-// prevents repeated wait/bash_output calls from duplicating receipts in the
-// collecting turn's ledger.
-func (m *Manager) TakeEvidenceForSession(parentSession, id string) evidence.ChildEvidenceSummary {
+// LeaseEvidenceForSession returns a copy of a terminal job's evidence without
+// consuming it. Collection is only provisional: the receipts merge into the
+// collecting turn's ledger, but that ledger is discarded if the turn is
+// cancelled, errors, or the process exits before the turn commits. Consuming
+// here would then lose the mutation for good — the parent's next turn resets its
+// ledger and this job would report nothing, so a background change would ship
+// unreviewed. The evidence is drained only by CommitEvidenceForSession, which
+// the agent calls after the collecting turn passes its delivery gates. A
+// committed job returns empty so a re-poll after successful delivery does not
+// re-demand review.
+func (m *Manager) LeaseEvidenceForSession(parentSession, id string) evidence.ChildEvidenceSummary {
 	j := m.get(parentSession, id)
 	if j == nil {
 		return evidence.ChildEvidenceSummary{}
@@ -1668,22 +1675,41 @@ func (m *Manager) TakeEvidenceForSession(parentSession, id string) evidence.Chil
 	default:
 		return evidence.ChildEvidenceSummary{}
 	}
-	if j.evidenceTaken {
+	if j.evidenceCommitted {
 		return evidence.ChildEvidenceSummary{}
 	}
-	j.evidenceTaken = true
 	out := make([]evidence.Receipt, len(j.evidence.Receipts))
 	copy(out, j.evidence.Receipts)
+	return evidence.ChildEvidenceSummary{Receipts: out}
+}
+
+// CommitEvidenceForSession permanently consumes a terminal job's evidence after
+// the collecting turn has accounted for it (passed final-readiness). It clears
+// the in-memory copy and drains the persisted mutation summary so neither a
+// same-process re-poll nor a restart resurrects receipts the delivered turn
+// already reviewed. Best-effort on the disk rewrite — a failed rewrite merely
+// restores the conservative resurrection behavior.
+func (m *Manager) CommitEvidenceForSession(parentSession, id string) {
+	j := m.get(parentSession, id)
+	if j == nil {
+		return
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	select {
+	case <-j.done:
+	default:
+		return
+	}
+	if j.evidenceCommitted {
+		return
+	}
+	hadEvidence := len(j.evidence.Receipts) > 0
+	j.evidenceCommitted = true
 	j.evidence = evidence.ChildEvidenceSummary{}
-	if len(out) > 0 {
-		// Drain the persisted copy too: the artifact meta still carries the
-		// mutation summary, and a restart would otherwise resurrect it for a
-		// re-polled job id, re-arming inspection and review demands for work
-		// the collecting turn already handled. Best-effort — a failed rewrite
-		// merely restores the conservative resurrection behavior.
+	if hadEvidence {
 		if err := m.writeJobMetaLocked(j, j.status); err != nil {
 			j.noteArtifactErr("evidence drain: " + err.Error())
 		}
 	}
-	return evidence.ChildEvidenceSummary{Receipts: out}
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -409,7 +409,7 @@ func (m *Manager) writeJobMetaLocked(j *Job, st Status) error {
 	if j.artifactMetaPath == "" {
 		return nil
 	}
-	return writeMeta(j.artifactMetaPath, artifactMeta{
+	meta := artifactMeta{
 		ID:               j.ID,
 		Kind:             j.Kind,
 		Label:            j.Label,
@@ -420,7 +420,71 @@ func (m *Manager) writeJobMetaLocked(j *Job, st Status) error {
 		ArtifactComplete: j.artifactComplete && j.artifactErr == "",
 		ArtifactError:    j.artifactErr,
 		LogPath:          filepath.Base(j.artifactPath),
-	})
+	}
+	if j.Kind == "task" {
+		meta.MutationEvidenceVersion = mutationEvidenceVersion
+		meta.MutationEvidence = mutationEvidenceForArtifact(j.evidence)
+	}
+	return writeMeta(j.artifactMetaPath, meta)
+}
+
+func mutationEvidenceForArtifact(summary evidence.ChildEvidenceSummary) *artifactMutationEvidence {
+	firstMutation := -1
+	for i, receipt := range summary.Receipts {
+		if receipt.Success && receipt.Mutation {
+			firstMutation = i
+			break
+		}
+	}
+	if firstMutation < 0 {
+		return nil
+	}
+	return &artifactMutationEvidence{
+		Risk:  string(evidence.ClassifyMutationRisk(summary.Receipts, firstMutation)),
+		Paths: summary.MutationPaths(),
+	}
+}
+
+func mutationEvidenceFromArtifact(meta artifactMeta) evidence.ChildEvidenceSummary {
+	if meta.Kind != "task" {
+		return evidence.ChildEvidenceSummary{}
+	}
+	if meta.MutationEvidenceVersion != mutationEvidenceVersion {
+		return opaqueRecoveredTaskMutation()
+	}
+	if meta.MutationEvidence == nil {
+		return evidence.ChildEvidenceSummary{}
+	}
+
+	paths := append([]string(nil), meta.MutationEvidence.Paths...)
+	switch evidence.RiskLevel(meta.MutationEvidence.Risk) {
+	case evidence.RiskLow, evidence.RiskMedium:
+		// Known paths preserve the original adaptive risk level while still
+		// requiring fresh inspection and verification after recovery.
+	case evidence.RiskHigh:
+		// The original risk may have come from an opaque or privileged tool,
+		// which the sanitized artifact intentionally does not retain. Recover it
+		// as opaque so restart cannot downgrade the security-review requirement.
+		paths = nil
+	default:
+		return opaqueRecoveredTaskMutation()
+	}
+	return evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+		ToolName: recoveredBackgroundTaskToolName,
+		Success:  true,
+		Write:    true,
+		Mutation: true,
+		Paths:    paths,
+	}}}
+}
+
+func opaqueRecoveredTaskMutation() evidence.ChildEvidenceSummary {
+	return evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+		ToolName: recoveredBackgroundTaskToolName,
+		Success:  true,
+		Write:    true,
+		Mutation: true,
+	}}}
 }
 
 func (m *Manager) artifactTargetDirForJob(j *Job) string {
@@ -1245,6 +1309,7 @@ func (m *Manager) loadSessionArtifacts(parentSession, dir string) {
 			artifactComplete: meta.ArtifactComplete,
 			artifactErr:      meta.ArtifactError,
 			tombstone:        true,
+			evidence:         mutationEvidenceFromArtifact(meta),
 		})
 	}
 	m.mu.Lock()
@@ -1598,5 +1663,6 @@ func (m *Manager) TakeEvidenceForSession(parentSession, id string) evidence.Chil
 	j.evidenceTaken = true
 	out := make([]evidence.Receipt, len(j.evidence.Receipts))
 	copy(out, j.evidence.Receipts)
+	j.evidence = evidence.ChildEvidenceSummary{}
 	return evidence.ChildEvidenceSummary{Receipts: out}
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -449,7 +449,18 @@ func mutationEvidenceFromArtifact(meta artifactMeta) evidence.ChildEvidenceSumma
 	if meta.Kind != "task" {
 		return evidence.ChildEvidenceSummary{}
 	}
+	if meta.MutationEvidenceVersion == 0 {
+		// Legacy artifact from before mutation evidence was persisted: that
+		// flow never published child receipts, so there is nothing to recover.
+		// Synthesizing a mutation here would retroactively demand inspection
+		// and review for work no collecting turn ever saw — pure burden with
+		// no safety gain over the old behavior.
+		return evidence.ChildEvidenceSummary{}
+	}
 	if meta.MutationEvidenceVersion != mutationEvidenceVersion {
+		// A newer build persisted a shape this one cannot parse. Assume the
+		// worst (an opaque mutation) so downgrade coexistence on a shared
+		// state directory cannot skip review.
 		return opaqueRecoveredTaskMutation()
 	}
 	if meta.MutationEvidence == nil {
@@ -1664,5 +1675,15 @@ func (m *Manager) TakeEvidenceForSession(parentSession, id string) evidence.Chil
 	out := make([]evidence.Receipt, len(j.evidence.Receipts))
 	copy(out, j.evidence.Receipts)
 	j.evidence = evidence.ChildEvidenceSummary{}
+	if len(out) > 0 {
+		// Drain the persisted copy too: the artifact meta still carries the
+		// mutation summary, and a restart would otherwise resurrect it for a
+		// re-polled job id, re-arming inspection and review demands for work
+		// the collecting turn already handled. Best-effort — a failed rewrite
+		// merely restores the conservative resurrection behavior.
+		if err := m.writeJobMetaLocked(j, j.status); err != nil {
+			j.noteArtifactErr("evidence drain: " + err.Error())
+		}
+	}
 	return evidence.ChildEvidenceSummary{Receipts: out}
 }

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 )
 
 type recordingSink struct {
@@ -60,6 +61,114 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("condition not met within deadline")
+}
+
+func TestStartForSessionStampsJobContext(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+	seen := make(chan string, 1)
+	j := m.StartForSession("session-a", "task", "scoped", func(ctx context.Context, _ io.Writer) (string, error) {
+		seen <- SessionFromContext(ctx)
+		return "done", nil
+	})
+	if got := <-seen; got != "session-a" {
+		t.Fatalf("job context session = %q, want session-a", got)
+	}
+	if res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5); len(res) != 1 || res[0].Status != Done {
+		t.Fatalf("job result = %+v, want done", res)
+	}
+}
+
+func TestReserveStartForSessionIsAtomic(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	const callers = 16
+	start := make(chan struct{})
+	releases := make(chan func(), callers)
+	results := make(chan bool, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			<-start
+			release, _, ok := m.ReserveStartForSession("session-a", "task", 3)
+			if ok {
+				releases <- release
+			}
+			results <- ok
+		}()
+	}
+	close(start)
+	reserved := 0
+	for i := 0; i < callers; i++ {
+		if <-results {
+			reserved++
+		}
+	}
+	if reserved != 3 {
+		t.Fatalf("concurrent reservations = %d, want exactly 3", reserved)
+	}
+	for i := 0; i < reserved; i++ {
+		(<-releases)()
+	}
+	if release, running, ok := m.ReserveStartForSession("session-a", "task", 3); !ok || running != 0 {
+		t.Fatalf("reservation after release = (running=%d, ok=%v), want (0, true)", running, ok)
+	} else {
+		release()
+	}
+}
+
+func TestReserveStartForSessionCountsKilledJobUntilExit(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+	exit := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "unwinding", func(context.Context, io.Writer) (string, error) {
+		<-exit
+		return "done", nil
+	})
+	if !m.KillForSession("session-a", j.ID) {
+		t.Fatal("KillForSession did not find running job")
+	}
+	if release, running, ok := m.ReserveStartForSession("session-a", "task", 1); ok {
+		release()
+		t.Fatal("reserved a replacement while killed writer goroutine was still running")
+	} else if running != 1 {
+		t.Fatalf("unwinding writer count = %d, want 1", running)
+	}
+	close(exit)
+	if res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5); len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("killed job result = %+v", res)
+	}
+	if release, running, ok := m.ReserveStartForSession("session-a", "task", 1); !ok || running != 0 {
+		t.Fatalf("reservation after exit = (running=%d, ok=%v), want (0, true)", running, ok)
+	} else {
+		release()
+	}
+}
+
+func TestTakeEvidenceWaitsForKilledJobExit(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+	exit := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "partial writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		<-exit
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Paths: []string{"partial.go"},
+		}}})
+		return "stopped", nil
+	})
+	if !m.KillForSession("session-a", j.ID) {
+		t.Fatal("KillForSession did not find running job")
+	}
+	if early := m.TakeEvidenceForSession("session-a", j.ID); len(early.Receipts) != 0 {
+		t.Fatalf("collected evidence before killed job exited: %+v", early)
+	}
+	close(exit)
+	if res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5); len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("killed job result = %+v", res)
+	}
+	if got := m.TakeEvidenceForSession("session-a", j.ID); !got.HasMutation() {
+		t.Fatalf("partial evidence lost after killed job exit: %+v", got)
+	}
 }
 
 func TestStalledWarningIgnoresReturnedJobBeforeTerminalStatusPublished(t *testing.T) {

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -180,6 +180,87 @@ func TestLeaseEvidenceWaitsForKilledJobExit(t *testing.T) {
 	}
 }
 
+func TestTryLeaseEvidenceForSessionReportsReadiness(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+	exit := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "partial writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		<-exit
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Paths: []string{"partial.go"},
+		}}})
+		return "stopped", nil
+	})
+	if _, ready := m.TryLeaseEvidenceForSession("session-a", "no-such-job"); ready {
+		t.Fatal("unknown job reported ready")
+	}
+	if _, ready := m.TryLeaseEvidenceForSession("session-a", j.ID); ready {
+		t.Fatal("running job reported ready before it reached a terminal state")
+	}
+	if !m.KillForSession("session-a", j.ID) {
+		t.Fatal("KillForSession did not find running job")
+	}
+	// Killed flips the status synchronously but the goroutine has not exited yet
+	// (still blocked on exit): must not report ready.
+	if _, ready := m.TryLeaseEvidenceForSession("session-a", j.ID); ready {
+		t.Fatal("killed-but-unwinding job reported ready before its evidence was flushed")
+	}
+	close(exit)
+	if res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5); len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("killed job result = %+v", res)
+	}
+	summary, ready := m.TryLeaseEvidenceForSession("session-a", j.ID)
+	if !ready || !summary.HasMutation() {
+		t.Fatalf("ready/summary after exit = %v/%+v, want ready with the published mutation", ready, summary)
+	}
+	m.CommitEvidenceForSession("session-a", j.ID)
+	if summary, ready := m.TryLeaseEvidenceForSession("session-a", j.ID); !ready || len(summary.Receipts) != 0 {
+		t.Fatalf("post-commit ready/summary = %v/%+v, want ready with no receipts", ready, summary)
+	}
+}
+
+func TestPendingEvidenceJobIDsForSession(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	running := m.StartForSession("session-a", "task", "still going", func(ctx context.Context, _ io.Writer) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	mutator := m.StartForSession("session-a", "task", "writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Paths: []string{"changed.go"},
+		}}})
+		return "done", nil
+	})
+	readOnly := m.StartForSession("session-a", "task", "reader", func(context.Context, io.Writer) (string, error) {
+		return "no changes", nil
+	})
+	otherSession := m.StartForSession("session-b", "task", "writer", func(ctx context.Context, _ io.Writer) (string, error) {
+		PublishEvidence(ctx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Paths: []string{"other.go"},
+		}}})
+		return "done", nil
+	})
+	if res := m.WaitForSession(context.Background(), "session-a", []string{mutator.ID, readOnly.ID}, 5); len(res) != 2 {
+		t.Fatalf("wait = %+v, want mutator and read-only jobs done", res)
+	}
+	if res := m.WaitForSession(context.Background(), "session-b", []string{otherSession.ID}, 5); len(res) != 1 {
+		t.Fatalf("wait = %+v, want other-session job done", res)
+	}
+
+	pending := m.PendingEvidenceJobIDsForSession("session-a")
+	if len(pending) != 1 || pending[0] != mutator.ID {
+		t.Fatalf("pending = %v, want only %q (running job excluded, read-only job has no receipts, other session excluded)", pending, mutator.ID)
+	}
+
+	m.CommitEvidenceForSession("session-a", mutator.ID)
+	if pending := m.PendingEvidenceJobIDsForSession("session-a"); len(pending) != 0 {
+		t.Fatalf("pending after commit = %v, want none", pending)
+	}
+	_ = running // still running when the test ends; Close() cancels and reaps it
+}
+
 func TestStalledWarningIgnoresReturnedJobBeforeTerminalStatusPublished(t *testing.T) {
 	sink := &blockingFinishedSink{entered: make(chan struct{}), released: make(chan struct{})}
 	m := NewManager(sink, WithStalledWarningAfter(20*time.Millisecond))

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -145,7 +145,7 @@ func TestReserveStartForSessionCountsKilledJobUntilExit(t *testing.T) {
 	}
 }
 
-func TestTakeEvidenceWaitsForKilledJobExit(t *testing.T) {
+func TestLeaseEvidenceWaitsForKilledJobExit(t *testing.T) {
 	m := NewManager(event.Discard)
 	defer m.Close()
 	exit := make(chan struct{})
@@ -159,15 +159,24 @@ func TestTakeEvidenceWaitsForKilledJobExit(t *testing.T) {
 	if !m.KillForSession("session-a", j.ID) {
 		t.Fatal("KillForSession did not find running job")
 	}
-	if early := m.TakeEvidenceForSession("session-a", j.ID); len(early.Receipts) != 0 {
+	if early := m.LeaseEvidenceForSession("session-a", j.ID); len(early.Receipts) != 0 {
 		t.Fatalf("collected evidence before killed job exited: %+v", early)
 	}
 	close(exit)
 	if res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5); len(res) != 1 || res[0].Status != Killed {
 		t.Fatalf("killed job result = %+v", res)
 	}
-	if got := m.TakeEvidenceForSession("session-a", j.ID); !got.HasMutation() {
+	if got := m.LeaseEvidenceForSession("session-a", j.ID); !got.HasMutation() {
 		t.Fatalf("partial evidence lost after killed job exit: %+v", got)
+	}
+	// Lease does not consume: a second lease still returns the receipts, and a
+	// commit is required to drain them.
+	if again := m.LeaseEvidenceForSession("session-a", j.ID); !again.HasMutation() {
+		t.Fatalf("lease consumed evidence without a commit: %+v", again)
+	}
+	m.CommitEvidenceForSession("session-a", j.ID)
+	if after := m.LeaseEvidenceForSession("session-a", j.ID); len(after.Receipts) != 0 {
+		t.Fatalf("committed evidence still leasable: %+v", after)
 	}
 }
 

--- a/internal/planmode/context.go
+++ b/internal/planmode/context.go
@@ -1,0 +1,20 @@
+package planmode
+
+import "context"
+
+type activeCtxKey struct{}
+
+// WithActive stamps ctx with whether the executing tool call runs under the
+// agent's plan-mode gate. The agent's call-context constructor is the single
+// production writer, so the flag stays in lockstep with the gate itself.
+// Leaf-package tools (which must not import the agent package) read it via
+// Active to defer follow-up work that belongs to an execution turn.
+func WithActive(ctx context.Context, active bool) context.Context {
+	return context.WithValue(ctx, activeCtxKey{}, active)
+}
+
+// Active reports whether ctx carries an active plan-mode flag.
+func Active(ctx context.Context) bool {
+	active, _ := ctx.Value(activeCtxKey{}).(bool)
+	return active
+}

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -197,13 +197,24 @@ func collectBackgroundEvidence(ctx context.Context, jm *jobs.Manager, jobID stri
 		return
 	}
 	session := jobs.SessionFromContext(ctx)
+	// A non-Running status from bash_output/wait does not guarantee the job's
+	// run goroutine has actually flushed PublishEvidence and closed done: kill_shell
+	// flips status to Killed synchronously, well before its cancelled goroutine
+	// unwinds. Check readiness before noting the lease — noting it on an empty,
+	// not-yet-ready read would dedupe away every later retry in this turn (the
+	// lease is idempotent per turn) while the job later publishes real mutation
+	// evidence nobody ever merges or reviews.
+	summary, ready := jm.TryLeaseEvidenceForSession(session, jobID)
+	if !ready {
+		return
+	}
 	// Note the lease before merging so a second wait/bash_output in the same
-	// turn does not double-count. The merge is provisional: LeaseEvidence does
-	// not consume, so if this turn fails the agent never commits and the next
-	// turn re-collects. The agent commits leased jobs only after the turn
-	// passes its delivery gates.
+	// turn does not double-count. The merge is provisional: the lease does not
+	// consume, so if this turn fails the agent never commits and the next turn
+	// re-collects. The agent commits leased jobs only after the turn passes its
+	// delivery gates.
 	if !ledger.NoteBackgroundLease(session, jobID) {
 		return
 	}
-	ledger.MergeChild(jm.LeaseEvidenceForSession(session, jobID))
+	ledger.MergeChild(summary)
 }

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 	"reasonix/internal/tool"
 )
@@ -58,6 +59,9 @@ func (bashOutput) Execute(ctx context.Context, args json.RawMessage) (string, er
 	text, status, found := jm.OutputForSession(jobs.SessionFromContext(ctx), p.JobID)
 	if !found {
 		return "", fmt.Errorf("no background job %q", p.JobID)
+	}
+	if status != jobs.Running {
+		collectBackgroundEvidence(ctx, jm, p.JobID)
 	}
 	if p.Filter != "" && text != "" {
 		filtered, err := filterLines(text, p.Filter)
@@ -160,6 +164,9 @@ func (waitJob) Execute(ctx context.Context, args json.RawMessage) (string, error
 	}
 	var b strings.Builder
 	for i, r := range results {
+		if r.Status != jobs.Running {
+			collectBackgroundEvidence(ctx, jm, r.ID)
+		}
 		if i > 0 {
 			b.WriteString("\n\n")
 		}
@@ -173,4 +180,12 @@ func (waitJob) Execute(ctx context.Context, args json.RawMessage) (string, error
 		}
 	}
 	return b.String(), nil
+}
+
+func collectBackgroundEvidence(ctx context.Context, jm *jobs.Manager, jobID string) {
+	ledger, ok := evidence.FromContext(ctx)
+	if !ok || ledger == nil || jm == nil {
+		return
+	}
+	ledger.MergeChild(jm.TakeEvidenceForSession(jobs.SessionFromContext(ctx), jobID))
 }

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -196,5 +196,14 @@ func collectBackgroundEvidence(ctx context.Context, jm *jobs.Manager, jobID stri
 	if !ok || ledger == nil || jm == nil {
 		return
 	}
-	ledger.MergeChild(jm.TakeEvidenceForSession(jobs.SessionFromContext(ctx), jobID))
+	session := jobs.SessionFromContext(ctx)
+	// Note the lease before merging so a second wait/bash_output in the same
+	// turn does not double-count. The merge is provisional: LeaseEvidence does
+	// not consume, so if this turn fails the agent never commits and the next
+	// turn re-collects. The agent commits leased jobs only after the turn
+	// passes its delivery gates.
+	if !ledger.NoteBackgroundLease(session, jobID) {
+		return
+	}
+	ledger.MergeChild(jm.LeaseEvidenceForSession(session, jobID))
 }

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -9,6 +9,7 @@ import (
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
+	"reasonix/internal/planmode"
 	"reasonix/internal/tool"
 )
 
@@ -183,6 +184,14 @@ func (waitJob) Execute(ctx context.Context, args json.RawMessage) (string, error
 }
 
 func collectBackgroundEvidence(ctx context.Context, jm *jobs.Manager, jobID string) {
+	// Plan mode researches with writers blocked: merging a finished background
+	// writer's mutation receipts into a planning turn would arm delivery
+	// sign-off demands (complete_step, verification, review) that the turn
+	// cannot satisfy. Skip without consuming — the job keeps its evidence, and
+	// the first collection from a normal turn merges it.
+	if planmode.Active(ctx) {
+		return
+	}
 	ledger, ok := evidence.FromContext(ctx)
 	if !ok || ledger == nil || jm == nil {
 		return

--- a/internal/tool/builtin/bgjobs_test.go
+++ b/internal/tool/builtin/bgjobs_test.go
@@ -176,6 +176,76 @@ func TestBackgroundKill(t *testing.T) {
 	}
 }
 
+// kill_shell flips a job's status to Killed synchronously, well before its
+// cancelled run goroutine actually unwinds, flushes PublishEvidence, and closes
+// done. A bash_output poll that lands in that window must not note an empty
+// lease: the ledger's lease is idempotent per turn, so noting it early would
+// dedupe away every later retry in this same turn while the job's real
+// mutation evidence is still forthcoming — and a turn that goes on to deliver
+// would then commit (permanently drain) evidence nobody ever merged or
+// reviewed. This deterministically drives that exact window with channels
+// instead of a timing race.
+func TestKilledJobBashOutputDoesNotNoteLeaseBeforeEvidenceIsReady(t *testing.T) {
+	m := jobs.NewManager(event.Discard)
+	defer m.Close()
+	ledger := evidence.NewLedger()
+	ctx := jobs.WithManager(context.Background(), m)
+	ctx = jobs.WithSession(ctx, "session")
+	ctx = evidence.WithLedger(ctx, ledger)
+
+	cancelSeen := make(chan struct{})
+	release := make(chan struct{})
+	j := m.StartForSession("session", "task", "writer", func(jobCtx context.Context, _ io.Writer) (string, error) {
+		<-jobCtx.Done()
+		close(cancelSeen)
+		// Simulate a job that keeps unwinding (e.g. a subprocess still tearing
+		// down) after cancellation is requested but before it actually returns.
+		<-release
+		jobs.PublishEvidence(jobCtx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Write: true, Paths: []string{"changed.go"},
+		}}})
+		return "", context.Canceled
+	})
+
+	if _, err := (killShell{}).Execute(ctx, []byte(`{"job_id":"`+j.ID+`"}`)); err != nil {
+		t.Fatalf("kill_shell: %v", err)
+	}
+	<-cancelSeen // the goroutine observed the cancellation but has not returned
+
+	// bash_output lands in the unwinding window: status already reports Killed,
+	// but the job's done channel is not closed yet and no evidence exists.
+	bo, err := bashOutput{}.Execute(ctx, []byte(`{"job_id":"`+j.ID+`"}`))
+	if err != nil {
+		t.Fatalf("bash_output during unwind: %v", err)
+	}
+	if !strings.Contains(bo, "killed") {
+		t.Fatalf("bash_output during unwind = %q, want killed status", bo)
+	}
+	if ledger.Summary().HasMutation() {
+		t.Fatal("bash_output merged mutation evidence before the job was ready")
+	}
+	if leases := ledger.BackgroundLeases(); len(leases) != 0 {
+		t.Fatalf("bash_output noted a lease before the job was ready: %+v", leases)
+	}
+
+	close(release)
+	if res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 5); len(res) != 1 || res[0].Status != jobs.Killed {
+		t.Fatalf("post-unwind wait = %+v, want one killed result", res)
+	}
+
+	// A later retry — the model calling bash_output again, or the next turn's
+	// automatic re-lease — must still find the evidence, not a dead dedupe entry.
+	if _, err := (bashOutput{}).Execute(ctx, []byte(`{"job_id":"`+j.ID+`"}`)); err != nil {
+		t.Fatalf("bash_output after unwind: %v", err)
+	}
+	if !ledger.Summary().HasMutation() {
+		t.Fatal("bash_output did not collect the killed job's evidence once it became ready")
+	}
+	if leases := ledger.BackgroundLeases(); len(leases) != 1 {
+		t.Fatalf("leases = %+v, want exactly one lease recorded", leases)
+	}
+}
+
 // Without a manager on the context the background tools degrade to a clear error
 // rather than panicking.
 func TestBackgroundToolsNoManager(t *testing.T) {

--- a/internal/tool/builtin/bgjobs_test.go
+++ b/internal/tool/builtin/bgjobs_test.go
@@ -2,10 +2,12 @@ package builtin
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 )
 
@@ -48,6 +50,65 @@ func TestBackgroundBashWaitAndOutput(t *testing.T) {
 	}
 	if !strings.Contains(bo, "hello") {
 		t.Errorf("bash_output = %q, want hello", bo)
+	}
+}
+
+func TestWaitMergesBackgroundEvidenceExactlyOnce(t *testing.T) {
+	m := jobs.NewManager(event.Discard)
+	defer m.Close()
+	ledger := evidence.NewLedger()
+	ctx := jobs.WithManager(context.Background(), m)
+	ctx = jobs.WithSession(ctx, "session")
+	ctx = evidence.WithLedger(ctx, ledger)
+
+	j := m.StartForSession("session", "task", "writer", func(jobCtx context.Context, _ io.Writer) (string, error) {
+		jobs.PublishEvidence(jobCtx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file",
+			Success:  true,
+			Mutation: true,
+			Write:    true,
+			Paths:    []string{"changed.go"},
+		}}})
+		return "done", nil
+	})
+
+	args := []byte(`{"job_ids":["` + j.ID + `"]}`)
+	if _, err := (waitJob{}).Execute(ctx, args); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if !ledger.Summary().HasMutation() {
+		t.Fatal("wait did not merge the task job's mutation evidence")
+	}
+	firstLen := ledger.Len()
+	if _, err := (waitJob{}).Execute(ctx, args); err != nil {
+		t.Fatalf("second wait: %v", err)
+	}
+	if got := ledger.Len(); got != firstLen {
+		t.Fatalf("second wait duplicated evidence: len %d -> %d", firstLen, got)
+	}
+}
+
+func TestWaitWithoutLedgerDoesNotConsumeBackgroundEvidence(t *testing.T) {
+	m := jobs.NewManager(event.Discard)
+	defer m.Close()
+	baseCtx := jobs.WithSession(jobs.WithManager(context.Background(), m), "session")
+	j := m.StartForSession("session", "task", "writer", func(jobCtx context.Context, _ io.Writer) (string, error) {
+		jobs.PublishEvidence(jobCtx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Write: true, Paths: []string{"changed.go"},
+		}}})
+		return "done", nil
+	})
+	args := []byte(`{"job_ids":["` + j.ID + `"]}`)
+	if _, err := (waitJob{}).Execute(baseCtx, args); err != nil {
+		t.Fatalf("wait without ledger: %v", err)
+	}
+
+	ledger := evidence.NewLedger()
+	if _, err := (waitJob{}).Execute(evidence.WithLedger(baseCtx, ledger), args); err != nil {
+		t.Fatalf("wait with ledger: %v", err)
+	}
+	if !ledger.Summary().HasMutation() {
+		t.Fatal("wait without a ledger consumed evidence before a collecting turn could merge it")
 	}
 }
 

--- a/internal/tool/builtin/bgjobs_test.go
+++ b/internal/tool/builtin/bgjobs_test.go
@@ -9,6 +9,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
+	"reasonix/internal/planmode"
 )
 
 // End-to-end through the actual tools: a background bash job runs under a manager
@@ -109,6 +110,40 @@ func TestWaitWithoutLedgerDoesNotConsumeBackgroundEvidence(t *testing.T) {
 	}
 	if !ledger.Summary().HasMutation() {
 		t.Fatal("wait without a ledger consumed evidence before a collecting turn could merge it")
+	}
+}
+
+func TestWaitInPlanModeDefersBackgroundEvidence(t *testing.T) {
+	m := jobs.NewManager(event.Discard)
+	defer m.Close()
+	baseCtx := jobs.WithSession(jobs.WithManager(context.Background(), m), "session")
+	j := m.StartForSession("session", "task", "writer", func(jobCtx context.Context, _ io.Writer) (string, error) {
+		jobs.PublishEvidence(jobCtx, evidence.ChildEvidenceSummary{Receipts: []evidence.Receipt{{
+			ToolName: "write_file", Success: true, Mutation: true, Write: true, Paths: []string{"changed.go"},
+		}}})
+		return "done", nil
+	})
+	args := []byte(`{"job_ids":["` + j.ID + `"]}`)
+
+	// A planning turn may wait on jobs, but merging mutation receipts there
+	// would arm delivery sign-off demands the read-only turn cannot satisfy.
+	planLedger := evidence.NewLedger()
+	planCtx := planmode.WithActive(evidence.WithLedger(baseCtx, planLedger), true)
+	if _, err := (waitJob{}).Execute(planCtx, args); err != nil {
+		t.Fatalf("wait in plan mode: %v", err)
+	}
+	if planLedger.Summary().HasMutation() {
+		t.Fatal("plan-mode wait merged mutation evidence into the planning turn")
+	}
+
+	// The evidence stays on the job for the first normal turn to collect.
+	ledger := evidence.NewLedger()
+	normalCtx := planmode.WithActive(evidence.WithLedger(baseCtx, ledger), false)
+	if _, err := (waitJob{}).Execute(normalCtx, args); err != nil {
+		t.Fatalf("wait after plan mode: %v", err)
+	}
+	if !ledger.Summary().HasMutation() {
+		t.Fatal("plan-mode wait consumed the background evidence instead of deferring it")
 	}
 }
 


### PR DESCRIPTION
## Problem

A delivery-mode background writer could finish real edits but exhaust the final-answer readiness protocol. The job then failed, discarded its answer, and encouraged the parent to spawn repair tasks for work already present on disk.

Four mechanisms amplified the cascade:

1. Readiness exhaustion discarded finished work instead of surfacing it as unverified.
2. Structured review was enforced inside depth-capped children that might not have the review tools.
3. Background jobs run under a session-lifetime context, not the parent turn context, so child mutation receipts could not safely merge into the parent turn ledger.
4. Background writer starts used an unbounded, then advisory read-before-start limit that concurrent callers could overshoot.

## Fix

- **Salvage completed writes explicitly** (`internal/agent/task.go`): a non-review sub-agent that exhausts `FinalReadinessError` after a real successful mutation returns its last answer under an `[unverified]` host banner. Mutation-less claims and report-required review sub-agents still fail.
- **Defer structured review to the parent** (`internal/agent/capability_gate.go`): children still perform the light post-mutation inspection gate, while their parent owns `review_report` / `security_review`.
- **Carry background evidence across turns** (`internal/jobs/jobs.go`, `internal/tool/builtin/bgjobs.go`): a background task records receipts in an isolated ledger, publishes them to its job at terminal completion, and `wait` or terminal `bash_output` merges them exactly once into the collecting parent turn. Evidence is never written directly into a turn ledger from a background goroutine.
- **Lease background evidence until the collecting turn delivers** (`internal/jobs/jobs.go`, `internal/evidence/evidence.go`, `internal/tool/builtin/bgjobs.go`, `internal/agent/agent.go`): collection is a non-consuming lease, not a take. `wait`/`bash_output` merge a copy of a finished writer's receipts into the turn ledger and note the lease on it; the agent commits the leased jobs — clearing the in-memory copy and draining the persisted summary — only after the turn reaches a final answer past its delivery gates. A cancelled/errored turn, or a process exit before delivery, leaves the lease uncommitted, so the next turn (or a restart, since the disk summary survives) re-collects the mutation rather than shipping it unreviewed. A committed job returns empty so a re-poll after delivery does not re-demand review; within a turn the lease note dedupes repeat collection.
- **Recover mutation evidence after restart** (`internal/jobs/artifacts.go`, `internal/jobs/jobs.go`): completed task artifacts persist only a versioned mutation summary (risk + normalized paths), never receipt args, commands, or review contents. Restored mutations re-enter the delivery ledger without stale sign-off receipts, forcing fresh inspection, verification, and review. Any version this build cannot parse — a pre-feature artifact (`mutationEvidenceVersion` 0) or one written by a newer build — recovers as an opaque `RiskHigh` mutation: a missing summary only proves the mutation state was not recorded, not that a legacy background writer task collected after upgrade made no changes, so review must not be skipped. A same-version artifact with no summary recovers as no evidence — that build did record the state and found none.
- **Defer collection during plan mode** (`internal/tool/builtin/bgjobs.go`, `internal/planmode/context.go`): a planning turn may wait on jobs, but merging a finished writer's mutation receipts there would arm delivery sign-off demands (complete_step, verification, review) that a read-only turn cannot satisfy. Collection now skips without consuming while plan mode is active; the first normal turn merges the evidence. The plan-mode flag reaches the leaf builtin package through a new `planmode` context key mirrored by the agent's call-context constructor (importing `internal/agent` from builtin would cycle through the agent package's tests), with a regression test pinning both flags in lockstep.
- **Preserve evidence order** (`internal/agent/agent.go`): `wait` and `bash_output` now execute in serial tool-call segments because they can add child receipts to the ledger.
- **Keep opaque writes conservative** (`internal/evidence/risk.go`): path-less mutations remain `RiskHigh`; they still require review and security review. No broad security downgrade is used to solve the readiness cascade.
- **Enforce the writer cap atomically** (`internal/jobs/jobs.go`, `internal/agent/task.go`): at most three unfinished background `task` jobs may occupy a session. Concurrent starts reserve capacity atomically, and killed jobs continue to occupy a slot until their goroutine exits. Background job contexts retain their session scope.

## Behavior compatibility

| Surface | Old behavior | New behavior | Compatibility |
| --- | --- | --- | --- |
| Readiness exhaustion after a real child mutation | Job failed and answer was discarded | Job completes with an explicit `[unverified]` result | Intentional recovery behavior |
| Readiness exhaustion without mutation | Job failed | Unchanged | Safe |
| Report-required review/security child | Missing typed report fails | Unchanged | Safe |
| Background child receipts | Could not safely reach the collecting parent turn | Stored on the job, persisted as a sanitized mutation summary, and merged once by `wait` / terminal `bash_output` | Versioned optional artifact fields; see below |
| Evidence collection during plan mode | n/a (receipts were dropped anyway) | Deferred without consuming; first normal turn merges | Planning turns stay free of delivery sign-off demands |
| Opaque mutation risk | High | High | Unchanged security policy |
| Background writer starts | Unbounded/advisory | Atomic maximum of three unfinished tasks per session | Foreground tasks and background bash unchanged |
| Job/session persistence | Existing artifact metadata and logs | Task metadata adds optional versioned mutation evidence | Backward-safe for old artifacts and old binaries |

### Persisted-format compatibility

| Field | Old artifact behavior in new code | New artifact behavior in old code | Conclusion |
| --- | --- | --- | --- |
| `mutationEvidenceVersion` | Any unparseable version — pre-feature (0) or newer — recovers as a conservative opaque `RiskHigh` mutation; a same-version artifact with no summary recovers as no evidence | Ignored as an unknown JSON field | Safe; no decode failure or silent security downgrade |
| `mutationEvidence` (`risk`, `paths`) | Missing with version 1 means the task recorded no mutation | Ignored as an unknown JSON field | Safe; args, commands, file contents, and review reports are never persisted |

## Verification

- `go test ./...` - pass
- `go test ./internal/jobs ./internal/tool/builtin ./internal/evidence ./internal/agent -count=1` - pass
- Focused `go test -race` for atomic reservations, killed-job evidence, wait collection, and background salvage - pass
- `./scripts/cache-guard.sh` (`TestReleaseCacheHitGuard`) - pass
- `git diff --check` - pass

New coverage includes background salvage publication, within-turn exactly-once collection, collection after a ledger-less observer, killed-job exit ordering, atomic concurrent reservations, session context propagation, serial background result collectors, plan-mode deferral (`TestWaitInPlanModeDefersBackgroundEvidence`), call-context flag mirroring (`TestCallContextMirrorsPlanModeOntoLeafKey`), metadata privacy, high-risk recovery without downgrade, and — for the two findings this revision addresses — a failed collecting turn not committing the lease (`TestBackgroundEvidenceNotCommittedWhenTurnFails`), a delivered turn committing it (`TestBackgroundEvidenceCommittedWhenTurnDelivers`), an uncommitted lease surviving restart while a committed one does not (`TestLeasedEvidenceResurrectsUntilCommitted`, `TestLeaseEvidenceWaitsForKilledJobExit`), and legacy/unknown-version artifacts recovering as opaque high-risk (`TestLegacyTaskArtifactRecoversAsOpaqueHighRiskMutation`, `TestFutureVersionTaskArtifactRecoversAsOpaqueHighRiskMutation`).

## Cache and security impact

No system prompt, sub-agent prompt, tool schema, tool order, provider request serialization, or compaction behavior changes. Background evidence remains host-side and only joins a turn ledger when the result is collected. Completed task artifacts now add optional versioned mutation metadata containing only risk and normalized paths; receipt args, commands, file contents, and review reports are excluded. No new dependency, network access, privilege expansion, or secret-handling path is introduced.


Cache-impact: none - host-side background evidence, artifact metadata, and scheduling only; no provider-visible prefix, schema, order, or serialization change.
Cache-guard: ./scripts/cache-guard.sh (TestReleaseCacheHitGuard) passes on this branch.
System-prompt-review: reviewed by maintainer @SivanCola; no system prompt, sub-agent prompt, or tool schema text changes.

