### PR TITLE
Prepare v1.17.16 release notes / 准备 v1.17.16 中英更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -6,17 +6,45 @@
       "date": "2026-07-20",
       "channel": "stable",
       "title": {
-        "en": "Reasonix Desktop 1.17.16",
-        "zh": "Reasonix 桌面版 1.17.16"
+        "en": "Reasonix 1.17.16",
+        "zh": "Reasonix 1.17.16"
       },
       "summary": {
-        "en": "Remote SSH, subagent fleets, regional typography, customizable shortcuts, and many fixes.",
-        "zh": "远程 SSH、子智能体舰队、分区域字体设置、可自定义快捷键以及大量修复。"
+        "en": "Remote SSH and parallel subagent fleets lead this release, alongside regional typography, customizable composer shortcuts, reliable exports, and stronger session and MCP recovery.",
+        "zh": "本次发布重点带来远程 SSH 与并行子智能体舰队，同时新增分区域字体和可自定义输入快捷键，并提升会话导出、会话恢复与 MCP 可靠性。"
       },
       "surfaces": [
-        "desktop"
+        "desktop",
+        "cli",
+        "agent",
+        "mcp",
+        "plugin",
+        "provider",
+        "security"
       ],
       "guides": [
+        {
+          "title": {
+            "en": "Remote SSH guide",
+            "zh": "远程 SSH 指南"
+          },
+          "body": {
+            "en": "Configure hosts, connect from the CLI or Desktop, browse remote files, and manage forwarded ports.",
+            "zh": "配置远程主机，通过 CLI 或 Desktop 连接、浏览远程文件并管理端口转发。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/GUIDE.md"
+        },
+        {
+          "title": {
+            "en": "Remote SSH guide (Chinese)",
+            "zh": "远程 SSH 指南（中文）"
+          },
+          "body": {
+            "en": "Chinese guide for Remote SSH host setup, connections, files, and port forwarding.",
+            "zh": "远程 SSH 主机配置、连接、文件浏览与端口转发的中文指南。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/GUIDE.zh-CN.md"
+        },
         {
           "title": {
             "en": "Subagent Profiles & Fleet",
@@ -283,19 +311,6 @@
             "refs": [
               6632
             ]
-          },
-          {
-            "title": {
-              "en": "Agent complete_step by index",
-              "zh": "通过索引完成步骤"
-            },
-            "body": {
-              "en": "The built‑in complete_step tool now accepts an optional step_index for unambiguous todo completion.",
-              "zh": "内置 complete_step 工具现在接受可选的 step_index，以便明确完成待办事项。"
-            },
-            "refs": [
-              5530
-            ]
           }
         ],
         "fixed": [
@@ -455,19 +470,6 @@
             "refs": [
               6630
             ]
-          },
-          {
-            "title": {
-              "en": "Language preference persistence",
-              "zh": "语言偏好持久化"
-            },
-            "body": {
-              "en": "User‑selected language is now correctly read from localStorage after restart.",
-              "zh": "重启后用户选择的语言现在能从 localStorage 正确读取。"
-            },
-            "refs": [
-              5507
-            ]
           }
         ]
       },
@@ -487,13 +489,38 @@
           ]
         }
       ],
