### PR TITLE
feat(tool): add JSON formatting built-in tool

### DIFF
--- a/internal/tool/builtin/json_format.go
+++ b/internal/tool/builtin/json_format.go
@@ -1,0 +1,96 @@
+// Package builtin provides Reasonix's compile-time built-in tools.
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(jsonFormatTool{}) }
+
+// jsonFormatTool pretty-prints or minifies JSON. It reads from a file
+// (input_file) or stdin and writes the formatted JSON to stdout. It is
+// read-only: it never writes to disk.
+type jsonFormatTool struct{}
+
+func (jsonFormatTool) Name() string { return "json_format" }
+
+func (jsonFormatTool) Description() string {
+	return "Pretty-print or minify JSON. Reads from input_file (or stdin if omitted) and returns formatted JSON. Use indent to control spacing (0 compacts to one line, default 2). Use minify to collapse to a single line."
+}
+
+func (jsonFormatTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "input_file":{"type":"string","description":"Path to a JSON file to read. Omit to read from stdin."},
+  "indent":{"type":"integer","description":"Spaces per indent level (0-8, default 2). Ignored when minify is true.","minimum":0,"maximum":8},
+  "minify":{"type":"boolean","description":"Collapse the JSON into a single line (default false)."}
+}
+}`)
+}
+
+func (jsonFormatTool) ReadOnly() bool { return true }
+
+// SnipHint keeps a generous head and tail so JSON is readable when truncated.
+func (jsonFormatTool) SnipHint() tool.SnipHint {
+	return tool.SnipHint{Head: 200, Tail: 40, HeadChars: 20000, TailChars: 4000}
+}
+
+func (jsonFormatTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		InputFile string `json:"input_file"`
+		Indent    int    `json:"indent"`
+		Minify    bool   `json:"minify"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Indent < 0 {
+		p.Indent = 2
+	}
+	if p.Indent > 8 {
+		p.Indent = 8
+	}
+
+	var raw []byte
+	if p.InputFile != "" {
+		b, err := os.ReadFile(p.InputFile)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", p.InputFile, err)
+		}
+		raw = b
+	} else {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		raw = b
+	}
+
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	if p.Minify {
+		out, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshal: %w", err)
+		}
+		return string(out), nil
+	}
+
+	indent := strings.Repeat(" ", p.Indent)
+	out, err := json.MarshalIndent(v, "", indent)
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/tool/builtin/json_format_test.go
+++ b/internal/tool/builtin/json_format_test.go
@@ -1,0 +1,102 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestJsonFormatToolName(t *testing.T) {
+	tool := jsonFormatTool{}
+	if got, want := tool.Name(), "json_format"; got != want {
+		t.Fatalf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestJsonFormatToolReadOnly(t *testing.T) {
+	tool := jsonFormatTool{}
+	if !tool.ReadOnly() {
+		t.Fatal("ReadOnly() = false, want true")
+	}
+}
+
+func TestJsonFormatToolExecute(t *testing.T) {
+	tool := jsonFormatTool{}
+
+	cases := []struct {
+		name         string
+		input        string
+		indent       int
+		minify       bool
+		wantContains string
+		wantErr      bool
+	}{
+		{
+			name:         "simple",
+			input:        `{"b":2,"a":1}`,
+			indent:       2,
+			wantContains: "\n  \"a\": 1",
+		},
+		{
+			name:         "nested",
+			input:        `{"x":{"y":{"z":true}}}`,
+			indent:       2,
+			wantContains: "    \"z\": true",
+		},
+		{
+			name:         "minify",
+			input:        `{"a":1,"b":2}`,
+			minify:       true,
+			wantContains: `{"a":1,"b":2}`,
+		},
+		{
+			name:         "indent_zero",
+			input:        `{"a":1}`,
+			indent:       0,
+			wantContains: "\"a\": 1",
+		},
+		{
+			name:    "invalid_json",
+			input:   `not json`,
+			indent:  2,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := t.TempDir() + "/input.json"
+			if err := os.WriteFile(path, []byte(tc.input), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			args, err := json.Marshal(map[string]any{
+				"input_file": path,
+				"indent":     tc.indent,
+				"minify":     tc.minify,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := tool.Execute(context.Background(), args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got output: %s", out)
+				}
+				if !strings.Contains(err.Error(), "invalid JSON") {
+					t.Fatalf("expected invalid JSON error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(out, tc.wantContains) {
+				t.Fatalf("output %q does not contain %q", out, tc.wantContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add a new built-in tool `json_format` for pretty-printing or minifying JSON files.

## Verification
- Added `internal/tool/builtin/json_format.go` implementing the `Tool` interface
- Added `internal/tool/builtin/json_format_test.go` with 5 test cases
- All tests pass:
  ```bash
  go test ./internal/tool/builtin/ -run TestJsonFormat -v
## Cache impact
- **Cache-impact:** none
- **Cache-guard:** N/A (new tool, no prompt changes)

---

This is my first open-source contribution. Please let me know if anything needs improvement!
