### PR TITLE
fix(config): 修复permissions配置更新时的数据丢失问题

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1708,8 +1708,21 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 func rememberPermissionRule(workspaceRoot, rule string) control.RememberResult {
 	path := rememberPermissionConfigPath(workspaceRoot)
-	edit := config.LoadForEdit(path)
 	result := control.RememberResult{Rule: strings.TrimSpace(rule), Path: path}
+	unlock, err := config.LockConfigFileEdits(path)
+	if err != nil {
+		slog.Warn("lock config for permission rule", "path", path, "err", err)
+		result.Err = err
+		return result
+	}
+	defer unlock()
+
+	edit, err := config.LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		slog.Warn("load config for permission rule", "path", path, "err", err)
+		result.Err = err
+		return result
+	}
 	if coveredBy := coveredPermissionRule(edit.Permissions.Allow, result.Rule); coveredBy != "" {
 		result.CoveredBy = coveredBy
 		return result
@@ -1720,7 +1733,7 @@ func rememberPermissionRule(workspaceRoot, rule string) control.RememberResult {
 		result.Err = err
 		return result
 	}
-	if err := config.WritePermissionsSection(path, edit.Permissions.Allow); err != nil {
+	if err := config.WritePermissionsAllow(path, edit.Permissions.Allow); err != nil {
 		slog.Warn("save config after permission rule", "err", err)
 		result.Err = err
 		return result

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -3263,6 +3264,221 @@ allow = ["Bash(workspace*)"]
 	workspaceCfg := config.LoadForEdit(filepath.Join(workspace, "reasonix.toml"))
 	if !hasPermissionRule(workspaceCfg.Permissions.Allow, rule) {
 		t.Fatalf("remembered rule missing from workspace config: %v", workspaceCfg.Permissions.Allow)
+	}
+}
+
+func TestRememberPermissionRulePreservesPermissionPolicyAndComments(t *testing.T) {
+	workspace := robustTempDir(t)
+	writeFile(t, workspace, "reasonix.toml", `
+[permissions]
+# Keep this rationale with the policy.
+mode = "deny"
+allow = ["Bash(existing)"] # Keep this allow rationale.
+ask = ["Edit(*.env)"]
+deny = ["Bash(rm:*)"]
+future_policy = "keep"
+
+[desktop]
+legacy_preference = "keep"
+`)
+
+	const rule = "Edit(src/app.go)"
+	result := rememberPermissionRule(workspace, rule)
+	if result.Err != nil || !result.Saved {
+		t.Fatalf("remember result = %+v, want saved without error", result)
+	}
+
+	path := filepath.Join(workspace, "reasonix.toml")
+	got := config.LoadForEdit(path)
+	if got.Permissions.Mode != "deny" {
+		t.Errorf("permissions.mode = %q, want deny", got.Permissions.Mode)
+	}
+	if !reflect.DeepEqual(got.Permissions.Ask, []string{"Edit(*.env)"}) {
+		t.Errorf("permissions.ask = %v, want existing ask policy", got.Permissions.Ask)
+	}
+	if !reflect.DeepEqual(got.Permissions.Deny, []string{"Bash(rm:*)"}) {
+		t.Errorf("permissions.deny = %v, want existing deny policy", got.Permissions.Deny)
+	}
+	if !hasPermissionRule(got.Permissions.Allow, "Bash(existing)") || !hasPermissionRule(got.Permissions.Allow, rule) {
+		t.Errorf("permissions.allow = %v, want existing and remembered rules", got.Permissions.Allow)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		"# Keep this rationale with the policy.",
+		"# Keep this allow rationale.",
+		`future_policy = "keep"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("permissions content %q was not preserved:\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, "[desktop]\nlegacy_preference = \"keep\"") {
+		t.Errorf("unrelated section was not preserved:\n%s", body)
+	}
+}
+
+func TestRememberPermissionRuleRejectsMalformedConfigWithoutWriting(t *testing.T) {
+	workspace := robustTempDir(t)
+	path := filepath.Join(workspace, "reasonix.toml")
+	original := []byte("[permissions]\nmode = \"deny\"\nallow = [\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := rememberPermissionRule(workspace, "Edit(src/app.go)")
+	if result.Err == nil || result.Saved {
+		t.Fatalf("remember result = %+v, want parse error without save", result)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("malformed config changed:\ngot:\n%s\nwant:\n%s", got, original)
+	}
+}
+
+func TestRememberPermissionRuleSerializesConcurrentWriters(t *testing.T) {
+	workspace := robustTempDir(t)
+	writeFile(t, workspace, "reasonix.toml", "[permissions]\nallow = []\n")
+
+	const writers = 32
+	start := make(chan struct{})
+	results := make(chan control.RememberResult, writers)
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			results <- rememberPermissionRule(workspace, fmt.Sprintf("Edit(file-%02d)", n))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		if result.Err != nil || !result.Saved {
+			t.Errorf("remember result = %+v, want saved without error", result)
+		}
+	}
+
+	got := config.LoadForEdit(filepath.Join(workspace, "reasonix.toml"))
+	for i := 0; i < writers; i++ {
+		rule := fmt.Sprintf("Edit(file-%02d)", i)
+		if !hasPermissionRule(got.Permissions.Allow, rule) {
+			t.Errorf("permissions.allow missing %q: %v", rule, got.Permissions.Allow)
+		}
+	}
+}
+
+func TestRememberPermissionRuleSerializesCrossProcessWriters(t *testing.T) {
+	workspace := robustTempDir(t)
+	writeFile(t, workspace, "reasonix.toml", "[permissions]\nallow = []\n")
+	readyDir := robustTempDir(t)
+	startPath := filepath.Join(readyDir, "start")
+
+	const workers = 4
+	const rulesPerWorker = 8
+	commands := make([]*exec.Cmd, 0, workers)
+	outputs := make([]bytes.Buffer, workers)
+	for worker := 0; worker < workers; worker++ {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestRememberPermissionRuleProcessHelper$")
+		cmd.Stdout = &outputs[worker]
+		cmd.Stderr = &outputs[worker]
+		cmd.Env = append(os.Environ(),
+			"REASONIX_PERMISSION_HELPER=1",
+			"REASONIX_PERMISSION_WORKSPACE="+workspace,
+			"REASONIX_PERMISSION_READY_DIR="+readyDir,
+			"REASONIX_PERMISSION_START="+startPath,
+			fmt.Sprintf("REASONIX_PERMISSION_WORKER=%d", worker),
+			fmt.Sprintf("REASONIX_PERMISSION_RULES=%d", rulesPerWorker),
+		)
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		commands = append(commands, cmd)
+	}
+	t.Cleanup(func() {
+		for _, cmd := range commands {
+			if cmd.ProcessState == nil {
+				_ = cmd.Process.Kill()
+				_, _ = cmd.Process.Wait()
+			}
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for worker := 0; worker < workers; {
+		if _, err := os.Stat(filepath.Join(readyDir, fmt.Sprintf("ready-%d", worker))); err == nil {
+			worker++
+			continue
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("permission helper processes did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := os.WriteFile(startPath, []byte("start"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i, cmd := range commands {
+		if err := cmd.Wait(); err != nil {
+			t.Fatalf("permission helper failed: %v\n%s", err, outputs[i].String())
+		}
+	}
+
+	got := config.LoadForEdit(filepath.Join(workspace, "reasonix.toml"))
+	for worker := 0; worker < workers; worker++ {
+		for n := 0; n < rulesPerWorker; n++ {
+			rule := fmt.Sprintf("Edit(process-%d-file-%02d)", worker, n)
+			if !hasPermissionRule(got.Permissions.Allow, rule) {
+				t.Errorf("permissions.allow missing %q: %v", rule, got.Permissions.Allow)
+			}
+		}
+	}
+}
+
+func TestRememberPermissionRuleProcessHelper(t *testing.T) {
+	if os.Getenv("REASONIX_PERMISSION_HELPER") != "1" {
+		return
+	}
+	workspace := os.Getenv("REASONIX_PERMISSION_WORKSPACE")
+	readyDir := os.Getenv("REASONIX_PERMISSION_READY_DIR")
+	startPath := os.Getenv("REASONIX_PERMISSION_START")
+	t.Setenv("REASONIX_CACHE_HOME", readyDir)
+	worker, err := strconv.Atoi(os.Getenv("REASONIX_PERMISSION_WORKER"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules, err := strconv.Atoi(os.Getenv("REASONIX_PERMISSION_RULES"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(readyDir, fmt.Sprintf("ready-%d", worker)), []byte("ready"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(startPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for permission helper start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	for n := 0; n < rules; n++ {
+		rule := fmt.Sprintf("Edit(process-%d-file-%02d)", worker, n)
+		result := rememberPermissionRule(workspace, rule)
+		if result.Err != nil || !result.Saved {
+			t.Fatalf("remember result = %+v, want saved without error", result)
+		}
 	}
 }
 

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3322,6 +3322,40 @@ legacy_preference = "keep"
 	}
 }
 
+func TestRememberPermissionRuleIgnoresTOMLExampleInMultilineSystemPrompt(t *testing.T) {
+	workspace := robustTempDir(t)
+	writeFile(t, workspace, "reasonix.toml", `[agent]
+system_prompt = """
+Example only:
+[permissions]
+allow = ["Bash(example)"]
+"""
+
+[permissions]
+mode = "ask"
+allow = ["Bash(existing)"]
+deny = ["Bash(rm:*)"]
+`)
+
+	const rule = "Edit(src/app.go)"
+	result := rememberPermissionRule(workspace, rule)
+	if result.Err != nil || !result.Saved {
+		t.Fatalf("remember result = %+v, want saved without error", result)
+	}
+
+	path := filepath.Join(workspace, "reasonix.toml")
+	got, err := config.LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		t.Fatalf("updated config does not parse: %v", err)
+	}
+	if !reflect.DeepEqual(got.Permissions.Allow, []string{"Bash(existing)", rule}) {
+		t.Fatalf("permissions.allow = %v", got.Permissions.Allow)
+	}
+	if !strings.Contains(got.Agent.SystemPrompt, "[permissions]\nallow = [\"Bash(example)\"]") {
+		t.Fatalf("system prompt example changed: %q", got.Agent.SystemPrompt)
+	}
+}
+
 func TestRememberPermissionRuleRejectsMalformedConfigWithoutWriting(t *testing.T) {
 	workspace := robustTempDir(t)
 	path := filepath.Join(workspace, "reasonix.toml")

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -9,7 +9,10 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
+
+	"github.com/BurntSushi/toml"
 
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
@@ -1333,10 +1336,17 @@ func WritePermissionsAllow(path string, allow []string) error {
 	body := string(raw)
 	if body == "" {
 		body = fmt.Sprintf("[permissions]\nallow = %s\n", renderStringArray(allow))
-		return writeConfigFile(path, body)
+	} else {
+		body = upsertTOMLSectionKey(body, "permissions", "allow", "allow = "+renderStringArray(allow))
 	}
 
-	body = upsertTOMLSectionKey(body, "permissions", "allow", "allow = "+renderStringArray(allow))
+	var candidate Config
+	if _, err := toml.Decode(body, &candidate); err != nil {
+		return fmt.Errorf("write permissions: validate updated config: %w", err)
+	}
+	if !slices.Equal(candidate.Permissions.Allow, allow) {
+		return fmt.Errorf("write permissions: validate updated allow: got %v, want %v", candidate.Permissions.Allow, allow)
+	}
 	return writeConfigFile(path, body)
 }
 
@@ -1346,8 +1356,12 @@ func WritePermissionsAllow(path string, allow []string) error {
 // at the end.
 func replaceTOMLSection(body, sectionName, newContent string) string {
 	spans := tomlLineSpans(body)
+	structural := tomlStructuralLineMask(spans)
 	arrayIdx := -1
 	for i, span := range spans {
+		if !structural[i] {
+			continue
+		}
 		name, isArray, ok := tomlEditSectionHeader(span.text)
 		if ok && isArray && name == sectionName {
 			arrayIdx = i
@@ -1358,6 +1372,9 @@ func replaceTOMLSection(body, sectionName, newContent string) string {
 		start := spans[arrayIdx].start
 		end := len(body)
 		for i := arrayIdx + 1; i < len(spans); i++ {
+			if !structural[i] {
+				continue
+			}
 			name, isArray, ok := tomlEditSectionHeader(spans[i].text)
 			if !ok {
 				continue
@@ -1371,13 +1388,19 @@ func replaceTOMLSection(body, sectionName, newContent string) string {
 		return body[:start] + strings.TrimRight(newContent, "\n") + "\n" + body[end:]
 	}
 
-	for _, span := range spans {
+	for i, span := range spans {
+		if !structural[i] {
+			continue
+		}
 		name, isArray, ok := tomlEditSectionHeader(span.text)
 		if !ok || isArray || name != sectionName {
 			continue
 		}
 		end := len(body)
-		for _, next := range spans {
+		for nextIdx, next := range spans {
+			if !structural[nextIdx] {
+				continue
+			}
 			if next.start <= span.start {
 				continue
 			}
@@ -1394,9 +1417,13 @@ func replaceTOMLSection(body, sectionName, newContent string) string {
 func upsertTOMLSectionKey(body, sectionName, key, line string) string {
 	line = strings.TrimRight(line, "\r\n") + "\n"
 	spans := tomlLineSpans(body)
+	structural := tomlStructuralLineMask(spans)
 	sectionIdx := -1
 	sectionEnd := len(body)
 	for i, span := range spans {
+		if !structural[i] {
+			continue
+		}
 		name, isArray, ok := tomlEditSectionHeader(span.text)
 		if ok {
 			if sectionIdx >= 0 {
@@ -1435,47 +1462,131 @@ func upsertTOMLSectionKey(body, sectionName, key, line string) string {
 }
 
 type tomlLexState struct {
-	inBasic   bool
-	inLiteral bool
-	escaped   bool
+	stringKind tomlStringKind
+	escaped    bool
+}
+
+type tomlStringKind uint8
+
+const (
+	tomlStringNone tomlStringKind = iota
+	tomlStringBasic
+	tomlStringLiteral
+	tomlStringMultilineBasic
+	tomlStringMultilineLiteral
+)
+
+func (s tomlLexState) inMultilineString() bool {
+	return s.stringKind == tomlStringMultilineBasic || s.stringKind == tomlStringMultilineLiteral
 }
 
 func scanTOMLLine(line string, state *tomlLexState, outsideString func(byte)) int {
-	for i := 0; i < len(line); i++ {
+	for i := 0; i < len(line); {
 		ch := line[i]
-		if state.escaped {
-			state.escaped = false
-			continue
-		}
-		if state.inBasic {
+		switch state.stringKind {
+		case tomlStringBasic:
+			if state.escaped {
+				state.escaped = false
+				i++
+				continue
+			}
 			switch ch {
 			case '\\':
 				state.escaped = true
 			case '"':
-				state.inBasic = false
+				state.stringKind = tomlStringNone
 			}
+			i++
 			continue
-		}
-		if state.inLiteral {
+		case tomlStringLiteral:
 			if ch == '\'' {
-				state.inLiteral = false
+				state.stringKind = tomlStringNone
 			}
+			i++
+			continue
+		case tomlStringMultilineBasic:
+			if state.escaped {
+				state.escaped = false
+				i++
+				continue
+			}
+			if ch == '\\' {
+				state.escaped = true
+				i++
+				continue
+			}
+			if ch == '"' {
+				run := tomlQuoteRun(line, i, '"')
+				if run >= 3 {
+					state.stringKind = tomlStringNone
+				}
+				i += run
+				continue
+			}
+			i++
+			continue
+		case tomlStringMultilineLiteral:
+			if ch == '\'' {
+				run := tomlQuoteRun(line, i, '\'')
+				if run >= 3 {
+					state.stringKind = tomlStringNone
+				}
+				i += run
+				continue
+			}
+			i++
 			continue
 		}
+
 		switch ch {
 		case '#':
 			return i
 		case '"':
-			state.inBasic = true
+			run := tomlQuoteRun(line, i, '"')
+			switch {
+			case run == 1:
+				state.stringKind = tomlStringBasic
+			case run >= 3 && run < 6:
+				state.stringKind = tomlStringMultilineBasic
+			}
+			i += run
+			continue
 		case '\'':
-			state.inLiteral = true
+			run := tomlQuoteRun(line, i, '\'')
+			switch {
+			case run == 1:
+				state.stringKind = tomlStringLiteral
+			case run >= 3 && run < 6:
+				state.stringKind = tomlStringMultilineLiteral
+			}
+			i += run
+			continue
 		default:
 			if outsideString != nil {
 				outsideString(ch)
 			}
 		}
+		i++
 	}
 	return -1
+}
+
+func tomlQuoteRun(line string, start int, quote byte) int {
+	end := start
+	for end < len(line) && line[end] == quote {
+		end++
+	}
+	return end - start
+}
+
+func tomlStructuralLineMask(spans []tomlLineSpan) []bool {
+	structural := make([]bool, len(spans))
+	state := tomlLexState{}
+	for i, span := range spans {
+		structural[i] = !state.inMultilineString()
+		scanTOMLLine(span.text, &state, nil)
+	}
+	return structural
 }
 
 func tomlValueEndSpan(spans []tomlLineSpan, start int) int {

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1313,10 +1313,11 @@ func configFilePerm(path string) os.FileMode {
 	return 0o644
 }
 
-// WritePermissionsSection replaces or creates the [permissions] section in a
-// TOML file, preserving all other sections verbatim. When the file doesn't
-// exist yet, it creates one containing only the permissions section.
-func WritePermissionsSection(path string, allow []string) error {
+// WritePermissionsAllow updates only permissions.allow in a TOML file. All
+// other permission policy fields and unrelated content remain byte-for-byte
+// unchanged. Callers must validate and lock the latest file across their full
+// read-modify-write transaction before calling this function.
+func WritePermissionsAllow(path string, allow []string) error {
 	if strings.TrimSpace(path) == "" {
 		return fmt.Errorf("write permissions: empty config path")
 	}
@@ -1329,14 +1330,13 @@ func WritePermissionsSection(path string, allow []string) error {
 		raw = nil
 	}
 
-	newBlock := fmt.Sprintf("[permissions]\nallow = %s\n", renderStringArray(allow))
-
 	body := string(raw)
 	if body == "" {
-		return writeConfigFile(path, newBlock)
+		body = fmt.Sprintf("[permissions]\nallow = %s\n", renderStringArray(allow))
+		return writeConfigFile(path, body)
 	}
 
-	body = replaceTOMLSection(body, "permissions", newBlock)
+	body = upsertTOMLSectionKey(body, "permissions", "allow", "allow = "+renderStringArray(allow))
 	return writeConfigFile(path, body)
 }
 
@@ -1410,7 +1410,16 @@ func upsertTOMLSectionKey(body, sectionName, key, line string) string {
 		}
 		if sectionIdx >= 0 {
 			if got, _, ok := tomlKeyValue(span.text); ok && got == key {
-				return body[:span.start] + line + body[span.end:]
+				endIdx := tomlValueEndSpan(spans, i)
+				end := spans[endIdx].end
+				if endIdx > i {
+					if comments := tomlCommentsInSpans(spans, i, endIdx); len(comments) > 0 {
+						line = strings.Join(comments, "\n") + "\n" + line
+					}
+				} else if comment := tomlInlineComment(spans[endIdx].text); comment != "" {
+					line = strings.TrimRight(line, "\r\n") + " " + comment + "\n"
+				}
+				return body[:span.start] + line + body[end:]
 			}
 		}
 	}
@@ -1423,6 +1432,109 @@ func upsertTOMLSectionKey(body, sectionName, key, line string) string {
 		prefix += "\n"
 	}
 	return prefix + line + body[sectionEnd:]
+}
+
+type tomlLexState struct {
+	inBasic   bool
+	inLiteral bool
+	escaped   bool
+}
+
+func scanTOMLLine(line string, state *tomlLexState, outsideString func(byte)) int {
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if state.escaped {
+			state.escaped = false
+			continue
+		}
+		if state.inBasic {
+			switch ch {
+			case '\\':
+				state.escaped = true
+			case '"':
+				state.inBasic = false
+			}
+			continue
+		}
+		if state.inLiteral {
+			if ch == '\'' {
+				state.inLiteral = false
+			}
+			continue
+		}
+		switch ch {
+		case '#':
+			return i
+		case '"':
+			state.inBasic = true
+		case '\'':
+			state.inLiteral = true
+		default:
+			if outsideString != nil {
+				outsideString(ch)
+			}
+		}
+	}
+	return -1
+}
+
+func tomlValueEndSpan(spans []tomlLineSpan, start int) int {
+	if start < 0 || start >= len(spans) {
+		return start
+	}
+	_, value, ok := tomlKeyValue(spans[start].text)
+	if !ok || !strings.HasPrefix(strings.TrimSpace(value), "[") {
+		return start
+	}
+	depth := 0
+	seenArray := false
+	state := tomlLexState{}
+	for i := start; i < len(spans); i++ {
+		closed := false
+		scanTOMLLine(spans[i].text, &state, func(ch byte) {
+			switch ch {
+			case '[':
+				seenArray = true
+				depth++
+			case ']':
+				if seenArray {
+					depth--
+					closed = depth == 0
+				}
+			}
+		})
+		if closed {
+			return i
+		}
+	}
+	return start
+}
+
+func tomlInlineComment(line string) string {
+	state := tomlLexState{}
+	if i := scanTOMLLine(line, &state, nil); i >= 0 {
+		return strings.TrimRight(line[i:], "\r\n")
+	}
+	return ""
+}
+
+func tomlCommentsInSpans(spans []tomlLineSpan, start, end int) []string {
+	state := tomlLexState{}
+	var comments []string
+	for i := start; i <= end; i++ {
+		line := spans[i].text
+		commentAt := scanTOMLLine(line, &state, nil)
+		if commentAt < 0 {
+			continue
+		}
+		indentEnd := 0
+		for indentEnd < len(line) && (line[indentEnd] == ' ' || line[indentEnd] == '\t') {
+			indentEnd++
+		}
+		comment := strings.TrimRight(line[commentAt:], "\r\n")
+		comments = append(comments, line[:indentEnd]+comment)
+	}
+	return comments
 }
 
 func removeTOMLSection(body, sectionName string) string {

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1819,6 +1819,58 @@ func TestSaveToExistingProjectPersistsProviderAccessWithoutReplacingDesktopSecti
 	}
 }
 
+func TestWritePermissionsAllowUpdatesOnlyAllow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	original := `[permissions]
+# Keep the policy rationale.
+mode = "deny"
+allow = [
+  # Keep the list rationale.
+  "Bash(existing)", # Keep the existing rule rationale.
+] # Keep the allow rationale.
+ask = ["Edit(*.env)"]
+deny = ["Bash(rm:*)"]
+future_policy = "keep"
+
+[desktop]
+legacy_preference = "keep"
+`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WritePermissionsAllow(path, []string{"Bash(existing)", "Edit(src/app.go)"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		t.Fatalf("updated config does not parse: %v", err)
+	}
+	if !reflect.DeepEqual(got.Permissions.Allow, []string{"Bash(existing)", "Edit(src/app.go)"}) {
+		t.Fatalf("permissions.allow = %v", got.Permissions.Allow)
+	}
+	if got.Permissions.Mode != "deny" || !reflect.DeepEqual(got.Permissions.Ask, []string{"Edit(*.env)"}) || !reflect.DeepEqual(got.Permissions.Deny, []string{"Bash(rm:*)"}) {
+		t.Fatalf("permission policy changed: %+v", got.Permissions)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		"# Keep the policy rationale.",
+		"# Keep the list rationale.",
+		"# Keep the existing rule rationale.",
+		"# Keep the allow rationale.",
+		`future_policy = "keep"`,
+		"[desktop]\nlegacy_preference = \"keep\"",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("updated config missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestProviderEntriesConfigEqualIgnoresResolvedCredentialState(t *testing.T) {
 	a := ProviderEntry{Name: "relay", Kind: "openai", BaseURL: "https://relay.example/v1", Model: "m", APIKeyEnv: "RELAY_API_KEY"}
 	b := a

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1871,6 +1871,117 @@ legacy_preference = "keep"
 	}
 }
 
+func TestWritePermissionsAllowIgnoresSectionExamplesInMultilineStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "multiline basic string with five-quote close before existing section",
+			body: `[agent]
+system_prompt = """
+Example only:
+A "quoted" explanation and an escaped \" marker.
+[permissions]
+allow = ["Bash(example)"]
+Ends with two quotes."""""
+
+[permissions]
+mode = "ask"
+allow = ["Bash(existing)"]
+deny = ["Bash(rm:*)"]
+`,
+		},
+		{
+			name: "multiline literal string with four-quote close without existing section",
+			body: `[agent]
+system_prompt = '''
+Example only:
+A 'quoted' explanation.
+[permissions]
+allow = ["Bash(example)"]
+Ends with one quote.''''
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "reasonix.toml")
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			wantAllow := []string{"Bash(existing)", "Edit(src/app.go)"}
+			if !strings.Contains(tt.body, `Bash(existing)`) {
+				wantAllow = []string{"Edit(src/app.go)"}
+			}
+			if err := WritePermissionsAllow(path, wantAllow); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := LoadForEditReadOnlyStrict(path)
+			if err != nil {
+				t.Fatalf("updated config does not parse: %v", err)
+			}
+			if !reflect.DeepEqual(got.Permissions.Allow, wantAllow) {
+				t.Fatalf("permissions.allow = %v, want %v", got.Permissions.Allow, wantAllow)
+			}
+			if !strings.Contains(got.Agent.SystemPrompt, "[permissions]\nallow = [\"Bash(example)\"]") {
+				t.Fatalf("system prompt example changed: %q", got.Agent.SystemPrompt)
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(raw), "[permissions]\nallow = [\"Bash(example)\"]") {
+				t.Fatalf("multiline string content changed:\n%s", raw)
+			}
+		})
+	}
+}
+
+func TestWritePermissionsAllowReplacesArrayContainingMultilineString(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	original := `[permissions]
+allow = [
+  """Bash(example]
+[desktop]
+)""",
+  "Bash(existing)",
+]
+deny = ["Bash(rm:*)"]
+
+[desktop]
+legacy_preference = "keep"
+`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wantAllow := []string{"Bash(existing)", "Edit(src/app.go)"}
+	if err := WritePermissionsAllow(path, wantAllow); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadForEditReadOnlyStrict(path)
+	if err != nil {
+		t.Fatalf("updated config does not parse: %v", err)
+	}
+	if !reflect.DeepEqual(got.Permissions.Allow, wantAllow) {
+		t.Fatalf("permissions.allow = %v, want %v", got.Permissions.Allow, wantAllow)
+	}
+	if !reflect.DeepEqual(got.Permissions.Deny, []string{"Bash(rm:*)"}) {
+		t.Fatalf("permissions.deny = %v", got.Permissions.Deny)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "[desktop]\nlegacy_preference = \"keep\"") {
+		t.Fatalf("unrelated section changed:\n%s", raw)
+	}
+}
+
 func TestProviderEntriesConfigEqualIgnoresResolvedCredentialState(t *testing.T) {
 	a := ProviderEntry{Name: "relay", Kind: "openai", BaseURL: "https://relay.example/v1", Model: "m", APIKeyEnv: "RELAY_API_KEY"}
 	b := a

--- a/internal/config/mutate.go
+++ b/internal/config/mutate.go
@@ -1,6 +1,18 @@
 package config
 
-import "sync"
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/filelock"
+)
 
 // userEditMu serializes in-process read-modify-write cycles on the user config
 // file. LoadForEdit+SaveTo is not atomic: two concurrent editors each load,
