### PR TITLE
Fix Windows portable entrypoint collision / 修复 Windows 便携包入口冲突

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -93,7 +93,7 @@ OutFile "..\..\bin\${INFO_PROJECTNAME}-${ARCH}-installer.exe" # Name of the inst
 !define REASONIX_UPDATE_HELPER "reasonix-update-helper.exe"
 !define REASONIX_GUARD "reasonix-guard.exe"
 !define REASONIX_LAUNCHER "reasonix-launcher.exe"
-!define REASONIX_CLI "reasonix.exe"
+!define REASONIX_CLI "reasonix-cli.exe"
 !define REASONIX_PORTABLE_ENTRY "Reasonix.exe"
 !define REASONIX_UNLOCK_RETRIES 60
 Var ReasonixUpdateMode

--- a/desktop/guard_packaging_test.go
+++ b/desktop/guard_packaging_test.go
@@ -3,9 +3,69 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func writePortableFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyWindowsPortableRejectsCaseCollisionsAndCLIOverwrite(t *testing.T) {
+	verify := filepath.Join("..", "scripts", "verify-windows-portable.sh")
+	good := t.TempDir()
+	for _, name := range []string{
+		"reasonix-desktop.exe",
+		"reasonix-guard.exe",
+		"reasonix-update-helper.exe",
+	} {
+		writePortableFixture(t, good, name, name)
+	}
+	writePortableFixture(t, good, "Reasonix.exe", "launcher")
+	writePortableFixture(t, good, "reasonix-launcher.exe", "launcher")
+	writePortableFixture(t, good, "reasonix-cli.exe", "cli")
+	if out, err := exec.Command("bash", verify, good).CombinedOutput(); err != nil {
+		t.Fatalf("valid portable fixture failed: %v\n%s", err, out)
+	}
+
+	overwritten := t.TempDir()
+	for _, name := range []string{
+		"reasonix-desktop.exe",
+		"reasonix-guard.exe",
+		"reasonix-update-helper.exe",
+	} {
+		writePortableFixture(t, overwritten, name, name)
+	}
+	writePortableFixture(t, overwritten, "Reasonix.exe", "cli")
+	writePortableFixture(t, overwritten, "reasonix-launcher.exe", "launcher")
+	writePortableFixture(t, overwritten, "reasonix-cli.exe", "cli")
+	if out, err := exec.Command("bash", verify, overwritten).CombinedOutput(); err == nil || !strings.Contains(string(out), "not the packaged GUI launcher") {
+		t.Fatalf("overwritten launcher result = %v, output %q", err, out)
+	}
+
+	// A case-sensitive test filesystem can represent the exact source-level
+	// mistake that NTFS collapses into one overwritten file. Either filesystem
+	// behavior must be rejected by the verifier.
+	collision := t.TempDir()
+	writePortableFixture(t, collision, "Reasonix.exe", "launcher")
+	writePortableFixture(t, collision, "reasonix.exe", "cli")
+	entries, err := os.ReadDir(collision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, verifyErr := exec.Command("bash", verify, collision).CombinedOutput()
+	if verifyErr == nil {
+		t.Fatal("case-only portable entry names were accepted")
+	}
+	if len(entries) == 2 && !strings.Contains(string(out), "collide case-insensitively") {
+		t.Fatalf("case-collision output = %q", out)
+	}
+}
 
 func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 	buildData, err := os.ReadFile("../scripts/desktop-build.sh")
@@ -15,6 +75,7 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 	build := string(buildData)
 	for _, want := range []string{
 		`CLINAME="reasonix"`,
+		`WINDOWS_CLINAME="reasonix-cli"`,
 		`./cmd/reasonix`,
 		`cp "$guard_out" "$app/Contents/MacOS/$GUARDNAME"`,
 		`cp "$cli_out" "$app/Contents/MacOS/$CLINAME"`,
@@ -28,7 +89,8 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 		`stamp_windows_executable "build/windows/installer/$UPDATE_HELPER" "Reasonix Update Helper"`,
 		`cp "$launcher_out" "$staging/${APPNAME}.exe"`,
 		`cp "$guard_out" "$staging/$GUARDNAME.exe"`,
-		`cp "build/windows/installer/$CLINAME.exe" "$staging/$CLINAME.exe"`,
+		`cp "build/windows/installer/$WINDOWS_CLINAME.exe" "$staging/$WINDOWS_CLINAME.exe"`,
+		`"$ROOT/scripts/verify-windows-portable.sh" "$staging"`,
 		`"$BINNAME" "$GUARDNAME" "$CLINAME"`,
 	} {
 		if !strings.Contains(build, want) {
@@ -42,6 +104,9 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 	portableCopy := strings.Index(build, `cp "$launcher_out" "$staging/${APPNAME}.exe"`)
 	if launcherStamp < 0 || portableCopy < 0 || launcherStamp > portableCopy {
 		t.Fatalf("portable Reasonix.exe must copy the already-stamped launcher (stamp=%d copy=%d)", launcherStamp, portableCopy)
+	}
+	if strings.Contains(build, `"$staging/$CLINAME.exe"`) {
+		t.Fatal("Windows package must not collide reasonix.exe with the Reasonix.exe launcher")
 	}
 
 	workflowData, err := os.ReadFile("../.github/workflows/release-desktop.yml")

--- a/desktop/remote_app.go
+++ b/desktop/remote_app.go
@@ -1480,15 +1480,13 @@ func hasUsableServeForward(entries []forward.Entry, targetAddr, localURL string)
 }
 
 func desktopCLIBinaryPath() string {
-	name := "reasonix"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
+	packagedName, commandName := desktopCLIBinaryNames(runtime.GOOS)
 	candidates := []string{}
 	if exe, err := os.Executable(); err == nil {
-		candidates = append(candidates, filepath.Join(filepath.Dir(exe), name))
+		dir := filepath.Dir(exe)
+		candidates = append(candidates, filepath.Join(dir, packagedName))
 	}
-	if found, err := exec.LookPath(name); err == nil {
+	if found, err := exec.LookPath(commandName); err == nil {
 		candidates = append(candidates, found)
 	}
 	for _, candidate := range candidates {
@@ -1502,6 +1500,13 @@ func desktopCLIBinaryPath() string {
 		return candidate
 	}
 	return ""
+}
+
+func desktopCLIBinaryNames(goos string) (packaged, command string) {
+	if goos == "windows" {
+		return "reasonix-cli.exe", "reasonix.exe"
+	}
+	return "reasonix", "reasonix"
 }
 
 func desktopNormalizeBind(bind string) string {

--- a/desktop/remote_lifecycle_test.go
+++ b/desktop/remote_lifecycle_test.go
@@ -304,10 +304,7 @@ func TestStopServerRejectsEmptyWorkspace(t *testing.T) {
 
 func TestDesktopCLIBinaryPathFallsBackToPATH(t *testing.T) {
 	dir := t.TempDir()
-	name := "reasonix"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
+	_, name := desktopCLIBinaryNames(runtime.GOOS)
 	cli := filepath.Join(dir, name)
 	if err := os.WriteFile(cli, []byte("test"), 0o755); err != nil {
 		t.Fatal(err)
@@ -315,6 +312,19 @@ func TestDesktopCLIBinaryPathFallsBackToPATH(t *testing.T) {
 	t.Setenv("PATH", dir)
 	if got := desktopCLIBinaryPath(); got != cli {
 		t.Fatalf("desktopCLIBinaryPath = %q, want %q", got, cli)
+	}
+}
+
+func TestDesktopCLIBinaryNamesAvoidWindowsPortableEntryCollision(t *testing.T) {
+	packaged, command := desktopCLIBinaryNames("windows")
+	if packaged != "reasonix-cli.exe" || command != "reasonix.exe" {
+		t.Fatalf("Windows CLI names = (%q, %q)", packaged, command)
+	}
+	if strings.EqualFold(packaged, "Reasonix.exe") {
+		t.Fatalf("packaged CLI %q collides with the desktop entry point", packaged)
+	}
+	if packaged, command := desktopCLIBinaryNames("linux"); packaged != "reasonix" || command != "reasonix" {
+		t.Fatalf("Linux CLI names = (%q, %q)", packaged, command)
 	}
 }
 

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -721,7 +721,7 @@ func updateSiblingArtifacts() []string {
 func updateSiblingNames(goos string) []string {
 	switch goos {
 	case "windows":
-		return []string{"reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe", "reasonix.exe", "Reasonix.exe"}
+		return []string{"reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe", "reasonix-cli.exe", "Reasonix.exe"}
 	case "linux":
 		return []string{"reasonix-guard", "reasonix"}
 	default:

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -46,10 +46,13 @@ func TestNormalizeVersion(t *testing.T) {
 
 func TestUpdateSiblingNamesCoverEveryReplacedEntryPoint(t *testing.T) {
 	windows := strings.Join(updateSiblingNames("windows"), "\x00")
-	for _, want := range []string{"reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe", "reasonix.exe", "Reasonix.exe"} {
+	for _, want := range []string{"reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe", "reasonix-cli.exe", "Reasonix.exe"} {
 		if !strings.Contains(windows, want) {
 			t.Errorf("Windows release unit omits %q: %q", want, windows)
 		}
+	}
+	if strings.Contains(windows, "reasonix.exe") {
+		t.Fatalf("Windows release unit reintroduces the case-only CLI/launcher collision: %q", windows)
 	}
 	if got := updateSiblingNames("linux"); len(got) != 2 || got[0] != "reasonix-guard" || got[1] != "reasonix" {
 		t.Fatalf("Linux release unit = %q", got)

--- a/desktop/windows_update_handoff_test.go
+++ b/desktop/windows_update_handoff_test.go
@@ -50,7 +50,7 @@ func TestWindowsInstallerScriptWaitsBeforeCopyingExecutable(t *testing.T) {
 		`!define REASONIX_UPDATE_HELPER "reasonix-update-helper.exe"`,
 		`!define REASONIX_GUARD "reasonix-guard.exe"`,
 		`!define REASONIX_LAUNCHER "reasonix-launcher.exe"`,
-		`!define REASONIX_CLI "reasonix.exe"`,
+		`!define REASONIX_CLI "reasonix-cli.exe"`,
 		`!define REASONIX_PORTABLE_ENTRY "Reasonix.exe"`,
 		"Var ReasonixUpdateMode",
 		`${GetOptions} $R0 "/REASONIXUPDATE=" $R1`,
@@ -111,6 +111,7 @@ func TestDesktopBuildScriptCompilesAndPackagesWindowsUpdateHelper(t *testing.T) 
 		`build/windows/installer/$UPDATE_HELPER`,
 		`stamp_windows_executable "build/windows/installer/$UPDATE_HELPER"`,
 		`cp "$helper" "$staging/$UPDATE_HELPER"`,
+		`"$ROOT/scripts/verify-windows-portable.sh" "$staging"`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("desktop-build.sh missing %q", want)

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -463,7 +463,7 @@ func allowedUpdateTargetBase(base string, primary bool) bool {
 		return primary
 	case "reasonix.exe":
 		return true
-	case "reasonix-guard", "reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe":
+	case "reasonix-guard", "reasonix-guard.exe", "reasonix-launcher.exe", "reasonix-update-helper.exe", "reasonix-cli.exe":
 		return !primary
 	default:
 		return false

--- a/internal/repair/update_security_test.go
+++ b/internal/repair/update_security_test.go
@@ -114,6 +114,50 @@ func TestPendingUpdateAcceptsMissingReleaseSibling(t *testing.T) {
 	}
 }
 
+func TestPendingUpdateAcceptsWindowsReleaseUnit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalExecutable := repairExecutable
+	repairExecutable = func() (string, error) { return filepath.Join(dir, "reasonix-launcher.exe"), nil }
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+
+	names := []string{
+		"reasonix-desktop.exe",
+		"reasonix-guard.exe",
+		"reasonix-launcher.exe",
+		"reasonix-update-helper.exe",
+		"reasonix-cli.exe",
+		"Reasonix.exe",
+	}
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+	}
+	if _, err := PrepareFileUpdate("v1", "v2", paths[0], paths[1:]...); err != nil {
+		t.Fatalf("prepare Windows release unit: %v", err)
+	}
+	tx, err := ReadPendingUpdate()
+	if err != nil {
+		t.Fatalf("read Windows release unit: %v", err)
+	}
+	if len(tx.Files) != len(names) {
+		t.Fatalf("release unit files = %d, want %d: %+v", len(tx.Files), len(names), tx.Files)
+	}
+	for i, file := range tx.Files {
+		if got := filepath.Base(file.TargetPath); got != names[i] {
+			t.Fatalf("release unit file %d = %q, want %q", i, got, names[i])
+		}
+	}
+}
+
 func TestPendingUpdateRejectsHashlessOrPrimaryLessTransactions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("REASONIX_HOME", home)

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -28,6 +28,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APPNAME="Reasonix"            # wails.json productName -> Reasonix.app
 BINNAME="reasonix-desktop"    # wails.json outputfilename -> linux binary name
 CLINAME="reasonix"            # bundled CLI sidecar used for remote serve upload
+WINDOWS_CLINAME="reasonix-cli" # Windows cannot store Reasonix.exe and reasonix.exe separately
 GUARDNAME="reasonix-guard"
 LAUNCHERNAME="reasonix-launcher"
 windows_resource_tool_dir=""
@@ -122,9 +123,9 @@ if [ "$os" = windows ]; then
 	GOOS=windows GOARCH="$arch" go build -trimpath -ldflags="-s -w" \
 		-o "build/windows/installer/$UPDATE_HELPER" ./cmd/update-helper
 	stamp_windows_executable "build/windows/installer/$UPDATE_HELPER" "Reasonix Update Helper" "reasonix-update-helper" "$UPDATE_HELPER"
-	cli_out="$ROOT/desktop/build/windows/installer/$CLINAME.exe"
+	cli_out="$ROOT/desktop/build/windows/installer/$WINDOWS_CLINAME.exe"
 	build_cli
-	stamp_windows_executable "$cli_out" "Reasonix CLI" "$CLINAME" "$CLINAME.exe"
+	stamp_windows_executable "$cli_out" "Reasonix CLI" "$WINDOWS_CLINAME" "$WINDOWS_CLINAME.exe"
 fi
 build_args=()
 [ "${DESKTOP_BUILD_CLEAN:-1}" != "0" ] && build_args+=(-clean)
@@ -253,7 +254,8 @@ windows)
 	cp "$launcher_out" "$staging/${APPNAME}.exe"
 	cp "$launcher_out" "$staging/$LAUNCHERNAME.exe"
 	cp "$guard_out" "$staging/$GUARDNAME.exe"
-	cp "build/windows/installer/$CLINAME.exe" "$staging/$CLINAME.exe"
+	cp "build/windows/installer/$WINDOWS_CLINAME.exe" "$staging/$WINDOWS_CLINAME.exe"
+	"$ROOT/scripts/verify-windows-portable.sh" "$staging"
 	staging_win=$(cygpath -w "$staging")
 	zip_win=$(cygpath -w "$ROOT/dist/${APPNAME}-windows-${arch}.zip")
 	powershell.exe -NoProfile -Command "Compress-Archive -Force -Path '$staging_win\\*' -DestinationPath '$zip_win'"

--- a/scripts/verify-windows-portable.sh
+++ b/scripts/verify-windows-portable.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Verify the exact Windows portable release unit before Compress-Archive sees it.
+# This must run on the Windows staging directory: NTFS treats file names
+# case-insensitively, so Reasonix.exe and reasonix.exe silently overwrite each
+# other even though a source-level packaging test sees two different strings.
+set -euo pipefail
+
+staging="${1:?usage: verify-windows-portable.sh STAGING_DIR}"
+[ -d "$staging" ] || { echo "Windows portable staging directory is missing: $staging" >&2; exit 1; }
+
+required=(
+	"Reasonix.exe"
+	"reasonix-cli.exe"
+	"reasonix-desktop.exe"
+	"reasonix-guard.exe"
+	"reasonix-launcher.exe"
+	"reasonix-update-helper.exe"
+)
+
+actual=()
+for path in "$staging"/*.exe; do
+	[ -f "$path" ] || continue
+	name="${path##*/}"
+	folded=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+	if [ "${#actual[@]}" -gt 0 ]; then
+		for previous in "${actual[@]}"; do
+			previous_folded=$(printf '%s' "$previous" | tr '[:upper:]' '[:lower:]')
+			if [ "$folded" = "$previous_folded" ]; then
+				echo "Windows portable names collide case-insensitively: $previous and $name" >&2
+				exit 1
+			fi
+		done
+	fi
+	actual+=("$name")
+done
+
+if [ "${#actual[@]}" -ne "${#required[@]}" ]; then
+	echo "Windows portable entry count is ${#actual[@]}, want ${#required[@]}: ${actual[*]}" >&2
+	exit 1
+fi
+
+for expected in "${required[@]}"; do
+	found=false
+	for name in "${actual[@]}"; do
+		if [ "$name" = "$expected" ]; then
+			found=true
+			break
+		fi
+	done
+	$found || { echo "Windows portable entry is missing or has wrong case: $expected" >&2; exit 1; }
+done
+
+# Reasonix.exe is the backward-compatible desktop entry point. Prove it is the
+# GUI Guard launcher rather than merely trusting the copy commands above.
+cmp -s "$staging/Reasonix.exe" "$staging/reasonix-launcher.exe" || {
+	echo "Reasonix.exe is not the packaged GUI launcher" >&2
+	exit 1
+}
+if cmp -s "$staging/Reasonix.exe" "$staging/reasonix-cli.exe"; then
+	echo "Reasonix.exe was overwritten by the CLI sidecar" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Problem

The `desktop-v1.17.17` Windows portable archive writes the GUI launcher as `Reasonix.exe` and the bundled CLI as `reasonix.exe`. Those names collide on the case-insensitive Windows staging filesystem, so the later CLI copy silently overwrites the launcher. As a result, package-manager shortcuts targeting `Reasonix.exe` open the CLI instead of Reasonix Desktop.

This is the upstream root cause of [ScoopInstaller/Extras#18363](https://github.com/ScoopInstaller/Extras/issues/18363).

## Fix

- Package the internal Windows CLI sidecar as `reasonix-cli.exe`.
- Keep `Reasonix.exe` as the backward-compatible GUI launcher and keep `reasonix-launcher.exe` as the canonical Guard launcher.
- Update the NSIS installer, update snapshot set, and Desktop remote-SSH CLI lookup to use the new sidecar name.
- Preserve fallback to the standalone `reasonix.exe` command when it is installed on `PATH`.
- Validate the exact Windows portable staging file set before compression, reject case-folded collisions, and prove `Reasonix.exe` is byte-identical to the GUI launcher rather than the CLI.

## Compatibility

| Surface | Result |
| --- | --- |
| Existing `Reasonix.exe` shortcuts | Preserved; they launch the Guard GUI entrypoint |
| Canonical `reasonix-launcher.exe` | Unchanged |
| Standalone CLI installed on `PATH` | Unchanged as `reasonix.exe` |
| Desktop-bundled remote CLI | Renamed internally to `reasonix-cli.exe` and resolved explicitly |
| macOS and Linux package names | Unchanged |
| Windows in-place update/rollback | Snapshot and installer contracts include the renamed sidecar |

## Verification

- `env -u DEEPSEEK_API_KEY go test ./...`
- `cd desktop && go test ./...`
- `cd desktop && go vet ./... && go build ./...`
- `go vet ./... && go build ./...`
- Cross-compiled Windows launcher and CLI: `Reasonix.exe` is a GUI PE and matches `reasonix-launcher.exe`; `reasonix-cli.exe` is a distinct console PE.
- Exercised the portable verifier against a valid package, a CLI-overwritten launcher, and case-only colliding names.