-      "risks": [],
+      "risks": [
+        {
+          "title": {
+            "en": "Remote host support",
+            "zh": "远程主机支持范围"
+          },
+          "body": {
+            "en": "Remote SSH V1 supports Linux and macOS remote hosts. Windows remote hosts are not yet supported and return a clear error.",
+            "zh": "远程 SSH V1 支持 Linux 与 macOS 远程主机；Windows 远程主机暂不支持，并会返回明确错误。"
+          },
+          "refs": [
+            6673
+          ]
+        },
+        {
+          "title": {
+            "en": "One-time prompt-cache cold start",
+            "zh": "一次性提示缓存冷启动"
+          },
+          "body": {
+            "en": "The new fleet tool and extended task schema intentionally cause one prompt-cache cold start after upgrading. Tool order and schemas remain stable afterward.",
+            "zh": "新的 fleet 工具与扩展后的 task schema 会在升级后触发一次提示缓存冷启动；此后工具顺序与 schema 保持稳定。"
+          },
+          "refs": [
+            6636
+          ]
+        }
+      ],
       "contributors": [
         "SivanCola",
         "sudoviber",
         "yuanchenglu",
-        "HUQIANTAO",
-        "cyq1017",
         "HaoyueQin",
         "SauronSkywalker",
         "ffff2004",

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -2,6 +2,510 @@
   "schemaVersion": 1,
   "releases": [
     {
+      "version": "1.17.16",
+      "date": "2026-07-20",
+      "channel": "stable",
+      "title": {
+        "en": "Reasonix Desktop 1.17.16",
+        "zh": "Reasonix 桌面版 1.17.16"
+      },
+      "summary": {
+        "en": "Remote SSH, subagent fleets, regional typography, customizable shortcuts, and many fixes.",
+        "zh": "远程 SSH、子智能体舰队、分区域字体设置、可自定义快捷键以及大量修复。"
+      },
+      "surfaces": [
+        "desktop"
+      ],
+      "guides": [
+        {
+          "title": {
+            "en": "Subagent Profiles & Fleet",
+            "zh": "子智能体配置文件与舰队"
+          },
+          "body": {
+            "en": "Learn how to define and use subagent profiles, configure fleets, and manage concurrency.",
+            "zh": "了解如何定义和使用子智能体配置文件、配置舰队并管理并发。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/SUBAGENT_PROFILES.md"
+        },
+        {
+          "title": {
+            "en": "Theme Packs",
+            "zh": "主题包"
+          },
+          "body": {
+            "en": "Customize pane opacity and explore theme pack authoring.",
+            "zh": "自定义面板透明度并探索主题包制作。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/THEME_PACK.md"
+        },
+        {
+          "title": {
+            "en": "Command-Line Interface",
+            "zh": "命令行界面"
+          },
+          "body": {
+            "en": "See the latest CLI features, including middle-click paste and improved transcript layout.",
+            "zh": "查看最新的 CLI 功能，包括中键粘贴和改进的消息布局。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/CLI.md"
+        }
+      ],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": {
+            "en": "Remote SSH",
+            "zh": "远程 SSH"
+          },
+          "body": {
+            "en": "Connect to a remote host over SSH and run the full Reasonix agent and tools remotely. Includes host manager, file browser, port forwarding, and automatic reconnection.",
+            "zh": "通过 SSH 连接到远程主机并远程运行完整的 Reasonix 智能体与工具。包含主机管理、文件浏览、端口转发和自动重连。"
+          },
+          "refs": [
+            6673
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Subagent Fleets",
+            "zh": "子智能体舰队"
+          },
+          "body": {
+            "en": "Run up to 64 independent subagent tasks in parallel with configurable concurrency and profile-based system prompts. Safe write-path coordination prevents conflicts.",
+            "zh": "以可配置的并发度并行运行最多 64 个独立子智能体任务，支持基于配置文件的系统提示。通过写入路径协调避免冲突。"
+          },
+          "refs": [
+            6636
+          ]
+        },
+        {
+          "kind": "improved",
+          "title": {
+            "en": "Regional Typography",
+            "zh": "分区域字体设置"
+          },
+          "body": {
+            "en": "Independently adjust font family and size for interface, conversation, composer, and code areas with live preview.",
+            "zh": "独立调整界面、对话、输入框和代码区域的字体与大小，支持实时预览。"
+          },
+          "refs": [
+            6634
+          ]
+        },
+        {
+          "kind": "improved",
+          "title": {
+            "en": "Simplified MCP Authorization",
+            "zh": "简化的 MCP 授权"
+          },
+          "body": {
+            "en": "Streamlined MCP server installation and tool approval. Direct add-and-connect flow, per-project launch grants, and removed legacy trust management.",
+            "zh": "简化了 MCP 服务器安装与工具批准流程。直接添加连接，按项目授予启动权限，移除了旧版信任管理。"
+          },
+          "refs": [
+            6669
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Reliable Session Exports",
+            "zh": "可靠的会话导出"
+          },
+          "body": {
+            "en": "Image and PDF exports now work reliably across all platforms, with large conversations automatically split into multiple files.",
+            "zh": "图片和 PDF 导出现在在所有平台上均可可靠运行，长篇对话会自动拆分为多个文件。"
+          },
+          "refs": [
+            6685
+          ]
+        }
+      ],
+      "changes": {
+        "new": [
+          {
+            "title": {
+              "en": "Remote SSH module",
+              "zh": "远程 SSH 模块"
+            },
+            "body": {
+              "en": "Full VS Code Remote‑SSH style experience: connect to a remote host, run the agent there, browse and edit files, forward ports, and reconnect automatically.",
+              "zh": "完整的 VS Code Remote‑SSH 风格体验：连接到远程主机，在那里运行智能体，浏览和编辑文件，端口转发，并自动重连。"
+            },
+            "refs": [
+              6673
+            ]
+          },
+          {
+            "title": {
+              "en": "Subagent fleets",
+              "zh": "子智能体舰队"
+            },
+            "body": {
+              "en": "Parallel subagent execution with profiles, concurrency limits, write-path coordination, and background task support.",
+              "zh": "支持配置文件的并行子智能体执行，具备并发限制、写入路径协调和后台任务支持。"
+            },
+            "refs": [
+              6636
+            ]
+          },
+          {
+            "title": {
+              "en": "Per-model context windows",
+              "zh": "逐模型上下文窗口"
+            },
+            "body": {
+              "en": "Set a custom context window for individual models behind a shared provider endpoint.",
+              "zh": "为共享提供程序端点后的各个模型设置自定义上下文窗口。"
+            },
+            "refs": [
+              6677
+            ]
+          },
+          {
+            "title": {
+              "en": "Custom keyboard shortcuts for send/newline",
+              "zh": "自定义发送与换行快捷键"
+            },
+            "body": {
+              "en": "Configure separate shortcuts for sending a message and inserting a newline in the composer.",
+              "zh": "为发送消息和在输入框中插入换行分别配置快捷键。"
+            },
+            "refs": [
+              6503
+            ]
+          },
+          {
+            "title": {
+              "en": "CLI middle-click paste",
+              "zh": "CLI 中键粘贴"
+            },
+            "body": {
+              "en": "Restore middle-click paste in the Reasonix CLI (tmux buffer or PRIMARY selection).",
+              "zh": "在 Reasonix CLI 中恢复中键粘贴功能（tmux 缓冲区或 PRIMARY 选择区）。"
+            },
+            "refs": [
+              6589
+            ]
+          }
+        ],
+        "improved": [
+          {
+            "title": {
+              "en": "Regional typography controls",
+              "zh": "分区域字体控制"
+            },
+            "body": {
+              "en": "Fine-tune fonts and sizes for different parts of the UI: interface, conversation, composer, and code/tools.",
+              "zh": "精细调整界面、对话、输入框、代码/工具等不同区域的字体和大小。"
+            },
+            "refs": [
+              6634
+            ]
+          },
+          {
+            "title": {
+              "en": "Configurable conversation width",
+              "zh": "可配置的对话宽度"
+            },
+            "body": {
+              "en": "Choose between Standard (960px) and Full width (90%) for the chat area.",
+              "zh": "在标准宽度（960px）和全宽（90%）之间选择聊天区域宽度。"
+            },
+            "refs": [
+              6590
+            ]
+          },
+          {
+            "title": {
+              "en": "Pane opacity & theme pack fixes",
+              "zh": "面板透明度与主题包修复"
+            },
+            "body": {
+              "en": "Added pane opacity controls for home/workspace scenes; fixed active theme reverting on settings save.",
+              "zh": "新增主界面/工作区场景的面板透明度控制；修复保存设置后活动主题回退的问题。"
+            },
+            "refs": [
+              6645,
+              6694
+            ]
+          },
+          {
+            "title": {
+              "en": "Streamlined MCP install & authorization",
+              "zh": "简化的 MCP 安装与授权"
+            },
+            "body": {
+              "en": "Removed legacy trust state machine; user‑added servers now connect directly, and tool approval respects explicit install authorization.",
+              "zh": "移除了旧版信任状态机；用户添加的服务器现在直接连接，工具批准遵循明确的安装授权。"
+            },
+            "refs": [
+              6669
+            ]
+          },
+          {
+            "title": {
+              "en": "Plugin skill MCP tool bindings",
+              "zh": "插件 Skill 的 MCP 工具绑定"
+            },
+            "body": {
+              "en": "Imported skills now correctly map to live MCP tools even when they use raw or upstream names.",
+              "zh": "导入的 skill 现在能正确映射到实时的 MCP 工具，即使它们使用原始或上游名称。"
+            },
+            "refs": [
+              6705
+            ]
+          },
+          {
+            "title": {
+              "en": "Crash diagnostics hardening",
+              "zh": "崩溃诊断强化"
+            },
+            "body": {
+              "en": "Separated release crashes from development signals; reduced spurious prompts; fixed virtualizer and Mermaid rendering errors.",
+              "zh": "将发布版崩溃与开发信号分离；减少误报提示；修复了虚拟列表和 Mermaid 渲染错误。"
+            },
+            "refs": [
+              6678
+            ]
+          },
+          {
+            "title": {
+              "en": "CLI terminal interactions",
+              "zh": "CLI 终端交互改进"
+            },
+            "body": {
+              "en": "Better copy/paste handling, restored right-click paste, and improved transcript layout and spacing.",
+              "zh": "改进了复制粘贴处理，恢复右键粘贴，并优化了消息布局和间距。"
+            },
+            "refs": [
+              6632
+            ]
+          },
+          {
+            "title": {
+              "en": "Agent complete_step by index",
+              "zh": "通过索引完成步骤"
+            },
+            "body": {
+              "en": "The built‑in complete_step tool now accepts an optional step_index for unambiguous todo completion.",
+              "zh": "内置 complete_step 工具现在接受可选的 step_index，以便明确完成待办事项。"
+            },
+            "refs": [
+              5530
+            ]
+          }
+        ],
+        "fixed": [
+          {
+            "title": {
+              "en": "Reliable session image/PDF exports",
+              "zh": "可靠的会话图片/PDF 导出"
+            },
+            "body": {
+              "en": "Fixed cross‑origin canvas taint and memory issues; exports now work everywhere and auto‑split long conversations.",
+              "zh": "修复了跨域画布污染和内存问题；导出现在可在任何地方使用，并自动分割长对话。"
+            },
+            "refs": [
+              6685
+            ]
+          },
+          {
+            "title": {
+              "en": "Interrupted turn display preservation",
+              "zh": "中断轮次显示保留"
+            },
+            "body": {
+              "en": "Cancelled or errored turns now keep their visible output in the UI across tab switches and reloads.",
+              "zh": "取消或出错的轮次现在在切换会话和重载后仍保留其可见输出。"
+            },
+            "refs": [
+              6703,
+              6666
+            ]
+          },
+          {
+            "title": {
+              "en": "Bounded session save locks",
+              "zh": "限制会话保存锁等待"
+            },
+            "body": {
+              "en": "Session save now times out after 5 seconds instead of hanging, preserving a recovery branch on shutdown.",
+              "zh": "会话保存现在在 5 秒后超时而不是挂起，并在关闭时保存恢复分支。"
+            },
+            "refs": [
+              6667
+            ]
+          },
+          {
+            "title": {
+              "en": "Windows batch plugin hook quoting",
+              "zh": "Windows 批处理插件 Hook 引号修复"
+            },
+            "body": {
+              "en": "Correctly invoke .bat/.cmd plugins with quoted paths on Windows.",
+              "zh": "在 Windows 上正确调用带引号路径的 .bat/.cmd 插件。"
+            },
+            "refs": [
+              6668
+            ]
+          },
+          {
+            "title": {
+              "en": "Digit‑leading custom provider credentials",
+              "zh": "数字开头的自定义提供程序凭据"
+            },
+            "body": {
+              "en": "Custom provider names starting with a digit now generate valid environment variable names.",
+              "zh": "以数字开头的自定义提供程序名称现在会生成有效的环境变量名。"
+            },
+            "refs": [
+              6701
+            ]
+          },
+          {
+            "title": {
+              "en": "SSH host‑key multi‑algorithm checks",
+              "zh": "SSH 主机密钥多算法检查"
+            },
+            "body": {
+              "en": "Servers with multiple valid host keys no longer cause false mismatch errors.",
+              "zh": "具有多个有效主机密钥的服务器不再导致误报的密钥不匹配错误。"
+            },
+            "refs": [
+              6699
+            ]
+          },
+          {
+            "title": {
+              "en": "Remote SSH error recovery UX",
+              "zh": "远程 SSH 错误恢复交互"
+            },
+            "body": {
+              "en": "Connection errors now appear in the status popover with retry and host management actions.",
+              "zh": "连接错误现在显示在状态弹出窗口中，并带有重试和主机管理操作。"
+            },
+            "refs": [
+              6700
+            ]
+          },
+          {
+            "title": {
+              "en": "Linux WebKit startup signal",
+              "zh": "Linux WebKit 启动信号修复"
+            },
+            "body": {
+              "en": "Prevent crashes on Linux by reapplying signal handler flags during WebKit startup.",
+              "zh": "通过在 WebKit 启动期间重新应用信号处理程序标志来防止 Linux 崩溃。"
+            },
+            "refs": [
+              6655
+            ]
+          },
+          {
+            "title": {
+              "en": "Maximized window cursor stuck",
+              "zh": "最大化窗口光标卡死"
+            },
+            "body": {
+              "en": "Cursor no longer stays as a resize handle when the desktop window is maximized.",
+              "zh": "桌面窗口最大化时光标不再卡死在调整大小形状。"
+            },
+            "refs": [
+              6610
+            ]
+          },
+          {
+            "title": {
+              "en": "LongCat‑2.0 context window",
+              "zh": "LongCat‑2.0 上下文窗口"
+            },
+            "body": {
+              "en": "Corrected the preset to the official 1,048,576‑token limit, delaying premature compaction.",
+              "zh": "将预设修正为官方的 1,048,576 令牌限制，推迟过早压缩。"
+            },
+            "refs": [
+              6690
+            ]
+          },
+          {
+            "title": {
+              "en": "Windows session filename safety",
+              "zh": "Windows 会话文件名安全"
+            },
+            "body": {
+              "en": "Replaced reserved characters like colon with hyphen when creating session files.",
+              "zh": "创建会话文件时将冒号等保留字符替换为连字符。"
+            },
+            "refs": [
+              6684
+            ]
+          },
+          {
+            "title": {
+              "en": "Registry publish button layout",
+              "zh": "技能市场发布按钮布局"
+            },
+            "body": {
+              "en": "Fixed the publish CTA in the registry toolbar rendering as a narrow pill.",
+              "zh": "修复了技能市场工具栏中发布按钮显示为窄竖条的问题。"
+            },
+            "refs": [
+              6630
+            ]
+          },
+          {
+            "title": {
+              "en": "Language preference persistence",
+              "zh": "语言偏好持久化"
+            },
+            "body": {
+              "en": "User‑selected language is now correctly read from localStorage after restart.",
+              "zh": "重启后用户选择的语言现在能从 localStorage 正确读取。"
+            },
+            "refs": [
+              5507
+            ]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": {
+            "en": "Simplified MCP authorization",
+            "zh": "简化的 MCP 授权"
+          },
+          "body": {
+            "en": "The legacy trust state machine has been replaced with per‑project launch grants. Existing MCP servers continue to work; manual trust management options have been removed.",
+            "zh": "旧版信任状态机已被替换为按项目的启动授权。现有的 MCP 服务器继续工作；手动信任管理选项已被移除。"
+          },
+          "refs": [
+            6669
+          ]
+        }
+      ],
+      "risks": [],
+      "contributors": [
+        "SivanCola",
+        "sudoviber",
+        "yuanchenglu",
+        "HUQIANTAO",
+        "cyq1017",
+        "HaoyueQin",
+        "SauronSkywalker",
+        "ffff2004",
+        "ikelvingo"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.17.16",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.15...desktop-v1.17.16",
+        "download": "https://reasonix.io/?download=desktop#start"
+      }
+    },
+    {
       "version": "1.17.15",
       "date": "2026-07-18",
       "channel": "stable",


### PR DESCRIPTION
> 本次发布重点带来远程 SSH 与并行子智能体舰队，同时新增分区域字体和可自定义输入快捷键，并提升会话导出、会话恢复与 MCP 可靠性。

[English →](https://reasonix.io/changelog/v1.17.16/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v1.17.16/)

## 使用攻略

- [**远程 SSH 指南**](https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/GUIDE.md) — 配置远程主机，通过 CLI 或 Desktop 连接、浏览远程文件并管理端口转发。
- [**远程 SSH 指南（中文）**](https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/GUIDE.zh-CN.md) — 远程 SSH 主机配置、连接、文件浏览与端口转发的中文指南。
- [**子智能体配置文件与舰队**](https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/SUBAGENT_PROFILES.md) — 了解如何定义和使用子智能体配置文件、配置舰队并管理并发。
- [**主题包**](https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/THEME_PACK.md) — 自定义面板透明度并探索主题包制作。
- [**命令行界面**](https://github.com/esengine/DeepSeek-Reasonix/blob/43993f5a10cd4afa46febf53ed9f7ab2a1ceab5b/docs/CLI.md) — 查看最新的 CLI 功能，包括中键粘贴和改进的消息布局。

## 概览

**Reasonix v1.17.16 — Reasonix 1.17.16**

本次发布重点带来远程 SSH 与并行子智能体舰队，同时新增分区域字体和可自定义输入快捷键，并提升会话导出、会话恢复与 MCP 可靠性。

发布日期：2026-07-20

## 重点内容

- **远程 SSH** — 通过 SSH 连接到远程主机并远程运行完整的 Reasonix 智能体与工具。包含主机管理、文件浏览、端口转发和自动重连。 ([#6673](https://github.com/esengine/DeepSeek-Reasonix/pull/6673))
- **子智能体舰队** — 以可配置的并发度并行运行最多 64 个独立子智能体任务，支持基于配置文件的系统提示。通过写入路径协调避免冲突。 ([#6636](https://github.com/esengine/DeepSeek-Reasonix/pull/6636))
- **分区域字体设置** — 独立调整界面、对话、输入框和代码区域的字体与大小，支持实时预览。 ([#6634](https://github.com/esengine/DeepSeek-Reasonix/pull/6634))
- **简化的 MCP 授权** — 简化了 MCP 服务器安装与工具批准流程。直接添加连接，按项目授予启动权限，移除了旧版信任管理。 ([#6669](https://github.com/esengine/DeepSeek-Reasonix/pull/6669))
- **可靠的会话导出** — 图片和 PDF 导出现在在所有平台上均可可靠运行，长篇对话会自动拆分为多个文件。 ([#6685](https://github.com/esengine/DeepSeek-Reasonix/pull/6685))

## 新功能

- **远程 SSH 模块** — 完整的 VS Code Remote‑SSH 风格体验：连接到远程主机，在那里运行智能体，浏览和编辑文件，端口转发，并自动重连。 ([#6673](https://github.com/esengine/DeepSeek-Reasonix/pull/6673))
- **子智能体舰队** — 支持配置文件的并行子智能体执行，具备并发限制、写入路径协调和后台任务支持。 ([#6636](https://github.com/esengine/DeepSeek-Reasonix/pull/6636))
- **逐模型上下文窗口** — 为共享提供程序端点后的各个模型设置自定义上下文窗口。 ([#6677](https://github.com/esengine/DeepSeek-Reasonix/pull/6677))
- **自定义发送与换行快捷键** — 为发送消息和在输入框中插入换行分别配置快捷键。 ([#6503](https://github.com/esengine/DeepSeek-Reasonix/pull/6503))
- **CLI 中键粘贴** — 在 Reasonix CLI 中恢复中键粘贴功能（tmux 缓冲区或 PRIMARY 选择区）。 ([#6589](https://github.com/esengine/DeepSeek-Reasonix/pull/6589))

## 改进

- **分区域字体控制** — 精细调整界面、对话、输入框、代码/工具等不同区域的字体和大小。 ([#6634](https://github.com/esengine/DeepSeek-Reasonix/pull/6634))
- **可配置的对话宽度** — 在标准宽度（960px）和全宽（90%）之间选择聊天区域宽度。 ([#6590](https://github.com/esengine/DeepSeek-Reasonix/pull/6590))
- **面板透明度与主题包修复** — 新增主界面/工作区场景的面板透明度控制；修复保存设置后活动主题回退的问题。 ([#6645](https://github.com/esengine/DeepSeek-Reasonix/pull/6645), [#6694](https://github.com/esengine/DeepSeek-Reasonix/pull/6694))
- **简化的 MCP 安装与授权** — 移除了旧版信任状态机；用户添加的服务器现在直接连接，工具批准遵循明确的安装授权。 ([#6669](https://github.com/esengine/DeepSeek-Reasonix/pull/6669))
- **插件 Skill 的 MCP 工具绑定** — 导入的 skill 现在能正确映射到实时的 MCP 工具，即使它们使用原始或上游名称。 ([#6705](https://github.com/esengine/DeepSeek-Reasonix/pull/6705))
- **崩溃诊断强化** — 将发布版崩溃与开发信号分离；减少误报提示；修复了虚拟列表和 Mermaid 渲染错误。 ([#6678](https://github.com/esengine/DeepSeek-Reasonix/pull/6678))
- **CLI 终端交互改进** — 改进了复制粘贴处理，恢复右键粘贴，并优化了消息布局和间距。 ([#6632](https://github.com/esengine/DeepSeek-Reasonix/pull/6632))

## 修复

- **可靠的会话图片/PDF 导出** — 修复了跨域画布污染和内存问题；导出现在可在任何地方使用，并自动分割长对话。 ([#6685](https://github.com/esengine/DeepSeek-Reasonix/pull/6685))
- **中断轮次显示保留** — 取消或出错的轮次现在在切换会话和重载后仍保留其可见输出。 ([#6703](https://github.com/esengine/DeepSeek-Reasonix/pull/6703), [#6666](https://github.com/esengine/DeepSeek-Reasonix/pull/6666))
- **限制会话保存锁等待** — 会话保存现在在 5 秒后超时而不是挂起，并在关闭时保存恢复分支。 ([#6667](https://github.com/esengine/DeepSeek-Reasonix/pull/6667))
- **Windows 批处理插件 Hook 引号修复** — 在 Windows 上正确调用带引号路径的 .bat/.cmd 插件。 ([#6668](https://github.com/esengine/DeepSeek-Reasonix/pull/6668))
- **数字开头的自定义提供程序凭据** — 以数字开头的自定义提供程序名称现在会生成有效的环境变量名。 ([#6701](https://github.com/esengine/DeepSeek-Reasonix/pull/6701))
- **SSH 主机密钥多算法检查** — 具有多个有效主机密钥的服务器不再导致误报的密钥不匹配错误。 ([#6699](https://github.com/esengine/DeepSeek-Reasonix/pull/6699))
- **远程 SSH 错误恢复交互** — 连接错误现在显示在状态弹出窗口中，并带有重试和主机管理操作。 ([#6700](https://github.com/esengine/DeepSeek-Reasonix/pull/6700))
- **Linux WebKit 启动信号修复** — 通过在 WebKit 启动期间重新应用信号处理程序标志来防止 Linux 崩溃。 ([#6655](https://github.com/esengine/DeepSeek-Reasonix/pull/6655))
- **最大化窗口光标卡死** — 桌面窗口最大化时光标不再卡死在调整大小形状。 ([#6610](https://github.com/esengine/DeepSeek-Reasonix/pull/6610))
- **LongCat‑2.0 上下文窗口** — 将预设修正为官方的 1,048,576 令牌限制，推迟过早压缩。 ([#6690](https://github.com/esengine/DeepSeek-Reasonix/pull/6690))
- **Windows 会话文件名安全** — 创建会话文件时将冒号等保留字符替换为连字符。 ([#6684](https://github.com/esengine/DeepSeek-Reasonix/pull/6684))
- **技能市场发布按钮布局** — 修复了技能市场工具栏中发布按钮显示为窄竖条的问题。 ([#6630](https://github.com/esengine/DeepSeek-Reasonix/pull/6630))

## 升级提醒

- **简化的 MCP 授权** — 旧版信任状态机已被替换为按项目的启动授权。现有的 MCP 服务器继续工作；手动信任管理选项已被移除。 ([#6669](https://github.com/esengine/DeepSeek-Reasonix/pull/6669))

## 风险提示

- **远程主机支持范围** — 远程 SSH V1 支持 Linux 与 macOS 远程主机；Windows 远程主机暂不支持，并会返回明确错误。 ([#6673](https://github.com/esengine/DeepSeek-Reasonix/pull/6673))
- **一次性提示缓存冷启动** — 新的 fleet 工具与扩展后的 task schema 会在升级后触发一次提示缓存冷启动；此后工具顺序与 schema 保持稳定。 ([#6636](https://github.com/esengine/DeepSeek-Reasonix/pull/6636))

## 致谢

感谢本版本的贡献者：[@SivanCola](https://github.com/SivanCola)、[@sudoviber](https://github.com/sudoviber)、[@yuanchenglu](https://github.com/yuanchenglu)、[@HaoyueQin](https://github.com/HaoyueQin)、[@SauronSkywalker](https://github.com/SauronSkywalker)、[@ffff2004](https://github.com/ffff2004)、[@ikelvingo](https://github.com/ikelvingo)

## 下载与安装

- [官网按平台下载](https://reasonix.io/?download=desktop#start)
- [查看完整差异](https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.15...desktop-v1.17.16)
