### PR TITLE
Fix Desktop session runtime ownership / 修复桌面会话运行时所有权

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ branch.
 
 ### Fixed
 
+- Fixed Desktop sessions incorrectly locking themselves during Goal + Delivery
+  mode changes, controller rebuilds, duplicate-tab restore, and background
+  reattachment. Desktop now keeps one process-local runtime owner per canonical
+  session, fences stale controller events by runtime epoch, blocks sends until
+  that runtime is ready, and scopes single-instance ownership to
+  `REASONIX_HOME` instead of the executable path. Switching saved sessions is
+  now transactional: a target build, restore, or lease failure leaves the
+  current controller, lease, path, mode profile, and runtime epoch untouched.
 - Stabilized the desktop rich composer caret after skill and plugin invocation
   tags. DOM→model and model→DOM selection mapping now treat invocation chips as
   zero-length atoms while still counting user text that lands inside the NBSP

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -120,6 +120,11 @@ type App struct {
 	activeTabID string
 	readyHook   func()
 
+	// runtimeByID/runtimeBySessionKey form the process-local ownership registry.
+	// App.mu guards both maps and every desktopSessionRuntime field.
+	runtimeByID         map[string]*desktopSessionRuntime
+	runtimeBySessionKey map[string]*desktopSessionRuntime
+
 	// tabsRestored is closed when restoreOrBuildTabs has finished populating
 	// a.tabs from desktop-tabs.json (or built the first-launch tab). Startup
 	// work that inspects "which sessions are open" or persists the tab list
@@ -162,6 +167,10 @@ type App struct {
 	// runtimeMutationBeforeLockHook is test-only. Set it before starting concurrent
 	// calls and never mutate it afterward.
 	runtimeMutationBeforeLockHook func(string)
+	// rebindCandidateHook is test-only. It exposes deterministic transaction
+	// boundaries without weakening the production lock order. Set it before
+	// starting a rebind and never mutate it until that rebind returns.
+	rebindCandidateHook func(string) error
 
 	// tryRunMu guards tryRunCancel — the cancel handle for the single
 	// in-flight settings-page subagent try run (TrySubagentProfile /
@@ -422,11 +431,13 @@ func (a *App) workspaceMediaMiddleware() func(http.Handler) http.Handler {
 // last session's desktop-tabs.json.
 func NewApp() *App {
 	a := &App{
-		tabs:             map[string]*WorkspaceTab{},
-		detachedSessions: map[string]*WorkspaceTab{},
-		mediaTokens:      newMediaTokenStore(),
-		botInstalls:      map[string]*botInstallSession{},
-		botRuntime:       newDesktopBotRuntime(),
+		tabs:                map[string]*WorkspaceTab{},
+		runtimeByID:         map[string]*desktopSessionRuntime{},
+		runtimeBySessionKey: map[string]*desktopSessionRuntime{},
+		detachedSessions:    map[string]*WorkspaceTab{},
+		mediaTokens:         newMediaTokenStore(),
+		botInstalls:         map[string]*botInstallSession{},
+		botRuntime:          newDesktopBotRuntime(),
 	}
 	a.botBridge = a.newBotBridge()
 	return a
@@ -841,6 +852,9 @@ func (a *App) shutdown(context.Context) {
 		}
 		it.ctrl.Close()
 		it.tab.releaseSessionLease()
+		a.mu.Lock()
+		a.releaseSessionRuntimeLocked(it.tab)
+		a.mu.Unlock()
 	}
 	if a.startupTracker != nil && a.startupReady.Load() {
 		// Only a run whose window actually became ready may reset the crash-loop
@@ -991,7 +1005,7 @@ func (a *App) beginTabTurn(tabID string, reclaim bool) (*tabTurnAdmission, contr
 	if a.tabIsReadOnly(tab) {
 		return nil, nil, readOnlyChannelErr()
 	}
-	if tab == nil || ctrl == nil {
+	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
 		return nil, nil, a.workspaceNotReadyErr(tab)
 	}
 	// Runtime work-admission barrier: held (shared) from here until the turn is
@@ -1013,18 +1027,18 @@ func (a *App) beginTabTurn(tabID string, reclaim bool) (*tabTurnAdmission, contr
 		a.botBridge.reclaimFromDesktop(tab.ID)
 	}
 	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
+	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
 		abort()
-		return nil, nil, a.workspaceNotReadyErr(tab)
+		return nil, nil, err
 	}
 	if err := a.ensureTabControllerWorkspaceAdmissionHeld(tab); err != nil {
 		abort()
 		return nil, nil, err
 	}
 	ctrl = a.controllerForTab(tab)
-	if ctrl == nil {
+	if err := a.workspaceRuntimeAdmissionErr(tab, ctrl); err != nil {
 		abort()
-		return nil, nil, a.workspaceNotReadyErr(tab)
+		return nil, nil, err
 	}
 	if ctrl.RuntimeStatus().Running || (tab.sink != nil && !tab.sink.tryBeginTurn()) {
 		abort()
@@ -1893,16 +1907,41 @@ func (a *App) CompactForTab(tabID string) error {
 // build goroutine while Submit-family calls race it, so read it under the
 // lock. Callers must not hold a.mu.
 func (a *App) workspaceNotReadyErr(tab *WorkspaceTab) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.workspaceNotReadyErrLocked(tab)
+}
+
+func (a *App) workspaceNotReadyErrLocked(tab *WorkspaceTab) error {
 	startupErr := ""
+	var issue *SessionRuntimeIssue
 	if tab != nil {
-		a.mu.RLock()
 		startupErr = tab.StartupErr
-		a.mu.RUnlock()
+		issue = a.sessionRuntimeViewLocked(tab).Issue
 	}
 	if strings.TrimSpace(startupErr) != "" {
 		return fmt.Errorf("workspace failed to start: %s", startupErr)
 	}
+	if issue != nil && strings.TrimSpace(issue.Message) != "" {
+		return fmt.Errorf("workspace failed to start: %s", issue.Message)
+	}
 	return fmt.Errorf("workspace is still starting")
+}
+
+// workspaceRuntimeAdmissionErr is the backend half of the composer readiness
+// contract. The frontend gate avoids an optimistic bubble for known startup
+// states; this check closes the race where a rebuild or lease failure lands
+// after the last metadata refresh but before a bound Submit call.
+func (a *App) workspaceRuntimeAdmissionErr(tab *WorkspaceTab, ctrl control.SessionAPI) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if tab != nil && ctrl != nil && tab.Ctrl == ctrl {
+		runtimeView := a.sessionRuntimeViewLocked(tab)
+		if runtimeView.Phase == sessionRuntimeReady {
+			return nil
+		}
+	}
+	return a.workspaceNotReadyErrLocked(tab)
 }
 
 // tabIsReadOnly reads tab.ReadOnly under a.mu; setTabReadOnly can flip it
@@ -2071,7 +2110,7 @@ func (a *App) ClearSessionForTab(tabID string) error {
 	if err := ctrl.ClearSession(); err != nil {
 		return err
 	}
-	if err := tab.ensureSessionLease(ctrl.SessionPath()); err != nil {
+	if err := a.ensureTabSessionLeaseForRebuild(tab, ctrl.SessionPath(), ""); err != nil {
 		// Wails bridge return: a raw lease error would carry the session path
 		// and holder id across to the frontend.
 		return userFacingSessionLeaseError("", err)
@@ -2193,7 +2232,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 	// Controller.ClearSession): the snapshot's goal belongs to the destroyed
 	// conversation and must not seed the replacement.
 	path := agent.NewSessionPath(newCtrl.SessionDir(), newCtrl.Label())
-	if err := tab.ensureSessionLease(path); err != nil {
+	if err := a.ensureTabSessionLeaseForRebuild(tab, path, ""); err != nil {
 		newCtrl.Close()
 		// Surfaces through ClearSession's Wails return; keep the holder's
 		// path/pid/writer id out of it.
@@ -3718,27 +3757,18 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 			return err
 		}
 	}
-	// Session rebinding is a full detach/close/build/swap of the tab's
-	// controller — the same shape as rebuildSetting/SetModelForTab. Hold the
-	// shared rebuild mutex so a concurrent model/effort/settings rebuild of the
-	// same tab cannot interleave: without it both builds pass the swap-time
-	// identity check, the loser's controller leaks un-closed, and the old
-	// controller can be double-closed.
+	// Session rebinding is a candidate transaction. Keep the source controller,
+	// lease, runtime key, epoch, and profile live until the target controller has
+	// built, restored, validated, and acquired its own lease. The lifecycle
+	// barrier blocks new turns and startup publication across the transaction.
 	a.runtimeRebuildMu.Lock()
 	defer a.runtimeRebuildMu.Unlock()
-	tab.turnStartMu.Lock()
-	defer tab.turnStartMu.Unlock()
 
-	// Validate the tab, compare session keys, invalidate any in-flight async
-	// build, and snapshot the controller in ONE a.mu critical section.
-	// runtimeRebuildMu does not cover startTabControllerBuild's goroutine, so
-	// observing ctrl == nil and bumping the generation later would leave a
-	// window where the async build passes its swap-time generation check,
-	// installs its controller after the observation, and the loaded build
-	// below silently overwrites it — leaking the runtime and its shared-host
-	// reference. Bump-before-snapshot makes the snapshot authoritative: after
-	// the bump the async build can only fall into its superseded branches,
-	// which release exactly what it acquired (abandonSupersededBuild).
+	// Fence an in-flight startup before waiting for the admission barrier. The
+	// startup build holds the barrier's read side for its whole build; cancelling
+	// its generation first lets it retire instead of making this writer wait on
+	// a build that still believes it can publish. App.mu is released before the
+	// barrier acquisition, so no inverted lock nesting is introduced.
 	a.mu.Lock()
 	if tab.removed || a.tabs[tab.ID] != tab {
 		a.mu.Unlock()
@@ -3757,80 +3787,312 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		a.mu.Unlock()
 		return nil
 	}
-	tab.buildGeneration++
-	if tab.buildCancel != nil {
-		tab.buildCancel()
-		tab.buildCancel = nil
-	}
-	ctrl := tab.Ctrl
+	a.supersedeTabBuildLocked(tab)
+	source := snapshotTabRuntimeLocked(tab)
 	a.mu.Unlock()
+
+	a.runtimeAdmissionMu.Lock()
+	defer a.runtimeAdmissionMu.Unlock()
+	tab.turnStartMu.Lock()
+	defer tab.turnStartMu.Unlock()
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
+		a.mu.Unlock()
+		return fmt.Errorf("tab changed while preparing to switch sessions; retry")
+	}
+	source = snapshotTabRuntimeLocked(tab)
+	a.mu.Unlock()
+
+	if source.ctrl != nil {
+		if err := a.snapshotTabForAction(tab, "switching sessions"); err != nil {
+			return err
+		}
+		if oldPath := a.reconciledSessionPathForTab(tab); oldPath != "" {
+			if err := a.saveTabSessionMeta(tab, oldPath); err != nil {
+				return fmt.Errorf("save current session metadata before switching sessions: %w", err)
+			}
+		}
+	}
+
+	// Snapshot recovery may have retargeted the source controller and runtime.
+	// Refresh the identity before reserving the target alias.
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
+		a.mu.Unlock()
+		return fmt.Errorf("tab changed while preparing to switch sessions; retry")
+	}
+	source = snapshotTabRuntimeLocked(tab)
+	a.mu.Unlock()
+
+	transition, err := a.reserveSessionRuntimePath(tab, sessionPath)
+	if err != nil {
+		return userFacingSessionLeaseError("", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			a.rollbackSessionRuntimePath(transition)
+		}
+	}()
 
 	profile := loadTabSessionProfile(sessionPath)
-
-	if ctrl == nil {
-		a.mu.Lock()
-		tab.SessionPath = sessionPath
-		applyTabSessionProfile(tab, profile)
-		tab.Ready = false
-		clearTabStartupError(tab)
-		tab.ActivityStatus = ""
-		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
-		a.saveTabsLocked()
-		a.mu.Unlock()
-		a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
-		a.mu.RLock()
-		builtCtrl, startupErr := tab.Ctrl, tab.StartupErr
-		a.mu.RUnlock()
-		if builtCtrl == nil {
-			if startupErr != "" {
-				return fmt.Errorf("resume session: %s", startupErr)
-			}
-			return fmt.Errorf("resume session: controller was not built")
-		}
-		return nil
+	detachSource := controllerHasActiveRuntimeWork(source.ctrl)
+	candidateNeedsHostRef := detachSource || source.ctrl == nil
+	candidate, err := a.buildSessionRebindCandidate(tab, source, sessionPath, loaded, profile, candidateNeedsHostRef)
+	if err != nil {
+		return fmt.Errorf("resume session: %w", err)
 	}
+	defer func() {
+		if !committed {
+			candidate.close()
+		}
+	}()
 
-	if err := a.snapshotTabForAction(tab, "switching sessions"); err != nil {
+	targetLease, err := a.acquireCandidateSessionLease(tab, sessionPath)
+	if err != nil {
 		return err
 	}
-	if oldPath := a.reconciledSessionPathForTab(tab); oldPath != "" {
-		if err := a.saveTabSessionMeta(tab, oldPath); err != nil {
-			return fmt.Errorf("save current session metadata before switching sessions: %w", err)
+	defer func() {
+		if !committed {
+			targetLease.Release()
 		}
+	}()
+	if err := a.runRebindCandidateHook("lease_acquired"); err != nil {
+		return fmt.Errorf("resume session: %w", err)
 	}
-	if controllerHasActiveRuntimeWork(ctrl) {
-		if !a.detachRuntimeForReplacement(tab) {
+
+	// All fallible candidate work is complete. Revalidate the source runtime
+	// generation, atomically publish the target controller/lease/profile/path,
+	// and advance the epoch in the same App.mu commit.
+	a.mu.Lock()
+	if tab.removed ||
+		a.tabs[tab.ID] != tab ||
+		tab.Ctrl != source.ctrl ||
+		a.runtimeForTabLocked(tab) != transition.runtime ||
+		!a.sessionRuntimePathTransitionValidLocked(transition) {
+		a.mu.Unlock()
+		return fmt.Errorf("tab runtime changed while switching sessions; retry")
+	}
+	var oldLease *agent.SessionLease
+	oldCtrl := tab.Ctrl
+	oldSink := tab.sink
+	if detachSource {
+		if !a.detachRuntimeForReplacementLocked(tab) {
+			a.mu.Unlock()
 			return fmt.Errorf("current session runtime cannot be detached")
 		}
+		if a.runtimeBySessionKey[transition.targetKey] == transition.runtime {
+			delete(a.runtimeBySessionKey, transition.targetKey)
+		}
 	} else {
-		ctrl.Close()
-		tab.releaseSessionLease()
+		if !a.commitSessionRuntimePathLocked(transition) {
+			a.mu.Unlock()
+			return fmt.Errorf("tab runtime changed while switching sessions; retry")
+		}
+		oldLease = tab.takeSessionLease()
 	}
-
-	a.mu.Lock()
-	// The generation was already bumped (and any async build cancelled) in
-	// the validation section above; only retarget the tab here.
-	tab.Ctrl = nil
+	tab.adoptSessionLease(targetLease)
+	targetLease = nil
+	tab.Ctrl = candidate.ctrl
+	tab.sink = candidate.sink
 	tab.SessionPath = sessionPath
-	applyTabSessionProfile(tab, profile)
-	tab.Ready = false
+	tab.model = candidate.model
+	tab.Label = candidate.ctrl.Label()
+	applyNormalizedRuntimeToTabLocked(tab, candidate.runtime)
+	tab.Ready = true
 	clearTabStartupError(tab)
 	tab.ActivityStatus = ""
-	tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
-	a.saveTabsLocked()
-	a.mu.Unlock()
-
-	a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
-	a.mu.RLock()
-	builtCtrl, startupErr := tab.Ctrl, tab.StartupErr
-	a.mu.RUnlock()
-	if builtCtrl == nil {
-		if startupErr != "" {
-			return fmt.Errorf("resume session: %s", startupErr)
-		}
-		return fmt.Errorf("resume session: controller was not built")
+	tab.telemMu.Lock()
+	tab.readTelemetry = append([]readFileRecord(nil), candidate.telemetry.ReadFiles...)
+	tab.usageTelemetry = cloneSessionUsageStats(candidate.telemetry.Usage)
+	tab.telemetrySessionKey = sessionRuntimeKey(sessionPath)
+	tab.telemMu.Unlock()
+	if tab.sink != nil {
+		tab.sink.setBinding(tab.ID, a)
+		tab.sink.setContext(a.ctx)
 	}
+	if detachSource {
+		a.newSessionRuntimeLocked(tab, transition.targetKey)
+	}
+	newEpoch := a.advanceSessionRuntimeEpochLocked(tab)
+	a.saveTabsLocked()
+	candidate.ctrl = nil
+	candidate.sink = nil
+	committed = true
+	a.mu.Unlock()
+	// Test-only observation point: the replacement is committed but the retired
+	// sink still carries its old epoch. Production has no hook and immediately
+	// fences that sink below.
+	_ = a.runRebindCandidateHook("committed")
+
+	// Teardown happens after publication and outside App.mu. The old lease is
+	// released only now, so every target failure above leaves source ownership
+	// intact. Fence the retired sink before closing the old controller so a
+	// close-time event cannot mutate or autosave the replacement runtime.
+	if !detachSource {
+		if oldSink != nil {
+			oldSink.setBinding("", nil)
+			oldSink.clearContext()
+		}
+		if oldCtrl != nil {
+			oldCtrl.Close()
+		}
+		if oldLease != nil {
+			oldLease.Release()
+		}
+	}
+	a.persistTabSessionPath(tab, sessionPath)
+	a.clearDeferredRebuild(tab.ID)
+	a.notifyTabRuntimeRebuiltAtEpoch(tab, newEpoch)
+	a.emitReady(a.ctx, tab.ID)
 	return nil
+}
+
+type sessionRebindCandidate struct {
+	app               *App
+	ctrl              control.SessionAPI
+	sink              *tabEventSink
+	model             string
+	runtime           normalizedTabRuntime
+	telemetry         tabTelemetrySnapshot
+	sharedHostKey     string
+	ownsSharedHostRef bool
+}
+
+func (c *sessionRebindCandidate) close() {
+	if c == nil {
+		return
+	}
+	if c.sink != nil {
+		c.sink.clearContext()
+	}
+	if c.ctrl != nil {
+		c.ctrl.Close()
+		c.ctrl = nil
+	}
+	if c.ownsSharedHostRef && c.app != nil && c.sharedHostKey != "" {
+		c.app.releaseSharedHost(c.sharedHostKey)
+		c.ownsSharedHostRef = false
+	}
+}
+
+func normalizedRuntimeForSessionProfile(profile tabSessionProfile) normalizedTabRuntime {
+	temp := &WorkspaceTab{}
+	applyTabSessionProfile(temp, profile)
+	return snapshotTabRuntimeLocked(temp).normalizedRuntime()
+}
+
+func (a *App) runRebindCandidateHook(stage string) error {
+	if a == nil || a.rebindCandidateHook == nil {
+		return nil
+	}
+	return a.rebindCandidateHook(stage)
+}
+
+func (a *App) buildSessionRebindCandidate(
+	tab *WorkspaceTab,
+	source tabRuntimeSnapshot,
+	sessionPath string,
+	loaded *agent.Session,
+	profile tabSessionProfile,
+	separateRuntime bool,
+) (*sessionRebindCandidate, error) {
+	root := strings.TrimSpace(source.workspaceRoot)
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
+		}
+	}
+	_ = config.MigrateLegacyCredentialsForRoot(root)
+	cfg, err := config.LoadForRoot(root)
+	if err != nil {
+		return nil, err
+	}
+
+	model := strings.TrimSpace(source.model)
+	if sessionModel, ok := agent.LoadSessionModel(sessionPath); ok {
+		config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, sessionModel)
+		if _, ok := cfg.ResolveModel(sessionModel); ok {
+			model = sessionModel
+		}
+	}
+	if model == "" {
+		model = cfg.DefaultModel
+	}
+	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, model)
+	if resolved, _, ok := cfg.ResolveModelWithFallback(model); ok {
+		model = resolved
+	}
+
+	sessionDir := controllerSessionDir(source.ctrl)
+	if strings.TrimSpace(sessionDir) == "" {
+		sessionDir = filepath.Dir(sessionPath)
+	}
+	sink := &tabEventSink{tabID: tab.ID, app: a}
+	runtimeProfile := normalizedRuntimeForSessionProfile(profile)
+	sharedHost := a.lookupSharedHost(source.sharedHostKey)
+	ownsSharedHostRef := false
+	if separateRuntime && source.sharedHostKey != "" {
+		sharedHost = a.acquireSharedHost(source.sharedHostKey)
+		ownsSharedHostRef = true
+	}
+	ctrl, err := boot.Build(a.bootContext(), boot.Options{
+		Model:                    model,
+		RequireKey:               false,
+		Sink:                     a.desktopControllerSink(sink, cfg.Notifications),
+		WorkspaceRoot:            root,
+		SessionDir:               sessionDir,
+		EffortOverride:           cloneStringPtr(source.effort),
+		TokenMode:                runtimeProfile.tokenMode,
+		SharedHost:               sharedHost,
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
+		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
+		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+	})
+	if err != nil {
+		sink.clearContext()
+		if ownsSharedHostRef {
+			a.releaseSharedHost(source.sharedHostKey)
+		}
+		return nil, err
+	}
+	candidate := &sessionRebindCandidate{
+		app: a, ctrl: ctrl, sink: sink, model: model, runtime: runtimeProfile,
+		sharedHostKey: source.sharedHostKey, ownsSharedHostRef: ownsSharedHostRef,
+	}
+	a.bindControllerDisplayRecorder(ctrl)
+	configureControllerRuntime(ctrl, nil, runtimeProfile)
+	if err := a.runRebindCandidateHook("built"); err != nil {
+		candidate.close()
+		return nil, err
+	}
+	restoredRuntime, err := resumeControllerRuntimeWithSession(ctrl, loaded, sessionPath, runtimeProfile)
+	if err != nil {
+		candidate.close()
+		return nil, err
+	}
+	candidate.runtime = restoredRuntime
+	candidate.telemetry = loadTelemetry(sessionPath + ".telemetry.json")
+	if err := a.runRebindCandidateHook("restored"); err != nil {
+		candidate.close()
+		return nil, err
+	}
+	return candidate, nil
+}
+
+func (a *App) acquireCandidateSessionLease(tab *WorkspaceTab, path string) (*agent.SessionLease, error) {
+	lease, err := agent.TryAcquireSessionLease(path)
+	if err == nil {
+		return lease, nil
+	}
+	if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
+		if reclaimed, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
+			return reclaimed, nil
+		} else {
+			err = reclaimErr
+		}
+	}
+	return nil, userFacingSessionLeaseError("", err)
 }
 
 func loadResumableSession(sessionPath string) (*agent.Session, error) {
@@ -5873,6 +6135,7 @@ func (a *App) jobsForCtrl(ctrl control.SessionAPI, out []JobView) []JobView {
 type Meta struct {
 	Label             string                   `json:"label"`
 	Ready             bool                     `json:"ready"`
+	Runtime           SessionRuntimeView       `json:"runtime"`
 	StartupErr        string                   `json:"startupErr,omitempty"`
 	EventChannel      string                   `json:"eventChannel"`
 	Cwd               string                   `json:"cwd"`
@@ -5986,6 +6249,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)
 	snap := snapshotTabRuntimeLocked(tab)
+	runtimeView := a.sessionRuntimeViewLocked(tab)
 	a.mu.RUnlock()
 	if tab == nil {
 		return Meta{EventChannel: eventChannel}
@@ -6002,7 +6266,8 @@ func (a *App) MetaForTab(tabID string) Meta {
 	goalStatus := snap.currentGoalStatus()
 	return Meta{
 		Label:             snap.label,
-		Ready:             snap.ready,
+		Ready:             runtimeView.Phase == sessionRuntimeReady && snap.ctrl != nil,
+		Runtime:           runtimeView,
 		StartupErr:        snap.startupErr,
 		EventChannel:      eventChannel,
 		Cwd:               cwd,
@@ -8805,17 +9070,24 @@ func sessionPathAfterSnapshot(ctrl control.SessionAPI, fallback string) string {
 }
 
 func (a *App) ensureTabSessionLeaseForRebuild(tab *WorkspaceTab, path, setting string) error {
+	transition, reserveErr := a.reserveSessionRuntimePath(tab, path)
+	if reserveErr != nil {
+		return userFacingSessionLeaseError(setting, reserveErr)
+	}
 	if err := tab.ensureSessionLease(path); err != nil {
 		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
 			if lease, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
 				tab.adoptSessionLease(lease)
+				a.commitSessionRuntimePath(transition)
 				return nil
 			} else {
 				err = reclaimErr
 			}
 		}
+		a.rollbackSessionRuntimePath(transition)
 		return userFacingSessionLeaseError(setting, err)
 	}
+	a.commitSessionRuntimePath(transition)
 	return nil
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -66,19 +66,22 @@ const eventChannel = "agent:event"
 const singleInstanceIDPrefix = "com.reasonix.desktop"
 
 // singleInstanceID is used by Wails to route a second desktop launch back to the
-// running instance. It is stable for a given binary path, while allowing a dev
-// build and an installed release at different paths to run side by side.
+// process that owns the same Reasonix data home. Basing the identity on the
+// executable path let installed, portable, stable, and canary binaries write the
+// same sessions concurrently. Explicit REASONIX_HOME isolation still produces
+// an independent instance; REASONIX_DEV continues to bypass the lock entirely.
 func singleInstanceID() string {
-	abs, err := os.Executable()
-	if err != nil {
+	root := strings.TrimSpace(config.ReasonixHomeDir())
+	if root == "" {
 		return singleInstanceIDPrefix
 	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		abs = resolved
-	} else if fallback, err := filepath.Abs(abs); err == nil {
-		abs = fallback
+	// Reuse the lease path canonicalizer so a missing home below a symlink or
+	// junction still hashes to the same physical data directory.
+	if marker := agent.CanonicalSessionPath(filepath.Join(root, ".reasonix-home.identity")); marker != "" {
+		root = filepath.Dir(marker)
 	}
-	sum := sha256.Sum256([]byte(abs))
+	root = filepath.Clean(root)
+	sum := sha256.Sum256([]byte(root))
 	return singleInstanceIDPrefix + "." + hex.EncodeToString(sum[:8])
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -5274,6 +5274,10 @@ func TestSetTokenModeLeaseHeldKeepsCurrentController(t *testing.T) {
 	if got := currentTabTokenMode(tab); got != "full" {
 		t.Fatalf("token mode = %q, want full", got)
 	}
+	meta := app.MetaForTab(tab.ID)
+	if !meta.Ready || meta.Runtime.Phase != sessionRuntimeReady {
+		t.Fatalf("failed switch disabled current runtime: ready=%v phase=%q", meta.Ready, meta.Runtime.Phase)
+	}
 }
 
 func TestSetTokenModeMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {

--- a/desktop/deferred_rebuild.go
+++ b/desktop/deferred_rebuild.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -239,6 +238,13 @@ func (a *App) retryDeferredStartupBuild(tabID string, tab *WorkspaceTab) {
 		a.clearDeferredRebuild(tabID)
 		return
 	}
+	a.mu.RLock()
+	path := strings.TrimSpace(tab.SessionPath)
+	a.mu.RUnlock()
+	if path != "" && a.attachExistingSessionRuntime(tab, path, a.ctx) {
+		a.clearDeferredRebuild(tabID)
+		return
+	}
 	if !a.deferredRebuildLeaseLooksFree(tab) {
 		return
 	}
@@ -289,6 +295,7 @@ func (a *App) rebuildStartupTabLocked(tab *WorkspaceTab) error {
 	tab.buildCancel = cancel
 	tab.Ready = false
 	clearTabStartupError(tab)
+	a.setSessionRuntimePhaseLocked(tab, sessionRuntimeStarting, nil)
 	tab.ActivityStatus = ""
 	if tab.sink == nil {
 		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
@@ -366,16 +373,25 @@ func (a *App) deferredRebuildLeaseLooksFree(tab *WorkspaceTab) bool {
 	if path == "" {
 		return true // nothing to probe; let the rebuild decide
 	}
-	lease, err := agent.TryAcquireSessionLease(sessionRuntimeKey(path))
+	key := sessionRuntimeKey(path)
+	a.mu.RLock()
+	rt := a.runtimeBySessionKey[key]
+	ownedByTab := rt != nil && rt.Owner == tab
+	ownedByOther := rt != nil && rt.Owner != nil && rt.Owner != tab && a.runtimeOwnerLiveLocked(rt)
+	a.mu.RUnlock()
+	if ownedByOther {
+		return false
+	}
+	if ownedByTab && tab.sessionLeaseRuntimeKey() == key {
+		return true
+	}
+	lease, err := agent.TryAcquireSessionLease(key)
 	if err != nil {
-		var leaseErr *agent.SessionLeaseError
-		if errors.As(err, &leaseErr) && leaseErr.Info != nil && leaseErr.Info.PID == os.Getpid() {
-			if host, _ := os.Hostname(); leaseErr.Info.Hostname == host {
-				// This process (usually this very tab) holds the probed path;
-				// the blocking lease is some other path. Attempt the rebuild
-				// and let its own lease checks decide.
-				return true
-			}
+		if sameCurrentProcessLease(err) {
+			// The registry ruled out a live sibling owner above, so this is an
+			// orphaned current-process lease. Let the rebuild helper reclaim it
+			// under runtimeRebuildMu instead of looping against our own marker.
+			return true
 		}
 		return !errors.Is(err, agent.ErrSessionLeaseHeld)
 	}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1626,7 +1626,12 @@ export default function App() {
   const toolApprovalMode = composerProfile.toolApprovalMode;
   const tokenMode: TokenMode = composerProfile.tokenMode;
   const runtimeTransitioning = Boolean(activeTabId && runtimeTransitionsByTab[activeTabId]) || workbenchTargetTransitioning(workbenchTarget);
-  const controllerReady = state.meta?.ready === true && !state.backendActivationPending && !runtimeTransitioning;
+  const controllerReady =
+    state.meta?.ready === true &&
+    (!state.meta.runtime || state.meta.runtime.phase === "ready") &&
+    !state.meta.startupErr &&
+    !state.backendActivationPending &&
+    !runtimeTransitioning;
   // Single footer decision surface. Composer stays mounted underneath and is
   // only visually/a11y-hidden so per-session draft caches survive.
   const decisionSurface = useMemo((): DecisionSurfaceKind | null => {
@@ -2893,7 +2898,13 @@ export default function App() {
     const sourceTab = tabMetas.find((tab) => tab.id === sourceTabId);
     if (!sourceTab) throw new Error(t("composer.workspaceStarting"));
     if (sourceTab.readOnly) throw new Error(t("composer.readOnlyChannel"));
-    if (sourceTab.ready === false) throw new Error(t("composer.workspaceStarting"));
+    if (
+      sourceTab.ready !== true ||
+      (sourceTab.runtime && sourceTab.runtime.phase !== "ready") ||
+      sourceTab.startupErr
+    ) {
+      throw new Error(sourceTab.runtime?.issue?.message || sourceTab.startupErr || t("composer.workspaceStarting"));
+    }
     const rs = rewindStatesByTabRef.current[sourceTabId];
     if (rs) {
       setRewindStateForTab(sourceTabId, null);

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -245,7 +245,7 @@ ok(
 );
 
 ok(
-  /const controllerReady = state\.meta\?\.ready === true && !state\.backendActivationPending && !runtimeTransitioning;/.test(appSource) &&
+  /const controllerReady =\s*state\.meta\?\.ready === true &&\s*\(!state\.meta\.runtime \|\| state\.meta\.runtime\.phase === "ready"\) &&\s*!state\.meta\.startupErr &&\s*!state\.backendActivationPending &&\s*!runtimeTransitioning;/.test(appSource) &&
     /if \(!activeTabId \|\| !controllerReady\) return;\s*void commitThenSend\(activeTabId, text\)\.catch/.test(appSource) &&
     /onPrompt=\{handleTranscriptPrompt\}/.test(appSource) &&
     /submitDisabled=\{!controllerReady\}/.test(appSource),

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { initialState, reducer, replayPendingPromptsForActiveTab } from "../lib/useController";
+import { acceptsRuntimeEventEpoch, initialState, reducer, replayPendingPromptsForActiveTab, runtimeReadyForSubmit } from "../lib/useController";
 import { continueDelivery } from "../lib/deliveryContinue";
 import type { WireEvent } from "../lib/types";
 
@@ -21,6 +21,15 @@ function eq(a: unknown, b: unknown, label: string) {
 }
 
 console.log("\nsend failure feedback");
+
+eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", runtime: { phase: "starting", epoch: "e1" } }), false, "starting runtime cannot submit");
+eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", runtime: { phase: "lease_blocked", epoch: "e1" } }), false, "lease-blocked runtime cannot submit");
+eq(runtimeReadyForSubmit({ label: "", ready: false, eventChannel: "", cwd: "", runtime: { phase: "failed", epoch: "e1" } }), false, "failed runtime cannot submit");
+eq(runtimeReadyForSubmit({ label: "", ready: true, eventChannel: "", cwd: "", runtime: { phase: "ready", epoch: "e1" } }), true, "ready runtime can submit");
+eq(acceptsRuntimeEventEpoch("e2", "e1"), false, "old runtime epoch is rejected");
+eq(acceptsRuntimeEventEpoch("e2", "e2"), true, "current runtime epoch is accepted");
+eq(acceptsRuntimeEventEpoch(undefined, "e1"), true, "first runtime epoch can establish the fence");
+eq(acceptsRuntimeEventEpoch("e2", undefined), true, "legacy events remain compatible");
 
 const sent = reducer({ ...initialState }, { type: "user", text: "hello", seq: 0 });
 eq(sent.items.length, 1, "submit appends the user bubble immediately");
@@ -177,7 +186,7 @@ eq(
   "failed runtime profile transitions roll back the optimistic token mode",
 );
 eq(
-  appSource.includes("!state.backendActivationPending && !runtimeTransitioning"),
+  appSource.includes("!state.backendActivationPending &&") && appSource.includes("!runtimeTransitioning"),
   true,
   "runtime profile transitions keep submit behind the controller-ready gate",
 );

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -698,9 +698,14 @@ export function onFilesDropped(cb: (paths: string[]) => void): () => void {
 // onRuntimeRebuilt fires when a tab's controller is replaced in place
 // (model/effort/token-mode switch, clear-while-running). The rebuilt
 // controller restarts prompt ids, so per-tab id-keyed state must reset.
-export function onRuntimeRebuilt(cb: (tabId?: string) => void): () => void {
+export function onRuntimeRebuilt(cb: (tabId?: string, runtimeEpoch?: string) => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
-    return window.runtime.EventsOn("runtime:rebuilt", (tabId?: unknown) => cb(typeof tabId === "string" ? tabId : undefined));
+    return window.runtime.EventsOn("runtime:rebuilt", (tabId?: unknown, runtimeEpoch?: unknown) =>
+      cb(
+        typeof tabId === "string" ? tabId : undefined,
+        typeof runtimeEpoch === "string" ? runtimeEpoch : undefined,
+      )
+    );
   }
   return () => {};
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -182,12 +182,30 @@ export interface WireEvent {
   // Tab routing: set by the Go-side tabEventSink so multi-tab frontends
   // route each event to the correct per-tab reducer.
   tabId?: string;
+  runtimeEpoch?: string;
   sessionHitTokens?: number;
   sessionMissTokens?: number;
   sessionCost?: number;
   sessionCurrency?: string;
   // Deprecated compatibility alias. Prefer sessionCost + sessionCurrency.
   sessionCostUsd?: number;
+}
+
+export type SessionRuntimePhase = "starting" | "ready" | "lease_blocked" | "failed" | "closing";
+
+export interface SessionRuntimeIssue {
+  code: "session_lease_held" | "startup_failed";
+  message: string;
+  retryable: boolean;
+  holderPid?: number;
+  holderHost?: string;
+  acquiredAt?: string;
+}
+
+export interface SessionRuntimeView {
+  phase: SessionRuntimePhase;
+  epoch: string;
+  issue?: SessionRuntimeIssue;
 }
 
 export interface WireFinalReadiness {
@@ -213,6 +231,7 @@ export interface TabMeta {
   projectColor?: string;
   label: string;
   ready: boolean;
+  runtime?: SessionRuntimeView;
   running: boolean;
   pendingPrompt?: boolean;
   backgroundJobs?: number;
@@ -489,6 +508,7 @@ export interface ContextInfo {
 export interface Meta {
   label: string;
   ready: boolean;
+  runtime?: SessionRuntimeView;
   startupErr?: string;
   eventChannel: string;
   cwd: string;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -291,6 +291,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
   return {
     label: tab.label || existing?.label || "",
     ready: tab.ready,
+    runtime: tab.runtime,
     startupErr: tab.startupErr,
     eventChannel: existing?.eventChannel ?? "agent:event",
     cwd,
@@ -321,6 +322,14 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
   return (
     a.label === b.label &&
     a.ready === b.ready &&
+    a.runtime?.phase === b.runtime?.phase &&
+    a.runtime?.epoch === b.runtime?.epoch &&
+    a.runtime?.issue?.code === b.runtime?.issue?.code &&
+    a.runtime?.issue?.message === b.runtime?.issue?.message &&
+    a.runtime?.issue?.retryable === b.runtime?.issue?.retryable &&
+    a.runtime?.issue?.holderPid === b.runtime?.issue?.holderPid &&
+    a.runtime?.issue?.holderHost === b.runtime?.issue?.holderHost &&
+    a.runtime?.issue?.acquiredAt === b.runtime?.issue?.acquiredAt &&
     a.startupErr === b.startupErr &&
     a.eventChannel === b.eventChannel &&
     a.cwd === b.cwd &&
@@ -340,6 +349,15 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
     a.goalStatus === b.goalStatus &&
     sameTodoList(a.canonicalTodos, b.canonicalTodos)
   );
+}
+
+export function runtimeReadyForSubmit(meta?: Meta): boolean {
+  if (!meta || meta.ready !== true || meta.startupErr) return false;
+  return !meta.runtime || meta.runtime.phase === "ready";
+}
+
+export function acceptsRuntimeEventEpoch(acceptedEpoch: string | undefined, eventEpoch: string | undefined): boolean {
+  return !eventEpoch || !acceptedEpoch || acceptedEpoch === eventEpoch;
 }
 
 function metaWithoutCanonicalTodos(meta?: Meta): Meta | undefined {
@@ -1723,6 +1741,7 @@ export function useController() {
   const modelSwitchSuccessVersionByTab = useRef(new Map<string, number>());
   const modelSwitchQueueByTab = useRef(new Map<string, ModelSwitchQueueState>());
   const lastTurnActivityAtByTab = useRef(new Map<string, number>());
+  const runtimeEpochByTabRef = useRef(new Map<string, string>());
   const cancelReconcileTimers = useRef(new Map<string, number>());
   const stalePromptReconcileTimers = useRef(new Map<string, number>());
   // Indirection so dispatchRuntimeStatusForTab (defined above reconcileTabRuntime)
@@ -1850,6 +1869,7 @@ export function useController() {
     const seq = bumpMetaRefreshSeq(tabId);
     const meta = await app.MetaForTab(tabId).catch(() => undefined);
     if (!metaRefreshCurrent(tabId, seq)) return undefined;
+    if (meta?.runtime?.epoch) runtimeEpochByTabRef.current.set(tabId, meta.runtime.epoch);
     return meta;
   }, [bumpMetaRefreshSeq, metaRefreshCurrent]);
   const refreshMetaOnlyForTab = useCallback(async (tabId: string): Promise<Meta | undefined> => {
@@ -2114,6 +2134,7 @@ export function useController() {
     setActiveTabId(active.id);
     activeTabIdRef.current = active.id;
     confirmBackendActiveTab(active.id);
+    if (active.runtime?.epoch) runtimeEpochByTabRef.current.set(active.id, active.runtime.epoch);
     dispatchTo(active.id, { type: "optimistic_meta", meta: metaFromTab(active, statesRef.current.get(active.id)?.meta) });
     const preserveCachedHistory = options.preserveCachedHistory ?? !reset;
     if (!reset) dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
@@ -2134,6 +2155,7 @@ export function useController() {
     const tabs = asArray(await app.ListTabs().catch(() => [] as TabMeta[]));
     const tab = tabs.find((candidate) => candidate.id === tabId);
     if (!tab) return undefined;
+    if (tab.runtime?.epoch) runtimeEpochByTabRef.current.set(tabId, tab.runtime.epoch);
     const local = statesRef.current.get(tabId);
     const needsInitialLoad = !local?.meta;
     const foregroundRunning = dispatchRuntimeStatusForTab(tabId, tab, snapshotAt);
@@ -2203,6 +2225,11 @@ export function useController() {
       // leaks the previous session's approval/ask gate into the new composer.
       const targetTabId = e.tabId || backendActiveTabIdRef.current || activeTabIdRef.current;
       if (!targetTabId) return;
+      const acceptedEpoch = runtimeEpochByTabRef.current.get(targetTabId);
+      if (e.runtimeEpoch) {
+        if (!acceptsRuntimeEventEpoch(acceptedEpoch, e.runtimeEpoch)) return;
+        if (!acceptedEpoch) runtimeEpochByTabRef.current.set(targetTabId, e.runtimeEpoch);
+      }
       if (
         e.kind === "turn_started" ||
         e.kind === "text" ||
@@ -2256,10 +2283,14 @@ export function useController() {
     // prompt from the new controller is never misread as a stale replay of
     // one the old controller already resolved (#6432 round 3). A tab-less
     // rebuild (settings-wide) affects every known tab.
-    const offRebuilt = onRuntimeRebuilt((rebuiltTabId) => {
+    const offRebuilt = onRuntimeRebuilt((rebuiltTabId, runtimeEpoch) => {
       if (rebuiltTabId) {
+        if (runtimeEpoch) runtimeEpochByTabRef.current.set(rebuiltTabId, runtimeEpoch);
         dispatchTo(rebuiltTabId, { type: "controller_rebuilt" });
       } else {
+        if (runtimeEpoch) {
+          for (const id of Array.from(statesRef.current.keys())) runtimeEpochByTabRef.current.set(id, runtimeEpoch);
+        }
         for (const id of Array.from(statesRef.current.keys())) dispatchTo(id, { type: "controller_rebuilt" });
       }
     });
@@ -2389,7 +2420,12 @@ export function useController() {
 
   const sendToTab = useCallback(async (tabId: string, displayText: string, submitText = displayText, originalText?: string, structured?: import("./invocationDisplay").StructuredInvocationSubmit) => {
     if (!tabId) throw new Error(t("composer.workspaceStarting"));
-    const seq = getOrCreateState(statesRef.current, tabId).seq;
+    const currentState = getOrCreateState(statesRef.current, tabId);
+    const runtime = currentState.meta?.runtime;
+    if (currentState.meta && !runtimeReadyForSubmit(currentState.meta)) {
+      throw new Error(runtime?.issue?.message || currentState.meta.startupErr || t("composer.workspaceStarting"));
+    }
+    const seq = currentState.seq;
     const display = displayText.trim();
     const submit = submitText.trim();
     const original = originalText?.trim() ?? "";
@@ -2412,7 +2448,12 @@ export function useController() {
 
   const recoverDeliveryToTab = useCallback(async (tabId: string, displayText: string, submitText = displayText) => {
     if (!tabId) throw new Error(t("composer.workspaceStarting"));
-    const seq = getOrCreateState(statesRef.current, tabId).seq;
+    const currentState = getOrCreateState(statesRef.current, tabId);
+    const runtime = currentState.meta?.runtime;
+    if (currentState.meta && !runtimeReadyForSubmit(currentState.meta)) {
+      throw new Error(runtime?.issue?.message || currentState.meta.startupErr || t("composer.workspaceStarting"));
+    }
+    const seq = currentState.seq;
     const display = displayText.trim();
     const submit = submitText.trim();
     dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq, deliveryRecovery: true });

--- a/desktop/goal_delivery_yolo_test.go
+++ b/desktop/goal_delivery_yolo_test.go
@@ -93,6 +93,10 @@ func newGoalDeliveryYoloTestApp(t *testing.T, goalStatus string) (*App, *Workspa
 	if err := tab.ensureSessionLease(path); err != nil {
 		t.Fatalf("ensure session lease: %v", err)
 	}
+	app.mu.Lock()
+	app.newSessionRuntimeLocked(tab, sessionRuntimeKey(path))
+	app.advanceSessionRuntimeEpochLocked(tab)
+	app.mu.Unlock()
 	t.Cleanup(func() {
 		if ctrl := app.controllerForTab(tab); ctrl != nil {
 			ctrl.Close()
@@ -119,6 +123,13 @@ func TestGoalDeliveryYoloTokenSwitchPreservesBlockedGoalCheckpoint(t *testing.T)
 	}
 	if currentTabTokenMode(tab) != boot.TokenModeDelivery {
 		t.Fatalf("token mode = %q, want delivery", currentTabTokenMode(tab))
+	}
+	app.mu.RLock()
+	runtimeForPath := app.runtimeBySessionKey[sessionRuntimeKey(path)]
+	runtimeCount := len(app.runtimeBySessionKey)
+	app.mu.RUnlock()
+	if runtimeForPath == nil || runtimeForPath.Owner != tab || runtimeCount != 1 {
+		t.Fatalf("runtime registry after Goal+Delivery switch = owner %p count %d, want tab %p count 1", runtimeForPath, runtimeCount, tab)
 	}
 	var persisted struct {
 		DeliveryCheckpoint evidence.DeliveryCheckpoint `json:"deliveryCheckpoint"`
@@ -371,6 +382,82 @@ func TestPlanYoloDeliveryOrderConverges(t *testing.T) {
 				t.Fatalf("final axes plan=%v approval=%q token=%q", ctrl.PlanMode(), ctrl.ToolApprovalMode(), currentTabTokenMode(tab))
 			}
 		})
+	}
+}
+
+func TestEveryCollaborationAndTokenModeCombinationConvergesInBothOrders(t *testing.T) {
+	collaborationModes := []string{"normal", "plan", "goal"}
+	tokenModes := []string{boot.TokenModeEconomy, boot.TokenModeFull, boot.TokenModeDelivery}
+	orders := []string{"collaboration-first", "token-first"}
+
+	for _, collaborationMode := range collaborationModes {
+		for _, tokenMode := range tokenModes {
+			for _, order := range orders {
+				t.Run(collaborationMode+"/"+tokenMode+"/"+order, func(t *testing.T) {
+					app, tab, _, path := newGoalDeliveryYoloTestApp(t, control.GoalStatusRunning)
+					app.SetToolApprovalModeForTab(tab.ID, control.ToolApprovalAsk)
+
+					setCollaboration := func() {
+						switch collaborationMode {
+						case "goal":
+							app.SetGoalForTab(tab.ID, "exercise all runtime axes")
+							app.SetCollaborationModeForTab(tab.ID, "goal")
+						case "plan":
+							app.SetCollaborationModeForTab(tab.ID, "plan")
+						default:
+							app.SetGoalForTab(tab.ID, "")
+							app.SetCollaborationModeForTab(tab.ID, "normal")
+						}
+					}
+					setToken := func() {
+						if err := app.SetTokenModeForTab(tab.ID, tokenMode); err != nil {
+							t.Fatalf("SetTokenModeForTab(%q): %v", tokenMode, err)
+						}
+					}
+					if order == "collaboration-first" {
+						setCollaboration()
+						setToken()
+					} else {
+						setToken()
+						setCollaboration()
+					}
+
+					ctrl := app.controllerForTab(tab)
+					if ctrl == nil {
+						t.Fatal("final controller is nil")
+					}
+					if got := currentTabTokenMode(tab); got != tokenMode {
+						t.Fatalf("token mode = %q, want %q", got, tokenMode)
+					}
+					switch collaborationMode {
+					case "goal":
+						if ctrl.PlanMode() || ctrl.GoalStatus() != control.GoalStatusRunning ||
+							ctrl.Goal() != "exercise all runtime axes" {
+							t.Fatalf("Goal axes plan=%v goal=%q status=%q", ctrl.PlanMode(), ctrl.Goal(), ctrl.GoalStatus())
+						}
+					case "plan":
+						if !ctrl.PlanMode() || ctrl.GoalStatus() == control.GoalStatusRunning {
+							t.Fatalf("Plan axes plan=%v goal=%q status=%q", ctrl.PlanMode(), ctrl.Goal(), ctrl.GoalStatus())
+						}
+					default:
+						if ctrl.PlanMode() || ctrl.GoalStatus() == control.GoalStatusRunning {
+							t.Fatalf("Normal axes plan=%v goal=%q status=%q", ctrl.PlanMode(), ctrl.Goal(), ctrl.GoalStatus())
+						}
+					}
+					app.mu.RLock()
+					runtimeForPath := app.runtimeBySessionKey[sessionRuntimeKey(path)]
+					runtimeCount := len(app.runtimeBySessionKey)
+					view := app.sessionRuntimeViewLocked(tab)
+					app.mu.RUnlock()
+					if runtimeForPath == nil || runtimeForPath.Owner != tab || runtimeCount != 1 {
+						t.Fatalf("runtime registry owner=%#v count=%d, want one runtime for tab", runtimeForPath, runtimeCount)
+					}
+					if view.Phase != sessionRuntimeReady || tab.sessionLeaseRuntimeKey() != sessionRuntimeKey(path) {
+						t.Fatalf("runtime phase=%q lease=%q, want ready/%q", view.Phase, tab.sessionLeaseRuntimeKey(), sessionRuntimeKey(path))
+					}
+				})
+			}
+		}
 	}
 }
 

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -195,6 +195,7 @@ func TestHeartbeatExecuteTaskPersistsFreshConversationTopicID(t *testing.T) {
 					tabToInject.Ctrl = ctrl
 					tabToInject.Ready = true
 					tabToInject.StartupErr = ""
+					app.advanceSessionRuntimeEpochLocked(tabToInject)
 					app.mu.Unlock()
 					close(injected)
 					return
@@ -275,6 +276,7 @@ func TestHeartbeatExecuteTaskSkipsPendingPrompt(t *testing.T) {
 					tabToInject.Ctrl = ctrl
 					tabToInject.Ready = true
 					tabToInject.StartupErr = ""
+					app.advanceSessionRuntimeEpochLocked(tabToInject)
 					app.mu.Unlock()
 					close(injected)
 					return

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1179,6 +1180,163 @@ func TestRebindTabToLoadedSessionPersistsAndRestoresSessionProfile(t *testing.T)
 	if got := currentTabToolApprovalMode(tab); got != control.ToolApprovalYolo {
 		t.Fatalf("rebound tool approval = %q, want yolo", got)
 	}
+}
+
+func newAtomicRebindTestApp(t *testing.T) (*App, *WorkspaceTab, control.SessionAPI, string, string, *agent.Session) {
+	t.Helper()
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sourcePath := filepath.Join(dir, "atomic-source.jsonl")
+	targetPath := filepath.Join(dir, "atomic-target.jsonl")
+	writeHistoryTestSession(t, sourcePath, "source prompt")
+	writeHistoryTestSession(t, targetPath, "target prompt")
+	if err := agent.SaveBranchMetaPreserveUpdated(targetPath, agent.BranchMeta{
+		TokenMode:        boot.TokenModeDelivery,
+		Mode:             "normal",
+		ToolApprovalMode: control.ToolApprovalAsk,
+	}); err != nil {
+		t.Fatalf("save target profile: %v", err)
+	}
+	loaded, err := agent.LoadSession(targetPath)
+	if err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+	sourceSession, err := agent.LoadSession(sourcePath)
+	if err != nil {
+		t.Fatalf("load source: %v", err)
+	}
+	exec := agent.New(nil, nil, sourceSession, agent.Options{}, event.Discard)
+	oldCtrl := control.New(control.Options{
+		Executor: exec, SessionDir: dir, SessionPath: sourcePath, Label: "source", Sink: event.Discard,
+	})
+	oldCtrl.Resume(sourceSession, sourcePath)
+	oldCtrl.SetPlanMode(true)
+	oldCtrl.SetToolApprovalMode(control.ToolApprovalYolo)
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := &WorkspaceTab{
+		ID:               "atomic-rebind",
+		Scope:            "global",
+		WorkspaceRoot:    root,
+		SessionPath:      sourcePath,
+		Ctrl:             oldCtrl,
+		Ready:            true,
+		model:            "",
+		tokenMode:        boot.TokenModeEconomy,
+		mode:             "plan-yolo",
+		toolApprovalMode: control.ToolApprovalYolo,
+		sink:             &tabEventSink{tabID: "atomic-rebind", app: app, ctx: app.ctx},
+		disabledMCP:      map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	if err := tab.ensureSessionLease(sourcePath); err != nil {
+		t.Fatalf("lease source: %v", err)
+	}
+	app.mu.Lock()
+	app.newSessionRuntimeLocked(tab, sessionRuntimeKey(sourcePath))
+	app.advanceSessionRuntimeEpochLocked(tab)
+	app.mu.Unlock()
+	t.Cleanup(func() {
+		if ctrl := app.controllerForTab(tab); ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+	return app, tab, oldCtrl, sourcePath, targetPath, loaded
+}
+
+func assertAtomicRebindFailurePreservedSource(
+	t *testing.T,
+	app *App,
+	tab *WorkspaceTab,
+	oldCtrl control.SessionAPI,
+	sourcePath string,
+	targetPath string,
+	oldEpoch string,
+) {
+	t.Helper()
+	if got := app.controllerForTab(tab); got != oldCtrl {
+		t.Fatalf("controller after failed rebind = %p, want source %p", got, oldCtrl)
+	}
+	if got := tab.currentSessionPath(); sessionRuntimeKey(got) != sessionRuntimeKey(sourcePath) {
+		t.Fatalf("session path after failed rebind = %q, want %q", got, sourcePath)
+	}
+	if got := tab.sessionLeaseRuntimeKey(); got != sessionRuntimeKey(sourcePath) {
+		t.Fatalf("lease after failed rebind = %q, want source key %q", got, sessionRuntimeKey(sourcePath))
+	}
+	if !oldCtrl.PlanMode() || oldCtrl.ToolApprovalMode() != control.ToolApprovalYolo ||
+		currentTabTokenMode(tab) != boot.TokenModeEconomy {
+		t.Fatalf("source profile changed after failed rebind: plan=%v approval=%q token=%q",
+			oldCtrl.PlanMode(), oldCtrl.ToolApprovalMode(), currentTabTokenMode(tab))
+	}
+	app.mu.RLock()
+	view := app.sessionRuntimeViewLocked(tab)
+	sourceRuntime := app.runtimeBySessionKey[sessionRuntimeKey(sourcePath)]
+	targetRuntime := app.runtimeBySessionKey[sessionRuntimeKey(targetPath)]
+	app.mu.RUnlock()
+	if view.Phase != sessionRuntimeReady || view.Epoch != oldEpoch {
+		t.Fatalf("runtime after failed rebind = phase %q epoch %q, want ready/%q", view.Phase, view.Epoch, oldEpoch)
+	}
+	if sourceRuntime == nil || sourceRuntime.Owner != tab || targetRuntime != nil {
+		t.Fatalf("registry after failed rebind source=%#v target=%#v", sourceRuntime, targetRuntime)
+	}
+	if meta := app.MetaForTab(tab.ID); !meta.Ready || meta.Runtime.Phase != sessionRuntimeReady {
+		t.Fatalf("failed rebind disabled source runtime: ready=%v phase=%q", meta.Ready, meta.Runtime.Phase)
+	}
+}
+
+func TestRebindTargetLeaseFailureKeepsSourceRuntimeAtomic(t *testing.T) {
+	app, tab, oldCtrl, sourcePath, targetPath, loaded := newAtomicRebindTestApp(t)
+	app.mu.RLock()
+	oldEpoch := app.sessionRuntimeViewLocked(tab).Epoch
+	app.mu.RUnlock()
+
+	holder, err := agent.TryAcquireSessionLease(targetPath)
+	if err != nil {
+		t.Fatalf("hold target lease: %v", err)
+	}
+	defer holder.Release()
+
+	err = app.rebindTabToLoadedSessionPath(tab, targetPath, loaded)
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("rebind error = %v, want ErrSessionLeaseHeld", err)
+	}
+	assertAtomicRebindFailurePreservedSource(t, app, tab, oldCtrl, sourcePath, targetPath, oldEpoch)
+	if _, err := agent.TryAcquireSessionLease(sourcePath); !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("source lease became acquirable after failed target claim: %v", err)
+	}
+}
+
+func TestRebindPostLeaseValidationFailureRollsBackCandidate(t *testing.T) {
+	app, tab, oldCtrl, sourcePath, targetPath, loaded := newAtomicRebindTestApp(t)
+	app.mu.RLock()
+	oldEpoch := app.sessionRuntimeViewLocked(tab).Epoch
+	app.mu.RUnlock()
+	app.rebindCandidateHook = func(stage string) error {
+		if stage == "lease_acquired" {
+			return errors.New("injected post-lease validation failure")
+		}
+		return nil
+	}
+
+	err := app.rebindTabToLoadedSessionPath(tab, targetPath, loaded)
+	if err == nil || !strings.Contains(err.Error(), "injected post-lease") {
+		t.Fatalf("rebind error = %v, want injected validation failure", err)
+	}
+	assertAtomicRebindFailurePreservedSource(t, app, tab, oldCtrl, sourcePath, targetPath, oldEpoch)
+	targetLease, err := agent.TryAcquireSessionLease(targetPath)
+	if err != nil {
+		t.Fatalf("candidate target lease leaked after rollback: %v", err)
+	}
+	targetLease.Release()
 }
 
 func TestCloseTabPersistsSessionProfileBeforeRemovingVisibleTab(t *testing.T) {

--- a/desktop/race_regression_test.go
+++ b/desktop/race_regression_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 )
@@ -154,6 +156,118 @@ func TestTabEventSinkEmitConcurrentRebind(t *testing.T) {
 	wg.Wait()
 	if tabID, _ := sink.binding(); tabID == "" {
 		t.Fatal("sink lost its tab binding")
+	}
+}
+
+func TestModeRebuildAndABANavigationFenceLeaseFailureAndOldEpochEvent(t *testing.T) {
+	app, tab, oldCtrl, pathA, pathB, loadedB := newAtomicRebindTestApp(t)
+	oldSink := tab.sink
+	app.mu.RLock()
+	epochA := app.sessionRuntimeViewLocked(tab).Epoch
+	app.mu.RUnlock()
+
+	restored := make(chan struct{})
+	continueCommit := make(chan struct{})
+	oldEvent := make(chan wireEventTab, 1)
+	var capturedOldEvent wireEventTab
+	oldSink.runtimeEvents.emit = func(_ context.Context, name string, payload ...interface{}) {
+		if name != eventChannel || len(payload) != 1 {
+			return
+		}
+		if wire, ok := payload[0].(wireEventTab); ok && wire.Text == "retired runtime event" {
+			oldEvent <- wire
+		}
+	}
+	var blockOnce sync.Once
+	app.rebindCandidateHook = func(stage string) error {
+		switch stage {
+		case "restored":
+			blockOnce.Do(func() {
+				close(restored)
+				<-continueCommit
+			})
+		case "committed":
+			oldSink.Emit(event.Event{Kind: event.Notice, Text: "retired runtime event"})
+			select {
+			case capturedOldEvent = <-oldEvent:
+			case <-time.After(5 * time.Second):
+				return errors.New("retired runtime event was not emitted")
+			}
+		}
+		return nil
+	}
+
+	rebindDone := make(chan error, 1)
+	go func() {
+		rebindDone <- app.rebindTabToLoadedSessionPath(tab, pathB, loadedB)
+	}()
+	select {
+	case <-restored:
+	case <-time.After(10 * time.Second):
+		t.Fatal("A to B rebind did not reach restored candidate")
+	}
+
+	// This call observes A/economy, then waits behind the rebind transaction.
+	// Once B commits it must rebuild B to full, never interleave with the
+	// candidate or publish a half-updated profile.
+	modeDone := make(chan error, 1)
+	go func() {
+		modeDone <- app.SetTokenModeForTab(tab.ID, boot.TokenModeFull)
+	}()
+	close(continueCommit)
+	if err := <-rebindDone; err != nil {
+		t.Fatalf("A to B rebind: %v", err)
+	}
+	if err := <-modeDone; err != nil {
+		t.Fatalf("mode rebuild after A to B: %v", err)
+	}
+
+	stale := capturedOldEvent
+	app.mu.RLock()
+	epochB := app.sessionRuntimeViewLocked(tab).Epoch
+	app.mu.RUnlock()
+	if stale.RuntimeEpoch != epochA || epochB == "" || epochB == epochA {
+		t.Fatalf("epoch fence stale=%q source=%q target=%q", stale.RuntimeEpoch, epochA, epochB)
+	}
+	if app.controllerForTab(tab) == oldCtrl ||
+		sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(pathB) ||
+		currentTabTokenMode(tab) != boot.TokenModeFull {
+		t.Fatalf("A to B plus mode rebuild did not converge: ctrl=%p path=%q token=%q",
+			app.controllerForTab(tab), tab.currentSessionPath(), currentTabTokenMode(tab))
+	}
+
+	// A is now free. Hold it as an external target, then attempt B to A. The
+	// failed return leg must keep the rebuilt B controller, lease, path, epoch,
+	// and full token profile unchanged.
+	app.rebindCandidateHook = nil
+	holderA, err := agent.TryAcquireSessionLease(pathA)
+	if err != nil {
+		t.Fatalf("hold A before return navigation: %v", err)
+	}
+	defer holderA.Release()
+	loadedA, err := agent.LoadSession(pathA)
+	if err != nil {
+		t.Fatalf("load A: %v", err)
+	}
+	ctrlB := app.controllerForTab(tab)
+	err = app.rebindTabToLoadedSessionPath(tab, pathA, loadedA)
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		t.Fatalf("B to A error = %v, want ErrSessionLeaseHeld", err)
+	}
+	if app.controllerForTab(tab) != ctrlB ||
+		sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(pathB) ||
+		tab.sessionLeaseRuntimeKey() != sessionRuntimeKey(pathB) ||
+		currentTabTokenMode(tab) != boot.TokenModeFull {
+		t.Fatalf("failed B to A changed B runtime: ctrl=%p path=%q lease=%q token=%q",
+			app.controllerForTab(tab), tab.currentSessionPath(), tab.sessionLeaseRuntimeKey(), currentTabTokenMode(tab))
+	}
+	app.mu.RLock()
+	finalView := app.sessionRuntimeViewLocked(tab)
+	targetAlias := app.runtimeBySessionKey[sessionRuntimeKey(pathA)]
+	app.mu.RUnlock()
+	if finalView.Phase != sessionRuntimeReady || finalView.Epoch != epochB || targetAlias != nil {
+		t.Fatalf("failed B to A runtime = phase %q epoch %q aliasA=%#v, want ready/%q/no alias",
+			finalView.Phase, finalView.Epoch, targetAlias, epochB)
 	}
 }
 

--- a/desktop/session_runtime.go
+++ b/desktop/session_runtime.go
@@ -1,0 +1,457 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+type SessionRuntimePhase string
+
+const (
+	sessionRuntimeStarting     SessionRuntimePhase = "starting"
+	sessionRuntimeReady        SessionRuntimePhase = "ready"
+	sessionRuntimeLeaseBlocked SessionRuntimePhase = "lease_blocked"
+	sessionRuntimeFailed       SessionRuntimePhase = "failed"
+	sessionRuntimeClosing      SessionRuntimePhase = "closing"
+)
+
+type SessionRuntimeIssue struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Retryable  bool   `json:"retryable"`
+	HolderPID  int    `json:"holderPid,omitempty"`
+	HolderHost string `json:"holderHost,omitempty"`
+	AcquiredAt string `json:"acquiredAt,omitempty"`
+}
+
+type SessionRuntimeView struct {
+	Phase SessionRuntimePhase  `json:"phase"`
+	Epoch string               `json:"epoch"`
+	Issue *SessionRuntimeIssue `json:"issue,omitempty"`
+}
+
+// desktopSessionRuntime is the process-local ownership record for one writable
+// session. WorkspaceTab still carries compatibility projections of controller
+// and lease fields while the desktop code migrates, but this registry is the
+// authority that prevents a second local build from competing for the same
+// session path.
+//
+// All fields are guarded by App.mu.
+type desktopSessionRuntime struct {
+	ID      string
+	Key     string
+	Epoch   string
+	Phase   SessionRuntimePhase
+	Issue   *SessionRuntimeIssue
+	Owner   *WorkspaceTab
+	readyCh chan struct{}
+}
+
+func newSessionRuntimeID(prefix string) string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return prefix + "_" + hex.EncodeToString(b[:])
+	}
+	return prefix + "_" + time.Now().UTC().Format("20060102150405.000000000")
+}
+
+func cloneSessionRuntimeIssue(issue *SessionRuntimeIssue) *SessionRuntimeIssue {
+	if issue == nil {
+		return nil
+	}
+	copy := *issue
+	return &copy
+}
+
+func sessionRuntimeIssueForError(err error) *SessionRuntimeIssue {
+	if err == nil {
+		return nil
+	}
+	issue := &SessionRuntimeIssue{
+		Code:      "startup_failed",
+		Message:   userFacingSessionLeaseError("", err).Error(),
+		Retryable: false,
+	}
+	if !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		return issue
+	}
+	issue.Code = "session_lease_held"
+	issue.Retryable = true
+	var leaseErr *agent.SessionLeaseError
+	if errors.As(err, &leaseErr) && leaseErr != nil && leaseErr.Info != nil {
+		issue.HolderPID = leaseErr.Info.PID
+		issue.HolderHost = strings.TrimSpace(leaseErr.Info.Hostname)
+		if !leaseErr.Info.AcquiredAt.IsZero() {
+			issue.AcquiredAt = leaseErr.Info.AcquiredAt.UTC().Format(time.RFC3339)
+		}
+	}
+	return issue
+}
+
+func (a *App) newSessionRuntimeLocked(tab *WorkspaceTab, key string) *desktopSessionRuntime {
+	if existing := a.runtimeBySessionKey[key]; key != "" && existing != nil && existing.Owner != tab {
+		// A second tab may begin restoring the same persisted path before it
+		// reaches claimSessionRuntime. Do not overwrite the first starting
+		// placeholder; the later build will wait for and attach to it.
+		key = ""
+	}
+	rt := &desktopSessionRuntime{
+		ID:      newSessionRuntimeID("runtime"),
+		Key:     key,
+		Epoch:   newSessionRuntimeID("epoch"),
+		Phase:   sessionRuntimeStarting,
+		Owner:   tab,
+		readyCh: make(chan struct{}),
+	}
+	if tab != nil && tab.Ctrl != nil && tab.Ready {
+		rt.Phase = sessionRuntimeReady
+		closeRuntimeReadyChannelLocked(rt)
+	}
+	if a.runtimeByID == nil {
+		a.runtimeByID = map[string]*desktopSessionRuntime{}
+	}
+	if a.runtimeBySessionKey == nil {
+		a.runtimeBySessionKey = map[string]*desktopSessionRuntime{}
+	}
+	a.runtimeByID[rt.ID] = rt
+	if key != "" {
+		a.runtimeBySessionKey[key] = rt
+	}
+	if tab != nil {
+		tab.runtimeID = rt.ID
+		if tab.sink != nil {
+			tab.sink.setRuntimeEpoch(rt.Epoch)
+		}
+	}
+	return rt
+}
+
+func (a *App) runtimeForTabLocked(tab *WorkspaceTab) *desktopSessionRuntime {
+	if tab == nil || strings.TrimSpace(tab.runtimeID) == "" {
+		return nil
+	}
+	rt := a.runtimeByID[tab.runtimeID]
+	if rt == nil || rt.Owner != tab {
+		return nil
+	}
+	return rt
+}
+
+func (a *App) runtimeForSessionLocked(path string) *desktopSessionRuntime {
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		return nil
+	}
+	return a.runtimeBySessionKey[key]
+}
+
+func (a *App) runtimeOwnerLiveLocked(rt *desktopSessionRuntime) bool {
+	if rt == nil || rt.Owner == nil {
+		return false
+	}
+	if a.tabs[rt.Owner.ID] == rt.Owner {
+		return true
+	}
+	for _, detached := range a.detachedSessions {
+		if detached == rt.Owner {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *App) removeSessionRuntimeMappingsLocked(rt *desktopSessionRuntime) {
+	if rt == nil {
+		return
+	}
+	for key, candidate := range a.runtimeBySessionKey {
+		if candidate == rt {
+			delete(a.runtimeBySessionKey, key)
+		}
+	}
+	delete(a.runtimeByID, rt.ID)
+}
+
+func closeRuntimeReadyChannelLocked(rt *desktopSessionRuntime) {
+	if rt == nil || rt.readyCh == nil {
+		return
+	}
+	close(rt.readyCh)
+	rt.readyCh = nil
+}
+
+func (a *App) setSessionRuntimePhaseLocked(tab *WorkspaceTab, phase SessionRuntimePhase, err error) {
+	if tab == nil {
+		return
+	}
+	rt := a.runtimeForTabLocked(tab)
+	if rt == nil {
+		key := sessionRuntimeKey(tab.SessionPath)
+		if existing := a.runtimeBySessionKey[key]; key != "" && existing != nil && existing.Owner != tab {
+			return
+		}
+		rt = a.newSessionRuntimeLocked(tab, key)
+	}
+	rt.Phase = phase
+	rt.Issue = sessionRuntimeIssueForError(err)
+	if phase == sessionRuntimeStarting {
+		rt.Issue = nil
+		if rt.readyCh == nil {
+			rt.readyCh = make(chan struct{})
+		}
+	} else {
+		closeRuntimeReadyChannelLocked(rt)
+	}
+	if tab.sink != nil {
+		tab.sink.setRuntimeEpoch(rt.Epoch)
+	}
+}
+
+func (a *App) advanceSessionRuntimeEpochLocked(tab *WorkspaceTab) string {
+	if tab == nil {
+		return ""
+	}
+	rt := a.runtimeForTabLocked(tab)
+	if rt == nil {
+		rt = a.newSessionRuntimeLocked(tab, sessionRuntimeKey(tab.SessionPath))
+	}
+	rt.Epoch = newSessionRuntimeID("epoch")
+	rt.Phase = sessionRuntimeReady
+	rt.Issue = nil
+	closeRuntimeReadyChannelLocked(rt)
+	if tab.sink != nil {
+		tab.sink.setRuntimeEpoch(rt.Epoch)
+	}
+	return rt.Epoch
+}
+
+func (a *App) sessionRuntimeViewLocked(tab *WorkspaceTab) SessionRuntimeView {
+	if tab == nil {
+		return SessionRuntimeView{Phase: sessionRuntimeStarting}
+	}
+	if rt := a.runtimeForTabLocked(tab); rt != nil {
+		return SessionRuntimeView{
+			Phase: rt.Phase,
+			Epoch: rt.Epoch,
+			Issue: cloneSessionRuntimeIssue(rt.Issue),
+		}
+	}
+	view := SessionRuntimeView{Phase: sessionRuntimeStarting}
+	switch {
+	case tab.Ctrl != nil && tab.Ready:
+		view.Phase = sessionRuntimeReady
+	case tab.StartupErrLeaseHeld:
+		view.Phase = sessionRuntimeLeaseBlocked
+		view.Issue = sessionRuntimeIssueForError(&agent.SessionLeaseError{})
+	case strings.TrimSpace(tab.StartupErr) != "":
+		view.Phase = sessionRuntimeFailed
+		view.Issue = &SessionRuntimeIssue{Code: "startup_failed", Message: tab.StartupErr}
+	}
+	return view
+}
+
+func (a *App) bindSessionRuntimeKeyLocked(tab *WorkspaceTab, path string) bool {
+	if tab == nil {
+		return false
+	}
+	key := sessionRuntimeKey(path)
+	if key == "" {
+		return true
+	}
+	if existing := a.runtimeBySessionKey[key]; existing != nil && existing.Owner != tab {
+		return false
+	}
+	rt := a.runtimeForTabLocked(tab)
+	if rt == nil {
+		a.newSessionRuntimeLocked(tab, key)
+		return true
+	}
+	if rt.Key != "" && rt.Key != key && a.runtimeBySessionKey[rt.Key] == rt {
+		delete(a.runtimeBySessionKey, rt.Key)
+	}
+	rt.Key = key
+	a.runtimeBySessionKey[key] = rt
+	return true
+}
+
+type sessionRuntimePathTransition struct {
+	runtime       *desktopSessionRuntime
+	owner         *WorkspaceTab
+	oldKey        string
+	targetKey     string
+	expectedEpoch string
+}
+
+func (a *App) reserveSessionRuntimePath(tab *WorkspaceTab, path string) (sessionRuntimePathTransition, error) {
+	targetKey := sessionRuntimeKey(path)
+	if tab == nil || targetKey == "" {
+		return sessionRuntimePathTransition{}, nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if existing := a.runtimeBySessionKey[targetKey]; existing != nil && existing.Owner != tab {
+		return sessionRuntimePathTransition{}, fmt.Errorf("%w: local runtime already owns session", agent.ErrSessionLeaseHeld)
+	}
+	rt := a.runtimeForTabLocked(tab)
+	if rt == nil {
+		// A path transition must retain the source identity until commit. Using
+		// targetKey here would make a failed first rebind forget the still-live
+		// source controller and its lease.
+		rt = a.newSessionRuntimeLocked(tab, sessionRuntimeKey(tab.currentSessionPath()))
+	}
+	transition := sessionRuntimePathTransition{
+		runtime:       rt,
+		owner:         tab,
+		oldKey:        rt.Key,
+		targetKey:     targetKey,
+		expectedEpoch: rt.Epoch,
+	}
+	// Keep the old key mapped until the lease rebind succeeds. The target alias
+	// prevents another local startup from claiming it during the off-lock file
+	// operation.
+	a.runtimeBySessionKey[targetKey] = rt
+	return transition, nil
+}
+
+func (a *App) commitSessionRuntimePath(transition sessionRuntimePathTransition) {
+	if transition.runtime == nil || transition.targetKey == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	rt := transition.runtime
+	if transition.oldKey != "" && transition.oldKey != transition.targetKey && a.runtimeBySessionKey[transition.oldKey] == rt {
+		delete(a.runtimeBySessionKey, transition.oldKey)
+	}
+	rt.Key = transition.targetKey
+	a.runtimeBySessionKey[transition.targetKey] = rt
+}
+
+// commitSessionRuntimePathLocked commits a previously reserved path only when
+// the same runtime generation still owns both aliases. It lets controller
+// swaps make the registry update part of their single App.mu commit.
+func (a *App) commitSessionRuntimePathLocked(transition sessionRuntimePathTransition) bool {
+	if transition.runtime == nil || transition.targetKey == "" {
+		return false
+	}
+	if !a.sessionRuntimePathTransitionValidLocked(transition) {
+		return false
+	}
+	rt := transition.runtime
+	if transition.oldKey != "" && transition.oldKey != transition.targetKey && a.runtimeBySessionKey[transition.oldKey] == rt {
+		delete(a.runtimeBySessionKey, transition.oldKey)
+	}
+	rt.Key = transition.targetKey
+	a.runtimeBySessionKey[transition.targetKey] = rt
+	return true
+}
+
+func (a *App) sessionRuntimePathTransitionValidLocked(transition sessionRuntimePathTransition) bool {
+	if transition.runtime == nil || transition.targetKey == "" {
+		return false
+	}
+	rt := transition.runtime
+	if a.runtimeByID[rt.ID] != rt ||
+		rt.Owner != transition.owner ||
+		rt.Epoch != transition.expectedEpoch ||
+		(rt.Key != transition.oldKey && rt.Key != transition.targetKey) ||
+		a.runtimeBySessionKey[transition.targetKey] != rt {
+		return false
+	}
+	return true
+}
+
+func (a *App) rollbackSessionRuntimePath(transition sessionRuntimePathTransition) {
+	if transition.runtime == nil || transition.targetKey == "" || transition.targetKey == transition.oldKey {
+		return
+	}
+	a.mu.Lock()
+	if a.runtimeBySessionKey[transition.targetKey] == transition.runtime {
+		delete(a.runtimeBySessionKey, transition.targetKey)
+	}
+	a.mu.Unlock()
+}
+
+// claimSessionRuntime reserves path for tab, or waits for/attaches the existing
+// local runtime. The caller owns its not-yet-published candidate controller; a
+// true return means that candidate must be closed because tab now uses the
+// already registered runtime.
+func (a *App) claimSessionRuntime(tab *WorkspaceTab, path string, ctx context.Context) bool {
+	key := sessionRuntimeKey(path)
+	if tab == nil || key == "" {
+		return false
+	}
+	for {
+		a.mu.Lock()
+		if tab.removed || a.tabs[tab.ID] != tab {
+			a.mu.Unlock()
+			return false
+		}
+		rt := a.runtimeBySessionKey[key]
+		if rt != nil && !a.runtimeOwnerLiveLocked(rt) {
+			a.removeSessionRuntimeMappingsLocked(rt)
+			rt = nil
+		}
+		switch {
+		case rt == nil:
+			a.bindSessionRuntimeKeyLocked(tab, path)
+			a.mu.Unlock()
+			return false
+		case rt.Owner == tab:
+			a.mu.Unlock()
+			return false
+		case rt.Phase == sessionRuntimeStarting && rt.readyCh != nil:
+			wait := rt.readyCh
+			a.mu.Unlock()
+			select {
+			case <-wait:
+				continue
+			case <-ctx.Done():
+				return false
+			case <-time.After(250 * time.Millisecond):
+				// Re-check owner liveness even when a superseded build exited
+				// before publishing a terminal phase.
+				continue
+			}
+		default:
+			a.mu.Unlock()
+			return a.attachExistingSessionRuntime(tab, path, a.ctx)
+		}
+	}
+}
+
+func (a *App) releaseSessionRuntimeLocked(tab *WorkspaceTab) {
+	rt := a.runtimeForTabLocked(tab)
+	if rt == nil {
+		if tab != nil {
+			tab.runtimeID = ""
+		}
+		return
+	}
+	rt.Phase = sessionRuntimeClosing
+	closeRuntimeReadyChannelLocked(rt)
+	a.removeSessionRuntimeMappingsLocked(rt)
+	if tab != nil {
+		tab.runtimeID = ""
+	}
+}
+
+func sameCurrentProcessLease(err error) bool {
+	var leaseErr *agent.SessionLeaseError
+	if !errors.As(err, &leaseErr) || leaseErr == nil || leaseErr.Info == nil {
+		return false
+	}
+	if leaseErr.Info.PID != os.Getpid() || leaseErr.Info.WriterID != agent.SessionWriterID() {
+		return false
+	}
+	host, _ := os.Hostname()
+	return strings.TrimSpace(leaseErr.Info.Hostname) == strings.TrimSpace(host)
+}

--- a/desktop/session_runtime.go
+++ b/desktop/session_runtime.go
@@ -394,12 +394,24 @@ func (a *App) claimSessionRuntime(tab *WorkspaceTab, path string, ctx context.Co
 		}
 		switch {
 		case rt == nil:
+			// Detached runtimes created before the admission registry was
+			// populated are a compatibility edge. Attach them before claiming
+			// the key so applyRuntimeTab can publish one authoritative runtime
+			// instead of leaving behind an unused placeholder.
+			if detached := a.detachedSessions[key]; detached != nil && detached.Ctrl != nil {
+				a.mu.Unlock()
+				return a.attachExistingSessionRuntime(tab, path, a.ctx)
+			}
 			a.bindSessionRuntimeKeyLocked(tab, path)
 			a.mu.Unlock()
 			return false
 		case rt.Owner == tab:
 			a.mu.Unlock()
-			return false
+			// The target may own the starting placeholder while a legacy
+			// visible/detached runtime for the same session predates the
+			// registry. Let attachExistingSessionRuntime adopt that usable
+			// controller; otherwise this remains the owner build.
+			return a.attachExistingSessionRuntime(tab, path, a.ctx)
 		case rt.Phase == sessionRuntimeStarting && rt.readyCh != nil:
 			wait := rt.readyCh
 			a.mu.Unlock()

--- a/desktop/session_runtime.go
+++ b/desktop/session_runtime.go
@@ -145,14 +145,6 @@ func (a *App) runtimeForTabLocked(tab *WorkspaceTab) *desktopSessionRuntime {
 	return rt
 }
 
-func (a *App) runtimeForSessionLocked(path string) *desktopSessionRuntime {
-	key := sessionRuntimeKey(path)
-	if key == "" {
-		return nil
-	}
-	return a.runtimeBySessionKey[key]
-}
-
 func (a *App) runtimeOwnerLiveLocked(rt *desktopSessionRuntime) bool {
 	if rt == nil || rt.Owner == nil {
 		return false

--- a/desktop/session_runtime_test.go
+++ b/desktop/session_runtime_test.go
@@ -90,10 +90,19 @@ func TestDeferredStartupReusesSameProcessTabLease(t *testing.T) {
 }
 
 func TestStartingRuntimePlaceholderIsNotOverwrittenByDuplicateTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
 	app := NewApp()
 	path := filepath.Join(t.TempDir(), "same-session.jsonl")
-	first := &WorkspaceTab{ID: "first", SessionPath: path}
-	second := &WorkspaceTab{ID: "second", SessionPath: path}
+	first := &WorkspaceTab{
+		ID:          "first",
+		SessionPath: path,
+		sink:        &tabEventSink{tabID: "first", app: app},
+	}
+	second := &WorkspaceTab{
+		ID:          "second",
+		SessionPath: path,
+		sink:        &tabEventSink{tabID: "second", app: app},
+	}
 	app.tabs[first.ID] = first
 	app.tabs[second.ID] = second
 
@@ -114,6 +123,51 @@ func TestStartingRuntimePlaceholderIsNotOverwrittenByDuplicateTab(t *testing.T) 
 	}
 	if secondRuntimeID != "" {
 		t.Fatalf("duplicate tab created private runtime %q before claim", secondRuntimeID)
+	}
+
+	// A starting placeholder is not an attachable runtime: its controller and
+	// lease are still private to the owner build. Attaching it would remove the
+	// owner tab and cause both candidate builds to retire.
+	if app.attachExistingSessionRuntime(second, path, context.Background()) {
+		t.Fatal("starting runtime attached before its controller was published")
+	}
+	if app.tabs[first.ID] != first || app.tabs[second.ID] != second {
+		t.Fatal("starting runtime attach removed one of the restoring tabs")
+	}
+	if first.Ctrl != nil || second.Ctrl != nil {
+		t.Fatal("starting runtime attach published a controller")
+	}
+
+	// Once the owner publishes its controller and ready phase, the same claim
+	// attaches that runtime and retires only the duplicate visible tab.
+	ctrl := control.New(control.Options{
+		SessionDir:  filepath.Dir(path),
+		SessionPath: path,
+		Label:       "ready",
+	})
+	t.Cleanup(ctrl.Close)
+	app.mu.Lock()
+	first.Ctrl = ctrl
+	first.Ready = true
+	app.advanceSessionRuntimeEpochLocked(first)
+	app.mu.Unlock()
+	if !app.claimSessionRuntime(second, path, context.Background()) {
+		t.Fatal("ready runtime was not attached by the duplicate claim")
+	}
+	app.mu.RLock()
+	readyOwner := app.runtimeBySessionKey[key]
+	firstStillVisible := app.tabs[first.ID]
+	secondStillVisible := app.tabs[second.ID]
+	view := app.sessionRuntimeViewLocked(second)
+	app.mu.RUnlock()
+	if readyOwner == nil || readyOwner.Owner != second || second.Ctrl != ctrl {
+		t.Fatalf("ready runtime owner/controller = %#v/%p, want second/%p", readyOwner, second.Ctrl, ctrl)
+	}
+	if firstStillVisible != nil || secondStillVisible != second {
+		t.Fatalf("visible tabs after attach = first %#v second %#v", firstStillVisible, secondStillVisible)
+	}
+	if view.Phase != sessionRuntimeReady {
+		t.Fatalf("attached runtime phase = %q, want ready", view.Phase)
 	}
 }
 

--- a/desktop/session_runtime_test.go
+++ b/desktop/session_runtime_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/control"
+)
+
+func TestMetaNeverReportsReadyWithoutController(t *testing.T) {
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:         "tab_broken_ready",
+		Scope:      "global",
+		Ready:      true, // compatibility field from an older persisted/runtime path
+		StartupErr: "startup failed",
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	meta := app.MetaForTab(tab.ID)
+	if meta.Ready {
+		t.Fatal("Meta reported ready with a nil controller")
+	}
+	if meta.Runtime.Phase != sessionRuntimeFailed {
+		t.Fatalf("runtime phase = %q, want %q", meta.Runtime.Phase, sessionRuntimeFailed)
+	}
+}
+
+func TestDeferredStartupReusesSameProcessTabLease(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalTabWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "self-owned-startup.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "self_owned")
+	tab.SessionPath = path
+	tab.StartupErr = (&sessionLeaseBusyError{}).Error()
+	tab.StartupErrLeaseHeld = true
+	tab.Ready = false
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	installNoopRuntimeEvents(app, tab.sink)
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	if err := tab.ensureSessionLease(path); err != nil {
+		t.Fatalf("pre-acquire tab lease: %v", err)
+	}
+	t.Cleanup(func() {
+		if ctrl := app.controllerForTab(tab); ctrl != nil {
+			ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+	app.mu.Lock()
+	app.bindSessionRuntimeKeyLocked(tab, path)
+	app.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, &sessionLeaseBusyError{})
+	app.mu.Unlock()
+
+	before := tab.buildGeneration
+	app.retryDeferredStartupBuild(tab.ID, tab)
+	if tab.Ctrl == nil {
+		t.Fatal("same-process owner was not rebuilt using its existing lease")
+	}
+	if tab.buildGeneration != before+1 {
+		t.Fatalf("build generation = %d, want exactly one retry from %d", tab.buildGeneration, before)
+	}
+	app.mu.RLock()
+	view := app.sessionRuntimeViewLocked(tab)
+	runtimeCount := len(app.runtimeBySessionKey)
+	app.mu.RUnlock()
+	if view.Phase != sessionRuntimeReady {
+		t.Fatalf("runtime phase = %q, want ready", view.Phase)
+	}
+	if runtimeCount != 1 {
+		t.Fatalf("runtime key count = %d, want one", runtimeCount)
+	}
+}
+
+func TestStartingRuntimePlaceholderIsNotOverwrittenByDuplicateTab(t *testing.T) {
+	app := NewApp()
+	path := filepath.Join(t.TempDir(), "same-session.jsonl")
+	first := &WorkspaceTab{ID: "first", SessionPath: path}
+	second := &WorkspaceTab{ID: "second", SessionPath: path}
+	app.tabs[first.ID] = first
+	app.tabs[second.ID] = second
+
+	app.mu.Lock()
+	app.setSessionRuntimePhaseLocked(first, sessionRuntimeStarting, nil)
+	app.setSessionRuntimePhaseLocked(second, sessionRuntimeStarting, nil)
+	key := sessionRuntimeKey(path)
+	owner := app.runtimeBySessionKey[key]
+	runtimeCount := len(app.runtimeBySessionKey)
+	secondRuntimeID := second.runtimeID
+	app.mu.Unlock()
+
+	if owner == nil || owner.Owner != first {
+		t.Fatalf("starting placeholder owner = %#v, want first tab", owner)
+	}
+	if runtimeCount != 1 {
+		t.Fatalf("runtime key count = %d, want one", runtimeCount)
+	}
+	if secondRuntimeID != "" {
+		t.Fatalf("duplicate tab created private runtime %q before claim", secondRuntimeID)
+	}
+}
+
+func TestBackendRejectsSubmitWhenRuntimeIsNotReady(t *testing.T) {
+	app := NewApp()
+	ctrl := &runtimeStatusSessionController{}
+	tab := &WorkspaceTab{ID: "blocked", Ctrl: ctrl, Ready: true}
+	app.tabs[tab.ID] = tab
+	app.activeTabID = tab.ID
+	app.mu.Lock()
+	app.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, &sessionLeaseBusyError{})
+	app.mu.Unlock()
+
+	err := app.SubmitToTab(tab.ID, "must not send")
+	if err == nil || !strings.Contains(err.Error(), "workspace failed to start") {
+		t.Fatalf("SubmitToTab error = %v, want runtime readiness failure", err)
+	}
+	if status := ctrl.RuntimeStatus(); status != (control.RuntimeStatus{}) {
+		t.Fatalf("controller status changed after rejected submit: %+v", status)
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1646,7 +1646,12 @@ func (a *App) rebuildSettingTurnLocked(setting string, tab *WorkspaceTab, admiss
 			leaseHeld := false
 			a.mu.Lock()
 			leaseHeld = setTabStartupError(tab, err)
-			tab.Ready = true
+			tab.Ready = false
+			if leaseHeld {
+				a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
+			} else {
+				a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
+			}
 			a.mu.Unlock()
 			if leaseHeld {
 				a.scheduleDeferredStartupBuild(tab.ID)
@@ -1690,6 +1695,7 @@ func (a *App) rebuildSettingTurnLocked(setting string, tab *WorkspaceTab, admiss
 	}
 	a.persistTabSessionPath(tab, path)
 	a.clearDeferredRebuild(tab.ID)
+	a.notifyTabRuntimeRebuilt(tab)
 	a.emitReady(a.ctx)
 	return nil
 }
@@ -2485,6 +2491,11 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 		clearTabStartupError(tab)
 		tab.Ready = a.ctx == nil
 		if a.ctx != nil {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeStarting, nil)
+		} else {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, fmt.Errorf("desktop runtime is not started"))
+		}
+		if a.ctx != nil {
 			rebuildTabs = append(rebuildTabs, tab)
 		}
 	}
@@ -2617,6 +2628,11 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 		tab.Label = fallbackRef
 		clearTabStartupError(tab)
 		tab.Ready = a.ctx == nil
+		if a.ctx != nil {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeStarting, nil)
+		} else {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, fmt.Errorf("desktop runtime is not started"))
+		}
 		if a.ctx != nil {
 			rebuildTabs = append(rebuildTabs, tab)
 		}

--- a/desktop/single_instance_test.go
+++ b/desktop/single_instance_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -8,6 +10,7 @@ import (
 )
 
 func TestSingleInstanceLockRestoresExistingInstance(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	app := NewApp()
 	lock := singleInstanceLock(app)
 
@@ -26,6 +29,51 @@ func TestSingleInstanceLockRestoresExistingInstance(t *testing.T) {
 	}
 
 	lock.OnSecondInstanceLaunch(options.SecondInstanceData{})
+}
+
+func TestSingleInstanceIDScopesToReasonixHome(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	t.Setenv("REASONIX_HOME", first)
+	firstID := singleInstanceID()
+	t.Setenv("REASONIX_HOME", filepath.Join(first, "."))
+	if got := singleInstanceID(); got != firstID {
+		t.Fatalf("same data home produced different ids: %q != %q", got, firstID)
+	}
+	t.Setenv("REASONIX_HOME", second)
+	if got := singleInstanceID(); got == firstID {
+		t.Fatalf("different data homes produced the same id %q", got)
+	}
+}
+
+func TestSingleInstanceIDDoesNotSplitReleaseChannels(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	oldChannel := channel
+	t.Cleanup(func() { channel = oldChannel })
+	channel = "stable"
+	stableID := singleInstanceID()
+	channel = "canary"
+	if got := singleInstanceID(); got != stableID {
+		t.Fatalf("same data home split by channel: stable=%q canary=%q", stableID, got)
+	}
+}
+
+func TestSingleInstanceIDResolvesMissingHomeThroughSymlink(t *testing.T) {
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	if err := os.MkdirAll(realParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasParent := filepath.Join(root, "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("REASONIX_HOME", filepath.Join(realParent, "not-created", "home"))
+	realID := singleInstanceID()
+	t.Setenv("REASONIX_HOME", filepath.Join(aliasParent, "not-created", "home"))
+	if got := singleInstanceID(); got != realID {
+		t.Fatalf("aliased missing data home produced different ids: %q != %q", got, realID)
+	}
 }
 
 func TestSingleInstanceLockSkipsInDevMode(t *testing.T) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -752,12 +752,20 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	if app != nil {
 		key := sessionRuntimeKey(path)
 		rt := app.runtimeForTabLocked(source)
+		targetRuntime := app.runtimeForTabLocked(target)
+		if rt == nil {
+			rt = targetRuntime
+		}
 		if rt == nil {
 			rt = app.newSessionRuntimeLocked(source, key)
-			if source.Ctrl != nil && source.Ready {
-				rt.Phase = sessionRuntimeReady
-				closeRuntimeReadyChannelLocked(rt)
-			}
+		} else if targetRuntime != nil && targetRuntime != rt {
+			app.removeSessionRuntimeMappingsLocked(targetRuntime)
+			target.runtimeID = ""
+		}
+		if source.Ctrl != nil && source.Ready {
+			rt.Phase = sessionRuntimeReady
+			rt.Issue = nil
+			closeRuntimeReadyChannelLocked(rt)
 		}
 		rt.Owner = target
 		if rt.Key != "" && rt.Key != key && app.runtimeBySessionKey[rt.Key] == rt {
@@ -787,6 +795,29 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	if rt := a.runtimeBySessionKey[key]; rt != nil && !a.runtimeOwnerLiveLocked(rt) {
 		a.removeSessionRuntimeMappingsLocked(rt)
 	}
+	registered := a.runtimeBySessionKey[key]
+	if registered != nil && registered.Phase == sessionRuntimeStarting && registered.Owner != tab {
+		// A starting runtime owns only an admission placeholder; its controller,
+		// lease, and sink have not been published yet. Moving that tab would
+		// supersede the owner build while the attaching build closes its own
+		// candidate, leaving the session permanently starting with no controller.
+		// claimSessionRuntime waits on readyCh and retries the attach after the
+		// owner publishes a terminal phase. The owner itself may still adopt a
+		// usable legacy runtime that predates the registry.
+		a.mu.Unlock()
+		return false
+	}
+	attachable := func(source *WorkspaceTab) bool {
+		if source == nil || source.Ctrl == nil {
+			return false
+		}
+		if rt := a.runtimeForTabLocked(source); rt != nil {
+			return rt.Phase == sessionRuntimeReady
+		}
+		// Compatibility for visible/detached runtimes constructed before the
+		// process-local registry existed.
+		return source.Ready
+	}
 	detached := a.detachedSessions[key]
 	if detached == nil {
 		if rt := a.runtimeBySessionKey[key]; rt != nil && rt.Owner != nil && rt.Owner != tab {
@@ -799,6 +830,10 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 		}
 	}
 	if detached != nil {
+		if !attachable(detached) {
+			a.mu.Unlock()
+			return false
+		}
 		delete(a.detachedSessions, key)
 		applyRuntimeTab(tab, detached, path, wailsCtx, a)
 		if current := a.tabs[tab.ID]; current == tab {
@@ -829,6 +864,10 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 		}
 	}
 	if source == nil {
+		a.mu.Unlock()
+		return false
+	}
+	if !attachable(source) {
 		a.mu.Unlock()
 		return false
 	}
@@ -3540,12 +3579,6 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 		}
 		// Write/update scope/session meta.
 		if path != "" {
-			if a.attachExistingSessionRuntime(tab, path, wailsCtx) {
-				ctrl.Close()
-				a.releaseSharedHost(rootKey)
-				a.emitReady(wailsCtx, tab.ID)
-				return
-			}
 			if a.claimSessionRuntime(tab, path, buildCtx) {
 				ctrl.Close()
 				a.releaseSharedHost(rootKey)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -165,6 +165,7 @@ type WorkspaceTab struct {
 	Ready               bool               // true once boot.Build completes
 	StartupErr          string             // build error, surfaced to the frontend
 	StartupErrLeaseHeld bool               // true when StartupErr can be retried after a session lease releases
+	runtimeID           string             // process-local SessionRuntime registry identity
 	sessionLease        *agent.SessionLease
 	sessionLeaseMu      sync.Mutex
 	sessionLeaseKey     atomic.Pointer[string] // lock-free mirror; updated with sessionLease under sessionLeaseMu
@@ -589,6 +590,7 @@ func (a *App) detachSessionRuntime(tab *WorkspaceTab) bool {
 	a.mu.Lock()
 	a.ensureDetachedSessionsLocked()
 	tab.SessionPath = canonicalTabSessionPath(path)
+	a.bindSessionRuntimeKeyLocked(tab, path)
 	a.detachedSessions[key] = tab
 	a.mu.Unlock()
 	return true
@@ -625,6 +627,7 @@ func cloneDetachedRuntimeTab(tab *WorkspaceTab, key, path string) *WorkspaceTab 
 		Ready:               tab.Ready,
 		StartupErr:          tab.StartupErr,
 		StartupErrLeaseHeld: tab.StartupErrLeaseHeld,
+		runtimeID:           tab.runtimeID,
 		sink:                tab.sink,
 		ActivityStatus:      tab.ActivityStatus,
 		readTelemetry:       readTelemetry,
@@ -658,25 +661,39 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	// The lease transfer stays deadlock-safe here: neither side holds a lease
 	// to release, so no lease I/O runs under a.mu.
 	a.mu.Lock()
+	detached := a.detachRuntimeForReplacementLocked(tab)
+	a.mu.Unlock()
+	return detached
+}
+
+// detachRuntimeForReplacementLocked transfers a visible tab's live runtime to
+// the detached registry without closing its controller or releasing its lease.
+// Callers must hold App.mu. The transfer itself performs no file or host I/O.
+func (a *App) detachRuntimeForReplacementLocked(tab *WorkspaceTab) bool {
+	if tab == nil {
+		return false
+	}
 	if tab.removed || a.tabs[tab.ID] != tab {
-		a.mu.Unlock()
 		return false
 	}
 	sourcePath := tab.currentSessionPath()
 	key := sessionRuntimeKey(sourcePath)
 	if key == "" {
-		a.mu.Unlock()
 		return false
 	}
 	detached := cloneDetachedRuntimeTab(tab, key, sourcePath)
 	if detached == nil {
-		a.mu.Unlock()
 		return false
 	}
 	// Transfer lease ownership through the locked helpers: a concurrent
 	// ensureSessionLease (blank-session boot, recovery callback) must never
 	// observe a torn pointer or have its freshly acquired lease clobbered.
 	detached.adoptSessionLease(tab.takeSessionLease())
+	if rt := a.runtimeForTabLocked(tab); rt != nil {
+		rt.Owner = detached
+		detached.runtimeID = rt.ID
+		tab.runtimeID = ""
+	}
 	if detached.sink != nil {
 		detached.sink.setBinding(detached.ID, nil)
 		// clearContext (locked nil + drain the queued emitter), not a bare
@@ -687,7 +704,6 @@ func (a *App) detachRuntimeForReplacement(tab *WorkspaceTab) bool {
 	}
 	a.ensureDetachedSessionsLocked()
 	a.detachedSessions[key] = detached
-	a.mu.Unlock()
 	return true
 }
 
@@ -719,7 +735,7 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.SessionPath = canonicalTabSessionPath(path)
 	target.SharedHostKey = source.SharedHostKey
 	target.Label = source.Label
-	target.Ready = true
+	target.Ready = source.Ready && source.Ctrl != nil
 	clearTabStartupError(target)
 	target.ActivityStatus = source.ActivityStatus
 	target.model = source.model
@@ -733,6 +749,28 @@ func applyRuntimeTab(target, source *WorkspaceTab, path string, wailsCtx context
 	target.readTelemetry = readTelemetry
 	target.usageTelemetry = usageTelemetry
 	target.telemetrySessionKey = telemetrySessionKey
+	if app != nil {
+		key := sessionRuntimeKey(path)
+		rt := app.runtimeForTabLocked(source)
+		if rt == nil {
+			rt = app.newSessionRuntimeLocked(source, key)
+			if source.Ctrl != nil && source.Ready {
+				rt.Phase = sessionRuntimeReady
+				closeRuntimeReadyChannelLocked(rt)
+			}
+		}
+		rt.Owner = target
+		if rt.Key != "" && rt.Key != key && app.runtimeBySessionKey[rt.Key] == rt {
+			delete(app.runtimeBySessionKey, rt.Key)
+		}
+		rt.Key = key
+		app.runtimeBySessionKey[key] = rt
+		target.runtimeID = rt.ID
+		source.runtimeID = ""
+		if target.sink != nil {
+			target.sink.setRuntimeEpoch(rt.Epoch)
+		}
+	}
 }
 
 func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wailsCtx context.Context) bool {
@@ -746,7 +784,20 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 		a.mu.Unlock()
 		return false
 	}
+	if rt := a.runtimeBySessionKey[key]; rt != nil && !a.runtimeOwnerLiveLocked(rt) {
+		a.removeSessionRuntimeMappingsLocked(rt)
+	}
 	detached := a.detachedSessions[key]
+	if detached == nil {
+		if rt := a.runtimeBySessionKey[key]; rt != nil && rt.Owner != nil && rt.Owner != tab {
+			detached = rt.Owner
+			if a.tabs[detached.ID] != detached {
+				delete(a.detachedSessions, key)
+			} else {
+				detached = nil
+			}
+		}
+	}
 	if detached != nil {
 		delete(a.detachedSessions, key)
 		applyRuntimeTab(tab, detached, path, wailsCtx, a)
@@ -762,7 +813,13 @@ func (a *App) attachExistingSessionRuntime(tab *WorkspaceTab, path string, wails
 	}
 
 	var source *WorkspaceTab
+	if rt := a.runtimeBySessionKey[key]; rt != nil && rt.Owner != nil && rt.Owner != tab {
+		source = rt.Owner
+	}
 	for _, candidate := range a.tabs {
+		if source != nil {
+			break
+		}
 		if candidate == nil || candidate == tab {
 			continue
 		}
@@ -1201,6 +1258,7 @@ type tabEventSink struct {
 	app           *App
 	mu            sync.RWMutex
 	ctx           context.Context
+	runtimeEpoch  string
 	runtimeEvents asyncRuntimeEmitter
 	botSink       event.Sink // optional: when set, events are also forwarded here
 	botSinkGen    uint64
@@ -1227,6 +1285,24 @@ func (s *tabEventSink) setBinding(tabID string, app *App) {
 		s.app = app
 	}
 	s.mu.Unlock()
+}
+
+func (s *tabEventSink) setRuntimeEpoch(epoch string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.runtimeEpoch = epoch
+	s.mu.Unlock()
+}
+
+func (s *tabEventSink) runtimeEpochSnapshot() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.runtimeEpoch
 }
 
 func (s *tabEventSink) Emit(e event.Event) {
@@ -1260,7 +1336,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.flushDisplay(e.Cancelled)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTab(e, tabID))
+	s.emitRuntimeEvent(eventChannel, toWireTab(e, tabID, s.runtimeEpochSnapshot()))
 	if app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update {
 			changed := app.setTabActivityStatus(tabID, status)
@@ -1536,15 +1612,28 @@ func (a *App) notifyTabRuntimeRebuilt(tab *WorkspaceTab) {
 	if tab == nil {
 		return
 	}
+	a.mu.Lock()
+	epoch := a.advanceSessionRuntimeEpochLocked(tab)
+	a.mu.Unlock()
+	a.notifyTabRuntimeRebuiltAtEpoch(tab, epoch)
+}
+
+// notifyTabRuntimeRebuiltAtEpoch emits the rebuild fence for a transaction
+// that advanced its epoch inside the controller/path/lease commit. Keeping the
+// chosen epoch avoids a second generation bump after publication.
+func (a *App) notifyTabRuntimeRebuiltAtEpoch(tab *WorkspaceTab, epoch string) {
+	if tab == nil {
+		return
+	}
 	a.mu.RLock()
 	sink := tab.sink
 	tabID := tab.ID
 	a.mu.RUnlock()
 	if sink != nil && sink.context() != nil {
-		sink.emitRuntimeEvent("runtime:rebuilt", tabID)
+		sink.emitRuntimeEvent("runtime:rebuilt", tabID, epoch)
 		return
 	}
-	a.emitRuntimeEvent("runtime:rebuilt", tabID)
+	a.emitRuntimeEvent("runtime:rebuilt", tabID, epoch)
 }
 
 func (a *App) emitReady(ctx context.Context, tabID ...string) {
@@ -1773,11 +1862,16 @@ func (s *tabEventSink) telemetryTab() (*WorkspaceTab, string) {
 
 // --- wire event with tab ----------------------------------------------------
 
-func toWireTab(e event.Event, tabID string) wireEventTab {
+func toWireTab(e event.Event, tabID string, runtimeEpoch ...string) wireEventTab {
 	w := eventwire.ToWire(e)
+	epoch := ""
+	if len(runtimeEpoch) > 0 {
+		epoch = runtimeEpoch[0]
+	}
 	return wireEventTab{
 		Event:             w,
 		TabID:             tabID,
+		RuntimeEpoch:      epoch,
 		SessionHitTokens:  e.SessionHit,
 		SessionMissTokens: e.SessionMiss,
 		SessionCost:       0, // filled by frontend accumulator per tab
@@ -1790,7 +1884,8 @@ func toWireTab(e event.Event, tabID string) wireEventTab {
 // uses tabId to dispatch to the correct per-tab state.
 type wireEventTab struct {
 	eventwire.Event
-	TabID string `json:"tabId"`
+	TabID        string `json:"tabId"`
+	RuntimeEpoch string `json:"runtimeEpoch,omitempty"`
 	// Session-cumulative tokens per tab.
 	SessionHitTokens  int `json:"sessionHitTokens,omitempty"`
 	SessionMissTokens int `json:"sessionMissTokens,omitempty"`
@@ -1820,6 +1915,7 @@ type TabMeta struct {
 	ProjectColor      string                   `json:"projectColor,omitempty"`
 	Label             string                   `json:"label"`
 	Ready             bool                     `json:"ready"`
+	Runtime           SessionRuntimeView       `json:"runtime"`
 	Running           bool                     `json:"running"`
 	PendingPrompt     bool                     `json:"pendingPrompt,omitempty"`
 	RemoteControlled  bool                     `json:"remoteControlled,omitempty"`
@@ -1859,6 +1955,7 @@ func enrichTabMetas(metas []TabMeta) []TabMeta {
 }
 
 func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
+	runtimeView := a.sessionRuntimeViewLocked(tab)
 	m := TabMeta{
 		ID:                tab.ID,
 		Scope:             tab.Scope,
@@ -1870,7 +1967,8 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		SessionPath:       tab.currentSessionPath(),
 		ReadOnly:          tab.ReadOnly,
 		Label:             tab.Label,
-		Ready:             tab.Ready,
+		Ready:             runtimeView.Phase == sessionRuntimeReady && tab.Ctrl != nil,
+		Runtime:           runtimeView,
 		Mode:              currentTabMode(tab),
 		CollaborationMode: currentTabCollaborationMode(tab),
 		ToolApprovalMode:  currentTabToolApprovalMode(tab),
@@ -3073,6 +3171,9 @@ func (a *App) closeTabRuntimeAdmissionHeld(tab *WorkspaceTab) {
 		sink.clearContext()
 	}
 	tab.releaseSessionLease()
+	a.mu.Lock()
+	a.releaseSessionRuntimeLocked(tab)
+	a.mu.Unlock()
 }
 
 // buildTabController assembles a controller for a tab in the background, the
@@ -3182,6 +3283,13 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 	if a.tabBuildSuperseded(tab, buildGeneration) {
 		return
 	}
+	a.mu.Lock()
+	if !tab.removed && tab.Ctrl == nil {
+		tab.Ready = false
+		clearTabStartupError(tab)
+		a.setSessionRuntimePhaseLocked(tab, sessionRuntimeStarting, nil)
+	}
+	a.mu.Unlock()
 
 	a.reconcileTabWithPinnedSessionMeta(tab)
 
@@ -3215,7 +3323,12 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 			return
 		}
 		leaseHeld = setTabStartupError(tab, err)
-		tab.Ready = true
+		tab.Ready = false
+		if leaseHeld {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
+		} else {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
+		}
 		tab.releaseSessionLease()
 		a.mu.Unlock()
 		if leaseHeld {
@@ -3351,7 +3464,12 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 			return
 		}
 		leaseHeld = setTabStartupError(tab, err)
-		tab.Ready = true
+		tab.Ready = false
+		if leaseHeld {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
+		} else {
+			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
+		}
 		hostKey := takeTabSharedHostKey(tab)
 		tab.releaseSessionLease()
 		a.mu.Unlock()
@@ -3428,8 +3546,14 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 				a.emitReady(wailsCtx, tab.ID)
 				return
 			}
+			if a.claimSessionRuntime(tab, path, buildCtx) {
+				ctrl.Close()
+				a.releaseSharedHost(rootKey)
+				a.emitReady(wailsCtx, tab.ID)
+				return
+			}
 			preLeaseKey := tab.sessionLeaseRuntimeKey()
-			if err := tab.ensureSessionLease(path); err != nil {
+			if err := a.ensureTabSessionLeaseForRebuild(tab, path, ""); err != nil {
 				leaseHeld := false
 				a.mu.Lock()
 				if a.tabBuildSupersededLocked(tab, buildGeneration) {
@@ -3438,7 +3562,12 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 					return
 				}
 				leaseHeld = setTabStartupError(tab, err)
-				tab.Ready = true
+				tab.Ready = false
+				if leaseHeld {
+					a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
+				} else {
+					a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
+				}
 				hostKey := takeTabSharedHostKey(tab)
 				// Release only a lease bound to THIS build's session: a failed
 				// ensure leaves any prior lease untouched, and that lease may
@@ -3483,7 +3612,12 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 					return
 				}
 				leaseHeld = setTabStartupError(tab, restoreErr)
-				tab.Ready = true
+				tab.Ready = false
+				if leaseHeld {
+					a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, restoreErr)
+				} else {
+					a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, restoreErr)
+				}
 				hostKey := takeTabSharedHostKey(tab)
 				tab.releaseSessionLeaseForKey(sessionRuntimeKey(path))
 				a.mu.Unlock()
@@ -3535,6 +3669,8 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 	applyNormalizedRuntimeToTabLocked(tab, restoredRuntime)
 	tab.Ready = true
 	clearTabStartupError(tab)
+	a.bindSessionRuntimeKeyLocked(tab, tab.currentSessionPath())
+	a.advanceSessionRuntimeEpochLocked(tab)
 	keepBuildContext = true
 	a.mu.Unlock()
 	a.emitReady(wailsCtx, tab.ID)
@@ -5495,7 +5631,7 @@ func (a *App) handleTabSessionRecovered(tab *WorkspaceTab) func(control.SessionR
 			return nil
 		}
 		if tab != nil && !tab.ReadOnly {
-			if err := tab.ensureSessionLease(info.RecoveryPath); err != nil {
+			if err := a.ensureTabSessionLeaseForRebuild(tab, info.RecoveryPath, ""); err != nil {
 				slog.Warn("desktop: acquire recovery session lease", "path", info.RecoveryPath, "err", err)
 				reason := "lease_unavailable"
 				if errors.Is(err, agent.ErrSessionLeaseHeld) {

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -962,8 +962,14 @@ func TestBuildTabControllerBlocksWhenSessionLeaseHeld(t *testing.T) {
 	if tab.Ctrl != nil {
 		t.Fatalf("tab controller = %T, want nil when lease is held", tab.Ctrl)
 	}
-	if !tab.Ready {
-		t.Fatal("tab should be ready with startup error")
+	if tab.Ready {
+		t.Fatal("tab with no controller must not report ready")
+	}
+	app.mu.RLock()
+	runtimeView := app.sessionRuntimeViewLocked(tab)
+	app.mu.RUnlock()
+	if runtimeView.Phase != sessionRuntimeLeaseBlocked {
+		t.Fatalf("runtime phase = %q, want %q", runtimeView.Phase, sessionRuntimeLeaseBlocked)
 	}
 	// The surfaced startup error is the sanitized busy message: the raw lease
 	// error would leak the session path and the holder's host-pid-writer id

--- a/internal/agent/canonical_path_test.go
+++ b/internal/agent/canonical_path_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -11,6 +12,40 @@ func TestCanonicalSessionPathMatchesLeaseRegistryKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "Mixed-Case", "20260705-Test.jsonl")
 	if got, want := CanonicalSessionPath(path), canonicalSessionSavePath(path); got != want {
 		t.Fatalf("CanonicalSessionPath(%q) = %q, want lease key %q", path, got, want)
+	}
+}
+
+func TestCanonicalSessionPathResolvesDirectorySymlink(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	realPath := filepath.Join(realDir, "session.jsonl")
+	aliasPath := filepath.Join(aliasDir, "session.jsonl")
+	if got, want := CanonicalSessionPath(aliasPath), CanonicalSessionPath(realPath); got != want {
+		t.Fatalf("directory alias split session identity: %q != %q", got, want)
+	}
+}
+
+func TestCanonicalSessionPathResolvesNearestExistingAncestor(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	realPath := filepath.Join(realDir, "not-created", "nested", "session.jsonl")
+	aliasPath := filepath.Join(aliasDir, "not-created", "nested", "session.jsonl")
+	if got, want := CanonicalSessionPath(aliasPath), CanonicalSessionPath(realPath); got != want {
+		t.Fatalf("nearest existing ancestor alias split session identity: %q != %q", got, want)
 	}
 }
 

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1226,10 +1226,41 @@ func canonicalSessionSavePath(path string) string {
 	if abs, err := filepath.Abs(key); err == nil {
 		key = abs
 	}
+	// Resolve physical identity, not just spelling. Otherwise a symlink or
+	// junction alias can acquire a second sidecar lock for the same transcript.
+	key = resolvePathThroughExistingAncestor(key)
 	if runtime.GOOS == "windows" {
+		if strings.HasPrefix(strings.ToUpper(key), `\\?\UNC\`) {
+			key = `\\` + key[len(`\\?\UNC\`):]
+		} else {
+			key = strings.TrimPrefix(key, `\\?\`)
+		}
 		key = strings.ToLower(key)
 	}
 	return key
+}
+
+// resolvePathThroughExistingAncestor resolves the deepest existing ancestor
+// and appends every still-missing component. Fresh sessions can be nested under
+// directories that have not been created yet; resolving only the immediate
+// parent leaves aliases above that directory split into different lease keys.
+func resolvePathThroughExistingAncestor(path string) string {
+	current := filepath.Clean(path)
+	missing := make([]string, 0, 4)
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return resolved
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 // CanonicalSessionPath is the identity key of a session path: cleaned,


### PR DESCRIPTION
## Summary

Goal + Delivery is a valid Desktop combination. It must not create a second writer or make a single visible Reasonix window collide with its own session lease.

This PR replaces tab-local startup ownership with one process-local SessionRuntime admission registry per canonical writable session. Existing visible, starting, and detached runtimes are attached or awaited; only a genuine external holder produces `lease_blocked`.

Fixes #6750. Fixes #6878.
Refs #6564, #6567, #6568, #6637, #5992, and #6573.

## Root cause

`WorkspaceTab` independently carried controller startup, lease state, build generation, and readiness. Goal or Delivery profile rebuilds, duplicate-tab restore, deferred retry, background reattachment, and saved-session navigation could therefore enter separate build paths for the same session. A second path could see the first path's lease and report the external-window error even though both belonged to one process.

Two adjacent identity gaps amplified the problem:

- deferred retry treated same-PID metadata as permission to build again instead of classifying a live local runtime versus an orphaned lease;
- single-instance identity followed the executable, so stable, canary, installed, and portable binaries could write one `REASONIX_HOME` concurrently;
- fresh paths resolved only their direct parent, allowing deeper symlink or junction aliases to split one file into multiple runtime keys.

## Changes

### One local runtime owner

- Add `runtimeByID` and `runtimeBySessionKey` registries guarded by `App.mu`.
- Add one SessionRuntime phase, issue, epoch, owner, and starting completion signal per writable canonical session.
- Route startup, restore, detached reattachment, ClearSession, recovery, and rebuild lease acquisition through the same reservation and claim path.
- A ready runtime attaches immediately; a starting runtime is awaited; a detached runtime is rebound; an orphaned current-process lease is reclaimed only after the OS lock proves it is free; an external holder remains blocked.
- Duplicate starting tabs cannot overwrite the first runtime placeholder.
- Shutdown and tab teardown remove runtime mappings exactly once.

`WorkspaceTab` remains a compatibility projection for the existing Desktop call surface, while the SessionRuntime registry is authoritative for admission and session-key ownership. No runtime ID is persisted.

### Transactional rebuild and saved-session switching

- Model, effort, token mode, Goal, Delivery, provider, recovery, and session rotation keep the old controller and existing lease until the candidate build and restore succeed.
- Saved-session switching now builds, restores, validates, and leases the target candidate before one atomic controller/lease/path/profile/epoch publication.
- Session-key transitions reserve both old and target keys while the target is prepared, preventing a concurrent local startup from claiming either side.
- A target controller build, history restore, validation, or lease failure closes only the candidate and leaves the source controller, lease, path, profile, runtime mapping, and epoch unchanged.
- A successful active-session switch detaches the still-running source runtime only at commit; an inactive source is closed and released only after the target has been published.
- Deferred retry no longer grows build generations while repeatedly colliding with a live runtime from the same process.

### Structured readiness and event fencing

Desktop metadata now includes an additive runtime object:

    phase: starting | ready | lease_blocked | failed | closing
    epoch: process-local runtime generation
    issue: structured startup or session-lease failure

Legacy `ready` and `startupErr` remain available. `ready` is true only when the runtime phase is `ready` and a controller exists.

- Composer, transcript prompt, Delivery recovery, and `commitThenSend` paths reject non-ready runtimes before optimistic user dispatch.
- Backend turn admission repeats the runtime-phase check to fence stale frontend metadata.
- Controller events carry `runtimeEpoch`; the frontend seeds the fence from metadata and ignores late events from replaced controllers.
- Genuine asynchronous submission failures still mark their pending bubble as failed.

### Cross-process and path identity

- Single-instance identity hashes canonical `REASONIX_HOME` instead of the executable path.
- Stable, canary, installed, and portable builds sharing one home now route to the existing instance.
- Different homes remain independent, and `REASONIX_DEV=1` still bypasses the single-instance restriction.
- Canonical session paths resolve the nearest existing ancestor before appending missing components, then normalize Windows long-path, UNC, case, symlink, and junction aliases.

## Attribution and relation to partial fixes

PR #6573 by @erphenheimer correctly proposed attach-first handling for one deferred-retry path. This PR adapts that attach-first classification and moves it into a shared runtime ownership path used by startup, restore, rebuild, detached reattachment, and session navigation. @erphenheimer is credited as a co-author on the runtime ownership commit. The stale-turn watchdog half of #6573 is independent and is not changed here.

PR #5992 adds same-session reuse coverage. This PR includes broader visible, starting, detached, orphaned-lease, external-holder, failure-atomicity, and Goal + Delivery coverage.

## Backward compatibility

| Surface | Compatibility |
| --- | --- |
| Session JSONL and sidecars | Unchanged format and identity on disk |
| `desktop-tabs.json` | Unchanged; RuntimeID and epoch are process-local only |
| Wails metadata | Additive `runtime` and `runtimeEpoch` fields; legacy `ready` and `startupErr` retained |
| Older frontend against new backend | Unknown additive fields are ignored |
| New frontend against older backend | `runtime` is optional and legacy readiness remains supported |
| `REASONIX_HOME` isolation | Preserved; only binaries sharing the same home now mutually exclude |
| `REASONIX_DEV=1` | Preserved parallel development behavior |

## Cache impact

Cache-impact: none. The changes are limited to Desktop lifecycle, lease identity, Wails metadata, and frontend event routing. No provider-visible prompt, tool schema, memory prefix, compaction input, request serialization, or model payload changes.

System-prompt-review: not applicable.

## Verification

- `go test ./...` with provider credentials removed from the hermetic suite
- `cd desktop && go test ./...`
- `cd desktop && go test -race .`
- `go test -race ./internal/agent/... ./internal/control/...`
- `go test -race ./internal/workspacelease ./internal/filelock ./internal/cli`
- all 18 Normal/Plan/Goal × Economy/Balanced/Delivery × both update-order combinations
- deterministic mode rebuild + A/B/A navigation + target-lease failure + stale-epoch event regression
- `cd desktop && go vet ./...`
- `cd desktop && go build ./...`
- `cd desktop/frontend && pnpm test:all`
- `cd desktop/frontend && pnpm build`
- Wails bindings generation and production Desktop build
- Windows CI for path aliases, canonical identity, and Desktop packaging
- `git diff --check` and public-text privacy scan

Focused regressions cover Goal + Delivery mode switching, duplicate starting tabs, same-process orphan reclaim, external-holder preservation, target failure atomicity, incorrect ready state, backend submission admission, optimistic-send gating, stale epoch rejection, data-home instance identity, aliased fresh paths, and concurrent A/B/A navigation.
