### PR TITLE
feat(worktree): add reusable lifecycle manager / 增加可复用 Worktree 生命周期管理器

### DIFF
--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -1,0 +1,482 @@
+package worktree
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const resourceMetadataFile = ".reasonix-worktree.json"
+
+// Kind identifies the feature that owns a managed worktree resource.
+type Kind string
+
+const (
+	KindDelivery Kind = "delivery"
+	KindSubagent Kind = "subagent"
+)
+
+// LifecycleState is persisted so crashed or resumed sessions can recover the
+// state of a managed worktree without guessing from UI history.
+type LifecycleState string
+
+const (
+	LifecycleStateCreated LifecycleState = "created"
+	LifecycleStateApplied LifecycleState = "applied"
+	LifecycleStateRemoved LifecycleState = "removed"
+)
+
+// CleanupState describes whether the resource is still present on disk.
+type CleanupState string
+
+const (
+	CleanupStateActive  CleanupState = "active"
+	CleanupStateOrphan  CleanupState = "orphaned"
+	CleanupStateRemoved CleanupState = "removed"
+)
+
+// DirtyPolicy controls how a source workspace with uncommitted changes is
+// handled before a child worktree is created.
+type DirtyPolicy string
+
+const (
+	DirtyPolicyCommittedHead DirtyPolicy = "committed-head"
+	DirtyPolicyReject        DirtyPolicy = "reject"
+)
+
+var (
+	ErrDirtySource   = errors.New("source workspace has uncommitted changes")
+	ErrApplyConflict = errors.New("worktree apply conflict")
+)
+
+// DirtySourceError is returned when policy requires a clean parent workspace.
+type DirtySourceError struct {
+	WorkspaceRoot string
+}
+
+func (e *DirtySourceError) Error() string {
+	if strings.TrimSpace(e.WorkspaceRoot) == "" {
+		return ErrDirtySource.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrDirtySource, e.WorkspaceRoot)
+}
+
+func (e *DirtySourceError) Unwrap() error { return ErrDirtySource }
+
+// CreatePolicy is the stable policy surface for managed worktree creation.
+type CreatePolicy struct {
+	Kind         Kind
+	BranchPrefix string
+	DirtyPolicy  DirtyPolicy
+	Durable      bool
+}
+
+// Resource is the durable identity of one managed worktree.
+type Resource struct {
+	IsolationID    string         `json:"isolation_id"`
+	Kind           Kind           `json:"kind"`
+	WorkspaceRoot  string         `json:"workspace_root"`
+	WorktreeRoot   string         `json:"worktree_root"`
+	SourceRoot     string         `json:"source_root"`
+	Branch         string         `json:"branch"`
+	BaseCommit     string         `json:"base_commit"`
+	HeadCommit     string         `json:"head_commit"`
+	SourceDirty    bool           `json:"source_dirty"`
+	LifecycleState LifecycleState `json:"lifecycle_state"`
+	CleanupState   CleanupState   `json:"cleanup_state"`
+	CreatedAt      time.Time      `json:"created_at"`
+
+	metadataPath string
+}
+
+// Status reports the current diff surface without mutating either workspace.
+type Status struct {
+	Dirty   bool     `json:"dirty"`
+	Paths   []string `json:"paths,omitempty"`
+	RawText string   `json:"raw_text,omitempty"`
+}
+
+// Diff contains the patch text and path list for explicit review/apply.
+type Diff struct {
+	Patch string   `json:"patch,omitempty"`
+	Paths []string `json:"paths,omitempty"`
+}
+
+// ApplyStatus is a structured apply result, not just a human string.
+type ApplyStatus string
+
+const (
+	ApplyStatusClean      ApplyStatus = "clean"
+	ApplyStatusApplied    ApplyStatus = "applied"
+	ApplyStatusConflicted ApplyStatus = "conflicted"
+	ApplyStatusBlocked    ApplyStatus = "blocked"
+)
+
+// ApplyResult describes the outcome of applying a child worktree patch back to
+// its source repository.
+type ApplyResult struct {
+	Status          ApplyStatus `json:"status"`
+	Paths           []string    `json:"paths,omitempty"`
+	ConflictedPaths []string    `json:"conflicted_paths,omitempty"`
+	Message         string      `json:"message,omitempty"`
+}
+
+// ApplyConflictError carries a structured conflict result.
+type ApplyConflictError struct {
+	Result ApplyResult
+}
+
+func (e *ApplyConflictError) Error() string {
+	if len(e.Result.ConflictedPaths) == 0 {
+		return ErrApplyConflict.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrApplyConflict, strings.Join(e.Result.ConflictedPaths, ", "))
+}
+
+func (e *ApplyConflictError) Unwrap() error { return ErrApplyConflict }
+
+// Manager owns the durable lifecycle for worktrees under one managed root.
+type Manager struct {
+	managedRoot string
+}
+
+// NewManager creates a worktree manager rooted at managedRoot.
+func NewManager(managedRoot string) *Manager {
+	return &Manager{managedRoot: strings.TrimSpace(managedRoot)}
+}
+
+func (m *Manager) managedRootOrError() (string, error) {
+	if m == nil || strings.TrimSpace(m.managedRoot) == "" {
+		return "", errors.New("Reasonix worktree storage is unavailable")
+	}
+	return m.managedRoot, nil
+}
+
+// Inspect checks whether workspaceRoot can be used as a source worktree.
+func (m *Manager) Inspect(ctx context.Context, workspaceRoot string) Availability {
+	return Inspect(ctx, workspaceRoot)
+}
+
+// Create makes a managed worktree resource according to policy.
+func (m *Manager) Create(ctx context.Context, workspaceRoot string, policy CreatePolicy) (Resource, error) {
+	managedRoot, err := m.managedRootOrError()
+	if err != nil {
+		return Resource{}, err
+	}
+	policy = normalizeCreatePolicy(policy)
+	info, err := inspect(ctx, workspaceRoot)
+	if err != nil {
+		return Resource{}, err
+	}
+	if info.SourceDirty && policy.DirtyPolicy == DirtyPolicyReject {
+		return Resource{}, &DirtySourceError{WorkspaceRoot: info.RepoRoot}
+	}
+	if err := os.MkdirAll(managedRoot, 0o700); err != nil {
+		return Resource{}, fmt.Errorf("create Reasonix worktree storage: %w", err)
+	}
+
+	repoKey := repoStorageKey(info.commonDir)
+	repoBase := safePathComponent(filepath.Base(info.RepoRoot))
+	if repoBase == "" {
+		repoBase = "repository"
+	}
+
+	now := time.Now().UTC()
+	for attempt := 0; attempt < 5; attempt++ {
+		id, randomErr := randomID()
+		if randomErr != nil {
+			return Resource{}, randomErr
+		}
+		branch := fmt.Sprintf("%s-%s-%s", strings.TrimRight(policy.BranchPrefix, "-/"), now.Format("20060102-150405"), id)
+		worktreeRoot := filepath.Join(managedRoot, repoKey, id, repoBase)
+		if _, statErr := os.Stat(worktreeRoot); statErr == nil {
+			continue
+		} else if !os.IsNotExist(statErr) {
+			return Resource{}, fmt.Errorf("inspect worktree destination: %w", statErr)
+		}
+		if err := os.MkdirAll(filepath.Dir(worktreeRoot), 0o700); err != nil {
+			return Resource{}, fmt.Errorf("create worktree parent: %w", err)
+		}
+
+		_, stderr, addErr := runGit(ctx, info.RepoRoot, "worktree", "add", "-b", branch, worktreeRoot, info.head)
+		if addErr != nil {
+			if strings.Contains(strings.ToLower(stderr), "already exists") {
+				continue
+			}
+			return Resource{}, fmt.Errorf("create Git worktree: %w%s", addErr, stderrSuffix(stderr))
+		}
+
+		selectedRoot := worktreeRoot
+		if prefix := filepath.FromSlash(strings.Trim(strings.TrimSpace(info.prefix), "/")); prefix != "" && prefix != "." {
+			selectedRoot = filepath.Join(worktreeRoot, prefix)
+			st, statErr := os.Stat(selectedRoot)
+			if statErr != nil || !st.IsDir() {
+				return Resource{}, fmt.Errorf("created worktree is missing selected project subdirectory %q", prefix)
+			}
+		}
+		res := Resource{
+			IsolationID:    id,
+			Kind:           policy.Kind,
+			WorkspaceRoot:  selectedRoot,
+			WorktreeRoot:   worktreeRoot,
+			SourceRoot:     info.RepoRoot,
+			Branch:         branch,
+			BaseCommit:     info.head,
+			HeadCommit:     info.head,
+			SourceDirty:    info.SourceDirty,
+			LifecycleState: LifecycleStateCreated,
+			CleanupState:   CleanupStateActive,
+			CreatedAt:      now,
+			metadataPath:   resourceMetadataPath(managedRoot, repoKey, id),
+		}
+		if err := m.writeResource(res); err != nil {
+			return Resource{}, err
+		}
+		return res, nil
+	}
+	return Resource{}, fmt.Errorf("could not allocate a unique %s worktree", policy.Kind)
+}
+
+// Show returns a resource by id.
+func (m *Manager) Show(ctx context.Context, isolationID string) (Resource, error) {
+	isolationID = strings.TrimSpace(isolationID)
+	if isolationID == "" {
+		return Resource{}, errors.New("worktree isolation id is required")
+	}
+	resources, err := m.List(ctx)
+	if err != nil {
+		return Resource{}, err
+	}
+	for _, res := range resources {
+		if res.IsolationID == isolationID {
+			return res, nil
+		}
+	}
+	return Resource{}, fmt.Errorf("worktree isolation %q was not found", isolationID)
+}
+
+// List returns persisted worktree resources, including removed records.
+func (m *Manager) List(ctx context.Context) ([]Resource, error) {
+	managedRoot, err := m.managedRootOrError()
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	var resources []Resource
+	if _, err := os.Stat(managedRoot); os.IsNotExist(err) {
+		return resources, nil
+	} else if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(managedRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != resourceMetadataFile {
+			return nil
+		}
+		res, readErr := readResource(path)
+		if readErr != nil {
+			return readErr
+		}
+		if res.CleanupState == CleanupStateActive {
+			if _, statErr := os.Stat(res.WorktreeRoot); os.IsNotExist(statErr) {
+				res.CleanupState = CleanupStateOrphan
+			}
+		}
+		res.metadataPath = path
+		resources = append(resources, res)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].CreatedAt.Equal(resources[j].CreatedAt) {
+			return resources[i].IsolationID < resources[j].IsolationID
+		}
+		return resources[i].CreatedAt.Before(resources[j].CreatedAt)
+	})
+	return resources, nil
+}
+
+// Status returns a porcelain status for the child worktree.
+func (m *Manager) Status(ctx context.Context, res Resource) (Status, error) {
+	if strings.TrimSpace(res.WorktreeRoot) == "" {
+		return Status{}, errors.New("worktree root is required")
+	}
+	out, stderr, err := runGit(ctx, res.WorktreeRoot, "status", "--porcelain=v1", "--untracked-files=normal")
+	if err != nil {
+		return Status{}, fmt.Errorf("inspect worktree status: %w%s", err, stderrSuffix(stderr))
+	}
+	paths := parsePorcelainPaths(out)
+	return Status{Dirty: strings.TrimSpace(out) != "", Paths: paths, RawText: strings.TrimRight(out, "\n")}, nil
+}
+
+// Diff returns the tracked patch plus changed paths. Untracked files are listed
+// in Paths but are deliberately not in Patch.
+func (m *Manager) Diff(ctx context.Context, res Resource) (Diff, error) {
+	status, err := m.Status(ctx, res)
+	if err != nil {
+		return Diff{}, err
+	}
+	patch, stderr, err := runGit(ctx, res.WorktreeRoot, "diff", "--binary", "HEAD")
+	if err != nil {
+		return Diff{}, fmt.Errorf("build worktree diff: %w%s", err, stderrSuffix(stderr))
+	}
+	return Diff{Patch: patch, Paths: status.Paths}, nil
+}
+
+// Apply explicitly applies a clean child worktree patch back to the source repo.
+func (m *Manager) Apply(ctx context.Context, res Resource) (ApplyResult, error) {
+	status, err := m.Status(ctx, res)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if !status.Dirty {
+		return ApplyResult{Status: ApplyStatusClean}, nil
+	}
+	untracked := untrackedPaths(status.RawText)
+	if len(untracked) > 0 {
+		return ApplyResult{Status: ApplyStatusBlocked, Paths: status.Paths, Message: "untracked files must be handled before apply"}, errors.New("cannot apply worktree with untracked files")
+	}
+	diff, err := m.Diff(ctx, res)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if strings.TrimSpace(diff.Patch) == "" {
+		return ApplyResult{Status: ApplyStatusBlocked, Paths: status.Paths, Message: "no tracked patch is available"}, errors.New("no tracked patch is available")
+	}
+	if _, stderr, checkErr := runGitInput(ctx, res.SourceRoot, []byte(diff.Patch), "apply", "--check", "-"); checkErr != nil {
+		result := ApplyResult{
+			Status:          ApplyStatusConflicted,
+			Paths:           diff.Paths,
+			ConflictedPaths: diff.Paths,
+			Message:         strings.TrimSpace(stderr),
+		}
+		return result, &ApplyConflictError{Result: result}
+	}
+	if _, stderr, applyErr := runGitInput(ctx, res.SourceRoot, []byte(diff.Patch), "apply", "-"); applyErr != nil {
+		return ApplyResult{}, fmt.Errorf("apply worktree diff: %w%s", applyErr, stderrSuffix(stderr))
+	}
+	res.LifecycleState = LifecycleStateApplied
+	if err := m.writeResource(res); err != nil {
+		return ApplyResult{}, err
+	}
+	return ApplyResult{Status: ApplyStatusApplied, Paths: diff.Paths}, nil
+}
+
+func (m *Manager) writeResource(res Resource) error {
+	path := res.metadataPath
+	if path == "" {
+		managedRoot, err := m.managedRootOrError()
+		if err != nil {
+			return err
+		}
+		repoKey := repoStorageKey(res.SourceRoot)
+		path = resourceMetadataPath(managedRoot, repoKey, res.IsolationID)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create worktree metadata directory: %w", err)
+	}
+	data, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode worktree metadata: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write worktree metadata: %w", err)
+	}
+	return nil
+}
+
+func normalizeCreatePolicy(policy CreatePolicy) CreatePolicy {
+	if policy.Kind == "" {
+		policy.Kind = KindDelivery
+	}
+	if policy.BranchPrefix == "" {
+		switch policy.Kind {
+		case KindSubagent:
+			policy.BranchPrefix = "reasonix/subagent"
+		default:
+			policy.BranchPrefix = "reasonix/delivery"
+		}
+	}
+	if policy.DirtyPolicy == "" {
+		switch policy.Kind {
+		case KindSubagent:
+			policy.DirtyPolicy = DirtyPolicyReject
+		default:
+			policy.DirtyPolicy = DirtyPolicyCommittedHead
+		}
+	}
+	return policy
+}
+
+func repoStorageKey(commonDir string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(strings.TrimSpace(commonDir))))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func readResource(path string) (Resource, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Resource{}, err
+	}
+	var res Resource
+	if err := json.Unmarshal(data, &res); err != nil {
+		return Resource{}, fmt.Errorf("decode worktree metadata %s: %w", path, err)
+	}
+	res.metadataPath = path
+	return res, nil
+}
+
+func resourceMetadataPath(managedRoot, repoKey, id string) string {
+	return filepath.Join(managedRoot, repoKey, id, resourceMetadataFile)
+}
+
+func parsePorcelainPaths(out string) []string {
+	var paths []string
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		path := line
+		if len(line) > 3 {
+			path = line[3:]
+		}
+		path = strings.TrimSpace(path)
+		if before, after, ok := strings.Cut(path, " -> "); ok {
+			_ = before
+			path = strings.TrimSpace(after)
+		}
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func untrackedPaths(porcelain string) []string {
+	var paths []string
+	for _, line := range strings.Split(strings.TrimRight(porcelain, "\n"), "\n") {
+		if strings.HasPrefix(line, "?? ") {
+			paths = append(paths, strings.TrimSpace(line[3:]))
+		}
+	}
+	return paths
+}

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -136,7 +136,7 @@ func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sourceBytes) != "first writer\n" {
+	if strings.ReplaceAll(string(sourceBytes), "\r\n", "\n") != "first writer\n" {
 		t.Fatalf("source content after clean apply = %q", sourceBytes)
 	}
 
@@ -154,7 +154,7 @@ func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sourceBytes) != "first writer\n" {
+	if strings.ReplaceAll(string(sourceBytes), "\r\n", "\n") != "first writer\n" {
 		t.Fatalf("conflicting apply polluted source content = %q", sourceBytes)
 	}
 	status := gitStatus(t, repo)

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,0 +1,196 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagerRejectsDirtySourceForSubagentWorktree(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManager(t.TempDir())
+	_, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if !errors.Is(err, ErrDirtySource) {
+		t.Fatalf("Create err = %v, want ErrDirtySource", err)
+	}
+	list, listErr := mgr.List(ctx)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(list) != 0 {
+		t.Fatalf("dirty source should not create resources, got %d", len(list))
+	}
+}
+
+func TestManagerCreatesInspectableSubagentResource(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	managed := t.TempDir()
+	mgr := NewManager(managed)
+
+	res, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kind != KindSubagent {
+		t.Fatalf("kind = %q", res.Kind)
+	}
+	if res.IsolationID == "" {
+		t.Fatal("isolation id is empty")
+	}
+	if !strings.HasPrefix(res.Branch, "reasonix/subagent-") {
+		t.Fatalf("branch = %q", res.Branch)
+	}
+	if res.WorkspaceRoot != res.WorktreeRoot {
+		t.Fatalf("workspace root = %q, worktree root = %q", res.WorkspaceRoot, res.WorktreeRoot)
+	}
+	if res.SourceRoot == res.WorktreeRoot || res.SourceRoot == "" {
+		t.Fatalf("source root = %q, worktree root = %q", res.SourceRoot, res.WorktreeRoot)
+	}
+	if res.BaseCommit == "" || res.HeadCommit == "" || res.BaseCommit != res.HeadCommit {
+		t.Fatalf("commits = base %q head %q", res.BaseCommit, res.HeadCommit)
+	}
+	if res.LifecycleState != LifecycleStateCreated || res.CleanupState != CleanupStateActive || res.CreatedAt.IsZero() {
+		t.Fatalf("unexpected lifecycle: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(res.WorktreeRoot, "README.md")); err != nil {
+		t.Fatalf("worktree missing committed file: %v", err)
+	}
+
+	list, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].IsolationID != res.IsolationID {
+		t.Fatalf("List = %+v, want one resource %q", list, res.IsolationID)
+	}
+	shown, err := mgr.Show(ctx, res.IsolationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shown.Branch != res.Branch {
+		t.Fatalf("Show branch = %q, want %q", shown.Branch, res.Branch)
+	}
+	status, err := mgr.Status(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dirty {
+		t.Fatalf("new worktree status dirty: %+v", status)
+	}
+
+	if err := os.WriteFile(filepath.Join(res.WorktreeRoot, "README.md"), []byte("child edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	status, err = mgr.Status(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Dirty || len(status.Paths) != 1 || status.Paths[0] != "README.md" {
+		t.Fatalf("dirty status = %+v", status)
+	}
+	diff, err := mgr.Diff(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(diff.Patch, "+child edit") || len(diff.Paths) != 1 || diff.Paths[0] != "README.md" {
+		t.Fatalf("diff = %+v", diff)
+	}
+}
+
+func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	mgr := NewManager(t.TempDir())
+
+	first, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(first.WorktreeRoot, "README.md"), []byte("first writer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := mgr.Apply(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != ApplyStatusApplied || len(result.Paths) != 1 || result.Paths[0] != "README.md" {
+		t.Fatalf("first apply result = %+v", result)
+	}
+	sourceBytes, err := os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceBytes) != "first writer\n" {
+		t.Fatalf("source content after clean apply = %q", sourceBytes)
+	}
+
+	if err := os.WriteFile(filepath.Join(second.WorktreeRoot, "README.md"), []byte("second writer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err = mgr.Apply(ctx, second)
+	if !errors.Is(err, ErrApplyConflict) {
+		t.Fatalf("second apply err = %v, want ErrApplyConflict", err)
+	}
+	if result.Status != ApplyStatusConflicted || len(result.ConflictedPaths) != 1 || result.ConflictedPaths[0] != "README.md" {
+		t.Fatalf("second apply result = %+v", result)
+	}
+	sourceBytes, err = os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceBytes) != "first writer\n" {
+		t.Fatalf("conflicting apply polluted source content = %q", sourceBytes)
+	}
+	status := gitStatus(t, repo)
+	if strings.Contains(status, "UU ") || strings.Contains(status, "<<<<<<<") {
+		t.Fatalf("source repo has unresolved conflict state: %q", status)
+	}
+}
+
+func TestLegacyCreateUsesDeliveryPolicyAndAllowsDirtyCommittedHead(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "scratch.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Create(ctx, repo, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result.Branch, "reasonix/delivery-") {
+		t.Fatalf("branch = %q", result.Branch)
+	}
+	if !result.SourceDirty {
+		t.Fatalf("SourceDirty = false, want true")
+	}
+	if _, err := os.Stat(filepath.Join(result.WorktreeRoot, "scratch.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty source file must not be copied, stat err = %v", err)
+	}
+}
+
+func gitStatus(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "status", "--porcelain=v1", "--untracked-files=normal")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	return string(out)
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -67,70 +66,22 @@ func Inspect(ctx context.Context, workspaceRoot string) Availability {
 // subdirectory, Result.WorkspaceRoot points at the corresponding subdirectory
 // in the new worktree.
 func Create(ctx context.Context, workspaceRoot, managedRoot string) (Result, error) {
-	info, err := inspect(ctx, workspaceRoot)
+	res, err := NewManager(managedRoot).Create(ctx, workspaceRoot, CreatePolicy{
+		Kind:        KindDelivery,
+		DirtyPolicy: DirtyPolicyCommittedHead,
+		Durable:     true,
+	})
 	if err != nil {
 		return Result{}, err
 	}
-	managedRoot = strings.TrimSpace(managedRoot)
-	if managedRoot == "" {
-		return Result{}, errors.New("Reasonix worktree storage is unavailable")
-	}
-	if err := os.MkdirAll(managedRoot, 0o700); err != nil {
-		return Result{}, fmt.Errorf("create Reasonix worktree storage: %w", err)
-	}
-
-	repoSum := sha256.Sum256([]byte(info.commonDir))
-	repoKey := hex.EncodeToString(repoSum[:8])
-	repoBase := safePathComponent(filepath.Base(info.RepoRoot))
-	if repoBase == "" {
-		repoBase = "repository"
-	}
-
-	for attempt := 0; attempt < 5; attempt++ {
-		id, randomErr := randomID()
-		if randomErr != nil {
-			return Result{}, randomErr
-		}
-		branch := fmt.Sprintf("reasonix/delivery-%s-%s", time.Now().Format("20060102-150405"), id)
-		worktreeRoot := filepath.Join(managedRoot, repoKey, id, repoBase)
-		if _, statErr := os.Stat(worktreeRoot); statErr == nil {
-			continue
-		} else if !os.IsNotExist(statErr) {
-			return Result{}, fmt.Errorf("inspect worktree destination: %w", statErr)
-		}
-		if err := os.MkdirAll(filepath.Dir(worktreeRoot), 0o700); err != nil {
-			return Result{}, fmt.Errorf("create worktree parent: %w", err)
-		}
-
-		_, stderr, addErr := runGit(ctx, info.RepoRoot, "worktree", "add", "-b", branch, worktreeRoot, info.head)
-		if addErr != nil {
-			// A random branch collision is retryable. We deliberately leave any
-			// non-empty partial directory untouched rather than risk deleting user
-			// data after Git returned an ambiguous failure.
-			if strings.Contains(strings.ToLower(stderr), "already exists") {
-				continue
-			}
-			return Result{}, fmt.Errorf("create Git worktree: %w%s", addErr, stderrSuffix(stderr))
-		}
-
-		selectedRoot := worktreeRoot
-		if prefix := filepath.FromSlash(strings.Trim(strings.TrimSpace(info.prefix), "/")); prefix != "" && prefix != "." {
-			selectedRoot = filepath.Join(worktreeRoot, prefix)
-			st, statErr := os.Stat(selectedRoot)
-			if statErr != nil || !st.IsDir() {
-				return Result{}, fmt.Errorf("created worktree is missing selected project subdirectory %q", prefix)
-			}
-		}
-		return Result{
-			WorkspaceRoot: selectedRoot,
-			WorktreeRoot:  worktreeRoot,
-			SourceRoot:    info.RepoRoot,
-			Branch:        branch,
-			Head:          info.head,
-			SourceDirty:   info.SourceDirty,
-		}, nil
-	}
-	return Result{}, errors.New("could not allocate a unique Delivery worktree")
+	return Result{
+		WorkspaceRoot: res.WorkspaceRoot,
+		WorktreeRoot:  res.WorktreeRoot,
+		SourceRoot:    res.SourceRoot,
+		Branch:        res.Branch,
+		Head:          res.BaseCommit,
+		SourceDirty:   res.SourceDirty,
+	}, nil
 }
 
 // IsManagedPath reports whether path belongs to Reasonix's durable worktree
@@ -235,6 +186,25 @@ func runGit(parent context.Context, dir string, args ...string) (stdout, stderr 
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", gitCommandArgs(runtime.GOOS, dir, args...)...)
 	proc.HideWindow(cmd)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return outBuf.String(), strings.TrimSpace(errBuf.String()), err
+}
+
+func runGitInput(parent context.Context, dir string, input []byte, args ...string) (stdout, stderr string, err error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, gitTimeout(args))
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", gitCommandArgs(runtime.GOOS, dir, args...)...)
+	proc.HideWindow(cmd)
+	cmd.Stdin = bytes.NewReader(input)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
## Summary / 摘要

Introduce a reusable core worktree lifecycle manager without changing existing Desktop Delivery semantics.

在不改变现有 Desktop Delivery 语义的前提下，新增可由其他内核能力复用的 Worktree 生命周期管理器。

## What changed / 变更内容

- Add structured resource identity and lifecycle state.
- Support inspect, create, list/show, status/diff, apply, discard/remove, and orphan GC primitives.
- Preserve durable delivery worktrees and committed-HEAD behavior.
- Keep dirty-source handling explicit instead of silently copying uncommitted files.
- Add focused lifecycle and compatibility tests.

- 增加结构化资源身份、生命周期状态与清理状态。
- 提供 inspect、create、list/show、status/diff、apply、discard/remove 和孤儿资源 GC 基础能力。
- 保持现有 Delivery worktree 的持久化及 committed HEAD 语义。
- 对 dirty source 显式处理，不静默复制未提交文件。
- 增加生命周期与兼容性测试。

## Compatibility / 兼容性

This PR does not enable subagent isolation and does not change any default user behavior. A follow-up PR will consume this manager from the subagent runtime.

本 PR 不启用 Subagent 隔离，也不改变默认用户行为；后续 PR 将在 Subagent runtime 中复用该 Manager。

## Validation / 验证

```sh
git diff --check
go test -count=1 ./internal/worktree
```