### PR TITLE
Isolate all stored credential env keys / 隔离所有已保存凭据环境变量

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -29,6 +29,7 @@ import (
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/tool"
 	"reasonix/internal/tool/builtin"
 
@@ -4033,6 +4034,27 @@ func TestRuntimeForbidReadRootsAddsOnlyGlobalCredentialFile(t *testing.T) {
 	}
 	if pathListContains(got, projectEnv) {
 		t.Fatalf("project .env was unexpectedly added to runtime forbid roots: %v", got)
+	}
+}
+
+func TestRuntimeForbidReadRootsFiltersUnconfiguredStoredCredential(t *testing.T) {
+	home := isolateConfigHome(t)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, "reasonix-home"))
+	const staleKey = "REASONIX_TEST_UNCONFIGURED_STORED_CREDENTIAL"
+	t.Setenv(staleKey, "opaque-stale-value")
+
+	credentialPath := config.UserCredentialsPath()
+	if err := os.MkdirAll(filepath.Dir(credentialPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentialPath, []byte(staleKey+"=opaque-stale-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = RuntimeForbidReadRoots(config.Default(), ".")
+	joined := strings.Join(secrets.ProcessEnv(), "\n")
+	if strings.Contains(joined, staleKey+"=") || strings.Contains(joined, "opaque-stale-value") {
+		t.Fatalf("unconfigured stored credential survived in subprocess env")
 	}
 }
 

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -178,12 +178,29 @@ func credentialEnvNamesFromConfig(cfg *Config) []string {
 	return out
 }
 
-// CredentialEnvNames returns the environment-variable names whose values are
-// loaded from Reasonix's global credential store for this configuration.
-// Callers use the names (never the values) to keep saved credentials out of
-// child-process environments.
+// CredentialEnvNames returns every environment-variable name whose value can
+// be loaded from Reasonix's global credential store. This includes configured
+// provider/bot keys and stored keys that are no longer referenced by the
+// current config: loadCredentialStoreForRoot loads the whole credential file,
+// so stale entries must remain outside child-process environments too.
 func (c *Config) CredentialEnvNames() []string {
-	return credentialEnvNamesFromConfig(c)
+	names := credentialEnvNamesFromConfig(c)
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		seen[name] = true
+	}
+	if file, ok := readDotEnvFile(UserCredentialsPath()); ok {
+		for name := range file.Values {
+			name = strings.TrimSpace(name)
+			if !isCredentialKey(name) || seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }
 
 func resolveProviderCredentialsForRoot(root string, cfg *Config) {

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -89,6 +89,27 @@ func TestLoadDotEnvReadsGlobalCredentials(t *testing.T) {
 	}
 }
 
+func TestCredentialEnvNamesIncludesUnconfiguredStoredKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", filepath.Join(home, "reasonix-home"))
+
+	credentialPath := UserCredentialsPath()
+	if err := os.MkdirAll(filepath.Dir(credentialPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentialPath, []byte("CONFIGURED_PROVIDER_KEY=configured\nSTALE_PROVIDER_KEY=stale\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{Providers: []ProviderEntry{{APIKeyEnv: "CONFIGURED_PROVIDER_KEY"}}}
+	got := cfg.CredentialEnvNames()
+	for _, want := range []string{"CONFIGURED_PROVIDER_KEY", "STALE_PROVIDER_KEY"} {
+		if !containsString(got, want) {
+			t.Fatalf("credential env names = %v, missing %s", got, want)
+		}
+	}
+}
+
 func TestLoadDotEnvDecodesGB18030Credentials(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- register every valid key present in the Reasonix global credential store, including entries no longer referenced by the active provider or bot configuration
- keep stored credentials out of shell and tool subprocess environments without enabling the broader opt-in environment filter
- add config-layer and boot-layer regression coverage for stale stored credentials

## Root cause

The credential file is loaded as a whole, but the runtime subprocess deny set previously contained only credential names referenced by the active configuration. A saved historical provider key could therefore remain in the parent process and pass through to Bash when filter_subprocess_env was disabled.

## Verification

- go test ./...
- go test -race ./internal/config ./internal/boot ./internal/secrets ./internal/tool/builtin
- go vet ./...
- ./scripts/cache-guard.sh
- isolated real-provider security smoke: global credential file denied, no provider credential variables in Bash, raw credential-value scan clean

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Existing global credential .env | Existing configured keys continue to resolve; historical stored keys remain on disk but are filtered from tool subprocesses | Safe |
| Inherited shell tokens not stored by Reasonix | Continue to pass through when filter_subprocess_env is disabled | Preserved |
| Config, session, trace, Wails, and skill formats | No persisted format changes | Unchanged |

## Cache review

Cache-impact: none - No provider-visible prompt, tool schema, tool order, or request serialization changes.
Cache-guard: ./scripts/cache-guard.sh passed all scenarios at 92%-95% tail average against the 90% threshold.
System-prompt-review: Reviewed; only a boot regression test changed, with no production system-prompt behavior change.
