### PR TITLE
Fix CLI TUI diagnostics and recovery ownership / 修复 CLI TUI 日志与恢复所有权

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -288,8 +288,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 			summaryTagClose,
 	})
 	compacted = append(compacted, msgs[start:]...)
-	a.session.Replace(compacted)
-	a.session.IncrementRewrite()
+	a.session.Rewrite(compacted)
 
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
@@ -332,8 +331,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 		Content: "Summary of the later conversation (compacted from here on):\n" + summary,
 	})
 	next = append(next, localOnly...)
-	a.session.Replace(next)
-	a.session.IncrementRewrite()
+	a.session.Rewrite(next)
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d later messages → summary", len(region))})
 	return nil
@@ -370,8 +368,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	})
 	next = append(next, localOnly...)
 	next = append(next, msgs[toIdx:]...)
-	a.session.Replace(next)
-	a.session.IncrementRewrite()
+	a.session.Rewrite(next)
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d earlier messages → summary", len(region))})
 	return nil

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -110,8 +110,7 @@ func (a *Agent) maintainStaleToolResults(mode toolResultMaintenanceMode) (PruneS
 	if st.Results == 0 {
 		return st, nil
 	}
-	a.session.Replace(next)
-	a.session.IncrementRewrite()
+	a.session.Rewrite(next)
 	return st, nil
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -135,12 +135,25 @@ func (s *Session) UpdateToolCallResolution(call provider.ToolCall) bool {
 	return false
 }
 
-// Replace swaps the whole message log — used by compaction, which rewrites the
-// middle of the history.
+// Replace swaps the whole message log without classifying the change as a
+// persisted-history rewrite. Call Rewrite when a live session changes messages
+// that a mid-turn snapshot may already have written.
 func (s *Session) Replace(msgs []provider.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = msgs
+	s.version++
+}
+
+// Rewrite atomically replaces the message log and marks it as a rewrite. The
+// atomic classification matters when a periodic snapshot races compaction,
+// pruning, or local metadata edits: a later autosave must use owned-rewrite
+// conflict checks instead of mistaking the modified prefix for another writer.
+func (s *Session) Rewrite(msgs []provider.Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Messages = msgs
+	s.rewriteVersion++
 	s.version++
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -97,9 +97,9 @@ type Options struct {
 	// access to extra directories without changing persisted sandbox config.
 	AdditionalDirs []string
 	// Stderr is the writer for diagnostic warnings and plugin subprocess
-	// stderr output. When nil, defaults to os.Stderr. Set to io.Discard
-	// during model switch inside a bubbletea session to prevent any output
-	// from corrupting the TUI's terminal raw mode.
+	// stderr output. When nil, defaults to os.Stderr. Interactive terminal
+	// frontends must provide a private diagnostic writer (or io.Discard) so
+	// background output cannot corrupt the TUI's terminal raw mode.
 	Stderr io.Writer
 	// WorkspaceRoot is the project root directory for config, skills, memory,
 	// commands, hooks, and tool confinement. When empty, the current working

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -248,11 +248,17 @@ type cliBuildOverrides struct {
 	AdditionalDirs       []string
 	WorkspaceRoot        string
 	HeadlessApprovalMode string
+	Stderr               io.Writer
+	OnSessionRecovered   func(control.SessionRecoveryInfo) error
 }
 
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
 	migrateMCPConfigForCLIWorkspace()
-	return boot.Build(ctx, boot.Options{
+	return boot.Build(ctx, cliProfileBuildOptions(modelName, maxStepsOverride, requireKey, sink, profile, overrides))
+}
+
+func cliProfileBuildOptions(modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) boot.Options {
+	return boot.Options{
 		Model:                modelName,
 		MaxSteps:             maxStepsOverride,
 		MaxStepsKey:          "--max-steps",
@@ -265,7 +271,9 @@ func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOv
 		PermissionAllow:      overrides.PermissionAllow,
 		AdditionalDirs:       overrides.AdditionalDirs,
 		HeadlessApprovalMode: overrides.HeadlessApprovalMode,
-	})
+		Stderr:               overrides.Stderr,
+		OnSessionRecovered:   overrides.OnSessionRecovered,
+	}
 }
 
 type cliPermissionMode struct {
@@ -319,24 +327,14 @@ func resolveCLISessionDir() string {
 	return config.SessionDir()
 }
 
-// setupQuietProfile is like setupProfile but suppresses plugin subprocess
-// stderr. Used during model switch inside a bubbletea session to prevent plugin
-// logs from corrupting the TUI's terminal raw mode.
+// setupQuietProfile is like setupProfile but guarantees plugin subprocess
+// stderr stays off the terminal. Interactive callers provide the private TUI
+// diagnostic writer; other callers fall back to io.Discard.
 func setupQuietProfile(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
-	return boot.Build(ctx, boot.Options{
-		Model:           modelName,
-		MaxSteps:        maxStepsOverride,
-		MaxStepsKey:     "--max-steps",
-		RequireKey:      requireKey,
-		Sink:            sink,
-		Stderr:          io.Discard,
-		TokenMode:       profile,
-		SessionDir:      resolveCLISessionDir(),
-		WorkspaceRoot:   overrides.WorkspaceRoot,
-		EffortOverride:  overrides.Effort,
-		PermissionAllow: overrides.PermissionAllow,
-		AdditionalDirs:  overrides.AdditionalDirs,
-	})
+	if overrides.Stderr == nil {
+		overrides.Stderr = io.Discard
+	}
+	return boot.Build(ctx, cliProfileBuildOptions(modelName, maxStepsOverride, requireKey, sink, profile, overrides))
 }
 
 func parseRuntimeProfile(value string) (string, error) {
@@ -966,6 +964,11 @@ func chatREPL(args []string) int {
 		configureCLIThemeWithStyle(cfg.UITheme(), cfg.UIThemeStyle())
 		cliCursorShape = cfg.UICursorShape()
 	}
+	// Bubble Tea owns the terminal from the resume picker through controller
+	// shutdown. Route process logs and plugin stderr to a private, bounded file
+	// for that whole lifetime; user-facing warnings arrive as typed TUI events.
+	diagnostics := startTUIDiagnostics(config.ReasonixHomeDir())
+	defer diagnostics.Close()
 
 	// Decide whether we're starting fresh or resuming. --resume opens an
 	// interactive picker; --continue / -c jumps straight into the newest.
@@ -1045,7 +1048,14 @@ func chatREPL(args []string) int {
 	if strings.TrimSpace(*effort) != "" {
 		effortOverride = effort
 	}
-	overrides := cliBuildOverrides{Effort: effortOverride, PermissionAllow: allowedTools, AdditionalDirs: additionalDirs, WorkspaceRoot: workspaceRoot}
+	overrides := cliBuildOverrides{
+		Effort:             effortOverride,
+		PermissionAllow:    allowedTools,
+		AdditionalDirs:     additionalDirs,
+		WorkspaceRoot:      workspaceRoot,
+		Stderr:             diagnostics.Writer(),
+		OnSessionRecovered: cliSessionRecoveredHandler(leases),
+	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, false, sink, profile, overrides)
 	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
 		// True first run whose default model can't resolve: guide setup, then retry.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -605,7 +605,14 @@ func runAgent(args []string) int {
 	// executor, not just the top-level one. Default/ask and acceptEdits already
 	// keep the default headless gate (ask decisions resolve to allow); only
 	// auto/dontAsk/yolo need the explicit contract.
-	overrides := cliBuildOverrides{Effort: effortOverride, PermissionAllow: allowedTools, AdditionalDirs: additionalDirs, WorkspaceRoot: workspaceRoot, HeadlessApprovalMode: permissions.approval}
+	overrides := cliBuildOverrides{
+		Effort:               effortOverride,
+		PermissionAllow:      allowedTools,
+		AdditionalDirs:       additionalDirs,
+		WorkspaceRoot:        workspaceRoot,
+		HeadlessApprovalMode: permissions.approval,
+		OnSessionRecovered:   cliSessionRecoveredHandler(leases),
+	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, true, sink, profile, overrides)
 	if err != nil {
 		if resultOutput != nil && format != runOutputText {
@@ -810,7 +817,9 @@ func runServe(args []string) int {
 			}
 		}
 	}
-	ctrl, err := setupProfile(ctx, *model, *maxSteps, true, bc, profile, "")
+	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, true, bc, profile, cliBuildOverrides{
+		OnSessionRecovered: cliSessionRecoveredHandler(leases),
+	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1

--- a/internal/cli/session_lease.go
+++ b/internal/cli/session_lease.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -56,6 +58,30 @@ func (m *chatTUI) followSessionLease() {
 	}
 	if err := m.leases.Rebind(m.ctrl.SessionPath()); err != nil {
 		m.notice(sessionLeaseHeldNotice(err))
+	}
+}
+
+// cliSessionRecoveredHandler moves the single-session CLI lease during the
+// controller's recovery commit. The callback runs before Controller changes its
+// session path, closing the unguarded interval that event-driven follow-up
+// calls left after ordinary turn-end and mid-turn autosaves.
+func cliSessionRecoveredHandler(leases *control.SessionLeaseKeeper) func(control.SessionRecoveryInfo) error {
+	return func(info control.SessionRecoveryInfo) error {
+		recoveryPath := strings.TrimSpace(info.RecoveryPath)
+		if leases == nil || recoveryPath == "" {
+			return nil
+		}
+		if err := leases.Rebind(recoveryPath); err != nil {
+			if errors.Is(err, agent.ErrSessionLeaseHeld) {
+				return fmt.Errorf("bind recovery session: %s; %s",
+					control.SessionInUseMessage(err), control.SessionLeaseCloseHint)
+			}
+			// The detailed error can contain a machine-local path. Keep it in
+			// the private TUI diagnostic log and return path-free UI text.
+			slog.Error("cli: bind recovery session lease", "err", err)
+			return fmt.Errorf("bind recovery session: unable to secure recovered transcript")
+		}
+		return nil
 	}
 }
 

--- a/internal/cli/session_lease.go
+++ b/internal/cli/session_lease.go
@@ -1,9 +1,7 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -66,23 +64,7 @@ func (m *chatTUI) followSessionLease() {
 // session path, closing the unguarded interval that event-driven follow-up
 // calls left after ordinary turn-end and mid-turn autosaves.
 func cliSessionRecoveredHandler(leases *control.SessionLeaseKeeper) func(control.SessionRecoveryInfo) error {
-	return func(info control.SessionRecoveryInfo) error {
-		recoveryPath := strings.TrimSpace(info.RecoveryPath)
-		if leases == nil || recoveryPath == "" {
-			return nil
-		}
-		if err := leases.Rebind(recoveryPath); err != nil {
-			if errors.Is(err, agent.ErrSessionLeaseHeld) {
-				return fmt.Errorf("bind recovery session: %s; %s",
-					control.SessionInUseMessage(err), control.SessionLeaseCloseHint)
-			}
-			// The detailed error can contain a machine-local path. Keep it in
-			// the private TUI diagnostic log and return path-free UI text.
-			slog.Error("cli: bind recovery session lease", "err", err)
-			return fmt.Errorf("bind recovery session: unable to secure recovered transcript")
-		}
-		return nil
-	}
+	return leases.HandleSessionRecovered
 }
 
 // copySessionForWriting duplicates the session at src into a fresh session

--- a/internal/cli/switch_recovery_test.go
+++ b/internal/cli/switch_recovery_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -74,6 +75,10 @@ func TestRuntimeSwitchesRejectRunningBackgroundJobs(t *testing.T) {
 // diverged from what path holds on disk, so its next Snapshot hits a conflict
 // and retargets the controller to a recovery branch.
 func divergedSessionController(t *testing.T, dir, path string) *control.Controller {
+	return divergedSessionControllerWithRecovery(t, dir, path, nil)
+}
+
+func divergedSessionControllerWithRecovery(t *testing.T, dir, path string, onRecovered func(control.SessionRecoveryInfo) error) *control.Controller {
 	t.Helper()
 	disk := agent.NewSession("sys prompt")
 	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
@@ -88,11 +93,89 @@ func divergedSessionController(t *testing.T, dir, path string) *control.Controll
 	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
 	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local second"})
 	return control.New(control.Options{
-		Executor:    agent.New(nil, nil, stale, agent.Options{}, event.Discard),
-		SessionDir:  dir,
-		SessionPath: path,
-		Label:       "deepseek-flash",
+		Executor:           agent.New(nil, nil, stale, agent.Options{}, event.Discard),
+		SessionDir:         dir,
+		SessionPath:        path,
+		Label:              "deepseek-flash",
+		OnSessionRecovered: onRecovered,
 	})
+}
+
+func TestSessionRecoveryCallbackMovesLeaseBeforeControllerCommit(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "turn-end-conflict.jsonl")
+	leases := control.NewSessionLeaseKeeper()
+	t.Cleanup(leases.Release)
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("seed original lease: %v", err)
+	}
+	ctrl := divergedSessionControllerWithRecovery(t, dir, originalPath, cliSessionRecoveredHandler(leases))
+	t.Cleanup(ctrl.Close)
+
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	recoveryPath := ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath || !strings.Contains(filepath.Base(recoveryPath), "-recovery-") {
+		t.Fatalf("controller path = %q, want recovery path distinct from %q", recoveryPath, originalPath)
+	}
+	if got, want := leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after recovery callback = %q, want %q", got, want)
+	}
+	if probe, err := agent.TryAcquireSessionLease(originalPath); err != nil {
+		t.Fatalf("original lease was not released after recovery: %v", err)
+	} else {
+		probe.Release()
+	}
+	if probe, err := agent.TryAcquireSessionLease(recoveryPath); !errors.Is(err, agent.ErrSessionLeaseHeld) {
+		if probe != nil {
+			probe.Release()
+		}
+		t.Fatalf("recovery path was not guarded after callback: %v", err)
+	}
+}
+
+func TestSessionRecoveryCallbackFailureKeepsOriginalLeaseAndPath(t *testing.T) {
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "held-recovery-conflict.jsonl")
+	leases := control.NewSessionLeaseKeeper()
+	t.Cleanup(leases.Release)
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("seed original lease: %v", err)
+	}
+	handler := cliSessionRecoveredHandler(leases)
+	var heldRecovery *agent.SessionLease
+	ctrl := divergedSessionControllerWithRecovery(t, dir, originalPath, func(info control.SessionRecoveryInfo) error {
+		var err error
+		heldRecovery, err = agent.TryAcquireSessionLease(info.RecoveryPath)
+		if err != nil {
+			return fmt.Errorf("hold recovery path for test: %w", err)
+		}
+		return handler(info)
+	})
+	t.Cleanup(ctrl.Close)
+	t.Cleanup(func() {
+		if heldRecovery != nil {
+			heldRecovery.Release()
+		}
+	})
+
+	err := ctrl.Snapshot()
+	if err == nil {
+		t.Fatal("Snapshot succeeded while recovery path lease was held")
+	}
+	if strings.Contains(err.Error(), dir) || strings.Contains(err.Error(), filepath.Base(originalPath)) {
+		t.Fatalf("recovery bind error exposed a local path: %q", err)
+	}
+	if !strings.Contains(err.Error(), "session is in use") {
+		t.Fatalf("recovery bind error = %q, want sanitized lease refusal", err)
+	}
+	if got := ctrl.SessionPath(); got != originalPath {
+		t.Fatalf("controller path after failed callback = %q, want original %q", got, originalPath)
+	}
+	if got, want := leases.HeldPath(), agent.CanonicalSessionPath(originalPath); got != want {
+		t.Fatalf("lease after failed callback = %q, want original %q", got, want)
+	}
 }
 
 // TestModelSwitchCarriesRecoveryPathAfterSnapshotConflict is the TUI /model

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	tuiDiagnosticLogLimit     = 4 << 20
+	tuiDiagnosticLogRetention = 7 * 24 * time.Hour
+)
+
+// tuiDiagnostics owns process-level diagnostics while an interactive terminal
+// UI is alive. Bubble Tea owns the terminal screen, so background logs and
+// plugin stderr must go to a private file instead of bypassing its renderer.
+// Failure to create that file degrades to io.Discard: typed event.Notice values
+// still carry user-facing warnings through the TUI.
+type tuiDiagnostics struct {
+	previous *slog.Logger
+	logger   *slog.Logger
+	writer   io.Writer
+	file     *os.File
+	path     string
+	close    sync.Once
+}
+
+func startTUIDiagnostics(reasonixHome string) *tuiDiagnostics {
+	d := &tuiDiagnostics{previous: slog.Default(), writer: io.Discard}
+	if logDir := tuiDiagnosticLogDir(reasonixHome); logDir != "" {
+		if err := os.MkdirAll(logDir, 0o700); err == nil {
+			pruneTUIDiagnosticLogs(logDir, time.Now())
+			if file, err := os.CreateTemp(logDir, "cli-tui-*.log"); err == nil {
+				d.file = file
+				d.path = file.Name()
+				d.writer = &boundedDiagnosticWriter{dst: file, remaining: tuiDiagnosticLogLimit}
+			}
+		}
+	}
+	d.logger = slog.New(slog.NewTextHandler(d.writer, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(d.logger)
+	return d
+}
+
+func (d *tuiDiagnostics) Writer() io.Writer {
+	if d == nil || d.writer == nil {
+		return io.Discard
+	}
+	return d.writer
+}
+
+func (d *tuiDiagnostics) Close() {
+	if d == nil {
+		return
+	}
+	d.close.Do(func() {
+		// Do not overwrite a logger deliberately installed by another owner
+		// after the TUI started.
+		if slog.Default() == d.logger && d.previous != nil {
+			slog.SetDefault(d.previous)
+		}
+		if d.file != nil {
+			_ = d.file.Close()
+		}
+	})
+}
+
+func tuiDiagnosticLogDir(reasonixHome string) string {
+	if strings.TrimSpace(reasonixHome) == "" {
+		return ""
+	}
+	return filepath.Join(reasonixHome, "logs")
+}
+
+func pruneTUIDiagnosticLogs(logDir string, now time.Time) {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return
+	}
+	cutoff := now.Add(-tuiDiagnosticLogRetention)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "cli-tui-") || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(logDir, entry.Name()))
+	}
+}
+
+type boundedDiagnosticWriter struct {
+	mu        sync.Mutex
+	dst       io.Writer
+	remaining int64
+	truncated bool
+}
+
+func (w *boundedDiagnosticWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	total := len(p)
+	if total == 0 || w.dst == nil || w.remaining <= 0 {
+		return total, nil
+	}
+	n := total
+	if int64(n) > w.remaining {
+		n = int(w.remaining)
+	}
+	written, err := w.dst.Write(p[:n])
+	if written > 0 {
+		w.remaining -= int64(written)
+	}
+	if err != nil || written != n {
+		w.remaining = 0
+		return total, nil
+	}
+	if n < total && !w.truncated {
+		w.truncated = true
+		_, _ = io.WriteString(w.dst, "\nreasonix: CLI TUI diagnostic log limit reached; further diagnostics omitted\n")
+		w.remaining = 0
+	}
+	return total, nil
+}

