### PR TITLE
Fix Windows plugin hook compatibility / 修复 Windows 插件 Hook 兼容性

### DIFF
--- a/docs/DESKTOP_HOOKS.zh-CN.md
+++ b/docs/DESKTOP_HOOKS.zh-CN.md
@@ -104,7 +104,11 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 
 `match` 是锚定正则：`"file"` 不会匹配 `read_file`，需要写成 `".*file"`。正则非法时该 hook 不会触发。
 
-`command` 会通过平台 shell 执行：macOS/Linux 使用 `sh -c`，Windows 使用 `cmd /c`。stdin 是 Reasonix 写入的一行 JSON，见下面的 payload 表。
+`command` 默认通过平台 shell 执行：macOS/Linux 使用 `sh -c`，Windows 使用
+`cmd /c`。如果 Windows hook 自己显式写了 `sh -c` 或 `bash -c`，Reasonix 会查找
+Git for Windows 自带的 Bash 并直接使用它；找不到时会返回可操作的依赖提示。Hook
+stdout/stderr 中的 Windows 旧代码页文本会转换为 UTF-8，避免中文错误信息显示成乱码。
+stdin 是 Reasonix 写入的一行 JSON，见下面的 payload 表。
 
 ## 配置里的事件 key
 

--- a/docs/DESKTOP_HOOKS.zh-CN.md
+++ b/docs/DESKTOP_HOOKS.zh-CN.md
@@ -105,10 +105,11 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 `match` 是锚定正则：`"file"` 不会匹配 `read_file`，需要写成 `".*file"`。正则非法时该 hook 不会触发。
 
 `command` 默认通过平台 shell 执行：macOS/Linux 使用 `sh -c`，Windows 使用
-`cmd /c`。如果 Windows hook 自己显式写了 `sh -c` 或 `bash -c`，Reasonix 会查找
-Git for Windows 自带的 Bash 并直接使用它；找不到时会返回可操作的依赖提示。Hook
-stdout/stderr 中的 Windows 旧代码页文本会转换为 UTF-8，避免中文错误信息显示成乱码。
-stdin 是 Reasonix 写入的一行 JSON，见下面的 payload 表。
+`cmd /c`。如果 Windows hook 自己显式写了裸命令 `sh -c` 或 `bash -c`，Reasonix
+会查找 Git for Windows 自带的 Bash 并直接使用它；带目录的显式解释器路径保持不变。
+找不到 Git Bash 时会返回可操作的依赖提示。Hook stdout/stderr 中的 Windows 旧代码页
+文本会转换为 UTF-8，避免中文错误信息显示成乱码。stdin 是 Reasonix 写入的一行 JSON，
+见下面的 payload 表。
 
 ## 配置里的事件 key
 

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -332,11 +332,12 @@ such as Superpowers and Claude-style skill packs, Reasonix maps:
   expands `${CLAUDE_PLUGIN_ROOT}` and `${REASONIX_PLUGIN_ROOT}` (plus their
   unbraced `$NAME` and Windows `%NAME%` spellings), so plugin-relative paths
   do not depend on the target shell's environment-variable syntax. On Windows,
-  an explicit `sh -c` or `bash -c` hook is routed through a discovered Git for
-  Windows Bash even when it is not on `cmd.exe`'s `PATH`; if no usable Bash is
-  installed, the hook reports a clear prerequisite error instead of the
-  localized `sh is not recognized` output. Captured legacy-code-page output is
-  normalized to UTF-8 before it reaches the UI. A `PreToolUse` or
+  a bare `sh -c` or `bash -c` hook is routed through a discovered Git for
+  Windows Bash even when it is not on `cmd.exe`'s `PATH`; an explicit
+  interpreter path remains untouched. If no usable Bash is installed, the hook
+  reports a clear prerequisite error instead of the localized `sh is not
+  recognized` output. Captured legacy-code-page output is normalized to UTF-8
+  before it reaches the UI. A `PreToolUse` or
   `UserPromptSubmit` hook can still deny via exit code 2 or its JSON deny
   shape on exit 0 (`hookSpecificOutput.permissionDecision` for `PreToolUse`,
   top-level `decision:"block"` for `UserPromptSubmit`); an imported

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -328,8 +328,15 @@ such as Superpowers and Claude-style skill packs, Reasonix maps:
   failure error text becomes `stderr`), which the official security-guidance
   plugin's commit/push checks read; other tools' responses pass through as
   the raw result. Imported hooks receive Claude-compatible snake_case stdin
-  payloads, including `hook_event_name`, and `${CLAUDE_PLUGIN_ROOT}` is
-  expanded by the host before process launch. A `PreToolUse` or
+  payloads, including `hook_event_name`. Before process launch, the host
+  expands `${CLAUDE_PLUGIN_ROOT}` and `${REASONIX_PLUGIN_ROOT}` (plus their
+  unbraced `$NAME` and Windows `%NAME%` spellings), so plugin-relative paths
+  do not depend on the target shell's environment-variable syntax. On Windows,
+  an explicit `sh -c` or `bash -c` hook is routed through a discovered Git for
+  Windows Bash even when it is not on `cmd.exe`'s `PATH`; if no usable Bash is
+  installed, the hook reports a clear prerequisite error instead of the
+  localized `sh is not recognized` output. Captured legacy-code-page output is
+  normalized to UTF-8 before it reaches the UI. A `PreToolUse` or
   `UserPromptSubmit` hook can still deny via exit code 2 or its JSON deny
   shape on exit 0 (`hookSpecificOutput.permissionDecision` for `PreToolUse`,
   top-level `decision:"block"` for `UserPromptSubmit`); an imported

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -283,8 +283,13 @@ Reasonix 的对应实现，并不代表导入 Hook 的每一种运行时决策�
   （Reasonix 的合并输出放在 `stdout`，失败错误文本作为 `stderr`），官方
   security-guidance 插件的 commit/push 检查读取的正是这些字段；其他工具的结果仍按
   原样透传。导入 Hook 的
