### PR TITLE
Fix SSH host-key checks for multi-algorithm servers / 修复多算法 SSH 主机密钥误判

### DIFF
--- a/internal/remote/dial.go
+++ b/internal/remote/dial.go
@@ -124,11 +124,17 @@ func newSSHClient(ctx context.Context, conn net.Conn, host ResolvedHost, auth *A
 		conn.Close()
 		return nil, err
 	}
+	hostKeyAlgorithms, err := hostKeys.HostKeyAlgorithms(host.Addr(), conn.RemoteAddr())
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
 	clientCfg := &ssh.ClientConfig{
-		User:            host.User,
-		Auth:            methods,
-		HostKeyCallback: hkCallback,
-		Timeout:         timeout,
+		User:              host.User,
+		Auth:              methods,
+		HostKeyCallback:   hkCallback,
+		HostKeyAlgorithms: hostKeyAlgorithms,
+		Timeout:           timeout,
 	}
 	// Bound the handshake even for ProxyJump channel connections, whose
 	// SetDeadline method returns "deadline not supported". A watcher closes the

--- a/internal/remote/knownhosts.go
+++ b/internal/remote/knownhosts.go
@@ -1,6 +1,8 @@
 package remote
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -73,10 +75,11 @@ func (p *HostKeyPolicy) Callback(ctx context.Context, host string) (ssh.HostKeyC
 	}, nil
 }
 