--- a/internal/cli/tui_diagnostics_test.go
+++ b/internal/cli/tui_diagnostics_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestTUIDiagnosticsKeepProcessAndPluginLogsOffTerminal(t *testing.T) {
+	var terminal bytes.Buffer
+	beforeTest := slog.Default()
+	terminalLogger := slog.New(slog.NewTextHandler(&terminal, nil))
+	slog.SetDefault(terminalLogger)
+	t.Cleanup(func() { slog.SetDefault(beforeTest) })
+
+	d := startTUIDiagnostics(t.TempDir())
+	t.Cleanup(d.Close)
+	slog.Warn("controller: snapshot conflict", "path", "private-session.jsonl")
+	fmt.Fprintln(d.Writer(), "plugin diagnostic")
+	if got := terminal.String(); got != "" {
+		t.Fatalf("terminal received diagnostics while TUI owned it: %q", got)
+	}
+
+	logPath := d.path
+	d.Close()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read TUI diagnostic log: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"controller: snapshot conflict", "private-session.jsonl", "plugin diagnostic"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diagnostic log = %q, want %q", got, want)
+		}
+	}
+
+	slog.Warn("after TUI")
+	if got := terminal.String(); !strings.Contains(got, "after TUI") {
+		t.Fatalf("previous logger was not restored after TUI close: %q", got)
+	}
+}
+
+func TestTUIDiagnosticsFallBackToDiscardWithoutLeakingToTerminal(t *testing.T) {
+	var terminal bytes.Buffer
+	beforeTest := slog.Default()
+	terminalLogger := slog.New(slog.NewTextHandler(&terminal, nil))
+	slog.SetDefault(terminalLogger)
+	t.Cleanup(func() { slog.SetDefault(beforeTest) })
+
+	blockedHome := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedHome, []byte("file"), 0o600); err != nil {
+		t.Fatalf("seed blocked home: %v", err)
+	}
+	d := startTUIDiagnostics(blockedHome)
+	defer d.Close()
+
+	slog.Warn("must stay off terminal")
+	fmt.Fprintln(d.Writer(), "plugin must stay off terminal")
+	if got := terminal.String(); got != "" {
+		t.Fatalf("fallback leaked diagnostics to terminal: %q", got)
+	}
+	if d.path != "" {
+		t.Fatalf("fallback diagnostic path = %q, want empty", d.path)
+	}
+}
+
+func TestBoundedDiagnosticWriterStopsAtLimit(t *testing.T) {
+	var dst bytes.Buffer
+	w := &boundedDiagnosticWriter{dst: &dst, remaining: 8}
+	payload := strings.Repeat("x", 32)
+	n, err := io.WriteString(w, payload)
+	if err != nil || n != len(payload) {
+		t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(payload))
+	}
+	if !strings.HasPrefix(dst.String(), strings.Repeat("x", 8)) {
+		t.Fatalf("bounded output = %q, want eight payload bytes first", dst.String())
+	}
+	if !strings.Contains(dst.String(), "diagnostic log limit reached") {
+		t.Fatalf("bounded output = %q, want truncation marker", dst.String())
+	}
+	before := dst.Len()
+	if _, err := io.WriteString(w, "more"); err != nil {
+		t.Fatalf("discard after cap: %v", err)
+	}
+	if dst.Len() != before {
+		t.Fatalf("writer grew after cap: before=%d after=%d", before, dst.Len())
+	}
+}
+
+func TestCLIProfileBuildOptionsPropagateInteractiveOwners(t *testing.T) {
+	var diagnostic bytes.Buffer
+	recovered := false
+	onRecovered := func(control.SessionRecoveryInfo) error {
+		recovered = true
+		return nil
+	}
+	opts := cliProfileBuildOptions("provider/model", 9, false, event.Discard, "delivery", cliBuildOverrides{
+		WorkspaceRoot:        "/workspace",
+		HeadlessApprovalMode: control.ToolApprovalAuto,
+		Stderr:               &diagnostic,
+		OnSessionRecovered:   onRecovered,
+	})
+
+	if opts.Stderr != &diagnostic {
+		t.Fatalf("Stderr = %T, want caller-owned diagnostic writer", opts.Stderr)
+	}
+	if opts.OnSessionRecovered == nil {
+		t.Fatal("OnSessionRecovered was dropped from CLI build options")
+	}
+	if err := opts.OnSessionRecovered(control.SessionRecoveryInfo{RecoveryPath: "recovery.jsonl"}); err != nil {
+		t.Fatalf("OnSessionRecovered: %v", err)
+	}
+	if !recovered {
+		t.Fatal("propagated recovery callback was not invoked")
+	}
+	if opts.HeadlessApprovalMode != control.ToolApprovalAuto {
+		t.Fatalf("HeadlessApprovalMode = %q, want %q", opts.HeadlessApprovalMode, control.ToolApprovalAuto)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -545,6 +545,25 @@ func (c *Controller) SetDisplayRecorder(fn func(content, display string)) {
 	c.displayRecorder = fn
 }
 
+// SetOnSessionRecovered installs the ownership handoff invoked before the
+// controller commits to an automatically created recovery branch. Frontends
+// that acquire their session owner after controller construction (for example
+// reasonix serve) use this before publishing the controller.
+func (c *Controller) SetOnSessionRecovered(fn func(SessionRecoveryInfo) error) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onSessionRecovered = fn
+}
+
+func (c *Controller) sessionRecoveredHandler() func(SessionRecoveryInfo) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.onSessionRecovered
+}
+
 func (c *Controller) recordDisplay(content, display string) {
 	if strings.TrimSpace(display) == "" || content == display {
 		return
@@ -3683,8 +3702,8 @@ func (c *Controller) commitRecoveredSession(originalPath, reason string, info ag
 		Reason:       reason,
 		Meta:         info.Meta,
 	}
-	if c.onSessionRecovered != nil {
-		if err := c.onSessionRecovered(recoveryInfo); err != nil {
+	if onSessionRecovered := c.sessionRecoveredHandler(); onSessionRecovered != nil {
+		if err := onSessionRecovered(recoveryInfo); err != nil {
 			return fmt.Errorf("commit recovered session: %w", err)
 		}
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -605,7 +605,11 @@ func (c *Controller) markEditedForNewUser(startMessages int, original string) {
 		}
 		msgs[i].Edited = true
 		msgs[i].Original = original
-		s.Replace(msgs)
+		// A periodic autosave may already contain this user message without its
+		// local edit metadata. Classify the prefix mutation atomically so the
+		// turn-end save performs an owned rewrite instead of forking a bogus
+		// same-revision recovery branch.
+		s.Rewrite(msgs)
 		return
 	}
 }

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1057,6 +1057,45 @@ func TestSnapshotActivityPersistsOwnedCompactionRewrite(t *testing.T) {
 	}
 }
 
+func TestEditedPromptMetadataAfterMidTurnSnapshotStaysOnOwnedSession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "edited-mid-turn.jsonl")
+
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edited prompt"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "partial"})
+	if err := sess.Save(path); err != nil {
+		t.Fatalf("Save mid-turn transcript: %v", err)
+	}
+	// The model finishes after the periodic snapshot. Turn teardown then adds
+	// local inline-edit metadata to the already-persisted user message.
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "final"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	ctrl := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	ctrl.markEditedForNewUser(1, "original prompt")
+
+	if err := ctrl.SnapshotActivity(); err != nil {
+		t.Fatalf("SnapshotActivity edited turn: %v", err)
+	}
+	if got := ctrl.SessionPath(); got != path {
+		t.Fatalf("edited turn moved to recovery path %q, want owned path %q", got, path)
+	}
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := len(loaded.Messages); got != 4 {
+		t.Fatalf("saved message count = %d, want 4: %+v", got, loaded.Messages)
+	}
+	user := loaded.Messages[1]
+	if !user.Edited || user.Original != "original prompt" || user.Content != "edited prompt" {
+		t.Fatalf("saved edited user metadata = %+v", user)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl")); err != nil || len(matches) != 0 {
+		t.Fatalf("spurious recovery branches = %v err=%v, want none", matches, err)
+	}
+}
+
 func TestRecoveryBranchPersistsLaterOwnedCompactionRewrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/control/session_lease_keeper.go
