### PR TITLE
fix(cli): support mouse selection in composer

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -962,10 +962,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, finalize(m, cmds)
 
 	case tea.PasteMsg:
+		pasteBefore := m.input.Value()
 		if m.state != tuiRunning && m.attachPastedImages(msg.Content) {
+			if shouldClearWideInputChange(pasteBefore, m.input.Value()) {
+				cmds = append(cmds, tea.ClearScreen)
+			}
 			return m, finalize(m, cmds)
 		}
-		pasteBefore := m.input.Value()
 		if m.validComposerSelection() && !m.composerSel.empty() {
 			inputBeforeSelection = pasteBefore
 			m.deleteComposerSelection()
@@ -1577,19 +1580,30 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice("paste image: " + msg.err.Error())
 			break
 		}
+		imageBefore := m.input.Value()
 		m.insertImageRef(msg.path)
+		if shouldClearWideInputChange(imageBefore, m.input.Value()) {
+			cmds = append(cmds, tea.ClearScreen)
+		}
 
 	case clipboardPasteMsg:
 		switch {
 		case msg.err != nil:
 			m.notice("paste: " + msg.err.Error())
 		case msg.path != "":
+			before := m.input.Value()
 			m.insertImageRef(msg.path)
+			if shouldClearWideInputChange(before, m.input.Value()) {
+				cmds = append(cmds, tea.ClearScreen)
+			}
 		case msg.text != "":
+			before := m.input.Value()
 			if m.attachPastedImages(msg.text) {
+				if shouldClearWideInputChange(before, m.input.Value()) {
+					cmds = append(cmds, tea.ClearScreen)
+				}
 				return m, finalize(m, cmds)
 			}
-			before := m.input.Value()
 			m.deleteComposerSelection()
 			if ref, ok := pastedFileRef(msg.text); ok {
 				m.input.InsertString(ref + " ")

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -61,8 +61,10 @@ type chatTUI struct {
 	// since the terminal no longer forwards those events to Reasonix.
 	mouseCaptureOff bool
 
-	input   textarea.Model
-	spinner spinner.Model
+	input       textarea.Model
+	composerSel composerSelection
+	composerMap composerLayoutCache
+	spinner     spinner.Model
 
 	submittedInputs      []string
 	submittedInputCursor int
@@ -796,6 +798,7 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // transcript viewport sized, fed, and tail-following after every message.
 func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
+	var inputBeforeSelection string
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -833,11 +836,27 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Right-click copies the active selection (Windows Terminal convention);
 		// left-press in the transcript region begins a text selection — unless
 		// the click lands on the scrollbar or a shell-output hint line.
+		if msg.Button == tea.MouseRight && m.validComposerSelection() && !m.composerSel.empty() {
+			cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
+			return m, finalize(m, cmds)
+		}
 		if msg.Button == tea.MouseRight && m.sel.active && !m.sel.empty() {
 			text := m.selectedText()
 			m.sel = selection{}
 			cmds = append(cmds, m.copySelectionWithNotice(text))
 			return m, finalize(m, cmds)
+		}
+		if msg.Button == tea.MouseLeft {
+			if at, ok := m.composerCaretAt(msg.X, msg.Y, false); ok {
+				m.sel = selection{}
+				m.autoScroll = 0
+				m.setComposerCursor(at.offset)
+				m.composerSel = composerSelection{
+					active: true, anchor: at.offset, head: at.offset, value: m.input.Value(),
+				}
+				return m, nil
+			}
+			m.composerSel = composerSelection{}
 		}
 		if msg.Button == tea.MouseLeft && m.inScrollbar(msg.X, msg.Y) {
 			m.sel = selection{}
@@ -864,6 +883,12 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseMotionMsg:
+		if m.validComposerSelection() {
+			if at, ok := m.composerCaretAt(msg.X, msg.Y, true); ok {
+				m.composerSel.head = at.offset
+			}
+			return m, nil
+		}
 		if m.scrollbarDrag {
 			m.dragScrollbar(msg.Y)
 			return m, nil
@@ -906,6 +931,16 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, autoScrollTick()
 
 	case tea.MouseReleaseMsg:
+		if msg.Button == tea.MouseLeft && m.validComposerSelection() {
+			if at, ok := m.composerCaretAt(msg.X, msg.Y, true); ok {
+				m.composerSel.head = at.offset
+				m.setComposerCursor(at.offset)
+			}
+			if m.composerSel.empty() {
+				m.composerSel = composerSelection{}
+			}
+			return m, nil
+		}
 		// Release finalizes the selection: a real drag auto-copies it (native
 		// terminal convention), while the highlight stays on as the visual
 		// "what's selected" cue and a right-click can still re-copy it. A plain
@@ -931,10 +966,18 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, finalize(m, cmds)
 		}
 		if ref, ok := pastedFileRef(msg.Content); ok {
+			if m.validComposerSelection() && !m.composerSel.empty() {
+				inputBeforeSelection = m.input.Value()
+				m.deleteComposerSelection()
+			}
 			m.input.InsertString(ref + " ")
 			m.growInputToFit()
 			m.updateCompletion()
 			return m, finalize(m, cmds)
+		}
+		if m.validComposerSelection() && !m.composerSel.empty() {
+			inputBeforeSelection = m.input.Value()
+			m.deleteComposerSelection()
 		}
 		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
@@ -948,6 +991,27 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// except Ctrl+C/Super+C/Meta+C which may copy the selection to clipboard.
 		sel := m.sel
 		m.sel = selection{}
+		if m.validComposerSelection() && !m.composerSel.empty() {
+			if msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c" {
+				cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
+				return m, finalize(m, cmds)
+			}
+			inputBeforeSelection = m.input.Value()
+			if composerSelectionDeletes(msg, m.input.KeyMap) {
+				m.deleteComposerSelection()
+				m.growInputToFit()
+				m.updateCompletion()
+				if shouldClearWideInputChange(inputBeforeSelection, m.input.Value()) {
+					cmds = append(cmds, tea.ClearScreen)
+				}
+				return m, finalize(m, cmds)
+			}
+			if composerSelectionReplaces(msg, m.input.KeyMap) {
+				m.deleteComposerSelection()
+			} else {
+				m.composerSel = composerSelection{}
+			}
+		}
 		// Transcript scroll keys work in any state (PgUp/PgDn are never text).
 		switch msg.String() {
 		case "pgup":
@@ -1506,10 +1570,18 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, finalize(m, cmds)
 			}
 			if ref, ok := pastedFileRef(msg.text); ok {
+				if m.validComposerSelection() && !m.composerSel.empty() {
+					inputBeforeSelection = m.input.Value()
+					m.deleteComposerSelection()
+				}
 				m.input.InsertString(ref + " ")
 			} else if m.shouldFoldPaste(msg.text) {
 				m.insertFoldedPaste(msg.text)
 			} else {
+				if m.validComposerSelection() && !m.composerSel.empty() {
+					inputBeforeSelection = m.input.Value()
+					m.deleteComposerSelection()
+				}
 				m.input.InsertString(msg.text)
 			}
 			m.growInputToFit()
@@ -1538,6 +1610,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	beforeInput := m.input.Value()
+	if inputBeforeSelection != "" {
+		beforeInput = inputBeforeSelection
+	}
 	var ic tea.Cmd
 	m.input, ic = m.input.Update(msg)
 	cmds = append(cmds, ic)
@@ -2546,7 +2621,7 @@ func (m chatTUI) View() tea.View {
 		if shellMode {
 			style = style.BorderForeground(lipgloss.Color(statusShellColor.hex))
 		}
-		box = style.Render(m.input.View())
+		box = style.Render(m.renderComposerInput())
 	}
 
 	var modeTag string
@@ -3320,6 +3395,7 @@ func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 func (m *chatTUI) toggleMouseCapture() {
 	m.mouseCaptureOff = !m.mouseCaptureOff
 	m.sel = selection{}
+	m.composerSel = composerSelection{}
 	m.scrollbarDrag = false
 	m.autoScroll = 0
 	if m.mouseCaptureOff {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -965,51 +965,71 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.state != tuiRunning && m.attachPastedImages(msg.Content) {
 			return m, finalize(m, cmds)
 		}
+		pasteBefore := m.input.Value()
+		if m.validComposerSelection() && !m.composerSel.empty() {
+			inputBeforeSelection = pasteBefore
+			m.deleteComposerSelection()
+		}
 		if ref, ok := pastedFileRef(msg.Content); ok {
-			if m.validComposerSelection() && !m.composerSel.empty() {
-				inputBeforeSelection = m.input.Value()
-				m.deleteComposerSelection()
-			}
 			m.input.InsertString(ref + " ")
 			m.growInputToFit()
 			m.updateCompletion()
+			if shouldClearWideInputChange(pasteBefore, m.input.Value()) {
+				cmds = append(cmds, tea.ClearScreen)
+			}
 			return m, finalize(m, cmds)
-		}
-		if m.validComposerSelection() && !m.composerSel.empty() {
-			inputBeforeSelection = m.input.Value()
-			m.deleteComposerSelection()
 		}
 		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
 			m.growInputToFit()
 			m.updateCompletion()
+			if shouldClearWideInputChange(pasteBefore, m.input.Value()) {
+				cmds = append(cmds, tea.ClearScreen)
+			}
 			return m, finalize(m, cmds)
 		}
 
 	case tea.KeyPressMsg:
 		// Any keystroke dismisses a finished selection (copy is a right-click),
-		// except Ctrl+C/Super+C/Meta+C which may copy the selection to clipboard.
+		// with a few exceptions: Ctrl/Super/Meta+C copies the selection, the
+		// paste shortcuts keep it so the async clipboard result can replace
+		// it, and Left/Right collapse it to its ordered start/end.
 		sel := m.sel
 		m.sel = selection{}
 		if m.validComposerSelection() && !m.composerSel.empty() {
-			if msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c" {
+			switch msg.String() {
+			case "ctrl+c", "super+c", "meta+c":
 				cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
 				return m, finalize(m, cmds)
-			}
-			inputBeforeSelection = m.input.Value()
-			if composerSelectionDeletes(msg, m.input.KeyMap) {
-				m.deleteComposerSelection()
-				m.growInputToFit()
-				m.updateCompletion()
-				if shouldClearWideInputChange(inputBeforeSelection, m.input.Value()) {
-					cmds = append(cmds, tea.ClearScreen)
-				}
-				return m, finalize(m, cmds)
-			}
-			if composerSelectionReplaces(msg, m.input.KeyMap) {
-				m.deleteComposerSelection()
-			} else {
+			case "ctrl+v", "ctrl+shift+v", "super+v", "meta+v":
+				// Handled by the shortcut switch below; the clipboardPasteMsg
+				// result replaces the still-active selection.
+			case "left":
+				start, _ := m.composerSel.ordered()
 				m.composerSel = composerSelection{}
+				m.setComposerCursor(start)
+				return m, finalize(m, cmds)
+			case "right":
+				_, end := m.composerSel.ordered()
+				m.composerSel = composerSelection{}
+				m.setComposerCursor(end)
+				return m, finalize(m, cmds)
+			default:
+				inputBeforeSelection = m.input.Value()
+				if composerSelectionDeletes(msg, m.input.KeyMap) {
+					m.deleteComposerSelection()
+					m.growInputToFit()
+					m.updateCompletion()
+					if shouldClearWideInputChange(inputBeforeSelection, m.input.Value()) {
+						cmds = append(cmds, tea.ClearScreen)
+					}
+					return m, finalize(m, cmds)
+				}
+				if composerSelectionReplaces(msg, m.input.KeyMap) {
+					m.deleteComposerSelection()
+				} else {
+					m.composerSel = composerSelection{}
+				}
 			}
 		}
 		// Transcript scroll keys work in any state (PgUp/PgDn are never text).
@@ -1569,23 +1589,20 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.attachPastedImages(msg.text) {
 				return m, finalize(m, cmds)
 			}
+			before := m.input.Value()
+			m.deleteComposerSelection()
 			if ref, ok := pastedFileRef(msg.text); ok {
-				if m.validComposerSelection() && !m.composerSel.empty() {
-					inputBeforeSelection = m.input.Value()
-					m.deleteComposerSelection()
-				}
 				m.input.InsertString(ref + " ")
 			} else if m.shouldFoldPaste(msg.text) {
 				m.insertFoldedPaste(msg.text)
 			} else {
-				if m.validComposerSelection() && !m.composerSel.empty() {
-					inputBeforeSelection = m.input.Value()
-					m.deleteComposerSelection()
-				}
 				m.input.InsertString(msg.text)
 			}
 			m.growInputToFit()
 			m.updateCompletion()
+			if shouldClearWideInputChange(before, m.input.Value()) {
+				cmds = append(cmds, tea.ClearScreen)
+			}
 			return m, finalize(m, cmds)
 		}
 

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -45,6 +45,7 @@ func (m *chatTUI) shouldFoldPaste(s string) bool {
 }
 
 func (m *chatTUI) insertFoldedPaste(s string) {
+	m.deleteComposerSelection()
 	label := foldedPasteLabel(m.nextPasteID, pastedLineCount(s))
 	m.nextPasteID++
 	m.pastedBlocks = append(m.pastedBlocks, pastedBlock{label: label, text: s})
@@ -55,6 +56,7 @@ func (m *chatTUI) insertFoldedPaste(s string) {
 // the saved attachment's @ref, expanded on submit) so a dragged/pasted image is
 // edited and removed like any other text, not stranded in a separate tray.
 func (m *chatTUI) insertImageRef(path string) {
+	m.deleteComposerSelection()
 	label := fmt.Sprintf("[image #%d]", m.nextPasteID)
 	m.nextPasteID++
 	m.pastedBlocks = append(m.pastedBlocks, pastedBlock{label: label, text: "@" + path, image: true})

--- a/internal/cli/composer_selection.go
+++ b/internal/cli/composer_selection.go
@@ -373,13 +373,15 @@ func composerRowSelectionSpan(row composerVisualRow, start, end int) (lo, hi int
 		}
 		visualCol = cluster.endVisualCol
 	}
-	// Make an explicitly selected newline visible, including on blank lines.
+	// Make an explicitly selected newline visible, including on blank lines:
+	// it occupies the textarea's trailing caret space, one cell past the row
+	// content (after the loop visualCol is the row's full content width).
 	if end > row.logicalEnd && start <= row.logicalEnd && row.endOffset == row.logicalEnd {
 		if !ok {
-			lo = max(0, visualCol-1) // the textarea's trailing caret space
+			lo = visualCol
 			ok = true
 		}
-		hi = max(hi, lo+1)
+		hi = max(hi, visualCol+1)
 	}
 	return lo, hi, ok
 }

--- a/internal/cli/composer_selection.go
+++ b/internal/cli/composer_selection.go
@@ -1,0 +1,406 @@
+package cli
+
+import (
+	"strings"
+	"unicode"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	rw "github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+)
+
+// composerSelection is an editable textarea selection expressed as rune offsets
+// into input.Value(). The value snapshot invalidates stale offsets whenever an
+// unrelated path replaces the composer contents.
+type composerSelection struct {
+	active       bool
+	anchor, head int
+	value        string
+}
+
+type composerLayoutCache struct {
+	value string
+	width int
+	rows  []composerVisualRow
+}
+
+func (s composerSelection) ordered() (start, end int) {
+	if s.anchor > s.head {
+		return s.head, s.anchor
+	}
+	return s.anchor, s.head
+}
+
+func (s composerSelection) empty() bool { return s.anchor == s.head }
+
+type composerCell struct {
+	r       rune
+	offset  int
+	lineCol int
+}
+
+type composerVisualRow struct {
+	cells                    []composerCell
+	logicalRow, logicalStart int
+	logicalEnd, visualRow    int
+	startOffset, endOffset   int
+}
+
+type composerCaret struct {
+	offset, logicalRow, logicalCol, visualRow int
+}
+
+type composerCluster struct {
+	startOffset, endOffset       int
+	startLineCol, endLineCol     int
+	startVisualCol, endVisualCol int
+}
+
+func composerCellsWidth(cells []composerCell) int {
+	var b strings.Builder
+	for _, cell := range cells {
+		b.WriteRune(cell.r)
+	}
+	return uniseg.StringWidth(b.String())
+}
+
+func composerSpaces(cells []composerCell) []composerCell {
+	out := make([]composerCell, len(cells))
+	for i, cell := range cells {
+		cell.r = ' '
+		out[i] = cell
+	}
+	return out
+}
+
+// wrapComposerLine mirrors bubbles/textarea.wrap. The dependency does not
+// export its visual rows, but mouse hit-testing must use the exact same word
+// wrapping and wide-rune rules as the rendered textarea.
+func wrapComposerLine(runes []rune, width, logicalRow, logicalStart int) []composerVisualRow {
+	if width < 1 {
+		width = 1
+	}
+	lines := [][]composerCell{{}}
+	var word, spaces []composerCell
+	row := 0
+	for col, r := range runes {
+		cell := composerCell{r: r, offset: logicalStart + col, lineCol: col}
+		if unicode.IsSpace(r) {
+			spaces = append(spaces, cell)
+		} else {
+			word = append(word, cell)
+		}
+
+		if len(spaces) > 0 {
+			if composerCellsWidth(lines[row])+composerCellsWidth(word)+len(spaces) > width {
+				row++
+				lines = append(lines, []composerCell{})
+			}
+			lines[row] = append(lines[row], word...)
+			lines[row] = append(lines[row], composerSpaces(spaces)...)
+			word = nil
+			spaces = nil
+		} else if len(word) > 0 {
+			lastWidth := rw.RuneWidth(word[len(word)-1].r)
+			if composerCellsWidth(word)+lastWidth > width {
+				if len(lines[row]) > 0 {
+					row++
+					lines = append(lines, []composerCell{})
+				}
+				lines[row] = append(lines[row], word...)
+				word = nil
+			}
+		}
+	}
+
+	if composerCellsWidth(lines[row])+composerCellsWidth(word)+len(spaces) >= width {
+		row++
+		lines = append(lines, append([]composerCell{}, word...))
+		lines[row] = append(lines[row], composerSpaces(spaces)...)
+	} else {
+		lines[row] = append(lines[row], word...)
+		lines[row] = append(lines[row], composerSpaces(spaces)...)
+	}
+
+	logicalEnd := logicalStart + len(runes)
+	// textarea appends one non-value space so a caret can sit at line end.
+	lines[row] = append(lines[row], composerCell{r: ' ', offset: -1, lineCol: len(runes)})
+	result := make([]composerVisualRow, len(lines))
+	for i, cells := range lines {
+		start, end := logicalEnd, logicalEnd
+		for _, cell := range cells {
+			if cell.offset < 0 {
+				continue
+			}
+			if start == logicalEnd {
+				start = cell.offset
+			}
+			end = cell.offset + 1
+		}
+		result[i] = composerVisualRow{
+			cells: cells, logicalRow: logicalRow, logicalStart: logicalStart,
+			logicalEnd: logicalEnd, startOffset: start, endOffset: end,
+		}
+	}
+	return result
+}
+
+func composerLayout(value string, width int) []composerVisualRow {
+	logicalLines := strings.Split(value, "\n")
+	rows := make([]composerVisualRow, 0, len(logicalLines))
+	offset := 0
+	for logicalRow, line := range logicalLines {
+		runes := []rune(line)
+		wrapped := wrapComposerLine(runes, width, logicalRow, offset)
+		for i := range wrapped {
+			wrapped[i].visualRow = len(rows)
+			rows = append(rows, wrapped[i])
+		}
+		offset += len(runes)
+		if logicalRow+1 < len(logicalLines) {
+			offset++ // explicit newline in input.Value()
+		}
+	}
+	return rows
+}
+
+func (m *chatTUI) composerRows() []composerVisualRow {
+	value, width := m.input.Value(), m.input.Width()
+	if m.composerMap.value != value || m.composerMap.width != width || m.composerMap.rows == nil {
+		m.composerMap = composerLayoutCache{value: value, width: width, rows: composerLayout(value, width)}
+	}
+	return m.composerMap.rows
+}
+
+func (m chatTUI) composerRowsForRender() []composerVisualRow {
+	value, width := m.input.Value(), m.input.Width()
+	if m.composerMap.value == value && m.composerMap.width == width && m.composerMap.rows != nil {
+		return m.composerMap.rows
+	}
+	return composerLayout(value, width)
+}
+
+func composerClusters(row composerVisualRow) []composerCluster {
+	actual := make([]composerCell, 0, len(row.cells))
+	var text strings.Builder
+	for _, cell := range row.cells {
+		if cell.offset < 0 {
+			continue
+		}
+		actual = append(actual, cell)
+		text.WriteRune(cell.r)
+	}
+	clusters := make([]composerCluster, 0, len(actual))
+	graphemes := uniseg.NewGraphemes(text.String())
+	cellIndex := 0
+	visualCol := 0
+	for graphemes.Next() {
+		clusterRunes := graphemes.Runes()
+		if len(clusterRunes) == 0 || cellIndex >= len(actual) {
+			continue
+		}
+		endIndex := min(cellIndex+len(clusterRunes), len(actual))
+		first := actual[cellIndex]
+		last := actual[endIndex-1]
+		width := graphemes.Width()
+		clusters = append(clusters, composerCluster{
+			startOffset: first.offset, endOffset: last.offset + 1,
+			startLineCol: first.lineCol, endLineCol: last.lineCol + 1,
+			startVisualCol: visualCol, endVisualCol: visualCol + width,
+		})
+		visualCol += width
+		cellIndex = endIndex
+	}
+	return clusters
+}
+
+func (row composerVisualRow) caretAt(x int) composerCaret {
+	if x < 0 {
+		x = 0
+	}
+	lastOffset := row.startOffset
+	lastLineCol := 0
+	for _, cluster := range composerClusters(row) {
+		width := cluster.endVisualCol - cluster.startVisualCol
+		if x <= cluster.startVisualCol ||
+			(x < cluster.endVisualCol && x-cluster.startVisualCol < (width+1)/2) {
+			return composerCaret{cluster.startOffset, row.logicalRow, cluster.startLineCol, row.visualRow}
+		}
+		lastOffset = cluster.endOffset
+		lastLineCol = cluster.endLineCol
+		if x < cluster.endVisualCol {
+			return composerCaret{lastOffset, row.logicalRow, lastLineCol, row.visualRow}
+		}
+	}
+	return composerCaret{lastOffset, row.logicalRow, lastLineCol, row.visualRow}
+}
+
+func composerCaretForOffset(rows []composerVisualRow, offset int) composerCaret {
+	if len(rows) == 0 {
+		return composerCaret{}
+	}
+	for i, row := range rows {
+		if offset < row.endOffset || offset == row.startOffset {
+			return composerCaret{offset, row.logicalRow, offset - row.logicalStart, row.visualRow}
+		}
+		if offset == row.endOffset {
+			if i+1 < len(rows) && rows[i+1].startOffset == offset {
+				continue
+			}
+			return composerCaret{offset, row.logicalRow, offset - row.logicalStart, row.visualRow}
+		}
+	}
+	last := rows[len(rows)-1]
+	return composerCaret{last.logicalEnd, last.logicalRow, last.logicalEnd - last.logicalStart, last.visualRow}
+}
+
+func (m chatTUI) validComposerSelection() bool {
+	return m.composerSel.active && m.composerSel.value == m.input.Value()
+}
+
+func (m chatTUI) selectedComposerText() string {
+	if !m.validComposerSelection() || m.composerSel.empty() {
+		return ""
+	}
+	start, end := m.composerSel.ordered()
+	runes := []rune(m.input.Value())
+	if start < 0 || end > len(runes) {
+		return ""
+	}
+	return string(runes[start:end])
+}
+
+// composerOrigin returns the terminal cell occupied by textarea content (after
+// the input box's top border and left padding). Deriving it from the two cursor
+// positions keeps hit-testing aligned with every optional panel above the box.
+func (m chatTUI) composerOrigin() (x, y int, ok bool) {
+	if m.hideComposer() {
+		return 0, 0, false
+	}
+	local := m.input.Cursor()
+	view := m.View()
+	if local == nil || view.Cursor == nil {
+		return 0, 0, false
+	}
+	return view.Cursor.X - local.X, view.Cursor.Y - local.Y, true
+}
+
+func (m *chatTUI) composerCaretAt(screenX, screenY int, clamp bool) (composerCaret, bool) {
+	x, y, ok := m.composerOrigin()
+	if !ok {
+		return composerCaret{}, false
+	}
+	relY := screenY - y
+	if !clamp && (relY < 0 || relY >= m.input.Height()) {
+		return composerCaret{}, false
+	}
+	if relY < 0 {
+		relY = 0
+	}
+	if relY >= m.input.Height() {
+		relY = m.input.Height() - 1
+	}
+	rows := m.composerRows()
+	visualRow := m.input.ScrollYOffset() + relY
+	if visualRow < 0 {
+		visualRow = 0
+	}
+	if visualRow >= len(rows) {
+		visualRow = len(rows) - 1
+	}
+	return rows[visualRow].caretAt(screenX - x), true
+}
+
+func (m *chatTUI) setComposerCursor(offset int) {
+	rows := m.composerRows()
+	caret := composerCaretForOffset(rows, offset)
+	m.input.MoveToBegin()
+	for i := 0; i < caret.visualRow; i++ {
+		m.input.CursorDown()
+	}
+	m.input.SetCursorColumn(caret.logicalCol)
+}
+
+func (m *chatTUI) deleteComposerSelection() bool {
+	if !m.validComposerSelection() || m.composerSel.empty() {
+		m.composerSel = composerSelection{}
+		return false
+	}
+	start, end := m.composerSel.ordered()
+	runes := []rune(m.input.Value())
+	if start < 0 || end > len(runes) {
+		m.composerSel = composerSelection{}
+		return false
+	}
+	m.input.SetValue(string(runes[:start]) + string(runes[end:]))
+	m.composerSel = composerSelection{}
+	m.setComposerCursor(start)
+	return true
+}
+
+func composerSelectionDeletes(msg tea.KeyPressMsg, keyMap textarea.KeyMap) bool {
+	return key.Matches(msg, keyMap.DeleteAfterCursor) ||
+		key.Matches(msg, keyMap.DeleteBeforeCursor) ||
+		key.Matches(msg, keyMap.DeleteCharacterBackward) ||
+		key.Matches(msg, keyMap.DeleteCharacterForward) ||
+		key.Matches(msg, keyMap.DeleteWordBackward) ||
+		key.Matches(msg, keyMap.DeleteWordForward)
+}
+
+func composerSelectionReplaces(msg tea.KeyPressMsg, keyMap textarea.KeyMap) bool {
+	if key.Matches(msg, keyMap.InsertNewline) {
+		return true
+	}
+	if msg.Text == "" {
+		return false
+	}
+	commandMods := tea.ModCtrl | tea.ModMeta | tea.ModHyper | tea.ModSuper
+	return msg.Key().Mod&commandMods == 0
+}
+
+func composerRowSelectionSpan(row composerVisualRow, start, end int) (lo, hi int, ok bool) {
+	visualCol := 0
+	for _, cluster := range composerClusters(row) {
+		if cluster.endOffset > start && cluster.startOffset < end {
+			if !ok {
+				lo = cluster.startVisualCol
+				ok = true
+			}
+			hi = cluster.endVisualCol
+		}
+		visualCol = cluster.endVisualCol
+	}
+	// Make an explicitly selected newline visible, including on blank lines.
+	if end > row.logicalEnd && start <= row.logicalEnd && row.endOffset == row.logicalEnd {
+		if !ok {
+			lo = max(0, visualCol-1) // the textarea's trailing caret space
+			ok = true
+		}
+		hi = max(hi, lo+1)
+	}
+	return lo, hi, ok
+}
+
+func (m chatTUI) renderComposerInput() string {
+	view := m.input.View()
+	if !m.validComposerSelection() || m.composerSel.empty() {
+		return view
+	}
+	start, end := m.composerSel.ordered()
+	rows := m.composerRowsForRender()
+	lines := strings.Split(view, "\n")
+	visualStart := m.input.ScrollYOffset()
+	for i := range lines {
+		visualRow := visualStart + i
+		if visualRow >= len(rows) {
+			break
+		}
+		if lo, hi, ok := composerRowSelectionSpan(rows[visualRow], start, end); ok {
+			lines[i] = lipgloss.StyleRanges(lines[i], lipgloss.NewRange(lo, hi, selStyle))
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/cli/composer_selection_test.go
+++ b/internal/cli/composer_selection_test.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func newComposerMouseTestTUI(t *testing.T, width, height int) chatTUI {
+	t.Helper()
+	m := newChatTUI(control.New(control.Options{}), "", make(chan event.Event, 1), width)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	return next.(chatTUI)
+}
+
+func updateComposerMouseTestTUI(t *testing.T, m chatTUI, msg tea.Msg) chatTUI {
+	t.Helper()
+	next, _ := m.Update(msg)
+	return next.(chatTUI)
+}
+
+func TestComposerMouseClickMovesCursorAcrossWideRunes(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("你好abc")
+	x, y, ok := m.composerOrigin()
+	if !ok {
+		t.Fatal("composer should expose a mouse origin while visible")
+	}
+
+	// Each CJK rune occupies two terminal cells. Clicking after both should put
+	// the textarea cursor before the ASCII suffix, not leave it at the end.
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	if got := m.input.Column(); got != 2 {
+		t.Fatalf("cursor column = %d, want 2 after two wide runes", got)
+	}
+	if m.composerSel.active {
+		t.Fatal("a plain click should position the cursor without leaving a selection")
+	}
+}
+
+func TestComposerMouseLayoutRoundTripsTextareaCursor(t *testing.T) {
+	cases := []struct {
+		width int
+		value string
+	}{
+		{40, ""},
+		{20, "hello world and wrapped words"},
+		{16, "1234567890中文"},
+		{18, "alpha  beta\n中文 mixed\n\nlast"},
+		{18, "one\ntwo\nthree\nfour\nfive\nsix\nseven"},
+	}
+	for _, tc := range cases {
+		m := newComposerMouseTestTUI(t, tc.width, 14)
+		m.input.SetValue(tc.value)
+		for offset := 0; offset <= len([]rune(tc.value)); offset++ {
+			m.setComposerCursor(offset)
+			local := m.input.Cursor()
+			x, y, ok := m.composerOrigin()
+			if !ok || local == nil {
+				t.Fatalf("value %q offset %d has no composer cursor", tc.value, offset)
+			}
+			caret, ok := m.composerCaretAt(x+local.X, y+local.Y, false)
+			if !ok || caret.offset != offset {
+				t.Fatalf("value %q offset %d round-tripped to %+v (ok=%v)", tc.value, offset, caret, ok)
+			}
+		}
+	}
+}
+
+func TestComposerMouseDragSelectsAndTypingReplaces(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("你好abc")
+	x, y, _ := m.composerOrigin()
+
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+
+	if got := m.selectedComposerText(); got != "你好" {
+		t.Fatalf("selected composer text = %q, want %q", got, "你好")
+	}
+	highlighted := m.renderComposerInput()
+	if !strings.Contains(highlighted, selStyle.Render("你好")) {
+		t.Fatalf("rendered composer should highlight exactly the selected wide runes: %q", highlighted)
+	}
+
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: 'X', Text: "X"})
+	if got := m.input.Value(); got != "Xabc" {
+		t.Fatalf("typing over selection produced %q, want %q", got, "Xabc")
+	}
+	if m.composerSel.active {
+		t.Fatal("typing over a selection should clear the selection")
+	}
+}
+
+func TestComposerMouseBackwardDragKeepsLogicalSelection(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("alpha beta")
+	x, y, _ := m.composerOrigin()
+
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 6, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 6, Y: y, Button: tea.MouseLeft})
+	if got := m.selectedComposerText(); got != "beta" {
+		t.Fatalf("backward drag selected %q, want %q", got, "beta")
+	}
+}
+
+func TestComposerMouseSelectionSnapsToGraphemeClusters(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("e\u0301x 👨‍👩‍👧‍👦z")
+	x, y, _ := m.composerOrigin()
+
+	// The combining accent is a separate rune but part of the same one-cell
+	// grapheme, so a one-cell drag must select both runes together.
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 1, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 1, Y: y, Button: tea.MouseLeft})
+	if got := m.selectedComposerText(); got != "e\u0301" {
+		t.Fatalf("combining grapheme selection = %q, want %q", got, "e\u0301")
+	}
+
+	// The family emoji contains seven runes but renders as one two-cell grapheme.
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 3, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 5, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 5, Y: y, Button: tea.MouseLeft})
+	if got := m.selectedComposerText(); got != "👨‍👩‍👧‍👦" {
+		t.Fatalf("emoji grapheme selection = %q, want family emoji", got)
+	}
+}
+
+func TestComposerSelectionTracksSoftWrapAndNewlines(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 16, 14)
+	m.input.SetValue("1234567890中文\nsecond")
+	x, y, _ := m.composerOrigin()
+
+	// The configured textarea content width is 12 cells. Drag from the final two
+	// ASCII characters on the first visual row through the two wide CJK runes on
+	// the wrapped row and into the explicit second logical line.
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 3, Y: y + 2, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 3, Y: y + 2, Button: tea.MouseLeft})
+
+	if got, want := m.selectedComposerText(), "中文\nsec"; got != want {
+		t.Fatalf("wrapped multi-line selection = %q, want %q", got, want)
+	}
+
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if got, want := m.input.Value(), "1234567890ond"; got != want {
+		t.Fatalf("backspace over wrapped selection = %q, want %q", got, want)
+	}
+}
+
+func TestComposerSelectionPasteAndCopyTakePrecedence(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("alpha beta")
+	x, y, _ := m.composerOrigin()
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 6, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	m = next.(chatTUI)
+	if cmd == nil {
+		t.Fatal("Ctrl+C with a composer selection should issue a clipboard command")
+	}
+	if got := m.input.Value(); got != "alpha beta" {
+		t.Fatalf("Ctrl+C changed composer value to %q", got)
+	}
+	if got := m.selectedComposerText(); got != "beta" {
+		t.Fatalf("Ctrl+C should preserve composer selection, got %q", got)
+	}
+
+	m = updateComposerMouseTestTUI(t, m, tea.PasteMsg{Content: "gamma"})
+	if got := ansi.Strip(m.input.Value()); got != "alpha gamma" {
+		t.Fatalf("paste over selection produced %q, want %q", got, "alpha gamma")
+	}
+}
+
+func TestComposerSelectionDoesNotTurnCommandShortcutIntoText(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("keep this")
+	x, y, _ := m.composerOrigin()
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+
+	// Ctrl+Y is an application command and must not replace the selected draft.
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl})
+	if got := m.input.Value(); got != "keep this" {
+		t.Fatalf("Ctrl+Y changed selected composer text to %q", got)
+	}
+}
+
+func TestFailedImagePastePreservesComposerSelection(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("keep this")
+	x, y, _ := m.composerOrigin()
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+
+	m = updateComposerMouseTestTUI(t, m, tea.PasteMsg{Content: "/path/that/does/not/exist.png"})
+	if got := m.input.Value(); got != "keep this" {
+		t.Fatalf("failed image paste changed composer value to %q", got)
+	}
+	if got := m.selectedComposerText(); got != "keep" {
+		t.Fatalf("failed image paste should preserve selection, got %q", got)
+	}
+}