-// HostKeyAlgorithms returns the secure host-key algorithms in negotiation
-// order, preferring algorithms compatible with keys already recorded for
-// hostname. The strict callback remains the authority: this only steers key
-// exchange toward a known identity on servers that expose multiple host keys.
+// HostKeyAlgorithms returns host-key algorithms in negotiation order,
+// preferring algorithms compatible with ordinary host identities already
+// recorded for hostname. Certificate-authority records are deliberately not
+// treated as host keys: the CA algorithm does not describe the certified host
+// key. The strict callback remains the authority for every negotiated key.
 func (p *HostKeyPolicy) HostKeyAlgorithms(hostname string, remote net.Addr) ([]string, error) {
 	base, _, err := p.loadCallback()
 	if err != nil || base == nil {
@@ -99,19 +102,31 @@ func (p *HostKeyPolicy) HostKeyAlgorithms(hostname string, remote net.Addr) ([]s
 		if known.Key == nil {
 			continue
 		}
+		marker, err := knownHostMarker(known)
+		if err != nil {
+			return nil, err
+		}
+		if marker != "" {
+			continue
+		}
 		keyType := known.Key.Type()
 		preferred[keyType] = true
-		if keyType == ssh.KeyAlgoRSA {
+		switch keyType {
+		case ssh.KeyAlgoRSA:
 			// An ssh-rsa public key can use the SHA-2 signature algorithms;
-			// do not re-enable the insecure SHA-1 ssh-rsa algorithm.
 			preferred[ssh.KeyAlgoRSASHA512] = true
 			preferred[ssh.KeyAlgoRSASHA256] = true
+		case ssh.CertAlgoRSAv01:
+			// RSA host certificates likewise support SHA-2 signature
+			// algorithms even though their public key format is ssh-rsa.
+			preferred[ssh.CertAlgoRSASHA512v01] = true
+			preferred[ssh.CertAlgoRSASHA256v01] = true
 		}
 	}
 
-	supported := ssh.SupportedAlgorithms().HostKeys
-	ordered := make([]string, 0, len(supported))
-	for _, algorithm := range supported {
+	candidates := hostKeyAlgorithmCandidates()
+	ordered := make([]string, 0, len(candidates))
+	for _, algorithm := range candidates {
 		if preferred[algorithm] {
 			ordered = append(ordered, algorithm)
 		}
@@ -119,12 +134,64 @@ func (p *HostKeyPolicy) HostKeyAlgorithms(hostname string, remote net.Addr) ([]s
 	if len(ordered) == 0 {
 		return nil, nil
 	}
-	for _, algorithm := range supported {
+	for _, algorithm := range candidates {
 		if !preferred[algorithm] {
 			ordered = append(ordered, algorithm)
 		}
 	}
 	return ordered, nil
+}
+
+// hostKeyAlgorithmCandidates preserves the algorithms in the Go SSH default
+// policy while keeping secure algorithms ahead of legacy fallbacks. Legacy
+// algorithms are only promoted when their exact public key format is already
+// recorded; the host-key callback must still verify the key material.
+func hostKeyAlgorithmCandidates() []string {
+	secure := ssh.SupportedAlgorithms().HostKeys
+	legacy := ssh.InsecureAlgorithms().HostKeys
+	algorithms := make([]string, 0, len(secure)+len(legacy))
+	seen := make(map[string]bool, cap(algorithms))
+	for _, algorithm := range append(secure, legacy...) {
+		if !seen[algorithm] {
+			seen[algorithm] = true
+			algorithms = append(algorithms, algorithm)
+		}
+	}
+	return algorithms
+}
+
+// knownHostMarker reads the original matching record so @cert-authority and
+// @revoked entries cannot be mistaken for ordinary host identities. KnownKey
+// exposes the exact file and line selected by knownhosts.New; ParseKnownHosts
+// supplies OpenSSH marker semantics without duplicating its parser.
+func knownHostMarker(known knownhosts.KnownKey) (string, error) {
+	if known.Filename == "" || known.Line <= 0 {
+		return "", fmt.Errorf("known_hosts record has no source location")
+	}
+	f, err := os.Open(known.Filename)
+	if err != nil {
+		return "", fmt.Errorf("open known_hosts record %s:%d: %w", known.Filename, known.Line, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for line := 1; scanner.Scan(); line++ {
+		if line != known.Line {
+			continue
+		}
+		marker, _, key, _, _, err := ssh.ParseKnownHosts(scanner.Bytes())
+		if err != nil {
+			return "", fmt.Errorf("parse known_hosts record %s:%d: %w", known.Filename, known.Line, err)
+		}
+		if key == nil || known.Key == nil || !bytes.Equal(key.Marshal(), known.Key.Marshal()) {
+			return "", fmt.Errorf("known_hosts record changed while connecting: %s:%d", known.Filename, known.Line)
+		}
+		return marker, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read known_hosts record %s:%d: %w", known.Filename, known.Line, err)
+	}
+	return "", fmt.Errorf("known_hosts record no longer exists: %s:%d", known.Filename, known.Line)
 }
 
 // hostKeyLookupProbe deliberately cannot equal a parsed OpenSSH public key.

--- a/internal/remote/knownhosts.go
+++ b/internal/remote/knownhosts.go
@@ -46,29 +46,9 @@ type HostKeyPolicy struct {
 // Callback builds an ssh.HostKeyCallback enforcing this policy for host (the
 // display label used in prompts). ctx bounds any interactive prompt.
 func (p *HostKeyPolicy) Callback(ctx context.Context, host string) (ssh.HostKeyCallback, error) {
-	files := p.systemFiles()
-	managed := p.managedPath()
-	if managed != "" {
-		if err := os.MkdirAll(filepath.Dir(managed), 0o700); err != nil {
-			return nil, err
-		}
-		// knownhosts.New requires each file to exist; create an empty managed
-		// file on first use.
-		if _, err := os.Stat(managed); os.IsNotExist(err) {
-			if err := os.WriteFile(managed, nil, 0o600); err != nil {
-				return nil, err
-			}
-		}
-		files = append(files, managed)
-	}
-
-	var base ssh.HostKeyCallback
-	if len(files) > 0 {
-		var err error
-		base, err = knownhosts.New(files...)
-		if err != nil {
-			return nil, fmt.Errorf("load known_hosts: %w", err)
-		}
+	base, managed, err := p.loadCallback()
+	if err != nil {
+		return nil, err
 	}
 
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
@@ -81,28 +61,109 @@ func (p *HostKeyPolicy) Callback(ctx context.Context, host string) (ssh.HostKeyC
 			if !asKeyError(err, &keyErr) {
 				return err
 			}
-			if hasKnownKeyType(keyErr, key.Type()) {
-				// The same key algorithm is already on record with different
-				// material: hard fail, never promptable. Keys of another
-				// algorithm are independent host identities and go through the
-				// normal TOFU confirmation below.
+			if len(keyErr.Want) > 0 {
+				// A different key is on record for this host: hard fail, never
+				// promptable. Name the file:line so the user can inspect it.
 				return fmt.Errorf("%w for %s: presented %s; known_hosts records a different key%s",
 					ErrHostKeyMismatch, host, ssh.FingerprintSHA256(key), knownHostsLocations(keyErr))
 			}
-			// No record, or records only for other algorithms: fall through
-			// to TOFU so the user can inspect and persist this key type.
+			// len(Want)==0 => host unknown. Fall through to TOFU.
 		}
 		return p.tofu(ctx, host, hostname, remote, key, managed)
 	}, nil
 }
 
-func hasKnownKeyType(e *knownhosts.KeyError, keyType string) bool {
-	for _, known := range e.Want {
-		if known.Key != nil && known.Key.Type() == keyType {
-			return true
+// HostKeyAlgorithms returns the secure host-key algorithms in negotiation
+// order, preferring algorithms compatible with keys already recorded for
+// hostname. The strict callback remains the authority: this only steers key
+// exchange toward a known identity on servers that expose multiple host keys.
+func (p *HostKeyPolicy) HostKeyAlgorithms(hostname string, remote net.Addr) ([]string, error) {
+	base, _, err := p.loadCallback()
+	if err != nil || base == nil {
+		return nil, err
+	}
+	err = base(hostname, remote, hostKeyLookupProbe{})
+	if err == nil {
+		return nil, nil
+	}
+	var keyErr *knownhosts.KeyError
+	if !asKeyError(err, &keyErr) {
+		return nil, err
+	}
+	if len(keyErr.Want) == 0 {
+		return nil, nil
+	}
+
+	preferred := make(map[string]bool, len(keyErr.Want))
+	for _, known := range keyErr.Want {
+		if known.Key == nil {
+			continue
+		}
+		keyType := known.Key.Type()
+		preferred[keyType] = true
+		if keyType == ssh.KeyAlgoRSA {
+			// An ssh-rsa public key can use the SHA-2 signature algorithms;
+			// do not re-enable the insecure SHA-1 ssh-rsa algorithm.
+			preferred[ssh.KeyAlgoRSASHA512] = true
+			preferred[ssh.KeyAlgoRSASHA256] = true
 		}
 	}
-	return false
+
+	supported := ssh.SupportedAlgorithms().HostKeys
+	ordered := make([]string, 0, len(supported))
+	for _, algorithm := range supported {
+		if preferred[algorithm] {
+			ordered = append(ordered, algorithm)
+		}
+	}
+	if len(ordered) == 0 {
+		return nil, nil
+	}
+	for _, algorithm := range supported {
+		if !preferred[algorithm] {
+			ordered = append(ordered, algorithm)
+		}
+	}
+	return ordered, nil
+}
+
+// hostKeyLookupProbe deliberately cannot equal a parsed OpenSSH public key.
+// Passing it through knownhosts.New lets us reuse the library's exact hostname,
+// wildcard, hashed-host, port, and file matching and inspect KeyError.Want.
+type hostKeyLookupProbe struct{}
+
+func (hostKeyLookupProbe) Type() string    { return "reasonix-host-key-lookup-probe" }
+func (hostKeyLookupProbe) Marshal() []byte { return []byte("reasonix-host-key-lookup-probe") }
+func (hostKeyLookupProbe) Verify([]byte, *ssh.Signature) error {
+	return fmt.Errorf("host-key lookup probe cannot verify signatures")
+}
+
+func (p *HostKeyPolicy) loadCallback() (ssh.HostKeyCallback, string, error) {
+	files := p.systemFiles()
+	managed := p.managedPath()
+	if managed != "" {
+		if err := os.MkdirAll(filepath.Dir(managed), 0o700); err != nil {
+			return nil, "", err
+		}
+		// knownhosts.New requires each file to exist; create an empty managed
+		// file on first use.
+		if _, err := os.Stat(managed); os.IsNotExist(err) {
+			if err := os.WriteFile(managed, nil, 0o600); err != nil {
+				return nil, "", err
+			}
+		}
+		files = append(files, managed)
+	}
+
+	var base ssh.HostKeyCallback
+	if len(files) > 0 {
+		var err error
+		base, err = knownhosts.New(files...)
+		if err != nil {
+			return nil, "", fmt.Errorf("load known_hosts: %w", err)
+		}
+	}
+	return base, managed, nil
 }
 
 func (p *HostKeyPolicy) tofu(ctx context.Context, host, hostname string, remote net.Addr, key ssh.PublicKey, managed string) error {

--- a/internal/remote/knownhosts.go
+++ b/internal/remote/knownhosts.go
@@ -81,16 +81,28 @@ func (p *HostKeyPolicy) Callback(ctx context.Context, host string) (ssh.HostKeyC
 			if !asKeyError(err, &keyErr) {
 				return err
 			}
-			if len(keyErr.Want) > 0 {
-				// A different key is on record for this host: hard fail, never
-				// promptable. Name the file:line so the user can inspect it.
+			if hasKnownKeyType(keyErr, key.Type()) {
+				// The same key algorithm is already on record with different
+				// material: hard fail, never promptable. Keys of another
+				// algorithm are independent host identities and go through the
+				// normal TOFU confirmation below.
 				return fmt.Errorf("%w for %s: presented %s; known_hosts records a different key%s",
 					ErrHostKeyMismatch, host, ssh.FingerprintSHA256(key), knownHostsLocations(keyErr))
 			}
-			// len(Want)==0 => host unknown. Fall through to TOFU.
+			// No record, or records only for other algorithms: fall through
+			// to TOFU so the user can inspect and persist this key type.
 		}
 		return p.tofu(ctx, host, hostname, remote, key, managed)
 	}, nil
+}
+
+func hasKnownKeyType(e *knownhosts.KeyError, keyType string) bool {
+	for _, known := range e.Want {
+		if known.Key != nil && known.Key.Type() == keyType {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *HostKeyPolicy) tofu(ctx context.Context, host, hostname string, remote net.Addr, key ssh.PublicKey, managed string) error {

--- a/internal/remote/knownhosts_test.go
+++ b/internal/remote/knownhosts_test.go
@@ -1,0 +1,128 @@
+package remote
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func TestHostKeyPolicyPromptsForNewKeyAlgorithm(t *testing.T) {
+	hostname := "example.test:2222"
+	knownED25519 := generateED25519Signer(t)
+	presentedECDSA := generateECDSASigner(t)
+	systemPath := filepath.Join(t.TempDir(), "known_hosts")
+	managedPath := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHost(t, systemPath, hostname, knownED25519.PublicKey())
+
+	prompted := 0
+	policy := &HostKeyPolicy{
+		SystemKnownHosts: []string{systemPath},
+		ManagedPath:      managedPath,
+		Prompt: func(_ context.Context, q HostKeyQuestion) (bool, error) {
+			prompted++
+			if q.KeyType != presentedECDSA.PublicKey().Type() {
+				t.Fatalf("prompt key type = %q, want %q", q.KeyType, presentedECDSA.PublicKey().Type())
+			}
+			return true, nil
+		},
+	}
+
+	callback, err := policy.Callback(context.Background(), "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteAddr := &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 2222}
+	if err := callback(hostname, remoteAddr, presentedECDSA.PublicKey()); err != nil {
+		t.Fatalf("new key algorithm: %v", err)
+	}
+	if prompted != 1 {
+		t.Fatalf("prompt count = %d, want 1", prompted)
+	}
+
+	// The accepted algorithm is persisted, so a fresh callback trusts the same
+	// key without prompting again.
+	callback, err = policy.Callback(context.Background(), "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := callback(hostname, remoteAddr, presentedECDSA.PublicKey()); err != nil {
+		t.Fatalf("persisted key algorithm: %v", err)
+	}
+	if prompted != 1 {
+		t.Fatalf("persisted key re-prompted; count = %d", prompted)
+	}
+}
+
+func TestHostKeyPolicyRejectsChangedKeyOfSameAlgorithm(t *testing.T) {
+	hostname := "example.test:2222"
+	knownKey := generateED25519Signer(t)
+	presentedKey := generateED25519Signer(t)
+	systemPath := filepath.Join(t.TempDir(), "known_hosts")
+	managedPath := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHost(t, systemPath, hostname, knownKey.PublicKey())
+
+	prompted := false
+	policy := &HostKeyPolicy{
+		SystemKnownHosts: []string{systemPath},
+		ManagedPath:      managedPath,
+		Prompt: func(context.Context, HostKeyQuestion) (bool, error) {
+			prompted = true
+			return true, nil
+		},
+	}
+	callback, err := policy.Callback(context.Background(), "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = callback(hostname, &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 2222}, presentedKey.PublicKey())
+	if !errors.Is(err, ErrHostKeyMismatch) {
+		t.Fatalf("error = %v, want ErrHostKeyMismatch", err)
+	}
+	if prompted {
+		t.Fatal("same-algorithm mismatch must not be promptable")
+	}
+}
+
+func writeKnownHost(t *testing.T, path, hostname string, key ssh.PublicKey) {
+	t.Helper()
+	line := knownhosts.Line([]string{knownhosts.Normalize(hostname)}, key)
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func generateED25519Signer(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}
+
+func generateECDSASigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}

--- a/internal/remote/knownhosts_test.go
+++ b/internal/remote/knownhosts_test.go
@@ -11,12 +11,51 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
+	"reasonix/internal/remote/sshtest"
 )
 
-func TestHostKeyPolicyPromptsForNewKeyAlgorithm(t *testing.T) {
+func TestNewSSHClientPrefersRecordedHostKeyAlgorithm(t *testing.T) {
+	knownED25519 := generateED25519Signer(t)
+	otherECDSA := generateECDSASigner(t)
+	server := sshtest.Start(t, sshtest.Options{
+		HostKeys: []ssh.Signer{otherECDSA, knownED25519},
+	})
+	systemPath := filepath.Join(t.TempDir(), "known_hosts")
+	managedPath := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHost(t, systemPath, server.Addr, knownED25519.PublicKey())
+
+	policy := &HostKeyPolicy{
+		SystemKnownHosts: []string{systemPath},
+		ManagedPath:      managedPath,
+		Prompt: func(context.Context, HostKeyQuestion) (bool, error) {
+			t.Fatal("known multi-algorithm host must not prompt")
+			return false, nil
+		},
+	}
+
+	_, hostName, port, err := ParseTarget(server.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.DialTimeout("tcp", server.Addr, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := newSSHClient(context.Background(), conn, ResolvedHost{
+		Name: server.Addr, HostName: hostName, Port: port, User: "test",
+	}, &AuthOptions{DisableAgent: true}, policy, time.Second)
+	if err != nil {
+		t.Fatalf("connect to multi-algorithm host: %v", err)
+	}
+	defer client.Close()
+}
+
+func TestHostKeyPolicyRejectsChangedKeyAcrossAlgorithms(t *testing.T) {
 	hostname := "example.test:2222"
 	knownED25519 := generateED25519Signer(t)
 	presentedECDSA := generateECDSASigner(t)
@@ -24,42 +63,25 @@ func TestHostKeyPolicyPromptsForNewKeyAlgorithm(t *testing.T) {
 	managedPath := filepath.Join(t.TempDir(), "known_hosts")
 	writeKnownHost(t, systemPath, hostname, knownED25519.PublicKey())
 
-	prompted := 0
+	prompted := false
 	policy := &HostKeyPolicy{
 		SystemKnownHosts: []string{systemPath},
 		ManagedPath:      managedPath,
-		Prompt: func(_ context.Context, q HostKeyQuestion) (bool, error) {
-			prompted++
-			if q.KeyType != presentedECDSA.PublicKey().Type() {
-				t.Fatalf("prompt key type = %q, want %q", q.KeyType, presentedECDSA.PublicKey().Type())
-			}
+		Prompt: func(context.Context, HostKeyQuestion) (bool, error) {
+			prompted = true
 			return true, nil
 		},
 	}
-
 	callback, err := policy.Callback(context.Background(), "example")
 	if err != nil {
 		t.Fatal(err)
 	}
-	remoteAddr := &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 2222}
-	if err := callback(hostname, remoteAddr, presentedECDSA.PublicKey()); err != nil {
-		t.Fatalf("new key algorithm: %v", err)
+	err = callback(hostname, &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 2222}, presentedECDSA.PublicKey())
+	if !errors.Is(err, ErrHostKeyMismatch) {
+		t.Fatalf("error = %v, want ErrHostKeyMismatch", err)
 	}
-	if prompted != 1 {
-		t.Fatalf("prompt count = %d, want 1", prompted)
-	}
-
-	// The accepted algorithm is persisted, so a fresh callback trusts the same
-	// key without prompting again.
-	callback, err = policy.Callback(context.Background(), "example")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := callback(hostname, remoteAddr, presentedECDSA.PublicKey()); err != nil {
-		t.Fatalf("persisted key algorithm: %v", err)
-	}
-	if prompted != 1 {
-		t.Fatalf("persisted key re-prompted; count = %d", prompted)
+	if prompted {
+		t.Fatal("cross-algorithm mismatch must not be promptable")
 	}
 }
 

--- a/internal/remote/knownhosts_test.go
+++ b/internal/remote/knownhosts_test.go
@@ -6,10 +6,13 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,20 +41,75 @@ func TestNewSSHClientPrefersRecordedHostKeyAlgorithm(t *testing.T) {
 		},
 	}
 
-	_, hostName, port, err := ParseTarget(server.Addr)
+	client := connectTestServer(t, server, policy)
+	defer client.Close()
+}
+
+func TestNewSSHClientReconnectsToRecordedLegacyRSAHost(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn, err := net.DialTimeout("tcp", server.Addr, time.Second)
+	signer, err := ssh.NewSignerFromKey(privateKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := newSSHClient(context.Background(), conn, ResolvedHost{
-		Name: server.Addr, HostName: hostName, Port: port, User: "test",
-	}, &AuthOptions{DisableAgent: true}, policy, time.Second)
+	restricted, err := ssh.NewSignerWithAlgorithms(signer.(ssh.AlgorithmSigner), []string{ssh.KeyAlgoRSA})
 	if err != nil {
-		t.Fatalf("connect to multi-algorithm host: %v", err)
+		t.Fatal(err)
 	}
+	server := sshtest.Start(t, sshtest.Options{HostKeys: []ssh.Signer{restricted}})
+	prompted := 0
+	policy := &HostKeyPolicy{
+		SystemKnownHosts: []string{filepath.Join(t.TempDir(), "missing")},
+		ManagedPath:      filepath.Join(t.TempDir(), "known_hosts"),
+		Prompt: func(context.Context, HostKeyQuestion) (bool, error) {
+			prompted++
+			return true, nil
+		},
+	}
+
+	client := connectTestServer(t, server, policy)
+	_ = client.Close()
+	client = connectTestServer(t, server, policy)
+	defer client.Close()
+	if prompted != 1 {
+		t.Fatalf("prompt count = %d, want 1", prompted)
+	}
+}
+
+func TestNewSSHClientPrefersTrustedHostCertificate(t *testing.T) {
+	caSigner := generateED25519Signer(t)
+	hostSigner := generateECDSASigner(t)
+	certificate := &ssh.Certificate{
+		Key:             hostSigner.PublicKey(),
+		CertType:        ssh.HostCert,
+		ValidPrincipals: []string{"127.0.0.1"},
+		ValidBefore:     ssh.CertTimeInfinity,
+	}
+	if err := certificate.SignCert(rand.Reader, caSigner); err != nil {
+		t.Fatal(err)
+	}
+	certificateSigner, err := ssh.NewCertSigner(certificate, hostSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherED25519 := generateED25519Signer(t)
+	server := sshtest.Start(t, sshtest.Options{
+		HostKeys: []ssh.Signer{otherED25519, certificateSigner},
+	})
+	systemPath := filepath.Join(t.TempDir(), "known_hosts")
+	writeKnownHostAuthority(t, systemPath, server.Addr, caSigner.PublicKey())
+	policy := &HostKeyPolicy{
+		SystemKnownHosts: []string{systemPath},
+		ManagedPath:      filepath.Join(t.TempDir(), "known_hosts"),
+		Prompt: func(context.Context, HostKeyQuestion) (bool, error) {
+			t.Fatal("certified host must not prompt")
+			return false, nil
+		},
+	}
+
+	client := connectTestServer(t, server, policy)
 	defer client.Close()
 }
 
@@ -121,6 +179,34 @@ func writeKnownHost(t *testing.T, path, hostname string, key ssh.PublicKey) {
 	if err := os.WriteFile(path, []byte(line+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeKnownHostAuthority(t *testing.T, path, hostname string, key ssh.PublicKey) {
+	t.Helper()
+	keyText := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(key)))
+	line := fmt.Sprintf("@cert-authority %s %s\n", knownhosts.Normalize(hostname), keyText)
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func connectTestServer(t *testing.T, server *sshtest.Server, policy *HostKeyPolicy) *ssh.Client {
+	t.Helper()
+	_, hostName, port, err := ParseTarget(server.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.DialTimeout("tcp", server.Addr, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := newSSHClient(context.Background(), conn, ResolvedHost{
+		Name: server.Addr, HostName: hostName, Port: port, User: "test",
+	}, &AuthOptions{DisableAgent: true}, policy, time.Second)
+	if err != nil {
+		t.Fatalf("connect to test SSH server: %v", err)
+	}
+	return client
 }
 
 func generateED25519Signer(t *testing.T) ssh.Signer {

--- a/internal/remote/sshtest/sshtest.go
+++ b/internal/remote/sshtest/sshtest.go
@@ -35,6 +35,9 @@ type Server struct {
 
 // Options configures a test server.
 type Options struct {
+	// HostKeys, when non-empty, are offered by the server. The first key is
+	// also exposed as Server.HostKey. Empty generates one ed25519 key.
+	HostKeys []ssh.Signer
 	// Password, when non-empty, enables password auth accepting (any user,
 	// this password).
 	Password string
@@ -49,12 +52,21 @@ type Options struct {
 // Start launches a server on 127.0.0.1:0.
 func Start(t *testing.T, opts Options) *Server {
 	t.Helper()
-	hostKey, err := generateHostKey()
-	if err != nil {
-		t.Fatalf("host key: %v", err)
+	hostKeys := opts.HostKeys
+	if len(hostKeys) == 0 {
+		hostKey, err := generateHostKey()
+		if err != nil {
+			t.Fatalf("host key: %v", err)
+		}
+		hostKeys = []ssh.Signer{hostKey}
 	}
 	cfg := &ssh.ServerConfig{}
-	cfg.AddHostKey(hostKey)
+	for _, hostKey := range hostKeys {
+		if hostKey == nil {
+			t.Fatal("host key must not be nil")
+		}
+		cfg.AddHostKey(hostKey)
+	}
 	if opts.Password != "" {
 		cfg.PasswordCallback = func(conn ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
 			if string(pass) == opts.Password {
@@ -82,7 +94,7 @@ func Start(t *testing.T, opts Options) *Server {
 	}
 	s := &Server{
 		Addr:      ln.Addr().String(),
-		HostKey:   hostKey,
+		HostKey:   hostKeys[0],
 		config:    cfg,
 		listener:  ln,
 		execFunc:  opts.Exec,


### PR DESCRIPTION
## Summary

- Prefer host-key algorithms compatible with ordinary keys already recorded for the destination before the SSH handshake.
- Keep every known-host key mismatch fail-closed and non-promptable.
- Preserve Go SSH compatibility for already trusted legacy RSA/DSA identities while keeping secure algorithms ahead of legacy fallbacks.
- Exclude `@cert-authority` and other marker records from ordinary host-key preference so trusted host certificates retain normal negotiation priority.
- Apply the same negotiation and verification path to the target and every ProxyJump hop.
- Add real multi-key, legacy reconnect, host-certificate, and mismatch regression coverage.

## Problem

SSH servers commonly expose multiple valid host keys. If known_hosts contains one algorithm but the Go SSH client negotiates another, strict verification correctly reports a mismatch even though the server can also prove the recorded identity.

Two compatibility boundaries also matter:

- Go SSH still permits explicitly trusted legacy host-key algorithms in its default policy. Removing those algorithms after a TOFU record is persisted makes an RSA-only host connect once and then fail on reconnect.
- An `@cert-authority` key identifies a signing authority, not the host key algorithm. Treating the CA key type as an ordinary host-key preference can select an unrelated raw key before a valid host certificate.

## Root cause

The Go SSH default host-key order does not use known_hosts to prefer a recorded ordinary host identity. The first implementation rebuilt the list only from secure algorithms and used `knownhosts.KeyError.Want` without recovering each record's OpenSSH marker.

## Fix

Reasonix now combines exact known_hosts matching with marker-aware algorithm ordering:

| Case | Behavior |
| --- | --- |
| Server offers a recorded ordinary host-key algorithm | Prefer and strictly verify that identity |
| Recorded RSA key or certificate | Prefer SHA-2 signatures, retain its exact legacy format as a compatibility fallback |
| `@cert-authority` record | Do not infer a host-key algorithm from the CA; retain certificate negotiation and verify the certificate through the CA callback |
| Known host presents any unrecorded key | Hard fail with `ErrHostKeyMismatch` |
| Genuinely unknown host | Use the existing fingerprint confirmation flow |
| Exact known key | Connect without prompting |

`knownhosts.New` remains responsible for hostname, port, wildcard, and hashed-host matching. Matching file/line records are parsed with `ssh.ParseKnownHosts` only to recover marker semantics. The final callback remains authoritative for all key material.

## Verification

- `go test ./internal/remote/... -count=1`
- `go vet ./internal/remote/...`
- `go test -race ./internal/remote -run "TestNewSSHClient|TestHostKeyPolicy" -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Compatibility

| Existing data | Behavior | Conclusion |
| --- | --- | --- |
| Ordinary known_hosts key | Same format; now preferred during negotiation | Compatible |
| Reasonix-managed TOFU key | Same line format and persistence path | Compatible |
| Legacy RSA/DSA key | Secure variants stay preferred; exact recorded legacy algorithm remains available | Compatible |
| `@cert-authority` record | Same CA verification; no longer misclassified as an ordinary host key | Compatible |
| Hashed, wildcard, host:port entries | Still matched by `knownhosts.New` | Compatible |

No persisted format or external public API changes.

## Cache impact

None. This change is isolated to SSH transport host-key negotiation and verification and does not affect prompts, tools, providers, memory, or request serialization.