### PR TITLE
Drain bot stop races and quote selection paths / 修复 bot 停止竞态、QQ 网关排空与选区路径引用

### DIFF
--- a/desktop/frontend/src/__tests__/composer-session-draft.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-session-draft.test.tsx
@@ -243,13 +243,23 @@ console.log("\ncomposer session draft");
 
   eq(
     formatSelectionReference("src/a.ts", "const `x` = ```1```;\r\n"),
-    "From `src/a.ts`:\n\n````typescript\nconst `x` = ```1```;\n````",
+    'From "src/a.ts":\n\n````typescript\nconst `x` = ```1```;\n````',
     "plan-revision rendering escalates the fence past embedded backtick runs and tags the language",
   );
   eq(
     formatSelectionReference("notes.xyz", "plain body"),
-    "From `notes.xyz`:\n\n```\nplain body\n```",
+    'From "notes.xyz":\n\n```\nplain body\n```',
     "unknown extensions render an untagged fence",
+  );
+  eq(
+    formatSelectionReference("weird ` name\r\n.ts", "body"),
+    'From "weird ` name\\r\\n.ts":\n\n```typescript\nbody\n```',
+    "backticks and newlines in file names stay escaped inside the quoted path",
+  );
+  eq(
+    formatSelectionReference('has "quotes" \\ slashes.md', "body"),
+    'From "has \\"quotes\\" \\\\ slashes.md":\n\n```markdown\nbody\n```',
+    "quotes and backslashes in file names cannot break the path string",
   );
 
   const oversized = normalizeSelectedText("x".repeat(SELECTED_TEXT_MAX_CHARS + 500));

--- a/desktop/frontend/src/lib/selectedTextContext.ts
+++ b/desktop/frontend/src/lib/selectedTextContext.ts
@@ -96,5 +96,8 @@ export function formatSelectionReference(path: string, text: string): string {
   const body = text.replace(/\r\n|\r/g, "\n").trimEnd();
   const fence = fenceFor(body);
   const lang = languageFor(path);
-  return `From \`${path}\`:\n\n${fence}${lang ?? ""}\n${body}\n${fence}`;
+  // The path is a JSON string, not a backtick code span: backticks and
+  // newlines are legal in file names and would terminate a code span early,
+  // letting the path spill out as plain (instruction-like) text.
+  return `From ${JSON.stringify(path)}:\n\n${fence}${lang ?? ""}\n${body}\n${fence}`;
 }

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -50,7 +50,16 @@ type GatewayConfig struct {
 	Allowlist          AllowlistConfig
 	Enabled            map[Platform]bool
 	Debounce           time.Duration
-	OnInbound          func(InboundMessage)
+	// OnInbound observes every allowlisted inbound message before dispatch.
+	//
+	// Reentrancy contract for all GatewayConfig callbacks (OnInbound,
+	// OnSessionReady, OnToolApprovalModeChange): they run synchronously on
+	// gateway-owned dispatch/turn goroutines that Stop drains before returning.
+	// A callback must therefore never call Stop, nor block until a goroutine
+	// that does so completes — Stop would wait on the very goroutine running
+	// the callback, a guaranteed deadlock. Hosts that want to shut the gateway
+	// down in reaction to a callback must trigger the shutdown asynchronously.
+	OnInbound func(InboundMessage)
 	// OnSessionReady notifies the host after the bot has created or reused the
 	// controller for an inbound remote. Hosts may persist the concrete session ID
 	// or keep the remote as a read-only channel.
@@ -556,7 +565,9 @@ func (gw *BotGateway) ensureAdapterHealthLocked(binding AdapterBinding) *Adapter
 	return health
 }
 
