### PR TITLE
feat(config): add isolated profiles with --home

### DIFF
--- a/cmd/reasonix-guard/main.go
+++ b/cmd/reasonix-guard/main.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"reasonix/internal/config"
 	"reasonix/internal/repair"
 )
 
@@ -244,10 +245,20 @@ func failedInstallBlocksLaunch(result repair.UpdateRollbackResult, err error) bo
 func runLaunch(args []string) int {
 	fs := flag.NewFlagSet("reasonix-guard launch", flag.ContinueOnError)
 	app := fs.String("app", "", "desktop executable path")
+	home := fs.String("home", "", "isolated Reasonix profile root")
 	safeMode := fs.Bool("safe-mode", false, "force Safe Mode")
 	detach := fs.Bool("detach", packagedDetachedLauncher(), "start the desktop and exit the launcher")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	normalizedHome := ""
+	if *home != "" {
+		var err error
+		normalizedHome, err = config.ApplyHomeOverride(*home)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error: invalid --home:", err)
+			return 2
+		}
 	}
 	// An update helper that watched the installer fail records a marker (it
 	// cannot roll back itself from outside the install directory). Restore the
@@ -300,6 +311,9 @@ func runLaunch(args []string) int {
 		return 1
 	}
 	childArgs := append([]string(nil), fs.Args()...)
+	if normalizedHome != "" {
+		childArgs = append([]string{"--home", normalizedHome}, childArgs...)
+	}
 	if useSafeMode {
 		childArgs = append([]string{"--safe-mode"}, childArgs...)
 	}

--- a/cmd/reasonix-guard/main_test.go
+++ b/cmd/reasonix-guard/main_test.go
@@ -4,10 +4,53 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"reasonix/internal/repair"
 )
