### PR TITLE
Restore v0.53 secret handling semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ branch.
   transcripts, recovery branches, and background-job artifacts retain their
   original text instead of being rewritten by heuristic secret redaction.
   Credential masking remains in key-entry summaries and explicit diagnostic or
-  session-cleanup paths.
+  session-cleanup paths. Transcript-bearing session/job sidecars are kept
+  private (`0600`, with private job directories), and the retired
+  `redact_tool_output` setting is removed with a one-time upgrade notice.
 
 ## [1.0.0] — 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ branch.
   but are ignored and removed by a one-time migration so stale hidden limits
   cannot truncate new behavior. One-off CLI and unattended bot limits remain.
 
+### Fixed
+
+- Restored the `0.53` content boundary: model output, tool output, session
+  transcripts, recovery branches, and background-job artifacts retain their
+  original text instead of being rewritten by heuristic secret redaction.
+  Credential masking remains in key-entry summaries and explicit diagnostic or
+  session-cleanup paths.
+
 ## [1.0.0] — 2026-06-03
 
 First stable release — a **ground-up rewrite in Go**. Not an upgrade of the `0.x`

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,7 +26,6 @@ import (
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
-	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
 	"reasonix/internal/workspacelease"
@@ -3170,7 +3169,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 			if rc.ProxyAction == "call" && !rc.Unavailable {
 				a.noteCapabilityInvocation(call.Name, json.RawMessage(call.Arguments), nil)
 			}
-			result := secrets.RedactToolOutput(rc.Result)
+			result := rc.Result
 			if a.evidence != nil {
 				// inspect/decline are not mutations; unavailable call targets are not success.
 				success := !rc.Unavailable
@@ -3386,7 +3385,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	callID := call.ID
 	cctx = tool.WithProgress(cctx, func(chunk string) {
-		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: secrets.RedactToolOutput(chunk)}})
+		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: chunk}})
 	})
 	var result string
 	var images []string
@@ -3418,7 +3417,6 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	} else {
 		result, err = runTool.Execute(cctx, runArgs)
 	}
-	result = secrets.RedactToolOutput(result)
 	if a.evidence != nil {
 		// Always record the model-visible call for audit, then the real target
 		// attributes for mutation/read classification when they differ.

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -20,7 +20,6 @@ import (
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/provider"
-	"reasonix/internal/secrets"
 	"reasonix/internal/store"
 )
 
@@ -203,16 +202,6 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 	// stalest capture written last would then read the newer transcript it
 	// lost the race to as a bogus stale-prefix conflict.
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
-	// Durable transcripts are always redacted, independent of the live
-	// [secrets] redact_tool_output toggle. Digest consistency holds because
-	// Redact is deterministic and idempotent (see secrets.Redact): a loaded
-	// session's messages are already redacted, so re-redacting them here is a
-	// byte-for-byte no-op and the snapshot keeps its prefix relationship to
-	// the on-disk transcript — the same digest/prefix machinery that guards
-	// against bogus stale-prefix conflicts (#6083) sees identical bytes. The
-	// persisted baseline (markPersisted) is likewise recorded over the
-	// redacted form, matching what LoadSession will digest back.
-	msgs = secrets.RedactMessages(msgs)
 	digest, contentBytes, err := digestAndSizeSessionMessages(msgs)
 	if err != nil {
 		return err
@@ -553,11 +542,6 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 		return RecoveryBranchInfo{}, fmt.Errorf("empty original session path")
 	}
 	msgs, version, rewriteVersion := s.snapshotWithVersion()
-	// Same redaction contract as save(): recovery branches are durable
-	// transcripts too, and the coverage checks below compare against on-disk
-	// content that save() already redacted — comparing a raw snapshot against
-	// it would misread pure coverage as divergence and fork a bogus branch.
-	msgs = secrets.RedactMessages(msgs)
 	preview, turns := SessionPreviewFromMessages(msgs)
 	if turns == 0 {
 		return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,43 @@ func TestSavePreservesToolContentOnDisk(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "DEEPSEEK_API_KEY="+secret) {
 		t.Fatalf("session did not persist tool content verbatim:\n%s", body)
+	}
+}
+
+func TestSaveProtectsVerbatimSessionEventLog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file ACLs are not represented by Unix permission bits")
+	}
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
+	s.Add(provider.Message{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "API_KEY=raw-secret"})
+	path := filepath.Join(t.TempDir(), "private.jsonl")
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("first SaveSnapshot: %v", err)
+	}
+	eventPath := store.SessionEventLog(path)
+	assertPrivateSessionFile(t, eventPath)
+
+	// Simulate an event log created by a previous release. The next append must
+	// tighten the existing inode before writing any new unredacted content.
+	if err := os.Chmod(eventPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("append SaveSnapshot: %v", err)
+	}
+	assertPrivateSessionFile(t, eventPath)
+}
+
+func assertPrivateSessionFile(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("%s mode = %04o, want 0600", path, got)
 	}
 }
 

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -68,7 +68,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSaveRedactsSecretsOnDisk(t *testing.T) {
+func TestSavePreservesToolContentOnDisk(t *testing.T) {
 	secret := "sk-real-secret-value-123456"
 	s := NewSession("sys")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
@@ -79,7 +79,7 @@ func TestSaveRedactsSecretsOnDisk(t *testing.T) {
 		Content:    "DEEPSEEK_API_KEY=" + secret + "\n",
 	})
 
-	path := filepath.Join(t.TempDir(), "redacted.jsonl")
+	path := filepath.Join(t.TempDir(), "verbatim.jsonl")
 	if err := s.Save(path); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -87,21 +87,15 @@ func TestSaveRedactsSecretsOnDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read saved session: %v", err)
 	}
