### PR TITLE
fix(acp): order command updates after session responses / 修复会话响应与命令通知顺序

### DIFF
--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -20,6 +20,13 @@ const maxMessageBytes = 32 << 20 // 32 MiB
 // *RPCError; any other error becomes ErrInternal.
 type RequestHandler func(ctx context.Context, params json.RawMessage) (any, error)
 
+// responseWithAfter lets a request handler schedule work that must run only
+// after its successful JSON-RPC response has been written to the wire.
+type responseWithAfter interface {
+	Response() any
+	AfterResponse()
+}
+
 // NotificationHandler reacts to an inbound notification. It cannot reply, so it
 // returns nothing — errors have nowhere to go on the wire (stderr would corrupt
 // stdout, which is the JSON-RPC channel).
@@ -238,12 +245,22 @@ func (c *Conn) serveRequest(ctx context.Context, id json.RawMessage, method stri
 		c.writeError(id, code, err.Error())
 		return
 	}
+	var after func()
+	if r, ok := result.(responseWithAfter); ok {
+		result = r.Response()
+		after = r.AfterResponse
+	}
 	raw, err := json.Marshal(result)
 	if err != nil {
 		c.writeError(id, ErrInternal, "marshal result: "+err.Error())
 		return
 	}
-	_ = c.write(outbound{JSONRPC: "2.0", ID: id, Result: raw})
+	if err := c.write(outbound{JSONRPC: "2.0", ID: id, Result: raw}); err != nil {
+		return
+	}
+	if after != nil {
+		after()
+	}
 }
 
 // resolve delivers a response to the goroutine waiting on its outbound request.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -85,7 +86,10 @@ type commandFactory struct {
 	commands []command.Command
 	skills   []skill.Skill
 	seen     chan string
+	dir      string
 }
+
+func (f *commandFactory) SessionDir() string { return f.dir }
 
 func (f *commandFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
 	runner := &fakeRunner{
@@ -96,7 +100,7 @@ func (f *commandFactory) NewSession(_ context.Context, p SessionParams) (*contro
 			return nil
 		},
 	}
-	return control.New(control.Options{Runner: runner, Sink: p.Sink, Commands: f.commands, Skills: f.skills}), nil
+	return control.New(control.Options{Runner: runner, Sink: p.Sink, Commands: f.commands, Skills: f.skills, SessionDir: f.dir}), nil
 }
 
 type configurableFactory struct {
@@ -409,6 +413,97 @@ func startServer(t *testing.T, factory Factory) (*rpcClient, func()) {
 	}
 }
 
+type orderedRPCClient struct {
+	enc    *json.Encoder
+	frames chan frame
+}
+
+func newOrderedRPCClient(in io.Writer, out io.Reader) *orderedRPCClient {
+	c := &orderedRPCClient{enc: json.NewEncoder(in), frames: make(chan frame, 16)}
+	dec := json.NewDecoder(out)
+	go func() {
+		defer close(c.frames)
+		for {
+			var f frame
+			if err := dec.Decode(&f); err != nil {
+				return
+			}
+			c.frames <- f
+		}
+	}()
+	return c
+}
+
+func (c *orderedRPCClient) send(t *testing.T, id int, method string, params any) {
+	t.Helper()
+	if err := c.enc.Encode(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params}); err != nil {
+		t.Fatalf("%s: send: %v", method, err)
+	}
+}
+
+func (c *orderedRPCClient) next(t *testing.T) frame {
+	t.Helper()
+	select {
+	case f, ok := <-c.frames:
+		if !ok {
+			t.Fatal("ACP output closed")
+		}
+		return f
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ACP frame")
+		return frame{}
+	}
+}
+
+func startOrderedServer(t *testing.T, factory Factory) (*orderedRPCClient, func()) {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		_ = Serve(context.Background(), inR, outW, factory, AgentInfo{Name: "reasonix-test", Version: "0"})
+		close(done)
+	}()
+	client := newOrderedRPCClient(inW, outR)
+	return client, func() {
+		_ = inW.Close()
+		<-done
+		_ = outW.Close()
+	}
+}
+
+func requireResponseFrame(t *testing.T, f frame, id int) {
+	t.Helper()
+	if f.Method != "" || f.ID == nil {
+		t.Fatalf("first frame = %+v, want response %d", f, id)
+	}
+	if f.Error != nil {
+		t.Fatalf("response %d error = %+v", id, f.Error)
+	}
+	var gotID int
+	if err := json.Unmarshal(*f.ID, &gotID); err != nil || gotID != id {
+		t.Fatalf("response id = %d (%v), want %d", gotID, err, id)
+	}
+}
+
+func requireAvailableCommandsFrame(t *testing.T, f frame) {
+	t.Helper()
+	if f.Method != "session/update" || f.ID != nil {
+		t.Fatalf("second frame = %+v, want session/update notification", f)
+	}
+	var params map[string]any
+	if err := json.Unmarshal(f.Params, &params); err != nil {
+		t.Fatalf("available commands update: %v", err)
+	}
+	update, ok := params["update"].(map[string]any)
+	if !ok {
+		t.Fatalf("session update payload = %#v, want object", params["update"])
+	}
+	if got := update["sessionUpdate"]; got != "available_commands_update" {
+		t.Fatalf("session update = %v, want available_commands_update", got)
+	}
+}
+
 // drainPrompt collects session/update notifications until the prompt's response
 // arrives, then sweeps any notifications still buffered.
 func drainPrompt(t *testing.T, c *rpcClient, promptCh chan frame) ([]frame, frame) {
@@ -666,6 +761,89 @@ func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("runner did not receive prompt")
 	}
