### PR TITLE
fix(agent): Let plans reach approval before delivery readiness / 让计划先完成审批再执行交付检查

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1607,16 +1607,29 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	}
 	var missing []string
 	out := finalReadinessCheck{}
-	if !a.planMode.Load() {
-		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
-		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
-			incomplete, hasTodos = a.incompleteCanonicalTodos()
+	// Planning returns a proposal to the controller, which owns the approval
+	// gate and starts a fresh execution turn after plan mode is disabled. Applying
+	// delivery execution requirements here would demand mutations that plan mode
+	// itself blocks, preventing the proposal from ever reaching that approval.
+	// Explicit capability requirements still apply because read-only skills and
+	// tools may be required to produce the plan itself.
+	if a.planMode.Load() {
+		if a.deliveryProfile {
+			if msg := a.capabilityGateFailure(); msg != "" {
+				out.applies = true
+				out.reason = msg
+			}
 		}
-		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
-			out.applies = true
-			out.incompleteTodos = len(incomplete)
-			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
-		}
+		return out
+	}
+	incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
+	if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
+		incomplete, hasTodos = a.incompleteCanonicalTodos()
+	}
+	if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
+		out.applies = true
+		out.incompleteTodos = len(incomplete)
+		missing = append(missing, finalReadinessIncompleteTodos(incomplete))
 	}
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	deliveryMutation := false

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1612,11 +1612,17 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	// delivery execution requirements here would demand mutations that plan mode
 	// itself blocks, preventing the proposal from ever reaching that approval.
 	// Explicit capability requirements still apply because read-only skills and
-	// tools may be required to produce the plan itself.
+	// tools may be required to produce the plan itself. The loop-guard pass
+	// applies here as in execution: a required capability that plan mode itself
+	// blocks can never succeed, so once a loop guard fires the model must be
+	// free to report the blocker instead of exhausting readiness retries.
 	if a.planMode.Load() {
 		if a.deliveryProfile {
 			if msg := a.capabilityGateFailure(); msg != "" {
 				out.applies = true
+				if a.loopGuardAllowsFinal() {
+					return out
+				}
 				out.reason = msg
 			}
 		}

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -119,6 +119,35 @@ func TestReadOnlyRegistryDisarmsMutationExpectation(t *testing.T) {
 	}
 }
 
+func TestDeliveryPlanModeReturnsProposalBeforeExecutionReadiness(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeWriterTool{})
+	proposal := "1. Fix the parser\n   - update a.go\n   - run the focused tests"
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: proposal}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession("sys"), Options{DeliveryProfile: true}, event.Discard)
+	a.SetPlanMode(true)
+
+	if err := a.Run(context.Background(), "fix the parser bug in a.go"); err != nil {
+		t.Fatalf("delivery plan proposal was blocked by execution readiness: %v", err)
+	}
+	if prov.call != 1 {
+		t.Fatalf("provider calls = %d, want 1 without readiness retries in plan mode", prov.call)
+	}
+	if got := lastAssistantContent(a.Session()); got != proposal {
+		t.Fatalf("last assistant text = %q, want proposal %q", got, proposal)
+	}
+
+	// Approval disables plan mode before the controller starts execution. The
+	// same delivery expectations must become enforceable again at that boundary.
+	a.SetPlanMode(false)
+	if got := a.finalReadinessFailure(); !strings.Contains(got, "state change") {
+		t.Fatalf("execution readiness did not resume after plan mode: %q", got)
+	}
+}
+
 func TestRunSubAgentReviewReportNudgeRecovers(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeReadFileTool{})

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -179,6 +179,58 @@ func TestPlanModeCapabilityGateHonorsLoopGuardPass(t *testing.T) {
 	}
 }
 
