### PR TITLE
feat(serve): add web UI light theme support with toggle button

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,22 @@ func (c *Config) UIThemeStyle() string {
 	return normalizeThemeStyle(c.UI.ThemeStyle)
 }
 
+// ServeTheme normalizes serve.theme. Falls back to ui.theme if serve.theme is empty.
+func (c *Config) ServeTheme() string {
+	t := strings.ToLower(strings.TrimSpace(c.Serve.Theme))
+	if t == "" {
+		return c.UITheme()
+	}
+	switch t {
+	case "dark":
+		return "dark"
+	case "light":
+		return "light"
+	default:
+		return "auto"
+	}
+}
+
 // UIShortcutLayout normalizes the legacy CLI shortcut layout setting. It is kept
 // for compatibility; Shift+Tab toggles Plan and Ctrl+Y toggles YOLO in both
 // layouts.
@@ -711,7 +727,7 @@ type BotConnectionSessionMapping struct {
 	UpdatedAt     string `toml:"updated_at"`
 }
 
-// ServeConfig controls the HTTP serve frontend security settings.
+// ServeConfig controls the HTTP serve frontend security and appearance settings.
 type ServeConfig struct {
 	// AuthMode selects the authentication mode for the HTTP serve frontend.
 	// "none" (default): no authentication.
@@ -730,6 +746,11 @@ type ServeConfig struct {
 	// rate-limiting and Secure-cookie decisions. When false (default), they
 	// are ignored — an attacker can otherwise forge them.
 	BehindProxy bool `toml:"behind_proxy"`
+	// Theme selects the color scheme for the web UI served by "reasonix serve".
+	// "auto" (default): respect OS preference (prefers-color-scheme).
+	// "light": force light mode.
+	// "dark": force dark mode.
+	Theme string `toml:"theme"`
 }
 
 // NetworkConfig controls ordinary outbound HTTP traffic such as model providers,

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -471,6 +471,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	fmt.Fprintf(&b, "network = %v\n", c.Sandbox.Network)
 	b.WriteString("\n")
 
+	if shouldRenderServe(c, defaults, scope) {
+		b.WriteString("[serve]\n")
+		fmt.Fprintf(&b, "theme = %q   # auto|dark|light; web UI color scheme; \"auto\" respects OS preference\n\n", c.ServeTheme())
+	}
+
 	b.WriteString("[statusline]\n")
 	b.WriteString("# A custom status line: a command whose first stdout line replaces the built-in\n")
 	b.WriteString("# data row. It receives {\"model\",\"contextUsed\",\"contextWindow\",\"cwd\"} as JSON on stdin.\n")
@@ -1206,6 +1211,10 @@ func shouldRenderUI(c, defaults *Config, scope RenderScope) bool {
 		return true
 	}
 	return !reflect.DeepEqual(c.UI, defaults.UI)
+}
+
+func shouldRenderServe(c, defaults *Config, scope RenderScope) bool {
+	return scope != RenderScopeProject || c.Serve.Theme != ""
 }
 
 func shouldRenderNetwork(c, defaults *Config, scope RenderScope) bool {

--- a/internal/serve/auth.go
+++ b/internal/serve/auth.go
@@ -319,10 +319,19 @@ func (ag *authGate) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func loginTheme() string {
+	_, _ = config.MigrateLegacyIfNeeded()
+	if cfg, err := config.Load(); err == nil {
+		return cfg.ServeTheme()
+	}
+	return "auto"
+}
+
 // loginPage serves the embedded login HTML.
 func (ag *authGate) loginPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write(loginHTML)
+	html := strings.Replace(string(loginHTML), "__THEME__", loginTheme(), 1)
+	_, _ = w.Write([]byte(html))
 }
 
 // loginSubmit verifies the password and issues a session cookie.
