### PR TITLE
test(tool): freeze canonical tool contract / 固定标准工具契约

### DIFF
--- a/internal/tool/contract_test.go
+++ b/internal/tool/contract_test.go
@@ -40,6 +40,29 @@ func TestBuiltinToolContractDocumentation(t *testing.T) {
 	}
 }
 
+// BenchmarkBuiltinToolContractBaseline records the size and export cost of the
+// single canonical provider contract. Any future harness projection must beat
+// this baseline in model-facing A/B tests without duplicating tool execution.
+func BenchmarkBuiltinToolContractBaseline(b *testing.B) {
+	r := tool.NewRegistry()
+	for _, builtin := range tool.Builtins() {
+		r.Add(builtin)
+	}
+
+	schemas := r.Schemas()
+	contractBytes := 0
+	for _, schema := range schemas {
+		contractBytes += len(schema.Name) + len(schema.Description) + len(schema.Parameters)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Schemas()
+	}
+	b.ReportMetric(float64(len(schemas)), "tools")
+	b.ReportMetric(float64(contractBytes), "contract_bytes")
+}
+
 func boolString(v bool) string {
 	if v {
 		return "true"


### PR DESCRIPTION
## English

Adds a small contract test that freezes the canonical tool identity and schema used by the shared executor.

This is a guardrail for future provider/model-specific tool projections: projections may adapt names, descriptions, schemas, or envelopes, but they must not create a second execution path with different permission, sandbox, path, event, or evidence semantics.

### Scope
- test-only; no runtime behavior change
- one canonical executor remains the source of truth
- no provider-specific executor or duplicate registry

### Verification
- `go test -count=1 ./internal/tool`
- `git diff --check`

## 中文

增加一个小型契约测试，固定共享 executor 使用的标准工具身份与 schema。

它为未来不同 Provider/模型的工具投影提供护栏：投影层可以适配名称、描述、JSON schema 或结果 envelope，但不能复制第二套执行路径，导致 permission、sandbox、路径、事件或 evidence 语义分叉。

### 范围
- 仅测试，不改变运行时行为
- 单一 canonical executor 继续作为事实真源
- 不增加 Provider 专用 executor 或重复 registry

### 验证
- `go test -count=1 ./internal/tool`
- `git diff --check`

## Cache impact review
Cache-impact: none - test-only contract snapshot; runtime prompt and tool schema are unchanged


## Cache impact review
Cache-guard: go test -count=1 ./internal/tool
