### PR TITLE
Validate site and Worker builds before deployment / 在部署前验证站点与 Worker 构建

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,9 @@ jobs:
             .github/workflows/release-desktop.yml
           bash scripts/release-workflows.test.sh
 
-  # The site/ auth client has security-sensitive redirect-validation logic
-  # (safeNext) covered by node:test unit tests. Those tests use only Node
-  # builtins, so no `npm install` is needed — run them directly on every PR so
-  # a regression in redirect validation fails the build instead of shipping.
+  # Cover both the security-sensitive client tests and the same install/build
+  # path used by the Pages deployment. This keeps lockfile and Astro upgrades
+  # from being discovered only after merging to main-v2.
   site:
     runs-on: ubuntu-latest
     defaults:
@@ -285,9 +284,85 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: install
+        run: npm ci
 
       - name: test
         run: npm test
+
+      - name: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build
+
+  worker-pnpm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: accounts
+            directory: workers/accounts
+            lockfile: workers/accounts/pnpm-lock.yaml
+          - name: forum
+            directory: workers/forum
+            lockfile: workers/forum/pnpm-lock.yaml
+    name: worker (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.lockfile }}
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: typecheck
+        run: pnpm typecheck
+
+      - name: deployment dry run
+        run: pnpm exec wrangler deploy --dry-run
+
+  worker-crash-report:
+    name: worker (crash-report)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/crash-report
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: workers/crash-report/package-lock.json
+
+      - name: install
+        run: npm ci
+
+      - name: typecheck
+        run: npm run typecheck
+
+      - name: test
+        run: npm test
+
+      - name: deployment dry run
+        run: npx wrangler deploy --dry-run
 
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-accounts-worker.yml
+++ b/.github/workflows/deploy-accounts-worker.yml
@@ -35,6 +35,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           pnpm install --frozen-lockfile
+          pnpm typecheck
           npx wrangler deploy
       - name: Sync RESEND_API_KEY to the worker
         working-directory: workers/accounts

--- a/.github/workflows/deploy-forum-worker.yml
+++ b/.github/workflows/deploy-forum-worker.yml
@@ -35,4 +35,5 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           pnpm install --frozen-lockfile
+          pnpm typecheck
           npx wrangler deploy


### PR DESCRIPTION
## Summary

- install, test, and production-build the Astro site during pull request CI
- typecheck and dry-run all three Cloudflare Worker projects before merge
- typecheck the accounts and forum Workers before their production deploy commands

## Problem

PR #6922 upgraded the site and Worker toolchains, but the required build paths were not exercised by pull request CI. A broken lockfile, type contract, or Wrangler configuration could first surface after merge while a production deployment was running.

## Root cause

The site CI job only ran dependency-free Node tests. Worker installation, typechecking, tests, and bundling lived only in push-triggered deployment workflows, and the accounts/forum deploy jobs did not run TypeScript checks.

## Fix

- add npm caching, `npm ci`, tests, and `npm run build` to the site job
- add a pnpm matrix for accounts/forum installation, typechecking, and `wrangler deploy --dry-run`
- add a crash-report job for installation, typechecking, tests, and Wrangler dry-run
- run `pnpm typecheck` before real accounts/forum deployments

## Production impact

Pull request dry-runs compile and validate Worker bundles without uploading them. A typecheck failure in a deployment workflow now stops the new deployment before Wrangler runs, leaving the currently deployed Worker unchanged. Runtime code, bindings, configuration, and persisted data are not modified.

## Verification

- actionlint passed for all affected workflow files
- site: fresh `npm ci`, 26 tests, and 25-page Astro production build
- accounts Worker: typecheck and Wrangler dry-run
- forum Worker: typecheck and Wrangler dry-run
- crash-report Worker: typecheck, 42 tests, and Wrangler dry-run
- `git diff --check`

## Compatibility

| Area | Existing behavior/data | Result |
| --- | --- | --- |
| Production site and Workers | Runtime code and configuration unchanged | Backward compatible |
| Persisted state and databases | Not touched | Backward compatible |
| Failed deployment validation | Existing deployment remains active | Safer failure behavior |

Follow-up to #6922.