### PR TITLE
fix(serve): keep transcript scrollable during streaming output / 修复网页版流式输出期间无法向上滚动查看历史内容

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -948,15 +948,20 @@ function post(path, body) {
 }
 // Follow streaming output only while the user is pinned to the bottom of the
 // transcript; scrolling up detaches so history stays readable mid-stream.
-// force re-pins (own message sent, session loaded, blocking action prompts
-// such as approval/ask — they require user action and their key handler is
-// document-level, so they must never sit off-screen). Scrolls are instant: a
-// smooth animation lags behind rapid chunks, and its intermediate positions
-// would read as "not at bottom" and break pin detection.
+// Detach triggers on wheel intent (any upward notch on scrollable content),
+// not only on position: during fast streaming every frame re-bottoms the
+// viewport, so a slow trackpad drag would never accumulate the 40px position
+// delta. force re-pins (own message sent, session loaded, action prompts,
+// click feedback) and wins over a concurrent user scroll — an approval needs
+// a decision and its key handler is document-level, so it must not sit
+// off-screen. Scrolls are instant: a smooth animation lags behind rapid
+// chunks, and its intermediate positions would read as "not at bottom" and
+// break pin detection.
 let pinnedToBottom=true;
 function atBottom() { return log.scrollHeight-log.scrollTop-log.clientHeight<40; }
 log.addEventListener('scroll',()=>{pinnedToBottom=atBottom();});
-function scrollDown(force) { if(force)pinnedToBottom=true; if(!pinnedToBottom)return; requestAnimationFrame(()=>{if(!pinnedToBottom)return; log.scrollTo({top:log.scrollHeight,behavior:'instant'});});}
+log.addEventListener('wheel',e=>{if(e.deltaY<0&&log.scrollHeight>log.clientHeight)pinnedToBottom=false;},{passive:true});
+function scrollDown(force) { if(force)pinnedToBottom=true; if(!pinnedToBottom)return; requestAnimationFrame(()=>{if(force)pinnedToBottom=true; else if(!pinnedToBottom)return; log.scrollTo({top:log.scrollHeight,behavior:'instant'});});}
 function hideWelcome() { if(welcome) welcome.style.display='none';}
 function showWelcome() { if(welcome) welcome.style.display='';}
 // Global single-key shortcuts must stay dead while the user is typing (the
