### PR TITLE
feat(config): add configurable command timeout (command_timeout_seconds)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1376,6 +1376,7 @@ func clonePricing(p *provider.Pricing) *provider.Pricing {
 type ToolsConfig struct {
 	Enabled               []string             `toml:"enabled"`
 	BashTimeoutSeconds    *int                 `toml:"bash_timeout_seconds"`
+	CommandTimeoutSeconds int                  `toml:"command_timeout_seconds"`
 	MCPCallTimeoutSeconds *int                 `toml:"mcp_call_timeout_seconds"`
 	BackgroundJobs        BackgroundJobsConfig `toml:"background_jobs"`
 	Search                SearchConfig         `toml:"search"`
@@ -1384,20 +1385,40 @@ type ToolsConfig struct {
 
 const (
 	defaultBashTimeoutSeconds             = 120
+	defaultCommandTimeoutSeconds          = 120
 	defaultMCPCallTimeoutSeconds          = 300
 	defaultBackgroundJobStalledWarningSec = 900
 	maxBackgroundJobStalledWarningSec     = 86400
 )
 
-// BashTimeoutSeconds returns the foreground bash timeout in seconds. An omitted
-// config keeps the historical 120s safety cap, explicit 0 disables the
-// tool-local cap, and positive values set a custom cap. Negative values fall
-// back to the default so a typo cannot silently remove the safety net.
-func (c *Config) BashTimeoutSeconds() int {
-	if c.Tools.BashTimeoutSeconds == nil || *c.Tools.BashTimeoutSeconds < 0 {
-		return defaultBashTimeoutSeconds
+// CommandTimeoutSeconds returns the configurable foreground command timeout in
+// seconds. A positive value overrides the default safety cap; zero (the unset
+// zero value) and negative values fall back to the default so a typo or an
+// omitted config cannot silently remove the safety net. This is the preferred
+// config key for customizing the bash tool's foreground timeout; the legacy
+// bash_timeout_seconds (*int) still works and additionally supports an explicit
+// 0 to disable the tool-local cap entirely.
+func (c *Config) CommandTimeoutSeconds() int {
+	if c.Tools.CommandTimeoutSeconds <= 0 {
+		return defaultCommandTimeoutSeconds
 	}
-	return *c.Tools.BashTimeoutSeconds
+	return c.Tools.CommandTimeoutSeconds
+}
+
+// BashTimeoutSeconds returns the foreground bash timeout in seconds. The legacy
+// bash_timeout_seconds (*int) takes precedence when explicitly set, preserving
+// its 0 = no-cap semantics for existing configs; otherwise the preferred
+// command_timeout_seconds (int) applies, defaulting to 120s. Negative legacy
+// values fall back to the default so a typo cannot silently remove the safety
+// net.
+func (c *Config) BashTimeoutSeconds() int {
+	if c.Tools.BashTimeoutSeconds != nil {
+		if *c.Tools.BashTimeoutSeconds < 0 {
+			return defaultBashTimeoutSeconds
+		}
+		return *c.Tools.BashTimeoutSeconds
+	}
+	return c.CommandTimeoutSeconds()
 }
 
 // MCPCallTimeoutSeconds returns the default MCP JSON-RPC call timeout in

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -392,7 +392,8 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		}
 		b.WriteString("]\n")
 	}
-	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # foreground safety cap; set 0 for no tool-local cap\n", c.BashTimeoutSeconds())
+	fmt.Fprintf(&b, "command_timeout_seconds = %d   # foreground command timeout in seconds; 0/negative falls back to default\n", c.CommandTimeoutSeconds())
+	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # legacy foreground safety cap; set 0 for no tool-local cap (prefer command_timeout_seconds)\n", c.BashTimeoutSeconds())
 	fmt.Fprintf(&b, "mcp_call_timeout_seconds = %d   # default MCP call safety cap; per-plugin/tool overrides may raise it\n\n", c.MCPCallTimeoutSeconds())
 
 	b.WriteString("[tools.background_jobs]\n")
@@ -991,11 +992,15 @@ func RenderTOMLProjectDelta(c *Config) string {
 
 	// [tools]
 	if len(c.Tools.Enabled) > 0 ||
+		c.Tools.CommandTimeoutSeconds > 0 ||
 		(c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0) ||
 		(c.Tools.MCPCallTimeoutSeconds != nil && *c.Tools.MCPCallTimeoutSeconds > 0) {
 		b.WriteString("[tools]\n")
 		if len(c.Tools.Enabled) > 0 {
 			fmt.Fprintf(&b, "enabled = %s\n", renderStringArray(c.Tools.Enabled))
+		}
+		if c.Tools.CommandTimeoutSeconds > 0 {
+			fmt.Fprintf(&b, "command_timeout_seconds = %d\n", c.Tools.CommandTimeoutSeconds)
 		}
 		if c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0 {
 			fmt.Fprintf(&b, "bash_timeout_seconds = %d\n", *c.Tools.BashTimeoutSeconds)

--- a/internal/config/tools_test.go
+++ b/internal/config/tools_test.go
@@ -122,3 +122,66 @@ func TestBackgroundJobStalledWarningSecondsBounds(t *testing.T) {
 		t.Fatalf("oversized BackgroundJobStalledWarningSeconds() = %d, want 86400", got)
 	}
 }
+
+func TestCommandTimeoutSecondsDefaultsToSafetyCap(t *testing.T) {
+	cfg := Default()
+	if cfg.Tools.CommandTimeoutSeconds != 0 {
+		t.Fatalf("default raw command timeout = %d, want 0 (unset)", cfg.Tools.CommandTimeoutSeconds)
+	}
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 120", got)
+	}
+}
+
+func TestCommandTimeoutSecondsCustomValue(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	if got := cfg.CommandTimeoutSeconds(); got != 600 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 600", got)
+	}
+}
+
+func TestCommandTimeoutSecondsFallsBackForZeroOrNegative(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 0
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("zero CommandTimeoutSeconds() = %d, want 120", got)
+	}
+	cfg.Tools.CommandTimeoutSeconds = -5
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("negative CommandTimeoutSeconds() = %d, want 120", got)
+	}
+}
+
+func TestCommandTimeoutSecondsParsesFromTOML(t *testing.T) {
+	cfg := Default()
+	if _, err := toml.Decode("[tools]\ncommand_timeout_seconds = 300\n", cfg); err != nil {
+		t.Fatalf("decode command timeout: %v", err)
+	}
+	if cfg.Tools.CommandTimeoutSeconds != 300 {
+		t.Fatalf("decoded command_timeout_seconds = %d, want 300", cfg.Tools.CommandTimeoutSeconds)
+	}
+	if got := cfg.CommandTimeoutSeconds(); got != 300 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 300", got)
+	}
+}
+
+func TestBashTimeoutSecondsPrefersLegacyWhenExplicitlySet(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	cfg.Tools.BashTimeoutSeconds = intPtr(30)
+	if got := cfg.BashTimeoutSeconds(); got != 30 {
+		t.Fatalf("legacy bash_timeout should win: BashTimeoutSeconds() = %d, want 30", got)
+	}
+}
+
+func TestBashTimeoutSecondsUsesCommandTimeoutWhenLegacyAbsent(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	if cfg.Tools.BashTimeoutSeconds != nil {
+		t.Fatal("legacy bash_timeout should be nil")
+	}
+	if got := cfg.BashTimeoutSeconds(); got != 600 {
+		t.Fatalf("BashTimeoutSeconds() = %d, want 600 (from command_timeout_seconds)", got)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -115,7 +115,8 @@ enabled = true   # inject a stable startup summary of OS, shell, and common tool
 
 [tools]
 enabled = []   # empty = all built-in tools
-bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+command_timeout_seconds = 120   # foreground command timeout in seconds; 0/negative falls back to default
+bash_timeout_seconds = 120   # legacy foreground safety cap; set 0 for no tool-local cap (prefer command_timeout_seconds)
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
 
 [tools.background_jobs]


### PR DESCRIPTION
## Summary

Fixes #6462 — the bash tool's 2-minute foreground timeout was not easily customizable. Users running long computation tasks (>2 min) hit the safety cap with no way to raise it through config.

## Changes

- **`internal/config/config.go`**: Add `CommandTimeoutSeconds int` field to `ToolsConfig` (TOML tag `command_timeout_seconds`), the `defaultCommandTimeoutSeconds = 120` constant, and the `CommandTimeoutSeconds()` getter (returns 120 for values <= 0, else the configured value). `BashTimeoutSeconds()` now prefers the legacy `bash_timeout_seconds` (*int) when explicitly set (backward compat, preserves 0 = no-cap), and falls back to `CommandTimeoutSeconds()` otherwise.
- **`internal/config/render.go`**: Render `command_timeout_seconds` in both the full template and the diff `[tools]` section for discoverability.
- **`internal/config/tools_test.go`**: Add 6 unit tests covering default value, custom value, zero/negative fallback, TOML parsing, legacy precedence, and command-timeout-when-legacy-absent.
- **`reasonix.example.toml`**: Document the new key alongside the legacy one.

## How it works

The bash tool already receives its timeout as a parameter (`bash.timeout`), wired through `boot.go -> Workspace.BashTimeout -> bash{timeout: ...}`. The composition root calls `cfg.BashTimeoutSeconds()`, which now incorporates `command_timeout_seconds`. No changes were needed in `internal/tool/builtin` — the timeout was never hardcoded in the tool itself; it flows from config through the parameter chain.

## Config precedence

| `bash_timeout_seconds` (*int) | `command_timeout_seconds` (int) | Resolved timeout |
|---|---|---|
| unset (nil) | unset (0) | 120s (default) |
| unset (nil) | 300 | 300s |
| unset (nil) | 0 or -1 | 120s (fallback) |
| 0 (explicit) | * | 0 = no cap (legacy wins) |
| 600 | * | 600s (legacy wins) |
| -1 | * | 120s (legacy negative fallback) |

## Dependency direction

`cli -> config -> tool` is preserved. `internal/config` does not import `internal/tool`; `internal/tool/builtin` does not import `internal/config` (receives timeout as a struct parameter). `internal/boot` is the composition root that wires them.

## Testing

```
go test ./internal/config/ -run "Timeout|CommandTimeout" -v -count=1   # 15 tests PASS
go test ./internal/tool/builtin/ -run "BashTimeout|BashForeground|WorkspacePassesBash" -v  # PASS
gofmt -l internal/config/config.go internal/config/render.go internal/config/tools_test.go  # clean
go vet ./internal/config/  # clean
```

## Cache impact

Cache-impact: low - new optional TOML field with the same default (120s) as the legacy `bash_timeout_seconds`; no behavior change for existing configs (zero-value int field, omit to keep current behavior). No tool schemas, system prompt, memory prefix, output style, or skill index surface changes.
Cache-guard: focused guard tests `go test ./internal/config/ -run "Timeout|CommandTimeout" -v -count=1` (15 tests pass) cover the new getter, zero/negative fallback, TOML parse, and the legacy-precedence resolution. Broader release-level guard covered by existing `scripts/cache-guard.sh` (REASONIX_RELEASE_CACHE_GUARD=1 go test ./internal/agent -run '^TestReleaseCacheHitGuard$'); this PR does not touch agent prompt construction so the release-level guard remains green.
System-prompt-review: `internal/config/config.go` change adds a new optional `command_timeout_seconds` field consumed only by the bash tool at runtime via the `bash.timeout` struct parameter (resolved in `boot.go` and passed through `Workspace.BashTimeout`). The field is never serialized into a provider-visible system prompt, memory prefix, output style, or skill index — no system-prompt cache-key churn. Reviewer note: no approval gates triggered; runtime-only timeout knob.
