### PR TITLE
Fix Windows launcher and support executable icons / 修复 Windows 启动器及辅助程序图标

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -216,8 +216,12 @@ Section
     IfFileExists "$INSTDIR\${REASONIX_PORTABLE_ENTRY}" 0 reasonix_no_portable_entry
     File "/oname=${REASONIX_PORTABLE_ENTRY}" "${REASONIX_LAUNCHER}"
 reasonix_no_portable_entry:
-    CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach"
-    CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach"
+    ; Keep the Guard launcher as the target while taking the visible shortcut
+    ; icon from the Wails application. The launcher embeds the same icon too,
+    ; but an explicit icon source prevents stale/generic taskbar pins after an
+    ; in-place upgrade from a launcher build that had no Windows resources.
+    CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach" "$INSTDIR\${PRODUCT_EXECUTABLE}" 0
+    CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach" "$INSTDIR\${PRODUCT_EXECUTABLE}" 0
     !else
     CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"
     CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${PRODUCT_EXECUTABLE}"

--- a/desktop/cmd/windows-resource/main.go
+++ b/desktop/cmd/windows-resource/main.go
@@ -1,0 +1,232 @@
+// Command windows-resource stamps Reasonix branding and metadata into a Windows
+// support executable after it has been built. Wails already uses the same
+// winres library for the desktop executable; keeping the support binaries on the
+// same resource path avoids generic Explorer, shortcut, and taskbar icons.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/tc-hib/winres"
+	"github.com/tc-hib/winres/version"
+)
+
+const (
+	companyName = "Reasonix"
+	copyright   = "Copyright © 2026 Reasonix Contributors"
+)
+
+type resourceOptions struct {
+	executable      string
+	icon            string
+	numericVersion  string
+	fileDescription string
+	internalName    string
+	originalName    string
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "windows-resource:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("windows-resource", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var opts resourceOptions
+	fs.StringVar(&opts.executable, "exe", "", "Windows executable to stamp")
+	fs.StringVar(&opts.icon, "icon", "", "ICO file to embed")
+	fs.StringVar(&opts.numericVersion, "version", "", "numeric X.Y.Z version")
+	fs.StringVar(&opts.fileDescription, "description", "", "Windows FileDescription")
+	fs.StringVar(&opts.internalName, "internal-name", "", "Windows InternalName")
+	fs.StringVar(&opts.originalName, "original-filename", "", "Windows OriginalFilename")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	for name, value := range map[string]string{
+		"-exe":               opts.executable,
+		"-icon":              opts.icon,
+		"-version":           opts.numericVersion,
+		"-description":       opts.fileDescription,
+		"-internal-name":     opts.internalName,
+		"-original-filename": opts.originalName,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+	}
+	return stampExecutable(opts)
+}
+
+func stampExecutable(opts resourceOptions) error {
+	numericVersion, err := parseNumericVersion(opts.numericVersion)
+	if err != nil {
+		return err
+	}
+
+	iconFile, err := os.Open(opts.icon)
+	if err != nil {
+		return fmt.Errorf("open icon: %w", err)
+	}
+	ico, err := winres.LoadICO(iconFile)
+	closeErr := iconFile.Close()
+	if err != nil {
+		return fmt.Errorf("load icon: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close icon: %w", closeErr)
+	}
+
+	rs := winres.ResourceSet{}
+	if err := rs.SetIcon(winres.ID(1), ico); err != nil {
+		return fmt.Errorf("set icon: %w", err)
+	}
+	rs.SetManifest(winres.AppManifest{
+		Identity: winres.AssemblyIdentity{
+			Name:    "Reasonix." + opts.internalName,
+			Version: numericVersion,
+		},
+		Description:         opts.fileDescription,
+		ExecutionLevel:      winres.AsInvoker,
+		DPIAwareness:        winres.DPIPerMonitorV2,
+		LongPathAware:       true,
+		UseCommonControlsV6: true,
+	})
+
+	info := version.Info{
+		FileVersion:    numericVersion,
+		ProductVersion: numericVersion,
+	}
+	for key, value := range map[string]string{
+		version.CompanyName:      companyName,
+		version.FileDescription:  opts.fileDescription,
+		version.FileVersion:      opts.numericVersion,
+		version.InternalName:     opts.internalName,
+		version.LegalCopyright:   copyright,
+		version.OriginalFilename: opts.originalName,
+		version.ProductName:      "Reasonix",
+		version.ProductVersion:   opts.numericVersion,
+		version.Comments:         "Reasonix desktop support component.",
+	} {
+		if err := info.Set(version.LangDefault, key, value); err != nil {
+			return fmt.Errorf("set version field %s: %w", key, err)
+		}
+	}
+	rs.SetVersionInfo(info)
+
+	source, err := os.ReadFile(opts.executable)
+	if err != nil {
+		return fmt.Errorf("read executable: %w", err)
+	}
+	var stamped bytes.Buffer
+	if err := rs.WriteToEXE(&stamped, bytes.NewReader(source)); err != nil {
+		return fmt.Errorf("write resources: %w", err)
+	}
+	if err := verifyResources(stamped.Bytes(), opts, numericVersion); err != nil {
+		return fmt.Errorf("verify resources: %w", err)
+	}
+
+	mode := os.FileMode(0o755)
+	if stat, err := os.Stat(opts.executable); err == nil {
+		mode = stat.Mode()
+	}
+	if err := replaceFile(opts.executable, stamped.Bytes(), mode); err != nil {
+		return fmt.Errorf("replace executable: %w", err)
+	}
+	return nil
+}
+
+func parseNumericVersion(value string) ([4]uint16, error) {
+	parts := strings.Split(strings.TrimSpace(value), ".")
+	if len(parts) != 3 && len(parts) != 4 {
+		return [4]uint16{}, fmt.Errorf("version %q must have three or four numeric parts", value)
+	}
+	var parsed [4]uint16
+	for i, part := range parts {
+		if part == "" {
+			return [4]uint16{}, fmt.Errorf("version %q contains an empty part", value)
+		}
+		n, err := strconv.ParseUint(part, 10, 16)
+		if err != nil {
+			return [4]uint16{}, fmt.Errorf("version %q is not a Windows numeric version: %w", value, err)
+		}
+		parsed[i] = uint16(n)
+	}
+	return parsed, nil
+}
+
+func verifyResources(executable []byte, opts resourceOptions, numericVersion [4]uint16) error {
+	rs, err := winres.LoadFromEXE(bytes.NewReader(executable))
+	if err != nil {
+		return err
+	}
+	if _, err := rs.GetIcon(winres.ID(1)); err != nil {
+		return fmt.Errorf("application icon: %w", err)
+	}
+	manifest := rs.Get(winres.RT_MANIFEST, winres.ID(1), winres.LCIDDefault)
+	if len(manifest) == 0 || !bytes.Contains(manifest, []byte(`requestedExecutionLevel level="asInvoker"`)) {
+		return errors.New("asInvoker application manifest is missing")
+	}
+	versionData := rs.Get(winres.RT_VERSION, winres.ID(1), version.LangDefault)
+	info, err := version.FromBytes(versionData)
+	if err != nil {
+		return fmt.Errorf("version info: %w", err)
+	}
+	if info.FileVersion != numericVersion || info.ProductVersion != numericVersion {
+		return fmt.Errorf("numeric version mismatch: file=%v product=%v want=%v", info.FileVersion, info.ProductVersion, numericVersion)
+	}
+	table := info.Table()[version.LangDefault]
+	if table == nil {
+		return errors.New("English version string table is missing")
+	}
+	for key, want := range map[string]string{
+		version.CompanyName:      companyName,
+		version.FileDescription:  opts.fileDescription,
+		version.InternalName:     opts.internalName,
+		version.OriginalFilename: opts.originalName,
+		version.ProductName:      "Reasonix",
+	} {
+		if got := (*table)[key]; got != want {
+			return fmt.Errorf("version field %s=%q, want %q", key, got, want)
+		}
+	}
+	return nil
+}
+
+func replaceFile(path string, data []byte, mode os.FileMode) error {
+	temp, err := os.CreateTemp(filepath.Dir(path), ".reasonix-resource-*.exe")
+	if err != nil {
+		return err
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+	if err := temp.Chmod(mode); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempName, path)
+}

