### PR TITLE
feat(release): add reviewed bilingual product changelog / 增加经审阅的中英产品更新日志

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy site
 on:
   push:
     branches: [main-v2]
-    paths: ['site/**', '.github/workflows/pages.yml']
+    paths: ['site/**', 'release-notes/**', '.github/workflows/pages.yml']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -1,0 +1,83 @@
+name: Prepare release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without a tag prefix (for example 1.18.0)"
+        required: true
+        type: string
+      from_tag:
+        description: "Previous release tag (defaults to the newest catalog entry)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft:
+    name: generate reviewable bilingual draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Prepare the release-notes branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          branch="release-notes/v${VERSION#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch" main-v2
+            git checkout -b "$branch" --track "origin/$branch"
+            git merge --no-edit origin/main-v2
+          else
+            git checkout -b "$branch"
+          fi
+          echo "RELEASE_NOTES_BRANCH=$branch" >> "$GITHUB_ENV"
+
+      - name: Generate and validate release notes
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: deepseek-v4-pro
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          FROM_TAG: ${{ inputs.from_tag }}
+        run: |
+          set -euo pipefail
+          args=(--version "$VERSION")
+          if [ -n "$FROM_TAG" ]; then args+=(--from "$FROM_TAG"); fi
+          node scripts/generate-release-notes.mjs "${args[@]}"
+          node scripts/release-notes.mjs validate
+          node --test scripts/release-notes.test.mjs
+          node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md
+
+      - name: Open or update the review PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git add release-notes/releases.json
+          if ! git diff --cached --quiet; then
+            git commit -m "docs(release): prepare v${VERSION#v} notes" \
+              -m "Generate a bilingual, product-focused draft from merged pull request metadata. The reviewed catalog will drive the website, desktop app, and GitHub releases."
+          fi
+          git push -u origin "$RELEASE_NOTES_BRANCH"
+          if ! gh pr list --head "$RELEASE_NOTES_BRANCH" --state open --json number --jq 'length > 0' | grep -q true; then
+            gh pr create \
+              --base main-v2 \
+              --head "$RELEASE_NOTES_BRANCH" \
+              --title "docs(release): 准备 v${VERSION#v} 中英更新日志" \
+              --body-file /tmp/release-notes.md
+          fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -236,6 +236,10 @@ jobs:
           cache: true
           cache-dependency-path: desktop/go.sum
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
       - uses: actions/download-artifact@v8
         with:
           path: dist
@@ -262,6 +266,10 @@ jobs:
       # Canary never appears on the GitHub releases page; the mirror job picks up
       # the signed dist via the canary-dist artifact below. Stable publishes a
       # GitHub release as usual.
+      - name: Render reviewed release notes
+        if: steps.ver.outputs.channel != 'canary'
+        run: node scripts/release-notes.mjs render --version "${{ steps.ver.outputs.version }}" --output /tmp/release-notes.md
+
       - name: Publish GitHub release
         if: steps.ver.outputs.channel != 'canary'
         env:
@@ -269,7 +277,7 @@ jobs:
         run: |
           # Keep the repository homepage focused on the installable desktop app;
           # the CLI release line is configured not to claim repository-wide latest.
-          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
+          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --notes-file /tmp/release-notes.md)
           if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then
             args+=(--prerelease --latest=false)
           else

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,26 @@
+name: Release notes
+
+on:
+  pull_request:
+    paths:
+      - "release-notes/**"
+      - "scripts/release-notes*.mjs"
+      - "site/src/pages/changelog/**"
+      - "site/src/components/ChangelogPage.astro"
+      - "desktop/frontend/src/App.tsx"
+      - "desktop/frontend/src/components/SettingsPanel.tsx"
+      - "desktop/frontend/src/components/UpdateBanner.tsx"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - run: node scripts/release-notes.mjs validate
+      - run: node --test scripts/release-notes.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Render reviewed release notes
+        run: node scripts/release-notes.mjs render --version "${{ github.ref_name }}" --output /tmp/release-notes.md
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
@@ -50,6 +55,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Publish product release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: gh release edit "$TAG" --notes-file /tmp/release-notes.md
 
       - name: Attach desktop manifest compatibility asset
         env:

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -39,7 +39,7 @@ import { useWailsResizeFix } from "./lib/useWailsResizeFix";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT, type Translator } from "./lib/i18n";
 import { localizedNoticeText, useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
 import { NoticeCard, Transcript } from "./components/Transcript";
@@ -3831,7 +3831,13 @@ export default function App() {
             <div className="banner banner--warning">{t("guard.safeMode")}</div>
           )}
 
-          <UpdateBanner enabled={startupUpdateChecksEnabled === true} />
+          <UpdateBanner
+            enabled={startupUpdateChecksEnabled === true}
+            onShowReleaseNotes={(latest) => {
+              const version = latest.replace(/^(?:desktop-)?v/, "");
+              void openExternal(`https://reasonix.io/changelog/v${version}/`);
+            }}
+          />
 
           <main className="main">
             {sidebarImDetailConnection ? (

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,8 +1,8 @@
 import { lazy, memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
-import { Bot as BotIcon, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, GripVertical, KeyRound, Loader2, MessageCircle, Minus, Play, Plus, QrCode, RefreshCw, RotateCcw, Send } from "lucide-react";
+import { Bot as BotIcon, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, ExternalLink, GripVertical, KeyRound, Loader2, MessageCircle, Minus, Play, Plus, QrCode, RefreshCw, RotateCcw, Send } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useDeferredClose } from "../lib/useMountTransition";
-import { app } from "../lib/bridge";
+import { app, openExternal } from "../lib/bridge";
 import { normalizeLangPref, useI18n, useT, type DictKey, type LangPref } from "../lib/i18n";
 import { apiKeyEnvFromProviderName, inferredVisionModels, mergedFetchedProviderModels, providerApiKeyEnvForSave, providerDefaultModel, providerIsConfigured, providerModelCandidates, providerRequiresKey } from "../lib/providerModels";
 import { useUpdater } from "../lib/useUpdater";
@@ -6968,6 +6968,16 @@ function UpdatesSection({
           {t("settings.config", { path: configPath })}
         </Tooltip>
       )}
+      <SettingsField
+        className="settings-field--wide-copy"
+        label={t("changelog.title")}
+        hint={t("changelog.subtitle")}
+      >
+        <button className="btn btn--small" onClick={() => void openExternal("https://reasonix.io/changelog/")}>
+          {t("changelog.openWeb")}
+          <ExternalLink size={14} aria-hidden="true" />
+        </button>
+      </SettingsField>
     </SettingsSection>
   );
 }

--- a/desktop/frontend/src/components/UpdateBanner.tsx
+++ b/desktop/frontend/src/components/UpdateBanner.tsx
@@ -11,7 +11,13 @@ const mb = (n: number) => (n / MB).toFixed(1);
 // or already current — a quiet auto-check that only surfaces when actionable. A
 // failed check can be dismissed here (network blips shouldn't pin the UI); the
 // Settings panel is where a manual check shows errors inline.
