### PR TITLE
fix(jobs): reject artifact path traversal / 拒绝 artifact 路径穿越

### DIFF
--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -319,10 +319,79 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 	return m.StartForSession("", kind, label, run)
 }
 
+// validatePathSegment rejects values that would let parentSession or kind
+// escape the job temp root via filepath.Join. It is intentionally conservative:
+// it forbids any path-separator character (forward slash, backslash), NUL, and
+// any control character. Empty parentSession is allowed (the unscoped default);
+// kind must be non-empty.
+//
+// See #6932. Before this check existed, a malicious or malformed parentSession
+// such as "../../etc" combined with filepath.Join(tempRoot, parentSession, id)
+// resolved to a directory outside the manager's temp root, allowing the
+// subsequent os.MkdirAll + os.OpenFile to create files at locations controlled
+// by the caller (subject to the running process's filesystem permissions).
+func validatePathSegment(name, field string) error {
+	if field == "kind" && name == "" {
+		return fmt.Errorf("jobs: %s must not be empty", field)
+	}
+	for i, r := range name {
+		switch {
+		case r < 0x20 || r == 0x7f:
+			return fmt.Errorf("jobs: %s contains control character 0x%02x at index %d", field, r, i)
+		case r == '/' || r == '\\':
+			return fmt.Errorf("jobs: %s contains path separator %q at index %d", field, r, i)
+		}
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("jobs: %s is reserved (%q)", field, name)
+	}
+	return nil
+}
+
+// startInvalid registers a job that failed validation BEFORE any goroutine or
+// artifact was created. The job is observable to Wait / list calls as Failed
+// with the validation error recorded in artifactErr, and no run goroutine is
+// started so the manager's wg is unaffected.
+func (m *Manager) startInvalid(parentSession, kind, label string, validationErr error) *Job {
+	finishedAt := nowMs()
+	m.mu.Lock()
+	m.seq++
+	id := fmt.Sprintf("invalid-%d", m.seq)
+	j := &Job{
+		ID:               id,
+		Kind:             kind,
+		Label:            label,
+		SessionID:        parentSession,
+		status:           Failed,
+		startedAt:        finishedAt,
+		activityAt:       finishedAt,
+		finishedAt:       finishedAt,
+		runReturned:      true,
+		cancel:           func() {},
+		done:             make(chan struct{}),
+		artifactComplete: false,
+		artifactErr:      validationErr.Error(),
+	}
+	key := jobKey(parentSession, id)
+	m.jobs[key] = j
+	m.order = append(m.order, key)
+	m.mu.Unlock()
+	close(j.done)
+	m.recordCompletion(parentSession, id, kind, label, Failed, validationErr)
+	return j
+}
+
 // StartForSession launches a job owned by parentSession. Session-scoped readers
 // only see jobs whose owner matches the active session.
 func (m *Manager) StartForSession(parentSession, kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
 	parentSession = strings.TrimSpace(parentSession)
+	kind = strings.TrimSpace(kind)
+	if err := validatePathSegment(parentSession, "parentSession"); err != nil {
+		return m.startInvalid(parentSession, kind, label, err)
+	}
+	if err := validatePathSegment(kind, "kind"); err != nil {
+		return m.startInvalid(parentSession, kind, label, err)
+	}
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -320,7 +320,9 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 }
 
 // validatePathSegment rejects values that would let parentSession or kind
-// escape the job temp root via filepath.Join. It is intentionally conservative:
+// escape the temp-root fallback built by artifactDirLocked. Persistent artifact
+// directories bound by SetActiveSessionPath are trusted store paths and are
+// intentionally outside that temp root. The check is intentionally conservative:
 // it forbids any path-separator character (forward slash, backslash), NUL, and
 // any control character. Empty parentSession is allowed (the unscoped default);
 // kind must be non-empty.

