### PR TITLE
fix(desktop): Show Windows update progress / 显示 Windows 更新进度

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -67,6 +67,7 @@ ManifestDPIAware true
 !insertmacro MUI_PAGE_DIRECTORY # In which folder install page.
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW reasonix.showUpdateProgress
 !insertmacro MUI_PAGE_INSTFILES # Installing page.
+!define MUI_PAGE_CUSTOMFUNCTION_PRE reasonix.skipFinishPageForUpdate
 !insertmacro MUI_PAGE_FINISH # Finished installation page.
 
 !insertmacro MUI_UNPAGE_INSTFILES # Uinstalling page
@@ -179,6 +180,13 @@ Function reasonix.showUpdateProgress
    BringToFront
 
 reasonix_update_progress_done:
+FunctionEnd
+
+Function reasonix.skipFinishPageForUpdate
+   StrCmp $ReasonixUpdateMode "1" 0 reasonix_show_finish_page
+   Abort
+
+reasonix_show_finish_page:
 FunctionEnd
 
 Function reasonix.waitForExecutableUnlock

--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -8,8 +8,8 @@ Unicode true
 ## Wails' default template:
 ##
 ##   1. REQUEST_EXECUTION_LEVEL "user" + InstallDir under $LOCALAPPDATA - install
-##      without administrator rights. This is what lets the auto-updater re-run a
-##      freshly downloaded installer silently (`/S`) with no UAC prompt.
+##      without administrator rights. This lets the auto-updater re-run a freshly
+##      downloaded installer in a visible progress-only mode with no UAC prompt.
 ##   2. Uninstall registry under HKCU (not HKLM). Wails' wails.writeUninstaller /
 ##      wails.deleteUninstaller macros hard-code HKLM, which a non-admin install
 ##      cannot write - so we inline HKCU versions below instead.
@@ -18,9 +18,9 @@ Unicode true
 ##      a build that did not write InstallLocation yet, .onInit falls back to the
 ##      old DisplayIcon path before using the default. Without this, every release
 ##      forces the user back to %LOCALAPPDATA%\Programs\Reasonix even if they had
-##      moved the install to a different drive (e.g. D:\Tools\Reasonix); the silent
-##      auto-updater would re-run with /S into the wrong dir, leaving the old
-##      install orphaned.
+##      moved the install to a different drive (e.g. D:\Tools\Reasonix); the
+##      auto-updater would overwrite the wrong dir, leaving the old install
+##      orphaned.
 ##
 ## Everything else mirrors Wails' generated default. Defines below override the
 ## ProjectInfo values that wails_tools.nsh would otherwise populate.
@@ -60,15 +60,27 @@ ManifestDPIAware true
 !define MUI_FINISHPAGE_NOAUTOCLOSE # Wait on the INSTFILES page so the user can take a look into the details of the installation steps
 !define MUI_ABORTWARNING # This will warn the user if they exit from the installer.
 
+!define MUI_PAGE_CUSTOMFUNCTION_PRE reasonix.skipSetupPageForUpdate
 !insertmacro MUI_PAGE_WELCOME # Welcome to the installer page.
 # !insertmacro MUI_PAGE_LICENSE "resources\eula.txt" # Adds a EULA page to the installer
+!define MUI_PAGE_CUSTOMFUNCTION_PRE reasonix.skipSetupPageForUpdate
 !insertmacro MUI_PAGE_DIRECTORY # In which folder install page.
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW reasonix.showUpdateProgress
 !insertmacro MUI_PAGE_INSTFILES # Installing page.
 !insertmacro MUI_PAGE_FINISH # Finished installation page.
 
 !insertmacro MUI_UNPAGE_INSTFILES # Uinstalling page
 
-!insertmacro MUI_LANGUAGE "English" # Set the Language of the installer
+!insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE "SimpChinese"
+!insertmacro MUI_LANGUAGE "TradChinese"
+
+LangString reasonixUpdateTitle ${LANG_ENGLISH} "Updating Reasonix"
+LangString reasonixUpdateTitle ${LANG_SIMPCHINESE} "正在更新 Reasonix"
+LangString reasonixUpdateTitle ${LANG_TRADCHINESE} "正在更新 Reasonix"
+LangString reasonixUpdateSubtitle ${LANG_ENGLISH} "Installing the verified update. Reasonix will restart automatically."
+LangString reasonixUpdateSubtitle ${LANG_SIMPCHINESE} "正在安装已验证的更新，完成后 Reasonix 将自动重启。"
+LangString reasonixUpdateSubtitle ${LANG_TRADCHINESE} "正在安裝已驗證的更新，完成後 Reasonix 將自動重新啟動。"
 
 ## The following two statements can be used to sign the installer and the uninstaller. The path to the binaries are provided in %1
 #!uninstfinalize 'signtool --file "%1"'
