### PR TITLE
fix(desktop): stop same-process lease rebuild thrash; keep stale-turn watchdog alive

### DIFF
--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -239,6 +239,13 @@ func (a *App) retryDeferredStartupBuild(tabID string, tab *WorkspaceTab) {
 		a.clearDeferredRebuild(tabID)
 		return
 	}
+	// Attach first when another same-process tab/detached runtime owns this
+	// session; looksFree would otherwise wait forever under the same-process
+	// hold (#6568).
+	if path := a.deferredRebuildSessionPath(tab); path != "" && a.attachExistingSessionRuntime(tab, path, a.ctx) {
+		a.clearDeferredRebuild(tabID)
+		return
+	}
 	if !a.deferredRebuildLeaseLooksFree(tab) {
 		return
 	}
@@ -331,6 +338,10 @@ func (a *App) tryRecoverStartupLeaseHeldTab(tab *WorkspaceTab) bool {
 	if !a.tabHasRetryableStartupLeaseError(tab) {
 		return a.controllerForTab(tab) != nil
 	}
+	if path := a.deferredRebuildSessionPath(tab); path != "" && a.attachExistingSessionRuntime(tab, path, a.ctx) {
+		a.clearDeferredRebuild(tab.ID)
+		return a.controllerForTab(tab) != nil
+	}
 	if !a.deferredRebuildLeaseLooksFree(tab) {
 		return false
 	}
@@ -347,13 +358,10 @@ func (a *App) tryRecoverStartupLeaseHeldTab(tab *WorkspaceTab) bool {
 	return false
 }
 
-// deferredRebuildLeaseLooksFree cheaply probes whether the tab's session lease
-// could be acquired right now, without touching tab.sessionLease (only the
-// serialized rebuild paths may mutate that). The probe path can lag the
-// reconciled path the rebuild will use; a stale answer either re-defers on the
-// next tick or lets the rebuild fail back into the pending set, so a mismatch
-// only delays the retry.
-func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
+func (a *App) deferredRebuildSessionPath(tab *WorkspaceTab) string {
+	if tab == nil {
+		return ""
+	}
 	a.mu.RLock()
 	ctrl := tab.Ctrl
 	path := strings.TrimSpace(tab.SessionPath)
@@ -363,6 +371,17 @@ func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
 			path = p
 		}
 	}
+	return path
+}
+
+// deferredRebuildLeaseLooksFree cheaply probes whether the tab's session lease
+// could be acquired right now, without touching tab.sessionLease (only the
+// serialized rebuild paths may mutate that). The probe path can lag the
+// reconciled path the rebuild will use; a stale answer either re-defers on the
+// next tick or lets the rebuild fail back into the pending set, so a mismatch
+// only delays the retry.
+func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
+	path := a.deferredRebuildSessionPath(tab)
 	if path == "" {
 		return true // nothing to probe; let the rebuild decide
 	}
@@ -371,10 +390,12 @@ func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
 		var leaseErr *agent.SessionLeaseError
 		if errors.As(err, &leaseErr) && leaseErr.Info != nil && leaseErr.Info.PID == os.Getpid() {
 			if host, _ := os.Hostname(); leaseErr.Info.Hostname == host {
-				// This process (usually this very tab) holds the probed path;
-				// the blocking lease is some other path. Attempt the rebuild
-				// and let its own lease checks decide.
-				return true
+				// Same-process hold: settings refresh (Ctrl set) owns its lease → proceed.
+				// Startup (Ctrl nil) must wait quietly after attach was tried (#6568).
+				a.mu.RLock()
+				hasCtrl := tab != nil && tab.Ctrl != nil
+				a.mu.RUnlock()
+				return hasCtrl
 			}
 		}
 		return !errors.Is(err, agent.ErrSessionLeaseHeld)

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2282,25 +2282,23 @@ export function useController() {
   // turn stream has gone quiet, reconcile with the backend. This catches cases
   // where the Wails event channel silently drops turn_done after the final
   // message or synthetic todo update has already closed the live stream.
+  // Use an interval, not a one-shot timer: activity timestamps advance on each
+  // text/tool event, so a single timeout scheduled at turn start often fires
+  // while the stream is still healthy and then never reschedules (#6569).
   useEffect(() => {
     if (!activeTabId) return;
     const s = statesRef.current.get(activeTabId);
-    const now = Date.now();
-    const lastTurnActivityAt = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
-    if (!s?.running || !s.turnActive || lastTurnActivityAt <= 0) return;
-    const since = Math.max(0, now - lastTurnActivityAt);
-    if (shouldReconcileStaleTurn(s, lastTurnActivityAt, now)) {
-      void reconcileTabRuntime(activeTabId);
-      return;
-    }
-    const timer = window.setTimeout(() => {
+    if (!s?.running || !s.turnActive) return;
+    const tick = () => {
       const cur = statesRef.current.get(activeTabId);
       const lastActivity = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
       if (shouldReconcileStaleTurn(cur, lastActivity)) {
         void reconcileTabRuntime(activeTabId);
       }
-    }, STALE_TURN_RECONCILE_MS - since);
-    return () => window.clearTimeout(timer);
+    };
+    tick();
+    const timer = window.setInterval(tick, STALE_TURN_RECONCILE_MS);
+    return () => window.clearInterval(timer);
   }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.turnActive]);
 
   // Replay any pending approval/ask prompts when switching tabs, so a

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -1069,6 +1069,75 @@ func TestTabAndCtrlByIDRecoversStartupLeaseBeforeAction(t *testing.T) {
 	}
 }
 
