### PR TITLE
Drain lazy MCP cache writes on close / 关闭时等待 Lazy MCP 缓存写入

### DIFF
--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -141,10 +141,11 @@ func (s *lazySpawn) run() {
 	s.trySwap()
 	cacheTools = real
 	s.broadcastReady()
-	// Save cache outside the critical path of tool dispatch, but still under
-	// the deferred end of run after unlock would also work; keep schema write
-	// after unlock by scheduling it here via a copy.
-	go saveLazyCachedSchema(s.spec, cacheTools)
+	// Save cache outside the critical path of tool dispatch. Register the write
+	// before this deferred spawn ends so Host.Close observes and drains it.
+	s.host.queueBackgroundWrite(func() {
+		saveLazyCachedSchema(s.spec, cacheTools)
+	})
 }
 
 func saveLazyCachedSchema(spec Spec, real []tool.Tool) {

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -376,8 +376,10 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 			safetyErr := lt.reconcileLiveSafety(r)
 			sp.broadcastReady()
 			sp.mu.Unlock()
+			sp.host.queueBackgroundWrite(func() {
+				saveLazyCachedSchema(sp.spec, real)
+			})
 			sp.host.endDeferredSpawn()
-			saveLazyCachedSchema(sp.spec, real)
 			if safetyErr != nil {
 				return "", safetyErr
 			}

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -116,6 +116,35 @@ func waitForCachedSchema(t *testing.T, spec Spec, timeout time.Duration) *Cached
 	return nil
 }
 
+func TestHostCloseWaitsForLazyBackgroundWrite(t *testing.T) {
+	host := NewHost()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	host.queueBackgroundWrite(func() {
+		close(started)
+		<-release
+	})
+	<-started
+
+	closed := make(chan struct{})
+	go func() {
+		host.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+		t.Fatal("Host.Close returned before the lazy background write finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Host.Close did not return after the lazy background write finished")
+	}
+}
+
 // TestLazyCacheHitSyncSpawn drives the cache-hit branch end-to-end: cache is
 // pre-populated, the model can see real schemas before any spawn, and the
 // first Execute synchronously handshakes, swaps the placeholder for the real

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -493,6 +493,17 @@ func (h *Host) Close() {
 	h.bgWrites.Wait() // drain detached stats/schema writers before returning
 }
 
+// queueBackgroundWrite keeps detached persistence inside the Host lifecycle.
+// Callers must enqueue before their Close-drained startup owner completes, so
+// Close cannot begin waiting before the WaitGroup increment is visible.
+func (h *Host) queueBackgroundWrite(write func()) {
+	h.bgWrites.Add(1)
+	go func() {
+		defer h.bgWrites.Done()
+		write()
+	}()
+}
+
 // StartPhaseB asynchronously fetches the auxiliary surfaces (prompts and
 // resources) for every connected client. Boot calls it right after Start
 // returns, on a session-scoped ctx, so the agent becomes responsive as soon as

--- a/internal/plugin/transport_sse_test.go
+++ b/internal/plugin/transport_sse_test.go
@@ -224,7 +224,6 @@ func TestLegacySSEBoundsConcurrentServerRequestReplies(t *testing.T) {
 		}
 	})
 	mux.HandleFunc("/messages", func(w http.ResponseWriter, r *http.Request) {
-		firstPost.Do(func() { close(postStarted) })
 		active := activePosts.Add(1)
 		defer activePosts.Add(-1)
 		for {
@@ -233,6 +232,7 @@ func TestLegacySSEBoundsConcurrentServerRequestReplies(t *testing.T) {
 				break
 			}
 		}
+		firstPost.Do(func() { close(postStarted) })
 		select {
 		case <-releasePosts:
 			w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
## What changed / 改动内容

- Track lazy MCP schema-cache persistence with the host background-write lifecycle.
- Make `Host.Close` wait for a detached lazy schema write before returning.
- Cover both asynchronous kick and synchronous cache-hit persistence paths.
- Add a deterministic regression test covering the close/write ordering.
- Publish the legacy SSE test's start signal only after its concurrency counters are visible.

## Why / 原因

The `1.17.19` formal release gate exposed intermittent `internal/plugin` failures while Go cleaned a test cache directory. Lazy MCP startup launched schema persistence in an untracked goroutine, allowing `Host.Close` to return while that goroutine was still writing.

`1.17.19` 正式发布门禁中，`internal/plugin` 偶发在清理测试缓存目录时失败。原因是 Lazy MCP 启动流程通过未纳入生命周期管理的 goroutine 持久化 schema，导致 `Host.Close` 返回后仍可能继续写入。

## Impact / 影响

The change only coordinates shutdown with an already-existing cache write. Runtime schema content, ordering, and persisted formats remain unchanged.

本次修改只让关闭流程等待已有的缓存写入完成，不改变运行时 schema 内容、顺序或持久化格式。

During review, Windows CI exposed a pre-existing ordering race in `TestLegacySSEBoundsConcurrentServerRequestReplies`: the handler signaled that a POST had started before publishing its active count. The test now publishes the count first; production SSE behavior is unchanged.

| Compatibility area | Result |
| --- | --- |
| Schema cache format | Unchanged |
| Provider-visible schema/order | Unchanged |
| Persisted config/session data | Unchanged |

## Verification / 验证

- `go test ./internal/plugin -run '^(TestHostCloseWaitsForLazyBackgroundWrite|TestLazyCacheMissAsyncSpawn|TestLazyBackgroundKick)$' -count=50`
- `go test ./internal/plugin -count=5`
- `go test -race ./internal/plugin`
- `go test ./internal/plugin -run '^TestLegacySSEBoundsConcurrentServerRequestReplies$' -count=5000`
- `go vet ./... && go build ./...`
- Windows/amd64 plugin test cross-compilation
- Two consecutive `REASONIX_RELEASE_CACHE_GUARD=1 go test ./... -count=1` runs

All checks passed locally. After this PR is merged, the complete `1.17.19` release gate will be rerun against the exact `main-v2` merge commit before any release tags are created.

以上检查均已在本地通过。PR 合并后，会针对 `main-v2` 的精确合并提交重新执行完整 `1.17.19` 发布门禁，通过前不会创建发布标签。

Cache-impact: none - This change only coordinates host shutdown with existing persistence and does not alter tool schemas, names, ordering, or provider request bytes.
Cache-guard: Focused lazy lifecycle tests passed for 50 runs, `go test -race ./internal/plugin` passed, and provider-visible schema bytes/order are unchanged.