-	if strings.Contains(string(body), secret) {
-		t.Fatalf("session persisted raw secret:\n%s", body)
-	}
-	if !strings.Contains(string(body), "DEEPSEEK_API_KEY=sk-rea") {
-		t.Fatalf("session did not persist a masked credential marker:\n%s", body)
+	if !strings.Contains(string(body), "DEEPSEEK_API_KEY="+secret) {
+		t.Fatalf("session did not persist tool content verbatim:\n%s", body)
 	}
 }
 
-// TestSaveRedactionKeepsSnapshotBaselineStable is the digest-consistency
-// contract behind redact-on-save: because Redact is idempotent, a loaded
-// (already-redacted) transcript re-saves as the exact same bytes, so
-// SaveSnapshot must take the up-to-date path — no rewrite, no revision bump,
-// and above all no bogus snapshot conflict / recovery fork (#6083's failure
-// shape). Appending after the resave must land as a plain append.
-func TestSaveRedactionKeepsSnapshotBaselineStable(t *testing.T) {
+// TestSaveVerbatimRoundTripKeepsSnapshotBaselineStable pins digest consistency
+// for byte-preserving transcripts: a loaded transcript re-saves without a
+// rewrite or revision bump, and appending afterward remains a plain append.
+func TestSaveVerbatimRoundTripKeepsSnapshotBaselineStable(t *testing.T) {
 	secret := "sk-real-secret-value-123456"
 	s := NewSession("sys")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "inspect"})
@@ -125,24 +119,21 @@ func TestSaveRedactionKeepsSnapshotBaselineStable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	// Re-saving the loaded transcript re-runs RedactMessages over content that
-	// is already masked; idempotence means identical bytes and the up-to-date
-	// skip, not a conflict or a revision bump.
 	if err := loaded.SaveSnapshot(path); err != nil {
-		t.Fatalf("resave of loaded redacted session: %v", err)
+		t.Fatalf("resave of loaded session: %v", err)
 	}
 	rev2, _, err := sessionContentRevision(path)
 	if err != nil {
 		t.Fatalf("read revision after resave: %v", err)
 	}
 	if rev1 != rev2 {
-		t.Fatalf("no-op resave bumped revision %d -> %d; redaction broke digest stability", rev1, rev2)
+		t.Fatalf("no-op resave bumped revision %d -> %d", rev1, rev2)
 	}
 
 	// A continued conversation still append-saves cleanly on top.
 	loaded.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
 	if err := loaded.SaveSnapshot(path); err != nil {
-		t.Fatalf("append snapshot after redacted round-trip: %v", err)
+		t.Fatalf("append snapshot after verbatim round-trip: %v", err)
 	}
 	reloaded, err := LoadSession(path)
 	if err != nil {

--- a/internal/agent/secret_redaction_test.go
+++ b/internal/agent/secret_redaction_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"reasonix/internal/provider"
@@ -20,16 +19,14 @@ func (secretOutputTool) Execute(context.Context, json.RawMessage) (string, error
 	return "DEEPSEEK_API_KEY=sk-real-secret-value-123456\n", nil
 }
 
-func TestExecuteOneRedactsToolResultBeforeHistory(t *testing.T) {
+func TestExecuteOnePreservesToolResultBeforeHistory(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(secretOutputTool{})
 	a := &Agent{tools: reg, session: NewSession("")}
 
 	outcome := a.executeOne(context.Background(), provider.ToolCall{ID: "call_1", Name: "secret_output", Arguments: `{}`})
-	if strings.Contains(outcome.output, "sk-real-secret-value-123456") {
-		t.Fatalf("tool outcome leaked raw secret:\n%s", outcome.output)
-	}
-	if !strings.Contains(outcome.output, "DEEPSEEK_API_KEY=sk-rea") {
-		t.Fatalf("tool outcome missing masked marker:\n%s", outcome.output)
+	const want = "DEEPSEEK_API_KEY=sk-real-secret-value-123456\n"
+	if outcome.output != want {
+		t.Fatalf("tool outcome = %q, want byte-preserving output %q", outcome.output, want)
 	}
 }

--- a/internal/agent/session_events.go
+++ b/internal/agent/session_events.go
@@ -320,8 +320,12 @@ func repairSessionEventLogTail(sessionPath string) error {
 	}
 	// The truncation point sits exactly at the end of a JSON value; restore
 	// the trailing newline so the file stays line-oriented for external tools.
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
+		return err
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
 		return err
 	}
 	if _, err := f.Write([]byte{'\n'}); err != nil {
@@ -351,9 +355,17 @@ func appendSessionEvent(sessionPath string, rec sessionEventRecord, sync bool) e
 		return fmt.Errorf("encode session event: %w", err)
 	}
 	buf = append(buf, '\n')
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("open session event log: %w", err)
+	}
+	// The event log carries the complete transcript. Chmod after opening so
+	// upgrading a pre-v0.53-boundary 0644 sidecar tightens the existing inode
+	// before any unredacted message is appended; OpenFile's perm only applies
+	// when the file is newly created.
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("protect session event log: %w", err)
 	}
 	if _, err := f.Write(buf); err != nil {
 		_ = f.Close()
@@ -421,7 +433,7 @@ func compactSessionEventLog(sessionPath string, msgs []provider.Message, digest 
 		return fmt.Errorf("encode session event: %w", err)
 	}
 	buf = append(buf, '\n')
-	return fileutil.AtomicWriteFile(path, buf, 0o644)
+	return fileutil.AtomicWriteFile(path, buf, 0o600)
 }
 
 func readSessionEventIndex(sessionPath string) (*sessionEventIndex, error) {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -178,9 +178,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	var migErr error
 	var stepLimitsMigrated bool
 	var stepLimitMigErr error
+	var redactToolOutputMigrated bool
+	var redactToolOutputMigErr error
 	if !config.SafeModeRequested() {
 		migrated, migErr = config.MigrateLegacyIfNeededForRoot(root)
 		stepLimitsMigrated, stepLimitMigErr = config.MigrateLegacyAgentStepLimitsForRoot(root)
+		redactToolOutputMigrated, redactToolOutputMigErr = config.MigrateLegacyRedactToolOutputForRoot(root)
 	}
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
@@ -254,6 +257,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		})
 	} else if stepLimitMigErr != nil {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "Deprecated agent step-limit migration did not complete.", Detail: stepLimitMigErr.Error()})
