### PR TITLE
fix(todo): add canonical todo state to MetaForTab so frontend reads authoritative server-side state / 修复待办面板状态：MetaForTab 传规范待办状态

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5879,7 +5879,8 @@ type Meta struct {
 	TokenMode         string                   `json:"tokenMode"`
 	Goal              string                   `json:"goal,omitempty"`
 	GoalStatus        string                   `json:"goalStatus,omitempty"`
-	AutoResearch      *AutoResearchCompactView `json:"autoResearch,omitempty"`
+	AutoResearch      *AutoResearchCompactView  `json:"autoResearch,omitempty"`
+	CanonicalTodos    []evidence.TodoItem        `json:"canonicalTodos,omitempty"`
 }
 
 type AutoResearchCompactView struct {
@@ -6007,6 +6008,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 		Goal:              goal,
 		GoalStatus:        goalStatus,
 		AutoResearch:      compactAutoResearchFromController(snap.ctrl),
+		CanonicalTodos:    ctrlTodos(snap.ctrl),
 	}
 }
 
@@ -6014,6 +6016,7 @@ func compactAutoResearchFromController(ctrl control.SessionAPI) *AutoResearchCom
 	if ctrl == nil {
 		return nil
 	}
+
 	summary, ok := ctrl.AutoResearchSummary()
 	if !ok || summary == nil || summary.TaskID == "" {
 		return nil
@@ -6025,6 +6028,16 @@ func compactAutoResearchFromController(ctrl control.SessionAPI) *AutoResearchCom
 		PivotRequired: summary.PivotRequired,
 		StaleCount:    summary.StaleCount,
 	}
