### PR TITLE
fix(parallel_tasks): add grace period drain on parent cancellation [Cache-impact: low]

### DIFF
--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -200,7 +200,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			// Ordinary parallel_tasks (no profile) keep the concise read-only
 			// default system prompt — profile-aware batches use fleet instead.
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth)
+			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth, "subagent:" + subID)
 			// Same contract as runSubSession: capture the pristine task before
 			// host framing is prepended so delivery intent classification judges
 			// the task, not the wrapper.

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -155,23 +155,6 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		go func() {
 			defer wg.Done()
 			nested := subSinkFor(subID, sink)
-			// Session scheduler bounds total concurrency for parallel_tasks the
-			// same way as fleet (read-only slots; no write claims).
-			releaseSlot, slotErr := p.taskTool.acquireSlot(ctx, AcquireRequest{
-				Writer: false,
-				Nested: SubagentDepth(ctx) > 0,
-				Label:  label,
-			})
-			if slotErr != nil {
-				sink.Emit(event.Event{
-					Kind: event.ToolResult,
-					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: slotErr.Error()},
-				})
-				doneCh <- subResult{index: idx, err: slotErr}
-				return
-			}
-			defer releaseSlot()
-
 			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
 			childDepth, depthErr := p.taskTool.nextSubagentDepth(ctx)
 			if depthErr != nil {
@@ -196,19 +179,28 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				return
 			}
 
-			// Ordinary parallel_tasks (no profile) keep the concise read-only
-			// default system prompt — profile-aware batches use fleet instead.
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth, "subagent:"+subID)
+			// Create an independent context so parent turn cancellation
+			// does not cascade to this sub-agent. The slot was already
+			// acquired using the parent ctx (above), so waiting for a slot
+			// still respects the parent turn lifecycle.
+			subCtx := context.WithoutCancel(ctx)
+			opts := p.taskTool.subagentOptions(subCtx, max, pricing, ctxWin, childDepth)
 			// Same contract as runSubSession: capture the pristine task before
 			// host framing is prepended so delivery intent classification judges
 			// the task, not the wrapper.
 			opts.ClassifierTaskText = t.Prompt
-			output, runErr := RunReadOnlySubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
+			output, runErr := RunReadOnlySubAgentWithSession(subCtx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
 				opts, nested)
 
 			if ctx.Err() != nil && runErr == nil {
-				runErr = ctx.Err()
+				// Parent context was cancelled but sub-agent completed.
+				// Use subCtx for the actual error check - if subCtx is
+				// also cancelled (genuine error, not parent cascade),
+				// surface it; otherwise the sub-agent finished fine.
+				if subCtx.Err() != nil {
+					runErr = subCtx.Err()
+				}
 			}
 			if runErr != nil {
 				errText := runErr.Error()
@@ -228,22 +220,6 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			})
 			doneCh <- subResult{index: idx, output: output}
 		}()
-	}
-
-	markCancelled := func(err error) {
-		for i := range params.Tasks {
-			if done[i] {
-				continue
-			}
-			done[i] = true
-			if running[i] {
-				statuses[i] = parallelTaskCancelled
-				taskErrs[i] = err
-				continue
-			}
-			statuses[i] = parallelTaskSkipped
-			taskErrs[i] = err
-		}
 	}
 
 	completed := 0
@@ -272,28 +248,36 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		case r := <-doneCh:
 			processResult(r)
 		case <-ctx.Done():
-			err := ctx.Err()
-		drain:
-			for {
-				select {
-				case r := <-doneCh:
-					processResult(r)
-				default:
-					break drain
-				}
+			// Parent context cancelled, but sub-agents have independent
+			// contexts (context.WithoutCancel in startTask). Keep receiving
+			// their results instead of marking them all as cancelled.
+			// Tasks that failed slot acquisition (parent ctx in acquireSlot)
+			// have already sent their errors to doneCh.
+			for completed < n {
+				r := <-doneCh
+				processResult(r)
 			}
-			markCancelled(err)
-			wg.Wait()
-			return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
 		}
 	}
 	wg.Wait()
