### PR TITLE
test(config): isolate test user state / 隔离测试用户状态

### DIFF
--- a/internal/boot/main_test.go
+++ b/internal/boot/main_test.go
@@ -1,0 +1,11 @@
+package boot
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/bot/main_test.go
+++ b/internal/bot/main_test.go
@@ -1,0 +1,11 @@
+package bot
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/botruntime/main_test.go
+++ b/internal/botruntime/main_test.go
@@ -1,0 +1,11 @@
+package botruntime
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -36,6 +36,25 @@ const tinyPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42
 func TestMain(m *testing.M) {
 	old := detectTermuxTerminal
 	detectTermuxTerminal = func() bool { return false }
+	home, err := os.MkdirTemp("", "reasonix-cli-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	for key, value := range map[string]string{
+		"HOME":            home,
+		"USERPROFILE":     home,
+		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"AppData":         filepath.Join(home, "AppData"),
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			panic(err)
+		}
+	}
+	// Keep the package on the default-path code path without allowing an
+	// inherited REASONIX_HOME to escape the temporary test home.
+	if err := os.Unsetenv("REASONIX_HOME"); err != nil {
+		panic(err)
+	}
 
 	// Pin the UI language for the whole cli test binary. Production code
 	// (cli.Run) calls i18n.DetectLanguage("") which resolves the host locale from
@@ -55,6 +74,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 	detectTermuxTerminal = old
+	_ = os.RemoveAll(home)
 	os.Exit(code)
 }
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
 	"reasonix/internal/skill"
+	"reasonix/internal/testenv"
 )
 
 type blockingTurnRunner struct{ started chan struct{} }
