### PR TITLE
feat(desktop): complete theme pane transparency and dock-tab compression / 完善主题面板透明度体系与侧栏标签压缩

### DIFF
--- a/desktop/frontend/src/lib/themePack.ts
+++ b/desktop/frontend/src/lib/themePack.ts
@@ -457,6 +457,9 @@ function applyBackgroundCSSVars(root: HTMLElement, pack: ThemePackView): void {
     // Clamp to 100% to prevent color-mix from receiving values > 100%.
     root.style.setProperty("--theme-pane-shell-pct", `${Math.min((homePane + 0.08) * 100, 100)}%`);
     root.style.setProperty("--theme-pane-card-pct", `${Math.min((homePane + 0.26) * 100, 100)}%`);
+    root.style.setProperty("--theme-pane-session-hover-pct", `${Math.min((homePane + 0.26) * 100, 100)}%`);
+    root.style.setProperty("--theme-pane-child-pct", `${Math.min((homePane + 0.30) * 100, 100)}%`);
+    root.style.setProperty("--theme-pane-interact-pct", `${Math.min((homePane + 0.40) * 100, 100)}%`);
     // Legacy aliases keep V1 tests and third-party diagnostics stable.
     root.style.setProperty("--theme-bg-image", `url("${cssUrlEscape(homeUrl)}")`);
     root.style.setProperty("--theme-bg-focus-x", `${clamp01(home.focusX) * 100}%`);
@@ -484,6 +487,9 @@ function applyBackgroundCSSVars(root: HTMLElement, pack: ThemePackView): void {
   root.style.setProperty("--theme-pane-task-alpha", String(taskPane));
   root.style.setProperty("--theme-pane-task-shell-pct", `${Math.min((taskPane + 0.08) * 100, 100)}%`);
   root.style.setProperty("--theme-pane-task-card-pct", `${Math.min((taskPane + 0.14) * 100, 100)}%`);
+  root.style.setProperty("--theme-pane-task-session-hover-pct", `${Math.min((taskPane + 0.26) * 100, 100)}%`);
+  root.style.setProperty("--theme-pane-task-child-pct", `${Math.min((taskPane + 0.30) * 100, 100)}%`);
+  root.style.setProperty("--theme-pane-task-interact-pct", `${Math.min((taskPane + 0.40) * 100, 100)}%`);
   const safe = taskSource?.safeArea === "left" || taskSource?.safeArea === "right" ? taskSource.safeArea : "center";
   root.setAttribute("data-theme-safe-area", safe);
   root.setAttribute("data-theme-has-bg", "true");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -27694,7 +27694,7 @@ body > .mermaid-diagram--fullscreen {
   position: absolute;
   left: 10px;
   right: 10px;
-  bottom: -1px;
+  bottom: 1px;
   height: 2px;
   border-radius: 2px;
   background: var(--accent);
@@ -33674,7 +33674,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .workbench-dock__tools,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .workspace-panel,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .statusbar {
-  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-shell-pct, 80%), transparent) !important;
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-shell-pct, 60%), transparent) !important;
 }
 
 /* Home: chat area — controlled by paneOpacity (面板透明度) */
@@ -33684,15 +33684,111 @@ body > .mermaid-diagram--fullscreen {
 
 /* Home: card elements — controlled by the paneOpacity card tier */
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer-card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__usage,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__section,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .topicbar__chrome-btn,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .topicbar__action-btn,
-:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .topicbar__icon-btn {
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .topicbar__icon-btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .external-opener {
   background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-card-pct, 88%), transparent) !important;
 }
 