-  stdin 使用 Claude 兼容的 snake_case 载荷（包括 `hook_event_name`），宿主会在启动
-  进程前展开 `${CLAUDE_PLUGIN_ROOT}`。`PreToolUse` 和 `UserPromptSubmit` hook 仍可
+  stdin 使用 Claude 兼容的 snake_case 载荷（包括 `hook_event_name`）。宿主会在启动
+  进程前展开 `${CLAUDE_PLUGIN_ROOT}` 和 `${REASONIX_PLUGIN_ROOT}`，也兼容不带花括号的
+  `$NAME` 与 Windows `%NAME%` 写法，因此插件相对路径不再依赖目标 shell 的环境变量
+  语法。Windows 上显式声明的 `sh -c`/`bash -c` hook 会复用 Git for Windows Bash
+  探测，即使 Bash 不在 `cmd.exe` 的 `PATH` 中也能执行；如果机器确实没有可用 Bash，
+  hook 会返回清晰的依赖提示，而不是本地化的“无法识别 sh”乱码。旧代码页输出也会在
+  进入界面前转换为 UTF-8。`PreToolUse` 和 `UserPromptSubmit` hook 仍可
   通过退出码 2 或退出码 0 时的 JSON 拒绝形态拒绝该次调用（`PreToolUse` 用
   `hookSpecificOutput.permissionDecision`，`UserPromptSubmit` 用顶层
   `decision:"block"`）；导入的 `PermissionRequest` hook 还能直接代答权限弹窗

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -286,10 +286,11 @@ Reasonix 的对应实现，并不代表导入 Hook 的每一种运行时决策�
   stdin 使用 Claude 兼容的 snake_case 载荷（包括 `hook_event_name`）。宿主会在启动
   进程前展开 `${CLAUDE_PLUGIN_ROOT}` 和 `${REASONIX_PLUGIN_ROOT}`，也兼容不带花括号的
   `$NAME` 与 Windows `%NAME%` 写法，因此插件相对路径不再依赖目标 shell 的环境变量
-  语法。Windows 上显式声明的 `sh -c`/`bash -c` hook 会复用 Git for Windows Bash
-  探测，即使 Bash 不在 `cmd.exe` 的 `PATH` 中也能执行；如果机器确实没有可用 Bash，
-  hook 会返回清晰的依赖提示，而不是本地化的“无法识别 sh”乱码。旧代码页输出也会在
-  进入界面前转换为 UTF-8。`PreToolUse` 和 `UserPromptSubmit` hook 仍可
+  语法。Windows 上显式声明的裸 `sh -c`/`bash -c` hook 会复用 Git for Windows Bash
+  探测，即使 Bash 不在 `cmd.exe` 的 `PATH` 中也能执行；带目录的显式解释器路径保持
+  不变。如果机器确实没有可用 Bash，hook 会返回清晰的依赖提示，而不是本地化的
+  “无法识别 sh”乱码。旧代码页输出也会在进入界面前转换为 UTF-8。`PreToolUse` 和
+  `UserPromptSubmit` hook 仍可
   通过退出码 2 或退出码 0 时的 JSON 拒绝形态拒绝该次调用（`PreToolUse` 用
   `hookSpecificOutput.permissionDecision`，`UserPromptSubmit` 用顶层
   `decision:"block"`）；导入的 `PermissionRequest` hook 还能直接代答权限弹窗

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -288,15 +288,25 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				for _, arg := range h.Args {
 					argv = append(argv, expandPluginRoot(arg, pkg.Root))
 				}
