### PR TITLE
fix(goal): reset idleTurns on [goal:blocked] to prevent premature idle intercept

### DIFF
--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -294,6 +294,7 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		g.interceptMsg = ""
 		notice = goalCompleteNotice
 	case GoalStatusBlocked:
+		g.idleTurns = 0
 		reason := cleanGoalBlockReason(in.reason)
 		if reason == "" {
 			reason = "blocked"

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -756,6 +756,26 @@ func TestGoalRepeatedBlockedStopsAfterThreeTurns(t *testing.T) {
 	}
 }
 
+func TestGoalBlockedSignalDoesNotTriggerIdleIntercept(t *testing.T) {
+	g := &goalMachine{
+		goal:      "wait for user review",
+		status:    GoalStatusRunning,
+		idleTurns: maxGoalIdleTurns - 1,
+	}
+
+	res := g.advance(goalAdvanceInput{
+		status: GoalStatusBlocked,
+		reason: "waiting for user review",
+	})
+
+	if !res.cont {
+		t.Fatal("first blocked signal should keep the goal audit running")
+	}
+	if msg, ok := g.takeIntercept(); ok {
+		t.Fatalf("blocked signal triggered idle intercept %q", msg)
+	}
+}
+
 func TestGoalRestartResetsBlockedAudit(t *testing.T) {
 	prov := &scriptedTurns{turns: [][]provider.Chunk{
 		textTurn("Blocked.\n\n[goal:blocked:needs credentials]"),


### PR DESCRIPTION
When the agent signals \`[goal:blocked]\`, the goal FSM increments the blocks counter but did not reset g.idleTurns. If blocks < 3 (so notice remains empty) and the agent makes no tool calls for 2 subsequent turns, the idle detection at maxGoalIdleTurns fires and sets an interceptMsg that overrides the agent's blocked signal.

**Fix:** Add \`g.idleTurns = 0\` in the \`GoalStatusBlocked\` case so that an explicit blocked signal resets the idle counter. The agent is not idling — it deliberately signalled a blocking condition.

**Fixes:** #6956

---

**Related:** The broader architectural issue of interceptMsg/notice cross-contamination between multiple FSM mechanisms is tracked in #6958.