### PR TITLE
fix(agent): keep planner text out of visible transcript / 避免 planner 文本污染可见对话

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -307,7 +307,7 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, input)
 	}
-	if isNoOpPlan(plan) {
+	if isNoOpPlan(plan) || isPlannerGreetingNoTask(plan) {
 		c.persistExecutorNoOp(ctx, input, plan)
 		// The relayed conclusion is planner text; keep its source so sinks
 		// attribute it like every other planner emission.
@@ -661,6 +661,54 @@ func isNoOpPlan(plan string) bool {
 	return strings.ToLower(lastNonEmptyLine(plan)) == noChangesMarker
 }
 
+func isPlannerGreetingNoTask(plan string) bool {
+	lower := strings.ToLower(strings.TrimSpace(plan))
+	if lower == "" {
+		return false
+	}
+	// Keep this heuristic intentionally narrow. It only deduplicates short
+	// user-facing greeting / no-task replies so the executor does not answer
+	// the same opening turn again. Real no-op task conclusions still require
+	// the explicit [no_changes] marker above.
+	if strings.Count(lower, "\n") > 8 || len([]rune(lower)) > 500 {
+		return false
+	}
+	actionTerms := []string{
+		" edit ", " write ", " create ", " delete ", " modify ", " run ", " execute ", " test ", " fix ", " build ",
+		"修改", "写入", "创建", "删除", "执行", "运行", "修复", "测试", "构建",
+	}
+	padded := " " + lower + " "
+	for _, term := range actionTerms {
+		if strings.Contains(padded, term) {
+			return false
+		}
+	}
+	noTaskPhrases := []string{
+		"no concrete task",
+		"no specific task",
+		"no task to execute",
+		"ready to help",
+		"what would you like to work on",
+		"what would you like me to help",
+		"how can i help",
+		"tell me what you need",
+		"没有具体任务",
+		"没有明确任务",
+		"没有需要执行",
+		"随时告诉我",
+		"随时准备帮",
+		"有什么需要",
+		"需要我帮忙",
+		"请告诉我",
+	}
+	for _, phrase := range noTaskPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
 func lastNonEmptyLine(s string) string {
 	lines := strings.Split(s, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
@@ -707,7 +755,6 @@ func (c *Coordinator) plan(ctx context.Context, input string) (string, error) {
 		switch chunk.Type {
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)
-			c.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text, Source: event.UsageSourcePlanner})
 		case provider.ChunkUsage:
 			usage = chunk.Usage
 		case provider.ChunkError:
@@ -893,20 +940,23 @@ func boundedToolNames(names []string, max int) string {
 // use it so dual-model sessions surface the user's words, not the handoff
 // boilerplate (#3860).
 func HandoffTask(s string) string {
-	trimmed := strings.TrimSpace(s)
-	if !strings.HasPrefix(trimmed, "# "+executorHandoffMarker) {
+	trimmed := strings.TrimSpace(StripTransientUserBlocks(s))
+	marker := "# " + executorHandoffMarker
+	markerIdx := strings.Index(trimmed, marker)
+	if markerIdx < 0 {
 		return s
 	}
+	trimmed = trimmed[markerIdx:]
 	const header = "Original task:\n"
-	i := strings.Index(trimmed, header)
-	if i < 0 {
+	headerIdx := strings.Index(trimmed, header)
+	if headerIdx < 0 {
 		return s
 	}
-	rest := trimmed[i+len(header):]
+	rest := trimmed[headerIdx+len(header):]
 	if j := strings.Index(rest, "\n\nPlanner output:"); j >= 0 {
 		rest = rest[:j]
 	}
-	if task := strings.TrimSpace(rest); task != "" {
+	if task := strings.TrimSpace(StripTransientUserBlocks(rest)); task != "" {
 		return task
 	}
 	return s

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -84,6 +84,37 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 	}
 }
 
+func TestCoordinatorDoesNotStreamPlannerTextToSink(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "planner-only plan"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "executor final"},
+		{Type: provider.ChunkDone},
+	}}
+
+	var visible []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Text {
+			visible = append(visible, e.Text)
+		}
+	})
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, sink)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, sink, nil)
+
+	if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	joined := strings.Join(visible, "")
+	if strings.Contains(joined, "planner-only plan") {
+		t.Fatalf("planner text leaked to visible sink: %q", joined)
+	}
+	if !strings.Contains(joined, "executor final") {
+		t.Fatalf("executor answer missing from visible sink: %q", joined)
+	}
+}
+
 type coordinatorApprovalGate struct {
 	calls int
 	allow bool
@@ -355,6 +386,10 @@ func TestCoordinatorPassesHostUserDecisionToExecutor(t *testing.T) {
 func TestHandoffTaskRecoversOriginalInput(t *testing.T) {
 	if got := HandoffTask(formatHandoff("修复登录页的 bug", "1. read login.go")); got != "修复登录页的 bug" {
 		t.Errorf("HandoffTask(handoff) = %q, want the original task", got)
+	}
+	prefixed := "<reasoning-language>\nuse Chinese\n</reasoning-language>\n\n" + formatHandoff("你好", "plan")
+	if got := HandoffTask(prefixed); got != "你好" {
+		t.Errorf("HandoffTask(prefixed handoff) = %q, want original task", got)
 	}
 	multi := "fix the bug\n\nsteps:\n- a\n- b"
 	if got := HandoffTask(formatHandoff(multi, "plan")); got != multi {
@@ -765,6 +800,66 @@ func TestCoordinatorSkipsExecutorWhenPlannerConcludesNoChanges(t *testing.T) {
 	}
 	if got := messages[2].Content; !strings.Contains(got, "No changes are needed") {
 		t.Fatalf("persisted executor assistant message = %q, want no-op planner conclusion", got)
+	}
+}
+
+func TestCoordinatorNoOpPlannerConclusionIsVisible(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "No changes are needed; the current implementation already handles this.\n[no_changes]"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Should not run."},
+		{Type: provider.ChunkDone},
+	}}
+
+	var visible []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Text {
+			visible = append(visible, e.Text)
+		}
+	})
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, sink)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, sink, nil)
+
+	if err := coord.Run(context.Background(), "check whether the fix is already present"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 0 {
+		t.Fatalf("executor requests = %d, want skip after no-op planner conclusion", got)
+	}
+	if joined := strings.Join(visible, ""); !strings.Contains(joined, "[no_changes]") {
+		t.Fatalf("no-op planner conclusion should be visible as final answer: %q", joined)
+	}
+}
+
+func TestCoordinatorSkipsExecutorForGreetingPlannerNoTask(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "你好！我很高兴，随时告诉我有什么需要我帮忙。"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Should not run."},
+		{Type: provider.ChunkDone},
+	}}
+
+	var visible []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Text {
+			visible = append(visible, e.Text)
+		}
+	})
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, sink)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, sink, nil)
+
+	if err := coord.Run(context.Background(), "你好"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 0 {
+		t.Fatalf("executor requests = %d, want skip after no-task greeting", got)
+	}
+	if joined := strings.Join(visible, ""); !strings.Contains(joined, "随时告诉我") {
+		t.Fatalf("planner greeting should be visible as final answer: %q", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary / 摘要

This PR tightens the dual-model coordinator transcript behavior. Planner output is still used as execution context, but intermediate planner text is no longer streamed directly into the visible transcript before the executor answers.

此 PR 收紧双模型 coordinator 的 transcript 行为：planner 输出仍会作为 executor 上下文使用，但不再在 executor 作答前直接流式写入可见对话。

## Changes / 变更

- Keep planner streaming text out of the visible sink during ordinary coordinator planning.
- Preserve `[no_changes]` planner conclusions as visible final answers when the executor is intentionally skipped.
- Skip the executor for short greeting/no-task planner replies to avoid duplicate opening answers.
- Recover the original task from handoff text even when transient context blocks are prefixed before the handoff marker.

- 普通 planning 阶段不再把 planner 中间文本写入可见 sink。
- planner 明确返回 `[no_changes]` 时仍作为最终可见答案展示，并跳过 executor。
- 对短 greeting / no-task planner 回复跳过 executor，避免开场问候被回答两次。
- handoff 前面存在临时上下文块时，仍能恢复真实 original task。

## Why / 原因

In dual-model sessions, planner text should be treated as coordinator context unless it is the intentional final answer. Showing both planner and executor answers makes the transcript noisy and can duplicate user-facing replies.

在双模型会话中，planner 文本通常是 coordinator 上下文，不应默认和 executor 答案一起进入可见对话；否则 transcript 会变吵，并可能出现重复回答。

## Validation / 验证

```sh
go test -count=1 ./internal/agent
go test -count=1 ./internal/agent -run 'TestCoordinatorDoesNotStreamPlannerTextToSink|TestCoordinatorNoOpPlannerConclusionIsVisible|TestCoordinatorSkipsExecutorForGreetingPlannerNoTask|TestHandoffTaskRecoversOriginalInput'
git diff --check
```

All passed locally.

本地验证全部通过。