-				contextFile := h.ContextFile
-				if contextFile != "" && !filepath.IsAbs(contextFile) {
-					contextFile = filepath.Join(pkg.Root, filepath.FromSlash(contextFile))
+				contextFile := expandPluginRoot(h.ContextFile, pkg.Root)
+				if contextFile != "" {
+					contextFile = filepath.FromSlash(contextFile)
+					if !filepath.IsAbs(contextFile) {
+						contextFile = filepath.Join(pkg.Root, contextFile)
+					} else {
+						contextFile = filepath.Clean(contextFile)
+					}
 				}
-				cwd := h.Cwd
+				cwd := expandPluginRoot(h.Cwd, pkg.Root)
 				if cwd == "" {
 					cwd = pkg.Root
-				} else if !filepath.IsAbs(cwd) {
-					cwd = filepath.Join(pkg.Root, filepath.FromSlash(cwd))
+				} else {
+					cwd = filepath.FromSlash(cwd)
+					if !filepath.IsAbs(cwd) {
+						cwd = filepath.Join(pkg.Root, cwd)
+					} else {
+						cwd = filepath.Clean(cwd)
+					}
 				}
 				env := cloneEnv(h.Env)
 				env["REASONIX_PLUGIN_ROOT"] = pkg.Root
@@ -334,8 +344,53 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 }
 
 func expandPluginRoot(value, root string) string {
-	value = strings.ReplaceAll(value, "${CLAUDE_PLUGIN_ROOT}", root)
-	return strings.ReplaceAll(value, "$CLAUDE_PLUGIN_ROOT", root)
+	// Plugin hook manifests are host configuration, not platform-native shell
+	// scripts. Expand both compatibility names before launch so the same package
+	// works under POSIX shells, cmd.exe, and direct exec without asking each shell
+	// to understand another platform's variable syntax.
+	for _, name := range []string{"CLAUDE_PLUGIN_ROOT", "REASONIX_PLUGIN_ROOT"} {
+		value = strings.ReplaceAll(value, "${"+name+"}", root)
+		value = replaceUnbracedPluginRoot(value, name, root)
+		value = strings.ReplaceAll(value, "%"+name+"%", root)
+	}
+	return value
+}
+
+func replaceUnbracedPluginRoot(value, name, root string) string {
+	token := "$" + name
+	searchFrom := 0
+	lastWrite := 0
+	replaced := false
+	var out strings.Builder
+	for searchFrom < len(value) {
+		rel := strings.Index(value[searchFrom:], token)
+		if rel < 0 {
+			break
+		}
+		start := searchFrom + rel
+		end := start + len(token)
+		if end < len(value) && isShellVariableNameByte(value[end]) {
+			searchFrom = end
+			continue
+		}
+		if !replaced {
+			out.Grow(len(value) - len(token) + len(root))
+			replaced = true
+		}
+		out.WriteString(value[lastWrite:start])
+		out.WriteString(root)
+		lastWrite = end
+		searchFrom = end
+	}
+	if !replaced {
+		return value
+	}
+	out.WriteString(value[lastWrite:])
+	return out.String()
+}
+
+func isShellVariableNameByte(c byte) bool {
+	return c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
 }
 
 func validEvent(event Event) bool {
@@ -1099,7 +1154,10 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	cctx, cancel := context.WithTimeout(ctx, in.Timeout)
 	defer cancel()
 
-	cmd := spawnCommand(cctx, in.Command, in.Args)
+	cmd, spawnErr := spawnCommand(cctx, in.Command, in.Args)
+	if spawnErr != nil {
+		return SpawnResult{ExitCode: -1, SpawnErr: spawnErr}
+	}
 	proc.HideWindow(cmd)
 	cmd.Dir = in.Cwd
 	env := secrets.ProcessEnv()
@@ -1125,8 +1183,8 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	err := cmd.Run()
 	res := SpawnResult{
 		ExitCode:  -1,
-		Stdout:    strings.TrimSpace(outBuf.String()),
-		Stderr:    strings.TrimSpace(errBuf.String()),
+		Stdout:    decodeHookOutput(outBuf.Bytes()),
+		Stderr:    decodeHookOutput(errBuf.Bytes()),
 		Truncated: outBuf.truncated || errBuf.truncated,
 	}
 	switch {
@@ -1156,27 +1214,43 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 //   - on Windows, a recognized node -e stdin-hook command: `cmd /c` mangles
 //     quoted JS (&, %, nested quotes), which is the breakage this repair
 //     exists for, and cmd performs no POSIX-style $ expansion to preserve.
+//   - on Windows, an explicit `sh -c` / `bash -c` command: Git Bash is often
+//     installed outside cmd.exe's PATH, and direct exec preserves its quoting.
 //
 // POSIX commands that were already well-formed keep their shell semantics
 // verbatim — normalizeStaticNodeEval's rendering escapes $ and backticks, so
 // even repaired commands re-entering here behave identically under sh -c.
-func spawnCommand(ctx context.Context, command string, argv ...[]string) *exec.Cmd {
+func spawnCommand(ctx context.Context, command string, argv ...[]string) (*exec.Cmd, error) {
 	if len(argv) > 0 && argv[0] != nil {
-		return exec.CommandContext(ctx, command, argv[0]...)
+		if runtime.GOOS == "windows" {
+			if shell, args, matched, err := windowsPOSIXShellArgvInvocation(command, argv[0]); matched {
+				if err != nil {
+					return nil, err
+				}
+				return exec.CommandContext(ctx, shell, args...), nil
+			}
+		}
+		return exec.CommandContext(ctx, command, argv[0]...), nil
 	}
 	if node, flag, script, ok := repairableNodeEvalArgs(command); ok {
-		return exec.CommandContext(ctx, node, flag, script)
+		return exec.CommandContext(ctx, node, flag, script), nil
 	}
 	if powershell, args, ok := repairablePowerShellFileArgs(command); ok {
-		return exec.CommandContext(ctx, powershell, args...)
+		return exec.CommandContext(ctx, powershell, args...), nil
 	}
 	if runtime.GOOS == "windows" {
+		if shell, args, matched, err := windowsPOSIXShellInvocation(command); matched {
+			if err != nil {
+				return nil, err
+			}
+			return exec.CommandContext(ctx, shell, args...), nil
+		}
 		if node, flag, script, ok := directNodeEvalArgs(command); ok {
-			return exec.CommandContext(ctx, node, flag, script)
+			return exec.CommandContext(ctx, node, flag, script), nil
 		}
 	}
 	name, args := shellInvocation(command)
-	return exec.CommandContext(ctx, name, args...)
+	return exec.CommandContext(ctx, name, args...), nil
 }
 
 func shellInvocation(command string) (string, []string) {
@@ -1209,6 +1283,7 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func (c *cappedBuffer) Bytes() []byte  { return c.buf.Bytes() }
 func (c *cappedBuffer) String() string { return c.buf.String() }
 
 func reasonixHome(override string) string {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -309,15 +309,15 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 					}
 				}
 				env := cloneEnv(h.Env)
+				for key, value := range env {
+					env[key] = expandPluginRoot(value, pkg.Root)
+				}
 				env["REASONIX_PLUGIN_ROOT"] = pkg.Root
 				env["REASONIX_PLUGIN_NAME"] = item.Installed.Name
 				env["REASONIX_HOME"] = reasonixHomeDir
 				env["REASONIX_WORKSPACE_ROOT"] = projectRoot
 				env["CLAUDE_PROJECT_DIR"] = projectRoot
 				env["CLAUDE_PLUGIN_ROOT"] = pkg.Root
-				for key, value := range env {
-					env[key] = expandPluginRoot(value, pkg.Root)
-				}
 				if item.Installed.Version != "" {
 					env["REASONIX_PLUGIN_VERSION"] = item.Installed.Version
 				}
@@ -345,48 +345,56 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 
 func expandPluginRoot(value, root string) string {
 	// Plugin hook manifests are host configuration, not platform-native shell
-	// scripts. Expand both compatibility names before launch so the same package
-	// works under POSIX shells, cmd.exe, and direct exec without asking each shell
-	// to understand another platform's variable syntax.
-	for _, name := range []string{"CLAUDE_PLUGIN_ROOT", "REASONIX_PLUGIN_ROOT"} {
-		value = strings.ReplaceAll(value, "${"+name+"}", root)
-		value = replaceUnbracedPluginRoot(value, name, root)
-		value = strings.ReplaceAll(value, "%"+name+"%", root)
-	}
-	return value
-}
-
-func replaceUnbracedPluginRoot(value, name, root string) string {
-	token := "$" + name
-	searchFrom := 0
+	// scripts. Scan the manifest value once so text inside the resolved root is
+	// never mistaken for another placeholder and expanded recursively.
 	lastWrite := 0
 	replaced := false
 	var out strings.Builder
-	for searchFrom < len(value) {
-		rel := strings.Index(value[searchFrom:], token)
-		if rel < 0 {
-			break
-		}
-		start := searchFrom + rel
-		end := start + len(token)
-		if end < len(value) && isShellVariableNameByte(value[end]) {
-			searchFrom = end
+	for i := 0; i < len(value); {
+		tokenLen := pluginRootTokenLen(value[i:])
+		if tokenLen == 0 {
+			i++
 			continue
 		}
 		if !replaced {
-			out.Grow(len(value) - len(token) + len(root))
+			out.Grow(len(value) - tokenLen + len(root))
 			replaced = true
 		}
-		out.WriteString(value[lastWrite:start])
+		out.WriteString(value[lastWrite:i])
 		out.WriteString(root)
-		lastWrite = end
-		searchFrom = end
+		i += tokenLen
+		lastWrite = i
 	}
 	if !replaced {
 		return value
 	}
 	out.WriteString(value[lastWrite:])
 	return out.String()
+}
+
+var pluginRootTokens = [...]struct {
+	value         string
+	needsBoundary bool
+}{
+	{value: "${CLAUDE_PLUGIN_ROOT}"},
+	{value: "$CLAUDE_PLUGIN_ROOT", needsBoundary: true},
+	{value: "%CLAUDE_PLUGIN_ROOT%"},
+	{value: "${REASONIX_PLUGIN_ROOT}"},
+	{value: "$REASONIX_PLUGIN_ROOT", needsBoundary: true},
+	{value: "%REASONIX_PLUGIN_ROOT%"},
+}
+
+func pluginRootTokenLen(value string) int {
+	for _, token := range pluginRootTokens {
+		if !strings.HasPrefix(value, token.value) {
+			continue
+		}
+		if token.needsBoundary && len(value) > len(token.value) && isShellVariableNameByte(value[len(token.value)]) {
+			continue
+		}
+		return len(token.value)
+	}
+	return 0
 }
 
 func isShellVariableNameByte(c byte) bool {
@@ -1183,8 +1191,8 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 	err := cmd.Run()
 	res := SpawnResult{
 		ExitCode:  -1,
-		Stdout:    decodeHookOutput(outBuf.Bytes()),
-		Stderr:    decodeHookOutput(errBuf.Bytes()),
+		Stdout:    decodeHookOutput(outBuf.Bytes(), outBuf.truncated),
+		Stderr:    decodeHookOutput(errBuf.Bytes(), errBuf.truncated),
 		Truncated: outBuf.truncated || errBuf.truncated,
 	}
 	switch {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -448,6 +448,158 @@ func TestLoadIncludesPluginClaudeCompatibilityHooks(t *testing.T) {
 	}
 }
 
+func TestLoadExpandsReasonixPluginRootBeforeShellLaunch(t *testing.T) {
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, ".reasonix")
+	root := filepath.Join(reasonixHome, "plugins", "impeccable")
+	writeHookTestFile(t, filepath.Join(root, pluginpkg.NativeManifest), `{
+  "name": "impeccable",
+  "version": "3.9.1",
+  "hooks": {
+    "PostToolUse": [{
+      "match": "edit",
+      "command": "node \"${REASONIX_PLUGIN_ROOT}/skills/impeccable/scripts/hook.mjs\"",
+      "shellCommand": true,
+      "cwd": "${REASONIX_PLUGIN_ROOT}/work",
+      "env": {"IMPECCABLE_CACHE": "%REASONIX_PLUGIN_ROOT%/cache"}
+    }]
+  }
+}`)
+	if err := pluginpkg.Upsert(reasonixHome, pluginpkg.InstalledPlugin{
+		Name:         "impeccable",
+		Root:         "plugins/impeccable",
+		Version:      "3.9.1",
+		ManifestKind: "native",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Load(LoadOptions{HomeDir: home, ProjectRoot: "/workspace", Trusted: true})
+	if len(got) != 1 {
+		t.Fatalf("hooks = %+v, want one plugin hook", got)
+	}
+	want := `node "` + root + `/skills/impeccable/scripts/hook.mjs"`
+	if got[0].Command != want {
+		t.Fatalf("plugin command = %q, want %q", got[0].Command, want)
+	}
+	if strings.Contains(got[0].Command, "PLUGIN_ROOT") {
+		t.Fatalf("plugin root token reached the shell: %q", got[0].Command)
+	}
+	if got[0].Cwd != filepath.Join(root, "work") || got[0].Env["IMPECCABLE_CACHE"] != root+"/cache" {
+		t.Fatalf("expanded plugin cwd/env = cwd %q env %#v", got[0].Cwd, got[0].Env)
+	}
+}
+
+func TestExpandPluginRootSupportsClaudeReasonixAndCmdAliases(t *testing.T) {
+	root := `C:\Program Files\Reasonix\plugins\impeccable`
+	for _, token := range []string{
+		"${CLAUDE_PLUGIN_ROOT}", "$CLAUDE_PLUGIN_ROOT", "%CLAUDE_PLUGIN_ROOT%",
+		"${REASONIX_PLUGIN_ROOT}", "$REASONIX_PLUGIN_ROOT", "%REASONIX_PLUGIN_ROOT%",
+	} {
+		t.Run(token, func(t *testing.T) {
+			command := `node "` + token + `/skills/impeccable/scripts/hook.mjs"`
+			want := `node "` + root + `/skills/impeccable/scripts/hook.mjs"`
+			if got := expandPluginRoot(command, root); got != want {
+				t.Fatalf("expandPluginRoot(%q) = %q, want %q", token, got, want)
+			}
+		})
+	}
+	// Shell parameter expressions belong to an explicitly requested POSIX
+	// shell and must stay intact for that shell to evaluate.
+	guard := `${CLAUDE_PLUGIN_ROOT:-missing}`
+	if got := expandPluginRoot(guard, root); got != guard {
+		t.Fatalf("shell parameter expression = %q, want unchanged %q", got, guard)
+	}
+	for _, longerName := range []string{
+		"$CLAUDE_PLUGIN_ROOT_SUFFIX",
+		"$REASONIX_PLUGIN_ROOT_OLD",
+		"$CLAUDE_PLUGIN_ROOT2",
+	} {
+		if got := expandPluginRoot(longerName, root); got != longerName {
+			t.Fatalf("longer variable name %q was partially expanded to %q", longerName, got)
+		}
+	}
+	if got, want := expandPluginRoot(`$CLAUDE_PLUGIN_ROOT-child`, root), root+"-child"; got != want {
+		t.Fatalf("delimited unbraced variable = %q, want %q", got, want)
+	}
+	if got, want := expandPluginRoot(`$CLAUDE_PLUGIN_ROOT/$REASONIX_PLUGIN_ROOT`, root), root+"/"+root; got != want {
+		t.Fatalf("both root aliases = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsPOSIXShellInvocationPreservesQuotedScript(t *testing.T) {
+	command := `sh -c '[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "plugin root missing" >&2; exit 1; }'`
+	wantShell := `C:\Program Files\Git\bin\bash.exe`
+	gotShell, gotArgs, matched, err := windowsPOSIXShellInvocationWith(command, func() (string, error) {
+		return wantShell, nil
+	})
+	if err != nil || !matched {
+		t.Fatalf("explicit sh command matched=%v err=%v", matched, err)
+	}
+	if gotShell != wantShell {
+		t.Fatalf("shell = %q, want %q", gotShell, wantShell)
+	}
+	wantArgs := []string{"-c", `[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || { echo "plugin root missing" >&2; exit 1; }`}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
+func TestWindowsPOSIXShellInvocationRejectsMissingBashClearly(t *testing.T) {
+	_, _, matched, err := windowsPOSIXShellInvocationWith(`bash -lc 'printf ok'`, func() (string, error) {
+		return "", missingWindowsHookBashError()
+	})
+	if !matched || err == nil || !strings.Contains(err.Error(), "Git Bash") {
+		t.Fatalf("missing Bash matched=%v err=%v", matched, err)
+	}
+	called := false
+	_, _, matched, err = windowsPOSIXShellInvocationWith(`node hook.mjs`, func() (string, error) {
+		called = true
+		return "", nil
+	})
+	if matched || err != nil || called {
+		t.Fatalf("non-shell command matched=%v err=%v resolver_called=%v", matched, err, called)
+	}
+}
+
+func TestWindowsPOSIXShellExecFormUsesDiscoveredBash(t *testing.T) {
+	wantShell := `C:\Program Files\Git\bin\bash.exe`
+	wantArgs := []string{"-lc", `printf "%s" "$HOOK_TEST_MARKER"`}
+	gotShell, gotArgs, matched, err := windowsPOSIXShellArgvInvocationWith("sh", wantArgs, func() (string, error) {
+		return wantShell, nil
+	})
+	if err != nil || !matched || gotShell != wantShell || !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("exec-form sh = shell %q args %#v matched=%v err=%v", gotShell, gotArgs, matched, err)
+	}
+}
+
+func TestDefaultSpawnerUsesGitBashForExplicitShOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("exercises Git for Windows Bash discovery")
+	}
+	r := DefaultSpawner(context.Background(), SpawnInput{
+		Command: `sh -c 'printf "%s" "$HOOK_TEST_MARKER"'`,
+		Timeout: realSpawnTimeout,
+		Env:     map[string]string{"HOOK_TEST_MARKER": "git-bash-ok"},
+	})
+	if r.ExitCode != 0 || r.Stdout != "git-bash-ok" {
+		t.Fatalf("explicit sh hook did not run through Git Bash: %+v", r)
+	}
+}
+
+func TestDecodeHookOutputRecoversGB18030WindowsErrors(t *testing.T) {
+	want := `'sh' 不是内部或外部命令，也不是可运行的程序`
+	raw := fileencoding.Encode(want, fileencoding.GB18030)
+	if got := decodeHookOutput(raw); got != want {
+		t.Fatalf("decoded hook stderr = %q, want %q", got, want)
+	}
+	utf8Text := "Error: Cannot find module 'hook.mjs'\nNode.js v24"
+	if got := decodeHookOutput([]byte(utf8Text)); got != utf8Text {
+		t.Fatalf("UTF-8 hook stderr changed: %q", got)
+	}
+}
+
 func TestReasonixHomeOverridesGlobalHookPaths(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(t.TempDir(), "rx-home")

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -452,6 +452,7 @@ func TestLoadExpandsReasonixPluginRootBeforeShellLaunch(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(home, ".reasonix")
 	root := filepath.Join(reasonixHome, "plugins", "impeccable")
+	projectRoot := filepath.Join(home, "$CLAUDE_PLUGIN_ROOT-project")
 	writeHookTestFile(t, filepath.Join(root, pluginpkg.NativeManifest), `{
   "name": "impeccable",
   "version": "3.9.1",
@@ -475,7 +476,7 @@ func TestLoadExpandsReasonixPluginRootBeforeShellLaunch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := Load(LoadOptions{HomeDir: home, ProjectRoot: "/workspace", Trusted: true})
+	got := Load(LoadOptions{HomeDir: home, ProjectRoot: projectRoot, Trusted: true})
 	if len(got) != 1 {
 		t.Fatalf("hooks = %+v, want one plugin hook", got)
 	}
@@ -488,6 +489,9 @@ func TestLoadExpandsReasonixPluginRootBeforeShellLaunch(t *testing.T) {
 	}
 	if got[0].Cwd != filepath.Join(root, "work") || got[0].Env["IMPECCABLE_CACHE"] != root+"/cache" {
 		t.Fatalf("expanded plugin cwd/env = cwd %q env %#v", got[0].Cwd, got[0].Env)
+	}
+	if got[0].Env["CLAUDE_PROJECT_DIR"] != projectRoot || got[0].Env["REASONIX_WORKSPACE_ROOT"] != projectRoot {
+		t.Fatalf("host-provided workspace paths were expanded: %#v", got[0].Env)
 	}
 }
 
@@ -525,6 +529,15 @@ func TestExpandPluginRootSupportsClaudeReasonixAndCmdAliases(t *testing.T) {
 	}
 	if got, want := expandPluginRoot(`$CLAUDE_PLUGIN_ROOT/$REASONIX_PLUGIN_ROOT`, root), root+"/"+root; got != want {
 		t.Fatalf("both root aliases = %q, want %q", got, want)
+	}
+}
+
+func TestExpandPluginRootDoesNotReprocessResolvedRoot(t *testing.T) {
+	root := `/tmp/$REASONIX_PLUGIN_ROOT/%CLAUDE_PLUGIN_ROOT%/${CLAUDE_PLUGIN_ROOT}`
+	value := `${CLAUDE_PLUGIN_ROOT}|$REASONIX_PLUGIN_ROOT|%CLAUDE_PLUGIN_ROOT%`
+	want := root + "|" + root + "|" + root
+	if got := expandPluginRoot(value, root); got != want {
+		t.Fatalf("resolved root was expanded again: got %q, want %q", got, want)
 	}
 }
 
@@ -574,6 +587,46 @@ func TestWindowsPOSIXShellExecFormUsesDiscoveredBash(t *testing.T) {
 	}
 }
 
+func TestWindowsPOSIXShellPreservesExplicitInterpreterPaths(t *testing.T) {
+	called := false
+	resolve := func() (string, error) {
+		called = true
+		return `C:\Program Files\Git\bin\bash.exe`, nil
+	}
+	command := `"C:\Custom MSYS2\usr\bin\bash.exe" -c 'printf ok'`
+	if _, _, matched, err := windowsPOSIXShellInvocationWith(command, resolve); matched || err != nil || called {
+		t.Fatalf("explicit shell command matched=%v err=%v resolver_called=%v", matched, err, called)
+	}
+	if _, _, matched, err := windowsPOSIXShellArgvInvocationWith(`C:\Custom\bin\bash.exe`, []string{"-c", "printf ok"}, resolve); matched || err != nil || called {
+		t.Fatalf("explicit shell argv matched=%v err=%v resolver_called=%v", matched, err, called)
+	}
+}
+
+func TestHasCommandStringFlagParsesBashOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "short", args: []string{"-c", "printf ok"}, want: true},
+		{name: "short cluster", args: []string{"-lc", "printf ok"}, want: true},
+		{name: "long option containing c", args: []string{"--norc", "script.sh"}, want: false},
+		{name: "inline set option operand", args: []string{"-oc", "script.sh"}, want: false},
+		{name: "shopt before command", args: []string{"-O", "extglob", "-c", "printf ok"}, want: true},
+		{name: "set option before command", args: []string{"-o", "pipefail", "-c", "printf ok"}, want: true},
+		{name: "rcfile before command", args: []string{"--rcfile", "custom.bashrc", "-c", "printf ok"}, want: true},
+		{name: "option terminator", args: []string{"--", "-c", "printf ok"}, want: false},
+		{name: "missing command string", args: []string{"-c"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCommandStringFlag(tt.args); got != tt.want {
+				t.Fatalf("hasCommandStringFlag(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultSpawnerUsesGitBashForExplicitShOnWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("exercises Git for Windows Bash discovery")
@@ -591,12 +644,19 @@ func TestDefaultSpawnerUsesGitBashForExplicitShOnWindows(t *testing.T) {
 func TestDecodeHookOutputRecoversGB18030WindowsErrors(t *testing.T) {
 	want := `'sh' 不是内部或外部命令，也不是可运行的程序`
 	raw := fileencoding.Encode(want, fileencoding.GB18030)
-	if got := decodeHookOutput(raw); got != want {
+	if got := decodeHookOutput(raw, false); got != want {
 		t.Fatalf("decoded hook stderr = %q, want %q", got, want)
 	}
 	utf8Text := "Error: Cannot find module 'hook.mjs'\nNode.js v24"
-	if got := decodeHookOutput([]byte(utf8Text)); got != utf8Text {
+	if got := decodeHookOutput([]byte(utf8Text), false); got != utf8Text {
 		t.Fatalf("UTF-8 hook stderr changed: %q", got)
+	}
+}
+
+func TestDecodeHookOutputPreservesTruncatedUTF8Prefix(t *testing.T) {
+	raw := []byte("中文")[:5]
+	if got, want := decodeHookOutput(raw, true), "中"; got != want {
+		t.Fatalf("truncated UTF-8 output = %q, want %q", got, want)
 	}
 }
 

--- a/internal/hook/inspect.go
+++ b/internal/hook/inspect.go
@@ -203,13 +203,18 @@ func appendPluginInspect(out *Inspection, reasonixHomeDir, projectRoot string) {
 			// Keep unknown event names so diagnostics can report them.
 			for _, h := range pkg.Manifest.Hooks[eventName] {
 				count++
-				command := h.Command
+				command := expandPluginRoot(h.Command, pkg.Root)
 				if command != "" && !h.ShellCommand && !filepath.IsAbs(command) {
 					command = filepath.Join(pkg.Root, filepath.FromSlash(command))
 				}
-				contextFile := h.ContextFile
-				if contextFile != "" && !filepath.IsAbs(contextFile) {
-					contextFile = filepath.Join(pkg.Root, filepath.FromSlash(contextFile))
+				contextFile := expandPluginRoot(h.ContextFile, pkg.Root)
+				if contextFile != "" {
+					contextFile = filepath.FromSlash(contextFile)
+					if !filepath.IsAbs(contextFile) {
+						contextFile = filepath.Join(pkg.Root, contextFile)
+					} else {
+						contextFile = filepath.Clean(contextFile)
+					}
 				}
 				out.Entries = append(out.Entries, Entry{
 					Event:       event,

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -1,0 +1,121 @@
+package hook
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	fileencoding "reasonix/internal/fileutil/encoding"
+	"reasonix/internal/sandbox"
+)
+
+var windowsHookBash struct {
+	sync.Once
+	path string
+	err  error
+}
+
+// windowsPOSIXShellInvocation preserves explicit `sh -c` / `bash -c` hook
+// contracts on Windows. Git for Windows normally ships a real Bash outside the
+// cmd.exe PATH, so reuse the same hardened discovery path as the shell tool
+// instead of asking cmd.exe to find an executable it cannot see.
+func windowsPOSIXShellInvocation(command string) (string, []string, bool, error) {
+	return windowsPOSIXShellInvocationWith(command, cachedWindowsHookBash)
+}
+
+func windowsPOSIXShellArgvInvocation(command string, args []string) (string, []string, bool, error) {
+	return windowsPOSIXShellArgvInvocationWith(command, args, cachedWindowsHookBash)
+}
+
+func windowsPOSIXShellArgvInvocationWith(command string, args []string, resolve func() (string, error)) (string, []string, bool, error) {
+	if !isPOSIXShellWord(command) || !hasCommandStringFlag(args) {
+		return "", nil, false, nil
+	}
+	path, err := resolve()
+	if err != nil {
+		return "", nil, true, err
+	}
+	return path, append([]string(nil), args...), true, nil
+}
+
+func windowsPOSIXShellInvocationWith(command string, resolve func() (string, error)) (string, []string, bool, error) {
+	fields, _, _, ok := parseSimpleHookCommandFields(command)
+	if !ok || len(fields) < 3 || !isPOSIXShellWord(fields[0]) || !hasCommandStringFlag(fields[1:]) {
+		return "", nil, false, nil
+	}
+	path, err := resolve()
+	if err != nil {
+		return "", nil, true, err
+	}
+	return path, append([]string(nil), fields[1:]...), true, nil
+}
+
+func isPOSIXShellWord(word string) bool {
+	if i := strings.LastIndexAny(word, `/\`); i >= 0 {
+		word = word[i+1:]
+	}
+	word = strings.ToLower(strings.TrimSpace(word))
+	return word == "sh" || word == "sh.exe" || word == "bash" || word == "bash.exe"
+}
+
+func hasCommandStringFlag(args []string) bool {
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") || arg == "-" || arg == "--" {
+			return false
+		}
+		if strings.Contains(strings.TrimLeft(arg, "-"), "c") {
+			return true
+		}
+	}
+	return false
+}
+
+func cachedWindowsHookBash() (string, error) {
+	windowsHookBash.Do(func() {
+		shell := sandbox.ResolveShell("bash", "", nil)
+		if shell.Kind != sandbox.ShellBash {
+			windowsHookBash.err = missingWindowsHookBashError()
+			return
+		}
+		path := strings.TrimSpace(shell.Path)
+		if path == "" {
+			windowsHookBash.err = missingWindowsHookBashError()
+			return
+		}
+		if resolved, err := exec.LookPath(path); err == nil {
+			windowsHookBash.path = resolved
+			return
+		}
+		if filepath.IsAbs(path) {
+			if info, err := os.Stat(path); err == nil && !info.IsDir() {
+				windowsHookBash.path = path
+				return
+			}
+		}
+		windowsHookBash.err = missingWindowsHookBashError()
+	})
+	return windowsHookBash.path, windowsHookBash.err
+}
+
+func missingWindowsHookBashError() error {
+	return errors.New("hook requires a POSIX shell on Windows, but no usable Git Bash was found; install Git for Windows or replace the POSIX shell hook with a native portable command")
+}
+
+// decodeHookOutput keeps UTF-8-native runtimes such as Node byte-for-byte,
+// while recovering legacy Windows cmd.exe output (notably CP936/GB18030) before
+// it reaches the desktop renderer. Hook stdout/stderr are text contracts, so a
+// final valid-UTF-8 guard is safer than surfacing raw invalid bytes.
+func decodeHookOutput(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	decoded := raw
+	if !utf8.Valid(raw) {
+		decoded = fileencoding.DecodeToUTF8(raw)
+	}
+	return strings.TrimSpace(strings.ToValidUTF8(string(decoded), "\uFFFD"))
+}

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -32,7 +32,7 @@ func windowsPOSIXShellArgvInvocation(command string, args []string) (string, []s
 }
 
 func windowsPOSIXShellArgvInvocationWith(command string, args []string, resolve func() (string, error)) (string, []string, bool, error) {
-	if !isPOSIXShellWord(command) || !hasCommandStringFlag(args) {
+	if !isBarePOSIXShellWord(command) || !hasCommandStringFlag(args) {
 		return "", nil, false, nil
 	}
 	path, err := resolve()
@@ -44,7 +44,7 @@ func windowsPOSIXShellArgvInvocationWith(command string, args []string, resolve 
 
 func windowsPOSIXShellInvocationWith(command string, resolve func() (string, error)) (string, []string, bool, error) {
 	fields, _, _, ok := parseSimpleHookCommandFields(command)
-	if !ok || len(fields) < 3 || !isPOSIXShellWord(fields[0]) || !hasCommandStringFlag(fields[1:]) {
+	if !ok || len(fields) < 3 || !isBarePOSIXShellWord(fields[0]) || !hasCommandStringFlag(fields[1:]) {
 		return "", nil, false, nil
 	}
 	path, err := resolve()
@@ -54,24 +54,54 @@ func windowsPOSIXShellInvocationWith(command string, resolve func() (string, err
 	return path, append([]string(nil), fields[1:]...), true, nil
 }
 
-func isPOSIXShellWord(word string) bool {
-	if i := strings.LastIndexAny(word, `/\`); i >= 0 {
-		word = word[i+1:]
+func isBarePOSIXShellWord(word string) bool {
+	word = strings.TrimSpace(word)
+	if strings.ContainsAny(word, `/\:`) {
+		return false
 	}
-	word = strings.ToLower(strings.TrimSpace(word))
+	word = strings.ToLower(word)
 	return word == "sh" || word == "sh.exe" || word == "bash" || word == "bash.exe"
 }
 
 func hasCommandStringFlag(args []string) bool {
-	for _, arg := range args {
-		if !strings.HasPrefix(arg, "-") || arg == "-" || arg == "--" {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-" || arg == "--" || !strings.HasPrefix(arg, "-") {
 			return false
 		}
-		if strings.Contains(strings.TrimLeft(arg, "-"), "c") {
-			return true
+		if strings.HasPrefix(arg, "--") {
+			name, _, hasInlineValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+			if !hasInlineValue && bashLongOptionNeedsOperand(name) {
+				if i+1 >= len(args) {
+					return false
+				}
+				i++
+			}
+			continue
+		}
+		options := strings.TrimPrefix(arg, "-")
+		for optionIndex := 0; optionIndex < len(options); optionIndex++ {
+			switch options[optionIndex] {
+			case 'c':
+				return i+1 < len(args)
+			case 'o', 'O':
+				// -o/-O consume an option name. Any remaining bytes in this
+				// argument are that operand, not more single-letter flags.
+				if optionIndex+1 == len(options) {
+					if i+1 >= len(args) {
+						return false
+					}
+					i++
+				}
+				optionIndex = len(options)
+			}
 		}
 	}
 	return false
+}
+
+func bashLongOptionNeedsOperand(name string) bool {
+	return name == "init-file" || name == "rcfile"
 }
 
 func cachedWindowsHookBash() (string, error) {
@@ -109,13 +139,31 @@ func missingWindowsHookBashError() error {
 // while recovering legacy Windows cmd.exe output (notably CP936/GB18030) before
 // it reaches the desktop renderer. Hook stdout/stderr are text contracts, so a
 // final valid-UTF-8 guard is safer than surfacing raw invalid bytes.
-func decodeHookOutput(raw []byte) string {
+func decodeHookOutput(raw []byte, truncated bool) string {
 	if len(raw) == 0 {
 		return ""
 	}
 	decoded := raw
 	if !utf8.Valid(raw) {
-		decoded = fileencoding.DecodeToUTF8(raw)
+		if prefix, ok := truncatedUTF8Prefix(raw, truncated); ok {
+			decoded = prefix
+		} else {
+			decoded = fileencoding.DecodeToUTF8(raw)
+		}
 	}
 	return strings.TrimSpace(strings.ToValidUTF8(string(decoded), "\uFFFD"))
+}
+
+func truncatedUTF8Prefix(raw []byte, truncated bool) ([]byte, bool) {
+	if !truncated {
+		return nil, false
+	}
+	for suffixLen := 1; suffixLen < utf8.UTFMax && suffixLen <= len(raw); suffixLen++ {
+		prefix := raw[:len(raw)-suffixLen]
+		suffix := raw[len(raw)-suffixLen:]
+		if utf8.Valid(prefix) && !utf8.FullRune(suffix) {
+			return prefix, true
+		}
+	}
+	return nil, false
 }


### PR DESCRIPTION
## Summary

- Expand the Claude and Reasonix plugin-root aliases in hook commands, arguments, working directories, context files, and environment values before spawning the hook.
- Route explicit `sh`/`bash` hooks through Reasonix's hardened Git Bash discovery on Windows, and normalize legacy GB18030 hook output to valid UTF-8.
- Preserve longer shell variable names such as `$CLAUDE_PLUGIN_ROOT_SUFFIX`, expose resolved hook values during inspection, and document the supported cross-platform forms.

## Root cause

Windows `cmd.exe` does not expand POSIX-style plugin variables or provide `sh`. As a result, Node received a literal `${REASONIX_PLUGIN_ROOT}` path and explicit `sh -c` hooks failed before their scripts could run. Localized command errors could also be rendered as mojibake when their output was not UTF-8.

## Verification

- `go test ./internal/hook ./internal/pluginpkg ./internal/config`
- `go test -race ./internal/hook`
- `go vet ./internal/hook ./internal/pluginpkg`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/hook`
- `env -u DEEPSEEK_API_KEY go test ./...`
- `cd desktop && go test ./...`
- `git diff --check`

## Backward compatibility

| Area | Existing behavior | Conclusion |
| --- | --- | --- |
| Hook configuration schema | No persisted fields or formats changed | Compatible |
| Claude plugin-root alias | Existing `${CLAUDE_PLUGIN_ROOT}` behavior remains supported | Compatible |
| Reasonix plugin-root alias | Added as an alias for the same resolved plugin directory | Compatible |
| Longer environment variable names | Names such as `$CLAUDE_PLUGIN_ROOT_SUFFIX` remain untouched | Compatible |
| Non-Windows execution | Existing direct-spawn behavior is unchanged | Compatible |

## Cache impact

Cache-impact: none - the change only affects local plugin hook spawning and output decoding; provider-visible prompts, tool schemas, and ordering are unchanged.
Cache-guard: `go test ./internal/hook` covers root expansion and Windows shell normalization; no cache-sensitive paths changed.
System-prompt-review: N/A
