### PR TITLE
test(config): isolate Windows user config writes

### DIFF
--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -789,12 +789,11 @@ func TestSetCredentialRejectsInvalidInput(t *testing.T) {
 }
 
 func TestProjectConfigCannotOverrideCredentialStoreMode(t *testing.T) {
-	home := t.TempDir()
+	home := isolateUserConfigHome(t)
 	project := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "")
 	os.Unsetenv("REASONIX_CREDENTIALS_STORE")
+	requireTestPathWithin(t, home, UserConfigPath())
 	if err := os.MkdirAll(filepath.Dir(UserConfigPath()), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1107,13 +1107,15 @@ func TestSaveToRoundTrips(t *testing.T) {
 }
 
 func TestSaveToScopesUserAndProjectFiles(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	home := isolateUserConfigHome(t)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
 	c := Default()
 	c.Desktop.Theme = "dark"
 	c.Desktop.ThemeStyle = "graphite"
 	c.Desktop.CloseBehavior = "background"
 
 	userPath := UserConfigPath()
+	requireTestPathWithin(t, home, userPath)
 	if err := c.SaveTo(userPath); err != nil {
 		t.Fatalf("SaveTo user config: %v", err)
 	}

--- a/internal/config/path_isolation_test.go
+++ b/internal/config/path_isolation_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requireTestPathWithin(t *testing.T, root, path string) {
+	t.Helper()
+	rel, err := filepath.Rel(root, path)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		t.Fatalf("test path %q escapes isolated root %q", path, root)
+	}
+}


### PR DESCRIPTION
## Summary

- isolate Windows user config paths in two write-capable config tests
- add a guard that fails if a test path escapes its temporary root
- prevent tests from overwriting `%APPDATA%\reasonix\config.toml`

## Verification

- `go test ./internal/config -run 'Test(SaveToScopesUserAndProjectFiles|ProjectConfigCannotOverrideCredentialStoreMode)$' -count=1 -v`
- `go test ./internal/config -count=1`
- `go test ./internal/control -count=1`
- `go test ./internal/provider/openai -run 'Test(BuildRequest.*Image|ImageURLDetail)' -count=1 -v`
- `go vet ./...`
- `go build ./...`

## Cache impact

Cache-impact: none; test-only config path isolation.
Cache-guard: `go test ./internal/config -count=1`
System-prompt-review: N/A