### PR TITLE
fix(cli): support shell-escaped Windows paths / 支持 Windows Shell 转义路径

### DIFF
--- a/internal/cli/chat_attachment_test.go
+++ b/internal/cli/chat_attachment_test.go
@@ -146,9 +146,16 @@ func TestPastedImageSources(t *testing.T) {
 			if c.posixOnly && runtime.GOOS == "windows" {
 				t.Skip("POSIX shell-escaped paths are not decoded on Windows")
 			}
-			got, ok := pastedImageSources(c.text)
+			sources, ok := pastedImageSources(c.text)
 			if ok != c.ok {
 				t.Fatalf("ok = %v, want %v", ok, c.ok)
+			}
+			var got []string
+			if sources != nil {
+				got = make([]string, 0, len(sources))
+				for _, source := range sources {
+					got = append(got, source.value)
+				}
 			}
 			if !reflect.DeepEqual(got, c.want) {
 				t.Fatalf("sources = %v, want %v", got, c.want)
@@ -246,6 +253,23 @@ func TestPasteMultipleShellEscapedImagePathsInsertsImageTokens(t *testing.T) {
 	}
 	if len(updated.pastedBlocks) != 2 || !updated.pastedBlocks[0].image || !updated.pastedBlocks[1].image {
 		t.Fatalf("pastedBlocks = %+v, want two image blocks", updated.pastedBlocks)
+	}
+}
+
+func TestMissingPastedImagePathRemainsText(t *testing.T) {
+	content := `/definitely-missing/reasonix-image.png`
+	if runtime.GOOS == "windows" {
+		content = `C:/definitely-missing/reasonix-image.png`
+	}
+
+	m := newTestChatTUI()
+	next, _ := m.Update(tea.PasteMsg{Content: content})
+	updated := next.(chatTUI)
+	if got := updated.input.Value(); got != content {
+		t.Fatalf("input after missing image paste = %q, want original %q", got, content)
+	}
+	if len(updated.pastedBlocks) != 0 {
+		t.Fatalf("pastedBlocks = %+v, want no image attachment", updated.pastedBlocks)
 	}
 }
 

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -2,9 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"net/url"
-	"os"
-	pathpkg "path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -14,6 +11,7 @@ import (
 	"github.com/atotto/clipboard"
 
 	"reasonix/internal/control"
+	"reasonix/internal/shellparse"
 )
 
 // This file holds the chat TUI's paste & image-attachment input layer: folding
