### PR TITLE
fix(recovery): add Auto Guard gentle mode, npx verification, and user…

### DIFF
--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -169,6 +169,9 @@ const (
 	RecoveryActionContinue     RecoveryAction = "continue"
 	RecoveryActionContinueTask RecoveryAction = "continue_task"
 	RecoveryActionRevise       RecoveryAction = "revise"
+	// RecoveryActionOverride lets the user clear an episode stop and reset
+	// failure counts so Auto can continue without switching modes.
+	RecoveryActionOverride RecoveryAction = "override"
 )
 
 func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args json.RawMessage, readOnly, mutates bool, result string, err error, blocked, userRejected bool, generation uint64) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -362,8 +362,12 @@ type Options struct {
 	// RecoveryHeadless blocks mutations that need confirmation instead of
 	// waiting forever when no human decision channel exists.
 	RecoveryHeadless bool
-	Sink             event.Sink
-	Policy           permission.Policy
+	// RecoveryGuardLevel sets the Auto Guard aggressiveness level. Defaults to
+	// recovery.AutoGuardNormal when empty. Set to recovery.AutoGuardGentle for
+	// a less intrusive experience.
+	RecoveryGuardLevel recovery.AutoGuardLevel
+	Sink               event.Sink
+	Policy             permission.Policy
 	// SubagentGate is the shared, mutable gate every headless-only sub-agent
 	// surface (task, writer-capable skill sub-agents, planner) reads from. Nil
 	// disables gating for those surfaces same as before this field existed.
@@ -532,7 +536,7 @@ func New(opts Options) *Controller {
 	}
 	// Auto Guard is built into Auto. Ask and YOLO bypass it through the mode
 	// provider, so no separate enablement state is needed.
-	c.initRecoveryGate(opts.RecoveryReviewer, opts.RecoveryHeadless)
+	c.initRecoveryGate(opts.RecoveryReviewer, opts.RecoveryHeadless, opts.RecoveryGuardLevel)
 	return c
 }
 