@@ -83,6 +95,7 @@ OutFile "..\..\bin\${INFO_PROJECTNAME}-${ARCH}-installer.exe" # Name of the inst
 !define REASONIX_CLI "reasonix.exe"
 !define REASONIX_PORTABLE_ENTRY "Reasonix.exe"
 !define REASONIX_UNLOCK_RETRIES 60
+Var ReasonixUpdateMode
 InstallDirRegKey HKCU "${UNINST_KEY}" "InstallLocation" # Reuse the previous install path on update; .onInit falls back to the default on first install.
 InstallDir "${REASONIX_DEFAULT_INSTALLDIR}" # Per-user install location (no admin rights required).
 ShowInstDetails show # This will always show the installation details.
@@ -104,8 +117,8 @@ ShowInstDetails show # This will always show the installation details.
     # via InstallDirRegKey above. Without this, every release would force the
     # user back to %LOCALAPPDATA%\Programs\Reasonix even if they had moved
     # the install to a different drive (e.g. D:\Tools\Reasonix). The auto-
-    # updater re-runs this installer with /S and trusts the persisted path,
-    # so it has to be present before the silent re-install.
+    # updater trusts this persisted path, so it has to be present before the
+    # visible progress-only re-install.
     WriteRegStr HKCU "${UNINST_KEY}" "InstallLocation" "$INSTDIR"
 
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
@@ -121,6 +134,20 @@ ShowInstDetails show # This will always show the installation details.
 Function .onInit
    !insertmacro wails.checkArchitecture
 
+   ; The helper passes /REASONIXUPDATE=1 and a final /D=<current directory>.
+   ; This mode remains visible but skips every page that could change the
+   ; destination, then closes automatically after the file copy so the helper
+   ; can relaunch Reasonix. A normal manual installer keeps the full wizard.
+   StrCpy $ReasonixUpdateMode "0"
+   ${GetParameters} $R0
+   ClearErrors
+   ${GetOptions} $R0 "/REASONIXUPDATE=" $R1
+   IfErrors reasonix_update_mode_done
+   StrCmp $R1 "1" 0 reasonix_update_mode_done
+   StrCpy $ReasonixUpdateMode "1"
+
+reasonix_update_mode_done:
+
    ; InstallDirRegKey leaves $INSTDIR empty when the InstallLocation value is
    ; missing. Older installers still wrote DisplayIcon, so use its parent folder
    ; as a compatibility bridge before falling back to the per-user default.
@@ -135,6 +162,23 @@ Function .onInit
 fallback:
    StrCpy $INSTDIR "${REASONIX_DEFAULT_INSTALLDIR}"
 done:
+FunctionEnd
+
+Function reasonix.skipSetupPageForUpdate
+   StrCmp $ReasonixUpdateMode "1" 0 reasonix_show_setup_page
+   Abort
+
+reasonix_show_setup_page:
+FunctionEnd
+
+Function reasonix.showUpdateProgress
+   StrCmp $ReasonixUpdateMode "1" 0 reasonix_update_progress_done
+   !insertmacro MUI_HEADER_TEXT "$(reasonixUpdateTitle)" "$(reasonixUpdateSubtitle)"
+   SetDetailsView hide
+   SetAutoClose true
+   BringToFront
+
+reasonix_update_progress_done:
 FunctionEnd
 
 Function reasonix.waitForExecutableUnlock

