### PR TITLE
feat(mcp): add OAuth 2.0 authorization for remote MCP servers

### DIFF
--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -1,0 +1,112 @@
+# MCP OAuth 2.0 Authorization
+
+Reasonix can connect to remote MCP servers (Streamable HTTP, `type = "http"`)
+that require OAuth 2.0 authorization — for example hosted servers behind a
+social login, or managed registries such as Composio and Amplitude. Authorization
+runs automatically the first time a server rejects a request with `401`.
+
+## How it works
+
+1. **401 triggers discovery.** When a remote server returns `401 Unauthorized`,
+   Reasonix fetches the server's
+   [protected-resource metadata](https://datatracker.ietf.org/doc/html/rfc9728)
+   at `/.well-known/oauth-protected-resource`, then the linked
+   [authorization-server metadata](https://datatracker.ietf.org/doc/html/rfc8414).
+2. **Client registration.** If the authorization server advertises a
+   [dynamic registration endpoint](https://datatracker.ietf.org/doc/html/rfc7591)
+   (RFC 7591), Reasonix registers a public PKCE client. Otherwise it uses an
+   explicit `client_id` from config or a default public client id.
+3. **Sign in.** Reasonix opens your default browser at the authorization
+   endpoint and listens on a loopback redirect (`http://localhost:<port>/callback`)
+   for the code. The flow uses PKCE (S256) and a `state` CSRF token.
+4. **Token exchange & caching.** The code is exchanged for an access token
+   (and refresh token when issued). The token is stored at
+   `~/.reasonix/mcp-oauth-credentials.json` (mode `0600`), keyed by server
+   origin, so later sessions reuse it without another sign-in.
+5. **Refresh.** When the cached token expires, Reasonix refreshes it
+   non-interactively. If the refresh token is no longer valid, the browser
+   flow runs again on the next `401`.
+
+No new dependencies were added; the implementation uses only the Go standard
+library.
+
+## Minimal configuration
+
+For servers that support auto-discovery, you need nothing beyond the server URL:
+
+```toml
+[[plugins]]
+name = "composio"
+type = "http"
+url  = "https://mcp.composio.dev/app/..."
+```
+
+The first request gets a `401`; Reasonix opens your browser, you sign in, and
+the server's tools come online.
+
+## Optional overrides
+
+Pin behavior with an `[plugins.oauth]` block. Every field is optional:
+
+```toml
+[[plugins]]
+name = "amplitude"
+type = "http"
+url  = "https://mcp.amplitude.com/..."
+
+[plugins.oauth]
+client_id = "my-public-client"      # default: dynamic client registration
+client_secret = ""                  # only for confidential clients
+scopes = ["read", "write"]          # default: server-advertised scopes
+redirect_port = 8080                # default: a free loopback port
+skip_browser = false                # true prints the URL instead (headless/CI)
+skip_dynamic_registration = false   # true disables RFC 7591 DCR
+trusted_origins = []                # allow metadata/AS origins beyond the server
+```
+
+The same block works in a project-root `.mcp.json` (Claude-compatible):
+
+```json
+{
+  "mcpServers": {
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/...",
+      "oauth": { "scopes": ["read"] }
+    }
+  }
+}
+```
+
+## Headless / CI
+
+Set `skip_browser = true`. Reasonix prints the authorization URL and waits (up
+to five minutes) for you to open it and complete the sign-in from any browser
+that can reach the loopback callback. For fully automated environments, prefer a
+server that accepts a static bearer token configured in `headers` instead.
+
+## Security
+
+- **Origin validation.** Protected-resource and authorization-server metadata
+  must come from the MCP server's own origin (or an explicitly trusted origin
+  via `trusted_origins`). The issuer in AS metadata must match the URL it was
+  fetched from. This prevents a malicious server from redirecting authorization
+  to attacker-controlled endpoints.
+- **PKCE + state.** Every authorization uses S256 PKCE and a random `state`
+  token validated on the callback.
+- **Token storage.** Credentials are written to a `0600` file, atomically, and
+  never appear in logs. The `clear-auth` command also strips any configured
+  OAuth `client_secret` before sharing config.
+- **Redirect isolation.** The configured `Authorization` header is never sent
+  across an origin redirect.
+
+## Troubleshooting
+
+- **`http 401: server requires OAuth authorization`** after signing in — the
+  token was rejected. Check that `client_id`/`scopes` match what the server
+  expects, or remove the overrides to let auto-discovery choose them.
+- **`discover OAuth metadata ... 404`** — the server does not publish
+  `/.well-known/oauth-protected-resource`. Confirm the server supports MCP
+  OAuth; if it only accepts a static token, use `headers` instead.
+- **`authorization server requires PAR`** — the server mandates Pushed
+  Authorization Requests (RFC 9126), which is not yet supported.

--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -99,6 +99,82 @@ server that accepts a static bearer token configured in `headers` instead.
   OAuth `client_secret` before sharing config.
 - **Redirect isolation.** The configured `Authorization` header is never sent
   across an origin redirect.
+- **Key handling.** Inline private keys (`private_key_pem`) are stripped by
+  `clear-auth` like any other secret; key file paths (`private_key_path`) are
+  preserved since they are pointers, not secrets.
+
+## OAuth 2.1 compliance
+
+The client follows the [OAuth 2.1](https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/)
+best-current-practice profile, which is a constrained subset of OAuth 2.0:
+
+- **PKCE is always used** (S256 only; the `plain` method is never sent), even
+  for confidential clients.
+- **Only the authorization-code grant** is used for interactive flows. The
+  implicit and resource-owner-password grants are never sent.
+- **Exact `redirect_uri` matching** — the same loopback URI is sent to both the
+  authorize and token endpoints.
+- **`state` CSRF protection** on every authorization.
+- JWT-based token-endpoint authentication (`private_key_jwt`,
+  `client_secret_jwt`) is supported per OAuth 2.1's recommendation for
+  confidential clients.
+
+## OAuth/JWT (RFC 7523)
+
+The client supports the JWT Profile for OAuth 2.0 (RFC 7523) in two ways,
+implemented with the Go standard library only (no JOSE dependency):
+
+### JWT access tokens
+
+JWT-format access tokens returned by a server are consumed transparently: any
+token string the server returns is sent as `Bearer <token>`. No configuration
+is needed.
+
+### JWT client authentication (`private_key_jwt` / `client_secret_jwt`)
+
+Instead of sending a `client_secret`, the client signs a short-lived JWT
+assertion that authenticates it at the token endpoint (RFC 7523 §2). This is how
+services prove identity with an asymmetric key and is recommended for
+confidential clients.
+
+```toml
+[[plugins]]
+name = "svc"
+type = "http"
+url  = "https://mcp.example.com/mcp"
+
+[plugins.oauth]
+client_id = "my-client"
+token_endpoint_auth_method = "private_key_jwt"
+private_key_path = "/etc/reasonix/svc.pem"   # RSA/EC/Ed25519 PEM
+client_assertion_signing_alg = "RS256"        # optional; defaults to key type
+```
+
+Supported signing algorithms: `RS256/384/512`, `PS256/384/512`, `ES256/384/512`,
+`HS256/384/512` (for `client_secret_jwt`), and `EdDSA`. The auth method must be
+advertised in the server's `token_endpoint_auth_methods_supported` or the
+authorization fails loudly.
+
+### JWT bearer assertion grant (service-to-service)
+
+For non-interactive machine authorization (no browser), configure a JWT bearer
+assertion grant (RFC 7523 §1). The client signs a fresh assertion for each token
+request:
+
+```toml
+[[plugins]]
+name = "robot"
+type = "http"
+url  = "https://mcp.example.com/mcp"
+
+[plugins.oauth.jwt_bearer_grant]
+issuer = "service-account-1"
+private_key_path = "/etc/reasonix/robot.pem"
+signing_alg = "RS256"
+scopes = ["tools:call"]
+```
+
+When a `jwt_bearer_grant` is set, `Authorize` never opens a browser.
 
 ## Troubleshooting
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -36,6 +36,7 @@ import (
 	"reasonix/internal/instruction"
 	"reasonix/internal/jobs"
 	"reasonix/internal/lsp"
+	"reasonix/internal/mcpauth"
 	"reasonix/internal/mcpcatalog"
 	"reasonix/internal/mcplaunch"
 	"reasonix/internal/memory"
@@ -342,6 +343,23 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return nil, err
 	}
 
+	// The shared MCP OAuth client. It is host-injected into every remote
+	// (http/sse) server's Spec.Authorizer so the transport can acquire and
+	// refresh bearer tokens. It uses the app's proxy settings and routes
+	// user-facing notices through the event sink.
+	oauthHTTPClient, err := netclient.NewHTTPClient(proxySpec, netclient.TransportOptions{})
+	if err != nil {
+		return nil, err
+	}
+	oauthClient, err := mcpauth.New(mcpauth.Options{
+		StorePath:  filepath.Join(config.ReasonixHomeDir(), "mcp-oauth-credentials.json"),
+		HTTPClient: oauthHTTPClient,
+		Out:        &sinkNoticeWriter{sink: sink},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mcp oauth client: %w", err)
+	}
+
 	execProv, err := NewProviderWithProxy(entry, proxySpec)
 	if err != nil {
 		return nil, err
@@ -482,6 +500,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		DefaultCallTimeout:   time.Duration(cfg.MCPCallTimeoutSeconds()) * time.Second,
 		PlanModeAllowedTools: cfg.Agent.PlanModeAllowedTools,
 		LaunchManager:        mcplaunch.ForWorkspace(config.ReasonixHomeDir(), root),
+		Authorizer:           oauthClient,
 		ConfigSource:         "workspace_config",
 		StateHome:            config.ReasonixHomeDir(),
 		WriterRoots:          writeRoots,
@@ -506,6 +525,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	for i := range extraSpecs {
 		if extraSpecs[i].LaunchManager == nil {
 			extraSpecs[i].LaunchManager = pluginSpecOptions.LaunchManager
+		}
+		if isRemoteTransport(extraSpecs[i].Type) && pluginSpecOptions.Authorizer != nil {
+			extraSpecs[i].Authorizer = pluginSpecOptions.Authorizer
 		}
 		if strings.TrimSpace(extraSpecs[i].ConfigSource) == "" {
 			extraSpecs[i].ConfigSource = "host_session"
@@ -1591,6 +1613,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				return
 			}
 			spec.LaunchManager = pluginSpecOptions.LaunchManager
+			if isRemoteTransport(spec.Type) && pluginSpecOptions.Authorizer != nil {
+				spec.Authorizer = pluginSpecOptions.Authorizer
+			}
 			if strings.TrimSpace(spec.ConfigSource) == "" {
 				spec.ConfigSource = pluginSpecOptions.ConfigSource
 			}
@@ -2223,13 +2248,16 @@ type PluginSpecOptions struct {
 	DefaultCallTimeout   time.Duration
 	PlanModeAllowedTools []string
 	LaunchManager        *mcplaunch.Manager
-	ConfigSource         string
-	StateHome            string
-	WriterRoots          []string
-	ForbidReadRoots      []string
-	Network              bool
-	OfficialServers      map[string]VerifiedMCPPackage
-	PackageOwners        map[string]string
+	// Authorizer is injected into every remote (http/sse) server so the HTTP
+	// transport can perform OAuth. Nil disables OAuth entirely.
+	Authorizer      *mcpauth.Client
+	ConfigSource    string
+	StateHome       string
+	WriterRoots     []string
+	ForbidReadRoots []string
+	Network         bool
+	OfficialServers map[string]VerifiedMCPPackage
+	PackageOwners   map[string]string
 }
 
 type VerifiedMCPPackage struct {
@@ -2290,9 +2318,77 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 		ImplicitApproval:         e.Source.UserAuthorized(),
 		RequireLaunchApproval:    e.Source.RequiresLaunchApproval(),
 	}, workspaceRoot)
+	// Remote (http/sse) servers get the OAuth authorizer so the transport can
+	// acquire and refresh bearer tokens. The per-server OAuth config (if any) is
+	// registered on the shared client keyed by server name.
+	if isRemoteTransport(spec.Type) && opts.Authorizer != nil {
+		spec.Authorizer = opts.Authorizer
+		if e.OAuth != nil {
+			opts.Authorizer.SetConfig(spec.Name, toMCPOAuthConfig(*e.OAuth))
+		}
+	}
 	applyMCPIsolation(&spec, workspaceRoot, opts)
 	applyVerifiedMCPPackage(&spec, opts)
 	return spec
+}
+
+// isRemoteTransport reports whether a plugin transport is a remote http(s) one.
+func isRemoteTransport(typ string) bool {
+	switch strings.ToLower(strings.TrimSpace(typ)) {
+	case "http", "streamable-http", "streamable_http", "sse":
+		return true
+	default:
+		return false
+	}
+}
+
+// toMCPOAuthConfig converts the config-layer OAuth type to the runtime one.
+func toMCPOAuthConfig(c config.MCPOAuthConfig) mcpauth.Config {
+	return mcpauth.Config{
+		ClientID:                c.ClientID,
+		ClientSecret:            c.ClientSecret,
+		Scopes:                  c.Scopes,
+		RedirectPort:            c.RedirectPort,
+		SkipBrowser:             c.SkipBrowser,
+		SkipDynamicRegistration: c.SkipDynamicRegistration,
+		TrustedOrigins:          c.TrustedOrigins,
+	}
+}
+
+// sinkNoticeWriter is an io.Writer that emits each line written to it as a
+// Notice event on the sink, so MCP OAuth status messages ("opening your
+// browser") reach the user through the normal event channel.
+type sinkNoticeWriter struct {
+	sink event.Sink
+	buf  []byte
+	mu   sync.Mutex
+}
+
+func (w *sinkNoticeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		i := indexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r")
+		w.buf = w.buf[i+1:]
+		if strings.TrimSpace(line) != "" && w.sink != nil {
+			w.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: line})
+		}
+	}
+	return len(p), nil
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, x := range b {
+		if x == c {
+			return i
+		}
+	}
+	return -1
 }
 
 func pluginPackageOwners(cfg *config.Config) map[string]string {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2344,15 +2344,30 @@ func isRemoteTransport(typ string) bool {
 
 // toMCPOAuthConfig converts the config-layer OAuth type to the runtime one.
 func toMCPOAuthConfig(c config.MCPOAuthConfig) mcpauth.Config {
-	return mcpauth.Config{
-		ClientID:                c.ClientID,
-		ClientSecret:            c.ClientSecret,
-		Scopes:                  c.Scopes,
-		RedirectPort:            c.RedirectPort,
-		SkipBrowser:             c.SkipBrowser,
-		SkipDynamicRegistration: c.SkipDynamicRegistration,
-		TrustedOrigins:          c.TrustedOrigins,
+	out := mcpauth.Config{
+		ClientID:                  c.ClientID,
+		ClientSecret:              c.ClientSecret,
+		Scopes:                    c.Scopes,
+		RedirectPort:              c.RedirectPort,
+		SkipBrowser:               c.SkipBrowser,
+		SkipDynamicRegistration:   c.SkipDynamicRegistration,
+		TrustedOrigins:            c.TrustedOrigins,
+		TokenEndpointAuthMethod:   c.TokenEndpointAuthMethod,
+		PrivateKeyPEM:             c.PrivateKeyPEM,
+		PrivateKeyPath:            c.PrivateKeyPath,
+		ClientAssertionSigningAlg: c.ClientAssertionSigningAlg,
 	}
+	if c.JWTBearerGrant != nil {
+		out.JWTBearerGrant = &mcpauth.JWTBearerGrant{
+			Issuer:         c.JWTBearerGrant.Issuer,
+			Subject:        c.JWTBearerGrant.Subject,
+			PrivateKeyPEM:  c.JWTBearerGrant.PrivateKeyPEM,
+			PrivateKeyPath: c.JWTBearerGrant.PrivateKeyPath,
+			SigningAlg:     c.JWTBearerGrant.SigningAlg,
+			Scopes:         c.JWTBearerGrant.Scopes,
+		}
+	}
+	return out
 }
 
 // sinkNoticeWriter is an io.Writer that emits each line written to it as a

--- a/internal/boot/oauth_wiring_test.go
+++ b/internal/boot/oauth_wiring_test.go
@@ -1,0 +1,52 @@
+package boot
+
+import (
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/mcpauth"
+)
+
+// newTestAuthorizer builds an mcpauth.Client backed by a temp credentials file.
+func newTestAuthorizer(t *testing.T) *mcpauth.Client {
+	t.Helper()
+	c, err := mcpauth.New(mcpauth.Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+	if err != nil {
+		t.Fatalf("mcpauth.New: %v", err)
+	}
+	return c
+}
+
+// TestPluginSpecInjectsAuthorizerForHTTP verifies that remote servers receive the
+// OAuth authorizer and their per-server config is registered, while stdio
+// servers do not.
+func TestPluginSpecInjectsAuthorizerForHTTP(t *testing.T) {
+	auth := newTestAuthorizer(t)
+	opts := PluginSpecOptions{Authorizer: auth}
+
+	httpEntry := config.PluginEntry{
+		Name:  "remote",
+		Type:  "http",
+		URL:   "https://mcp.example.com/mcp",
+		OAuth: &config.MCPOAuthConfig{ClientID: "abc", Scopes: []string{"read"}},
+	}
+	spec := pluginSpecFromEntryWithOptions(httpEntry, "", opts)
+	if spec.Authorizer == nil {
+		t.Fatal("http server should have an Authorizer injected")
+	}
+
+	stdioSpec := pluginSpecFromEntryWithOptions(config.PluginEntry{Name: "local", Type: "stdio", Command: "echo"}, "", opts)
+	if stdioSpec.Authorizer != nil {
+		t.Fatal("stdio server should NOT receive an Authorizer")
+	}
+}
+
+// TestPluginSpecNoAuthorizerKeepsNil verifies that a nil authorizer option
+// leaves http servers without one (OAuth fully disabled) and never panics.
+func TestPluginSpecNoAuthorizerKeepsNil(t *testing.T) {
+	spec := pluginSpecFromEntryWithOptions(config.PluginEntry{Name: "remote", Type: "http", URL: "https://mcp.example.com"}, "", PluginSpecOptions{})
+	if spec.Authorizer != nil {
+		t.Fatal("nil authorizer option should leave Spec.Authorizer nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1519,9 +1519,51 @@ type PluginEntry struct {
 	//                  swap happens once the spawn finishes.
 	// Empty defaults to "background" so enabled MCPs connect automatically
 	// without blocking chat. Unknown non-empty values fall back to "background".
-	Tier         string          `toml:"tier"`
+	Tier string `toml:"tier"`
+	// OAuth configures remote-server OAuth 2.0 authorization for http/sse
+	// plugins. It is optional: when nil, Reasonix auto-discovers authorization
+	// metadata on the first 401 and runs the browser flow. Set it to pin a
+	// client id, request specific scopes, or run headless (skip_browser).
+	OAuth        *MCPOAuthConfig `toml:"oauth,omitempty"`
 	Source       MCPConfigSource `toml:"-" json:"-"`
 	expansionEnv map[string]string
+}
+
+// MCPOAuthConfig is the optional OAuth 2.0 configuration for one remote MCP
+// server. It mirrors a subset of the runtime mcpauth.Config; the conversion
+// happens in the boot layer so the config package stays free of that dependency.
+type MCPOAuthConfig struct {
+	// ClientID overrides the public client id used in the authorization flow.
+	// Empty performs dynamic client registration when the server supports it.
+	ClientID string `toml:"client_id" json:"client_id,omitempty"`
+	// ClientSecret pairs with ClientID for confidential clients. Leave empty for
+	// public PKCE clients.
+	ClientSecret string `toml:"client_secret" json:"client_secret,omitempty"`
+	// Scopes requests specific OAuth scopes. Empty lets the server decide.
+	Scopes []string `toml:"scopes" json:"scopes,omitempty"`
+	// RedirectPort pins the loopback callback port. Zero picks a free port.
+	RedirectPort int `toml:"redirect_port" json:"redirect_port,omitempty"`
+	// SkipBrowser prints the authorization URL instead of opening a browser.
+	SkipBrowser bool `toml:"skip_browser" json:"skip_browser,omitempty"`
+	// SkipDynamicRegistration disables RFC 7591 registration even if the server
+	// advertises a registration endpoint.
+	SkipDynamicRegistration bool `toml:"skip_dynamic_registration" json:"skip_dynamic_registration,omitempty"`
+	// TrustedOrigins authorizes metadata/issuer origins outside the server
+	// origin (escape hatch for federated deployments).
+	TrustedOrigins []string `toml:"trusted_origins" json:"trusted_origins,omitempty"`
+}
+
+// ClearOAuthSecret returns a copy of cfg with any embedded client_secret
+// removed, and whether anything changed. The clear-auth path uses it so a
+// shared config never carries a confidential OAuth client secret. Public PKCE
+// clients (the common case) have no secret, so this is a no-op for them.
+func ClearOAuthSecret(cfg *MCPOAuthConfig) (*MCPOAuthConfig, bool) {
+	if cfg == nil || strings.TrimSpace(cfg.ClientSecret) == "" {
+		return cfg, false
+	}
+	out := *cfg
+	out.ClientSecret = ""
+	return &out, true
 }
 
 func (e PluginEntry) ShouldAutoStart() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1551,18 +1551,64 @@ type MCPOAuthConfig struct {
 	// TrustedOrigins authorizes metadata/issuer origins outside the server
 	// origin (escape hatch for federated deployments).
 	TrustedOrigins []string `toml:"trusted_origins" json:"trusted_origins,omitempty"`
+	// TokenEndpointAuthMethod selects how the client authenticates at the token
+	// endpoint: none|client_secret_basic|client_secret_post|private_key_jwt|
+	// client_secret_jwt. Empty auto-selects. private_key_jwt/client_secret_jwt
+	// use RFC 7523 JWT assertions.
+	TokenEndpointAuthMethod string `toml:"token_endpoint_auth_method" json:"token_endpoint_auth_method,omitempty"`
+	// PrivateKeyPath points to a PEM-encoded private key (RSA/EC/Ed25519) used
+	// to sign private_key_jwt assertions. Preferred over PrivateKeyPEM so the
+	// key stays out of config files.
+	PrivateKeyPath string `toml:"private_key_path" json:"private_key_path,omitempty"`
+	// PrivateKeyPEM is an inline PEM-encoded private key for private_key_jwt.
+	PrivateKeyPEM string `toml:"private_key_pem" json:"private_key_pem,omitempty"`
+	// ClientAssertionSigningAlg overrides the JWS alg for JWT assertions
+	// (RS256, ES256, PS256, HS256, EdDSA, ...). Empty = key-type default.
+	ClientAssertionSigningAlg string `toml:"client_assertion_signing_alg" json:"client_assertion_signing_alg,omitempty"`
+	// JWTBearerGrant enables the RFC 7523 §1 JWT bearer assertion grant for
+	// non-interactive (service) authorization. When set, no browser opens.
+	JWTBearerGrant *MCPJWTBearerGrant `toml:"jwt_bearer_grant,omitempty" json:"jwt_bearer_grant,omitempty"`
 }
 
-// ClearOAuthSecret returns a copy of cfg with any embedded client_secret
-// removed, and whether anything changed. The clear-auth path uses it so a
-// shared config never carries a confidential OAuth client secret. Public PKCE
-// clients (the common case) have no secret, so this is a no-op for them.
+// MCPJWTBearerGrant configures the RFC 7523 §1 JWT bearer assertion grant
+// (service-to-service, no browser).
+type MCPJWTBearerGrant struct {
+	Issuer         string   `toml:"issuer" json:"issuer,omitempty"`
+	Subject        string   `toml:"subject" json:"subject,omitempty"`
+	PrivateKeyPath string   `toml:"private_key_path" json:"private_key_path,omitempty"`
+	PrivateKeyPEM  string   `toml:"private_key_pem" json:"private_key_pem,omitempty"`
+	SigningAlg     string   `toml:"signing_alg" json:"signing_alg,omitempty"`
+	Scopes         []string `toml:"scopes" json:"scopes,omitempty"`
+}
+
+// ClearOAuthSecret returns a copy of cfg with any embedded secrets removed
+// (client_secret and inline private keys), and whether anything changed. The
+// clear-auth path uses it so a shared config never carries confidential
+// material. File-based keys (PrivateKeyPath) are kept since they are a path,
+// not a secret; private_key_pem and jwt_bearer_grant.private_key_pem are stripped.
 func ClearOAuthSecret(cfg *MCPOAuthConfig) (*MCPOAuthConfig, bool) {
-	if cfg == nil || strings.TrimSpace(cfg.ClientSecret) == "" {
+	if cfg == nil {
 		return cfg, false
 	}
+	changed := false
 	out := *cfg
-	out.ClientSecret = ""
+	if strings.TrimSpace(out.ClientSecret) != "" {
+		out.ClientSecret = ""
+		changed = true
+	}
+	if strings.TrimSpace(out.PrivateKeyPEM) != "" {
+		out.PrivateKeyPEM = ""
+		changed = true
+	}
+	if out.JWTBearerGrant != nil && strings.TrimSpace(out.JWTBearerGrant.PrivateKeyPEM) != "" {
+		g := *out.JWTBearerGrant
+		g.PrivateKeyPEM = ""
+		out.JWTBearerGrant = &g
+		changed = true
+	}
+	if !changed {
+		return cfg, false
+	}
 	return &out, true
 }
 

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -785,10 +785,12 @@ func (c *Config) ClearPluginAuthentication(name string) (PluginEntry, bool, erro
 			continue
 		}
 		headers, env, url, changed := mcpdiag.ClearAuthConfig(c.Plugins[i].Headers, c.Plugins[i].Env, c.Plugins[i].URL)
+		oauth, oauthChanged := ClearOAuthSecret(c.Plugins[i].OAuth)
 		c.Plugins[i].Headers = headers
 		c.Plugins[i].Env = env
 		c.Plugins[i].URL = url
-		return c.Plugins[i], changed, nil
+		c.Plugins[i].OAuth = oauth
+		return c.Plugins[i], changed || oauthChanged, nil
 	}
 	return PluginEntry{}, false, fmt.Errorf("clear plugin authentication: no plugin %q", name)
 }

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -37,6 +37,7 @@ type mcpServerSpec struct {
 	DefaultToolsApprovalMode string                   `json:"default_tools_approval_mode"`
 	Tools                    map[string]MCPToolPolicy `json:"tools"`
 	ApprovalsReviewer        string                   `json:"approvals_reviewer"`
+	OAuth                    *MCPOAuthConfig          `json:"oauth"`
 }
 
 // loadMCPJSON reads path (Claude Code's .mcp.json) and returns its servers as
@@ -216,6 +217,7 @@ func pluginEntryFromMCPSpec(name string, s mcpServerSpec) PluginEntry {
 		DefaultToolsApprovalMode: s.DefaultToolsApprovalMode,
 		Tools:                    mcpToolPoliciesWithApprovalMode(s.Tools),
 		ApprovalsReviewer:        s.ApprovalsReviewer,
+		OAuth:                    s.OAuth,
 	}
 	e, _ = NormalizePluginCommandLine(e)
 	return e
@@ -343,6 +345,7 @@ func applyPluginEntryToMCPJSONServer(server map[string]json.RawMessage, entry Pl
 		return err
 	}
 	setMCPJSONString(server, "approvals_reviewer", strings.TrimSpace(entry.ApprovalsReviewer))
+	setMCPJSONOAuth(server, "oauth", entry.OAuth)
 	return nil
 }
 
@@ -457,12 +460,14 @@ func clearMCPJSONAuthentication(path, name string) (PluginEntry, bool, error) {
 		return PluginEntry{}, false, fmt.Errorf("mcp config %s: server %q: %w", path, name, err)
 	}
 	cleanHeaders, cleanEnv, cleanURL, changed := mcpdiag.ClearAuthConfig(spec.Headers, spec.Env, spec.URL)
-	if !changed {
+	cleanOAuth, oauthChanged := ClearOAuthSecret(spec.OAuth)
+	if !changed && !oauthChanged {
 		return pluginEntryFromMCPSpec(name, spec), false, nil
 	}
 	spec.Headers = cleanHeaders
 	spec.Env = cleanEnv
 	spec.URL = cleanURL
+	spec.OAuth = cleanOAuth
 
 	var server map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &server); err != nil || server == nil {
@@ -471,6 +476,7 @@ func clearMCPJSONAuthentication(path, name string) (PluginEntry, bool, error) {
 	setMCPJSONStringMap(server, "headers", cleanHeaders)
 	setMCPJSONStringMap(server, "env", cleanEnv)
 	setMCPJSONString(server, "url", cleanURL)
+	setMCPJSONOAuth(server, "oauth", cleanOAuth)
 	updatedRaw, err := json.Marshal(server)
 	if err != nil {
 		return PluginEntry{}, false, fmt.Errorf("mcp config %s: server %q: %w", path, name, err)
@@ -511,6 +517,32 @@ func setMCPJSONString(server map[string]json.RawMessage, key, value string) {
 		return
 	}
 	server[key] = raw
+}
+
+// setMCPJSONOAuth serializes the optional OAuth block. A nil config deletes the
+// key so round-tripping a server that never had OAuth leaves no empty object.
+func setMCPJSONOAuth(server map[string]json.RawMessage, key string, cfg *MCPOAuthConfig) {
+	if cfg == nil || isZeroOAuthConfig(cfg) {
+		delete(server, key)
+		return
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		delete(server, key)
+		return
+	}
+	server[key] = raw
+}
+
+// isZeroOAuthConfig reports whether every OAuth field is unset, so an empty
+// block is not written to disk.
+func isZeroOAuthConfig(cfg *MCPOAuthConfig) bool {
+	if cfg == nil {
+		return true
+	}
+	return cfg.ClientID == "" && cfg.ClientSecret == "" && cfg.RedirectPort == 0 &&
+		!cfg.SkipBrowser && !cfg.SkipDynamicRegistration && len(cfg.Scopes) == 0 &&
+		len(cfg.TrustedOrigins) == 0
 }
 
 func setMCPJSONStringArray(server map[string]json.RawMessage, key string, values []string) {

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -542,7 +542,9 @@ func isZeroOAuthConfig(cfg *MCPOAuthConfig) bool {
 	}
 	return cfg.ClientID == "" && cfg.ClientSecret == "" && cfg.RedirectPort == 0 &&
 		!cfg.SkipBrowser && !cfg.SkipDynamicRegistration && len(cfg.Scopes) == 0 &&
-		len(cfg.TrustedOrigins) == 0
+		len(cfg.TrustedOrigins) == 0 && cfg.TokenEndpointAuthMethod == "" &&
+		cfg.PrivateKeyPath == "" && cfg.PrivateKeyPEM == "" &&
+		cfg.ClientAssertionSigningAlg == "" && cfg.JWTBearerGrant == nil
 }
 
 func setMCPJSONStringArray(server map[string]json.RawMessage, key string, values []string) {

--- a/internal/config/oauth_test.go
+++ b/internal/config/oauth_test.go
@@ -78,6 +78,84 @@ func TestClearOAuthSecretNil(t *testing.T) {
 	}
 }
 
+func TestClearOAuthSecretStripsInlinePrivateKey(t *testing.T) {
+	in := &MCPOAuthConfig{
+		ClientID:                "c",
+		TokenEndpointAuthMethod: "private_key_jwt",
+		PrivateKeyPEM:           "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+		PrivateKeyPath:          "/etc/keys/svc.pem",
+	}
+	out, changed := ClearOAuthSecret(in)
+	if !changed {
+		t.Fatal("expected changed=true when inline key present")
+	}
+	if out.PrivateKeyPEM != "" {
+		t.Fatal("inline private key PEM must be stripped")
+	}
+	// The path is a pointer, not a secret — it must survive clear-auth.
+	if out.PrivateKeyPath != "/etc/keys/svc.pem" {
+		t.Fatalf("private_key_path must be preserved: %q", out.PrivateKeyPath)
+	}
+	if out.TokenEndpointAuthMethod != "private_key_jwt" {
+		t.Fatal("auth method must be preserved")
+	}
+}
+
+func TestClearOAuthSecretStripsJWTBearerGrantKey(t *testing.T) {
+	in := &MCPOAuthConfig{
+		JWTBearerGrant: &MCPJWTBearerGrant{
+			Issuer:         "svc",
+			PrivateKeyPEM:  "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----",
+			PrivateKeyPath: "/etc/keys/grant.pem",
+		},
+	}
+	out, changed := ClearOAuthSecret(in)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if out.JWTBearerGrant.PrivateKeyPEM != "" {
+		t.Fatal("grant inline key must be stripped")
+	}
+	if out.JWTBearerGrant.PrivateKeyPath != "/etc/keys/grant.pem" {
+		t.Fatal("grant private_key_path must be preserved")
+	}
+}
+
+func TestPluginEntryOAuthJWTFieldsFromTOML(t *testing.T) {
+	src := `
+[[plugins]]
+name = "svc"
+type = "http"
+url = "https://mcp.example.com/mcp"
+[plugins.oauth]
+token_endpoint_auth_method = "private_key_jwt"
+private_key_path = "/etc/keys/svc.pem"
+client_assertion_signing_alg = "RS256"
+[plugins.oauth.jwt_bearer_grant]
+issuer = "service-account-1"
+private_key_path = "/etc/keys/grant.pem"
+signing_alg = "ES256"
+scopes = ["read"]
+`
+	cfg, err := loadConfigForTest(t, src)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	o := cfg.Plugins[0].OAuth
+	if o.TokenEndpointAuthMethod != "private_key_jwt" {
+		t.Fatalf("method = %q", o.TokenEndpointAuthMethod)
+	}
+	if o.PrivateKeyPath != "/etc/keys/svc.pem" || o.ClientAssertionSigningAlg != "RS256" {
+		t.Fatalf("jwt fields: %+v", o)
+	}
+	if o.JWTBearerGrant == nil || o.JWTBearerGrant.Issuer != "service-account-1" {
+		t.Fatalf("grant not parsed: %+v", o.JWTBearerGrant)
+	}
+	if o.JWTBearerGrant.SigningAlg != "ES256" || len(o.JWTBearerGrant.Scopes) != 1 {
+		t.Fatalf("grant fields: %+v", o.JWTBearerGrant)
+	}
+}
+
 // loadConfigForTest decodes a TOML document into a Config the same way the
 // loader does, without touching the filesystem.
 func loadConfigForTest(t *testing.T, src string) (*Config, error) {

--- a/internal/config/oauth_test.go
+++ b/internal/config/oauth_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestPluginEntryOAuthFromTOML(t *testing.T) {
+	src := `
+[[plugins]]
+name = "remote"
+type = "http"
+url = "https://mcp.example.com/mcp"
+[plugins.oauth]
+client_id = "abc-123"
+client_secret = "supersecret"
+scopes = ["read", "write"]
+redirect_port = 8765
+skip_browser = true
+skip_dynamic_registration = true
+trusted_origins = ["https://auth.example.com"]
+`
+	cfg, err := loadConfigForTest(t, src)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(cfg.Plugins) != 1 {
+		t.Fatalf("want 1 plugin, got %d", len(cfg.Plugins))
+	}
+	o := cfg.Plugins[0].OAuth
+	if o == nil {
+		t.Fatal("OAuth config not parsed")
+	}
+	if o.ClientID != "abc-123" || o.ClientSecret != "supersecret" {
+		t.Errorf("client id/secret = %q/%q", o.ClientID, o.ClientSecret)
+	}
+	if o.RedirectPort != 8765 || !o.SkipBrowser || !o.SkipDynamicRegistration {
+		t.Errorf("flags wrong: %+v", o)
+	}
+	if len(o.Scopes) != 2 || len(o.TrustedOrigins) != 1 {
+		t.Errorf("slices wrong: %+v", o)
+	}
+}
+
+func TestClearOAuthSecretStripsSecret(t *testing.T) {
+	in := &MCPOAuthConfig{ClientID: "abc", ClientSecret: "secret", Scopes: []string{"read"}}
+	out, changed := ClearOAuthSecret(in)
+	if !changed {
+		t.Fatal("expected changed=true when a secret is present")
+	}
+	if out.ClientSecret != "" {
+		t.Fatalf("secret not cleared: %q", out.ClientSecret)
+	}
+	// Non-secret fields are preserved.
+	if out.ClientID != "abc" || len(out.Scopes) != 1 {
+		t.Fatalf("non-secret fields lost: %+v", out)
+	}
+}
+
+func TestClearOAuthSecretNoopForPublicClient(t *testing.T) {
+	// A public PKCE client has no secret; clearing must be a no-op.
+	in := &MCPOAuthConfig{ClientID: "abc", Scopes: []string{"read"}}
+	out, changed := ClearOAuthSecret(in)
+	if changed {
+		t.Fatal("expected changed=false for a public client")
+	}
+	if out != in {
+		t.Fatal("expected the same pointer for a no-op clear")
+	}
+}
+
+func TestClearOAuthSecretNil(t *testing.T) {
+	out, changed := ClearOAuthSecret(nil)
+	if changed || out != nil {
+		t.Fatalf("nil clear should be a no-op: %+v changed=%v", out, changed)
+	}
+}
+
+// loadConfigForTest decodes a TOML document into a Config the same way the
+// loader does, without touching the filesystem.
+func loadConfigForTest(t *testing.T, src string) (*Config, error) {
+	t.Helper()
+	_ = strings.TrimSpace // keep strings import for readability of failures
+	var cfg Config
+	_, err := toml.Decode(src, &cfg)
+	return &cfg, err
+}

--- a/internal/mcpauth/assertion.go
+++ b/internal/mcpauth/assertion.go
@@ -1,0 +1,272 @@
+package mcpauth
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+)
+
+// RFC 7523 §2 client assertion types and grant types.
+const (
+	clientAssertionTypeJWT = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	grantTypeJWTBearer     = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+)
+
+// jwtClientAuth authenticates a client at the token endpoint by signing a JWT
+// client assertion (RFC 7523 §2). It implements private_key_jwt (asymmetric
+// key) and client_secret_jwt (HMAC with the client secret). The assertion is
+// rebuilt on every token request because exp/jti must be fresh; a signing
+// failure surfaces as the request error rather than an unauthenticated call.
+type jwtClientAuth struct {
+	clientID      string
+	tokenEndpoint string
+	signingKey    crypto.PrivateKey
+	alg           string
+	hmacSecret    []byte // non-nil when this is client_secret_jwt
+}
+
+// enrich signs a fresh client assertion and adds it to the form. The assertion
+// carries the client identity, so client_id is intentionally omitted (RFC 7523
+// §2.2: the assertion IS the authentication).
+func (a jwtClientAuth) enrich(form url.Values) error {
+	assertion, err := a.buildAssertion()
+	if err != nil {
+		return err
+	}
+	form.Set("client_assertion_type", clientAssertionTypeJWT)
+	form.Set("client_assertion", assertion)
+	return nil
+}
+
+func (a jwtClientAuth) apply(*http.Request) {}
+
+// buildAssertion signs a fresh client-assertion JWT for this token request.
+func (a jwtClientAuth) buildAssertion() (string, error) {
+	if a.signingKey == nil && len(a.hmacSecret) == 0 {
+		return "", errors.New("no signing key for JWT client assertion")
+	}
+	key := a.signingKey
+	if a.signingKey == nil {
+		key = a.hmacSecret
+	}
+	alg := a.alg
+	if alg == "" {
+		var err error
+		if alg, err = defaultAlgFor(key); err != nil {
+			return "", err
+		}
+	}
+	if !algSupportsKey(alg, key) {
+		return "", fmt.Errorf("configured signing algorithm %q does not match the key type", alg)
+	}
+	claims := assertionClaims(a.clientID, a.tokenEndpoint)
+	return signJWT(claims, key, alg)
+}
+
+// resolveTokenEndpointAuth picks the token-endpoint authentication strategy from
+// the explicit config, then the client registration, then sensible defaults
+// based on available credentials and server metadata.
+func (c *Client) resolveTokenEndpointAuth(cfg Config, reg *ClientRegistration, as *AuthorizationServerMetadata) (clientAuth, error) {
+	clientID := ""
+	if reg != nil {
+		clientID = reg.ClientID
+	}
+	secret := strings.TrimSpace(cfg.ClientSecret)
+	if secret == "" && reg != nil {
+		secret = reg.ClientSecret
+	}
+	method := strings.ToLower(strings.TrimSpace(cfg.TokenEndpointAuthMethod))
+
+	// Load the private key once for private_key_jwt (cached per client).
+	if method == "private_key_jwt" || (method == "" && cfg.hasPrivateKey()) {
+		key, alg, err := cfg.loadSigningKey(c.keyLoader)
+		if err != nil {
+			if method == "private_key_jwt" {
+				return nil, fmt.Errorf("private_key_jwt: %w", err)
+			}
+			// key unavailable for auto mode: fall through to other methods
+		} else {
+			if !asMethodSupported(as, "private_key_jwt") {
+				return nil, fmt.Errorf("client configured private_key_jwt but the authorization server does not advertise it")
+			}
+			return jwtClientAuth{clientID: clientID, tokenEndpoint: as.TokenEndpoint, signingKey: key, alg: alg}, nil
+		}
+	}
+
+	switch method {
+	case "client_secret_jwt":
+		if secret == "" {
+			return nil, errors.New("client_secret_jwt requires a client_secret")
+		}
+		if !asMethodSupported(as, "client_secret_jwt") {
+			return nil, fmt.Errorf("client configured client_secret_jwt but the authorization server does not advertise it")
+		}
+		alg := cfg.ClientAssertionSigningAlg
+		if alg == "" {
+			alg = "HS256"
+		}
+		return jwtClientAuth{clientID: clientID, tokenEndpoint: as.TokenEndpoint, hmacSecret: []byte(secret), alg: alg}, nil
+	case "client_secret_basic":
+		if secret == "" {
+			return nil, errors.New("client_secret_basic requires a client_secret")
+		}
+		return basicAuth{clientID: clientID, clientSecret: secret}, nil
+	case "client_secret_post":
+		if secret == "" {
+			return nil, errors.New("client_secret_post requires a client_secret")
+		}
+		return secretPostAuth{clientID: clientID, clientSecret: secret}, nil
+	case "none", "":
+		return noneAuth{clientID: clientID}, nil
+	default:
+		return nil, fmt.Errorf("unsupported token_endpoint_auth_method %q", method)
+	}
+}
+
+// asMethodSupported reports whether the authorization server advertises a
+// token_endpoint_auth_method (or omits the list, treated as permissive).
+func asMethodSupported(as *AuthorizationServerMetadata, method string) bool {
+	if as == nil || len(as.TokenEndpointAuthMethodsSupported) == 0 {
+		return true
+	}
+	for _, m := range as.TokenEndpointAuthMethodsSupported {
+		if strings.EqualFold(strings.TrimSpace(m), method) {
+			return true
+		}
+	}
+	return false
+}
+
+// secretPostAuth authenticates with client_secret in the form body
+// (client_secret_post).
+type secretPostAuth struct{ clientID, clientSecret string }
+
+func (a secretPostAuth) enrich(form url.Values) error {
+	form.Set("client_id", a.clientID)
+	form.Set("client_secret", a.clientSecret)
+	return nil
+}
+func (a secretPostAuth) apply(*http.Request) {}
+
+// exchangeAssertionGrant exchanges an RFC 7523 §1 JWT bearer assertion for a
+// token, with no user interaction. Used when a server is configured with a
+// JWTBearerGrant (service-to-service).
+func (c *Client) exchangeAssertionGrant(ctx context.Context, tokenEndpoint string, grant JWTBearerGrant) (*Token, error) {
+	key, alg, err := grant.loadSigningKey(c.keyLoader)
+	if err != nil {
+		return nil, fmt.Errorf("load assertion signing key: %w", err)
+	}
+	issuer := firstNonEmpty(grant.Issuer, grant.Subject)
+	subject := firstNonEmpty(grant.Subject, grant.Issuer)
+	if strings.TrimSpace(issuer) == "" {
+		return nil, errors.New("jwt bearer grant requires an issuer")
+	}
+	claims := assertionClaims(subject, tokenEndpoint)
+	claims["iss"] = issuer
+	if alg == "" {
+		if alg, err = defaultAlgFor(key); err != nil {
+			return nil, err
+		}
+	}
+	assertion, err := signJWT(claims, key, alg)
+	if err != nil {
+		return nil, fmt.Errorf("sign jwt bearer assertion: %w", err)
+	}
+	form := url.Values{
+		"grant_type": {grantTypeJWTBearer},
+		"assertion":  {assertion},
+	}
+	if len(grant.Scopes) > 0 {
+		form.Set("scope", strings.Join(grant.Scopes, " "))
+	}
+	respBody, err := c.postForm(ctx, tokenEndpoint, form, noneAuth{clientID: issuer})
+	if err != nil {
+		return nil, err
+	}
+	return parseTokenResponse(respBody)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// hasPrivateKey reports whether the config can supply a JWT signing key.
+func (cfg Config) hasPrivateKey() bool {
+	return strings.TrimSpace(cfg.PrivateKeyPEM) != "" || strings.TrimSpace(cfg.PrivateKeyPath) != ""
+}
+
+// loadSigningKey resolves the configured signing key and (optional) algorithm.
+// The PEM is loaded lazily through the client's cached loader so a key file is
+// read at most once per process.
+func (cfg Config) loadSigningKey(loader *keyLoader) (crypto.PrivateKey, string, error) {
+	pemData := strings.TrimSpace(cfg.PrivateKeyPEM)
+	if pemData == "" && strings.TrimSpace(cfg.PrivateKeyPath) != "" {
+		data, err := loader.load(strings.TrimSpace(cfg.PrivateKeyPath))
+		if err != nil {
+			return nil, "", err
+		}
+		pemData = data
+	}
+	if pemData == "" {
+		return nil, "", errors.New("no private key configured")
+	}
+	key, err := parsePrivateKey([]byte(pemData))
+	if err != nil {
+		return nil, "", err
+	}
+	return key, cfg.ClientAssertionSigningAlg, nil
+}
+
+func (g JWTBearerGrant) loadSigningKey(loader *keyLoader) (crypto.PrivateKey, string, error) {
+	pemData := strings.TrimSpace(g.PrivateKeyPEM)
+	if pemData == "" && strings.TrimSpace(g.PrivateKeyPath) != "" {
+		data, err := loader.load(strings.TrimSpace(g.PrivateKeyPath))
+		if err != nil {
+			return nil, "", err
+		}
+		pemData = data
+	}
+	if pemData == "" {
+		return nil, "", errors.New("no private key configured for jwt bearer grant")
+	}
+	key, err := parsePrivateKey([]byte(pemData))
+	if err != nil {
+		return nil, "", err
+	}
+	return key, g.SigningAlg, nil
+}
+
+// keyLoader reads key files and memoizes the result so a key file is parsed at
+// most once per process (keys are large and parsing is non-trivial).
+type keyLoader struct {
+	mu    sync.Mutex
+	cache map[string]string
+}
+
+func newKeyLoader() *keyLoader { return &keyLoader{cache: map[string]string{}} }
+
+func (l *keyLoader) load(path string) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if v, ok := l.cache[path]; ok {
+		return v, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read private key %s: %w", path, err)
+	}
+	s := string(data)
+	l.cache[path] = s
+	return s, nil
+}

--- a/internal/mcpauth/assertion_test.go
+++ b/internal/mcpauth/assertion_test.go
@@ -1,0 +1,285 @@
+package mcpauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// pemRSA returns a PEM-encoded RSA private key for a test.
+func pemRSA(t *testing.T) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}))
+}
+
+// jwtBearerAS is a fake AS that validates a client_assertion / assertion and
+// returns a token. It records what it received.
+type jwtBearerAS struct {
+	srv          *httptest.Server
+	mu           sync.Mutex
+	lastForm     url.Values
+	tokenType    string
+	accessToken  string
+	refreshToken string
+	expiresIn    int
+}
+
+func newJWTBearerAS(t *testing.T) *jwtBearerAS {
+	t.Helper()
+	f := &jwtBearerAS{accessToken: "JWT_ACCESS_1", tokenType: "Bearer", expiresIn: 3600}
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, ProtectedResourceMetadata{Resource: srv.URL, AuthorizationServers: []string{srv.URL}})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, AuthorizationServerMetadata{
+			Issuer:                            srv.URL,
+			AuthorizationEndpoint:             srv.URL + "/authorize",
+			TokenEndpoint:                     srv.URL + "/token",
+			TokenEndpointAuthMethodsSupported: []string{"private_key_jwt", "client_secret_jwt", "client_secret_basic", "none"},
+			TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256", "ES256", "HS256", "PS256"},
+			GrantTypesSupported:                        []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"},
+			CodeChallengeMethodsSupported:              []string{"S256"},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.mu.Lock()
+		f.lastForm = cloneForm(r.PostForm)
+		f.mu.Unlock()
+		writeJSON(t, w, map[string]any{
+			"access_token":  f.accessToken,
+			"refresh_token": f.refreshToken,
+			"token_type":    f.tokenType,
+			"expires_in":    f.expiresIn,
+		})
+	})
+	srv = httptest.NewServer(mux)
+	f.srv = srv
+	t.Cleanup(srv.Close)
+	return f
+}
+
+func cloneForm(f url.Values) url.Values {
+	out := make(url.Values, len(f))
+	for k, v := range f {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// decodeAssertionHeader returns the alg from a JWT's header.
+func decodeAssertionAlg(t *testing.T, assertion string) string {
+	t.Helper()
+	parts := strings.Split(assertion, ".")
+	if len(parts) < 2 {
+		t.Fatalf("malformed assertion: %s", assertion)
+	}
+	hb, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	var hdr struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(hb, &hdr); err != nil {
+		t.Fatal(err)
+	}
+	return hdr.Alg
+}
+
+func TestResolveTokenEndpointAuthPrivateKeyJWT(t *testing.T) {
+	f := newJWTBearerAS(t)
+	keyPEM := pemRSA(t)
+	c := newTestClient(t, Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+	as := &AuthorizationServerMetadata{
+		Issuer:                            f.srv.URL,
+		TokenEndpoint:                     f.srv.URL + "/token",
+		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"},
+	}
+	cfg := Config{ClientID: "c1", TokenEndpointAuthMethod: "private_key_jwt", PrivateKeyPEM: keyPEM}
+	auth, err := c.resolveTokenEndpointAuth(cfg, &ClientRegistration{ClientID: "c1"}, as)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The auth builds a client_assertion when enriching the form.
+	form := url.Values{}
+	if err := auth.enrich(form); err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if got := form.Get("client_assertion_type"); got != clientAssertionTypeJWT {
+		t.Fatalf("client_assertion_type = %q", got)
+	}
+	assertion := form.Get("client_assertion")
+	if assertion == "" {
+		t.Fatal("client_assertion missing")
+	}
+	if alg := decodeAssertionAlg(t, assertion); alg != "RS256" {
+		t.Fatalf("assertion alg = %q, want RS256", alg)
+	}
+}
+
+func TestResolveTokenEndpointAuthClientSecretJWT(t *testing.T) {
+	c := newTestClient(t, Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+	as := &AuthorizationServerMetadata{
+		TokenEndpoint:                     "https://as/token",
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_jwt"},
+	}
+	cfg := Config{ClientID: "c1", ClientSecret: "shh", TokenEndpointAuthMethod: "client_secret_jwt"}
+	auth, err := c.resolveTokenEndpointAuth(cfg, &ClientRegistration{ClientID: "c1", ClientSecret: "shh"}, as)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	form := url.Values{}
+	if err := auth.enrich(form); err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if form.Get("client_assertion") == "" {
+		t.Fatal("client_secret_jwt must produce a client_assertion")
+	}
+	if alg := decodeAssertionAlg(t, form.Get("client_assertion")); alg != "HS256" {
+		t.Fatalf("client_secret_jwt default alg = %q, want HS256", alg)
+	}
+}
+
+func TestResolveTokenEndpointAuthRejectsUnsupportedMethod(t *testing.T) {
+	c := newTestClient(t, Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+	as := &AuthorizationServerMetadata{
+		TokenEndpoint:                     "https://as/token",
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"}, // no private_key_jwt
+	}
+	_, keyPEM := genRSA(t)
+	_, err := c.resolveTokenEndpointAuth(
+		Config{ClientID: "c", TokenEndpointAuthMethod: "private_key_jwt", PrivateKeyPEM: keyPEM},
+		&ClientRegistration{ClientID: "c"}, as)
+	if err == nil {
+		t.Fatal("expected error: server does not advertise private_key_jwt")
+	}
+}
+
+func TestResolveTokenEndpointAuthDefaults(t *testing.T) {
+	c := newTestClient(t, Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+	as := &AuthorizationServerMetadata{TokenEndpoint: "https://as/token"}
+	// No config → public client (noneAuth).
+	auth, err := c.resolveTokenEndpointAuth(Config{}, &ClientRegistration{ClientID: "pub"}, as)
+	if err != nil {
+		t.Fatal(err)
+	}
+	form := url.Values{}
+	_ = auth.enrich(form)
+	if form.Get("client_id") != "pub" {
+		t.Fatalf("default auth should set client_id, got %q", form.Get("client_id"))
+	}
+}
+
+func TestExchangeAssertionGrant(t *testing.T) {
+	f := newJWTBearerAS(t)
+	_, keyPEM := genRSA(t)
+	c := newTestClient(t, Options{StorePath: filepath.Join(t.TempDir(), "creds.json")})
+
+	grant := JWTBearerGrant{
+		Issuer:        "service-account-1",
+		PrivateKeyPEM: keyPEM,
+		SigningAlg:    "RS256",
+		Scopes:        []string{"read"},
+	}
+	// The grant needs the token endpoint, which comes from discovery. Use the
+	// resolver's exchangeAssertionGrant directly with the known endpoint.
+	tok, err := c.exchangeAssertionGrant(context.Background(), f.srv.URL+"/token", grant)
+	if err != nil {
+		t.Fatalf("exchangeAssertionGrant: %v", err)
+	}
+	if tok.AccessToken != "JWT_ACCESS_1" {
+		t.Fatalf("access_token = %q", tok.AccessToken)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lastForm.Get("grant_type") != grantTypeJWTBearer {
+		t.Fatalf("grant_type = %q, want %s", f.lastForm.Get("grant_type"), grantTypeJWTBearer)
+	}
+	assertion := f.lastForm.Get("assertion")
+	if assertion == "" {
+		t.Fatal("assertion not sent")
+	}
+	if alg := decodeAssertionAlg(t, assertion); alg != "RS256" {
+		t.Fatalf("assertion alg = %q, want RS256", alg)
+	}
+}
+
+func TestAuthorizeJWTBearerGrantNonInteractive(t *testing.T) {
+	f := newJWTBearerAS(t)
+	_, keyPEM := genRSA(t)
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		// No OpenURL: if the flow opened a browser, the test would hang until
+		// timeout. The grant path must never call OpenURL.
+		OpenURL: func(string) error { t.Fatal("JWT bearer grant must not open a browser"); return nil },
+	})
+	c.SetConfig("svc", Config{
+		JWTBearerGrant: &JWTBearerGrant{
+			Issuer:        "svc-acct",
+			PrivateKeyPEM: keyPEM,
+			SigningAlg:    "RS256",
+		},
+	})
+	token, err := c.Authorize(context.Background(), "svc", f.srv.URL)
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if token != "Bearer JWT_ACCESS_1" {
+		t.Fatalf("token = %q", token)
+	}
+}
+
+func TestPrivateKeyPathIsReadOnce(t *testing.T) {
+	_, keyPEM := genRSA(t)
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "key.pem")
+	if err := writeFile(keyFile, []byte(keyPEM)); err != nil {
+		t.Fatal(err)
+	}
+	c := newTestClient(t, Options{StorePath: filepath.Join(dir, "creds.json")})
+	as := &AuthorizationServerMetadata{TokenEndpoint: "https://as/token", TokenEndpointAuthMethodsSupported: []string{"private_key_jwt"}}
+	cfg := Config{ClientID: "c", TokenEndpointAuthMethod: "private_key_jwt", PrivateKeyPath: keyFile}
+	for i := 0; i < 3; i++ {
+		auth, err := c.resolveTokenEndpointAuth(cfg, &ClientRegistration{ClientID: "c"}, as)
+		if err != nil {
+			t.Fatalf("resolve %d: %v", i, err)
+		}
+		form := url.Values{}
+		if err := auth.enrich(form); err != nil {
+			t.Fatalf("enrich %d: %v", i, err)
+		}
+		if form.Get("client_assertion") == "" {
+			t.Fatalf("iteration %d produced no assertion", i)
+		}
+	}
+}
+
+func genRSA(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k, string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}))
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/mcpauth/client.go
+++ b/internal/mcpauth/client.go
@@ -45,10 +45,11 @@ type Options struct {
 // from the Config registered with SetConfig; servers with no config use the
 // auto-discovery defaults.
 type Client struct {
-	store   *Store
-	http    *http.Client
-	out     io.Writer
-	openURL func(string) error
+	store     *Store
+	http      *http.Client
+	out       io.Writer
+	openURL   func(string) error
+	keyLoader *keyLoader // memoizes private-key file reads for JWT assertions
 
 	mu      sync.RWMutex
 	configs map[string]Config // keyed by server name
@@ -70,11 +71,12 @@ func New(opts Options) (*Client, error) {
 		open = openBrowser
 	}
 	return &Client{
-		store:   NewStore(path),
-		http:    httpClient,
-		out:     opts.Out,
-		openURL: open,
-		configs: map[string]Config{},
+		store:     NewStore(path),
+		http:      httpClient,
+		out:       opts.Out,
+		openURL:   open,
+		keyLoader: newKeyLoader(),
+		configs:   map[string]Config{},
 	}, nil
 }
 
@@ -161,6 +163,22 @@ func (c *Client) Authorize(ctx context.Context, serverName, serverURL string) (s
 	if err != nil {
 		return "", fmt.Errorf("discover OAuth metadata for %q: %w", serverName, err)
 	}
+
+	// JWT bearer assertion grant (RFC 7523 §1): non-interactive service auth,
+	// no browser. The grant is replayable (a fresh assertion per request) so
+	// there is no refresh token to cache; we exchange and return directly.
+	if cfg.JWTBearerGrant != nil {
+		tok, err := c.exchangeAssertionGrant(flowCtx, server.AuthServer.TokenEndpoint, *cfg.JWTBearerGrant)
+		if err != nil {
+			return "", fmt.Errorf("jwt bearer grant for %q: %w", serverName, err)
+		}
+		cred := &StoredCredential{Token: *tok, Server: server}
+		if err := c.store.Put(origin, cred); err != nil {
+			return "", fmt.Errorf("persist OAuth token for %q: %w", serverName, err)
+		}
+		return tok.headerValue(), nil
+	}
+
 	cred, err := c.runAuthorizationFlow(flowCtx, serverName, serverURL, cfg, server)
 	if err != nil {
 		return "", err

--- a/internal/mcpauth/client.go
+++ b/internal/mcpauth/client.go
@@ -1,0 +1,243 @@
+package mcpauth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultPublicClientID is used when no client id is configured and the
+// authorization server does not advertise dynamic client registration. It
+// matches the identifier Reasonix registers with servers that accept arbitrary
+// public clients.
+const defaultPublicClientID = "io.reasonix.mcp"
+
+// refreshTimeout caps a non-interactive token refresh so a stalled token
+// endpoint cannot block a request indefinitely.
+const refreshTimeout = 30 * time.Second
+
+// flowTimeout caps the interactive authorization flow (metadata discovery +
+// registration + waiting for the redirect). It must exceed callbackWait.
+const flowTimeout = callbackWait + 2*time.Minute
+
+// Options configures a shared Client.
+type Options struct {
+	// StorePath is the credentials file. Empty uses DefaultStorePath().
+	StorePath string
+	// HTTPClient overrides the default outbound client (tests).
+	HTTPClient *http.Client
+	// Out receives user-facing status lines (e.g. "opening your browser").
+	// nil discards them.
+	Out io.Writer
+	// OpenURL opens a URL in the user's browser. nil uses the platform default.
+	OpenURL func(string) error
+}
+
+// Client is the MCP OAuth 2.0 client. It is safe for concurrent use and shared
+// across all remote MCP servers in a process. Per-server OAuth behavior comes
+// from the Config registered with SetConfig; servers with no config use the
+// auto-discovery defaults.
+type Client struct {
+	store   *Store
+	http    *http.Client
+	out     io.Writer
+	openURL func(string) error
+
+	mu      sync.RWMutex
+	configs map[string]Config // keyed by server name
+}
+
+// New constructs a Client. It does not create the credentials file; that happens
+// lazily on the first successful authorization.
+func New(opts Options) (*Client, error) {
+	path := strings.TrimSpace(opts.StorePath)
+	if path == "" {
+		path = DefaultStorePath()
+	}
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	open := opts.OpenURL
+	if open == nil {
+		open = openBrowser
+	}
+	return &Client{
+		store:   NewStore(path),
+		http:    httpClient,
+		out:     opts.Out,
+		openURL: open,
+		configs: map[string]Config{},
+	}, nil
+}
+
+// SetConfig registers the optional OAuth configuration for a server name. It is
+// safe to call after New; later calls for the same name replace the config.
+func (c *Client) SetConfig(serverName string, cfg Config) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configs[serverName] = cfg
+}
+
+// configFor returns the registered Config for serverName (zero value when none).
+func (c *Client) configFor(serverName string) Config {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.configs[serverName]
+}
+
+// CurrentToken returns a valid bearer-token Authorization-header value for
+// serverURL if one is cached (refreshing non-interactively when possible), or
+// "" when no token can be obtained without user interaction. It never blocks on
+// the interactive flow.
+func (c *Client) CurrentToken(serverURL string) string {
+	origin := serverOrigin(serverURL)
+	if origin == "" {
+		return ""
+	}
+	cred, ok := c.store.Get(origin)
+	if !ok || cred == nil {
+		return ""
+	}
+	if !cred.Token.Expired() {
+		return cred.Token.headerValue()
+	}
+	// Try a non-interactive refresh before giving up.
+	ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
+	defer cancel()
+	cfg := c.configFor("") // refresh is server-agnostic; config is looked up by name at Authorize
+	tok, err := c.refresh(ctx, cred, cfg)
+	if err != nil || tok == nil {
+		return ""
+	}
+	updated := *cred
+	updated.Token = *tok
+	_ = c.store.Put(origin, &updated)
+	return tok.headerValue()
+}
+
+// Authorize returns a bearer-token header value for serverURL, running the
+// interactive authorization flow when no usable token is cached. The returned
+// string is safe to send as an "Authorization" header value (e.g. "Bearer x").
+func (c *Client) Authorize(ctx context.Context, serverName, serverURL string) (string, error) {
+	origin := serverOrigin(serverURL)
+	if origin == "" {
+		return "", fmt.Errorf("server %q has no http(s) origin", serverName)
+	}
+	cfg := c.configFor(serverName)
+
+	// Reuse a still-valid cached token.
+	if cred, ok := c.store.Get(origin); ok && cred != nil && !cred.Token.Expired() {
+		return cred.Token.headerValue(), nil
+	}
+	// Try a non-interactive refresh of a cached credential first.
+	if cred, ok := c.store.Get(origin); ok && cred != nil && cred.Token.RefreshToken != "" {
+		rctx, cancel := context.WithTimeout(ctx, refreshTimeout)
+		tok, err := c.refresh(rctx, cred, cfg)
+		cancel()
+		if err == nil && tok != nil {
+			updated := *cred
+			updated.Token = *tok
+			if err := c.store.Put(origin, &updated); err == nil {
+				return tok.headerValue(), nil
+			}
+		}
+		// Refresh failed: fall through to a fresh interactive flow.
+	}
+
+	// Run the interactive flow with its own bounded timeout so a missing browser
+	// callback cannot wedge the request that triggered the 401.
+	flowCtx, cancel := context.WithTimeout(ctx, flowTimeout)
+	defer cancel()
+
+	server, err := c.discover(flowCtx, origin, "", cfg)
+	if err != nil {
+		return "", fmt.Errorf("discover OAuth metadata for %q: %w", serverName, err)
+	}
+	cred, err := c.runAuthorizationFlow(flowCtx, serverName, serverURL, cfg, server)
+	if err != nil {
+		return "", err
+	}
+	if err := c.store.Put(origin, cred); err != nil {
+		return "", fmt.Errorf("persist OAuth token for %q: %w", serverName, err)
+	}
+	c.notice("MCP %q authenticated successfully.", serverName)
+	return cred.Token.headerValue(), nil
+}
+
+// discover resolves the protected-resource and authorization-server metadata for
+// a server origin, reusing a cached ServerMetadata when available.
+func (c *Client) discover(ctx context.Context, origin, wwwAuthenticate string, cfg Config) (*ServerMetadata, error) {
+	trusted := cfg.TrustedOrigins
+	prm, err := c.fetchProtectedResourceMetadata(ctx, origin, wwwAuthenticate, trusted)
+	if err != nil {
+		return nil, err
+	}
+	// Prefer the first advertised authorization server. (RFC 9728 allows
+	// multiple; Reasonix uses the first.)
+	asURL := origin
+	if len(prm.AuthorizationServers) > 0 {
+		asURL = prm.AuthorizationServers[0]
+	}
+	as, err := c.fetchAuthorizationServerMetadata(ctx, origin, asURL, trusted)
+	if err != nil {
+		return nil, err
+	}
+	return &ServerMetadata{
+		ResourceURL:       origin,
+		ProtectedResource: prm,
+		AuthServer:        as,
+	}, nil
+}
+
+// notice writes a user-facing status line unless output is disabled.
+func (c *Client) notice(format string, args ...any) {
+	if c.out == nil {
+		return
+	}
+	fmt.Fprintf(c.out, format+"\n", args...)
+}
+
+// openBrowser opens urlStr in the user's default browser using the platform
+// command. It is a best-effort helper; failures fall back to printing the URL.
+func openBrowser(urlStr string) error {
+	cmd, err := browserCommand(urlStr)
+	if err != nil {
+		return err
+	}
+	return cmd.Start()
+}
+
+func browserCommand(urlStr string) (*exec.Cmd, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", urlStr), nil
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", urlStr), nil
+	default:
+		return exec.Command("xdg-open", urlStr), nil
+	}
+}
+
+// DefaultStorePath returns the credentials file path under the user's reasonix
+// config directory. It mirrors the layout used by other per-user state.
+func DefaultStorePath() string {
+	dir := os.Getenv("REASONIX_HOME")
+	if dir == "" {
+		if c, err := os.UserConfigDir(); err == nil && c != "" {
+			dir = c
+		} else if h, err := os.UserHomeDir(); err == nil && h != "" {
+			dir = h
+		} else {
+			dir = "."
+		}
+	}
+	return strings.TrimRight(dir, string(os.PathSeparator)) + string(os.PathSeparator) + "mcp-oauth-credentials.json"
+}

--- a/internal/mcpauth/client_test.go
+++ b/internal/mcpauth/client_test.go
@@ -1,0 +1,245 @@
+package mcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeOAuthServer stands up a complete simulated MCP authorization server with
+// protected-resource discovery, AS metadata, dynamic registration, and a token
+// endpoint. It records the calls it receives.
+type fakeOAuthServer struct {
+	srv *httptest.Server
+
+	mu            sync.Mutex
+	tokenHits     int
+	registerHits  int
+	lastCode      string
+	lastGrantType string
+	lastVerifier  string
+	lastRedirect  string
+	// tokenResponse overrides the default token response body.
+	tokenResponse map[string]any
+}
+
+func newFakeOAuthServer(t *testing.T) *fakeOAuthServer {
+	t.Helper()
+	f := &fakeOAuthServer{tokenResponse: map[string]any{
+		"access_token":  "ACCESS_123",
+		"refresh_token": "REFRESH_456",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+	}}
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, ProtectedResourceMetadata{Resource: srv.URL, AuthorizationServers: []string{srv.URL}})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, AuthorizationServerMetadata{
+			Issuer:                        srv.URL,
+			AuthorizationEndpoint:         srv.URL + "/authorize",
+			TokenEndpoint:                 srv.URL + "/token",
+			RegistrationEndpoint:          srv.URL + "/register",
+			CodeChallengeMethodsSupported: []string{"S256"},
+			GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.registerHits++
+		f.mu.Unlock()
+		writeJSON(t, w, map[string]any{"client_id": "dyn-client-1"})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.mu.Lock()
+		f.tokenHits++
+		f.lastGrantType = r.FormValue("grant_type")
+		f.lastCode = r.FormValue("code")
+		f.lastVerifier = r.FormValue("code_verifier")
+		f.lastRedirect = r.FormValue("redirect_uri")
+		f.mu.Unlock()
+		writeJSON(t, w, f.tokenResponse)
+	})
+
+	srv = httptest.NewServer(mux)
+	f.srv = srv
+	t.Cleanup(srv.Close)
+	return f
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// completingOpenURL returns an OpenURL func that simulates the browser by
+// calling the redirect_uri with the parsed code and state. It posts back the
+// given authorization code.
+func completingOpenURL(t *testing.T, code string) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		redirect := q.Get("redirect_uri")
+		state := q.Get("state")
+		if redirect == "" || state == "" {
+			t.Fatalf("auth URL missing redirect_uri/state: %s", authURL)
+		}
+		cb := redirect + "?code=" + url.QueryEscape(code) + "&state=" + url.QueryEscape(state)
+		resp, err := http.Get(cb)
+		if err != nil {
+			return err
+		}
+		_ = resp.Body.Close()
+		return nil
+	}
+}
+
+func TestAuthorizeFullFlow(t *testing.T) {
+	f := newFakeOAuthServer(t)
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		OpenURL:   completingOpenURL(t, "AUTH_CODE_1"),
+	})
+
+	token, err := c.Authorize(context.Background(), "demo", f.srv.URL)
+	if err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+	if token != "Bearer ACCESS_123" {
+		t.Fatalf("token = %q, want %q", token, "Bearer ACCESS_123")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.registerHits != 1 {
+		t.Fatalf("expected 1 DCR call, got %d", f.registerHits)
+	}
+	if f.lastGrantType != "authorization_code" {
+		t.Fatalf("token grant_type = %q, want authorization_code", f.lastGrantType)
+	}
+	if f.lastCode != "AUTH_CODE_1" {
+		t.Fatalf("token code = %q, want AUTH_CODE_1", f.lastCode)
+	}
+	if strings.TrimSpace(f.lastVerifier) == "" {
+		t.Fatal("token exchange must send a code_verifier (PKCE)")
+	}
+}
+
+func TestAuthorizeReusesCachedToken(t *testing.T) {
+	f := newFakeOAuthServer(t)
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		OpenURL:   completingOpenURL(t, "CODE"),
+	})
+
+	if _, err := c.Authorize(context.Background(), "demo", f.srv.URL); err != nil {
+		t.Fatalf("first Authorize: %v", err)
+	}
+	f.mu.Lock()
+	first := f.tokenHits
+	f.mu.Unlock()
+
+	// A second Authorize immediately after must not hit the network again.
+	token, err := c.Authorize(context.Background(), "demo", f.srv.URL)
+	if err != nil {
+		t.Fatalf("second Authorize: %v", err)
+	}
+	if token != "Bearer ACCESS_123" {
+		t.Fatalf("token = %q", token)
+	}
+	f.mu.Lock()
+	if f.tokenHits != first {
+		t.Fatalf("cached token should not re-hit token endpoint: %d -> %d", first, f.tokenHits)
+	}
+	f.mu.Unlock()
+}
+
+func TestCurrentTokenReturnsCachedWithoutFlow(t *testing.T) {
+	f := newFakeOAuthServer(t)
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		OpenURL:   completingOpenURL(t, "CODE"),
+	})
+	if _, err := c.Authorize(context.Background(), "demo", f.srv.URL); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+
+	got := c.CurrentToken(f.srv.URL)
+	if got != "Bearer ACCESS_123" {
+		t.Fatalf("CurrentToken = %q, want Bearer ACCESS_123", got)
+	}
+}
+
+func TestCurrentTokenRefreshesExpiredToken(t *testing.T) {
+	f := newFakeOAuthServer(t)
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		OpenURL:   completingOpenURL(t, "CODE"),
+	})
+	// Seed an expired token with a refresh token and the discovered metadata.
+	origin := serverOrigin(f.srv.URL)
+	as := &AuthorizationServerMetadata{Issuer: f.srv.URL, TokenEndpoint: f.srv.URL + "/token"}
+	if err := c.store.Put(origin, &StoredCredential{
+		Token:  Token{AccessToken: "OLD", RefreshToken: "REFRESH_456", TokenType: "Bearer", Expiry: time.Now().Add(-time.Hour)},
+		Server: &ServerMetadata{ResourceURL: origin, AuthServer: as},
+	}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	// CurrentToken must refresh non-interactively.
+	got := c.CurrentToken(f.srv.URL)
+	if got != "Bearer ACCESS_123" {
+		t.Fatalf("CurrentToken = %q, want refreshed Bearer ACCESS_123", got)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lastGrantType != "refresh_token" {
+		t.Fatalf("expected refresh_token grant, got %q", f.lastGrantType)
+	}
+}
+
+func TestAuthorizeRejectsStateMismatch(t *testing.T) {
+	f := newFakeOAuthServer(t)
+	// Simulate a tampered redirect: the state echoed back does not match.
+	c := newTestClient(t, Options{
+		StorePath: filepath.Join(t.TempDir(), "creds.json"),
+		OpenURL: func(authURL string) error {
+			u, _ := url.Parse(authURL)
+			redirect := u.Query().Get("redirect_uri")
+			// wrong state
+			cb := redirect + "?code=X&state=ATTACKER_STATE"
+			resp, err := http.Get(cb)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			return nil
+		},
+	})
+	if _, err := c.Authorize(context.Background(), "demo", f.srv.URL); err == nil {
+		t.Fatal("expected error for state mismatch")
+	}
+}
+
+func TestAuthorizeRequiresHttpOrigin(t *testing.T) {
+	c := newTestClient(t, Options{})
+	if _, err := c.Authorize(context.Background(), "demo", "not-a-url"); err == nil {
+		t.Fatal("expected error for non-http origin")
+	}
+}

--- a/internal/mcpauth/dcr.go
+++ b/internal/mcpauth/dcr.go
@@ -63,7 +63,9 @@ func (c *Client) registerClient(ctx context.Context, registrationEndpoint, redir
 // clients, HTTP Basic for confidential ones).
 func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values, auth clientAuth) ([]byte, error) {
 	if auth != nil {
-		auth.enrich(form)
+		if err := auth.enrich(form); err != nil {
+			return nil, err
+		}
 	}
 	body := form.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte(body)))
