### PR TITLE
feat(desktop): add line numbers to workspace file preview

### DIFF
--- a/desktop/frontend/src/components/CodeViewer.tsx
+++ b/desktop/frontend/src/components/CodeViewer.tsx
@@ -5,6 +5,7 @@ export interface EditorProps {
   language?: string;
   readOnly?: boolean;
   maxHeight?: number;
+  showLineNumbers?: boolean;
 }
 
 // ── EDITOR SEAM (code) ───────────────────────────────────────────────────────

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -1612,7 +1612,7 @@ export function WorkspacePanel({
               {isMarkdown ? (
                 <Markdown text={preview.body} />
               ) : (
-                <CodeViewer value={preview.body || " "} language={languageFor(selectedPath)} />
+                <CodeViewer value={preview.body || " "} language={languageFor(selectedPath)} showLineNumbers />
               )}
             </>
           ) : null}

--- a/desktop/frontend/src/components/editors/HljsCode.tsx
+++ b/desktop/frontend/src/components/editors/HljsCode.tsx
@@ -7,13 +7,44 @@ import { CopyButton } from "../CopyButton";
 // renders highlight.js token markup into a <pre>; token colors live in styles.css
 // (.hljs-*). To upgrade to a full editor, point CodeViewer.tsx's lazy import at a
 // Monaco/CodeMirror module honoring the same EditorProps.
-const HljsCode = memo(function HljsCode({ value, language, maxHeight }: EditorProps) {
+const HljsCode = memo(function HljsCode({ value, language, maxHeight, showLineNumbers }: EditorProps) {
   const html = useMemo(() => highlightToHtml(value, language), [value, language]);
+
+  if (!showLineNumbers) {
+    return (
+      <div className="code-block__wrap">
+        <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
+          <code dangerouslySetInnerHTML={{ __html: html }} />
+        </pre>
+        <CopyButton text={value} className="code-block__copy" />
+      </div>
+    );
+  }
+
+  const codeLines = html.split("\n");
+  const lineCount = codeLines.length;
+  const gutterWidth = lineCount >= 10000 ? "5ch" : lineCount >= 1000 ? "4ch" : "3ch";
+
   return (
     <div className="code-block__wrap">
-      <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
-        <code dangerouslySetInnerHTML={{ __html: html }} />
-      </pre>
+      <div
+        className="code code--ln hljs"
+        data-lang={language}
+        role="list"
+        style={maxHeight ? { maxHeight } : undefined}
+      >
+        {codeLines.map((lineHtml, i) => (
+          <div key={i} className="code-block__ln-row" role="listitem">
+            <span className="code-block__ln-gutter" style={{ minWidth: gutterWidth }}>
+              {i + 1}
+            </span>
+            <code
+              className="code-block__ln-code"
+              dangerouslySetInnerHTML={{ __html: lineHtml || "\u00A0" }}
+            />
+          </div>
+        ))}
+      </div>
       <CopyButton text={value} className="code-block__copy" />
     </div>
   );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4727,6 +4727,40 @@ a[href] {
   position: relative;
 }
 
+/* ── Line-numbered code view (#6557) ──────────────────────────────────────── */
+.code--ln {
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}
+.code-block__ln-row {
+  display: flex;
+  min-height: 1.55em;
+  line-height: 1.55;
+  font-family: var(--font-mono);
+  font-size: inherit;
+}
+.code-block__ln-row:hover {
+  background: var(--bg-hover);
+}
+.code-block__ln-gutter {
+  flex: 0 0 auto;
+  text-align: right;
+  padding-right: 12px;
+  color: var(--color-text-muted);
+  user-select: none;
+  border-right: 1px solid var(--border-soft);
+  margin-right: 8px;
+  opacity: 0.6;
+}
+.code-block__ln-code {
+  flex: 1 1 auto;
+  white-space: pre;
+  word-break: normal;
+  overflow: hidden;
+  display: block;
+}
+
 /* ── Mermaid diagram renderer ───────────────────────────────────────────── */
 .mermaid-diagram {
   position: relative;


### PR DESCRIPTION
## Summary

Adds line numbers to workspace file previews, addressing issue #6557.

### Changes

| File | Change |
|------|--------|
| `CodeViewer.tsx` | `EditorProps` adds `showLineNumbers?: boolean` |
| `HljsCode.tsx` | When `showLineNumbers` is true, renders each line as a flex row with a line-number gutter |
| `styles.css` | New CSS classes for line-numbered code view |
| `WorkspacePanel.tsx` | File preview passes `showLineNumbers` |

### Design decisions

- Only workspace file previews show line numbers — diff views, tool results, and markdown code blocks remain unchanged
- Gutter width adapts to line count (3ch / 4ch / 5ch)
- Hover highlighting on each row for visual tracking
- Line numbers are `user-select: none` — Ctrl+A still only copies code, not line numbers
- No search feature (browser Ctrl+F covers that, as per @Crayzzze's original issue suggestion)

### Verification

- `pnpm build` passes with no errors
- TypeScript `tsc --noEmit` passes with no errors

Closes #6557