+++ b/internal/control/session_lease_keeper.go
@@ -3,6 +3,7 @@ package control
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -52,6 +53,29 @@ func (k *SessionLeaseKeeper) Rebind(path string) error {
 	}
 	k.releaseLocked()
 	k.lease = lease
+	return nil
+}
+
+// HandleSessionRecovered moves the single-session frontend lease before a
+// controller commits to a recovery branch. It is suitable for
+// Options.OnSessionRecovered in CLI chat/run/serve surfaces. Rebind acquires the
+// recovery path before releasing the original lease, so a failed handoff keeps
+// the previous session protected.
+func (k *SessionLeaseKeeper) HandleSessionRecovered(info SessionRecoveryInfo) error {
+	recoveryPath := strings.TrimSpace(info.RecoveryPath)
+	if k == nil || recoveryPath == "" {
+		return nil
+	}
+	if err := k.Rebind(recoveryPath); err != nil {
+		if errors.Is(err, agent.ErrSessionLeaseHeld) {
+			return fmt.Errorf("bind recovery session: %s; %s",
+				SessionInUseMessage(err), SessionLeaseCloseHint)
+		}
+		// The detailed error can contain a machine-local path. Keep it in
+		// diagnostics and return path-free text to every frontend.
+		slog.Error("control: bind recovery session lease", "err", err)
+		return fmt.Errorf("bind recovery session: unable to secure recovered transcript")
+	}
 	return nil
 }
 