--- a/desktop/cmd/update-helper/args.go
+++ b/desktop/cmd/update-helper/args.go
@@ -3,7 +3,11 @@ package main
 import "fmt"
 
 func installerCommandLine(installer, dir string) string {
-	line := fmt.Sprintf(`"%s" /S`, installer)
+	// Auto-updates use a dedicated visible progress mode instead of NSIS /S.
+	// The installer skips its welcome and directory pages in this mode, keeps
+	// the current install directory fixed, and closes itself after the file copy
+	// completes so this helper can relaunch Reasonix.
+	line := fmt.Sprintf(`"%s" /REASONIXUPDATE=1`, installer)
 	if dir != "" {
 		line += " /D=" + dir
 	}

--- a/desktop/cmd/update-helper/args_test.go
+++ b/desktop/cmd/update-helper/args_test.go
@@ -5,11 +5,14 @@ import (
 	"testing"
 )
 
-func TestInstallerCommandLineIsSilentAndLeavesDFlagLast(t *testing.T) {
+func TestInstallerCommandLineUsesVisibleUpdateModeAndLeavesDFlagLast(t *testing.T) {
 	got := installerCommandLine(`C:\Temp\Reasonix Installer.exe`, `D:\Tools\Reasonix App`)
-	want := `"C:\Temp\Reasonix Installer.exe" /S /D=D:\Tools\Reasonix App`
+	want := `"C:\Temp\Reasonix Installer.exe" /REASONIXUPDATE=1 /D=D:\Tools\Reasonix App`
 	if got != want {
 		t.Fatalf("installerCommandLine = %q, want %q", got, want)
+	}
+	if strings.Contains(got, " /S") {
+		t.Fatalf("auto-update must expose progress instead of using silent mode, got %q", got)
 	}
 	if !strings.HasSuffix(got, `/D=D:\Tools\Reasonix App`) {
 		t.Fatalf("/D= must be the final unquoted NSIS token, got %q", got)

--- a/desktop/cmd/update-helper/main_windows.go
+++ b/desktop/cmd/update-helper/main_windows.go
@@ -116,7 +116,10 @@ func waitForProcessExit(pid uint32, timeout time.Duration) error {
 
 func runInstaller(installer, installDir string) error {
 	cmd := exec.Command(installer)
-	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(installer, installDir), HideWindow: true}
+	// Keep the helper itself hidden, but let the NSIS update-progress window be
+	// visible. The dedicated /REASONIXUPDATE mode prevents directory changes and
+	// closes automatically after the update finishes.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(installer, installDir)}
 	return cmd.Run()
 }
 

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2597,7 +2597,7 @@ export const en = {
   "updater.releaseNotes": "Release notes",
   "updater.downloadUpdate": "Download update",
   "updater.downloaded": "Update {v} has been downloaded.",
-  "updater.restartInstall": "Restart to install",
+  "updater.restartInstall": "Install and restart",
   "updater.installNow": "Update now",
   "updater.goToDownload": "Go to download page",
   "updater.macHint": "Automatic install isn't available for this macOS build — please download and install manually.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1798,7 +1798,7 @@ export const zhTW: Record<DictKey, string> = {
   "updater.releaseNotes": "更新說明",
   "updater.downloadUpdate": "下載更新",
   "updater.downloaded": "更新 {v} 已下載。",
-  "updater.restartInstall": "重新啟動並安裝",
+  "updater.restartInstall": "安裝並重新啟動",
   "updater.installNow": "立即更新",
   "updater.goToDownload": "前往下載頁",
   "updater.macHint": "目前 macOS 建置暫不支援自動安裝，請前往下載頁手動安裝。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2600,7 +2600,7 @@ export const zh: Record<DictKey, string> = {
   "updater.releaseNotes": "更新说明",
   "updater.downloadUpdate": "下载更新",
   "updater.downloaded": "更新 {v} 已下载。",
-  "updater.restartInstall": "重启安装",
+  "updater.restartInstall": "安装并重启",
   "updater.installNow": "立即更新",
   "updater.goToDownload": "前往下载页",
   "updater.macHint": "当前 macOS 构建暂不支持自动安装，请前往下载页手动安装。",

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -12,14 +12,15 @@ import (
 
 const windowsUpdateHelperFileName = "reasonix-update-helper.exe"
 
-// installerCommand runs the NSIS updater, forcing $INSTDIR to dir via /D= so the
-// update overwrites the current install in place. NSIS requires /D= to be the
-// final, unquoted token taken verbatim to the end of the line, so the raw command
-// line is set directly — exec.Command would quote a path containing spaces (e.g.
-// C:\Users\Jane Doe\...) and NSIS would then mis-parse the target directory.
+// installerCommand runs the NSIS updater in its visible, progress-only update
+// mode, forcing $INSTDIR to dir via /D= so the update overwrites the current
+// install in place. NSIS requires /D= to be the final, unquoted token taken
+// verbatim to the end of the line, so the raw command line is set directly —
+// exec.Command would quote a path containing spaces (e.g. C:\Users\Jane Doe\...)
+// and NSIS would then mis-parse the target directory.
 func installerCommand(name, dir string) *exec.Cmd {
 	cmd := exec.Command(name)
-	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(name, dir), HideWindow: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: installerCommandLine(name, dir)}
 	return cmd
 }
 

--- a/desktop/updater_windows_args.go
+++ b/desktop/updater_windows_args.go
@@ -6,7 +6,10 @@ import (
 )
 
 func installerCommandLine(installer, dir string) string {
-	line := fmt.Sprintf(`"%s" /S`, installer)
+	// Keep this in sync with cmd/update-helper/args.go. The desktop uses it for
+	// its Windows command invariant tests; the copied helper uses the same mode
+	// after the desktop exits.
+	line := fmt.Sprintf(`"%s" /REASONIXUPDATE=1`, installer)
 	if dir != "" {
 		line += " /D=" + dir
 	}

--- a/desktop/updater_windows_test.go
+++ b/desktop/updater_windows_test.go
@@ -4,25 +4,28 @@ package main
 
 import "testing"
 
-func TestInstallerCommandPassesUnquotedDFlagLast(t *testing.T) {
+func TestInstallerCommandShowsUpdateProgressAndPassesUnquotedDFlagLast(t *testing.T) {
 	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, `D:\Tools\Reasonix App`)
 	if cmd.SysProcAttr == nil {
 		t.Fatal("expected a raw command line forcing the install dir")
 	}
 	got := cmd.SysProcAttr.CmdLine
-	want := `"C:\Temp\reasonix-update-1.exe" /S /D=D:\Tools\Reasonix App`
+	want := `"C:\Temp\reasonix-update-1.exe" /REASONIXUPDATE=1 /D=D:\Tools\Reasonix App`
 	if got != want {
 		t.Fatalf("CmdLine = %q, want %q", got, want)
+	}
+	if cmd.SysProcAttr.HideWindow {
+		t.Fatal("NSIS update progress window must remain visible")
 	}
 }
 
 func TestInstallerCommandWithoutDirSkipsDFlag(t *testing.T) {
 	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, "")
 	if cmd.SysProcAttr == nil {
-		t.Fatal("expected a raw command line for silent updater installs")
+		t.Fatal("expected a raw command line for visible updater installs")
 	}
 	got := cmd.SysProcAttr.CmdLine
-	want := `"C:\Temp\reasonix-update-1.exe" /S`
+	want := `"C:\Temp\reasonix-update-1.exe" /REASONIXUPDATE=1`
 	if got != want {
 		t.Fatalf("CmdLine = %q, want %q", got, want)
 	}

--- a/desktop/windows_update_handoff_test.go
+++ b/desktop/windows_update_handoff_test.go
@@ -56,6 +56,9 @@ func TestWindowsInstallerScriptWaitsBeforeCopyingExecutable(t *testing.T) {
 		`${GetOptions} $R0 "/REASONIXUPDATE=" $R1`,
 		"Function reasonix.skipSetupPageForUpdate",
 		"Function reasonix.showUpdateProgress",
+		`!define MUI_PAGE_CUSTOMFUNCTION_PRE reasonix.skipFinishPageForUpdate`,
+		"Function reasonix.skipFinishPageForUpdate",
+		`StrCmp $ReasonixUpdateMode "1" 0 reasonix_show_finish_page`,
 		"SetAutoClose true",
 		"BringToFront",
 		`LangString reasonixUpdateTitle ${LANG_ENGLISH} "Updating Reasonix"`,
@@ -81,6 +84,11 @@ func TestWindowsInstallerScriptWaitsBeforeCopyingExecutable(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("project.nsi missing %q", want)
 		}
+	}
+	finishPageHook := strings.Index(script, "!define MUI_PAGE_CUSTOMFUNCTION_PRE reasonix.skipFinishPageForUpdate")
+	finishPage := strings.Index(script, "!insertmacro MUI_PAGE_FINISH")
+	if finishPageHook < 0 || finishPage < 0 || finishPageHook > finishPage {
+		t.Fatalf("update-only finish page hook must be attached to MUI_PAGE_FINISH (hook=%d page=%d)", finishPageHook, finishPage)
 	}
 	wait := strings.Index(script, "Call reasonix.waitForExecutableUnlock")
 	copyFiles := strings.Index(script, "!insertmacro wails.files")

--- a/desktop/windows_update_handoff_test.go
+++ b/desktop/windows_update_handoff_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 )
 
-func TestInstallerCommandLineIsSilentAndKeepsDFlagLast(t *testing.T) {
+func TestInstallerCommandLineUsesVisibleUpdateModeAndKeepsDFlagLast(t *testing.T) {
 	got := installerCommandLine(`C:\Temp\Reasonix Installer.exe`, `D:\Tools\Reasonix App`)
-	want := `"C:\Temp\Reasonix Installer.exe" /S /D=D:\Tools\Reasonix App`
+	want := `"C:\Temp\Reasonix Installer.exe" /REASONIXUPDATE=1 /D=D:\Tools\Reasonix App`
 	if got != want {
 		t.Fatalf("installerCommandLine = %q, want %q", got, want)
+	}
+	if strings.Contains(got, " /S") {
+		t.Fatalf("auto-update must expose progress instead of using silent mode, got %q", got)
 	}
 	if !strings.HasSuffix(got, `/D=D:\Tools\Reasonix App`) {
 		t.Fatalf("/D= must be the final unquoted NSIS token, got %q", got)
@@ -49,6 +52,18 @@ func TestWindowsInstallerScriptWaitsBeforeCopyingExecutable(t *testing.T) {
 		`!define REASONIX_LAUNCHER "reasonix-launcher.exe"`,
 		`!define REASONIX_CLI "reasonix.exe"`,
 		`!define REASONIX_PORTABLE_ENTRY "Reasonix.exe"`,
+		"Var ReasonixUpdateMode",
+		`${GetOptions} $R0 "/REASONIXUPDATE=" $R1`,
+		"Function reasonix.skipSetupPageForUpdate",
+		"Function reasonix.showUpdateProgress",
+		"SetAutoClose true",
+		"BringToFront",
+		`LangString reasonixUpdateTitle ${LANG_ENGLISH} "Updating Reasonix"`,
+		`LangString reasonixUpdateTitle ${LANG_SIMPCHINESE} "正在更新 Reasonix"`,
+		`LangString reasonixUpdateTitle ${LANG_TRADCHINESE} "正在更新 Reasonix"`,
+		`LangString reasonixUpdateSubtitle ${LANG_ENGLISH} "Installing the verified update. Reasonix will restart automatically."`,
+		`LangString reasonixUpdateSubtitle ${LANG_SIMPCHINESE} "正在安装已验证的更新，完成后 Reasonix 将自动重启。"`,
+		`LangString reasonixUpdateSubtitle ${LANG_TRADCHINESE} "正在安裝已驗證的更新，完成後 Reasonix 將自動重新啟動。"`,
 		"Function reasonix.waitForExecutableUnlock",
 		`FileOpen $1 "$INSTDIR\${PRODUCT_EXECUTABLE}" a`,
 		`FileOpen $1 "$INSTDIR\${REASONIX_GUARD}" a`,
@@ -106,5 +121,16 @@ func TestWindowsUpdateRequiresObservedHelperHandoff(t *testing.T) {
 	}
 	if strings.Contains(source, "return installerCommand(installerPath, installDir).Start()") {
 		t.Fatal("Windows update silently falls back to an unobserved installer")
+	}
+	if !strings.Contains(source, "cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}") {
+		t.Fatal("Windows handoff helper should stay hidden while NSIS shows update progress")
+	}
+	helperData, err := os.ReadFile("cmd/update-helper/main_windows.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	helperSource := string(helperData)
+	if strings.Contains(helperSource, "installerCommandLine(installer, installDir), HideWindow: true") {
+		t.Fatal("update helper still hides the NSIS progress window")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the silent Windows auto-update handoff with a dedicated visible NSIS progress mode.
- Show the standard Reasonix-branded installation page with localized English, Simplified Chinese, and Traditional Chinese status text, a progress bar, hidden details, and automatic close on success.
- Keep the verified current install directory fixed, preserve the hidden helper and Guard recovery flow, and leave the normal manual installer wizard unchanged.
- Update the desktop action label to "Install and restart" and add regression coverage for the installer/helper handoff contract.

## Compatibility

| Path | Behavior | Compatibility |
| --- | --- | --- |
| Persisted user data | No schema or storage changes | Safe |
| Manual installer | No update flag; full welcome/directory/install/finish wizard remains | Unchanged |
| Upgrade from an older Reasonix build | The older helper may still invoke this first transition with `/S`; installation still completes silently | Safe rollout bridge |
| Future auto-updates | `/REASONIXUPDATE=1` shows progress, fixes the existing directory, auto-closes, then relaunches Reasonix | Intended change |

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `cd desktop/frontend && pnpm typecheck`
- Cross-compiled the Windows desktop and update helper for amd64 and arm64.
- Compiled the actual NSIS installer with makensis 3.12 and all three language tables.
- `git diff --check`

No live Windows UI run was available on the macOS development host; the Windows command-line, handoff, architecture builds, and NSIS compile paths are covered above.

## Cache impact

Cache-impact: none — this changes only the Windows desktop updater, installer UI, localized labels, and their tests; provider prompts, tool schemas, request serialization, and cache keys are untouched.
Cache-guard: existing updater handoff tests plus `cd desktop && go test ./...` cover the changed path; no cache-sensitive files are modified.
System-prompt-review: N/A
