### PR TITLE
Fix digit-leading custom provider credentials / 修复数字开头自定义 Provider 凭据

### DIFF
--- a/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
@@ -199,6 +199,12 @@ eq(
 );
 
 eq(
+  providerApiKeyEnvForSave("9router", "", "sk-test"),
+  "CUSTOM_9ROUTER_API_KEY",
+  "creates a valid key env for a digit-leading custom provider",
+);
+
+eq(
   providerApiKeyEnvForSave("Local Gateway", "GATEWAY_KEY", ""),
   "GATEWAY_KEY",
   "preserves an explicitly configured key env",
@@ -206,11 +212,12 @@ eq(
 
 eq(
   [
+    apiKeyEnvFromProviderName("9router"),
     apiKeyEnvFromProviderName("商汤"),
     apiKeyEnvFromProviderName("通义千问"),
   ],
-  ["CUSTOM_d39b9067_API_KEY", "CUSTOM_e995c4c9_API_KEY"],
-  "generates distinct stable key envs for non-ASCII provider names",
+  ["CUSTOM_9ROUTER_API_KEY", "CUSTOM_d39b9067_API_KEY", "CUSTOM_e995c4c9_API_KEY"],
+  "generates valid stable key envs for digit-leading and non-ASCII provider names",
 );
 
 eq(

--- a/desktop/frontend/src/lib/providerModels.ts
+++ b/desktop/frontend/src/lib/providerModels.ts
@@ -92,7 +92,13 @@ export function apiKeyEnvFromProviderName(name: string): string {
     .toUpperCase()
     .replace(/[^A-Z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
-  if (stem) return `${stem}_API_KEY`;
+  if (stem) {
+    // Dotenv/environment variable names cannot start with a digit. Keep the
+    // readable name while giving digit-leading providers (for example
+    // "9router") a valid, stable credential slot.
+    const validStem = /^[0-9]/.test(stem) ? `CUSTOM_${stem}` : stem;
+    return `${validStem}_API_KEY`;
+  }
   // When the provider name is entirely non-ASCII (e.g. Chinese characters),
   // generate a stable hash suffix so each custom provider gets a unique slot.
   const hash = fnv1a32(name.trim());

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -114,7 +114,9 @@ Reasonix derives the default from the provider name. Names that normalize to
 ASCII keep readable env names such as `LOCAL_GATEWAY_API_KEY`; names made
 entirely of non-ASCII characters get a stable hash suffix such as
 `CUSTOM_d39b9067_API_KEY` so two Chinese provider names do not share
-`CUSTOM_API_KEY`.
+`CUSTOM_API_KEY`. Names beginning with a digit get a `CUSTOM_` prefix so the
+generated environment variable remains valid; for example, `9router` becomes
+`CUSTOM_9ROUTER_API_KEY`.
 
 In the CLI custom-provider wizard, the provider name is generated from the base
 URL first, then the same provider-name rule is applied. For example

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -98,7 +98,8 @@ CJK 双宽字符；如果偏好其它形状，可以设为 `block` 或 `underlin
 Reasonix 会根据 provider 名称生成默认值。能规范化成 ASCII 的名称会得到可读的
 env 名，例如 `LOCAL_GATEWAY_API_KEY`；如果名称全部由中文等非 ASCII 字符组成，则会
 生成带稳定 hash 后缀的名称，例如 `CUSTOM_d39b9067_API_KEY`，避免多个中文 provider
-都共用 `CUSTOM_API_KEY`。
+都共用 `CUSTOM_API_KEY`。如果名称以数字开头，则会添加 `CUSTOM_` 前缀以保证生成的
+环境变量名合法；例如 `9router` 会生成 `CUSTOM_9ROUTER_API_KEY`。
 
 CLI 的自定义 provider 向导会先根据 base URL 生成 provider 名称，再套用同一套
 provider-name 规则。例如 `https://token.sensenova.cn/v1` 会生成 provider 名

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1630,6 +1630,9 @@ func apiKeyEnvFromProviderName(name string) string {
 	if stem == "" {
 		return "CUSTOM_" + fnv1a32Hex(name) + "_API_KEY"
 	}
+	if stem[0] >= '0' && stem[0] <= '9' {
+		stem = "CUSTOM_" + stem
+	}
 	return stem + "_API_KEY"
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1258,6 +1258,7 @@ func TestAPIKeyEnvFromProviderName(t *testing.T) {
 		{"custom host slug", "custom-token-sensenova-cn", "CUSTOM_TOKEN_SENSENOVA_CN_API_KEY"},
 		{"localhost slug with port", "custom-localhost-11434", "CUSTOM_LOCALHOST_11434_API_KEY"},
 		{"desktop-style custom name", "Local Gateway", "LOCAL_GATEWAY_API_KEY"},
+		{"digit-leading provider name", "9router", "CUSTOM_9ROUTER_API_KEY"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Generate a valid `CUSTOM_`-prefixed credential name when a custom provider name begins with a digit.
- Keep desktop settings and the CLI custom-provider flow aligned.
- Add regression coverage for `9router` and document the rule in English and Chinese.

## Problem

A custom provider named `9router` generated `9ROUTER_API_KEY`. Reasonix credential validation rejects environment-variable names that begin with a digit, so automatic model discovery failed before making the provider request. Manually entering model IDs did not help because the provider save path reused the same invalid generated key.

The fix generates `CUSTOM_9ROUTER_API_KEY`, allowing both model discovery and manual provider saves to proceed.

## Compatibility

| Input or stored field | Previous behavior | New behavior | Conclusion |
| --- | --- | --- | --- |
| Letter-leading provider names | Readable names such as `LOCAL_GATEWAY_API_KEY` | Unchanged | Backward-compatible |
| Non-ASCII provider names | Stable hashed names such as `CUSTOM_d39b9067_API_KEY` | Unchanged | Backward-compatible |
| Digit-leading provider names | Generated an invalid, unsaveable key | Adds `CUSTOM_` to produce a valid key | Changes only the demonstrably broken case |
| Explicit `api_key_env` values | Preserved as entered | Unchanged | Existing valid configuration remains stable |

No persisted schema or Wails contract changes are introduced.

## Verification

- `pnpm typecheck && pnpm test` in `desktop/frontend`
- `go test ./internal/config ./internal/cli`
- `git diff --check`
