### PR TITLE
fix(registry): reject bare package-name sources for kind=skill

### DIFF
--- a/workers/crash-report/src/registry/lib/validation.test.ts
+++ b/workers/crash-report/src/registry/lib/validation.test.ts
@@ -40,4 +40,11 @@ describe("PublishSchema source", () => {
   it("allows a whole-repo GitHub source for kind=mcp (a repo root is a valid plugin/MCP source)", () => {
     expect(parse({ kind: "mcp", source: "https://github.com/o/r" }).success).toBe(true);
   });
+
+  it("rejects a bare package name for kind=skill (it would resolve as an MCP, not a skill)", () => {
+    for (const source of ["123", "my-skill", "@scope/pkg"]) {
+      expect(parse({ kind: "skill", source }).success, source).toBe(false);
+      expect(parse({ kind: "mcp", source }).success, source).toBe(true);
+    }
+  });
 });

--- a/workers/crash-report/src/registry/lib/validation.ts
+++ b/workers/crash-report/src/registry/lib/validation.ts
@@ -107,6 +107,17 @@ export const PublishSchema = z
           "source points at a whole GitHub repo, which installs every skill in it. Point it at one skill — e.g. https://github.com/<owner>/<repo>/tree/<branch>/skills/<name> or a raw SKILL.md URL.",
       });
     }
+    // A skill lives in a SKILL.md file/dir; install_source only reaches the
+    // npx-package branch for kind auto/mcp, so a bare package-name source
+    // (e.g. "123") resolves as an MCP server, never a skill.
+    if (val.kind === "skill" && looksLikePackage(val.source)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["source"],
+        message:
+          "a skill source must be a SKILL.md URL or a GitHub repo path, not a bare package name.",
+      });
+    }
   });
 
 export type PublishInput = z.infer<typeof PublishSchema>;


### PR DESCRIPTION
## Why

Follow-up to #6442. That change validated the **shape** of `source`, but a package-name-shaped token like `123` still passes — correctly for `kind=mcp` (`npx -y 123`), but wrongly for `kind=skill`.

`install_source` only reaches the npx-package branch for `kind` auto/mcp; its skill path only accepts a SKILL.md file/dir/URL or a repo path. So a bare-name source published as a **skill** resolves to an MCP server, not a skill — a `kind`/behaviour mismatch. A `359807859/123` test submission (kind=skill, source `123`) sailed through the live gate for exactly this reason.

## What

Add a `superRefine` guard: when `kind === "skill"`, a bare package-name source is rejected (a skill source must be a SKILL.md URL or a GitHub repo path). Still purely syntactic — no fetch — so it stays within the "registry stores metadata, never fetches" architecture. `kind=mcp` package-name sources are unchanged.

## Scope

This closes the `123`-as-skill hole. A *plausible* but nonexistent source (a well-formed GitHub URL to a repo that has no manifest, or a bare name that isn't a real npm package for kind=mcp) still passes — that needs the resolvability fetch (Control #2), a separate follow-up.

## Test

```
cd workers/crash-report && npm ci && npm run typecheck && npm test
```
5/5 pass (adds: bare name rejected for skill, accepted for mcp).