@@ -992,7 +997,7 @@ function showNotice(text, tone) {
   hideWelcome();
   const n=el('div','notice'+(tone==='warn'?' notice--warn':''),text);
   log.appendChild(n);
-  scrollDown();
+  scrollDown(true); // synchronous feedback to a user action — always reveal
 }
 function updateActionAvailability() {
   setActionDisabled('btn-compact', running || !hasVisibleHistory, running ? __('thinking') : __('no_conversation'));
@@ -1155,6 +1160,12 @@ function dangerousBashCommand(command) {
     || /^dd\s+if=/.test(command)
     || /^fdisk\b/.test(command);
 }
+// A turn's approval/ask prompts die with the turn: cancel (composer Esc, stop
+// button) or turn end must remove the cards and their key listeners, or a
+// stale card keeps soliciting a decision for a dead request and the approval
+// key listener would resolve it on a later unrelated keypress.
+let pendingPrompts=[];
+function clearPendingPrompts(){pendingPrompts.splice(0).forEach(fn=>fn());}
 function showApproval(a) {
   const d=el('div','approval');
   const prefix = a.tool === 'bash' ? bashCommandPrefix(a.subject) : '';
@@ -1173,7 +1184,9 @@ function showApproval(a) {
   actions.push('<button class="approval__btn approval__btn--deny" data-allow="false"><span class="approval__key">N</span> '+__('deny')+'</button>');
   d.innerHTML='<div class="approval__header"><svg class="approval__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><span class="approval__title">'+__('approval_title')+'</span></div><div class="approval__subject">'+escHtml(a.tool)+(a.subject?' — '+escHtml(a.subject):'')+'</div><div class="approval__actions">'+actions.join('')+'</div>';
   log.appendChild(d);scrollDown(true);
-  const resolve=payload=>{post('/approve',Object.assign({id:a.id},payload));d.remove();document.removeEventListener('keydown',onkey);};
+  const cleanup=()=>{pendingPrompts=pendingPrompts.filter(f=>f!==cleanup);d.remove();document.removeEventListener('keydown',onkey);};
+  pendingPrompts.push(cleanup);
+  const resolve=payload=>{post('/approve',Object.assign({id:a.id},payload));cleanup();};
   d.querySelectorAll('.approval__btn').forEach(btn=>{btn.onclick=()=>resolve({allow:btn.dataset.allow==='true',session:btn.dataset.session==='true',persist:btn.dataset.persist==='true',scope:btn.dataset.scope||''});});
   const onkey=e=>{if(!isPlainKey(e))return; const k=e.key.toLowerCase();if(k==='y'||k==='1'){resolve({allow:true,session:false});}else if(k==='a'||k==='2'){resolve({allow:true,session:true});}else if(hasPrefix&&k==='3'){resolve({allow:true,session:true,scope:'prefix'});}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){resolve({allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''});}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){resolve({allow:false,session:false});}};
   document.addEventListener('keydown',onkey);
@@ -1182,6 +1195,7 @@ function showApproval(a) {
 // ── ask ──
 function showAsk(ask) {
   const d=el('div','ask');
+  const cleanup=()=>{pendingPrompts=pendingPrompts.filter(f=>f!==cleanup);d.remove();};
   ask.questions.forEach(q=>{
     const qDiv=el('div'); qDiv.appendChild(el('div','ask__prompt',q.prompt));
     const opts=el('div','ask__options'); const selected=new Set();
@@ -1193,10 +1207,11 @@ function showAsk(ask) {
     qDiv.appendChild(opts);
     const submit=el('button','ask__submit',__('submit')); submit.disabled=true;
     opts.addEventListener('click',()=>{submit.disabled=selected.size===0;});
-    submit.onclick=()=>{const answers=ask.questions.map(qq=>({questionId:qq.id,selected:Array.from(selected).map(i=>qq.options[i].label)}));post('/answer',{id:ask.id,answers});d.remove();};
+    submit.onclick=()=>{const answers=ask.questions.map(qq=>({questionId:qq.id,selected:Array.from(selected).map(i=>qq.options[i].label)}));post('/answer',{id:ask.id,answers});cleanup();};
     qDiv.appendChild(submit); d.appendChild(qDiv);
   });
   log.appendChild(d);scrollDown(true);
+  pendingPrompts.push(cleanup);
 }
 
 // ── compaction ──
@@ -1280,23 +1295,27 @@ function applyRewind() {
 
 document.addEventListener('keydown',e=>{
   const overlay=$('#rewind-overlay'); if(!overlay)return;
-  // Modifier chords (copy/reload/devtools) must not drive the picker — a bare
-  // Cmd+C would otherwise hit a scope key and apply a rewind. Target is not
-  // checked: double-Esc opens the picker from the focused composer, so the
-  // picker intentionally owns plain keys regardless of focus.
-  if(e.ctrlKey||e.metaKey||e.altKey)return;
-  if(e.key==='Escape'){e.preventDefault();if(rewindStage===0)overlay.remove();else{rewindStage=0;renderRewindPicker();}return;}
+  // The picker is modal and runs in the capture phase: plain keys it owns are
+  // swallowed before they reach the composer underneath — Enter would
+  // otherwise both send the composer draft and advance the picker, and
+  // letters would type into the hidden draft. Modifier chords
+  // (copy/reload/devtools), IME composition, and non-printable keys (F5, Tab)
+  // pass through — a bare Cmd+C must not hit a scope key and apply a rewind.
+  if(e.ctrlKey||e.metaKey||e.altKey||e.isComposing||e.key==='Process')return;
+  if(!(e.key==='Escape'||e.key==='Enter'||e.key==='ArrowDown'||e.key==='ArrowUp'||e.key.length===1))return;
+  e.preventDefault();e.stopPropagation();
+  if(e.key==='Escape'){if(rewindStage===0)overlay.remove();else{rewindStage=0;renderRewindPicker();}return;}
   if(rewindStage===0){
-    if(e.key==='j'||e.key==='ArrowDown'){e.preventDefault();rewindSelected=Math.min(rewindSelected+1,rewindCheckpoints.length-1);renderRewindPicker();}
-    if(e.key==='k'||e.key==='ArrowUp'){e.preventDefault();rewindSelected=Math.max(rewindSelected-1,0);renderRewindPicker();}
-    if(e.key==='Enter'){e.preventDefault();rewindStage=1;rewindScope=0;renderRewindPicker();}
+    if(e.key==='j'||e.key==='ArrowDown'){rewindSelected=Math.min(rewindSelected+1,rewindCheckpoints.length-1);renderRewindPicker();}
+    if(e.key==='k'||e.key==='ArrowUp'){rewindSelected=Math.max(rewindSelected-1,0);renderRewindPicker();}
+    if(e.key==='Enter'){rewindStage=1;rewindScope=0;renderRewindPicker();}
   } else {
-    if(e.key==='j'||e.key==='ArrowDown'){e.preventDefault();rewindScope=Math.min(rewindScope+1,SCOPES.length-1);renderRewindPicker();}
-    if(e.key==='k'||e.key==='ArrowUp'){e.preventDefault();rewindScope=Math.max(rewindScope-1,0);renderRewindPicker();}
-    if(e.key==='Enter'){e.preventDefault();applyRewind();}
-    const idx=SCOPES.findIndex(s=>s.key===e.key); if(idx>=0){e.preventDefault();rewindScope=idx;applyRewind();}
+    if(e.key==='j'||e.key==='ArrowDown'){rewindScope=Math.min(rewindScope+1,SCOPES.length-1);renderRewindPicker();}
+    if(e.key==='k'||e.key==='ArrowUp'){rewindScope=Math.max(rewindScope-1,0);renderRewindPicker();}
+    if(e.key==='Enter'){applyRewind();}
+    const idx=SCOPES.findIndex(s=>s.key===e.key); if(idx>=0){rewindScope=idx;applyRewind();}
   }
-});
+},true);
 
 // ── slash menu ──
 let slashOpen=false, slashIndex=0, slashFiltered=[];
@@ -1349,7 +1368,7 @@ es.onmessage=ev=>{setConnState('connected');
   const e=JSON.parse(ev.data);
   if(e.kind!=='retrying')clearRetrying();
   switch(e.kind){
-    case 'turn_started': setRunning(true); finalizeMsg(); toolCards={}; todosDismissed=false; break;
+    case 'turn_started': setRunning(true); clearPendingPrompts(); finalizeMsg(); toolCards={}; todosDismissed=false; break;
     case 'reasoning': appendReasoning(e.reasoning||e.text||''); break;
     case 'text': currentReasoning=null; appendText(e.text||''); break;
     case 'message': finalizeMsg(); break;
@@ -1378,7 +1397,7 @@ es.onmessage=ev=>{setConnState('connected');
     case 'compaction_started': showCompaction({trigger:e.compaction?.trigger}); break;
     case 'compaction_done': showCompaction(e.compaction||{}); break;
     case 'retrying': setRetrying(e.retryAttempt,e.retryMax); break;
-    case 'turn_done': finalizeMsg(); setRunning(false); if(e.err){log.appendChild(el('div','msg--error','✗ '+e.err));scrollDown();} fetchStatus(); fetchTodos(); refreshCheckpointAvailability(); break;
+    case 'turn_done': clearPendingPrompts(); finalizeMsg(); setRunning(false); if(e.err){log.appendChild(el('div','msg--error','✗ '+e.err));scrollDown();} fetchStatus(); fetchTodos(); refreshCheckpointAvailability(); break;
   }
 };
 es.onerror=()=>{

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -141,6 +141,7 @@ input,textarea{font:inherit;color:inherit}
 
 /* approval */
 .approval{background:var(--panel);border:1px solid var(--accent);border-radius:var(--radius-lg);padding:12px 14px;margin:8px 0;box-shadow:var(--shadow-md);animation:msg-in .2s ease}
+.approval:focus{outline:none}
 .approval__header{display:flex;align-items:center;gap:7px;margin-bottom:8px}
 .approval__icon{color:var(--warning);width:16px;height:16px}
 .approval__title{font-weight:600;font-size:13px}
@@ -1184,11 +1185,24 @@ function showApproval(a) {
   actions.push('<button class="approval__btn approval__btn--deny" data-allow="false"><span class="approval__key">N</span> '+__('deny')+'</button>');
   d.innerHTML='<div class="approval__header"><svg class="approval__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><span class="approval__title">'+__('approval_title')+'</span></div><div class="approval__subject">'+escHtml(a.tool)+(a.subject?' — '+escHtml(a.subject):'')+'</div><div class="approval__actions">'+actions.join('')+'</div>';
   log.appendChild(d);scrollDown(true);
-  const cleanup=()=>{pendingPrompts=pendingPrompts.filter(f=>f!==cleanup);d.remove();document.removeEventListener('keydown',onkey);};
+  // The advertised Y/A/P/N keys need a non-text-entry target (isPlainKey), but
+  // the composer is autofocused, so in the default state every shortcut would
+  // just type into the draft. Move focus onto the card so the keys route here —
+  // unless the user is mid-entry (a non-empty composer draft, or any other
+  // text field such as the session search): stealing focus there would turn
+  // their next keystroke into an unintended approval. Cleanup hands focus back
+  // to the composer only when it still sits inside the card, so a user who
+  // deliberately moved elsewhere is not yanked back.
+  d.tabIndex=-1;
+  if(!isTextEntry(document.activeElement)||(document.activeElement===input&&!input.value))d.focus({preventScroll:true});
+  const cleanup=()=>{pendingPrompts=pendingPrompts.filter(f=>f!==cleanup);const hadFocus=d.contains(document.activeElement);d.remove();document.removeEventListener('keydown',onkey);if(hadFocus)input.focus();};
   pendingPrompts.push(cleanup);
   const resolve=payload=>{post('/approve',Object.assign({id:a.id},payload));cleanup();};
   d.querySelectorAll('.approval__btn').forEach(btn=>{btn.onclick=()=>resolve({allow:btn.dataset.allow==='true',session:btn.dataset.session==='true',persist:btn.dataset.persist==='true',scope:btn.dataset.scope||''});});
-  const onkey=e=>{if(!isPlainKey(e))return; const k=e.key.toLowerCase();if(k==='y'||k==='1'){resolve({allow:true,session:false});}else if(k==='a'||k==='2'){resolve({allow:true,session:true});}else if(hasPrefix&&k==='3'){resolve({allow:true,session:true,scope:'prefix'});}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){resolve({allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''});}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){resolve({allow:false,session:false});}};
+  // A consumed shortcut must preventDefault: cleanup refocuses the composer
+  // synchronously, and the keystroke's default text insertion runs after
+  // keydown — without it the approving key lands in the draft as a stray char.
+  const onkey=e=>{if(!isPlainKey(e))return; const k=e.key.toLowerCase(); let payload=null;if(k==='y'||k==='1'){payload={allow:true,session:false};}else if(k==='a'||k==='2'){payload={allow:true,session:true};}else if(hasPrefix&&k==='3'){payload={allow:true,session:true,scope:'prefix'};}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){payload={allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''};}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){payload={allow:false,session:false};}if(payload){e.preventDefault();resolve(payload);}};
   document.addEventListener('keydown',onkey);
 }
 

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -41,7 +41,7 @@ input,textarea{font:inherit;color:inherit}
 
 .app{display:grid;grid-template-columns:220px 1fr;grid-template-rows:1fr auto;height:100vh}
 .sidebar{grid-row:1/3;background:var(--bg-2);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:hidden}
