### PR TITLE
feat(subagent): add opt-in worktree isolation / 增加可选 Subagent Worktree 隔离

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -47,6 +47,13 @@ type SubagentMeta struct {
 	ToolSchemaHash   string         `json:"toolSchemaHash"`
 	Model            string         `json:"model"`
 	Effort           string         `json:"effort"`
+	Isolation        string         `json:"isolation,omitempty"` // none | worktree
+	IsolationID      string         `json:"isolationId,omitempty"`
+	WorktreeRoot     string         `json:"worktreeRoot,omitempty"`
+	SourceRoot       string         `json:"sourceRoot,omitempty"`
+	WorktreeBranch   string         `json:"worktreeBranch,omitempty"`
+	BaseCommit       string         `json:"baseCommit,omitempty"`
+	HeadCommit       string         `json:"headCommit,omitempty"`
 }
 
 // SubagentSpec describes the current invocation identity.
@@ -60,6 +67,13 @@ type SubagentSpec struct {
 	Registry         *tool.Registry
 	Model            string
 	Effort           string
+	Isolation        string
+	IsolationID      string
+	WorktreeRoot     string
+	SourceRoot       string
+	WorktreeBranch   string
+	BaseCommit       string
+	HeadCommit       string
 }
 
 // SubagentRun is a prepared transcript run. Call Release exactly once.
@@ -594,6 +608,13 @@ func metaFromSpec(ref string, status SubagentStatus, created, updated time.Time,
 		ToolSchemaHash:   schemaHash,
 		Model:            strings.TrimSpace(spec.Model),
 		Effort:           strings.TrimSpace(spec.Effort),
+		Isolation:        normalizeSubagentMetaIsolation(spec.Isolation),
+		IsolationID:      strings.TrimSpace(spec.IsolationID),
+		WorktreeRoot:     strings.TrimSpace(spec.WorktreeRoot),
+		SourceRoot:       strings.TrimSpace(spec.SourceRoot),
+		WorktreeBranch:   strings.TrimSpace(spec.WorktreeBranch),
+		BaseCommit:       strings.TrimSpace(spec.BaseCommit),
+		HeadCommit:       strings.TrimSpace(spec.HeadCommit),
 	}
 }
 
@@ -623,8 +644,28 @@ func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
 		return fmt.Errorf("subagent reference %q uses different tool schemas", meta.Ref)
 	case meta.Model != want.Model || meta.Effort != want.Effort:
 		return fmt.Errorf("subagent reference %q uses model/effort %q/%q, current run would use %q/%q", meta.Ref, meta.Model, meta.Effort, want.Model, want.Effort)
+	case normalizeSubagentMetaIsolation(meta.Isolation) != normalizeSubagentMetaIsolation(want.Isolation):
+		return fmt.Errorf("subagent reference %q uses isolation %q, current run would use %q", meta.Ref, normalizeSubagentMetaIsolation(meta.Isolation), normalizeSubagentMetaIsolation(want.Isolation))
+	case strings.TrimSpace(meta.IsolationID) != strings.TrimSpace(want.IsolationID):
+		return fmt.Errorf("subagent reference %q belongs to isolation %q, current run would use %q", meta.Ref, meta.IsolationID, want.IsolationID)
+	case strings.TrimSpace(meta.WorktreeRoot) != strings.TrimSpace(want.WorktreeRoot):
+		return fmt.Errorf("subagent reference %q belongs to worktree %q, current run would use %q", meta.Ref, meta.WorktreeRoot, want.WorktreeRoot)
+	case strings.TrimSpace(meta.SourceRoot) != strings.TrimSpace(want.SourceRoot):
+		return fmt.Errorf("subagent reference %q belongs to source root %q, current run would use %q", meta.Ref, meta.SourceRoot, want.SourceRoot)
+	case strings.TrimSpace(meta.WorktreeBranch) != strings.TrimSpace(want.WorktreeBranch):
+		return fmt.Errorf("subagent reference %q belongs to branch %q, current run would use %q", meta.Ref, meta.WorktreeBranch, want.WorktreeBranch)
+	case strings.TrimSpace(meta.BaseCommit) != strings.TrimSpace(want.BaseCommit):
+		return fmt.Errorf("subagent reference %q belongs to base commit %q, current run would use %q", meta.Ref, meta.BaseCommit, want.BaseCommit)
 	}
 	return nil
+}
+
+func normalizeSubagentMetaIsolation(v string) string {
+	v = strings.TrimSpace(strings.ToLower(v))
+	if v == "" {
+		return "none"
+	}
+	return v
 }
 
 func requireParentSession(spec SubagentSpec) error {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -690,6 +690,46 @@ func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 	}
 }
 
