### PR TITLE
Fix release-notes generation test / 修复更新日志生成测试

### DIFF
--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -5,7 +5,6 @@ import { loadCatalog, releaseForVersion, renderGitHubRelease, validateCatalog } 
 test("the committed release catalog is valid and newest first", async () => {
   const catalog = await loadCatalog();
   assert.equal(catalog.schemaVersion, 1);
-  assert.equal(catalog.releases[0].version, "1.17.13");
   assert.equal(new Set(catalog.releases.map((release) => release.version)).size, catalog.releases.length);
 });
 


### PR DESCRIPTION
## Problem

The release-notes preparation workflow generates the next catalog entry and then immediately runs the catalog tests. The test required version 1.17.13 to remain the first entry, so every later release failed after successful generation and validation.

## Root cause

A mutable release version was duplicated as a hard-coded assertion. loadCatalog already validates schema, uniqueness, and descending semantic-version order.

## Fix

Remove the stale version assertion while retaining the durable catalog invariants.

## Verification

- node scripts/release-notes.mjs validate
- node --test scripts/release-notes.test.mjs
- git diff --check