-// Stop 停止所有适配器并关闭所有 session。
+// Stop 停止所有适配器并关闭所有 session。它会等待 dispatch 与 turn goroutine
+// 全部退出，所以绝不能在 GatewayConfig 回调里同步调用（见 OnInbound 的
+// reentrancy contract），否则 Stop 会等待正在运行该回调的 goroutine 自己。
 func (gw *BotGateway) Stop() {
 	gw.lifecycleMu.Lock()
 	if gw.stopped {
@@ -609,7 +620,28 @@ func (gw *BotGateway) closeSessions() {
 	}
 	gw.mu.Unlock()
 	for _, state := range states {
-		closeBotSessionState(state)
+		gw.closeSessionState(state)
+	}
+}
+
+// closeSessionState tears down a session state that has been unlinked from
+// gw.controllers. runTurn publishes state.cancel under gw.mu on every turn —
+// possibly after the state was already unlinked — so snapshot and clear the
+// field inside the lock and invoke it outside (the same discipline as
+// cancelActiveSession).
+func (gw *BotGateway) closeSessionState(state *sessionState) {
+	if state == nil {
+		return
+	}
+	gw.mu.Lock()
+	cancel := state.cancel
+	state.cancel = nil
+	gw.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if state.ctrl != nil {
+		state.ctrl.Close()
 	}
 }
 
@@ -1554,7 +1586,7 @@ func (gw *BotGateway) setSessionRuntimeOverride(key string, override sessionRunt
 		delete(gw.sessionOverrides, key)
 	}
 	gw.mu.Unlock()
-	closeBotSessionState(old)
+	gw.closeSessionState(old)
 	gw.sessions.ForceRelease(key)
 }
 
@@ -1850,9 +1882,18 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 	defer cancel()
 
 	gw.mu.Lock()
-	state.cancel = cancel
+	live := gw.controllers[key] == state
+	if live {
+		state.cancel = cancel
+	}
 	state.lastActive = time.Now()
 	gw.mu.Unlock()
+	if !live {
+		// The session was closed (gateway stop or runtime rebuild) after this
+		// turn picked it up; a cancel published now would never be consumed, so
+		// abort the turn instead of running it uncancellable.
+		cancel()
+	}
 
 	// 运行一轮对话
 	err := state.ctrl.RunTurn(turnCtx, input)
@@ -1896,7 +1937,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 			delete(gw.controllers, key)
 			stale = state
 			gw.mu.Unlock()
-			closeBotSessionState(stale)
+			gw.closeSessionState(stale)
 			gw.logger.Warn("bot session runtime changed; rebuilding", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "old_workspace_set", strings.TrimSpace(stale.workspaceRoot) != "", "new_workspace_set", profile.workspaceRoot != "", "old_model", stale.model, "new_model", profile.model)
 		} else {
 			updateSessionStateRuntime(state, msg, profile)
@@ -1974,7 +2015,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	}
 	gw.controllers[key] = state
 	gw.mu.Unlock()
-	closeBotSessionState(replace)
+	gw.closeSessionState(replace)
 
 	gw.logger.Info("bot session created", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8])
 	return state
@@ -1995,18 +2036,6 @@ func updateSessionStateRuntime(state *sessionState, msg InboundMessage, profile 
 	state.toolApprovalMode = profile.toolApprovalMode
 	state.sessionPath = profile.sessionPath
 	state.lastActive = time.Now()
-}
-
-func closeBotSessionState(state *sessionState) {
-	if state == nil {
-		return
-	}
-	if state.cancel != nil {
-		state.cancel()
-	}
-	if state.ctrl != nil {
-		state.ctrl.Close()
-	}
 }
 
 func (gw *BotGateway) sessionProfileForMessage(msg InboundMessage) sessionRuntimeProfile {

--- a/internal/bot/gateway_lock_test.go
+++ b/internal/bot/gateway_lock_test.go
@@ -184,6 +184,121 @@ func TestBotGatewayStopWaitsForTurn(t *testing.T) {
 	}
 }
 