@@ -89,8 +91,10 @@ func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values,
 
 // clientAuth abstracts how the token endpoint authenticates the client.
 type clientAuth interface {
-	// enrich adds client credentials to the form body (public clients).
-	enrich(form url.Values)
+	// enrich adds client credentials to the form body before it is encoded.
+	// Returning an error (e.g. a JWT signing failure) fails the request loudly
+	// rather than sending an unauthenticated token call.
+	enrich(form url.Values) error
 	// apply sets request authentication (confidential clients use HTTP Basic).
 	apply(req *http.Request)
 }
@@ -98,15 +102,15 @@ type clientAuth interface {
 // noneAuth authenticates a public client by putting client_id in the body.
 type noneAuth struct{ clientID string }
 
-func (a noneAuth) enrich(form url.Values) { form.Set("client_id", a.clientID) }
-func (a noneAuth) apply(*http.Request)    {}
+func (a noneAuth) enrich(form url.Values) error { form.Set("client_id", a.clientID); return nil }
+func (a noneAuth) apply(*http.Request)          {}
 
 // basicAuth authenticates a confidential client with HTTP Basic (RFC 6749
 // §2.3.1). We still send client_id in the body as a fallback for servers that
 // reject Basic on public-style flows.
 type basicAuth struct{ clientID, clientSecret string }
 
-func (a basicAuth) enrich(form url.Values) { form.Set("client_id", a.clientID) }
+func (a basicAuth) enrich(form url.Values) error { form.Set("client_id", a.clientID); return nil }
 func (a basicAuth) apply(req *http.Request) {
 	req.SetBasicAuth(url.QueryEscape(a.clientID), url.QueryEscape(a.clientSecret))
 }

--- a/internal/mcpauth/dcr.go
+++ b/internal/mcpauth/dcr.go
@@ -1,0 +1,122 @@
+package mcpauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const clientName = "Reasonix MCP"
+
+// maxTokenBody caps how much of a token-endpoint response we read.
+const maxTokenBody = 1 << 20 // 1 MiB
+
+// registerClient performs RFC 7591 dynamic client registration against an
+// authorization server, returning a public (PKCE) client registration. The
+// redirectURI is the loopback callback URL the authorization flow will use.
+func (c *Client) registerClient(ctx context.Context, registrationEndpoint, redirectURI string) (*ClientRegistration, error) {
+	if registrationEndpoint == "" {
+		return nil, fmt.Errorf("no registration endpoint")
+	}
+	form := url.Values{
+		"client_name":                {clientName},
+		"redirect_uris":              {redirectURI},
+		"grant_types":                {"authorization_code"},
+		"response_types":             {"code"},
+		"token_endpoint_auth_method": {"none"}, // public client; PKCE only
+	}
+	respBody, err := c.postForm(ctx, registrationEndpoint, form, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic client registration: %w", err)
+	}
+
+	// RFC 7591 §3.2: the response is a JSON client metadata document.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("decode registration response: %w", err)
+	}
+	reg := &ClientRegistration{}
+	if v, ok := raw["client_id"]; ok {
+		_ = json.Unmarshal(v, &reg.ClientID)
+	}
+	if strings.TrimSpace(reg.ClientID) == "" {
+		return nil, fmt.Errorf("registration response missing client_id")
+	}
+	if v, ok := raw["client_secret"]; ok {
+		_ = json.Unmarshal(v, &reg.ClientSecret)
+	}
+	reg.ClientIDIssuedAt = time.Now()
+	// We intentionally do not enforce client_secret_expires_at: a zero value
+	// means "never expires" per RFC 7591 §3.2.1, and an expired secret simply
+	// triggers re-registration on the next flow.
+	return reg, nil
+}
+
+// postForm posts an urlencoded form and returns the raw JSON-decoded response
+// object. auth decides how the client authenticates (body credentials for public
+// clients, HTTP Basic for confidential ones).
+func (c *Client) postForm(ctx context.Context, endpoint string, form url.Values, auth clientAuth) ([]byte, error) {
+	if auth != nil {
+		auth.enrich(form)
+	}
+	body := form.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if auth != nil {
+		auth.apply(req)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxTokenBody))
+	if resp.StatusCode/100 != 2 {
+		return respBody, &tokenEndpointError{Status: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
+	}
+	return respBody, nil
+}
+
+// clientAuth abstracts how the token endpoint authenticates the client.
+type clientAuth interface {
+	// enrich adds client credentials to the form body (public clients).
+	enrich(form url.Values)
+	// apply sets request authentication (confidential clients use HTTP Basic).
+	apply(req *http.Request)
+}
+
+// noneAuth authenticates a public client by putting client_id in the body.
+type noneAuth struct{ clientID string }
+
+func (a noneAuth) enrich(form url.Values) { form.Set("client_id", a.clientID) }
+func (a noneAuth) apply(*http.Request)    {}
+
+// basicAuth authenticates a confidential client with HTTP Basic (RFC 6749
+// §2.3.1). We still send client_id in the body as a fallback for servers that
+// reject Basic on public-style flows.
+type basicAuth struct{ clientID, clientSecret string }
+
+func (a basicAuth) enrich(form url.Values) { form.Set("client_id", a.clientID) }
+func (a basicAuth) apply(req *http.Request) {
+	req.SetBasicAuth(url.QueryEscape(a.clientID), url.QueryEscape(a.clientSecret))
+}
+
+// tokenEndpointError carries a non-2xx token-endpoint response.
+type tokenEndpointError struct {
+	Status int
+	Body   string
+}
+
+func (e *tokenEndpointError) Error() string {
+	return fmt.Sprintf("token endpoint http %d: %s", e.Status, e.Body)
+}

