### PR TITLE
feat: support for anthropic web_search

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2024,6 +2024,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"proxy_spec":         proxy,
 			"vision":             config.EffectiveVision(e),
 			"vision_detail":      e.VisionDetail,
+			"web_search":         e.WebSearch,
 		},
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1179,6 +1179,13 @@ type ProviderEntry struct {
 	// (the field is omitted). "low" caps an image to a fixed ~85 tokens for cheap
 	// coarse reads; ignored by providers without the knob (e.g. anthropic).
 	VisionDetail string `toml:"vision_detail"`
+	// WebSearch enables the server-side web_search tool for the anthropic
+	// provider kind. When true, the provider includes {"type":"web_search"} in
+	// the tools array, and the API executes searches server-side, returning
+	// web_search_tool_result content blocks in the stream. This is the primary
+	// way to use DeepSeek's built-in search via its Anthropic-compatible
+	// endpoint (https://api.deepseek.com/anthropic). Off by default.
+	WebSearch bool `toml:"web_search"`
 	// ReasoningProtocol selects the request shape for OpenAI-compatible reasoning
 	// models. Empty/auto uses the model capability registry plus endpoint
 	// heuristics; none disables automatic reasoning controls for this provider.

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -348,6 +348,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q   # openai image detail hint: low|high; empty = auto\n", p.VisionDetail)
 			}
+			if p.WebSearch {
+				b.WriteString("web_search  = true   # enable server-side web_search tool (Anthropic/DeepSeek API)\n")
+			}
 			if p.ReasoningProtocol != "" {
 				fmt.Fprintf(&b, "reasoning_protocol = %q   # auto|deepseek|openai|none; overrides model/endpoint reasoning detection\n", p.ReasoningProtocol)
 			}
@@ -963,6 +966,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 			}
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q\n", p.VisionDetail)
+			}
+			if p.WebSearch {
+				b.WriteString("web_search  = true\n")
 			}
 			if p.ReasoningProtocol != "" {
 				fmt.Fprintf(&b, "reasoning_protocol = %q\n", p.ReasoningProtocol)

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -77,6 +77,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
+	webSearch, _ := cfg.Extra["web_search"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)
 	httpClient, err := newHTTPClient(cfg)
@@ -109,6 +110,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		effort:      effort,
 		vision:      vision,
 		mimo:        provider.IsMiMoEndpoint(root),
+		webSearch:   webSearch,
 		headers:     cleanCustomHeaders(headers),
 		authHeader:  authHeader,
 		http:        httpClient, // no overall timeout; lifecycle is ctx-driven
@@ -132,6 +134,7 @@ type client struct {
 	effort      string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
 	vision      bool   // model accepts image input — embed attached images as base64 image blocks
 	mimo        bool   // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
+	webSearch   bool   // enable server-side web_search tool (DeepSeek Anthropic API)
 	headers     map[string]string
 	authHeader  bool // send Authorization: Bearer instead of Anthropic's x-api-key header
 	http        *http.Client
@@ -303,6 +306,9 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 	}
 
 	var tools []anthTool
+	if c.webSearch {
+		tools = append(tools, anthTool{Type: "web_search_20250305", Name: "web_search"})
+	}
 	for _, t := range req.Tools {
 		schema := t.Parameters
 		if len(schema) == 0 {
@@ -464,11 +470,27 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 				mergeUsage(ev.Message.Usage)
 			}
 		case "content_block_start":
-			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
-				tc := &provider.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
-				tools[ev.Index] = tc
-				if !send(provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}}) {
-					return
+			if ev.ContentBlock != nil {
+				switch ev.ContentBlock.Type {
+				case "tool_use":
+					tc := &provider.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
+					tools[ev.Index] = tc
+					if !send(provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}}) {
+						return
+					}
+				case "web_search_tool_result":
+					// Search results are delivered inline in content_block.content as a
+					// JSON array of result objects (title, url, encrypted_content).
+					// Only the model sees the plain text; we surface titles and URLs.
+					// server_tool_use blocks (the model initiating the search) are
+					// intentionally skipped — the API executes them server-side and
+					// the results appear here.
+					formatted := formatWebSearchResults(ev.ContentBlock.Content)
+					if formatted != "" {
+						if !send(provider.Chunk{Type: provider.ChunkText, Text: formatted}) {
+							return
+						}
+					}
 				}
 			}
 		case "content_block_delta":
@@ -587,6 +609,46 @@ func mapStopReason(s string) string {
 	}
 }
 
