### PR TITLE
fix(desktop): Make classic tabbar whitespace draggable / 经典标签栏空白区支持拖动窗口

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -79,6 +79,18 @@ ok(
 );
 
 ok(
+  finalDeclaration(".app--darwin .app-chrome--tabs .tabbar", "--wails-draggable") === "drag" &&
+    finalDeclaration(".app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .tabbar", "--wails-draggable") === "drag",
+  "classic tabbar whitespace drags the window on macOS and frameless Windows",
+);
+
+ok(
+  finalDeclaration(".app--darwin .app-chrome--tabs .tabbar *", "--wails-draggable") === "no-drag" &&
+    finalDeclaration(".app--windows .app-chrome--native-tabs .tabbar *", "--wails-draggable") === "no-drag",
+  "classic tabbar controls and tab gaps remain interactive no-drag regions",
+);
+
+ok(
   /const WORKSPACE_PANEL_DEFAULT_OPEN = true;/.test(layoutStoreSource) &&
     /workspacePanelOpen:\s*WORKSPACE_PANEL_DEFAULT_OPEN/.test(layoutStoreSource),
   "right dock starts expanded on launch",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -19506,7 +19506,10 @@ body > .mermaid-diagram--fullscreen {
   transition: padding 0.28s cubic-bezier(0.2, 0.72, 0.2, 1);
 }
 
-.app--darwin .app-chrome--tabs .tabbar,
+.app--darwin .app-chrome--tabs .tabbar {
+  --wails-draggable: drag;
+}
+
 .app--darwin .app-chrome--tabs .tabbar * {
   --wails-draggable: no-drag;
 }
@@ -19829,6 +19832,10 @@ body > .mermaid-diagram--fullscreen {
 .app--windows .app-chrome--native-tabs .tabbar *,
 .app--linux .app-chrome--native-tabs .tabbar * {
   --wails-draggable: no-drag;
+}
+
+.app--windows-frameless:not(.app--workbench):not(.app--creation) .app-chrome--native-tabs .tabbar {
+  --wails-draggable: drag;
 }
 
 .app--windows .app-chrome--native-tabs .app-chrome__identity {


### PR DESCRIPTION
## Summary

- Allow only unused classic tabbar whitespace to inherit the Wails drag region on macOS and frameless Windows.
- Keep tab content, tab-list gaps, the new-tab control, search, and other interactive descendants as no-drag regions.
- Add source-level regression coverage for the parent drag and descendant no-drag boundary.
- Adapt the core direction from #6286 while narrowing the platform and interaction scope; credit is preserved for @SauronSkywalker in the commit trailer.

Fixes #6251
Refs #6286

## Compatibility

| Surface | Existing behavior | Conclusion |
| --- | --- | --- |
| Persisted data and configuration | Unchanged | Backward compatible |
| Workbench and creation layouts | Unchanged | Backward compatible |
| Linux native chrome | Unchanged | Backward compatible |

## Verification

- `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts` — 82 passed
- `pnpm test:typecheck`
- `pnpm check:css`
- `git diff --check`
- Browser DOM/CSS check at 1440x900: empty space resolves to `.tabbar` with `--wails-draggable: drag`; tabs, tab list, new-tab, and search controls resolve to `no-drag`
- Native window movement still requires a Wails desktop runtime check

## Cache impact

Cache-impact: none — desktop-only CSS and regression-test changes; no provider-visible prompt, tool schema, request serialization, or cache-key changes.
Cache-guard: N/A — existing cache behavior is untouched; focused desktop frontend checks cover this change.
System-prompt-review: N/A