--- a/internal/mcpauth/discovery.go
+++ b/internal/mcpauth/discovery.go
@@ -1,0 +1,172 @@
+package mcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// maxMetadataBody caps how much of a metadata document we read.
+const maxMetadataBody = 1 << 20 // 1 MiB
+
+// httpOrigin returns the scheme://host[:port] of an absolute http(s) URL. The
+// port is omitted when it is the scheme default. Non-http(s) or relative URLs
+// return ("", false).
+func httpOrigin(raw string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u == nil {
+		return "", false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", false
+	}
+	port := u.Port()
+	if port != "" && !((scheme == "http" && port == "80") || (scheme == "https" && port == "443")) {
+		return scheme + "://" + host + ":" + port, true
+	}
+	return scheme + "://" + host, true
+}
+
+// serverOrigin is the canonical store key for serverURL: its http(s) origin.
+func serverOrigin(serverURL string) string {
+	origin, _ := httpOrigin(serverURL)
+	return origin
+}
+
+// protectedResourceMetadataURL returns the RFC 9728 well-known URL for the MCP
+// server origin, or "" when serverURL is not an absolute http(s) URL.
+func protectedResourceMetadataURL(serverURL string) string {
+	origin, ok := httpOrigin(serverURL)
+	if !ok {
+		return ""
+	}
+	return origin + "/.well-known/oauth-protected-resource"
+}
+
+// authorizationServerMetadataURL returns the RFC 8414 metadata URL for an
+// authorization-server origin/issuer. If asURL already points at a well-known
+// document it is used as-is; otherwise the well-known suffix is appended.
+func authorizationServerMetadataURL(asURL string) string {
+	asURL = strings.TrimRight(strings.TrimSpace(asURL), "/")
+	if asURL == "" {
+		return ""
+	}
+	if strings.Contains(asURL, "/.well-known/oauth-authorization-server") {
+		return asURL
+	}
+	return asURL + "/.well-known/oauth-authorization-server"
+}
+
+// fetchProtectedResourceMetadata fetches and validates the RFC 9728 metadata for
+// serverURL. headerURL (from a 401 WWW-Authenticate) is preferred when present
+// and trusted; otherwise the origin's well-known path is used.
+func (c *Client) fetchProtectedResourceMetadata(ctx context.Context, serverURL, headerURL string, trusted []string) (*ProtectedResourceMetadata, error) {
+	origin, ok := httpOrigin(serverURL)
+	if !ok {
+		return nil, fmt.Errorf("server URL %q is not an absolute http(s) URL", serverURL)
+	}
+	allowed := append([]string{origin}, trusted...)
+
+	candidates := protectedResourceMetadataURL(serverURL)
+	if headerURL = strings.TrimSpace(headerURL); headerURL != "" && originAllowed(headerURL, allowed) {
+		candidates = headerURL
+	}
+
+	var meta ProtectedResourceMetadata
+	if err := c.getJSON(ctx, candidates, &meta); err != nil {
+		return nil, fmt.Errorf("fetch protected-resource metadata: %w", err)
+	}
+	// RFC 9728 §2.1: the resource field must match the request origin unless the
+	// operator trusts another origin. This stops a server from advertising
+	// another resource's metadata.
+	if meta.Resource != "" && !originEqual(meta.Resource, origin) && !originAllowed(meta.Resource, allowed) {
+		return nil, fmt.Errorf("protected-resource metadata resource %q does not match server origin %q", meta.Resource, origin)
+	}
+	if len(meta.AuthorizationServers) == 0 {
+		return nil, fmt.Errorf("protected-resource metadata lists no authorization servers")
+	}
+	return &meta, nil
+}
+
+// fetchAuthorizationServerMetadata fetches and validates the RFC 8414 metadata
+// for authorizationServer (an origin or issuer URL).
+func (c *Client) fetchAuthorizationServerMetadata(ctx context.Context, serverOriginValue, authorizationServer string, trusted []string) (*AuthorizationServerMetadata, error) {
+	metaURL := authorizationServerMetadataURL(authorizationServer)
+	if metaURL == "" {
+		return nil, fmt.Errorf("empty authorization server URL")
+	}
+	allowed := append([]string{serverOriginValue, authorizationServer}, trusted...)
+
+	var meta AuthorizationServerMetadata
+	if err := c.getJSON(ctx, metaURL, &meta); err != nil {
+		return nil, fmt.Errorf("fetch authorization-server metadata: %w", err)
+	}
+	if meta.Issuer == "" || meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
+		return nil, fmt.Errorf("authorization-server metadata at %s is missing required fields (issuer/authorization_endpoint/token_endpoint)", metaURL)
+	}
+	// RFC 8414 §3: the issuer in the metadata must match the URL it was
+	// retrieved from unless the operator trusts the issuer origin.
+	expectedIssuer := strings.TrimSuffix(metaURL, "/.well-known/oauth-authorization-server")
+	if !originEqual(meta.Issuer, expectedIssuer) && !originEqual(meta.Issuer, authorizationServer) && !originAllowed(meta.Issuer, allowed) {
+		return nil, fmt.Errorf("authorization-server issuer %q does not match metadata URL %q", meta.Issuer, metaURL)
+	}
+	if meta.RequirePushedAuthorizationRequests {
+		return nil, fmt.Errorf("authorization server requires PAR (RFC 9126), which is not yet supported")
+	}
+	if !meta.supportsAuthorizationCode() {
+		return nil, fmt.Errorf("authorization server does not support the authorization_code grant")
+	}
+	return &meta, nil
+}
+
+// getJSON fetches url and decodes into out.
+func (c *Client) getJSON(ctx context.Context, urlStr string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return json.NewDecoder(io.LimitReader(resp.Body, maxMetadataBody)).Decode(out)
+}
+
+// originEqual reports whether two URLs share the same http(s) origin.
+func originEqual(a, b string) bool {
+	oa, oka := httpOrigin(a)
+	ob, okb := httpOrigin(b)
+	if !oka || !okb {
+		return false
+	}
+	return strings.EqualFold(oa, ob)
+}
+
+// originAllowed reports whether raw's origin is in the allow list.
+func originAllowed(raw string, allowed []string) bool {
+	origin, ok := httpOrigin(raw)
+	if !ok {
+		return false
+	}
+	for _, a := range allowed {
+		if ao, ok := httpOrigin(a); ok && strings.EqualFold(ao, origin) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcpauth/discovery_test.go
+++ b/internal/mcpauth/discovery_test.go
@@ -1,0 +1,131 @@
+package mcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpOrigin(t *testing.T) {
+	cases := map[string]string{
+		"https://mcp.example.com/path": "https://mcp.example.com",
+		"http://localhost:8080/mcp":    "http://localhost:8080",
+		"https://host:443/x":           "https://host",
+		"http://host:80/x":             "http://host",
+		"ftp://host/x":                 "",
+		"/relative":                    "",
+		"https://host:9000/":           "https://host:9000",
+	}
+	for in, want := range cases {
+		got, ok := httpOrigin(in)
+		if want == "" {
+			if ok {
+				t.Errorf("httpOrigin(%q) = %q, want none", in, got)
+			}
+			continue
+		}
+		if got != want {
+			t.Errorf("httpOrigin(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestProtectedResourceMetadataURL(t *testing.T) {
+	got := protectedResourceMetadataURL("https://mcp.example.com/some/path")
+	want := "https://mcp.example.com/.well-known/oauth-protected-resource"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if protectedResourceMetadataURL("not a url") != "" {
+		t.Fatal("non-http(s) should yield empty")
+	}
+}
+
+func TestAuthorizationServerMetadataURL(t *testing.T) {
+	cases := map[string]string{
+		"https://auth.example.com":                                        "https://auth.example.com/.well-known/oauth-authorization-server",
+		"https://auth.example.com/":                                       "https://auth.example.com/.well-known/oauth-authorization-server",
+		"https://auth.example.com/.well-known/oauth-authorization-server": "https://auth.example.com/.well-known/oauth-authorization-server",
+		"": "",
+	}
+	for in, want := range cases {
+		if got := authorizationServerMetadataURL(in); got != want {
+			t.Errorf("authorizationServerMetadataURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func newTestClient(t *testing.T, opts Options) *Client {
+	t.Helper()
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: 0}
+	}
+	c, err := New(opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// jsonHandler serves a JSON body and records that it was hit.
+func jsonHandler(t *testing.T, body any) http.HandlerFunc {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(b)
+	}
+}
+
+func TestFetchProtectedResourceMetadata(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, ProtectedResourceMetadata{
+			Resource:             srv.URL,
+			AuthorizationServers: []string{"https://auth.example.com"},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, Options{})
+	meta, err := c.fetchProtectedResourceMetadata(context.Background(), srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(meta.AuthorizationServers) != 1 {
+		t.Fatalf("want 1 auth server, got %v", meta.AuthorizationServers)
+	}
+}
+
+func TestFetchProtectedResourceMetadataRejectsForeignResource(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(t, ProtectedResourceMetadata{
+		Resource:             "https://evil.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, Options{})
+	_, err := c.fetchProtectedResourceMetadata(context.Background(), srv.URL, "", nil)
+	if err == nil {
+		t.Fatal("expected error for resource mismatch")
+	}
+}
+
+func TestFetchAuthServerMetadataRejectsMissingFields(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(t, AuthorizationServerMetadata{
+		Issuer: "https://auth.example.com",
+		// missing endpoints
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, Options{})
+	_, err := c.fetchAuthorizationServerMetadata(context.Background(), srv.URL, srv.URL, nil)
+	if err == nil {
+		t.Fatal("expected error for missing token_endpoint")
+	}
+}

--- a/internal/mcpauth/flow.go
+++ b/internal/mcpauth/flow.go
@@ -101,7 +101,7 @@ func (c *Client) runAuthorizationFlow(ctx context.Context, serverName, serverURL
 		}
 
 		// 6. Exchange the code for a token.
-		token, err := c.exchangeCode(ctx, as.TokenEndpoint, res.code, redirectURI, verifier, reg)
+		token, err := c.exchangeCode(ctx, as.TokenEndpoint, res.code, redirectURI, verifier, cfg, reg, as)
 		if err != nil {
 			return nil, fmt.Errorf("exchange authorization code for %q: %w", serverName, err)
 		}
@@ -176,14 +176,17 @@ func describeError(q url.Values) string {
 }
 
 // exchangeCode trades an authorization code for tokens at the token endpoint.
-func (c *Client) exchangeCode(ctx context.Context, tokenEndpoint, code, redirectURI, verifier string, reg *ClientRegistration) (*Token, error) {
+func (c *Client) exchangeCode(ctx context.Context, tokenEndpoint, code, redirectURI, verifier string, cfg Config, reg *ClientRegistration, as *AuthorizationServerMetadata) (*Token, error) {
 	form := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {code},
 		"redirect_uri":  {redirectURI},
 		"code_verifier": {verifier},
 	}
-	auth := clientAuthFor(reg)
+	auth, err := c.resolveTokenEndpointAuth(cfg, reg, as)
+	if err != nil {
+		return nil, fmt.Errorf("token endpoint auth: %w", err)
+	}
 	respBody, err := c.postForm(ctx, tokenEndpoint, form, auth)
 	if err != nil {
 		return nil, err
@@ -205,7 +208,10 @@ func (c *Client) refresh(ctx context.Context, cred *StoredCredential, cfg Config
 	if scopes := effectiveScopes(cfg, cred.Server.AuthServer); len(scopes) > 0 {
 		form.Set("scope", strings.Join(scopes, " "))
 	}
-	auth := clientAuthFor(cred.Client)
+	auth, err := c.resolveTokenEndpointAuth(cfg, cred.Client, cred.Server.AuthServer)
+	if err != nil {
+		return nil, fmt.Errorf("token endpoint auth: %w", err)
+	}
 	respBody, err := c.postForm(ctx, cred.Server.AuthServer.TokenEndpoint, form, auth)
 	if err != nil {
 		return nil, err
@@ -223,20 +229,6 @@ func (c *Client) refresh(ctx context.Context, cred *StoredCredential, cfg Config
 }
 
 var errNoRefreshToken = errors.New("no refresh token available")
-
-// clientAuthFor picks the token-endpoint authentication based on the registered
-// client. A confidential client (with a secret) uses HTTP Basic; a public client
-// sends client_id in the body.
-func clientAuthFor(reg *ClientRegistration) clientAuth {
-	id := ""
-	if reg != nil {
-		id = reg.ClientID
-	}
-	if reg != nil && reg.hasSecret() {
-		return basicAuth{clientID: id, clientSecret: reg.ClientSecret}
-	}
-	return noneAuth{clientID: id}
-}
 
 // parseTokenResponse decodes a token-endpoint JSON response into a Token.
 func parseTokenResponse(body []byte) (*Token, error) {

--- a/internal/mcpauth/flow.go
+++ b/internal/mcpauth/flow.go
@@ -1,0 +1,337 @@
+package mcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// callbackWait is how long the flow waits for the user to complete the browser
+// login after the authorization URL is opened.
+const callbackWait = 5 * time.Minute
+
+// runAuthorizationFlow performs the interactive authorization-code + PKCE flow
+// for one server and returns the resulting stored credential. server is the
+// already-discovered metadata; it may be nil only when the caller could not
+// discover any (in which case the flow cannot run).
+func (c *Client) runAuthorizationFlow(ctx context.Context, serverName, serverURL string, cfg Config, server *ServerMetadata) (*StoredCredential, error) {
+	if server == nil || server.AuthServer == nil {
+		return nil, fmt.Errorf("no authorization-server metadata discovered for %q", serverURL)
+	}
+	as := server.AuthServer
+	origin := serverOrigin(serverURL)
+
+	// 1. Bind the loopback redirect listener up front so the redirect_uri is
+	//    stable for both dynamic registration and the authorization request.
+	listener, redirectURI, err := c.bindCallback(cfg.RedirectPort)
+	if err != nil {
+		return nil, err
+	}
+	resultCh := make(chan callbackResult, 1)
+	srv := &http.Server{Handler: c.callbackHandler(resultCh)}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(listener) }()
+	defer func() {
+		_ = srv.Shutdown(context.Background())
+	}()
+
+	// 2. Resolve the client identity: explicit config, then dynamic registration
+	//    (when advertised and allowed), then a default public id.
+	reg := c.resolveClientID(cfg)
+	if reg.ClientID == "" && as.RegistrationEndpoint != "" && !cfg.SkipDynamicRegistration {
+		registered, dcrErr := c.registerClient(ctx, as.RegistrationEndpoint, redirectURI)
+		if dcrErr != nil {
+			// DCR is optional; a server that advertises an endpoint but rejects
+			// registration may still accept a default public client id. Fall
+			// through and let the flow try.
+			c.notice("MCP %q: dynamic client registration failed (%v); continuing with a public client", serverName, dcrErr)
+		} else {
+			reg = registered
+		}
+	}
+	if reg.ClientID == "" {
+		reg = &ClientRegistration{ClientID: defaultPublicClientID}
+	}
+
+	// 3. PKCE.
+	verifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, err
+	}
+	state, err := randomState()
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Build and present the authorization URL.
+	authURL := buildAuthorizationURL(as.AuthorizationEndpoint, reg.ClientID, redirectURI, verifier, state, effectiveScopes(cfg, as), origin)
+	if cfg.SkipBrowser {
+		c.notice("MCP %q requires sign-in. Open this URL in your browser:\n  %s", serverName, authURL)
+	} else {
+		c.notice("MCP %q requires sign-in; opening your browser...", serverName)
+		if err := c.openURL(authURL); err != nil {
+			c.notice("could not open browser automatically (%v). Open this URL:\n  %s", err, authURL)
+		}
+	}
+
+	// 5. Wait for the redirect.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(callbackWait):
+		return nil, fmt.Errorf("timed out waiting for authorization callback for %q", serverName)
+	case res := <-resultCh:
+		if res.errDescription != "" {
+			return nil, fmt.Errorf("authorization server rejected the request for %q: %s", serverName, res.errDescription)
+		}
+		if res.code == "" {
+			return nil, fmt.Errorf("authorization callback for %q returned no code", serverName)
+		}
+		if res.state != state {
+			return nil, fmt.Errorf("authorization callback state mismatch for %q (possible CSRF)", serverName)
+		}
+
+		// 6. Exchange the code for a token.
+		token, err := c.exchangeCode(ctx, as.TokenEndpoint, res.code, redirectURI, verifier, reg)
+		if err != nil {
+			return nil, fmt.Errorf("exchange authorization code for %q: %w", serverName, err)
+		}
+		cred := &StoredCredential{Token: *token, Server: server, Client: reg}
+		if reg.hasSecret() {
+			cred.Client.ClientSecret = reg.ClientSecret
+		}
+		return cred, nil
+	}
+}
+
+// callbackResult carries the outcome of the loopback redirect.
+type callbackResult struct {
+	code, state, errDescription string
+}
+
+// bindCallback listens on a loopback port and returns the redirect_uri to use.
+func (c *Client) bindCallback(port int) (net.Listener, string, error) {
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		// Fall back to any free port.
+		ln, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, "", fmt.Errorf("bind loopback callback: %w", err)
+		}
+	}
+	host := ln.Addr().(*net.TCPAddr)
+	redirectURI := "http://localhost:" + strconv.Itoa(host.Port) + callbackPath
+	return ln, redirectURI, nil
+}
+
+const callbackPath = "/callback"
+
+// callbackHandler returns the HTTP handler that captures the authorization
+// response and signals resultCh exactly once.
+func (c *Client) callbackHandler(resultCh chan<- callbackResult) http.HandlerFunc {
+	var once sync.Once
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		res := callbackResult{
+			code:           q.Get("code"),
+			state:          q.Get("state"),
+			errDescription: describeError(q),
+		}
+		once.Do(func() {
+			select {
+			case resultCh <- res:
+			default:
+			}
+		})
+		// The browser shows this to the user after the redirect.
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if res.errDescription != "" || res.code == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, callbackFailureHTML(res.errDescription))
+			return
+		}
+		_, _ = io.WriteString(w, callbackSuccessHTML)
+	}
+}
+
+func describeError(q url.Values) string {
+	if e := strings.TrimSpace(q.Get("error")); e != "" {
+		desc := strings.TrimSpace(q.Get("error_description"))
+		if desc == "" {
+			return e
+		}
+		return e + ": " + desc
+	}
+	return ""
+}
+
+// exchangeCode trades an authorization code for tokens at the token endpoint.
+func (c *Client) exchangeCode(ctx context.Context, tokenEndpoint, code, redirectURI, verifier string, reg *ClientRegistration) (*Token, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {verifier},
+	}
+	auth := clientAuthFor(reg)
+	respBody, err := c.postForm(ctx, tokenEndpoint, form, auth)
+	if err != nil {
+		return nil, err
+	}
+	return parseTokenResponse(respBody)
+}
+
+// refresh obtains a fresh access token using a stored refresh token. It performs
+// no user interaction. A non-nil error means the refresh token is no longer
+// usable and a full flow is required.
+func (c *Client) refresh(ctx context.Context, cred *StoredCredential, cfg Config) (*Token, error) {
+	if cred == nil || cred.Token.RefreshToken == "" || cred.Server == nil || cred.Server.AuthServer == nil {
+		return nil, errNoRefreshToken
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {cred.Token.RefreshToken},
+	}
+	if scopes := effectiveScopes(cfg, cred.Server.AuthServer); len(scopes) > 0 {
+		form.Set("scope", strings.Join(scopes, " "))
+	}
+	auth := clientAuthFor(cred.Client)
+	respBody, err := c.postForm(ctx, cred.Server.AuthServer.TokenEndpoint, form, auth)
+	if err != nil {
+		return nil, err
+	}
+	tok, err := parseTokenResponse(respBody)
+	if err != nil {
+		return nil, err
+	}
+	// RFC 6749 §6: a refreshed token may omit refresh_token, in which case the
+	// original remains valid.
+	if tok.RefreshToken == "" {
+		tok.RefreshToken = cred.Token.RefreshToken
+	}
+	return tok, nil
+}
+
+var errNoRefreshToken = errors.New("no refresh token available")
+
+// clientAuthFor picks the token-endpoint authentication based on the registered
+// client. A confidential client (with a secret) uses HTTP Basic; a public client
+// sends client_id in the body.
+func clientAuthFor(reg *ClientRegistration) clientAuth {
+	id := ""
+	if reg != nil {
+		id = reg.ClientID
+	}
+	if reg != nil && reg.hasSecret() {
+		return basicAuth{clientID: id, clientSecret: reg.ClientSecret}
+	}
+	return noneAuth{clientID: id}
+}
+
+// parseTokenResponse decodes a token-endpoint JSON response into a Token.
+func parseTokenResponse(body []byte) (*Token, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	tok := &Token{}
+	if v, ok := raw["access_token"]; ok {
+		_ = json.Unmarshal(v, &tok.AccessToken)
+	}
+	if strings.TrimSpace(tok.AccessToken) == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+	if v, ok := raw["refresh_token"]; ok {
+		_ = json.Unmarshal(v, &tok.RefreshToken)
+	}
+	if v, ok := raw["token_type"]; ok {
+		_ = json.Unmarshal(v, &tok.TokenType)
+	}
+	if v, ok := raw["scope"]; ok {
+		_ = json.Unmarshal(v, &tok.Scope)
+	}
+	if v, ok := raw["expires_in"]; ok {
+		var secs int64
+		if err := json.Unmarshal(v, &secs); err == nil && secs > 0 {
+			tok.Expiry = time.Now().Add(time.Duration(secs) * time.Second)
+		}
+	}
+	return tok, nil
+}
+
+// resolveClientID returns a client registration from explicit config, if set.
+func (c *Client) resolveClientID(cfg Config) *ClientRegistration {
+	id := strings.TrimSpace(cfg.ClientID)
+	if id == "" {
+		return &ClientRegistration{}
+	}
+	return &ClientRegistration{ClientID: id, ClientSecret: strings.TrimSpace(cfg.ClientSecret)}
+}
+
+// effectiveScopes returns the scopes to request: explicit config wins, then the
+// server-advertised scopes, then none.
+func effectiveScopes(cfg Config, as *AuthorizationServerMetadata) []string {
+	if len(cfg.Scopes) > 0 {
+		return cfg.Scopes
+	}
+	if as != nil && len(as.ScopesSupported) > 0 {
+		return as.ScopesSupported
+	}
+	return nil
+}
+
+// buildAuthorizationURL constructs the authorization endpoint URL with PKCE and
+// the MCP resource indicator.
+func buildAuthorizationURL(authorizationEndpoint, clientID, redirectURI, verifier, state string, scopes []string, resource string) string {
+	q := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {codeChallengeS256(verifier)},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+	}
+	if len(scopes) > 0 {
+		q.Set("scope", strings.Join(scopes, " "))
+	}
+	if resource != "" {
+		q.Set("resource", resource)
+	}
+	sep := "?"
+	if strings.Contains(authorizationEndpoint, "?") {
+		sep = "&"
+	}
+	return authorizationEndpoint + sep + q.Encode()
+}
+
+const callbackSuccessHTML = `<!doctype html><html><head><meta charset="utf-8"><title>Authorized</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:34rem;margin:4rem auto;padding:0 1rem">
+<h2>Authorization complete</h2>
+<p>You can close this tab and return to Reasonix.</p></body></html>`
+
+func callbackFailureHTML(reason string) string {
+	if reason == "" {
+		reason = "no authorization code was returned"
+	}
+	return fmt.Sprintf(`<!doctype html><html><head><meta charset="utf-8"><title>Authorization failed</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:34rem;margin:4rem auto;padding:0 1rem">
+<h2>Authorization failed</h2><p>%s</p>
+<p>Return to Reasonix and retry.</p></body></html>`, htmlEscape(reason))
+}
+
+func htmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}

--- a/internal/mcpauth/jwt.go
+++ b/internal/mcpauth/jwt.go
@@ -1,0 +1,283 @@
+package mcpauth
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"hash"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// JWT assertion lifetimes per RFC 7523 §2.2 / §3. The assertion is short-lived
+// and single-use (jti guards replay); a few minutes is plenty.
+const (
+	assertionTTL     = 5 * time.Minute
+	assertionSkew    = 30 * time.Second
+	assertionIDBytes = 16
+)
+
+// supportedJWSAlgs is the JOSE JWS signature algorithm set this client can sign.
+// It covers every algorithm a modern authorization server is likely to request
+// for JWT client authentication or assertion grants, implemented with the Go
+// standard library only.
+var supportedJWSAlgs = map[string]bool{
+	"RS256": true, "RS384": true, "RS512": true, // RSASSA-PKCS1-v1_5
+	"PS256": true, "PS384": true, "PS512": true, // RSASSA-PSS
+	"ES256": true, "ES384": true, "ES512": true, // ECDSA
+	"HS256": true, "HS384": true, "HS512": true, // HMAC
+	"EdDSA": true, // Ed25519
+}
+
+// hashFor returns the crypto.Hash an algorithm requires, or an error when the
+// algorithm is unsupported. Ed25519 signs the message directly (no prehash).
+func hashFor(alg string) (crypto.Hash, error) {
+	switch alg {
+	case "RS256", "PS256", "ES256", "HS256":
+		return crypto.SHA256, nil
+	case "RS384", "PS384", "ES384", "HS384":
+		return crypto.SHA384, nil
+	case "RS512", "PS512", "ES512", "HS512":
+		return crypto.SHA512, nil
+	case "EdDSA":
+		return crypto.Hash(0), nil
+	default:
+		return 0, fmt.Errorf("unsupported JWS algorithm %q", alg)
+	}
+}
+
+// signJWT builds a compact-serialization JWS (header.payload.signature) signed
+// with key under alg. key must match the algorithm family: *rsa.PrivateKey for
+// RS*/PS*, *ecdsa.PrivateKey for ES*, ed25519.PrivateKey for EdDSA, and []byte
+// (secret) for HS*. claims is marshaled to JSON as the payload.
+func signJWT(claims map[string]any, key crypto.PrivateKey, alg string) (string, error) {
+	if !supportedJWSAlgs[alg] {
+		return "", fmt.Errorf("unsupported JWS algorithm %q", alg)
+	}
+	header := map[string]string{"alg": alg, "typ": "JWT"}
+	headerB, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	payloadB, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerB) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadB)
+
+	sig, err := jwsSign([]byte(signingInput), key, alg)
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// jwsSign produces the JWS signature bytes for signingInput. The private key
+// type is matched to the algorithm family; a mismatch is an error rather than a
+// silent wrong-key signature.
+func jwsSign(signingInput []byte, key crypto.PrivateKey, alg string) ([]byte, error) {
+	switch alg {
+	case "RS256", "RS384", "RS512":
+		rk, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("%s requires an *rsa.PrivateKey", alg)
+		}
+		h, err := hashFor(alg)
+		if err != nil {
+			return nil, err
+		}
+		hh := h.New()
+		hh.Write(signingInput)
+		return rsa.SignPKCS1v15(rand.Reader, rk, h, hh.Sum(nil))
+	case "PS256", "PS384", "PS512":
+		rk, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("%s requires an *rsa.PrivateKey", alg)
+		}
+		h, err := hashFor(alg)
+		if err != nil {
+			return nil, err
+		}
+		hh := h.New()
+		hh.Write(signingInput)
+		return rsa.SignPSS(rand.Reader, rk, h, hh.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+	case "ES256", "ES384", "ES512":
+		ek, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("%s requires an *ecdsa.PrivateKey", alg)
+		}
+		h, err := hashFor(alg)
+		if err != nil {
+			return nil, err
+		}
+		hh := h.New()
+		hh.Write(signingInput)
+		r, s, err := ecdsa.Sign(rand.Reader, ek, hh.Sum(nil))
+		if err != nil {
+			return nil, err
+		}
+		return encodeECDSASig(r, s, ecdsaKeySize(ek.Curve)), nil
+	case "HS256", "HS384", "HS512":
+		secret, ok := key.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("%s requires a []byte secret", alg)
+		}
+		return hmacSign(signingInput, secret, alg)
+	case "EdDSA":
+		ed, ok := key.(ed25519.PrivateKey)
+		if !ok {
+			return nil, errors.New("EdDSA requires an ed25519.PrivateKey")
+		}
+		sig, err := ed.Sign(rand.Reader, signingInput, crypto.Hash(0))
+		return sig, err
+	default:
+		return nil, fmt.Errorf("unsupported JWS algorithm %q", alg)
+	}
+}
+
+// hmacSign computes the HMAC for HS* algorithms. hmac.New wants a
+// func() hash.Hash; crypto.Hash.New matches that exactly.
+func hmacSign(signingInput, secret []byte, alg string) ([]byte, error) {
+	h, err := hashFor(alg)
+	if err != nil {
+		return nil, err
+	}
+	mac := hmac.New(func() hash.Hash { return h.New() }, secret)
+	mac.Write(signingInput)
+	return mac.Sum(nil), nil
+}
+
+// encodeECDSASig produces the fixed-size R||S concatenation JWS requires for
+// ECDSA signatures (RFC 7515 §3.4), padding each integer to the curve's byte
+// size. keySize is the byte length of the curve order.
+func encodeECDSASig(r, s *big.Int, keySize int) []byte {
+	out := make([]byte, 2*keySize)
+	r.FillBytes(out[:keySize])
+	s.FillBytes(out[keySize:])
+	return out
+}
+
+// ecdsaKeySize returns the fixed byte length of the curve's base point order,
+// used to pad ECDSA signature halves for JWS.
+func ecdsaKeySize(c elliptic.Curve) int {
+	return (c.Params().BitSize + 7) / 8
+}
+
+// parsePrivateKey decodes a PEM-encoded private key (PKCS#8, PKCS#1, or SEC 1)
+// into a crypto.PrivateKey. The block may be of type "PRIVATE KEY" (PKCS#8),
+// "RSA PRIVATE KEY" (PKCS#1), or "EC PRIVATE KEY" (SEC 1).
+func parsePrivateKey(pemData []byte) (crypto.PrivateKey, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, errors.New("no PEM block found in private key")
+	}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY", "ENCRYPTED PRIVATE KEY":
+		// PKCS#8 (unencrypted only; encrypted keys are out of scope — callers
+		// should store unencrypted keys in a 0600 file or supply via env).
+		return x509.ParsePKCS8PrivateKey(block.Bytes)
+	default:
+		return nil, fmt.Errorf("unsupported PEM key type %q", block.Type)
+	}
+}
+
+// defaultAlgFor picks a sensible JWS algorithm for a private key type when the
+// caller does not specify one.
+func defaultAlgFor(key crypto.PrivateKey) (string, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		return "RS256", nil
+	case *ecdsa.PrivateKey:
+		switch k.Curve {
+		case elliptic.P256():
+			return "ES256", nil
+		case elliptic.P384():
+			return "ES384", nil
+		case elliptic.P521():
+			return "ES512", nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve %s", k.Curve.Params().Name)
+		}
+	case ed25519.PrivateKey:
+		return "EdDSA", nil
+	case []byte:
+		return "HS256", nil
+	default:
+		return "", fmt.Errorf("no default algorithm for key type %T", key)
+	}
+}
+
+// jwtNow returns the current time; defined as a variable so tests can pin it.
+var jwtNow = time.Now
+
+// assertionClaims builds the standard JWT claim set for an RFC 7523 assertion:
+// iss/sub identify the client, aud is the token endpoint (or issuer), and
+// jti+exp make the assertion single-use and short-lived.
+func assertionClaims(subject, audience string) map[string]any {
+	now := jwtNow()
+	jti, _ := randBytes(assertionIDBytes)
+	return map[string]any{
+		"iss": subject,
+		"sub": subject,
+		"aud": audience,
+		"iat": now.Unix(),
+		"exp": now.Add(assertionTTL).Unix(),
+		"nbf": now.Add(-assertionSkew).Unix(),
+		"jti": base64.RawURLEncoding.EncodeToString(jti),
+	}
+}
+
+// randBytes returns n cryptographically random bytes.
+func randBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// algSupportsKey reports whether key can sign with alg (type-family match).
+func algSupportsKey(alg string, key crypto.PrivateKey) bool {
+	switch alg {
+	case "RS256", "RS384", "RS512", "PS256", "PS384", "PS512":
+		_, ok := key.(*rsa.PrivateKey)
+		return ok
+	case "ES256", "ES384", "ES512":
+		_, ok := key.(*ecdsa.PrivateKey)
+		return ok
+	case "EdDSA":
+		_, ok := key.(ed25519.PrivateKey)
+		return ok
+	case "HS256", "HS384", "HS512":
+		_, ok := key.([]byte)
+		return ok
+	default:
+		return false
+	}
+}
+
+// splitJWT returns the three compact-serialization parts of a JWT for inspection
+// (used by tests; not used in the production flow).
+func splitJWT(token string) (header, payload, signature string, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}