+	}
+	if redactToolOutputMigrated || redactToolOutputMigErr != nil {
+		level := event.LevelInfo
+		text := "Deprecated redact_tool_output setting was removed."
+		detail := "[secrets].redact_tool_output no longer has any effect: ordinary model/tool content and local session/job artifacts now preserve their original text. Explicit diagnostics and reasonix doctor redact-sessions still redact credential values."
+		if redactToolOutputMigErr != nil {
+			level = event.LevelWarn
+			text = "Deprecated redact_tool_output setting was ignored."
+			detail += " The old key could not be removed: " + redactToolOutputMigErr.Error()
+		}
+		sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text, Detail: detail})
 	}
 	// Safe Mode is a recovery boundary: it must not rewrite memory or session
 	// state that a crash may have corrupted, so the legacy-store imports run

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -190,7 +190,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// section before any tool, hook, or plugin subprocess can spawn. Package
 	// globals are correct here because [secrets] is user-global (project
 	// reasonix.toml cannot override it), so concurrent workspaces agree.
-	secrets.SetRedactToolOutput(cfg.SecretsRedactToolOutput())
 	secrets.SetFilterSubprocessEnv(cfg.Secrets.FilterSubprocessEnv)
 	secrets.SetProtectSensitiveFiles(cfg.Secrets.ProtectSensitiveFiles)
 	secrets.RegisterCredentialEnvKeys(cfg.CredentialEnvNames())

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3542,6 +3542,70 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildMigratesDeprecatedRedactToolOutputWithOneNotice(t *testing.T) {
+	home := isolateConfigHome(t)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, "reasonix-home"))
+	project := robustTempDir(t)
+	configPath := filepath.Join(project, "reasonix.toml")
+	writeFile(t, project, "reasonix.toml", `
+default_model = "test-model"
+
+[secrets]
+redact_tool_output = true
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	var notices []event.Event
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	})
+	build := func() {
+		t.Helper()
+		ctrl, err := Build(context.Background(), Options{Sink: sink, WorkspaceRoot: project})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		ctrl.Close()
+	}
+
+	build()
+	migrationNotices := 0
+	for _, notice := range notices {
+		if notice.Text == "Deprecated redact_tool_output setting was removed." {
+			migrationNotices++
+			if notice.Level != event.LevelInfo || !strings.Contains(notice.Detail, "doctor redact-sessions") {
+				t.Fatalf("migration notice = %+v", notice)
+			}
+		}
+	}
+	if migrationNotices != 1 {
+		t.Fatalf("migration notices = %d, want 1; got %+v", migrationNotices, notices)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "redact_tool_output") {
+		t.Fatalf("deprecated redact_tool_output remains after boot:\n%s", raw)
+	}
+
+	notices = nil
+	build()
+	for _, notice := range notices {
+		if strings.Contains(notice.Text, "redact_tool_output") {
+			t.Fatalf("second boot repeated migration notice: %+v", notice)
+		}
+	}
+}
+
 func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
 	home := robustTempDir(t)
 	t.Setenv("HOME", home)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,14 +98,9 @@ func (c *Config) IgnoredProjectDefaultModel() string {
 
 // SecretsConfig controls the credential protection layers. It is a user-global
 // setting: project reasonix.toml values are ignored (see LoadForRoot), so a
-// cloned repository cannot silently switch off redaction or opt the user into
-// workflow-breaking protections.
+// cloned repository cannot silently opt the user into workflow-breaking
+// protections.
 type SecretsConfig struct {
-	// RedactToolOutput masks credential-shaped values in tool output before it
-	// enters model context and UI events. Nil keeps the default enabled.
-	// Session transcripts and background-job artifacts on disk are always
-	// redacted, regardless of this switch.
-	RedactToolOutput *bool `toml:"redact_tool_output"`
 	// FilterSubprocessEnv strips credential-like environment variables
 	// (*_API_KEY, *TOKEN*, *SECRET*, ...) from tool subprocesses (bash, hooks,
 	// LSP, MCP stdio). Default off: it breaks token-based workflows such as
@@ -113,15 +108,9 @@ type SecretsConfig struct {
 	FilterSubprocessEnv bool `toml:"filter_subprocess_env"`
 	// ProtectSensitiveFiles makes read/list/search tools treat credential
 	// paths (.env, .git-credentials, .netrc, *.pem/*.key/*.p12/*.pfx, ~/.ssh)
-	// as invisible. Default off: output redaction already masks the values,
-	// and hiding the files breaks legitimate "edit my .env" workflows.
+	// as invisible. Default off because hiding the files breaks legitimate
+	// "edit my .env" workflows.
 	ProtectSensitiveFiles bool `toml:"protect_sensitive_files"`
-}
-
-// SecretsRedactToolOutput reports whether live tool output redaction is
-// enabled (default true).
-func (c *Config) SecretsRedactToolOutput() bool {
-	return c == nil || c.Secrets.RedactToolOutput == nil || *c.Secrets.RedactToolOutput
 }
 
 type providerSourceScope string

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1348,6 +1348,67 @@ temperature = 0.8
 	}
 }
 
+func TestMigrateLegacyRedactToolOutputForRoot(t *testing.T) {
+	isolateUserConfigHome(t)
+	root := t.TempDir()
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(`[secrets]
+redact_tool_output = true
+filter_subprocess_env = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(root, "reasonix.toml")
+	if err := os.WriteFile(projectPath, []byte(`[secrets]
+redact_tool_output = false
+protect_sensitive_files = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := MigrateLegacyRedactToolOutputForRoot(root)
+	if err != nil {
+		t.Fatalf("MigrateLegacyRedactToolOutputForRoot: %v", err)
+	}
+	if !changed {
+		t.Fatal("first migration should remove deprecated redact_tool_output keys")
+	}
+	for _, path := range []string{userPath, projectPath} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(raw), "redact_tool_output") {
+			t.Fatalf("deprecated redact_tool_output remains in %s:\n%s", path, raw)
+		}
+	}
+	userRaw, err := os.ReadFile(userPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(userRaw), "filter_subprocess_env = true") {
+		t.Fatalf("migration removed an active secrets setting:\n%s", userRaw)
+	}
+	projectRaw, err := os.ReadFile(projectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(projectRaw), "protect_sensitive_files = true") {
+		t.Fatalf("migration removed an unrelated project setting:\n%s", projectRaw)
+	}
+
+	again, err := MigrateLegacyRedactToolOutputForRoot(root)
+	if err != nil {
+		t.Fatalf("second migration: %v", err)
+	}
+	if again {
+		t.Fatal("migration should be a no-op after deprecated keys are removed")
+	}
+}
+
 func TestLoadForRootReadOnlyIgnoresDeprecatedAgentStepLimitsWithoutRewriting(t *testing.T) {
 	isolateUserConfigHome(t)
 	root := t.TempDir()

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -733,7 +733,11 @@ func normalizeLegacyAgentStepLimits(c *Config) bool {
 	return found
 }
 
-var legacyAgentStepLimitMigrationMu sync.Mutex
+// retiredConfigKeyMigrationMu serializes the independent one-time removals
+// below. They may target the same user/project TOML files from concurrent
+// desktop builds, so separate locks could race and restore a key another
+// migration had just removed.
+var retiredConfigKeyMigrationMu sync.Mutex
 
 // MigrateLegacyAgentStepLimitsForRoot removes retired [agent] step-limit keys
 // from the user and project config selected for root. Boot calls it immediately
@@ -772,8 +776,8 @@ func MigrateLegacyAgentStepLimitsForRoot(root string) (bool, error) {
 // before runtime decoding. A process-wide lock makes concurrent desktop tab
 // builds observe a single migration; the atomic rewrite protects other readers.
 func migrateLegacyAgentStepLimitsFile(path string) (bool, error) {
-	legacyAgentStepLimitMigrationMu.Lock()
-	defer legacyAgentStepLimitMigrationMu.Unlock()
+	retiredConfigKeyMigrationMu.Lock()
+	defer retiredConfigKeyMigrationMu.Unlock()
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -806,6 +810,83 @@ func stripLegacyAgentStepLimitLines(raw string) (string, bool) {
 			section = header
 		}
 		if section == "agent" && (isTOMLKeyAssignment(line, "max_steps") || isTOMLKeyAssignment(line, "planner_max_steps")) {
+			changed = true
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n"), changed
+}
+
+// MigrateLegacyRedactToolOutputForRoot removes the retired
+// [secrets].redact_tool_output setting from the user and project configs chosen
+// for root. The setting no longer controls any runtime behavior; removing it
+// avoids leaving an explicit `true` value on disk that falsely suggests live
+// output or transcript redaction is still active.
+func MigrateLegacyRedactToolOutputForRoot(root string) (bool, error) {
+	root = resolveRoot(root)
+	paths := make([]string, 0, 2)
+	if userPath := userConfigLoadPath(); userPath != "" {
+		paths = append(paths, userPath)
+	}
+	projectPath := "reasonix.toml"
+	if root != "." {
+		projectPath = filepath.Join(root, "reasonix.toml")
+	}
+	paths = append(paths, projectPath)
+
+	changedAny := false
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		changed, err := migrateLegacyRedactToolOutputFile(path)
+		if err != nil {
+			return changedAny, fmt.Errorf("migrate deprecated redact_tool_output in %s: %w", path, err)
+		}
+		changedAny = changedAny || changed
+	}
+	return changedAny, nil
+}
+
+func migrateLegacyRedactToolOutputFile(path string) (bool, error) {
+	retiredConfigKeyMigrationMu.Lock()
+	defer retiredConfigKeyMigrationMu.Unlock()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	raw, err := fileencoding.ReadFileUTF8(path)
+	if err != nil {
+		return false, err
+	}
+	next, changed := stripLegacyRedactToolOutputLines(string(raw))
+	if !changed {
+		return false, nil
+	}
+	if err := fileutil.AtomicWriteFile(path, []byte(next), info.Mode().Perm()); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func stripLegacyRedactToolOutputLines(raw string) (string, bool) {
+	lines := strings.Split(raw, "\n")
+	section := ""
+	changed := false
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if header := tomlSectionHeader(line); header != "" {
+			section = header
+		}
+		if section == "secrets" && isTOMLKeyAssignment(line, "redact_tool_output") {
 			changed = true
 			continue
 		}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -73,14 +73,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	}
 	globalMemoryCompiler := cfg.Agent.MemoryCompiler
 	userDefaultModel := cfg.DefaultModel
-	// Deep-copy: TOML decoding writes through an existing *bool rather than
-	// replacing it, so a shallow struct copy would alias the pointer and the
-	// project merge below would mutate the captured global value in place.
 	globalSecrets := cfg.Secrets
-	if cfg.Secrets.RedactToolOutput != nil {
-		v := *cfg.Secrets.RedactToolOutput
-		globalSecrets.RedactToolOutput = &v
-	}
 
 	tomlSources = append(tomlSources, projectTOML)
 	if err := mergeTOML(cfg, projectTOML); err != nil {
@@ -88,8 +81,8 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	}
 	cfg.Agent.MemoryCompiler = globalMemoryCompiler
 	// Secret protection is a user-global security control: a cloned repo's
-	// reasonix.toml must not be able to disable redaction or flip on the
-	// workflow-breaking env/path protections.
+	// reasonix.toml must not be able to flip on the workflow-breaking env/path
+	// protections.
 	cfg.Secrets = globalSecrets
 	// TOML decoding replaces [[plugins]] wholesale, so cfg.Plugins now holds
 	// only the last file's. Re-merge by name across all sources (later wins) so a

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -638,11 +638,6 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	// whole file from the struct).
 	if scope != RenderScopeProject {
 		b.WriteString("[secrets]   # credential protection; user/global only, ./reasonix.toml cannot override\n")
-		if c.Secrets.RedactToolOutput != nil {
-			fmt.Fprintf(&b, "redact_tool_output = %v   # mask secret-shaped values in tool output before model context/UI; transcripts and job artifacts are always redacted on disk\n", *c.Secrets.RedactToolOutput)
-		} else {
-			b.WriteString("# redact_tool_output = true   # default on; set false only if masking breaks fixture-heavy edit workflows\n")
-		}
 		if c.Secrets.FilterSubprocessEnv {
 			b.WriteString("filter_subprocess_env = true   # strip credential-named env vars from tool/hook/LSP/MCP subprocesses\n")
 		} else {
@@ -651,7 +646,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		if c.Secrets.ProtectSensitiveFiles {
 			b.WriteString("protect_sensitive_files = true   # hide .env/.git-credentials/key files/~/.ssh from read tools\n")
 		} else {
-			b.WriteString("# protect_sensitive_files = false   # opt-in; values are already masked by redaction even when files stay readable\n")
+			b.WriteString("# protect_sensitive_files = false   # opt-in; hiding credential files can break legitimate edit workflows\n")
 		}
 		b.WriteString("\n")
 	}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1321,8 +1321,7 @@ func TestMigrateLegacyIfNeededSkipsWhenIsolated(t *testing.T) {
 
 // TestProjectConfigCannotOverrideSecrets pins [secrets] as a user-global
 // security control: a cloned repository's reasonix.toml must not be able to
-// switch off tool-output redaction or opt the user into subprocess env
-// stripping / sensitive-path hiding.
+// opt the user into subprocess env stripping or sensitive-path hiding.
 func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
 	isolateUserConfigHome(t)
 	t.Setenv("REASONIX_HOME", "")
@@ -1330,13 +1329,13 @@ func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
 	if err := os.MkdirAll(globalDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	globalTOML := "[secrets]\nredact_tool_output = true\nfilter_subprocess_env = false\nprotect_sensitive_files = false\n"
+	globalTOML := "[secrets]\nfilter_subprocess_env = false\nprotect_sensitive_files = false\n"
 	if err := os.WriteFile(filepath.Join(globalDir, "config.toml"), []byte(globalTOML), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	project := t.TempDir()
-	projectTOML := "[secrets]\nredact_tool_output = false\nfilter_subprocess_env = true\nprotect_sensitive_files = true\n"
+	projectTOML := "[secrets]\nfilter_subprocess_env = true\nprotect_sensitive_files = true\n"
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(projectTOML), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1344,9 +1343,6 @@ func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
 	cfg, err := LoadForRoot(project)
 	if err != nil {
 		t.Fatalf("LoadForRoot() error = %v", err)
-	}
-	if !cfg.SecretsRedactToolOutput() {
-		t.Error("project reasonix.toml disabled redact_tool_output; [secrets] must stay user-global")
 	}
 	if cfg.Secrets.FilterSubprocessEnv {
 		t.Error("project reasonix.toml enabled filter_subprocess_env; [secrets] must stay user-global")
@@ -1361,13 +1357,11 @@ func TestProjectConfigCannotOverrideSecrets(t *testing.T) {
 // silently drop the user's security toggles.
 func TestRenderTOMLPersistsSecretsSection(t *testing.T) {
 	cfg := Default()
-	off := false
-	cfg.Secrets.RedactToolOutput = &off
 	cfg.Secrets.FilterSubprocessEnv = true
 	cfg.Secrets.ProtectSensitiveFiles = true
 
 	out := RenderTOMLForScope(cfg, RenderScopeUser)
-	for _, want := range []string{"[secrets]", "redact_tool_output = false", "filter_subprocess_env = true", "protect_sensitive_files = true"} {
+	for _, want := range []string{"[secrets]", "filter_subprocess_env = true", "protect_sensitive_files = true"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("user-scope render missing %q:\n%s", want, out)
 		}
@@ -1381,9 +1375,6 @@ func TestRenderTOMLPersistsSecretsSection(t *testing.T) {
 	if err := mergeFile(back, path); err != nil {
 		t.Fatalf("round-trip decode: %v", err)
 	}
-	if back.SecretsRedactToolOutput() {
-		t.Fatal("redact_tool_output=false lost in render round-trip")
-	}
 	if !back.Secrets.FilterSubprocessEnv || !back.Secrets.ProtectSensitiveFiles {
 		t.Fatalf("secrets toggles lost in render round-trip: %+v", back.Secrets)
 	}
@@ -1391,5 +1382,8 @@ func TestRenderTOMLPersistsSecretsSection(t *testing.T) {
 	// Project scope must not render the section — LoadForRoot ignores it there.
 	if proj := RenderTOMLForScope(cfg, RenderScopeProject); strings.Contains(proj, "[secrets]") {
 		t.Fatalf("project scope rendered [secrets]:\n%s", proj)
+	}
+	if strings.Contains(out, "redact_tool_output") {
+		t.Fatalf("user-scope render still exposes removed live-redaction setting:\n%s", out)
 	}
 }

--- a/internal/doctor/session_redact.go
+++ b/internal/doctor/session_redact.go
@@ -188,12 +188,11 @@ func redactSessionArtifact(path string, dryRun bool) (changed int64, bytesRewrit
 }
 
 // redactSessionTranscript rewrites one session (anchor .jsonl plus its event
-// log) through the agent's own save machinery. Session.Save re-runs
-// RedactMessages on the snapshot, folds the event log into a single redacted
-// replace event, refreshes the anchor and event index, and records the
-// revision under the same cross-process file locks live sessions use — so
-// digests, the CAS ledger, and event-log replay stay coherent, and a rerun is
-// a no-op because Redact is idempotent on decoded content.
+// log) through the agent's own save machinery. This explicit cleanup command
+// redacts the loaded snapshot before saving it, folds the event log into one
+// clean replace event, and refreshes the anchor, index, and revision under the
+// same cross-process locks live sessions use. Ordinary Session.Save calls keep
+// transcript content byte-for-byte intact.
 func redactSessionTranscript(path string, dryRun bool) (int64, int64, error) {
 	s, err := agent.LoadSession(path)
 	if err != nil {
@@ -220,6 +219,7 @@ func redactSessionTranscript(path string, dryRun bool) (int64, int64, error) {
 	if dryRun {
 		return files, redactedEncodedSize(s.Messages), nil
 	}
+	s.Replace(secrets.RedactMessages(s.Messages))
 	if err := s.Save(path); err != nil {
 		return 0, 0, err
 	}

--- a/internal/doctor/session_redact_test.go
+++ b/internal/doctor/session_redact_test.go
@@ -100,9 +100,8 @@ func TestRedactSessionsHandlesQuotedSecretsWithoutCorruption(t *testing.T) {
 	}
 }
 
-// TestRedactSessionsIsNoOpOnHealthyStore pins idempotence: a store written by
-// a redacting build must survive the doctor untouched — rerunning cleanup on
-// clean sessions must never rewrite (or worse, corrupt) them.
+// TestRedactSessionsIsNoOpOnHealthyStore pins idempotence: after an explicit
+// cleanup, rerunning the command must not rewrite or corrupt the clean store.
 func TestRedactSessionsIsNoOpOnHealthyStore(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "abc.jsonl")
@@ -117,17 +116,21 @@ func TestRedactSessionsIsNoOpOnHealthyStore(t *testing.T) {
 	if err := s.Save(sessionPath); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
+	first := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(first.Errors) > 0 || first.FilesChanged == 0 {
+		t.Fatalf("first RedactSessions() = %+v, want a successful rewrite", first)
+	}
 	before, err := os.ReadFile(sessionPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	res := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
-	if len(res.Errors) > 0 {
-		t.Fatalf("RedactSessions errors = %v", res.Errors)
+	second := RedactSessions(RedactSessionsOptions{Dirs: []string{dir}})
+	if len(second.Errors) > 0 {
+		t.Fatalf("second RedactSessions errors = %v", second.Errors)
 	}
-	if res.FilesChanged != 0 {
-		t.Fatalf("healthy already-redacted store rewritten: %+v", res)
+	if second.FilesChanged != 0 {
+		t.Fatalf("healthy already-redacted store rewritten: %+v", second)
 	}
 	after, err := os.ReadFile(sessionPath)
 	if err != nil {

--- a/internal/jobs/artifacts.go
+++ b/internal/jobs/artifacts.go
@@ -61,7 +61,7 @@ func writeMeta(path string, meta artifactMeta) error {
 	if path == "" {
 		return fmt.Errorf("empty metadata path")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := ensurePrivateArtifactDir(filepath.Dir(path)); err != nil {
 		return err
 	}
 	b, err := json.MarshalIndent(meta, "", "  ")

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -97,6 +98,55 @@ func TestJobArtifactMetadataPreservesLabel(t *testing.T) {
 	}
 	if !strings.Contains(string(data), secret) {
 		t.Fatalf("job metadata did not preserve label:\n%s", data)
+	}
+}
+
+func TestJobArtifactUsesPrivatePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file ACLs are not represented by Unix permission bits")
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+
+	// Simulate a legacy artifact at the path the first job will reuse.
+	dir := ArtifactDir(sessionPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "bash-1"+jobLogExt)
+	if err := os.WriteFile(logPath, []byte("old redacted output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	j := m.StartForSession("session", "bash", "echo API_KEY=raw-secret", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "API_KEY=raw-secret\n")
+		return "", nil
+	})
+	<-j.done
+	if j.ID != "bash-1" {
+		t.Fatalf("job id = %q, want bash-1", j.ID)
+	}
+	assertPrivateArtifactMode(t, logPath)
+	assertPrivateArtifactMode(t, filepath.Join(dir, j.ID+jobMetaExt))
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("artifact dir mode = %04o, want 0700", got)
+	}
+}
+
+func assertPrivateArtifactMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("%s mode = %04o, want 0600", path, got)
 	}
 }
 
@@ -465,6 +515,9 @@ func TestMigrateArtifactDirFallsBackToCopyWhenRenameFails(t *testing.T) {
 	}
 	if string(got) != "persisted output" {
 		t.Fatalf("migrated artifact = %q, want persisted output", got)
+	}
+	if runtime.GOOS != "windows" {
+		assertPrivateArtifactMode(t, filepath.Join(dst, "bash-1.log"))
 	}
 	if _, err := os.Stat(filepath.Join(src, "bash-1.log")); !os.IsNotExist(err) {
 		t.Fatalf("source artifact should be removed after copy fallback, stat err = %v", err)

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -49,7 +49,7 @@ func TestCompletedJobPersistsOutputAndReleasesMemory(t *testing.T) {
 	}
 }
 
-func TestJobArtifactRedactsSecrets(t *testing.T) {
+func TestJobArtifactPreservesOutput(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	m := NewManager(event.Discard)
 	defer m.Close()
@@ -66,20 +66,20 @@ func TestJobArtifactRedactsSecrets(t *testing.T) {
 	if len(res) != 1 {
 		t.Fatalf("wait result = %+v", res)
 	}
-	if strings.Contains(res[0].Output, secret) || strings.Contains(res[0].Output, "ghp_abcdefghijklmnopqrstuvwxyz") {
-		t.Fatalf("wait output leaked secret:\n%s", res[0].Output)
+	if !strings.Contains(res[0].Output, secret) || !strings.Contains(res[0].Output, "ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("wait output did not preserve job output:\n%s", res[0].Output)
 	}
 
 	data, err := os.ReadFile(filepath.Join(ArtifactDir(sessionPath), j.ID+jobLogExt))
 	if err != nil {
 		t.Fatalf("read artifact: %v", err)
 	}
-	if strings.Contains(string(data), secret) || strings.Contains(string(data), "ghp_abcdefghijklmnopqrstuvwxyz") {
-		t.Fatalf("artifact leaked secret:\n%s", data)
+	if !strings.Contains(string(data), secret) || !strings.Contains(string(data), "ghp_abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("artifact did not preserve job output:\n%s", data)
 	}
 }
 
-func TestJobArtifactMetadataRedactsLabel(t *testing.T) {
+func TestJobArtifactMetadataPreservesLabel(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	m := NewManager(event.Discard)
 	defer m.Close()
@@ -95,8 +95,8 @@ func TestJobArtifactMetadataRedactsLabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(data), secret) {
-		t.Fatalf("job metadata leaked label secret:\n%s", data)
+	if !strings.Contains(string(data), secret) {
+		t.Fatalf("job metadata did not preserve label:\n%s", data)
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -384,16 +384,31 @@ func (m *Manager) openArtifactLocked(parentSession, id string) (logPath, metaPat
 	if dir == "" {
 		return "", "", nil, "artifact directory unavailable"
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := ensurePrivateArtifactDir(dir); err != nil {
 		return filepath.Join(dir, id+jobLogExt), filepath.Join(dir, id+jobMetaExt), nil, err.Error()
 	}
 	logPath = filepath.Join(dir, id+jobLogExt)
 	metaPath = filepath.Join(dir, id+jobMetaExt)
-	f, err := os.Create(logPath)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return logPath, metaPath, nil, err.Error()
 	}
+	// O_TRUNC does not apply the requested mode to an existing artifact. Tighten
+	// it before any raw tool output is written so upgrades cannot append secrets
+	// to a legacy 0644 log.
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return logPath, metaPath, nil, err.Error()
+	}
 	return logPath, metaPath, f, ""
+}
+
+func ensurePrivateArtifactDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// MkdirAll leaves an existing 0755 directory unchanged.
+	return os.Chmod(dir, 0o700)
 }
 
 func (m *Manager) artifactDirLocked(parentSession string) string {
@@ -539,7 +554,7 @@ func (j *Job) moveArtifactToDirLocked(dir string) error {
 	if filepath.Clean(filepath.Dir(j.artifactPath)) == filepath.Clean(dir) {
 		return nil
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := ensurePrivateArtifactDir(dir); err != nil {
 		return err
 	}
 	newLogPath := filepath.Join(dir, filepath.Base(j.artifactPath))
@@ -1229,7 +1244,7 @@ func migrateArtifactDirSkipping(src, dst string, skip map[string]bool) error {
 		}
 		return err
 	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	if err := ensurePrivateArtifactDir(dst); err != nil {
 		return err
 	}
 	for _, entry := range entries {
@@ -1248,6 +1263,11 @@ func migrateArtifactDirSkipping(src, dst string, skip map[string]bool) error {
 }
 
 func moveArtifactFile(src, dst string) error {
+	// A rename preserves the source mode, so tighten legacy artifacts before
+	// either the fast rename or the cross-device copy fallback.
+	if err := os.Chmod(src, 0o600); err != nil {
+		return err
+	}
 	if err := renamePath(src, dst); err == nil {
 		return nil
 	}
@@ -1263,12 +1283,13 @@ func copyArtifactFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	info, err := in.Stat()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
-	if err != nil {
+	if err := out.Chmod(0o600); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
 		return err
 	}
 	_, copyErr := io.Copy(out, in)

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -26,7 +26,6 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/nilutil"
-	"reasonix/internal/secrets"
 )
 
 var renamePath = os.Rename
@@ -231,13 +230,12 @@ func NewManager(sink event.Sink, opts ...Option) *Manager {
 type jobWriter struct{ j *Job }
 
 func (w jobWriter) Write(p []byte) (int, error) {
-	redacted := []byte(secrets.Redact(string(p)))
 	w.j.mu.Lock()
 	defer w.j.mu.Unlock()
 	w.j.activityAt = nowMs()
-	w.j.tail = appendTail(w.j.tail, redacted, defaultTailBytes)
+	w.j.tail = appendTail(w.j.tail, p, defaultTailBytes)
 	if w.j.artifactFile != nil {
-		if _, err := w.j.artifactFile.Write(redacted); err != nil {
+		if _, err := w.j.artifactFile.Write(p); err != nil {
 			w.j.artifactErr = err.Error()
 		}
 	}
@@ -257,7 +255,6 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 // only see jobs whose owner matches the active session.
 func (m *Manager) StartForSession(parentSession, kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
 	parentSession = strings.TrimSpace(parentSession)
-	label = secrets.Redact(label)
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)
@@ -318,7 +315,6 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		}
 		finishedAt := nowMs()
 		if result != "" {
-			result = secrets.Redact(result)
 			j.mu.Lock()
 			if j.artifactFile != nil {
 				if _, writeErr := j.artifactFile.WriteString(result); writeErr != nil {

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -45,7 +45,6 @@ const redactedValue = "[redacted]"
 // globals are safe here because [secrets] cannot be overridden per-project:
 // every concurrent workspace in one process shares the same user setting.
 var (
-	redactToolOutputEnabled      atomic.Bool
 	filterSubprocessEnvEnabled   atomic.Bool
 	protectSensitiveFilesEnabled atomic.Bool
 	credentialEnvKeys            = struct {
@@ -53,19 +52,6 @@ var (
 		keys map[string]struct{}
 	}{keys: map[string]struct{}{}}
 )
-
-func init() {
-	// Tool-output redaction defaults on; subprocess env filtering defaults
-	// off because it breaks legitimate token-based workflows (gh, git push
-	// over HTTPS, npm publish) and needs an explicit user opt-in.
-	redactToolOutputEnabled.Store(true)
-}
-
-// SetRedactToolOutput enables or disables masking of tool output before it
-// enters model context and UI events ([secrets] redact_tool_output). Durable
-// surfaces — session transcripts and background-job artifacts — are always
-// redacted regardless of this toggle.
-func SetRedactToolOutput(enabled bool) { redactToolOutputEnabled.Store(enabled) }
 
 // SetFilterSubprocessEnv enables or disables stripping credential-like
 // variables from tool subprocess environments ([secrets]
@@ -159,22 +145,10 @@ func ProcessEnv() []string {
 	return FilterEnv(os.Environ())
 }
 
-// RedactToolOutput masks credential-like values in live tool output (model
-// context, UI events) unless the user disabled [secrets] redact_tool_output.
-// Durable writers (session save, job artifacts) call Redact directly instead:
-// disk logs stay redacted even when live output is not.
-func RedactToolOutput(s string) string {
-	if !redactToolOutputEnabled.Load() {
-		return s
-	}
-	return Redact(s)
-}
-
-// Redact masks credential-like values in text before the text enters durable
-// transcripts, job artifacts, or diagnostic records. It is deterministic and
-// idempotent: redacting already-redacted text is a byte-for-byte no-op, which
-// the session save path relies on for digest stability across load/save cycles
-// (see Session.save).
+// Redact masks credential-like values for explicit diagnostic, export, and
+// cleanup paths. Normal model content, tool output, session transcripts, and
+// background-job artifacts deliberately bypass this helper to retain v0.53's
+// byte-preserving behavior.
 func Redact(s string) string {
 	if s == "" {
 		return s

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -183,22 +183,6 @@ func TestProcessEnvAlwaysFiltersRegisteredCredentialKeys(t *testing.T) {
 	}
 }
 
-func TestRedactToolOutputHonorsToggle(t *testing.T) {
-	const in = "DEEPSEEK_API_KEY=sk-real-secret-value-123456"
-	if got := RedactToolOutput(in); strings.Contains(got, "sk-real-secret-value-123456") {
-		t.Fatalf("tool output not redacted by default:\n%s", got)
-	}
-	SetRedactToolOutput(false)
-	t.Cleanup(func() { SetRedactToolOutput(true) })
-	if got := RedactToolOutput(in); got != in {
-		t.Fatalf("RedactToolOutput altered output with the toggle off:\n%s", got)
-	}
-	// The durable-surface entry point ignores the toggle.
-	if got := Redact(in); strings.Contains(got, "sk-real-secret-value-123456") {
-		t.Fatalf("Redact must stay active regardless of the toggle:\n%s", got)
-	}
-}
-
 func TestRedactMessagesDoesNotMutateInput(t *testing.T) {
 	const secret = "sk-real-secret-value-123456"
 	msgs := []provider.Message{


### PR DESCRIPTION
## Summary

- preserve tool results and progress text verbatim in model/UI context
- persist ordinary sessions, recovery branches, and background-job artifacts without heuristic secret rewriting
- keep transcript-bearing session/job files private (`0600`) and job artifact directories private (`0700`), including upgrades and migrated artifacts
- remove the obsolete `redact_tool_output` setting with a one-time migration notice while retaining optional subprocess-env filtering and sensitive-file protection
- keep credential masking in key-entry summaries and explicit diagnostic or `doctor redact-sessions` cleanup paths

## Why

The global redaction path treated secret-shaped identifiers and environment-variable references as credential values. Generated code such as `os.getenv("BINANCE_API_KEY")` could therefore be replaced with `[redacted]`, corrupting otherwise valid code and producing syntax errors.

This restores the v0.53 content boundary: ordinary model/tool/session content remains byte-preserving, while explicitly security-oriented outputs continue to be scrubbed.

## Impact

Generated code and tool output keep their original structure across UI display, model context, resumes, recovery branches, and background jobs. As in v0.53, a real credential printed by a tool can be stored in local session or job files; those files are restricted to the current user, and existing or migrated artifacts are tightened before raw content is written. Users can explicitly scrub historical artifacts with `reasonix doctor redact-sessions` before sharing them.

Existing `redact_tool_output` entries are removed once at normal startup with a clear notice so an obsolete `true` value cannot create a false expectation that live output is still redacted.

## Validation

- `go test ./...`
- `go vet ./...`
- `cd desktop && go test -short ./...`
- `GOOS=windows GOARCH=amd64 go build ./cmd/reasonix`
- `git diff --check`
- focused permission and upgrade tests in `internal/agent`, `internal/jobs`, `internal/config`, and `internal/boot`

## Cache impact

Cache-impact: low - static system/tool prefixes are unchanged; only secret-shaped tool-result bytes and subsequent resumed-transcript bytes differ under the restored verbatim behavior.
Cache-guard: `go test ./internal/agent ./internal/jobs ./internal/config ./internal/boot` plus the full Go, desktop, and Windows build validation listed above.
System-prompt-review: Codex reviewed the boot/config changes and confirmed they do not alter system-prompt construction, memory prefixes, output styles, or skill indexes.
