### PR TITLE
Harden crash diagnostics and recurring runtime failures / 强化崩溃诊断并修复高频运行时故障

### DIFF
--- a/desktop/crash_app.go
+++ b/desktop/crash_app.go
@@ -59,45 +59,47 @@ type crashBreadcrumb struct {
 }
 
 type crashReport struct {
-	Kind           string            `json:"kind"`
-	Version        string            `json:"version"`
-	OS             string            `json:"os"`
-	Arch           string            `json:"arch"`
-	Message        string            `json:"message"`
-	Device         deviceInfo        `json:"device"`
-	SchemaVersion  int               `json:"schemaVersion,omitempty"`
-	Source         string            `json:"source,omitempty"`
-	Label          string            `json:"label,omitempty"`
-	ErrorType      string            `json:"errorType,omitempty"`
-	ErrorMessage   string            `json:"errorMessage,omitempty"`
-	Stack          string            `json:"stack,omitempty"`
-	ComponentStack string            `json:"componentStack,omitempty"`
-	TopFrame       string            `json:"topFrame,omitempty"`
-	BuildCommit    string            `json:"buildCommit,omitempty"`
-	Channel        string            `json:"channel,omitempty"`
-	Language       string            `json:"language,omitempty"`
-	View           string            `json:"view,omitempty"`
-	Breadcrumbs    []crashBreadcrumb `json:"breadcrumbs,omitempty"`
-	OccurredAt     string            `json:"occurredAt,omitempty"`
+	Kind            string            `json:"kind"`
+	Version         string            `json:"version"`
+	OS              string            `json:"os"`
+	Arch            string            `json:"arch"`
+	Message         string            `json:"message"`
+	Device          deviceInfo        `json:"device"`
+	SchemaVersion   int               `json:"schemaVersion,omitempty"`
+	Source          string            `json:"source,omitempty"`
+	Label           string            `json:"label,omitempty"`
+	ErrorType       string            `json:"errorType,omitempty"`
+	ErrorMessage    string            `json:"errorMessage,omitempty"`
+	Stack           string            `json:"stack,omitempty"`
+	ComponentStack  string            `json:"componentStack,omitempty"`
+	TopFrame        string            `json:"topFrame,omitempty"`
+	FingerprintHint string            `json:"fingerprintHint,omitempty"`
+	BuildCommit     string            `json:"buildCommit,omitempty"`
+	Channel         string            `json:"channel,omitempty"`
+	Language        string            `json:"language,omitempty"`
+	View            string            `json:"view,omitempty"`
+	Breadcrumbs     []crashBreadcrumb `json:"breadcrumbs,omitempty"`
+	OccurredAt      string            `json:"occurredAt,omitempty"`
 }
 
 type frontendCrashPayload struct {
-	SchemaVersion  int               `json:"schemaVersion"`
-	Kind           string            `json:"kind"`
-	Source         string            `json:"source"`
-	Label          string            `json:"label"`
-	Message        string            `json:"message"`
-	ErrorType      string            `json:"errorType"`
-	ErrorMessage   string            `json:"errorMessage"`
-	Stack          string            `json:"stack"`
-	ComponentStack string            `json:"componentStack"`
-	TopFrame       string            `json:"topFrame"`
-	BuildCommit    string            `json:"buildCommit"`
-	Channel        string            `json:"channel"`
-	Language       string            `json:"language"`
-	View           string            `json:"view"`
-	Breadcrumbs    []crashBreadcrumb `json:"breadcrumbs"`
-	OccurredAt     string            `json:"occurredAt"`
+	SchemaVersion   int               `json:"schemaVersion"`
+	Kind            string            `json:"kind"`
+	Source          string            `json:"source"`
+	Label           string            `json:"label"`
+	Message         string            `json:"message"`
+	ErrorType       string            `json:"errorType"`
+	ErrorMessage    string            `json:"errorMessage"`
+	Stack           string            `json:"stack"`
+	ComponentStack  string            `json:"componentStack"`
+	TopFrame        string            `json:"topFrame"`
+	FingerprintHint string            `json:"fingerprintHint"`
+	BuildCommit     string            `json:"buildCommit"`
+	Channel         string            `json:"channel"`
+	Language        string            `json:"language"`
+	View            string            `json:"view"`
+	Breadcrumbs     []crashBreadcrumb `json:"breadcrumbs"`
+	OccurredAt      string            `json:"occurredAt"`
 }
 
 func normalizeReportKind(kind string) (string, bool) {
@@ -213,6 +215,7 @@ func crashReportFromDetail(kind, detail string) (crashReport, error) {
 		r.Stack = sanitizeCrashText(payload.Stack, maxCrashStackBytes)
 		r.ComponentStack = sanitizeCrashText(payload.ComponentStack, maxCrashStackBytes)
 		r.TopFrame = sanitizeCrashText(payload.TopFrame, 300)
+		r.FingerprintHint = sanitizeCrashText(payload.FingerprintHint, 300)
 		r.BuildCommit = sanitizeCrashField(payload.BuildCommit, 64)
 		r.Channel = sanitizeCrashField(payload.Channel, 32)
 		r.Language = sanitizeCrashField(payload.Language, 64)

--- a/desktop/crash_app_test.go
+++ b/desktop/crash_app_test.go
@@ -100,20 +100,21 @@ func TestCrashReportFromStructuredDetail(t *testing.T) {
 	secretHex := "abcdefabcdefabcdefabcdefabcdef12"
 	buildCommit := "0123456789abcdef0123456789abcdef01234567"
 	payload := frontendCrashPayload{
-		SchemaVersion: 2,
-		Kind:          "exception",
-		Source:        "frontend",
-		Label:         "unhandledrejection",
-		Message:       "[unhandledrejection]\n\ninvalid argument at C:\\Users\\alice\\app.ts:1 from alice@example.com",
-		ErrorType:     "TypeError",
-		ErrorMessage:  "invalid argument at /Users/alice/project/app.ts api_key=" + apiKey,
-		Stack:         "TypeError: invalid argument\n    at run (/Users/alice/project/app.ts:12:3)\nsecret=" + secretHex,
-		TopFrame:      "at run (/Users/alice/project/app.ts:12:3)",
-		BuildCommit:   buildCommit,
-		Channel:       "canary",
-		Language:      "zh-CN",
-		View:          "wails://wails.localhost/index.html?token=" + secretHex,
-		Breadcrumbs:   []crashBreadcrumb{{T: 1, Cat: "bridge", Msg: "turn SubmitToTab token=" + apiKey}},
+		SchemaVersion:   2,
+		Kind:            "exception",
+		Source:          "frontend",
+		Label:           "unhandledrejection",
+		Message:         "[unhandledrejection]\n\ninvalid argument at C:\\Users\\alice\\app.ts:1 from alice@example.com",
+		ErrorType:       "TypeError",
+		ErrorMessage:    "invalid argument at /Users/alice/project/app.ts api_key=" + apiKey,
+		Stack:           "TypeError: invalid argument\n    at run (/Users/alice/project/app.ts:12:3)\nsecret=" + secretHex,
+		TopFrame:        "at run (/Users/alice/project/app.ts:12:3)",
+		FingerprintHint: "build:01234567|view:app://reasonix/|cats:startup>tabs",
+		BuildCommit:     buildCommit,
+		Channel:         "canary",
+		Language:        "zh-CN",
+		View:            "wails://wails.localhost/index.html?token=" + secretHex,
+		Breadcrumbs:     []crashBreadcrumb{{T: 1, Cat: "bridge", Msg: "turn SubmitToTab token=" + apiKey}},
 	}
 	detail, err := json.Marshal(payload)
 	if err != nil {
@@ -129,7 +130,7 @@ func TestCrashReportFromStructuredDetail(t *testing.T) {
 	if strings.Contains(r.Message, "alice") || strings.Contains(r.ErrorMessage, "alice") || strings.Contains(r.Stack, "alice") {
 		t.Fatalf("user path was not scrubbed: %+v", r)
 	}
-	if r.TopFrame == "" || r.BuildCommit != buildCommit || r.Channel != "canary" || len(r.Breadcrumbs) != 1 {
+	if r.TopFrame == "" || r.FingerprintHint != payload.FingerprintHint || r.BuildCommit != buildCommit || r.Channel != "canary" || len(r.Breadcrumbs) != 1 {
 		t.Fatalf("metadata missing: %+v", r)
 	}
 	freeText := strings.Join([]string{

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -7,12 +7,15 @@ import {
   formatLongTaskAttribution,
   formatPerformanceContext,
   globalCrashReportReason,
+  isOpaqueScriptErrorEvent,
   installPerformancePressureMonitor,
   normalizeCrashError,
+  opaqueScriptFingerprintHint,
   parseReportedPerf,
   performanceLabelForReason,
   serializeReportedPerf,
   shouldPromptForLongTasks,
+  shouldPromptForEventLoopLag,
   shouldRecordEventLoopLagSample,
   shouldPromptForPerformanceLabel,
   shouldReportGlobalCrashEvent,
@@ -22,6 +25,10 @@ import {
   type ProfilerTrace,
 } from "../lib/crash";
 import { writeClipboardText } from "../lib/clipboard";
+import { installObjectHasOwnPolyfill } from "../lib/compat";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 let passed = 0;
 let failed = 0;
@@ -37,6 +44,28 @@ function eq(a: unknown, b: unknown, label: string) {
 }
 
 console.log("\ncrash reporting");
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const mainSource = readFileSync(resolve(testDir, "../main.tsx"), "utf8");
+eq(mainSource.startsWith('import "./lib/compat";'), true, "installs WebKit compatibility before application imports");
+const legacyObject = function LegacyObject() {} as unknown as ObjectConstructor & {
+  hasOwn?: (value: object, property: PropertyKey) => boolean;
+};
+installObjectHasOwnPolyfill(legacyObject);
+eq(legacyObject.hasOwn?.({ own: true }, "own"), true, "Object.hasOwn polyfill accepts own properties");
+eq(legacyObject.hasOwn?.(Object.create({ inherited: true }), "inherited"), false, "Object.hasOwn polyfill rejects inherited properties");
+for (const file of ["../components/VirtualMenu.tsx", "../components/WorkspacePanel.tsx", "../components/editors/HljsDiff.tsx"]) {
+  const source = readFileSync(resolve(testDir, file), "utf8");
+  const fileParts = file.split("/");
+  const label = fileParts[fileParts.length - 1];
+  eq(
+    source.includes("directDomUpdates: true") &&
+      source.includes("ref={virtualizer.containerRef}") &&
+      !source.includes("transform: `translateY(${row.start}px)`"),
+    true,
+    `${label} avoids measurement-triggered React update loops`,
+  );
+}
 
 const err = new TypeError("invalid argument");
 err.stack = "TypeError: invalid argument\n    at submit (src/App.tsx:12:3)";
@@ -57,6 +86,11 @@ eq(
   "ignores Chromium ResizeObserver loop limit notices",
 );
 eq(
+  shouldReportGlobalCrashEvent({ defaultPrevented: false, message: "Minified React error #520; recovered synchronously" }),
+  false,
+  "suppresses React's recoverable concurrent-render diagnostic",
+);
+eq(
   shouldReportGlobalCrashEvent({
     defaultPrevented: false,
     message: "ResizeObserver loop completed with undelivered notifications.",
@@ -64,6 +98,19 @@ eq(
   false,
   "ignores Chromium ResizeObserver undelivered notification notices",
 );
+eq(isOpaqueScriptErrorEvent({ defaultPrevented: false, message: "Script error." }), true, "identifies locationless opaque script errors");
+eq(
+  isOpaqueScriptErrorEvent({ defaultPrevented: false, message: "Script error.", filename: "wails://wails/assets/index.js" }),
+  false,
+  "keeps located script errors out of opaque grouping",
+);
+const opaqueHint = opaqueScriptFingerprintHint(
+  "wails://wails.localhost/tabs/123456789?token=private#abcdef123456",
+  [{ t: 1, cat: "tab hydration", msg: "private path /Users/alice/project" }],
+  "0123456789abcdefdeadbeef",
+);
+eq(opaqueHint, "build:0123456789abcdef|view:wails://wails.localhost/tabs/_|cats:tab_hydration", "opaque grouping uses stable safe context");
+eq(opaqueHint.includes("alice"), false, "opaque grouping never includes breadcrumb messages");
 eq(
   shouldReportGlobalCrashEvent({ defaultPrevented: false, error: new Error("ResizeObserver loop limit exceeded") }),
   false,
@@ -154,6 +201,18 @@ eq(
 );
 eq(shouldPromptForLongTasks({ count: 16, totalMs: 3_100, maxMs: 237 }), true, "prompts past the 3s cumulative budget");
 eq(shouldPromptForLongTasks({ count: 2, totalMs: 3_100, maxMs: 790 }), false, "cumulative path needs at least 3 tasks");
+eq(shouldPromptForEventLoopLag([6_007]), false, "ignores an isolated lag spike without long-task evidence");
+eq(shouldPromptForEventLoopLag([1_350, 1_420]), true, "prompts on consecutive lag samples");
+eq(
+  shouldPromptForEventLoopLag([1_350], { count: 1, totalMs: 900, maxMs: 900 }),
+  true,
+  "prompts on a lag spike corroborated by a blocking long task",
+);
+eq(
+  shouldPromptForEventLoopLag([1_350], { count: 2, totalMs: 300, maxMs: 180 }),
+  false,
+  "does not treat unrelated short long tasks as lag corroboration",
+);
 
 eq(formatLongTaskAttribution("self", [{ containerType: "window" }]), "", "hides the no-signal self/window attribution");
 eq(formatLongTaskAttribution("unknown", undefined), "", "hides unknown attribution");
@@ -332,8 +391,8 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   now = 66_600;
   interval?.(); // both grace windows over, steady samples resume
 
-  // A severe main-thread freeze while visible, focused, and settled must still
-  // produce a report — there is deliberately no absolute duration cap.
+  // A single delayed callback can still be a timer discontinuity. It is held
+  // until the next delayed sample (or a long-task entry) corroborates the freeze.
   let promptAttempted = false;
   (globalThis as any).document.getElementById = () => {
     promptAttempted = true;
@@ -341,11 +400,18 @@ eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "ne
   };
   now = 112_600;
   try {
-    interval?.(); // 45s late with no visibility or focus transition: a real freeze
+    interval?.(); // isolated 45s delay: not enough evidence by itself
   } catch {
     // paint intentionally stopped at getElementById
   }
-  eq(promptAttempted, true, "a severe settled-state freeze still prompts (no absolute suspension cap)");
+  eq(promptAttempted, false, "an isolated settled-state timer discontinuity does not prompt");
+  now = 115_100;
+  try {
+    interval?.(); // a second consecutive 1.5s delay corroborates sustained lag
+  } catch {
+    // paint intentionally stopped at getElementById
+  }
+  eq(promptAttempted, true, "consecutive settled-state lag still prompts");
   (globalThis as any).window = previousWindow;
   (globalThis as any).document = previousDocument;
   (globalThis as any).performance = previousPerformance;

--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -13,6 +13,8 @@ import {
   __setMermaidRenderAdapterForTest,
   isOpenableMermaidHref,
   isSafeMermaidHref,
+  safelyRunPanZoom,
+  safelySyncPanZoom,
   sanitizeMermaidSvg,
 } from "../components/MermaidDiagram";
 import { LocaleProvider } from "../lib/i18n";
@@ -76,6 +78,10 @@ function installDom() {
   globalThis.localStorage = dom.window.localStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+  Object.defineProperty(dom.window.HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ x: 0, y: 0, width: 640, height: 360, top: 0, right: 640, bottom: 360, left: 0, toJSON: () => ({}) }),
+  });
   Object.defineProperty(dom.window, "matchMedia", {
     configurable: true,
     value: (query: string) => ({
@@ -96,6 +102,27 @@ function installDom() {
   document.head.appendChild(style);
 
   return dom;
+}
+
+{
+  const dom = installDom();
+  const container = document.createElement("div");
+  const throwing = {
+    destroy: () => {},
+    resize: () => { throw new DOMException("matrix is not invertible", "InvalidStateError"); },
+    fit: () => { throw new DOMException("matrix is not invertible", "InvalidStateError"); },
+    center: () => {},
+    zoomIn: () => { throw new DOMException("matrix is not invertible", "InvalidStateError"); },
+    zoomOut: () => {},
+    reset: () => {},
+  };
+  eq(safelySyncPanZoom(throwing, container), false, "matrix failures are contained during pan/zoom layout sync");
+  eq(safelyRunPanZoom(throwing, () => throwing.zoomIn()), false, "matrix failures are contained during toolbar actions");
+  Object.defineProperty(container, "getBoundingClientRect", {
+    value: () => ({ x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0, toJSON: () => ({}) }),
+  });
+  eq(safelySyncPanZoom(throwing, container), false, "zero-sized layouts are deferred before SVG matrix work");
+  dom.window.close();
 }
 
 function parseSvg(svg: string): Document {

--- a/desktop/frontend/src/components/MermaidDiagram.tsx
+++ b/desktop/frontend/src/components/MermaidDiagram.tsx
@@ -310,6 +310,33 @@ function destroyPanZoom(instance: PanZoomInstance | null): void {
   }
 }
 
+function panZoomLayoutReady(container: HTMLElement): boolean {
+  const rect = container.getBoundingClientRect();
+  return Number.isFinite(rect.width) && Number.isFinite(rect.height) && rect.width > 0 && rect.height > 0;
+}
+
+export function safelyRunPanZoom(instance: PanZoomInstance | null, action: () => void): boolean {
+  if (!instance) return false;
+  try {
+    action();
+    return true;
+  } catch {
+    // svg-pan-zoom asks SVGMatrix.inverse() to invert the current transform.
+    // Hidden/zero-sized layouts can produce a singular matrix in WebKit and
+    // Chromium; keep that library detail out of the global crash surface.
+    return false;
+  }
+}
+
+export function safelySyncPanZoom(instance: PanZoomInstance | null, container: HTMLElement | null): boolean {
+  if (!instance || !container || !panZoomLayoutReady(container)) return false;
+  return safelyRunPanZoom(instance, () => {
+    instance.resize();
+    instance.fit();
+    instance.center();
+  });
+}
+
 const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagramProps) {
   const [state, setState] = useState<DiagramState>({ status: "loading" });
   const [tab, setTab] = useState<DiagramTab>("preview");
@@ -359,7 +386,23 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
 
     let cancelled = false;
     let raf = 0;
+    let syncRaf = 0;
+    let resizeObserver: ResizeObserver | null = null;
     let instance: PanZoomInstance | null = null;
+
+    const queueSync = () => {
+      if (syncRaf) window.cancelAnimationFrame(syncRaf);
+      let attempts = 0;
+      const sync = () => {
+        syncRaf = 0;
+        if (cancelled || panZoomRef.current !== instance) return;
+        attempts += 1;
+        if (!safelySyncPanZoom(instance, container) && attempts < 4) {
+          syncRaf = window.requestAnimationFrame(sync);
+        }
+      };
+      syncRaf = window.requestAnimationFrame(sync);
+    };
 
     void ensurePanZoomFactory().then((factory) => {
       if (cancelled || !factory) return;
@@ -379,19 +422,20 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
             panEnabled: true,
             controlIconsEnabled: false,
             dblClickZoomEnabled: true,
-            fit: true,
-            center: true,
+            // Fitting inside the constructor can run before the portal/layout has
+            // dimensions, which is the matrix-inverse crash seen in diagnostics.
+            fit: false,
+            center: false,
             minZoom: MIN_ZOOM,
             maxZoom: MAX_ZOOM,
             zoomScaleSensitivity: 0.3,
           });
           panZoomRef.current = instance;
-          window.requestAnimationFrame(() => {
-            if (panZoomRef.current !== instance) return;
-            instance?.resize();
-            instance?.fit();
-            instance?.center();
-          });
+          queueSync();
+          if (typeof ResizeObserver !== "undefined") {
+            resizeObserver = new ResizeObserver(queueSync);
+            resizeObserver.observe(container);
+          }
         } catch {
           instance = null;
           panZoomRef.current = null;
@@ -402,6 +446,8 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
     return () => {
       cancelled = true;
       if (raf) window.cancelAnimationFrame(raf);
+      if (syncRaf) window.cancelAnimationFrame(syncRaf);
+      resizeObserver?.disconnect();
       if (panZoomRef.current === instance) panZoomRef.current = null;
       destroyPanZoom(instance);
     };
@@ -421,9 +467,10 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
 
   useEffect(() => {
     if (!fullscreen || !panZoomRef.current) return;
-    panZoomRef.current.resize();
-    panZoomRef.current.fit();
-    panZoomRef.current.center();
+    const raf = window.requestAnimationFrame(() => {
+      safelySyncPanZoom(panZoomRef.current, previewRef.current);
+    });
+    return () => window.cancelAnimationFrame(raf);
   }, [fullscreen]);
 
   const toggleFullscreen = useCallback(() => {
@@ -435,19 +482,20 @@ const MermaidDiagram = memo(function MermaidDiagram({ definition }: MermaidDiagr
   }, []);
 
   const zoomIn = useCallback(() => {
-    panZoomRef.current?.zoomIn();
+    const instance = panZoomRef.current;
+    safelyRunPanZoom(instance, () => instance?.zoomIn());
   }, []);
 
   const zoomOut = useCallback(() => {
-    panZoomRef.current?.zoomOut();
+    const instance = panZoomRef.current;
+    safelyRunPanZoom(instance, () => instance?.zoomOut());
   }, []);
 
   const resetZoom = useCallback(() => {
     const instance = panZoomRef.current;
     if (!instance) return;
-    instance.reset();
-    instance.fit();
-    instance.center();
+    safelyRunPanZoom(instance, () => instance.reset());
+    safelySyncPanZoom(instance, previewRef.current);
   }, []);
 
   const body = (

--- a/desktop/frontend/src/components/VirtualMenu.tsx
+++ b/desktop/frontend/src/components/VirtualMenu.tsx
@@ -25,6 +25,10 @@ export function VirtualMenu<T>({
     getScrollElement: () => scrollRef.current,
     estimateSize: (index) => estimateSize?.(items[index], index) ?? 34,
     overscan: 10,
+    // Measurement callbacks can arrive during React's commit phase. Let the
+    // virtualizer update stable row positions directly instead of dispatching a
+    // reducer update for every ResizeObserver measurement (React #185).
+    directDomUpdates: true,
   });
 
   useEffect(() => {
@@ -35,14 +39,13 @@ export function VirtualMenu<T>({
 
   return (
     <div ref={scrollRef} className="slashmenu" role="listbox">
-      <div className="slashmenu__sizer" style={{ height: virtualizer.getTotalSize() }}>
+      <div ref={virtualizer.containerRef} className="slashmenu__sizer">
         {virtualizer.getVirtualItems().map((row) => (
           <div
             key={itemKey(items[row.index], row.index)}
             data-index={row.index}
             ref={virtualizer.measureElement}
             className="slashmenu__row"
-            style={{ transform: `translateY(${row.start}px)` }}
           >
             {renderItem(items[row.index], row.index)}
           </div>

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -851,6 +851,7 @@ export function WorkspacePanel({
     getScrollElement: () => treeRef.current,
     estimateSize: () => 24,
     overscan: 10,
+    directDomUpdates: true,
   });
 
   const searchPlaceholder = t(scopedFilePaths ? "workspace.filterReferencedFiles" : changedMode ? "workspace.filterChanges" : "workspace.filter");
@@ -1744,9 +1745,9 @@ export function WorkspacePanel({
         >
           {treeRows.length > 0 ? (
             <div
+              ref={virtualizer.containerRef}
               className="workspace-tree__sizer"
               style={{
-                height: virtualizer.getTotalSize(),
                 width: "100%",
                 position: "relative",
               }}
@@ -1764,7 +1765,6 @@ export function WorkspacePanel({
                       top: 0,
                       left: 0,
                       width: "100%",
-                      transform: `translateY(${row.start}px)`,
                     }}
                   >
                     {item.isSearch ? renderSearchRow(item) : renderNormalRow(item)}

--- a/desktop/frontend/src/components/editors/HljsDiff.tsx
+++ b/desktop/frontend/src/components/editors/HljsDiff.tsx
@@ -25,6 +25,7 @@ export default function HljsDiff({ original = "", modified = "", diff = "", lang
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 24,
     overscan: 10,
+    directDomUpdates: true,
   });
 
   const renderRow = (r: typeof rows[0], idx: number) => (
@@ -53,9 +54,9 @@ export default function HljsDiff({ original = "", modified = "", diff = "", lang
     >
       {isVirtual ? (
         <div
+          ref={virtualizer.containerRef}
           className="diff__table"
           style={{
-            height: virtualizer.getTotalSize(),
             width: "100%",
             position: "relative",
           }}
@@ -73,7 +74,6 @@ export default function HljsDiff({ original = "", modified = "", diff = "", lang
                   top: 0,
                   left: 0,
                   width: "100%",
-                  transform: `translateY(${row.start}px)`,
                 }}
               >
                 {renderRow(item, row.index)}

--- a/desktop/frontend/src/lib/compat.ts
+++ b/desktop/frontend/src/lib/compat.ts
@@ -1,0 +1,19 @@
+type ObjectConstructorWithHasOwn = ObjectConstructor & {
+  hasOwn?: (value: object, property: PropertyKey) => boolean;
+};
+
+// Safari 15.3 / the matching macOS WebKit used by older Wails shells predates
+// Object.hasOwn. react-markdown 10 calls it while validating deprecated props,
+// so install the tiny ES2022 primitive before React imports the markdown chunk.
+export function installObjectHasOwnPolyfill(target: ObjectConstructorWithHasOwn = Object): void {
+  if (typeof target.hasOwn === "function") return;
+  Object.defineProperty(target, "hasOwn", {
+    configurable: true,
+    writable: true,
+    value(value: object, property: PropertyKey) {
+      return Object.prototype.hasOwnProperty.call(value, property);
+    },
+  });
+}
+
+installObjectHasOwnPolyfill();

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -56,6 +56,10 @@ export type CrashPayload = {
   stack?: string;
   componentStack?: string;
   topFrame?: string;
+  // Optional, non-display grouping context for otherwise opaque WebView errors.
+  // It is deliberately restricted to build/view/breadcrumb categories and never
+  // contains breadcrumb messages, tab IDs, paths, or user content.
+  fingerprintHint?: string;
   buildCommit: string;
   channel: string;
   language: string;
@@ -114,6 +118,7 @@ const LONG_TASK_PROMPT_MS = 800;
 // user-visible jank, so the cumulative prompt only fires past half of that budget spent blocked.
 const LONG_TASK_TOTAL_PROMPT_MS = 3_000;
 const EVENT_LOOP_LAG_PROMPT_MS = 1_200;
+const EVENT_LOOP_LAG_CONSECUTIVE_SAMPLES = 2;
 const STARTUP_GRACE_MS = 15_000;
 const PROMPT_COOLDOWN_MS = 10 * 60_000;
 const MAX_LAG_SAMPLES = 60;
@@ -450,6 +455,19 @@ export function shouldPromptForLongTasks(summary: { count: number; totalMs: numb
   return summary.maxMs >= LONG_TASK_PROMPT_MS || (summary.count >= 3 && summary.totalMs >= LONG_TASK_TOTAL_PROMPT_MS);
 }
 
+export function shouldPromptForEventLoopLag(
+  samples: readonly number[],
+  longTask?: { count: number; totalMs: number; maxMs: number },
+): boolean {
+  const recent = samples.slice(-EVENT_LOOP_LAG_CONSECUTIVE_SAMPLES);
+  const sustained =
+    recent.length === EVENT_LOOP_LAG_CONSECUTIVE_SAMPLES &&
+    recent.every((sample) => sample >= EVENT_LOOP_LAG_PROMPT_MS);
+  const current = samples.length ? samples[samples.length - 1] : 0;
+  const corroborated = current >= EVENT_LOOP_LAG_PROMPT_MS && Boolean(longTask && shouldPromptForLongTasks(longTask));
+  return sustained || corroborated;
+}
+
 type TaskAttributionLike = {
   containerType?: string;
   containerName?: string;
@@ -573,6 +591,23 @@ export function buildCrashPayload(label: string, err: unknown, extra?: string): 
     breadcrumbs: snapshotBreadcrumbs(),
     occurredAt: new Date().toISOString(),
   };
+}
+
+export function opaqueScriptFingerprintHint(
+  rawView = currentView(),
+  breadcrumbs = snapshotBreadcrumbs(),
+  buildCommit = currentBuildCommit(),
+): string {
+  const view = rawView
+    .replace(/[?#].*$/, "")
+    .replace(/\b[0-9a-f]{8,}\b/gi, "_")
+    .replace(/\/\d+(?=\/|$)/g, "/_");
+  const categories = breadcrumbs
+    .slice(-8)
+    .map((crumb) => crumb.cat?.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "_") ?? "")
+    .filter(Boolean)
+    .join(">");
+  return clip(`build:${buildCommit.slice(0, 16)}|view:${view}|cats:${categories || "none"}`, 300);
 }
 
 function sendButton(
@@ -724,7 +759,17 @@ function globalCrashEventMessages(e: GlobalCrashEventLike): string[] {
 export function shouldReportGlobalCrashEvent(e: GlobalCrashEventLike): boolean {
   if (e.defaultPrevented) return false;
   if (globalCrashEventMessages(e).some((message) => RESIZE_OBSERVER_LOOP_MESSAGE_RE.test(message))) return false;
+  if (globalCrashEventMessages(e).some((message) => /Minified React error #520\b/.test(message))) return false;
   return true;
+}
+
+export function isOpaqueScriptErrorEvent(e: GlobalCrashEventLike): boolean {
+  return (
+    (e.error === undefined || e.error === null) &&
+    typeof e.message === "string" &&
+    e.message.trim() === OPAQUE_SCRIPT_ERROR_MESSAGE &&
+    globalScriptErrorLocation(e) === ""
+  );
 }
 
 function globalScriptErrorLocation(e: GlobalCrashEventLike): string {
@@ -902,14 +947,19 @@ export function installPerformancePressureMonitor() {
     if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused(), now - focusedSince)) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
-    if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);
+    if (shouldPromptForEventLoopLag(lagSamples, longTaskSummary(now))) {
+      promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);
+    }
     maybePromptForHeapPressure();
   }, 1000);
 }
 
 export function installGlobalCrashHandlers() {
   window.addEventListener("error", (e) => {
-    if (shouldReportGlobalCrashEvent(e)) reportCrash("window.error", globalCrashReportReason(e));
+    if (!shouldReportGlobalCrashEvent(e)) return;
+    const payload = buildCrashPayload("window.error", globalCrashReportReason(e));
+    if (isOpaqueScriptErrorEvent(e)) payload.fingerprintHint = opaqueScriptFingerprintHint();
+    paint(payload);
   });
   window.addEventListener("unhandledrejection", (e) => {
     if (shouldReportGlobalCrashEvent(e)) reportCrash("unhandledrejection", e.reason);

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import "./lib/compat";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -16,15 +16,6 @@ var (
 	// only counts with a leading separator (DB_PWD, MYSQL-PWD), so the POSIX
 	// PWD / OLDPWD working-directory variables never match.
 	secretKeyNamePattern = regexp.MustCompile(`(?i)((^|[_-])(api[_-]?key|access[_-]?key|private[_-]?key|secret|token|password|passwd)([_-]|$)|[_-]pwd([_-]|$))`)
-	// keyValuePattern mirrors secretKeyNamePattern for KEY=value / key: value
-	// text: PWD requires a prefixed separator so "PWD=/home/user" stays intact.
-	// The optional auth-scheme group keeps schemes like "Basic"/"Digest" out of
-	// the value capture, so the credential after the scheme word is what gets
-	// masked (an uncaptured scheme would itself be swallowed as the value,
-	// leaving the real credential in the clear right behind it). The separator
-	// group tolerates quotes around the key and before the value so JSON bodies
-	// ("access_token":"...") match, not just env/header text.
-	keyValuePattern = regexp.MustCompile(`(?i)\b([A-Z0-9_.-]*(?:API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD)[A-Z0-9_.-]*|[A-Z0-9_.-]+[_-]PWD[A-Z0-9_.-]*|AUTHORIZATION)\b(['"]?\s*[:=]\s*['"]?)((?:Bearer|Basic|Digest|Negotiate|NTLM|Token|Bot|ApiKey)\s+)?(['"]?)([^'"\s,;]+)(['"]?)`)
 	// cookieHeaderPattern captures Cookie/Set-Cookie header values so every
 	// name=value pair gets its value masked; attribute flags without a value
 	// (HttpOnly, Secure) pass through untouched.
@@ -153,22 +144,7 @@ func Redact(s string) string {
 	if s == "" {
 		return s
 	}
-	s = keyValuePattern.ReplaceAllStringFunc(s, func(match string) string {
-		parts := keyValuePattern.FindStringSubmatch(match)
-		if len(parts) != 7 {
-			return redactedValue
-		}
-		key := parts[1]
-		sep := parts[2]
-		scheme := parts[3]
-		quote := parts[4]
-		value := parts[5]
-		endQuote := parts[6]
-		if strings.EqualFold(key, "authorization") {
-			return key + sep + scheme + quote + redactedValue + endQuote
-		}
-		return key + sep + scheme + quote + mask(value) + endQuote
-	})
+	s = redactKeyValues(s)
 	s = cookieHeaderPattern.ReplaceAllStringFunc(s, func(match string) string {
 		parts := cookieHeaderPattern.FindStringSubmatch(match)
 		if len(parts) != 4 {
@@ -187,6 +163,114 @@ func Redact(s string) string {
 		s = rx.ReplaceAllStringFunc(s, mask)
 	}
 	return s
+}
+
+func redactKeyValues(s string) string {
+	var out strings.Builder
+	last := 0
+	for sep := 0; sep < len(s); sep++ {
+		if s[sep] != ':' && s[sep] != '=' {
+			continue
+		}
+		keyEnd := sep
+		for keyEnd > 0 && asciiSpace(s[keyEnd-1]) {
+			keyEnd--
+		}
+		if keyEnd > 0 && (s[keyEnd-1] == '\'' || s[keyEnd-1] == '"') {
+			keyEnd--
+		}
+		keyStart := keyEnd
+		for keyStart > 0 && credentialKeyByte(s[keyStart-1]) {
+			keyStart--
+		}
+		key := s[keyStart:keyEnd]
+		if !credentialTextKeySensitive(key) {
+			continue
+		}
+
+		valueStart := sep + 1
+		for valueStart < len(s) && asciiSpace(s[valueStart]) {
+			valueStart++
+		}
+		if valueStart < len(s) && (s[valueStart] == '\'' || s[valueStart] == '"') {
+			valueStart++
+		}
+		schemeStart := valueStart
+		for valueStart < len(s) && credentialKeyByte(s[valueStart]) {
+			valueStart++
+		}
+		if valueStart < len(s) && asciiSpace(s[valueStart]) && authorizationScheme(s[schemeStart:valueStart]) {
+			for valueStart < len(s) && asciiSpace(s[valueStart]) {
+				valueStart++
+			}
+			if valueStart < len(s) && (s[valueStart] == '\'' || s[valueStart] == '"') {
+				valueStart++
+			}
+		} else {
+			valueStart = schemeStart
+		}
+
+		valueEnd := valueStart
+		for valueEnd < len(s) && !asciiSpace(s[valueEnd]) && s[valueEnd] != '\'' && s[valueEnd] != '"' && s[valueEnd] != ',' && s[valueEnd] != ';' {
+			valueEnd++
+		}
+		if valueEnd == valueStart {
+			continue
+		}
+		if last == 0 {
+			out.Grow(len(s))
+		}
+		out.WriteString(s[last:valueStart])
+		if authorizationKey(key) {
+			out.WriteString(redactedValue)
+		} else {
+			out.WriteString(mask(s[valueStart:valueEnd]))
+		}
+		last = valueEnd
+		sep = valueEnd - 1
+	}
+	if last == 0 {
+		return s
+	}
+	out.WriteString(s[last:])
+	return out.String()
+}
+
+func credentialKeyByte(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9' || b == '_' || b == '-' || b == '.'
+}
+
+func asciiSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\f'
+}
+
+func authorizationKey(key string) bool {
+	upper := strings.ToUpper(key)
+	return upper == "AUTHORIZATION" || strings.HasSuffix(upper, "-AUTHORIZATION") || strings.HasSuffix(upper, "_AUTHORIZATION") || strings.HasSuffix(upper, ".AUTHORIZATION")
+}
+
+func credentialTextKeySensitive(key string) bool {
+	upper := strings.ToUpper(key)
+	compact := strings.NewReplacer("_", "", "-", "").Replace(upper)
+	return authorizationKey(key) ||
+		strings.Contains(compact, "APIKEY") ||
+		strings.Contains(compact, "ACCESSKEY") ||
+		strings.Contains(compact, "PRIVATEKEY") ||
+		strings.Contains(upper, "SECRET") ||
+		strings.Contains(upper, "TOKEN") ||
+		strings.Contains(upper, "PASSWORD") ||
+		strings.Contains(upper, "PASSWD") ||
+		strings.Contains(upper, "_PWD") ||
+		strings.Contains(upper, "-PWD")
+}
+
+func authorizationScheme(s string) bool {
+	switch strings.ToLower(s) {
+	case "bearer", "basic", "digest", "negotiate", "ntlm", "token", "bot", "apikey":
+		return true
+	default:
+		return false
+	}
 }
 
 func mask(value string) string {

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -1,7 +1,9 @@
 package secrets
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"reasonix/internal/provider"
@@ -30,6 +32,42 @@ func TestRedactMasksCommonSecretShapes(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("redacted output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestRedactLongConcurrentTranscriptAvoidsRegexpBacktracking(t *testing.T) {
+	const secret = "sk-real-secret-value-1234567890"
+	var transcript strings.Builder
+	for i := 0; i < 2_000; i++ {
+		fmt.Fprintf(&transcript, "message %d payload=%s DEEPSEEK_API_KEY=%s Authorization: Bearer %s\n", i, strings.Repeat("x", i%31), secret, secret)
+	}
+	input := transcript.String()
+
+	const workers = 24
+	const iterations = 20
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				got := Redact(input)
+				if strings.Contains(got, secret) {
+					errs <- "long concurrent redaction leaked the test secret"
+					return
+				}
+				if again := Redact(got); again != got {
+					errs <- "long concurrent redaction was not idempotent"
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
 	}
 }
 

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDevelopmentReport,
+  effectiveGroupSeverity,
+  isKnownNonCrashDiagnostic,
+  normalizeForFingerprint,
+  severityForReport,
+} from "./index";
+import { renderStats } from "./stats";
+
+const base = {
+  kind: "crash",
+  source: "frontend.global",
+  label: "window.error",
+  errorType: "Error",
+  errorMessage: "boom",
+  topFrame: "at render (assets/index.js:1:2)",
+};
+
+describe("diagnostic classification", () => {
+  it("keeps development reports out of release crash priority", () => {
+    expect(isDevelopmentReport({ ...base, version: "dev-32bit" })).toBe(true);
+    expect(isDevelopmentReport({ ...base, version: "v1.40.0", channel: "dev" })).toBe(true);
+    expect(severityForReport({ ...base, version: "dev" })).toBe("low");
+  });
+
+  it("downranks browser notices and recovered React renders", () => {
+    expect(
+      isKnownNonCrashDiagnostic({ ...base, errorMessage: "ResizeObserver loop limit exceeded" }),
+    ).toBe(true);
+    expect(
+      isKnownNonCrashDiagnostic({ ...base, errorMessage: "Minified React error #520; recovered" }),
+    ).toBe(true);
+    expect(
+      severityForReport({ ...base, errorMessage: "additional File object is not a file on the disk" }),
+    ).toBe("low");
+  });
+
+  it("keeps actionable release crashes high", () => {
+    expect(severityForReport({ ...base, version: "v1.40.0", channel: "stable" })).toBe("high");
+  });
+
+  it("reclassifies historical groups before dashboard prioritization", () => {
+    expect(
+      effectiveGroupSeverity({
+        severity: "high",
+        title: "[window.error] ResizeObserver loop limit exceeded",
+        last_version: "v1.8.1",
+        last_channel: "stable",
+      }),
+    ).toBe("low");
+    expect(
+      effectiveGroupSeverity({
+        severity: "critical",
+        title: "[window.error] ResizeObserver loop limit exceeded",
+        last_version: "dev",
+        last_channel: "DEV",
+      }),
+    ).toBe("critical");
+  });
+});
+
+describe("opaque crash fingerprints", () => {
+  const opaque = {
+    kind: "crash",
+    source: "frontend.global",
+    label: "window.error",
+    errorType: "string",
+    errorMessage: "Script error.",
+    message: "[window.error]\n\nScript error.",
+    topFrame: "",
+  };
+
+  it("splits locationless Script error reports by safe context hint", () => {
+    const startup = normalizeForFingerprint({ ...opaque, fingerprintHint: "build:abc|view:app://reasonix/|cats:startup>tabs" });
+    const markdown = normalizeForFingerprint({ ...opaque, fingerprintHint: "build:abc|view:app://reasonix/|cats:render>markdown" });
+    expect(startup).not.toBe(markdown);
+  });
+
+  it("preserves grouping when old clients omit the optional hint", () => {
+    expect(normalizeForFingerprint(opaque)).toBe(normalizeForFingerprint({ ...opaque, fingerprintHint: "" }));
+    expect(normalizeForFingerprint(opaque)).toBe(
+      "crash\nfrontend.global\nwindow.error\nstring\n\nScript error.",
+    );
+  });
+});
+
+describe("diagnostics dashboard lanes", () => {
+  it("keeps release, performance, development, and notices out of one another's priority lists", () => {
+    type StatsData = Parameters<typeof renderStats>[0];
+    const row = {
+      fingerprint: "fingerprint",
+      kind: "crash",
+      count: 1,
+      first_version: "v1.40.0",
+      last_version: "v1.40.0",
+      seen: "2026-07-19",
+      status: "open",
+      title: "release-actionable",
+      source: "frontend.global",
+      label: "window.error",
+      error_type: "Error",
+      top_frame: "at render",
+      severity: "high",
+      last_os: "windows",
+      last_arch: "amd64",
+      last_channel: "stable",
+      regressed_at: "",
+    };
+    const data: StatsData = {
+      daily: [],
+      versions: [],
+      platforms: [],
+      crashes: [
+        row,
+        { ...row, fingerprint: "perf", kind: "performance", title: "performance-only", severity: "medium" },
+        { ...row, fingerprint: "dev", title: "development-only", last_version: "dev-32bit", last_channel: "DEV", severity: "low" },
+        { ...row, fingerprint: "notice", title: "browser-notice-only", severity: "low" },
+      ],
+      metrics: [],
+      previousMetrics: [],
+      metricUsers: [],
+      sources: [],
+      overview: { latestAdoptionPct: null, openReports: 4, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 1 },
+      latestVersion: "v1.40.0",
+      filters: {
+        status: "",
+        source: "",
+        version: "",
+        os: "",
+        platform: "",
+        newLatest: false,
+        regressed: false,
+        windowDays: 30,
+        preferenceMode: "users",
+      },
+    };
+
+    const html = renderStats(
+      data,
+      { id: 1, email: "admin@example.com", role: "admin", created_at: "", approved_at: "" },
+      "diagnostics",
+    );
+    const releaseLane = html.slice(html.indexOf("Needs attention"), html.indexOf("Performance signals"));
+    const performanceLane = html.slice(html.indexOf("Performance signals"), html.indexOf("Development diagnostics"));
+    const developmentLane = html.slice(html.indexOf("Development diagnostics"), html.indexOf("Report filters"));
+
+    expect(releaseLane).toContain("release-actionable");
+    expect(releaseLane).not.toContain("performance-only");
+    expect(releaseLane).not.toContain("development-only");
+    expect(releaseLane).not.toContain("browser-notice-only");
+    expect(performanceLane).toContain("performance-only");
+    expect(performanceLane).not.toContain("development-only");
+    expect(developmentLane).toContain("development-only");
+  });
+});

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  groupFingerprintFromPath,
   isDevelopmentReport,
   effectiveGroupSeverity,
+  isDevelopmentGroup,
   isKnownNonCrashDiagnostic,
+  namespaceReportFingerprint,
   normalizeForFingerprint,
   severityForReport,
 } from "./index";
@@ -43,20 +46,72 @@ describe("diagnostic classification", () => {
   it("reclassifies historical groups before dashboard prioritization", () => {
     expect(
       effectiveGroupSeverity({
+        fingerprint: "a".repeat(64),
         severity: "high",
         title: "[window.error] ResizeObserver loop limit exceeded",
+        first_version: "v1.8.0",
         last_version: "v1.8.1",
         last_channel: "stable",
       }),
     ).toBe("low");
     expect(
       effectiveGroupSeverity({
+        fingerprint: `dev:${"b".repeat(64)}`,
         severity: "critical",
         title: "[window.error] ResizeObserver loop limit exceeded",
+        first_version: "dev",
         last_version: "dev",
         last_channel: "DEV",
       }),
     ).toBe("critical");
+  });
+
+  it("does not classify mixed release/development history as development-only", () => {
+    const fingerprint = "c".repeat(64);
+    const stableThenDevelopment = {
+      fingerprint,
+      severity: "high",
+      title: "[window.error] actionable release crash",
+      first_version: "v1.17.15",
+      last_version: "dev-32bit",
+      last_channel: "dev",
+    };
+    const developmentThenStable = {
+      ...stableThenDevelopment,
+      first_version: "dev-32bit",
+      last_version: "v1.17.15",
+      last_channel: "stable",
+    };
+    expect(isDevelopmentGroup(stableThenDevelopment)).toBe(false);
+    expect(effectiveGroupSeverity(stableThenDevelopment)).toBe("high");
+    expect(isDevelopmentGroup(developmentThenStable)).toBe(false);
+    expect(effectiveGroupSeverity(developmentThenStable)).toBe("high");
+  });
+});
+
+describe("development fingerprint namespace", () => {
+  const hash = "d".repeat(64);
+
+  it("preserves stable fingerprints and isolates development reports", () => {
+    expect(namespaceReportFingerprint(hash, false)).toBe(hash);
+    expect(namespaceReportFingerprint(hash, true)).toBe(`dev:${hash}`);
+  });
+
+  it("recognizes namespaced development groups independently of version labels", () => {
+    expect(
+      isDevelopmentGroup({
+        fingerprint: `dev:${hash}`,
+        first_version: "v1.17.15",
+        last_version: "v1.17.15",
+        last_channel: "stable",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps namespaced fingerprints reachable from dashboard links", () => {
+    expect(groupFingerprintFromPath(`/stats/group/dev:${hash}`)).toBe(`dev:${hash}`);
+    expect(groupFingerprintFromPath(`/stats/group/${hash}`)).toBe(hash);
+    expect(groupFingerprintFromPath("/stats/group/dev:not-a-hash")).toBe(null);
   });
 });
 
@@ -114,7 +169,15 @@ describe("diagnostics dashboard lanes", () => {
       crashes: [
         row,
         { ...row, fingerprint: "perf", kind: "performance", title: "performance-only", severity: "medium" },
-        { ...row, fingerprint: "dev", title: "development-only", last_version: "dev-32bit", last_channel: "DEV", severity: "low" },
+        {
+          ...row,
+          fingerprint: `dev:${"e".repeat(64)}`,
+          title: "development-only",
+          last_version: "dev-32bit",
+          last_channel: "DEV",
+          severity: "low",
+          development: true,
+        },
         { ...row, fingerprint: "notice", title: "browser-notice-only", severity: "low" },
       ],
       metrics: [],

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -49,9 +49,6 @@ describe("diagnostic classification", () => {
         fingerprint: "a".repeat(64),
         severity: "high",
         title: "[window.error] ResizeObserver loop limit exceeded",
-        first_version: "v1.8.0",
-        last_version: "v1.8.1",
-        last_channel: "stable",
       }),
     ).toBe("low");
     expect(
@@ -59,14 +56,11 @@ describe("diagnostic classification", () => {
         fingerprint: `dev:${"b".repeat(64)}`,
         severity: "critical",
         title: "[window.error] ResizeObserver loop limit exceeded",
-        first_version: "dev",
-        last_version: "dev",
-        last_channel: "DEV",
       }),
     ).toBe("critical");
   });
 
-  it("does not classify mixed release/development history as development-only", () => {
+  it("keeps ambiguous legacy history out of the development-only lane", () => {
     const fingerprint = "c".repeat(64);
     const stableThenDevelopment = {
       fingerprint,
@@ -82,10 +76,20 @@ describe("diagnostic classification", () => {
       last_version: "v1.17.15",
       last_channel: "stable",
     };
+    // A retained first/last summary cannot distinguish a dev-only group from
+    // dev -> stable -> dev once the middle release sample has been pruned.
+    const developmentAroundStable = {
+      ...stableThenDevelopment,
+      first_version: "dev-32bit",
+      last_version: "dev-32bit",
+      last_channel: "dev",
+    };
     expect(isDevelopmentGroup(stableThenDevelopment)).toBe(false);
     expect(effectiveGroupSeverity(stableThenDevelopment)).toBe("high");
     expect(isDevelopmentGroup(developmentThenStable)).toBe(false);
     expect(effectiveGroupSeverity(developmentThenStable)).toBe("high");
+    expect(isDevelopmentGroup(developmentAroundStable)).toBe(false);
+    expect(effectiveGroupSeverity(developmentAroundStable)).toBe("high");
   });
 });
 
@@ -101,9 +105,6 @@ describe("development fingerprint namespace", () => {
     expect(
       isDevelopmentGroup({
         fingerprint: `dev:${hash}`,
-        first_version: "v1.17.15",
-        last_version: "v1.17.15",
-        last_channel: "stable",
       }),
     ).toBe(true);
   });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -673,26 +673,16 @@ type GroupPriorityRow = {
   last_channel: string;
 };
 
-const developmentGroupSQL = `(fingerprint LIKE 'dev:%' OR (
-  lower(trim(COALESCE(first_version, ''))) LIKE 'dev%'
-  AND (
-    lower(trim(COALESCE(last_channel, ''))) = 'dev'
-    OR lower(trim(COALESCE(last_version, ''))) LIKE 'dev%'
-  )
-))`;
+const developmentGroupSQL = `fingerprint LIKE 'dev:%'`;
 
-export function isDevelopmentGroup(
-  row: Pick<GroupPriorityRow, "fingerprint" | "first_version" | "last_version" | "last_channel">,
-): boolean {
-  if (row.fingerprint.startsWith(DEVELOPMENT_FINGERPRINT_PREFIX)) return true;
-  const firstWasDevelopment = row.first_version.trim().toLowerCase().startsWith("dev");
-  const lastWasDevelopment =
-    row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
-  return firstWasDevelopment && lastWasDevelopment;
+export function isDevelopmentGroup(row: Pick<GroupPriorityRow, "fingerprint">): boolean {
+  // Legacy hashes can contain release observations between retained development
+  // samples, so only the explicit namespace proves that a group is dev-only.
+  return row.fingerprint.startsWith(DEVELOPMENT_FINGERPRINT_PREFIX);
 }
 
 export function effectiveGroupSeverity(
-  row: Pick<GroupPriorityRow, "fingerprint" | "severity" | "title" | "first_version" | "last_version" | "last_channel">,
+  row: Pick<GroupPriorityRow, "fingerprint" | "severity" | "title">,
 ): string {
   if (row.severity === "critical") return row.severity;
   if (isDevelopmentGroup(row)) return "low";

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -51,6 +51,7 @@ const Report = z.object({
   stack: z.string().max(16 * 1024).optional(),
   componentStack: z.string().max(16 * 1024).optional(),
   topFrame: z.string().max(300).optional(),
+  fingerprintHint: z.string().max(300).optional(),
   buildCommit: z.string().max(64).optional(),
   channel: z.string().max(32).optional(),
   language: z.string().max(64).optional(),
@@ -158,6 +159,7 @@ type FingerprintInput = {
   errorType?: string;
   errorMessage?: string;
   topFrame?: string;
+  fingerprintHint?: string;
 };
 
 export function scrubSensitiveText(input: string): string {
@@ -214,6 +216,7 @@ export function normalizeForFingerprint(inputOrKind: FingerprintInput | string, 
     "\n" +
     normalizeStackFrame(input.topFrame || "") +
     "\n" +
+    (input.fingerprintHint ? `${input.fingerprintHint}\n` : "") +
     normalizeFingerprintText(head)
   );
 }
@@ -228,6 +231,7 @@ function hasStructuredCrashFields(r: ReportPayload): boolean {
       r.stack ||
       r.componentStack ||
       r.topFrame ||
+      r.fingerprintHint ||
       r.buildCommit ||
       r.channel ||
       r.language ||
@@ -251,12 +255,29 @@ export function crashTitle(message: string): string {
 
 type SeverityInput = {
   kind: string;
+  version?: string;
   source: string;
   label: string;
   errorType: string;
   errorMessage: string;
   topFrame: string;
+  channel?: string;
 };
+
+const RESIZE_OBSERVER_NOTICE_RE = /^ResizeObserver loop (?:limit exceeded|completed with undelivered notifications\.?)$/;
+
+export function isDevelopmentReport(input: SeverityInput): boolean {
+  return input.channel?.trim().toLowerCase() === "dev" || input.version?.trim().toLowerCase().startsWith("dev") === true;
+}
+
+export function isKnownNonCrashDiagnostic(input: SeverityInput): boolean {
+  const message = input.errorMessage.trim();
+  return (
+    RESIZE_OBSERVER_NOTICE_RE.test(message) ||
+    /Minified React error #520\b/.test(message) ||
+    message.includes("additional File object is not a file on the disk")
+  );
+}
 
 export function isOpaqueScriptErrorReport(input: SeverityInput): boolean {
   return (
@@ -278,7 +299,7 @@ function severityForKind(kind: string): string {
 }
 
 export function severityForReport(input: SeverityInput): string {
-  if (isOpaqueScriptErrorReport(input)) return "low";
+  if (isDevelopmentReport(input) || isOpaqueScriptErrorReport(input) || isKnownNonCrashDiagnostic(input)) return "low";
   return severityForKind(input.kind);
 }
 
@@ -322,6 +343,7 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   const stack = scrubSensitiveText(r.stack ?? "");
   const componentStack = scrubSensitiveText(r.componentStack ?? "");
   const topFrame = scrubSensitiveText(r.topFrame ?? "");
+  const fingerprintHint = scrubSensitiveText(r.fingerprintHint ?? "");
   const view = scrubSensitiveText(r.view ?? "");
   const breadcrumbs = (r.breadcrumbs ?? []).map((b) => ({
     ...b,
@@ -337,6 +359,7 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
         errorType: r.errorType,
         errorMessage,
         topFrame,
+        fingerprintHint,
       })
     : normalizeForFingerprint(r.kind, message);
   const fingerprint = await sha256Hex(fingerprintBasis);
@@ -347,7 +370,16 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   const errorType = r.errorType ?? "";
   const buildCommit = r.buildCommit ?? "";
   const channel = r.channel ?? "";
-  const severity = severityForReport({ kind: r.kind, source, label, errorType, errorMessage, topFrame });
+  const severity = severityForReport({
+    kind: r.kind,
+    version: r.version,
+    source,
+    label,
+    errorType,
+    errorMessage,
+    topFrame,
+    channel,
+  });
   try {
     const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
       .bind(fingerprint)
@@ -370,6 +402,7 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
          label = ?7,
          error_type = ?8,
          top_frame = ?9,
+         severity = CASE WHEN severity = 'critical' THEN severity WHEN ?10 = 'low' THEN 'low' ELSE severity END,
          last_os = ?11,
          last_arch = ?12,
          last_build_commit = ?13,
@@ -567,19 +600,31 @@ async function crashGroups(env: Env, filters: StatsFilters, latestVersion: strin
     binds.push(latestVersion);
   }
   const sql = `SELECT fingerprint, kind, count, first_version, last_version, substr(last_seen, 1, 10) AS seen,
-      status, title, source, label, error_type, top_frame, severity, last_os, last_arch, regressed_at
+      status, title, source, label, error_type, top_frame, severity, last_os, last_arch, last_channel, regressed_at
     FROM groups ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
     ORDER BY
       CASE WHEN status = 'open' THEN 0 ELSE 1 END,
-      CASE WHEN regressed_at <> '' THEN 0 ELSE 1 END,
+      CASE
+        WHEN severity = 'critical' THEN 0
+        WHEN lower(trim(COALESCE(last_channel, ''))) = 'dev'
+          OR lower(trim(COALESCE(last_version, ''))) LIKE 'dev%'
+          OR title = '[window.error] Script error.'
+          OR title LIKE '%ResizeObserver loop %'
+          OR title LIKE '%Minified React error #520%'
+          OR title LIKE '%additional File object is not a file on the disk%'
+          THEN 3
+        WHEN severity = 'high' THEN 1
+        WHEN severity = 'medium' THEN 2
+        ELSE 3
+      END,
       ${latestOrder}
-      CASE severity WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+      CASE WHEN regressed_at <> '' THEN 0 ELSE 1 END,
       count DESC,
       last_seen DESC
     LIMIT 50`;
   const stmt = env.DB.prepare(sql);
   const query = binds.length ? stmt.bind(...binds) : stmt;
-  return query.all<{
+  const result = await query.all<{
     fingerprint: string;
     kind: string;
     count: number;
@@ -595,8 +640,56 @@ async function crashGroups(env: Env, filters: StatsFilters, latestVersion: strin
     severity: string;
     last_os: string;
     last_arch: string;
+    last_channel: string;
     regressed_at: string;
   }>();
+  result.results = result.results
+    .map((row) => ({ ...row, severity: effectiveGroupSeverity(row) }))
+    .sort((a, b) => compareDiagnosticPriority(a, b, latestVersion));
+  return result;
+}
+
+type GroupPriorityRow = {
+  status: string;
+  severity: string;
+  regressed_at: string;
+  first_version: string;
+  count: number;
+  seen: string;
+  title: string;
+  last_version: string;
+  last_channel: string;
+};
+
+export function isDevelopmentGroup(row: Pick<GroupPriorityRow, "last_version" | "last_channel">): boolean {
+  return row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
+}
+
+export function effectiveGroupSeverity(row: Pick<GroupPriorityRow, "severity" | "title" | "last_version" | "last_channel">): string {
+  if (row.severity === "critical") return row.severity;
+  if (isDevelopmentGroup(row)) return "low";
+  if (
+    row.title === "[window.error] Script error." ||
+    row.title.includes("ResizeObserver loop ") ||
+    row.title.includes("Minified React error #520") ||
+    row.title.includes("additional File object is not a file on the disk")
+  ) {
+    return "low";
+  }
+  return row.severity;
+}
+
+function compareDiagnosticPriority(a: GroupPriorityRow, b: GroupPriorityRow, latestVersion: string): number {
+  const statusRank = (value: string) => (value === "open" ? 0 : 1);
+  const severityRank = (value: string) => ({ critical: 0, high: 1, medium: 2, low: 3 })[value] ?? 4;
+  return (
+    statusRank(a.status) - statusRank(b.status) ||
+    severityRank(a.severity) - severityRank(b.severity) ||
+    Number(b.first_version === latestVersion) - Number(a.first_version === latestVersion) ||
+    Number(Boolean(b.regressed_at)) - Number(Boolean(a.regressed_at)) ||
+    b.count - a.count ||
+    b.seen.localeCompare(a.seen)
+  );
 }
 
 type ParsedVersion = {
@@ -667,13 +760,26 @@ async function latestAdoptionPct(env: Env, latestVersion: string, days: 7 | 30):
 }
 
 async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30): Promise<OverviewCounts> {
+  // Keep the overview's red state aligned with the effective severity used by
+  // the diagnostics list. Historical rows retain their stored severity, so
+  // known browser notices and development builds must be discounted here too.
+  const criticalActionable = `(severity = 'critical' OR (
+    severity = 'high'
+    AND kind <> 'performance'
+    AND lower(trim(COALESCE(last_channel, ''))) <> 'dev'
+    AND lower(trim(COALESCE(last_version, ''))) NOT LIKE 'dev%'
+    AND title <> '[window.error] Script error.'
+    AND title NOT LIKE '%ResizeObserver loop %'
+    AND title NOT LIKE '%Minified React error #520%'
+    AND title NOT LIKE '%additional File object is not a file on the disk%'
+  ))`;
   const diagnosticCounts = latestVersion
     ? env.DB.prepare(
         `SELECT
           SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_reports,
           SUM(CASE WHEN first_version = ?1 THEN 1 ELSE 0 END) AS new_latest_reports,
           SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
-          SUM(CASE WHEN status = 'open' AND severity IN ('critical', 'high') THEN 1 ELSE 0 END) AS critical_open_reports
+          SUM(CASE WHEN status = 'open' AND ${criticalActionable} THEN 1 ELSE 0 END) AS critical_open_reports
         FROM groups`,
       )
         .bind(latestVersion)
@@ -683,7 +789,7 @@ async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30)
           SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_reports,
           0 AS new_latest_reports,
           SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
-          SUM(CASE WHEN status = 'open' AND severity IN ('critical', 'high') THEN 1 ELSE 0 END) AS critical_open_reports
+          SUM(CASE WHEN status = 'open' AND ${criticalActionable} THEN 1 ELSE 0 END) AS critical_open_reports
         FROM groups`,
       ).first<{ open_reports: number; new_latest_reports: number; regressed_reports: number; critical_open_reports: number }>();
   const [row, adoptionPct] = await Promise.all([
@@ -813,6 +919,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
 async function handleGroup(env: Env, fingerprint: string, user: User): Promise<Response> {
   const group = await env.DB.prepare("SELECT * FROM groups WHERE fingerprint = ?1").bind(fingerprint).first<Group>();
   if (!group) return new Response("not found", { status: 404 });
+  group.severity = effectiveGroupSeverity(group);
   const reports = await env.DB.prepare(
     `SELECT version, os, arch, message, device, created_at, source, label, error_type, error_message,
       top_frame, build_commit, channel, language, view, breadcrumbs, component_stack, stack, occurred_at

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -26,6 +26,8 @@ import { desktopReleaseChannel, handleDesktopReleaseManifest } from "./desktop_r
 
 const MAX_BODY_BYTES = 96 * 1024;
 const LATEST_SAMPLES_PER_GROUP = 5;
+const DEVELOPMENT_FINGERPRINT_PREFIX = "dev:";
+const GROUP_PATH_RE = /^\/stats\/group\/((?:dev:)?[0-9a-f]{64})$/;
 
 const Device = z
   .object({
@@ -270,6 +272,14 @@ export function isDevelopmentReport(input: SeverityInput): boolean {
   return input.channel?.trim().toLowerCase() === "dev" || input.version?.trim().toLowerCase().startsWith("dev") === true;
 }
 
+export function namespaceReportFingerprint(hash: string, development: boolean): string {
+  return development ? `${DEVELOPMENT_FINGERPRINT_PREFIX}${hash}` : hash;
+}
+
+export function groupFingerprintFromPath(path: string): string | null {
+  return path.match(GROUP_PATH_RE)?.[1] ?? null;
+}
+
 export function isKnownNonCrashDiagnostic(input: SeverityInput): boolean {
   const message = input.errorMessage.trim();
   return (
@@ -362,7 +372,6 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
         fingerprintHint,
       })
     : normalizeForFingerprint(r.kind, message);
-  const fingerprint = await sha256Hex(fingerprintBasis);
   const now = new Date().toISOString();
   const title = crashTitle(message);
   const source = r.source ?? "legacy";
@@ -370,7 +379,7 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
   const errorType = r.errorType ?? "";
   const buildCommit = r.buildCommit ?? "";
   const channel = r.channel ?? "";
-  const severity = severityForReport({
+  const severityInput = {
     kind: r.kind,
     version: r.version,
     source,
@@ -379,7 +388,10 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
     errorMessage,
     topFrame,
     channel,
-  });
+  };
+  const development = isDevelopmentReport(severityInput);
+  const fingerprint = namespaceReportFingerprint(await sha256Hex(fingerprintBasis), development);
+  const severity = severityForReport(severityInput);
   try {
     const prior = await env.DB.prepare("SELECT status FROM groups WHERE fingerprint = ?1")
       .bind(fingerprint)
@@ -606,8 +618,7 @@ async function crashGroups(env: Env, filters: StatsFilters, latestVersion: strin
       CASE WHEN status = 'open' THEN 0 ELSE 1 END,
       CASE
         WHEN severity = 'critical' THEN 0
-        WHEN lower(trim(COALESCE(last_channel, ''))) = 'dev'
-          OR lower(trim(COALESCE(last_version, ''))) LIKE 'dev%'
+        WHEN ${developmentGroupSQL}
           OR title = '[window.error] Script error.'
           OR title LIKE '%ResizeObserver loop %'
           OR title LIKE '%Minified React error #520%'
@@ -644,12 +655,13 @@ async function crashGroups(env: Env, filters: StatsFilters, latestVersion: strin
     regressed_at: string;
   }>();
   result.results = result.results
-    .map((row) => ({ ...row, severity: effectiveGroupSeverity(row) }))
+    .map((row) => ({ ...row, severity: effectiveGroupSeverity(row), development: isDevelopmentGroup(row) }))
     .sort((a, b) => compareDiagnosticPriority(a, b, latestVersion));
   return result;
 }
 
 type GroupPriorityRow = {
+  fingerprint: string;
   status: string;
   severity: string;
   regressed_at: string;
@@ -661,11 +673,27 @@ type GroupPriorityRow = {
   last_channel: string;
 };
 
-export function isDevelopmentGroup(row: Pick<GroupPriorityRow, "last_version" | "last_channel">): boolean {
-  return row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
+const developmentGroupSQL = `(fingerprint LIKE 'dev:%' OR (
+  lower(trim(COALESCE(first_version, ''))) LIKE 'dev%'
+  AND (
+    lower(trim(COALESCE(last_channel, ''))) = 'dev'
+    OR lower(trim(COALESCE(last_version, ''))) LIKE 'dev%'
+  )
+))`;
+
+export function isDevelopmentGroup(
+  row: Pick<GroupPriorityRow, "fingerprint" | "first_version" | "last_version" | "last_channel">,
+): boolean {
+  if (row.fingerprint.startsWith(DEVELOPMENT_FINGERPRINT_PREFIX)) return true;
+  const firstWasDevelopment = row.first_version.trim().toLowerCase().startsWith("dev");
+  const lastWasDevelopment =
+    row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
+  return firstWasDevelopment && lastWasDevelopment;
 }
 
-export function effectiveGroupSeverity(row: Pick<GroupPriorityRow, "severity" | "title" | "last_version" | "last_channel">): string {
+export function effectiveGroupSeverity(
+  row: Pick<GroupPriorityRow, "fingerprint" | "severity" | "title" | "first_version" | "last_version" | "last_channel">,
+): string {
   if (row.severity === "critical") return row.severity;
   if (isDevelopmentGroup(row)) return "low";
   if (
@@ -766,8 +794,7 @@ async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30)
   const criticalActionable = `(severity = 'critical' OR (
     severity = 'high'
     AND kind <> 'performance'
-    AND lower(trim(COALESCE(last_channel, ''))) <> 'dev'
-    AND lower(trim(COALESCE(last_version, ''))) NOT LIKE 'dev%'
+    AND NOT ${developmentGroupSQL}
     AND title <> '[window.error] Script error.'
     AND title NOT LIKE '%ResizeObserver loop %'
     AND title NOT LIKE '%Minified React error #520%'
@@ -1295,14 +1322,14 @@ export default {
 
     if (path === "/account" && method === "GET") return user ? html(renderAccount(user)) : redirect(login);
 
-    const groupMatch = path.match(/^\/stats\/group\/([0-9a-f]{64})$/);
+    const groupFingerprint = groupFingerprintFromPath(path);
     const statsModuleMatch = path.match(/^\/stats\/(diagnostics|usage|preferences|health)$/);
     if ((path === "/stats" || statsModuleMatch) && method === "GET")
       return requireViewer(user, login) ?? handleStats(request, env, user as User, (statsModuleMatch?.[1] as StatsModule | undefined) ?? "usage");
-    if (groupMatch && method === "GET") return requireViewer(user, login) ?? handleGroup(env, groupMatch[1], user as User);
-    if (groupMatch && method === "POST") {
+    if (groupFingerprint && method === "GET") return requireViewer(user, login) ?? handleGroup(env, groupFingerprint, user as User);
+    if (groupFingerprint && method === "POST") {
       if (user?.role !== "admin") return new Response("forbidden", { status: 403 });
-      return handleGroupAction(request, env, user, groupMatch[1]);
+      return handleGroupAction(request, env, user, groupFingerprint);
     }
 
     if (path === "/admin" && method === "GET") {

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -605,10 +605,7 @@ export function renderStats(
   )}">${i18n("Opens", "按启动")}</a>
 </div>`;
   const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
-  const isDevelopmentDiagnostic = (row: CrashRow) =>
-    row.development ??
-    (row.first_version.trim().toLowerCase().startsWith("dev") &&
-      (row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev")));
+  const isDevelopmentDiagnostic = (row: CrashRow) => row.development ?? row.fingerprint.startsWith("dev:");
   const releaseCrashes = data.crashes.filter(
     (row) => row.kind !== "performance" && row.severity !== "low" && !isDevelopmentDiagnostic(row),
   );

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -450,6 +450,7 @@ type CrashRow = {
   last_arch: string;
   last_channel: string;
   regressed_at: string;
+  development?: boolean;
 };
 
 function clip(s: string, n: number): string {
@@ -605,7 +606,9 @@ export function renderStats(
 </div>`;
   const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
   const isDevelopmentDiagnostic = (row: CrashRow) =>
-    row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
+    row.development ??
+    (row.first_version.trim().toLowerCase().startsWith("dev") &&
+      (row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev")));
   const releaseCrashes = data.crashes.filter(
     (row) => row.kind !== "performance" && row.severity !== "low" && !isDevelopmentDiagnostic(row),
   );

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -448,6 +448,7 @@ type CrashRow = {
   severity: string;
   last_os: string;
   last_arch: string;
+  last_channel: string;
   regressed_at: string;
 };
 
@@ -512,7 +513,7 @@ function reportGroups(rows: CrashRow[], compact = false): string {
 <span class="crash-summary"><span>${c.title ? esc(clip(c.title, compact ? 88 : 120)) : `<span class="muted">${i18n("No summary captured", "暂无摘要")}</span>`}</span><small>${esc(c.fingerprint.slice(0, 8))} · ${esc(c.seen)}</small>${
         c.regressed_at ? `<em>${i18nHTML(`regressed ${esc(c.regressed_at.slice(0, 10))}`, `回归 ${esc(c.regressed_at.slice(0, 10))}`)}</em>` : ""
       }</span>
-<span class="crash-scope"><small>${esc(c.source || "legacy")}</small><small>${esc(versions)}</small><small>${platform ? esc(platform) : "unknown platform"}</small></span>
+<span class="crash-scope"><small>${esc(c.source || "legacy")}</small><small>${esc(versions)}</small><small>${platform ? esc(platform) : "unknown platform"}</small>${c.last_channel && c.last_channel !== "stable" ? `<small>${esc(c.last_channel)}</small>` : ""}</span>
 <span class="crash-health"><span class="pill">${esc(c.severity || "medium")}</span><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span>${statusPill(c.status)}</span>
 <span class="crash-count">${c.count}</span>
 </a>`;
@@ -603,6 +604,15 @@ export function renderStats(
   )}">${i18n("Opens", "按启动")}</a>
 </div>`;
   const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
+  const isDevelopmentDiagnostic = (row: CrashRow) =>
+    row.last_channel.trim().toLowerCase() === "dev" || row.last_version.trim().toLowerCase().startsWith("dev");
+  const releaseCrashes = data.crashes.filter(
+    (row) => row.kind !== "performance" && row.severity !== "low" && !isDevelopmentDiagnostic(row),
+  );
+  const performanceDiagnostics = data.crashes.filter(
+    (row) => row.kind === "performance" && !isDevelopmentDiagnostic(row),
+  );
+  const developmentDiagnostics = data.crashes.filter(isDevelopmentDiagnostic);
   const overview = `<section class="overview-grid">
 ${statCard({ en: "Active today", zh: "今日活跃" }, String(totalUsers), i18n("anonymous installs", "匿名安装"), filterQS({}, "usage"))}
 ${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionShare(data.overview.latestAdoptionPct), i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`), filterQS({}, "usage"))}
@@ -640,7 +650,9 @@ ${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data
 <section class="module-panel"><h3>${i18nHTML(`Platforms <b>— ${rangeText}</b>`, `平台分布 <b>— ${rangeText}</b>`)}</h3>${listBars(data.platforms)}</section>
 </div></section>`;
   const diagnosticsModule = `<section id="diagnostics" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Diagnostic triage", "诊断分诊")}</h2></div><a class="module-action" href="#top">${i18n("Back to overview", "回到概览")}</a></div>
-<section class="module-panel"><h3>${i18nHTML("Needs attention <b>— top 10 prioritized diagnostics</b>", "优先处理 <b>— 最需要看的 10 条诊断</b>")}</h3>${reportGroups(data.crashes.slice(0, 10), true)}</section>
+<section class="module-panel"><h3>${i18nHTML("Needs attention <b>— top 10 release crashes and exceptions</b>", "优先处理 <b>— 正式版崩溃与异常 Top 10</b>")}</h3>${reportGroups(releaseCrashes.slice(0, 10), true)}</section>
+${performanceDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Performance signals <b>— tracked separately from crashes</b>", "性能信号 <b>— 与崩溃分开统计</b>")}</h3>${reportGroups(performanceDiagnostics.slice(0, 5), true)}</section>` : ""}
+${developmentDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML("Development diagnostics <b>— excluded from release priority</b>", "开发版诊断 <b>— 不计入正式版优先级</b>")}</h3>${reportGroups(developmentDiagnostics.slice(0, 5), true)}</section>` : ""}
 ${filters}
 <section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
 </section>`;


### PR DESCRIPTION
## Summary

- separate release crashes and exceptions from performance signals, development diagnostics, browser notices, and recovered React reports
- isolate development report fingerprints from release groups while preserving existing release fingerprints
- preserve legacy crash fingerprints while adding an optional privacy-safe hint for otherwise opaque `Script error.` groups
- require sustained event-loop lag or corroborating long-task evidence before prompting
- avoid React commit re-entry by enabling direct DOM updates for all measured virtualizers
- defer and contain Mermaid pan/zoom matrix work until layout is valid
- install an early `Object.hasOwn` compatibility shim for legacy WebKit
- replace the credential key/value regexp replacement path with a linear scanner

## Root cause

The diagnostics dashboard treated several non-crash signals as release crashes, while opaque WebView errors collapsed into one group. Development and release reports also shared the same fingerprint, allowing a development observation to downgrade an actionable release group. The remaining recurring runtime failures came from virtualizer measurement updates during React commits, svg-pan-zoom matrix inversion before layout stabilized, a missing ES2022 primitive in legacy WebKit, and the complex key/value redaction regexp reached by concurrent session snapshots.

## Compatibility

| Surface | Old-version behavior | Conclusion |
| --- | --- | --- |
| `fingerprintHint` Wails/report field | Old desktops omit it; new readers use the empty zero value. Old workers strip the unknown optional field. | Backward-safe; no schema migration |
| Release fingerprint | The optional hint line is inserted only when non-empty, and release reports retain the original 64-character hash format. | Existing release groups remain stable |
| Development fingerprint | New development reports use `dev:<hash>`; both legacy 64-character and namespaced fingerprints remain valid dashboard routes. Legacy groups remain release/unknown because retained samples cannot prove their complete history. | No D1 migration; development samples cannot downgrade release groups |
| Stored group severity | Existing notice rows are reclassified at read time; future development upserts are isolated from release groups while explicit `critical` remains preserved. | Existing D1 data remains readable |
| `Object.hasOwn` shim | Defines the method only when the runtime does not provide it. | Modern runtimes are unchanged |
| Secret redaction | Output remains masked and idempotent; only the internal matching algorithm changes. | Persisted session format is unchanged |

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/secrets`
- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm test:all && pnpm build`
- `cd workers/crash-report && npm test -- --run && npm run typecheck`
- `cd workers/crash-report && npm exec -- wrangler deploy --dry-run --outdir /tmp/reasonix-pr-6678-worker-dryrun`
- `git diff --check`

## Impact

Deploying the worker updates dashboard classification immediately. The runtime crash fixes take effect with the next desktop release. No user-data or database migration is required.
