### PR TITLE
fix(config): fail before overwriting invalid config / 避免坏配置被默认配置覆盖

### DIFF
--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -151,7 +152,7 @@ func TestNormalizeLegacyStepFunBaseURLsMigratesPresetProviders(t *testing.T) {
 	}
 }
 
-func TestLoadForEditPersistsLegacyStepFunBaseURLMigration(t *testing.T) {
+func TestLoadForEditNormalizesLegacyStepFunBaseURLMigrationWithoutWriting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	cfg := Default()
 	stepfun, ok := CuratedProviderPreset("stepfun")
@@ -171,6 +172,10 @@ func TestLoadForEditPersistsLegacyStepFunBaseURLMigration(t *testing.T) {
 	if err := cfg.SaveTo(path); err != nil {
 		t.Fatalf("SaveTo: %v", err)
 	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	loaded := LoadForEdit(path)
 	if got, _ := loaded.Provider("stepfun"); got == nil || got.BaseURL != officialStepFunOpenAIBaseURL {
@@ -178,6 +183,16 @@ func TestLoadForEditPersistsLegacyStepFunBaseURLMigration(t *testing.T) {
 	}
 	if got, _ := loaded.Provider("stepfun-anthropic"); got == nil || got.BaseURL != officialStepFunAnthropicBaseURL {
 		t.Fatalf("loaded stepfun-anthropic = %+v, want official base URL", got)
+	}
+	afterLoad, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterLoad) != string(original) {
+		t.Fatalf("LoadForEdit should not rewrite legacy config:\n%s", afterLoad)
+	}
+	if err := loaded.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
 	}
 
 	var disk Config

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -838,8 +838,15 @@ func (c *Config) TrustPluginReadOnlyTool(name, toolName string) (PluginEntry, bo
 // user config. Source priority mirrors Load(): project TOML, user TOML, then the
 // project .mcp.json entry if TOML did not define that server.
 func ClearPluginAuthenticationInSource(name string) (PluginEntry, bool, string, error) {
-	if path := pluginTOMLSourcePath(name); path != "" {
-		cfg := LoadForEdit(path)
+	path, err := pluginTOMLSourcePath(name)
+	if err != nil {
+		return PluginEntry{}, false, "", err
+	}
+	if path != "" {
+		cfg, err := LoadForEditStrict(path)
+		if err != nil {
+			return PluginEntry{}, false, path, err
+		}
 		updated, changed, err := cfg.ClearPluginAuthentication(name)
 		if err != nil {
 			return PluginEntry{}, false, path, err
@@ -858,7 +865,7 @@ func ClearPluginAuthenticationInSource(name string) (PluginEntry, bool, string, 
 	return updated, changed, mcpJSONFile, nil
 }
 
-func pluginTOMLSourcePath(name string) string {
+func pluginTOMLSourcePath(name string) (string, error) {
 	return pluginTOMLSourcePathForRoot(".", name)
 }
 
@@ -1103,8 +1110,15 @@ func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
 // into the file that owns the server for root. TOML declarations win over
 // .mcp.json, matching LoadForRoot merge precedence.
 func TrustPluginReadOnlyToolInSourceForRoot(root, name, toolName string) (PluginEntry, bool, string, error) {
-	if path := pluginTOMLSourcePathForRoot(root, name); path != "" {
-		cfg := LoadForEdit(path)
+	path, err := pluginTOMLSourcePathForRoot(root, name)
+	if err != nil {
+		return PluginEntry{}, false, "", err
+	}
+	if path != "" {
+		cfg, err := LoadForEditStrict(path)
+		if err != nil {
+			return PluginEntry{}, false, path, err
+		}
 		updated, changed, err := cfg.TrustPluginReadOnlyTool(name, toolName)
 		if err != nil {
 			return PluginEntry{}, false, path, err
@@ -1131,7 +1145,7 @@ func TrustPluginReadOnlyToolInSource(name, toolName string) (PluginEntry, bool, 
 	return TrustPluginReadOnlyToolInSourceForRoot(".", name, toolName)
 }
 
-func pluginTOMLSourcePathForRoot(root, name string) string {
+func pluginTOMLSourcePathForRoot(root, name string) (string, error) {
 	projectTOML := "reasonix.toml"
 	if resolved := resolveRoot(root); resolved != "." {
 		projectTOML = filepath.Join(resolved, "reasonix.toml")
@@ -1141,14 +1155,17 @@ func pluginTOMLSourcePathForRoot(root, name string) string {
 		if strings.TrimSpace(path) == "" {
 			continue
 		}
-		cfg := LoadForEdit(path)
+		cfg, err := LoadForEditStrict(path)
+		if err != nil {
+			return "", err
+		}
 		for _, p := range cfg.Plugins {
 			if p.Name == name {
-				return path
+				return path, nil
 			}
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // validatePlugin checks a plugin entry by transport. An empty Type means stdio.
@@ -1738,7 +1755,10 @@ func (c *Config) SaveForRoot(root string) error {
 		projectTOML = filepath.Join(root, "reasonix.toml")
 	}
 	if _, err := os.Stat(projectTOML); err == nil {
-		projectCfg := LoadForEditWithoutCredentials(projectTOML)
+		projectCfg, err := LoadForEditWithoutCredentialsStrict(projectTOML)
+		if err != nil {
+			return err
+		}
 		return projectCfg.SaveTo(projectTOML)
 	}
 	if uc := userConfigPath(); uc != "" {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -27,15 +27,15 @@ func Load() (*Config, error) {
 // each project's reasonix.toml + .mcp.json are resolved independently without
 // changing the process cwd, while provider keys stay rooted in Reasonix home.
 //
-// Legacy MCP `tier` lines are normalized in memory. Loading never rewrites
-// config files; explicit Save/SaveTo calls are the only persistence boundary.
+// Legacy MCP `tier` lines are normalized in memory. Normal runtime loading also
+// removes those retired keys on disk, but only after the TOML parsed
+// successfully; edit/read-only paths never rewrite a failed or inspected file.
 func LoadForRoot(root string) (*Config, error) {
 	return loadForRoot(root, true)
 }
 
-// LoadForRootReadOnly is like LoadForRoot but never writes config files: it skips
-// on-disk legacy MCP tier migration. Prefer this for diagnostics, doctor, and
-// other read-only inspection paths.
+// LoadForRootReadOnly is like LoadForRoot but skips runtime-only on-disk
+// cleanup. Prefer this for diagnostics, doctor, and other inspection paths.
 func LoadForRootReadOnly(root string) (*Config, error) {
 	return loadForRoot(root, false)
 }
@@ -640,7 +640,13 @@ func mergeFile(cfg *Config, path string) error {
 }
 
 func mergeRuntimeTOMLFile(cfg *Config, path string) error {
-	return mergeFile(cfg, path)
+	if err := mergeFile(cfg, path); err != nil {
+		return err
+	}
+	if err := migrateLegacyMCPTiersFile(path); err != nil {
+		return fmt.Errorf("migrate legacy MCP tiers in %s: %w", path, err)
+	}
+	return nil
 }
 
 // normalizeLegacyMCPTiers keeps loaded legacy config files on the new product
@@ -752,6 +758,9 @@ func stripLegacyAgentStepLimitLines(raw string) (string, bool) {
 func migrateLegacyMCPTiersFile(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	raw, err := fileencoding.ReadFileUTF8(path)
@@ -762,7 +771,7 @@ func migrateLegacyMCPTiersFile(path string) error {
 	if !changed {
 		return nil
 	}
-	return os.WriteFile(path, []byte(next), info.Mode().Perm())
+	return fileutil.AtomicWriteFile(path, []byte(next), info.Mode().Perm())
 }
 
 func stripLegacyMCPTierLines(raw string) (string, bool) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -28,9 +27,8 @@ func Load() (*Config, error) {
 // each project's reasonix.toml + .mcp.json are resolved independently without
 // changing the process cwd, while provider keys stay rooted in Reasonix home.
 //
-// Note: LoadForRoot may rewrite legacy MCP `tier` lines on disk (see
-// mergeRuntimeTOMLFile). Callers that must not mutate config files should use
-// LoadForRootReadOnly instead.
+// Legacy MCP `tier` lines are normalized in memory. Loading never rewrites
+// config files; explicit Save/SaveTo calls are the only persistence boundary.
 func LoadForRoot(root string) (*Config, error) {
 	return loadForRoot(root, true)
 }
@@ -544,14 +542,18 @@ func DesktopProviderAccessDeclared(path string) (bool, error) {
 // of resetting to defaults. Reasonix's global .env is loaded so api_key_env
 // resolution works while the wizard decides which keys are still missing.
 func LoadForEdit(path string) *Config {
-	return loadForEdit(path, true, true)
+	cfg, err := LoadForEditStrict(path)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
 }
 
 // LoadForEditReadOnlyStrict is the error-returning commit-time variant. It must
 // not fall back to defaults when another writer leaves malformed TOML, because
 // saving that fallback would overwrite the user's recoverable file.
 func LoadForEditReadOnlyStrict(path string) (*Config, error) {
-	return loadForEditStrict(path, true, false)
+	return LoadForEditStrict(path)
 }
 
 // ValidateFile parses one TOML config in isolation without loading credentials,
@@ -574,47 +576,31 @@ func ValidateFile(path string) error {
 	return nil
 }
 
-func loadForEdit(path string, loadCredentials, persistMigrations bool) *Config {
-	cfg, err := loadForEditStrict(path, loadCredentials, persistMigrations)
-	if err == nil {
-		return cfg
-	}
-	slog.Warn("config: load for edit failed, using defaults", "path", path, "err", err)
-	if loadCredentials {
-		loadDotEnvForEditPath(path)
-	}
-	cfg = Default()
-	normalizeConfigForEdit(cfg)
-	return cfg
+func LoadForEditStrict(path string) (*Config, error) {
+	return loadForEditStrict(path, true)
 }
 
 func LoadForEditWithoutCredentials(path string) *Config {
-	return loadForEdit(path, false, true)
+	cfg, err := LoadForEditWithoutCredentialsStrict(path)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
 }
 
-func loadForEditStrict(path string, loadCredentials, persistMigrations bool) (*Config, error) {
+func LoadForEditWithoutCredentialsStrict(path string) (*Config, error) {
+	return loadForEditStrict(path, false)
+}
+
+func loadForEditStrict(path string, loadCredentials bool) (*Config, error) {
 	if loadCredentials {
 		loadDotEnvForEditPath(path)
 	}
 	cfg := Default()
-	if persistMigrations {
-		if _, err := os.Stat(path); err == nil {
-			if err := migrateLegacyMCPTiersFile(path); err != nil {
-				return nil, fmt.Errorf("config %s: %w", path, err)
-			}
-		}
-	}
 	if err := mergeFile(cfg, path); err != nil {
 		return nil, err
 	}
-	changed := normalizeConfigForEdit(cfg)
-	if persistMigrations && changed && strings.TrimSpace(path) != "" {
-		if _, err := os.Stat(path); err == nil {
-			if err := cfg.SaveTo(path); err != nil {
-				return nil, err
-			}
-		}
-	}
+	normalizeConfigForEdit(cfg)
 	return cfg, nil
 }
 
@@ -654,11 +640,6 @@ func mergeFile(cfg *Config, path string) error {
 }
 
 func mergeRuntimeTOMLFile(cfg *Config, path string) error {
-	if _, err := os.Stat(path); err == nil {
-		if err := migrateLegacyMCPTiersFile(path); err != nil {
-			slog.Warn("config: legacy mcp tier migration failed", "path", path, "err", err)
-		}
-	}
 	return mergeFile(cfg, path)
 }
 

--- a/internal/config/loadedit_test.go
+++ b/internal/config/loadedit_test.go
@@ -40,6 +40,27 @@ api_key_env = "X_KEY"
 	}
 }
 
+func TestLoadForEditRefusesInvalidExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	body := []byte("default_model = [\n")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadForEditStrict(path); err == nil {
+		t.Fatal("LoadForEditStrict should reject malformed TOML")
+	} else if !strings.Contains(err.Error(), path) {
+		t.Fatalf("error %q should include config path %q", err, path)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(body) {
+		t.Fatalf("failed load changed config on disk:\n%s", after)
+	}
+}
+
 func TestLoadForEditDecodesGB18030TOML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -65,7 +86,7 @@ api_key_env = "LOCAL_KEY"
 	}
 }
 
-func TestLoadForEditMigratesLegacyMCPTiers(t *testing.T) {
+func TestLoadForEditNormalizesLegacyMCPTiersWithoutWriting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "reasonix.toml")
 	body := `
@@ -88,15 +109,32 @@ model = "m"
 	if len(cfg.Plugins) != 1 || cfg.Plugins[0].Tier != "" {
 		t.Fatalf("plugins after migration = %+v, want empty tier", cfg.Plugins)
 	}
+	afterLoad, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterLoad) != body {
+		t.Fatalf("LoadForEdit should not change config on disk:\n%s", afterLoad)
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
 	updated, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(string(updated), "\ntier") {
-		t.Fatalf("legacy tier lines should be removed from file:\n%s", updated)
+		t.Fatalf("explicit save should remove legacy tier lines from file:\n%s", updated)
 	}
-	if !strings.Contains(string(updated), `command = "npx"`) || !strings.Contains(string(updated), `name = "local"`) {
-		t.Fatalf("migration should preserve ordinary config:\n%s", updated)
+	persisted, err := LoadForEditStrict(path)
+	if err != nil {
+		t.Fatalf("reload after SaveTo: %v", err)
+	}
+	if len(persisted.Plugins) != 1 || persisted.Plugins[0].Command != "npx" {
+		t.Fatalf("explicit save should preserve plugin config: %+v", persisted.Plugins)
+	}
+	if got, ok := persisted.Provider("local"); !ok || got.BaseURL != "https://x" || got.Model != "m" {
+		t.Fatalf("explicit save should preserve provider config: %+v", got)
 	}
 }
 

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -214,7 +214,7 @@ func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, e
 	if dest == "" {
 		return nil, nil
 	}
-	userCfg, err := loadForEditStrict(dest, true, true)
+	userCfg, err := LoadForEditStrict(dest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/installsource/apply.go
+++ b/internal/installsource/apply.go
@@ -58,7 +58,10 @@ func (t *installSourceTool) apply(ctx context.Context, req request, act *action)
 // applySkillRoot appends the path to the active config's [skills].paths and
 // re-builds the Store to confirm the listed skills are discoverable.
 func (t *installSourceTool) applySkillRoot(req request, act *action) error {
-	cfg := config.LoadForEdit(act.ConfigPath)
+	cfg, err := config.LoadForEditStrict(act.ConfigPath)
+	if err != nil {
+		return err
+	}
 	if err := cfg.AddSkillPath(act.Source); err != nil {
 		return err
 	}
@@ -205,7 +208,10 @@ func (t *installSourceTool) applyInstallMCP(ctx context.Context, req request, ac
 	if act.entry.Name == "" {
 		return newErr(ErrInvalidManifest, "MCP action has no server entry")
 	}
-	cfg := config.LoadForEdit(act.ConfigPath)
+	cfg, err := config.LoadForEditStrict(act.ConfigPath)
+	if err != nil {
+		return err
+	}
 	var previous config.PluginEntry
 	hadPrevious := false
 	for _, existing := range cfg.Plugins {
@@ -303,7 +309,10 @@ func (t *installSourceTool) applyRemoveSkillRoot(_ request, act *action) error {
 	if target == "" {
 		return newErr(ErrInvalidManifest, "remove_skill_root action is missing target")
 	}
-	cfg := config.LoadForEdit(act.ConfigPath)
+	cfg, err := config.LoadForEditStrict(act.ConfigPath)
+	if err != nil {
+		return err
+	}
 	removed, err := cfg.RemoveSkillPath(target)
 	if err != nil {
 		return err
@@ -320,7 +329,10 @@ func (t *installSourceTool) applyRemoveSkillRoot(_ request, act *action) error {
 // applyRemoveMCP removes an MCP server entry from the active config and
 // asks the host to disconnect it (if a connector is wired).
 func (t *installSourceTool) applyRemoveMCP(_ request, act *action) error {
-	cfg := config.LoadForEdit(act.ConfigPath)
+	cfg, err := config.LoadForEditStrict(act.ConfigPath)
+	if err != nil {
+		return err
+	}
 	if !cfg.RemovePlugin(act.Name) {
 		// Nothing to remove is not a failure: idempotent.
 		return nil

--- a/internal/installsource/apply.go
+++ b/internal/installsource/apply.go
@@ -55,6 +55,13 @@ func (t *installSourceTool) apply(ctx context.Context, req request, act *action)
 	}
 }
 
+func (t *installSourceTool) saveConfigTo(cfg *config.Config, path string) error {
+	if t.saveConfig != nil {
+		return t.saveConfig(cfg, path)
+	}
+	return cfg.SaveTo(path)
+}
+
 // applySkillRoot appends the path to the active config's [skills].paths and
 // re-builds the Store to confirm the listed skills are discoverable.
 func (t *installSourceTool) applySkillRoot(req request, act *action) error {
@@ -65,7 +72,7 @@ func (t *installSourceTool) applySkillRoot(req request, act *action) error {
 	if err := cfg.AddSkillPath(act.Source); err != nil {
 		return err
 	}
-	if err := cfg.SaveTo(act.ConfigPath); err != nil {
+	if err := t.saveConfigTo(cfg, act.ConfigPath); err != nil {
 		return err
 	}
 	store := skill.New(skill.Options{HomeDir: t.home, ReasonixHomeDir: t.reasonixHome, ProjectRoot: t.root, CustomPaths: append(cfg.SkillCustomPaths(), act.Source)})
@@ -254,7 +261,7 @@ func (t *installSourceTool) applyInstallMCP(ctx context.Context, req request, ac
 		}
 		return err
 	}
-	if err := cfg.SaveTo(act.ConfigPath); err != nil {
+	if err := t.saveConfigTo(cfg, act.ConfigPath); err != nil {
 		if rbErr := t.rollbackMCPReplace(act, previous, oldDisconnected, connected); rbErr != nil {
 			return fmt.Errorf("%w; rollback failed: %v", err, rbErr)
 		}
@@ -320,7 +327,7 @@ func (t *installSourceTool) applyRemoveSkillRoot(_ request, act *action) error {
 	if !removed {
 		return nil
 	}
-	if err := cfg.SaveTo(act.ConfigPath); err != nil {
+	if err := t.saveConfigTo(cfg, act.ConfigPath); err != nil {
 		return err
 	}
 	return nil
@@ -337,7 +344,7 @@ func (t *installSourceTool) applyRemoveMCP(_ request, act *action) error {
 		// Nothing to remove is not a failure: idempotent.
 		return nil
 	}
-	if err := cfg.SaveTo(act.ConfigPath); err != nil {
+	if err := t.saveConfigTo(cfg, act.ConfigPath); err != nil {
 		return err
 	}
 	if t.onDisconnect != nil {

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -67,6 +67,7 @@ type installSourceTool struct {
 	connectMCP   MCPConnector
 	onDisconnect OnDisconnectFunc
 	approval     ApprovalFunc
+	saveConfig   func(*config.Config, string) error
 	// preparePlugin overrides plugin source preparation in tests. nil uses
 	// preparePluginSource. Plan and apply both resolve the source through the
 	// same function, and git sources additionally report the resolved commit,
@@ -118,6 +119,7 @@ func NewTool(opts Options) tool.Tool {
 		connectMCP:   opts.ConnectMCP,
 		onDisconnect: opts.OnDisconnect,
 		approval:     opts.Approval,
+		saveConfig:   func(cfg *config.Config, path string) error { return cfg.SaveTo(path) },
 	}
 }
 

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -335,7 +335,22 @@ func (t *installSourceTool) executeUninstall(req request) string {
 	actions := []action{}
 	scopes := t.uninstallSearchScopes(req)
 	for _, scope := range scopes {
-		actions = t.uninstallActionsForScope(req.Name, scope)
+		var err error
+		actions, err = t.uninstallActionsForScope(req.Name, scope)
+		if err != nil {
+			return marshalJSON(response{
+				OK:       false,
+				Status:   "failed",
+				Op:       req.Op,
+				Applied:  false,
+				Source:   req.Source,
+				Name:     req.Name,
+				Scope:    scope,
+				Warnings: []string{err.Error()},
+				Error:    err.Error(),
+				Next:     "Fix the config file, then retry op=uninstall.",
+			})
+		}
 		if len(actions) > 0 {
 			break
 		}
@@ -408,10 +423,13 @@ func (t *installSourceTool) uninstallSearchScopes(req request) []string {
 	return append(scopes, "global")
 }
 
-func (t *installSourceTool) uninstallActionsForScope(name, scope string) []action {
+func (t *installSourceTool) uninstallActionsForScope(name, scope string) ([]action, error) {
 	var actions []action
 	cfgPath := t.configPath(scope)
-	cfg := config.LoadForEdit(cfgPath)
+	cfg, err := config.LoadForEditStrict(cfgPath)
+	if err != nil {
+		return nil, err
+	}
 
 	// Skills: try the flat file, then the directory layout, in the chosen
 	// scope. We don't require a kind — "name" disambiguates.
@@ -473,7 +491,7 @@ func (t *installSourceTool) uninstallActionsForScope(name, scope string) []actio
 			}
 		}
 	}
-	return actions
+	return actions, nil
 }
 
 // resolveSkillPath finds the on-disk location of a previously installed

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -951,12 +951,6 @@ func TestApplyMCPRollsBackOnSaveFailure(t *testing.T) {
 	if err := cfg.SaveTo(filepath.Join(project, "reasonix.toml")); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(project, 0o555); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chmod(project, 0o755)
-	})
 
 	var disconnects atomic.Int32
 	stub := &stubConnector{toolCount: 2, disconnectCalls: &disconnects}
@@ -968,7 +962,10 @@ func TestApplyMCPRollsBackOnSaveFailure(t *testing.T) {
 			disconnects.Add(1)
 			return true
 		},
-	})
+	}).(*installSourceTool)
+	tl.saveConfig = func(*config.Config, string) error {
+		return errors.New("forced save failure")
+	}
 
 	resp := execInstall(t, tl, map[string]any{
 		"source": "https://mcp.example.com/mcp",

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -947,12 +947,16 @@ func TestApplyMCPReplaceDisconnectsLiveServerBeforeConnect(t *testing.T) {
 func TestApplyMCPRollsBackOnSaveFailure(t *testing.T) {
 	project := t.TempDir()
 	home := t.TempDir()
-	// Pre-create a directory at the config path so cfg.SaveTo will fail
-	// (it cannot overwrite a non-empty directory with the file it wants).
-	if err := os.MkdirAll(filepath.Join(project, "reasonix.toml"), 0o755); err != nil {
+	cfg := config.Default()
+	if err := cfg.SaveTo(filepath.Join(project, "reasonix.toml")); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, filepath.Join(project, "reasonix.toml", "blocker"), "x")
+	if err := os.Chmod(project, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(project, 0o755)
+	})
 
 	var disconnects atomic.Int32
 	stub := &stubConnector{toolCount: 2, disconnectCalls: &disconnects}
@@ -979,6 +983,41 @@ func TestApplyMCPRollsBackOnSaveFailure(t *testing.T) {
 	}
 	if got := disconnects.Load(); got != 1 {
 		t.Errorf("rollback expected to call the new connection Disconnect once, got %d", got)
+	}
+}
+
+func TestApplyMCPRefusesInvalidConfigBeforeConnect(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+	writeFile(t, filepath.Join(project, "reasonix.toml"), "default_model = [\n")
+
+	var disconnects atomic.Int32
+	stub := &stubConnector{toolCount: 2, disconnectCalls: &disconnects}
+	tl := NewTool(Options{
+		ProjectRoot: project,
+		HomeDir:     home,
+		ConnectMCP:  stub.connector(),
+	})
+
+	resp := execInstall(t, tl, map[string]any{
+		"source": "https://mcp.example.com/mcp",
+		"kind":   "mcp",
+		"apply":  true,
+		"name":   "ghost",
+		"scope":  "project",
+	})
+
+	if resp.OK || resp.Status != "failed" {
+		t.Fatalf("expected config failure, got %+v", resp)
+	}
+	if len(stub.connected) != 0 {
+		t.Fatalf("invalid config should fail before ConnectMCP, connected %+v", stub.connected)
+	}
+	if got := disconnects.Load(); got != 0 {
+		t.Errorf("invalid config should not need rollback, got %d disconnects", got)
+	}
+	if len(resp.Actions) != 1 || !strings.Contains(resp.Actions[0].Error, "reasonix.toml") {
+		t.Fatalf("action error should name config path, got %+v", resp.Actions)
 	}
 }
 

--- a/internal/installsource/skill.go
+++ b/internal/installsource/skill.go
@@ -126,10 +126,16 @@ func (t *installSourceTool) skillCanonicalPath(name, scope string) (string, erro
 func (t *installSourceTool) verifySkill(scope, name string, act *action) error {
 	custom := []string(nil)
 	if scope == "project" {
-		cfg := config.LoadForEdit(filepath.Join(t.root, "reasonix.toml"))
+		cfg, err := config.LoadForEditStrict(filepath.Join(t.root, "reasonix.toml"))
+		if err != nil {
+			return err
+		}
 		custom = cfg.SkillCustomPaths()
 	} else {
-		cfg := config.LoadForEdit(t.configPath(scope))
+		cfg, err := config.LoadForEditStrict(t.configPath(scope))
+		if err != nil {
+			return err
+		}
 		custom = cfg.SkillCustomPaths()
 	}
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Summary / 摘要

- make config edit paths fail before saving when an existing TOML file cannot be parsed
- stop falling back to generated defaults in edit/save paths
- keep legacy normalization in memory and only persist it through explicit save paths
- validate plugin source TOML before mutating it
- return install-source errors instead of panicking when the active config is unreadable

## Why / 背景

Config edit commands commonly load a TOML file and then write it back. If the load path silently falls back to defaults after a parse/migration error, a recoverable user config can be replaced by a default template.

配置编辑命令通常会先加载 TOML，再写回。如果加载失败后静默退回默认配置，原本可修复的用户配置可能会被默认模板覆盖。

## Scope / 范围

No local/user config files, private worklogs, preview HTML, research docs, or scripts are included.

不包含本地用户配置、私有 worklog、预览 HTML、研究文档或同步脚本。

## Validation / 验证

- `go test -count=1 ./internal/config`
- `go test -count=1 ./internal/installsource`
- `go test -count=1 ./internal/cli -run 'TestSetup|TestModel|TestEffort|TestLanguage|TestTheme|TestTitle|TestSkill|TestSubagent|TestBot'`
- `go test -count=1 ./internal/boot -run 'Test.*Config|Test.*ReasonixTOML|Test.*Project'`
- `git diff --check`


Cache-impact: low - changes are limited to config/install-source error handling and legacy cleanup order; no prompt text, model routing, or cached transcript format is changed.
Cache-guard: go test -count=1 ./internal/config ./internal/control ./internal/boot ./internal/cli
