### PR TITLE
Replace const defaultTopicTitle language from Chinese to English

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5051,7 +5051,7 @@ const (
 	topicTitleSourcesFile  = "desktop-topic-title-sources.json"
 	topicCreatedAtsFile    = "desktop-topic-created-at.json"
 	topicAutoTitlesFile    = "desktop-topic-auto-title-meta.json"
-	defaultTopicTitle      = "新的会话"
+	defaultTopicTitle      = "New Session"
 	topicTitleSourceAuto   = "auto"
 	topicTitleSourceManual = "manual"
 )


### PR DESCRIPTION
Changed defaultTopicTitle from Chinese to English.

## Summary
Fix issue #6754 
Desktop application
Chinese characters being displayed for const defaultTopicTitle
Single-line change on Line 5054 
defaultTopicTitle      = "新的会话" --> defaultTopicTitle      = "New Session" 

## Verification

Recompiled on Windows 11 home desktop, no issues

## Cache impact

Cache-impact: None
Cache-guard: None
System-prompt-review: none

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
