### PR TITLE
fix(tui): 从 quickPicker 选择模型后正确返回 pendingModelSwitch 作为 tea.Cmd（解决 /model 切换模型问题）

### DIFF
--- a/internal/cli/provider.go
+++ b/internal/cli/provider.go
@@ -144,8 +144,14 @@ func (m chatTUI) handleQuickPickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	switch kind {
 	case quickPickerModel, quickPickerProviderModel:
 		m.runModelSubcommand("/model " + choice.ID)
+		if m.pendingModelSwitch != nil {
+			return m, m.pendingModelSwitch
+		}
 	case quickPickerProvider:
 		m.switchToProvider(choice.ID)
+		if m.pendingModelSwitch != nil {
+			return m, m.pendingModelSwitch
+		}
 	}
 	return m, nil
 }

--- a/internal/cli/quick_picker_test.go
+++ b/internal/cli/quick_picker_test.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/command"
+	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -155,5 +156,57 @@ func TestQuickPickerModelSwitch(t *testing.T) {
 	}
 	if swMsg.oldCtrl != oldCtrl {
 		t.Fatal("modelSwitchMsg did not carry the old controller")
+	}
+}
+
+func TestQuickPickerProviderSingleModelSwitch(t *testing.T) {
+	isolateUserConfig(t)
+	cfg := config.Default()
+	cfg.Providers = []config.ProviderEntry{{
+		Name:    "new-provider",
+		Kind:    "openai",
+		BaseURL: "http://localhost:1234/v1",
+		Model:   "new-model",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save provider config: %v", err)
+	}
+
+	oldCtrl := control.New(control.Options{Label: "old"})
+	newCtrl := control.New(control.Options{Label: "new-model"})
+	m := newChatTUI(oldCtrl, "", make(chan event.Event, 1), 100)
+	m.modelRef = "old-provider/old-model"
+	m.quickPick = &quickPicker{
+		kind:     quickPickerProvider,
+		title:    "Select provider",
+		items:    []quickPickerItem{{ID: "new-provider", Label: "new-provider"}},
+		selected: 0,
+	}
+	m.buildController = func(_ controllerBuildSpec, _ []provider.Message, _ string, _ control.SessionAPI) (*control.Controller, error) {
+		return newCtrl, nil
+	}
+
+	next, cmd := m.handleQuickPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m2 := next.(chatTUI)
+	if cmd == nil {
+		t.Fatal("provider quickPick did not schedule a controller build (cmd is nil)")
+	}
+	if !m2.modelSwitchPending || m2.pendingModelSwitch == nil {
+		t.Fatal("provider quickPick did not retain the pending model switch")
+	}
+
+	msg := cmd()
+	swMsg, ok := msg.(modelSwitchMsg)
+	if !ok {
+		t.Fatalf("controller build returned %T, want modelSwitchMsg", msg)
+	}
+	if swMsg.err != nil {
+		t.Fatalf("controller build failed: %v", swMsg.err)
+	}
+	if swMsg.ref != "new-provider/new-model" {
+		t.Fatalf("modelSwitchMsg ref = %q, want %q", swMsg.ref, "new-provider/new-model")
+	}
+	if swMsg.ctrl != newCtrl || swMsg.oldCtrl != oldCtrl {
+		t.Fatal("modelSwitchMsg did not carry the expected controllers")
 	}
 }

--- a/internal/cli/quick_picker_test.go
+++ b/internal/cli/quick_picker_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/command"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/skill"
 )
 
 func TestQuickPickerNavigationFilterAndConfirm(t *testing.T) {
@@ -87,5 +93,67 @@ func TestQuickPickerEscCancels(t *testing.T) {
 	p := &quickPicker{items: []quickPickerItem{{ID: "one", Label: "One"}}}
 	if result := p.handleKey(tea.KeyPressMsg{Code: tea.KeyEsc}); !result.cancelled {
 		t.Fatal("Esc should cancel picker")
+	}
+}
+
+// TestQuickPickerModelSwitch verifies that selecting a model from the
+// quickPicker returns a non-nil tea.Cmd that produces a modelSwitchMsg.
+// Regression test for the bug where handleQuickPickerKey set
+// m.pendingModelSwitch but returned nil as the tea.Cmd, causing the async
+// controller build to never execute.
+func TestQuickPickerModelSwitch(t *testing.T) {
+	oldCtrl := control.New(control.Options{Label: "old"})
+	newCtrl := control.New(control.Options{Label: "new-model", Commands: []command.Command{{Name: "cmd"}}, Skills: []skill.Skill{{Name: "sk"}}})
+	m := newChatTUI(oldCtrl, "", make(chan event.Event, 1), 100)
+	m.modelRef = "provider/old-model"
+	m.quickPick = &quickPicker{
+		kind:  quickPickerModel,
+		title: "Select model",
+		items: []quickPickerItem{
+			{ID: "provider/new-model", Label: "provider/new-model"},
+		},
+		selected: 0,
+	}
+	m.buildController = func(_ controllerBuildSpec, _ []provider.Message, _ string, _ control.SessionAPI) (*control.Controller, error) {
+		return newCtrl, nil
+	}
+
+	// Simulate pressing Enter in the quickPicker
+	next, cmd := m.handleQuickPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m2 := next.(chatTUI)
+
+	if cmd == nil {
+		t.Fatal("quickPick model switch did not schedule a controller build (cmd is nil)")
+	}
+	if !m2.modelSwitchPending {
+		t.Fatal("quickPick model switch did not set modelSwitchPending")
+	}
+	if m2.pendingModelSwitch == nil {
+		t.Fatal("quickPick model switch did not set pendingModelSwitch")
+	}
+	if m2.ctrl != oldCtrl {
+		t.Fatal("controller changed before the replacement build completed")
+	}
+
+	// Execute the cmd and verify it produces a modelSwitchMsg
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("controller build cmd returned nil message")
+	}
+	swMsg, ok := msg.(modelSwitchMsg)
+	if !ok {
+		t.Fatalf("controller build returned %T, want modelSwitchMsg", msg)
+	}
+	if swMsg.err != nil {
+		t.Fatalf("controller build failed: %v", swMsg.err)
+	}
+	if swMsg.ref != "provider/new-model" {
+		t.Fatalf("modelSwitchMsg ref = %q, want %q", swMsg.ref, "provider/new-model")
+	}
+	if swMsg.ctrl != newCtrl {
+		t.Fatal("modelSwitchMsg did not carry the new controller")
+	}
+	if swMsg.oldCtrl != oldCtrl {
+		t.Fatal("modelSwitchMsg did not carry the old controller")
 	}
 }


