### PR TITLE
Add cache-stable agent capability runtime / 新增缓存稳定的 Agent 能力运行时

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -419,6 +419,20 @@ type Agent struct {
 	// failed turn's receipts once; an ordinary user turn still resets evidence.
 	deliveryRecoveryPending bool
 
+	// runtimeContract pins tool surface / edit protocol / prompt layout for
+	// this session. Idle-only ApplyRuntimeContract switches the provider registry.
+	runtimeContract RuntimeContract
+	// registryBundle holds legacy/capability-classic/capability-hashline
+	// provider surfaces plus the shared execution registry for Resume switches.
+	registryBundle *RegistryBundle
+	// compactionState, when non-nil, supplies deterministic Goal/Todo/Job/path
+	// state for post-compaction recovery (never model-summarized).
+	compactionState CompactionStateProvider
+	// lastProviderMsgs/Tools cache the most recent provider-ready request so
+	// compaction prefix_reuse can append a tool-disabled summary turn.
+	lastProviderMsgs  []provider.Message
+	lastProviderTools []provider.ToolSchema
+
 	// capabilityLedger tracks require/prefer outcomes for this user turn only.
 	// Never serialized into prompts or session state.
 	capabilityLedger *capability.Ledger
@@ -528,6 +542,99 @@ func (a *Agent) SetTools(tools *tool.Registry) {
 		return
 	}
 	a.tools = tools
+	// Registry swaps reset session-level cache diagnostics counters so a new
+	// surface does not inherit stale hit/miss attribution. History is untouched.
+	a.sessCacheHit.Store(0)
+	a.sessCacheMiss.Store(0)
+	a.haveLastPrefixShape = false
+	a.lastProviderMsgs = nil
+	a.lastProviderTools = nil
+}
+
+// SetRuntimeContract atomically installs the session contract while idle.
+// Callers must not invoke this mid-turn. Prefer ApplyRuntimeContract when a
+// RegistryBundle is available so the provider registry switches with the contract.
+func (a *Agent) SetRuntimeContract(c RuntimeContract) error {
+	if a == nil {
+		return fmt.Errorf("nil agent")
+	}
+	c = NormalizeRuntimeContract(&c)
+	if err := ValidateRuntimeContract(c); err != nil {
+		return err
+	}
+	a.runtimeContract = c
+	return nil
+}
+
+// ApplyRuntimeContract installs the contract and switches the provider tool
+// registry from bundle. Idle-only; mid-turn calls are undefined. Returns an
+// error when the bundle cannot supply a registry for the contract.
+func (a *Agent) ApplyRuntimeContract(c RuntimeContract, bundle *RegistryBundle) error {
+	if a == nil {
+		return fmt.Errorf("nil agent")
+	}
+	c = NormalizeRuntimeContract(&c)
+	if err := ValidateRuntimeContract(c); err != nil {
+		return err
+	}
+	if bundle != nil {
+		reg := bundle.ProviderRegistry(c)
+		if reg == nil {
+			return fmt.Errorf("no provider registry for contract %s/%s", c.ToolSurface, c.EditProtocol)
+		}
+		a.SetTools(reg)
+		// Keep use_capability / search_capabilities wired to the execution registry.
+		if exec := bundle.ExecutionRegistry(); exec != nil {
+			if t, ok := reg.Get("use_capability"); ok {
+				if proxy, ok := t.(*UseCapabilityTool); ok {
+					proxy.WithExecutionRegistry(exec)
+					proxy.WithEditProtocol(c.EditProtocol)
+					if sk, ok := exec.Get("run_skill"); ok {
+						proxy.WithSkillRunner(sk)
+					}
+				}
+			}
+		}
+	}
+	a.runtimeContract = c
+	return nil
+}
+
+// RuntimeContract returns the session-stable contract (legacy default when unset).
+func (a *Agent) RuntimeContract() RuntimeContract {
+	if a == nil {
+		return LegacyDefaultRuntimeContract()
+	}
+	if a.runtimeContract.ToolSurface == "" {
+		return LegacyDefaultRuntimeContract()
+	}
+	return NormalizeRuntimeContract(&a.runtimeContract)
+}
+
+// SetRegistryBundle stores the boot-built surface bundle for idle-time Resume
+// switches. Nil clears the bundle.
+func (a *Agent) SetRegistryBundle(b *RegistryBundle) {
+	if a == nil {
+		return
+	}
+	a.registryBundle = b
+}
+
+// RegistryBundle returns the boot-built tool surface bundle, if any.
+func (a *Agent) RegistryBundle() *RegistryBundle {
+	if a == nil {
+		return nil
+	}
+	return a.registryBundle
+}
+
+// SetCompactionStateProvider attaches the Controller-side deterministic state
+// snapshot used during compaction. nil disables state messages.
+func (a *Agent) SetCompactionStateProvider(p CompactionStateProvider) {
+	if a == nil {
+		return
+	}
+	a.compactionState = p
 }
 
 // SetReasoningLanguage updates the visible reasoning language preference for
@@ -1168,10 +1275,10 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 						WorkDurationMs:     workDurationMs(),
 					})
 				}
-				a.session.Add(provider.Message{
-					Role:    provider.RoleUser,
-					Content: a.withTurnPreferences(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
-				})
+				a.session.Add(SyntheticUser(
+					provider.SyntheticStreamRecovery,
+					a.withTurnPreferences(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
+				))
 				a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: streamRecoveries, RetryMax: maxStreamRecoveries})
 				step-- // recovery retries do not consume the tool-round maxSteps budget
 				continue
@@ -2187,9 +2294,13 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 	for i := range requestMessages {
 		requestMessages[i].CreatedAt = 0
 	}
+	tools := a.tools.Schemas()
+	// Snapshot provider-ready messages for compaction prefix_reuse (same tools).
+	a.lastProviderMsgs = append([]provider.Message(nil), requestMessages...)
+	a.lastProviderTools = append([]provider.ToolSchema(nil), tools...)
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages:    requestMessages,
-		Tools:       a.tools.Schemas(),
+		Tools:       tools,
 		Temperature: provider.OptionalTemperature(a.temperature),
 	})
 	if err != nil {

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -65,6 +65,11 @@ type BranchMeta struct {
 	Turns        int               `json:"turns,omitempty"`
 	Preview      string            `json:"preview,omitempty"`
 	InFlightTurn *InFlightTurnMeta `json:"in_flight_turn,omitempty"`
+	// RuntimeContract pins tool surface, edit protocol, and prompt layout for
+	// the life of this session. Omitted on legacy sidecars → legacy-v1 triple.
+	// Fork/Branch/Continue/model-switch inherit; only "new task" creates a fresh
+	// contract from current config. Mid-session switches are forbidden.
+	RuntimeContract *RuntimeContract `json:"runtime_contract,omitempty"`
 }
 
 // BranchMetaCountsVersion is stamped into BranchMeta.SchemaVersion whenever a
@@ -417,11 +422,26 @@ func SetBranchModelPreserveUpdated(sessionPath, model string) error {
 // false preserves it (used to backfill legacy sessions during a read). An empty
 // model leaves the stored model untouched.
 func UpdateSessionMeta(sessionPath, model, preview string, turns int, markActivity bool) error {
+	return UpdateSessionMetaWithContract(sessionPath, model, preview, turns, markActivity, nil)
+}
+
+// UpdateSessionMetaWithContract is like UpdateSessionMeta but also stamps
+// RuntimeContract on first write. Existing contracts are never overwritten.
+//
+// Rules (no silent upgrade of old sessions):
+//   - Meta already has RuntimeContract → leave it.
+//   - Meta file already existed without the field → pin legacy (old session).
+//   - Brand-new meta created by EnsureBranchMeta → stamp the live contract.
+func UpdateSessionMetaWithContract(sessionPath, model, preview string, turns int, markActivity bool, contract *RuntimeContract) error {
 	if sessionPath == "" {
 		return fmt.Errorf("empty session path")
 	}
 	unlock := lockSessionSavePath(sessionPath)
 	defer unlock()
+	_, existed, loadErr := LoadBranchMeta(sessionPath)
+	if loadErr != nil {
+		return loadErr
+	}
 	m, err := EnsureBranchMeta(sessionPath)
 	if err != nil {
 		return err
@@ -434,5 +454,13 @@ func UpdateSessionMeta(sessionPath, model, preview string, turns int, markActivi
 	// These counts were derived from the current content, so mark them
 	// authoritative — listing can then trust Turns (even 0) without re-decoding.
 	m.SchemaVersion = BranchMetaCountsVersion
+	if m.RuntimeContract == nil {
+		if existed {
+			// Pre-contract sidecar: never upgrade to process config defaults.
+			m.RuntimeContract = LegacyDefaultRuntimeContract().Clone()
+		} else if contract != nil {
+			m.RuntimeContract = contract.Clone()
+		}
+	}
 	return saveBranchMeta(sessionPath, m, markActivity)
 }

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,31 +50,20 @@ const summaryTimeout = 90 * time.Second
 
 // summarySystemPrompt steers the executor to distill older history into a
 // structured briefing it can keep relying on after the originals are dropped.
-// The section layout mirrors what a coding agent actually needs to resume work
-// mid-task: the goal verbatim, the concrete state of the code, and an explicit
-// next step — so the post-compaction turn doesn't lose the thread or re-derive
-// decisions already made.
+// Quality gate requires the four primary headings below; detail subsections may
+// appear under ## Current state.
 const summarySystemPrompt = `You are compacting the earlier part of a coding agent's conversation to save context.
 The agent keeps your summary alongside the user's own turns (kept verbatim) and the recent tail; your job is to fold the assistant/tool work into a briefing it can resume from.
-Write under these exact headings, omitting a heading only if it has no content:
-
-## Standing facts & constraints
-Everything the user stated that still governs the work — names, paths, IDs, versions, tokens, preferences, and hard "never do X" rules — in their own words. Be exhaustive; this is the durable contract, so prefer over- to under-including.
+Write under these exact headings (all four are required):
 
 ## Goal
-The user's request and intent.
+The user's request and intent, plus standing facts & constraints they stated that still govern the work (names, paths, IDs, versions, hard "never do X" rules) in their own words.
 
-## Decisions & rationale
-Key choices made so far and why — so they are not re-litigated or reversed.
+## Completed & decisions
+What was finished, key choices made so far and why — so they are not re-litigated or reversed. Include commands run and their outcomes when relevant.
 
-## Files & code
-Files read or modified, with the specific facts that matter: signatures, line locations, data shapes, and exact edits applied. Be concrete; this is what lets the agent act without re-reading everything.
-
-## Commands & outcomes
-Commands run (builds, tests, git) and their relevant results — what passed, what failed, and the error text that matters.
-
-## Errors & fixes
-Problems hit and how they were resolved (or not), so the same dead ends are not repeated.
+## Current state
+Concrete code/workspace state: files read or modified (signatures, locations, data shapes, exact edits), open errors and how they were fixed (or not).
 
 ## Pending & next step
 What is still in progress or unstarted, and the single most concrete next action to take.
@@ -253,7 +244,21 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	// are spliced back verbatim, so a fact that reached a digest once is never
 	// re-summarized away and the user's own words are never touched. Digests
 	// accumulate (small) rather than collapsing into one lossy rolling summary.
-	summary, err := a.summarizeWithRetry(ctx, fold, instructions)
+	// Also pin the latest real user request from the fold region when it would
+	// otherwise only live inside the summary (already-kept or still-in-tail
+	// copies are left alone so large foldable pastes can still shrink).
+	latestUser := latestRealUserRequest(fold)
+	if latestUser != nil {
+		// Already preserved in kept or still present in the recent tail.
+		if messageInSlice(kept, *latestUser) || messageInSlice(msgs[start:], *latestUser) {
+			latestUser = nil
+		} else if !a.pinnableUserTurn(*latestUser) {
+			// Large pasted user turns stay foldable; re-pinning them would undo
+			// the compaction savings the fold was meant to buy.
+			latestUser = nil
+		}
+	}
+	summary, stage, attempts, prefixReused, failClass, err := a.summarizeLadder(ctx, fold, instructions)
 	if err != nil {
 		// Mechanical fold: the foldable region is already archived, so stand in a
 		// deterministic marker rather than aborting. /compact then always frees
@@ -261,24 +266,57 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 		// verbatim user turns kept above are untouched.
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context was compacted without a generated summary.", Detail: "compaction summary unavailable (" + err.Error() + "); folded mechanically"})
 		summary = mechanicalFoldDigest(len(fold), archived)
+		stage = "mechanical"
+		failClass = classifySummaryError(err)
 	}
 
-	compacted := make([]provider.Message, 0, head+len(kept)+1+len(msgs)-start)
+	summaryMsg := CompactionSummaryMessage(
+		"Summary of earlier conversation (older messages were compacted to save context):\n" + summary,
+	)
+	// Ensure legacy prefixes remain for downgrade compatibility.
+	if !strings.Contains(summaryMsg.Content, summaryTagOpen) {
+		summaryMsg.Content = summaryTagOpen + "\n" + summaryMsg.Content + "\n" + summaryTagClose
+	}
+
+	var stateMsg *provider.Message
+	var stateBytes int
+	if a.compactionState != nil {
+		st := a.compactionState.CompactionState()
+		if archived != "" && st.ArchivePath == "" {
+			st.ArchivePath = archived
+		}
+		body := RenderCompactionState(st)
+		stateBytes = len(body)
+		m := CompactionStateMessage(st)
+		stateMsg = &m
+	}
+
+	compacted := make([]provider.Message, 0, head+len(kept)+3+len(msgs)-start)
 	compacted = append(compacted, msgs[:head]...)
 	compacted = append(compacted, kept...)
-	compacted = append(compacted, provider.Message{
-		Role: provider.RoleUser,
-		Content: summaryTagOpen + "\n" +
-			"Summary of earlier conversation (older messages were compacted to save context):\n" +
-			summary + "\n" +
-			summaryTagClose,
-	})
+	if latestUser != nil {
+		// Keep latest real user request verbatim after the pinned prefix/kept
+		// facts and before the summary, so post-compaction always has the task text.
+		compacted = append(compacted, *latestUser)
+	}
+	compacted = append(compacted, summaryMsg)
+	if stateMsg != nil {
+		compacted = append(compacted, *stateMsg)
+	}
 	compacted = append(compacted, msgs[start:]...)
 	a.session.Replace(compacted)
 	a.session.IncrementRewrite()
 
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
-		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
+		Trigger:      trigger,
+		Messages:     len(fold),
+		Summary:      summary,
+		Archive:      archived,
+		Stage:        stage,
+		Attempts:     attempts,
+		PrefixReused: prefixReused,
+		FailureClass: failClass,
+		StateBytes:   stateBytes,
 	}})
 	return nil
 }
@@ -310,10 +348,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 	}
 	next := make([]provider.Message, 0, fromIdx+1)
 	next = append(next, msgs[:fromIdx]...)
-	next = append(next, provider.Message{
-		Role:    provider.RoleUser,
-		Content: "Summary of the later conversation (compacted from here on):\n" + summary,
-	})
+	next = append(next, CompactionSummaryMessage("Summary of the later conversation (compacted from here on):\n"+summary))
 	a.session.Replace(next)
 	a.session.IncrementRewrite()
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -343,10 +378,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	}
 	next := make([]provider.Message, 0, head+1+len(msgs)-toIdx)
 	next = append(next, msgs[:head]...)
-	next = append(next, provider.Message{
-		Role:    provider.RoleUser,
-		Content: "Summary of earlier conversation (compacted up to here):\n" + summary,
-	})
+	next = append(next, CompactionSummaryMessage("Summary of earlier conversation (compacted up to here):\n"+summary))
 	next = append(next, msgs[toIdx:]...)
 	a.session.Replace(next)
 	a.session.IncrementRewrite()
@@ -363,29 +395,77 @@ func IsCompactionSummary(m provider.Message) bool { return isCompactionSummary(m
 
 // isCompactionSummary reports whether m is a rolling summary from a prior fold.
 func isCompactionSummary(m provider.Message) bool {
-	return m.Role == provider.RoleUser &&
-		strings.HasPrefix(strings.TrimLeft(m.Content, "\n "), summaryTagOpen)
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	if m.SyntheticReason == provider.SyntheticCompactionSummary {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimLeft(m.Content, "\n "), summaryTagOpen)
+}
+
+// isCompactionState reports whether m is the deterministic host state block.
+func isCompactionState(m provider.Message) bool {
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	if m.SyntheticReason == provider.SyntheticCompactionState {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(m.Content), "<compaction-state")
 }
 
 // pinnedPrefixLen counts the leading messages a fold keeps verbatim: the system
-// prompt, the first user turn (its task + stated facts/constraints) when it is
-// small enough to be a brief, and any prior summaries — so a fold never
-// summarizes the user's facts away, and a later fold never re-summarizes an
-// earlier summary into nothing (the drift that silently dropped user-stated facts
-// after the second compaction). A large first turn (pasted content) stays
-// foldable so pinning never starves the window.
+// prompt, the pinned session-context message (always), the first user turn when
+// small enough, and any prior summaries — so a fold never summarizes the user's
+// facts away, and a later fold never re-summarizes an earlier summary into
+// nothing. A large first turn (pasted content) stays foldable so pinning never
+// starves the window.
 func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	i := 0
 	if i < len(msgs) && msgs[i].Role == provider.RoleSystem {
 		i++
 	}
-	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && a.pinnableUserTurn(msgs[i]) {
+	// Session context is always pinned for session-context-v2 layouts.
+	if i < len(msgs) && IsSessionContextMessage(msgs[i]) {
 		i++
 	}
-	for i < len(msgs) && isCompactionSummary(msgs[i]) {
+	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && !isCompactionState(msgs[i]) && !IsSessionContextMessage(msgs[i]) && a.pinnableUserTurn(msgs[i]) {
+		i++
+	}
+	for i < len(msgs) && (isCompactionSummary(msgs[i]) || isCompactionState(msgs[i])) {
 		i++
 	}
 	return i
+}
+
+// latestRealUserRequest returns a copy of the newest user-authored (non-synthetic)
+// message in region, or nil.
+func latestRealUserRequest(region []provider.Message) *provider.Message {
+	for i := len(region) - 1; i >= 0; i-- {
+		m := region[i]
+		if m.Role != provider.RoleUser {
+			continue
+		}
+		if IsSyntheticUserMessage(m) || isCompactionSummary(m) || isCompactionState(m) {
+			continue
+		}
+		if _, isSteer := SteerText(m.Content); isSteer {
+			continue
+		}
+		cp := m
+		return &cp
+	}
+	return nil
+}
+
+func messageInSlice(msgs []provider.Message, want provider.Message) bool {
+	for _, m := range msgs {
+		if m.Role == want.Role && m.Content == want.Content && m.SyntheticReason == want.SyntheticReason {
+			return true
+		}
+	}
+	return false
 }
 
 // pinnableUserTurn reports whether a user turn is small enough to keep verbatim. A
@@ -619,19 +699,49 @@ func charsOfMessages(msgs []provider.Message) int {
 // is appended to the system prompt as extra focus guidance (from /compact <focus>
 // and/or a PreCompact hook).
 func (a *Agent) summarize(ctx context.Context, region []provider.Message, instructions string) (string, error) {
+	return a.summarizeStage(ctx, region, instructions, "fitted_transcript", false)
+}
+
+// summarizeStage runs one summarization attempt at the given ladder stage.
+// prefixReuse reuses the last provider-ready messages + identical tools with
+// ToolChoiceNone when the provider supports it.
+func (a *Agent) summarizeStage(ctx context.Context, region []provider.Message, instructions, stage string, prefixReuse bool) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, summaryTimeout)
 	defer cancel()
 	sys := summarySystemPrompt
 	if strings.TrimSpace(instructions) != "" {
 		sys += "\n\nAdditional focus for this compaction (prioritize keeping this):\n" + strings.TrimSpace(instructions)
 	}
-	ch, err := a.prov.Stream(ctx, provider.Request{
-		Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: sys},
-			{Role: provider.RoleUser, Content: renderTranscript(region)},
-		},
-		Temperature: provider.OptionalTemperature(a.temperature),
-	})
+
+	var req provider.Request
+	if prefixReuse && a.supportsToolChoiceNone() && len(a.lastProviderMsgs) > 0 {
+		// Reuse the exact last provider-ready prefix and tool schemas; only append
+		// one user turn that carries the full summarizer policy (and optional
+		// focus). Do NOT re-embed the transcript — it is already in the prefix
+		// and would push past the 80% window. ToolChoiceNone disables tools.
+		msgs := append([]provider.Message(nil), a.lastProviderMsgs...)
+		msgs = append(msgs, provider.Message{
+			Role:    provider.RoleUser,
+			Content: prefixReuseSummaryUserTurn(sys, instructions),
+		})
+		req = provider.Request{
+			Messages:    msgs,
+			Tools:       append([]provider.ToolSchema(nil), a.lastProviderTools...),
+			Temperature: provider.OptionalTemperature(a.temperature),
+			ToolChoice:  provider.ToolChoiceNone,
+		}
+	} else {
+		req = provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: sys},
+				{Role: provider.RoleUser, Content: renderTranscriptForStage(region, stage)},
+			},
+			Temperature: provider.OptionalTemperature(a.temperature),
+			ToolChoice:  provider.ToolChoiceNone,
+		}
+	}
+
+	ch, err := a.prov.Stream(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -656,11 +766,17 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 				if s == "" {
 					return "", fmt.Errorf("summarizer returned empty output")
 				}
+				// Tool calls in a summary are a quality failure.
+				if strings.Contains(s, "tool_calls") && strings.Contains(s, `"name"`) {
+					return "", fmt.Errorf("summarizer returned tool call content")
+				}
 				return s, nil
 			}
 			switch chunk.Type {
 			case provider.ChunkText:
 				b.WriteString(chunk.Text)
+			case provider.ChunkToolCall:
+				return "", fmt.Errorf("summarizer attempted tool call")
 			case provider.ChunkUsage:
 				usage = chunk.Usage
 			case provider.ChunkError:
@@ -679,6 +795,266 @@ func (a *Agent) summarizeWithRetry(ctx context.Context, fold []provider.Message,
 		return summary, err
 	}
 	return a.summarize(ctx, fold, instructions)
+}
+
+// summarizeLadder tries up to three stages (prefix_reuse → fitted → minimal)
+// with one extra transient retry. Auth/cancel go straight to mechanical fallback.
+// Quality failures step down the ladder; a non-empty but sub-quality last-stage
+// summary is still preferred over a purely mechanical fold so the model keeps
+// some briefing when headings are incomplete.
+func (a *Agent) summarizeLadder(ctx context.Context, fold []provider.Message, instructions string) (summary, stage string, attempts int, prefixReused bool, failureClass string, err error) {
+	stages := []struct {
+		name        string
+		prefixReuse bool
+	}{
+		{"prefix_reuse", true},
+		{"fitted_transcript", false},
+		{"minimal_transcript", false},
+	}
+	inputChars := charsOfMessages(fold)
+	var lastErr error
+	var best string
+	var bestStage string
+	var bestPrefix bool
+	transientUsed := false
+	for _, st := range stages {
+		if st.prefixReuse && !a.supportsToolChoiceNone() {
+			continue
+		}
+		if st.prefixReuse && len(a.lastProviderMsgs) == 0 {
+			continue
+		}
+		attempts++
+		out, e := a.summarizeStage(ctx, fold, instructions, st.name, st.prefixReuse)
+		if e != nil {
+			lastErr = e
+			fc := classifySummaryError(e)
+			if fc == "auth" || fc == "cancel" {
+				return "", st.name, attempts, st.prefixReuse, fc, e
+			}
+			if fc == "transient" && !transientUsed {
+				transientUsed = true
+				attempts++
+				out, e = a.summarizeStage(ctx, fold, instructions, st.name, st.prefixReuse)
+				if e == nil {
+					if summaryQualityOK(out, inputChars) {
+						return out, st.name, attempts, st.prefixReuse, "", nil
+					}
+					if len(out) > len(best) {
+						best, bestStage, bestPrefix = out, st.name, st.prefixReuse
+					}
+					lastErr = fmt.Errorf("summary failed quality gate")
+					failureClass = "quality"
+				} else {
+					lastErr = e
+					if classifySummaryError(e) == "auth" || classifySummaryError(e) == "cancel" {
+						return "", st.name, attempts, st.prefixReuse, classifySummaryError(e), e
+					}
+				}
+			}
+			// context-too-long and other errors fall through to next stage
+			continue
+		}
+		if !summaryQualityOK(out, inputChars) {
+			lastErr = fmt.Errorf("summary failed quality gate")
+			failureClass = "quality"
+			if len(out) > len(best) {
+				best, bestStage, bestPrefix = out, st.name, st.prefixReuse
+			}
+			continue
+		}
+		return out, st.name, attempts, st.prefixReuse, "", nil
+	}
+	if strings.TrimSpace(best) != "" {
+		// Prefer the best non-empty model summary over a mechanical fold.
+		return best, bestStage, attempts, bestPrefix, "quality", nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("all summary stages failed")
+	}
+	if failureClass == "" {
+		failureClass = classifySummaryError(lastErr)
+	}
+	return "", "mechanical", attempts, false, failureClass, lastErr
+}
+
+func (a *Agent) supportsToolChoiceNone() bool {
+	// OpenAI-compatible and Anthropic adapters both support ToolChoiceNone.
+	// Unknown providers still receive the field; if they reject it, classify as
+	// context/transient and fall through. We optimistically allow when the
+	// provider kind is empty (tests/mocks).
+	return true
+}
+
+func summaryQualityOK(s string, inputChars int) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	minChars := inputChars / 20
+	if minChars < 200 {
+		minChars = 200
+	}
+	if minChars > 500 {
+		minChars = 500
+	}
+	// Short folds cannot meet a large min; floor against input size.
+	if inputChars > 0 && inputChars < minChars {
+		minChars = inputChars / 2
+		if minChars < 40 {
+			minChars = 40
+		}
+	}
+	if len(s) < minChars {
+		return false
+	}
+	required := []string{"## Goal", "## Completed & decisions", "## Current state", "## Pending & next step"}
+	// Accept legacy heading set used by older digests still in the wild.
+	legacyOK := strings.Contains(s, "## Goal") && strings.Contains(s, "## Pending & next step") &&
+		(strings.Contains(s, "## Decisions") || strings.Contains(s, "## Standing facts"))
+	for _, h := range required {
+		if !strings.Contains(s, h) {
+			return legacyOK
+		}
+	}
+	return true
+}
+
+func classifySummaryError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "cancel"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "transient"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "401"), strings.Contains(msg, "403"), strings.Contains(msg, "auth"), strings.Contains(msg, "unauthorized"), strings.Contains(msg, "api key"):
+		return "auth"
+	case strings.Contains(msg, "413"), strings.Contains(msg, "context"), strings.Contains(msg, "too long"), strings.Contains(msg, "maximum context"), strings.Contains(msg, "token"):
+		if strings.Contains(msg, "422") || strings.Contains(msg, "400") || strings.Contains(msg, "413") || strings.Contains(msg, "context") || strings.Contains(msg, "too long") {
+			return "context"
+		}
+	case strings.Contains(msg, "quality"):
+		return "quality"
+	case strings.Contains(msg, "empty"):
+		return "empty"
+	}
+	if strings.Contains(msg, "400") || strings.Contains(msg, "422") {
+		return "context"
+	}
+	return "transient"
+}
+
+// prefixReuseSummaryUserTurn is appended to the last provider-ready messages
+// during prefix_reuse. It carries the full quality headings and optional focus
+// without re-sending the transcript (already present in the reused prefix).
+func prefixReuseSummaryUserTurn(sys, instructions string) string {
+	var b strings.Builder
+	b.WriteString("Compact the earlier conversation already present above into a structured briefing. ")
+	b.WriteString("Do not call tools. Follow these exact requirements:\n\n")
+	b.WriteString(sys)
+	if strings.TrimSpace(instructions) != "" {
+		b.WriteString("\n\nAdditional focus for this compaction (prioritize keeping this):\n")
+		b.WriteString(strings.TrimSpace(instructions))
+	}
+	return b.String()
+}
+
+func renderTranscriptForStage(msgs []provider.Message, stage string) string {
+	switch stage {
+	case "minimal_transcript":
+		return renderMinimalTranscript(msgs)
+	case "fitted_transcript", "prefix_reuse":
+		// prefix_reuse does not use this path; fitted does.
+		return renderFittedTranscript(msgs)
+	default:
+		return renderTranscript(msgs)
+	}
+}
+
+// renderFittedTranscript replaces large tool results with name/status/head/tail/digest.
+func renderFittedTranscript(msgs []provider.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		switch m.Role {
+		case provider.RoleUser:
+			fmt.Fprintf(&b, "[user]\n%s\n\n", m.Content)
+		case provider.RoleAssistant:
+			if m.Content != "" {
+				fmt.Fprintf(&b, "[assistant]\n%s\n", m.Content)
+			}
+			for _, tc := range m.ToolCalls {
+				fmt.Fprintf(&b, "[assistant calls %s] %s\n", tc.Name, summarizeToolArgs(tc.Arguments))
+			}
+			b.WriteString("\n")
+		case provider.RoleTool:
+			fmt.Fprintf(&b, "[tool %s result]\n%s\n\n", m.Name, fitToolResult(m.Content))
+		case provider.RoleSystem:
+			fmt.Fprintf(&b, "[system]\n%s\n\n", m.Content)
+		}
+	}
+	return b.String()
+}
+
+func renderMinimalTranscript(msgs []provider.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		switch m.Role {
+		case provider.RoleUser:
+			if IsSyntheticUserMessage(m) {
+				continue
+			}
+			fmt.Fprintf(&b, "[user]\n%s\n\n", m.Content)
+		case provider.RoleAssistant:
+			if m.Content != "" {
+				// Keep assistant conclusions only (first ~500 chars).
+				c := m.Content
+				if len(c) > 500 {
+					c = c[:500] + "…"
+				}
+				fmt.Fprintf(&b, "[assistant]\n%s\n", c)
+			}
+			for _, tc := range m.ToolCalls {
+				fmt.Fprintf(&b, "[tool %s args_digest %s]\n", tc.Name, shortDigest(tc.Arguments))
+			}
+			b.WriteString("\n")
+		case provider.RoleTool:
+			line := strings.SplitN(strings.TrimSpace(m.Content), "\n", 2)[0]
+			if len(line) > 200 {
+				line = line[:200] + "…"
+			}
+			fmt.Fprintf(&b, "[tool %s] %s\n\n", m.Name, line)
+		}
+	}
+	return b.String()
+}
+
+func fitToolResult(content string) string {
+	const headTail = 400
+	ok := !strings.HasPrefix(strings.TrimSpace(strings.ToLower(content)), "error:")
+	status := "ok"
+	if !ok {
+		status = "error"
+	}
+	if len(content) <= headTail*2+64 {
+		return content
+	}
+	head := content
+	if len(head) > headTail {
+		head = content[:headTail]
+	}
+	tail := content[len(content)-headTail:]
+	return fmt.Sprintf("status=%s chars=%d digest=%s\nHEAD:\n%s\n…\nTAIL:\n%s",
+		status, len(content), shortDigest(content), head, tail)
+}
+
+func shortDigest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:8])
 }
 
 // mechanicalFoldDigest is the deterministic stand-in used when the summarizer is

--- a/internal/agent/compaction_state.go
+++ b/internal/agent/compaction_state.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+const (
+	// maxCompactionStateBytes is the hard cap for the deterministic state block.
+	maxCompactionStateBytes = 12 * 1024
+	maxCompactionTodos      = 32
+	maxCompactionJobs       = 16
+	maxCompactionPaths      = 64
+)
+
+// CompactionState is a deterministic snapshot the Controller supplies so
+// post-compaction recovery never relies on the model summarizing Goals/Todos.
+type CompactionState struct {
+	ActiveGoal     string
+	BlockedGoal    string
+	GoalStatus     string
+	BlockReason    string
+	Todos          []CompactionTodo // pending + in_progress, capped
+	CompletedTodos int
+	CancelledTodos int
+	Jobs           []CompactionJob // running jobs/sub-agents, capped
+	EditedPaths    []string        // sorted union, capped
+	DeliveryCP     string          // delivery checkpoint summary
+	ArchivePath    string
+}
+
+// CompactionTodo is a compact todo line for state recovery.
+type CompactionTodo struct {
+	ID     string
+	Status string
+	Text   string
+}
+
+// CompactionJob is a running background job or sub-agent.
+type CompactionJob struct {
+	ID    string
+	Kind  string
+	Label string
+}
+
+// CompactionStateProvider is implemented by the Controller to supply state at
+// compact time without importing control into agent cycles.
+type CompactionStateProvider interface {
+	CompactionState() CompactionState
+}
+
+// RenderCompactionState formats CompactionState deterministically. Over-limit
+// content is truncated in fixed order and closed with a SHA-256 digest.
+func RenderCompactionState(st CompactionState) string {
+	var b strings.Builder
+	b.WriteString("<compaction-state version=\"1\">\n")
+
+	writeKV(&b, "active_goal", st.ActiveGoal)
+	writeKV(&b, "blocked_goal", st.BlockedGoal)
+	writeKV(&b, "goal_status", st.GoalStatus)
+	writeKV(&b, "block_reason", st.BlockReason)
+
+	b.WriteString("## Todos\n")
+	todos := st.Todos
+	if len(todos) > maxCompactionTodos {
+		todos = todos[:maxCompactionTodos]
+	}
+	for _, t := range todos {
+		fmt.Fprintf(&b, "- [%s] %s: %s\n", t.Status, t.ID, singleLine(t.Text))
+	}
+	fmt.Fprintf(&b, "completed_count: %d\n", st.CompletedTodos)
+	fmt.Fprintf(&b, "cancelled_count: %d\n", st.CancelledTodos)
+
+	b.WriteString("## Jobs\n")
+	jobs := st.Jobs
+	if len(jobs) > maxCompactionJobs {
+		jobs = jobs[:maxCompactionJobs]
+	}
+	for _, j := range jobs {
+		fmt.Fprintf(&b, "- %s/%s: %s\n", j.Kind, j.ID, singleLine(j.Label))
+	}
+
+	b.WriteString("## Edited paths\n")
+	paths := append([]string(nil), st.EditedPaths...)
+	sort.Strings(paths)
+	if len(paths) > maxCompactionPaths {
+		paths = paths[:maxCompactionPaths]
+	}
+	for _, p := range paths {
+		fmt.Fprintf(&b, "- %s\n", p)
+	}
+
+	writeKV(&b, "delivery_checkpoint", st.DeliveryCP)
+	writeKV(&b, "archive_path", st.ArchivePath)
+	b.WriteString("</compaction-state>\n")
+
+	out := b.String()
+	if len(out) <= maxCompactionStateBytes {
+		return out
+	}
+	// Truncate body, keep tags, append digest of the full intended content.
+	sum := sha256.Sum256([]byte(out))
+	digest := hex.EncodeToString(sum[:])
+	keep := maxCompactionStateBytes - 96
+	if keep < 128 {
+		keep = 128
+	}
+	truncated := out[:keep]
+	// Ensure we don't cut mid-line awkwardly
+	if i := strings.LastIndexByte(truncated, '\n'); i > 64 {
+		truncated = truncated[:i+1]
+	}
+	return truncated + fmt.Sprintf("… truncated; sha256=%s\n</compaction-state>\n", digest)
+}
+
+func writeKV(b *strings.Builder, k, v string) {
+	v = singleLine(v)
+	if v == "" {
+		return
+	}
+	fmt.Fprintf(b, "%s: %s\n", k, v)
+}
+
+func singleLine(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+// CompactionStateMessage builds the synthetic state message.
+func CompactionStateMessage(st CompactionState) provider.Message {
+	return SyntheticUser(provider.SyntheticCompactionState, RenderCompactionState(st))
+}
+
+// CompactionSummaryMessage wraps a model or mechanical summary with metadata.
+func CompactionSummaryMessage(content string) provider.Message {
+	body := content
+	if !strings.Contains(content, summaryTagOpen) {
+		body = summaryTagOpen + "\n" + strings.TrimSpace(content) + "\n" + summaryTagClose
+	}
+	return SyntheticUser(provider.SyntheticCompactionSummary, body)
+}

--- a/internal/agent/compaction_state_test.go
+++ b/internal/agent/compaction_state_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderCompactionStateDeterministic(t *testing.T) {
+	st := CompactionState{
+		ActiveGoal: "ship feature",
+		GoalStatus: "running",
+		Todos: []CompactionTodo{
+			{ID: "2", Status: "pending", Text: "b"},
+			{ID: "1", Status: "in_progress", Text: "a"},
+		},
+		CompletedTodos: 3,
+		EditedPaths:    []string{"z.go", "a.go"},
+	}
+	a := RenderCompactionState(st)
+	b := RenderCompactionState(st)
+	if a != b {
+		t.Fatal("not deterministic")
+	}
+	if !strings.Contains(a, "- a.go") || !strings.Contains(a, "- z.go") {
+		t.Fatalf("paths not sorted:\n%s", a)
+	}
+	// a.go should appear before z.go
+	if strings.Index(a, "- a.go") > strings.Index(a, "- z.go") {
+		t.Fatal("edited paths must be sorted")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(a), "<compaction-state") {
+		t.Fatal("missing open tag")
+	}
+}
+
+func TestRenderCompactionStateTruncates(t *testing.T) {
+	st := CompactionState{ActiveGoal: strings.Repeat("x", maxCompactionStateBytes)}
+	out := RenderCompactionState(st)
+	if len(out) > maxCompactionStateBytes+128 {
+		t.Fatalf("len=%d still too large", len(out))
+	}
+	if !strings.Contains(out, "sha256=") {
+		t.Fatal("expected digest on truncate")
+	}
+}
+
+func TestCompactionMessagesSynthetic(t *testing.T) {
+	sum := CompactionSummaryMessage("## Goal\nok")
+	if sum.SyntheticReason != "compaction_summary" {
+		t.Fatalf("reason=%q", sum.SyntheticReason)
+	}
+	st := CompactionStateMessage(CompactionState{ActiveGoal: "g"})
+	if st.SyntheticReason != "compaction_state" {
+		t.Fatalf("reason=%q", st.SyntheticReason)
+	}
+}

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
+
+	"reasonix/internal/provider"
 )
 
 var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route)>\s*\n?`)
@@ -158,7 +160,8 @@ var SyntheticUserPrefixes = []string{
 }
 
 // IsSyntheticUserText reports whether a persisted user-role message is a
-// host-injected synthetic turn rather than user-authored input.
+// host-injected synthetic turn rather than user-authored input (text-prefix
+// path only). Prefer IsSyntheticUserMessage when the Message is available.
 func IsSyntheticUserText(content string) bool {
 	trimmed := strings.TrimSpace(StripTransientUserBlocks(content))
 	for _, prefix := range SyntheticUserPrefixes {
@@ -166,7 +169,31 @@ func IsSyntheticUserText(content string) bool {
 			return true
 		}
 	}
+	// Session-context and capability-delta tags are pinned synthetic messages.
+	if strings.HasPrefix(trimmed, "<session-context") || strings.HasPrefix(trimmed, "<capability-delta") ||
+		strings.HasPrefix(trimmed, "<compaction-state") {
+		return true
+	}
 	return false
+}
+
+// IsSyntheticUserMessage prefers provider.Message.SyntheticReason metadata, then
+// falls back to legacy text-prefix recognition so old sessions still classify
+// correctly after a downgrade/upgrade cycle.
+func IsSyntheticUserMessage(m provider.Message) bool {
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	if m.IsSyntheticUser() {
+		return true
+	}
+	return IsSyntheticUserText(m.Content)
+}
+
+// SyntheticUser builds a host-injected user message with SyntheticReason set.
+// Content may still carry legacy prefixes for downgrade compatibility.
+func SyntheticUser(reason provider.SyntheticReason, content string) provider.Message {
+	return provider.SyntheticUser(reason, content)
 }
 
 // IsUserAuthoredTurn reports whether a persisted user-role message counts as a
@@ -178,6 +205,20 @@ func IsUserAuthoredTurn(content string) bool {
 		return false
 	}
 	if _, isSteer := SteerText(content); isSteer {
+		return false
+	}
+	return true
+}
+
+// IsUserAuthoredMessage is the Message-aware form of IsUserAuthoredTurn.
+func IsUserAuthoredMessage(m provider.Message) bool {
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	if IsSyntheticUserMessage(m) {
+		return false
+	}
+	if _, isSteer := SteerText(m.Content); isSteer {
 		return false
 	}
 	return true

--- a/internal/agent/registry_surface.go
+++ b/internal/agent/registry_surface.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+
+	"reasonix/internal/tool"
+)
+
+// RegistrySurface names one of the three provider-visible tool surfaces built
+// at boot and reused for the process lifetime.
+type RegistrySurface string
+
+const (
+	SurfaceLegacy             RegistrySurface = "legacy"
+	SurfaceCapabilityClassic  RegistrySurface = "capability-classic"
+	SurfaceCapabilityHashline RegistrySurface = "capability-hashline"
+)
+
+// RegistryBundle holds the three provider surfaces plus the shared execution
+// registry used by use_capability / search_capabilities for optional tools.
+// Provider-visible schemas on capability surfaces never gain MCP tools at
+// runtime; only the execution registry and internal catalog update.
+type RegistryBundle struct {
+	mu sync.RWMutex
+
+	Legacy             *tool.Registry
+	CapabilityClassic  *tool.Registry
+	CapabilityHashline *tool.Registry
+	// Execution holds every enabled tool for proxy dispatch (includes optional
+	// tools not on the capability provider surface).
+	Execution *tool.Registry
+}
+
+// ProviderRegistry returns the registry for the given contract.
+// Falls back to Legacy when a capability surface was not built.
+func (b *RegistryBundle) ProviderRegistry(c RuntimeContract) *tool.Registry {
+	if b == nil {
+		return nil
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	c = NormalizeRuntimeContract(&c)
+	if !c.IsCapabilitySurface() {
+		if b.Legacy != nil {
+			return b.Legacy
+		}
+		// Single-surface boots store the active registry in Execution.
+		return b.Execution
+	}
+	if c.IsHashline() {
+		if b.CapabilityHashline != nil {
+			return b.CapabilityHashline
+		}
+		if b.CapabilityClassic != nil {
+			return b.CapabilityClassic
+		}
+	} else if b.CapabilityClassic != nil {
+		return b.CapabilityClassic
+	}
+	if b.Legacy != nil {
+		return b.Legacy
+	}
+	return b.Execution
+}
+
+// ExecutionRegistry returns the full proxy dispatch registry.
+func (b *RegistryBundle) ExecutionRegistry() *tool.Registry {
+	if b == nil {
+		return nil
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.Execution != nil {
+		return b.Execution
+	}
+	return b.Legacy
+}
+
+// SurfaceName returns the surface key for diagnostics.
+func (b *RegistryBundle) SurfaceName(c RuntimeContract) RegistrySurface {
+	c = NormalizeRuntimeContract(&c)
+	if !c.IsCapabilitySurface() {
+		return SurfaceLegacy
+	}
+	if c.IsHashline() {
+		return SurfaceCapabilityHashline
+	}
+	return SurfaceCapabilityClassic
+}
+
+// HasCapabilitySurfaces reports whether classic/hashline provider registries
+// were built (so Resume can switch without a full rebuild).
+func (b *RegistryBundle) HasCapabilitySurfaces() bool {
+	if b == nil {
+		return false
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.CapabilityClassic != nil || b.CapabilityHashline != nil
+}
+
+// MCPWriteTargets returns registries that receive MCP tool mutations:
+// Execution (always) and Legacy when distinct. Capability surfaces are never
+// included — their provider-visible schema stays stable across MCP connect.
+func (b *RegistryBundle) MCPWriteTargets() []*tool.Registry {
+	if b == nil {
+		return nil
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	var out []*tool.Registry
+	seen := map[*tool.Registry]bool{}
+	add := func(r *tool.Registry) {
+		if r == nil || seen[r] {
+			return
+		}
+		seen[r] = true
+		out = append(out, r)
+	}
+	add(b.Execution)
+	add(b.Legacy)
+	return out
+}
+
+// CoreCapabilityToolNames are always provider-visible on capability surfaces
+// (before classic/hashline edit tools).
+var CoreCapabilityToolNames = []string{
+	"ask",
+	"bash",
+	"bash_output",
+	"kill_shell",
+	"wait",
+	"search_capabilities",
+	"use_capability",
+}
+
+// ClassicEditToolNames are provider-visible only on classic edit protocol.
+var ClassicEditToolNames = []string{
+	"read_file",
+	"edit_file",
+	"write_file",
+}
+
+// HashlineEditToolNames are provider-visible only on hashline edit protocol.
+var HashlineEditToolNames = []string{
+	"hashline_read",
+	"hashline_edit",
+	"hashline_grep",
+}
+
+// ClassicExcludedFromHashline must not appear on hashline provider surface or
+// capability catalog (and use_capability hard-rejects them).
+var ClassicExcludedFromHashline = []string{
+	"read_file",
+	"edit_file",
+	"write_file",
+	"multi_edit",
+	"grep",
+}
+
+// HashlineExcludedFromClassic are rejected via use_capability on classic sessions.
+var HashlineExcludedFromClassic = []string{
+	"hashline_read",
+	"hashline_edit",
+	"hashline_grep",
+}
+
+// IsProviderVisibleCore reports whether name is always on capability surfaces.
+func IsProviderVisibleCore(name string) bool {
+	for _, n := range CoreCapabilityToolNames {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsCrossProtocolTool reports whether capability_id / tool name is forbidden
+// under the given edit protocol when routed through use_capability.
+// editProtocol accepts classic|hashline|classic-v1|hashline-v1; empty skips.
+func IsCrossProtocolTool(editProtocol, toolName string) bool {
+	toolName = strings.TrimSpace(toolName)
+	switch normalizeEditProtocol(editProtocol) {
+	case EditProtocolHashline:
+		for _, n := range ClassicExcludedFromHashline {
+			if n == toolName {
+				return true
+			}
+		}
+	case EditProtocolClassic:
+		for _, n := range HashlineExcludedFromClassic {
+			if n == toolName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FilterRegistryBySets copies tools from src whose names are in allow (nil = all)
+// and not in deny. Distinct from FilterRegistry (whitelist + exclude list) used
+// by sub-agent assembly.
+func FilterRegistryBySets(src *tool.Registry, allow map[string]bool, deny map[string]bool) *tool.Registry {
+	out := tool.NewRegistry()
+	if src == nil {
+		return out
+	}
+	for _, name := range src.Names() {
+		if deny != nil && deny[name] {
+			continue
+		}
+		if allow != nil && !allow[name] {
+			continue
+		}
+		if t, ok := src.Get(name); ok {
+			out.Add(t)
+		}
+	}
+	return out
+}
+
+// AllowSet builds a set from names.
+func AllowSet(names ...string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}

--- a/internal/agent/registry_surface_test.go
+++ b/internal/agent/registry_surface_test.go
@@ -1,0 +1,31 @@
+package agent
+
+import "testing"
+
+func TestIsCrossProtocolToolAcceptsShortAndWireForms(t *testing.T) {
+	// Wire form
+	if !IsCrossProtocolTool(EditProtocolHashline, "read_file") {
+		t.Fatal("hashline-v1 must reject classic read_file")
+	}
+	if !IsCrossProtocolTool(EditProtocolClassic, "hashline_edit") {
+		t.Fatal("classic-v1 must reject hashline_edit")
+	}
+	// Short CLI form
+	if !IsCrossProtocolTool("hashline", "write_file") {
+		t.Fatal("hashline must reject write_file")
+	}
+	if !IsCrossProtocolTool("classic", "hashline_read") {
+		t.Fatal("classic must reject hashline_read")
+	}
+	// Empty skips filtering
+	if IsCrossProtocolTool("", "hashline_edit") {
+		t.Fatal("empty protocol must not filter")
+	}
+	// Same-protocol tools are allowed
+	if IsCrossProtocolTool(EditProtocolHashline, "hashline_edit") {
+		t.Fatal("hashline must allow hashline_edit")
+	}
+	if IsCrossProtocolTool(EditProtocolClassic, "edit_file") {
+		t.Fatal("classic must allow edit_file")
+	}
+}

--- a/internal/agent/runtime_contract.go
+++ b/internal/agent/runtime_contract.go
@@ -1,0 +1,181 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Runtime contract constants pin the session-stable provider-visible surfaces.
+// Mid-session switching of these values is forbidden: cache keys, tool schemas,
+// and prompt layout must stay fixed for the life of a session.
+const (
+	ToolSurfaceLegacy      = "legacy-v1"
+	ToolSurfaceCapability  = "capability-v2"
+	EditProtocolClassic    = "classic-v1"
+	EditProtocolHashline   = "hashline-v1"
+	PromptLayoutSystem     = "system-v1"
+	PromptLayoutSessionCtx = "session-context-v2"
+)
+
+// RuntimeContract is the session-stable protocol bundle persisted in BranchMeta.
+// Old sidecars missing the field resolve to LegacyDefaultRuntimeContract.
+type RuntimeContract struct {
+	ToolSurface  string `json:"tool_surface"`  // legacy-v1 | capability-v2
+	EditProtocol string `json:"edit_protocol"` // classic-v1 | hashline-v1
+	PromptLayout string `json:"prompt_layout"` // system-v1 | session-context-v2
+}
+
+// LegacyDefaultRuntimeContract is used for pre-contract sessions and for
+// corrupted sidecars that cannot be inferred safely.
+func LegacyDefaultRuntimeContract() RuntimeContract {
+	return RuntimeContract{
+		ToolSurface:  ToolSurfaceLegacy,
+		EditProtocol: EditProtocolClassic,
+		PromptLayout: PromptLayoutSystem,
+	}
+}
+
+// DefaultRuntimeContract is the contract used when tests or callers request the
+// post-upgrade target (capability-v2 + session-context-v2 + classic). Product
+// new-session defaults stay on LegacyDefaultRuntimeContract until the release
+// gate in the capability-upgrade plan flips them.
+func DefaultRuntimeContract() RuntimeContract {
+	return RuntimeContract{
+		ToolSurface:  ToolSurfaceCapability,
+		EditProtocol: EditProtocolClassic,
+		PromptLayout: PromptLayoutSessionCtx,
+	}
+}
+
+// NormalizeRuntimeContract validates and canonicalizes a contract. Empty fields
+// fall back to the legacy triple so old data remains readable.
+func NormalizeRuntimeContract(c *RuntimeContract) RuntimeContract {
+	if c == nil {
+		return LegacyDefaultRuntimeContract()
+	}
+	out := *c
+	if strings.TrimSpace(out.ToolSurface) == "" {
+		out.ToolSurface = ToolSurfaceLegacy
+	}
+	if strings.TrimSpace(out.EditProtocol) == "" {
+		out.EditProtocol = EditProtocolClassic
+	}
+	if strings.TrimSpace(out.PromptLayout) == "" {
+		out.PromptLayout = PromptLayoutSystem
+	}
+	return out
+}
+
+// ValidateRuntimeContract returns an error for unknown enum values. Callers that
+// load user config must reject illegal values instead of silently correcting them.
+func ValidateRuntimeContract(c RuntimeContract) error {
+	switch c.ToolSurface {
+	case ToolSurfaceLegacy, ToolSurfaceCapability:
+	default:
+		return fmt.Errorf("unknown tool_surface %q (want %s|%s)", c.ToolSurface, ToolSurfaceLegacy, ToolSurfaceCapability)
+	}
+	switch c.EditProtocol {
+	case EditProtocolClassic, EditProtocolHashline:
+	default:
+		return fmt.Errorf("unknown edit_protocol %q (want %s|%s)", c.EditProtocol, EditProtocolClassic, EditProtocolHashline)
+	}
+	switch c.PromptLayout {
+	case PromptLayoutSystem, PromptLayoutSessionCtx:
+	default:
+		return fmt.Errorf("unknown prompt_layout %q (want %s|%s)", c.PromptLayout, PromptLayoutSystem, PromptLayoutSessionCtx)
+	}
+	// Hashline only exists as a capability-surface edit protocol.
+	if c.EditProtocol == EditProtocolHashline && c.ToolSurface != ToolSurfaceCapability {
+		return fmt.Errorf("edit_protocol %s requires tool_surface %s", EditProtocolHashline, ToolSurfaceCapability)
+	}
+	return nil
+}
+
+// Equal reports whether two contracts are identical after normalization.
+func (c RuntimeContract) Equal(other RuntimeContract) bool {
+	a := NormalizeRuntimeContract(&c)
+	b := NormalizeRuntimeContract(&other)
+	return a.ToolSurface == b.ToolSurface &&
+		a.EditProtocol == b.EditProtocol &&
+		a.PromptLayout == b.PromptLayout
+}
+
+// Clone returns a deep copy pointer suitable for BranchMeta persistence.
+func (c RuntimeContract) Clone() *RuntimeContract {
+	n := NormalizeRuntimeContract(&c)
+	return &n
+}
+
+// ResolveRuntimeContractFromMeta returns the contract for a loaded BranchMeta.
+// Missing fields always resolve to the legacy triple so old sessions keep their
+// original prompt and tool protocol (no in-place migration).
+func ResolveRuntimeContractFromMeta(meta BranchMeta) RuntimeContract {
+	return NormalizeRuntimeContract(meta.RuntimeContract)
+}
+
+// Config capability_surface / edit_protocol / prompt_layout map to wire values.
+// Empty capability_surface / prompt_layout keep the pre-gate legacy defaults;
+// pass "stable" / "session_context" to opt into the upgrade target.
+func RuntimeContractFromConfigValues(capabilitySurface, editProtocol, promptLayout string) (RuntimeContract, error) {
+	c := LegacyDefaultRuntimeContract()
+
+	switch strings.ToLower(strings.TrimSpace(capabilitySurface)) {
+	case "stable":
+		c.ToolSurface = ToolSurfaceCapability
+	case "", "legacy":
+		c.ToolSurface = ToolSurfaceLegacy
+	default:
+		return RuntimeContract{}, fmt.Errorf("tools.capability_surface: invalid value %q (want stable|legacy)", capabilitySurface)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(editProtocol)) {
+	case "", "classic":
+		c.EditProtocol = EditProtocolClassic
+	case "hashline":
+		c.EditProtocol = EditProtocolHashline
+	default:
+		return RuntimeContract{}, fmt.Errorf("tools.edit_protocol: invalid value %q (want classic|hashline)", editProtocol)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(promptLayout)) {
+	case "session_context":
+		c.PromptLayout = PromptLayoutSessionCtx
+	case "", "legacy_system":
+		c.PromptLayout = PromptLayoutSystem
+	default:
+		return RuntimeContract{}, fmt.Errorf("agent.prompt_layout: invalid value %q (want session_context|legacy_system)", promptLayout)
+	}
+
+	if err := ValidateRuntimeContract(c); err != nil {
+		return RuntimeContract{}, err
+	}
+	return c, nil
+}
+
+// ParseEditProtocolFlag maps CLI --edit-protocol classic|hashline to contract values.
+func ParseEditProtocolFlag(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "classic":
+		return EditProtocolClassic, nil
+	case "hashline":
+		return EditProtocolHashline, nil
+	default:
+		return "", fmt.Errorf("--edit-protocol: invalid value %q (want classic|hashline)", v)
+	}
+}
+
+// IsCapabilitySurface reports whether the contract uses the stable capability proxy.
+func (c RuntimeContract) IsCapabilitySurface() bool {
+	return NormalizeRuntimeContract(&c).ToolSurface == ToolSurfaceCapability
+}
+
+// IsHashline reports whether the contract uses Hashline edit tools.
+func (c RuntimeContract) IsHashline() bool {
+	return NormalizeRuntimeContract(&c).EditProtocol == EditProtocolHashline
+}
+
+// IsSessionContextLayout reports whether workspace/env/memory/skills live in a
+// pinned synthetic user message rather than the system prompt.
+func (c RuntimeContract) IsSessionContextLayout() bool {
+	return NormalizeRuntimeContract(&c).PromptLayout == PromptLayoutSessionCtx
+}

--- a/internal/agent/runtime_contract_test.go
+++ b/internal/agent/runtime_contract_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import "testing"
+
+func TestLegacyDefaultRuntimeContract(t *testing.T) {
+	c := LegacyDefaultRuntimeContract()
+	if c.ToolSurface != ToolSurfaceLegacy || c.EditProtocol != EditProtocolClassic || c.PromptLayout != PromptLayoutSystem {
+		t.Fatalf("legacy default = %+v", c)
+	}
+	if err := ValidateRuntimeContract(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDefaultRuntimeContract(t *testing.T) {
+	c := DefaultRuntimeContract()
+	if c.ToolSurface != ToolSurfaceCapability || c.EditProtocol != EditProtocolClassic || c.PromptLayout != PromptLayoutSessionCtx {
+		t.Fatalf("default = %+v", c)
+	}
+	if err := ValidateRuntimeContract(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNormalizeRuntimeContractNilIsLegacy(t *testing.T) {
+	got := NormalizeRuntimeContract(nil)
+	want := LegacyDefaultRuntimeContract()
+	if !got.Equal(want) {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestValidateRuntimeContractRejectsUnknown(t *testing.T) {
+	if err := ValidateRuntimeContract(RuntimeContract{ToolSurface: "x", EditProtocol: EditProtocolClassic, PromptLayout: PromptLayoutSystem}); err == nil {
+		t.Fatal("expected error for unknown tool surface")
+	}
+	if err := ValidateRuntimeContract(RuntimeContract{
+		ToolSurface:  ToolSurfaceLegacy,
+		EditProtocol: EditProtocolHashline,
+		PromptLayout: PromptLayoutSystem,
+	}); err == nil {
+		t.Fatal("hashline requires capability surface")
+	}
+}
+
+func TestRuntimeContractFromConfigValues(t *testing.T) {
+	c, err := RuntimeContractFromConfigValues("stable", "classic", "session_context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Equal(DefaultRuntimeContract()) {
+		t.Fatalf("got %+v", c)
+	}
+	legacy, err := RuntimeContractFromConfigValues("legacy", "classic", "legacy_system")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !legacy.Equal(LegacyDefaultRuntimeContract()) {
+		t.Fatalf("got %+v", legacy)
+	}
+	_, err = RuntimeContractFromConfigValues("nope", "classic", "session_context")
+	if err == nil {
+		t.Fatal("expected config error")
+	}
+	_, err = RuntimeContractFromConfigValues("legacy", "hashline", "legacy_system")
+	if err == nil {
+		t.Fatal("hashline+legacy surface must fail")
+	}
+}
+
+func TestResolveRuntimeContractFromMeta(t *testing.T) {
+	old := ResolveRuntimeContractFromMeta(BranchMeta{})
+	if !old.Equal(LegacyDefaultRuntimeContract()) {
+		t.Fatalf("missing meta field should be legacy, got %+v", old)
+	}
+	want := DefaultRuntimeContract()
+	got := ResolveRuntimeContractFromMeta(BranchMeta{RuntimeContract: want.Clone()})
+	if !got.Equal(want) {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestParseEditProtocolFlag(t *testing.T) {
+	got, err := ParseEditProtocolFlag("hashline")
+	if err != nil || got != EditProtocolHashline {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	if _, err := ParseEditProtocolFlag("x"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/agent/search_capabilities.go
+++ b/internal/agent/search_capabilities.go
@@ -1,0 +1,243 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/capability"
+	"reasonix/internal/plugin"
+	"reasonix/internal/tool"
+)
+
+// SearchCapabilitiesTool is the stable, read-only catalog search tool. It never
+// starts MCP processes, opens network connections, or prompts for permission.
+type SearchCapabilitiesTool struct {
+	catalog func() capability.Catalog
+	// schemas returns capability_id → input JSON Schema. Prefer a live function
+	// over a static map so execution-registry and MCP cache schemas stay current
+	// without touching the provider-visible tool schema.
+	schemas func() map[string]json.RawMessage
+}
+
+// NewSearchCapabilitiesTool builds search_capabilities.
+// catalog may be nil (empty results). schemas may be a static map or nil;
+// prefer NewSearchCapabilitiesToolDynamic for production wiring.
+func NewSearchCapabilitiesTool(catalog func() capability.Catalog, schemas map[string]json.RawMessage) *SearchCapabilitiesTool {
+	var fn func() map[string]json.RawMessage
+	if len(schemas) > 0 {
+		copySchemas := make(map[string]json.RawMessage, len(schemas))
+		for k, v := range schemas {
+			copySchemas[k] = append(json.RawMessage(nil), v...)
+		}
+		fn = func() map[string]json.RawMessage { return copySchemas }
+	}
+	return &SearchCapabilitiesTool{catalog: catalog, schemas: fn}
+}
+
+// NewSearchCapabilitiesToolDynamic builds search_capabilities with a live schema
+// resolver (execution registry + MCP cache). The resolver runs only inside
+// Execute; it never mutates provider-visible tool schemas.
+func NewSearchCapabilitiesToolDynamic(catalog func() capability.Catalog, schemas func() map[string]json.RawMessage) *SearchCapabilitiesTool {
+	return &SearchCapabilitiesTool{catalog: catalog, schemas: schemas}
+}
+
+func (*SearchCapabilitiesTool) Name() string { return "search_capabilities" }
+
+func (*SearchCapabilitiesTool) Description() string {
+	return "Search the capability catalog by free-text query. Returns ranked tool, skill, and MCP capabilities with metadata and input schemas. Read-only: never starts MCP servers, network calls, or permission prompts. Prefer this before use_capability(action=\"inspect\") when looking up which capability_id to call."
+}
+
+func (*SearchCapabilitiesTool) ReadOnly() bool { return true }
+
+func (*SearchCapabilitiesTool) Schema() json.RawMessage {
+	// Stable schema — must not change across turns.
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"query":{"type":"string","minLength":1},
+			"limit":{"type":"integer","minimum":1,"maximum":10,"default":5},
+			"kind":{"type":"string","enum":["all","tool","skill","mcp"],"default":"all"}
+		},
+		"required":["query"]
+	}`)
+}
+
+type searchCapabilitiesResult struct {
+	Status  string                  `json:"status"`
+	Query   string                  `json:"query"`
+	Total   int                     `json:"total"`
+	Results []searchCapabilitiesHit `json:"results"`
+}
+
+type searchCapabilitiesHit struct {
+	CapabilityID string          `json:"capability_id"`
+	Kind         string          `json:"kind"`
+	Name         string          `json:"name"`
+	Source       string          `json:"source"`
+	Description  string          `json:"description"`
+	Status       string          `json:"status"`
+	ReadOnly     bool            `json:"read_only"`
+	Requires     []string        `json:"requires"`
+	InputSchema  json.RawMessage `json:"input_schema"`
+	Score        float64         `json:"score"`
+}
+
+func (t *SearchCapabilitiesTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+		Kind  string `json:"kind"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	query := strings.TrimSpace(p.Query)
+	if query == "" {
+		return "", fmt.Errorf("query is required")
+	}
+	kind := capability.ParseSearchKind(p.Kind)
+	switch kind {
+	case capability.SearchKindAll, capability.SearchKindTool, capability.SearchKindSkill, capability.SearchKindMCP:
+	default:
+		return "", fmt.Errorf("kind must be one of all, tool, skill, mcp; got %q", p.Kind)
+	}
+
+	var entries []capability.Entry
+	if t.catalog != nil {
+		entries = t.catalog().Entries
+	}
+	hits := capability.Search(entries, capability.SearchOptions{
+		Query: query,
+		Limit: p.Limit,
+		Kind:  kind,
+	})
+
+	schemaMap := map[string]json.RawMessage{}
+	if t.schemas != nil {
+		if m := t.schemas(); m != nil {
+			schemaMap = m
+		}
+	}
+
+	out := searchCapabilitiesResult{
+		Status:  "ready",
+		Query:   query,
+		Total:   len(hits),
+		Results: make([]searchCapabilitiesHit, 0, len(hits)),
+	}
+	for _, h := range hits {
+		e := h.Entry
+		requires := e.Requires
+		if requires == nil {
+			requires = []string{}
+		}
+		schema := resolveCapabilitySchema(schemaMap, e)
+		status := string(e.Status)
+		if status == "" {
+			status = string(capability.StatusReady)
+		}
+		source := e.Source
+		if source == "" && e.Kind == capability.KindTool {
+			source = "builtin"
+		}
+		out.Results = append(out.Results, searchCapabilitiesHit{
+			CapabilityID: e.ID,
+			Kind:         string(e.Kind),
+			Name:         e.Name,
+			Source:       source,
+			Description:  e.Description,
+			Status:       status,
+			ReadOnly:     e.ReadOnly,
+			Requires:     requires,
+			InputSchema:  schema,
+			Score:        h.Score,
+		})
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func resolveCapabilitySchema(schemas map[string]json.RawMessage, e capability.Entry) json.RawMessage {
+	empty := json.RawMessage(`{}`)
+	if len(schemas) == 0 {
+		return empty
+	}
+	if raw, ok := schemas[e.ID]; ok && len(raw) > 0 && string(raw) != "null" {
+		return raw
+	}
+	if e.ToolName != "" {
+		if raw, ok := schemas["tool:"+e.ToolName]; ok && len(raw) > 0 && string(raw) != "null" {
+			return raw
+		}
+	}
+	return empty
+}
+
+// SchemasFromContractEntries builds a capability_id → schema map from provider-
+// visible or execution-registry contract snapshots.
+func SchemasFromContractEntries(entries []tool.ContractEntry) map[string]json.RawMessage {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(entries))
+	for _, e := range entries {
+		if e.Name == "" || len(e.Schema) == 0 {
+			continue
+		}
+		id := "tool:" + e.Name
+		if server, raw, ok := tool.SplitMCPName(e.Name); ok {
+			id = "mcp-tool:" + server + "/" + raw
+		}
+		out[id] = append(json.RawMessage(nil), e.Schema...)
+	}
+	return out
+}
+
+// SchemasFromCachedMCPTools merges MCP schema-cache / proxy-live tools into a
+// capability_id → schema map. Does not start servers or network I/O.
+func SchemasFromCachedMCPTools(byServer map[string][]plugin.CachedTool) map[string]json.RawMessage {
+	if len(byServer) == 0 {
+		return nil
+	}
+	out := make(map[string]json.RawMessage)
+	for server, tools := range byServer {
+		server = strings.TrimSpace(server)
+		if server == "" {
+			continue
+		}
+		for _, ct := range tools {
+			name := strings.TrimSpace(ct.Name)
+			if name == "" || len(ct.Schema) == 0 {
+				continue
+			}
+			id := "mcp-tool:" + server + "/" + name
+			out[id] = append(json.RawMessage(nil), ct.Schema...)
+		}
+	}
+	return out
+}
+
+// MergeSchemaMaps returns a new map with later maps overwriting earlier keys.
+func MergeSchemaMaps(maps ...map[string]json.RawMessage) map[string]json.RawMessage {
+	out := map[string]json.RawMessage{}
+	for _, m := range maps {
+		for k, v := range m {
+			if len(v) == 0 {
+				continue
+			}
+			out[k] = append(json.RawMessage(nil), v...)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// Ensure SearchCapabilitiesTool satisfies the tool contract.
+var _ tool.Tool = (*SearchCapabilitiesTool)(nil)

--- a/internal/agent/search_capabilities_test.go
+++ b/internal/agent/search_capabilities_test.go
@@ -1,0 +1,254 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/capability"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestSearchCapabilitiesSchemaStability(t *testing.T) {
+	tl := NewSearchCapabilitiesTool(nil, nil)
+	if tl.Name() != "search_capabilities" {
+		t.Fatalf("name = %q", tl.Name())
+	}
+	if !tl.ReadOnly() {
+		t.Fatal("search_capabilities must be ReadOnly")
+	}
+	raw := string(tl.Schema())
+	for _, want := range []string{
+		`"query"`,
+		`"minLength":1`,
+		`"limit"`,
+		`"minimum":1`,
+		`"maximum":10`,
+		`"default":5`,
+		`"kind"`,
+		`"enum":["all","tool","skill","mcp"]`,
+		`"required":["query"]`,
+	} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("schema missing %s:\n%s", want, raw)
+		}
+	}
+}
+
+func TestSearchCapabilitiesExecute(t *testing.T) {
+	cat := capability.Catalog{Entries: []capability.Entry{
+		{ID: "tool:grep", Kind: capability.KindTool, Name: "grep", Description: "search file contents", Status: capability.StatusReady, ReadOnly: true, ToolName: "grep"},
+		{ID: "tool:write_file", Kind: capability.KindTool, Name: "write_file", Description: "write files", Status: capability.StatusReady, ReadOnly: false, ToolName: "write_file"},
+		{ID: "skill:review", Kind: capability.KindSkill, Name: "review", Description: "review code", Status: capability.StatusReady, Source: "builtin", Requires: []string{"tool:read_file"}},
+		{ID: "mcp-server:disabled", Kind: capability.KindMCPServer, Name: "disabled", Description: "off", Status: capability.StatusDisabled},
+	}}
+	schemas := map[string]json.RawMessage{
+		"tool:grep": json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"}}}`),
+	}
+	tl := NewSearchCapabilitiesTool(func() capability.Catalog { return cat }, schemas)
+
+	out, err := tl.Execute(context.Background(), json.RawMessage(`{"query":"grep","limit":5,"kind":"tool"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res struct {
+		Status  string `json:"status"`
+		Query   string `json:"query"`
+		Total   int    `json:"total"`
+		Results []struct {
+			CapabilityID string          `json:"capability_id"`
+			Kind         string          `json:"kind"`
+			Name         string          `json:"name"`
+			Source       string          `json:"source"`
+			ReadOnly     bool            `json:"read_only"`
+			Requires     []string        `json:"requires"`
+			InputSchema  json.RawMessage `json:"input_schema"`
+			Score        float64         `json:"score"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if res.Status != "ready" || res.Query != "grep" || res.Total < 1 {
+		t.Fatalf("result = %+v", res)
+	}
+	if res.Results[0].CapabilityID != "tool:grep" {
+		t.Fatalf("top = %+v", res.Results[0])
+	}
+	if res.Results[0].Source != "builtin" {
+		t.Fatalf("source = %q, want builtin default for tools", res.Results[0].Source)
+	}
+	if !res.Results[0].ReadOnly {
+		t.Fatal("grep should be read_only")
+	}
+	if !strings.Contains(string(res.Results[0].InputSchema), "pattern") {
+		t.Fatalf("input_schema = %s", res.Results[0].InputSchema)
+	}
+	for _, r := range res.Results {
+		if r.CapabilityID == "mcp-server:disabled" {
+			t.Fatal("disabled capability must not appear")
+		}
+	}
+}
+
+func TestSearchCapabilitiesRequiresQuery(t *testing.T) {
+	tl := NewSearchCapabilitiesTool(nil, nil)
+	if _, err := tl.Execute(context.Background(), json.RawMessage(`{"query":""}`)); err == nil {
+		t.Fatal("empty query should fail")
+	}
+	if _, err := tl.Execute(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("missing query should fail")
+	}
+}
+
+func TestSchemasFromContractEntries(t *testing.T) {
+	schemas := SchemasFromContractEntries([]tool.ContractEntry{
+		{Name: "grep", Schema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "mcp__gh__search", Schema: json.RawMessage(`{"type":"object","properties":{}}`)},
+	})
+	if _, ok := schemas["tool:grep"]; !ok {
+		t.Fatalf("missing tool:grep: %v", schemas)
+	}
+	if _, ok := schemas["mcp-tool:gh/search"]; !ok {
+		t.Fatalf("missing mcp-tool:gh/search: %v", schemas)
+	}
+}
+
+func TestSearchCapabilitiesDynamicSchemas(t *testing.T) {
+	cat := capability.Catalog{Entries: []capability.Entry{
+		{ID: "tool:grep", Kind: capability.KindTool, Name: "grep", Description: "search", Status: capability.StatusReady, ToolName: "grep"},
+		{ID: "mcp-tool:gh/search", Kind: capability.KindMCPTool, Name: "gh/search", Description: "mcp search", Status: capability.StatusReady, Source: "gh"},
+	}}
+	call := 0
+	tl := NewSearchCapabilitiesToolDynamic(
+		func() capability.Catalog { return cat },
+		func() map[string]json.RawMessage {
+			call++
+			return map[string]json.RawMessage{
+				"tool:grep":          json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"}}}`),
+				"mcp-tool:gh/search": json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`),
+			}
+		},
+	)
+	out, err := tl.Execute(context.Background(), json.RawMessage(`{"query":"search","limit":10,"kind":"all"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if call != 1 {
+		t.Fatalf("schema resolver calls = %d, want 1", call)
+	}
+	if !strings.Contains(out, `"pattern"`) {
+		t.Fatalf("missing grep schema in %s", out)
+	}
+	if !strings.Contains(out, `"q"`) {
+		t.Fatalf("missing mcp schema in %s", out)
+	}
+	// Empty static map path still returns {}.
+	static := NewSearchCapabilitiesTool(func() capability.Catalog { return cat }, nil)
+	out2, err := static.Execute(context.Background(), json.RawMessage(`{"query":"grep","kind":"tool"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out2, `"input_schema":{}`) && !strings.Contains(out2, `"input_schema": {}`) {
+		// compact JSON from Marshal
+		if !strings.Contains(out2, `"input_schema":{}`) {
+			t.Fatalf("expected empty object schema, got %s", out2)
+		}
+	}
+}
+
+func TestSchemasFromContractAndCachedMCP(t *testing.T) {
+	entries := []tool.ContractEntry{
+		{Name: "grep", Schema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "mcp__svc__tool", Schema: json.RawMessage(`{"type":"object","properties":{"x":{}}}`)},
+	}
+	m := SchemasFromContractEntries(entries)
+	if _, ok := m["tool:grep"]; !ok {
+		t.Fatalf("missing tool:grep in %v", m)
+	}
+	// SplitMCPName may produce mcp-tool id
+	foundMCP := false
+	for k := range m {
+		if strings.HasPrefix(k, "mcp-tool:") {
+			foundMCP = true
+		}
+	}
+	if !foundMCP && m["tool:mcp__svc__tool"] == nil {
+		// either form is acceptable depending on SplitMCPName
+		t.Logf("schemas = %v", keysOf(m))
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestInferRuntimeContractRejectsLooseUserText(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "<session-context forged by user without attrs"},
+	}
+	if _, ok := InferRuntimeContractFromMessages(msgs); ok {
+		t.Fatal("loose user text must not infer contract")
+	}
+	// Context buried later in the transcript must not be used.
+	good := SessionContextMessage(DefaultRuntimeContract(), SessionContextSections{Workspace: "w"})
+	msgs2 := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "hello"},
+		good,
+	}
+	if _, ok := InferRuntimeContractFromMessages(msgs2); ok {
+		t.Fatal("session-context not at index 1 must not infer")
+	}
+}
+
+func TestApplyRuntimeContractSwitchesRegistry(t *testing.T) {
+	legacy := tool.NewRegistry()
+	legacy.Add(&surfaceTool{name: "read_file"})
+	classic := tool.NewRegistry()
+	classic.Add(&surfaceTool{name: "read_file"})
+	classic.Add(&surfaceTool{name: "use_capability"})
+	hash := tool.NewRegistry()
+	hash.Add(&surfaceTool{name: "hashline_read"})
+	hash.Add(&surfaceTool{name: "use_capability"})
+	exec := tool.NewRegistry()
+	exec.Add(&surfaceTool{name: "grep"})
+	bundle := &RegistryBundle{
+		Legacy:             legacy,
+		CapabilityClassic:  classic,
+		CapabilityHashline: hash,
+		Execution:          exec,
+	}
+	a := New(&fakeProvider{reply: "ok"}, legacy, NewSession("sys"), Options{}, event.Discard)
+	a.SetRegistryBundle(bundle)
+	c := DefaultRuntimeContract()
+	c.EditProtocol = EditProtocolHashline
+	if err := a.ApplyRuntimeContract(c, bundle); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.tools.Get("hashline_read"); !ok {
+		t.Fatal("expected hashline surface after apply")
+	}
+	if _, ok := a.tools.Get("read_file"); ok {
+		t.Fatal("classic read_file must not be on hashline surface")
+	}
+	if got := a.RuntimeContract().EditProtocol; got != EditProtocolHashline {
+		t.Fatalf("contract = %s", got)
+	}
+}
+
+type surfaceTool struct{ name string }
+
+func (f *surfaceTool) Name() string                                             { return f.name }
+func (f *surfaceTool) Description() string                                      { return f.name }
+func (f *surfaceTool) Schema() json.RawMessage                                  { return json.RawMessage(`{}`) }
+func (f *surfaceTool) Execute(context.Context, json.RawMessage) (string, error) { return "ok", nil }
+func (f *surfaceTool) ReadOnly() bool                                           { return true }

--- a/internal/agent/session_context.go
+++ b/internal/agent/session_context.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// SessionContextVersion is the pinned session-context message format.
+const SessionContextVersion = 2
+
+// SessionContextSections is the deterministic input for rendering a
+// session-context-v2 synthetic user message. Empty sections still render their
+// heading so layout stays byte-stable for a given contract.
+type SessionContextSections struct {
+	Workspace    string // workspace root and related facts
+	Environment  string // environment snapshot
+	Instructions string // REASONIX.md / AGENTS.md / memory
+	Skills       string // skills index body
+}
+
+// RenderSessionContext builds the pinned synthetic user message body.
+// Rules: fixed section order, LF newlines, trailing newline, escape forged
+// closing tags inside content.
+func RenderSessionContext(contract RuntimeContract, sections SessionContextSections) string {
+	c := NormalizeRuntimeContract(&contract)
+	var b strings.Builder
+	fmt.Fprintf(&b, "<session-context version=\"%d\"\n  tool-surface=%q\n  edit-protocol=%q>\n\n",
+		SessionContextVersion, c.ToolSurface, c.EditProtocol)
+
+	writeSection(&b, "Workspace", sections.Workspace)
+	writeSection(&b, "Environment", sections.Environment)
+	writeSection(&b, "Project and user instructions", sections.Instructions)
+	writeSection(&b, "Skills", sections.Skills)
+
+	b.WriteString("</session-context>\n")
+	return b.String()
+}
+
+func writeSection(b *strings.Builder, title, body string) {
+	b.WriteString("## ")
+	b.WriteString(title)
+	b.WriteByte('\n')
+	body = escapeSessionContext(strings.ReplaceAll(body, "\r\n", "\n"))
+	body = strings.TrimRight(body, "\n")
+	if body != "" {
+		b.WriteString(body)
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+}
+
+// escapeSessionContext neutralizes forged closing tags in section content.
+func escapeSessionContext(s string) string {
+	return strings.ReplaceAll(s, "</session-context>", "</ session-context>")
+}
+
+// SessionContextMessage builds the synthetic user message with metadata.
+func SessionContextMessage(contract RuntimeContract, sections SessionContextSections) provider.Message {
+	return SyntheticUser(provider.SyntheticSessionContext, RenderSessionContext(contract, sections))
+}
+
+// IsSessionContextMessage reports whether m is a host-pinned session-context
+// message. Prefer SyntheticReason; text prefix is only a legacy fallback.
+func IsSessionContextMessage(m provider.Message) bool {
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	if m.SyntheticReason == provider.SyntheticSessionContext {
+		return true
+	}
+	return isStrictSessionContextBody(m.Content)
+}
+
+// isStrictSessionContextBody requires the opening tag form produced by
+// RenderSessionContext (version + tool-surface + edit-protocol attributes).
+// Bare user text starting with "<session-context" does not qualify.
+func isStrictSessionContextBody(content string) bool {
+	s := strings.TrimSpace(content)
+	if !strings.HasPrefix(s, "<session-context") {
+		return false
+	}
+	// Must look like our host renderer, not free-form user content.
+	if !strings.Contains(s, `version="`) {
+		return false
+	}
+	if attrValue(s, "tool-surface") == "" || attrValue(s, "edit-protocol") == "" {
+		return false
+	}
+	if !strings.Contains(s, "</session-context>") {
+		return false
+	}
+	return true
+}
+
+// FindSessionContextIndex returns the index of the pinned session-context
+// message, or -1 if absent. Host layout places it immediately after system
+// (index 1 when system is present).
+func FindSessionContextIndex(msgs []provider.Message) int {
+	// Strict position: only accept index 1 after a system message, or index 0
+	// when there is no system (tests). Never scan arbitrary later user turns.
+	if len(msgs) == 0 {
+		return -1
+	}
+	if msgs[0].Role == provider.RoleSystem {
+		if len(msgs) > 1 && IsSessionContextMessage(msgs[1]) {
+			return 1
+		}
+		return -1
+	}
+	if IsSessionContextMessage(msgs[0]) {
+		return 0
+	}
+	return -1
+}
+
+// InferRuntimeContractFromMessages attempts to recover a contract from a
+// session-context message when the sidecar is missing/corrupt. Only the
+// host-positioned message (immediately after system) with strict attributes is
+// accepted; otherwise ok=false and callers must fall back to legacy.
+func InferRuntimeContractFromMessages(msgs []provider.Message) (RuntimeContract, bool) {
+	idx := FindSessionContextIndex(msgs)
+	if idx < 0 {
+		return RuntimeContract{}, false
+	}
+	// Must be immediately after system when a system message exists.
+	if idx == 1 && msgs[0].Role != provider.RoleSystem {
+		return RuntimeContract{}, false
+	}
+	if idx > 1 {
+		return RuntimeContract{}, false
+	}
+	content := msgs[idx].Content
+	if !isStrictSessionContextBody(content) && msgs[idx].SyntheticReason != provider.SyntheticSessionContext {
+		return RuntimeContract{}, false
+	}
+	surface := attrValue(content, "tool-surface")
+	edit := attrValue(content, "edit-protocol")
+	if surface == "" || edit == "" {
+		// Metadata-only synthetic message without render attributes cannot be inferred.
+		return RuntimeContract{}, false
+	}
+	c := RuntimeContract{
+		ToolSurface:  surface,
+		EditProtocol: edit,
+		PromptLayout: PromptLayoutSessionCtx,
+	}
+	if err := ValidateRuntimeContract(c); err != nil {
+		return RuntimeContract{}, false
+	}
+	return c, true
+}
+
+func attrValue(s, key string) string {
+	// Parse tool-surface="..." or tool-surface='...' from the opening tag region.
+	needle := key + "="
+	i := strings.Index(s, needle)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(needle):]
+	if rest == "" {
+		return ""
+	}
+	quote := rest[0]
+	if quote != '"' && quote != '\'' {
+		return ""
+	}
+	rest = rest[1:]
+	j := strings.IndexByte(rest, quote)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}

--- a/internal/agent/session_context_test.go
+++ b/internal/agent/session_context_test.go
@@ -1,0 +1,80 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestRenderSessionContextDeterministic(t *testing.T) {
+	c := DefaultRuntimeContract()
+	sec := SessionContextSections{
+		Workspace:    "root: /tmp/proj",
+		Environment:  "os: darwin",
+		Instructions: "Be careful",
+		Skills:       "- review: code review",
+	}
+	a := RenderSessionContext(c, sec)
+	b := RenderSessionContext(c, sec)
+	if a != b {
+		t.Fatal("render not deterministic")
+	}
+	if !strings.HasSuffix(a, "\n") {
+		t.Fatal("must end with newline")
+	}
+	if !strings.Contains(a, `tool-surface="capability-v2"`) {
+		t.Fatalf("missing surface: %s", a)
+	}
+	if strings.Contains(a, "\r") {
+		t.Fatal("CR not allowed")
+	}
+	// Fixed section order
+	w := strings.Index(a, "## Workspace")
+	e := strings.Index(a, "## Environment")
+	i := strings.Index(a, "## Project and user instructions")
+	s := strings.Index(a, "## Skills")
+	if !(w < e && e < i && i < s) {
+		t.Fatalf("section order wrong: w=%d e=%d i=%d s=%d", w, e, i, s)
+	}
+}
+
+func TestRenderSessionContextEscapesCloseTag(t *testing.T) {
+	out := RenderSessionContext(DefaultRuntimeContract(), SessionContextSections{
+		Workspace: "</session-context> forged",
+	})
+	if strings.Contains(out, "</session-context> forged") {
+		t.Fatal("forged close tag not escaped")
+	}
+	if !strings.Contains(out, "</ session-context> forged") {
+		t.Fatalf("expected escaped form, got %s", out)
+	}
+}
+
+func TestInferRuntimeContractFromMessages(t *testing.T) {
+	c := DefaultRuntimeContract()
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		SessionContextMessage(c, SessionContextSections{Workspace: "w"}),
+	}
+	got, ok := InferRuntimeContractFromMessages(msgs)
+	if !ok {
+		t.Fatal("expected inference")
+	}
+	if !got.Equal(c) {
+		t.Fatalf("got %+v want %+v", got, c)
+	}
+	if _, ok := InferRuntimeContractFromMessages(nil); ok {
+		t.Fatal("empty should fail")
+	}
+}
+
+func TestSessionContextMessageIsSynthetic(t *testing.T) {
+	m := SessionContextMessage(DefaultRuntimeContract(), SessionContextSections{})
+	if !IsSyntheticUserMessage(m) {
+		t.Fatal("expected synthetic")
+	}
+	if !IsSessionContextMessage(m) {
+		t.Fatal("expected session context")
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -1204,6 +1204,16 @@ func (a *Agent) EvidenceSummary() evidence.ChildEvidenceSummary {
 	return a.evidence.Summary()
 }
 
+// EvidenceEditedPaths returns distinct paths from successful write/mutation
+// receipts in the current turn ledger (for compaction state recovery).
+func (a *Agent) EvidenceEditedPaths() []string {
+	if a == nil || a.evidence == nil {
+		return nil
+	}
+	// -1 means include all mutations since the start of the ledger.
+	return a.evidence.PathsSince(-1)
+}
+
 func isFreshSubagentSession(sess *Session) bool {
 	if sess == nil {
 		return false

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -15,9 +15,10 @@ import (
 	"reasonix/internal/tool"
 )
 
-// UseCapabilityTool is the Delivery-only stable proxy for inspecting, calling,
-// or declining catalog capabilities. Call never adds dynamic MCP tools to the
-// main registry — subsequent calls keep using this stable schema.
+// UseCapabilityTool is the stable proxy for inspecting, calling, or declining
+// catalog capabilities (tool:*, skill:*, mcp-tool:*, mcp-server:*). Call never
+// adds dynamic MCP tools to the provider-visible registry — subsequent calls
+// keep using this stable schema.
 type UseCapabilityTool struct {
 	mu sync.Mutex
 
@@ -30,11 +31,25 @@ type UseCapabilityTool struct {
 	// specs are the boot-converted plugin specs (env expansion, workspace
 	// overrides, timeouts, trusted read-only tools). The proxy never rebuilds
 	// specs from raw config entries — that would fork the conversion logic.
-	specs    []plugin.Spec
-	registry *tool.Registry // live registry for already-exposed MCP tools
-	ledger   *capability.Ledger
-	audit    *capability.Audit
-	catalog  func() capability.Catalog
+	specs []plugin.Spec
+	// registry is the provider-visible registry (already-exposed MCP tools).
+	registry *tool.Registry
+	// execution is the full execution registry used for tool:* resolution. It
+	// may include tools that are not provider-visible (hidden under capability
+	// surface). When nil, tool:* falls back to registry.
+	execution *tool.Registry
+	// skillRunner is the hidden run_skill tool used for skill:* calls. When
+	// nil, skill:* looks up "run_skill" on execution then registry.
+	skillRunner tool.Tool
+	// rejectIDs optionally hard-rejects a capability_id before resolution
+	// (e.g. protocol or policy filters).
+	rejectIDs func(id string) error
+	// editProtocol is classic-v1|hashline-v1 (or classic|hashline). When set,
+	// cross-protocol file-edit capability IDs are rejected.
+	editProtocol string
+	ledger       *capability.Ledger
+	audit        *capability.Audit
+	catalog      func() capability.Catalog
 	// proxyClients holds on-demand connected clients that must not pollute the
 	// provider-visible registry. Tools are looked up via host.ToolsFor.
 	connected map[string]bool
@@ -44,9 +59,11 @@ type UseCapabilityTool struct {
 	liveTools map[string][]plugin.CachedTool
 }
 
-// NewUseCapabilityTool builds the Delivery-only capability proxy. lifeCtx is
-// the session-scoped context that owns on-demand MCP subprocess lifetimes;
-// specs must be the same boot-converted specs used for auto-started servers.
+// NewUseCapabilityTool builds the capability proxy. lifeCtx is the
+// session-scoped context that owns on-demand MCP subprocess lifetimes; specs
+// must be the same boot-converted specs used for auto-started servers.
+// Optional execution registry, skill runner, and protocol filters are set via
+// With* methods after construction.
 func NewUseCapabilityTool(lifeCtx context.Context, host *plugin.Host, specs []plugin.Spec, reg *tool.Registry, ledger *capability.Ledger, audit *capability.Audit, catalog func() capability.Catalog) *UseCapabilityTool {
 	return &UseCapabilityTool{
 		host:      host,
@@ -60,10 +77,43 @@ func NewUseCapabilityTool(lifeCtx context.Context, host *plugin.Host, specs []pl
 	}
 }
 
+// WithExecutionRegistry sets the registry used for tool:* resolution.
+func (t *UseCapabilityTool) WithExecutionRegistry(reg *tool.Registry) *UseCapabilityTool {
+	t.execution = reg
+	return t
+}
+
+// WithSkillRunner sets the hidden run_skill tool used for skill:* calls.
+func (t *UseCapabilityTool) WithSkillRunner(tl tool.Tool) *UseCapabilityTool {
+	t.skillRunner = tl
+	return t
+}
+
+// WithRejectIDs installs a hard-reject hook for capability IDs.
+func (t *UseCapabilityTool) WithRejectIDs(fn func(id string) error) *UseCapabilityTool {
+	t.rejectIDs = fn
+	return t
+}
+
+// WithEditProtocol sets classic/hashline filtering for file-edit capabilities.
+func (t *UseCapabilityTool) WithEditProtocol(protocol string) *UseCapabilityTool {
+	t.editProtocol = strings.TrimSpace(protocol)
+	return t
+}
+
+// EditProtocol returns the live edit protocol used for cross-protocol rejection
+// and catalog search filtering.
+func (t *UseCapabilityTool) EditProtocol() string {
+	if t == nil {
+		return ""
+	}
+	return t.editProtocol
+}
+
 func (*UseCapabilityTool) Name() string { return "use_capability" }
 
 func (*UseCapabilityTool) Description() string {
-	return "Delivery profile capability proxy: inspect Skill/MCP metadata, call MCP tools (including auto_start=false servers) without changing the provider tool schema, or decline a prefer capability with a non-empty reason. Skills still use run_skill; this tool only proxies MCP calls."
+	return "Capability proxy: inspect catalog metadata, call tool:*, skill:*, mcp-tool:*, or mcp-server:* capabilities without changing the provider tool schema, or decline a prefer capability with a non-empty reason. MCP servers with auto_start=false connect on demand after approval. Prefer search_capabilities to discover IDs first."
 }
 
 func (*UseCapabilityTool) ReadOnly() bool { return true }
@@ -104,6 +154,9 @@ func (t *UseCapabilityTool) ResolveCall(ctx context.Context, args json.RawMessag
 		ProxyAction:  action,
 		CapabilityID: id,
 		Args:         p.Arguments,
+	}
+	if err := t.allowCapabilityID(id); err != nil {
+		return tool.ResolvedCall{}, err
 	}
 	switch action {
 	case "inspect":
@@ -302,12 +355,17 @@ func (t *UseCapabilityTool) resolveCall(ctx context.Context, id string, args jso
 	if server, ok := parseMCPServerCapabilityID(id); ok {
 		return t.resolveServerConnect(ctx, server, base)
 	}
+	if name, ok := parseToolCapabilityID(id); ok {
+		return t.resolveToolCall(name, args, base)
+	}
+	if name, ok := parseSkillCapabilityID(id); ok {
+		return t.resolveSkillCall(name, args, base)
+	}
+	if strings.HasPrefix(id, "source:") {
+		return tool.ResolvedCall{}, fmt.Errorf("%q is a legacy source id; use tool:*, skill:*, mcp-tool:*, or mcp-server:* capability ids", id)
+	}
 	server, raw, err := parseMCPCapabilityID(id)
 	if err != nil {
-		// Skills must use run_skill.
-		if strings.HasPrefix(id, "skill:") {
-			return tool.ResolvedCall{}, fmt.Errorf("call only proxies MCP tools; use run_skill for %s", id)
-		}
 		return tool.ResolvedCall{}, err
 	}
 	// Prefer already-exposed registry tool (auto-started MCP). The model name
@@ -744,8 +802,210 @@ func parseMCPCapabilityID(id string) (server, raw string, err error) {
 	case strings.HasPrefix(id, "mcp-server:"):
 		return "", "", fmt.Errorf("%q is a server id; call it directly to connect and list tools, or use mcp-tool:<server>/<tool>", id)
 	default:
-		return "", "", fmt.Errorf("action=call requires an mcp-tool capability id, got %q", id)
+		return "", "", fmt.Errorf("action=call requires tool:*, skill:*, mcp-tool:*, or mcp-server:* capability id, got %q", id)
 	}
+}
+
+func parseToolCapabilityID(id string) (name string, ok bool) {
+	if !strings.HasPrefix(id, "tool:") {
+		return "", false
+	}
+	name = strings.TrimSpace(strings.TrimPrefix(id, "tool:"))
+	return name, name != ""
+}
+
+func parseSkillCapabilityID(id string) (name string, ok bool) {
+	if !strings.HasPrefix(id, "skill:") {
+		return "", false
+	}
+	name = strings.TrimSpace(strings.TrimPrefix(id, "skill:"))
+	return name, name != ""
+}
+
+// allowCapabilityID applies RejectIDs and edit-protocol cross filters before
+// any permission/plan/hook/evidence path sees the call.
+func (t *UseCapabilityTool) allowCapabilityID(id string) error {
+	if t.rejectIDs != nil {
+		if err := t.rejectIDs(id); err != nil {
+			return err
+		}
+	}
+	return RejectCrossProtocolFileCapability(id, t.editProtocol)
+}
+
+// FileEditCapabilityProtocol returns "classic", "hashline", or "" when the id
+// is not a cross-protocol file tool (see ClassicExcludedFromHashline /
+// HashlineExcludedFromClassic).
+func FileEditCapabilityProtocol(id string) string {
+	name, ok := parseToolCapabilityID(id)
+	if !ok {
+		// Also accept bare tool names for callers that strip the prefix.
+		name = strings.TrimSpace(id)
+	}
+	for _, n := range ClassicExcludedFromHashline {
+		if n == name {
+			return "classic"
+		}
+	}
+	for _, n := range HashlineExcludedFromClassic {
+		if n == name {
+			return "hashline"
+		}
+	}
+	return ""
+}
+
+// RejectCrossProtocolFileCapability hard-rejects classic file tools under a
+// hashline contract and hashline file tools under a classic contract.
+// editProtocol accepts classic|hashline|classic-v1|hashline-v1; empty skips.
+func RejectCrossProtocolFileCapability(id, editProtocol string) error {
+	proto := normalizeEditProtocol(editProtocol)
+	if proto == "" {
+		return nil
+	}
+	name, ok := parseToolCapabilityID(id)
+	if !ok {
+		name = strings.TrimSpace(strings.TrimPrefix(id, "tool:"))
+	}
+	if name == "" || !IsCrossProtocolTool(proto, name) {
+		return nil
+	}
+	toolProto := FileEditCapabilityProtocol("tool:" + name)
+	if toolProto == "" {
+		toolProto = "other"
+	}
+	return fmt.Errorf("capability %q belongs to the %s edit protocol and is not allowed under %s", id, toolProto, proto)
+}
+
+func normalizeEditProtocol(editProtocol string) string {
+	switch strings.ToLower(strings.TrimSpace(editProtocol)) {
+	case "", "classic", EditProtocolClassic:
+		if strings.TrimSpace(editProtocol) == "" {
+			return ""
+		}
+		return EditProtocolClassic
+	case "hashline", EditProtocolHashline:
+		return EditProtocolHashline
+	default:
+		return ""
+	}
+}
+
+// resolveToolCall maps tool:<name> onto the execution registry. ResolvedCall
+// uses the target's own ReadOnly classification — never inherits the proxy's
+// ReadOnly=true.
+func (t *UseCapabilityTool) resolveToolCall(name string, args json.RawMessage, base tool.ResolvedCall) (tool.ResolvedCall, error) {
+	id := "tool:" + name
+	reg := t.execution
+	if reg == nil {
+		reg = t.registry
+	}
+	if reg == nil {
+		return t.resolveUnavailable(base, id, name, fmt.Sprintf("tool %q is unavailable (no execution registry)", name)), nil
+	}
+	tl, ok := reg.Get(name)
+	if !ok || tl == nil {
+		return t.resolveUnavailable(base, id, name, fmt.Sprintf("tool %q is not registered", name)), nil
+	}
+	base.Target = tl
+	base.TargetName = tl.Name()
+	base.ReadOnly = tl.ReadOnly()
+	if len(args) == 0 {
+		base.Args = json.RawMessage(`{}`)
+	} else {
+		base.Args = args
+	}
+	return base, nil
+}
+
+// resolveSkillCall maps skill:<name> onto the hidden run_skill runner with an
+// immutable injected skill name so the model cannot retarget the capability.
+func (t *UseCapabilityTool) resolveSkillCall(name string, args json.RawMessage, base tool.ResolvedCall) (tool.ResolvedCall, error) {
+	id := "skill:" + name
+	runner := t.skillRunner
+	if runner == nil {
+		if t.execution != nil {
+			if tl, ok := t.execution.Get("run_skill"); ok {
+				runner = tl
+			}
+		}
+		if runner == nil && t.registry != nil {
+			if tl, ok := t.registry.Get("run_skill"); ok {
+				runner = tl
+			}
+		}
+	}
+	if runner == nil {
+		return t.resolveUnavailable(base, id, "run_skill", fmt.Sprintf("skill runner unavailable for %s", id)), nil
+	}
+	injected := forceSkillNameArgs(args, name)
+	target := &skillRunnerTarget{runner: runner, skillName: name}
+	base.Target = target
+	base.TargetName = "run_skill"
+	base.ReadOnly = runner.ReadOnly()
+	base.Args = injected
+	return base, nil
+}
+
+func forceSkillNameArgs(args json.RawMessage, name string) json.RawMessage {
+	var m map[string]any
+	if len(args) > 0 && string(args) != "null" {
+		if err := json.Unmarshal(args, &m); err != nil || m == nil {
+			m = map[string]any{}
+			// Preserve free-form string payloads as run_skill's arguments field.
+			var s string
+			if err := json.Unmarshal(args, &s); err == nil {
+				m["arguments"] = s
+			}
+		}
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+	m["name"] = name
+	b, err := json.Marshal(m)
+	if err != nil {
+		fallback, _ := json.Marshal(map[string]string{"name": name})
+		return fallback
+	}
+	return b
+}
+
+// skillRunnerTarget wraps run_skill and re-injects the capability skill name on
+// every Execute so permission/hooks see run_skill while the skill id stays fixed.
+type skillRunnerTarget struct {
+	runner    tool.Tool
+	skillName string
+}
+
+func (s *skillRunnerTarget) Name() string { return "run_skill" }
+
+func (s *skillRunnerTarget) Description() string {
+	if s.runner != nil {
+		return s.runner.Description()
+	}
+	return "run skill " + s.skillName
+}
+
+func (s *skillRunnerTarget) Schema() json.RawMessage {
+	if s.runner != nil {
+		return s.runner.Schema()
+	}
+	return json.RawMessage(`{"type":"object"}`)
+}
+
+func (s *skillRunnerTarget) ReadOnly() bool {
+	if s.runner != nil {
+		return s.runner.ReadOnly()
+	}
+	return false
+}
+
+func (s *skillRunnerTarget) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if s.runner == nil {
+		return "", fmt.Errorf("skill runner unavailable")
+	}
+	return s.runner.Execute(ctx, forceSkillNameArgs(args, s.skillName))
 }
 
 // Ensure UseCapabilityTool satisfies the tool contracts used by the agent.

--- a/internal/agent/usecapability_test.go
+++ b/internal/agent/usecapability_test.go
@@ -907,6 +907,147 @@ func TestCapabilityGateAppliesToReadOnlyTasks(t *testing.T) {
 	}
 }
 
+func TestUseCapabilityToolCallUsesTargetReadOnly(t *testing.T) {
+	exec := tool.NewRegistry()
+	exec.Add(fakeTool{name: "write_file", readOnly: false})
+	exec.Add(fakeTool{name: "grep", readOnly: true})
+	// Provider-visible registry does not include the writer — execution does.
+	providerReg := tool.NewRegistry()
+	uc := NewUseCapabilityTool(context.Background(), nil, nil, providerReg, capability.NewLedger(), nil, nil).
+		WithExecutionRegistry(exec)
+
+	writer, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:write_file","arguments":{"path":"a.go","content":"x"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writer.ReadOnly {
+		t.Fatal("writer tool:* ResolvedCall must not inherit use_capability ReadOnly=true")
+	}
+	if writer.TargetName != "write_file" || writer.Target == nil {
+		t.Fatalf("writer resolve = %+v", writer)
+	}
+	if writer.Target.ReadOnly() {
+		t.Fatal("target itself must remain a writer")
+	}
+
+	reader, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:grep","arguments":{"pattern":"x"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reader.ReadOnly || reader.TargetName != "grep" {
+		t.Fatalf("reader resolve = %+v", reader)
+	}
+}
+
+func TestUseCapabilitySkillInjectsImmutableName(t *testing.T) {
+	var gotArgs string
+	runner := skillCaptureTool{onExec: func(args json.RawMessage) {
+		gotArgs = string(args)
+	}}
+	uc := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), capability.NewLedger(), nil, nil).
+		WithSkillRunner(runner)
+
+	resolved, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"skill:review","arguments":{"name":"evil","arguments":"look at auth"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.TargetName != "run_skill" || resolved.Target == nil {
+		t.Fatalf("resolve = %+v", resolved)
+	}
+	if _, err := resolved.Target.Execute(context.Background(), resolved.Args); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotArgs, `"name":"review"`) || strings.Contains(gotArgs, `"name":"evil"`) {
+		t.Fatalf("skill name not pinned: %s", gotArgs)
+	}
+	// Even if Execute is handed a retargeted payload, the wrapper re-injects.
+	if _, err := resolved.Target.Execute(context.Background(), json.RawMessage(`{"name":"other"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotArgs, `"name":"review"`) {
+		t.Fatalf("re-inject failed: %s", gotArgs)
+	}
+}
+
+func TestUseCapabilityRejectsCrossProtocolFileTools(t *testing.T) {
+	exec := tool.NewRegistry()
+	exec.Add(fakeTool{name: "edit_file", readOnly: false})
+	exec.Add(fakeTool{name: "hashline_edit", readOnly: false})
+	exec.Add(fakeTool{name: "bash", readOnly: false})
+	uc := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), capability.NewLedger(), nil, nil).
+		WithExecutionRegistry(exec).
+		WithEditProtocol(EditProtocolHashline)
+
+	if _, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:edit_file","arguments":{}}`)); err == nil || !strings.Contains(err.Error(), "classic") {
+		t.Fatalf("hashline session must reject classic edit_file, err=%v", err)
+	}
+	// hashline_edit is allowed under hashline.
+	if _, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:hashline_edit","arguments":{}}`)); err != nil {
+		t.Fatalf("hashline should allow hashline_edit: %v", err)
+	}
+	// Shared tools remain allowed.
+	if _, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:bash","arguments":{}}`)); err != nil {
+		t.Fatalf("shared tool bash should be allowed: %v", err)
+	}
+
+	classic := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), capability.NewLedger(), nil, nil).
+		WithExecutionRegistry(exec).
+		WithEditProtocol(EditProtocolClassic)
+	if _, err := classic.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"tool:hashline_edit","arguments":{}}`)); err == nil || !strings.Contains(err.Error(), "hashline") {
+		t.Fatalf("classic session must reject hashline_edit, err=%v", err)
+	}
+}
+
+func TestFileEditCapabilityProtocolHelper(t *testing.T) {
+	if got := FileEditCapabilityProtocol("tool:edit_file"); got != "classic" {
+		t.Fatalf("edit_file = %q", got)
+	}
+	if got := FileEditCapabilityProtocol("tool:hashline_edit"); got != "hashline" {
+		t.Fatalf("hashline_edit = %q", got)
+	}
+	if got := FileEditCapabilityProtocol("tool:bash"); got != "" {
+		t.Fatalf("bash = %q", got)
+	}
+	if err := RejectCrossProtocolFileCapability("tool:write_file", EditProtocolHashline); err == nil {
+		t.Fatal("expected reject")
+	}
+	if err := RejectCrossProtocolFileCapability("skill:review", EditProtocolHashline); err != nil {
+		t.Fatalf("non-file tool should pass: %v", err)
+	}
+	// grep is classic-only under hashline per ClassicExcludedFromHashline.
+	if err := RejectCrossProtocolFileCapability("tool:grep", EditProtocolHashline); err == nil {
+		t.Fatal("expected grep rejected under hashline")
+	}
+}
+
+func TestUseCapabilityRejectIDsHook(t *testing.T) {
+	uc := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), capability.NewLedger(), nil, nil).
+		WithRejectIDs(func(id string) error {
+			if id == "tool:bash" {
+				return fmt.Errorf("bash blocked by policy")
+			}
+			return nil
+		})
+	if _, err := uc.ResolveCall(context.Background(), json.RawMessage(`{"action":"inspect","capability_id":"tool:bash"}`)); err == nil || !strings.Contains(err.Error(), "bash blocked") {
+		t.Fatalf("reject hook not applied: %v", err)
+	}
+}
+
+type skillCaptureTool struct {
+	onExec func(args json.RawMessage)
+}
+
+func (skillCaptureTool) Name() string            { return "run_skill" }
+func (skillCaptureTool) Description() string     { return "run skill" }
+func (skillCaptureTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (skillCaptureTool) ReadOnly() bool          { return false }
+func (s skillCaptureTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	if s.onExec != nil {
+		s.onExec(args)
+	}
+	return "ok", nil
+}
+
 func TestStrictReadOnlyFailsClosedWithoutTrustAuthority(t *testing.T) {
 	host := plugin.NewHost()
 	defer host.Close()

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -10,6 +10,7 @@ package boot
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -51,6 +52,7 @@ import (
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 	"reasonix/internal/tool/builtin"
+	"reasonix/internal/tool/builtin/hashline"
 	"reasonix/internal/tool/sessiontool"
 	"reasonix/internal/workspacelease"
 )
@@ -154,6 +156,16 @@ type Options struct {
 	// schemas stay byte-identical, so the provider-visible surface is unchanged.
 	FileOverlay    builtin.FileOverlay
 	TerminalRunner builtin.TerminalRunner
+	// RuntimeContract, when non-nil, pins the session tool surface / edit protocol
+	// / prompt layout (new task or resume). Nil means derive from config for a
+	// new session. Resume/fork paths must pass the saved contract so the schema
+	// and prompt layout never drift mid-session.
+	RuntimeContract *agent.RuntimeContract
+	// EditProtocolOverride is a CLI/Desktop new-session override for classic|
+	// hashline (wire values classic-v1|hashline-v1). Empty keeps config/default.
+	// Resume rejects overrides that conflict with a saved contract (callers
+	// must validate before Build).
+	EditProtocolOverride string
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -348,6 +360,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	shell := sandbox.ResolveShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path, stderr)
 
+	// Resolve the session-stable runtime contract once. Old sessions pass their
+	// saved contract; new sessions derive from config (+ optional CLI override).
+	runtimeContract, err := resolveRuntimeContract(cfg, opts)
+	if err != nil {
+		return nil, err
+	}
+	sessionCtxLayout := runtimeContract.IsSessionContextLayout()
+
 	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
 	if err != nil {
 		return nil, err
@@ -360,20 +380,32 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	sysPrompt += "\n\n" + config.UserDecisionPolicy
 	sysPrompt += "\n\n" + config.LanguagePolicy
-	if workspaceLine := currentWorkspacePromptLine(root); workspaceLine != "" {
-		sysPrompt += "\n\n" + workspaceLine
-	}
+	// Profile static policy always stays in system (cache-stable across workspaces).
 	if tokenEconomy {
 		sysPrompt += "\n\n" + tokenEconomyPrompt
 	} else if tokenDelivery {
 		sysPrompt += "\n\n" + tokenDeliveryPrompt
 	}
+
+	// Session-context sections (workspace/env/memory/skills). On session-context-v2
+	// they become a pinned synthetic user message; on system-v1 they stay in system.
+	var sessionCtx agent.SessionContextSections
+	workspaceLine := currentWorkspacePromptLine(root)
+	if !sessionCtxLayout {
+		if workspaceLine != "" {
+			sysPrompt += "\n\n" + workspaceLine
+		}
+	} else {
+		sessionCtx.Workspace = workspaceLine
+	}
+
+	var envSection string
 	if cfg.EnvironmentEnabled() {
 		shellLabel := shell.Kind.String()
 		if strings.TrimSpace(cfg.Tools.Shell.Path) != "" {
 			shellLabel = shell.Path
 		}
-		envSection := environment.FormatSection(
+		envSection = environment.FormatSection(
 			environment.RunProbesWithOptions(ctx, environment.DefaultProbes(), environment.ProbeOptions{
 				Overrides: cfg.Environment.Tools,
 				DenyRoots: []string{root},
@@ -387,22 +419,29 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			shellLabel,
 			cfg.Environment.Tools,
 		)
-		if envSection != "" {
+		if envSection != "" && !sessionCtxLayout {
 			sysPrompt += "\n\n" + envSection
 		}
 	}
+	if sessionCtxLayout {
+		sessionCtx.Environment = envSection
+	}
 
-	// Persistent memory (REASONIX.md / AGENTS.md hierarchy + auto-memory index)
-	// folds into the system prompt exactly here, once: it becomes part of the
-	// durable, cache-stable prefix every turn reuses, so memory costs nothing per
-	// turn. Mid-session changes never touch this prefix — they ride the
-	// controller's transient turn-injection and fold in on the next session.
+	// Persistent memory (REASONIX.md / AGENTS.md hierarchy + auto-memory index).
+	// system-v1: folds into the system prompt once (cache-stable prefix).
+	// session-context-v2: pinned synthetic user message; mid-session updates still
+	// use turn-tail injection and only re-enter context on the next new session.
 	mem := &memory.Set{CWD: root}
 	if !cfg.SafeMode() {
 		mem = memory.Load(memory.Options{CWD: root, UserDir: config.MemoryUserDir()})
 	}
 	projectChecks := instruction.ExtractHostChecks(mem.Docs)
-	sysPrompt = memory.Compose(sysPrompt, mem)
+	if sessionCtxLayout {
+		// Compose with empty base so only the memory/instruction body is stored.
+		sessionCtx.Instructions = strings.TrimSpace(memory.Compose("", mem))
+	} else {
+		sysPrompt = memory.Compose(sysPrompt, mem)
+	}
 
 	// Skills: discover playbooks (built-in + project/custom/global) and fold their
 	// one-liner index into the same cache-stable prefix — names + descriptions
@@ -430,10 +469,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	allSkills := allSkillStore.List()
 	if !tokenEconomy && !cfg.SafeMode() {
-		sysPrompt = skill.ApplyIndex(sysPrompt, skills)
+		if sessionCtxLayout {
+			sessionCtx.Skills = strings.TrimSpace(skill.ApplyIndex("", skills))
+		} else {
+			sysPrompt = skill.ApplyIndex(sysPrompt, skills)
+		}
 	}
 
 	reg := tool.NewRegistry()
+	// Runtime MCP publications begin on the bootstrap registry, then atomically
+	// switch to Execution + Legacy when those snapshots are built below.
+	runtimeMCP := newRuntimeMCPRegistry(reg)
 	writeRoots := cfg.WriteRootsForRoot(root)
 	writeRoots = appendUniquePaths(writeRoots, additionalDirs...)
 	forbidReadRoots := RuntimeForbidReadRoots(cfg, root)
@@ -638,12 +684,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				// Shared host relies on Host's spawn guard to avoid duplicate
 				// processes across tabs for the same workspace root.
 				cs, _ := plugin.LoadCachedSchemaForSpec(s)
-				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, true) {
+				for _, t := range plugin.LazyToolset(s, cs, pluginHost, runtimeMCP, ctx, true) {
 					reg.Add(t)
 				}
 			} else {
 				cs, _ := plugin.LoadCachedSchemaForSpec(s)
-				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, true) {
+				for _, t := range plugin.LazyToolset(s, cs, pluginHost, runtimeMCP, ctx, true) {
 					reg.Add(t)
 				}
 			}
@@ -1106,15 +1152,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				if err != nil {
 					return installsource.MCPConnectResult{}, err
 				}
-				reg.RemovePrefix(plugin.ToolPrefix(spec.Name))
-				for _, t := range tools {
-					reg.Add(t)
-				}
+				runtimeMCP.replacePrefix(plugin.ToolPrefix(spec.Name), tools)
 				// Disconnect closes the server and drops its namespaced tools.
 				// Used by the install_source rollback path when SaveTo fails.
 				disconnect := func() {
 					if prefix, ok := pluginHost.Remove(spec.Name); ok {
-						reg.RemovePrefix(prefix)
+						runtimeMCP.RemovePrefix(prefix)
 					}
 				}
 				return installsource.MCPConnectResult{
@@ -1124,7 +1167,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			},
 			OnDisconnect: func(serverName string) bool {
 				if prefix, ok := pluginHost.Remove(serverName); ok {
-					reg.RemovePrefix(prefix)
+					runtimeMCP.RemovePrefix(prefix)
 					return true
 				}
 				return false
@@ -1284,8 +1327,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 						if err2 != nil {
 							return "", err2
 						}
-						reg.RemovePrefix(plugin.ToolPrefix(spec.Name))
-						names := addTools(reg, tools)
+						names := runtimeMCP.replacePrefix(plugin.ToolPrefix(spec.Name), tools)
 						if len(names) == 0 {
 							return fmt.Sprintf("MCP server %q connected but exposed no tools.", spec.Name), nil
 						}
@@ -1293,8 +1335,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 					}
 					return "", err
 				}
-				reg.RemovePrefix(plugin.ToolPrefix(spec.Name))
-				names := addTools(reg, tools)
+				names := runtimeMCP.replacePrefix(plugin.ToolPrefix(spec.Name), tools)
 				if len(names) == 0 {
 					return fmt.Sprintf("MCP server %q connected but exposed no tools.", spec.Name), nil
 				}
@@ -1304,56 +1345,130 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		})
 	}
 
-	// Delivery-only stable capability proxy. Registered before agent.New so the
-	// tool schema is part of the Delivery cache prefix and never changes when
-	// on-demand MCP servers connect through the proxy.
+	// Snapshot pure legacy + execution registries while runtime MCP publication
+	// is paused. Once both clones exist, lazy/hot MCP mutations are mirrored to
+	// them and can no longer land in the abandoned bootstrap registry.
+	var legacyReg, execution *tool.Registry
+	runtimeMCP.bindSnapshot(func() []*tool.Registry {
+		legacyReg = reg.Clone()
+		execution = legacyReg.Clone()
+		return []*tool.Registry{execution, legacyReg}
+	})
+
 	var capLedger *capability.Ledger
 	var capAudit *capability.Audit
 	capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions)
 	cachedTools, cacheHashOK := capability.LoadCachedToolsForSpecs(capSpecs)
 	var capProxy *agent.UseCapabilityTool
-	if tokenDelivery {
-		capLedger = capability.NewLedger()
-		capAudit = &capability.Audit{}
-		failed := map[string]string{}
-		if pluginHost != nil {
-			for _, f := range pluginHost.Failures() {
-				failed[f.Name] = f.Error
-			}
+	// catalogTools feeds search/use_capability catalogs (execution registry).
+	catalogTools := legacyReg
+
+	// Always build capability infrastructure so Boot→Resume can switch surfaces
+	// regardless of the process-start contract.
+	capLedger = capability.NewLedger()
+	capAudit = &capability.Audit{}
+	failed := map[string]string{}
+	if pluginHost != nil {
+		for _, f := range pluginHost.Failures() {
+			failed[f.Name] = f.Error
 		}
-		// The proxy and the catalog share the boot-converted specs (env
-		// expansion, workspace overrides, timeouts, trusted read-only tools) —
-		// every configured server, including auto_start=false, is proxy-callable.
-		catalogFn := func() capability.Catalog {
-			conn := map[string]bool{}
-			if pluginHost != nil {
-				for _, n := range pluginHost.ServerNames() {
-					conn[n] = true
-				}
-			}
-			catOpts := capability.CatalogOptions{
-				Tools:       reg.ContractEntries(),
-				Skills:      skillStore.List(),
-				Plugins:     cfg.Plugins,
-				Profile:     capability.ProfileDelivery,
-				Connected:   conn,
-				Failed:      failed,
-				CachedTools: cachedTools,
-				CacheHashOK: cacheHashOK,
-			}
-			// Live proxy-observed tools keep mcp-tool entries routable after an
-			// on-demand connect (proxied tools never enter the registry).
-			if capProxy != nil {
-				catOpts.ProxyTools = capProxy.ConnectedProxyTools()
-			}
-			return capability.BuildCatalog(catOpts)
-		}
-		// ctx is the session-scoped boot context (the lifetime PluginCtx hands
-		// the controller): on-demand MCP children must survive the tool call
-		// that starts them and die with the session, not a resolve timeout.
-		capProxy = agent.NewUseCapabilityTool(ctx, pluginHost, capSpecs, reg, capLedger, capAudit, catalogFn)
-		reg.Add(capProxy)
 	}
+	profileForCatalog := runtimeProfile
+	if tokenDelivery {
+		profileForCatalog = capability.ProfileDelivery
+	}
+	// Proxies attach to the execution registry (built below), not legacyReg.
+	// catalogFn is closed over catalogTools + capProxy after they are assigned.
+	catalogFn := func() capability.Catalog {
+		conn := map[string]bool{}
+		if pluginHost != nil {
+			for _, n := range pluginHost.ServerNames() {
+				conn[n] = true
+			}
+		}
+		src := catalogTools
+		if src == nil {
+			src = legacyReg
+		}
+		entries := src.ContractEntries()
+		// Filter cross-protocol edit tools using the live proxy edit protocol
+		// (updated by ApplyRuntimeContract on Resume).
+		editProto := agent.EditProtocolClassic
+		if capProxy != nil {
+			editProto = capProxy.EditProtocol()
+		}
+		entries = filterContractEntriesByEditProtocol(entries, editProto)
+		catOpts := capability.CatalogOptions{
+			Tools:       entries,
+			Skills:      skillStore.List(),
+			Plugins:     cfg.Plugins,
+			Profile:     profileForCatalog,
+			Connected:   conn,
+			Failed:      failed,
+			CachedTools: cachedTools,
+			CacheHashOK: cacheHashOK,
+		}
+		if capProxy != nil {
+			catOpts.ProxyTools = capProxy.ConnectedProxyTools()
+		}
+		return capability.BuildCatalog(catOpts)
+	}
+	capProxy = agent.NewUseCapabilityTool(ctx, pluginHost, capSpecs, legacyReg, capLedger, capAudit, catalogFn)
+	capProxy.WithEditProtocol(runtimeContract.EditProtocol)
+	schemaFn := func() map[string]json.RawMessage {
+		src := catalogTools
+		if src == nil {
+			src = legacyReg
+		}
+		live := agent.SchemasFromContractEntries(src.ContractEntries())
+		cached := agent.SchemasFromCachedMCPTools(cachedTools)
+		var proxy map[string][]plugin.CachedTool
+		if capProxy != nil {
+			proxy = capProxy.ConnectedProxyTools()
+		}
+		return agent.MergeSchemaMaps(live, cached, agent.SchemasFromCachedMCPTools(proxy))
+	}
+	searchCap := agent.NewSearchCapabilitiesToolDynamic(catalogFn, schemaFn)
+
+	execution, classicProv, hashlineProv := buildCapabilitySurfaces(
+		execution, root, writeRoots, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, searchSpec, bashSpec,
+		capProxy, searchCap,
+	)
+	catalogTools = execution
+	capProxy.WithExecutionRegistry(execution)
+	if sk, ok := execution.Get("run_skill"); ok {
+		capProxy.WithSkillRunner(sk)
+	}
+
+	// Delivery legacy always exposed use_capability (not search_capabilities).
+	// Keep that on the pure legacy snapshot so Delivery cache shape stays stable.
+	if tokenDelivery {
+		deliveryProxy := agent.NewUseCapabilityTool(ctx, pluginHost, capSpecs, legacyReg, capLedger, capAudit, catalogFn)
+		deliveryProxy.WithEditProtocol(agent.EditProtocolClassic)
+		deliveryProxy.WithExecutionRegistry(execution)
+		if sk, ok := execution.Get("run_skill"); ok {
+			deliveryProxy.WithSkillRunner(sk)
+		}
+		legacyReg.Add(deliveryProxy)
+	}
+
+	registryBundle := &agent.RegistryBundle{
+		Legacy:             legacyReg,
+		Execution:          execution,
+		CapabilityClassic:  classicProv,
+		CapabilityHashline: hashlineProv,
+	}
+
+	if runtimeContract.IsCapabilitySurface() {
+		reg = registryBundle.ProviderRegistry(runtimeContract)
+		if reg == nil {
+			reg = classicProv
+		}
+		capProxy.WithEditProtocol(runtimeContract.EditProtocol)
+	} else {
+		reg = legacyReg
+	}
+
 	skillStore.ConfigureInvocationPolicy(string(runtimeProfile), func(requires []string) []string {
 		connected := map[string]bool{}
 		failed := map[string]string{}
@@ -1369,8 +1484,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if capProxy != nil {
 			proxyTools = capProxy.ConnectedProxyTools()
 		}
+		// Use execution/catalogTools so hidden-but-callable tools are not reported missing.
+		src := catalogTools
+		if src == nil {
+			src = legacyReg
+		}
 		catalog := capability.BuildCatalog(capability.CatalogOptions{
-			Tools:       reg.ContractEntries(),
+			Tools:       src.ContractEntries(),
 			Skills:      skillStore.List(),
 			Plugins:     cfg.Plugins,
 			Profile:     runtimeProfile,
@@ -1385,6 +1505,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	})
 
 	execSess := agent.NewSession(sysPrompt)
+	if sessionCtxLayout {
+		// Pin session context immediately so Resume never re-probes env or
+		// re-assembles workspace/skills. Mid-session Memory/Skill changes still
+		// use turn-tail injection; the next new session regenerates context.
+		execSess.Add(agent.SessionContextMessage(runtimeContract, sessionCtx))
+	}
 	executor := agent.New(execProv, reg, execSess, agent.Options{
 		MaxSteps:                 maxSteps,
 		MaxStepsKey:              opts.MaxStepsKey,
@@ -1412,6 +1538,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		SubagentDepth:            0,
 		MaxSubagentDepth:         maxSubagentDepth,
 	}, sink)
+	_ = executor.SetRuntimeContract(runtimeContract)
+	if registryBundle != nil {
+		executor.SetRegistryBundle(registryBundle)
+	}
 
 	var runner agent.Runner = executor
 	label := entry.Model
@@ -1491,6 +1621,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		BalanceClient:         balanceClient,
 		Jobs:                  jm,
 		Registry:              reg,
+		RegistryBundle:        registryBundle,
 		PluginCtx:             ctx,
 		MCPDefaultCallTimeout: pluginSpecOptions.DefaultCallTimeout,
 		MCPConfigureSpec: func(spec *plugin.Spec) {
@@ -1547,6 +1678,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ctrlOpts.Classifier = classifier
 	}
 	ctrl := control.New(ctrlOpts)
+	// Deterministic Goal/Todo compaction state — never model-summarized.
+	executor.SetCompactionStateProvider(ctrl)
 	refreshMCPCatalogInBackground(pluginHost)
 	if tokenDelivery {
 		var router *capability.SemanticRouter
@@ -2503,4 +2636,133 @@ func providerNames(cfg *config.Config) string {
 		names[i] = p.Name
 	}
 	return strings.Join(names, "/")
+}
+
+// resolveRuntimeContract returns the session-stable contract for this Build.
+// Prefer opts.RuntimeContract (resume/fork); otherwise derive from config with
+// optional EditProtocolOverride for new sessions only.
+func resolveRuntimeContract(cfg *config.Config, opts Options) (agent.RuntimeContract, error) {
+	if opts.RuntimeContract != nil {
+		c := agent.NormalizeRuntimeContract(opts.RuntimeContract)
+		if err := agent.ValidateRuntimeContract(c); err != nil {
+			return agent.RuntimeContract{}, err
+		}
+		if override := strings.TrimSpace(opts.EditProtocolOverride); override != "" {
+			if override != c.EditProtocol {
+				return agent.RuntimeContract{}, fmt.Errorf("resume --edit-protocol %q conflicts with saved session edit_protocol %q", override, c.EditProtocol)
+			}
+		}
+		return c, nil
+	}
+	surface, edit, layout, err := cfg.NewSessionRuntimeContract()
+	if err != nil {
+		return agent.RuntimeContract{}, err
+	}
+	c := agent.RuntimeContract{
+		ToolSurface:  surface,
+		EditProtocol: edit,
+		PromptLayout: layout,
+	}
+	if override := strings.TrimSpace(opts.EditProtocolOverride); override != "" {
+		c.EditProtocol = override
+	}
+	if err := agent.ValidateRuntimeContract(c); err != nil {
+		return agent.RuntimeContract{}, err
+	}
+	return c, nil
+}
+
+// buildCapabilitySurfaces extends the pre-snapshotted execution registry with
+// hashline tools + capability proxies, then builds classic/hashline provider
+// surfaces for Resume switches.
+func buildCapabilitySurfaces(
+	baseExecution *tool.Registry,
+	root string,
+	writeRoots, forbidReadRoots []string,
+	paths *builtin.PathResolver,
+	guard builtin.SessionDataGuard,
+	managed builtin.ManagedConfigPaths,
+	overlay builtin.FileOverlay,
+	search builtin.SearchSpec,
+	bash sandbox.Spec,
+	capProxy *agent.UseCapabilityTool,
+	searchCap tool.Tool,
+) (execution, classic, hashlineReg *tool.Registry) {
+	execution = baseExecution
+	if execution == nil {
+		execution = tool.NewRegistry()
+	}
+	classic = tool.NewRegistry()
+	hashlineReg = tool.NewRegistry()
+
+	// Hashline tools are not in Builtins(); always attach for hashline sessions
+	// and use_capability dispatch.
+	hlCfg := hashline.Config{
+		WorkDir:     root,
+		WriteRoots:  writeRoots,
+		ForbidRoots: forbidReadRoots,
+		Paths:       paths,
+		Guard:       guard,
+		Managed:     managed,
+		Overlay:     overlay,
+		Search:      search,
+		Sandbox:     bash,
+	}
+	for _, t := range hlCfg.Tools() {
+		execution.Add(t)
+	}
+	// Capability proxies live only on execution + capability provider surfaces.
+	if capProxy != nil {
+		execution.Add(capProxy)
+		capProxy.WithExecutionRegistry(execution)
+		if sk, ok := execution.Get("run_skill"); ok {
+			capProxy.WithSkillRunner(sk)
+		}
+	}
+	if searchCap != nil {
+		execution.Add(searchCap)
+	}
+
+	classicAllow := agent.AllowSet(agent.CoreCapabilityToolNames...)
+	for _, n := range agent.ClassicEditToolNames {
+		classicAllow[n] = true
+	}
+	hashAllow := agent.AllowSet(agent.CoreCapabilityToolNames...)
+	for _, n := range agent.HashlineEditToolNames {
+		hashAllow[n] = true
+	}
+	// Hashline provider surface excludes classic file primitives that overlap.
+	hashDeny := agent.AllowSet(agent.ClassicExcludedFromHashline...)
+
+	for _, name := range execution.Names() {
+		t, ok := execution.Get(name)
+		if !ok {
+			continue
+		}
+		if classicAllow[name] {
+			classic.Add(t)
+		}
+		if hashAllow[name] && !hashDeny[name] {
+			hashlineReg.Add(t)
+		}
+	}
+	return execution, classic, hashlineReg
+}
+
+// filterContractEntriesByEditProtocol drops cross-protocol file tools so
+// search_capabilities never recommends IDs that use_capability will reject.
+// editProtocol accepts classic|hashline|classic-v1|hashline-v1; empty keeps all
+// entries (same as use_capability when protocol is unset).
+func filterContractEntriesByEditProtocol(entries []tool.ContractEntry, editProtocol string) []tool.ContractEntry {
+	if len(entries) == 0 {
+		return entries
+	}
+	out := make([]tool.ContractEntry, 0, len(entries))
+	for _, e := range entries {
+		if agent.IsCrossProtocolTool(editProtocol, e.Name) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1551,12 +1551,20 @@ model = "x"
 	if strings.Replace(deliverySystem, "\n\n"+tokenDeliveryPrompt, "", 1) != fullSystem {
 		t.Fatal("delivery profile changed the full system prompt beyond its stable contract")
 	}
-	// Delivery keeps the full surface and adds one stable proxy tool.
+	// Delivery keeps the full surface and adds the stable use_capability proxy
+	// (legacy Delivery shape). search_capabilities is capability-v2 only and must
+	// not pollute the pure legacy Full/Delivery provider schema.
 	if !requestHasTool(deliveryReq, "use_capability") {
 		t.Fatal("delivery profile must expose the stable use_capability proxy")
 	}
+	if requestHasTool(deliveryReq, "search_capabilities") {
+		t.Fatal("legacy delivery must not expose search_capabilities (capability-v2 only)")
+	}
 	if requestHasTool(fullReq, "use_capability") {
 		t.Fatal("balanced/full profile must not expose use_capability")
+	}
+	if requestHasTool(fullReq, "search_capabilities") {
+		t.Fatal("balanced/full profile must not expose search_capabilities")
 	}
 	fullNames := toolSchemaNames(fullReq.Tools)
 	deliveryNames := toolSchemaNames(deliveryReq.Tools)

--- a/internal/boot/registry_bundle_test.go
+++ b/internal/boot/registry_bundle_test.go
@@ -1,0 +1,134 @@
+package boot
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+func sortedToolNames(reg *tool.Registry) []string {
+	if reg == nil {
+		return nil
+	}
+	names := append([]string(nil), reg.Names()...)
+	sort.Strings(names)
+	return names
+}
+
+func hasTool(reg *tool.Registry, name string) bool {
+	if reg == nil {
+		return false
+	}
+	_, ok := reg.Get(name)
+	return ok
+}
+
+func TestLegacyBootBundleAllowsResumeToCapability(t *testing.T) {
+	// Pure legacy Full boot must keep provider schema free of v2 proxies,
+	// while the RegistryBundle still carries complete capability surfaces.
+	ctrl, err := Build(context.Background(), Options{
+		Model:           "deepseek-flash",
+		RequireKey:      false,
+		Sink:            event.Discard,
+		SessionDir:      t.TempDir(),
+		WorkspaceRoot:   t.TempDir(),
+		RuntimeContract: agent.LegacyDefaultRuntimeContract().Clone(),
+	})
+	if err != nil {
+		t.Skipf("build unavailable: %v", err)
+	}
+	defer ctrl.Close()
+	exec := ctrl.Executor()
+	if exec == nil {
+		t.Fatal("nil executor")
+	}
+	bundle := exec.RegistryBundle()
+	if bundle == nil {
+		t.Fatal("expected RegistryBundle on legacy boot")
+	}
+	// Active provider surface is pure legacy Full: no search_capabilities.
+	if hasTool(bundle.Legacy, "search_capabilities") {
+		t.Fatal("legacy registry must not include search_capabilities")
+	}
+	if hasTool(bundle.Legacy, "use_capability") {
+		// Full profile (not Delivery) must not have use_capability on legacy.
+		t.Fatal("legacy Full registry must not include use_capability")
+	}
+	// Capability surfaces must still expose both proxies for Resume.
+	if !hasTool(bundle.CapabilityClassic, "use_capability") || !hasTool(bundle.CapabilityClassic, "search_capabilities") {
+		t.Fatalf("capability-classic tools = %v, want use_capability+search_capabilities", sortedToolNames(bundle.CapabilityClassic))
+	}
+	if !hasTool(bundle.CapabilityHashline, "use_capability") || !hasTool(bundle.CapabilityHashline, "search_capabilities") {
+		t.Fatalf("capability-hashline tools = %v, want proxies", sortedToolNames(bundle.CapabilityHashline))
+	}
+	if !hasTool(bundle.CapabilityHashline, "hashline_read") {
+		t.Fatal("hashline surface missing hashline_read")
+	}
+	if hasTool(bundle.CapabilityHashline, "read_file") {
+		t.Fatal("hashline surface must exclude classic read_file")
+	}
+
+	// Resume to capability-v2 classic: active tools gain proxies, not pollute Legacy.
+	v2 := agent.DefaultRuntimeContract()
+	if err := exec.ApplyRuntimeContract(v2, bundle); err != nil {
+		t.Fatal(err)
+	}
+	if !hasTool(bundle.ProviderRegistry(v2), "use_capability") {
+		t.Fatal("after resume to v2, provider must expose use_capability")
+	}
+	// Legacy snapshot must remain pure.
+	if hasTool(bundle.Legacy, "use_capability") || hasTool(bundle.Legacy, "search_capabilities") {
+		t.Fatal("ApplyRuntimeContract must not mutate the pure Legacy snapshot")
+	}
+}
+
+func TestCapabilityBootBundleAllowsResumeToLegacy(t *testing.T) {
+	v2 := agent.DefaultRuntimeContract()
+	ctrl, err := Build(context.Background(), Options{
+		Model:           "deepseek-flash",
+		RequireKey:      false,
+		Sink:            event.Discard,
+		SessionDir:      t.TempDir(),
+		WorkspaceRoot:   t.TempDir(),
+		RuntimeContract: v2.Clone(),
+	})
+	if err != nil {
+		t.Skipf("build unavailable: %v", err)
+	}
+	defer ctrl.Close()
+	exec := ctrl.Executor()
+	bundle := exec.RegistryBundle()
+	if bundle == nil {
+		t.Fatal("expected RegistryBundle")
+	}
+	// Active surface is capability classic.
+	active := bundle.ProviderRegistry(exec.RuntimeContract())
+	if !hasTool(active, "use_capability") || !hasTool(active, "search_capabilities") {
+		t.Fatalf("v2 boot active tools = %v", sortedToolNames(active))
+	}
+	// Pure legacy snapshot must not carry v2 proxies (Full profile).
+	if hasTool(bundle.Legacy, "use_capability") || hasTool(bundle.Legacy, "search_capabilities") {
+		t.Fatalf("legacy snapshot polluted: %v", sortedToolNames(bundle.Legacy))
+	}
+
+	// Resume to legacy: switch to pure legacy schema.
+	legacy := agent.LegacyDefaultRuntimeContract()
+	if err := exec.ApplyRuntimeContract(legacy, bundle); err != nil {
+		t.Fatal(err)
+	}
+	if got := exec.RuntimeContract(); !got.Equal(legacy) {
+		t.Fatalf("contract = %+v", got)
+	}
+	// After apply, provider registry for legacy is the pure snapshot.
+	leg := bundle.ProviderRegistry(legacy)
+	if hasTool(leg, "use_capability") || hasTool(leg, "search_capabilities") {
+		t.Fatalf("resumed legacy tools polluted: %v", sortedToolNames(leg))
+	}
+	if !hasTool(leg, "read_file") {
+		t.Fatal("legacy surface should keep classic read_file")
+	}
+}

--- a/internal/boot/runtime_mcp_registry.go
+++ b/internal/boot/runtime_mcp_registry.go
@@ -1,0 +1,104 @@
+package boot
+
+import (
+	"sync"
+
+	"reasonix/internal/tool"
+)
+
+// runtimeMCPRegistry routes MCP tools that arrive after boot. Before the
+// RuntimeContract surfaces are snapshotted it writes to the bootstrap registry;
+// afterwards it mirrors mutations to Execution and Legacy only. Capability
+// provider registries are deliberately never targets.
+//
+// It also implements plugin's lazy registry writer contract, so a background
+// cache-miss handshake cannot publish real tools into the abandoned pre-clone
+// registry.
+type runtimeMCPRegistry struct {
+	mu       sync.Mutex
+	fallback *tool.Registry
+	targets  []*tool.Registry
+}
+
+func newRuntimeMCPRegistry(fallback *tool.Registry) *runtimeMCPRegistry {
+	return &runtimeMCPRegistry{fallback: fallback}
+}
+
+// bindSnapshot runs snapshot while runtime MCP writes are paused, then installs
+// its returned targets before writes resume. This closes the race where a
+// background lazy handshake could finish between Clone and target binding.
+func (r *runtimeMCPRegistry) bindSnapshot(snapshot func() []*tool.Registry) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.targets = uniqueRegistries(snapshot())
+}
+
+func (r *runtimeMCPRegistry) Add(t tool.Tool) {
+	if r == nil || t == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, reg := range r.targetsLocked() {
+		reg.Add(t)
+	}
+}
+
+func (r *runtimeMCPRegistry) RemovePrefix(prefix string) int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	removed := 0
+	for _, reg := range r.targetsLocked() {
+		removed += reg.RemovePrefix(prefix)
+	}
+	return removed
+}
+
+// replacePrefix is used by explicit connect flows. Unlike a late background
+// publish, an explicit reconnect intentionally clears a prior suspension.
+func (r *runtimeMCPRegistry) replacePrefix(prefix string, tools []tool.Tool) []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var names []string
+	for i, reg := range r.targetsLocked() {
+		reg.ResumePrefix(prefix)
+		reg.RemovePrefix(prefix)
+		added := addTools(reg, tools)
+		if i == 0 {
+			names = added
+		}
+	}
+	return names
+}
+
+func (r *runtimeMCPRegistry) targetsLocked() []*tool.Registry {
+	if len(r.targets) > 0 {
+		return r.targets
+	}
+	if r.fallback != nil {
+		return []*tool.Registry{r.fallback}
+	}
+	return nil
+}
+
+func uniqueRegistries(in []*tool.Registry) []*tool.Registry {
+	out := make([]*tool.Registry, 0, len(in))
+	seen := map[*tool.Registry]bool{}
+	for _, reg := range in {
+		if reg == nil || seen[reg] {
+			continue
+		}
+		seen[reg] = true
+		out = append(out, reg)
+	}
+	return out
+}

--- a/internal/boot/runtime_mcp_registry_test.go
+++ b/internal/boot/runtime_mcp_registry_test.go
@@ -1,0 +1,84 @@
+package boot
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/tool"
+)
+
+type runtimeMCPTestTool struct{ name string }
+
+func (t *runtimeMCPTestTool) Name() string            { return t.name }
+func (t *runtimeMCPTestTool) Description() string     { return t.name }
+func (t *runtimeMCPTestTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (t *runtimeMCPTestTool) ReadOnly() bool          { return true }
+func (t *runtimeMCPTestTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "ok", nil
+}
+
+func TestRuntimeMCPRegistryPublishesPostSnapshotSwapToExecutionAndLegacy(t *testing.T) {
+	fallback := tool.NewRegistry()
+	fallback.Add(&runtimeMCPTestTool{name: "mcp__svc__connect"})
+	router := newRuntimeMCPRegistry(fallback)
+
+	var legacy, execution *tool.Registry
+	router.bindSnapshot(func() []*tool.Registry {
+		legacy = fallback.Clone()
+		execution = legacy.Clone()
+		return []*tool.Registry{execution, legacy}
+	})
+
+	// Mirror plugin.lazySpawn.trySwap: remove the cache-miss placeholder, then
+	// publish the real tools through the same writer.
+	router.RemovePrefix("mcp__svc__")
+	router.Add(&runtimeMCPTestTool{name: "mcp__svc__search"})
+
+	for name, reg := range map[string]*tool.Registry{"execution": execution, "legacy": legacy} {
+		if _, ok := reg.Get("mcp__svc__connect"); ok {
+			t.Fatalf("%s kept cache-miss placeholder after swap", name)
+		}
+		if _, ok := reg.Get("mcp__svc__search"); !ok {
+			t.Fatalf("%s missed real tool after swap", name)
+		}
+	}
+	if _, ok := fallback.Get("mcp__svc__search"); ok {
+		t.Fatal("post-snapshot swap wrote to abandoned bootstrap registry")
+	}
+}
+
+func TestRuntimeMCPRegistryExplicitReplaceResumesBothTargets(t *testing.T) {
+	legacy := tool.NewRegistry()
+	execution := tool.NewRegistry()
+	router := newRuntimeMCPRegistry(tool.NewRegistry())
+	router.bindSnapshot(func() []*tool.Registry { return []*tool.Registry{execution, legacy} })
+
+	for _, reg := range []*tool.Registry{execution, legacy} {
+		reg.SuspendPrefix("mcp__svc__")
+	}
+	names := router.replacePrefix("mcp__svc__", []tool.Tool{
+		&runtimeMCPTestTool{name: "mcp__svc__z"},
+		&runtimeMCPTestTool{name: "mcp__svc__a"},
+	})
+	if got, want := names, []string{"mcp__svc__a", "mcp__svc__z"}; !sameStrings(got, want) {
+		t.Fatalf("names = %v, want %v", got, want)
+	}
+	for label, reg := range map[string]*tool.Registry{"execution": execution, "legacy": legacy} {
+		if _, ok := reg.Get("mcp__svc__a"); !ok {
+			t.Fatalf("%s remained suspended after explicit reconnect", label)
+		}
+	}
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/capability/search.go
+++ b/internal/capability/search.go
@@ -1,0 +1,216 @@
+package capability
+
+import (
+	"sort"
+	"strings"
+
+	"reasonix/internal/retrieval"
+)
+
+// SearchKind filters catalog entries for Search.
+type SearchKind string
+
+const (
+	SearchKindAll   SearchKind = "all"
+	SearchKindTool  SearchKind = "tool"
+	SearchKindSkill SearchKind = "skill"
+	SearchKindMCP   SearchKind = "mcp"
+)
+
+// SearchOptions configures a catalog search.
+type SearchOptions struct {
+	Query string
+	// Limit caps results (default 5, max 10). Values outside the range are clamped.
+	Limit int
+	// Kind is all|tool|skill|mcp (default all).
+	Kind SearchKind
+}
+
+// SearchHit is one ranked catalog entry.
+type SearchHit struct {
+	Entry Entry
+	Score float64
+	// Tier is 0=exact ID/name, 1=prefix, 2=BM25-only. Lower ranks first.
+	Tier int
+}
+
+const (
+	searchTierExact  = 0
+	searchTierPrefix = 1
+	searchTierBM25   = 2
+)
+
+// Search ranks catalog entries for query using exact/prefix preference then
+// BM25 over ID, name (weight 3), source, description (weight 2), triggers, and
+// requires. Disabled entries are skipped. Tie-break is capability ID.
+// Search never starts processes or contacts the network; it only reads entries.
+func Search(entries []Entry, opts SearchOptions) []SearchHit {
+	query := strings.TrimSpace(opts.Query)
+	if query == "" {
+		return nil
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 5
+	}
+	if limit > 10 {
+		limit = 10
+	}
+	kind := opts.Kind
+	if kind == "" {
+		kind = SearchKindAll
+	}
+
+	queryNorm := strings.ToLower(query)
+	queryTerms, err := retrieval.QueryTerms(query)
+	if err != nil {
+		// Non-token queries can still exact/prefix match IDs/names (e.g. punctuation-only
+		// is empty; bare symbols fall through to nil).
+		queryTerms = nil
+	}
+
+	type doc struct {
+		entry  Entry
+		counts map[string]int
+		length int
+		tier   int
+	}
+
+	filtered := make([]doc, 0, len(entries))
+	for _, e := range entries {
+		if e.Status == StatusDisabled {
+			continue
+		}
+		if !matchSearchKind(e.Kind, kind) {
+			continue
+		}
+		idNorm := strings.ToLower(strings.TrimSpace(e.ID))
+		nameNorm := strings.ToLower(strings.TrimSpace(e.Name))
+		tier := searchTierBM25
+		switch {
+		case idNorm == queryNorm || nameNorm == queryNorm:
+			tier = searchTierExact
+		case idNorm != "" && (strings.HasPrefix(idNorm, queryNorm) || strings.HasPrefix(queryNorm, idNorm)):
+			tier = searchTierPrefix
+		case nameNorm != "" && (strings.HasPrefix(nameNorm, queryNorm) || strings.HasPrefix(queryNorm, nameNorm)):
+			tier = searchTierPrefix
+		}
+		text := indexText(e)
+		terms := retrieval.Tokens(text)
+		counts := retrieval.Counts(terms)
+		filtered = append(filtered, doc{
+			entry:  e,
+			counts: counts,
+			length: len(terms),
+			tier:   tier,
+		})
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	// BM25 corpus over the filtered set (including exact/prefix candidates).
+	countMaps := make([]map[string]int, len(filtered))
+	var totalLen int
+	for i, d := range filtered {
+		countMaps[i] = d.counts
+		totalLen += d.length
+	}
+	df := retrieval.DocumentFrequency(countMaps)
+	avgLen := 1.0
+	if len(filtered) > 0 {
+		avgLen = float64(totalLen) / float64(len(filtered))
+	}
+	if avgLen <= 0 {
+		avgLen = 1
+	}
+
+	hits := make([]SearchHit, 0, len(filtered))
+	for _, d := range filtered {
+		score := 0.0
+		if len(queryTerms) > 0 {
+			score = retrieval.BM25Score(d.counts, d.length, queryTerms, df, len(filtered), avgLen)
+		}
+		// Exact/prefix always surface; BM25-only needs a positive score.
+		if d.tier == searchTierBM25 && score <= 0 {
+			continue
+		}
+		// Boost score slightly by tier so result payloads still reflect rank quality
+		// without overturning the primary tier sort.
+		hits = append(hits, SearchHit{Entry: d.entry, Score: score, Tier: d.tier})
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Tier != hits[j].Tier {
+			return hits[i].Tier < hits[j].Tier
+		}
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].Entry.ID < hits[j].Entry.ID
+	})
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+	return hits
+}
+
+func matchSearchKind(k Kind, filter SearchKind) bool {
+	switch filter {
+	case SearchKindAll, "":
+		return true
+	case SearchKindTool:
+		return k == KindTool
+	case SearchKindSkill:
+		return k == KindSkill
+	case SearchKindMCP:
+		return k == KindMCPServer || k == KindMCPTool
+	default:
+		return false
+	}
+}
+
+// indexText builds the BM25 document for an entry. Name is weighted 3× and
+// description 2×; remaining fields contribute once.
+func indexText(e Entry) string {
+	var b strings.Builder
+	writeN := func(s string, n int) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		for i := 0; i < n; i++ {
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(s)
+		}
+	}
+	writeN(e.Name, 3)
+	writeN(e.Description, 2)
+	writeN(e.ID, 1)
+	writeN(e.Source, 1)
+	for _, t := range e.Triggers {
+		writeN(t, 1)
+	}
+	for _, r := range e.Requires {
+		writeN(r, 1)
+	}
+	return b.String()
+}
+
+// ParseSearchKind normalizes a kind filter string.
+func ParseSearchKind(raw string) SearchKind {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "all":
+		return SearchKindAll
+	case "tool":
+		return SearchKindTool
+	case "skill":
+		return SearchKindSkill
+	case "mcp":
+		return SearchKindMCP
+	default:
+		return SearchKind(strings.ToLower(strings.TrimSpace(raw)))
+	}
+}

--- a/internal/capability/search_test.go
+++ b/internal/capability/search_test.go
@@ -1,0 +1,131 @@
+package capability
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSearchExactMatchRanksFirst(t *testing.T) {
+	entries := []Entry{
+		{ID: "tool:grep_other", Kind: KindTool, Name: "grep_other", Description: "grep helper", Status: StatusReady},
+		{ID: "tool:grep", Kind: KindTool, Name: "grep", Description: "search files", Status: StatusReady},
+		{ID: "tool:glob", Kind: KindTool, Name: "glob", Description: "glob paths with grep-like patterns", Status: StatusReady},
+	}
+	hits := Search(entries, SearchOptions{Query: "grep", Limit: 5})
+	if len(hits) == 0 {
+		t.Fatal("expected hits")
+	}
+	if hits[0].Entry.ID != "tool:grep" || hits[0].Tier != searchTierExact {
+		t.Fatalf("top hit = %+v, want exact tool:grep", hits[0])
+	}
+}
+
+func TestSearchPrefixBeforeBM25(t *testing.T) {
+	entries := []Entry{
+		// BM25-friendly description with the query term, but no name/id prefix.
+		{ID: "tool:search_code", Kind: KindTool, Name: "search_code", Description: "grep code base thoroughly", Status: StatusReady},
+		// Prefix on name.
+		{ID: "tool:gre", Kind: KindTool, Name: "gre_helper", Description: "unrelated", Status: StatusReady},
+	}
+	hits := Search(entries, SearchOptions{Query: "gre", Limit: 5})
+	if len(hits) < 1 {
+		t.Fatal("expected hits")
+	}
+	if hits[0].Entry.ID != "tool:gre" || hits[0].Tier != searchTierPrefix {
+		t.Fatalf("top hit = %+v, want prefix tool:gre", hits[0])
+	}
+}
+
+func TestSearchBM25ChineseAndEnglish(t *testing.T) {
+	entries := []Entry{
+		{ID: "skill:review", Kind: KindSkill, Name: "review", Description: "审查代码查找问题 code review", Status: StatusReady, Triggers: []string{"review", "审查"}},
+		{ID: "skill:deploy", Kind: KindSkill, Name: "deploy", Description: "deploy services", Status: StatusReady},
+		{ID: "tool:bash", Kind: KindTool, Name: "bash", Description: "run shell", Status: StatusReady},
+	}
+	en := Search(entries, SearchOptions{Query: "code review", Limit: 5, Kind: SearchKindSkill})
+	if len(en) == 0 || en[0].Entry.ID != "skill:review" {
+		t.Fatalf("EN hits = %+v, want skill:review first", en)
+	}
+	cn := Search(entries, SearchOptions{Query: "审查", Limit: 5, Kind: SearchKindSkill})
+	if len(cn) == 0 || cn[0].Entry.ID != "skill:review" {
+		t.Fatalf("CN hits = %+v, want skill:review first", cn)
+	}
+}
+
+func TestSearchTieBreakByCapabilityID(t *testing.T) {
+	// Two exact name matches for different IDs with identical fields → ID order.
+	entries := []Entry{
+		{ID: "tool:z_tool", Kind: KindTool, Name: "same", Description: "x", Status: StatusReady},
+		{ID: "tool:a_tool", Kind: KindTool, Name: "same", Description: "x", Status: StatusReady},
+	}
+	hits := Search(entries, SearchOptions{Query: "same", Limit: 5})
+	if len(hits) != 2 {
+		t.Fatalf("hits = %d, want 2", len(hits))
+	}
+	if hits[0].Entry.ID != "tool:a_tool" || hits[1].Entry.ID != "tool:z_tool" {
+		t.Fatalf("tie-break order = %q, %q", hits[0].Entry.ID, hits[1].Entry.ID)
+	}
+}
+
+func TestSearchSkipsDisabled(t *testing.T) {
+	entries := []Entry{
+		{ID: "mcp-server:off", Kind: KindMCPServer, Name: "off", Description: "github mcp", Status: StatusDisabled},
+		{ID: "mcp-server:on", Kind: KindMCPServer, Name: "on", Description: "github mcp", Status: StatusReady},
+	}
+	hits := Search(entries, SearchOptions{Query: "github", Limit: 5, Kind: SearchKindMCP})
+	for _, h := range hits {
+		if h.Entry.Status == StatusDisabled {
+			t.Fatalf("disabled entry returned: %+v", h)
+		}
+	}
+	if len(hits) != 1 || hits[0].Entry.ID != "mcp-server:on" {
+		t.Fatalf("hits = %+v", hits)
+	}
+}
+
+func TestSearchKindFilter(t *testing.T) {
+	entries := []Entry{
+		{ID: "tool:grep", Kind: KindTool, Name: "grep", Description: "grep", Status: StatusReady},
+		{ID: "skill:grep", Kind: KindSkill, Name: "grep", Description: "grep skill", Status: StatusReady},
+		{ID: "mcp-tool:gh/search", Kind: KindMCPTool, Name: "gh/search", Description: "grep issues", Status: StatusReady},
+	}
+	hits := Search(entries, SearchOptions{Query: "grep", Limit: 10, Kind: SearchKindTool})
+	if len(hits) != 1 || hits[0].Entry.ID != "tool:grep" {
+		t.Fatalf("tool filter = %+v", hits)
+	}
+	mcp := Search(entries, SearchOptions{Query: "grep", Limit: 10, Kind: SearchKindMCP})
+	if len(mcp) != 1 || !strings.HasPrefix(mcp[0].Entry.ID, "mcp-") {
+		t.Fatalf("mcp filter = %+v", mcp)
+	}
+}
+
+func TestSearchLimitClamp(t *testing.T) {
+	entries := make([]Entry, 0, 12)
+	for i := 0; i < 12; i++ {
+		entries = append(entries, Entry{
+			ID: "tool:item" + string(rune('a'+i)), Kind: KindTool, Name: "item", Description: "item", Status: StatusReady,
+		})
+	}
+	hits := Search(entries, SearchOptions{Query: "item", Limit: 100})
+	if len(hits) > 10 {
+		t.Fatalf("limit not clamped: %d", len(hits))
+	}
+}
+
+func TestIndexTextWeightsNameAndDescription(t *testing.T) {
+	text := indexText(Entry{
+		ID: "tool:x", Name: "alpha", Description: "beta", Source: "src",
+		Triggers: []string{"trig"}, Requires: []string{"req"},
+	})
+	if strings.Count(text, "alpha") < 3 {
+		t.Fatalf("name weight missing: %q", text)
+	}
+	if strings.Count(text, "beta") < 2 {
+		t.Fatalf("description weight missing: %q", text)
+	}
+	for _, want := range []string{"tool:x", "src", "trig", "req"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("index missing %q in %q", want, text)
+		}
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -235,6 +235,8 @@ type cliBuildOverrides struct {
 	AdditionalDirs       []string
 	WorkspaceRoot        string
 	HeadlessApprovalMode string
+	EditProtocolOverride string
+	RuntimeContract      *agent.RuntimeContract
 }
 
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
@@ -252,6 +254,8 @@ func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOv
 		PermissionAllow:      overrides.PermissionAllow,
 		AdditionalDirs:       overrides.AdditionalDirs,
 		HeadlessApprovalMode: overrides.HeadlessApprovalMode,
+		EditProtocolOverride: overrides.EditProtocolOverride,
+		RuntimeContract:      overrides.RuntimeContract,
 	})
 }
 
@@ -418,6 +422,7 @@ func runAgent(args []string) int {
 	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
 	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	effort := fs.String("effort", "", "session reasoning effort override")
+	editProtocolFlag := fs.String("edit-protocol", "", "new-session edit protocol: classic | hashline (default from config; resume must match saved contract)")
 	permissionMode := fs.String("permission-mode", "ask", "permission mode: manual | ask | auto | acceptEdits | dontAsk | plan | bypassPermissions")
 	printOnly := fs.BoolP("print", "p", false, "print only the final response")
 	outputFormat := fs.String("output-format", "text", "output format: text | json | stream-json")
@@ -429,6 +434,16 @@ func runAgent(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	var editProtocolOverride string
+	if strings.TrimSpace(*editProtocolFlag) != "" {
+		ep, err := agent.ParseEditProtocolFlag(*editProtocolFlag)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 2
+		}
+		editProtocolOverride = ep
+	}
+	// editProtocolOverride is applied on new sessions via cliBuildOverrides
 	allowedTools, err := splitAllowedToolRules(allowedToolValues)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -578,7 +593,31 @@ func runAgent(args []string) int {
 	// executor, not just the top-level one. Default/ask and acceptEdits already
 	// keep the default headless gate (ask decisions resolve to allow); only
 	// auto/dontAsk/yolo need the explicit contract.
-	overrides := cliBuildOverrides{Effort: effortOverride, PermissionAllow: allowedTools, AdditionalDirs: additionalDirs, WorkspaceRoot: workspaceRoot, HeadlessApprovalMode: permissions.approval}
+	overrides := cliBuildOverrides{Effort: effortOverride, PermissionAllow: allowedTools, AdditionalDirs: additionalDirs, WorkspaceRoot: workspaceRoot, HeadlessApprovalMode: permissions.approval, EditProtocolOverride: editProtocolOverride}
+	// Resume/fork must rebuild with the saved RuntimeContract so tool schemas
+	// and prompt layout never drift. New sessions leave RuntimeContract nil
+	// and derive from config (+ optional --edit-protocol).
+	if resumePath != "" {
+		if meta, ok, err := agent.LoadBranchMeta(resumePath); err == nil && ok {
+			rc := agent.ResolveRuntimeContractFromMeta(meta)
+			// If sidecar is missing contract, try inferring from session context.
+			if meta.RuntimeContract == nil && resumeSession != nil {
+				if inferred, ok := agent.InferRuntimeContractFromMessages(resumeSession.Snapshot()); ok {
+					rc = inferred
+				}
+			}
+			overrides.RuntimeContract = rc.Clone()
+			// Resume rejects --edit-protocol that conflicts with the saved contract.
+			if editProtocolOverride != "" && editProtocolOverride != rc.EditProtocol {
+				fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix,
+					"--edit-protocol conflicts with the saved session contract; start a new task instead of overriding resume")
+				return 2
+			}
+			// Clear override so boot does not double-check as a false conflict
+			// when the values already match.
+			overrides.EditProtocolOverride = ""
+		}
+	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, true, sink, profile, overrides)
 	if err != nil {
 		if resultOutput != nil && format != runOutputText {
@@ -946,6 +985,19 @@ func chatREPL(args []string) int {
 		effortOverride = effort
 	}
 	overrides := cliBuildOverrides{Effort: effortOverride, PermissionAllow: allowedTools, AdditionalDirs: additionalDirs, WorkspaceRoot: workspaceRoot}
+	if resumePath != "" {
+		if meta, ok, err := agent.LoadBranchMeta(resumePath); err == nil && ok {
+			rc := agent.ResolveRuntimeContractFromMeta(meta)
+			if meta.RuntimeContract == nil {
+				if loaded, lerr := agent.LoadSession(resumePath); lerr == nil && loaded != nil {
+					if inferred, ok := agent.InferRuntimeContractFromMessages(loaded.Snapshot()); ok {
+						rc = inferred
+					}
+				}
+			}
+			overrides.RuntimeContract = rc.Clone()
+		}
+	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, false, sink, profile, overrides)
 	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
 		// True first run whose default model can't resolve: guide setup, then retry.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1083,6 +1083,12 @@ type AgentConfig struct {
 	// PlanModeReadOnlyCommands is retained for old config/session round trips. Main
 	// Plan bash calls now use the ordinary Permissions classifier and Sandbox.
 	PlanModeReadOnlyCommands []string `toml:"plan_mode_read_only_commands"`
+	// PromptLayout selects the new-session system/context split:
+	// "session_context" (default) keeps only static policy in system and pins
+	// workspace/env/memory/skills as a synthetic user message; "legacy_system"
+	// keeps the pre-upgrade layout. Illegal values are rejected at load time.
+	// Existing sessions ignore this and keep their RuntimeContract.
+	PromptLayout string `toml:"prompt_layout"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's
@@ -1339,6 +1345,15 @@ type ToolsConfig struct {
 	BackgroundJobs        BackgroundJobsConfig `toml:"background_jobs"`
 	Search                SearchConfig         `toml:"search"`
 	Shell                 ShellConfig          `toml:"shell"`
+	// CapabilitySurface selects the new-session provider tool surface:
+	// "stable" (default) = capability-v2 proxy for optional tools;
+	// "legacy" keeps Full/Economy/Delivery dynamic schema behavior.
+	// Illegal values are rejected at load time. Existing sessions keep their
+	// RuntimeContract and never re-read this mid-session.
+	CapabilitySurface string `toml:"capability_surface"`
+	// EditProtocol selects the new-session file-edit protocol:
+	// "classic" (default) or "hashline" (Beta). Hashline requires stable surface.
+	EditProtocol string `toml:"edit_protocol"`
 }
 
 const (

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -148,7 +148,77 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	cfg.CredentialsStore = credentialsStoreMode()
 	cfg.setExpansionEnv(expansionEnv)
 	resolveProviderCredentialsForRoot(root, cfg)
+	if err := validateRuntimeContractConfig(cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
+}
+
+// validateRuntimeContractConfig rejects illegal capability_surface / edit_protocol /
+// prompt_layout enums. Values are not silently corrected — misconfiguration must
+// fail at load so new-session contracts stay intentional.
+func validateRuntimeContractConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	surface := strings.ToLower(strings.TrimSpace(cfg.Tools.CapabilitySurface))
+	switch surface {
+	case "", "stable", "legacy":
+	default:
+		return fmt.Errorf("tools.capability_surface: invalid value %q (want stable|legacy)", cfg.Tools.CapabilitySurface)
+	}
+	edit := strings.ToLower(strings.TrimSpace(cfg.Tools.EditProtocol))
+	switch edit {
+	case "", "classic", "hashline":
+	default:
+		return fmt.Errorf("tools.edit_protocol: invalid value %q (want classic|hashline)", cfg.Tools.EditProtocol)
+	}
+	layout := strings.ToLower(strings.TrimSpace(cfg.Agent.PromptLayout))
+	switch layout {
+	case "", "session_context", "legacy_system":
+	default:
+		return fmt.Errorf("agent.prompt_layout: invalid value %q (want session_context|legacy_system)", cfg.Agent.PromptLayout)
+	}
+	if edit == "hashline" && surface == "legacy" {
+		return fmt.Errorf("tools.edit_protocol=hashline requires tools.capability_surface=stable")
+	}
+	return nil
+}
+
+// NewSessionRuntimeContract maps config enums to the wire RuntimeContract values
+// used by agent/boot. Empty fields keep the pre-gate legacy triple so existing
+// sessions and tests stay stable until the release gate flips product defaults
+// to capability-v2 / session-context-v2 (see capability upgrade plan §6).
+// Explicit stable|session_context enables the new surfaces. Does not mutate cfg.
+func (c *Config) NewSessionRuntimeContract() (toolSurface, editProtocol, promptLayout string, err error) {
+	if c == nil {
+		return "legacy-v1", "classic-v1", "system-v1", nil
+	}
+	if err := validateRuntimeContractConfig(c); err != nil {
+		return "", "", "", err
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Tools.CapabilitySurface)) {
+	case "stable":
+		toolSurface = "capability-v2"
+	default: // "" | "legacy"
+		toolSurface = "legacy-v1"
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Tools.EditProtocol)) {
+	case "hashline":
+		editProtocol = "hashline-v1"
+	default:
+		editProtocol = "classic-v1"
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Agent.PromptLayout)) {
+	case "session_context":
+		promptLayout = "session-context-v2"
+	default: // "" | "legacy_system"
+		promptLayout = "system-v1"
+	}
+	if editProtocol == "hashline-v1" && toolSurface != "capability-v2" {
+		return "", "", "", fmt.Errorf("tools.edit_protocol=hashline requires tools.capability_surface=stable")
+	}
+	return toolSurface, editProtocol, promptLayout, nil
 }
 
 // SafeModeRequested reports whether this process should ignore user/project

--- a/internal/config/runtime_contract_config_test.go
+++ b/internal/config/runtime_contract_config_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestValidateRuntimeContractConfigRejectsIllegal(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.CapabilitySurface = "nope"
+	if err := validateRuntimeContractConfig(cfg); err == nil {
+		t.Fatal("expected error for bad capability_surface")
+	}
+	cfg = Default()
+	cfg.Tools.EditProtocol = "hashline"
+	cfg.Tools.CapabilitySurface = "legacy"
+	if err := validateRuntimeContractConfig(cfg); err == nil {
+		t.Fatal("hashline requires stable")
+	}
+	cfg = Default()
+	cfg.Tools.CapabilitySurface = "stable"
+	cfg.Tools.EditProtocol = "hashline"
+	cfg.Agent.PromptLayout = "session_context"
+	if err := validateRuntimeContractConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	surface, edit, layout, err := cfg.NewSessionRuntimeContract()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if surface != "capability-v2" || edit != "hashline-v1" || layout != "session-context-v2" {
+		t.Fatalf("got %s %s %s", surface, edit, layout)
+	}
+}
+
+func TestNewSessionRuntimeContractEmptyIsLegacy(t *testing.T) {
+	cfg := Default()
+	surface, edit, layout, err := cfg.NewSessionRuntimeContract()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if surface != "legacy-v1" || edit != "classic-v1" || layout != "system-v1" {
+		t.Fatalf("empty defaults should be legacy triple, got %s/%s/%s", surface, edit, layout)
+	}
+}

--- a/internal/control/checkpoint.go
+++ b/internal/control/checkpoint.go
@@ -2,6 +2,8 @@ package control
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"reasonix/internal/checkpoint"
@@ -107,6 +109,32 @@ func (m *checkpointManager) list() []checkpoint.Meta {
 		return nil
 	}
 	return store.List()
+}
+
+// editedPaths returns the sorted union of paths snapshotted across all
+// checkpoints (current session). Used by compaction state recovery.
+func (m *checkpointManager) editedPaths() []string {
+	metas := m.list()
+	if len(metas) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, meta := range metas {
+		for _, p := range meta.Paths {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // restoreCode reverts every file changed at or after turn to its pre-turn

--- a/internal/control/compaction_state.go
+++ b/internal/control/compaction_state.go
@@ -1,0 +1,100 @@
+package control
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+// CompactionState implements agent.CompactionStateProvider for the Controller.
+// It snapshots Goal/Todo/Job/path state deterministically for post-compaction
+// recovery; the model never summarizes this block.
+func (c *Controller) CompactionState() agent.CompactionState {
+	if c == nil {
+		return agent.CompactionState{}
+	}
+	st := agent.CompactionState{}
+
+	goal, status, _, _ := c.goals.snapshot()
+	st.ActiveGoal = goal
+	st.GoalStatus = status
+	if status == GoalStatusBlocked {
+		st.BlockedGoal = goal
+		// Persist any host-visible block reason from the goal machine state file
+		// path or last known intercept when available.
+		if reason := c.goals.blockReasonText(); reason != "" {
+			st.BlockReason = reason
+		}
+	}
+
+	todos := c.Todos()
+	for i, t := range todos {
+		status := strings.ToLower(strings.TrimSpace(t.Status))
+		switch status {
+		case "completed", "done":
+			st.CompletedTodos++
+		case "cancelled", "canceled":
+			st.CancelledTodos++
+		default:
+			st.Todos = append(st.Todos, agent.CompactionTodo{
+				ID:     fmt.Sprintf("%d", i+1),
+				Status: t.Status,
+				Text:   t.Content,
+			})
+		}
+	}
+
+	// Running background jobs / sub-agents for this session.
+	if c.jobs != nil {
+		parent := c.parentSessionID()
+		for _, v := range c.jobs.RunningForSession(parent) {
+			st.Jobs = append(st.Jobs, agent.CompactionJob{
+				ID:    v.ID,
+				Kind:  v.Kind,
+				Label: v.Label,
+			})
+		}
+	}
+
+	// Edited paths: checkpoint store + evidence receipts union.
+	pathSet := map[string]struct{}{}
+	if c.checkpoints.enabled() {
+		for _, p := range c.checkpoints.editedPaths() {
+			if p = strings.TrimSpace(p); p != "" {
+				pathSet[p] = struct{}{}
+			}
+		}
+	}
+	if c.executor != nil {
+		for _, p := range c.executor.EvidenceEditedPaths() {
+			if p = strings.TrimSpace(p); p != "" {
+				pathSet[p] = struct{}{}
+			}
+		}
+	}
+	for p := range pathSet {
+		st.EditedPaths = append(st.EditedPaths, p)
+	}
+	sort.Strings(st.EditedPaths)
+
+	if cp := c.goals.deliveryState(); cp.CriteriaEstablished || cp.WorkObserved || cp.MutationObserved {
+		var parts []string
+		if cp.CriteriaEstablished {
+			parts = append(parts, "criteria")
+		}
+		if cp.WorkObserved {
+			parts = append(parts, "work")
+		}
+		if cp.MutationObserved {
+			parts = append(parts, "mutation")
+		}
+		if cp.PendingMutation {
+			parts = append(parts, "pending_mutation")
+		}
+		st.DeliveryCP = strings.Join(parts, ",")
+	}
+
+	return st
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -386,9 +386,13 @@ type Options struct {
 	BalanceClient *http.Client
 	// Jobs is the session-scoped background-job manager (nil disables background jobs).
 	Jobs *jobs.Manager
-	// Registry is the executor's live tool set, and PluginCtx the session-scoped
-	// context; both are needed for hot-adding MCP servers via AddMCPServer.
-	Registry  *tool.Registry
+	// Registry is the fallback single tool registry (tests / no bundle). Prefer
+	// RegistryBundle for production boots so MCP mutations route correctly.
+	Registry *tool.Registry
+	// RegistryBundle, when set, routes MCP tool mutations to Execution (+ Legacy
+	// mirror) and never to capability provider surfaces.
+	RegistryBundle *agent.RegistryBundle
+	// PluginCtx is the session-scoped context for hot-added MCP subprocesses.
 	PluginCtx context.Context
 	// MCPDefaultCallTimeout is the global MCP call cap used by hot-connected
 	// servers when they do not declare a server- or tool-specific override.
@@ -509,6 +513,14 @@ func New(opts Options) *Controller {
 		externalFolderToolRefs:            opts.ExternalFolderToolRefs,
 		approval:                          newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
+	// Route MCP mutations via the boot RegistryBundle (Execution + Legacy mirror).
+	if opts.RegistryBundle != nil {
+		c.mcp.setBundle(opts.RegistryBundle)
+	} else if c.executor != nil {
+		if b := c.executor.RegistryBundle(); b != nil {
+			c.mcp.setBundle(b)
+		}
+	}
 	if strings.TrimSpace(opts.WorkspaceRoot) != "" {
 		c.autoResearch = autoresearch.NewStore(opts.WorkspaceRoot)
 	}
@@ -553,11 +565,26 @@ func (c *Controller) ToolContractEntries() []tool.ContractEntry {
 	if c == nil {
 		return nil
 	}
-	reg := c.mcp.registry()
-	if reg == nil {
+	if reg := c.providerRegistry(); reg != nil {
+		return reg.ContractEntries()
+	}
+	return nil
+}
+
+// providerRegistry returns the active provider-visible tool registry for the
+// current RuntimeContract (via RegistryBundle), falling back to the single reg.
+func (c *Controller) providerRegistry() *tool.Registry {
+	if c == nil {
 		return nil
 	}
-	return reg.ContractEntries()
+	if c.executor != nil {
+		if b := c.executor.RegistryBundle(); b != nil {
+			if reg := b.ProviderRegistry(c.executor.RuntimeContract()); reg != nil {
+				return reg
+			}
+		}
+	}
+	return c.mcp.registry()
 }
 
 func (c *Controller) recordDisplayForNewUser(startMessages int, display string) {
@@ -2924,6 +2951,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		Preview:          forkPreview,
 		Turns:            forkTurns,
 		SchemaVersion:    agent.BranchMetaCountsVersion,
+		RuntimeContract:  c.inheritRuntimeContract(parentPath),
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}
@@ -2946,6 +2974,21 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("forked conversation at turn %d into a new session", turn)})
 	return newPath, nil
+}
+
+// inheritRuntimeContract copies the parent session's contract for Fork/Branch.
+// Missing parent meta falls back to the live executor contract, then legacy.
+func (c *Controller) inheritRuntimeContract(parentPath string) *agent.RuntimeContract {
+	if parentPath != "" {
+		if meta, ok, err := agent.LoadBranchMeta(parentPath); err == nil && ok && meta.RuntimeContract != nil {
+			return meta.RuntimeContract.Clone()
+		}
+	}
+	if c != nil && c.executor != nil {
+		rc := c.executor.RuntimeContract()
+		return rc.Clone()
+	}
+	return agent.LegacyDefaultRuntimeContract().Clone()
 }
 
 func (c *Controller) CheckpointHasBoundary(turn int) bool {
@@ -3004,6 +3047,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		Preview:          branchPreview,
 		Turns:            branchTurns,
 		SchemaVersion:    agent.BranchMetaCountsVersion,
+		RuntimeContract:  c.inheritRuntimeContract(parentPath),
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}
@@ -3181,13 +3225,22 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 }
 
 // Resume seeds the session from a loaded transcript and pins the active file to
-// its path so auto-save keeps appending there.
+// its path so auto-save keeps appending there. Before the next provider request
+// it restores the session RuntimeContract (tool surface / edit protocol / prompt
+// layout) from BranchMeta — never the current process config — and switches the
+// provider registry via the boot RegistryBundle when available.
 func (c *Controller) Resume(s *agent.Session, path string) {
 	// See snapshotMu: the swap must not interleave with an in-flight save.
 	// recoverInterruptedTurn and maybeColdResumePrune snapshot on their own,
 	// so they stay outside the locked section (snapshotMu is not reentrant).
 	c.snapshotMu.Lock()
 	if c.executor != nil {
+		// Apply saved contract before binding the session so the first resumed
+		// turn uses the correct tools. applySavedRuntimeContract always applies
+		// a contract (legacy on failure); non-nil err is diagnostic only.
+		if err := c.applySavedRuntimeContract(path, s); err != nil {
+			slog.Warn("controller: resume runtime contract", "path", path, "err", err)
+		}
 		c.executor.SetSession(s)
 	}
 	c.ResetPlannerSession()
@@ -3206,6 +3259,65 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.snapshotMu.Unlock()
 	c.recoverInterruptedTurn(path)
 	c.maybeColdResumePrune(path)
+}
+
+// applySavedRuntimeContract loads BranchMeta.runtime_contract and switches the
+// executor registry. Never upgrades old sessions to process-wide config defaults.
+//
+//	| state                              | applied contract              |
+//	|------------------------------------|-------------------------------|
+//	| sidecar has valid contract         | saved value                   |
+//	| sidecar exists but no contract     | legacy (permanent)            |
+//	| sidecar missing                    | strict transcript infer / legacy |
+//	| sidecar corrupt / unreadable       | legacy + error for diagnostics|
+func (c *Controller) applySavedRuntimeContract(path string, s *agent.Session) error {
+	if c == nil || c.executor == nil {
+		return nil
+	}
+	rc := agent.LegacyDefaultRuntimeContract()
+	var applyErr error
+
+	meta, ok, err := agent.LoadBranchMeta(path)
+	switch {
+	case err != nil:
+		// Corrupt/unreadable sidecar: force legacy immediately; still report.
+		rc = agent.LegacyDefaultRuntimeContract()
+		applyErr = fmt.Errorf("sidecar unreadable: %w", err)
+	case ok && meta.RuntimeContract != nil:
+		rc = agent.NormalizeRuntimeContract(meta.RuntimeContract)
+		if vErr := agent.ValidateRuntimeContract(rc); vErr != nil {
+			rc = agent.LegacyDefaultRuntimeContract()
+			applyErr = fmt.Errorf("sidecar contract invalid: %w", vErr)
+		}
+	case ok && meta.RuntimeContract == nil:
+		// Pre-contract sidecar: permanent legacy. Do NOT infer from transcript
+		// (would flip process surface to v2 while next write pins legacy).
+		rc = agent.LegacyDefaultRuntimeContract()
+	default:
+		// Sidecar file missing: strict transcript inference only, else legacy.
+		if s != nil {
+			if inferred, ok := agent.InferRuntimeContractFromMessages(s.Snapshot()); ok {
+				rc = inferred
+			}
+		}
+	}
+
+	bundle := c.executor.RegistryBundle()
+	var switchErr error
+	if bundle != nil {
+		switchErr = c.executor.ApplyRuntimeContract(rc, bundle)
+	} else {
+		switchErr = c.executor.SetRuntimeContract(rc)
+	}
+	if switchErr != nil {
+		// Last resort: force legacy surface so Resume never leaves a stale v2 set.
+		_ = c.executor.ApplyRuntimeContract(agent.LegacyDefaultRuntimeContract(), bundle)
+		if applyErr != nil {
+			return fmt.Errorf("%v; also failed to apply contract: %w", applyErr, switchErr)
+		}
+		return switchErr
+	}
+	return applyErr
 }
 
 func (c *Controller) loadGuardianSession() {
@@ -3408,7 +3520,12 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 	// like SetBranchModelPreserveUpdated. The single write subsumes the old
 	// EnsureBranchMeta / SetBranchModel / TouchBranchMeta sequence.
 	preview, turns := agent.SessionPreviewFromMessages(s.Snapshot())
-	if err := agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity); err != nil {
+	var contract *agent.RuntimeContract
+	if c.executor != nil {
+		rc := c.executor.RuntimeContract()
+		contract = rc.Clone()
+	}
+	if err := agent.UpdateSessionMetaWithContract(path, modelRef, preview, turns, markActivity, contract); err != nil {
 		return err
 	}
 	return nil
@@ -5498,7 +5615,9 @@ func (c *Controller) approvalRequestEvent(approval event.Approval) event.Event {
 }
 
 func (c *Controller) mcpTrustApprovalPayload(toolName string) *event.MCPTrust {
-	registry := c.mcp.registry()
+	// MCP tools live on Execution (and Legacy mirror), never on capability
+	// provider surfaces — look them up where ConnectMCPServer registered them.
+	registry := c.mcp.executionRegistry()
 	if registry == nil {
 		return nil
 	}

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -155,6 +155,16 @@ func (g *goalMachine) active() bool {
 }
 
 // statusForDisplay maps the empty zero status to "stopped" for frontends.
+// blockReasonText returns the last host-recorded block reason, if any.
+func (g *goalMachine) blockReasonText() string {
+	if g == nil {
+		return ""
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return strings.TrimSpace(g.block)
+}
+
 func (g *goalMachine) statusForDisplay() string {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -9,6 +9,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/planmode"
+	"reasonix/internal/provider"
 	"reasonix/internal/skill"
 )
 
@@ -119,6 +120,9 @@ func StripReferencedContextPrefix(content string) string {
 // synthetic user messages injected by the controller or agent loop (plan
 // approval, stream recovery, readiness retry, etc.). These should not be shown
 // in the chat UI.
+//
+// Prefer IsSyntheticUserProviderMessage when the full Message (with
+// SyntheticReason metadata) is available.
 func IsSyntheticUserMessage(content string) bool {
 	if trimmed := strings.TrimSpace(agent.StripTransientUserBlocks(content)); trimmed == planApprovedMessage {
 		return true
@@ -127,6 +131,15 @@ func IsSyntheticUserMessage(content string) bool {
 	// preview/title/turn-count derivations there share the exact same filter
 	// (#3653).
 	return agent.IsSyntheticUserText(content)
+}
+
+// IsSyntheticUserProviderMessage prefers SyntheticReason metadata, then legacy
+// text-prefix detection.
+func IsSyntheticUserProviderMessage(m provider.Message) bool {
+	if m.IsSyntheticUser() {
+		return true
+	}
+	return IsSyntheticUserMessage(m.Content)
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/mcp.go
+++ b/internal/control/mcp.go
@@ -6,31 +6,38 @@ import (
 	"sync"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/plugin"
 	"reasonix/internal/tool"
 )
 
 // mcpManager owns the session's live tool/plugin surface: the MCP plugin Host
-// (live server connections), the tool Registry the executor reads each turn, and
-// the session-scoped context a hot-added stdio server binds its subprocess to.
-// Like approvalManager it holds the live plumbing behind its own lock, off c.mu —
-// the Controller keeps the config-facing orchestration (persisting reasonix.toml
-// on add/remove, building specs from entries).
+// (live server connections), tool registries that receive mutations, and the
+// session-scoped context a hot-added stdio server binds its subprocess to.
 //
-// mu guards the lazy host creation and host-pointer reads. The registry is
-// internally thread-safe (its own RWMutex) and pluginCtx is write-once, so the
-// lock is held only briefly — never across the host's network/subprocess I/O.
-// host is either injected at construction (the desktop shared-host path) or
-// created lazily on the first connect; once set it never reverts to nil.
+// MCP tool mutations always go to RegistryBundle.Execution, and are mirrored to
+// Legacy for historical provider-visible MCP on legacy sessions. They NEVER
+// write CapabilityClassic/CapabilityHashline — those surfaces stay schema-stable.
+//
+// mu guards host creation and pointer reads. Registry mutations use each
+// registry's own lock. Host network/subprocess I/O runs off mu.
 type mcpManager struct {
 	mu        sync.Mutex
 	host      *plugin.Host
-	reg       *tool.Registry
+	reg       *tool.Registry // fallback single-registry path (tests / no bundle)
+	bundle    *agent.RegistryBundle
 	pluginCtx context.Context
 }
 
 func newMcpManager(host *plugin.Host, reg *tool.Registry, pluginCtx context.Context) mcpManager {
 	return mcpManager{host: host, reg: reg, pluginCtx: pluginCtx}
+}
+
+// setBundle installs the boot RegistryBundle used for MCP mutation routing.
+func (m *mcpManager) setBundle(b *agent.RegistryBundle) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bundle = b
 }
 
 // hostRef returns the live plugin host (nil until one is injected or lazily
@@ -42,14 +49,14 @@ func (m *mcpManager) hostRef() *plugin.Host {
 }
 
 // connectSpec connects (or attaches to an already-connected) MCP server and
-// registers its tools, replacing any prior tools under the same prefix. Returns
-// the tool count. The host's network/subprocess I/O runs off mu.
+// registers its tools on MCP write targets (Execution + Legacy), replacing any
+// prior tools under the same prefix. Returns the tool count.
 func (m *mcpManager) connectSpec(s plugin.Spec) (int, error) {
 	m.mu.Lock()
 	if m.host == nil {
 		m.host = plugin.NewHost()
 	}
-	host, ctx, reg := m.host, m.pluginCtx, m.reg
+	host, ctx := m.host, m.pluginCtx
 	m.mu.Unlock()
 
 	tools, err := host.Add(ctx, s)
@@ -64,9 +71,10 @@ func (m *mcpManager) connectSpec(s plugin.Spec) (int, error) {
 			return 0, err
 		}
 	}
-	if reg != nil {
-		reg.ResumePrefix(plugin.ToolPrefix(s.Name))
-		reg.RemovePrefix(plugin.ToolPrefix(s.Name))
+	prefix := plugin.ToolPrefix(s.Name)
+	for _, reg := range m.mcpWriteTargets() {
+		reg.ResumePrefix(prefix)
+		reg.RemovePrefix(prefix)
 		for _, t := range tools {
 			reg.Add(t)
 		}
@@ -74,8 +82,7 @@ func (m *mcpManager) connectSpec(s plugin.Spec) (int, error) {
 	return len(tools), nil
 }
 
-// disconnect drops a live server and its tools from the registry. Reports whether
-// a live server was removed.
+// disconnect drops a live server and its tools from MCP write targets.
 func (m *mcpManager) disconnect(name string) bool {
 	host := m.hostRef()
 	if host == nil {
@@ -83,48 +90,86 @@ func (m *mcpManager) disconnect(name string) bool {
 	}
 	prefix, ok := host.Remove(name)
 	if ok {
-		if reg := m.registry(); reg != nil {
+		for _, reg := range m.mcpWriteTargets() {
 			reg.RemovePrefix(prefix)
 		}
 	}
 	return ok
 }
 
-// removeToolPrefix drops a server's tools from the registry without touching the
-// host — the placeholder / not-connected path. Returns the number removed.
+// removeToolPrefix drops a server's tools from MCP write targets without
+// touching the host — the placeholder / not-connected path.
 func (m *mcpManager) removeToolPrefix(name string) int {
-	reg := m.registry()
-	if reg == nil {
-		return 0
+	prefix := plugin.ToolPrefix(name)
+	n := 0
+	for _, reg := range m.mcpWriteTargets() {
+		n += reg.RemovePrefix(prefix)
 	}
-	return reg.RemovePrefix(plugin.ToolPrefix(name))
+	return n
 }
 
-// suspendToolPrefix hides a server's tools from this session's registry while a
-// shared host keeps the client alive for sibling sessions.
+// suspendToolPrefix hides a server's tools on MCP write targets while a shared
+// host keeps the client alive for sibling sessions. Suspend blocks later Add
+// with the same prefix on those registries (including late tools).
 func (m *mcpManager) suspendToolPrefix(name string) bool {
-	reg := m.registry()
-	if reg == nil {
-		return false
+	prefix := plugin.ToolPrefix(name)
+	ok := false
+	for _, reg := range m.mcpWriteTargets() {
+		if reg.SuspendPrefix(prefix) > 0 {
+			ok = true
+		}
 	}
-	reg.SuspendPrefix(plugin.ToolPrefix(name))
-	return true
+	// Even if no tools were present, mark suspended so late Adds are blocked.
+	if !ok {
+		for _, reg := range m.mcpWriteTargets() {
+			reg.SuspendPrefix(prefix)
+			ok = true
+		}
+	}
+	return ok
 }
 
-// registerTool adds a built-in tool to the live registry (e.g. the slash-command
-// tool rebuilt by ReloadCommands). No-op when no registry is bound.
+// registerTool publishes a dynamically rebuilt built-in (for example
+// slash_command) to Execution + Legacy only. Capability provider surfaces stay
+// fixed even when command files change during a session.
 func (m *mcpManager) registerTool(t tool.Tool) {
-	if reg := m.registry(); reg != nil {
+	for _, reg := range m.mcpWriteTargets() {
 		reg.Add(t)
 	}
 }
 
-// registry returns the shared tool registry under mu (write-once, but read under
-// the lock for consistency with the host pointer).
+// registry returns a registry suitable for provider-facing lookups when no
+// bundle is present. Prefer Controller.providerRegistry() when a bundle exists.
 func (m *mcpManager) registry() *tool.Registry {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.reg
+}
+
+// executionRegistry returns the bundle execution registry (MCP tool home), or
+// the single fallback registry.
+func (m *mcpManager) executionRegistry() *tool.Registry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.bundle != nil {
+		if exec := m.bundle.ExecutionRegistry(); exec != nil {
+			return exec
+		}
+	}
+	return m.reg
+}
+
+// mcpWriteTargets: Execution always; Legacy when distinct. Never capability surfaces.
+func (m *mcpManager) mcpWriteTargets() []*tool.Registry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.bundle != nil {
+		return m.bundle.MCPWriteTargets()
+	}
+	if m.reg != nil {
+		return []*tool.Registry{m.reg}
+	}
+	return nil
 }
 
 // serverNames lists the live server names (nil when no host is connected).

--- a/internal/control/mcp_bundle_test.go
+++ b/internal/control/mcp_bundle_test.go
@@ -1,0 +1,285 @@
+package control
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/plugin"
+	"reasonix/internal/tool"
+)
+
+// mockMCPHTTPServer serves a minimal MCP HTTP surface with one tool.
+func mockMCPHTTPServer(t *testing.T, toolName string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if len(req.ID) == 0 || string(req.ID) == "null" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2025-03-26",
+				"serverInfo":      map[string]any{"name": "mock", "version": "1"},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name":        toolName,
+				"description": "mock tool",
+				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"q": map[string]any{"type": "string"}}},
+			}}}
+		case "tools/call":
+			result = map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}
+		default:
+			result = map[string]any{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+	}))
+}
+
+func testBundleSurfaces() (legacy, exec, classic, hash *tool.Registry, bundle *agent.RegistryBundle) {
+	legacy = tool.NewRegistry()
+	legacy.Add(&resumeSurfaceTool{name: "read_file"})
+	legacy.Add(&resumeSurfaceTool{name: "bash"})
+
+	exec = tool.NewRegistry()
+	exec.Add(&resumeSurfaceTool{name: "read_file"})
+	exec.Add(&resumeSurfaceTool{name: "bash"})
+	exec.Add(&resumeSurfaceTool{name: "grep"})
+	exec.Add(&resumeSurfaceTool{name: "use_capability"})
+	exec.Add(&resumeSurfaceTool{name: "search_capabilities"})
+	exec.Add(&resumeSurfaceTool{name: "hashline_read"})
+
+	classic = tool.NewRegistry()
+	classic.Add(&resumeSurfaceTool{name: "read_file"})
+	classic.Add(&resumeSurfaceTool{name: "bash"})
+	classic.Add(&resumeSurfaceTool{name: "use_capability"})
+	classic.Add(&resumeSurfaceTool{name: "search_capabilities"})
+
+	hash = tool.NewRegistry()
+	hash.Add(&resumeSurfaceTool{name: "bash"})
+	hash.Add(&resumeSurfaceTool{name: "hashline_read"})
+	hash.Add(&resumeSurfaceTool{name: "use_capability"})
+	hash.Add(&resumeSurfaceTool{name: "search_capabilities"})
+
+	bundle = &agent.RegistryBundle{
+		Legacy:             legacy,
+		Execution:          exec,
+		CapabilityClassic:  classic,
+		CapabilityHashline: hash,
+	}
+	return
+}
+
+func TestV2ConnectMCPDoesNotPolluteCapabilityProviderSchema(t *testing.T) {
+	server := mockMCPHTTPServer(t, "search")
+	defer server.Close()
+
+	legacy, exec, classic, hash, bundle := testBundleSurfaces()
+	host := plugin.NewHost()
+	defer host.Close()
+
+	execAgent := agent.New(&resumeFakeProv{}, classic, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = execAgent.SetRuntimeContract(agent.DefaultRuntimeContract())
+	execAgent.SetRegistryBundle(bundle)
+	ctrl := New(Options{
+		Host:           host,
+		Registry:       classic,
+		RegistryBundle: bundle,
+		Executor:       execAgent,
+		Runner:         execAgent,
+	})
+
+	beforeClassic := classic.Schemas()
+	beforeHash := hash.Schemas()
+
+	entry := config.PluginEntry{Name: "mocksvc", Type: "http", URL: server.URL}
+	if _, err := ctrl.ConnectMCPServer(entry); err != nil {
+		t.Fatalf("ConnectMCPServer: %v", err)
+	}
+	mcpName := "mcp__mocksvc__search"
+	if _, ok := classic.Get(mcpName); ok {
+		t.Fatalf("capability-classic polluted with %s; tools=%v", mcpName, classic.Names())
+	}
+	if _, ok := hash.Get(mcpName); ok {
+		t.Fatalf("capability-hashline polluted with %s", mcpName)
+	}
+	if _, ok := exec.Get(mcpName); !ok {
+		t.Fatalf("execution missing %s; tools=%v", mcpName, exec.Names())
+	}
+	if _, ok := legacy.Get(mcpName); !ok {
+		t.Fatalf("legacy mirror missing %s", mcpName)
+	}
+	if after := classic.Schemas(); !reflect.DeepEqual(beforeClassic, after) {
+		t.Fatalf("classic provider schema/order changed: before=%v after=%v", beforeClassic, after)
+	}
+	if after := hash.Schemas(); !reflect.DeepEqual(beforeHash, after) {
+		t.Fatalf("hashline provider schema/order changed: before=%v after=%v", beforeHash, after)
+	}
+}
+
+func TestMCPConnectSurvivesLegacyToV2Resume(t *testing.T) {
+	server := mockMCPHTTPServer(t, "ping")
+	defer server.Close()
+
+	legacy, exec, classic, _, bundle := testBundleSurfaces()
+	host := plugin.NewHost()
+	defer host.Close()
+
+	execAgent := agent.New(&resumeFakeProv{}, legacy, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = execAgent.SetRuntimeContract(agent.LegacyDefaultRuntimeContract())
+	execAgent.SetRegistryBundle(bundle)
+	ctrl := New(Options{Host: host, Registry: legacy, RegistryBundle: bundle, Executor: execAgent, Runner: execAgent})
+
+	entry := config.PluginEntry{Name: "svc", Type: "http", URL: server.URL}
+	if _, err := ctrl.ConnectMCPServer(entry); err != nil {
+		t.Fatalf("ConnectMCPServer: %v", err)
+	}
+	mcpName := "mcp__svc__ping"
+	if _, ok := legacy.Get(mcpName); !ok {
+		t.Fatal("legacy missing MCP after connect")
+	}
+
+	v2 := agent.DefaultRuntimeContract()
+	if err := execAgent.ApplyRuntimeContract(v2, bundle); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := classic.Get(mcpName); ok {
+		t.Fatal("v2 classic surface must not gain MCP tools on resume")
+	}
+	if _, ok := exec.Get(mcpName); !ok {
+		t.Fatal("execution lost MCP tools after resume to v2")
+	}
+	if !ctrl.DisconnectMCPServer("svc") {
+		t.Fatal("DisconnectMCPServer returned false")
+	}
+	if _, ok := exec.Get(mcpName); ok {
+		t.Fatal("execution still has MCP after disconnect")
+	}
+	if _, ok := legacy.Get(mcpName); ok {
+		t.Fatal("legacy still has MCP after disconnect")
+	}
+}
+
+func TestMCPConnectSurvivesV2ToLegacyResume(t *testing.T) {
+	server := mockMCPHTTPServer(t, "echo")
+	defer server.Close()
+
+	legacy, exec, classic, _, bundle := testBundleSurfaces()
+	host := plugin.NewHost()
+	defer host.Close()
+
+	execAgent := agent.New(&resumeFakeProv{}, classic, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = execAgent.SetRuntimeContract(agent.DefaultRuntimeContract())
+	execAgent.SetRegistryBundle(bundle)
+	ctrl := New(Options{Host: host, Registry: classic, RegistryBundle: bundle, Executor: execAgent, Runner: execAgent})
+
+	entry := config.PluginEntry{Name: "echo", Type: "http", URL: server.URL}
+	if _, err := ctrl.ConnectMCPServer(entry); err != nil {
+		t.Fatalf("ConnectMCPServer: %v", err)
+	}
+	mcpName := "mcp__echo__echo"
+	if _, ok := classic.Get(mcpName); ok {
+		t.Fatal("v2 provider polluted on connect")
+	}
+	if _, ok := exec.Get(mcpName); !ok {
+		t.Fatal("execution missing MCP after connect")
+	}
+	if _, ok := legacy.Get(mcpName); !ok {
+		t.Fatal("legacy missing MCP after connect")
+	}
+
+	if err := execAgent.ApplyRuntimeContract(agent.LegacyDefaultRuntimeContract(), bundle); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := legacy.Get(mcpName); !ok {
+		t.Fatal("legacy lost MCP after resume from v2")
+	}
+	// Disconnect still clears both MCP write targets after surface switch.
+	if !ctrl.DisconnectMCPServer("echo") {
+		t.Fatal("disconnect failed")
+	}
+	if _, ok := exec.Get(mcpName); ok {
+		t.Fatal("execution still has tool after disconnect post-resume")
+	}
+	if _, ok := legacy.Get(mcpName); ok {
+		t.Fatal("legacy still has tool after disconnect post-resume")
+	}
+}
+
+func TestMCPSuspendBlocksLateAdd(t *testing.T) {
+	legacy, exec, classic, _, bundle := testBundleSurfaces()
+	host := plugin.NewHost()
+	defer host.Close()
+	ctrl := New(Options{Host: host, Registry: classic, RegistryBundle: bundle})
+
+	server := mockMCPHTTPServer(t, "t")
+	defer server.Close()
+	entry := config.PluginEntry{Name: "late", Type: "http", URL: server.URL}
+	if _, err := ctrl.ConnectMCPServer(entry); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	mcpName := "mcp__late__t"
+	if _, ok := exec.Get(mcpName); !ok {
+		t.Fatal("expected tool after connect")
+	}
+	if !ctrl.UnregisterMCPServerTools("late") {
+		t.Fatal("UnregisterMCPServerTools returned false")
+	}
+	if _, ok := exec.Get(mcpName); ok {
+		t.Fatal("tool still present after suspend")
+	}
+	if _, ok := legacy.Get(mcpName); ok {
+		t.Fatal("legacy tool still present after suspend")
+	}
+	// Late Add with suspended prefix must be rejected by Registry.Add.
+	exec.Add(&resumeSurfaceTool{name: mcpName})
+	if _, ok := exec.Get(mcpName); ok {
+		t.Fatal("suspended prefix allowed late Add to revive tool")
+	}
+	legacy.Add(&resumeSurfaceTool{name: mcpName})
+	if _, ok := legacy.Get(mcpName); ok {
+		t.Fatal("suspended prefix allowed late Add on legacy")
+	}
+	// Capability surface must never have gained the tool.
+	if _, ok := classic.Get(mcpName); ok {
+		t.Fatal("classic surface had MCP tool")
+	}
+}
+
+func TestDynamicBuiltinRegistrationDoesNotPolluteCapabilityProviderSchema(t *testing.T) {
+	legacy, exec, classic, hash, bundle := testBundleSurfaces()
+	ctrl := New(Options{Registry: classic, RegistryBundle: bundle})
+
+	beforeClassic := classic.Schemas()
+	beforeHash := hash.Schemas()
+	ctrl.mcp.registerTool(&resumeSurfaceTool{name: "slash_command"})
+
+	for label, reg := range map[string]*tool.Registry{"execution": exec, "legacy": legacy} {
+		if _, ok := reg.Get("slash_command"); !ok {
+			t.Fatalf("%s missing dynamic built-in", label)
+		}
+	}
+	if after := classic.Schemas(); !reflect.DeepEqual(beforeClassic, after) {
+		t.Fatalf("classic provider schema/order changed: before=%v after=%v", beforeClassic, after)
+	}
+	if after := hash.Schemas(); !reflect.DeepEqual(beforeHash, after) {
+		t.Fatalf("hashline provider schema/order changed: before=%v after=%v", beforeHash, after)
+	}
+}

--- a/internal/control/resume_contract_test.go
+++ b/internal/control/resume_contract_test.go
@@ -1,0 +1,183 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestResumeAppliesSavedRuntimeContract(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sess.jsonl")
+
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := sess.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	hl := agent.DefaultRuntimeContract()
+	hl.EditProtocol = agent.EditProtocolHashline
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		ID:              agent.BranchID(path),
+		RuntimeContract: hl.Clone(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyReg := tool.NewRegistry()
+	legacyReg.Add(&resumeSurfaceTool{name: "read_file"})
+	classicReg := tool.NewRegistry()
+	classicReg.Add(&resumeSurfaceTool{name: "read_file"})
+	classicReg.Add(&resumeSurfaceTool{name: "use_capability"})
+	hashReg := tool.NewRegistry()
+	hashReg.Add(&resumeSurfaceTool{name: "hashline_read"})
+	hashReg.Add(&resumeSurfaceTool{name: "use_capability"})
+	execReg := tool.NewRegistry()
+	execReg.Add(&resumeSurfaceTool{name: "grep"})
+
+	bundle := &agent.RegistryBundle{
+		Legacy:             legacyReg,
+		CapabilityClassic:  classicReg,
+		CapabilityHashline: hashReg,
+		Execution:          execReg,
+	}
+
+	// Boots on classic capability surface.
+	exec := agent.New(&resumeFakeProv{}, classicReg, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = exec.SetRuntimeContract(agent.DefaultRuntimeContract())
+	exec.SetRegistryBundle(bundle)
+
+	c := New(Options{Runner: exec, Executor: exec, Sink: event.Discard})
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Resume(loaded, path)
+
+	if got := exec.RuntimeContract().EditProtocol; got != agent.EditProtocolHashline {
+		t.Fatalf("after resume edit_protocol = %s, want hashline-v1", got)
+	}
+	// Bundle surface for the applied contract must be hashline.
+	reg := bundle.ProviderRegistry(exec.RuntimeContract())
+	if _, ok := reg.Get("hashline_read"); !ok {
+		t.Fatalf("provider surface for resumed contract tools=%v, want hashline_read", reg.Names())
+	}
+	if _, ok := reg.Get("read_file"); ok {
+		t.Fatal("classic read_file must not be on hashline provider surface")
+	}
+}
+
+func TestResumeWithoutContractStaysLegacy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.jsonl")
+	// Transcript looks like session-context-v2 — must NOT be used when sidecar exists.
+	c2 := agent.DefaultRuntimeContract()
+	sess := agent.NewSession("sys")
+	sess.Add(agent.SessionContextMessage(c2, agent.SessionContextSections{Workspace: "w"}))
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := sess.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{ID: agent.BranchID(path)}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyReg := tool.NewRegistry()
+	legacyReg.Add(&resumeSurfaceTool{name: "read_file"})
+	classicReg := tool.NewRegistry()
+	classicReg.Add(&resumeSurfaceTool{name: "use_capability"})
+	bundle := &agent.RegistryBundle{
+		Legacy:            legacyReg,
+		CapabilityClassic: classicReg,
+		Execution:         legacyReg,
+	}
+	// Process defaults to capability-v2; old session must not upgrade via inference.
+	exec := agent.New(&resumeFakeProv{}, classicReg, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = exec.SetRuntimeContract(agent.DefaultRuntimeContract())
+	exec.SetRegistryBundle(bundle)
+
+	c := New(Options{Runner: exec, Executor: exec, Sink: event.Discard})
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Resume(loaded, path)
+	if got := exec.RuntimeContract(); !got.Equal(agent.LegacyDefaultRuntimeContract()) {
+		t.Fatalf("old session upgraded to %+v, want legacy (no transcript inference when sidecar exists)", got)
+	}
+}
+
+func TestResumeCorruptSidecarForcesLegacy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.jsonl")
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := sess.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	// Write unreadable/corrupt meta beside the session.
+	metaPath := agent.BranchMetaPath(path)
+	if err := os.WriteFile(metaPath, []byte("{not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyReg := tool.NewRegistry()
+	legacyReg.Add(&resumeSurfaceTool{name: "read_file"})
+	classicReg := tool.NewRegistry()
+	classicReg.Add(&resumeSurfaceTool{name: "use_capability"})
+	hashReg := tool.NewRegistry()
+	hashReg.Add(&resumeSurfaceTool{name: "hashline_read"})
+	bundle := &agent.RegistryBundle{
+		Legacy:             legacyReg,
+		CapabilityClassic:  classicReg,
+		CapabilityHashline: hashReg,
+		Execution:          classicReg,
+	}
+	exec := agent.New(&resumeFakeProv{}, classicReg, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	_ = exec.SetRuntimeContract(agent.DefaultRuntimeContract())
+	exec.SetRegistryBundle(bundle)
+
+	ctrl := New(Options{Runner: exec, Executor: exec, Sink: event.Discard})
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl.Resume(loaded, path)
+	if got := exec.RuntimeContract(); !got.Equal(agent.LegacyDefaultRuntimeContract()) {
+		t.Fatalf("corrupt sidecar applied %+v, want legacy", got)
+	}
+	// Surface must switch off the polluted v2 provider registry.
+	reg := bundle.ProviderRegistry(exec.RuntimeContract())
+	if _, ok := reg.Get("use_capability"); ok {
+		t.Fatal("legacy surface after corrupt sidecar must not expose use_capability")
+	}
+	if _, ok := reg.Get("read_file"); !ok {
+		t.Fatal("legacy surface must keep read_file")
+	}
+}
+
+type resumeSurfaceTool struct{ name string }
+
+func (f *resumeSurfaceTool) Name() string            { return f.name }
+func (f *resumeSurfaceTool) Description() string     { return f.name }
+func (f *resumeSurfaceTool) Schema() json.RawMessage { return json.RawMessage(`{}`) }
+func (f *resumeSurfaceTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "ok", nil
+}
+func (f *resumeSurfaceTool) ReadOnly() bool { return true }
+
+type resumeFakeProv struct{}
+
+func (resumeFakeProv) Name() string { return "fake" }
+func (resumeFakeProv) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk)
+	close(ch)
+	return ch, nil
+}

--- a/internal/doctor/quality.go
+++ b/internal/doctor/quality.go
@@ -195,7 +195,7 @@ func summarizeQualityTranscript(messages []provider.Message) QualityTranscript {
 
 func qualityWriterTool(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "edit_file", "multi_edit", "write_file", "move_file", "delete_range", "delete_symbol", "notebook_edit":
+	case "edit_file", "multi_edit", "write_file", "move_file", "delete_range", "delete_symbol", "notebook_edit", "hashline_edit":
 		return true
 	default:
 		return false

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -221,6 +221,14 @@ type Compaction struct {
 	Messages int    // Done: how many messages were folded into the summary
 	Summary  string // Done: the briefing the agent keeps relying on
 	Archive  string // Done: path the dropped originals were archived to ("" if none)
+	// Optional telemetry for the capability-upgrade compaction ladder.
+	Stage        string `json:"stage,omitempty"` // prefix_reuse | fitted_transcript | minimal_transcript | mechanical
+	Attempts     int    `json:"attempts,omitempty"`
+	PrefixReused bool   `json:"prefix_reused,omitempty"`
+	FailureClass string `json:"failure_class,omitempty"` // quality | context | auth | cancel | transient | empty
+	StateBytes   int    `json:"state_bytes,omitempty"`
+	BeforeTokens int    `json:"before_tokens,omitempty"`
+	AfterTokens  int    `json:"after_tokens,omitempty"`
 }
 
 // GuardianResult carries the outcome of a guardian sub-agent safety review.

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -84,8 +84,17 @@ func ToWire(e event.Event) Event {
 		w.Ask = ToWireAsk(e.Ask)
 	case event.CompactionStarted, event.CompactionDone:
 		w.Compaction = &Compaction{
-			Trigger: e.Compaction.Trigger, Messages: e.Compaction.Messages,
-			Summary: e.Compaction.Summary, Archive: e.Compaction.Archive,
+			Trigger:      e.Compaction.Trigger,
+			Messages:     e.Compaction.Messages,
+			Summary:      e.Compaction.Summary,
+			Archive:      e.Compaction.Archive,
+			Stage:        e.Compaction.Stage,
+			Attempts:     e.Compaction.Attempts,
+			PrefixReused: e.Compaction.PrefixReused,
+			FailureClass: e.Compaction.FailureClass,
+			StateBytes:   e.Compaction.StateBytes,
+			BeforeTokens: e.Compaction.BeforeTokens,
+			AfterTokens:  e.Compaction.AfterTokens,
 		}
 	case event.GuardianAssessment:
 		w.Guardian = ToWireGuardian(e.Guardian)
@@ -139,11 +148,19 @@ func ToWireMemoryCitations(in []provider.MemoryCitation) []MemoryCitation {
 }
 
 // Compaction is the JSON form of an event.Compaction.
+// Compaction mirrors event.Compaction for the wire protocol.
 type Compaction struct {
-	Trigger  string `json:"trigger,omitempty"`
-	Messages int    `json:"messages,omitempty"`
-	Summary  string `json:"summary,omitempty"`
-	Archive  string `json:"archive,omitempty"`
+	Trigger      string `json:"trigger,omitempty"`
+	Messages     int    `json:"messages,omitempty"`
+	Summary      string `json:"summary,omitempty"`
+	Archive      string `json:"archive,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Attempts     int    `json:"attempts,omitempty"`
+	PrefixReused bool   `json:"prefix_reused,omitempty"`
+	FailureClass string `json:"failure_class,omitempty"`
+	StateBytes   int    `json:"state_bytes,omitempty"`
+	BeforeTokens int    `json:"before_tokens,omitempty"`
+	AfterTokens  int    `json:"after_tokens,omitempty"`
 }
 
 // AskOption is one JSON-formatted choice in a structured ask request.

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1027,7 +1027,7 @@ func (l *Ledger) HasSuccessfulAnchorRefreshReadAfter(paths []string, after int) 
 }
 
 func anchorRefreshRead(r Receipt) bool {
-	if r.ToolName != "read_file" || !r.Read {
+	if (r.ToolName != "read_file" && r.ToolName != "hashline_read") || !r.Read {
 		return false
 	}
 	var fields map[string]json.RawMessage
@@ -2032,7 +2032,8 @@ func isReadReceipt(name string, readOnly bool) bool {
 
 func isWriterTool(name string) bool {
 	switch name {
-	case "write_file", "edit_file", "multi_edit", "move_file", "notebook_edit", "delete_range", "delete_symbol":
+	case "write_file", "edit_file", "multi_edit", "move_file", "notebook_edit", "delete_range", "delete_symbol",
+		"hashline_edit":
 		return true
 	default:
 		return false
@@ -2041,7 +2042,7 @@ func isWriterTool(name string) bool {
 
 func isReaderTool(name string) bool {
 	switch name {
-	case "read_file", "ls", "grep":
+	case "read_file", "ls", "grep", "hashline_read", "hashline_grep":
 		return true
 	default:
 		return false

--- a/internal/permission/hashline_alias_test.go
+++ b/internal/permission/hashline_alias_test.go
@@ -1,0 +1,75 @@
+package permission
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHashlinePermissionAliasesMatchClassicRules(t *testing.T) {
+	// deny edit_file must block hashline_edit (anchor ops).
+	denyEdit := New("allow", nil, nil, []string{"edit_file"})
+	if got := denyEdit.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"replace","anchor":"1:abc:def","content":"x"}}`)); got != Deny {
+		t.Fatalf("deny edit_file vs hashline_edit = %v, want Deny", got)
+	}
+	// deny hashline_edit must still block sole-write (identity set keeps original name).
+	denyHL := New("allow", nil, nil, []string{"hashline_edit"})
+	if got := denyHL.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"write","content":"whole"}}`)); got != Deny {
+		t.Fatalf("deny hashline_edit vs sole-write = %v, want Deny", got)
+	}
+	// deny write_file must block sole write via hashline_edit.
+	denyWrite := New("allow", nil, nil, []string{"write_file"})
+	if got := denyWrite.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"write","content":"whole"}}`)); got != Deny {
+		t.Fatalf("deny write_file vs hashline write = %v, want Deny", got)
+	}
+	// deny edit_file must NOT block sole-write (write semantics, not edit).
+	if got := denyEdit.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"write","content":"whole"}}`)); got != Allow {
+		t.Fatalf("deny edit_file vs sole-write = %v, want Allow (write maps to write_file only)", got)
+	}
+	// deny read_file must block hashline_read.
+	denyRead := New("allow", nil, nil, []string{"read_file"})
+	if got := denyRead.Decide("hashline_read", true, json.RawMessage(`{"path":"a.go"}`)); got != Deny {
+		t.Fatalf("deny read_file vs hashline_read = %v, want Deny", got)
+	}
+	// deny grep must block hashline_grep.
+	denyGrep := New("allow", nil, nil, []string{"grep"})
+	if got := denyGrep.Decide("hashline_grep", true, json.RawMessage(`{"pattern":"x"}`)); got != Deny {
+		t.Fatalf("deny grep vs hashline_grep = %v, want Deny", got)
+	}
+	// ask edit_file must ask for hashline_edit under mode=allow.
+	askEdit := New("allow", nil, []string{"edit_file"}, nil)
+	if got := askEdit.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"replace","anchor":"1:abc:def","content":"x"}}`)); got != Ask {
+		t.Fatalf("ask edit_file vs hashline_edit = %v, want Ask", got)
+	}
+	// allow edit_file under mode=ask covers hashline_edit.
+	allowEdit := New("ask", []string{"edit_file"}, nil, nil)
+	if got := allowEdit.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"replace","anchor":"1:abc:def","content":"x"}}`)); got != Allow {
+		t.Fatalf("allow edit_file vs hashline_edit = %v, want Allow", got)
+	}
+	// file_mutation still covers hashline_edit.
+	denyMut := New("allow", nil, nil, []string{"file_mutation"})
+	if got := denyMut.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"replace","anchor":"1:abc:def","content":"x"}}`)); got != Deny {
+		t.Fatalf("deny file_mutation vs hashline_edit = %v, want Deny", got)
+	}
+}
+
+func TestPermissionIdentity(t *testing.T) {
+	if got := PermissionIdentity("hashline_read"); got != "read_file" {
+		t.Fatalf("hashline_read → %q", got)
+	}
+	if got := PermissionIdentity("hashline_edit"); got != "edit_file" {
+		t.Fatalf("hashline_edit → %q", got)
+	}
+	if got := PermissionIdentity("hashline_grep"); got != "grep" {
+		t.Fatalf("hashline_grep → %q", got)
+	}
+	if got := PermissionIdentity("bash"); got != "bash" {
+		t.Fatalf("bash → %q", got)
+	}
+}
+
+func TestHashlineSoleWriteDenyHashlineEdit(t *testing.T) {
+	denyHL := New("allow", nil, nil, []string{"hashline_edit"})
+	if got := denyHL.Decide("hashline_edit", false, json.RawMessage(`{"path":"a.go","edits":{"op":"write","content":"whole"}}`)); got != Deny {
+		t.Fatalf("deny hashline_edit vs sole write = %v, want Deny", got)
+	}
+}

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -142,26 +142,187 @@ func New(mode string, allow, ask, deny []string) Policy {
 // is the raw JSON the model sent, from which the call's subject is extracted
 // for glob matching. Calls with multiple subjects, such as move_file's source
 // and destination paths, must be safe for every subject before the call is
-// allowed. Precedence: deny > ask > allow > fallback (Allow for readers, Mode
-// for writers). SessionAllow sits between deny and configured ask rules.
+// allowed. Precedence: deny > ask > session allow > allow > fallback (Allow for
+// readers, Mode for writers). Hashline calls are evaluated across an identity
+// set (e.g. hashline_edit + edit_file, or hashline_edit + write_file for sole
+// write) so deny=["hashline_edit"] and deny=["write_file"] both apply.
 func (p Policy) Decide(toolName string, readOnly bool, args json.RawMessage) Decision {
-	return p.DecideSubjects(toolName, readOnly, Subjects(args))
+	ids := PermissionIdentitiesForCall(toolName, args)
+	return p.DecideSubjectsAcross(ids, readOnly, Subjects(args))
 }
 
 // ExplicitlyDenies reports only configured deny-rule matches. It deliberately
 // excludes the fallback Mode so higher-priority local MCP policy can be applied
 // before the global posture.
 func (p Policy) ExplicitlyDenies(toolName string, args json.RawMessage) bool {
+	ids := PermissionIdentitiesForCall(toolName, args)
 	subjects := Subjects(args)
 	if len(subjects) == 0 {
 		subjects = []string{""}
 	}
+	for _, id := range ids {
+		for _, subject := range subjects {
+			if matchAnyExact(p.Deny, id, subject) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// PermissionIdentitiesForCall returns every policy identity that should be
+// checked for this call. Sole-write hashline_edit maps to write_file (not
+// edit_file); other hashline_edit ops map to edit_file. The original tool name
+// is always included so deny=["hashline_edit"] still matches.
+func PermissionIdentitiesForCall(toolName string, args json.RawMessage) []string {
+	toolName = strings.TrimSpace(toolName)
+	switch toolName {
+	case "hashline_read":
+		return []string{"hashline_read", "read_file"}
+	case "hashline_grep":
+		return []string{"hashline_grep", "grep"}
+	case "hashline_edit":
+		if hashlineEditIsSoleWrite(args) {
+			return []string{"hashline_edit", "write_file"}
+		}
+		return []string{"hashline_edit", "edit_file"}
+	default:
+		return []string{toolName}
+	}
+}
+
+// DecideSubjectsAcross evaluates policy across a set of tool identities and
+// subjects. Deny on any identity wins; Ask wins over Allow; explicit allow on
+// any identity allows; otherwise readOnly/Mode fallback.
+func (p Policy) DecideSubjectsAcross(ids []string, readOnly bool, subjects []string) Decision {
+	if len(ids) == 0 {
+		ids = []string{""}
+	}
+	if len(subjects) == 0 {
+		subjects = []string{""}
+	}
+	// Bash keeps its segment-aware path when bash is among identities.
+	for _, id := range ids {
+		if canonicalRuleTool(id) == "bash" {
+			out := Allow
+			for _, subject := range subjects {
+				switch p.DecideSubject(id, readOnly, subject) {
+				case Deny:
+					return Deny
+				case Ask:
+					out = Ask
+				}
+			}
+			return out
+		}
+	}
+	out := Allow
 	for _, subject := range subjects {
-		if matchAny(p.Deny, toolName, subject) {
+		switch p.decideAcrossIdentities(ids, readOnly, subject) {
+		case Deny:
+			return Deny
+		case Ask:
+			out = Ask
+		}
+	}
+	return out
+}
+
+func (p Policy) decideAcrossIdentities(ids []string, readOnly bool, subject string) Decision {
+	// deny > session allow > ask > allow > fallback — any identity can match.
+	if matchAnyAcrossExact(p.Deny, ids, subject) {
+		return Deny
+	}
+	if matchAnyAcrossExact(p.SessionAllow, ids, subject) {
+		return Allow
+	}
+	if matchAnyAcrossExact(p.Ask, ids, subject) {
+		return Ask
+	}
+	if matchAnyAcrossExact(p.Allow, ids, subject) {
+		return Allow
+	}
+	if readOnly {
+		return Allow
+	}
+	return p.Mode
+}
+
+func matchAnyAcrossExact(rules []Rule, ids []string, subject string) bool {
+	for _, id := range ids {
+		if matchAnyExact(rules, id, subject) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchAnyExact matches rules against a single tool identity without further
+// Hashline alias expansion (aliases are expanded by the caller).
+func matchAnyExact(rules []Rule, toolName, subject string) bool {
+	for _, r := range rules {
+		if !ruleToolMatchesExact(r.Tool, toolName) {
+			continue
+		}
+		if r.Subject == "" {
+			return true
+		}
+		if subject == "" {
+			continue
+		}
+		if ruleSubjectMatches(r, subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func ruleToolMatchesExact(ruleTool, toolName string) bool {
+	ruleTool = canonicalRuleTool(ruleTool)
+	toolName = strings.TrimSpace(toolName)
+	if ruleTool == toolName {
+		return true
+	}
+	return ruleTool == "file_mutation" && IsFileMutationTool(toolName)
+}
+
+func hashlineEditIsSoleWrite(args json.RawMessage) bool {
+	if len(args) == 0 {
+		return false
+	}
+	var raw struct {
+		Edits json.RawMessage `json:"edits"`
+	}
+	if err := json.Unmarshal(args, &raw); err != nil || len(raw.Edits) == 0 {
+		return false
+	}
+	// Accept array, single object, or double-encoded string — mirror hashline.ParseEdits lightly.
+	var v any
+	if err := json.Unmarshal(raw.Edits, &v); err != nil {
+		return false
+	}
+	if s, ok := v.(string); ok {
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return false
+		}
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		op, _ := t["op"].(string)
+		return strings.EqualFold(strings.TrimSpace(op), "write")
+	case []any:
+		if len(t) != 1 {
+			return false
+		}
+		m, ok := t[0].(map[string]any)
+		if !ok {
+			return false
+		}
+		op, _ := m["op"].(string)
+		return strings.EqualFold(strings.TrimSpace(op), "write")
+	default:
+		return false
+	}
 }
 
 // DecideSubject evaluates a tool call when the caller already extracted the
@@ -268,19 +429,11 @@ func (p Policy) DecideSubjects(toolName string, readOnly bool, subjects []string
 }
 
 // matchAny reports whether any rule matches the (toolName, subject) pair. A
-// subject-specific rule cannot match a call that exposes no subject.
+// subject-specific rule cannot match a call that exposes no subject. Hashline
+// tools also match their classic aliases via PermissionIdentities (no-args).
 func matchAny(rules []Rule, toolName, subject string) bool {
-	for _, r := range rules {
-		if !ruleToolMatches(r.Tool, toolName) {
-			continue
-		}
-		if r.Subject == "" {
-			return true
-		}
-		if subject == "" {
-			continue
-		}
-		if ruleSubjectMatches(r, subject) {
+	for _, id := range PermissionIdentities(toolName) {
+		if matchAnyExact(rules, id, subject) {
 			return true
 		}
 	}
@@ -712,20 +865,67 @@ func isPackageManagerRun(base string) bool {
 // IsFileMutationTool reports whether a built-in tool mutates workspace files.
 func IsFileMutationTool(toolName string) bool {
 	switch toolName {
-	case "write_file", "edit_file", "multi_edit", "move_file", "notebook_edit", "delete_range", "delete_symbol":
+	case "write_file", "edit_file", "multi_edit", "move_file", "notebook_edit", "delete_range", "delete_symbol",
+		// hashline_edit covers replace/insert (edit_file-like) and write (write_file-like).
+		"hashline_edit":
 		return true
 	default:
 		return false
 	}
 }
 
+// PermissionIdentity returns the canonical permission identity for a tool name.
+// Hashline tools map onto their classic counterparts so deny/allow/ask rules
+// written for read_file/edit_file/write_file/grep also cover Hashline.
+func PermissionIdentity(toolName string) string {
+	switch strings.TrimSpace(toolName) {
+	case "hashline_read":
+		return "read_file"
+	case "hashline_grep":
+		return "grep"
+	case "hashline_edit":
+		// Anchor edits map to edit_file; whole-file write still uses the same
+		// tool name today. file_mutation rules also cover hashline_edit via
+		// IsFileMutationTool. Precise write_file-only rules need op-aware
+		// resolution at call time (see Gate when args include op=write).
+		return "edit_file"
+	default:
+		return toolName
+	}
+}
+
+// PermissionIdentities returns all identities that should participate in rule
+// matching for toolName without call args (actual name + classic alias).
+// For arg-sensitive mapping (hashline sole-write → write_file) use
+// PermissionIdentitiesForCall.
+func PermissionIdentities(toolName string) []string {
+	toolName = strings.TrimSpace(toolName)
+	alias := PermissionIdentity(toolName)
+	if alias == toolName || alias == "" {
+		return []string{toolName}
+	}
+	return []string{toolName, alias}
+}
+
 func ruleToolMatches(ruleTool, toolName string) bool {
-	ruleTool = canonicalRuleTool(ruleTool)
-	return ruleTool == toolName || (ruleTool == "file_mutation" && IsFileMutationTool(toolName))
+	// Expand no-arg identities so config rules like edit_file cover hashline_edit.
+	for _, id := range PermissionIdentities(toolName) {
+		if ruleToolMatchesExact(ruleTool, id) {
+			return true
+		}
+	}
+	return false
 }
 
 func ruleToolCompatible(existingTool, candidateTool string) bool {
 	existingTool = canonicalRuleTool(existingTool)
+	for _, id := range PermissionIdentities(candidateTool) {
+		id = canonicalRuleTool(id)
+		if existingTool == id ||
+			(existingTool == "file_mutation" && (id == "file_mutation" || IsFileMutationTool(id))) {
+			return true
+		}
+	}
 	candidateTool = canonicalRuleTool(candidateTool)
 	return existingTool == candidateTool ||
 		(existingTool == "file_mutation" && (candidateTool == "file_mutation" || IsFileMutationTool(candidateTool)))

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -54,7 +54,7 @@ const (
 type lazySpawn struct {
 	spec       Spec
 	host       *Host
-	reg        *tool.Registry
+	reg        lazyRegistry
 	ctx        context.Context // session-scoped — outlives any single turn
 	generation uint64
 
@@ -69,6 +69,15 @@ type lazySpawn struct {
 	// same names as the real tools, so reg.Add overwrites in place and no
 	// prefix removal is needed.
 	removePrefix string
+}
+
+// lazyRegistry is the minimal publication surface a lazy cache-miss handshake
+// needs. Boot supplies a runtime router so post-clone swaps reach Execution and
+// Legacy without ever mutating capability provider registries; ordinary callers
+// can keep passing *tool.Registry.
+type lazyRegistry interface {
+	Add(tool.Tool)
+	RemovePrefix(string) int
 }
 
 // kick starts the spawn if it has not yet started. Background registration calls
@@ -474,7 +483,7 @@ func destructiveHintChangedError(server, rawTool string) error {
 // real tools land after a successful spawn. sessionCtx must outlive any
 // single Execute (use the controller's PluginCtx) — a turn-scoped ctx would
 // kill the stdio child between turns.
-func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, sessionCtx context.Context, kick bool) []tool.Tool {
+func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg lazyRegistry, sessionCtx context.Context, kick bool) []tool.Tool {
 	spawnCtx, cancel := context.WithCancel(sessionCtx)
 	shared := &lazySpawn{
 		spec: spec,

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -342,6 +342,9 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		Tools:     tools,
 		Stream:    true,
 	}
+	if req.ToolChoice == provider.ToolChoiceNone {
+		r.ToolChoice = map[string]string{"type": "none"}
+	}
 	// Extended thinking is opt-in and provider-specific. Anthropic proper uses
 	// type=adaptive plus display/output_config. LongCat-style compatible gateways
 	// use the simpler enabled|disabled knob and do not accept output_config.
@@ -596,11 +599,13 @@ type cacheControl struct {
 }
 
 type anthRequest struct {
-	Model        string          `json:"model"`
-	MaxTokens    int             `json:"max_tokens"`
-	System       []textBlock     `json:"system,omitempty"`
-	Messages     []anthMessage   `json:"messages"`
-	Tools        []anthTool      `json:"tools,omitempty"`
+	Model     string        `json:"model"`
+	MaxTokens int           `json:"max_tokens"`
+	System    []textBlock   `json:"system,omitempty"`
+	Messages  []anthMessage `json:"messages"`
+	Tools     []anthTool    `json:"tools,omitempty"`
+	// ToolChoice is {"type":"none"} when summarization must not invoke tools.
+	ToolChoice   any             `json:"tool_choice,omitempty"`
 	Thinking     *thinkingConfig `json:"thinking,omitempty"`
 	OutputConfig *outputConfig   `json:"output_config,omitempty"`
 	Stream       bool            `json:"stream"`

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -541,6 +541,9 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		ReasoningEffort: c.effort,
 		ExtraBody:       c.extraBody,
 	}
+	if req.ToolChoice == provider.ToolChoiceNone {
+		out.ToolChoice = "none"
+	}
 	switch {
 	case c.deepseek:
 		// DeepSeek's CoT is controlled by `thinking` plus `reasoning_effort` for
@@ -836,9 +839,11 @@ func normaliseUsage(u *wireUsage) *provider.Usage {
 // --- OpenAI-compatible wire protocol ---
 
 type chatRequest struct {
-	Model           string         `json:"model"`
-	Messages        []chatMessage  `json:"messages"`
-	Tools           []chatTool     `json:"tools,omitempty"`
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Tools    []chatTool    `json:"tools,omitempty"`
+	// ToolChoice is "none" when summarization must not invoke tools; omitted otherwise.
+	ToolChoice      any            `json:"tool_choice,omitempty"`
 	Stream          bool           `json:"stream"`
 	StreamOptions   *streamOptions `json:"stream_options,omitempty"`
 	Temperature     *float64       `json:"temperature,omitempty"`

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -26,6 +26,27 @@ const (
 	RoleTool      Role = "tool"
 )
 
+// SyntheticReason marks a host-injected user-role message. It is persisted in
+// JSONL/event logs/forks but never sent on the provider wire. Prefer this over
+// fragile text-prefix detection; empty values fall back to legacy prefixes.
+type SyntheticReason string
+
+const (
+	SyntheticSessionContext    SyntheticReason = "session_context"
+	SyntheticCompactionSummary SyntheticReason = "compaction_summary"
+	SyntheticCompactionState   SyntheticReason = "compaction_state"
+	SyntheticPlanTransition    SyntheticReason = "plan_transition"
+	SyntheticReadinessRetry    SyntheticReason = "readiness_retry"
+	SyntheticStreamRecovery    SyntheticReason = "stream_recovery"
+	SyntheticGoalContinue      SyntheticReason = "goal_continue"
+	SyntheticGoalCompletion    SyntheticReason = "goal_completion"
+	SyntheticAutoContinue      SyntheticReason = "auto_continue"
+	SyntheticBackgroundUpdate  SyntheticReason = "background_update"
+	SyntheticCapabilityDelta   SyntheticReason = "capability_delta"
+	SyntheticSystemReminder    SyntheticReason = "system_reminder"
+	SyntheticLazinessNudge     SyntheticReason = "laziness_nudge"
+)
+
 // Message is a single conversation message.
 type Message struct {
 	Role             Role     `json:"role"`
@@ -46,6 +67,21 @@ type Message struct {
 	CreatedAt          int64            `json:"createdAt,omitempty"`       // local UI metadata; unix milliseconds; stripped before provider requests
 	Edited             bool             `json:"edited,omitempty"`          // local UI metadata; provider requests ignore it
 	Original           string           `json:"original,omitempty"`        // user prompt before inline edit
+	// SyntheticReason is host metadata only. OpenAI/Anthropic adapters must omit
+	// it from wire payloads so provider-visible bytes stay stable.
+	SyntheticReason SyntheticReason `json:"synthetic_reason,omitempty"`
+}
+
+// SyntheticUser builds a user-role host injection with a non-empty SyntheticReason.
+func SyntheticUser(reason SyntheticReason, content string) Message {
+	return Message{Role: RoleUser, Content: content, SyntheticReason: reason}
+}
+
+// IsSyntheticUser reports whether m is a host-injected user message. Non-empty
+// SyntheticReason always wins (including unknown future reasons for forward
+// compatibility). Empty reason falls through to text-prefix checks at the call site.
+func (m Message) IsSyntheticUser() bool {
+	return m.Role == RoleUser && strings.TrimSpace(string(m.SyntheticReason)) != ""
 }
 
 // MemoryCitation is local display metadata for memories that influenced an
@@ -95,12 +131,26 @@ type ToolSchema struct {
 	Parameters  json.RawMessage `json:"parameters"`
 }
 
+// ToolChoice controls whether the model may invoke tools for this request.
+// Empty keeps the provider default (tools available when present). ToolChoiceNone
+// disables tool use for summarization / prefix-reuse compaction stages.
+type ToolChoice string
+
+const (
+	ToolChoiceDefault ToolChoice = ""
+	ToolChoiceNone    ToolChoice = "none"
+)
+
 // Request is a single completion request.
 type Request struct {
 	Messages    []Message
 	Tools       []ToolSchema
 	Temperature *float64 // nil = omit; non-nil = send the value, including 0
 	MaxTokens   int
+	// ToolChoice is omitted from the wire when empty. OpenAI-compatible adapters
+	// send tool_choice:"none"; Anthropic sends {"type":"none"}. Providers that
+	// cannot safely disable tools must leave this unsupported and skip prefix_reuse.
+	ToolChoice ToolChoice
 }
 
 // TemperaturePtr wraps v in a pointer so callers that explicitly want a

--- a/internal/tool/builtin/hashline/LICENSE-Apache-2.0
+++ b/internal/tool/builtin/hashline/LICENSE-Apache-2.0
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranty or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/internal/tool/builtin/hashline/NOTICE
+++ b/internal/tool/builtin/hashline/NOTICE
@@ -1,0 +1,29 @@
+Hashline v1 for Reasonix
+========================
+
+This package contains code adapted from xAI grok-build's `grok_build_hashline`
+implementation (baseline commit c68e39f), originally under:
+
+  crates/codegen/xai-grok-tools/src/implementations/grok_build_hashline/
+
+Original work:
+  Copyright 2024–2026 xAI
+  Licensed under the Apache License, Version 2.0
+  Full license text: LICENSE-Apache-2.0 (this directory)
+
+This is a modified/adapted derivative work for Reasonix (Go port).
+
+Modifications for Reasonix:
+- Ported from Rust to Go
+- Fixed Anchor v1 constants (chunk size 8, hash length 3, search radius ±15)
+- Integrated with Reasonix path resolution, read confinement, session-data
+  write guards, file encoding (UTF-8 BOM / UTF-16 / GBK), CRLF preservation,
+  and host file overlays
+- Tools are NOT auto-registered into the classic builtin surface; constructors
+  are exported for hashline-protocol sessions only
+
+Reasonix-authored integration code in this package is dual-noted under the
+repository MIT License where it is original; algorithm and protocol material
+adapted from grok-build remains under Apache-2.0 as required by that license.
+
+Source file headers mark adapted modules with "modified/adapted from grok-build".

--- a/internal/tool/builtin/hashline/apply.go
+++ b/internal/tool/builtin/hashline/apply.go
@@ -1,0 +1,605 @@
+// Copyright 2024–2026 xAI and Reasonix contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Modified/adapted from grok-build grok_build_hashline (commit c68e39f).
+// See NOTICE and LICENSE-Apache-2.0 in this directory.
+
+// Copyright adapted from xAI grok-build (Apache-2.0), edit/apply.rs + types.rs.
+// Modified for Reasonix Hashline v1.
+
+package hashline
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Op is a single hashline edit operation.
+type Op struct {
+	// Kind: "replace" | "insert_after" | "write"
+	Kind string `json:"op"`
+
+	Anchor    string `json:"anchor,omitempty"`
+	EndAnchor string `json:"end_anchor,omitempty"`
+	Content   string `json:"content"`
+}
+
+// MaxEdits is the maximum number of operations in one batch.
+const MaxEdits = 64
+
+const (
+	snippetContext       = 3
+	maxContiguousSnippet = 80
+	recoveryContext      = 5
+)
+
+// ErrorKind classifies edit failures.
+type ErrorKind string
+
+const (
+	ErrAnchorStale      ErrorKind = "anchor_stale"
+	ErrAmbiguousAnchor  ErrorKind = "ambiguous_anchor"
+	ErrAnchorNotFound   ErrorKind = "anchor_not_found"
+	ErrOverlappingEdits ErrorKind = "overlapping_edits"
+	ErrInvalidInput     ErrorKind = "invalid_input"
+	ErrIO               ErrorKind = "io_error"
+)
+
+// EditError is a structured edit failure (no writes applied).
+type EditError struct {
+	Kind             ErrorKind
+	Message          string
+	RequestedAnchor  string
+	Current          string
+	Context          string
+	ContextStartLine int
+	ShiftedTo        int
+	ShiftedAnchor    string
+	AmbiguousCands   []int
+}
+
+func (e *EditError) Error() string {
+	if e == nil {
+		return "hashline edit error"
+	}
+	var b strings.Builder
+	b.WriteString(e.Message)
+	if e.Context != "" {
+		label := "Fresh anchors — use these to retry your edit:"
+		if e.ContextStartLine > 0 {
+			label = fmt.Sprintf("Fresh anchors around line %d — use these to retry your edit:", e.ContextStartLine)
+		}
+		b.WriteString("\n\n")
+		b.WriteString(label)
+		b.WriteByte('\n')
+		b.WriteString(e.Context)
+	}
+	if e.ShiftedAnchor != "" {
+		fmt.Fprintf(&b, "\n\nSuggested anchor: %s", e.ShiftedAnchor)
+	}
+	return b.String()
+}
+
+// ApplyResult is the pure outcome of applying edits to content.
+type ApplyResult struct {
+	// NewContent is set only on success (caller writes to disk).
+	NewContent string
+	// Snippet is a fresh-anchor window around the edit region.
+	Snippet string
+	// Warnings are medium/large range cautions.
+	Warnings []string
+	// Applied is the number of ops applied.
+	Applied int
+	// Err is set on failure (NewContent empty; zero writes).
+	Err *EditError
+}
+
+type resolvedOp struct {
+	originalIdx int
+	start       int // 0-based inclusive
+	end         int // 0-based exclusive; insert: start==end
+	newLines    []string
+}
+
+// ApplyEdits validates all anchors against the pre-edit snapshot, rejects
+// overlaps, and applies bottom-up. Any failure yields zero writes (Err set,
+// NewContent empty).
+func ApplyEdits(content string, ops []Op) ApplyResult {
+	if len(ops) == 0 {
+		return ApplyResult{Err: &EditError{Kind: ErrInvalidInput, Message: "No edit operations provided."}}
+	}
+	if len(ops) > MaxEdits {
+		return ApplyResult{Err: &EditError{
+			Kind:    ErrInvalidInput,
+			Message: fmt.Sprintf("Too many edits (%d); maximum is %d.", len(ops), MaxEdits),
+		}}
+	}
+
+	// Sole write op.
+	if len(ops) == 1 && ops[0].Kind == "write" {
+		if line := detectAnchorPrefixInContent(ops[0].Content); line > 0 {
+			return ApplyResult{Err: anchorContentError("write", ops[0].Content, line)}
+		}
+		crlf := UsesCRLF(content)
+		// Preserve write content as given, but normalize line endings to match file.
+		newContent := ops[0].Content
+		if crlf && !UsesCRLF(newContent) {
+			newContent = toCRLF(newContent)
+		}
+		snippet := FormatHashlineContent(newContent, 0, snippetContext*2)
+		return ApplyResult{
+			NewContent: newContent,
+			Snippet:    snippet,
+			Applied:    1,
+		}
+	}
+
+	lines := SplitLines(content)
+	crlf := UsesCRLF(content)
+	resolved := make([]resolvedOp, 0, len(ops))
+
+	for i, op := range ops {
+		r, err := resolveOp(op, i, lines)
+		if err != nil {
+			if len(ops) > 1 {
+				err.Message = fmt.Sprintf(
+					"Edit %d/%d (%s): %s\n\nThis batch contained %d edits. Because this anchor failed validation, none of the edits were applied. Retry all %d edits with fresh anchors, not just the failed one.",
+					i+1, len(ops), op.Kind, err.Message, len(ops), len(ops),
+				)
+			}
+			return ApplyResult{Err: err}
+		}
+		resolved = append(resolved, r)
+	}
+
+	if err := checkOverlaps(resolved); err != nil {
+		if len(ops) > 1 {
+			err.Message = fmt.Sprintf(
+				"%s\n\nThis batch contained %d edits. Because of the overlap, none were applied. Fix the overlapping ranges and retry all edits.",
+				err.Message, len(ops),
+			)
+		}
+		return ApplyResult{Err: err}
+	}
+
+	var warnings []string
+	for _, op := range resolved {
+		if w := RangeWarning(op.start, op.end); w != "" {
+			warnings = append(warnings, w)
+		}
+	}
+
+	// Bottom-up + reverse original index → preserve request order for same position.
+	sortResolvedBottomUp(resolved)
+
+	result := make([]string, len(lines))
+	copy(result, lines)
+
+	// Track edit regions in top-down order for snippets (post-shift coords).
+	var regions []editRegion
+	var cumulativeShift int
+	// Iterate reverse of bottom-up (= top-down) for region tracking.
+	for i := len(resolved) - 1; i >= 0; i-- {
+		op := resolved[i]
+		shiftedStart := op.start + cumulativeShift
+		inserted := len(op.newLines)
+		regions = append(regions, editRegion{shiftedStart, shiftedStart + inserted})
+		cumulativeShift += inserted - (op.end - op.start)
+	}
+
+	for _, op := range resolved {
+		// splice op.start..op.end with op.newLines
+		tail := append([]string{}, result[op.end:]...)
+		result = append(result[:op.start], op.newLines...)
+		result = append(result, tail...)
+	}
+
+	newContent := JoinLines(result, crlf)
+	// Recompute total lines via SplitLines for consistency.
+	totalNew := len(SplitLines(newContent))
+	snippet := buildSnippet(newContent, regions, totalNew)
+
+	return ApplyResult{
+		NewContent: newContent,
+		Snippet:    snippet,
+		Warnings:   warnings,
+		Applied:    len(ops),
+	}
+}
+
+func sortResolvedBottomUp(ops []resolvedOp) {
+	// Sort by start descending, then originalIdx descending.
+	for i := 0; i < len(ops); i++ {
+		for j := i + 1; j < len(ops); j++ {
+			if ops[j].start > ops[i].start ||
+				(ops[j].start == ops[i].start && ops[j].originalIdx > ops[i].originalIdx) {
+				ops[i], ops[j] = ops[j], ops[i]
+			}
+		}
+	}
+}
+
+func resolveOp(op Op, originalIdx int, lines []string) (resolvedOp, *EditError) {
+	switch op.Kind {
+	case "replace":
+		start, err := validateAnchor(op.Anchor, lines)
+		if err != nil {
+			return resolvedOp{}, err
+		}
+		end := start + 1
+		if op.EndAnchor != "" {
+			e, err := validateAnchor(op.EndAnchor, lines)
+			if err != nil {
+				return resolvedOp{}, err
+			}
+			if e < start {
+				return resolvedOp{}, &EditError{
+					Kind:            ErrInvalidInput,
+					Message:         fmt.Sprintf("end_anchor line %d is before start anchor line %d.", e+1, start+1),
+					RequestedAnchor: op.EndAnchor,
+				}
+			}
+			end = e + 1
+		}
+		if line := detectAnchorPrefixInContent(op.Content); line > 0 {
+			return resolvedOp{}, anchorContentError("replace", op.Content, line)
+		}
+		var newLines []string
+		if op.Content != "" {
+			newLines = contentToLines(op.Content)
+		}
+		return resolvedOp{originalIdx: originalIdx, start: start, end: end, newLines: newLines}, nil
+
+	case "insert_after":
+		var insertAt int
+		switch op.Anchor {
+		case "0:":
+			insertAt = 0
+		case "EOF":
+			// Insert before synthetic trailing empty line when file ends with '\n'.
+			n := len(lines)
+			if n > 1 && lines[n-1] == "" {
+				insertAt = n - 1
+			} else {
+				insertAt = n
+			}
+		default:
+			line, err := validateAnchor(op.Anchor, lines)
+			if err != nil {
+				return resolvedOp{}, err
+			}
+			insertAt = line + 1
+		}
+		if line := detectAnchorPrefixInContent(op.Content); line > 0 {
+			return resolvedOp{}, anchorContentError("insert_after", op.Content, line)
+		}
+		var newLines []string
+		if op.Content == "" {
+			newLines = []string{""} // blank line
+		} else {
+			newLines = contentToLines(op.Content)
+		}
+		return resolvedOp{originalIdx: originalIdx, start: insertAt, end: insertAt, newLines: newLines}, nil
+
+	case "write":
+		return resolvedOp{}, &EditError{
+			Kind: ErrInvalidInput,
+			Message: "Write op must be the only operation in a batch. " +
+				"Either use write alone (to replace the entire file) or use replace/insert_after ops without write.",
+		}
+	default:
+		return resolvedOp{}, &EditError{
+			Kind:    ErrInvalidInput,
+			Message: fmt.Sprintf("Unknown op %q; expected replace, insert_after, or write.", op.Kind),
+		}
+	}
+}
+
+// contentToLines splits model content the same way Rust str::lines does
+// (no synthetic trailing empty for a final '\n').
+func contentToLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	// Normalize CRLF in model payload to LF for splitting.
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	parts := strings.Split(content, "\n")
+	// Drop trailing empty if content ended with newline (str::lines behavior).
+	if strings.HasSuffix(content, "\n") && len(parts) > 0 {
+		parts = parts[:len(parts)-1]
+	}
+	return parts
+}
+
+func toCRLF(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\n", "\r\n")
+}
+
+func validateAnchor(anchorStr string, lines []string) (int, *EditError) {
+	// Strip arrow-copied content.
+	s := anchorStr
+	if i := strings.Index(s, "\u2192"); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, "->"); i >= 0 {
+		s = s[:i]
+	}
+
+	parsed, ok := ParseAnchor(s)
+	if !ok {
+		// Recovery: hash-only suffix like "ab:cd" when unique.
+		if recovered, ok := recoverBySuffix(s, lines); ok {
+			parsed = recovered
+		} else {
+			return 0, &EditError{
+				Kind:            ErrInvalidInput,
+				Message:         fmt.Sprintf("Malformed anchor: %q. Expected format: \"LINE:HASH1:HASH2\" (e.g. \"22:abc:rst\").", anchorStr),
+				RequestedAnchor: anchorStr,
+			}
+		}
+	}
+
+	switch Validate(parsed, lines) {
+	case Valid:
+		return parsed.Line - 1, nil
+	case OutOfRange:
+		return 0, &EditError{
+			Kind:            ErrAnchorNotFound,
+			Message:         fmt.Sprintf("Line %d is out of range (file has %d lines).", parsed.Line, len(lines)),
+			RequestedAnchor: anchorStr,
+		}
+	default: // Stale
+		return 0, staleError(parsed, lines, anchorStr)
+	}
+}
+
+func recoverBySuffix(suffix string, lines []string) (ParsedAnchor, bool) {
+	anchors := GenerateAnchors(lines)
+	var match *Anchor
+	for i := range anchors {
+		a := &anchors[i]
+		if a.Suffix() == suffix {
+			if match != nil {
+				return ParsedAnchor{}, false // ambiguous
+			}
+			match = a
+		}
+	}
+	if match == nil {
+		return ParsedAnchor{}, false
+	}
+	return ParsedAnchor{Line: match.Line, Local: match.Local, Context: match.Context}, true
+}
+
+func staleError(parsed ParsedAnchor, lines []string, requested string) *EditError {
+	shift := FindShifted(parsed, lines, SearchRadius)
+	anchors := GenerateAnchors(lines)
+
+	ctxStart := parsed.Line - 1 - recoveryContext
+	if ctxStart < 0 {
+		ctxStart = 0
+	}
+	ctxEnd := parsed.Line + recoveryContext
+	if ctxEnd > len(lines) {
+		ctxEnd = len(lines)
+	}
+	var ctxParts []string
+	for i := ctxStart; i < ctxEnd; i++ {
+		ctxParts = append(ctxParts, FormatAnchoredLine(anchors[i], lines[i]))
+	}
+	context := strings.Join(ctxParts, "\n")
+
+	var current string
+	idx := parsed.Line - 1
+	if idx >= 0 && idx < len(lines) {
+		current = FormatAnchoredLine(anchors[idx], lines[idx])
+	}
+
+	err := &EditError{
+		Kind:             ErrAnchorStale,
+		RequestedAnchor:  requested,
+		Current:          current,
+		Context:          context,
+		ContextStartLine: ctxStart + 1,
+	}
+
+	switch shift.Kind {
+	case "found":
+		fresh := anchors[shift.NewLine-1].Render()
+		err.ShiftedTo = shift.NewLine
+		err.ShiftedAnchor = fresh
+		err.Message = fmt.Sprintf(
+			"Anchor stale at line %d. Content appears to have shifted to line %d. Retry with anchor %q.",
+			parsed.Line, shift.NewLine, fresh,
+		)
+	case "ambiguous":
+		err.Kind = ErrAmbiguousAnchor
+		err.AmbiguousCands = shift.Candidates
+		err.Message = fmt.Sprintf(
+			"Anchor stale at line %d. Multiple candidates at lines %v. Use the fresh anchors from the context below to retry your edit.",
+			parsed.Line, shift.Candidates,
+		)
+	default:
+		err.Message = fmt.Sprintf(
+			"Anchor stale at line %d. Use the fresh anchors from the context below to retry your edit.",
+			parsed.Line,
+		)
+	}
+	return err
+}
+
+func checkOverlaps(ops []resolvedOp) *EditError {
+	type rng struct{ start, end, idx int }
+	var ranges []rng
+	for _, op := range ops {
+		if op.start != op.end {
+			ranges = append(ranges, rng{op.start, op.end, op.originalIdx})
+		}
+	}
+	// sort ranges by start
+	for i := 0; i < len(ranges); i++ {
+		for j := i + 1; j < len(ranges); j++ {
+			if ranges[j].start < ranges[i].start {
+				ranges[i], ranges[j] = ranges[j], ranges[i]
+			}
+		}
+	}
+	for i := 0; i+1 < len(ranges); i++ {
+		if ranges[i].end > ranges[i+1].start {
+			return overlapError(ranges[i].start, ranges[i].end, ranges[i].idx, ranges[i+1].start, ranges[i+1].end, ranges[i+1].idx)
+		}
+	}
+	// Insertion inside a replace span.
+	for _, op := range ops {
+		if op.start != op.end {
+			continue
+		}
+		insertAt := op.start
+		for _, r := range ranges {
+			if r.start <= insertAt && insertAt < r.end {
+				return overlapError(r.start, r.end, r.idx, insertAt, insertAt, op.originalIdx)
+			}
+		}
+	}
+	return nil
+}
+
+func overlapError(aStart, aEnd, aIdx, bStart, bEnd, bIdx int) *EditError {
+	aDesc := formatEditDesc(aStart, aEnd, aIdx)
+	bDesc := formatEditDesc(bStart, bEnd, bIdx)
+	return &EditError{
+		Kind:    ErrOverlappingEdits,
+		Message: fmt.Sprintf("Overlapping edits: %s and %s.", aDesc, bDesc),
+	}
+}
+
+func formatEditDesc(start, end, idx int) string {
+	if start == end {
+		return fmt.Sprintf("edit #%d (insertion at line %d)", idx+1, start+1)
+	}
+	return fmt.Sprintf("edit #%d (lines %d-%d)", idx+1, start+1, end)
+}
+
+type editRegion struct{ start, end int }
+
+func buildSnippet(newContent string, regions []editRegion, totalNew int) string {
+	if len(regions) == 0 {
+		return ""
+	}
+	// Sort regions top-down.
+	for i := 0; i < len(regions); i++ {
+		for j := i + 1; j < len(regions); j++ {
+			if regions[j].start < regions[i].start {
+				regions[i], regions[j] = regions[j], regions[i]
+			}
+		}
+	}
+	globalStart := regions[0].start - snippetContext
+	if globalStart < 0 {
+		globalStart = 0
+	}
+	globalEnd := regions[len(regions)-1].end + snippetContext
+	if globalEnd > totalNew {
+		globalEnd = totalNew
+	}
+	if globalEnd-globalStart <= maxContiguousSnippet {
+		return FormatHashlineContent(newContent, globalStart, globalEnd-globalStart)
+	}
+
+	// Merge overlapping/adjacent regions with context.
+	var merged []editRegion
+	for _, r := range regions {
+		cs := r.start - snippetContext
+		if cs < 0 {
+			cs = 0
+		}
+		ce := r.end + snippetContext
+		if ce > totalNew {
+			ce = totalNew
+		}
+		if len(merged) > 0 && cs <= merged[len(merged)-1].end {
+			if ce > merged[len(merged)-1].end {
+				merged[len(merged)-1].end = ce
+			}
+			continue
+		}
+		merged = append(merged, editRegion{cs, ce})
+	}
+
+	var parts []string
+	prevEnd := 0
+	for i, m := range merged {
+		if i > 0 {
+			gap := m.start - prevEnd
+			if gap < 0 {
+				gap = 0
+			}
+			parts = append(parts, fmt.Sprintf("... %d lines not shown ...", gap))
+		} else if m.start > 0 {
+			parts = append(parts, fmt.Sprintf("... %d lines not shown ...", m.start))
+		}
+		parts = append(parts, FormatHashlineContent(newContent, m.start, m.end-m.start))
+		prevEnd = m.end
+	}
+	if prevEnd < totalNew {
+		parts = append(parts, fmt.Sprintf("... %d lines not shown ...", totalNew-prevEnd))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// detectAnchorPrefixInContent rejects replacements that include hashline
+// "LINE:HASH→" prefixes copied from read output.
+func detectAnchorPrefixInContent(content string) int {
+	for idx, line := range strings.Split(content, "\n") {
+		s := strings.TrimLeft(line, " \t")
+		if before, _, ok := strings.Cut(s, "\u2192"); ok && looksLikeAnchorPrefix(before) {
+			return idx + 1
+		}
+		if before, _, ok := strings.Cut(s, "->"); ok && looksLikeAnchorPrefix(before) {
+			return idx + 1
+		}
+	}
+	return 0
+}
+
+func looksLikeAnchorPrefix(before string) bool {
+	if len(before) == 0 || len(before) > 25 {
+		return false
+	}
+	if !strings.Contains(before, ":") || strings.Contains(before, " ") {
+		return false
+	}
+	return true
+}
+
+func anchorContentError(opLabel, content string, lineNum int) *EditError {
+	lines := strings.Split(content, "\n")
+	offending := ""
+	if lineNum-1 >= 0 && lineNum-1 < len(lines) {
+		offending = lines[lineNum-1]
+	}
+	ctxStart := lineNum - 2
+	if ctxStart < 0 {
+		ctxStart = 0
+	}
+	ctxEnd := lineNum + 1
+	if ctxEnd > len(lines) {
+		ctxEnd = len(lines)
+	}
+	var ctx []string
+	for i := ctxStart; i < ctxEnd; i++ {
+		marker := "   "
+		if i+1 == lineNum {
+			marker = ">>>"
+		}
+		ctx = append(ctx, fmt.Sprintf("%s line %d: %s", marker, i+1, lines[i]))
+	}
+	return &EditError{
+		Kind:             ErrInvalidInput,
+		Message:          fmt.Sprintf("%s content contains anchor prefixes (e.g. \"22:abc:rst\u2192\") copied from hashline_read output. The first offending line is line %d. Strip the anchor prefixes and the \u2192 separator from every line, keeping only the actual file content, then retry.", opLabel, lineNum),
+		Current:          offending,
+		Context:          strings.Join(ctx, "\n"),
+		ContextStartLine: ctxStart + 1,
+	}
+}

--- a/internal/tool/builtin/hashline/apply_test.go
+++ b/internal/tool/builtin/hashline/apply_test.go
@@ -1,0 +1,367 @@
+package hashline
+
+import (
+	"strings"
+	"testing"
+)
+
+const sample = "fn main() {\n    let x = 1;\n    let y = 2;\n    println!(\"{x} {y}\");\n}\n"
+
+func anchorsFor(content string) []string {
+	lines := SplitLines(content)
+	as := GenerateAnchors(lines)
+	out := make([]string, len(as))
+	for i, a := range as {
+		out[i] = a.Render()
+	}
+	return out
+}
+
+func TestApplyPointReplace(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{{Kind: "replace", Anchor: a[1], Content: "    let x = 999;"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if !strings.Contains(r.NewContent, "999") || strings.Contains(r.NewContent, "let x = 1;") {
+		t.Fatalf("content: %q", r.NewContent)
+	}
+	if !strings.Contains(r.Snippet, "\u2192") {
+		t.Fatal("snippet missing anchors")
+	}
+	// Fresh anchors must re-validate.
+	lines := SplitLines(r.NewContent)
+	fresh := GenerateAnchors(lines)
+	for _, fa := range fresh {
+		if Validate(ParsedAnchor{Line: fa.Line, Local: fa.Local, Context: fa.Context}, lines) != Valid {
+			t.Fatal("fresh anchors must validate")
+		}
+	}
+}
+
+func TestApplyDelete(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{{Kind: "replace", Anchor: a[1], Content: ""}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if strings.Contains(r.NewContent, "let x = 1;") {
+		t.Fatal("delete failed")
+	}
+}
+
+func TestApplyRangeReplace(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{{Kind: "replace", Anchor: a[1], EndAnchor: a[2], Content: "    let z = 42;"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if !strings.Contains(r.NewContent, "42") {
+		t.Fatal(r.NewContent)
+	}
+}
+
+func TestApplyBOFAndEOF(t *testing.T) {
+	r := ApplyEdits(sample, []Op{{Kind: "insert_after", Anchor: "0:", Content: "// header"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if !strings.HasPrefix(strings.TrimPrefix(r.NewContent, "\ufeff"), "// header\n") {
+		t.Fatalf("bof: %q", r.NewContent)
+	}
+
+	r2 := ApplyEdits("line1\nline2\n", []Op{{Kind: "insert_after", Anchor: "EOF", Content: "line3"}})
+	if r2.Err != nil {
+		t.Fatal(r2.Err)
+	}
+	if !strings.Contains(r2.NewContent, "line2\nline3") {
+		t.Fatalf("eof trailing nl: %q", r2.NewContent)
+	}
+
+	r3 := ApplyEdits("line1\nline2", []Op{{Kind: "insert_after", Anchor: "EOF", Content: "line3"}})
+	if r3.Err != nil {
+		t.Fatal(r3.Err)
+	}
+	if !strings.HasSuffix(r3.NewContent, "line3") {
+		t.Fatalf("eof no nl: %q", r3.NewContent)
+	}
+}
+
+func TestApplyWrite(t *testing.T) {
+	r := ApplyEdits(sample, []Op{{Kind: "write", Content: "new\n"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if r.NewContent != "new\n" {
+		t.Fatalf("%q", r.NewContent)
+	}
+}
+
+func TestApplyWriteMustBeSole(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "write", Content: "x"},
+		{Kind: "replace", Anchor: a[0], Content: "y"},
+	})
+	if r.Err == nil || r.Err.Kind != ErrInvalidInput {
+		t.Fatalf("want invalid, got %+v", r.Err)
+	}
+	if r.NewContent != "" {
+		t.Fatal("partial write")
+	}
+}
+
+func TestApplyStaleNoWrite(t *testing.T) {
+	r := ApplyEdits(sample, []Op{{Kind: "replace", Anchor: "2:zzz:zzz", Content: "nope"}})
+	if r.Err == nil || r.Err.Kind != ErrAnchorStale {
+		t.Fatalf("got %+v", r.Err)
+	}
+	if r.NewContent != "" {
+		t.Fatal("must not produce content on failure")
+	}
+	if r.Err.Context == "" || r.Err.Current == "" {
+		t.Fatal("stale must include current+context")
+	}
+}
+
+func TestApplyOverlapRejected(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "replace", Anchor: a[1], EndAnchor: a[3], Content: "a"},
+		{Kind: "replace", Anchor: a[2], Content: "b"},
+	})
+	if r.Err == nil || r.Err.Kind != ErrOverlappingEdits {
+		t.Fatalf("got %+v", r.Err)
+	}
+	if r.NewContent != "" {
+		t.Fatal("partial write on overlap")
+	}
+}
+
+func TestApplyInsertInsideReplaceRejected(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "replace", Anchor: a[1], EndAnchor: a[3], Content: "replaced"},
+		{Kind: "insert_after", Anchor: a[2], Content: "ins"},
+	})
+	if r.Err == nil || r.Err.Kind != ErrOverlappingEdits {
+		t.Fatalf("got %+v", r.Err)
+	}
+}
+
+func TestApplyMisCopiedAnchorPrefix(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{{
+		Kind:    "replace",
+		Anchor:  a[1],
+		Content: a[1] + "\u2192    let x = 9;",
+	}})
+	if r.Err == nil || r.Err.Kind != ErrInvalidInput {
+		t.Fatalf("got %+v", r.Err)
+	}
+	if r.NewContent != "" {
+		t.Fatal("partial")
+	}
+}
+
+func TestApplySameAnchorInsertOrder(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "insert_after", Anchor: a[1], Content: "    // first"},
+		{Kind: "insert_after", Anchor: a[1], Content: "    // second"},
+	})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	fi := strings.Index(r.NewContent, "// first")
+	se := strings.Index(r.NewContent, "// second")
+	if fi < 0 || se < 0 || fi > se {
+		t.Fatalf("order: %q", r.NewContent)
+	}
+}
+
+func TestApplyBatchStaleRejectsAll(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "replace", Anchor: a[0], Content: "valid"},
+		{Kind: "replace", Anchor: "3:zzz:zzz", Content: "stale"},
+	})
+	if r.Err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(r.Err.Message, "none of the edits were applied") {
+		t.Fatal(r.Err.Message)
+	}
+	if r.NewContent != "" {
+		t.Fatal("partial batch write")
+	}
+}
+
+func TestApplyMediumLargeWarnings(t *testing.T) {
+	var lines []string
+	for i := 0; i < 30; i++ {
+		lines = append(lines, "line")
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	a := anchorsFor(content)
+	r := ApplyEdits(content, []Op{{Kind: "replace", Anchor: a[0], EndAnchor: a[9], Content: "x"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if len(r.Warnings) == 0 || !strings.Contains(r.Warnings[0], "medium") {
+		t.Fatalf("warnings: %v", r.Warnings)
+	}
+	r2 := ApplyEdits(content, []Op{{Kind: "replace", Anchor: a[0], EndAnchor: a[24], Content: "x"}})
+	if r2.Err != nil {
+		t.Fatal(r2.Err)
+	}
+	if len(r2.Warnings) == 0 || !strings.Contains(r2.Warnings[0], "large") {
+		t.Fatalf("warnings: %v", r2.Warnings)
+	}
+}
+
+func TestApplyCRLFPreserved(t *testing.T) {
+	content := "a\r\nb\r\nc\r\n"
+	a := anchorsFor(content)
+	r := ApplyEdits(content, []Op{{Kind: "replace", Anchor: a[1], Content: "B"}})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if !strings.Contains(r.NewContent, "\r\n") {
+		t.Fatalf("lost CRLF: %q", r.NewContent)
+	}
+	if strings.Contains(strings.ReplaceAll(r.NewContent, "\r\n", ""), "\n") {
+		t.Fatalf("bare LF leaked: %q", r.NewContent)
+	}
+}
+
+func TestApplyMaxEdits(t *testing.T) {
+	ops := make([]Op, MaxEdits+1)
+	for i := range ops {
+		ops[i] = Op{Kind: "insert_after", Anchor: "EOF", Content: "x"}
+	}
+	r := ApplyEdits("a\n", ops)
+	if r.Err == nil || r.Err.Kind != ErrInvalidInput {
+		t.Fatalf("got %+v", r.Err)
+	}
+}
+
+func TestApplyPropertyNoPartialWrite(t *testing.T) {
+	// Property-style: any failing batch leaves NewContent empty.
+	a := anchorsFor(sample)
+	bad := [][]Op{
+		{{Kind: "replace", Anchor: "bad", Content: "x"}},
+		{{Kind: "replace", Anchor: a[0], Content: a[0] + "\u2192x"}},
+		{{Kind: "replace", Anchor: a[1], EndAnchor: a[0], Content: "x"}},
+		{
+			{Kind: "replace", Anchor: a[1], EndAnchor: a[3], Content: "a"},
+			{Kind: "replace", Anchor: a[2], Content: "b"},
+		},
+	}
+	for i, ops := range bad {
+		r := ApplyEdits(sample, ops)
+		if r.Err == nil {
+			t.Fatalf("case %d: expected error", i)
+		}
+		if r.NewContent != "" {
+			t.Fatalf("case %d: partial write %q", i, r.NewContent)
+		}
+	}
+}
+
+func TestApplySuccessRegeneratesVerifiableAnchors(t *testing.T) {
+	a := anchorsFor(sample)
+	r := ApplyEdits(sample, []Op{
+		{Kind: "insert_after", Anchor: a[0], Content: "    // note"},
+		{Kind: "replace", Anchor: a[3], Content: "    println!(\"hi\");"},
+	})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	lines := SplitLines(r.NewContent)
+	for _, fa := range GenerateAnchors(lines) {
+		if Validate(ParsedAnchor{Line: fa.Line, Local: fa.Local, Context: fa.Context}, lines) != Valid {
+			t.Fatal("unverifiable anchor after success")
+		}
+	}
+	// Snippet anchors should parse and match generated.
+	for _, line := range strings.Split(r.Snippet, "\n") {
+		if strings.HasPrefix(line, "...") || line == "" {
+			continue
+		}
+		before, _, ok := strings.Cut(line, "\u2192")
+		if !ok {
+			continue
+		}
+		p, ok := ParseAnchor(before)
+		if !ok {
+			t.Fatalf("snippet anchor %q", before)
+		}
+		if Validate(p, lines) != Valid {
+			t.Fatalf("snippet anchor stale: %s", before)
+		}
+	}
+}
+
+func TestParseEditsDoubleJSON(t *testing.T) {
+	ops, err := ParseEdits([]byte(`[{"op":"replace","anchor":"1:ab:cd","content":"x"}]`))
+	if err != nil || len(ops) != 1 {
+		t.Fatalf("%v %v", ops, err)
+	}
+	ops, err = ParseEdits([]byte(`"[{\"op\":\"replace\",\"anchor\":\"1:ab:cd\",\"content\":\"x\"}]"`))
+	if err != nil || len(ops) != 1 {
+		t.Fatalf("double json: %v %v", ops, err)
+	}
+	ops, err = ParseEdits([]byte(`{"op":"insert_after","anchor":"EOF","content":"z"}`))
+	if err != nil || len(ops) != 1 || ops[0].Kind != "insert_after" {
+		t.Fatalf("object: %v %v", ops, err)
+	}
+}
+
+func TestRangePolicy(t *testing.T) {
+	if RangeWarning(0, 3) != "" {
+		t.Fatal("small")
+	}
+	if !strings.Contains(RangeWarning(0, 10), "medium") {
+		t.Fatal("medium")
+	}
+	if !strings.Contains(RangeWarning(0, 30), "large") {
+		t.Fatal("large")
+	}
+}
+
+func TestApplyScatteredSnippet(t *testing.T) {
+	var lines []string
+	for i := 0; i < 200; i++ {
+		lines = append(lines, "line_"+itoa(i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	a := anchorsFor(content)
+	r := ApplyEdits(content, []Op{
+		{Kind: "replace", Anchor: a[4], Content: "TOP"},
+		{Kind: "replace", Anchor: a[194], Content: "BOTTOM"},
+	})
+	if r.Err != nil {
+		t.Fatal(r.Err)
+	}
+	if !strings.Contains(r.Snippet, "TOP") || !strings.Contains(r.Snippet, "BOTTOM") {
+		t.Fatal(r.Snippet)
+	}
+	if !strings.Contains(r.Snippet, "lines not shown") {
+		t.Fatal("expected gap markers")
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	n := len(b)
+	for i > 0 {
+		n--
+		b[n] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[n:])
+}

--- a/internal/tool/builtin/hashline/doc.go
+++ b/internal/tool/builtin/hashline/doc.go
@@ -1,0 +1,18 @@
+// Package hashline implements Hashline v1: whitespace-normalized FNV-1a line
+// anchors and the three tools hashline_read, hashline_edit, and hashline_grep.
+//
+// Adapted from xAI grok-build (Apache-2.0), commit c68e39f, package
+// grok_build_hashline. See NOTICE in this directory.
+//
+// Tools are NOT registered via init() — classic sessions must not see them in
+// tool.BuiltinContractEntries. Boot adds them only for hashline-protocol
+// sessions via NewRead / NewEdit / NewGrep or Tools().
+//
+// Anchor v1 fixed scheme (no runtime schema parameters):
+//   - whitespace-normalized FNV-1a 32-bit line hash
+//   - lowercase letter encoding, local hash length 3
+//   - chunk fingerprint length 3, chunk size 8
+//   - display format LINE:LOCAL:CHUNK→CONTENT
+//   - shifted recovery radius ±15 lines
+//   - special anchors: "EOF", "0:" (before first line)
+package hashline

--- a/internal/tool/builtin/hashline/edit.go
+++ b/internal/tool/builtin/hashline/edit.go
@@ -1,0 +1,199 @@
+package hashline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/diff"
+	fileenc "reasonix/internal/fileutil/encoding"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+// Edit is the hashline_edit tool. Construct via NewEdit; do not init-register.
+type Edit struct {
+	workDir string
+	roots   []string
+	guard   builtin.SessionDataGuard
+	managed builtin.ManagedConfigPaths
+	overlay builtin.FileOverlay
+}
+
+// NewEdit returns a configured hashline_edit tool.
+func NewEdit(workDir string, roots []string, guard builtin.SessionDataGuard, managed builtin.ManagedConfigPaths, overlay builtin.FileOverlay) *Edit {
+	return &Edit{
+		workDir: workDir,
+		roots:   builtin.HashlineRealRoots(roots),
+		guard:   guard,
+		managed: managed,
+		overlay: overlay,
+	}
+}
+
+func (Edit) Name() string { return "hashline_edit" }
+
+func (Edit) Description() string {
+	return `Edit a file using Hashline v1 anchors from hashline_read or hashline_grep.
+
+Operations (use the "op" field):
+  "replace" — Replace one line or a range (end_anchor inclusive). Empty content deletes.
+  "insert_after" — Insert after anchor; "0:" = beginning of file; "EOF" = end of file.
+  "write" — Replace entire file (must be the sole op).
+
+Batch: pass multiple ops in "edits" (array, single object, or double-JSON string; max 64).
+All anchors validate against the same pre-edit snapshot; overlapping ranges are rejected;
+any failure applies zero writes. Success returns ±3 lines of fresh anchors (segmented if span >80 lines).
+Never copy LINE:HASH→ prefixes into content. Never auto-shift stale anchors — use suggested anchors to retry.`
+}
+
+func (Edit) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "path":{"type":"string","description":"File path"},
+  "edits":{
+    "description":"Edit ops: array, single object, or double-JSON-encoded string (max 64)",
+    "oneOf":[
+      {"type":"array","items":{"type":"object"}},
+      {"type":"object"},
+      {"type":"string"}
+    ]
+  }
+},
+"required":["path","edits"]
+}`)
+}
+
+func (Edit) ReadOnly() bool { return false }
+
+// PermissionAlias documents the classic file-mutation family this maps to.
+// permission.PermissionIdentity / Decide map hashline_edit → edit_file (and
+// sole write → write_file) so deny=["edit_file"] covers anchor edits.
+func (Edit) PermissionAlias() string { return "edit_file" }
+
+// Preview computes the change hashline_edit would make without writing.
+// Mirrors Execute's validation (anchors, overlap, sole-write) so approval cards
+// and changed-files panels see the real target path and diff.
+func (e Edit) Preview(args json.RawMessage) (diff.Change, error) {
+	var raw struct {
+		Path  string          `json:"path"`
+		Edits json.RawMessage `json:"edits"`
+	}
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return diff.Change{}, fmt.Errorf("invalid args: %w", err)
+	}
+	if raw.Path == "" {
+		return diff.Change{}, fmt.Errorf("path is required")
+	}
+	ops, err := ParseEdits(raw.Edits)
+	if err != nil {
+		return diff.Change{}, err
+	}
+	path := builtin.HashlineResolvePath(e.workDir, raw.Path)
+	// Same write boundary as Execute (roots / session guard / managed config),
+	// so approval cards never preview a path the call would refuse.
+	if err := builtin.HashlineConfinePreview(e.roots, e.guard, e.managed, path); err != nil {
+		return diff.Change{}, err
+	}
+
+	content, _, rerr := builtin.HashlineReadEncoded(path)
+	if rerr != nil {
+		if os.IsNotExist(rerr) && len(ops) == 1 && ops[0].Kind == "write" {
+			return diff.Build(path, "", ops[0].Content, diff.Create), nil
+		}
+		return diff.Change{}, fmt.Errorf("read %s: %w", path, rerr)
+	}
+	result := ApplyEdits(content, ops)
+	if result.Err != nil {
+		return diff.Change{}, result.Err
+	}
+	return diff.Build(path, content, result.NewContent, diff.Modify), nil
+}
+
+var _ tool.Previewer = Edit{}
+
+func (e Edit) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var raw struct {
+		Path  string          `json:"path"`
+		Edits json.RawMessage `json:"edits"`
+	}
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if raw.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	ops, err := ParseEdits(raw.Edits)
+	if err != nil {
+		return "", err
+	}
+
+	path := builtin.HashlineResolvePath(e.workDir, raw.Path)
+	if err := builtin.HashlineConfineWrite(ctx, e.roots, e.guard, e.managed, path); err != nil {
+		return "", err
+	}
+
+	// New-file write-only path.
+	content, enc, rerr := builtin.HashlineReadEncoded(path)
+	if rerr != nil {
+		if os.IsNotExist(rerr) && len(ops) == 1 && ops[0].Kind == "write" {
+			return e.writeNew(ctx, path, ops[0].Content)
+		}
+		return "", fmt.Errorf("read %s: %w", path, rerr)
+	}
+
+	result := ApplyEdits(content, ops)
+	if result.Err != nil {
+		return "", result.Err
+	}
+
+	if err := e.writeContent(ctx, path, result.NewContent, enc); err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "edited %s (%d op(s), scheme=%s)\n", path, result.Applied, SchemeName)
+	if len(result.Warnings) > 0 {
+		b.WriteString(strings.Join(result.Warnings, "\n"))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Fresh anchors around the edit:\n")
+	b.WriteString(result.Snippet)
+	return b.String(), nil
+}
+
+func (e Edit) writeNew(ctx context.Context, path, content string) (string, error) {
+	if line := detectAnchorPrefixInContent(content); line > 0 {
+		return "", anchorContentError("write", content, line)
+	}
+	if err := e.writeContent(ctx, path, content, fileenc.UTF8); err != nil {
+		return "", err
+	}
+	snippet := FormatHashlineContent(content, 0, snippetContext*2)
+	return fmt.Sprintf("wrote %s (1 op, scheme=%s)\nFresh anchors:\n%s", path, SchemeName, snippet), nil
+}
+
+func (e Edit) writeContent(ctx context.Context, path, content string, enc fileenc.Kind) error {
+	// Overlay for plain UTF-8 absolute paths (mirrors write_file).
+	if e.overlay != nil && filepath.IsAbs(path) && (enc == fileenc.UTF8) {
+		if ok, werr := e.overlay.WriteTextFile(ctx, path, content); ok {
+			if werr != nil {
+				return fmt.Errorf("write %s: %w", path, werr)
+			}
+			return nil
+		}
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+	if err := builtin.HashlineWriteEncoded(path, content, enc); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/tool/builtin/hashline/grep.go
+++ b/internal/tool/builtin/hashline/grep.go
@@ -1,0 +1,179 @@
+package hashline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+// Grep is the hashline_grep tool. Construct via NewGrep; do not init-register.
+type Grep struct {
+	workDir     string
+	paths       *builtin.PathResolver
+	forbidRoots []string
+	underlying  tool.Tool // classic grep, configured the same way
+}
+
+// NewGrep returns a configured hashline_grep tool.
+func NewGrep(workDir string, paths *builtin.PathResolver, spec builtin.SearchSpec, sb sandbox.Spec, forbidRoots []string) *Grep {
+	return &Grep{
+		workDir:     workDir,
+		paths:       paths,
+		forbidRoots: builtin.HashlineRealRoots(forbidRoots),
+		underlying:  builtin.NewGrepTool(workDir, paths, spec, sb, forbidRoots),
+	}
+}
+
+func (Grep) Name() string { return "hashline_grep" }
+
+func (Grep) Description() string {
+	return "Search file contents with Hashline v1 anchors on match lines " +
+		"(LINE:LOCAL:CHUNK:content for matches). Anchors can be passed to hashline_edit " +
+		"without an intermediate read. Pattern is RE2; path defaults to \".\"; " +
+		"results capped like classic grep. Stale/unreadable files drop anchors for those lines."
+}
+
+func (Grep) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"Regular expression (RE2 syntax)"},"path":{"type":"string","description":"File or directory to search (default \".\")"},"timeout_seconds":{"type":"integer","description":"Abort and return partial matches after this many seconds (default 30, max 300).","minimum":1}},"required":["pattern"]}`)
+}
+
+func (Grep) ReadOnly() bool { return true }
+
+func (Grep) SnipHint() tool.SnipHint {
+	return tool.SnipHint{Head: 80, Tail: 8, HeadChars: 10000, TailChars: 1000}
+}
+
+// PermissionAlias documents the classic tool this maps to for policy authors.
+func (Grep) PermissionAlias() string { return "grep" }
+
+func (g Grep) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if g.underlying == nil {
+		return "", fmt.Errorf("hashline_grep: not configured")
+	}
+	out, err := g.underlying.Execute(ctx, args)
+	if err != nil {
+		return "", err
+	}
+	// Inject anchors into path:line:text lines.
+	return g.injectAnchors(ctx, out), nil
+}
+
+func (g Grep) injectAnchors(ctx context.Context, out string) string {
+	if out == "" || strings.HasPrefix(out, "(no matches") {
+		return out
+	}
+	cache := map[string][]Anchor{}
+	linesSnap := map[string][]string{}
+	var b strings.Builder
+	for i, line := range strings.Split(out, "\n") {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		// Trailer lines from formatGrep.
+		if strings.HasPrefix(line, "...") || line == "" {
+			b.WriteString(line)
+			continue
+		}
+		path, lineNo, sep, rest, ok := parseGrepLine(line)
+		if !ok {
+			b.WriteString(line)
+			continue
+		}
+		// Resolve path relative to workDir when needed.
+		abs := path
+		if !filepath.IsAbs(path) {
+			abs = builtin.HashlineResolvePath(g.workDir, path)
+		}
+		if builtin.HashlineConfineRead(g.forbidRoots, abs) {
+			b.WriteString(line) // drop anchors; keep original
+			continue
+		}
+		anchors, ok := cache[abs]
+		if !ok {
+			if ctx.Err() != nil {
+				b.WriteString(line)
+				continue
+			}
+			content, err := readTextFile(abs)
+			if err != nil {
+				b.WriteString(line)
+				continue
+			}
+			ls := SplitLines(content)
+			anchors = GenerateAnchors(ls)
+			cache[abs] = anchors
+			linesSnap[abs] = ls
+		}
+		// Re-validate: if line number is out of range or content at that line
+		// no longer matches rest (stale snapshot vs grep), drop anchors.
+		if lineNo < 1 || lineNo > len(anchors) {
+			b.WriteString(line)
+			continue
+		}
+		// Soft content check: if rest is non-empty and differs from snap line
+		// after whitespace-normalization mismatch of local hash, discard.
+		snap := linesSnap[abs]
+		if lineNo <= len(snap) {
+			// Grep rest may include content as emitted; compare loosely.
+			if rest != "" && snap[lineNo-1] != rest {
+				// Still attach anchors if the line number exists — grep may
+				// have truncated, but prefer validating local hash.
+				local := EncodeHash(LineHash(snap[lineNo-1]), DefaultHashLen)
+				if local != anchors[lineNo-1].Local {
+					b.WriteString(line)
+					continue
+				}
+			}
+		}
+		a := anchors[lineNo-1]
+		// Match lines use ':' after the anchor (grep style); context would use '-'.
+		fmt.Fprintf(&b, "%s:%d:%s%s%s", path, lineNo, a.Suffix(), string(sep), rest)
+	}
+	return b.String()
+}
+
+// parseGrepLine parses "path:line:text" (or path:line-text for context).
+// Path may contain colons (Windows drive); we find the last ":digits:" pattern.
+func parseGrepLine(line string) (path string, lineNo int, sep byte, rest string, ok bool) {
+	// Scan for :digits: or :digits- from the left after first colon-ish path.
+	// Reasonix native/rg output is path:line:text with absolute or relative path.
+	// Strategy: find ":N:" where N is digits, taking the rightmost plausible
+	// match that leaves a non-empty path.
+	for i := 0; i < len(line); i++ {
+		if line[i] != ':' {
+			continue
+		}
+		j := i + 1
+		if j >= len(line) || line[j] < '0' || line[j] > '9' {
+			continue
+		}
+		for j < len(line) && line[j] >= '0' && line[j] <= '9' {
+			j++
+		}
+		if j >= len(line) {
+			continue
+		}
+		sepCand := line[j]
+		if sepCand != ':' && sepCand != '-' {
+			continue
+		}
+		// Prefer first valid path:line:text (paths rarely embed :digits:).
+		n, err := strconv.Atoi(line[i+1 : j])
+		if err != nil || n <= 0 {
+			continue
+		}
+		path = line[:i]
+		if path == "" {
+			continue
+		}
+		return path, n, sepCand, line[j+1:], true
+	}
+	return "", 0, 0, "", false
+}

--- a/internal/tool/builtin/hashline/hash.go
+++ b/internal/tool/builtin/hashline/hash.go
@@ -1,0 +1,73 @@
+// Copyright 2024–2026 xAI and Reasonix contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Modified/adapted from grok-build grok_build_hashline (commit c68e39f).
+// See NOTICE and LICENSE-Apache-2.0 in this directory.
+
+// Copyright adapted from xAI grok-build (Apache-2.0), util/hash.rs.
+// Modified for Reasonix Hashline v1.
+
+package hashline
+
+import "strings"
+
+// FNV-1a 32-bit constants.
+const (
+	fnvOffset = 2166136261
+	fnvPrime  = 16777619
+)
+
+// DefaultHashLen is the fixed Anchor v1 local/chunk hash length.
+const DefaultHashLen = 3
+
+// FNV1a32 computes the FNV-1a 32-bit hash of raw bytes.
+func FNV1a32(data []byte) uint32 {
+	h := uint32(fnvOffset)
+	for _, b := range data {
+		h ^= uint32(b)
+		h *= fnvPrime
+	}
+	return h
+}
+
+// LineHash computes a whitespace-normalized FNV-1a 32-bit fingerprint of a line.
+// Leading/trailing Unicode whitespace is trimmed (strings.TrimSpace / Rust
+// str::trim); internal ASCII whitespace runs collapse to a single ASCII space.
+func LineHash(line string) uint32 {
+	trimmed := strings.TrimSpace(line)
+	h := uint32(fnvOffset)
+	prevWS := false
+	for i := 0; i < len(trimmed); i++ {
+		b := trimmed[i]
+		if isASCIIWhitespace(b) {
+			if !prevWS {
+				h ^= uint32(' ')
+				h *= fnvPrime
+				prevWS = true
+			}
+			continue
+		}
+		h ^= uint32(b)
+		h *= fnvPrime
+		prevWS = false
+	}
+	return h
+}
+
+// EncodeHash encodes a 32-bit hash as n lowercase ASCII letters (a–z).
+// len must be in 1..=4 (Anchor v1 uses 3).
+func EncodeHash(hash uint32, length int) string {
+	if length < 1 || length > 4 {
+		length = DefaultHashLen
+	}
+	buf := make([]byte, length)
+	for i := 0; i < length; i++ {
+		buf[i] = byte((hash>>(i*8))%26) + 'a'
+	}
+	return string(buf)
+}
+
+func isASCIIWhitespace(b byte) bool {
+	// Matches Rust u8::is_ascii_whitespace: space, tab, LF, FF, CR, VT.
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f' || b == '\v'
+}

--- a/internal/tool/builtin/hashline/hash_test.go
+++ b/internal/tool/builtin/hashline/hash_test.go
@@ -1,0 +1,87 @@
+package hashline
+
+import "testing"
+
+func TestFNV1a32Empty(t *testing.T) {
+	if got := FNV1a32(nil); got != fnvOffset {
+		t.Fatalf("empty = %d, want %d", got, fnvOffset)
+	}
+	if got := FNV1a32([]byte{}); got != fnvOffset {
+		t.Fatalf("empty slice = %d, want %d", got, fnvOffset)
+	}
+}
+
+func TestFNV1a32Deterministic(t *testing.T) {
+	a := FNV1a32([]byte("hello world"))
+	b := FNV1a32([]byte("hello world"))
+	if a != b {
+		t.Fatal("not deterministic")
+	}
+	if a == FNV1a32([]byte("world")) {
+		t.Fatal("different inputs should differ")
+	}
+}
+
+func TestLineHashWhitespaceNormalization(t *testing.T) {
+	a := LineHash("    let x = 1;")
+	b := LineHash("  let x = 1;")
+	c := LineHash("\tlet x = 1;")
+	d := LineHash("let x = 1;   ")
+	e := LineHash("let  x  =  1;")
+	if a != b || b != c || c != d || d != e {
+		t.Fatalf("whitespace variants differ: %d %d %d %d %d", a, b, c, d, e)
+	}
+}
+
+func TestLineHashPreservesTokenBoundaries(t *testing.T) {
+	if LineHash("return x") == LineHash("returnx") {
+		t.Fatal("token boundary must change hash")
+	}
+}
+
+func TestLineHashEmpty(t *testing.T) {
+	if LineHash("") != LineHash("   ") || LineHash("") != LineHash("\t\t") {
+		t.Fatal("empty/whitespace-only should match")
+	}
+}
+
+func TestLineHashCJK(t *testing.T) {
+	a := LineHash("  你好世界  ")
+	b := LineHash("你好世界")
+	if a != b {
+		t.Fatal("CJK whitespace trim failed")
+	}
+	if LineHash("你好") == LineHash("世界") {
+		t.Fatal("different CJK must differ")
+	}
+}
+
+func TestEncodeHash(t *testing.T) {
+	h := FNV1a32([]byte("test"))
+	enc := EncodeHash(h, 3)
+	if len(enc) != 3 {
+		t.Fatalf("len=%d", len(enc))
+	}
+	for _, c := range enc {
+		if c < 'a' || c > 'z' {
+			t.Fatalf("non-lowercase: %q", enc)
+		}
+	}
+	if EncodeHash(h, 3) != enc {
+		t.Fatal("not deterministic")
+	}
+	// Known values cross-checked against Python port of the algorithm.
+	if got := EncodeHash(LineHash("let x = 1;"), 3); got != "rsj" {
+		t.Fatalf("let x = 1; hash encode = %q, want rsj", got)
+	}
+	if got := EncodeHash(LineHash(""), 3); got != "ddg" {
+		t.Fatalf("empty line encode = %q, want ddg", got)
+	}
+}
+
+func TestLineHashKnownValues(t *testing.T) {
+	// Cross-check against the Rust/Python FNV-1a port used in grok-build.
+	if got := LineHash("hello world"); got != 3582672807 {
+		t.Fatalf("hello world = %d, want 3582672807", got)
+	}
+}

--- a/internal/tool/builtin/hashline/ops.go
+++ b/internal/tool/builtin/hashline/ops.go
@@ -1,0 +1,62 @@
+package hashline
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ParseEdits accepts an edits value that may be:
+//   - a JSON array of ops
+//   - a single op object
+//   - a double-JSON-encoded string of either form
+func ParseEdits(raw json.RawMessage) ([]Op, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("edits is required")
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, fmt.Errorf("invalid edits: %w", err)
+	}
+	return decodeEditsValue(v)
+}
+
+func decodeEditsValue(v any) ([]Op, error) {
+	switch t := v.(type) {
+	case string:
+		var inner any
+		if err := json.Unmarshal([]byte(t), &inner); err != nil {
+			return nil, fmt.Errorf("edits was a JSON string but could not be parsed as an array of operations: %w", err)
+		}
+		return decodeEditsValue(inner)
+	case []any:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return nil, err
+		}
+		var ops []Op
+		if err := json.Unmarshal(b, &ops); err != nil {
+			return nil, fmt.Errorf("invalid edits array: %w", err)
+		}
+		for i := range ops {
+			if ops[i].Kind == "" {
+				return nil, fmt.Errorf("edits[%d]: op is required", i)
+			}
+		}
+		return ops, nil
+	case map[string]any:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return nil, err
+		}
+		var op Op
+		if err := json.Unmarshal(b, &op); err != nil {
+			return nil, fmt.Errorf("invalid edit object: %w", err)
+		}
+		if op.Kind == "" {
+			return nil, fmt.Errorf("edits: op is required")
+		}
+		return []Op{op}, nil
+	default:
+		return nil, fmt.Errorf("edits must be an array of edit operations")
+	}
+}

--- a/internal/tool/builtin/hashline/preview_test.go
+++ b/internal/tool/builtin/hashline/preview_test.go
@@ -1,0 +1,83 @@
+package hashline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/diff"
+	"reasonix/internal/tool/builtin"
+)
+
+func TestHashlineEditPreviewDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.go")
+	content := "line one\nline two\nline three\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	anchors := GenerateAnchors(SplitLines(content))
+	ed := NewEdit(dir, []string{dir}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+	args, err := json.Marshal(map[string]any{
+		"path": path,
+		"edits": map[string]any{
+			"op":      "replace",
+			"anchor":  anchors[0].Render(),
+			"content": "LINE ONE",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := ed.Preview(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ch.Kind != diff.Modify {
+		t.Fatalf("kind = %v", ch.Kind)
+	}
+	if ch.Path != path {
+		t.Fatalf("path = %s", ch.Path)
+	}
+	if ch.NewText == "" || ch.NewText == content {
+		t.Fatalf("expected modified NewText, got %q", ch.NewText)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != content {
+		t.Fatal("Preview must not write the file")
+	}
+}
+
+func TestHashlineEditPreviewRejectsOutsideRoot(t *testing.T) {
+	ws := t.TempDir()
+	outside := t.TempDir()
+	path := filepath.Join(outside, "secret.go")
+	if err := os.WriteFile(path, []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := NewEdit(ws, []string{ws}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+	args, err := json.Marshal(map[string]any{
+		"path": path,
+		"edits": map[string]any{
+			"op":      "write",
+			"content": "x",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ed.Preview(args); err == nil {
+		t.Fatal("preview outside write root must fail")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "secret\n" {
+		t.Fatalf("outside file changed by Preview: %q", raw)
+	}
+}

--- a/internal/tool/builtin/hashline/range_policy.go
+++ b/internal/tool/builtin/hashline/range_policy.go
@@ -1,0 +1,40 @@
+// Copyright 2024–2026 xAI and Reasonix contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Modified/adapted from grok-build grok_build_hashline (commit c68e39f).
+// See NOTICE and LICENSE-Apache-2.0 in this directory.
+
+// Copyright adapted from xAI grok-build (Apache-2.0), edit/range_policy.rs.
+// Modified for Reasonix Hashline v1.
+
+package hashline
+
+import "fmt"
+
+const (
+	smallMax  = 5
+	mediumMax = 20
+)
+
+// RangeWarning returns a caution string for medium (6–20) or large (>20) line
+// ranges. start/end are 0-based, end exclusive.
+func RangeWarning(start, end int) string {
+	count := end - start
+	if count < 0 {
+		count = 0
+	}
+	switch {
+	case count > mediumMax:
+		return fmt.Sprintf(
+			"Caution: large range edit (%d lines, lines %d-%d). Verify the target range is correct.",
+			count, start+1, end,
+		)
+	case count > smallMax:
+		return fmt.Sprintf(
+			"Note: medium range edit (%d lines, lines %d-%d).",
+			count, start+1, end,
+		)
+	default:
+		return ""
+	}
+}

--- a/internal/tool/builtin/hashline/read.go
+++ b/internal/tool/builtin/hashline/read.go
@@ -1,0 +1,146 @@
+package hashline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+const readDefaultLimit = 2000
+
+// Read is the hashline_read tool. Construct via NewRead; do not init-register.
+type Read struct {
+	workDir     string
+	paths       *builtin.PathResolver
+	forbidRoots []string
+	overlay     builtin.FileOverlay
+}
+
+// NewRead returns a configured hashline_read tool.
+func NewRead(workDir string, paths *builtin.PathResolver, forbidRoots []string, overlay builtin.FileOverlay) *Read {
+	return &Read{
+		workDir:     workDir,
+		paths:       paths,
+		forbidRoots: builtin.HashlineRealRoots(forbidRoots),
+		overlay:     overlay,
+	}
+}
+
+func (Read) Name() string { return "hashline_read" }
+
+func (Read) Description() string {
+	return "Read a text file with Hashline v1 anchors on each line (LINE:LOCAL:CHUNK→CONTENT). " +
+		"Pass anchors to hashline_edit for validated edits. Use offset/limit to page large files; " +
+		"anchors always use full-file chunk context. Anchors are valid only for the file state at read time."
+}
+
+func (Read) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "path":{"type":"string","description":"File path"},
+  "offset":{"type":"integer","description":"0-based line offset to start reading from (default 0)","minimum":0},
+  "limit":{"type":"integer","description":"Maximum lines to return (default 2000)","minimum":1}
+},
+"required":["path"]
+}`)
+}
+
+func (Read) ReadOnly() bool { return true }
+
+func (Read) SnipHint() tool.SnipHint {
+	return tool.SnipHint{Head: 120, Tail: 12, HeadChars: 12000, TailChars: 2000}
+}
+
+// PermissionAlias documents the classic tool this maps to for policy authors.
+// The tool reports Name()=hashline_read; permission rules match that name (or
+// bare reader-allow). There is no runtime alias interface today.
+func (Read) PermissionAlias() string { return "read_file" }
+
+func (r Read) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Path   string `json:"path"`
+		Offset int    `json:"offset"`
+		Limit  int    `json:"limit"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+	if p.Limit <= 0 {
+		p.Limit = readDefaultLimit
+	}
+
+	rp := builtin.HashlineResolveReadable(r.workDir, p.Path, r.paths)
+	path := rp.Path
+	display := rp.DisplayPath
+	if builtin.HashlineConfineRead(r.forbidRoots, path) {
+		err := &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}
+		if rp.External {
+			return "", fmt.Errorf("read %s: %s", display, rp.ErrorText(err))
+		}
+		return "", err
+	}
+
+	// Overlay (unsaved editor buffers) first for non-external absolute paths.
+	if r.overlay != nil && !rp.External && filepath.IsAbs(path) {
+		if content, ok := r.overlay.ReadTextFile(ctx, path); ok {
+			return formatReadResult(content, p.Offset, p.Limit), nil
+		}
+	}
+
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return "", fmt.Errorf("%s is a directory, not a file — use the ls tool to list it, or read a specific file inside it", display)
+	}
+
+	content, err := readTextFile(path)
+	if err != nil {
+		if rp.External {
+			return "", fmt.Errorf("read %s: %s", display, rp.ErrorText(err))
+		}
+		return "", fmt.Errorf("read %s: %w", display, err)
+	}
+	return formatReadResult(content, p.Offset, p.Limit), nil
+}
+
+func formatReadResult(content string, offset, limit int) string {
+	if content == "" {
+		return FormatHashlineContent("", 0, 1) + "\n\n(empty file)"
+	}
+	lines := SplitLines(content)
+	total := len(lines)
+	if offset >= total {
+		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, total)
+	}
+	window := FormatHashlineContent(content, offset, limit)
+	var trailer strings.Builder
+	if offset+limit < total {
+		fmt.Fprintf(&trailer, "\n\n[more lines below; pass offset=%d to continue; total_lines=%d]", offset+limit, total)
+	} else if offset > 0 {
+		fmt.Fprintf(&trailer, "\n\n[total_lines=%d]", total)
+	}
+	return window + trailer.String()
+}
+
+func readTextFile(path string) (string, error) {
+	content, _, err := builtin.HashlineReadEncoded(path)
+	if err != nil {
+		return "", err
+	}
+	// Reject binary: NUL after decode (UTF-16 already decoded).
+	if strings.IndexByte(content, 0) >= 0 {
+		return "", fmt.Errorf("binary file %s (NUL byte detected); not shown by hashline_read", path)
+	}
+	return content, nil
+}

--- a/internal/tool/builtin/hashline/scheme.go
+++ b/internal/tool/builtin/hashline/scheme.go
@@ -1,0 +1,323 @@
+// Copyright 2024–2026 xAI and Reasonix contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Modified/adapted from grok-build grok_build_hashline (commit c68e39f).
+// See NOTICE and LICENSE-Apache-2.0 in this directory.
+
+// Copyright adapted from xAI grok-build (Apache-2.0), scheme.rs / anchor.rs.
+// Modified for Reasonix Hashline v1 fixed constants.
+
+package hashline
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Fixed Anchor v1 parameters (not runtime-configurable).
+const (
+	// ChunkSize is the fixed chunk window for chunk fingerprints.
+	ChunkSize = 8
+	// SearchRadius is the ± line window for shifted-anchor recovery.
+	SearchRadius = 15
+	// SchemeName is the machine-readable scheme id.
+	SchemeName = "chunk_v1"
+)
+
+// Anchor is a rendered anchor for a single line.
+type Anchor struct {
+	Line    int    // 1-based
+	Local   string // e.g. "abc"
+	Context string // chunk fingerprint; always set for v1
+}
+
+// Render returns "LINE:LOCAL:CHUNK".
+func (a Anchor) Render() string {
+	return fmt.Sprintf("%d:%s:%s", a.Line, a.Local, a.Context)
+}
+
+// Suffix returns "LOCAL:CHUNK" (without line number).
+func (a Anchor) Suffix() string {
+	return a.Local + ":" + a.Context
+}
+
+// ParsedAnchor is a model-supplied anchor after parse.
+type ParsedAnchor struct {
+	Line    int
+	Local   string
+	Context string // empty when omitted
+}
+
+// Render returns the canonical string form.
+func (p ParsedAnchor) Render() string {
+	if p.Context == "" {
+		return fmt.Sprintf("%d:%s", p.Line, p.Local)
+	}
+	return fmt.Sprintf("%d:%s:%s", p.Line, p.Local, p.Context)
+}
+
+// ValidationResult is the outcome of validating an anchor.
+type ValidationResult int
+
+const (
+	Valid ValidationResult = iota
+	Stale
+	OutOfRange
+)
+
+// ShiftResult is the outcome of shifted-anchor recovery.
+type ShiftResult struct {
+	// Kind: "found", "ambiguous", "not_found"
+	Kind       string
+	NewLine    int   // 1-based when Kind=="found"
+	Candidates []int // 1-based when Kind=="ambiguous"
+}
+
+// ParseAnchor parses "22:abc" or "22:abc:rst". Returns ok=false if malformed.
+// Line 0 is rejected (use the special "0:" insert anchor separately).
+func ParseAnchor(s string) (ParsedAnchor, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ParsedAnchor{}, false
+	}
+	// Strip accidentally copied "→content" / "->content".
+	if i := strings.Index(s, "\u2192"); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, "->"); i >= 0 {
+		s = s[:i]
+	}
+
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) < 2 {
+		return ParsedAnchor{}, false
+	}
+	lineStr, local := parts[0], parts[1]
+	if lineStr == "" || local == "" {
+		return ParsedAnchor{}, false
+	}
+	line, err := strconv.Atoi(lineStr)
+	if err != nil || line <= 0 {
+		return ParsedAnchor{}, false
+	}
+	if !isLowerLetters(local) {
+		return ParsedAnchor{}, false
+	}
+	ctx := ""
+	if len(parts) == 3 {
+		ctx = parts[2]
+		if ctx == "" || !isLowerLetters(ctx) {
+			return ParsedAnchor{}, false
+		}
+	}
+	return ParsedAnchor{Line: line, Local: local, Context: ctx}, true
+}
+
+func isLowerLetters(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < 'a' || s[i] > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// SplitLines splits file content into logical lines without trailing newlines.
+// A trailing newline produces a final empty entry (so "a\n" → ["a", ""]).
+// Empty content yields a single empty line.
+// CRLF is accepted; the trailing '\r' is stripped from each line body.
+func SplitLines(content string) []string {
+	if content == "" {
+		return []string{""}
+	}
+	var lines []string
+	start := 0
+	for i := 0; i < len(content); i++ {
+		if content[i] != '\n' {
+			continue
+		}
+		line := content[start:i]
+		if strings.HasSuffix(line, "\r") {
+			line = line[:len(line)-1]
+		}
+		lines = append(lines, line)
+		start = i + 1
+	}
+	if start < len(content) {
+		line := content[start:]
+		if strings.HasSuffix(line, "\r") {
+			line = line[:len(line)-1]
+		}
+		lines = append(lines, line)
+	} else {
+		// content ended with '\n' — synthetic trailing empty line
+		lines = append(lines, "")
+	}
+	return lines
+}
+
+// UsesCRLF reports whether content primarily uses CRLF line endings.
+func UsesCRLF(content string) bool {
+	return strings.Contains(content, "\r\n")
+}
+
+// JoinLines joins lines with LF or CRLF. A trailing empty line produces a
+// trailing newline (matching SplitLines round-trip).
+func JoinLines(lines []string, crlf bool) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	sep := "\n"
+	if crlf {
+		sep = "\r\n"
+	}
+	return strings.Join(lines, sep)
+}
+
+// GenerateAnchors builds Anchor v1 (chunk) anchors for every line.
+func GenerateAnchors(lines []string) []Anchor {
+	n := len(lines)
+	if n == 0 {
+		return nil
+	}
+	numChunks := (n + ChunkSize - 1) / ChunkSize
+	chunkFPs := make([]string, numChunks)
+	for c := 0; c < numChunks; c++ {
+		start := c * ChunkSize
+		end := start + ChunkSize
+		if end > n {
+			end = n
+		}
+		combined := FNV1a32([]byte("chunk"))
+		for _, line := range lines[start:end] {
+			lh := LineHash(line)
+			combined ^= lh
+			combined *= fnvPrime
+		}
+		chunkFPs[c] = EncodeHash(combined, DefaultHashLen)
+	}
+
+	out := make([]Anchor, n)
+	for i, line := range lines {
+		h := LineHash(line)
+		ci := i / ChunkSize
+		out[i] = Anchor{
+			Line:    i + 1,
+			Local:   EncodeHash(h, DefaultHashLen),
+			Context: chunkFPs[ci],
+		}
+	}
+	return out
+}
+
+// Validate checks a parsed anchor against the current lines.
+func Validate(anchor ParsedAnchor, lines []string) ValidationResult {
+	idx := anchor.Line - 1
+	if idx < 0 || idx >= len(lines) {
+		return OutOfRange
+	}
+	expectedLocal := EncodeHash(LineHash(lines[idx]), DefaultHashLen)
+	if anchor.Local != expectedLocal {
+		return Stale
+	}
+	// Chunk scheme requires context — truncated anchors are stale.
+	if anchor.Context == "" {
+		return Stale
+	}
+	if anchor.Context != chunkFingerprint(lines, idx) {
+		return Stale
+	}
+	return Valid
+}
+
+func chunkFingerprint(lines []string, lineIdx int) string {
+	start := (lineIdx / ChunkSize) * ChunkSize
+	end := start + ChunkSize
+	if end > len(lines) {
+		end = len(lines)
+	}
+	combined := FNV1a32([]byte("chunk"))
+	for _, line := range lines[start:end] {
+		lh := LineHash(line)
+		combined ^= lh
+		combined *= fnvPrime
+	}
+	return EncodeHash(combined, DefaultHashLen)
+}
+
+// FindShifted searches ±SearchRadius (or custom radius) for a unique match.
+// Never auto-applies; callers surface Found/Ambiguous/NotFound to the model.
+func FindShifted(anchor ParsedAnchor, lines []string, radius int) ShiftResult {
+	if radius <= 0 {
+		radius = SearchRadius
+	}
+	origIdx := anchor.Line - 1
+	if origIdx < 0 {
+		origIdx = 0
+	}
+	start := origIdx - radius
+	if start < 0 {
+		start = 0
+	}
+	end := origIdx + radius + 1
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	var candidates []int
+	for idx := start; idx < end; idx++ {
+		if idx == origIdx {
+			continue
+		}
+		local := EncodeHash(LineHash(lines[idx]), DefaultHashLen)
+		if local != anchor.Local {
+			continue
+		}
+		if anchor.Context != "" {
+			probe := ParsedAnchor{Line: idx + 1, Local: local, Context: anchor.Context}
+			if Validate(probe, lines) != Valid {
+				continue
+			}
+		}
+		candidates = append(candidates, idx+1)
+	}
+	switch len(candidates) {
+	case 0:
+		return ShiftResult{Kind: "not_found"}
+	case 1:
+		return ShiftResult{Kind: "found", NewLine: candidates[0]}
+	default:
+		return ShiftResult{Kind: "ambiguous", Candidates: candidates}
+	}
+}
+
+// FormatAnchoredLine returns "LINE:LOCAL:CHUNK→CONTENT".
+func FormatAnchoredLine(a Anchor, content string) string {
+	return fmt.Sprintf("%s\u2192%s", a.Render(), content)
+}
+
+// FormatHashlineContent formats a window of lines with anchors.
+// offset is 0-based line offset; limit is max lines (0 = all remaining).
+func FormatHashlineContent(content string, offset, limit int) string {
+	lines := SplitLines(content)
+	anchors := GenerateAnchors(lines)
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = len(lines)
+	}
+	var b strings.Builder
+	written := 0
+	for i := offset; i < len(lines) && written < limit; i++ {
+		if written > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(FormatAnchoredLine(anchors[i], lines[i]))
+		written++
+	}
+	return b.String()
+}

--- a/internal/tool/builtin/hashline/scheme_test.go
+++ b/internal/tool/builtin/hashline/scheme_test.go
@@ -1,0 +1,194 @@
+package hashline
+
+import (
+	"strings"
+	"testing"
+)
+
+func sampleLines() []string {
+	return []string{
+		"import React from 'react';",
+		"",
+		"export function App() {",
+		"  return <div>Hello</div>;",
+		"}",
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", []string{""}},
+		{"a\nb\nc", []string{"a", "b", "c"}},
+		{"a\nb\n", []string{"a", "b", ""}},
+		{"\n", []string{"", ""}},
+		{"a\r\nb\r\n", []string{"a", "b", ""}},
+		{"a\r\nb", []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		got := SplitLines(tc.in)
+		if len(got) != len(tc.want) {
+			t.Fatalf("SplitLines(%q) len=%d want %d (%v)", tc.in, len(got), len(tc.want), got)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("SplitLines(%q)[%d]=%q want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestJoinLinesRoundTrip(t *testing.T) {
+	for _, content := range []string{"a\nb\n", "a\nb", "a\r\nb\r\n", ""} {
+		crlf := UsesCRLF(content)
+		lines := SplitLines(content)
+		got := JoinLines(lines, crlf)
+		// Empty content special-cases to single empty line join → ""
+		if content == "" {
+			if got != "" {
+				t.Fatalf("empty roundtrip = %q", got)
+			}
+			continue
+		}
+		if got != content {
+			t.Fatalf("roundtrip %q → %q", content, got)
+		}
+	}
+}
+
+func TestParseAnchor(t *testing.T) {
+	a, ok := ParseAnchor("22:abc:rst")
+	if !ok || a.Line != 22 || a.Local != "abc" || a.Context != "rst" {
+		t.Fatalf("got %+v ok=%v", a, ok)
+	}
+	if _, ok := ParseAnchor("0:abc:rst"); ok {
+		t.Fatal("line 0 should be rejected")
+	}
+	if _, ok := ParseAnchor("22:ABC:rst"); ok {
+		t.Fatal("uppercase rejected")
+	}
+	// Strip arrow
+	a, ok = ParseAnchor("22:abc:rst→code")
+	if !ok || a.Render() != "22:abc:rst" {
+		t.Fatalf("arrow strip failed: %+v", a)
+	}
+}
+
+func TestGenerateAnchorsChunkV1(t *testing.T) {
+	lines := sampleLines()
+	a1 := GenerateAnchors(lines)
+	a2 := GenerateAnchors(lines)
+	if len(a1) != len(lines) {
+		t.Fatalf("count %d", len(a1))
+	}
+	for i := range a1 {
+		if a1[i] != a2[i] {
+			t.Fatal("not deterministic")
+		}
+		if a1[i].Line != i+1 {
+			t.Fatal("1-based line numbers")
+		}
+		if len(a1[i].Local) != 3 || len(a1[i].Context) != 3 {
+			t.Fatalf("hash len: %+v", a1[i])
+		}
+		// All 5 lines in one chunk (size 8) → same context.
+		if a1[i].Context != a1[0].Context {
+			t.Fatal("same chunk should share context")
+		}
+		if Validate(ParsedAnchor{Line: a1[i].Line, Local: a1[i].Local, Context: a1[i].Context}, lines) != Valid {
+			t.Fatalf("self-validate failed line %d", i+1)
+		}
+	}
+}
+
+func TestChunkDifferentChunksDiffer(t *testing.T) {
+	owned := make([]string, 20)
+	for i := range owned {
+		owned[i] = "line " + strings.Repeat("x", i+1)
+	}
+	anchors := GenerateAnchors(owned)
+	if anchors[0].Context == anchors[16].Context {
+		// Unlikely with this input; if equal, still check chunk indices.
+		t.Log("chunk fps collided (rare); checking indices only")
+	}
+	if anchors[0].Context == "" || anchors[16].Context == "" {
+		t.Fatal("missing context")
+	}
+}
+
+func TestValidateStaleAndIndentation(t *testing.T) {
+	lines := sampleLines()
+	anchors := GenerateAnchors(lines)
+	parsed := ParsedAnchor{Line: anchors[3].Line, Local: anchors[3].Local, Context: anchors[3].Context}
+
+	mut := append([]string{}, lines...)
+	mut[3] = "  return <div>World</div>;"
+	if Validate(parsed, mut) != Stale {
+		t.Fatal("content change should stale")
+	}
+
+	// Indentation-only: local hash survives; chunk may still match if only whitespace.
+	re := append([]string{}, lines...)
+	re[3] = "    return <div>Hello</div>;"
+	// Local should match (whitespace-normalized); chunk fingerprint also uses
+	// line hashes so it should remain Valid.
+	if Validate(parsed, re) != Valid {
+		t.Fatal("reindent should keep valid for whitespace-normalized scheme")
+	}
+}
+
+func TestFindShiftedAfterInsert(t *testing.T) {
+	orig := sampleLines()
+	anchors := GenerateAnchors(orig)
+	shifted := append([]string{"// new line"}, orig...)
+	parsed := ParsedAnchor{Line: anchors[2].Line, Local: anchors[2].Local, Context: anchors[2].Context}
+	// Insert above changes every chunk fingerprint, so local+context recovery
+	// typically returns not_found for the chunk scheme (strong freshness).
+	res := FindShifted(parsed, shifted, 5)
+	if res.Kind == "found" && res.NewLine != 4 {
+		t.Fatalf("unexpected found line %d", res.NewLine)
+	}
+}
+
+func TestFindShiftedContentOnlyLocal(t *testing.T) {
+	// When context is empty, recovery is local-hash only (used for suffix recovery paths).
+	// Insert above shifts "b" from line 2 to line 3.
+	shifted := []string{"new", "a", "b", "c"}
+	localB := EncodeHash(LineHash("b"), DefaultHashLen)
+	res := FindShifted(ParsedAnchor{Line: 2, Local: localB, Context: ""}, shifted, 5)
+	if res.Kind != "found" || res.NewLine != 3 {
+		t.Fatalf("got %+v", res)
+	}
+}
+
+func TestDuplicateLinesAmbiguous(t *testing.T) {
+	lines := []string{"same", "x", "same", "y", "same"}
+	local := EncodeHash(LineHash("same"), DefaultHashLen)
+	// Anchor at line 1; after no shift, original skipped; nearby duplicates match local.
+	// Without context, multiple "same" → ambiguous.
+	res := FindShifted(ParsedAnchor{Line: 1, Local: local, Context: ""}, lines, 15)
+	if res.Kind != "ambiguous" {
+		t.Fatalf("want ambiguous, got %+v", res)
+	}
+}
+
+func TestFormatHashlineContent(t *testing.T) {
+	content := "line one\nline two\nline three\n"
+	out := FormatHashlineContent(content, 0, 0)
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "\u2192") {
+			t.Fatalf("missing arrow: %q", line)
+		}
+		before, _, _ := strings.Cut(line, "\u2192")
+		if strings.Count(before, ":") != 2 {
+			t.Fatalf("want LINE:LOCAL:CHUNK, got %q", before)
+		}
+	}
+	// Window
+	win := FormatHashlineContent(content, 1, 1)
+	if !strings.HasPrefix(win, "2:") {
+		t.Fatalf("offset window: %q", win)
+	}
+}

--- a/internal/tool/builtin/hashline/tools.go
+++ b/internal/tool/builtin/hashline/tools.go
@@ -1,0 +1,38 @@
+package hashline
+
+import (
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+// Config binds hashline tools to a workspace the same way classic built-ins are.
+type Config struct {
+	WorkDir     string
+	WriteRoots  []string
+	ForbidRoots []string
+	Paths       *builtin.PathResolver
+	Guard       builtin.SessionDataGuard
+	Managed     builtin.ManagedConfigPaths
+	Overlay     builtin.FileOverlay
+	Search      builtin.SearchSpec
+	Sandbox     sandbox.Spec
+}
+
+// Tools returns the three hashline tools bound to cfg.
+// They are NOT registered into tool.Builtins(); boot must Add them only for
+// hashline-protocol sessions.
+func (c Config) Tools() []tool.Tool {
+	writeRoots := c.WriteRoots
+	if len(writeRoots) == 0 && c.WorkDir != "" {
+		writeRoots = []string{c.WorkDir}
+	}
+	return []tool.Tool{
+		NewRead(c.WorkDir, c.Paths, c.ForbidRoots, c.Overlay),
+		NewEdit(c.WorkDir, writeRoots, c.Guard, c.Managed, c.Overlay),
+		NewGrep(c.WorkDir, c.Paths, c.Search, c.Sandbox, c.ForbidRoots),
+	}
+}
+
+// ToolNames are the provider-visible hashline tool ids.
+var ToolNames = []string{"hashline_read", "hashline_edit", "hashline_grep"}

--- a/internal/tool/builtin/hashline/tools_test.go
+++ b/internal/tool/builtin/hashline/tools_test.go
@@ -1,0 +1,304 @@
+package hashline
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+func jsonArgs(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestHashlineReadBasic(t *testing.T) {
+	dir := t.TempDir()
+	body := "package main\n\nfunc main() {}\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rd := NewRead(dir, nil, nil, nil)
+	out, err := rd.Execute(context.Background(), jsonArgs(t, map[string]any{"path": "main.go"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "\u2192package main") {
+		t.Fatalf("got %q", out)
+	}
+	first := strings.Split(out, "\n")[0]
+	before, _, ok := strings.Cut(first, "\u2192")
+	if !ok || strings.Count(before, ":") != 2 {
+		t.Fatalf("anchor form: %q", first)
+	}
+}
+
+func TestHashlineReadEmptyAndCJK(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "empty.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rd := NewRead(dir, nil, nil, nil)
+	out, err := rd.Execute(context.Background(), jsonArgs(t, map[string]any{"path": "empty.txt"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "empty file") || !strings.Contains(out, "\u2192") {
+		t.Fatalf("%q", out)
+	}
+
+	cjk := "第一行\n第二行\n"
+	if err := os.WriteFile(filepath.Join(dir, "cjk.txt"), []byte(cjk), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err = rd.Execute(context.Background(), jsonArgs(t, map[string]any{"path": "cjk.txt"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "第一行") {
+		t.Fatal(out)
+	}
+}
+
+func TestHashlineReadPagination(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < 10; i++ {
+		b.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "p.txt"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rd := NewRead(dir, nil, nil, nil)
+	out, err := rd.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"path": "p.txt", "offset": 2, "limit": 2,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(out, "3:") {
+		t.Fatalf("%q", out)
+	}
+	if !strings.Contains(out, "offset=4") {
+		t.Fatalf("pagination trailer: %q", out)
+	}
+}
+
+func TestHashlineEditAndReadEncoding(t *testing.T) {
+	dir := t.TempDir()
+	src := "第一行 hello\r\n第二行 world\r\n"
+	enc, err := simplifiedchinese.GB18030.NewEncoder().Bytes([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "f.cs")
+	if err := os.WriteFile(path, enc, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content, _, err := builtin.HashlineReadEncoded(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := anchorsFor(content)
+	ed := NewEdit(dir, []string{dir}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+	_, err = ed.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"path": "f.cs",
+		"edits": []map[string]any{
+			{"op": "replace", "anchor": a[0], "content": "第一行 HELLO"},
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := simplifiedchinese.GB18030.NewDecoder().Bytes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(dec)
+	if !strings.Contains(got, "HELLO") || !strings.Contains(got, "\r\n") {
+		t.Fatalf("encoding/endings: %q", got)
+	}
+}
+
+func TestHashlineEditUTF16BOM(t *testing.T) {
+	dir := t.TempDir()
+	text := "alpha\nbeta\n"
+	u := utf16.Encode([]rune(text))
+	buf := make([]byte, 2+len(u)*2)
+	buf[0], buf[1] = 0xFF, 0xFE
+	for i, v := range u {
+		binary.LittleEndian.PutUint16(buf[2+i*2:], v)
+	}
+	path := filepath.Join(dir, "u.txt")
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content, _, err := builtin.HashlineReadEncoded(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := anchorsFor(content)
+	ed := NewEdit(dir, []string{dir}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+	_, err = ed.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"path":  "u.txt",
+		"edits": []map[string]any{{"op": "replace", "anchor": a[0], "content": "ALPHA"}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if len(raw) < 2 || raw[0] != 0xFF || raw[1] != 0xFE {
+		t.Fatalf("BOM lost: %v", raw[:min(4, len(raw))])
+	}
+}
+
+func TestHashlineEditDoubleJSONAndStale(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "t.txt"), []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := anchorsFor("a\nb\n")
+	ed := NewEdit(dir, []string{dir}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+
+	inner, _ := json.Marshal([]map[string]any{
+		{"op": "replace", "anchor": a[0], "content": "A"},
+	})
+	_, err := ed.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"path":  "t.txt",
+		"edits": string(inner),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before, _ := os.ReadFile(filepath.Join(dir, "t.txt"))
+	_, err = ed.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"path":  "t.txt",
+		"edits": []map[string]any{{"op": "replace", "anchor": "1:zzz:zzz", "content": "X"}},
+	}))
+	if err == nil {
+		t.Fatal("expected stale error")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "t.txt"))
+	if string(before) != string(after) {
+		t.Fatalf("stale wrote to disk: %q → %q", before, after)
+	}
+}
+
+func TestHashlineGrepAnchors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "s.go"), []byte("package main\nfunc Hello() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g := NewGrep(dir, nil, builtin.SearchSpec{}, sandbox.Spec{}, nil)
+	out, err := g.Execute(context.Background(), jsonArgs(t, map[string]any{
+		"pattern": "Hello",
+		"path":    ".",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "(no matches)" {
+		t.Fatal("expected match")
+	}
+	found := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Hello") && strings.Count(line, ":") >= 4 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected anchored line, got %q", out)
+	}
+}
+
+func TestNotInBuiltinRegistry(t *testing.T) {
+	// Ensure blank-import of this package wouldn't be required; constructors only.
+	// Classic Builtins must not include hashline tools.
+	for _, name := range ToolNames {
+		if _, ok := tool.LookupBuiltin(name); ok {
+			t.Fatalf("%s must not auto-register into Builtins", name)
+		}
+	}
+	// Config.Tools still constructs them for hashline sessions.
+	tools := Config{WorkDir: t.TempDir()}.Tools()
+	if len(tools) != 3 {
+		t.Fatalf("Tools() = %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tl := range tools {
+		names[tl.Name()] = true
+		if tl.Name() == "hashline_read" && !tl.ReadOnly() {
+			t.Fatal("read must be ReadOnly")
+		}
+		if tl.Name() == "hashline_edit" && tl.ReadOnly() {
+			t.Fatal("edit must not be ReadOnly")
+		}
+	}
+	for _, n := range ToolNames {
+		if !names[n] {
+			t.Fatalf("missing %s", n)
+		}
+	}
+}
+
+func TestPermissionAliasesDocumented(t *testing.T) {
+	if (Read{}).PermissionAlias() != "read_file" {
+		t.Fatal()
+	}
+	if (Edit{}).PermissionAlias() != "edit_file" {
+		t.Fatal()
+	}
+	if (Grep{}).PermissionAlias() != "grep" {
+		t.Fatal()
+	}
+}
+
+func TestFuzzFailureNeverPartialWriteOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.txt")
+	orig := "one\ntwo\nthree\n"
+	if err := os.WriteFile(path, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := NewEdit(dir, []string{dir}, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil)
+	a := anchorsFor(orig)
+	// Mix of failing batches
+	batches := []any{
+		[]map[string]any{{"op": "replace", "anchor": "nope", "content": "x"}},
+		[]map[string]any{{"op": "replace", "anchor": a[0], "content": a[0] + "\u2192x"}},
+		[]map[string]any{
+			{"op": "replace", "anchor": a[0], "end_anchor": a[2], "content": "a"},
+			{"op": "replace", "anchor": a[1], "content": "b"},
+		},
+	}
+	for i, batch := range batches {
+		_, err := ed.Execute(context.Background(), jsonArgs(t, map[string]any{"path": "x.txt", "edits": batch}))
+		if err == nil {
+			t.Fatalf("batch %d expected error", i)
+		}
+		got, _ := os.ReadFile(path)
+		if string(got) != orig {
+			t.Fatalf("batch %d partial write: %q", i, got)
+		}
+	}
+}

--- a/internal/tool/builtin/hashline_support.go
+++ b/internal/tool/builtin/hashline_support.go
@@ -1,0 +1,69 @@
+package builtin
+
+import (
+	"context"
+
+	fileenc "reasonix/internal/fileutil/encoding"
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+)
+
+// Helpers below are exported for the hashline subpackage so it can reuse the
+// same path resolution, confinement, encoding, and search wiring as the classic
+// built-ins without registering hashline tools into the global Builtin set.
+
+// HashlineResolvePath resolves a model-supplied path against workDir.
+func HashlineResolvePath(workDir, p string) string {
+	return resolveIn(workDir, p)
+}
+
+// HashlineResolveReadable resolves a path for a read/search tool, including
+// session-scoped external read aliases.
+func HashlineResolveReadable(workDir, path string, resolver *PathResolver) ResolvedPath {
+	return resolveReadablePath(workDir, path, resolver)
+}
+
+// HashlineConfineRead reports whether target is forbidden for read tools.
+func HashlineConfineRead(forbidRoots []string, target string) bool {
+	return confineRead(forbidRoots, target)
+}
+
+// HashlineConfineWrite is the write-tool boundary check (workspace + session
+// guard + managed-config approval).
+func HashlineConfineWrite(ctx context.Context, roots []string, guard SessionDataGuard, managed ManagedConfigPaths, target string) error {
+	return confineWrite(ctx, roots, guard, managed, target)
+}
+
+// HashlineConfinePreview mirrors confinePreview for hashline_edit Previewer:
+// same writable-root / session-guard / managed-config visibility checks as
+// Execute, without the managed-config approval prompt.
+func HashlineConfinePreview(roots []string, guard SessionDataGuard, managed ManagedConfigPaths, target string) error {
+	return confinePreview(roots, guard, managed, target)
+}
+
+// HashlineRealRoots resolves write/forbid roots the same way classic tools do.
+func HashlineRealRoots(roots []string) []string {
+	return realRoots(roots)
+}
+
+// HashlineReadEncoded reads and decodes a file, preserving encoding kind for
+// a subsequent write-back.
+func HashlineReadEncoded(path string) (content string, enc fileenc.Kind, err error) {
+	return readFileEncoded(path)
+}
+
+// HashlineWriteEncoded re-encodes content and writes it, preserving charset/BOM.
+func HashlineWriteEncoded(path, content string, enc fileenc.Kind) error {
+	return writeFileEncoded(path, content, enc)
+}
+
+// NewGrepTool constructs a configured grep tool for post-processing (hashline_grep).
+func NewGrepTool(workDir string, paths *PathResolver, spec SearchSpec, sb sandbox.Spec, forbidRoots []string) tool.Tool {
+	return grepTool{
+		workDir:     workDir,
+		paths:       paths,
+		rg:          spec.RgPath,
+		forbidRoots: realRoots(forbidRoots),
+		sb:          sb,
+	}
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -285,6 +285,33 @@ func NewRegistry() *Registry {
 	return &Registry{tools: map[string]Tool{}, canon: map[string]json.RawMessage{}, suspended: map[string]bool{}}
 }
 
+// Clone returns a shallow copy of the registry: the same Tool instances are
+// shared, but order/canon maps are independent so later Add/Remove on either
+// side does not mutate the other. Suspended prefixes are not copied.
+func (r *Registry) Clone() *Registry {
+	if r == nil {
+		return NewRegistry()
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := NewRegistry()
+	for _, name := range r.order {
+		if r.suspended[name] {
+			continue
+		}
+		t := r.tools[name]
+		if t == nil {
+			continue
+		}
+		out.tools[name] = t
+		out.order = append(out.order, name)
+		if c, ok := r.canon[name]; ok {
+			out.canon[name] = append(json.RawMessage(nil), c...)
+		}
+	}
+	return out
+}
+
 // Add inserts (or replaces) a tool, preserving first-seen order. The schema is
 // canonicalized once here — it never changes after registration, so Schemas()
 // (called every turn) reuses the result instead of re-marshaling.

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -37,6 +37,10 @@ soft_compact_ratio  = 0.5   # notice only; keeps the cache-first prefix intact
 tool_result_snip_ratio = 0.6   # snip stale tool results before summary compaction
 compact_ratio       = 0.8   # try compacting when prompt reaches this fraction
 compact_force_ratio = 0.9   # force compacting at this high-water mark
+# prompt_layout = "legacy_system"   # new sessions: session_context | legacy_system
+#                                     # (default legacy_system until release gate; set
+#                                     # session_context for workspace/env/skills as a
+#                                     # pinned synthetic user message)
 # planner_model = "deepseek-pro"   # optional: enable two-model collaboration
 # subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides
@@ -114,6 +118,9 @@ enabled = true   # inject a stable startup summary of OS, shell, and common tool
 enabled = []   # empty = all built-in tools
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
+# capability_surface = "legacy"   # new sessions: stable | legacy (default legacy until
+#                                   # release gate; stable = capability-v2 proxy for optional tools)
+# edit_protocol = "classic"       # new sessions: classic | hashline (Beta; requires stable)
 
 [tools.background_jobs]
 stalled_warning_seconds = 900   # warn once per background job after this many quiet seconds; 0 disables


### PR DESCRIPTION
## Summary

- Persist a session RuntimeContract for capability surface, edit protocol, and prompt layout.
- Add stable BM25 capability discovery and proxy execution without mutating provider-visible schemas.
- Add the session-context prompt layout and deterministic three-level compaction state.
- Add opt-in Hashline v1 editing with preview confinement and permission aliases.
- Route dynamic MCP tools to execution and legacy registries while keeping capability schemas stable across connect, disconnect, resume, and lazy cache misses.

## Why

Agent sessions previously derived provider-visible tools and prompt layout from process state. Dynamic MCP registration and non-deterministic compaction could change cached prefixes or alter behavior after resume. This change makes those choices session-owned and persisted while preserving the existing default behavior.

## Cache and rollout

- Empty configuration still selects legacy-v1, classic-v1, and system-v1.
- Enabling the v2 surface or Hashline intentionally causes one cold prefix when a new session starts.
- Provider-visible capability schemas remain fixed after session creation.
- Cache guard tail averages remain 92–95 percent across all covered dialogue and tool-loop scenarios.
- The default switch remains gated on live provider A/B results.

## Compatibility

| Area | Existing behavior or data | Result |
| --- | --- | --- |
| Pre-contract sidecars | No runtime contract | Pinned to legacy behavior |
| Missing transcript sidecar | Strict inference, otherwise legacy fallback | Compatible |
| Corrupt sidecar | Diagnostic plus legacy fallback | Compatible |
| Session JSON | Optional runtime_contract field | Compatible |
| Configuration | Missing new fields | Legacy defaults |
| Provider tool schema | Legacy unchanged; v2 opt-in | Compatible |

## Validation

- `./scripts/cache-guard.sh`
- Root module: `go test ./...`, `go vet ./...`, `go build ./...`, and `go test -race ./...`
- Desktop module: `go test ./...`, `go vet ./...`, `go build ./...`, and `go test -race ./...`

## Attribution

Hashline is adapted from the xAI grok-build implementation at baseline commit `c68e39f` under Apache-2.0. The package includes the required license, NOTICE, and adapted-source headers.

## Not included

- Switching the product default to the v2 runtime
- Desktop new-task editing protocol controls
- Live provider A/B and the token-reduction release gate
