### PR TITLE
feat(memory): add provenance-aware diverse recall / 增加来源感知与多样性记忆召回

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -834,7 +834,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "memory tools are already enabled."
 		}
 		memoryToolsAdded = true
-		reg.Add(memory.NewRecallTool(mem.Store))
+		recallPolicy := cfg.MemoryRecallPolicy()
+		reg.Add(memory.NewRecallToolWithOptions(mem.Store, memory.RecallOptions{
+			Diversity:          recallPolicy.Diversity,
+			DiversityWeight:    recallPolicy.DiversityWeight,
+			DuplicateThreshold: recallPolicy.DuplicateThreshold,
+			Staleness:          recallPolicy.Staleness,
+			StalenessHalfLife:  time.Duration(recallPolicy.StalenessHalfLifeDays * float64(24*time.Hour)),
+		}))
 		reg.Add(memory.NewRememberTool(mem.Store))
 		reg.Add(memory.NewForgetTool(mem.Store))
 		return "enabled memory, remember, forget."

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1083,6 +1083,52 @@ type AgentConfig struct {
 	// PlanModeReadOnlyCommands is retained for old config/session round trips. Main
 	// Plan bash calls now use the ordinary Permissions classifier and Sandbox.
 	PlanModeReadOnlyCommands []string `toml:"plan_mode_read_only_commands"`
+	// MemoryRecall controls the lightweight post-BM25 ranking layer. It remains
+	// user-global so a cloned repository cannot silently weaken recall quality.
+	MemoryRecall MemoryRecallConfig `toml:"memory_recall"`
+}
+
+// MemoryRecallConfig controls duplicate suppression and freshness influence.
+// Pointer booleans distinguish an omitted setting (enabled by default) from an
+// explicit opt-out while keeping old configuration files compatible.
+type MemoryRecallConfig struct {
+	Diversity             *bool   `toml:"diversity"`
+	DiversityWeight       float64 `toml:"diversity_weight"`
+	DuplicateThreshold    float64 `toml:"duplicate_threshold"`
+	Staleness             *bool   `toml:"staleness"`
+	StalenessHalfLifeDays float64 `toml:"staleness_half_life_days"`
+}
+
+const (
+	DefaultMemoryRecallDiversityWeight       = 0.35
+	DefaultMemoryRecallDuplicateThreshold    = 0.82
+	DefaultMemoryRecallStalenessHalfLifeDays = 365.0
+)
+
+// MemoryRecallPolicy returns normalized user-global recall policy values.
+func (c *Config) MemoryRecallPolicy() MemoryRecallConfig {
+	var policy MemoryRecallConfig
+	if c != nil {
+		policy = c.Agent.MemoryRecall
+	}
+	if policy.Diversity == nil {
+		enabled := true
+		policy.Diversity = &enabled
+	}
+	if policy.Staleness == nil {
+		enabled := true
+		policy.Staleness = &enabled
+	}
+	if policy.DiversityWeight <= 0 || policy.DiversityWeight > 1 {
+		policy.DiversityWeight = DefaultMemoryRecallDiversityWeight
+	}
+	if policy.DuplicateThreshold <= 0 || policy.DuplicateThreshold > 1 {
+		policy.DuplicateThreshold = DefaultMemoryRecallDuplicateThreshold
+	}
+	if policy.StalenessHalfLifeDays <= 0 {
+		policy.StalenessHalfLifeDays = DefaultMemoryRecallStalenessHalfLifeDays
+	}
+	return policy
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -14,6 +14,25 @@ func TestDefaultReasoningLanguageAuto(t *testing.T) {
 	}
 }
 
+func TestDefaultMemoryRecallPolicy(t *testing.T) {
+	policy := Default().MemoryRecallPolicy()
+	if policy.Diversity == nil || !*policy.Diversity || policy.Staleness == nil || !*policy.Staleness {
+		t.Fatalf("default memory recall policy should enable diversity and staleness: %+v", policy)
+	}
+	if policy.DiversityWeight != DefaultMemoryRecallDiversityWeight ||
+		policy.DuplicateThreshold != DefaultMemoryRecallDuplicateThreshold ||
+		policy.StalenessHalfLifeDays != DefaultMemoryRecallStalenessHalfLifeDays {
+		t.Fatalf("unexpected default memory recall policy: %+v", policy)
+	}
+	disabled := false
+	cfg := Default()
+	cfg.Agent.MemoryRecall.Diversity = &disabled
+	cfg.Agent.MemoryRecall.Staleness = &disabled
+	policy = cfg.MemoryRecallPolicy()
+	if *policy.Diversity || *policy.Staleness {
+		t.Fatalf("explicit memory recall opt-out was not preserved: %+v", policy)
+	}
+}
 func TestDefaultDesktopAppearanceAutoGraphite(t *testing.T) {
 	cfg := Default()
 	if got := cfg.DesktopTheme(); got != "auto" {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -71,6 +71,15 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 		}
 		userDefaultModelExplicit = tomlFileDefinesKey(uc, "default_model")
 	}