+func TestSubagentStoreContinuePreservesWorktreeIdentity(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "writer")
+	spec.WorkspaceRoot = "/tmp/reasonix-isolated-workspace"
+	spec.Isolation = "worktree"
+	spec.IsolationID = "iso-contract"
+	spec.WorktreeRoot = "/tmp/reasonix-isolated-worktree"
+	spec.SourceRoot = "/tmp/reasonix-source"
+	spec.WorktreeBranch = "reasonix/subagent-contract"
+	spec.BaseCommit = "base123"
+	spec.HeadCommit = "head456"
+
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+
+	continued, err := store.PrepareContinue(ref, spec)
+	if err != nil {
+		t.Fatalf("PrepareContinue: %v", err)
+	}
+	if continued.Meta.Isolation != spec.Isolation || continued.Meta.IsolationID != spec.IsolationID ||
+		continued.Meta.WorktreeRoot != spec.WorktreeRoot || continued.Meta.SourceRoot != spec.SourceRoot ||
+		continued.Meta.WorktreeBranch != spec.WorktreeBranch || continued.Meta.BaseCommit != spec.BaseCommit {
+		t.Fatalf("continued worktree identity changed: %+v", continued.Meta)
+	}
+	continued.Release()
+
+	mismatch := spec
+	mismatch.IsolationID = "iso-other"
+	if _, err := store.PrepareContinue(ref, mismatch); err == nil || !strings.Contains(err.Error(), "belongs to isolation") {
+		t.Fatalf("isolation mismatch error = %v, want structured identity rejection", err)
+	}
+}
+
 func saveTestBranchMeta(t *testing.T, sessionDir, id, parent string) {
 	t.Helper()
 	if err := SaveBranchMeta(filepath.Join(sessionDir, id+".jsonl"), BranchMeta{ParentID: parent}); err != nil {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 	"reasonix/internal/workspacelease"
+	"reasonix/internal/worktree"
 )
 
 // DefaultTaskSystemPrompt steers a sub-agent toward focused, terse delivery —
@@ -77,12 +78,24 @@ var readOnlySubagentWorkflowTools = []string{
 const subagentToolBoundarySummary = "Recursive agent/skill tools are exposed only while max_subagent_depth leaves another delegation layer; unsupported background job tools (parallel_tasks, wait, bash_output, kill_shell) are excluded; bash is exposed as foreground-only inside subagents."
 
 // maxConcurrentBackgroundTasks bounds writer-capable background sub-agents per
-// session. They all mutate the same workspace (there is no worktree isolation),
-// so a wide fan-out risks conflicting concurrent writes — and feeds the failure
-// cascade where every "needs attention" notice tempts the model into spawning
-// yet more repair tasks. Further sub-tasks can run in the foreground, or start
-// once a running job is collected with wait.
+// session. The default still shares the parent workspace; callers can opt into
+// explicit worktree isolation when they need reviewable parallel writes. A wide
+// fan-out still risks failure cascades where every "needs attention" notice
+// tempts the model into spawning yet more repair tasks. Further sub-tasks can
+// run in the foreground, or start once a running job is collected with wait.
 const maxConcurrentBackgroundTasks = 3
+
+type SubagentIsolation string
+
+const (
+	SubagentIsolationNone     SubagentIsolation = "none"
+	SubagentIsolationWorktree SubagentIsolation = "worktree"
+)
+
+// SubagentRegistryFactory rebuilds the child registry for a concrete workspace
+// root. It lets file and shell tools bind to an isolated worktree while keeping
+// the canonical parent registry and ToolKind filtering rules.
+type SubagentRegistryFactory func(ctx context.Context, workspaceRoot string, names []string, childDepth, maxDepth int) (*tool.Registry, error)
 
 // AlwaysHiddenSubagentTools returns the tool names excluded from every
 // subagent's registry regardless of an explicit allowlist or delegation
@@ -207,32 +220,34 @@ func (readOnlyBash) ReadOnly() bool { return true }
 // parallel research across independent areas (the parallel-dispatch path picks
 // these up only when readOnly, which task is not).
 type TaskTool struct {
-	prov                provider.Provider
-	pricing             *provider.Pricing
-	parentReg           *tool.Registry
-	maxSteps            int
-	contextWindow       int
-	softCompactRatio    float64
-	toolResultSnipRatio float64
-	compactRatio        float64
-	compactForceRatio   float64
-	recentKeep          int
-	temperature         float64
-	archiveDir          string
-	keepPolicy          KeepPolicy
-	sysPrompt           string
-	gate                Gate
-	subagentModel       string
-	subagentEffort      string
-	resolveProvider     func(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error)
-	transcripts         *SubagentStore
-	workspaceRoot       string
-	baseModel           string
-	baseEffort          string
-	identityProfile     func(modelRef, effort string) (string, string)
-	maxSubagentDepth    int
-	deliveryProfile     bool
-	workspaceLease      *workspacelease.Owner
+	prov                         provider.Provider
+	pricing                      *provider.Pricing
+	parentReg                    *tool.Registry
+	maxSteps                     int
+	contextWindow                int
+	softCompactRatio             float64
+	toolResultSnipRatio          float64
+	compactRatio                 float64
+	compactForceRatio            float64
+	recentKeep                   int
+	temperature                  float64
+	archiveDir                   string
+	keepPolicy                   KeepPolicy
+	sysPrompt                    string
+	gate                         Gate
+	subagentModel                string
+	subagentEffort               string
+	resolveProvider              func(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error)
+	transcripts                  *SubagentStore
+	workspaceRoot                string
+	baseModel                    string
+	baseEffort                   string
+	identityProfile              func(modelRef, effort string) (string, string)
+	maxSubagentDepth             int
+	deliveryProfile              bool
+	workspaceLease               *workspacelease.Owner
+	worktreeManager              *worktree.Manager
+	subagentRegistryForWorkspace SubagentRegistryFactory
 }
 
 // NewTaskTool wires a task tool to the parent agent's environment so its
@@ -308,6 +323,15 @@ func (t *TaskTool) WithWorkspaceLease(owner *workspacelease.Owner) *TaskTool {
 	return t
 }
 
+// WithWorkspaceIsolation lets writer-capable subagents opt into a worktree
+// workspace root while preserving the canonical parent registry and filtering
+// contract. Passing nil keeps isolation unavailable.
+func (t *TaskTool) WithWorkspaceIsolation(manager *worktree.Manager, factory SubagentRegistryFactory) *TaskTool {
+	t.worktreeManager = manager
+	t.subagentRegistryForWorkspace = factory
+	return t
+}
+
 func (t *TaskTool) Name() string { return "task" }
 
 func (t *TaskTool) Description() string {
@@ -323,6 +347,7 @@ func (t *TaskTool) Schema() json.RawMessage {
   "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. ` + subagentToolBoundarySummary + `"},
   "max_steps":{"type":"integer","description":"Optional cap on tool-call rounds. Defaults to half the parent's cap (min 5).","minimum":1},
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
+  "isolation":{"type":"string","enum":["none","worktree"],"description":"Optional filesystem isolation for writer subagents. Defaults to none. ` + string(SubagentIsolationWorktree) + ` creates a Git worktree resource; applying its diff back to the parent workspace is a separate explicit operation."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
   "continue_from":{"type":"string","description":"Continue a prior compatible subagent transcript in the current conversation context. Pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. If the ref belongs to an ancestor conversation, the framework continues a current-conversation copy."}
@@ -472,6 +497,17 @@ func (t *TaskTool) effectiveProfile(model, effort string) (string, string) {
 	return model, effort
 }
 
+func normalizeSubagentIsolation(raw string) (SubagentIsolation, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", string(SubagentIsolationNone):
+		return SubagentIsolationNone, nil
+	case string(SubagentIsolationWorktree):
+		return SubagentIsolationWorktree, nil
+	default:
+		return "", fmt.Errorf("unsupported subagent isolation %q (expected %q or %q)", raw, SubagentIsolationNone, SubagentIsolationWorktree)
+	}
+}
+
 func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
 		Prompt          string   `json:"prompt"`
@@ -483,12 +519,17 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		Effort          string   `json:"effort"`
 		ContinueFrom    string   `json:"continue_from"`
 		ForkFrom        string   `json:"fork_from"`
+		Isolation       string   `json:"isolation"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
 	}
 	if p.Prompt == "" {
 		return "", fmt.Errorf("prompt is required")
+	}
+	isolation, err := normalizeSubagentIsolation(p.Isolation)
+	if err != nil {
+		return "", err
 	}
 
 	maxSteps := t.childMaxSteps(p.MaxSteps)
@@ -497,10 +538,18 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	if err != nil {
 		return "", err
 	}
-	subReg := t.buildSubReg(p.Tools, childDepth)
+	childWorkspaceRoot, isolationResource, err := t.resolveSubagentWorkspace(ctx, isolation, p.ContinueFrom, p.ForkFrom)
+	if err != nil {
+		return "", err
+	}
+	isolation = subagentIsolationFromResource(isolation, isolationResource)
+	subReg, err := t.buildSubRegForWorkspace(ctx, childWorkspaceRoot, p.Tools, childDepth)
+	if err != nil {
+		return "", err
+	}
 	modelRef, effortRef := t.effectiveProfile(p.Model, p.Effort)
 	parentID, parent, _, _ := CallContext(ctx)
-	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom, p.ForkFrom)
+	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom, p.ForkFrom, childWorkspaceRoot, isolation, isolationResource)
 	if err != nil {
 		return "", err
 	}
@@ -555,7 +604,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 					err = errors.Join(panicErr, t.transcripts.SaveFailed(run))
 				}
 			}()
-			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session, childDepth)
+			answer, err := t.runSubSession(jobCtx, p.Prompt, childWorkspaceRoot, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session, childDepth)
 			if err != nil {
 				return FormatSubagentRunResult("", run, true), errors.Join(err, t.transcripts.SaveFailed(run))
 			}
@@ -573,7 +622,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 
 	// Foreground: run synchronously, nesting events under this call.
 	defer run.Release()
-	answer, err := t.runSubSession(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, prov, pricing, ctxWin, run.Session, childDepth)
+	answer, err := t.runSubSession(ctx, p.Prompt, childWorkspaceRoot, subReg, subSink(ctx), maxSteps, prov, pricing, ctxWin, run.Session, childDepth)
 	if err != nil {
 		return "", errors.Join(err, t.transcripts.SaveFailed(run))
 	}
@@ -586,7 +635,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	return GuardSubagentHostDecisionText(answer), nil
 }
 
-func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom, legacyForkFrom string) (*SubagentRun, error) {
+func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom, legacyForkFrom string, workspaceRoot string, isolation SubagentIsolation, isolationResource worktree.Resource) (*SubagentRun, error) {
 	continueFrom = strings.TrimSpace(continueFrom)
 	legacyForkFrom = strings.TrimSpace(legacyForkFrom)
 	parentSession = strings.TrimSpace(parentSession)
@@ -608,17 +657,27 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 		}
 		return EphemeralSubagentRun(t.sysPrompt), nil
 	}
+	if strings.TrimSpace(workspaceRoot) == "" {
+		workspaceRoot = strings.TrimSpace(t.workspaceRoot)
+	}
 	identityModel, identityEffort := t.effectiveIdentity(modelRef, effortRef)
 	spec := SubagentSpec{
 		Kind:             "task",
 		Name:             "task",
-		WorkspaceRoot:    t.workspaceRoot,
+		WorkspaceRoot:    workspaceRoot,
 		ParentSession:    parentSession,
 		ParentToolCallID: parentID,
 		SystemPrompt:     t.sysPrompt,
 		Registry:         subReg,
 		Model:            identityModel,
 		Effort:           identityEffort,
+		Isolation:        string(isolation),
+		IsolationID:      strings.TrimSpace(isolationResource.IsolationID),
+		WorktreeRoot:     strings.TrimSpace(isolationResource.WorktreeRoot),
+		SourceRoot:       strings.TrimSpace(isolationResource.SourceRoot),
+		WorktreeBranch:   strings.TrimSpace(isolationResource.Branch),
+		BaseCommit:       strings.TrimSpace(isolationResource.BaseCommit),
+		HeadCommit:       strings.TrimSpace(isolationResource.HeadCommit),
 	}
 	if continueFrom != "" {
 		return t.transcripts.PrepareContinue(continueFrom, spec)
@@ -651,10 +710,111 @@ func (t *TaskTool) effectiveEffortIdentity(effort string) string {
 	return strings.TrimSpace(t.baseEffort)
 }
 
+func (t *TaskTool) resolveSubagentWorkspace(ctx context.Context, requested SubagentIsolation, continueFrom, legacyForkFrom string) (string, worktree.Resource, error) {
+	parentRoot := strings.TrimSpace(t.workspaceRoot)
+	ref := strings.TrimSpace(continueFrom)
+	if ref == "" {
+		ref = strings.TrimSpace(legacyForkFrom)
+	}
+	if ref != "" && t != nil && t.transcripts != nil {
+		meta, err := t.transcripts.LoadMeta(ref)
+		if err == nil {
+			metaIsolation, err := normalizeSubagentIsolation(meta.Isolation)
+			if err != nil {
+				return "", worktree.Resource{}, fmt.Errorf("subagent reference %q has unsupported isolation metadata: %w", ref, err)
+			}
+			if requested != SubagentIsolationNone && requested != metaIsolation {
+				return "", worktree.Resource{}, fmt.Errorf("subagent reference %q uses isolation %q, requested %q", ref, metaIsolation, requested)
+			}
+			if metaIsolation == SubagentIsolationWorktree {
+				root := strings.TrimSpace(meta.WorktreeRoot)
+				if root == "" {
+					root = strings.TrimSpace(meta.WorkspaceRoot)
+				}
+				if root == "" {
+					return "", worktree.Resource{}, fmt.Errorf("subagent reference %q declares worktree isolation without a workspace root", ref)
+				}
+				return root, resourceFromSubagentMeta(meta), nil
+			}
+			root := strings.TrimSpace(meta.WorkspaceRoot)
+			if root == "" {
+				root = parentRoot
+			}
+			return root, worktree.Resource{}, nil
+		}
+	}
+	if requested != SubagentIsolationWorktree {
+		return parentRoot, worktree.Resource{}, nil
+	}
+	if t == nil || t.worktreeManager == nil {
+		return "", worktree.Resource{}, fmt.Errorf("subagent worktree isolation is not available in this runtime")
+	}
+	res, err := t.worktreeManager.Create(ctx, parentRoot, worktree.CreatePolicy{
+		Kind:        worktree.KindSubagent,
+		DirtyPolicy: worktree.DirtyPolicyReject,
+	})
+	if err != nil {
+		return "", worktree.Resource{}, err
+	}
+	return res.WorkspaceRoot, res, nil
+}
+
+func subagentIsolationFromResource(requested SubagentIsolation, res worktree.Resource) SubagentIsolation {
+	if strings.TrimSpace(res.IsolationID) != "" {
+		return SubagentIsolationWorktree
+	}
+	return requested
+}
+
+func resourceFromSubagentMeta(meta SubagentMeta) worktree.Resource {
+	return worktree.Resource{
+		IsolationID:   strings.TrimSpace(meta.IsolationID),
+		Kind:          worktree.KindSubagent,
+		WorkspaceRoot: strings.TrimSpace(meta.WorkspaceRoot),
+		WorktreeRoot:  strings.TrimSpace(meta.WorktreeRoot),
+		SourceRoot:    strings.TrimSpace(meta.SourceRoot),
+		Branch:        strings.TrimSpace(meta.WorktreeBranch),
+		BaseCommit:    strings.TrimSpace(meta.BaseCommit),
+		HeadCommit:    strings.TrimSpace(meta.HeadCommit),
+	}
+}
+
 // buildSubReg returns the sub-agent's tool set: the named whitelist (minus
 // unavailable sub-agent tools), or every parent tool except those tools.
 func (t *TaskTool) buildSubReg(names []string, childDepth int) *tool.Registry {
 	return SubagentToolRegistryForDepth(t.parentReg, names, childDepth, t.maxDepth())
+}
+
+func (t *TaskTool) buildSubRegForWorkspace(ctx context.Context, workspaceRoot string, names []string, childDepth int) (*tool.Registry, error) {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	if workspaceRoot == "" || cleanPathEqual(workspaceRoot, t.workspaceRoot) || t.subagentRegistryForWorkspace == nil {
+		return t.buildSubReg(names, childDepth), nil
+	}
+	sub, err := t.subagentRegistryForWorkspace(ctx, workspaceRoot, names, childDepth, t.maxDepth())
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, fmt.Errorf("subagent registry factory returned nil for workspace %q", workspaceRoot)
+	}
+	return sub, nil
+}
+
+func cleanPathEqual(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return a == b
+	}
+	aa, errA := filepath.Abs(a)
+	if errA == nil {
+		a = aa
+	}
+	bb, errB := filepath.Abs(b)
+	if errB == nil {
+		b = bb
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 func (t *TaskTool) maxDepth() int {
@@ -851,12 +1011,12 @@ func (t *TaskTool) resolveSubSessionRuntime(modelRef, effort string) (provider.P
 	return prov, pricing, ctxWin, nil
 }
 
-func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session, childDepth int) (string, error) {
+func (t *TaskTool) runSubSession(ctx context.Context, prompt, workspaceRoot string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session, childDepth int) (string, error) {
 	opts := t.subagentOptions(ctx, maxSteps, pricing, ctxWin, childDepth)
 	// Capture the pristine task before host framing is prepended: delivery
 	// intent classification must judge the task, not the wrapper.
 	opts.ClassifierTaskText = prompt
-	prompt = t.withWorkspaceContext(prompt)
+	prompt = t.withWorkspaceContextForRoot(prompt, workspaceRoot)
 	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, opts, sink)
 }
 
@@ -901,7 +1061,14 @@ func (t *TaskTool) withWorkspaceContext(prompt string) string {
 	if t == nil {
 		return prompt
 	}
-	ctx := subagentWorkspaceContext(t.workspaceRoot)
+	return t.withWorkspaceContextForRoot(prompt, t.workspaceRoot)
+}
+
+func (t *TaskTool) withWorkspaceContextForRoot(prompt, root string) string {
+	if t == nil {
+		return prompt
+	}
+	ctx := subagentWorkspaceContext(root)
 	if ctx == "" {
 		return prompt
 	}
@@ -930,13 +1097,31 @@ func FormatSubagentReference(run *SubagentRun) string {
 	fmt.Fprintf(&b, "Subagent reference: %s\n", run.Ref)
 	if strings.TrimSpace(run.ForkedFrom) != "" {
 		fmt.Fprintf(&b, "Forked from: %s\n", strings.TrimSpace(run.ForkedFrom))
+		appendSubagentIsolationReference(&b, run.Meta)
 		b.WriteString("The requested ref resolves to an ancestor conversation transcript, so the framework continues a copy owned by the current conversation. To continue this copied subagent transcript in a later call, pass ")
 		b.WriteString(run.Ref)
 		b.WriteString(" as `continue_from`. Start a fresh subagent when the next task is independent.")
 		return b.String()
 	}
+	appendSubagentIsolationReference(&b, run.Meta)
 	b.WriteString("To continue this same subagent transcript in a later call, pass this ref as `continue_from`. Start a fresh subagent when the next task is independent.")
 	return b.String()
+}
+
+func appendSubagentIsolationReference(b *strings.Builder, meta SubagentMeta) {
+	if b == nil || normalizeSubagentMetaIsolation(meta.Isolation) != string(SubagentIsolationWorktree) {
+		return
+	}
+	if strings.TrimSpace(meta.IsolationID) != "" {
+		fmt.Fprintf(b, "Worktree isolation: %s\n", strings.TrimSpace(meta.IsolationID))
+	}
+	if strings.TrimSpace(meta.WorktreeRoot) != "" {
+		fmt.Fprintf(b, "Workspace: %s\n", strings.TrimSpace(meta.WorktreeRoot))
+	}
+	if strings.TrimSpace(meta.WorktreeBranch) != "" {
+		fmt.Fprintf(b, "Branch: %s\n", strings.TrimSpace(meta.WorktreeBranch))
+	}
+	b.WriteString("Apply is explicit: review status/diff before merging this worktree back into the parent workspace.\n")
 }
 
 func FormatSubagentRunResult(answer string, run *SubagentRun, failed bool) string {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -592,6 +592,9 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		}
 		parentSession := ParentSession(ctx)
 		backgroundEvidence := evidence.NewLedger()
+		// The background worker updates run metadata as it completes. Format the
+		// immutable launch reference before handing ownership to that goroutine.
+		backgroundReference := FormatSubagentReference(run)
 		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (result string, err error) {
 			jobCtx = WithParentSession(jobCtx, parentSession)
 			jobCtx = evidence.WithLedger(jobCtx, backgroundEvidence)
@@ -614,8 +617,8 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			return FormatSubagentRunResult(answer, run, false), nil
 		})
 		releaseStart()
-		if run != nil && run.Ref != "" {
-			return fmt.Sprintf("Started background task %q (%s).\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, FormatSubagentReference(run)), nil
+		if backgroundReference != "" {
+			return fmt.Sprintf("Started background task %q (%s).\n%s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, backgroundReference), nil
 		}
 		return fmt.Sprintf("Started background task %q (%s). It runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label), nil
 	}

--- a/internal/agent/task_isolation_contract_test.go
+++ b/internal/agent/task_isolation_contract_test.go
@@ -3,9 +3,14 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/tool"
 	"reasonix/internal/worktree"
 )
@@ -149,4 +154,167 @@ func TestTaskToolNormalizeSubagentIsolation(t *testing.T) {
 	if _, err := normalizeSubagentIsolation("sandbox"); err == nil {
 		t.Fatal("unknown isolation should be rejected")
 	}
+}
+
+func TestTaskToolWriterRunsInsideWorktreeAndContinueReusesResource(t *testing.T) {
+	source := initTaskIsolationRepo(t)
+	manager := worktree.NewManager(filepath.Join(t.TempDir(), "managed"))
+	store := NewSubagentStore(t.TempDir())
+	parentReg := tool.NewRegistry()
+	provider := writerCallingProvider{}
+
+	task := NewTaskTool(provider, nil, parentReg, 20, 0, 0, 0, 0, 0, 0, 0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, source, "base-model", "base-effort").
+		WithWorkspaceIsolation(manager, func(_ context.Context, workspaceRoot string, _ []string, _, _ int) (*tool.Registry, error) {
+			reg := tool.NewRegistry()
+			reg.Add(worktreeRootWriter{root: workspaceRoot})
+			return reg, nil
+		})
+
+	out, err := task.Execute(testTaskContext(), []byte(`{"prompt":"write the isolated file","isolation":"worktree"}`))
+	if err != nil {
+		t.Fatalf("isolated Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, out)
+	resources, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("managed resources = %d, want 1: %+v", len(resources), resources)
+	}
+	childPath := filepath.Join(resources[0].WorkspaceRoot, "x")
+	if got, err := os.ReadFile(childPath); err != nil || string(got) != "y" {
+		t.Fatalf("isolated writer result = %q, %v; want child x=y", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(source, "x")); !os.IsNotExist(err) {
+		t.Fatalf("parent workspace was mutated, stat err = %v", err)
+	}
+
+	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"continue","continue_from":"`+ref+`"}`)); err != nil {
+		t.Fatalf("continued Execute: %v", err)
+	}
+	after, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List after continuation: %v", err)
+	}
+	if len(after) != 1 || after[0].IsolationID != resources[0].IsolationID || after[0].WorkspaceRoot != resources[0].WorkspaceRoot {
+		t.Fatalf("continuation created or changed isolation resource: before=%+v after=%+v", resources, after)
+	}
+}
+
+func TestTaskToolBackgroundWritersUseIndependentWorktrees(t *testing.T) {
+	source := initTaskIsolationRepo(t)
+	manager := worktree.NewManager(filepath.Join(t.TempDir(), "managed"))
+	store := NewSubagentStore(t.TempDir())
+	task := NewTaskTool(writerCallingProvider{}, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0, 0, "", "sys", nil, 0, "", "", nil).
+		WithTranscripts(store, source, "base-model", "base-effort").
+		WithWorkspaceIsolation(manager, func(_ context.Context, workspaceRoot string, _ []string, _, _ int) (*tool.Registry, error) {
+			reg := tool.NewRegistry()
+			reg.Add(worktreeRootWriter{root: workspaceRoot})
+			return reg, nil
+		})
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctx := jobs.WithManager(jobs.WithSession(testTaskContext(), "parent-session"), jm)
+
+	var jobIDs []string
+	for _, prompt := range []string{"writer one", "writer two"} {
+		out, err := task.Execute(ctx, []byte(`{"prompt":"`+prompt+`","run_in_background":true,"isolation":"worktree"}`))
+		if err != nil {
+			t.Fatalf("start %q: %v", prompt, err)
+		}
+		jobID := extractJobID(out)
+		if jobID == "" {
+			t.Fatalf("start %q returned no job ID:\n%s", prompt, out)
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+
+	results := jm.WaitForSession(context.Background(), "parent-session", jobIDs, 10)
+	if len(results) != 2 {
+		t.Fatalf("background results = %d, want 2: %+v", len(results), results)
+	}
+	for _, result := range results {
+		if result.Status != jobs.Done {
+			t.Fatalf("background writer %s status = %s, want done: %+v", result.ID, result.Status, result)
+		}
+	}
+
+	resources, err := manager.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("managed resources = %d, want 2: %+v", len(resources), resources)
+	}
+	if resources[0].IsolationID == resources[1].IsolationID || cleanPathEqual(resources[0].WorkspaceRoot, resources[1].WorkspaceRoot) {
+		t.Fatalf("background writers shared isolation: %+v", resources)
+	}
+	for _, resource := range resources {
+		got, err := os.ReadFile(filepath.Join(resource.WorkspaceRoot, "x"))
+		if err != nil || string(got) != "y" {
+			t.Fatalf("isolated result for %s = %q, %v; want x=y", resource.IsolationID, got, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(source, "x")); !os.IsNotExist(err) {
+		t.Fatalf("parent workspace was mutated, stat err = %v", err)
+	}
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = source
+	if out, err := cmd.CombinedOutput(); err != nil || len(out) != 0 {
+		t.Fatalf("parent git status = %q, %v; want clean", out, err)
+	}
+}
+
+type worktreeRootWriter struct {
+	root string
+}
+
+func (w worktreeRootWriter) Name() string            { return "write_file" }
+func (w worktreeRootWriter) Description() string     { return "write a file" }
+func (w worktreeRootWriter) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (w worktreeRootWriter) ReadOnly() bool          { return false }
+func (w worktreeRootWriter) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", err
+	}
+	path := filepath.Join(w.root, filepath.Clean(p.Path))
+	if err := os.WriteFile(path, []byte(p.Content), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func initTaskIsolationRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	commands := [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "reasonix@example.test"},
+		{"config", "user.name", "Reasonix Test"},
+	}
+	for _, args := range commands {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "seed.txt"}, {"commit", "-m", "seed"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return root
 }

--- a/internal/agent/task_isolation_contract_test.go
+++ b/internal/agent/task_isolation_contract_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/tool"
+	"reasonix/internal/worktree"
+)
+
+func TestTaskToolSchemaExposesExplicitIsolationContract(t *testing.T) {
+	schema := string((&TaskTool{}).Schema())
+	if !strings.Contains(schema, `"run_in_background"`) {
+		t.Fatalf("task schema no longer exposes run_in_background:\n%s", schema)
+	}
+	for _, want := range []string{`"isolation"`, `"none"`, `"worktree"`} {
+		if !strings.Contains(schema, want) {
+			t.Fatalf("task schema should expose %s:\n%s", want, schema)
+		}
+	}
+}
+
+func TestTaskToolPersistedSubagentRunsDefaultToSharedParentWorkspace(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	parentWorkspace := t.TempDir()
+	task := (&TaskTool{sysPrompt: "system"}).WithTranscripts(store, parentWorkspace, "base-model", "base-effort")
+	reg := tool.NewRegistry()
+
+	run1, err := task.prepareTranscriptRun(reg, "", "", "parent-session", "call-1", "", "", parentWorkspace, SubagentIsolationNone, worktree.Resource{})
+	if err != nil {
+		t.Fatalf("prepare run1: %v", err)
+	}
+	defer run1.Release()
+	run2, err := task.prepareTranscriptRun(reg, "", "", "parent-session", "call-2", "", "", parentWorkspace, SubagentIsolationNone, worktree.Resource{})
+	if err != nil {
+		t.Fatalf("prepare run2: %v", err)
+	}
+	defer run2.Release()
+
+	if run1.Meta.WorkspaceRoot != parentWorkspace || run2.Meta.WorkspaceRoot != parentWorkspace {
+		t.Fatalf("runs should share parent workspace by default: run1=%q run2=%q parent=%q", run1.Meta.WorkspaceRoot, run2.Meta.WorkspaceRoot, parentWorkspace)
+	}
+	if run1.Meta.WorkspaceRoot != run2.Meta.WorkspaceRoot {
+		t.Fatalf("default runs should not be isolated: run1=%q run2=%q", run1.Meta.WorkspaceRoot, run2.Meta.WorkspaceRoot)
+	}
+
+	raw, err := json.Marshal(run1.Meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta["isolation"] != "none" {
+		t.Fatalf("default isolation = %v, want none; raw=%s", meta["isolation"], string(raw))
+	}
+	for _, key := range []string{"isolationId", "isolation_id", "worktreeRoot", "worktree_root", "sourceRoot", "source_root"} {
+		if _, ok := meta[key]; ok {
+			t.Fatalf("default shared subagent metadata should not have %q: %s", key, string(raw))
+		}
+	}
+}
+
+func TestTaskToolPersistsWorktreeIsolationMetadata(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	parentWorkspace := t.TempDir()
+	childWorkspace := t.TempDir()
+	task := (&TaskTool{sysPrompt: "system"}).WithTranscripts(store, parentWorkspace, "base-model", "base-effort")
+	reg := tool.NewRegistry()
+	res := worktree.Resource{
+		IsolationID:   "iso-test",
+		WorkspaceRoot: childWorkspace,
+		WorktreeRoot:  childWorkspace,
+		SourceRoot:    parentWorkspace,
+		Branch:        "reasonix/subagent-test",
+		BaseCommit:    "abc123",
+		HeadCommit:    "def456",
+	}
+
+	run, err := task.prepareTranscriptRun(reg, "", "", "parent-session", "call-1", "", "", childWorkspace, SubagentIsolationWorktree, res)
+	if err != nil {
+		t.Fatalf("prepare isolated run: %v", err)
+	}
+	defer run.Release()
+
+	if run.Meta.WorkspaceRoot != childWorkspace {
+		t.Fatalf("workspace root = %q, want %q", run.Meta.WorkspaceRoot, childWorkspace)
+	}
+	if run.Meta.Isolation != "worktree" || run.Meta.IsolationID != "iso-test" || run.Meta.WorktreeRoot != childWorkspace || run.Meta.SourceRoot != parentWorkspace {
+		t.Fatalf("worktree metadata not persisted: %+v", run.Meta)
+	}
+	if run.Meta.WorktreeBranch != "reasonix/subagent-test" || run.Meta.BaseCommit != "abc123" || run.Meta.HeadCommit != "def456" {
+		t.Fatalf("worktree git metadata not persisted: %+v", run.Meta)
+	}
+
+	ref := FormatSubagentReference(run)
+	for _, want := range []string{"Worktree isolation: iso-test", "Workspace: " + childWorkspace, "Branch: reasonix/subagent-test", "Apply is explicit"} {
+		if !strings.Contains(ref, want) {
+			t.Fatalf("reference should contain %q:\n%s", want, ref)
+		}
+	}
+}
+
+func TestTaskToolBuildSubRegUsesWorkspaceFactory(t *testing.T) {
+	parentWorkspace := t.TempDir()
+	childWorkspace := t.TempDir()
+	parent := tool.NewRegistry()
+	parent.Add(subagentRegistryTool{name: "parent_tool"})
+	called := false
+	task := (&TaskTool{parentReg: parent, workspaceRoot: parentWorkspace}).WithWorkspaceIsolation(nil, func(ctx context.Context, workspaceRoot string, names []string, childDepth, maxDepth int) (*tool.Registry, error) {
+		called = true
+		if !cleanPathEqual(workspaceRoot, childWorkspace) {
+			t.Fatalf("factory workspace = %q, want %q", workspaceRoot, childWorkspace)
+		}
+		child := tool.NewRegistry()
+		child.Add(subagentRegistryTool{name: "child_tool"})
+		return child, nil
+	})
+
+	sub, err := task.buildSubRegForWorkspace(context.Background(), childWorkspace, nil, 1)
+	if err != nil {
+		t.Fatalf("build child registry: %v", err)
+	}
+	if !called {
+		t.Fatal("workspace factory was not called for child worktree root")
+	}
+	if _, ok := sub.Get("child_tool"); !ok {
+		t.Fatalf("child registry missing child tool; got %v", sub.Names())
+	}
+	if _, ok := sub.Get("parent_tool"); ok {
+		t.Fatalf("isolated child registry should be rebuilt for child root, got parent tool in %v", sub.Names())
+	}
+}
+
+func TestTaskToolNormalizeSubagentIsolation(t *testing.T) {
+	for _, raw := range []string{"", "none", " NONE "} {
+		got, err := normalizeSubagentIsolation(raw)
+		if err != nil || got != SubagentIsolationNone {
+			t.Fatalf("normalize %q = %q, %v; want none, nil", raw, got, err)
+		}
+	}
+	got, err := normalizeSubagentIsolation(" WORKTREE ")
+	if err != nil || got != SubagentIsolationWorktree {
+		t.Fatalf("normalize worktree = %q, %v", got, err)
+	}
+	if _, err := normalizeSubagentIsolation("sandbox"); err == nil {
+		t.Fatal("unknown isolation should be rejected")
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -53,6 +53,7 @@ import (
 	"reasonix/internal/tool/builtin"
 	"reasonix/internal/tool/sessiontool"
 	"reasonix/internal/workspacelease"
+	"reasonix/internal/worktree"
 )
 
 // ErrUnknownModel is returned by Build when the configured model can't be
@@ -468,6 +469,33 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if !tokenEconomy || len(cfg.Tools.Enabled) == 0 || len(enabledBuiltins) > 0 {
 		addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner)
 	}
+	subagentRegistryFactory := func(_ context.Context, workspaceRoot string, names []string, childDepth, maxDepth int) (*tool.Registry, error) {
+		workspaceRoot = strings.TrimSpace(workspaceRoot)
+		if workspaceRoot == "" || sameWorkspacePath(workspaceRoot, root) {
+			return agent.SubagentToolRegistryForDepth(reg, names, childDepth, maxDepth), nil
+		}
+		childReg := tool.NewRegistry()
+		childWriteRoots := rebaseWorkspaceRoots(writeRoots, root, workspaceRoot)
+		rebasedForbidReadRoots := rebaseWorkspaceRoots(forbidReadRoots, root, workspaceRoot)
+		childForbidReadRoots := appendUniquePaths(forbidReadRoots, rebasedForbidReadRoots...)
+		childBashSpec := bashSpec
+		childBashSpec.WriteRoots = childWriteRoots
+		childBashSpec.ForbidReadRoots = childForbidReadRoots
+		childReadPathResolver := builtin.NewPathResolver()
+		childSessionGuard := builtin.NewSessionDataGuard(config.MemoryUserDir(), cfg.AllowWriteRoots())
+		if !tokenEconomy || len(cfg.Tools.Enabled) == 0 || len(enabledBuiltins) > 0 {
+			addBuiltins(childReg, enabledBuiltins, childWriteRoots, childBashSpec, bashTimeout, searchSpec, stderr, workspaceRoot, proxySpec, childForbidReadRoots, childReadPathResolver, childSessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner)
+		}
+		for _, name := range reg.Names() {
+			if _, exists := childReg.Get(name); exists {
+				continue
+			}
+			if tl, ok := reg.Get(name); ok {
+				childReg.Add(tl)
+			}
+		}
+		return agent.SubagentToolRegistryForDepth(childReg, names, childDepth, maxDepth), nil
+	}
 	// Use the caller-supplied shared host when set, so controllers for the same
 	// workspace root reuse running MCP processes (e.g. one CodeGraph daemon
 	// instead of one per tab). Otherwise construct a private host per controller.
@@ -770,6 +798,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	taskModel := firstNonEmpty(cfg.Agent.SubagentModels["task"], cfg.Agent.SubagentModel)
 	taskEffort := firstNonEmpty(cfg.Agent.SubagentEfforts["task"], cfg.Agent.SubagentEffort)
+	worktreeManager := worktree.NewManager(config.DeliveryWorktreeDir())
 	maxSubagentDepth := agent.NormalizeMaxSubagentDepth(cfg.Agent.MaxSubagentDepth)
 	taskToolAdded := false
 	readOnlyTaskToolAdded := false
@@ -784,7 +813,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			WithTranscriptIdentityResolver(subagentIdentity).
 			WithMaxSubagentDepth(maxSubagentDepth).
 			WithDeliveryProfile(tokenDelivery).
-			WithWorkspaceLease(workspaceLease)
+			WithWorkspaceLease(workspaceLease).
+			WithWorkspaceIsolation(worktreeManager, subagentRegistryFactory)
 	}
 	addTaskTool := func() string {
 		if taskToolAdded {
@@ -887,6 +917,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if strings.TrimSpace(runOpts.ContinueFrom) != "" || strings.TrimSpace(runOpts.ForkFrom) != "" {
 			return "", fmt.Errorf("read_only_skill does not support continue_from/fork_from")
 		}
+		isolation, err := normalizeBootSubagentIsolation(firstNonEmpty(runOpts.Isolation, sk.Isolation))
+		if err != nil {
+			return "", err
+		}
+		if isolation == agent.SubagentIsolationWorktree {
+			return "", fmt.Errorf("read_only_skill %q cannot use worktree isolation", sk.Name)
+		}
 		sk = skill.WithCodeGraphTools(sk, skill.CodeGraphReadTools(reg))
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
 		modelRef := subagentModelRef(cfg, sk)
@@ -933,6 +970,19 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// them. Its tool activity nests under the invoking call, like `task`.
 	skillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
 		sk = skill.WithCodeGraphTools(sk, skill.CodeGraphReadTools(reg))
+		continueFrom := strings.TrimSpace(runOpts.ContinueFrom)
+		legacyForkFrom := strings.TrimSpace(runOpts.ForkFrom)
+		if continueFrom != "" && legacyForkFrom != "" {
+			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
+		}
+		isolationRaw := firstNonEmpty(runOpts.Isolation, sk.Isolation)
+		isolation, err := normalizeBootSubagentIsolation(isolationRaw)
+		if err != nil {
+			return "", err
+		}
+		if sk.ReadOnly && isolation == agent.SubagentIsolationWorktree {
+			return "", fmt.Errorf("read-only subagent skill %q cannot use worktree isolation", sk.Name)
+		}
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
 		modelRef := subagentModelRef(cfg, sk)
 		effortRef := subagentEffortRef(cfg, sk)
@@ -947,15 +997,63 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if childDepth > maxSubagentDepth {
 			return "", fmt.Errorf("subagent delegation depth limit reached (max_subagent_depth=%d)", maxSubagentDepth)
 		}
+		parentID, _, _, _ := agent.CallContext(sctx)
+		if runOpts.HostInitiated {
+			parentID = ""
+		}
+		parentSession := agent.ParentSession(sctx)
+
+		workspaceRoot := root
+		var isolationResource worktree.Resource
+		if ref := firstNonEmpty(continueFrom, legacyForkFrom); ref != "" {
+			if subagentStore == nil || parentSession == "" {
+				return "", fmt.Errorf("subagent continuation requires a persisted session; none is active in this run")
+			}
+			meta, err := subagentStore.LoadMeta(ref)
+			if err != nil {
+				return "", err
+			}
+			metaIsolation, err := normalizeBootSubagentIsolation(meta.Isolation)
+			if err != nil {
+				return "", err
+			}
+			if strings.TrimSpace(isolationRaw) != "" && metaIsolation != isolation {
+				return "", fmt.Errorf("subagent continuation isolation mismatch: requested %s but %s was %s", isolation, ref, metaIsolation)
+			}
+			isolation = metaIsolation
+			if isolation == agent.SubagentIsolationWorktree {
+				workspaceRoot = strings.TrimSpace(meta.WorktreeRoot)
+				if workspaceRoot == "" {
+					return "", fmt.Errorf("subagent %s was recorded with worktree isolation but has no worktree_root", ref)
+				}
+				isolationResource = worktreeResourceFromSubagentMeta(meta)
+			}
+		} else if isolation == agent.SubagentIsolationWorktree {
+			res, err := worktreeManager.Create(sctx, root, worktree.CreatePolicy{
+				Kind:        worktree.KindSubagent,
+				DirtyPolicy: worktree.DirtyPolicyReject,
+			})
+			if err != nil {
+				return "", err
+			}
+			workspaceRoot = res.WorkspaceRoot
+			isolationResource = res
+		}
+
 		// A read-only skill (builtin review/security-review, or frontmatter
 		// `read-only: true`) gets its promise enforced at the tool boundary:
 		// writer tools are stripped and bash runs under the read-only
-		// command policy. Transcripts recorded against the writer-capable
-		// registry stop matching on continue_from (schema-hash check reports
-		// the mismatch).
+		// command policy. Writer skills rebuild their registry against
+		// workspaceRoot so filesystem, shell, project config, and MCP discovery
+		// follow the isolation boundary.
 		var subReg *tool.Registry
 		if sk.ReadOnly {
 			subReg = agent.ReadOnlySubagentToolRegistryForDepth(reg, sk.AllowedTools, childDepth, maxSubagentDepth)
+		} else if subagentRegistryFactory != nil {
+			subReg, err = subagentRegistryFactory(sctx, workspaceRoot, sk.AllowedTools, childDepth, maxSubagentDepth)
+			if err != nil {
+				return "", err
+			}
 		} else {
 			subReg = agent.SubagentToolRegistryForDepth(reg, sk.AllowedTools, childDepth, maxSubagentDepth)
 		}
@@ -965,38 +1063,32 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		case "review", "security-review", "security_review":
 			agent.AttachReviewReportTool(subReg)
 		}
-		continueFrom := strings.TrimSpace(runOpts.ContinueFrom)
-		legacyForkFrom := strings.TrimSpace(runOpts.ForkFrom)
-		if continueFrom != "" && legacyForkFrom != "" {
-			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive; pass only continue_from")
-		}
-		parentID, _, _, _ := agent.CallContext(sctx)
-		if runOpts.HostInitiated {
-			parentID = ""
-		}
-		parentSession := agent.ParentSession(sctx)
 		var run *agent.SubagentRun
 		if subagentStore == nil || parentSession == "" {
 			// Headless runs (e.g. `reasonix run`) have no persistent session to
 			// own a transcript. Run the skill sub-agent ephemerally, as before
 			// persisted transcripts existed, instead of failing. Continuation needs
 			// a persisted owner, so it errors here.
-			if continueFrom != "" || legacyForkFrom != "" {
-				return "", fmt.Errorf("subagent continuation requires a persisted session; none is active in this run")
-			}
 			run = agent.EphemeralSubagentRun(sk.Body)
 		} else {
 			identityModel, identityEffort := subagentIdentity(modelRef, effortRef)
 			spec := agent.SubagentSpec{
 				Kind:             "skill",
 				Name:             sk.Name,
-				WorkspaceRoot:    root,
+				WorkspaceRoot:    workspaceRoot,
 				ParentSession:    parentSession,
 				ParentToolCallID: parentID,
 				SystemPrompt:     sk.Body,
 				Registry:         subReg,
 				Model:            identityModel,
 				Effort:           identityEffort,
+				Isolation:        string(isolation),
+				IsolationID:      isolationResource.IsolationID,
+				WorktreeRoot:     isolationResource.WorktreeRoot,
+				SourceRoot:       isolationResource.SourceRoot,
+				WorktreeBranch:   isolationResource.Branch,
+				BaseCommit:       isolationResource.BaseCommit,
+				HeadCommit:       isolationResource.HeadCommit,
 			}
 			var prepErr error
 			if continueFrom != "" {
@@ -1032,10 +1124,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				runOptions, agent.NestedSink(sctx, event.Discard))
 		}
 		if err != nil {
+			if subagentStore == nil {
+				return "", err
+			}
 			return "", errors.Join(err, subagentStore.SaveFailed(run))
 		}
-		if err := subagentStore.SaveCompleted(run); err != nil {
-			return "", errors.Join(err, subagentStore.SaveFailed(run))
+		if subagentStore != nil {
+			if err := subagentStore.SaveCompleted(run); err != nil {
+				return "", errors.Join(err, subagentStore.SaveFailed(run))
+			}
 		}
 		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}
@@ -1882,6 +1979,76 @@ func appendUniquePaths(base []string, extra ...string) []string {
 		out = append(out, path)
 	}
 	return out
+}
+
+func sameWorkspacePath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return a == b
+	}
+	return pathComparisonKey(a) == pathComparisonKey(b)
+}
+
+func rebaseWorkspaceRoots(paths []string, sourceRoot, workspaceRoot string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		rebased, ok := rebaseWorkspacePath(path, sourceRoot, workspaceRoot)
+		if !ok {
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+			rebased = path
+		}
+		out = appendUniquePaths(out, rebased)
+	}
+	return out
+}
+
+func rebaseWorkspacePath(path, sourceRoot, workspaceRoot string) (string, bool) {
+	path = strings.TrimSpace(path)
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	if path == "" || sourceRoot == "" || workspaceRoot == "" {
+		return "", false
+	}
+	if pathComparisonKey(path) == pathComparisonKey(sourceRoot) {
+		return filepath.Clean(workspaceRoot), true
+	}
+	rel, err := filepath.Rel(sourceRoot, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(workspaceRoot, rel)), true
+}
+
+func normalizeBootSubagentIsolation(raw string) (agent.SubagentIsolation, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return agent.SubagentIsolationNone, nil
+	}
+	switch skill.ParseIsolation(raw) {
+	case "none":
+		return agent.SubagentIsolationNone, nil
+	case "worktree":
+		return agent.SubagentIsolationWorktree, nil
+	default:
+		return "", fmt.Errorf("unsupported subagent isolation %q; use none or worktree", raw)
+	}
+}
+
+func worktreeResourceFromSubagentMeta(meta agent.SubagentMeta) worktree.Resource {
+	return worktree.Resource{
+		IsolationID:   strings.TrimSpace(meta.IsolationID),
+		Kind:          worktree.KindSubagent,
+		WorkspaceRoot: strings.TrimSpace(meta.WorkspaceRoot),
+		WorktreeRoot:  strings.TrimSpace(meta.WorktreeRoot),
+		SourceRoot:    strings.TrimSpace(meta.SourceRoot),
+		Branch:        strings.TrimSpace(meta.WorktreeBranch),
+		BaseCommit:    strings.TrimSpace(meta.BaseCommit),
+		HeadCommit:    strings.TrimSpace(meta.HeadCommit),
+	}
 }
 
 // RuntimeForbidReadRoots returns the configured deny roots plus Reasonix's