+}
+
+func TestServeRequestRunsAfterResponseHookAfterWritingResult(t *testing.T) {
+	var buf bytes.Buffer
+	conn := NewConn(strings.NewReader(""), &buf)
+	conn.Handle("test/hook", func(context.Context, json.RawMessage) (any, error) {
+		return afterResponse{
+			result: map[string]string{"ok": "yes"},
+			after: func() {
+				_ = conn.Notify("test/notification", map[string]string{"after": "yes"})
+			},
+		}, nil
+	})
+
+	conn.serveRequest(context.Background(), json.RawMessage("1"), "test/hook", nil)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("wrote %d frames, want 2: %q", len(lines), buf.String())
+	}
+	var response frame
+	if err := json.Unmarshal([]byte(lines[0]), &response); err != nil {
+		t.Fatalf("response frame: %v", err)
+	}
+	requireResponseFrame(t, response, 1)
+	var notification frame
+	if err := json.Unmarshal([]byte(lines[1]), &notification); err != nil {
+		t.Fatalf("notification frame: %v", err)
+	}
+	if notification.Method != "test/notification" || notification.ID != nil {
+		t.Fatalf("second frame = %+v, want notification", notification)
+	}
+}
+
+func TestServeAdvertisesCommandsAfterEverySessionOpenResponse(t *testing.T) {
+	sessionDir := t.TempDir()
+	factory := &commandFactory{
+		dir:      sessionDir,
+		commands: []command.Command{{Name: "review", Description: "Review the target"}},
+	}
+	client, stop := startOrderedServer(t, factory)
+	defer stop()
+
+	client.send(t, 1, "initialize", InitializeParams{ProtocolVersion: 1})
+	requireResponseFrame(t, client.next(t), 1)
+
+	client.send(t, 2, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	newResponse := client.next(t)
+	requireResponseFrame(t, newResponse, 2)
+	requireAvailableCommandsFrame(t, client.next(t))
+	var created SessionNewResult
+	if err := json.Unmarshal(newResponse.Result, &created); err != nil || created.SessionID == "" {
+		t.Fatalf("session/new result: %v (%q)", err, created.SessionID)
+	}
+
+	client.send(t, 3, "session/close", SessionCloseParams{SessionID: created.SessionID})
+	requireResponseFrame(t, client.next(t), 3)
+
+	persistedID := "ordered-session-open"
+	path := transcriptPath(sessionDir, persistedID)
+	if err := agent.NewSession("").Save(path); err != nil {
+		t.Fatalf("save transcript: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := saveACPMeta(path, acpSessionMeta{
+		SessionID: persistedID,
+		Cwd:       sessionDir,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("save ACP metadata: %v", err)
+	}
+
+	client.send(t, 4, "session/load", SessionLoadParams{SessionID: persistedID, Cwd: sessionDir})
+	requireResponseFrame(t, client.next(t), 4)
+	requireAvailableCommandsFrame(t, client.next(t))
+
+	client.send(t, 5, "session/close", SessionCloseParams{SessionID: persistedID})
+	requireResponseFrame(t, client.next(t), 5)
+
+	client.send(t, 6, "session/resume", SessionResumeParams{SessionID: persistedID, Cwd: sessionDir})
+	requireResponseFrame(t, client.next(t), 6)
+	requireAvailableCommandsFrame(t, client.next(t))
 }
 
 func TestServeSessionConfigSwitchesModelAndEffort(t *testing.T) {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -152,6 +152,22 @@ type service struct {
 	clientCaps ClientCapabilities
 }
 
+// afterResponse wraps a result with work that must run after the transport has
+// successfully written that result. Session-opening notifications use this so a
+// client can register the returned session before receiving its first update.
+type afterResponse struct {
+	result any
+	after  func()
+}
+
+func (r afterResponse) Response() any { return r.result }
+
+func (r afterResponse) AfterResponse() {
+	if r.after != nil {
+		r.after()
+	}
+}
+
 func (s *service) setClientCapabilities(caps ClientCapabilities) {
 	s.mu.Lock()
 	s.clientCaps = caps
@@ -651,13 +667,15 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	s.mu.Lock()
 	s.sessions[id] = sess
 	s.mu.Unlock()
-	s.sendAvailableCommands(sess)
 
-	return SessionNewResult{
-		SessionID:     id,
-		Models:        cfgState.Models,
-		Modes:         sessionModesState(sessionModeNormal),
-		ConfigOptions: cfgState.ConfigOptions,
+	return afterResponse{
+		result: SessionNewResult{
+			SessionID:     id,
+			Models:        cfgState.Models,
+			Modes:         sessionModesState(sessionModeNormal),
+			ConfigOptions: cfgState.ConfigOptions,
+		},
+		after: func() { s.sendAvailableCommands(sess) },
 	}, nil
 }
 
@@ -791,7 +809,10 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	if err != nil {
 		return nil, err
 	}
-	return SessionLoadResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions}, nil
+	return afterResponse{
+		result: SessionLoadResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions},
+		after:  func() { s.sendAvailableCommands(s.session(p.SessionID)) },
+	}, nil
 }
 
 // sessionModesFor reports the modes state for a just-opened session. A live
@@ -815,7 +836,10 @@ func (s *service) sessionResume(ctx context.Context, raw json.RawMessage) (any, 
 	if err != nil {
 		return nil, err
 	}
-	return SessionResumeResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions}, nil
+	return afterResponse{
+		result: SessionResumeResult{Models: cfgState.Models, Modes: s.sessionModesFor(p.SessionID), ConfigOptions: cfgState.ConfigOptions},
+		after:  func() { s.sendAvailableCommands(s.session(p.SessionID)) },
+	}, nil
 }
 
 func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) (SessionConfigState, error) {
@@ -972,7 +996,6 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	s.mu.Lock()
 	s.sessions[id] = sess
 	s.mu.Unlock()
-	s.sendAvailableCommands(sess)
 
 	if replay {
 		sink.replay(ctrl.History())


### PR DESCRIPTION
## Summary

- add a transport-owned post-response hook so follow-up work runs only after a successful JSON-RPC response is written
- advertise ACP commands after session/new, session/load, and session/resume responses
- preserve the existing transcript replay contract and deterministic config-rebuild notification order
- add transport-level and end-to-end NDJSON wire-order regression coverage

## Root cause

available_commands_update was emitted while session-opening request handlers were still executing. Clients such as Zed and agentic.nvim can register their session subscriber only after receiving the response, so they discard an earlier notification and show no slash commands.

Moving the send into a goroutine reduces the frequency but does not establish a wire-order guarantee: the goroutine can run on another processor before the handler returns and before serveRequest writes the response.

## Consolidation

### Kept and adapted

- #5485 by @RainbowXie: kept the transport-level responseWithAfter mechanism and its response-before-notification contract test, adapted to the current ACP server.
- #6765 by @ssfdust: kept the additional session-lifecycle audit and extended deterministic coverage to session/load and session/resume.

### Reviewed but not adopted

- The goroutine-based deferral from #6765 was replaced with the explicit transport hook because goroutine scheduling cannot guarantee wire order.
- Config-rebuild notification deferral was not adopted. Rebuilds target an already-established session, and preserving the existing available_commands_update then config_option_update order avoids a new nondeterministic reorder.

Fixes #5483.

This integration PR supersedes #5485 and #6765 while preserving both contributors' adopted work in the commit attribution.

## Compatibility

| Surface | Previous-client / old-data behavior | Conclusion |
| --- | --- | --- |
| ACP response schemas | Result fields are unchanged | Compatible |
| ACP notification payloads | available_commands_update shape is unchanged; only ordering is corrected | Compatible |
| Persisted session metadata | No format or read/write path changes | Compatible |
| Cross-version sessions | No stored representation changes | Compatible |

## Security and cache impact

- no new dependencies, network calls, permissions, command execution, or persistence surfaces
- no provider request, system prompt, tool schema, or tool ordering changes

Cache-impact: none
Cache-guard: none
System-prompt-review: none

## Verification

- go test ./internal/acp/ with focused response-order tests repeated 10 times
- go test ./internal/acp/ ./internal/control/
- go test -race ./internal/acp/
- go vet ./...
- env -u DEEPSEEK_API_KEY go test ./...
- git diff --check