+	globalMemoryRecall := cfg.Agent.MemoryRecall
+	if cfg.Agent.MemoryRecall.Diversity != nil {
+		v := *cfg.Agent.MemoryRecall.Diversity
+		globalMemoryRecall.Diversity = &v
+	}
+	if cfg.Agent.MemoryRecall.Staleness != nil {
+		v := *cfg.Agent.MemoryRecall.Staleness
+		globalMemoryRecall.Staleness = &v
+	}
 	userDefaultModel := cfg.DefaultModel
 	globalSecrets := cfg.Secrets
 
@@ -78,6 +87,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	if err := mergeTOML(cfg, projectTOML); err != nil {
 		return nil, err
 	}
+	cfg.Agent.MemoryRecall = globalMemoryRecall
 	// Secret protection is a user-global security control: a cloned repo's
 	// reasonix.toml must not be able to flip on the workflow-breaking env/path
 	// protections.

--- a/internal/config/load_project_default_test.go
+++ b/internal/config/load_project_default_test.go
@@ -182,3 +182,24 @@ api_key_env = "DEEPSEEK_API_KEY"
 		t.Fatalf("IgnoredProjectDefaultModel() = %q, want empty", got)
 	}
 }
+
+func TestLoadForRoot_ProjectCannotOverrideUserMemoryRecallPolicy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	writeProjectDefaultTestConfig(t, home, "config.toml", `[agent]
+memory_recall = { diversity = false, diversity_weight = 0.2, duplicate_threshold = 0.7, staleness = false, staleness_half_life_days = 90 }
+`)
+	project := t.TempDir()
+	writeProjectDefaultTestConfig(t, project, "reasonix.toml", `[agent]
+memory_recall = { diversity = true, diversity_weight = 0.9, duplicate_threshold = 0.95, staleness = true, staleness_half_life_days = 1 }
+`)
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	policy := cfg.MemoryRecallPolicy()
+	if *policy.Diversity || *policy.Staleness || policy.DiversityWeight != 0.2 ||
+		policy.DuplicateThreshold != 0.7 || policy.StalenessHalfLifeDays != 90 {
+		t.Fatalf("project changed user-global memory recall policy: %+v", policy)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -211,6 +211,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			autoPlan = "off"
 		}
 		fmt.Fprintf(&b, "auto_plan   = %q   # user-level only: off|on; off keeps plan mode manual\n", autoPlan)
