### PR TITLE
fix: stop overwriting user USD prices with ¥ on config load/save

### DIFF
--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -250,7 +250,7 @@ func isKnownDeepSeekOfficialPricing(model string, price *provider.Pricing) bool 
 	if model == "" || price == nil {
 		return false
 	}
-	for _, prices := range []map[string]*provider.Pricing{deepSeekV4Prices(), deepSeekV4PricesUSD()} {
+	for _, prices := range []map[string]*provider.Pricing{deepSeekV4Prices()} {
 		if samePricing(price, prices[model]) {
 			return true
 		}


### PR DESCRIPTION
### Problem

When a user configures DeepSeek provider prices in USD (the official pricing for their region), the desktop app silently overwrites them with ¥ (CNY) on every config load and every settings save. This means the session cost display — and any downstream price calculations — always show ¥ instead of the user's chosen currency, making cost tracking confusing and requiring manual re-entry after every restart.

### Root cause

`isKnownDeepSeekOfficialPricing()` compares user-configured prices against **both** the current official ¥ defaults and the legacy $ defaults. When a user explicitly sets USD prices that match the official $ rates (e.g. `cache_hit = 0.0028, input = 0.14, output = 0.28, currency = "$"` for `deepseek-v4-flash`), these custom prices are identified as "known official" and silently replaced with ¥ defaults — directly contradicting the documented intent that "Custom user prices are left untouched."

The overwrite happens in `applyDeepSeekOfficialDefaultPricing()`, which runs on every config load (`load.go:144`, `load.go:621`) and every settings edit (`edit.go:187`, `edit.go:220`).

### Fix

Remove `deepSeekV4PricesUSD()` from the comparison set in `isKnownDeepSeekOfficialPricing()`. Only the current ¥ defaults are now considered "known official"; any USD-denominated prices are treated as custom user overrides and preserved across load/save cycles.

The one-time config migration (`resetOfficialProviderPricingDefaults`, gated by `ConfigVersion`) remains unchanged — pre-v3 configurations still correctly upgrade legacy $ defaults to ¥ at first launch.

### Impact

- **Cache-impact:** none — a single element removed from a loop predicate, no changes to system prompt, tool definitions, or provider configuration.
- **Backward compatibility:** existing ¥-denominated configs are unaffected; USD-using configs no longer reset on every restart.

### Testing

- `TestApplyDeepSeekOfficialDefaultPricingKeepsCustomPrice` — passes: custom $9/$9/$9 prices remain untouched.
- `TestApplyDeepSeekOfficialDefaultPricingUsesConfiguredLanguage` — passes: ¥ defaults still apply correctly.