--- a/internal/cli/composer_selection_test.go
+++ b/internal/cli/composer_selection_test.go
@@ -198,6 +198,123 @@ func TestComposerSelectionDoesNotTurnCommandShortcutIntoText(t *testing.T) {
 	}
 }
 
+func TestComposerCtrlVKeepsSelectionUntilClipboardArrives(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("alpha beta")
+	x, y, _ := m.composerOrigin()
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + 6, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 10, Y: y, Button: tea.MouseLeft})
+
+	// The shortcut resolves the clipboard asynchronously, so the selection
+	// must survive the key press for the result to replace it.
+	next, cmd := m.Update(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+	m = next.(chatTUI)
+	if cmd == nil {
+		t.Fatal("Ctrl+V should issue an async clipboard read")
+	}
+	if got := m.selectedComposerText(); got != "beta" {
+		t.Fatalf("Ctrl+V should keep the selection until the clipboard arrives, got %q", got)
+	}
+
+	m = updateComposerMouseTestTUI(t, m, clipboardPasteMsg{text: "gamma"})
+	if got := m.input.Value(); got != "alpha gamma" {
+		t.Fatalf("clipboard paste over selection produced %q, want %q", got, "alpha gamma")
+	}
+	if m.validComposerSelection() && !m.composerSel.empty() {
+		t.Fatal("clipboard paste should consume the selection")
+	}
+}
+
+func TestComposerArrowKeysCollapseSelection(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("alpha beta")
+	x, y, _ := m.composerOrigin()
+	drag := func(m chatTUI, from, to int) chatTUI {
+		m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x + from, Y: y, Button: tea.MouseLeft})
+		m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + to, Y: y, Button: tea.MouseLeft})
+		return updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + to, Y: y, Button: tea.MouseLeft})
+	}
+
+	// Left/Right collapse to the ordered selection start/end without moving
+	// an extra character, for forward and backward drags alike.
+	m = drag(m, 6, 10)
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: tea.KeyLeft})
+	if m.composerSel.active {
+		t.Fatal("Left should dismiss the selection")
+	}
+	if got := m.input.Column(); got != 6 {
+		t.Fatalf("Left collapsed cursor to column %d, want 6 (selection start)", got)
+	}
+
+	m = drag(m, 6, 10)
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
+	if got := m.input.Column(); got != 10 {
+		t.Fatalf("Right collapsed cursor to column %d, want 10 (selection end)", got)
+	}
+
+	m = drag(m, 10, 6)
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: tea.KeyLeft})
+	if got := m.input.Column(); got != 6 {
+		t.Fatalf("Left after backward drag collapsed to column %d, want 6", got)
+	}
+
+	m = drag(m, 10, 6)
+	m = updateComposerMouseTestTUI(t, m, tea.KeyPressMsg{Code: tea.KeyRight})
+	if got := m.input.Column(); got != 10 {
+		t.Fatalf("Right after backward drag collapsed to column %d, want 10", got)
+	}
+
+	if got := m.input.Value(); got != "alpha beta" {
+		t.Fatalf("arrow keys changed composer value to %q", got)
+	}
+}
+
+func TestComposerNewlineSelectionHighlightsTrailingSpace(t *testing.T) {
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("abc\ndef")
+
+	// Selecting only the newline must highlight the caret space after the
+	// line, not the preceding character.
+	m.composerSel = composerSelection{active: true, anchor: 3, head: 4, value: m.input.Value()}
+	highlighted := m.renderComposerInput()
+	if strings.Contains(highlighted, selStyle.Render("c")) {
+		t.Fatalf("newline-only selection must not highlight the previous character: %q", highlighted)
+	}
+	if !strings.Contains(highlighted, "abc"+selStyle.Render(" ")) {
+		t.Fatalf("newline-only selection should highlight the trailing caret space: %q", highlighted)
+	}
+
+	// A selection covering content plus the newline extends one cell past it.
+	m.composerSel = composerSelection{active: true, anchor: 2, head: 4, value: m.input.Value()}
+	highlighted = m.renderComposerInput()
+	if !strings.Contains(highlighted, selStyle.Render("c ")) {
+		t.Fatalf("selecting the last char plus newline should highlight both cells: %q", highlighted)
+	}
+}
+
+func TestClipboardPasteOverWideSelectionRequestsClearScreen(t *testing.T) {
+	prev := clearWideInputChanges
+	clearWideInputChanges = true
+	defer func() { clearWideInputChanges = prev }()
+
+	m := newComposerMouseTestTUI(t, 40, 12)
+	m.input.SetValue("你好abc")
+	x, y, _ := m.composerOrigin()
+	m = updateComposerMouseTestTUI(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseMotionMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+	m = updateComposerMouseTestTUI(t, m, tea.MouseReleaseMsg{X: x + 4, Y: y, Button: tea.MouseLeft})
+
+	next, cmd := m.Update(clipboardPasteMsg{text: "hi"})
+	m = next.(chatTUI)
+	if got := m.input.Value(); got != "hiabc" {
+		t.Fatalf("clipboard paste over wide selection produced %q, want %q", got, "hiabc")
+	}
+	if cmd == nil {
+		t.Fatal("replacing a wide selection should request a full redraw")
+	}
+}
+
 func TestFailedImagePastePreservesComposerSelection(t *testing.T) {
 	m := newComposerMouseTestTUI(t, 40, 12)
 	m.input.SetValue("keep this")


### PR DESCRIPTION
## Summary

- add left-click cursor placement and drag selection to the CLI composer while keeping Reasonix mouse capture enabled
- make composer selections editable: typing, newline, delete, backspace, file/text paste, and image insertion replace the selected range; Ctrl/Cmd+C and right-click copy it
- align hit testing with the existing textarea's soft wrapping, internal scrolling, wide characters, combining marks, and ZWJ grapheme clusters
- preserve the draft and selection when an image-shaped paste is recognized but cannot be saved

## Verification

- `go test ./internal/cli/... -count=1`
- `go test -race ./internal/cli/... -count=1`
- `go vet ./internal/cli/...`
- `go build ./...`
- Windows amd64 test-binary cross-compilation for `./internal/cli`
- `go test ./internal/provider/openai -skip '^TestRealDeepSeekCacheProbe$' -count=1`
- `go test ./... -count=1` passed all packages except the live `TestRealDeepSeekCacheProbe`, which returned HTTP 401 because the local DeepSeek credential is invalid or expired

## Cache impact

Cache-impact: none — this is limited to CLI mouse/input state and rendering; it does not change provider-visible prompts, tool schemas, request serialization, memory prefixes, or compaction.
Cache-guard: `go test ./internal/cli/... -count=1`, `go test -race ./internal/cli/... -count=1`, and `go build ./...`.
System-prompt-review: N/A
