### PR TITLE
feat(control): add optional image-understanding sidecar / 增加可选图片理解旁路

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1378,6 +1378,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	var runner agent.Runner = executor
 	label := entry.Model
 	var classifier *control.ProviderAutoPlanClassifier
+	var imageUnderstanding control.ImageUnderstanding
 
 	if !tokenEconomy && !strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoPlan), "off") && cfg.Agent.AutoPlanClassifier != "" {
 		cm := cfg.Agent.AutoPlanClassifier
@@ -1390,6 +1391,30 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return nil, fmt.Errorf("auto_plan_classifier %q: %w", cm, err)
 		}
 		classifier = control.NewBillableProviderAutoPlanClassifier(classifierProv, ce.Price, sink)
+	}
+
+	if cmd := strings.TrimSpace(cfg.Agent.ImageUnderstandingCommand); cmd != "" {
+		iu, err := control.NewCommandImageUnderstandingForRoot(cmd, root)
+		if err != nil {
+			slog.Warn("image understanding command disabled", "command", cmd, "err", err)
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf("image_understanding_command disabled: %v", err)})
+		} else {
+			imageUnderstanding = iu
+		}
+	} else if im := strings.TrimSpace(cfg.Agent.ImageUnderstandingModel); im != "" && !tokenEconomy {
+		ie, ok := cfg.ResolveModel(im)
+		switch {
+		case !ok:
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf("image_understanding_model %q not found — image understanding disabled", im)})
+		case !config.EffectiveVision(ie):
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf("image_understanding_model %q is not marked vision-capable — image understanding disabled", im)})
+		default:
+			visionProv, err := NewProviderWithProxy(ie, proxySpec)
+			if err != nil {
+				return nil, fmt.Errorf("image_understanding_model %q: %w", im, err)
+			}
+			imageUnderstanding = control.NewBillableProviderImageUnderstanding(visionProv, ie.Price, sink)
+		}
 	}
 
 	// Two-model collaboration: a distinct planner_model wraps the executor in a
@@ -1456,6 +1481,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:              ctx,
 		WorkspaceRoot:          root,
 		ExternalFolderToolRefs: readPathResolver,
+		ImageUnderstanding:     imageUnderstanding,
+		ImageUnderstandingLog:  cfg.UIImageUnderstandingLog(),
 		AutoPlan:               cfg.Agent.AutoPlan,
 		ResponseLanguage:       cfg.ResponseLanguage(),
 		ReasoningLanguage:      cfg.ReasoningLanguage(),

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1912,6 +1912,7 @@ func providersWithMissingKeys(cfg *config.Config) []config.ProviderEntry {
 	if !strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoPlan), "off") {
 		refs = append(refs, cfg.Agent.AutoPlanClassifier)
 	}
+	refs = append(refs, cfg.Agent.ImageUnderstandingModel)
 	if len(cfg.Agent.SubagentModels) > 0 {
 		keys := make([]string, 0, len(cfg.Agent.SubagentModels))
 		for key := range cfg.Agent.SubagentModels {
@@ -2085,6 +2086,8 @@ func configCommand(args []string) int {
 		return configMemoryV5Command(args[1:])
 	case "reasoning-language":
 		return configReasoningLanguageCommand(args[1:])
+	case "image-understanding-log":
+		return configImageUnderstandingLogCommand(args[1:])
 	default:
 		configUsage()
 		return 2
@@ -2265,11 +2268,69 @@ func configReasoningLanguageCommand(args []string) int {
 	return 0
 }
 
+func configImageUnderstandingLogCommand(args []string) int {
+	fs := flag.NewFlagSet("config image-understanding-log", flag.ContinueOnError)
+	local := fs.Bool("local", false, "unsupported; image-understanding-log is user-level only")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *local {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "image-understanding-log is user-level only; --local is not supported")
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) > 1 {
+		configImageUnderstandingLogUsage()
+		return 2
+	}
+	if len(rest) == 0 || strings.EqualFold(rest[0], "status") {
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		fmt.Printf("ui.image_understanding_log = %q\n", cfg.UIImageUnderstandingLog())
+		cmd := strings.TrimSpace(cfg.Agent.ImageUnderstandingCommand)
+		model := strings.TrimSpace(cfg.Agent.ImageUnderstandingModel)
+		switch {
+		case cmd != "":
+			fmt.Println("image_understanding_backend = \"command\"")
+			fmt.Printf("agent.image_understanding_command = %q\n", cmd)
+			fmt.Printf("image_understanding_cache = %q\n", control.ImageUnderstandingCachePathForRoot(""))
+		case model != "":
+			fmt.Println("image_understanding_backend = \"model\"")
+			fmt.Printf("agent.image_understanding_model = %q\n", model)
+		default:
+			fmt.Println("image_understanding_backend = \"disabled\"")
+		}
+		return 0
+	}
+	path := config.UserConfigPath()
+	if path == "" {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "cannot resolve config path")
+		return 1
+	}
+	unlock := config.LockUserConfigEdits()
+	defer unlock()
+	cfg := config.LoadForEdit(path)
+	if err := cfg.SetImageUnderstandingLog(rest[0]); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 1
+	}
+	fmt.Printf("ui.image_understanding_log = %q (%s)\n", cfg.UIImageUnderstandingLog(), displayPath(path))
+	return 0
+}
+
 func configUsage() {
 	fmt.Print(`Usage:
   reasonix config auto-plan [off|on]
   reasonix config memory-v5 [off|observe|compact|on|status]
   reasonix config reasoning-language [--local] [auto|zh|en]
+  reasonix config image-understanding-log [off|summary|detail|status]
 `)
 }
 
