### PR TITLE
fix(desktop): performance popup resume false positives and copy reliability / 修复性能弹窗恢复期误报与复制可靠性

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -4,7 +4,6 @@ import {
   aggregateLongTaskProfile,
   buildCrashPayload,
   buildPerformancePayload,
-  copyReportText,
   formatLongTaskAttribution,
   formatPerformanceContext,
   globalCrashReportReason,
@@ -22,6 +21,7 @@ import {
   type PerformanceSnapshot,
   type ProfilerTrace,
 } from "../lib/crash";
+import { writeClipboardText } from "../lib/clipboard";
 
 let passed = 0;
 let failed = 0;
@@ -226,8 +226,12 @@ eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag 
 eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
 eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");
 eq(shouldRecordEventLoopLagSample(false, 60_000, false), false, "ignores event-loop lag while unfocused");
-eq(shouldRecordEventLoopLagSample(false, 60_000, true, 29_000), true, "records large lag spikes while visible and focused");
-eq(shouldRecordEventLoopLagSample(false, 60_000, true, 30_000), false, "treats suspension-scale lag readings as paused timers, not jank");
+eq(
+  shouldRecordEventLoopLagSample(false, 60_000, true, 3_000),
+  false,
+  "ignores event-loop lag immediately after focus resumes",
+);
+eq(shouldRecordEventLoopLagSample(false, 60_000, true, 6_000), true, "records event-loop lag once both resume grace windows pass");
 
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false), true, "prompts an unhandled label past cooldown while visible");
 eq(shouldPromptForPerformanceLabel(true, 11 * 60_000, false), false, "suppresses an already reported or dismissed label");