+// webSearchResult is a single result from a web_search_tool_result block.
+type webSearchResult struct {
+	URL      string `json:"url"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	SiteName string `json:"site_name"`
+}
+
+// formatWebSearchResults parses a web_search_tool_result content array
+// and formats titles and URLs as human-readable text. DeepSeek returns
+// encrypted_content rather than plain text at the transport layer; the
+// model still sees the original content.
+func formatWebSearchResults(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var results []webSearchResult
+	if err := json.Unmarshal(raw, &results); err != nil {
+		return ""
+	}
+	if len(results) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n")
+	for i, r := range results {
+		if r.Title == "" && r.URL == "" {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("\n- **%s**", r.Title))
+		if r.URL != "" {
+			b.WriteString(fmt.Sprintf("\n  <%s>", r.URL))
+		}
+		if i == len(results)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
 // --- Messages API wire protocol ---
 
 func ephemeral() *cacheControl { return &cacheControl{Type: "ephemeral"} }
@@ -667,9 +729,10 @@ func toolResultBlocks(text string, images []string) []contentBlock {
 }
 
 type anthTool struct {
-	Name         string          `json:"name"`
+	Type         string          `json:"type,omitempty"` // "web_search" for server-side search; empty for named tools
+	Name         string          `json:"name,omitempty"`
 	Description  string          `json:"description,omitempty"`
-	InputSchema  json.RawMessage `json:"input_schema"`
+	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
 	CacheControl *cacheControl   `json:"cache_control,omitempty"`
 }
 
@@ -681,17 +744,20 @@ type streamEvent struct {
 		Usage *wireUsage `json:"usage"`
 	} `json:"message"`
 	ContentBlock *struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
-		Name string `json:"name"`
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		Name      string          `json:"name"`
+		ToolUseID string          `json:"tool_use_id"` // web_search_tool_result
+		Content   json.RawMessage `json:"content"`     // web_search_tool_result: array of result objects
 	} `json:"content_block"`
 	Delta *struct {
-		Type        string `json:"type"`         // text_delta | thinking_delta | signature_delta | input_json_delta
-		Text        string `json:"text"`         // text_delta
-		Thinking    string `json:"thinking"`     // thinking_delta
-		Signature   string `json:"signature"`    // signature_delta
-		PartialJSON string `json:"partial_json"` // input_json_delta
-		StopReason  string `json:"stop_reason"`  // message_delta
+		Type             string          `json:"type"`         // text_delta | thinking_delta | signature_delta | input_json_delta | web_search_tool_result_delta
+		Text             string          `json:"text"`         // text_delta
+		Thinking         string          `json:"thinking"`     // thinking_delta
+		Signature        string          `json:"signature"`    // signature_delta
+		PartialJSON      string          `json:"partial_json"` // input_json_delta
+		StopReason       string          `json:"stop_reason"`  // message_delta
+		WebSearchResults json.RawMessage `json:"results"`      // web_search_tool_result_delta
 	} `json:"delta"`
 	Usage *wireUsage `json:"usage"` // message_delta (cumulative output_tokens)
 	Error *struct {


### PR DESCRIPTION
## Summary

Adds support for calling web_search via the provider.

## Verification

Example provider config, using DeepSeek's support for the web_search tool:

```toml
[[providers]]
name        = "anthropic-api-deepseek-com"
kind        = "anthropic"
base_url    = "https://api.deepseek.com/anthropic"
models      = ["deepseek-v4-flash", "deepseek-v4-pro"]
api_key_env = "DEEPSEEK_API_KEY"
context_window = 128000   # tokens; compaction triggers near this limit
prices      = { "deepseek-v4-flash" = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }, "deepseek-v4-pro" = { cache_hit = 0.025, input = 3, output = 6, currency = "¥" } }   # per-model prices, per 1M tokens
web_search  = true   # enable server-side web_search tool (Anthropic/DeepSeek API)
```

Example use, note that it doesn't try to perform the search via a call to a search engine:

```
◆ reasonix  · deepseek-v4-pro
  Context is kept across turns. Type 'exit' or Ctrl-D to quit.

  › search the web for hello

  ▎ thought for 1s
• Hello Definition & Meaning | Britannica Dictionary
  https://www.britannica.com/dictionary/hello?srch_tag=e2cdp6pptoimak7ydbp6kjxddhwqysz3
• hello https://baike.baidu.com/item/hello/38467
• hello _ 百科 https://baike.sogou.com/v64731937.htm?addressbar=hide&jump_from=undefined&vrid=81001007
• hello
  https://baike.sogou.com/v64731937.htm?ch=frombaikevr&fromTitle=hello&vrid=30010097&entryScene=baike_VR_ruo&j
  ump_from=sogou-mobb-e447193f2b83d789&addressbar=hide#paragraph_3
• hello http://dict.youdao.com/w/hell_o/
• hello是什么意思 https://www.hanzidaquan.com/yingyu/hello.html
• Hello! https://www.ldoceonline.com/dictionary/hello
• hello是什么意思？ https://wenwen.sogou.com/z/q961078741.htm
• hello是什么意思，hello怎么读，hello的意思是：“喂”的招呼声或问候 https://fanyi.kkabc.com/ci/Hello
• hello https://www.wordreference.com/enzh/hello Here are the top results from the web search for "hello":

1. Britannica Dictionary — Defines "hello" as a greeting, a telephone answer, a way to get attention, and an
   expression of surprise. Pronunciation: /həˈloʊ/.
2. Baidu Baike (百度百科) — Covers the history: derived from Old High German "halâ", popularized by Edison
   with the telephone. Notes its use in Chinese as "你好".
3. Sogou Baike (搜狗百科) — Similar to the Baidu entry, covering meanings, usage, and etymology including the
   Edison telephone story.
4. Youdao Dictionary — Lists: interjection (greeting, telephone, getting attention), noun (a greeting), and
   verb (to say hello). Also notes "Hello" as a song by Karmin.
5. Longman Dictionary — Comprehensive entry with usage examples: greeting, telephone, attracting attention,
   expressing surprise/confusion. Also covers informal alternatives (hi, hey, hiya).
6. WordReference — Bilingual English-Chinese entry with translations, compound forms ("golden hello", "say
   hello"), and pronunciation guides.

If you had something more specific in mind, let me know and I can refine the search!

  ▎ thought for 0s
  · 33233 tok · in 32870 (12800 cached / 20070 new) · out 363 · ¥0.0627
```

For #4217
For #5166

## Cache impact

Cache-impact: none, deterministically adds a new tool definition, nothing else added to context
Cache-guard: new tool should not affect context.
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