+type typingHoldAdapter struct {
+	*fakeAdapter
+	entered chan struct{} // one send per turn parked in SendTyping
+	release chan struct{}
+}
+
+func (a *typingHoldAdapter) SendTyping(context.Context, string) error {
+	a.entered <- struct{}{}
+	<-a.release
+	return nil
+}
+
+type cancelPublishBotController struct {
+	botController
+	closeEntered chan struct{} // one send when Close begins
+	closeHold    chan struct{} // Close parks here, pinning Stop inside the closeSessions loop
+	turnCtx      chan error    // ctx.Err() observed on RunTurn entry
+}
+
+func (c *cancelPublishBotController) RunTurn(ctx context.Context, _ string) error {
+	c.turnCtx <- ctx.Err()
+	return nil
+}
+
+func (c *cancelPublishBotController) SessionPath() string   { return "" }
+func (c *cancelPublishBotController) WorkspaceRoot() string { return "" }
+func (c *cancelPublishBotController) Close() {
+	c.closeEntered <- struct{}{}
+	<-c.closeHold
+}
+
+// Guards the cancel-publication window: runTurn publishes state.cancel under
+// gw.mu only after the session is already visible in gw.controllers, so Stop
+// can consume the field from another goroutine while the turn is still on its
+// way to publication. TestBotGatewayStopWaitsForTurn stops only after RunTurn
+// has begun (cancel already published) and never covers this window.
+//
+// Two sessions are needed because whichever state closeSessions visits first
+// has its cancel read before Close signals the test — any write released off
+// that signal is ordered after the read and invisible to the race detector.
+// The first state's blocking Close pins Stop mid-loop instead, so the second
+// state's cancel read happens after the turns were let through to publish.
+// Run with -race: an unlocked read of state.cancel here is a data race.
+func TestBotGatewayStopBeforeTurnCancelPublication(t *testing.T) {
+	adapter := &typingHoldAdapter{
+		fakeAdapter: newFakeAdapter(PlatformWeixin, "fake-weixin"),
+		entered:     make(chan struct{}, 2),
+		release:     make(chan struct{}),
+	}
+	gw := NewGatewayWithAdapterBindings(GatewayConfig{
+		Enabled:   map[Platform]bool{PlatformWeixin: true},
+		Allowlist: AllowlistConfig{AllowAll: true},
+	}, []AdapterBinding{{ID: "weixin", Platform: PlatformWeixin, Adapter: adapter}}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	closeEntered := make(chan struct{}, 2)
+	closeHold := make(chan struct{})
+	turnCtx := make(chan error, 2)
+	chats := []string{"chat-a", "chat-b"}
+	for _, chat := range chats {
+		msg := InboundMessage{Platform: PlatformWeixin, ConnectionID: "weixin", ChatType: ChatDM, ChatID: chat, UserID: "user"}
+		gw.controllers[BuildSessionKey(msg.Session())] = &sessionState{
+			ctrl: &cancelPublishBotController{closeEntered: closeEntered, closeHold: closeHold, turnCtx: turnCtx},
+			sink: &sessionEventSink{},
+		}
+	}
+	if err := gw.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	for _, chat := range chats {
+		adapter.msgCh <- InboundMessage{Platform: PlatformWeixin, ConnectionID: "weixin", ChatType: ChatDM, ChatID: chat, UserID: "user", Text: "hello"}
+	}
+	for range chats {
+		select {
+		case <-adapter.entered:
+		case <-time.After(time.Second):
+			t.Fatal("turn did not reach the pre-publication window")
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		gw.Stop()
+		close(done)
+	}()
+	// Stop is parked inside the closeSessions loop: the first state's cancel is
+	// consumed and its Close is held; the second state's cancel is still unread.
+	select {
+	case <-closeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not reach the session close loop")
+	}
+	// Let both turns publish their cancel funcs while Stop stays parked. The
+	// sleep is deliberate and cannot become a channel handshake: observing the
+	// publication would order the write before Stop's read and hide the race
+	// from the detector.
+	close(adapter.release)
+	time.Sleep(200 * time.Millisecond)
+	close(closeHold)
+
+	for range chats {
+		select {
+		case err := <-turnCtx:
+			if err == nil {
+				t.Fatal("turn ran with a live context after Stop closed its session")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("turn did not run to completion")
+		}
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the late turns exited")
+	}
+}
+
 func TestBotGatewayStopIsIdempotent(t *testing.T) {
 	adapter := &countingStopAdapter{fakeAdapter: newFakeAdapter(PlatformFeishu, "fake-feishu")}
 	gw := NewGatewayWithAdapterBindings(GatewayConfig{

--- a/internal/bot/qq/adapter.go
+++ b/internal/bot/qq/adapter.go
@@ -15,6 +15,8 @@ import (
 
 	"reasonix/internal/bot"
 	"reasonix/internal/config"
+
+	"golang.org/x/net/websocket"
 )
 
 // New 创建 QQ Bot 适配器。
@@ -30,9 +32,11 @@ type adapter struct {
 	logger *slog.Logger
 	msgCh  chan bot.InboundMessage
 	cancel context.CancelFunc
+	loopWG sync.WaitGroup
 
 	// gateway 状态
-	ws          *wsClient
+	connMu      sync.Mutex
+	conn        *websocket.Conn // live gateway connection, closed by Stop to unblock reads
 	sessionID   string
 	seq         int64
 	token       string
@@ -60,14 +64,23 @@ func (a *adapter) Start(ctx context.Context) error {
 	}
 	ctx, a.cancel = context.WithCancel(ctx)
 
-	go a.gatewayLoop(ctx)
+	a.loopWG.Add(1)
+	go func() {
+		defer a.loopWG.Done()
+		a.gatewayLoop(ctx)
+	}()
 	return nil
 }
 
+// Stop 取消 gateway context、关闭当前 WebSocket 连接并等待 gatewayLoop 退出。
+// websocket 的阻塞读不响应 context，只有关闭连接才能解除阻塞；不等待就返回
+// 会在宿主重建 bot runtime 后留下仍占用 QQ gateway session 的僵尸连接。
 func (a *adapter) Stop() error {
 	if a.cancel != nil {
 		a.cancel()
 	}
+	a.closeConn()
+	a.loopWG.Wait()
 	return nil
 }
 

--- a/internal/bot/qq/adapter_stop_test.go
+++ b/internal/bot/qq/adapter_stop_test.go
@@ -1,0 +1,100 @@
+package qq
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+// Guards the Stop drain contract: the gateway loop blocks in websocket reads
+// that do not honor ctx, so Stop must close the tracked connection to unblock
+// them and must wait for the loop goroutine to exit before returning.
+func TestStopClosesTrackedConnAndWaitsForLoop(t *testing.T) {
+	srv := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		_, _ = io.Copy(io.Discard, ws) // hold the connection open, send nothing
+	}))
+	defer srv.Close()
+
+	conn, err := websocket.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), "", srv.URL)
+	if err != nil {
+		t.Fatalf("dial test server: %v", err)
+	}
+
+	a := &adapter{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	tracked := make(chan struct{})
+	decodeReturned := make(chan struct{})
+	a.loopWG.Add(1)
+	go func() {
+		defer a.loopWG.Done()
+		if !a.trackConn(ctx, conn) {
+			conn.Close()
+			return
+		}
+		defer a.dropConn(conn)
+		close(tracked)
+		var payload gatewayPayload
+		_ = json.NewDecoder(conn).Decode(&payload) // blocks like connectGateway's reads
+		close(decodeReturned)
+	}()
+	select {
+	case <-tracked:
+	case <-time.After(time.Second):
+		t.Fatal("gateway loop did not track its connection")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = a.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not close the gateway connection and wait for the loop")
+	}
+	select {
+	case <-decodeReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Stop returned before the blocking gateway read exited")
+	}
+}
+
+// A connection that finishes dialing after Stop must not be published: Stop
+// has already emptied the tracked slot, so a late publication would leave a
+// conn (and its blocked reader) that nothing can ever close.
+func TestTrackConnRefusesPublicationAfterCancel(t *testing.T) {
+	a := &adapter{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if a.trackConn(ctx, &websocket.Conn{}) {
+		t.Fatal("trackConn published a connection after cancellation")
+	}
+	a.connMu.Lock()
+	defer a.connMu.Unlock()
+	if a.conn != nil {
+		t.Fatal("cancelled publication still stored the connection")
+	}
+}
+
+func TestStopWithoutStartIsSafe(t *testing.T) {
+	a := &adapter{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	done := make(chan struct{})
+	go func() {
+		_ = a.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop blocked on a never-started adapter")
+	}
+}

--- a/internal/bot/qq/adapter_stop_test.go
+++ b/internal/bot/qq/adapter_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -65,6 +66,76 @@ func TestStopClosesTrackedConnAndWaitsForLoop(t *testing.T) {
 	case <-decodeReturned:
 	case <-time.After(time.Second):
 		t.Fatal("Stop returned before the blocking gateway read exited")
+	}
+}
+
+// Guards the dial-phase Stop contract: until the dial returns, the conn is
+// not tracked and closeConn has nothing to close, so cancelling the adapter
+// context must abort a stalled TCP dial or WebSocket handshake. This locks in
+// cfg.DialContext(ctx) over websocket.DialConfig, which dials with
+// context.Background() and would leave Stop blocked on loopWG.Wait.
+func TestStopUnblocksStalledHandshakeDial(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- conn // hold the conn open, never answer the handshake
+	}()
+	defer func() {
+		select {
+		case conn := <-accepted:
+			conn.Close()
+		default:
+		}
+	}()
+
+	a := &adapter{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	dialErr := make(chan error, 1)
+	a.loopWG.Add(1)
+	go func() {
+		defer a.loopWG.Done()
+		conn, err := a.dialGateway(ctx, "ws://"+ln.Addr().String(), "test-token")
+		if err == nil {
+			conn.Close()
+		}
+		dialErr <- err
+	}()
+
+	var srvConn net.Conn
+	select {
+	case srvConn = <-accepted:
+		defer srvConn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("dial never reached the stalled server")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = a.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop blocked on a stalled gateway handshake")
+	}
+	select {
+	case err := <-dialErr:
+		if err == nil {
+			t.Fatal("stalled handshake dial unexpectedly succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dial did not return after Stop cancelled the context")
 	}
 }
 

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -235,10 +235,15 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 		return fmt.Errorf("dial gateway: %w", err)
 	}
 	defer conn.Close()
+	defer a.dropConn(conn)
+	if !a.trackConn(ctx, conn) {
+		// Stop already closed the tracked conn slot; entering a blocking read
+		// now would leave a connection Stop can no longer unblock.
+		return ctx.Err()
+	}
 	a.logger.Info("qq gateway connected", "sandbox", a.cfg.Sandbox)
 
 	ws := &wsClient{conn: conn, token: token, logger: a.logger}
-	a.ws = ws
 
 	var msg gatewayPayload
 	decoder := json.NewDecoder(conn)
@@ -347,6 +352,38 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 			<-heartbeatDone
 			return nil
 		}
+	}
+}
+
+// trackConn publishes the live gateway connection so Stop can close it and
+// unblock the blocking websocket reads, which do not honor ctx. Publication is
+// refused once ctx is cancelled, so a conn that finishes dialing concurrently
+// with Stop can never be left open but unreachable.
+func (a *adapter) trackConn(ctx context.Context, conn *websocket.Conn) bool {
+	a.connMu.Lock()
+	defer a.connMu.Unlock()
+	if ctx.Err() != nil {
+		return false
+	}
+	a.conn = conn
+	return true
+}
+
+func (a *adapter) dropConn(conn *websocket.Conn) {
+	a.connMu.Lock()
+	if a.conn == conn {
+		a.conn = nil
+	}
+	a.connMu.Unlock()
+}
+
+func (a *adapter) closeConn() {
+	a.connMu.Lock()
+	conn := a.conn
+	a.conn = nil
+	a.connMu.Unlock()
+	if conn != nil {
+		conn.Close()
 	}
 }
 

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -222,15 +222,7 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 	if parsed, parseErr := url.Parse(gatewayURL); parseErr == nil {
 		a.logger.Info("qq gateway endpoint resolved", "host", parsed.Hostname(), "sandbox", a.cfg.Sandbox)
 	}