--- a/internal/guardian/guardian.go
+++ b/internal/guardian/guardian.go
@@ -344,8 +344,7 @@ func (gs *Session) normalizeAlternation() {
 	if !merged {
 		return
 	}
-	gs.sess.Replace(out)
-	gs.sess.IncrementRewrite()
+	gs.sess.Rewrite(out)
 }
 
 // Load replaces the guardian's internal agent session with the one at path,

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -95,6 +95,16 @@ func (s *Server) ctl() control.SessionAPI {
 // Call it before serving; a nil keeper leaves lease gating off.
 func (s *Server) SetSessionLeases(k *control.SessionLeaseKeeper) {
 	s.leases = k
+	if ctrl, ok := s.ctl().(*control.Controller); ok {
+		ctrl.SetOnSessionRecovered(sessionLeaseRecoveryHandler(k))
+	}
+}
+
+func sessionLeaseRecoveryHandler(k *control.SessionLeaseKeeper) func(control.SessionRecoveryInfo) error {
+	if k == nil {
+		return nil
+	}
+	return k.HandleSessionRecovered
 }
 
 // rebindSessionLease moves the server's session lease to path. A nil keeper
@@ -228,6 +238,20 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 		}
 	}
 
+	// Acquire the replacement controller's actual post-snapshot path before
+	// publishing it. Its initial snapshot can itself recover onto a new branch;
+	// binding the pre-snapshot newPath would leave that branch unguarded.
+	activePath := newCtrl.SessionPath()
+	if err := s.rebindSessionLease(activePath); err != nil {
+		newCtrl.Close()
+		if errors.Is(err, agent.ErrSessionLeaseHeld) {
+			return fmt.Errorf("switch model: %s", sessionInUseError(err))
+		}
+		slog.Error("serve: bind replacement session lease", "err", err)
+		return fmt.Errorf("switch model: unable to secure replacement session")
+	}
+	newCtrl.SetOnSessionRecovered(sessionLeaseRecoveryHandler(s.leases))
+
 	// Publish the swap under a short write lock. bindMu already serializes
 	// switches — today the only writer of s.ctrl — so the identity re-check is
 	// defensive: it keeps a future controller-swapping path (or a test doing so)
