### PR TITLE
feat(cli): show build metadata in version output / 在版本输出中展示构建元信息

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
-VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
-LDFLAGS := -s -w -X main.version=$(VERSION)
+VERSION := $(shell \
+	tag=$$(git tag --merged HEAD --list 'desktop-v[0-9]*' --sort=-v:refname 2>/dev/null | head -n 1); \
+	if [ -n "$$tag" ]; then \
+		git describe --tags --dirty --match "$$tag" 2>/dev/null; \
+	else \
+		git describe --tags --always --dirty 2>/dev/null || echo dev; \
+	fi)
+BUILD_NUMBER := $(shell date -u +%Y%m%d%H%M%S)
+BUILD_TIME_UTC := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+GIT_DIRTY := $(shell test -z "$$(git status --porcelain --untracked-files=no 2>/dev/null)" && echo clean || echo dirty)
+BUILD_PROFILE ?= release
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.buildNumber=$(BUILD_NUMBER) \
+	-X main.buildTimeUTC=$(BUILD_TIME_UTC) \
+	-X main.gitCommit=$(GIT_COMMIT) \
+	-X main.gitDirty=$(GIT_DIRTY) \
+	-X main.buildProfile=$(BUILD_PROFILE)
 GOEXE := $(shell go env GOEXE)
 
 .PHONY: build vet fmt test desktop-test desktop-test-short desktop-test-times hooks cross clean

--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -12,9 +12,25 @@ import (
 	_ "reasonix/internal/tool/builtin"
 )
 
-// version is injected at build time via -ldflags "-X main.version=...".
-var version = "dev"
+// Build identity is injected at build time via -ldflags.
+var (
+	version      = "dev"
+	buildNumber  = ""
+	buildTimeUTC = ""
+	gitCommit    = ""
+	gitDirty     = ""
+	buildProfile = ""
+	buildTarget  = ""
+)
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:], version))
+	os.Exit(cli.RunWithBuildInfo(os.Args[1:], cli.BuildInfo{
+		Version:      version,
+		BuildNumber:  buildNumber,
+		BuildTimeUTC: buildTimeUTC,
+		GitCommit:    gitCommit,
+		GitDirty:     gitDirty,
+		BuildProfile: buildProfile,
+		BuildTarget:  buildTarget,
+	}))
 }