-.transcript{overflow-y:auto;padding:24px 28px;scroll-behavior:smooth}
+.transcript{overflow-y:auto;padding:24px 28px}
 .footer{border-top:1px solid var(--border);background:var(--bg);padding:12px 28px 16px;display:flex;flex-direction:column;gap:8px;position:relative}
 .footer::before{content:'';position:absolute;inset:-20px 0 auto 0;height:20px;background:linear-gradient(to top,var(--bg),transparent);pointer-events:none}
 
@@ -946,7 +946,15 @@ function slashGroupLabel(group){return __('cmd_group_'+group)||group;}
 function post(path, body) {
   return fetch(path, {method:'POST',headers:{'content-type':'application/json'},body:body?JSON.stringify(body):undefined});
 }
-function scrollDown() { requestAnimationFrame(()=>{log.scrollTop=log.scrollHeight;});}
+// Follow streaming output only while the user is pinned to the bottom of the
+// transcript; scrolling up detaches so history stays readable mid-stream.
+// force re-pins (own message sent, session loaded). Scrolls are instant: a
+// smooth animation lags behind rapid chunks, and its intermediate positions
+// would read as "not at bottom" and break pin detection.
+let pinnedToBottom=true;
+function atBottom() { return log.scrollHeight-log.scrollTop-log.clientHeight<40; }
+log.addEventListener('scroll',()=>{pinnedToBottom=atBottom();});
+function scrollDown(force) { if(force)pinnedToBottom=true; if(!pinnedToBottom)return; requestAnimationFrame(()=>{if(!pinnedToBottom)return; log.scrollTo({top:log.scrollHeight,behavior:'instant'});});}
 function hideWelcome() { if(welcome) welcome.style.display='none';}
 function showWelcome() { if(welcome) welcome.style.display='';}
 function fmtTok(n) { return n>=1000?(n/1000).toFixed(1).replace(/\.0$/,'')+'k':String(n);}