@@ -504,7 +513,9 @@ func (ag *authGate) verifySession(token string) bool {
 func (ag *authGate) loginPageWithError(w http.ResponseWriter, msg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusUnauthorized)
-	html := strings.Replace(string(loginHTML), "<!--ERROR-->",
+	html := string(loginHTML)
+	html = strings.Replace(html, "__THEME__", loginTheme(), 1)
+	html = strings.Replace(html, "<!--ERROR-->",
 		`<div class="error">`+htmlEscape(msg)+`</div>`, 1)
 	_, _ = w.Write([]byte(html))
 }

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="__THEME__">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -29,6 +29,23 @@
   --heading:'Space Grotesk',var(--sans);
   --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   color-scheme:dark;
+}
+:root[data-theme="light"]{
+  --bg:oklch(97% .005 280);--bg-2:oklch(93% .006 275);
+  --panel:oklch(90% .007 275);--panel-2:oklch(87% .008 275);
+  --card:oklch(95% .007 275);--card-hover:oklch(88% .008 275);
+  --border:oklch(85% .008 275);--border-strong:oklch(75% .01 275);
+  --fg:oklch(20% .004 280);--fg-2:oklch(40% .005 280);
+  --muted:oklch(55% .006 280);--muted-2:oklch(65% .006 280);
+  --accent:oklch(55% .18 38);--accent-soft:oklch(55% .18 38/.12);--accent-strong:oklch(48% .2 36);
+  --success:oklch(50% .16 145);--success-soft:oklch(50% .16 145/.12);
+  --warning:oklch(60% .16 85);--warning-soft:oklch(60% .16 85/.14);
+  --danger:oklch(52% .2 25);--danger-soft:oklch(52% .2 25/.14);
+  --violet:oklch(55% .16 295);--violet-soft:oklch(55% .16 295/.14);
+  --shadow-sm:0 1px 0 oklch(0% 0 0/.08);
+  --shadow-md:0 8px 24px -8px oklch(0% 0 0/.12);
+  --shadow-lg:0 24px 60px -16px oklch(0% 0 0/.18);
+  color-scheme:light;
 }
 html,body{height:100%;overflow:hidden}
 body{font:14px/1.6 var(--sans);color:var(--fg);background:var(--bg);-webkit-font-smoothing:antialiased}
@@ -588,6 +605,8 @@ input,textarea{font:inherit;color:inherit}
   </div>
 </div>
 <script>
