### PR TITLE
fix(desktop): pin BranchMeta scope on new session to prevent project-to-global misclassification / 修复新建项目会话被错误归类为全局工作空间

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3408,6 +3408,7 @@ func (a *App) openTransientBlankRuntime(scope, workspaceRoot string) error {
 	if err != nil {
 		return err
 	}
+	pinSessionBranchMeta(sessionPath, scope, actualRoot, "", defaultTopicTitle)
 	tab := &WorkspaceTab{
 		Scope:            scope,
 		WorkspaceRoot:    actualRoot,

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3408,7 +3408,9 @@ func (a *App) openTransientBlankRuntime(scope, workspaceRoot string) error {
 	if err != nil {
 		return err
 	}
-	pinSessionBranchMeta(sessionPath, scope, actualRoot, "", defaultTopicTitle)
+	if err := pinNewEmptySessionBranchMeta(sessionPath, scope, actualRoot, "", defaultTopicTitle); err != nil {
+		return err
+	}
 	tab := &WorkspaceTab{
 		Scope:            scope,
 		WorkspaceRoot:    actualRoot,

--- a/desktop/new_session_meta_test.go
+++ b/desktop/new_session_meta_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestPinNewEmptySessionBranchMetaStoresBinding(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	tests := []struct {
+		name          string
+		scope         string
+		workspaceRoot string
+		topicID       string
+		topicTitle    string
+		wantRoot      string
+	}{
+		{
+			name:          "project",
+			scope:         "project",
+			workspaceRoot: projectRoot,
+			topicID:       "topic_project",
+			topicTitle:    "Project topic",
+			wantRoot:      normalizeProjectRoot(projectRoot),
+		},
+		{
+			name:          "global",
+			scope:         "global",
+			workspaceRoot: globalWorkspaceRoot(),
+			topicID:       "topic_global",
+			topicTitle:    "Global topic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := createEmptySessionFile(t.TempDir(), "test-model")
+			if err != nil {
+				t.Fatalf("createEmptySessionFile: %v", err)
+			}
+			err = pinNewEmptySessionBranchMeta(
+				path,
+				tt.scope,
+				tt.workspaceRoot,
+				tt.topicID,
+				tt.topicTitle,
+			)
+			if err != nil {
+				t.Fatalf("pinNewEmptySessionBranchMeta: %v", err)
+			}
+			meta, ok, err := agent.LoadBranchMeta(path)
+			if err != nil || !ok {
+				t.Fatalf("LoadBranchMeta(%q): ok=%v err=%v", path, ok, err)
+			}
+			if meta.Scope != tt.scope ||
+				meta.WorkspaceRoot != tt.wantRoot ||
+				meta.TopicID != tt.topicID ||
+				meta.TopicTitle != tt.topicTitle {
+				t.Fatalf(
+					"branch meta binding = scope %q root %q topic %q title %q, want %q %q %q %q",
+					meta.Scope,
+					meta.WorkspaceRoot,
+					meta.TopicID,
+					meta.TopicTitle,
+					tt.scope,
+					tt.wantRoot,
+					tt.topicID,
+					tt.topicTitle,
+				)
+			}
+		})
+	}
+}
+
+func TestPinnedSessionMetaKeepsProjectBindingOutsideKnownDirectories(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_unknown_dir"
+	topicTitle := "Unknown directory"
+	sessionPath, err := createEmptySessionFile(t.TempDir(), "test-model")
+	if err != nil {
+		t.Fatalf("createEmptySessionFile: %v", err)
+	}
+	if err := pinNewEmptySessionBranchMeta(
+		sessionPath,
+		"project",
+		projectRoot,
+		topicID,
+		topicTitle,
+	); err != nil {
+		t.Fatalf("pinNewEmptySessionBranchMeta: %v", err)
+	}
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:            "tab_unknown_dir",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       topicID,
+		TopicTitle:    topicTitle,
+		SessionPath:   sessionPath,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	resolved, ok := app.reconcileTabWithPinnedSessionMeta(tab)
+	if !ok || !sameDesktopPath(resolved, sessionPath) {
+		t.Fatalf("reconcile binding = %q, %v, want %q, true", resolved, ok, sessionPath)
+	}
+	if tab.Scope != "project" || !sameProjectRoot(tab.WorkspaceRoot, projectRoot) {
+		t.Fatalf("reconciled tab binding = %q/%q, want project/%q", tab.Scope, tab.WorkspaceRoot, projectRoot)
+	}
+}
+
+func TestPinSessionBranchMetaReturnsCorruptSidecarError(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	sessionPath := filepath.Join(t.TempDir(), "corrupt.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	metaPath := agent.BranchMetaPath(sessionPath)
+	const corruptMeta = `{"scope":`
+	if err := os.WriteFile(metaPath, []byte(corruptMeta), 0o644); err != nil {
+		t.Fatalf("write corrupt branch meta: %v", err)
+	}
+
+	if err := pinSessionBranchMeta(sessionPath, "project", t.TempDir(), "topic", "Topic"); err == nil {
+		t.Fatal("pinSessionBranchMeta error = nil, want corrupt sidecar error")
+	}
+	got, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read corrupt branch meta: %v", err)
+	}
+	if string(got) != corruptMeta {
+		t.Fatalf("corrupt branch meta was overwritten: %q", got)
+	}
+}
+
+func TestPinNewEmptySessionBranchMetaCleansUpRejectedBinding(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := t.TempDir()
+	path, err := createEmptySessionFile(dir, "test-model")
+	if err != nil {
+		t.Fatalf("createEmptySessionFile: %v", err)
+	}
+	if err := pinNewEmptySessionBranchMeta(
+		path,
+		"project",
+		"",
+		"topic",
+		"Topic",
+	); err == nil {
+		t.Fatal("pinNewEmptySessionBranchMeta error = nil, want missing project root error")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read session dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".meta") {
+			t.Fatalf("rejected binding left session artifact %q", name)
+		}
+	}
+}
+
+func TestPinSessionBranchMetaPreservesExistingFields(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	sessionPath := filepath.Join(t.TempDir(), "existing.jsonl")
+	if err := os.WriteFile(sessionPath, nil, 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	existing := agent.BranchMeta{
+		CustomTitle:    "Keep title",
+		Model:          "provider/model",
+		Revision:       7,
+		ContentDigest:  "digest",
+		WriterID:       "writer",
+		SchemaVersion:  agent.BranchMetaCountsVersion,
+		Turns:          3,
+		Preview:        "Keep preview",
+		RecoveryReason: "keep recovery",
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, existing); err != nil {
+		t.Fatalf("save existing branch meta: %v", err)
+	}
+
+	projectRoot := t.TempDir()
+	if err := pinSessionBranchMeta(sessionPath, "project", projectRoot, "topic", "Topic"); err != nil {
+		t.Fatalf("pinSessionBranchMeta: %v", err)
+	}
+	got, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+	}
+	if got.CustomTitle != existing.CustomTitle ||
+		got.Model != existing.Model ||
+		got.Revision != existing.Revision ||
+		got.ContentDigest != existing.ContentDigest ||
+		got.WriterID != existing.WriterID ||
+		got.SchemaVersion != existing.SchemaVersion ||
+		got.Turns != existing.Turns ||
+		got.Preview != existing.Preview ||
+		got.RecoveryReason != existing.RecoveryReason {
+		t.Fatalf("pinning dropped existing fields: got %+v, existing %+v", got, existing)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2220,7 +2220,10 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.mu.Unlock()
 			return TabMeta{}, err
 		}
-		pinSessionBranchMeta(sessionPath, scope, actualRoot, topicID, topicTitle)
+		if err := pinNewEmptySessionBranchMeta(sessionPath, scope, actualRoot, topicID, topicTitle); err != nil {
+			a.mu.Unlock()
+			return TabMeta{}, err
+		}
 	}
 	profile := loadTabSessionProfile(sessionPath)
 	tab := &WorkspaceTab{
@@ -2478,7 +2481,12 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 			a.mu.Unlock()
 			return TabMeta{}, err
 		}
-		pinSessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle)
+		if err := pinNewEmptySessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle); err != nil {
+			delete(a.tabs, tabID)
+			a.removeTabOrderLocked(tabID)
+			a.mu.Unlock()
+			return TabMeta{}, err
+		}
 		created.SessionPath = prePath
 		a.saveTabsLocked()
 		meta := a.tabMeta(created, true)
