### PR TITLE
fix(desktop): allow skill invocation anywhere in the composer

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -1386,11 +1386,15 @@ console.log("\ncomposer goal toggle");
   });
   const { root, calls, rerender } = await renderComposer();
 
-  const initialText = "请用/检查";
+  const initialText = "请用/writing-plans检查";
   await replaceComposerDraft(rerender, 1900, initialText);
   let textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
   if (!textarea) throw new Error("composer textarea did not render for middle slash completion");
-  const slashCaret = "请用/".length;
+  const slashCaret = "请用/writ".length;
+  await act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await flushTimers();
+  });
   await act(async () => {
     textarea!.focus();
     textarea!.setSelectionRange(slashCaret, slashCaret);
@@ -2059,6 +2063,54 @@ console.log("\ncomposer goal toggle");
     await flushTimers();
   });
   eq(calls.structured[0]?.input, "拼", "compositionend commits the composed text to the model exactly once");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  mockApp({
+    Commands: async () => [
+      { name: "review", description: "Review the current task", kind: "skill" },
+    ],
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => [],
+  });
+  const sessionA = "session:project:/repo:topic-a:session-a";
+  const sessionB = "session:project:/repo:topic-b:session-b";
+  const { root, rerender } = await renderComposer({ sessionKey: sessionA });
+
+  await replaceComposerDraft(rerender, 5000, "x/review");
+  await waitFor("session A slash menu", () => Boolean(document.querySelector(".slashmenu")));
+
+  await rerender({ sessionKey: sessionB, insertRequest: null });
+  await replaceComposerDraft(rerender, 5001, "b");
+  const sessionBInput = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!sessionBInput) throw new Error("session B textarea did not render");
+  await act(async () => {
+    sessionBInput.focus();
+    sessionBInput.setSelectionRange(1, 1);
+    sessionBInput.dispatchEvent(new window.KeyboardEvent("keyup", { key: "b", bubbles: true }));
+    await flushTimers();
+  });
+
+  await rerender({ sessionKey: sessionA, insertRequest: null });
+  eq(
+    (document.querySelector("textarea") as HTMLTextAreaElement | null)?.value,
+    "x/review",
+    "switching back restores session A slash draft",
+  );
+  await waitFor(
+    "restored session A slash menu",
+    () => Boolean(document.querySelector(".slashmenu")),
+  );
+  ok(
+    document.querySelector(".slashmenu") !== null,
+    "restoring a draft recomputes slash completion from its end caret",
+  );
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -2118,5 +2118,105 @@ console.log("\ncomposer goal toggle");
   dom.window.close();
 }
 