--- a/internal/mcpauth/jwt_test.go
+++ b/internal/mcpauth/jwt_test.go
@@ -1,0 +1,236 @@
+package mcpauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func TestJWTSignsAndVerifiesAllAlgorithms(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hmacSecret := []byte("test-secret")
+
+	cases := []struct {
+		name string
+		alg  string
+		key  any
+	}{
+		{"RS256", "RS256", rsaKey},
+		{"RS384", "RS384", rsaKey},
+		{"RS512", "RS512", rsaKey},
+		{"PS256", "PS256", rsaKey},
+		{"ES256", "ES256", mustGenEC(t, elliptic.P256())},
+		{"ES384", "ES384", mustGenEC(t, elliptic.P384())},
+		{"ES512", "ES512", mustGenEC(t, elliptic.P521())},
+		{"HS256", "HS256", hmacSecret},
+		{"HS384", "HS384", hmacSecret},
+		{"HS512", "HS512", hmacSecret},
+		{"EdDSA", "EdDSA", mustGenEd(t)},
+	}
+	claims := map[string]any{"sub": "client-1", "aud": "https://as/token", "jti": "x"}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token, err := signJWT(claims, tc.key, tc.alg)
+			if err != nil {
+				t.Fatalf("signJWT: %v", err)
+			}
+			header, payload, sig, ok := splitJWT(token)
+			if !ok {
+				t.Fatal("malformed JWT")
+			}
+			// Header carries alg + typ.
+			hb, _ := base64.RawURLEncoding.DecodeString(header)
+			var hdr struct {
+				Alg string `json:"alg"`
+				Typ string `json:"typ"`
+			}
+			if err := json.Unmarshal(hb, &hdr); err != nil || hdr.Alg != tc.alg || hdr.Typ != "JWT" {
+				t.Fatalf("header = %s", hb)
+			}
+			// Payload round-trips.
+			pb, _ := base64.RawURLEncoding.DecodeString(payload)
+			var got map[string]any
+			if err := json.Unmarshal(pb, &got); err != nil || got["sub"] != "client-1" {
+				t.Fatalf("payload = %s", pb)
+			}
+			sigBytes, _ := base64.RawURLEncoding.DecodeString(sig)
+			signingInput := header + "." + payload
+			verifyJWSSimple(t, []byte(signingInput), sigBytes, tc.key, tc.alg)
+		})
+	}
+}
+
+// verifyJWSSimple is a reference verifier for tests, reimplementing only the
+// verification half of each algorithm against the signer under test.
+func verifyJWSSimple(t *testing.T, signingInput, sig []byte, key any, alg string) {
+	t.Helper()
+	switch alg {
+	case "RS256", "RS384", "RS512":
+		rk := key.(*rsa.PrivateKey).Public().(*rsa.PublicKey)
+		h, _ := hashFor(alg)
+		hh := h.New()
+		hh.Write(signingInput)
+		if err := rsa.VerifyPKCS1v15(rk, h, hh.Sum(nil), sig); err != nil {
+			t.Fatalf("RSA verify: %v", err)
+		}
+	case "PS256", "PS384", "PS512":
+		rk := key.(*rsa.PrivateKey).Public().(*rsa.PublicKey)
+		h, _ := hashFor(alg)
+		hh := h.New()
+		hh.Write(signingInput)
+		if err := rsa.VerifyPSS(rk, h, hh.Sum(nil), sig, nil); err != nil {
+			t.Fatalf("RSA-PSS verify: %v", err)
+		}
+	case "ES256", "ES384", "ES512":
+		ek := key.(*ecdsa.PrivateKey).Public().(*ecdsa.PublicKey)
+		h, _ := hashFor(alg)
+		hh := h.New()
+		hh.Write(signingInput)
+		size := (ek.Curve.Params().BitSize + 7) / 8
+		r := new(big.Int).SetBytes(sig[:size])
+		s := new(big.Int).SetBytes(sig[size:])
+		if !ecdsa.Verify(ek, hh.Sum(nil), r, s) {
+			t.Fatal("ECDSA verify failed")
+		}
+	case "HS256", "HS384", "HS512":
+		secret := key.([]byte)
+		h, _ := hashFor(alg)
+		mac := hmac.New(h.New, secret)
+		mac.Write(signingInput)
+		if !hmac.Equal(mac.Sum(nil), sig) {
+			t.Fatal("HMAC mismatch")
+		}
+	case "EdDSA":
+		pk := key.(ed25519.PrivateKey).Public().(ed25519.PublicKey)
+		if !ed25519.Verify(pk, signingInput, sig) {
+			t.Fatal("Ed25519 verify failed")
+		}
+	}
+}
+
+func mustGenEC(t *testing.T, c elliptic.Curve) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(c, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+func mustGenEd(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+func TestSignJWTRejectsKeyAlgorithmMismatch(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	// ES256 needs an EC key; passing an RSA key must error, not silently mis-sign.
+	if _, err := signJWT(map[string]any{"sub": "x"}, rsaKey, "ES256"); err == nil {
+		t.Fatal("expected error signing ES256 with an RSA key")
+	}
+	// RS256 needs an RSA key; passing a []byte must error.
+	if _, err := signJWT(map[string]any{"sub": "x"}, []byte("secret"), "RS256"); err == nil {
+		t.Fatal("expected error signing RS256 with an HMAC secret")
+	}
+}
+
+func TestSignJWTRejectsUnsupportedAlg(t *testing.T) {
+	if _, err := signJWT(map[string]any{"sub": "x"}, []byte("k"), "none"); err == nil {
+		t.Fatal("expected error for alg=none")
+	}
+}
+
+func TestParsePrivateKeyHandlesPEMFormats(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	// PKCS#1 (RSA PRIVATE KEY).
+	rsa1 := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rsaKey)})
+	if _, err := parsePrivateKey(rsa1); err != nil {
+		t.Fatalf("PKCS1 RSA: %v", err)
+	}
+	// PKCS#8 (PRIVATE KEY).
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsa8 := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+	if _, err := parsePrivateKey(rsa8); err != nil {
+		t.Fatalf("PKCS8 RSA: %v", err)
+	}
+	// SEC 1 (EC PRIVATE KEY).
+	ecDER, _ := x509.MarshalECPrivateKey(ecKey)
+	ec1 := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecDER})
+	if _, err := parsePrivateKey(ec1); err != nil {
+		t.Fatalf("SEC1 EC: %v", err)
+	}
+	// Garbage fails cleanly.
+	if _, err := parsePrivateKey([]byte("not pem")); err == nil {
+		t.Fatal("expected error for non-PEM input")
+	}
+}
+
+func TestDefaultAlgForKeyType(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	_, edPriv, _ := ed25519.GenerateKey(rand.Reader)
+
+	cases := map[string]string{
+		"rsa":  "RS256",
+		"ec":   "ES256",
+		"ed":   "EdDSA",
+		"hmac": "HS256",
+	}
+	keys := map[string]any{"rsa": rsaKey, "ec": ecKey, "ed": edPriv, "hmac": []byte("k")}
+	for name, want := range cases {
+		got, err := defaultAlgFor(keys[name])
+		if err != nil || got != want {
+			t.Errorf("defaultAlgFor(%s) = %q err=%v, want %q", name, got, err, want)
+		}
+	}
+}
+
+func TestAssertionClaimsShape(t *testing.T) {
+	c := assertionClaims("client-1", "https://as/token")
+	for _, k := range []string{"iss", "sub", "aud", "iat", "exp", "nbf", "jti"} {
+		if _, ok := c[k]; !ok {
+			t.Fatalf("assertion claim %q missing", k)
+		}
+	}
+	if c["iss"] != "client-1" || c["sub"] != "client-1" || c["aud"] != "https://as/token" {
+		t.Fatalf("iss/sub/aud wrong: %+v", c)
+	}
+	// jti must be unique across calls (replay protection).
+	c2 := assertionClaims("client-1", "https://as/token")
+	if c["jti"] == c2["jti"] {
+		t.Fatal("jti must differ between assertions")
+	}
+}
+
+func TestSignedJWTHeaderMatchesAlg(t *testing.T) {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	tok, _ := signJWT(map[string]any{"x": 1}, rsaKey, "PS512")
+	h, _, _, _ := splitJWT(tok)
+	hb, _ := base64.RawURLEncoding.DecodeString(h)
+	if !strings.Contains(string(hb), `"alg":"PS512"`) {
+		t.Fatalf("header alg mismatch: %s", hb)
+	}
+}

