### PR TITLE
Fix quoted Windows batch plugin hooks / 修复 Windows 插件批处理 Hook 引号兼容

### DIFF
--- a/internal/hook/batch_command_other.go
+++ b/internal/hook/batch_command_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package hook
+
+import (
+	"context"
+	"os/exec"
+)
+
+func windowsBatchCommand(context.Context, string) (*exec.Cmd, bool) {
+	return nil, false
+}
+
+func windowsBatchArgvCommand(context.Context, string, []string) (*exec.Cmd, bool) {
+	return nil, false
+}

--- a/internal/hook/batch_command_windows.go
+++ b/internal/hook/batch_command_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package hook
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+func windowsBatchCommand(ctx context.Context, command string) (*exec.Cmd, bool) {
+	commandLine, ok := windowsBatchCommandLine(command)
+	return newWindowsBatchCommand(ctx, commandLine, ok)
+}
+
+func windowsBatchArgvCommand(ctx context.Context, command string, args []string) (*exec.Cmd, bool) {
+	commandLine, ok := windowsBatchArgvCommandLine(command, args)
+	return newWindowsBatchCommand(ctx, commandLine, ok)
+}
+
+func newWindowsBatchCommand(ctx context.Context, commandLine string, ok bool) (*exec.Cmd, bool) {
+	if !ok {
+		return nil, false
+	}
+	cmd := exec.CommandContext(ctx, "cmd.exe")
+	// cmd.exe does not use CommandLineToArgvW. Supply the exact command line so
+	// Go does not backslash-escape the leading quoted batch path.
+	cmd.Args = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: commandLine}
+	return cmd, true
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1231,6 +1231,9 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 func spawnCommand(ctx context.Context, command string, argv ...[]string) (*exec.Cmd, error) {
 	if len(argv) > 0 && argv[0] != nil {
 		if runtime.GOOS == "windows" {
+			if cmd, matched := windowsBatchArgvCommand(ctx, command, argv[0]); matched {
+				return cmd, nil
+			}
 			if shell, args, matched, err := windowsPOSIXShellArgvInvocation(command, argv[0]); matched {
 				if err != nil {
 					return nil, err
@@ -1247,6 +1250,9 @@ func spawnCommand(ctx context.Context, command string, argv ...[]string) (*exec.
 		return exec.CommandContext(ctx, powershell, args...), nil
 	}
 	if runtime.GOOS == "windows" {
+		if cmd, matched := windowsBatchCommand(ctx, command); matched {
+			return cmd, nil
+		}
 		if shell, args, matched, err := windowsPOSIXShellInvocation(command); matched {
 			if err != nil {
 				return nil, err

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -587,6 +587,46 @@ func TestWindowsPOSIXShellExecFormUsesDiscoveredBash(t *testing.T) {
 	}
 }
 
+func TestWindowsBatchCommandLinePreservesQuotedPluginPath(t *testing.T) {
+	command := `"C:\Users\Test User\AppData\Roaming\reasonix\plugins\superpowers/hooks/run-hook.cmd" session-start`
+	got, ok := windowsBatchCommandLine(command)
+	if !ok {
+		t.Fatal("quoted plugin batch command was not recognized")
+	}
+	want := `cmd.exe /d /s /c ""C:\Users\Test User\AppData\Roaming\reasonix\plugins\superpowers\hooks\run-hook.cmd" "session-start""`
+	if got != want {
+		t.Fatalf("batch command line = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsBatchArgvCommandLineSupportsNativePluginHooks(t *testing.T) {
+	got, ok := windowsBatchArgvCommandLine(
+		`C:\Program Files\Reasonix\plugins\example/hooks/run-hook.cmd`,
+		[]string{"session-start", "argument with spaces"},
+	)
+	if !ok {
+		t.Fatal("native plugin batch command was not recognized")
+	}
+	want := `cmd.exe /d /s /c ""C:\Program Files\Reasonix\plugins\example\hooks\run-hook.cmd" "session-start" "argument with spaces""`
+	if got != want {
+		t.Fatalf("batch argv command line = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsBatchCommandLineLeavesOtherShellContractsAlone(t *testing.T) {
+	commands := []string{
+		`"C:\plugins\hook.cmd" session-start && echo chained`,
+		`powershell -File "C:\plugins\hook.ps1"`,
+		`node "C:\plugins\hook.js"`,
+		`echo hook.cmd`,
+	}
+	for _, command := range commands {
+		if got, ok := windowsBatchCommandLine(command); ok {
+			t.Errorf("windowsBatchCommandLine(%q) unexpectedly matched as %q", command, got)
+		}
+	}
+}
+
 func TestWindowsPOSIXShellPreservesExplicitInterpreterPaths(t *testing.T) {
 	called := false
 	resolve := func() (string, error) {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -593,9 +593,21 @@ func TestWindowsBatchCommandLinePreservesQuotedPluginPath(t *testing.T) {
 	if !ok {
 		t.Fatal("quoted plugin batch command was not recognized")
 	}
-	want := `cmd.exe /d /s /c ""C:\Users\Test User\AppData\Roaming\reasonix\plugins\superpowers\hooks\run-hook.cmd" "session-start""`
+	want := `cmd.exe /d /s /c ""C:\Users\Test User\AppData\Roaming\reasonix\plugins\superpowers\hooks\run-hook.cmd" session-start"`
 	if got != want {
 		t.Fatalf("batch command line = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsBatchCommandLinePreservesArgumentText(t *testing.T) {
+	command := `"C:\plugins\hook.cmd" plain "argument with spaces" caret^ escaped`
+	got, ok := windowsBatchCommandLine(command)
+	if !ok {
+		t.Fatal("quoted batch command was not recognized")
+	}
+	want := `cmd.exe /d /s /c ""C:\plugins\hook.cmd" plain "argument with spaces" caret^ escaped"`
+	if got != want {
+		t.Fatalf("batch argument text changed: got %q, want %q", got, want)
 	}
 }
 
@@ -607,15 +619,24 @@ func TestWindowsBatchArgvCommandLineSupportsNativePluginHooks(t *testing.T) {
 	if !ok {
 		t.Fatal("native plugin batch command was not recognized")
 	}
-	want := `cmd.exe /d /s /c ""C:\Program Files\Reasonix\plugins\example\hooks\run-hook.cmd" "session-start" "argument with spaces""`
+	want := `cmd.exe /d /s /c ""C:\Program Files\Reasonix\plugins\example\hooks\run-hook.cmd" session-start "argument with spaces""`
 	if got != want {
 		t.Fatalf("batch argv command line = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsBatchArgvCommandLineRejectsCmdExpansionSyntax(t *testing.T) {
+	for _, arg := range []string{`%PATH%`, `!HOOK_MODE!`, `embedded"quote`} {
+		if got, ok := windowsBatchArgvCommandLine(`C:\plugins\hook.cmd`, []string{arg}); ok {
+			t.Errorf("argv argument %q unexpectedly matched as %q", arg, got)
+		}
 	}
 }
 
 func TestWindowsBatchCommandLineLeavesOtherShellContractsAlone(t *testing.T) {
 	commands := []string{
 		`"C:\plugins\hook.cmd" session-start && echo chained`,
+		`C:\plugins\hook.cmd session-start`,
 		`powershell -File "C:\plugins\hook.ps1"`,
 		`node "C:\plugins\hook.js"`,
 		`echo hook.cmd`,

--- a/internal/hook/windows_batch_test.go
+++ b/internal/hook/windows_batch_test.go
@@ -16,7 +16,9 @@ func TestDefaultSpawnerRunsQuotedPluginBatchHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	script := filepath.Join(hooksDir, "run-hook.cmd")
-	contents := "@echo off\r\nset /p hook_input=\r\necho %~1:%hook_input%\r\n"
+	// Use raw %1 rather than %~1 so the test catches accidental argument
+	// re-quoting; %~1 would hide added surrounding quotes.
+	contents := "@echo off\r\nset /p hook_input=\r\necho %1:%hook_input%\r\n"
 	if err := os.WriteFile(script, []byte(contents), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hook/windows_batch_test.go
+++ b/internal/hook/windows_batch_test.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package hook
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultSpawnerRunsQuotedPluginBatchHook(t *testing.T) {
+	pluginRoot := filepath.Join(t.TempDir(), "plugin root")
+	hooksDir := filepath.Join(pluginRoot, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(hooksDir, "run-hook.cmd")
+	contents := "@echo off\r\nset /p hook_input=\r\necho %~1:%hook_input%\r\n"
+	if err := os.WriteFile(script, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		command string
+		args    []string
+	}{
+		{name: "shell form", command: `"` + filepath.ToSlash(script) + `" session-start`},
+		{name: "argv form", command: filepath.ToSlash(script), args: []string{"session-start"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultSpawner(context.Background(), SpawnInput{
+				Command: tt.command,
+				Args:    tt.args,
+				Stdin:   `{"event":"SessionStart"}`,
+				Timeout: realSpawnTimeout,
+			})
+			if result.ExitCode != 0 || result.SpawnErr != nil {
+				t.Fatalf("batch hook failed: %+v", result)
+			}
+			if got, want := result.Stdout, `session-start:{"event":"SessionStart"}`; got != want {
+				t.Fatalf("batch hook stdout = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -54,53 +54,97 @@ func windowsPOSIXShellInvocationWith(command string, resolve func() (string, err
 	return path, append([]string(nil), fields[1:]...), true, nil
 }
 
-// windowsBatchCommandLine builds the cmd.exe command line for a simple .cmd or
-// .bat hook. Go's default Windows argument encoder follows CommandLineToArgvW,
-// but cmd.exe has different quote rules: passing a command string that starts
-// with a quoted executable can leave the quotes escaped into the command name.
-// /s deliberately strips the outer pair below and leaves the individually
-// quoted batch path and arguments intact.
+// windowsBatchCommandLine builds the cmd.exe command line for a shell-form .cmd
+// or .bat hook whose executable is already quoted. Go's default Windows
+// argument encoder follows CommandLineToArgvW, but cmd.exe has different quote
+// rules: passing a command string that starts with a quoted executable can leave
+// the quotes escaped into the command name. Preserve the original argument tail
+// byte-for-byte so valid batch syntax is not reinterpreted.
 func windowsBatchCommandLine(command string) (string, bool) {
-	fields, _, _, ok := parseSimpleHookCommandFields(command)
-	if !ok || len(fields) == 0 {
+	command = strings.TrimSpace(command)
+	if len(command) < 2 || command[0] != '"' {
 		return "", false
 	}
-	return windowsBatchFieldsCommandLine(fields)
+	closingQuote := strings.IndexByte(command[1:], '"')
+	if closingQuote < 0 {
+		return "", false
+	}
+	closingQuote++
+	executable := normalizeWindowsBatchExecutable(command[1:closingQuote])
+	if !isWindowsBatchExecutable(executable) {
+		return "", false
+	}
+	tail := command[closingQuote+1:]
+	if tail != "" && !isShellWhitespace(tail[0]) {
+		return "", false
+	}
+	if !isSimpleWindowsBatchTail(tail) {
+		return "", false
+	}
+	// /s strips the first and last quotes around the /c string, leaving the
+	// quoted executable and its untouched argument tail for cmd.exe to parse.
+	return `cmd.exe /d /s /c ""` + executable + `"` + tail + `"`, true
 }
 
 func windowsBatchArgvCommandLine(command string, args []string) (string, bool) {
-	fields := make([]string, 1, len(args)+1)
-	fields[0] = command
-	fields = append(fields, args...)
-	return windowsBatchFieldsCommandLine(fields)
-}
-
-func windowsBatchFieldsCommandLine(fields []string) (string, bool) {
-	executable := strings.ReplaceAll(strings.TrimSpace(fields[0]), "/", `\`)
-	lower := strings.ToLower(executable)
-	if !strings.HasSuffix(lower, ".cmd") && !strings.HasSuffix(lower, ".bat") {
+	executable := normalizeWindowsBatchExecutable(command)
+	if !isWindowsBatchExecutable(executable) || strings.ContainsAny(executable, "\"%!\r\n") {
 		return "", false
 	}
-	fields[0] = executable
 
 	var b strings.Builder
-	b.WriteString(`cmd.exe /d /s /c "`)
-	for i, field := range fields {
-		// Embedded quotes need cmd.exe-specific escaping that is outside this
-		// narrow compatibility path. Preserve such commands' existing shell
-		// contract instead of guessing.
-		if strings.ContainsAny(field, "\"\r\n") {
+	b.WriteString(`cmd.exe /d /s /c ""`)
+	b.WriteString(executable)
+	b.WriteByte('"')
+	for _, arg := range args {
+		rendered, ok := renderWindowsBatchArg(arg)
+		if !ok {
 			return "", false
 		}
-		if i > 0 {
-			b.WriteByte(' ')
-		}
-		b.WriteByte('"')
-		b.WriteString(field)
-		b.WriteByte('"')
+		b.WriteByte(' ')
+		b.WriteString(rendered)
 	}
 	b.WriteByte('"')
 	return b.String(), true
+}
+
+func normalizeWindowsBatchExecutable(executable string) string {
+	return strings.ReplaceAll(strings.TrimSpace(executable), "/", `\`)
+}
+
+func isWindowsBatchExecutable(executable string) bool {
+	lower := strings.ToLower(executable)
+	return strings.HasSuffix(lower, ".cmd") || strings.HasSuffix(lower, ".bat")
+}
+
+func isSimpleWindowsBatchTail(tail string) bool {
+	quoted := false
+	for i := 0; i < len(tail); i++ {
+		switch tail[i] {
+		case '\r', '\n':
+			return false
+		case '"':
+			quoted = !quoted
+		case '&', '|', ';', '<', '>', '(', ')':
+			if !quoted {
+				return false
+			}
+		}
+	}
+	return !quoted
+}
+
+func renderWindowsBatchArg(arg string) (string, bool) {
+	// cmd.exe expands percent variables even inside quotes, and delayed
+	// expansion can do the same for exclamation marks. Keep argv-form support
+	// deliberately narrow instead of silently changing a literal argument.
+	if strings.ContainsAny(arg, "\"%!\r\n") {
+		return "", false
+	}
+	if arg == "" || strings.ContainsAny(arg, " \t&|;<>()^[]{}=' +,`~") {
+		return `"` + arg + `"`, true
+	}
+	return arg, true
 }
 
 func isBarePOSIXShellWord(word string) bool {

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -54,6 +54,55 @@ func windowsPOSIXShellInvocationWith(command string, resolve func() (string, err
 	return path, append([]string(nil), fields[1:]...), true, nil
 }
 
+// windowsBatchCommandLine builds the cmd.exe command line for a simple .cmd or
+// .bat hook. Go's default Windows argument encoder follows CommandLineToArgvW,
+// but cmd.exe has different quote rules: passing a command string that starts
+// with a quoted executable can leave the quotes escaped into the command name.
+// /s deliberately strips the outer pair below and leaves the individually
+// quoted batch path and arguments intact.
+func windowsBatchCommandLine(command string) (string, bool) {
+	fields, _, _, ok := parseSimpleHookCommandFields(command)
+	if !ok || len(fields) == 0 {
+		return "", false
+	}
+	return windowsBatchFieldsCommandLine(fields)
+}
+
+func windowsBatchArgvCommandLine(command string, args []string) (string, bool) {
+	fields := make([]string, 1, len(args)+1)
+	fields[0] = command
+	fields = append(fields, args...)
+	return windowsBatchFieldsCommandLine(fields)
+}
+
+func windowsBatchFieldsCommandLine(fields []string) (string, bool) {
+	executable := strings.ReplaceAll(strings.TrimSpace(fields[0]), "/", `\`)
+	lower := strings.ToLower(executable)
+	if !strings.HasSuffix(lower, ".cmd") && !strings.HasSuffix(lower, ".bat") {
+		return "", false
+	}
+	fields[0] = executable
+
+	var b strings.Builder
+	b.WriteString(`cmd.exe /d /s /c "`)
+	for i, field := range fields {
+		// Embedded quotes need cmd.exe-specific escaping that is outside this
+		// narrow compatibility path. Preserve such commands' existing shell
+		// contract instead of guessing.
+		if strings.ContainsAny(field, "\"\r\n") {
+			return "", false
+		}
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteByte('"')
+		b.WriteString(field)
+		b.WriteByte('"')
+	}
+	b.WriteByte('"')
+	return b.String(), true
+}
+
 func isBarePOSIXShellWord(word string) bool {
 	word = strings.TrimSpace(word)
 	if strings.ContainsAny(word, `/\:`) {


### PR DESCRIPTION
## Summary

- Run simple quoted `.cmd` / `.bat` plugin hooks through an exact `cmd.exe /d /s /c` command line on Windows.
- Support both Claude-style shell command strings and native Reasonix `command` plus `args` hook forms.
- Normalize mixed separators in the batch executable path while leaving compound commands and non-batch shell contracts unchanged.
- Add a Windows runtime regression test using the same quoted `run-hook.cmd` shape reported by superpowers users.

## Root cause

The superpowers SessionStart hook expands to a quoted batch path followed by `session-start`. Go normally serializes Windows process arguments with `CommandLineToArgvW` quoting, but `cmd.exe` and batch files use different quote stripping rules. The leading quoted path could therefore reach `cmd.exe` as part of the command name and fail with “not recognized as an internal or external command.”

The fix recognizes only statically parseable `.cmd` / `.bat` hook invocations. It supplies the exact command line through `SysProcAttr.CmdLine`, uses `/s` for the documented outer-quote stripping behavior, and uses `/d` to disable user AutoRun commands.

## Verification

- `go test ./internal/hook ./internal/pluginpkg ./internal/config -count=1`
- `go test -race ./internal/hook -count=1`
- `go vet ./internal/hook ./internal/pluginpkg ./internal/config`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/hook`
- `go test ./internal/environment -count=1`
- `go test -p 4 ./...`
- `cd desktop && go test -p 4 ./...`
- `./scripts/check-cache-impact.sh`

## Backward compatibility

| Area | Existing behavior | Conclusion |
| --- | --- | --- |
| Hook configuration schema | No fields or persisted formats changed | Compatible |
| Existing `.cmd` / `.bat` hooks | Simple invocations now use correct `cmd.exe` quoting | Compatible bug fix |
| Compound shell commands | Continue through the existing platform shell path | Unchanged |
| Node, PowerShell, and POSIX shell hooks | Existing specialized execution paths remain in place | Unchanged |
| Non-Windows platforms | Windows-specific command creation is build-tagged | Unchanged |

## Security and cache impact

- The specialized path accepts only statically parseable batch invocations; compound commands and embedded-quote arguments fall back to the existing shell contract.
- Cache-impact: none — provider-visible prompts, tool schemas, request serialization, and ordering are unchanged.
- System-prompt-review: not required.

Addresses #6602 and #6643. The issues should remain open until the fix is merged and available in a release.