### PR TITLE
Harden SignPath stable release gating / 强化 SignPath 稳定版发布门禁

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,15 @@
 # Every pull request requests review from the maintainers below.
 # Either maintainer can review and merge any change.
 * @SivanCola @esengine
+
+# Keep the provider-side signing policy and its GitHub control plane under the
+# same explicit review boundary as the machine-readable contract.
+/.signpath/ @SivanCola @esengine
+/.github/workflows/release-stable.yml @SivanCola @esengine
+/.github/workflows/release-stable-trigger.yml @SivanCola @esengine
+/.github/workflows/release-desktop.yml @SivanCola @esengine
+/.github/workflows/release-desktop-trigger.yml @SivanCola @esengine
+/scripts/complete-signpath-request.ps1 @SivanCola @esengine
+/scripts/package-windows-desktop.sh @SivanCola @esengine
+/scripts/verify-windows-authenticode.ps1 @SivanCola @esengine
+/cmd/signpath-contract/ @SivanCola @esengine

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -36,7 +36,12 @@ on:
         required: false
         type: string
       production_signing_smoke:
-        description: "Sign with the production certificate, verify trust, and do not publish"
+        description: "Wait for external SignPath approval, verify trust, and do not publish"
+        required: false
+        default: false
+        type: boolean
+      signing_preflight:
+        description: "Auto-approve through CI, verify the full signing path, attest it, and do not publish"
         required: false
         default: false
         type: boolean
@@ -66,6 +71,16 @@ on:
         type: string
       orchestrated:
         description: "True only when called by release-stable.yml after approval"
+        required: false
+        default: false
+        type: boolean
+      signing_preflight:
+        description: "Verify both Windows signing stages without publishing"
+        required: false
+        default: false
+        type: boolean
+      signing_preflight_verified:
+        description: "The approved stable caller completed signing_preflight in this run"
         required: false
         default: false
         type: boolean