+// ── theme ──
+(function(){var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}document.documentElement.setAttribute('data-theme',t)})();
 // ── i18n ──
 const __LANG_PREF = '__LANG__';
 const __LANG = (__LANG_PREF === 'zh' || __LANG_PREF === 'en') ? __LANG_PREF : ((navigator.language || '').startsWith('zh') ? 'zh' : 'en');

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -31,20 +31,20 @@
   color-scheme:dark;
 }
 :root[data-theme="light"]{
-  --bg:oklch(97% .005 280);--bg-2:oklch(93% .006 275);
-  --panel:oklch(90% .007 275);--panel-2:oklch(87% .008 275);
-  --card:oklch(95% .007 275);--card-hover:oklch(88% .008 275);
-  --border:oklch(85% .008 275);--border-strong:oklch(75% .01 275);
-  --fg:oklch(20% .004 280);--fg-2:oklch(40% .005 280);
-  --muted:oklch(55% .006 280);--muted-2:oklch(65% .006 280);
-  --accent:oklch(55% .18 38);--accent-soft:oklch(55% .18 38/.12);--accent-strong:oklch(48% .2 36);
-  --success:oklch(50% .16 145);--success-soft:oklch(50% .16 145/.12);
-  --warning:oklch(60% .16 85);--warning-soft:oklch(60% .16 85/.14);
-  --danger:oklch(52% .2 25);--danger-soft:oklch(52% .2 25/.14);
-  --violet:oklch(55% .16 295);--violet-soft:oklch(55% .16 295/.14);
-  --shadow-sm:0 1px 0 oklch(0% 0 0/.08);
-  --shadow-md:0 8px 24px -8px oklch(0% 0 0/.12);
-  --shadow-lg:0 24px 60px -16px oklch(0% 0 0/.18);
+  --bg:oklch(97.5% .003 280);--bg-2:oklch(94% .004 270);
+  --panel:oklch(92% .004 275);--panel-2:oklch(89% .005 270);
+  --card:oklch(96% .003 280);--card-hover:oklch(91% .004 270);
+  --border:oklch(86% .005 270);--border-strong:oklch(78% .006 270);
+  --fg:oklch(18% .005 280);--fg-2:oklch(38% .006 275);
+  --muted:oklch(55% .006 275);--muted-2:oklch(65% .005 270);
+  --accent:oklch(52% .19 35);--accent-soft:oklch(52% .19 35/.1);--accent-strong:oklch(45% .21 33);
+  --success:oklch(46% .17 145);--success-soft:oklch(46% .17 145/.1);
+  --warning:oklch(58% .17 82);--warning-soft:oklch(58% .17 82/.12);
+  --danger:oklch(48% .21 22);--danger-soft:oklch(48% .21 22/.12);
+  --violet:oklch(50% .17 292);--violet-soft:oklch(50% .17 292/.12);
+  --shadow-sm:0 1px 0 oklch(0% 0 0/.05);
+  --shadow-md:0 8px 24px -8px oklch(0% 0 0/.08);
+  --shadow-lg:0 24px 60px -16px oklch(0% 0 0/.12);
   color-scheme:light;
 }
 html,body{height:100%;overflow:hidden}
@@ -66,6 +66,7 @@ input,textarea{font:inherit;color:inherit}
 .sidebar__logo{width:26px;height:26px;border-radius:7px;background:linear-gradient(135deg,var(--accent),var(--violet));display:flex;align-items:center;justify-content:center;font-family:var(--heading);font-weight:700;font-size:13px;color:oklch(99% 0 0)}
 .sidebar__name{font-family:var(--heading);font-size:14px;font-weight:600}
 .brand-wordmark{display:block;object-fit:contain;filter:brightness(0) invert(1);opacity:.94}
+:root[data-theme="light"] .brand-wordmark{filter:none;opacity:.8}
 .brand-wordmark--sidebar{width:136px;height:32px;object-position:left center}
 .brand-wordmark--welcome{width:240px;height:56px}
 .sidebar__nav{flex:1;padding:8px;display:flex;flex-direction:column;gap:1px;overflow-y:auto}
@@ -76,6 +77,13 @@ input,textarea{font:inherit;color:inherit}
 .sidebar__item--accent:hover{background:var(--accent-strong);color:oklch(99% 0 0)}
 .sidebar__item--disabled{opacity:.45;cursor:not-allowed}
 .sidebar__item--disabled:hover{background:transparent;color:var(--fg-2)}
+.sidebar__theme-tgl{display:flex;align-items:center;gap:7px;padding:8px 10px;margin:4px 8px;border-radius:6px;color:var(--muted);font-size:12px;cursor:pointer;transition:background .18s ease,color .18s ease}
+.sidebar__theme-tgl:hover{background:var(--panel);color:var(--fg-2)}
+.sidebar__theme-tgl svg{width:15px;height:15px;flex-shrink:0}
+.theme-tgl__icon--dark{display:block}
+.theme-tgl__icon--light{display:none}
+:root[data-theme="light"] .theme-tgl__icon--dark{display:none}
+:root[data-theme="light"] .theme-tgl__icon--light{display:block}
 .sidebar__item svg{width:15px;height:15px;flex-shrink:0;opacity:.7}
 .sidebar__item--active svg,.sidebar__item--accent svg{opacity:1}
 .sidebar__section{padding:8px;border-top:1px solid var(--border)}