@@ -238,15 +242,21 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
 {
   let interval: (() => void) | undefined;
   let now = 0;
+  let focused = true;
   let promptPainted = false;
   const previousWindow = (globalThis as any).window;
   const previousDocument = (globalThis as any).document;
   const previousPerformance = (globalThis as any).performance;
   const previousPerformanceObserver = (globalThis as any).PerformanceObserver;
   (globalThis as any).performance = { now: () => now };
+  // Listeners are intentionally no-ops: this exercises the sampler's own
+  // hidden/unfocused self-observation, i.e. the case where a throttled tick
+  // runs before the visibilitychange/focus task is delivered (the race behind
+  // the field reports #6419/#5909).
   (globalThis as any).window = {
     runtime: {},
     location: { protocol: "app:", host: "test", pathname: "/", hash: "" },
+    addEventListener: () => {},
     setInterval: (cb: () => void) => {
       interval = cb;
       return 1;
@@ -254,7 +264,7 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   };
   (globalThis as any).document = {
     visibilityState: "visible",
-    hasFocus: () => true,
+    hasFocus: () => focused,
     addEventListener: () => {},
     getElementById: () => {
       promptPainted = true;
@@ -274,18 +284,16 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   interval?.(); // records a 0ms sample in the steady visible state
   (globalThis as any).document.visibilityState = "hidden";
   now = 47_000;
-  interval?.(); // hidden tick: observed hidden, sample dropped
+  interval?.(); // hidden tick: observed hidden, sample dropped (visibilitychange never delivered)
   (globalThis as any).document.visibilityState = "visible";
   now = 49_500;
   try {
-    interval?.(); // resume-boundary tick, 1.5s overdue, visibilitychange never ran
+    interval?.(); // resume-boundary tick, 1.5s overdue, visibilitychange still not delivered
   } catch {
     // a regressed sampler paints into the stubbed DOM and throws; the eq below reports it
   }
   eq(promptPainted, false, "resume-boundary tick does not report suspended-timer delay as event-loop lag");
 
-  // The restarted visible window must not permanently mute the detector:
-  // sustained lag while visible and past the resume grace still prompts.
   now = 50_500;
   interval?.(); // re-primes after the restart
   now = 51_500;
@@ -296,18 +304,48 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   interval?.();
   now = 54_500;
   interval?.(); // grace over, steady 0ms samples resume
+
+  // Focus-only cycle, self-observed: the window loses focus (a throttled tick
+  // observes it before any blur task), the app naps, and on refocus the overdue
+  // tick runs before the focus task. Without focus tracking this reads as a
+  // multi-second lag spike and prompts (the #6138 path #6424 must absorb).
+  focused = false;
+  now = 59_000;
+  interval?.(); // unfocused tick: arms the resume restart, records nothing
+  focused = true;
+  now = 61_500;
+  try {
+    interval?.(); // refocus-boundary tick, 1.5s overdue, focus task not yet delivered
+  } catch {
+    // a regressed sampler paints into the stubbed DOM and throws; the eq below reports it
+  }
+  eq(promptPainted, false, "refocus-boundary tick does not report napped-timer delay as event-loop lag");
+
+  now = 62_600;
+  interval?.(); // re-primes
+  now = 63_600;
+  interval?.();
+  now = 64_600;
+  interval?.();
+  now = 65_600;
+  interval?.();
+  now = 66_600;
+  interval?.(); // both grace windows over, steady samples resume
+
+  // A severe main-thread freeze while visible, focused, and settled must still
+  // produce a report — there is deliberately no absolute duration cap.
   let promptAttempted = false;
   (globalThis as any).document.getElementById = () => {
     promptAttempted = true;
     throw new Error("stop before painting into the stubbed DOM");
   };
-  now = 57_000;
+  now = 112_600;
   try {
-    interval?.(); // 1.5s late while visible and settled: a genuine lag spike
+    interval?.(); // 45s late with no visibility or focus transition: a real freeze
   } catch {
     // paint intentionally stopped at getElementById
   }
-  eq(promptAttempted, true, "sustained visible lag past the restarted grace window still prompts");
+  eq(promptAttempted, true, "a severe settled-state freeze still prompts (no absolute suspension cap)");
   (globalThis as any).window = previousWindow;
   (globalThis as any).document = previousDocument;
   (globalThis as any).performance = previousPerformance;
@@ -322,23 +360,41 @@ eq([...parseReportedPerf("{not json", "abc123")], [], "tolerates corrupt storage
 
 {
   const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const previousWindow = (globalThis as any).window;
+  const previousHTMLElement = (globalThis as any).HTMLElement;
   const setNavigator = (value: unknown) =>
     Object.defineProperty(globalThis, "navigator", { value, configurable: true });
 
   setNavigator({ clipboard: { writeText: async () => {} } });
-  eq(await copyReportText("report"), true, "copy reports success through the async clipboard API");
+  eq(await writeClipboardText("report"), true, "copy reports success through the async clipboard API");
 
-  setNavigator({
+  const rejectingClipboard = {
     clipboard: {
       writeText: async () => {
         throw new Error("denied");
       },
     },
-  });
-  eq(await copyReportText("report"), false, "copy reports failure when the clipboard rejects and no DOM fallback exists");
+  };
+  setNavigator(rejectingClipboard);
+  let bridgeCalls = 0;
+  (globalThis as any).window = {
+    runtime: {
+      ClipboardSetText: async (value: string) => {
+        bridgeCalls += 1;
+        return value.length > 0;
+      },
+    },
+  };
+  eq(await writeClipboardText("report"), true, "copy falls back to the Wails native clipboard bridge when the clipboard API rejects");
+  eq(bridgeCalls, 1, "the rejected clipboard write goes through the native bridge exactly once");
 
+  setNavigator(rejectingClipboard);
   const execCommands: string[] = [];
+  (globalThis as any).window = {};
+  (globalThis as any).HTMLElement = class {};
   (globalThis as any).document = {
+    activeElement: undefined,
+    getSelection: () => null,
     createElement: () => ({ value: "", style: {}, setAttribute: () => {}, select: () => {}, remove: () => {} }),
     body: { appendChild: () => {} },
     execCommand: (command: string) => {
@@ -346,10 +402,13 @@ eq([...parseReportedPerf("{not json", "abc123")], [], "tolerates corrupt storage
       return true;
     },
   };
-  eq(await copyReportText("report"), true, "copy falls back to execCommand when the clipboard write is rejected");
-  eq(execCommands, ["copy"], "fallback drives the execCommand copy path");
+  eq(await writeClipboardText("report"), true, "copy falls back to execCommand when both the clipboard API and bridge are unavailable");
+  eq(execCommands, ["copy"], "the last-resort path drives the execCommand copy");
   delete (globalThis as any).document;
 
+  (globalThis as any).window = previousWindow;
+  if (previousHTMLElement === undefined) delete (globalThis as any).HTMLElement;
+  else (globalThis as any).HTMLElement = previousHTMLElement;
   if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
   else delete (globalThis as any).navigator;
 }

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -404,6 +404,30 @@ eq([...parseReportedPerf("{not json", "abc123")], [], "tolerates corrupt storage
   };
   eq(await writeClipboardText("report"), true, "copy falls back to execCommand when both the clipboard API and bridge are unavailable");
   eq(execCommands, ["copy"], "the last-resort path drives the execCommand copy");
+
+  // Some WebViews reject execCommand("copy") with NotAllowedError. It must
+  // surface as a resolved `false`, never a thrown rejection — otherwise the crash
+  // overlay's Copy button stays disabled (the #6388 unresponsive symptom).
+  let removed = false;
+  (globalThis as any).document = {
+    activeElement: undefined,
+    getSelection: () => null,
+    createElement: () => ({ value: "", style: {}, setAttribute: () => {}, select: () => {}, remove: () => { removed = true; } }),
+    body: { appendChild: () => {} },
+    execCommand: () => {
+      throw new DOMException("not allowed", "NotAllowedError");
+    },
+  };
+  let threw = false;
+  let result: boolean | undefined;
+  try {
+    result = await writeClipboardText("report");
+  } catch {
+    threw = true;
+  }
+  eq(threw, false, "writeClipboardText never rejects when execCommand throws");
+  eq(result, false, "an execCommand that throws resolves to a failed copy");
+  eq(removed, true, "the hidden textarea is still cleaned up when execCommand throws");
   delete (globalThis as any).document;
 
   (globalThis as any).window = previousWindow;

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateLongTaskProfile,
   buildCrashPayload,
   buildPerformancePayload,
+  copyReportText,
   formatLongTaskAttribution,
   formatPerformanceContext,
   globalCrashReportReason,
@@ -225,6 +226,8 @@ eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag 
 eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
 eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");
 eq(shouldRecordEventLoopLagSample(false, 60_000, false), false, "ignores event-loop lag while unfocused");
+eq(shouldRecordEventLoopLagSample(false, 60_000, true, 29_000), true, "records large lag spikes while visible and focused");
+eq(shouldRecordEventLoopLagSample(false, 60_000, true, 30_000), false, "treats suspension-scale lag readings as paused timers, not jank");
 
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false), true, "prompts an unhandled label past cooldown while visible");
 eq(shouldPromptForPerformanceLabel(true, 11 * 60_000, false), false, "suppresses an already reported or dismissed label");
@@ -243,6 +246,7 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   (globalThis as any).performance = { now: () => now };
   (globalThis as any).window = {
     runtime: {},
+    location: { protocol: "app:", host: "test", pathname: "/", hash: "" },
     setInterval: (cb: () => void) => {
       interval = cb;
       return 1;
@@ -262,6 +266,48 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   now = 26_000;
   interval?.();
   eq(promptPainted, false, "first post-grace event-loop tick primes without reporting startup backlog");
+
+  // Hidden-view timer throttling defers ticks; when the view is shown again the
+  // overdue tick can run before any visibilitychange handler. The accumulated
+  // delay must read as suspension, not as an event-loop lag report.
+  now = 27_000;
+  interval?.(); // records a 0ms sample in the steady visible state
+  (globalThis as any).document.visibilityState = "hidden";
+  now = 47_000;
+  interval?.(); // hidden tick: observed hidden, sample dropped
+  (globalThis as any).document.visibilityState = "visible";
+  now = 49_500;
+  try {
+    interval?.(); // resume-boundary tick, 1.5s overdue, visibilitychange never ran
+  } catch {
+    // a regressed sampler paints into the stubbed DOM and throws; the eq below reports it
+  }
+  eq(promptPainted, false, "resume-boundary tick does not report suspended-timer delay as event-loop lag");
+
+  // The restarted visible window must not permanently mute the detector:
+  // sustained lag while visible and past the resume grace still prompts.
+  now = 50_500;
+  interval?.(); // re-primes after the restart
+  now = 51_500;
+  interval?.();
+  now = 52_500;
+  interval?.();
+  now = 53_500;
+  interval?.();
+  now = 54_500;
+  interval?.(); // grace over, steady 0ms samples resume
+  let promptAttempted = false;
+  (globalThis as any).document.getElementById = () => {
+    promptAttempted = true;
+    throw new Error("stop before painting into the stubbed DOM");
+  };
+  now = 57_000;
+  try {
+    interval?.(); // 1.5s late while visible and settled: a genuine lag spike
+  } catch {
+    // paint intentionally stopped at getElementById
+  }
+  eq(promptAttempted, true, "sustained visible lag past the restarted grace window still prompts");
   (globalThis as any).window = previousWindow;
   (globalThis as any).document = previousDocument;
   (globalThis as any).performance = previousPerformance;
@@ -273,6 +319,40 @@ eq([...parseReportedPerf(reportedPerf, "abc123")], ["performance.lag"], "round-t
 eq([...parseReportedPerf(reportedPerf, "def456")], [], "re-surfaces reported labels on a new build");
 eq([...parseReportedPerf(null, "abc123")], [], "tolerates missing storage");
 eq([...parseReportedPerf("{not json", "abc123")], [], "tolerates corrupt storage");
+
+{
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const setNavigator = (value: unknown) =>
+    Object.defineProperty(globalThis, "navigator", { value, configurable: true });
+
+  setNavigator({ clipboard: { writeText: async () => {} } });
+  eq(await copyReportText("report"), true, "copy reports success through the async clipboard API");
+
+  setNavigator({
+    clipboard: {
+      writeText: async () => {
+        throw new Error("denied");
+      },
+    },
+  });
+  eq(await copyReportText("report"), false, "copy reports failure when the clipboard rejects and no DOM fallback exists");
+
+  const execCommands: string[] = [];
+  (globalThis as any).document = {
+    createElement: () => ({ value: "", style: {}, setAttribute: () => {}, select: () => {}, remove: () => {} }),
+    body: { appendChild: () => {} },
+    execCommand: (command: string) => {
+      execCommands.push(command);
+      return true;
+    },
+  };
+  eq(await copyReportText("report"), true, "copy falls back to execCommand when the clipboard write is rejected");
+  eq(execCommands, ["copy"], "fallback drives the execCommand copy path");
+  delete (globalThis as any).document;
+
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else delete (globalThis as any).navigator;
+}
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/clipboard.ts
+++ b/desktop/frontend/src/lib/clipboard.ts
@@ -45,6 +45,11 @@ export function fallbackCopyText(value: string): boolean {
   let ok = false;
   try {
     ok = document.execCommand("copy");
+  } catch {
+    // Some WebViews reject execCommand("copy") with NotAllowedError instead of
+    // returning false; treat that as a failed copy, never a thrown rejection, so
+    // callers (and writeClipboardText's Promise<boolean> contract) stay honored.
+    ok = false;
   } finally {
     textarea.remove();
     if (selection) {

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -611,12 +611,22 @@ function copyButton(text: string, className: string): HTMLButtonElement {
   copy.textContent = t("crash.copy");
   copy.onclick = async () => {
     copy.disabled = true;
-    const copied = await writeClipboardText(text);
-    copy.textContent = copied ? t("crash.copied") : t("crash.copyFailed");
-    copy.disabled = false;
-    window.setTimeout(() => {
-      copy.textContent = t("crash.copy");
-    }, COPY_FEEDBACK_MS);
+    let copied = false;
+    // The crash overlay is the last-resort surface, so the button must re-enable
+    // even if the clipboard path throws unexpectedly — a stuck disabled Copy is
+    // exactly the #6388 unresponsive symptom. Catch so a rejection can't escape as
+    // an unhandledrejection into the global crash handler either.
+    try {
+      copied = await writeClipboardText(text);
+    } catch {
+      copied = false;
+    } finally {
+      copy.textContent = copied ? t("crash.copied") : t("crash.copyFailed");
+      copy.disabled = false;
+      window.setTimeout(() => {
+        copy.textContent = t("crash.copy");
+      }, COPY_FEEDBACK_MS);
+    }
   };
   return copy;
 }

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -2,6 +2,7 @@
 // whole tree (blank window), and global errors/rejections leave no trace either.
 
 import { addBreadcrumb, dumpBreadcrumbs, snapshotBreadcrumbs, type Breadcrumb } from "./breadcrumbs";
+import { writeClipboardText } from "./clipboard";
 import { t } from "./i18n";
 
 declare const __BUILD_COMMIT__: string;
@@ -117,10 +118,6 @@ const STARTUP_GRACE_MS = 15_000;
 const PROMPT_COOLDOWN_MS = 10 * 60_000;
 const MAX_LAG_SAMPLES = 60;
 const VISIBILITY_RESUME_GRACE_MS = 5_000;
-// Timer callbacks that were suspended (hidden-view throttling, system sleep, debugger
-// pauses) report the whole pause as "lag" when they finally run; past this bound the
-// reading describes scheduler suspension rather than main-thread jank.
-const EVENT_LOOP_SUSPEND_LAG_MS = 30_000;
 
 const longTasks: LongTaskSample[] = [];
 const lagSamples: number[] = [];
@@ -516,12 +513,11 @@ export function shouldRecordEventLoopLagSample(
   visibilityHidden: boolean,
   msSinceVisible: number,
   focused = true,
-  lagMs = 0,
+  msSinceFocused = msSinceVisible,
 ): boolean {
   if (!focused) return false;
   if (visibilityHidden) return false;
-  if (lagMs >= EVENT_LOOP_SUSPEND_LAG_MS) return false;
-  return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS;
+  return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS && msSinceFocused >= VISIBILITY_RESUME_GRACE_MS;
 }
 
 export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPayload {
@@ -609,47 +605,13 @@ function sendButton(
 
 const COPY_FEEDBACK_MS = 2_000;
 
-function fallbackCopyToClipboard(text: string): boolean {
-  if (typeof document === "undefined") return false;
-  const area = document.createElement("textarea");
-  area.value = text;
-  area.setAttribute("readonly", "");
-  area.style.position = "fixed";
-  area.style.opacity = "0";
-  document.body.appendChild(area);
-  area.select();
-  let copied = false;
-  try {
-    copied = document.execCommand("copy");
-  } catch {
-    copied = false;
-  }
-  area.remove();
-  return copied;
-}
-
-// WebViews can leave navigator.clipboard undefined or reject writes (focus and
-// permission rules differ per platform), so fall back to an execCommand copy.
-export async function copyReportText(text: string): Promise<boolean> {
-  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
-  try {
-    if (clipboard?.writeText) {
-      await clipboard.writeText(text);
-      return true;
-    }
-  } catch {
-    // fall through to the legacy path
-  }
-  return fallbackCopyToClipboard(text);
-}
-
 function copyButton(text: string, className: string): HTMLButtonElement {
   const copy = document.createElement("button");
   copy.className = className;
   copy.textContent = t("crash.copy");
   copy.onclick = async () => {
     copy.disabled = true;
-    const copied = await copyReportText(text);
+    const copied = await writeClipboardText(text);
     copy.textContent = copied ? t("crash.copied") : t("crash.copyFailed");
     copy.disabled = false;
     window.setTimeout(() => {
@@ -837,13 +799,15 @@ export function installPerformancePressureMonitor() {
   const isHidden = () => typeof document !== "undefined" && document.visibilityState === "hidden";
   const isFocused = () => typeof document === "undefined" || document.hasFocus?.() !== false;
   let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
+  let focusedSince = isFocused() ? startedAt : Number.POSITIVE_INFINITY;
   let expected = performance.now() + 1000;
   let eventLoopLagPrimed = false;
-  // When the view is shown again, overdue timer callbacks can run before the queued
-  // visibilitychange task, so visibleSince may still describe the previous visible
-  // period at that point. The sampler tracks hidden observations itself and restarts
-  // the visible window on the first visible tick instead of trusting visibleSince.
-  let pendingResume = isHidden();
+  // When the view is shown or focused again, overdue timer callbacks can run before
+  // the queued visibilitychange/focus task, so visibleSince/focusedSince may still
+  // describe the previous settled period at that point. The sampler tracks hidden and
+  // unfocused observations itself and restarts both windows on the first settled tick
+  // instead of trusting the listener-maintained timestamps.
+  let pendingResume = isHidden() || !isFocused();
 
   const pastGrace = () => performance.now() >= graceUntil;
   const inspectLongTasks = () => {
@@ -857,20 +821,24 @@ export function installPerformancePressureMonitor() {
 
   startLongTaskProfiler();
 
+  // Blur/hide park the timestamps at +Infinity so a stale read before the matching
+  // resume listener has run can never satisfy the grace windows.
+  const resetSamples = () => {
+    const now = performance.now();
+    longTasks.length = 0;
+    lagSamples.length = 0;
+    expected = now + 1000;
+    eventLoopLagPrimed = false;
+    visibleSince = isHidden() ? Number.POSITIVE_INFINITY : now;
+    focusedSince = isFocused() ? now : Number.POSITIVE_INFINITY;
+    pendingResume = isHidden() || !isFocused();
+  };
+
   if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", () => {
-      longTasks.length = 0;
-      lagSamples.length = 0;
-      expected = performance.now() + 1000;
-      eventLoopLagPrimed = false;
-      if (isHidden()) {
-        pendingResume = true;
-      } else {
-        visibleSince = performance.now();
-        pendingResume = false;
-      }
-    });
+    document.addEventListener("visibilitychange", resetSamples);
   }
+  window.addEventListener("focus", resetSamples);
+  window.addEventListener("blur", resetSamples);
 
   if (typeof PerformanceObserver !== "undefined") {
     try {
@@ -898,11 +866,12 @@ export function installPerformancePressureMonitor() {
 
   window.setInterval(() => {
     const now = performance.now();
-    if (isHidden()) {
+    if (isHidden() || !isFocused()) {
       pendingResume = true;
     } else if (pendingResume) {
       pendingResume = false;
       visibleSince = now;
+      focusedSince = now;
       longTasks.length = 0;
       lagSamples.length = 0;
       expected = now + 1000;
@@ -920,7 +889,7 @@ export function installPerformancePressureMonitor() {
     }
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
-    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused(), lagMs)) return;
+    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused(), now - focusedSince)) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -117,6 +117,10 @@ const STARTUP_GRACE_MS = 15_000;
 const PROMPT_COOLDOWN_MS = 10 * 60_000;
 const MAX_LAG_SAMPLES = 60;
 const VISIBILITY_RESUME_GRACE_MS = 5_000;
+// Timer callbacks that were suspended (hidden-view throttling, system sleep, debugger
+// pauses) report the whole pause as "lag" when they finally run; past this bound the
+// reading describes scheduler suspension rather than main-thread jank.
+const EVENT_LOOP_SUSPEND_LAG_MS = 30_000;
 
 const longTasks: LongTaskSample[] = [];
 const lagSamples: number[] = [];
@@ -512,9 +516,11 @@ export function shouldRecordEventLoopLagSample(
   visibilityHidden: boolean,
   msSinceVisible: number,
   focused = true,
+  lagMs = 0,
 ): boolean {
   if (!focused) return false;
   if (visibilityHidden) return false;
+  if (lagMs >= EVENT_LOOP_SUSPEND_LAG_MS) return false;
   return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS;
 }
 
@@ -592,11 +598,65 @@ function sendButton(
       await report(payload.kind, JSON.stringify(payload));
       send.textContent = t("crash.sent");
       onSent?.();
-    } catch {
+    } catch (err) {
       send.textContent = t("crash.sendFailed");
+      send.title = err instanceof Error ? err.message : String(err);
+      send.disabled = false;
     }
   };
   return send;
+}
+
+const COPY_FEEDBACK_MS = 2_000;
+
+function fallbackCopyToClipboard(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const area = document.createElement("textarea");
+  area.value = text;
+  area.setAttribute("readonly", "");
+  area.style.position = "fixed";
+  area.style.opacity = "0";
+  document.body.appendChild(area);
+  area.select();
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+  area.remove();
+  return copied;
+}
+
+// WebViews can leave navigator.clipboard undefined or reject writes (focus and
+// permission rules differ per platform), so fall back to an execCommand copy.
+export async function copyReportText(text: string): Promise<boolean> {
+  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  try {
+    if (clipboard?.writeText) {
+      await clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  return fallbackCopyToClipboard(text);
+}
+
+function copyButton(text: string, className: string): HTMLButtonElement {
+  const copy = document.createElement("button");
+  copy.className = className;
+  copy.textContent = t("crash.copy");
+  copy.onclick = async () => {
+    copy.disabled = true;
+    const copied = await copyReportText(text);
+    copy.textContent = copied ? t("crash.copied") : t("crash.copyFailed");
+    copy.disabled = false;
+    window.setTimeout(() => {
+      copy.textContent = t("crash.copy");
+    }, COPY_FEEDBACK_MS);
+  };
+  return copy;
 }
 
 function paintPerformancePrompt(payload: CrashPayload, snapshot: PerformanceSnapshot) {
@@ -616,10 +676,7 @@ function paintPerformancePrompt(payload: CrashPayload, snapshot: PerformanceSnap
   const actions = document.createElement("div");
   actions.className = "performance-report__actions";
   const send = sendButton(payload, "performance-report__send", () => markPerfReported(payload.label));
-  const copy = document.createElement("button");
-  copy.className = "performance-report__copy";
-  copy.textContent = t("crash.copy");
-  copy.onclick = () => void navigator.clipboard?.writeText(payload.message);
+  const copy = copyButton(payload.message, "performance-report__copy");
   const dismiss = document.createElement("button");
   dismiss.className = "performance-report__dismiss";
   dismiss.textContent = t("performanceReport.dismiss");
@@ -648,10 +705,7 @@ function paint(payload: CrashPayload) {
   const body = document.createElement("pre");
   body.className = "crash-overlay__body";
   body.textContent = payload.message;
-  const copy = document.createElement("button");
-  copy.className = "crash-overlay__copy";
-  copy.textContent = t("crash.copy");
-  copy.onclick = () => void navigator.clipboard?.writeText(payload.message);
+  const copy = copyButton(payload.message, "crash-overlay__copy");
   const actions = document.createElement("div");
   actions.className = "crash-overlay__actions";
   const send = sendButton(payload);
@@ -785,6 +839,11 @@ export function installPerformancePressureMonitor() {
   let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
   let expected = performance.now() + 1000;
   let eventLoopLagPrimed = false;
+  // When the view is shown again, overdue timer callbacks can run before the queued
+  // visibilitychange task, so visibleSince may still describe the previous visible
+  // period at that point. The sampler tracks hidden observations itself and restarts
+  // the visible window on the first visible tick instead of trusting visibleSince.
+  let pendingResume = isHidden();
 
   const pastGrace = () => performance.now() >= graceUntil;
   const inspectLongTasks = () => {
@@ -804,7 +863,12 @@ export function installPerformancePressureMonitor() {
       lagSamples.length = 0;
       expected = performance.now() + 1000;
       eventLoopLagPrimed = false;
-      if (!isHidden()) visibleSince = performance.now();
+      if (isHidden()) {
+        pendingResume = true;
+      } else {
+        visibleSince = performance.now();
+        pendingResume = false;
+      }
     });
   }
 
@@ -834,6 +898,17 @@ export function installPerformancePressureMonitor() {
 
   window.setInterval(() => {
     const now = performance.now();
+    if (isHidden()) {
+      pendingResume = true;
+    } else if (pendingResume) {
+      pendingResume = false;
+      visibleSince = now;
+      longTasks.length = 0;
+      lagSamples.length = 0;
+      expected = now + 1000;
+      eventLoopLagPrimed = false;
+      return;
+    }
     if (!pastGrace()) {
       expected = now + 1000;
       return;
@@ -845,7 +920,7 @@ export function installPerformancePressureMonitor() {
     }
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
-    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused())) return;
+    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused(), lagMs)) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2289,6 +2289,8 @@ export const en = {
   // crash page
   "crash.title": "Reasonix hit an error — send us the report, or copy it",
   "crash.copy": "Copy",
+  "crash.copied": "Copied",
+  "crash.copyFailed": "Copy failed — select the report text and copy manually",
   "crash.send": "Send report",
   "crash.sending": "Sending…",
   "crash.sent": "Sent — thanks!",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1507,6 +1507,8 @@ export const zhTW: Record<DictKey, string> = {
   // 崩潰兜底頁
   "crash.title": "Reasonix 遇到錯誤 —— 請截圖傳送",
   "crash.copy": "複製",
+  "crash.copied": "已複製",
+  "crash.copyFailed": "複製失敗 —— 請手動選取上方文字複製",
 
   // 模擬/演示種子資料（僅瀏覽器開發模式）
   "mock.sessionFixLogin": "fix the login bug in auth.go",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2291,6 +2291,8 @@ export const zh: Record<DictKey, string> = {
   // 崩溃兜底页
   "crash.title": "Reasonix 遇到错误 —— 可以一键发送报告，或复制后反馈",
   "crash.copy": "复制",
+  "crash.copied": "已复制",
+  "crash.copyFailed": "复制失败 —— 请手动选择上方文本复制",
   "crash.send": "发送报告",
   "crash.sending": "发送中…",
   "crash.sent": "已发送，谢谢！",


### PR DESCRIPTION
## Problem

Desktop users get an unprompted `[performance.lag]` popup right after switching back to the app (#6419, #5909; the follow-up comments on #5306 show the same signature). The reports share one shape: `event loop lag NNNNms` with `avg == current` over very few samples, hours of uptime, and breadcrumbs ending in a `[view] hidden` transition with no `[view] visible` line before the event.

Separately, the popup's Copy button gives no feedback and can silently fail in WebViews, and a failed Send stays disabled with no reason shown (#6388).

## Root cause

When the view is shown or refocused, WebKit can run overdue timer callbacks **before** the queued `visibilitychange` / `focus` task. The lag sampler's tick then observes `visibilityState === "visible"` (and `hasFocus() === true`) while `visibleSince` / `focusedSince` still describe the *previous* settled period, so the resume-grace check passes and the accumulated background-throttling delay is recorded as a lag sample — instantly crossing the 1200ms prompt threshold. The missing `[view] visible` breadcrumb in the field reports confirms the popup fired before the transition handler ran.

## Fix

This PR is the integration point for the resume-lag work. It absorbs the focus-resume mechanism from #6138 (thanks @GTC2080) and reuses the existing three-tier clipboard helper (the approach from #5745, thanks @ttmouse) rather than re-rolling either.

- **Visibility + focus resume**: `shouldRecordEventLoopLagSample` now requires *both* the visibility-resume and focus-resume grace windows (`msSinceFocused`) to pass. `focus`/`blur` join `visibilitychange` on a shared `resetSamples`, which parks `visibleSince`/`focusedSince` at `+Infinity` while hidden/blurred so a stale pre-listener read can never satisfy the grace.
- **Listener-independent self-heal**: the sampler tick tracks hidden/unfocused observations itself (`pendingResume`). The first settled tick after any hidden/unfocused observation restarts both windows and records nothing — so the fix holds even when the throttled tick runs before the transition task (the actual race), not just when the listener wins.
- **No absolute duration cap**: suppression is driven entirely by visibility/focus state, never by lag magnitude. A genuine multi-second main-thread freeze while visible, focused, and settled still produces a report.
- **Clipboard**: the popup Copy button now goes through `writeClipboardText` (async Clipboard API → `window.runtime.ClipboardSetText` Wails bridge → hidden-textarea `execCommand`), with `Copied` / `Copy failed` states (new locale keys en/zh/zh-TW). A failed Send re-enables with the failure reason as tooltip so it can be retried.

## Verification

- `pnpm --dir desktop/frontend test` — full suite green (crash-reporting: 73/73), plus `tsc --noEmit -p tsconfig.test.json` and `check:css` clean.
- New regression coverage drives the sampler through hidden→resume **and** blur→refocus with the transition task deliberately never delivered (the race window): both boundary ticks must not prompt, and a 45s settled-state freeze must still prompt. Clipboard tests pin the native-bridge fallback (`bridgeCalls === 1`) and the execCommand last resort.
- Mutation checks: removing the focus grace, removing the tick's focus self-observation, or reintroducing an absolute lag cap each fails exactly the corresponding assertion; the full suite is green only with all three in place.

## Compatibility

Frontend-only. No persisted formats, provider-visible surfaces, or Wails contracts change; prompt thresholds and the existing hidden/unfocused suppression are untouched.

Refs #6419, #5909, #6388. Integrates the mechanisms proposed in #6138 and #5745 — see the commit `Co-authored-by` trailers.