### PR TITLE
Fix registry publish button layout / 修复技能市场发布按钮布局

### DIFF
--- a/site/src/pages/skills.astro
+++ b/site/src/pages/skills.astro
@@ -38,7 +38,7 @@ const desc = "Browse, publish, and install community skills and MCP servers for 
           <button data-sort="trending" role="tab"><span class="l-en">Trending</span><span class="l-zh">趋势</span></button>
           <button data-sort="installs" role="tab"><span class="l-en">Top</span><span class="l-zh">最热</span></button>
         </div>
-        <a class="btn btn-dark reg-publish" id="publish-open" href="#publish">
+        <a class="btn btn-dark reg-publish-cta" id="publish-open" href="#publish">
           <span class="l-en">Publish</span><span class="l-zh">发布</span>
         </a>
       </div>

--- a/site/src/scripts/skills-layout-contract.test.mjs
+++ b/site/src/scripts/skills-layout-contract.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = () => readFile(new URL("../pages/skills.astro", import.meta.url), "utf8");
+
+test("the registry publish CTA does not inherit the publish panel layout", async () => {
+  const page = await source();
+
+  assert.match(page, /class="btn btn-dark reg-publish-cta" id="publish-open"/);
+  assert.match(page, /<section class="reg-publish" id="publish" hidden>/);
+  assert.doesNotMatch(page, /class="btn btn-dark reg-publish" id="publish-open"/);
+});


### PR DESCRIPTION
## Summary

- isolate the registry toolbar's publish CTA from the publish panel layout class
- add a source contract test that prevents the CTA and panel from sharing the layout class again

## Root cause

The publish CTA reused the existing `reg-publish` class when it moved into the registry toolbar. The page-level `.reg-publish` section rule then overrode the shared button padding, rendering the CTA as a narrow vertical pill.

## User impact

The publish CTA now renders as a normal horizontal button while the hidden publish panel keeps its existing section spacing and behavior.

## Verification

- `npm test` in `site/`: 21 passed
- `npm run build` in `site/`: passed
- `git diff --check`: passed
- in-app browser: CTA renders at 82 × 45 px with 12 px 26 px padding

## Compatibility and cache impact

- no persisted data, API, or Wails contract changes
- no provider-visible prompt, tool schema, request serialization, or cache behavior changes