--- a/internal/control/recovery.go
+++ b/internal/control/recovery.go
@@ -23,7 +23,7 @@ func (c *Controller) ResolveRecovery(id string, action agent.RecoveryAction, fee
 		return fmt.Errorf("empty recovery approval id")
 	}
 	switch action {
-	case agent.RecoveryActionContinue, agent.RecoveryActionContinueTask, agent.RecoveryActionRevise:
+	case agent.RecoveryActionContinue, agent.RecoveryActionContinueTask, agent.RecoveryActionRevise, agent.RecoveryActionOverride:
 	default:
 		// Accept plain strings from wire clients.
 		switch strings.ToLower(strings.TrimSpace(string(action))) {
@@ -33,6 +33,8 @@ func (c *Controller) ResolveRecovery(id string, action agent.RecoveryAction, fee
 			action = agent.RecoveryActionContinueTask
 		case "revise":
 			action = agent.RecoveryActionRevise
+		case "override":
+			action = agent.RecoveryActionOverride
 		case "stop":
 			// Compatibility for older clients: cancel this proposed mutation.
 			// Whole-task cancellation remains on the app's ordinary Stop control.
@@ -89,12 +91,13 @@ func clipUTF8(s string, n int) string {
 
 // initRecoveryGate constructs the shared recovery gate and attaches it to the
 // executor. Called from New when recovery is available.
-func (c *Controller) initRecoveryGate(reviewer recovery.Reviewer, headless bool) {
+func (c *Controller) initRecoveryGate(reviewer recovery.Reviewer, headless bool, level recovery.AutoGuardLevel) {
 	if c == nil || c.executor == nil {
 		return
 	}
 	gate := recovery.NewGate(recovery.Options{
 		Headless: headless,
+		Level:    level,
 		Mode: func() string {
 			return c.ToolApprovalMode()
 		},

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1736,6 +1736,14 @@ func bashSegmentIsVerification(fields []string) bool {
 			return true
 		}
 		return len(args) > 1 && args[0] == "run" && hasCommandArg(args[1:2], "test", "check", "lint", "typecheck")
+	case "npx":
+		// npx runs packages directly; known test/lint/check tools are verification.
+		if len(args) > 0 && hasCommandArg(args[:1],
+			"vitest", "playwright", "jest", "mocha", "ava", "cypress",
+			"eslint", "prettier", "biome", "tsc") {
+			return !hasWriteOutputFlag(args)
+		}
+		return false
 	case "node":
 		return nodeSegmentIsVerification(args)
 	case "make", "just":

--- a/internal/recovery/budget.go
+++ b/internal/recovery/budget.go
@@ -1,5 +1,22 @@
 package recovery
 
+// AutoGuardLevel controls how aggressively Auto Guard blocks and escalates.
+// It is configured per-controller and persisted as a user preference.
+type AutoGuardLevel string
+
+const (
+	// AutoGuardGentle only blocks deterministic high-risk operations (rm, sudo,
+	// chmod, etc.) and never escalates to Episode stop. Safe for vibecoding
+	// users who work inside their workspace.
+	AutoGuardGentle AutoGuardLevel = "gentle"
+	// AutoGuardNormal (default) blocks repeated failures, reviewer rejects, and
+	// stopped-op retries with the host-defined budgets.
+	AutoGuardNormal AutoGuardLevel = "normal"
+	// AutoGuardStrict tightens budgets and adds additional checks for sensitive
+	// operations. Suitable for shared or regulated environments.
+	AutoGuardStrict AutoGuardLevel = "strict"
+)
+
 // Fixed product defaults for Auto recovery budgets. These are not configurable
 // via UI, CLI, or config files — they define the host-owned Auto safety envelope.
 const (
@@ -17,6 +34,10 @@ const (
 	// MaxStoppedOperationRetries is how many times an already-stopped operation
 	// may be re-proposed before the turn escalates to a hard Episode stop.
 	MaxStoppedOperationRetries = 3
+	// MaxGentleOperationFailures is the per-operation failure limit in gentle
+	// mode before the operation is blocked. Higher than normal mode to give
+	// vibecoding users more runway before intervention.
+	MaxGentleOperationFailures = 5
 )
 
 // StopReason identifies why an Episode-level stop was raised. Values are

--- a/internal/recovery/gate.go
+++ b/internal/recovery/gate.go
@@ -35,6 +35,9 @@ type Options struct {
 	// Headless, when true, never waits for a human: blocks the mutation with a
 	// structured blocker message instead.
 	Headless bool
+	// Level controls how aggressively Auto Guard escalates. Defaults to
+	// AutoGuardNormal when empty.
+	Level AutoGuardLevel
 	// PersistenceKey is sampled synchronously when a state change is scheduled.
 	// Persist receives that captured key so an asynchronous write cannot follow
 	// a later session switch and land in the wrong sidecar.
@@ -123,6 +126,9 @@ func NewGate(opts Options) *Gate {
 		generation:     1,
 		persistPending: map[string]int{},
 		persistDone:    map[string]uint64{},
+	}
+	if opts.Level == "" {
+		opts.Level = AutoGuardNormal
 	}
 	g.persistCond = sync.NewCond(&g.persistMu)
 	return g
@@ -513,6 +519,14 @@ func (g *Gate) Resolve(id string, action Action, feedback string) error {
 		if strings.TrimSpace(feedback) == "" {
 			feedback = DefaultReviseFeedback
 		}
+	case ActionOverride:
+		// Override clears the episode stop and resets all failure counts so
+		// Auto can continue without switching modes. Task grants are preserved.
+		rotateEpisode = true
+		g.metrics.HumanRevises++
+		if strings.TrimSpace(feedback) == "" {
+			feedback = "User overrode the Auto Guard stop. Continue with the task."
+		}
 	default:
 		g.mu.Unlock()
 		return fmt.Errorf("unknown recovery action %q", action)
@@ -605,7 +619,9 @@ func (g *Gate) ObserveResult(_ context.Context, obs Observation) string {
 		st.markOperationStopped(fp)
 		g.metrics.OperationStops++
 	}
-	if g.episode.totalFailures >= MaxEpisodeFailures {
+	// Episode-level stop is disabled in gentle mode so users never hit a
+	// hard dead-end. Per-operation limits still apply through BeforeMutation.
+	if g.opts.Level != AutoGuardGentle && g.episode.totalFailures >= MaxEpisodeFailures {
 		g.episode.stopped = true
 		g.episode.stopReason = StopReasonEpisodeFailures
 		g.metrics.EpisodeFailureStops++
@@ -641,6 +657,13 @@ func (g *Gate) ObserveResult(_ context.Context, obs Observation) string {
 func (g *Gate) BeforeMutation(ctx context.Context, proposal Proposal) (Decision, error) {
 	if g == nil {
 		return Decision{Allow: true}, nil
+	}
+
+	// Gentle mode: only intervene for deterministic high-risk operations that
+	// have already failed. Never escalate to Episode stop. Ordinary workspace
+	// commands (including test runners, build tools, package managers) run freely.
+	if g.opts.Level == AutoGuardGentle {
+		return g.beforeMutationGentle(ctx, proposal)
 	}
 
 	// Host-proven read-only diagnostics always continue unless the Episode is
@@ -692,6 +715,54 @@ func (g *Gate) BeforeMutation(ctx context.Context, proposal Proposal) (Decision,
 	default:
 		return Decision{Allow: true, Generation: gen}, nil
 	}
+}
+
+// beforeMutationGentle implements the gentle Auto Guard policy.
+// It only blocks deterministic high-risk operations (rm, sudo, chmod, etc.) after
+// repeated failures of the same exact operation. Ordinary workspace commands and
+// first-time high-risk attempts are allowed through. Episode stop is never used.
+func (g *Gate) beforeMutationGentle(ctx context.Context, proposal Proposal) (Decision, error) {
+	if !g.activeMode() {
+		return Decision{Allow: true}, nil
+	}
+	// Non-mutating diagnostic reads always continue.
+	if proposal.ReadOnly && !proposal.Mutates {
+		return Decision{Allow: true}, nil
+	}
+	if !proposal.Mutates && !proposal.Verification {
+		return Decision{Allow: true}, nil
+	}
+	// Only classify high-risk for gentle mode — the allowlist check is skipped
+	// so ordinary workspace commands flow freely.
+	boundary := riskBoundaryForProposal(proposal)
+	isHighRisk := boundary.highRisk
+	if !isHighRisk {
+		return Decision{Allow: true}, nil
+	}
+
+	taskID := normalizeTaskID(proposal.TaskID)
+	fp := CallFingerprint(proposal.Tool, proposal.Subject, proposal.Preview, proposal.Args)
+
+	g.mu.Lock()
+	gen := g.generation
+	st := g.tasks[taskID]
+	count := uint8(0)
+	if st != nil {
+		count = st.operationFailures[fp]
+	}
+	g.mu.Unlock()
+
+	// Gentle: allow up to MaxGentleOperationFailures attempts before blocking.
+	if count < MaxGentleOperationFailures {
+		return Decision{Allow: true, Generation: gen}, nil
+	}
+	return Decision{
+		Allow:      false,
+		Blocked:    true,
+		Message:    fmt.Sprintf("Auto Guard (gentle) blocked this operation after %d repeated failures: %s. Try a different approach or switch to Ask mode for manual control.", count, proposal.Tool),
+		Generation: gen,
+		StopReason: string(StopReasonOperationFailures),
+	}, nil
 }
 
 func (g *Gate) noteStoppedOpRetry(taskID, _ string, gen uint64, proposal Proposal) (Decision, bool) {
@@ -1155,6 +1226,14 @@ func (g *Gate) decisionFromResolve(payload resolvePayload) (Decision, error) {
 		}
 		msg += ": " + feedback
 		return Decision{Allow: false, Blocked: true, Message: msg}, nil
+	case ActionOverride:
+		// Override lets the user clear the stop and continue. The episode was
+		// already rotated by Resolve; return allow so the next proposal passes.
+		msg := "Auto Guard override accepted. Continuing with the task."
+		if f := strings.TrimSpace(payload.feedback); f != "" {
+			msg += " Note: " + f
+		}
+		return Decision{Allow: true, Message: msg}, nil
 	default:
 		return Decision{Allow: false, Blocked: true, Message: "blocked: unknown Auto Guard action"}, nil
 	}

--- a/internal/recovery/rules.go
+++ b/internal/recovery/rules.go
@@ -591,6 +591,11 @@ func commandFieldsKnownSafeMutation(fields []string) bool {
 		return containsAny(args, "install", "add", "remove", "update", "dedupe", "import") && !hasGlobalFlag(args)
 	case "yarn":
 		return containsAny(args, "install", "add", "remove", "up", "upgrade", "dedupe") && !hasGlobalFlag(args) && !containsAny(args, "global")
+	case "npx":
+		// npx executes packages in the project scope; the ordinary permission/sandbox
+		// layer handles path confinement. Allow by default so common dev commands
+		// (npx vitest, npx eslint, npx prettier) aren't blocked as high-risk.
+		return true
 	case "go":
 		return containsAny(args, "get", "mod", "work", "fmt", "build", "test") && !containsAny(args, "install", "clean")
 	case "cargo":

--- a/internal/recovery/types.go
+++ b/internal/recovery/types.go
@@ -214,6 +214,7 @@ const (
 	ActionContinue     = agent.RecoveryActionContinue
 	ActionContinueTask = agent.RecoveryActionContinueTask
 	ActionRevise       = agent.RecoveryActionRevise
+	ActionOverride     = agent.RecoveryActionOverride
 )
 
 // DefaultReviseFeedback is injected when the user chooses "try another approach"


### PR DESCRIPTION
… override / Auto Guard 增加柔和模式、npx 识别和用户撤销

- Add AutoGuardLevel config (gentle/normal/strict) with gentle mode that only blocks deterministic high-risk ops (rm/sudo/chmod) after 5 retries and never escalates to Episode stop. Fixes #6844 #6876.
- Add npx to bashSegmentIsVerification (vitest/playwright/jest/eslint etc.) and commandFieldsKnownSafeMutation so test/build commands are not misclassified as destructive. Fixes #6834.
- Add RecoveryActionOverride so users can clear an episode stop and reset failure counts without switching modes. Fixes #6886.
- Remove tsx/ts-node from npx verification list (execution engines, not test runners).

Closes: #6834 #6876 #6844 #6886

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
