### PR TITLE
fix: make safe-area buttons equal width in theme editor / 修复主题编辑器中安全区域按钮宽度不一致

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -34126,7 +34126,8 @@ body > .mermaid-diagram--fullscreen {
 .theme-editor__recipe-groups .set-seg,
 .theme-editor__base-styles { width: 100%; }
 .theme-editor__recipe-groups .set-seg__btn,
-.theme-editor__base-styles .set-seg__btn { flex: 1; min-width: 0; }
+.theme-editor__base-styles .set-seg__btn,
+.theme-editor__setting-row .set-seg__btn { flex: 1; min-width: 0; }
 .theme-editor__fields--grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
### Summary

The three safe-area position buttons ("Left" / "Center" / "Right") in the theme editor's background scene (`ThemeGallery.tsx` → scene image → "Interface content area") render at uneven widths. The last button appears visibly wider than the other two and pushes against the right edge of the container, while the first two remain content-sized.

### Root Cause

The safe-area buttons are rendered inside a `.set-seg` container that is a direct child of `.theme-editor__setting-row`. The CSS rule `.theme-editor__setting-row > .set-seg` applies `flex: 1`, stretching the container to fill the available row width. However, the buttons themselves (`.set-seg__btn`) had no `flex: 1` rule in this context, so they rendered at their natural content width, packed to the left inside the stretched container. This made the third button appear to be wider because it was the only one next to the empty stretched space.

Elsewhere in the theme editor, identical `.set-seg__btn` elements inside `.theme-editor__recipe-groups`, `.theme-editor__base-styles`, and `.theme-gallery__preview-control` all have `flex: 1; min-width: 0;` — the safe-area row was the only one missing this rule.

### Fix

Added `.theme-editor__setting-row .set-seg__btn` to the existing combined CSS rule at `desktop/frontend/src/styles.css:34038`, joining `.theme-editor__recipe-groups .set-seg__btn` and `.theme-editor__base-styles .set-seg__btn`. The three buttons now distribute evenly across the container, consistent with every other segmented button group in the theme editor.

Changed file: `desktop/frontend/src/styles.css` (+2, −1).

### Verification

- Built with `wails build` on Windows/amd64 (Go 1.26.5, Wails 2.13.0) — build succeeded.
- Manually verified: the three buttons ("左侧" / "居中" / "右侧") are equal width and evenly spaced in the theme editor scene-image panel.
- No visual regression in other `.set-seg` usages (base styles, recipe groups, gallery preview controls) — their existing `flex: 1` rules are unchanged.
- `gofmt` and `go vet` pass on the full tree. Existing test failures are pre-existing environment issues (missing `DEEPSEEK_API_KEY`) unrelated to this CSS change.

### Cache impact

```
Cache-impact: none — CSS-only change under desktop/frontend/src/, not in any cache-sensitive path.
Cache-guard: existing theme-pack.test.ts contract tests remain sufficient; no provider-visible surface changed.
System-prompt-review: N/A
```

---

### 摘要

主题编辑器场景图片面板中，"界面内容区域"的三个位置按钮（"左侧"/"居中"/"右侧"）宽度不一致。第三个按钮明显比前两个更宽，且右侧边缘几乎紧贴容器边界。

### 根因

三个按钮位于 `.theme-editor__setting-row > .set-seg` 容器内。CSS 规则 `.theme-editor__setting-row > .set-seg` 设置了 `flex: 1`，将容器拉伸至整行宽度。但容器内的 `.set-seg__btn` 按钮缺少 `flex: 1` 规则，仅按内容宽度渲染，紧密排列在左侧。被拉伸的容器右侧留下大片空白，视觉上第三个按钮显得"更宽"——实际上它并非更宽，而是右侧空白的起点紧邻它。

主题编辑器其他位置的同类按钮（`.theme-editor__recipe-groups`、`.theme-editor__base-styles`、`.theme-gallery__preview-control` 中的 `.set-seg__btn`）均已设置 `flex: 1; min-width: 0;`，唯独安全区域这一处遗漏。

### 修复

在 `desktop/frontend/src/styles.css:34038` 的已有合并规则中追加 `.theme-editor__setting-row .set-seg__btn` 选择器，使其与 `.theme-editor__recipe-groups .set-seg__btn` 和 `.theme-editor__base-styles .set-seg__btn` 共享 `flex: 1; min-width: 0;`。现在三个按钮均分容器宽度，与主题编辑器中其他分段按钮组行为一致。

修改文件：`desktop/frontend/src/styles.css`（+2 行，−1 行）。

### 验证

- 使用 `wails build` 在 Windows/amd64 上构建（Go 1.26.5, Wails 2.13.0）——构建成功。
- 手动验证：主题编辑器场景图片面板中三个按钮（"左侧"/"居中"/"右侧"）等宽且均匀分布。
- 其他 `.set-seg` 使用处（基础样式、配方组、画廊预览控件）无视觉回归——其已有 `flex: 1` 规则未变。
- `gofmt` 和 `go vet` 全仓库通过。已存在的测试失败为环境问题（缺少 `DEEPSEEK_API_KEY`），与本次 CSS 改动无关。

### 缓存影响

```
Cache-impact: none — 仅修改 desktop/frontend/src/ 下的 CSS 文件，不在任何缓存敏感路径中。
Cache-guard: 已有的 theme-pack.test.ts 合约测试可充分覆盖；无 provider 可见面变更。
System-prompt-review: N/A
```

---

## 效果展示

### 修复前
<img width="398" height="293" alt="image" src="https://github.com/user-attachments/assets/531c7109-f226-4e65-82a5-f060eafb1291" />

### 修复后
<img width="389" height="295" alt="image" src="https://github.com/user-attachments/assets/3e0f0314-a959-4cbe-80aa-de8fe1f8d71b" />
