### PR TITLE
Fix sensitive data exposure in error logs / 修复错误日志敏感信息泄露

### DIFF
--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -23,6 +23,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/secrets"
 )
 
 // ── Data model ──────────────────────────────────────────────────────────────
@@ -310,7 +311,7 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		tabMeta, err = e.app.openGlobalTabInactive(topicID)
 	}
 	if err != nil {
-		log.Printf("[heartbeat] OpenTab(%q): %v", t.Title, err)
+		log.Printf("[heartbeat] OpenTab(%q): %s", t.Title, secrets.RedactError(err))
 		t.LastRunAt = time.Now().UnixMilli()
 		return t
 	}

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -17,6 +17,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/secrets"
 )
 
 // GatewayConfig 是 BotGateway 的配置。
@@ -2208,7 +2209,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		ApprovalTimeout: gw.approvalTimeout(),
 	})
 	if err != nil {
-		gw.logger.Error("build controller failed", "err", err)
+		gw.logger.Error("build controller failed", "err", secrets.RedactError(err))
 		return nil
 	}
 	leases := control.NewSessionLeaseKeeper()

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -113,52 +113,12 @@ func providerContentSafetyMessage(e *provider.APIError) string {
 	}
 }
 
-// Auth failure bodies are where servers echo credentials: providers include a
-// masked tail ("Your api key: ****ae54 is invalid") and a sloppy relay can
-// reflect the full key it received. Both narrow or reveal the key, and the
-// displayed turn error can travel further than the user's terminal (bot
-// forwarding, shared screenshots).
-var (
-	// maskedFragmentRe matches a partially masked credential and any visible
-	// prefix/suffix around the stars ("****ae54", "sk-ab****") — including the
-	// head/tail remnants secrets.Redact's own mask leaves behind. For auth
-	// display even the remnant narrows the key, so the whole run collapses.
-	maskedFragmentRe = regexp.MustCompile(`[A-Za-z0-9._-]*\*{2,}[A-Za-z0-9._-]*`)
-	// credContextRe masks any long value that follows a credential word.
-	// secrets.Redact's KEY=value rule only matches API_KEY/APIKEY-style names;
-	// providers write prose forms like "api key: <value>", where the value must
-	// go regardless of its composition.
-	credContextRe = regexp.MustCompile(`(?i)\b(api[ _-]?key|access[ _-]?key|secret|token|authorization|bearer|credential)s?\b(['"]?\s*[:=]?\s*['"]?)([A-Za-z0-9._~+/-]{12,})`)
-	// keyTokenRe matches key-shaped runs for the no-context fallback; a run is
-	// treated as a credential when it carries a digit or mixed case, so
-	// single-case digit-free identifiers like "invalid_authentication_token"
-	// stay readable.
-	keyTokenRe = regexp.MustCompile(`[A-Za-z0-9_-]{16,}`)
-	digitRe    = regexp.MustCompile(`[0-9]`)
-)
-
 // redactAuthReason scrubs key material from an auth-failure reason before
-// display, in layers: secrets.Redact for known key shapes (sk-/rk- prefixes,
-// Bearer, JWT, KEY=value forms), the credential-context rule for prose forms,
-// full collapse of masked fragments, then the key-shaped-token fallback. The
-// residual blind spot is a long single-case digit-free token with no context
-// word — indistinguishable from an identifier. Deliberately applied only to
-// 401/403 bodies: other statuses don't carry credentials, and 400 schema
-// errors legitimately contain long identifiers that this scrub would mangle.
+// display. Deliberately applied only to 401/403 bodies: other statuses don't
+// carry credentials, and 400 schema errors legitimately contain long
+// identifiers that this stronger scrub would mangle.
 func redactAuthReason(s string) string {
-	if s == "" {
-		return s
-	}
-	s = secrets.Redact(s)
-	s = credContextRe.ReplaceAllString(s, "${1}${2}****")
-	s = maskedFragmentRe.ReplaceAllString(s, "****")
-	return keyTokenRe.ReplaceAllStringFunc(s, func(tok string) string {
-		mixedCase := strings.ToLower(tok) != tok && strings.ToUpper(tok) != tok
-		if digitRe.MatchString(tok) || mixedCase {
-			return "****"
-		}
-		return tok
-	})
+	return secrets.RedactCredentials(s)
 }
 
 // providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -27,6 +27,18 @@ var (
 	slackTokenPattern   = regexp.MustCompile(`\b(xox[baprs]-[A-Za-z0-9-]{16,})\b`)
 	awsAccessKeyPattern = regexp.MustCompile(`\b(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b`)
 	jwtPattern          = regexp.MustCompile(`\b(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`)