+
+func TestRunLaunchAppliesAndForwardsHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "profile with spaces")
+	output := filepath.Join(dir, "args")
+	app := filepath.Join(dir, "desktop")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$REASONIX_HOME\" \"$REASONIX_STATE_HOME\" \"$REASONIX_CACHE_HOME\" \"$@\" > \"$REASONIX_GUARD_TEST_OUTPUT\"\n"
+	if err := os.WriteFile(app, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REASONIX_GUARD_TEST_OUTPUT", output)
+	t.Setenv("REASONIX_HOME", filepath.Join(dir, "old-home"))
+	t.Setenv("REASONIX_STATE_HOME", filepath.Join(dir, "old-state"))
+	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(dir, "old-cache"))
+
+	if code := runLaunch([]string{"--app", app, "--detach=false", "--home", profile, "--safe-mode", "extra"}); code != 0 {
+		t.Fatalf("runLaunch exit code = %d", code)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{profile, profile, filepath.Join(profile, "cache"), "--safe-mode", "--home", profile, "extra"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("child environment and args = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunLaunchRejectsInvalidHomeBeforeStartingChild(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile-file")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := runLaunch([]string{"--home", path, "--app", filepath.Join(t.TempDir(), "missing")}); code != 2 {
+		t.Fatalf("runLaunch exit code = %d, want 2", code)
+	}
+}
 
 func TestCheckReportsInvalidProjectConfig(t *testing.T) {
 	root := t.TempDir()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -66,19 +66,27 @@ const eventChannel = "agent:event"
 const singleInstanceIDPrefix = "com.reasonix.desktop"
 
 // singleInstanceID is used by Wails to route a second desktop launch back to the
-// running instance. It is stable for a given binary path, while allowing a dev
-// build and an installed release at different paths to run side by side.
+// running instance. It is stable for a given binary path and isolated profile.
 func singleInstanceID() string {
-	abs, err := os.Executable()
+	executable, err := os.Executable()
 	if err != nil {
 		return singleInstanceIDPrefix
 	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		abs = resolved
-	} else if fallback, err := filepath.Abs(abs); err == nil {
-		abs = fallback
+	return singleInstanceIDFor(executable, config.IsolatedHomeDir())
+}
+
+func singleInstanceIDFor(executable, home string) string {
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		executable = resolved
+	} else if fallback, err := filepath.Abs(executable); err == nil {
+		executable = fallback
 	}
-	sum := sha256.Sum256([]byte(abs))
+	identity := executable
+	if home != "" {
+		home = filepath.Clean(home)
+		identity += "\x00" + home
+	}
+	sum := sha256.Sum256([]byte(identity))
 	return singleInstanceIDPrefix + "." + hex.EncodeToString(sum[:8])
 }
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"embed"
+	"fmt"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
@@ -100,7 +101,17 @@ func main() {
 		os.Exit(exitCode)
 	}
 
-	launch := parseDesktopLaunchArgs(os.Args[1:])
+	launch, err := parseDesktopLaunchArgs(os.Args[1:])
+	if err != nil {
+		println("Error:", err.Error())
+		os.Exit(2)
+	}
+	if launch.Home != "" {
+		if _, err := config.ApplyHomeOverride(launch.Home); err != nil {
+			println("Error: invalid --home:", err.Error())
+			os.Exit(2)
+		}
+	}
 	if config.SafeModeRequested() {
 		launch.SafeMode = true
 	}
@@ -157,7 +168,7 @@ func main() {
 	// Other platforms provide a no-op implementation.
 	scheduleWebKitSignalHandlerRepair()
 
-	err := wails.Run(&options.App{
+	err = wails.Run(&options.App{
 		Title:     title,
 		Width:     width,
 		Height:    height,
@@ -232,14 +243,33 @@ func main() {
 
 type desktopLaunchOptions struct {
 	SafeMode bool
+	Home     string
 }
 
-func parseDesktopLaunchArgs(args []string) desktopLaunchOptions {
+func parseDesktopLaunchArgs(args []string) (desktopLaunchOptions, error) {
 	var out desktopLaunchOptions
-	for _, arg := range args {
-		if arg == "--safe-mode" {
+	parseHome := true
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			parseHome = false
+			continue
+		}
+		switch {
+		case arg == "--safe-mode":
 			out.SafeMode = true
+		case parseHome && arg == "--home":
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				return out, fmt.Errorf("--home requires a path")
+			}
+			out.Home = args[i+1]
+			i++
+		case parseHome && strings.HasPrefix(arg, "--home="):
+			out.Home = strings.TrimPrefix(arg, "--home=")
+			if strings.TrimSpace(out.Home) == "" {
+				return out, fmt.Errorf("--home requires a path")
+			}
 		}
 	}
-	return out
+	return out, nil
 }

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -9,12 +9,28 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
 )
 
-func TestParseDesktopLaunchArgsSafeMode(t *testing.T) {
-	if !parseDesktopLaunchArgs([]string{"--safe-mode"}).SafeMode {
-		t.Fatal("--safe-mode was not recognized")
+func TestParseDesktopLaunchArgs(t *testing.T) {
+	launch, err := parseDesktopLaunchArgs([]string{"--other", "--home", "profile path", "--safe-mode"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if parseDesktopLaunchArgs([]string{"--other"}).SafeMode {
-		t.Fatal("unrelated argument enabled safe mode")
+	if !launch.SafeMode || launch.Home != "profile path" {
+		t.Fatalf("launch options = %+v", launch)
+	}
+	launch, err = parseDesktopLaunchArgs([]string{"--home=other", "--", "--safe-mode"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !launch.SafeMode || launch.Home != "other" {
+		t.Fatalf("launch options after -- = %+v", launch)
+	}
+}
+
+func TestParseDesktopLaunchArgsRejectsMissingHome(t *testing.T) {
+	for _, args := range [][]string{{"--home"}, {"--home="}, {"--home", "--"}} {
+		if _, err := parseDesktopLaunchArgs(args); err == nil {
+			t.Fatalf("parseDesktopLaunchArgs(%#v) unexpectedly succeeded", args)
+		}
 	}
 }
 

--- a/desktop/single_instance_test.go
+++ b/desktop/single_instance_test.go
@@ -1,11 +1,34 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
+
+func TestSingleInstanceIDUsesProfileHome(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "reasonix-desktop")
+	legacy := sha256.Sum256([]byte(executable))
+	wantLegacy := singleInstanceIDPrefix + "." + hex.EncodeToString(legacy[:8])
+	if got := singleInstanceIDFor(executable, ""); got != wantLegacy {
+		t.Fatalf("default ID = %q, want legacy ID %q", got, wantLegacy)
+	}
+
+	base := t.TempDir()
+	homeA := filepath.Join(base, "a")
+	homeB := filepath.Join(base, "b")
+	idA := singleInstanceIDFor(executable, homeA)
+	if idA != singleInstanceIDFor(executable, filepath.Join(base, ".", "a")) {
+		t.Fatal("equivalent home paths produced different IDs")
+	}
+	if idA == singleInstanceIDFor(executable, homeB) {
+		t.Fatal("different homes produced the same ID")
+	}
+}
 
 func TestSingleInstanceLockRestoresExistingInstance(t *testing.T) {
 	app := NewApp()

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -15,6 +15,19 @@ location.
 Set `REASONIX_HOME` to override Reasonix home for tests, CI, or portable
 installations. Normal users should not need it.
 
+Pass `--home PATH` to the CLI, Desktop, or `reasonix-guard launch` to select a
+complete isolated profile for that process. Relative paths are resolved from the
+startup working directory; `~` and `${VAR}` are expanded. This option overrides
+inherited `REASONIX_HOME`, `REASONIX_STATE_HOME`, and `REASONIX_CACHE_HOME`, using
+`PATH` for configuration and state and `PATH/cache` for cache. The selected profile
+is inherited by MCP servers, plugins, hooks, and other child processes.
+
+An isolated profile does not import or fall back to the default user profile.
+Workspace-local `reasonix.toml` and `.mcp.json` files still participate in their
+normal configuration merge. Desktop instances using different homes can run at
+the same time; launching the same executable again with the same home keeps the
+normal single-instance behavior.
+
 When `REASONIX_HOME` is set, the runtime is fully self-contained: all
 configuration, state, cache, and data live under that directory tree. Legacy
 migration, OS-home convention directory scanning, and all other fallback paths

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -12,6 +12,15 @@
 
 可以设置 `REASONIX_HOME` 覆盖 Reasonix home，主要用于测试、CI 或便携安装。普通用户通常不需要设置。
 
+CLI、Desktop 或 `reasonix-guard launch` 都可以通过 `--home PATH` 选择一个完整的隔离
+profile。相对路径基于启动时工作目录解析，并支持展开 `~` 和 `${VAR}`。该参数优先于继承的
+`REASONIX_HOME`、`REASONIX_STATE_HOME` 和 `REASONIX_CACHE_HOME`：配置与状态使用
+`PATH`，缓存使用 `PATH/cache`。MCP server、plugin、hook 和其他子进程会继承同一 profile。
+
+隔离 profile 不会导入或 fallback 到默认用户 profile。Workspace 本地的 `reasonix.toml`
+和 `.mcp.json` 仍按原有规则参与配置合并。使用不同 home 的 Desktop 实例可以同时运行；
+同一 executable 使用同一 home 重复启动时，仍保持原有单实例行为。
+
 设置 `REASONIX_HOME` 后，运行时会变成完整自包含模式：配置、状态、缓存和数据都会位于该目录树下。
 Legacy 迁移、OS home 约定目录扫描以及其他 fallback 路径都会跳过，避免从系统级正式安装带入或写回数据。
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,6 +48,19 @@ var (
 
 // Run is the CLI entry point; it returns a process exit code.
 func Run(args []string, version string) int {
+	var home string
+	var err error
+	args, home, err = extractGlobalHome(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 2
+	}
+	if home != "" {
+		if _, err := config.ApplyHomeOverride(home); err != nil {
+			fmt.Fprintln(os.Stderr, "error: invalid --home:", err)
+			return 2
+		}
+	}
 	// Pick the UI language up front so even pre-config paths (the first-run
 	// welcome banner) come through localized. Env-only first; if a config
 	// exists and pins a language, that wins.
@@ -154,6 +167,35 @@ func Run(args []string, version string) int {
 		usage()
 		return 2
 	}
+}
+
+func extractGlobalHome(args []string) ([]string, string, error) {
+	out := make([]string, 0, len(args))
+	home := ""
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
+		if arg == "--home" {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				return nil, "", fmt.Errorf("--home requires a path")
+			}
+			home = args[i+1]
+			i++
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "--home="); ok {
+			if strings.TrimSpace(value) == "" {
+				return nil, "", fmt.Errorf("--home requires a path")
+			}
+			home = value
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out, home, nil
 }
 
 func isDoctorRepairCommand(args []string) bool {

--- a/internal/cli/cli_flags_test.go
+++ b/internal/cli/cli_flags_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -9,6 +10,57 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/provider"
 )
+
+func TestRunAppliesHomeBeforeCommandRouting(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "profile")
+	t.Setenv("REASONIX_HOME", filepath.Join(base, "old-home"))
+	t.Setenv("REASONIX_STATE_HOME", filepath.Join(base, "old-state"))
+	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(base, "old-cache"))
+
+	if code := Run([]string{"version", "--home", home}, "test"); code != 0 {
+		t.Fatalf("Run exit code = %d", code)
+	}
+	if got := os.Getenv("REASONIX_HOME"); got != home {
+		t.Fatalf("REASONIX_HOME = %q, want %q", got, home)
+	}
+	if got := os.Getenv("REASONIX_STATE_HOME"); got != home {
+		t.Fatalf("REASONIX_STATE_HOME = %q, want %q", got, home)
+	}
+	if got := os.Getenv("REASONIX_CACHE_HOME"); got != filepath.Join(home, "cache") {
+		t.Fatalf("REASONIX_CACHE_HOME = %q", got)
+	}
+}
+
+func TestExtractGlobalHome(t *testing.T) {
+	cases := []struct {
+		args     []string
+		wantArgs []string
+		wantHome string
+	}{
+		{[]string{"--home", "profiles/a", "version"}, []string{"version"}, "profiles/a"},
+		{[]string{"version", "--home", "profiles/a"}, []string{"version"}, "profiles/a"},
+		{[]string{"--home=profile with spaces", "-p", "task"}, []string{"-p", "task"}, "profile with spaces"},
+		{[]string{"run", "--", "--home", "literal"}, []string{"run", "--", "--home", "literal"}, ""},
+	}
+	for _, tc := range cases {
+		gotArgs, gotHome, err := extractGlobalHome(tc.args)
+		if err != nil {
+			t.Fatalf("extractGlobalHome(%#v): %v", tc.args, err)
+		}
+		if !reflect.DeepEqual(gotArgs, tc.wantArgs) || gotHome != tc.wantHome {
+			t.Fatalf("extractGlobalHome(%#v) = (%#v, %q), want (%#v, %q)", tc.args, gotArgs, gotHome, tc.wantArgs, tc.wantHome)
+		}
+	}
+}
+
+func TestExtractGlobalHomeRejectsMissingValue(t *testing.T) {
+	for _, args := range [][]string{{"--home"}, {"--home="}, {"--home", "--"}} {
+		if _, _, err := extractGlobalHome(args); err == nil {
+			t.Fatalf("extractGlobalHome(%#v) unexpectedly succeeded", args)
+		}
+	}
+}
 
 func TestSplitAllowedToolRules(t *testing.T) {
 	got, err := splitAllowedToolRules([]string{

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -201,6 +201,88 @@ func cleanEnvDir(name string) string {
 	return filepath.Clean(dir)
 }
 
+func normalizeHomeDir(raw string) (string, error) {
+	dir := strings.TrimSpace(raw)
+	if dir == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	for _, match := range varRef.FindAllStringSubmatch(dir, -1) {
+		if value, ok := os.LookupEnv(match[1]); (!ok || value == "") && match[2] == "" {
+			return "", fmt.Errorf("environment variable %s is not set", match[1])
+		}
+	}
+	dir = ExpandVars(dir)
+	if strings.TrimSpace(dir) == "" {
+		return "", fmt.Errorf("path is empty after environment expansion")
+	}
+	if dir == "~" || strings.HasPrefix(dir, "~/") || strings.HasPrefix(dir, `~\`) {
+		home, err := osUserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", fmt.Errorf("resolve user home")
+		}
+		if dir == "~" {
+			dir = home
+		} else {
+			dir = filepath.Join(home, dir[2:])
+		}
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+// NormalizeHomeOverride validates and resolves a --home value without creating it.
+func NormalizeHomeOverride(raw string) (string, error) {
+	dir, err := normalizeHomeDir(raw)
+	if err != nil {
+		return "", err
+	}
+	if info, err := os.Stat(dir); err == nil {
+		if !info.IsDir() {
+			return "", fmt.Errorf("path exists and is not a directory")
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	return dir, nil
+}
+
+// ApplyHomeOverride makes a --home value authoritative for this process and its children.
+func ApplyHomeOverride(raw string) (string, error) {
+	dir, err := NormalizeHomeOverride(raw)
+	if err != nil {
+		return "", err
+	}
+	values := []struct {
+		name  string
+		value string
+	}{
+		{"REASONIX_HOME", dir},
+		{"REASONIX_STATE_HOME", dir},
+		{"REASONIX_CACHE_HOME", filepath.Join(dir, "cache")},
+	}
+	previous := make([]struct {
+		value string
+		set   bool
+	}, len(values))
+	for i, item := range values {
+		previous[i].value, previous[i].set = os.LookupEnv(item.name)
+		if err := os.Setenv(item.name, item.value); err != nil {
+			for j := 0; j < i; j++ {
+				if previous[j].set {
+					_ = os.Setenv(values[j].name, previous[j].value)
+				} else {
+					_ = os.Unsetenv(values[j].name)
+				}
+			}
+			return "", fmt.Errorf("set %s: %w", item.name, err)
+		}
+	}
+	return dir, nil
+}
+
 func samePath(a, b string) bool {
 	if a == "" || b == "" {
 		return false

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1245,6 +1245,105 @@ func TestLoadForEditIgnoresAndDropsDeprecatedAgentStepLimitsOnSave(t *testing.T)
 	}
 }
 
+func TestApplyHomeOverrideUsesOneProfileRoot(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("REASONIX_HOME", filepath.Join(base, "old-home"))
+	t.Setenv("REASONIX_STATE_HOME", filepath.Join(base, "old-state"))
+	t.Setenv("REASONIX_CACHE_HOME", filepath.Join(base, "old-cache"))
+
+	home := filepath.Join(base, "profile with spaces")
+	got, err := ApplyHomeOverride(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("ApplyHomeOverride() = %q, want %q", got, home)
+	}
+	paths := map[string]string{
+		"home":        ReasonixHomeDir(),
+		"config":      UserConfigPath(),
+		"credentials": UserCredentialsPath(),
+		"sessions":    SessionDir(),
+		"memory":      MemoryUserDir(),
+		"cache":       CacheDir(),
+	}
+	want := map[string]string{
+		"home":        home,
+		"config":      filepath.Join(home, "config.toml"),
+		"credentials": filepath.Join(home, ".env"),
+		"sessions":    filepath.Join(home, "sessions"),
+		"memory":      home,
+		"cache":       filepath.Join(home, "cache"),
+	}
+	for name, path := range paths {
+		if path != want[name] {
+			t.Errorf("%s path = %q, want %q", name, path, want[name])
+		}
+	}
+	if _, err := os.Stat(home); !os.IsNotExist(err) {
+		t.Fatalf("ApplyHomeOverride created profile directory: %v", err)
+	}
+}
+
+func TestNormalizeHomeOverrideRejectsInvalidPaths(t *testing.T) {
+	if _, err := NormalizeHomeOverride("   "); err == nil {
+		t.Fatal("empty home unexpectedly succeeded")
+	}
+	if _, err := NormalizeHomeOverride("${REASONIX_MISSING_HOME}/profile"); err == nil {
+		t.Fatal("missing embedded variable unexpectedly succeeded")
+	}
+	path := filepath.Join(t.TempDir(), "profile-file")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NormalizeHomeOverride(path); err == nil {
+		t.Fatal("file home unexpectedly succeeded")
+	}
+}
+
+func TestNormalizeHomeOverrideExpandsRelativeAndTildePaths(t *testing.T) {
+	base := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(base); err == nil {
+		base = resolved
+	}
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(base); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+
+	got, err := NormalizeHomeOverride(filepath.Join("profiles", "test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(base, "profiles", "test"); !samePath(got, want) {
+		t.Fatalf("relative home = %q, want %q", got, want)
+	}
+
+	t.Setenv("REASONIX_TEST_PROFILE_ROOT", base)
+	got, err = NormalizeHomeOverride("${REASONIX_TEST_PROFILE_ROOT}/expanded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(base, "expanded"); !samePath(got, want) {
+		t.Fatalf("expanded home = %q, want %q", got, want)
+	}
+
+	oldHome := osUserHomeDir
+	osUserHomeDir = func() (string, error) { return base, nil }
+	t.Cleanup(func() { osUserHomeDir = oldHome })
+	got, err = NormalizeHomeOverride("~/profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(base, "profile"); !samePath(got, want) {
+		t.Fatalf("tilde home = %q, want %q", got, want)
+	}
+}
+
 func TestIsolatedHomeDirEmptyByDefault(t *testing.T) {
 	t.Setenv("REASONIX_HOME", "")
 	if got := IsolatedHomeDir(); got != "" {

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -501,6 +501,7 @@ var English = Messages{
 	UsageBody: `reasonix — a config- and plugin-driven coding agent (multi-model)
 
 Usage:
+  reasonix [--home PATH] <command or interactive options>        use an isolated user profile
   reasonix [--model NAME] [-c|--continue] [-r|--resume [QUERY]] [--permission-mode MODE] [--effort LEVEL] [--add-dir PATH]   interactive session
   reasonix -p|--print [--model NAME] [--output-format text|json|stream-json] [--allowed-tools RULES] [--add-dir PATH] <task>
   reasonix run [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] [--output-format FORMAT] <task>

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -502,6 +502,7 @@ var Chinese = Messages{
 	UsageBody: `reasonix — 由配置和插件驱动的 coding agent（多模型）
 
 用法：
+  reasonix [--home PATH] <命令或交互选项>                        使用隔离的用户 profile
   reasonix [--model NAME] [-c|--continue] [-r|--resume [QUERY]] [--permission-mode MODE] [--effort LEVEL] [--add-dir PATH]   交互式会话
   reasonix -p|--print [--model NAME] [--output-format text|json|stream-json] [--allowed-tools RULES] [--add-dir PATH] <task>
   reasonix run [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] [--output-format FORMAT] <task>

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -450,6 +450,7 @@ var ChineseTraditional = Messages{
 	UsageBody: `reasonix — 由設定和插件驅動的 coding agent（多模型）
 
 用法：
+  reasonix [--home PATH] <命令或互動選項>                        使用隔離的使用者 profile
   reasonix [--model NAME] [-c|--continue] [-r|--resume [QUERY]] [--permission-mode MODE] [--effort LEVEL] [--add-dir PATH]   互動式會話
   reasonix -p|--print [--model NAME] [--output-format text|json|stream-json] [--allowed-tools RULES] [--add-dir PATH] <task>
   reasonix run [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] [--copy] [--output-format FORMAT] <task>


### PR DESCRIPTION
## Summary
- add a global `--home PATH` option for CLI, Desktop, and Guard launches
- isolate configuration, credentials, sessions, state, memory, and cache while preserving workspace-local configuration
- make Desktop single-instance behavior profile-aware so different homes can run concurrently
- document profile path semantics and add coverage across config, CLI, Guard, and Desktop

Closes #6760

## Test plan
- [x] `go test ./internal/config ./internal/cli ./cmd/reasonix-guard`
- [x] `go -C desktop test ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go -C desktop vet ./...`
- [x] `git diff --check`
- [x] manually verify `--home PATH` and `--home=PATH` with temporary profiles