+}
+
+// ctrlTodos returns the canonical task list from a session controller, or nil
+// if the controller is not yet bound. Used by MetaForTab so the frontend
+// task panel has access to the authoritative server-side todo state.
+func ctrlTodos(ctrl control.SessionAPI) []evidence.TodoItem {
+	if ctrl == nil {
+		return nil
+	}
+	return ctrl.Todos()
 }
 
 func compactAutoResearch(tab *WorkspaceTab) *AutoResearchCompactView {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5880,7 +5880,9 @@ type Meta struct {
 	Goal              string                   `json:"goal,omitempty"`
 	GoalStatus        string                   `json:"goalStatus,omitempty"`
 	AutoResearch      *AutoResearchCompactView `json:"autoResearch,omitempty"`
-	CanonicalTodos    []evidence.TodoItem      `json:"canonicalTodos,omitempty"`
+	// A nil pointer means the controller cannot provide an authoritative snapshot;
+	// a non-nil pointer preserves an empty list as an explicit panel clear.
+	CanonicalTodos *[]evidence.TodoItem `json:"canonicalTodos,omitempty"`
 }
 
 type AutoResearchCompactView struct {
@@ -6033,11 +6035,15 @@ func compactAutoResearchFromController(ctrl control.SessionAPI) *AutoResearchCom
 // ctrlTodos returns the canonical task list from a session controller, or nil
 // if the controller is not yet bound. Used by MetaForTab so the frontend
 // task panel has access to the authoritative server-side todo state.
-func ctrlTodos(ctrl control.SessionAPI) []evidence.TodoItem {
+func ctrlTodos(ctrl control.SessionAPI) *[]evidence.TodoItem {
 	if ctrl == nil {
 		return nil
 	}
-	return ctrl.Todos()
+	todos := ctrl.Todos()
+	if todos == nil {
+		todos = []evidence.TodoItem{}
+	}
+	return &todos
 }
 
 func compactAutoResearch(tab *WorkspaceTab) *AutoResearchCompactView {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5880,7 +5880,7 @@ type Meta struct {
 	Goal              string                   `json:"goal,omitempty"`
 	GoalStatus        string                   `json:"goalStatus,omitempty"`
 	AutoResearch      *AutoResearchCompactView `json:"autoResearch,omitempty"`
-	CanonicalTodos    []evidence.TodoItem       `json:"canonicalTodos,omitempty"`
+	CanonicalTodos    []evidence.TodoItem      `json:"canonicalTodos,omitempty"`
 }
 
 type AutoResearchCompactView struct {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5879,8 +5879,8 @@ type Meta struct {
 	TokenMode         string                   `json:"tokenMode"`
 	Goal              string                   `json:"goal,omitempty"`
 	GoalStatus        string                   `json:"goalStatus,omitempty"`
-	AutoResearch      *AutoResearchCompactView  `json:"autoResearch,omitempty"`
-	CanonicalTodos    []evidence.TodoItem        `json:"canonicalTodos,omitempty"`
+	AutoResearch      *AutoResearchCompactView `json:"autoResearch,omitempty"`
+	CanonicalTodos    []evidence.TodoItem       `json:"canonicalTodos,omitempty"`
 }
 
 type AutoResearchCompactView struct {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -27,6 +27,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 	"reasonix/internal/mcplaunch"
 	"reasonix/internal/memory"
@@ -38,6 +39,44 @@ import (
 	"reasonix/internal/store"
 	"reasonix/internal/tool"
 )
+
+type todoMetaController struct {
+	control.SessionAPI
+	todos []evidence.TodoItem
+}
+
+func (c *todoMetaController) Todos() []evidence.TodoItem {
+	return append([]evidence.TodoItem(nil), c.todos...)
+}
+
+func TestCanonicalTodosMetaWireContract(t *testing.T) {
+	if got := ctrlTodos(nil); got != nil {
+		t.Fatalf("nil controller todos = %+v, want unavailable", *got)
+	}
+
+	empty := Meta{CanonicalTodos: ctrlTodos(&todoMetaController{})}
+	raw, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("marshal empty canonical todos: %v", err)
+	}
+	if !strings.Contains(string(raw), `"canonicalTodos":[]`) {
+		t.Fatalf("empty canonical todos must encode as an authoritative empty array: %s", raw)
+	}
+
+	ctrl := &todoMetaController{todos: []evidence.TodoItem{{Content: "Ship", Status: "completed"}}}
+	got := ctrlTodos(ctrl)
+	if got == nil || len(*got) != 1 || (*got)[0].Status != "completed" {
+		t.Fatalf("canonical todos = %+v, want completed task", got)
+	}
+
+	unavailable, err := json.Marshal(Meta{CanonicalTodos: ctrlTodos(nil)})
+	if err != nil {
+		t.Fatalf("marshal unavailable canonical todos: %v", err)
+	}
+	if strings.Contains(string(unavailable), "canonicalTodos") {
+		t.Fatalf("unavailable canonical todos should preserve the legacy fallback contract: %s", unavailable)
+	}
+}
 
 func TestPluginToolsToViewPreservesSchemaError(t *testing.T) {
 	got := pluginToolsToView([]plugin.ToolInfo{{

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -18,6 +18,8 @@ const transpiled = ts.transpileModule(source, {
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
 const {
   dismissedTodoKeyForScope,
+  resolveTodoPanelTodos,
+  sameTodoList,
   scopedTodoBatchKey,
   scopedTodoDismissalKey,
   shouldOpenTodoPanelByDefault,
@@ -35,6 +37,27 @@ const activeTodos = [
   { content: "Inspect the report", status: "in_progress" },
   { content: "Ship the fix", status: "pending" },
 ];
+
+assert.deepEqual(
+  resolveTodoPanelTodos([], activeTodos),
+  [],
+  "an authoritative empty canonical list clears the transcript fallback",
+);
+assert.deepEqual(
+  resolveTodoPanelTodos(undefined, activeTodos),
+  activeTodos,
+  "an unavailable canonical list falls back to the transcript snapshot",
+);
+assert.equal(
+  sameTodoList(activeTodos, activeTodos.map((todo) => ({ ...todo }))),
+  true,
+  "equivalent canonical lists do not churn meta state",
+);
+assert.equal(
+  sameTodoList(activeTodos, [{ ...activeTodos[0], status: "completed" }, activeTodos[1]]),
+  false,
+  "canonical status changes invalidate meta state",
+);
 
 assert.equal(
   shouldShowTodoPanel("todo-final", null, completedTodos),

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1865,7 +1865,11 @@ export default function App() {
     return null;
   }, [state.items]);
   const todoItem = todoEntry?.item ?? null;
-  const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
+  const metaTodos = state.meta?.canonicalTodos;
+  const todos = useMemo(() => {
+    if (metaTodos && metaTodos.length > 0) return metaTodos;
+    return todoItem ? parseTodos(todoItem.args) : [];
+  }, [metaTodos, todoItem]);
   const [dismissedTodoKeys, setDismissedTodoKeys] = useState<Set<string>>(loadDismissedTodoKeys);
   const todoKey = useMemo(() => todoDismissalKey(todos), [todos]);
   const todoBatch = useMemo(() => todoBatchKey(todos), [todos]);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -80,6 +80,7 @@ import { ExternalOpener } from "./components/ExternalOpener";
 import { parseTodos } from "./lib/tools";
 import {
   dismissedTodoKeyForScope,
+  resolveTodoPanelTodos,
   scopedTodoBatchKey,
   scopedTodoDismissalKey,
   shouldShowTodoPanel,
@@ -1866,10 +1867,10 @@ export default function App() {
   }, [state.items]);
   const todoItem = todoEntry?.item ?? null;
   const metaTodos = state.meta?.canonicalTodos;
-  const todos = useMemo(() => {
-    if (metaTodos && metaTodos.length > 0) return metaTodos;
-    return todoItem ? parseTodos(todoItem.args) : [];
-  }, [metaTodos, todoItem]);
+  const todos = useMemo(
+    () => resolveTodoPanelTodos(metaTodos, todoItem ? parseTodos(todoItem.args) : []),
+    [metaTodos, todoItem],
+  );
   const [dismissedTodoKeys, setDismissedTodoKeys] = useState<Set<string>>(loadDismissedTodoKeys);
   const todoKey = useMemo(() => todoDismissalKey(todos), [todos]);
   const todoBatch = useMemo(() => todoBatchKey(todos), [todos]);

--- a/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
+++ b/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
@@ -5,7 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { initialState, reducer, useController, type Item } from "../lib/useController";
 import type { AppBindings } from "../lib/bridge";
-import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta } from "../lib/types";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -139,8 +139,12 @@ globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.win
 globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
 
 const staleHistory = deferred<HistoryMessage[]>();
+const staleSessionMeta = deferred<Meta>();
 let newSessionCalls = 0;
 let backendCanonicalTodos = [{ content: "Old task", status: "in_progress" }];
+let holdNextMeta = false;
+let staleMetaStarted = false;
+const eventHandlers: Array<(event: WireEvent) => void> = [];
 const context: ContextInfo = { used: 12, window: 100, sessionTokens: 12 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 const balance: BalanceInfo = { available: false, display: "" };
@@ -148,14 +152,24 @@ const jobs: JobView[] = [];
 const checkpoints: CheckpointMeta[] = [];
 
 window.runtime = {
-  EventsOn: () => () => {},
+  EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(cb as (event: WireEvent) => void);
+    return () => {};
+  },
   BrowserOpenURL: () => {},
 };
 window.go = {
   main: {
     App: {
       ListTabs: async () => [tabMeta()],
-      MetaForTab: async () => meta({ canonicalTodos: backendCanonicalTodos }),
+      MetaForTab: async () => {
+        if (holdNextMeta) {
+          holdNextMeta = false;
+          staleMetaStarted = true;
+          return staleSessionMeta.promise;
+        }
+        return meta({ canonicalTodos: backendCanonicalTodos });
+      },
       ContextUsageForTab: async () => context,
       EffortForTab: async () => effort,
       BalanceForTab: async () => balance,
@@ -215,6 +229,13 @@ await act(async () => {
 });
 eq(controller?.state.meta?.canonicalTodos?.[0]?.content, "Old task", "pre-reset metadata exposes the current session todo");
 
+holdNextMeta = true;
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-a" });
+  await flushPromises();
+});
+await waitFor("stale metadata request", () => staleMetaStarted);
+
 await act(async () => {
   await controller?.newSession();
   await flushPromises();
@@ -222,6 +243,13 @@ await act(async () => {
 eq(newSessionCalls, 1, "tab-scoped NewSession is called once");
 eq(controller?.state.items.length, 0, "new session clears the visible transcript");
 eq(controller?.state.meta?.canonicalTodos?.length, 0, "new session refresh replaces the previous session todo with an authoritative empty list");
+
+await act(async () => {
+  staleSessionMeta.resolve(meta({ canonicalTodos: [{ content: "Old task", status: "in_progress" }] }));
+  await staleSessionMeta.promise;
+  await flushPromises();
+});
+eq(controller?.state.meta?.canonicalTodos?.length, 0, "metadata started before a session transition cannot restore the previous todo");
 
 await act(async () => {
   staleHistory.resolve([{ role: "user", content: "old prompt" }]);

--- a/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
+++ b/desktop/frontend/src/__tests__/new-session-load-race.test.tsx
@@ -140,6 +140,7 @@ globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.windo
 
 const staleHistory = deferred<HistoryMessage[]>();
 let newSessionCalls = 0;
+let backendCanonicalTodos = [{ content: "Old task", status: "in_progress" }];
 const context: ContextInfo = { used: 12, window: 100, sessionTokens: 12 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 const balance: BalanceInfo = { available: false, display: "" };
@@ -154,7 +155,7 @@ window.go = {
   main: {
     App: {
       ListTabs: async () => [tabMeta()],
-      MetaForTab: async () => meta(),
+      MetaForTab: async () => meta({ canonicalTodos: backendCanonicalTodos }),
       ContextUsageForTab: async () => context,
       EffortForTab: async () => effort,
       BalanceForTab: async () => balance,
@@ -169,10 +170,22 @@ window.go = {
       ReplayPendingPrompts: async () => {},
       NewSession: async () => {
         newSessionCalls += 1;
+        backendCanonicalTodos = [];
       },
       NewSessionForTab: async (tabID: string) => {
         if (tabID !== "tab-a") throw new Error(`unexpected new-session target ${tabID}`);
         newSessionCalls += 1;
+        backendCanonicalTodos = [];
+      },
+      ResumeSessionPageForTab: async () => {
+        backendCanonicalTodos = [{ content: "Restored task", status: "completed" }];
+        return {
+          messages: [{ role: "user", content: "restore" }, { role: "assistant", content: "done" }],
+          startTurn: 0,
+          endTurn: 1,
+          totalTurns: 1,
+          hasOlder: false,
+        };
       },
     } as Partial<AppBindings> as AppBindings,
   },
@@ -197,11 +210,18 @@ await act(async () => {
 await waitFor("active tab", () => controller?.activeTabId === "tab-a");
 
 await act(async () => {
+  await controller?.refreshMeta();
+  await flushPromises();
+});
+eq(controller?.state.meta?.canonicalTodos?.[0]?.content, "Old task", "pre-reset metadata exposes the current session todo");
+
+await act(async () => {
   await controller?.newSession();
   await flushPromises();
 });
 eq(newSessionCalls, 1, "tab-scoped NewSession is called once");
 eq(controller?.state.items.length, 0, "new session clears the visible transcript");
+eq(controller?.state.meta?.canonicalTodos?.length, 0, "new session refresh replaces the previous session todo with an authoritative empty list");
 
 await act(async () => {
   staleHistory.resolve([{ role: "user", content: "old prompt" }]);
@@ -210,6 +230,12 @@ await act(async () => {
 });
 
 eq(controller?.state.items.length, 0, "stale history load cannot repopulate a new blank session");
+
+await act(async () => {
+  await controller?.resumeSession("/sessions/restored.jsonl", "tab-a");
+  await flushPromises();
+});
+eq(controller?.state.meta?.canonicalTodos?.[0]?.status, "completed", "resuming a session refreshes its authoritative canonical todo state");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -342,12 +342,41 @@ console.log("\nuse controller meta");
   eq(sameMeta(meta({ workspacePath: "/repo" }), meta({ workspacePath: "/other" })), false, "workspace path changes invalidate meta equality");
   eq(sameMeta(meta({ gitBranch: "main" }), meta({ gitBranch: "feature" })), false, "git branch changes invalidate meta equality");
   eq(sameMeta(meta({ imageInputEnabled: true }), meta({ imageInputEnabled: false })), false, "image input capability changes invalidate meta equality");
+  eq(
+    sameMeta(
+      meta({ canonicalTodos: [{ content: "Ship", status: "in_progress" }] }),
+      meta({ canonicalTodos: [{ content: "Ship", status: "completed" }] }),
+    ),
+    false,
+    "canonical todo progress invalidates meta equality",
+  );
+  eq(
+    sameMeta(meta({ canonicalTodos: [] }), meta({ canonicalTodos: [] })),
+    true,
+    "equivalent empty canonical todo lists keep meta stable",
+  );
 }
 
 {
   const preserved = metaFromTab(tab({ toolApprovalMode: "" }), meta({ toolApprovalMode: "auto", autoApproveTools: false }));
   eq(preserved.toolApprovalMode, "auto", "blank tab snapshot preserves explicit auto approval mode");
   eq(preserved.autoApproveTools, false, "blank tab snapshot does not silently resurrect yolo approval");
+  const todos = [{ content: "Keep task state", status: "in_progress" }];
+  const withTodos = metaFromTab(tab(), meta({ canonicalTodos: todos }));
+  eq(withTodos.canonicalTodos, todos, "optimistic tab metadata preserves canonical todos for the same session");
+}
+
+{
+  const before = meta({ canonicalTodos: [{ content: "Ship", status: "in_progress" }] });
+  const completed = meta({ canonicalTodos: [{ content: "Ship", status: "completed" }] });
+  const updated = reducer({ ...initialState, meta: before }, { type: "meta", meta: completed });
+  eq(updated.meta?.canonicalTodos?.[0]?.status, "completed", "meta refresh applies canonical todo progress");
+
+  const reset = reducer(updated, { type: "reset" });
+  eq(reset.meta?.canonicalTodos, undefined, "session reset clears canonical todos from the previous session");
+
+  const cleared = reducer(reset, { type: "meta", meta: meta({ canonicalTodos: [] }) });
+  eq(cleared.meta?.canonicalTodos?.length, 0, "authoritative empty canonical todos survive meta refresh");
 }
 
 {

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -12,6 +12,24 @@ export interface TodoPanelScopeInput {
   eventChannel?: string | null;
 }
 
+export function resolveTodoPanelTodos(canonical: Todo[] | null | undefined, fallback: Todo[]): Todo[] {
+  return Array.isArray(canonical) ? canonical : fallback;
+}
+
+export function sameTodoList(a: Todo[] | null | undefined, b: Todo[] | null | undefined): boolean {
+  if (a === b) return true;
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  return a.every((todo, index) => {
+    const other = b[index];
+    return (
+      todo.content === other.content &&
+      todo.status === other.status &&
+      todo.activeForm === other.activeForm &&
+      todo.level === other.level
+    );
+  });
+}
+
 export function todoDismissalKey(todos: Todo[]): string {
   if (todos.length === 0) return "";
   return JSON.stringify(todos.map((todo) => ({

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1,6 +1,8 @@
 // Wire contract — mirrors desktop/wire.go (itself mirroring internal/serve/wire.go).
 // One event channel carries every kind; `kind` discriminates the payload.
 
+import type { Todo } from "./tools";
+
 export type EventKind =
   | "turn_started"
   | "reasoning"

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -499,6 +499,7 @@ export interface Meta {
   goal?: string;
   goalStatus?: GoalStatus;
   autoResearch?: AutoResearchCompactView;
+  canonicalTodos?: Todo[];
 }
 
 export type CollaborationMode = "normal" | "plan" | "goal";

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -11,6 +11,7 @@ import { invalidateCache } from "./composerHistory";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { createRafBatch } from "./rafBatch";
 import { t, type DictKey } from "./i18n";
+import { sameTodoList } from "./todoVisibility";
 import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
 import { modeHasAutoApproveTools, normalizeMode, normalizeToolApprovalMode } from "./types";
 import type {
@@ -299,6 +300,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     tokenMode: tab.tokenMode ?? existing?.tokenMode ?? "full",
     goal: tab.goal ?? existing?.goal,
     goalStatus: tab.goalStatus ?? existing?.goalStatus,
+    canonicalTodos: existing?.canonicalTodos,
   };
 }
 
@@ -328,8 +330,14 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
 
     a.tokenMode === b.tokenMode &&
     a.goal === b.goal &&
-    a.goalStatus === b.goalStatus
+    a.goalStatus === b.goalStatus &&
+    sameTodoList(a.canonicalTodos, b.canonicalTodos)
   );
+}
+
+function metaWithoutCanonicalTodos(meta?: Meta): Meta | undefined {
+  if (!meta || meta.canonicalTodos === undefined) return meta;
+  return { ...meta, canonicalTodos: undefined };
 }
 
 const STALE_TURN_RECONCILE_MS = 30_000;
@@ -1335,7 +1343,7 @@ export function reducer(s: State, a: Action): State {
     // as a stale replay of an already-answered prompt and silently ignored.
     case "controller_rebuilt":
       return { ...s, promptEpoch: s.promptEpoch + 1, resolvedPromptId: undefined, promptArrivedId: undefined, promptArrivedAt: undefined };
-    case "reset": return { ...initialState, meta: s.meta, context: { used: 0, window: s.context.window, sessionTokens: 0, compactRatio: s.context.compactRatio }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1, promptEpoch: s.promptEpoch + 1 };
+    case "reset": return { ...initialState, meta: metaWithoutCanonicalTodos(s.meta), context: { used: 0, window: s.context.window, sessionTokens: 0, compactRatio: s.context.compactRatio }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1, promptEpoch: s.promptEpoch + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }
@@ -2629,6 +2637,9 @@ export function useController() {
     dispatchTo(targetTabId, { type: "reset" });
     dispatchTo(targetTabId, { type: "history_page", page, mode: "replace" });
     dispatchTo(targetTabId, { type: "hydrate_done" });
+    const meta = await app.MetaForTab(targetTabId).catch(() => undefined);
+    if (!sessionLoadCurrent(targetTabId, seq)) return;
+    if (meta !== undefined) dispatchTo(targetTabId, { type: "meta", meta });
     app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
     void refreshCheckpoints(targetTabId);
   }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
@@ -2653,6 +2664,9 @@ export function useController() {
     dispatchTo(tabId, { type: "reset" });
     dispatchTo(tabId, { type: "history_page", page, mode: "replace" });
     dispatchTo(tabId, { type: "hydrate_done" });
+    const meta = await app.MetaForTab(tabId).catch(() => undefined);
+    if (!sessionLoadCurrent(tabId, seq)) return;
+    if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
     app.ContextUsageForTab(tabId).then((context) => dispatchTo(tabId, { type: "context", context })).catch(() => {});
     void refreshCheckpoints(tabId);
   }, [beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, sessionLoadCurrent, waitForTabReady]);
@@ -2800,6 +2814,7 @@ export function useController() {
       const messages = asArray(await app.HistoryForTab(sourceTabId).catch(() => [] as HistoryMessage[]));
       dispatchTo(sourceTabId, { type: "reset" });
       dispatchTo(sourceTabId, { type: "history", messages });
+      await refreshMetaOnlyForTab(sourceTabId, dispatchTo);
       dispatchTo(sourceTabId, { type: "context", context: await app.ContextUsageForTab(sourceTabId) });
       dispatchTo(sourceTabId, { type: "checkpoints", checkpoints: asArray(await app.CheckpointsForTab(sourceTabId)) });
       return true;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1690,26 +1690,6 @@ function settingSwitchNoticeText(
   return t(keys.failed, { err: msg });
 }
 
-async function refreshMetaForTab(tabId: string, dispatchTo: (tabId: string, action: Action) => void): Promise<void> {
-  try {
-    dispatchTo(tabId, { type: "meta", meta: await app.MetaForTab(tabId) });
-    dispatchTo(tabId, { type: "context", context: await app.ContextUsageForTab(tabId) });
-    dispatchTo(tabId, { type: "effort", effort: await app.EffortForTab(tabId) });
-  } catch {
-    /* ignore */
-  }
-}
-
-async function refreshMetaOnlyForTab(tabId: string, dispatchTo: (tabId: string, action: Action) => void): Promise<Meta | undefined> {
-  try {
-    const meta = await app.MetaForTab(tabId);
-    dispatchTo(tabId, { type: "meta", meta });
-    return meta;
-  } catch {
-    return undefined;
-  }
-}
-
 export function replayPendingPromptsForActiveTab(activeTabId: string | undefined, replay: () => Promise<void> = () => app.ReplayPendingPrompts()): void {
   if (!activeTabId) return;
   void replay().catch(() => {});
@@ -1783,16 +1763,52 @@ export function useController() {
   }, []);
 
   const checkpointRefreshSeq = useRef(new Map<string, number>());
+  const metaRefreshSeq = useRef(new Map<string, number>());
   const sessionLoadSeq = useRef(new Map<string, number>());
   const sessionLoadInFlight = useRef(new Map<string, { sessionPath: string; promise: Promise<void> }>());
+  const bumpMetaRefreshSeq = useCallback((tabId: string): number => {
+    const seq = (metaRefreshSeq.current.get(tabId) ?? 0) + 1;
+    metaRefreshSeq.current.set(tabId, seq);
+    return seq;
+  }, []);
+  const metaRefreshCurrent = useCallback((tabId: string, seq: number): boolean => {
+    return metaRefreshSeq.current.get(tabId) === seq;
+  }, []);
   const bumpSessionLoadSeq = useCallback((tabId: string): number => {
+    // A session transition changes the meaning of every tab-scoped Meta field.
+    // Invalidate requests that started against the previous session before
+    // resetting or hydrating the visible state.
+    bumpMetaRefreshSeq(tabId);
     const seq = (sessionLoadSeq.current.get(tabId) ?? 0) + 1;
     sessionLoadSeq.current.set(tabId, seq);
     return seq;
-  }, []);
+  }, [bumpMetaRefreshSeq]);
   const sessionLoadCurrent = useCallback((tabId: string, seq: number): boolean => {
     return sessionLoadSeq.current.get(tabId) === seq;
   }, []);
+  const loadMetaForTab = useCallback(async (tabId: string): Promise<Meta | undefined> => {
+    const seq = bumpMetaRefreshSeq(tabId);
+    const meta = await app.MetaForTab(tabId).catch(() => undefined);
+    if (!metaRefreshCurrent(tabId, seq)) return undefined;
+    return meta;
+  }, [bumpMetaRefreshSeq, metaRefreshCurrent]);
+  const refreshMetaOnlyForTab = useCallback(async (tabId: string): Promise<Meta | undefined> => {
+    const meta = await loadMetaForTab(tabId);
+    if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
+    return meta;
+  }, [dispatchTo, loadMetaForTab]);
+  const refreshMetaForTab = useCallback(async (tabId: string): Promise<void> => {
+    const sessionSeq = sessionLoadSeq.current.get(tabId) ?? 0;
+    const meta = await refreshMetaOnlyForTab(tabId);
+    if (meta === undefined || (sessionLoadSeq.current.get(tabId) ?? 0) !== sessionSeq) return;
+    const [context, effort] = await Promise.all([
+      app.ContextUsageForTab(tabId).catch(() => undefined),
+      app.EffortForTab(tabId).catch(() => undefined),
+    ]);
+    if ((sessionLoadSeq.current.get(tabId) ?? 0) !== sessionSeq) return;
+    if (context !== undefined) dispatchTo(tabId, { type: "context", context });
+    if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
+  }, [dispatchTo, refreshMetaOnlyForTab]);
   const bumpCheckpointRefreshSeq = useCallback((tabId: string): number => {
     const seq = (checkpointRefreshSeq.current.get(tabId) ?? 0) + 1;
     checkpointRefreshSeq.current.set(tabId, seq);
@@ -1892,7 +1908,7 @@ export function useController() {
         addBreadcrumb("tab.hydrate", `ancillary skipped inactive ${reason} ${tabId}`);
         return;
       }
-      const meta = await loadTimed("meta", () => app.MetaForTab(tabId));
+      const meta = await loadTimed("meta", () => loadMetaForTab(tabId));
       if (!stillCurrent()) return;
       if (!stillVisible()) {
         addBreadcrumb("tab.hydrate", `meta ignored inactive ${reason} ${tabId}`);
@@ -1946,7 +1962,7 @@ export function useController() {
         sessionLoadInFlight.current.delete(tabId);
       }
     }
-  }, [bumpSessionLoadSeq, dispatchTo, sessionLoadCurrent]);
+  }, [bumpSessionLoadSeq, dispatchTo, loadMetaForTab, sessionLoadCurrent]);
 
   const loadOlderHistory = useCallback(async (tabId?: string): Promise<void> => {
     const targetTabId = tabId || activeTabIdRef.current;
@@ -2160,7 +2176,7 @@ export function useController() {
         app.BalanceForTab(targetTabId).then((balance) => dispatchTo(targetTabId, { type: "balance", balance })).catch(() => {});
         app.EffortForTab(targetTabId).then((effort) => dispatchTo(targetTabId, { type: "effort", effort })).catch(() => {});
         void refreshCheckpoints(targetTabId);
-        void refreshMetaForTab(targetTabId, dispatchTo);
+        void refreshMetaForTab(targetTabId);
       }
       if (e.kind === "turn_done" || e.kind === "notice") {
         app.JobsForTab(targetTabId).then((jobs) => dispatchTo(targetTabId, { type: "jobs", jobs: asArray(jobs) })).catch(() => {});
@@ -2212,7 +2228,7 @@ export function useController() {
       offReady();
       offRebuilt();
     };
-  }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, syncActiveTabFromBackend]);
+  }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, refreshMetaForTab, syncActiveTabFromBackend]);
 
   // Keep shared all-source telemetry live between turn boundaries. Delivery
   // mode can complete dozens of provider requests inside one UI turn, while
@@ -2270,7 +2286,7 @@ export function useController() {
       if (!stillCurrent()) return;
       const current = statesRef.current.get(tabId);
       if (!current?.meta || current.meta.ready || current.meta.startupErr || current.backendActivationPending) return;
-      const nextMeta = await refreshMetaOnlyForTab(tabId, dispatchTo);
+      const nextMeta = await refreshMetaOnlyForTab(tabId);
       if (!stillCurrent()) return;
       if (nextMeta?.ready || nextMeta?.startupErr || attempt + 1 >= STARTUP_READY_META_RECONCILE_ATTEMPTS) return;
       schedule(attempt + 1);
@@ -2281,7 +2297,7 @@ export function useController() {
       cancelled = true;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [activeTabId, activeState.meta?.ready, activeState.meta?.startupErr, activeState.backendActivationPending, dispatchTo]);
+  }, [activeTabId, activeState.meta?.ready, activeState.meta?.startupErr, activeState.backendActivationPending, refreshMetaOnlyForTab]);
 
   // Stale-turn watchdog: if the frontend thinks the agent is running but the
   // turn stream has gone quiet, reconcile with the backend. This catches cases
@@ -2491,8 +2507,8 @@ export function useController() {
   const setCollaborationModeForTab = useCallback(async (tabId: string, mode: CollaborationMode): Promise<void> => {
     if (!tabId) return;
     await app.SetCollaborationModeForTab(tabId, mode).catch(() => {});
-    await refreshMetaForTab(tabId, dispatchTo);
-  }, [dispatchTo]);
+    await refreshMetaForTab(tabId);
+  }, [refreshMetaForTab]);
 
   const setCollaborationMode = useCallback(async (mode: CollaborationMode): Promise<void> => {
     if (!activeTabId) return;
@@ -2508,8 +2524,8 @@ export function useController() {
     const drained = await app.SetToolApprovalModeForTab(tabId, mode).catch(() => undefined);
     const ids = Array.isArray(drained) ? drained : [];
     if (ids.length) dispatchTo(tabId, { type: "approval_drained", ids, epoch });
-    await refreshMetaForTab(tabId, dispatchTo);
-  }, [dispatchTo]);
+    await refreshMetaForTab(tabId);
+  }, [dispatchTo, refreshMetaForTab]);
 
   const setToolApprovalMode = useCallback(async (mode: ToolApprovalMode): Promise<void> => {
     if (!activeTabId) return;
@@ -2519,8 +2535,8 @@ export function useController() {
   const setGoalForTab = useCallback(async (tabId: string, goal: string): Promise<void> => {
     if (!tabId) return;
     await app.SetGoalForTab(tabId, goal).catch(() => {});
-    await refreshMetaForTab(tabId, dispatchTo);
-  }, [dispatchTo]);
+    await refreshMetaForTab(tabId);
+  }, [refreshMetaForTab]);
 
   const setGoal = useCallback(async (goal: string): Promise<void> => {
     if (!activeTabId) return;
@@ -2530,8 +2546,8 @@ export function useController() {
   const clearGoalForTab = useCallback(async (tabId: string): Promise<void> => {
     if (!tabId) return;
     await app.ClearGoalForTab(tabId).catch(() => {});
-    await refreshMetaForTab(tabId, dispatchTo);
-  }, [dispatchTo]);
+    await refreshMetaForTab(tabId);
+  }, [refreshMetaForTab]);
 
   const clearGoal = useCallback(async (): Promise<void> => {
     if (!activeTabId) return;
@@ -2542,12 +2558,12 @@ export function useController() {
     if (!tabId) return false;
     try {
       const resumed = await app.ResumeGoalForTab(tabId);
-      await refreshMetaForTab(tabId, dispatchTo);
+      await refreshMetaForTab(tabId);
       return resumed;
     } catch {
       return false;
     }
-  }, [dispatchTo]);
+  }, [refreshMetaForTab]);
 
   const resumeGoal = useCallback(async (): Promise<boolean> => {
     if (!activeTabId) return false;
@@ -2582,11 +2598,11 @@ export function useController() {
     if (tabId) {
       dispatchTo(tabId, { type: "history", messages: [] });
       dispatchTo(tabId, { type: "hydrate_done" });
-      void refreshMetaForTab(tabId, dispatchTo);
+      void refreshMetaForTab(tabId);
       app.ContextUsageForTab(tabId).then((context) => dispatchTo(tabId, { type: "context", context })).catch(() => {});
       void refreshCheckpoints(tabId);
     }
-  }, [activeTabId, bumpCheckpointRefreshSeq, bumpSessionLoadSeq, dispatchTo, loadSessionDataForTab, refreshCheckpoints, waitForTabReady]);
+  }, [activeTabId, bumpCheckpointRefreshSeq, bumpSessionLoadSeq, dispatchTo, loadSessionDataForTab, refreshCheckpoints, refreshMetaForTab, waitForTabReady]);
 
   const clearSession = useCallback(async () => {
     const tabId = activeTabId;
@@ -2637,12 +2653,11 @@ export function useController() {
     dispatchTo(targetTabId, { type: "reset" });
     dispatchTo(targetTabId, { type: "history_page", page, mode: "replace" });
     dispatchTo(targetTabId, { type: "hydrate_done" });
-    const meta = await app.MetaForTab(targetTabId).catch(() => undefined);
+    await refreshMetaOnlyForTab(targetTabId);
     if (!sessionLoadCurrent(targetTabId, seq)) return;
-    if (meta !== undefined) dispatchTo(targetTabId, { type: "meta", meta });
     app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
     void refreshCheckpoints(targetTabId);
-  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
+  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, refreshMetaOnlyForTab, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
 
   const openChannelSession = useCallback(async (path: string, tabId: string) => {
     if (!tabId) return;
@@ -2664,12 +2679,11 @@ export function useController() {
     dispatchTo(tabId, { type: "reset" });
     dispatchTo(tabId, { type: "history_page", page, mode: "replace" });
     dispatchTo(tabId, { type: "hydrate_done" });
-    const meta = await app.MetaForTab(tabId).catch(() => undefined);
+    await refreshMetaOnlyForTab(tabId);
     if (!sessionLoadCurrent(tabId, seq)) return;
-    if (meta !== undefined) dispatchTo(tabId, { type: "meta", meta });
     app.ContextUsageForTab(tabId).then((context) => dispatchTo(tabId, { type: "context", context })).catch(() => {});
     void refreshCheckpoints(tabId);
-  }, [beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, sessionLoadCurrent, waitForTabReady]);
+  }, [beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, refreshCheckpoints, refreshMetaOnlyForTab, sessionLoadCurrent, waitForTabReady]);
 
   const previewSession = useCallback(async (path: string): Promise<HistoryMessage[]> => asArray<HistoryMessage>(await app.PreviewSession(path).catch(() => [])), []);
   const deleteSession = useCallback((path: string) => app.DeleteSession(path).finally(() => invalidateCache()), []);
@@ -2679,12 +2693,8 @@ export function useController() {
 
   const refreshMeta = useCallback(async () => {
     if (!activeTabId) return;
-    try {
-      dispatchTo(activeTabId, { type: "meta", meta: await app.MetaForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "context", context: await app.ContextUsageForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "effort", effort: await app.EffortForTab(activeTabId) });
-    } catch { /* ignore */ }
-  }, [activeTabId, dispatchTo]);
+    await refreshMetaForTab(activeTabId);
+  }, [activeTabId, refreshMetaForTab]);
 
   const refreshWorkspaceState = useCallback(async (path: string): Promise<string> => {
     if (path) await syncActiveTabFromBackend(true);
@@ -2716,12 +2726,8 @@ export function useController() {
       dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: modelSwitchNoticeText(err) });
       return;
     }
-    try {
-      dispatchTo(activeTabId, { type: "meta", meta: await app.MetaForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "context", context: await app.ContextUsageForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "effort", effort: await app.EffortForTab(activeTabId) });
-    } catch { /* ignore */ }
-  }, [activeTabId, dispatchTo]);
+    await refreshMetaForTab(activeTabId);
+  }, [activeTabId, dispatchTo, refreshMetaForTab]);
 
   const setEffort = useCallback(async (level: string) => {
     if (!activeTabId) return;
@@ -2731,12 +2737,8 @@ export function useController() {
       dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: effortSwitchNoticeText(err) });
       return;
     }
-    try {
-      dispatchTo(activeTabId, { type: "meta", meta: await app.MetaForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "context", context: await app.ContextUsageForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "effort", effort: await app.EffortForTab(activeTabId) });
-    } catch { /* ignore */ }
-  }, [activeTabId, dispatchTo]);
+    await refreshMetaForTab(activeTabId);
+  }, [activeTabId, dispatchTo, refreshMetaForTab]);
 
   const setTokenMode = useCallback(async (mode: TokenMode): Promise<boolean> => {
     if (!activeTabId) return false;
@@ -2746,13 +2748,9 @@ export function useController() {
       dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: tokenModeSwitchNoticeText(err) });
       return false;
     }
-    try {
-      dispatchTo(activeTabId, { type: "meta", meta: await app.MetaForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "context", context: await app.ContextUsageForTab(activeTabId) });
-      dispatchTo(activeTabId, { type: "effort", effort: await app.EffortForTab(activeTabId) });
-    } catch { /* ignore */ }
+    await refreshMetaForTab(activeTabId);
     return true;
-  }, [activeTabId, dispatchTo]);
+  }, [activeTabId, dispatchTo, refreshMetaForTab]);
 
   const fetchMemory = useCallback((): Promise<MemoryView> =>
     app.Memory().catch(() => ({ docs: [], facts: [], archives: [], scopes: [], storeDir: "", available: false })), []);
@@ -2814,7 +2812,7 @@ export function useController() {
       const messages = asArray(await app.HistoryForTab(sourceTabId).catch(() => [] as HistoryMessage[]));
       dispatchTo(sourceTabId, { type: "reset" });
       dispatchTo(sourceTabId, { type: "history", messages });
-      await refreshMetaOnlyForTab(sourceTabId, dispatchTo);
+      await refreshMetaOnlyForTab(sourceTabId);
       dispatchTo(sourceTabId, { type: "context", context: await app.ContextUsageForTab(sourceTabId) });
       dispatchTo(sourceTabId, { type: "checkpoints", checkpoints: asArray(await app.CheckpointsForTab(sourceTabId)) });
       return true;
@@ -2824,7 +2822,7 @@ export function useController() {
     } finally {
       dispatchTo(sourceTabId, { type: "message_action_done" });
     }
-  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, reconcileTabRuntime, syncActiveTabFromBackend, waitForTabReady]);
+  }, [beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab, reconcileTabRuntime, refreshMetaOnlyForTab, syncActiveTabFromBackend, waitForTabReady]);
 
   const rewind = useCallback(async (turn: number, scope: string): Promise<boolean> => {
     if (!activeTabId) return false;

--- a/desktop/workbench_projection.go
+++ b/desktop/workbench_projection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"path/filepath"
 
+	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
 	"reasonix/internal/remote/protocol"
 )
@@ -103,6 +104,29 @@ func workbenchModels(catalog protocol.WorkspaceCatalogResult, current string) []
 	return out
 }
 
+func workbenchCanonicalTodos(values []protocol.TodoItem) *[]evidence.TodoItem {
+	if values == nil {
+		return nil
+	}
+	out := make([]evidence.TodoItem, 0, len(values))
+	for _, todo := range values {
+		switch todo.Status {
+		case protocol.TodoPending, protocol.TodoInProgress, protocol.TodoCompleted:
+		default:
+			continue
+		}
+		level := todo.Level
+		if level < 0 {
+			level = 0
+		}
+		out = append(out, evidence.TodoItem{
+			Content: workbenchString(todo.Content), Status: string(todo.Status),
+			ActiveForm: todo.ActiveForm, Level: level,
+		})
+	}
+	return &out
+}
+
 func workbenchMeta(snapshot protocol.SessionSnapshot, workspace string) Meta {
 	profile := snapshot.Meta.ResolvedProfile
 	label := profile.Model
@@ -113,6 +137,7 @@ func workbenchMeta(snapshot protocol.SessionSnapshot, workspace string) Meta {
 		Bypass:            profile.ToolApprovalMode == protocol.ToolApprovalYOLO,
 		CollaborationMode: string(profile.CollaborationMode), ToolApprovalMode: string(profile.ToolApprovalMode),
 		TokenMode: string(profile.TokenMode), Goal: workbenchString(snapshot.Meta.Goal), GoalStatus: string(snapshot.Meta.GoalStatus),
+		CanonicalTodos: workbenchCanonicalTodos(snapshot.Todos),
 	}
 }
 

--- a/desktop/workbench_projection_test.go
+++ b/desktop/workbench_projection_test.go
@@ -49,6 +49,29 @@ func TestWorkbenchSnapshotProjectionUsesRemoteWorkspaceAndProfile(t *testing.T) 
 	}
 }
 
+func TestWorkbenchSnapshotProjectionPreservesCanonicalTodos(t *testing.T) {
+	content := "Ship the fix"
+	meta := workbenchMeta(protocol.SessionSnapshot{Todos: []protocol.TodoItem{{
+		Content: &content, Status: protocol.TodoCompleted, ActiveForm: "Shipping the fix", Level: 1,
+	}}}, "/srv/app")
+	if meta.CanonicalTodos == nil {
+		t.Fatal("canonical todos are unavailable, want projected remote snapshot")
+	}
+	if got := *meta.CanonicalTodos; len(got) != 1 || got[0].Content != content || got[0].Status != "completed" || got[0].ActiveForm != "Shipping the fix" || got[0].Level != 1 {
+		t.Fatalf("canonical todos = %+v", got)
+	}
+
+	empty := workbenchMeta(protocol.SessionSnapshot{Todos: []protocol.TodoItem{}}, "/srv/app")
+	if empty.CanonicalTodos == nil || len(*empty.CanonicalTodos) != 0 {
+		t.Fatalf("empty canonical todos = %#v, want authoritative empty list", empty.CanonicalTodos)
+	}
+
+	unavailable := workbenchMeta(protocol.SessionSnapshot{}, "/srv/app")
+	if unavailable.CanonicalTodos != nil {
+		t.Fatalf("unavailable canonical todos = %#v, want omitted field", unavailable.CanonicalTodos)
+	}
+}
+
 func TestWorkbenchContextProjectionPreservesAllSourceTotals(t *testing.T) {
 	context := workbenchContextInfo(protocol.ContextView{
 		UsedTokens: 10, WindowTokens: 100, TotalTokens: 30, SessionCacheHitTokens: 7, SessionCacheMissTokens: 2,

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"


### PR DESCRIPTION
### English

**Problem:** The Todo panel can show stale incomplete items after the agent has completed every task. `complete_step` advances the server-side `CanonicalTodoState`, but the frontend previously rebuilt the panel from persisted `todo_write` arguments. Synthetic `host-advance-*` events do not survive session persistence.

**Root cause:** The frontend had no durable authoritative Todo snapshot, and the original patch left several state-transition and runtime gaps:
- `sameMeta` ignored `canonicalTodos`, so status-only Meta refreshes could be discarded.
- An unavailable controller and an authoritative empty task list collapsed to the same omitted JSON value.
- Session reset, resume, channel-open, and rewind paths could retain or miss authoritative state.
- Concurrent `MetaForTab` reads were not sequenced, so a response started before a session transition could overwrite the new session state.
- Native Remote workbench projection ignored `SessionSnapshot.Todos`.

**Solution:**
- Expose `Controller.Todos()` through `MetaForTab` as an optional canonical snapshot.
- Preserve three wire states: omitted means unavailable/fall back, `[]` means authoritative clear, and a non-empty array is authoritative.
- Deep-compare canonical Todo content, preserve it through same-session optimistic metadata, and clear it on session reset.
- Centralize per-tab Meta reads with latest-request-wins sequencing and invalidate pending reads on every session transition.
- Refresh Meta after resume, channel-session open, and rewind with stale-navigation guards.
- Project validated Remote snapshot Todos into the same tri-state Meta contract.
- Prefer every valid canonical array, including an empty array, over transcript parsing.

**Changes:**
- `desktop/app.go`: canonical Todo Meta contract and nil-safe controller snapshot.
- `desktop/workbench_projection.go`: Remote canonical Todo projection.
- `desktop/frontend/src/lib/types.ts`: optional `canonicalTodos` wire type.
- `desktop/frontend/src/App.tsx` and `todoVisibility.ts`: authoritative/fallback resolution and stable list comparison.
- `desktop/frontend/src/lib/useController.ts`: Meta equality, reset/session integration, and guarded Meta requests.
- Go and frontend regressions for wire encoding, progress updates, empty clears, stale Meta responses, new/restored sessions, and Remote projection.

**Compatibility:**

| Contract | Old or unavailable input | New behavior | Conclusion |
| --- | --- | --- | --- |
| `canonicalTodos` omitted | Frontend reads the latest successful `todo_write` | Existing fallback remains active | Backward compatible |
| `canonicalTodos: []` | Not previously representable as authoritative | Explicitly clears the Todo panel | Safe additive contract |
| Native Remote snapshot | Todos were present in the protocol but dropped by Desktop projection | Uses the same canonical tri-state contract as Local | Runtime parity restored |
| Persisted sessions/config | Existing formats remain unchanged | Canonical state is rebuilt by the controller and exposed read-only | No migration required |

**Verification on the PR head:**
- `cd desktop && go test ./...`
- `pnpm --dir desktop/frontend test`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend test:typecheck`
- `pnpm --dir desktop/frontend build`
- `git diff --check`

**Latest `main-v2` integration:** auto-merge is conflict-free; Desktop Go tests, frontend production typecheck/build, and the Todo race regression pass. The three `capabilities-panel-actions.test.ts` test-typecheck diagnostics reproduce unchanged on a clean latest `main-v2`, so they are a base-branch issue rather than a regression from this PR.

---

### 中文

**问题：** Agent 已完成全部任务后，Todo 面板仍可能显示旧的未完成状态。服务端 `complete_step` 已推进 `CanonicalTodoState`，但前端此前依赖持久化记录中最后一次 `todo_write`；合成的 `host-advance-*` 事件不会随会话持久化。

**根因：** 前端缺少持久、权威的 Todo 快照，初版补丁还遗漏了以下边界：
- `sameMeta` 未比较 `canonicalTodos`，仅 Todo 状态变化的 Meta 刷新会被丢弃。
- “控制器暂不可用”和“权威空列表”都会被编码成字段缺失。
- 新建、恢复、频道打开或回滚会话时可能保留或漏读权威状态。
- 并发 `MetaForTab` 请求没有按 tab 和会话代际排序，旧会话请求可能晚到并覆盖新状态。
- 原生 Remote Workbench 投影丢弃了 `SessionSnapshot.Todos`。

**方案：**
- 通过 `MetaForTab` 暴露 `Controller.Todos()`，保留“缺失 / 空数组 / 非空数组”三态语义。
- 深比较 canonical Todo；同一会话的乐观元数据保留 Todo；会话重置时清除旧 Todo。
- 对每个 tab 的 Meta 请求实施 latest-request-wins，并在每次会话切换时使旧请求失效。
- 恢复会话、打开频道会话和回滚后重新读取权威 Meta，并保留过期导航保护。
- 将 Remote 快照中的 Todos 映射到相同三态协议。
- 任何合法的权威数组（包括空数组）都优先于历史 `todo_write` 解析结果。

**兼容性：** 旧后端或控制器尚未就绪时仍走原有历史回退；没有修改会话、配置或持久化文件格式；Remote 与 Local 现在使用同一权威状态契约，不需要迁移。

**验证：** PR head 的 Desktop Go 全量测试、前端完整测试、生产类型检查、测试类型检查、生产构建和 `git diff --check` 均通过。与最新 `main-v2` 自动合并无冲突；最新基线中的 3 个 `capabilities-panel-actions.test.ts` 类型诊断可在干净基线独立复现，与本 PR 无关。

Fixes #6724