@@ -24,4 +36,49 @@ var userEditMu sync.Mutex
 func LockUserConfigEdits() func() {
 	userEditMu.Lock()
 	return userEditMu.Unlock
+}
+
+// LockConfigFileEdits serializes a configuration read-modify-write transaction
+// with both other goroutines and other Reasonix processes. The cross-process
+// lock lives in the cache rather than beside path, so project repositories do
+// not accumulate lock files.
+func LockConfigFileEdits(path string) (func(), error) {
+	path = filepath.Clean(path)
+	if path == "." || path == "" {
+		return nil, fmt.Errorf("lock config edits: empty config path")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("lock config edits: resolve path: %w", err)
+	}
+	cacheDir := CacheDir()
+	if cacheDir == "" {
+		return nil, fmt.Errorf("lock config edits: cache directory unavailable")
+	}
+	lockDir := filepath.Join(cacheDir, "config-locks")
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("lock config edits: create lock directory: %w", err)
+	}
+	lockKey := filepath.Clean(abs)
+	if runtime.GOOS == "windows" {
+		lockKey = strings.ToLower(filepath.ToSlash(lockKey))
+	}
+	digest := sha256.Sum256([]byte(lockKey))
+	lockPath := filepath.Join(lockDir, fmt.Sprintf("%x.lock", digest))
+
+	unlockLocal := LockUserConfigEdits()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	unlockFile, err := filelock.Acquire(ctx, lockPath)
+	if err != nil {
+		unlockLocal()
+		return nil, fmt.Errorf("lock config edits: %w", err)
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			unlockFile()
+			unlockLocal()
+		})
+	}, nil
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3449,6 +3449,42 @@ func TestApprovalPersistentBashPrefixRememberRule(t *testing.T) {
 	}
 }
 
