### PR TITLE
Restore frontend release typecheck gate / 恢复前端发布类型检查门禁

### DIFF
--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -82,7 +82,9 @@ function ok(value: unknown, message: string) {
           return 1;
         },
         InstallMCPServer: async (input) => {
-          const toolCount = await window.go!.main.App.AddMCPServer(input);
+          const app = window.go?.main?.App;
+          if (!app) throw new Error("missing App bindings");
+          const toolCount = await app.AddMCPServer(input);
           return { name: input.name, state: "ready", toolCount, action: "none", message: "ready" };
         },
       } as Partial<AppBindings> as AppBindings,
@@ -352,17 +354,6 @@ function setInputValue(input: HTMLInputElement, value: string) {
   const eventCtor = win?.Event ?? Event;
   input.dispatchEvent(new eventCtor("input", { bubbles: true }));
   input.dispatchEvent(new eventCtor("change", { bubbles: true }));
-}
-
-function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
-  const win = textarea.ownerDocument.defaultView;
-  const previous = textarea.value;
-  const setter = Object.getOwnPropertyDescriptor((win?.HTMLTextAreaElement ?? HTMLTextAreaElement).prototype, "value")?.set;
-  setter?.call(textarea, value);
-  (textarea as HTMLTextAreaElement & { _valueTracker?: { setValue: (next: string) => void } })._valueTracker?.setValue(previous);
-  const eventCtor = win?.Event ?? Event;
-  textarea.dispatchEvent(new eventCtor("input", { bubbles: true }));
-  textarea.dispatchEvent(new eventCtor("change", { bubbles: true }));
 }
 
 ok(


### PR DESCRIPTION
## What changed

- Narrow the optional Wails `App` binding before the MCP install mock delegates to it.
- Remove the obsolete textarea input helper left behind by the simplified MCP test flow.

## Why

The formal `1.17.19` pre-release gate ran `pnpm test:all` and failed during test TypeScript checking. The new MCP install mock dereferenced optional Wails globals without narrowing them, while the previous textarea-driven flow had been removed but its helper remained.

## Impact

This restores the frontend release typecheck gate without changing production behavior, provider-visible tool schemas, runtime protocol, or persisted data.

## Compatibility

| Field or surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted config, sessions, and traces | No production or persisted-format changes | Compatible |
| Wails runtime payloads | Test-only mock narrowing; runtime contract is unchanged | Compatible |

## Verification

- `pnpm test:typecheck`
- `pnpm exec tsx src/__tests__/capabilities-panel-actions.test.ts`
- `pnpm test:all`
- `pnpm build`
