### PR TITLE
Bound session save lock waits / 限制会话保存锁等待时间

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -792,19 +792,22 @@ func (a *App) shutdown(context.Context) {
 	a.mu.RLock()
 	tabs := a.runtimeTabsLocked()
 	type shutdownItem struct {
-		tab  *WorkspaceTab
-		ctrl control.SessionAPI
+		tab      *WorkspaceTab
+		ctrl     control.SessionAPI
+		readOnly bool
 	}
 	items := make([]shutdownItem, 0, len(tabs))
 	for _, t := range tabs {
 		if t.Ctrl != nil {
-			items = append(items, shutdownItem{tab: t, ctrl: t.Ctrl})
+			items = append(items, shutdownItem{tab: t, ctrl: t.Ctrl, readOnly: t.ReadOnly})
 		}
 	}
 	a.mu.RUnlock()
 	for _, it := range items {
-		if err := a.snapshotTab(it.tab); err != nil {
-			slog.Warn("desktop: shutdown snapshot failed", "tab", it.tab.ID, "err", err)
+		if !it.readOnly {
+			if err := it.ctrl.SnapshotForShutdown(); err != nil {
+				slog.Warn("desktop: shutdown snapshot failed", "tab", it.tab.ID, "err", err)
+			}
 		}
 		it.ctrl.Close()
 		it.tab.releaseSessionLease()

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -247,6 +247,13 @@ func TestDesktopSnapshotConflictRecoveryUpdatesTabAndProjectTree(t *testing.T) {
 	if tab.SessionPath != recoveryPath {
 		t.Fatalf("tab session path = %q, want recovery path %q", tab.SessionPath, recoveryPath)
 	}
+	saved := loadTabsFile()
+	if len(saved.Tabs) != 1 || saved.Tabs[0].ID != tab.ID {
+		t.Fatalf("saved tabs = %+v, want recovered tab %q", saved.Tabs, tab.ID)
+	}
+	if got := saved.Tabs[0].SessionPath; got != recoveryPath {
+		t.Fatalf("saved tab session path = %q, want recovery path %q", got, recoveryPath)
+	}
 	if tab.TopicID != originalTopic {
 		t.Fatalf("tab topic ID = %q, want original topic %q", tab.TopicID, originalTopic)
 	}
@@ -357,6 +364,9 @@ func TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease(t *testing.T) {
 		OnSessionRecovered:  app.handleTabSessionRecovered(tab),
 	})
 	app.tabs[tab.ID] = tab
+	app.mu.Lock()
+	app.saveTabsLocked()
+	app.mu.Unlock()
 
 	err = tab.Ctrl.Snapshot()
 	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
@@ -370,6 +380,10 @@ func TestDesktopSnapshotConflictRecoveryRequiresRecoveryLease(t *testing.T) {
 	}
 	if tab.TopicID != "topic_original" {
 		t.Fatalf("tab topic ID = %q, want original topic", tab.TopicID)
+	}
+	saved := loadTabsFile()
+	if len(saved.Tabs) != 1 || saved.Tabs[0].SessionPath != originalPath {
+		t.Fatalf("saved tabs after failed recovery = %+v, want original path %q", saved.Tabs, originalPath)
 	}
 
 	deadline := time.After(time.Second)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3531,11 +3531,11 @@ func TestSetModelForTabReattachesDetachedRuntime(t *testing.T) {
 		Ctrl:           oldCtrl,
 		Ready:          true,
 		model:          "old/old-model",
-		sessionLease:   lease,
 		disabledMCP:    map[string]ServerView{},
 		SharedHostKey:  "detached-host",
 		ActivityStatus: "",
 	}
+	detached.adoptSessionLease(lease)
 	tab := &WorkspaceTab{
 		ID:          "tab_a",
 		Scope:       "global",

--- a/desktop/startup_health_test.go
+++ b/desktop/startup_health_test.go
@@ -5,8 +5,32 @@ import (
 	"path/filepath"
 	"testing"
 
+	"reasonix/internal/control"
 	"reasonix/internal/repair"
 )
+
+type shutdownSnapshotController struct {
+	control.SessionAPI
+	calls           []string
+	normalSnapshots int
+}
+
+func (c *shutdownSnapshotController) Snapshot() error {
+	c.normalSnapshots++
+	return nil
+}
+
+func (c *shutdownSnapshotController) SnapshotForShutdown() error {
+	c.calls = append(c.calls, "shutdown-snapshot")
+	return nil
+}
+
+func (c *shutdownSnapshotController) Close() {
+	c.calls = append(c.calls, "close")
+	if c.SessionAPI != nil {
+		c.SessionAPI.Close()
+	}
+}
 
 // TestShutdownDoesNotBlessStartupBeforeReady pins the recovery contract that a
 // clean exit before the window ever reached domReady keeps the incomplete
@@ -40,5 +64,22 @@ func TestShutdownDoesNotBlessStartupBeforeReady(t *testing.T) {
 	}
 	if state.Phase != "clean-exit" {
 		t.Fatalf("post-ready shutdown must mark clean-exit, got %q", state.Phase)
+	}
+}
+
+func TestShutdownUsesDurableSnapshotBeforeClosingController(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	ctrl := &shutdownSnapshotController{SessionAPI: control.New(control.Options{Label: "shutdown"})}
+	a := NewApp()
+	a.tabs["tab"] = &WorkspaceTab{ID: "tab", Ctrl: ctrl}
+	a.tabOrder = []string{"tab"}
+
+	a.shutdown(context.Background())
+
+	if ctrl.normalSnapshots != 0 {
+		t.Fatalf("ordinary Snapshot calls = %d, want shutdown-specific persistence", ctrl.normalSnapshots)
+	}
+	if len(ctrl.calls) != 2 || ctrl.calls[0] != "shutdown-snapshot" || ctrl.calls[1] != "close" {
+		t.Fatalf("shutdown call order = %v, want [shutdown-snapshot close]", ctrl.calls)
 	}
 }

--- a/desktop/startup_health_test.go
+++ b/desktop/startup_health_test.go
@@ -13,6 +13,8 @@ type shutdownSnapshotController struct {
 	control.SessionAPI
 	calls           []string
 	normalSnapshots int
+	sessionPath     string
+	shutdown        func() error
 }
 
 func (c *shutdownSnapshotController) Snapshot() error {
@@ -22,7 +24,20 @@ func (c *shutdownSnapshotController) Snapshot() error {
 
 func (c *shutdownSnapshotController) SnapshotForShutdown() error {
 	c.calls = append(c.calls, "shutdown-snapshot")
+	if c.shutdown != nil {
+		return c.shutdown()
+	}
 	return nil
+}
+
+func (c *shutdownSnapshotController) SessionPath() string {
+	if c.sessionPath != "" {
+		return c.sessionPath
+	}
+	if c.SessionAPI != nil {
+		return c.SessionAPI.SessionPath()
+	}
+	return ""
 }
 
 func (c *shutdownSnapshotController) Close() {
@@ -78,6 +93,53 @@ func TestShutdownUsesDurableSnapshotBeforeClosingController(t *testing.T) {
 
 	if ctrl.normalSnapshots != 0 {
 		t.Fatalf("ordinary Snapshot calls = %d, want shutdown-specific persistence", ctrl.normalSnapshots)
+	}
+	if len(ctrl.calls) != 2 || ctrl.calls[0] != "shutdown-snapshot" || ctrl.calls[1] != "close" {
+		t.Fatalf("shutdown call order = %v, want [shutdown-snapshot close]", ctrl.calls)
+	}
+}
+
+func TestShutdownPersistsRecoveryPathCommittedAfterCallback(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "original.jsonl")
+	recoveryPath := filepath.Join(dir, "original-recovery.jsonl")
+	a := NewApp()
+	ctrl := &shutdownSnapshotController{
+		SessionAPI:  control.New(control.Options{Label: "shutdown", SessionPath: originalPath}),
+		sessionPath: originalPath,
+	}
+	tab := &WorkspaceTab{ID: "tab", Ctrl: ctrl, SessionPath: originalPath}
+	a.tabs[tab.ID] = tab
+	a.tabOrder = []string{tab.ID}
+	a.activeTabID = tab.ID
+	ctrl.shutdown = func() error {
+		err := a.handleTabSessionRecovered(tab)(control.SessionRecoveryInfo{
+			OriginalPath: originalPath,
+			RecoveryPath: recoveryPath,
+		})
+		if err == nil {
+			// Force a newer ordinary layout write while Controller still exposes
+			// the old path. The recovery lease must keep this write anchored to
+			// recovery instead of undoing the callback's first save.
+			a.mu.Lock()
+			a.saveTabsLocked()
+			a.mu.Unlock()
+			// Controller.commitRecoveredSession updates its path only after the
+			// callback succeeds. Mirror that ordering exactly.
+			ctrl.sessionPath = recoveryPath
+		}
+		return err
+	}
+
+	a.shutdown(context.Background())
+
+	saved := loadTabsFile()
+	if len(saved.Tabs) != 1 || saved.Tabs[0].ID != tab.ID {
+		t.Fatalf("saved tabs = %+v, want recovered tab %q", saved.Tabs, tab.ID)
+	}
+	if got := saved.Tabs[0].SessionPath; got != recoveryPath {
+		t.Fatalf("saved shutdown session path = %q, want recovery path %q", got, recoveryPath)
 	}
 	if len(ctrl.calls) != 2 || ctrl.calls[0] != "shutdown-snapshot" || ctrl.calls[1] != "close" {
 		t.Fatalf("shutdown call order = %v, want [shutdown-snapshot close]", ctrl.calls)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -55,12 +55,13 @@ type WorkspaceTab struct {
 	StartupErrLeaseHeld bool               // true when StartupErr can be retried after a session lease releases
 	sessionLease        *agent.SessionLease
 	sessionLeaseMu      sync.Mutex
-	sink                *tabEventSink      // routes events with this tab's ID
-	buildCancel         context.CancelFunc // cancels in-flight boot for tabs removed before Ready
-	buildGeneration     uint64             // identifies the current in-flight build
-	removed             bool               // set when the visible tab is pruned/closed before build completes
-	reconcileMu         sync.Mutex         // serializes stale controller workspace repair for this tab
-	turnStartMu         sync.Mutex         // serializes foreground turn admission for this tab
+	sessionLeaseKey     atomic.Pointer[string] // lock-free mirror; updated with sessionLease under sessionLeaseMu
+	sink                *tabEventSink          // routes events with this tab's ID
+	buildCancel         context.CancelFunc     // cancels in-flight boot for tabs removed before Ready
+	buildGeneration     uint64                 // identifies the current in-flight build
+	removed             bool                   // set when the visible tab is pruned/closed before build completes
+	reconcileMu         sync.Mutex             // serializes stale controller workspace repair for this tab
+	turnStartMu         sync.Mutex             // serializes foreground turn admission for this tab
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
@@ -239,12 +240,22 @@ func (t *WorkspaceTab) currentSessionPath() string {
 	if t == nil {
 		return ""
 	}
+	tabPath := strings.TrimSpace(t.SessionPath)
+	// Recovery handoff is two-phase: the desktop callback acquires the new
+	// lease and updates SessionPath before Controller commits its own path. The
+	// lease-backed tab path is authoritative during that window; otherwise a
+	// concurrent, newer tab-layout save can overwrite the recovery anchor with
+	// the controller's old path. Outside a handoff, keep the controller-first
+	// behavior so an unleased/stale tab field cannot mask the live runtime.
+	if tabPath != "" && sessionRuntimeKey(tabPath) == t.sessionLeaseRuntimeKey() {
+		return tabPath
+	}
 	if t.Ctrl != nil {
 		if path := strings.TrimSpace(t.Ctrl.SessionPath()); path != "" {
 			return path
 		}
 	}
-	return strings.TrimSpace(t.SessionPath)
+	return tabPath
 }
 
 func (t *WorkspaceTab) hasActiveRuntimeWork() bool {
@@ -277,6 +288,7 @@ func (t *WorkspaceTab) ensureSessionLease(path string) error {
 	}
 	t.sessionLeaseMu.Lock()
 	if t.sessionLease != nil && sessionRuntimeKey(t.sessionLease.Path()) == key {
+		t.storeSessionLeaseRuntimeKey(key)
 		t.sessionLeaseMu.Unlock()
 		return nil
 	}
@@ -290,6 +302,7 @@ func (t *WorkspaceTab) ensureSessionLease(path string) error {
 	}
 	old := t.sessionLease
 	t.sessionLease = lease
+	t.storeSessionLeaseRuntimeKey(key)
 	t.sessionLeaseMu.Unlock()
 	if old != nil {
 		old.Release()
@@ -304,6 +317,7 @@ func (t *WorkspaceTab) releaseSessionLease() {
 	t.sessionLeaseMu.Lock()
 	lease := t.sessionLease
 	t.sessionLease = nil
+	t.storeSessionLeaseRuntimeKey("")
 	t.sessionLeaseMu.Unlock()
 	if lease != nil {
 		lease.Release()
@@ -321,6 +335,7 @@ func (t *WorkspaceTab) takeSessionLease() *agent.SessionLease {
 	t.sessionLeaseMu.Lock()
 	lease := t.sessionLease
 	t.sessionLease = nil
+	t.storeSessionLeaseRuntimeKey("")
 	t.sessionLeaseMu.Unlock()
 	return lease
 }
@@ -338,26 +353,41 @@ func (t *WorkspaceTab) adoptSessionLease(lease *agent.SessionLease) {
 	t.sessionLeaseMu.Lock()
 	old := t.sessionLease
 	t.sessionLease = lease
+	key := ""
+	if lease != nil {
+		key = sessionRuntimeKey(lease.Path())
+	}
+	t.storeSessionLeaseRuntimeKey(key)
 	t.sessionLeaseMu.Unlock()
 	if old != nil && old != lease {
 		old.Release()
 	}
 }
 
+func (t *WorkspaceTab) storeSessionLeaseRuntimeKey(key string) {
+	if t == nil || key == "" {
+		if t != nil {
+			t.sessionLeaseKey.Store(nil)
+		}
+		return
+	}
+	stored := key
+	t.sessionLeaseKey.Store(&stored)
+}
+
 // sessionLeaseRuntimeKey reports the runtime key of the currently held lease,
-// or "" when no lease is held. Safe to call while holding App.mu: the lock
-// order App.mu → sessionLeaseMu has no reverse path (the lease helpers never
-// touch App state while holding sessionLeaseMu).
+// or "" when no lease is held. The mirror is lock-free so callers holding
+// App.mu never wait on a concurrent lease acquisition (whose test hook and
+// platform file operations run under sessionLeaseMu).
 func (t *WorkspaceTab) sessionLeaseRuntimeKey() string {
 	if t == nil {
 		return ""
 	}
-	t.sessionLeaseMu.Lock()
-	defer t.sessionLeaseMu.Unlock()
-	if t.sessionLease == nil {
+	key := t.sessionLeaseKey.Load()
+	if key == nil {
 		return ""
 	}
-	return sessionRuntimeKey(t.sessionLease.Path())
+	return *key
 }
 
 // releaseSessionLeaseForKey releases the tab's lease only when it is bound to
@@ -377,6 +407,7 @@ func (t *WorkspaceTab) releaseSessionLeaseForKey(key string) {
 		return
 	}
 	t.sessionLease = nil
+	t.storeSessionLeaseRuntimeKey("")
 	t.sessionLeaseMu.Unlock()
 	lease.Release()
 }

--- a/internal/agent/recovery_gc_test.go
+++ b/internal/agent/recovery_gc_test.go
@@ -188,12 +188,12 @@ func TestRecoveryParentGuardBlocksRewindAfterValidation(t *testing.T) {
 	// concurrent rewind tries to take the parent's save lock before purge. The
 	// guard must keep that lock unavailable until the caller finishes deleting
 	// the redundant branch.
-	if lock, err := tryTakeSessionLockFile(store.SessionLockFile(parentPath)); !errors.Is(err, errSessionFileLockHeld) {
+	if lock, err := tryTakeSessionLockFile(store.SessionLockFile(parentPath)); !errors.Is(err, ErrSessionFileLockHeld) {
 		if lock != nil {
 			lock.Unlock()
 		}
 		guard.Release()
-		t.Fatalf("parent save lock after coverage validation = %v, want errSessionFileLockHeld", err)
+		t.Fatalf("parent save lock after coverage validation = %v, want ErrSessionFileLockHeld", err)
 	}
 	guard.Release()
 

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -54,12 +54,16 @@ var (
 	sessionFileLockPollInterval = 25 * time.Millisecond
 	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
 	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
+	// ErrSessionFileLockHeld reports that another process kept the
+	// compatibility save lock for the full bounded acquisition window. Callers
+	// that are about to terminate can use this sentinel to persist a recovery
+	// branch without waiting on the same stalled file again.
+	ErrSessionFileLockHeld = errors.New("session file lock held")
 	// ErrSessionRecoveryDepthExceeded refuses a recovery fork whose parent is
 	// already SessionRecoveryMaxDepth recovery forks deep. A chain that deep
 	// means saves keep conflicting on branches this runtime itself created;
 	// forking further multiplies session files without converging (#5993).
 	ErrSessionRecoveryDepthExceeded = errors.New("session recovery chain depth exceeded")
-	errSessionFileLockHeld          = errors.New("session file lock held")
 	sessionWriterID                 = newSessionWriterID()
 )
 
@@ -568,6 +572,24 @@ func snapshotConflict(path string, existing, next []provider.Message, baseRevisi
 }
 
 func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranchInfo, error) {
+	return s.saveRecoveryBranch(opts, false)
+}
+
+// SaveShutdownRecoveryBranch persists the current transcript to a distinct
+// recovery branch after the normal shutdown snapshot failed with
+// ErrSessionFileLockHeld. It deliberately does not re-lock or inspect the
+// original session file: doing so would repeat the same bounded timeout and
+// let process teardown discard the only remaining in-memory copy.
+//
+// The recovery filename includes this process writer ID, so a stalled writer
+// on the digest-deduplicated conflict path cannot block the emergency copy too.
+// The result still uses the normal session, event-log, and branch-meta formats
+// and is therefore discoverable and resumable through existing flows.
+func (s *Session) SaveShutdownRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranchInfo, error) {
+	return s.saveRecoveryBranch(opts, true)
+}
+
+func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) (RecoveryBranchInfo, error) {
 	originalPath := strings.TrimSpace(opts.OriginalPath)
 	if originalPath == "" {
 		return RecoveryBranchInfo{}, fmt.Errorf("empty original session path")
@@ -583,44 +605,46 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	}
 	digestText := digestString(digest)
 
-	unlockOriginal := lockSessionSavePath(originalPath)
-	unlockOriginalFile, lockErr := lockSessionFile(originalPath)
-	if lockErr != nil {
+	if !shutdown {
+		unlockOriginal := lockSessionSavePath(originalPath)
+		unlockOriginalFile, lockErr := lockSessionFile(originalPath)
+		if lockErr != nil {
+			unlockOriginal()
+			return RecoveryBranchInfo{}, fmt.Errorf("lock original session file: %w", lockErr)
+		}
+		current, loadErr := loadSessionUnlocked(originalPath)
+		unlockOriginalFile()
 		unlockOriginal()
-		return RecoveryBranchInfo{}, fmt.Errorf("lock original session file: %w", lockErr)
-	}
-	current, err := loadSessionUnlocked(originalPath)
-	unlockOriginalFile()
-	unlockOriginal()
-	if err != nil && !os.IsNotExist(err) {
-		return RecoveryBranchInfo{}, err
-	}
-	if err == nil && current != nil {
-		existing := current.Snapshot()
-		existingDigest, digestErr := digestSessionMessages(existing)
-		if digestErr != nil {
-			return RecoveryBranchInfo{}, digestErr
+		if loadErr != nil && !os.IsNotExist(loadErr) {
+			return RecoveryBranchInfo{}, loadErr
 		}
-		covered := bytes.Equal(existingDigest[:], digest[:]) ||
-			messagesHavePrefix(existing, msgs) ||
-			messagesHavePrefixWithCompatibleSystem(existing, msgs)
-		if !covered && current.normalizedDirty && len(current.rawMessages) > 0 {
-			// Judge coverage against the pre-repair transcript too, for the
-			// same reason as checkSnapshotWrite: load-time normalization can
-			// reshape what is actually stored, and a recovery fork is only
-			// warranted when the stored bytes themselves fail to cover this
-			// snapshot.
-			raw := current.rawMessages
-			rawDigest, rawErr := digestSessionMessages(raw)
-			if rawErr != nil {
-				return RecoveryBranchInfo{}, rawErr
+		if loadErr == nil && current != nil {
+			existing := current.Snapshot()
+			existingDigest, digestErr := digestSessionMessages(existing)
+			if digestErr != nil {
+				return RecoveryBranchInfo{}, digestErr
 			}
-			covered = bytes.Equal(rawDigest[:], digest[:]) ||
-				messagesHavePrefix(raw, msgs) ||
-				messagesHavePrefixWithCompatibleSystem(raw, msgs)
-		}
-		if covered {
-			return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded
+			covered := bytes.Equal(existingDigest[:], digest[:]) ||
+				messagesHavePrefix(existing, msgs) ||
+				messagesHavePrefixWithCompatibleSystem(existing, msgs)
+			if !covered && current.normalizedDirty && len(current.rawMessages) > 0 {
+				// Judge coverage against the pre-repair transcript too, for the
+				// same reason as checkSnapshotWrite: load-time normalization can
+				// reshape what is actually stored, and a recovery fork is only
+				// warranted when the stored bytes themselves fail to cover this
+				// snapshot.
+				raw := current.rawMessages
+				rawDigest, rawErr := digestSessionMessages(raw)
+				if rawErr != nil {
+					return RecoveryBranchInfo{}, rawErr
+				}
+				covered = bytes.Equal(rawDigest[:], digest[:]) ||
+					messagesHavePrefix(raw, msgs) ||
+					messagesHavePrefixWithCompatibleSystem(raw, msgs)
+			}
+			if covered {
+				return RecoveryBranchInfo{}, ErrSessionRecoveryNotNeeded
+			}
 		}
 	}
 
@@ -635,12 +659,23 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 			parentDepth = 1
 		}
 	}
-	if parentDepth >= SessionRecoveryMaxDepth {
+	if parentDepth >= SessionRecoveryMaxDepth && !shutdown {
 		return RecoveryBranchInfo{}, fmt.Errorf("%w: %s is already %d recovery forks deep",
 			ErrSessionRecoveryDepthExceeded, originalPath, parentDepth)
 	}
+	recoveryDepth := parentDepth + 1
+	if recoveryDepth > SessionRecoveryMaxDepth {
+		// A shutdown copy is allowed even when the ordinary conflict chain is
+		// capped because losing the only in-memory transcript is worse than one
+		// additional branch. Keep the saturated depth so later ordinary saves
+		// still enforce the existing anti-cascade policy.
+		recoveryDepth = SessionRecoveryMaxDepth
+	}
 
 	recoveryPath := recoverySessionPath(originalPath, digest)
+	if shutdown {
+		recoveryPath = shutdownRecoverySessionPath(originalPath, digest)
+	}
 	unlockRecovery := lockSessionSavePath(recoveryPath)
 	defer unlockRecovery()
 	unlockRecoveryFile, err := lockSessionFile(recoveryPath)
@@ -654,7 +689,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 			return RecoveryBranchInfo{}, digestErr
 		}
 		if bytes.Equal(existingDigest[:], digest[:]) {
-			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, parentDepth+1)
+			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, recoveryDepth)
 			if err != nil {
 				return RecoveryBranchInfo{}, err
 			}
@@ -683,7 +718,7 @@ func (s *Session) SaveRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranch
 	if err := writeSessionMessages(recoveryPath, msgs); err != nil {
 		return RecoveryBranchInfo{}, err
 	}
-	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, parentDepth+1)
+	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, recoveryDepth)
 	if err != nil {
 		return RecoveryBranchInfo{}, err
 	}
@@ -742,6 +777,13 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 func recoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
 	parent := recoveryParentStem(BranchID(originalPath))
 	return filepath.Join(filepath.Dir(originalPath), fmt.Sprintf("%s-recovery-%x.jsonl", parent, digest[:8]))
+}
+
+func shutdownRecoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
+	parent := recoveryParentStem(BranchID(originalPath))
+	writerDigest := sha256.Sum256([]byte(SessionWriterID()))
+	return filepath.Join(filepath.Dir(originalPath),
+		fmt.Sprintf("%s-recovery-%x-%x.jsonl", parent, digest[:8], writerDigest[:6]))
 }
 
 func recoveryParentStem(parent string) string {
@@ -1157,12 +1199,12 @@ func lockSessionFile(path string) (func(), error) {
 		if err == nil {
 			return unlock, nil
 		}
-		if !errors.Is(err, errSessionFileLockHeld) {
+		if !errors.Is(err, ErrSessionFileLockHeld) {
 			return nil, err
 		}
 		remaining := time.Until(deadline)
 		if wait <= 0 || remaining <= 0 {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		if poll > remaining {
 			poll = remaining
@@ -1503,7 +1545,7 @@ func removeStaleSessionLockSidecar(basePath, sidecarPath string) error {
 	}
 	lock, err := tryTakeSessionLockFile(sidecarPath)
 	if err != nil {
-		if errors.Is(err, errSessionFileLockHeld) {
+		if errors.Is(err, ErrSessionFileLockHeld) {
 			return nil
 		}
 		return err
@@ -1524,7 +1566,7 @@ func removeStaleSessionLeaseLockSidecar(basePath, sidecarPath string) error {
 	}
 	lock, err := tryTakeSessionLockFile(sidecarPath)
 	if err != nil {
-		if errors.Is(err, errSessionFileLockHeld) {
+		if errors.Is(err, ErrSessionFileLockHeld) {
 			return nil
 		}
 		return err
@@ -1668,7 +1710,7 @@ func renameOverlongSession(oldPath string) (string, error) {
 	if sessionLockSidecarFits(oldPath) {
 		lock, err := tryTakeSessionLockFile(oldPath + ".lock")
 		if err != nil {
-			if errors.Is(err, errSessionFileLockHeld) {
+			if errors.Is(err, ErrSessionFileLockHeld) {
 				return "", nil
 			}
 			return "", err

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -43,7 +43,15 @@ const (
 )
 
 var (
-	sessionSaveLocks            sync.Map
+	sessionSaveLocks sync.Map
+	// sessionFileLockWait bounds cross-process save-lock acquisition. Session
+	// leases normally prevent competing writers, but CLI/legacy writers and a
+	// stalled process can still hold the compatibility .lock file. Navigation
+	// and desktop shutdown snapshot synchronously; waiting forever here wedges
+	// the UI and keeps the session lease (and WebView) alive indefinitely.
+	// Package vars let focused tests shorten the wait without slowing the suite.
+	sessionFileLockWait         = 5 * time.Second
+	sessionFileLockPollInterval = 25 * time.Millisecond
 	ErrSessionSnapshotConflict  = errors.New("session snapshot conflicts with newer transcript")
 	ErrSessionRecoveryNotNeeded = errors.New("session recovery not needed")
 	// ErrSessionRecoveryDepthExceeded refuses a recovery fork whose parent is
@@ -1130,6 +1138,37 @@ func lockSessionSavePath(path string) func() {
 	mu := v.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock
+}
+
+// lockSessionFile waits briefly for the cross-process compatibility save lock.
+// A short overlap with a legitimate writer is allowed to settle, but an
+// stalled or indefinitely held lock fails the save instead of freezing tab
+// switching or application shutdown. The caller keeps its in-memory transcript
+// and can retry through the existing autosave/recovery paths.
+func lockSessionFile(path string) (func(), error) {
+	wait := sessionFileLockWait
+	poll := sessionFileLockPollInterval
+	if poll <= 0 {
+		poll = time.Millisecond
+	}
+	deadline := time.Now().Add(wait)
+	for {
+		unlock, err := tryLockSessionFile(path)
+		if err == nil {
+			return unlock, nil
+		}
+		if !errors.Is(err, errSessionFileLockHeld) {
+			return nil, err
+		}
+		remaining := time.Until(deadline)
+		if wait <= 0 || remaining <= 0 {
+			return nil, errSessionFileLockHeld
+		}
+		if poll > remaining {
+			poll = remaining
+		}
+		time.Sleep(poll)
+	}
 }
 
 // LockSessionMetaPath serializes a read-modify-write cycle on a session's

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -106,6 +106,37 @@ func TestSnapshotUpToDateFastPath(t *testing.T) {
 	}
 }
 
+func TestSaveSnapshotBoundsCrossProcessFileLockWait(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lock, err := tryTakeSessionLockFile(store.SessionLockFile(path))
+	if err != nil {
+		t.Fatalf("take competing session lock: %v", err)
+	}
+	defer lock.Unlock()
+
+	prevWait, prevPoll := sessionFileLockWait, sessionFileLockPollInterval
+	sessionFileLockWait = 40 * time.Millisecond
+	sessionFileLockPollInterval = 5 * time.Millisecond
+	defer func() {
+		sessionFileLockWait = prevWait
+		sessionFileLockPollInterval = prevPoll
+	}()
+
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "must stay in memory"})
+	started := time.Now()
+	err = s.SaveSnapshot(path)
+	if !errors.Is(err, errSessionFileLockHeld) {
+		t.Fatalf("SaveSnapshot error = %v, want errSessionFileLockHeld", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("SaveSnapshot waited %v for a held cross-process lock; want a bounded failure", elapsed)
+	}
+	if got := s.Snapshot(); len(got) != 2 || got[1].Content != "must stay in memory" {
+		t.Fatalf("failed save changed in-memory transcript: %+v", got)
+	}
+}
+
 // TestRepairedSessionArmsFastPath (#6613 review P2): a session loaded with a
 // damaged event log — or carrying a load-time normalization repair — must
 // re-arm the snapshot no-op fast path once a successful save persists the

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -126,14 +126,116 @@ func TestSaveSnapshotBoundsCrossProcessFileLockWait(t *testing.T) {
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "must stay in memory"})
 	started := time.Now()
 	err = s.SaveSnapshot(path)
-	if !errors.Is(err, errSessionFileLockHeld) {
-		t.Fatalf("SaveSnapshot error = %v, want errSessionFileLockHeld", err)
+	if !errors.Is(err, ErrSessionFileLockHeld) {
+		t.Fatalf("SaveSnapshot error = %v, want ErrSessionFileLockHeld", err)
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("SaveSnapshot waited %v for a held cross-process lock; want a bounded failure", elapsed)
 	}
 	if got := s.Snapshot(); len(got) != 2 || got[1].Content != "must stay in memory" {
 		t.Fatalf("failed save changed in-memory transcript: %+v", got)
+	}
+}
+
+func TestSaveSnapshotSucceedsWhenCrossProcessFileLockReleasesBeforeDeadline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lock, err := tryTakeSessionLockFile(store.SessionLockFile(path))
+	if err != nil {
+		t.Fatalf("take competing session lock: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		lock.Unlock()
+		close(released)
+	}()
+	t.Cleanup(func() { <-released })
+
+	prevWait, prevPoll := sessionFileLockWait, sessionFileLockPollInterval
+	sessionFileLockWait = 500 * time.Millisecond
+	sessionFileLockPollInterval = 5 * time.Millisecond
+	defer func() {
+		sessionFileLockWait = prevWait
+		sessionFileLockPollInterval = prevPoll
+	}()
+
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "save after transient lock"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot after transient lock: %v", err)
+	}
+	select {
+	case <-released:
+	default:
+		t.Fatal("SaveSnapshot returned before the competing lock was released")
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := loaded.Snapshot(); len(got) != 2 || got[1].Content != "save after transient lock" {
+		t.Fatalf("persisted transcript = %+v", got)
+	}
+}
+
+func TestSaveShutdownRecoveryBranchBypassesHeldOriginalFileLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "persisted"})
+	if err := base.SaveSnapshot(path); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	current, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "unsaved shutdown tail"})
+	lock, err := tryTakeSessionLockFile(store.SessionLockFile(path))
+	if err != nil {
+		t.Fatalf("take competing session lock: %v", err)
+	}
+	defer lock.Unlock()
+
+	prevWait, prevPoll := sessionFileLockWait, sessionFileLockPollInterval
+	sessionFileLockWait = 40 * time.Millisecond
+	sessionFileLockPollInterval = 5 * time.Millisecond
+	defer func() {
+		sessionFileLockWait = prevWait
+		sessionFileLockPollInterval = prevPoll
+	}()
+
+	saveErr := current.SaveSnapshot(path)
+	if !errors.Is(saveErr, ErrSessionFileLockHeld) {
+		t.Fatalf("SaveSnapshot error = %v, want ErrSessionFileLockHeld", saveErr)
+	}
+	info, err := current.SaveShutdownRecoveryBranch(RecoveryBranchOptions{
+		OriginalPath: path,
+		Reason:       "shutdown session file lock timeout",
+	})
+	if err != nil {
+		t.Fatalf("SaveShutdownRecoveryBranch: %v", err)
+	}
+	if info.Path == path {
+		t.Fatalf("shutdown recovery path = original path %q", path)
+	}
+	if !info.Meta.Recovered || info.Meta.RecoveryReason != "shutdown session file lock timeout" {
+		t.Fatalf("shutdown recovery meta = %+v", info.Meta)
+	}
+	recovered, err := LoadSession(info.Path)
+	if err != nil {
+		t.Fatalf("load shutdown recovery: %v", err)
+	}
+	if got := recovered.Snapshot(); len(got) != 3 || got[2].Content != "unsaved shutdown tail" {
+		t.Fatalf("shutdown recovery transcript = %+v", got)
+	}
+	original, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("reload original session: %v", err)
+	}
+	if got := original.Snapshot(); len(got) != 2 {
+		t.Fatalf("held original transcript changed: %+v", got)
 	}
 }
 

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -21,7 +21,7 @@ func tryLockSessionFile(path string) (func(), error) {
 	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 		_ = f.Close()
 		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}
@@ -38,7 +38,7 @@ type sessionLockFile struct {
 }
 
 // tryTakeSessionLockFile opens lockPath and takes its exclusive flock without
-// blocking. A live holder surfaces as errSessionFileLockHeld.
+// blocking. A live holder surfaces as ErrSessionFileLockHeld.
 func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
@@ -47,7 +47,7 @@ func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
 	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 		_ = f.Close()
 		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}

--- a/internal/agent/session_lock_unix.go
+++ b/internal/agent/session_lock_unix.go
@@ -11,13 +11,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func lockSessionFile(path string) (func(), error) {
+// tryLockSessionFile attempts the compatibility save lock once without
+// blocking. The shared wrapper in save.go supplies the bounded retry window.
+func tryLockSessionFile(path string) (func(), error) {
 	f, err := os.OpenFile(store.SessionLockFile(path), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, err
 	}
-	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return nil, errSessionFileLockHeld
+		}
 		return nil, err
 	}
 	return func() {

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -19,7 +19,7 @@ func tryLockSessionFile(path string) (func(), error) {
 	f, err := os.OpenFile(store.SessionLockFile(path), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func tryLockSessionFile(path string) (func(), error) {
 	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
 		_ = f.Close()
 		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}
@@ -53,7 +53,7 @@ type sessionLockFile struct {
 var sessionLockDispositionFallbacks atomic.Int64
 
 // tryTakeSessionLockFile opens lockPath and takes its exclusive LockFileEx
-// region without blocking. A live holder surfaces as errSessionFileLockHeld.
+// region without blocking. A live holder surfaces as ErrSessionFileLockHeld.
 //
 // The handle asks for DELETE access up front: FileDispositionInfo requires it,
 // and requesting it at open time keeps RemoveAndUnlock's deletion on the very
@@ -71,7 +71,7 @@ func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
 		nil, windows.OPEN_ALWAYS, windows.FILE_ATTRIBUTE_NORMAL, 0)
 	if err != nil {
 		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func tryTakeSessionLockFile(lockPath string) (*sessionLockFile, error) {
 	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &l.overlapped); err != nil {
 		_ = windows.CloseHandle(handle)
 		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
-			return nil, errSessionFileLockHeld
+			return nil, ErrSessionFileLockHeld
 		}
 		return nil, err
 	}

--- a/internal/agent/session_lock_windows.go
+++ b/internal/agent/session_lock_windows.go
@@ -13,15 +13,24 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func lockSessionFile(path string) (func(), error) {
+// tryLockSessionFile attempts the compatibility save lock once without
+// blocking. The shared wrapper in save.go supplies the bounded retry window.
+func tryLockSessionFile(path string) (func(), error) {
 	f, err := os.OpenFile(store.SessionLockFile(path), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		if errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, errSessionFileLockHeld
+		}
 		return nil, err
 	}
 	handle := windows.Handle(f.Fd())
 	var overlapped windows.Overlapped
-	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
+	if err := windows.LockFileEx(handle, flags, 0, 1, 0, &overlapped); err != nil {
 		_ = f.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			return nil, errSessionFileLockHeld
+		}
 		return nil, err
 	}
 	return func() {

--- a/internal/agent/session_lock_windows_test.go
+++ b/internal/agent/session_lock_windows_test.go
@@ -44,7 +44,7 @@ func TestTryTakeSessionLockFileTreatsOpenHandleAsHeld(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	if _, err := tryTakeSessionLockFile(lockPath); !errors.Is(err, errSessionFileLockHeld) {
-		t.Fatalf("tryTakeSessionLockFile with plain open handle = %v, want errSessionFileLockHeld", err)
+	if _, err := tryTakeSessionLockFile(lockPath); !errors.Is(err, ErrSessionFileLockHeld) {
+		t.Fatalf("tryTakeSessionLockFile with plain open handle = %v, want ErrSessionFileLockHeld", err)
 	}
 }

--- a/internal/agent/session_removal.go
+++ b/internal/agent/session_removal.go
@@ -36,7 +36,7 @@ func TryAcquireSessionRemovalGuard(path string) (*SessionRemovalGuard, error) {
 	}
 	leaseLock, err := tryTakeSessionLockFile(store.SessionLeaseLock(path))
 	if err != nil {
-		if errors.Is(err, errSessionFileLockHeld) {
+		if errors.Is(err, ErrSessionFileLockHeld) {
 			info, _ := LoadSessionLeaseInfo(path)
 			return nil, &SessionLeaseError{Path: path, Info: info}
 		}
@@ -45,7 +45,7 @@ func TryAcquireSessionRemovalGuard(path string) (*SessionRemovalGuard, error) {
 	saveLock, err := tryTakeSessionLockFile(store.SessionLockFile(path))
 	if err != nil {
 		leaseLock.Unlock()
-		if errors.Is(err, errSessionFileLockHeld) {
+		if errors.Is(err, ErrSessionFileLockHeld) {
 			// A save is in flight; deleting mid-write would race it.
 			return nil, &SessionLeaseError{Path: path}
 		}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3277,7 +3277,16 @@ func (c *Controller) maybeColdResumePrune(path string) {
 // path, so a misconfigured deployment surfaces instead of dropping data.
 // Called after every turn so a crash loses at most one in-flight prompt.
 func (c *Controller) Snapshot() error {
-	return c.snapshot(false, false)
+	return c.snapshot(false, false, false)
+}
+
+// SnapshotForShutdown performs the final session snapshot and, only when the
+// compatibility file lock remains held for the full bounded wait, persists the
+// in-memory transcript to a distinct recovery branch before teardown proceeds.
+// Other snapshot errors retain their normal behavior and remain visible to the
+// caller.
+func (c *Controller) SnapshotForShutdown() error {
+	return c.snapshot(false, false, true)
 }
 
 // SnapshotActivity writes the active conversation and marks the session as
@@ -3285,14 +3294,14 @@ func (c *Controller) Snapshot() error {
 // transcript; switch/close snapshots should call Snapshot so they do not reorder
 // recent-session pickers.
 func (c *Controller) SnapshotActivity() error {
-	return c.snapshot(true, false)
+	return c.snapshot(true, false, false)
 }
 
 // SnapshotRewrite persists an intentional history rewrite, such as rewind or
 // manual compaction. Ordinary autosave paths should use Snapshot so stale
 // controllers cannot overwrite a newer transcript.
 func (c *Controller) SnapshotRewrite() error {
-	return c.snapshot(false, true)
+	return c.snapshot(false, true, false)
 }
 
 // midTurnSnapshotInterval is atomic (nanoseconds) so a test shrinking it
@@ -3313,14 +3322,14 @@ func (c *Controller) autosaveWhileRunning(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			if err := c.snapshot(false, false); err != nil {
+			if err := c.snapshot(false, false, false); err != nil {
 				slog.Warn("controller: mid-turn snapshot", "err", err)
 			}
 		}
 	}
 }
 
-func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
+func (c *Controller) snapshot(markActivity, forceRewrite, shutdownRecovery bool) error {
 	c.snapshotMu.Lock()
 	defer c.snapshotMu.Unlock()
 
@@ -3375,22 +3384,43 @@ func (c *Controller) snapshot(markActivity, forceRewrite bool) error {
 		}
 	}
 	if err != nil {
+		if shutdownRecovery && errors.Is(err, agent.ErrSessionFileLockHeld) {
+			recoveredPath, recoverErr := c.recoverShutdownSnapshot(path, err)
+			if recoverErr != nil {
+				return recoverErr
+			}
+			path = recoveredPath
+			s = c.executor.Session()
+			err = nil
+		}
+	}
+	if err != nil {
 		if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
 			return err
 		}
 		recoveredPath, outcome, recoverErr := c.recoverSnapshotConflict(path, err, forceRewrite)
 		if recoverErr != nil {
-			return recoverErr
+			if shutdownRecovery && errors.Is(recoverErr, agent.ErrSessionFileLockHeld) {
+				recoveredPath, recoverErr = c.recoverShutdownSnapshot(path, recoverErr)
+				if recoverErr != nil {
+					return recoverErr
+				}
+				path = recoveredPath
+				s = c.executor.Session()
+			} else {
+				return recoverErr
+			}
+		} else {
+			if outcome == conflictDropped {
+				return nil
+			}
+			// Whatever recovery did — adopted the disk transcript, force-saved
+			// the depth-capped branch, or forked — the rewrite baseline lives on
+			// the session object and was advanced by the save that succeeded, so
+			// there is nothing to re-anchor here.
+			path = recoveredPath
+			s = c.executor.Session()
 		}
-		if outcome == conflictDropped {
-			return nil
-		}
-		// Whatever recovery did — adopted the disk transcript, force-saved
-		// the depth-capped branch, or forked — the rewrite baseline lives on
-		// the session object and was advanced by the save that succeeded, so
-		// there is nothing to re-anchor here.
-		path = recoveredPath
-		s = c.executor.Session()
 	}
 	// Persist guardian session so the prefix cache stays warm after restart.
 	if c.guardianSess != nil {
@@ -3590,8 +3620,49 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 		}
 		return "", conflictDropped, fmt.Errorf("recover stale session snapshot: %w", err)
 	}
-	recoveryInfo := SessionRecoveryInfo{
+	if err := c.commitRecoveredSession(path, reason, info); err != nil {
+		return "", conflictDropped, err
+	}
+	appendSnapshotConflictDiagnostic(path, mode, "forked_recovery_branch", saveErr, info.Path, info.Existing)
+	slog.Warn("controller: snapshot conflict; forked recovery branch",
+		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
+	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text: "session changed on disk; unsaved local transcript was saved as a conflict copy"})
+	return info.Path, conflictForkedBranch, nil
+}
+
+func (c *Controller) recoverShutdownSnapshot(path string, saveErr error) (string, error) {
+	if c.executor == nil || strings.TrimSpace(path) == "" {
+		return "", saveErr
+	}
+	const reason = "shutdown session file lock timeout"
+	req := SessionRecoveryRequest{OriginalPath: path, Reason: reason, Mode: "shutdown"}
+	meta := agent.BranchMeta{}
+	if c.sessionRecoveryMeta != nil {
+		meta = c.sessionRecoveryMeta(req)
+	}
+	info, err := c.executor.Session().SaveShutdownRecoveryBranch(agent.RecoveryBranchOptions{
 		OriginalPath: path,
+		Reason:       reason,
+		BranchMeta:   meta,
+	})
+	if err != nil {
+		return "", fmt.Errorf("save shutdown recovery branch: %w", err)
+	}
+	if err := c.commitRecoveredSession(path, reason, info); err != nil {
+		return "", err
+	}
+	appendSnapshotConflictDiagnostic(path, "shutdown", "forked_file_lock_recovery", saveErr, info.Path, info.Existing)
+	slog.Warn("controller: shutdown snapshot lock timed out; forked recovery branch",
+		"path", path, "recovery", info.Path, "existing", info.Existing)
+	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text: "session file stayed busy during shutdown; unsaved transcript was saved as a recovery copy"})
+	return info.Path, nil
+}
+
+func (c *Controller) commitRecoveredSession(originalPath, reason string, info agent.RecoveryBranchInfo) error {
+	recoveryInfo := SessionRecoveryInfo{
+		OriginalPath: originalPath,
 		RecoveryPath: info.Path,
 		Existing:     info.Existing,
 		Reason:       reason,
@@ -3599,7 +3670,7 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	}
 	if c.onSessionRecovered != nil {
 		if err := c.onSessionRecovered(recoveryInfo); err != nil {
-			return "", conflictDropped, fmt.Errorf("commit recovered session: %w", err)
+			return fmt.Errorf("commit recovered session: %w", err)
 		}
 	}
 	c.mu.Lock()
@@ -3608,13 +3679,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	c.mu.Unlock()
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
-	c.transplantInFlightTurnMarker(path, info.Path)
-	appendSnapshotConflictDiagnostic(path, mode, "forked_recovery_branch", saveErr, info.Path, info.Existing)
-	slog.Warn("controller: snapshot conflict; forked recovery branch",
-		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
-	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-		Text: "session changed on disk; unsaved local transcript was saved as a conflict copy"})
-	return info.Path, conflictForkedBranch, nil
+	c.transplantInFlightTurnMarker(originalPath, info.Path)
+	return nil
 }
 
 func (c *Controller) adoptDiskSession(path string) bool {
@@ -3717,7 +3783,7 @@ func (c *Controller) recoverInterruptedTurn(path string) {
 		} else {
 			c.stripTurnMessagesAfter(marker.StartMessageIndex)
 		}
-		if err := c.snapshot(false, true); err != nil {
+		if err := c.snapshot(false, true, false); err != nil {
 			slog.Warn("controller: post-interrupted-turn snapshot", "err", err)
 		}
 	}

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1114,6 +1114,55 @@ func TestConcurrentSnapshotsShareSingleRecoveryHandoff(t *testing.T) {
 	}
 }
 
+func TestRecoverShutdownSnapshotPersistsAndReanchorsSession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	base := agent.NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "persisted"})
+	if err := base.SaveSnapshot(path); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	current, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "shutdown tail"})
+	exec := agent.New(nil, nil, current, agent.Options{}, event.Discard)
+	var handoff SessionRecoveryInfo
+	c := New(Options{
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "shutdown",
+		OnSessionRecovered: func(info SessionRecoveryInfo) error {
+			handoff = info
+			return nil
+		},
+	})
+
+	recoveryPath, err := c.recoverShutdownSnapshot(path, agent.ErrSessionFileLockHeld)
+	if err != nil {
+		t.Fatalf("recoverShutdownSnapshot: %v", err)
+	}
+	if recoveryPath == "" || recoveryPath == path {
+		t.Fatalf("recovery path = %q, want a distinct session", recoveryPath)
+	}
+	if c.SessionPath() != recoveryPath {
+		t.Fatalf("controller session path = %q, want %q", c.SessionPath(), recoveryPath)
+	}
+	if handoff.OriginalPath != path || handoff.RecoveryPath != recoveryPath || handoff.Reason != "shutdown session file lock timeout" {
+		t.Fatalf("shutdown recovery handoff = %+v", handoff)
+	}
+	recovered, err := agent.LoadSession(recoveryPath)
+	if err != nil {
+		t.Fatalf("load shutdown recovery: %v", err)
+	}
+	if got := recovered.Snapshot(); len(got) != 3 || got[2].Content != "shutdown tail" {
+		t.Fatalf("shutdown recovery transcript = %+v", got)
+	}
+}
+
 func recoveryTranscriptPaths(paths []string) []string {
 	out := paths[:0]
 	for _, path := range paths {

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -182,6 +182,7 @@ type Status interface {
 // state.
 type SessionPersistence interface {
 	Snapshot() error
+	SnapshotForShutdown() error
 	SnapshotActivity() error
 	SessionCache() (hit, miss int)
 	BeginDestroySession(sessionPath string) SessionDestroyHandle


### PR DESCRIPTION
## Summary

- bound cross-process compatibility session-save lock acquisition to five seconds on Unix and Windows
- keep retrying short-lived lock contention and save normally when the competing writer releases before the deadline
- on a true desktop shutdown timeout, persist the in-memory transcript to a process-specific recovery branch before closing controllers or releasing session leases
- reuse the existing session checkpoint, event log, branch metadata, recovery handoff, telemetry, and session-listing flows
- add regressions for bounded failure, transient lock release, durable shutdown recovery, controller re-anchoring, and desktop shutdown ordering
- relates to the true-quit/session-lock portion of #6637; it does not change close-to-background behavior or claim to fix upstream long-context 503 responses

## Verification

- `go test -race ./internal/agent`
- `go test -race ./internal/control`
- `go test ./...`
- `go vet ./...`
- `cd desktop && go test -race ./...`
- `cd desktop && go vet ./...`
- Windows amd64 cross-compilation for `internal/agent`, `internal/control`, and the desktop module
- focused lock/recovery tests repeated 20 times
- focused desktop shutdown test repeated 10 times
- cache-impact guard

## Compatibility and safety

- no persisted session-format, configuration, provider-request, tool-schema, or frontend API changes
- ordinary snapshots retain their existing behavior; the recovery branch is used only when the final shutdown snapshot returns the bounded file-lock sentinel
- the shutdown recovery path never reacquires the stalled original file lock and includes a process-specific suffix to avoid a second blocked recovery target
- recovery depth remains capped for ordinary conflict handling; shutdown recovery saturates at the cap so data durability does not reintroduce unbounded recovery chains
- all application mutexes are released before persistence and recovery callbacks; controller snapshot serialization remains in place

## Cache impact

Cache-impact: none — session persistence and desktop shutdown only; provider-visible prompts, request bodies, tool schemas, and compaction thresholds are unchanged.

Cache-guard: `scripts/check-cache-impact.sh` reports no cache-sensitive files changed.

System-prompt-review: N/A