@@ -236,20 +260,16 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.mu.Lock()
 	if s.ctrl != cur {
 		s.mu.Unlock()
+		if restoreErr := s.rebindSessionLease(cur.SessionPath()); restoreErr != nil {
+			newCtrl.Close()
+			slog.Error("serve: restore outgoing session lease after aborted model switch", "err", restoreErr)
+			return fmt.Errorf("switch model: session changed during switch; unable to restore outgoing session ownership")
+		}
 		newCtrl.Close()
 		return fmt.Errorf("switch model: session changed during switch")
 	}
 	s.ctrl = newCtrl
 	s.mu.Unlock()
-
-	// The lease follows the active session file. Rebind is a no-op for the
-	// common carried case (newPath == held path); it moves when a previously
-	// file-less session got a fresh path here, or when the pre-switch snapshot
-	// recovered onto a recovery branch. Both targets are fresh files created
-	// by this process, so failure is theoretical.
-	if err := s.rebindSessionLease(newPath); err != nil {
-		slog.Warn("serve: session lease after model switch", "err", err)
-	}
 
 	// Off-lock: tear down the old controller. Close can block up to 15s.
 	cur.Close()

--- a/internal/serve/switch_recovery_test.go
+++ b/internal/serve/switch_recovery_test.go
@@ -62,6 +62,12 @@ func TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
 		Sink:        bc,
 	})
 	s := &Server{ctrl: old, bc: bc}
