### PR TITLE
Restore historical message timestamps and simplify history navigation / 恢复历史消息时间戳并简化历史入口

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3892,6 +3892,7 @@ func promptHistoryFallbackMillis(path string, info os.FileInfo) int64 {
 
 func promptHistoryEventMillis(rec previewEventRecord) (int64, bool) {
 	for _, raw := range []json.RawMessage{
+		rec.TS,
 		rec.Time,
 		rec.Timestamp,
 		rec.CreatedAt,
@@ -4312,6 +4313,7 @@ type HistoryMessage struct {
 	Code               string                    `json:"code,omitempty"`
 	SubmitText         string                    `json:"submitText,omitempty"`
 	CheckpointTurn     *int                      `json:"checkpointTurn,omitempty"`
+	CreatedAt          int64                     `json:"createdAt,omitempty"`
 	Reasoning          string                    `json:"reasoning,omitempty"`
 	MemoryCitations    []provider.MemoryCitation `json:"memoryCitations,omitempty"`
 	WorkDurationMs     int64                     `json:"workDurationMs,omitempty"`
@@ -4353,6 +4355,46 @@ type HistoryPage struct {
 	HasOlder   bool             `json:"hasOlder"`
 }
 
+// historyProviderMessagesWithPersistedTimes overlays legacy event-record
+// timestamps onto a copy for display. It deliberately leaves the controller's
+// provider transcript untouched: timestamp migration must not change session
+// digests, conflict detection, or model-request cache prefixes.
+func historyProviderMessagesWithPersistedTimes(msgs []provider.Message, sessionPath string) []provider.Message {
+	if len(msgs) == 0 || strings.TrimSpace(sessionPath) == "" {
+		return msgs
+	}
+	needsPersistedTime := false
+	for _, msg := range msgs {
+		if msg.Role == provider.RoleUser && msg.CreatedAt <= 0 && agent.IsUserAuthoredTurn(msg.Content) {
+			needsPersistedTime = true
+			break
+		}
+	}
+	if !needsPersistedTime {
+		return msgs
+	}
+	users, err := agent.LoadSessionUserMessages(sessionPath)
+	if err != nil || len(users) == 0 {
+		return msgs
+	}
+	out := append([]provider.Message(nil), msgs...)
+	userIndex := 0
+	for i := range out {
+		if out[i].Role != provider.RoleUser {
+			continue
+		}
+		if userIndex >= len(users) {
+			break
+		}
+		user := users[userIndex]
+		userIndex++
+		if out[i].CreatedAt <= 0 && !user.At.IsZero() {
+			out[i].CreatedAt = user.At.UnixMilli()
+		}
+	}
+	return out
+}
+
 // History returns the session's message log.
 func (a *App) History() []HistoryMessage {
 	return a.HistoryForTab("")
@@ -4383,9 +4425,9 @@ func (a *App) HistoryPageForTab(tabID string, beforeTurn, limit int) HistoryPage
 		}
 		return page
 	}
-	msgs := ctrl.History()
 	dir := controllerSessionDir(ctrl)
 	path := ctrl.SessionPath()
+	msgs := historyProviderMessagesWithPersistedTimes(ctrl.History(), path)
 	return historyPageFromProviderMessages(
 		msgs,
 		sessionDisplayResolver(dir, path),
@@ -4476,9 +4518,9 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 		}
 		return messages
 	}
-	msgs := ctrl.History()
 	dir := controllerSessionDir(ctrl)
 	path := ctrl.SessionPath()
+	msgs := historyProviderMessagesWithPersistedTimes(ctrl.History(), path)
 	return historyMessagesWithPlannerDisplays(
 		msgs,
 		sessionDisplayResolver(dir, path),
@@ -4573,7 +4615,7 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		hm := HistoryMessage{Role: string(m.Role), Content: content, CheckpointTurn: checkpointTurn, Reasoning: reasoning, WorkDurationMs: m.WorkDurationMs}
+		hm := HistoryMessage{Role: string(m.Role), Content: content, CheckpointTurn: checkpointTurn, CreatedAt: m.CreatedAt, Reasoning: reasoning, WorkDurationMs: m.WorkDurationMs}
 		if m.Role == provider.RoleAssistant && len(m.MemoryCitations) > 0 {
 			hm.MemoryCitations = append([]provider.MemoryCitation(nil), m.MemoryCitations...)
 		}
@@ -5027,7 +5069,7 @@ func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
 		return nil, err
 	}
 	return historyMessagesWithPlannerDisplays(
-		loaded.Snapshot(),
+		historyProviderMessagesWithPersistedTimes(loaded.Snapshot(), sessionPath),
 		sessionDisplayResolver(sessionDir, sessionPath),
 		sessionPlannerDisplayTurns(sessionDir, sessionPath),
 		nil,
@@ -5050,7 +5092,7 @@ func previewSessionPage(sessionDir, path string, beforeTurn, limit int) (History
 		return HistoryPage{}, err
 	}
 	return historyPageFromProviderMessages(
-		loaded.Snapshot(),
+		historyProviderMessagesWithPersistedTimes(loaded.Snapshot(), sessionPath),
 		sessionDisplayResolver(sessionDir, sessionPath),
 		sessionPlannerDisplayTurns(sessionDir, sessionPath),
 		nil,
@@ -5063,6 +5105,7 @@ type previewEventRecord struct {
 	Kind             string                    `json:"kind"`
 	Type             string                    `json:"type"`
 	Role             string                    `json:"role"`
+	TS               json.RawMessage           `json:"ts"`
 	Time             json.RawMessage           `json:"time"`
 	Timestamp        json.RawMessage           `json:"timestamp"`
 	CreatedAt        json.RawMessage           `json:"createdAt"`
@@ -5140,7 +5183,11 @@ func previewEventSessionMessages(path string) ([]HistoryMessage, bool, error) {
 		switch eventName {
 		case "user.message":
 			if rec.Text != "" {
-				out = append(out, HistoryMessage{Role: "user", Content: rec.Text})
+				hm := HistoryMessage{Role: "user", Content: rec.Text}
+				if at, ok := promptHistoryEventMillis(rec); ok {
+					hm.CreatedAt = at
+				}
+				out = append(out, hm)
 			}
 		case "model.final":
 			hm := HistoryMessage{Role: "assistant", Content: rec.Content, Reasoning: firstNonEmpty(rec.Reasoning, rec.ReasoningContent)}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -23,7 +23,6 @@ import {
   FileText,
   FileJson,
   GitBranch,
-  History,
   MessageSquare,
   Settings as SettingsIcon,
   Pencil,
@@ -2784,17 +2783,6 @@ export default function App() {
     }
   }, [activeTab?.readOnly, activeTabId, clearContextPending, controllerReady, hydratePlaceholderActive, sendToTab, state.approval, state.ask, state.items, state.messageAction, state.running, rewindForTab]);
 
-  // History drawer: project menus can open a scoped saved-session list. Idle row
-  // clicks resume; running row clicks only preview through PreviewSession.
-  const openProjectHistory = useCallback(async (scope: "global" | "project", workspaceRoot: string) => {
-    closeTransientOverlays();
-    const filter = { scope, workspaceRoot };
-    setHistView({ kind: "history", source: "scope", filter, sessions: sessionsForScope(await listSessions(), filter) });
-  }, [closeTransientOverlays, listSessions]);
-  const openAllHistory = useCallback(async () => {
-    closeTransientOverlays();
-    setHistView({ kind: "history", source: "all", sessions: await listSessions() });
-  }, [closeTransientOverlays, listSessions]);
   const openTrash = useCallback(async () => {
     closeTransientOverlays();
     setHistView({ kind: "trash", sessions: await listTrashedSessions() });
@@ -3053,7 +3041,6 @@ export default function App() {
   const paletteItems = useMemo<PaletteItem[]>(() => {
     const cmds: PaletteItem[] = [
       { id: "cmd-new", group: t("palette.group.commands"), title: t("palette.cmd.newSession"), icon: <SquarePen size={15} />, compact: true, keywords: ["new", "新建"], run: () => void handleNewTab() },
-      { id: "cmd-history", group: t("palette.group.commands"), title: t("palette.cmd.history"), icon: <History size={15} />, compact: true, keywords: ["history", "历史"], run: () => void openAllHistory() },
       { id: "cmd-trash", group: t("palette.group.commands"), title: t("palette.cmd.trash"), icon: <Trash2 size={15} />, compact: true, keywords: ["trash", "回收站"], run: () => void openTrash() },
       { id: "cmd-settings", group: t("palette.group.commands"), title: t("palette.cmd.settings"), icon: <SettingsIcon size={15} />, compact: true, keywords: ["settings", "设置"], run: () => setSettingsTarget("general") },
       { id: "cmd-appearance", group: t("palette.group.commands"), title: t("palette.cmd.appearance"), icon: <Palette size={15} />, compact: true, keywords: ["theme", "appearance", "外观", "主题"], run: () => setSettingsTarget("appearance") },
@@ -3078,7 +3065,7 @@ export default function App() {
       run: () => void onResumeSession(s),
     }));
     return [...cmds, ...sessionItems];
-  }, [t, paletteSessions, handleNewTab, openAllHistory, openTrash, onResumeSession]);
+  }, [t, paletteSessions, handleNewTab, openTrash, onResumeSession]);
   // Delete / rename act on disk, then re-fetch so the panel reflects the change.
   const onDeleteSession = useCallback(
     async (path: string) => {
@@ -3447,7 +3434,6 @@ export default function App() {
               activeSessionPath={activeTab?.sessionPath}
               imTopicSources={imTopicSources}
               onOpenTopic={handleOpenTopic}
-              onOpenProjectHistory={openProjectHistory}
               onCreateTopic={(scope, workspaceRoot) => openBlankSession(scope, scope === "project" ? workspaceRoot : "")}
               onCreateDeliveryWorktree={(workspaceRoot) => enqueueNavigation({ kind: "delivery-worktree", workspaceRoot })}
               onTopicsChanged={refreshProjectsAndTabs}
@@ -3470,16 +3456,6 @@ export default function App() {
           {sidebarWorkbench ? (
             <nav className="sidebar__nav sidebar__nav--footer">
               <div className="sidebar__utility-row" aria-label={t("sidebar.utilityActions")}>
-                <Tooltip label={t("sidebar.allHistory")} fill side="top">
-                  <button
-                    className="sidebar__utility-button"
-                    type="button"
-                    onClick={() => void openAllHistory()}
-                  >
-                    <History size={16} aria-hidden="true" />
-                    <span className="sr-only">{t("sidebar.allHistory")}</span>
-                  </button>
-                </Tooltip>
                 <Tooltip label={t("sidebar.trash")} fill side="top">
                   <button
                     className="sidebar__utility-button"
@@ -3534,15 +3510,6 @@ export default function App() {
                   </button>
                 </Tooltip>
               )}
-              <Tooltip label={t("sidebar.allHistory")} fill side="right" disabled={sidebarNavTooltipDisabled}>
-                <button
-                  className="sidebar__navitem"
-                  onClick={() => void openAllHistory()}
-                >
-                  <History size={15} />
-                  <span>{t("sidebar.allHistory")}</span>
-                </button>
-              </Tooltip>
               <Tooltip label={t("sidebar.trash")} fill side="right" disabled={sidebarNavTooltipDisabled}>
                 <button
                   className="sidebar__navitem"

--- a/desktop/frontend/src/__tests__/bundle-contract.test.ts
+++ b/desktop/frontend/src/__tests__/bundle-contract.test.ts
@@ -19,8 +19,10 @@ function ok(cond: boolean, label: string) {
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
+const projectTreeSource = readFileSync(resolve(here, "../components/ProjectTree.tsx"), "utf8");
 const settingsSource = readFileSync(resolve(here, "../components/SettingsPanel.tsx"), "utf8");
 const markdownSource = readFileSync(resolve(here, "../components/Markdown.tsx"), "utf8");
+const stylesSource = readFileSync(resolve(here, "../styles.css"), "utf8");
 
 console.log("\nbundle contract");
 
@@ -41,6 +43,29 @@ ok(
   appSource.includes('import("./components/SettingsPanel")') &&
     appSource.includes('import("./components/HistoryPanel")'),
   "App loads secondary drawers on demand",
+);
+ok(
+  !appSource.includes("openAllHistory") &&
+    !appSource.includes("cmd-history") &&
+    !appSource.includes("sidebar.allHistory") &&
+    !projectTreeSource.includes("onOpenProjectHistory") &&
+    !projectTreeSource.includes("project-history"),
+  "App has no dedicated history-page entry points",
+);
+ok(
+  appSource.includes('id: "cmd-trash"') &&
+    appSource.includes("openTrash") &&
+    appSource.includes("paletteSessions.slice(0, 12)") &&
+    projectTreeSource.includes('t("projectTree.searchPlaceholder")'),
+  "Trash and existing session search remain available",
+);
+ok(
+  /\.sidebar--workbench\s+\.sidebar__utility-row\s*\{[^}]*grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/s.test(stylesSource),
+  "Workbench footer distributes its three utility actions evenly",
+);
+ok(
+  /\.app--creation\s+\.sidebar__nav,\s*:root\[data-theme-style\]\s+\.app--creation\s+\.sidebar__nav\s*\{[^}]*grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/s.test(stylesSource),
+  "Creation footer distributes search, trash, and settings evenly",
 );
 ok(
   !/import\s+\{[^}]*\b(?:MCPServersSettingsPage|SkillsSettingsPage|PluginsSettingsPage)\b[^}]*\}\s+from\s+["']\.\/CapabilitiesPanel["']/.test(settingsSource) &&

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch } from "lucide-react";
+import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2, GitBranch } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
@@ -29,7 +29,6 @@ interface ProjectTreeProps {
   imTopicSources?: Record<string, ProjectTreeImTopicSource>;
   variant?: ProjectTreeVariant;
   onOpenTopic: (scope: string, workspaceRoot: string, topicId: string, sessionPath?: string) => Promise<void> | void;
-  onOpenProjectHistory: (scope: "global" | "project", workspaceRoot: string) => Promise<void> | void;
   onAddProject: () => Promise<void>;
   onCreateTopic?: (scope: string, workspaceRoot: string) => Promise<void> | void;
   onCreateDeliveryWorktree?: (workspaceRoot: string) => Promise<void> | void;
@@ -590,7 +589,6 @@ export function ProjectTree({
   imTopicSources = {},
   variant = "classic",
   onOpenTopic,
-  onOpenProjectHistory,
   onAddProject,
   onCreateTopic,
   onCreateDeliveryWorktree,
@@ -1652,19 +1650,6 @@ export function ProjectTree({
           void handleCreateTopic(scope, projectRoot, key);
         },
       },
-      ...(scope === "project"
-        ? [
-            {
-              key: "project-history",
-              icon: <History size={13} />,
-              label: t("projectTree.projectHistory"),
-              onSelect: () => {
-                closeMenu();
-                void onOpenProjectHistory(scope, projectRoot);
-              },
-            },
-          ]
-        : []),
       ...isolatedWorkspaceItems,
       {
         key: "rename",
@@ -1741,19 +1726,6 @@ export function ProjectTree({
           closeMenu();
         },
       },
-      ...(scope === "project"
-        ? [
-            {
-              key: "project-history",
-              icon: <History size={13} />,
-              label: t("projectTree.projectHistory"),
-              onSelect: () => {
-                closeMenu();
-                void onOpenProjectHistory(scope, projectRoot);
-              },
-            },
-          ]
-        : []),
       {
         key: "rename",
         icon: <Pencil size={13} />,

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1456,6 +1456,7 @@ function makeMockApp(): AppBindings {
       out.push({
         role: "user",
         content: `第 ${i} 轮：检查聊天滚动定位，切换会话后应该自动停在最新消息底部。`,
+        createdAt: t0 - (19 - i) * 15 * 60_000,
       });
       if (i === 4) {
         out.push({ role: "phase", content: "复现切换会话后的滚动位置" });

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -48,7 +48,6 @@ export const en = {
 
   // sidebar
   "sidebar.conversations": "Chats",
-  "sidebar.allHistory": "History",
   "sidebar.trash": "Trash",
   "sidebar.automation": "Automation",
   "sidebar.memorySkills": "Memory & Skills",
@@ -1019,7 +1018,6 @@ export const en = {
   "projectTree.archiveConversation": "Archive conversation",
   "projectTree.renameProject": "Rename display name",
   "projectTree.renameProjectWorkbench": "Rename project",
-  "projectTree.projectHistory": "View project history",
   "projectTree.justNow": "just now",
   "projectTree.previously": "previously",
   "projectTree.running": "responding",
@@ -1746,7 +1744,6 @@ export const en = {
   "palette.group.commands": "Commands",
   "palette.group.sessions": "Recent sessions",
   "palette.cmd.newSession": "New session",
-  "palette.cmd.history": "History",
   "palette.cmd.trash": "Trash",
   "palette.cmd.settings": "Settings",
   "palette.cmd.appearance": "Appearance",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -40,7 +40,6 @@ export const zhTW: Record<DictKey, string> = {
 
   // 側邊欄
   "sidebar.conversations": "會話",
-  "sidebar.allHistory": "歷史",
   "sidebar.trash": "回收站",
   "sidebar.automation": "自動化",
   "sidebar.workspace": "工作區",
@@ -814,7 +813,6 @@ export const zhTW: Record<DictKey, string> = {
   "projectTree.archiveConversation": "歸檔對話",
   "projectTree.renameProject": "修改顯示名稱",
   "projectTree.renameProjectWorkbench": "重新命名專案",
-  "projectTree.projectHistory": "檢視專案歷史",
   "projectTree.removeProject": "移出側邊欄",
   "projectTree.confirmRemoveProject": "確認移出側邊欄",
   "projectTree.removeProjectShort": "移除",
@@ -2262,7 +2260,6 @@ export const zhTW: Record<DictKey, string> = {
   "palette.group.commands": "命令",
   "palette.group.sessions": "最近會話",
   "palette.cmd.newSession": "新建會話",
-  "palette.cmd.history": "歷史",
   "palette.cmd.trash": "回收站",
   "palette.cmd.settings": "設定",
   "palette.cmd.appearance": "外觀",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -49,7 +49,6 @@ export const zh: Record<DictKey, string> = {
 
   // 侧边栏
   "sidebar.conversations": "会话",
-  "sidebar.allHistory": "历史",
   "sidebar.trash": "回收站",
   "sidebar.automation": "自动化",
   "sidebar.memorySkills": "记忆与技能",
@@ -1020,7 +1019,6 @@ export const zh: Record<DictKey, string> = {
   "projectTree.archiveConversation": "归档对话",
   "projectTree.renameProject": "修改显示名称",
   "projectTree.renameProjectWorkbench": "重命名项目",
-  "projectTree.projectHistory": "查看项目历史",
   "projectTree.justNow": "刚刚",
   "projectTree.previously": "之前",
   "projectTree.running": "输出中",
@@ -1748,7 +1746,6 @@ export const zh: Record<DictKey, string> = {
   "palette.group.commands": "命令",
   "palette.group.sessions": "最近会话",
   "palette.cmd.newSession": "新建会话",
-  "palette.cmd.history": "历史",
   "palette.cmd.trash": "回收站",
   "palette.cmd.settings": "设置",
   "palette.cmd.appearance": "外观",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -27849,7 +27849,7 @@ body > .mermaid-diagram--fullscreen {
 
 .sidebar--workbench .sidebar__utility-row {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
 }
 
@@ -29864,7 +29864,7 @@ body > .mermaid-diagram--fullscreen {
 .app--creation .sidebar__nav,
 :root[data-theme-style] .app--creation .sidebar__nav {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
   padding: 12px 0 0;
   border-top-color: color-mix(in srgb, var(--fg-faint) 9%, transparent);

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: "expanded prompt"},
+		{Role: provider.RoleUser, Content: "expanded prompt", CreatedAt: 1_718_000_000_000},
 		{Role: provider.RoleAssistant, Content: "answer", ReasoningContent: "thinking trace", WorkDurationMs: 24_000, ToolCalls: []provider.ToolCall{{
 			ID: "call_1", Name: "bash", Arguments: `{"command":"pwd"}`,
 		}}, MemoryCitations: []provider.MemoryCitation{{
@@ -44,6 +44,9 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	}
 	if got[0].SubmitText != "expanded prompt" {
 		t.Fatalf("user submit text = %q, want expanded prompt", got[0].SubmitText)
+	}
+	if got[0].CreatedAt != 1_718_000_000_000 {
+		t.Fatalf("user createdAt = %d, want 1718000000000", got[0].CreatedAt)
 	}
 	if got[1].Reasoning != "thinking trace" {
 		t.Fatalf("assistant reasoning = %q, want thinking trace", got[1].Reasoning)
@@ -595,7 +598,7 @@ func TestPreviewSessionMessagesIncludesProcessEvents(t *testing.T) {
 		`{"kind":"notice","level":"warn","text":"Network changed"}`,
 		`{"kind":"compaction_started","compaction":{"trigger":"manual"}}`,
 		`{"kind":"compaction_done","compaction":{"trigger":"manual","messages":6,"summary":"Kept the current task.","archive":"/tmp/archive.jsonl"}}`,
-		`{"type":"user.message","text":"hello"}`,
+		`{"type":"user.message","text":"hello","ts":1718000000000}`,
 		`{"type":"model.final","content":"hi","reasoningContent":"thinking"}`,
 	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
@@ -623,6 +626,35 @@ func TestPreviewSessionMessagesIncludesProcessEvents(t *testing.T) {
 	}
 	if got[4].Role != "user" || got[5].Reasoning != "thinking" {
 		t.Fatalf("conversation events not preserved: %+v", got[4:])
+	}
+	if got[4].CreatedAt != 1_718_000_000_000 {
+		t.Fatalf("event user createdAt = %d, want 1718000000000", got[4].CreatedAt)
+	}
+}
+
+func TestPreviewSessionMessagesRestoresAppendEventUserTime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	session := agent.NewSession("")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	if err := session.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot first: %v", err)
+	}
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := session.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot second: %v", err)
+	}
+
+	got, err := previewSessionMessages(dir, path)
+	if err != nil {
+		t.Fatalf("previewSessionMessages: %v", err)
+	}
+	if len(got) != 3 || got[2].Role != "user" || got[2].Content != "second" {
+		t.Fatalf("preview history = %+v, want second user at index 2", got)
+	}
+	if got[2].CreatedAt <= 0 {
+		t.Fatalf("append-event user timestamp was not restored: %+v", got[2])
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1381,7 +1381,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			}
 		}
 	}
-	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
+	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx), CreatedAt: time.Now().UnixMilli()})
 
 	finalReadinessBlocks := 0
 	seenReadinessStates := make(map[string]struct{})
@@ -2466,8 +2466,15 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
 		a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max})
 	})
+	// CreatedAt is durable UI metadata, not model input. Strip it from the
+	// transport copy so wall-clock differences never invalidate the provider's
+	// prompt-cache prefix (and custom providers cannot accidentally send it).
+	requestMessages := append([]provider.Message(nil), a.session.Messages...)
+	for i := range requestMessages {
+		requestMessages[i].CreatedAt = 0
+	}
 	ch, err := a.prov.Stream(ctx, provider.Request{
-		Messages:    a.session.Messages,
+		Messages:    requestMessages,
 		Tools:       a.tools.Schemas(),
 		Temperature: provider.OptionalTemperature(a.temperature),
 	})

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/nilutil"
@@ -675,7 +676,7 @@ func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan strin
 	if c == nil || c.executor == nil || c.executor.session == nil {
 		return
 	}
-	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withTurnPreferences(input), Images: userImages(ctx)})
+	c.executor.session.Add(provider.Message{Role: provider.RoleUser, Content: c.executor.withTurnPreferences(input), Images: userImages(ctx), CreatedAt: time.Now().UnixMilli()})
 	c.executor.session.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
 }
 

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -25,6 +25,35 @@ func echoRegistry() *tool.Registry {
 	return reg
 }
 
+func TestRunPersistsUserCreatedAtWithoutSendingItToProvider(t *testing.T) {
+	const existingCreatedAt int64 = 1_718_000_000_000
+	prov := testutil.NewMock("m", testutil.Turn{Text: "done"})
+	session := NewSession("system")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "existing", CreatedAt: existingCreatedAt})
+	agent := New(prov, tool.NewRegistry(), session, Options{}, event.Discard)
+
+	if err := agent.Run(context.Background(), "new prompt"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	request := prov.LastRequest()
+	if request == nil {
+		t.Fatal("provider received no request")
+	}
+	for i, message := range request.Messages {
+		if message.CreatedAt != 0 {
+			t.Fatalf("provider message %d leaked createdAt %d", i, message.CreatedAt)
+		}
+	}
+
+	messages := session.Snapshot()
+	if len(messages) < 3 || messages[1].CreatedAt != existingCreatedAt {
+		t.Fatalf("persisted existing timestamp changed: %+v", messages)
+	}
+	if messages[2].Role != provider.RoleUser || messages[2].CreatedAt <= 0 {
+		t.Fatalf("new user timestamp was not persisted: %+v", messages[2])
+	}
+}
+
 // TestRunMultiToolRoundEmptyIDsSurvivePairing drives the real loop through a turn
 // that fans out two tool calls carrying no id (a gateway that streams by index),
 // then asserts both results still pair back after SanitizeToolPairing — the repair

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -922,12 +922,21 @@ func digestSessionMessages(msgs []provider.Message) ([sha256.Size]byte, error) {
 	return digest, err
 }
 
+func messageForSessionIdentity(m provider.Message) provider.Message {
+	// CreatedAt is local display metadata. Keep it out of transcript identity
+	// so older builds that ignore the optional field can share the same event-
+	// log revision and append without false conflicts.
+	m.CreatedAt = 0
+	return m
+}
+
 // digestAndSizeSessionMessages also reports the encoded transcript size, which
 // the save path uses to bound the event log relative to the live content.
 func digestAndSizeSessionMessages(msgs []provider.Message) ([sha256.Size]byte, int64, error) {
 	h := sha256.New()
 	size := int64(0)
 	for _, m := range msgs {
+		m = messageForSessionIdentity(m)
 		b, err := json.Marshal(m)
 		if err != nil {
 			return [sha256.Size]byte{}, 0, err
@@ -960,11 +969,12 @@ func messagesHavePrefix(full, prefix []provider.Message) bool {
 // messagesPrefixDigestDepth returns the number of leading messages of msgs
 // whose storage digest equals target, or -1 when no prefix matches. The
 // digest accumulates exactly like digestAndSizeSessionMessages, so a match at
-// depth k means msgs[:k] is byte-for-byte the transcript that produced target.
+// depth k means msgs[:k] has the same transcript identity as target.
 func messagesPrefixDigestDepth(msgs []provider.Message, target [sha256.Size]byte) int {
 	h := sha256.New()
 	sum := make([]byte, 0, sha256.Size)
 	for i, m := range msgs {
+		m = messageForSessionIdentity(m)
 		b, err := json.Marshal(m)
 		if err != nil {
 			return -1
@@ -1014,6 +1024,8 @@ func messagesWithoutLeadingSystem(msgs []provider.Message) []provider.Message {
 }
 
 func messagesEqualForStorage(a, b provider.Message) bool {
+	a = messageForSessionIdentity(a)
+	b = messageForSessionIdentity(b)
 	ab, err := json.Marshal(a)
 	if err != nil {
 		return false

--- a/internal/agent/session_content.go
+++ b/internal/agent/session_content.go
@@ -58,6 +58,9 @@ func LoadSessionUserMessages(path string) ([]SessionUserMessage, error) {
 				if i < len(replay.times) {
 					at = replay.times[i]
 				}
+				if m.CreatedAt > 0 {
+					at = time.UnixMilli(m.CreatedAt)
+				}
 				out = append(out, SessionUserMessage{Text: m.Content, At: at})
 			}
 			return out, nil
@@ -72,7 +75,11 @@ func LoadSessionUserMessages(path string) ([]SessionUserMessage, error) {
 		if m.Role != provider.RoleUser {
 			continue
 		}
-		out = append(out, SessionUserMessage{Text: m.Content})
+		at := time.Time{}
+		if m.CreatedAt > 0 {
+			at = time.UnixMilli(m.CreatedAt)
+		}
+		out = append(out, SessionUserMessage{Text: m.Content, At: at})
 	}
 	return out, nil
 }

--- a/internal/agent/session_events_test.go
+++ b/internal/agent/session_events_test.go
@@ -412,6 +412,52 @@ func TestLoadSessionUserMessagesSeesEventLogTurns(t *testing.T) {
 	}
 }
 
+func TestSessionEventLogPreservesUserCreatedAt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	want := time.Date(2026, 7, 16, 8, 30, 0, 0, time.UTC).UnixMilli()
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "timed prompt", CreatedAt: want})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	msgs := loaded.Snapshot()
+	if len(msgs) != 2 || msgs[1].CreatedAt != want {
+		t.Fatalf("loaded messages = %+v, want user createdAt %d", msgs, want)
+	}
+}
+
+func TestSessionDigestIgnoresUserCreatedAt(t *testing.T) {
+	withoutTime := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "prompt"},
+	}
+	withTime := append([]provider.Message(nil), withoutTime...)
+	withTime[1].CreatedAt = 1_718_000_000_000
+
+	withoutDigest, withoutSize, err := digestAndSizeSessionMessages(withoutTime)
+	if err != nil {
+		t.Fatalf("digest without createdAt: %v", err)
+	}
+	withDigest, withSize, err := digestAndSizeSessionMessages(withTime)
+	if err != nil {
+		t.Fatalf("digest with createdAt: %v", err)
+	}
+	if withoutDigest != withDigest || withoutSize != withSize {
+		t.Fatalf("local createdAt changed transcript identity: digestEqual=%v size=%d/%d", withoutDigest == withDigest, withoutSize, withSize)
+	}
+	if !messagesHavePrefix(withTime, withoutTime) || !messagesHavePrefix(withoutTime, withTime) {
+		t.Fatal("local createdAt broke cross-version transcript prefix matching")
+	}
+	if depth := messagesPrefixDigestDepth(withTime, withoutDigest); depth != len(withTime) {
+		t.Fatalf("createdAt-aware prefix digest depth = %d, want %d", depth, len(withTime))
+	}
+}
+
 func TestSessionContentModTimeTracksEventLog(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	s := sessionWithTurns(t, path, 1)

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/autoresearch"
@@ -114,7 +115,7 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	if c.executor == nil {
 		return fmt.Errorf("subagent slash invocation requires an active session")
 	}
-	c.executor.Session().Add(provider.Message{Role: provider.RoleUser, Content: input, Images: images})
+	c.executor.Session().Add(provider.Message{Role: provider.RoleUser, Content: input, Images: images, CreatedAt: time.Now().UnixMilli()})
 
 	for _, sk := range skills {
 		callID := fmt.Sprintf("slash-skill-%d", c.slashSkillSeq.Add(1))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,6 +43,7 @@ type Message struct {
 	Name               string           `json:"name,omitempty"`            // tool message: tool name
 	MemoryCitations    []MemoryCitation `json:"memoryCitations,omitempty"` // local UI metadata; provider requests ignore it
 	WorkDurationMs     int64            `json:"workDurationMs,omitempty"`  // local UI metadata; provider requests ignore it
+	CreatedAt          int64            `json:"createdAt,omitempty"`       // local UI metadata; unix milliseconds; stripped before provider requests
 	Edited             bool             `json:"edited,omitempty"`          // local UI metadata; provider requests ignore it
 	Original           string           `json:"original,omitempty"`        // user prompt before inline edit
 }


### PR DESCRIPTION
## Summary

- Restore send times for historical user messages by persisting local `createdAt` metadata and recovering timestamps from modern session events and legacy `ts` / `time` / `timestamp` fields.
- Keep `createdAt` out of provider requests and transcript identity so prompt-cache prefixes and cross-version session conflict detection stay stable.
- Remove the standalone History entries from both desktop navigation styles, the command palette, and project context menus while retaining project/session search and Trash.
- Redistribute the Workbench and Creation utility footers into three equal-width actions.
- Add backend and frontend regression coverage for timestamp restoration and navigation removal.

## Root cause

Live user bubbles received `Date.now()` in the frontend, but persisted history did not expose a durable per-user timestamp. Reloaded and previewed sessions therefore hydrated without `createdAt`.

The standalone History manager also duplicated project-tree and session-search navigation, and its removal required the remaining footer actions to be redistributed.

## Compatibility

| Surface | Old-data behavior | Result |
| --- | --- | --- |
| `provider.Message.createdAt` | Optional with `omitempty`; old sessions deserialize to zero, and legacy event times backfill where available. Older builds ignore the unknown field. | Backward compatible |
| Session digest and prefix identity | `createdAt` is normalized out of digest, prefix-depth, and storage comparisons. | No false cross-version conflicts |
| Provider requests | `createdAt` is stripped from the transport copy before streaming. | Prompt-cache prefix unchanged |
| UI navigation | Standalone History is removed; project/session search and Trash remain available. | No data migration |

## Cache impact

Cache-impact: low - `createdAt` is local display metadata; provider-bound messages and transcript identity normalize it out, so prompt prefixes stay stable.
Cache-guard: `./scripts/cache-guard.sh` plus `TestRunPersistsUserCreatedAtWithoutSendingItToProvider` verifies provider requests never carry the field.

## Validation

- `go test ./...`
- `(cd desktop && go test ./...)`
- `./scripts/cache-guard.sh`
- `pnpm test:typecheck`
- `pnpm typecheck`
- `pnpm check:css`
- `pnpm test`
- `pnpm build`
- Browser DOM/CSS verification: 18 historical timestamps rendered, no standalone History entry, and three equal-width footer actions in both Workbench and Creation styles.
- Browser console: no errors.

The production build reports only the existing chunk-size and mixed-import warnings.

## Related pull requests

- #5634 adds an in-transcript chat-history sidebar; it is a distinct interaction and does not replace this persisted timestamp fix.
- #5750 is a broader desktop UI cleanup and may overlap at the stylesheet level, but it does not implement this compatibility boundary.