### PR TITLE
agent/save: make session filenames Windows-safe / 修复 Windows 会话文件名兼容性

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1953,7 +1953,7 @@ func ContinueSessionPath(prevPath, dir, model string) string {
 // the model so the filename hints at what the conversation was with. dir is
 // typically config.SessionDir().
 func NewSessionPath(dir, model string) string {
-	safe := strings.NewReplacer("/", "-", "\\", "-").Replace(model)
+	safe := strings.NewReplacer("/", "-", "\\", "-", ":", "-", "<", "-", ">", "-", "\"", "-", "|", "-", "?", "-", "*", "-").Replace(model)
 	if safe == "" {
 		safe = "session"
 	}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -396,6 +396,27 @@ func TestNewSessionPathSanitizesSlashes(t *testing.T) {
 	}
 }
 
+func TestNewSessionPathSanitizesWindowsReservedPunctuation(t *testing.T) {
+	dir := t.TempDir()
+	path := NewSessionPath(dir, `nemotron-3-nano:30b<>"|?*`)
+	base := filepath.Base(path)
+	if strings.ContainsAny(base, `:<>"|?*`) {
+		t.Fatalf("filename contains Windows-reserved punctuation: %s", base)
+	}
+	if !strings.Contains(base, "nemotron-3-nano-30b") {
+		t.Fatalf("colon should be replaced without hiding the model hint: %s", base)
+	}
+
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("save session with sanitized model filename: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat saved session: %v", err)
+	}
+}
+
 func TestNewSessionPathEmptyModel(t *testing.T) {
 	path := NewSessionPath("/dir", "")
 	if !strings.Contains(path, "session") {


### PR DESCRIPTION
Fixes #6683

## Problem

Fresh session filenames include the controller's model label. The curated Ollama Cloud model `nemotron-3-nano:30b` contains `:`, which Windows reserves and NTFS uses for stream syntax. The generated transcript path and its derived sidecars can therefore fail to create or resolve correctly on Windows.

## Fix

Sanitize Windows-reserved punctuation in `NewSessionPath` by mapping `:<>"|?*`, together with the already handled `/` and `\`, to `-`.

## Tests

- Add `TestNewSessionPathSanitizesWindowsReservedPunctuation`.
- Cover the real colon-bearing Ollama Cloud model shape.
- Verify every newly handled punctuation character is absent from the basename.
- Save and stat a session through the real persistence path.

## Verification

- `go test ./internal/agent -run TestNewSessionPath -count=1`
- `go test ./internal/agent ./internal/control ./internal/cli ./internal/boot`
- `cd desktop && go test ./...`
- Applied both commits to the latest `main-v2`; `go test ./internal/agent` passed.
- `git diff --check`

## Compatibility

| Area | Existing-data behavior | Conclusion |
| --- | --- | --- |
| Existing session paths | Existing paths are not renamed; continued sessions keep their persisted path. | Backward-compatible |
| Safe model labels | Labels without reserved punctuation retain the existing filename shape. | Backward-compatible |
| New labels with reserved punctuation | Only newly generated filenames map the reserved punctuation to `-`. | Intentional fix |
| Session and sidecar formats | No JSONL, metadata, lease, checkpoint, or event format changes. | Backward-compatible |

## Cache impact

None. This changes only the local filename chosen for a fresh session; provider-visible prompts, tool schemas, request serialization, and model configuration are unchanged.
