### PR TITLE
Fix LongCat-2.0 context window / 修正 LongCat-2.0 上下文窗口

### DIFF
--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -192,34 +192,68 @@ func TestLoadForEditPersistsLegacyStepFunBaseURLMigration(t *testing.T) {
 	}
 }
 
-func TestNormalizeLegacyLongCatContextWindowsMigratesOnlyOfficialPresets(t *testing.T) {
+func TestNormalizeLegacyLongCatContextWindowsMigratesOnlyUntouchedOfficialPresets(t *testing.T) {
 	c := &Config{Providers: []ProviderEntry{
 		{
 			Name:          "longcat-openai",
 			Kind:          "openai",
-			BaseURL:       "https://api.longcat.chat/openai/v1",
+			BaseURL:       longCatOpenAIBaseURL,
+			Models:        []string{"LongCat-2.0"},
+			Default:       "LongCat-2.0",
 			PresetID:      "longcat-openai",
 			ContextWindow: legacyLongCat20ContextWindow,
 		},
 		{
 			Name:          "longcat-anthropic",
 			Kind:          "anthropic",
-			BaseURL:       "https://api.longcat.chat/anthropic",
+			BaseURL:       longCatAnthropicBaseURL + "/",
+			Models:        []string{"LongCat-2.0"},
+			Default:       "LongCat-2.0",
 			PresetID:      "longcat-anthropic",
 			ContextWindow: legacyLongCat20ContextWindow,
 		},
 		{
 			Name:          "custom-longcat",
 			Kind:          "openai",
-			BaseURL:       "https://api.longcat.chat/openai/v1",
+			BaseURL:       longCatOpenAIBaseURL,
+			Models:        []string{"LongCat-2.0"},
+			Default:       "LongCat-2.0",
 			ContextWindow: legacyLongCat20ContextWindow,
 		},
 		{
 			Name:          "longcat-custom-window",
 			Kind:          "openai",
-			BaseURL:       "https://api.longcat.chat/openai/v1",
+			BaseURL:       longCatOpenAIBaseURL,
+			Models:        []string{"LongCat-2.0"},
+			Default:       "LongCat-2.0",
 			PresetID:      "longcat-openai",
 			ContextWindow: 262_144,
+		},
+		{
+			Name:          "longcat-custom-models",
+			Kind:          "openai",
+			BaseURL:       longCatOpenAIBaseURL,
+			Models:        []string{"LongCat-2.0", "LongCat-Future"},
+			Default:       "LongCat-2.0",
+			PresetID:      "longcat-openai",
+			ContextWindow: legacyLongCat20ContextWindow,
+		},
+		{
+			Name:          "longcat-custom-endpoint",
+			Kind:          "openai",
+			BaseURL:       "https://api.longcat.chat/custom/v1",
+			Models:        []string{"LongCat-2.0"},
+			Default:       "LongCat-2.0",
+			PresetID:      "longcat-openai",
+			ContextWindow: legacyLongCat20ContextWindow,
+		},
+		{
+			Name:          "longcat-custom-default",
+			Kind:          "openai",
+			BaseURL:       longCatOpenAIBaseURL,
+			Models:        []string{"LongCat-2.0"},
+			PresetID:      "longcat-openai",
+			ContextWindow: legacyLongCat20ContextWindow,
 		},
 	}}
 
@@ -238,9 +272,18 @@ func TestNormalizeLegacyLongCatContextWindowsMigratesOnlyOfficialPresets(t *test
 	if got := c.Providers[3].ContextWindow; got != 262_144 {
 		t.Fatalf("customized preset context_window = %d, want unchanged 262144", got)
 	}
+	if got := c.Providers[4].ContextWindow; got != legacyLongCat20ContextWindow {
+		t.Fatalf("customized model catalog context_window = %d, want unchanged %d", got, legacyLongCat20ContextWindow)
+	}
+	if got := c.Providers[5].ContextWindow; got != legacyLongCat20ContextWindow {
+		t.Fatalf("customized endpoint context_window = %d, want unchanged %d", got, legacyLongCat20ContextWindow)
+	}
+	if got := c.Providers[6].ContextWindow; got != legacyLongCat20ContextWindow {
+		t.Fatalf("customized default model context_window = %d, want unchanged %d", got, legacyLongCat20ContextWindow)
+	}
 }
 
-func TestLoadForEditPersistsLegacyLongCatContextWindowMigration(t *testing.T) {
+func TestLoadForEditAppliesLegacyLongCatContextWindowMigration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	cfg := Default()
 	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
@@ -260,16 +303,6 @@ func TestLoadForEditPersistsLegacyLongCatContextWindowMigration(t *testing.T) {
 	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
 		if got, _ := loaded.Provider(id); got == nil || got.ContextWindow != longCat20ContextWindow {
 			t.Fatalf("loaded %s = %+v, want context_window %d", id, got, longCat20ContextWindow)
-		}
-	}
-
-	var disk Config
-	if _, err := toml.DecodeFile(path, &disk); err != nil {
-		t.Fatalf("decode persisted config: %v", err)
-	}
-	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
-		if got, _ := disk.Provider(id); got == nil || got.ContextWindow != longCat20ContextWindow {
-			t.Fatalf("persisted %s = %+v, want context_window %d", id, got, longCat20ContextWindow)
 		}
 	}
 }

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -192,6 +192,88 @@ func TestLoadForEditPersistsLegacyStepFunBaseURLMigration(t *testing.T) {
 	}
 }
 