+// fakeMCPDeployTool is a write-capable tool with an MCP-style name, so a call
+// maps to the mcp-tool:srv/deploy capability and plan mode blocks it.
+type fakeMCPDeployTool struct{}
+
+func (fakeMCPDeployTool) Name() string            { return "mcp__srv__deploy" }
+func (fakeMCPDeployTool) Description() string     { return "fake deploy" }
+func (fakeMCPDeployTool) ReadOnly() bool          { return false }
+func (fakeMCPDeployTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (fakeMCPDeployTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "deployed", nil
+}
+
+// TestPlanModeBlockedRequiredCapabilityRecoversViaLoopGuard drives the full
+// failure loop from the review finding through Run(): a required write-capable
+// capability is attempted three times, each blocked by plan mode, which arms
+// the loop-guard pass via the storm breaker; the following blocker report must
+// then be accepted instead of exhausting readiness retries.
+func TestPlanModeBlockedRequiredCapabilityRecoversViaLoopGuard(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeMCPDeployTool{})
+	blocker := "The required deploy capability is blocked while plan mode is active; it needs approval before execution."
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("1", "mcp__srv__deploy", `{"target":"prod"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("2", "mcp__srv__deploy", `{"target":"staging"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("3", "mcp__srv__deploy", `{"target":"prod","force":true}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: blocker}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession("sys"),
+		Options{DeliveryProfile: true, CapabilityLedger: capability.NewLedger()}, event.Discard)
+	a.SetPlanMode(true)
+	a.SeedCapabilityRoute(capability.RouteDecision{Candidates: []capability.RouteCandidate{
+		{Entry: capability.Entry{ID: "mcp-tool:srv/deploy"}, Policy: capability.AutoUseRequire},
+	}})
+
+	if err := a.Run(context.Background(), "deploy the parser fix"); err != nil {
+		t.Fatalf("plan-blocked required capability ended in readiness exhaustion: %v", err)
+	}
+	if !a.loopGuardArmed {
+		t.Fatal("three plan-mode blocks should arm the final-readiness loop-guard pass")
+	}
+	if got := lastToolResult(a.Session(), "mcp__srv__deploy"); !strings.Contains(got, "[loop guard]") {
+		t.Fatalf("third blocked attempt should carry the loop-guard directive, got: %q", got)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want 4 (three blocked attempts + one blocker report)", prov.call)
+	}
+	if got := lastAssistantContent(a.Session()); got != blocker {
+		t.Fatalf("last assistant text = %q, want blocker report %q", got, blocker)
+	}
+}
+
 func TestRunSubAgentReviewReportNudgeRecovers(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeReadFileTool{})

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/capability"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
@@ -145,6 +146,36 @@ func TestDeliveryPlanModeReturnsProposalBeforeExecutionReadiness(t *testing.T) {
 	a.SetPlanMode(false)
 	if got := a.finalReadinessFailure(); !strings.Contains(got, "state change") {
 		t.Fatalf("execution readiness did not resume after plan mode: %q", got)
+	}
+}
+
+// TestPlanModeCapabilityGateHonorsLoopGuardPass covers the case where a
+// required capability is itself blocked by plan mode (for example a writer
+// skill): the capability gate keeps applying in plan mode, but once a loop
+// guard fires with no host-observable progress since, readiness must stand
+// down so the model can report the blocker instead of ending in readiness
+// exhaustion.
+func TestPlanModeCapabilityGateHonorsLoopGuardPass(t *testing.T) {
+	reg := tool.NewRegistry()
+	a := New(&scriptedProvider{name: "p"}, reg, NewSession("sys"),
+		Options{DeliveryProfile: true, CapabilityLedger: capability.NewLedger()}, event.Discard)
+	a.SetPlanMode(true)
+	a.SeedCapabilityRoute(capability.RouteDecision{Candidates: []capability.RouteCandidate{
+		{Entry: capability.Entry{ID: "skill:deploy"}, Policy: capability.AutoUseRequire},
+	}})
+
+	if got := a.finalReadinessCheck(); !strings.Contains(got.reason, "required capabilities") {
+		t.Fatalf("expected require miss to apply in plan mode, reason=%q", got.reason)
+	}
+
+	a.armLoopGuardPass(a.evidence.Len())
+
+	got := a.finalReadinessCheck()
+	if !got.applies {
+		t.Fatal("finalReadinessCheck() applies = false, want true audit after loop guard")
+	}
+	if got.reason != "" {
+		t.Fatalf("finalReadinessCheck() reason = %q, want loop guard to allow final blocker report in plan mode", got.reason)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Let plan-mode turns return their proposal to the controller before delivery execution readiness is evaluated.
- Keep explicit Skill/MCP capability requirements active while planning, while deferring mutation, verification, review, and `complete_step` requirements until plan approval disables plan mode.
- Add an end-to-end regression test proving a delivery-profile plan returns after one provider call and that execution readiness resumes after leaving plan mode.

The previous ordering let delivery final-readiness intercept the planner's final text before the controller could issue `exit_plan_mode`. The resulting retry asked the model for mutation evidence while plan mode rejected every writer and `complete_step`, producing repeated ask/write/block loops.

Fixes #6440

## Verification

- `env -u DEEPSEEK_API_KEY go test ./...`
- `./scripts/cache-guard.sh` (all scenarios passed; tail averages 92-95%)
- `git diff --check`

## Compatibility

| Surface | Old-data behavior | Result |
| --- | --- | --- |
| Session and config data | No persisted fields or formats changed | No migration |
| Plan approval flow | Existing `exit_plan_mode` approval still disables plan mode before the execution turn | Compatible |
| Delivery execution gates | Existing mutation, verification, review, and sign-off checks remain active after plan approval | Preserved |

## Cache impact

Cache-impact: none - no system prompt, tool schema/order, provider request serialization, or stable prefix changed; the fix only suppresses invalid readiness retries during plan mode.
Cache-guard: `./scripts/cache-guard.sh` passed all scenarios with 92-95% tail averages.
System-prompt-review: N/A
