### PR TITLE
Streamline stable release preparation and prepare v1.17.20 notes / 精简稳定版准备流程并准备 v1.17.20 发布说明

### DIFF
--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -11,6 +11,10 @@ on:
         description: "Previous release tag (defaults to the newest catalog entry)"
         required: false
         type: string
+      target_pr:
+        description: "Optional open same-repository PR into main-v2 to reuse instead of opening a release-only PR"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -29,20 +33,54 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Prepare the release-notes branch
+      - name: Select the review branch
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
+          TARGET_PR: ${{ inputs.target_pr }}
         run: |
           set -euo pipefail
-          branch="release-notes/v${VERSION#v}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch" main-v2
+          git fetch origin main-v2
+
+          if [ -n "$TARGET_PR" ]; then
+            if [[ ! "$TARGET_PR" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::target_pr must be a positive pull request number"
+              exit 1
+            fi
+            mapfile -t pr_state < <(
+              gh pr view "$TARGET_PR" --repo "$REPOSITORY" \
+                --json state,baseRefName,headRefName,isCrossRepository \
+                --jq '[.state, .baseRefName, .headRefName, (.isCrossRepository | tostring)][]'
+            )
+            if [ "${pr_state[0]}" != "OPEN" ] || [ "${pr_state[1]}" != "main-v2" ]; then
+              echo "::error::target_pr must be an open pull request into main-v2"
+              exit 1
+            fi
+            if [ "${pr_state[3]}" != "false" ]; then
+              echo "::error::target_pr comes from a fork; the repository token cannot safely update that branch"
+              exit 1
+            fi
+            branch="${pr_state[2]}"
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
             git checkout -b "$branch" --track "origin/$branch"
-            git merge --no-edit origin/main-v2
+            if ! git merge-base --is-ancestor origin/main-v2 HEAD; then
+              echo "::error::target_pr must include the latest main-v2 before release notes are generated"
+              exit 1
+            fi
+            echo "RELEASE_NOTES_PR=$TARGET_PR" >> "$GITHUB_ENV"
           else
-            git checkout -b "$branch"
+            branch="release-notes/v${VERSION#v}"
+            if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+              git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
+              git checkout -b "$branch" --track "origin/$branch"
+              git merge --no-edit origin/main-v2
+            else
+              git checkout -b "$branch"
+            fi
+            echo "RELEASE_NOTES_PR=" >> "$GITHUB_ENV"
           fi
           echo "RELEASE_NOTES_BRANCH=$branch" >> "$GITHUB_ENV"
 
@@ -61,6 +99,11 @@ jobs:
           node scripts/release-notes.mjs validate
           node --test scripts/release-notes.test.mjs
           node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md
+          {
+            echo "## Review draft for v${VERSION#v}"
+            echo
+            cat /tmp/release-notes.md
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open or update the review PR
         env:
@@ -71,10 +114,16 @@ jobs:
           git add release-notes/releases.json
           if ! git diff --cached --quiet; then
             git commit -m "docs(release): prepare v${VERSION#v} notes" \
-              -m "Generate a bilingual, product-focused draft from merged pull request metadata. The reviewed catalog will drive the website, desktop app, and GitHub releases."
+              -m "Summary:
+          Generate a bilingual, product-focused draft from merged pull request metadata. Reuse the selected release-bound PR when one is available.
+
+          Verification:
+          Validate the catalog, citations, bilingual fields, and rendered GitHub release notes before committing."
           fi
           git push -u origin "$RELEASE_NOTES_BRANCH"
-          if ! gh pr list --head "$RELEASE_NOTES_BRANCH" --state open --json number --jq 'length > 0' | grep -q true; then
+          if [ -n "$RELEASE_NOTES_PR" ]; then
+            echo "Updated existing release-bound PR #$RELEASE_NOTES_PR"
+          elif ! gh pr list --head "$RELEASE_NOTES_BRANCH" --state open --json number --jq 'length > 0' | grep -q true; then
             gh pr create \
               --base main-v2 \
               --head "$RELEASE_NOTES_BRANCH" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,14 +64,27 @@ from accidental or unauthorized invocation.
 ## The release loop
 
 1. **Develop** — PRs land on `main-v2` (branch auto-deletes on merge).
-2. **Prepare the release notes** — Actions → **Prepare release notes**. Enter the
-   intended version and, when needed, the previous desktop tag. The workflow sends
-   only public merged-PR metadata to DeepSeek, creates equivalent English and Chinese
-   product notes, validates their structure and citations, and opens a review PR.
-   Review and edit that PR like product copy. Once merged, the same catalog entry
-   drives `/changelog/` and both CLI and Desktop GitHub Releases; the desktop
-   app links to that web history from Settings → Updates. A missing catalog
-   entry blocks stable publication.
+2. **Prepare the release notes without creating a release-only PR by default** —
+   Actions → **Prepare release notes**. Enter the intended version, the previous
+   desktop tag when needed, and the number of an existing release-bound PR when
+   one is available. The reusable PR must be open, target `main-v2`, come from a
+   branch in this repository, and already include the latest `main-v2`. The
+   workflow commits the generated notes onto that branch, so product changes and
+   their release copy share one PR and one review surface. The added commit still
+   reruns that PR's required checks.
+
+   Leave `target_pr` empty only when there is no suitable PR, the candidate PR
+   comes from a fork that the repository token cannot update, or the release copy
+   needs independent editorial review. In that fallback, the workflow opens or
+   updates the dedicated `release-notes/vX.Y.Z` PR as before.
+
+   The workflow sends only public merged-PR metadata to DeepSeek, creates
+   equivalent English and Chinese product notes, validates their structure and
+   citations, and includes the rendered draft in the workflow summary. Review
+   the catalog diff like product copy. Once merged, the same entry drives
+   `/changelog/` and both CLI and Desktop GitHub Releases; the desktop app links
+   to that web history from Settings → Updates. A missing catalog entry still
+   blocks stable publication.
 3. **Cut a canary** before the intended release (e.g. heading for `1.4.0`):
    - Desktop: Actions → **Release desktop** → `channel: canary`, `base_version: 1.4.0`
    - CLI: Actions → **Release npm** → `base_version: 1.4.0`
@@ -79,8 +92,9 @@ from accidental or unauthorized invocation.
 4. **Test** — testers install `reasonix@canary` (CLI) or grab the desktop canary
    build from its R2 link, and report bugs.
 5. **Fix** on `main-v2` via PRs; re-cut the canary as needed (`canary.N` bumps).
-   Re-run **Prepare release notes** after material fixes; it updates the same branch
-   and PR without publishing anything.
+   Re-run **Prepare release notes** after material fixes. Reuse the still-open
+   release-bound PR when possible; otherwise the workflow updates the same
+   dedicated release-notes branch and PR without publishing anything.
 6. **Ship stable** when the canary is clean and the release-notes PR is merged —
    create the three tags locally, then push them atomically:
    ```sh
@@ -109,6 +123,22 @@ from accidental or unauthorized invocation.
    matches the approved version; missing artifacts can no longer produce a green
    stable run.
 7. **Next cycle** — the canary rolls on toward `1.5.0`.
+
+### Release-PR frequency rule
+
+- Do not open a dedicated PR merely because a version is being published.
+- Prefer the final same-repository product, fix, or release-infrastructure PR
+  that already defines the candidate boundary. Generate the notes into that PR
+  before its final review.
+- A dedicated release-notes PR is the safe fallback, not the default. Use it
+  when no suitable PR exists, the only candidate PR comes from a fork, or the
+  release copy needs an independent approval boundary.
+- Never bypass protected `main-v2` with a direct catalog commit. Reducing PR
+  frequency must not remove release-copy review, catalog validation, cache
+  checks, atomic tags, the single `release` environment approval, or public
+  artifact postflight.
+- Release infrastructure and release-note schema changes still require their
+  own focused PR. This rule only avoids redundant version-only PRs.
 
 ## Notes
 

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -175,6 +175,19 @@
             "refs": [
               6843
             ]
+          },
+          {
+            "title": {
+              "en": "Fewer release-only pull requests",
+              "zh": "减少仅用于发版的 Pull Request"
+            },
+            "body": {
+              "en": "Release notes can now be generated into an existing same-repository release-bound pull request, keeping the dedicated release-notes PR as a fallback while preserving protected-main review and every publication gate.",
+              "zh": "发布说明现在可直接生成到同仓库已有的发版边界 Pull Request 中，专用发布说明 PR 仅作为兜底，同时继续保留受保护 main-v2 审核和全部发布门禁。"
+            },
+            "refs": [
+              6893
+            ]
           }
         ],
         "fixed": [

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -2,6 +2,310 @@
   "schemaVersion": 1,
   "releases": [
     {
+      "version": "1.17.20",
+      "date": "2026-07-24",
+      "channel": "stable",
+      "title": {
+        "en": "Machine-ready CLI, trusted MCP delegation, and safer desktop updates",
+        "zh": "机器友好 CLI、可信 MCP 协作与更安全的桌面更新"
+      },
+      "summary": {
+        "en": "This release adds privacy-preserving machine interfaces for CLI automation, lets Planner and sub-agents use authorized MCP capabilities through a stable cache-friendly proxy, enables verified in-app updates for Debian packages, and makes desktop model switching, rich-text editing, Plan recovery, and code previews more reliable.",
+        "zh": "此版本为 CLI 自动化新增保护隐私的机器接口，让 Planner 与子 Agent 通过稳定且缓存友好的代理使用已授权 MCP 能力，为 Debian 安装包带来经过验证的应用内更新，并提升桌面端模型切换、富文本编辑、Plan 恢复和代码预览的可靠性。"
+      },
+      "surfaces": [
+        "cli",
+        "agent",
+        "mcp",
+        "desktop",
+        "updates",
+        "recovery"
+      ],
+      "guides": [
+        {
+          "title": {
+            "en": "CLI automation interfaces",
+            "zh": "CLI 自动化接口"
+          },
+          "body": {
+            "en": "Use the documented session, task, hook, and event-stream contracts to integrate Reasonix without parsing terminal presentation.",
+            "zh": "使用文档化的会话、任务、Hook 和事件流契约集成 Reasonix，无需解析终端展示文本。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/16d71aa4758765b6e7f86d8659e794bdd4a5b535/docs/CLI.md"
+        }
+      ],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": {
+            "en": "Privacy-preserving machine interfaces",
+            "zh": "保护隐私的机器接口"
+          },
+          "body": {
+            "en": "CLI automation can inspect sessions, tasks, hooks, and lifecycle events through structured contracts with opaque machine identities, verified artifact state, and fail-closed runtime ownership.",
+            "zh": "CLI 自动化现在可通过结构化契约检查会话、任务、Hook 和生命周期事件，并使用不透明机器身份、经过验证的制品状态和安全失败的运行时所有权边界。"
+          },
+          "refs": [
+            6859
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Planner and sub-agents can use trusted MCPs",
+            "zh": "Planner 与子 Agent 可使用可信 MCP"
+          },
+          "body": {
+            "en": "Installed and authorized MCP capabilities are available through one stable use_capability schema, preserving provider-prefix cache stability while enforcing live authorization, exact runtime identity, revocation, and destructive-effect boundaries.",
+            "zh": "已安装并授权的 MCP 能力现在通过稳定的 use_capability schema 提供，在保持 Provider 前缀缓存稳定的同时，执行实时授权、精确运行时身份、撤销和破坏性效果边界。"
+          },
+          "refs": [
+            6865
+          ]
+        },
+        {
+          "kind": "improved",
+          "title": {
+            "en": "Verified Debian package updates",
+            "zh": "经过验证的 Debian 安装包更新"
+          },
+          "body": {
+            "en": "Debian and Ubuntu desktop installs can authorize upgrades through a packaged Polkit helper that rechecks ownership, signatures, package identity, architecture, and version before apt installs the update.",
+            "zh": "Debian 与 Ubuntu 桌面安装现在可通过随包提供的 Polkit helper 授权升级；在 apt 安装更新前，会重新检查所有权、签名、包身份、架构和版本。"
+          },
+          "refs": [
+            6866
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Desktop editing and provider state stay stable",
+            "zh": "桌面编辑与 Provider 状态更加稳定"
+          },
+          "body": {
+            "en": "Rich-composer edits no longer jump to the end around invocation chips, transcript selections survive Plan revision refreshes, and rapid model switches cannot restore stale provider balance or overwrite session and global defaults.",
+            "zh": "富文本输入框在调用标签附近编辑时不再跳到末尾，Plan 修订刷新不会清除历史文本选择，快速模型切换也不会恢复过期余额或混淆会话模型与全局默认值。"
+          },
+          "refs": [
+            6872,
+            6466,
+            6881
+          ]
+        }
+      ],
+      "changes": {
+        "new": [
+          {
+            "title": {
+              "en": "Structured session, task, hook, and event output",
+              "zh": "结构化会话、任务、Hook 与事件输出"
+            },
+            "body": {
+              "en": "New machine-facing CLI projections expose durable lifecycle state without leaking provider-controlled tool names or guessable transcript identities, while existing json and stream-json session identifiers remain compatible.",
+              "zh": "新的 CLI 机器投影可提供持久生命周期状态，同时避免泄露 Provider 控制的工具名称或可猜测的历史记录身份；现有 json 与 stream-json 会话标识保持兼容。"
+            },
+            "refs": [
+              6859
+            ]
+          },
+          {
+            "title": {
+              "en": "Stable MCP capability routing for delegated work",
+              "zh": "委派任务的稳定 MCP 能力路由"
+            },
+            "body": {
+              "en": "Planner, review, task, fleet, and dual-model Executor paths share authorized MCP runtime state while keeping per-agent ledgers, exact allowlists, serialized writers, structured image results, and provider-visible schemas stable.",
+              "zh": "Planner、Review、Task、Fleet 和双模型 Executor 现在共享已授权 MCP 运行时状态，同时保持每个 Agent 的独立记录、精确白名单、写操作串行化、结构化图片结果和稳定的 Provider 可见 schema。"
+            },
+            "refs": [
+              6865
+            ]
+          }
+        ],
+        "improved": [
+          {
+            "title": {
+              "en": "Episode-bounded Auto recovery and explicit Plan exit",
+              "zh": "按 Episode 限制 Auto 恢复并支持明确退出 Plan"
+            },
+            "body": {
+              "en": "Recovery limits now apply to the current execution episode and reset on real new work, while Desktop and CLI can leave Plan without executing or discarding the active Goal.",
+              "zh": "恢复上限现在只作用于当前执行 Episode，并会在真正的新工作开始时重置；桌面端和 CLI 也可退出 Plan 而不执行计划或丢失当前 Goal。"
+            },
+            "refs": [
+              6871
+            ]
+          },
+          {
+            "title": {
+              "en": "More accurate completion evidence",
+              "zh": "更准确的完成证据"
+            },
+            "body": {
+              "en": "complete_step accepts fresh structured review receipts only when they follow the latest mutation and cover the changed result, rejecting stale reviews and background-task starts.",
+              "zh": "complete_step 现在只接受位于最新变更之后并覆盖其结果的新鲜结构化 Review 回执，同时拒绝过期 Review 和仅启动的后台任务。"
+            },
+            "refs": [
+              6762
+            ]
+          },
+          {
+            "title": {
+              "en": "Broader and bounded syntax highlighting",
+              "zh": "覆盖更广且有安全上限的语法高亮"
+            },
+            "body": {
+              "en": "Desktop previews support 52 languages and share one path-aware resolver across chat, diffs, and files, with large blocks falling back to escaped plain text instead of overloading highlighting.",
+              "zh": "桌面预览现在支持 52 种语言，并在聊天、Diff 和文件视图中共用路径感知的解析器；超大代码块会安全回退为转义纯文本，避免高亮负载过大。"
+            },
+            "refs": [
+              6861
+            ]
+          },
+          {
+            "title": {
+              "en": "Recoverable stable-release channels",
+              "zh": "可按通道恢复的稳定版发布"
+            },
+            "body": {
+              "en": "Stable release recoveries now carry the reviewed notes validated by the protected control plane and can retry only failed channels while still verifying every public artifact.",
+              "zh": "稳定版恢复现在会携带受保护控制面验证过的审核版说明，并可只重试失败通道，同时仍校验全部公开制品。"
+            },
+            "refs": [
+              6843
+            ]
+          }
+        ],
+        "fixed": [
+          {
+            "title": {
+              "en": "Rich-composer caret and IME stability",
+              "zh": "富文本输入框光标与输入法稳定性"
+            },
+            "body": {
+              "en": "Selection mapping now handles invocation chips, NBSP anchors, ranges, repeated text, temporary selection loss, and WebView2 IME ordering without moving mid-text edits to the end.",
+              "zh": "选择映射现在能正确处理调用标签、NBSP 锚点、范围选择、重复文本、临时选择丢失和 WebView2 输入法事件顺序，不再把中间编辑移到末尾。"
+            },
+            "refs": [
+              6872
+            ]
+          },
+          {
+            "title": {
+              "en": "Last-click-wins model switching",
+              "zh": "最后点击生效的模型切换"
+            },
+            "body": {
+              "en": "Per-tab model switches are serialized, stale balance and catalog responses are discarded, failed switches restore safe state, and session-local picks no longer rewrite the global default for new sessions.",
+              "zh": "每个标签页的模型切换现在会串行执行，过期余额和模型目录响应会被丢弃，失败切换会恢复安全状态，会话内选择也不会改写新会话使用的全局默认值。"
+            },
+            "refs": [
+              6881
+            ]
+          },
+          {
+            "title": {
+              "en": "Plan revision preserves transcript selection",
+              "zh": "Plan 修订保留历史文本选择"
+            },
+            "body": {
+              "en": "Periodic parent refreshes no longer refocus the revision editor and clear transcript text that the user selected for copying.",
+              "zh": "周期性父级刷新不再重新聚焦修订编辑器，也不会清除用户为复制而选中的历史文本。"
+            },
+            "refs": [
+              6466
+            ]
+          },
+          {
+            "title": {
+              "en": "Documentation sidebar tracks the active section",
+              "zh": "文档侧边栏正确跟随当前章节"
+            },
+            "body": {
+              "en": "The documentation site now highlights the section that is actually visible instead of leaving a stale sidebar item active.",
+              "zh": "文档站现在会高亮实际可见的章节，不再让过期的侧边栏项目保持激活。"
+            },
+            "refs": [
+              6222
+            ]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "warning",
+          "title": {
+            "en": "One-time bootstrap for existing Debian packages",
+            "zh": "现有 Debian 安装需要一次性 bootstrap"
+          },
+          "body": {
+            "en": "Older .deb installs do not contain the new Polkit helper. Install the 1.17.20 .deb once with sudo apt install ./Reasonix-linux-amd64.deb; later in-app updates can use the authorized helper without uninstalling first.",
+            "zh": "旧版 .deb 尚未包含新的 Polkit helper。请先执行一次 sudo apt install ./Reasonix-linux-amd64.deb 安装 1.17.20；之后即可使用应用内授权更新，无需先卸载。"
+          },
+          "refs": [
+            6866
+          ]
+        },
+        {
+          "level": "info",
+          "title": {
+            "en": "Keep Desktop and Remote hosts on matching versions",
+            "zh": "Desktop 与 Remote Host 请保持同版本"
+          },
+          "body": {
+            "en": "The remote protocol adds optional resolved-capability metadata. Old data remains readable, but Desktop and Remote hosts should follow the existing matching-build upgrade contract.",
+            "zh": "远程协议新增可选的已解析能力元数据。旧数据仍可读取，但 Desktop 与 Remote Host 应继续遵循同版本构建的升级约定。"
+          },
+          "refs": [
+            6865
+          ]
+        },
+        {
+          "level": "info",
+          "title": {
+            "en": "No manual data migration required",
+            "zh": "无需手动迁移数据"
+          },
+          "body": {
+            "en": "Existing providers, sessions, projects, Goals, jobs, and MCP definitions continue to load. The events-jsonl machine interface creates a private per-install identity key on first use; legacy json and stream-json resume identifiers remain unchanged.",
+            "zh": "现有 Provider、会话、项目、Goal、后台任务和 MCP 定义会继续加载。events-jsonl 机器接口首次使用时会创建每次安装私有的身份密钥；旧有 json 与 stream-json 恢复标识保持不变。"
+          },
+          "refs": [
+            6859
+          ]
+        }
+      ],
+      "risks": [
+        {
+          "title": {
+            "en": "Installed MCP authorization is the trust boundary",
+            "zh": "已安装 MCP 的授权状态是信任边界"
+          },
+          "body": {
+            "en": "Planner and ordinary sub-agents can call installed and authorized MCP capabilities without another launch prompt. Explicit deny rules, live revocation, destructive checks, exact runtime identity, and serialized writer dispatch still apply.",
+            "zh": "Planner 与普通子 Agent 可在不重复弹出启动确认的情况下调用已安装且授权的 MCP 能力。显式 deny、实时撤销、破坏性检查、精确运行时身份和写操作串行化仍然生效。"
+          },
+          "refs": [
+            6865
+          ]
+        }
+      ],
+      "contributors": [
+        "SivanCola",
+        "mchenziyi",
+        "JesonChou",
+        "SauronSkywalker",
+        "9710willy",
+        "par73e"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.17.20",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.17.19...desktop-v1.17.20",
+        "download": "https://reasonix.io/?download=desktop#start"
+      }
+    },
+    {
       "version": "1.17.19",
       "date": "2026-07-22",
       "channel": "stable",

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -39,6 +39,19 @@ for workflow in release.yml release-desktop.yml; do
 	grep -Eq 'if: \$\{\{ !inputs\.orchestrated' "$repo_root/.github/workflows/$workflow"
 done
 
+# Release notes should normally reuse an existing release-bound PR instead of
+# opening one PR per version. Fork PRs and stale branches must fail closed, and
+# the dedicated release-notes PR remains the explicit fallback.
+prepare_notes="$repo_root/.github/workflows/prepare-release-notes.yml"
+grep -Eq '^      target_pr:$' "$prepare_notes"
+grep -Eq 'isCrossRepository' "$prepare_notes"
+grep -Eq 'target_pr comes from a fork' "$prepare_notes"
+grep -Eq 'git merge-base --is-ancestor origin/main-v2 HEAD' "$prepare_notes"
+grep -Eq 'RELEASE_NOTES_PR=\$TARGET_PR' "$prepare_notes"
+grep -Eq 'Updated existing release-bound PR' "$prepare_notes"
+grep -Eq 'release-notes/v\$\{VERSION#v\}' "$prepare_notes"
+grep -Eq 'GITHUB_STEP_SUMMARY' "$prepare_notes"
+
 git init --bare -q "$test_root/remote.git"
 git clone -q "$test_root/remote.git" "$test_root/repo"
 (


### PR DESCRIPTION
## Summary

Prepare the reviewed bilingual v1.17.20 release notes and remove the need for a dedicated release-notes pull request on every future stable version.

## Problem and root cause

The release catalog must enter protected main-v2 before stable tags are created, but the preparation workflow always used a version-specific branch. That forced one extra release-only pull request even when an existing final product, fix, or release-infrastructure pull request already defined the candidate boundary.

## New default flow

- Prepare release notes accepts an optional target_pr.
- The target must be open, target main-v2, come from this repository, and already contain the latest main-v2.
- The workflow commits the generated bilingual notes into that existing PR and places the rendered draft in the workflow summary.
- A dedicated release-notes/vX.Y.Z PR remains the fail-closed fallback for fork PRs, stale branches, missing candidate PRs, or independent editorial review.
- Direct catalog commits to protected main-v2 remain prohibited.

This reduces redundant release-only PRs without removing review, CI, cache validation, atomic tags, the single release-environment approval, publisher authorization, or public-artifact postflight.

## v1.17.20 notes

The catalog covers the merged work since v1.17.19: machine-facing CLI contracts, stable trusted-MCP delegation, verified Debian updates, Episode-bounded recovery, explicit Plan exit, broader bounded syntax highlighting, fresh completion evidence, and Desktop model/editor reliability fixes.

It explicitly documents the one-time Debian bootstrap, matching Desktop/Remote versions, machine identity initialization, legacy json and stream-json compatibility, and the installed-MCP trust boundary.

## Compatibility

| Surface | Existing behavior | Conclusion |
| --- | --- | --- |
| Release review | Notes may share an existing same-repository PR; protected main-v2 still requires PR review | Safety preserved |
| Fork PRs | Repository token does not write to the fork | Dedicated PR fallback |
| Stale candidate branches | Missing latest main-v2 fails before generation | Fail closed |
| Existing data | Providers, sessions, projects, Goals, jobs, and MCP definitions continue to load | Backward-safe |
| CLI json and stream-json IDs | Existing resume identifiers remain unchanged | Preserved |
| events-jsonl machine IDs | A private per-install identity key initializes on first use | Automatic migration |
| Desktop and Remote protocol | Optional capability metadata; matching builds remain required | Existing contract preserved |
| Debian updater | Older packages need one bootstrap install | Documented one-time action |
| Provider-visible MCP schema | Delegated agents use one stable use_capability schema | Intentional stable proxy migration; cache guard retained |

## Verification

- bash scripts/release-workflows.test.sh
- node scripts/release-notes.mjs validate
- node --test scripts/release-notes.test.mjs
- rendered the v1.17.20 GitHub release notes successfully
- git diff --check