### PR TITLE
fix: Open desktop downloads for manual updates / 修复手动更新下载深链

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -390,7 +390,7 @@ jobs:
           f=assets/latest.json
           jq -e --arg version "$VERSION" --arg prefix "https://dl.reasonix.io/${TAG}/" '
             .version == $version and
-            .download_page == "https://reasonix.io/#start" and
+            .download_page == "https://reasonix.io/?download=desktop#start" and
             ([.platforms[] | (.url, .sig)] |
               all(type == "string" and startswith($prefix) and (contains("/releases/latest/") | not)))
           ' "$f" >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           aws configure set region auto
           aws s3 cp "s3://${R2_BUCKET}/latest/latest.json" latest.raw.json \
             --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          jq '.download_page = "https://reasonix.io/#start"' latest.raw.json > latest.json
+          jq '.download_page = "https://reasonix.io/?download=desktop#start"' latest.raw.json > latest.json
           jq -e '
             ([.platforms[] | (.url, .sig)] |
               all(type == "string" and startswith("https://dl.reasonix.io/") and (contains("/releases/latest/") | not)))

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -171,7 +171,7 @@ func genManifest(dir, version, tag string) error {
 	}
 	m := update.Manifest{
 		Version:      version,
-		DownloadPage: "https://reasonix.io/#start",
+		DownloadPage: "https://reasonix.io/?download=desktop#start",
 		Platforms:    map[string]update.Asset{},
 	}
 	entries, err := os.ReadDir(dir)

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -85,7 +85,7 @@ func TestGenManifest(t *testing.T) {
 	if m.Version != "v1.2.0" {
 		t.Fatalf("version = %q, want v1.2.0", m.Version)
 	}
-	if m.DownloadPage != "https://reasonix.io/#start" {
+	if m.DownloadPage != "https://reasonix.io/?download=desktop#start" {
 		t.Fatalf("download_page = %q, want official install page", m.DownloadPage)
 	}
 	if len(m.Platforms) != 5 {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -3766,7 +3766,7 @@ function makeMockApp(): AppBindings {
     },
     async OpenDownloadPage() {
       if (typeof window !== "undefined") {
-        window.open("https://reasonix.io/#start", "_blank", "noopener");
+        window.open("https://reasonix.io/?download=desktop#start", "_blank", "noopener");
       }
     },
     // Dev seam: drives the overlay flow in the browser until ConnectKey sets the

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -43,7 +43,7 @@ import (
 const (
 	r2Base             = "https://dl.reasonix.io"
 	releaseGatewayBase = "https://crash.reasonix.io/v1/desktop/releases"
-	downloadPageURL    = "https://reasonix.io/#start"
+	downloadPageURL    = "https://reasonix.io/?download=desktop#start"
 	httpTimeout        = 15 * time.Second
 )
 

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -142,6 +142,9 @@ func TestChannelSelectsDistinctPointers(t *testing.T) {
 	if strings.Contains(downloadPage(), "/releases/latest") {
 		t.Errorf("download page should not use GitHub's repository-wide latest release: %q", downloadPage())
 	}
+	if downloadPage() != "https://reasonix.io/?download=desktop#start" {
+		t.Errorf("download page = %q, want the desktop install deep link", downloadPage())
+	}
 }
 
 func withUpdateCacheDir(t *testing.T) string {

--- a/site/src/scripts/download-link.js
+++ b/site/src/scripts/download-link.js
@@ -1,0 +1,15 @@
+const DOWNLOAD_PANES = new Set(["npm", "brew", "desktop"]);
+
+// Return the requested install pane only for the homepage download section.
+// Plain #start links keep the default npm pane; updater links opt into desktop.
+export function downloadPaneFromURL(input, base = "https://reasonix.io/") {
+  let url;
+  try {
+    url = new URL(input, base);
+  } catch {
+    return "";
+  }
+  if (url.hash !== "#start") return "";
+  const pane = url.searchParams.get("download") || "";
+  return DOWNLOAD_PANES.has(pane) ? pane : "";
+}

--- a/site/src/scripts/download-link.test.mjs
+++ b/site/src/scripts/download-link.test.mjs
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { downloadPaneFromURL } from "./download-link.js";
+
+test("desktop updater deep link selects the desktop pane", () => {
+  assert.equal(downloadPaneFromURL("https://reasonix.io/?download=desktop#start"), "desktop");
+});
+
+test("plain install links preserve the default pane", () => {
+  assert.equal(downloadPaneFromURL("https://reasonix.io/#start"), "");
+  assert.equal(downloadPaneFromURL("https://reasonix.io/?download=desktop"), "");
+});
+
+test("recognized download panes are strict", () => {
+  assert.equal(downloadPaneFromURL("/?download=brew#start"), "brew");
+  assert.equal(downloadPaneFromURL("/?download=npm#start"), "npm");
+  assert.equal(downloadPaneFromURL("/?download=DESKTOP#start"), "");
+  assert.equal(downloadPaneFromURL("/?download=unknown#start"), "");
+  assert.equal(downloadPaneFromURL("not a url", "not a base"), "");
+});

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -1,3 +1,5 @@
+import { downloadPaneFromURL } from "./download-link.js";
+
 // Reasonix site — vanilla interactions
 (function () {
   const motionOK = () =>
@@ -81,16 +83,29 @@
     osCard.appendChild(chip);
   }
 
+  const flashOSCard = () => {
+    if (!osCard) return;
+    osCard.classList.remove("flash");
+    void osCard.offsetWidth;
+    setTimeout(() => osCard.classList.add("flash"), 450);
+    setTimeout(() => osCard.classList.remove("flash"), 2600);
+  };
+
+  const requestedPane = downloadPaneFromURL(window.location.href);
+  if (requestedPane) {
+    activatePane(requestedPane);
+    if (requestedPane === "desktop") flashOSCard();
+    requestAnimationFrame(() => {
+      document.getElementById("start")?.scrollIntoView({ block: "start" });
+      queueSweep();
+    });
+  }
+
   /* links that deep-link into a specific download tab */
   document.querySelectorAll("[data-goto]").forEach((a) => {
     a.addEventListener("click", () => {
       activatePane(a.dataset.goto);
-      if (a.hasAttribute("data-os-dl") && osCard) {
-        osCard.classList.remove("flash");
-        void osCard.offsetWidth;
-        setTimeout(() => osCard.classList.add("flash"), 450);
-        setTimeout(() => osCard.classList.remove("flash"), 2600);
-      }
+      if (a.hasAttribute("data-os-dl")) flashOSCard();
       setTimeout(queueSweep, 500);
     });
   });


### PR DESCRIPTION
## Summary

- route manual-only desktop updates to `https://reasonix.io/?download=desktop#start` instead of the generic install anchor
- make the site select the Desktop pane, scroll to the install section, and highlight the detected OS when that deep link loads
- preserve the existing plain `#start` behavior for npm/Homebrew visitors and keep updater manifests, mocks, and release validation aligned
- add focused URL parsing and updater manifest regression coverage

## Verification

- `npm --prefix site test` — 12 tests passed
- `npm --prefix site run build` — 14 pages built successfully
- `cd desktop && go test ./cmd/sign .` — passed
- `pnpm --dir desktop/frontend typecheck` — passed
- `pnpm --dir desktop/frontend check:css` — passed
- local browser: `?download=desktop#start` selected the Desktop pane, scrolled `#start` to the viewport top, detected macOS, and applied the OS-card highlight
- local browser: plain `#start` still selected the default npm pane
- `git diff --check` — passed

## Compatibility

| Contract | Existing behavior | Result |
| --- | --- | --- |
| updater manifest schema | `download_page` remains the same optional string field | compatible |
| previously published manifests | old `https://reasonix.io/#start` values still open normally | compatible |
| plain website `#start` links | npm remains the default pane | unchanged |
| older desktop clients | open the new HTTPS URL through the existing browser handoff | compatible |

## Cache impact

Cache-impact: none — this changes only the human-facing updater download URL, website tab selection, and release manifest validation; provider prompts, request serialization, tool schemas, and ordering are untouched.
Cache-guard: N/A — no provider-visible or cache-sensitive path changed; focused site, updater, and release-manifest tests cover the affected behavior.
System-prompt-review: N/A
