### PR TITLE
fix(desktop): reattach detached runtime when rapidly switching sessions on same tab (#6955)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3851,16 +3851,13 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 			a.runtimeAdmissionMu.Unlock()
 			return fmt.Errorf("tab changed while reattaching session; retry")
 		}
-		oldCtrl := tab.Ctrl
-		oldSink := tab.sink
-		oldLease := tab.takeSessionLease()
 		a.mu.Unlock()
 
-		attached := a.attachExistingSessionRuntime(tab, sessionPath, a.ctx)
+		detachSource := controllerHasActiveRuntimeWork(source.ctrl)
+		oldCtrl, oldSink, oldLease, attached := a.reattachDetachedSessionRuntimeForRebind(
+			tab, source, sessionPath, detachSource,
+		)
 		if !attached {
-			if oldLease != nil {
-				tab.adoptSessionLease(oldLease)
-			}
 			tab.turnStartMu.Unlock()
 			a.runtimeAdmissionMu.Unlock()
 			return fmt.Errorf("failed to reattach detached session runtime")
@@ -4040,6 +4037,75 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	a.notifyTabRuntimeRebuiltAtEpoch(tab, newEpoch)
 	a.emitReady(a.ctx, tab.ID)
 	return nil
+}
+
+// reattachDetachedSessionRuntimeForRebind atomically replaces tab with the
+// already-running detached target. If the visible source is still active, its
+// controller, sink, lease, and runtime registry entry move to detachedSessions
+// in the same App.mu transaction; an idle source is returned for off-lock
+// teardown. The caller must hold runtimeRebuildMu, runtimeAdmissionMu, and
+// tab.turnStartMu so detachSource cannot become stale through new turn admission.
+func (a *App) reattachDetachedSessionRuntimeForRebind(
+	tab *WorkspaceTab,
+	source tabRuntimeSnapshot,
+	sessionPath string,
+	detachSource bool,
+) (control.SessionAPI, *tabEventSink, *agent.SessionLease, bool) {
+	key := sessionRuntimeKey(sessionPath)
+	if tab == nil || key == "" {
+		return nil, nil, nil, false
+	}
+
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
+		a.mu.Unlock()
+		return nil, nil, nil, false
+	}
+	detached := a.detachedSessions[key]
+	if detached == nil || detached.Ctrl == nil {
+		a.mu.Unlock()
+		return nil, nil, nil, false
+	}
+	if rt := a.runtimeForTabLocked(detached); rt != nil {
+		if rt.Phase != sessionRuntimeReady {
+			a.mu.Unlock()
+			return nil, nil, nil, false
+		}
+	} else if !detached.Ready {
+		// Compatibility for detached runtimes created before the process-local
+		// registry existed.
+		a.mu.Unlock()
+		return nil, nil, nil, false
+	}
+
+	oldCtrl := tab.Ctrl
+	oldSink := tab.sink
+	var oldLease *agent.SessionLease
+	if detachSource {
+		if !a.detachRuntimeForReplacementLocked(tab) {
+			a.mu.Unlock()
+			return nil, nil, nil, false
+		}
+		// Ownership moved to the detached clone. Nothing from the source may be
+		// closed or released after the target becomes visible.
+		oldCtrl = nil
+		oldSink = nil
+	} else {
+		// Prevent applyRuntimeTab from releasing the source lease under App.mu;
+		// teardown remains outside the app lock as on the normal rebuild path.
+		oldLease = tab.takeSessionLease()
+	}
+
+	delete(a.detachedSessions, key)
+	applyRuntimeTab(tab, detached, sessionPath, a.ctx, a)
+	a.saveTabsLocked()
+	attachedCtrl := tab.Ctrl
+	a.mu.Unlock()
+
+	if attachedCtrl != nil {
+		attachedCtrl.ReplayPendingPrompts()
+	}
+	return oldCtrl, oldSink, oldLease, true
 }
 
 type sessionRebindCandidate struct {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3805,6 +3805,86 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 	source := snapshotTabRuntimeLocked(tab)
 	a.mu.Unlock()
 
+	// If the target session has a detached runtime (from a recent running-session
+	// detach), reattach it instead of building a new controller. This avoids the
+	// Windows LockFileEx/LOCKFILE_EXCLUSIVE_LOCK conflict where a second handle
+	// from the same process cannot lock a file already held by the detached
+	// controller's fd (#6955).
+	targetKey := sessionRuntimeKey(sessionPath)
+	a.mu.Lock()
+	detached := a.detachedSessions[targetKey]
+	hasDetached := detached != nil && detached.Ctrl != nil
+	a.mu.Unlock()
+
+	if hasDetached {
+		a.runtimeAdmissionMu.Lock()
+		tab.turnStartMu.Lock()
+
+		a.mu.Lock()
+		if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
+			a.mu.Unlock()
+			tab.turnStartMu.Unlock()
+			a.runtimeAdmissionMu.Unlock()
+			return fmt.Errorf("tab changed while reattaching session; retry")
+		}
+		a.mu.Unlock()
+
+		if source.ctrl != nil {
+			if err := a.snapshotTabForAction(tab, "switching sessions"); err != nil {
+				tab.turnStartMu.Unlock()
+				a.runtimeAdmissionMu.Unlock()
+				return err
+			}
+			if oldPath := a.reconciledSessionPathForTab(tab); oldPath != "" {
+				if err := a.saveTabSessionMeta(tab, oldPath); err != nil {
+					tab.turnStartMu.Unlock()
+					a.runtimeAdmissionMu.Unlock()
+					return fmt.Errorf("save current session metadata before switching sessions: %w", err)
+				}
+			}
+		}
+
+		a.mu.Lock()
+		if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
+			a.mu.Unlock()
+			tab.turnStartMu.Unlock()
+			a.runtimeAdmissionMu.Unlock()
+			return fmt.Errorf("tab changed while reattaching session; retry")
+		}
+		oldCtrl := tab.Ctrl
+		oldSink := tab.sink
+		oldLease := tab.takeSessionLease()
+		a.mu.Unlock()
+
+		attached := a.attachExistingSessionRuntime(tab, sessionPath, a.ctx)
+		if !attached {
+			if oldLease != nil {
+				tab.adoptSessionLease(oldLease)
+			}
+			tab.turnStartMu.Unlock()
+			a.runtimeAdmissionMu.Unlock()
+			return fmt.Errorf("failed to reattach detached session runtime")
+		}
+
+		if oldSink != nil {
+			oldSink.setBinding("", nil)
+			oldSink.clearContext()
+		}
+		if oldCtrl != nil {
+			oldCtrl.Close()
+		}
+		if oldLease != nil {
+			oldLease.Release()
+		}
+
+		a.clearDeferredRebuild(tab.ID)
+		a.emitReady(a.ctx, tab.ID)
+
+		tab.turnStartMu.Unlock()
+		a.runtimeAdmissionMu.Unlock()
+		return nil
+	}
+
 	a.runtimeAdmissionMu.Lock()
 	defer a.runtimeAdmissionMu.Unlock()
 	tab.turnStartMu.Lock()