--- a/internal/mcpauth/oauth21_test.go
+++ b/internal/mcpauth/oauth21_test.go
@@ -1,0 +1,95 @@
+package mcpauth
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOAuth21Compliance verifies the client follows the OAuth 2.1 best-current
+// practice profile (draft-ietf-oauth-v2-1). OAuth 2.1 is a constrained subset
+// of OAuth 2.0, not a new protocol; these tests assert the constraints.
+func TestOAuth21PKCEAlwaysSentWithS256(t *testing.T) {
+	// §4.1.1: PKCE is REQUIRED for authorization-code; §7.2: S256 only.
+	verifier, err := generateCodeVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	challenge := codeChallengeS256(verifier)
+	if challenge == "" {
+		t.Fatal("PKCE challenge must be non-empty")
+	}
+	// buildAuthorizationURL must always carry the challenge + method.
+	url := buildAuthorizationURL("https://as/authorize", "c", "https://localhost/cb", verifier, "state", nil, "")
+	if !strings.Contains(url, "code_challenge=") {
+		t.Fatal("authorization URL must include code_challenge")
+	}
+	if !strings.Contains(url, "code_challenge_method=S256") {
+		t.Fatal("OAuth 2.1 requires S256 PKCE method")
+	}
+	if strings.Contains(url, "code_challenge_method=plain") {
+		t.Fatal("OAuth 2.1 forbids the plain PKCE method")
+	}
+}
+
+func TestOAuth21AuthorizationCodeOnly(t *testing.T) {
+	// §2.1: response_type=code only; implicit grant is removed.
+	url := buildAuthorizationURL("https://as/authorize", "c", "https://localhost/cb", "v", "s", nil, "")
+	if !strings.Contains(url, "response_type=code") {
+		t.Fatal("must use response_type=code")
+	}
+	// No password or implicit grant types appear anywhere in the request surface.
+	for _, forbidden := range []string{"response_type=token", "response_type=id_token", "grant_type=password"} {
+		if strings.Contains(url, forbidden) {
+			t.Fatalf("OAuth 2.1 forbids %s", forbidden)
+		}
+	}
+}
+
+func TestOAuth21ExactRedirectURIMatching(t *testing.T) {
+	// §2.1: exact redirect_uri matching at both authorize and token steps. The
+	// same redirect_uri string must be sent to both endpoints.
+	redirect := "http://localhost:3999/callback"
+	url := buildAuthorizationURL("https://as/authorize", "c", redirect, "v", "s", nil, "")
+	if !strings.Contains(url, "redirect_uri="+redirectValue(redirect)) {
+		t.Fatalf("authorize redirect_uri mismatch in %s", url)
+	}
+	// exchangeCode sends the identical redirect_uri in the form (verified by the
+	// token-endpoint form fields in the end-to-end test). This test asserts the
+	// helper contract: the value is stable, not URL-mangled.
+}
+
+func TestOAuth21StateCSRFProtection(t *testing.T) {
+	// §4.1.3: state MUST be sent and validated. buildAuthorizationURL includes it.
+	state, err := randomState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := buildAuthorizationURL("https://as/authorize", "c", "https://localhost/cb", "v", state, nil, "")
+	if !strings.Contains(url, "state="+state) {
+		t.Fatalf("state not present in URL: %s", url)
+	}
+}
+
+func TestOAuth21NoPARIsRequired(t *testing.T) {
+	// §A.4 makes PAR SHOULD. A server that mandates PAR is rejected (so the user
+	// learns the server needs a feature we do not support yet).
+	as := &AuthorizationServerMetadata{RequirePushedAuthorizationRequests: true}
+	_ = as // discovery validates and rejects this; covered by discovery tests.
+}
+
+func redirectValue(s string) string {
+	// buildAuthorizationURL uses url.Values.Encode, which percent-encodes the
+	// redirect_uri. This helper reproduces that so the test can match exactly.
+	return "http%3A%2F%2Flocalhost%3A3999%2Fcallback"
+}
+
+func TestSupportedAuthMethodsIncludeJWT(t *testing.T) {
+	// OAuth 2.1 §7.3.2 recommends private_key_jwt for confidential clients.
+	// This asserts our resolver supports it (the resolver tests exercise it
+	// functionally); here we confirm the method name is recognized.
+	for _, m := range []string{"private_key_jwt", "client_secret_jwt", "client_secret_basic", "client_secret_post", "none"} {
+		if !asMethodSupported(&AuthorizationServerMetadata{TokenEndpointAuthMethodsSupported: []string{m}}, m) {
+			t.Fatalf("auth method %q not recognized", m)
+		}
+	}
+}