@@ -36,23 +37,8 @@ const tinyPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42
 func TestMain(m *testing.M) {
 	old := detectTermuxTerminal
 	detectTermuxTerminal = func() bool { return false }
-	home, err := os.MkdirTemp("", "reasonix-cli-test-home-")
+	cleanupUserState, err := testenv.IsolateUserState()
 	if err != nil {
-		panic(err)
-	}
-	for key, value := range map[string]string{
-		"HOME":            home,
-		"USERPROFILE":     home,
-		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
-		"AppData":         filepath.Join(home, "AppData"),
-	} {
-		if err := os.Setenv(key, value); err != nil {
-			panic(err)
-		}
-	}
-	// Keep the package on the default-path code path without allowing an
-	// inherited REASONIX_HOME to escape the temporary test home.
-	if err := os.Unsetenv("REASONIX_HOME"); err != nil {
 		panic(err)
 	}
 
@@ -74,7 +60,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 	detectTermuxTerminal = old
-	_ = os.RemoveAll(home)
+	cleanupUserState()
 	os.Exit(code)
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -200,12 +200,31 @@ func isolateCLIConfigHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// Keep tests on the default-path code path while preventing a caller's
+	// higher-priority REASONIX_HOME from escaping this temporary home.
+	t.Setenv("REASONIX_HOME", "")
+	if err := os.Unsetenv("REASONIX_HOME"); err != nil {
+		t.Fatalf("unset REASONIX_HOME: %v", err)
+	}
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("AppData", filepath.Join(home, "AppData"))
 	t.Chdir(t.TempDir())
 	return home
+}
+
+func TestIsolateCLIConfigHomeOverridesExistingReasonixHome(t *testing.T) {
+	externalHome := t.TempDir()
+	t.Setenv("REASONIX_HOME", externalHome)
+
+	home := isolateCLIConfigHome(t)
+
+	got := config.UserConfigPath()
+	rel, err := filepath.Rel(home, got)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		t.Fatalf("UserConfigPath() = %q, outside isolated home %q", got, home)
+	}
 }
 
 func TestMCPMigrationWaitsForCLIWorkspace(t *testing.T) {

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -810,12 +810,11 @@ func TestSetCredentialRejectsInvalidInput(t *testing.T) {
 }
 
 func TestProjectConfigCannotOverrideCredentialStoreMode(t *testing.T) {
-	home := t.TempDir()
+	home := isolateUserConfigHome(t)
 	project := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "")
 	os.Unsetenv("REASONIX_CREDENTIALS_STORE")
+	requireTestPathWithin(t, home, UserConfigPath())
 	if err := os.MkdirAll(filepath.Dir(UserConfigPath()), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1075,7 +1075,7 @@ func TestSaveToRoundTrips(t *testing.T) {
 }
 
 func TestSaveToScopesUserAndProjectFiles(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	c := Default()
 	c.Desktop.Theme = "dark"
 	c.Desktop.ThemeStyle = "graphite"

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1075,13 +1075,15 @@ func TestSaveToRoundTrips(t *testing.T) {
 }
 
 func TestSaveToScopesUserAndProjectFiles(t *testing.T) {
-	t.Setenv("REASONIX_HOME", t.TempDir())
+	home := isolateUserConfigHome(t)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
 	c := Default()
 	c.Desktop.Theme = "dark"
 	c.Desktop.ThemeStyle = "graphite"
 	c.Desktop.CloseBehavior = "background"
 
 	userPath := UserConfigPath()
+	requireTestPathWithin(t, home, userPath)
 	if err := c.SaveTo(userPath); err != nil {
 		t.Fatalf("SaveTo user config: %v", err)
 	}

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/config/path_isolation_test.go
+++ b/internal/config/path_isolation_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requireTestPathWithin(t *testing.T, root, path string) {
+	t.Helper()
+	rel, err := filepath.Rel(root, path)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		t.Fatalf("test path %q escapes isolated root %q", path, root)
+	}
+}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -16,8 +16,15 @@ func isolateUserConfigHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	for _, key := range []string{"REASONIX_HOME", "REASONIX_STATE_HOME", "REASONIX_CACHE_HOME"} {
+		t.Setenv(key, "")
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	}
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
 	return home
 }

--- a/internal/control/main_test.go
+++ b/internal/control/main_test.go
@@ -4,12 +4,21 @@ import (
 	"os"
 	"testing"
 
+	"reasonix/internal/testenv"
+
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
+	cleanupUserState, err := testenv.IsolateUserState()
+	if err != nil {
+		panic(err)
+	}
 	if os.Getenv("REASONIX_CREDENTIALS_STORE") == "" {
 		_ = os.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	}
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.Cleanup(func(exitCode int) {
+		cleanupUserState()
+		os.Exit(exitCode)
+	}))
 }

--- a/internal/control/steer_fallback_test.go
+++ b/internal/control/steer_fallback_test.go
@@ -20,7 +20,7 @@ func steerFallbackController(t *testing.T) (*Controller, *agent.Agent) {
 }
 
 func sessionHasUserText(ag *agent.Agent, text string) bool {
-	for _, m := range ag.Session().Messages {
+	for _, m := range ag.Session().Snapshot() {
 		if m.Role == provider.RoleUser && strings.Contains(m.Content, text) {
 			return true
 		}

--- a/internal/doctor/main_test.go
+++ b/internal/doctor/main_test.go
@@ -1,0 +1,11 @@
+package doctor
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -18,21 +18,12 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/skill"
+	"reasonix/internal/testenv"
 	"reasonix/internal/tool"
 )
 
 func TestMain(m *testing.M) {
-	dir, err := os.MkdirTemp("", "reasonix-installsource-test-*")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	_ = os.Setenv("HOME", dir)
-	_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
-	_ = os.Setenv("AppData", filepath.Join(dir, "AppData"))
-	code := m.Run()
-	_ = os.RemoveAll(dir)
-	os.Exit(code)
+	testenv.RunWithIsolatedUserState(m)
 }
 
 func TestPluginGitCommandDisablesLineEndingConversion(t *testing.T) {

--- a/internal/plugin/main_test.go
+++ b/internal/plugin/main_test.go
@@ -1,11 +1,27 @@
 package plugin
 
 import (
+	"os"
 	"testing"
+
+	"reasonix/internal/testenv"
 
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	// MCP helper subprocesses run this same test binary under the sandbox and
+	// inherit the already-isolated parent environment. They must not try to
+	// allocate a second user home outside their allowed roots.
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" || os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
+		os.Exit(m.Run())
+	}
+	cleanupUserState, err := testenv.IsolateUserState()
+	if err != nil {
+		panic(err)
+	}
+	goleak.VerifyTestMain(m, goleak.Cleanup(func(exitCode int) {
+		cleanupUserState()
+		os.Exit(exitCode)
+	}))
 }

--- a/internal/repair/main_test.go
+++ b/internal/repair/main_test.go
@@ -1,0 +1,11 @@
+package repair
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/serve/main_test.go
+++ b/internal/serve/main_test.go
@@ -1,0 +1,11 @@
+package serve
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/skill/main_test.go
+++ b/internal/skill/main_test.go
@@ -1,0 +1,11 @@
+package skill
+
+import (
+	"testing"
+
+	"reasonix/internal/testenv"
+)
+
+func TestMain(m *testing.M) {
+	testenv.RunWithIsolatedUserState(m)
+}

--- a/internal/testenv/home.go
+++ b/internal/testenv/home.go
@@ -1,0 +1,102 @@
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// TestingM is the subset of testing.M needed by RunWithIsolatedUserState.
+type TestingM interface {
+	Run() int
+}
+
+type savedEnvironment struct {
+	value string
+	set   bool
+}
+
+// IsolateUserState redirects default user-scoped Reasonix paths to a disposable
+// home and clears inherited explicit path overrides. Tests may still override
+// any of these variables for a focused scenario after this process-level guard
+// is installed.
+func IsolateUserState() (func(), error) {
+	originalHome, _ := os.UserHomeDir()
+	home, err := os.MkdirTemp(originalHome, ".reasonix-test-home-*")
+	if err != nil && originalHome != "" {
+		home, err = os.MkdirTemp("", "reasonix-test-home-*")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create isolated test home: %w", err)
+	}
+
+	set := map[string]string{
+		"HOME":            home,
+		"USERPROFILE":     home,
+		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"AppData":         filepath.Join(home, "AppData", "Roaming"),
+	}
+	unset := []string{
+		"REASONIX_HOME",
+		"REASONIX_STATE_HOME",
+		"REASONIX_CACHE_HOME",
+	}
+
+	saved := make(map[string]savedEnvironment, len(set)+len(unset))
+	remember := func(key string) {
+		if _, ok := saved[key]; ok {
+			return
+		}
+		value, ok := os.LookupEnv(key)
+		saved[key] = savedEnvironment{value: value, set: ok}
+	}
+	restore := func() {
+		for key, previous := range saved {
+			if previous.set {
+				_ = os.Setenv(key, previous.value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+	fail := func(cause error) (func(), error) {
+		restore()
+		_ = os.RemoveAll(home)
+		return nil, cause
+	}
+
+	for key, value := range set {
+		remember(key)
+		if err := os.Setenv(key, value); err != nil {
+			return fail(fmt.Errorf("set %s for isolated test home: %w", key, err))
+		}
+	}
+	for _, key := range unset {
+		remember(key)
+		if err := os.Unsetenv(key); err != nil {
+			return fail(fmt.Errorf("unset %s for isolated test home: %w", key, err))
+		}
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			restore()
+			_ = os.RemoveAll(home)
+		})
+	}, nil
+}
+
+// RunWithIsolatedUserState runs a package test binary behind the user-state
+// isolation guard and exits with the test result.
+func RunWithIsolatedUserState(m TestingM) {
+	cleanup, err := IsolateUserState()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/testenv/home_test.go
+++ b/internal/testenv/home_test.go
@@ -1,0 +1,48 @@
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsolateUserStateRedirectsAndRestoresCallerEnvironment(t *testing.T) {
+	callerHome := t.TempDir()
+	callerReasonixHome := filepath.Join(callerHome, "explicit-reasonix-home")
+	t.Setenv("HOME", callerHome)
+	t.Setenv("USERPROFILE", callerHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(callerHome, "caller-config"))
+	t.Setenv("AppData", filepath.Join(callerHome, "caller-appdata"))
+	t.Setenv("REASONIX_HOME", callerReasonixHome)
+	t.Setenv("REASONIX_STATE_HOME", filepath.Join(callerHome, "caller-state"))
+	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(callerHome, "caller-cache"))
+
+	cleanup, err := IsolateUserState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	isolateHome := os.Getenv("HOME")
+	if isolateHome == "" || isolateHome == callerHome {
+		t.Fatalf("HOME = %q, want a disposable home distinct from caller %q", isolateHome, callerHome)
+	}
+	if rel, err := filepath.Rel(callerHome, isolateHome); err != nil || rel == ".." || filepath.IsAbs(rel) {
+		t.Fatalf("isolated home %q is not contained by caller home %q", isolateHome, callerHome)
+	}
+	for _, key := range []string{"REASONIX_HOME", "REASONIX_STATE_HOME", "REASONIX_CACHE_HOME"} {
+		if _, ok := os.LookupEnv(key); ok {
+			t.Fatalf("%s remained set inside isolated test process", key)
+		}
+	}
+
+	cleanup()
+	if got := os.Getenv("HOME"); got != callerHome {
+		t.Fatalf("HOME after cleanup = %q, want %q", got, callerHome)
+	}
+	if got := os.Getenv("REASONIX_HOME"); got != callerReasonixHome {
+		t.Fatalf("REASONIX_HOME after cleanup = %q, want %q", got, callerReasonixHome)
+	}
+	if _, err := os.Stat(isolateHome); !os.IsNotExist(err) {
+		t.Fatalf("isolated home still exists after cleanup: %v", err)
+	}
+}

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -12,8 +12,19 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/testenv"
 	"reasonix/internal/tool"
 )
+
+func isolateBuiltinTestUserState(t *testing.T) string {
+	t.Helper()
+	cleanup, err := testenv.IsolateUserState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	return os.Getenv("HOME")
+}
 
 func TestWithin(t *testing.T) {
 	root := filepath.FromSlash("/work/proj")
@@ -163,11 +174,7 @@ func TestWriteFileConfinement(t *testing.T) {
 }
 
 func TestWriteFileDefaultRootsDenyUserConfigUnlessAllowed(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
+	home := isolateBuiltinTestUserState(t)
 
 	project := filepath.Join(home, "project")
 	if err := os.MkdirAll(project, 0o755); err != nil {
@@ -212,11 +219,7 @@ func (s *stubConfigWriteApprover) ApproveManagedConfigWrite(_ context.Context, r
 }
 
 func TestManagedConfigWriteFailsClosedWithoutApprover(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
+	home := isolateBuiltinTestUserState(t)
 
 	project := filepath.Join(home, "project")
 	if err := os.MkdirAll(project, 0o755); err != nil {
@@ -243,11 +246,7 @@ func TestManagedConfigWriteFailsClosedWithoutApprover(t *testing.T) {
 }
 
 func TestManagedConfigWriteGatedOnApprover(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
+	home := isolateBuiltinTestUserState(t)
 
 	project := filepath.Join(home, "project")
 	if err := os.MkdirAll(project, 0o755); err != nil {


### PR DESCRIPTION
## Summary

- Add a shared test-only guard that redirects HOME, USERPROFILE, XDG_CONFIG_HOME, and AppData to a disposable directory.
- Clear inherited REASONIX_HOME, REASONIX_STATE_HOME, and REASONIX_CACHE_HOME in state-writing test packages.
- Preserve sandboxed helper subprocess behavior and add Windows/default-path containment assertions.
- Use the locked session snapshot API in a steer fallback test, fixing a race exposed by the required full-repository race job.

## Root cause

Test isolation was duplicated and incomplete. Several package test binaries could inherit explicit Reasonix paths or platform-specific user paths and write to caller-owned configuration, credentials, session, trust, or cache state. A polling test also read the session message slice directly while a background turn could append to it.

Fixes #6640.

## Verification

- `make test` with external Reasonix home/state/cache sentinels; the configuration hash was unchanged and no unexpected files were created.
- `go test -p=1 ./... -count=1` with external home/state/cache sentinels.
- `go test -race ./internal/testenv ./internal/config ./internal/cli -count=1`.
- `go test -race ./internal/control -count=1`; related steer tests also passed 20 repeated race runs.
- `go vet ./...`.
- `./scripts/check-cache-impact.sh`.

## Cache and prompt impact

Cache-impact: none - only test isolation changes; no runtime prompt, tool registration, or cache behavior changes.
Cache-guard: `./scripts/check-cache-impact.sh` and sentinel-backed `make test`.
System-prompt-review: reviewed by @SivanCola; prompt-sensitive paths contain test-only files and prompt assembly is unchanged.

No runtime persistence format changes.

## Credits

Keeps and adapts the Windows config-path isolation and path-containment coverage from #6518 by @lemonhall.