@@ -1025,7 +1033,7 @@ function setConnState(state) {
 }
 
 // ── messages ──
-function addUserMsg(text) { hasVisibleHistory=true; updateActionAvailability(); hideWelcome(); const d=el('div','msg msg--user'); d.appendChild(el('span','msg__caret','›')); d.appendChild(el('div','msg__text',text)); log.appendChild(d); scrollDown(); currentMsg=null;currentText=null;currentReasoning=null; }
+function addUserMsg(text) { hasVisibleHistory=true; updateActionAvailability(); hideWelcome(); const d=el('div','msg msg--user'); d.appendChild(el('span','msg__caret','›')); d.appendChild(el('div','msg__text',text)); log.appendChild(d); scrollDown(true); currentMsg=null;currentText=null;currentReasoning=null; }
 function ensureMsg() { if(!currentMsg){hasVisibleHistory=true; updateActionAvailability(); hideWelcome();currentMsg=el('div','msg msg--assistant');log.appendChild(currentMsg);} return currentMsg; }
 function appendText(t) { const m=ensureMsg(); if(!currentText){currentText=document.createElement('span');currentText.className='msg__text'; const old=m.querySelector('.cursor');if(old)old.remove(); m.appendChild(currentText); m.appendChild(el('span','cursor'));} currentText.textContent+=t; scrollDown(); }
 function appendReasoning(t) { const m=ensureMsg(); if(!currentReasoning){const w=el('div','reasoning'); const b=el('button','reasoning__toggle'); b.innerHTML='<span class="reasoning__chevron">▶</span> '+__('thinking'); const body=el('div','reasoning__body'); body.style.display='none'; b.onclick=()=>{body.style.display=body.style.display==='none'?'':'none';b.querySelector('.reasoning__chevron').className='reasoning__chevron'+(body.style.display!=='none'?' reasoning__chevron--open':'');}; w.appendChild(b);w.appendChild(body); if(currentText) m.insertBefore(w,currentText); else m.appendChild(w); currentReasoning=body;} currentReasoning.textContent+=t; scrollDown(); }
