### PR TITLE
Fix MCP re-verification flow / 修复 MCP 重新验证流程

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6000,6 +6000,7 @@ type ServerView struct {
 	Resources                int                             `json:"resources"`
 	HasTools                 bool                            `json:"hasTools,omitempty"`
 	Error                    string                          `json:"error,omitempty"`
+	RequiresReverification   bool                            `json:"requiresReverification,omitempty"`
 	ToolList                 []ToolView                      `json:"toolList,omitempty"`
 	TrustedReadOnlyTools     []string                        `json:"trustedReadOnlyTools,omitempty"`
 	CallTimeoutSeconds       int                             `json:"callTimeoutSeconds,omitempty"`
@@ -6583,6 +6584,7 @@ func (a *App) mcpServersView() []ServerView {
 			seen[f.Name] = true
 			view := ServerView{
 				Name: f.Name, Transport: f.Transport, Status: "failed", RuntimeState: "issue", Error: f.Error,
+				RequiresReverification: f.RequiresReverification,
 			}
 			applyMCPTrustStatus(&view, securityByName[f.Name])
 			if p, ok := configured[f.Name]; ok {
@@ -7742,7 +7744,10 @@ func findMCPServerView(ctrl control.SessionAPI, name string) (ServerView, bool) 
 	}
 	for _, f := range ctrl.Host().Failures() {
 		if f.Name == name {
-			return ServerView{Name: f.Name, Transport: f.Transport, Status: "failed", Error: f.Error}, true
+			return ServerView{
+				Name: f.Name, Transport: f.Transport, Status: "failed", Error: f.Error,
+				RequiresReverification: f.RequiresReverification,
+			}, true
 		}
 	}
 	return ServerView{}, false

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -355,19 +355,23 @@ console.log("capabilities panel MCP actions");
     cwd: "/tmp/reasonix-test",
   }];
   let trustDecision = "";
+  let reconnectCount = 0;
   let servers: ServerView[] = [{
     name: "github",
     transport: "stdio",
-    status: "connected",
+    status: "failed",
+    runtimeState: "issue",
     configured: true,
     autoStart: true,
-    tools: 3,
+    tools: 0,
     prompts: 0,
     resources: 0,
-    trustState: "changed",
-    identityChanged: true,
-    changedTools: ["issue_read"],
-    toolChanges: [{ name: "issue_read", kind: "reader_to_writer" }],
+    error: 'MCP server "github" identity changed; blocked before process or network startup and requires explicit re-verification',
+    requiresReverification: true,
+    trustState: "untrusted",
+    identityChanged: false,
+    changedTools: [],
+    toolChanges: [],
     isolationState: "unavailable_unconfined",
     isolationReason: "sandbox-exec is unavailable on PATH",
     toolList: [
@@ -400,6 +404,10 @@ console.log("capabilities panel MCP actions");
           trustDecision = decision;
           servers = servers.map((item) => ({ ...item, trustState: decision, identityChanged: false, changedTools: [], toolChanges: [] }));
         },
+        ReconnectMCPServer: async () => {
+          reconnectCount += 1;
+          servers = servers.map((item) => ({ ...item, status: "connected", runtimeState: "ready", requiresReverification: false, error: "" }));
+        },
         RefreshMCPCatalog: async () => ({ source: "cached", sequence: 3, offline: true, stale: true }),
       } as Partial<AppBindings> as AppBindings,
     },
@@ -409,7 +417,7 @@ console.log("capabilities panel MCP actions");
     root.render(React.createElement(LocaleProvider, null, React.createElement(MCPServersSettingsPage)));
     await flush();
   });
-  await waitFor("changed MCP trust badge", () => Boolean(document.body.textContent?.includes("Security changed")));
+  await waitFor("untrusted MCP badge", () => Boolean(document.body.textContent?.includes("Not trusted")));
   ok(document.body.textContent?.includes("Unisolated") ?? false, "server list keeps an unisolated warning visible");
   const refreshCatalog = findButton("Refresh catalog");
   if (!refreshCatalog) throw new Error("missing catalog refresh action");
@@ -419,14 +427,9 @@ console.log("capabilities panel MCP actions");
   });
   await waitFor("offline catalog result", () => Boolean(document.body.textContent?.includes("Catalog sequence 3")));
   ok(document.body.textContent?.includes("Offline verified snapshot") && document.body.textContent?.includes("older than 30 days"), "catalog refresh reports verified LKG fallback and staleness without disabling plugins");
-  const openServer = document.querySelector<HTMLButtonElement>(".cap-mcp-list-row__main");
-  if (!openServer) throw new Error("missing changed MCP details button");
-  await act(async () => {
-    openServer.click();
-    await flush();
-  });
   const reverify = findButton("Reverify");
-  if (!reverify) throw new Error("missing MCP reverify action");
+  if (!reverify) throw new Error("missing MCP reverify action in failed server row");
+  ok(!findButton("Retry"), "identity drift must not offer a retry action that will hit the same preflight block");
   await act(async () => {
     reverify.click();
     await flush();
@@ -443,8 +446,44 @@ console.log("capabilities panel MCP actions");
     trustWorkspace.click();
     await flush();
   });
