### PR TITLE
Clarify AppChrome tab boundaries / 增强顶部标签页视觉分隔

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -139,6 +139,24 @@ ok(
 );
 
 ok(
+  finalDeclaration(":root[data-theme-style] .tabbar__tabs", "gap") === "6px" &&
+    finalDeclaration(":root[data-theme-style] .tabbar__tab", "border") === "1px solid var(--border)",
+  "themed tabs keep distinct full outlines with visible spacing",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tab + .tabbar__tab:not(.tabbar__tab--drop-before)::before", "width") === "1px" &&
+    finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tab + .tabbar__tab:not(.tabbar__tab--drop-before)::before", "background") === "var(--border-2)",
+  "adjacent AppChrome tabs render a stronger divider inside their gap",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .tabbar__tab--active", "border-color") === "var(--border-2)" &&
+    finalDeclaration(":root[data-theme-style] .tabbar__tab--active", "font-weight") === "600",
+  "active themed tabs combine a stronger border outline and heavier label weight",
+);
+
+ok(
   /workbenchChrome \? \(\s*<span className="app-chrome__spacer" aria-hidden="true" \/>/s.test(appChromeSource),
   "AppChrome workbench branch skips the tab strip",
 );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24023,7 +24023,7 @@ body > .mermaid-diagram--fullscreen {
   flex: 0 1 auto;
   min-width: 0;
   max-width: none;
-  gap: 4px;
+  gap: 6px;
   height: 46px;
   align-items: center;
   overflow-x: auto;
@@ -24098,15 +24098,27 @@ body > .mermaid-diagram--fullscreen {
   max-width: var(--tabbar-tab-width);
   gap: 8px;
   padding: 0 37px 0 11px;
-  border: 0;
+  border: 1px solid var(--border);
   border-radius: var(--r-s);
   background: transparent;
   color: var(--fg-dim);
   font-size: 12.5px;
   font-weight: 500;
   box-shadow: none;
-  transition: background var(--dur-fast), color var(--dur-fast);
+  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast), box-shadow var(--dur-fast);
   animation: none;
+}
+
+:root[data-theme-style] .app-chrome--tabs .tabbar__tab + .tabbar__tab:not(.tabbar__tab--drop-before)::before {
+  content: "";
+  position: absolute;
+  top: 7px;
+  bottom: 7px;
+  left: -4px;
+  width: 1px;
+  border-radius: 1px;
+  background: var(--border-2);
+  pointer-events: none;
 }
 
 :root[data-theme-style] .tabbar__tab:not(.tabbar__tab--active):hover {
@@ -24116,10 +24128,12 @@ body > .mermaid-diagram--fullscreen {
 
 :root[data-theme-style] .tabbar__tab--active {
   color: var(--fg);
+  border-color: var(--border-2);
   background: var(--surface-2);
   box-shadow:
     var(--app-graphite-shadow),
     inset 0 -2px 0 var(--project-accent, var(--accent));
+  font-weight: 600;
 }
 
 :root[data-theme-style] .tabbar__tab:focus {


### PR DESCRIPTION
## Summary

- increase spacing and add full outlines around themed AppChrome tabs
- render a short, higher-contrast divider between adjacent top-level tabs
- give the active tab a stronger border outline and heavier label weight

## Why

Adjacent session tabs were difficult to distinguish, especially in light themes. The previous styling relied on transparent backgrounds and low-contrast borders, so separate tabs could read as one continuous strip.

## Scope

This PR is intentionally limited to tab **boundaries**: spacing, per-tab outlines, and the inter-tab divider. The active-tab accent underline is provided by #6416 (fixes #6391, now merged), which renders a uniform bottom-edge accent honouring per-project accent colours via `var(--project-accent)`. To avoid duplicating that work, this PR does not add its own underline. The active tab still gets a stronger `border-color` and heavier label weight, which sit alongside #6416's underline in the shared `.tabbar__tab--active` rule.

## User impact

Session boundaries are easier to scan without changing tab dimensions or interaction behavior. Drag-and-drop placement indicators continue to override the static divider when reordering tabs.

## Validation

- `pnpm check:css`
- `pnpm typecheck`
- `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts` (`80 passed, 0 failed`)
- verified the three-tab light-theme layout in the local browser preview with no console errors

## Related work

- #6416 (fixes #6391) owns the active-tab accent underline and is now merged; this PR has been rebased on top of it. It covers only boundaries, dividers, and spacing, and composes cleanly with the merged accent — its `border-color`/`font-weight` sit alongside #6416's box-shadow underline in the shared `.tabbar__tab--active` rule, with no remaining conflict.
- #6286 adjusts native drag regions in different selectors and does not overlap with these visual rules.