+func TestNormalizeLegacyLongCatContextWindowsMigratesOnlyOfficialPresets(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{
+			Name:          "longcat-openai",
+			Kind:          "openai",
+			BaseURL:       "https://api.longcat.chat/openai/v1",
+			PresetID:      "longcat-openai",
+			ContextWindow: legacyLongCat20ContextWindow,
+		},
+		{
+			Name:          "longcat-anthropic",
+			Kind:          "anthropic",
+			BaseURL:       "https://api.longcat.chat/anthropic",
+			PresetID:      "longcat-anthropic",
+			ContextWindow: legacyLongCat20ContextWindow,
+		},
+		{
+			Name:          "custom-longcat",
+			Kind:          "openai",
+			BaseURL:       "https://api.longcat.chat/openai/v1",
+			ContextWindow: legacyLongCat20ContextWindow,
+		},
+		{
+			Name:          "longcat-custom-window",
+			Kind:          "openai",
+			BaseURL:       "https://api.longcat.chat/openai/v1",
+			PresetID:      "longcat-openai",
+			ContextWindow: 262_144,
+		},
+	}}
+
+	if !normalizeLegacyLongCatContextWindows(c) {
+		t.Fatal("legacy LongCat context-window migration did not report a change")
+	}
+	if got := c.Providers[0].ContextWindow; got != longCat20ContextWindow {
+		t.Fatalf("longcat-openai context_window = %d, want %d", got, longCat20ContextWindow)
+	}
+	if got := c.Providers[1].ContextWindow; got != longCat20ContextWindow {
+		t.Fatalf("longcat-anthropic context_window = %d, want %d", got, longCat20ContextWindow)
+	}
+	if got := c.Providers[2].ContextWindow; got != legacyLongCat20ContextWindow {
+		t.Fatalf("custom LongCat context_window = %d, want unchanged %d", got, legacyLongCat20ContextWindow)
+	}
+	if got := c.Providers[3].ContextWindow; got != 262_144 {
+		t.Fatalf("customized preset context_window = %d, want unchanged 262144", got)
+	}
+}
+
+func TestLoadForEditPersistsLegacyLongCatContextWindowMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := Default()
+	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
+		preset, ok := CuratedProviderPreset(id)
+		if !ok || len(preset.Entries) != 1 {
+			t.Fatalf("missing %s preset", id)
+		}
+		entry := preset.Entries[0]
+		entry.ContextWindow = legacyLongCat20ContextWindow
+		cfg.Providers = append(cfg.Providers, entry)
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded := LoadForEdit(path)
+	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
+		if got, _ := loaded.Provider(id); got == nil || got.ContextWindow != longCat20ContextWindow {
+			t.Fatalf("loaded %s = %+v, want context_window %d", id, got, longCat20ContextWindow)
+		}
+	}
+
+	var disk Config
+	if _, err := toml.DecodeFile(path, &disk); err != nil {
+		t.Fatalf("decode persisted config: %v", err)
+	}
+	for _, id := range []string{"longcat-openai", "longcat-anthropic"} {
+		if got, _ := disk.Provider(id); got == nil || got.ContextWindow != longCat20ContextWindow {
+			t.Fatalf("persisted %s = %+v, want context_window %d", id, got, longCat20ContextWindow)
+		}
+	}
+}
+
 func TestNormalizeDesktopOfficialProviderAccessCanonicalizesOnlyDeepSeekIDs(t *testing.T) {
 	c := Default()
 	c.DefaultModel = "deepseek-flash/deepseek-v4-pro"

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -133,6 +133,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	cfg.ignoredLegacyStepLimits = normalizeLegacyAgentStepLimits(cfg)
 	normalizeLegacyMCPTiers(cfg)
 	normalizeLegacyStepFunBaseURLs(cfg)
+	normalizeLegacyLongCatContextWindows(cfg)
 	normalizeLegacyMimoCustomProviders(cfg)
 	normalizeLegacyProviderModels(cfg)
 	normalizeDesktopOfficialProviderAccess(cfg)
@@ -670,6 +671,7 @@ func normalizeConfigForEdit(cfg *Config) bool {
 	normalizeLegacyAgentStepLimits(cfg)
 	normalizeLegacyMCPTiers(cfg)
 	changed := normalizeLegacyStepFunBaseURLs(cfg)
+	changed = normalizeLegacyLongCatContextWindows(cfg) || changed
 	changed = normalizeLegacyMimoCustomProviders(cfg) || changed
 	normalizeLegacyProviderModels(cfg)
 	normalizeDesktopOfficialProviderAccess(cfg)
@@ -1148,6 +1150,34 @@ func isLegacyStepFunPresetProvider(p ProviderEntry, id, kind string) bool {
 
 func normalizedBaseURLForMigration(raw string) string {
 	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+func normalizeLegacyLongCatContextWindows(c *Config) bool {
+	if c == nil {
+		return false
+	}
+	changed := false
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		if p.ContextWindow != legacyLongCat20ContextWindow || officialProviderHost(p.BaseURL) != "api.longcat.chat" {
+			continue
+		}
+		switch strings.TrimSpace(p.PresetID) {
+		case "longcat-openai":
+			if !strings.EqualFold(strings.TrimSpace(p.Kind), "openai") {
+				continue
+			}
+		case "longcat-anthropic":
+			if !strings.EqualFold(strings.TrimSpace(p.Kind), "anthropic") {
+				continue
+			}
+		default:
+			continue
+		}
+		p.ContextWindow = longCat20ContextWindow
+		changed = true
+	}
+	return changed
 }
 
 func normalizeLegacyMimoProviderCatalogs(c *Config) bool {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1159,19 +1159,23 @@ func normalizeLegacyLongCatContextWindows(c *Config) bool {
 	changed := false
 	for i := range c.Providers {
 		p := &c.Providers[i]
-		if p.ContextWindow != legacyLongCat20ContextWindow || officialProviderHost(p.BaseURL) != "api.longcat.chat" {
+		if p.ContextWindow != legacyLongCat20ContextWindow {
 			continue
 		}
+		var kind, baseURL string
 		switch strings.TrimSpace(p.PresetID) {
 		case "longcat-openai":
-			if !strings.EqualFold(strings.TrimSpace(p.Kind), "openai") {
-				continue
-			}
+			kind, baseURL = "openai", longCatOpenAIBaseURL
 		case "longcat-anthropic":
-			if !strings.EqualFold(strings.TrimSpace(p.Kind), "anthropic") {
-				continue
-			}
+			kind, baseURL = "anthropic", longCatAnthropicBaseURL
 		default:
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(p.Kind), kind) ||
+			normalizedBaseURLForMigration(p.BaseURL) != baseURL ||
+			!stringSlicesEqual(p.Models, longCat20Models) ||
+			p.Model != "" ||
+			p.Default != longCat20Models[0] {
 			continue
 		}
 		p.ContextWindow = longCat20ContextWindow

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -17,7 +17,11 @@ type ProviderPreset struct {
 	Entries     []ProviderEntry
 }
 
-const ProviderPresetVersion = 1
+const (
+	ProviderPresetVersion        = 1
+	longCat20ContextWindow       = 1_048_576
+	legacyLongCat20ContextWindow = 131_072
+)
 
 // CuratedProviderPresets returns one-click provider templates for common
 // OpenAI-compatible and Anthropic-compatible coding-plan services. These are
@@ -109,7 +113,7 @@ var curatedProviderPresets = []ProviderPreset{
 			Models:           longCat20Models,
 			Default:          "LongCat-2.0",
 			APIKeyEnv:        "LONGCAT_API_KEY",
-			ContextWindow:    131072,
+			ContextWindow:    longCat20ContextWindow,
 			Prices:           longCat20Prices(longCat20Models),
 			Thinking:         "enabled",
 			SupportedEfforts: []string{"enabled", "disabled"},
@@ -133,7 +137,7 @@ var curatedProviderPresets = []ProviderPreset{
 			Thinking:         "enabled",
 			SupportedEfforts: []string{"enabled", "disabled"},
 			DefaultEffort:    "enabled",
-			ContextWindow:    131072,
+			ContextWindow:    longCat20ContextWindow,
 			Prices:           longCat20Prices(longCat20Models),
 		}},
 	},

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -21,6 +21,8 @@ const (
 	ProviderPresetVersion        = 1
 	longCat20ContextWindow       = 1_048_576
 	legacyLongCat20ContextWindow = 131_072
+	longCatOpenAIBaseURL         = "https://api.longcat.chat/openai/v1"
+	longCatAnthropicBaseURL      = "https://api.longcat.chat/anthropic"
 )
 
 // CuratedProviderPresets returns one-click provider templates for common
@@ -108,7 +110,7 @@ var curatedProviderPresets = []ProviderPreset{
 		Entries: []ProviderEntry{{
 			Name:             "longcat-openai",
 			Kind:             "openai",
-			BaseURL:          "https://api.longcat.chat/openai/v1",
+			BaseURL:          longCatOpenAIBaseURL,
 			ModelsURL:        "https://api.longcat.chat/openai/v1/models",
 			Models:           longCat20Models,
 			Default:          "LongCat-2.0",
@@ -128,7 +130,7 @@ var curatedProviderPresets = []ProviderPreset{
 		Entries: []ProviderEntry{{
 			Name:             "longcat-anthropic",
 			Kind:             "anthropic",
-			BaseURL:          "https://api.longcat.chat/anthropic",
+			BaseURL:          longCatAnthropicBaseURL,
 			ModelsURL:        "https://api.longcat.chat/anthropic/v1/models",
 			Models:           longCat20Models,
 			Default:          "LongCat-2.0",

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -204,6 +204,9 @@ func TestCuratedProviderPresetCapabilities(t *testing.T) {
 	if longcat.BaseURL != "https://api.longcat.chat/openai/v1" || longcat.ModelsURL != "https://api.longcat.chat/openai/v1/models" || longcat.APIKeyEnv != "LONGCAT_API_KEY" {
 		t.Fatalf("longcat-openai endpoint/key mismatch: %+v", longcat)
 	}
+	if longcat.ContextWindow != longCat20ContextWindow {
+		t.Fatalf("longcat-openai context_window = %d, want %d", longcat.ContextWindow, longCat20ContextWindow)
+	}
 	if cap := EffortCapabilityForEntry(longcat); !cap.Supported || cap.Default != "enabled" || !containsString(cap.Levels, "disabled") {
 		t.Fatalf("longcat-openai effort capability = %+v, want enabled/disabled", cap)
 	}
@@ -216,6 +219,9 @@ func TestCuratedProviderPresetCapabilities(t *testing.T) {
 	}
 	if longcatAnthropic.Kind != "anthropic" || longcatAnthropic.BaseURL != "https://api.longcat.chat/anthropic" || longcatAnthropic.ModelsURL != "https://api.longcat.chat/anthropic/v1/models" || !longcatAnthropic.AuthHeader || longcatAnthropic.Thinking != "enabled" {
 		t.Fatalf("longcat-anthropic capability mismatch: %+v", longcatAnthropic)
+	}
+	if longcatAnthropic.ContextWindow != longCat20ContextWindow {
+		t.Fatalf("longcat-anthropic context_window = %d, want %d", longcatAnthropic.ContextWindow, longCat20ContextWindow)
 	}
 
 	mimo, ok := cfg.Provider("mimo-api")


### PR DESCRIPTION
## Summary

- Set both LongCat-2.0 curated provider presets to the official 1,048,576-token context length.
- Migrate previously installed, otherwise untouched official LongCat-2.0 presets that still contain the legacy 131,072 value.
- Preserve custom providers, endpoints, model catalogs, default models, and user-edited context windows.
- Add regression coverage for both preset transports and persisted-config loading.

## Root cause

The preset copied LongCat-2.0's `max_tokens` value (131,072 maximum output tokens) into Reasonix's `context_window` field. LongCat's model metadata reports `context_length: 1048576`.

Because Reasonix uses `context_window` to schedule context maintenance, the incorrect value caused stale-tool-result cleanup and compaction to run roughly eight times earlier than intended.

Official references:

- https://longcat.chat/platform/docs/api/model
- https://longcat.chat/platform/docs/api/chat
- https://longcat.chat/platform/docs/faq

## Cache impact

Positive. This change does not alter provider-visible prompt bytes, tool schemas, ordering, or request serialization. It delays premature compaction for LongCat-2.0, preserving the append-only cached prefix for longer.

## Compatibility audit

| Field | Old-data behavior | Conclusion |
| --- | --- | --- |
| `providers[].context_window` | Official LongCat-2.0 preset entries with the exact legacy value `131072`, matching `preset_id`, provider kind, normalized official endpoint, original single-model catalog, and explicit default model are migrated to `1048576`. | Backward-safe targeted correction. |
| Custom context windows | Values other than `131072` are left unchanged. | User customization is preserved. |
| Custom providers/endpoints/catalogs | Entries without the exact original preset identity, endpoint, `LongCat-2.0`-only catalog, and default are left unchanged. | No unrelated provider or added model is mutated. |
| Persisted schema | No fields, enums, or identifier formats change. | Older configs remain readable; no cross-version format change. |

## Verification

- `./scripts/cache-guard.sh`
- `go test ./internal/config`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
