### PR TITLE
Fix Goal + Delivery + YOLO lifecycle integration / 修复目标、交付与 YOLO 组合生命周期

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -913,8 +913,6 @@ func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
 		if tab == nil {
 			return a.workspaceNotReadyErr(tab)
 		}
-		tab.turnStartMu.Lock()
-		defer tab.turnStartMu.Unlock()
 		if !fromBridge && a.botBridge != nil {
 			a.botBridge.reclaimFromDesktop(tab.ID)
 		}
@@ -1388,10 +1386,15 @@ func (a *App) SetMode(mode string) {
 }
 
 func (a *App) SetModeForTab(tabID, mode string) {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return
+	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	normalized := normalizeTabMode(mode)
 	a.mu.Lock()
-	tab := a.tabByIDLocked(tabID)
-	if tab == nil {
+	if a.tabs[tab.ID] != tab {
 		a.mu.Unlock()
 		return
 	}
@@ -1465,10 +1468,15 @@ func (a *App) SetCollaborationMode(mode string) {
 }
 
 func (a *App) SetCollaborationModeForTab(tabID, mode string) {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return
+	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	mode = normalizeCollaborationMode(mode)
 	a.mu.Lock()
-	tab := a.tabByIDLocked(tabID)
-	if tab == nil {
+	if a.tabs[tab.ID] != tab {
 		a.mu.Unlock()
 		return
 	}
@@ -1490,7 +1498,7 @@ func (a *App) SetCollaborationModeForTab(tabID, mode string) {
 	a.mu.Unlock()
 	if ctrl != nil {
 		ctrl.SetPlanMode(plan)
-		ctrl.SetGoal(goal)
+		syncTabGoalToController(ctrl, goal)
 	}
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
@@ -1758,6 +1766,8 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	// runtimeRebuildMu → sessionRemovalMu (no path acquires them in reverse).
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	// This path destroys the old session's files (removeDesktopSessionArtifacts);
 	// serialize with DeleteSession/TrashTopic/workspace removal so they never
 	// trash or restore the same files mid-clear.
@@ -3247,6 +3257,8 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	// controller can be double-closed.
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 
 	// Validate the tab, compare session keys, invalidate any in-flight async
 	// build, and snapshot the controller in ONE a.mu critical section.
@@ -5566,10 +5578,15 @@ func (a *App) SetGoal(goal string) {
 }
 
 func (a *App) SetGoalForTab(tabID, goal string) {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return
+	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	goal = strings.TrimSpace(goal)
 	a.mu.Lock()
-	tab := a.tabByIDLocked(tabID)
-	if tab == nil {
+	if a.tabs[tab.ID] != tab {
 		a.mu.Unlock()
 		return
 	}
@@ -5583,7 +5600,7 @@ func (a *App) SetGoalForTab(tabID, goal string) {
 	a.mu.Unlock()
 	if ctrl != nil {
 		ctrl.SetPlanMode(plan)
-		ctrl.SetGoal(goal)
+		syncTabGoalToController(ctrl, goal)
 	}
 	a.mu.Lock()
 	if a.tabs[tabIDForSave] == tab {
@@ -5592,12 +5609,49 @@ func (a *App) SetGoalForTab(tabID, goal string) {
 	a.mu.Unlock()
 }
 
+// The composer re-syncs collaboration mode and Goal immediately before every
+// send. Keep those acknowledgements idempotent so one multi-turn Goal retains
+// its delivery scope; a terminal Goal with the same text still starts a fresh
+// scope when the user explicitly enters it again.
+func syncTabGoalToController(ctrl control.SessionAPI, goal string) {
+	if ctrl == nil {
+		return
+	}
+	goal = strings.TrimSpace(goal)
+	if goal != "" && strings.TrimSpace(ctrl.Goal()) == goal && ctrl.GoalStatus() == control.GoalStatusRunning {
+		return
+	}
+	ctrl.SetGoal(goal)
+}
+
 func (a *App) ClearGoal() {
 	a.SetGoal("")
 }
 
 func (a *App) ClearGoalForTab(tabID string) {
 	a.SetGoalForTab(tabID, "")
+}
+
+// ResumeGoalForTab re-enters a blocked or stopped Goal while preserving its
+// delivery scope and persisted verification checkpoint.
+func (a *App) ResumeGoalForTab(tabID string) bool {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return false
+	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
+	ctrl := a.controllerForTab(tab)
+	if ctrl == nil || !ctrl.ResumeGoal() {
+		return false
+	}
+	a.mu.Lock()
+	if a.tabs[tab.ID] == tab {
+		tab.goal = strings.TrimSpace(ctrl.Goal())
+		a.saveTabsLocked()
+	}
+	a.mu.Unlock()
+	return true
 }
 
 // SetAutoApproveTools toggles YOLO/full-access tool auto-approval:
@@ -5621,10 +5675,15 @@ func (a *App) SetToolApprovalMode(mode string) {
 }
 
 func (a *App) SetToolApprovalModeForTab(tabID, mode string) {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return
+	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	mode = normalizeToolApprovalMode(mode)
 	a.mu.Lock()
-	tab := a.tabByIDLocked(tabID)
-	if tab == nil {
+	if a.tabs[tab.ID] != tab {
 		a.mu.Unlock()
 		return
 	}
@@ -7490,6 +7549,8 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	// switch cannot interleave on one tab.
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
 		prevPath = a.currentSessionPathFor(tab)
@@ -7582,14 +7643,13 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	newCtrl.EnableInteractiveApproval()
 	applyTabModeToController(newCtrl, snap.mode)
 	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
-	newCtrl.SetGoal(snap.goal)
 
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "model"); err != nil {
 		newCtrl.Close()
 		return err
 	}
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
+	resumeWithFreshSystemPromptAndGoal(newCtrl, carried, path, snap.goal)
 	a.mu.Lock()
 	if current := a.tabs[tab.ID]; current != tab {
 		// The tab was closed/replaced while we built the new controller off-lock;
@@ -7664,6 +7724,8 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	// applyProviderEffortConfig → rebuildSetting, which takes the lock itself.
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
 		prevPath = a.currentSessionPathFor(tab)
@@ -7738,13 +7800,12 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	newCtrl.EnableInteractiveApproval()
 	applyTabModeToController(newCtrl, snap.mode)
 	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
-	newCtrl.SetGoal(snap.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "effort"); err != nil {
 		newCtrl.Close()
 		return err
 	}
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
+	resumeWithFreshSystemPromptAndGoal(newCtrl, carried, path, snap.goal)
 	a.mu.Lock()
 	if current := a.tabs[tab.ID]; current != tab {
 		a.mu.Unlock()
@@ -7793,6 +7854,8 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	// Build+swap path; serialize with the other rebuild paths (see runtimeRebuildMu).
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	prevPath := a.reconciledSessionPathForTab(tab)
 	if prevPath == "" {
 		prevPath = a.currentSessionPathFor(tab)
@@ -7866,13 +7929,12 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	newCtrl.EnableInteractiveApproval()
 	applyTabModeToController(newCtrl, snap.mode)
 	applyTabToolApprovalModeToController(newCtrl, snap.toolApprovalMode)
-	newCtrl.SetGoal(snap.goal)
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if err := a.ensureTabSessionLeaseForRebuild(tab, path, "token mode"); err != nil {
 		newCtrl.Close()
 		return err
 	}
-	resumeWithFreshSystemPrompt(newCtrl, carried, path)
+	resumeWithFreshSystemPromptAndGoal(newCtrl, carried, path, snap.goal)
 	a.mu.Lock()
 	if current := a.tabs[tab.ID]; current != tab {
 		a.mu.Unlock()

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -170,6 +170,7 @@ import { createRafResizeUpdater } from "./lib/resizeDrag";
 import { useGlobalShortcut } from "./lib/keyboardShortcuts";
 import { topicShortcutIndexFromEvent, useTopicShortcuts, type TopicShortcutEntry } from "./lib/topicShortcuts";
 import { composerDraftKeyForTab } from "./lib/composerDraftKey";
+import { continueDelivery } from "./lib/deliveryContinue";
 import logoWordmark from "./assets/logo-wordmark.svg";
 
 function noticePreviewMockEnabled(): boolean {
@@ -2614,13 +2615,15 @@ export default function App() {
   }, [activeTabId, commitThenSend, controllerReady]);
 
   const handleDeliveryContinue = useCallback(async () => {
-    const tabId = activeTabIdRef.current;
-    if (!tabId || !controllerReady) return;
-    const resumed = await resumeControllerGoalForTab(tabId);
-    if (!resumed) return;
-    if (activeTabIdRef.current !== tabId) return;
-    await commitThenSend(tabId, t("notice.deliveryIncompleteContinuePrompt"));
-  }, [commitThenSend, controllerReady, resumeControllerGoalForTab, t]);
+    await continueDelivery({
+      tabId: activeTabIdRef.current,
+      ready: controllerReady,
+      goal: state.meta?.goal,
+      activeTabId: () => activeTabIdRef.current,
+      resumeGoal: resumeControllerGoalForTab,
+      send: (tabId) => commitThenSend(tabId, t("notice.deliveryIncompleteContinuePrompt")),
+    });
+  }, [commitThenSend, controllerReady, resumeControllerGoalForTab, state.meta?.goal, t]);
   commitThenSendRef.current = commitThenSend;
 
   const handleMessageAction = useCallback((turn: number, scope: string) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1008,6 +1008,7 @@ export default function App() {
     setToolApprovalModeForTab: setControllerToolApprovalModeForTab,
     setGoal: setControllerGoal,
     setGoalForTab: setControllerGoalForTab,
+    resumeGoalForTab: resumeControllerGoalForTab,
     clearGoal: clearControllerGoal,
     clearSession,
     listSessions,
@@ -1041,6 +1042,8 @@ export default function App() {
   const { locale, setPref: setLocalePref } = useI18n();
   const t = useT();
   const [composerProfilesByTab, setComposerProfilesByTab] = useState<Record<string, ComposerProfile>>({});
+  const runtimeTransitionTabsRef = useRef<Set<string>>(new Set());
+  const [runtimeTransitionsByTab, setRuntimeTransitionsByTab] = useState<Record<string, true>>({});
   const yoloRestoreToolApprovalModesRef = useRef<Record<string, RestorableToolApprovalMode>>({});
   const userPlanModeByTabRef = useRef<UserPlanModeIntents>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
@@ -1504,7 +1507,8 @@ export default function App() {
   const collaborationMode = displayedComposerProfileCollaborationMode(composerProfile);
   const toolApprovalMode = composerProfile.toolApprovalMode;
   const tokenMode: TokenMode = composerProfile.tokenMode;
-  const controllerReady = state.meta?.ready === true && !state.backendActivationPending;
+  const runtimeTransitioning = Boolean(activeTabId && runtimeTransitionsByTab[activeTabId]);
+  const controllerReady = state.meta?.ready === true && !state.backendActivationPending && !runtimeTransitioning;
   // Single footer decision surface. Composer stays mounted underneath and is
   // only visually/a11y-hidden so per-session draft caches survive.
   const decisionSurface = useMemo((): DecisionSurfaceKind | null => {
@@ -1656,7 +1660,7 @@ export default function App() {
     applyToolApprovalMode(next.mode);
   }, [activeTabId, applyToolApprovalMode, toolApprovalMode]);
   const applyGoal = useCallback(
-    (nextGoal: string) => {
+    async (nextGoal: string): Promise<void> => {
       userPlanModeByTabRef.current = updateUserPlanModeIntent(userPlanModeByTabRef.current, activeTabId, false);
       const trimmed = nextGoal.trim();
       patchActiveComposerProfile({
@@ -1664,16 +1668,36 @@ export default function App() {
         goalDraftMode: false,
         goal: trimmed,
       }, ["collaborationMode", "goal"]);
-      void (trimmed ? setControllerGoal(trimmed) : clearControllerGoal());
+      await (trimmed ? setControllerGoal(trimmed) : clearControllerGoal());
     },
     [activeTabId, clearControllerGoal, patchActiveComposerProfile, setControllerGoal],
   );
   const applyTokenMode = useCallback(
-    (m: TokenMode) => {
-      patchActiveComposerProfile({ tokenMode: m }, ["tokenMode"]);
-      void setTokenMode(m);
+    async (m: TokenMode): Promise<void> => {
+      const tabId = activeTabId;
+      if (!tabId || runtimeTransitionTabsRef.current.has(tabId) || m === composerProfile.tokenMode) return;
+      const previous = composerProfile.tokenMode;
+      runtimeTransitionTabsRef.current.add(tabId);
+      setRuntimeTransitionsByTab((current) => ({ ...current, [tabId]: true }));
+      setComposerProfilesByTab((current) => patchComposerProfile(current, tabId, composerProfile, { tokenMode: m }, ["tokenMode"]));
+      const switched = await setTokenMode(m);
+      if (!switched) {
+        setComposerProfilesByTab((current) => {
+          const profile = current[tabId] ?? composerProfile;
+          const pending = { ...profile.pending };
+          delete pending.tokenMode;
+          return { ...current, [tabId]: { ...profile, tokenMode: previous, pending } };
+        });
+      }
+      runtimeTransitionTabsRef.current.delete(tabId);
+      setRuntimeTransitionsByTab((current) => {
+        if (!current[tabId]) return current;
+        const next = { ...current };
+        delete next[tabId];
+        return next;
+      });
     },
-    [patchActiveComposerProfile, setTokenMode],
+    [activeTabId, composerProfile, setTokenMode],
   );
   // Shift+Tab toggles only the collaboration axis; Ctrl/Cmd+Y toggles YOLO on the
   // tool-permission axis while preserving the Ask/Auto base mode.
@@ -1902,10 +1926,10 @@ export default function App() {
               goal: displayGoal,
             }, ["collaborationMode", "goal"]);
           } else {
-            applyGoal(displayGoal);
+            await applyGoal(displayGoal);
           }
         } else if (["clear", "off", "stop", "done"].includes(displayGoal.toLowerCase())) {
-          applyGoal("");
+          await applyGoal("");
         }
         if (!controllerReady) return;
         await commitThenSendRef.current(sourceTabId, trimmed, submitText.trim());
@@ -1913,7 +1937,7 @@ export default function App() {
       }
       if (collaborationMode === "goal" && !goal.trim()) {
         if (!controllerReady) return;
-        applyGoal(trimmed);
+        await applyGoal(trimmed);
         await commitThenSendRef.current(sourceTabId, trimmed, `/goal ${submitText.trim()}`);
         return;
       }
@@ -2588,6 +2612,15 @@ export default function App() {
       console.warn("Failed to submit transcript prompt", err);
     });
   }, [activeTabId, commitThenSend, controllerReady]);
+
+  const handleDeliveryContinue = useCallback(async () => {
+    const tabId = activeTabIdRef.current;
+    if (!tabId || !controllerReady) return;
+    const resumed = await resumeControllerGoalForTab(tabId);
+    if (!resumed) return;
+    if (activeTabIdRef.current !== tabId) return;
+    await commitThenSend(tabId, t("notice.deliveryIncompleteContinuePrompt"));
+  }, [commitThenSend, controllerReady, resumeControllerGoalForTab, t]);
   commitThenSendRef.current = commitThenSend;
 
   const handleMessageAction = useCallback((turn: number, scope: string) => {
@@ -3745,6 +3778,7 @@ export default function App() {
                 tabId={activeTabId}
                 footerHeight={footerHeight}
                 onPrompt={handleTranscriptPrompt}
+                onDeliveryContinue={() => void handleDeliveryContinue()}
                 onEditPrompt={handleEditPrompt}
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
@@ -3882,7 +3916,7 @@ export default function App() {
               onSetTokenMode={applyTokenMode}
               insertRequest={composerInsertRequest}
               readOnly={Boolean(activeTab?.readOnly)}
-              disabled={rewindCommitting || state.messageAction != null || Boolean(decisionSurface)}
+              disabled={runtimeTransitioning || rewindCommitting || state.messageAction != null || Boolean(decisionSurface)}
               submitDisabled={!controllerReady}
               decisionPending={rewindCommitting || state.messageAction != null || Boolean(decisionSurface)}
               ready={controllerReady}

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -243,7 +243,7 @@ ok(
 );
 
 ok(
-  /const controllerReady = state\.meta\?\.ready === true && !state\.backendActivationPending;/.test(appSource) &&
+  /const controllerReady = state\.meta\?\.ready === true && !state\.backendActivationPending && !runtimeTransitioning;/.test(appSource) &&
     /if \(!activeTabId \|\| !controllerReady\) return;\s*void commitThenSend\(activeTabId, text\)\.catch/.test(appSource) &&
     /onPrompt=\{handleTranscriptPrompt\}/.test(appSource) &&
     /submitDisabled=\{!controllerReady\}/.test(appSource),

--- a/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
@@ -209,6 +209,26 @@ console.log("\ncomposer run strip");
   dom.window.close();
 }
 
+// Runtime controller transitions disable every mode axis and submit together,
+// so rapid Goal + Delivery + YOLO clicks cannot mutate a half-rebuilt runtime.
+{
+  const dom = installDom();
+  const { root } = await renderComposer({ disabled: true, goal: "ship it", collaborationMode: "goal" });
+  const profile = document.querySelector<HTMLButtonElement>(".composer-profile-trigger");
+  const task = document.querySelector<HTMLButtonElement>(".composer-task-mode-trigger");
+  const approvals = Array.from(document.querySelectorAll<HTMLButtonElement>(".composer-modebar--approval button"));
+  const send = document.querySelector<HTMLButtonElement>(".composer__btn--send");
+  ok(Boolean(profile?.disabled), "runtime transition disables Delivery profile changes");
+  ok(Boolean(task?.disabled), "runtime transition disables Goal mode changes");
+  ok(approvals.length === 3 && approvals.every((button) => button.disabled), "runtime transition disables Ask/Auto/YOLO changes");
+  ok(Boolean(send?.disabled), "runtime transition disables submit");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 // Running: strip lives inside the card, ticker is aria-hidden, stop cancels.
 {
   const dom = installDom();

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { initialState, reducer, replayPendingPromptsForActiveTab } from "../lib/useController";
+import { continueDelivery } from "../lib/deliveryContinue";
 import type { WireEvent } from "../lib/types";
 
 let passed = 0;
@@ -168,9 +169,9 @@ eq(
   "runtime profile transitions keep submit behind the controller-ready gate",
 );
 eq(
-  /const resumed = await resumeControllerGoalForTab\(tabId\);[\s\S]{0,80}if \(!resumed\) return;[\s\S]{0,180}await commitThenSend/.test(appSource),
+  /await continueDelivery\(\{[\s\S]{0,240}goal: state\.meta\?\.goal,[\s\S]{0,240}resumeGoal: resumeControllerGoalForTab,/.test(appSource),
   true,
-  "delivery recovery submits the continuation only after a blocked Goal resumes",
+  "delivery recovery routes through continueDelivery with the backend Goal state",
 );
 eq(
   /await applyGoal\(trimmed\);[\s\S]{0,120}await commitThenSendRef\.current\(sourceTabId/.test(appSource),
@@ -214,6 +215,63 @@ replayPendingPromptsForActiveTab("tab-b", () => {
 });
 await new Promise((resolve) => setTimeout(resolve, 0));
 eq(replayCalls, 2, "replay bridge failures are swallowed by the tab-switch effect");
+
+console.log("\ndelivery recovery continuation");
+
+interface ContinueCalls {
+  resumes: string[];
+  sends: string[];
+}
+
+async function runContinueDelivery(opts: {
+  goal: string | undefined;
+  resumed?: boolean;
+  ready?: boolean;
+  tabId?: string | null;
+  tabAfterResume?: string;
+}): Promise<ContinueCalls> {
+  const calls: ContinueCalls = { resumes: [], sends: [] };
+  await continueDelivery({
+    tabId: opts.tabId === undefined ? "tab-a" : opts.tabId,
+    ready: opts.ready ?? true,
+    goal: opts.goal,
+    activeTabId: () => opts.tabAfterResume ?? "tab-a",
+    resumeGoal: (tabId) => {
+      calls.resumes.push(tabId);
+      return Promise.resolve(opts.resumed ?? true);
+    },
+    send: (tabId) => {
+      calls.sends.push(tabId);
+      return Promise.resolve();
+    },
+  });
+  return calls;
+}
+
+const noGoal = await runContinueDelivery({ goal: undefined });
+eq(noGoal.resumes.length, 0, "delivery recovery without a Goal skips the resume call");
+eq(noGoal.sends.join(","), "tab-a", "delivery recovery without a Goal submits the continuation directly");
+
+const blankGoal = await runContinueDelivery({ goal: "   " });
+eq(blankGoal.resumes.length, 0, "delivery recovery treats a blank Goal as absent");
+eq(blankGoal.sends.join(","), "tab-a", "delivery recovery with a blank Goal still submits the continuation");
+
+const goalResumed = await runContinueDelivery({ goal: "ship it", resumed: true });
+eq(goalResumed.resumes.join(","), "tab-a", "delivery recovery with a Goal resumes it first");
+eq(goalResumed.sends.join(","), "tab-a", "delivery recovery submits after the Goal resumes");
+
+const goalRefused = await runContinueDelivery({ goal: "ship it", resumed: false });
+eq(goalRefused.resumes.join(","), "tab-a", "an unresumable Goal is still offered the resume");
+eq(goalRefused.sends.length, 0, "an unresumable (completed) Goal does not submit the continuation");
+
+const tabSwitched = await runContinueDelivery({ goal: "ship it", resumed: true, tabAfterResume: "tab-b" });
+eq(tabSwitched.sends.length, 0, "a tab switch during resume drops the continuation");
+
+const notReady = await runContinueDelivery({ goal: undefined, ready: false });
+eq(notReady.sends.length, 0, "delivery recovery waits for controller readiness");
+
+const noTab = await runContinueDelivery({ goal: undefined, tabId: null });
+eq(noTab.sends.length, 0, "delivery recovery without an active tab is a no-op");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -152,6 +152,31 @@ eq(
   true,
   "collaboration mode changes always reconcile the remembered plan restore intent",
 );
+eq(
+  appSource.includes("runtimeTransitionTabsRef.current.has(tabId)"),
+  true,
+  "runtime profile transitions reject rapid duplicate switches for one tab",
+);
+eq(
+  appSource.includes("delete pending.tokenMode") && appSource.includes("tokenMode: previous"),
+  true,
+  "failed runtime profile transitions roll back the optimistic token mode",
+);
+eq(
+  appSource.includes("!state.backendActivationPending && !runtimeTransitioning"),
+  true,
+  "runtime profile transitions keep submit behind the controller-ready gate",
+);
+eq(
+  /const resumed = await resumeControllerGoalForTab\(tabId\);[\s\S]{0,80}if \(!resumed\) return;[\s\S]{0,180}await commitThenSend/.test(appSource),
+  true,
+  "delivery recovery submits the continuation only after a blocked Goal resumes",
+);
+eq(
+  /await applyGoal\(trimmed\);[\s\S]{0,120}await commitThenSendRef\.current\(sourceTabId/.test(appSource),
+  true,
+  "the first Goal turn waits for the controller Goal before submitting",
+);
 
 const unsent = reducer(sent, { type: "unsend" });
 eq(unsent.pendingUser, undefined, "unsend clears the pending marker");

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -266,6 +266,7 @@ export function Transcript({
   tabId,
   footerHeight = 0,
   onPrompt,
+  onDeliveryContinue,
   onEditPrompt,
   onRewind,
   checkpoints = [],
@@ -291,6 +292,7 @@ export function Transcript({
   tabId?: string;
   footerHeight?: number;
   onPrompt: (text: string) => void;
+  onDeliveryContinue?: () => void;
   onEditPrompt?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   onRewind?: (turn: number, scope: string) => void;
   checkpoints?: CheckpointMeta[];
@@ -817,7 +819,7 @@ export function Transcript({
                 key={item.id}
                 item={item}
                 actionDisabled={running}
-                onAction={item.action === "continue_delivery" ? () => onPrompt(t("notice.deliveryIncompleteContinuePrompt")) : undefined}
+                onAction={item.action === "continue_delivery" ? (onDeliveryContinue ?? (() => onPrompt(t("notice.deliveryIncompleteContinuePrompt")))) : undefined}
               />,
             );
           } else {
@@ -922,6 +924,7 @@ export function Transcript({
               warmSetOpenAction={setOpenAction}
               warmOnEdit={onEditPrompt}
               warmOnPrompt={onPrompt}
+              warmOnDeliveryContinue={onDeliveryContinue}
               warmRunning={running}
               tabId={tabId}
               creationMode={creationMode}
@@ -996,6 +999,7 @@ const WarmZone = memo(function WarmZone({
   warmSetOpenAction,
   warmOnEdit,
   warmOnPrompt,
+  warmOnDeliveryContinue,
   warmRunning,
   tabId,
   creationMode,
@@ -1022,6 +1026,7 @@ const WarmZone = memo(function WarmZone({
   warmSetOpenAction: (action: OpenTurnAction | null) => void;
   warmOnEdit?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   warmOnPrompt: (text: string) => void;
+  warmOnDeliveryContinue?: () => void;
   warmRunning: boolean;
   tabId?: string;
   creationMode?: boolean;
@@ -1080,6 +1085,7 @@ const WarmZone = memo(function WarmZone({
               setOpenAction={warmSetOpenAction}
               onEdit={warmOnEdit}
               onPrompt={warmOnPrompt}
+              onDeliveryContinue={warmOnDeliveryContinue}
               running={warmRunning}
               tabId={tabId}
               creationMode={creationMode}
@@ -1131,6 +1137,7 @@ function WarmTurnItems({
   setOpenAction,
   onEdit,
   onPrompt,
+  onDeliveryContinue,
   running,
   tabId,
   creationMode = false,
@@ -1151,6 +1158,7 @@ function WarmTurnItems({
   setOpenAction: (action: OpenTurnAction | null) => void;
   onEdit?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   onPrompt: (text: string) => void;
+  onDeliveryContinue?: () => void;
   running: boolean;
   tabId?: string;
   creationMode?: boolean;
@@ -1210,7 +1218,7 @@ function WarmTurnItems({
             key={item.id}
             item={item}
             actionDisabled={running}
-            onAction={item.action === "continue_delivery" ? () => onPrompt(t("notice.deliveryIncompleteContinuePrompt")) : undefined}
+            onAction={item.action === "continue_delivery" ? (onDeliveryContinue ?? (() => onPrompt(t("notice.deliveryIncompleteContinuePrompt")))) : undefined}
           />,
         );
       } else {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -165,6 +165,7 @@ export interface AppBindings {
   SetToolApprovalModeForTab(tabID: string, mode: string): Promise<void>;
   SetGoal(goal: string): Promise<void>;
   SetGoalForTab(tabID: string, goal: string): Promise<void>;
+  ResumeGoalForTab(tabID: string): Promise<boolean>;
   ClearGoal(): Promise<void>;
   ClearGoalForTab(tabID: string): Promise<void>;
   Compact(): Promise<void>;
@@ -2256,6 +2257,15 @@ function makeMockApp(): AppBindings {
                 }
               : tab,
           );
+        },
+        async ResumeGoalForTab(tabID) {
+          let resumed = false;
+          mockTabs = mockTabs.map((tab) => {
+            if (tab.id !== tabID || !tab.goal || tab.goalStatus === "complete") return tab;
+            resumed = true;
+            return { ...tab, goalStatus: "running", collaborationMode: "goal" };
+          });
+          return resumed;
         },
         async ClearGoal() {
           await this.SetGoal("");

--- a/desktop/frontend/src/lib/deliveryContinue.ts
+++ b/desktop/frontend/src/lib/deliveryContinue.ts
@@ -1,0 +1,27 @@
+// Delivery recovery ("continue checks") flow for final_readiness notices.
+//
+// Ordinary Delivery turns carry no Goal, so the recovery prompt is submitted
+// directly. A tab with a Goal must resume it first so its delivery scope and
+// persisted checkpoint survive the continuation; a Goal that refuses to resume
+// (completed, or the tab vanished) is not poked further. The active tab is
+// re-checked after the async resume so a mid-flight tab switch cannot deliver
+// the continuation into the wrong session.
+export interface DeliveryContinueOptions {
+  tabId: string | null | undefined;
+  ready: boolean;
+  goal: string | undefined;
+  activeTabId: () => string | null | undefined;
+  resumeGoal: (tabId: string) => Promise<boolean>;
+  send: (tabId: string) => Promise<void>;
+}
+
+export async function continueDelivery(opts: DeliveryContinueOptions): Promise<void> {
+  const { tabId, ready, goal } = opts;
+  if (!tabId || !ready) return;
+  if ((goal ?? "").trim()) {
+    const resumed = await opts.resumeGoal(tabId);
+    if (!resumed) return;
+    if (opts.activeTabId() !== tabId) return;
+  }
+  await opts.send(tabId);
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2267,6 +2267,22 @@ export function useController() {
     await clearGoalForTab(activeTabId);
   }, [activeTabId, clearGoalForTab]);
 
+  const resumeGoalForTab = useCallback(async (tabId: string): Promise<boolean> => {
+    if (!tabId) return false;
+    try {
+      const resumed = await app.ResumeGoalForTab(tabId);
+      await refreshMetaForTab(tabId, dispatchTo);
+      return resumed;
+    } catch {
+      return false;
+    }
+  }, [dispatchTo]);
+
+  const resumeGoal = useCallback(async (): Promise<boolean> => {
+    if (!activeTabId) return false;
+    return resumeGoalForTab(activeTabId);
+  }, [activeTabId, resumeGoalForTab]);
+
   const newSession = useCallback(async () => {
     const tabId = activeTabId;
     if (tabId) await waitForTabReady(tabId);
@@ -2445,19 +2461,20 @@ export function useController() {
     } catch { /* ignore */ }
   }, [activeTabId, dispatchTo]);
 
-  const setTokenMode = useCallback(async (mode: TokenMode) => {
-    if (!activeTabId) return;
+  const setTokenMode = useCallback(async (mode: TokenMode): Promise<boolean> => {
+    if (!activeTabId) return false;
     try {
       await app.SetTokenModeForTab(activeTabId, mode);
     } catch (err) {
       dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: tokenModeSwitchNoticeText(err) });
-      return;
+      return false;
     }
     try {
       dispatchTo(activeTabId, { type: "meta", meta: await app.MetaForTab(activeTabId) });
       dispatchTo(activeTabId, { type: "context", context: await app.ContextUsageForTab(activeTabId) });
       dispatchTo(activeTabId, { type: "effort", effort: await app.EffortForTab(activeTabId) });
     } catch { /* ignore */ }
+    return true;
   }, [activeTabId, dispatchTo]);
 
   const fetchMemory = useCallback((): Promise<MemoryView> =>
@@ -2740,7 +2757,7 @@ export function useController() {
     state: activeState,
     activeTabId,
     send, sendToTab, runShell, runShellForTab, steer, steerForTab, notice, cancel, approve, answerQuestion, setControllerMode,
-    setCollaborationMode, setCollaborationModeForTab, setToolApprovalMode, setToolApprovalModeForTab, setGoal, setGoalForTab, clearGoal, clearGoalForTab,
+    setCollaborationMode, setCollaborationModeForTab, setToolApprovalMode, setToolApprovalModeForTab, setGoal, setGoalForTab, clearGoal, clearGoalForTab, resumeGoal, resumeGoalForTab,
     newSession, clearSession, listSessions, listTrashedSessions, resumeSession, openChannelSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     loadOlderHistory,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, rewindForTab, setModel, setEffort, setTokenMode,

--- a/desktop/goal_delivery_yolo_test.go
+++ b/desktop/goal_delivery_yolo_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/boot"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/store"
+)
+
+func newGoalDeliveryYoloTestApp(t *testing.T, goalStatus string) (*App, *WorkspaceTab, control.SessionAPI, string) {
+	t.Helper()
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "GOAL_DELIVERY_KEY", "sk-test")
+	cfg := config.Default()
+	cfg.DefaultModel = "test/model"
+	cfg.Desktop.ProviderAccess = []string{"test"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name: "test", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "model", APIKeyEnv: "GOAL_DELIVERY_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "goal-delivery-yolo.jsonl")
+	writeHistoryTestSession(t, path, "continue the delivery")
+	checkpoint := evidence.DeliveryCheckpoint{
+		ScopeID:             "goal-test-scope",
+		CriteriaEstablished: true,
+		WorkObserved:        true,
+		MutationObserved:    true,
+		PendingMutation:     true,
+	}
+	state := map[string]any{
+		"goal":               "ship the combined mode",
+		"status":             goalStatus,
+		"scopeID":            checkpoint.ScopeID,
+		"deliveryCheckpoint": checkpoint,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.SessionGoalState(path), data, 0o600); err != nil {
+		t.Fatalf("write Goal sidecar: %v", err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	exec := agent.New(nil, nil, loaded, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test/model", Sink: event.Discard})
+	oldCtrl.Resume(loaded, path)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID: "tab_goal_delivery_yolo", Scope: "global", Ready: true,
+		SessionPath: path, model: "test/model", tokenMode: boot.TokenModeFull,
+		mode: "yolo", toolApprovalMode: control.ToolApprovalYolo,
+		goal: "stale tab goal", Ctrl: oldCtrl,
+		disabledMCP: map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("ensure session lease: %v", err)
+	}
+	t.Cleanup(func() {
+		if ctrl := app.controllerForTab(tab); ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+	return app, tab, oldCtrl, path
+}
+
+func TestGoalDeliveryYoloTokenSwitchPreservesBlockedGoalCheckpoint(t *testing.T) {
+	app, tab, oldCtrl, path := newGoalDeliveryYoloTestApp(t, control.GoalStatusBlocked)
+	if err := app.SetTokenModeForTab(tab.ID, boot.TokenModeDelivery); err != nil {
+		t.Fatalf("SetTokenModeForTab: %v", err)
+	}
+	ctrl := app.controllerForTab(tab)
+	if ctrl == nil || ctrl == oldCtrl {
+		t.Fatal("token-mode switch did not install a replacement controller")
+	}
+	if ctrl.GoalStatus() != control.GoalStatusBlocked || ctrl.Goal() != "ship the combined mode" {
+		t.Fatalf("rebuilt Goal = (%q, %q), want blocked Goal", ctrl.Goal(), ctrl.GoalStatus())
+	}
+	if ctrl.ToolApprovalMode() != control.ToolApprovalYolo {
+		t.Fatalf("tool approval = %q, want yolo", ctrl.ToolApprovalMode())
+	}
+	if currentTabTokenMode(tab) != boot.TokenModeDelivery {
+		t.Fatalf("token mode = %q, want delivery", currentTabTokenMode(tab))
+	}
+	var persisted struct {
+		DeliveryCheckpoint evidence.DeliveryCheckpoint `json:"deliveryCheckpoint"`
+	}
+	data, err := os.ReadFile(store.SessionGoalState(path))
+	if err != nil {
+		t.Fatalf("read Goal sidecar: %v", err)
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("decode Goal sidecar: %v", err)
+	}
+	if persisted.DeliveryCheckpoint.ScopeID != "goal-test-scope" || !persisted.DeliveryCheckpoint.PendingMutation {
+		t.Fatalf("persisted checkpoint = %+v", persisted.DeliveryCheckpoint)
+	}
+	if !app.ResumeGoalForTab(tab.ID) || ctrl.GoalStatus() != control.GoalStatusRunning {
+		t.Fatal("blocked Goal did not resume after controller rebuild")
+	}
+}
+
+func TestGoalDeliveryYoloTokenSwitchDoesNotReviveCompletedGoal(t *testing.T) {
+	app, tab, _, _ := newGoalDeliveryYoloTestApp(t, control.GoalStatusComplete)
+	if err := app.SetTokenModeForTab(tab.ID, boot.TokenModeDelivery); err != nil {
+		t.Fatalf("SetTokenModeForTab: %v", err)
+	}
+	ctrl := app.controllerForTab(tab)
+	if ctrl.GoalStatus() == control.GoalStatusRunning {
+		t.Fatalf("completed Goal was revived: goal=%q status=%q", ctrl.Goal(), ctrl.GoalStatus())
+	}
+	if app.ResumeGoalForTab(tab.ID) {
+		t.Fatal("completed Goal should not be resumable")
+	}
+}
+
+func TestGoalAndCollaborationResyncBeforeSendPreserveRunningDeliveryScope(t *testing.T) {
+	app, tab, ctrl, path := newGoalDeliveryYoloTestApp(t, control.GoalStatusRunning)
+	tab.goal = ctrl.Goal()
+	app.SetCollaborationModeForTab(tab.ID, "goal")
+	app.SetGoalForTab(tab.ID, ctrl.Goal())
+
+	var persisted struct {
+		ScopeID string `json:"scopeID"`
+	}
+	data, err := os.ReadFile(store.SessionGoalState(path))
+	if err != nil {
+		t.Fatalf("read Goal sidecar: %v", err)
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("decode Goal sidecar: %v", err)
+	}
+	if persisted.ScopeID != "goal-test-scope" {
+		t.Fatalf("Goal resync replaced delivery scope: got %q", persisted.ScopeID)
+	}
+}
+
+func TestTokenModeSwitchWaitsForForegroundTurnAdmission(t *testing.T) {
+	app, tab, _, _ := newGoalDeliveryYoloTestApp(t, control.GoalStatusBlocked)
+	tab.turnStartMu.Lock()
+	done := make(chan error, 1)
+	go func() { done <- app.SetTokenModeForTab(tab.ID, boot.TokenModeDelivery) }()
+	select {
+	case err := <-done:
+		t.Fatalf("token-mode switch crossed the turn-admission gate: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	tab.turnStartMu.Unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SetTokenModeForTab after admission release: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("token-mode switch did not finish after turn admission released")
+	}
+}

--- a/desktop/session_prompt.go
+++ b/desktop/session_prompt.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"strings"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/control"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 func systemPromptFrom(messages []provider.Message) string {
@@ -89,5 +92,30 @@ func resumeWithFreshSystemPrompt(ctrl interface {
 	}
 	if path != "" {
 		ctrl.SetSessionPath(path)
+	}
+}
+
+// resumeWithFreshSystemPromptAndGoal resumes an existing session without
+// seeding Goal state before Resume. A goal-state sidecar is authoritative;
+// only legacy sessions that predate the sidecar fall back to the tab profile.
+func resumeWithFreshSystemPromptAndGoal(ctrl control.SessionAPI, messages []provider.Message, path, legacyGoal string) {
+	if ctrl == nil {
+		return
+	}
+	_, sidecarErr := os.Stat(store.SessionGoalState(path))
+	resumeWithFreshSystemPrompt(ctrl, messages, path)
+	if os.IsNotExist(sidecarErr) {
+		ctrl.SetGoal(strings.TrimSpace(legacyGoal))
+	}
+}
+
+func resumeLoadedSessionAndGoal(ctrl control.SessionAPI, session *agent.Session, path, legacyGoal string) {
+	if ctrl == nil || session == nil {
+		return
+	}
+	_, sidecarErr := os.Stat(store.SessionGoalState(path))
+	ctrl.Resume(sessionWithFreshSystemPrompt(session, systemPromptFrom(ctrl.History())), path)
+	if os.IsNotExist(sidecarErr) {
+		ctrl.SetGoal(strings.TrimSpace(legacyGoal))
 	}
 }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1517,6 +1517,8 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	if tab == nil {
 		return fmt.Errorf("no active tab")
 	}
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
 	if controllerHasActiveRuntimeWork(a.controllerForTab(tab)) {
 		return rebuildControllerActiveWorkError(setting)
 	}
@@ -1607,11 +1609,7 @@ func (a *App) rebuildSettingLocked(setting string) error {
 		ctrl.Close()
 		return err
 	}
-	resumeWithFreshSystemPrompt(ctrl, carried, path)
-	if oldCtrl != nil {
-		oldCtrl.Close()
-	}
-	a.persistTabSessionPath(tab, path)
+	resumeWithFreshSystemPromptAndGoal(ctrl, carried, path, snap.goal)
 	a.mu.Lock()
 	if current := a.tabs[tab.ID]; current != tab {
 		a.mu.Unlock()
@@ -1629,6 +1627,10 @@ func (a *App) rebuildSettingLocked(setting string) error {
 	a.supersedeTabBuildLocked(tab)
 	a.saveTabsLocked()
 	a.mu.Unlock()
+	if oldCtrl != nil {
+		oldCtrl.Close()
+	}
+	a.persistTabSessionPath(tab, path)
 	a.clearDeferredRebuild(tab.ID)
 	a.emitReady(a.ctx)
 	return nil

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2962,7 +2962,6 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 	ctrl.EnableInteractiveApproval()
 	applyTabModeToController(ctrl, buildMode)
 	applyTabToolApprovalModeToController(ctrl, buildToolApprovalMode)
-	ctrl.SetGoal(buildGoal)
 
 	acquiredLeaseKey := ""
 	if dir := ctrl.SessionDir(); dir != "" {
@@ -3064,9 +3063,10 @@ func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loa
 				return
 			}
 			if resumeSession != nil {
-				ctrl.Resume(sessionWithFreshSystemPrompt(resumeSession, systemPromptFrom(ctrl.History())), path)
+				resumeLoadedSessionAndGoal(ctrl, resumeSession, path, buildGoal)
 			} else {
 				ctrl.SetSessionPath(path)
+				ctrl.SetGoal(buildGoal)
 			}
 			a.persistTabSessionPath(tab, path)
 			a.mu.RLock()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -388,6 +388,9 @@ type Agent struct {
 	deliveryCriteriaEstablished bool
 	deliveryTaskExpected        bool
 	deliveryMutationExpected    bool
+	deliveryScopeID             string
+	deliveryScopeActive         bool
+	deliveryCheckpoint          evidence.DeliveryCheckpoint
 
 	// classifierTaskText is the host-trusted task text for delivery intent
 	// classification, set by sub-agent spawners whose Run input carries host
@@ -1208,10 +1211,28 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	a.steerConsumed = false
 	a.steerRunActive = true
 	a.steerMu.Unlock()
-	if a.evidence != nil && !a.preserveEvidenceOnce {
-		a.evidence.Reset()
+	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
+	preserveEvidence := a.preserveEvidenceOnce
+	if a.evidence != nil {
+		switch {
+		case preserveEvidence:
+			a.evidence.ResetBackgroundLeases()
+		case scoped && a.deliveryScopeID == scope.ID:
+			a.evidence.ResetBackgroundLeases()
+		default:
+			a.evidence.Reset()
+		}
 	}
 	a.preserveEvidenceOnce = false
+	if scoped {
+		a.deliveryScopeID = scope.ID
+	} else if !preserveEvidence {
+		a.deliveryScopeID = ""
+	}
+	a.deliveryScopeActive = scoped
+	if scoped && a.deliveryCheckpoint.ScopeID != scope.ID {
+		a.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: scope.ID}
+	}
 	// Re-lease this session's background-job mutations that no turn has
 	// committed yet. The Reset above just wiped any lease a failed or
 	// cancelled turn held (its ledger is gone), and a process restart starts
@@ -1249,7 +1270,12 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			a.jobs.CommitEvidenceForSession(lease.Session, lease.JobID)
 		}
 	}()
-	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria()
+	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria() ||
+		(a.evidence != nil && a.evidence.HasSuccessfulTodoWrite()) ||
+		(scoped && a.deliveryCheckpoint.CriteriaEstablished)
+	if scoped {
+		defer func() { a.updateDeliveryCheckpoint(runErr) }()
+	}
 	// Classify delivery expectations from the task text. Sub-agent spawners
 	// pass the pristine task through Options.ClassifierTaskText (a trusted
 	// host channel) because their Run input carries host framing whose
@@ -1259,7 +1285,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	// classified verbatim: stripping user-controllable markup here would let
 	// input dressed up as host framing disarm the delivery gates.
 	classifierInput := a.classifierTaskText
-	if strings.TrimSpace(classifierInput) == "" {
+	if scoped && strings.TrimSpace(scope.TaskText) != "" {
+		classifierInput = scope.TaskText
+	} else if strings.TrimSpace(classifierInput) == "" {
 		classifierInput = rawInput
 	}
 	a.deliveryTaskExpected = deliveryTaskNeedsEvidence(classifierInput)
@@ -1400,7 +1428,8 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		})
 
 		if len(calls) == 0 {
-			readiness := a.finalReadinessCheck()
+			finalizeTask := !a.deliveryScopeActive || deliveryDisposition(text) == deliveryGoalFinal
+			readiness := a.finalReadinessCheckFor(finalizeTask)
 			if readiness.reason != "" {
 				// A block only counts against the base budget when the model made
 				// no host-observable progress since the previous block. A turn that
@@ -1562,7 +1591,7 @@ func (a *Agent) emitMemoryCompilerStats(turn *memorycompiler.Turn) {
 }
 
 func (a *Agent) finalReadinessFailure() string {
-	return a.finalReadinessCheck().reason
+	return a.finalReadinessCheckFor(true).reason
 }
 
 // GoalReadinessFailure returns the final-readiness failure reason — a summary of
@@ -1602,6 +1631,10 @@ func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recover
 }
 
 func (a *Agent) finalReadinessCheck() finalReadinessCheck {
+	return a.finalReadinessCheckFor(true)
+}
+
+func (a *Agent) finalReadinessCheckFor(finalizeTask bool) finalReadinessCheck {
 	if a.evidence == nil {
 		return finalReadinessCheck{}
 	}
@@ -1628,28 +1661,41 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		}
 		return out
 	}
-	incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
-	if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
-		incomplete, hasTodos = a.incompleteCanonicalTodos()
-	}
-	if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
-		out.applies = true
-		out.incompleteTodos = len(incomplete)
-		missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+	if finalizeTask {
+		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
+		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
+			incomplete, hasTodos = a.incompleteCanonicalTodos()
+		}
+		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
+			out.applies = true
+			out.incompleteTodos = len(incomplete)
+			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+		}
 	}
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	deliveryMutation := false
 	deliveryVerificationOnly := false
+	checkpoint := a.deliveryCheckpoint
+	checkpointApplies := a.deliveryScopeActive && checkpoint.ScopeID == a.deliveryScopeID
 	if a.deliveryProfile {
 		if mutation, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
 			writer, hasWriter = mutation, true
 			deliveryMutation = true
+		} else if checkpointApplies && checkpoint.PendingMutation {
+			// The mutation happened before a controller rebuild/restart. Treat it as
+			// the baseline so this run can satisfy verification/review/sign-off
+			// without manufacturing another write.
+			writer, hasWriter = -1, true
+			deliveryMutation = true
+		} else if checkpointApplies && checkpoint.MutationObserved {
+			deliveryMutation = true
 		}
-		if a.deliveryTaskExpected && !a.evidence.HasSuccessfulWorkReceipt() {
+		workObserved := a.evidence.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
+		if finalizeTask && a.deliveryTaskExpected && !workObserved {
 			out.missingActionEvidence++
 			missing = append(missing, "perform host-observable work for this technical task before answering")
 		}
-		if a.deliveryMutationExpected && !deliveryMutation {
+		if finalizeTask && a.deliveryMutationExpected && !deliveryMutation {
 			out.missingMutation++
 			missing = append(missing, "the request requires a state change, but no successful mutation was observed")
 		}
@@ -1660,9 +1706,11 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		// Required/preferred capability gates apply before the no-writer fast
 		// path below: a user-required Skill/MCP must not be skippable by
 		// answering from ordinary reads alone.
-		if msg := a.capabilityGateFailure(); msg != "" {
-			out.applies = true
-			missing = append(missing, msg)
+		if finalizeTask {
+			if msg := a.capabilityGateFailure(); msg != "" {
+				out.applies = true
+				missing = append(missing, msg)
+			}
 		}
 	}
 	if !hasWriter {
@@ -1681,7 +1729,8 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	}
 	out.applies = true
 	if a.deliveryProfile {
-		if !a.deliveryCriteriaEstablished {
+		criteriaEstablished := a.deliveryCriteriaEstablished || (checkpointApplies && checkpoint.CriteriaEstablished)
+		if !criteriaEstablished {
 			out.missingAcceptanceCriteria++
 			missing = append(missing, "establish concrete acceptance criteria with todo_write before changing state")
 		}
@@ -1726,6 +1775,57 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	}
 	out.reason = strings.Join(missing, "; ")
 	return out
+}
+
+// DeliveryCheckpoint returns the compact Goal-scoped delivery state. It is safe
+// to persist next to the Goal sidecar because it contains no raw arguments.
+func (a *Agent) DeliveryCheckpoint() evidence.DeliveryCheckpoint {
+	return a.deliveryCheckpoint
+}
+
+// RestoreDeliveryCheckpoint seeds a rebuilt controller before its next Goal
+// run. A mismatched/empty scope is ignored conservatively.
+func (a *Agent) RestoreDeliveryCheckpoint(checkpoint evidence.DeliveryCheckpoint) {
+	checkpoint.ScopeID = strings.TrimSpace(checkpoint.ScopeID)
+	if checkpoint.ScopeID == "" {
+		return
+	}
+	a.deliveryCheckpoint = checkpoint
+	a.deliveryScopeID = checkpoint.ScopeID
+}
+
+func (a *Agent) updateDeliveryCheckpoint(runErr error) {
+	if !a.deliveryScopeActive || a.deliveryScopeID == "" || a.evidence == nil {
+		return
+	}
+	cp := a.deliveryCheckpoint
+	if cp.ScopeID != a.deliveryScopeID {
+		cp = evidence.DeliveryCheckpoint{ScopeID: a.deliveryScopeID}
+	}
+	cp.CriteriaEstablished = cp.CriteriaEstablished || a.deliveryCriteriaEstablished || a.evidence.HasSuccessfulTodoWrite()
+	cp.WorkObserved = cp.WorkObserved || a.evidence.HasSuccessfulWorkReceipt()
+	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+		cp.MutationObserved = true
+		cp.PendingMutation = true
+	}
+	if runErr == nil && cp.PendingMutation && a.deliveryMutationCheckpointReady() {
+		cp.PendingMutation = false
+	}
+	a.deliveryCheckpoint = cp
+}
+
+func (a *Agent) deliveryMutationCheckpointReady() bool {
+	if a.evidence == nil || !a.deliveryCriteriaEstablished {
+		return false
+	}
+	mutation, ok := a.evidence.LatestSuccessfulMutationIndex()
+	if !ok {
+		mutation = -1
+	}
+	return a.evidence.HasSuccessfulCompleteStepAfter(mutation) &&
+		a.evidence.HasSuccessfulDeliverySignoffAfter(mutation) &&
+		a.evidence.HasSuccessfulReviewAfter(mutation) &&
+		a.deliveryReviewGateFailure() == ""
 }
 
 // armLoopGuardPass records that a loop guard fired this user turn.

--- a/internal/agent/delivery_scope.go
+++ b/internal/agent/delivery_scope.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"context"
+	"strings"
+)
+
+// DeliveryExecutionScope is host-owned state for a multi-turn task. It never
+// enters the provider request; it only controls delivery evidence lifetime and
+// trusted task classification across synthetic continuation turns.
+type DeliveryExecutionScope struct {
+	ID       string
+	TaskText string
+}
+
+type deliveryExecutionScopeKey struct{}
+
+func WithDeliveryExecutionScope(ctx context.Context, scope DeliveryExecutionScope) context.Context {
+	scope.ID = strings.TrimSpace(scope.ID)
+	scope.TaskText = strings.TrimSpace(scope.TaskText)
+	if scope.ID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, deliveryExecutionScopeKey{}, scope)
+}
+
+func DeliveryExecutionScopeFromContext(ctx context.Context) (DeliveryExecutionScope, bool) {
+	if ctx == nil {
+		return DeliveryExecutionScope{}, false
+	}
+	scope, ok := ctx.Value(deliveryExecutionScopeKey{}).(DeliveryExecutionScope)
+	if !ok || strings.TrimSpace(scope.ID) == "" {
+		return DeliveryExecutionScope{}, false
+	}
+	return scope, true
+}
+
+type deliveryGoalDisposition int
+
+const (
+	deliveryGoalFinal deliveryGoalDisposition = iota
+	deliveryGoalContinue
+	deliveryGoalBlocked
+)
+
+func deliveryDisposition(text string) deliveryGoalDisposition {
+	lines := strings.Split(text, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.ToLower(strings.TrimSpace(lines[i]))
+		if line == "" {
+			continue
+		}
+		switch {
+		case line == "[goal:continue]":
+			return deliveryGoalContinue
+		case strings.HasPrefix(line, "[goal:blocked:") && strings.HasSuffix(line, "]"):
+			return deliveryGoalBlocked
+		default:
+			return deliveryGoalFinal
+		}
+	}
+	return deliveryGoalFinal
+}

--- a/internal/agent/delivery_scope_test.go
+++ b/internal/agent/delivery_scope_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -84,6 +85,35 @@ func TestDeliveryGoalScopeCarriesSignedOffMutationAcrossTurns(t *testing.T) {
 	}
 	if err := a.Run(ctx, "finish the goal"); err != nil {
 		t.Fatalf("verification-only completion should reuse scoped evidence: %v", err)
+	}
+}
+
+func TestDeliveryGoalRestoredPendingMutationCompletesWithoutNewWrite(t *testing.T) {
+	// A controller rebuild or cold resume restores PendingMutation with no
+	// mutation receipt in the fresh ledger (a -1 baseline). Fresh review,
+	// verification, and sign-off receipts must finish the Goal without
+	// manufacturing another write, and the checkpoint must clear.
+	reg := evidenceRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	prov := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("verify", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("signoff", "complete_step", `{"step":"Ship main","result":"implemented","evidence":[{"kind":"verification","summary":"tests pass","command":"go test ./..."}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Recovered and verified.\n\n[goal:complete]"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true}, event.Discard)
+	a.RestoreDeliveryCheckpoint(evidence.DeliveryCheckpoint{
+		ScopeID:             "goal-1",
+		CriteriaEstablished: true,
+		WorkObserved:        true,
+		MutationObserved:    true,
+		PendingMutation:     true,
+	})
+	if err := a.Run(deliveryGoalContext("goal-1", "implement main"), "continue the goal"); err != nil {
+		t.Fatalf("restored pending mutation should complete with fresh review/verification/sign-off: %v", err)
+	}
+	if cp := a.DeliveryCheckpoint(); cp.PendingMutation {
+		t.Fatalf("checkpoint = %+v, want PendingMutation cleared after sign-off", cp)
 	}
 }
 

--- a/internal/agent/delivery_scope_test.go
+++ b/internal/agent/delivery_scope_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestDeliveryExecutionScopeDoesNotChangeProviderRequestBytes(t *testing.T) {
+	turn := []provider.Chunk{{Type: provider.ChunkText, Text: "Here is the explanation."}, {Type: provider.ChunkDone}}
+	unscopedProvider := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{turn}}
+	scopedProvider := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{turn}}
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+
+	unscoped := New(unscopedProvider, reg, NewSession("stable system"), Options{DeliveryProfile: true}, event.Discard)
+	scoped := New(scopedProvider, reg, NewSession("stable system"), Options{DeliveryProfile: true}, event.Discard)
+	input := "explain the current implementation"
+	if err := unscoped.Run(context.Background(), input); err != nil {
+		t.Fatalf("unscoped run: %v", err)
+	}
+	if err := scoped.Run(deliveryGoalContext("goal-stable", input), input); err != nil {
+		t.Fatalf("scoped run: %v", err)
+	}
+	if len(unscopedProvider.requests) != 1 || len(scopedProvider.requests) != 1 {
+		t.Fatalf("request counts = (%d, %d), want one each", len(unscopedProvider.requests), len(scopedProvider.requests))
+	}
+	left, right := unscopedProvider.requests[0], scopedProvider.requests[0]
+	if !reflect.DeepEqual(left.Messages, right.Messages) {
+		t.Fatalf("Delivery scope changed provider-visible messages:\nunscoped=%+v\nscoped=%+v", left.Messages, right.Messages)
+	}
+	if !reflect.DeepEqual(left.Tools, right.Tools) {
+		t.Fatal("Delivery scope changed provider-visible tool schemas")
+	}
+}
+
+func deliveryGoalContext(id, task string) context.Context {
+	return WithDeliveryExecutionScope(context.Background(), DeliveryExecutionScope{ID: id, TaskText: task})
+}
+
+func TestDeliveryGoalContinueDefersTaskMutationExpectation(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeReadFileTool{})
+	reg.Add(fakeWriterTool{})
+	prov := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{
+		{toolCallChunk("read", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Investigation complete.\n\n[goal:continue]"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Implemented.\n\n[goal:complete]"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true}, event.Discard)
+	ctx := deliveryGoalContext("goal-1", "fix the crash in main.go")
+	if err := a.Run(ctx, "investigate the crash"); err != nil {
+		t.Fatalf("continue turn: %v", err)
+	}
+	err := a.Run(ctx, "continue the goal")
+	var readiness *FinalReadinessError
+	if !errors.As(err, &readiness) || !strings.Contains(readiness.Reason, "state change") {
+		t.Fatalf("complete without any goal mutation err = %v, want mutation readiness failure", err)
+	}
+}
+
+func TestDeliveryGoalScopeCarriesSignedOffMutationAcrossTurns(t *testing.T) {
+	reg := evidenceRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	prov := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{
+		{toolCallChunk("criteria", "todo_write", `{"todos":[{"content":"Ship main","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("write", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("verify", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("signoff", "complete_step", `{"step":"Ship main","result":"implemented","evidence":[{"kind":"verification","summary":"tests pass","command":"go test ./..."}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Implementation complete.\n\n[goal:continue]"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Final summary.\n\n[goal:complete]"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true}, event.Discard)
+	ctx := deliveryGoalContext("goal-1", "implement main")
+	if err := a.Run(ctx, "implement the first chunk"); err != nil {
+		t.Fatalf("mutation turn: %v", err)
+	}
+	if err := a.Run(ctx, "finish the goal"); err != nil {
+		t.Fatalf("verification-only completion should reuse scoped evidence: %v", err)
+	}
+}
+
+func TestDeliveryGoalNewMutationInvalidatesPriorSignoff(t *testing.T) {
+	reg := evidenceRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	prov := &scriptedProvider{name: "delivery", turns: [][]provider.Chunk{
+		{toolCallChunk("criteria-1", "todo_write", `{"todos":[{"content":"Ship main","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("write-1", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("review-1", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("verify-1", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("signoff-1", "complete_step", `{"step":"Ship main","result":"implemented","evidence":[{"kind":"verification","summary":"tests pass","command":"go test ./..."}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "First chunk done.\n\n[goal:continue]"}, {Type: provider.ChunkDone}},
+		{toolCallChunk("criteria-2", "todo_write", `{"todos":[{"content":"Polish main","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("write-2", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "All done.\n\n[goal:complete]"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{DeliveryProfile: true}, event.Discard)
+	ctx := deliveryGoalContext("goal-1", "implement main")
+	if err := a.Run(ctx, "implement the first chunk"); err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	err := a.Run(ctx, "polish and finish")
+	var readiness *FinalReadinessError
+	if !errors.As(err, &readiness) || !strings.Contains(readiness.Reason, "verification") {
+		t.Fatalf("new mutation err = %v, want fresh verification failure", err)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2190,6 +2190,29 @@ func (c *Controller) SetGoalWithResearchMode(goal string, researchMode GoalResea
 	}
 }
 
+// ResumeGoal re-enters a recoverable blocked/stopped Goal without resetting its
+// delivery evidence scope or AutoResearch identity.
+func (c *Controller) ResumeGoal() bool {
+	path, data, persist, resumed := c.goals.resume(c.goalTodos())
+	if !resumed {
+		return false
+	}
+	c.persistGoalState(path, data, persist)
+	if c.executor != nil {
+		c.executor.RestoreDeliveryCheckpoint(c.goals.deliveryState())
+	}
+	return true
+}
+
+func (c *Controller) persistGoalDeliveryCheckpoint() {
+	if c.executor == nil {
+		return
+	}
+	checkpoint := c.executor.DeliveryCheckpoint()
+	path, data, ok := c.goals.setDeliveryCheckpoint(checkpoint, c.goalTodos())
+	c.persistGoalState(path, data, ok)
+}
+
 func (c *Controller) ensureAutoResearchTask(goal string, researchMode GoalResearchMode) (string, string) {
 	goal = strings.TrimSpace(goal)
 	if goal == "" || c.autoResearch == nil || !shouldUseAutoResearch(goal, researchMode) {
@@ -3170,7 +3193,10 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.mu.Unlock()
 	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
-	c.goals.restoreRunningFromState(path)
+	c.goals.restoreFromState(path)
+	if c.executor != nil {
+		c.executor.RestoreDeliveryCheckpoint(c.goals.deliveryState())
+	}
 	c.restoreTerminalGoalTodos(path)
 	c.loadGuardianSession()
 	c.snapshotMu.Unlock()

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"reasonix/internal/evidence"
@@ -38,6 +40,8 @@ type goalMachine struct {
 	status             string
 	researchMode       GoalResearchMode
 	autoResearchTaskID string
+	scopeID            string
+	deliveryCheckpoint evidence.DeliveryCheckpoint
 	turns              int
 	blocks             int
 	block              string
@@ -56,15 +60,17 @@ type goalMachine struct {
 
 // goalState is the serializable form of a running goal.
 type goalState struct {
-	Goal               string              `json:"goal,omitempty"`
-	Status             string              `json:"status,omitempty"`
-	ResearchMode       GoalResearchMode    `json:"researchMode,omitempty"`
-	AutoResearchTaskID string              `json:"autoResearchTaskID,omitempty"`
-	Turns              int                 `json:"turns,omitempty"`
-	Blocks             int                 `json:"blocks,omitempty"`
-	Block              string              `json:"block,omitempty"`
-	Strict             bool                `json:"strict,omitempty"`
-	Todos              []evidence.TodoItem `json:"todos,omitempty"`
+	Goal               string                      `json:"goal,omitempty"`
+	Status             string                      `json:"status,omitempty"`
+	ResearchMode       GoalResearchMode            `json:"researchMode,omitempty"`
+	AutoResearchTaskID string                      `json:"autoResearchTaskID,omitempty"`
+	ScopeID            string                      `json:"scopeID,omitempty"`
+	DeliveryCheckpoint evidence.DeliveryCheckpoint `json:"deliveryCheckpoint,omitempty"`
+	Turns              int                         `json:"turns,omitempty"`
+	Blocks             int                         `json:"blocks,omitempty"`
+	Block              string                      `json:"block,omitempty"`
+	Strict             bool                        `json:"strict,omitempty"`
+	Todos              []evidence.TodoItem         `json:"todos,omitempty"`
 }
 
 // goalAdvanceInput carries everything the FSM needs for one continuation step,
@@ -121,6 +127,26 @@ func (g *goalMachine) currentAutoResearchTaskID() string {
 	return g.autoResearchTaskID
 }
 
+func (g *goalMachine) deliveryScope() (id, task string, ok bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if strings.TrimSpace(g.goal) == "" || g.status != GoalStatusRunning {
+		return "", "", false
+	}
+	if g.scopeID == "" {
+		g.scopeID = newGoalScopeID()
+	}
+	return g.scopeID, g.goal, true
+}
+
+func newGoalScopeID() string {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err == nil {
+		return fmt.Sprintf("goal-%x", raw[:])
+	}
+	return fmt.Sprintf("goal-fallback-%d-%d", os.Getpid(), time.Now().UnixNano())
+}
+
 // active reports whether a goal is currently running.
 func (g *goalMachine) active() bool {
 	g.mu.Lock()
@@ -153,8 +179,12 @@ func (g *goalMachine) set(goal string, mode GoalResearchMode, autoResearchTaskID
 	g.selfCheckDone, g.idleTurns, g.strict = false, 0, false
 	if goal == "" {
 		g.goal, g.status, g.researchMode, g.autoResearchTaskID = "", GoalStatusStopped, GoalResearchAuto, ""
+		g.scopeID = ""
+		g.deliveryCheckpoint = evidence.DeliveryCheckpoint{}
 	} else {
 		g.goal, g.status, g.researchMode, g.autoResearchTaskID = goal, GoalStatusRunning, mode, autoResearchTaskID
+		g.scopeID = newGoalScopeID()
+		g.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: g.scopeID}
 	}
 	return g.buildStateLocked(todos)
 }
@@ -179,6 +209,39 @@ func (g *goalMachine) stop(status string, todos []evidence.TodoItem) (string, []
 	g.selfCheckDone = false
 	g.idleTurns = 0
 	return g.buildStateLocked(todos)
+}
+
+func (g *goalMachine) resume(todos []evidence.TodoItem) (path string, data []byte, persist, resumed bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if strings.TrimSpace(g.goal) == "" || g.status == GoalStatusComplete {
+		return "", nil, false, false
+	}
+	g.status = GoalStatusRunning
+	g.blocks, g.block = 0, ""
+	g.interceptMsg, g.intercepts = "", 0
+	g.selfCheckDone, g.idleTurns = false, 0
+	if g.scopeID == "" {
+		g.scopeID = newGoalScopeID()
+	}
+	path, data, persist = g.buildStateLocked(todos)
+	return path, data, persist, true
+}
+
+func (g *goalMachine) setDeliveryCheckpoint(checkpoint evidence.DeliveryCheckpoint, todos []evidence.TodoItem) (string, []byte, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.scopeID == "" || checkpoint.ScopeID != g.scopeID {
+		return "", nil, false
+	}
+	g.deliveryCheckpoint = checkpoint
+	return g.buildStateLocked(todos)
+}
+
+func (g *goalMachine) deliveryState() evidence.DeliveryCheckpoint {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.deliveryCheckpoint
 }
 
 // takeIntercept consumes a pending continuation-turn override, if any.
@@ -295,6 +358,8 @@ func (g *goalMachine) buildStateLocked(todos []evidence.TodoItem) (path string, 
 		Status:             g.status,
 		ResearchMode:       g.researchMode,
 		AutoResearchTaskID: g.autoResearchTaskID,
+		ScopeID:            g.scopeID,
+		DeliveryCheckpoint: g.deliveryCheckpoint,
 		Turns:              g.turns,
 		Blocks:             g.blocks,
 		Block:              g.block,
@@ -371,11 +436,11 @@ func (g *goalMachine) terminalTodosFromState(sessionPath string) ([]evidence.Tod
 	return append([]evidence.TodoItem(nil), state.Todos...), true
 }
 
-// restoreRunningFromState reloads the active running goal from the persisted
-// sidecar during cold resume. Terminal sidecar data is intentionally ignored:
-// terminal todo repair is handled by terminalTodosFromState without reviving the
-// goal loop.
-func (g *goalMachine) restoreRunningFromState(sessionPath string) {
+// restoreFromState reloads Goal state from the persisted sidecar during resume.
+// The sidecar is authoritative when present: a stale tab profile must not turn
+// a blocked or stopped Goal back into a running one during a controller rebuild.
+// Recoverable terminal states retain their scope for an explicit ResumeGoal.
+func (g *goalMachine) restoreFromState(sessionPath string) {
 	if strings.TrimSpace(sessionPath) == "" {
 		return
 	}
@@ -391,15 +456,27 @@ func (g *goalMachine) restoreRunningFromState(sessionPath string) {
 		slog.Warn("controller: parse goal state", "err", err)
 		return
 	}
-	if state.Status != GoalStatusRunning || strings.TrimSpace(state.Goal) == "" {
-		return
-	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.goal = strings.TrimSpace(state.Goal)
-	g.status = GoalStatusRunning
+	g.status = state.Status
+	if g.status == "" {
+		g.status = GoalStatusStopped
+	}
 	g.researchMode = state.ResearchMode
 	g.autoResearchTaskID = strings.TrimSpace(state.AutoResearchTaskID)
+	g.scopeID = strings.TrimSpace(state.ScopeID)
+	if g.goal != "" && g.scopeID == "" {
+		g.scopeID = newGoalScopeID()
+	}
+	g.deliveryCheckpoint = state.DeliveryCheckpoint
+	if g.scopeID == "" {
+		g.deliveryCheckpoint = evidence.DeliveryCheckpoint{}
+	} else if g.deliveryCheckpoint.ScopeID == "" {
+		g.deliveryCheckpoint.ScopeID = g.scopeID
+	} else if g.deliveryCheckpoint.ScopeID != g.scopeID {
+		g.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: g.scopeID}
+	}
 	g.turns = state.Turns
 	g.blocks = state.Blocks
 	g.block = state.Block

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -1159,3 +1159,61 @@ func TestSessionRotationClearsActiveGoal(t *testing.T) {
 		t.Fatalf("old goal leaked into the cleared session's turn: %q", composed)
 	}
 }
+
+func TestGoalSidecarRoundTripPreservesBlockedDeliveryCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	c.SetGoal("finish the delivery")
+	scopeID, _, ok := c.goals.deliveryScope()
+	if !ok || scopeID == "" {
+		t.Fatal("Goal did not allocate a delivery scope")
+	}
+	cp := evidence.DeliveryCheckpoint{
+		ScopeID:             scopeID,
+		CriteriaEstablished: true,
+		WorkObserved:        true,
+		MutationObserved:    true,
+		PendingMutation:     true,
+	}
+	statePath, data, persist := c.goals.setDeliveryCheckpoint(cp, nil)
+	c.persistGoalState(statePath, data, persist)
+	c.stopGoal(GoalStatusBlocked)
+
+	freshExec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	fresh := New(Options{Executor: freshExec, SessionDir: dir, Label: "fresh"})
+	fresh.Resume(agent.NewSession("sys"), path)
+	if fresh.Goal() != "finish the delivery" || fresh.GoalStatus() != GoalStatusBlocked {
+		t.Fatalf("restored Goal = (%q, %q), want blocked Goal", fresh.Goal(), fresh.GoalStatus())
+	}
+	if got := freshExec.DeliveryCheckpoint(); got != cp {
+		t.Fatalf("restored checkpoint = %+v, want %+v", got, cp)
+	}
+	if !fresh.ResumeGoal() {
+		t.Fatal("ResumeGoal rejected a restored blocked Goal")
+	}
+	id, _, ok := fresh.goals.deliveryScope()
+	if !ok || id != scopeID {
+		t.Fatalf("resumed scope = %q, want %q", id, scopeID)
+	}
+}
+
+func TestLegacyRunningGoalSidecarAllocatesScope(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	data := []byte(`{"goal":"legacy goal","status":"running"}`)
+	if err := os.WriteFile(store.SessionGoalState(path), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.Resume(agent.NewSession("sys"), path)
+	id, task, ok := c.goals.deliveryScope()
+	if !ok || id == "" || task != "legacy goal" {
+		t.Fatalf("legacy delivery scope = (%q, %q, %v)", id, task, ok)
+	}
+	if got := exec.DeliveryCheckpoint(); got.ScopeID != id {
+		t.Fatalf("legacy checkpoint scope = %q, want %q", got.ScopeID, id)
+	}
+}

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -94,6 +94,7 @@ type Goals interface {
 	GoalStatus() string
 	SetGoal(goal string)
 	SetGoalWithResearchMode(goal string, researchMode GoalResearchMode)
+	ResumeGoal() bool
 	GoalStrict(strict bool)
 	ClearGoal()
 	AutoResearchSummary() (*autoresearch.Summary, bool)

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -208,7 +208,11 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	if !turn.synthetic {
 		modelInput = c.withCapabilityRoute(input, turn.raw)
 	}
+	if scopeID, task, ok := c.goals.deliveryScope(); ok {
+		ctx = agent.WithDeliveryExecutionScope(ctx, agent.DeliveryExecutionScope{ID: scopeID, TaskText: task})
+	}
 	err := c.runner.Run(ctx, modelInput)
+	c.persistGoalDeliveryCheckpoint()
 	if err == nil {
 		c.recordAutoResearchEvidenceFromAssistant(autoResearchTaskID, lastAssistantText(c.History()))
 		c.recordAutoResearchTurnProgress(autoResearchTaskID, autoResearchAcceptedBefore)
@@ -280,6 +284,11 @@ func (o *turnOrchestrator) runGoalLoopWithRawDisplay(ctx context.Context, input,
 	if err := o.runTurnWithRawDisplay(ctx, input, raw, display); err != nil {
 		if ctx.Err() != nil {
 			o.c.stopGoal(GoalStatusStopped)
+		} else {
+			var readiness *agent.FinalReadinessError
+			if errors.As(err, &readiness) {
+				o.c.stopGoal(GoalStatusBlocked)
+			}
 		}
 		return err
 	}
@@ -290,6 +299,11 @@ func (o *turnOrchestrator) runEditedGoalLoopWithRawDisplay(ctx context.Context, 
 	if err := o.runEditedTurnWithRawDisplay(ctx, input, raw, display, original); err != nil {
 		if ctx.Err() != nil {
 			o.c.stopGoal(GoalStatusStopped)
+		} else {
+			var readiness *agent.FinalReadinessError
+			if errors.As(err, &readiness) {
+				o.c.stopGoal(GoalStatusBlocked)
+			}
 		}
 		return err
 	}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -150,6 +150,41 @@ type recordingSessionRunner struct {
 	memoryCompilerInputs []string
 }
 
+type deliveryScopeErrorRunner struct {
+	scopes []agent.DeliveryExecutionScope
+}
+
+func (r *deliveryScopeErrorRunner) Run(ctx context.Context, _ string) error {
+	if scope, ok := agent.DeliveryExecutionScopeFromContext(ctx); ok {
+		r.scopes = append(r.scopes, scope)
+	}
+	return &agent.FinalReadinessError{Attempts: 3, Reason: "missing verification"}
+}
+
+func TestGoalReadinessFailureBlocksAndKeepsDeliveryScope(t *testing.T) {
+	runner := &deliveryScopeErrorRunner{}
+	c := New(Options{Runner: runner})
+	c.SetGoal("ship the integration")
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "start", "start", "")
+	var readiness *agent.FinalReadinessError
+	if !errors.As(err, &readiness) {
+		t.Fatalf("run err = %v, want FinalReadinessError", err)
+	}
+	if got := c.GoalStatus(); got != GoalStatusBlocked {
+		t.Fatalf("GoalStatus = %q, want blocked", got)
+	}
+	if len(runner.scopes) != 1 || runner.scopes[0].ID == "" || runner.scopes[0].TaskText != "ship the integration" {
+		t.Fatalf("delivery scopes = %+v", runner.scopes)
+	}
+	if !c.ResumeGoal() || c.GoalStatus() != GoalStatusRunning {
+		t.Fatal("blocked Goal should resume with its existing scope")
+	}
+	if id, task, ok := c.goals.deliveryScope(); !ok || id != runner.scopes[0].ID || task != "ship the integration" {
+		t.Fatalf("resumed scope = (%q, %q, %v), want preserved id/task", id, task, ok)
+	}
+}
+
 func (r *recordingSessionRunner) Run(ctx context.Context, input string) error {
 	r.inputs = append(r.inputs, input)
 	if source, ok := agent.MemoryCompilerSourceInputFromContext(ctx); ok {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -393,7 +393,9 @@ func (l *Ledger) HasSuccessfulDeliverySignoffAfter(after int) bool {
 // HasSuccessfulReviewAfter reports whether the changed result was inspected
 // after the latest mutation. A read of a touched path is sufficient; git/diff
 // inspection commands cover shell-driven or delegated mutations whose paths are
-// not knowable to the host.
+// not knowable to the host. A negative index is the restored-checkpoint
+// baseline: the mutation predates this ledger (controller rebuild or cold
+// resume), so any successful review-shaped receipt counts.
 func (l *Ledger) HasSuccessfulReviewAfter(after int) bool {
 	if l == nil {
 		return false
@@ -406,17 +408,23 @@ func (l *Ledger) HasSuccessfulReviewAfter(after int) bool {
 	l.mu.Lock()
 	receipts := append([]Receipt(nil), l.receipts...)
 	l.mu.Unlock()
-	if after < 0 || after >= len(receipts) {
+	if after >= len(receipts) {
 		return false
 	}
 	return receiptsReviewChanges(receipts, start, len(receipts), after)
 }
 
 func receiptsReviewChanges(receipts []Receipt, start, end, mutationIndex int) bool {
-	if mutationIndex < 0 || mutationIndex >= len(receipts) {
+	if mutationIndex >= len(receipts) {
 		return false
 	}
-	wanted := pathSet(receipts[mutationIndex].Paths)
+	// A negative mutationIndex is the restored-checkpoint baseline: the
+	// mutation's receipt is not in this ledger, so its touched paths are
+	// unknowable and any successful review-shaped receipt counts.
+	var wanted map[string]bool
+	if mutationIndex >= 0 {
+		wanted = pathSet(receipts[mutationIndex].Paths)
+	}
 	for i := start; i < end && i < len(receipts); i++ {
 		r := receipts[i]
 		if !r.Success {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -65,6 +65,18 @@ type BackgroundLease struct {
 	JobID   string
 }
 
+// DeliveryCheckpoint is the compact, persistence-safe state carried across
+// runs of one host-owned Goal. It intentionally stores no raw tool arguments or
+// output. PendingMutation means a previously observed change still needs fresh
+// verification, review, and sign-off before the Goal can finalize.
+type DeliveryCheckpoint struct {
+	ScopeID             string `json:"scopeID,omitempty"`
+	CriteriaEstablished bool   `json:"criteriaEstablished,omitempty"`
+	WorkObserved        bool   `json:"workObserved,omitempty"`
+	MutationObserved    bool   `json:"mutationObserved,omitempty"`
+	PendingMutation     bool   `json:"pendingMutation,omitempty"`
+}
+
 // Ledger stores the receipts available to complete_step for the current turn.
 type Ledger struct {
 	mu               sync.Mutex
@@ -83,6 +95,18 @@ func (l *Ledger) Reset() {
 	defer l.mu.Unlock()
 	l.receipts = nil
 	l.backgroundLeases = nil
+}
+
+// ResetBackgroundLeases starts a new run inside the same delivery scope. The
+// durable receipts remain available, while per-run job leases must be collected
+// and committed independently.
+func (l *Ledger) ResetBackgroundLeases() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.backgroundLeases = nil
+	l.mu.Unlock()
 }
 
 // NoteBackgroundLease records that a background job's evidence was merged into

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -741,6 +741,40 @@ func TestNodeTestRunnerWriteFlagsCannotMasqueradeAsDeliveryVerification(t *testi
 	}
 }
 
+func TestLedgerReviewAfterRestoredCheckpointBaseline(t *testing.T) {
+	// A negative index is the restored-checkpoint baseline: the mutation
+	// happened before a controller rebuild or cold resume, so its receipt (and
+	// touched paths) are not in this ledger. Fresh review-shaped receipts must
+	// still be able to satisfy the review gate.
+	if NewLedger().HasSuccessfulReviewAfter(-1) {
+		t.Fatal("an empty ledger must not satisfy the checkpoint-baseline review")
+	}
+
+	read := NewLedger()
+	read.Record(ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"internal/parser.go"}`), true, true))
+	if !read.HasSuccessfulReviewAfter(-1) {
+		t.Fatal("a successful read must satisfy review for a restored mutation baseline")
+	}
+
+	diff := NewLedger()
+	diff.Record(ReceiptFromToolCall("bash", json.RawMessage(`{"command":"git diff"}`), true, false))
+	if !diff.HasSuccessfulReviewAfter(-1) {
+		t.Fatal("a git diff inspection must satisfy review for a restored mutation baseline")
+	}
+
+	failed := NewLedger()
+	failed.Record(ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"internal/parser.go"}`), false, true))
+	if failed.HasSuccessfulReviewAfter(-1) {
+		t.Fatal("a failed read must not satisfy the checkpoint-baseline review")
+	}
+
+	opaque := NewLedger()
+	opaque.Record(ReceiptFromToolCall("bash", json.RawMessage(`{"command":"echo done"}`), true, false))
+	if opaque.HasSuccessfulReviewAfter(-1) {
+		t.Fatal("a non-review command must not satisfy the checkpoint-baseline review")
+	}
+}
+
 func TestLedgerDeliverySignoffRequiresPostMutationVerificationAndReview(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(ReceiptFromToolCall("todo_write", json.RawMessage(`{"todos":[{"content":"Ship parser","status":"in_progress"}]}`), true, true))


### PR DESCRIPTION
## Summary

- Keep Delivery evidence within one host-owned Goal scope so multi-turn Goal work can finalize without repeating already verified work. A later mutation still invalidates earlier verification, review, and sign-off.
- Persist a compact Goal scope and Delivery checkpoint across desktop controller rebuilds and cold resumes. Blocked/stopped Goals can be resumed explicitly, while completed Goals are never revived from stale tab metadata.
- Serialize Goal, Delivery/token-mode, YOLO, model, effort, settings, rebind, and clear transitions against foreground turn admission. Replacement controllers are swapped only after build, resume, lease acquisition, and identity checks succeed.
- Make frontend transitions transactional: prevent duplicate switches, disable conflicting controls and submit, roll back failed token-mode changes, await the first Goal activation, and resume a blocked Goal before sending Delivery recovery input.
- Preserve YOLO permission semantics and provider-visible prompt/tool-schema bytes. The persisted checkpoint contains booleans and a scope ID only, never raw tool arguments or output.

## Compatibility

| Field | Old-data behavior | Conclusion |
| --- | --- | --- |
| `scopeID` | Missing legacy Goal sidecars receive a new Goal scope when restored. | Backward compatible |
| `deliveryCheckpoint` | Missing legacy data starts with an empty, conservative checkpoint and requires fresh evidence. | Backward compatible |
| New JSON fields | Existing readers ignore unknown `goal-state.json` fields. | Cross-version readable |

## Verification

- `env -u DEEPSEEK_API_KEY go test ./... -count=1 -timeout 10m`
- `cd desktop && go test ./... -count=1 -timeout 10m`
- `go test -race ./internal/agent ./internal/control -count=1 -timeout 10m`
- `cd desktop && go test -race . -run 'Test(GoalDeliveryYolo|GoalAndCollaborationResync|TokenModeSwitchWaits|EffortCommand|RuntimeRebuilds|Rebind)' -count=1 -timeout 10m`
- `cd desktop/frontend && pnpm test`
- `cd desktop/frontend && pnpm typecheck`
- `cd desktop/frontend && pnpm test:typecheck`
- `./scripts/cache-guard.sh`
- Browser interaction and geometry checks at 1280x800 and 390x844: Goal + Delivery + YOLO selected, no control overlap, no horizontal overflow, and no console errors/warnings.
- `git diff --check origin/main-v2...HEAD`

## Cache impact

Cache-impact: none - Goal scope/checkpoint state stays host-side, and regression coverage confirms provider-visible messages and tool schemas are byte-for-byte unchanged.
Cache-guard: ./scripts/cache-guard.sh
System-prompt-review: Reviewed by the PR author - `desktop/session_prompt.go` only changes Goal sidecar restoration order; provider-visible system prompt bytes are unchanged and covered by the request-stability regression test.