### PR DESCRIPTION
## Summary

handleQuickPickerKey（value receiver）调用了 runModelSubcommand 设置了 m.pendingModelSwitch，但返回了 nil 作为 tea.Cmd — bubbletea 事件循环 因此永远不会执行异步 controller 构建闭包。

slash 命令路径（runSlashCommand → "/model" 分支）已正确返回
m.pendingModelSwitch；quickPicker 路径缺少同样的检查。

后果：从 /model 的 quickPicker 选择模型后显示"正在切换到…"，但构建
从未启动，"已切换到…" 从不出现，且 modelSwitchPending 保持 true，
永久阻塞后续 Enter 键。

修复：在两个 quickPicker 分支（quickPickerModel/quickPickerProviderModel 和 quickPickerProvider）的 runModelSubcommand / switchToProvider 调用后， 检查 m.pendingModelSwitch 并将其作为 tea.Cmd 返回。

测试：TestQuickPickerModelSwitch 和 TestQuickPickerProviderSingleModelSwitch 验证 cmd != nil、modelSwitchPending 正确设置，且 cmd() 产生包含正确 ref/ctrl/oldCtrl 的 modelSwitchMsg。

Fixes #6558

## Verification

- `go vet ./...`
- `go test ./internal/cli/ -run "Test(model|Model|QuickPick|Provider)"`
- `go test ./internal/tool/builtin/`

- 集成测试
  - 确保配置了至少两个 model
  - 进入 TUI 模式，敲入 /model ，并直接按回车，从列表中进行当前模型切换
  - 期望是切换成功，消息框显示 “已切换到 xxx” 消息

<img width="1162" height="708" alt="fix" src="https://github.com/user-attachments/assets/ca26ece2-5067-48bd-996c-980c2d067b13" />


## Cache impact

Cache-impact: low
Cache-guard: N/A
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
