### PR TITLE
feat(cli): support middle-click paste / 支持 CLI 中键粘贴

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -894,6 +894,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the mouse: copy an active selection, otherwise paste clipboard text into
 		// the visible composer. Left-press begins a selection unless it lands on
 		// the transcript scrollbar or a shell-output hint line.
+		// Middle-click pastes the PRIMARY selection (X11/Wayland convention).
+		if msg.Button == tea.MouseMiddle {
+			cmds = append(cmds, pastePrimary())
+			return m, finalize(m, cmds)
+		}
 		if msg.Button == tea.MouseRight && m.validComposerSelection() && !m.composerSel.empty() {
 			cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
 			return m, finalize(m, cmds)

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -897,6 +897,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Middle-click pastes tmux's current buffer when tmux owns the pane;
 		// otherwise it follows the X11/Wayland PRIMARY-selection convention.
 		if msg.Button == tea.MouseMiddle {
+			if m.hideComposer() {
+				return m, nil
+			}
 			cmds = append(cmds, pasteMiddleClick())
 			return m, finalize(m, cmds)
 		}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -894,9 +894,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the mouse: copy an active selection, otherwise paste clipboard text into
 		// the visible composer. Left-press begins a selection unless it lands on
 		// the transcript scrollbar or a shell-output hint line.
-		// Middle-click pastes the PRIMARY selection (X11/Wayland convention).
+		// Middle-click pastes tmux's current buffer when tmux owns the pane;
+		// otherwise it follows the X11/Wayland PRIMARY-selection convention.
 		if msg.Button == tea.MouseMiddle {
-			cmds = append(cmds, pastePrimary())
+			cmds = append(cmds, pasteMiddleClick())
 			return m, finalize(m, cmds)
 		}
 		if msg.Button == tea.MouseRight && m.validComposerSelection() && !m.composerSel.empty() {

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atotto/clipboard"
 
 	"reasonix/internal/control"
+	"reasonix/internal/secrets"
 	"reasonix/internal/shellparse"
 )
 
@@ -156,6 +157,7 @@ func (m *chatTUI) beginClipboardImagePaste() tea.Cmd {
 var (
 	readTmuxPasteBuffer       = readTmuxBuffer
 	readPrimaryPasteSelection = readPrimarySelection
+	newPasteCommand           = exec.Command
 )
 
 // pasteMiddleClick returns a tea.Cmd that reads from the selection owner for the
@@ -165,11 +167,17 @@ var (
 // here instead of unexpectedly switching to the desktop PRIMARY selection.
 func pasteMiddleClick() tea.Cmd {
 	return func() tea.Msg {
-		reader := readPrimaryPasteSelection
 		if os.Getenv("TMUX") != "" {
-			reader = readTmuxPasteBuffer
+			text, err := readTmuxPasteBuffer()
+			if err != nil || text == "" {
+				return nil
+			}
+			return tea.PasteMsg{Content: text}
 		}
-		text, err := reader()
+		if remoteClipboardSession() {
+			return clipboardTextPasteMsg{remote: true}
+		}
+		text, err := readPrimaryPasteSelection()
 		if err != nil || text == "" {
 			return nil
 		}
@@ -181,7 +189,9 @@ func pasteMiddleClick() tea.Cmd {
 // environment variable identifies the correct server socket, just as the tmux
 // client command does for an interactive shell inside the pane.
 func readTmuxBuffer() (string, error) {
-	out, err := exec.Command("tmux", "save-buffer", "-").Output()
+	cmd := newPasteCommand("tmux", "save-buffer", "-")
+	cmd.Env = secrets.ProcessEnv()
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("read tmux paste buffer: %w", err)
 	}
@@ -193,14 +203,15 @@ func readTmuxBuffer() (string, error) {
 func readPrimarySelection() (string, error) {
 	// Match the order used by SaveClipboardImage: Wayland tool first, then X11.
 	for _, args := range [][]string{
-		{"wl-paste", "--primary", "--no-newline"},
+		{"wl-paste", "--primary", "--type", "text", "--no-newline"},
 		{"xclip", "-selection", "primary", "-o"},
 		{"xsel", "--output", "--primary"},
 	} {
-		cmd := exec.Command(args[0], args[1:]...)
+		cmd := newPasteCommand(args[0], args[1:]...)
+		cmd.Env = secrets.ProcessEnv()
 		out, err := cmd.Output()
 		if err == nil {
-			return strings.TrimRight(string(out), "\n\r"), nil
+			return string(out), nil
 		}
 	}
 	return "", fmt.Errorf("no primary selection tool found (need wl-paste, xclip, or xsel)")

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -149,6 +150,39 @@ func (m *chatTUI) beginClipboardImagePaste() tea.Cmd {
 	}
 	m.clipboardImagePending = true
 	return pasteClipboardImage()
+}
+
+// pastePrimary returns a tea.Cmd that reads the PRIMARY selection (the X11/Wayland
+// selection filled by highlighting text and pasted with middle-click) and sends it
+// as a tea.PasteMsg. If no PRIMARY content is available or no tool is found,
+// it returns nil (silent no-op), matching the terminal expectation that middle-click
+// with an empty selection does nothing.
+func pastePrimary() tea.Cmd {
+	return func() tea.Msg {
+		text, err := readPrimarySelection()
+		if err != nil || text == "" {
+			return nil
+		}
+		return tea.PasteMsg{Content: text}
+	}
+}
+
+// readPrimarySelection attempts to retrieve text from the PRIMARY selection by
+// trying wl-paste (Wayland), xclip (X11), and xsel (X11) in order.
+func readPrimarySelection() (string, error) {
+	// Match the order used by SaveClipboardImage: Wayland tool first, then X11.
+	for _, args := range [][]string{
+		{"wl-paste", "--primary", "--no-newline"},
+		{"xclip", "-selection", "primary", "-o"},
+		{"xsel", "--output", "--primary"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimRight(string(out), "\n\r"), nil
+		}
+	}
+	return "", fmt.Errorf("no primary selection tool found (need wl-paste, xclip, or xsel)")
 }
 
 func (m *chatTUI) attachPastedImages(text string) bool {

--- a/internal/cli/chat_tui_paste.go
+++ b/internal/cli/chat_tui_paste.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -152,19 +153,39 @@ func (m *chatTUI) beginClipboardImagePaste() tea.Cmd {
 	return pasteClipboardImage()
 }
 
-// pastePrimary returns a tea.Cmd that reads the PRIMARY selection (the X11/Wayland
-// selection filled by highlighting text and pasted with middle-click) and sends it
-// as a tea.PasteMsg. If no PRIMARY content is available or no tool is found,
-// it returns nil (silent no-op), matching the terminal expectation that middle-click
-// with an empty selection does nothing.
-func pastePrimary() tea.Cmd {
+var (
+	readTmuxPasteBuffer       = readTmuxBuffer
+	readPrimaryPasteSelection = readPrimarySelection
+)
+
+// pasteMiddleClick returns a tea.Cmd that reads from the selection owner for the
+// current terminal environment and sends the result through the canonical paste
+// path. tmux normally owns middle-click and pastes its current buffer, but forwards
+// the event when an application enables mouse reporting; honor that same contract
+// here instead of unexpectedly switching to the desktop PRIMARY selection.
+func pasteMiddleClick() tea.Cmd {
 	return func() tea.Msg {
-		text, err := readPrimarySelection()
+		reader := readPrimaryPasteSelection
+		if os.Getenv("TMUX") != "" {
+			reader = readTmuxPasteBuffer
+		}
+		text, err := reader()
 		if err != nil || text == "" {
 			return nil
 		}
 		return tea.PasteMsg{Content: text}
 	}
+}
+
+// readTmuxBuffer retrieves the current tmux buffer verbatim. The inherited TMUX
+// environment variable identifies the correct server socket, just as the tmux
+// client command does for an interactive shell inside the pane.
+func readTmuxBuffer() (string, error) {
+	out, err := exec.Command("tmux", "save-buffer", "-").Output()
+	if err != nil {
+		return "", fmt.Errorf("read tmux paste buffer: %w", err)
+	}
+	return string(out), nil
 }
 
 // readPrimarySelection attempts to retrieve text from the PRIMARY selection by

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
+	"reasonix/internal/secrets"
 	"reasonix/internal/skill"
 	"reasonix/internal/testenv"
 )
@@ -33,6 +35,31 @@ type stubbornTurnRunner struct {
 }
 
 const tinyPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+const (
+	middleClickPasteHelperFlag = "GO_WANT_REASONIX_MIDDLE_CLICK_PASTE_HELPER"
+	middleClickPasteHelperMode = "REASONIX_MIDDLE_CLICK_PASTE_HELPER_MODE"
+	middleClickPasteTestValue  = "REASONIX_MIDDLE_CLICK_TEST_VALUE"
+)
+
+func TestMiddleClickPasteCommandHelper(t *testing.T) {
+	if os.Getenv(middleClickPasteHelperFlag) != "1" {
+		return
+	}
+	switch os.Getenv(middleClickPasteHelperMode) {
+	case "credential":
+		if value := os.Getenv(middleClickPasteTestValue); value != "" {
+			_, _ = fmt.Fprint(os.Stdout, value)
+		} else {
+			_, _ = fmt.Fprint(os.Stdout, "filtered")
+		}
+	case "newlines":
+		_, _ = fmt.Fprint(os.Stdout, "line\n\n")
+	default:
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
 
 func TestMain(m *testing.M) {
 	old := detectTermuxTerminal
@@ -1458,6 +1485,29 @@ func clipboardTextPasteResultFromCmd(t *testing.T, cmd tea.Cmd) clipboardTextPas
 	return clipboardTextPasteMsg{}
 }
 
+func middleClickPasteResultFromCmd(t *testing.T, cmd tea.Cmd) tea.PasteMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected middle-click paste command")
+	}
+	msg := cmd()
+	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		return msg
+	case tea.BatchMsg:
+		for _, child := range msg {
+			if child == nil {
+				continue
+			}
+			if result, ok := child().(tea.PasteMsg); ok {
+				return result
+			}
+		}
+	}
+	t.Fatalf("middle-click command returned %T, want tea.PasteMsg", msg)
+	return tea.PasteMsg{}
+}
+
 func setLocalClipboardSession(t *testing.T) {
 	t.Helper()
 	t.Setenv("SSH_CONNECTION", "")
@@ -1561,6 +1611,80 @@ func TestMiddleClickUsesTmuxPasteBufferInsideTmux(t *testing.T) {
 	}
 }
 
+func TestMouseMiddleClickPastesPrimarySelectionThroughCanonicalPath(t *testing.T) {
+	setLocalClipboardSession(t)
+	t.Setenv("TMUX", "")
+	previous := readPrimaryPasteSelection
+	t.Cleanup(func() { readPrimaryPasteSelection = previous })
+	readPrimaryPasteSelection = func() (string, error) { return "primary selection", nil }
+
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before ")
+	next, cmd := m.Update(tea.MouseClickMsg{Button: tea.MouseMiddle})
+	m = next.(chatTUI)
+	paste := middleClickPasteResultFromCmd(t, cmd)
+	next, _ = m.Update(paste)
+	m = next.(chatTUI)
+
+	if got := m.input.Value(); got != "before primary selection" {
+		t.Fatalf("middle-click paste produced %q, want %q", got, "before primary selection")
+	}
+}
+
+func TestMouseMiddleClickDoesNotMutateHiddenComposer(t *testing.T) {
+	setLocalClipboardSession(t)
+	t.Setenv("TMUX", "")
+	previous := readPrimaryPasteSelection
+	t.Cleanup(func() { readPrimaryPasteSelection = previous })
+	readPrimaryPasteSelection = func() (string, error) {
+		t.Fatal("middle-click with a hidden composer must not read PRIMARY")
+		return "", nil
+	}
+
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before")
+	m.pendingApproval = &event.Approval{ID: "approval", Tool: "bash", Subject: "echo hi"}
+	if !m.hideComposer() {
+		t.Fatal("test setup did not hide composer")
+	}
+
+	next, cmd := m.Update(tea.MouseClickMsg{Button: tea.MouseMiddle})
+	m = next.(chatTUI)
+	if cmd != nil {
+		t.Fatalf("hidden-composer middle-click returned command with message %#v", cmd())
+	}
+	if got := m.input.Value(); got != "before" {
+		t.Fatalf("hidden composer changed to %q", got)
+	}
+}
+
+func TestMouseMiddleClickPasteOverSSHDoesNotReadRemotePrimary(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "host 22 client 1234")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+	t.Setenv("TMUX", "")
+	previous := readPrimaryPasteSelection
+	t.Cleanup(func() { readPrimaryPasteSelection = previous })
+	readPrimaryPasteSelection = func() (string, error) {
+		t.Fatal("SSH middle-click must not read PRIMARY on the remote host")
+		return "", nil
+	}
+
+	m := newComposerMouseTestTUI(t, 60, 16)
+	next, cmd := m.Update(tea.MouseClickMsg{Button: tea.MouseMiddle})
+	m = next.(chatTUI)
+	result := clipboardTextPasteResultFromCmd(t, cmd)
+	if !result.remote {
+		t.Fatalf("SSH middle-click paste result = %+v, want remote hint", result)
+	}
+
+	next, _ = m.Update(result)
+	m = next.(chatTUI)
+	if got := strings.Join(m.transcript, "\n"); !strings.Contains(got, i18n.M.ClipboardTextPasteRemoteHint) {
+		t.Fatalf("SSH middle-click paste notice = %q, want %q", got, i18n.M.ClipboardTextPasteRemoteHint)
+	}
+}
+
 func TestMiddleClickUsesPrimarySelectionOutsideTmux(t *testing.T) {
 	t.Setenv("TMUX", "")
 	previousTmux := readTmuxPasteBuffer
@@ -1590,6 +1714,65 @@ func TestMiddleClickTmuxReadFailureIsSilent(t *testing.T) {
 
 	if msg := pasteMiddleClick()(); msg != nil {
 		t.Fatalf("failed tmux-buffer read returned %#v, want silent no-op", msg)
+	}
+}
+
+func TestMiddleClickPasteCommandsFilterRegisteredCredentials(t *testing.T) {
+	t.Setenv(middleClickPasteHelperFlag, "1")
+	t.Setenv(middleClickPasteHelperMode, "credential")
+	t.Setenv(middleClickPasteTestValue, "credential-leaked")
+	secrets.RegisterCredentialEnvKeys([]string{middleClickPasteTestValue})
+
+	previous := newPasteCommand
+	t.Cleanup(func() { newPasteCommand = previous })
+	newPasteCommand = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command(os.Args[0], "-test.run=^TestMiddleClickPasteCommandHelper$")
+	}
+
+	for name, read := range map[string]func() (string, error){
+		"tmux":    readTmuxBuffer,
+		"primary": readPrimarySelection,
+	} {
+		t.Run(name, func(t *testing.T) {
+			text, err := read()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != "filtered" {
+				t.Fatalf("paste helper inherited registered credential: %q", text)
+			}
+		})
+	}
+}
+
+func TestReadPrimarySelectionRequestsTextAndPreservesNewlines(t *testing.T) {
+	t.Setenv(middleClickPasteHelperFlag, "1")
+	t.Setenv(middleClickPasteHelperMode, "newlines")
+
+	previous := newPasteCommand
+	t.Cleanup(func() { newPasteCommand = previous })
+	called := false
+	newPasteCommand = func(name string, args ...string) *exec.Cmd {
+		called = true
+		if name != "wl-paste" {
+			t.Fatalf("first PRIMARY helper = %q, want wl-paste", name)
+		}
+		want := []string{"--primary", "--type", "text", "--no-newline"}
+		if !reflect.DeepEqual(args, want) {
+			t.Fatalf("wl-paste args = %q, want %q", args, want)
+		}
+		return exec.Command(os.Args[0], "-test.run=^TestMiddleClickPasteCommandHelper$")
+	}
+
+	text, err := readPrimarySelection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("PRIMARY helper was not invoked")
+	}
+	if text != "line\n\n" {
+		t.Fatalf("PRIMARY selection = %q, want trailing newlines preserved", text)
 	}
 }
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1540,6 +1540,59 @@ func TestMouseRightClickPasteUsesCanonicalFoldedPastePath(t *testing.T) {
 	}
 }
 
+func TestMiddleClickUsesTmuxPasteBufferInsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1,0")
+	previousTmux := readTmuxPasteBuffer
+	previousPrimary := readPrimaryPasteSelection
+	t.Cleanup(func() {
+		readTmuxPasteBuffer = previousTmux
+		readPrimaryPasteSelection = previousPrimary
+	})
+	readTmuxPasteBuffer = func() (string, error) { return "tmux buffer", nil }
+	readPrimaryPasteSelection = func() (string, error) {
+		t.Fatal("middle-click inside tmux must not read the desktop PRIMARY selection")
+		return "", nil
+	}
+
+	msg := pasteMiddleClick()()
+	paste, ok := msg.(tea.PasteMsg)
+	if !ok || paste.Content != "tmux buffer" {
+		t.Fatalf("middle-click result = %#v, want tmux-buffer PasteMsg", msg)
+	}
+}
+
+func TestMiddleClickUsesPrimarySelectionOutsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	previousTmux := readTmuxPasteBuffer
+	previousPrimary := readPrimaryPasteSelection
+	t.Cleanup(func() {
+		readTmuxPasteBuffer = previousTmux
+		readPrimaryPasteSelection = previousPrimary
+	})
+	readTmuxPasteBuffer = func() (string, error) {
+		t.Fatal("middle-click outside tmux must not read a tmux buffer")
+		return "", nil
+	}
+	readPrimaryPasteSelection = func() (string, error) { return "primary selection", nil }
+
+	msg := pasteMiddleClick()()
+	paste, ok := msg.(tea.PasteMsg)
+	if !ok || paste.Content != "primary selection" {
+		t.Fatalf("middle-click result = %#v, want PRIMARY-selection PasteMsg", msg)
+	}
+}
+
+func TestMiddleClickTmuxReadFailureIsSilent(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1,0")
+	previous := readTmuxPasteBuffer
+	t.Cleanup(func() { readTmuxPasteBuffer = previous })
+	readTmuxPasteBuffer = func() (string, error) { return "", errors.New("no buffers") }
+
+	if msg := pasteMiddleClick()(); msg != nil {
+		t.Fatalf("failed tmux-buffer read returned %#v, want silent no-op", msg)
+	}
+}
+
 // TestMouseDragReleaseAutoCopies verifies that releasing the mouse after a
 // left-drag over the transcript copies the selection to the clipboard
 // automatically (native terminal convention), keeps the selection highlighted

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -195,7 +195,7 @@ type Messages struct {
 	MouseCopiedHint              string // transient status-line hint after a mouse/Ctrl+C selection copy
 	ClipboardCopyOSC52Hint       string // copy was sent through OSC 52 because the session is remote
 	ClipboardCopyFallbackHint    string // native clipboard failed and copy fell back to OSC 52
-	ClipboardTextPasteRemoteHint string // right-click paste cannot read the user's local clipboard over SSH
+	ClipboardTextPasteRemoteHint string // mouse paste cannot read the user's local clipboard/PRIMARY selection over SSH
 	ClipboardTextPasteFailedFmt  string // text clipboard read failed, one %v
 	ClipboardImagePastingHint    string // shown while an image is being read from the system clipboard
 	ClipboardImagePasteFailedFmt string // image clipboard read failed, one %v

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -209,7 +209,7 @@ var English = Messages{
 	MouseCopiedHint:              "copied to clipboard",
 	ClipboardCopyOSC52Hint:       "copy sent via OSC 52 — terminal permission may be required",
 	ClipboardCopyFallbackHint:    "native clipboard unavailable — copy sent via OSC 52",
-	ClipboardTextPasteRemoteHint: "right-click paste cannot read your local clipboard over SSH — use the terminal paste shortcut or /mouse",
+	ClipboardTextPasteRemoteHint: "mouse paste cannot read your local clipboard or PRIMARY selection over SSH — use the terminal paste shortcut or /mouse",
 	ClipboardTextPasteFailedFmt:  "paste text failed: %v",
 	ClipboardImagePastingHint:    "Pasting image…",
 	ClipboardImagePasteFailedFmt: "paste image failed: %v",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -210,7 +210,7 @@ var Chinese = Messages{
 	MouseCopiedHint:              "已复制到剪贴板",
 	ClipboardCopyOSC52Hint:       "已通过 OSC 52 请求复制 — 可能需要终端授权",
 	ClipboardCopyFallbackHint:    "系统剪贴板不可用 — 已回退到 OSC 52",
-	ClipboardTextPasteRemoteHint: "SSH 下右键粘贴无法读取本地剪贴板 — 请使用终端粘贴快捷键或 /mouse",
+	ClipboardTextPasteRemoteHint: "SSH 下鼠标粘贴无法读取本地剪贴板或 PRIMARY 选区 — 请使用终端粘贴快捷键或 /mouse",
 	ClipboardTextPasteFailedFmt:  "粘贴文本失败：%v",
 	ClipboardImagePastingHint:    "正在粘贴图片…",
 	ClipboardImagePasteFailedFmt: "粘贴图片失败：%v",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -200,7 +200,7 @@ var ChineseTraditional = Messages{
 	MouseCopiedHint:              "已複製到剪貼簿",
 	ClipboardCopyOSC52Hint:       "已透過 OSC 52 請求複製 — 可能需要終端授權",
 	ClipboardCopyFallbackHint:    "系統剪貼簿無法使用 — 已改用 OSC 52",
-	ClipboardTextPasteRemoteHint: "SSH 下右鍵貼上無法讀取本機剪貼簿 — 請使用終端貼上快捷鍵或 /mouse",
+	ClipboardTextPasteRemoteHint: "SSH 下滑鼠貼上無法讀取本機剪貼簿或 PRIMARY 選取區 — 請使用終端貼上快捷鍵或 /mouse",
 	ClipboardTextPasteFailedFmt:  "貼上文字失敗：%v",
 	ClipboardImagePastingHint:    "正在貼上圖片…",
 	ClipboardImagePasteFailedFmt: "貼上圖片失敗：%v",


### PR DESCRIPTION
## Summary

Restore conventional middle-click paste while the Reasonix CLI owns terminal
mouse events.

- Inside tmux, paste the current tmux buffer to match tmux's normal button-2
  behavior.
- In a local X11/Wayland session, read the PRIMARY selection through
  `wl-paste`, `xclip`, or `xsel`.
- Over SSH outside tmux, show the existing remote-paste guidance instead of
  probing the remote host's graphical selection.
- Ignore middle-click paste while a modal panel owns input and the composer is
  hidden.

## Security and correctness

- Run every clipboard/tmux helper with `secrets.ProcessEnv()` so registered
  credential-store variables are not inherited by subprocesses.
- Request text explicitly from `wl-paste`.
- Preserve the selected text byte-for-byte, including intentional trailing
  newlines.
- Keep empty selections and unavailable helpers as silent no-ops.

## Verification

- `go test ./internal/cli`
- `go test -race ./internal/cli`
- `go vet ./...`
- `git diff --check`
- Synthetic merge with the latest `origin/main-v2`: focused and race CLI tests
  passed

## Compatibility

| Field or format | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted state/config | No persisted format or field changed | Backward-safe |

## Cache impact

- Cache-impact: none — only CLI input handling and localized UI text changed.
- Cache-guard: n/a — no provider-visible prompt, tool schema, or request
  serialization paths changed.
- System-prompt-review: N/A.