@@ -432,6 +440,11 @@ input,textarea{font:inherit;color:inherit}
       <div style="padding:4px 10px">
         <div class="status" id="sidebar-status"><span class="status__dot" id="status-dot"></span><span id="status-model">-</span></div>
       </div>
+      <div class="sidebar__theme-tgl" id="theme-toggle" title="__('toggle_theme')">
+        <svg class="theme-tgl__icon theme-tgl__icon--dark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg class="theme-tgl__icon theme-tgl__icon--light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <span id="theme-toggle-label">__('toggle_theme')</span>
+      </div>
     </div>
   </aside>
 
@@ -606,7 +619,7 @@ input,textarea{font:inherit;color:inherit}
 </div>
 <script>
 // ── theme ──
-(function(){var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}document.documentElement.setAttribute('data-theme',t)})();
+(function(){var k='theme-pref',c=function(t){document.documentElement.setAttribute('data-theme',t)};var p=localStorage.getItem(k);if(p){c(p)}else{var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}c(t)};window.matchMedia('(prefers-color-scheme:light)').addEventListener('change',function(e){if(!localStorage.getItem(k)){c(e.matches?'light':'dark')}});document.getElementById('theme-toggle').addEventListener('click',function(){var n=document.documentElement.getAttribute('data-theme')==='light'?'dark':'light';c(n);localStorage.setItem(k,n)})})();
 // ── i18n ──
 const __LANG_PREF = '__LANG__';
 const __LANG = (__LANG_PREF === 'zh' || __LANG_PREF === 'en') ? __LANG_PREF : ((navigator.language || '').startsWith('zh') ? 'zh' : 'en');
@@ -709,6 +722,7 @@ const __T = {
     'delete': 'Delete',
     'delete_session': 'Delete Session',
     'search_sessions': 'Search sessions',
+    'toggle_theme': 'Toggle theme',
     'active': 'Active',
     'use_model': 'Use',
     'no_sessions': 'No sessions',
@@ -843,6 +857,7 @@ const __T = {
     'delete': '删除',
     'delete_session': '删除会话',
     'search_sessions': '搜索会话',
+    'toggle_theme': '切换主题',
     'active': '当前',
     'use_model': '使用',
     'no_sessions': '暂无会话',

--- a/internal/serve/login.html
+++ b/internal/serve/login.html
@@ -82,7 +82,7 @@
     text-align: center;
   }
 </style>
-<script>(function(){var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}document.documentElement.setAttribute('data-theme',t)})();</script>
+<script>(function(){var k='theme-pref',c=function(t){document.documentElement.setAttribute('data-theme',t)};var p=localStorage.getItem(k);if(p){c(p)}else{var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}c(t)}})();</script>
 </head>
 <body>
 <div class="login-box">

