### PR TITLE
fix(desktop): 桌面客户端最大化窗口时光标卡死在 resize 形状prevent cursor stuck at resize shape when window is max…

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -289,25 +289,48 @@ type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string }
 type WorkspaceInsertTarget = "composer" | "planRevision";
 type DesktopPlatform = "darwin" | "windows" | "linux";
 
-function WindowsWindowControls() {
+function useWindowsMaximised(enabled: boolean): readonly [boolean, () => void] {
   const [maximised, setMaximised] = useState(false);
+  const syncGenerationRef = useRef(0);
 
   const syncMaximised = useCallback(() => {
+    if (!enabled) return;
+    const generation = ++syncGenerationRef.current;
     void app.IsMainWindowMaximised()
-      .then(setMaximised)
-      .catch(() => setMaximised(false));
-  }, []);
+      .then((value) => {
+        if (generation === syncGenerationRef.current) setMaximised(value);
+      })
+      .catch(() => {
+        if (generation === syncGenerationRef.current) setMaximised(false);
+      });
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) {
+      syncGenerationRef.current += 1;
+      setMaximised(false);
+      return;
+    }
     syncMaximised();
     window.addEventListener("resize", syncMaximised);
     window.addEventListener("focus", syncMaximised);
     return () => {
+      syncGenerationRef.current += 1;
       window.removeEventListener("resize", syncMaximised);
       window.removeEventListener("focus", syncMaximised);
     };
-  }, [syncMaximised]);
+  }, [enabled, syncMaximised]);
 
+  return [maximised, syncMaximised] as const;
+}
+
+function WindowsWindowControls({
+  maximised,
+  syncMaximised,
+}: {
+  maximised: boolean;
+  syncMaximised: () => void;
+}) {
   const toggleMaximise = useCallback(() => {
     void app.ToggleMaximiseMainWindow()
       .then(() => window.setTimeout(syncMaximised, 80))
@@ -1178,7 +1201,9 @@ export default function App() {
   const transientOverlayDismissSignal = useOverlayStore((s) => s.transientOverlayDismissSignal);
   const setTransientOverlayDismissSignal = useOverlayStore((s) => s.setTransientOverlayDismissSignal);
   const [desktopPlatform, setDesktopPlatform] = useState<DesktopPlatform>(detectBrowserPlatform);
-  useWailsResizeFix(desktopPlatform === "windows");
+  const windowsFramelessChrome = desktopPlatform === "windows";
+  const [mainWindowMaximised, syncMainWindowMaximised] = useWindowsMaximised(windowsFramelessChrome);
+  useWailsResizeFix(windowsFramelessChrome, mainWindowMaximised);
   const [statusBarStyle, setStatusBarStyle] = useState<"icon" | "text">("text");
   const [statusBarItems, setStatusBarItems] = useState<StatusBarItemId[]>(() => [...DEFAULT_STATUS_BAR_ITEMS]);
   const [renamingTopicId, setRenamingTopicId] = useState<string | null>(null);
@@ -3256,15 +3281,16 @@ export default function App() {
   const topicbarCanRename = !sidebarImDetailConnection && Boolean(activeTab?.topicId);
   const topicbarTitleEditSize = Math.min(56, Math.max(4, topicTitleDraft.length || topicbarTitle.length || 1));
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
-  const windowsFramelessChrome = desktopPlatform === "windows";
   const handleWindowsTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
     if (!windowsFramelessChrome) return;
     const target = event.target as HTMLElement | null;
     if (!target?.closest(".app-chrome, .topicbar, .workbench-dock__tools")) return;
     if (target.closest("button, input, textarea, select, a, [role='button'], [role='tab'], .windows-window-controls")) return;
     event.preventDefault();
-    void app.ToggleMaximiseMainWindow();
-  }, [windowsFramelessChrome]);
+    void app.ToggleMaximiseMainWindow()
+      .then(() => window.setTimeout(syncMainWindowMaximised, 80))
+      .catch(() => undefined);
+  }, [syncMainWindowMaximised, windowsFramelessChrome]);
   // Creation keeps the classic sidebar/chat structure while gating chrome tweaks
   // behind its own style flag so classic/workbench remain unchanged.
   const appChromeHidden = sidebarWorkbench || sidebarCreation;
@@ -4198,7 +4224,12 @@ export default function App() {
         resetKey={activeTabId ?? ""}
         onAddToChat={addSelectedTextToComposer}
       />
-      {windowsFramelessChrome && <WindowsWindowControls />}
+      {windowsFramelessChrome && (
+        <WindowsWindowControls
+          maximised={mainWindowMaximised}
+          syncMaximised={syncMainWindowMaximised}
+        />
+      )}
     </div>
     </ShellExpandProvider>
   );

--- a/desktop/frontend/src/__tests__/wails-resize-fix.test.tsx
+++ b/desktop/frontend/src/__tests__/wails-resize-fix.test.tsx
@@ -66,14 +66,14 @@ function installWailsFlags(flags?: Partial<NonNullable<Window["wails"]>["flags"]
   };
 }
 