+	leases := control.NewSessionLeaseKeeper()
+	t.Cleanup(leases.Release)
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("seed original lease: %v", err)
+	}
+	s.SetSessionLeases(leases)
 
 	var built *control.Controller
 	s.buildController = func(_ context.Context, _ string) (*control.Controller, error) {
@@ -85,6 +91,9 @@ func TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
 	if s.ctl() != built {
 		t.Fatal("switchModel did not publish the rebuilt controller")
 	}
+	if got, want := leases.HeldPath(), agent.CanonicalSessionPath(recoveryPath); got != want {
+		t.Fatalf("lease after pre-switch recovery = %q, want %q", got, want)
+	}
 
 	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
 	if err != nil {
@@ -107,6 +116,29 @@ func TestSwitchModelContinuesRecoveryPathAfterSnapshotConflict(t *testing.T) {
 	matches = primarySessionFiles(matches)
 	if len(matches) != 1 || matches[0] != recoveryPath {
 		t.Fatalf("recovery branches after follow-up snapshot = %v, want only %q", matches, recoveryPath)
+	}
+
+	// A later ordinary autosave on the rebuilt controller must use the same
+	// ownership callback. Force another divergence after the switch and verify
+	// the keeper follows the second recovery before the controller commits it.
+	diskAfterSwitch, err := agent.LoadSession(recoveryPath)
+	if err != nil {
+		t.Fatalf("load recovery transcript for external change: %v", err)
+	}
+	diskAfterSwitch.Add(provider.Message{Role: provider.RoleUser, Content: "disk third"})
+	if err := diskAfterSwitch.Save(recoveryPath); err != nil {
+		t.Fatalf("save external recovery transcript change: %v", err)
+	}
+	built.Executor().Session().Add(provider.Message{Role: provider.RoleUser, Content: "local third"})
+	if err := built.Snapshot(); err != nil {
+		t.Fatalf("Snapshot rebuilt controller after divergence: %v", err)
+	}
+	secondRecoveryPath := built.SessionPath()
+	if secondRecoveryPath == recoveryPath || !strings.Contains(filepath.Base(secondRecoveryPath), "-recovery-") {
+		t.Fatalf("rebuilt controller path = %q, want recovery path distinct from %q", secondRecoveryPath, recoveryPath)
+	}
+	if got, want := leases.HeldPath(), agent.CanonicalSessionPath(secondRecoveryPath); got != want {
+		t.Fatalf("lease after rebuilt-controller recovery = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Keep process-level structured logs and plugin stderr out of Bubble Tea's terminal renderer by routing interactive diagnostics to a private, bounded, short-retention log.
- Move the CLI session lease inside `OnSessionRecovered`, before the controller commits a recovery path, and preserve that ownership callback across runtime rebuilds.
- Classify in-place session history mutations atomically so compaction, pruning, guardian normalization, and edited-message metadata cannot create false same-revision snapshot conflicts after an autosave.
- Add regression coverage for terminal isolation, diagnostic fallback and limits, boot option propagation, recovery lease migration and failure atomicity, and post-autosave edited-message persistence.

## Verification

- `go test -race ./internal/cli ./internal/control ./internal/agent ./internal/guardian`
- `env -u DEEPSEEK_API_KEY go test ./...`
- `go build ./cmd/reasonix`
- Windows amd64 test-binary cross-compile (`PE32+ executable (console) x86-64`)

The first full test run reached the opt-in real DeepSeek cache probe and received HTTP 401 from a configured credential. With that external credential unset, the complete deterministic suite passed.

## Compatibility

| Surface | Existing data behavior | Conclusion |
| --- | --- | --- |
| Session JSONL and sidecars | No fields, enum values, or identifiers changed; existing histories use the same serialization | Backward compatible |
| User configuration | No setting or schema change; log routing is automatic | Backward compatible |
| Provider-visible requests | Prompt text, tool schemas, ordering, and serialized provider messages are unchanged | No cache-shape change |
| Cross-version sessions | Recovery output remains in the existing session format and is readable by older releases | Backward compatible |

## Cache impact

Cache-impact: none — the change is limited to host-side diagnostics, session lease ownership, and persistence classification.
Cache-guard: N/A — no provider-visible prompt, tool schema, ordering, or request serialization changed.
System-prompt-review: Self-reviewed — `internal/boot/boot.go` only clarifies the host-side diagnostic writer contract; no system-prompt text, prompt assembly, tool schema, ordering, or provider payload changes.