+	urlUserInfoPattern  = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)([^/\s@]+)@`)
+
+	// maskedCredentialPattern collapses partially masked credentials and any
+	// visible prefix/suffix around the stars ("****ae54", "sk-ab****").
+	maskedCredentialPattern = regexp.MustCompile(`[A-Za-z0-9._-]*\*{2,}[A-Za-z0-9._-]*`)
+	// credentialContextPattern catches prose forms such as
+	// "api key: relaykey..." that are not KEY=value pairs.
+	credentialContextPattern = regexp.MustCompile(`(?i)\b(api[ _-]?key|access[ _-]?key|secret|token|authorization|bearer|credential)s?\b(['"]?\s*[:=]?\s*['"]?)([A-Za-z0-9._~+/-]{12,})`)
+	// credentialTokenPattern is a conservative fallback for opaque key-shaped
+	// runs. Single-case, digit-free identifiers remain readable.
+	credentialTokenPattern = regexp.MustCompile(`[A-Za-z0-9_-]{16,}`)
+	digitPattern           = regexp.MustCompile(`[0-9]`)
 )
 
 const redactedValue = "[redacted]"
@@ -144,6 +156,7 @@ func Redact(s string) string {
 	if s == "" {
 		return s
 	}
+	s = urlUserInfoPattern.ReplaceAllString(s, "$1"+redactedValue+"@")
 	s = redactKeyValues(s)
 	s = cookieHeaderPattern.ReplaceAllStringFunc(s, func(match string) string {
 		parts := cookieHeaderPattern.FindStringSubmatch(match)
@@ -163,6 +176,35 @@ func Redact(s string) string {
 		s = rx.ReplaceAllStringFunc(s, mask)
 	}
 	return s
+}
+
+// RedactCredentials applies the stronger credential scrub used at external
+// error and logging boundaries. In addition to known key shapes, it removes
+// partially masked credentials, prose-form credentials, and opaque tokens that
+// carry a digit or mixed case.
+func RedactCredentials(s string) string {
+	if s == "" {
+		return s
+	}
+	s = Redact(s)
+	s = credentialContextPattern.ReplaceAllString(s, "${1}${2}****")
+	s = maskedCredentialPattern.ReplaceAllString(s, "****")
+	return credentialTokenPattern.ReplaceAllStringFunc(s, func(token string) string {
+		mixedCase := strings.ToLower(token) != token && strings.ToUpper(token) != token
+		if digitPattern.MatchString(token) || mixedCase {
+			return "****"
+		}
+		return token
+	})
+}
+
+// RedactError returns an error string safe for an external log or diagnostic
+// boundary. A nil error produces an empty string.
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return RedactCredentials(err.Error())
 }
 
 func redactKeyValues(s string) string {

--- a/internal/secrets/redact.go
+++ b/internal/secrets/redact.go
@@ -27,7 +27,9 @@ var (
 	slackTokenPattern   = regexp.MustCompile(`\b(xox[baprs]-[A-Za-z0-9-]{16,})\b`)
 	awsAccessKeyPattern = regexp.MustCompile(`\b(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16})\b`)
 	jwtPattern          = regexp.MustCompile(`\b(eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b`)
-	urlUserInfoPattern  = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)([^/\s@]+)@`)
+	// Match through the final @ before a path/whitespace so raw @ characters
+	// inside userinfo cannot leave a password suffix visible.
+	urlUserInfoPattern = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)([^/\s]+)@`)
 
 	// maskedCredentialPattern collapses partially masked credentials and any
 	// visible prefix/suffix around the stars ("****ae54", "sk-ab****").
@@ -263,10 +265,13 @@ func redactKeyValues(s string) string {
 			out.Grow(len(s))
 		}
 		out.WriteString(s[last:valueStart])
+		value := s[valueStart:valueEnd]
 		if authorizationKey(key) {
 			out.WriteString(redactedValue)
+		} else if value == "****" || value == redactedValue {
+			out.WriteString(value)
 		} else {
-			out.WriteString(mask(s[valueStart:valueEnd]))
+			out.WriteString(mask(value))
 		}
 		last = valueEnd
 		sep = valueEnd - 1

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -124,6 +125,83 @@ func TestRedactMasksNonBearerAuthorizationSchemes(t *testing.T) {
 	}
 	if again := Redact(got); again != got {
 		t.Fatalf("authorization redaction not idempotent:\nonce:  %q\ntwice: %q", got, again)
+	}
+}
+
+func TestRedactMasksURLUserInfo(t *testing.T) {
+	in := "proxy request failed: https://proxy-user:proxy-password@proxy.example.com:8443/connect"
+	got := Redact(in)
+	for _, leaked := range []string{"proxy-user", "proxy-password"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("URL credential leaked %q in:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{"https://[redacted]@proxy.example.com:8443/connect", "proxy request failed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted output missing %q:\n%s", want, got)
+		}
+	}
+	if again := Redact(got); again != got {
+		t.Fatalf("URL redaction not idempotent:\nonce:  %q\ntwice: %q", got, again)
+	}
+}
+
+func TestRedactCredentialsForExternalErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		leaked []string
+		want   string
+	}{
+		{
+			name:   "prose api key",
+			err:    errors.New("provider rejected api key: relaykey_abcdefghijklmn"),
+			leaked: []string{"relaykey_abcdefghijklmn"},
+			want:   "provider rejected api key:",
+		},
+		{
+			name:   "partially masked token",
+			err:    errors.New("provider rejected token ****ae54"),
+			leaked: []string{"ae54"},
+			want:   "provider rejected token",
+		},
+		{
+			name:   "bearer token",
+			err:    errors.New("upstream returned Authorization: Bearer abcdef0123456789abcdef"),
+			leaked: []string{"abcdef0123456789abcdef"},
+			want:   "upstream returned",
+		},
+		{
+			name:   "proxy URL user info",
+			err:    errors.New("dial https://proxy-user:proxy-password@proxy.example.com:8443: refused"),
+			leaked: []string{"proxy-user", "proxy-password"},
+			want:   "proxy.example.com:8443",
+		},
+		{
+			name:   "opaque mixed case token",
+			err:    errors.New("credential relayKeyAbcdefghijkl rejected"),
+			leaked: []string{"relayKeyAbcdefghijkl"},
+			want:   "credential",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactError(tt.err)
+			for _, leaked := range tt.leaked {
+				if strings.Contains(got, leaked) {
+					t.Fatalf("credential leaked %q in %q", leaked, got)
+				}
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("diagnostic context missing %q in %q", tt.want, got)
+			}
+			if again := RedactCredentials(got); again != got {
+				t.Fatalf("external error redaction not idempotent:\nonce:  %q\ntwice: %q", got, again)
+			}
+		})
+	}
+	if got := RedactError(nil); got != "" {
+		t.Fatalf("RedactError(nil) = %q, want empty", got)
 	}
 }
 

