### PR TITLE
fix(desktop): Show MCP npm connection endpoints / 显示 MCP npm 连接端点

### DIFF
--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { MCPServersSettingsPage, PluginsSettingsPage, mcpServerDraftJSON, parseMCPServerJSON, withExplicitMCPClears } from "../components/CapabilitiesPanel";
+import { MCPServersSettingsPage, PluginsSettingsPage, failureKind, mcpServerDraftJSON, parseMCPServerJSON, summarizeServerError, withExplicitMCPClears } from "../components/CapabilitiesPanel";
 import { slashCommandGroup, slashCommandKindTag, sortSlashCommandsForMenu } from "../components/SlashMenu";
 import { selectToolsOnFirstCustomUse } from "../components/SubagentsPanel";
 import type { AppBindings } from "../lib/bridge";
@@ -56,6 +56,26 @@ const sparseEdit = withExplicitMCPClears(parseMCPServerJSON(JSON.stringify({ adm
 ok(sparseEdit.callTimeoutSeconds === 0 && sparseEdit.defaultToolsApprovalMode === "" && sparseEdit.approvalsReviewer === "", "editing an existing server with fields removed must clear those settings");
 ok(sparseEdit.autoStart === true && Object.keys(sparseEdit.toolTimeoutSeconds ?? { x: 1 }).length === 0 && sparseEdit.trustedReadOnlyTools === undefined && Object.keys(sparseEdit.tools ?? { x: 1 }).length === 0, "removed collection fields must clear while legacy trust stays absent");
 ok(sparseEdit.env === null && sparseEdit.headers === null, "absent env/headers must stay preserve-on-absent because their values are never seeded into the editor");
+
+const refusedRegistryError = [
+  'plugin "fs": read EOF: stderr:',
+  "npm error code ECONNREFUSED",
+  "npm error syscall connect",
+  "npm error FetchError: request to https://registry.npmjs.org/@modelcontextprotocol%2fserver-filesystem failed, reason: connect ECONNREFUSED 127.0.0.1:7890",
+].join("\n");
+ok(
+  summarizeServerError(refusedRegistryError) === "fs: npm ECONNREFUSED · registry.npmjs.org → 127.0.0.1:7890",
+  "npm connection failures should identify both the registry and the refused endpoint",
+);
+const credentialedRegistryError =
+  'plugin "private": stderr: npm error code ECONNREFUSED npm error request to https://build-user:registry-secret@packages.example.test/npm failed, reason: connect ECONNREFUSED proxy.internal.test:8443';
+const credentialedRegistrySummary = summarizeServerError(credentialedRegistryError);
+ok(credentialedRegistrySummary.includes("packages.example.test → proxy.internal.test:8443"), "private registries should keep actionable hosts");
+ok(!credentialedRegistrySummary.includes("build-user") && !credentialedRegistrySummary.includes("registry-secret"), "registry credentials must not appear in the summary");
+ok(
+  failureKind({ ...server("failed"), error: refusedRegistryError }) === "network",
+  "npm connection refusal should be grouped as a network/proxy issue",
+);
 
 const subagentTools = [
   { name: "read_file", description: "Read files" },

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -67,6 +67,16 @@ ok(
   summarizeServerError(refusedRegistryError) === "fs: npm ECONNREFUSED · registry.npmjs.org → 127.0.0.1:7890",
   "npm connection failures should identify both the registry and the refused endpoint",
 );
+const legacyNpmRefusedRegistryError = [
+  'plugin "fs": read EOF: stderr:',
+  "npm ERR! code ECONNREFUSED",
+  "npm ERR! syscall connect",
+  "npm ERR! FetchError: request to https://registry.npmjs.org/@modelcontextprotocol%2fserver-filesystem failed, reason: connect ECONNREFUSED 127.0.0.1:7890",
+].join("\n");
+ok(
+  summarizeServerError(legacyNpmRefusedRegistryError) === "fs: npm ECONNREFUSED · registry.npmjs.org → 127.0.0.1:7890",
+  "legacy npm ERR! failures should identify both the registry and the refused endpoint",
+);
 const credentialedRegistryError =
   'plugin "private": stderr: npm error code ECONNREFUSED npm error request to https://build-user:registry-secret@packages.example.test/npm failed, reason: connect ECONNREFUSED proxy.internal.test:8443';
 const credentialedRegistrySummary = summarizeServerError(credentialedRegistryError);

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -1274,7 +1274,7 @@ function serverStatusLabel(s: ServerView, t: ReturnType<typeof useT>): string {
 export function summarizeServerError(error: string): string {
   const normalized = error.replace(/\s+/g, " ").trim();
   const plugin = normalized.match(/plugin "([^"]+)"/i)?.[1];
-  const npmCode = normalized.match(/\bnpm error code ([A-Z0-9_]+)/i)?.[1];
+  const npmCode = normalized.match(/\bnpm (?:error|ERR!) code ([A-Z0-9_]+)/i)?.[1];
   const errno = normalized.match(/\berrno (-?\d+)/i)?.[1];
   const networkContext = npmCode ? npmNetworkContext(normalized, npmCode) : "";
   const reason = npmCode

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -1271,21 +1271,49 @@ function serverStatusLabel(s: ServerView, t: ReturnType<typeof useT>): string {
   }
 }
 
-function summarizeServerError(error: string): string {
+export function summarizeServerError(error: string): string {
   const normalized = error.replace(/\s+/g, " ").trim();
   const plugin = normalized.match(/plugin "([^"]+)"/i)?.[1];
   const npmCode = normalized.match(/\bnpm error code ([A-Z0-9_]+)/i)?.[1];
   const errno = normalized.match(/\berrno (-?\d+)/i)?.[1];
+  const networkContext = npmCode ? npmNetworkContext(normalized, npmCode) : "";
   const reason = npmCode
-    ? `npm ${npmCode}${errno ? ` (${errno})` : ""}`
+    ? `npm ${npmCode}${errno ? ` (${errno})` : ""}${networkContext}`
     : normalized.split(/(?:\.\s+|\n)/)[0];
   const summary = plugin ? `${plugin}: ${reason}` : reason;
   return summary.length > 180 ? `${summary.slice(0, 176).trim()}…` : summary;
 }
 
-type FailureKind = "auth" | "missing-command" | "command-unavailable" | "network" | "other";
+function npmNetworkContext(error: string, code: string): string {
+  if (!/^(?:ECONNREFUSED|ECONNRESET|ENETUNREACH|ETIMEDOUT|EAI_AGAIN|ENOTFOUND)$/i.test(code)) return "";
 
-function failureKind(server: ServerView): FailureKind {
+  let registry = "";
+  const requestURL = error.match(/\brequest to (https?:\/\/[^\s]+)/i)?.[1]?.replace(/[),.;]+$/, "");
+  if (requestURL) {
+    try {
+      registry = new URL(requestURL).host;
+    } catch {
+      registry = "";
+    }
+  }
+
+  let endpoint = error.match(
+    /\b(?:connect\s+)?(?:ECONNREFUSED|ECONNRESET|ENETUNREACH|ETIMEDOUT|EAI_AGAIN|ENOTFOUND)\s+((?:\[[0-9a-f:]+\]|[a-z0-9._-]+):\d{1,5})\b/i,
+  )?.[1] ?? "";
+  if (!endpoint) {
+    const address = error.match(/\baddress\s+([^\s,;]+)/i)?.[1];
+    const port = error.match(/\bport\s+(\d{1,5})\b/i)?.[1];
+    if (address && port) endpoint = `${address}:${port}`;
+  }
+
+  if (registry && endpoint && registry.toLowerCase() !== endpoint.toLowerCase()) return ` · ${registry} → ${endpoint}`;
+  if (registry || endpoint) return ` · ${registry || endpoint}`;
+  return "";
+}
+
+export type FailureKind = "auth" | "missing-command" | "command-unavailable" | "network" | "other";
+
+export function failureKind(server: ServerView): FailureKind {
   if (server.authStatus === "required") return "auth";
   const err = (server.error || "").toLowerCase();
   if (err.includes("command is required")) return "missing-command";
@@ -1303,7 +1331,13 @@ function failureKind(server: ServerView): FailureKind {
     err.includes("unauthorized") ||
     err.includes("forbidden") ||
     err.includes("timeout") ||
-    err.includes("network")
+    err.includes("network") ||
+    err.includes("econnrefused") ||
+    err.includes("econnreset") ||
+    err.includes("enetunreach") ||
+    err.includes("etimedout") ||
+    err.includes("eai_again") ||
+    err.includes("enotfound")
   ) {
     return "network";
   }


### PR DESCRIPTION
## Summary

- Preserve the credential-free npm registry host and refused connection endpoint in MCP failure summaries, so ECONNREFUSED reports identify both the intended registry and the failing proxy or network target.
- Support both current npm error output and the legacy npm ERR! format used by npm 9 / Node 18 environments.
- Classify ECONNREFUSED, ECONNRESET, ENETUNREACH, ETIMEDOUT, EAI_AGAIN, and ENOTFOUND as network issues instead of generic failures.
- Keep private-registry credentials out of the compact summary while retaining actionable host information.

## Verification

- pnpm --dir desktop/frontend test:typecheck
- pnpm --dir desktop/frontend test
- pnpm --dir desktop/frontend build
- Real npm 9.9.4 failure path: launched the filesystem MCP through an unreachable local proxy; npx returned npm ERR! ECONNREFUSED and the UI summary resolved to registry.npmjs.org → 127.0.0.1:9.
- Real success path: launched the filesystem MCP through the official npm registry; the server started on stdio and exited cleanly on EOF.

## Cache impact

Cache-impact: none — desktop-only failure presentation and grouping; no provider-visible prompt, tool schema, name, or registration-order changes.
Cache-guard: N/A — existing frontend tests cover the presentation contract; provider cache inputs are untouched.
System-prompt-review: N/A