### PR TITLE
fix(acp): strip transient user blocks in session replay

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -208,6 +208,7 @@ func (s *updateSink) replay(msgs []provider.Message) {
 			if steer, ok := agent.SteerText(text); ok {
 				text = steer
 			}
+			text = agent.StripTransientUserBlocks(text)
 			if text != "" {
 				s.send(messageChunk{SessionUpdate: "user_message_chunk", Content: textBlock(text)})
 			}


### PR DESCRIPTION
## Summary

Fix  #6882 

The `replay` function in `dispatch.go` sends raw `m.Content` for user messages, which includes blocks like `<response-language>` that the agent injected via `WithResponseLanguage` before sending to the model. The desktop app's display path strips these via `StripComposePrefixes` → `StripTransientUserBlocks`, but the ACP replay path did not. This caused the blocks to appear verbatim in the chat UI after `session/load`.

- `dispatch.go`: add `agent.StripTransientUserBlocks(text)` after `SteerText` in the `provider.RoleUser` case of `replay`.

## Known limitation

This fix only covers transient blocks in the top-level session's user messages. Sub-agent turns may still carry transient blocks in their own persisted transcripts; those are replayed and are not addressed here.

## Verification

- [x] `go test ./internal/acp/ -count=1` — all tests pass, including the new unit test and existing e2e tests
- [x] `go vet ./internal/acp/...` — clean
- [x] `gofmt -w .` — no formatting changes

## Cache impact

Cache-impact: none — only touches ACP replay display path in `internal/acp/`, which is not in any cache-sensitive directory.
Cache-guard: new unit test `TestUpdateSinkReplayStripsTransientBlocks` directly covers the stripping behavior; existing e2e `TestE2ESessionLoad` covers the session/load replay path end-to-end.
System-prompt-review: N/A