-export function UpdateBanner({ enabled = true }: { enabled?: boolean }) {
+export function UpdateBanner({
+  enabled = true,
+  onShowReleaseNotes,
+}: {
+  enabled?: boolean;
+  onShowReleaseNotes?: (version: string) => void;
+}) {
   const t = useT();
   const { status, check, download, install, reset } = useUpdater();
   const [dismissed, setDismissed] = useState<string | null>(null);
@@ -32,6 +38,11 @@ export function UpdateBanner({ enabled = true }: { enabled?: boolean }) {
           <span className="banner__msg">{t("updater.available", { v: info.latest })}</span>
           {!info.canSelfUpdate && <span className="banner__hint">{info.manualReason || t("updater.macHint")}</span>}
           <span className="banner__spacer" />
+          {onShowReleaseNotes && (
+            <button className="btn btn--small" onClick={() => onShowReleaseNotes(info.latest)}>
+              {t("updater.releaseNotes")}
+            </button>
+          )}
           <button className="btn btn--small btn--primary" onClick={() => download(info)}>
             {info.canSelfUpdate ? t("updater.downloadUpdate") : t("updater.goToDownload")}
           </button>
@@ -60,6 +71,11 @@ export function UpdateBanner({ enabled = true }: { enabled?: boolean }) {
         <div className="banner banner--update">
           <span className="banner__msg">{t("updater.downloaded", { v: status.info.latest })}</span>
           <span className="banner__spacer" />
+          {onShowReleaseNotes && (
+            <button className="btn btn--small" onClick={() => onShowReleaseNotes(status.info.latest)}>
+              {t("updater.releaseNotes")}
+            </button>
+          )}
           <button className="btn btn--small btn--primary" onClick={install}>
             {t("updater.restartInstall")}
           </button>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2284,6 +2284,9 @@ export const en = {
   "updater.failed": "Update failed: {msg}",
   "updater.retry": "Retry",
   "updater.dismiss": "Later",
+  "changelog.title": "Release notes",
+  "changelog.subtitle": "A product-focused history of new capabilities, improvements, fixes, and upgrade guidance.",
+  "changelog.openWeb": "Open on web",
 
   // onboarding — first-run API-key overlay
   "onboarding.title": "Connect Reasonix",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1530,6 +1530,9 @@ export const zhTW: Record<DictKey, string> = {
   "updater.failed": "更新失敗：{msg}",
   "updater.retry": "重試",
   "updater.dismiss": "稍後",
+  "changelog.title": "更新日誌",
+  "changelog.subtitle": "依產品能力整理新功能、改進、修復與升級提醒，不再只是提交記錄。",
+  "changelog.openWeb": "在網頁查看",
 
   // onboarding — first-run API-key overlay
   "onboarding.title": "連線 Reasonix",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2286,6 +2286,9 @@ export const zh: Record<DictKey, string> = {
   "updater.failed": "更新失败：{msg}",
   "updater.retry": "重试",
   "updater.dismiss": "稍后",
+  "changelog.title": "更新日志",
+  "changelog.subtitle": "按产品能力整理新功能、改进、修复与升级提醒，不再只是提交记录。",
+  "changelog.openWeb": "在网页查看",
 
   // onboarding — first-run API-key overlay
   "onboarding.title": "连接 Reasonix",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,14 +43,24 @@ the `release` environment deployment.
 ## The release loop
 
 1. **Develop** — PRs land on `main-v2` (branch auto-deletes on merge).
-2. **Cut a canary** before the intended release (e.g. heading for `1.4.0`):
+2. **Prepare the release notes** — Actions → **Prepare release notes**. Enter the
+   intended version and, when needed, the previous desktop tag. The workflow sends
+   only public merged-PR metadata to DeepSeek, creates equivalent English and Chinese
+   product notes, validates their structure and citations, and opens a review PR.
+   Review and edit that PR like product copy. Once merged, the same catalog entry
+   drives `/changelog/` and both CLI and Desktop GitHub Releases; the desktop
+   app links to that web history from Settings → Updates. A missing catalog
+   entry blocks stable publication.
+3. **Cut a canary** before the intended release (e.g. heading for `1.4.0`):
    - Desktop: Actions → **Release desktop** → `channel: canary`, `base_version: 1.4.0`
    - CLI: Actions → **Release npm** → `base_version: 1.4.0`
    - Publishes `1.4.0-canary.N` to the desktop R2 `canary/` pointer (no GitHub release) and npm `@canary`.
-3. **Test** — testers install `reasonix@canary` (CLI) or grab the desktop canary
+4. **Test** — testers install `reasonix@canary` (CLI) or grab the desktop canary
    build from its R2 link, and report bugs.
-4. **Fix** on `main-v2` via PRs; re-cut the canary as needed (`canary.N` bumps).
-5. **Ship stable** when the canary is clean — push the three tags:
+5. **Fix** on `main-v2` via PRs; re-cut the canary as needed (`canary.N` bumps).
+   Re-run **Prepare release notes** after material fixes; it updates the same branch
+   and PR without publishing anything.
+6. **Ship stable** when the canary is clean and the release-notes PR is merged — push the three tags:
    ```sh
    git tag v1.4.0         && git push origin v1.4.0          # CLI binaries + Homebrew
    git tag npm-v1.4.0     && git push origin npm-v1.4.0      # npm -> latest
@@ -64,7 +74,7 @@ the `release` environment deployment.
    `npm update -g` silently downgraded users to 0.53.2 (#5822). A pushed tag whose
    publish is still awaiting approval only warns; release-npm.yml's verify step
    owns asserting the dist-tag lands.
-6. **Next cycle** — the canary rolls on toward `1.5.0`.
+7. **Next cycle** — the canary rolls on toward `1.5.0`.
 
 ## Notes
 
@@ -78,6 +88,9 @@ the `release` environment deployment.
   older desktop builds that still use GitHub `latest` do not 404.
 - Canary uses R2 plus the same gateway proxy for the `canary/` pointer; it never
   appears on the GitHub releases page.
+- DeepSeek is an editorial drafting dependency, not a runtime or publishing dependency.
+  The API key is available only to the manually dispatched preparation workflow; tag
+  workflows publish the reviewed JSON already committed to `main-v2` and never call a model.
 - Windows and Linux apply downloaded, minisign-verified artifacts in place. macOS
   applies in-app only for Developer ID signed and notarized builds; ad-hoc/local
   builds fall back to the download page.

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -1,0 +1,305 @@
+{
+  "schemaVersion": 1,
+  "releases": [
+    {
+      "version": "1.17.13",
+      "date": "2026-07-16",
+      "channel": "stable",
+      "title": {
+        "en": "A safer delivery loop, trusted MCP execution, and offline recovery",
+        "zh": "交付链路、MCP 可信执行与离线恢复的系统加固"
+      },
+      "summary": {
+        "en": "This release makes long-running work safer from planning through delivery. It adds an offline recovery Guard and Safe Mode, hardens MCP package identity and credentials, improves Claude plugin compatibility, and polishes the desktop and CLI workflows used every day.",
+        "zh": "这一版把从计划到交付的长任务链路做得更可靠：新增离线恢复 Guard 与安全模式，加固 MCP 包身份、凭据与可信执行，完善 Claude 插件兼容，并集中打磨 Desktop 与 CLI 的高频工作流。"
+      },
+      "surfaces": ["agent", "desktop", "cli", "mcp", "security"],
+      "guides": [
+        {
+          "title": { "en": "Recover a broken installation", "zh": "恢复损坏的安装" },
+          "body": {
+            "en": "Use reasonix-guard to diagnose configuration and installation failures, restore a snapshot, or start in Safe Mode.",
+            "zh": "使用 reasonix-guard 诊断配置与安装故障、恢复快照，或进入安全模式。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/docs/RECOVERY.zh-CN.md"
+        },
+        {
+          "title": { "en": "Understand plugin packages", "zh": "了解插件包" },
+          "body": {
+            "en": "Learn how plugin packages bundle skills, hooks, and MCP servers while preserving explicit trust boundaries.",
+            "zh": "了解插件包如何组合技能、Hooks 与 MCP 服务器，同时维持清晰的可信边界。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/docs/PLUGIN_PACKAGES.zh-CN.md"
+        }
+      ],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": { "en": "Offline Guard and Safe Mode", "zh": "离线恢复 Guard 与安全模式" },
+          "body": {
+            "en": "A recovery path now exists outside the normal desktop startup. It can inspect failures, restore known-good state, and launch a minimal Safe Mode when normal boot is blocked.",
+            "zh": "恢复能力不再依赖 Desktop 正常启动。现在可以在应用之外检查故障、恢复已知可用状态，并在正常启动受阻时进入最小化安全模式。"
+          },
+          "refs": [6460]
+        },
+        {
+          "kind": "security",
+          "title": { "en": "Trusted MCP execution", "zh": "MCP 可信执行" },
+          "body": {
+            "en": "MCP startup now verifies package identity, signed catalog metadata, approval receipts, executable paths, and credential boundaries before a server is trusted.",
+            "zh": "MCP 启动前会校验包身份、签名目录元数据、审批回执、可执行路径与凭据边界，避免旧授权被错误复用。"
+          },
+          "refs": [6482, 6449]
+        },
+        {
+          "kind": "improved",
+          "title": { "en": "Delivery that recovers instead of cascading", "zh": "交付失败不再级联" },
+          "body": {
+            "en": "Goal, Plan, Delivery, YOLO, and review readiness now share a consistent lifecycle. Interrupted delivery can recover without concurrent writers corrupting the final state.",
+            "zh": "Goal、Plan、Delivery、YOLO 与审查就绪检查现在共享一致的生命周期；交付中断后可以恢复，同时隔离并发写入。"
+          },
+          "refs": [6421, 6458, 6467, 6542]
+        },
+        {
+          "kind": "new",
+          "title": { "en": "Claude plugin compatibility", "zh": "Claude 插件兼容" },
+          "body": {
+            "en": "Reasonix can consume Claude-compatible plugin packages and adapt their commands and hooks into the existing plugin runtime.",
+            "zh": "Reasonix 现在可以加载 Claude 兼容插件包，并把其中的命令与 Hooks 接入现有插件运行时。"
+          },
+          "refs": [6434]
+        },
+        {
+          "kind": "improved",
+          "title": { "en": "Faster desktop navigation", "zh": "更顺手的 Desktop 导航" },
+          "body": {
+            "en": "Pinned conversations get their own section, selected chat text or workspace code can be sent to the composer, and files can open through a dynamically discovered external-app menu.",
+            "zh": "置顶会话拥有独立分组；聊天选区与工作区代码可直接加入输入区；文件可通过动态发现的外部应用菜单打开。"
+          },
+          "refs": [6494, 6454, 6457]
+        }
+      ],
+      "changes": {
+        "new": [
+          {
+            "title": { "en": "Mouse selection in the CLI composer", "zh": "CLI 输入区支持鼠标选择" },
+            "body": { "en": "Text in the terminal composer can now be selected with the mouse.", "zh": "终端输入区现在可以直接使用鼠标选择文本。" },
+            "refs": [6456]
+          },
+          {
+            "title": { "en": "Pinned conversations in the classic sidebar", "zh": "经典侧栏显示置顶会话" },
+            "body": { "en": "Pinned topics stay visible in a dedicated section instead of being mixed into recency sorting.", "zh": "置顶话题会保留在独立区域，不再混入按时间排序的普通会话。" },
+            "refs": [6494]
+          }
+        ],
+        "improved": [
+          {
+            "title": { "en": "Grounded edits without forced rereads", "zh": "编辑后无需强制重读" },
+            "body": { "en": "Bounded edit receipts keep the agent grounded while avoiding redundant full-file reads.", "zh": "通过有界编辑回执维持事实锚点，同时避免无意义的整文件重读。" },
+            "refs": [6504]
+          },
+          {
+            "title": { "en": "Classic sidebar and tab polish", "zh": "经典侧栏与标签页打磨" },
+            "body": { "en": "Sorting, previews, topic actions, tab boundaries, and draggable whitespace now behave more consistently.", "zh": "排序、预览、话题操作、标签页边界与可拖动空白区的行为更加一致。" },
+            "refs": [6468, 6433, 6463]
+          }
+        ],
+        "fixed": [
+          {
+            "title": { "en": "Pending approvals survive session switches", "zh": "切换会话后待审批内容仍然可见" },
+            "body": { "en": "A pending plan approval no longer disappears after moving between sessions.", "zh": "在会话之间切换后，待确认的计划审批不再消失。" },
+            "refs": [6432]
+          },
+          {
+            "title": { "en": "Windows paths and display scaling", "zh": "Windows 路径与显示缩放" },
+            "body": { "en": "Shell-escaped paths, mixed-DPI restore, and long isolated checkout paths are handled safely.", "zh": "Shell 转义路径、混合 DPI 恢复和超长隔离工作树路径现在都能正确处理。" },
+            "refs": [6469, 6472]
+          },
+          {
+            "title": { "en": "Credential isolation", "zh": "凭据隔离" },
+            "body": { "en": "All persisted credential environment keys are isolated from unrelated providers and subprocesses.", "zh": "所有持久化凭据环境变量都会与无关 Provider 和子进程隔离。" },
+            "refs": [6536, 6544]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "warning",
+          "title": { "en": "Windows native sandbox retired", "zh": "Windows 原生沙箱后端已退役" },
+          "body": {
+            "en": "If you previously selected the retired native Windows sandbox, open Settings → Sandbox after upgrading and choose a supported isolation mode. Reasonix reports a remediation message instead of silently falling back.",
+            "zh": "如果此前选择了已退役的 Windows 原生沙箱，升级后请打开“设置 → 沙箱”并选择受支持的隔离方式。Reasonix 会显示修复提示，不会静默降级。"
+          },
+          "refs": [6516]
+        },
+        {
+          "level": "info",
+          "title": { "en": "MCP trust may require fresh approval", "zh": "MCP 信任可能需要重新确认" },
+          "body": {
+            "en": "When a package identity or executable no longer matches its stored receipt, Reasonix asks for a new approval rather than reusing stale trust.",
+            "zh": "当插件包身份或可执行文件与已保存回执不一致时，Reasonix 会请求新的审批，而不会沿用过期信任。"
+          },
+          "refs": [6482]
+        }
+      ],
+      "risks": [
+        {
+          "title": { "en": "No automatic permission expansion", "zh": "不会自动扩大权限" },
+          "body": {
+            "en": "The MCP and read-only subagent changes fail closed. Invalid schemas, identities, or receipts are quarantined or returned to human approval instead of being accepted automatically.",
+            "zh": "MCP 与只读子智能体的变更采用失败关闭策略。无效 Schema、身份或回执会被隔离，或退回人工审批，不会被自动接受。"
+          },
+          "refs": [6449, 6482, 6498]
+        }
+      ],
+      "contributors": ["SivanCola", "JesonChou", "SauronSkywalker", "billycat", "h4rk8s", "myipanta", "esengine"],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.17.13",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.12...desktop-v1.17.13",
+        "download": "https://reasonix.io/?download=desktop#start"
+      }
+    },
+    {
+      "version": "1.17.12",
+      "date": "2026-07-13",
+      "channel": "stable",
+      "title": {
+        "en": "Provider setup becomes a real control center",
+        "zh": "Provider 配置中心与交付质量门槛升级"
+      },
+      "summary": {
+        "en": "Provider setup now works as a complete manager instead of a one-time wizard. Delivery review and liveness checks are stricter, while the Creation workspace, performance diagnostics, and everyday desktop interactions receive focused polish.",
+        "zh": "Provider setup 从一次性向导升级为完整配置中心；交付审查与流式活性检查更加严格，同时集中打磨 Creation 工作区、性能诊断与 Desktop 日常交互。"
+      },
+      "surfaces": ["desktop", "cli", "provider", "agent"],
+      "guides": [],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": { "en": "Provider manager in reasonix setup", "zh": "reasonix setup 变成 Provider 管理器" },
+          "body": { "en": "Add, edit, test, and choose provider access from one terminal workflow instead of rerunning a first-use wizard.", "zh": "现在可以在同一套终端流程中添加、编辑、测试和选择 Provider，不再只是重复运行首次向导。" },
+          "refs": [6384]
+        },
+        {
+          "kind": "improved",
+          "title": { "en": "Stronger delivery review", "zh": "更严格的交付审查" },
+          "body": { "en": "Delivery mode now aligns review protocol, readiness gates, sign-off evidence, and streaming liveness.", "zh": "交付模式现在统一了审查协议、就绪门槛、签收证据与流式活性判定。" },
+          "refs": [6382, 6407]
+        },
+        {
+          "kind": "improved",
+          "title": { "en": "Actionable performance reports", "zh": "可定位的性能报告" },
+          "body": { "en": "Desktop performance prompts use JavaScript self-profiling attribution and suppress false positives during recovery.", "zh": "Desktop 性能提示接入 JavaScript 自采样归因，并减少恢复阶段的误报。" },
+          "refs": [6374]
+        }
+      ],
+      "changes": {
+        "new": [],
+        "improved": [
+          {
+            "title": { "en": "Creation workspace polish", "zh": "Creation 工作区打磨" },
+            "body": { "en": "The changes view, sidebar alignment, dock geometry, chat scrollbar, and text scaling now follow one visual system.", "zh": "变更视图、侧栏对齐、停靠区几何、聊天滚动条与字号缩放现在遵循同一视觉系统。" },
+            "refs": [6287, 6292, 6400]
+          }
+        ],
+        "fixed": [
+          {
+            "title": { "en": "Composer height recovery", "zh": "输入框高度恢复" },
+            "body": { "en": "A manually resized composer no longer collapses to a single visible line.", "zh": "手动调整过高度的输入框不再错误收缩为单行。" },
+            "refs": [6399]
+          },
+          {
+            "title": { "en": "Live cache averages stay current", "zh": "实时缓存平均值保持同步" },
+            "body": { "en": "The desktop cache summary updates with the active session instead of showing stale averages.", "zh": "Desktop 缓存摘要会跟随当前会话更新，不再显示过期平均值。" },
+            "refs": [6406]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": { "en": "No manual migration required", "zh": "无需手动迁移" },
+          "body": { "en": "Existing providers and desktop preferences continue to load unchanged.", "zh": "现有 Provider 与 Desktop 偏好会按原样继续加载。" }
+        }
+      ],
+      "risks": [],
+      "contributors": ["SivanCola", "Li-Charles-One", "J3y0r"],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.17.12",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.11...desktop-v1.17.12",
+        "download": "https://reasonix.io/?download=desktop#start"
+      }
+    },
+    {
+      "version": "1.17.11",
+      "date": "2026-07-12",
+      "channel": "stable",
+      "title": {
+        "en": "Runtime profiles, plugin commands, and safer session handoffs",
+        "zh": "运行档、插件命令与更安全的会话交接"
+      },
+      "summary": {
+        "en": "This release introduces configurable subagent and runtime profiles, maps Claude plugin commands into Reasonix, and closes several session handoff gaps that could hide messages, drop turns, or obscure provider failures.",
+        "zh": "这一版新增可配置子智能体与运行档，把 Claude 插件命令接入 Reasonix，并修复多个会话交接缺口，避免消息隐藏、回合丢失或 Provider 错误被掩盖。"
+      },
+      "surfaces": ["agent", "desktop", "plugin", "provider"],
+      "guides": [],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": { "en": "Configurable subagent profiles", "zh": "可配置子智能体档案" },
+          "body": { "en": "Create isolated subagent profiles with their own instructions, models, and capability boundaries.", "zh": "可以创建拥有独立指令、模型与能力边界的子智能体档案。" },
+          "refs": [6310]
+        },
+        {
+          "kind": "new",
+          "title": { "en": "Runtime profiles and delivery routing", "zh": "运行档与交付能力路由" },
+          "body": { "en": "Work modes can select the runtime profile and delivery capabilities appropriate to the task.", "zh": "工作模式现在可以选择适合当前任务的运行档和交付能力。" },
+          "refs": [6322, 6341]
+        },
+        {
+          "kind": "new",
+          "title": { "en": "Claude plugin commands", "zh": "Claude 插件命令" },
+          "body": { "en": "Claude-compatible plugin commands and skills appear as qualified custom slash commands without name collisions.", "zh": "Claude 兼容插件中的命令与技能会映射为带限定名的自定义斜杠命令，避免命名冲突。" },
+          "refs": [6311, 6326, 6328]
+        }
+      ],
+      "changes": {
+        "new": [],
+        "improved": [
+          {
+            "title": { "en": "Real provider error messages", "zh": "显示真实 Provider 错误" },
+            "body": { "en": "402, 429, 5xx, 401, and 403 responses now surface the upstream reason instead of a generic failure.", "zh": "402、429、5xx、401 与 403 响应会显示上游真实原因，不再只有通用失败提示。" },
+            "refs": [6345]
+          }
+        ],
+        "fixed": [
+          {
+            "title": { "en": "Turns are not dropped during finish", "zh": "收尾窗口不再丢失回合" },
+            "body": { "en": "Messages submitted while a turn is finishing are parked and resumed instead of silently disappearing.", "zh": "在回合收尾阶段提交的消息会被暂存并继续处理，不再静默消失。" },
+            "refs": [6324, 6352]
+          },
+          {
+            "title": { "en": "Diagnostics handles empty arrays", "zh": "诊断页正确处理空数组" },
+            "body": { "en": "Missing capability arrays no longer crash the diagnostics page.", "zh": "缺失的能力数组不再导致诊断页崩溃。" },
+            "refs": [6367]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": { "en": "No manual migration required", "zh": "无需手动迁移" },
+          "body": { "en": "Runtime profiles and plugin command qualification preserve existing configuration.", "zh": "运行档与插件命令限定名会兼容现有配置。" }
+        }
+      ],
+      "risks": [],
+      "contributors": ["ttmouse", "SivanCola"],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.17.11",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.10...desktop-v1.17.11",
+        "download": "https://reasonix.io/?download=desktop#start"
+      }
+    }
+  ]
+}

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { loadCatalog, upsertRelease, validateCatalog } from "./release-notes.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const apiBase = process.env.DEEPSEEK_API_BASE || "https://api.deepseek.com";
+const model = process.env.DEEPSEEK_MODEL || "deepseek-v4-pro";
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument ${arg}`);
+    values[arg.slice(2)] = argv[++index];
+  }
+  return values;
+}
+
+function runGit(args) {
+  return execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" }).trim();
+}
+
+function normalizeVersion(version) {
+  return String(version || "").replace(/^(?:desktop-|npm-)?v/, "");
+}
+
+function repositoryName() {
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  const remote = runGit(["remote", "get-url", "origin"]);
+  const match = remote.match(/github\.com[/:]([^/]+\/[^/.]+)(?:\.git)?$/);
+  if (!match) throw new Error("cannot determine GitHub repository; set GITHUB_REPOSITORY");
+  return match[1];
+}
+
+function commitRange(from, to) {
+  return runGit(["log", "--first-parent", "--format=%H%x09%s%x09%b%x00", `${from}..${to}`])
+    .split("\0")
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha, subject, ...body] = record.split("\t");
+      return { sha, subject, body: body.join("\t").trim() };
+    });
+}
+
+function prNumbersFromCommits(commits) {
+  const refs = new Set();
+  for (const commit of commits) {
+    for (const match of `${commit.subject}\n${commit.body}`.matchAll(/#(\d+)/g)) refs.add(Number(match[1]));
+  }
+  return [...refs];
+}
+
+async function githubJson(path, { allowMissing = false } = {}) {
+  const headers = { Accept: "application/vnd.github+json", "User-Agent": "reasonix-release-notes" };
+  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN || process.env.GH_TOKEN}`;
+  }
+  const response = await fetch(`https://api.github.com${path}`, { headers, signal: AbortSignal.timeout(30_000) });
+  if (allowMissing && response.status === 404) return null;
+  if (!response.ok) throw new Error(`GitHub API ${path} failed: ${response.status}`);
+  return response.json();
+}
+
+async function collectPullRequests(repository, commits) {
+  const numbers = new Set(prNumbersFromCommits(commits));
+  const associated = await Promise.all(
+    commits.map((commit) => githubJson(`/repos/${repository}/commits/${commit.sha}/pulls`, { allowMissing: true })),
+  );
+  for (const pulls of associated) for (const pull of pulls || []) numbers.add(pull.number);
+  const pulls = await Promise.all([...numbers].map((number) => githubJson(`/repos/${repository}/pulls/${number}`, { allowMissing: true })));
+  return pulls.filter(Boolean).map((pull) => ({
+    number: pull.number,
+    title: pull.title,
+    body: String(pull.body || "").slice(0, 2000),
+    author: pull.user?.login || "",
+    labels: (pull.labels || []).map((label) => label.name),
+  }));
+}
+
+function collectDocLinks(from, repository, to) {
+  const paths = runGit(["diff", "--name-only", `${from}..${to}`])
+    .split("\n")
+    .filter((path) => /^(?:docs|README)[/\w.-]*\.(?:md|mdx)$/i.test(path));
+  return paths.map((path) => `https://github.com/${repository}/blob/${to}/${path}`);
+}
+
+function assertGroundedRefs(value, allowedRefs, path = "release") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertGroundedRefs(item, allowedRefs, `${path}[${index}]`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value.refs)) {
+    for (const ref of value.refs) {
+      if (!allowedRefs.has(ref)) throw new Error(`${path}.refs contains PR #${ref}, which is outside the release range`);
+    }
+  }
+  for (const [key, child] of Object.entries(value)) assertGroundedRefs(child, allowedRefs, `${path}.${key}`);
+}
+
+function extractJson(content) {
+  if (!content?.trim()) throw new Error("DeepSeek returned empty content");
+  const parsed = JSON.parse(content);
+  return parsed.release || parsed;
+}
+
+async function askDeepSeek(payload, retry = true) {
+  const key = process.env.DEEPSEEK_API_KEY;
+  if (!key) throw new Error("DEEPSEEK_API_KEY is required");
+  const response = await fetch(`${apiBase.replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_tokens: 8000,
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content: `You are Reasonix's release editor. Return one JSON object with a \"release\" property. Write factual, user-facing product release notes in equivalent English and Simplified Chinese. Group changes by user outcome, not by commit. Never invent capabilities, migrations, risks, PR numbers, contributors, URLs, or metrics. Every highlight and change must cite one or more supplied PR numbers. Use this exact release shape:
+{
+  \"version\": \"semver\", \"date\": \"YYYY-MM-DD\", \"channel\": \"stable|prerelease\",
+  \"title\": {\"en\":\"\",\"zh\":\"\"}, \"summary\": {\"en\":\"\",\"zh\":\"\"},
+  \"surfaces\": [\"desktop\"],
+  \"guides\": [{\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"href\":\"https://...\"}],
+  \"highlights\": [{\"kind\":\"new|improved|fixed|security\",\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"changes\": {\"new\":[],\"improved\":[],\"fixed\":[]},
+  \"upgrade\": [{\"level\":\"info|warning\",\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"risks\": [{\"title\":{\"en\":\"\",\"zh\":\"\"},\"body\":{\"en\":\"\",\"zh\":\"\"},\"refs\":[123]}],
+  \"contributors\": [], \"links\": {\"github\":\"https://...\",\"compare\":\"https://...\",\"download\":\"https://...\"}
+}
+Return guides only for supplied documentation URLs. Mention upgrade action or risk only when explicitly supported; otherwise use empty arrays. Output JSON only.`,
+        },
+        { role: "user", content: `Create the release record from these public GitHub sources:\n${JSON.stringify(payload)}` },
+      ],
+    }),
+  });
+  if (!response.ok) throw new Error(`DeepSeek API failed: ${response.status} ${await response.text()}`);
+  const data = await response.json();
+  try {
+    return extractJson(data.choices?.[0]?.message?.content);
+  } catch (error) {
+    if (!retry) throw error;
+    return askDeepSeek(payload, false);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.version) throw new Error("--version is required");
+  const version = normalizeVersion(args.version);
+  const catalog = await loadCatalog();
+  const previous = args.from || catalog.releases.find((release) => release.version !== version)?.version;
+  if (!previous) throw new Error("--from is required when no previous release exists");
+  const from = previous.match(/^(?:desktop-|npm-)?v/) ? previous : `desktop-v${previous}`;
+  const to = args.to || "HEAD";
+  const repository = repositoryName();
+  const commits = commitRange(from, to);
+  if (!commits.length) throw new Error(`no commits found in ${from}..${to}`);
+  const pulls = await collectPullRequests(repository, commits);
+  if (!pulls.length) throw new Error(`no pull requests found in ${from}..${to}`);
+  const docLinks = collectDocLinks(from, repository, to);
+  const date = args.date || new Date().toISOString().slice(0, 10);
+  const tag = args.tag || `desktop-v${version}`;
+  const source = {
+    version,
+    date,
+    channel: version.includes("-") ? "prerelease" : "stable",
+    range: `${from}..${to}`,
+    pullRequests: pulls,
+    documentationUrls: docLinks,
+  };
+  const release = await askDeepSeek(source);
+  release.version = version;
+  release.date = date;
+  release.channel = source.channel;
+  release.contributors = [...new Set(pulls.map((pull) => pull.author).filter(Boolean))];
+  release.links = {
+    github: `https://github.com/${repository}/releases/tag/${tag}`,
+    compare: `https://github.com/${repository}/compare/${from}...${tag}`,
+    download: "https://reasonix.io/?download=desktop#start",
+  };
+  release.guides = (release.guides || []).filter((guide) => docLinks.includes(guide.href));
+  assertGroundedRefs(release, new Set(pulls.map((pull) => pull.number)));
+  validateCatalog({ schemaVersion: 1, releases: [release] });
+  await upsertRelease(release);
+  console.log(`Generated bilingual release notes for v${version} from ${pulls.length} pull request(s).`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+export const defaultCatalogPath = resolve(repoRoot, "release-notes/releases.json");
+
+const localizedFields = ["title", "body"];
+const changeKinds = ["new", "improved", "fixed"];
+const itemKinds = new Set(["new", "improved", "fixed", "security"]);
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateLocalized(value, path) {
+  invariant(isObject(value), `${path} must be an object`);
+  for (const lang of ["en", "zh"]) {
+    invariant(typeof value[lang] === "string" && value[lang].trim(), `${path}.${lang} must be a non-empty string`);
+  }
+}
+
+function validateRefs(refs, path) {
+  if (refs === undefined) return;
+  invariant(Array.isArray(refs), `${path} must be an array`);
+  for (const ref of refs) invariant(Number.isInteger(ref) && ref > 0, `${path} contains invalid PR number ${ref}`);
+}
+
+function validateItem(item, path, { kind = false, href = false, level = false } = {}) {
+  invariant(isObject(item), `${path} must be an object`);
+  for (const field of localizedFields) validateLocalized(item[field], `${path}.${field}`);
+  if (kind) invariant(itemKinds.has(item.kind), `${path}.kind is invalid`);
+  if (href) invariant(typeof item.href === "string" && /^https:\/\//.test(item.href), `${path}.href must be HTTPS`);
+  if (level) invariant(item.level === "info" || item.level === "warning", `${path}.level is invalid`);
+  validateRefs(item.refs, `${path}.refs`);
+}
+
+function semverParts(version) {
+  const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  invariant(match, `invalid version ${version}`);
+  return [Number(match[1]), Number(match[2]), Number(match[3]), match[4] || ""];
+}
+
+function compareVersionsDesc(a, b) {
+  const aa = semverParts(a);
+  const bb = semverParts(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (aa[i] !== bb[i]) return bb[i] - aa[i];
+  }
+  if (aa[3] === bb[3]) return 0;
+  if (!aa[3]) return -1;
+  if (!bb[3]) return 1;
+  return String(bb[3]).localeCompare(String(aa[3]), "en", { numeric: true });
+}
+
+export function validateCatalog(catalog) {
+  invariant(isObject(catalog), "catalog must be an object");
+  invariant(catalog.schemaVersion === 1, "catalog.schemaVersion must be 1");
+  invariant(Array.isArray(catalog.releases) && catalog.releases.length > 0, "catalog.releases must not be empty");
+
+  const versions = new Set();
+  for (const [index, release] of catalog.releases.entries()) {
+    const path = `releases[${index}]`;
+    invariant(isObject(release), `${path} must be an object`);
+    semverParts(release.version);
+    invariant(!versions.has(release.version), `duplicate version ${release.version}`);
+    versions.add(release.version);
+    invariant(/^\d{4}-\d{2}-\d{2}$/.test(release.date), `${path}.date must use YYYY-MM-DD`);
+    invariant(release.channel === "stable" || release.channel === "prerelease", `${path}.channel is invalid`);
+    validateLocalized(release.title, `${path}.title`);
+    validateLocalized(release.summary, `${path}.summary`);
+    invariant(Array.isArray(release.surfaces) && release.surfaces.length > 0, `${path}.surfaces must not be empty`);
+    invariant(new Set(release.surfaces).size === release.surfaces.length, `${path}.surfaces contains duplicates`);
+    invariant(Array.isArray(release.guides), `${path}.guides must be an array`);
+    release.guides.forEach((item, itemIndex) => validateItem(item, `${path}.guides[${itemIndex}]`, { href: true }));
+    invariant(Array.isArray(release.highlights) && release.highlights.length > 0, `${path}.highlights must not be empty`);
+    release.highlights.forEach((item, itemIndex) => validateItem(item, `${path}.highlights[${itemIndex}]`, { kind: true }));
+    invariant(isObject(release.changes), `${path}.changes must be an object`);
+    for (const changeKind of changeKinds) {
+      invariant(Array.isArray(release.changes[changeKind]), `${path}.changes.${changeKind} must be an array`);
+      release.changes[changeKind].forEach((item, itemIndex) =>
+        validateItem(item, `${path}.changes.${changeKind}[${itemIndex}]`),
+      );
+    }
+    invariant(Array.isArray(release.upgrade), `${path}.upgrade must be an array`);
+    release.upgrade.forEach((item, itemIndex) => validateItem(item, `${path}.upgrade[${itemIndex}]`, { level: true }));
+    invariant(Array.isArray(release.risks), `${path}.risks must be an array`);
+    release.risks.forEach((item, itemIndex) => validateItem(item, `${path}.risks[${itemIndex}]`));
+    invariant(Array.isArray(release.contributors), `${path}.contributors must be an array`);
+    invariant(isObject(release.links), `${path}.links must be an object`);
+    for (const link of ["github", "compare", "download"]) {
+      invariant(typeof release.links[link] === "string" && /^https:\/\//.test(release.links[link]), `${path}.links.${link} must be HTTPS`);
+    }
+  }
+
+  const sorted = [...catalog.releases].sort((a, b) => compareVersionsDesc(a.version, b.version));
+  invariant(
+    sorted.every((release, index) => release.version === catalog.releases[index].version),
+    "catalog.releases must be sorted newest first",
+  );
+  return catalog;
+}
+
+export async function loadCatalog(path = defaultCatalogPath) {
+  const catalog = JSON.parse(await readFile(path, "utf8"));
+  return validateCatalog(catalog);
+}
+
+export function releaseForVersion(catalog, version) {
+  const normalized = String(version).replace(/^(?:desktop-|npm-)?v/, "");
+  const release = catalog.releases.find((entry) => entry.version === normalized);
+  invariant(release, `release notes for v${normalized} are missing`);
+  return release;
+}
+
+function localized(value, lang) {
+  return value[lang] || value.en;
+}
+
+function refsSuffix(refs = []) {
+  if (!refs.length) return "";
+  return ` (${refs.map((ref) => `[#${ref}](https://github.com/esengine/DeepSeek-Reasonix/pull/${ref})`).join(", ")})`;
+}
+
+function renderItems(items, lang) {
+  return items
+    .map((item) => `- **${localized(item.title, lang)}** — ${localized(item.body, lang)}${refsSuffix(item.refs)}`)
+    .join("\n");
+}
+
+export function renderGitHubRelease(release, lang = "zh") {
+  const isZh = lang === "zh";
+  const lines = [
+    `> ${localized(release.summary, lang)}`,
+    "",
+    isZh
+      ? `[English →](https://reasonix.io/changelog/v${release.version}/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v${release.version}/)`
+      : `[中文 →](https://reasonix.io/changelog/v${release.version}/?lang=zh) · [Full release notes →](https://reasonix.io/changelog/v${release.version}/?lang=en)`,
+    "",
+  ];
+
+  if (release.guides.length) {
+    lines.push(`## ${isZh ? "使用攻略" : "Guides"}`, "");
+    for (const guide of release.guides) {
+      lines.push(`- [**${localized(guide.title, lang)}**](${guide.href}) — ${localized(guide.body, lang)}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    `## ${isZh ? "概览" : "Overview"}`,
+    "",
+    `**Reasonix v${release.version} — ${localized(release.title, lang)}**`,
+    "",
+    localized(release.summary, lang),
+    "",
+    `${isZh ? "发布日期" : "Released"}：${release.date}`,
+    "",
+    `## ${isZh ? "重点内容" : "Highlights"}`,
+    "",
+    renderItems(release.highlights, lang),
+    "",
+  );
+
+  const headings = {
+    new: isZh ? "新功能" : "New",
+    improved: isZh ? "改进" : "Improved",
+    fixed: isZh ? "修复" : "Fixed",
+  };
+  for (const kind of changeKinds) {
+    const items = release.changes[kind];
+    if (!items.length) continue;
+    lines.push(`## ${headings[kind]}`, "", renderItems(items, lang), "");
+  }
+
+  lines.push(`## ${isZh ? "升级提醒" : "Upgrade notes"}`, "");
+  if (release.upgrade.length) lines.push(renderItems(release.upgrade, lang));
+  else lines.push(isZh ? "本版本无需手动迁移。" : "No manual migration is required.");
+  lines.push("");
+
+  lines.push(`## ${isZh ? "风险提示" : "Risk notes"}`, "");
+  if (release.risks.length) lines.push(renderItems(release.risks, lang));
+  else lines.push(isZh ? "当前没有需要额外操作的已知风险。" : "There are no known risks requiring extra action.");
+  lines.push("");
+
+  if (release.contributors.length) {
+    lines.push(
+      `## ${isZh ? "致谢" : "Thanks"}`,
+      "",
+      `${isZh ? "感谢本版本的贡献者" : "Thanks to the contributors in this release"}：${release.contributors
+        .map((name) => `[@${name}](https://github.com/${name})`)
+        .join("、")}`,
+      "",
+    );
+  }
+
+  lines.push(
+    `## ${isZh ? "下载与安装" : "Download and install"}`,
+    "",
+    `- [${isZh ? "官网按平台下载" : "Platform downloads"}](${release.links.download})`,
+    `- [${isZh ? "查看完整差异" : "Full comparison"}](${release.links.compare})`,
+    "",
+  );
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export async function upsertRelease(release, path = defaultCatalogPath) {
+  const catalog = await loadCatalog(path);
+  const next = {
+    ...catalog,
+    releases: [release, ...catalog.releases.filter((entry) => entry.version !== release.version)].sort((a, b) =>
+      compareVersionsDesc(a.version, b.version),
+    ),
+  };
+  validateCatalog(next);
+  await writeFile(path, `${JSON.stringify(next, null, 2)}\n`);
+  return next;
+}
+
+function parseArgs(argv) {
+  const [command = "validate", ...rest] = argv;
+  const values = { command };
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument ${arg}`);
+    values[arg.slice(2)] = rest[++i];
+  }
+  return values;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const catalogPath = args.catalog ? resolve(args.catalog) : defaultCatalogPath;
+  const catalog = await loadCatalog(catalogPath);
+  if (args.command === "validate") {
+    console.log(`Validated ${catalog.releases.length} release note(s).`);
+    return;
+  }
+  if (args.command !== "render") throw new Error(`unknown command ${args.command}`);
+  invariant(args.version, "render requires --version");
+  invariant(args.output, "render requires --output");
+  const release = releaseForVersion(catalog, args.version);
+  const output = resolve(args.output);
+  await writeFile(output, renderGitHubRelease(release, args.lang === "en" ? "en" : "zh"));
+  console.log(`Rendered v${release.version} release notes to ${output}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadCatalog, releaseForVersion, renderGitHubRelease, validateCatalog } from "./release-notes.mjs";
+
+test("the committed release catalog is valid and newest first", async () => {
+  const catalog = await loadCatalog();
+  assert.equal(catalog.schemaVersion, 1);
+  assert.equal(catalog.releases[0].version, "1.17.13");
+  assert.equal(new Set(catalog.releases.map((release) => release.version)).size, catalog.releases.length);
+});
+
+test("tag namespaces resolve to the same product release", async () => {
+  const catalog = await loadCatalog();
+  assert.equal(releaseForVersion(catalog, "v1.17.13").version, "1.17.13");
+  assert.equal(releaseForVersion(catalog, "desktop-v1.17.13").version, "1.17.13");
+  assert.equal(releaseForVersion(catalog, "npm-v1.17.13").version, "1.17.13");
+});
+
+test("GitHub rendering keeps product sections and source PR links", async () => {
+  const catalog = await loadCatalog();
+  const markdown = renderGitHubRelease(releaseForVersion(catalog, "1.17.13"), "zh");
+  assert.match(markdown, /## 使用攻略/);
+  assert.match(markdown, /## 重点内容/);
+  assert.match(markdown, /## 升级提醒/);
+  assert.match(markdown, /## 风险提示/);
+  assert.match(markdown, /## 致谢/);
+  assert.match(markdown, /\/pull\/6460/);
+  assert.match(markdown, /reasonix\.io\/changelog\/v1\.17\.13/);
+});
+
+test("validation rejects bilingual drift", () => {
+  assert.throws(
+    () =>
+      validateCatalog({
+        schemaVersion: 1,
+        releases: [
+          {
+            version: "1.0.0",
+            date: "2026-01-01",
+            channel: "stable",
+            title: { en: "Title", zh: "" },
+            summary: { en: "Summary", zh: "摘要" },
+          },
+        ],
+      }),
+    /title\.zh/,
+  );
+});

--- a/site/src/components/ChangelogPage.astro
+++ b/site/src/components/ChangelogPage.astro
@@ -1,0 +1,212 @@
+---
+import Base from '../layouts/Base.astro';
+import SiteHeader from './SiteHeader.astro';
+import type { ReleaseItem, ReleaseRecord } from '../data/releases';
+import { releasePath } from '../data/releases';
+import '../styles/changelog.css';
+
+const { release, releases } = Astro.props as { release: ReleaseRecord; releases: ReleaseRecord[] };
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
+const prHref = (ref: number) => `${repo}/pull/${ref}`;
+const sectionItems = [
+  ...(release.guides.length ? [{ id: 'guides', en: 'Guides', zh: '使用攻略' }] : []),
+  { id: 'highlights', en: 'Highlights', zh: '重点内容' },
+  ...(release.changes.new.length ? [{ id: 'new', en: 'New', zh: '新功能' }] : []),
+  ...(release.changes.improved.length ? [{ id: 'improved', en: 'Improved', zh: '改进' }] : []),
+  ...(release.changes.fixed.length ? [{ id: 'fixed', en: 'Fixed', zh: '修复' }] : []),
+  { id: 'upgrade', en: 'Upgrade notes', zh: '升级提醒' },
+  { id: 'risks', en: 'Risk notes', zh: '风险提示' },
+  ...(release.contributors.length ? [{ id: 'thanks', en: 'Thanks', zh: '致谢' }] : []),
+  { id: 'download', en: 'Download', zh: '下载与安装' },
+];
+
+const kindLabel = (kind: string) => ({
+  new: { en: 'New', zh: '新增' },
+  improved: { en: 'Improved', zh: '改进' },
+  fixed: { en: 'Fixed', zh: '修复' },
+  security: { en: 'Security', zh: '安全' },
+}[kind] ?? { en: kind, zh: kind });
+
+const surfaceLabel = (surface: string) => ({
+  agent: { en: 'Agent', zh: 'Agent' },
+  desktop: { en: 'Desktop', zh: '桌面端' },
+  cli: { en: 'CLI', zh: 'CLI' },
+  mcp: { en: 'MCP', zh: 'MCP' },
+  security: { en: 'Security', zh: '安全' },
+  provider: { en: 'Provider', zh: '模型服务' },
+  plugin: { en: 'Plugins', zh: '插件' },
+}[surface] ?? { en: surface, zh: surface });
+
+const titleEn = `Reasonix v${release.version} release notes`;
+const titleZh = `Reasonix v${release.version} 更新日志`;
+const description = release.summary.en;
+---
+
+<Base title={titleEn} titleEn={titleEn} titleZh={titleZh} description={description}>
+  <SiteHeader active="changelog" scrolled />
+
+  <main class="release-stage">
+    <div class="release-mobile-switcher">
+      <label for="release-version"><span class="l-en">Version</span><span class="l-zh">版本</span></label>
+      <select id="release-version" data-release-version>
+        {releases.map((item) => <option value={item.version} selected={item.version === release.version}>v{item.version}</option>)}
+      </select>
+    </div>
+
+    <div class="release-grid">
+      <aside class="release-rail" aria-label="Release versions">
+        <div class="release-rail__eyebrow"><span class="release-rail__mark"></span><span class="l-en">Release ledger</span><span class="l-zh">版本档案</span></div>
+        <nav>
+          {releases.map((item, index) => (
+            <a class:list={["release-version-link", { active: item.version === release.version }]} href={`${base}${releasePath(item.version)}`}>
+              <span class="release-version-link__line"><strong>v{item.version}</strong>{index === 0 && <em><span class="l-en">Latest</span><span class="l-zh">最新</span></em>}</span>
+              <small>{item.date}</small>
+            </a>
+          ))}
+        </nav>
+        <a class="release-rail__all" href={`${repo}/releases`}><span class="l-en">All GitHub releases ↗</span><span class="l-zh">全部 GitHub Releases ↗</span></a>
+      </aside>
+
+      <article class="release-paper">
+        <header class="release-hero">
+          <div class="release-hero__meta">
+            <span class="release-channel"><span class="release-channel__dot"></span>{release.channel}</span>
+            <time datetime={release.date}>{release.date}</time>
+          </div>
+          <p class="release-hero__version">Reasonix / v{release.version}</p>
+          <h1><span class="l-en">{release.title.en}</span><span class="l-zh">{release.title.zh}</span></h1>
+          <div class="release-surfaces">
+            {release.surfaces.map((surface) => {
+              const label = surfaceLabel(surface);
+              return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
+            })}
+          </div>
+          <blockquote><span class="l-en">{release.summary.en}</span><span class="l-zh">{release.summary.zh}</span></blockquote>
+          <div class="release-hero__actions">
+            <a class="btn btn-dark" href={release.links.download}><span class="l-en">Download v{release.version}</span><span class="l-zh">下载 v{release.version}</span></a>
+            <a class="btn btn-ghost" href={release.links.github}><span class="l-en">View on GitHub ↗</span><span class="l-zh">在 GitHub 查看 ↗</span></a>
+          </div>
+        </header>
+
+        {release.guides.length > 0 && (
+          <section id="guides" class="release-section release-guides">
+            <div class="release-section__head"><span>01</span><h2><span class="l-en">Start here</span><span class="l-zh">使用攻略</span></h2></div>
+            <div class="release-guide-grid">
+              {release.guides.map((guide) => (
+                <a class="release-guide" href={guide.href}>
+                  <span class="release-guide__arrow">↗</span>
+                  <h3><span class="l-en">{guide.title.en}</span><span class="l-zh">{guide.title.zh}</span></h3>
+                  <p><span class="l-en">{guide.body.en}</span><span class="l-zh">{guide.body.zh}</span></p>
+                </a>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section id="highlights" class="release-section">
+          <div class="release-section__head"><span>02</span><h2><span class="l-en">Highlights</span><span class="l-zh">重点内容</span></h2></div>
+          <div class="release-highlight-list">
+            {release.highlights.map((item, index) => {
+              const kind = kindLabel(item.kind);
+              return (
+                <article class="release-highlight" data-kind={item.kind}>
+                  <div class="release-highlight__index">{String(index + 1).padStart(2, '0')}</div>
+                  <div>
+                    <div class="release-highlight__kind"><span class="l-en">{kind.en}</span><span class="l-zh">{kind.zh}</span></div>
+                    <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                    <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                    {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        {(['new', 'improved', 'fixed'] as const).map((kind, index) => {
+          const items = release.changes[kind];
+          if (!items.length) return null;
+          const label = kindLabel(kind);
+          return (
+            <section id={kind} class="release-section release-change-section">
+              <div class="release-section__head"><span>{String(index + 3).padStart(2, '0')}</span><h2><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></h2></div>
+              <div class="release-change-list">
+                {items.map((item: ReleaseItem) => (
+                  <article>
+                    <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                    <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                    {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                  </article>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+
+        <section id="upgrade" class="release-section">
+          <div class="release-section__head"><span>U</span><h2><span class="l-en">Upgrade notes</span><span class="l-zh">升级提醒</span></h2></div>
+          <div class="release-notice-list">
+            {release.upgrade.length ? release.upgrade.map((item) => (
+              <article class:list={["release-notice", `release-notice--${item.level}`]}>
+                <div class="release-notice__icon">{item.level === 'warning' ? '!' : 'i'}</div>
+                <div>
+                  <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                  <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                  {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+                </div>
+              </article>
+            )) : <p><span class="l-en">No manual migration is required.</span><span class="l-zh">本版本无需手动迁移。</span></p>}
+          </div>
+        </section>
+
+        <section id="risks" class="release-section">
+          <div class="release-section__head"><span>R</span><h2><span class="l-en">Risk notes</span><span class="l-zh">风险提示</span></h2></div>
+          <div class="release-change-list">
+            {release.risks.length ? release.risks.map((item) => (
+              <article>
+                <h3><span class="l-en">{item.title.en}</span><span class="l-zh">{item.title.zh}</span></h3>
+                <p><span class="l-en">{item.body.en}</span><span class="l-zh">{item.body.zh}</span></p>
+                {item.refs?.length && <div class="release-refs">{item.refs.map((ref) => <a href={prHref(ref)}>#{ref}</a>)}</div>}
+              </article>
+            )) : <p><span class="l-en">There are no known risks requiring extra action.</span><span class="l-zh">当前没有需要额外操作的已知风险。</span></p>}
+          </div>
+        </section>
+
+        {release.contributors.length > 0 && (
+          <section id="thanks" class="release-section release-thanks">
+            <div class="release-section__head"><span>♥</span><h2><span class="l-en">Thanks</span><span class="l-zh">致谢</span></h2></div>
+            <p><span class="l-en">This release was shaped by:</span><span class="l-zh">感谢本版本的贡献者：</span></p>
+            <div>{release.contributors.map((name) => <a href={`https://github.com/${name}`}>@{name}</a>)}</div>
+          </section>
+        )}
+
+        <section id="download" class="release-section release-download">
+          <div>
+            <p class="release-download__kicker"><span class="l-en">Ready when you are</span><span class="l-zh">准备好即可升级</span></p>
+            <h2><span class="l-en">Ship with a safer Reasonix.</span><span class="l-zh">升级到更可靠的 Reasonix。</span></h2>
+          </div>
+          <div class="release-download__actions">
+            <a class="btn btn-dark" href={release.links.download}><span class="l-en">Download</span><span class="l-zh">下载</span></a>
+            <a class="release-compare" href={release.links.compare}><span class="l-en">Full comparison ↗</span><span class="l-zh">完整差异 ↗</span></a>
+          </div>
+        </section>
+      </article>
+
+      <aside class="release-toc">
+        <p><span class="l-en">In v{release.version}</span><span class="l-zh">在 v{release.version} 中</span></p>
+        <nav>{sectionItems.map((item) => <a href={`#${item.id}`}><span class="l-en">{item.en}</span><span class="l-zh">{item.zh}</span></a>)}</nav>
+      </aside>
+    </div>
+  </main>
+
+  <footer class="release-footer">
+    <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="" /><span>Reasonix</span></a>
+    <span>© 2026 Reasonix · MIT</span>
+    <a href={repo}>GitHub ↗</a>
+  </footer>
+
+  <script>
+    import '../scripts/changelog.js';
+  </script>
+</Base>

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,0 +1,67 @@
+---
+type ActiveItem = 'features' | 'how' | 'skills' | 'community' | 'docs' | 'changelog' | 'start';
+
+const {
+  active,
+  scrolled = false,
+  accountSlot = false,
+} = Astro.props as {
+  active?: ActiveItem;
+  scrolled?: boolean;
+  accountSlot?: boolean;
+};
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const items: Array<{
+  id: ActiveItem;
+  href: string;
+  en: string;
+  zh: string;
+  secondary?: boolean;
+}> = [
+  { id: 'features', href: `${base}/#features`, en: 'Features', zh: '特性' },
+  { id: 'how', href: `${base}/#how`, en: 'How it works', zh: '工作原理', secondary: true },
+  { id: 'skills', href: `${base}/skills/`, en: 'Skills', zh: '技能市场' },
+  { id: 'community', href: `${base}/#community`, en: 'Community', zh: '社区', secondary: true },
+  { id: 'docs', href: `${base}/docs/`, en: 'Docs', zh: '文档' },
+  { id: 'changelog', href: `${base}/changelog/`, en: 'Changelog', zh: '更新日志' },
+  { id: 'start', href: `${base}/#start`, en: 'Get started', zh: '快速开始', secondary: true },
+];
+---
+
+<header class:list={['nav', { scrolled }]}>
+  <div class="nav-inner">
+    <a class="brand" href={`${base}/`}>
+      <img src={`${base}/logo.svg`} alt="Reasonix logo" />
+      <span>Reasonix</span>
+    </a>
+    <nav class="nav-links" aria-label="Primary navigation">
+      {items.map((item) => (
+        <a
+          class:list={[{ here: active === item.id, 'nav-link--secondary': item.secondary }]}
+          href={item.href}
+          aria-current={active === item.id ? 'page' : undefined}
+        >
+          <span class="l-en">{item.en}</span>
+          <span class="l-zh">{item.zh}</span>
+        </a>
+      ))}
+    </nav>
+    <div class="lang-switch" role="group" aria-label="Language">
+      <button type="button" data-lang="en" class="active">EN</button>
+      <button type="button" data-lang="zh">中文</button>
+    </div>
+    {accountSlot ? (
+      <span class="nav-acct" data-account-slot></span>
+    ) : (
+      <a class="btn btn-ghost nav-sign-in" href={`${base}/login/`}>
+        <span class="l-en">Sign in</span>
+        <span class="l-zh">登录</span>
+      </a>
+    )}
+    <a class="btn btn-dark nav-install" href={`${base}/#start`}>
+      <span class="l-en">Install</span>
+      <span class="l-zh">安装</span>
+    </a>
+  </div>
+</header>

--- a/site/src/data/releases.ts
+++ b/site/src/data/releases.ts
@@ -1,0 +1,40 @@
+import source from '../../../release-notes/releases.json';
+
+export type LocalizedText = { en: string; zh: string };
+
+export type ReleaseItem = {
+  title: LocalizedText;
+  body: LocalizedText;
+  refs?: number[];
+};
+
+export type ReleaseHighlight = ReleaseItem & {
+  kind: 'new' | 'improved' | 'fixed' | 'security';
+};
+
+export type ReleaseGuide = ReleaseItem & { href: string };
+export type ReleaseUpgrade = ReleaseItem & { level: 'info' | 'warning' };
+
+export type ReleaseRecord = {
+  version: string;
+  date: string;
+  channel: 'stable' | 'prerelease';
+  title: LocalizedText;
+  summary: LocalizedText;
+  surfaces: string[];
+  guides: ReleaseGuide[];
+  highlights: ReleaseHighlight[];
+  changes: { new: ReleaseItem[]; improved: ReleaseItem[]; fixed: ReleaseItem[] };
+  upgrade: ReleaseUpgrade[];
+  risks: ReleaseItem[];
+  contributors: string[];
+  links: { github: string; compare: string; download: string };
+};
+
+export const releaseCatalog = source as { schemaVersion: number; releases: ReleaseRecord[] };
+export const releases = releaseCatalog.releases;
+export const latestRelease = releases[0];
+
+export function releasePath(version: string): string {
+  return `/changelog/v${version}/`;
+}

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 <Base
@@ -10,16 +11,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
   <Fragment slot="head"><meta name="robots" content="noindex" /></Fragment>
 
-  <header class="nav scrolled">
-    <div class="nav-inner">
-      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
-      <div class="lang-switch" role="group" aria-label="Language">
-        <button type="button" data-lang="en" class="active">EN</button>
-        <button type="button" data-lang="zh">中文</button>
-      </div>
-      <a class="btn btn-dark" href={`${base}/#start`}><span class="l-en">Install</span><span class="l-zh">安装</span></a>
-    </div>
-  </header>
+  <SiteHeader scrolled />
 
   <main class="hero" style="padding-bottom:150px">
     <div class="wrap">

--- a/site/src/pages/changelog/[version].astro
+++ b/site/src/pages/changelog/[version].astro
@@ -1,0 +1,12 @@
+---
+import ChangelogPage from '../../components/ChangelogPage.astro';
+import { releases } from '../../data/releases';
+
+export function getStaticPaths() {
+  return releases.map((release) => ({ params: { version: `v${release.version}` }, props: { release } }));
+}
+
+const { release } = Astro.props;
+---
+
+<ChangelogPage release={release} releases={releases} />

--- a/site/src/pages/changelog/index.astro
+++ b/site/src/pages/changelog/index.astro
@@ -1,0 +1,6 @@
+---
+import ChangelogPage from '../../components/ChangelogPage.astro';
+import { latestRelease, releases } from '../../data/releases';
+---
+
+<ChangelogPage release={latestRelease} releases={releases} />

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const R2_LATEST = 'https://dl.reasonix.io/latest';
@@ -24,23 +25,7 @@ const R2_DESKTOP = `https://dl.reasonix.io/desktop-${desktopVersion}`;
   titleZh="文档 — Reasonix"
   description="Install Reasonix, start your first session, configure providers and credentials, and understand prefix cache, permissions, sandboxing, MCP plugins, memory, rewind, desktop and bot workflows.">
 
-  <header class="nav scrolled">
-    <div class="nav-inner">
-      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
-      <nav class="nav-links">
-        <a href={`${base}/#features`}><span class="l-en">Features</span><span class="l-zh">特性</span></a>
-        <a href={`${base}/#how`}><span class="l-en">How it works</span><span class="l-zh">工作原理</span></a>
-        <a href={`${base}/#community`}><span class="l-en">Community</span><span class="l-zh">社区</span></a>
-        <a href={`${base}/docs/`} class="here"><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
-        <a href={`${base}/#start`}><span class="l-en">Get started</span><span class="l-zh">快速开始</span></a>
-      </nav>
-      <div class="lang-switch" role="group" aria-label="Language">
-        <button type="button" data-lang="en" class="active">EN</button>
-        <button type="button" data-lang="zh">中文</button>
-      </div>
-      <a class="btn btn-dark" href={`${base}/#start`}><span class="l-en">Install</span><span class="l-zh">安装</span></a>
-    </div>
-  </header>
+  <SiteHeader active="docs" scrolled />
 
   <main class="docs-layout">
     <aside class="docs-side" aria-label="Documentation navigation">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 import community from '../data/community.json';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -48,25 +49,7 @@ const ld = {
 
   <script type="application/ld+json" set:html={JSON.stringify(ld)} slot="head" is:inline />
 
-  <header class="nav">
-    <div class="nav-inner">
-      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
-      <nav class="nav-links">
-        <a href="#features"><span class="l-en">Features</span><span class="l-zh">特性</span></a>
-        <a href="#how"><span class="l-en">How it works</span><span class="l-zh">工作原理</span></a>
-        <a href={`${base}/skills/`}><span class="l-en">Skills</span><span class="l-zh">技能市场</span></a>
-        <a href="#community"><span class="l-en">Community</span><span class="l-zh">社区</span></a>
-        <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
-        <a href="#start"><span class="l-en">Get started</span><span class="l-zh">快速开始</span></a>
-      </nav>
-      <div class="lang-switch" role="group" aria-label="Language">
-        <button type="button" data-lang="en" class="active">EN</button>
-        <button type="button" data-lang="zh">中文</button>
-      </div>
-      <a class="btn btn-ghost" href={`${base}/login/`}><span class="l-en">Sign in</span><span class="l-zh">登录</span></a>
-      <a class="btn btn-dark" href="#start"><span class="l-en">Install</span><span class="l-zh">安装</span></a>
-    </div>
-  </header>
+  <SiteHeader />
 
   <main>
   <section class="hero">
@@ -285,7 +268,7 @@ const ld = {
             <span class="chan-badge pre"><span class="l-en">deprecated</span><span class="l-zh">已废弃</span></span>
           </div>
         </div>
-        <div class="dl-note"><span class="l-en">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> tracks the current 1.x stable · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> release notes →</a></span><span class="l-zh">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> 指向当前 1.x 稳定版 · <a class="rxnotes" href={`${repo}/releases/tag/v${goVer}`}>v<span class="rxv">{goVer}</span> 更新说明 →</a></span></div>
+        <div class="dl-note"><span class="l-en">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> tracks the current 1.x stable · <a class="rxnotes" href={`${base}/changelog/v${goVer}/`}>v<span class="rxv">{goVer}</span> release notes →</a></span><span class="l-zh">macOS / Linux / Windows / WSL · npm <span class="mono">latest</span> 指向当前 1.x 稳定版 · <a class="rxnotes" href={`${base}/changelog/v${goVer}/`}>v<span class="rxv">{goVer}</span> 更新说明 →</a></span></div>
       </div>
 
       <div class="dl-pane" data-pane="brew">

--- a/site/src/pages/skills.astro
+++ b/site/src/pages/skills.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SiteHeader from '../components/SiteHeader.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
@@ -11,23 +12,7 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
   titleZh="Reasonix — 技能与 MCP 市场"
   description={desc}>
 
-  <header class="nav">
-    <div class="nav-inner">
-      <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>
-      <nav class="nav-links">
-        <a href={`${base}/#features`}><span class="l-en">Features</span><span class="l-zh">特性</span></a>
-        <a href={`${base}/skills/`} class="here"><span class="l-en">Skills</span><span class="l-zh">技能市场</span></a>
-        <a href={`${base}/#community`}><span class="l-en">Community</span><span class="l-zh">社区</span></a>
-        <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
-      </nav>
-      <div class="lang-switch" role="group" aria-label="Language">
-        <button type="button" data-lang="en" class="active">EN</button>
-        <button type="button" data-lang="zh">中文</button>
-      </div>
-      <span class="nav-acct" data-account-slot></span>
-      <a class="btn btn-dark" id="publish-open" href="#publish"><span class="l-en">Publish</span><span class="l-zh">发布</span></a>
-    </div>
-  </header>
+  <SiteHeader active="skills" accountSlot />
 
   <main>
   <section class="reg-head">
@@ -53,6 +38,9 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
           <button data-sort="trending" role="tab"><span class="l-en">Trending</span><span class="l-zh">趋势</span></button>
           <button data-sort="installs" role="tab"><span class="l-en">Top</span><span class="l-zh">最热</span></button>
         </div>
+        <a class="btn btn-dark reg-publish" id="publish-open" href="#publish">
+          <span class="l-en">Publish</span><span class="l-zh">发布</span>
+        </a>
       </div>
     </div>
   </section>

--- a/site/src/scripts/changelog.js
+++ b/site/src/scripts/changelog.js
@@ -1,0 +1,31 @@
+(function () {
+  const versionSelect = document.querySelector('[data-release-version]');
+  versionSelect?.addEventListener('change', () => {
+    const version = String(versionSelect.value || '').replace(/^v/, '');
+    if (/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+      window.location.href = `/changelog/v${version}/`;
+    }
+  });
+
+  const links = Array.from(document.querySelectorAll('.release-toc a[href^="#"]'));
+  const sections = links.map((link) => document.querySelector(link.getAttribute('href'))).filter(Boolean);
+  if (!links.length || !sections.length) return;
+
+  let ticking = false;
+  const update = () => {
+    ticking = false;
+    let current = sections[0];
+    for (const section of sections) {
+      if (section.getBoundingClientRect().top <= 150) current = section;
+    }
+    links.forEach((link) => link.classList.toggle('active', link.hash === `#${current.id}`));
+  };
+  const queue = () => {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(update);
+  };
+  window.addEventListener('scroll', queue, { passive: true });
+  window.addEventListener('resize', queue, { passive: true });
+  update();
+})();

--- a/site/src/scripts/header-contract.test.mjs
+++ b/site/src/scripts/header-contract.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("primary site pages share the same header component", async () => {
+  const pages = await Promise.all([
+    source("../pages/index.astro"),
+    source("../pages/docs.astro"),
+    source("../pages/skills.astro"),
+    source("../components/ChangelogPage.astro"),
+    source("../pages/404.astro"),
+  ]);
+
+  for (const page of pages) {
+    assert.match(page, /<SiteHeader\b/);
+    assert.doesNotMatch(page, /<header class="nav/);
+  }
+});
+
+test("the shared header owns the complete global navigation", async () => {
+  const header = await source("../components/SiteHeader.astro");
+
+  for (const id of ["features", "how", "skills", "community", "docs", "changelog", "start"]) {
+    assert.match(header, new RegExp(`id: '${id}'`));
+  }
+
+  assert.match(header, /nav-sign-in/);
+  assert.match(header, /nav-install/);
+});

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -124,7 +124,11 @@ import { downloadPaneFromURL } from "./download-link.js";
   langBtns.forEach((b) => b.addEventListener("click", () => setLang(b.dataset.lang)));
   let savedLang = "";
   try { savedLang = localStorage.getItem(LANG_KEY) || ""; } catch (e) {}
-  setLang(savedLang || ((navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en"));
+  const requestedLang = new URLSearchParams(window.location.search).get("lang");
+  const initialLang = requestedLang === "zh" || requestedLang === "en"
+    ? requestedLang
+    : savedLang || ((navigator.language || "").toLowerCase().startsWith("zh") ? "zh" : "en");
+  setLang(initialLang);
 
   /* docs scrollspy */
   const sideLinks = Array.from(document.querySelectorAll(".docs-side a[href^='#']"));
@@ -169,9 +173,11 @@ import { downloadPaneFromURL } from "./download-link.js";
     "Reasonix-linux-amd64.deb",
     "Reasonix-linux-amd64.tar.gz",
   ];
-  fetch("https://dl.reasonix.io/latest/latest.json", { cache: "no-cache" })
-    .then((r) => (r.ok ? r.json() : null))
-    .then((d) => {
+  const localPreview = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+  if (!localPreview) {
+    fetch("https://dl.reasonix.io/latest/latest.json", { cache: "no-cache" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
       const rawVersion = String((d && d.version) || "");
       const versionMatch = rawVersion.match(/^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/);
       if (!versionMatch) return;
@@ -184,8 +190,9 @@ import { downloadPaneFromURL } from "./download-link.js";
         });
       });
       document.querySelectorAll("a.rxnotes").forEach((a) => {
-        a.href = a.href.replace(/releases\/tag\/v[^/]*$/, "releases/tag/v" + v);
+        a.href = new URL("changelog/v" + v + "/", window.location.origin + "/").href;
       });
-    })
-    .catch(() => {});
+      })
+      .catch(() => {});
+  }
 })();

--- a/site/src/styles/changelog.css
+++ b/site/src/styles/changelog.css
@@ -1,0 +1,376 @@
+:root {
+  --release-paper: #fbfaf7;
+  --release-ink: #20242d;
+  --release-blue: #2f6fe4;
+  --release-blue-soft: #eaf1ff;
+  --release-orange: #d97732;
+  --release-green: #178b67;
+}
+
+body {
+  background:
+    linear-gradient(90deg, transparent 0 49.94%, rgba(47, 111, 228, 0.025) 50%, transparent 50.06%),
+    #f3f5f8;
+}
+
+.release-stage {
+  min-height: 100vh;
+  padding: 108px 34px 80px;
+}
+
+.release-grid {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 220px minmax(0, 920px) 190px;
+  gap: 30px;
+  align-items: start;
+  justify-content: center;
+}
+
+.release-rail,
+.release-toc {
+  position: sticky;
+  top: 96px;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.release-rail__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 4px 0 18px 10px;
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.release-rail__mark {
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--release-blue);
+  border-radius: 3px 3px 3px 0;
+  transform: rotate(-12deg);
+}
+
+.release-rail nav { display: grid; gap: 7px; }
+
+.release-version-link {
+  display: grid;
+  gap: 4px;
+  padding: 12px 13px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: var(--ink-2);
+  text-decoration: none;
+  transition: background .18s, border-color .18s, transform .18s;
+}
+
+.release-version-link:hover {
+  transform: translateX(2px);
+  border-color: var(--line);
+  background: rgba(255,255,255,.68);
+}
+
+.release-version-link.active {
+  border-color: color-mix(in srgb, var(--release-blue) 22%, transparent);
+  background: #fff;
+  color: var(--release-blue);
+  box-shadow: 0 8px 24px rgba(35, 55, 92, .08);
+}
+
+.release-version-link__line { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.release-version-link strong { font-family: var(--font-mono); font-size: 13px; }
+.release-version-link small { color: var(--ink-3); font-size: 11px; }
+.release-version-link em {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--release-blue-soft);
+  color: var(--release-blue);
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.release-rail__all {
+  display: inline-block;
+  margin: 18px 10px;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.release-rail__all:hover { color: var(--release-blue); }
+
+.release-paper {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(41, 50, 70, .11);
+  border-radius: 20px;
+  background:
+    linear-gradient(rgba(47, 111, 228, .035) 1px, transparent 1px) 0 0 / 100% 34px,
+    var(--release-paper);
+  box-shadow: 0 28px 80px -42px rgba(24, 35, 60, .38);
+}
+
+.release-hero {
+  position: relative;
+  padding: 58px 62px 52px;
+  background:
+    radial-gradient(circle at 90% 5%, rgba(47, 111, 228, .14), transparent 28%),
+    linear-gradient(180deg, rgba(255,255,255,.88), rgba(251,250,247,.92));
+}
+
+.release-hero::after {
+  content: "";
+  position: absolute;
+  left: 62px;
+  right: 62px;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--release-blue), var(--line) 36%, transparent);
+}
+
+.release-hero__meta { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.release-hero__meta time { font-family: var(--font-mono); color: var(--ink-3); font-size: 12px; }
+.release-channel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--release-green);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.release-channel__dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 14%, transparent); }
+.release-hero__version { margin: 50px 0 10px; font-family: var(--font-mono); color: var(--release-blue); font-size: 13px; }
+.release-hero h1 {
+  max-width: 15em;
+  margin: 0;
+  color: var(--release-ink);
+  font-size: clamp(38px, 5vw, 62px);
+  font-weight: 600;
+  letter-spacing: -.032em;
+  line-height: 1.04;
+  text-wrap: balance;
+}
+
+.release-surfaces { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 24px; }
+.release-surfaces > span {
+  padding: 5px 9px;
+  border: 1px solid color-mix(in srgb, var(--release-blue) 18%, var(--line));
+  border-radius: 999px;
+  background: rgba(255,255,255,.72);
+  color: var(--ink-2);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.release-hero blockquote {
+  margin: 34px 0 0;
+  padding: 20px 24px;
+  border-left: 3px solid var(--release-blue);
+  border-radius: 0 12px 12px 0;
+  background: rgba(47, 111, 228, .055);
+  color: var(--ink-2);
+  font-size: 17px;
+  line-height: 1.72;
+}
+
+.release-hero__actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
+
+.release-section { padding: 52px 62px 0; scroll-margin-top: 100px; }
+.release-section__head { display: flex; align-items: center; gap: 14px; margin-bottom: 24px; }
+.release-section__head > span {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid color-mix(in srgb, var(--release-blue) 24%, var(--line));
+  border-radius: 8px;
+  color: var(--release-blue);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+.release-section h2 { color: var(--release-ink); font-size: 27px; font-weight: 650; letter-spacing: -.02em; }
+.release-section h3 { color: var(--release-ink); font-size: 17px; font-weight: 650; line-height: 1.35; }
+.release-section p { color: var(--ink-2); font-size: 15px; line-height: 1.68; }
+
+.release-guide-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.release-guide {
+  position: relative;
+  display: grid;
+  align-content: start;
+  min-height: 168px;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255,255,255,.72);
+  color: inherit;
+  text-decoration: none;
+  transition: transform .2s, border-color .2s, box-shadow .2s;
+}
+.release-guide:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--release-blue) 35%, var(--line)); box-shadow: 0 18px 35px -24px rgba(35, 65, 120, .4); }
+.release-guide__arrow { position: absolute; top: 18px; right: 18px; color: var(--release-blue); font-size: 18px; }
+.release-guide h3 { padding-right: 24px; }
+.release-guide p { margin-top: 12px; font-size: 13.5px; }
+
+.release-highlight-list { display: grid; gap: 12px; }
+.release-highlight {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255,255,255,.68);
+}
+.release-highlight__index { color: color-mix(in srgb, var(--release-blue) 48%, var(--ink-3)); font-family: var(--font-mono); font-size: 12px; padding-top: 4px; }
+.release-highlight__kind { margin-bottom: 7px; color: var(--release-blue); font-size: 10px; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.release-highlight[data-kind="security"] .release-highlight__kind { color: var(--release-orange); }
+.release-highlight[data-kind="fixed"] .release-highlight__kind { color: var(--release-green); }
+.release-highlight p { margin-top: 8px; }
+.release-refs { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 13px; }
+.release-refs a {
+  padding: 3px 7px;
+  border-radius: 6px;
+  background: var(--release-blue-soft);
+  color: #2456b8;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.release-change-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.release-change-list article {
+  padding: 20px 22px;
+  border-top: 2px solid color-mix(in srgb, var(--release-blue) 42%, var(--line));
+  background: rgba(255,255,255,.46);
+}
+.release-change-list p { margin-top: 8px; font-size: 14px; }
+
+.release-notice-list { display: grid; gap: 10px; }
+.release-notice {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 14px;
+  padding: 18px 20px;
+  border: 1px solid color-mix(in srgb, var(--release-blue) 22%, var(--line));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--release-blue-soft) 56%, white);
+}
+.release-notice--warning { border-color: color-mix(in srgb, var(--release-orange) 32%, var(--line)); background: color-mix(in srgb, #fff0e5 66%, white); }
+.release-notice__icon { display: grid; place-items: center; width: 26px; height: 26px; border-radius: 50%; background: var(--release-blue); color: white; font-family: var(--font-mono); font-size: 12px; font-weight: 700; }
+.release-notice--warning .release-notice__icon { background: var(--release-orange); }
+.release-notice p { margin-top: 6px; font-size: 14px; }
+
+.release-thanks > p { margin-bottom: 14px; }
+.release-thanks > div { display: flex; flex-wrap: wrap; gap: 8px; }
+.release-thanks a { padding: 6px 10px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,.7); color: var(--ink-2); font-family: var(--font-mono); font-size: 11px; text-decoration: none; }
+.release-thanks a:hover { color: var(--release-blue); border-color: color-mix(in srgb, var(--release-blue) 34%, var(--line)); }
+
+.release-download {
+  margin: 56px 62px 62px;
+  padding: 30px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 26px;
+  border-radius: 16px;
+  background: var(--release-ink);
+}
+.release-download h2 { max-width: 480px; color: #fff; font-size: 28px; }
+.release-download__kicker { margin-bottom: 7px; color: #91b8ff !important; font-size: 11px !important; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.release-download__actions { display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+.release-compare { color: #c9d4e9; font-size: 13px; font-weight: 600; text-decoration: none; }
+.release-compare:hover { color: #fff; }
+
+.release-toc { padding: 6px 0 20px; }
+.release-toc > p { margin: 0 0 16px 12px; color: var(--release-ink); font-size: 13px; font-weight: 700; }
+.release-toc nav { display: grid; border-left: 1px solid var(--line); }
+.release-toc a {
+  position: relative;
+  padding: 7px 0 7px 13px;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 550;
+  text-decoration: none;
+  transition: color .16s;
+}
+.release-toc a::before { content: ""; position: absolute; left: -1px; top: 5px; bottom: 5px; width: 2px; border-radius: 4px; background: transparent; }
+.release-toc a:hover { color: var(--release-ink); }
+.release-toc a.active { color: var(--release-blue); }
+.release-toc a.active::before { background: var(--release-blue); }
+
+.release-mobile-switcher { display: none; }
+.release-footer {
+  width: min(1180px, calc(100% - 64px));
+  margin: 0 auto;
+  padding: 28px 0 38px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  border-top: 1px solid var(--line);
+  color: var(--ink-3);
+  font-size: 12px;
+}
+.release-footer > span { margin-left: auto; color: #686b70; }
+.release-footer > a:last-child { color: var(--ink-2); text-decoration: none; }
+
+@media (max-width: 1180px) {
+  .release-grid { grid-template-columns: 200px minmax(0, 850px); }
+  .release-toc { display: none; }
+}
+
+@media (max-width: 840px) {
+  .release-stage { padding: 92px 16px 48px; }
+  .release-grid { display: block; }
+  .release-rail { display: none; }
+  .release-mobile-switcher {
+    width: min(720px, 100%);
+    margin: 0 auto 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: #fff;
+    color: var(--ink-2);
+    font-size: 12px;
+    font-weight: 700;
+  }
+  .release-mobile-switcher select { min-width: 130px; padding: 7px 28px 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-soft); color: var(--ink); font: inherit; }
+  .release-paper { width: min(720px, 100%); margin: 0 auto; border-radius: 15px; }
+  .release-hero { padding: 38px 28px 34px; }
+  .release-hero::after { left: 28px; right: 28px; }
+  .release-hero__version { margin-top: 36px; }
+  .release-section { padding: 40px 28px 0; }
+  .release-guide-grid, .release-change-list { grid-template-columns: 1fr; }
+  .release-download { margin: 44px 28px 28px; padding: 26px; flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 560px) {
+  .release-hero h1 { font-size: 36px; }
+  .release-hero blockquote { padding: 17px 18px; font-size: 15px; }
+  .release-highlight { grid-template-columns: 1fr; gap: 8px; padding: 20px; }
+  .release-highlight__index { display: none; }
+  .release-section h2 { font-size: 23px; }
+  .release-download__actions { align-items: flex-start; flex-direction: column; }
+  .release-footer { width: calc(100% - 32px); flex-wrap: wrap; }
+  .release-footer > span { order: 3; width: 100%; margin: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .release-version-link, .release-guide { transition: none; }
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -74,14 +74,15 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
   box-shadow: 0 1px 0 var(--line);
 }
 .nav-inner {
-  display: flex; align-items: center; gap: 24px;
-  height: 68px; max-width: 1180px; margin: 0 auto; padding: 0 40px;
+  display: flex; align-items: center; gap: 18px;
+  height: 68px; max-width: 1480px; margin: 0 auto; padding: 0 40px;
 }
-.brand { display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
+.brand { display: flex; flex: none; align-items: center; gap: 10px; text-decoration: none; color: var(--ink); }
 .brand img { width: 28px; height: 28px; border-radius: 8px; display: block; }
 .brand span { font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
-.nav-links { display: flex; gap: 6px; margin-right: auto; margin-left: 18px; }
+.nav-links { display: flex; min-width: 0; gap: 6px; margin-right: auto; margin-left: 18px; }
 .nav-links a {
+  flex: none; white-space: nowrap;
   color: var(--ink-2); text-decoration: none; font-size: 14.5px; font-weight: 500;
   padding: 8px 14px; border-radius: 999px;
   transition: color 0.2s, background 0.2s;
@@ -100,6 +101,11 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .btn-ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
 .btn-ghost:hover { background: var(--accent-soft); border-color: transparent; }
 .nav .btn { padding: 9px 20px; font-size: 14px; }
+.nav .btn, .nav .lang-switch, .nav-acct { flex: none; }
+
+@media (max-width: 1260px) {
+  .nav-link--secondary { display: none; }
+}
 
 /* hero */
 .hero { position: relative; padding: 150px 0 0; text-align: center; }


### PR DESCRIPTION
## Summary

- Add a versioned, validated bilingual release catalog that drives the website changelog and the CLI/Desktop GitHub release bodies from one reviewed source.
- Add a manually dispatched `Prepare release notes` workflow that collects public merged-PR metadata, asks DeepSeek V4 Pro for a product-focused English/Chinese draft, validates its structure and PR citations, and opens or updates a review PR.
- Add responsive `/changelog/` and `/changelog/vX.Y.Z/` pages, share one primary site header across the main public pages, and link the homepage release note entry to the matching version.
- Keep the Desktop experience lightweight: Settings exposes one “Open on web” row, while update banners link directly to the matching version page.
- Make stable CLI and Desktop release jobs render the reviewed catalog entry instead of generating independent commit-oriented notes, and document the updated release loop.

Operational notes:

- `DEEPSEEK_API_KEY` must be configured as a repository Actions secret before running the manual draft workflow.
- DeepSeek is an editorial drafting dependency only. Runtime code and tag-triggered publication never call a model and never receive the API key.
- A missing reviewed catalog entry intentionally blocks a stable CLI or Desktop publication.
- No credential value is committed in this change.

## Verification

- `node scripts/release-notes.mjs validate`
- `node --test scripts/release-notes.test.mjs`
- `npm test` in `site/` — 14 tests passed
- `astro build` in `site/` — 18 static pages built
- `pnpm run build` in `desktop/frontend/`
- `actionlint` on all affected workflows, ignoring only the repository's existing `windows-11-arm` custom-runner label
- `git diff --check`
- Browser verification at 1440 px and 1024 px for the homepage and v1.17.13 changelog navigation
- Cross-checked every PR reference in the v1.17.13 record against its merged GitHub PR

## Cache impact

Cache-impact: none — release metadata, website UI, Desktop links, and publication workflows do not change provider-visible prompts, tool schemas, request serialization, compaction, or ordering.
Cache-guard: existing `scripts/cache-guard.sh` remains applicable; no cache-sensitive path changed.
System-prompt-review: N/A
