### PR TITLE
feat(config): add configurable command timeout (command_timeout_seconds)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1376,6 +1376,7 @@ func clonePricing(p *provider.Pricing) *provider.Pricing {
 type ToolsConfig struct {
 	Enabled               []string             `toml:"enabled"`
 	BashTimeoutSeconds    *int                 `toml:"bash_timeout_seconds"`
+	CommandTimeoutSeconds int                  `toml:"command_timeout_seconds"`
 	MCPCallTimeoutSeconds *int                 `toml:"mcp_call_timeout_seconds"`
 	BackgroundJobs        BackgroundJobsConfig `toml:"background_jobs"`
 	Search                SearchConfig         `toml:"search"`
@@ -1384,20 +1385,40 @@ type ToolsConfig struct {
 
 const (
 	defaultBashTimeoutSeconds             = 120
+	defaultCommandTimeoutSeconds          = 120
 	defaultMCPCallTimeoutSeconds          = 300
 	defaultBackgroundJobStalledWarningSec = 900
 	maxBackgroundJobStalledWarningSec     = 86400
 )
 
-// BashTimeoutSeconds returns the foreground bash timeout in seconds. An omitted
-// config keeps the historical 120s safety cap, explicit 0 disables the
-// tool-local cap, and positive values set a custom cap. Negative values fall
-// back to the default so a typo cannot silently remove the safety net.
-func (c *Config) BashTimeoutSeconds() int {
-	if c.Tools.BashTimeoutSeconds == nil || *c.Tools.BashTimeoutSeconds < 0 {
-		return defaultBashTimeoutSeconds
+// CommandTimeoutSeconds returns the configurable foreground command timeout in
+// seconds. A positive value overrides the default safety cap; zero (the unset
+// zero value) and negative values fall back to the default so a typo or an
+// omitted config cannot silently remove the safety net. This is the preferred
+// config key for customizing the bash tool's foreground timeout; the legacy
+// bash_timeout_seconds (*int) still works and additionally supports an explicit
+// 0 to disable the tool-local cap entirely.
+func (c *Config) CommandTimeoutSeconds() int {
+	if c.Tools.CommandTimeoutSeconds <= 0 {
+		return defaultCommandTimeoutSeconds
 	}
-	return *c.Tools.BashTimeoutSeconds
+	return c.Tools.CommandTimeoutSeconds
+}
+
+// BashTimeoutSeconds returns the foreground bash timeout in seconds. The legacy
+// bash_timeout_seconds (*int) takes precedence when explicitly set, preserving
+// its 0 = no-cap semantics for existing configs; otherwise the preferred
+// command_timeout_seconds (int) applies, defaulting to 120s. Negative legacy
+// values fall back to the default so a typo cannot silently remove the safety
+// net.
+func (c *Config) BashTimeoutSeconds() int {
+	if c.Tools.BashTimeoutSeconds != nil {
+		if *c.Tools.BashTimeoutSeconds < 0 {
+			return defaultBashTimeoutSeconds
+		}
+		return *c.Tools.BashTimeoutSeconds
+	}
+	return c.CommandTimeoutSeconds()
 }
 
 // MCPCallTimeoutSeconds returns the default MCP JSON-RPC call timeout in

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -392,7 +392,8 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		}
 		b.WriteString("]\n")
 	}
-	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # foreground safety cap; set 0 for no tool-local cap\n", c.BashTimeoutSeconds())
+	fmt.Fprintf(&b, "command_timeout_seconds = %d   # foreground command timeout in seconds; 0/negative falls back to default\n", c.CommandTimeoutSeconds())
+	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # legacy foreground safety cap; set 0 for no tool-local cap (prefer command_timeout_seconds)\n", c.BashTimeoutSeconds())
 	fmt.Fprintf(&b, "mcp_call_timeout_seconds = %d   # default MCP call safety cap; per-plugin/tool overrides may raise it\n\n", c.MCPCallTimeoutSeconds())
 
 	b.WriteString("[tools.background_jobs]\n")
@@ -991,11 +992,15 @@ func RenderTOMLProjectDelta(c *Config) string {
 
 	// [tools]
 	if len(c.Tools.Enabled) > 0 ||
+		c.Tools.CommandTimeoutSeconds > 0 ||
 		(c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0) ||
 		(c.Tools.MCPCallTimeoutSeconds != nil && *c.Tools.MCPCallTimeoutSeconds > 0) {
 		b.WriteString("[tools]\n")
 		if len(c.Tools.Enabled) > 0 {
 			fmt.Fprintf(&b, "enabled = %s\n", renderStringArray(c.Tools.Enabled))
+		}
+		if c.Tools.CommandTimeoutSeconds > 0 {
+			fmt.Fprintf(&b, "command_timeout_seconds = %d\n", c.Tools.CommandTimeoutSeconds)
 		}
 		if c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0 {
 			fmt.Fprintf(&b, "bash_timeout_seconds = %d\n", *c.Tools.BashTimeoutSeconds)

--- a/internal/config/tools_test.go
+++ b/internal/config/tools_test.go
@@ -122,3 +122,66 @@ func TestBackgroundJobStalledWarningSecondsBounds(t *testing.T) {
 		t.Fatalf("oversized BackgroundJobStalledWarningSeconds() = %d, want 86400", got)
 	}
 }
+
+func TestCommandTimeoutSecondsDefaultsToSafetyCap(t *testing.T) {
+	cfg := Default()
+	if cfg.Tools.CommandTimeoutSeconds != 0 {
+		t.Fatalf("default raw command timeout = %d, want 0 (unset)", cfg.Tools.CommandTimeoutSeconds)
+	}
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 120", got)
+	}
+}
+
+func TestCommandTimeoutSecondsCustomValue(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	if got := cfg.CommandTimeoutSeconds(); got != 600 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 600", got)
+	}
+}
+
+func TestCommandTimeoutSecondsFallsBackForZeroOrNegative(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 0
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("zero CommandTimeoutSeconds() = %d, want 120", got)
+	}
+	cfg.Tools.CommandTimeoutSeconds = -5
+	if got := cfg.CommandTimeoutSeconds(); got != 120 {
+		t.Fatalf("negative CommandTimeoutSeconds() = %d, want 120", got)
+	}
+}
+
+func TestCommandTimeoutSecondsParsesFromTOML(t *testing.T) {
+	cfg := Default()
+	if _, err := toml.Decode("[tools]\ncommand_timeout_seconds = 300\n", cfg); err != nil {
+		t.Fatalf("decode command timeout: %v", err)
+	}
+	if cfg.Tools.CommandTimeoutSeconds != 300 {
+		t.Fatalf("decoded command_timeout_seconds = %d, want 300", cfg.Tools.CommandTimeoutSeconds)
+	}
+	if got := cfg.CommandTimeoutSeconds(); got != 300 {
+		t.Fatalf("CommandTimeoutSeconds() = %d, want 300", got)
+	}
+}
+
+func TestBashTimeoutSecondsPrefersLegacyWhenExplicitlySet(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	cfg.Tools.BashTimeoutSeconds = intPtr(30)
+	if got := cfg.BashTimeoutSeconds(); got != 30 {
+		t.Fatalf("legacy bash_timeout should win: BashTimeoutSeconds() = %d, want 30", got)
+	}
+}
+
+func TestBashTimeoutSecondsUsesCommandTimeoutWhenLegacyAbsent(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CommandTimeoutSeconds = 600
+	if cfg.Tools.BashTimeoutSeconds != nil {
+		t.Fatal("legacy bash_timeout should be nil")
+	}
+	if got := cfg.BashTimeoutSeconds(); got != 600 {
+		t.Fatalf("BashTimeoutSeconds() = %d, want 600 (from command_timeout_seconds)", got)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -115,7 +115,8 @@ enabled = true   # inject a stable startup summary of OS, shell, and common tool
 
 [tools]
 enabled = []   # empty = all built-in tools
-bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+command_timeout_seconds = 120   # foreground command timeout in seconds; 0/negative falls back to default
+bash_timeout_seconds = 120   # legacy foreground safety cap; set 0 for no tool-local cap (prefer command_timeout_seconds)
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
 
 [tools.background_jobs]


### PR DESCRIPTION
## 概述

修复 #6462 —— bash 工具的 2 分钟前台超时无法通过配置自定义。运行长计算任务（>2 分钟）的用户会命中安全上限，且无法通过配置调高，导致任务频繁超时失败并反复重试。

## 改动内容

- **`internal/config/config.go`**：在 `ToolsConfig` 中新增 `CommandTimeoutSeconds int` 字段（TOML 标签 `command_timeout_seconds`），新增 `defaultCommandTimeoutSeconds = 120` 常量和 `CommandTimeoutSeconds()` getter（值 ≤ 0 时返回 120，否则返回配置值）。`BashTimeoutSeconds()` 的解析逻辑调整为：legacy `bash_timeout_seconds`（`*int`）显式设置时优先（向后兼容，保留 0 = 无上限语义），否则回退到 `CommandTimeoutSeconds()`。
- **`internal/config/render.go`**：在完整模板和 diff `[tools]` 段落中渲染 `command_timeout_seconds`，提升可发现性。
- **`internal/config/tools_test.go`**：新增 6 个单元测试，覆盖默认值、自定义值、零/负值回退、TOML 解析、legacy 优先级、legacy 缺失时使用 command_timeout 的场景。
- **`reasonix.example.toml`**：在 legacy 字段旁文档化新配置项。

## 实现原理

bash 工具已通过参数（`bash.timeout`）接收超时值，接线链为 `boot.go -> Workspace.BashTimeout -> bash{timeout: ...}`。组合根调用 `cfg.BashTimeoutSeconds()`，该方法现已整合 `command_timeout_seconds`。`internal/tool/builtin` 无需改动——超时从未在工具内硬编码，而是通过参数链从配置传递。

## 配置优先级

| `bash_timeout_seconds` (*int) | `command_timeout_seconds` (int) | 解析结果 |
|---|---|---|
| 未设置 (nil) | 未设置 (0) | 120s（默认） |
| 未设置 (nil) | 300 | 300s |
| 未设置 (nil) | 0 或 -1 | 120s（回退） |
| 0（显式设置） | * | 0 = 无上限（legacy 优先） |
| 600 | * | 600s（legacy 优先） |
| -1 | * | 120s（legacy 负值回退） |

## 依赖方向

`cli -> config -> tool` 保持正确。`internal/config` 不导入 `internal/tool`；`internal/tool/builtin` 不导入 `internal/config`（通过结构体参数接收超时）。`internal/boot` 是组合根，负责将两者接线。

## 验证

```
go test ./internal/config/ -run "Timeout|CommandTimeout" -v -count=1   # 15 个测试通过
go test ./internal/tool/builtin/ -run "BashTimeout|BashForeground|WorkspacePassesBash" -v  # 通过
gofmt -l internal/config/config.go internal/config/render.go internal/config/tools_test.go  # 干净
go vet ./internal/config/  # 无问题
golangci-lint run ./internal/config/... ./internal/boot/... ./internal/tool/builtin/...  # 0 issues
```

Fork 仓库 CI 全绿（CI / CodeQL / Cache impact guard / Auto-label PRs 均通过）。

## Cache impact

Cache-impact: low - 新增可选 TOML 字段，默认值（120s）与 legacy bash_timeout_seconds 相同；现有配置不设置该字段时行为完全一致（int 零值，省略即保持当前行为）。不涉及工具 schema、系统提示词、记忆前缀、输出风格或技能索引的变更。
Cache-guard: 聚焦测试 `go test ./internal/config/ -run "Timeout|CommandTimeout" -v -count=1`（15 个测试通过）覆盖了新 getter、零/负值回退、TOML 解析和 legacy 优先级解析。更广泛的 release 级 guard 由现有 `scripts/cache-guard.sh` 覆盖（REASONIX_RELEASE_CACHE_GUARD=1 go test ./internal/agent -run '^TestReleaseCacheHitGuard$'）；本 PR 不触及 agent 提示词构建，release 级 guard 保持绿色。
System-prompt-review: `internal/config/config.go` 的改动仅新增一个可选 `command_timeout_seconds` 字段，该字段仅被 bash 工具在运行时通过 `bash.timeout` 结构体参数消费（在 `boot.go` 中解析并通过 `Workspace.BashTimeout` 传递）。该字段不会被序列化到 provider 可见的系统提示词、记忆前缀、输出风格或技能索引中——不产生系统提示词缓存键变更。审查备注：无审批门控触发；仅为运行时超时旋钮。