--- a/internal/cli/buildinfo.go
+++ b/internal/cli/buildinfo.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"reasonix/internal/config"
+)
+
+// BuildInfo is the human-facing build identity printed by `reasonix --version`.
+// Release builds may only fill Version; source builds can inject the rest with
+// -ldflags so the binary is traceable without invoking git at runtime.
+type BuildInfo struct {
+	Version      string
+	BuildNumber  string
+	BuildTimeUTC string
+	GitCommit    string
+	GitDirty     string
+	BuildProfile string
+	BuildTarget  string
+}
+
+func (b BuildInfo) VersionText() string {
+	b = b.withDefaults()
+	version := strings.TrimSpace(b.Version)
+	lines := []string{"reasonix " + version}
+	appendField := func(k, v string) {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			lines = append(lines, k+": "+v)
+		}
+	}
+	appendField("build_number", b.BuildNumber)
+	appendField("build_time_utc", b.BuildTimeUTC)
+	if cst := buildTimeCST(b.BuildTimeUTC); cst != "" {
+		appendField("build_time_cst", cst)
+	}
+	appendField("git_commit", b.GitCommit)
+	appendField("git_dirty", b.GitDirty)
+	appendField("build_profile", b.BuildProfile)
+	appendField("build_target", b.BuildTarget)
+	appendField("go", fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH))
+	if path, mode := versionConfigSummary(); path != "" {
+		appendField("config_path", path)
+		appendField("config_mode", mode)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (b BuildInfo) withDefaults() BuildInfo {
+	if strings.TrimSpace(b.Version) == "" {
+		b.Version = "dev"
+	}
+	if strings.TrimSpace(b.BuildTarget) == "" {
+		b.BuildTarget = defaultBuildTarget()
+	}
+	if strings.TrimSpace(b.BuildProfile) == "" {
+		b.BuildProfile = "debug"
+	}
+	if strings.TrimSpace(b.GitCommit) == "" || strings.TrimSpace(b.GitDirty) == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					if strings.TrimSpace(b.GitCommit) == "" {
+						b.GitCommit = shortGitRevision(setting.Value)
+					}
+				case "vcs.modified":
+					if strings.TrimSpace(b.GitDirty) == "" {
+						switch setting.Value {
+						case "true":
+							b.GitDirty = "dirty"
+						case "false":
+							b.GitDirty = "clean"
+						}
+					}
+				}
+			}
+		}
+	}
+	if strings.TrimSpace(b.GitCommit) == "" {
+		b.GitCommit = "unknown"
+	}
+	if strings.TrimSpace(b.GitDirty) == "" {
+		b.GitDirty = "unknown"
+	}
+	if strings.TrimSpace(b.BuildTimeUTC) == "" {
+		b.BuildTimeUTC = "unknown"
+	}
+	if strings.TrimSpace(b.BuildNumber) == "" {
+		if number := buildNumberFromUTC(b.BuildTimeUTC); number != "" {
+			b.BuildNumber = number
+		} else {
+			b.BuildNumber = "dev"
+		}
+	}
+	return b
+}
+
+func shortGitRevision(revision string) string {
+	revision = strings.TrimSpace(revision)
+	if len(revision) > 8 {
+		return revision[:8]
+	}
+	return revision
+}
+
+func buildNumberFromUTC(utc string) string {
+	t, err := time.Parse(time.RFC3339, strings.TrimSpace(utc))
+	if err != nil {
+		return ""
+	}
+	return t.UTC().Format("20060102150405")
+}
+
+func buildTimeCST(utc string) string {
+	utc = strings.TrimSpace(utc)
+	if utc == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, utc)
+	if err != nil {
+		return ""
+	}
+	cst := time.FixedZone("CST", 8*60*60)
+	return t.In(cst).Format("2006-01-02 15:04:05 MST")
+}
+
+func defaultBuildTarget() string {
+	switch runtime.GOOS + "/" + runtime.GOARCH {
+	case "darwin/arm64":
+		return "aarch64-apple-darwin"
+	case "darwin/amd64":
+		return "x86_64-apple-darwin"
+	case "linux/arm64":
+		return "aarch64-unknown-linux-gnu"
+	case "linux/amd64":
+		return "x86_64-unknown-linux-gnu"
+	case "windows/amd64":
+		return "x86_64-pc-windows-msvc"
+	case "windows/arm64":
+		return "aarch64-pc-windows-msvc"
+	default:
+		if runtime.GOOS == "" || runtime.GOARCH == "" {
+			return ""
+		}
+		return runtime.GOARCH + "-" + runtime.GOOS
+	}
+}
+
+func versionConfigSummary() (string, string) {
+	if wd, err := os.Getwd(); err == nil {
+		project := filepath.Join(wd, "reasonix.toml")
+		if _, err := os.Stat(project); err == nil {
+			if abs, err := filepath.Abs(project); err == nil {
+				return abs, "project"
+			}
+			return project, "project"
+		}
+	}
+	user := config.UserConfigPath()
+	if user == "" {
+		return "", ""
+	}
+	if _, err := os.Stat(user); err == nil {
+		return user, "user"
+	}
+	return user, "missing"
+}

