### PR TITLE
Show pinned conversations in classic sidebar / 经典侧边栏独立显示置顶会话

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   projectTreeShouldRenderTopicActions,
   projectTreeTopicMetaLine,
   arrangeClassicProjectTree,
+  splitPinnedProjectTree,
   classicTopicWindow,
   projectTreeTopicHoverCardModel,
   projectTreeTopicMenuOffersPin,
@@ -349,6 +350,88 @@ eq(
   ).map((node) => (node.children ?? []).map((child) => child.topicId)),
   [["pinned-old", "recent"]],
   "classic sorting keeps pinned topics above unpinned ones",
+);
+
+const classicPinnedSections = splitPinnedProjectTree(
+  [
+    {
+      key: "project_/repo/a",
+      kind: "project",
+      label: "a",
+      root: "/repo/a",
+      children: [
+        classicTopic("pinned-old", { lastActivityAt: 100, pinned: true }),
+        classicTopic("recent", { lastActivityAt: 900 }),
+      ],
+    },
+    {
+      key: "project_/repo/b",
+      kind: "project",
+      label: "b",
+      root: "/repo/b",
+      pinned: true,
+      children: [classicTopic("pinned-new", { root: "/repo/b", lastActivityAt: 500, pinned: true })],
+    },
+  ],
+  "updated",
+  false,
+);
+
+eq(
+  classicPinnedSections.pinned.map((node) => node.topicId),
+  ["pinned-new", "pinned-old"],
+  "classic pinned section collects topics across projects by activity",
+);
+
+eq(
+  classicPinnedSections.projects.map((node) => ({
+    root: node.root,
+    pinned: Boolean(node.pinned),
+    topics: (node.children ?? []).map((child) => child.topicId),
+  })),
+  [
+    { root: "/repo/a", pinned: false, topics: ["recent"] },
+    { root: "/repo/b", pinned: true, topics: [] },
+  ],
+  "classic pinned topics appear once while pinned projects stay in project order",
+);
+
+eq(
+  splitPinnedProjectTree(
+    [
+      {
+        key: "project_/repo/a",
+        kind: "project",
+        label: "a",
+        root: "/repo/a",
+        children: [classicTopic("unpinned-again", { lastActivityAt: 100 })],
+      },
+    ],
+    "updated",
+    false,
+  ),
+  {
+    pinned: [],
+    projects: [
+      {
+        key: "project_/repo/a",
+        kind: "project",
+        label: "a",
+        root: "/repo/a",
+        children: [classicTopic("unpinned-again", { lastActivityAt: 100 })],
+      },
+    ],
+  },
+  "unpinning returns a topic to its original project",
+);
+
+eq(
+  splitPinnedProjectTree(
+    [{ key: "project_/repo/a", kind: "project", label: "a", root: "/repo/a", pinned: true, children: [] }],
+    "updated",
+  ).pinned.map((node) => node.root),
+  ["/repo/a"],
+  "workbench pinned section still extracts pinned projects",
 );
 
 console.log("\nclassic topic window and hover card");

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -300,7 +300,7 @@ type CollapseSnapshot = {
   manuallyCollapsed: Set<string>;
 };
 
-type WorkbenchTreeSections = {
+type PinnedTreeSections = {
   pinned: ProjectNode[];
   projects: ProjectNode[];
 };
@@ -485,7 +485,11 @@ export function classicTopicWindow(children: ProjectNode[], showAll: boolean): {
   };
 }
 
