### PR TITLE
fix: project-only provider_access must not hide user-level providers

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -519,6 +519,7 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 	var merged []string
 	seen := map[string]bool{}
 	saw := false
+	userDeclared := false
 	for _, path := range paths {
 		if _, err := os.Stat(path); err != nil {
 			continue
@@ -532,6 +533,9 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 			continue
 		}
 		saw = true
+		if isUserConfigPath(path) {
+			userDeclared = true
+		}
 		for _, name := range f.Desktop.ProviderAccess {
 			name = strings.TrimSpace(name)
 			if name == "" || seen[name] {
@@ -540,6 +544,12 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 			seen[name] = true
 			merged = append(merged, name)
 		}
+	}
+	// If only the project config declared provider_access (not the user), the
+	// user's implicit "allow all" takes precedence: project-level restrictions
+	// must not hide account-level providers from the desktop model switcher.
+	if saw && !userDeclared {
+		return nil, false, nil
 	}
 	return merged, saw, nil
 }

--- a/internal/config/loadedit_test.go
+++ b/internal/config/loadedit_test.go
@@ -127,6 +127,208 @@ tier = "lazy"
 	}
 }
 
+func TestMergeTOMLProviderAccessProjectOnlyDoesNotRestrictWhenUserUndefined(t *testing.T) {
+	isolateUserConfigHome(t)
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User config exists but does NOT declare provider_access (implicit "allow all").
+	if err := os.WriteFile(userPath, []byte(`
+default_model = "deepseek/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	projectTOML := filepath.Join(projectDir, "reasonix.toml")
+	if err := os.WriteFile(projectTOML, []byte(`
+[desktop]
+provider_access = ["deepseek"]
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the project declares provider_access — the merge must skip it.
+	access, ok, err := mergeTOMLProviderAccess([]string{userPath, projectTOML})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if ok {
+		t.Fatalf("merge returned ok=true, access=%v; want ok=false (project-only restriction skipped)", access)
+	}
+}
+
+func TestMergeTOMLProviderAccessUserAndProjectMergeAsUnion(t *testing.T) {
+	isolateUserConfigHome(t)
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(`
+[desktop]
+provider_access = ["deepseek", "custom-a"]
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	projectTOML := filepath.Join(projectDir, "reasonix.toml")
+	if err := os.WriteFile(projectTOML, []byte(`
+[desktop]
+provider_access = ["deepseek", "project-b"]
+
+[[providers]]
+name = "project-b"
+kind = "openai"
+base_url = "https://project-b.example.com/v1"
+model = "b-model"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both user and project declare provider_access — the union includes them all.
+	access, ok, err := mergeTOMLProviderAccess([]string{userPath, projectTOML})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if !ok {
+		t.Fatal("merge returned ok=false; want ok=true (user declared access)")
+	}
+	want := []string{"deepseek", "custom-a", "project-b"}
+	if !equalStringSlice(access, want) {
+		t.Fatalf("merged access = %v, want %v", access, want)
+	}
+}
+
+func TestMergeTOMLProviderAccessNoDeclarations(t *testing.T) {
+	isolateUserConfigHome(t)
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User config with no provider_access and no desktop section at all.
+	if err := os.WriteFile(userPath, []byte(`
+default_model = "deepseek/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	projectTOML := filepath.Join(projectDir, "reasonix.toml")
+	// Project config with no provider_access either.
+	if err := os.WriteFile(projectTOML, []byte(`
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	access, ok, err := mergeTOMLProviderAccess([]string{userPath, projectTOML})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if ok {
+		t.Fatalf("merge returned ok=true, access=%v; want ok=false (no declarations)", access)
+	}
+	if len(access) != 0 {
+		t.Fatalf("access = %v, want empty", access)
+	}
+}
+
+func TestMergeTOMLProviderAccessUserDeclaresEmptyList(t *testing.T) {
+	isolateUserConfigHome(t)
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User explicitly declares an empty list: provider_access = []
+	if err := os.WriteFile(userPath, []byte(`
+default_model = "deepseek/deepseek-v4-flash"
+
+[desktop]
+provider_access = []
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "[redacted]"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	projectTOML := filepath.Join(projectDir, "reasonix.toml")
+	if err := os.WriteFile(projectTOML, []byte(`
+[desktop]
+provider_access = ["deepseek"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// User explicitly declared an empty list (which means "allow all" but is
+	// a deliberate declaration). It is indistinguishable from an omission at
+	// this layer, so the project restriction still applies (merged = union).
+	access, ok, err := mergeTOMLProviderAccess([]string{userPath, projectTOML})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if !ok {
+		t.Fatal("merge returned ok=false; want ok=true (user declared access, even if empty)")
+	}
+	want := []string{"deepseek"}
+	if !equalStringSlice(access, want) {
+		t.Fatalf("merged access = %v, want %v (project deepseek only; user's empty list contributes nothing)", access, want)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestLoadForEditIgnoresProjectDotEnvForProviderCredentials(t *testing.T) {
 	project := t.TempDir()
 	launch := t.TempDir()


### PR DESCRIPTION
## Summary

When the user config (`~/.reasonix/config.toml`) does not declare `desktop.provider_access` (implicit "allow all"), a project-level `reasonix.toml` that defines `provider_access` currently restricts the desktop model switcher to only those listed providers — hiding the user-level providers that exist outside the project-scoped access list.

**Root cause:** `mergeTOMLProviderAccess` merges `provider_access` as a union across config sources. When only the project config declares it (user config does not), the union equals the project's list alone. The user's default "allow all" is lost.

**Fix:** Track whether the user-level config explicitly declared `provider_access`. If only the project declares it (user did not), skip the restriction so all configured providers remain visible in the model switcher.

## Verification

- `TestMergeTOMLProviderAccessProjectOnlyDoesNotRestrictWhenUserUndefined` — NEW: project-only restriction is correctly skipped
- `TestMergeTOMLProviderAccessUserAndProjectMergeAsUnion` — NEW: both user and project declare → union merge unchanged
- `TestMergeTOMLProviderAccessNoDeclarations` — NEW: neither declares → no restriction
- `TestMergeTOMLProviderAccessUserDeclaresEmptyList` — NEW: user declares `[]`, project has list → project list takes effect (user explicitly opted into per-project control)
- `TestModelsForTabKeepsUserProvidersWithProjectConfig` — EXISTING PASS: user + project both declare → union unchanged
- `go test ./internal/config/...` — all pass
- `go build ./...` — all pass

## Cache impact

Cache-impact: none — only a small logic change in config loading, no system prompt or provider changes
Cache-guard: existing config tests and desktop ModelsForTab tests cover the behavior
System-prompt-review: N/A

## Related PRs

- PR #4492 (merged) — Added `mergeTOMLProviderAccess` with union logic, but left the gap when only the project declares the list.
- PR #4516 (open) — Related provider access resolution changes in `desktop/app.go`, does not overlap with this fix.

---
🤖 This contribution was prepared with Reasonix (DeepSeek fork of Claude Code), no additional plugins installed.