+// Same-process lease holders must not drive rebuildStartupTabLocked every tick:
+// that path clears StartupErr then re-sets it, which flashes the topbar banner
+// forever (#6568). The retry loop should wait quietly (and prefer attach).
+func TestDeferredStartupRetryDoesNotRebuildWhileSameProcessHoldsLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	prevInterval := deferredRebuildRetryInterval
+	deferredRebuildRetryInterval = 20 * time.Millisecond
+	t.Cleanup(func() { deferredRebuildRetryInterval = prevInterval })
+
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "startup-same-process.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write placeholder session: %v", err)
+	}
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	t.Cleanup(lease.Release)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.enableDeferredRebuildRetry()
+	t.Cleanup(app.stopDeferredRebuildRetry)
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "startup_same_process")
+	tab.SessionPath = path
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	installNoopRuntimeEvents(app, tab.sink)
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.buildTabController(tab)
+	if tab.Ctrl != nil {
+		t.Fatalf("controller = %T, want nil while same-process lease is held", tab.Ctrl)
+	}
+	if !tab.StartupErrLeaseHeld {
+		t.Fatalf("startup retry flag = false, startup err = %q", tab.StartupErr)
+	}
+	if !app.deferredRebuildPending(tab.ID) {
+		t.Fatal("startup retry was not scheduled while the lease was held")
+	}
+	firstErr := tab.StartupErr
+	if firstErr == "" {
+		t.Fatal("startup error empty after lease-held build")
+	}
+
+	// Several retry ticks must not clear the banner or rebuild (no Ready flip).
+	for i := 0; i < 5; i++ {
+		app.retryDeferredStartupBuild(tab.ID, tab)
+		if tab.Ctrl != nil {
+			t.Fatalf("tick %d rebuilt controller while same-process lease still held", i)
+		}
+		if !tab.StartupErrLeaseHeld {
+			t.Fatalf("tick %d cleared StartupErrLeaseHeld", i)
+		}
+		if tab.StartupErr != firstErr {
+			t.Fatalf("tick %d changed StartupErr from %q to %q (banner thrash)", i, firstErr, tab.StartupErr)
+		}
+		if !app.deferredRebuildPending(tab.ID) {
+			t.Fatalf("tick %d dropped deferred retry while foreign same-process holder remains", i)
+		}
+	}
+}
+
 func TestOpenGlobalTabResolvesTopicToLatestSessionRuntime(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := desktopSessionDir(globalTabWorkspaceRoot())


### PR DESCRIPTION
## Summary

Two desktop reliability fixes:

### #6568 — deferred startup rebuild thrash
When a session lease was held by **this same process** (active controller / detached runtime), deferred startup rebuild treated the lease as free, ran `rebuildStartupTabLocked`, cleared `StartupErr`, failed `ensureSessionLease` again, and rescheduled. The topbar “session already open…” banner flashed every ~2s forever.

- Prefer `attachExistingSessionRuntime` before probing/rebuilding.
- Same-process hold with `Ctrl == nil` waits quietly after attach fails.
- Settings refresh path (`Ctrl != nil`) still proceeds so the tab’s own lease can no-op.

### #6569 — stale-turn watchdog dies after one fire
The frontend stale-turn reconciler used a one-shot `setTimeout`. Activity timestamps advance during streaming, so the timer often fired while healthy and **never rescheduled** after a later quiet drop (sleep/resume, Wails EventsOn drop, etc.).

- Switch the watchdog to `setInterval` while `running && turnActive`.
- Scope: keeps status reconcile alive after quiet. Does **not** re-subscribe EventsOn or re-stream mid-turn tokens; that remains a follow-up if needed.

## Changes

- `desktop/deferred_rebuild.go`: attach-first + same-process wait for startup retries
- `desktop/tabs_order_test.go`: `TestDeferredStartupRetryDoesNotRebuildWhileSameProcessHoldsLease`
- `desktop/frontend/src/lib/useController.ts`: interval stale-turn watchdog

## Cache impact

- Cache-impact: none — desktop lease retry / frontend reconcile only; no system prompt, memory prefix, provider request shape, or skill index changes.
- Cache-guard: N/A
- System-prompt-review: N/A

## Test plan

- [x] `go test ./desktop -run "TestDeferredStartupRetry|TestTabAndCtrlByIDRecoversStartupLease|TestBuildTabControllerBlocksWhenSessionLeaseHeld" -count=1`
- [x] `pnpm exec tsx src/__tests__/use-controller-meta.test.ts` (stale-turn helpers)
- [ ] CI full matrix on PR
- [ ] Manual: hold session lease in-process → deferred startup no longer flashes banner every 2s
- [ ] Manual: long turn / sleep-resume → quiet stream still reconciles running state without full page refresh

Fixes #6568
Fixes #6569