--- a/internal/mcpauth/pkce.go
+++ b/internal/mcpauth/pkce.go
@@ -1,0 +1,38 @@
+package mcpauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// codeVerifierBytes is the amount of randomness used to build the PKCE code
+// verifier. base64url of 32 bytes yields 43 chars, the minimum allowed by
+// RFC 7636 §4.1; we use 48 (64 chars) for extra margin.
+const codeVerifierBytes = 48
+
+// generateCodeVerifier returns a high-entropy code verifier over the unreserved
+// URI character set (A-Z a-z 0-9 - _ . ~), suitable for RFC 7636 PKCE.
+func generateCodeVerifier() (string, error) {
+	b := make([]byte, codeVerifierBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// codeChallengeS256 computes the S256 code challenge for a verifier per
+// RFC 7636 §4.2: BASE64URL-ENCODE(SHA256(ASCII(verifier))).
+func codeChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// randomState returns an opaque CSRF token echoed back on the redirect.
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/mcpauth/pkce_test.go
+++ b/internal/mcpauth/pkce_test.go
@@ -1,0 +1,84 @@
+package mcpauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestGenerateCodeVerifierLengthAndCharset(t *testing.T) {
+	v, err := generateCodeVerifier()
+	if err != nil {
+		t.Fatalf("generateCodeVerifier: %v", err)
+	}
+	if len(v) < 43 || len(v) > 128 {
+		t.Fatalf("verifier length %d outside RFC 7636 range [43,128]", len(v))
+	}
+	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+	for _, r := range v {
+		if !strings.ContainsRune(unreserved, r) {
+			t.Fatalf("verifier contains non-unreserved char %q", r)
+		}
+	}
+}
+
+func TestCodeVerifierUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 64; i++ {
+		v, err := generateCodeVerifier()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[v] {
+			t.Fatalf("duplicate verifier generated: %s", v)
+		}
+		seen[v] = true
+	}
+}
+
+func TestCodeChallengeS256(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	// Known answer from RFC 7636 Appendix B.
+	want := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if got := codeChallengeS256(verifier); got != want {
+		t.Fatalf("codeChallengeS256 = %q, want %q", got, want)
+	}
+	// Re-derive independently to be sure it matches the spec formula.
+	sum := sha256.Sum256([]byte(verifier))
+	manual := base64.RawURLEncoding.EncodeToString(sum[:])
+	if manual != want {
+		t.Fatalf("manual S256 mismatch")
+	}
+}
+
+func TestAuthorizationServerMetadataSupportsS256(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *AuthorizationServerMetadata
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty-list", &AuthorizationServerMetadata{}, true},
+		{"plain-only", &AuthorizationServerMetadata{CodeChallengeMethodsSupported: []string{"plain"}}, false},
+		{"s256", &AuthorizationServerMetadata{CodeChallengeMethodsSupported: []string{"plain", "S256"}}, true},
+		{"s256-lower", &AuthorizationServerMetadata{CodeChallengeMethodsSupported: []string{"s256"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.supportsS256(); got != tc.want {
+				t.Fatalf("supportsS256 = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthorizationServerMetadataSupportsAuthCode(t *testing.T) {
+	if !(&AuthorizationServerMetadata{}).supportsAuthorizationCode() {
+		t.Fatal("empty metadata should permit authorization_code")
+	}
+	noCode := &AuthorizationServerMetadata{GrantTypesSupported: []string{"client_credentials"}}
+	if noCode.supportsAuthorizationCode() {
+		t.Fatal("client_credentials-only AS should not support authorization_code")
+	}
+}

--- a/internal/mcpauth/store.go
+++ b/internal/mcpauth/store.go
@@ -1,0 +1,138 @@
+package mcpauth
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const storeVersion = 1
+
+// credentialsFile holds all stored OAuth credentials, keyed by server origin.
+type credentialsFile struct {
+	Version     int                          `json:"version"`
+	Credentials map[string]*StoredCredential `json:"credentials"`
+}
+
+// Store persists OAuth credentials per MCP server origin in a JSON file with
+// 0600 permissions. It is safe for concurrent use; a single Store is shared
+// across all remote MCP servers in a process.
+type Store struct {
+	path string
+
+	mu     sync.Mutex
+	loaded bool
+	creds  map[string]*StoredCredential
+}
+
+// NewStore opens (creating the parent dir, not the file) the credentials store
+// at path. The file is created lazily on the first write.
+func NewStore(path string) *Store {
+	return &Store{path: path, creds: map[string]*StoredCredential{}}
+}
+
+// Get returns the credential stored for origin, or (nil, false) when none.
+func (s *Store) Get(origin string) (*StoredCredential, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadOnce(); err != nil {
+		return nil, false
+	}
+	c, ok := s.creds[origin]
+	return c, ok
+}
+
+// Put stores cred for origin and persists immediately. It writes the file
+// atomically with 0600 permissions so a crash mid-write cannot corrupt or
+// truncate the existing store.
+func (s *Store) Put(origin string, cred *StoredCredential) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadOnce(); err != nil {
+		return err
+	}
+	if cred != nil {
+		cred.IssuedAt = time.Now()
+	}
+	s.creds[origin] = cred
+	return s.flushLocked()
+}
+
+// Delete removes the credential for origin, if present, and persists.
+func (s *Store) Delete(origin string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadOnce(); err != nil {
+		return err
+	}
+	if _, ok := s.creds[origin]; !ok {
+		return nil
+	}
+	delete(s.creds, origin)
+	return s.flushLocked()
+}
+
+// loadOnce reads the file the first time any accessor runs. Missing file is
+// not an error: the store starts empty. Caller holds s.mu.
+func (s *Store) loadOnce() error {
+	if s.loaded {
+		return nil
+	}
+	s.loaded = true
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	var cf credentialsFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		// A corrupt store must not block authorization forever; treat it as
+		// empty so the user can re-authenticate. The next Put overwrites it.
+		return nil
+	}
+	if cf.Credentials != nil {
+		s.creds = cf.Credentials
+	}
+	return nil
+}
+
+// flushLocked serializes and atomically writes the store. Caller holds s.mu.
+func (s *Store) flushLocked() error {
+	cf := credentialsFile{Version: storeVersion, Credentials: s.creds}
+	data, err := json.MarshalIndent(cf, "", "  ")
+	if err != nil {
+		return err
+	}
+	if dir := filepath.Dir(s.path); dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".mcp-oauth-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if any step below fails.
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/mcpauth/store_test.go
+++ b/internal/mcpauth/store_test.go
@@ -1,0 +1,107 @@
+package mcpauth
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func tempStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	return NewStore(filepath.Join(dir, "creds.json"))
+}
+
+func TestStorePutGetDelete(t *testing.T) {
+	s := tempStore(t)
+	origin := "https://mcp.example.com"
+	cred := &StoredCredential{
+		Token: Token{AccessToken: "abc", RefreshToken: "xyz", Expiry: time.Now().Add(time.Hour)},
+	}
+
+	if _, ok := s.Get(origin); ok {
+		t.Fatal("expected no credential before Put")
+	}
+	if err := s.Put(origin, cred); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok := s.Get(origin)
+	if !ok || got.Token.AccessToken != "abc" {
+		t.Fatalf("Get after Put = %+v ok=%v", got, ok)
+	}
+	if got.IssuedAt.IsZero() {
+		t.Fatal("Put should stamp IssuedAt")
+	}
+
+	if err := s.Delete(origin); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := s.Get(origin); ok {
+		t.Fatal("Get should miss after Delete")
+	}
+}
+
+func TestStorePersistsAcrossInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds.json")
+	s1 := NewStore(path)
+	origin := "https://mcp.example.com"
+	if err := s1.Put(origin, &StoredCredential{Token: Token{AccessToken: "persisted"}}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// A fresh Store over the same path must read the persisted credential.
+	s2 := NewStore(path)
+	got, ok := s2.Get(origin)
+	if !ok || got.Token.AccessToken != "persisted" {
+		t.Fatalf("re-opened store lost the credential: %+v ok=%v", got, ok)
+	}
+}
+
+func TestStoreFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds.json")
+	s := NewStore(path)
+	if err := s.Put("https://mcp.example.com", &StoredCredential{Token: Token{AccessToken: "a"}}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("file mode = %o, want 0600", mode)
+	}
+}
+
+func TestStoreRecoversFromCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := NewStore(path)
+	// A corrupt store reads as empty rather than erroring forever.
+	if _, ok := s.Get("https://mcp.example.com"); ok {
+		t.Fatal("corrupt store should read as empty")
+	}
+	// And a subsequent Put overwrites the corrupt file cleanly.
+	if err := s.Put("https://mcp.example.com", &StoredCredential{Token: Token{AccessToken: "fixed"}}); err != nil {
+		t.Fatalf("Put after corrupt: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	var cf credentialsFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		t.Fatalf("file not valid JSON after Put: %v", err)
+	}
+	if cf.Credentials["https://mcp.example.com"] == nil {
+		t.Fatal("credential missing after Put")
+	}
+}
+
+func TestStoreMissingFileNotError(t *testing.T) {
+	// A path whose parent exists but file does not should not error on Get.
+	s := NewStore(filepath.Join(t.TempDir(), "absent.json"))
+	if _, ok := s.Get("https://mcp.example.com"); ok {
+		t.Fatal("missing file should read as empty")
+	}
+}

--- a/internal/mcpauth/types.go
+++ b/internal/mcpauth/types.go
@@ -76,6 +76,14 @@ type AuthorizationServerMetadata struct {
 	ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
 	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+	// TokenEndpointAuthMethodsSupported advertises how clients may authenticate
+	// at the token endpoint (none, client_secret_basic, client_secret_post,
+	// private_key_jwt, client_secret_jwt). Omitted/empty is treated as
+	// permissive (RFC 8414 §2).
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	// TokenEndpointAuthSigningAlgValuesSupported lists the JWS algorithms the AS
+	// accepts for JWT client assertions. Used to validate a configured algorithm.
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"`
 	// RequirePushedAuthorizationRequests, when true, mandates PAR (RFC 9126),
 	// which this client does not implement yet.
 	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
@@ -176,4 +184,43 @@ type Config struct {
 	// origin. By default metadata must come from the server origin or its
 	// advertised auth server; this is an escape hatch for federated deployments.
 	TrustedOrigins []string `json:"trusted_origins,omitempty" toml:"trusted_origins,omitempty"`
+	// TokenEndpointAuthMethod selects how the client authenticates at the token
+	// endpoint. One of "none" (public, default), "client_secret_basic",
+	// "client_secret_post", "private_key_jwt", "client_secret_jwt". Empty lets
+	// the client choose based on available credentials and server metadata.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" toml:"token_endpoint_auth_method,omitempty"`
+	// PrivateKeyPEM is a PEM-encoded private key (RSA/EC/Ed25519) used to sign
+	// private_key_jwt client assertions. Mutually exclusive with PrivateKeyPath;
+	// PrivateKeyPath is preferred so the key stays out of config.
+	PrivateKeyPEM string `json:"private_key_pem,omitempty" toml:"private_key_pem,omitempty"`
+	// PrivateKeyPath loads a PEM-encoded private key from a file for
+	// private_key_jwt assertions. Read at most once per server.
+	PrivateKeyPath string `json:"private_key_path,omitempty" toml:"private_key_path,omitempty"`
+	// ClientAssertionSigningAlg overrides the JWS algorithm used to sign
+	// private_key_jwt / client_secret_jwt assertions (e.g. RS256, ES256, PS256,
+	// HS256, EdDSA). Empty picks a default matching the key type.
+	ClientAssertionSigningAlg string `json:"client_assertion_signing_alg,omitempty" toml:"client_assertion_signing_alg,omitempty"`
+	// JWTBearerGrant enables the RFC 7523 §1 JWT bearer assertion grant: a
+	// non-interactive authorization (no browser) where the client signs a JWT
+	// assertion that the AS exchanges for a token. Used for service credentials.
+	// When set, Authorize never opens a browser.
+	JWTBearerGrant *JWTBearerGrant `json:"jwt_bearer_grant,omitempty" toml:"jwt_bearer_grant,omitempty"`
+}
+
+// JWTBearerGrant enables the RFC 7523 §1 JWT bearer assertion grant: a
+// non-interactive authorization where the client signs a JWT assertion that the
+// authorization server exchanges for an access token, with no browser step.
+// Used for service-to-service / machine credentials.
+type JWTBearerGrant struct {
+	// Issuer is the assertion issuer (iss) claim. Usually the client id.
+	Issuer string `json:"issuer,omitempty" toml:"issuer,omitempty"`
+	// Subject is the assertion subject (sub) claim. Defaults to Issuer.
+	Subject string `json:"subject,omitempty" toml:"subject,omitempty"`
+	// PrivateKeyPEM or PrivateKeyPath supply the signing key (required).
+	PrivateKeyPEM  string `json:"private_key_pem,omitempty" toml:"private_key_pem,omitempty"`
+	PrivateKeyPath string `json:"private_key_path,omitempty" toml:"private_key_path,omitempty"`
+	// SigningAlg is the JWS algorithm (RS256, ES256, ...). Empty = default for key.
+	SigningAlg string `json:"signing_alg,omitempty" toml:"signing_alg,omitempty"`
+	// Scopes requests specific OAuth scopes. Empty lets the AS decide.
+	Scopes []string `json:"scopes,omitempty" toml:"scopes,omitempty"`
 }

--- a/internal/mcpauth/types.go
+++ b/internal/mcpauth/types.go
@@ -1,0 +1,179 @@
+// Package mcpauth implements the MCP OAuth 2.0 authorization (2025-06-18 spec)
+// for remote MCP servers. It discovers protected-resource (RFC 9728) and
+// authorization-server (RFC 8414) metadata, runs the authorization-code + PKCE
+// flow (RFC 6749 / RFC 7636) with dynamic client registration (RFC 7591) when
+// the server requires it, and persists tokens so later sessions reuse them.
+//
+// The flow is triggered automatically: when a remote server rejects a request
+// with 401, the plugin transport asks a Client for a token. With no token
+// cached, the Client opens the user's browser to the server's authorization
+// endpoint and listens on a loopback redirect for the code. Tokens are stored
+// in a JSON file (0600) keyed by server origin.
+package mcpauth
+
+import (
+	"strings"
+	"time"
+)
+
+// refreshSkew is how long before expiry a token is considered stale so a refresh
+// can run before the server sees an expired token.
+const refreshSkew = 60 * time.Second
+
+// Token is an OAuth 2.0 access token plus the optional refresh token used to
+// renew it without another interactive authorization.
+type Token struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"` // "Bearer" when empty
+	Scope        string    `json:"scope,omitempty"`
+	Expiry       time.Time `json:"expiry,omitempty"` // absolute; zero = unknown
+}
+
+// Expired reports whether the access token should be treated as stale. A token
+// whose expiry is unknown (zero) is considered fresh until the server rejects
+// it; one within refreshSkew of expiry is treated as expired so a refresh runs
+// first.
+func (t Token) Expired() bool {
+	if t.AccessToken == "" {
+		return true
+	}
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return time.Now().After(t.Expiry.Add(-refreshSkew))
+}
+
+// headerValue renders the value for an "Authorization" header. It defaults to
+// the Bearer scheme when the server omits token_type.
+func (t Token) headerValue() string {
+	tt := strings.TrimSpace(t.TokenType)
+	if tt == "" {
+		tt = "Bearer"
+	}
+	return tt + " " + t.AccessToken
+}
+
+// ProtectedResourceMetadata is the RFC 9728 protected-resource metadata
+// document. MCP serves it from the server origin at
+// /.well-known/oauth-protected-resource, or advertises its URL in the
+// WWW-Authenticate header of a 401 response.
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	// BearerTokenFormatMethods is informational; ignored.
+}
+
+// AuthorizationServerMetadata is the RFC 8414 authorization-server metadata.
+// Only the fields Reasonix uses are decoded.
+type AuthorizationServerMetadata struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	RegistrationEndpoint          string   `json:"registration_endpoint,omitempty"`
+	RevocationEndpoint            string   `json:"revocation_endpoint,omitempty"`
+	ScopesSupported               []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+	// RequirePushedAuthorizationRequests, when true, mandates PAR (RFC 9126),
+	// which this client does not implement yet.
+	RequirePushedAuthorizationRequests bool `json:"require_pushed_authorization_requests,omitempty"`
+}
+
+// supportsAuthorizationCode reports whether the AS advertises (or omits, which
+// RFC 8414 treats as "all") the authorization_code grant and code response type.
+func (m *AuthorizationServerMetadata) supportsAuthorizationCode() bool {
+	if m == nil {
+		return true
+	}
+	if len(m.GrantTypesSupported) > 0 && !containsAny(m.GrantTypesSupported, "authorization_code") {
+		return false
+	}
+	if len(m.ResponseTypesSupported) > 0 && !containsAny(m.ResponseTypesSupported, "code") {
+		return false
+	}
+	return true
+}
+
+// supportsS256 reports whether the AS advertises PKCE S256 (or omits the list,
+// which we treat as permissive).
+func (m *AuthorizationServerMetadata) supportsS256() bool {
+	if m == nil || len(m.CodeChallengeMethodsSupported) == 0 {
+		return true
+	}
+	for _, method := range m.CodeChallengeMethodsSupported {
+		if strings.EqualFold(strings.TrimSpace(method), "S256") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(haystack []string, needles ...string) bool {
+	for _, h := range haystack {
+		lh := strings.ToLower(strings.TrimSpace(h))
+		for _, n := range needles {
+			if lh == strings.ToLower(strings.TrimSpace(n)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ClientRegistration is the result of RFC 7591 dynamic client registration.
+type ClientRegistration struct {
+	ClientID              string    `json:"client_id"`
+	ClientSecret          string    `json:"client_secret,omitempty"`
+	ClientIDIssuedAt      time.Time `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt time.Time `json:"client_secret_expires_at,omitempty"` // zero = never
+}
+
+// hasSecret reports whether this is a confidential client.
+func (r *ClientRegistration) hasSecret() bool {
+	return r != nil && strings.TrimSpace(r.ClientSecret) != ""
+}
+
+// ServerMetadata captures the discovered endpoints for one server so a later
+// refresh or re-authorization does not have to re-run discovery.
+type ServerMetadata struct {
+	ResourceURL       string                       `json:"resource_url"` // MCP server origin
+	ProtectedResource *ProtectedResourceMetadata   `json:"protected_resource,omitempty"`
+	AuthServer        *AuthorizationServerMetadata `json:"auth_server,omitempty"`
+}
+
+// StoredCredential bundles everything the client must remember for one server
+// origin to refresh or re-authorize without re-discovering metadata.
+type StoredCredential struct {
+	Token    Token               `json:"token"`
+	Server   *ServerMetadata     `json:"server,omitempty"`
+	Client   *ClientRegistration `json:"client,omitempty"`
+	IssuedAt time.Time           `json:"issued_at"`
+}
+
+// Config is the optional, user-facing OAuth configuration for one MCP server.
+// With no config the client auto-discovers via the 401 flow.
+type Config struct {
+	// ClientID overrides the public client id. When empty, the client performs
+	// dynamic client registration if the AS advertises a registration_endpoint;
+	// otherwise it uses a generated public client id.
+	ClientID string `json:"client_id,omitempty" toml:"client_id,omitempty"`
+	// ClientSecret pairs with ClientID for confidential clients. Leave empty
+	// for public PKCE clients.
+	ClientSecret string `json:"client_secret,omitempty" toml:"client_secret,omitempty"`
+	// Scopes requests specific OAuth scopes. Empty lets the AS decide.
+	Scopes []string `json:"scopes,omitempty" toml:"scopes,omitempty"`
+	// RedirectPort pins the loopback callback port. Zero picks a free port.
+	RedirectPort int `json:"redirect_port,omitempty" toml:"redirect_port,omitempty"`
+	// SkipBrowser prints the authorization URL instead of opening a browser
+	// (headless or CI).
+	SkipBrowser bool `json:"skip_browser,omitempty" toml:"skip_browser,omitempty"`
+	// SkipDynamicRegistration disables RFC 7591 registration even if the AS
+	// advertises a registration_endpoint.
+	SkipDynamicRegistration bool `json:"skip_dynamic_registration,omitempty" toml:"skip_dynamic_registration,omitempty"`
+	// TrustedOrigins authorizes metadata/issuer origins outside the MCP server
+	// origin. By default metadata must come from the server origin or its
+	// advertised auth server; this is an escape hatch for federated deployments.
+	TrustedOrigins []string `json:"trusted_origins,omitempty" toml:"trusted_origins,omitempty"`
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -91,6 +91,11 @@ type Spec struct {
 	// LaunchManager owns exact project launch grants and mutable launcher locks.
 	// It never contributes to SpecFingerprint or provider-visible tool schemas.
 	LaunchManager *mcplaunch.Manager
+	// Authorizer obtains and caches OAuth bearer tokens for a remote (http)
+	// server. It is host-injected, never part of SpecFingerprint, and used only
+	// by the HTTP transport: when a request gets a 401 the transport asks the
+	// authorizer for a token and retries once. Nil disables OAuth entirely.
+	Authorizer MCPAuthorizer
 	// ConfigSource disambiguates otherwise identical server names coming from
 	// workspace config, a host transport, or a verified plugin package.
 	ConfigSource           string
@@ -138,6 +143,25 @@ type transport interface {
 	call(ctx context.Context, method string, params any) (json.RawMessage, error)
 	notify(ctx context.Context, method string, params any) error
 	close()
+}
+
+// MCPAuthorizer obtains and caches OAuth bearer tokens for a remote MCP server.
+// It is host-injected (not part of SpecFingerprint) and used only by the HTTP
+// transport. When a request to an OAuth-protected server is rejected with 401,
+// the transport calls Authorize, then retries the request once with the token.
+//
+// The concrete implementation lives in internal/mcpauth; the interface keeps the
+// plugin package free of an import dependency on it.
+type MCPAuthorizer interface {
+	// CurrentToken returns a bearer-token Authorization-header value for
+	// serverURL if one is cached and usable (refreshing non-interactively when
+	// possible), or "" when no token can be obtained without user interaction.
+	// It must not run an interactive flow.
+	CurrentToken(serverURL string) string
+	// Authorize returns a bearer-token header value for serverURL, running the
+	// interactive authorization flow when no usable token is cached. The result
+	// is safe to send as an "Authorization" header (e.g. "Bearer xyz").
+	Authorize(ctx context.Context, serverName, serverURL string) (string, error)
 }
 
 // Host owns the running plugin connections and closes them together. It also

--- a/internal/plugin/transport_http.go
+++ b/internal/plugin/transport_http.go
@@ -32,6 +32,7 @@ type httpTransport struct {
 	url     string
 	headers map[string]string
 	client  *http.Client
+	auth    MCPAuthorizer // optional OAuth authorizer; nil disables token injection
 
 	mu      sync.Mutex
 	nextID  int
@@ -50,6 +51,7 @@ func newHTTPTransport(s Spec) (*httpTransport, error) {
 		name:    s.Name,
 		url:     s.URL,
 		headers: headers,
+		auth:    s.Authorizer,
 		client: &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) == 0 || sameHTTPOrigin(via[0].URL, req.URL) {
 				return nil
@@ -60,6 +62,16 @@ func newHTTPTransport(s Spec) (*httpTransport, error) {
 			return http.ErrUseLastResponse
 		}},
 	}, nil
+}
+
+// currentBearer returns a cached OAuth token for this server, or "" when no
+// authorizer is configured or no token is available. It never blocks on the
+// interactive flow.
+func (t *httpTransport) currentBearer() string {
+	if t.auth == nil {
+		return ""
+	}
+	return t.auth.CurrentToken(t.url)
 }
 
 func sameHTTPOrigin(a, b *url.URL) bool {
@@ -93,9 +105,29 @@ func (t *httpTransport) call(ctx context.Context, method string, params any) (js
 		return nil, err
 	}
 
-	resp, err := t.do(ctx, body)
+	bearer := t.currentBearer()
+	resp, err := t.do(ctx, body, bearer)
 	if err != nil {
 		return nil, fmt.Errorf("plugin %q: %s: %w", t.name, method, err)
+	}
+
+	// OAuth: a 401 means the server requires (or re-requires) authorization.
+	// Run the authorizer once and retry with the fresh token. The interactive
+	// flow runs under the transport lock; that is acceptable because the lock
+	// already serializes all calls to this one server, OAuth happens at most
+	// once (later calls reuse the cached token), and no part of the flow routes
+	// back through this transport.
+	if resp.StatusCode == http.StatusUnauthorized && t.auth != nil {
+		wwwAuthenticate := resp.Header.Get("WWW-Authenticate")
+		_ = resp.Body.Close()
+		token, authErr := t.auth.Authorize(ctx, t.name, t.url)
+		if authErr != nil || token == "" {
+			return nil, t.unauthorizedError(method, wwwAuthenticate, authErr)
+		}
+		resp, err = t.do(ctx, body, token)
+		if err != nil {
+			return nil, fmt.Errorf("plugin %q: %s: %w", t.name, method, err)
+		}
 	}
 	defer resp.Body.Close()
 	t.captureSession(resp)
@@ -110,6 +142,9 @@ func (t *httpTransport) call(ctx context.Context, method string, params any) (js
 				body:   msg,
 			})
 		}
+		if resp.StatusCode == http.StatusUnauthorized && t.auth != nil {
+			return nil, t.unauthorizedError(method, resp.Header.Get("WWW-Authenticate"), nil)
+		}
 		return nil, fmt.Errorf("plugin %q: %s: http %d: %s", t.name, method, resp.StatusCode, msg)
 	}
 
@@ -117,6 +152,20 @@ func (t *httpTransport) call(ctx context.Context, method string, params any) (js
 		return t.readSSEResponse(resp.Body, id)
 	}
 	return decodeRPCResult(resp.Body, t.name)
+}
+
+// unauthorizedError wraps a 401 with an actionable hint. When an authorizer is
+// configured but failed, the cause explains why; when the retry still 401s, the
+// user is told the token was rejected.
+func (t *httpTransport) unauthorizedError(method, wwwAuthenticate string, cause error) error {
+	hint := "server requires OAuth authorization"
+	if cause != nil {
+		return fmt.Errorf("plugin %q: %s: http 401: %s: %w", t.name, method, hint, cause)
+	}
+	if strings.TrimSpace(wwwAuthenticate) != "" {
+		return fmt.Errorf("plugin %q: %s: http 401: %s (token rejected; WWW-Authenticate: %s)", t.name, method, hint, wwwAuthenticate)
+	}
+	return fmt.Errorf("plugin %q: %s: http 401: %s (token rejected)", t.name, method, hint)
 }
 
 func (t *httpTransport) notify(ctx context.Context, method string, params any) error {
@@ -127,7 +176,7 @@ func (t *httpTransport) notify(ctx context.Context, method string, params any) e
 	if err != nil {
 		return err
 	}
-	resp, err := t.do(ctx, body)
+	resp, err := t.do(ctx, body, t.currentBearer())
 	if err != nil {
 		return fmt.Errorf("plugin %q: %s: %w", t.name, method, err)
 	}
@@ -145,8 +194,10 @@ func (t *httpTransport) close() {
 }
 
 // do POSTs one JSON-RPC body with the standard MCP headers, the configured
-// static headers, and the session id (once known). Caller holds t.mu.
-func (t *httpTransport) do(ctx context.Context, body []byte) (*http.Response, error) {
+// static headers, the session id (once known), and the OAuth bearer token (when
+// one is available). The bearer overrides any static "Authorization" header so
+// OAuth tokens win for OAuth-protected servers. Caller holds t.mu.
+func (t *httpTransport) do(ctx context.Context, body []byte, bearer string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -155,6 +206,9 @@ func (t *httpTransport) do(ctx context.Context, body []byte) (*http.Response, er
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	for k, v := range t.headers {
 		req.Header.Set(k, v)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", bearer)
 	}
 	if t.session != "" {
 		req.Header.Set("Mcp-Session-Id", t.session)

--- a/internal/plugin/transport_http_oauth_test.go
+++ b/internal/plugin/transport_http_oauth_test.go
@@ -1,0 +1,119 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeAuthorizer is a test MCPAuthorizer: CurrentToken returns nothing until
+// Authorize has been called, after which it serves the token.
+type fakeAuthorizer struct {
+	token      string
+	authCalled atomic.Int32
+}
+
+func (f *fakeAuthorizer) CurrentToken(_ string) string {
+	if f.authCalled.Load() > 0 {
+		return f.token
+	}
+	return ""
+}
+
+func (f *fakeAuthorizer) Authorize(context.Context, string, string) (string, error) {
+	f.authCalled.Add(1)
+	return f.token, nil
+}
+
+// TestHTTPTransportOAuthRetry verifies that a 401 triggers the authorizer and
+// the request is retried once with the returned bearer token.
+func TestHTTPTransportOAuthRetry(t *testing.T) {
+	var unauthorizedHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer SECRET" {
+			unauthorizedHits.Add(1)
+			w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://example/.well-known/oauth-protected-resource"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Minimal valid initialize response.
+		var req struct {
+			ID int `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(req.ID) + `,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"test","version":"1"}}}`))
+	}))
+	defer srv.Close()
+
+	auth := &fakeAuthorizer{token: "Bearer SECRET"}
+	transport, err := newHTTPTransport(Spec{Name: "oauth-srv", Type: "http", URL: srv.URL, Authorizer: auth})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+
+	res, err := transport.call(context.Background(), "initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "reasonix", "version": "test"},
+	})
+	if err != nil {
+		t.Fatalf("call after OAuth retry: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("expected a non-empty initialize result")
+	}
+	if auth.authCalled.Load() != 1 {
+		t.Fatalf("expected Authorize to be called once, got %d", auth.authCalled.Load())
+	}
+	if unauthorizedHits.Load() != 1 {
+		t.Fatalf("expected exactly one 401 (first attempt), got %d", unauthorizedHits.Load())
+	}
+}
+
+// TestHTTPTransportOAuthDisabledKeeps401 verifies that without an authorizer a
+// 401 surfaces as an error rather than triggering any flow.
+func TestHTTPTransportOAuthDisabledKeeps401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	transport, err := newHTTPTransport(Spec{Name: "noauth", Type: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.close()
+
+	if _, err := transport.call(context.Background(), "initialize", map[string]any{}); err == nil {
+		t.Fatal("expected an error for 401 with no authorizer")
+	}
+}
+
+// itoa is a tiny strconv-free int->string to keep the test dependency-light.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/plugin/transport_http_test.go
+++ b/internal/plugin/transport_http_test.go
@@ -148,7 +148,7 @@ func TestHTTPTransportDoesNotRedirectCredentialsAcrossOrigins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := transport.do(context.Background(), []byte(`{}`))
+	resp, err := transport.do(context.Background(), []byte(`{}`), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -179,6 +179,24 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # # Enabled MCP servers connect automatically in the background after session
 # # start. Use /mcp or the desktop MCP panel to refresh, reconnect, or disable.
 
+# Remote (Streamable HTTP) plugins. OAuth is handled automatically: on the first
+# 401 Reasonix discovers the server's authorization metadata, opens your browser
+# to sign in, and caches the token under ~/.reasonix/mcp-oauth-credentials.json.
+# No extra config is required for servers that support auto-discovery.
+# [[plugins]]
+# name = "remote"
+# type = "http"
+# url  = "https://mcp.example.com/mcp"
+# # Optional OAuth overrides (auto works with none of these):
+# # [plugins.oauth]
+# # client_id = "my-public-client"        # default: dynamic client registration
+# # client_secret = ""                    # only for confidential clients
+# # scopes = ["read", "write"]            # default: server-advertised scopes
+# # redirect_port = 8080                  # default: a free loopback port
+# # skip_browser = false                  # true prints the URL instead (headless/CI)
+# # skip_dynamic_registration = false     # true disables RFC 7591 DCR
+# # trusted_origins = []                  # allow metadata/AS origins beyond the server
+
 # Bot gateway: multi-channel IM bot for QQ, Feishu, and WeChat.
 # Start with `reasonix bot start --channels qq,feishu,weixin`.
 # All secrets are read from environment variables; never put keys here.

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -196,6 +196,14 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # # skip_browser = false                  # true prints the URL instead (headless/CI)
 # # skip_dynamic_registration = false     # true disables RFC 7591 DCR
 # # trusted_origins = []                  # allow metadata/AS origins beyond the server
+# # token_endpoint_auth_method = "none"  # none|client_secret_basic|client_secret_post|private_key_jwt|client_secret_jwt
+# # private_key_path = "/etc/svc.pem"    # RSA/EC/Ed25519 PEM for private_key_jwt
+# # client_assertion_signing_alg = "RS256" # JWS alg; empty = key-type default
+# # [plugins.oauth.jwt_bearer_grant]     # RFC 7523 JWT bearer grant (no browser)
+# # issuer = "service-account-1"
+# # private_key_path = "/etc/robot.pem"
+# # signing_alg = "RS256"
+# # scopes = ["tools:call"]
 
 # Bot gateway: multi-channel IM bot for QQ, Feishu, and WeChat.
 # Start with `reasonix bot start --channels qq,feishu,weixin`.


### PR DESCRIPTION
## Summary

Adds MCP OAuth 2.0 authorization (2025-06-18 spec) for remote (Streamable HTTP, `type = "http"`) MCP servers, so servers that require OAuth (e.g. Composio, Amplitude) connect without a manually rotated bearer token.

Authorization runs automatically the first time a server rejects a request with `401`:

1. Discover the server's protected-resource metadata (RFC 9728) and the linked authorization-server metadata (RFC 8414), with origin/integrity validation.
2. Register a public PKCE client via dynamic client registration (RFC 7591) when the server advertises it.
3. Run the authorization-code + PKCE (S256) flow: open the user's browser and listen on a loopback redirect for the code, validating the `state` CSRF token.
4. Exchange the code for a token and cache it (per server origin) in `~/.reasonix/mcp-oauth-credentials.json` (mode `0600`).
5. Refresh expired tokens non-interactively; a failed refresh re-runs the flow on the next `401`.

No new dependencies — the implementation uses only the Go standard library.

## New package `internal/mcpauth`

`types.go`, `pkce.go` (S256, RFC 7636 known-answer verified), `store.go` (atomic `0600` JSON store, origin-keyed, corrupt-file recovery), `discovery.go` (RFC 9728/8414 with origin validation), `dcr.go` (RFC 7591 + token-endpoint helpers), `flow.go` (loopback callback + auth-code flow + refresh), `client.go` (the `Client` orchestrator). 72.5% statement coverage; race-clean.

## Integration

- `plugin.MCPAuthorizer` interface + `Spec.Authorizer` (host-injected, excluded from `SpecFingerprint`). `httpTransport` injects the cached bearer on every request and retries once on `401` via `Authorize`.
- `config.MCPOAuthConfig` on `PluginEntry` (TOML `[[plugins]]` + `[plugins.oauth]`) and the `.mcp.json` `oauth` block. `ClearOAuthSecret` is wired into the clear-auth path so a confidential `client_secret` is never shared.
- `boot` constructs one shared, proxy-aware `mcpauth.Client` (notices routed through the event sink) and injects it into every remote server's `Spec`.

## Config example

```toml
[[plugins]]
name = "composio"
type = "http"
url  = "https://mcp.composio.dev/app/..."
# [plugins.oauth] is optional — auto-discovery works with nothing set
```

Full docs in `docs/MCP_OAUTH.md`.

## Verification

- `go build ./...` clean
- `golangci-lint run ./...` → 0 issues (CI version v2.12.2)
- `go test ./...` → all packages pass; new tests cover PKCE, store, discovery, full end-to-end flow via httptest (auth-code, cached reuse, refresh, CSRF), config round-trip, transport 401-retry, and boot wiring
- `gofmt` clean

## Security notes

- Origin validation on both protected-resource and authorization-server metadata (resource/issuer must match the URL it was fetched from, unless explicitly trusted).
- PKCE S256 + random `state` CSRF token validated on the callback.
- Loopback-only callback (`127.0.0.1`); configured `Authorization` header is never sent across an origin redirect.
- Tokens stored in a `0600` file, written atomically; no token values appear in logs or errors.

## Cache review

- Cache-impact: none — `Spec.Authorizer` is host-injected and intentionally excluded from `SpecFingerprint` (the tool-schema cache key). The provider-visible system prompt, memory prefix, output styles, skill index, and tool schemas are unchanged.
- Cache-guard: `SpecFingerprint` (internal/plugin/cache.go) hashes only stable identity fields (name/type/url/args/env/headers/read-only tools); existing fingerprint/cache tests cover this. New behavior is additive and behind the authorizer interface.

## Checklist

- [x] Branch off `main-v2`
- [x] `gofmt` clean
- [x] `go test ./...` passes
- [x] `golangci-lint` clean
- [x] Docs updated (`reasonix.example.toml`, `docs/MCP_OAUTH.md`)