@@ -1433,7 +1441,7 @@ function renderHistoryMessages(ms){
       renderToolResult({id,name:m.toolName||'tool',output:m.content||''});
     }
   });
-  currentMsg=null;currentText=null;currentReasoning=null; scrollDown(); updateActionAvailability(); return true;
+  currentMsg=null;currentText=null;currentReasoning=null; scrollDown(true); updateActionAvailability(); return true;
 }
 fetch('/history').then(r=>r.json()).then(msgs=>{renderHistoryMessages(msgs);fetchTodos();}).catch(()=>{});
 

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -948,7 +948,9 @@ function post(path, body) {
 }
 // Follow streaming output only while the user is pinned to the bottom of the
 // transcript; scrolling up detaches so history stays readable mid-stream.
-// force re-pins (own message sent, session loaded). Scrolls are instant: a
+// force re-pins (own message sent, session loaded, blocking action prompts
+// such as approval/ask — they require user action and their key handler is
+// document-level, so they must never sit off-screen). Scrolls are instant: a
 // smooth animation lags behind rapid chunks, and its intermediate positions
 // would read as "not at bottom" and break pin detection.
 let pinnedToBottom=true;
@@ -1165,7 +1167,7 @@ function showApproval(a) {
   }
   actions.push('<button class="approval__btn approval__btn--deny" data-allow="false"><span class="approval__key">N</span> '+__('deny')+'</button>');
   d.innerHTML='<div class="approval__header"><svg class="approval__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><span class="approval__title">'+__('approval_title')+'</span></div><div class="approval__subject">'+escHtml(a.tool)+(a.subject?' — '+escHtml(a.subject):'')+'</div><div class="approval__actions">'+actions.join('')+'</div>';