-	cfg, err := websocket.NewConfig(gatewayURL, gatewayURL)
-	if err != nil {
-		return err
-	}
-	cfg.Header = http.Header{}
-	cfg.Header.Set("Authorization", "QQBot "+token)
-	cfg.Header.Set("X-Union-Appid", a.appID())
-
-	conn, err := websocket.DialConfig(cfg)
+	conn, err := a.dialGateway(ctx, gatewayURL, token)
 	if err != nil {
 		return fmt.Errorf("dial gateway: %w", err)
 	}
@@ -353,6 +345,22 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 			return nil
 		}
 	}
+}
+
+// dialGateway dials the QQ gateway honoring ctx. The conn only becomes
+// trackable after the dial returns, so Stop can interrupt a stalled TCP dial
+// or WebSocket/TLS handshake only through ctx cancellation —
+// websocket.DialConfig would dial with context.Background() and leave Stop's
+// loopWG.Wait blocked with nothing to close.
+func (a *adapter) dialGateway(ctx context.Context, gatewayURL, token string) (*websocket.Conn, error) {
+	cfg, err := websocket.NewConfig(gatewayURL, gatewayURL)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Header = http.Header{}
+	cfg.Header.Set("Authorization", "QQBot "+token)
+	cfg.Header.Set("X-Union-Appid", a.appID())
+	return cfg.DialContext(ctx)
 }
 
 // trackConn publishes the live gateway connection so Stop can close it and


