### PR TITLE
fix(provider): classify MiniMax content-review errors / 正确识别 MiniMax 内容审查错误

### DIFF
--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -27,6 +27,12 @@ func explainError(err error) error {
 	}
 	var apiErr *provider.APIError
 	if errors.As(err, &apiErr) {
+		if msg := providerContentSafetyMessage(apiErr); msg != "" {
+			if reason := apiErrorReason(apiErr); reason != "" {
+				return fmt.Errorf("%s\n%s", msg, reason)
+			}
+			return errors.New(msg)
+		}
 		msg := i18n.M.ProviderStatusMessage(apiErr.Status)
 		if msg == "" {
 			return err
@@ -67,14 +73,44 @@ func explainError(err error) error {
 // channel, unsupported tools, exhausted quota — in a 402/429/5xx body, and
 // without it those errors are undiagnosable from the category line alone.
 func apiErrorReason(e *provider.APIError) string {
-	reason := providerBodyReason(e.Body)
-	if e.ToolContext == "" {
-		return reason
+	details := make([]string, 0, 3)
+	if reason := providerBodyReason(e.Body); reason != "" {
+		details = append(details, reason)
 	}
-	if reason == "" {
-		return e.ToolContext
+	if traceID := strings.TrimSpace(e.TraceID); traceID != "" {
+		details = append(details, "Trace ID: "+clampRunes(traceID, 200))
 	}
-	return reason + "\n" + e.ToolContext
+	if e.ToolContext != "" {
+		details = append(details, e.ToolContext)
+	}
+	return strings.Join(details, "\n")
+}
+
+var (
+	miniMax1026CodeRe = regexp.MustCompile(`(^|[^0-9])1026([^0-9]|$)`)
+	miniMax1027CodeRe = regexp.MustCompile(`(^|[^0-9])1027([^0-9]|$)`)
+)
+
+// providerContentSafetyMessage recognizes MiniMax's provider-specific content
+// review failures before the generic HTTP 422 mapping calls them invalid
+// parameters. A custom-named MiniMax provider is still recognized by the
+// documented status text; numeric-only errors require a MiniMax provider name
+// so another OpenAI-compatible API cannot accidentally inherit this meaning.
+func providerContentSafetyMessage(e *provider.APIError) string {
+	if e == nil || e.Status != 422 {
+		return ""
+	}
+	body := strings.ToLower(e.Body)
+	providerName := strings.ToLower(e.Provider)
+	isMiniMax := strings.Contains(providerName, "minimax")
+	switch {
+	case strings.Contains(body, "input new_sensitive") || isMiniMax && miniMax1026CodeRe.MatchString(body):
+		return i18n.M.ProviderErrInputSensitive
+	case strings.Contains(body, "output new_sensitive") || isMiniMax && miniMax1027CodeRe.MatchString(body):
+		return i18n.M.ProviderErrOutputSensitive
+	default:
+		return ""
+	}
 }
 
 // Auth failure bodies are where servers echo credentials: providers include a
@@ -125,8 +161,9 @@ func redactAuthReason(s string) string {
 	})
 }
 
-// providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped error
-// body ({"error":{"message":…}}), falling back to the trimmed raw body.
+// providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped
+// error body ({"error":{"message":…}}) or MiniMax's base_resp envelope,
+// falling back to the trimmed raw body.
 func providerBodyReason(body string) string {
 	if body == "" {
 		return ""
@@ -135,9 +172,17 @@ func providerBodyReason(body string) string {
 		Error struct {
 			Message string `json:"message"`
 		} `json:"error"`
+		BaseResp struct {
+			StatusMsg string `json:"status_msg"`
+		} `json:"base_resp"`
 	}
-	if json.Unmarshal([]byte(body), &parsed) == nil && parsed.Error.Message != "" {
-		return clampRunes(parsed.Error.Message, 800)
+	if json.Unmarshal([]byte(body), &parsed) == nil {
+		switch {
+		case parsed.Error.Message != "":
+			return clampRunes(parsed.Error.Message, 800)
+		case parsed.BaseResp.StatusMsg != "":
+			return clampRunes(parsed.BaseResp.StatusMsg, 800)
+		}
 	}
 	return clampRunes(body, 800)
 }

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -85,6 +85,37 @@ func TestExplainError(t *testing.T) {
 		t.Errorf("422 should fall back to the raw body, got %q", rawBody.Error())
 	}
 
+	miniMaxInput := explainError(&provider.APIError{
+		Provider: "custom-m3",
+		Status:   422,
+		Body:     `{"error":{"message":"input new_sensitive (1026)","code":"1026"}}`,
+		TraceID:  "minimax-trace-123",
+	})
+	for _, want := range []string{i18n.M.ProviderErrInputSensitive, "input new_sensitive", "Trace ID: minimax-trace-123"} {
+		if !strings.Contains(miniMaxInput.Error(), want) {
+			t.Errorf("MiniMax 1026 = %q, want %q", miniMaxInput.Error(), want)
+		}
+	}
+	if strings.Contains(miniMaxInput.Error(), i18n.M.ProviderErrUnprocessable) {
+		t.Errorf("MiniMax 1026 must not use the generic 422 message: %q", miniMaxInput.Error())
+	}
+
+	miniMaxOutput := explainError(&provider.APIError{
+		Provider: "minimax-cn-api",
+		Status:   422,
+		Body:     `{"base_resp":{"status_code":1027,"status_msg":"output new_sensitive"}}`,
+	})
+	for _, want := range []string{i18n.M.ProviderErrOutputSensitive, "output new_sensitive"} {
+		if !strings.Contains(miniMaxOutput.Error(), want) {
+			t.Errorf("MiniMax 1027 = %q, want %q", miniMaxOutput.Error(), want)
+		}
+	}
+
+	unrelated1026 := explainError(&provider.APIError{Provider: "other", Status: 422, Body: `{"code":1026,"message":"other meaning"}`})
+	if !strings.Contains(unrelated1026.Error(), i18n.M.ProviderErrUnprocessable) {
+		t.Errorf("another provider's numeric code 1026 must remain generic: %q", unrelated1026.Error())
+	}
+
 	rate := explainError(&provider.APIError{Provider: "deepseek", Status: 429, Body: `{"error":{"message":"slow down"}}`})
 	if !strings.Contains(rate.Error(), i18n.M.ProviderErrRateLimited) || !strings.Contains(rate.Error(), "slow down") {
 		t.Errorf("429 should append the provider reason, got %q", rate.Error())

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -505,6 +505,8 @@ type Messages struct {
 	ProviderErrAuthRejected        string // 401 — a key was sent but the server rejected it
 	ProviderErrInsufficientBalance string // 402
 	ProviderErrUnprocessable       string // 422
+	ProviderErrInputSensitive      string // MiniMax 1026
+	ProviderErrOutputSensitive     string // MiniMax 1027
 	ProviderErrRateLimited         string // 429
 	ProviderErrServer              string // 500
 	ProviderErrServerBusy          string // 503

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -464,6 +464,8 @@ var English = Messages{
 	ProviderErrAuthRejected:        "Authentication failed (HTTP 401): the server rejected your API key. It may be wrong or expired, or the provider hit a transient auth/quota issue — retried with backoff and still failed. Try again shortly, or check the key in .env / run `reasonix setup`.",
 	ProviderErrInsufficientBalance: "Insufficient balance (HTTP 402): your account is out of credit. Top up your account, then retry.",
 	ProviderErrUnprocessable:       "Invalid parameters (HTTP 422): a request parameter was rejected. This is likely a bug — please report it if it persists.",
+	ProviderErrInputSensitive:      "MiniMax rejected the input during content review (error 1026). The review may include conversation history and tool results; adjust the relevant content or start a new session with only the necessary context. Repeating the same request is unlikely to help.",
+	ProviderErrOutputSensitive:     "MiniMax rejected the generated output during content review (error 1027). Adjust the request and try again, or use another provider if the rejection persists.",
 	ProviderErrRateLimited:         "Rate limit reached (HTTP 429): too many requests (TPM/RPM). Retried with backoff — slow down or try again shortly.",
 	ProviderErrServer:              "Server error (HTTP 500): the provider hit an internal fault. Retried with backoff; if it keeps failing, try again later.",
 	ProviderErrServerBusy:          "Server busy (HTTP 503): the provider is overloaded. Retried with backoff; please try again shortly.",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -465,6 +465,8 @@ var Chinese = Messages{
 	ProviderErrAuthRejected:        "认证失败 (HTTP 401)：服务端拒绝了你的 API key。可能是 key 错误或已过期，也可能是服务端出现瞬时鉴权/额度问题——已退避重试仍失败。请稍后再试，或检查 .env 中的密钥 / 运行 `reasonix setup`。",
 	ProviderErrInsufficientBalance: "余额不足 (HTTP 402)：账户余额不足，请前往充值后重试。",
 	ProviderErrUnprocessable:       "参数错误 (HTTP 422)：某个请求参数被拒绝，通常是程序缺陷。若持续出现请反馈。",
+	ProviderErrInputSensitive:      "输入被 MiniMax 内容审查拒绝（错误码 1026）。审查对象可能包含会话历史和工具结果；请调整相关内容，或新建会话仅保留必要上下文。原样重试通常无效。",
+	ProviderErrOutputSensitive:     "MiniMax 生成的内容被内容审查拒绝（错误码 1027）。请调整请求内容后重试；若持续出现，可改用其他服务商。",
 	ProviderErrRateLimited:         "请求速率达到上限 (HTTP 429)：请求过于频繁 (TPM/RPM)。已退避重试，请放慢速率或稍后再试。",
 	ProviderErrServer:              "服务器故障 (HTTP 500)：服务端内部错误。已退避重试；若持续失败请稍后再试。",
 	ProviderErrServerBusy:          "服务器繁忙 (HTTP 503)：服务端负载过高。已退避重试，请稍后再试。",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -444,6 +444,8 @@ var ChineseTraditional = Messages{
 	ProviderErrAuth:                "認證失敗 (HTTP 401)：API key 缺失、錯誤或已過期。請檢查 .env 中的金鑰，或執行 `reasonix setup`。",
 	ProviderErrInsufficientBalance: "餘額不足 (HTTP 402)：帳戶餘額不足，請前往儲值後重試。",
 	ProviderErrUnprocessable:       "參數錯誤 (HTTP 422)：某個請求參數被拒絕，通常是程式缺陷。若持續出現請回報。",
+	ProviderErrInputSensitive:      "輸入被 MiniMax 內容審查拒絕（錯誤碼 1026）。審查對象可能包含對話歷史和工具結果；請調整相關內容，或建立新對話只保留必要上下文。原樣重試通常無效。",
+	ProviderErrOutputSensitive:     "MiniMax 產生的內容被內容審查拒絕（錯誤碼 1027）。請調整請求內容後重試；若持續出現，可改用其他服務商。",
 	ProviderErrRateLimited:         "請求速率達到上限 (HTTP 429)：請求過於頻繁 (TPM/RPM)。已退避重試，請放慢速率或稍後再試。",
 	ProviderErrServer:              "伺服器故障 (HTTP 500)：服務端內部錯誤。已退避重試；若持續失敗請稍後再試。",
 	ProviderErrServerBusy:          "伺服器繁忙 (HTTP 503)：服務端負載過高。已退避重試，請稍後再試。",

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -79,6 +79,7 @@ type APIError struct {
 	Provider    string
 	Status      int
 	Body        string
+	TraceID     string // provider trace identifier from the response headers, when present
 	ToolContext string // resolved Reasonix/MCP identity for provider-indexed tool schema errors
 }
 
@@ -235,11 +236,25 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 			}
 			return nil, authErr
 		}
-		apiErr := &APIError{Provider: opts.Provider, Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
+		apiErr := &APIError{
+			Provider: opts.Provider,
+			Status:   resp.StatusCode,
+			Body:     strings.TrimSpace(string(msg)),
+			TraceID:  responseTraceID(resp.Header),
+		}
 		if !RetryableStatus(resp.StatusCode) {
 			return nil, apiErr
 		}
 		lastErr = apiErr
 	}
 	return nil, lastErr
+}
+
+func responseTraceID(header http.Header) string {
+	for _, name := range []string{"trace_id", "trace-id", "x-trace-id"} {
+		if value := strings.TrimSpace(header.Get(name)); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -109,6 +109,20 @@ func TestSendWithRetryFailsFastOnClientErrors(t *testing.T) {
 	}
 }
 
+func TestSendWithRetryPreservesProviderTraceID(t *testing.T) {
+	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		return statusResp(422, map[string]string{"trace_id": "minimax-trace-123"}), nil
+	})}
+	_, err := SendWithRetry(context.Background(), cl, SendOptions{Provider: "minimax-cn-api"}, newDummyReq)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %T: %v", err, err)
+	}
+	if apiErr.TraceID != "minimax-trace-123" {
+		t.Fatalf("TraceID = %q, want minimax-trace-123", apiErr.TraceID)
+	}
+}
+
 func TestSendWithRetryAuthError(t *testing.T) {
 	calls := 0
 	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- Recognize MiniMax content-review failures `1026` and `1027` before the generic HTTP 422 mapping, while preserving the existing fail-fast behavior for non-retryable requests.
- Preserve MiniMax `trace_id` response headers and parse `base_resp.status_msg` so users retain actionable upstream diagnostics.
- Add English, Simplified Chinese, and Traditional Chinese guidance that explains the full conversation context may be involved and avoids suggesting blind retries.

Refs #6818

## Verification

- `go test ./internal/provider ./internal/control ./internal/i18n`
- `env -u DEEPSEEK_API_KEY go test ./...`
- `go vet ./...`
- `./scripts/cache-guard.sh`
- `git diff --check origin/main-v2...HEAD`

## Compatibility

| Surface | Existing behavior | Conclusion |
| --- | --- | --- |
| Generic HTTP 422 errors | Continue using the existing invalid-parameters message unless the response is explicitly identifiable as MiniMax `1026` or `1027`. | Backward compatible |
| Retry policy | HTTP 422 remains non-retryable; only the user-facing classification changes. | Backward compatible |
| `APIError.TraceID` | New in-memory diagnostic field; no persisted data, config, session, or Wails contract changes. | Backward compatible |

## Cache impact

Cache-impact: none — this changes only error-response classification and display; provider request bodies, prompt content, tool schemas, and ordering are unchanged.
Cache-guard: `./scripts/cache-guard.sh` passed all release cache-hit scenarios.
System-prompt-review: N/A
