### PR TITLE
fix(control): include selected turn when forking conversation

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6662,8 +6662,8 @@ func TestForkCreatesActiveTabWithoutSwitchingSourceController(t *testing.T) {
 		}
 		if ok && m.TopicID == meta.TopicID {
 			forkPath = candidate
-			if m.ParentID != agent.BranchID(path) || m.ForkTurn != 1 || m.ForkMessageIndex != 3 {
-				t.Fatalf("fork branch meta = %+v, want parent %q turn 1 index 3", m, agent.BranchID(path))
+			if m.ParentID != agent.BranchID(path) || m.ForkTurn != 1 || m.ForkMessageIndex != 5 {
+				t.Fatalf("fork branch meta = %+v, want parent %q turn 1 index 5", m, agent.BranchID(path))
 			}
 			if m.Scope != "project" || m.WorkspaceRoot != workspace || m.TopicTitle != "Source topic · 分叉" {
 				t.Fatalf("fork topic meta = %+v", m)

--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -207,11 +207,48 @@ func TestSubmitBranchHonorsNumericTurnTarget(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("load branch meta ok=%v err=%v", ok, err)
 	}
-	if meta.ForkTurn != 1 || meta.ForkMessageIndex != 3 || meta.Name != "experiment" {
-		t.Fatalf("meta = %+v, want turn 1, msg index 3, name experiment", meta)
+	if meta.ForkTurn != 1 || meta.ForkMessageIndex != 4 || meta.Name != "experiment" {
+		t.Fatalf("meta = %+v, want turn 1, msg index 4, name experiment", meta)
 	}
-	if got := len(c.History()); got != 3 {
-		t.Fatalf("forked history length = %d, want 3", got)
+	if got := len(c.History()); got != 4 {
+		t.Fatalf("forked history length = %d, want 4", got)
+	}
+}
+
+func TestForkIncludesSelectedTurn(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "first prompt"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "first answer"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "second prompt"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "second answer"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "third prompt"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "third answer"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.SetSessionPath(agent.NewSessionPath(dir, "test"))
+	if err := c.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	c.checkpoints.mu.Lock()
+	c.checkpoints.bound[0] = 1
+	c.checkpoints.bound[1] = 3
+	c.checkpoints.bound[2] = 5
+	c.checkpoints.mu.Unlock()
+
+	newPath, err := c.ForkSession(1, "keep-second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := agent.LoadSession(newPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(loaded.Messages); got != 5 {
+		t.Fatalf("forked messages = %d, want 5", got)
+	}
+	if loaded.Messages[4].Content != "second answer" {
+		t.Fatalf("fork tip = %q, want second answer", loaded.Messages[4].Content)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2857,7 +2857,7 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 	return nil
 }
 
-// Fork branches the conversation at the start of turn into a NEW session file,
+// Fork branches the conversation through the selected turn into a NEW session file,
 // preserving the current one as the branch point, and switches to the branch. Code
 // is untouched (it's a conversation operation). Like a conversation rewind it needs
 // the live boundary, so it is unavailable for resumed-session turns and refused
@@ -2870,7 +2870,7 @@ func (c *Controller) ForkNamed(turn int, name string) (string, error) {
 	return c.forkNamed(turn, name, true)
 }
 
-// ForkSession copies the conversation at the start of turn into a new session
+// ForkSession copies the conversation through the selected turn into a new session
 // file without switching this controller to it. Desktop uses this to open the
 // branch in a new tab while the source tab keeps its current transcript.
 func (c *Controller) ForkSession(turn int, name string) (string, error) {
@@ -2900,7 +2900,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	}
 
 	// Persist the current conversation first so the branch point survives, then
-	// seed a fresh session with the messages up to the fork and switch to it.
+	// seed a fresh session through the selected turn (inclusive) and switch to it.
 	if err := c.Snapshot(); err != nil {
 		slog.Warn("controller: pre-fork snapshot", "err", err)
 	}
@@ -2910,7 +2910,16 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	if boundary > len(src) {
 		boundary = len(src)
 	}
-	forked := append([]provider.Message(nil), src[:boundary]...)
+	// Inclusive of the selected turn: keep through this turn, cut before the
+	// next visible user message (steer/synthetic user rows are ignored).
+	end := len(src)
+	if cut := nextVisibleUserAfter(src, boundary); cut >= 0 {
+		end = cut
+	}
+	if end < boundary {
+		end = boundary
+	}
+	forked := append([]provider.Message(nil), src[:end]...)
 	sess := agent.NewSession("")
 	sess.Messages = forked
 
@@ -2923,7 +2932,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		Name:             strings.TrimSpace(name),
 		ParentID:         parentID,
 		ForkTurn:         turn,
-		ForkMessageIndex: boundary,
+		ForkMessageIndex: end,
 		Preview:          forkPreview,
 		Turns:            forkTurns,
 		SchemaVersion:    agent.BranchMetaCountsVersion,
@@ -2949,6 +2958,31 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("forked conversation at turn %d into a new session", turn)})
 	return newPath, nil
+}
+
+// nextVisibleUserAfter returns the index of the next visible user message after
+// the selected turn's user prompt, or -1 if none. Steer/synthetic rows are skipped.
+func nextVisibleUserAfter(src []provider.Message, turnStart int) int {
+	if turnStart < 0 {
+		turnStart = 0
+	}
+	seenTurnUser := false
+	for i := turnStart; i < len(src); i++ {
+		if src[i].Role != provider.RoleUser {
+			continue
+		}
+		if _, isSteer := agent.SteerText(src[i].Content); isSteer {
+			continue
+		}
+		if IsSyntheticUserMessage(src[i].Content) {
+			continue
+		}
+		if seenTurnUser {
+			return i
+		}
+		seenTurnUser = true
+	}
+	return -1
 }
 
 func (c *Controller) CheckpointHasBoundary(turn int) bool {


### PR DESCRIPTION
## Summary

Fork previously truncated at the checkpoint **start** of the selected turn
(`src[:boundary]`), so the new branch dropped that turn's user message and
reply. Clicking fork on a turn looked like "the previous message only."

This makes fork **inclusive of the selected turn**: keep through the current
turn, cut before the next visible user message. Conversation rewind stays
exclusive (before the turn) so edit/re-send is unchanged.

```text
M1 → A1 → M2 → A2 → M3 → A3
Click fork on M2/A2

Before: M1 → A1
After:  M1 → A1 → M2 → A2
```

## Changes

- `internal/control/controller.go`: `forkNamed` ends at the next visible user
  (skips steer/synthetic user rows); `ForkMessageIndex` records that end index
- `internal/control/branches_test.go`: update `/branch` expectations; add
  `TestForkIncludesSelectedTurn`
- `desktop/app_test.go`: update `ForkMessageIndex` expectation for inclusive fork

## Out of scope / follow-up

- `desktop/app.go` still comments that fork branches "at the start of turn."
  Behavior is now inclusive via `controller.forkNamed`; the comment is stale but
  runtime-unused. Left unchanged to keep this PR minimal; can clean up separately.

## Cache impact

- Cache-impact: none — conversation fork truncation only; no system prompt, memory prefix, provider request shape, or skill index changes.
- Cache-guard: N/A
- System-prompt-review: N/A

## Test plan

- [x] `go test ./internal/control -run "TestForkIncludesSelectedTurn|TestSubmitBranchHonorsNumericTurnTarget" -count=1`
- [x] `go test ./desktop -run "TestFork" -count=1` (from `desktop/`)
- [ ] CI full matrix on PR
- [ ] Manual: multi-turn chat → fork middle turn → new tab includes that turn, not later ones
- [ ] Manual: conversation rewind on same turn still drops the turn (exclusive)

Fixes #6510