+		recall := c.MemoryRecallPolicy()
+		fmt.Fprintf(&b, "memory_recall = { diversity = %v, diversity_weight = %s, duplicate_threshold = %s, staleness = %v, staleness_half_life_days = %s }   # user-level only: post-BM25 ranking\n",
+			*recall.Diversity, formatFloat(recall.DiversityWeight), formatFloat(recall.DuplicateThreshold), *recall.Staleness, formatFloat(recall.StalenessHalfLifeDays))
 	}
 	if lang := c.ReasoningLanguage(); lang != "auto" {
 		fmt.Fprintf(&b, "reasoning_language = %q   # visible reasoning language: auto|zh|en\n", lang)

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -800,14 +800,14 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c.Desktop.CheckUpdates = boolPtr(false)
 
 	user := RenderTOMLForScope(c, RenderScopeUser)
-	for _, want := range []string{"config_version = 4", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `default_tool_approval_mode = "auto"`, `check_updates = false`, "[notifications]", "[tools.shell]"} {
+	for _, want := range []string{"config_version = 4", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `status_bar_style = "text"`, `default_tool_approval_mode = "auto"`, `check_updates = false`, "memory_recall =", "[notifications]", "[tools.shell]"} {
 		if !strings.Contains(user, want) {
 			t.Fatalf("user render missing %q:\n%s", want, user)
 		}
 	}
 
 	project := RenderTOMLForScope(c, RenderScopeProject)
-	for _, forbidden := range []string{"[desktop]", "[notifications]", "close_behavior =", "default_tool_approval_mode =", "check_updates =", "max_steps", "planner_max_steps"} {
+	for _, forbidden := range []string{"[desktop]", "[notifications]", "close_behavior =", "default_tool_approval_mode =", "check_updates =", "memory_recall =", "max_steps", "planner_max_steps"} {
 		if strings.Contains(project, forbidden) {
 			t.Fatalf("project render should not contain %q:\n%s", forbidden, project)
 		}

--- a/internal/control/memory.go
+++ b/internal/control/memory.go
@@ -129,6 +129,9 @@ func (m *memoryManager) saveMemory(fact memory.Memory) (string, error) {
 	if mem == nil {
 		return "", nil
 	}
+	if strings.TrimSpace(fact.SourceKind) == "" {
+		fact.SourceKind = "user_confirmed"
+	}
 	path, err := mem.Store.Save(fact)
 	if err != nil {
 		return "", err

--- a/internal/memory/memory_contract_test.go
+++ b/internal/memory/memory_contract_test.go
@@ -1,0 +1,143 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMemoryOldFormatLoadsWithoutWritingMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old-fact.md")
+	old := "---\nname: old-fact\ntitle: Old Fact\ndescription: Existing note\ntype: project\n---\n\nbody\n"
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := Store{Dir: dir}
+	memories := store.List()
+	if len(memories) != 1 {
+		t.Fatalf("List() returned %d memories, want 1", len(memories))
+	}
+	if memories[0].Name != "old-fact" || memories[0].Title != "Old Fact" || memories[0].Description != "Existing note" || string(memories[0].Type) != "project" || memories[0].Body != "body" {
+		t.Fatalf("old memory parsed incorrectly: %+v", memories[0])
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("List() should not migrate/write old memory files on read\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestMemoryRecallDiversifiesNearDuplicateHits(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"cache-prefix-a", "cache-prefix-b", "cache-prefix-c"} {
+		body := "---\nname: " + name + "\ntitle: Cache Prefix\ndescription: cache prefix hit rate tuning\ntype: project\n---\n\ncache prefix hit rate tuning repeated note\n"
+		if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	other := "---\nname: cache-debugging\ntitle: Cache Debugging\ndescription: cache prefix miss diagnostics\ntype: project\n---\n\ncache prefix miss diagnostics inspect request headers and provider logs\n"
+	if err := os.WriteFile(filepath.Join(dir, "cache-debugging.md"), []byte(other), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := searchMemories(context.Background(), Store{Dir: dir}, "cache prefix hit rate", "", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("diversified recall returned %d hits, want 2 distinct results: %+v", len(hits), hits)
+	}
+	if hits[0].Memory.Name != "cache-prefix-a" || hits[1].Memory.Name != "cache-debugging" {
+		t.Fatalf("unexpected diversified order: %s, %s", hits[0].Memory.Name, hits[1].Memory.Name)
+	}
+	if hits[1].DiversityPenalty <= 0 {
+		t.Fatalf("expected diversity explanation on second hit: %+v", hits[1])
+	}
+}
+
+func TestMemoryRecallDiversityCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"cache-prefix-a", "cache-prefix-b", "cache-prefix-c"} {
+		body := "---\nname: " + name + "\ntitle: Cache Prefix\ndescription: cache prefix hit rate tuning\ntype: project\n---\n\ncache prefix hit rate tuning repeated note\n"
+		if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	off := false
+	hits, err := searchMemoriesWithOptions(context.Background(), Store{Dir: dir}, "cache prefix hit rate", "", 3, RecallOptions{Diversity: &off})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("disabled diversity returned %d hits, want 3", len(hits))
+	}
+}
+
+func TestMemoryRecallStalenessRanksBelowTopHitWithoutDiversity(t *testing.T) {
+	now := time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC)
+	off := false
+	hits := []memoryHit{
+		{Memory: Memory{Name: "top", LastConfirmedAt: now}, Score: 1},
+		{Memory: Memory{Name: "old", LastConfirmedAt: now.AddDate(-3, 0, 0)}, Score: 0.9},
+		{Memory: Memory{Name: "recent", LastConfirmedAt: now}, Score: 0.9},
+	}
+	got := rerankMemoryHits(hits, 3, normalizeRecallOptions(RecallOptions{
+		Diversity: &off,
+		Now:       func() time.Time { return now },
+	}))
+	if got[0].Memory.Name != "top" || got[1].Memory.Name != "recent" || got[2].Memory.Name != "old" {
+		t.Fatalf("staleness did not influence non-top ranking: %+v", got)
+	}
+}
+
+func TestStoreSaveAddsAndPreservesMemoryMetadata(t *testing.T) {
+	dir := t.TempDir()
+	store := Store{Dir: dir}
+	created := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	confirmed := created.Add(2 * time.Hour)
+	path, err := store.SaveAt(Memory{Name: "durable-fact", Type: TypeProject, Description: "fact", Body: "body", SourceKind: "remember_tool"}, created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, ok := loadMemory(path)
+	if !ok {
+		t.Fatal("saved memory did not load")
+	}
+	if !loaded.CreatedAt.Equal(created) || !loaded.LastConfirmedAt.Equal(created) || loaded.SourceScope != "project" || loaded.SourceKind != "remember_tool" {
+		t.Fatalf("unexpected initial metadata: %+v", loaded)
+	}
+	if _, err := store.SaveAt(Memory{Name: "durable-fact", Type: TypeProject, Description: "updated", Body: "new body"}, confirmed); err != nil {
+		t.Fatal(err)
+	}
+	loaded, ok = loadMemory(path)
+	if !ok {
+		t.Fatal("updated memory did not load")
+	}
+	if !loaded.CreatedAt.Equal(created) || !loaded.LastConfirmedAt.Equal(confirmed) || loaded.SourceKind != "remember_tool" {
+		t.Fatalf("update did not preserve origin metadata: %+v", loaded)
+	}
+}
+
+func TestArchivePreservesMemoryMetadata(t *testing.T) {
+	store := Store{Dir: t.TempDir()}
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	if _, err := store.SaveAt(Memory{Name: "old-fact", Type: TypeProject, Description: "old", Body: "body", SourceKind: "user_confirmed"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Archive("old-fact"); err != nil {
+		t.Fatal(err)
+	}
+	archived := store.ListArchived()
+	if len(archived) != 1 || !archived[0].CreatedAt.Equal(now) || archived[0].SourceKind != "user_confirmed" {
+		t.Fatalf("archive lost metadata: %+v", archived)
+	}
+}

--- a/internal/memory/recall.go
+++ b/internal/memory/recall.go
@@ -4,24 +4,49 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"reasonix/internal/retrieval"
 	"reasonix/internal/tool"
 )
 
 const (
-	defaultRecallLimit = 8
-	maxRecallLimit     = 20
-	maxRecallSnippet   = 260
-	recallScoreFloor   = 0.15
+	defaultRecallLimit        = 8
+	maxRecallLimit            = 20
+	maxRecallSnippet          = 260
+	recallScoreFloor          = 0.15
+	defaultDiversityWeight    = 0.35
+	defaultDuplicateThreshold = 0.82
+	defaultStalenessHalfLife  = 365 * 24 * time.Hour
 )
 
-type recallTool struct{ store Store }
+// RecallOptions controls the post-BM25 ranking layer. Nil booleans use the
+// production defaults (enabled); pointers let callers explicitly disable each
+// behavior without changing legacy constructor semantics.
+type RecallOptions struct {
+	Diversity          *bool
+	DiversityWeight    float64
+	DuplicateThreshold float64
+	Staleness          *bool
+	StalenessHalfLife  time.Duration
+	Now                func() time.Time
+}
+
+type recallTool struct {
+	store   Store
+	options RecallOptions
+}
 
 // NewRecallTool returns the read-only `memory` tool for searching saved facts.
 func NewRecallTool(store Store) tool.Tool { return recallTool{store: store} }
+
+// NewRecallToolWithOptions returns a recall tool with explicit ranking policy.
+func NewRecallToolWithOptions(store Store, options RecallOptions) tool.Tool {
+	return recallTool{store: store, options: options}
+}
 
 func (recallTool) Name() string { return "memory" }
 
@@ -66,7 +91,7 @@ func (t recallTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 	limit := clampRecallLimit(in.Limit)
 	switch strings.TrimSpace(in.Operation) {
 	case "search":
-		hits, err := searchMemories(ctx, t.store, in.Query, memType, limit)
+		hits, err := searchMemoriesWithOptions(ctx, t.store, in.Query, memType, limit, t.options)
 		if err != nil {
 			return "", err
 		}
@@ -89,10 +114,14 @@ func (t recallTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 func (recallTool) ReadOnly() bool { return true }
 
 type memoryHit struct {
-	Memory  Memory
-	Path    string
-	Score   float64
-	Snippet string
+	Memory           Memory
+	Path             string
+	Score            float64
+	RankScore        float64
+	DiversityPenalty float64
+	StalenessFactor  float64
+	Snippet          string
+	terms            []string
 }
 
 type memoryDoc struct {
@@ -104,6 +133,10 @@ type memoryDoc struct {
 }
 
 func searchMemories(ctx context.Context, store Store, query string, typ Type, limit int) ([]memoryHit, error) {
+	return searchMemoriesWithOptions(ctx, store, query, typ, limit, RecallOptions{})
+}
+
+func searchMemoriesWithOptions(ctx context.Context, store Store, query string, typ Type, limit int, options RecallOptions) ([]memoryHit, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return nil, fmt.Errorf("query is required")
@@ -154,6 +187,7 @@ func searchMemories(ctx context.Context, store Store, query string, typ Type, li
 			Path:    doc.path,
 			Score:   score,
 			Snippet: retrieval.MakeSnippet(doc.text, query, queryTerms, maxRecallSnippet),
+			terms:   retrieval.Unique(retrieval.Tokens(memorySimilarityText(doc.memory))),
 		})
 	}
 	sort.Slice(hits, func(i, j int) bool {
@@ -165,10 +199,130 @@ func searchMemories(ctx context.Context, store Store, query string, typ Type, li
 	hits = retrieval.KeepTopRelativeScore(hits, recallScoreFloor, func(hit memoryHit) float64 {
 		return hit.Score
 	})
-	if len(hits) > limit {
-		hits = hits[:limit]
+	return rerankMemoryHits(hits, limit, normalizeRecallOptions(options)), nil
+}
+
+type normalizedRecallOptions struct {
+	diversity          bool
+	diversityWeight    float64
+	duplicateThreshold float64
+	staleness          bool
+	stalenessHalfLife  time.Duration
+	now                time.Time
+}
+
+func normalizeRecallOptions(in RecallOptions) normalizedRecallOptions {
+	out := normalizedRecallOptions{
+		diversity:          in.Diversity == nil || *in.Diversity,
+		diversityWeight:    in.DiversityWeight,
+		duplicateThreshold: in.DuplicateThreshold,
+		staleness:          in.Staleness == nil || *in.Staleness,
+		stalenessHalfLife:  in.StalenessHalfLife,
+		now:                time.Now().UTC(),
 	}
-	return hits, nil
+	if out.diversityWeight <= 0 || out.diversityWeight > 1 {
+		out.diversityWeight = defaultDiversityWeight
+	}
+	if out.duplicateThreshold <= 0 || out.duplicateThreshold > 1 {
+		out.duplicateThreshold = defaultDuplicateThreshold
+	}
+	if out.stalenessHalfLife <= 0 {
+		out.stalenessHalfLife = defaultStalenessHalfLife
+	}
+	if in.Now != nil {
+		out.now = in.Now().UTC()
+	}
+	return out
+}
+
+func rerankMemoryHits(hits []memoryHit, limit int, options normalizedRecallOptions) []memoryHit {
+	if len(hits) == 0 || limit <= 0 {
+		return nil
+	}
+	for i := range hits {
+		hits[i].StalenessFactor = memoryStalenessFactor(hits[i].Memory, options)
+		hits[i].RankScore = hits[i].Score * hits[i].StalenessFactor
+	}
+	if !options.diversity {
+		if options.staleness && len(hits) > 2 {
+			// Preserve the strongest lexical hit, but let confirmation age
+			// influence the remaining order even when diversity is disabled.
+			sort.SliceStable(hits[1:], func(i, j int) bool {
+				left := &hits[i+1]
+				right := &hits[j+1]
+				if left.RankScore == right.RankScore {
+					return left.Memory.Name < right.Memory.Name
+				}
+				return left.RankScore > right.RankScore
+			})
+		}
+		if len(hits) > limit {
+			hits = hits[:limit]
+		}
+		return hits
+	}
+
+	// Keep the strongest lexical hit stable, then greedily choose complementary
+	// evidence. Near-identical notes are omitted rather than consuming context.
+	selected := []memoryHit{hits[0]}
+	remaining := append([]memoryHit(nil), hits[1:]...)
+	topScore := hits[0].Score
+	for len(selected) < limit && len(remaining) > 0 {
+		best := -1
+		for i := range remaining {
+			maxSimilarity := 0.0
+			for _, prior := range selected {
+				maxSimilarity = math.Max(maxSimilarity, tokenJaccard(remaining[i].terms, prior.terms))
+			}
+			if maxSimilarity >= options.duplicateThreshold {
+				continue
+			}
+			remaining[i].DiversityPenalty = maxSimilarity
+			remaining[i].RankScore = remaining[i].Score*remaining[i].StalenessFactor - options.diversityWeight*maxSimilarity*topScore
+			if best < 0 || remaining[i].RankScore > remaining[best].RankScore ||
+				(remaining[i].RankScore == remaining[best].RankScore && remaining[i].Memory.Name < remaining[best].Memory.Name) {
+				best = i
+			}
+		}
+		if best < 0 {
+			break
+		}
+		selected = append(selected, remaining[best])
+		remaining = append(remaining[:best], remaining[best+1:]...)
+	}
+	return selected
+}
+
+func memoryStalenessFactor(m Memory, options normalizedRecallOptions) float64 {
+	if !options.staleness || m.LastConfirmedAt.IsZero() || !options.now.After(m.LastConfirmedAt) {
+		return 1
+	}
+	age := options.now.Sub(m.LastConfirmedAt)
+	factor := math.Exp2(-float64(age) / float64(options.stalenessHalfLife))
+	return math.Max(0.5, factor)
+}
+
+func tokenJaccard(a, b []string) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, term := range a {
+		set[term] = struct{}{}
+	}
+	intersection := 0
+	union := len(set)
+	for _, term := range b {
+		if _, ok := set[term]; ok {
+			intersection++
+		} else {
+			union++
+		}
+	}
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
 }
 
 func recallTypeFilter(s string) (Type, error) {
@@ -218,6 +372,18 @@ func memorySearchText(m Memory) string {
 	}, "\n")
 }
 
+// memorySimilarityText intentionally excludes the memory name and filesystem
+// path. Those identifiers help exact BM25 lookup, but treating them as semantic
+// content makes otherwise identical notes appear artificially different.
+func memorySimilarityText(m Memory) string {
+	return strings.Join([]string{
+		m.Title,
+		m.Description,
+		string(NormalizeType(string(m.Type))),
+		m.Body,
+	}, "\n")
+}
+
 func formatMemoryHits(query string, hits []memoryHit) string {
 	if len(hits) == 0 {
 		return strings.Join([]string{
@@ -233,11 +399,18 @@ func formatMemoryHits(query string, hits []memoryHit) string {
 	fmt.Fprintf(&b, "Memory search results for %s:\n", strconvQuote(query))
 	for i, hit := range hits {
 		m := hit.Memory
-		fmt.Fprintf(&b, "\n%d. score=%.3f name=%s type=%s title=%s\n   description: %s\n   path: %s\n   snippet: %s\n",
-			i+1, hit.Score, m.Name, NormalizeType(string(m.Type)), displayTitle(m.Title, m.Name), oneLine(m.Description), hit.Path, hit.Snippet)
+		fmt.Fprintf(&b, "\n%d. score=%.3f rank=%.3f diversity=%.3f staleness=%.3f name=%s type=%s source=%s/%s title=%s\n   description: %s\n   path: %s\n   snippet: %s\n",
+			i+1, hit.Score, hit.RankScore, hit.DiversityPenalty, hit.StalenessFactor, m.Name, NormalizeType(string(m.Type)), emptyLabel(m.SourceScope), emptyLabel(m.SourceKind), displayTitle(m.Title, m.Name), oneLine(m.Description), hit.Path, hit.Snippet)
 	}
 	b.WriteString("\nUse operation=\"read\" with a memory name to inspect the full saved fact.")
 	return strings.TrimSpace(b.String())
+}
+
+func emptyLabel(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "legacy"
+	}
+	return strings.TrimSpace(value)
 }
 
 func formatMemory(store Store, m Memory) string {

--- a/internal/memory/recall_quality_test.go
+++ b/internal/memory/recall_quality_test.go
@@ -1,0 +1,125 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/retrieval"
+)
+
+type recallQualityMetrics struct {
+	recallAtK     float64
+	duplicateRate float64
+	injectedTerms int
+	top1          string
+}
+
+func seedRecallQualityCorpus(t testing.TB) (Store, time.Time) {
+	t.Helper()
+	store := Store{Dir: t.TempDir()}
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "cache-prefix-a", Title: "Prefix cache tuning", Description: "cache prefix hit rate tuning", Type: TypeProject, Body: "Keep stable tool schemas and inspect cache hit metrics.", SourceKind: "remember_tool"},
+		{Name: "cache-prefix-b", Title: "Prefix cache tuning", Description: "cache prefix hit rate tuning", Type: TypeProject, Body: "Keep stable tool schemas and inspect cache hit metrics.", SourceKind: "remember_tool"},
+		{Name: "cache-prefix-c", Title: "Prefix cache tuning", Description: "cache prefix hit rate tuning", Type: TypeProject, Body: "Keep stable tool schemas and inspect cache hit metrics.", SourceKind: "remember_tool"},
+		{Name: "cache-debugging", Title: "Cache miss diagnostics", Description: "debug cache prefix misses", Type: TypeProject, Body: "Inspect request headers, provider logs, and dynamic prompt tails.", SourceKind: "user_confirmed"},
+		{Name: "zh-command", Title: "中文命令参数", Description: "排查 sandbox-exec 命令失败", Type: TypeFeedback, Body: "检查命令参数、文件路径和错误短语，不要重复失败命令。", SourceKind: "user_confirmed"},
+		{Name: "truth-locked-old", Title: "Durable port truth", Description: "FRP remote port 10023 belongs to mini SSH", Type: TypeProject, Body: "This old confirmed fact remains true and may rank lower, but must not be discarded.", SourceKind: "user_confirmed", CreatedAt: now.AddDate(-3, 0, 0), LastConfirmedAt: now.AddDate(-3, 0, 0)},
+	}
+	for _, m := range memories {
+		if _, err := store.SaveAt(m, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.SaveAt(Memory{Name: "archived-cache", Title: "Prefix cache tuning", Description: "cache prefix hit rate tuning", Type: TypeProject, Body: "archived duplicate", SourceKind: "remember_tool"}, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Archive("archived-cache"); err != nil {
+		t.Fatal(err)
+	}
+	return store, now
+}
+
+func measureRecallQuality(hits []memoryHit, relevant map[string]bool) recallQualityMetrics {
+	metrics := recallQualityMetrics{}
+	if len(hits) > 0 {
+		metrics.top1 = hits[0].Memory.Name
+	}
+	seenRelevant := 0
+	for _, hit := range hits {
+		if relevant[hit.Memory.Name] {
+			seenRelevant++
+		}
+		metrics.injectedTerms += len(retrieval.Tokens(memorySearchText(hit.Memory)))
+	}
+	if len(relevant) > 0 {
+		metrics.recallAtK = float64(seenRelevant) / float64(len(relevant))
+	}
+	duplicatePairs := 0
+	pairs := 0
+	for i := range hits {
+		for j := i + 1; j < len(hits); j++ {
+			pairs++
+			if tokenJaccard(hits[i].terms, hits[j].terms) >= defaultDuplicateThreshold {
+				duplicatePairs++
+			}
+		}
+	}
+	if pairs > 0 {
+		metrics.duplicateRate = float64(duplicatePairs) / float64(pairs)
+	}
+	return metrics
+}
+
+func TestMemoryRecallQualityCorpus(t *testing.T) {
+	store, now := seedRecallQualityCorpus(t)
+	off := false
+	legacy, err := searchMemoriesWithOptions(context.Background(), store, "cache prefix hit rate diagnostics", "", 4, RecallOptions{Diversity: &off, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	diverse, err := searchMemoriesWithOptions(context.Background(), store, "cache prefix hit rate diagnostics", "", 4, RecallOptions{Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relevant := map[string]bool{"cache-prefix-a": true, "cache-debugging": true}
+	before := measureRecallQuality(legacy, relevant)
+	after := measureRecallQuality(diverse, relevant)
+	if after.top1 != before.top1 || after.top1 != "cache-prefix-a" {
+		t.Fatalf("top-1 changed: before=%+v after=%+v", before, after)
+	}
+	if after.recallAtK < before.recallAtK || after.recallAtK != 1 {
+		t.Fatalf("Recall@K regressed: before=%+v after=%+v", before, after)
+	}
+	if after.duplicateRate >= before.duplicateRate || after.duplicateRate != 0 {
+		t.Fatalf("duplicate rate did not improve: before=%+v after=%+v", before, after)
+	}
+	if after.injectedTerms >= before.injectedTerms {
+		t.Fatalf("injected token proxy did not shrink: before=%+v after=%+v", before, after)
+	}
+	zh, err := searchMemoriesWithOptions(context.Background(), store, "sandbox-exec 命令失败 文件路径", "", 3, RecallOptions{Now: func() time.Time { return now }})
+	if err != nil || len(zh) == 0 || zh[0].Memory.Name != "zh-command" {
+		t.Fatalf("CJK/error phrase recall failed: hits=%+v err=%v", zh, err)
+	}
+	old, err := searchMemoriesWithOptions(context.Background(), store, "FRP remote port 10023 mini SSH", "", 3, RecallOptions{Now: func() time.Time { return now }})
+	if err != nil || len(old) == 0 || old[0].Memory.Name != "truth-locked-old" || old[0].StalenessFactor >= 1 {
+		t.Fatalf("old truth was lost or not explained: hits=%+v err=%v", old, err)
+	}
+	for _, hit := range append(append([]memoryHit{}, diverse...), append(zh, old...)...) {
+		if hit.Memory.Name == "archived-cache" {
+			t.Fatal("archived memory entered active recall")
+		}
+	}
+}
+
+func BenchmarkMemoryRecallQualityCorpus(b *testing.B) {
+	store, now := seedRecallQualityCorpus(b)
+	options := RecallOptions{Now: func() time.Time { return now }}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := searchMemoriesWithOptions(context.Background(), store, "cache prefix hit rate diagnostics", "", 4, options); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/memory/remember.go
+++ b/internal/memory/remember.go
@@ -75,6 +75,7 @@ func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string
 		Description: in.Description,
 		Type:        NormalizeType(in.Type),
 		Body:        in.Body,
+		SourceKind:  "remember_tool",
 	})
 	if err != nil {
 		return "", err

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -62,6 +62,12 @@ type Memory struct {
 	Description string // one-line summary used for the index and recall
 	Type        Type
 	Body        string // the fact itself (Markdown)
+	// Optional provenance metadata. Zero values preserve compatibility with
+	// hand-authored and pre-metadata memory files.
+	CreatedAt       time.Time
+	LastConfirmedAt time.Time
+	SourceScope     string
+	SourceKind      string
 }
 
 // ArchivedMemory is a saved fact that has been removed from active memory but
@@ -176,6 +182,13 @@ func (s Store) Path(name string) string {
 // editor, and any future importer all go through here so the index never drifts
 // from the files. Returns the path written.
 func (s Store) Save(m Memory) (string, error) {
+	return s.SaveAt(m, time.Now())
+}
+
+// SaveAt is Save with an explicit clock for deterministic importers and tests.
+// Updating an existing fact preserves its creation time and provenance unless
+// the caller explicitly supplies replacements, while confirmation time advances.
+func (s Store) SaveAt(m Memory, now time.Time) (string, error) {
 	dir := s.DirFor(m.Type)
 	if dir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
@@ -186,6 +199,34 @@ func (s Store) Save(m Memory) (string, error) {
 	name := slug(m.Name)
 	if name == "" {
 		return "", fmt.Errorf("memory name needs at least one letter or digit")
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if existing, ok := loadMemory(s.Path(name)); ok {
+		if m.CreatedAt.IsZero() {
+			m.CreatedAt = existing.CreatedAt
+		}
+		if strings.TrimSpace(m.SourceScope) == "" {
+			m.SourceScope = existing.SourceScope
+		}
+		if strings.TrimSpace(m.SourceKind) == "" {
+			m.SourceKind = existing.SourceKind
+		}
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	if m.LastConfirmedAt.IsZero() {
+		m.LastConfirmedAt = now
+	}
+	if strings.TrimSpace(m.SourceScope) == "" {
+		if m.Type == TypeUser || m.Type == TypeFeedback {
+			m.SourceScope = "global"
+		} else {
+			m.SourceScope = "project"
+		}
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
@@ -391,7 +432,11 @@ type memoryFrontmatter struct {
 	Title    string `yaml:"title,omitempty"`
 	Desc     string `yaml:"description"`
 	Metadata struct {
-		Type string `yaml:"type"`
+		Type            string `yaml:"type"`
+		CreatedAt       string `yaml:"created_at,omitempty"`
+		LastConfirmedAt string `yaml:"last_confirmed_at,omitempty"`
+		SourceScope     string `yaml:"source_scope,omitempty"`
+		SourceKind      string `yaml:"source_kind,omitempty"`
 	} `yaml:"metadata"`
 }
 
@@ -399,6 +444,10 @@ type memoryFrontmatter struct {
 func render(m Memory, name string) string {
 	fm := memoryFrontmatter{Name: name, Title: oneLine(m.Title), Desc: oneLine(m.Description)}
 	fm.Metadata.Type = string(NormalizeType(string(m.Type)))
+	fm.Metadata.CreatedAt = formatMetadataTime(m.CreatedAt)
+	fm.Metadata.LastConfirmedAt = formatMetadataTime(m.LastConfirmedAt)
+	fm.Metadata.SourceScope = strings.TrimSpace(m.SourceScope)
+	fm.Metadata.SourceKind = strings.TrimSpace(m.SourceKind)
 	var b strings.Builder
 	b.WriteString("---\n")
 	enc := yaml.NewEncoder(&b)
@@ -608,16 +657,35 @@ func loadMemory(path string) (Memory, bool) {
 	}
 	fm, body := splitFrontmatter(string(b))
 	m := Memory{
-		Name:        fm["name"],
-		Title:       fm["title"],
-		Description: fm["description"],
-		Type:        NormalizeType(fm["type"]),
-		Body:        strings.TrimSpace(body),
+		Name:            fm["name"],
+		Title:           fm["title"],
+		Description:     fm["description"],
+		Type:            NormalizeType(fm["type"]),
+		Body:            strings.TrimSpace(body),
+		CreatedAt:       parseMetadataTime(fm["created_at"]),
+		LastConfirmedAt: parseMetadataTime(fm["last_confirmed_at"]),
+		SourceScope:     strings.TrimSpace(fm["source_scope"]),
+		SourceKind:      strings.TrimSpace(fm["source_kind"]),
 	}
 	if m.Name == "" {
 		m.Name = strings.TrimSuffix(filepath.Base(path), ".md")
 	}
 	return m, true
+}
+
+func formatMetadataTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseMetadataTime(value string) time.Time {
+	t, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
 }
 
 // splitFrontmatter is a thin wrapper; the real parser lives in


### PR DESCRIPTION
## English

Adds a lightweight, backward-compatible ranking layer after the existing BM25 + relative-floor recall stage.

### What changes
- optional `created_at`, `last_confirmed_at`, `source_scope`, and `source_kind` metadata
- old Markdown memories load without migration; reads never rewrite files
- lightweight Jaccard/MMR-style diversity reranking before the final limit
- configurable duplicate suppression and staleness influence
- debug output exposes relevance, diversity, staleness, and source signals
- archive-on-forget preserves metadata

### Non-goals / safety
- no SQLite, CGO, vector DB, embedding lane, or second memory store
- staleness only influences ranking; it never declares a fact false
- the highest-relevance hit is preserved
- project config cannot silently override the user-global recall policy
- does not restore the retired `memory_compiler` setting from newer upstream

### Verification
- `go test -count=1 ./internal/config ./internal/memory ./internal/control ./internal/boot`
- `git diff --check`

## 中文

在现有 BM25 + 相对分数门槛之后增加轻量、向后兼容的召回排序层。

### 改动内容
- 增加可选的 `created_at`、`last_confirmed_at`、`source_scope`、`source_kind` 元数据
- 旧 Markdown memory 无需迁移即可读取，读取过程不会自动写盘
- 在最终 limit 之前增加轻量 Jaccard/MMR 风格多样性重排
- 重复抑制和时效影响均可配置、可关闭
- 调试输出可解释 relevance、diversity、staleness 和 source 信号
- forget 归档时保留原元数据

### 边界与安全性
- 不引入 SQLite、CGO、向量数据库、embedding 通道或第二套 memory store
- staleness 只影响排序，不会把事实判定为错误
- 保留最高相关性命中
- 项目配置不能静默覆盖用户全局 recall 策略
- 不恢复新版上游已经退休的 `memory_compiler` 配置

### 验证
- `go test -count=1 ./internal/config ./internal/memory ./internal/control ./internal/boot`
- `git diff --check`

## Cache impact review
Cache-impact: medium - recall ranking and optional metadata can change dynamic memory tail contents, not the stable prefix


## Cache impact review
Cache-guard: go test -count=1 ./internal/memory ./internal/control ./internal/agent && go test -run TestCacheHitPrefixStable -count=1 ./internal/agent


## Cache impact review
System-prompt-review: reviewed; memory results remain dynamic tail data and no worktree or usage values enter the stable prefix
