### PR TITLE
fix(desktop): keep Windows opener menu above transcript

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -410,6 +410,13 @@ ok(
   "Windows sidebar avoids native window drag without changing other platforms",
 );
 
+ok(
+  finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
+    finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
+    finalDeclaration(".app--windows.app--creation .topicbar", "transform") === "translateY(-4px) !important",
+  "Windows Creation topic bar lifts its menus above conversation content without changing titlebar alignment",
+);
+
 for (const selector of [
   ".layout--workbench-chrome-hidden",
   ":root[data-theme-style] .layout--workbench-chrome-hidden",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -32312,6 +32312,8 @@ body > .mermaid-diagram--fullscreen {
 
 /* Align topicbar (replaces app-chrome in Creation mode) with Windows controls */
 .app--windows.app--creation .topicbar {
+  position: relative;
+  z-index: var(--z-app-chrome);
   transform: translateY(-4px) !important;
 }
 


### PR DESCRIPTION
## Summary

- Fix the external-opener menu being covered by conversation content in Windows Creation mode.
- Raise the Windows Creation topic bar to the existing app-chrome stacking layer.
- Preserve the existing titlebar alignment transform and add CSS regression coverage.

Fixes #6594

## Verification

- `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts` — 83 passed
- `pnpm exec tsx src/__tests__/external-opener.test.tsx` — 17 passed
- `pnpm run build`
- Manually verified that the menu is visible and clickable in Windows Creation mode.
- Confirmed that the macOS Creation layout remains unchanged.

## Cache impact

Cache-impact: none — CSS stacking and a focused CSS contract test only.
Cache-guard: `pnpm exec tsx src/__tests__/app-chrome-tabs.test.ts`
System-prompt-review: N/A