### PR TITLE
Harden NSIS setup for release workflows / 加固 NSIS 发版安装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,9 +238,7 @@ jobs:
         run: go test ./...
 
       - name: Install NSIS
-        run: |
-          choco install nsis -y --no-progress
-          echo "C:\Program Files (x86)\NSIS" >> "$GITHUB_PATH"
+        run: pwsh -NoProfile -File ../scripts/install-nsis.ps1
 
       - name: Build Windows installer and portable archive
         timeout-minutes: 20

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -110,9 +110,7 @@ jobs:
       # Windows: NSIS provides makensis for `wails build -nsis`.
       - name: Install NSIS
         if: runner.os == 'Windows'
-        run: |
-          choco install nsis -y --no-progress
-          echo "C:\Program Files (x86)\NSIS" >> "$GITHUB_PATH"
+        run: pwsh -NoProfile -File scripts/install-nsis.ps1
 
       # macOS: create-dmg packages the .app into a drag-to-Applications .dmg.
       - name: Install create-dmg

--- a/scripts/install-nsis.ps1
+++ b/scripts/install-nsis.ps1
@@ -1,0 +1,50 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Keep Windows packaging independent from Chocolatey's package-index availability.
+# The portable archive is pinned and checksum-verified before it reaches PATH.
+$version = "3.12"
+$url = "https://sourceforge.net/projects/nsis/files/NSIS%203/$version/nsis-$version.zip/download"
+$expectedSha256 = "56581f90db321581c5381193d796fffcf2d24b2f8fed2160a6c6a3baa67f2c4f"
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [IO.Path]::GetTempPath() }
+$archive = Join-Path $tempRoot "nsis-$version.zip"
+$extractRoot = Join-Path $tempRoot "reasonix-nsis"
+$nsisDir = Join-Path $extractRoot "nsis-$version"
+
+for ($attempt = 1; $attempt -le 3; $attempt++) {
+    try {
+        Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+        Invoke-WebRequest -Uri $url -OutFile $archive -MaximumRedirection 10
+        break
+    }
+    catch {
+        if ($attempt -eq 3) {
+            throw
+        }
+        Write-Warning "NSIS download attempt $attempt failed; retrying in $($attempt * 5) seconds"
+        Start-Sleep -Seconds ($attempt * 5)
+    }
+}
+
+$actualSha256 = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $expectedSha256) {
+    throw "NSIS archive checksum mismatch: expected $expectedSha256, got $actualSha256"
+}
+
+Remove-Item -LiteralPath $extractRoot -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot
+Remove-Item -LiteralPath $archive -Force
+
+$makensis = Join-Path $nsisDir "makensis.exe"
+if (-not (Test-Path -LiteralPath $makensis -PathType Leaf)) {
+    throw "NSIS extraction did not produce $makensis"
+}
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+    throw "GITHUB_PATH is not set"
+}
+
+Add-Content -LiteralPath $env:GITHUB_PATH -Value $nsisDir -Encoding utf8
+& $makensis /VERSION
+if ($LASTEXITCODE -ne 0) {
+    throw "makensis version check failed with exit code $LASTEXITCODE"
+}

--- a/scripts/install-nsis.ps1
+++ b/scripts/install-nsis.ps1
@@ -14,7 +14,10 @@ $nsisDir = Join-Path $extractRoot "nsis-$version"
 for ($attempt = 1; $attempt -le 3; $attempt++) {
     try {
         Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
-        Invoke-WebRequest -Uri $url -OutFile $archive -MaximumRedirection 10
+        & curl.exe --fail --location --silent --show-error --connect-timeout 30 --max-time 120 --output $archive $url
+        if ($LASTEXITCODE -ne 0) {
+            throw "curl failed with exit code $LASTEXITCODE"
+        }
         break
     }
     catch {


### PR DESCRIPTION
## Summary / 摘要

- replace the Chocolatey package-index lookup with the official pinned NSIS 3.12 portable archive
- retry downloads and verify SHA-256 before extracting or adding `makensis` to PATH
- share the same installer script between CI and the production desktop release workflow

This addresses the only red main-v2 gate after #6536: Chocolatey returned HTTP 504 on the first run and HTTP 499 on the failed-job rerun. All Windows desktop tests completed successfully before the dependency-install step.

## Verification / 验证

- `actionlint` passes for both changed workflows (ignoring only its stale unknown-label warning for GitHub official runner `windows-11-arm`)
- both workflow YAML files parse successfully
- official SourceForge archive downloaded twice successfully
- SHA-256 matched `56581f90db321581c5381193d796fffcf2d24b2f8fed2160a6c6a3baa67f2c4f`
- ZIP integrity and required `makensis.exe` paths verified
- `git diff --check` passes

Cache-impact: low - Workflow-only dependency installation changes do not alter provider-visible prompts, tool schemas, tool ordering, request prefixes, or runtime behavior.

Cache-guard: Not rerun for this workflow-only patch; the release candidate passed `./scripts/cache-guard.sh` 8/8 before #6536 merged.

System-prompt-review: Not applicable; no system prompt content, stable prefix, tool schema, tool ordering, or request serialization changed.