### PR TITLE
Preserve cancelled turn display history / 保留中断轮次的可见历史

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2007,6 +2007,9 @@ func removeDesktopSessionArtifacts(path string) error {
 	if err := removeSessionDisplay(filepath.Dir(path), path); err != nil {
 		return err
 	}
+	if err := removeSessionPlannerDisplay(filepath.Dir(path), path); err != nil {
+		return err
+	}
 	if err := agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path)); err != nil {
 		return err
 	}
@@ -2385,6 +2388,7 @@ func (a *App) ListSessions() []SessionMeta {
 		}
 	}
 	_ = pruneSessionDisplays(dir, protectedDisplays)
+	_ = pruneSessionPlannerDisplays(dir, protectedDisplays)
 	titles := loadSessionTitles(dir)
 	channelRoutes := channelSessionRoutesForDir(dir)
 	active := a.activeSessionPath(dir)

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -236,6 +236,11 @@ console.log("\nuse controller meta");
     "workspace lease contention uses its stable localized notice code",
   );
   eq(
+    localizedNoticeText("reworded cancelled-turn copy", "cancelled_turn_display"),
+    "This turn was interrupted. Partial output is kept for reference but is not included in the model's next-turn history; inspect the workspace before continuing or reverting changes.",
+    "cancelled turn history explains the model-context boundary",
+  );
+  eq(
     localizedNoticeText("Tool round limit reached; asking the assistant to summarize progress.", "unknown_future_code"),
     "Tool round limit reached; asking the assistant to summarize progress.",
     "an unknown notice code falls back to exact-text matching",

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1424,6 +1424,7 @@ const noticeCodeKeys: Record<string, DictKey> = {
   tool_budget: "notice.toolBudget",
   loop_guard: "notice.loopGuard",
   workspace_lease: "notice.workspaceLease",
+  cancelled_turn_display: "notice.cancelledTurnDisplay",
 };
 
 // localizedNoticeText localizes a notice's main copy by its stable code first,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2360,6 +2360,7 @@ export const en = {
   "notice.toolBudget": "Tool round limit reached; asking the assistant to summarize progress.",
   "notice.loopGuard": "The assistant is not making progress; asking it to reassess the current step.",
   "notice.workspaceLease": "Another Delivery session is writing to this workspace; this session will continue automatically when it is safe.",
+  "notice.cancelledTurnDisplay": "This turn was interrupted. Partial output is kept for reference but is not included in the model's next-turn history; inspect the workspace before continuing or reverting changes.",
   "notice.contextLarge": "Context is getting large; preserving cache until cleanup is needed.",
   "notice.contextCleanupSkipped": "Context cleanup skipped for now.",
   "notice.contextCleanupPaused": "Automatic context cleanup paused because the context window is too small.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1580,6 +1580,7 @@ export const zhTW: Record<DictKey, string> = {
   "notice.toolBudget": "工具呼叫輪數已達上限，已要求助手總結目前進度。",
   "notice.loopGuard": "助手沒有取得有效進展，已要求它重新評估目前步驟。",
   "notice.workspaceLease": "另一個交付會話正在寫入此工作區；安全後本會話會自動繼續。",
+  "notice.cancelledTurnDisplay": "本輪已中斷。上方的部分輸出僅供查看，不會進入模型下一輪上下文；繼續或回復前請先檢查目前工作區。",
   "notice.contextLarge": "上下文正在變大，暫時保留快取，等需要時再清理。",
   "notice.contextCleanupSkipped": "本次暫未清理上下文。",
   "notice.contextCleanupPaused": "自動上下文清理已暫停：目前上下文視窗太小。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2363,6 +2363,7 @@ export const zh: Record<DictKey, string> = {
   "notice.toolBudget": "工具调用轮数已达上限，已要求助手总结当前进展。",
   "notice.loopGuard": "助手没有取得有效进展，已要求它重新评估当前步骤。",
   "notice.workspaceLease": "另一个交付会话正在写入此工作区；安全后本会话会自动继续。",
+  "notice.cancelledTurnDisplay": "本轮已中断。上方的部分输出仅供查看，不会进入模型下一轮上下文；继续或回滚前请先检查当前工作区。",
   "notice.contextLarge": "上下文正在变大，暂时保留缓存，等需要时再清理。",
   "notice.contextCleanupSkipped": "本次暂未清理上下文。",
   "notice.contextCleanupPaused": "自动上下文清理已暂停：当前上下文窗口太小。",

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"reasonix/internal/agent"
@@ -309,6 +311,8 @@ func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	tab.sink.Emit(event.Event{Kind: event.Text, Text: "planner visible plan", Source: event.UsageSourcePlanner})
 	tab.sink.Emit(event.Event{Kind: event.Message, Text: "planner visible plan", Reasoning: "planner thinking\n", Source: event.UsageSourcePlanner})
 	tab.sink.Emit(event.Event{Kind: event.TurnStarted})
+	tab.sink.Emit(event.Event{Kind: event.Text, Text: "executor kept working", Source: event.UsageSourceExecutor})
+	tab.sink.Emit(event.Event{Kind: event.Message, Text: "executor kept working", Source: event.UsageSourceExecutor})
 	tab.sink.Emit(event.Event{Kind: event.TurnDone})
 	waitForAutosaveIdle(t, tab)
 
@@ -327,6 +331,74 @@ func TestHistoryForTabRestoresPlannerDisplayAfterReload(t *testing.T) {
 	}
 	if got[4].Role != "assistant" || got[4].Content != "executor kept working" {
 		t.Fatalf("executor answer missing after reload: %+v", got[4])
+	}
+}
+
+type cancelledDisplayRunner struct {
+	session *agent.Session
+	sink    event.Sink
+	started chan struct{}
+}
+
+func (r *cancelledDisplayRunner) Run(ctx context.Context, input string) error {
+	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
+	r.session.Add(provider.Message{Role: provider.RoleAssistant, ReasoningContent: "checking settings\n", ToolCalls: []provider.ToolCall{{
+		ID: "call_1", Name: "read_file", Arguments: `{"path":"settings.json"}`,
+	}}})
+	r.session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "partial settings"})
+	r.sink.Emit(event.Event{Kind: event.Reasoning, Text: "checking settings\n", Source: event.UsageSourceExecutor})
+	r.sink.Emit(event.Event{Kind: event.ToolDispatch, Source: event.UsageSourceExecutor, Tool: event.Tool{
+		ID: "call_1", Name: "read_file", Args: `{"path":"settings.json"}`, ReadOnly: true,
+	}})
+	r.sink.Emit(event.Event{Kind: event.ToolResult, Source: event.UsageSourceExecutor, Tool: event.Tool{
+		ID: "call_1", Name: "read_file", Output: "partial settings", Err: "cancelled",
+	}})
+	close(r.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestHistoryForTabRestoresCancelledExecutorDisplayAfterReload(t *testing.T) {
+	dir := t.TempDir()
+	path := agent.NewSessionPath(dir, "test-model")
+	sess := agent.NewSession("system")
+	app := &App{tabs: map[string]*WorkspaceTab{}, activeTabID: "cancelled_tab"}
+	tab := &WorkspaceTab{ID: "cancelled_tab", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	runner := &cancelledDisplayRunner{session: sess, sink: tab.sink, started: make(chan struct{})}
+	ag := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Runner: runner, Executor: ag, SessionDir: dir, SessionPath: path, Sink: tab.sink})
+	tab.Ctrl = ctrl
+	app.tabs[tab.ID] = tab
+
+	ctrl.Send("continue setup")
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled turn did not start")
+	}
+	ctrl.Cancel()
+	waitNotRunning(t, ctrl)
+	waitForAutosaveIdle(t, tab)
+
+	if got := ctrl.History(); len(got) != 2 {
+		t.Fatalf("model transcript length = %d, want system + user only: %+v", len(got), got)
+	}
+	got := app.HistoryForTab(tab.ID)
+	if len(got) != 5 {
+		t.Fatalf("history length = %d, want system + user + assistant + tool + notice: %+v", len(got), got)
+	}
+	if got[1].Role != "user" || got[1].Content != "continue setup" {
+		t.Fatalf("cancelled turn user missing after reload: %+v", got[1])
+	}
+	if got[2].Role != "assistant" || got[2].Reasoning != "checking settings\n" || len(got[2].ToolCalls) != 1 || got[2].ToolCalls[0].Name != "read_file" {
+		t.Fatalf("cancelled assistant display missing after reload: %+v", got[2])
+	}
+	if got[3].Role != "tool" || got[3].ToolName != "read_file" || got[3].Content != "partial settings" || got[3].ToolResultError != "partial settings" {
+		t.Fatalf("cancelled tool display missing after reload: %+v", got[3])
+	}
+	if got[4].Role != "notice" || got[4].Code != event.NoticeCodeCancelledTurn {
+		t.Fatalf("cancelled turn context notice missing after reload: %+v", got[4])
 	}
 }
 

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -340,6 +340,18 @@ type cancelledDisplayRunner struct {
 	started chan struct{}
 }
 