-function splitWorkbenchPinnedTree(nodes: ProjectNode[], sortMode: WorkbenchSortMode): WorkbenchTreeSections {
+export function splitPinnedProjectTree(
+  nodes: ProjectNode[],
+  sortMode: WorkbenchSortMode,
+  includePinnedProjects = true,
+): PinnedTreeSections {
   const pinnedTopics: ProjectNode[] = [];
   const pinnedProjects: ProjectNode[] = [];
   const projects: ProjectNode[] = [];
@@ -499,7 +503,7 @@ function splitWorkbenchPinnedTree(nodes: ProjectNode[], sortMode: WorkbenchSortM
       continue;
     }
 
-    if (node.pinned && node.kind === "project") {
+    if (includePinnedProjects && node.pinned && node.kind === "project") {
       pinnedProjects.push(node);
       continue;
     }
@@ -1146,10 +1150,10 @@ export function ProjectTree({
     return arrangeClassicProjectTree(filtered, workbenchSortMode);
   }, [compactTopics, creationTopics, query, tree, timeFilter, workbenchOrganizeMode, workbenchSortMode]);
 
-  const workbenchTreeSections = useMemo<WorkbenchTreeSections>(() => {
-    if (!compactTopics) return { pinned: [], projects: visibleTree };
-    return splitWorkbenchPinnedTree(visibleTree, workbenchSortMode);
-  }, [compactTopics, visibleTree, workbenchSortMode]);
+  const pinnedTreeSections = useMemo<PinnedTreeSections>(() => {
+    if (creationTopics) return { pinned: [], projects: visibleTree };
+    return splitPinnedProjectTree(visibleTree, workbenchSortMode, compactTopics);
+  }, [compactTopics, creationTopics, visibleTree, workbenchSortMode]);
 
   const classicTopics = !compactTopics && !creationTopics;
   const classicTruncationActive = classicTopics && query.trim() === "" && timeFilter === "all";
@@ -2255,7 +2259,7 @@ export function ProjectTree({
     );
   };
 
-  const hasWorkbenchRows = workbenchTreeSections.pinned.length > 0 || workbenchTreeSections.projects.length > 0;
+  const hasTreeRows = pinnedTreeSections.pinned.length > 0 || pinnedTreeSections.projects.length > 0;
 
   // Report visible topics to parent after render so shortcuts match sidebar order.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -2284,18 +2288,18 @@ export function ProjectTree({
         <>
           {renderProjectHeader("workbench")}
           <div className="project-tree__list project-tree__list--workbench">
-            {!hasWorkbenchRows ? (
+            {!hasTreeRows ? (
               renderEmptyState()
             ) : (
               <>
-                {workbenchTreeSections.pinned.length > 0 && (
+                {pinnedTreeSections.pinned.length > 0 && (
                   <div className="project-tree__section project-tree__section--pinned">
                     <div className="project-tree__section-title">{t("projectTree.pinnedTitle")}</div>
-                    {workbenchTreeSections.pinned.map((node) => renderNode(node, 0, "pinned"))}
+                    {pinnedTreeSections.pinned.map((node) => renderNode(node, 0, "pinned"))}
                   </div>
                 )}
                 <div className="project-tree__section project-tree__section--projects">
-                  {workbenchTreeSections.projects.map((node) => renderNode(node, 0, "projects"))}
+                  {pinnedTreeSections.projects.map((node) => renderNode(node, 0, "projects"))}
                 </div>
               </>
             )}
@@ -2305,7 +2309,21 @@ export function ProjectTree({
         <>
           {renderProjectHeader("classic")}
           <div className="project-tree__list" onScroll={cancelHoverCard}>
-            {visibleTree.length === 0 ? renderEmptyState() : visibleTree.map((node) => renderNode(node, 0))}
+            {!hasTreeRows ? (
+              renderEmptyState()
+            ) : (
+              <>
+                {pinnedTreeSections.pinned.length > 0 && (
+                  <div className="project-tree__section project-tree__section--pinned">
+                    <div className="project-tree__section-title">{t("projectTree.pinnedTitle")}</div>
+                    {pinnedTreeSections.pinned.map((node) => renderNode(node, 1, "pinned"))}
+                  </div>
+                )}
+                <div className="project-tree__section project-tree__section--projects">
+                  {pinnedTreeSections.projects.map((node) => renderNode(node, 0, "projects"))}
+                </div>
+              </>
+            )}
           </div>
         </>
       )}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -21356,6 +21356,27 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
+.app--classic .project-tree__section {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.app--classic .project-tree__section--pinned {
+  margin-bottom: 12px;
+}
+
+.app--classic .project-tree__section-title {
+  min-height: 26px;
+  padding: 6px 8px 2px;
+  color: var(--fg-faint);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
 .project-tree__folder {
   position: relative;
   height: 34px;


### PR DESCRIPTION
## Summary

- add a dedicated pinned section to the classic desktop sidebar
- remove pinned conversations from their project rows while they are pinned, avoiding duplicate entries
- return conversations to their original project order after unpinning
- preserve the existing classic row density, activity time, hover actions, active state, and project ordering

## Root cause

The classic layout only sorted pinned conversations before unpinned siblings inside each project. The shared pinned-section splitter and section markup were gated to the workbench layout, so pinning changed the button state without creating a visible top-level group.

## User impact

Classic-layout users now get the same clear pinned hierarchy as workbench users while retaining classic styling. Archive, History, Trash, restore, and persisted pin metadata behavior are unchanged.

## Compatibility

| Surface | Existing data behavior | Conclusion |
| --- | --- | --- |
| Topic pin metadata | Reads the existing `pinned` field from project-tree nodes | Compatible |
| Project and topic persistence | No format or write-path changes | Compatible |
| History and Trash | Existing APIs and session records are untouched | Compatible |
| Workbench and Creation layouts | Workbench keeps pinned projects and topics; Creation remains unsplit | Compatible |

## Verification

- `tsx src/__tests__/project-tree-runtime.test.ts` (44 passed)
- `tsc --noEmit`
- `tsc --noEmit -p tsconfig.test.json`
- CSS syntax and z-index token checks
- browser DOM/click verification for pin, deduplication, unpin restore, project order, classic row geometry, and zero console warnings/errors
- `git diff --check`
