### PR TITLE
test(config): isolate platform cache roots / 隔离平台缓存根目录

### DIFF
--- a/internal/config/path_isolation_test.go
+++ b/internal/config/path_isolation_test.go
@@ -14,3 +14,18 @@ func requireTestPathWithin(t *testing.T, root, path string) {
 		t.Fatalf("test path %q escapes isolated root %q", path, root)
 	}
 }
+
+func TestProcessTestEnvironmentContainsAllUserStatePaths(t *testing.T) {
+	home := os.Getenv("HOME")
+	paths := map[string]string{
+		"operating system cache": osUserCacheDir(),
+		"Reasonix cache":         CacheDir(),
+		"workspace leases":       WorkspaceLeaseDir(),
+		"delivery worktrees":     DeliveryWorktreeDir(),
+	}
+	for name, path := range paths {
+		t.Run(name, func(t *testing.T) {
+			requireTestPathWithin(t, home, path)
+		})
+	}
+}

--- a/internal/testenv/home.go
+++ b/internal/testenv/home.go
@@ -35,7 +35,10 @@ func IsolateUserState() (func(), error) {
 		"HOME":            home,
 		"USERPROFILE":     home,
 		"XDG_CONFIG_HOME": filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(home, ".cache"),
+		"XDG_STATE_HOME":  filepath.Join(home, ".local", "state"),
 		"AppData":         filepath.Join(home, "AppData", "Roaming"),
+		"LocalAppData":    filepath.Join(home, "AppData", "Local"),
 	}
 	unset := []string{
 		"REASONIX_HOME",

--- a/internal/testenv/home_test.go
+++ b/internal/testenv/home_test.go
@@ -3,19 +3,27 @@ package testenv
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestIsolateUserStateRedirectsAndRestoresCallerEnvironment(t *testing.T) {
 	callerHome := t.TempDir()
-	callerReasonixHome := filepath.Join(callerHome, "explicit-reasonix-home")
-	t.Setenv("HOME", callerHome)
-	t.Setenv("USERPROFILE", callerHome)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(callerHome, "caller-config"))
-	t.Setenv("AppData", filepath.Join(callerHome, "caller-appdata"))
-	t.Setenv("REASONIX_HOME", callerReasonixHome)
-	t.Setenv("REASONIX_STATE_HOME", filepath.Join(callerHome, "caller-state"))
-	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(callerHome, "caller-cache"))
+	callerEnvironment := map[string]string{
+		"HOME":                callerHome,
+		"USERPROFILE":         callerHome,
+		"XDG_CONFIG_HOME":     filepath.Join(callerHome, "caller-config"),
+		"XDG_CACHE_HOME":      filepath.Join(callerHome, "caller-xdg-cache"),
+		"XDG_STATE_HOME":      filepath.Join(callerHome, "caller-xdg-state"),
+		"AppData":             filepath.Join(callerHome, "caller-appdata"),
+		"LocalAppData":        filepath.Join(callerHome, "caller-local-appdata"),
+		"REASONIX_HOME":       filepath.Join(callerHome, "explicit-reasonix-home"),
+		"REASONIX_STATE_HOME": filepath.Join(callerHome, "caller-state"),
+		"REASONIX_CACHE_HOME": filepath.Join(callerHome, "caller-cache"),
+	}
+	for key, value := range callerEnvironment {
+		t.Setenv(key, value)
+	}
 
 	cleanup, err := IsolateUserState()
 	if err != nil {
@@ -26,8 +34,22 @@ func TestIsolateUserStateRedirectsAndRestoresCallerEnvironment(t *testing.T) {
 	if isolateHome == "" || isolateHome == callerHome {
 		t.Fatalf("HOME = %q, want a disposable home distinct from caller %q", isolateHome, callerHome)
 	}
-	if rel, err := filepath.Rel(callerHome, isolateHome); err != nil || rel == ".." || filepath.IsAbs(rel) {
+	if rel, err := filepath.Rel(callerHome, isolateHome); err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		t.Fatalf("isolated home %q is not contained by caller home %q", isolateHome, callerHome)
+	}
+	wantIsolatedEnvironment := map[string]string{
+		"HOME":            isolateHome,
+		"USERPROFILE":     isolateHome,
+		"XDG_CONFIG_HOME": filepath.Join(isolateHome, ".config"),
+		"XDG_CACHE_HOME":  filepath.Join(isolateHome, ".cache"),
+		"XDG_STATE_HOME":  filepath.Join(isolateHome, ".local", "state"),
+		"AppData":         filepath.Join(isolateHome, "AppData", "Roaming"),
+		"LocalAppData":    filepath.Join(isolateHome, "AppData", "Local"),
+	}
+	for key, want := range wantIsolatedEnvironment {
+		if got := os.Getenv(key); got != want {
+			t.Errorf("%s inside isolated test process = %q, want %q", key, got, want)
+		}
 	}
 	for _, key := range []string{"REASONIX_HOME", "REASONIX_STATE_HOME", "REASONIX_CACHE_HOME"} {
 		if _, ok := os.LookupEnv(key); ok {
@@ -36,11 +58,10 @@ func TestIsolateUserStateRedirectsAndRestoresCallerEnvironment(t *testing.T) {
 	}
 
 	cleanup()
-	if got := os.Getenv("HOME"); got != callerHome {
-		t.Fatalf("HOME after cleanup = %q, want %q", got, callerHome)
-	}
-	if got := os.Getenv("REASONIX_HOME"); got != callerReasonixHome {
-		t.Fatalf("REASONIX_HOME after cleanup = %q, want %q", got, callerReasonixHome)
+	for key, want := range callerEnvironment {
+		if got := os.Getenv(key); got != want {
+			t.Errorf("%s after cleanup = %q, want %q", key, got, want)
+		}
 	}
 	if _, err := os.Stat(isolateHome); !os.IsNotExist(err) {
 		t.Fatalf("isolated home still exists after cleanup: %v", err)


### PR DESCRIPTION
## Summary

- Redirect `XDG_CACHE_HOME`, `XDG_STATE_HOME`, and Windows `LocalAppData` into the disposable test home.
- Verify every redirected and cleared environment variable is restored exactly after cleanup.
- Assert the real OS cache, Reasonix cache, workspace lease, and delivery worktree paths remain inside the isolated test home.

## Root cause

#6639 isolated Reasonix overrides, HOME, and config roots, but `os.UserCacheDir()` also reads `XDG_CACHE_HOME` on Unix and `LocalAppData` on Windows. Inherited values could therefore let tests write workspace leases or cache data outside the disposable home.

## Verification

- `go test ./internal/testenv ./internal/config -count=1`
- `go test -race ./internal/testenv ./internal/config -count=1`
- `go test -p=1 ./... -count=1`
- `go vet ./...`
- `./scripts/check-cache-impact.sh`
- `git diff --check`

## Compatibility

- Production path resolution: unchanged.
- Runtime config, state, and cache formats: unchanged.
- Test processes: platform cache and state roots are now redirected into disposable storage.

Cache-impact: none - test-only environment isolation; no runtime prompt, tool, provider request, or cache behavior changes.
Cache-guard: `./scripts/check-cache-impact.sh` reports no cache-sensitive prompt or tool files changed.
System-prompt-review: no system prompt, memory prefix, tool schema, or provider serialization changes.

Follow-up to #6639.