+type blockingPlannerProvider struct {
+	started chan struct{}
+}
+
+func (p *blockingPlannerProvider) Name() string { return "blocking-planner" }
+
+func (p *blockingPlannerProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	close(p.started)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 func (r *cancelledDisplayRunner) Run(ctx context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	r.session.Add(provider.Message{Role: provider.RoleAssistant, ReasoningContent: "checking settings\n", ToolCalls: []provider.ToolCall{{
@@ -399,6 +411,110 @@ func TestHistoryForTabRestoresCancelledExecutorDisplayAfterReload(t *testing.T) 
 	}
 	if got[4].Role != "notice" || got[4].Code != event.NoticeCodeCancelledTurn {
 		t.Fatalf("cancelled turn context notice missing after reload: %+v", got[4])
+	}
+}
+
+func TestHistoryForTabRestoresPlannerDisplayWhenCancelledBeforeExecutorStarts(t *testing.T) {
+	dir := t.TempDir()
+	path := agent.NewSessionPath(dir, "test-model")
+	app := &App{tabs: map[string]*WorkspaceTab{}, activeTabID: "planner_cancelled_tab"}
+	tab := &WorkspaceTab{ID: "planner_cancelled_tab", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	executorSession := agent.NewSession("system")
+	executor := agent.New(stubProvider{}, tool.NewRegistry(), executorSession, agent.Options{}, tab.sink)
+	planner := &blockingPlannerProvider{started: make(chan struct{})}
+	runner := agent.NewCoordinator(planner, agent.NewSession("planner system"), nil, nil, agent.Options{}, executor, 0, tab.sink, nil)
+	ctrl := control.New(control.Options{Runner: runner, Executor: executor, SessionDir: dir, SessionPath: path, Sink: tab.sink})
+	defer ctrl.Close()
+	ctrl.SetPlanMode(true)
+	tab.Ctrl = ctrl
+	app.tabs[tab.ID] = tab
+
+	ctrl.Send("new question")
+	select {
+	case <-planner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("planner did not start")
+	}
+	ctrl.Cancel()
+	waitNotRunning(t, ctrl)
+	waitForAutosaveIdle(t, tab)
+
+	canonical := ctrl.History()
+	if len(canonical) != 2 || canonical[1].Role != provider.RoleUser || canonical[1].Content != "new question" {
+		t.Fatalf("canonical history = %+v, want system + prefix-free current user", canonical)
+	}
+	visible := app.HistoryForTab(tab.ID)
+	if len(visible) != 4 {
+		t.Fatalf("visible history length = %d, want system + user + planner phase + notice: %+v", len(visible), visible)
+	}
+	if visible[1].Role != "user" || visible[1].Content != "new question" {
+		t.Fatalf("cancelled planner user missing after reload: %+v", visible[1])
+	}
+	if visible[2].Role != "phase" || !strings.Contains(visible[2].Content, "planning") {
+		t.Fatalf("cancelled planner display missing after reload: %+v", visible[2])
+	}
+	if visible[3].Role != "notice" || visible[3].Code != event.NoticeCodeCancelledTurn {
+		t.Fatalf("cancelled planner context notice missing after reload: %+v", visible[3])
+	}
+}
+
+func TestCancelledExecutorDisplayFollowsDetachedAndReattachedRuntime(t *testing.T) {
+	dir := t.TempDir()
+	path := agent.NewSessionPath(dir, "test-model")
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}, activeTabID: "source_tab"}
+	source := &WorkspaceTab{ID: "source_tab", Scope: "global", Ready: true, SessionPath: path, disabledMCP: map[string]ServerView{}}
+	source.sink = &tabEventSink{tabID: source.ID, app: app}
+	sess := agent.NewSession("system")
+	runner := &cancelledDisplayRunner{session: sess, sink: source.sink, started: make(chan struct{})}
+	executor := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Runner: runner, Executor: executor, SessionDir: dir, SessionPath: path, Sink: source.sink})
+	defer ctrl.Close()
+	source.Ctrl = ctrl
+	app.tabs[source.ID] = source
+
+	ctrl.Send("continue setup")
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled turn did not start")
+	}
+	if !app.detachRuntimeForReplacement(source) {
+		t.Fatal("running session could not be detached")
+	}
+	key := sessionRuntimeKey(path)
+	detached := app.detachedSessions[key]
+	if detached == nil {
+		t.Fatal("detached runtime missing")
+	}
+	target := &WorkspaceTab{ID: "reattached_tab", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	app.mu.Lock()
+	delete(app.tabs, source.ID)
+	app.tabs[target.ID] = target
+	delete(app.detachedSessions, key)
+	applyRuntimeTab(target, detached, path, app.ctx, app)
+	app.activeTabID = target.ID
+	app.mu.Unlock()
+	target.sink.Emit(event.Event{Kind: event.Text, Text: "after reattach", Source: event.UsageSourceExecutor})
+
+	ctrl.Cancel()
+	waitNotRunning(t, ctrl)
+	waitForAutosaveIdle(t, target)
+	visible := app.HistoryForTab(target.ID)
+	var sawBefore, sawAfter, sawNotice bool
+	for _, message := range visible {
+		if message.Role == "assistant" && message.Reasoning == "checking settings\n" {
+			sawBefore = true
+		}
+		if message.Role == "assistant" && message.Content == "after reattach" {
+			sawAfter = true
+		}
+		if message.Role == "notice" && message.Code == event.NoticeCodeCancelledTurn {
+			sawNotice = true
+		}
+	}
+	if !sawBefore || !sawAfter || !sawNotice {
+		t.Fatalf("reattached cancelled history lost display state: before=%v after=%v notice=%v history=%+v", sawBefore, sawAfter, sawNotice, visible)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -936,6 +937,11 @@ type plannerDisplayTurn struct {
 	Messages []HistoryMessage `json:"messages"`
 }
 
+// The planner display sidecar is shared by every session in one directory.
+// Serialize its load-modify-save cycle so two tabs finishing together cannot
+// publish maps that each drop the other tab's newly appended turn.
+var sessionPlannerDisplayMu sync.Mutex
+
 func messageDisplayKey(content string) string {
 	sum := sha256.Sum256([]byte(content))
 	return fmt.Sprintf("%x", sum[:])
@@ -997,6 +1003,8 @@ func recordSessionPlannerDisplay(dir, sessionPath, userContent string, messages 
 	if strings.TrimSpace(sessionPath) == "" || strings.TrimSpace(userContent) == "" || len(messages) == 0 {
 		return nil
 	}
+	sessionPlannerDisplayMu.Lock()
+	defer sessionPlannerDisplayMu.Unlock()
 	m := loadSessionPlannerDisplays(dir)
 	key := filepath.Base(sessionPath)
 	turn := plannerDisplayTurn{

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -9,13 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/filelock"
 	"reasonix/internal/fileutil"
 	"reasonix/internal/store"
 )
@@ -940,10 +941,15 @@ type plannerDisplayTurn struct {
 	Messages []HistoryMessage `json:"messages"`
 }
 
-// The planner display sidecar is shared by every session in one directory.
-// Serialize its load-modify-save cycle so two tabs finishing together cannot
-// publish maps that each drop the other tab's newly appended turn.
-var sessionPlannerDisplayMu sync.Mutex
+var (
+	sessionPlannerDisplayLockTimeout = 750 * time.Millisecond
+	errCorruptSessionPlannerDisplay  = errors.New("corrupt planner display sidecar")
+)
+
+// sessionPlannerDisplayUpdateAfterLoad is a subprocess-test seam. Production
+// leaves it nil; tests use it to force two independent processes into the old
+// stale read-modify-write window without relying on scheduler timing.
+var sessionPlannerDisplayUpdateAfterLoad func()
 
 func messageDisplayKey(content string) string {
 	sum := sha256.Sum256([]byte(content))
@@ -975,6 +981,24 @@ func loadSessionPlannerDisplays(dir string) sessionPlannerDisplayMap {
 	}
 	_ = json.Unmarshal(b, &m)
 	return m
+}
+
+func loadSessionPlannerDisplaysForUpdate(dir string) (sessionPlannerDisplayMap, error) {
+	m := sessionPlannerDisplayMap{}
+	b, err := readFileUTF8(sessionPlannerDisplayPath(dir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("%w: %v", errCorruptSessionPlannerDisplay, err)
+	}
+	if m == nil {
+		m = sessionPlannerDisplayMap{}
+	}
+	return m, nil
 }
 
 func saveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
@@ -1013,56 +1037,84 @@ func saveOrRemoveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) 
 	return saveSessionPlannerDisplays(dir, m)
 }
 
+func updateSessionPlannerDisplays(dir string, recoverCorrupt bool, mutate func(sessionPlannerDisplayMap) bool) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("planner display directory is empty")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionPlannerDisplayLockTimeout)
+	defer cancel()
+	release, err := filelock.Acquire(ctx, sessionPlannerDisplayPath(dir)+".lock")
+	if err != nil {
+		return fmt.Errorf("lock planner display sidecar: %w", err)
+	}
+	defer release()
+
+	m, err := loadSessionPlannerDisplaysForUpdate(dir)
+	if err != nil {
+		if !recoverCorrupt || !errors.Is(err, errCorruptSessionPlannerDisplay) {
+			return err
+		}
+		// A corrupt shared map cannot be edited safely. Destructive cleanup is
+		// allowed to retire the unreadable sidecar so deleted-session display
+		// data does not linger and later records can start from a valid map.
+		if removeErr := os.Remove(sessionPlannerDisplayPath(dir)); removeErr != nil && !os.IsNotExist(removeErr) {
+			return errors.Join(err, removeErr)
+		}
+		m = sessionPlannerDisplayMap{}
+	}
+	if sessionPlannerDisplayUpdateAfterLoad != nil {
+		sessionPlannerDisplayUpdateAfterLoad()
+	}
+	if !mutate(m) {
+		return nil
+	}
+	return saveOrRemoveSessionPlannerDisplays(dir, m)
+}
+
 func recordSessionPlannerDisplay(dir, sessionPath, userContent string, messages []HistoryMessage) error {
 	if strings.TrimSpace(sessionPath) == "" || strings.TrimSpace(userContent) == "" || len(messages) == 0 {
 		return nil
 	}
-	sessionPlannerDisplayMu.Lock()
-	defer sessionPlannerDisplayMu.Unlock()
-	m := loadSessionPlannerDisplays(dir)
 	key := filepath.Base(sessionPath)
 	turn := plannerDisplayTurn{
 		UserHash: messageDisplayKey(userContent),
 		Messages: cloneHistoryMessages(messages),
 	}
-	m[key] = append(m[key], turn)
-	return saveSessionPlannerDisplays(dir, m)
+	return updateSessionPlannerDisplays(dir, false, func(m sessionPlannerDisplayMap) bool {
+		m[key] = append(m[key], turn)
+		return true
+	})
 }
 
 func removeSessionPlannerDisplay(dir, sessionPath string) error {
 	if strings.TrimSpace(sessionPath) == "" {
 		return nil
 	}
-	sessionPlannerDisplayMu.Lock()
-	defer sessionPlannerDisplayMu.Unlock()
-	m := loadSessionPlannerDisplays(dir)
 	key := filepath.Base(sessionPath)
-	if _, ok := m[key]; !ok {
-		return nil
-	}
-	delete(m, key)
-	return saveOrRemoveSessionPlannerDisplays(dir, m)
+	return updateSessionPlannerDisplays(dir, true, func(m sessionPlannerDisplayMap) bool {
+		if _, ok := m[key]; !ok {
+			return false
+		}
+		delete(m, key)
+		return true
+	})
 }
 
 func pruneSessionPlannerDisplays(dir string, protected map[string]struct{}) error {
-	sessionPlannerDisplayMu.Lock()
-	defer sessionPlannerDisplayMu.Unlock()
-	m := loadSessionPlannerDisplays(dir)
-	if len(m) == 0 {
-		return nil
-	}
-	changed := false
-	for key := range m {
-		if sessionDisplayKeyStillOwned(dir, key, protected) {
-			continue
+	return updateSessionPlannerDisplays(dir, true, func(m sessionPlannerDisplayMap) bool {
+		changed := false
+		for key := range m {
+			if sessionDisplayKeyStillOwned(dir, key, protected) {
+				continue
+			}
+			delete(m, key)
+			changed = true
 		}
-		delete(m, key)
-		changed = true
-	}
-	if !changed {
-		return nil
-	}
-	return saveOrRemoveSessionPlannerDisplays(dir, m)
+		return changed
+	})
 }
 
 func sessionPlannerDisplayTurns(dir, sessionPath string) []plannerDisplayTurn {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -603,6 +603,9 @@ func purgeTrashedSessionFile(dir, path string) error {
 	if err := removeSessionDisplayKey(dir, key); err != nil {
 		return err
 	}
+	if err := removeSessionPlannerDisplay(dir, key); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -999,6 +1002,17 @@ func saveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
 	return fileutil.ReplaceFile(tmpPath, sessionPlannerDisplayPath(dir))
 }
 
+func saveOrRemoveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
+	if len(m) == 0 {
+		err := os.Remove(sessionPlannerDisplayPath(dir))
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return saveSessionPlannerDisplays(dir, m)
+}
+
 func recordSessionPlannerDisplay(dir, sessionPath, userContent string, messages []HistoryMessage) error {
 	if strings.TrimSpace(sessionPath) == "" || strings.TrimSpace(userContent) == "" || len(messages) == 0 {
 		return nil
@@ -1013,6 +1027,42 @@ func recordSessionPlannerDisplay(dir, sessionPath, userContent string, messages 
 	}
 	m[key] = append(m[key], turn)
 	return saveSessionPlannerDisplays(dir, m)
+}
+
+func removeSessionPlannerDisplay(dir, sessionPath string) error {
+	if strings.TrimSpace(sessionPath) == "" {
+		return nil
+	}
+	sessionPlannerDisplayMu.Lock()
+	defer sessionPlannerDisplayMu.Unlock()
+	m := loadSessionPlannerDisplays(dir)
+	key := filepath.Base(sessionPath)
+	if _, ok := m[key]; !ok {
+		return nil
+	}
+	delete(m, key)
+	return saveOrRemoveSessionPlannerDisplays(dir, m)
+}
+
+func pruneSessionPlannerDisplays(dir string, protected map[string]struct{}) error {
+	sessionPlannerDisplayMu.Lock()
+	defer sessionPlannerDisplayMu.Unlock()
+	m := loadSessionPlannerDisplays(dir)
+	if len(m) == 0 {
+		return nil
+	}
+	changed := false
+	for key := range m {
+		if sessionDisplayKeyStillOwned(dir, key, protected) {
+			continue
+		}
+		delete(m, key)
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return saveOrRemoveSessionPlannerDisplays(dir, m)
 }
 
 func sessionPlannerDisplayTurns(dir, sessionPath string) []plannerDisplayTurn {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"reasonix/internal/agent"
@@ -1173,6 +1175,44 @@ func TestSessionDisplayRoundTrip(t *testing.T) {
 	}
 	if got := resolveSessionDisplay(dir, sessionPath, "other"); got != "other" {
 		t.Fatalf("unknown content should pass through, got %q", got)
+	}
+}
+
+func TestRecordSessionPlannerDisplayConcurrentPreservesEverySession(t *testing.T) {
+	dir := t.TempDir()
+	const writers = 32
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			path := filepath.Join(dir, fmt.Sprintf("session-%02d.jsonl", i))
+			errs <- recordSessionPlannerDisplay(dir, path, fmt.Sprintf("prompt-%02d", i), []HistoryMessage{{
+				Role: "assistant", Content: fmt.Sprintf("answer-%02d", i),
+			}})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("record planner display: %v", err)
+		}
+	}
+
+	got := loadSessionPlannerDisplays(dir)
+	if len(got) != writers {
+		t.Fatalf("planner display sessions = %d, want %d", len(got), writers)
+	}
+	for i := 0; i < writers; i++ {
+		key := fmt.Sprintf("session-%02d.jsonl", i)
+		if len(got[key]) != 1 || len(got[key][0].Messages) != 1 || got[key][0].Messages[0].Content != fmt.Sprintf("answer-%02d", i) {
+			t.Fatalf("planner display %s = %+v", key, got[key])
+		}
 	}
 }
 

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/jobs"
@@ -1225,6 +1227,151 @@ func TestRecordSessionPlannerDisplayConcurrentPreservesEverySession(t *testing.T
 			t.Fatalf("planner display %s = %+v", key, got[key])
 		}
 	}
+}
+
+func TestRecordSessionPlannerDisplayCrossProcessPreservesEverySession(t *testing.T) {
+	if role := os.Getenv("REASONIX_PLANNER_DISPLAY_HELPER"); role != "" {
+		dir := os.Getenv("REASONIX_PLANNER_DISPLAY_DIR")
+		sessionPlannerDisplayLockTimeout = 5 * time.Second
+		attempted := filepath.Join(dir, role+".attempted")
+		loaded := filepath.Join(dir, role+".loaded")
+		release := filepath.Join(dir, role+".release")
+		if err := os.WriteFile(attempted, []byte("ready"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if role == "second" && !waitForPlannerDisplayTestFile(filepath.Join(dir, "second.begin"), 10*time.Second) {
+			t.Fatal("timed out waiting to begin second update")
+		}
+		sessionPlannerDisplayUpdateAfterLoad = func() {
+			if err := os.WriteFile(loaded, []byte("loaded"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if !waitForPlannerDisplayTestFile(release, 10*time.Second) {
+				t.Fatalf("timed out waiting for %s release", role)
+			}
+		}
+		err := recordSessionPlannerDisplay(dir, filepath.Join(dir, role+".jsonl"), role+" prompt", []HistoryMessage{{
+			Role: "assistant", Content: role + " answer",
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	dir := t.TempDir()
+	startHelper := func(role string, output *strings.Builder) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestRecordSessionPlannerDisplayCrossProcessPreservesEverySession$")
+		cmd.Env = append(os.Environ(),
+			"REASONIX_PLANNER_DISPLAY_HELPER="+role,
+			"REASONIX_PLANNER_DISPLAY_DIR="+dir,
+		)
+		cmd.Stdout = output
+		cmd.Stderr = output
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start %s helper: %v", role, err)
+		}
+		return cmd
+	}
+	releaseHelper := func(role string) {
+		if err := os.WriteFile(filepath.Join(dir, role+".release"), []byte("release"), 0o600); err != nil {
+			t.Fatalf("release %s helper: %v", role, err)
+		}
+	}
+
+	var firstOutput, secondOutput strings.Builder
+	first := startHelper("first", &firstOutput)
+	if !waitForPlannerDisplayTestFile(filepath.Join(dir, "first.loaded"), 5*time.Second) {
+		releaseHelper("first")
+		_ = first.Wait()
+		t.Fatalf("first helper did not load sidecar: %s", firstOutput.String())
+	}
+	second := startHelper("second", &secondOutput)
+	if !waitForPlannerDisplayTestFile(filepath.Join(dir, "second.attempted"), 5*time.Second) {
+		releaseHelper("first")
+		_ = os.WriteFile(filepath.Join(dir, "second.begin"), []byte("begin"), 0o600)
+		releaseHelper("second")
+		_ = first.Wait()
+		_ = second.Wait()
+		t.Fatalf("second helper did not attempt update: %s", secondOutput.String())
+	}
+	if err := os.WriteFile(filepath.Join(dir, "second.begin"), []byte("begin"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if waitForPlannerDisplayTestFile(filepath.Join(dir, "second.loaded"), time.Second) {
+		releaseHelper("first")
+		releaseHelper("second")
+		_ = first.Wait()
+		_ = second.Wait()
+		t.Fatal("second process loaded the stale sidecar while the first update still held its transaction lock")
+	}
+
+	releaseHelper("first")
+	if err := first.Wait(); err != nil {
+		releaseHelper("second")
+		_ = second.Wait()
+		t.Fatalf("first helper failed: %v\n%s", err, firstOutput.String())
+	}
+	if !waitForPlannerDisplayTestFile(filepath.Join(dir, "second.loaded"), 5*time.Second) {
+		releaseHelper("second")
+		_ = second.Wait()
+		t.Fatalf("second helper did not enter transaction after release: %s", secondOutput.String())
+	}
+	releaseHelper("second")
+	if err := second.Wait(); err != nil {
+		t.Fatalf("second helper failed: %v\n%s", err, secondOutput.String())
+	}
+
+	got := loadSessionPlannerDisplays(dir)
+	for _, role := range []string{"first", "second"} {
+		turns := got[role+".jsonl"]
+		if len(turns) != 1 || len(turns[0].Messages) != 1 || turns[0].Messages[0].Content != role+" answer" {
+			t.Fatalf("%s planner display lost after cross-process updates: %#v", role, got)
+		}
+	}
+}
+
+func TestRecordSessionPlannerDisplayDoesNotOverwriteCorruptSidecar(t *testing.T) {
+	dir := t.TempDir()
+	corrupt := []byte(`{"session.jsonl":[`)
+	if err := os.WriteFile(sessionPlannerDisplayPath(dir), corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := recordSessionPlannerDisplay(dir, filepath.Join(dir, "new.jsonl"), "prompt", []HistoryMessage{{Role: "assistant", Content: "answer"}})
+	if err == nil {
+		t.Fatal("record should reject a corrupt sidecar instead of replacing it with an empty map")
+	}
+	got, readErr := os.ReadFile(sessionPlannerDisplayPath(dir))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(corrupt) {
+		t.Fatalf("corrupt sidecar was overwritten: %q", got)
+	}
+}
+
+func TestRemoveSessionPlannerDisplayRetiresCorruptSidecar(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(sessionPlannerDisplayPath(dir), []byte(`{"session.jsonl":[`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeSessionPlannerDisplay(dir, filepath.Join(dir, "session.jsonl")); err != nil {
+		t.Fatalf("remove display from corrupt sidecar: %v", err)
+	}
+	if _, err := os.Stat(sessionPlannerDisplayPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("corrupt sidecar should be retired during destructive cleanup, stat err = %v", err)
+	}
+}
+
+func waitForPlannerDisplayTestFile(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
 }
 
 func TestRemoveDesktopSessionArtifactsPrunesPlannerDisplay(t *testing.T) {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -786,8 +786,16 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	if err := recordSessionDisplay(dir, sessionPath, "expanded prompt", "[Pasted text #1 · 5 lines]"); err != nil {
 		t.Fatal(err)
 	}
+	if err := recordSessionPlannerDisplay(dir, sessionPath, "prompt", []HistoryMessage{{
+		Role: "tool", ToolName: "read_file", Content: "sensitive cancelled output",
+	}}); err != nil {
+		t.Fatal(err)
+	}
 	if err := deleteSessionFile(dir, sessionPath); err != nil {
 		t.Fatalf("trash: %v", err)
+	}
+	if got := sessionPlannerDisplayTurns(dir, sessionPath); len(got) != 1 {
+		t.Fatalf("planner display should remain available while session is in trash: %+v", got)
 	}
 	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
 	if err := purgeTrashedSessionFile(dir, trashPath); err != nil {
@@ -810,6 +818,9 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	}
 	if got := resolveSessionDisplay(dir, sessionPath, "expanded prompt"); got != "expanded prompt" {
 		t.Fatalf("display sidecar should be removed after purge, got %q", got)
+	}
+	if got := sessionPlannerDisplayTurns(dir, sessionPath); len(got) != 0 {
+		t.Fatalf("planner display sidecar should be removed after purge: %+v", got)
 	}
 }
 
@@ -1212,6 +1223,67 @@ func TestRecordSessionPlannerDisplayConcurrentPreservesEverySession(t *testing.T
 		key := fmt.Sprintf("session-%02d.jsonl", i)
 		if len(got[key]) != 1 || len(got[key][0].Messages) != 1 || got[key][0].Messages[0].Content != fmt.Sprintf("answer-%02d", i) {
 			t.Fatalf("planner display %s = %+v", key, got[key])
+		}
+	}
+}
+
+func TestRemoveDesktopSessionArtifactsPrunesPlannerDisplay(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordSessionPlannerDisplay(dir, path, "prompt", []HistoryMessage{{
+		Role: "tool", ToolName: "read_file", Content: "sensitive cancelled output",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeDesktopSessionArtifacts(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := sessionPlannerDisplayTurns(dir, path); len(got) != 0 {
+		t.Fatalf("planner display retained after permanent session removal: %+v", got)
+	}
+	if _, err := os.Stat(sessionPlannerDisplayPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("empty planner display sidecar should be removed, stat err = %v", err)
+	}
+}
+
+func TestPruneSessionPlannerDisplaysRemovesOnlyOrphans(t *testing.T) {
+	dir := t.TempDir()
+	turn := []plannerDisplayTurn{{UserHash: messageDisplayKey("prompt"), Messages: []HistoryMessage{{Role: "assistant", Content: "display"}}}}
+	if err := saveSessionPlannerDisplays(dir, sessionPlannerDisplayMap{
+		"live.jsonl":           turn,
+		"trashed.jsonl":        turn,
+		"protected.jsonl":      turn,
+		"missing.jsonl":        turn,
+		"sidecar.events.jsonl": turn,
+	}); err != nil {
+		t.Fatalf("save planner displays: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "live.jsonl"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("write live session: %v", err)
+	}
+	trashDir := filepath.Join(dir, sessionTrashDir, "trashed.jsonl")
+	if err := os.MkdirAll(trashDir, 0o755); err != nil {
+		t.Fatalf("mkdir trash: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(trashDir, "trashed.jsonl"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("write trashed session: %v", err)
+	}
+
+	if err := pruneSessionPlannerDisplays(dir, map[string]struct{}{"protected.jsonl": {}}); err != nil {
+		t.Fatalf("prune planner displays: %v", err)
+	}
+	got := loadSessionPlannerDisplays(dir)
+	for _, key := range []string{"live.jsonl", "trashed.jsonl", "protected.jsonl"} {
+		if got[key] == nil {
+			t.Fatalf("%s planner display should be retained; got %#v", key, got)
+		}
+	}
+	for _, key := range []string{"missing.jsonl", "sidecar.events.jsonl"} {
+		if got[key] != nil {
+			t.Fatalf("%s planner display should be pruned; got %#v", key, got)
 		}
 	}
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -40,11 +40,110 @@ import (
 // handoff window where an event already routed to the old wrapper could append
 // after a clone copied its buffers.
 type tabDisplayState struct {
-	mu               sync.Mutex
-	plannerMessages  []HistoryMessage
-	plannerTools     map[string]string
-	executorMessages []HistoryMessage
-	executorTools    map[string]string
+	mu             sync.Mutex
+	planner        displayTurnBuffer
+	executor       displayTurnBuffer
+	pendingWrites  []*pendingDisplayWrite
+	persistRunning bool
+}
+
+const displayPersistRetryLimit = 4
+
+type pendingDisplayWrite struct {
+	dir         string
+	sessionPath string
+	userContent string
+	messages    []HistoryMessage
+	persist     func(string, string, string, []HistoryMessage) error
+}
+
+// displayTextAccumulator retains provider chunks without repeatedly copying
+// the complete prefix. A turn only materializes the final string when its
+// display-only history is persisted; successful executor turns are discarded
+// without ever joining their chunks.
+type displayTextAccumulator struct {
+	parts []string
+	size  int
+}
+
+func (a *displayTextAccumulator) append(text string) {
+	if text == "" {
+		return
+	}
+	a.parts = append(a.parts, text)
+	a.size += len(text)
+}
+
+func (a *displayTextAccumulator) replace(text string) {
+	a.parts = nil
+	a.size = 0
+	a.append(text)
+}
+
+func (a *displayTextAccumulator) hasNonWhitespace() bool {
+	for _, part := range a.parts {
+		if strings.TrimSpace(part) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *displayTextAccumulator) string() string {
+	switch len(a.parts) {
+	case 0:
+		return ""
+	case 1:
+		return a.parts[0]
+	}
+	var out strings.Builder
+	out.Grow(a.size)
+	for _, part := range a.parts {
+		out.WriteString(part)
+	}
+	return out.String()
+}
+
+type bufferedHistoryMessage struct {
+	message   HistoryMessage
+	content   displayTextAccumulator
+	reasoning displayTextAccumulator
+}
+
+func (m *bufferedHistoryMessage) materialize() HistoryMessage {
+	out := m.message
+	if out.Role == "assistant" {
+		out.Content = m.content.string()
+		out.Reasoning = m.reasoning.string()
+	}
+	if len(out.MemoryCitations) > 0 {
+		out.MemoryCitations = append([]provider.MemoryCitation(nil), out.MemoryCitations...)
+	}
+	if len(out.ToolCalls) > 0 {
+		out.ToolCalls = append([]HistoryToolCall(nil), out.ToolCalls...)
+	}
+	return out
+}
+
+type displayTurnBuffer struct {
+	messages []*bufferedHistoryMessage
+	tools    map[string]string
+}
+
+func (b *displayTurnBuffer) reset() {
+	b.messages = nil
+	b.tools = nil
+}
+
+func (b *displayTurnBuffer) materialize() []HistoryMessage {
+	if len(b.messages) == 0 {
+		return nil
+	}
+	out := make([]HistoryMessage, 0, len(b.messages))
+	for _, message := range b.messages {
+		out = append(out, message.materialize())
+	}
+	return out
 }
 
 // WorkspaceTab is one open conversation tab in the desktop. Each tab owns an
@@ -789,11 +888,11 @@ func (t *WorkspaceTab) syncTelemetryToSession(sessionPath string) {
 func (t *WorkspaceTab) resetDisplayTurn() {
 	state := t.displayBufferState()
 	state.mu.Lock()
-	if len(state.plannerMessages) == 0 {
-		state.plannerTools = nil
+	if len(state.planner.messages) == 0 {
+		state.planner.tools = nil
 	}
-	if len(state.executorMessages) == 0 {
-		state.executorTools = nil
+	if len(state.executor.messages) == 0 {
+		state.executor.tools = nil
 	}
 	state.mu.Unlock()
 }
@@ -802,13 +901,11 @@ func (t *WorkspaceTab) recordDisplayEvent(e event.Event) {
 	state := t.displayBufferState()
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	messages := &state.executorMessages
-	tools := &state.executorTools
+	buffer := &state.executor
 	if strings.TrimSpace(e.Source) == event.UsageSourcePlanner {
-		messages = &state.plannerMessages
-		tools = &state.plannerTools
+		buffer = &state.planner
 	}
-	recordHistoryDisplayEvent(messages, tools, e)
+	recordHistoryDisplayEvent(buffer, e)
 }
 
 func (t *WorkspaceTab) displayBufferState() *tabDisplayState {
@@ -829,40 +926,40 @@ func (t *WorkspaceTab) adoptDisplayState(state *tabDisplayState) {
 	t.displayStateMu.Unlock()
 }
 
-func recordHistoryDisplayEvent(messages *[]HistoryMessage, tools *map[string]string, e event.Event) {
+func recordHistoryDisplayEvent(buffer *displayTurnBuffer, e event.Event) {
 	switch e.Kind {
 	case event.Phase:
 		if strings.TrimSpace(e.Text) != "" {
-			*messages = append(*messages, HistoryMessage{Role: "phase", Content: e.Text})
+			buffer.messages = append(buffer.messages, &bufferedHistoryMessage{message: HistoryMessage{Role: "phase", Content: e.Text}})
 		}
 	case event.Reasoning:
 		if e.Text != "" {
-			hm := ensureDisplayAssistant(messages)
-			hm.Reasoning += e.Text
+			hm := ensureDisplayAssistant(buffer)
+			hm.reasoning.append(e.Text)
 		}
 	case event.Text:
 		if e.Text != "" {
-			hm := ensureDisplayAssistant(messages)
-			hm.Content += e.Text
+			hm := ensureDisplayAssistant(buffer)
+			hm.content.append(e.Text)
 		}
 	case event.Message:
 		if e.Text != "" || e.Reasoning != "" || len(e.MemoryCitations) > 0 {
-			hm := ensureDisplayAssistant(messages)
+			hm := ensureDisplayAssistant(buffer)
 			if e.Text != "" {
-				hm.Content = e.Text
+				hm.content.replace(e.Text)
 			}
 			if e.Reasoning != "" {
-				hm.Reasoning = e.Reasoning
+				hm.reasoning.replace(e.Reasoning)
 			}
 			if len(e.MemoryCitations) > 0 {
-				hm.MemoryCitations = append([]provider.MemoryCitation(nil), e.MemoryCitations...)
+				hm.message.MemoryCitations = append([]provider.MemoryCitation(nil), e.MemoryCitations...)
 			}
 		}
 	case event.ToolDispatch:
 		if e.Tool.Partial || strings.TrimSpace(e.Tool.Name) == "" {
 			return
 		}
-		hm := ensureDisplayAssistantForTool(messages)
+		hm := ensureDisplayAssistantForTool(buffer)
 		call := HistoryToolCall{
 			ID:        e.Tool.ID,
 			Name:      e.Tool.Name,
@@ -875,64 +972,84 @@ func recordHistoryDisplayEvent(messages *[]HistoryMessage, tools *map[string]str
 		}
 		replaced := false
 		if call.ID != "" {
-			for i := range hm.ToolCalls {
-				if hm.ToolCalls[i].ID == call.ID {
-					hm.ToolCalls[i] = call
+			for i := range hm.message.ToolCalls {
+				if hm.message.ToolCalls[i].ID == call.ID {
+					hm.message.ToolCalls[i] = call
 					replaced = true
 					break
 				}
 			}
-			if *tools == nil {
-				*tools = map[string]string{}
+			if buffer.tools == nil {
+				buffer.tools = map[string]string{}
 			}
-			(*tools)[call.ID] = call.Name
+			buffer.tools[call.ID] = call.Name
 		}
 		if !replaced {
-			hm.ToolCalls = append(hm.ToolCalls, call)
+			hm.message.ToolCalls = append(hm.message.ToolCalls, call)
 		}
 	case event.ToolResult:
 		callID := strings.TrimSpace(e.Tool.ID)
 		content := firstNonEmpty(e.Tool.Output, e.Tool.Err)
 		display, errPreview := plannerToolResultDisplay(content, e.Tool.Err != "")
 		if callID != "" {
-			updateHistoryToolCallSummary(*messages, callID, content)
+			updateBufferedHistoryToolCallSummary(buffer.messages, callID, content)
 		}
 		toolName := e.Tool.Name
-		if toolName == "" && *tools != nil {
-			toolName = (*tools)[callID]
+		if toolName == "" && buffer.tools != nil {
+			toolName = buffer.tools[callID]
 		}
-		*messages = append(*messages, HistoryMessage{
+		buffer.messages = append(buffer.messages, &bufferedHistoryMessage{message: HistoryMessage{
 			Role:            "tool",
 			ToolCallID:      callID,
 			ToolName:        toolName,
 			Content:         display,
 			ToolResultError: errPreview,
-		})
+		}})
 	case event.Notice:
 		if strings.TrimSpace(e.Text) != "" {
 			level := "info"
 			if e.Level == event.LevelWarn {
 				level = "warn"
 			}
-			*messages = append(*messages, HistoryMessage{Role: "notice", Level: level, Content: e.Text, Detail: e.Detail, Code: e.Code})
+			buffer.messages = append(buffer.messages, &bufferedHistoryMessage{message: HistoryMessage{Role: "notice", Level: level, Content: e.Text, Detail: e.Detail, Code: e.Code}})
 		}
 	}
 }
 
-func ensureDisplayAssistant(messages *[]HistoryMessage) *HistoryMessage {
-	if n := len(*messages); n > 0 && (*messages)[n-1].Role == "assistant" {
-		return &(*messages)[n-1]
+func ensureDisplayAssistant(buffer *displayTurnBuffer) *bufferedHistoryMessage {
+	if n := len(buffer.messages); n > 0 && buffer.messages[n-1].message.Role == "assistant" {
+		return buffer.messages[n-1]
 	}
-	*messages = append(*messages, HistoryMessage{Role: "assistant"})
-	return &(*messages)[len(*messages)-1]
+	message := &bufferedHistoryMessage{message: HistoryMessage{Role: "assistant"}}
+	buffer.messages = append(buffer.messages, message)
+	return message
 }
 
-func ensureDisplayAssistantForTool(messages *[]HistoryMessage) *HistoryMessage {
-	if n := len(*messages); n > 0 && (*messages)[n-1].Role == "assistant" && strings.TrimSpace((*messages)[n-1].Content) == "" {
-		return &(*messages)[n-1]
+func ensureDisplayAssistantForTool(buffer *displayTurnBuffer) *bufferedHistoryMessage {
+	if n := len(buffer.messages); n > 0 && buffer.messages[n-1].message.Role == "assistant" && !buffer.messages[n-1].content.hasNonWhitespace() {
+		return buffer.messages[n-1]
 	}
-	*messages = append(*messages, HistoryMessage{Role: "assistant"})
-	return &(*messages)[len(*messages)-1]
+	message := &bufferedHistoryMessage{message: HistoryMessage{Role: "assistant"}}
+	buffer.messages = append(buffer.messages, message)
+	return message
+}
+
+func updateBufferedHistoryToolCallSummary(messages []*bufferedHistoryMessage, callID, output string) {
+	if callID == "" {
+		return
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		for j := range messages[i].message.ToolCalls {
+			call := &messages[i].message.ToolCalls[j]
+			if call.ID != callID {
+				continue
+			}
+			if call.Summary == "" {
+				call.Summary = historyToolSummary(call.Name, call.Arguments, output)
+			}
+			return
+		}
+	}
 }
 
 func plannerToolResultDisplay(content string, failed bool) (display, errPreview string) {
@@ -950,9 +1067,9 @@ func (t *WorkspaceTab) takeDisplayTurn(cancelled bool) []HistoryMessage {
 	state := t.displayBufferState()
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	out := cloneHistoryMessages(state.plannerMessages)
+	out := state.planner.materialize()
 	if cancelled {
-		out = append(out, cloneHistoryMessages(state.executorMessages)...)
+		out = append(out, state.executor.materialize()...)
 		if len(out) > 0 {
 			out = append(out, HistoryMessage{
 				Role:    "notice",
@@ -962,11 +1079,78 @@ func (t *WorkspaceTab) takeDisplayTurn(cancelled bool) []HistoryMessage {
 			})
 		}
 	}
-	state.plannerMessages = nil
-	state.plannerTools = nil
-	state.executorMessages = nil
-	state.executorTools = nil
+	state.planner.reset()
+	state.executor.reset()
 	return out
+}
+
+func enqueuePendingDisplayWrite(state *tabDisplayState, write *pendingDisplayWrite) {
+	if state == nil || write == nil || write.persist == nil {
+		return
+	}
+	state.mu.Lock()
+	state.pendingWrites = append(state.pendingWrites, write)
+	if state.persistRunning {
+		state.mu.Unlock()
+		return
+	}
+	state.persistRunning = true
+	state.mu.Unlock()
+	go retryPendingDisplayWrites(state)
+}
+
+func persistOrEnqueueDisplayWrite(state *tabDisplayState, write *pendingDisplayWrite) {
+	if state == nil || write == nil || write.persist == nil {
+		return
+	}
+	state.mu.Lock()
+	hasPending := len(state.pendingWrites) > 0
+	state.mu.Unlock()
+	if hasPending {
+		enqueuePendingDisplayWrite(state, write)
+		return
+	}
+	if err := write.persist(write.dir, write.sessionPath, write.userContent, write.messages); err != nil {
+		slog.Warn("desktop: persist display-only turn history; queued for retry", "err", err)
+		enqueuePendingDisplayWrite(state, write)
+	}
+}
+
+func retryPendingDisplayWrites(state *tabDisplayState) {
+	failures := 0
+	for {
+		state.mu.Lock()
+		if len(state.pendingWrites) == 0 {
+			state.persistRunning = false
+			state.mu.Unlock()
+			return
+		}
+		write := state.pendingWrites[0]
+		state.mu.Unlock()
+
+		if failures > 0 {
+			time.Sleep(time.Duration(failures*failures) * 50 * time.Millisecond)
+		}
+		if err := write.persist(write.dir, write.sessionPath, write.userContent, write.messages); err != nil {
+			failures++
+			if failures < displayPersistRetryLimit {
+				continue
+			}
+			state.mu.Lock()
+			state.persistRunning = false
+			state.mu.Unlock()
+			slog.Warn("desktop: display-only turn history remains pending after retries", "err", err)
+			return
+		}
+
+		state.mu.Lock()
+		if len(state.pendingWrites) > 0 && state.pendingWrites[0] == write {
+			state.pendingWrites[0] = nil
+			state.pendingWrites = state.pendingWrites[1:]
+		}
+		state.mu.Unlock()
+		failures = 0
+	}
 }
 
 // tabEventSink wraps a parent event.Sink and prepends a tabId to every wire
@@ -1473,9 +1657,13 @@ func (s *tabEventSink) flushDisplay(cancelRequested bool) {
 	if strings.TrimSpace(userContent) == "" {
 		return
 	}
-	if err := recordSessionPlannerDisplay(controllerSessionDir(ctrl), sessionPath, userContent, messages); err != nil {
-		slog.Warn("desktop: persist display-only turn history", "err", err)
-	}
+	persistOrEnqueueDisplayWrite(tab.displayBufferState(), &pendingDisplayWrite{
+		dir:         controllerSessionDir(ctrl),
+		sessionPath: sessionPath,
+		userContent: userContent,
+		messages:    messages,
+		persist:     recordSessionPlannerDisplay,
+	})
 }
 
 func (s *tabEventSink) eventTabAndController() (*WorkspaceTab, control.SessionAPI) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -95,12 +95,15 @@ type WorkspaceTab struct {
 	telemetrySessionKey string
 	telemMu             sync.Mutex
 
-	// plannerDisplay keeps display-only planner output for the in-flight turn.
-	// The executor session remains the model-facing transcript; this sidecar
-	// lets frontend history restore the planner cards after a rebuild/reload.
-	plannerDisplay      []HistoryMessage
-	plannerDisplayTools map[string]string
-	plannerDisplayMu    sync.Mutex
+	// Display-only output for the in-flight turn. The executor session remains
+	// the model-facing transcript; these buffers let history restore planner
+	// cards and user-cancelled executor output without replaying either to the
+	// model after a rebuild/reload.
+	plannerDisplay       []HistoryMessage
+	plannerDisplayTools  map[string]string
+	executorDisplay      []HistoryMessage
+	executorDisplayTools map[string]string
+	displayMu            sync.Mutex
 
 	model            string // active model ref (for meta)
 	effort           *string
@@ -770,38 +773,48 @@ func (t *WorkspaceTab) syncTelemetryToSession(sessionPath string) {
 	t.telemMu.Unlock()
 }
 
-func (t *WorkspaceTab) resetPlannerDisplayTurn() {
-	t.plannerDisplayMu.Lock()
+func (t *WorkspaceTab) resetDisplayTurn() {
+	t.displayMu.Lock()
 	if len(t.plannerDisplay) == 0 {
 		t.plannerDisplayTools = nil
 	}
-	t.plannerDisplayMu.Unlock()
+	if len(t.executorDisplay) == 0 {
+		t.executorDisplayTools = nil
+	}
+	t.displayMu.Unlock()
 }
 
-func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
-	if strings.TrimSpace(e.Source) != event.UsageSourcePlanner {
-		return
+func (t *WorkspaceTab) recordDisplayEvent(e event.Event) {
+	t.displayMu.Lock()
+	defer t.displayMu.Unlock()
+	messages := &t.executorDisplay
+	tools := &t.executorDisplayTools
+	if strings.TrimSpace(e.Source) == event.UsageSourcePlanner {
+		messages = &t.plannerDisplay
+		tools = &t.plannerDisplayTools
 	}
-	t.plannerDisplayMu.Lock()
-	defer t.plannerDisplayMu.Unlock()
+	recordHistoryDisplayEvent(messages, tools, e)
+}
+
+func recordHistoryDisplayEvent(messages *[]HistoryMessage, tools *map[string]string, e event.Event) {
 	switch e.Kind {
 	case event.Phase:
 		if strings.TrimSpace(e.Text) != "" {
-			t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "phase", Content: e.Text})
+			*messages = append(*messages, HistoryMessage{Role: "phase", Content: e.Text})
 		}
 	case event.Reasoning:
 		if e.Text != "" {
-			hm := t.ensurePlannerAssistantLocked()
+			hm := ensureDisplayAssistant(messages)
 			hm.Reasoning += e.Text
 		}
 	case event.Text:
 		if e.Text != "" {
-			hm := t.ensurePlannerAssistantLocked()
+			hm := ensureDisplayAssistant(messages)
 			hm.Content += e.Text
 		}
 	case event.Message:
 		if e.Text != "" || e.Reasoning != "" || len(e.MemoryCitations) > 0 {
-			hm := t.ensurePlannerAssistantLocked()
+			hm := ensureDisplayAssistant(messages)
 			if e.Text != "" {
 				hm.Content = e.Text
 			}
@@ -816,7 +829,7 @@ func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
 		if e.Tool.Partial || strings.TrimSpace(e.Tool.Name) == "" {
 			return
 		}
-		hm := t.ensurePlannerAssistantForToolLocked()
+		hm := ensureDisplayAssistantForTool(messages)
 		call := HistoryToolCall{
 			ID:        e.Tool.ID,
 			Name:      e.Tool.Name,
@@ -836,10 +849,10 @@ func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
 					break
 				}
 			}
-			if t.plannerDisplayTools == nil {
-				t.plannerDisplayTools = map[string]string{}
+			if *tools == nil {
+				*tools = map[string]string{}
 			}
-			t.plannerDisplayTools[call.ID] = call.Name
+			(*tools)[call.ID] = call.Name
 		}
 		if !replaced {
 			hm.ToolCalls = append(hm.ToolCalls, call)
@@ -849,13 +862,13 @@ func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
 		content := firstNonEmpty(e.Tool.Output, e.Tool.Err)
 		display, errPreview := plannerToolResultDisplay(content, e.Tool.Err != "")
 		if callID != "" {
-			updateHistoryToolCallSummary(t.plannerDisplay, callID, content)
+			updateHistoryToolCallSummary(*messages, callID, content)
 		}
 		toolName := e.Tool.Name
-		if toolName == "" && t.plannerDisplayTools != nil {
-			toolName = t.plannerDisplayTools[callID]
+		if toolName == "" && *tools != nil {
+			toolName = (*tools)[callID]
 		}
-		t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{
+		*messages = append(*messages, HistoryMessage{
 			Role:            "tool",
 			ToolCallID:      callID,
 			ToolName:        toolName,
@@ -868,25 +881,25 @@ func (t *WorkspaceTab) recordPlannerDisplayEvent(e event.Event) {
 			if e.Level == event.LevelWarn {
 				level = "warn"
 			}
-			t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "notice", Level: level, Content: e.Text, Detail: e.Detail, Code: e.Code})
+			*messages = append(*messages, HistoryMessage{Role: "notice", Level: level, Content: e.Text, Detail: e.Detail, Code: e.Code})
 		}
 	}
 }
 
-func (t *WorkspaceTab) ensurePlannerAssistantLocked() *HistoryMessage {
-	if n := len(t.plannerDisplay); n > 0 && t.plannerDisplay[n-1].Role == "assistant" {
-		return &t.plannerDisplay[n-1]
+func ensureDisplayAssistant(messages *[]HistoryMessage) *HistoryMessage {
+	if n := len(*messages); n > 0 && (*messages)[n-1].Role == "assistant" {
+		return &(*messages)[n-1]
 	}
-	t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "assistant"})
-	return &t.plannerDisplay[len(t.plannerDisplay)-1]
+	*messages = append(*messages, HistoryMessage{Role: "assistant"})
+	return &(*messages)[len(*messages)-1]
 }
 
-func (t *WorkspaceTab) ensurePlannerAssistantForToolLocked() *HistoryMessage {
-	if n := len(t.plannerDisplay); n > 0 && t.plannerDisplay[n-1].Role == "assistant" && strings.TrimSpace(t.plannerDisplay[n-1].Content) == "" {
-		return &t.plannerDisplay[n-1]
+func ensureDisplayAssistantForTool(messages *[]HistoryMessage) *HistoryMessage {
+	if n := len(*messages); n > 0 && (*messages)[n-1].Role == "assistant" && strings.TrimSpace((*messages)[n-1].Content) == "" {
+		return &(*messages)[n-1]
 	}
-	t.plannerDisplay = append(t.plannerDisplay, HistoryMessage{Role: "assistant"})
-	return &t.plannerDisplay[len(t.plannerDisplay)-1]
+	*messages = append(*messages, HistoryMessage{Role: "assistant"})
+	return &(*messages)[len(*messages)-1]
 }
 
 func plannerToolResultDisplay(content string, failed bool) (display, errPreview string) {
@@ -900,12 +913,25 @@ func plannerToolResultDisplay(content string, failed bool) (display, errPreview 
 	return "", ""
 }
 
-func (t *WorkspaceTab) takePlannerDisplayTurn() []HistoryMessage {
-	t.plannerDisplayMu.Lock()
-	defer t.plannerDisplayMu.Unlock()
+func (t *WorkspaceTab) takeDisplayTurn(cancelled bool) []HistoryMessage {
+	t.displayMu.Lock()
+	defer t.displayMu.Unlock()
 	out := cloneHistoryMessages(t.plannerDisplay)
+	if cancelled {
+		out = append(out, cloneHistoryMessages(t.executorDisplay)...)
+		if len(out) > 0 {
+			out = append(out, HistoryMessage{
+				Role:    "notice",
+				Level:   "info",
+				Code:    event.NoticeCodeCancelledTurn,
+				Content: "This turn was interrupted. Partial output is kept for reference but is not included in the model's next-turn history; inspect the workspace before continuing or reverting changes.",
+			})
+		}
+	}
 	t.plannerDisplay = nil
 	t.plannerDisplayTools = nil
+	t.executorDisplay = nil
+	t.executorDisplayTools = nil
 	return out
 }
 
@@ -959,7 +985,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 	if app != nil {
 		switch e.Kind {
 		case event.TurnStarted:
-			s.resetPlannerDisplayTurn()
+			s.resetDisplayTurn()
 			s.recordTurnStarted()
 		case event.Usage:
 			s.recordUsageTelemetry(e)
@@ -973,7 +999,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			}
 		}
 		if e.Kind == event.TurnDone {
-			s.flushPlannerDisplay()
+			s.flushDisplay(e.Cancelled)
 		}
 	}
 	s.emitRuntimeEvent(eventChannel, toWireTab(e, tabID))
@@ -990,7 +1016,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 		s.recordReadTelemetry(e)
 	}
 	if app != nil {
-		s.recordPlannerDisplay(e)
+		s.recordDisplay(e)
 	}
 	// Persist after each turn so a force-kill loses at most the in-flight prompt.
 	if e.Kind == event.TurnDone && app != nil {
@@ -1380,26 +1406,28 @@ func (s *tabEventSink) recordUsageTelemetry(e event.Event) {
 	}
 }
 
-func (s *tabEventSink) resetPlannerDisplayTurn() {
+func (s *tabEventSink) resetDisplayTurn() {
 	tab, _ := s.eventTabAndController()
 	if tab != nil {
-		tab.resetPlannerDisplayTurn()
+		tab.resetDisplayTurn()
 	}
 }
 
-func (s *tabEventSink) recordPlannerDisplay(e event.Event) {
+func (s *tabEventSink) recordDisplay(e event.Event) {
 	tab, _ := s.eventTabAndController()
 	if tab != nil {
-		tab.recordPlannerDisplayEvent(e)
+		tab.recordDisplayEvent(e)
 	}
 }
 
-func (s *tabEventSink) flushPlannerDisplay() {
+func (s *tabEventSink) flushDisplay(cancelRequested bool) {
 	tab, ctrl := s.eventTabAndController()
 	if tab == nil || ctrl == nil {
 		return
 	}
-	messages := tab.takePlannerDisplayTurn()
+	history := ctrl.History()
+	keepExecutorDisplay := cancelRequested && len(history) > 0 && history[len(history)-1].Role == provider.RoleUser
+	messages := tab.takeDisplayTurn(keepExecutorDisplay)
 	if len(messages) == 0 {
 		return
 	}
@@ -1407,11 +1435,13 @@ func (s *tabEventSink) flushPlannerDisplay() {
 	if sessionPath == "" {
 		return
 	}
-	userContent := lastUserMessageContent(ctrl.History())
+	userContent := lastUserMessageContent(history)
 	if strings.TrimSpace(userContent) == "" {
 		return
 	}
-	_ = recordSessionPlannerDisplay(controllerSessionDir(ctrl), sessionPath, userContent, messages)
+	if err := recordSessionPlannerDisplay(controllerSessionDir(ctrl), sessionPath, userContent, messages); err != nil {
+		slog.Warn("desktop: persist display-only turn history", "err", err)
+	}
 }
 
 func (s *tabEventSink) eventTabAndController() (*WorkspaceTab, control.SessionAPI) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -35,6 +35,18 @@ import (
 
 // --- WorkspaceTab -----------------------------------------------------------
 
+// tabDisplayState follows one live runtime across visible, detached, and
+// reattached WorkspaceTab wrappers. Keeping one shared state pointer closes the
+// handoff window where an event already routed to the old wrapper could append
+// after a clone copied its buffers.
+type tabDisplayState struct {
+	mu               sync.Mutex
+	plannerMessages  []HistoryMessage
+	plannerTools     map[string]string
+	executorMessages []HistoryMessage
+	executorTools    map[string]string
+}
+
 // WorkspaceTab is one open conversation tab in the desktop. Each tab owns an
 // independent controller (its own agent, session, tool registry, plugin host,
 // memory, permissions) scoped to a workspace root, so multiple projects and
@@ -95,15 +107,11 @@ type WorkspaceTab struct {
 	telemetrySessionKey string
 	telemMu             sync.Mutex
 
-	// Display-only output for the in-flight turn. The executor session remains
-	// the model-facing transcript; these buffers let history restore planner
-	// cards and user-cancelled executor output without replaying either to the
-	// model after a rebuild/reload.
-	plannerDisplay       []HistoryMessage
-	plannerDisplayTools  map[string]string
-	executorDisplay      []HistoryMessage
-	executorDisplayTools map[string]string
-	displayMu            sync.Mutex
+	// Display-only output belongs to the live runtime, not a particular visible
+	// tab wrapper. detach/reattach paths share this state before rebinding the
+	// event sink so output cannot fall into a discarded wrapper.
+	displayStateMu sync.Mutex
+	displayState   *tabDisplayState
 
 	model            string // active model ref (for meta)
 	effort           *string
@@ -491,6 +499,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab 
 		readTelemetry:       readTelemetry,
 		usageTelemetry:      usageTelemetry,
 		telemetrySessionKey: telemetrySessionKey,
+		displayState:        tab.displayBufferState(),
 		model:               tab.model,
 		effort:              cloneStringPtr(tab.effort),
 		tokenMode:           tab.tokenMode,
@@ -564,6 +573,10 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	telemetrySessionKey := source.telemetrySessionKey
 	source.telemMu.Unlock()
 
+	// Share the runtime-owned display state before rebinding the sink. An event
+	// already routed to source and one arriving on target after setBinding then
+	// append under the same state lock instead of straddling two buffers.
+	target.adoptDisplayState(source.displayBufferState())
 	if source.sink != nil {
 		source.sink.setBinding(target.ID, app)
 		source.sink.setContext(wailsCtx)
@@ -774,26 +787,46 @@ func (t *WorkspaceTab) syncTelemetryToSession(sessionPath string) {
 }
 
 func (t *WorkspaceTab) resetDisplayTurn() {
-	t.displayMu.Lock()
-	if len(t.plannerDisplay) == 0 {
-		t.plannerDisplayTools = nil
+	state := t.displayBufferState()
+	state.mu.Lock()
+	if len(state.plannerMessages) == 0 {
+		state.plannerTools = nil
 	}
-	if len(t.executorDisplay) == 0 {
-		t.executorDisplayTools = nil
+	if len(state.executorMessages) == 0 {
+		state.executorTools = nil
 	}
-	t.displayMu.Unlock()
+	state.mu.Unlock()
 }
 
 func (t *WorkspaceTab) recordDisplayEvent(e event.Event) {
-	t.displayMu.Lock()
-	defer t.displayMu.Unlock()
-	messages := &t.executorDisplay
-	tools := &t.executorDisplayTools
+	state := t.displayBufferState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	messages := &state.executorMessages
+	tools := &state.executorTools
 	if strings.TrimSpace(e.Source) == event.UsageSourcePlanner {
-		messages = &t.plannerDisplay
-		tools = &t.plannerDisplayTools
+		messages = &state.plannerMessages
+		tools = &state.plannerTools
 	}
 	recordHistoryDisplayEvent(messages, tools, e)
+}
+
+func (t *WorkspaceTab) displayBufferState() *tabDisplayState {
+	t.displayStateMu.Lock()
+	defer t.displayStateMu.Unlock()
+	if t.displayState == nil {
+		t.displayState = &tabDisplayState{}
+	}
+	return t.displayState
+}
+
+func (t *WorkspaceTab) adoptDisplayState(state *tabDisplayState) {
+	if t == nil || state == nil {
+		return
+	}
+	t.displayStateMu.Lock()
+	t.displayState = state
+	t.displayStateMu.Unlock()
 }
 
 func recordHistoryDisplayEvent(messages *[]HistoryMessage, tools *map[string]string, e event.Event) {
@@ -914,11 +947,12 @@ func plannerToolResultDisplay(content string, failed bool) (display, errPreview 
 }
 
 func (t *WorkspaceTab) takeDisplayTurn(cancelled bool) []HistoryMessage {
-	t.displayMu.Lock()
-	defer t.displayMu.Unlock()
-	out := cloneHistoryMessages(t.plannerDisplay)
+	state := t.displayBufferState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	out := cloneHistoryMessages(state.plannerMessages)
 	if cancelled {
-		out = append(out, cloneHistoryMessages(t.executorDisplay)...)
+		out = append(out, cloneHistoryMessages(state.executorMessages)...)
 		if len(out) > 0 {
 			out = append(out, HistoryMessage{
 				Role:    "notice",
@@ -928,10 +962,10 @@ func (t *WorkspaceTab) takeDisplayTurn(cancelled bool) []HistoryMessage {
 			})
 		}
 	}
-	t.plannerDisplay = nil
-	t.plannerDisplayTools = nil
-	t.executorDisplay = nil
-	t.executorDisplayTools = nil
+	state.plannerMessages = nil
+	state.plannerTools = nil
+	state.executorMessages = nil
+	state.executorTools = nil
 	return out
 }
 

--- a/desktop/tabs_display_buffer_test.go
+++ b/desktop/tabs_display_buffer_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func TestDisplayTurnBufferPreservesStreamingReplacementAndTools(t *testing.T) {
+	var buffer displayTurnBuffer
+	recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.Reasoning, Text: "draft reason "})
+	recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.Reasoning, Text: "continued"})
+	recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.Text, Text: "draft answer"})
+	recordHistoryDisplayEvent(&buffer, event.Event{
+		Kind:      event.Message,
+		Text:      "final answer",
+		Reasoning: "final reason",
+		MemoryCitations: []provider.MemoryCitation{{
+			ID: "memory-1", Source: "project",
+		}},
+	})
+	recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: "call-1", Name: "read_file", Args: `{"path":"settings.json"}`,
+	}})
+	recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.ToolResult, Tool: event.Tool{
+		ID: "call-1", Output: "settings contents",
+	}})
+
+	got := buffer.materialize()
+	if len(got) != 3 {
+		t.Fatalf("messages = %d, want 3: %+v", len(got), got)
+	}
+	if got[0].Role != "assistant" || got[0].Content != "final answer" || got[0].Reasoning != "final reason" {
+		t.Fatalf("stream replacement changed: %+v", got[0])
+	}
+	if len(got[0].MemoryCitations) != 1 || got[0].MemoryCitations[0].ID != "memory-1" {
+		t.Fatalf("memory citations changed: %+v", got[0].MemoryCitations)
+	}
+	if got[1].Role != "assistant" || len(got[1].ToolCalls) != 1 || got[1].ToolCalls[0].ID != "call-1" || got[1].ToolCalls[0].Summary == "" {
+		t.Fatalf("tool call changed: %+v", got[1])
+	}
+	if got[2].Role != "tool" || got[2].ToolCallID != "call-1" || got[2].ToolName != "read_file" {
+		t.Fatalf("tool result changed: %+v", got[2])
+	}
+}
+
+func TestDisplayTurnBufferStreamingAllocationsStayNearLinear(t *testing.T) {
+	const (
+		chunks    = 2_000
+		chunkSize = 32
+	)
+	chunk := strings.Repeat("x", chunkSize)
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var buffer displayTurnBuffer
+			for part := 0; part < chunks; part++ {
+				recordHistoryDisplayEvent(&buffer, event.Event{Kind: event.Text, Text: chunk})
+			}
+			messages := buffer.materialize()
+			if len(messages) != 1 || len(messages[0].Content) != chunks*chunkSize {
+				b.Fatalf("materialized display length changed")
+			}
+		}
+	})
+
+	// Repeated string concatenation allocated roughly one full growing prefix
+	// per chunk (>69 MiB for this 64 KiB stream). Keep a generous ceiling for
+	// platform/runtime variance while pinning the intended near-linear shape.
+	if got, max := result.AllocedBytesPerOp(), int64(chunks*chunkSize*16); got > max {
+		t.Fatalf("stream allocated %d bytes/op, want <= %d (%s)", got, max, result.String())
+	}
+	if got := result.AllocsPerOp(); got > 100 {
+		t.Fatalf("stream allocated %d objects/op, want <= 100 (%s)", got, result.String())
+	}
+	t.Logf("64 KiB stream: %d bytes/op, %d allocs/op", result.AllocedBytesPerOp(), result.AllocsPerOp())
+}
+
+func TestPendingDisplayWriteRetriesWithoutDroppingTurn(t *testing.T) {
+	state := &tabDisplayState{}
+	var attempts atomic.Int32
+	persisted := make(chan struct{})
+	write := &pendingDisplayWrite{
+		dir:         "sessions",
+		sessionPath: "sessions/session.jsonl",
+		userContent: "prompt",
+		messages:    []HistoryMessage{{Role: "assistant", Content: "partial answer"}},
+		persist: func(_, _, _ string, messages []HistoryMessage) error {
+			attempt := attempts.Add(1)
+			if len(messages) != 1 || messages[0].Content != "partial answer" {
+				return errors.New("queued turn changed")
+			}
+			if attempt < 3 {
+				return errors.New("temporary lock contention")
+			}
+			close(persisted)
+			return nil
+		},
+	}
+	persistOrEnqueueDisplayWrite(state, write)
+	select {
+	case <-persisted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pending display write was not retried")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		state.mu.Lock()
+		pending := len(state.pendingWrites)
+		running := state.persistRunning
+		state.mu.Unlock()
+		if pending == 0 && !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("retry worker did not drain: pending=%d running=%v", pending, running)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("persist attempts = %d, want 3", got)
+	}
+}

--- a/desktop/tabs_planner_notice_test.go
+++ b/desktop/tabs_planner_notice_test.go
@@ -11,7 +11,7 @@ import (
 // a reload even though the live transcript showed them.
 func TestRecordPlannerDisplayEventKeepsNoticeDetail(t *testing.T) {
 	tab := &WorkspaceTab{}
-	tab.recordPlannerDisplayEvent(event.Event{
+	tab.recordDisplayEvent(event.Event{
 		Kind:   event.Notice,
 		Level:  event.LevelWarn,
 		Source: event.UsageSourcePlanner,

--- a/desktop/tabs_planner_notice_test.go
+++ b/desktop/tabs_planner_notice_test.go
@@ -18,10 +18,11 @@ func TestRecordPlannerDisplayEventKeepsNoticeDetail(t *testing.T) {
 		Text:   "An MCP server failed to start.",
 		Detail: `mcp server "github" failed to start: command not found`,
 	})
-	if len(tab.plannerDisplay) != 1 {
-		t.Fatalf("plannerDisplay len = %d, want 1", len(tab.plannerDisplay))
+	messages := tab.takeDisplayTurn(false)
+	if len(messages) != 1 {
+		t.Fatalf("planner display len = %d, want 1", len(messages))
 	}
-	got := tab.plannerDisplay[0]
+	got := messages[0]
 	if got.Role != "notice" || got.Level != "warn" {
 		t.Fatalf("unexpected notice message: %+v", got)
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -745,6 +745,7 @@ func (c *Controller) spawnGuardedTurn(ctx context.Context, cancel context.Cancel
 // finishing directly into running.
 func (c *Controller) finishGuardedTurn(err error) {
 	c.mu.Lock()
+	cancelRequested := c.canceling
 	c.running = false
 	c.finishing = true
 	c.cancel = nil
@@ -770,7 +771,7 @@ func (c *Controller) finishGuardedTurn(err error) {
 		c.mu.Unlock()
 		c.spawnGuardedTurn(ctx, cancel, next)
 	}()
-	done := event.Event{Kind: event.TurnDone, Err: err, Outcome: turnOutcome(err)}
+	done := event.Event{Kind: event.TurnDone, Err: err, Cancelled: cancelRequested, Outcome: turnOutcome(err)}
 	var readinessErr *agent.FinalReadinessError
 	if errors.As(err, &readinessErr) {
 		done.Readiness = &event.FinalReadiness{Attempts: readinessErr.Attempts, Missing: append([]string(nil), readinessErr.Missing...)}
@@ -3786,6 +3787,7 @@ func (c *Controller) stripCancelledVisibleTurnMessagesAfter(idx int) {
 		if _, ok := agent.SteerText(m.Content); ok {
 			continue
 		}
+		m.Content = StripComposePrefixes(m.Content)
 		next = append(next, m)
 		break
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3769,14 +3769,26 @@ func (c *Controller) stripTurnMessagesAfter(idx int) {
 // stripCancelledVisibleTurnMessagesAfter removes assistant/tool remnants from a
 // cancelled visible turn while preserving the real user prompt that started it.
 func (c *Controller) stripCancelledVisibleTurnMessagesAfter(idx int) {
+	c.stripCancelledVisibleTurnMessagesAfterWithFallback(idx, provider.Message{})
+}
+
+// stripCancelledVisibleTurnMessagesAfterWithFallback also covers coordinator
+// cancellation before the executor has appended the visible user message. The
+// orchestrator owns that input, so it supplies the exact message rather than
+// letting cancellation infer the current turn from older transcript history.
+func (c *Controller) stripCancelledVisibleTurnMessagesAfterWithFallback(idx int, fallback provider.Message) {
 	if c.executor == nil {
 		return
 	}
 	msgs := c.executor.Session().Snapshot()
-	if len(msgs) <= idx {
-		return
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(msgs) {
+		idx = len(msgs)
 	}
 	next := append([]provider.Message{}, msgs[:idx]...)
+	keptUser := false
 	for _, m := range msgs[idx:] {
 		if m.Role != provider.RoleUser {
 			continue
@@ -3789,7 +3801,19 @@ func (c *Controller) stripCancelledVisibleTurnMessagesAfter(idx int) {
 		}
 		m.Content = StripComposePrefixes(m.Content)
 		next = append(next, m)
+		keptUser = true
 		break
+	}
+	if !keptUser && fallback.Role == provider.RoleUser {
+		fallback.Content = StripComposePrefixes(fallback.Content)
+		if strings.TrimSpace(fallback.Content) != "" {
+			fallback.Images = append([]string(nil), fallback.Images...)
+			next = append(next, fallback)
+			keptUser = true
+		}
+	}
+	if !keptUser && len(msgs) <= idx {
+		return
 	}
 	c.replaceSessionAfterCancel(next)
 }

--- a/internal/control/runtime_status_test.go
+++ b/internal/control/runtime_status_test.go
@@ -57,7 +57,9 @@ func TestCancelClearsPendingApprovalRuntimeStatus(t *testing.T) {
 	c.Cancel()
 	c.Cancel()
 	assertCancelClearedPendingRuntimeStatus(t, c.RuntimeStatus())
-	waitTurnDoneEvent(t, done)
+	if e := waitTurnDoneEvent(t, done); !e.Cancelled {
+		t.Fatal("cancelled turn_done event was not marked as user-cancelled")
+	}
 	// TurnDone is emitted inside the finishing window; Running() (and the
 	// RuntimeStatus it feeds) stays true until finishGuardedTurn's deferred
 	// clear runs. Wait for the gate to reopen before asserting idle.
@@ -119,14 +121,16 @@ func assertCancelClearedPendingRuntimeStatus(t *testing.T, st RuntimeStatus) {
 	}
 }
 
-func waitTurnDoneEvent(t *testing.T, done <-chan event.Event) {
+func waitTurnDoneEvent(t *testing.T, done <-chan event.Event) event.Event {
 	t.Helper()
 	select {
 	case e := <-done:
 		if e.Kind != event.TurnDone {
 			t.Fatalf("event = %v, want TurnDone", e.Kind)
 		}
+		return e
 	case <-time.After(30 * time.Second):
 		t.Fatal("timed out waiting for turn_done")
 	}
+	return event.Event{}
 }

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -160,7 +160,8 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	parentSession := c.parentSessionID()
 	ctx = agent.WithParentSession(ctx, parentSession)
 	ctx = jobs.WithSession(ctx, parentSession)
-	ctx = agent.WithUserImages(ctx, c.inputImages(turn.input))
+	userImages := c.inputImages(turn.input)
+	ctx = agent.WithUserImages(ctx, userImages)
 	input := c.compose(turn.input, turn.raw, !turn.synthetic)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -222,7 +223,12 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 			if turn.synthetic || IsSyntheticUserMessage(turn.raw) {
 				c.stripTurnMessagesAfter(startMessages)
 			} else {
-				c.stripCancelledVisibleTurnMessagesAfter(startMessages)
+				c.stripCancelledVisibleTurnMessagesAfterWithFallback(startMessages, provider.Message{
+					Role:      provider.RoleUser,
+					Content:   input,
+					Images:    append([]string(nil), userImages...),
+					CreatedAt: time.Now().UnixMilli(),
+				})
 			}
 		}
 		c.clearInFlightTurn()

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -453,6 +453,7 @@ func TestTurnOrchestratorCancelPreservesVisibleUserPrompt(t *testing.T) {
 
 	ex := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
 	c := New(Options{Runner: runner, Executor: ex})
+	c.SetPlanMode(true)
 	// Simulate a user-initiated cancel: set the cancelling flag.
 	c.mu.Lock()
 	c.canceling = true
@@ -477,7 +478,7 @@ func TestTurnOrchestratorCancelPreservesVisibleUserPrompt(t *testing.T) {
 	}
 	last := msgs[len(msgs)-1]
 	if last.Role != provider.RoleUser || last.Content != "add config file abc" {
-		t.Fatalf("last message after cancel = %+v, want preserved visible user prompt", last)
+		t.Fatalf("last message after cancel = %+v, want preserved user prompt without compose prefixes", last)
 	}
 	for _, m := range msgs[preCount+1:] {
 		if m.Role == provider.RoleAssistant || m.Role == provider.RoleTool {
@@ -527,6 +528,7 @@ func TestTurnOrchestratorCancelFlushesCleanTranscriptToDisk(t *testing.T) {
 		Executor:    agent.New(nil, nil, sess, agent.Options{}, event.Discard),
 		SessionPath: sessionPath,
 	})
+	c.SetPlanMode(true)
 	c.mu.Lock()
 	c.canceling = true
 	c.mu.Unlock()

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -493,6 +493,39 @@ func TestTurnOrchestratorCancelPreservesVisibleUserPrompt(t *testing.T) {
 	}
 }
 
+func TestTurnOrchestratorCancelBeforeRunnerAddsUserPreservesVisiblePrompt(t *testing.T) {
+	workspace := t.TempDir()
+	writeVisionTestConfig(t, workspace)
+	imagePath := filepath.Join(workspace, "diagram.png")
+	if err := os.WriteFile(imagePath, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sess := agent.NewSession("system")
+	ex := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{
+		Runner:        cancelBeforeUserRunner{},
+		Executor:      ex,
+		WorkspaceRoot: workspace,
+		ModelRef:      "custom/vision-pro",
+	})
+	c.SetPlanMode(true)
+	c.mu.Lock()
+	c.canceling = true
+	c.mu.Unlock()
+
+	err := newTurnOrchestrator(c).runTurnWithRawDisplay(context.Background(), "inspect @diagram.png", "inspect @diagram.png", "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	msgs := sess.Snapshot()
+	if len(msgs) != 2 || msgs[1].Role != provider.RoleUser || msgs[1].Content != "inspect @diagram.png" {
+		t.Fatalf("session after pre-executor cancel = %+v, want system + prefix-free visible user", msgs)
+	}
+	if len(msgs[1].Images) != 1 || !strings.HasPrefix(msgs[1].Images[0], "data:image/png;base64,") {
+		t.Fatalf("session after pre-executor cancel lost user image: %+v", msgs[1].Images)
+	}
+}
+
 // TestTurnOrchestratorCancelFlushesCleanTranscriptToDisk verifies that after a
 // user-cancel strip the cleaned transcript is written to disk, so a restart or
 // session resume does not reload the partial turn from a stale mid-turn
@@ -661,6 +694,12 @@ type cancelStrippingRunner struct {
 	session *agent.Session
 	add     []provider.Message
 	err     error
+}
+
+type cancelBeforeUserRunner struct{}
+
+func (cancelBeforeUserRunner) Run(context.Context, string) error {
+	return context.Canceled
 }
 
 func (r *cancelStrippingRunner) Run(ctx context.Context, input string) error {

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -292,6 +292,7 @@ const (
 	NoticeCodeToolBudget      = "tool_budget"
 	NoticeCodeLoopGuard       = "loop_guard"
 	NoticeCodeWorkspaceLease  = "workspace_lease"
+	NoticeCodeCancelledTurn   = "cancelled_turn_display"
 )
 
 type Event struct {
@@ -317,6 +318,7 @@ type Event struct {
 	Approval     Approval        // ApprovalRequest
 	Ask          Ask             // AskRequest
 	Err          error           // TurnDone: non-nil on failure
+	Cancelled    bool            // TurnDone: Cancel was requested while the turn was active
 	Outcome      string          // TurnDone: optional machine-readable recoverable outcome
 	Readiness    *FinalReadiness // TurnDone: structured final-readiness recovery state
 	Compaction   Compaction      // Compaction

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,102 @@
+// Package filelock provides bounded, cross-process advisory file locks.
+package filelock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const retryInterval = 20 * time.Millisecond
+
+// ErrHeld reports that another file descriptor currently owns the lock.
+// Callers normally see their context error after Acquire's bounded retry loop.
+var ErrHeld = errors.New("file lock held")
+
+type localLock struct {
+	token chan struct{}
+}
+
+var localRegistry = struct {
+	sync.Mutex
+	locks map[string]*localLock
+}{locks: map[string]*localLock{}}
+
+// Acquire obtains an exclusive lock on path until the returned release
+// function is called. It serializes both goroutines in this process and other
+// Reasonix processes, and never waits past ctx's deadline.
+func Acquire(ctx context.Context, path string) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	key, err := canonicalLockPath(path)
+	if err != nil {
+		return nil, err
+	}
+	localRegistry.Lock()
+	local := localRegistry.locks[key]
+	if local == nil {
+		local = &localLock{token: make(chan struct{}, 1)}
+		local.token <- struct{}{}
+		localRegistry.locks[key] = local
+	}
+	localRegistry.Unlock()
+
+	select {
+	case <-local.token:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
+	}
+	releaseLocal := func() { local.token <- struct{}{} }
+
+	for {
+		releaseFile, err := tryLockFile(key)
+		if err == nil {
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					releaseFile()
+					releaseLocal()
+				})
+			}, nil
+		}
+		if !errors.Is(err, ErrHeld) {
+			releaseLocal()
+			return nil, fmt.Errorf("acquire file lock: %w", err)
+		}
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			releaseLocal()
+			return nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
+		}
+	}
+}
+
+func canonicalLockPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("file lock path is empty")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve file lock path: %w", err)
+	}
+	abs = filepath.Clean(abs)
+	if runtime.GOOS == "windows" {
+		abs = strings.ToLower(filepath.ToSlash(abs))
+	}
+	return abs, nil
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,30 @@
+package filelock
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquireHonorsDeadlineAndRecoversAfterRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.lock")
+	release, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := Acquire(ctx, path); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contended acquire error = %v, want deadline exceeded", err)
+	}
+
+	release()
+	secondRelease, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	secondRelease()
+}

--- a/internal/filelock/lock_unix.go
+++ b/internal/filelock/lock_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package filelock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockFile(path string) (func(), error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, ErrHeld
+		}
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/filelock/lock_windows.go
+++ b/internal/filelock/lock_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package filelock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockFile(path string) (func(), error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, ErrHeld
+		}
+		return nil, err
+	}
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
+		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, ErrHeld
+		}
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+		_ = f.Close()
+	}, nil
+}


### PR DESCRIPTION
## Summary

Preserve the visible output of a user-cancelled Desktop turn across planner cancellation, tab switches, reloads, and runtime detach/reattach without treating incomplete assistant, reasoning, or tool output as trusted model context.

The canonical session transcript retains the user's original message (including image attachments) and removes the incomplete assistant/tool tail. Already-rendered output is persisted separately in the existing display-only planner sidecar, together with a localized notice that explains the context boundary and asks the user to inspect the workspace before continuing or reverting.

Fixes #6260
Fixes #6297
Fixes #6644

Refs #6278
Refs #6270

## Problem and root cause

Desktop kept streaming cards only in frontend memory. After cancellation, the controller correctly removed incomplete assistant/tool messages from the provider transcript to prevent malformed tool sequences and repeated execution, but there was no durable display buffer for the output the user had already seen. Switching sessions or reloading therefore made the cancelled turn appear to disappear.

The full lifecycle had several gaps:

- cancellation during planning could happen before the executor appended the current user message;
- display buffers belonged to a transient `WorkspaceTab`, so runtime detach/reattach could split one turn across discarded wrappers;
- the shared planner display sidecar handled writes but did not remove entries on every permanent deletion path;
- executor text was appended with growing-string concatenation, causing quadratic allocation amplification for every streamed turn;
- sidecar load-modify-save serialization used only an in-process mutex, so two Reasonix processes could each publish a stale map and drop the other process's entry.

The cancellation flag was also cleared during the current turn-finalization path before Desktop could distinguish a user cancellation from other completion outcomes.

## Changes

- Add an internal cancellation marker to `TurnDone` and capture it before finalization clears the cancellation state.
- Preserve an explicit, prefix-free current user fallback (including image attachments) when planning is cancelled before the executor starts.
- Buffer planner and executor display messages in runtime-owned shared state and transfer it before sink rebinding during detach/reattach.
- Accumulate streamed display text as chunks and materialize it once; successful executor turns discard their chunks without joining them.
- Persist cancelled executor output in the existing display-only sidecar while keeping incomplete assistant/reasoning/tool output out of the canonical provider transcript.
- Guard the full planner-display load-modify-save/remove transaction with a fixed, bounded cross-process advisory lock on Unix and Windows.
- Keep failed display-only writes in an ordered in-memory queue and retry them asynchronously instead of dropping the turn after a transient lock or filesystem failure.
- Reject corrupt planner-display maps during normal recording and retire an unreadable map during destructive cleanup so deleted display data does not linger.
- Remove planner display entries during live-session cleanup and trash purge; prune only orphaned entries while retaining data for restorable trashed sessions.
- Add a stable `cancelled_turn_display` notice code with English, Simplified Chinese, and Traditional Chinese translations.
- Cover planner-stage cancellation, image preservation, reload, runtime detach/reattach, permanent deletion, trash retention, orphan pruning, allocation growth, retry behavior, corrupt data, in-process concurrency, cross-process concurrency, runtime status, and frontend localization with regression tests.

## Consolidation notes

### Kept and adapted

- #6278 by @GTC2080 established the safer architecture: separate display-only cancelled history from the canonical model transcript. This PR adapts that mechanism to the current `main-v2` finalization path, adds stable notice localization, cross-process-safe persistence, and expanded end-to-end and race coverage. The adopted contribution is credited with a commit-level `Co-authored-by` trailer.

### Reviewed but not adopted

- #6270 by @SauronSkywalker explored preserving partial assistant/tool state directly in the continuation transcript. That path was not adopted because incomplete or unpaired tool state can produce invalid provider sequences or cause interrupted work to be repeated. Its reproduction, investigation, and alternative design informed this integration, so @SauronSkywalker is also credited as a repository contributor with a commit-level `Co-authored-by` trailer.

## Backward compatibility

| Field or artifact | Old-data behavior | Conclusion |
| --- | --- | --- |
| Session JSONL / canonical transcript | Format is unchanged; existing sessions load exactly as before | Backward-safe |
| `.planner-display.json` sidecar | Path and JSON schema are unchanged; old files remain readable and new writes remain readable by older Desktop versions | Backward-safe |
| `.planner-display.json.lock` | New empty advisory lock file is ignored by older versions and contains no user content | Backward-safe |
| Notice `code` | Older readers ignore the unknown optional field and can still display the persisted content | Backward-safe |
| Internal `Event.Cancelled` boolean | Existing event producers deserialize or construct the zero value (`false`) | Backward-safe |
| Cross-version Desktop use | No provider request or canonical transcript shape changes; old versions can read the same session and display files | Backward-safe |

## Cache impact

No provider-visible system prompt, tool schema, tool ordering, or request serialization changes were made. The canonical cancelled-turn transcript remains clean. Only transient compose prefixes are removed from the preserved cancelled user message, which avoids carrying stale mode instructions into later turns. `./scripts/cache-guard.sh` passes all scenarios.

## Security and privacy

- No dependency, network, credential, permission, or privilege changes.
- The display sidecar keeps its existing local history format and sensitivity boundary; temporary writes and the new lock file use restrictive permissions.
- Cross-process lock acquisition is deadline-bounded, and no `App` or controller callback lock is held while waiting.
- Planner display entries are removed when a session is permanently deleted or purged, and orphaned entries are pruned during session listing.
- Partial cancelled output is explicitly marked as display-only and is not silently promoted into trusted model context.

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...` in both Go modules
- Focused `internal/control`, file-lock, and Desktop cancellation, planner, reload, detach/reattach, deletion, pruning, corruption, and retry tests
- Focused `-race` tests for controller cancellation, runtime handoff, display buffering, sidecar persistence, and file locking
- Deterministic subprocess regression that forces two independent Reasonix processes through the former stale read-modify-write window
- Allocation regression: a 64 KiB stream split into 2,000 chunks uses 166,968 bytes and 17 allocations per operation (previous repeated concatenation reproduced about 69 MiB)
- Windows/amd64 cross-compilation for the file-lock package and Desktop test binary
- `pnpm typecheck`
- `pnpm exec tsx src/__tests__/use-controller-meta.test.ts` (124 passed)
- `./scripts/cache-guard.sh`
- `git diff --check`