@@ -139,6 +137,7 @@ func (m *chatTUI) attachPastedImages(text string) bool {
 	if !ok {
 		return false
 	}
+	attached := false
 	for _, src := range sources {
 		path, err := savePastedImageSource(src)
 		if err != nil {
@@ -146,40 +145,74 @@ func (m *chatTUI) attachPastedImages(text string) bool {
 			continue
 		}
 		m.insertImageRef(path)
+		attached = true
 	}
-	return true
+	if !attached && m.validComposerSelection() && !m.composerSel.empty() {
+		// A failed attachment must not replace an active selection. The notice
+		// above explains the failure; callers otherwise fall back to text paste.
+		return true
+	}
+	return attached
 }
 
 var markdownImageSourceRe = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)`)
 
-func pastedImageSources(text string) ([]string, bool) {
+type pastedImageSource struct {
+	value        string
+	shellDecoded bool
+}
+
+func pastedImageSources(text string) ([]pastedImageSource, bool) {
+	return pastedImageSourcesForOS(text, runtime.GOOS)
+}
+
+func pastedImageSourcesForOS(text, goos string) ([]pastedImageSource, bool) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return nil, false
 	}
 	if isDataImage(trimmed) {
-		return []string{trimmed}, true
+		return []pastedImageSource{{value: trimmed}}, true
 	}
 	if matches := markdownImageSourceRe.FindAllStringSubmatch(trimmed, -1); len(matches) > 0 {
 		rest := strings.TrimSpace(markdownImageSourceRe.ReplaceAllString(trimmed, ""))
 		if rest == "" {
-			sources := make([]string, 0, len(matches))
+			sources := make([]pastedImageSource, 0, len(matches))
 			for _, m := range matches {
-				sources = append(sources, m[1])
+				sources = append(sources, pastedImageSource{value: m[1]})
 			}
 			return sources, true
 		}
 	}
 
 	lines := nonEmptyPasteLines(trimmed)
-	if len(lines) > 0 && allImageSources(lines) {
-		return lines, true
+	lineSources := rawPastedImageSources(lines)
+	if len(lines) > 0 && allImageSources(lineSources, goos) {
+		return lineSources, true
 	}
 	fields := splitPastePathTokens(trimmed)
-	if len(fields) > 1 && allImageSources(fields) {
-		return fields, true
+	fieldSources := rawPastedImageSources(fields)
+	if len(fields) > 1 && allImageSources(fieldSources, goos) {
+		return fieldSources, true
+	}
+	if staticFields, malformed := shellparse.StaticFields(trimmed); malformed == "" && len(staticFields) > 1 {
+		sources := make([]pastedImageSource, 0, len(staticFields))
+		for _, field := range staticFields {
+			sources = append(sources, pastedImageSource{value: field, shellDecoded: true})
+		}
+		if allImageSources(sources, goos) {
+			return sources, true
+		}
 	}
 	return nil, false
+}
+
+func rawPastedImageSources(values []string) []pastedImageSource {
+	sources := make([]pastedImageSource, 0, len(values))
+	for _, value := range values {
+		sources = append(sources, pastedImageSource{value: value})
+	}
+	return sources
 }
 
 // splitPastePathTokens splits pasted text into path tokens the way a shell
@@ -238,98 +271,74 @@ func nonEmptyPasteLines(text string) []string {
 	return out
 }
 
-func allImageSources(sources []string) bool {
+func allImageSources(sources []pastedImageSource, goos string) bool {
 	if len(sources) == 0 {
 		return false
 	}
 	for _, src := range sources {
-		if !looksLikeImageSource(src) {
+		if !looksLikeImageSource(src, goos) {
 			return false
 		}
 	}
 	return true
 }
 
-func looksLikeImageSource(src string) bool {
-	if isDataImage(strings.TrimSpace(src)) {
+func looksLikeImageSource(src pastedImageSource, goos string) bool {
+	if isDataImage(strings.TrimSpace(src.value)) {
 		return true
 	}
-	path, ok := pastedImagePath(src)
-	if !ok {
-		return false
-	}
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
-		return true
+	for _, path := range pastedPathCandidates(src.value, goos, src.shellDecoded) {
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".png", ".jpg", ".jpeg", ".gif", ".webp":
+			return true
+		}
 	}
 	return false
 }
 
-func savePastedImageSource(src string) (string, error) {
-	src = strings.TrimSpace(src)
-	if isDataImage(src) {
-		return control.SaveImageDataURL(src)
+func savePastedImageSource(src pastedImageSource) (string, error) {
+	value := strings.TrimSpace(src.value)
+	if isDataImage(value) {
+		return control.SaveImageDataURL(value)
 	}
-	path, ok := pastedImagePath(src)
-	if !ok {
-		return "", fmt.Errorf("unsupported pasted image source")
+	var lastErr error
+	for _, path := range pastedPathCandidates(value, runtime.GOOS, src.shellDecoded) {
+		if !looksLikeImagePath(path) {
+			continue
+		}
+		saved, err := control.SaveImageFile(path)
+		if err == nil {
+			return saved, nil
+		}
+		lastErr = err
 	}
-	return control.SaveImageFile(path)
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("unsupported pasted image source")
+}
+
+func looksLikeImagePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
+		return true
+	default:
+		return false
+	}
 }
 
 func isDataImage(src string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(src)), "data:image/")
 }
 
-func pastedImagePath(src string) (string, bool) {
-	return pastedImagePathForOS(src, runtime.GOOS)
-}
-
-// pastedImagePathForOS is pastedImagePath with the OS injected so both
-// branches are testable everywhere. On Windows the backslash is the path
-// separator — terminals there quote dragged paths instead of escaping them —
-// so shell-style unescaping is skipped to keep native paths intact.
+// pastedImagePathForOS returns the preferred syntactic candidate with the OS
+// injected so platform-specific path handling is testable everywhere.
 func pastedImagePathForOS(src, goos string) (string, bool) {
-	src = strings.TrimSpace(src)
-	src = strings.TrimPrefix(src, "@")
-	quoted := (strings.HasPrefix(src, `"`) && strings.HasSuffix(src, `"`)) || (strings.HasPrefix(src, `'`) && strings.HasSuffix(src, `'`))
-	src = strings.Trim(src, "\"'")
-	if src == "" {
+	candidates := pastedPathCandidates(src, goos, false)
+	if len(candidates) == 0 {
 		return "", false
 	}
-	if !quoted {
-		if goos == "windows" {
-			if strings.ContainsAny(src, " \t\r\n") {
-				return "", false
-			}
-		} else {
-			if hasUnescapedPathWhitespace(src) {
-				return "", false
-			}
-			src = unescapeShellPath(src)
-		}
-	}
-	lower := strings.ToLower(src)
-	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
-		return "", false
-	}
-	if strings.HasPrefix(lower, "file://") {
-		u, err := url.Parse(src)
-		if err != nil || u.Path == "" {
-			return "", false
-		}
-		src = u.Path
-	}
-	if strings.HasPrefix(src, "~/") {
-		home, err := os.UserHomeDir()
-		if err == nil && home != "" {
-			src = filepath.Join(home, strings.TrimPrefix(src, "~/"))
-		}
-	}
-	if goos == "windows" {
-		return filepath.Clean(src), true
-	}
-	return pathpkg.Clean(src), true
+	return candidates[0], true
 }
 
 func hasUnescapedPathWhitespace(s string) bool {
@@ -375,11 +384,8 @@ func unescapeShellPath(s string) string {
 // pasted word is left alone. Whitespace in the path is escaped so the ref
 // survives @-token parsing on submit.
 func pastedFileRef(content string) (string, bool) {
-	path, ok := pastedImagePath(content)
+	path, ok := resolveExistingPastedPath(content, runtime.GOOS, false, pastedPathExists)
 	if !ok || !strings.ContainsAny(path, `/\`) {
-		return "", false
-	}
-	if info, err := os.Stat(path); err != nil || info.IsDir() {
 		return "", false
 	}
 	return "@" + control.EscapeRefPath(path), true

--- a/internal/cli/pasted_path.go
+++ b/internal/cli/pasted_path.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"net/url"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/shellparse"
+)
+
+// pastedPathCandidates returns literal filesystem paths without executing a
+// shell. Windows tries the native spelling first, then static shell-decoded
+// forms used by Git Bash, MSYS2, Cygwin, and WSL drive mounts.
+func pastedPathCandidates(src, goos string, shellDecoded bool) []string {
+	src = strings.TrimSpace(src)
+	src = strings.TrimPrefix(src, "@")
+	if src == "" {
+		return nil
+	}
+
+	var out []string
+	seen := map[string]bool{}
+	add := func(candidate string) {
+		candidate, ok := normalizePastedPathCandidate(candidate, goos)
+		if !ok || seen[candidate] {
+			return
+		}
+		seen[candidate] = true
+		out = append(out, candidate)
+	}
+
+	if shellDecoded {
+		add(src)
+		return out
+	}
+
+	inner, quoted := trimMatchingPathQuotes(src)
+	if goos == "windows" {
+		if quoted {
+			add(inner)
+		} else if !hasUnescapedPathWhitespace(src) {
+			add(src)
+		}
+	}
+
+	if fields, malformed := shellparse.StaticFields(src); malformed == "" && len(fields) == 1 {
+		add(fields[0])
+	}
+
+	if goos == "windows" {
+		if !quoted && !hasUnescapedPathWhitespace(src) && strings.Contains(src, `\`) {
+			add(unescapeWindowsShellPath(src))
+		}
+	} else if quoted {
+		add(inner)
+	} else if !hasUnescapedPathWhitespace(src) {
+		// Preserve the pre-existing POSIX behavior for unusual inputs the static
+		// parser rejects, such as a trailing literal backslash.
+		add(unescapeShellPath(src))
+	}
+
+	return out
+}
+
+func resolveExistingPastedPath(src, goos string, shellDecoded bool, exists func(string) bool) (string, bool) {
+	if exists == nil {
+		return "", false
+	}
+	for _, candidate := range pastedPathCandidates(src, goos, shellDecoded) {
+		if exists(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func pastedPathExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func trimMatchingPathQuotes(src string) (string, bool) {
+	if len(src) < 2 {
+		return src, false
+	}
+	first, last := src[0], src[len(src)-1]
+	if (first == '\'' || first == '"') && first == last {
+		return src[1 : len(src)-1], true
+	}
+	return src, false
+}
+
+func normalizePastedPathCandidate(src, goos string) (string, bool) {
+	if src == "" {
+		return "", false
+	}
+	lower := strings.ToLower(src)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return "", false
+	}
+	if strings.HasPrefix(lower, "file://") {
+		u, err := url.Parse(src)
+		if err != nil || u.Path == "" {
+			return "", false
+		}
+		src = u.Path
+		if goos == "windows" && u.Host != "" {
+			src = "//" + u.Host + u.Path
+		}
+	}
+	if strings.HasPrefix(src, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil && home != "" {
+			src = filepath.Join(home, strings.TrimPrefix(src, "~/"))
+		}
+	}
+	if goos == "windows" {
+		src = normalizeWindowsPOSIXPath(src)
+		return src, src != ""
+	}
+	return pathpkg.Clean(src), true
+}
+
+func normalizeWindowsPOSIXPath(src string) string {
+	if len(src) >= 4 && src[0] == '/' && isASCIIAlpha(src[1]) && src[2] == ':' && src[3] == '/' {
+		return strings.ToUpper(src[1:2]) + src[2:]
+	}
+	if len(src) >= 3 && src[0] == '/' && isASCIIAlpha(src[1]) && src[2] == '/' {
+		return strings.ToUpper(src[1:2]) + ":" + src[2:]
+	}
+	lower := strings.ToLower(src)
+	if len(src) >= 7 && strings.HasPrefix(lower, "/mnt/") && isASCIIAlpha(src[5]) && src[6] == '/' {
+		return strings.ToUpper(src[5:6]) + ":" + src[6:]
+	}
+	const cygdrive = "/cygdrive/"
+	if len(src) >= len(cygdrive)+2 && strings.HasPrefix(lower, cygdrive) && isASCIIAlpha(src[len(cygdrive)]) && src[len(cygdrive)+1] == '/' {
+		return strings.ToUpper(src[len(cygdrive):len(cygdrive)+1]) + ":" + src[len(cygdrive)+1:]
+	}
+	return src
+}
+
+// unescapeWindowsShellPath keeps likely native separator backslashes while
+// decoding shell escapes. This candidate is only used after the exact native
+// spelling fails the caller's existence check, so punctuation-led native path
+// components still resolve through the native candidate first.
+func unescapeWindowsShellPath(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != '\\' || i+1 >= len(src) {
+			b.WriteByte(src[i])
+			continue
+		}
+		next := src[i+1]
+		if windowsPathComponentByte(next) {
+			b.WriteByte(src[i])
+			continue
+		}
+		b.WriteByte(next)
+		i++
+	}
+	return b.String()
+}
+
+func windowsPathComponentByte(ch byte) bool {
+	return ch >= 0x80 || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' || ch == '.' || ch == '_' || ch == '-'
+}
+
+func isASCIIAlpha(ch byte) bool {
+	return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z'
+}

--- a/internal/cli/pasted_path.go
+++ b/internal/cli/pasted_path.go
@@ -148,7 +148,14 @@ func normalizeWindowsPOSIXPath(src string) string {
 func unescapeWindowsShellPath(src string) string {
 	var b strings.Builder
 	b.Grow(len(src))
-	for i := 0; i < len(src); i++ {
+	i := 0
+	// A leading double backslash is a UNC or device prefix (\\server\share,
+	// \\?\C:\..., \\.\...), not an escape pair; keep it verbatim.
+	if strings.HasPrefix(src, `\\`) {
+		b.WriteString(`\\`)
+		i = 2
+	}
+	for ; i < len(src); i++ {
 		if src[i] != '\\' || i+1 >= len(src) {
 			b.WriteByte(src[i])
 			continue

--- a/internal/cli/pasted_path_test.go
+++ b/internal/cli/pasted_path_test.go
@@ -60,6 +60,20 @@ func TestResolveExistingPastedPathWindowsCandidates(t *testing.T) {
 			ok:     true,
 		},
 		{
+			name:   "unc backslash path",
+			input:  `\\server\share\My\ Shot.png`,
+			exists: []string{`\\server\share\My Shot.png`},
+			want:   `\\server\share\My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "extended-length path",
+			input:  `\\?\C:\Users\me\My\ Shot.png`,
+			exists: []string{`\\?\C:\Users\me\My Shot.png`},
+			want:   `\\?\C:\Users\me\My Shot.png`,
+			ok:     true,
+		},
+		{
 			name:  "native interpretation precedes shell fallback",
 			input: `C:\work\(draft)\shot.png`,
 			exists: []string{

--- a/internal/cli/pasted_path_test.go
+++ b/internal/cli/pasted_path_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import "testing"
+
+func TestResolveExistingPastedPathWindowsCandidates(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		exists []string
+		want   string
+		ok     bool
+	}{
+		{
+			name:   "native windows path wins",
+			input:  `C:\Users\me\shot.png`,
+			exists: []string{`C:\Users\me\shot.png`},
+			want:   `C:\Users\me\shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "git bash slash path",
+			input:  `C:/Users/me/My\ Shot.png`,
+			exists: []string{`C:/Users/me/My Shot.png`},
+			want:   `C:/Users/me/My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "git bash backslash path",
+			input:  `C:\Users\me\My\ Shot.png`,
+			exists: []string{`C:\Users\me\My Shot.png`},
+			want:   `C:\Users\me\My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "msys drive path",
+			input:  `/c/Users/me/My\ Shot.png`,
+			exists: []string{`C:/Users/me/My Shot.png`},
+			want:   `C:/Users/me/My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "wsl mounted drive path",
+			input:  `/mnt/c/Users/me/My\ Shot.png`,
+			exists: []string{`C:/Users/me/My Shot.png`},
+			want:   `C:/Users/me/My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "cygwin drive path",
+			input:  `/cygdrive/c/Users/me/My\ Shot.png`,
+			exists: []string{`C:/Users/me/My Shot.png`},
+			want:   `C:/Users/me/My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:   "unc path",
+			input:  `//server/share/My\ Shot.png`,
+			exists: []string{`//server/share/My Shot.png`},
+			want:   `//server/share/My Shot.png`,
+			ok:     true,
+		},
+		{
+			name:  "native interpretation precedes shell fallback",
+			input: `C:\work\(draft)\shot.png`,
+			exists: []string{
+				`C:\work\(draft)\shot.png`,
+				`C:\work(draft)\shot.png`,
+			},
+			want: `C:\work\(draft)\shot.png`,
+			ok:   true,
+		},
+		{
+			name:  "missing candidates rejected",
+			input: `C:/Users/me/Missing\ Shot.png`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := make(map[string]bool, len(tt.exists))
+			for _, path := range tt.exists {
+				existing[path] = true
+			}
+			got, ok := resolveExistingPastedPath(tt.input, "windows", false, func(path string) bool {
+				return existing[path]
+			})
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("resolveExistingPastedPath(%q) = %q, %v; want %q, %v", tt.input, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestPastedImageSourcesUsesStaticShellFields(t *testing.T) {
+	input := `C:/Users/me/first" image".png C:/Users/me/second\ image.jpg`
+	got, ok := pastedImageSourcesForOS(input, "windows")
+	if !ok {
+		t.Fatal("pastedImageSourcesForOS rejected static shell paths")
+	}
+	want := []pastedImageSource{
+		{value: "C:/Users/me/first image.png", shellDecoded: true},
+		{value: "C:/Users/me/second image.jpg", shellDecoded: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sources = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("source[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- follow up on #6060 by recognizing Windows paths pasted from Git Bash/MSYS2, including `C:/...`, `/c/...`, WSL `/mnt/c/...`, Cygwin `/cygdrive/c/...`, and UNC spellings
- parse shell quoting and escapes statically through the existing shell parser; no shell is executed
- try the native Windows spelling first, then decoded candidates, and accept only a candidate that refers to an existing file
- keep missing image paths as ordinary pasted text; when a composer selection is active, preserve the selection and show the attachment error instead of replacing user text

## Compatibility

| Surface | Existing behavior | Conclusion |
| --- | --- | --- |
| Native Windows paths | Native spelling remains the first candidate | Preserved |
| Existing POSIX paste handling | Existing quoting and escape behavior remains covered | Preserved |
| Persisted state, config, and contracts | No format or field changes | Backward-compatible |

## Verification

- `env -u DEEPSEEK_API_KEY go test ./...`
- `go test ./internal/cli ./internal/control ./internal/shellparse`
- `go test -race ./internal/cli ./internal/control`
- `go vet ./internal/cli ./internal/control ./internal/shellparse`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/cli`
- `git diff --check origin/main-v2...HEAD`

## Cache impact

Cache-impact: none; this only changes local CLI paste-path recognition and attachment handling.
Cache-guard: `go test ./internal/cli ./internal/control ./internal/shellparse`
System-prompt-review: N/A