### PR DESCRIPTION
Follow-up to the #6454 post-merge review feedback: 1 P1 and 3 P2 findings on the merged lifecycle/selection work, all confirmed against the live code.

## Fixes

### P1 — data race between `Stop` and turn cancel publication (`internal/bot/gateway.go`)
`runTurn` publishes `state.cancel` under `gw.mu` after the session is already visible in `gw.controllers`, while `closeBotSessionState` read the field without the lock. A `Stop` (or runtime rebuild) racing a turn between session pickup and publication was a data race; the existing lifecycle tests only stopped after `RunTurn` had begun and never covered that window.

- `closeSessionState` (now a gateway method) snapshots and clears `cancel` inside `gw.mu` and invokes it outside — the same discipline `cancelActiveSession` already documents.
- `runTurn` refuses to publish onto a state that was unlinked in the meantime and cancels that turn immediately, so a closed session can never run an uncancellable turn.
- New regression test `TestBotGatewayStopBeforeTurnCancelPublication` deterministically reproduces the race on the pre-fix tree under `-race` (read in `closeBotSessionState` vs write in `runTurn`) and passes with the fix. It needs two sessions: whichever state the close loop visits first has its cancel consumed before any test-observable signal, so only the second state's read can be left genuinely unordered against the turns' writes.

