### PR TITLE
Fix plugin skill MCP tool bindings / 修复插件 Skill 的 MCP 工具绑定

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2425,7 +2425,8 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) ([]
 	// The first writer stays on the single-preview fast path.
 	earlierWriterRan := false
 	run := func(i int) {
-		t, known := a.tools.Get(calls[i].Name)
+		t, _, ambiguous := a.tools.ResolveCall(calls[i].Name)
+		known := t != nil && len(ambiguous) == 0
 		writer := known && !t.ReadOnly()
 		if earlierWriterRan && writer {
 			if refreshed, changed := refreshCurrentFileDiff(t, calls[i]); changed {
@@ -2509,7 +2510,8 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) ([]
 
 	for i, c := range calls {
 		o := outcomes[i]
-		t, ok := a.tools.Get(c.Name)
+		t, _, ambiguous := a.tools.ResolveCall(c.Name)
+		ok := t != nil && len(ambiguous) == 0
 		a.sink.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{
 			ID:         c.ID,
 			Name:       c.Name,
@@ -2535,7 +2537,8 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) ([]
 }
 
 func (a *Agent) emitFullToolDispatch(c provider.ToolCall, refreshed bool) {
-	t, ok := a.tools.Get(c.Name)
+	t, _, ambiguous := a.tools.ResolveCall(c.Name)
+	ok := t != nil && len(ambiguous) == 0
 	ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly(), Refreshed: refreshed}
 	ev.FileDiff = event.FileDiff{Diff: c.Diff, Added: c.Added, Removed: c.Removed}
 	if ok && ev.Diff == "" && ev.Added == 0 && ev.Removed == 0 {
@@ -2585,7 +2588,8 @@ func (a *Agent) withPreviewFileDiffs(calls []provider.ToolCall) []provider.ToolC
 		if out[i].Diff != "" || out[i].Added != 0 || out[i].Removed != 0 {
 			continue
 		}
-		t, ok := a.tools.Get(out[i].Name)
+		t, _, ambiguous := a.tools.ResolveCall(out[i].Name)
+		ok := t != nil && len(ambiguous) == 0
 		if !ok {
 			continue
 		}
@@ -2634,8 +2638,8 @@ func parallelisable(r *tool.Registry, name string) bool {
 	case "complete_step", "todo_write", "wait", "bash_output":
 		return false
 	}
-	t, ok := r.Get(name)
-	return ok && t.ReadOnly()
+	t, _, ambiguous := r.ResolveCall(name)
+	return t != nil && len(ambiguous) == 0 && t.ReadOnly()
 }
 
 func runParallel(ctx context.Context, start, end int, run func(int)) int {
@@ -2842,8 +2846,15 @@ type toolOutcome struct {
 // — the caller emits ToolDispatch/ToolResult — so it is safe to invoke from
 // parallel goroutines.
 func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutcome {
-	t, ok := a.tools.Get(call.Name)
-	if !ok {
+	t, canonicalName, ambiguous := a.tools.ResolveCall(call.Name)
+	if len(ambiguous) > 0 {
+		msg := fmt.Sprintf("ambiguous MCP tool reference %q; use one of: %s", call.Name, strings.Join(ambiguous, ", "))
+		return toolOutcome{
+			output: "error: " + msg,
+			errMsg: msg,
+		}
+	}
+	if t == nil {
 		return toolOutcome{
 			output: fmt.Sprintf("error: unknown tool %q", call.Name),
 			errMsg: fmt.Sprintf("unknown tool %q", call.Name),
@@ -2874,7 +2885,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 				safety = planmode.PlanSafetyUnsafe
 			}
 		}
-		if decision := a.planModeDecision(call.Name, t.ReadOnly(), planModeUntrustedReadOnly(t), safety, json.RawMessage(call.Arguments)); decision.Blocked {
+		if decision := a.planModeDecision(canonicalName, t.ReadOnly(), planModeUntrustedReadOnly(t), safety, json.RawMessage(call.Arguments)); decision.Blocked {
 			return toolOutcome{
 				output:  decision.Message,
 				blocked: true,
@@ -2884,11 +2895,11 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	// Resolve proxy tools (use_capability) to the real MCP target before
 	// permission, hooks, and evidence. Provider transcript keeps call.Name.
-	permName := call.Name
+	permName := canonicalName
 	permArgs := json.RawMessage(call.Arguments)
 	execTool := t
 	execArgs := json.RawMessage(call.Arguments)
-	evidenceName := call.Name
+	evidenceName := canonicalName
 	evidenceArgs := json.RawMessage(call.Arguments)
 	readOnly := t.ReadOnly()
 	var resolved tool.ResolvedCall
@@ -3641,8 +3652,8 @@ func isBackgroundTaskCall(args string) bool {
 // toolReadOnly reports a tool's ReadOnly classification by name (false for an
 // unknown tool), for stamping early ToolDispatch events.
 func (a *Agent) toolReadOnly(name string) bool {
-	t, ok := a.tools.Get(name)
-	return ok && t.ReadOnly()
+	t, _, ambiguous := a.tools.ResolveCall(name)
+	return t != nil && len(ambiguous) == 0 && t.ReadOnly()
 }
 
 // firstLine returns s up to its first newline — a one-line failure summary for

--- a/internal/agent/outcome_test.go
+++ b/internal/agent/outcome_test.go
@@ -2,12 +2,26 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
+
+type mcpAliasTool struct {
+	fakeTool
+	server  string
+	raw     string
+	visible string
+	pkg     string
+}
+
+func (t mcpAliasTool) MCPServerName() string      { return t.server }
+func (t mcpAliasTool) MCPRawToolName() string     { return t.raw }
+func (t mcpAliasTool) MCPVisibleToolName() string { return t.visible }
+func (t mcpAliasTool) MCPPackageName() string     { return t.pkg }
 
 // TestFailedCallsSurfaceError guards the bug where a failed tool call (an unknown
 // tool, e.g. a hallucinated "find", or a permission-denied writer) was reported
@@ -32,5 +46,38 @@ func TestFailedCallsSurfaceError(t *testing.T) {
 	gate.reason = "denied by permission policy"
 	if o := a.executeOne(context.Background(), provider.ToolCall{Name: "writer"}); o.errMsg == "" {
 		t.Errorf("permission-denied writer should surface an errMsg, got %+v", o)
+	}
+}
+
+func TestPortableMCPCallUsesCanonicalSecurityIdentity(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mcpAliasTool{
+		fakeTool: fakeTool{name: "mcp__figma__get_design_context", readOnly: true},
+		server:   "figma",
+		raw:      "figma_get_design_context",
+		visible:  "get_design_context",
+		pkg:      "figma",
+	})
+	gate := &recordingPermissionGate{allow: true}
+	a := New(nil, reg, NewSession(""), Options{Gate: gate}, event.Discard)
+
+	out := a.executeOne(context.Background(), provider.ToolCall{Name: "get_design_context", Arguments: `{}`})
+	if out.errMsg != "" {
+		t.Fatalf("portable MCP call failed: %+v", out)
+	}
+	if len(gate.calls) != 1 || gate.calls[0].name != "mcp__figma__get_design_context" {
+		t.Fatalf("permission gate calls = %v, want canonical MCP name", gate.calls)
+	}
+}
+
+func TestAmbiguousPortableMCPCallIsRejected(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mcpAliasTool{fakeTool: fakeTool{name: "mcp__one__search", readOnly: true}, server: "one", raw: "search", visible: "search"})
+	reg.Add(mcpAliasTool{fakeTool: fakeTool{name: "mcp__two__search", readOnly: true}, server: "two", raw: "search", visible: "search"})
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+
+	out := a.executeOne(context.Background(), provider.ToolCall{Name: "search", Arguments: `{}`})
+	if out.errMsg == "" || !strings.Contains(out.errMsg, "ambiguous MCP tool reference") {
+		t.Fatalf("ambiguous MCP alias was not rejected: %+v", out)
 	}
 }

--- a/internal/agent/subagent_registry_test.go
+++ b/internal/agent/subagent_registry_test.go
@@ -16,6 +16,29 @@ type subagentRegistryTool struct {
 	result   string
 }
 
+type subagentCapabilityProxy struct {
+	subagentRegistryTool
+}
+
+type subagentMCPTool struct {
+	subagentRegistryTool
+	server string
+	raw    string
+}
+
+func (t subagentMCPTool) MCPServerName() string  { return t.server }
+func (t subagentMCPTool) MCPRawToolName() string { return t.raw }
+
+func (t subagentCapabilityProxy) ResolveCall(_ context.Context, args json.RawMessage) (tool.ResolvedCall, error) {
+	var p struct {
+		CapabilityID string `json:"capability_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return tool.ResolvedCall{}, err
+	}
+	return tool.ResolvedCall{DisplayName: t.Name(), CapabilityID: p.CapabilityID, ReadOnly: true, SkipExecute: true, Result: p.CapabilityID}, nil
+}
+
 func (t subagentRegistryTool) Name() string { return t.name }
 func (t subagentRegistryTool) Description() string {
 	return "Execute a command in the shell and return combined stdout/stderr."
@@ -104,6 +127,48 @@ func TestSubagentToolRegistryFiltersUnavailableToolsAndWrapsBash(t *testing.T) {
 	}
 	if _, err := bash.Execute(context.Background(), json.RawMessage(`{"command":"sleep 1","run_in_background":true}`)); err == nil || !strings.Contains(err.Error(), "background bash is unavailable in subagents") {
 		t.Fatalf("background bash should return a subagent-specific error, got %v", err)
+	}
+}
+
+func TestSubagentToolRegistryRestrictsCapabilityProxyToAllowedMCPIDs(t *testing.T) {
+	parent := tool.NewRegistry()
+	parent.Add(subagentCapabilityProxy{subagentRegistryTool{name: "use_capability", readOnly: true}})
+	allowedID := "mcp-tool:figma/search"
+
+	for _, sub := range []*tool.Registry{
+		SubagentToolRegistry(parent, []string{allowedID}),
+		ReadOnlySubagentToolRegistry(parent, []string{allowedID}),
+	} {
+		proxy, ok := sub.Get("use_capability")
+		if !ok {
+			t.Fatalf("restricted capability proxy missing: %v", sub.Names())
+		}
+		resolver, ok := proxy.(tool.CallResolver)
+		if !ok {
+			t.Fatalf("restricted proxy does not resolve calls: %T", proxy)
+		}
+		if _, err := resolver.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"mcp-tool:figma/search"}`)); err != nil {
+			t.Fatalf("allowed capability was rejected: %v", err)
+		}
+		if _, err := resolver.ResolveCall(context.Background(), json.RawMessage(`{"action":"call","capability_id":"mcp-tool:other/delete"}`)); err == nil || !strings.Contains(err.Error(), "outside this subagent's allowed-tools") {
+			t.Fatalf("disallowed capability was not rejected: %v", err)
+		}
+		if _, err := proxy.Execute(context.Background(), json.RawMessage(`{"action":"call","capability_id":"mcp-tool:other/delete"}`)); err == nil {
+			t.Fatal("direct execution bypassed the restricted capability allowlist")
+		}
+	}
+
+	parent.Add(subagentMCPTool{
+		subagentRegistryTool: subagentRegistryTool{name: "mcp__figma__search", readOnly: true},
+		server:               "figma",
+		raw:                  "search",
+	})
+	direct := SubagentToolRegistry(parent, []string{"mcp__figma__search", allowedID})
+	if _, ok := direct.Get("mcp__figma__search"); !ok {
+		t.Fatalf("direct MCP tool missing: %v", direct.Names())
+	}
+	if _, ok := direct.Get("use_capability"); ok {
+		t.Fatalf("restricted proxy should not duplicate an available direct MCP tool: %v", direct.Names())
 	}
 }
 

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -986,7 +987,97 @@ func FilterRegistry(parent *tool.Registry, names []string, exclude ...string) *t
 			sub.Add(tl)
 		}
 	}
+	addRestrictedCapabilityProxy(parent, sub, names, ex, false)
 	return sub
+}
+
+// restrictedCapabilityProxy preserves a subagent allowed-tools boundary when
+// an MCP tool is available only through use_capability. The pseudo
+// mcp-tool:<server>/<raw> entries never become provider tools themselves; they
+// select one proxy schema whose resolver rejects every capability outside the
+// exact allowlist.
+type restrictedCapabilityProxy struct {
+	tool.Tool
+	resolver tool.CallResolver
+	allowed  map[string]bool
+	ids      []string
+}
+
+func (t *restrictedCapabilityProxy) Description() string {
+	base := strings.TrimSpace(t.Tool.Description())
+	if base != "" {
+		base += " "
+	}
+	return base + "This subagent is restricted to capability IDs: " + strings.Join(t.ids, ", ") + "."
+}
+
+func (t *restrictedCapabilityProxy) check(args json.RawMessage) error {
+	var p struct {
+		CapabilityID string `json:"capability_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return fmt.Errorf("invalid args: %w", err)
+	}
+	id := strings.TrimSpace(p.CapabilityID)
+	if id == "" {
+		return fmt.Errorf("capability_id is required")
+	}
+	if !t.allowed[id] {
+		return fmt.Errorf("capability %q is outside this subagent's allowed-tools", id)
+	}
+	return nil
+}
+
+func (t *restrictedCapabilityProxy) ResolveCall(ctx context.Context, args json.RawMessage) (tool.ResolvedCall, error) {
+	if err := t.check(args); err != nil {
+		return tool.ResolvedCall{}, err
+	}
+	return t.resolver.ResolveCall(ctx, args)
+}
+
+func (t *restrictedCapabilityProxy) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if err := t.check(args); err != nil {
+		return "", err
+	}
+	return t.Tool.Execute(ctx, args)
+}
+
+func addRestrictedCapabilityProxy(parent, sub *tool.Registry, names []string, excluded map[string]bool, requireReadOnly bool) {
+	if parent == nil || sub == nil || excluded["use_capability"] {
+		return
+	}
+	if _, ok := sub.Get("use_capability"); ok {
+		// An explicit name or wildcard already granted the ordinary proxy.
+		return
+	}
+	direct := map[string]bool{}
+	for _, binding := range parent.MCPBindings() {
+		direct[binding.CapabilityID] = true
+	}
+	allowed := map[string]bool{}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if strings.HasPrefix(name, "mcp-tool:") && !direct[name] {
+			allowed[name] = true
+		}
+	}
+	if len(allowed) == 0 {
+		return
+	}
+	inner, ok := parent.Get("use_capability")
+	if !ok || requireReadOnly && (!inner.ReadOnly() || planModeUntrustedReadOnly(inner) || mcpDestructiveHint(inner)) {
+		return
+	}
+	resolver, ok := inner.(tool.CallResolver)
+	if !ok {
+		return
+	}
+	ids := make([]string, 0, len(allowed))
+	for id := range allowed {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	sub.Add(&restrictedCapabilityProxy{Tool: inner, resolver: resolver, allowed: allowed, ids: ids})
 }
 
 var plannerNonResearchTools = []string{
@@ -1062,6 +1153,7 @@ func ReadOnlySubagentToolRegistryForDepth(parent *tool.Registry, names []string,
 		}
 		sub.Add(tl)
 	}
+	addRestrictedCapabilityProxy(parent, sub, names, ex, true)
 	return sub
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -488,6 +488,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ForbidReadRoots:      forbidReadRoots,
 		Network:              cfg.Sandbox.Network,
 		OfficialServers:      LoadVerifiedMCPPackages(ctx, cfg),
+		PackageOwners:        pluginPackageOwners(cfg),
 	}
 	autoStartEntries := cfg.AutoStartPlugins()
 	eagerEntries, bgEntries := partitionByTier(autoStartEntries)
@@ -780,6 +781,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if !ok || sk.RunAs != skill.RunSubagent {
 			return agent.ProfileDefinition{}, false
 		}
+		sk = skillStore.Prepare(sk)
 		return agent.ProfileDefinition{
 			Name:         sk.Name,
 			Body:         sk.Body,
@@ -1146,7 +1148,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				slashEntries = append(slashEntries, command.SlashEntry{
 					Name:        sk.SlashName(),
 					Description: sk.Description,
-					Render:      func(args []string) string { return skill.Render(sk, strings.Join(args, " ")) },
+					Render:      func(args []string) string { return skillStore.Render(sk, strings.Join(args, " ")) },
 				})
 			}
 		}
@@ -1410,6 +1412,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	var capAudit *capability.Audit
 	capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions)
 	cachedTools, cacheHashOK := capability.LoadCachedToolsForSpecs(capSpecs)
+	skillStore.ConfigureToolBindings(func(sk skill.Skill) []tool.MCPBinding {
+		return skillMCPBindings(sk, reg, capSpecs, cachedTools, cacheHashOK)
+	})
 	var capProxy *agent.UseCapabilityTool
 	if tokenDelivery {
 		capLedger = capability.NewLedger()
@@ -2243,6 +2248,7 @@ type PluginSpecOptions struct {
 	ForbidReadRoots      []string
 	Network              bool
 	OfficialServers      map[string]VerifiedMCPPackage
+	PackageOwners        map[string]string
 }
 
 type VerifiedMCPPackage struct {
@@ -2284,6 +2290,7 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 	}
 	spec := plugin.ApplyKnownOverrides(plugin.Spec{
 		Name:                     e.Name,
+		Package:                  strings.TrimSpace(opts.PackageOwners[e.Name]),
 		Type:                     e.Type,
 		Command:                  e.Command,
 		Args:                     e.Args,
@@ -2305,6 +2312,55 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 	applyMCPIsolation(&spec, workspaceRoot, opts)
 	applyVerifiedMCPPackage(&spec, opts)
 	return spec
+}
+
+func pluginPackageOwners(cfg *config.Config) map[string]string {
+	out := map[string]string{}
+	if cfg == nil {
+		return out
+	}
+	for _, configured := range cfg.Plugins {
+		if owner, ok := cfg.PluginPackageOwner(configured.Name); ok {
+			out[configured.Name] = owner
+		}
+	}
+	return out
+}
+
+func skillMCPBindings(sk skill.Skill, reg *tool.Registry, specs []plugin.Spec, cachedTools map[string][]plugin.CachedTool, cacheHashOK map[string]bool) []tool.MCPBinding {
+	var out []tool.MCPBinding
+	if reg != nil {
+		bindings := reg.MCPBindings()
+		out = make([]tool.MCPBinding, 0, len(bindings))
+		for _, binding := range bindings {
+			if binding.Package == sk.Plugin {
+				out = append(out, binding)
+			}
+		}
+	}
+	// A valid cached schema also supplies stable bindings for an on-demand
+	// package server before it is connected. The skill can then route through
+	// use_capability without inventing Reasonix's canonical name.
+	for _, spec := range specs {
+		if spec.Package != sk.Plugin || !cacheHashOK[spec.Name] {
+			continue
+		}
+		for _, cached := range cachedTools[spec.Name] {
+			visible := cached.Name
+			if spec.StripRawPrefix != "" {
+				visible = strings.TrimPrefix(visible, spec.StripRawPrefix)
+			}
+			out = append(out, tool.MCPBinding{
+				Package:      spec.Package,
+				Server:       spec.Name,
+				RawName:      cached.Name,
+				VisibleName:  visible,
+				CallableName: plugin.ModelToolName(spec.Name, visible),
+				CapabilityID: "mcp-tool:" + spec.Name + "/" + cached.Name,
+			})
+		}
+	}
+	return out
 }
 
 func applyVerifiedMCPPackage(spec *plugin.Spec, opts PluginSpecOptions) {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2329,10 +2329,12 @@ func pluginPackageOwners(cfg *config.Config) map[string]string {
 
 func skillMCPBindings(sk skill.Skill, reg *tool.Registry, specs []plugin.Spec, cachedTools map[string][]plugin.CachedTool, cacheHashOK map[string]bool) []tool.MCPBinding {
 	var out []tool.MCPBinding
+	liveServers := map[string]bool{}
 	if reg != nil {
 		bindings := reg.MCPBindings()
 		out = make([]tool.MCPBinding, 0, len(bindings))
 		for _, binding := range bindings {
+			liveServers[binding.Server] = true
 			if binding.Package == sk.Plugin {
 				out = append(out, binding)
 			}
@@ -2342,7 +2344,7 @@ func skillMCPBindings(sk skill.Skill, reg *tool.Registry, specs []plugin.Spec, c
 	// package server before it is connected. The skill can then route through
 	// use_capability without inventing Reasonix's canonical name.
 	for _, spec := range specs {
-		if spec.Package != sk.Plugin || !cacheHashOK[spec.Name] {
+		if spec.Package != sk.Plugin || liveServers[spec.Name] || !cacheHashOK[spec.Name] {
 			continue
 		}
 		for _, cached := range cachedTools[spec.Name] {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3869,6 +3869,19 @@ func TestSkillMCPBindingsUseOnlyValidOwnedCache(t *testing.T) {
 	if stale := skillMCPBindings(skill.Skill{Plugin: "design-plugin"}, nil, specs, cached, map[string]bool{"figma": false}); len(stale) != 0 {
 		t.Fatalf("stale cache supplied skill bindings: %+v", stale)
 	}
+
+	reg := tool.NewRegistry()
+	host := plugin.NewHost()
+	t.Cleanup(host.Close)
+	liveTools := plugin.LazyToolset(specs[0], &plugin.CachedSchema{Tools: []plugin.CachedTool{{Name: "figma_current_tool"}}}, host, reg, context.Background(), false)
+	for _, live := range liveTools {
+		reg.Add(live)
+	}
+	oldCache := map[string][]plugin.CachedTool{"figma": {{Name: "figma_removed_tool"}}}
+	got = skillMCPBindings(skill.Skill{Plugin: "design-plugin"}, reg, specs, oldCache, map[string]bool{"figma": true})
+	if len(got) != 1 || got[0].RawName != "figma_current_tool" {
+		t.Fatalf("live registry did not supersede stale boot cache: %+v", got)
+	}
 }
 
 func TestVerifiedMCPPackageRequiresMatchingTransport(t *testing.T) {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -30,6 +30,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 	"reasonix/internal/tool/builtin"
 
@@ -3840,6 +3841,33 @@ func TestPluginSpecsMapMCPSourceDefaults(t *testing.T) {
 	}
 	if specs[1].ImplicitApproval || !specs[1].RequireLaunchApproval || specs[1].ConfigSource != string(config.MCPSourceProjectConfig) {
 		t.Fatalf("project source defaults = %+v", specs[1])
+	}
+}
+
+func TestPluginSpecsCarryPluginPackageProvenance(t *testing.T) {
+	specs := PluginSpecsForRootWithOptions([]config.PluginEntry{{Name: "figma"}}, "/workspace", PluginSpecOptions{
+		PackageOwners: map[string]string{"figma": "design-plugin"},
+	})
+	if len(specs) != 1 || specs[0].Package != "design-plugin" {
+		t.Fatalf("plugin package provenance = %+v, want design-plugin", specs)
+	}
+}
+
+func TestSkillMCPBindingsUseOnlyValidOwnedCache(t *testing.T) {
+	specs := []plugin.Spec{
+		{Name: "figma", Package: "design-plugin", StripRawPrefix: "figma_"},
+		{Name: "other", Package: "other-plugin"},
+	}
+	cached := map[string][]plugin.CachedTool{
+		"figma": {{Name: "figma_get_design_context"}},
+		"other": {{Name: "search"}},
+	}
+	got := skillMCPBindings(skill.Skill{Plugin: "design-plugin"}, nil, specs, cached, map[string]bool{"figma": true, "other": true})
+	if len(got) != 1 || got[0].VisibleName != "get_design_context" || got[0].CallableName != plugin.ModelToolName("figma", "get_design_context") || got[0].CapabilityID != "mcp-tool:figma/figma_get_design_context" {
+		t.Fatalf("cached skill bindings = %+v", got)
+	}
+	if stale := skillMCPBindings(skill.Skill{Plugin: "design-plugin"}, nil, specs, cached, map[string]bool{"figma": false}); len(stale) != 0 {
+		t.Fatalf("stale cache supplied skill bindings: %+v", stale)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1693,6 +1693,7 @@ func (c *Controller) RunSubagentProfile(ctx context.Context, name, task string, 
 	if sk.RunAs != skill.RunSubagent {
 		return "", fmt.Errorf("skill %q is not runAs=subagent", name)
 	}
+	sk = c.skills.prepare(sk)
 	runner := c.skillRunner
 	if readOnly {
 		runner = c.readOnlySkillRunner

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -891,6 +891,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 }
 
 func (c *Controller) runSubagentSkillSlash(sk skill.Skill, task, raw, display string) {
+	sk = c.skills.prepare(sk)
 	c.runGuarded(func(ctx context.Context) error {
 		planMode := c.PlanMode()
 		runner := c.skillRunner
@@ -1011,7 +1012,7 @@ func (c *Controller) submitInvocations(input, display string, requests []Invocat
 
 	parts := make([]string, 0, len(inline)+1)
 	for _, sk := range inline {
-		parts = append(parts, skill.Render(sk, ""))
+		parts = append(parts, c.skills.render(sk, ""))
 	}
 	if strings.TrimSpace(input) != "" {
 		parts = append(parts, input)
@@ -1233,7 +1234,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 				c.runSubagentSkillSlash(sk, task, trimmed, display)
 				return
 			}
-			sent := skill.Render(sk, task)
+			sent := c.skills.render(sk, task)
 			c.runGuarded(func(ctx context.Context) error {
 				return runGoalLoop(ctx, sent, sent, display)
 			})
@@ -4158,7 +4159,7 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 		entries = append(entries, command.SlashEntry{
 			Name:        sk.SlashName(),
 			Description: sk.Description,
-			Render:      func(args []string) string { return skill.Render(sk, strings.Join(args, " ")) },
+			Render:      func(args []string) string { return c.skills.render(sk, strings.Join(args, " ")) },
 		})
 	}
 	for _, cmd := range cmds {

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -630,7 +630,7 @@ func (c *Controller) RunSkill(input string) (sent string, found bool) {
 	if !ok {
 		return "", false
 	}
-	return skill.Render(sk, task), true
+	return c.skills.render(sk, task), true
 }
 
 // MCPPrompt resolves a "/mcp__server__prompt args…" line: it maps the positional

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -233,6 +233,77 @@ func TestSubmitInvocationDisplayExecutesStructuredEntitiesInVisualOrder(t *testi
 	}
 }
 
+func TestSubmitInvocationDisplayPreparesPluginSubagentBindings(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := t.TempDir()
+	writeControlSkill(t, pluginRoot, "helper/SKILL.md", "---\ndescription: Plugin helper\nrunAs: subagent\n---\nCall search.")
+	store := skill.New(skill.Options{
+		HomeDir: home, CustomPaths: []string{pluginRoot},
+		PluginPaths: map[string][]string{pluginRoot: {"search-plugin"}}, DisableBuiltins: true,
+	})
+	store.ConfigureToolBindings(func(skill.Skill) []tool.MCPBinding {
+		return []tool.MCPBinding{{
+			Package: "search-plugin", Server: "search", RawName: "search",
+			VisibleName: "search", CallableName: "mcp__search__search", CapabilityID: "mcp-tool:search/search",
+		}}
+	})
+
+	sess := agent.NewSession("parent system")
+	exec := agent.New(nil, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	events := make(chan event.Event, 12)
+	var got skill.Skill
+	c := New(Options{
+		Executor: exec, SkillStore: store, Skills: store.List(),
+		Sink: event.FuncSink(func(e event.Event) { events <- e }),
+		SkillRunner: func(_ context.Context, sk skill.Skill, _ string, _ skill.SubagentRunOptions) (string, error) {
+			got = sk
+			return "done", nil
+		},
+	})
+	defer c.Close()
+
+	c.SubmitInvocationDisplay("inspect", "inspect", []InvocationRequest{{Name: "search-plugin:helper", Kind: "subagent"}})
+	waitForTurnEvents(t, events)
+	waitIdle(t, c)
+	if !strings.Contains(got.Body, "## Runtime MCP tool bindings") || !strings.Contains(got.Body, "`mcp__search__search`") {
+		t.Fatalf("structured plugin subagent was not prepared: %q", got.Body)
+	}
+}
+
+func TestRunSubagentProfilePreparesPluginBindings(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := t.TempDir()
+	writeControlSkill(t, pluginRoot, "helper/SKILL.md", "---\ndescription: Plugin helper\nrunAs: subagent\n---\nCall search.")
+	store := skill.New(skill.Options{
+		HomeDir: home, CustomPaths: []string{pluginRoot},
+		PluginPaths: map[string][]string{pluginRoot: {"search-plugin"}}, DisableBuiltins: true,
+	})
+	store.ConfigureToolBindings(func(skill.Skill) []tool.MCPBinding {
+		return []tool.MCPBinding{{
+			Package: "search-plugin", Server: "search", RawName: "search",
+			VisibleName: "search", CallableName: "mcp__search__search", CapabilityID: "mcp-tool:search/search",
+		}}
+	})
+
+	var got skill.Skill
+	c := New(Options{
+		SkillStore: store, Skills: store.List(),
+		SkillRunner: func(_ context.Context, sk skill.Skill, _ string, _ skill.SubagentRunOptions) (string, error) {
+			got = sk
+			return "done", nil
+		},
+	})
+	defer c.Close()
+
+	answer, err := c.RunSubagentProfile(context.Background(), "search-plugin:helper", "inspect", false)
+	if err != nil || answer != "done" {
+		t.Fatalf("RunSubagentProfile() = %q, %v", answer, err)
+	}
+	if !strings.Contains(got.Body, "## Runtime MCP tool bindings") || !strings.Contains(got.Body, "`mcp__search__search`") {
+		t.Fatalf("headless plugin subagent was not prepared: %q", got.Body)
+	}
+}
+
 func TestSubmitInvocationDisplayRunsInlineSkillWithoutArguments(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	c := New(Options{

--- a/internal/control/skill.go
+++ b/internal/control/skill.go
@@ -56,6 +56,20 @@ func (s *skillSet) bySlashName(name string) (skill.Skill, bool) {
 	return skill.ResolveSlashSkill(s.enabled, name)
 }
 
+func (s *skillSet) prepare(sk skill.Skill) skill.Skill {
+	if s.store != nil {
+		return s.store.Prepare(sk)
+	}
+	return sk
+}
+
+func (s *skillSet) render(sk skill.Skill, args string) string {
+	if s.store != nil {
+		return s.store.Render(sk, args)
+	}
+	return skill.Render(sk, args)
+}
+
 // discovered returns the construction-time enabled snapshot (not the live store),
 // for the /skills listing which reflects what was discovered at boot.
 func (s *skillSet) discovered() []skill.Skill {

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -118,6 +118,7 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	c.executor.Session().Add(provider.Message{Role: provider.RoleUser, Content: input, Images: images, CreatedAt: time.Now().UnixMilli()})
 
 	for _, sk := range skills {
+		sk = c.skills.prepare(sk)
 		callID := fmt.Sprintf("slash-skill-%d", c.slashSkillSeq.Add(1))
 		args, _ := json.Marshal(map[string]string{"name": sk.Name, "arguments": task})
 		toolEvent := event.Tool{

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -281,6 +281,7 @@ func TestSpecFingerprintIgnoresHostLocalTrustAndIsolation(t *testing.T) {
 	changed := base
 	changed.LaunchManager = mcplaunch.NewManager(filepath.Join(t.TempDir(), mcplaunch.StateFilename), "/workspace")
 	changed.ConfigSource = "project:.mcp.json"
+	changed.Package = "figma"
 	changed.OfficialCatalogEntryID = "plugin@example.com@1.0.0"
 	changed.OfficialReaderNames = []string{"search"}
 	changed.PackageDigest = "sha256:package"

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -197,6 +197,7 @@ type lazyTool struct {
 	shared                *lazySpawn
 	name                  string // namespaced "mcp__<server>__<tool>"
 	rawName               string // original server-local tool name, when cached
+	visibleName           string // raw name after configured prefix stripping
 	desc                  string
 	schema                json.RawMessage
 	capabilityFingerprint string
@@ -231,7 +232,14 @@ func (lt *lazyTool) MCPServerName() string {
 	}
 	return lt.shared.spec.Name
 }
-func (lt *lazyTool) MCPRawToolName() string { return lt.rawName }
+func (lt *lazyTool) MCPRawToolName() string     { return lt.rawName }
+func (lt *lazyTool) MCPVisibleToolName() string { return lt.visibleName }
+func (lt *lazyTool) MCPPackageName() string {
+	if lt.shared == nil {
+		return ""
+	}
+	return lt.shared.spec.Package
+}
 
 // ReadOnlyExecutionAuthority mirrors remoteTool: reader classification
 // counts for strict read-only execution only when launch state is available.
@@ -544,6 +552,7 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 				shared:                shared,
 				name:                  toolName(spec.Name, visibleName),
 				rawName:               ct.Name,
+				visibleName:           visibleName,
 				desc:                  ct.Description,
 				schema:                ct.Schema,
 				capabilityFingerprint: capabilityFingerprint(cachedCapabilities[ct.Name]),

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -40,7 +40,10 @@ const defaultCallTimeout = 300 * time.Second
 // (default) runs Command/Args/Env as a subprocess; "http" / "streamable-http"
 // and "sse" connect to URL with optional static Headers.
 type Spec struct {
-	Name    string
+	Name string
+	// Package is the installed plugin package that contributed this server.
+	// It is host-only provenance and intentionally excluded from fingerprints.
+	Package string
 	Type    string
 	Command string
 	Args    []string
@@ -1430,6 +1433,7 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 			client:                c,
 			name:                  toolName(c.name, visibleName),
 			rawName:               t.Name,
+			visibleName:           visibleName,
 			desc:                  t.Description,
 			schema:                schema,
 			outputSchema:          t.OutputSchema,
@@ -1537,9 +1541,9 @@ func (c *Client) cachedTools() ([]tool.Tool, bool) {
 	return append([]tool.Tool(nil), c.toolAdapters...), true
 }
 
-// toolName builds the model-visible namespaced name "mcp__<server>__<tool>",
-// matching Claude Code. Spaces in either part are normalised to underscores so
-// the name is a clean identifier the model can call.
+// toolName builds Reasonix's canonical model-visible name
+// "mcp__<server>__<tool>". The registry separately resolves unique portable
+// and Claude plugin-qualified references without exposing duplicate schemas.
 func toolName(server, raw string) string {
 	return ToolPrefix(server) + normalizeName(raw)
 }
@@ -1624,6 +1628,7 @@ type remoteTool struct {
 	client                *Client
 	name                  string // namespaced "mcp__<server>__<tool>"
 	rawName               string // original name for tools/call
+	visibleName           string // raw name after configured prefix stripping
 	desc                  string
 	schema                json.RawMessage
 	outputSchema          json.RawMessage
@@ -1647,7 +1652,14 @@ func (t *remoteTool) MCPServerName() string {
 	}
 	return t.client.name
 }
-func (t *remoteTool) MCPRawToolName() string { return t.rawName }
+func (t *remoteTool) MCPRawToolName() string     { return t.rawName }
+func (t *remoteTool) MCPVisibleToolName() string { return t.visibleName }
+func (t *remoteTool) MCPPackageName() string {
+	if t.client == nil {
+		return ""
+	}
+	return t.client.spec.Package
+}
 
 // ReadOnlyExecutionAuthority reports whether this adapter's reader
 // classification comes from explicit local or signed package policy. Without a LaunchManager the

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -303,7 +303,7 @@ func bindAllowedTools(refs []string, bindings []tool.MCPBinding) []string {
 		}
 	}
 	for _, ref := range refs {
-		matches := map[string]bool{}
+		matches := map[string]tool.MCPBinding{}
 		isPattern := strings.ContainsAny(ref, "*?[")
 		for _, binding := range bindings {
 			aliases := append(tool.MCPBindingAliases(binding), binding.CallableName)
@@ -313,7 +313,7 @@ func bindAllowedTools(refs []string, bindings []tool.MCPBinding) []string {
 					matched, _ = path.Match(ref, alias)
 				}
 				if matched {
-					matches[binding.CallableName] = true
+					matches[binding.CallableName] = binding
 					break
 				}
 			}
@@ -332,12 +332,20 @@ func bindAllowedTools(refs []string, bindings []tool.MCPBinding) []string {
 				if matched, err := path.Match(ref, name); err != nil || !matched {
 					appendOne(name)
 				}
+				// Capability IDs are host-only allowlist entries consumed when the
+				// session exposes this MCP tool solely through use_capability. Do not
+				// add one when the authored pattern already grants the proxy itself.
+				proxyMatched, _ := path.Match(ref, "use_capability")
+				if !proxyMatched {
+					appendOne(matches[name].CapabilityID)
+				}
 			}
 			continue
 		}
 		if len(matches) == 1 {
-			for name := range matches {
+			for name, binding := range matches {
 				appendOne(name)
+				appendOne(binding.CapabilityID)
 			}
 			continue
 		}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -69,6 +69,9 @@ type Skill struct {
 	Scope       Scope  // where it came from
 	Path        string // absolute path to the SKILL.md / <name>.md, or "(builtin)"
 	Plugin      string // installed plugin package name; empty for non-plugin skills
+	// runtimeBindingsPrepared is session-local invocation state. It must not be
+	// inferred from untrusted Markdown content or persisted skill metadata.
+	runtimeBindingsPrepared bool
 	// SlashPrefix overrides Plugin only for the user-facing invocation name.
 	// Imported Claude agents use <plugin>:agent so an agent and skill may safely
 	// share the same upstream name.
@@ -249,7 +252,7 @@ func (s *Store) ConfigureToolBindings(resolve func(Skill) []tool.MCPBinding) {
 // exact callable names. Non-plugin skills and sessions without bindings are
 // returned byte-for-byte unchanged.
 func (s *Store) Prepare(sk Skill) Skill {
-	if s == nil || s.toolBindings == nil || strings.TrimSpace(sk.Plugin) == "" {
+	if s == nil || s.toolBindings == nil || strings.TrimSpace(sk.Plugin) == "" || sk.runtimeBindingsPrepared {
 		return sk
 	}
 	bindings := append([]tool.MCPBinding(nil), s.toolBindings(sk)...)
@@ -271,9 +274,7 @@ func (s *Store) Prepare(sk Skill) Skill {
 		return sk
 	}
 	sk.AllowedTools = bindAllowedTools(sk.AllowedTools, bindings)
-	if strings.Contains(sk.Body, "\n## Runtime MCP tool bindings\n") {
-		return sk
-	}
+	sk.runtimeBindingsPrepared = true
 
 	var b strings.Builder
 	b.WriteString(strings.TrimRight(sk.Body, " \t\r\n"))
@@ -317,13 +318,25 @@ func bindAllowedTools(refs []string, bindings []tool.MCPBinding) []string {
 				}
 			}
 		}
-		if len(matches) == 1 || isPattern && len(matches) > 0 {
+		if isPattern {
+			// Preserve the original pattern so an existing broad allowlist such as
+			// "*" keeps all of its prior tools. Add only canonical MCP names the
+			// upstream/Claude pattern itself cannot match in Reasonix.
+			appendOne(ref)
 			names := make([]string, 0, len(matches))
 			for name := range matches {
 				names = append(names, name)
 			}
 			sort.Strings(names)
 			for _, name := range names {
+				if matched, err := path.Match(ref, name); err != nil || !matched {
+					appendOne(name)
+				}
+			}
+			continue
+		}
+		if len(matches) == 1 {
+			for name := range matches {
 				appendOne(name)
 			}
 			continue

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/frontmatter"
+	"reasonix/internal/tool"
 )
 
 // ErrInvocationUnavailable marks a profile/dependency gate that can become
@@ -164,6 +166,7 @@ type Store struct {
 	stderr           io.Writer
 	runtimeProfile   string
 	requiresReady    func([]string) []string
+	toolBindings     func(Skill) []tool.MCPBinding
 }
 
 // New builds a Store. Relative custom paths and a relative project root are made
@@ -231,6 +234,105 @@ func (s *Store) ConfigureInvocationPolicy(profile string, requiresReady func([]s
 	}
 	s.runtimeProfile = normalizeRuntimeProfile(profile)
 	s.requiresReady = requiresReady
+}
+
+// ConfigureToolBindings installs a session-local resolver for plugin-owned MCP
+// tools. It affects only an invoked skill body and never the cache-stable index.
+func (s *Store) ConfigureToolBindings(resolve func(Skill) []tool.MCPBinding) {
+	if s == nil {
+		return
+	}
+	s.toolBindings = resolve
+}
+
+// Prepare binds a plugin skill's portable MCP references to this session's
+// exact callable names. Non-plugin skills and sessions without bindings are
+// returned byte-for-byte unchanged.
+func (s *Store) Prepare(sk Skill) Skill {
+	if s == nil || s.toolBindings == nil || strings.TrimSpace(sk.Plugin) == "" {
+		return sk
+	}
+	bindings := append([]tool.MCPBinding(nil), s.toolBindings(sk)...)
+	if len(bindings) == 0 {
+		return sk
+	}
+	sort.Slice(bindings, func(i, j int) bool { return bindings[i].CallableName < bindings[j].CallableName })
+	seen := map[string]bool{}
+	unique := bindings[:0]
+	for _, binding := range bindings {
+		if binding.CallableName == "" || seen[binding.CallableName] {
+			continue
+		}
+		seen[binding.CallableName] = true
+		unique = append(unique, binding)
+	}
+	bindings = unique
+	if len(bindings) == 0 {
+		return sk
+	}
+	sk.AllowedTools = bindAllowedTools(sk.AllowedTools, bindings)
+	if strings.Contains(sk.Body, "\n## Runtime MCP tool bindings\n") {
+		return sk
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(sk.Body, " \t\r\n"))
+	b.WriteString("\n\n## Runtime MCP tool bindings\n\n")
+	b.WriteString("These host-generated bindings are authoritative for this invocation. Use the exact direct name below; if only `use_capability` is available, use the stable capability ID. Short or Claude-style MCP names in this skill refer to these bindings.\n")
+	for _, binding := range bindings {
+		fmt.Fprintf(&b, "\n- `%s/%s` → `%s` (capability `%s`)", binding.Server, binding.RawName, binding.CallableName, binding.CapabilityID)
+	}
+	sk.Body = b.String()
+	return sk
+}
+
+// Render prepares and renders a skill for a direct slash invocation.
+func (s *Store) Render(sk Skill, args string) string { return Render(s.Prepare(sk), args) }
+
+func bindAllowedTools(refs []string, bindings []tool.MCPBinding) []string {
+	if len(refs) == 0 {
+		return refs
+	}
+	out := make([]string, 0, len(refs))
+	seen := map[string]bool{}
+	appendOne := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, ref := range refs {
+		matches := map[string]bool{}
+		isPattern := strings.ContainsAny(ref, "*?[")
+		for _, binding := range bindings {
+			aliases := append(tool.MCPBindingAliases(binding), binding.CallableName)
+			for _, alias := range aliases {
+				matched := ref == alias
+				if isPattern {
+					matched, _ = path.Match(ref, alias)
+				}
+				if matched {
+					matches[binding.CallableName] = true
+					break
+				}
+			}
+		}
+		if len(matches) == 1 || isPattern && len(matches) > 0 {
+			names := make([]string, 0, len(matches))
+			for name := range matches {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				appendOne(name)
+			}
+			continue
+		}
+		// Preserve unresolved or ambiguous literals. The child registry will not
+		// gain any broader permission from them.
+		appendOne(ref)
+	}
+	return out
 }
 
 // ValidateInvocation enforces profiles/requires frontmatter at the host tool

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -101,6 +101,7 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	if err := t.store.ValidateInvocation(sk); err != nil {
 		return "", fmt.Errorf("run_skill: %w", err)
 	}
+	sk = t.store.Prepare(sk)
 	rawArgs := strings.TrimSpace(p.Arguments)
 	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
 	if opts.ContinueFrom != "" && opts.ForkFrom != "" {
@@ -209,6 +210,7 @@ func (t *readOnlySkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if err := t.store.ValidateInvocation(sk); err != nil {
 		return "", fmt.Errorf("read_only_skill: %w", err)
 	}
+	sk = t.store.Prepare(sk)
 	rawArgs := strings.TrimSpace(p.Arguments)
 	if sk.RunAs == RunSubagent {
 		if t.runner == nil {
@@ -306,6 +308,7 @@ func (t *readSkillTool) Execute(_ context.Context, args json.RawMessage) (string
 	if err := t.store.ValidateInvocation(sk); err != nil {
 		return "", fmt.Errorf("read_skill: %w", err)
 	}
+	sk = t.store.Prepare(sk)
 	if sk.RunAs == RunSubagent {
 		return "", fmt.Errorf("read_skill: skill %q is a subagent and must be executed, not read — use run_skill (or the dedicated %s tool)", name, name)
 	}
@@ -353,6 +356,7 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if err := t.store.ValidateInvocation(sk); err != nil {
 		return "", fmt.Errorf("%s: %w", t.toolName, err)
 	}
+	sk = t.store.Prepare(sk)
 	// A user file overriding the built-in name with runAs:inline would lose
 	// isolation if dispatched here — bounce to run_skill where inline is defined.
 	if sk.RunAs != RunSubagent {

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -11,7 +11,45 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
+
+func TestPreparePluginSkillBindsMCPNamesAndAllowedTools(t *testing.T) {
+	store := New(Options{HomeDir: t.TempDir(), DisableBuiltins: true})
+	bindings := []tool.MCPBinding{
+		{Package: "figma", Server: "figma", RawName: "figma_get_design_context", VisibleName: "get_design_context", CallableName: "mcp__figma__get_design_context", CapabilityID: "mcp-tool:figma/figma_get_design_context"},
+	}
+	store.ConfigureToolBindings(func(Skill) []tool.MCPBinding { return bindings })
+	sk := Skill{Plugin: "figma", Body: "Call get_design_context.", AllowedTools: []string{"mcp__plugin_figma_figma__get_design_context"}}
+
+	got := store.Prepare(sk)
+	if !strings.Contains(got.Body, "## Runtime MCP tool bindings") || !strings.Contains(got.Body, "`mcp__figma__get_design_context`") {
+		t.Fatalf("runtime binding missing:\n%s", got.Body)
+	}
+	if len(got.AllowedTools) != 1 || got.AllowedTools[0] != "mcp__figma__get_design_context" {
+		t.Fatalf("AllowedTools = %v, want canonical name", got.AllowedTools)
+	}
+	if twice := store.Prepare(got); twice.Body != got.Body {
+		t.Fatalf("Prepare is not idempotent:\n%s", twice.Body)
+	}
+	if plain := store.Prepare(Skill{Body: "unchanged"}); plain.Body != "unchanged" {
+		t.Fatalf("non-plugin skill changed: %q", plain.Body)
+	}
+}
+
+func TestPreparePluginSkillDoesNotWidenAmbiguousAllowedTool(t *testing.T) {
+	store := New(Options{HomeDir: t.TempDir(), DisableBuiltins: true})
+	store.ConfigureToolBindings(func(Skill) []tool.MCPBinding {
+		return []tool.MCPBinding{
+			{Server: "one", RawName: "search", VisibleName: "search", CallableName: "mcp__one__search", CapabilityID: "mcp-tool:one/search"},
+			{Server: "two", RawName: "search", VisibleName: "search", CallableName: "mcp__two__search", CapabilityID: "mcp-tool:two/search"},
+		}
+	})
+	got := store.Prepare(Skill{Plugin: "pkg", Body: "Search.", AllowedTools: []string{"search"}})
+	if len(got.AllowedTools) != 1 || got.AllowedTools[0] != "search" {
+		t.Fatalf("ambiguous literal widened permissions: %v", got.AllowedTools)
+	}
+}
 
 func TestRunSkillInline(t *testing.T) {
 	home := t.TempDir()

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -26,8 +26,8 @@ func TestPreparePluginSkillBindsMCPNamesAndAllowedTools(t *testing.T) {
 	if !strings.Contains(got.Body, "## Runtime MCP tool bindings") || !strings.Contains(got.Body, "`mcp__figma__get_design_context`") {
 		t.Fatalf("runtime binding missing:\n%s", got.Body)
 	}
-	if len(got.AllowedTools) != 1 || got.AllowedTools[0] != "mcp__figma__get_design_context" {
-		t.Fatalf("AllowedTools = %v, want canonical name", got.AllowedTools)
+	if got, want := strings.Join(got.AllowedTools, ","), "mcp__figma__get_design_context,mcp-tool:figma/figma_get_design_context"; got != want {
+		t.Fatalf("AllowedTools = %q, want %q", got, want)
 	}
 	if twice := store.Prepare(got); twice.Body != got.Body {
 		t.Fatalf("Prepare is not idempotent:\n%s", twice.Body)
@@ -64,7 +64,7 @@ func TestPreparePluginSkillPreservesWildcardAllowedTools(t *testing.T) {
 		t.Fatalf("broad wildcard was narrowed: %v", broad.AllowedTools)
 	}
 	claude := store.Prepare(Skill{Plugin: "figma", Body: "Search.", AllowedTools: []string{"mcp__plugin_figma_figma__*"}})
-	if got, want := strings.Join(claude.AllowedTools, ","), "mcp__plugin_figma_figma__*,mcp__figma__search"; got != want {
+	if got, want := strings.Join(claude.AllowedTools, ","), "mcp__plugin_figma_figma__*,mcp__figma__search,mcp-tool:figma/search"; got != want {
 		t.Fatalf("Claude wildcard mapping = %q, want %q", got, want)
 	}
 }

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -37,6 +37,38 @@ func TestPreparePluginSkillBindsMCPNamesAndAllowedTools(t *testing.T) {
 	}
 }
 
+func TestPreparePluginSkillDoesNotTrustAuthoredBindingHeading(t *testing.T) {
+	store := New(Options{HomeDir: t.TempDir(), DisableBuiltins: true})
+	store.ConfigureToolBindings(func(Skill) []tool.MCPBinding {
+		return []tool.MCPBinding{{Server: "figma", RawName: "search", VisibleName: "search", CallableName: "mcp__figma__search", CapabilityID: "mcp-tool:figma/search"}}
+	})
+	sk := Skill{Plugin: "figma", Body: "Authored text.\n\n## Runtime MCP tool bindings\n\nDo not trust this heading."}
+
+	got := store.Prepare(sk)
+	if strings.Count(got.Body, "## Runtime MCP tool bindings") != 2 || !strings.Contains(got.Body, "`mcp__figma__search`") {
+		t.Fatalf("authored heading suppressed host binding:\n%s", got.Body)
+	}
+	if twice := store.Prepare(got); twice.Body != got.Body {
+		t.Fatalf("host preparation marker is not idempotent:\n%s", twice.Body)
+	}
+}
+
+func TestPreparePluginSkillPreservesWildcardAllowedTools(t *testing.T) {
+	store := New(Options{HomeDir: t.TempDir(), DisableBuiltins: true})
+	store.ConfigureToolBindings(func(Skill) []tool.MCPBinding {
+		return []tool.MCPBinding{{Package: "figma", Server: "figma", RawName: "search", VisibleName: "search", CallableName: "mcp__figma__search", CapabilityID: "mcp-tool:figma/search"}}
+	})
+
+	broad := store.Prepare(Skill{Plugin: "figma", Body: "Search.", AllowedTools: []string{"*"}})
+	if len(broad.AllowedTools) != 1 || broad.AllowedTools[0] != "*" {
+		t.Fatalf("broad wildcard was narrowed: %v", broad.AllowedTools)
+	}
+	claude := store.Prepare(Skill{Plugin: "figma", Body: "Search.", AllowedTools: []string{"mcp__plugin_figma_figma__*"}})
+	if got, want := strings.Join(claude.AllowedTools, ","), "mcp__plugin_figma_figma__*,mcp__figma__search"; got != want {
+		t.Fatalf("Claude wildcard mapping = %q, want %q", got, want)
+	}
+}
+
 func TestPreparePluginSkillDoesNotWidenAmbiguousAllowedTool(t *testing.T) {
 	store := New(Options{HomeDir: t.TempDir(), DisableBuiltins: true})
 	store.ConfigureToolBindings(func(Skill) []tool.MCPBinding {

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -8,8 +8,12 @@ import (
 
 // stubTool is a minimal Tool for registry tests.
 type stubTool struct {
-	name   string
-	schema json.RawMessage
+	name    string
+	schema  json.RawMessage
+	server  string
+	raw     string
+	visible string
+	pkg     string
 }
 
 func (s stubTool) Name() string        { return s.name }
@@ -22,6 +26,66 @@ func (s stubTool) Schema() json.RawMessage {
 }
 func (s stubTool) Execute(context.Context, json.RawMessage) (string, error) { return "", nil }
 func (s stubTool) ReadOnly() bool                                           { return true }
+func (s stubTool) MCPServerName() string                                    { return s.server }
+func (s stubTool) MCPRawToolName() string                                   { return s.raw }
+func (s stubTool) MCPVisibleToolName() string                               { return s.visible }
+func (s stubTool) MCPPackageName() string                                   { return s.pkg }
+
+func TestRegistryResolvesPortableMCPReferencesOnlyWhenUnique(t *testing.T) {
+	r := NewRegistry()
+	first := stubTool{name: "mcp__figma__get_design_context", server: "figma", raw: "figma_get_design_context", visible: "get_design_context", pkg: "figma"}
+	r.Add(first)
+
+	refs := []string{
+		"get_design_context",
+		"figma_get_design_context",
+		"figma/get_design_context",
+		"mcp-tool:figma/figma_get_design_context",
+		"mcp__plugin_figma_figma__get_design_context",
+	}
+	for _, ref := range refs {
+		got, canonical, ambiguous := r.ResolveCall(ref)
+		if got == nil || canonical != first.name || len(ambiguous) != 0 {
+			t.Errorf("ResolveCall(%q) = (%v, %q, %v), want %q", ref, got, canonical, ambiguous, first.name)
+		}
+	}
+
+	// Exact registered names always win, even if they are also another MCP
+	// tool's short/raw alias.
+	r.Add(stubTool{name: "get_design_context"})
+	got, canonical, ambiguous := r.ResolveCall("get_design_context")
+	if got == nil || canonical != "get_design_context" || len(ambiguous) != 0 {
+		t.Fatalf("exact name did not win: (%v, %q, %v)", got, canonical, ambiguous)
+	}
+
+	r.Add(stubTool{name: "mcp__other__get_design_context", server: "other", raw: "get_design_context", visible: "get_design_context"})
+	_, _, ambiguous = r.ResolveCall("figma_get_design_context")
+	if len(ambiguous) != 0 {
+		t.Fatalf("distinct raw name became ambiguous: %v", ambiguous)
+	}
+	_, _, ambiguous = r.ResolveCall("get_design_context")
+	if len(ambiguous) != 0 { // exact builtin-style name still wins
+		t.Fatalf("exact registered name should suppress alias ambiguity: %v", ambiguous)
+	}
+	r.RemovePrefix("get_design_context")
+	_, canonical, ambiguous = r.ResolveCall("get_design_context")
+	if canonical != "" || len(ambiguous) != 2 {
+		t.Fatalf("ambiguous short reference = canonical %q candidates %v, want two candidates", canonical, ambiguous)
+	}
+}
+
+func TestRegistryPortableAliasesDoNotChangeProviderSchemas(t *testing.T) {
+	r := NewRegistry()
+	r.Add(stubTool{name: "mcp__my_server_deadbeef__do_thing_deadbeef", server: "my.server", raw: "do.thing", visible: "do.thing"})
+	before := r.Schemas()
+	if got, canonical, ambiguous := r.ResolveCall("mcp__my_server__do_thing"); got == nil || canonical == "" || len(ambiguous) != 0 {
+		t.Fatalf("portable normalized reference did not resolve: (%v, %q, %v)", got, canonical, ambiguous)
+	}
+	after := r.Schemas()
+	if len(before) != 1 || len(after) != 1 || before[0].Name != after[0].Name {
+		t.Fatalf("alias resolution changed provider schemas: before=%v after=%v", before, after)
+	}
+}
 
 // TestRegistryRemovePrefix proves an MCP server's namespaced tools are dropped as
 // a group on disconnect, leaving built-ins and other servers' tools — and their

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -117,6 +117,30 @@ type MCPMetadata interface {
 	MCPRawToolName() string
 }
 
+// MCPVisibleMetadata exposes the server-local name after any host-configured
+// prefix stripping. It is the short name authors usually write in skills.
+type MCPVisibleMetadata interface {
+	MCPVisibleToolName() string
+}
+
+// MCPPackageMetadata identifies the plugin package that contributed an MCP
+// server. Empty means the server came from ordinary user/workspace config.
+type MCPPackageMetadata interface {
+	MCPPackageName() string
+}
+
+// MCPBinding describes one stable MCP capability and the exact provider-visible
+// name currently bound to it. Bindings are host metadata only: they never add
+// aliases to provider schemas or alter schema ordering.
+type MCPBinding struct {
+	Package      string
+	Server       string
+	RawName      string
+	VisibleName  string
+	CallableName string
+	CapabilityID string
+}
+
 // MCPAnnotations exposes safety-relevant annotations reported by an installed
 // MCP server. These hints do not change the provider-visible tool contract;
 // execution policy consumes them locally.
@@ -383,6 +407,124 @@ func (r *Registry) Get(name string) (Tool, bool) {
 
 	t, ok := r.tools[name]
 	return t, ok
+}
+
+// MCPBindings returns live MCP capability bindings in canonical-name order.
+func (r *Registry) MCPBindings() []MCPBinding {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]MCPBinding, 0, len(r.tools))
+	for _, t := range r.tools {
+		if b, ok := mcpBinding(t); ok {
+			out = append(out, b)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CallableName < out[j].CallableName })
+	return out
+}
+
+// ResolveCall resolves an exact provider-visible name or a unique portable MCP
+// reference. Exact names always win. Ambiguous aliases return their canonical
+// candidates and are never executed.
+func (r *Registry) ResolveCall(name string) (resolved Tool, canonical string, candidates []string) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if t, ok := r.tools[name]; ok {
+		return t, name, nil
+	}
+	matches := map[string]Tool{}
+	for canonicalName, t := range r.tools {
+		b, ok := mcpBinding(t)
+		if !ok {
+			continue
+		}
+		for _, alias := range mcpBindingAliases(b) {
+			if name == alias {
+				matches[canonicalName] = t
+				break
+			}
+		}
+	}
+	if len(matches) == 1 {
+		for canonicalName, t := range matches {
+			return t, canonicalName, nil
+		}
+	}
+	if len(matches) > 1 {
+		candidates = make([]string, 0, len(matches))
+		for canonicalName := range matches {
+			candidates = append(candidates, canonicalName)
+		}
+		sort.Strings(candidates)
+	}
+	return nil, "", candidates
+}
+
+func mcpBinding(t Tool) (MCPBinding, bool) {
+	meta, ok := t.(MCPMetadata)
+	if !ok {
+		return MCPBinding{}, false
+	}
+	server := strings.TrimSpace(meta.MCPServerName())
+	raw := strings.TrimSpace(meta.MCPRawToolName())
+	if server == "" || raw == "" {
+		return MCPBinding{}, false
+	}
+	visible := raw
+	if v, ok := t.(MCPVisibleMetadata); ok && strings.TrimSpace(v.MCPVisibleToolName()) != "" {
+		visible = strings.TrimSpace(v.MCPVisibleToolName())
+	}
+	pkg := ""
+	if p, ok := t.(MCPPackageMetadata); ok {
+		pkg = strings.TrimSpace(p.MCPPackageName())
+	}
+	return MCPBinding{
+		Package:      pkg,
+		Server:       server,
+		RawName:      raw,
+		VisibleName:  visible,
+		CallableName: t.Name(),
+		CapabilityID: "mcp-tool:" + server + "/" + raw,
+	}, true
+}
+
+func mcpBindingAliases(b MCPBinding) []string {
+	aliases := []string{
+		b.RawName,
+		b.VisibleName,
+		b.Server + "/" + b.RawName,
+		b.Server + "/" + b.VisibleName,
+		b.CapabilityID,
+		"mcp-tool:" + b.Server + "/" + b.VisibleName,
+		"mcp__" + portableMCPPart(b.Server) + "__" + portableMCPPart(b.RawName),
+		"mcp__" + portableMCPPart(b.Server) + "__" + portableMCPPart(b.VisibleName),
+	}
+	if b.Package != "" {
+		prefix := "mcp__plugin_" + portableMCPPart(b.Package) + "_" + portableMCPPart(b.Server) + "__"
+		aliases = append(aliases, prefix+portableMCPPart(b.RawName), prefix+portableMCPPart(b.VisibleName))
+	}
+	return aliases
+}
+
+// MCPBindingAliases returns accepted portable references for a binding. The
+// canonical provider-visible name remains MCPBinding.CallableName.
+func MCPBindingAliases(b MCPBinding) []string {
+	return append([]string(nil), mcpBindingAliases(b)...)
+}
+
+func portableMCPPart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // Len returns the number of registered tools.


### PR DESCRIPTION
## Summary

- Add package-aware runtime bindings between plugin skills and their MCP tools.
- Accept raw names, stable `mcp-tool:<server>/<raw>` capability IDs, Reasonix-style names, and Claude plugin-qualified names only when they resolve uniquely.
- Rewrite exact `allowed-tools` references to canonical names when safe, while preserving broad wildcard patterns and supplementing only canonical names those patterns cannot match.
- Preserve MCP-specific subagent allowlists for on-demand tools through an exact-ID-restricted `use_capability` proxy, without granting other capabilities.
- Keep permission checks, Plan mode, hooks, evidence, and audit identities on the canonical Reasonix tool name.
- Use fingerprint-valid cached schemas for on-demand package tools, while treating live registry bindings as authoritative for connected servers.

## Problem

Reasonix canonicalizes MCP tools into provider-visible names such as `mcp__server__tool`, while imported plugin skills preserve their upstream Markdown and structured tool references. A skill that names the raw MCP tool or Claude's plugin-qualified form can therefore ask the model to call a name that is not registered, even though the underlying MCP tool is available.

## Root cause

MCP registration and skill import were independent paths. The registry knew the canonical adapter name, but an invoked plugin skill had no session-local mapping from its upstream references to that adapter. Dispatch also required an exact registry name.

## Fix

The registry now exposes host-only MCP binding metadata and resolves portable references only when exactly one live tool matches. Exact registered names always win, and ambiguous aliases fail closed with canonical candidates.

Plugin package provenance is carried into live and lazy MCP adapters. Every host invocation path prepares the selected plugin skill and appends a deterministic, authoritative binding block to that invocation only. Structured `allowed-tools` entries map to canonical names when safe; stable capability IDs remain host-only allowlist entries so a subagent can use an on-demand tool through a restricted `use_capability` wrapper when no direct binding exists. That wrapper enforces the exact ID set in both resolver and direct execution paths.

Preparation idempotence is tracked with host-only state rather than trusting authored Markdown. Valid cached metadata supplies the same mapping for on-demand servers, but never overrides a server already represented by the live registry.

This does not add alias schemas or mutate the global Skills index. Provider-visible parent tool names, schemas, and ordering remain unchanged.

## Security and cache behavior

- Alias resolution cannot bypass policy: permission, approval, Plan-mode, hook, and audit decisions use the canonical name.
- Ambiguous short names never execute and never broaden a subagent allowlist.
- Broad wildcard allowlists retain their existing semantics; exact portable aliases are canonicalized only on unique resolution.
- A capability-only subagent proxy rejects every capability ID outside the prepared MCP allowlist; direct live tools still take precedence.
- Authored skill content cannot suppress the host-generated runtime binding block.
- Dynamic bindings are injected only into the selected skill invocation, not the stable system prompt or parent provider tool list.
- MCP package provenance and preparation state are host-only and excluded from schema fingerprints and persisted source.
- No dependencies, network behavior, sandbox roots, or persisted user data formats are changed.

## Backward compatibility

| Field or surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| `plugin.Spec.Package` | Missing/empty remains an ordinary non-package MCP server; the field is host-only and not serialized | Compatible |
| Existing skill Markdown/frontmatter | Stored source remains unchanged; runtime preparation operates on a value copy, and authored binding-like headings have no control effect | Compatible |
| Existing canonical MCP calls | Exact registry lookup still wins before alias resolution | Compatible |
| Existing `allowed-tools` entries | Wildcards are preserved; unique MCP references bind directly or through an exact-ID proxy; nonmatching or ambiguous literals remain unchanged | Compatible / fail-closed |
| MCP schema cache | Package provenance does not affect `SpecFingerprint`; only fingerprint-valid cached tools are bound, and a live server surface takes precedence | Compatible |
| Provider tool contract | No alias schemas are registered; canonical parent names and sorted schemas are unchanged | Compatible |

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/skill ./internal/boot ./internal/tool ./internal/agent ./internal/plugin ./internal/control`
- `./scripts/cache-guard.sh`
- `git diff --check`

Focused coverage verifies unique raw/capability/Claude references, ambiguity rejection, canonical permission identity, wildcard preservation, `allowed-tools` fail-closed behavior, capability-only exact-ID enforcement, untrusted authored headings, every host invocation path, live-over-stale-cache precedence, cached on-demand bindings, package provenance, fingerprint stability, and unchanged parent provider schemas.

Cache-impact: low - Runtime MCP bindings are appended only to the selected skill invocation; provider-visible parent tool schemas, ordering, and the global system prompt remain unchanged.
Cache-guard: `./scripts/cache-guard.sh` passed all dialogue and tool-loop cases with 92-95% tail averages on both the PR head and its simulated merge with current `main-v2`.
System-prompt-review: Reviewed locally against the system-prompt cache contract; no global system-prompt or cache-stable Skills index mutation is introduced.

## Integration

- Current `main-v2` includes #6703. A simulated merge of that head with this PR is conflict-free and passes the full test, vet, formatting, and cache-guard suite.
- Draft PR #6623 overlaps this PR in `internal/boot/boot.go`, `internal/control/controller.go`, and `internal/plugin/lazy.go` and currently produces content conflicts. This focused fix should land first; #6623 should then rebase and preserve the binding, canonical-security, and scoped-proxy contracts added here.