-  log.appendChild(d);scrollDown();
+  log.appendChild(d);scrollDown(true);
   const resolve=payload=>{post('/approve',Object.assign({id:a.id},payload));d.remove();document.removeEventListener('keydown',onkey);};
   d.querySelectorAll('.approval__btn').forEach(btn=>{btn.onclick=()=>resolve({allow:btn.dataset.allow==='true',session:btn.dataset.session==='true',persist:btn.dataset.persist==='true',scope:btn.dataset.scope||''});});
   const onkey=e=>{const k=e.key.toLowerCase();if(k==='y'||k==='1'){resolve({allow:true,session:false});}else if(k==='a'||k==='2'){resolve({allow:true,session:true});}else if(hasPrefix&&k==='3'){resolve({allow:true,session:true,scope:'prefix'});}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){resolve({allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''});}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){resolve({allow:false,session:false});}};
@@ -1189,7 +1191,7 @@ function showAsk(ask) {
     submit.onclick=()=>{const answers=ask.questions.map(qq=>({questionId:qq.id,selected:Array.from(selected).map(i=>qq.options[i].label)}));post('/answer',{id:ask.id,answers});d.remove();};
     qDiv.appendChild(submit); d.appendChild(qDiv);
   });
-  log.appendChild(d);scrollDown();
+  log.appendChild(d);scrollDown(true);
 }
 
 // ── compaction ──

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -959,6 +959,11 @@ log.addEventListener('scroll',()=>{pinnedToBottom=atBottom();});
 function scrollDown(force) { if(force)pinnedToBottom=true; if(!pinnedToBottom)return; requestAnimationFrame(()=>{if(!pinnedToBottom)return; log.scrollTo({top:log.scrollHeight,behavior:'instant'});});}
 function hideWelcome() { if(welcome) welcome.style.display='none';}
 function showWelcome() { if(welcome) welcome.style.display='';}
+// Global single-key shortcuts must stay dead while the user is typing (the
+// composer is autofocused, so this is the default state) and when a
+// browser/OS chord is held (Cmd+A must never resolve an approval).
+function isTextEntry(t) { return !!t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.tagName==='SELECT'||t.isContentEditable); }
+function isPlainKey(e) { return !e.ctrlKey&&!e.metaKey&&!e.altKey&&!isTextEntry(e.target); }
 function fmtTok(n) { return n>=1000?(n/1000).toFixed(1).replace(/\.0$/,'')+'k':String(n);}
 function currencySymbol(c){const v=String(c||'¥').trim();if(/^(cny|rmb|yuan)$/i.test(v))return '¥';if(/^(usd|dollar)$/i.test(v))return '$';return v||'¥';}
 function fmtMoney(n,c){if(typeof n!=='number'||!isFinite(n))return '—';const s=currencySymbol(c);return s+(n<1?n.toFixed(4):n.toFixed(2));}
