### PR TITLE
fix(agent): honour DeepSeek finish_reason=stop on reasoning-only final answer

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1502,15 +1502,15 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				continue
 			}
 			if !hasVisibleFinalAnswer(text) {
-				// DeepSeek thinking mode frequently streams a long reasoning_content
-				// and then finishes with finish_reason="stop" but an empty content
+				// DeepSeek thinking mode can stream a long reasoning_content and
+				// then finish with finish_reason="stop" but an empty content
 				// block: the model has explicitly signalled completion and its
 				// reasoning was already streamed to the user. Retrying here overrides
 				// that stop signal and forces another expensive thinking round (the
 				// "still thinking after the task is done" symptom), so honour the
 				// stop when reasoning carried the substance of the answer and treat
 				// the turn as a final answer instead of retrying.
-				if !reasoningOnlyFinishHonoured(usage, reasoning) {
+				if !reasoningOnlyFinishHonoured(a.prov, usage, reasoning) {
 					emptyFinalBlocks++
 					if emptyFinalBlocks >= maxEmptyFinalBlocks {
 						return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
@@ -2434,11 +2434,20 @@ func hasVisibleFinalAnswer(text string) bool {
 
 // reasoningOnlyFinishHonoured reports whether the model finished with a stop
 // signal but placed its answer in the reasoning stream rather than the content
-// block. DeepSeek thinking mode does this routinely: it streams a long
+// block. DeepSeek thinking mode does this occasionally: it streams a long
 // reasoning_content, then returns finish_reason="stop" with an empty content.
 // The model has signalled completion, so the host accepts the turn instead of
 // retrying and forcing another expensive thinking round.
-func reasoningOnlyFinishHonoured(u *provider.Usage, reasoning string) bool {
+//
+// The accept is scoped to DeepSeek thinking mode (ToolCallReasoningPolicy):
+// for other providers a reasoning-only turn keeps the empty-final retry
+// safety net — local <think>-tag models often recover a visible answer on
+// the second attempt, and a gateway that mislabels truncation as "stop"
+// must not have a degenerate turn committed as the final answer.
+func reasoningOnlyFinishHonoured(p provider.Provider, u *provider.Usage, reasoning string) bool {
+	if !provider.RequiresToolCallReasoning(p) {
+		return false
+	}
 	if u == nil || u.FinishReason != "stop" {
 		return false
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1502,14 +1502,24 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 				continue
 			}
 			if !hasVisibleFinalAnswer(text) {
-				emptyFinalBlocks++
-				if emptyFinalBlocks >= maxEmptyFinalBlocks {
-					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
+				// DeepSeek thinking mode frequently streams a long reasoning_content
+				// and then finishes with finish_reason="stop" but an empty content
+				// block: the model has explicitly signalled completion and its
+				// reasoning was already streamed to the user. Retrying here overrides
+				// that stop signal and forces another expensive thinking round (the
+				// "still thinking after the task is done" symptom), so honour the
+				// stop when reasoning carried the substance of the answer and treat
+				// the turn as a final answer instead of retrying.
+				if !reasoningOnlyFinishHonoured(usage, reasoning) {
+					emptyFinalBlocks++
+					if emptyFinalBlocks >= maxEmptyFinalBlocks {
+						return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
+					}
+					a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEmptyFinal, Text: emptyFinalNotice(), Detail: emptyFinalNoticeDetail(a.prov.Name(), usage, len(reasoning))})
+					a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
+					a.maybeCompact(ctx, usage)
+					continue
 				}
-				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEmptyFinal, Text: emptyFinalNotice(), Detail: emptyFinalNoticeDetail(a.prov.Name(), usage, len(reasoning))})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
-				a.maybeCompact(ctx, usage)
-				continue
 			}
 			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(input, text) {
 				handoffNudges++
@@ -2420,6 +2430,19 @@ Use your available tools now to carry out the task. If carrying out the planner'
 
 func hasVisibleFinalAnswer(text string) bool {
 	return strings.TrimSpace(text) != ""
+}
+
+// reasoningOnlyFinishHonoured reports whether the model finished with a stop
+// signal but placed its answer in the reasoning stream rather than the content
+// block. DeepSeek thinking mode does this routinely: it streams a long
+// reasoning_content, then returns finish_reason="stop" with an empty content.
+// The model has signalled completion, so the host accepts the turn instead of
+// retrying and forcing another expensive thinking round.
+func reasoningOnlyFinishHonoured(u *provider.Usage, reasoning string) bool {
+	if u == nil || u.FinishReason != "stop" {
+		return false
+	}
+	return strings.TrimSpace(reasoning) != ""
 }
 
 func emptyFinalRetryMessage() string {

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -97,6 +97,13 @@ func lastAssistantContent(s *Session) string {
 	return out
 }
 
+// deepseekThinkingProvider marks a scripted provider as DeepSeek thinking mode
+// (provider.ToolCallReasoningPolicy) — the scope within which a reasoning-only
+// finish_reason="stop" turn is accepted as a final answer.
+type deepseekThinkingProvider struct{ *scriptedProvider }
+
+func (deepseekThinkingProvider) RequiresToolCallReasoning() bool { return true }
+
 func TestRunAcceptsReasoningOnlyFinalWhenModelStopped(t *testing.T) {
 	// DeepSeek thinking mode streams a long reasoning_content and then
 	// finishes with finish_reason="stop" but an empty content block. The
@@ -110,7 +117,7 @@ func TestRunAcceptsReasoningOnlyFinalWhenModelStopped(t *testing.T) {
 			{Type: provider.ChunkDone},
 		},
 	}}
-	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	a := New(deepseekThinkingProvider{prov}, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
 
 	if err := a.Run(context.Background(), "answer me"); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -123,6 +130,40 @@ func TestRunAcceptsReasoningOnlyFinalWhenModelStopped(t *testing.T) {
 	}
 	if got := lastAssistantContent(a.session); got != "" {
 		t.Fatalf("last assistant content = %q, want empty (answer lived in reasoning)", got)
+	}
+}
+
+func TestRunRetriesReasoningOnlyStopWithoutDeepSeekPolicy(t *testing.T) {
+	// Same chunk sequence as the accept test, but the provider does not
+	// declare DeepSeek thinking mode (ToolCallReasoningPolicy). The accept
+	// path must stay scoped to DeepSeek: local <think>-tag models keep the
+	// retry safety net that often recovers a visible answer on the second
+	// attempt, and a gateway that mislabels truncation as "stop" must not
+	// have a degenerate turn committed as the final answer.
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkReasoning, Text: "thinking only, nothing visible"},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop", TotalTokens: 10}},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "visible reply"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "answer me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2 (non-DeepSeek providers must keep the retry)", prov.call)
+	}
+	if !sessionHasUserMessageContaining(a.session, "visible answer") {
+		t.Fatal("missing synthetic visible-answer retry message for non-DeepSeek provider")
+	}
+	if got := lastAssistantContent(a.session); got != "visible reply" {
+		t.Fatalf("last assistant content = %q, want visible reply", got)
 	}
 }
 

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -97,6 +97,35 @@ func lastAssistantContent(s *Session) string {
 	return out
 }
 
+func TestRunAcceptsReasoningOnlyFinalWhenModelStopped(t *testing.T) {
+	// DeepSeek thinking mode streams a long reasoning_content and then
+	// finishes with finish_reason="stop" but an empty content block. The
+	// model has explicitly signalled completion and its reasoning was
+	// streamed to the user, so the host must accept the turn instead of
+	// retrying and forcing another expensive thinking round.
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkReasoning, Text: "The user asked a simple question; I have reasoned through it and the answer is ready."},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop", TotalTokens: 10}},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "answer me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 1 {
+		t.Fatalf("provider calls = %d, want 1 (model signalled stop; no retry)", prov.call)
+	}
+	if sessionHasUserMessageContaining(a.session, "visible answer") {
+		t.Fatal("must not inject a synthetic visible-answer retry when the model signalled stop")
+	}
+	if got := lastAssistantContent(a.session); got != "" {
+		t.Fatalf("last assistant content = %q, want empty (answer lived in reasoning)", got)
+	}
+}
+
 func BenchmarkHasVisibleFinalAnswer(b *testing.B) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

DeepSeek thinking mode occasionally streams a long `reasoning_content` and then finishes with `finish_reason="stop"` but an empty `content` block - the model has explicitly signalled completion and its answer lives in the reasoning stream that was already streamed to the user. The empty-final-answer retry only checked text content (`hasVisibleFinalAnswer`, `internal/agent/agent.go`), so it misclassified such a finished turn as "no answer", overrode the model's stop signal, and forced another expensive thinking round (the user-visible "still thinking after the task is done" symptom), up to 3 times - or indefinitely when interleaved with tool calls, since `emptyFinalBlocks` only resets when a tool is called.

This guards the retry with `reasoningOnlyFinishHonoured(usage, reasoning)` so a `finish_reason="stop"` + non-empty `reasoning` turn is accepted as a final answer (falls through to `return nil`) instead of being retried.

Closes #6617

## Verification

- New test `TestRunAcceptsReasoningOnlyFinalWhenModelStopped` (`internal/agent/empty_final_test.go`) replays the exact DeepSeek sequence - `ChunkReasoning` + `ChunkUsage{FinishReason:"stop"}` + `ChunkDone`, no content - and asserts the turn is accepted: 1 provider call, no synthetic "visible answer" retry message injected.
- Existing `TestRunRetriesReasoningOnlyFinalAnswer` and `TestRunStopsAfterRepeatedEmptyFinalAnswers` still pass unchanged - `scriptedProvider` emits no usage chunk, so `usage` is `nil` and `reasoningOnlyFinishHonoured` returns `false`, preserving the current retry-then-error behaviour when there is genuinely no answer.
- `go test ./internal/agent/ ./internal/provider/openai/` - ok (full suites, ~29s).
- `go vet ./internal/agent/ ./internal/provider/openai/` - clean.
- `gofmt -l internal/agent/agent.go internal/agent/empty_final_test.go` - clean.

## Cache impact

Cache-impact: low - change is to the empty-final-answer retry control flow only; it does not mutate the system-prompt prefix, tool schemas, memory prefix, output styles, or provider request serialization that form the cache-stable surface. The provider-visible request shape is unchanged.
Cache-guard: TestRunAcceptsReasoningOnlyFinalWhenModelStopped covers the new accept path; TestRunRetriesReasoningOnlyFinalAnswer + TestRunStopsAfterRepeatedEmptyFinalAnswers guard the unchanged retry path; full internal/agent + internal/provider/openai suites pass and go vet is clean.
System-prompt-review: N/A

