### PR TITLE
fix(desktop): improve first-run provider onboarding / 改进桌面端首次模型接入引导

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9966,7 +9966,21 @@ func (a *App) ConfirmAction(req NativeConfirmRequest) (bool, error) {
 }
 
 func (a *App) NeedsOnboarding() bool {
-	return !config.CredentialStored(onboardingKeyEnv)
+	cfg, err := config.LoadForRootReadOnly(a.activeWorkspaceRoot())
+	if err != nil {
+		// Configuration errors already surface through the startup error banner.
+		// Do not cover their recovery path with an onboarding gate.
+		return false
+	}
+	access := providerAccessSet(cfg.Desktop.ProviderAccess)
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if !modelProviderAccessAllowed(access, p.Name) || !p.Configured() || len(p.ChatModelList()) == 0 {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // ConnectKey validates apiKey against the balance endpoint, persists it to
@@ -9987,6 +10001,9 @@ func (a *App) ConnectKey(apiKey string) (string, error) {
 	warning, err := a.saveProviderCredential(onboardingKeyEnv, apiKey)
 	if err != nil {
 		return "", fmt.Errorf("save: %w", err)
+	}
+	if err := a.ensureProviderAccessForKey(onboardingKeyEnv); err != nil {
+		return "", fmt.Errorf("enable provider: %w", err)
 	}
 	if err := a.rebuildSetting("provider key"); err != nil {
 		if rebuildWarning, ok := a.deferredRebuildWarning("provider key", err); ok {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -254,6 +254,43 @@ func TestNeedsOnboardingTreatsBlankSavedKeyAsMissing(t *testing.T) {
 	}
 }
 
+func TestNeedsOnboardingAcceptsConfiguredCustomProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	cfg := config.Default()
+	cfg.DefaultModel = "custom/custom-model"
+	cfg.Desktop.ProviderAccess = []string{"custom"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name: "custom", Kind: "openai", BaseURL: "https://models.example.invalid/v1",
+		Model: "custom-model", APIKeyEnv: "CUSTOM_API_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save custom provider config: %v", err)
+	}
+	setDesktopTestCredential(t, "CUSTOM_API_KEY", "saved-custom-key")
+
+	if NewApp().NeedsOnboarding() {
+		t.Fatal("NeedsOnboarding should be false when a custom provider is configured")
+	}
+}
+
+func TestNeedsOnboardingAcceptsNoAuthLocalProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	cfg := config.Default()
+	cfg.DefaultModel = "local/local-model"
+	cfg.Desktop.ProviderAccess = []string{"local"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name: "local", Kind: "openai", BaseURL: "http://127.0.0.1:11434/v1",
+		Model: "local-model",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save local provider config: %v", err)
+	}
+
+	if NewApp().NeedsOnboarding() {
+		t.Fatal("NeedsOnboarding should be false for a no-auth local provider")
+	}
+}
+
 func providerNamesFromView(providers []ProviderView) []string {
 	out := make([]string, 0, len(providers))
 	for _, p := range providers {
@@ -4747,6 +4784,50 @@ func TestConnectKeyRejectsBackgroundJobsBeforeSavingKey(t *testing.T) {
 	}
 	if data, readErr := os.ReadFile(config.UserCredentialsPath()); readErr == nil && strings.Contains(string(data), "DEEPSEEK_API_KEY") {
 		t.Fatalf("onboarding key should not be saved after rejected connect:\n%s", data)
+	}
+}
+
+func TestConnectKeyRestoresDeepSeekProviderAccess(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	cfg := config.Default()
+	cfg.DefaultModel = "custom/custom-model"
+	cfg.Desktop.ProviderAccess = []string{"custom"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name: "custom", Kind: "openai", BaseURL: "https://models.example.invalid/v1",
+		Model: "custom-model", APIKeyEnv: "CUSTOM_API_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save custom provider config: %v", err)
+	}
+
+	oldFetch := connectKeyBalanceFetch
+	connectKeyBalanceFetch = func(context.Context, *http.Client, string, string) (*billing.Balance, error) {
+		return &billing.Balance{Available: true}, nil
+	}
+	t.Cleanup(func() { connectKeyBalanceFetch = oldFetch })
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.setTestCtrl(control.New(control.Options{Label: "custom"}), "custom/custom-model")
+	defer func() {
+		if ctrl := app.activeCtrl(); ctrl != nil {
+			ctrl.Close()
+		}
+	}()
+	if _, err := app.ConnectKey("sk-test"); err != nil {
+		t.Fatalf("ConnectKey: %v", err)
+	}
+
+	got := config.LoadForEditWithoutCredentials(config.UserConfigPath())
+	if !providerAccessSet(got.Desktop.ProviderAccess)["deepseek"] {
+		t.Fatalf("provider_access = %v, want DeepSeek restored", got.Desktop.ProviderAccess)
+	}
+	if _, ok := got.Provider("deepseek"); !ok {
+		t.Fatal("DeepSeek provider template should be restored")
+	}
+	if app.NeedsOnboarding() {
+		t.Fatal("restored DeepSeek access and saved key should satisfy onboarding")
 	}
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -65,6 +65,7 @@ import { WorkspacePanel } from "./components/WorkspacePanel";
 import { Tooltip } from "./components/Tooltip";
 import { StartupSplash } from "./components/StartupSplash";
 import { OnboardingOverlay } from "./components/OnboardingOverlay";
+import { dismissOnboarding, shouldOpenOnboarding } from "./lib/onboarding";
 import { AppChrome } from "./components/AppChrome";
 import { ShortcutsCheatsheet } from "./components/ShortcutsCheatsheet";
 import { ProjectTree } from "./components/ProjectTree";
@@ -1090,10 +1091,10 @@ export default function App() {
   const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
   const startupSplashVisible = useOverlayStore((s) => s.startupSplashVisible);
   const setStartupSplashVisible = useOverlayStore((s) => s.setStartupSplashVisible);
-  // null until the mount probe resolves; true shows the overlay. Probed once —
-  // clearing the key mid-session is the Settings panel's job, not the gate's.
+  // null until the mount probe resolves; true shows the first-run guide.
   const needsOnboarding = useOverlayStore((s) => s.needsOnboarding);
   const setNeedsOnboarding = useOverlayStore((s) => s.setNeedsOnboarding);
+  const [providerSetupNeeded, setProviderSetupNeeded] = useState(false);
   const settingsTarget = useOverlayStore((s) => s.settingsTarget);
   const setSettingsTarget = useOverlayStore((s) => s.setSettingsTarget);
   const settingsFocus = useOverlayStore((s) => s.settingsFocus);
@@ -2208,12 +2209,21 @@ export default function App() {
     };
   }, [hydrateRemoteStatuses, setRemoteHosts]);
 
+  const refreshProviderSetupState = useCallback(async () => {
+    const needs = await app.NeedsOnboarding();
+    setProviderSetupNeeded(needs);
+    return needs;
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const needs = await app.NeedsOnboarding();
-        if (!cancelled) setNeedsOnboarding(needs);
+        if (!cancelled) {
+          setProviderSetupNeeded(needs);
+          setNeedsOnboarding(shouldOpenOnboarding(needs));
+        }
       } catch {
         // Bridge unavailable (browser dev seam) — skip the gate; a real key
         // failure still surfaces via the topbar startupError banner.
@@ -2223,7 +2233,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [setNeedsOnboarding]);
 
   useEffect(() => {
     const el = footerRef.current;
@@ -4057,6 +4067,18 @@ export default function App() {
           {safeMode && (
             <div className="banner banner--warning">{t("guard.safeMode")}</div>
           )}
+          {providerSetupNeeded && !needsOnboarding && (
+            <div className="banner banner--warning banner--actionable">
+              <span className="banner__msg">{t("onboarding.inlinePrompt")}</span>
+              <span className="banner__spacer" />
+              <button type="button" className="btn btn--small" onClick={() => {
+                setSettingsFocus({ target: "model-access" });
+                setSettingsTarget("models");
+              }}>
+                {t("onboarding.configureProvider")}
+              </button>
+            </div>
+          )}
 
           <UpdateBanner
             enabled={startupUpdateChecksEnabled === true}
@@ -4435,6 +4457,7 @@ export default function App() {
             }}
             onChanged={(settings) => {
               void refreshMeta();
+              void refreshProviderSetupState().catch(() => {});
               if (settings) {
                 applyDesktopPreferences(settings);
                 void refreshSidebarImConnectionsFromSettings(settings).catch((e) => console.warn("bot sidebar refresh failed", e));
@@ -4471,7 +4494,23 @@ export default function App() {
         <StartupSplash hold={startupSplashHold} onDone={() => setStartupSplashVisible(false)} />
       )}
 
-      {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
+      {needsOnboarding && (
+        <OnboardingOverlay
+          onComplete={() => {
+            setProviderSetupNeeded(false);
+            setNeedsOnboarding(false);
+          }}
+          onChooseProvider={() => {
+            setNeedsOnboarding(false);
+            setSettingsFocus({ target: "model-access" });
+            setSettingsTarget("models");
+          }}
+          onSkip={() => {
+            dismissOnboarding();
+            setNeedsOnboarding(false);
+          }}
+        />
+      )}
 
       <HeartbeatPanel open={heartbeatOpen} onClose={() => setHeartbeatOpen(false)} onOpenTopic={(scope, workspaceRoot, topicId) => {
         void handleOpenTopic(scope, workspaceRoot, topicId);

--- a/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
+++ b/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
@@ -3,6 +3,12 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  ONBOARDING_DISMISSED_STORAGE_KEY,
+  dismissOnboarding,
+  onboardingWasDismissed,
+  shouldOpenOnboarding,
+} from "../lib/onboarding";
 
 let passed = 0;
 let failed = 0;
@@ -20,6 +26,7 @@ function ok(cond: boolean, label: string) {
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
 const bridgeSource = readFileSync(resolve(here, "../lib/bridge.ts"), "utf8");
+const settingsSource = readFileSync(resolve(here, "../components/SettingsPanel.tsx"), "utf8");
 
 console.log("\nstartup settings contract");
 
@@ -39,6 +46,31 @@ ok(
   !/const\s+syncDesktopPreferences[\s\S]*?app\.Settings\(\)[\s\S]*?\};/.test(appSource),
   "startup preference sync avoids rebuilding the full Settings payload",
 );
+ok(
+  /onChooseProvider=\{\(\) => \{[\s\S]*?setSettingsFocus\(\{ target: "model-access" \}\);[\s\S]*?setSettingsTarget\("models"\);/.test(appSource),
+  "onboarding opens the model access flow instead of model usage",
+);
+ok(
+  /initialFocus\?\.target === "model-access" \? "access" : "usage"/.test(settingsSource),
+  "model settings honor the onboarding access target while preserving usage as the default",
+);
+
+const values = new Map<string, string>();
+const storage = {
+  getItem: (key: string) => values.get(key) ?? null,
+  setItem: (key: string, value: string) => values.set(key, value),
+  removeItem: (key: string) => values.delete(key),
+  clear: () => values.clear(),
+  key: (index: number) => [...values.keys()][index] ?? null,
+  get length() { return values.size; },
+} as Storage;
+
+ok(!onboardingWasDismissed(storage), "fresh installs have no onboarding dismissal marker");
+ok(shouldOpenOnboarding(true, storage), "missing providers open the guide before dismissal");
+ok(!shouldOpenOnboarding(false, storage), "configured providers never open the guide");
+dismissOnboarding(storage);
+ok(values.get(ONBOARDING_DISMISSED_STORAGE_KEY) === "1", "skip persists a versioned dismissal marker");
+ok(!shouldOpenOnboarding(true, storage), "persisted skip prevents repeated full-screen interruption");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/OnboardingOverlay.tsx
+++ b/desktop/frontend/src/components/OnboardingOverlay.tsx
@@ -3,9 +3,17 @@ import logo from "../assets/logo.svg";
 import { useT } from "../lib/i18n";
 import { app, openExternal } from "../lib/bridge";
 
-// Full-window first-run gate: validate a pasted key via Go, then onComplete
-// unmounts us so the rebuilt controller's main UI takes over.
-export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
+// Full-window first-run guide: DeepSeek stays the fastest path, while users can
+// open the provider settings or defer setup without being trapped in the gate.
+export function OnboardingOverlay({
+  onComplete,
+  onChooseProvider,
+  onSkip,
+}: {
+  onComplete: () => void;
+  onChooseProvider: () => void;
+  onSkip: () => void;
+}) {
   const t = useT();
   const [value, setValue] = useState("");
   const [state, setState] = useState<"idle" | "validating" | "error">("idle");
@@ -41,10 +49,10 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
   }, [t, value, onComplete]);
 
   return (
-    <div className="onboarding">
+    <div className="onboarding" role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
       <div className="onboarding__card">
         <img src={logo} className="onboarding__logo" alt="Reasonix" draggable={false} />
-        <div className="onboarding__title">{t("onboarding.title")}</div>
+        <div id="onboarding-title" className="onboarding__title">{t("onboarding.title")}</div>
         <div className="onboarding__tag">{t("onboarding.tagline")}</div>
 
         <label className="onboarding__label" htmlFor="onboarding-key">
@@ -57,6 +65,7 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
           type="password"
           autoComplete="off"
           spellCheck={false}
+          autoFocus
           placeholder={t("onboarding.inputPlaceholder")}
           value={value}
           onChange={(e) => {
@@ -93,6 +102,15 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
           )}
         </button>
 
+        <button
+          type="button"
+          className="onboarding__provider"
+          onClick={onChooseProvider}
+          disabled={state === "validating"}
+        >
+          {t("onboarding.chooseProvider")}
+        </button>
+
         <div className="onboarding__links">
           <button
             type="button"
@@ -108,7 +126,7 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
         <button
           type="button"
           className="onboarding__skip"
-          onClick={onComplete}
+          onClick={onSkip}
           disabled={state === "validating"}
         >
           {t("onboarding.skip")}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -65,7 +65,9 @@ import { ModalCloseButton } from "./ModalCloseButton";
 import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "remote", "skills", "subagents", "plugins", "memory", "hooks", "diagnostics", "shortcuts", "permissions", "sandbox", "network", "appearance", "updates"];
-export type SettingsInitialFocus = { target: "bot-allowlist"; connectionId?: string };
+export type SettingsInitialFocus =
+  | { target: "bot-allowlist"; connectionId?: string }
+  | { target: "model-access" };
 type DesktopPlatform = "darwin" | "windows" | "linux";
 
 const MCPServersSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.MCPServersSettingsPage })));
@@ -267,7 +269,7 @@ export function SettingsPanel({
             ) : (
               <>
                 {tab === "general" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><GeneralSection s={s} busy={busy} apply={apply} agentRunning={agentRunning} /></SettingsPageShell>}
-                {tab === "models" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><ModelsSection s={s} busy={busy} apply={apply} backgroundApply={backgroundApply} /></SettingsPageShell>}
+                {tab === "models" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><ModelsSection s={s} busy={busy} apply={apply} backgroundApply={backgroundApply} initialFocus={initialFocus} /></SettingsPageShell>}
                 {tab === "bots" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><BotsSection s={s} busy={busy} apply={apply} initialFocus={initialFocus} /></SettingsPageShell>}
                 {tab === "mcp" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><Suspense fallback={lazySettingsPageFallback}><MCPServersSettingsPage /></Suspense></SettingsPageShell>}
                 {tab === "remote" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><Suspense fallback={lazySettingsPageFallback}><RemoteHostsPage /></Suspense></SettingsPageShell>}
@@ -486,6 +488,7 @@ type SectionProps = {
 
 type ModelsSectionProps = SectionProps & {
   backgroundApply: (fn: () => Promise<void>) => Promise<void>;
+  initialFocus?: SettingsInitialFocus;
 };
 
 function settingsTabLabel(id: SettingsTab, t: ReturnType<typeof useT>): string {
@@ -3985,9 +3988,11 @@ function botDraftWithDerivedGatewayState(draft: BotSettingsView): BotSettingsVie
   };
 }
 
-function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) {
+function ModelsSection({ s, busy, apply, backgroundApply, initialFocus }: ModelsSectionProps) {
   const t = useT();
-  const [subtab, setSubtab] = useState<"usage" | "access">("usage");
+  const [subtab, setSubtab] = useState<"usage" | "access">(
+    initialFocus?.target === "model-access" ? "access" : "usage",
+  );
   const autoRefreshKeyRef = useRef("");
   const refs = useMemo(() => allRefs(s), [s.providers]);
   const defaultRef = toRef(s.defaultModel, s);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -12,7 +12,7 @@ import type { InvocationRequest } from "./invocationDisplay";
 
 import { addBreadcrumb } from "./breadcrumbs";
 import { t } from "./i18n";
-import { providerRequiresKey } from "./providerModels";
+import { providerIsConfigured, providerRequiresKey } from "./providerModels";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems } from "./statusBarItems";
 import { registerTrustedThemeBackgroundURLs } from "./themePack";
 import { modeHasAutoApproveTools, modeWithAutoApproveTools, modeWithPlan, normalizeCollaborationMode, normalizeMode, normalizeTokenMode, normalizeToolApprovalMode } from "./types";
@@ -4054,15 +4054,18 @@ function makeMockApp(): AppBindings {
         window.open("https://reasonix.io/?download=desktop#start", "_blank", "noopener");
       }
     },
-    // Dev seam: drives the overlay flow in the browser until ConnectKey sets the
-    // key. Matches ConnectKey on apiKeyEnv so the two stay in sync.
+    // Dev seam: match the backend's provider-agnostic onboarding predicate.
     async NeedsOnboarding() {
-      return !settings.providers.find((p) => p.apiKeyEnv === "DEEPSEEK_API_KEY")?.keySet;
+      return !settings.providers.some((p) => p.models.length > 0 && providerIsConfigured(p));
     },
     async ConnectKey(apiKey: string) {
       if (!apiKey.trim()) throw new Error("key is required");
       settings.providers.forEach((p) => {
-        if (p.apiKeyEnv === "DEEPSEEK_API_KEY") p.keySet = true;
+        if (p.apiKeyEnv === "DEEPSEEK_API_KEY") {
+          p.added = true;
+          p.keySet = true;
+          p.configured = true;
+        }
       });
       await delay(300);
       return "";

--- a/desktop/frontend/src/lib/onboarding.ts
+++ b/desktop/frontend/src/lib/onboarding.ts
@@ -1,0 +1,29 @@
+export const ONBOARDING_DISMISSED_STORAGE_KEY = "reasonix.onboarding.dismissed.v1";
+
+function onboardingStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function onboardingWasDismissed(storage: Storage | null = onboardingStorage()): boolean {
+  try {
+    return storage?.getItem(ONBOARDING_DISMISSED_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function dismissOnboarding(storage: Storage | null = onboardingStorage()): void {
+  try {
+    storage?.setItem(ONBOARDING_DISMISSED_STORAGE_KEY, "1");
+  } catch {
+    // A blocked localStorage should not trap the user in the onboarding gate.
+  }
+}
+
+export function shouldOpenOnboarding(needsProviderSetup: boolean, storage: Storage | null = onboardingStorage()): boolean {
+  return needsProviderSetup && !onboardingWasDismissed(storage);
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2613,20 +2613,23 @@ export const en = {
   "changelog.subtitle": "A product-focused history of new capabilities, improvements, fixes, and upgrade guidance.",
   "changelog.openWeb": "Open on web",
 
-  // onboarding — first-run API-key overlay
-  "onboarding.title": "Connect Reasonix",
-  "onboarding.tagline": "Paste a DeepSeek API key to start. Stored in Reasonix home .env and used only for provider requests.",
-  "onboarding.inputLabel": "API key",
+  // onboarding — first-run model provider guide
+  "onboarding.title": "Get started with Reasonix",
+  "onboarding.tagline": "Connect a model provider to start chatting. DeepSeek is recommended.",
+  "onboarding.inputLabel": "DeepSeek API key",
   "onboarding.inputPlaceholder": "sk-…",
-  "onboarding.submit": "Connect & start",
+  "onboarding.submit": "Connect DeepSeek",
+  "onboarding.chooseProvider": "Connect another model provider",
   "onboarding.validating": "Validating…",
   "onboarding.getKey": "How do I get a key?",
-  "onboarding.privacy": "Stored only in Reasonix home .env",
+  "onboarding.privacy": "Saved locally and never synced by Reasonix",
   "onboarding.error.empty": "Please paste a key first.",
   "onboarding.error.invalid": "That key didn't work — double-check it's active and has billing set up.",
   "onboarding.error.network": "Couldn't reach DeepSeek — check your network and try again.",
   "onboarding.error.unknown": "Something went wrong: {msg}",
   "onboarding.skip": "Skip for now",
+  "onboarding.inlinePrompt": "Connect a model provider before starting a conversation.",
+  "onboarding.configureProvider": "Configure model provider",
 
   // context panel
   "context.overview": "Session overview",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1814,20 +1814,23 @@ export const zhTW: Record<DictKey, string> = {
   "changelog.subtitle": "依產品能力整理新功能、改進、修復與升級提醒，不再只是提交記錄。",
   "changelog.openWeb": "在網頁查看",
 
-  // onboarding — first-run API-key overlay
-  "onboarding.title": "連線 Reasonix",
-  "onboarding.tagline": "貼上一個 DeepSeek API key 即可開始。金鑰僅存於本應用的本機憑證檔案，不會傳送到任何地方。",
-  "onboarding.inputLabel": "API 金鑰",
+  // onboarding — 首次使用模型服務引導
+  "onboarding.title": "開始使用 Reasonix",
+  "onboarding.tagline": "連線模型服務後即可開始對話。推薦使用 DeepSeek。",
+  "onboarding.inputLabel": "DeepSeek API 金鑰",
   "onboarding.inputPlaceholder": "sk-…",
-  "onboarding.submit": "連線並開始",
+  "onboarding.submit": "連線 DeepSeek",
+  "onboarding.chooseProvider": "接入其他模型服務",
   "onboarding.validating": "驗證中…",
   "onboarding.getKey": "如何取得 API key？",
-  "onboarding.privacy": "僅儲存在本應用的本機憑證檔案",
+  "onboarding.privacy": "金鑰僅儲存在本機，Reasonix 不會同步",
   "onboarding.error.empty": "請先貼上金鑰。",
   "onboarding.error.invalid": "這個 key 無法使用 —— 檢查一下是否已啟用、是否開通了計費。",
   "onboarding.error.network": "無法連線 DeepSeek —— 檢查網路後再試。",
   "onboarding.error.unknown": "出錯啦：{msg}",
   "onboarding.skip": "稍後設定",
+  "onboarding.inlinePrompt": "開始對話前，請先連線一個模型服務。",
+  "onboarding.configureProvider": "設定模型服務",
 
   // 上下文面板
   "context.overview": "當前會話概覽",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2616,20 +2616,23 @@ export const zh: Record<DictKey, string> = {
   "changelog.subtitle": "按产品能力整理新功能、改进、修复与升级提醒，不再只是提交记录。",
   "changelog.openWeb": "在网页查看",
 
-  // onboarding — first-run API-key overlay
-  "onboarding.title": "连接 Reasonix",
-  "onboarding.tagline": "粘贴一个 DeepSeek API key 即可开始。密钥仅保存到 Reasonix 全局 .env，仅用于 provider 请求。",
-  "onboarding.inputLabel": "API 密钥",
+  // onboarding — 首次使用模型服务引导
+  "onboarding.title": "开始使用 Reasonix",
+  "onboarding.tagline": "连接模型服务后即可开始对话。推荐使用 DeepSeek。",
+  "onboarding.inputLabel": "DeepSeek API 密钥",
   "onboarding.inputPlaceholder": "sk-…",
-  "onboarding.submit": "连接并开始",
+  "onboarding.submit": "连接 DeepSeek",
+  "onboarding.chooseProvider": "接入其他模型服务",
   "onboarding.validating": "校验中…",
   "onboarding.getKey": "如何获取 API key？",
-  "onboarding.privacy": "仅保存在 Reasonix 全局 .env",
+  "onboarding.privacy": "密钥仅保存在本机，Reasonix 不会同步",
   "onboarding.error.empty": "请先粘贴密钥。",
   "onboarding.error.invalid": "这个 key 无法使用 —— 检查一下是否已激活、是否开通了计费。",
   "onboarding.error.network": "无法连接 DeepSeek —— 检查网络后再试。",
   "onboarding.error.unknown": "出错啦：{msg}",
   "onboarding.skip": "稍后设置",
+  "onboarding.inlinePrompt": "开始对话前，请先连接一个模型服务。",
+  "onboarding.configureProvider": "配置模型服务",
 
   // 上下文面板
   "context.overview": "当前会话概览",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -19602,6 +19602,25 @@ body > .mermaid-diagram--fullscreen {
   opacity: 0.7;
   cursor: not-allowed;
 }
+.onboarding__provider {
+  padding: 9px 14px;
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 550;
+  font-family: inherit;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.onboarding__provider:hover:not(:disabled) {
+  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
+  border-color: var(--border-strong, var(--border));
+}
+.onboarding__provider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 .onboarding__spinner {
   display: inline-block;
   width: 12px;


### PR DESCRIPTION
## Summary

- Replace the DeepSeek-key-only onboarding predicate with the effective enabled provider configuration, so configured custom and no-auth local providers are accepted.
- Turn the blocking first-run key prompt into a provider onboarding guide with a DeepSeek quick path, direct access to other model providers, and a durable defer option backed by an actionable inline banner.
- Route onboarding and missing-provider setup actions to **Settings > Models > Access** while preserving **Models > Usage** as the normal settings default.
- Restore the DeepSeek provider template/access after quick-connect and add backend plus frontend regression coverage.

Closes #6418

## Verification

- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/startup-settings-contract.test.ts` (11 passed)
- `cd desktop/frontend && pnpm build`
- In-app browser: verified the first-run dialog, defer flow, persistent setup banner, and both setup routes selecting **Models > Access** (`aria-selected=true`).

## Compatibility

| Surface | Existing data behavior | Conclusion |
| --- | --- | --- |
| Provider TOML | No fields or formats change; onboarding reads the existing provider and `provider_access` configuration. | Compatible |
| Credential store | Provider secrets remain in the existing Reasonix home `.env`; no secret values move into TOML or frontend storage. | Compatible |
| Onboarding dismissal | Existing installations have no marker and retain the normal eligibility check; the versioned local marker is written only after **Skip for now**. | Compatible |
| Wails bridge | Existing `NeedsOnboarding` and `ConnectKey` method signatures are unchanged. | Compatible |

## Cache impact

Cache-impact: none — no provider request serialization, prompt construction, tool schema, compaction, or agent context changes.
Cache-guard: N/A — the change is limited to desktop provider detection, setup persistence, and UI routing.
System-prompt-review: N/A