--- a/internal/jobs/jobs_security_test.go
+++ b/internal/jobs/jobs_security_test.go
@@ -1,0 +1,209 @@
+package jobs
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/store"
+)
+
+// TestValidatePathSegment exhaustively covers the segment validator that guards
+// StartForSession against #6932 (path traversal in artifact paths).
+func TestValidatePathSegment(t *testing.T) {
+	cases := []struct {
+		name    string
+		field   string
+		input   string
+		wantErr bool
+	}{
+		// parentSession: empty is the documented unscoped default.
+		{"empty parentSession is allowed", "parentSession", "", false},
+		// kind: empty is rejected because id is built from kind.
+		{"empty kind is rejected", "kind", "", true},
+		// Typical safe values.
+		{"simple lowercase kind", "kind", "task", false},
+		{"hyphenated kind", "kind", "bash-bg", false},
+		{"underscored kind", "kind", "bash_bg", false},
+		{"digits-only kind", "kind", "123", false},
+		{"unicode kind (no separators)", "kind", "任务", false},
+		{"parentSession with timestamp", "parentSession", "20260724-142525abc", false},
+		// Path separators: must reject on any field.
+		{"forward slash", "kind", "task/evil", true},
+		{"back slash", "kind", "task\\evil", true},
+		{"only slash", "parentSession", "/", true},
+		{"only backslash", "parentSession", "\\", true},
+		// Traversal: must reject both `.` and `..` even without separators,
+		// because filepath.Clean treats them as parent references.
+		{"single dot", "kind", ".", true},
+		{"double dot", "kind", "..", true},
+		{"traversal prefix", "parentSession", "..", true},
+		{"parentSession with traversal", "parentSession", "../../etc", true},
+		{"kind with embedded traversal", "kind", "task/../../etc", true},
+		// Control characters and NUL.
+		{"NUL byte", "kind", "task\x00evil", true},
+		{"newline", "kind", "task\nevil", true},
+		{"tab", "kind", "task\tevil", true},
+		{"DEL char", "kind", "task\x7fevil", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePathSegment(tc.input, tc.field)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validatePathSegment(%q, %q) = nil, want error", tc.input, tc.field)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validatePathSegment(%q, %q) = %v, want nil", tc.input, tc.field, err)
+			}
+		})
+	}
+}
+
+// TestStartForSession_RejectsPathTraversalParentSession ensures a malicious
+// parentSession like "../../etc" does not create files outside the manager's
+// temp root. See #6932.
+func TestStartForSession_RejectsPathTraversalParentSession(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	// Snapshot the temp root before; afterwards the directory listing must be
+	// unchanged. This proves no traversal payload created any subdirectory.
+	beforeEntries, err := os.ReadDir(m.tempRoot)
+	if err != nil {
+		t.Fatalf("read temp root before: %v", err)
+	}
+
+	// "../../etc" with a leading traversal walks two parents up from
+	// m.tempRoot and then descends into "etc". The exact resolution does not
+	// matter; what matters is that the validator rejects it before any
+	// mkdir or open happens, anywhere.
+	ran := false
+	j := m.StartForSession("../../etc", "task", "escape attempt", func(_ context.Context, _ io.Writer) (string, error) {
+		ran = true
+		return "", nil
+	})
+	if ran {
+		t.Fatal("run goroutine executed for an invalid parentSession; the fix failed")
+	}
+	if j.status != Failed {
+		t.Fatalf("job status = %q, want %q (artifactErr=%q)", j.status, Failed, j.artifactErr)
+	}
+	if !strings.Contains(j.artifactErr, "parentSession") {
+		t.Fatalf("artifactErr should reference parentSession, got %q", j.artifactErr)
+	}
+	if j.artifactPath != "" {
+		t.Fatalf("artifactPath = %q, want empty (no file should be created)", j.artifactPath)
+	}
+
+	afterEntries, err := os.ReadDir(m.tempRoot)
+	if err != nil {
+		t.Fatalf("read temp root after: %v", err)
+	}
+	if len(afterEntries) != len(beforeEntries) {
+		names := make([]string, 0, len(afterEntries))
+		for _, e := range afterEntries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("temp root gained %d new entries; want no change. New entries: %v", len(afterEntries)-len(beforeEntries), names)
+	}
+}
+
+// TestStartForSession_RejectsPathTraversalKind ensures a malicious kind
+// containing path separators is rejected before any artifact is created.
+// See #6932.
+func TestStartForSession_RejectsPathTraversalKind(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	ran := false
+	j := m.StartForSession("safe-session", "../../../etc", "escape via kind", func(_ context.Context, _ io.Writer) (string, error) {
+		ran = true
+		return "", nil
+	})
+	if ran {
+		t.Fatal("run goroutine executed for an invalid kind; the fix failed")
+	}
+	if j.status != Failed {
+		t.Fatalf("job status = %q, want %q (artifactErr=%q)", j.status, Failed, j.artifactErr)
+	}
+	if !strings.Contains(j.artifactErr, "kind") {
+		t.Fatalf("artifactErr should reference kind, got %q", j.artifactErr)
+	}
+	if j.artifactPath != "" {
+		t.Fatalf("artifactPath = %q, want empty", j.artifactPath)
+	}
+}
+
+// TestStartForSession_AcceptsValidInput is a regression guard: the validator
+// must not break legitimate callers that use typical session ids and kinds.
+func TestStartForSession_AcceptsValidInput(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	ran := false
+	done := make(chan struct{})
+	j := m.StartForSession("session-20260724-142525abc", "task", "normal call", func(_ context.Context, _ io.Writer) (string, error) {
+		ran = true
+		close(done)
+		return "ok", nil
+	})
+	if j.status != Running {
+		t.Fatalf("job status = %q, want Running (artifactErr=%q)", j.status, j.artifactErr)
+	}
+	if j.artifactPath == "" {
+		t.Fatal("artifactPath empty; expected a path under the temp root")
+	}
+	if !strings.HasPrefix(j.artifactPath, m.tempRoot) {
+		t.Fatalf("artifactPath = %q does not start with temp root %q", j.artifactPath, m.tempRoot)
+	}
+
+	// Wait for run to finish and confirm cleanup paths still work.
+	<-done
+	res := m.WaitForSession(context.Background(), "session-20260724-142525abc", []string{j.ID}, 5)
+	if len(res) != 1 {
+		t.Fatalf("WaitForSession returned %d results, want 1", len(res))
+	}
+	if res[0].Output != "ok" {
+		t.Fatalf("run output = %q, want %q", res[0].Output, "ok")
+	}
+	if !ran {
+		t.Fatal("run callback never executed")
+	}
+}
+
+// TestStartForSession_AcceptsSetActiveSessionPathDir guards against a previous
+// regression where a defense-in-depth containment check in openArtifactLocked
+// rejected legitimate artifact directories produced by SetActiveSessionPath.
+// That path resolves to <root>/<id>.jobs (an absolute directory outside the
+// manager's temp root), so a temp-root containment check was a false positive.
+// The fix relies on validatePathSegment rejecting the path-segment components
+// at StartForSession entry, which keeps artifacts inside the temp root for
+// every legal code path. See #6932.
+func TestStartForSession_AcceptsSetActiveSessionPathDir(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "a.jsonl")
+
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session-a", sessionPath)
+
+	j := m.StartForSession("session-a", "bash", "regression", func(_ context.Context, _ io.Writer) (string, error) {
+		return "ok", nil
+	})
+	<-j.done
+	if j.artifactErr != "" {
+		t.Fatalf("artifactErr = %q, want empty (SetActiveSessionPath dir must be accepted)", j.artifactErr)
+	}
+	if j.artifactPath == "" {
+		t.Fatal("artifactPath empty; expected a path under the session dir")
+	}
+	// The log file must live next to the session transcript.
+	wantDir := store.SessionJobsDir(sessionPath)
+	if !strings.HasPrefix(j.artifactPath, wantDir) {
+		t.Fatalf("artifactPath = %q, want prefix %q", j.artifactPath, wantDir)
+	}
+}

