### PR TITLE
fix(permission): 裸名规则自动匹配 bash，比如"git status" 。

### DIFF
--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -177,6 +177,16 @@ func (p Policy) DecideSubject(toolName string, readOnly bool, subject string) De
 			return Ask
 		case matchAny(p.Allow, toolName, subject):
 			return Allow
+		// Fallback: bare-name rules like "git status" or "rm" that were
+		// entered without a Bash() wrapper. They are parsed as
+		// Rule{Tool: "git status"} and don't match "bash" via
+		// ruleToolMatches. Treat them as Bash(git status:*) prefix rules.
+		case matchAnyBareNameAsBash(p.Deny, subject):
+			return Deny
+		case matchAnyBareNameAsBash(p.Ask, subject):
+			return Ask
+		case matchAnyBareNameAsBash(p.Allow, subject):
+			return Allow
 		}
 		if parts := DecomposeBashCommand(subject); parts != nil {
 			return p.decideBashSegments(readOnly, parts)
@@ -269,6 +279,33 @@ func (p Policy) DecideSubjects(toolName string, readOnly bool, subjects []string
 
 // matchAny reports whether any rule matches the (toolName, subject) pair. A
 // subject-specific rule cannot match a call that exposes no subject.
+// matchAnyBareNameAsBash checks whether any bare-name rule (no subject,
+// unknown tool family) matches the given bash command by treating the rule's
+// tool name as a bash command prefix. For example, a rule string "git status"
+// is parsed as Rule{Tool: "git status"}, which doesn't match "bash" via
+// ruleToolMatches. This function matches it by checking whether the actual
+// bash command starts with "git status".
+func matchAnyBareNameAsBash(rules []Rule, subject string) bool {
+	if subject == "" {
+		return false
+	}
+	for _, r := range rules {
+		if r.Subject != "" {
+			continue
+		}
+		if canonicalRuleTool(r.Tool) != r.Tool {
+			continue
+		}
+		if IsFileMutationTool(r.Tool) {
+			continue
+		}
+		if bashPrefixMatches(r.Tool, subject) {
+			return true
+		}
+	}
+	return false
+}
+
 func matchAny(rules []Rule, toolName, subject string) bool {
 	for _, r := range rules {
 		if !ruleToolMatches(r.Tool, toolName) {

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -460,3 +460,60 @@ func TestLegacyLiteralRuleMatchesExactly(t *testing.T) {
 		t.Errorf("literal rule wildcard-matched %q — '*' must stay literal", "rm secrets.log")
 	}
 }
+
+func TestBareNameRulesMatchBash(t *testing.T) {
+	// Simulate rules entered as bare tool names (without Bash() wrapper).
+	// These are common in desktop UI-generated configs and should be
+	// treated as Bash(prefix:*) prefix rules.
+
+	t.Run("deny bare rm", func(t *testing.T) {
+		p := New("ask", nil, nil, []string{"rm"})
+		if got := p.DecideSubject("bash", false, "rm secrets.log"); got != Deny {
+			t.Errorf("bare 'rm' deny should match 'rm secrets.log', got %v", got)
+		}
+		// Different command should not match.
+		if got := p.DecideSubject("bash", false, "ls -la"); got == Deny {
+			t.Errorf("bare 'rm' deny should NOT match 'ls -la', got Deny")
+		}
+	})
+
+	t.Run("allow bare git status prefix", func(t *testing.T) {
+		p := New("ask", []string{"git status"}, nil, nil)
+		if got := p.DecideSubject("bash", false, "git status"); got != Allow {
+			t.Errorf("bare 'git status' allow should match exact command, got %v", got)
+		}
+		if got := p.DecideSubject("bash", false, "git status --porcelain"); got != Allow {
+			t.Errorf("bare 'git status' allow should match prefix 'git status --porcelain', got %v", got)
+		}
+		// Substring that is not a field-prefix should not match.
+		if got := p.DecideSubject("bash", false, "git stash"); got == Allow {
+			t.Errorf("bare 'git status' allow should NOT match 'git stash', got Allow")
+		}
+	})
+
+	t.Run("deny beats bare allow", func(t *testing.T) {
+		p := New("ask", []string{"go test"}, nil, []string{"go test -race"})
+		if got := p.DecideSubject("bash", false, "go test -race"); got != Deny {
+			t.Errorf("deny should beat allow for bare-name rules, got %v", got)
+		}
+	})
+
+	t.Run("bare name does not affect non-bash tools", func(t *testing.T) {
+		// A bare name like "rm" should not match the write_file tool.
+		p := New("ask", nil, nil, []string{"rm"})
+		if got := p.DecideSubject("write_file", false, "test.txt"); got == Deny {
+			t.Errorf("bare 'rm' deny should NOT affect write_file, got Deny")
+		}
+	})
+
+	t.Run("Bash-format rule still works", func(t *testing.T) {
+		// Ensure the normal Bash(prefix:*) format still works alongside bare names.
+		p := New("ask", []string{"Bash(go test:*)"}, nil, []string{"rm"})
+		if got := p.DecideSubject("bash", false, "go test -v"); got != Allow {
+			t.Errorf("Bash(go test:*) allow should match, got %v", got)
+		}
+		if got := p.DecideSubject("bash", false, "rm -rf /"); got != Deny {
+			t.Errorf("bare 'rm' deny should match, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`:  `low`, 极小。 2 文件，+45 行（permission.go）+ 49 行测试。只改 bash 权限判定的一条回退路径。
- `Cache-guard`: 规则 "git status" 被解析为 Rule{Tool:"git status", Subject:""}，不匹配任何工具名。现在当 bash 调用无法匹配时，会把这些裸名改为 Bash 前缀规则重新匹配。
- `System-prompt-review`: 跳过带有 Bash(...) 或 file_mutation 别名的规则（这些由正常路径处理），跳过已知的文件变更工具名（IsFileMutationTool），并且不改变非 bash 工具的匹配行为。