@@ -2288,5 +2349,11 @@ func configMemoryV5Usage() {
 func configReasoningLanguageUsage() {
 	fmt.Print(`Usage:
   reasonix config reasoning-language [--local] [auto|zh|en]
+`)
+}
+
+func configImageUnderstandingLogUsage() {
+	fmt.Print(`Usage:
+  reasonix config image-understanding-log [off|summary|detail|status]
 `)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,6 +140,9 @@ type UIConfig struct {
 	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
 	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
 	CursorShape    string `toml:"cursor_shape"`    // block|underline|bar; empty defaults to underline
+	// ImageUnderstandingLog controls how much OCR/vision sidecar output the CLI
+	// transcript shows. The model-facing context is controlled by [agent].
+	ImageUnderstandingLog string `toml:"image_understanding_log"` // off|summary|detail
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally
@@ -237,6 +240,20 @@ func (c *Config) UICursorShape() string {
 		return "bar"
 	default:
 		return "underline"
+	}
+}
+
+// UIImageUnderstandingLog normalizes ui.image_understanding_log. The default is
+// a compact one-line transcript notice; the sidecar detail remains available to
+// the model without flooding terminal history.
+func (c *Config) UIImageUnderstandingLog() string {
+	switch strings.ToLower(strings.TrimSpace(c.UI.ImageUnderstandingLog)) {
+	case "off", "none", "false", "0", "disabled":
+		return "off"
+	case "detail", "details", "verbose", "full":
+		return "detail"
+	default:
+		return "summary"
 	}
 }
 
@@ -1076,6 +1093,13 @@ type AgentConfig struct {
 	// AutoPlanClassifier optionally names a provider/model used to classify
 	// borderline auto-plan decisions. Empty keeps the zero-cost heuristic path.
 	AutoPlanClassifier string `toml:"auto_plan_classifier"`
+	// ImageUnderstandingModel optionally names a vision-capable provider/model
+	// used to describe pasted images before text-only active models see a turn.
+	ImageUnderstandingModel string `toml:"image_understanding_model"`
+	// ImageUnderstandingCommand optionally names a local command that receives
+	// image paths and emits <image-understanding> text. When set, it wins over
+	// image_understanding_model so local OCR can keep image bytes off-network.
+	ImageUnderstandingCommand string `toml:"image_understanding_command"`
 	// Compaction window fractions: soft = notice only, compact = trigger, force = hard ceiling.
 	SoftCompactRatio    float64 `toml:"soft_compact_ratio"`
 	ToolResultSnipRatio float64 `toml:"tool_result_snip_ratio"`

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -84,6 +84,23 @@ func (c *Config) SetAutoPlan(mode string) error {
 	return nil
 }
 
+// SetImageUnderstandingLog controls how much OCR/vision sidecar output the CLI
+// should display. The prompt injection itself is controlled by agent settings.
+func (c *Config) SetImageUnderstandingLog(mode string) error {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "off", "none", "false", "0", "disabled":
+		c.UI.ImageUnderstandingLog = "off"
+	case "", "summary", "status":
+		c.UI.ImageUnderstandingLog = "summary"
+	case "detail", "details", "verbose", "full":
+		c.UI.ImageUnderstandingLog = "detail"
+	default:
+		c.UI.ImageUnderstandingLog = ""
+		return fmt.Errorf("image_understanding_log %q: must be off|summary|detail", mode)
+	}
+	return nil
+}
+
 // SetDesktopDefaultToolApprovalMode sets the Ask/Auto/YOLO posture used only
 // for newly-created desktop sessions.
 func (c *Config) SetDesktopDefaultToolApprovalMode(mode string) error {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1075,6 +1075,7 @@ func legacyMimoConfigRefs(c *Config) []string {
 		c.Agent.PlannerModel,
 		c.Agent.SubagentModel,
 		c.Agent.AutoPlanClassifier,
+		c.Agent.ImageUnderstandingModel,
 		c.Bot.Model,
 	}
 	for _, ref := range c.Agent.SubagentModels {
@@ -1217,6 +1218,7 @@ func NormalizeLegacyDesktopProviderAccess(c *Config) {
 	addRef(c.Agent.PlannerModel)
 	addRef(c.Agent.SubagentModel)
 	addRef(c.Agent.AutoPlanClassifier)
+	addRef(c.Agent.ImageUnderstandingModel)
 	for _, ref := range c.Agent.SubagentModels {
 		addRef(ref)
 	}
@@ -1405,6 +1407,7 @@ func retargetDesktopOfficialRefs(c *Config, access map[string]bool) {
 	c.Agent.PlannerModel = retargetDesktopOfficialRef(c.Agent.PlannerModel, access)
 	c.Agent.SubagentModel = retargetDesktopOfficialRef(c.Agent.SubagentModel, access)
 	c.Agent.AutoPlanClassifier = retargetDesktopOfficialRef(c.Agent.AutoPlanClassifier, access)
+	c.Agent.ImageUnderstandingModel = retargetDesktopOfficialRef(c.Agent.ImageUnderstandingModel, access)
 	for skill, ref := range c.Agent.SubagentModels {
 		c.Agent.SubagentModels[skill] = retargetDesktopOfficialRef(ref, access)
 	}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -87,6 +87,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		} else {
 			b.WriteString("# show_reasoning = true   # CLI: show thinking text by default; false = collapsed (toggle with Ctrl+O)\n")
 		}
+		if strings.TrimSpace(c.UI.ImageUnderstandingLog) != "" {
+			fmt.Fprintf(&b, "image_understanding_log = %q   # off|summary|detail; CLI visibility for OCR/vision sidecar notices\n", c.UIImageUnderstandingLog())
+		} else {
+			b.WriteString("# image_understanding_log = \"summary\"   # off|summary|detail; CLI visibility for OCR/vision sidecar notices\n")
+		}
 		b.WriteString("\n")
 	}
 
@@ -222,6 +227,16 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		fmt.Fprintf(&b, "auto_plan_classifier = %q   # optional provider/model for borderline auto-plan decisions\n", c.Agent.AutoPlanClassifier)
 	} else {
 		b.WriteString("# auto_plan_classifier = \"deepseek-flash\"   # optional; only used for borderline tasks\n")
+	}
+	if c.Agent.ImageUnderstandingModel != "" {
+		fmt.Fprintf(&b, "image_understanding_model = %q   # optional vision sidecar for images when the active model is text-only\n", c.Agent.ImageUnderstandingModel)
+	} else {
+		b.WriteString("# image_understanding_model = \"provider/vision-model\"   # optional; describes images for text-only active models\n")
+	}
+	if c.Agent.ImageUnderstandingCommand != "" {
+		fmt.Fprintf(&b, "image_understanding_command = %q   # optional local OCR/vision sidecar command; receives image paths\n", c.Agent.ImageUnderstandingCommand)
+	} else {
+		b.WriteString("# image_understanding_command = \"reasonix-vision-ocr\"   # optional; local sidecar, no model downloads\n")
 	}
 	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
 	fmt.Fprintf(&b, "tool_result_snip_ratio = %s   # snip stale tool results at this fraction before summary compaction\n", formatFloat(c.Agent.ToolResultSnipRatio))
@@ -756,6 +771,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		if c.UI.ShowReasoning != d.UI.ShowReasoning {
 			fmt.Fprintf(&b, "show_reasoning = %v\n", c.UI.ShowReasoning)
 		}
+		if strings.TrimSpace(c.UI.ImageUnderstandingLog) != "" {
+			fmt.Fprintf(&b, "image_understanding_log = %q\n", c.UIImageUnderstandingLog())
+		}
 		b.WriteString("\n")
 	}
 
@@ -820,6 +838,14 @@ func RenderTOMLProjectDelta(c *Config) string {
 	}
 	if c.Agent.AutoPlanClassifier != "" && c.Agent.AutoPlanClassifier != d.Agent.AutoPlanClassifier {
 		fmt.Fprintf(&agentBuf, "auto_plan_classifier = %q\n", c.Agent.AutoPlanClassifier)
+		anyAgent = true
+	}
+	if c.Agent.ImageUnderstandingModel != "" && c.Agent.ImageUnderstandingModel != d.Agent.ImageUnderstandingModel {
+		fmt.Fprintf(&agentBuf, "image_understanding_model = %q\n", c.Agent.ImageUnderstandingModel)
+		anyAgent = true
+	}
+	if c.Agent.ImageUnderstandingCommand != "" && c.Agent.ImageUnderstandingCommand != d.Agent.ImageUnderstandingCommand {
+		fmt.Fprintf(&agentBuf, "image_understanding_command = %q\n", c.Agent.ImageUnderstandingCommand)
 		anyAgent = true
 	}
 	if c.Agent.SoftCompactRatio != d.Agent.SoftCompactRatio {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -118,6 +118,8 @@ type Controller struct {
 	disableColdResumePrune            bool
 	shell                             sandbox.Shell // interpreter for user-invoked "!" commands; zero = auto
 	classifier                        autoPlanClassifier
+	imageUnderstanding                ImageUnderstanding
+	imageUnderstandingLog             string
 	startedOnce                       bool                             // guards the one-shot SessionStart hook on first turn
 	closeOnce                         sync.Once                        // makes close idempotent under racing teardown paths
 	onRemember                        func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
@@ -417,6 +419,12 @@ type Options struct {
 	// matches the agent's configured [tools.shell] choice. Zero value = auto.
 	Shell      sandbox.Shell
 	Classifier autoPlanClassifier
+	// ImageUnderstanding is an optional vision sidecar for text-only active
+	// models. Vision-capable active models still receive image bytes directly.
+	ImageUnderstanding ImageUnderstanding
+	// ImageUnderstandingLog controls successful sidecar transcript notices:
+	// off, summary, or detail.
+	ImageUnderstandingLog string
 	// OnRemember, when set, is invoked with a new allow rule the user chose to
 	// persist to disk (e.g. "Bash(go test:*)"). The callback is wired into the
 	// permission Gate on EnableInteractiveApproval.
@@ -458,6 +466,10 @@ func New(opts Options) *Controller {
 	if nilutil.IsNil(classifier) {
 		classifier = nil
 	}
+	imageUnderstanding := opts.ImageUnderstanding
+	if nilutil.IsNil(imageUnderstanding) {
+		imageUnderstanding = nil
+	}
 	pluginCtx := opts.PluginCtx
 	if pluginCtx == nil {
 		pluginCtx = context.Background()
@@ -496,6 +508,8 @@ func New(opts Options) *Controller {
 		disableColdResumePrune:            opts.DisableColdResumePrune,
 		shell:                             opts.Shell,
 		classifier:                        classifier,
+		imageUnderstanding:                imageUnderstanding,
+		imageUnderstandingLog:             normalizeImageUnderstandingLog(opts.ImageUnderstandingLog),
 		onRemember:                        opts.OnRemember,
 		onRememberMCPReadOnlyTrust:        opts.OnRememberMCPReadOnlyTrust,
 		onRememberPlanModeReadOnlyCommand: opts.OnRememberPlanModeReadOnlyCommand,
@@ -1638,6 +1652,7 @@ func (c *Controller) Run(ctx context.Context, input string) (err error) {
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	rawInput := input
 	input = c.Compose(input)
+	input = c.withImageUnderstanding(ctx, input, rawInput)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	if c.guardianSess != nil {
@@ -4426,6 +4441,83 @@ func (c *Controller) imageInputEnabled() bool {
 // ImageInputEnabled reports whether the current model accepts direct image
 // inputs, so frontends can gate image-only UX before a turn starts.
 func (c *Controller) ImageInputEnabled() bool { return c.imageInputEnabled() }
+
+func (c *Controller) withImageUnderstanding(ctx context.Context, input string, sourceInputs ...string) string {
+	if nilutil.IsNil(c.imageUnderstanding) || c.imageInputEnabled() {
+		return input
+	}
+	source := input
+	for _, candidate := range sourceInputs {
+		if strings.TrimSpace(candidate) != "" {
+			source = candidate
+			break
+		}
+	}
+	images := c.inputImageRefs(source)
+	if len(images) == 0 {
+		return input
+	}
+	started := time.Now()
+	desc, err := c.imageUnderstanding.DescribeImages(ctx, source, images)
+	if err != nil {
+		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "image understanding failed: " + err.Error()})
+		return input
+	}
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return input
+	}
+	c.emitImageUnderstandingNotice(len(images), desc, time.Since(started))
+	return "Image understanding context:\n\n" + desc + "\n\n" + input
+}
+
+func normalizeImageUnderstandingLog(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "off", "none", "false", "0", "disabled":
+		return "off"
+	case "detail", "details", "verbose", "full":
+		return "detail"
+	default:
+		return "summary"
+	}
+}
+
+func (c *Controller) emitImageUnderstandingNotice(count int, desc string, elapsed time.Duration) {
+	mode := normalizeImageUnderstandingLog(c.imageUnderstandingLog)
+	if mode == "off" {
+		return
+	}
+	label := "image"
+	if count != 1 {
+		label = "images"
+	}
+	parts := []string{fmt.Sprintf("%d %s", count, label), "OCR + UI state"}
+	if elapsedText := formatImageUnderstandingElapsed(elapsed); elapsedText != "" {
+		parts = append(parts, elapsedText)
+	}
+	e := event.Event{
+		Kind:   event.Notice,
+		Level:  event.LevelInfo,
+		Source: event.UsageSourceVision,
+		Text:   "image understood: " + strings.Join(parts, " · "),
+		Detail: desc,
+	}
+	c.sink.Emit(e)
+}
+
+func formatImageUnderstandingElapsed(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	if d < time.Second {
+		ms := int(d.Round(time.Millisecond) / time.Millisecond)
+		if ms < 1 {
+			ms = 1
+		}
+		return fmt.Sprintf("%dms", ms)
+	}
+	return d.Round(100 * time.Millisecond).String()
+}
 
 // InheritLifecycleFrom carries same-session lifecycle state across controller
 // rebuilds, such as model switches that preserve the conversation.

--- a/internal/control/image_understanding.go
+++ b/internal/control/image_understanding.go
@@ -1,0 +1,180 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+
+	"reasonix/internal/event"
+	"reasonix/internal/nilutil"
+	"reasonix/internal/provider"
+)
+
+const imageUnderstandingPrompt = `You are an image understanding sidecar for a coding agent.
+Describe the attached image(s) so a text-only main model can use them.
+Focus on visible UI text, errors, code, status bars, diagrams, layout, and the user's likely target.
+Preserve exact visible strings when useful. Be concise and factual.
+Use the user's language when obvious. Do not solve the whole task; only describe visual evidence.`
+
+// ImageUnderstandingRef is one user-referenced image prepared for an optional
+// sidecar. DataURL is for provider-native vision; Path/Source/SHA256 let local
+// OCR commands emit portable, auditable context without inlining image bytes.
+type ImageUnderstandingRef struct {
+	Source  string
+	Path    string
+	DataURL string
+	SHA256  string
+}
+
+// ImageUnderstanding describes attached user images, producing compact text
+// that can be injected into a text-only main turn.
+type ImageUnderstanding interface {
+	DescribeImages(ctx context.Context, userInput string, images []ImageUnderstandingRef) (string, error)
+}
+
+type ProviderImageUnderstanding struct {
+	prov    provider.Provider
+	pricing *provider.Pricing
+	sink    event.Sink
+}
+
+func NewProviderImageUnderstanding(prov provider.Provider) *ProviderImageUnderstanding {
+	if nilutil.IsNil(prov) {
+		return nil
+	}
+	return &ProviderImageUnderstanding{prov: prov}
+}
+
+func NewBillableProviderImageUnderstanding(prov provider.Provider, pricing *provider.Pricing, sink event.Sink) *ProviderImageUnderstanding {
+	if nilutil.IsNil(prov) {
+		return nil
+	}
+	if nilutil.IsNil(sink) {
+		sink = event.Discard
+	}
+	return &ProviderImageUnderstanding{prov: prov, pricing: pricing, sink: sink}
+}
+
+func (u *ProviderImageUnderstanding) DescribeImages(ctx context.Context, userInput string, images []ImageUnderstandingRef) (string, error) {
+	if u == nil || nilutil.IsNil(u.prov) {
+		return "", fmt.Errorf("image understanding is not initialized")
+	}
+	dataURLs := make([]string, 0, len(images))
+	for _, img := range images {
+		if strings.TrimSpace(img.DataURL) != "" {
+			dataURLs = append(dataURLs, img.DataURL)
+		}
+	}
+	if len(dataURLs) == 0 {
+		return "", nil
+	}
+	ch, err := u.prov.Stream(ctx, provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: imageUnderstandingPrompt},
+			{Role: provider.RoleUser, Content: imageUnderstandingUserPrompt(userInput, len(dataURLs)), Images: dataURLs},
+		},
+		Temperature: provider.TemperaturePtr(0),
+		MaxTokens:   700,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var text strings.Builder
+	var usage *provider.Usage
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkUsage:
+			usage = chunk.Usage
+		case provider.ChunkError:
+			return "", chunk.Err
+		}
+	}
+	if usage != nil && usage.TotalTokens > 0 && !nilutil.IsNil(u.sink) {
+		u.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: u.pricing, UsageSource: event.UsageSourceVision})
+	}
+	desc := strings.TrimSpace(text.String())
+	if desc == "" {
+		return "", nil
+	}
+	return formatImageUnderstandingBlock(combinedImageUnderstandingSource(images), combinedImageUnderstandingSHA(images), "", desc, "", "", "medium"), nil
+}
+
+func imageUnderstandingUserPrompt(userInput string, count int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Image count: %d\n\n", count)
+	if strings.TrimSpace(userInput) != "" {
+		b.WriteString("User request:\n")
+		b.WriteString(userInput)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Return a compact visual description. If the image is a screenshot, include the most relevant visible text and UI state.")
+	return b.String()
+}
+
+func formatImageUnderstandingBlock(source, sha, visibleText, uiState, errors, layout, confidence string) string {
+	if strings.TrimSpace(confidence) == "" {
+		confidence = "medium"
+	}
+	var b strings.Builder
+	b.WriteString(imageUnderstandingOpenTag(source, sha))
+	b.WriteString("\n")
+	writeImageUnderstandingField(&b, "visible_text", visibleText)
+	writeImageUnderstandingField(&b, "ui_state", uiState)
+	writeImageUnderstandingField(&b, "errors", errors)
+	writeImageUnderstandingField(&b, "layout", layout)
+	writeImageUnderstandingField(&b, "confidence", confidence)
+	b.WriteString("\n</image-understanding>")
+	return b.String()
+}
+
+func imageUnderstandingOpenTag(source, sha string) string {
+	var b strings.Builder
+	b.WriteString(`<image-understanding source="`)
+	b.WriteString(html.EscapeString(strings.TrimSpace(source)))
+	b.WriteString(`"`)
+	if strings.TrimSpace(sha) != "" {
+		b.WriteString(` sha256="`)
+		b.WriteString(html.EscapeString(strings.TrimSpace(sha)))
+		b.WriteString(`"`)
+	}
+	b.WriteString(">")
+	return b.String()
+}
+
+func writeImageUnderstandingField(b *strings.Builder, name, value string) {
+	value = strings.TrimSpace(value)
+	b.WriteString(name)
+	b.WriteString(":")
+	if value != "" {
+		b.WriteString(" ")
+		if strings.Contains(value, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString(value)
+	}
+	b.WriteString("\n")
+}
+
+func combinedImageUnderstandingSource(images []ImageUnderstandingRef) string {
+	var parts []string
+	for _, img := range images {
+		if s := strings.TrimSpace(img.Source); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+func combinedImageUnderstandingSHA(images []ImageUnderstandingRef) string {
+	var parts []string
+	for _, img := range images {
+		if s := strings.TrimSpace(img.SHA256); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/control/image_understanding_command.go
+++ b/internal/control/image_understanding_command.go
@@ -1,0 +1,404 @@
+package control
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"reasonix/internal/proc"
+
+	"mvdan.cc/sh/v3/shell"
+)
+
+const imageUnderstandingCommandTimeout = 5 * time.Second
+const imageUnderstandingCommandMaxConcurrency = 4
+const imageUnderstandingCacheVersion = 1
+
+// CommandImageUnderstanding runs a user-configured local OCR/vision sidecar.
+// The command is called once per image with the local image path appended as the
+// final argument. It may return a ready-made <image-understanding> block, JSON,
+// or plain text.
+type CommandImageUnderstanding struct {
+	argv    []string
+	timeout time.Duration
+	cache   string
+}
+
+type imageUnderstandingCacheEntry struct {
+	Version   int    `json:"version"`
+	Key       string `json:"key"`
+	SHA256    string `json:"sha256"`
+	Command   string `json:"command"`
+	Block     string `json:"block"`
+	CreatedAt string `json:"created_at"`
+}
+
+func NewCommandImageUnderstanding(command string) (*CommandImageUnderstanding, error) {
+	fields, err := shell.Fields(strings.TrimSpace(command), os.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("parse image_understanding_command: %w", err)
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("image_understanding_command is empty")
+	}
+	return &CommandImageUnderstanding{argv: fields, timeout: imageUnderstandingCommandTimeout}, nil
+}
+
+func NewCommandImageUnderstandingForRoot(command, workspaceRoot string) (*CommandImageUnderstanding, error) {
+	iu, err := NewCommandImageUnderstanding(command)
+	if err != nil {
+		return nil, err
+	}
+	iu.cache = ImageUnderstandingCachePathForRoot(workspaceRoot)
+	return iu, nil
+}
+
+func ImageUnderstandingCachePathForRoot(workspaceRoot string) string {
+	root := strings.TrimSpace(workspaceRoot)
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
+		}
+	}
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, ".reasonix", "image-understanding-cache.jsonl")
+}
+
+func (u *CommandImageUnderstanding) DescribeImages(ctx context.Context, userInput string, images []ImageUnderstandingRef) (string, error) {
+	if u == nil || len(u.argv) == 0 {
+		return "", fmt.Errorf("image understanding command is not initialized")
+	}
+	filtered := make([]ImageUnderstandingRef, 0, len(images))
+	for _, img := range images {
+		if strings.TrimSpace(img.Path) == "" {
+			continue
+		}
+		filtered = append(filtered, img)
+	}
+	if len(filtered) == 0 {
+		return "", nil
+	}
+	results := make([]string, len(filtered))
+	signature := u.cacheSignature()
+	cache := u.loadCache()
+	var misses []int
+	for i, img := range filtered {
+		if block, ok := cache[imageUnderstandingCacheKey(signature, img.SHA256)]; ok {
+			results[i] = rewriteImageUnderstandingBlockSource(block, img)
+			continue
+		}
+		misses = append(misses, i)
+	}
+
+	type imageResult struct {
+		idx   int
+		block string
+		err   error
+	}
+	ch := make(chan imageResult, len(misses))
+	sem := make(chan struct{}, imageUnderstandingCommandMaxConcurrency)
+	for _, idx := range misses {
+		idx := idx
+		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			block, err := u.describeOne(ctx, userInput, filtered[idx])
+			ch <- imageResult{idx: idx, block: strings.TrimSpace(block), err: err}
+		}()
+	}
+
+	var firstErr error
+	var entries []imageUnderstandingCacheEntry
+	for range misses {
+		res := <-ch
+		if res.err != nil && firstErr == nil {
+			firstErr = res.err
+			continue
+		}
+		if res.block == "" {
+			continue
+		}
+		results[res.idx] = res.block
+		img := filtered[res.idx]
+		if strings.TrimSpace(img.SHA256) != "" {
+			entries = append(entries, imageUnderstandingCacheEntry{
+				Version:   imageUnderstandingCacheVersion,
+				Key:       imageUnderstandingCacheKey(signature, img.SHA256),
+				SHA256:    img.SHA256,
+				Command:   signature,
+				Block:     res.block,
+				CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			})
+		}
+	}
+	if firstErr != nil {
+		return "", firstErr
+	}
+	u.appendCache(entries)
+
+	var blocks []string
+	for _, block := range results {
+		if strings.TrimSpace(block) != "" {
+			blocks = append(blocks, strings.TrimSpace(block))
+		}
+	}
+	return strings.Join(blocks, "\n\n"), nil
+}
+
+func (u *CommandImageUnderstanding) describeOne(ctx context.Context, userInput string, img ImageUnderstandingRef) (string, error) {
+	timeout := u.timeout
+	if timeout <= 0 {
+		timeout = imageUnderstandingCommandTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	args := append([]string{}, u.argv[1:]...)
+	args = append(args, img.Path)
+	cmd := exec.CommandContext(runCtx, u.argv[0], args...)
+	setShellKillTree(cmd)
+	cmd.WaitDelay = time.Second
+	proc.HideWindow(cmd)
+	cmd.Env = append(os.Environ(),
+		"REASONIX_IMAGE_SOURCE="+img.Source,
+		"REASONIX_IMAGE_SHA256="+img.SHA256,
+		"REASONIX_USER_INPUT="+userInput,
+	)
+	var stdout limitedBuffer
+	var stderr limitedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	waitErr := cmd.Run()
+	if runCtx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("image understanding command timed out")
+	}
+	if waitErr != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			if stderr.Truncated() {
+				msg += "\n[truncated]"
+			}
+			return "", fmt.Errorf("image understanding command failed: %w: %s", waitErr, msg)
+		}
+		return "", fmt.Errorf("image understanding command failed: %w", waitErr)
+	}
+	if stdout.Truncated() {
+		return normalizeImageUnderstandingOutput(img, stdout.String()+"\n[truncated]"), nil
+	}
+	return normalizeImageUnderstandingOutput(img, stdout.String()), nil
+}
+
+func (u *CommandImageUnderstanding) loadCache() map[string]string {
+	out := map[string]string{}
+	path := strings.TrimSpace(u.cache)
+	if path == "" {
+		return out
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		var entry imageUnderstandingCacheEntry
+		if json.Unmarshal(scanner.Bytes(), &entry) != nil {
+			continue
+		}
+		if entry.Version != imageUnderstandingCacheVersion || strings.TrimSpace(entry.Key) == "" || strings.TrimSpace(entry.Block) == "" {
+			continue
+		}
+		out[entry.Key] = entry.Block
+	}
+	return out
+}
+
+func (u *CommandImageUnderstanding) appendCache(entries []imageUnderstandingCacheEntry) {
+	if len(entries) == 0 || strings.TrimSpace(u.cache) == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(u.cache), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(u.cache, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, entry := range entries {
+		_ = enc.Encode(entry)
+	}
+}
+
+func (u *CommandImageUnderstanding) cacheSignature() string {
+	if u == nil || len(u.argv) == 0 {
+		return ""
+	}
+	parts := []string{strings.Join(u.argv, "\x00")}
+	if exe, err := exec.LookPath(u.argv[0]); err == nil {
+		parts = append(parts, exe)
+		if st, err := os.Stat(exe); err == nil {
+			parts = append(parts, strconv.FormatInt(st.ModTime().UnixNano(), 10), strconv.FormatInt(st.Size(), 10))
+		}
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func imageUnderstandingCacheKey(commandSignature, sha string) string {
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("v%d\x00%s\x00%s", imageUnderstandingCacheVersion, commandSignature, sha)))
+	return hex.EncodeToString(sum[:])
+}
+
+func rewriteImageUnderstandingBlockSource(block string, img ImageUnderstandingRef) string {
+	block = strings.TrimSpace(block)
+	if !strings.HasPrefix(block, "<image-understanding") {
+		return normalizeImageUnderstandingOutput(img, block)
+	}
+	newOpen := imageUnderstandingOpenTag(img.Source, img.SHA256)
+	if idx := strings.Index(block, "\n"); idx >= 0 {
+		return newOpen + block[idx:]
+	}
+	return newOpen + "\n</image-understanding>"
+}
+
+func normalizeImageUnderstandingOutput(img ImageUnderstandingRef, out string) string {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return ""
+	}
+	if strings.HasPrefix(out, "<image-understanding") {
+		return out
+	}
+	var payload map[string]any
+	if json.Unmarshal([]byte(out), &payload) == nil && len(payload) > 0 {
+		visible := firstJSONText(payload, "visible_text", "text", "ocr", "ocr_text")
+		uiState := firstJSONText(payload, "ui_state", "summary", "description")
+		errorsText := firstJSONText(payload, "errors", "error")
+		layout := firstJSONText(payload, "layout")
+		if layout == "" {
+			layout = jsonLayoutSummary(payload)
+		}
+		confidence := firstJSONText(payload, "confidence")
+		if confidence == "" {
+			confidence = "medium"
+		}
+		return formatImageUnderstandingBlock(img.Source, img.SHA256, visible, uiState, errorsText, layout, confidence)
+	}
+	return formatImageUnderstandingBlock(img.Source, img.SHA256, out, "", "", "", "medium")
+}
+
+func firstJSONText(payload map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := payload[key]; ok {
+			if s := jsonValueText(v); strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}
+
+func jsonValueText(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, item := range x {
+			if s := jsonValueText(item); strings.TrimSpace(s) != "" {
+				parts = append(parts, strings.TrimSpace(s))
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		if text := firstJSONText(x, "text", "value", "label"); text != "" {
+			return text
+		}
+		raw, _ := json.Marshal(x)
+		return string(raw)
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(x)
+	default:
+		raw, _ := json.Marshal(x)
+		return string(raw)
+	}
+}
+
+func jsonLayoutSummary(payload map[string]any) string {
+	var parts []string
+	width, wok := jsonNumber(payload["width"])
+	height, hok := jsonNumber(payload["height"])
+	if wok && hok {
+		parts = append(parts, fmt.Sprintf("%gx%g", width, height))
+	}
+	switch regions := payload["text_regions"].(type) {
+	case []any:
+		parts = append(parts, fmt.Sprintf("text_regions=%d", len(regions)))
+	case float64:
+		parts = append(parts, fmt.Sprintf("text_regions=%d", int(regions)))
+	}
+	if elapsed, ok := jsonNumber(payload["elapsed_ms"]); ok {
+		parts = append(parts, fmt.Sprintf("ocr_ms=%.1f", elapsed))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func jsonNumber(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case json.Number:
+		f, err := x.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func fileSHA256(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func imageRefSource(r ref) string {
+	source := strings.TrimSpace(r.raw)
+	if source == "" {
+		source = strings.TrimSpace(r.displayPath)
+	}
+	if source == "" {
+		source = strings.TrimSpace(r.path)
+	}
+	if source == "" {
+		return ""
+	}
+	if strings.HasPrefix(source, "@") {
+		return source
+	}
+	return "@" + filepath.ToSlash(source)
+}

--- a/internal/control/image_understanding_command_test.go
+++ b/internal/control/image_understanding_command_test.go
@@ -2,8 +2,10 @@ package control
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -21,13 +23,8 @@ func TestCommandImageUnderstandingWrapsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	script := filepath.Join(dir, "ocr.sh")
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-printf '%s\n' '{"visible_text":"状态栏\nYOLO","width":10,"height":20,"text_regions":[{"text":"状态栏"}],"elapsed_ms":12.3}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	iu, err := NewCommandImageUnderstanding(script)
+	command := imageUnderstandingTestCommand(t, `{"visible_text":"状态栏\nYOLO","width":10,"height":20,"text_regions":[{"text":"状态栏"}],"elapsed_ms":12.3}`, "")
+	iu, err := NewCommandImageUnderstanding(command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,18 +61,8 @@ func TestCommandImageUnderstandingCachesBySHA(t *testing.T) {
 		t.Fatal(err)
 	}
 	counter := filepath.Join(dir, "runs.txt")
-	script := filepath.Join(dir, "ocr.sh")
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-counter="`+counter+`"
-n=0
-if [ -f "$counter" ]; then n=$(cat "$counter"); fi
-n=$((n + 1))
-printf '%s\n' "$n" > "$counter"
-printf '%s\n' '{"visible_text":"cached text","confidence":"high"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	iu, err := NewCommandImageUnderstandingForRoot(script, dir)
+	command := imageUnderstandingTestCommand(t, `{"visible_text":"cached text","confidence":"high"}`, counter)
+	iu, err := NewCommandImageUnderstandingForRoot(command, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,13 +114,8 @@ func TestControllerWithImageUnderstandingInjectsOnlyForTextOnlyModel(t *testing.
 	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	script := filepath.Join(workspace, "ocr.sh")
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-printf '%s\n' '{"visible_text":"button text","confidence":"high"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	iu, err := NewCommandImageUnderstanding(script)
+	command := imageUnderstandingTestCommand(t, `{"visible_text":"button text","confidence":"high"}`, "")
+	iu, err := NewCommandImageUnderstanding(command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,13 +151,8 @@ func TestControllerImageUnderstandingNoticeCarriesDisclosureDetail(t *testing.T)
 	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	script := filepath.Join(workspace, "ocr.sh")
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-printf '%s\n' '{"visible_text":"statusbar text","confidence":"high"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	iu, err := NewCommandImageUnderstanding(script)
+	command := imageUnderstandingTestCommand(t, `{"visible_text":"statusbar text","confidence":"high"}`, "")
+	iu, err := NewCommandImageUnderstanding(command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,13 +209,8 @@ func TestRunPrependsImageUnderstandingAfterCompose(t *testing.T) {
 	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	script := filepath.Join(workspace, "ocr.sh")
-	if err := os.WriteFile(script, []byte(`#!/bin/sh
-printf '%s\n' '{"visible_text":"compose path text","confidence":"high"}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	iu, err := NewCommandImageUnderstanding(script)
+	command := imageUnderstandingTestCommand(t, `{"visible_text":"compose path text","confidence":"high"}`, "")
+	iu, err := NewCommandImageUnderstanding(command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,4 +228,48 @@ printf '%s\n' '{"visible_text":"compose path text","confidence":"high"}'
 			t.Fatalf("Run input missing %q:\n%s", want, runner.input)
 		}
 	}
+}
+
+func imageUnderstandingTestCommand(t *testing.T, payload, counterPath string) string {
+	t.Helper()
+	args := []string{os.Args[0], "-test.run=TestImageUnderstandingCommandHelper", "--", payload}
+	if counterPath != "" {
+		args = append(args, counterPath)
+	}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuoteTestArg(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuoteTestArg(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func TestImageUnderstandingCommandHelper(t *testing.T) {
+	marker := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			marker = i
+			break
+		}
+	}
+	if marker < 0 || marker+1 >= len(os.Args) {
+		return
+	}
+	payload := os.Args[marker+1]
+	if marker+2 < len(os.Args) {
+		counterPath := os.Args[marker+2]
+		n := 0
+		if raw, err := os.ReadFile(counterPath); err == nil {
+			n, _ = strconv.Atoi(strings.TrimSpace(string(raw)))
+		}
+		if err := os.WriteFile(counterPath, []byte(strconv.Itoa(n+1)), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	fmt.Fprintln(os.Stdout, payload)
+	os.Exit(0)
 }

--- a/internal/control/image_understanding_command_test.go
+++ b/internal/control/image_understanding_command_test.go
@@ -1,0 +1,259 @@
+package control
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+func TestCommandImageUnderstandingWrapsJSON(t *testing.T) {
+	dir := t.TempDir()
+	image := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sha, err := fileSHA256(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(dir, "ocr.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf '%s\n' '{"visible_text":"状态栏\nYOLO","width":10,"height":20,"text_regions":[{"text":"状态栏"}],"elapsed_ms":12.3}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iu, err := NewCommandImageUnderstanding(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := iu.DescribeImages(context.Background(), "look", []ImageUnderstandingRef{{
+		Source: "@shot.png",
+		Path:   image,
+		SHA256: sha,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`<image-understanding source="@shot.png" sha256="` + sha + `">`,
+		"visible_text:",
+		"状态栏",
+		"YOLO",
+		"layout: 10x20; text_regions=1; ocr_ms=12.3",
+		"confidence: medium",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("DescribeImages output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestCommandImageUnderstandingCachesBySHA(t *testing.T) {
+	dir := t.TempDir()
+	image := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sha, err := fileSHA256(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := filepath.Join(dir, "runs.txt")
+	script := filepath.Join(dir, "ocr.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+counter="`+counter+`"
+n=0
+if [ -f "$counter" ]; then n=$(cat "$counter"); fi
+n=$((n + 1))
+printf '%s\n' "$n" > "$counter"
+printf '%s\n' '{"visible_text":"cached text","confidence":"high"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iu, err := NewCommandImageUnderstandingForRoot(script, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got1, err := iu.DescribeImages(context.Background(), "look", []ImageUnderstandingRef{{
+		Source: "@first.png",
+		Path:   image,
+		SHA256: sha,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := iu.DescribeImages(context.Background(), "look again", []ImageUnderstandingRef{{
+		Source: "@second.png",
+		Path:   image,
+		SHA256: sha,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw, err := os.ReadFile(counter); err != nil || strings.TrimSpace(string(raw)) != "1" {
+		t.Fatalf("command runs = %q, err=%v; want 1", string(raw), err)
+	}
+	if !strings.Contains(got1, `source="@first.png"`) || !strings.Contains(got1, "cached text") {
+		t.Fatalf("first output mismatch:\n%s", got1)
+	}
+	if !strings.Contains(got2, `source="@second.png"`) || strings.Contains(got2, `source="@first.png"`) {
+		t.Fatalf("cache hit should rewrite source for current ref:\n%s", got2)
+	}
+	if _, err := os.Stat(ImageUnderstandingCachePathForRoot(dir)); err != nil {
+		t.Fatalf("cache was not written: %v", err)
+	}
+}
+
+func TestControllerWithImageUnderstandingInjectsOnlyForTextOnlyModel(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.Default()
+	cfg.DefaultModel = "custom/text-only"
+	cfg.Providers = []config.ProviderEntry{{
+		Name:         "custom",
+		Kind:         "openai",
+		BaseURL:      "https://example.invalid/v1",
+		Models:       []string{"text-only", "vision-pro"},
+		VisionModels: []string{"vision-pro"},
+	}}
+	if err := cfg.SaveTo(filepath.Join(workspace, "reasonix.toml")); err != nil {
+		t.Fatalf("save workspace config: %v", err)
+	}
+	image := filepath.Join(workspace, "shot.png")
+	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(workspace, "ocr.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf '%s\n' '{"visible_text":"button text","confidence":"high"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iu, err := NewCommandImageUnderstanding(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := New(Options{WorkspaceRoot: workspace, ImageUnderstanding: iu, ModelRef: "custom/text-only"})
+	got := c.withImageUnderstanding(context.Background(), "see @shot.png")
+	if !strings.HasPrefix(got, "Image understanding context:\n\n<image-understanding ") {
+		t.Fatalf("withImageUnderstanding did not prepend image context:\n%s", got)
+	}
+	if !strings.Contains(got, `source="@shot.png"`) || !strings.Contains(got, "button text") || !strings.HasSuffix(got, "\n\nsee @shot.png") {
+		t.Fatalf("withImageUnderstanding output mismatch:\n%s", got)
+	}
+
+	c.modelRef = "custom/vision-pro"
+	if got := c.withImageUnderstanding(context.Background(), "see @shot.png"); got != "see @shot.png" {
+		t.Fatalf("vision model should receive direct image input without sidecar, got:\n%s", got)
+	}
+}
+
+func TestControllerImageUnderstandingNoticeCarriesDisclosureDetail(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.Default()
+	cfg.DefaultModel = "custom/text-only"
+	cfg.Providers = []config.ProviderEntry{{
+		Name:    "custom",
+		Kind:    "openai",
+		BaseURL: "https://example.invalid/v1",
+		Models:  []string{"text-only"},
+	}}
+	if err := cfg.SaveTo(filepath.Join(workspace, "reasonix.toml")); err != nil {
+		t.Fatalf("save workspace config: %v", err)
+	}
+	image := filepath.Join(workspace, "shot.png")
+	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(workspace, "ocr.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf '%s\n' '{"visible_text":"statusbar text","confidence":"high"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iu, err := NewCommandImageUnderstanding(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &noticeSink{}
+	c := New(Options{Sink: sink, WorkspaceRoot: workspace, ImageUnderstanding: iu, ImageUnderstandingLog: "summary", ModelRef: "custom/text-only"})
+	_ = c.withImageUnderstanding(context.Background(), "see @shot.png")
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	var got *event.Event
+	for i := range sink.events {
+		if sink.events[i].Kind == event.Notice && strings.HasPrefix(sink.events[i].Text, "image understood:") {
+			got = &sink.events[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("missing image understood notice: %+v", sink.events)
+	}
+	if got.Source != event.UsageSourceVision {
+		t.Fatalf("notice source = %q, want vision", got.Source)
+	}
+	if !strings.Contains(got.Text, "1 image") || !strings.Contains(got.Text, "OCR + UI state") {
+		t.Fatalf("notice text missing summary fields: %q", got.Text)
+	}
+	if !strings.Contains(got.Detail, "<image-understanding ") || !strings.Contains(got.Detail, "statusbar text") {
+		t.Fatalf("notice detail missing disclosure body:\n%s", got.Detail)
+	}
+}
+
+type imageUnderstandingRunRecorder struct {
+	input string
+}
+
+func (r *imageUnderstandingRunRecorder) Run(_ context.Context, input string) error {
+	r.input = input
+	return nil
+}
+
+func TestRunPrependsImageUnderstandingAfterCompose(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.Default()
+	cfg.DefaultModel = "custom/text-only"
+	cfg.Providers = []config.ProviderEntry{{
+		Name:    "custom",
+		Kind:    "openai",
+		BaseURL: "https://example.invalid/v1",
+		Models:  []string{"text-only"},
+	}}
+	if err := cfg.SaveTo(filepath.Join(workspace, "reasonix.toml")); err != nil {
+		t.Fatalf("save workspace config: %v", err)
+	}
+	image := filepath.Join(workspace, "shot.png")
+	if err := os.WriteFile(image, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(workspace, "ocr.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf '%s\n' '{"visible_text":"compose path text","confidence":"high"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	iu, err := NewCommandImageUnderstanding(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &imageUnderstandingRunRecorder{}
+	c := New(Options{Runner: runner, WorkspaceRoot: workspace, ImageUnderstanding: iu, ModelRef: "custom/text-only"})
+	if err := c.Run(context.Background(), "see @shot.png"); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Image understanding context:",
+		"compose path text",
+		"see @shot.png",
+	} {
+		if !strings.Contains(runner.input, want) {
+			t.Fatalf("Run input missing %q:\n%s", want, runner.input)
+		}
+	}
+}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -566,6 +566,59 @@ func (c *Controller) inputImages(line string) []string {
 	return urls
 }
 
+func (c *Controller) inputImageRefs(line string) []ImageUnderstandingRef {
+	var images []ImageUnderstandingRef
+	seen := map[string]bool{}
+	for _, r := range c.detectRefs(line) {
+		baseDir := c.workspaceRoot
+		if r.baseDir != "" {
+			baseDir = r.baseDir
+		}
+		url, err := visionRefImageDataURL(r, baseDir)
+		if err != nil {
+			continue
+		}
+		path, err := imageRefLocalPath(r, baseDir)
+		if err != nil {
+			continue
+		}
+		key := path
+		if key == "" {
+			key = url
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		sha, _ := fileSHA256(path)
+		images = append(images, ImageUnderstandingRef{
+			Source:  imageRefSource(r),
+			Path:    path,
+			DataURL: url,
+			SHA256:  sha,
+		})
+	}
+	return images
+}
+
+func imageRefLocalPath(r ref, baseDir string) (string, error) {
+	switch r.kind {
+	case refImage:
+		if strings.HasPrefix(r.path, ".reasonix/attachments/") {
+			return filepath.Join(baseDir, filepath.FromSlash(r.path)), nil
+		}
+		return "", fmt.Errorf("image reference has no local path")
+	case refFile:
+		absPath, _, ok := resolveAbsRef(r.path, baseDir)
+		if !ok {
+			return "", os.ErrNotExist
+		}
+		return absPath, nil
+	default:
+		return "", fmt.Errorf("reference is not an image")
+	}
+}
+
 func visionRefImageDataURL(r ref, baseDir string) (string, error) {
 	switch r.kind {
 	case refImage:

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -170,6 +170,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 		ctx = agent.WithMemoryCompilerSourceInput(ctx, turn.raw)
 	}
 	input := c.compose(turn.input, turn.raw, !turn.synthetic)
+	input = c.withImageUnderstanding(ctx, input, turn.raw, turn.input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	defer c.recordDisplayForNewUser(startMessages, turn.display)

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -245,6 +245,7 @@ const (
 	UsageSourceSubagent         = "subagent"
 	UsageSourceCompaction       = "compaction"
 	UsageSourceClassifier       = "classifier"
+	UsageSourceVision           = "vision"
 	UsageSourceTitle            = "title"
 	UsageSourceCapabilityRouter = "capability-router"
 )


### PR DESCRIPTION
Cache-impact: low - default behavior is unchanged unless image_understanding_command or image_understanding_model is configured; enabled sidecars add compact current-turn image summaries instead of inlining image bytes.
Cache-guard: go test -count=1 ./internal/config ./internal/control ./internal/boot ./internal/cli && go test -count=1 ./...
System-prompt-review: h4rk8s self-review; sidecar output is explicit referenced context and default startup leaves the existing prompt path unchanged.

## 中文

这个 PR 把图片附件理解拆成一个可选 sidecar，而不是把图片字节内联进普通文本 prompt。这样 text-only 模型仍能读到结构化的 `<image-understanding>` 摘要，同时 vision-capable 模型/本地 OCR 命令可以按需接入。

### 主要变更

- 新增 `control.ImageUnderstanding` sidecar 接口。
- 支持 provider-backed sidecar：调用已配置的 vision provider/model 生成 `<image-understanding>` 结构化文本。
- 支持 command-backed sidecar：本地命令接收图片路径并输出结构化理解结果，适合 macOS OCR 或其他本地工具。
- 启动配置接线：
  - `[agent].image_understanding_command` 优先；
  - `[agent].image_understanding_model` 作为 vision provider fallback；
  - `[ui].image_understanding_log = "off"|"summary"|"detail"` 控制 CLI transcript 显示级别。
- 新增 `reasonix config image-understanding-log [off|summary|detail|status]` 查看/设置 CLI 显示级别。
- sidecar 失败时降级为原始图片引用，不阻断正常回合。

### 为什么这样做

Reasonix 的缓存设计不适合把图片 bytes 或大段 OCR 噪声反复混入稳定 prompt。这个实现把“图片理解”放在转瞬即用的 sidecar 阶段：结果以小型文本摘要进入当前回合，既保留 text-only model 兼容性，也避免破坏缓存前缀。

### 验证

- `go test -count=1 ./internal/config ./internal/control ./internal/boot ./internal/cli`
- `go test -count=1 ./...`
- `git diff --check`

## English

This PR adds optional image-understanding sidecars for pasted image attachments without inlining image bytes into normal text prompts. Text-only models can consume a structured `<image-understanding>` summary, while vision-capable providers or local OCR commands can be wired in explicitly.

### Changes

- Add the `control.ImageUnderstanding` sidecar interface.
- Add provider-backed image understanding for configured vision models.
- Add command-backed image understanding for local OCR/vision tools.
- Wire configuration:
  - `[agent].image_understanding_command` takes priority;
  - `[agent].image_understanding_model` is used as a vision-provider fallback;
  - `[ui].image_understanding_log = "off"|"summary"|"detail"` controls CLI transcript visibility.
- Add `reasonix config image-understanding-log [off|summary|detail|status]`.
- Sidecar failures degrade to the original image reference instead of blocking the turn.

### Rationale

Reasonix is cache-sensitive. Keeping image bytes and noisy OCR output out of the stable prompt preserves cache locality while still giving text-only models a compact, current-turn image summary.

### Verification

- `go test -count=1 ./internal/config ./internal/control ./internal/boot ./internal/cli`
- `go test -count=1 ./...`
- `git diff --check`
