### PR TITLE
fix(desktop): preserve active theme after settings refresh / 修复设置刷新后主题配色回退

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -172,7 +172,7 @@ import {
   type Theme,
 } from "./lib/theme";
 import { applyConversationWidth } from "./lib/conversationWidth";
-import { applyThemePack, applyThemeScene, clearThemePack, setBaseAppearance } from "./lib/themePack";
+import { applyConfiguredBaseAppearance, applyThemePack, applyThemeScene, clearThemePack } from "./lib/themePack";
 import { ThemeBackground } from "./components/ThemeBackground";
 import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./lib/textSize";
 import { useViewportHeightVar, useWindowStatePersistence } from "./lib/windowState";
@@ -1359,10 +1359,8 @@ export default function App() {
     (settings: Pick<SettingsView, "desktopTheme" | "desktopThemeStyle" | "desktopLayoutStyle" | "desktopLanguage" | "checkUpdates" | "statusBarStyle" | "statusBarItems" | "conversationWidth">) => {
       const nextTheme = normalizeThemePreference(settings.desktopTheme);
       const nextStyle = normalizeThemeStyleForTheme(settings.desktopThemeStyle, nextTheme);
-      applyTheme(nextTheme, nextStyle, { persist: false });
+      applyConfiguredBaseAppearance(nextTheme, nextStyle);
       applyConversationWidth(settings.conversationWidth);
-      // Config appearance is the restore target for clearThemePack / restore-default.
-      setBaseAppearance(nextTheme, nextStyle);
       const nextLayoutStyle = normalizeDesktopLayoutStyle(settings.desktopLayoutStyle);
       setDesktopLayoutStyle(nextLayoutStyle);
       applyLayoutStyleDefaults(nextLayoutStyle);

--- a/desktop/frontend/src/__tests__/theme-pack.test.ts
+++ b/desktop/frontend/src/__tests__/theme-pack.test.ts
@@ -4,12 +4,15 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  applyConfiguredBaseAppearance,
   applyThemePack,
   applyThemeScene,
   beginThemePreview,
   cancelThemePreview,
   clearThemePack,
   draftPackView,
+  getActiveThemePack,
+  getBaseAppearance,
   isSafeBackgroundURL,
   isSafeHex,
   isThemeTokenKey,
@@ -273,6 +276,20 @@ clearThemePack();
 ok(!attrs.has("data-theme-pack"), "clear removes data-theme-pack");
 ok(getThemeStyle() === "graphite", "clear restores config graphite style");
 
+// Generic settings refreshes must update the configured restore target without
+// replacing an active pack's effective style in the live DOM.
+applyThemePack(aurora);
+applyConfiguredBaseAppearance("light", "slate");
+ok(getActiveThemePack()?.id === "aurora", "settings refresh preserves the active pack");
+ok(attrs.get("data-theme-pack") === "aurora", "settings refresh preserves the pack DOM marker");
+ok(getThemeStyle() === "aurora", "settings refresh preserves the pack effective style");
+ok(
+  getBaseAppearance()?.theme === "light" && getBaseAppearance()?.style === "slate",
+  "settings refresh updates the configured restore appearance",
+);
+clearThemePack();
+ok(getThemeStyle() === "slate", "clear restores the configured appearance after settings refresh");
+
 // React owners must not replace the configured base style with a pack's
 // effective style. Direct reset entry points depend on this restore snapshot.
 const activeAuroraExperience = {
@@ -361,7 +378,7 @@ ok(
 ok(themeBgSlice.includes(".theme-bg__overlay"), "overlay wash element styled");
 ok(appSource.includes("applyThemeScene"), "App wires scene from session content");
 ok(appSource.includes("ThemeBackground"), "App mounts background layer");
-ok(appSource.includes("setBaseAppearance"), "App seeds base appearance from config");
+ok(appSource.includes("applyConfiguredBaseAppearance"), "App applies configured appearance without replacing an active pack");
 ok(appSource.includes("ResetThemePack") || appSource.includes("theme reset") || appSource.includes('arg === "reset"'), "reset entry exists");
 
 console.log("\nofficial themes (kind/grouping/i18n)");

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -53,7 +53,7 @@ import {
 } from "../lib/keyboardShortcuts";
 import type { BotAccessView, BotAllowlistView, BotConnectionDiagnostic, BotConnectionView, BotInstallStartResult, BotRouteView, BotSettingsView, HookConfigView, HooksSettingsView, NetworkView, ProviderPresetView, ProviderView, SettingsTab, SettingsView } from "../lib/types";
 import { AppearanceOverview } from "./AppearanceOverview";
-import { applyThemePack, getActiveThemePack, setBaseAppearance } from "../lib/themePack";
+import { applyConfiguredBaseAppearance, setBaseAppearance } from "../lib/themePack";
 import { InlineConfirmButton } from "./InlineConfirmButton";
 import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
@@ -297,11 +297,8 @@ export function SettingsPanel({
                       customFontName={customFontName}
                       customMonoFontName={customMonoFontName}
                       onTheme={(nextTheme) => {
-                        applyTheme(nextTheme, themeStyle, { persist: false });
+                        applyConfiguredBaseAppearance(nextTheme, themeStyle);
                         setThemeState(nextTheme);
-                        setBaseAppearance(nextTheme, themeStyle);
-                        const pack = getActiveThemePack();
-                        if (pack) applyThemePack(pack);
                         void apply(() => app.SetDesktopAppearance(nextTheme, themeStyle));
                       }}
                       onConversationWidth={(width) => {

--- a/desktop/frontend/src/lib/themePack.ts
+++ b/desktop/frontend/src/lib/themePack.ts
@@ -216,6 +216,17 @@ export function setBaseAppearance(theme: Theme, style: ThemeStyle): void {
   baseAppearance = { theme, style };
 }
 
+/**
+ * Apply a configured appearance without replacing an active pack's live base
+ * style. The configured values remain the restore target when the pack is
+ * cleared, while the pack continues to own the effective visual direction.
+ */
+export function applyConfiguredBaseAppearance(theme: Theme, style: ThemeStyle): void {
+  setBaseAppearance(theme, style);
+  applyTheme(theme, style, { persist: false });
+  if (activePack) applyThemePack(activePack);
+}
+
 /** Apply or clear the active theme pack overlay. Pass null only clears overlay attrs — prefer clearThemePack(). */
 export function applyThemePack(pack: ThemePackView | null | undefined, options?: { preview?: boolean }): void {
   if (typeof document === "undefined") return;


### PR DESCRIPTION
## Summary

This follow-up fixes the theme palette regression reported after #6590: saving conversation width or another desktop setting could keep the theme pack selected while replacing its effective base palette in the live UI.

本后续修复解决 #6590 合并后报告的主题配色回退：保存会话宽度或其他桌面设置时，主题包仍显示为启用，但实时界面的基础配色会被配置中的恢复配色覆盖。

## Root cause

The generic settings refresh reapplied the configured base appearance after every save, but it did not reapply the active theme pack. The persisted theme pack was not modified; only the effective DOM style was overwritten.

## Fix

- Add one theme-pack-owned helper that updates the configured restore appearance and then reapplies the active pack.
- Use it in the generic desktop preference refresh path and the direct theme-mode path.
- Add a behavior regression test covering active-pack preservation and correct restoration after the pack is cleared.

## Compatibility

- Shared desktop frontend: macOS, Windows, and Linux.
- All desktop layout styles use the corrected preference refresh path.
- No settings schema, persisted theme-pack format, cache, or backend behavior changes.
- Disabling a pack still restores the latest configured base appearance.

## Verification

- Theme-pack contract test: 237 passed, 0 failed.
- Full frontend test suite passed.
- TypeScript typecheck passed.
- CSS checks passed.
- Production frontend build passed.
- Browser regression: applied Spark Notebook, switched conversation width from Standard to Full, and confirmed the active pack marker and Aurora effective style remained unchanged; no console errors.

Cache impact: none.
Cache guard: full frontend tests and production build.
System-prompt review: N/A.

Reported by @HaoyueQin in #6590.