### PR TITLE
fix(i18n): localize default session titles via titleKind semantic field

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -19,6 +19,20 @@ import { ContextMenu, contextMenuPointFromEvent, type ContextMenuItem, type Cont
 import { Tooltip } from "./Tooltip";
 import { WorktreeBadge } from "./WorktreeBadge";
 
+
+/**
+ * Return a localized display title for a project tree node.
+ * When the backend sets titleKind, it indicates the label is a 
+ * locale-agnostic default that should be translated.
+ */
+function nodeDisplayTitle(node: ProjectNode, t: Translator): string {
+  switch (node.titleKind) {
+    case "new_session": return t("topbar.newSession");
+    case "forked":      return t("tabBar.forkSession");
+    default:            return node.label || t("topbar.newSession");
+  }
+}
+
 type ProjectTreeVariant = "classic" | "workbench" | "creation";
 
 interface ProjectTreeProps {
@@ -161,7 +175,7 @@ export function projectTreeTopicHoverCardModel(node: ProjectNode, t: Translator,
   const metaLine = projectTreeTopicMetaLine(node, t);
   const exactTime = activityAt ? topicActivityDateLabel(activityAt) : "";
   return {
-    title: (node.label || node.topicId || "Untitled").replace(/^●\s*/, ""),
+    title: nodeDisplayTitle(node, t).replace(/^●\s*/, ""),
     statusLabel: topicStatusLabel(node, t),
     metaLine,
     exactTime: projectTreeDedupedExactTime(metaLine, exactTime),
@@ -1301,7 +1315,7 @@ export function ProjectTree({
       const scopeClass = scope === "global" ? " project-tree__topic--global" : " project-tree__topic--project";
       const accentStyle = projectAccentStyle(node.projectColor, scope === "global" ? "var(--project-tree-global-accent)" : undefined);
       const active = topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
-      const label = (node.label || node.topicId || "Untitled").replace(/^●\s*/, "");
+      const label = nodeDisplayTitle(node, t).replace(/^●\s*/, "");
       const conflictCopyLabel = isSessionNode && node.recovered ? t("recovery.badge") : "";
       const activityAt = node.lastActivityAt || node.createdAt || 0;
       // Every variant is a single-line row with the activity time on the right;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -236,6 +236,7 @@ export interface ProjectNode {
   key: string;
   kind: "project" | "topic" | "session" | "global_folder" | "global_topic" | "global_session";
   label: string;
+  titleKind?: string;
   root?: string;
   topicId?: string;
   sessionPath?: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -45,6 +45,7 @@ export const en = {
   "tabBar.tabActions": "Tab actions",
   "tabBar.commandSearch": "Search · Command · Open file",
   "tabBar.commandSearchCompact": "Search",
+  "tabBar.forkSession": "Forked session",
 
   // sidebar
   "sidebar.conversations": "Chats",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2006,6 +2006,7 @@ export const zhTW: Record<DictKey, string> = {
   "tabBar.commandSearch": "搜尋 · 命令 · 開啟檔案",
   "tabBar.commandSearchCompact": "搜尋",
   "sidebar.memorySkills": "記憶與技能",
+  "tabBar.forkSession": "分叉會話",
   "sidebar.im": "機器人",
   "sidebar.imAdd": "新增 Bot",
   "sidebar.imEmpty": "連線 QQ / 飛書 / Lark / 微信",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -46,6 +46,7 @@ export const zh: Record<DictKey, string> = {
   "tabBar.tabActions": "标签页操作",
   "tabBar.commandSearch": "搜索 · 命令 · 打开文件",
   "tabBar.commandSearchCompact": "搜索",
+  "tabBar.forkSession": "分叉会话",
 
   // 侧边栏
   "sidebar.conversations": "会话",

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5766,7 +5766,7 @@ type ProjectNode struct {
 	RecoveryParentID string        `json:"recoveryParentId,omitempty"`
 	IsolatedWorktree bool          `json:"isolatedWorktree,omitempty"`
 	Children         []ProjectNode `json:"children,omitempty"`
-	TitleKind string `json:"titleKind,omitempty"`
+	TitleKind string        `json:"titleKind,omitempty"`
 }
 
 func normalizeTopicStatus(status string) string {
@@ -7191,11 +7191,11 @@ func (a *App) ListProjectTree() []ProjectNode {
 		titleKind := ""
 		switch {
 		case label == defaultTopicTitle || label == "New Session":
-		titleKind = "new_session"
+			titleKind = "new_session"
 		case strings.HasPrefix(label, "分叉会话") || strings.HasPrefix(label, "Forked Session") || strings.HasSuffix(label, " · 分叉"):
-		titleKind = "forked"
+			titleKind = "forked"
 		case strings.HasPrefix(label, "历史会话") || strings.HasPrefix(label, "History Session"):
-		titleKind = "history"
+			titleKind = "history"
 		}
 		status := activityStatusForTab(tab)
 		runtimeStatus := control.RuntimeStatus{}
@@ -7206,7 +7206,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 		runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)] = append(runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)], runtimeSessionStatus{
 			sessionPath:      sessionPath,
 			label:            label,
-			titleKind: titleKind,
+			titleKind:        titleKind,
 			turns:            info.Turns,
 			createdAt:        unixMilliOrZero(info.CreatedAt),
 			lastActivityAt:   unixMilliOrZero(info.LastActivityAt),

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5766,7 +5766,7 @@ type ProjectNode struct {
 	RecoveryParentID string        `json:"recoveryParentId,omitempty"`
 	IsolatedWorktree bool          `json:"isolatedWorktree,omitempty"`
 	Children         []ProjectNode `json:"children,omitempty"`
-	TitleKind string        `json:"titleKind,omitempty"`
+	TitleKind        string        `json:"titleKind,omitempty"`
 }
 
 func normalizeTopicStatus(status string) string {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5766,6 +5766,7 @@ type ProjectNode struct {
 	RecoveryParentID string        `json:"recoveryParentId,omitempty"`
 	IsolatedWorktree bool          `json:"isolatedWorktree,omitempty"`
 	Children         []ProjectNode `json:"children,omitempty"`
+	TitleKind string `json:"titleKind,omitempty"`
 }
 
 func normalizeTopicStatus(status string) string {
@@ -7067,6 +7068,7 @@ type runtimeSessionStatus struct {
 	recoveryReason   string
 	recoveryDigest   string
 	recoveryParentID string
+	titleKind        string
 }
 
 // topicHiddenAsRecoveryOnly hides topics whose only on-disk sessions are
@@ -7186,6 +7188,15 @@ func (a *App) ListProjectTree() []ProjectNode {
 		info := sessionInfos[sessionPath]
 		recovered := sessionInfoIsAutomaticRecovery(info) || isAutomaticRecoverySessionPath(sessionPath)
 		label := runtimeSessionTreeLabel(tab, info, sessionTitles[sessionPath])
+		titleKind := ""
+		switch {
+		case label == defaultTopicTitle || label == "New Session":
+		titleKind = "new_session"
+		case strings.HasPrefix(label, "分叉会话") || strings.HasPrefix(label, "Forked Session") || strings.HasSuffix(label, " · 分叉"):
+		titleKind = "forked"
+		case strings.HasPrefix(label, "历史会话") || strings.HasPrefix(label, "History Session"):
+		titleKind = "history"
+		}
 		status := activityStatusForTab(tab)
 		runtimeStatus := control.RuntimeStatus{}
 		if tab.Ctrl != nil {
@@ -7195,6 +7206,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 		runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)] = append(runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)], runtimeSessionStatus{
 			sessionPath:      sessionPath,
 			label:            label,
+			titleKind: titleKind,
 			turns:            info.Turns,
 			createdAt:        unixMilliOrZero(info.CreatedAt),
 			lastActivityAt:   unixMilliOrZero(info.LastActivityAt),
@@ -7248,6 +7260,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 				Key:              projectSessionNodeKey(scope, session.sessionPath),
 				Kind:             kind,
 				Label:            session.label,
+				TitleKind:        session.titleKind,
 				Root:             workspaceRoot,
 				TopicID:          topicID,
 				SessionPath:      session.sessionPath,


### PR DESCRIPTION
Add titleKind semantic field to ProjectNode so the frontend can display localized session titles instead of hardcoded Chinese fallbacks. Fixes #6754.