--- a/desktop/cmd/windows-resource/main_test.go
+++ b/desktop/cmd/windows-resource/main_test.go
@@ -77,8 +77,8 @@ func TestStampExecutableSupportsWindowsReleaseArchitectures(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if peFile.FileHeader.Machine != test.machine {
-				t.Errorf("PE machine = %#x, want %#x", peFile.FileHeader.Machine, test.machine)
+			if peFile.Machine != test.machine {
+				t.Errorf("PE machine = %#x, want %#x", peFile.Machine, test.machine)
 			}
 			peFile.Close()
 

--- a/desktop/cmd/windows-resource/main_test.go
+++ b/desktop/cmd/windows-resource/main_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"debug/pe"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/tc-hib/winres"
+	"github.com/tc-hib/winres/version"
+)
+
+func TestParseNumericVersion(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  [4]uint16
+	}{
+		{"1.17.13", [4]uint16{1, 17, 13, 0}},
+		{"2.3.4.5", [4]uint16{2, 3, 4, 5}},
+	} {
+		got, err := parseNumericVersion(test.value)
+		if err != nil {
+			t.Fatalf("parseNumericVersion(%q): %v", test.value, err)
+		}
+		if got != test.want {
+			t.Fatalf("parseNumericVersion(%q) = %v, want %v", test.value, got, test.want)
+		}
+	}
+	for _, value := range []string{"", "1.2", "1.2.3-beta", "1.2.70000"} {
+		if _, err := parseNumericVersion(value); err == nil {
+			t.Errorf("parseNumericVersion(%q) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestStampExecutableSupportsWindowsReleaseArchitectures(t *testing.T) {
+	icon, err := filepath.Abs(filepath.Join("..", "..", "build", "windows", "icon.ico"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		arch    string
+		machine uint16
+	}{
+		{"amd64", pe.IMAGE_FILE_MACHINE_AMD64},
+		{"arm64", pe.IMAGE_FILE_MACHINE_ARM64},
+	} {
+		t.Run(test.arch, func(t *testing.T) {
+			dir := t.TempDir()
+			source := filepath.Join(dir, "main.go")
+			if err := os.WriteFile(source, []byte("package main\nfunc main() {}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			executable := filepath.Join(dir, "reasonix-launcher.exe")
+			cmd := exec.Command("go", "build", "-trimpath", "-o", executable, source)
+			cmd.Env = append(os.Environ(), "GOOS=windows", "GOARCH="+test.arch, "CGO_ENABLED=0")
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("cross-build %s fixture: %v\n%s", test.arch, err, output)
+			}
+
+			opts := resourceOptions{
+				executable:      executable,
+				icon:            icon,
+				numericVersion:  "1.17.13",
+				fileDescription: "Reasonix Launcher",
+				internalName:    "reasonix-launcher",
+				originalName:    "reasonix-launcher.exe",
+			}
+			if err := stampExecutable(opts); err != nil {
+				t.Fatal(err)
+			}
+
+			peFile, err := pe.Open(executable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if peFile.FileHeader.Machine != test.machine {
+				t.Errorf("PE machine = %#x, want %#x", peFile.FileHeader.Machine, test.machine)
+			}
+			peFile.Close()
+
+			data, err := os.ReadFile(executable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rs, err := winres.LoadFromEXE(bytes.NewReader(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := rs.GetIcon(winres.ID(1)); err != nil {
+				t.Fatalf("embedded icon: %v", err)
+			}
+			info, err := version.FromBytes(rs.Get(winres.RT_VERSION, winres.ID(1), version.LangDefault))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := (*info.Table()[version.LangDefault])[version.OriginalFilename]; got != "reasonix-launcher.exe" {
+				t.Errorf("OriginalFilename = %q", got)
+			}
+			manifest := rs.Get(winres.RT_MANIFEST, winres.ID(1), winres.LCIDDefault)
+			if !bytes.Contains(manifest, []byte(`dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,system`)) {
+				t.Errorf("per-monitor-v2 manifest setting is missing: %s", manifest)
+			}
+		})
+	}
+}
+
+func TestReplaceFilePreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix executable mode bits")
+	}
+	path := filepath.Join(t.TempDir(), "program.exe")
+	if err := os.WriteFile(path, []byte("old"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceFile(path, []byte("new"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stat.Mode().Perm(); got != 0o751 {
+		t.Fatalf("mode = %#o, want 0751", got)
+	}
+}

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -16,6 +16,7 @@ require (
 	fyne.io/systray v1.12.2
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/minio/selfupdate v0.6.0
+	github.com/tc-hib/winres v0.3.1
 	github.com/wailsapp/wails/v2 v2.12.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/sys v0.46.0
@@ -47,6 +48,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -76,6 +76,8 @@ github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/a
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=
 github.com/minio/selfupdate v0.6.0/go.mod h1:bO02GTIPCMQFTEvE5h4DjYB58bCoZ35XLeBf0buTDdM=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -99,6 +101,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tc-hib/winres v0.3.1 h1:CwRjEGrKdbi5CvZ4ID+iyVhgyfatxFoizjPhzez9Io4=
+github.com/tc-hib/winres v0.3.1/go.mod h1:C/JaNhH3KBvhNKVbvdlDWkbMDO9H4fKKDaN7/07SSuk=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=

--- a/desktop/guard_packaging_test.go
+++ b/desktop/guard_packaging_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -15,8 +16,13 @@ func TestDesktopPackagesUseGuardAsDefaultLauncher(t *testing.T) {
 	for _, want := range []string{
 		`cp "$guard_out" "$app/Contents/MacOS/$GUARDNAME"`,
 		`Set :CFBundleExecutable $GUARDNAME`,
+		`Print :CFBundleIconFile`,
+		`Contents/Resources/$bundle_icon`,
 		`cp "$portable" "$staging/$BINNAME.exe"`,
 		`-H windowsgui`,
+		`stamp_windows_executable "$guard_out" "Reasonix Guard"`,
+		`stamp_windows_executable "$launcher_out" "Reasonix Launcher"`,
+		`stamp_windows_executable "build/windows/installer/$UPDATE_HELPER" "Reasonix Update Helper"`,
 		`cp "$launcher_out" "$staging/${APPNAME}.exe"`,
 		`cp "$guard_out" "$staging/$GUARDNAME.exe"`,
 	} {
@@ -24,13 +30,60 @@ func TestDesktopPackagesUseGuardAsDefaultLauncher(t *testing.T) {
 			t.Errorf("desktop-build.sh missing guard launcher contract %q", want)
 		}
 	}
+	launcherStamp := strings.Index(build, `stamp_windows_executable "$launcher_out" "Reasonix Launcher"`)
+	portableCopy := strings.Index(build, `cp "$launcher_out" "$staging/${APPNAME}.exe"`)
+	if launcherStamp < 0 || portableCopy < 0 || launcherStamp > portableCopy {
+		t.Fatalf("portable Reasonix.exe must copy the already-stamped launcher (stamp=%d copy=%d)", launcherStamp, portableCopy)
+	}
+
+	workflowData, err := os.ReadFile("../.github/workflows/release-desktop.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(workflowData)
+	for _, platform := range []string{"windows/amd64", "windows/arm64"} {
+		if !strings.Contains(workflow, "platform: "+platform) {
+			t.Errorf("desktop release matrix missing resource-stamped target %s", platform)
+		}
+	}
 
 	linuxData, err := os.ReadFile("build/linux/reasonix.desktop")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(linuxData), "Exec=reasonix-guard launch --detach") {
-		t.Error("Linux desktop entry does not launch through Reasonix Guard")
+	linux := string(linuxData)
+	for _, want := range []string{
+		"Exec=reasonix-guard launch --detach",
+		"Icon=reasonix-desktop",
+		"StartupWMClass=reasonix-desktop",
+	} {
+		if !strings.Contains(linux, want) {
+			t.Errorf("Linux desktop entry missing identity contract %q", want)
+		}
+	}
+	nfpmData, err := os.ReadFile("build/linux/nfpm.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nfpm := string(nfpmData)
+	for _, size := range []int{16, 24, 32, 48, 64, 128, 256, 512} {
+		asset := fmt.Sprintf("build/linux/icons/hicolor/%dx%d/apps/reasonix-desktop.png", size, size)
+		if stat, err := os.Stat(asset); err != nil || stat.Size() == 0 {
+			t.Errorf("Linux app icon %s is missing or empty", asset)
+		}
+		destination := fmt.Sprintf("/usr/share/icons/hicolor/%dx%d/apps/reasonix-desktop.png", size, size)
+		if !strings.Contains(nfpm, destination) {
+			t.Errorf("Linux package does not install %s", destination)
+		}
+	}
+	for _, want := range []string{
+		"/usr/share/applications/reasonix.desktop",
+		"/usr/share/pixmaps/reasonix-desktop.png",
+		"/usr/share/icons/hicolor/scalable/apps/reasonix-desktop.svg",
+	} {
+		if !strings.Contains(nfpm, want) {
+			t.Errorf("Linux package missing desktop identity asset %q", want)
+		}
 	}
 
 	windowsData, err := os.ReadFile("build/windows/installer/project.nsi")
@@ -39,8 +92,8 @@ func TestDesktopPackagesUseGuardAsDefaultLauncher(t *testing.T) {
 	}
 	windows := string(windowsData)
 	for _, want := range []string{
-		`CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach"`,
-		`CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach"`,
+		`CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach" "$INSTDIR\${PRODUCT_EXECUTABLE}" 0`,
+		`CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "launch --detach" "$INSTDIR\${PRODUCT_EXECUTABLE}" 0`,
 	} {
 		if !strings.Contains(windows, want) {
 			t.Errorf("Windows installer missing guard shortcut contract %q", want)

--- a/desktop/windows_update_handoff_test.go
+++ b/desktop/windows_update_handoff_test.go
@@ -78,9 +78,11 @@ func TestDesktopBuildScriptCompilesAndPackagesWindowsUpdateHelper(t *testing.T) 
 	script := string(data)
 	for _, want := range []string{
 		`UPDATE_HELPER="reasonix-update-helper.exe"`,
+		`go build -trimpath -o "$windows_resource_tool" ./cmd/windows-resource`,
 		`GOOS=windows GOARCH="$arch" go build`,
 		`./cmd/update-helper`,
 		`build/windows/installer/$UPDATE_HELPER`,
+		`stamp_windows_executable "build/windows/installer/$UPDATE_HELPER"`,
 		`cp "$helper" "$staging/$UPDATE_HELPER"`,
 	} {
 		if !strings.Contains(script, want) {

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -29,6 +29,14 @@ APPNAME="Reasonix"            # wails.json productName -> Reasonix.app
 BINNAME="reasonix-desktop"    # wails.json outputfilename -> linux binary name
 GUARDNAME="reasonix-guard"
 LAUNCHERNAME="reasonix-launcher"
+windows_resource_tool_dir=""
+
+cleanup() {
+	if [ -n "$windows_resource_tool_dir" ]; then
+		rm -rf "$windows_resource_tool_dir"
+	fi
+}
+trap cleanup EXIT
 
 cd "$ROOT/desktop"
 
@@ -46,6 +54,20 @@ build_guard() {
 	fi
 }
 
+stamp_windows_executable() {
+	local target="$1"
+	local description="$2"
+	local internal_name="$3"
+	local original_filename="$4"
+	"$windows_resource_tool" \
+		-exe "$target" \
+		-icon "$ROOT/desktop/build/windows/icon.ico" \
+		-version "$numver" \
+		-description "$description" \
+		-internal-name "$internal_name" \
+		-original-filename "$original_filename"
+}
+
 # Stamp the version resource (Windows file properties, macOS CFBundleVersion) from
 # the tag. Wails feeds info.productVersion into goversioninfo and NSIS's
 # VIFileVersion, both of which demand a strictly numeric X.X.X, so strip the
@@ -59,15 +81,22 @@ ldflags="-X main.version=$VERSION -X main.channel=$CHANNEL"
 [ "$os" = "darwin" ] && [ "${HAS_APPLE_CERT:-}" = "true" ] && ldflags="$ldflags -X main.macSelfUpdate=true"
 UPDATE_HELPER="reasonix-update-helper.exe"
 if [ "$os" = windows ]; then
+	windows_resource_tool_dir=$(mktemp -d)
+	windows_resource_tool="$windows_resource_tool_dir/reasonix-windows-resource.exe"
+	echo "==> build Windows resource stamper"
+	go build -trimpath -o "$windows_resource_tool" ./cmd/windows-resource
 	guard_out="$ROOT/desktop/build/windows/installer/$GUARDNAME.exe"
 	build_guard
+	stamp_windows_executable "$guard_out" "Reasonix Guard" "$GUARDNAME" "$GUARDNAME.exe"
 	launcher_out="$ROOT/desktop/build/windows/installer/$LAUNCHERNAME.exe"
 	echo "==> go build Windows GUI launcher"
 	(cd "$ROOT" && GOOS=windows GOARCH="$arch" CGO_ENABLED=0 go build -trimpath \
 		-ldflags="-s -w -H windowsgui -X main.version=$VERSION" -o "$launcher_out" ./cmd/reasonix-guard)
+	stamp_windows_executable "$launcher_out" "Reasonix Launcher" "$LAUNCHERNAME" "$LAUNCHERNAME.exe"
 	echo "==> go build Windows update helper"
 	GOOS=windows GOARCH="$arch" go build -trimpath -ldflags="-s -w" \
 		-o "build/windows/installer/$UPDATE_HELPER" ./cmd/update-helper
+	stamp_windows_executable "build/windows/installer/$UPDATE_HELPER" "Reasonix Update Helper" "reasonix-update-helper" "$UPDATE_HELPER"
 fi
 build_args=()
 [ "${DESKTOP_BUILD_CLEAN:-1}" != "0" ] && build_args+=(-clean)
@@ -95,6 +124,14 @@ darwin)
 	cp -R "build/bin/reasonix-desktop.app" "$app"
 	cp "$guard_out" "$app/Contents/MacOS/$GUARDNAME"
 	/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $GUARDNAME" "$app/Contents/Info.plist"
+	bundle_executable=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$app/Contents/Info.plist")
+	[ "$bundle_executable" = "$GUARDNAME" ] || { echo "macOS bundle executable is $bundle_executable, want $GUARDNAME" >&2; exit 1; }
+	bundle_icon=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$app/Contents/Info.plist")
+	case "$bundle_icon" in
+	*.icns) ;;
+	*) bundle_icon="$bundle_icon.icns" ;;
+	esac
+	[ -s "$app/Contents/Resources/$bundle_icon" ] || { echo "macOS bundle icon is missing: $bundle_icon" >&2; exit 1; }
 
 	# Two signing paths, selected by HAS_APPLE_CERT (set by release-desktop.yml when
 	# the APPLE_* secrets are present). With a real Developer ID cert + notarization
@@ -188,6 +225,12 @@ windows)
 	rm -rf "$staging"
 	;;
 linux)
+	for desktop_contract in \
+		'Exec=reasonix-guard launch --detach' \
+		'Icon=reasonix-desktop' \
+		'StartupWMClass=reasonix-desktop'; do
+		grep -F -x -q "$desktop_contract" build/linux/reasonix.desktop || { echo "Linux desktop entry missing: $desktop_contract" >&2; exit 1; }
+	done
 	tar -czf "$ROOT/dist/${APPNAME}-linux-${arch}.tar.gz" -C build/bin "$BINNAME" "$GUARDNAME"
 	# Also build a .deb for Debian/Ubuntu users (goreleaser/nfpm; see
 	# desktop/build/linux/nfpm.yaml). Human-download only: the Linux updater channel


### PR DESCRIPTION
## Summary

- stamp the Windows Guard, launcher, and update helper with the Reasonix icon, version metadata, and an `asInvoker` application manifest using the same `winres` library as Wails
- keep shortcuts targeting the recovery-aware launcher while explicitly sourcing their visible icon from the Wails desktop executable; portable `Reasonix.exe` inherits the stamped launcher resources
- add build-time resource verification for Windows amd64/arm64 plus macOS bundle icon and Linux desktop identity/package coverage

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go vet ./cmd/windows-resource`
- cross-built and resource-verified Guard, launcher, and update-helper PE files for Windows amd64 and arm64
- `DESKTOP_BUILD_SKIP_DMG=1 ./scripts/desktop-build.sh darwin/arm64 v0.0.0`
- verified the packaged macOS app has `CFBundleExecutable=reasonix-guard`, a present `iconfile.icns`, and passes `codesign --verify --deep --strict`
- `bash -n scripts/desktop-build.sh`
- Windows taskbar visual smoke remains for the native Windows release build

## Cache impact

Cache-impact: none — this only changes desktop packaging resources and platform identity checks.
Cache-guard: N/A — no provider-visible prompt, tool schema, or request serialization changes.
System-prompt-review: N/A