--- a/internal/jobs/jobs_security_test.go
+++ b/internal/jobs/jobs_security_test.go
@@ -180,9 +180,9 @@ func TestStartForSession_AcceptsValidInput(t *testing.T) {
 // rejected legitimate artifact directories produced by SetActiveSessionPath.
 // That path resolves to <root>/<id>.jobs (an absolute directory outside the
 // manager's temp root), so a temp-root containment check was a false positive.
-// The fix relies on validatePathSegment rejecting the path-segment components
-// at StartForSession entry, which keeps artifacts inside the temp root for
-// every legal code path. See #6932.
+// validatePathSegment confines only the temp-root fallback; persistent artifact
+// directories come from the trusted transcript path bound by the store layer.
+// See #6932.
 func TestStartForSession_AcceptsSetActiveSessionPathDir(t *testing.T) {
 	root := t.TempDir()
 	sessionPath := filepath.Join(root, "a.jsonl")


### PR DESCRIPTION
Closes #6932.

## Summary / 摘要

`StartForSession` previously passed caller-influenced `parentSession` and `kind` values into artifact paths without validating that they were single path segments. A separator or `..` value could make the temp-root fallback escape `m.tempRoot` before `os.MkdirAll` and `os.OpenFile` ran.

`StartForSession` 之前会把调用方可影响的 `parentSession` 和 `kind` 直接用于 artifact 路径，没有校验它们是否为单一 path segment。路径分隔符或 `..` 值可能让 temp-root fallback 在执行 `os.MkdirAll` / `os.OpenFile` 前逃出 `m.tempRoot`。

## Fix / 修复

- Validate trimmed `parentSession` and `kind` at `StartForSession` entry.
- Reject separators, control characters, `.` / `..`, and an empty `kind`.
- On rejection, register an observable `Failed` job without creating an artifact or starting a goroutine.
- Cover traversal attempts, normal jobs, and persistent sidecar directories with regression tests.

The containment claim is intentionally limited to the temp-root fallback built from `parentSession`. Persistent artifact directories configured by `SetActiveSessionPath` come from trusted store transcript paths and intentionally live outside `m.tempRoot`.

该 containment 结论只适用于由 `parentSession` 构造的 temp-root fallback。`SetActiveSessionPath` 配置的持久化 artifact 目录来自可信 store transcript 路径，本来就位于 `m.tempRoot` 之外。

## Files / 文件

| File | Change |
|:--|:--|
| `internal/jobs/jobs.go` | Add `validatePathSegment` and `startInvalid`; validate before artifact creation or goroutine start. |
| `internal/jobs/jobs_security_test.go` | Add validator, traversal, valid-input, and persistent-sidecar regression coverage. |

## Verification / 验证

- `git diff --check` - passed
- `go test -count=1 ./internal/jobs/...` - passed
- `go test -race -count=1 ./internal/jobs/...` - passed during review
- `go test -count=1 ./...` - passed

## Related follow-up / 相关后续

#6937 adds defense-in-depth syntax validation for trusted transcript paths. It is not a trusted-root containment boundary and is not required to close the caller-influenced `StartForSession` vulnerability fixed here.

#6937 为可信 transcript 路径增加防御性语法校验；它不是 trusted-root containment 边界，也不是关闭本 PR 所修复 `StartForSession` 漏洞的前置条件。

Cache-impact: none - no provider-visible serialization, prompt, tool schema, memory, or model-call path changed.