-  await waitFor("workspace trust decision", () => trustDecision === "workspace");
+  await waitFor(
+    "workspace trust decision and reconnect",
+    () => trustDecision === "workspace" && reconnectCount === 1 && Boolean(document.querySelector('[data-status="connected"]')),
+  );
   ok(!document.querySelector('[role="dialog"]'), "successful trust closes the combined confirmation modal");
+  ok(Boolean(document.querySelector('[data-status="connected"]')), "failed server reconnects after explicit re-verification");
+
+  servers = servers.map((item) => ({
+    ...item,
+    status: "failed",
+    runtimeState: "issue",
+    error: "authentication required",
+    requiresReverification: true,
+    authStatus: "required",
+    authUrl: "https://mcp.example.test/authorize",
+  }));
+  await act(async () => {
+    refreshCatalog.click();
+    await flush();
+  });
+  await waitFor("authorization action", () => Boolean(findButton("Reauthorize")));
+  ok(!findButton("Reverify"), "an actionable OAuth failure must take precedence over identity re-verification");
+
+  servers = servers.map((item) => ({
+    ...item,
+    status: "failed",
+    runtimeState: "issue",
+    error: "connection refused",
+    requiresReverification: false,
+    authStatus: "none",
+    authUrl: "",
+  }));
+  await act(async () => {
+    refreshCatalog.click();
+    await flush();
+  });
+  await waitFor("ordinary retry action", () => Boolean(findButton("Retry")));
+  ok(!findButton("Reverify"), "ordinary startup failures must keep the retry action");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2390,20 +2390,30 @@ function MCPSettingsServerRow({
 	busy,
 	onOpen,
 	onRetry,
+	onReverify,
 	onToggle,
 }: {
 	server: ServerView;
 	busy: boolean;
 	onOpen: () => void;
 	onRetry: () => void;
+	onReverify: () => void;
 	onToggle: (enabled: boolean) => void;
 }) {
 	const t = useT();
 	const lifecycle = mcpServerLifecycleActions(server);
 	const target = serverCommand(server);
-	const actionLabel = serverActionLabel(server, t);
+	const opensAuth = shouldOpenAuth(server);
+	const requiresReverification = !opensAuth && server.status !== "disabled" && Boolean(
+		server.requiresReverification || server.identityChanged || server.trustState === "changed",
+	);
+	const actionLabel = requiresReverification ? t("caps.reverify") : serverActionLabel(server, t);
 	const handlePrimaryAction = () => {
-		if (shouldOpenAuth(server)) {
+		if (requiresReverification) {
+			onReverify();
+			return;
+		}
+		if (opensAuth) {
 			openExternal((server.authUrl || "").trim());
 			return;
 		}
@@ -2436,7 +2446,7 @@ function MCPSettingsServerRow({
 				<ChevronRight className="cap-mcp-list-row__chevron" aria-hidden size={16} />
 			</button>
 			<div className="cap-mcp-list-row__actions">
-				{lifecycle.showRetryInRow ? (
+				{requiresReverification || lifecycle.showRetryInRow ? (
 					<button className="btn btn--small" disabled={busy} type="button" onClick={handlePrimaryAction}>
 						{actionLabel}
 					</button>
@@ -2465,6 +2475,7 @@ function MCPSettingsServerGroup({
 	busy,
 	onOpen,
 	onRetry,
+	onReverify,
 	onToggle,
 }: {
 	title: string;
@@ -2473,6 +2484,7 @@ function MCPSettingsServerGroup({
 	busy: boolean;
 	onOpen: (name: string) => void;
 	onRetry: (name: string) => void;
+	onReverify: (name: string) => void;
 	onToggle: (name: string, enabled: boolean) => void;
 }) {
 	if (servers.length === 0) return null;
@@ -2492,6 +2504,7 @@ function MCPSettingsServerGroup({
 						busy={busy}
 						onOpen={() => onOpen(server.name)}
 						onRetry={() => onRetry(server.name)}
+						onReverify={() => onReverify(server.name)}
 						onToggle={(enabled) => onToggle(server.name, enabled)}
 					/>
 				))}
@@ -2984,8 +2997,11 @@ export function MCPServersSettingsPage() {
 	const decideTrust = async (decision: "workspace" | "session") => {
 		if (!trustInspection) return;
 		const name = trustInspection.name;
+		const reconnectAfterTrust = servers?.some((server) => server.name === name && server.runtimeState === "issue") ?? false;
 		const ok = await mutate(() => app.SetMCPTrust(name, decision));
-		if (ok) setTrustInspection(null);
+		if (!ok) return;
+		setTrustInspection(null);
+		if (reconnectAfterTrust) await mutate(() => app.ReconnectMCPServer(name));
 	};
 	const refreshCatalog = async () => {
 		setBusy(true);
@@ -3064,6 +3080,7 @@ export function MCPServersSettingsPage() {
 						busy={actionBusy}
 						onOpen={(name) => setScreen({ kind: "detail", name })}
 						onRetry={(name) => void mutate(() => app.ReconnectMCPServer(name))}
+						onReverify={(name) => void inspectTrust(name)}
 						onToggle={(name, enabled) => void mutate(() => app.SetMCPServerEnabled(name, enabled))}
 					/>
 					<MCPSettingsServerGroup
@@ -3073,6 +3090,7 @@ export function MCPServersSettingsPage() {
 						busy={actionBusy}
 						onOpen={(name) => setScreen({ kind: "detail", name })}
 						onRetry={(name) => void mutate(() => app.ReconnectMCPServer(name))}
+						onReverify={(name) => void inspectTrust(name)}
 						onToggle={(name, enabled) => void mutate(() => app.SetMCPServerEnabled(name, enabled))}
 					/>
 				</>

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -728,6 +728,7 @@ export interface ServerView {
   resources: number;
   hasTools?: boolean;
   error?: string;
+  requiresReverification?: boolean;
   toolList?: MCPToolView[];
   trustedReadOnlyTools?: string[];
   callTimeoutSeconds?: number;

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -651,9 +651,23 @@ type ServerStatus struct {
 
 // Failure records one MCP server that was configured but could not connect.
 type Failure struct {
-	Name      string
-	Transport string
-	Error     string
+	Name                   string
+	Transport              string
+	Error                  string
+	RequiresReverification bool
+}
+
+type identityChangedError struct {
+	server string
+}
+
+func (e *identityChangedError) Error() string {
+	return fmt.Sprintf("MCP server %q identity changed; blocked before process or network startup and requires explicit re-verification", e.server)
+}
+
+func requiresReverification(err error) bool {
+	var target *identityChangedError
+	return errors.As(err, &target)
 }
 
 // Servers returns a status summary per connected server, in connection order.
@@ -984,7 +998,10 @@ func (h *Host) RecordFailure(s Spec, err error) {
 	if tt == "" {
 		tt = "stdio"
 	}
-	f := Failure{Name: s.Name, Transport: tt, Error: summarizeFailureError(err)}
+	f := Failure{
+		Name: s.Name, Transport: tt, Error: summarizeFailureError(err),
+		RequiresReverification: requiresReverification(err),
+	}
 	for i := range h.failures {
 		if h.failures[i].Name == s.Name {
 			h.failures[i] = f
@@ -1357,7 +1374,7 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 			// migrated above instead of blocking: eager and cache-miss servers
 			// must reach the credential-aware rollout too, not only paths that
 			// get as far as a post-handshake evaluation.
-			return nil, fmt.Errorf("MCP server %q identity changed; blocked before process or network startup and requires explicit re-verification", s.Name)
+			return nil, &identityChangedError{server: s.Name}
 		}
 	}
 	t, err := newTransport(lifeCtx, s)

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -709,6 +710,23 @@ func TestStartAvailableKeepsGoodServers(t *testing.T) {
 	failures := host.Failures()
 	if len(failures) != 1 || failures[0].Name != "bad" {
 		t.Fatalf("failures = %+v, want bad", failures)
+	}
+}
+
+func TestRecordFailurePreservesReverificationAction(t *testing.T) {
+	host := NewHost()
+	host.RecordFailure(Spec{Name: "changed", Type: "stdio"}, fmt.Errorf("connect changed MCP: %w", &identityChangedError{server: "changed"}))
+	host.RecordFailure(Spec{Name: "ordinary", Type: "stdio"}, errors.New("connection refused"))
+
+	failures := host.Failures()
+	if len(failures) != 2 {
+		t.Fatalf("failures = %+v, want two", failures)
+	}
+	if !failures[0].RequiresReverification {
+		t.Fatalf("identity drift failure = %+v, want re-verification action", failures[0])
+	}
+	if failures[1].RequiresReverification {
+		t.Fatalf("ordinary failure = %+v, must remain retryable", failures[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve MCP identity-drift startup failures as a structured `requiresReverification` status instead of forcing the desktop to infer the required action from an English error string.
- Show **Reverify** directly in the failed server row, while preserving OAuth reauthorization precedence, ordinary **Retry** behavior, and the disabled-server boundary.
- Reconnect a failed MCP server automatically after the user explicitly confirms session or workspace trust.
- Add backend and frontend regression coverage for identity drift, OAuth precedence, ordinary failures, the confirmation modal, and post-verification reconnect.

### Compatibility

| Field | Old-data behavior | Conclusion |
| --- | --- | --- |
| `requiresReverification` | Missing/zero values remain `false`; existing failures keep the ordinary retry path | Backward compatible |

## Verification

- `env -u DEEPSEEK_API_KEY go test ./...`
- `(cd desktop && go test ./...)`
- `pnpm --dir desktop/frontend build`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/capabilities-panel-actions.test.ts`
- `pnpm --dir desktop/frontend test:typecheck`

## Cache impact

Cache-impact: none — this changes host-local MCP failure metadata and desktop interaction routing only; provider-visible prompts, MCP tool schemas/order, and request serialization are unchanged.
Cache-guard: existing MCP startup and desktop interaction regressions cover the changed path; the diff does not touch provider prompt or tool-registration construction.
System-prompt-review: N/A
