### PR TITLE
Fix/6475 session recovery silent failure

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1151,6 +1151,16 @@ func loadSessionUnlocked(path string) (*Session, error) {
 			// branch. Anchor the baseline on digest+version only until a
 			// successful save re-learns the revision.
 			s.markPersistedRevisionUnknown(path, digest, s.version, s.rewriteVersion)
+		} else if ok && meta.WriterID != "" && meta.WriterID != SessionWriterID() {
+			// The session was last written by a different process (stale
+			// writer_id). The current process legitimately owns the session —
+			// the lease check at open time already confirmed no other runtime
+			// holds it. Disarm the revision-based CAS check so the first save
+			// proceeds without a spurious conflict against the old writer's
+			// ledger. Digest + version matching still anchor ownership;
+			// revision equality is re-established on the next successful save
+			// when recordSessionContentRevision stamps the current WriterID.
+			s.markPersistedRevisionUnknown(path, digest, s.version, s.rewriteVersion)
 		} else {
 			revision := int64(0)
 			if ok {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3386,6 +3386,10 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 			return recoverErr
 		}
 		if outcome == conflictDropped {
+			slog.Warn("controller: snapshot dropped after conflict recovery failed",
+				"path", path, "mode", map[bool]string{true: "rewrite", false: "snapshot"}[forceRewrite])
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: "session snapshot was not saved — your most recent turn may be lost. Try saving manually or restarting the conversation."})
 			return nil
 		}
 		// Whatever recovery did — adopted the disk transcript, force-saved


### PR DESCRIPTION
## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
