### PR TITLE
fix(rewind): restore code immediately on "both" scope, warn on empty snapshots / 修复回滚代码和对话时代码未恢复，空快照时添加警告通知

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2863,7 +2863,9 @@ export default function App() {
       }
       setRewindSignal((v) => v + 1);
       if (rs.scope === "both") {
-        // Code was only reverted now (deferred), so refresh the dock here.
+        // When "both" arrives via /rewind or the Go API (not the UI flow,
+        // which splits code/conversation), code was reverted inside Rewind
+        // and the dock needs a refresh here.
         setDockRefreshKey((v) => v + 1);
         setProjectRevision((v) => v + 1);
       }
@@ -2890,7 +2892,7 @@ export default function App() {
   }, [controllerReady, recoverDeliveryToTab, resumeControllerGoalForTab, state.meta?.goal, t]);
   commitThenSendRef.current = commitThenSend;
 
-  const handleMessageAction = useCallback((turn: number, scope: string) => {
+  const handleMessageAction = useCallback(async (turn: number, scope: string) => {
     const sourceTabId = activeTabId;
     if (!sourceTabId || activeTab?.readOnly) return;
     if (hydratePlaceholderActive) return;
@@ -2913,6 +2915,19 @@ export default function App() {
         setProjectRevision((v) => v + 1);
       });
       return;
+    }
+
+    // "both" rewinds code AND conversation. Execute the code revert immediately
+    // so checkpoint state is still current — the delayed commitThenSend path would
+    // otherwise race with background autosaves that may shift checkpoint boundaries
+    // (#6674). Only proceed with the optimistic conversation truncation when the
+    // code revert succeeds; otherwise abort so the user can retry.
+    if (scope === "both") {
+      const ok = await rewindForTab(sourceTabId, turn, "code");
+      if (!ok) return;
+      setDockRefreshKey((v) => v + 1);
+      setProjectRevision((v) => v + 1);
+      scope = "conversation"; // fall through to optimistic conversation rewind below
     }
 
     // Summarize only compresses the conversation log — no files touched,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2757,6 +2757,9 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 		if len(written) > 0 || len(deleted) > 0 {
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 				Text: fmt.Sprintf("rewound code to turn %d — %d file(s) restored, %d removed", turn, len(written), len(deleted))})
+		} else {
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: fmt.Sprintf("rewound code to turn %d: no file snapshots found — code was not restored", turn)})
 		}
 	}
 	if scope == RewindConversation || scope == RewindBoth {


### PR DESCRIPTION
### Background

Closes #6674

When choosing "rewind code + conversation" (scope=`"both"`), the desktop frontend treats it as a conversation variant and takes the optimistic UI path: the conversation is truncated in the UI immediately, while the actual Go `Rewind` call is deferred until the user sends the next message (`commitThenSend`). During that window, checkpoint snapshots may drift due to background autosaves or compaction, causing `RestoreCode` to return empty — the conversation is truncated but code is silently left unchanged. In contrast, "code only" (scope=`"code"`) executes immediately and is not affected.

### Solution

**Frontend**: In `handleMessageAction`, when scope is `"both"`, **immediately** invoke `rewindForTab(turn, "code")` to revert code while checkpoint state is still current, then mutate scope to `"conversation"` to fall through to the existing optimistic conversation truncation. The `rs.scope === "both"` guard in `commitThenSend` naturally skips, avoiding duplicate dock refresh or redundant code restore.

**Backend**: When `RestoreCode` returns zero written or deleted files in `Rewind`, emit a `LevelWarn` notice so the user knows the code was not restored, replacing the prior silent no-op.

### Core Changes

| File | Change |
|:--:|:--:|
| `desktop/frontend/src/App.tsx` | Add immediate code revert for `scope="both"` before optimistic path (+14 lines) |
| `internal/control/controller.go` | Emit `LevelWarn` notice when `RestoreCode` returns empty (+3 lines) |

### Testing

go test ./internal/checkpoint/ PASS (12 tests) go test ./internal/control/ PASS (incl. RewindConversation* e2e) go test ./internal/serve/ PASS go vet ./internal/... PASS gofmt PASS (modified files clean)


### Impact

| Component | Change |
|:--:|:--:|
| `App.tsx` `handleMessageAction` | "both" branch executes code revert immediately, then falls through to optimistic conversation truncation |
| `controller.go` `Rewind` | Emits `LevelWarn` notice on empty snapshots (was silent no-op) |
| Not affected | `RewindCode` path, `RewindConversation` path, `commitThenSend`, checkpoint store, serve layer, CLI rewind |

**Risk: Low.** The frontend change follows the existing fire-and-forget pattern of the `scope="code"` branch. The backend change is purely observational. Existing `rewind_e2e_test.go` `RewindBoth` tests do not depend on notice text.