### PR TITLE
Fix MCP persistent sessions and simplify trust / 修复 MCP 持久会话并简化授权

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ branch.
 
 - Restored stateful MCP behavior after the v1.17.13 regression: compatible
   trust receipts migrate instead of prompting again, user-added servers work
-  without extra trust settings, and stdio tools reuse one persistent process
-  so browser sessions survive across calls without repeated startup latency.
+  without extra trust settings (including delivery-mode on-demand calls), and
+  stdio tools reuse one persistent process so browser sessions survive across
+  calls without repeated startup latency. Authorized project servers keep a
+  revoke entry in the desktop server details page.
 - Localized persistent-footer labels and displayed work-mode values in English,
   Simplified Chinese, and Traditional Chinese, while keeping command arguments
   stable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ branch.
 
 ### Fixed
 
+- Restored stateful MCP behavior after the v1.17.13 regression: compatible
+  trust receipts migrate instead of prompting again, user-added servers work
+  without extra trust settings, and stdio tools reuse one persistent process
+  so browser sessions survive across calls without repeated startup latency.
 - Localized persistent-footer labels and displayed work-mode values in English,
   Simplified Chinese, and Traditional Chinese, while keeping command arguments
   stable.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6009,6 +6009,7 @@ type ServerView struct {
 	ToolPolicies             map[string]config.MCPToolPolicy `json:"toolPolicies,omitempty"`
 	ApprovalsReviewer        string                          `json:"approvalsReviewer,omitempty"`
 	RequiresLaunchApproval   bool                            `json:"requiresLaunchApproval,omitempty"`
+	LaunchApprovalGoverned   bool                            `json:"launchApprovalGoverned,omitempty"`
 	AuthStatus               string                          `json:"authStatus,omitempty"`
 	AuthURL                  string                          `json:"authUrl,omitempty"`
 	AuthConfigured           bool                            `json:"authConfigured,omitempty"`
@@ -6738,10 +6739,12 @@ func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	v.ToolPolicies = cloneMCPToolPolicies(p.Tools)
 	v.ApprovalsReviewer = p.ApprovalsReviewer
 	// Source says whether this server is governed by the project launch gate;
-	// the view flag says whether that gate is blocking it right now. Keeping the
-	// two distinct prevents an already-authorized connected server from showing
-	// a permanent reauthorization warning.
-	v.RequiresLaunchApproval = p.Source.RequiresLaunchApproval() && v.RequiresReverification
+	// RequiresLaunchApproval says whether that gate is blocking it right now.
+	// Keeping the two distinct prevents an already-authorized connected server
+	// from showing a permanent reauthorization warning, while the static flag
+	// keeps a revoke entry for the persistent grant reachable.
+	v.LaunchApprovalGoverned = p.Source.RequiresLaunchApproval()
+	v.RequiresLaunchApproval = v.LaunchApprovalGoverned && v.RequiresReverification
 	v.AuthConfigured = mcpdiag.HasAuthConfig(p.Headers, p.Env, p.URL)
 	v.EnvKeys = nil
 	v.HeaderKeys = nil

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6008,6 +6008,7 @@ type ServerView struct {
 	DefaultToolsApprovalMode string                          `json:"defaultToolsApprovalMode,omitempty"`
 	ToolPolicies             map[string]config.MCPToolPolicy `json:"toolPolicies,omitempty"`
 	ApprovalsReviewer        string                          `json:"approvalsReviewer,omitempty"`
+	RequiresLaunchApproval   bool                            `json:"requiresLaunchApproval,omitempty"`
 	AuthStatus               string                          `json:"authStatus,omitempty"`
 	AuthURL                  string                          `json:"authUrl,omitempty"`
 	AuthConfigured           bool                            `json:"authConfigured,omitempty"`
@@ -6034,18 +6035,19 @@ type ToolView struct {
 }
 
 type MCPTrustInspectionView struct {
-	Name            string                   `json:"name"`
-	TrustState      string                   `json:"trustState"`
-	TrustSource     string                   `json:"trustSource,omitempty"`
-	TrustScope      string                   `json:"trustScope,omitempty"`
-	IsolationState  string                   `json:"isolationState"`
-	IsolationReason string                   `json:"isolationReason,omitempty"`
-	IdentityChanged bool                     `json:"identityChanged,omitempty"`
-	ChangedTools    []string                 `json:"changedTools"`
-	ToolChanges     []MCPToolTrustChangeView `json:"toolChanges"`
-	Readers         []string                 `json:"readers"`
-	Writers         []string                 `json:"writers"`
-	Destructive     []string                 `json:"destructive"`
+	Name                   string                   `json:"name"`
+	TrustState             string                   `json:"trustState"`
+	TrustSource            string                   `json:"trustSource,omitempty"`
+	TrustScope             string                   `json:"trustScope,omitempty"`
+	IsolationState         string                   `json:"isolationState"`
+	IsolationReason        string                   `json:"isolationReason,omitempty"`
+	IdentityChanged        bool                     `json:"identityChanged,omitempty"`
+	ChangedTools           []string                 `json:"changedTools"`
+	ToolChanges            []MCPToolTrustChangeView `json:"toolChanges"`
+	Readers                []string                 `json:"readers"`
+	Writers                []string                 `json:"writers"`
+	Destructive            []string                 `json:"destructive"`
+	RequiresLaunchApproval bool                     `json:"requiresLaunchApproval,omitempty"`
 }
 
 type MCPToolTrustChangeView struct {
@@ -6407,6 +6409,7 @@ func mcpTrustInspectionView(in plugin.TrustInspection) MCPTrustInspectionView {
 		ChangedTools: append([]string{}, in.Security.ChangedTools...), Readers: append([]string{}, in.Readers...),
 		ToolChanges: mcpToolTrustChangeViews(in.Security.ToolChanges),
 		Writers:     append([]string{}, in.Writers...), Destructive: append([]string{}, in.Destructive...),
+		RequiresLaunchApproval: in.RequiresLaunchApproval,
 	}
 }
 
@@ -6734,6 +6737,7 @@ func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	v.DefaultToolsApprovalMode = p.DefaultToolsApprovalMode
 	v.ToolPolicies = cloneMCPToolPolicies(p.Tools)
 	v.ApprovalsReviewer = p.ApprovalsReviewer
+	v.RequiresLaunchApproval = p.Source.RequiresLaunchApproval()
 	v.AuthConfigured = mcpdiag.HasAuthConfig(p.Headers, p.Env, p.URL)
 	v.EnvKeys = nil
 	v.HeaderKeys = nil
@@ -7198,6 +7202,7 @@ func (a *App) AddMCPServer(in MCPServerInput) (int, error) {
 		DefaultToolsApprovalMode: mcpStringValue(in.DefaultToolsApprovalMode),
 		Tools:                    cloneMCPToolPolicies(in.ToolPolicies),
 		ApprovalsReviewer:        mcpStringValue(in.ApprovalsReviewer),
+		Source:                   config.MCPSourceUserConfig,
 	}
 	entry, _ = config.NormalizePluginCommandLine(entry)
 	if err := a.saveDesktopMCPServer(entry); err != nil {
@@ -7209,8 +7214,8 @@ func (a *App) AddMCPServer(in MCPServerInput) (int, error) {
 // UpdateMCPServer edits a persisted external MCP server. The name is the stable
 // identity; callers must remove + add if they want to rename a server.
 func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
-	ctrl := a.activeCtrl()
-	if ctrl == nil {
+	tab, ctrl := a.activeTabAndCtrl()
+	if tab == nil || ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
 	if controllerHasActiveRuntimeWork(ctrl) {
@@ -7268,10 +7273,10 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 	}
 
 	a.mu.RLock()
-	tab := a.activeTabLocked()
+	activeTab := a.activeTabLocked()
 	sessionDisabled := false
-	if tab != nil {
-		_, sessionDisabled = tab.disabledMCP[name]
+	if activeTab != nil {
+		_, sessionDisabled = activeTab.disabledMCP[name]
 	}
 	a.mu.RUnlock()
 	wasConnected := mcpConnected(ctrl, name)
@@ -7279,7 +7284,19 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 		ctrl.DisconnectMCPServer(name)
 	}
 	if !sessionDisabled {
-		if _, err := ctrl.ConnectMCPServer(updated); err != nil {
+		spec, specErr := a.mcpTrustSpec(name)
+		if specErr != nil {
+			return specErr
+		}
+		if spec.RequireLaunchApproval {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := plugin.SetSpecTrust(ctx, spec, "workspace"); err != nil {
+				recordMCPFailure(ctrl, updated, err)
+				return nil
+			}
+		}
+		if _, err := a.connectConfiguredMCPServerForTab(tab, name); err != nil {
 			recordMCPFailure(ctrl, updated, err)
 			return nil
 		}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6737,7 +6737,11 @@ func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	v.DefaultToolsApprovalMode = p.DefaultToolsApprovalMode
 	v.ToolPolicies = cloneMCPToolPolicies(p.Tools)
 	v.ApprovalsReviewer = p.ApprovalsReviewer
-	v.RequiresLaunchApproval = p.Source.RequiresLaunchApproval()
+	// Source says whether this server is governed by the project launch gate;
+	// the view flag says whether that gate is blocking it right now. Keeping the
+	// two distinct prevents an already-authorized connected server from showing
+	// a permanent reauthorization warning.
+	v.RequiresLaunchApproval = p.Source.RequiresLaunchApproval() && v.RequiresReverification
 	v.AuthConfigured = mcpdiag.HasAuthConfig(p.Headers, p.Env, p.URL)
 	v.EnvKeys = nil
 	v.HeaderKeys = nil

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6964,12 +6964,23 @@ func TestProjectMCPLaunchApprovalViewOnlyShowsWhileBlocked(t *testing.T) {
 	if connected.RequiresLaunchApproval {
 		t.Fatalf("connected project MCP still requires launch approval: %+v", connected)
 	}
+	// The static governance flag must survive a successful authorization so the
+	// UI can keep a revoke entry for the persistent grant.
+	if !connected.LaunchApprovalGoverned {
+		t.Fatalf("connected project MCP lost launch governance flag: %+v", connected)
+	}
 
 	blocked := withPluginConfig(ServerView{
 		Name: entry.Name, Status: "failed", RequiresReverification: true,
 	}, entry)
-	if !blocked.RequiresLaunchApproval {
+	if !blocked.RequiresLaunchApproval || !blocked.LaunchApprovalGoverned {
 		t.Fatalf("blocked project MCP lost launch approval action: %+v", blocked)
+	}
+
+	user := withPluginConfig(ServerView{Name: "user", Status: "connected"},
+		config.PluginEntry{Name: "user", Source: config.MCPSourceUserConfig})
+	if user.LaunchApprovalGoverned || user.RequiresLaunchApproval {
+		t.Fatalf("user-config MCP must not be launch-gate governed: %+v", user)
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6958,6 +6958,21 @@ url = %q
 	}
 }
 
+func TestProjectMCPLaunchApprovalViewOnlyShowsWhileBlocked(t *testing.T) {
+	entry := config.PluginEntry{Name: "project", Source: config.MCPSourceProjectConfig}
+	connected := withPluginConfig(ServerView{Name: entry.Name, Status: "connected"}, entry)
+	if connected.RequiresLaunchApproval {
+		t.Fatalf("connected project MCP still requires launch approval: %+v", connected)
+	}
+
+	blocked := withPluginConfig(ServerView{
+		Name: entry.Name, Status: "failed", RequiresReverification: true,
+	}, entry)
+	if !blocked.RequiresLaunchApproval {
+		t.Fatalf("blocked project MCP lost launch approval action: %+v", blocked)
+	}
+}
+
 func TestMCPServersMatchesCapabilitiesServerProjection(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -6891,7 +6891,7 @@ func TestCapabilitiesIncludesInstalledPlugins(t *testing.T) {
 	}
 }
 
-func TestDesktopSharedHostBackgroundMCPAutoConnectsOnBoot(t *testing.T) {
+func TestDesktopSharedHostProjectMCPWaitsForLaunchApproval(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping background MCP boot integration test in short mode")
 	}
@@ -6927,11 +6927,15 @@ url = %q
 	defer ctrl.Close()
 
 	deadline := time.Now().Add(3 * time.Second)
-	for !sharedHost.HasClient("h") && time.Now().Before(deadline) {
+	for len(sharedHost.Failures()) == 0 && time.Now().Before(deadline) {
 		time.Sleep(25 * time.Millisecond)
 	}
-	if !sharedHost.HasClient("h") {
-		t.Fatalf("background MCP did not auto-connect; connecting=%v failures=%+v", sharedHost.ConnectingServers(), sharedHost.Failures())
+	if sharedHost.HasClient("h") {
+		t.Fatal("project MCP connected before launch approval")
+	}
+	failures := sharedHost.Failures()
+	if len(failures) != 1 || !failures[0].RequiresReverification || !strings.Contains(failures[0].Error, "until the user authorizes") {
+		t.Fatalf("project MCP failure = %+v", failures)
 	}
 
 	app := NewApp()
@@ -6949,8 +6953,8 @@ url = %q
 	app.activeTabID = "test"
 
 	view := app.MCPServers()
-	if len(view) != 1 || view[0].Name != "h" || view[0].Status != "connected" || view[0].StartIntent != "automatic" || view[0].RuntimeState != "ready" || view[0].Tools != 1 {
-		t.Fatalf("MCPServers() = %+v, want h connected automatic ready with one tool", view)
+	if len(view) != 1 || view[0].Name != "h" || view[0].Status != "failed" || view[0].RuntimeState != "issue" || !view[0].RequiresLaunchApproval || !view[0].RequiresReverification {
+		t.Fatalf("MCPServers() = %+v, want project h awaiting launch approval", view)
 	}
 }
 

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -647,6 +647,7 @@ console.log("capabilities panel MCP actions");
     cwd: "/tmp/reasonix-test",
   }];
   let addedInput: MCPServerInput | undefined;
+  let inspectCalls = 0;
   let servers: ServerView[] = [
     {
       name: "github",
@@ -695,6 +696,10 @@ console.log("capabilities panel MCP actions");
             resources: 0,
           }];
           return 0;
+        },
+        InspectMCPTrust: async () => {
+          inspectCalls++;
+          throw new Error("new user servers should not need a second trust prompt");
         },
       } as Partial<AppBindings> as AppBindings,
     },
@@ -780,6 +785,7 @@ console.log("capabilities panel MCP actions");
   ok(addedInput?.command === "npx", "valid MCP JSON keeps the executable separate from its arguments");
   ok(addedInput?.args?.[2] === "hello world", "valid MCP JSON passes structured arguments to AddMCPServer");
   ok(addedInput?.env?.TOKEN === "test-token", "valid MCP JSON passes environment variables to AddMCPServer");
+  ok(inspectCalls === 0, "adding a user MCP server does not open a second trust inspection");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -356,6 +356,7 @@ console.log("capabilities panel MCP actions");
   }];
   let trustDecision = "";
   let reconnectCount = 0;
+  let projectLaunch = false;
   let servers: ServerView[] = [{
     name: "github",
     transport: "stdio",
@@ -386,7 +387,17 @@ console.log("capabilities panel MCP actions");
         Meta: async () => meta,
         ListTabs: async () => tabs,
         MCPServers: async () => servers,
-        InspectMCPTrust: async () => ({
+        InspectMCPTrust: async () => projectLaunch ? ({
+          name: "github",
+          trustState: "untrusted",
+          isolationState: "enforced",
+          changedTools: [],
+          toolChanges: [],
+          readers: [],
+          writers: [],
+          destructive: [],
+          requiresLaunchApproval: true,
+        }) : ({
           name: "github",
           trustState: "changed",
           trustSource: "user",
@@ -452,6 +463,36 @@ console.log("capabilities panel MCP actions");
   );
   ok(!document.querySelector('[role="dialog"]'), "successful trust closes the combined confirmation modal");
   ok(Boolean(document.querySelector('[data-status="connected"]')), "failed server reconnects after explicit re-verification");
+
+  projectLaunch = true;
+  trustDecision = "";
+  servers = servers.map((item) => ({
+    ...item,
+    status: "failed",
+    runtimeState: "issue",
+    error: "project-provided MCP server is blocked until the user authorizes it",
+    requiresLaunchApproval: true,
+    requiresReverification: true,
+    trustState: "untrusted",
+  }));
+  await act(async () => {
+    refreshCatalog.click();
+    await flush();
+  });
+  await waitFor("project MCP authorization action", () => Boolean(findButton("Reverify")));
+  await act(async () => {
+    findButton("Reverify")?.click();
+    await flush();
+  });
+  await waitFor("project MCP launch modal", () => Boolean(findButton("Authorize and connect")));
+  ok(!findButton("Only this connection"), "project launch uses one durable authorization action instead of a scope choice");
+  ok(document.body.textContent?.includes("comes from the current project") ?? false, "project launch modal explains why authorization is required");
+  await act(async () => {
+    findButton("Authorize and connect")?.click();
+    await flush();
+  });
+  await waitFor("durable project launch authorization", () => trustDecision === "workspace" && Boolean(document.querySelector('[data-status="connected"]')));
+  projectLaunch = false;
 
   servers = servers.map((item) => ({
     ...item,

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -526,6 +526,35 @@ console.log("capabilities panel MCP actions");
   await waitFor("ordinary retry action", () => Boolean(findButton("Retry")));
   ok(!findButton("Reverify"), "ordinary startup failures must keep the retry action");
 
+  trustDecision = "";
+  servers = servers.map((item) => ({
+    ...item,
+    status: "connected",
+    runtimeState: "ready",
+    error: "",
+    requiresLaunchApproval: false,
+    requiresReverification: false,
+    launchApprovalGoverned: true,
+    trustState: "workspace",
+  }));
+  await act(async () => {
+    findButton("Refresh catalog")?.click();
+    await flush();
+  });
+  await waitFor("authorized project server row", () => Boolean(document.querySelector('[data-status="connected"]')));
+  await act(async () => {
+    (document.querySelector(".cap-mcp-list-row__main") as HTMLButtonElement | null)?.click();
+    await flush();
+  });
+  await waitFor("revocable persistent grant entry", () => Boolean(findButton("Revoke trust")));
+  ok(!findButton("Reverify"), "an authorized connected project server must not show the reauthorization alarm");
+  await act(async () => {
+    findButton("Revoke trust")?.click();
+    await flush();
+  });
+  await waitFor("persistent launch grant revoked", () => trustDecision === "revoke");
+  ok(!findButton("Revoke trust"), "revoking clears the persistent grant entry");
+
   await act(async () => {
     root.unmount();
   });

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2923,8 +2923,14 @@ function MCPTrustModal({
 				</div>}
 				<div className="modal__actions">
 					<button className="btn btn--small" type="button" disabled={busy} onClick={onCancel}>{t("common.cancel")}</button>
-					<button className="btn btn--small" type="button" disabled={busy} onClick={() => onDecision("session")}>{t("caps.trustSessionAction")}</button>
-					<button className="btn btn--primary btn--small" type="button" disabled={busy} onClick={() => onDecision("workspace")}>{t("caps.trustWorkspaceAction")}</button>
+					{inspection.requiresLaunchApproval ? (
+						<button className="btn btn--primary btn--small" type="button" disabled={busy} onClick={() => onDecision("workspace")}>{t("caps.authorizeAndConnect")}</button>
+					) : (
+						<>
+							<button className="btn btn--small" type="button" disabled={busy} onClick={() => onDecision("session")}>{t("caps.trustSessionAction")}</button>
+							<button className="btn btn--primary btn--small" type="button" disabled={busy} onClick={() => onDecision("workspace")}>{t("caps.trustWorkspaceAction")}</button>
+						</>
+					)}
 				</div>
 			</div>
 		</div>

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2321,6 +2321,18 @@ function mcpTrustLabel(server: ServerView, t: ReturnType<typeof useT>): string {
 	return t("caps.trustUntrusted");
 }
 
+function mcpTrustActionRequired(server: ServerView): boolean {
+	return Boolean(server.requiresLaunchApproval || server.requiresReverification || server.trustState === "changed");
+}
+
+// A launch-gate-governed server whose grant is currently established. Revoking
+// is only offered where it sticks: user-config and official sources auto-trust
+// again on the next evaluation, so a revoke entry there would be misleading.
+function mcpRevocableLaunchGrant(server: ServerView): boolean {
+	return !mcpTrustActionRequired(server) && Boolean(server.launchApprovalGoverned)
+		&& (server.trustState === "workspace" || server.trustState === "session");
+}
+
 function mcpIsolationLabel(server: ServerView, t: ReturnType<typeof useT>): string {
 	if (server.isolationState === "unavailable_unconfined") return t("caps.unisolated");
 	if (server.isolationState === "not_applicable") return t("caps.isolationNotApplicable");
@@ -3134,13 +3146,19 @@ export function MCPServersSettingsPage() {
 							</details>
 						</div>
 					)}
-					{(selectedServer.requiresLaunchApproval || selectedServer.requiresReverification || selectedServer.trustState === "changed") && <div className="cap-mcp-detail-error">
+					{mcpTrustActionRequired(selectedServer) && <div className="cap-mcp-detail-error">
 						<div className="drawer__summary">{mcpTrustLabel(selectedServer, t)} · {mcpIsolationLabel(selectedServer, t)}</div>
 						{selectedServer.isolationState === "unavailable_unconfined" && selectedServer.isolationReason && <div className="drawer__summary">{selectedServer.isolationReason}</div>}
 						{mcpToolChangeMessages(selectedServer.toolChanges, selectedServer.changedTools, t).map((message) => <div className="banner banner--warn" key={message}>{message}</div>)}
 						<div className="cap-mcp-editor__actions">
 							<button className="btn btn--small" disabled={actionBusy} type="button" onClick={() => void inspectTrust(selectedServer.name)}>{t("caps.reverify")}</button>
 							{selectedServer.trustState !== "untrusted" && <button className="btn btn--small" disabled={actionBusy} type="button" onClick={() => void mutate(() => app.SetMCPTrust(selectedServer.name, "revoke"))}>{t("caps.revokeTrust")}</button>}
+						</div>
+					</div>}
+					{mcpRevocableLaunchGrant(selectedServer) && <div className="cap-mcp-detail-trust">
+						<div className="drawer__summary">{mcpTrustLabel(selectedServer, t)} · {mcpIsolationLabel(selectedServer, t)}</div>
+						<div className="cap-mcp-editor__actions">
+							<button className="btn btn--small" disabled={actionBusy} type="button" onClick={() => void mutate(() => app.SetMCPTrust(selectedServer.name, "revoke"))}>{t("caps.revokeTrust")}</button>
 						</div>
 					</div>}
 					<ServerDetails

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2911,16 +2911,16 @@ function MCPTrustModal({
 		<div className="modal-backdrop" role="presentation">
 			<div className="modal" role="dialog" aria-modal="true" aria-labelledby="mcp-trust-title">
 				<div className="modal__title" id="mcp-trust-title">{t("caps.trustTitle", { name: inspection.name })}</div>
-				<p>{t("caps.trustExplanation")}</p>
+				<p>{t(inspection.requiresLaunchApproval ? "caps.projectLaunchExplanation" : "caps.trustExplanation")}</p>
 				{inspection.isolationState === "unavailable_unconfined" && <div className="banner banner--warn">{t("caps.unisolatedWarning")}</div>}
 				{inspection.isolationState === "unavailable_unconfined" && inspection.isolationReason && <div className="drawer__summary">{inspection.isolationReason}</div>}
 				{inspection.identityChanged && <div className="banner banner--warn">{t("caps.identityChanged")}</div>}
 				{mcpToolChangeMessages(inspection.toolChanges, inspection.changedTools, t).map((message) => <div className="banner banner--warn" key={message}>{message}</div>)}
-				<div className="modal__subject">
+				{!inspection.requiresLaunchApproval && <div className="modal__subject">
 					<div>{t("caps.readerTools", { count: inspection.readers.length })}: {inspection.readers.join(", ") || "—"}</div>
 					<div>{t("caps.writerTools", { count: inspection.writers.length })}: {inspection.writers.join(", ") || "—"}</div>
 					<div>{t("caps.destructiveTools", { count: inspection.destructive.length })}: {inspection.destructive.join(", ") || "—"}</div>
-				</div>
+				</div>}
 				<div className="modal__actions">
 					<button className="btn btn--small" type="button" disabled={busy} onClick={onCancel}>{t("common.cancel")}</button>
 					<button className="btn btn--small" type="button" disabled={busy} onClick={() => onDecision("session")}>{t("caps.trustSessionAction")}</button>
@@ -3101,7 +3101,7 @@ export function MCPServersSettingsPage() {
 					<MCPServerSettingsEditor
 						busy={busy}
 						onCancel={() => setScreen({ kind: "list" })}
-						onSubmit={(input) => void mutate(() => app.AddMCPServer(input)).then((ok) => { if (ok) { setScreen({ kind: "list" }); void inspectTrust(input.name); } })}
+						onSubmit={(input) => void mutate(() => app.AddMCPServer(input)).then((ok) => { if (ok) setScreen({ kind: "list" }); })}
 					/>
 				</div>
 			)}
@@ -3112,7 +3112,7 @@ export function MCPServersSettingsPage() {
 						server={selectedServer}
 						busy={busy}
 						onCancel={() => setScreen({ kind: "detail", name: selectedServer.name })}
-						onSubmit={(input) => void mutate(() => app.UpdateMCPServer(selectedServer.name, input)).then((ok) => { if (ok) { setScreen({ kind: "detail", name: selectedServer.name }); void inspectTrust(selectedServer.name); } })}
+						onSubmit={(input) => void mutate(() => app.UpdateMCPServer(selectedServer.name, input)).then((ok) => { if (ok) setScreen({ kind: "detail", name: selectedServer.name }); })}
 					/>
 				</div>
 			)}
@@ -3128,7 +3128,7 @@ export function MCPServersSettingsPage() {
 							</details>
 						</div>
 					)}
-					<div className="cap-mcp-detail-error">
+					{(selectedServer.requiresLaunchApproval || selectedServer.requiresReverification || selectedServer.trustState === "changed") && <div className="cap-mcp-detail-error">
 						<div className="drawer__summary">{mcpTrustLabel(selectedServer, t)} · {mcpIsolationLabel(selectedServer, t)}</div>
 						{selectedServer.isolationState === "unavailable_unconfined" && selectedServer.isolationReason && <div className="drawer__summary">{selectedServer.isolationReason}</div>}
 						{mcpToolChangeMessages(selectedServer.toolChanges, selectedServer.changedTools, t).map((message) => <div className="banner banner--warn" key={message}>{message}</div>)}
@@ -3136,7 +3136,7 @@ export function MCPServersSettingsPage() {
 							<button className="btn btn--small" disabled={actionBusy} type="button" onClick={() => void inspectTrust(selectedServer.name)}>{t("caps.reverify")}</button>
 							{selectedServer.trustState !== "untrusted" && <button className="btn btn--small" disabled={actionBusy} type="button" onClick={() => void mutate(() => app.SetMCPTrust(selectedServer.name, "revoke"))}>{t("caps.revokeTrust")}</button>}
 						</div>
-					</div>
+					</div>}
 					<ServerDetails
 						s={selectedServer}
 						tools={selectedServer.toolList ?? []}

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -736,6 +736,7 @@ export interface ServerView {
   defaultToolsApprovalMode?: MCPApprovalMode;
   toolPolicies?: Record<string, MCPToolPolicy>;
   approvalsReviewer?: MCPApprovalsReviewer;
+  requiresLaunchApproval?: boolean;
   authStatus?: "none" | "possible" | "required" | string;
   authUrl?: string;
   authConfigured?: boolean;
@@ -783,6 +784,7 @@ export interface MCPTrustInspectionView {
   readers: string[];
   writers: string[];
   destructive: string[];
+  requiresLaunchApproval?: boolean;
 }
 
 export interface MCPCatalogRefreshView {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -737,6 +737,7 @@ export interface ServerView {
   toolPolicies?: Record<string, MCPToolPolicy>;
   approvalsReviewer?: MCPApprovalsReviewer;
   requiresLaunchApproval?: boolean;
+  launchApprovalGoverned?: boolean;
   authStatus?: "none" | "possible" | "required" | string;
   authUrl?: string;
   authConfigured?: boolean;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -343,6 +343,7 @@ export const en = {
   "caps.destructiveTools": "Destructive tools ({count})",
   "caps.trustSessionAction": "Only this connection",
   "caps.trustWorkspaceAction": "Trust this workspace",
+  "caps.authorizeAndConnect": "Authorize and connect",
   "caps.reverify": "Reverify",
   "caps.revokeTrust": "Revoke trust",
   "caps.refreshCatalog": "Refresh catalog",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -327,6 +327,7 @@ export const en = {
   "caps.isolationNotApplicable": "Process isolation not applicable",
   "caps.trustTitle": "Trust {name}?",
   "caps.trustExplanation": "Trust applies only to the exact server identity and reader snapshots below. Writer tools still require approval.",
+  "caps.projectLaunchExplanation": "This MCP server comes from the current project. Authorize its exact command or endpoint before Reasonix starts it; changes require authorization again.",
   "caps.unisolatedWarning": "The OS sandbox is unavailable. This server will run unisolated and may have startup side effects.",
   "caps.identityChanged": "The server program or connection identity changed.",
   "caps.changedTools": "Changed tools: {tools}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -239,6 +239,7 @@ export const zhTW: Record<DictKey, string> = {
   "caps.isolationNotApplicable": "不適用程序隔離",
   "caps.trustTitle": "信任 {name}？",
   "caps.trustExplanation": "信任僅適用於下方精確的伺服器身分和唯讀工具快照；寫入工具仍需審批。",
+  "caps.projectLaunchExplanation": "此 MCP 伺服器來自目前專案。Reasonix 會在啟動前確認其精確命令或位址；設定變更後需要重新確認。",
   "caps.unisolatedWarning": "系統沙箱不可用。該伺服器將無隔離執行，啟動階段可能產生副作用。",
   "caps.identityChanged": "伺服器程式或連線身分已變更。",
   "caps.changedTools": "發生變更的工具：{tools}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -255,6 +255,7 @@ export const zhTW: Record<DictKey, string> = {
   "caps.destructiveTools": "破壞性工具（{count}）",
   "caps.trustSessionAction": "僅本次連線",
   "caps.trustWorkspaceAction": "信任目前工作區",
+  "caps.authorizeAndConnect": "授權並連線",
   "caps.reverify": "重新驗證",
   "caps.revokeTrust": "撤銷信任",
   "caps.refreshCatalog": "重新整理驗證目錄",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -344,6 +344,7 @@ export const zh: Record<DictKey, string> = {
   "caps.destructiveTools": "破坏性工具（{count}）",
   "caps.trustSessionAction": "仅本次连接",
   "caps.trustWorkspaceAction": "信任当前工作区",
+  "caps.authorizeAndConnect": "授权并连接",
   "caps.reverify": "重新验证",
   "caps.revokeTrust": "撤销信任",
   "caps.refreshCatalog": "刷新验证目录",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -328,6 +328,7 @@ export const zh: Record<DictKey, string> = {
   "caps.isolationNotApplicable": "不适用进程隔离",
   "caps.trustTitle": "信任 {name}？",
   "caps.trustExplanation": "信任仅适用于下方精确的服务器身份和只读工具快照；写入工具仍需审批。",
+  "caps.projectLaunchExplanation": "此 MCP 服务器来自当前项目。Reasonix 会在启动前确认其精确命令或地址；配置发生变化后需要重新确认。",
   "caps.unisolatedWarning": "系统沙箱不可用。该服务器将无隔离运行，启动阶段可能产生副作用。",
   "caps.identityChanged": "服务器程序或连接身份已变化。",
   "caps.changedTools": "发生变化的工具：{tools}",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11327,6 +11327,9 @@ body > .mermaid-diagram--fullscreen {
 .cap-mcp-detail-error {
   margin-bottom: 14px;
 }
+.cap-mcp-detail-trust {
+  margin-bottom: 14px;
+}
 .cap-mcp-detail-error details {
   margin-top: 7px;
   color: var(--fg-faint);

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -588,13 +588,17 @@ The normal setup path is intentionally one step: adding a server in Desktop or
 the user config means you authorize that server, so it connects immediately,
 trusts its current capability snapshot, and ordinary calls do not need another
 MCP-specific approval setting. Explicit deny rules still win, destructive tools
-still require a fresh human decision, and Plan/read-only sub-agent boundaries
-remain unchanged. Repository-controlled `reasonix.toml` and `.mcp.json` entries
-are different: Reasonix shows one launch confirmation for the exact command or
-endpoint before starting it, and asks again if that identity changes.
+still require a fresh human decision, and Plan/read-only sub-agents still expose
+only eligible tool identities. Repository-controlled `reasonix.toml` and
+`.mcp.json` entries are different: Reasonix shows one launch confirmation for
+the exact command or endpoint before starting it, and asks again if that
+identity changes.
 
 stdio servers keep one process for initialize, reads, and writes, so stateful
-servers such as browsers retain sessions and open pages.
+servers such as browsers retain sessions and open pages. Because an OS sandbox
+is fixed when a process starts, this shared process uses the server's normal
+writer sandbox for every call; `readOnlyHint` and read-only sub-agent filtering
+are dispatch policy, not a second per-call process sandbox.
 
 Tools surface to the model as `mcp__<server>__<tool>`. A tool declaring MCP's
 `readOnlyHint: true` joins parallel dispatch and the ordinary

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -582,8 +582,22 @@ Reasonix is an MCP client. A `[[plugins]]` entry's `type` selects the transport:
 `stdio` (default) launches a local subprocess (`command`/`args`/`env`); `http`
 (Streamable HTTP) connects to a remote `url` with optional static `headers`
 (`${VAR}` / `${VAR:-default}` expanded from the environment, so tokens stay out
-of the file). Tools surface to the model as `mcp__<server>__<tool>`; a tool
-declaring MCP's `readOnlyHint: true` joins parallel dispatch and the ordinary
+of the file).
+
+The normal setup path is intentionally one step: adding a server in Desktop or
+the user config means you authorize that server, so it connects immediately,
+trusts its current capability snapshot, and ordinary calls do not need another
+MCP-specific approval setting. Explicit deny rules still win, destructive tools
+still require a fresh human decision, and Plan/read-only sub-agent boundaries
+remain unchanged. Repository-controlled `reasonix.toml` and `.mcp.json` entries
+are different: Reasonix shows one launch confirmation for the exact command or
+endpoint before starting it, and asks again if that identity changes.
+
+stdio servers keep one process for initialize, reads, and writes, so stateful
+servers such as browsers retain sessions and open pages.
+
+Tools surface to the model as `mcp__<server>__<tool>`. A tool declaring MCP's
+`readOnlyHint: true` joins parallel dispatch and the ordinary
 permission reader-default. Because the annotation is supplied by a third-party
 server, it is accepted by the main Plan workflow only as ordinary permission
 classification; it does not grant access to the dedicated planner or read-only
@@ -620,7 +634,9 @@ approvals_reviewer = "auto_review"     # user|auto_review
 trusted_read_only_tools = ["issue_read", "pull_request_read"]
 ```
 
-`auto` delegates to the global Ask/Auto/YOLO permission posture; `prompt`
+For a user-authorized server, omitting these advanced approval fields permits
+ordinary calls directly. If a field is present, `auto` delegates to the global
+Ask/Auto/YOLO permission posture; `prompt`
 reviews every call; `writes` reviews only writer-classified calls; and `approve`
 allows ordinary calls. Explicit deny rules always win, and `destructiveHint`
 always forces a new review. A raw-tool `tools` entry overrides the server

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -475,8 +475,18 @@ reasonix doctor capabilities --live --timeout 5s
 
 Reasonix 是一个 MCP 客户端。`[[plugins]]` 的 `type` 选择传输：`stdio`（默认）启动本地子进
 程（`command`/`args`/`env`）；`http`（Streamable HTTP）连接远程 `url`，可带静态
-`headers`（`${VAR}` / `${VAR:-default}` 从环境展开，密钥不入文件）。工具以
-`mcp__<server>__<tool>` 暴露给模型，与 Claude Code 一致；声明 MCP `readOnlyHint: true`
+`headers`（`${VAR}` / `${VAR:-default}` 从环境展开，密钥不入文件）。
+
+普通配置流程现在只有一步：在桌面端或用户全局配置中添加 server，就表示用户授权该
+server；保存后会立即连接、信任当前能力快照，普通调用无需再配置一套 MCP 专用审批。
+显式 deny 仍然优先，destructive 工具仍需每次由用户确认，Plan 与只读 subagent 的边界也
+不变。仓库控制的 `reasonix.toml` 和 `.mcp.json` 不会直接执行：Reasonix 会在启动其进程或
+访问其地址之前，对精确身份确认一次；命令、可执行文件或地址变化后会重新确认。
+
+stdio server 从初始化到读写都复用同一个进程，因此浏览器等有状态 MCP 能保留会话和
+已打开页面。
+
+工具以 `mcp__<server>__<tool>` 暴露给模型，与 Claude Code 一致；声明 MCP `readOnlyHint: true`
 的工具会参与并行调度并命中普通权限层的只读默认放行。这个标注来自第三方 server，主 Plan 只把它
 当作普通权限分类；它不会让工具进入独立 planner 或只读研究 subagent。已审计的 reader 应写入本地
 `trusted_read_only_tools`。没有 `readOnlyHint` 的工具仍按写工具处理。计划期间，内置 writer 仍走
@@ -505,7 +515,8 @@ approvals_reviewer = "auto_review"     # user|auto_review
 trusted_read_only_tools = ["issue_read", "pull_request_read"]
 ```
 
-`auto` 交给全局 Ask/Auto/YOLO；`prompt` 每次调用都审查；`writes` 只审查写工具；`approve`
+用户已授权的 server 若省略这些高级审批字段，普通调用会直接放行。显式配置后，`auto`
+交给全局 Ask/Auto/YOLO；`prompt` 每次调用都审查；`writes` 只审查写工具；`approve`
 放行普通调用。显式 deny 永远优先，`destructiveHint` 永远强制一次新审查，`tools` 中的 raw tool
 配置覆盖 server 默认值。`trusted_read_only_tools` 继续作为兼容字段和本地信任声明，用于已审计、
 但没有可靠 annotation 的 reader。

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -479,12 +479,14 @@ Reasonix 是一个 MCP 客户端。`[[plugins]]` 的 `type` 选择传输：`stdi
 
 普通配置流程现在只有一步：在桌面端或用户全局配置中添加 server，就表示用户授权该
 server；保存后会立即连接、信任当前能力快照，普通调用无需再配置一套 MCP 专用审批。
-显式 deny 仍然优先，destructive 工具仍需每次由用户确认，Plan 与只读 subagent 的边界也
-不变。仓库控制的 `reasonix.toml` 和 `.mcp.json` 不会直接执行：Reasonix 会在启动其进程或
-访问其地址之前，对精确身份确认一次；命令、可执行文件或地址变化后会重新确认。
+显式 deny 仍然优先，destructive 工具仍需每次由用户确认，Plan 与只读 subagent 仍只暴露
+符合条件的工具身份。仓库控制的 `reasonix.toml` 和 `.mcp.json` 不会直接执行：Reasonix 会在
+启动其进程或访问其地址之前，对精确身份确认一次；命令、可执行文件或地址变化后会重新确认。
 
 stdio server 从初始化到读写都复用同一个进程，因此浏览器等有状态 MCP 能保留会话和
-已打开页面。
+已打开页面。由于进程启动后无法按调用切换 OS 沙箱，这个共享进程始终使用该 server 的普通
+writer 沙箱；`readOnlyHint` 与只读 subagent 过滤属于调用分发策略，不再对应第二个按调用隔离
+的进程沙箱。
 
 工具以 `mcp__<server>__<tool>` 暴露给模型，与 Claude Code 一致；声明 MCP `readOnlyHint: true`
 的工具会参与并行调度并命中普通权限层的只读默认放行。这个标注来自第三方 server，主 Plan 只把它

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -106,6 +106,17 @@ and DeepSeek prefix-cache–oriented design.
   servers, or on first evaluation otherwise — when nothing else changed; the read-only
   legacy fingerprint calculator is scheduled for removal two minor releases
   after this rollout.
+- **MCP setup is now add-and-use.** Servers added by the user (Desktop, user
+  config, legacy user import, or an installed verified plugin package) connect
+  with an automatic trust snapshot and permit ordinary calls when no explicit
+  MCP approval policy is configured. Repository `reasonix.toml` / `.mcp.json`
+  servers instead require one pre-launch confirmation for their exact stable
+  identity, before a subprocess or network request exists. Older receipts and
+  the former `workspace_config` source migrate automatically when server code
+  and capabilities are unchanged. Host sandbox/read/write-root policy changes
+  no longer invalidate server identity.
+- **stdio MCP connections are persistent.** This fixes stateful servers that
+  lost browser/session state when writer calls received a fresh process.
 - **Plan mode and permission policy are now independent**: Plan directs the
   model to plan first. Ordinary built-in and Bash calls still use the active
   Ask/Auto/YOLO rules and Sandbox, while installed MCP and proxy-resolved MCP
@@ -124,7 +135,7 @@ and DeepSeek prefix-cache–oriented design.
   planner/read-only sub-agent trust. Tools without the hint remain
   writer-classified. New optional MCP-local fields
   (`default_tools_approval_mode`, `tools.<raw>.approval_mode`, and
-  `approvals_reviewer`) default to the previous behavior when absent. MCP tools
+  `approvals_reviewer`) override the new source-aware default when present. MCP tools
   declaring `destructiveHint: true` require a fresh human approval on every
   call — the configured reviewer is never consulted for them — and
   non-interactive sessions fail closed.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -141,6 +141,15 @@ interface (`call` / `notify` / `close`) abstracts that, so the MCP-level logic
   and `headers` so secrets come from the environment, not the config file.
 - Lifecycle: `initialize` → `notifications/initialized` → `tools/list`;
   invocation via `tools/call {name, arguments}`.
+- A stdio server uses one persistent transport for initialize, reads, and
+  writes, preserving state such as browser sessions across tool calls.
+- Configuration provenance is runtime metadata. User config, legacy user MCP,
+  and verified plugin-package servers are authorized by installation: the host
+  records their current trust snapshot automatically and ordinary calls default
+  to direct approval. Project `reasonix.toml` and `.mcp.json` servers require a
+  session/workspace launch grant for the exact stable identity before any
+  process or network transport is created. Existing receipts count as launch
+  grants for backward compatibility; identity changes invalidate the grant.
 - Each remote tool is adapted to the `Tool` interface and injected into the run
   registry, namespaced `mcp__<server>__<tool>` (spaces normalised to `_`) to
   match Claude Code and avoid clashes.
@@ -305,7 +314,8 @@ func (p Policy) Decide(toolName string, readOnly bool, args json.RawMessage) Dec
 - **MCP approval policy.** Installed MCP tools may set a server default and raw
   tool overrides using `auto|prompt|writes|approve`. Precedence is explicit deny,
   `destructiveHint`, raw-tool mode, server default, then global Ask/Auto/YOLO.
-  `auto` delegates to the ordinary permission decision; `prompt` reviews every
+  A user-authorized server with no explicit MCP approval fields defaults to
+  `approve`; project-provided servers retain `auto`. `auto` delegates to the ordinary permission decision; `prompt` reviews every
   call; `writes` reviews writers only; and `approve` allows ordinary calls.
   `approvals_reviewer = "user"` uses the interactive user, while `auto_review`
   sends the calls that need review (`prompt`, writer hits under `writes`, and
@@ -637,7 +647,6 @@ args    = []
 # default_tools_approval_mode = "auto"   # auto|prompt|writes|approve
 # tools = { "delete_all" = { approval_mode = "prompt" } }
 # approvals_reviewer = "user"            # user|auto_review
-
 # [[plugins]]                   # a remote MCP server over Streamable HTTP
 # name    = "stripe"
 # type    = "http"             # "stdio" (default) | "http" | "sse"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -142,7 +142,10 @@ interface (`call` / `notify` / `close`) abstracts that, so the MCP-level logic
 - Lifecycle: `initialize` → `notifications/initialized` → `tools/list`;
   invocation via `tools/call {name, arguments}`.
 - A stdio server uses one persistent transport for initialize, reads, and
-  writes, preserving state such as browser sessions across tool calls.
+  writes, preserving state such as browser sessions across tool calls. The
+  process uses the server's writer sandbox because process confinement cannot
+  change per RPC; read-only eligibility and destructive approval remain local
+  dispatch gates rather than separate process sandboxes.
 - Configuration provenance is runtime metadata. User config, legacy user MCP,
   and verified plugin-package servers are authorized by installation: the host
   records their current trust snapshot automatically and ordinary calls default

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -494,10 +494,7 @@ func (o *onDemandMCPTool) MCPDestructiveHint() bool {
 }
 
 func (o *onDemandMCPTool) MCPApprovalMode() string {
-	if mode := strings.TrimSpace(o.spec.ToolApprovalModes[o.raw]); mode != "" {
-		return tool.NormalizeMCPApprovalMode(mode)
-	}
-	return tool.NormalizeMCPApprovalMode(o.spec.DefaultToolsApprovalMode)
+	return o.spec.ToolApprovalMode(o.raw)
 }
 
 func (o *onDemandMCPTool) MCPApprovalReviewer() string {

--- a/internal/agent/usecapability_test.go
+++ b/internal/agent/usecapability_test.go
@@ -647,6 +647,40 @@ func TestOnDemandModelNameMatchesPluginCanonicalName(t *testing.T) {
 	}
 }
 
+func TestOnDemandMCPToolUsesSharedApprovalResolution(t *testing.T) {
+	host := plugin.NewHost()
+	defer host.Close()
+	specs := []plugin.Spec{
+		{Name: "user", Type: "stdio", Command: "reasonix-test-definitely-missing-binary", ImplicitApproval: true},
+		{Name: "scoped", Type: "stdio", Command: "reasonix-test-definitely-missing-binary", ImplicitApproval: true,
+			ToolApprovalModes: map[string]string{"wipe": "prompt"}},
+		{Name: "project", Type: "stdio", Command: "reasonix-test-definitely-missing-binary"},
+	}
+	tl := NewUseCapabilityTool(context.Background(), host, specs, tool.NewRegistry(), capability.NewLedger(), nil, nil)
+	cases := []struct{ id, want string }{
+		// A user-configured server carries implicit approval; the delivery
+		// on-demand path must resolve it to direct approval exactly like the
+		// direct MCP tool path, not fall back to the global posture.
+		{"mcp-tool:user/write", tool.MCPApprovalApprove},
+		{"mcp-tool:scoped/wipe", tool.MCPApprovalPrompt},
+		{"mcp-tool:project/write", tool.MCPApprovalAuto},
+	}
+	for _, tc := range cases {
+		resolved, err := tl.ResolveCall(context.Background(),
+			json.RawMessage(`{"action":"call","capability_id":"`+tc.id+`"}`))
+		if err != nil {
+			t.Fatalf("%s: %v", tc.id, err)
+		}
+		policy, ok := resolved.Target.(tool.MCPApprovalPolicy)
+		if !ok {
+			t.Fatalf("%s: resolved target %T does not expose an MCP approval policy", tc.id, resolved.Target)
+		}
+		if got := policy.MCPApprovalMode(); got != tc.want {
+			t.Fatalf("%s: on-demand approval mode = %q, want %q (plugin.Spec.ToolApprovalMode parity)", tc.id, got, tc.want)
+		}
+	}
+}
+
 func TestProxyCallAuditCountsOnAgentPath(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "mcp__github__search_issues", readOnly: true})

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1494,7 +1494,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				return
 			}
 			spec.TrustManager = pluginSpecOptions.TrustManager
-			spec.ConfigSource = pluginSpecOptions.ConfigSource
+			if strings.TrimSpace(spec.ConfigSource) == "" {
+				spec.ConfigSource = pluginSpecOptions.ConfigSource
+			}
 			applyMCPIsolation(spec, root, pluginSpecOptions)
 			applyOfficialMCPTrust(spec, pluginSpecOptions)
 		},
@@ -2169,6 +2171,10 @@ func PluginSpecsForRootWithOptions(entries []config.PluginEntry, workspaceRoot s
 
 func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, opts PluginSpecOptions) plugin.Spec {
 	e = e.ExpandedPlugin() // resolve ${VAR} / ${VAR:-default} from the environment
+	configSource := strings.TrimSpace(string(e.Source))
+	if configSource == "" {
+		configSource = opts.ConfigSource
+	}
 	spec := plugin.ApplyKnownOverrides(plugin.Spec{
 		Name:                     e.Name,
 		Type:                     e.Type,
@@ -2185,7 +2191,10 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 		ToolApprovalModes:        mcpToolApprovalModes(e.Tools),
 		ApprovalsReviewer:        e.ApprovalsReviewer,
 		TrustManager:             opts.TrustManager,
-		ConfigSource:             opts.ConfigSource,
+		ConfigSource:             configSource,
+		AutoTrust:                e.Source.UserAuthorized(),
+		ImplicitApproval:         e.Source.UserAuthorized(),
+		RequireLaunchApproval:    e.Source.RequiresLaunchApproval(),
 	}, workspaceRoot)
 	applyMCPIsolation(&spec, workspaceRoot, opts)
 	applyOfficialMCPTrust(&spec, opts)
@@ -2206,6 +2215,9 @@ func applyOfficialMCPTrust(spec *plugin.Spec, opts PluginSpecOptions) {
 		spec.PackageRoot = official.PackageRoot
 		spec.VerifiedVersion = official.Version
 		spec.CatalogSequence = official.CatalogSequence
+		spec.AutoTrust = true
+		spec.ImplicitApproval = true
+		spec.RequireLaunchApproval = false
 		spec.ReaderSandbox.Network = official.Network
 		spec.WriterSandbox.Network = official.Network
 	}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -2384,7 +2384,7 @@ func TestBuildTokenEconomyPlanModeCanConnectInstalledMCPSource(t *testing.T) {
 		testutil.Turn{Text: "done"},
 	)
 	setBootTokenProfileTestProvider(t, prov)
-	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
 
 [agent]
@@ -2394,6 +2394,9 @@ system_prompt = "BASE"
 name = "test-model"
 kind = "boot-token-profile-test"
 model = "x"
+	`)
+	userConfig := config.UserConfigPath()
+	writeFile(t, filepath.Dir(userConfig), filepath.Base(userConfig), fmt.Sprintf(`
 
 [[plugins]]
 name = "mockmcp"
@@ -2444,7 +2447,7 @@ func TestBuildTokenEconomyPlanModeKeepsLegacyMCPReadOnlyOverride(t *testing.T) {
 		testutil.Turn{Text: "done"},
 	)
 	setBootTokenProfileTestProvider(t, prov)
-	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
 
 [agent]
@@ -2454,6 +2457,9 @@ system_prompt = "BASE"
 name = "test-model"
 kind = "boot-token-profile-test"
 model = "x"
+	`)
+	userConfig := config.UserConfigPath()
+	writeFile(t, filepath.Dir(userConfig), filepath.Base(userConfig), fmt.Sprintf(`
 
 [[plugins]]
 name = "mockmcp"
@@ -3817,6 +3823,22 @@ func TestPluginSpecsMapMCPApprovalPolicy(t *testing.T) {
 	if len(specs) != 1 || specs[0].DefaultToolsApprovalMode != "writes" ||
 		specs[0].ToolApprovalModes["wipe"] != "prompt" || specs[0].ApprovalsReviewer != "auto_review" {
 		t.Fatalf("mapped MCP approval policy = %+v", specs)
+	}
+}
+
+func TestPluginSpecsMapMCPSourceDefaults(t *testing.T) {
+	specs := PluginSpecsForRootWithOptions([]config.PluginEntry{
+		{Name: "user", Source: config.MCPSourceUserConfig},
+		{Name: "project", Source: config.MCPSourceProjectConfig},
+	}, "/workspace", PluginSpecOptions{ConfigSource: "workspace_config"})
+	if len(specs) != 2 {
+		t.Fatalf("spec count = %d", len(specs))
+	}
+	if !specs[0].AutoTrust || !specs[0].ImplicitApproval || specs[0].RequireLaunchApproval || specs[0].ConfigSource != string(config.MCPSourceUserConfig) {
+		t.Fatalf("user source defaults = %+v", specs[0])
+	}
+	if specs[1].AutoTrust || specs[1].ImplicitApproval || !specs[1].RequireLaunchApproval || specs[1].ConfigSource != string(config.MCPSourceProjectConfig) {
+		t.Fatalf("project source defaults = %+v", specs[1])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1518,7 +1518,9 @@ type PluginEntry struct {
 	// audited readers. Third-party readOnlyHint alone is not a Plan-mode trust
 	// boundary.
 	TrustedReadOnlyTools []string `toml:"trusted_read_only_tools"`
-	// DefaultToolsApprovalMode is auto|prompt|writes|approve. Empty is auto.
+	// DefaultToolsApprovalMode is auto|prompt|writes|approve. Empty uses the
+	// source-aware runtime default (direct for user-authorized servers, auto for
+	// project-provided servers).
 	DefaultToolsApprovalMode string `toml:"default_tools_approval_mode"`
 	// Tools overrides approval policy by raw server-local tool name.
 	Tools map[string]MCPToolPolicy `toml:"tools"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1471,6 +1471,27 @@ type MCPToolPolicy struct {
 	ApprovalMode string `toml:"approval_mode" json:"approval_mode"`
 }
 
+// MCPConfigSource records where a merged MCP entry came from. It is runtime
+// provenance only and is never serialized back into TOML or .mcp.json.
+type MCPConfigSource string
+
+const (
+	MCPSourceUnknown        MCPConfigSource = ""
+	MCPSourceUserConfig     MCPConfigSource = "user_config"
+	MCPSourceProjectConfig  MCPConfigSource = "project_config"
+	MCPSourceProjectMCPJSON MCPConfigSource = "project_mcp_json"
+	MCPSourceLegacyUser     MCPConfigSource = "legacy_user_config"
+	MCPSourcePluginPackage  MCPConfigSource = "plugin_package"
+)
+
+func (s MCPConfigSource) UserAuthorized() bool {
+	return s == MCPSourceUserConfig || s == MCPSourceLegacyUser || s == MCPSourcePluginPackage
+}
+
+func (s MCPConfigSource) RequiresLaunchApproval() bool {
+	return s == MCPSourceProjectConfig || s == MCPSourceProjectMCPJSON
+}
+
 // PluginEntry declares an external MCP server. Type selects the transport:
 // "stdio" (default) launches Command/Args/Env as a subprocess; "http"
 // (a.k.a. streamable-http) and "sse" connect to a remote URL with optional
@@ -1516,7 +1537,8 @@ type PluginEntry struct {
 	//                  swap happens once the spawn finishes.
 	// Empty defaults to "background" so enabled MCPs connect automatically
 	// without blocking chat. Unknown non-empty values fall back to "background".
-	Tier         string `toml:"tier"`
+	Tier         string          `toml:"tier"`
+	Source       MCPConfigSource `toml:"-" json:"-"`
 	expansionEnv map[string]string
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -389,8 +389,10 @@ func mergeTOMLPlugins(paths []string) ([]PluginEntry, error) {
 		for _, p := range f.Plugins {
 			p, _ = NormalizePluginCommandLine(p)
 			if isUserConfigPath(path) {
+				p.Source = MCPSourceUserConfig
 				userApprovalPolicies[p.Name] = p
 			} else {
+				p.Source = MCPSourceProjectConfig
 				p = restrictProjectMCPApprovalPolicy(p)
 				if userPolicy, ok := userApprovalPolicies[p.Name]; ok {
 					p = inheritUserMCPApprovalPolicy(p, userPolicy)

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -87,7 +87,9 @@ func specsToEntries(specs map[string]mcpServerSpec, skip map[string]bool) []Plug
 	sort.Strings(names)
 	entries := make([]PluginEntry, 0, len(names))
 	for _, name := range names {
-		entries = append(entries, pluginEntryFromMCPSpec(name, specs[name]))
+		entry := pluginEntryFromMCPSpec(name, specs[name])
+		entry.Source = MCPSourceProjectMCPJSON
+		entries = append(entries, entry)
 	}
 	return entries
 }
@@ -154,6 +156,9 @@ func loadLegacyMCP(path string) []PluginEntry {
 		have[pe.Name] = true
 		pe, _ = NormalizePluginCommandLine(pe)
 		entries = append(entries, pe)
+	}
+	for i := range entries {
+		entries[i].Source = MCPSourceLegacyUser
 	}
 	return entries
 }

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -45,6 +45,9 @@ func TestLoadMCPJSON(t *testing.T) {
 	if fs.Command != "npx" || len(fs.Args) != 3 || fs.Env["FOO"] != "bar" {
 		t.Errorf("filesystem decoded wrong: %+v", fs)
 	}
+	if fs.Source != MCPSourceProjectMCPJSON {
+		t.Errorf("filesystem source = %q, want project .mcp.json", fs.Source)
+	}
 	st := got[1]
 	if st.Type != "http" || st.URL != "https://mcp.stripe.com" ||
 		st.Headers["Authorization"] != "Bearer ${STRIPE_KEY}" {
@@ -549,11 +552,16 @@ func TestLoadMergesPluginsAcrossTOMLSources(t *testing.T) {
 		t.Fatal(err)
 	}
 	names := map[string]bool{}
+	sources := map[string]MCPConfigSource{}
 	for _, p := range cfg.Plugins {
 		names[p.Name] = true
+		sources[p.Name] = p.Source
 	}
 	if !names["globalmcp"] || !names["projectmcp"] {
 		t.Fatalf("a project reasonix.toml [[plugins]] dropped the global config's server; got %+v", cfg.Plugins)
+	}
+	if sources["globalmcp"] != MCPSourceUserConfig || sources["projectmcp"] != MCPSourceProjectConfig {
+		t.Fatalf("plugin provenance = %+v", sources)
 	}
 }
 

--- a/internal/config/plugin_packages.go
+++ b/internal/config/plugin_packages.go
@@ -49,6 +49,7 @@ func mergeInstalledPluginPackages(cfg *Config, root string) []string {
 				Headers:   pluginPackageWorkspaceMap(pkg.Root, root, srv.Headers),
 				AutoStart: srv.AutoStart,
 				Tier:      srv.Tier,
+				Source:    MCPSourcePluginPackage,
 			}
 			if existing, ok := pluginEntryByName(cfg.Plugins, name); ok {
 				if owner, packageOwned := cfg.pluginPackageOwners[name]; packageOwned && pluginPackageEntriesEqual(existing, entry) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4258,6 +4258,7 @@ func (c *Controller) ConnectMCPServer(e config.PluginEntry) (int, error) {
 // overrides scoped to the workspace, and connects it live via the mcp manager.
 func (c *Controller) connectMCPServer(e config.PluginEntry) (int, error) {
 	exp := e.ExpandedPlugin()
+	configSource := strings.TrimSpace(string(exp.Source))
 	spec := plugin.ApplyKnownOverrides(plugin.Spec{
 		Name:                     exp.Name,
 		Type:                     exp.Type,
@@ -4273,6 +4274,10 @@ func (c *Controller) connectMCPServer(e config.PluginEntry) (int, error) {
 		DefaultToolsApprovalMode: exp.DefaultToolsApprovalMode,
 		ToolApprovalModes:        controllerMCPToolApprovalModes(exp.Tools),
 		ApprovalsReviewer:        exp.ApprovalsReviewer,
+		ConfigSource:             configSource,
+		AutoTrust:                exp.Source.UserAuthorized(),
+		ImplicitApproval:         exp.Source.UserAuthorized(),
+		RequireLaunchApproval:    exp.Source.RequiresLaunchApproval(),
 	}, c.WorkspaceRoot())
 	if c.mcpConfigureSpec != nil {
 		c.mcpConfigureSpec(&spec)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4230,6 +4230,10 @@ func (c *Controller) HookRunner() *hook.Runner { return c.hooks }
 // of tools the server exposed. A save failure after a successful connect is
 // reported but non-fatal: the server still works this session.
 func (c *Controller) AddMCPServer(e config.PluginEntry) (int, error) {
+	// AddMCPServer is an explicit user action. Mark the live entry with the same
+	// provenance it will receive when the saved user config is loaded next time,
+	// so /mcp add is add-and-use in the current session too.
+	e.Source = config.MCPSourceUserConfig
 	n, err := c.connectMCPServer(e)
 	if err != nil {
 		return 0, err

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2339,6 +2339,21 @@ func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
 	}
 }
 
+func TestAddMCPServerAuthorizesExplicitUserAddBeforeConnecting(t *testing.T) {
+	var configured plugin.Spec
+	c := New(Options{
+		MCPConfigureSpec: func(spec *plugin.Spec) { configured = *spec },
+	})
+
+	if _, err := c.AddMCPServer(config.PluginEntry{Name: "user-added"}); err == nil {
+		t.Fatal("AddMCPServer without a command unexpectedly succeeded")
+	}
+	if configured.ConfigSource != string(config.MCPSourceUserConfig) ||
+		!configured.AutoTrust || !configured.ImplicitApproval || configured.RequireLaunchApproval {
+		t.Fatalf("configured spec = %+v, want user-authorized add-and-use policy", configured)
+	}
+}
+
 func TestConnectMCPServerAppliesConfiguredCallTimeouts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req struct {

--- a/internal/mcptrust/process_unix.go
+++ b/internal/mcptrust/process_unix.go
@@ -11,3 +11,5 @@ func trustLockProcessAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || err == syscall.EPERM
 }
+
+func trustLockContention(error) bool { return false }

--- a/internal/mcptrust/process_windows.go
+++ b/internal/mcptrust/process_windows.go
@@ -2,7 +2,11 @@
 
 package mcptrust
 
-import "golang.org/x/sys/windows"
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
 
 const trustLockStillActiveExitCode = 259
 
@@ -19,4 +23,13 @@ func trustLockProcessAlive(pid int) bool {
 	defer windows.CloseHandle(handle)
 	var code uint32
 	return windows.GetExitCodeProcess(handle, &code) == nil && code == trustLockStillActiveExitCode
+}
+
+// trustLockContention reports transient Windows name/handle races while one
+// owner removes the exclusive-create lock and another tries to create it.
+// OpenFile can surface those races as access or sharing violations instead of
+// os.ErrExist, so callers must retry them within the normal lock deadline.
+func trustLockContention(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
 }

--- a/internal/mcptrust/process_windows_test.go
+++ b/internal/mcptrust/process_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package mcptrust
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestTrustLockContentionRecognizesWindowsDeleteRaces(t *testing.T) {
+	for _, err := range []error{
+		windows.ERROR_ACCESS_DENIED,
+		windows.ERROR_SHARING_VIOLATION,
+		fmt.Errorf("open lock: %w", windows.ERROR_ACCESS_DENIED),
+	} {
+		if !trustLockContention(err) {
+			t.Fatalf("trustLockContention(%v) = false, want true", err)
+		}
+	}
+	if trustLockContention(windows.ERROR_PATH_NOT_FOUND) {
+		t.Fatal("path-not-found must not be retried as lock contention")
+	}
+}

--- a/internal/mcptrust/trust.go
+++ b/internal/mcptrust/trust.go
@@ -126,9 +126,22 @@ type LauncherLock struct {
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
+// LaunchGrant is the pre-execution consent for repository-controlled MCP
+// configuration. It is separate from capability receipts because a server must
+// not be started merely to discover its tools before the user approves launch.
+type LaunchGrant struct {
+	Scope                Scope     `json:"scope"`
+	WorkspaceFingerprint string    `json:"workspace_fingerprint,omitempty"`
+	Server               string    `json:"server"`
+	ConfigSource         string    `json:"config_source"`
+	IdentityFingerprint  string    `json:"identity_fingerprint"`
+	CreatedAt            time.Time `json:"created_at"`
+}
+
 type State struct {
 	Version         int            `json:"version"`
 	Receipts        []Receipt      `json:"receipts,omitempty"`
+	LaunchGrants    []LaunchGrant  `json:"launch_grants,omitempty"`
 	LauncherLocks   []LauncherLock `json:"launcher_locks,omitempty"`
 	OfficialDenials []string       `json:"official_denials,omitempty"`
 	LegacyImports   []string       `json:"legacy_imports,omitempty"`
@@ -155,8 +168,9 @@ type Manager struct {
 	path                 string
 	workspaceFingerprint string
 
-	mu      sync.Mutex
-	session []Receipt
+	mu            sync.Mutex
+	session       []Receipt
+	sessionLaunch []LaunchGrant
 }
 
 var managerRegistry struct {
@@ -203,6 +217,54 @@ func WorkspaceFingerprint(workspace string) string {
 }
 
 func IdentityFingerprint(identity Identity) (string, error) {
+	identity = normalizeIdentity(identity, runtime.GOOS == "windows")
+	// Runtime confinement is deliberately not part of server identity. Tightening
+	// Reasonix's own sandbox, changing workspace roots, or moving a config between
+	// equivalent source labels must not invalidate trust in unchanged server code.
+	payload := struct {
+		Server, Transport, CommandPath, CommandSHA256, Dir, URL string
+		Args, EnvKeys, HeaderKeys                               []string
+		PackageDigest, LauncherDigest                           string
+	}{
+		identity.Server, identity.Transport, identity.CommandPath, identity.CommandSHA256,
+		identity.Dir, identity.URL, identity.Args, identity.EnvKeys, identity.HeaderKeys,
+		identity.PackageDigest, identity.LauncherDigest,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return digestBytes(body), nil
+}
+
+// LegacyIdentityFingerprints returns the policy-coupled identity variants used
+// by the first trust-receipt rollout. Callers use them only for exact digest
+// migration; new receipts always use IdentityFingerprint above.
+func LegacyIdentityFingerprints(identity Identity) []string {
+	variants := make([]Identity, 0, 4)
+	for _, source := range compactStrings([]string{identity.ConfigSource, "workspace_config"}) {
+		withSource := identity
+		withSource.ConfigSource = source
+		variants = append(variants, withSource)
+		withoutForbid := withSource
+		withoutForbid.ForbidReadRoots = nil
+		variants = append(variants, withoutForbid)
+	}
+	out := make([]string, 0, len(variants)*2)
+	seen := map[string]bool{}
+	for _, variant := range variants {
+		for _, insensitive := range []bool{runtime.GOOS == "windows", false} {
+			fp, err := legacyIdentityFingerprint(variant, insensitive)
+			if err == nil && fp != "" && !seen[fp] {
+				seen[fp] = true
+				out = append(out, fp)
+			}
+		}
+	}
+	return out
+}
+
+func normalizeIdentity(identity Identity, envCaseInsensitive bool) Identity {
 	identity.Server = strings.TrimSpace(identity.Server)
 	identity.Transport = normalizeTransport(identity.Transport)
 	identity.CommandPath = canonicalPath(identity.CommandPath)
@@ -215,11 +277,16 @@ func IdentityFingerprint(identity Identity) (string, error) {
 	identity.Args = append([]string(nil), identity.Args...)
 	// Environment names are case-sensitive on Unix and case-insensitive on
 	// Windows. Header names are case-insensitive on every supported platform.
-	identity.EnvKeys = cleanStrings(identity.EnvKeys, runtime.GOOS == "windows")
+	identity.EnvKeys = cleanStrings(identity.EnvKeys, envCaseInsensitive)
 	identity.HeaderKeys = cleanStrings(identity.HeaderKeys, true)
 	identity.WriteRoots = canonicalPaths(identity.WriteRoots)
 	identity.ReadRoots = canonicalPaths(identity.ReadRoots)
 	identity.ForbidReadRoots = canonicalPaths(identity.ForbidReadRoots)
+	return identity
+}
+
+func legacyIdentityFingerprint(identity Identity, envCaseInsensitive bool) (string, error) {
+	identity = normalizeIdentity(identity, envCaseInsensitive)
 	body, err := json.Marshal(identity)
 	if err != nil {
 		return "", err
@@ -307,6 +374,76 @@ func (m *Manager) TrustOfficial(server, configSource, identityFingerprint, catal
 	return m.trust(ScopeGlobal, SourceOfficialCatalog, server, configSource, identityFingerprint, catalogEntryID, capabilities, readers)
 }
 
+// TrustLaunch records the user's consent to start one exact project-provided
+// server identity. Session grants stay in memory; workspace grants are persisted.
+func (m *Manager) TrustLaunch(scope Scope, server, configSource, identityFingerprint string) error {
+	if scope != ScopeSession && scope != ScopeWorkspace {
+		return fmt.Errorf("invalid MCP launch grant scope %q", scope)
+	}
+	grant := LaunchGrant{
+		Scope: scope, Server: strings.TrimSpace(server), ConfigSource: strings.TrimSpace(configSource),
+		IdentityFingerprint: strings.TrimSpace(identityFingerprint), CreatedAt: time.Now().UTC(),
+	}
+	if grant.Server == "" || grant.ConfigSource == "" || grant.IdentityFingerprint == "" {
+		return fmt.Errorf("MCP launch grant requires server, config source, and identity")
+	}
+	if scope == ScopeWorkspace {
+		grant.WorkspaceFingerprint = m.workspaceFingerprint
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if scope == ScopeSession {
+		m.sessionLaunch = upsertLaunchGrant(m.sessionLaunch, grant)
+		return nil
+	}
+	m.sessionLaunch = removeLaunchGrantSlot(m.sessionLaunch, grant.Server, grant.ConfigSource, m.workspaceFingerprint)
+	return m.updatePersistent(func(state *State) {
+		state.LaunchGrants = upsertLaunchGrant(state.LaunchGrants, grant)
+	})
+}
+
+// LaunchAuthorized checks consent without starting the server. A matching
+// capability receipt from an earlier version also counts as consent so the new
+// launch gate does not re-prompt already trusted projects.
+func (m *Manager) LaunchAuthorized(server, configSource, identityFingerprint string) (authorized, changed bool, err error) {
+	server = strings.TrimSpace(server)
+	configSource = strings.TrimSpace(configSource)
+	identityFingerprint = strings.TrimSpace(identityFingerprint)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state, err := m.Load()
+	if err != nil {
+		return false, false, err
+	}
+	changed = false
+	for _, grant := range append(append([]LaunchGrant(nil), m.sessionLaunch...), state.LaunchGrants...) {
+		if grant.Server != server || grant.ConfigSource != configSource {
+			continue
+		}
+		if grant.Scope != ScopeSession && grant.WorkspaceFingerprint != m.workspaceFingerprint {
+			continue
+		}
+		if grant.IdentityFingerprint == identityFingerprint {
+			return true, false, nil
+		}
+		changed = true
+	}
+	receipts := append(append([]Receipt(nil), m.session...), state.Receipts...)
+	for _, receipt := range receipts {
+		if receipt.Server != server || receipt.ConfigSource != configSource {
+			continue
+		}
+		if receipt.Scope != ScopeGlobal && receipt.WorkspaceFingerprint != m.workspaceFingerprint {
+			continue
+		}
+		if receipt.IdentityFingerprint == identityFingerprint {
+			return true, false, nil
+		}
+		changed = true
+	}
+	return false, changed, nil
+}
+
 func (m *Manager) trust(scope Scope, source Source, server, configSource, identityFingerprint, catalogEntryID string, capabilities []Capability, selectedReaders map[string]bool) error {
 	if !validScope(scope) {
 		return fmt.Errorf("invalid MCP trust scope %q", scope)
@@ -328,6 +465,9 @@ func (m *Manager) trust(scope Scope, source Source, server, configSource, identi
 	if scope == ScopeSession {
 		m.session = upsertReceipt(m.session, receipt)
 		return nil
+	}
+	if scope == ScopeWorkspace {
+		m.session = removeReceiptSlot(m.session, receipt.Server, receipt.ConfigSource, m.workspaceFingerprint)
 	}
 	return m.updatePersistent(func(state *State) {
 		state.Receipts = upsertReceipt(state.Receipts, receipt)
@@ -385,8 +525,10 @@ func (m *Manager) Revoke(server string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.session = removeReceipts(m.session, server, m.workspaceFingerprint)
+	m.sessionLaunch = removeLaunchGrants(m.sessionLaunch, server, m.workspaceFingerprint)
 	return m.updatePersistent(func(state *State) {
 		state.Receipts = removeReceipts(state.Receipts, server, m.workspaceFingerprint)
+		state.LaunchGrants = removeLaunchGrants(state.LaunchGrants, server, m.workspaceFingerprint)
 	})
 }
 
@@ -668,26 +810,46 @@ func (m *Manager) evaluate(server, configSource, identityFingerprint string, cap
 // from demanding a redundant re-trust. Remove together with the legacy URL
 // fingerprint calculator (see docs/MIGRATING.md).
 func (m *Manager) MigrateIdentityFingerprint(server, configSource, legacyFingerprint, currentFingerprint string, capabilities []Capability) (bool, error) {
+	return m.MigrateIdentityFingerprints(server, configSource, []string{configSource}, []string{legacyFingerprint}, currentFingerprint, capabilities)
+}
+
+// MigrateIdentityFingerprints upgrades receipts from a bounded set of legacy
+// source labels and identity digests. It is used when runtime provenance becomes
+// more precise (for example workspace_config -> user_config/project_mcp_json)
+// without treating that host-only classification change as a new server.
+func (m *Manager) MigrateIdentityFingerprints(server, configSource string, legacySources, legacyFingerprints []string, currentFingerprint string, capabilities []Capability) (bool, error) {
 	server = strings.TrimSpace(server)
 	configSource = strings.TrimSpace(configSource)
-	legacyFingerprint = strings.TrimSpace(legacyFingerprint)
 	currentFingerprint = strings.TrimSpace(currentFingerprint)
-	if server == "" || legacyFingerprint == "" || currentFingerprint == "" || legacyFingerprint == currentFingerprint {
+	sourceSet := map[string]bool{}
+	for _, source := range legacySources {
+		if source = strings.TrimSpace(source); source != "" {
+			sourceSet[source] = true
+		}
+	}
+	fingerprintSet := map[string]bool{}
+	for _, fingerprint := range legacyFingerprints {
+		if fingerprint = strings.TrimSpace(fingerprint); fingerprint != "" && fingerprint != currentFingerprint {
+			fingerprintSet[fingerprint] = true
+		}
+	}
+	if server == "" || configSource == "" || currentFingerprint == "" || len(sourceSet) == 0 || len(fingerprintSet) == 0 {
 		return false, nil
 	}
 	upgrade := func(receipts []Receipt) bool {
 		changed := false
 		for i := range receipts {
 			r := &receipts[i]
-			if r.Server != server || r.ConfigSource != configSource {
+			if r.Server != server || !sourceSet[r.ConfigSource] {
 				continue
 			}
 			if r.Scope != ScopeGlobal && r.WorkspaceFingerprint != m.workspaceFingerprint {
 				continue
 			}
-			if r.IdentityFingerprint != legacyFingerprint || receiptCapabilitiesChanged(*r, capabilities) {
+			if !fingerprintSet[r.IdentityFingerprint] || receiptCapabilitiesChanged(*r, capabilities) {
 				continue
 			}
+			r.ConfigSource = configSource
 			r.IdentityFingerprint = currentFingerprint
 			r.LastVerifiedAt = time.Now().UTC()
 			changed = true
@@ -864,6 +1026,7 @@ func normalizeState(state *State) {
 		state.Version = StoreVersion
 	}
 	state.Receipts = dedupeReceipts(state.Receipts)
+	state.LaunchGrants = dedupeLaunchGrants(state.LaunchGrants)
 	for i := range state.Receipts {
 		r := &state.Receipts[i]
 		sort.Slice(r.Tools, func(i, j int) bool { return r.Tools[i].RawName < r.Tools[j].RawName })
@@ -885,8 +1048,40 @@ func normalizeState(state *State) {
 		}
 		return a.Locator < b.Locator
 	})
+	sort.Slice(state.LaunchGrants, func(i, j int) bool {
+		a, b := state.LaunchGrants[i], state.LaunchGrants[j]
+		if a.Server != b.Server {
+			return a.Server < b.Server
+		}
+		if a.Scope != b.Scope {
+			return a.Scope < b.Scope
+		}
+		return a.ConfigSource < b.ConfigSource
+	})
 	state.OfficialDenials = cleanStrings(state.OfficialDenials, false)
 	state.LegacyImports = cleanStrings(state.LegacyImports, false)
+}
+
+func upsertLaunchGrant(grants []LaunchGrant, grant LaunchGrant) []LaunchGrant {
+	for i := range grants {
+		if sameLaunchGrantKey(grants[i], grant) {
+			grants[i] = grant
+			return grants
+		}
+	}
+	return append(grants, grant)
+}
+
+func dedupeLaunchGrants(grants []LaunchGrant) []LaunchGrant {
+	out := make([]LaunchGrant, 0, len(grants))
+	for _, grant := range grants {
+		out = upsertLaunchGrant(out, grant)
+	}
+	return out
+}
+
+func sameLaunchGrantKey(a, b LaunchGrant) bool {
+	return a.Scope == b.Scope && a.WorkspaceFingerprint == b.WorkspaceFingerprint && a.Server == b.Server && a.ConfigSource == b.ConfigSource
 }
 
 func upsertReceipt(receipts []Receipt, receipt Receipt) []Receipt {
@@ -941,6 +1136,39 @@ func removeReceipts(receipts []Receipt, server, workspaceFP string) []Receipt {
 	out := receipts[:0]
 	for _, receipt := range receipts {
 		if receipt.Server == server && (receipt.Scope == ScopeGlobal || receipt.WorkspaceFingerprint == workspaceFP) {
+			continue
+		}
+		out = append(out, receipt)
+	}
+	return out
+}
+
+func removeLaunchGrants(grants []LaunchGrant, server, workspaceFP string) []LaunchGrant {
+	out := grants[:0]
+	for _, grant := range grants {
+		if grant.Server == server && (grant.Scope == ScopeSession || grant.WorkspaceFingerprint == workspaceFP) {
+			continue
+		}
+		out = append(out, grant)
+	}
+	return out
+}
+
+func removeLaunchGrantSlot(grants []LaunchGrant, server, configSource, workspaceFP string) []LaunchGrant {
+	out := grants[:0]
+	for _, grant := range grants {
+		if grant.Server == server && grant.ConfigSource == configSource && (grant.Scope == ScopeSession || grant.WorkspaceFingerprint == workspaceFP) {
+			continue
+		}
+		out = append(out, grant)
+	}
+	return out
+}
+
+func removeReceiptSlot(receipts []Receipt, server, configSource, workspaceFP string) []Receipt {
+	out := receipts[:0]
+	for _, receipt := range receipts {
+		if receipt.Server == server && receipt.ConfigSource == configSource && receipt.Scope == ScopeSession && receipt.WorkspaceFingerprint == workspaceFP {
 			continue
 		}
 		out = append(out, receipt)

--- a/internal/mcptrust/trust.go
+++ b/internal/mcptrust/trust.go
@@ -1349,7 +1349,7 @@ func acquireFileLock(path string, wait time.Duration) (func(), error) {
 			}
 			return func() { removeOwnedFileLock(path, owner) }, nil
 		}
-		if !errors.Is(err, os.ErrExist) {
+		if !errors.Is(err, os.ErrExist) && !trustLockContention(err) {
 			return nil, err
 		}
 		if info, statErr := os.Stat(path); statErr == nil && time.Since(info.ModTime()) > 30*time.Second {

--- a/internal/mcptrust/trust_test.go
+++ b/internal/mcptrust/trust_test.go
@@ -177,6 +177,30 @@ func TestTrustScopesAndFineGrainedDrift(t *testing.T) {
 	}
 }
 
+func TestWorkspaceTrustSupersedesStaleSessionLaunchAndReceipt(t *testing.T) {
+	m := NewManager(filepath.Join(t.TempDir(), StateFilename), "/workspace")
+	if err := m.TrustLaunch(ScopeSession, "srv", "project_config", "old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Trust(ScopeSession, SourceUser, "srv", "project_config", "old", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.TrustLaunch(ScopeWorkspace, "srv", "project_config", "current"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Trust(ScopeWorkspace, SourceUser, "srv", "project_config", "current", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	authorized, changed, err := m.LaunchAuthorized("srv", "project_config", "current")
+	if err != nil || !authorized || changed {
+		t.Fatalf("workspace launch authorization = (authorized=%v changed=%v err=%v)", authorized, changed, err)
+	}
+	has, changed, err := m.IdentityChanged("srv", "project_config", "current")
+	if err != nil || !has || changed {
+		t.Fatalf("workspace receipt = (has=%v changed=%v err=%v)", has, changed, err)
+	}
+}
+
 func TestSessionTrustIsNotPersisted(t *testing.T) {
 	path := filepath.Join(t.TempDir(), StateFilename)
 	m := NewManager(path, "/workspace")

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -298,7 +298,6 @@ func TestSpecFingerprintIgnoresHostLocalTrustAndIsolation(t *testing.T) {
 	changed.ReaderSandbox = sandbox.Spec{Mode: "enforce", Network: true, WriteRoots: []string{"/host/state"}, MinimalWrites: true}
 	changed.WriterSandbox = sandbox.Spec{Mode: "enforce", WriteRoots: []string{"/workspace"}, MinimalWrites: true}
 	changed.StateDir = "/host/state"
-	changed.OneShot = true
 	if got, want := SpecFingerprint(changed), SpecFingerprint(base); got != want {
 		t.Fatalf("host-local security state changed provider cache fingerprint: %q != %q", got, want)
 	}

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -268,7 +268,7 @@ func (lt *lazyTool) MCPApprovalMode() string {
 	if lt.shared == nil {
 		return tool.MCPApprovalAuto
 	}
-	return lt.shared.spec.toolApprovalMode(lt.rawName)
+	return lt.shared.spec.ToolApprovalMode(lt.rawName)
 }
 func (lt *lazyTool) MCPApprovalReviewer() string {
 	if lt.shared == nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -76,7 +76,8 @@ type Spec struct {
 	// normalized MCP tool names back into raw server-local names.
 	ReadOnlyModelToolNames map[string]bool
 	// DefaultToolsApprovalMode controls MCP approval when no raw-tool override
-	// exists: auto|prompt|writes|approve. Empty is auto.
+	// exists: auto|prompt|writes|approve. Empty uses auto unless the composition
+	// root marks this explicitly user-authorized server for implicit approval.
 	DefaultToolsApprovalMode string
 	// ToolApprovalModes overrides approval behavior by raw server-local tool name.
 	ToolApprovalModes map[string]string

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -90,6 +90,9 @@ type Spec struct {
 	// ConfigSource disambiguates otherwise identical server names coming from
 	// workspace config, a host transport, or a verified plugin package.
 	ConfigSource           string
+	AutoTrust              bool
+	ImplicitApproval       bool
+	RequireLaunchApproval  bool
 	OfficialCatalogEntryID string
 	OfficialReaderNames    []string
 	PackageDigest          string
@@ -103,12 +106,12 @@ type Spec struct {
 	LauncherLocator         string
 	LauncherResolvedVersion string
 	LauncherDigest          string
-	// ReaderSandbox confines the long-lived initialize/list/read lane. The
-	// writer profile is used only by one-shot, post-approval stdio calls.
+	// ReaderSandbox and WriterSandbox describe the host isolation policy used
+	// for trust evaluation. The persistent stdio process runs with WriterSandbox
+	// so one stateful session is preserved across reads and writes.
 	ReaderSandbox sandbox.Spec
 	WriterSandbox sandbox.Spec
 	StateDir      string
-	OneShot       bool
 	// AllowIdentityDriftPreflight is set only by explicit user verification.
 	// Ordinary/lazy starts stop a changed server before creating its process.
 	AllowIdentityDriftPreflight bool
@@ -632,10 +635,11 @@ type SecurityStatus struct {
 // session or workspace trust. It contains names and safety classes, never args,
 // environment/header values, URLs, or credentials.
 type TrustInspection struct {
-	Security    SecurityStatus
-	Readers     []string
-	Writers     []string
-	Destructive []string
+	Security               SecurityStatus
+	Readers                []string
+	Writers                []string
+	Destructive            []string
+	RequiresLaunchApproval bool
 }
 
 // ServerStatus summarises one connected server for the /mcp command.
@@ -665,9 +669,22 @@ func (e *identityChangedError) Error() string {
 	return fmt.Sprintf("MCP server %q identity changed; blocked before process or network startup and requires explicit re-verification", e.server)
 }
 
+type launchApprovalError struct {
+	server  string
+	changed bool
+}
+
+func (e *launchApprovalError) Error() string {
+	if e.changed {
+		return fmt.Sprintf("project-provided MCP server %q changed; blocked before process or network startup and requires explicit re-authorization", e.server)
+	}
+	return fmt.Sprintf("project-provided MCP server %q is blocked before process or network startup until the user authorizes it", e.server)
+}
+
 func requiresReverification(err error) bool {
-	var target *identityChangedError
-	return errors.As(err, &target)
+	var identityTarget *identityChangedError
+	var launchTarget *launchApprovalError
+	return errors.As(err, &identityTarget) || errors.As(err, &launchTarget)
 }
 
 // Servers returns a status summary per connected server, in connection order.
@@ -745,6 +762,45 @@ func (h *Host) InspectTrust(name string) (TrustInspection, error) {
 // closes it without invoking any tool. Callers use this for an unconnected
 // server before presenting the trust decision.
 func InspectSpec(ctx context.Context, spec Spec) (TrustInspection, error) {
+	var err error
+	spec, err = applyStoredLauncherLock(spec)
+	if err != nil {
+		return TrustInspection{}, err
+	}
+	identity, err := specIdentityFingerprint(ctx, spec)
+	if err != nil {
+		return TrustInspection{}, err
+	}
+	if spec.TrustManager != nil {
+		if _, err := migrateLegacyIdentity(spec, identity, nil); err != nil {
+			return TrustInspection{}, err
+		}
+	}
+	if spec.RequireLaunchApproval {
+		if spec.TrustManager == nil {
+			return TrustInspection{}, fmt.Errorf("MCP trust store is unavailable")
+		}
+		authorized, changed, err := spec.TrustManager.LaunchAuthorized(spec.Name, trustConfigSource(spec), identity)
+		if err != nil {
+			return TrustInspection{}, err
+		}
+		if !authorized {
+			state := mcptrust.TrustUntrusted
+			if changed {
+				state = mcptrust.TrustChanged
+			}
+			return TrustInspection{
+				Security: SecurityStatus{
+					Name:            spec.Name,
+					TrustState:      state,
+					IdentityChanged: changed,
+					Identity:        identity,
+					IsolationState:  isolationStateForSpec(spec),
+				},
+				RequiresLaunchApproval: true,
+			}, nil
+		}
+	}
 	spec.AllowIdentityDriftPreflight = true
 	client, err := start(ctx, ctx, spec)
 	if err != nil {
@@ -804,6 +860,23 @@ func SetSpecTrust(ctx context.Context, spec Spec, decision string) error {
 			return fmt.Errorf("persistent trust is unavailable; use session trust or make the launcher immutable: %w", err)
 		}
 	}
+	spec, err := applyStoredLauncherLock(spec)
+	if err != nil {
+		return err
+	}
+	identity, err := specIdentityFingerprint(ctx, spec)
+	if err != nil {
+		return err
+	}
+	if spec.RequireLaunchApproval {
+		scope := mcptrust.ScopeSession
+		if decision == "workspace" {
+			scope = mcptrust.ScopeWorkspace
+		}
+		if err := manager.TrustLaunch(scope, spec.Name, trustConfigSource(spec), identity); err != nil {
+			return err
+		}
+	}
 	spec.AllowIdentityDriftPreflight = true
 	client, err := start(ctx, ctx, spec)
 	if err != nil {
@@ -815,7 +888,7 @@ func SetSpecTrust(ctx context.Context, spec Spec, decision string) error {
 		return err
 	}
 	client.toolsMu.Lock()
-	identity := client.identityFingerprint
+	identity = client.identityFingerprint
 	capabilities := append([]mcptrust.Capability(nil), client.capabilities...)
 	cache := CachedSchema{
 		SpecHash: SpecFingerprint(spec),
@@ -1366,10 +1439,41 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if s.TrustManager != nil {
+		configSource := trustConfigSource(s)
+		hasCurrent, currentChanged, checkErr := s.TrustManager.IdentityChanged(s.Name, configSource, identity)
+		if checkErr != nil {
+			return nil, checkErr
+		}
+		hasLegacySource := false
+		if configSource != "workspace_config" {
+			hasLegacySource, checkErr = s.TrustManager.HasReceipt(s.Name, "workspace_config")
+			if checkErr != nil {
+				return nil, checkErr
+			}
+		}
+		if currentChanged || (!hasCurrent && hasLegacySource) {
+			if _, migrateErr := migrateLegacyIdentity(s, identity, nil); migrateErr != nil {
+				return nil, migrateErr
+			}
+		}
+	}
+	if s.RequireLaunchApproval {
+		if s.TrustManager == nil {
+			return nil, fmt.Errorf("MCP trust store is unavailable")
+		}
+		authorized, changed, checkErr := s.TrustManager.LaunchAuthorized(s.Name, trustConfigSource(s), identity)
+		if checkErr != nil {
+			return nil, checkErr
+		}
+		if !authorized {
+			return nil, &launchApprovalError{server: s.Name, changed: changed}
+		}
+	}
 	if s.TrustManager != nil && !s.AllowIdentityDriftPreflight {
 		if _, changed, checkErr := s.TrustManager.IdentityChanged(s.Name, trustConfigSource(s), identity); checkErr != nil {
 			return nil, checkErr
-		} else if changed && !migrateLegacyIdentity(s, identity) {
+		} else if changed && !s.AutoTrust {
 			// A receipt that exactly matches this spec's legacy URL fingerprint
 			// migrated above instead of blocking: eager and cache-miss servers
 			// must reach the credential-aware rollout too, not only paths that
@@ -1561,6 +1665,9 @@ func (s Spec) toolApprovalMode(rawName string) string {
 	if mode := strings.TrimSpace(s.ToolApprovalModes[rawName]); mode != "" {
 		return tool.NormalizeMCPApprovalMode(mode)
 	}
+	if strings.TrimSpace(s.DefaultToolsApprovalMode) == "" && s.ImplicitApproval {
+		return tool.MCPApprovalApprove
+	}
 	return tool.NormalizeMCPApprovalMode(s.DefaultToolsApprovalMode)
 }
 
@@ -1680,10 +1787,8 @@ func (c *Client) listToolsRaw(ctx context.Context) ([]mcpTool, error) {
 	return out.Tools, nil
 }
 
-// listToolsRawSettled gives dynamically registering servers the same bounded
-// startup window in both the long-lived reader lane and a fresh one-shot writer
-// lane. Without this, a writer that is present a few milliseconds after
-// initialize can appear in the UI but then fail every approved invocation.
+// listToolsRawSettled gives dynamically registering servers a bounded startup
+// window before their initial tool catalog is considered complete.
 func (c *Client) listToolsRawSettled(ctx context.Context) ([]mcpTool, error) {
 	out, err := c.listToolsRaw(ctx)
 	if err != nil || !c.hasTools || len(out) > 0 {
@@ -1930,14 +2035,12 @@ func (t *remoteTool) ExecuteWithImages(ctx context.Context, args json.RawMessage
 		// Final, linearizable check for a reader-authorized call: the snapshot
 		// above and every trust mutation (catalog revocations, live security
 		// reconciliation) serialize on the owning client's toolsMu. A call that
-		// was approved as a non-destructive reader must never promote itself
-		// into the one-shot writer lane or execute after trust changed — state
-		// drift here returns an actionable error instead of dispatching.
+		// was approved as a non-destructive reader must never execute after trust
+		// changed — state drift here returns an actionable error instead of
+		// dispatching.
 		if !readOnly || destructive || (intent.CapabilityFingerprint != "" && fingerprint != "" && fingerprint != intent.CapabilityFingerprint) {
 			return "", nil, fmt.Errorf("MCP server %q no longer classifies tool %q as a trusted reader; the call was blocked before dispatch — re-verify the server and request fresh approval before retrying", t.client.name, t.rawName)
 		}
-	} else if t.client != nil && t.client.usesOneShotWriterLane() && (!readOnly || destructive) {
-		return t.client.callOneShotTool(ctx, t, argMap)
 	}
 	res, err := t.client.call(ctx, "tools/call", map[string]any{
 		"name":      t.rawName,
@@ -1945,51 +2048,6 @@ func (t *remoteTool) ExecuteWithImages(ctx context.Context, args json.RawMessage
 	})
 	if err != nil {
 		return "", nil, err
-	}
-	return parseToolResult(res)
-}
-
-func (c *Client) usesOneShotWriterLane() bool {
-	transport := strings.ToLower(strings.TrimSpace(c.spec.Type))
-	return (transport == "" || transport == "stdio") && (c.spec.WriterSandbox.Enforce() || strings.TrimSpace(c.spec.StateDir) != "")
-}
-
-func (c *Client) callOneShotTool(ctx context.Context, expected *remoteTool, args map[string]any) (string, []string, error) {
-	spec := c.spec
-	spec.OneShot = true
-	writer, err := start(ctx, ctx, spec)
-	if err != nil {
-		return "", nil, fmt.Errorf("start isolated one-shot MCP writer %q: %w", c.name, err)
-	}
-	defer writer.close()
-	tools, err := writer.listToolsRawSettled(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("revalidate one-shot MCP writer %q: %w", c.name, err)
-	}
-	if err := validateMCPToolNames(tools); err != nil {
-		return "", nil, fmt.Errorf("revalidate one-shot MCP writer %q: %w", c.name, err)
-	}
-	var live *mcpTool
-	for i := range tools {
-		if tools[i].Name == expected.rawName {
-			live = &tools[i]
-			break
-		}
-	}
-	if live == nil {
-		return "", nil, fmt.Errorf("MCP server %q no longer exposes tool %q; current call was blocked before execution", c.name, expected.rawName)
-	}
-	schema, err := normalizeAndValidateToolSchema(live.InputSchema)
-	if err != nil {
-		return "", nil, fmt.Errorf("MCP server %q returned an invalid schema for %q; current call was blocked before execution: %w", c.name, expected.rawName, err)
-	}
-	liveFingerprint := capabilityFingerprint(capabilityOf(spec, *live, schema))
-	if expected.capabilityFingerprint == "" || liveFingerprint != expected.capabilityFingerprint {
-		return "", nil, fmt.Errorf("MCP server %q changed the security schema for tool %q; current call was blocked before execution and requires review", c.name, expected.rawName)
-	}
-	res, err := writer.call(ctx, "tools/call", map[string]any{"name": expected.rawName, "arguments": args})
-	if err != nil {
-		return "", nil, fmt.Errorf("one-shot MCP writer %q failed (stateful writers are not supported): %w", expected.rawName, err)
 	}
 	return parseToolResult(res)
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1662,7 +1662,13 @@ func (s Spec) toolReadOnlyOverride(rawName, visibleName string) bool {
 	return s.ReadOnlyToolNames[rawName] || s.ReadOnlyModelToolNames[toolName(s.Name, visibleName)]
 }
 
-func (s Spec) toolApprovalMode(rawName string) string {
+// ToolApprovalMode resolves the effective approval mode for one raw tool
+// name: an explicit per-tool override wins, an unset server default becomes
+// direct approval for user-authorized (implicit approval) sources, and the
+// normalized server default applies otherwise. Every approval surface,
+// including proxies outside this package, must use this resolution instead of
+// re-deriving the policy from Spec fields.
+func (s Spec) ToolApprovalMode(rawName string) string {
 	if mode := strings.TrimSpace(s.ToolApprovalModes[rawName]); mode != "" {
 		return tool.NormalizeMCPApprovalMode(mode)
 	}
@@ -1999,7 +2005,7 @@ func (t *remoteTool) MCPApprovalMode() string {
 	if t.client == nil {
 		return tool.MCPApprovalAuto
 	}
-	return t.client.spec.toolApprovalMode(t.rawName)
+	return t.client.spec.ToolApprovalMode(t.rawName)
 }
 
 func (t *remoteTool) MCPApprovalReviewer() string {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1573,13 +1573,15 @@ func TestProjectLaunchApprovalBlocksBeforeProcessStart(t *testing.T) {
 }
 
 func TestLegacyPolicyCoupledIdentityAndWorkspaceSourceMigrate(t *testing.T) {
-	manager := mcptrust.NewManager(filepath.Join(t.TempDir(), mcptrust.StateFilename), "/workspace")
+	workspace := t.TempDir()
+	secret := t.TempDir()
+	manager := mcptrust.NewManager(filepath.Join(t.TempDir(), mcptrust.StateFilename), workspace)
 	spec := Spec{
 		Name: "legacy-policy", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
 		Env:          map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
 		ConfigSource: "project_config", TrustManager: manager, RequireLaunchApproval: true,
-		ReaderSandbox: sandbox.Spec{Mode: "enforce", ReadRoots: []string{"/workspace"}, ForbidReadRoots: []string{"/secret"}},
-		WriterSandbox: sandbox.Spec{Mode: "enforce", WriteRoots: []string{"/workspace"}},
+		ReaderSandbox: sandbox.Spec{Mode: "enforce", ReadRoots: []string{workspace}, ForbidReadRoots: []string{secret}},
+		WriterSandbox: sandbox.Spec{Mode: "enforce", WriteRoots: []string{workspace}},
 	}
 	identity, err := buildSpecIdentity(context.Background(), spec)
 	if err != nil {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -511,10 +511,26 @@ func TestMCPApprovalPolicyDoesNotChangeProviderSchemas(t *testing.T) {
 	configured := makeSchemas(Spec{
 		Name: "admin", DefaultToolsApprovalMode: "writes",
 		ToolApprovalModes: map[string]string{"wipe": "prompt"},
-		ApprovalsReviewer: "auto_review",
+		ApprovalsReviewer: "auto_review", ImplicitApproval: true, AutoTrust: true,
 	})
 	if !bytes.Equal(baseline, configured) {
 		t.Fatalf("provider schemas changed with local approval policy:\nbaseline=%s\nconfigured=%s", baseline, configured)
+	}
+}
+
+func TestUserAuthorizedMCPDefaultsToDirectApprovalWithoutChangingOverrides(t *testing.T) {
+	spec := Spec{Name: "user-server", ImplicitApproval: true}
+	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalApprove {
+		t.Fatalf("implicit user approval mode = %q, want approve", got)
+	}
+	spec.ToolApprovalModes = map[string]string{"write": "prompt"}
+	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalPrompt {
+		t.Fatalf("explicit per-tool policy = %q, want prompt", got)
+	}
+	spec.ToolApprovalModes = nil
+	spec.DefaultToolsApprovalMode = "writes"
+	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalWrites {
+		t.Fatalf("explicit server policy = %q, want writes", got)
 	}
 }
 
@@ -1161,8 +1177,7 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 	defer os.Exit(0)
-	helperProcessNumber := incrementHelperCounter(os.Getenv("GO_WANT_HELPER_START_COUNT"))
-	toolsListCount := 0
+	incrementHelperCounter(os.Getenv("GO_WANT_HELPER_START_COUNT"))
 
 	var initDelay time.Duration
 	if ms := os.Getenv("GO_WANT_HELPER_INIT_MS"); ms != "" {
@@ -1197,22 +1212,10 @@ func TestHelperProcess(t *testing.T) {
 		var result any
 		switch req.Method {
 		case "initialize":
-			for _, key := range []string{
-				"GO_WANT_HELPER_INIT_WRITE_WORKSPACE",
-				"GO_WANT_HELPER_INIT_WRITE_HOME",
-				"GO_WANT_HELPER_INIT_WRITE_STATE",
-			} {
-				if path := strings.TrimSpace(os.Getenv(key)); path != "" {
-					_ = os.WriteFile(path, []byte("initialize write"), 0o600)
-				}
-			}
 			if initDelay > 0 {
 				time.Sleep(initDelay)
 			}
 			caps := map[string]any{}
-			if os.Getenv("GO_WANT_HELPER_EMPTY_FIRST_TOOLS") == "1" {
-				caps["tools"] = map[string]any{}
-			}
 			if os.Getenv("GO_WANT_HELPER_PROMPTS") == "1" {
 				caps["prompts"] = map[string]any{}
 			}
@@ -1233,15 +1236,6 @@ func TestHelperProcess(t *testing.T) {
 				"arguments":   []map[string]any{},
 			}}}
 		case "tools/list":
-			toolsListCount++
-			if os.Getenv("GO_WANT_HELPER_EMPTY_FIRST_TOOLS") == "1" && toolsListCount == 1 {
-				result = map[string]any{"tools": []map[string]any{}}
-				break
-			}
-			messageType := "string"
-			if os.Getenv("GO_WANT_HELPER_DRIFT_ON_SECOND") == "1" && helperProcessNumber > 1 {
-				messageType = "integer"
-			}
 			result = map[string]any{"tools": []map[string]any{{
 				"name":        "zed",
 				"description": "Sorted after echo.",
@@ -1251,7 +1245,7 @@ func TestHelperProcess(t *testing.T) {
 				"description": "Echo back the message.",
 				"inputSchema": map[string]any{
 					"type":       "object",
-					"properties": map[string]any{"msg": map[string]any{"type": messageType}},
+					"properties": map[string]any{"msg": map[string]any{"type": "string"}},
 					"required":   []string{"z", "msg"},
 				},
 			}}}
@@ -1312,12 +1306,12 @@ func findToolByName(tools []tool.Tool, name string) tool.Tool {
 	return nil
 }
 
-func TestStdioWriterUsesFreshOneShotProcess(t *testing.T) {
+func TestStdioWriterPreservesPersistentProcessByDefault(t *testing.T) {
 	stateDir := t.TempDir()
 	startCount := filepath.Join(t.TempDir(), "starts")
 	callCount := filepath.Join(t.TempDir(), "calls")
 	spec := Spec{
-		Name: "writer-lane", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
+		Name: "stateful-writer", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
 		Env: map[string]string{
 			"GO_WANT_HELPER_PROCESS":     "1",
 			"GO_WANT_HELPER_START_COUNT": startCount,
@@ -1332,7 +1326,7 @@ func TestStdioWriterUsesFreshOneShotProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer host.Close()
-	writer := findToolByName(tools, "mcp__writer-lane__echo")
+	writer := findToolByName(tools, "mcp__stateful-writer__echo")
 	if writer == nil {
 		t.Fatalf("writer tool missing from %v", toolNames(tools))
 	}
@@ -1342,36 +1336,11 @@ func TestStdioWriterUsesFreshOneShotProcess(t *testing.T) {
 	if _, err := writer.Execute(ctx, json.RawMessage(`{"msg":"two","z":"ok"}`)); err != nil {
 		t.Fatal(err)
 	}
-	if got := readHelperCounter(t, startCount); got != 3 {
-		t.Fatalf("process starts = %d, want one reader plus two one-shot writers", got)
+	if got := readHelperCounter(t, startCount); got != 1 {
+		t.Fatalf("process starts = %d, want one persistent MCP process", got)
 	}
 	if got := readHelperCounter(t, callCount); got != 2 {
-		t.Fatalf("tool calls = %d, want exactly one per writer process", got)
-	}
-}
-
-func TestStdioOneShotWriterWaitsForDynamicToolRegistration(t *testing.T) {
-	spec := Spec{
-		Name: "dynamic-writer", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
-		Env: map[string]string{
-			"GO_WANT_HELPER_PROCESS":           "1",
-			"GO_WANT_HELPER_EMPTY_FIRST_TOOLS": "1",
-		},
-		StateDir: t.TempDir(),
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	host, tools, err := StartAll(ctx, []Spec{spec})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer host.Close()
-	writer := findToolByName(tools, "mcp__dynamic-writer__echo")
-	if writer == nil {
-		t.Fatalf("writer tool missing from %v", toolNames(tools))
-	}
-	if _, err := writer.Execute(ctx, json.RawMessage(`{"msg":"ready","z":"ok"}`)); err != nil {
-		t.Fatalf("dynamic one-shot writer call: %v", err)
+		t.Fatalf("tool calls = %d, want two calls on the persistent process", got)
 	}
 }
 
@@ -1385,98 +1354,6 @@ func TestValidateMCPToolNamesRejectsAmbiguousLists(t *testing.T) {
 				t.Fatalf("validateMCPToolNames(%+v) succeeded", tools)
 			}
 		})
-	}
-}
-
-func TestStdioWriterSchemaDriftBlocksBeforeToolCall(t *testing.T) {
-	startCount := filepath.Join(t.TempDir(), "starts")
-	callCount := filepath.Join(t.TempDir(), "calls")
-	spec := Spec{
-		Name: "writer-drift", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
-		Env: map[string]string{
-			"GO_WANT_HELPER_PROCESS":         "1",
-			"GO_WANT_HELPER_START_COUNT":     startCount,
-			"GO_WANT_HELPER_CALL_COUNT":      callCount,
-			"GO_WANT_HELPER_DRIFT_ON_SECOND": "1",
-		},
-		StateDir: t.TempDir(),
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	host, tools, err := StartAll(ctx, []Spec{spec})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer host.Close()
-	writer := findToolByName(tools, "mcp__writer-drift__echo")
-	if writer == nil {
-		t.Fatalf("writer tool missing from %v", toolNames(tools))
-	}
-	if _, err := writer.Execute(ctx, json.RawMessage(`{"msg":"blocked","z":"ok"}`)); err == nil || !strings.Contains(err.Error(), "blocked before execution") {
-		t.Fatalf("schema drift error = %v", err)
-	}
-	if got := readHelperCounter(t, startCount); got != 2 {
-		t.Fatalf("process starts = %d, want reader plus revalidation writer", got)
-	}
-	if got := readHelperCounter(t, callCount); got != 0 {
-		t.Fatalf("tool calls = %d, want 0 after drift", got)
-	}
-}
-
-func TestStdioReaderSandboxBlocksInitializeSideEffects(t *testing.T) {
-	if !sandbox.Available() {
-		t.Skip("OS sandbox backend unavailable")
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("home directory unavailable: %v", err)
-	}
-	workspace, err := os.MkdirTemp(home, ".reasonix-mcp-workspace-")
-	if err != nil {
-		t.Skipf("cannot create workspace fixture: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(workspace) })
-	outside, err := os.MkdirTemp(home, ".reasonix-mcp-home-")
-	if err != nil {
-		t.Skipf("cannot create home fixture: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(outside) })
-	stateDir, err := os.MkdirTemp(home, ".reasonix-mcp-state-")
-	if err != nil {
-		t.Skipf("cannot create state fixture: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(stateDir) })
-
-	workspaceWrite := filepath.Join(workspace, "initialize-write")
-	homeWrite := filepath.Join(outside, "initialize-write")
-	stateWrite := filepath.Join(stateDir, "tmp", "initialize-write")
-	spec := Spec{
-		Name: "reader-sandbox", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"}, Dir: workspace,
-		Env: map[string]string{
-			"GO_WANT_HELPER_PROCESS":              "1",
-			"GO_WANT_HELPER_INIT_WRITE_WORKSPACE": workspaceWrite,
-			"GO_WANT_HELPER_INIT_WRITE_HOME":      homeWrite,
-			"GO_WANT_HELPER_INIT_WRITE_STATE":     stateWrite,
-		},
-		StateDir: stateDir,
-		ReaderSandbox: sandbox.Spec{
-			Mode: "enforce", WriteRoots: []string{stateDir}, ReadRoots: []string{workspace, home}, AppContainerWriteRoots: []string{stateDir}, Network: true, MinimalWrites: true,
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	host, _, err := StartAll(ctx, []Spec{spec})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer host.Close()
-	for _, path := range []string{workspaceWrite, homeWrite} {
-		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("reader initialize escaped into %s: stat error %v", path, err)
-		}
-	}
-	if body, err := os.ReadFile(stateWrite); err != nil || string(body) != "initialize write" {
-		t.Fatalf("reader private state write = %q, %v; want allowed", body, err)
 	}
 }
 
@@ -1546,7 +1423,7 @@ func TestOfficialIdentityIsStableAcrossWorkspaceIsolationRoots(t *testing.T) {
 	}
 }
 
-func TestWorkspaceIdentityTracksForbiddenReadRoots(t *testing.T) {
+func TestWorkspaceIdentityIgnoresHostPolicyChanges(t *testing.T) {
 	base := Spec{
 		Name: "custom", Command: os.Args[0], ConfigSource: "workspace_config",
 		ReaderSandbox: sandbox.Spec{Mode: "enforce", ForbidReadRoots: []string{"/secret/a"}},
@@ -1561,8 +1438,8 @@ func TestWorkspaceIdentityTracksForbiddenReadRoots(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if a == b {
-		t.Fatal("forbidden-read policy change did not alter workspace identity")
+	if a != b {
+		t.Fatal("host sandbox policy change altered stable server identity")
 	}
 }
 
@@ -1621,6 +1498,119 @@ func TestIdentityDriftBlocksBeforeProcessStart(t *testing.T) {
 	}
 }
 
+func TestUserAuthorizedIdentityChangeRefreshesWithoutAnotherPrompt(t *testing.T) {
+	manager := mcptrust.NewManager(filepath.Join(t.TempDir(), mcptrust.StateFilename), "/workspace")
+	if err := manager.Trust(mcptrust.ScopeWorkspace, mcptrust.SourceUser, "user-refresh", "user_config", "old-identity", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	spec := Spec{
+		Name: "user-refresh", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{"GO_WANT_HELPER_PROCESS": "1"}, TrustManager: manager,
+		ConfigSource: "user_config", AutoTrust: true, ImplicitApproval: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	host, _, err := StartAll(ctx, []Spec{spec})
+	if err != nil {
+		t.Fatalf("user-authorized refresh: %v", err)
+	}
+	defer host.Close()
+	identity, err := specIdentityFingerprint(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	has, changed, err := manager.IdentityChanged(spec.Name, spec.ConfigSource, identity)
+	if err != nil || !has || changed {
+		t.Fatalf("refreshed user receipt = (has=%v changed=%v err=%v)", has, changed, err)
+	}
+}
+
+func TestProjectLaunchApprovalBlocksBeforeProcessStart(t *testing.T) {
+	redirectCache(t)
+	startCount := filepath.Join(t.TempDir(), "starts")
+	manager := mcptrust.NewManager(filepath.Join(t.TempDir(), mcptrust.StateFilename), "/workspace")
+	spec := Spec{
+		Name: "project-server", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":     "1",
+			"GO_WANT_HELPER_START_COUNT": startCount,
+		},
+		TrustManager: manager, ConfigSource: "project_config", RequireLaunchApproval: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, _, err := StartAll(ctx, []Spec{spec}); err == nil || !strings.Contains(err.Error(), "until the user authorizes") {
+		t.Fatalf("unauthorized project start error = %v", err)
+	}
+	if got := readHelperCounter(t, startCount); got != 0 {
+		t.Fatalf("unauthorized project starts = %d, want 0", got)
+	}
+	inspection, err := InspectSpec(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inspection.RequiresLaunchApproval || inspection.Security.TrustState != mcptrust.TrustUntrusted {
+		t.Fatalf("launch inspection = %+v", inspection)
+	}
+	if got := readHelperCounter(t, startCount); got != 0 {
+		t.Fatalf("inspection started unauthorized project %d times", got)
+	}
+	if err := SetSpecTrust(ctx, spec, "workspace"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHelperCounter(t, startCount); got != 1 {
+		t.Fatalf("authorized preflight starts = %d, want 1", got)
+	}
+	host, _, err := StartAll(ctx, []Spec{spec})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host.Close()
+	if got := readHelperCounter(t, startCount); got != 2 {
+		t.Fatalf("post-authorization starts = %d, want 2", got)
+	}
+}
+
+func TestLegacyPolicyCoupledIdentityAndWorkspaceSourceMigrate(t *testing.T) {
+	manager := mcptrust.NewManager(filepath.Join(t.TempDir(), mcptrust.StateFilename), "/workspace")
+	spec := Spec{
+		Name: "legacy-policy", Command: os.Args[0], Args: []string{"-test.run=TestHelperProcess", "--"},
+		Env:          map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+		ConfigSource: "project_config", TrustManager: manager, RequireLaunchApproval: true,
+		ReaderSandbox: sandbox.Spec{Mode: "enforce", ReadRoots: []string{"/workspace"}, ForbidReadRoots: []string{"/secret"}},
+		WriterSandbox: sandbox.Spec{Mode: "enforce", WriteRoots: []string{"/workspace"}},
+	}
+	identity, err := buildSpecIdentity(context.Background(), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyIdentity := identity
+	legacyIdentity.ConfigSource = "workspace_config"
+	legacyFPs := mcptrust.LegacyIdentityFingerprints(legacyIdentity)
+	if len(legacyFPs) == 0 {
+		t.Fatal("missing legacy fingerprints")
+	}
+	if err := manager.Trust(mcptrust.ScopeWorkspace, mcptrust.SourceUser, spec.Name, "workspace_config", legacyFPs[0], "", nil); err != nil {
+		t.Fatal(err)
+	}
+	currentFP, err := mcptrust.IdentityFingerprint(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := start(ctx, ctx, spec)
+	if err != nil {
+		t.Fatalf("legacy receipt should migrate before the project launch gate: %v", err)
+	}
+	client.close()
+	has, changed, err := manager.IdentityChanged(spec.Name, spec.ConfigSource, currentFP)
+	if err != nil || !has || changed {
+		t.Fatalf("migrated identity = (has=%v changed=%v err=%v)", has, changed, err)
+	}
+}
+
 // TestReadOnlyOverrideDoesNotChangeModelVisibleSchema locks the cache invariant
 // behind the backward-compatible MCP read-only override: classification may
 // change ReadOnly, but must not alter the provider-visible name or input schema.
@@ -1674,7 +1664,7 @@ func TestReadOnlyOverrideDoesNotChangeModelVisibleSchema(t *testing.T) {
 	}
 }
 
-func TestReaderIntentRefusesWriterLanePromotionAfterRevocation(t *testing.T) {
+func TestReaderIntentRefusesDispatchAfterRevocation(t *testing.T) {
 	stateDir := t.TempDir()
 	startCount := filepath.Join(t.TempDir(), "starts")
 	callCount := filepath.Join(t.TempDir(), "calls")
@@ -1720,7 +1710,7 @@ func TestReaderIntentRefusesWriterLanePromotionAfterRevocation(t *testing.T) {
 
 	// A concurrent revocation (catalog refresh, trust re-evaluation) lands
 	// after the authorization: the reader-authorized call must refuse instead
-	// of promoting itself into the one-shot writer lane or issuing tools/call.
+	// of issuing tools/call.
 	rt.client.toolsMu.Lock()
 	rt.readOnly, rt.readOnlyTrusted = false, false
 	rt.client.toolsMu.Unlock()
@@ -1747,16 +1737,16 @@ func TestReaderIntentRefusesWriterLanePromotionAfterRevocation(t *testing.T) {
 		t.Fatalf("stale fingerprint call reached tools/call: calls=%d", got)
 	}
 
-	// Without reader intent the ordinary writer path is unchanged: the
-	// approved writer spawns its one-shot lane exactly as before.
+	// Without reader intent the ordinary writer path remains on the persistent
+	// connection.
 	rt.client.toolsMu.Lock()
 	rt.readOnly, rt.readOnlyTrusted = false, false
 	rt.client.toolsMu.Unlock()
 	if _, _, err := rt.ExecuteWithImages(ctx, json.RawMessage(`{"msg":"writer","z":"ok"}`)); err != nil {
 		t.Fatalf("approved writer call failed: %v", err)
 	}
-	if got := readHelperCounter(t, startCount); got != 2 {
-		t.Fatalf("writer call starts = %d, want reader process plus one one-shot writer", got)
+	if got := readHelperCounter(t, startCount); got != 1 {
+		t.Fatalf("writer call starts = %d, want one persistent process", got)
 	}
 	if got := readHelperCounter(t, callCount); got != 2 {
 		t.Fatalf("writer call count = %d, want 2", got)

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -520,16 +520,16 @@ func TestMCPApprovalPolicyDoesNotChangeProviderSchemas(t *testing.T) {
 
 func TestUserAuthorizedMCPDefaultsToDirectApprovalWithoutChangingOverrides(t *testing.T) {
 	spec := Spec{Name: "user-server", ImplicitApproval: true}
-	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalApprove {
+	if got := spec.ToolApprovalMode("write"); got != tool.MCPApprovalApprove {
 		t.Fatalf("implicit user approval mode = %q, want approve", got)
 	}
 	spec.ToolApprovalModes = map[string]string{"write": "prompt"}
-	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalPrompt {
+	if got := spec.ToolApprovalMode("write"); got != tool.MCPApprovalPrompt {
 		t.Fatalf("explicit per-tool policy = %q, want prompt", got)
 	}
 	spec.ToolApprovalModes = nil
 	spec.DefaultToolsApprovalMode = "writes"
-	if got := spec.toolApprovalMode("write"); got != tool.MCPApprovalWrites {
+	if got := spec.ToolApprovalMode("write"); got != tool.MCPApprovalWrites {
 		t.Fatalf("explicit server policy = %q, want writes", got)
 	}
 }

--- a/internal/plugin/security.go
+++ b/internal/plugin/security.go
@@ -148,7 +148,7 @@ func buildSpecIdentity(ctx context.Context, s Spec) (mcptrust.Identity, error) {
 }
 
 // MCPStateDir returns a stable, server-scoped host directory outside the
-// workspace. MCP sandboxes permit writes only here in the reader lane.
+// workspace for state that must survive across calls and sessions.
 func MCPStateDir(reasonixHome, workspace, server string) string {
 	if strings.TrimSpace(reasonixHome) == "" {
 		return ""

--- a/internal/plugin/security.go
+++ b/internal/plugin/security.go
@@ -43,8 +43,36 @@ func legacySpecIdentityFingerprint(s Spec) (string, bool) {
 		return "", false
 	}
 	identity.URL = legacyURL
-	fp, err := mcptrust.IdentityFingerprint(identity)
-	return fp, err == nil
+	fingerprints := mcptrust.LegacyIdentityFingerprints(identity)
+	if len(fingerprints) == 0 {
+		return "", false
+	}
+	return fingerprints[0], true
+}
+
+func legacySpecIdentityFingerprints(s Spec) []string {
+	identity, err := buildSpecIdentity(context.Background(), s)
+	if err != nil {
+		return nil
+	}
+	out := mcptrust.LegacyIdentityFingerprints(identity)
+	if legacyURL := legacyNormalizeIdentityURL(s.URL); identity.URL != "" && legacyURL != normalizeIdentityURL(s.URL) {
+		identity.URL = legacyURL
+		out = append(out, mcptrust.LegacyIdentityFingerprints(identity)...)
+	}
+	return compactFingerprints(out)
+}
+
+func compactFingerprints(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" && !seen[value] {
+			seen[value] = true
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func buildSpecIdentity(ctx context.Context, s Spec) (mcptrust.Identity, error) {
@@ -322,15 +350,14 @@ func capabilityOf(s Spec, raw mcpTool, schema []byte) mcptrust.Capability {
 // fingerprint upgrades in place when nothing else drifted.
 func managerEvaluate(manager *mcptrust.Manager, s Spec, identity string, capabilities []mcptrust.Capability) (mcptrust.Evaluation, error) {
 	eval, err := managerEvaluateOnce(manager, s, identity, capabilities)
-	if err != nil || !eval.IdentityChanged {
+	if err != nil {
 		return eval, err
 	}
-	legacy, ok := legacySpecIdentityFingerprint(s)
-	if !ok {
-		return eval, nil
+	migrated, migErr := migrateLegacyIdentity(s, identity, capabilities)
+	if migErr != nil {
+		return eval, migErr
 	}
-	migrated, migErr := manager.MigrateIdentityFingerprint(s.Name, trustConfigSource(s), legacy, identity, capabilities)
-	if migErr != nil || !migrated {
+	if !migrated {
 		return eval, nil
 	}
 	return managerEvaluateOnce(manager, s, identity, capabilities)
@@ -342,16 +369,23 @@ func managerEvaluate(manager *mcptrust.Manager, s Spec, identity string, capabil
 // exist yet, so the drift comparison is deliberately skipped (nil): the
 // receipt's tool snapshot is untouched and the post-handshake evaluation
 // still performs the full capability drift check against it.
-func migrateLegacyIdentity(s Spec, identity string) bool {
+func migrateLegacyIdentity(s Spec, identity string, capabilities []mcptrust.Capability) (bool, error) {
 	if s.TrustManager == nil {
-		return false
+		return false, nil
 	}
-	legacy, ok := legacySpecIdentityFingerprint(s)
-	if !ok {
-		return false
+	legacy := legacySpecIdentityFingerprints(s)
+	if len(legacy) == 0 {
+		return false, nil
 	}
-	migrated, err := s.TrustManager.MigrateIdentityFingerprint(s.Name, trustConfigSource(s), legacy, identity, nil)
-	return err == nil && migrated
+	currentSource := trustConfigSource(s)
+	return s.TrustManager.MigrateIdentityFingerprints(
+		s.Name,
+		currentSource,
+		[]string{currentSource, "workspace_config"},
+		legacy,
+		identity,
+		capabilities,
+	)
 }
 
 func managerEvaluateOnce(manager *mcptrust.Manager, s Spec, identity string, capabilities []mcptrust.Capability) (mcptrust.Evaluation, error) {
@@ -379,6 +413,9 @@ func evaluateSpecTrust(s Spec, identity string, capabilities []mcptrust.Capabili
 		return mcptrust.Evaluation{State: mcptrust.TrustUntrusted, TrustedReaders: trusted}, nil
 	}
 	configSource := trustConfigSource(s)
+	if _, err := migrateLegacyIdentity(s, identity, capabilities); err != nil {
+		return untrustedEvaluation(), err
+	}
 	if s.OfficialCatalogEntryID != "" && mcpcatalog.RuntimeEntryRevoked(s.OfficialCatalogEntryID) {
 		return untrustedEvaluation(), nil
 	}
@@ -398,6 +435,12 @@ func evaluateSpecTrust(s Spec, identity string, capabilities []mcptrust.Capabili
 	if !hasReceipt {
 		if s.OfficialCatalogEntryID != "" {
 			if err := manager.TrustOfficial(s.Name, configSource, identity, s.OfficialCatalogEntryID, capabilities, s.OfficialReaderNames); err != nil {
+				return untrustedEvaluation(), err
+			}
+			return managerEvaluate(manager, s, identity, capabilities)
+		}
+		if s.AutoTrust {
+			if err := manager.Trust(mcptrust.ScopeWorkspace, mcptrust.SourceUser, s.Name, configSource, identity, "", capabilities); err != nil {
 				return untrustedEvaluation(), err
 			}
 			return managerEvaluate(manager, s, identity, capabilities)
@@ -428,6 +471,12 @@ func evaluateSpecTrust(s Spec, identity string, capabilities []mcptrust.Capabili
 	eval, err := managerEvaluate(manager, s, identity, capabilities)
 	if err != nil {
 		return untrustedEvaluation(), err
+	}
+	if s.AutoTrust && (eval.IdentityChanged || len(eval.ChangedTools) > 0) {
+		if err := manager.Trust(mcptrust.ScopeWorkspace, mcptrust.SourceUser, s.Name, configSource, identity, "", capabilities); err != nil {
+			return untrustedEvaluation(), err
+		}
+		return managerEvaluate(manager, s, identity, capabilities)
 	}
 	return eval, nil
 }

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -46,7 +46,6 @@ type stdioTransport struct {
 
 	waitOnce    sync.Once
 	releaseSlot func() // returns a bounded instance slot (e.g. CodeGraph) on close; nil when unbounded
-	cleanupDir  string
 }
 
 func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
@@ -73,21 +72,12 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if err != nil {
 		return nil, err
 	}
-	processSandbox := s.ReaderSandbox
-	if s.OneShot {
-		processSandbox = s.WriterSandbox
-	}
+	processSandbox := s.WriterSandbox
 	processSandbox.MinimalWrites = true
-	processSandbox, env, cleanupDir, err := prepareMCPPrivateState(s, processSandbox, env)
+	processSandbox, env, err = prepareMCPPrivateState(s, processSandbox, env)
 	if err != nil {
 		return nil, err
 	}
-	cleanupOnFailure := cleanupDir
-	defer func() {
-		if cleanupOnFailure != "" {
-			_ = os.RemoveAll(cleanupOnFailure)
-		}
-	}()
 	argv, _ := sandbox.CommandArgs(processSandbox, append([]string{exe}, effectiveLaunchArgs(s)...))
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	proc.HideWindow(cmd)
@@ -128,41 +118,27 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 		stderr:      stderr,
 		pending:     map[int]chan rpcResponse{},
 		releaseSlot: releaseSlot,
-		cleanupDir:  cleanupDir,
 	}
-	cleanupOnFailure = ""
 	releaseSlot = nil // ownership transferred to t; close() releases it
 	go t.readLoop()
 	return t, nil
 }
 
-func prepareMCPPrivateState(s Spec, processSandbox sandbox.Spec, env []string) (sandbox.Spec, []string, string, error) {
+func prepareMCPPrivateState(s Spec, processSandbox sandbox.Spec, env []string) (sandbox.Spec, []string, error) {
 	root := strings.TrimSpace(s.StateDir)
 	if root == "" {
-		return processSandbox, env, "", nil
+		return processSandbox, env, nil
 	}
 	if err := os.MkdirAll(root, 0o700); err != nil {
-		return processSandbox, env, "", err
+		return processSandbox, env, err
 	}
 	privateRoot := root
-	cleanupDir := ""
-	if s.OneShot {
-		var err error
-		privateRoot, err = os.MkdirTemp(root, "writer-call-")
-		if err != nil {
-			return processSandbox, env, "", err
-		}
-		cleanupDir = privateRoot
-	}
 	tmpDir := filepath.Join(privateRoot, "tmp")
 	cacheDir := filepath.Join(privateRoot, "cache")
 	stateDir := filepath.Join(privateRoot, "state")
 	for _, dir := range []string{tmpDir, cacheDir, stateDir} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
-			if cleanupDir != "" {
-				_ = os.RemoveAll(cleanupDir)
-			}
-			return processSandbox, env, "", err
+			return processSandbox, env, err
 		}
 	}
 	for key, value := range map[string]string{
@@ -176,7 +152,7 @@ func prepareMCPPrivateState(s Spec, processSandbox sandbox.Spec, env []string) (
 	}
 	processSandbox.WriteRoots = append(processSandbox.WriteRoots, root, privateRoot)
 	processSandbox.AppContainerWriteRoots = append(processSandbox.AppContainerWriteRoots, root, privateRoot)
-	return processSandbox, env, cleanupDir, nil
+	return processSandbox, env, nil
 }
 
 var stdioShellPATH = cachedShellPATH(defaultStdioShellPATH)
@@ -661,11 +637,6 @@ func waitWithBudget(wait func(), budget time.Duration) {
 // blocking forever) and reaps it under a budget so one wedged server can never
 // stall a boot or a turn teardown.
 func (t *stdioTransport) close() {
-	defer func() {
-		if t.cleanupDir != "" {
-			_ = os.RemoveAll(t.cleanupDir)
-		}
-	}()
 	if t.releaseSlot != nil {
 		t.releaseSlot() // idempotent; frees the bounded CodeGraph instance slot
 	}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -72,6 +72,10 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A stateful stdio process cannot switch its OS sandbox after launch. Keep
+	// one process in the server's normal writer sandbox; local permission, Plan,
+	// read-only-child, and destructive-call gates still decide which tools may
+	// be dispatched over the shared transport.
 	processSandbox := s.WriterSandbox
 	processSandbox.MinimalWrites = true
 	processSandbox, env, err = prepareMCPPrivateState(s, processSandbox, env)


### PR DESCRIPTION
## Summary

- Fixes #6606 by migrating compatible v1.17.13 MCP trust receipts to a stable identity that excludes host-local sandbox policy and legacy source labels.
- Makes MCP setup add-and-use: Desktop, user config, legacy imports, verified packages, and `/mcp add` receive their authorized source policy before the first live connection, with no second MCP-specific trust setting.
- Keeps repository-controlled `reasonix.toml` and `.mcp.json` safe with one durable "Authorize and connect" action for the exact command or endpoint. Connected servers no longer show a permanent authorization warning, and identity changes still require re-authorization.
- Reuses one persistent stdio process for tool initialization and calls, preserving browser sessions and removing per-call process startup and tool-catalog revalidation latency.
- Retries transient Windows access and sharing violations during trust-store lock handoff, fixing the concurrent-process failure seen in the previous Windows CI run.
- Keeps explicit deny rules and fresh approval for destructive tools unchanged, while simplifying Desktop copy and English, Simplified Chinese, and Traditional Chinese documentation.

## Security trade-off

A persistent stdio process cannot change its OS sandbox after launch, so the shared process uses the server's normal writer sandbox for all RPCs. Plan mode, read-only sub-agent filtering, tool policy, explicit deny rules, and destructive-call approval remain dispatch and approval gates. No `writer_isolation` or other advanced user setting is added.

## Verification

- `wails generate module`
- `env -u DEEPSEEK_API_KEY go test ./...`
- `cd desktop && env -u DEEPSEEK_API_KEY go test ./...`
- `cd desktop/frontend && pnpm test:typecheck`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/capabilities-panel-actions.test.ts`
- `go test ./internal/mcptrust -count=20`
- Windows cross-compile: `GOOS=windows GOARCH=amd64 go test ./internal/mcptrust -c`
- `./scripts/cache-guard.sh`
- `./scripts/check-cache-impact.sh`
- `git diff --check`

## Compatibility audit

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Existing MCP trust receipts | Bounded legacy source and identity fingerprints migrate only when the server capability snapshot is unchanged. | Existing trusted servers keep working without silently trusting changed code or tools. |
| MCP trust state JSON | Missing `launch_grants` decodes as empty; the new field uses `omitempty`. Older binaries ignore it and may drop it on a later write, which only causes safe re-authorization in the new version. | Backward-readable and fail-safe across versions. |
| `reasonix.toml` and `.mcp.json` | Configuration provenance is runtime-only (`toml:\"-\"`, `json:\"-\"`) and is never written into user files. | Existing configuration files remain byte-shape compatible. |
| Desktop/Wails JSON | `requiresLaunchApproval` is optional and defaults to `false` when absent; older frontends ignore the new field. | Old and new desktop payloads remain compatible. |

## Cache impact

Cache-impact: none - this changes host-side trust and transport lifecycle only; provider-visible tool names, schemas, descriptions, order, and prompts are unchanged.
Cache-guard: `./scripts/cache-guard.sh` passed all dialogue and tool-loop scenarios (tail averages 92-95, threshold 90).
System-prompt-review: Reviewed and approved by @SivanCola as provenance-only boot/config changes; no provider-visible system prompt, memory prefix, output style, or skill index bytes change.
