### PR TITLE
fix(desktop): harden auto-update recovery / 加固桌面端自动更新恢复链路

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -14,7 +14,8 @@
     "test:remote": "tsx src/__tests__/remote-store.test.ts && tsx src/__tests__/remote-error-ux.test.tsx && tsx src/__tests__/remote-hosts-page.test.tsx && tsx src/__tests__/remote-secret-dialog.test.tsx",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test:delivery-worktree": "tsx src/__tests__/delivery-worktree.test.ts",
-    "test:all": "pnpm test:typecheck && pnpm test && pnpm test:remote"
+    "test:updater": "tsx src/__tests__/updater-shared-state.test.tsx",
+    "test:all": "pnpm test:typecheck && pnpm test:updater && pnpm test && pnpm test:remote"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -60,6 +60,7 @@ import { onRemoteStatus, onRemoteForwards, onRemoteServer } from "./lib/bridge";
 import { RemoteConnectionTimeoutError, useRemoteStore, waitForRemoteConnection } from "./store/remote";
 import { CommandPalette, type PaletteItem } from "./components/CommandPalette";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { UpdaterProvider } from "./lib/useUpdater";
 import { ContextPanel } from "./components/ContextPanel";
 import { WorkspacePanel } from "./components/WorkspacePanel";
 import { Tooltip } from "./components/Tooltip";
@@ -3543,6 +3544,7 @@ export default function App() {
 
   return (
     <ShellExpandProvider>
+    <UpdaterProvider>
     <ShellHotkeys />
     <TextSizeHotkeys />
       <div
@@ -4527,6 +4529,7 @@ export default function App() {
         />
       )}
     </div>
+    </UpdaterProvider>
     </ShellExpandProvider>
   );
 }