@@ -1170,7 +1175,7 @@ function showApproval(a) {
   log.appendChild(d);scrollDown(true);
   const resolve=payload=>{post('/approve',Object.assign({id:a.id},payload));d.remove();document.removeEventListener('keydown',onkey);};
   d.querySelectorAll('.approval__btn').forEach(btn=>{btn.onclick=()=>resolve({allow:btn.dataset.allow==='true',session:btn.dataset.session==='true',persist:btn.dataset.persist==='true',scope:btn.dataset.scope||''});});
-  const onkey=e=>{const k=e.key.toLowerCase();if(k==='y'||k==='1'){resolve({allow:true,session:false});}else if(k==='a'||k==='2'){resolve({allow:true,session:true});}else if(hasPrefix&&k==='3'){resolve({allow:true,session:true,scope:'prefix'});}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){resolve({allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''});}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){resolve({allow:false,session:false});}};
+  const onkey=e=>{if(!isPlainKey(e))return; const k=e.key.toLowerCase();if(k==='y'||k==='1'){resolve({allow:true,session:false});}else if(k==='a'||k==='2'){resolve({allow:true,session:true});}else if(hasPrefix&&k==='3'){resolve({allow:true,session:true,scope:'prefix'});}else if(k==='p'||(!hasPrefix&&k==='3')||(hasPrefix&&k==='4')){resolve({allow:true,session:true,persist:true,scope:hasPrefix?'prefix':''});}else if(k==='n'||k==='escape'||(!hasPrefix&&k==='4')||(hasPrefix&&k==='5')){resolve({allow:false,session:false});}};
   document.addEventListener('keydown',onkey);
 }
 