@@ -2528,7 +2536,12 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 		a.mu.Unlock()
 		return TabMeta{}, err
 	}
-	pinSessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle)
+	if err := pinNewEmptySessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle); err != nil {
+		delete(a.tabs, tabID)
+		a.removeTabOrderLocked(tabID)
+		a.mu.Unlock()
+		return TabMeta{}, err
+	}
 	created.SessionPath = prePath
 	a.saveTabsLocked()
 	meta := a.tabMeta(created, true)
@@ -2585,21 +2598,41 @@ func createEmptySessionFile(dir, model string) (string, error) {
 	return "", fmt.Errorf("create empty session file: exhausted filename retries")
 }
 
-// pinSessionBranchMeta stores the workspace scope, root, and topic on a
-// newly created session's BranchMeta sidecar so that the tab controller
-// build (reconcileTabWithPinnedSessionMeta) does not reclassify a
-// project-scoped tab as global (issue #6914).
-func pinSessionBranchMeta(sessionPath, scope, workspaceRoot, topicID, topicTitle string) {
-	m, ok, err := agent.LoadBranchMeta(sessionPath)
-	if err != nil || !ok {
-		return
+func pinNewEmptySessionBranchMeta(path, scope, workspaceRoot, topicID, topicTitle string) error {
+	if err := pinSessionBranchMeta(path, scope, workspaceRoot, topicID, topicTitle); err != nil {
+		pinErr := fmt.Errorf("pin empty session metadata: %w", err)
+		if cleanupErr := removeDesktopSessionArtifacts(path); cleanupErr != nil {
+			return errors.Join(pinErr, fmt.Errorf("clean up unbound empty session: %w", cleanupErr))
+		}
+		return pinErr
+	}
+	return nil
+}
+
+// pinSessionBranchMeta stores the workspace scope, root, and topic on a newly
+// created session before a controller can reconcile the tab against it.
+func pinSessionBranchMeta(sessionPath, scope, workspaceRoot, topicID, topicTitle string) error {
+	unlock := agent.LockSessionMetaPath(sessionPath)
+	defer unlock()
+	m, err := agent.EnsureBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(scope) == "project" {
+		workspaceRoot = normalizeProjectRoot(workspaceRoot)
+		if workspaceRoot == "" {
+			return fmt.Errorf("project workspace root is required")
+		}
+		scope = "project"
+	} else {
+		scope = "global"
+		workspaceRoot = ""
 	}
 	m.Scope = scope
 	m.WorkspaceRoot = workspaceRoot
 	m.TopicID = topicID
 	m.TopicTitle = topicTitle
-	m.UpdatedAt = time.Now().UTC()
-	_ = agent.SaveBranchMeta(sessionPath, m)
+	return agent.SaveBranchMetaPreserveUpdated(sessionPath, m)
 }
 
 func blankTabSessionPathHasNoContent(tab *WorkspaceTab) bool {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2220,6 +2220,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.mu.Unlock()
 			return TabMeta{}, err
 		}
+		pinSessionBranchMeta(sessionPath, scope, actualRoot, topicID, topicTitle)
 	}
 	profile := loadTabSessionProfile(sessionPath)
 	tab := &WorkspaceTab{
@@ -2477,6 +2478,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 			a.mu.Unlock()
 			return TabMeta{}, err
 		}
+		pinSessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle)
 		created.SessionPath = prePath
 		a.saveTabsLocked()
 		meta := a.tabMeta(created, true)
