### PR TITLE
fix(desktop): resolve context_window=0 for custom providers, move setting to visible area

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -5627,8 +5627,9 @@ function ProviderEditor({
   const [keyDraft, setKeyDraft] = useState("");
   const [balanceUrl, setBalanceUrl] = useState(initial?.balanceUrl ?? "");
   // Empty when unset so the placeholder (and its "0 = disabled" hint) reads instead
-  // of a bare "0"; saved back as 0.
-  const [ctx, setCtx] = useState(initial?.contextWindow ? String(initial.contextWindow) : "");
+  // of a bare "0"; saved back as 0. New providers start with 128000 (matching the
+  // TUI's hardcoded default for custom providers).
+  const [ctx, setCtx] = useState(initial?.contextWindow ? String(initial.contextWindow) : (initial ? "" : "128000"));
   const [modelContextWindows, setModelContextWindows] = useState<Record<string, string>>(
     () => providerModelContextWindowDrafts(initial?.modelOverrides),
   );
@@ -5950,17 +5951,6 @@ function ProviderEditor({
           onChange={(e) => setBalanceUrl(e.target.value)}
         />
         <div className="mem-hint">{t("settings.balanceUrlHint")}</div>
-        <label className="set-label">{t("settings.providerContextWindow")}</label>
-        <input
-          className="mem-input"
-          inputMode="numeric"
-          min={0}
-          placeholder={t("settings.contextWindowPlaceholder")}
-          type="number"
-          value={ctx}
-          onChange={(e) => setCtx(e.target.value)}
-        />
-        <div className="mem-hint">{t("settings.contextWindowHint")}</div>
       </div>
     </details>
   );
@@ -6060,6 +6050,17 @@ function ProviderEditor({
       <label className="set-label">{t("settings.manualModels")}</label>
       <input className="mem-input" placeholder={t("settings.providerModels")} value={models} onChange={(e) => updateManualModels(e.target.value)} />
       <div className="mem-hint">{t("settings.manualModelsHint")}</div>
+      <label className="set-label">{t("settings.providerContextWindow")}</label>
+      <input
+        className="mem-input"
+        inputMode="numeric"
+        min={0}
+        placeholder={t("settings.contextWindowPlaceholder")}
+        type="number"
+        value={ctx}
+        onChange={(e) => setCtx(e.target.value)}
+      />
+      <div className="mem-hint">{t("settings.contextWindowHint")}</div>
       <ProviderEditorModelPicker
         candidates={modelCandidateNames}
         selectedModels={modelNames}


### PR DESCRIPTION
## Problem

When adding a custom model provider via **Settings → Models → Add Provider** (desktop UI), the "Context window" field was buried inside the collapsed "Compatibility settings (usually leave unchanged)" section. Most users never saw it, leaving the value at 0.

The CLI/TUI path was unaffected — it already hardcodes `128000` for custom providers.

## What This PR Does

**Moved the context window field** from the collapsed advanced section to the visible area (after manual models input, before the model picker), matching the TUI's existing behavior.

**Pre-fills 128000** for new custom providers — same value the TUI uses — instead of leaving it empty.

## What This PR Does NOT Do

- Does **not** backfill `context_window = 0` to 128000 (respects #6677's semantic: `0 = disable compaction`)
- Does **not** clamp the save value (explicit 0 saves as 0, preserving the compaction-disable escape hatch)
- Does **not** change locale strings (already updated by #6677 to say "0 = disable auto-compaction")

## Changes

**`desktop/frontend/src/components/SettingsPanel.tsx`** (1 file):
- Removed context window input from `<details>` "Compatibility settings" advanced section
- Added it to the visible area before `ProviderEditorModelPicker`
- New providers pre-fill with `128000`; existing providers keep their saved value

## After / Before

**Before:** Context window hidden in collapsed advanced section, defaults to empty/0, context gauge shows `64987/0`, compaction disabled

**After:** Context window visible in main settings area, pre-fills 128K for new providers, context gauge shows `64987/128000`, compaction works. Explicit 0 still means "disable compaction".

## Testing

- Config tests — PASS
- Desktop preset tests — PASS (including `TestAddEveryProviderPresetAccessInstallsTemplate`)
- Provider model override tests — PASS

---
Closes #6439