+{
+  const dom = installDom();
+  mockApp({
+    Commands: async () => [
+      { name: "review", description: "Review the current task", kind: "skill" },
+    ],
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => [],
+  });
+  const sessionA = "session:project:/repo:rich-topic-a:rich-session-a";
+  const sessionB = "session:project:/repo:rich-topic-b:rich-session-b";
+  const realRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const queuedComposerFrames: FrameRequestCallback[] = [];
+  globalThis.requestAnimationFrame = (callback) => {
+    queuedComposerFrames.push(callback);
+    return queuedComposerFrames.length;
+  };
+  const { root, rerender } = await renderComposer({ sessionKey: sessionA });
+
+  await replaceComposerDraft(rerender, 6000, "/review");
+  await waitFor("session A first skill menu", () => Boolean(document.querySelector(".slashmenu")));
+  const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("session A textarea did not render");
+  await act(async () => {
+    textarea.dispatchEvent(new window.KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await flushTimers();
+  });
+
+  let richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("session A rich input did not render");
+  await appendRichComposerInput(richInput, " /review");
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("session A rich input disappeared");
+  const queryAtEnd = document.createRange();
+  queryAtEnd.selectNodeContents(richInput);
+  queryAtEnd.collapse(false);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(queryAtEnd);
+  await act(async () => {
+    richInput.dispatchEvent(new window.KeyboardEvent("keyup", { key: "w", bubbles: true }));
+    await flushTimers();
+  });
+  await waitFor("session A second skill menu", () => Boolean(document.querySelector(".slashmenu")));
+
+  await rerender({ sessionKey: sessionB, insertRequest: null });
+  await replaceComposerDraft(rerender, 6001, "b");
+  await rerender({ sessionKey: sessionA, insertRequest: null });
+  await act(async () => {
+    let frameTime = 0;
+    while (queuedComposerFrames.length > 0) {
+      queuedComposerFrames.shift()?.(frameTime += 16);
+    }
+    await flushTimers();
+  });
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("session A rich input was not restored");
+  eq(richComposerTaskText(richInput), " /review", "switching back restores the rich invocation draft");
+  await waitFor(
+    "restored session A rich slash menu",
+    () => Boolean(document.querySelector(".slashmenu")),
+  );
+  ok(
+    document.querySelector(".slashmenu") !== null,
+    "restoring a rich invocation draft recomputes slash completion from its end caret",
+  );
+
+  await act(async () => {
+    richInput.dispatchEvent(new window.KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await flushTimers();
+  });
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  eq(
+    richInput?.querySelectorAll(".composer-invocation-token").length,
+    2,
+    "the restored rich slash query can select a second skill",
+  );
+  eq(richInput ? richComposerTaskText(richInput) : "", " ", "selecting the restored query replaces its slash token");
+
+  await rerender({ sessionKey: sessionB, insertRequest: null });
+  eq(
+    (document.querySelector("textarea") as HTMLTextAreaElement | null)?.value,
+    "b",
+    "switching away again preserves the other session draft",
+  );
+
+  await act(async () => {
+    root.unmount();
+  });
+  globalThis.requestAnimationFrame = realRequestAnimationFrame;
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -1375,6 +1375,115 @@ console.log("\ncomposer goal toggle");
 
 {
   const dom = installDom();
+  mockApp({
+    Commands: async () => [
+      { name: "writing-plans", description: "Write a plan", kind: "skill", color: "amber" },
+      { name: "review", description: "Review the result", kind: "skill" },
+      { name: "mcp", description: "Manage MCP servers", kind: "builtin", group: "integrations" },
+    ],
+    ListDirForTab: async () => [],
+    SearchFileRefsForTab: async () => [],
+  });
+  const { root, calls, rerender } = await renderComposer();
+
+  const initialText = "请用/检查";
+  await replaceComposerDraft(rerender, 1900, initialText);
+  let textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render for middle slash completion");
+  const slashCaret = "请用/".length;
+  await act(async () => {
+    textarea!.focus();
+    textarea!.setSelectionRange(slashCaret, slashCaret);
+    textarea!.dispatchEvent(new window.Event("select", { bubbles: true }));
+    textarea!.dispatchEvent(new window.KeyboardEvent("keyup", { key: "/", bubbles: true }));
+    await flushTimers();
+  });
+  await waitFor("middle slash command menu", () => Boolean(document.querySelector(".slashmenu")));
+
+  await act(async () => {
+    textarea!.dispatchEvent(new window.KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await flushTimers();
+  });
+
+  let richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  let tokens = richInput?.querySelectorAll<HTMLElement>(".composer-invocation-token");
+  if (!richInput || !tokens?.[0]) throw new Error("middle skill invocation did not render");
+  eq(richComposerTaskText(richInput), "请用检查", "first middle skill selection preserves surrounding text");
+  eq(
+    document.querySelector<HTMLElement>(".invocation-display--composer")?.style.getPropertyValue("--invocation-color"),
+    "#d59a2f",
+    "middle skill selection keeps its configured color",
+  );
+
+  const afterFirstToken = document.createRange();
+  afterFirstToken.setStartAfter(tokens[0]);
+  afterFirstToken.collapse(true);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(afterFirstToken);
+  await act(async () => {
+    dispatchPasteText(richInput!, "更多");
+    await flushTimers();
+  });
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("rich input disappeared after middle-skill paste");
+  eq(richComposerTaskText(richInput), "请用更多检查", "paste after a middle skill preserves the entity and suffix");
+  eq(
+    richInput.querySelectorAll(".composer-invocation-token").length,
+    1,
+    "paste after a middle skill keeps the selected entity",
+  );
+
+  await appendRichComposerInput(richInput, " /review");
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  if (!richInput) throw new Error("rich input disappeared before the second skill selection");
+  const queryAtEnd = document.createRange();
+  queryAtEnd.selectNodeContents(richInput);
+  queryAtEnd.collapse(false);
+  document.getSelection()?.removeAllRanges();
+  document.getSelection()?.addRange(queryAtEnd);
+  await act(async () => {
+    richInput!.dispatchEvent(new window.KeyboardEvent("keyup", { key: "w", bubbles: true }));
+    await flushTimers();
+  });
+  await waitFor("second skill menu at the end", () => Boolean(document.querySelector(".slashmenu")));
+  await act(async () => {
+    richInput!.dispatchEvent(new window.KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    }));
+    await flushTimers();
+  });
+
+  richInput = document.querySelector(".composer__rich-input") as HTMLDivElement | null;
+  tokens = richInput?.querySelectorAll<HTMLElement>(".composer-invocation-token");
+  eq(tokens?.length, 2, "a second skill can be inserted after existing text and an entity");
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("send button did not render for middle skill submission");
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+  eq(calls.structured[0]?.input, "请用更多检查", "middle skills submit the surrounding task text without slash tokens");
+  eq(
+    calls.structured[0]?.invocations.map((item) => item.name).join(","),
+    "writing-plans,review",
+    "multiple middle/end skills submit in visual order",
+  );
+  eq(calls.structured[0]?.invocations[0]?.offset, 2, "first middle skill keeps its text offset");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
   let commandsCalls = 0;
   const slashArgInputs: string[] = [];
   let availableCommands: CommandInfo[] = [

--- a/desktop/frontend/src/__tests__/composer-resized-input-css.test.ts
+++ b/desktop/frontend/src/__tests__/composer-resized-input-css.test.ts
@@ -56,6 +56,9 @@ eq(finalDeclaration(".composer-card--resized .composer__input", "height"), "100%
 eq(finalDeclaration(".composer-card--resized .composer__input", "overflow-y"), "auto", "resized textarea scrolls internally");
 eq(finalDeclaration(".composer-card--resized .composer__rich-input", "height"), "100%", "resized rich input fills the card's input area");
 eq(finalDeclaration(".composer-card--resized .composer__rich-input", "overflow-y"), "auto", "resized rich input scrolls internally");
+eq(finalDeclaration(".composer-invocation-caret-anchor", "min-width"), "1px", "invocation caret anchor keeps a compact hit target");
+eq(finalDeclaration(".composer-invocation-caret-anchor", "width"), undefined, "invocation caret anchor can expand around WebView2-hosted text");
+eq(finalDeclaration(".composer-invocation-caret-anchor", "overflow"), undefined, "invocation caret anchor does not clip WebView2-hosted text");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/rich-composer-selection.test.tsx
+++ b/desktop/frontend/src/__tests__/rich-composer-selection.test.tsx
@@ -184,6 +184,11 @@ console.log("\nrich composer slash queries");
   eq(middle?.to, 9, "slash query ends at the middle caret");
   eq(middle?.query, "review", "slash query after adjacent Chinese text captures its filter");
 
+  const insideToken = slashQueryAt("/review", { start: 4, end: 4 });
+  eq(insideToken?.from, 0, "slash query inside a token starts at its slash");
+  eq(insideToken?.to, 7, "slash query inside a token replaces the full command token");
+  eq(insideToken?.query, "rev", "slash query inside a token filters by text before the caret");
+
   const end = slashQueryAt("please inspect /", { start: 16, end: 16 });
   eq(end?.from, 15, "trailing slash opens a query at the end");
   eq(end?.query, "", "bare trailing slash exposes the full command menu");
@@ -753,6 +758,52 @@ function Harness({
     const remaining = document.querySelectorAll("[data-invocation-id]").length;
     eq(remaining, 0, "Backspace after skill tag removes the invocation");
   }
+
+  // The inline remove button is the pointer/touch-accessible counterpart to
+  // Backspace and must preserve the surrounding task text.
+  let clickRemovalSelection: RichComposerSelection | null = null;
+  let clickRemovalText = "";
+  function ClickRemoveHarness() {
+    const [invocations, setInvocations] = useState([
+      invocation("click-remove-target", 2, skillCommand),
+    ]);
+    return (
+      <LocaleProvider>
+        <RichComposerInput
+          text="task"
+          invocations={invocations}
+          placeholder="Message"
+          disabled={false}
+          onChange={(nextText, nextInvocations, origin) => {
+            clickRemovalText = nextText;
+            clickRemovalSelection = origin.afterSelection;
+            setInvocations(nextInvocations);
+          }}
+          onSelectionChange={() => {}}
+          onKeyDown={() => {}}
+          onPaste={() => {}}
+          onCompositionStart={() => {}}
+          onCompositionEnd={() => {}}
+        />
+      </LocaleProvider>
+    );
+  }
+
+  await act(async () => {
+    root.render(<ClickRemoveHarness />);
+    await flushTimers();
+  });
+  const removeInvocation = document.querySelector(
+    ".composer-invocation-token .invocation-display__remove",
+  ) as HTMLButtonElement | null;
+  ok(removeInvocation !== null, "inline invocation exposes an accessible remove button");
+  await act(async () => {
+    removeInvocation?.click();
+    await flushTimers();
+  });
+  eq(document.querySelectorAll("[data-invocation-id]").length, 0, "clicking remove deletes the invocation");
+  eq(clickRemovalText, "task", "clicking remove preserves surrounding task text");
+  eq(clickRemovalSelection?.start, 2, "clicking remove places the caret at the invocation offset");
 
   // External draft replacement rebuilds DOM; only explicit pending selection is restored.
   let externalSel: RichComposerSelection = { start: 0, end: 0 };

--- a/desktop/frontend/src/__tests__/rich-composer-selection.test.tsx
+++ b/desktop/frontend/src/__tests__/rich-composer-selection.test.tsx
@@ -13,11 +13,15 @@ import {
   RichComposerInput,
   selectionFromDom,
   setDomSelection,
+  slashQueryAt,
   type RichComposerInputHandle,
   type RichComposerSelection,
 } from "../components/RichComposerInput";
 import { LocaleProvider } from "../lib/i18n";
-import type { ComposerInvocation } from "../lib/invocationDisplay";
+import {
+  commandAvailableAtSlashPosition,
+  type ComposerInvocation,
+} from "../lib/invocationDisplay";
 import type { CommandInfo } from "../lib/types";
 
 let passed = 0;
@@ -166,6 +170,50 @@ function insertTextAtSelection(root: HTMLElement, data: string, known: Map<strin
   const afterModel = modelFromDom(root, known);
   const afterSel = selectionFromDom(root, known);
   return { beforeModel, beforeSel: beforeSel.selection, afterModel, afterSel };
+}
+
+console.log("\nrich composer slash queries");
+
+{
+  const start = slashQueryAt("/review", { start: 7, end: 7 });
+  eq(start?.from, 0, "slash query at the start keeps offset zero");
+  eq(start?.query, "review", "slash query at the start captures its filter");
+
+  const middle = slashQueryAt("请用/review检查", { start: 9, end: 9 });
+  eq(middle?.from, 2, "slash query after adjacent Chinese text keeps its real offset");
+  eq(middle?.to, 9, "slash query ends at the middle caret");
+  eq(middle?.query, "review", "slash query after adjacent Chinese text captures its filter");
+
+  const end = slashQueryAt("please inspect /", { start: 16, end: 16 });
+  eq(end?.from, 15, "trailing slash opens a query at the end");
+  eq(end?.query, "", "bare trailing slash exposes the full command menu");
+
+  eq(
+    slashQueryAt("please /review", { start: 7, end: 14 }),
+    null,
+    "a range selection does not open slash completion",
+  );
+  eq(
+    slashQueryAt("please /review later", { start: 20, end: 20 }),
+    null,
+    "moving beyond the slash token closes completion",
+  );
+  ok(
+    commandAvailableAtSlashPosition(skillCommand, false),
+    "skills remain available away from the message start",
+  );
+  ok(
+    commandAvailableAtSlashPosition(subagentCommand, false),
+    "subagents remain available away from the message start",
+  );
+  ok(
+    !commandAvailableAtSlashPosition({
+      name: "mcp",
+      description: "Manage MCP servers",
+      kind: "builtin",
+    }, false),
+    "builtin commands remain start-only",
+  );
 }
 
 console.log("\nrich composer selection mapping");

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -833,7 +833,9 @@ export function Composer({
     setPendingPaste(next.pendingPaste);
     setSubmitting(next.submitting);
     setHistoryIndex(next.historyIndex);
-    lastSelectionRef.current = { start: next.text.length, end: next.text.length };
+    const restoredSelection = { start: next.text.length, end: next.text.length };
+    lastSelectionRef.current = restoredSelection;
+    setPlainSelection(restoredSelection);
     setComposerPrompt(null);
     setShowPastChats(false);
     setDirectPastChats(false);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -11,6 +11,7 @@ import { SPINNER_WORDS, useI18n } from "../lib/i18n";
 import { detectShortcutPlatform, formatShortcutCombo, isReservedComposerHistoryShortcut, matchesShortcut, useShortcutComboLabel } from "../lib/keyboardShortcuts";
 import { fallbackCopyText } from "../lib/clipboard";
 import {
+  commandAvailableAtSlashPosition,
   commandUsesStructuredInvocation,
   invocationRequests,
   replaceInvocationTextRange,
@@ -42,6 +43,7 @@ import { ContextWindowRing } from "./ContextWindowRing";
 import { ImageViewer } from "./ImageViewer";
 import {
   RichComposerInput,
+  slashQueryAt,
   type RichComposerChangeOrigin,
   type RichComposerInputHandle,
   type RichComposerSelection,
@@ -667,6 +669,7 @@ export function Composer({
 
   const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceReference[]>([]);
   const [invocations, setInvocations] = useState<ComposerInvocation[]>([]);
+  const [plainSelection, setPlainSelection] = useState<RichComposerSelection>({ start: 0, end: 0 });
   const [richSelection, setRichSelection] = useState<RichComposerSelection>({ start: 0, end: 0 });
   const [richSlashQuery, setRichSlashQuery] = useState<RichSlashQuery | null>(null);
   const [pastedBlocks, setPastedBlocks] = useState<PastedBlock[]>([]);
@@ -1204,17 +1207,34 @@ export function Composer({
   }, [commands, onInvocationMetadataChange]);
 
   const slashText = useMemo(() => text.replace(/[\r\n]+$/u, ""), [text]);
-  const slashQuery = useMemo(() => {
-    if (invocations.length > 0) return richSlashQuery?.query ?? null;
-    if (!slashText.startsWith("/") || /\s/.test(slashText)) return null;
-    return slashText.slice(1).toLowerCase();
-  }, [invocations.length, richSlashQuery, slashText]);
+  const plainSlashQuery = useMemo(() => slashQueryAt(slashText, {
+    start: Math.min(plainSelection.start, slashText.length),
+    end: Math.min(plainSelection.end, slashText.length),
+  }), [plainSelection, slashText]);
+  const activeSlashQuery = invocations.length > 0 ? richSlashQuery : plainSlashQuery;
+  const slashQuery = activeSlashQuery?.query ?? null;
   const slashMatches = useMemo(
     () => slashQuery === null
       ? []
       : sortSlashCommandsForMenu(commands.filter((c) => c.name.toLowerCase().includes(slashQuery))),
     [slashQuery, commands],
   );
+  const slashCommandAtStart = Boolean(
+    activeSlashQuery
+    && invocations.length === 0
+    && slashText.slice(0, activeSlashQuery.from).trim() === "",
+  );
+  const slashCommandDisabled = useCallback(
+    (command: CommandInfo) => !commandAvailableAtSlashPosition(command, slashCommandAtStart),
+    [slashCommandAtStart],
+  );
+  const slashSelectableIndices = useMemo(
+    () => slashMatches.flatMap((command, index) => slashCommandDisabled(command) ? [] : [index]),
+    [slashCommandDisabled, slashMatches],
+  );
+  const slashQueryKey = activeSlashQuery
+    ? `${activeSlashQuery.from}:${activeSlashQuery.to}:${activeSlashQuery.query}`
+    : "";
 
   // --- slash argument completion ("/cmd <args>") --- mirrors the CLI: once past
   // the command word, the backend suggests sub-commands (/skill → list/show/…,
@@ -1405,7 +1425,7 @@ export function Composer({
   useEffect(() => {
     setActive(0);
     setDismissed(false);
-  }, [slashQuery, atRaw, pastChatTokenQuery]);
+  }, [slashQueryKey, atRaw, pastChatTokenQuery]);
 
   useEffect(() => {
     if (transientDismissSignal === undefined || transientDismissSignal === lastTransientDismissSignal.current) return;
@@ -1523,6 +1543,9 @@ export function Composer({
   };
 
   const setComposerSelection = (start: number, end = start, afterInvocationId?: string) => {
+    const nextSelection = { start, end, afterInvocationId };
+    lastSelectionRef.current = { start, end };
+    if (invocationsRef.current.length === 0) setPlainSelection(nextSelection);
     requestAnimationFrame(() => {
       if (invocationsRef.current.length > 0) {
         richInputRef.current?.setSelectionRange(start, end, afterInvocationId);
@@ -1532,7 +1555,6 @@ export function Composer({
       if (!ta) return;
       ta.focus();
       ta.setSelectionRange(start, end);
-      lastSelectionRef.current = { start, end };
     });
   };
 
@@ -1565,7 +1587,9 @@ export function Composer({
     }
     const ta = taRef.current;
     if (!ta) return;
-    lastSelectionRef.current = { start: ta.selectionStart ?? text.length, end: ta.selectionEnd ?? text.length };
+    const nextSelection = { start: ta.selectionStart ?? text.length, end: ta.selectionEnd ?? text.length };
+    lastSelectionRef.current = nextSelection;
+    setPlainSelection(nextSelection);
   };
 
   const insertNewlineAtCaret = () => {
@@ -2540,11 +2564,30 @@ export function Composer({
   };
 
   const pickCommand = (c: CommandInfo) => {
+    const query = activeSlashQuery;
+    if (!query || slashCommandDisabled(c)) return;
     if (!commandUsesStructuredInvocation(c)) {
       if (invocationsRef.current.length > 0 && richSlashQuery) {
         richInputRef.current?.replaceRange(`/${c.name} `, richSlashQuery.from, richSlashQuery.to);
       } else {
-        setTextCaretEnd("/" + c.name + " ");
+        const targetDraftKey = activeDraftKeyRef.current;
+        const beforeEdit = composerEditSnapshot(targetDraftKey, { start: query.from, end: query.to });
+        const next = replaceInvocationTextRange(
+          textRef.current,
+          invocationsRef.current,
+          query.from,
+          query.to,
+          `/${c.name} `,
+        );
+        const caret = query.from + c.name.length + 2;
+        textRef.current = next.text;
+        setText(next.text);
+        setComposerSelection(caret);
+        recordComposerEdit(
+          targetDraftKey,
+          beforeEdit,
+          composerEditSnapshot(targetDraftKey, { start: caret, end: caret }),
+        );
       }
       return;
     }
@@ -2554,23 +2597,38 @@ export function Composer({
       return;
     }
     const targetDraftKey = activeDraftKeyRef.current;
-    const beforeEdit = composerEditSnapshot(targetDraftKey);
+    const beforeEdit = composerEditSnapshot(targetDraftKey, { start: query.from, end: query.to });
     const invocation: ComposerInvocation = {
       id: `composer-invocation-${nextInvocationId.current++}`,
-      offset: 0,
+      offset: query.from,
       command: c,
     };
-    textRef.current = "";
+    const next = replaceInvocationTextRange(
+      textRef.current,
+      invocationsRef.current,
+      query.from,
+      query.to,
+      "",
+    );
+    textRef.current = next.text;
     invocationsRef.current = [invocation];
-    setText("");
+    setText(next.text);
     setInvocations([invocation]);
     setRichSlashQuery(null);
     recordComposerEdit(
       targetDraftKey,
       beforeEdit,
-      composerEditSnapshot(targetDraftKey, { start: 0, end: 0, afterInvocationId: invocation.id }),
+      composerEditSnapshot(targetDraftKey, {
+        start: query.from,
+        end: query.from,
+        afterInvocationId: invocation.id,
+      }),
     );
-    requestAnimationFrame(() => richInputRef.current?.setSelectionRange(0));
+    requestAnimationFrame(() => richInputRef.current?.setSelectionRange(
+      query.from,
+      query.from,
+      invocation.id,
+    ));
   };
 
   const activePastedBlocks = pastedBlocks.filter((block) => text.includes(block.label));
@@ -2933,9 +2991,15 @@ export function Composer({
   // Clamp active index when the menu item count changes (e.g. switching
   // between file list and past:chats list, or filtering sessions).
   useEffect(() => {
+    if (menuMode === "slash") {
+      if (!slashSelectableIndices.includes(active)) {
+        setActive(slashSelectableIndices[0] ?? 0);
+      }
+      return;
+    }
     const maxIdx = Math.max(0, count - 1);
     setActive((prev) => (prev > maxIdx ? 0 : prev));
-  }, [count]);
+  }, [active, count, menuMode, slashSelectableIndices]);
 
 
   const removeAtToken = (value: string) => {
@@ -2983,7 +3047,7 @@ export function Composer({
   const pickActive = () => {
     if (menuMode === "slash") {
       const item = slashMatches[active];
-      if (item) pickCommand(item);
+      if (item && !slashCommandDisabled(item)) pickCommand(item);
       return;
     }
     if (menuMode === "slasharg" && argRes) {
@@ -3135,12 +3199,33 @@ export function Composer({
     if (menuMode && !composing) {
       if (e.key === "ArrowDown" && count > 0) {
         e.preventDefault();
-        setActive((i) => (i + 1) % count);
+        if (menuMode === "slash") {
+          if (slashSelectableIndices.length > 0) {
+            setActive((current) => {
+              const currentPosition = slashSelectableIndices.indexOf(current);
+              return slashSelectableIndices[(currentPosition + 1) % slashSelectableIndices.length];
+            });
+          }
+        } else {
+          setActive((i) => (i + 1) % count);
+        }
         return;
       }
       if (e.key === "ArrowUp" && count > 0) {
         e.preventDefault();
-        setActive((i) => (i - 1 + count) % count);
+        if (menuMode === "slash") {
+          if (slashSelectableIndices.length > 0) {
+            setActive((current) => {
+              const currentPosition = slashSelectableIndices.indexOf(current);
+              const previousPosition = currentPosition < 0 ? 0 : currentPosition - 1;
+              return slashSelectableIndices[
+                (previousPosition + slashSelectableIndices.length) % slashSelectableIndices.length
+              ];
+            });
+          }
+        } else {
+          setActive((i) => (i - 1 + count) % count);
+        }
         return;
       }
       if (e.key === "Enter" || e.key === "Tab") {
@@ -3719,7 +3804,14 @@ export function Composer({
         )}
       </AnchoredPopover>
       {menuMode === "slash" && (
-        <SlashMenu items={slashMatches} activeIndex={active} onPick={pickCommand} onHover={setActive} />
+        <SlashMenu
+          items={slashMatches}
+          activeIndex={active}
+          onPick={pickCommand}
+          onHover={setActive}
+          isDisabled={slashCommandDisabled}
+          disabledReason={t("slash.startOnly")}
+        />
       )}
       {menuMode === "slasharg" && argRes && (
         <ArgMenu items={argRes.items} activeIndex={active} onPick={pickArg} onHover={setActive} />
@@ -4153,6 +4245,12 @@ export function Composer({
                     resetPromptHistoryNavigation();
                     textRef.current = e.target.value;
                     setText(e.target.value);
+                    const nextSelection = {
+                      start: e.target.selectionStart ?? e.target.value.length,
+                      end: e.target.selectionEnd ?? e.target.value.length,
+                    };
+                    lastSelectionRef.current = nextSelection;
+                    setPlainSelection(nextSelection);
                     syncComposerNativeHistory(targetDraftKey, inputType);
                     if (composerPrompt) setComposerPrompt(null);
                   }}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -757,6 +757,7 @@ export function Composer({
   const guidanceQueuePreviewKey = (guidanceQueuePreviewItems ?? []).map((item) => item.trim()).filter(Boolean).join("\n");
   const draftsBySessionRef = useRef<Record<string, ComposerDraft>>({});
   const activeDraftKeyRef = useRef(draftKey);
+  const draftActivationEpochRef = useRef(0);
   const textRef = useRef(text);
   const invocationsRef = useRef(invocations);
   const attachmentsRef = useRef(attachments);
@@ -809,7 +810,6 @@ export function Composer({
     selectedTextRefsRef.current = next.selectedTextRefs;
     setText(next.text);
     setInvocations(next.invocations);
-    setRichSlashQuery(null);
     setAttachments(next.attachments);
     setWorkspaceRefs(next.workspaceRefs);
     pastedBlocksRef.current = next.pastedBlocks;
@@ -836,6 +836,12 @@ export function Composer({
     const restoredSelection = { start: next.text.length, end: next.text.length };
     lastSelectionRef.current = restoredSelection;
     setPlainSelection(restoredSelection);
+    setRichSelection(restoredSelection);
+    setRichSlashQuery(
+      next.invocations.length > 0
+        ? slashQueryAt(next.text, restoredSelection)
+        : null,
+    );
     setComposerPrompt(null);
     setShowPastChats(false);
     setDirectPastChats(false);
@@ -1114,6 +1120,7 @@ export function Composer({
     const previousKey = activeDraftKeyRef.current;
     if (previousKey === draftKey) return;
     draftsBySessionRef.current[previousKey] = snapshotComposerDraft();
+    draftActivationEpochRef.current += 1;
     activeDraftKeyRef.current = draftKey;
     setGuidanceDraftKey(draftKey);
     restoreComposerDraft(draftsBySessionRef.current[draftKey] ?? emptyComposerDraft());
@@ -1536,6 +1543,14 @@ export function Composer({
     else taRef.current?.focus();
   };
 
+  const requestActiveDraftFrame = (callback: () => void) => {
+    const activationEpoch = draftActivationEpochRef.current;
+    requestAnimationFrame(() => {
+      if (draftActivationEpochRef.current !== activationEpoch) return;
+      callback();
+    });
+  };
+
   const getComposerSelection = () => {
     if (invocationsRef.current.length > 0) return richInputRef.current?.getSelection() ?? richSelection;
     const ta = taRef.current;
@@ -1548,7 +1563,7 @@ export function Composer({
     const nextSelection = { start, end, afterInvocationId };
     lastSelectionRef.current = { start, end };
     if (invocationsRef.current.length === 0) setPlainSelection(nextSelection);
-    requestAnimationFrame(() => {
+    requestActiveDraftFrame(() => {
       if (invocationsRef.current.length > 0) {
         richInputRef.current?.setSelectionRange(start, end, afterInvocationId);
         return;
@@ -1660,7 +1675,7 @@ export function Composer({
       workspaceRefsRef.current = next;
       return next;
     });
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   };
 
   useEffect(() => {
@@ -1706,7 +1721,7 @@ export function Composer({
       selectedTextRefsRef.current = next;
       setSelectedTextRefs(next);
     }
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   }, [draftKey, selectedTextRequest, showToast, t]);
 
   const expandPastedBlocks = (displayText: string, blocks = pastedBlocksRef.current): string => {
@@ -1742,7 +1757,7 @@ export function Composer({
   const removeAttachment = (path: string) => {
     forgetAttachment(path);
     setAttachments(attachmentsRef.current.filter((x) => x.path !== path));
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   };
 
   const attachmentSeenInDraft = (targetDraftKey: string, key: AttachmentDedupKey): boolean => {
@@ -1939,16 +1954,16 @@ export function Composer({
       // /goal ...), which would swallow entity invocations as goal prose and
       // never run them. Ask for a plain-text goal first.
       setComposerPrompt(t("composer.goalEntityBlocked"));
-      requestAnimationFrame(focusComposerInput);
+      requestActiveDraftFrame(focusComposerInput);
       return;
     }
     if (!trimmedText && currentAttachments.length === 0 && currentWorkspaceRefs.length === 0 && inlineInvocationCount === 0) {
       if (goalModeOn && !activeGoal) {
         setComposerPrompt(t("composer.goalInputRequired"));
-        requestAnimationFrame(focusComposerInput);
+        requestActiveDraftFrame(focusComposerInput);
       } else if (subagentInvocationCount > 0) {
         setComposerPrompt(t("composer.subagentTaskRequired"));
-        requestAnimationFrame(focusComposerInput);
+        requestActiveDraftFrame(focusComposerInput);
       }
       return;
     }
@@ -2626,7 +2641,7 @@ export function Composer({
         afterInvocationId: invocation.id,
       }),
     );
-    requestAnimationFrame(() => richInputRef.current?.setSelectionRange(
+    requestActiveDraftFrame(() => richInputRef.current?.setSelectionRange(
       query.from,
       query.from,
       invocation.id,
@@ -2639,7 +2654,7 @@ export function Composer({
   const removeWorkspaceReference = (target: WorkspaceReference) => {
     const key = workspaceReferenceKey(target);
     setWorkspaceRefs((prev) => prev.filter((ref) => workspaceReferenceKey(ref) !== key));
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   };
 
   const togglePastedPreview = (label: string) => {
@@ -2897,7 +2912,7 @@ export function Composer({
     setShowPastChats(false);
     setPastChatQuery("");
     setActive(0);
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   };
 
   // The typed panel follows the live token: typing in the composer extends
@@ -3377,24 +3392,24 @@ export function Composer({
   void onSetMode;
   const chooseApprovalMode = (nextMode: ToolApprovalMode) => {
     onSetToolApprovalMode(nextMode);
-    requestAnimationFrame(focusComposerInput);
+    requestActiveDraftFrame(focusComposerInput);
   };
   const chooseTaskMode = (nextMode: CollaborationMode) => {
     closeIntentMenu(() => {
       if (nextMode !== collaborationMode) onSetCollaborationMode(nextMode);
-      requestAnimationFrame(focusComposerInput);
+      requestActiveDraftFrame(focusComposerInput);
     });
   };
   const stopGoalMode = () => {
     closeIntentMenu(() => {
       onClearGoal();
-      requestAnimationFrame(focusComposerInput);
+      requestActiveDraftFrame(focusComposerInput);
     });
   };
   const chooseTokenMode = (mode: TokenMode) => {
     closeProfileMenu(() => {
       if (mode !== tokenMode) onSetTokenMode(mode);
-      requestAnimationFrame(focusComposerInput);
+      requestActiveDraftFrame(focusComposerInput);
     });
   };
   const runtimeProfileShortKey = tokenMode === "economy"
@@ -3440,7 +3455,7 @@ export function Composer({
   const chooseEffortLevel = (level: string) => {
     closeMoreMenu(() => {
       if (level !== currentEffort) onSetEffort(level);
-      requestAnimationFrame(focusComposerInput);
+      requestActiveDraftFrame(focusComposerInput);
     });
   };
   // Run-strip state machine: retry > waiting-approval > waiting-ask > streaming.
@@ -3623,7 +3638,7 @@ export function Composer({
           const files = Array.from(event.currentTarget.files ?? []);
           event.currentTarget.value = "";
           if (files.length > 0) attachFiles(files);
-          requestAnimationFrame(() => taRef.current?.focus());
+          requestActiveDraftFrame(() => taRef.current?.focus());
         }}
       />
       <AnchoredPopover
@@ -4083,7 +4098,7 @@ export function Composer({
                 const next = selectedTextRefsRef.current.filter((item) => item.id !== reference.id);
                 selectedTextRefsRef.current = next;
                 setSelectedTextRefs(next);
-                requestAnimationFrame(focusComposerInput);
+                requestActiveDraftFrame(focusComposerInput);
               }}
               name={reference.path ? reference.path.split("/").filter(Boolean).pop() ?? reference.path : selectedTextSnippet(reference.text)}
               meta={reference.path ? t("composer.selectedCode") : t("composer.selectedText")}

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -476,7 +476,9 @@ export function slashQueryAt(text: string, selection: RichComposerSelection): Ri
   const match = /\/([A-Za-z0-9_.:-]*)$/.exec(before);
   if (!match) return null;
   const slashOffset = before.length - match[1].length - 1;
-  return { from: slashOffset, to: selection.start, query: match[1].toLowerCase() };
+  let tokenEnd = selection.start;
+  while (tokenEnd < text.length && /[A-Za-z0-9_.:-]/.test(text[tokenEnd])) tokenEnd += 1;
+  return { from: slashOffset, to: tokenEnd, query: match[1].toLowerCase() };
 }
 
 let nextInvocationID = 1;
@@ -875,6 +877,18 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
           invocation={invocation}
           kind={invocation.kind}
           description={item.command.description}
+          onRemove={() => {
+            const current = known.get(item.id);
+            const currentOffset = current?.offset ?? offset;
+            const afterSelection = { start: currentOffset, end: currentOffset };
+            pendingSelectionRef.current = afterSelection;
+            onSelectionChange(afterSelection, null);
+            onChange(text, invocations.filter((candidate) => candidate.id !== item.id), {
+              source: "programmatic",
+              beforeSelection: lastValidSelectionRef.current,
+              afterSelection,
+            });
+          }}
           variant="composer"
         />
       </span>,

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -470,10 +470,10 @@ export function recoverSelectionAfterEdit(
   return collapsedAt(fallback.end);
 }
 
-function slashQueryAt(text: string, selection: RichComposerSelection): RichSlashQuery | null {
+export function slashQueryAt(text: string, selection: RichComposerSelection): RichSlashQuery | null {
   if (selection.start !== selection.end) return null;
   const before = text.slice(0, selection.start);
-  const match = /(?:^|\s)\/([A-Za-z0-9_.:-]*)$/.exec(before);
+  const match = /\/([A-Za-z0-9_.:-]*)$/.exec(before);
   if (!match) return null;
   const slashOffset = before.length - match[1].length - 1;
   return { from: slashOffset, to: selection.start, query: match[1].toLowerCase() };
@@ -563,7 +563,14 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
     const root = rootRef.current;
     if (!root) return;
     const selection = readSelection(root);
-    onSelectionChange(selection, slashQueryAt(text, selection));
+    const liveText = modelFromDom(root, known).text;
+    // A real selection event supersedes any browser-echo caret restoration
+    // that has not reached the layout effect yet.
+    if (pendingSelectionRef.current) pendingSelectionRef.current = selection;
+    // A keyup can arrive before React has echoed the preceding browser input
+    // back through props. Read the live DOM so slash completion sees the
+    // just-typed token instead of one render behind.
+    onSelectionChange(selection, slashQueryAt(liveText, selection));
   };
 
   const replaceRange = (value: string, start: number, end: number) => {
@@ -588,6 +595,15 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
       const target = { start, end, afterInvocationId };
       pendingSelectionRef.current = target;
       requestAnimationFrame(() => {
+        const pending = pendingSelectionRef.current;
+        if (
+          !pending
+          || pending.start !== target.start
+          || pending.end !== target.end
+          || pending.afterInvocationId !== target.afterInvocationId
+        ) {
+          return;
+        }
         const root = rootRef.current;
         if (!root) return;
         root.focus();
@@ -859,18 +875,6 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
           invocation={invocation}
           kind={invocation.kind}
           description={item.command.description}
-          onRemove={() => {
-            const current = known.get(item.id);
-            const currentOffset = current?.offset ?? offset;
-            const afterSelection = { start: currentOffset, end: currentOffset };
-            pendingSelectionRef.current = afterSelection;
-            onSelectionChange(afterSelection, null);
-            onChange(text, invocations.filter((candidate) => candidate.id !== item.id), {
-              source: "programmatic",
-              beforeSelection: lastValidSelectionRef.current,
-              afterSelection,
-            });
-          }}
           variant="composer"
         />
       </span>,

--- a/desktop/frontend/src/components/SlashMenu.tsx
+++ b/desktop/frontend/src/components/SlashMenu.tsx
@@ -51,11 +51,15 @@ export function SlashMenu({
   activeIndex,
   onPick,
   onHover,
+  isDisabled,
+  disabledReason,
 }: {
   items: CommandInfo[];
   activeIndex: number;
   onPick: (c: CommandInfo) => void;
   onHover: (i: number) => void;
+  isDisabled?: (c: CommandInfo) => boolean;
+  disabledReason?: string;
 }) {
   const t = useT();
   const grouped = new Map<SlashCommandGroup, Array<{ command: CommandInfo; commandIndex: number }>>();
@@ -88,16 +92,23 @@ export function SlashMenu({
         <button
           role="option"
           aria-selected={row.commandIndex === activeIndex}
-          className={`slashmenu__item ${row.commandIndex === activeIndex ? "slashmenu__item--active" : ""}`}
+          aria-disabled={isDisabled?.(row.command) || undefined}
+          className={`slashmenu__item ${row.commandIndex === activeIndex ? "slashmenu__item--active" : ""}${isDisabled?.(row.command) ? " slashmenu__item--disabled" : ""}`}
+          disabled={isDisabled?.(row.command)}
           onMouseDown={(e) => {
             e.preventDefault();
+            if (isDisabled?.(row.command)) return;
             onPick(row.command);
           }}
-          onMouseMove={() => onHover(row.commandIndex)}
+          onMouseMove={() => {
+            if (!isDisabled?.(row.command)) onHover(row.commandIndex);
+          }}
         >
           <span className="slashmenu__name">/{row.command.name}</span>
           {row.command.hint && <span className="slashmenu__hint">{row.command.hint}</span>}
-          <span className="slashmenu__desc">{row.command.description}</span>
+          <span className="slashmenu__desc">
+            {isDisabled?.(row.command) ? disabledReason : row.command.description}
+          </span>
           {slashCommandKindTag(row.command, t) && <span className="slashmenu__kind">{slashCommandKindTag(row.command, t)}</span>}
         </button>
       )}

--- a/desktop/frontend/src/lib/invocationDisplay.ts
+++ b/desktop/frontend/src/lib/invocationDisplay.ts
@@ -49,6 +49,10 @@ export function commandUsesStructuredInvocation(command: CommandInfo): boolean {
   return command.kind === "skill" || command.kind === "subagent";
 }
 
+export function commandAvailableAtSlashPosition(command: CommandInfo, atMessageStart: boolean): boolean {
+  return atMessageStart || commandUsesStructuredInvocation(command);
+}
+
 export function invocationLabel(name: string): string {
   const unqualified = name.split(":").pop() || name;
   return unqualified

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2513,6 +2513,7 @@ export const en = {
   "slash.mcp": "mcp",
   "slash.skill": "skill",
   "slash.subagent": "subagent",
+  "slash.startOnly": "Only available at the start of a message",
   "slash.group.actions": "Quick actions",
   "slash.group.management": "More commands",
   "slash.group.subagents": "Subagents",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1728,6 +1728,7 @@ export const zhTW: Record<DictKey, string> = {
   "slash.mcp": "mcp",
   "slash.skill": "skill",
   "slash.subagent": "子智能體",
+  "slash.startOnly": "僅可在訊息開頭使用",
   "slash.group.actions": "快速操作",
   "slash.group.management": "更多命令",
   "slash.group.subagents": "子智能體",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2516,6 +2516,7 @@ export const zh: Record<DictKey, string> = {
   "slash.mcp": "mcp",
   "slash.skill": "skill",
   "slash.subagent": "子智能体",
+  "slash.startOnly": "仅可在消息开头使用",
   "slash.group.actions": "快捷操作",
   "slash.group.management": "更多命令",
   "slash.group.subagents": "子智能体",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6033,6 +6033,14 @@ body > .mermaid-diagram--fullscreen {
 .slashmenu__item--active {
   background: var(--accent-soft);
 }
+.slashmenu__item--disabled {
+  color: var(--fg-faint);
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+.slashmenu__item--disabled .slashmenu__name {
+  color: var(--fg-faint);
+}
 .slashmenu__name {
   font-family: var(--mono);
   font-size: 13px;
@@ -6270,17 +6278,36 @@ body > .mermaid-diagram--fullscreen {
 .composer-invocation-token {
   display: inline-block;
   max-width: min(100%, 320px);
-  margin: 0 3px;
+  margin: 0 1px;
   vertical-align: baseline;
   white-space: nowrap;
 }
 .composer-invocation-token:first-child {
   margin-left: 0;
 }
+.composer-invocation-token .invocation-display--composer {
+  gap: 0;
+  min-height: 0;
+}
+.composer-invocation-token .invocation-display__identity {
+  gap: 4px;
+  padding: 0;
+}
+.composer-invocation-token .invocation-display__identity > svg {
+  width: 1em;
+  height: 1em;
+}
+.composer-invocation-token .invocation-display__name {
+  font-size: inherit;
+  font-weight: 600;
+  line-height: inherit;
+}
 .composer-invocation-caret-anchor {
   display: inline-block;
-  min-width: 8px;
+  width: 1px;
+  min-width: 1px;
   min-height: 1em;
+  overflow: hidden;
   vertical-align: text-bottom;
 }
 .composer-card--resized .composer__rich-input {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6304,10 +6304,8 @@ body > .mermaid-diagram--fullscreen {
 }
 .composer-invocation-caret-anchor {
   display: inline-block;
-  width: 1px;
   min-width: 1px;
   min-height: 1em;
-  overflow: hidden;
   vertical-align: text-bottom;
 }
 .composer-card--resized .composer__rich-input {


### PR DESCRIPTION
Related to #6953.

### Summary

- Open the slash menu from the current caret position instead of limiting it to
  an empty composer or the beginning of the message.
- Allow skills and subagents to be inserted as structured inline entities at
  the beginning, middle, or end of the task.
- Preserve surrounding text, invocation offsets, ordering, and structured
  submission metadata when multiple skills are used.
- Keep management and other start-only slash commands visible but disabled away
  from the beginning of the message.
- Make inline skill entities compact and theme-aware so they align with normal
  composer text.

### Problem

The desktop composer treated the beginning of the message as the primary slash
command boundary:

- the plain textarea only opened completion when the whole draft started with
  `/`;
- the rich composer required `/` to follow whitespace or the beginning of the
  text;
- selecting the first structured invocation forced its offset to `0` and
  cleared the existing task text;
- contentEditable key events could observe React props one render behind the
  live browser DOM.

As a result, users could not reliably insert a skill after existing text,
between CJK characters, or at the end of a draft.

### Implementation

- Represent the active slash token as a caret-relative
  `{ from, to, query }` range shared by the plain and rich composer paths.
- Track the textarea selection and replace only the active slash range when a
  command is selected.
- Store skills and subagents as zero-length structured invocations with their
  real logical text offsets instead of converting them into ordinary slash
  text.
- Read the live contentEditable DOM when reporting slash completion so the
  just-typed token is not one React render behind.
- Ignore stale asynchronous caret-restoration work after the user moves or
  continues typing, preventing an old selection from closing the slash menu.
- Centralize position eligibility:
  - all slash commands remain available at the beginning of a message;
  - only structured skills and subagents are selectable elsewhere.
- Skip disabled start-only commands during keyboard navigation and expose their
  restriction through disabled and accessible menu states.
- Tighten inline invocation typography, icon size, token spacing, and WebKit
  caret-anchor width. Skills without an explicit custom color continue to use
  the active theme accent.

### User impact

Users can now type `/` at any caret position, including directly after Chinese
text, and insert a skill without losing or relocating surrounding text.
Multiple skills can coexist in one task and are submitted in visual order with
correct offsets.

Existing command semantics are preserved: management commands still execute
only at the beginning of a message.

### Validation

- `rich-composer-selection`: 92 passed
- `composer-goal-toggle`: 193 passed
- TypeScript typecheck passed
- CSS syntax and z-index token checks passed
- Production frontend build passed
- `wails build -debug` passed
- Manually verified in an isolated native macOS Wails build:
  - slash completion at the beginning, middle, and end;
  - insertion adjacent to CJK text;
  - multiple skills;
  - paste after an inline skill;
  - theme-aware color and compact inline layout;
  - normal startup without Safe Mode skill-discovery suppression.