@@ -106,6 +121,8 @@ jobs:
     name: approve standalone desktop release
     if: ${{ !inputs.orchestrated }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Keep Preview fast, but do not make its public, formally signed binaries an
     # unreviewed path. The `canary` environment must use the same required
     # reviewers as `release`.
@@ -115,11 +132,65 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: echo "Approved standalone desktop release $RELEASE_TAG"
 
-  cache-guard:
-    name: cache hit guard
+  signing-contract:
+    name: validate SignPath release contract
     needs: [orchestration-guard, release-gate]
     if: ${{ always() && !cancelled() && ((inputs.orchestrated && needs.orchestration-guard.result == 'success') || (!inputs.orchestrated && needs.release-gate.result == 'success')) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      fingerprint: ${{ steps.contract.outputs.fingerprint }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Validate the protected control-plane files that GitHub and SignPath
+          # execute, including during recovery of an older candidate.
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Validate signing mode
+        run: |
+          if [ "${{ inputs.production_signing_smoke }}" = "true" ] && [ "${{ inputs.signing_preflight }}" = "true" ]; then
+            echo "::error::production_signing_smoke and signing_preflight are mutually exclusive"
+            exit 1
+          fi
+          if [ "${{ inputs.signing_preflight_verified }}" = "true" ] && [ "${{ inputs.orchestrated }}" != "true" ]; then
+            echo "::error::only the approved stable orchestrator can assert signing_preflight_verified"
+            exit 1
+          fi
+
+      - name: Validate and fingerprint SignPath contract
+        id: contract
+        run: |
+          go run ./cmd/signpath-contract validate
+          fingerprint="$(go run ./cmd/signpath-contract fingerprint)"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Require current standalone signing attestation
+        if: ${{ github.repository == 'esengine/DeepSeek-Reasonix' && !inputs.signing_preflight && !inputs.production_signing_smoke && !(inputs.orchestrated && inputs.signing_preflight_verified) }}
+        env:
+          ACTUAL: ${{ vars.SIGNPATH_RELEASE_SIGNING_ATTESTATION }}
+          EXPECTED: ${{ steps.contract.outputs.fingerprint }}
+        run: |
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::SIGNPATH_RELEASE_SIGNING_ATTESTATION does not match the current protected signing contract"
+            echo "::error::Run release-desktop.yml with signing_preflight=true before publishing"
+            echo "expected=$EXPECTED"
+            exit 1
+          fi
+
+  cache-guard:
+    name: cache hit guard
+    needs: signing-contract
+    if: ${{ always() && !cancelled() && needs.signing-contract.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -144,8 +215,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # One universal macOS build (Intel + Apple Silicon) on a single arm64
-          # runner — avoids the scarce/slow macos-13 Intel runner.
+          # Keep preflight on the same complete native matrix as publication so
+          # it cannot attest a release whose adjacent platform build is broken.
           - { runner: macos-14, platform: darwin/universal, name: darwin-universal }
           - { runner: windows-latest, platform: windows/amd64, name: windows-amd64 }
           - { runner: windows-11-arm, platform: windows/arm64, name: windows-arm64 }
@@ -250,15 +321,9 @@ jobs:
       # may never publish an unsigned payload or installer.
       - name: Require Windows Authenticode signing
         if: runner.os == 'Windows' && github.repository == 'esengine/DeepSeek-Reasonix'
-        env:
-          RELEASE_SIGNING_READY: ${{ vars.SIGNPATH_RELEASE_SIGNING_READY }}
         run: |
           if [ "$HAS_SIGNPATH" != "true" ]; then
             echo "::error::SIGNPATH_API_TOKEN is required for public Windows Preview and Stable releases"
-            exit 1
-          fi
-          if [ "${{ inputs.production_signing_smoke }}" != "true" ] && [ "$RELEASE_SIGNING_READY" != "true" ]; then
-            echo "::error::SIGNPATH_RELEASE_SIGNING_READY must be true before publishing public Windows artifacts"
             exit 1
           fi
 
@@ -278,7 +343,7 @@ jobs:
       # container leaves reasonix-desktop.exe and its sidecars unsigned after
       # installation, which can trigger Defender reputation/ML quarantine.
       - name: Upload unsigned Windows payload for SignPath
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         id: unsigned-windows-payload
         uses: actions/upload-artifact@v7
         with:
@@ -288,7 +353,7 @@ jobs:
           retention-days: 1
 
       - name: Submit Windows payload for Authenticode signing
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         id: submit-windows-payload
         uses: signpath/github-action-submit-signing-request@v2
         with:
@@ -306,7 +371,7 @@ jobs:
       # approved; the dedicated SignPath CI identity records the corresponding
       # request approval without adding another human gate.
       - name: Approve and download signed Windows payload
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         shell: pwsh
         env:
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -321,13 +386,13 @@ jobs:
             -WaitForExternalApproval:$waitForExternalApproval
 
       - name: Rebuild Windows packages from signed payload
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         run: scripts/package-windows-desktop.sh "${{ matrix.platform == 'windows/arm64' && 'arm64' || 'amd64' }}" signed-payload
 
       # The second request signs the rebuilt NSIS container. Release signing
       # also verifies every payload signature against a Windows trusted root.
       - name: Upload unsigned installer for SignPath
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         id: unsigned-installer
         uses: actions/upload-artifact@v7
         with:
@@ -337,7 +402,7 @@ jobs:
           retention-days: 1
 
       - name: Submit installer for Authenticode signing
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         id: submit-windows-installer
         uses: signpath/github-action-submit-signing-request@v2
         with:
@@ -351,7 +416,7 @@ jobs:
           wait-for-completion: false
 
       - name: Approve and download signed Windows installer
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         shell: pwsh
         env:
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -366,11 +431,11 @@ jobs:
             -WaitForExternalApproval:$waitForExternalApproval
 
       - name: Replace installer with signed build
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         run: cp signed-installer/*installer*.exe dist/
 
       - name: Verify Windows Authenticode release contract
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (inputs.production_signing_smoke || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         shell: pwsh
         run: |
           $arch = if ("${{ matrix.platform }}" -eq "windows/arm64") { "arm64" } else { "amd64" }
@@ -396,8 +461,10 @@ jobs:
   publish:
     name: publish release
     needs: build
-    if: ${{ always() && !cancelled() && needs.build.result == 'success' && !inputs.production_signing_smoke }}
+    if: ${{ always() && !cancelled() && needs.build.result == 'success' && !inputs.production_signing_smoke && !inputs.signing_preflight }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # The stable caller has already passed the single GitHub release approval.
     # Direct prereleases, manual stable recovery, and Preview all pass the
     # appropriate release gate. The SignPath CI identity records each payload
@@ -489,6 +556,30 @@ jobs:
           name: preview-dist
           path: dist/*
           if-no-files-found: error
+
+  attest-signing-contract:
+    name: record standalone SignPath attestation
+    needs: [signing-contract, build]
+    if: ${{ always() && !cancelled() && inputs.signing_preflight && !inputs.orchestrated && github.repository == 'esengine/DeepSeek-Reasonix' && needs.signing-contract.result == 'success' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VARIABLE_NAME: SIGNPATH_RELEASE_SIGNING_ATTESTATION
+      VARIABLE_VALUE: ${{ needs.signing-contract.outputs.fingerprint }}
+    steps:
+      - name: Record verified signing contract
+        run: |
+          endpoint="repos/$GITHUB_REPOSITORY/actions/variables/$VARIABLE_NAME"
+          if gh api "$endpoint" >/dev/null 2>&1; then
+            gh api --method PATCH "$endpoint" -f value="$VARIABLE_VALUE" >/dev/null
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/actions/variables" \
+              -f name="$VARIABLE_NAME" -f value="$VARIABLE_VALUE" >/dev/null
+          fi
+          echo "Recorded $VARIABLE_NAME=$VARIABLE_VALUE"
 
   mirror:
     name: mirror to R2

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -5,7 +5,9 @@ run-name: Release stable ${{ inputs.tag || github.ref_name }}
 # npm, and desktop tags atomically; release-stable-trigger.yml relays the vX.Y.Z
 # tag to this workflow on protected main-v2. Preflight verifies that all three
 # tags point to the current main-v2 commit, and one GitHub approval releases
-# every channel. Keeping the control-plane ref on main-v2 lets SignPath restrict
+# every channel. After approval, a zero-publication Windows preflight verifies
+# both architectures and signing stages before any public channel starts.
+# Keeping the control-plane ref on main-v2 lets SignPath restrict
 # production signing to that one protected origin instead of trusting wildcard
 # tag-like branch names. Manual recovery uses the same fixed control plane while
 # preserving an older tagged candidate on main-v2 history.
@@ -128,8 +130,8 @@ jobs:
 
   cli:
     name: publish CLI and Homebrew
-    needs: authorize
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_cli }}
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && (needs.signpath-preflight.result == 'success' || needs.signpath-preflight.result == 'skipped') && (github.event_name != 'workflow_dispatch' || inputs.publish_cli) }}
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.authorize.outputs.cli_tag }}
@@ -140,8 +142,8 @@ jobs:
 
   npm:
     name: publish npm
-    needs: authorize
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_npm }}
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && (needs.signpath-preflight.result == 'success' || needs.signpath-preflight.result == 'skipped') && (github.event_name != 'workflow_dispatch' || inputs.publish_npm) }}
     uses: ./.github/workflows/release-npm.yml
     with:
       channel: stable
@@ -152,8 +154,8 @@ jobs:
       orchestrated: true
     secrets: inherit
 
-  desktop:
-    name: publish desktop
+  signpath-preflight:
+    name: verify stable SignPath control plane
     needs: authorize
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish_desktop }}
     uses: ./.github/workflows/release-desktop.yml
@@ -163,6 +165,21 @@ jobs:
       approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
       approved_sha: ${{ needs.authorize.outputs.sha }}
       orchestrated: true
+      signing_preflight: true
+    secrets: inherit
+
+  desktop:
+    name: publish desktop
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.publish_desktop) }}
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: stable
+      tag: ${{ needs.authorize.outputs.desktop_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      signing_preflight_verified: true
     secrets: inherit
 
   postflight:

--- a/.signpath/contracts/release-signing.yml
+++ b/.signpath/contracts/release-signing.yml
@@ -1,0 +1,20 @@
+version: 1
+project_slug: DeepSeek-Reasonix
+signing_policy_slug: release-signing
+repository_url: https://github.com/esengine/DeepSeek-Reasonix.git
+allowed_branch_names:
+  - main-v2
+allowed_build_definitions:
+  - .github/workflows/release-stable.yml
+  - .github/workflows/release-desktop.yml
+fingerprint_files:
+  - .github/workflows/release-stable.yml
+  - .github/workflows/release-stable-trigger.yml
+  - .github/workflows/release-desktop.yml
+  - .github/workflows/release-desktop-trigger.yml
+  - .signpath/artifact-configurations/windows-payload.xml
+  - .signpath/artifact-configurations/windows-installer-v2.xml
+  - scripts/complete-signpath-request.ps1
+  - scripts/package-windows-desktop.sh
+  - scripts/verify-windows-authenticode.ps1
+  - cmd/signpath-contract/main.go

--- a/cmd/signpath-contract/main.go
+++ b/cmd/signpath-contract/main.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	contractPath = ".signpath/contracts/release-signing.yml"
+	projectSlug  = "DeepSeek-Reasonix"
+	policySlug   = "release-signing"
+	repository   = "https://github.com/esengine/DeepSeek-Reasonix.git"
+)
+
+var expectedBranches = []string{"main-v2"}
+
+type releaseSigningContract struct {
+	Version                 int      `yaml:"version"`
+	ProjectSlug             string   `yaml:"project_slug"`
+	SigningPolicySlug       string   `yaml:"signing_policy_slug"`
+	RepositoryURL           string   `yaml:"repository_url"`
+	AllowedBranchNames      []string `yaml:"allowed_branch_names"`
+	AllowedBuildDefinitions []string `yaml:"allowed_build_definitions"`
+	FingerprintFiles        []string `yaml:"fingerprint_files"`
+}
+
+type workflowInfo struct {
+	externallyTriggered bool
+	directSigning       bool
+	calls               []string
+}
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		fatalf("usage: signpath-contract <validate|fingerprint> [repository-root]")
+	}
+	root := "."
+	if len(os.Args) == 3 {
+		root = os.Args[2]
+	}
+	contract, err := loadAndValidate(root)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	switch os.Args[1] {
+	case "validate":
+		fmt.Println("SignPath release signing contract is valid")
+	case "fingerprint":
+		fingerprint, err := contractFingerprint(root, contract)
+		if err != nil {
+			fatalf("fingerprint contract: %v", err)
+		}
+		fmt.Printf("v1:%x\n", fingerprint)
+	default:
+		fatalf("unknown command %q", os.Args[1])
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "signpath-contract: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func loadAndValidate(root string) (releaseSigningContract, error) {
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(contractPath)))
+	if err != nil {
+		return releaseSigningContract{}, fmt.Errorf("read %s: %w", contractPath, err)
+	}
+	var contract releaseSigningContract
+	if err := yaml.Unmarshal(data, &contract); err != nil {
+		return releaseSigningContract{}, fmt.Errorf("parse %s: %w", contractPath, err)
+	}
+	if err := validateContract(root, contract); err != nil {
+		return releaseSigningContract{}, err
+	}
+	return contract, nil
+}
+
+func validateContract(root string, contract releaseSigningContract) error {
+	if contract.Version != 1 {
+		return fmt.Errorf("%s version is %d, want 1", contractPath, contract.Version)
+	}
+	if contract.ProjectSlug != projectSlug {
+		return fmt.Errorf("project_slug is %q, want %q", contract.ProjectSlug, projectSlug)
+	}
+	if contract.SigningPolicySlug != policySlug {
+		return fmt.Errorf("signing_policy_slug is %q, want %q", contract.SigningPolicySlug, policySlug)
+	}
+	if contract.RepositoryURL != repository {
+		return fmt.Errorf("repository_url is %q, want %q", contract.RepositoryURL, repository)
+	}
+	if err := requireExactSet("allowed_branch_names", contract.AllowedBranchNames, expectedBranches); err != nil {
+		return err
+	}
+	if len(contract.AllowedBuildDefinitions) == 0 {
+		return errors.New("allowed_build_definitions must not be empty")
+	}
+	for _, value := range append(append([]string{}, contract.AllowedBranchNames...), contract.AllowedBuildDefinitions...) {
+		if strings.ContainsAny(value, "*?[") {
+			return fmt.Errorf("SignPath allowlists must not contain wildcard %q", value)
+		}
+	}
+	for _, name := range contract.AllowedBuildDefinitions {
+		if err := validateRepositoryPath(name); err != nil {
+			return fmt.Errorf("invalid allowed build definition %q: %w", name, err)
+		}
+		if !strings.HasPrefix(name, ".github/workflows/") {
+			return fmt.Errorf("allowed build definition %q is outside .github/workflows", name)
+		}
+	}
+	if err := requireUnique("allowed_build_definitions", contract.AllowedBuildDefinitions); err != nil {
+		return err
+	}
+	if len(contract.FingerprintFiles) == 0 {
+		return errors.New("fingerprint_files must not be empty")
+	}
+	seen := make(map[string]bool, len(contract.FingerprintFiles))
+	for _, name := range contract.FingerprintFiles {
+		if err := validateRepositoryPath(name); err != nil {
+			return fmt.Errorf("invalid fingerprint file %q: %w", name, err)
+		}
+		if seen[name] {
+			return fmt.Errorf("duplicate fingerprint file %q", name)
+		}
+		seen[name] = true
+		info, err := os.Stat(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			return fmt.Errorf("fingerprint file %q: %w", name, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("fingerprint file %q is not a regular file", name)
+		}
+	}
+
+	reachable, err := discoverTopLevelSigningWorkflows(root)
+	if err != nil {
+		return err
+	}
+	if err := requireExactSet("top-level workflows that reach SignPath", reachable, contract.AllowedBuildDefinitions); err != nil {
+		return fmt.Errorf("SignPath build-definition drift: %w", err)
+	}
+	return nil
+}
+
+func requireExactSet(name string, got, want []string) error {
+	gotCopy := append([]string(nil), got...)
+	wantCopy := append([]string(nil), want...)
+	sort.Strings(gotCopy)
+	sort.Strings(wantCopy)
+	if len(gotCopy) != len(wantCopy) {
+		return fmt.Errorf("%s is %v, want %v", name, got, want)
+	}
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return fmt.Errorf("%s is %v, want %v", name, got, want)
+		}
+		if i > 0 && gotCopy[i] == gotCopy[i-1] {
+			return fmt.Errorf("%s contains duplicate %q", name, gotCopy[i])
+		}
+	}
+	return nil
+}
+
+func requireUnique(name string, values []string) error {
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if seen[value] {
+			return fmt.Errorf("%s contains duplicate %q", name, value)
+		}
+		seen[value] = true
+	}
+	return nil
+}
+
+func validateRepositoryPath(name string) error {
+	if name == "" || filepath.IsAbs(filepath.FromSlash(name)) {
+		return errors.New("path must be non-empty and repository-relative")
+	}
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return errors.New("path escapes the repository")
+	}
+	if filepath.ToSlash(clean) != name {
+		return errors.New("path must be normalized with forward slashes")
+	}
+	return nil
+}
+
+func discoverTopLevelSigningWorkflows(root string) ([]string, error) {
+	paths, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.y*ml"))
+	if err != nil {
+		return nil, fmt.Errorf("list workflows: %w", err)
+	}
+	workflows := make(map[string]workflowInfo, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read workflow %s: %w", path, err)
+		}
+		name, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+		name = filepath.ToSlash(name)
+		info, err := parseWorkflow(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse workflow %s: %w", name, err)
+		}
+		workflows[name] = info
+	}
+
+	state := make(map[string]uint8, len(workflows))
+	memo := make(map[string]bool, len(workflows))
+	var reachesSigning func(string) (bool, error)
+	reachesSigning = func(name string) (bool, error) {
+		if state[name] == 2 {
+			return memo[name], nil
+		}
+		if state[name] == 1 {
+			return false, fmt.Errorf("reusable workflow cycle includes %s", name)
+		}
+		info, ok := workflows[name]
+		if !ok {
+			return false, fmt.Errorf("workflow calls missing local workflow %s", name)
+		}
+		state[name] = 1
+		reachable := info.directSigning
+		for _, called := range info.calls {
+			calledReachable, err := reachesSigning(called)
+			if err != nil {
+				return false, err
+			}
+			reachable = reachable || calledReachable
+		}
+		state[name] = 2
+		memo[name] = reachable
+		return reachable, nil
+	}
+
+	var result []string
+	for name, info := range workflows {
+		if !info.externallyTriggered {
+			continue
+		}
+		reachable, err := reachesSigning(name)
+		if err != nil {
+			return nil, err
+		}
+		if reachable {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func parseWorkflow(data []byte) (workflowInfo, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return workflowInfo{}, err
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return workflowInfo{}, errors.New("workflow root must be a mapping")
+	}
+	root := document.Content[0]
+	on := mappingValue(root, "on")
+	jobs := mappingValue(root, "jobs")
+	if on == nil || jobs == nil || jobs.Kind != yaml.MappingNode {
+		return workflowInfo{}, errors.New("workflow must contain on and jobs mappings")
+	}
+
+	info := workflowInfo{externallyTriggered: hasExternalTrigger(on)}
+	for i := 1; i < len(jobs.Content); i += 2 {
+		job := jobs.Content[i]
+		if job.Kind != yaml.MappingNode {
+			continue
+		}
+		if uses := mappingScalar(job, "uses"); strings.HasPrefix(uses, "./.github/workflows/") {
+			info.calls = append(info.calls, strings.TrimPrefix(uses, "./"))
+		}
+		if nodeContains(job, "secrets.SIGNPATH_API_TOKEN") {
+			info.directSigning = true
+		}
+		steps := mappingValue(job, "steps")
+		if steps == nil || steps.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, step := range steps.Content {
+			if step.Kind != yaml.MappingNode {
+				continue
+			}
+			if strings.HasPrefix(mappingScalar(step, "uses"), "signpath/github-action-submit-signing-request@") {
+				info.directSigning = true
+			}
+		}
+	}
+	sort.Strings(info.calls)
+	return info, nil
+}
+
+func nodeContains(node *yaml.Node, text string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.ScalarNode && strings.Contains(node.Value, text) {
+		return true
+	}
+	for _, child := range node.Content {
+		if nodeContains(child, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalTrigger(node *yaml.Node) bool {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Value != "workflow_call"
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if child.Value != "workflow_call" {
+				return true
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			if node.Content[i].Value != "workflow_call" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func mappingScalar(node *yaml.Node, key string) string {
+	value := mappingValue(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
+}
+
+func contractFingerprint(root string, contract releaseSigningContract) ([sha256.Size]byte, error) {
+	names := append([]string{contractPath}, contract.FingerprintFiles...)
+	sort.Strings(names)
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, "reasonix-signpath-release-contract-v1\x00")
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			return [sha256.Size]byte{}, fmt.Errorf("read %s: %w", name, err)
+		}
+		writeLengthPrefixed(hash, []byte(name))
+		writeLengthPrefixed(hash, data)
+	}
+	var result [sha256.Size]byte
+	copy(result[:], hash.Sum(nil))
+	return result, nil
+}
+
+func writeLengthPrefixed(writer io.Writer, data []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(data)))
+	_, _ = writer.Write(length[:])
+	_, _ = writer.Write(data)
+}

--- a/cmd/signpath-contract/main_test.go
+++ b/cmd/signpath-contract/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRepositoryReleaseSigningContract(t *testing.T) {
+	root := "../.."
+	contract, err := loadAndValidate(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := contractFingerprint(root, contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", fingerprint); len(got) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64", len(got))
+	}
+}
+
+func TestTopLevelSignPathWorkflowCallGraph(t *testing.T) {
+	got, err := discoverTopLevelSigningWorkflows("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		".github/workflows/release-desktop.yml",
+		".github/workflows/release-stable.yml",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("top-level workflows that reach SignPath = %v, want %v", got, want)
+	}
+}
+
+func TestReleaseSigningContractRejectsWildcards(t *testing.T) {
+	contract, err := loadAndValidate("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract.AllowedBuildDefinitions = []string{".github/workflows/release-*.yml"}
+	if err := validateContract("../..", contract); err == nil {
+		t.Fatal("wildcard build definition unexpectedly passed validation")
+	}
+}
+
+func TestWorkflowUsingSignPathTokenIsSigningEntryPoint(t *testing.T) {
+	workflow := []byte(`
+on: workflow_dispatch
+jobs:
+  sign:
+    runs-on: windows-latest
+    steps:
+      - shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: ./submit-signing-request.ps1
+`)
+	info, err := parseWorkflow(workflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.externallyTriggered || !info.directSigning {
+		t.Fatalf("token-backed workflow was not classified as a signing entry point: %+v", info)
+	}
+}

--- a/desktop/windows_signing_packaging_test.go
+++ b/desktop/windows_signing_packaging_test.go
@@ -76,8 +76,10 @@ func TestWindowsReleaseSignsPayloadBeforeRepackaging(t *testing.T) {
 		`path: desktop/build/windows/installer-signing-bundle/*.exe`,
 		`github.repository == 'esengine/DeepSeek-Reasonix'`,
 		`SIGNPATH_API_TOKEN is required for public Windows Preview and Stable releases`,
+		`SIGNPATH_RELEASE_SIGNING_ATTESTATION does not match the current protected signing contract`,
 		`signing-policy-slug: release-signing`,
-		`needs.build.result == 'success' && !inputs.production_signing_smoke`,
+		`needs.build.result == 'success' && !inputs.production_signing_smoke && !inputs.signing_preflight`,
+		`go run ./cmd/signpath-contract fingerprint`,
 		`wait-for-completion: false`,
 		`steps.submit-windows-payload.outputs.signing-request-id`,
 		`steps.submit-windows-installer.outputs.signing-request-id`,
@@ -167,6 +169,9 @@ func TestProductionSigningRunsOnlyFromProtectedControlPlane(t *testing.T) {
 	for _, want := range []string{
 		`ALLOW_STABLE_RECOVERY: ${{ inputs.allow_recovery }}`,
 		`allow_recovery: 'false'`,
+		`signing_preflight: true`,
+		`signing_preflight_verified: true`,
+		`needs: [authorize, signpath-preflight]`,
 	} {
 		if !strings.Contains(stable+"\n"+readTestFile(t, "../.github/workflows/release-stable-trigger.yml"), want) {
 			t.Errorf("stable relay is missing normal-release recovery guard %q", want)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -90,7 +90,8 @@ cannot claim that it already passed the approval job.
 Repository `write` access remains a privileged role because repository-level
 Actions secrets are available to workflows on repository branches. Production
 Windows signing has an additional provider-side boundary: SignPath accepts the
-trusted `.github/workflows/release-desktop.yml` build definition only when its
+trusted `.github/workflows/release-stable.yml` and
+`.github/workflows/release-desktop.yml` build definitions only when their
 origin branch is exactly `main-v2`. Never broaden that policy to `**` or a
 tag-shaped wildcard. Other publication credentials should move to protected
 environment secrets or provider-side OIDC/trusted-publishing policies when
@@ -151,8 +152,10 @@ strict separation from repository writers is required.
    exact current `main-v2` commit, renders the reviewed release notes, and runs
    the cache guard. It then **waits once for a configured reviewer to approve the
    GitHub `release` environment** before invoking all three publishers. The
-   approval records the immutable release commit; every publisher checks out
-   that SHA and fails if its remote tag moves afterward.
+   approval records the immutable release commit. Before any publisher starts,
+   **Release stable** runs a zero-publication AMD64/ARM64 SignPath preflight for
+   both the payload and installer stages. Every publisher checks out that SHA
+   and fails if its remote tag moves afterward.
    Windows signing then runs automatically under SignPath trusted-build and
    origin verification: each architecture signs its installed executable
    payload first, rebuilds the portable archive and NSIS package, and finally
@@ -213,12 +216,17 @@ strict separation from repository writers is required.
   request through the SignPath API. Human SignPath approvers remain available
   for emergency recovery, but normal releases do not require additional
   SignPath clicks. SignPath must restrict `release-signing` to the trusted
-  `.github/workflows/release-desktop.yml` build definition and exact `main-v2`
+  `.github/workflows/release-stable.yml` and
+  `.github/workflows/release-desktop.yml` build definitions and exact `main-v2`
   branch. Stable and prerelease tag events are relayed to that protected control
-  plane; do not replace the exact branch match with `**`, `v*`, or
-  `desktop-v*`. Set `SIGNPATH_RELEASE_SIGNING_READY=true` only after AMD64 and
-  ARM64 pass a production certificate smoke run; Preview and Stable both fail
-  closed while the production signing path is not ready.
+  plane; do not replace exact matches with wildcards. The machine-readable
+  `.signpath/contracts/release-signing.yml` policy is checked against the parsed
+  workflow call graph in CI. Standalone Desktop releases require
+  `SIGNPATH_RELEASE_SIGNING_ATTESTATION` to match the current contract hash;
+  `signing_preflight=true` refreshes it only after both architectures complete
+  both signing stages. Stable performs the same live preflight in its approved
+  run before CLI, npm, or Desktop publication, so a provider-side policy drift
+  fails before any public channel starts.
 - Desktop in-app updates use R2 first, then the `crash.reasonix.io` desktop release
   gateway. The gateway resolves the `desktop-v*` release line directly and never uses
   GitHub's repository-wide `/releases/latest`, because plain `v*` tags are the CLI

--- a/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md
+++ b/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md
@@ -8,7 +8,9 @@ Reasonix Windows Authenticode 两阶段签名链路。
 - PR：[esengine/DeepSeek-Reasonix#6904](https://github.com/esengine/DeepSeek-Reasonix/pull/6904)
 - Preview 渠道改造：[esengine/DeepSeek-Reasonix#6155](https://github.com/esengine/DeepSeek-Reasonix/pull/6155)
 - 本 SOP 的验收对象：每次执行前通过 PR API 读回的当前 PR Head
-- 签名工作流：`.github/workflows/release-desktop.yml`
+- 签名工作流：`.github/workflows/release-stable.yml`、
+  `.github/workflows/release-desktop.yml`
+- 机器契约：`.signpath/contracts/release-signing.yml`
 - Authenticode 验证脚本：`scripts/verify-windows-authenticode.ps1`
 
 > 如果 PR Head 已经发生变化，必须重新审查新的 commit 和 workflow diff，
@@ -34,7 +36,7 @@ Reasonix Windows Authenticode 两阶段签名链路。
   GitHub 批准一次。
 - `test-signing-ci-approval` 和 `windows-installer-test-v2` 仅保留给内部签名
   验证，不得被公共 Desktop 发布工作流引用。
-- AMD64 和 ARM64 均完成正式证书的零发布烟测。
+- AMD64 和 ARM64 均完成正式证书的零发布预检。
 - 正式证书 RC 中，所有 Authenticode 签名均为 `Status = Valid`。
 - Windows Defender 环境下安装、启动、更新和卸载均通过。
 
@@ -54,7 +56,7 @@ SignPath 权限说明：
 
 ## 3. 当前配置基线
 
-截至 2026-07-24 的只读核对结果：
+截至 2026-07-25 的线上核对结果：
 
 - SignPath 组织：`DeepSeek-Reasonix [OSS]`
 - SignPath 项目：`DeepSeek-Reasonix`
@@ -69,8 +71,9 @@ SignPath 权限说明：
   - `windows-payload`
 - `release-signing` 已开启 Trusted Build System 和 Origin Verification。
 - `release-signing` 开启 `Use approval process`，Required approvals 为 `1`。
-- `release-signing` 的 Allowed build definitions 仅允许
-  `.github/workflows/release-desktop.yml`。
+- `release-signing` 的 Allowed build definitions 精确允许：
+  - `.github/workflows/release-stable.yml`
+  - `.github/workflows/release-desktop.yml`
 - `release-signing` 的 Allowed branches 必须精确为 `main-v2`；稳定版和 RC
   标签由最小 relay workflow 转发到该受保护控制面。
 - `test-signing-ci-approval` 使用测试证书，只允许 `CI builds` 提交和审批，
@@ -247,6 +250,17 @@ GitHub `upload-artifact` 提交给 SignPath 的产物是 ZIP，因此配置根�
   ```
 
 - Allowed branches：**只能填写 `main-v2`**
+- Allowed build definitions：**只能逐行填写以下两个精确路径**：
+
+  ```text
+  .github/workflows/release-stable.yml
+  .github/workflows/release-desktop.yml
+  ```
+
+  不得使用 `.github/workflows/release-*.yml` 通配符，也不得加入只负责转发
+  dispatch 的 trigger workflow。仓库内
+  `.signpath/contracts/release-signing.yml` 是该列表的机器可读事实源；CI 会
+  解析 workflow 调用图，发现新的顶层签名入口时失败关闭。
 - `Use approval process`：**保持开启**
 - Required approvals：`1`
 - Approvers：必须至少包含能够处理正式发布的 SignPath 人工审批人
@@ -258,6 +272,7 @@ GitHub `upload-artifact` 提交给 SignPath 的产物是 ZIP，因此配置根�
 - Trusted Build System 和 Origin Verification 仍然开启。
 - Allowed branches 精确显示 `main-v2`，没有 `**`、`v*`、
   `desktop-v*` 或临时测试分支。
+- Allowed build definitions 与仓库机器契约逐项相同，没有通配符。
 
 正式版和 RC 的标签事件由 `release-stable-trigger.yml` /
 `release-desktop-trigger.yml` 转发：relay 只携带候选 tag，实际
@@ -302,27 +317,29 @@ Preview 和 Stable 都使用 `release-signing`；测试证书仅用于不发布�
 - GitHub `release` environment 的审批人仍然有效。
 - `release-signing` 的 Allowed branches 精确为 `main-v2`。
 
-正式验收前，应保持 release readiness 关闭：
+正式验收前，应使签名契约 attestation 失效：
 
 ```bash
-gh variable set SIGNPATH_RELEASE_SIGNING_READY \
+gh variable set SIGNPATH_RELEASE_SIGNING_ATTESTATION \
   --repo esengine/DeepSeek-Reasonix \
-  --body false
+  --body unverified
 ```
 
-这会使 Preview、正式版和 RC 在 SignPath 未完成验收时失败关闭。
+这会使 standalone Preview 和 RC 在当前 SignPath 契约未完成验收时失败关闭。
+Stable 不读取旧 attestation 放行，而是在同一次获批运行中先完成真实签名预检，
+成功后才启动 CLI、npm 和 Desktop 发布。
 
-## 10. 运行 AMD64/ARM64 正式证书零发布烟测
+## 10. 运行 AMD64/ARM64 正式证书零发布预检
 
 Fork PR 工作流拿不到官方仓库的 SignPath Secrets，因此不能直接在 PR 分支
 完成真实签名。不要为了合并前验证而放宽 `release-signing` 的精确
 `main-v2` 分支限制。代码、workflow 契约和无 Secrets 的打包测试在 PR 中
-通过后，合并到受保护的 `main-v2`，再执行正式证书烟测。
+通过后，合并到受保护的 `main-v2`，再执行正式证书预检。
 
-`production_signing_smoke` 会经过 Preview 对应的 GitHub `canary`
-environment 审批，使用 `release-signing` 和正式证书验证 AMD64/ARM64，
-但跳过 publish job，因此不会创建 GitHub Release，也不会更新 R2 的
-`preview/`、`canary/` 或 `latest/` 指针：
+`signing_preflight` 会经过 Preview 对应的 GitHub `canary` environment
+审批，使用 `release-signing` 和正式证书验证 AMD64/ARM64。它由 `CI builds`
+自动批准 SignPath 请求，跳过 publish job，并在四个请求全部完成后自动把当前
+契约指纹写入 `SIGNPATH_RELEASE_SIGNING_ATTESTATION`：
 
 ```bash
 gh workflow run release-desktop.yml \
@@ -330,12 +347,16 @@ gh workflow run release-desktop.yml \
   --ref main-v2 \
   -f channel=preview \
   -f base_version=X.Y.Z \
-  -f production_signing_smoke=true
+  -f signing_preflight=true
 ```
 
-将 `X.Y.Z` 替换为计划中的下一版本号。烟测模式会等待 SignPath 外部审批，
-管理员应逐一核对并批准 4 个请求；正常 Preview/Stable 发布则在 GitHub
-environment 获批后由 `CI builds` 自动记录 SignPath 审批。
+将 `X.Y.Z` 替换为计划中的下一版本号。需要人工逐项检查请求再批准时，改用
+`production_signing_smoke=true`；该人工烟测不会写入 attestation，不能代替
+自动闭环预检。
+
+Stable 发布由 `.github/workflows/release-stable.yml` 在唯一的 `release`
+environment 审批之后自动调用相同预检。该预检完成前，CLI、npm 和 Desktop
+三个公开 publisher 均不会启动，因此 SignPath 策略漂移不会再形成半发布。
 
 ### 10.1 监控运行
 
@@ -354,7 +375,7 @@ gh run watch "$RUN_ID" \
   --exit-status
 ```
 
-## 11. 正式证书烟测验收标准
+## 11. 正式证书预检验收标准
 
 以下两个任务必须同时成功：
 
@@ -365,12 +386,12 @@ gh run watch "$RUN_ID" \
 
 1. 构建未签名 payload。
 2. 上传 payload。
-3. 使用 `windows-payload` 签署 6 个 EXE；管理员核对后批准烟测请求。
+3. 使用 `windows-payload` 签署 6 个 EXE；`CI builds` 自动记录审批。
 4. 使用已签 payload 重新生成 portable ZIP 和 NSIS 安装器。
 5. 上传 installer signing bundle。
 6. 使用 `windows-installer-v2` 验证内层可信签名并签署外层安装器。
 7. 执行 Authenticode release contract 验证。
-8. `publish` job 因 `production_signing_smoke=true` 被跳过。
+8. `publish` job 因 `signing_preflight=true` 被跳过。
 
 SignPath Signing Requests 中应出现 4 个成功请求：
 
@@ -386,45 +407,42 @@ SignPath Signing Requests 中应出现 4 个成功请求：
 - Origin 指向官方仓库。
 - Commit SHA 与 GitHub Actions 运行 SHA 一致。
 - Trusted Build、Origin Verification、Malware Scan 均通过。
-- 烟测请求由人工核对后批准；正常发布请求的批准 Actor 为 `CI builds`。
+- 自动预检和正常发布请求的批准 Actor 均为 `CI builds`。
 - AMD64 和 ARM64 的 payload、portable ZIP 内文件及最终 installer 均通过
   `Status = Valid` 信任链验证。
 
-## 12. 开启正式签名门禁
+## 12. 核对正式签名 attestation
 
 只有以下条件全部满足后才能开启：
 
 - 两个新 Artifact Configuration 均为 `VALID`。
 - 旧 `windows-installer` 未改变。
 - `release-signing` 的证书级审批保持开启，正式审批人可用。
-- `release-signing` 的 Build Definition 仅允许
+- `release-signing` 的 Build Definitions 精确允许
+  `.github/workflows/release-stable.yml` 和
   `.github/workflows/release-desktop.yml`。
 - `release-signing` 的 Allowed branches 精确为 `main-v2`。
 - `CI builds` 是 `release-signing` 的 Submitter 和 Approver，GitHub Secret 使用其专用
   Token。
-- AMD64 和 ARM64 正式证书零发布烟测全部成功。
+- AMD64 和 ARM64 正式证书零发布预检全部成功。
 - 4 个 SignPath Signing Request 全部成功。
 
-设置：
+预检会自动写入变量，只需读回核对：
 
 ```bash
-gh variable set SIGNPATH_RELEASE_SIGNING_READY \
-  --repo esengine/DeepSeek-Reasonix \
-  --body true
-```
-
-读回确认：
-
-```bash
-gh variable get SIGNPATH_RELEASE_SIGNING_READY \
+gh variable get SIGNPATH_RELEASE_SIGNING_ATTESTATION \
   --repo esengine/DeepSeek-Reasonix
 ```
 
+值必须为 `v1:` 加 64 位小写十六进制 SHA-256。只要 workflow、签名脚本、
+Artifact Configuration 或机器契约改变，CI 计算出的新指纹就不再匹配，必须
+重新运行零发布预检。
+
 ## 13. 合并后运行正式证书 RC
 
-`production_signing_smoke=true` 证明正式证书和双阶段产物链正确，但不会
-发布。开启 readiness 后，RC 用于验证真实公开 prerelease 发布；如果零发布
-烟测未完成，不得用 RC 代替它，更不得直接发布稳定版。
+`signing_preflight=true` 证明正式证书、双阶段产物链和自动审批闭环正确，但
+不会发布。attestation 有效后，RC 用于验证真实公开 prerelease 发布；如果
+零发布预检未完成，不得用 RC 代替它，更不得直接发布稳定版。
 
 首先核对目标 commit：
 
@@ -497,15 +515,15 @@ Get-ChildItem "<Reasonix安装目录>" -Recurse -Filter *.exe |
 | 提示文件缺失或存在额外文件 | 检查 signing bundle 与 XML 文件清单是否一致 |
 | `authenticode-verify` 失败 | 检查内层文件是否未签名，或签名后被重新编译/修改 |
 | 只有 AMD64 成功 | 不放行，ARM64 也是硬门槛 |
-| RC 签名不是 `Status = Valid` | 关闭 readiness，禁止稳定发布 |
-| 正式请求等待人工审批 | 关闭 readiness，检查 `CI builds` Approver 权限、API Token 和自动审批步骤；不得关闭证书强制审批 |
+| RC 签名不是 `Status = Valid` | 将 attestation 设为 `unverified`，禁止 standalone 发布 |
+| 自动预检请求等待人工审批 | 将 attestation 设为 `unverified`，检查 `CI builds` Approver 权限、API Token 和自动审批步骤；不得关闭证书强制审批 |
 
 发生正式签名故障时，立即恢复失败关闭：
 
 ```bash
-gh variable set SIGNPATH_RELEASE_SIGNING_READY \
+gh variable set SIGNPATH_RELEASE_SIGNING_ATTESTATION \
   --repo esengine/DeepSeek-Reasonix \
-  --body false
+  --body unverified
 ```
 
 在故障解除并重新完成 AMD64/ARM64 验收前，不得发布稳定版。
@@ -520,14 +538,14 @@ gh variable set SIGNPATH_RELEASE_SIGNING_READY \
 - [ ] `SIGNPATH_API_TOKEN` 对应专用 `CI builds`，不是个人账号
 - [ ] `release-signing` 已开启 Trusted Build System
 - [ ] `release-signing` 已开启 Origin Verification
-- [ ] `release-signing` 的 Allowed build definition 为 `.github/workflows/release-desktop.yml`
+- [ ] `release-signing` 的 Allowed build definitions 精确为 `.github/workflows/release-stable.yml` 和 `.github/workflows/release-desktop.yml`
 - [ ] `release-signing` 的 Allowed branches 精确为 `main-v2`
 - [ ] `release-signing` 的 SignPath 审批已开启，Required approvals 为 `1`
 - [ ] GitHub `release` environment 的正式发布审批人和响应流程已经明确
-- [ ] AMD64 正式证书零发布烟测两阶段签名成功
-- [ ] ARM64 正式证书零发布烟测两阶段签名成功
+- [ ] AMD64 正式证书零发布预检两阶段签名成功
+- [ ] ARM64 正式证书零发布预检两阶段签名成功
 - [ ] 4 个 SignPath Signing Request 均为 `Completed`
-- [ ] `SIGNPATH_RELEASE_SIGNING_READY=true`
+- [ ] `SIGNPATH_RELEASE_SIGNING_ATTESTATION` 与当前机器契约指纹一致
 - [ ] 正式证书 RC 的 AMD64 签名均为 `Valid`
 - [ ] 正式证书 RC 的 ARM64 签名均为 `Valid`
 - [ ] Defender 安装、启动、更新和卸载验证通过

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -66,11 +66,15 @@ if grep -Eq 'signing-policy-slug:.*test-signing' "$repo_root/.github/workflows/r
 	echo "public desktop workflow must not use the SignPath test certificate" >&2
 	exit 1
 fi
-grep -Eq 'SIGNPATH_RELEASE_SIGNING_READY must be true' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq 'SIGNPATH_RELEASE_SIGNING_ATTESTATION does not match' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq '^      signing_preflight:$' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq '^      signing_preflight_verified:$' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq '^  signing-contract:$' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq '^  attest-signing-contract:$' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq 'R2_BUCKET.*/preview/' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq 'R2_BUCKET.*/canary/' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq '^      production_signing_smoke:$' "$repo_root/.github/workflows/release-desktop.yml"
-grep -Eq "needs\.build\.result == 'success'.*!inputs\.production_signing_smoke" \
+grep -Eq "needs\.build\.result == 'success'.*!inputs\.production_signing_smoke.*!inputs\.signing_preflight" \
 	"$repo_root/.github/workflows/release-desktop.yml"
 [ "$(grep -Ec 'wait-for-completion: false' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Ec 'complete-signpath-request\.ps1' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
@@ -83,6 +87,10 @@ grep -Eq 'steps\.submit-windows-installer\.outputs\.signing-request-id' \
 grep -Eq 'artifact-configuration-slug: windows-payload' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq 'artifact-configuration-slug: windows-installer-v2' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq -- '-RequireTrusted:$true' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq '^  signpath-preflight:$' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'signing_preflight: true' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'signing_preflight_verified: true' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'needs: \[authorize, signpath-preflight\]' "$repo_root/.github/workflows/release-stable.yml"
 grep -Eq 'name: Require R2 for Preview' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq "channel == 'preview'.*HAS_R2 != 'true'" "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq '^  postflight:$' "$repo_root/.github/workflows/release-stable.yml"
@@ -93,6 +101,12 @@ for channel in cli npm desktop; do
 	grep -Eq '^      publish_'"$channel"':' "$repo_root/.github/workflows/release-stable.yml"
 	grep -Eq "inputs\.publish_$channel" "$repo_root/.github/workflows/release-stable.yml"
 done
+
+# The checked-in SignPath policy contract is the single source of truth for the
+# provider allowlist and every top-level workflow that can reach signing.
+go run ./cmd/signpath-contract validate
+contract_fingerprint="$(go run ./cmd/signpath-contract fingerprint)"
+grep -Eq '^v1:[0-9a-f]{64}$' <<<"$contract_fingerprint"
 grep -Eq 'public postflight will still verify it' "$repo_root/.github/workflows/release-stable.yml"
 for workflow in release.yml release-desktop.yml; do
 	grep -Eq 'name: Download orchestrator-reviewed release notes' "$repo_root/.github/workflows/$workflow"


### PR DESCRIPTION
## Summary

- Fix the v1.17.21 Desktop release blocker: the stable orchestrator reaches SignPath as `.github/workflows/release-stable.yml`, while the provider policy previously allowed only `.github/workflows/release-desktop.yml`.
- Add a machine-readable SignPath contract and a Go validator that parses the workflow call graph, rejects wildcards, and fails when the exact provider allowlist drifts from the signing entry points.
- Gate every normal stable publisher behind a zero-publication AMD64/ARM64 SignPath preflight, and replace the manually toggled readiness boolean with a protected contract fingerprint for standalone Desktop releases.
- Protect the signing control plane with explicit CODEOWNERS entries, focused regression tests, and updated release/operator documentation.
- The live `release-signing` policy has been verified as `VALID` with exact `main-v2` origin, Trusted Build and Origin Verification enabled, and both exact workflow definitions allowed.

Release recovery after merge will reuse the existing immutable v1.17.21 tag set and recover Desktop/R2 only. CLI/Homebrew and npm already completed successfully; no release tag will be moved or recreated.

### Backward compatibility

| Surface | Old-data / old-release behavior | Conclusion |
| --- | --- | --- |
| Persisted Reasonix data | No config, state, session, trace, or Wails JSON format changed | Compatible |
| Existing release tags | Manual recovery continues to accept a tagged candidate on `main-v2` history | Compatible |
| Standalone Desktop release | Requires a matching signing-contract fingerprint instead of a mutable boolean | Fail-closed operational migration; no user data impact |

## Verification

- `env -u DEEPSEEK_API_KEY go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `./scripts/cache-guard.sh`
- `bash scripts/release-workflows.test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'label "windows-11-arm" is unknown' .github/workflows/release-stable.yml .github/workflows/release-desktop.yml`
- `node npm/build.mjs npm-v1.17.21`
- `git diff --check`

## Cache impact

Cache-impact: none; release workflows, signing policy contracts, and operator documentation do not change provider-visible prompts or tool schemas.
Cache-guard: `./scripts/cache-guard.sh` passed all release cache scenarios.
System-prompt-review: N/A