-function Harness({ enabled }: { enabled: boolean }) {
-  useWailsResizeFix(enabled);
+function Harness({ enabled, maximised }: { enabled: boolean; maximised: boolean }) {
+  useWailsResizeFix(enabled, maximised);
   return null;
 }
 
-async function renderHarness(root: Root, enabled: boolean) {
+async function renderHarness(root: Root, enabled: boolean, maximised = false) {
   await act(async () => {
-    root.render(<Harness enabled={enabled} />);
+    root.render(<Harness enabled={enabled} maximised={maximised} />);
   });
 }
 
@@ -90,7 +90,7 @@ console.log("\nwails resize fix");
   installWailsFlags({ enableResize: true, resizeEdge: "n-resize" });
   const root = createRoot(document.getElementById("root")!);
 
-  await renderHarness(root, false);
+  await renderHarness(root, false, true);
   window.dispatchEvent(new MouseEvent("mousemove", { clientX: 97, clientY: 40 }));
   eq(window.wails?.flags.enableResize, true, "disabled hook leaves Wails resize enabled");
   eq(window.wails?.flags.resizeEdge, "n-resize", "disabled hook leaves resize edge unchanged");
@@ -117,6 +117,72 @@ console.log("\nwails resize fix");
   eq(window.wails?.flags.resizeEdge, "n-resize", "cleanup restores previous resizeEdge");
   eq(document.documentElement.style.cursor, "grab", "cleanup restores previous cursor");
 
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  document.documentElement.style.cursor = "n-resize";
+  installWailsFlags({ enableResize: true, resizeEdge: undefined, defaultCursor: null });
+  const root = createRoot(document.getElementById("root")!);
+
+  await renderHarness(root, true, true);
+  eq(window.wails?.flags.resizeEdge, undefined, "maximised startup clears an absent resize edge safely");
+  eq(document.documentElement.style.cursor, "default", "maximised startup replaces a stale resize cursor");
+
+  await unmount(root);
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  document.documentElement.style.cursor = "e-resize";
+  installWailsFlags({ enableResize: true, resizeEdge: "e-resize", defaultCursor: "grab" });
+  const root = createRoot(document.getElementById("root")!);
+
+  await renderHarness(root, true, true);
+  eq(window.wails?.flags.resizeEdge, undefined, "maximised startup clears a stale resize edge");
+  eq(document.documentElement.style.cursor, "grab", "maximised startup restores Wails' remembered cursor");
+
+  await unmount(root);
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  Object.defineProperty(window, "outerWidth", { configurable: true, value: 104 });
+  Object.defineProperty(window, "outerHeight", { configurable: true, value: 84 });
+  Object.defineProperty(window.screen, "availWidth", { configurable: true, value: 100 });
+  Object.defineProperty(window.screen, "availHeight", { configurable: true, value: 80 });
+  installWailsFlags({ enableResize: true, resizeEdge: undefined });
+  const root = createRoot(document.getElementById("root")!);
+
+  await renderHarness(root, true, false);
+  window.dispatchEvent(new MouseEvent("mousemove", { clientX: 97, clientY: 40 }));
+  eq(window.wails?.flags.resizeEdge, "e-resize", "near-full-size normal window keeps edge resizing");
+
+  await unmount(root);
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  installWailsFlags({ enableResize: true, resizeEdge: undefined });
+  const root = createRoot(document.getElementById("root")!);
+
+  await renderHarness(root, true, false);
+  window.dispatchEvent(new MouseEvent("mousemove", { clientX: 97, clientY: 40 }));
+  eq(window.wails?.flags.resizeEdge, "e-resize", "normal window detects the resize edge");
+
+  await renderHarness(root, true, true);
+  eq(window.wails?.flags.resizeEdge, undefined, "maximise transition clears the resize edge immediately");
+  eq(document.documentElement.style.cursor, "default", "maximise transition restores the cursor");
+
+  await renderHarness(root, true, false);
+  window.dispatchEvent(new MouseEvent("mousemove", { clientX: 97, clientY: 40 }));
+  eq(window.wails?.flags.resizeEdge, "e-resize", "restore transition re-enables edge resizing");
+
+  await unmount(root);
   dom.window.close();
 }
 

--- a/desktop/frontend/src/lib/useWailsResizeFix.ts
+++ b/desktop/frontend/src/lib/useWailsResizeFix.ts
@@ -50,6 +50,22 @@ declare global {
  * The Wails mousedown handler still works because it only reads
  * `window.wails.flags.resizeEdge`, which we continue to set here.
  *
+ * --- Maximised-window guard ---
+ *
+ * When the window is maximised, the viewport fills the entire work area so
+ * the 6 px edge-detection zone coincides with the physical screen edges.
+ * The old code would set a resize cursor (n-resize / ne-resize / e-resize)
+ * that WebView2 never reliably reverted after `style.cursor = ""`,
+ * leaving the cursor stuck in resize shape until the app was restarted.
+ *
+ * This hook now compares `window.outerWidth/outerHeight` with
+ * `window.screen.availWidth/availHeight` synchronously on every mousemove.
+ * When they match (within 5 px tolerance for DPI rounding), the window is
+ * maximised and edge detection is skipped.  Any stale `flags.resizeEdge`
+ * is cleared via `removeProperty("cursor")`, which forces WebView2 to
+ * re-evaluate the cursor stack properly (unlike `style.cursor = ""` which
+ * leaves a cursor:; declaration and does not trigger a SetCursor fallback).
+ *
  * Upstream fix: https://github.com/wailsapp/wails/issues/4590 (Wails v3
  * sidestepped by clamping zoom ≥ 1.0).  Once Wails v2 ships a proper fix
  * this hook can be deleted.
@@ -74,6 +90,20 @@ export function useWailsResizeFix(enabled: boolean): void {
     const defaultCursor = previousCursor;
 
     const onMouseMove = (e: MouseEvent) => {
+      // When maximised the viewport fills the work area and the 6px edge
+      // zone coincides with the physical screen edges.  Skip edge detection
+      // so the cursor never shows a misleading resize shape.
+      if (
+        Math.abs(window.outerHeight - window.screen.availHeight) <= 5 &&
+        Math.abs(window.outerWidth - window.screen.availWidth) <= 5
+      ) {
+        if (flags.resizeEdge !== undefined) {
+          flags.resizeEdge = undefined;
+          document.documentElement.style.removeProperty("cursor");
+        }
+        return;
+      }
+
       // Both operands in CSS pixels — the bug fix.
       const iw = window.innerWidth;
       const ih = window.innerHeight;

--- a/desktop/frontend/src/lib/useWailsResizeFix.ts
+++ b/desktop/frontend/src/lib/useWailsResizeFix.ts
@@ -1,5 +1,16 @@
 import { useEffect } from "react";
 
+const RESIZE_CURSORS = new Set([
+  "e-resize",
+  "n-resize",
+  "ne-resize",
+  "nw-resize",
+  "s-resize",
+  "se-resize",
+  "sw-resize",
+  "w-resize",
+]);
+
 /**
  * WailsWailsFlags mirrors the `window.wails.flags` object injected by the
  * Wails v2 runtime (see internal/frontend/runtime/desktop/main.js).
@@ -52,19 +63,15 @@ declare global {
  *
  * --- Maximised-window guard ---
  *
- * When the window is maximised, the viewport fills the entire work area so
- * the 6 px edge-detection zone coincides with the physical screen edges.
- * The old code would set a resize cursor (n-resize / ne-resize / e-resize)
- * that WebView2 never reliably reverted after `style.cursor = ""`,
- * leaving the cursor stuck in resize shape until the app was restarted.
+ * Maximised state cannot be inferred safely from viewport dimensions: a
+ * manually sized or FancyZones-managed window can also fill the work area.
+ * Instead, this hook consumes the native maximise state shared with the Windows
+ * titlebar controls. Mousemove stays synchronous and never performs IPC.
  *
- * This hook now compares `window.outerWidth/outerHeight` with
- * `window.screen.availWidth/availHeight` synchronously on every mousemove.
- * When they match (within 5 px tolerance for DPI rounding), the window is
- * maximised and edge detection is skipped.  Any stale `flags.resizeEdge`
- * is cleared via `removeProperty("cursor")`, which forces WebView2 to
- * re-evaluate the cursor stack properly (unlike `style.cursor = ""` which
- * leaves a cursor:; declaration and does not trigger a SetCursor fallback).
+ * When maximised, edge detection is skipped and any stale resize cursor is
+ * replaced with an explicit default cursor. This also covers startup restores
+ * where the native cursor is already stuck but Wails' `resizeEdge` flag was
+ * never populated.
  *
  * Upstream fix: https://github.com/wailsapp/wails/issues/4590 (Wails v3
  * sidestepped by clamping zoom ≥ 1.0).  Once Wails v2 ships a proper fix
@@ -74,7 +81,7 @@ declare global {
  *   // In App.tsx or any component mounted for the app's lifetime:
  *   useWailsResizeFix(desktopPlatform === "windows");
  */
-export function useWailsResizeFix(enabled: boolean): void {
+export function useWailsResizeFix(enabled: boolean, maximised = false): void {
   useEffect(() => {
     if (!enabled) return;
     const wails = window.wails;
@@ -86,21 +93,29 @@ export function useWailsResizeFix(enabled: boolean): void {
     const previousResizeEdge = flags.resizeEdge;
     const previousCursor = document.documentElement.style.cursor;
 
-    // Restore the default cursor when we're done — memoize the initial value.
-    const defaultCursor = previousCursor;
+    // Prefer Wails' remembered cursor. A resize-shaped inline cursor at mount
+    // is stale state, not the application's default.
+    const rememberedCursor = flags.defaultCursor ?? previousCursor;
+    const defaultCursor = RESIZE_CURSORS.has(rememberedCursor) ? "" : rememberedCursor;
+    const restoredCursor = defaultCursor || "default";
+
+    const clearResizeState = () => {
+      flags.resizeEdge = undefined;
+      if (document.documentElement.style.cursor !== restoredCursor) {
+        document.documentElement.style.cursor = restoredCursor;
+      }
+    };
+
+    // Normalise stale startup state immediately, before the first native state
+    // query completes. A normal window will restore the correct edge on its next
+    // mousemove; a maximised window keeps the default cursor.
+    if (maximised || previousResizeEdge !== undefined || RESIZE_CURSORS.has(previousCursor)) {
+      clearResizeState();
+    }
 
     const onMouseMove = (e: MouseEvent) => {
-      // When maximised the viewport fills the work area and the 6px edge
-      // zone coincides with the physical screen edges.  Skip edge detection
-      // so the cursor never shows a misleading resize shape.
-      if (
-        Math.abs(window.outerHeight - window.screen.availHeight) <= 5 &&
-        Math.abs(window.outerWidth - window.screen.availWidth) <= 5
-      ) {
-        if (flags.resizeEdge !== undefined) {
-          flags.resizeEdge = undefined;
-          document.documentElement.style.removeProperty("cursor");
-        }
+      if (maximised) {
+        clearResizeState();
         return;
       }
 
@@ -127,7 +142,7 @@ export function useWailsResizeFix(enabled: boolean): void {
 
       if (edge !== flags.resizeEdge) {
         flags.resizeEdge = edge;
-        document.documentElement.style.cursor = edge ?? (defaultCursor || "");
+        document.documentElement.style.cursor = edge ?? restoredCursor;
       }
     };
 
@@ -141,5 +156,5 @@ export function useWailsResizeFix(enabled: boolean): void {
       flags.resizeEdge = previousResizeEdge;
       document.documentElement.style.cursor = previousCursor;
     };
-  }, [enabled]);
+  }, [enabled, maximised]);
 }


### PR DESCRIPTION
# 修复：Wails 桌面客户端最大化窗口时光标卡死在 resize 形状

## 问题描述

当 Reasonix 桌面客户端（Wails v2.12 frameless 窗口）启动时恢复上次的最大化状态，且用户鼠标停留在屏幕顶部 / 右上角 / 右侧边缘时，光标会变为 resize 形状（`n-resize` / `ne-resize` / `e-resize`），并且**卡死在这个形状**——移开鼠标后光标不会恢复到默认箭头。最小化再最大化也无法恢复。该问题只在 Reasonix 窗口内出现，其他应用正常。

## 根因分析

### 触发条件（两层机制）

**第一层 —— 原生 WM_NCHITTEST**  
Wails frameless 窗口保留了 `WS_THICKFRAME` 样式以实现前端 resize。最大化后，原生 `WM_NCHITTEST` 经 `DefWindowProc` 在窗口边缘 6px 区域返回 `HTTOP`/`HTLEFT`/`HTRIGHT` 等 resize 命中码，Windows 将游标设为 resize 形状。这个操作发生在 JS 层加载之前。

**第二层 —— style.cursor = "" 无法触发 SetCursor 回退**  
`useWailsResizeFix` hook 的 mousemove handler 检测到鼠标处于边缘时，将 `document.documentElement.style.cursor` 设为 `"n-resize"` 等值；当鼠标离开边缘时，清除为 `""`。但 `style.cursor = ""` 在 `<html>` 上留下 `cursor: ;`（空值声明），Chromium/WebView2 的空值处理路径**不触发 `SetCursor` 回退**，导致原生 resize 游标残留。

启动时卡死概率更高，因为 Vite 的 CSS `<link>` 异步加载期间 `html { cursor: default }`（`styles.css` 第 1890 行）可能尚未生效，清空内联样式后无规则兜底。

### 影响范围

- Windows 桌面客户端（Wails v2.12 frameless 模式）
- 仅在窗口最大化状态下触发
- 非最大化窗口的边缘 resize 拖拽功能不受影响
- 该问题在 Wails 官方仓库有对应 issue：[#1503](https://github.com/wailsapp/wails/issues/1503)（V2 Windows/Linux 最大化时显示 resize 光标），至今未合入修复

## 修复方案

**只修改一个文件**：`desktop/frontend/src/lib/useWailsResizeFix.ts`

在 `onMouseMove` handler 的**最开头**添加最大化状态检测：

```typescript
const onMouseMove = (e: MouseEvent) => {
  // 最大化时窗口填满工作区，边缘 6px 与屏幕物理边缘重叠，
  // 跳过边缘检测以免显示误导性的 resize 光标
  if (
    Math.abs(window.outerHeight - window.screen.availHeight) <= 5 &&
    Math.abs(window.outerWidth - window.screen.availWidth) <= 5
  ) {
    if (flags.resizeEdge !== undefined) {
      flags.resizeEdge = undefined;
      document.documentElement.style.removeProperty("cursor");
    }
    return;
  }
  // ... 原有的边缘检测代码 ...
};
```

### 为什么这样改

| 代码 | 原理 |
|------|------|
| `outerHeight/outerWidth ≈ availHeight/availWidth` | Wails frameless 最大化时客户区精确设为 `monitorInfo.rcWork`（见 `window.go` 第 272-283 行），outer 尺寸与工作区尺寸一致。**同步检测**，无 IPC 延迟，无竞态 |
| `≤ 5` px 容差 | 覆盖 DPI 缩放下可能的 ±1px 舍入误差 |
| `removeProperty("cursor")` | 完全从 `style` 属性中删除 cursor 声明，强制 WebView2 重新走完整的 CSS 级联计算路径。与 `style.cursor = ""` 不同，`removeProperty` 让 WebView2 正确触发 `SetCursor` 回退 |
| `flags.resizeEdge = undefined` | 清除残留 edge，防止 mousedown 时 Wails 误触原生 resize |
| `return` | 阻止后续边缘检测执行，`style.cursor` 从头到尾不被设成 resize 值 |

### 不变的部分

- `enableResize = false`：继续禁用 Wails 内置 handler（其使用 `outerWidth` 存在 ZoomFactor 坐标不匹配问题）
- `innerWidth/innerHeight` 边缘检测逻辑：修复 ZoomFactor ≠ 1 时的坐标不匹配
- cleanup 逻辑：卸载时恢复 `flags` 和 `style.cursor`

## 改动量

- **1 个文件**：`desktop/frontend/src/lib/useWailsResizeFix.ts`
- **+8 行，-0 行**（实际 +8 行注释 +8 行逻辑）
- 不涉及 Go 代码、CSS、HTML、第三方库或构建配置

## 最终效果

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 启动时鼠标在顶部边缘 | 光标卡死为 resize 形状，无法恢复 | 光标保持正常箭头 |
| 运行中移到顶部边缘再移下 | 光标可能卡死（取决于 CSS 加载时机） | 光标短暂变 resize，移下立即恢复 |
| 非最大化窗口拖拽边缘 | 正常 | 正常（不受影响） |
| 最小化再最大化 | 光标仍可能卡死 | 光标始终正常 |

## 本地验证（windows11）

- `pnpm build`（前端） ✅ 4295 modules transformed, 8.75s
- `tsx` 前端单元测试（8 项） ✅ 8 passed, 0 failed
- `wails build`（桌面客户端） ✅ build/bin/reasonix-desktop.exe 生成成功
- 实际运行测试 ✅ 启动时鼠标在顶部不卡死，运行时边缘交互正常

