### PR TITLE
fix(desktop): keep provider retries cancellable / 保持桌面端重试可停止

### DIFF
--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -7,9 +7,10 @@
 //    panel keeps refreshing during sub-agent runs.
 // 3. A mid-turn context snapshot reporting used=0 does not collapse a gauge
 //    that already shows real usage.
-// 4. A retry event repairs a stale idle snapshot so the turn remains stoppable.
+// 4. A retry event repairs stale idle snapshots in either delivery order so
+//    the turn remains stoppable.
 
-import { initialState, reducer } from "../lib/useController";
+import { initialState, promptEventClock, reducer } from "../lib/useController";
 import type { WireEvent } from "../lib/types";
 
 let passed = 0;
@@ -147,9 +148,38 @@ function ev(s: typeof initialState, e: WireEvent) {
   eq(s.cancellable, true, "retry event keeps Stop and Escape cancellation available");
   eq(s.turnStartAt > 0, true, "retry event restores timing for a reattached turn");
 
-  s = ev(s, { kind: "turn_done" } as WireEvent);
-  eq(s.running, false, "turn_done still ends the repaired turn");
-  eq(s.retry, undefined, "turn_done clears the retry indicator");
+  const repaired = s;
+  const completed = ev(repaired, { kind: "turn_done" } as WireEvent);
+  eq(completed.running, false, "turn_done still ends the repaired turn");
+  eq(completed.retry, undefined, "turn_done clears the retry indicator");
+
+  const staleSnapshotAt = promptEventClock();
+  s = ev(repaired, { kind: "retrying", retryAttempt: 4, retryMax: 10 } as WireEvent);
+  s = reducer(s, {
+    type: "backend_status",
+    running: false,
+    pendingPrompt: false,
+    backgroundJobs: 0,
+    cancelRequested: false,
+    cancellable: false,
+    snapshotAt: staleSnapshotAt,
+  });
+  eq(s.running, true, "idle snapshot fetched before retry cannot hide Stop when it returns later");
+  eq(s.turnActive, true, "idle snapshot fetched before retry cannot end the active turn");
+  eq(s.cancellable, true, "idle snapshot fetched before retry preserves cancellation");
+  eq(s.retry?.attempt, 4, "stale idle snapshot preserves the newer retry status");
+
+  s = reducer(s, {
+    type: "backend_status",
+    running: false,
+    pendingPrompt: false,
+    backgroundJobs: 0,
+    cancelRequested: false,
+    cancellable: false,
+    snapshotAt: Number.MAX_SAFE_INTEGER,
+  });
+  eq(s.running, false, "fresh idle snapshot can reconcile a missed turn_done");
+  eq(s.retry, undefined, "fresh idle snapshot clears the retry indicator");
 }
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -7,6 +7,7 @@
 //    panel keeps refreshing during sub-agent runs.
 // 3. A mid-turn context snapshot reporting used=0 does not collapse a gauge
 //    that already shows real usage.
+// 4. A retry event repairs a stale idle snapshot so the turn remains stoppable.
 
 import { initialState, reducer } from "../lib/useController";
 import type { WireEvent } from "../lib/types";