@@ -2526,6 +2528,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 		a.mu.Unlock()
 		return TabMeta{}, err
 	}
+	pinSessionBranchMeta(prePath, scope, actualRoot, topicID, topicTitle)
 	created.SessionPath = prePath
 	a.saveTabsLocked()
 	meta := a.tabMeta(created, true)
@@ -2580,6 +2583,23 @@ func createEmptySessionFile(dir, model string) (string, error) {
 		return "", err
 	}
 	return "", fmt.Errorf("create empty session file: exhausted filename retries")
+}
+
+// pinSessionBranchMeta stores the workspace scope, root, and topic on a
+// newly created session's BranchMeta sidecar so that the tab controller
+// build (reconcileTabWithPinnedSessionMeta) does not reclassify a
+// project-scoped tab as global (issue #6914).
+func pinSessionBranchMeta(sessionPath, scope, workspaceRoot, topicID, topicTitle string) {
+	m, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return
+	}
+	m.Scope = scope
+	m.WorkspaceRoot = workspaceRoot
+	m.TopicID = topicID
+	m.TopicTitle = topicTitle
+	m.UpdatedAt = time.Now().UTC()
+	_ = agent.SaveBranchMeta(sessionPath, m)
 }
 
 func blankTabSessionPathHasNoContent(tab *WorkspaceTab) bool {


### PR DESCRIPTION
## Summary

When a user opens a folder, `createEmptySessionFile` writes the new
session's BranchMeta sidecar with an empty `Scope` field. During the
tab controller build, if `resolveSessionBinding` reaches
`sessionBindingFromMeta` (for example, when the project's session directory is
not yet discoverable in `knownSessionDirs`), the empty scope causes
`DefaultScope()` to return `"global"`. `applySessionBindingToTab` then
overwrites the tab's correct `"project"` scope, and the wrong value is
persisted to `desktop-tabs.json` while `desktop-projects.json` remains correct.

The fix pins the session scope, normalized workspace root, topic ID, and topic
title before controller reconciliation can read the sidecar.

The metadata write is failure-atomic:

- the read-modify-write is serialized with the per-session metadata lock;
- BranchMeta load/save failures are returned instead of being ignored;
- controller startup does not continue with an unbound session;
- a newly created session is cleaned up if its binding cannot be persisted.

## Affected paths

- `openTopicTabWithActivation` — open-folder, OpenProjectTab, etc.
- `ensureBlankTab` (×2) — new blank topic and reused blank topic
- `openTransientBlankRuntime` — session-deletion fallback

## Regression coverage

- project and global sessions persist the expected binding at creation;
- fallback reconciliation preserves project scope when the session directory is
  outside `knownSessionDirs`;
- corrupt BranchMeta sidecars fail visibly instead of being overwritten;
- rejected project bindings leave no orphaned session or sidecar;
- existing BranchMeta revision, digest, writer, title, recovery, and listing
  fields survive the locked read-modify-write.

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| `BranchMeta.scope`, `workspace_root`, `topic_id`, `topic_title` | These optional fields already exist; old sidecars missing them still deserialize to their existing zero-value behavior. | No schema migration required. |
| Existing BranchMeta fields | The pin operation loads and updates the existing record under the session metadata lock. Regression coverage verifies revision/digest/writer/title/recovery/listing fields are preserved. | Safe read-modify-write. |
| Older Reasonix versions | The change writes only field names already understood by previous releases. | Cross-version readable. |
| `desktop-tabs.json` | No field or identifier format changes. | Unchanged. |

## Verification

- [x] Focused new-session and affected-path tests pass
- [x] `go test -short -count=1 ./...` from `desktop/` passes on the PR head
- [x] `go test -short -count=1 ./...` from `desktop/` passes on a clean merge
  simulation with the latest `main-v2`
- [x] Focused `go test -race` regression suite passes
- [x] `git diff --check` passes
- [x] The PR merges cleanly with the latest `main-v2`

Cache-impact: none
Cache-guard: N/A
System-prompt-review: N/A

Fix #6914