--- a/internal/secrets/redact_test.go
+++ b/internal/secrets/redact_test.go
@@ -129,9 +129,9 @@ func TestRedactMasksNonBearerAuthorizationSchemes(t *testing.T) {
 }
 
 func TestRedactMasksURLUserInfo(t *testing.T) {
-	in := "proxy request failed: https://proxy-user:proxy-password@proxy.example.com:8443/connect"
+	in := "proxy request failed: https://proxy-user:pa@ss@proxy.example.com:8443/connect"
 	got := Redact(in)
-	for _, leaked := range []string{"proxy-user", "proxy-password"} {
+	for _, leaked := range []string{"proxy-user", "pa", "ss"} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("URL credential leaked %q in:\n%s", leaked, got)
 		}
@@ -173,9 +173,15 @@ func TestRedactCredentialsForExternalErrors(t *testing.T) {
 		},
 		{
 			name:   "proxy URL user info",
-			err:    errors.New("dial https://proxy-user:proxy-password@proxy.example.com:8443: refused"),
-			leaked: []string{"proxy-user", "proxy-password"},
+			err:    errors.New("dial https://proxy-user:pa@ss@proxy.example.com:8443: refused"),
+			leaked: []string{"proxy-user", "pa", "ss"},
 			want:   "proxy.example.com:8443",
+		},
+		{
+			name:   "key value is idempotent",
+			err:    errors.New("provider rejected DEEPSEEK_API_KEY=sk-real-secret-value-123456"),
+			leaked: []string{"sk-real-secret-value-123456"},
+			want:   "provider rejected DEEPSEEK_API_KEY=",
 		},
 		{
 			name:   "opaque mixed case token",


### PR DESCRIPTION
## Summary

- Sanitize errors before writing them from the heartbeat and bot controller failure paths flagged by CodeQL.
- Add shared credential/error redaction helpers for external logging boundaries.
- Mask credentials embedded in URL userinfo, including authenticated proxy URLs.
- Reuse the shared stronger scrub for provider authentication error messages.
- Add regression coverage for prose-form keys, partially masked credentials, bearer tokens, proxy URL credentials, opaque mixed-case tokens, nil errors, and redaction idempotency.

## Problem

CodeQL reported two clear-text logging paths:

- [Alert 267](https://github.com/esengine/DeepSeek-Reasonix/security/code-scanning/267): heartbeat tab-open failures logged raw errors.
- [Alert 266](https://github.com/esengine/DeepSeek-Reasonix/security/code-scanning/266): bot controller build failures logged raw errors.

Runtime errors can include provider credentials, authorization headers, or authenticated proxy URLs. Logging the raw error therefore created a defense-in-depth gap even though the currently observed call paths do not intentionally attach secrets.

## Root cause

The two logging sinks accepted raw `error` values. Reasonix already had a stronger authentication-body scrub, but it was private to the control package and could not be reused at general external logging boundaries. The base redactor also did not recognize URL userinfo.

## Fix

Introduce `secrets.RedactCredentials` and `secrets.RedactError`, move the existing layered authentication scrub into the shared secrets package, add URL-userinfo masking to the base redactor, and route both CodeQL-reported log sinks through `RedactError`.

Diagnostic context such as the operation, host, port, and refusal reason remains visible while credential material is removed.

## Compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Persisted state and sessions | No schema or serialization changes | Backward compatible |
| Wails/frontend contracts | No binding, JSON, or frontend changes | Backward compatible |
| Existing authentication errors | Same layered scrub, now delegated to the shared helper | Behavior preserved |
| Diagnostic/export redaction | Authenticated URL userinfo is now masked; non-credential context remains unchanged | Security hardening only |

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `git diff --check`

All checks passed locally.