@@ -123,6 +124,32 @@ function ev(s: typeof initialState, e: WireEvent) {
   let idle = { ...initialState, context: { used: 14000, window: 1000000, sessionTokens: 20000 } };
   idle = reducer(idle, { type: "context", context: { used: 0, window: 1000000, sessionTokens: 0 } } as never);
   eq(idle.context.used, 0, "idle used=0 snapshot applies (genuine reset)");
+}
+
+// --- 4. retrying is authoritative foreground activity ---
+{
+  let s = ev({ ...initialState }, { kind: "turn_started" } as WireEvent);
+  s = reducer(s, {
+    type: "backend_status",
+    running: false,
+    pendingPrompt: false,
+    backgroundJobs: 0,
+    cancelRequested: false,
+    cancellable: false,
+  });
+  eq(s.running, false, "stale idle snapshot reproduces the hidden-stop state");
+
+  s = ev(s, { kind: "retrying", retryAttempt: 3, retryMax: 10 } as WireEvent);
+  eq(s.retry?.attempt, 3, "retry status keeps the current attempt");
+  eq(s.retry?.max, 10, "retry status keeps the retry budget");
+  eq(s.running, true, "retry event restores the active turn");
+  eq(s.turnActive, true, "retry event restores the turn epoch");
+  eq(s.cancellable, true, "retry event keeps Stop and Escape cancellation available");
+  eq(s.turnStartAt > 0, true, "retry event restores timing for a reattached turn");
+
+  s = ev(s, { kind: "turn_done" } as WireEvent);
+  eq(s.running, false, "turn_done still ends the repaired turn");
+  eq(s.retry, undefined, "turn_done clears the retry indicator");
 }
 
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -777,7 +777,20 @@ function applyEvent(s: State, e: WireEvent): State {
     s = flushPendingUser(s);
   }
   if (e.kind === "retrying") {
-    return { ...s, retry: { attempt: e.retryAttempt ?? 0, max: e.retryMax ?? 0 } };
+    // Retrying is emitted synchronously from inside the foreground provider
+    // request, immediately before its cancellation-aware backoff. Treat it as
+    // authoritative proof that the turn is still active. An older idle
+    // ListTabs snapshot can otherwise arrive after turn_started, clear
+    // `running`, and leave the composer showing "retrying (n/m)" without its
+    // Stop button (or Escape cancellation) until all retries are exhausted.
+    return {
+      ...s,
+      retry: { attempt: e.retryAttempt ?? 0, max: e.retryMax ?? 0 },
+      running: true,
+      turnActive: true,
+      cancellable: true,
+      turnStartAt: s.turnStartAt || Date.now(),
+    };
   }
   if (s.retry) s = { ...s, retry: undefined };
   switch (e.kind) {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -187,7 +187,7 @@ interface State {
   sessionTokens: number;
   sessionCost: number;
   sessionCurrency: string;
-  retry?: { attempt: number; max: number };
+  retry?: { attempt: number; max: number; observedAt: number };
   seq: number;
   sessionGen: number;
   // Monotonic count of usage events from ANY source (executor, subagent,
@@ -272,6 +272,14 @@ export function runtimeSnapshotPredatesPrompt(
   if (!state || (!state.approval && !state.ask)) return false;
   if (snapshotAt === undefined || state.promptArrivedAt === undefined) return false;
   return snapshotAt <= state.promptArrivedAt;
+}
+
+function runtimeSnapshotPredatesRetry(
+  state: Pick<State, "retry"> | undefined,
+  snapshotAt: number | undefined,
+): boolean {
+  if (snapshotAt === undefined || state?.retry?.observedAt === undefined) return false;
+  return snapshotAt <= state.retry.observedAt;
 }
 
 function updatesContextGauge(usage?: WireUsage): boolean {
@@ -779,13 +787,18 @@ function applyEvent(s: State, e: WireEvent): State {
   if (e.kind === "retrying") {
     // Retrying is emitted synchronously from inside the foreground provider
     // request, immediately before its cancellation-aware backoff. Treat it as
-    // authoritative proof that the turn is still active. An older idle
-    // ListTabs snapshot can otherwise arrive after turn_started, clear
-    // `running`, and leave the composer showing "retrying (n/m)" without its
-    // Stop button (or Escape cancellation) until all retries are exhausted.
+    // authoritative proof that the turn is still active. An idle ListTabs
+    // snapshot fetched before this event can otherwise clear `running`,
+    // regardless of which one reaches the reducer first, and leave the
+    // composer showing "retrying (n/m)" without its Stop button (or Escape
+    // cancellation) until all retries are exhausted.
     return {
       ...s,
-      retry: { attempt: e.retryAttempt ?? 0, max: e.retryMax ?? 0 },
+      retry: {
+        attempt: e.retryAttempt ?? 0,
+        max: e.retryMax ?? 0,
+        observedAt: promptEventClock(),
+      },
       running: true,
       turnActive: true,
       cancellable: true,
@@ -1212,13 +1225,19 @@ export function reducer(s: State, a: Action): State {
       const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
       const cancelRequested = Boolean(a.cancelRequested);
       const foregroundRunning = foregroundRunningFromRuntimeMeta({ running: a.running, pendingPrompt, backgroundJobs, cancellable: a.cancellable });
+      // A retry event is newer evidence of foreground activity than an idle
+      // snapshot whose fetch started earlier. Keep the turn cancellable until
+      // a snapshot started after the retry confirms that it is actually idle.
+      if (!foregroundRunning && runtimeSnapshotPredatesRetry(s, a.snapshotAt)) return s;
       const cancellable = foregroundRunning;
+      const clearsRetry = !foregroundRunning && s.retry !== undefined;
       if (
         foregroundRunning === s.running &&
         pendingPrompt === s.pendingPrompt &&
         backgroundJobs === s.backgroundJobs &&
         cancelRequested === s.cancelRequested &&
-        cancellable === s.cancellable
+        cancellable === s.cancellable &&
+        !clearsRetry
       ) return s;
       if (foregroundRunning) {
         return {
@@ -1251,6 +1270,7 @@ export function reducer(s: State, a: Action): State {
         currentAssistant: undefined,
         approval: undefined,
         ask: undefined,
+        retry: undefined,
       });
     }
     case "meta": {


### PR DESCRIPTION
## Summary

- treat `retrying` as authoritative foreground activity in the Desktop controller reducer
- timestamp retry activity on the same monotonic clock as runtime snapshot fetches
- ignore idle snapshots fetched before the latest retry, regardless of which event reaches the reducer first
- let a genuinely fresh idle snapshot reconcile a missed `turn_done` and clear the retry indicator
- cover both race orderings that could show `Retrying (n/m)` without Stop or Escape cancellation

## Root cause

`ListTabs` snapshots are fetched asynchronously. The original fix repaired the UI when a stale idle snapshot reached the reducer before `retrying`, but the reverse ordering was still possible: an idle fetch could start first, `retrying` could restore the active/cancellable state, and the older idle result could then arrive late and clear it again. Idle reconciliation also retained the retry indicator, which could leave a ghost retry banner after a missed `turn_done`.

## Verification

- `pnpm --dir desktop/frontend exec tsx src/__tests__/use-controller-stream-progress.test.ts` — 41 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/use-controller-cancel-reconcile.test.tsx` — 6 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/pending-prompt-stale-status.test.tsx` — 78 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/use-controller-meta.test.ts` — 130 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-run-strip.test.tsx` — 55 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/tab-switch-hydration.test.tsx` — 75 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/activate-topic-stale.test.tsx` — 6 passed
- `pnpm --dir desktop/frontend test` — full frontend suite passed
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend test:typecheck`
- `pnpm --dir desktop/frontend check:css`
- real-browser check: retry state kept Stop visible and clickable; cancellation restored the composer without console warnings or errors
- `git diff --check`

## Compatibility

| Surface | Old-data / old-version behavior | Conclusion |
| --- | --- | --- |
| Session history and persistence | No format or persistence changes | Backward-safe |
| Wails and wire event contracts | No fields or event shapes changed | Backward-safe |
| Desktop retry handling | The new timestamp is transient frontend state; older snapshots without freshness metadata retain the legacy reconciliation path | Backward-safe behavior fix |

## Cache impact

Cache-impact: none — Desktop-only reducer state; no provider-visible prompt, tool schema/order, memory prefix, compaction, or request serialization changes.
Cache-guard: N/A — no provider-visible bytes changed.
System-prompt-review: N/A