@@ -9102,6 +9182,11 @@ func (a *App) canReclaimCurrentProcessSessionLease(tab *WorkspaceTab, path strin
 		if candidate.Ctrl != nil && sessionRuntimeKey(candidate.currentSessionPath()) == key {
 			return false
 		}
+	}
+	// A detached runtime's controller still holds the OS lock; refuse reclaim
+	// even when PID matches (#6955).
+	if detached := a.detachedSessions[key]; detached != nil && detached.Ctrl != nil {
+		return false
 	}
 	return true
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3854,7 +3854,7 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		a.mu.Unlock()
 
 		detachSource := controllerHasActiveRuntimeWork(source.ctrl)
-		oldCtrl, oldSink, oldLease, attached := a.reattachDetachedSessionRuntimeForRebind(
+		oldCtrl, oldSink, oldLease, oldHostKey, attached := a.reattachDetachedSessionRuntimeForRebind(
 			tab, source, sessionPath, detachSource,
 		)
 		if !attached {
@@ -3869,6 +3869,9 @@ func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string
 		}
 		if oldCtrl != nil {
 			oldCtrl.Close()
+		}
+		if oldHostKey != "" {
+			a.releaseSharedHost(oldHostKey)
 		}
 		if oldLease != nil {
 			oldLease.Release()
@@ -4050,50 +4053,53 @@ func (a *App) reattachDetachedSessionRuntimeForRebind(
 	source tabRuntimeSnapshot,
 	sessionPath string,
 	detachSource bool,
-) (control.SessionAPI, *tabEventSink, *agent.SessionLease, bool) {
+) (control.SessionAPI, *tabEventSink, *agent.SessionLease, string, bool) {
 	key := sessionRuntimeKey(sessionPath)
 	if tab == nil || key == "" {
-		return nil, nil, nil, false
+		return nil, nil, nil, "", false
 	}
 
 	a.mu.Lock()
 	if tab.removed || a.tabs[tab.ID] != tab || tab.Ctrl != source.ctrl {
 		a.mu.Unlock()
-		return nil, nil, nil, false
+		return nil, nil, nil, "", false
 	}
 	detached := a.detachedSessions[key]
 	if detached == nil || detached.Ctrl == nil {
 		a.mu.Unlock()
-		return nil, nil, nil, false
+		return nil, nil, nil, "", false
 	}
 	if rt := a.runtimeForTabLocked(detached); rt != nil {
 		if rt.Phase != sessionRuntimeReady {
 			a.mu.Unlock()
-			return nil, nil, nil, false
+			return nil, nil, nil, "", false
 		}
 	} else if !detached.Ready {
 		// Compatibility for detached runtimes created before the process-local
 		// registry existed.
 		a.mu.Unlock()
-		return nil, nil, nil, false
+		return nil, nil, nil, "", false
 	}
 
 	oldCtrl := tab.Ctrl
 	oldSink := tab.sink
 	var oldLease *agent.SessionLease
+	oldHostKey := ""
 	if detachSource {
 		if !a.detachRuntimeForReplacementLocked(tab) {
 			a.mu.Unlock()
-			return nil, nil, nil, false
+			return nil, nil, nil, "", false
 		}
 		// Ownership moved to the detached clone. Nothing from the source may be
 		// closed or released after the target becomes visible.
 		oldCtrl = nil
 		oldSink = nil
 	} else {
-		// Prevent applyRuntimeTab from releasing the source lease under App.mu;
-		// teardown remains outside the app lock as on the normal rebuild path.
+		// Prevent applyRuntimeTab from overwriting resources owned by the idle
+		// source. Teardown remains outside the app lock as on the normal rebuild
+		// path; the detached target already owns a separate shared-host ref.
 		oldLease = tab.takeSessionLease()
+		oldHostKey = takeTabSharedHostKey(tab)
 	}
 
 	delete(a.detachedSessions, key)
@@ -4105,7 +4111,7 @@ func (a *App) reattachDetachedSessionRuntimeForRebind(
 	if attachedCtrl != nil {
 		attachedCtrl.ReplayPendingPrompts()
 	}
-	return oldCtrl, oldSink, oldLease, true
+	return oldCtrl, oldSink, oldLease, oldHostKey, true
 }
 
 type sessionRebindCandidate struct {

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -1295,6 +1295,98 @@ func TestRebindTabToDetachedSessionPreservesRunningSourceRuntime(t *testing.T) {
 	waitNotRunning(t, sourceCtrl)
 }
 
+func TestRebindTabToDetachedSessionReleasesIdleSourceSharedHost(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	sourcePath := filepath.Join(dir, "idle-source.jsonl")
+	targetPath := filepath.Join(dir, "detached-target.jsonl")
+	writeHistoryTestSession(t, sourcePath, "source prompt")
+	writeHistoryTestSession(t, targetPath, "target prompt")
+	loaded, err := agent.LoadSession(targetPath)
+	if err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	hostKey := root
+	sharedHost := app.acquireSharedHost(hostKey)
+	if got := app.acquireSharedHost(hostKey); got != sharedHost {
+		t.Fatal("source and detached target did not share one plugin host")
+	}
+
+	sourceSink := &tabEventSink{tabID: "visible", app: app, ctx: app.ctx}
+	targetSink := &tabEventSink{tabID: "detached", app: app}
+	installNoopRuntimeEvents(app, sourceSink, targetSink)
+	sourceCtrl := control.New(control.Options{
+		SessionDir: dir, SessionPath: sourcePath, Label: "source",
+		Sink: sourceSink, Host: sharedHost,
+	})
+	targetCtrl := control.New(control.Options{
+		SessionDir: dir, SessionPath: targetPath, Label: "target",
+		Sink: targetSink, Host: sharedHost,
+	})
+	tab := &WorkspaceTab{
+		ID: "visible", Scope: "global", WorkspaceRoot: root,
+		SessionPath: sourcePath, Ctrl: sourceCtrl, Ready: true, sink: sourceSink,
+		SharedHostKey: hostKey, disabledMCP: map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	if err := tab.ensureSessionLease(sourcePath); err != nil {
+		t.Fatalf("lease source: %v", err)
+	}
+	app.mu.Lock()
+	app.newSessionRuntimeLocked(tab, sessionRuntimeKey(sourcePath))
+	app.advanceSessionRuntimeEpochLocked(tab)
+	app.mu.Unlock()
+
+	targetLease, err := agent.TryAcquireSessionLease(targetPath)
+	if err != nil {
+		t.Fatalf("lease target: %v", err)
+	}
+	detachedTarget := &WorkspaceTab{
+		ID: detachedRuntimeTabID(sessionRuntimeKey(targetPath)), Scope: "global",
+		WorkspaceRoot: root, SessionPath: targetPath, Ctrl: targetCtrl,
+		Ready: true, sink: targetSink, SharedHostKey: hostKey,
+		disabledMCP: map[string]ServerView{},
+	}
+	detachedTarget.adoptSessionLease(targetLease)
+	app.mu.Lock()
+	app.detachedSessions[sessionRuntimeKey(targetPath)] = detachedTarget
+	app.newSessionRuntimeLocked(detachedTarget, sessionRuntimeKey(targetPath))
+	app.advanceSessionRuntimeEpochLocked(detachedTarget)
+	app.mu.Unlock()
+	t.Cleanup(func() {
+		sourceCtrl.Close()
+		targetCtrl.Close()
+		tab.releaseSessionLease()
+		detachedTarget.releaseSessionLease()
+		app.closeAllSharedHosts()
+	})
+
+	if refs, ok := sharedHostRefsForTest(t, app, hostKey); !ok || refs != 2 {
+		t.Fatalf("shared host refs before reattach = %d, present=%v, want 2/true", refs, ok)
+	}
+	if err := app.rebindTabToLoadedSessionPath(tab, targetPath, loaded); err != nil {
+		t.Fatalf("reattach target: %v", err)
+	}
+	if tab.Ctrl != targetCtrl || tab.SharedHostKey != hostKey {
+		t.Fatalf("visible target runtime = ctrl %p host %q, want %p/%q",
+			tab.Ctrl, tab.SharedHostKey, targetCtrl, hostKey)
+	}
+	if refs, ok := sharedHostRefsForTest(t, app, hostKey); !ok || refs != 1 {
+		t.Fatalf("shared host refs after reattach = %d, present=%v, want 1/true", refs, ok)
+	}
+}
+
 func newAtomicRebindTestApp(t *testing.T) (*App, *WorkspaceTab, control.SessionAPI, string, string, *agent.Session) {
 	t.Helper()
 	isolateDesktopUserDirs(t)

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -1182,6 +1182,119 @@ func TestRebindTabToLoadedSessionPersistsAndRestoresSessionProfile(t *testing.T)
 	}
 }
 
+func TestRebindTabToDetachedSessionPreservesRunningSourceRuntime(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	sourcePath := filepath.Join(dir, "running-source.jsonl")
+	targetPath := filepath.Join(dir, "detached-target.jsonl")
+	writeHistoryTestSession(t, sourcePath, "source prompt")
+	writeHistoryTestSession(t, targetPath, "target prompt")
+	loaded, err := agent.LoadSession(targetPath)
+	if err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+
+	sourceRunner := &blockingRunner{started: make(chan struct{}), release: make(chan struct{})}
+	sourceSink := &tabEventSink{tabID: "visible", app: app, ctx: app.ctx}
+	targetSink := &tabEventSink{tabID: "detached", app: app}
+	installNoopRuntimeEvents(app, sourceSink, targetSink)
+	sourceCtrl := control.New(control.Options{
+		Runner: sourceRunner, SessionDir: dir, SessionPath: sourcePath,
+		Label: "source", Sink: sourceSink,
+	})
+	targetCtrl := control.New(control.Options{
+		SessionDir: dir, SessionPath: targetPath, Label: "target", Sink: targetSink,
+	})
+	tab := &WorkspaceTab{
+		ID: "visible", Scope: "global", WorkspaceRoot: root,
+		SessionPath: sourcePath, Ctrl: sourceCtrl, Ready: true, sink: sourceSink,
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	if err := tab.ensureSessionLease(sourcePath); err != nil {
+		t.Fatalf("lease source: %v", err)
+	}
+	app.mu.Lock()
+	app.newSessionRuntimeLocked(tab, sessionRuntimeKey(sourcePath))
+	app.advanceSessionRuntimeEpochLocked(tab)
+	app.mu.Unlock()
+
+	targetLease, err := agent.TryAcquireSessionLease(targetPath)
+	if err != nil {
+		t.Fatalf("lease target: %v", err)
+	}
+	detachedTarget := &WorkspaceTab{
+		ID: detachedRuntimeTabID(sessionRuntimeKey(targetPath)), Scope: "global",
+		WorkspaceRoot: root, SessionPath: targetPath, Ctrl: targetCtrl,
+		Ready: true, sink: targetSink, disabledMCP: map[string]ServerView{},
+	}
+	detachedTarget.adoptSessionLease(targetLease)
+	app.mu.Lock()
+	app.detachedSessions[sessionRuntimeKey(targetPath)] = detachedTarget
+	app.newSessionRuntimeLocked(detachedTarget, sessionRuntimeKey(targetPath))
+	app.advanceSessionRuntimeEpochLocked(detachedTarget)
+	app.mu.Unlock()
+	sourceReleased := false
+	t.Cleanup(func() {
+		if !sourceReleased {
+			close(sourceRunner.release)
+		}
+		sourceCtrl.Close()
+		targetCtrl.Close()
+		tab.releaseSessionLease()
+		app.mu.RLock()
+		detachedSource := app.detachedSessions[sessionRuntimeKey(sourcePath)]
+		app.mu.RUnlock()
+		if detachedSource != nil {
+			detachedSource.releaseSessionLease()
+		}
+	})
+
+	sourceCtrl.Submit("keep source running")
+	select {
+	case <-sourceRunner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("source turn did not start")
+	}
+
+	if err := app.rebindTabToLoadedSessionPath(tab, targetPath, loaded); err != nil {
+		t.Fatalf("reattach target: %v", err)
+	}
+	if tab.Ctrl != targetCtrl || tab.sessionLeaseRuntimeKey() != sessionRuntimeKey(targetPath) {
+		t.Fatalf("visible target runtime = ctrl %p lease %q, want %p/%q",
+			tab.Ctrl, tab.sessionLeaseRuntimeKey(), targetCtrl, sessionRuntimeKey(targetPath))
+	}
+	if !sourceCtrl.Running() {
+		t.Fatal("reattaching the target cancelled the running source controller")
+	}
+	app.mu.RLock()
+	detachedSource := app.detachedSessions[sessionRuntimeKey(sourcePath)]
+	targetStillDetached := app.detachedSessions[sessionRuntimeKey(targetPath)]
+	app.mu.RUnlock()
+	if detachedSource == nil || detachedSource.Ctrl != sourceCtrl ||
+		detachedSource.sessionLeaseRuntimeKey() != sessionRuntimeKey(sourcePath) {
+		t.Fatalf("running source was not preserved as detached runtime: %#v", detachedSource)
+	}
+	if targetStillDetached != nil {
+		t.Fatalf("target remained detached after reattach: %#v", targetStillDetached)
+	}
+
+	close(sourceRunner.release)
+	sourceReleased = true
+	waitNotRunning(t, sourceCtrl)
+}
+
 func newAtomicRebindTestApp(t *testing.T) (*App, *WorkspaceTab, control.SessionAPI, string, string, *agent.Session) {
 	t.Helper()
 	isolateDesktopUserDirs(t)

--- a/desktop/session_key_test.go
+++ b/desktop/session_key_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/control"
 )
 
 // The lease registry folds session paths through agent.CanonicalSessionPath
@@ -122,6 +123,33 @@ func TestCanReclaimAllowsMissingLeaseInfo(t *testing.T) {
 	}}
 	if app.canReclaimCurrentProcessSessionLease(tab, path, foreign) {
 		t.Fatal("foreign-holder lease error must not allow reclaim")
+	}
+}
+
+func TestCanReclaimRejectsDetachedRuntimeOwner(t *testing.T) {
+	app := NewApp()
+	tab := &WorkspaceTab{ID: "visible"}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	path := filepath.Join(t.TempDir(), "Sessions", "detached-owner.jsonl")
+	ctrl := control.New(control.Options{
+		SessionDir:  filepath.Dir(path),
+		SessionPath: path,
+		Label:       "detached",
+	})
+	t.Cleanup(ctrl.Close)
+	app.detachedSessions[sessionRuntimeKey(path)] = &WorkspaceTab{
+		ID:          "detached",
+		SessionPath: path,
+		Ctrl:        ctrl,
+	}
+	err := &agent.SessionLeaseError{Path: path, Info: &agent.SessionLeaseInfo{
+		SessionPath: path,
+		WriterID:    agent.SessionWriterID(),
+		PID:         os.Getpid(),
+	}}
+
+	if app.canReclaimCurrentProcessSessionLease(tab, path, err) {
+		t.Fatal("detached runtime owner must block same-process lease reclaim")
 	}
 }
 


### PR DESCRIPTION
When rapidly switching between saved sessions on the same tab, a running
source session is detached and keeps its controller and session lease alive.
Switching back previously entered the rebuild path and attempted to acquire a
second OS-level lock for the same session. On Windows, LockFileEx rejects that
second handle, so the user saw a misleading "this session is already open"
error.

**Changes:**

1. **Reattach detached targets before rebuilding**
   - Detect an existing detached runtime for the requested session.
   - Reattach its controller, sink, lease, telemetry, profile, and runtime
     registry entry instead of building a duplicate controller.
   - Keep the lock order
     `runtimeRebuildMu → runtimeAdmissionMu → turnStartMu → App.mu`.

2. **Preserve an active visible source runtime**
   - If the currently visible source still has a running turn, pending prompt,
     or background job, atomically move it into `detachedSessions` while the
     target becomes visible.
   - Only close and release an idle source after the target runtime has been
     attached successfully.
   - This preserves both sessions in the A-running → B-running → return-to-A
     workflow.

3. **Reject unsafe same-process lease reclaim**
   - `canReclaimCurrentProcessSessionLease` now refuses reclaim when a detached
     runtime still owns the session.

4. **Regression coverage**
   - Verify that reattaching a detached target does not cancel a running source.
   - Verify controller and lease ownership transfer for both sessions.
   - Verify a detached runtime owner blocks same-process lease reclaim.

**Verification:**

- `cd desktop && go test ./...`
- Focused session rebind and lease tests
- Focused `go test -race` for the new dual-runtime scenarios
- Clean three-way merge and full Desktop test pass against the latest
  `main-v2`

**Fixes:** #6955