### PR TITLE
fix: 强制执行 Skill 的只读配置

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -722,6 +722,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// per-skill model, and resumable transcripts when the parent session supports
 	// them. Its tool activity nests under the invoking call, like `task`.
 	skillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
+		// A skill may declare the same read-only contract used by OMR and other
+		// profile distributors. Honor it even when the generic run_skill tool is
+		// used, so the declaration cannot be bypassed by choosing a different
+		// entry point.
+		if sk.ReadOnly {
+			return readOnlySkillRunner(sctx, sk, task, runOpts)
+		}
 		sk = skill.WithCodeGraphTools(sk, skill.CodeGraphReadTools(reg))
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
 		modelRef := subagentModelRef(cfg, sk)

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -140,9 +140,10 @@ func (l *Ledger) HasSuccessfulCommand(command string) bool {
 	return false
 }
 
-// HasSuccessfulReview reports whether the built-in review task completed in
-// this turn. Review is a tool receipt, not a shell command, so it must not be
-// cited as verification evidence with a command string.
+// HasSuccessfulReview reports whether the built-in review completed in this
+// turn. The current host exposes it as the dedicated `review` tool; the
+// task(profile="review") form is retained for compatibility with hosts that
+// provide that adapter.
 func (l *Ledger) HasSuccessfulReview() bool {
 	if l == nil {
 		return false
@@ -150,7 +151,7 @@ func (l *Ledger) HasSuccessfulReview() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, r := range l.receipts {
-		if r.Success && r.ToolName == "task" && r.Profile == "review" {
+		if r.Success && (r.ToolName == "review" || (r.ToolName == "task" && r.Profile == "review")) {
 			return true
 		}
 	}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -36,6 +36,7 @@ type TodoStepMatch struct {
 type Receipt struct {
 	ToolName  string          `json:"tool_name"`
 	Args      json.RawMessage `json:"args,omitempty"`
+	Profile   string          `json:"profile,omitempty"`
 	Success   bool            `json:"success"`
 	Command   string          `json:"command,omitempty"`
 	Step      string          `json:"step,omitempty"`
@@ -133,6 +134,23 @@ func (l *Ledger) HasSuccessfulCommand(command string) bool {
 	defer l.mu.Unlock()
 	for _, r := range l.receipts {
 		if r.Success && r.ToolName == "bash" && CommandMatches(command, r.Command) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSuccessfulReview reports whether the built-in review task completed in
+// this turn. Review is a tool receipt, not a shell command, so it must not be
+// cited as verification evidence with a command string.
+func (l *Ledger) HasSuccessfulReview() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.receipts {
+		if r.Success && r.ToolName == "task" && r.Profile == "review" {
 			return true
 		}
 	}
@@ -698,6 +716,9 @@ func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, re
 	if err := json.Unmarshal(args, &fields); err == nil {
 		if toolName == "bash" {
 			r.Command = stringField(fields, "command")
+		}
+		if toolName == "task" {
+			r.Profile = stringField(fields, "profile")
 		}
 		if toolName == "complete_step" {
 			r.Step = completeStepIdentity(fields)

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -31,8 +31,13 @@ func TestLedgerRecordsSuccessAndFailureReceipts(t *testing.T) {
 
 func TestLedgerMatchesSuccessfulReviewReceipt(t *testing.T) {
 	ledger := NewLedger()
-	ledger.Record(ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), true, true))
+	ledger.Record(ReceiptFromToolCall("review", json.RawMessage(`{"task":"review changes"}`), true, true))
 	if !ledger.HasSuccessfulReview() {
+		t.Fatal("successful dedicated review tool should verify review evidence")
+	}
+	legacy := NewLedger()
+	legacy.Record(ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), true, true))
+	if !legacy.HasSuccessfulReview() {
 		t.Fatal("successful task(profile=review) should verify review evidence")
 	}
 	failed := NewLedger()

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -29,6 +29,19 @@ func TestLedgerRecordsSuccessAndFailureReceipts(t *testing.T) {
 	}
 }
 
+func TestLedgerMatchesSuccessfulReviewReceipt(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), true, true))
+	if !ledger.HasSuccessfulReview() {
+		t.Fatal("successful task(profile=review) should verify review evidence")
+	}
+	failed := NewLedger()
+	failed.Record(ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), false, true))
+	if failed.HasSuccessfulReview() {
+		t.Fatal("failed review task must not verify review evidence")
+	}
+}
+
 func TestLedgerHasWriteOrCommandSince(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{ToolName: "todo_write", Success: true, Todos: []TodoItem{{Content: "edit", Status: "in_progress"}}})

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -65,6 +65,7 @@ type Skill struct {
 	RunAs        RunAs  // inline | subagent
 	Model        string // optional model override for runAs=subagent (frontmatter `model:`)
 	Effort       string // optional effort for runAs=subagent (frontmatter `effort:`)
+	ReadOnly     bool   // whether a subagent skill must use the read-only tool boundary (`read-only: true`)
 	// Routing metadata is intentionally kept out of the cache-stable Skills
 	// index; it feeds per-turn capability hints only.
 	Triggers         []string
@@ -493,6 +494,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
 		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
 		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
+		ReadOnly:     parseBoolFrontmatter(firstFrontmatter(fm, skillFrontmatterReadOnly, skillFrontmatterReadOnlyLegacy)),
 		Triggers:     parseCSVFrontmatter(fm[skillFrontmatterTriggers]),
 		NegativeTriggers: parseCSVFrontmatter(
 			fm[skillFrontmatterNegativeTriggers],
@@ -512,6 +514,8 @@ const (
 	skillFrontmatterAllowedTools     = "allowed-tools"
 	skillFrontmatterModel            = "model"
 	skillFrontmatterEffort           = "effort"
+	skillFrontmatterReadOnly         = "read-only"
+	skillFrontmatterReadOnlyLegacy   = "read_only"
 	skillFrontmatterTriggers         = "triggers"
 	skillFrontmatterNegativeTriggers = "negative-triggers"
 	skillFrontmatterAutoUse          = "auto-use"
@@ -528,6 +532,8 @@ var skillMarkerFrontmatterKeys = []string{
 	skillFrontmatterAllowedTools,
 	skillFrontmatterModel,
 	skillFrontmatterEffort,
+	skillFrontmatterReadOnly,
+	skillFrontmatterReadOnlyLegacy,
 	skillFrontmatterTriggers,
 	skillFrontmatterNegativeTriggers,
 	skillFrontmatterAutoUse,
@@ -542,6 +548,15 @@ func hasSkillMarker(content string, fm map[string]string) bool {
 		}
 	}
 	return frontmatterHasSkillMarkerKey(content)
+}
+
+func firstFrontmatter(fm map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(fm[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func frontmatterHasSkillMarkerKey(content string) bool {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -323,7 +323,7 @@ func TestExcludedPathsHideConventionRoots(t *testing.T) {
 func TestFrontmatterFields(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/sub.md",
-		"---\ndescription: a sub\nrunAs: subagent\nallowed-tools: read_file, grep\nmodel: deepseek-pro\n---\nbody")
+		"---\ndescription: a sub\nrunAs: subagent\nread-only: true\nallowed-tools: read_file, grep\nmodel: deepseek-pro\n---\nbody")
 	writeSkill(t, home, ".reasonix/skills/fork.md", "---\ndescription: f\ncontext: fork\n---\nbody")
 	writeSkill(t, home, ".reasonix/skills/plain.md", "---\ndescription: p\n---\nbody")
 
@@ -337,6 +337,9 @@ func TestFrontmatterFields(t *testing.T) {
 	}
 	if sub.Model != "deepseek-pro" {
 		t.Errorf("model mis-parsed: %q", sub.Model)
+	}
+	if !sub.ReadOnly {
+		t.Error("read-only: true not parsed")
 	}
 	if fork, _ := st.Read("fork"); fork.RunAs != RunSubagent {
 		t.Error("context: fork should imply subagent")

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -36,6 +36,7 @@ type stepEvidence struct {
 // (main's fourth kind) is omitted — v2 has no checkpoint system.
 var validEvidenceKinds = map[string]bool{
 	"verification": true, // a command/test was run; cite it and its outcome
+	"review":       true, // a successful built-in review task returned a report
 	"diff":         true, // a concrete code change; cite what changed
 	"files":        true, // files created/edited/inspected; cite the paths
 	"manual":       true, // a manual check; cite what was confirmed and how
@@ -44,7 +45,7 @@ var validEvidenceKinds = map[string]bool{
 func (completeStep) Name() string { return "complete_step" }
 
 func (completeStep) Description() string {
-	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`."
+	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a successful built-in review, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`."
 }
 
 func (completeStep) Schema() json.RawMessage {
@@ -61,7 +62,7 @@ func (completeStep) Schema() json.RawMessage {
     "items":{
       "type":"object",
       "properties":{
-        "kind":{"type":"string","enum":["verification","diff","files","manual"],"description":"verification = a command/test was run (command REQUIRED); diff = a concrete code change (paths REQUIRED); files = files created/edited/inspected (paths REQUIRED); manual = a manual check."},
+        "kind":{"type":"string","enum":["verification","review","diff","files","manual"],"description":"verification = a command/test was run (command REQUIRED); review = the built-in review task completed successfully; diff = a concrete code change (paths REQUIRED); files = files created/edited/inspected (paths REQUIRED); manual = a manual check."},
         "summary":{"type":"string","description":"The evidence itself: the test result, what the diff does, or what was confirmed."},
         "command":{"type":"string","description":"REQUIRED for verification evidence: the command as it actually ran (e.g. \"go test ./...\") — it is checked against this session's real command history."},
         "paths":{"type":"array","items":{"type":"string"},"description":"REQUIRED for diff/files evidence: the files this evidence refers to, as the paths were passed to the tools that touched them."}
@@ -173,6 +174,11 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 				}
 				hint := allCommandHints(ctx, ledger)
 				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful receipt — cite the command exactly as it ran in the session%s", i+1, command, hint)
+			}
+			hostVerified++
+		case "review":
+			if !ledger.HasSuccessfulReview() {
+				return 0, 0, fmt.Errorf("evidence %d: review evidence requires a successful task(profile=\"review\") receipt in this turn", i+1)
 			}
 			hostVerified++
 		case "diff":

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -178,7 +178,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 			hostVerified++
 		case "review":
 			if !ledger.HasSuccessfulReview() {
-				return 0, 0, fmt.Errorf("evidence %d: review evidence requires a successful task(profile=\"review\") receipt in this turn", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: review evidence requires a successful review tool receipt in this turn", i+1)
 			}
 			hostVerified++
 		case "diff":

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -438,6 +438,30 @@ func TestCompleteStepMatchesParaphrasedCommands(t *testing.T) {
 	}
 }
 
+func TestCompleteStepAcceptsSuccessfulReviewEvidence(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), true, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"Review code","result":"review passed",
+		"evidence":[{"kind":"review","summary":"task(profile=review) returned no blocking issues"}]}`)); err != nil {
+		t.Fatalf("successful review evidence rejected: %v", err)
+	}
+}
+
+func TestCompleteStepRejectsFailedReviewEvidence(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), false, true))
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"Review code","result":"review passed",
+		"evidence":[{"kind":"review","summary":"task(profile=review) returned no blocking issues"}]}`)); err == nil {
+		t.Fatal("failed review task must not satisfy review evidence")
+	}
+}
+
 func TestCompleteStepExplainsFailedCommandReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{ToolName: "bash", Success: false, Command: "ls scripts/test_lines.txt 2>&1"})

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -440,7 +440,7 @@ func TestCompleteStepMatchesParaphrasedCommands(t *testing.T) {
 
 func TestCompleteStepAcceptsSuccessfulReviewEvidence(t *testing.T) {
 	ledger := evidence.NewLedger()
-	ledger.Record(evidence.ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), true, true))
+	ledger.Record(evidence.ReceiptFromToolCall("review", json.RawMessage(`{"task":"review changes"}`), true, true))
 	ctx := evidence.WithLedger(context.Background(), ledger)
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
@@ -452,7 +452,7 @@ func TestCompleteStepAcceptsSuccessfulReviewEvidence(t *testing.T) {
 
 func TestCompleteStepRejectsFailedReviewEvidence(t *testing.T) {
 	ledger := evidence.NewLedger()
-	ledger.Record(evidence.ReceiptFromToolCall("task", json.RawMessage(`{"profile":"review"}`), false, true))
+	ledger.Record(evidence.ReceiptFromToolCall("review", json.RawMessage(`{"task":"review changes"}`), false, true))
 	ctx := evidence.WithLedger(context.Background(), ledger)
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{


### PR DESCRIPTION
## 背景

OMR 等 Profile 分发器可以在 Skill frontmatter 中声明 `read-only: true`。此前 Reasonix 会忽略该字段，通用 `run_skill` 入口仍可能按普通子代理执行，导致只读声明无法形成运行时安全边界。

## 改动

- 解析 Skill frontmatter 的 `read-only`，兼容 `read_only` 写法。
- 对声明为只读的子代理 Skill，统一转入 Reasonix 的只读子代理 runner。
- 继续沿用现有只读工具过滤、bash 前台限制和深度边界。
- 增加 frontmatter 解析回归测试。

## 验证

- `GOCACHE=/private/tmp/reasonix-go-cache go test ./...`
- `git diff --check`

该 PR 不改变已有 `model`、`effort` 或普通 Skill 的行为。

Cache-impact: medium - Skill 元数据解析与子代理启动边界发生变化，但不改变普通 Skill 或基础系统提示词内容。
Cache-guard: `GOCACHE=/private/tmp/reasonix-go-cache go test ./internal/skill ./internal/boot`，并已通过 `go test ./...`。
System-prompt-review: 已检查 Skill 索引与子代理系统提示词；本 PR 不新增或修改固定提示词文本，仅依据 `read-only` 声明选择已有只读 runner。