@@ -1275,6 +1280,11 @@ function applyRewind() {
 
 document.addEventListener('keydown',e=>{
   const overlay=$('#rewind-overlay'); if(!overlay)return;
+  // Modifier chords (copy/reload/devtools) must not drive the picker — a bare
+  // Cmd+C would otherwise hit a scope key and apply a rewind. Target is not
+  // checked: double-Esc opens the picker from the focused composer, so the
+  // picker intentionally owns plain keys regardless of focus.
+  if(e.ctrlKey||e.metaKey||e.altKey)return;
   if(e.key==='Escape'){e.preventDefault();if(rewindStage===0)overlay.remove();else{rewindStage=0;renderRewindPicker();}return;}
   if(rewindStage===0){
     if(e.key==='j'||e.key==='ArrowDown'){e.preventDefault();rewindSelected=Math.min(rewindSelected+1,rewindCheckpoints.length-1);renderRewindPicker();}
@@ -1617,7 +1627,7 @@ input.addEventListener('keydown',e=>{
 document.addEventListener('keydown',e=>{
   if(e.target===input&&e.key==='Tab'&&e.shiftKey){e.preventDefault();cycleMode();return;}
   if(e.target===input&&(e.key==='y'||e.key==='Y')&&(e.ctrlKey||e.metaKey)&&!e.altKey&&!e.shiftKey){e.preventDefault();toggleYolo();return;}
-  if(e.key==='/'&&e.target!==input){e.preventDefault();input.focus();return;}
+  if(e.key==='/'&&isPlainKey(e)){e.preventDefault();input.focus();return;}
 });
 
 // mode helpers — Shift+Tab toggles Plan; Ctrl+Y toggles YOLO separately.


### PR DESCRIPTION
## Problem

User report: in the `reasonix serve` web UI, while a response is streaming you cannot scroll up to read earlier output — the transcript keeps snapping to the newest content, so you are forced to watch the tail of the stream.

## Root cause

`scrollDown()` in `internal/serve/index.html` unconditionally set `log.scrollTop = log.scrollHeight`, and both `appendText` and `appendReasoning` call it on **every** streamed delta. There was no tracking of whether the user had scrolled away from the bottom, so each incoming chunk yanked the viewport back down. `.transcript { scroll-behavior: smooth }` made it worse: every forced jump animated, continuously fighting wheel input.

## Fix

- Track a `pinnedToBottom` state from the transcript's `scroll` events (within 40px of the bottom counts as pinned).
- Streamed content (text, reasoning, tool cards, metrics) only auto-follows while pinned; any upward wheel notch on scrollable content detaches immediately (position alone can't be trusted: during fast streaming every frame re-bottoms the viewport, so a slow trackpad drag would never accumulate the 40px position delta); scrolling back to the bottom re-pins.
- Direct user actions re-pin via `scrollDown(true)`: sending a message (`addUserMsg`) and loading session history (`renderHistoryMessages`, which also covers `/resume` and `/switch`).
- Blocking action prompts also force re-pin: tool approval (`showApproval`) and AskUserQuestion (`showAsk`) cards are action requests, not stream content. Left off-screen the session looks hung, and the document-level approval key handler could resolve a prompt the user never saw. Forced reveals win over a concurrent user scroll: the rAF re-asserts the pin for forced calls, since a scroll event landing before the rAF (scroll steps run first in the frame) would otherwise swallow the reveal.
- A turn's approval/ask prompts die with the turn: `turn_started`/`turn_done` remove unresolved cards and their key listeners. Previously, cancelling (composer Esc, or the stop button — the latter a pre-existing bug) stranded a stale card whose buttons posted to a dead id, with the approval key listener armed until an unrelated later keypress resolved it invisibly.
- `showNotice` — synchronous feedback to direct clicks (disabled Compact/Rewind, rewind with no checkpoints) — always reveals.
- Programmatic scrolls now use `behavior: 'instant'` and the CSS `scroll-behavior: smooth` is removed from the transcript: the smooth animation lagged behind rapid chunks and its intermediate positions would read as "not at bottom", breaking pin detection.
- Global key-shortcut hygiene (`isPlainKey`): the approval keys (`y/a/p/n/1-5/Esc`) and the `/` focus shortcut listened document-wide with no target or modifier check. With the autofocused composer this meant typing matching letters into the input while an approval was pending resolved it invisibly, Cmd+A could grant a session-wide allow, and `/` typed into the session search stole focus. Both now require a plain key (no Ctrl/Cmd/Alt) outside any text entry.
- The rewind picker is now truly modal: it runs in the capture phase and swallows the plain keys it owns, so letters no longer type into the hidden composer draft and Enter no longer both sends the draft and advances the picker (the next scope key would have applied a rewind against the just-started turn). Modifier chords (a bare Cmd+C must not hit a scope key and apply a rewind), IME composition, and non-printable keys (F5, Tab) pass through.

## Verification

- Behavioral test in headless Chromium (playwright-core driving the real browser), injecting the exact scroll-logic block extracted from `index.html` into a scrollable transcript fixture — all pass:
  - follows stream while pinned
  - detaches after user scrolls up
  - viewport stays put while more chunks stream in (the reported bug)
  - re-pins when user returns to bottom, then resumes following
  - force scroll (send / session load) re-pins from a scrolled-up position
- `node --check` on the extracted inline script.
- `go vet ./internal/serve/` and `go test ./internal/serve/` pass.
- Follow-up commit (approval/ask force-scroll): Node behavioral simulation of the extracted pin/scroll block — unpinned streaming does not yank the viewport, `scrollDown(true)` re-pins and scrolls instantly, and following resumes after the re-pin; `node --check` and `go vet`/`go test ./internal/serve/` re-run and pass.
- Follow-up commit (key-shortcut hygiene): Node simulation driving the real extracted handlers — approval ignores keys typed into text entries and modifier chords yet still resolves on plain keys and removes its listener; `/` no longer fires from the session search or with modifiers; Shift+Tab mode cycle and Ctrl+Y YOLO toggle are unaffected. All prior checks re-run and pass.
- Hardening commit (adversarial re-review findings): 23-scenario Node simulation of the extracted real handlers — pin/wheel/force-vs-scroll-race contracts (S1–S8), prompt lifecycle including turn-end cleanup, resolve deregistration and guard regression (L1–L4), picker capture-phase ownership including IME/chord/F-key pass-through (RW-A..F), plus the `/` and composer-chord regression checks; `node --check`, `go vet`/`go test ./internal/serve/` re-run and pass.

