### PR TITLE
fix(controller): cancel foreground work during close / 关闭 Controller 时取消前台任务

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -747,7 +747,10 @@ func (c *Controller) finishGuardedTurn(err error) {
 	c.mu.Lock()
 	cancelRequested := c.canceling
 	c.running = false
-	c.finishing = true
+	// A live controller keeps admission closed until TurnDone fan-out finishes.
+	// Close has already sealed admission permanently, so a late completion must
+	// not resurrect a finishing state after teardown.
+	c.finishing = !c.closed
 	c.cancel = nil
 	c.canceling = false
 	c.mu.Unlock()
@@ -4644,6 +4647,7 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 	c.closeOnce.Do(func() {
 		c.mu.Lock()
 		started := c.startedOnce
+		cancel := c.cancel
 		// Seal turn admission and drop anything already parked: a parked turn
 		// must not start against a controller that is being torn down, and
 		// without the closed flag a submit landing after this critical
@@ -4651,11 +4655,21 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 		// flight) would park again and start after teardown.
 		c.closed = true
 		c.parkedTurns = nil
-		c.running = false
+		// A finishing-only controller no longer needs the delivery gate because
+		// closed seals every admission path. Keep running truthful until the
+		// foreground goroutine actually exits; clearing it here would report idle
+		// while tools and prompt waiters were still live.
 		c.finishing = false
-		c.canceling = false
+		if cancel != nil {
+			c.canceling = true
+		}
 		c.mu.Unlock()
-		c.approval.clearAll()
+		if cancel != nil {
+			// clearAll deliberately does not signal waiters. Pair it with the
+			// foreground cancellation so approval/ask waits always unblock.
+			c.approval.clearAll()
+			cancel()
+		}
 		if fireSessionEnd && started {
 			c.hooks.SessionEnd(context.Background(), "other")
 		}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4651,7 +4651,11 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 		// flight) would park again and start after teardown.
 		c.closed = true
 		c.parkedTurns = nil
+		c.running = false
+		c.finishing = false
+		c.canceling = false
 		c.mu.Unlock()
+		c.approval.clearAll()
 		if fireSessionEnd && started {
 			c.hooks.SessionEnd(context.Background(), "other")
 		}

--- a/internal/control/runtime_status_test.go
+++ b/internal/control/runtime_status_test.go
@@ -105,6 +105,69 @@ func TestCancelClearsPendingAskRuntimeStatus(t *testing.T) {
 	}
 }
 
+func TestCloseCancelsPendingAskRuntimeStatus(t *testing.T) {
+	asks := make(chan event.Ask, 1)
+	done := make(chan event.Event, 1)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		switch e.Kind {
+		case event.AskRequest:
+			asks <- e.Ask
+		case event.TurnDone:
+			done <- e
+		}
+	})})
+	c.runner = &askBlockingRunner{c: c}
+
+	c.Send("ask user")
+	select {
+	case <-asks:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ask request")
+	}
+
+	c.Close()
+	select {
+	case e := <-done:
+		if !e.Cancelled {
+			t.Fatal("closed turn_done event was not marked as cancelled")
+		}
+	case <-time.After(time.Second):
+		c.Cancel()
+		t.Fatal("Close did not cancel the pending ask waiter")
+	}
+	waitIdle(t, c)
+	if st := c.RuntimeStatus(); st.Running || st.PendingPrompt || st.Cancellable || st.CancelRequested {
+		t.Fatalf("status after Close = %+v, want idle", st)
+	}
+}
+
+func TestCloseDoesNotResurrectFinishingState(t *testing.T) {
+	turnStarted := make(chan struct{})
+	turnDoneEntered := make(chan struct{}, 1)
+	releaseTurnDone := make(chan struct{})
+	c := New(Options{Sink: holdFinishingWindow(releaseTurnDone, turnDoneEntered, nil)})
+
+	c.runGuarded(func(ctx context.Context) error {
+		close(turnStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	<-turnStarted
+
+	c.Close()
+	select {
+	case <-turnDoneEntered:
+	case <-time.After(time.Second):
+		c.Cancel()
+		t.Fatal("Close did not cancel the active turn")
+	}
+	defer close(releaseTurnDone)
+
+	if st := c.RuntimeStatus(); st.Running || st.PendingPrompt || st.Cancellable || st.CancelRequested {
+		t.Fatalf("closed controller resurrected active state during TurnDone delivery: %+v", st)
+	}
+}
+
 func assertCancelClearedPendingRuntimeStatus(t *testing.T, st RuntimeStatus) {
 	t.Helper()
 	if st.PendingPrompt {


### PR DESCRIPTION
## English

### Confirmed scope

The original v1.17.12 report described a reasoning-effort/model/token-mode switch remaining blocked after a foreground turn finished naturally. That exact flow was re-tested against Desktop v1.17.16 and the latest `main-v2`; it succeeded 20/20 times on both revisions, and `Close()` is not on the switch precondition path.

The investigation did confirm a related controller lifecycle defect present in both revisions: `Controller.Close()` sealed new turn admission but did not cancel an active foreground context or a pending approval/ask waiter. Resetting status flags and clearing prompt maps without cancelling the real work could report false idle state, orphan a waiter, and allow a late completion to re-enter `finishing` after teardown.

### Fix

- Capture and cancel the active foreground context after sealing admission.
- Clear pending prompts only together with that cancellation, so waiters unblock.
- Keep `running` truthful until the foreground goroutine actually exits.
- Prevent a closed controller's late completion from reopening `finishing`.
- Add deterministic regressions for pending asks and delayed `TurnDone` delivery.

### Verification

- `go test ./internal/control`
- `go test -race ./internal/control`
- `go test ./...`
- Full Desktop Go suite after integrating the PR with the latest `main-v2`
- Focused Desktop model/effort/token-mode and close/detach lifecycle tests
- `git diff --check`

Cache impact: none. No provider-visible prompt, tool schema, tool ordering, or request serialization changes.

Compatibility: no persisted data format or Wails contract changes.

---

## 中文

### 已确认范围

原始 v1.17.12 报告称前台回合自然结束后，推理力度、模型或 Token 模式切换会持续被阻塞。该流程已在 Desktop v1.17.16 与最新 `main-v2` 上分别连续验证 20 次，均正常通过；`Close()` 也不位于切换前置检查的执行链路中。

排查确认线上两个版本都存在一个相关的 Controller 生命周期缺陷：`Controller.Close()` 会封闭新的回合准入，但不会取消仍在运行的前台上下文或待处理的审批/问答等待。只重置状态位并清空 prompt 映射会产生虚假的空闲状态、遗弃等待者，并可能让迟到的完成回调在关闭后重新进入 `finishing`。

### 修复

- 封闭准入后捕获并取消真实的前台上下文。
- 仅在执行取消时清理 pending prompts，确保等待者能够退出。
- 在前台 goroutine 真正退出前保持 `running` 状态真实。
- 阻止已关闭 Controller 的迟到完成回调重新开启 `finishing`。
- 增加 pending ask 与延迟 `TurnDone` 的确定性回归测试。

### 验证

- `go test ./internal/control`
- `go test -race ./internal/control`
- `go test ./...`
- PR 合入最新 `main-v2` 后运行完整 Desktop Go 测试
- Desktop 模型/推理力度/Token 模式与关闭/分离生命周期聚焦测试
- `git diff --check`

缓存影响：无。未修改模型可见 prompt、工具 schema、工具顺序或请求序列化。

兼容性：未修改持久化数据格式或 Wails 合约。
