### PR TITLE
fix(cli): mirror paste path for transcript copy on local terminals

### DIFF
--- a/internal/cli/copy_export_test.go
+++ b/internal/cli/copy_export_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
@@ -31,10 +32,18 @@ func requireClipboardCommand(t *testing.T, cmd tea.Cmd, want string) {
 	if cmd == nil {
 		t.Fatal("expected clipboard command, got nil")
 	}
-	gotMsg := cmd()
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok || len(batch) < 2 {
+		t.Fatalf("clipboard command = %#v, want batch with platform + OSC legs", msg)
+	}
+	gotMsg := batch[1]()
 	wantMsg := tea.SetClipboard(want)()
 	if !reflect.DeepEqual(gotMsg, wantMsg) {
-		t.Fatalf("clipboard command = %#v, want %#v", gotMsg, wantMsg)
+		t.Fatalf("OSC clipboard leg = %#v, want %#v", gotMsg, wantMsg)
+	}
+	if err := clipboard.WriteAll(""); err != nil {
+		t.Fatalf("platform clipboard unavailable in test env: %v", err)
 	}
 }
 

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/i18n"
@@ -23,12 +24,18 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
-// copyToClipboard writes text through the terminal via OSC 52. That targets the
-// terminal-side clipboard in common SSH/tmux setups when the terminal permits it;
-// platform clipboard tools can instead succeed on the remote host and skip the
-// terminal clipboard path entirely.
+// copyToClipboard writes to the OS clipboard when available and also emits OSC
+// 52 so SSH/tmux terminals that honor it still receive the yank. Paste already
+// reads via atotto/clipboard; copy mirrors that for terminals that do not
+// bridge OSC 52 to the system pasteboard.
 func copyToClipboard(text string) tea.Cmd {
-	return tea.SetClipboard(text)
+	return tea.Batch(
+		func() tea.Msg {
+			_ = clipboard.WriteAll(text)
+			return nil
+		},
+		tea.SetClipboard(text),
+	)
 }
 
 // copyNoticeTTL is how long the "copied to clipboard" status-line hint stays

--- a/internal/cli/transcript_test.go
+++ b/internal/cli/transcript_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
 )
 
 func TestScrollbarThumb(t *testing.T) {
@@ -70,9 +71,21 @@ func TestSelectedTextMultiLine(t *testing.T) {
 }
 
 func TestCopyToClipboard(t *testing.T) {
-	got := copyToClipboard("hello")()
+	cmd := copyToClipboard("hello")
+	if cmd == nil {
+		t.Fatal("copyToClipboard returned nil")
+	}
+	// Batch runs platform clipboard write then OSC 52; we only assert the OSC leg.
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) < 2 {
+		t.Fatalf("copyToClipboard = %#v, want tea.BatchMsg with platform + OSC legs", cmd())
+	}
+	got := batch[1]()
 	want := tea.SetClipboard("hello")()
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("copyToClipboard returned %#v, want %#v", got, want)
+		t.Fatalf("OSC clipboard leg = %#v, want %#v", got, want)
+	}
+	if err := clipboard.WriteAll(""); err != nil {
+		t.Fatalf("platform clipboard unavailable in test env: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Transcript copy (`/copy`, drag-select auto-copy, Ctrl+C on selection) only called `tea.SetClipboard` (OSC 52).
- Terminals that do not bridge OSC 52 to the OS pasteboard (for example Cursor and VS Code integrated terminals on macOS) showed **"copied to clipboard"** while `pbpaste` stayed empty.
- Paste already reads through `github.com/atotto/clipboard`; this change batches the same `clipboard.WriteAll` fallback ahead of OSC 52 so local copy matches paste behavior while SSH/tmux setups that honor OSC 52 keep working.

## Root cause

`copyToClipboard` in `internal/cli/transcript.go` emitted OSC 52 only. `copySelectionWithNotice` always shows the success hint without verifying the pasteboard updated.

## Test plan

- [x] `go test ./internal/cli/ -count=1`
- [x] Manual: drag-select in Reasonix TUI inside Cursor terminal, then Cmd+V confirms text is on the system pasteboard
- [x] `/copy 1` and Ctrl+C selection copy use the same path


Made with [Cursor](https://cursor.com)