--- a/internal/cli/subagent.go
+++ b/internal/cli/subagent.go
@@ -25,11 +25,11 @@ var setupSubagentCommand = func(ctx context.Context, modelName string, maxStepsO
 
 const subagentUsageText = `usage:
   reasonix subagent list [--dir PATH]
-  reasonix subagent create <name> --description TEXT (--prompt TEXT | --prompt-file PATH) [--scope project|global] [--model REF] [--effort LEVEL] [--tools a,b] [--color NAME] [--dir PATH]
-  reasonix subagent edit <name> [--description TEXT] [--prompt TEXT | --prompt-file PATH] [--model REF] [--effort LEVEL] [--tools a,b] [--color NAME] [--dir PATH]
+  reasonix subagent create <name> --description TEXT (--prompt TEXT | --prompt-file PATH) [--scope project|global] [--model REF] [--effort LEVEL] [--tools a,b] [--color NAME] [--isolation none|worktree] [--dir PATH]
+  reasonix subagent edit <name> [--description TEXT] [--prompt TEXT | --prompt-file PATH] [--model REF] [--effort LEVEL] [--tools a,b] [--color NAME] [--isolation none|worktree] [--dir PATH]
   reasonix subagent delete <name> --yes [--dir PATH]
-  reasonix subagent try <name> [--model REF] [--max-steps N] [--dir PATH] <task>
-  reasonix subagent run <name> [--model REF] [--max-steps N] [--dir PATH] <task>
+  reasonix subagent try <name> [--model REF] [--max-steps N] [--isolation none] [--dir PATH] <task>
+  reasonix subagent run <name> [--model REF] [--max-steps N] [--isolation none|worktree] [--dir PATH] <task>
 
 Use --prompt-file - or pipe stdin to read a system prompt from stdin.
 `
@@ -129,6 +129,7 @@ type subagentProfileFlags struct {
 	effort      optionalString
 	tools       optionalString
 	color       optionalString
+	isolation   optionalString
 	dir         string
 }
 
@@ -140,6 +141,7 @@ func addSubagentProfileFlags(fs *flag.FlagSet, values *subagentProfileFlags) {
 	fs.Var(&values.effort, "effort", "per-profile reasoning effort (empty clears on edit)")
 	fs.Var(&values.tools, "tools", "comma-separated allowed tools (empty means all tools)")
 	fs.Var(&values.color, "color", "profile color tag (empty clears on edit)")
+	fs.Var(&values.isolation, "isolation", "workspace isolation for writer subagents: none or worktree")
 	fs.StringVar(&values.dir, "dir", "", "project root")
 }
 
@@ -176,6 +178,11 @@ func subagentCreateCommand(args []string) int {
 		fmt.Fprintln(os.Stderr, "subagent create: --prompt or --prompt-file is required")
 		return 2
 	}
+	isolation, err := normalizeCLIIsolation(values.isolation.value)
+	if values.isolation.set && err != nil {
+		fmt.Fprintln(os.Stderr, "subagent create:", err)
+		return 2
+	}
 	store := newCLISubagentStore()
 	scope, err := profileCreateScope(*scopeText, store.HasProjectScope())
 	if err != nil {
@@ -186,7 +193,7 @@ func subagentCreateCommand(args []string) int {
 		fmt.Fprintln(os.Stderr, "subagent create:", err)
 		return 1
 	}
-	content := renderCLIProfile(name, values.description.value, prompt, values.model.value, values.effort.value, parseToolList(values.tools.value), values.color.value)
+	content := renderCLIProfile(name, values.description.value, prompt, values.model.value, values.effort.value, parseToolList(values.tools.value), values.color.value, isolation)
 	path, err := store.CreateWithContent(name, scope, content)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "subagent create:", err)
@@ -239,7 +246,7 @@ func subagentEditCommand(args []string) int {
 		return 2
 	}
 	description, body := sk.Description, sk.Body
-	model, effort, color := sk.Model, sk.Effort, sk.Color
+	model, effort, color, isolation := sk.Model, sk.Effort, sk.Color, sk.Isolation
 	tools := append([]string(nil), sk.AllowedTools...)
 	if values.description.set {
 		description = values.description.value
@@ -259,11 +266,19 @@ func subagentEditCommand(args []string) int {
 	if values.color.set {
 		color = values.color.value
 	}
+	if values.isolation.set {
+		next, err := normalizeCLIIsolation(values.isolation.value)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "subagent edit:", err)
+			return 2
+		}
+		isolation = next
+	}
 	if strings.TrimSpace(description) == "" || strings.TrimSpace(body) == "" {
 		fmt.Fprintln(os.Stderr, "subagent edit: description and prompt cannot be empty")
 		return 2
 	}
-	content := renderCLIProfile(sk.Name, description, body, model, effort, tools, color)
+	content := renderCLIProfile(sk.Name, description, body, model, effort, tools, color, isolation)
 	if err := store.UpdateContent(sk.Name, sk.Scope, content); err != nil {
 		fmt.Fprintln(os.Stderr, "subagent edit:", err)
 		return 1
@@ -322,6 +337,7 @@ func subagentRunCommand(args []string, readOnly bool) int {
 	fs := flag.NewFlagSet("subagent "+verb, flag.ContinueOnError)
 	model := fs.String("model", "", "default model reference")
 	maxSteps := fs.Int("max-steps", 0, "max tool-call rounds")
+	isolationFlag := fs.String("isolation", "", "workspace isolation for writer subagents: none or worktree")
 	dir := fs.String("dir", "", "project root")
 	if err := fs.Parse(rest); err != nil {
 		return 2
@@ -342,6 +358,15 @@ func subagentRunCommand(args []string, readOnly bool) int {
 		fmt.Fprintf(os.Stderr, "subagent %s: task is required\n", verb)
 		return 2
 	}
+	isolation, err := normalizeCLIIsolation(*isolationFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "subagent %s: %v\n", verb, err)
+		return 2
+	}
+	if readOnly && isolation == "worktree" {
+		fmt.Fprintf(os.Stderr, "subagent %s: read-only try does not support worktree isolation\n", verb)
+		return 2
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 	ctrl, err := setupSubagentCommand(ctx, *model, *maxSteps, true, event.Discard, workspaceRoot)
@@ -350,7 +375,10 @@ func subagentRunCommand(args []string, readOnly bool) int {
 		return 1
 	}
 	defer ctrl.Close()
-	answer, err := ctrl.RunSubagentProfile(ctx, name, task, readOnly)
+	answer, err := ctrl.RunSubagentProfileWithOptions(ctx, name, task, control.RunSubagentProfileOptions{
+		ReadOnly:  readOnly,
+		Isolation: isolation,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "subagent %s: %v\n", verb, err)
 		return 1
@@ -429,7 +457,7 @@ func refuseSubagentNameCollision(skills []skill.Skill, name string) error {
 }
 
 func editBuiltinSubagentProfile(sk skill.Skill, values subagentProfileFlags) error {
-	if values.description.set || values.prompt.set || values.promptFile.set || values.tools.set || values.color.set {
+	if values.description.set || values.prompt.set || values.promptFile.set || values.tools.set || values.color.set || values.isolation.set {
 		return fmt.Errorf("built-in profile %q only supports --model and --effort overrides", sk.Name)
 	}
 	unlock := config.LockUserConfigEdits()
@@ -519,7 +547,18 @@ func resolveSubagentPrompt(prompt, promptFile optionalString) (string, bool, err
 
 func profileFlagsChanged(values subagentProfileFlags) bool {
 	return values.description.set || values.prompt.set || values.promptFile.set || values.model.set ||
-		values.effort.set || values.tools.set || values.color.set
+		values.effort.set || values.tools.set || values.color.set || values.isolation.set
+}
+
+func normalizeCLIIsolation(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if isolation := skill.ParseIsolation(raw); isolation != "" {
+		return isolation, nil
+	}
+	return "", fmt.Errorf("unsupported isolation %q; use none or worktree", raw)
 }
 
 func parseToolList(raw string) []string {
@@ -536,7 +575,7 @@ func parseToolList(raw string) []string {
 	return tools
 }
 
-func renderCLIProfile(name, description, prompt, model, effort string, tools []string, color string) string {
+func renderCLIProfile(name, description, prompt, model, effort string, tools []string, color string, isolation string) string {
 	return skill.RenderSkillFile(skill.SkillFileOptions{
 		Name:         strings.TrimSpace(name),
 		Description:  strings.TrimSpace(description),
@@ -546,6 +585,7 @@ func renderCLIProfile(name, description, prompt, model, effort string, tools []s
 		Effort:       strings.TrimSpace(effort),
 		AllowedTools: tools,
 		Color:        strings.TrimSpace(color),
+		Isolation:    strings.TrimSpace(isolation),
 		Invocation:   "manual",
 	})
 }

--- a/internal/cli/subagent_test.go
+++ b/internal/cli/subagent_test.go
@@ -30,6 +30,7 @@ func TestSubagentProfileCLIManageRoundTrip(t *testing.T) {
 		if rc := subagentCommand([]string{
 			"create", "helper", "--description", "Initial helper", "--prompt", "Initial prompt",
 			"--model", "provider/model", "--effort", "high", "--tools", "read_file,grep,read_file", "--color", "orange",
+			"--isolation", "worktree",
 		}); rc != 0 {
 			t.Fatalf("create rc = %d", rc)
 		}
@@ -44,17 +45,19 @@ func TestSubagentProfileCLIManageRoundTrip(t *testing.T) {
 	}
 	if sk.Scope != skill.ScopeProject || sk.RunAs != skill.RunSubagent || sk.Invocation != "manual" ||
 		sk.Description != "Initial helper" || sk.Body != "Initial prompt" || sk.Model != "provider/model" ||
-		sk.Effort != "high" || sk.Color != "orange" || strings.Join(sk.AllowedTools, ",") != "read_file,grep" {
+		sk.Effort != "high" || sk.Color != "orange" || sk.Isolation != "worktree" ||
+		strings.Join(sk.AllowedTools, ",") != "read_file,grep" {
 		t.Fatalf("created profile = %+v", sk)
 	}
 
 	if rc := subagentCommand([]string{
-		"edit", "helper", "--description", "Updated helper", "--prompt", "Updated prompt", "--model=", "--tools=",
+		"edit", "helper", "--description", "Updated helper", "--prompt", "Updated prompt", "--model=", "--tools=", "--isolation=",
 	}); rc != 0 {
 		t.Fatalf("edit rc = %d", rc)
 	}
 	sk, ok = store.Read("helper")
-	if !ok || sk.Description != "Updated helper" || sk.Body != "Updated prompt" || sk.Model != "" || len(sk.AllowedTools) != 0 {
+	if !ok || sk.Description != "Updated helper" || sk.Body != "Updated prompt" || sk.Model != "" ||
+		sk.Isolation != "" || len(sk.AllowedTools) != 0 {
 		t.Fatalf("updated profile = %+v, found=%v", sk, ok)
 	}
 
@@ -221,12 +224,14 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 
 	var normalCalls, readOnlyCalls int
 	var normalTask, tryTask string
+	var normalIsolation, tryIsolation string
 	setupSubagentCommand = func(context.Context, string, int, bool, event.Sink, string) (*control.Controller, error) {
 		return control.New(control.Options{
 			Skills: []skill.Skill{{Name: "helper", RunAs: skill.RunSubagent, Invocation: "manual", Scope: skill.ScopeGlobal}},
 			SkillRunner: func(_ context.Context, _ skill.Skill, task string, opts skill.SubagentRunOptions) (string, error) {
 				normalCalls++
 				normalTask = task
+				normalIsolation = opts.Isolation
 				if !opts.HostInitiated {
 					t.Fatal("run did not mark host-initiated invocation")
 				}
@@ -235,6 +240,7 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 			ReadOnlySkillRunner: func(_ context.Context, _ skill.Skill, task string, opts skill.SubagentRunOptions) (string, error) {
 				readOnlyCalls++
 				tryTask = task
+				tryIsolation = opts.Isolation
 				if !opts.HostInitiated {
 					t.Fatal("try did not mark host-initiated invocation")
 				}
@@ -244,12 +250,12 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 	}
 
 	out := captureStdout(t, func() {
-		if rc := subagentCommand([]string{"run", "helper", "inspect auth"}); rc != 0 {
+		if rc := subagentCommand([]string{"run", "helper", "--isolation", "worktree", "inspect auth"}); rc != 0 {
 			t.Fatalf("run rc = %d", rc)
 		}
 	})
-	if strings.TrimSpace(out) != "run answer" || normalCalls != 1 || normalTask != "inspect auth" || readOnlyCalls != 0 {
-		t.Fatalf("run output=%q normal=%d task=%q readonly=%d", out, normalCalls, normalTask, readOnlyCalls)
+	if strings.TrimSpace(out) != "run answer" || normalCalls != 1 || normalTask != "inspect auth" || normalIsolation != "worktree" || readOnlyCalls != 0 {
+		t.Fatalf("run output=%q normal=%d task=%q isolation=%q readonly=%d", out, normalCalls, normalTask, normalIsolation, readOnlyCalls)
 	}
 
 	out = captureStdout(t, func() {
@@ -257,8 +263,17 @@ func TestSubagentProfileCLIRunAndTrySelectIsolatedRunners(t *testing.T) {
 			t.Fatalf("try rc = %d", rc)
 		}
 	})
-	if strings.TrimSpace(out) != "try answer" || readOnlyCalls != 1 || tryTask != "inspect only" {
-		t.Fatalf("try output=%q readonly=%d task=%q", out, readOnlyCalls, tryTask)
+	if strings.TrimSpace(out) != "try answer" || readOnlyCalls != 1 || tryTask != "inspect only" || tryIsolation != "" {
+		t.Fatalf("try output=%q readonly=%d task=%q isolation=%q", out, readOnlyCalls, tryTask, tryIsolation)
+	}
+
+	errOut := captureStderr(t, func() {
+		if rc := subagentCommand([]string{"try", "helper", "--isolation", "worktree", "inspect only"}); rc != 2 {
+			t.Fatalf("try worktree rc = %d", rc)
+		}
+	})
+	if !strings.Contains(errOut, "read-only try does not support worktree isolation") {
+		t.Fatalf("try worktree error = %q", errOut)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1676,6 +1676,19 @@ func (c *Controller) Run(ctx context.Context, input string) (err error) {
 // stdout rendering and exit status. readOnly selects the preview-safe runner
 // used by `reasonix subagent try`.
 func (c *Controller) RunSubagentProfile(ctx context.Context, name, task string, readOnly bool) (string, error) {
+	return c.RunSubagentProfileWithOptions(ctx, name, task, RunSubagentProfileOptions{ReadOnly: readOnly})
+}
+
+// RunSubagentProfileOptions carries headless subagent invocation knobs that are
+// part of the public CLI contract but should not be encoded into prompt text.
+type RunSubagentProfileOptions struct {
+	ReadOnly  bool
+	Isolation string
+}
+
+// RunSubagentProfileWithOptions is the typed variant used by CLI/headless
+// adapters. Empty Isolation preserves the profile/default behavior.
+func (c *Controller) RunSubagentProfileWithOptions(ctx context.Context, name, task string, opts RunSubagentProfileOptions) (string, error) {
 	name = strings.TrimSpace(name)
 	task = strings.TrimSpace(task)
 	if name == "" {
@@ -1691,8 +1704,22 @@ func (c *Controller) RunSubagentProfile(ctx context.Context, name, task string, 
 	if sk.RunAs != skill.RunSubagent {
 		return "", fmt.Errorf("skill %q is not runAs=subagent", name)
 	}
+	isolation := strings.TrimSpace(opts.Isolation)
+	if isolation == "" {
+		isolation = strings.TrimSpace(sk.Isolation)
+	}
+	if isolation != "" {
+		normalized := skill.ParseIsolation(isolation)
+		if normalized == "" {
+			return "", fmt.Errorf("unsupported isolation %q; use none or worktree", isolation)
+		}
+		isolation = normalized
+	}
+	if opts.ReadOnly && isolation == "worktree" {
+		return "", fmt.Errorf("read-only subagent profile %q cannot use worktree isolation", name)
+	}
 	runner := c.skillRunner
-	if readOnly {
+	if opts.ReadOnly {
 		runner = c.readOnlySkillRunner
 	}
 	if runner == nil {
@@ -1707,7 +1734,10 @@ func (c *Controller) RunSubagentProfile(ctx context.Context, name, task string, 
 	ctx = agent.WithResponseLanguagePreference(ctx, c.responseLanguage)
 	ctx = agent.WithReasoningLanguagePreference(ctx, c.reasoningLanguage)
 	ctx = agent.WithSubagentDepth(ctx, 0)
-	answer, err := runner(ctx, sk, task, skill.SubagentRunOptions{HostInitiated: true})
+	answer, err := runner(ctx, sk, task, skill.SubagentRunOptions{
+		HostInitiated: true,
+		Isolation:     isolation,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -132,7 +132,11 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 		c.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: toolEvent})
 		runCtx := agent.WithToolCallContext(ctx, callID, c.sink, c, planMode)
 		runCtx = agent.WithSubagentDepth(runCtx, 0)
-		answer, err := runner(runCtx, sk, input, skill.SubagentRunOptions{HostInitiated: true})
+		runOpts := skill.SubagentRunOptions{HostInitiated: true}
+		if !sk.ReadOnly {
+			runOpts.Isolation = sk.Isolation
+		}
+		answer, err := runner(runCtx, sk, input, runOpts)
 		if err != nil {
 			toolEvent.Err = err.Error()
 			c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: toolEvent})

--- a/internal/skill/profile.go
+++ b/internal/skill/profile.go
@@ -45,7 +45,7 @@ func ValidateSubagentProfileName(name string, occupied []string) error {
 // profile editors can round-trip without changing execution semantics.
 var subagentProfileManagedKeys = map[string]bool{
 	"name": true, "description": true, "color": true, "invocation": true,
-	"runas": true, "model": true, "effort": true, "allowed-tools": true,
+	"runas": true, "model": true, "effort": true, "isolation": true, "allowed-tools": true,
 }
 
 // ValidateEditableSubagentProfile verifies that a loaded skill is a manual

--- a/internal/skill/profile_contract_test.go
+++ b/internal/skill/profile_contract_test.go
@@ -1,0 +1,60 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSubagentSkillIsolationFrontmatterLoadsWithoutRewriting(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".reasonix", SkillsDirname, "worker.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\ndescription: worker\nrunAs: subagent\ninvocation: manual\nmodel: deepseek-pro\neffort: auto\nallowed-tools: read_file, grep\nisolation: worktree\n---\nbody\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := store.Read("worker")
+	if !ok {
+		t.Fatal("skill not loaded")
+	}
+	if sk.RunAs != RunSubagent || sk.Model != "deepseek-pro" || sk.Effort != "auto" || sk.Invocation != "manual" {
+		t.Fatalf("subagent frontmatter parsed incorrectly: %+v", sk)
+	}
+	if len(sk.AllowedTools) != 2 || sk.AllowedTools[0] != "read_file" || sk.AllowedTools[1] != "grep" {
+		t.Fatalf("allowed tools parsed incorrectly: %#v", sk.AllowedTools)
+	}
+	if sk.Isolation != "worktree" {
+		t.Fatalf("isolation = %q, want worktree", sk.Isolation)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("Read should preserve unknown frontmatter on disk\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEditableSubagentProfileAcceptsManagedIsolationFrontmatter(t *testing.T) {
+	home := t.TempDir()
+	store := New(Options{HomeDir: home, DisableBuiltins: true})
+	if _, err := store.CreateWithContent("worker", ScopeGlobal, "---\ndescription: worker\nrunAs: subagent\ninvocation: manual\nisolation: worktree\n---\nbody\n"); err != nil {
+		t.Fatalf("CreateWithContent: %v", err)
+	}
+	sk, ok := store.Read("worker")
+	if !ok {
+		t.Fatal("skill not loaded")
+	}
+	if err := ValidateEditableSubagentProfile(sk); err != nil {
+		t.Fatalf("editable profile should accept managed isolation frontmatter: %v", err)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -77,6 +77,7 @@ type Skill struct {
 	RunAs        RunAs  // inline | subagent
 	Model        string // optional model override for runAs=subagent (frontmatter `model:`)
 	Effort       string // optional effort for runAs=subagent (frontmatter `effort:`)
+	Isolation    string // optional workspace isolation for runAs=subagent: none | worktree
 	// ReadOnly, when true, runs a subagent skill against the read-only tool
 	// registry: writer tools are stripped and bash enforces the read-only
 	// command policy at execution time (frontmatter `read-only:`). This is a
@@ -766,6 +767,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
 		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
 		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
+		Isolation:    ParseIsolation(fm[skillFrontmatterIsolation]),
 		ReadOnly:     parseBoolFrontmatter(fm[skillFrontmatterReadOnly]),
 		Triggers:     parseCSVFrontmatter(fm[skillFrontmatterTriggers]),
 		NegativeTriggers: parseCSVFrontmatter(
@@ -789,6 +791,17 @@ func firstNonEmptySkillValue(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func ParseIsolation(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "none":
+		return "none"
+	case "worktree":
+		return "worktree"
+	default:
+		return ""
+	}
 }
 
 func isClaudeModelAlias(model string) bool {
@@ -830,6 +843,7 @@ const (
 	skillFrontmatterAllowedTools     = "allowed-tools"
 	skillFrontmatterModel            = "model"
 	skillFrontmatterEffort           = "effort"
+	skillFrontmatterIsolation        = "isolation"
 	skillFrontmatterReadOnly         = "read-only"
 	skillFrontmatterTriggers         = "triggers"
 	skillFrontmatterNegativeTriggers = "negative-triggers"
@@ -851,6 +865,7 @@ var skillMarkerFrontmatterKeys = []string{
 	skillFrontmatterAllowedTools,
 	skillFrontmatterModel,
 	skillFrontmatterEffort,
+	skillFrontmatterIsolation,
 	skillFrontmatterReadOnly,
 	skillFrontmatterTriggers,
 	skillFrontmatterNegativeTriggers,

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -22,6 +22,7 @@ import (
 type SubagentRunOptions struct {
 	ContinueFrom string
 	ForkFrom     string
+	Isolation    string
 	// HostInitiated marks an explicit controller entry point such as
 	// /<subagent-skill>. It may still carry a synthetic call context for nested
 	// UI events, but that ephemeral event ID must not be persisted as though it
@@ -102,7 +103,11 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		return "", fmt.Errorf("run_skill: %w", err)
 	}
 	rawArgs := strings.TrimSpace(p.Arguments)
-	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
+	opts := SubagentRunOptions{
+		ContinueFrom: strings.TrimSpace(p.Continue),
+		ForkFrom:     strings.TrimSpace(p.Fork),
+		Isolation:    sk.Isolation,
+	}
 	if opts.ContinueFrom != "" && opts.ForkFrom != "" {
 		return "", fmt.Errorf("run_skill: continue_from and fork_from are mutually exclusive; pass only continue_from")
 	}
@@ -361,7 +366,11 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if t.runner == nil {
 		return "", fmt.Errorf("%s: no subagent runner is configured in this session", t.toolName)
 	}
-	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
+	opts := SubagentRunOptions{
+		ContinueFrom: strings.TrimSpace(p.Continue),
+		ForkFrom:     strings.TrimSpace(p.Fork),
+		Isolation:    sk.Isolation,
+	}
 	if opts.ContinueFrom != "" && opts.ForkFrom != "" {
 		return "", fmt.Errorf("%s: continue_from and fork_from are mutually exclusive; pass only continue_from", t.toolName)
 	}
@@ -467,6 +476,7 @@ func (*installSkillTool) Schema() json.RawMessage {
   "runAs":{"type":"string","enum":["inline","subagent"],"description":"inline (default) folds the body into the parent turn; subagent spawns an isolated child loop returning only its final answer (use for context-heavy work)."},
   "model":{"type":"string","description":"Optional model override for runAs=subagent (a configured provider/model name). Ignored otherwise."},
   "effort":{"type":"string","description":"Optional effort for runAs=subagent (e.g. high, max). Ignored otherwise."},
+  "isolation":{"type":"string","enum":["none","worktree"],"description":"Optional workspace isolation for runAs=subagent. Defaults to none; worktree creates a separate Git worktree and requires an explicit apply step."},
   "allowedTools":{"type":"array","items":{"type":"string"},"description":"Optional tool allowlist for runAs=subagent (e.g. ['read_file','grep'])."}
 },
 "required":["name","description","body"]
@@ -482,6 +492,7 @@ func (t *installSkillTool) Execute(_ context.Context, args json.RawMessage) (str
 		RunAs        string   `json:"runAs"`
 		Model        string   `json:"model"`
 		Effort       string   `json:"effort"`
+		Isolation    string   `json:"isolation"`
 		AllowedTools []string `json:"allowedTools"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
@@ -526,6 +537,7 @@ func (t *installSkillTool) Execute(_ context.Context, args json.RawMessage) (str
 		RunAs:        runAs,
 		Model:        strings.TrimSpace(p.Model),
 		Effort:       strings.TrimSpace(p.Effort),
+		Isolation:    strings.TrimSpace(p.Isolation),
 		AllowedTools: p.AllowedTools,
 	})
 	path, err := t.store.CreateWithContent(name, scope, content)
@@ -557,6 +569,7 @@ type SkillFileOptions struct {
 	RunAs        RunAs
 	Model        string // subagent-only; ignored when RunAs != RunSubagent
 	Effort       string // subagent-only; ignored when RunAs != RunSubagent
+	Isolation    string // subagent-only; none | worktree; ignored when RunAs != RunSubagent
 	AllowedTools []string
 	Color        string // optional display tag; emitted regardless of RunAs
 	// Invocation, when "manual", keeps the written skill out of the pinned
@@ -579,6 +592,7 @@ type skillFileFrontmatter struct {
 	RunAs        string   `yaml:"runAs,omitempty"`
 	Model        string   `yaml:"model,omitempty"`
 	Effort       string   `yaml:"effort,omitempty"`
+	Isolation    string   `yaml:"isolation,omitempty"`
 	AllowedTools []string `yaml:"allowed-tools,omitempty,flow"`
 }
 
@@ -598,6 +612,7 @@ func RenderSkillFile(opts SkillFileOptions) string {
 		fm.RunAs = string(RunSubagent)
 		fm.Model = strings.TrimSpace(opts.Model)
 		fm.Effort = strings.TrimSpace(opts.Effort)
+		fm.Isolation = ParseIsolation(opts.Isolation)
 		for _, t := range opts.AllowedTools {
 			if t = strings.TrimSpace(t); t != "" {
 				fm.AllowedTools = append(fm.AllowedTools, t)

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -76,10 +76,12 @@ func TestRunSkillSubagentNeedsRunner(t *testing.T) {
 
 func TestRunSkillSubagentRuns(t *testing.T) {
 	home := t.TempDir()
-	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\n---\nbody")
+	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\nisolation: worktree\n---\nbody")
 	var gotTask string
-	runner := func(_ context.Context, sk Skill, task string, _ SubagentRunOptions) (string, error) {
+	var gotOpts SubagentRunOptions
+	runner := func(_ context.Context, sk Skill, task string, opts SubagentRunOptions) (string, error) {
 		gotTask = task
+		gotOpts = opts
 		return "answer from " + sk.Name, nil
 	}
 	tl := NewRunSkillTool(New(Options{HomeDir: home, DisableBuiltins: true}), runner)
@@ -89,6 +91,9 @@ func TestRunSkillSubagentRuns(t *testing.T) {
 	}
 	if gotTask != "find X" {
 		t.Errorf("runner got task %q", gotTask)
+	}
+	if gotOpts.Isolation != "worktree" {
+		t.Errorf("runner isolation = %q, want worktree", gotOpts.Isolation)
 	}
 	if out != "answer from dig" {
 		t.Errorf("runner output not returned: %q", out)
@@ -177,6 +182,9 @@ func TestReadOnlySkillSubagentRunsWithoutContinuation(t *testing.T) {
 	}
 	if gotOpts.ContinueFrom != "" || gotOpts.ForkFrom != "" {
 		t.Fatalf("read_only_skill should not pass continuation opts, got %+v", gotOpts)
+	}
+	if gotOpts.Isolation != "" {
+		t.Fatalf("read_only_skill should not pass isolation opts, got %+v", gotOpts)
 	}
 	if out != "read-only answer from dig" {
 		t.Errorf("runner output not returned: %q", out)
@@ -408,7 +416,7 @@ func TestInstallSkill(t *testing.T) {
 	tl := NewInstallSkillTool(st, nil)
 
 	out, err := tl.Execute(context.Background(), json.RawMessage(
-		`{"name":"deploy","description":"ship it","body":"steps","runAs":"subagent","model":"deepseek-pro","effort":"max","allowedTools":["bash","read_file"]}`))
+		`{"name":"deploy","description":"ship it","body":"steps","runAs":"subagent","isolation":"worktree","model":"deepseek-pro","effort":"max","allowedTools":["bash","read_file"]}`))
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
@@ -436,8 +444,8 @@ func TestInstallSkill(t *testing.T) {
 	if !ok {
 		t.Fatal("installed skill not readable")
 	}
-	if sk.RunAs != RunSubagent || sk.Model != "deepseek-pro" || sk.Effort != "max" || len(sk.AllowedTools) != 2 {
-		t.Errorf("frontmatter not round-tripped: runAs=%s model=%q effort=%q tools=%v", sk.RunAs, sk.Model, sk.Effort, sk.AllowedTools)
+	if sk.RunAs != RunSubagent || sk.Isolation != "worktree" || sk.Model != "deepseek-pro" || sk.Effort != "max" || len(sk.AllowedTools) != 2 {
+		t.Errorf("frontmatter not round-tripped: runAs=%s isolation=%q model=%q effort=%q tools=%v", sk.RunAs, sk.Isolation, sk.Model, sk.Effort, sk.AllowedTools)
 	}
 	// Refuses overwrite.
 	if _, err := tl.Execute(context.Background(), json.RawMessage(
@@ -457,10 +465,11 @@ func TestRenderSkillFileEmitsColorAndInvocationWhenSet(t *testing.T) {
 		Description: "a private helper",
 		Body:        "be helpful",
 		RunAs:       RunSubagent,
+		Isolation:   "worktree",
 		Color:       "amber",
 		Invocation:  "manual",
 	})
-	for _, want := range []string{"color: amber\n", "invocation: manual\n", "runAs: subagent\n"} {
+	for _, want := range []string{"color: amber\n", "invocation: manual\n", "runAs: subagent\n", "isolation: worktree\n"} {
 		if !strings.Contains(content, want) {
 			t.Errorf("rendered content missing %q:\n%s", want, content)
 		}
@@ -475,8 +484,8 @@ func TestRenderSkillFileEmitsColorAndInvocationWhenSet(t *testing.T) {
 	if !ok {
 		t.Fatal("skill not readable after CreateWithContent")
 	}
-	if sk.Color != "amber" || sk.Invocation != "manual" {
-		t.Errorf("round-trip mismatch: color=%q invocation=%q", sk.Color, sk.Invocation)
+	if sk.Color != "amber" || sk.Invocation != "manual" || sk.Isolation != "worktree" {
+		t.Errorf("round-trip mismatch: color=%q invocation=%q isolation=%q", sk.Color, sk.Invocation, sk.Isolation)
 	}
 }
 
@@ -509,6 +518,7 @@ func TestRenderSkillFileEscapesYAMLMetacharacters(t *testing.T) {
 				Description: tc.desc,
 				Body:        "the body",
 				RunAs:       RunSubagent,
+				Isolation:   "worktree",
 				Invocation:  "manual",
 			})
 			if _, err := st.CreateWithContent("esc", ScopeGlobal, content); err != nil {
@@ -522,6 +532,9 @@ func TestRenderSkillFileEscapesYAMLMetacharacters(t *testing.T) {
 			// survive, never silently reset to their permissive defaults.
 			if sk.RunAs != RunSubagent {
 				t.Errorf("RunAs = %q, want subagent (isolation lost); content:\n%s", sk.RunAs, content)
+			}
+			if sk.Isolation != "worktree" {
+				t.Errorf("Isolation = %q, want worktree; content:\n%s", sk.Isolation, content)
 			}
 			if sk.Invocation != "manual" {
 				t.Errorf("Invocation = %q, want manual (autodiscovery re-enabled); content:\n%s", sk.Invocation, content)

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -52,8 +52,9 @@ const (
 )
 
 var (
-	ErrDirtySource   = errors.New("source workspace has uncommitted changes")
-	ErrApplyConflict = errors.New("worktree apply conflict")
+	ErrDirtySource        = errors.New("source workspace has uncommitted changes")
+	ErrApplyConflict      = errors.New("worktree apply conflict")
+	ErrResourceHasChanges = errors.New("worktree resource has changes")
 )
 
 // DirtySourceError is returned when policy requires a clean parent workspace.
@@ -141,6 +142,36 @@ func (e *ApplyConflictError) Error() string {
 }
 
 func (e *ApplyConflictError) Unwrap() error { return ErrApplyConflict }
+
+// ResourceChangesError prevents implicit cleanup from deleting uncommitted
+// files or commits that may belong to the user.
+type ResourceChangesError struct {
+	Paths       []string
+	HeadChanged bool
+}
+
+func (e *ResourceChangesError) Error() string {
+	parts := make([]string, 0, 2)
+	if len(e.Paths) > 0 {
+		parts = append(parts, "paths: "+strings.Join(e.Paths, ", "))
+	}
+	if e.HeadChanged {
+		parts = append(parts, "branch contains commits after the isolation base")
+	}
+	if len(parts) == 0 {
+		return ErrResourceHasChanges.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrResourceHasChanges, strings.Join(parts, "; "))
+}
+
+func (e *ResourceChangesError) Unwrap() error { return ErrResourceHasChanges }
+
+// GCResult reports which orphaned resources were reclaimed and which were
+// retained because their branch contains commits not represented elsewhere.
+type GCResult struct {
+	Removed []Resource `json:"removed,omitempty"`
+	Blocked []Resource `json:"blocked,omitempty"`
+}
 
 // Manager owns the durable lifecycle for worktrees under one managed root.
 type Manager struct {
@@ -378,6 +409,114 @@ func (m *Manager) Apply(ctx context.Context, res Resource) (ApplyResult, error) 
 		return ApplyResult{}, err
 	}
 	return ApplyResult{Status: ApplyStatusApplied, Paths: diff.Paths}, nil
+}
+
+// Remove safely removes an unchanged worktree. It refuses both uncommitted
+// changes and commits created after the isolation base.
+func (m *Manager) Remove(ctx context.Context, res Resource) (Resource, error) {
+	if res.CleanupState == CleanupStateRemoved {
+		return res, nil
+	}
+	status, err := m.Status(ctx, res)
+	if err != nil {
+		return Resource{}, err
+	}
+	head, err := worktreeHead(ctx, res.WorktreeRoot)
+	if err != nil {
+		return Resource{}, err
+	}
+	if status.Dirty || head != res.BaseCommit {
+		return Resource{}, &ResourceChangesError{Paths: status.Paths, HeadChanged: head != res.BaseCommit}
+	}
+	return m.removeResource(ctx, res, false)
+}
+
+// Discard explicitly removes a worktree and its managed branch even when it
+// contains changes. Callers must put this behind their approval boundary.
+func (m *Manager) Discard(ctx context.Context, res Resource) (Resource, error) {
+	return m.removeResource(ctx, res, true)
+}
+
+// GC reclaims orphaned resources only when their managed branch still points
+// at the original base commit. Branches with later commits are retained.
+func (m *Manager) GC(ctx context.Context) (GCResult, error) {
+	resources, err := m.List(ctx)
+	if err != nil {
+		return GCResult{}, err
+	}
+	var result GCResult
+	for _, res := range resources {
+		if res.CleanupState != CleanupStateOrphan {
+			continue
+		}
+		head, exists, err := branchHead(ctx, res.SourceRoot, res.Branch)
+		if err != nil {
+			return result, err
+		}
+		if exists && head != res.BaseCommit {
+			result.Blocked = append(result.Blocked, res)
+			continue
+		}
+		if exists {
+			if _, stderr, err := runGit(ctx, res.SourceRoot, "branch", "-D", res.Branch); err != nil {
+				return result, fmt.Errorf("delete orphaned worktree branch: %w%s", err, stderrSuffix(stderr))
+			}
+		}
+		res.LifecycleState = LifecycleStateRemoved
+		res.CleanupState = CleanupStateRemoved
+		if err := m.writeResource(res); err != nil {
+			return result, err
+		}
+		result.Removed = append(result.Removed, res)
+	}
+	return result, nil
+}
+
+func (m *Manager) removeResource(ctx context.Context, res Resource, force bool) (Resource, error) {
+	if res.CleanupState == CleanupStateRemoved {
+		return res, nil
+	}
+	if _, err := os.Stat(res.WorktreeRoot); err == nil {
+		args := []string{"worktree", "remove"}
+		if force {
+			args = append(args, "--force")
+		}
+		args = append(args, res.WorktreeRoot)
+		if _, stderr, err := runGit(ctx, res.SourceRoot, args...); err != nil {
+			return Resource{}, fmt.Errorf("remove managed worktree: %w%s", err, stderrSuffix(stderr))
+		}
+	} else if !os.IsNotExist(err) {
+		return Resource{}, fmt.Errorf("inspect managed worktree: %w", err)
+	}
+	if _, exists, err := branchHead(ctx, res.SourceRoot, res.Branch); err != nil {
+		return Resource{}, err
+	} else if exists {
+		if _, stderr, err := runGit(ctx, res.SourceRoot, "branch", "-D", res.Branch); err != nil {
+			return Resource{}, fmt.Errorf("delete managed worktree branch: %w%s", err, stderrSuffix(stderr))
+		}
+	}
+	res.LifecycleState = LifecycleStateRemoved
+	res.CleanupState = CleanupStateRemoved
+	if err := m.writeResource(res); err != nil {
+		return Resource{}, err
+	}
+	return res, nil
+}
+
+func worktreeHead(ctx context.Context, root string) (string, error) {
+	head, stderr, err := runGit(ctx, root, "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree head: %w%s", err, stderrSuffix(stderr))
+	}
+	return strings.TrimSpace(head), nil
+}
+
+func branchHead(ctx context.Context, sourceRoot, branch string) (head string, exists bool, err error) {
+	head, _, err = runGit(ctx, sourceRoot, "rev-parse", "--verify", "refs/heads/"+branch)
+	if err != nil {
+		return "", false, nil
+	}
+	return strings.TrimSpace(head), true, nil
 }
 
 func (m *Manager) writeResource(res Resource) error {

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -1,0 +1,482 @@
+package worktree
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const resourceMetadataFile = ".reasonix-worktree.json"
+
+// Kind identifies the feature that owns a managed worktree resource.
+type Kind string
+
+const (
+	KindDelivery Kind = "delivery"
+	KindSubagent Kind = "subagent"
+)
+
+// LifecycleState is persisted so crashed or resumed sessions can recover the
+// state of a managed worktree without guessing from UI history.
+type LifecycleState string
+
+const (
+	LifecycleStateCreated LifecycleState = "created"
+	LifecycleStateApplied LifecycleState = "applied"
+	LifecycleStateRemoved LifecycleState = "removed"
+)
+
+// CleanupState describes whether the resource is still present on disk.
+type CleanupState string
+
+const (
+	CleanupStateActive  CleanupState = "active"
+	CleanupStateOrphan  CleanupState = "orphaned"
+	CleanupStateRemoved CleanupState = "removed"
+)
+
+// DirtyPolicy controls how a source workspace with uncommitted changes is
+// handled before a child worktree is created.
+type DirtyPolicy string
+
+const (
+	DirtyPolicyCommittedHead DirtyPolicy = "committed-head"
+	DirtyPolicyReject        DirtyPolicy = "reject"
+)
+
+var (
+	ErrDirtySource   = errors.New("source workspace has uncommitted changes")
+	ErrApplyConflict = errors.New("worktree apply conflict")
+)
+
+// DirtySourceError is returned when policy requires a clean parent workspace.
+type DirtySourceError struct {
+	WorkspaceRoot string
+}
+
+func (e *DirtySourceError) Error() string {
+	if strings.TrimSpace(e.WorkspaceRoot) == "" {
+		return ErrDirtySource.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrDirtySource, e.WorkspaceRoot)
+}
+
+func (e *DirtySourceError) Unwrap() error { return ErrDirtySource }
+
+// CreatePolicy is the stable policy surface for managed worktree creation.
+type CreatePolicy struct {
+	Kind         Kind
+	BranchPrefix string
+	DirtyPolicy  DirtyPolicy
+	Durable      bool
+}
+
+// Resource is the durable identity of one managed worktree.
+type Resource struct {
+	IsolationID    string         `json:"isolation_id"`
+	Kind           Kind           `json:"kind"`
+	WorkspaceRoot  string         `json:"workspace_root"`
+	WorktreeRoot   string         `json:"worktree_root"`
+	SourceRoot     string         `json:"source_root"`
+	Branch         string         `json:"branch"`
+	BaseCommit     string         `json:"base_commit"`
+	HeadCommit     string         `json:"head_commit"`
+	SourceDirty    bool           `json:"source_dirty"`
+	LifecycleState LifecycleState `json:"lifecycle_state"`
+	CleanupState   CleanupState   `json:"cleanup_state"`
+	CreatedAt      time.Time      `json:"created_at"`
+
+	metadataPath string
+}
+
+// Status reports the current diff surface without mutating either workspace.
+type Status struct {
+	Dirty   bool     `json:"dirty"`
+	Paths   []string `json:"paths,omitempty"`
+	RawText string   `json:"raw_text,omitempty"`
+}
+
+// Diff contains the patch text and path list for explicit review/apply.
+type Diff struct {
+	Patch string   `json:"patch,omitempty"`
+	Paths []string `json:"paths,omitempty"`
+}
+
+// ApplyStatus is a structured apply result, not just a human string.
+type ApplyStatus string
+
+const (
+	ApplyStatusClean      ApplyStatus = "clean"
+	ApplyStatusApplied    ApplyStatus = "applied"
+	ApplyStatusConflicted ApplyStatus = "conflicted"
+	ApplyStatusBlocked    ApplyStatus = "blocked"
+)
+
+// ApplyResult describes the outcome of applying a child worktree patch back to
+// its source repository.
+type ApplyResult struct {
+	Status          ApplyStatus `json:"status"`
+	Paths           []string    `json:"paths,omitempty"`
+	ConflictedPaths []string    `json:"conflicted_paths,omitempty"`
+	Message         string      `json:"message,omitempty"`
+}
+
+// ApplyConflictError carries a structured conflict result.
+type ApplyConflictError struct {
+	Result ApplyResult
+}
+
+func (e *ApplyConflictError) Error() string {
+	if len(e.Result.ConflictedPaths) == 0 {
+		return ErrApplyConflict.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrApplyConflict, strings.Join(e.Result.ConflictedPaths, ", "))
+}
+
+func (e *ApplyConflictError) Unwrap() error { return ErrApplyConflict }
+
+// Manager owns the durable lifecycle for worktrees under one managed root.
+type Manager struct {
+	managedRoot string
+}
+
+// NewManager creates a worktree manager rooted at managedRoot.
+func NewManager(managedRoot string) *Manager {
+	return &Manager{managedRoot: strings.TrimSpace(managedRoot)}
+}
+
+func (m *Manager) managedRootOrError() (string, error) {
+	if m == nil || strings.TrimSpace(m.managedRoot) == "" {
+		return "", errors.New("Reasonix worktree storage is unavailable")
+	}
+	return m.managedRoot, nil
+}
+
+// Inspect checks whether workspaceRoot can be used as a source worktree.
+func (m *Manager) Inspect(ctx context.Context, workspaceRoot string) Availability {
+	return Inspect(ctx, workspaceRoot)
+}
+
+// Create makes a managed worktree resource according to policy.
+func (m *Manager) Create(ctx context.Context, workspaceRoot string, policy CreatePolicy) (Resource, error) {
+	managedRoot, err := m.managedRootOrError()
+	if err != nil {
+		return Resource{}, err
+	}
+	policy = normalizeCreatePolicy(policy)
+	info, err := inspect(ctx, workspaceRoot)
+	if err != nil {
+		return Resource{}, err
+	}
+	if info.SourceDirty && policy.DirtyPolicy == DirtyPolicyReject {
+		return Resource{}, &DirtySourceError{WorkspaceRoot: info.RepoRoot}
+	}
+	if err := os.MkdirAll(managedRoot, 0o700); err != nil {
+		return Resource{}, fmt.Errorf("create Reasonix worktree storage: %w", err)
+	}
+
+	repoKey := repoStorageKey(info.commonDir)
+	repoBase := safePathComponent(filepath.Base(info.RepoRoot))
+	if repoBase == "" {
+		repoBase = "repository"
+	}
+
+	now := time.Now().UTC()
+	for attempt := 0; attempt < 5; attempt++ {
+		id, randomErr := randomID()
+		if randomErr != nil {
+			return Resource{}, randomErr
+		}
+		branch := fmt.Sprintf("%s-%s-%s", strings.TrimRight(policy.BranchPrefix, "-/"), now.Format("20060102-150405"), id)
+		worktreeRoot := filepath.Join(managedRoot, repoKey, id, repoBase)
+		if _, statErr := os.Stat(worktreeRoot); statErr == nil {
+			continue
+		} else if !os.IsNotExist(statErr) {
+			return Resource{}, fmt.Errorf("inspect worktree destination: %w", statErr)
+		}
+		if err := os.MkdirAll(filepath.Dir(worktreeRoot), 0o700); err != nil {
+			return Resource{}, fmt.Errorf("create worktree parent: %w", err)
+		}
+
+		_, stderr, addErr := runGit(ctx, info.RepoRoot, "worktree", "add", "-b", branch, worktreeRoot, info.head)
+		if addErr != nil {
+			if strings.Contains(strings.ToLower(stderr), "already exists") {
+				continue
+			}
+			return Resource{}, fmt.Errorf("create Git worktree: %w%s", addErr, stderrSuffix(stderr))
+		}
+
+		selectedRoot := worktreeRoot
+		if prefix := filepath.FromSlash(strings.Trim(strings.TrimSpace(info.prefix), "/")); prefix != "" && prefix != "." {
+			selectedRoot = filepath.Join(worktreeRoot, prefix)
+			st, statErr := os.Stat(selectedRoot)
+			if statErr != nil || !st.IsDir() {
+				return Resource{}, fmt.Errorf("created worktree is missing selected project subdirectory %q", prefix)
+			}
+		}
+		res := Resource{
+			IsolationID:    id,
+			Kind:           policy.Kind,
+			WorkspaceRoot:  selectedRoot,
+			WorktreeRoot:   worktreeRoot,
+			SourceRoot:     info.RepoRoot,
+			Branch:         branch,
+			BaseCommit:     info.head,
+			HeadCommit:     info.head,
+			SourceDirty:    info.SourceDirty,
+			LifecycleState: LifecycleStateCreated,
+			CleanupState:   CleanupStateActive,
+			CreatedAt:      now,
+			metadataPath:   resourceMetadataPath(managedRoot, repoKey, id),
+		}
+		if err := m.writeResource(res); err != nil {
+			return Resource{}, err
+		}
+		return res, nil
+	}
+	return Resource{}, fmt.Errorf("could not allocate a unique %s worktree", policy.Kind)
+}
+
+// Show returns a resource by id.
+func (m *Manager) Show(ctx context.Context, isolationID string) (Resource, error) {
+	isolationID = strings.TrimSpace(isolationID)
+	if isolationID == "" {
+		return Resource{}, errors.New("worktree isolation id is required")
+	}
+	resources, err := m.List(ctx)
+	if err != nil {
+		return Resource{}, err
+	}
+	for _, res := range resources {
+		if res.IsolationID == isolationID {
+			return res, nil
+		}
+	}
+	return Resource{}, fmt.Errorf("worktree isolation %q was not found", isolationID)
+}
+
+// List returns persisted worktree resources, including removed records.
+func (m *Manager) List(ctx context.Context) ([]Resource, error) {
+	managedRoot, err := m.managedRootOrError()
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	var resources []Resource
+	if _, err := os.Stat(managedRoot); os.IsNotExist(err) {
+		return resources, nil
+	} else if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(managedRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != resourceMetadataFile {
+			return nil
+		}
+		res, readErr := readResource(path)
+		if readErr != nil {
+			return readErr
+		}
+		if res.CleanupState == CleanupStateActive {
+			if _, statErr := os.Stat(res.WorktreeRoot); os.IsNotExist(statErr) {
+				res.CleanupState = CleanupStateOrphan
+			}
+		}
+		res.metadataPath = path
+		resources = append(resources, res)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].CreatedAt.Equal(resources[j].CreatedAt) {
+			return resources[i].IsolationID < resources[j].IsolationID
+		}
+		return resources[i].CreatedAt.Before(resources[j].CreatedAt)
+	})
+	return resources, nil
+}
+
+// Status returns a porcelain status for the child worktree.
+func (m *Manager) Status(ctx context.Context, res Resource) (Status, error) {
+	if strings.TrimSpace(res.WorktreeRoot) == "" {
+		return Status{}, errors.New("worktree root is required")
+	}
+	out, stderr, err := runGit(ctx, res.WorktreeRoot, "status", "--porcelain=v1", "--untracked-files=normal")
+	if err != nil {
+		return Status{}, fmt.Errorf("inspect worktree status: %w%s", err, stderrSuffix(stderr))
+	}
+	paths := parsePorcelainPaths(out)
+	return Status{Dirty: strings.TrimSpace(out) != "", Paths: paths, RawText: strings.TrimRight(out, "\n")}, nil
+}
+
+// Diff returns the tracked patch plus changed paths. Untracked files are listed
+// in Paths but are deliberately not in Patch.
+func (m *Manager) Diff(ctx context.Context, res Resource) (Diff, error) {
+	status, err := m.Status(ctx, res)
+	if err != nil {
+		return Diff{}, err
+	}
+	patch, stderr, err := runGit(ctx, res.WorktreeRoot, "diff", "--binary", "HEAD")
+	if err != nil {
+		return Diff{}, fmt.Errorf("build worktree diff: %w%s", err, stderrSuffix(stderr))
+	}
+	return Diff{Patch: patch, Paths: status.Paths}, nil
+}
+
+// Apply explicitly applies a clean child worktree patch back to the source repo.
+func (m *Manager) Apply(ctx context.Context, res Resource) (ApplyResult, error) {
+	status, err := m.Status(ctx, res)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if !status.Dirty {
+		return ApplyResult{Status: ApplyStatusClean}, nil
+	}
+	untracked := untrackedPaths(status.RawText)
+	if len(untracked) > 0 {
+		return ApplyResult{Status: ApplyStatusBlocked, Paths: status.Paths, Message: "untracked files must be handled before apply"}, errors.New("cannot apply worktree with untracked files")
+	}
+	diff, err := m.Diff(ctx, res)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if strings.TrimSpace(diff.Patch) == "" {
+		return ApplyResult{Status: ApplyStatusBlocked, Paths: status.Paths, Message: "no tracked patch is available"}, errors.New("no tracked patch is available")
+	}
+	if _, stderr, checkErr := runGitInput(ctx, res.SourceRoot, []byte(diff.Patch), "apply", "--check", "-"); checkErr != nil {
+		result := ApplyResult{
+			Status:          ApplyStatusConflicted,
+			Paths:           diff.Paths,
+			ConflictedPaths: diff.Paths,
+			Message:         strings.TrimSpace(stderr),
+		}
+		return result, &ApplyConflictError{Result: result}
+	}
+	if _, stderr, applyErr := runGitInput(ctx, res.SourceRoot, []byte(diff.Patch), "apply", "-"); applyErr != nil {
+		return ApplyResult{}, fmt.Errorf("apply worktree diff: %w%s", applyErr, stderrSuffix(stderr))
+	}
+	res.LifecycleState = LifecycleStateApplied
+	if err := m.writeResource(res); err != nil {
+		return ApplyResult{}, err
+	}
+	return ApplyResult{Status: ApplyStatusApplied, Paths: diff.Paths}, nil
+}
+
+func (m *Manager) writeResource(res Resource) error {
+	path := res.metadataPath
+	if path == "" {
+		managedRoot, err := m.managedRootOrError()
+		if err != nil {
+			return err
+		}
+		repoKey := repoStorageKey(res.SourceRoot)
+		path = resourceMetadataPath(managedRoot, repoKey, res.IsolationID)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create worktree metadata directory: %w", err)
+	}
+	data, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode worktree metadata: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write worktree metadata: %w", err)
+	}
+	return nil
+}
+
+func normalizeCreatePolicy(policy CreatePolicy) CreatePolicy {
+	if policy.Kind == "" {
+		policy.Kind = KindDelivery
+	}
+	if policy.BranchPrefix == "" {
+		switch policy.Kind {
+		case KindSubagent:
+			policy.BranchPrefix = "reasonix/subagent"
+		default:
+			policy.BranchPrefix = "reasonix/delivery"
+		}
+	}
+	if policy.DirtyPolicy == "" {
+		switch policy.Kind {
+		case KindSubagent:
+			policy.DirtyPolicy = DirtyPolicyReject
+		default:
+			policy.DirtyPolicy = DirtyPolicyCommittedHead
+		}
+	}
+	return policy
+}
+
+func repoStorageKey(commonDir string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(strings.TrimSpace(commonDir))))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func readResource(path string) (Resource, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Resource{}, err
+	}
+	var res Resource
+	if err := json.Unmarshal(data, &res); err != nil {
+		return Resource{}, fmt.Errorf("decode worktree metadata %s: %w", path, err)
+	}
+	res.metadataPath = path
+	return res, nil
+}
+
+func resourceMetadataPath(managedRoot, repoKey, id string) string {
+	return filepath.Join(managedRoot, repoKey, id, resourceMetadataFile)
+}
+
+func parsePorcelainPaths(out string) []string {
+	var paths []string
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		path := line
+		if len(line) > 3 {
+			path = line[3:]
+		}
+		path = strings.TrimSpace(path)
+		if before, after, ok := strings.Cut(path, " -> "); ok {
+			_ = before
+			path = strings.TrimSpace(after)
+		}
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
+func untrackedPaths(porcelain string) []string {
+	var paths []string
+	for _, line := range strings.Split(strings.TrimRight(porcelain, "\n"), "\n") {
+		if strings.HasPrefix(line, "?? ") {
+			paths = append(paths, strings.TrimSpace(line[3:]))
+		}
+	}
+	return paths
+}

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,0 +1,196 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagerRejectsDirtySourceForSubagentWorktree(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mgr := NewManager(t.TempDir())
+	_, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if !errors.Is(err, ErrDirtySource) {
+		t.Fatalf("Create err = %v, want ErrDirtySource", err)
+	}
+	list, listErr := mgr.List(ctx)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	if len(list) != 0 {
+		t.Fatalf("dirty source should not create resources, got %d", len(list))
+	}
+}
+
+func TestManagerCreatesInspectableSubagentResource(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	managed := t.TempDir()
+	mgr := NewManager(managed)
+
+	res, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kind != KindSubagent {
+		t.Fatalf("kind = %q", res.Kind)
+	}
+	if res.IsolationID == "" {
+		t.Fatal("isolation id is empty")
+	}
+	if !strings.HasPrefix(res.Branch, "reasonix/subagent-") {
+		t.Fatalf("branch = %q", res.Branch)
+	}
+	if res.WorkspaceRoot != res.WorktreeRoot {
+		t.Fatalf("workspace root = %q, worktree root = %q", res.WorkspaceRoot, res.WorktreeRoot)
+	}
+	if res.SourceRoot == res.WorktreeRoot || res.SourceRoot == "" {
+		t.Fatalf("source root = %q, worktree root = %q", res.SourceRoot, res.WorktreeRoot)
+	}
+	if res.BaseCommit == "" || res.HeadCommit == "" || res.BaseCommit != res.HeadCommit {
+		t.Fatalf("commits = base %q head %q", res.BaseCommit, res.HeadCommit)
+	}
+	if res.LifecycleState != LifecycleStateCreated || res.CleanupState != CleanupStateActive || res.CreatedAt.IsZero() {
+		t.Fatalf("unexpected lifecycle: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(res.WorktreeRoot, "README.md")); err != nil {
+		t.Fatalf("worktree missing committed file: %v", err)
+	}
+
+	list, err := mgr.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].IsolationID != res.IsolationID {
+		t.Fatalf("List = %+v, want one resource %q", list, res.IsolationID)
+	}
+	shown, err := mgr.Show(ctx, res.IsolationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shown.Branch != res.Branch {
+		t.Fatalf("Show branch = %q, want %q", shown.Branch, res.Branch)
+	}
+	status, err := mgr.Status(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dirty {
+		t.Fatalf("new worktree status dirty: %+v", status)
+	}
+
+	if err := os.WriteFile(filepath.Join(res.WorktreeRoot, "README.md"), []byte("child edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	status, err = mgr.Status(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Dirty || len(status.Paths) != 1 || status.Paths[0] != "README.md" {
+		t.Fatalf("dirty status = %+v", status)
+	}
+	diff, err := mgr.Diff(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(diff.Patch, "+child edit") || len(diff.Paths) != 1 || diff.Paths[0] != "README.md" {
+		t.Fatalf("diff = %+v", diff)
+	}
+}
+
+func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	mgr := NewManager(t.TempDir())
+
+	first, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(first.WorktreeRoot, "README.md"), []byte("first writer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := mgr.Apply(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != ApplyStatusApplied || len(result.Paths) != 1 || result.Paths[0] != "README.md" {
+		t.Fatalf("first apply result = %+v", result)
+	}
+	sourceBytes, err := os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceBytes) != "first writer\n" {
+		t.Fatalf("source content after clean apply = %q", sourceBytes)
+	}
+
+	if err := os.WriteFile(filepath.Join(second.WorktreeRoot, "README.md"), []byte("second writer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err = mgr.Apply(ctx, second)
+	if !errors.Is(err, ErrApplyConflict) {
+		t.Fatalf("second apply err = %v, want ErrApplyConflict", err)
+	}
+	if result.Status != ApplyStatusConflicted || len(result.ConflictedPaths) != 1 || result.ConflictedPaths[0] != "README.md" {
+		t.Fatalf("second apply result = %+v", result)
+	}
+	sourceBytes, err = os.ReadFile(filepath.Join(repo, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceBytes) != "first writer\n" {
+		t.Fatalf("conflicting apply polluted source content = %q", sourceBytes)
+	}
+	status := gitStatus(t, repo)
+	if strings.Contains(status, "UU ") || strings.Contains(status, "<<<<<<<") {
+		t.Fatalf("source repo has unresolved conflict state: %q", status)
+	}
+}
+
+func TestLegacyCreateUsesDeliveryPolicyAndAllowsDirtyCommittedHead(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "scratch.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Create(ctx, repo, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result.Branch, "reasonix/delivery-") {
+		t.Fatalf("branch = %q", result.Branch)
+	}
+	if !result.SourceDirty {
+		t.Fatalf("SourceDirty = false, want true")
+	}
+	if _, err := os.Stat(filepath.Join(result.WorktreeRoot, "scratch.txt")); !os.IsNotExist(err) {
+		t.Fatalf("dirty source file must not be copied, stat err = %v", err)
+	}
+}
+
+func gitStatus(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "status", "--porcelain=v1", "--untracked-files=normal")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	return string(out)
+}

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -185,6 +185,131 @@ func TestLegacyCreateUsesDeliveryPolicyAndAllowsDirtyCommittedHead(t *testing.T)
 	}
 }
 
+func TestManagerRemoveRefusesUncommittedAndCommittedChanges(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	mgr := NewManager(t.TempDir())
+
+	dirty, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirty.WorktreeRoot, "README.md"), []byte("dirty child\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.Remove(ctx, dirty); !errors.Is(err, ErrResourceHasChanges) {
+		t.Fatalf("Remove dirty err = %v, want ErrResourceHasChanges", err)
+	}
+	if _, err := os.Stat(dirty.WorktreeRoot); err != nil {
+		t.Fatalf("dirty worktree was removed: %v", err)
+	}
+
+	committed, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(committed.WorktreeRoot, "README.md"), []byte("committed child\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, committed.WorktreeRoot, "add", "README.md")
+	runGitTest(t, committed.WorktreeRoot, "commit", "-m", "child commit")
+	if _, err := mgr.Remove(ctx, committed); !errors.Is(err, ErrResourceHasChanges) {
+		t.Fatalf("Remove committed err = %v, want ErrResourceHasChanges", err)
+	}
+	if _, err := os.Stat(committed.WorktreeRoot); err != nil {
+		t.Fatalf("committed worktree was removed: %v", err)
+	}
+}
+
+func TestManagerDiscardRequiresExplicitCallAndPersistsRemoval(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	mgr := NewManager(t.TempDir())
+	res, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(res.WorktreeRoot, "scratch.txt"), []byte("user data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := mgr.Discard(ctx, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.CleanupState != CleanupStateRemoved || removed.LifecycleState != LifecycleStateRemoved {
+		t.Fatalf("removed resource = %+v", removed)
+	}
+	if _, err := os.Stat(res.WorktreeRoot); !os.IsNotExist(err) {
+		t.Fatalf("discarded worktree still exists: %v", err)
+	}
+	shown, err := mgr.Show(ctx, res.IsolationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shown.CleanupState != CleanupStateRemoved {
+		t.Fatalf("persisted cleanup state = %q", shown.CleanupState)
+	}
+}
+
+func TestManagerGCReclaimsSafeOrphanAndRetainsCommittedBranch(t *testing.T) {
+	requireGit(t)
+	ctx := context.Background()
+	repo := initRepo(t)
+	mgr := NewManager(t.TempDir())
+
+	safe, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(safe.WorktreeRoot); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repo, "worktree", "prune")
+
+	committed, err := mgr.Create(ctx, repo, CreatePolicy{Kind: KindSubagent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(committed.WorktreeRoot, "README.md"), []byte("orphan commit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, committed.WorktreeRoot, "add", "README.md")
+	runGitTest(t, committed.WorktreeRoot, "commit", "-m", "orphan commit")
+	if err := os.RemoveAll(committed.WorktreeRoot); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repo, "worktree", "prune")
+
+	result, err := mgr.GC(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0].IsolationID != safe.IsolationID {
+		t.Fatalf("GC removed = %+v, want safe orphan", result.Removed)
+	}
+	if len(result.Blocked) != 1 || result.Blocked[0].IsolationID != committed.IsolationID {
+		t.Fatalf("GC blocked = %+v, want committed orphan", result.Blocked)
+	}
+	if out := runGitTest(t, repo, "branch", "--list", safe.Branch); strings.TrimSpace(out) != "" {
+		t.Fatalf("safe orphan branch remains: %q", out)
+	}
+	if out := runGitTest(t, repo, "branch", "--list", committed.Branch); strings.TrimSpace(out) == "" {
+		t.Fatal("committed orphan branch was deleted")
+	}
+}
+
+func runGitTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
 func gitStatus(t *testing.T, repo string) string {
 	t.Helper()
 	cmd := exec.Command("git", "-C", repo, "status", "--porcelain=v1", "--untracked-files=normal")

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -136,7 +136,7 @@ func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sourceBytes) != "first writer\n" {
+	if strings.ReplaceAll(string(sourceBytes), "\r\n", "\n") != "first writer\n" {
 		t.Fatalf("source content after clean apply = %q", sourceBytes)
 	}
 
@@ -154,7 +154,7 @@ func TestManagerApplyCleanPatchAndReportConflictWithoutPollution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(sourceBytes) != "first writer\n" {
+	if strings.ReplaceAll(string(sourceBytes), "\r\n", "\n") != "first writer\n" {
 		t.Fatalf("conflicting apply polluted source content = %q", sourceBytes)
 	}
 	status := gitStatus(t, repo)
@@ -302,7 +302,12 @@ func TestManagerGCReclaimsSafeOrphanAndRetainsCommittedBranch(t *testing.T) {
 
 func runGitTest(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	baseArgs := []string{
+		"-c", "user.name=Reasonix Test",
+		"-c", "user.email=reasonix-test@example.invalid",
+		"-C", dir,
+	}
+	cmd := exec.Command("git", append(baseArgs, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -67,70 +66,22 @@ func Inspect(ctx context.Context, workspaceRoot string) Availability {
 // subdirectory, Result.WorkspaceRoot points at the corresponding subdirectory
 // in the new worktree.
 func Create(ctx context.Context, workspaceRoot, managedRoot string) (Result, error) {
-	info, err := inspect(ctx, workspaceRoot)
+	res, err := NewManager(managedRoot).Create(ctx, workspaceRoot, CreatePolicy{
+		Kind:        KindDelivery,
+		DirtyPolicy: DirtyPolicyCommittedHead,
+		Durable:     true,
+	})
 	if err != nil {
 		return Result{}, err
 	}
-	managedRoot = strings.TrimSpace(managedRoot)
-	if managedRoot == "" {
-		return Result{}, errors.New("Reasonix worktree storage is unavailable")
-	}
-	if err := os.MkdirAll(managedRoot, 0o700); err != nil {
-		return Result{}, fmt.Errorf("create Reasonix worktree storage: %w", err)
-	}
-
-	repoSum := sha256.Sum256([]byte(info.commonDir))
-	repoKey := hex.EncodeToString(repoSum[:8])
-	repoBase := safePathComponent(filepath.Base(info.RepoRoot))
-	if repoBase == "" {
-		repoBase = "repository"
-	}
-
-	for attempt := 0; attempt < 5; attempt++ {
-		id, randomErr := randomID()
-		if randomErr != nil {
-			return Result{}, randomErr
-		}
-		branch := fmt.Sprintf("reasonix/delivery-%s-%s", time.Now().Format("20060102-150405"), id)
-		worktreeRoot := filepath.Join(managedRoot, repoKey, id, repoBase)
-		if _, statErr := os.Stat(worktreeRoot); statErr == nil {
-			continue
-		} else if !os.IsNotExist(statErr) {
-			return Result{}, fmt.Errorf("inspect worktree destination: %w", statErr)
-		}
-		if err := os.MkdirAll(filepath.Dir(worktreeRoot), 0o700); err != nil {
-			return Result{}, fmt.Errorf("create worktree parent: %w", err)
-		}
-
-		_, stderr, addErr := runGit(ctx, info.RepoRoot, "worktree", "add", "-b", branch, worktreeRoot, info.head)
-		if addErr != nil {
-			// A random branch collision is retryable. We deliberately leave any
-			// non-empty partial directory untouched rather than risk deleting user
-			// data after Git returned an ambiguous failure.
-			if strings.Contains(strings.ToLower(stderr), "already exists") {
-				continue
-			}
-			return Result{}, fmt.Errorf("create Git worktree: %w%s", addErr, stderrSuffix(stderr))
-		}
-
-		selectedRoot := worktreeRoot
-		if prefix := filepath.FromSlash(strings.Trim(strings.TrimSpace(info.prefix), "/")); prefix != "" && prefix != "." {
-			selectedRoot = filepath.Join(worktreeRoot, prefix)
-			st, statErr := os.Stat(selectedRoot)
-			if statErr != nil || !st.IsDir() {
-				return Result{}, fmt.Errorf("created worktree is missing selected project subdirectory %q", prefix)
-			}
-		}
-		return Result{
-			WorkspaceRoot: selectedRoot,
-			WorktreeRoot:  worktreeRoot,
-			SourceRoot:    info.RepoRoot,
-			Branch:        branch,
-			Head:          info.head,
-			SourceDirty:   info.SourceDirty,
-		}, nil
-	}
-	return Result{}, errors.New("could not allocate a unique Delivery worktree")
+	return Result{
+		WorkspaceRoot: res.WorkspaceRoot,
+		WorktreeRoot:  res.WorktreeRoot,
+		SourceRoot:    res.SourceRoot,
+		Branch:        res.Branch,
+		Head:          res.BaseCommit,
+		SourceDirty:   res.SourceDirty,
+	}, nil
 }
 
 // IsManagedPath reports whether path belongs to Reasonix's durable worktree
@@ -235,6 +186,25 @@ func runGit(parent context.Context, dir string, args ...string) (stdout, stderr 
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", gitCommandArgs(runtime.GOOS, dir, args...)...)
 	proc.HideWindow(cmd)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return outBuf.String(), strings.TrimSpace(errBuf.String()), err
+}
+
+func runGitInput(parent context.Context, dir string, input []byte, args ...string) (stdout, stderr string, err error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, gitTimeout(args))
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", gitCommandArgs(runtime.GOOS, dir, args...)...)
+	proc.HideWindow(cmd)
+	cmd.Stdin = bytes.NewReader(input)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
## 中文

> 依赖 / Depends on #6647。当前 PR 以 stacked diff 包含基础 Worktree Manager；#6647 合并后，本 PR 将只保留 Subagent 隔离增量。

为可写 Subagent 增加**显式、可恢复、可审查**的 Git worktree 隔离。现有行为保持兼容：`isolation` 默认仍为 `none`，不会静默改变现有 task、profile 或只读 Subagent。

### 协议与入口

- 新增稳定枚举：`isolation: none | worktree`
- 贯通 task tool schema、`runAs: subagent` profile、CLI create/edit/run/try
- 将 isolation identity 与 lifecycle metadata 持久化到 Subagent run
- Headless / ACP 可投影隔离资源状态，供自动化客户端审查

### 运行时语义

- child workspace、文件工具、Bash、项目配置、instructions、skills、commands、hooks 与 MCP discovery 全部绑定隔离后的 root
- 动态 worktree path 只进入 runtime metadata / dynamic tail，不进入 cache-stable prompt prefix
- source workspace 有未提交修改时 fail closed，避免 child 静默遗漏 parent 的 dirty diff
- read-only/shared workspace 不创建无意义 worktree
- background writer 可并行运行，各自 diff 独立，parent workspace 保持不变

### 生命周期与安全边界

- 完成 Subagent 任务只返回 exact path、branch、diff/stat，不自动 apply
- apply、discard、remove、GC 均为显式操作
- apply 冲突返回结构化状态与精确路径，不允许半应用污染 parent
- resume / `continue_from` 可重新定位同一 isolation resource
- worktree isolation 不替代 permission、sandbox、folder trust 或 hook trust

### 本轮 CI 修正

- 测试 Git 提交显式注入 identity，不依赖 CI runner 的全局 Git 配置
- Windows 断言统一 CRLF/LF 语义
- 修复真实后台竞态：在 run 交给 goroutine 前生成 immutable background reference，避免完成路径更新 metadata 时与 launch 返回路径并发读取

### 验证

- `go test -count=1 ./internal/worktree ./internal/agent`
- `go test -race -count=1 ./internal/agent -run 'TestTaskToolBackground(CapRefusesFanOut|SalvagePublishesEvidenceForCollection)'`
- `go test -count=1 ./internal/control ./internal/cli ./internal/skill`
- `git diff --check`

## English

Adds **explicit, recoverable, and reviewable** Git worktree isolation for writer-capable subagents without changing the compatibility default.

- Threads `isolation: none | worktree` through task schema, subagent profiles, CLI, persisted run metadata, and protocol projections.
- Rebinds the complete child runtime to the isolated root.
- Fails closed on dirty source workspaces instead of silently dropping parent changes.
- Keeps read-only subagents on the shared workspace.
- Never auto-applies child changes; apply/discard/remove/GC remain explicit lifecycle operations.
- Preserves isolation identity across resume and `continue_from`.
- Reports apply conflicts structurally and keeps the parent workspace unmodified on failure.
- Keeps worktree isolation independent from permissions, sandboxing, folder trust, and hook trust.
- Fixes a background-run metadata race found by GitHub race CI.

## Cache impact review

Cache-impact: medium - adds opt-in isolation fields and runtime wiring while preserving isolation=none as the default

Cache-guard: go test -count=1 ./internal/boot ./internal/agent ./internal/skill && go test -run TestCacheHitPrefixStable -count=1 ./internal/agent

System-prompt-review: reviewed; dynamic worktree paths stay in runtime metadata and the runtime tail, outside the cache-stable prefix