+/* Home: session/folder hover — session-hover tier */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .hist-item:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .project-tree__topic:hover {
+  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-session-hover-pct, 76%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .project-tree__folder:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .project-tree__folder--active:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .project-tree__folder--menu-open:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) var(--theme-pane-session-hover-pct, 76%), transparent) !important;
+}
+
+/* Home: child elements — neutral backgrounds */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__capacity-card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__source-overview,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__source-row,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__type-overview,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .context-panel__view-switch,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .mermaid-diagram,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .md th,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .diff,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .code,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .md-code,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .copybtn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .msg-meta__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .turn-actions__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .rewind__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .prompt-shelf__card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .prompt-action,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .prompt-shelf__header-button,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .approval-subject,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .ask-shelf__detail,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .welcome__ex,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .banner--update {
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+
+/* Home: child elements — surface-2 base (composer chrome) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer-modebar,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer-task-mode-trigger,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .modelsw__trigger {
+  background: color-mix(in srgb, var(--surface-2) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+
+/* Home: child elements — sidebar nav/utility hover (sidebar-hover base) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .sidebar__navitem:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .sidebar__utility-button:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+
+/* Home: child elements — preserve original colors */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--send {
+  background: color-mix(in srgb, var(--control-primary-bg) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--stop {
+  background: color-mix(in srgb, color-mix(in srgb, var(--err) 14%, var(--bg-elev-2)) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer {
+  background: color-mix(in srgb, color-mix(in srgb, var(--control-primary-bg) 16%, var(--bg-elev-2)) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .msg--user .msg__body {
+  background: color-mix(in srgb, var(--chat-user-bg) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .approval-reason {
+  background: color-mix(in srgb, color-mix(in srgb, var(--warning, #f59e0b) 10%, var(--bg-soft)) var(--theme-pane-child-pct, 80%), transparent) !important;
+}
+
+/* Home: interact elements — hover/active states */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .turn-actions__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .rewind__btn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .msg-meta__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .msg-meta .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer-task-mode-trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .modelsw__trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .prompt-action:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .prompt-shelf__header-button:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .welcome__ex:hover {
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-interact-pct, 90%), transparent) !important;
+}
+/* Home: interact — colored button hover (use original darker formula, no transparency) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--send:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 88%, #000) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--stop:hover {
+  background: color-mix(in srgb, var(--err) 38%, var(--bg-elev-2)) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 24%, var(--bg-elev-2)) !important;
+}
+/* Home: active modebar item hover — mirror send-btn darken pattern */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .composer-modebar__item--active:hover {
+  background: color-mix(in srgb, var(--composer-modebar-active-bg) 88%, #000) !important;
+}
+
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .workspace-change-scope__head {
-  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-shell-pct, 80%), transparent) !important;
+  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-shell-pct, 60%), transparent) !important;
 }
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .transcript,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="home"] .app:not(.app--creation) .transcript-shell {
@@ -33706,7 +33802,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .workbench-dock__tools,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .workspace-panel,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .statusbar {
-  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-task-shell-pct, 88%), transparent) !important;
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-task-shell-pct, 78%), transparent) !important;
 }
 
 /* Task: chat area — controlled by paneOpacity (面板透明度) */
@@ -33716,15 +33812,109 @@ body > .mermaid-diagram--fullscreen {
 
 /* Task: card elements — controlled by the paneOpacity card tier */
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer-card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__usage,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__section,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .topicbar__chrome-btn,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .topicbar__action-btn,
-:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .topicbar__icon-btn {
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .topicbar__icon-btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .external-opener {
   background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-task-card-pct, 88%), transparent) !important;
 }
 
+/* Task: session/folder hover — session-hover tier */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .hist-item:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .project-tree__topic:hover {
+  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-task-session-hover-pct, 94%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .project-tree__folder:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .project-tree__folder--active:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .project-tree__folder--menu-open:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) var(--theme-pane-task-session-hover-pct, 94%), transparent) !important;
+}
+
+/* Task: child elements — neutral backgrounds */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__capacity-card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__source-overview,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__source-row,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__type-overview,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .context-panel__view-switch,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .mermaid-diagram,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .md th,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .diff,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .code,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .md-code,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .copybtn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .msg-meta__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .turn-actions__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .rewind__btn,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .prompt-shelf__card,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .prompt-action,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .prompt-shelf__header-button,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .approval-subject,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .ask-shelf__detail,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .banner--update {
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+
+/* Task: child elements — surface-2 base (composer chrome) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer-modebar,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer-task-mode-trigger,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .modelsw__trigger {
+  background: color-mix(in srgb, var(--surface-2) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+
+/* Task: child elements — sidebar nav/utility hover (sidebar-hover base) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .sidebar__navitem:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .sidebar__utility-button:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+
+/* Task: child elements — preserve original colors */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--send {
+  background: color-mix(in srgb, var(--control-primary-bg) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--stop {
+  background: color-mix(in srgb, color-mix(in srgb, var(--err) 14%, var(--bg-elev-2)) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer {
+  background: color-mix(in srgb, color-mix(in srgb, var(--control-primary-bg) 16%, var(--bg-elev-2)) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .msg--user .msg__body {
+  background: color-mix(in srgb, var(--chat-user-bg) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .approval-reason {
+  background: color-mix(in srgb, color-mix(in srgb, var(--warning, #f59e0b) 10%, var(--bg-soft)) var(--theme-pane-task-child-pct, 98%), transparent) !important;
+}
+
+/* Task: interact elements — hover/active states */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .turn-actions__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .rewind__btn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .msg-meta__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .msg-meta .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer-task-mode-trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .modelsw__trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .prompt-action:hover,
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .prompt-shelf__header-button:hover {
+  background: color-mix(in srgb, var(--bg-elev) var(--theme-pane-task-interact-pct, 100%), transparent) !important;
+}
+/* Task: interact — colored button hover (use original darker formula, no transparency) */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--send:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 88%, #000) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--stop:hover {
+  background: color-mix(in srgb, var(--err) 38%, var(--bg-elev-2)) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 24%, var(--bg-elev-2)) !important;
+}
+/* Task: active modebar item hover — mirror send-btn darken pattern */
+:root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .composer-modebar__item--active:hover {
+  background: color-mix(in srgb, var(--composer-modebar-active-bg) 88%, #000) !important;
+}
+
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .workspace-change-scope__head {
-  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-task-shell-pct, 88%), transparent) !important;
+  background: color-mix(in srgb, var(--bg-soft) var(--theme-pane-task-shell-pct, 78%), transparent) !important;
 }
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .transcript,
 :root[data-theme-pack][data-theme-has-bg="true"][data-theme-scene="task"] .app:not(.app--creation) .transcript-shell {
@@ -33747,11 +33937,107 @@ body > .mermaid-diagram--fullscreen {
   background: transparent !important;
 }
 :root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer-card,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__usage,
 :root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__section,
 :root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .topicbar__chrome-btn,
 :root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .topicbar__action-btn,
-:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .topicbar__icon-btn {
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .topicbar__icon-btn,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .external-opener {
   background: color-mix(in srgb, var(--bg-elev) 88%, transparent) !important;
+}
+
+/* Fallback: session/folder hover */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .hist-item:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .project-tree__topic:hover {
+  background: color-mix(in srgb, var(--bg-soft) 76%, transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .project-tree__folder:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .project-tree__folder--active:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .project-tree__folder--menu-open:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) 76%, transparent) !important;
+}
+
+/* Fallback: child elements — neutral backgrounds */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__capacity-card,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__source-overview,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__source-row,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__type-overview,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .context-panel__view-switch,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .mermaid-diagram,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .md th,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .diff,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .code,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .md-code,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .copybtn,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .msg-meta__btn,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .turn-actions__btn,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .rewind__btn,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .prompt-shelf__card,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .prompt-action,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .prompt-shelf__header-button,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .approval-subject,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .ask-shelf__detail,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .welcome__ex,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .banner--update {
+  background: color-mix(in srgb, var(--bg-elev) 80%, transparent) !important;
+}
+
+/* Fallback: child elements — surface-2 base (composer chrome) */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer-modebar,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer-task-mode-trigger,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .modelsw__trigger {
+  background: color-mix(in srgb, var(--surface-2) 80%, transparent) !important;
+}
+
+/* Fallback: child elements — sidebar nav/utility hover (sidebar-hover base) */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .sidebar__navitem:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .sidebar__utility-button:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) 80%, transparent) !important;
+}
+
+/* Fallback: child elements — preserve original colors */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--send {
+  background: color-mix(in srgb, var(--control-primary-bg) 80%, transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--stop {
+  background: color-mix(in srgb, color-mix(in srgb, var(--err) 14%, var(--bg-elev-2)) 80%, transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer {
+  background: color-mix(in srgb, color-mix(in srgb, var(--control-primary-bg) 16%, var(--bg-elev-2)) 80%, transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .msg--user .msg__body {
+  background: color-mix(in srgb, var(--chat-user-bg) 80%, transparent) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .approval-reason {
+  background: color-mix(in srgb, color-mix(in srgb, var(--warning, #f59e0b) 10%, var(--bg-soft)) 80%, transparent) !important;
+}
+
+/* Fallback: interact elements — hover/active states */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .turn-actions__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .rewind__btn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .msg-meta__btn:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .msg-meta .copybtn:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer-task-mode-trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .modelsw__trigger:hover:not(:disabled),
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .prompt-action:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .prompt-shelf__header-button:hover,
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .welcome__ex:hover {
+  background: color-mix(in srgb, var(--bg-elev) 90%, transparent) !important;
+}
+/* Fallback: interact — colored button hover (use original darker formula, no transparency) */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--send:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 88%, #000) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--stop:hover {
+  background: color-mix(in srgb, var(--err) 38%, var(--bg-elev-2)) !important;
+}
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer__btn--send.composer__btn--steer:hover {
+  background: color-mix(in srgb, var(--control-primary-bg) 24%, var(--bg-elev-2)) !important;
+}
+/* Fallback: active modebar item hover — mirror send-btn darken pattern */
+:root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .composer-modebar__item--active:hover {
+  background: color-mix(in srgb, var(--composer-modebar-active-bg) 88%, #000) !important;
 }
 :root[data-theme-pack][data-theme-has-bg="true"] .app:not(.app--creation) .workspace-change-scope__head {
   background: color-mix(in srgb, var(--bg-soft) 80%, transparent) !important;
@@ -36137,4 +36423,31 @@ body > .mermaid-diagram--fullscreen {
    padding that would otherwise waste space between the status bar and terminal. */
 .footer.footer--compact {
   padding-bottom: 4px !important;
+}
+
+/* ── Windows frameless workbench: dock tab compression ─────────── */
+/* Only compress spacing; never shrink tabs or truncate labels.
+   Classic layout (.app--classic) is untouched. */
+@container (max-width: 420px) {
+  .app--windows-frameless.app--workbench .workbench-dock__tools,
+  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools {
+    /* 420 px dock → 12 px left pad     300 px dock →  4 px          */
+    padding-left: clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
+  }
+  .app--windows-frameless.app--workbench .workbench-dock__tabs,
+  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tabs {
+    /* 420 px dock →  2 px gap          300 px dock →  0 px          */
+    gap: clamp(0px, calc(1.667 * 1cqi - 5px), 2px);
+  }
+  .app--windows-frameless.app--workbench .workbench-dock__tab,
+  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tab {
+    flex: 0 0 auto;
+    min-width: auto;
+    max-width: none;
+    /* 420 px dock → 12 px padding      300 px dock →  4 px          */
+    padding-left:  clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
+    padding-right: clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
+    /* icon↔label gap: 420→6px          300→2px                     */
+    gap:           clamp(2px, calc(3.333 * 1cqi - 8px), 6px);
+  }
 }


### PR DESCRIPTION
## Summary

This PR extends the theme pack background system with a five-tier pane transparency architecture, merges the Windows frameless dock-tab overlap fix, and corrects several CSS-target gaps discovered during testing.

### Five-tier pane transparency system

When a theme pack with a background image is active, the paneOpacity slider controls how much the background image shows through the UI. Previously only the primary panes (sidebar, chat-pane) had transparency. This PR adds a **five-tier hierarchy** with pre-computed CSS custom properties:

| Tier | CSS variable | Offset | Default (Home) | Default (Task) |
|------|-------------|--------|----------------|----------------|
| Shell | `--theme-pane-shell-pct` | unchanged (+0.08) | 58% | 76% |
| Card | `--theme-pane-card-pct` | unchanged (+0.26 / +0.14) | 76% | 82% |
| Session-hover | `--theme-pane-session-hover-pct` | +0.26 | 76% | 94% |
| Child | `--theme-pane-child-pct` | +0.30 | 80% | 98% |
| Interact | `--theme-pane-interact-pct` | +0.40 | 90% | 100% |

Each tier is deployed across three CSS selector groups: **Home scene**, **Task scene**, and a **scene-independent fallback** (for packs that don't define a scene).

**Shell tier** — sidebar, topicbar, workbench-dock, workspace-panel, statusbar, layout.

**Card tier** — composer-card, context-panel__section, context-panel__usage, topicbar buttons (chrome-btn, action-btn, icon-btn), external-opener.

**Session-hover tier** — `.hist-item:hover` (HistoryPanel modal), `.project-tree__topic:hover` (sidebar session list), `.project-tree__folder:hover` (sidebar folders). All use `--theme-pane-session-hover-pct` so they respond uniformly to the panel opacity slider.

**Child tier** — context-panel cards/rows/switches, mermaid diagrams, code blocks, copy/rewind/turn-action buttons, prompt-shelf cards, approval cards, msg-meta buttons, **welcome example buttons** (`.welcome__ex`), **update banner** (`.banner--update`), composer-modebar, sidebar nav/utility hover, and colored elements (send/stop/steer buttons, user message bubbles, approval warnings) — each using its own natural color variable as the `color-mix` base.

**Interact tier** — hover states for all buttons in the child tier plus modebar active hover. Colored buttons (send/stop/steer) use the original darken formula rather than transparency, preserving their visual weight.

### Dock-tab underline fix

Moved `workbench-dock__tab--active::after` from `bottom: -1px` (outside the button, clipped by content below) to `bottom: 1px` (inside) so the accent underline is uniformly visible across all three tabs.

### Windows frameless dock-tab overlap (#5825)

**Cause.** On Windows frameless, the custom window-controls box (138 px wide, `position: fixed`) sits at the top-right corner. `workbench-dock__tools` reserves `padding-right: 156 px` to keep the three view tabs — Overview, Files, Changes — clear. However, themed styles (`:root[data-theme-style]`) unconditionally set `flex: 0 0 auto; min-width: auto` on `.workbench-dock__tab`, preventing the tabs from shrinking when the right dock narrows. When the dock is dragged to its minimum width (300 px tree / 420 px preview) the three auto-sized tabs overflow the available content area, pushing the rightmost "Changes" tab under the window-controls box where it is invisible and unclickable.

**Fix.** An `@container (max-width: 420 px)` query appended at end-of-file, scoped entirely to `.app--windows-frameless.app--workbench` so Classic, Creation, macOS, and Linux layouts are unaffected:

- **Spacing-only** strategy: `padding-left` (tools), `gap` (tabs container), `padding` (each tab), and icon↔label `gap` are compressed via `clamp()` with `cqi` units from their defaults at 420 px dock down to sensible minima (4 px / 2 px / 0 px) at 300 px dock.
- Tabs stay `flex: 0 0 auto` — **never shrink, labels are never truncated**.

### Design invariant

All pane transparency rules are guarded by `[data-theme-pack][data-theme-has-bg="true"]`. When no theme pack is active, every element retains its original 100%-opaque appearance — exactly as before this PR.

## Verification

- Built and tested on Windows 11 (Workbench layout, theme pack with background active).
- `gofmt` ✓  `go vet ./...` ✓
- Existing test suite: `go test ./internal/tool/builtin/ ./internal/boot/` passes.
- DevTools console confirmed `data-theme-pack` and `data-theme-has-bg` attributes present when pack is active; absent when cleared.

## Files changed

| File | Delta |
|------|-------|
| `desktop/frontend/src/lib/themePack.ts` | +6 |
| `desktop/frontend/src/styles.css` | +321 / −8 |

## Cache impact

Cache-impact: none — CSS-only frontend change. No Go, provider, boot, config, memory, skill, or output-style files are touched.
Cache-guard: existing theme-pack tests (`theme-pack.test.ts`) exercise the pack activation path and CSS-variable surface; dock-tab selectors are guarded by `app-chrome-tabs.test.ts`.
System-prompt-review: N/A

---

## 摘要

本 PR 在主题包背景系统之上扩展了五档面板透明度架构，并修复了 Windows 无边框侧栏标签遮挡问题，同时修正了实测中发现的多个 CSS 选择器目标错误。

### 五档面板透明度体系

当激活含背景图片的主题包时，面板透明度滑块控制背景图片透过 UI 的可见程度。之前仅主面板（sidebar、chat-pane）具有透明度。本 PR 新增**五档层级体系**，使用预计算的 CSS 自定义属性：

| 层级 | CSS 变量 | 偏移 | 默认值(Home) | 默认值(Task) |
|------|-------------|--------|----------------|----------------|
| Shell | `--theme-pane-shell-pct` | unchanged (+0.08) | 58% | 76% |
| Card | `--theme-pane-card-pct` | unchanged (+0.26 / +0.14) | 76% | 82% |
| Session-hover | `--theme-pane-session-hover-pct` | +0.26 | 76% | 94% |
| Child | `--theme-pane-child-pct` | +0.30 | 80% | 98% |
| Interact | `--theme-pane-interact-pct` | +0.40 | 90% | 100% |

每档通过三组 CSS 选择器部署：**Home 场景**、**Task 场景**，以及**场景无关的 fallback**（适用于未定义场景的主题包）。

**Shell 层级** — sidebar、topicbar、workbench-dock、workspace-panel、statusbar、layout。

**Card 层级** — composer-card、context-panel__section、context-panel__usage、topicbar 按钮（chrome-btn、action-btn、icon-btn）、external-opener。

**Session-hover 层级** — `.hist-item:hover`（历史面板模态框）、`.project-tree__topic:hover`（侧边栏会话列表）、`.project-tree__folder:hover`（侧边栏文件夹）。全部使用 `--theme-pane-session-hover-pct`，统一响应面板透明度滑块。

**Child 层级** — context-panel 卡片/行/开关、mermaid 图表、代码块、copy/rewind/turn-action 按钮、prompt-shelf 卡片、审批卡片、msg-meta 按钮、**Welcome 示例按钮**（`.welcome__ex`）、**更新横幅**（`.banner--update`）、composer-modebar、侧边栏导航/工具悬浮、以及彩色元素（发送/停止/steer 按钮、用户消息气泡、审批警告）——每个使用自身的颜色变量作为 `color-mix` 基色。

**Interact 层级** — Child 层级所有按钮的悬浮态，以及 modebar 选中悬浮。彩色按钮（发送/停止/steer）使用原始加深公式而非透明度，保留其视觉权重。

### 选中标签下划线

将 `workbench-dock__tab--active::after` 从 `bottom: -1px`（按钮外部，被下方内容裁剪）移至 `bottom: 1px`（按钮内部），使三个标签的强调下划线均匀可见。

### Windows 无边框侧栏标签遮挡（#5825）

**起因。** Windows 无边框模式下，自定义窗口控件（138 px 宽，`position: fixed`）固定在右上角。`workbench-dock__tools` 预留了 `padding-right: 156 px` 以避免"概览 / 文件 / 改动"三个标签被遮挡，但主题样式（`:root[data-theme-style]`）无条件地将 `.workbench-dock__tab` 设为 `flex: 0 0 auto; min-width: auto`，阻止了标签在窄屏下收缩。当右侧栏收窄至最小宽度（tree 模式 300 px / preview 模式 420 px）时，三个按内容自适应的标签溢出内容区，最右侧的"改动"标签被推到窗口控件下方，不可见、不可点击。

**修复。** 在 CSS 文件末尾追加一个 `@container (max-width: 420 px)` 查询，全部用 `.app--windows-frameless.app--workbench` 限定，经典、创作、macOS、Linux 布局均不受影响：

- **仅压缩间距**策略：`padding-left`（tools）、`gap`（tabs 容器）、`padding`（每个 tab）以及图标↔标签 `gap` 通过 `clamp()` 配合 `cqi` 单位从 420 px dock 时的默认值渐进压缩至 300 px dock 时的合理最小值（4 px / 2 px / 0 px）。
- 标签保持 `flex: 0 0 auto`——**从不收缩，文字永不截断**。

### 设计不变量

所有面板透明度规则均以 `[data-theme-pack][data-theme-has-bg="true"]` 守卫。无主题包激活时，每个元素保持原始 100% 不透明外观——与 PR 之前完全一致。

## 验证

- Windows 11 实机构建测试（工作台布局，已激活含背景的主题包）。
- `gofmt` ✓  `go vet ./...` ✓
- 现有测试套件通过。
- DevTools Console 确认主题包激活时 `data-theme-pack` 和 `data-theme-has-bg` 属性存在；清除后消失。

## 文件变更

| 文件 | 变更量 |
|------|-------|
| `desktop/frontend/src/lib/themePack.ts` | +6 |
| `desktop/frontend/src/styles.css` | +321 / −8 |

## 缓存影响

Cache-impact: none — 仅前端 CSS 变更。未触及 Go、provider、boot、config、memory、skill、output-style 任一文件。
Cache-guard: 现有主题包测试覆盖 pack 激活路径和 CSS 变量表面；dock-tab 选择器由现有 UI 测试守卫。
System-prompt-review: N/A

---

Closes #5825.

---

## 效果展示

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/ed4f4557-941b-4d24-90e1-1d3cb9b6ad3d" />

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/34a5d3cd-0732-4afd-ad7b-6e485e2abd08" />

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/b465098f-10d2-484e-9713-c7e37dc1ec54" />