### PR TITLE
fix(release): carry reviewed notes into stable recoveries

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -346,11 +346,24 @@ jobs:
         working-directory: desktop
         run: go run ./cmd/sign manifest ../dist "${{ steps.ver.outputs.version }}" "${{ steps.ver.outputs.tag }}"
 
+      - name: Download orchestrator-reviewed release notes
+        if: ${{ inputs.orchestrated && steps.ver.outputs.channel != 'canary' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: stable-reviewed-release-notes
+          path: /tmp/stable-reviewed-release-notes
+
+      - name: Use orchestrator-reviewed release notes
+        if: ${{ inputs.orchestrated && steps.ver.outputs.channel != 'canary' }}
+        run: |
+          test -s /tmp/stable-reviewed-release-notes/release-notes.md
+          cp /tmp/stable-reviewed-release-notes/release-notes.md /tmp/release-notes.md
+
       # Canary never appears on the GitHub releases page; the mirror job picks up
       # the signed dist via the canary-dist artifact below. Stable publishes a
       # GitHub release as usual.
       - name: Render reviewed release notes
-        if: steps.ver.outputs.channel != 'canary'
+        if: ${{ !inputs.orchestrated && steps.ver.outputs.channel != 'canary' }}
         run: node scripts/release-notes.mjs render --version "${{ steps.ver.outputs.version }}" --output /tmp/release-notes.md
 
       - name: Revalidate approved release ref

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -20,6 +20,21 @@ on:
         description: "Existing stable CLI tag to recover (for example v1.18.0)"
         required: true
         type: string
+      publish_cli:
+        description: "Recover the CLI/Homebrew channel"
+        required: false
+        default: true
+        type: boolean
+      publish_npm:
+        description: "Recover the npm channel"
+        required: false
+        default: true
+        type: boolean
+      publish_desktop:
+        description: "Recover the Desktop/R2 channel"
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: stable-release-${{ inputs.tag || github.ref_name }}
@@ -65,6 +80,16 @@ jobs:
         run: bash scripts/resolve-stable-release.sh
       - name: Validate reviewed release notes
         run: node scripts/release-notes.mjs render --version "${{ steps.release.outputs.cli_tag }}" --output /tmp/release-notes.md
+      # Recovery builds deliberately check out the immutable tagged candidate,
+      # which can predate its reviewed release-note entry. Carry the exact file
+      # validated by this protected control-plane job into both publishers.
+      - name: Upload reviewed release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: stable-reviewed-release-notes
+          path: /tmp/release-notes.md
+          if-no-files-found: error
+          retention-days: 1
       - name: Cache hit guard
         run: ./scripts/cache-guard.sh
 
@@ -103,6 +128,7 @@ jobs:
   cli:
     name: publish CLI and Homebrew
     needs: authorize
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_cli }}
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.authorize.outputs.cli_tag }}
@@ -114,6 +140,7 @@ jobs:
   npm:
     name: publish npm
     needs: authorize
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_npm }}
     uses: ./.github/workflows/release-npm.yml
     with:
       channel: stable
@@ -127,6 +154,7 @@ jobs:
   desktop:
     name: publish desktop
     needs: authorize
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_desktop }}
     uses: ./.github/workflows/release-desktop.yml
     with:
       channel: stable
@@ -146,14 +174,25 @@ jobs:
     steps:
       - name: Require every publisher to succeed
         env:
+          PUBLISH_CLI: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_cli }}
+          PUBLISH_NPM: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_npm }}
+          PUBLISH_DESKTOP: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_desktop }}
           CLI_RESULT: ${{ needs.cli.result }}
           NPM_RESULT: ${{ needs.npm.result }}
           DESKTOP_RESULT: ${{ needs.desktop.result }}
         run: |
           set -euo pipefail
-          for result in "$CLI_RESULT" "$NPM_RESULT" "$DESKTOP_RESULT"; do
+          for channel in cli npm desktop; do
+            selected_var="PUBLISH_${channel^^}"
+            result_var="${channel^^}_RESULT"
+            selected="${!selected_var}"
+            result="${!result_var}"
+            if [ "$selected" != "true" ]; then
+              echo "$channel recovery skipped; public postflight will still verify it"
+              continue
+            fi
             if [ "$result" != "success" ]; then
-              echo "::error::stable publisher result is $result, expected success"
+              echo "::error::$channel stable publisher result is $result, expected success"
               exit 1
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,19 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+      - name: Download orchestrator-reviewed release notes
+        if: ${{ inputs.orchestrated }}
+        uses: actions/download-artifact@v8
+        with:
+          name: stable-reviewed-release-notes
+          path: /tmp/stable-reviewed-release-notes
+      - name: Use orchestrator-reviewed release notes
+        if: ${{ inputs.orchestrated }}
+        run: |
+          test -s /tmp/stable-reviewed-release-notes/release-notes.md
+          cp /tmp/stable-reviewed-release-notes/release-notes.md /tmp/release-notes.md
       - name: Render reviewed release notes
+        if: ${{ !inputs.orchestrated }}
         env:
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: node scripts/release-notes.mjs render --version "$RELEASE_TAG" --output /tmp/release-notes.md

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -26,6 +26,18 @@ grep -Eq "needs\.build\.result == 'success'" "$repo_root/.github/workflows/relea
 grep -Eq "needs\.publish\.result == 'success'" "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq '^  postflight:$' "$repo_root/.github/workflows/release-stable.yml"
 grep -Eq 'verify-stable-release-artifacts\.sh' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'name: Upload reviewed release notes' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'name: stable-reviewed-release-notes' "$repo_root/.github/workflows/release-stable.yml"
+for channel in cli npm desktop; do
+	grep -Eq '^      publish_'"$channel"':' "$repo_root/.github/workflows/release-stable.yml"
+	grep -Eq "inputs\.publish_$channel" "$repo_root/.github/workflows/release-stable.yml"
+done
+grep -Eq 'public postflight will still verify it' "$repo_root/.github/workflows/release-stable.yml"
+for workflow in release.yml release-desktop.yml; do
+	grep -Eq 'name: Download orchestrator-reviewed release notes' "$repo_root/.github/workflows/$workflow"
+	grep -Eq 'name: stable-reviewed-release-notes' "$repo_root/.github/workflows/$workflow"
+	grep -Eq 'if: \$\{\{ !inputs\.orchestrated' "$repo_root/.github/workflows/$workflow"
+done
 
 git init --bare -q "$test_root/remote.git"
 git clone -q "$test_root/remote.git" "$test_root/repo"


### PR DESCRIPTION
## Summary

- upload the exact release notes rendered and validated by the protected stable preflight
- consume that artifact in orchestrated CLI and Desktop publishers instead of reading notes from an older immutable candidate
- allow a manual recovery to retry only selected channels while public postflight still verifies every channel

## Root cause

Recovery run [29933982410](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/29933982410) correctly built commit `b8f715b546ee1252530005ff1d7c3b157beed644`, but the CLI publisher also tried to read release notes from that commit. The reviewed 1.17.19 notes were added later on protected `main-v2`, so preflight passed and the publisher failed with `release notes for v1.17.19 are missing`. Desktop had the same boundary in its publish job.

## Verification

- `bash scripts/release-workflows.test.sh`
- `node scripts/release-notes.mjs render --version v1.17.19 --output /tmp/reasonix-release-notes-v1.17.19.md`
- `git diff --check`