### P2 — QQ adapter was never truly stopped (`internal/bot/qq`)
`Stop` only cancelled the context, but the gateway loop blocks in websocket reads that do not honor ctx — violating `RunWithRetry`'s documented "attempt MUST honor ctx and clean up its own connection" contract — and nothing closed the saved conn or waited for the loop. Every bot-runtime rebuild could leave a zombie goroutine holding a live QQ gateway session that keeps receiving dispatches.

`Stop` now cancels, closes the tracked connection to unblock the read, and waits on the loop's WaitGroup. Tracked-conn publication is refused once ctx is cancelled, so a dial racing `Stop` can never leave an open-but-unreachable connection. The dead `a.ws` field (written, never read, never closed) is replaced by the mutex-guarded tracked conn. Covered by `TestStopClosesTrackedConnAndWaitsForLoop`, `TestTrackConnRefusesPublicationAfterCancel`, and `TestStopWithoutStartIsSafe` against a local httptest websocket server.

### P2 — `Stop` from a gateway callback self-deadlocks (`internal/bot/gateway.go`)
`OnInbound` runs on a `gatewayWG`-counted dispatch goroutine and `OnSessionReady` on a `turnWG` goroutine; a callback calling `Stop` synchronously would wait for itself. No in-repo host does this (desktop and CLI wire persistence-only rememberers), so per the review's "declare and forbid" option this adds the explicit reentrancy contract to the callback fields and to `Stop`: callbacks must never call `Stop`; hosts must trigger shutdown asynchronously.

### P2 — selection reference paths could escape their quoting (`desktop/frontend/src/lib/selectedTextContext.ts`)
`formatSelectionReference` fenced the selection body adaptively but placed the path in a single-backtick code span; backtick and newline file names are legal and would terminate the span early, spilling the path as plain instruction-like text. The path is now rendered as a JSON string, which escapes quotes, backslashes, and control characters. Tests cover backtick, CR/LF, quote, and backslash names.

## Backward compatibility

| Surface | Change | Old-data behavior | Conclusion |
| --- | --- | --- | --- |
| `bot.Adapter` interface | unchanged (QQ `Stop` semantics tightened internally) | n/a | safe |
| Persisted formats (`state.json`, sessions, config) | none touched | n/a | safe |
| Plan-revision insert text | ``From `path`:`` → `From "path":` | per-turn user-visible text only; nothing stored or parsed back, no provider prompt-prefix involvement | safe, no cache risk |

## Verification

- `go test -race ./internal/bot ./internal/bot/qq ./internal/bot/feishu ./internal/bot/weixin ./internal/cli` — all pass; the new gateway test fails with a race report on the pre-fix tree and passes post-fix (5× repeats).
- Root `go test ./...` — pass, except the pre-existing machine-local `TestRealDeepSeekCacheProbe` (requires a live `DEEPSEEK_API_KEY`; unrelated to this change).
- `cd desktop && go test ./...` — pass.
- Frontend: `tsc --noEmit`, `check:css`, `composer-session-draft` (67), `transcript-selection-menu` (37), `message-selection-copy` (6) — all pass.
- `gofmt` / `go vet ./internal/bot/...` — clean.

Sibling sweep for the same defect shapes: feishu `Stop` already closes its SDK ws client (its loop unblocks promptly) and weixin polls over ctx-aware HTTP, so neither strands a blocked read the way QQ did; neither waits for its loop goroutine either, but both loops exit promptly on cancel and adapter instances are not reused across rebuilds. `state.ctrl` is immutable after publication, and `pendingApprovals`/`pendingAsks` are consistently accessed under `gw.mu`.