--- a/desktop/frontend/src/__tests__/updater-shared-state.test.tsx
+++ b/desktop/frontend/src/__tests__/updater-shared-state.test.tsx
@@ -1,0 +1,69 @@
+// Run: tsx src/__tests__/updater-shared-state.test.tsx
+
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { UpdaterProvider, useUpdater } from "../lib/useUpdater";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function Consumer({ id, checking = false }: { id: string; checking?: boolean }) {
+  const updater = useUpdater();
+  return (
+    <section>
+      <output id={`${id}-status`}>{updater.status.kind}</output>
+      {checking && <button id="check-update" type="button" onClick={() => void updater.check()}>Check</button>}
+    </section>
+  );
+}
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+globalThis.Node = dom.window.Node;
+globalThis.Element = dom.window.Element;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.MouseEvent = dom.window.MouseEvent;
+
+const root = createRoot(document.getElementById("root")!);
+await act(async () => {
+  root.render(
+    <UpdaterProvider>
+      <Consumer id="banner" checking />
+      <Consumer id="settings" />
+    </UpdaterProvider>,
+  );
+});
+
+ok(document.getElementById("banner-status")?.textContent === "idle", "banner starts idle");
+ok(document.getElementById("settings-status")?.textContent === "idle", "settings starts idle");
+
+await act(async () => {
+  (document.getElementById("check-update") as HTMLButtonElement).click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+ok(document.getElementById("banner-status")?.textContent === "upToDate", "banner receives the check result");
+ok(document.getElementById("settings-status")?.textContent === "upToDate", "settings receives the same check result");
+
+await act(async () => root.unmount());
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/useUpdater.ts
+++ b/desktop/frontend/src/lib/useUpdater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { createContext, createElement, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import { app, onUpdaterProgress } from "./bridge";
 import type { UpdateInfo } from "./types";
 
@@ -30,7 +30,9 @@ function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
-export function useUpdater(): Updater {
+const UpdaterContext = createContext<Updater | null>(null);
+
+function useUpdaterInternal(): Updater {
   const [status, setStatus] = useState<UpdateStatus>({ kind: "idle" });
 
   // A single long-lived subscription advances the state machine through the apply
@@ -107,4 +109,15 @@ export function useUpdater(): Updater {
   const reset = useCallback(() => setStatus({ kind: "idle" }), []);
 
   return { status, check, download, install, openDownload, reset };
+}
+
+export function UpdaterProvider({ children }: { children: ReactNode }) {
+  const updater = useUpdaterInternal();
+  return createElement(UpdaterContext.Provider, { value: updater, children });
+}
+
+export function useUpdater(): Updater {
+  const updater = useContext(UpdaterContext);
+  if (!updater) throw new Error("useUpdater must be used within an UpdaterProvider");
+  return updater;
 }

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -41,11 +41,14 @@ import (
 // avoids GitHub's repository-wide /releases/latest shortcut so the app is not
 // coupled to GitHub's homepage badge semantics.
 const (
-	r2Base             = "https://dl.reasonix.io"
-	releaseGatewayBase = "https://crash.reasonix.io/v1/desktop/releases"
-	downloadPageURL    = "https://reasonix.io/?download=desktop#start"
-	httpTimeout        = 15 * time.Second
+	r2Base                  = "https://dl.reasonix.io"
+	releaseGatewayBase      = "https://crash.reasonix.io/v1/desktop/releases"
+	downloadPageURL         = "https://reasonix.io/?download=desktop#start"
+	httpTimeout             = 15 * time.Second
+	manifestEndpointTimeout = 5 * time.Second
 )
+
+var fetchAttemptTimeout = 5 * time.Second
 
 // githubManifestFallback is the stable channel's last-resort manifest source.
 // dl.reasonix.io and crash.reasonix.io share one Cloudflare zone, so bot
@@ -171,10 +174,12 @@ func normalizeVersion(v string) (string, bool) {
 // responds and decodes. Every endpoint's failure is kept — a user staring at a
 // gateway 403 (#6005) needs to see that the R2 pointer failed too, not just
 // whichever endpoint happened to die last.
-func fetchManifest(ctx context.Context, c *http.Client) (*update.Manifest, error) {
+func fetchManifest(ctx context.Context, c, fallback *http.Client) (*update.Manifest, error) {
 	var errs []error
 	for _, url := range manifestEndpoints() {
-		b, err := fetchBytes(ctx, c, url)
+		endpointCtx, cancel := context.WithTimeout(ctx, manifestEndpointTimeout)
+		b, err := fetchManifestBytes(endpointCtx, c, fallback, url)
+		cancel()
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -187,6 +192,26 @@ func fetchManifest(ctx context.Context, c *http.Client) (*update.Manifest, error
 		return &m, nil
 	}
 	return nil, fmt.Errorf("update: fetch manifest: %w", errors.Join(errs...))
+}
+
+// fetchManifestBytes gives the default and IPv4 transports separate halves of
+// the endpoint budget. A stalled IPv6 dial must not consume the whole timeout
+// before the IPv4 fallback gets a chance to run (#6713).
+func fetchManifestBytes(ctx context.Context, c, fallback *http.Client, url string) ([]byte, error) {
+	attemptTimeout := manifestEndpointTimeout / 2
+	attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+	data, err := fetchBytesOnce(attemptCtx, c, url)
+	cancel()
+	if err == nil || !isTransientFetchError(err) || fallback == nil {
+		return data, err
+	}
+	attemptCtx, cancel = context.WithTimeout(ctx, attemptTimeout)
+	fallbackData, fallbackErr := fetchBytesOnce(attemptCtx, fallback, url)
+	cancel()
+	if fallbackErr == nil {
+		return fallbackData, nil
+	}
+	return nil, errors.Join(err, fallbackErr)
 }
 
 // evaluate compares the running version against the manifest and builds the
@@ -423,6 +448,9 @@ func retryTransient(ctx context.Context, fetch func(attempt int) error) error {
 		if err = fetch(attempt); err == nil {
 			return nil
 		}
+		if !isTransientFetchError(err) {
+			break
+		}
 		if ctx.Err() != nil || attempt == downloadAttempts {
 			break
 		}
@@ -435,12 +463,41 @@ func retryTransient(ctx context.Context, fetch func(attempt int) error) error {
 	return err
 }
 
+type httpStatusError struct {
+	url    string
+	status string
+	code   int
+}
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("GET %s: %s", e.url, e.status) }
+
+func isTransientFetchError(err error) bool {
+	var statusErr *httpStatusError
+	if !errors.As(err, &statusErr) {
+		return true
+	}
+	return statusErr.code == http.StatusRequestTimeout || statusErr.code == http.StatusTooManyRequests || statusErr.code >= 500
+}
+
 // fetchBytes GETs a URL fully into memory, retrying transient transport failures.
 func fetchBytes(ctx context.Context, c *http.Client, url string) ([]byte, error) {
+	return fetchBytesFallback(ctx, c, nil, url)
+}
+
+// fetchBytesFallback retries transport failures with the IPv4-pinned client.
+// This covers small manifest/signature requests as well as the artifact body;
+// previously only the large artifact download escaped a broken IPv6 route.
+func fetchBytesFallback(ctx context.Context, c, fallback *http.Client, url string) ([]byte, error) {
 	var data []byte
-	err := retryTransient(ctx, func(int) error {
+	err := retryTransient(ctx, func(attempt int) error {
+		client := c
+		if attempt > 1 && fallback != nil {
+			client = fallback
+		}
 		var e error
-		data, e = fetchBytesOnce(ctx, c, url)
+		attemptCtx, cancel := context.WithTimeout(ctx, fetchAttemptTimeout)
+		data, e = fetchBytesOnce(attemptCtx, client, url)
+		cancel()
 		return e
 	})
 	return data, err
@@ -458,7 +515,7 @@ func fetchBytesOnce(ctx context.Context, c *http.Client, url string) ([]byte, er
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+		return nil, &httpStatusError{url: url, status: resp.Status, code: resp.StatusCode}
 	}
 	return io.ReadAll(resp.Body)
 }

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -41,7 +41,8 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 	}
 	ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
 	defer cancel()
-	m, err := fetchManifest(ctx, c)
+	v4, _ := httpClientIPv4()
+	m, err := fetchManifest(ctx, c, v4)
 	if err != nil {
 		a.recordUpdateError(err)
 		return &UpdateInfo{
@@ -65,7 +66,8 @@ func (a *App) OpenDownloadPage() {
 	if c, err := httpClient(); err == nil {
 		ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
 		defer cancel()
-		if m, err := fetchManifest(ctx, c); err == nil && m.DownloadPage != "" {
+		v4, _ := httpClientIPv4()
+		if m, err := fetchManifest(ctx, c, v4); err == nil && m.DownloadPage != "" {
 			page = m.DownloadPage
 		}
 	}
@@ -88,7 +90,8 @@ func (a *App) DownloadUpdate() (*UpdateDownloadResult, error) {
 	}
 	ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
 	defer cancel()
-	m, err := fetchManifest(ctx, c)
+	v4, _ := httpClientIPv4()
+	m, err := fetchManifest(ctx, c, v4)
 	if err != nil {
 		return nil, a.failUpdate(err)
 	}
@@ -202,7 +205,7 @@ func (a *App) downloadVerify(asset update.Asset) ([]byte, error) {
 		return nil, err
 	}
 	a.emitProgress("verifying", asset.Size, asset.Size, "")
-	sig, err := fetchBytes(a.reqCtx(), c, asset.Sig)
+	sig, err := fetchBytesFallback(a.reqCtx(), c, v4, asset.Sig)
 	if err != nil {
 		return nil, err
 	}

--- a/desktop/updater_mac.go
+++ b/desktop/updater_mac.go
@@ -46,32 +46,13 @@ func applyMac(zipPath, targetVersion string) error {
 	if _, err := repair.PrepareAppBundleUpdate(version, targetVersion, currentApp, backupApp); err != nil {
 		return err
 	}
+	cacheDir, err := updateCacheDir()
+	if err != nil {
+		_ = repair.CancelPendingUpdate(targetVersion)
+		return err
+	}
 	script := filepath.Join(staging, "install-reasonix-update.sh")
-	body := fmt.Sprintf(`#!/bin/sh
-set -eu
-old_app=%q
-new_app=%q
-backup_app=%q
-pending_update=%q
-sleep 1
-rm -rf "$backup_app"
-if ! mv "$old_app" "$backup_app"; then
-  rm -f "$pending_update"
-  rm -rf %q
-  exit 1
-fi
-if ditto "$new_app" "$old_app"; then
-  open "$old_app"
-  rm -rf %q
-  exit 0
-fi
-rm -rf "$old_app"
-mv "$backup_app" "$old_app"
-rm -f "$pending_update"
-open "$old_app"
-rm -rf %q
-exit 1
-`, currentApp, nextApp, backupApp, repair.PendingUpdatePath(), staging, staging, staging)
+	body := macUpdateScript(currentApp, nextApp, backupApp, repair.PendingUpdatePath(), staging, filepath.Join(cacheDir, "update-helper.log"), os.Getpid())
 	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
 		_ = repair.CancelPendingUpdate(targetVersion)
 		return err
@@ -82,6 +63,71 @@ exit 1
 	}
 	handedOff = true
 	return nil
+}
+
+func macUpdateScript(currentApp, nextApp, backupApp, pendingUpdate, staging, logPath string, oldPID int) string {
+	return fmt.Sprintf(`#!/bin/sh
+set -u
+old_app=%q
+new_app=%q
+backup_app=%q
+pending_update=%q
+staging=%q
+log_file=%q
+old_pid=%d
+exec >>"$log_file" 2>&1
+echo "macOS update handoff started for PID $old_pid"
+
+# The desktop starts this helper before it shuts itself down. Wait for that exact
+# process instead of sleeping for a fixed interval; LaunchServices can otherwise
+# keep the old bundle registered and refuse to launch the replacement (#5149).
+attempt=0
+while kill -0 "$old_pid" 2>/dev/null; do
+  if [ "$attempt" -ge 300 ]; then
+    echo "timed out waiting for PID $old_pid to exit"
+    rm -f "$pending_update"
+    rm -rf "$staging"
+    open "$old_app" >/dev/null 2>&1 || true
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 0.2
+done
+
+rollback() {
+  echo "rolling back macOS update"
+  rm -rf "$old_app"
+  if ! mv "$backup_app" "$old_app"; then
+    echo "failed to restore backup bundle"
+  fi
+  rm -f "$pending_update"
+  xattr -dr com.apple.quarantine "$old_app" 2>/dev/null || true
+  open -n "$old_app" >/dev/null 2>&1 || open "$old_app" >/dev/null 2>&1 || true
+  rm -rf "$staging"
+  exit 1
+}
+
+rm -rf "$backup_app"
+if ! mv "$old_app" "$backup_app"; then
+  echo "failed to move current app bundle to backup"
+  rm -f "$pending_update"
+  rm -rf "$staging"
+  open "$old_app" >/dev/null 2>&1 || true
+  exit 1
+fi
+if ! ditto "$new_app" "$old_app"; then
+  echo "failed to copy replacement app bundle"
+  rollback
+fi
+xattr -dr com.apple.quarantine "$old_app" 2>/dev/null || true
+if ! open -n "$old_app"; then
+  echo "LaunchServices rejected the replacement app bundle"
+  rollback
+fi
+echo "replacement app bundle launched"
+rm -rf "$staging"
+exit 0
+`, currentApp, nextApp, backupApp, pendingUpdate, staging, logPath, oldPID)
 }
 
 func currentMacAppBundle() (string, error) {

--- a/desktop/updater_mac_test.go
+++ b/desktop/updater_mac_test.go
@@ -1,0 +1,69 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMacUpdateScriptWaitsForExactProcessAndRollsBackLaunchFailure(t *testing.T) {
+	root := t.TempDir()
+	oldApp := filepath.Join(root, "Reasonix.app")
+	newApp := filepath.Join(root, "staging", "Reasonix.app")
+	backupApp := oldApp + ".reasonix-update-backup"
+	pending := filepath.Join(root, "pending.json")
+	logPath := filepath.Join(root, "update.log")
+	binDir := filepath.Join(root, "bin")
+	for _, dir := range []string{oldApp, newApp, binDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(oldApp, "marker"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newApp, "marker"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pending, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	openStub := filepath.Join(binDir, "open")
+	if err := os.WriteFile(openStub, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(root, "handoff.sh")
+	body := macUpdateScript(oldApp, newApp, backupApp, pending, filepath.Dir(newApp), logPath, 99999999)
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", script)
+	cmd.Env = append(os.Environ(), "PATH="+binDir+":/usr/bin:/bin")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("handoff should fail when LaunchServices rejects the replacement")
+	}
+
+	marker, err := os.ReadFile(filepath.Join(oldApp, "marker"))
+	if err != nil {
+		t.Fatalf("read restored marker: %v", err)
+	}
+	if string(marker) != "old" {
+		t.Fatalf("restored marker = %q, want old", marker)
+	}
+	if _, err := os.Stat(pending); !os.IsNotExist(err) {
+		t.Fatalf("pending transaction was not cleared: %v", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "PID 99999999") || !strings.Contains(logText, "rolling back") {
+		t.Fatalf("handoff log lacks PID/rollback diagnostics: %s", logText)
+	}
+}

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -441,6 +441,77 @@ func TestDownloadFallsBackToSecondClient(t *testing.T) {
 	}
 }
 
+func TestFetchBytesFallsBackToSecondClient(t *testing.T) {
+	fastRetry(t)
+	primary := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("read tcp [ipv6]: connection reset")
+	})}
+	fallback := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("manifest")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	data, err := fetchBytesFallback(context.Background(), primary, fallback, "https://example.invalid/latest.json")
+	if err != nil {
+		t.Fatalf("fetchBytesFallback: %v", err)
+	}
+	if string(data) != "manifest" {
+		t.Fatalf("got %q, want manifest", data)
+	}
+}
+
+func TestFetchBytesFallbackEscapesStalledPrimary(t *testing.T) {
+	fastRetry(t)
+	originalTimeout := fetchAttemptTimeout
+	fetchAttemptTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { fetchAttemptTimeout = originalTimeout })
+	primary := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})}
+	fallback := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("ipv4")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	data, err := fetchBytesFallback(context.Background(), primary, fallback, "https://example.invalid/latest.json")
+	if err != nil {
+		t.Fatalf("fetchBytesFallback: %v", err)
+	}
+	if string(data) != "ipv4" {
+		t.Fatalf("got %q, want ipv4", data)
+	}
+}
+
+func TestFetchBytesDoesNotRetryPermanentHTTPStatus(t *testing.T) {
+	fastRetry(t)
+	var calls int32
+	client := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader("forbidden")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	if _, err := fetchBytes(context.Background(), client, "https://example.invalid/latest.json"); err == nil {
+		t.Fatal("fetchBytes should return a permanent HTTP error")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("permanent HTTP error made %d requests, want 1", got)
+	}
+}
+
 type rtFunc func(*http.Request) (*http.Response, error)
 
 func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -3,11 +3,19 @@
 package main
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"debug/pe"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 const windowsUpdateHelperFileName = "reasonix-update-helper.exe"
@@ -40,9 +48,15 @@ func startWindowsUpdateHelper(installerPath, installDir, relaunchPath, toVersion
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(helperPath, windowsUpdateHandoffArgs(os.Getpid(), installerPath, installDir, relaunchPath, toVersion)...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	return cmd.Start()
+	err = retryWindowsUpdateHelperStart(func() error {
+		cmd := exec.Command(helperPath, windowsUpdateHandoffArgs(os.Getpid(), installerPath, installDir, relaunchPath, toVersion)...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		return cmd.Start()
+	})
+	if err != nil {
+		return windowsUpdateHelperStartError(err)
+	}
+	return nil
 }
 
 func prepareWindowsUpdateHelper(installDir string) (string, error) {
@@ -51,16 +65,100 @@ func prepareWindowsUpdateHelper(installDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := validateWindowsUpdateHelper(data, runtime.GOARCH); err != nil {
+		return "", fmt.Errorf("validate packaged Windows update helper: %w", err)
+	}
 	dir, err := updateCacheDir()
 	if err != nil {
 		return "", err
 	}
 	cleanupWindowsUpdateHelpers(dir)
 	dst := filepath.Join(dir, "reasonix-update-helper-"+time.Now().UTC().Format("20060102150405.000000000")+".exe")
-	if err := os.WriteFile(dst, data, 0o700); err != nil {
+	if err := writeAtomic(dst, data, 0o700); err != nil {
 		return "", err
 	}
+	copied, err := os.ReadFile(dst)
+	if err != nil {
+		return "", err
+	}
+	if sha256.Sum256(copied) != sha256.Sum256(data) {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("copied Windows update helper failed integrity verification")
+	}
 	return dst, nil
+}
+
+func validateWindowsUpdateHelper(data []byte, goarch string) error {
+	f, err := pe.NewFile(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("invalid PE image: %w", err)
+	}
+	defer f.Close()
+	want, ok := windowsPEMachine(goarch)
+	if !ok {
+		return fmt.Errorf("unsupported Windows architecture %q", goarch)
+	}
+	if f.FileHeader.Machine != want {
+		return fmt.Errorf("PE machine 0x%x does not match %s", f.FileHeader.Machine, goarch)
+	}
+	return nil
+}
+
+func windowsPEMachine(goarch string) (uint16, bool) {
+	switch goarch {
+	case "amd64":
+		return pe.IMAGE_FILE_MACHINE_AMD64, true
+	case "arm64":
+		return pe.IMAGE_FILE_MACHINE_ARM64, true
+	case "386":
+		return pe.IMAGE_FILE_MACHINE_I386, true
+	default:
+		return 0, false
+	}
+}
+
+const windowsHelperStartAttempts = 3
+
+var windowsHelperStartBackoff = func(attempt int) time.Duration {
+	return time.Duration(attempt) * 250 * time.Millisecond
+}
+
+func retryWindowsUpdateHelperStart(start func() error) error {
+	var err error
+	for attempt := 1; attempt <= windowsHelperStartAttempts; attempt++ {
+		if err = start(); err == nil {
+			return nil
+		}
+		if !isRetryableWindowsHelperStartError(err) || attempt == windowsHelperStartAttempts {
+			break
+		}
+		time.Sleep(windowsHelperStartBackoff(attempt))
+	}
+	return err
+}
+
+func isRetryableWindowsHelperStartError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}
+
+func windowsUpdateHelperStartError(err error) error {
+	switch {
+	case errors.Is(err, windows.ERROR_FILE_NOT_FOUND), errors.Is(err, windows.ERROR_PATH_NOT_FOUND):
+		return fmt.Errorf("start Windows update helper: the helper disappeared after verification; security software may have quarantined it")
+	case errors.Is(err, windows.ERROR_BAD_EXE_FORMAT):
+		return fmt.Errorf("start Windows update helper: Windows rejected the helper as corrupt or incompatible")
+	case errors.Is(err, windows.ERROR_ELEVATION_REQUIRED):
+		return fmt.Errorf("start Windows update helper: Windows unexpectedly requested administrator elevation")
+	case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+		return fmt.Errorf("start Windows update helper: Windows or security software denied process creation")
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return fmt.Errorf("start Windows update helper: Windows error %d (%s)", errno, errno.Error())
+	}
+	return fmt.Errorf("start Windows update helper: process creation failed")
 }
 
 func cleanupWindowsUpdateHelpers(dir string) {

--- a/desktop/updater_windows_test.go
+++ b/desktop/updater_windows_test.go
@@ -2,7 +2,15 @@
 
 package main
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
 
 func TestInstallerCommandShowsUpdateProgressAndPassesUnquotedDFlagLast(t *testing.T) {
 	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, `D:\Tools\Reasonix App`)
@@ -28,5 +36,54 @@ func TestInstallerCommandWithoutDirSkipsDFlag(t *testing.T) {
 	want := `"C:\Temp\reasonix-update-1.exe" /REASONIXUPDATE=1`
 	if got != want {
 		t.Fatalf("CmdLine = %q, want %q", got, want)
+	}
+}
+
+func TestWindowsHelperStartRetriesTransientSecurityScan(t *testing.T) {
+	originalBackoff := windowsHelperStartBackoff
+	windowsHelperStartBackoff = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { windowsHelperStartBackoff = originalBackoff })
+
+	calls := 0
+	err := retryWindowsUpdateHelperStart(func() error {
+		calls++
+		if calls < 3 {
+			return &os.PathError{Op: "fork/exec", Path: `C:\private\helper.exe`, Err: windows.ERROR_SHARING_VIOLATION}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryWindowsUpdateHelperStart: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("start calls = %d, want 3", calls)
+	}
+}
+
+func TestWindowsHelperStartErrorIsActionableAndPathSafe(t *testing.T) {
+	raw := &os.PathError{Op: "fork/exec", Path: `C:\Users\Private\helper.exe`, Err: windows.ERROR_ACCESS_DENIED}
+	err := windowsUpdateHelperStartError(raw)
+	if !strings.Contains(err.Error(), "security software") {
+		t.Fatalf("error is not actionable: %v", err)
+	}
+	if strings.Contains(err.Error(), `C:\Users`) {
+		t.Fatalf("error leaks local path: %v", err)
+	}
+	if !errors.Is(raw, windows.ERROR_ACCESS_DENIED) {
+		t.Fatal("test setup does not expose the wrapped Windows error")
+	}
+}
+
+func TestWindowsPEMachineMatchesSupportedArchitectures(t *testing.T) {
+	for _, arch := range []string{"amd64", "arm64", "386"} {
+		if machine, ok := windowsPEMachine(arch); !ok || machine == 0 {
+			t.Fatalf("windowsPEMachine(%q) = (0x%x, %v)", arch, machine, ok)
+		}
+	}
+	if _, ok := windowsPEMachine("mips"); ok {
+		t.Fatal("unsupported architecture was accepted")
+	}
+	if err := validateWindowsUpdateHelper([]byte("not a PE image"), "amd64"); err == nil {
+		t.Fatal("malformed helper image was accepted")
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes the updater failures reported in #6596, #6713, and #5149 across the shared frontend state, network transport, and platform handoff layers.

- Shares one updater state machine between the startup banner and Settings, so a background check cannot simultaneously show an error in one surface and “up to date” in another.
- Gives manifest and signature requests bounded attempts and an IPv4 fallback, while avoiding pointless retries for permanent HTTP errors.
- Replaces macOS's fixed one-second delay with an exact parent-PID wait, persistent handoff logging, quarantine cleanup, and rollback when the replacement cannot be launched.
- Atomically copies and verifies the Windows helper's PE image, architecture, and bytes; retries transient security-software locks; and returns actionable errors without exposing local paths.

Fixes #6596
Fixes #6713
Fixes #5149

## User impact

Windows installation remains visible as introduced by #6751; only the handoff helper stays hidden. macOS self-update remains limited to signed and notarized builds. Linux behavior is unchanged.

Existing installations whose old helper already cannot start still need one manual update to reach a release containing this fix. After that, future handoffs gain the validation, retry, and diagnostics added here.

## Source integration and credit

| Source | Contributor | Decision |
| --- | --- | --- |
| #6009 | @HaoyueQin | Adapted the shared `UpdaterProvider` design onto current `main-v2`, replacing the static contract test with a rendered two-consumer state-sharing regression test. |
| [`b51f26e`](https://github.com/ttmouse/DeepSeek-Reasonix/commit/b51f26ef4cdbe8e2543498578bc9bc599a1bf7c2) | @ttmouse | Adapted the process-exit wait, then narrowed it to the exact parent PID and added timeout cleanup, logging, relaunch verification, and rollback. |

Both contributors are also credited with `Co-authored-by` trailers on the commits that adapt their work.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `cd desktop/frontend && pnpm test:all`
- `cd desktop/frontend && pnpm build`
- Windows amd64 and arm64 test binaries cross-compiled successfully.
- Parallels Desktop Windows 11 ARM64: all five targeted Windows updater tests passed.
- Parallels Desktop Windows 11 ARM64, ordinary user session: the release-stamped `asInvoker` update helper started without UAC and returned the expected exit code for missing arguments.
- macOS handoff regression test executes the generated shell script and verifies rollback, pending-transaction cleanup, and path-safe diagnostics when relaunch fails.

## Compatibility

| Area | Result |
| --- | --- |
| Windows | Visible NSIS update flow retained; helper handoff hardened. |
| macOS | Signed/notarized automatic update retained; relaunch race and rollback handling fixed. |
| Linux | No behavior change. |
| Stable/canary channels | Existing endpoint selection retained; both gain bounded IPv4 fallback. |

## Cache impact

Cache-impact: none. The change is confined to the desktop updater and frontend state management; it does not modify system prompts, tool schemas, skill indexes, memory prefixes, or other cache-sensitive agent paths.

Cache-guard: updater transport/unit tests, the rendered shared-state regression test, macOS handoff execution test, Windows helper tests, and the existing full desktop/frontend suites.

System-prompt-review: not required.

---

## 中文概述

本 PR 统一了更新横幅与设置页的状态，补充更新清单/签名请求的 IPv4 回退，修复 macOS 旧进程尚未退出就替换并拉起应用的竞态，同时为 Windows 更新 helper 增加 PE/架构/完整性校验、短暂安全软件锁定重试和可操作错误提示。Windows 安装器仍保持非静默、可见进度的交互。