-	if parallelTasksWereCancelled(statuses) {
-		err := ctx.Err()
-		if err == nil {
-			err = context.Canceled
+	// Collect any errors from failed tasks (non-cancelled, non-completed).
+	// Cancelled/skipped tasks from the ctx.Done() drain path below are
+	// also reported when they exist, but with the independent sub-agent
+	// context fix, most tasks should complete normally.
+	var firstErr error
+	for i, st := range statuses {
+		if st == parallelTaskFailed && taskErrs[i] != nil && firstErr == nil {
+			firstErr = taskErrs[i]
 		}
-		return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
+	}
+	if parallelTasksWereCancelled(statuses) {
+		if firstErr == nil {
+			firstErr = context.Canceled
+		}
+		return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), firstErr
+	}
+	if firstErr != nil {
+		return formatParallelTasksAggregate(outputs, taskErrs, statuses, false), firstErr
 	}
 	return formatParallelTasksAggregate(outputs, taskErrs, statuses, false), nil
 }

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -200,7 +200,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			// Ordinary parallel_tasks (no profile) keep the concise read-only
 			// default system prompt — profile-aware batches use fleet instead.
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth, "subagent:" + subID)
+			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth, "subagent:"+subID)
 			// Same contract as runSubSession: capture the pristine task before
 			// host framing is prepended so delivery intent classification judges
 			// the task, not the wrapper.

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -155,6 +155,23 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		go func() {
 			defer wg.Done()
 			nested := subSinkFor(subID, sink)
+			// Session scheduler bounds total concurrency for parallel_tasks the
+			// same way as fleet (read-only slots; no write claims).
+			releaseSlot, slotErr := p.taskTool.acquireSlot(ctx, AcquireRequest{
+				Writer: false,
+				Nested: SubagentDepth(ctx) > 0,
+				Label:  label,
+			})
+			if slotErr != nil {
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: slotErr.Error()},
+				})
+				doneCh <- subResult{index: idx, err: slotErr}
+				return
+			}
+			defer releaseSlot()
+
 			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
 			childDepth, depthErr := p.taskTool.nextSubagentDepth(ctx)
 			if depthErr != nil {
@@ -179,28 +196,19 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				return
 			}
 
+			// Ordinary parallel_tasks (no profile) keep the concise read-only
+			// default system prompt — profile-aware batches use fleet instead.
 			sess := NewSession(DefaultReadOnlyTaskSystemPrompt)
-			// Create an independent context so parent turn cancellation
-			// does not cascade to this sub-agent. The slot was already
-			// acquired using the parent ctx (above), so waiting for a slot
-			// still respects the parent turn lifecycle.
-			subCtx := context.WithoutCancel(ctx)
-			opts := p.taskTool.subagentOptions(subCtx, max, pricing, ctxWin, childDepth)
+			opts := p.taskTool.subagentOptions(ctx, max, pricing, ctxWin, childDepth)
 			// Same contract as runSubSession: capture the pristine task before
 			// host framing is prepended so delivery intent classification judges
 			// the task, not the wrapper.
 			opts.ClassifierTaskText = t.Prompt
-			output, runErr := RunReadOnlySubAgentWithSession(subCtx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
+			output, runErr := RunReadOnlySubAgentWithSession(ctx, prov, subReg, sess, p.taskTool.withWorkspaceContext(t.Prompt),
 				opts, nested)
 
 			if ctx.Err() != nil && runErr == nil {
-				// Parent context was cancelled but sub-agent completed.
-				// Use subCtx for the actual error check - if subCtx is
-				// also cancelled (genuine error, not parent cascade),
-				// surface it; otherwise the sub-agent finished fine.
-				if subCtx.Err() != nil {
-					runErr = subCtx.Err()
-				}
+				runErr = ctx.Err()
 			}
 			if runErr != nil {
 				errText := runErr.Error()
@@ -220,6 +228,22 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			})
 			doneCh <- subResult{index: idx, output: output}
 		}()
+	}
+
+	markCancelled := func(err error) {
+		for i := range params.Tasks {
+			if done[i] {
+				continue
+			}
+			done[i] = true
+			if running[i] {
+				statuses[i] = parallelTaskCancelled
+				taskErrs[i] = err
+				continue
+			}
+			statuses[i] = parallelTaskSkipped
+			taskErrs[i] = err
+		}
 	}
 
 	completed := 0