--- a/internal/cli/buildinfo_test.go
+++ b/internal/cli/buildinfo_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildInfoVersionTextIncludesLocalBuildIdentity(t *testing.T) {
+	isolateCLIConfigHome(t)
+	out := BuildInfo{
+		Version:      "desktop-v1.17.3-4-gabcdef0-dirty",
+		BuildNumber:  "20260706091213",
+		BuildTimeUTC: "2026-07-06T09:12:13Z",
+		GitCommit:    "abcdef0",
+		GitDirty:     "dirty",
+		BuildProfile: "release",
+		BuildTarget:  "aarch64-apple-darwin",
+	}.VersionText()
+
+	for _, want := range []string{
+		"reasonix desktop-v1.17.3-4-gabcdef0-dirty",
+		"build_number: 20260706091213",
+		"build_time_utc: 2026-07-06T09:12:13Z",
+		"build_time_cst: 2026-07-06 17:12:13 CST",
+		"git_commit: abcdef0",
+		"git_dirty: dirty",
+		"build_profile: release",
+		"build_target: aarch64-apple-darwin",
+		"go: go version ",
+		"config_path: ",
+		"config_mode: missing",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("VersionText missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildInfoVersionTextKeepsVersionFirstLine(t *testing.T) {
+	if got := (BuildInfo{Version: "test-version"}).VersionText(); !strings.HasPrefix(got, "reasonix test-version") {
+		t.Fatalf("VersionText = %q", got)
+	}
+}
+
+func TestBuildInfoVersionTextShowsFallbackIdentityForPlainGoBuild(t *testing.T) {
+	isolateCLIConfigHome(t)
+	out := (BuildInfo{Version: "dev"}).VersionText()
+
+	for _, want := range []string{
+		"reasonix dev",
+		"build_number: ",
+		"build_time_utc: ",
+		"git_commit: ",
+		"git_dirty: ",
+		"build_profile: debug",
+		"build_target: ",
+		"go: go version ",
+		"config_path: ",
+		"config_mode: missing",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("VersionText missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildNumberFromUTC(t *testing.T) {
+	if got := buildNumberFromUTC("2026-07-08T04:05:06Z"); got != "20260708040506" {
+		t.Fatalf("buildNumberFromUTC = %q", got)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,6 +47,17 @@ var (
 
 // Run is the CLI entry point; it returns a process exit code.
 func Run(args []string, version string) int {
+	return RunWithBuildInfo(args, BuildInfo{Version: version})
+}
+
+// RunWithBuildInfo is the CLI entry point with full build metadata. Tests and
+// embedders that only have a semantic version can keep using Run.
+func RunWithBuildInfo(args []string, build BuildInfo) int {
+	version := strings.TrimSpace(build.Version)
+	if version == "" {
+		version = "dev"
+	}
+
 	// Pick the UI language up front so even pre-config paths (the first-run
 	// welcome banner) come through localized. Env-only first; if a config
 	// exists and pins a language, that wins.
@@ -140,7 +151,8 @@ func Run(args []string, version string) int {
 		configureCLIThemeFromConfigNoProbe()
 		return upgradeCommand(rest, version)
 	case "version", "--version", "-v":
-		fmt.Println("reasonix", version)
+		build.Version = version
+		fmt.Println(build.VersionText())
 		return 0
 	case "help", "--help", "-h":
 		usage()


### PR DESCRIPTION
## 中文

这个 PR 扩展 `reasonix --version` / `reasonix version` 的输出，让源码构建和本地安装的二进制更容易追踪。

### 改了什么

- 新增 `internal/cli.BuildInfo`，集中渲染版本、构建时间、git 提交、dirty 状态、构建目标、Go 版本和配置路径摘要。
- `cmd/reasonix` 通过 `-ldflags` 接收更完整的构建身份。
- `Makefile` 注入 `build_number`、`build_time_utc`、`git_commit`、`git_dirty`、`build_profile`。
- 保留 `cli.Run(args, version)` 兼容入口，新增 `RunWithBuildInfo` 给主程序使用。

### 为什么

现在 `reasonix --version` 只输出一行版本号。对源码安装、fork 测试、用户反馈和 bug 复现来说，这不够定位当前二进制来自哪次构建。

### 验证

- `go test -count=1 ./internal/cli -run 'TestBuildInfo|TestMetadataCommandsDoNotProbeTerminalTheme'`
- `go test -count=1 ./internal/cli`
- `make build`
- `./bin/reasonix --version`

## English

This PR expands `reasonix --version` / `reasonix version` so source-built and locally installed binaries are easier to identify.

### What changed

- Adds `internal/cli.BuildInfo` to render version, build time, git revision, dirty state, build target, Go version, and config path summary.
- Lets `cmd/reasonix` receive richer build identity through `-ldflags`.
- Updates the `Makefile` to inject `build_number`, `build_time_utc`, `git_commit`, `git_dirty`, and `build_profile`.
- Keeps the existing `cli.Run(args, version)` API, and adds `RunWithBuildInfo` for the main binary.

### Why

The current version output only prints one line. That makes source installs, fork testing, user reports, and bug reproduction harder to trace.

### Validation

- `go test -count=1 ./internal/cli -run 'TestBuildInfo|TestMetadataCommandsDoNotProbeTerminalTheme'`
- `go test -count=1 ./internal/cli`
- `make build`
- `./bin/reasonix --version`
