### PR TITLE
fix(desktop/composer): don't cancel in-flight turn on ESC while IME is composing

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -3425,7 +3425,11 @@ export function Composer({
     }
     // Esc interrupts the in-flight turn (matches the Stop button's hint), and
     // restores the text if the server hadn't replied yet.
-    if (e.key === "Escape" && running) {
+    // Guard against IME: pressing ESC to dismiss the Chinese/Japanese
+    // candidate window must not be treated as an interrupt. `composing`
+    // already folds in composingRef + nativeEvent.isComposing + keyCode 229 +
+    // the post-compositionend grace window (see isImeKeyEvent).
+    if (e.key === "Escape" && running && !composing) {
       e.preventDefault();
       handleCancel();
     }


### PR DESCRIPTION
## Problem

The composer's ESC handler unconditionally calls `handleCancel()` whenever a turn is running, even when the ESC keydown was fired to dismiss a Chinese/Japanese IME candidate window. On macOS this is easy to hit while replying is streaming:

1. Send a prompt and let the agent start replying.
2. Start typing a new message with a Chinese IME while the reply streams.
3. With the candidate list still open, press `ESC` to dismiss the candidate.
4. **Expected:** candidate closes, agent keeps replying.
5. **Actual:** the agent turn is cancelled mid-reply.

## Root cause

`desktop/frontend/src/components/Composer.tsx` — the same `onKeyDown` handler that gates the send-Enter chord, the mention/past-chats menu, Shift+Tab plan toggle, and paste shortcuts with `!composing` was missing that guard on the running-turn ESC branch:

```ts
// Esc interrupts the in-flight turn (matches the Stop button's hint), and
// restores the text if the server hadn't replied yet.
if (e.key === "Escape" && running) {
  e.preventDefault();
  handleCancel();
}
```

So an IME dismiss ESC on a running turn falls straight into `handleCancel()`.

## Fix

Add `!composing` to the ESC guard. The existing `isImeKeyEvent()` helper already folds together `composingRef`, `nativeEvent.isComposing`, `keyCode === 229`, and a short post-`compositionend` grace window (`IME_CONFIRM_GRACE_MS`), so `composing` is already the right signal — no new state or listeners.

```ts
if (e.key === "Escape" && running && !composing) {
  e.preventDefault();
  handleCancel();
}
```

Diff: **+5 / -1** (four lines are the comment explaining why).

## Verification

Local Wails build (`main-v2` HEAD + this patch, macOS arm64):

1. Send a prompt; agent starts streaming a reply.
2. In the composer, start typing with a Chinese IME (macOS 拼音 / 双拼).
3. Press `ESC` while the candidate window is open.
4. Result: candidate window closes; agent continues streaming without interruption. ✅

Non-IME ESC behavior is unchanged:
- `ESC` with no composition and `running` still cancels the turn as before (matches the Stop button's hint).
- Menu/past-chats ESC branch above is untouched.
- Send-Enter, Shift+Tab, prompt-history nav paths are untouched.

## Notes

- Fix is scoped to `desktop/frontend/src/components/Composer.tsx`; no changes to the Go side or bindings.
- Same class of bug (IME composition ESC being interpreted as an abort) has bitten other Electron/Tauri/Wails chat frontends on macOS WKWebView; this is the minimal per-component fix.

## Documentation impact

Documentation-impact: none - `Composer.tsx` is the user-facing chat composer, but this change is purely a behavior guard (don't treat ESC as an interrupt while the IME composition is active). No public API, no documented keybinding surface, no user-visible setting changes. The existing docs for the ESC interrupt / Stop button remain accurate as-is.