@@ -248,36 +272,38 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		case r := <-doneCh:
 			processResult(r)
 		case <-ctx.Done():
-			// Parent context cancelled, but sub-agents have independent
-			// contexts (context.WithoutCancel in startTask). Keep receiving
-			// their results instead of marking them all as cancelled.
-			// Tasks that failed slot acquisition (parent ctx in acquireSlot)
-			// have already sent their errors to doneCh.
-			for completed < n {
-				r := <-doneCh
-				processResult(r)
+			err := ctx.Err()
+			// Grace period: sub-agents that are near completion
+			// can finish before being marked as cancelled.
+			// This prevents unnecessary context.Canceled results
+			// for sub-agents that would have completed within a
+			// few hundred milliseconds.
+			drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer drainCancel()
+		drain:
+			for {
+				select {
+				case r := <-doneCh:
+					processResult(r)
+					if completed >= n {
+						break drain
+					}
+				case <-drainCtx.Done():
+					break drain
+				}
 			}
+			markCancelled(err)
+			wg.Wait()
+			return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
 		}
 	}
 	wg.Wait()
-	// Collect any errors from failed tasks (non-cancelled, non-completed).
-	// Cancelled/skipped tasks from the ctx.Done() drain path below are
-	// also reported when they exist, but with the independent sub-agent
-	// context fix, most tasks should complete normally.
-	var firstErr error
-	for i, st := range statuses {
-		if st == parallelTaskFailed && taskErrs[i] != nil && firstErr == nil {
-			firstErr = taskErrs[i]
-		}
-	}
 	if parallelTasksWereCancelled(statuses) {
-		if firstErr == nil {
-			firstErr = context.Canceled
+		err := ctx.Err()
+		if err == nil {
+			err = context.Canceled
 		}
-		return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), firstErr
-	}
-	if firstErr != nil {
-		return formatParallelTasksAggregate(outputs, taskErrs, statuses, false), firstErr
+		return formatParallelTasksAggregate(outputs, taskErrs, statuses, true), err
 	}
 	return formatParallelTasksAggregate(outputs, taskErrs, statuses, false), nil
 }


### PR DESCRIPTION
Fixes #6773

---

### English

**Problem:** `parallel_tasks` sub-agents that are near completion get needlessly cancelled when the parent turn context fires. The immediate drain+markCancelled pattern in the `ctx.Done()` handler penalizes sub-agents that could have completed within a few hundred milliseconds.

**Root cause:** The `ctx.Done()` handler performed a non-blocking drain (completed results only), then immediately marked all remaining sub-agents as cancelled and returned partial results. Sub-agents that finished their work and were about to send their results to `doneCh` were lost.

**Fix:** Replace the non-blocking drain with a 2-second grace period using `context.WithTimeout`. During this grace period, sub-agents that complete normally are properly captured. After the grace period, any still-incomplete sub-agents are cancelled via `markCancelled`.

This is a minimal change (+11 lines) — only the `ctx.Done()` handler is modified. No other behavior changes.

Cache-impact: low - no persisted format changes, no provider-visible changes, no request serialization changes
Cache-guard: existing TestParallelTasksCancelReturnsPartialAggregate (verifies cancellation still works), go test ./internal/agent/...

---

### 中文

**问题：** `parallel_tasks` 中即将完成的子 Agent 在父轮次上下文取消时被不必要地取消。`ctx.Done()` 处理器的"立即排空+标记取消"模式损害了本可在几百毫秒内完成的子 Agent。

**根因：** `ctx.Done()` 处理器执行非阻塞排空（仅已完成的），然后立即将所有剩余子 Agent 标记为已取消并返回部分结果。完成了工作但即将发送结果到 `doneCh` 的子 Agent 丢失了。

**修复：** 将非阻塞排空替换为 2 秒宽限期（使用 `context.WithTimeout`）。在此宽限期内，正常完成的子 Agent 被正确捕获。宽限期后，仍未完成的子 Agent 通过 `markCancelled` 取消。

这是最小改动（+11 行）——仅修改 `ctx.Done()` 处理器，无其他行为变化。