+func TestApprovalPersistenceFailureKeepsSessionGrant(t *testing.T) {
+	ids := make(chan string, 1)
+	var notices []event.Event
+	prompts := 0
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest {
+				prompts++
+				ids <- e.Approval.ID
+			}
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+		OnRemember: func(rule string) RememberResult {
+			return RememberResult{Rule: rule, Path: "reasonix.toml", Err: errors.New("disk unavailable")}
+		},
+	})
+	go func() {
+		c.Approve(<-ids, true, true, true)
+	}()
+
+	for i := 0; i < 2; i++ {
+		allow, remember, err := gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", nil)
+		if err != nil || !allow || remember {
+			t.Fatalf("Approve call %d = (%v,%v,%v), want session-allowed despite persistence failure", i, allow, remember, err)
+		}
+	}
+	if prompts != 1 {
+		t.Fatalf("approval prompts = %d, want one because failed persistence must retain the session grant", prompts)
+	}
+	if len(notices) != 1 || notices[0].Level != event.LevelWarn || !strings.Contains(notices[0].Text, "disk unavailable") {
+		t.Fatalf("notices = %+v, want one persistence failure warning", notices)
+	}
+}
+
 func TestPlanModeReadOnlyTrustApprovalPersistsBashCommandTrust(t *testing.T) {
 	ids := make(chan string, 2)
 	var approval event.Approval


### PR DESCRIPTION
## Summary

- Preserve the complete permission policy when persisting a newly approved allow rule.
- Reject malformed configuration without writing and serialize concurrent permission updates across goroutines and Reasonix processes.
- Preserve permission comments and unrelated TOML content while retaining atomic replacement.

## Root cause

The approval persistence path loaded the target configuration with the non-strict edit loader, calculated a new `permissions.allow` list, and passed only that list to `WritePermissionsSection`. The writer then reconstructed and replaced the complete `[permissions]` block from the allow list alone. As a result, `mode`, `ask`, `deny`, unknown fields, and comments disappeared after the next configuration reload.

The same read-modify-write sequence was outside the existing configuration edit lock. Atomic replacement prevented torn files but did not serialize logical updates, so concurrent controllers or Reasonix processes could each read stale state and overwrite rules successfully written by another writer. The non-strict loader could also fall back to defaults after a parse error and then overwrite the malformed but recoverable source file.

This change makes persistence one transaction: acquire in-process and cross-process locks, strictly reload the latest file, merge and deduplicate the allow rule, update only `permissions.allow`, and publish the result through the existing atomic writer. Persistence errors remain independent from the active controller's session grant.

## Verification

- `gofmt -w .`
- `go vet ./...`
- `go test ./internal/tool/builtin/ ./internal/boot/`
- `go test ./...`
- Focused in-process, cross-process, malformed-TOML, comment-preservation, and session-grant regression tests.

## Cache impact

Cache-impact: none — Permission-config persistence changes do not alter provider-visible prompt bytes, tool schemas, or tool registration.
Cache-guard: `go test ./internal/boot -run '^TestRememberPermissionRule' -count=1` covers the changed boot persistence path; `go test ./...` also passed.
System-prompt-review: Codex review approved — changes are limited to permission-config persistence and tests; provider-visible system prompt construction is unchanged.