--- a/internal/serve/login.html
+++ b/internal/serve/login.html
@@ -1,59 +1,61 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="__THEME__">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Reasonix — Login</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root{--bg:#1a1a2e;--bg-2:#16213e;--border:#0f3460;--fg:#e0e0e0;--fg-2:#aaa;--subtle:#888;--accent:#e94560;--accent-hover:#d63851;--shadow:rgba(0,0,0,0.3)}
+  :root[data-theme="light"]{--bg:#f5f5f7;--bg-2:#ffffff;--border:#d1d1d6;--fg:#1d1d1f;--fg-2:#6e6e73;--subtle:#86868b;--accent:#e94560;--accent-hover:#d63851;--shadow:rgba(0,0,0,0.08)}
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: var(--bg);
+    color: var(--fg);
     display: flex; align-items: center; justify-content: center;
-    min-height: 100vh;
+    min-height: 100vh;transition:background .2s;
   }
   .login-box {
-    background: #16213e;
-    border: 1px solid #0f3460;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
     border-radius: 12px;
     padding: 40px 36px;
     width: 100%;
     max-width: 380px;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+    box-shadow: 0 8px 32px var(--shadow);
   }
   .login-box h1 {
     font-size: 22px;
     font-weight: 600;
     text-align: center;
     margin-bottom: 8px;
-    color: #e94560;
+    color: var(--accent);
   }
   .login-box .subtitle {
     text-align: center;
     font-size: 13px;
-    color: #888;
+    color: var(--subtle);
     margin-bottom: 28px;
   }
   .login-box label {
     display: block;
     font-size: 13px;
-    color: #aaa;
+    color: var(--fg-2);
     margin-bottom: 6px;
   }
   .login-box input[type="password"] {
     width: 100%;
     padding: 10px 14px;
-    border: 1px solid #0f3460;
+    border: 1px solid var(--border);
     border-radius: 8px;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: var(--bg);
+    color: var(--fg);
     font-size: 15px;
     outline: none;
     transition: border-color 0.2s;
   }
   .login-box input[type="password"]:focus {
-    border-color: #e94560;
+    border-color: var(--accent);
   }
   .login-box button {
     width: 100%;
@@ -61,25 +63,26 @@
     padding: 10px 0;
     border: none;
     border-radius: 8px;
-    background: #e94560;
+    background: var(--accent);
     color: #fff;
     font-size: 15px;
     font-weight: 600;
     cursor: pointer;
     transition: background 0.2s;
   }
-  .login-box button:hover { background: #d63851; }
+  .login-box button:hover { background: var(--accent-hover); }
   .error {
-    background: rgba(233, 69, 96, 0.15);
-    border: 1px solid #e94560;
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    border: 1px solid var(--accent);
     border-radius: 8px;
     padding: 10px 14px;
     font-size: 13px;
-    color: #e94560;
+    color: var(--accent);
     margin-bottom: 18px;
     text-align: center;
   }
 </style>
+<script>(function(){var t='__THEME__';if(t==='auto'){t=window.matchMedia('(prefers-color-scheme:light)').matches?'light':'dark'}document.documentElement.setAttribute('data-theme',t)})();</script>
 </head>
 <body>
 <div class="login-box">

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -443,13 +443,16 @@ func (s *Server) index(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = config.MigrateLegacyIfNeeded()
 	lang := "auto"
+	theme := "auto"
 	if cfg, err := config.Load(); err == nil {
 		if dl := cfg.DesktopLanguage(); dl != "" {
 			lang = dl
 		}
+		theme = cfg.ServeTheme()
 	}
 	html := string(indexHTML)
 	html = strings.ReplaceAll(html, "__LANG__", lang)
+	html = strings.ReplaceAll(html, "__THEME__", theme)
 	_, _ = w.Write([]byte(html))
 }
 


### PR DESCRIPTION
## Summary

Add light theme support to the `reasonix serve` web UI, including a toggle button for switching between light and dark modes.

### Changes

**`internal/config/config.go`**
- Add `Theme` field to `ServeConfig` for web UI color scheme
- Add `ServeTheme()` method with fallback to `ui.theme`

**`internal/config/render.go`**
- Add `[serve] theme` section rendering in TOML config output
- Add `shouldRenderServe()` helper

**`internal/serve/serve.go`**
- Inject `__THEME__` placeholder in the `index()` handler

**`internal/serve/auth.go`**
- Inject theme config into login page handlers

**`internal/serve/index.html`**
- Add light CSS variables under `:root[data-theme="light"]`
- Add theme toggle button in sidebar with sun/moon icons
- Add JavaScript for theme switching with localStorage persistence
- Respect OS `prefers-color-scheme` media query when no user preference is set
- Fix brand-wordmark filter for light mode
- Add i18n strings for toggle button

**`internal/serve/login.html`**
- Update theme JS to respect saved preference from localStorage

### Usage

Configure in `reasonix.toml`:
```toml
[serve]
theme = "light"   # auto|dark|light
```

Or toggle via the sidebar button in the web UI (preference saved to localStorage).