### PR TITLE
fix(cli): 恢复TUI状态栏第二行完整信息显示（#6577）

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2723,14 +2723,26 @@ func (m chatTUI) View() tea.View {
 	// only while a turn runs); the status/data rows stay below. This mirrors Claude
 	// Code: live progress over the composer, shortcuts + stats under it.
 	working := m.runningWorkingLine(cancelRequested, true)
-	// Keep the persistent data row deliberately compact. Detailed profile, cache,
-	// jobs, balance, effort, git, and mouse state is available through /status.
+	// Restore the detailed data row: model, work mode, cache rates, context,
+	// background jobs, and wallet balance, matching the pre-simplification format.
 	var data []string
 	if mt := m.modelTag(); mt != "" {
 		data = append(data, mt)
 	}
+	if wt := m.workModeTag(); wt != "" {
+		data = append(data, wt)
+	}
+	if cache := m.cacheTag(); cache != "" {
+		data = append(data, cache)
+	}
 	if ctxTag != "" {
 		data = append(data, ctxTag)
+	}
+	if jt := m.jobsTag(); jt != "" {
+		data = append(data, jt)
+	}
+	if m.balance != "" {
+		data = append(data, dim(m.balance))
 	}
 	dataLine := "  " + strings.Join(data, " · ")
 	// A configured custom status line replaces the built-in data row entirely.
@@ -3246,13 +3258,25 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	default:
 		status += " · " + i18n.M.ChatStatusIdle + " (" + m.cycleHint() + ")"
 	}
-	// Replicate the compact data line from View().
+	// Replicate the detailed data line from View().
 	var data []string
 	if mt := m.modelTag(); mt != "" {
 		data = append(data, mt)
 	}
+	if wt := m.workModeTag(); wt != "" {
+		data = append(data, wt)
+	}
+	if cache := m.cacheTag(); cache != "" {
+		data = append(data, cache)
+	}
 	if ct := m.contextTag(); ct != "" {
 		data = append(data, ct)
+	}
+	if jt := m.jobsTag(); jt != "" {
+		data = append(data, jt)
+	}
+	if m.balance != "" {
+		data = append(data, dim(m.balance))
 	}
 	dataLine := "  " + strings.Join(data, " · ")
 	if m.statuslineCmd != "" && m.statuslineOut != "" {

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -204,7 +204,7 @@ func TestStatuslineKeepsEffortOutOfPersistentFooter(t *testing.T) {
 	}
 }
 
-func TestStatuslineKeepsCacheRatesOutOfPersistentFooter(t *testing.T) {
+func TestStatuslineShowsCacheRatesInDataRow(t *testing.T) {
 	i18n.DetectLanguage("en")
 
 	content := renderStatuslineViewWithCache(t)
@@ -212,8 +212,8 @@ func TestStatuslineKeepsCacheRatesOutOfPersistentFooter(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("status block lines = %d, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
 	}
-	if !strings.Contains(lines[1], "deepseek-v4-flash") || strings.Contains(lines[1], "hit") {
-		t.Fatalf("data row should keep model but omit cache rates:\n%s", strings.Join(lines, "\n"))
+	if !strings.Contains(lines[1], "deepseek-v4-flash") || !strings.Contains(lines[1], "hit") {
+		t.Fatalf("data row should show model and cache rates:\n%s", strings.Join(lines, "\n"))
 	}
 }
 


### PR DESCRIPTION
## Summary

提交 a99256d5 将 dataLine 精简为仅显示 model + context，
但用户期望在常驻状态栏中看到更丰富的信息。本次变更将
dataLine 恢复为完整的六项内容：

  model · work mode · cache rates · context · jobs · balance

同时恢复 computeStatusLineCount 中的镜像逻辑, 并更新对应测试。

变更文件：
  - internal/cli/chat_tui.go: View() 和 computeStatusLineCount() 两处 dataLine 构建恢复完整格式
  - internal/cli/statusline_test.go: TestStatuslineKeepsCacheRatesOutOfPersistentFooter 改回 TestStatuslineShowsCacheRatesInDataRow，断言 cache 信息出现在 data line

Closes #6577

## Verification

- `go vet ./internal/cli/`
- `go test ./internal/i18n/`
- `TestStatuslineShowsCacheRatesInDataRow`
- `TestStatusLineWrapAccounting`
- `TestStatusLineRenderedHeightMatchesBudget`
- `TestStatuslineKeepsEffortOutOfPersistentFooter`
- `TestStatuslineKeepsGitAndEffortOutOfPersistentFooter`
- 集成测试
  - 进入 TUI 模式， 状态栏第二行恢复显示 余额等信息
  - 与大模型对话，状态栏第二栏恢复显示本次命中、平均命中

<img width="1244" height="457" alt="fix2" src="https://github.com/user-attachments/assets/f2b93792-b729-45c6-b995-a554b44c1e0e" />

 

## Cache impact

Cache-impact: low
Cache-guard: N/A
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
