### PR TITLE
Preserve machine session directory scope and add project root / 保留机器接口 Session 目录并支持项目根目录

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -146,18 +146,20 @@ first redacted-machine invocation may initialize a private identity key in the
 Reasonix user-state directory:
 
 ```sh
-reasonix session list --json [--dir SESSION_DIR]
-reasonix session show <machine-session-id> --json [--dir SESSION_DIR]
-reasonix session status <machine-session-id> --json [--dir SESSION_DIR]
-reasonix session recovery [<machine-session-id>] --json [--dir SESSION_DIR]
-reasonix task list --json [--dir SESSION_DIR] [--session MACHINE_SESSION_ID]
-reasonix task show <task-id> --json [--dir SESSION_DIR] [--session MACHINE_SESSION_ID]
+reasonix session list --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session show <machine-session-id> --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session status <machine-session-id> --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session recovery [<machine-session-id>] --json [--dir SESSION_DIR | --project-root PATH]
+reasonix task list --json [--dir SESSION_DIR | --project-root PATH] [--session MACHINE_SESSION_ID]
+reasonix task show <task-id> --json [--dir SESSION_DIR | --project-root PATH] [--session MACHINE_SESSION_ID]
 reasonix hook list --json [--project-root PATH] [--home-dir PATH]
 reasonix hook status --json [--project-root PATH] [--home-dir PATH]
 ```
 
 For `session` and `task`, `--dir` explicitly selects the session storage
-directory; without it, Reasonix selects the current project's session store.
+directory, while `--project-root` resolves the selected project's session
+store. The two options cannot be combined. Without either option, Reasonix
+selects the current project's session store.
 For `hook`, `--dir` is an alias for `--project-root`.
 `hook list` reports `active` or `invalid`; `invalid` means the
 configured event cannot execute because its event, command/context source, or

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -138,18 +138,19 @@ PID 或 hostname。这里的“只读”是指不会修改 transcript、runtime�
 状态；首次使用脱敏机器接口时，Reasonix 可能会在用户状态目录初始化一个私有身份密钥：
 
 ```sh
-reasonix session list --json [--dir SESSION_DIR]
-reasonix session show <machine-session-id> --json [--dir SESSION_DIR]
-reasonix session status <machine-session-id> --json [--dir SESSION_DIR]
-reasonix session recovery [<machine-session-id>] --json [--dir SESSION_DIR]
-reasonix task list --json [--dir SESSION_DIR] [--session MACHINE_SESSION_ID]
-reasonix task show <task-id> --json [--dir SESSION_DIR] [--session MACHINE_SESSION_ID]
+reasonix session list --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session show <machine-session-id> --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session status <machine-session-id> --json [--dir SESSION_DIR | --project-root PATH]
+reasonix session recovery [<machine-session-id>] --json [--dir SESSION_DIR | --project-root PATH]
+reasonix task list --json [--dir SESSION_DIR | --project-root PATH] [--session MACHINE_SESSION_ID]
+reasonix task show <task-id> --json [--dir SESSION_DIR | --project-root PATH] [--session MACHINE_SESSION_ID]
 reasonix hook list --json [--project-root PATH] [--home-dir PATH]
 reasonix hook status --json [--project-root PATH] [--home-dir PATH]
 ```
 
-对于 `session` 和 `task`，`--dir` 明确指定 session 存储目录；未指定时，Reasonix
-选择当前项目的 session store。对于 `hook`，`--dir` 是 `--project-root` 的别名。
+对于 `session` 和 `task`，`--dir` 明确指定 session 存储目录，`--project-root`
+则解析指定项目的 session store；两者不能同时使用。都未指定时，Reasonix 选择当前
+项目的 session store。对于 `hook`，`--dir` 是 `--project-root` 的别名。
 `hook list` 的状态值为 `active` 或 `invalid`；`invalid` 表示配置的
 event 因事件名、命令/context 来源或工具事件 matcher 无效而无法执行。非工具事件
 会忽略 matcher。

--- a/internal/cli/recovery_machine_test.go
+++ b/internal/cli/recovery_machine_test.go
@@ -16,7 +16,7 @@ func TestSessionMachineRecoveryIsContentFree(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "recoverable", time.Date(2026, 7, 23, 14, 0, 0, 0, time.UTC))
-	path := filepath.Join(dir, "recoverable.jsonl")
+	path := filepath.Join(machineTestSessionDir(dir), "recoverable.jsonl")
 	if err := agent.MarkSessionInFlightTurn(path, 1, true); err != nil {
 		t.Fatalf("mark in-flight: %v", err)
 	}

--- a/internal/cli/recovery_machine_test.go
+++ b/internal/cli/recovery_machine_test.go
@@ -16,7 +16,7 @@ func TestSessionMachineRecoveryIsContentFree(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "recoverable", time.Date(2026, 7, 23, 14, 0, 0, 0, time.UTC))
-	path := filepath.Join(machineTestSessionDir(dir), "recoverable.jsonl")
+	path := filepath.Join(dir, "recoverable.jsonl")
 	if err := agent.MarkSessionInFlightTurn(path, 1, true); err != nil {
 		t.Fatalf("mark in-flight: %v", err)
 	}

--- a/internal/cli/session_machine.go
+++ b/internal/cli/session_machine.go
@@ -107,6 +107,8 @@ func runSessionCommand(args []string, out io.Writer) int {
 	}
 	if options.dir == "" {
 		options.dir = resolveCLISessionDir()
+	} else {
+		options.dir = machineProjectSessionDir(options.dir)
 	}
 	identityKey, err := loadMachineIdentityKey()
 	if err != nil {
@@ -141,6 +143,15 @@ func runSessionCommand(args []string, out io.Writer) int {
 		})
 	}
 	return writeMachineError(out, command, "session_not_found", "session was not found")
+}
+
+// machineProjectSessionDir maps the public --dir project-root argument to the
+// per-project session store used by the machine interface.
+func machineProjectSessionDir(projectRoot string) string {
+	if dir := config.ProjectSessionDir(projectRoot); dir != "" {
+		return dir
+	}
+	return projectRoot
 }
 
 func parseSessionMachineOptions(args []string, operation string) (sessionMachineOptions, string, string) {

--- a/internal/cli/session_machine.go
+++ b/internal/cli/session_machine.go
@@ -79,9 +79,10 @@ type machineErrorResponse struct {
 }
 
 type sessionMachineOptions struct {
-	dir    string
-	target string
-	json   bool
+	dir         string
+	projectRoot string
+	target      string
+	json        bool
 }
 
 func sessionCommand(args []string) int {
@@ -105,11 +106,7 @@ func runSessionCommand(args []string, out io.Writer) int {
 	if !options.json {
 		return writeMachineError(out, command, "invalid_argument", "--json is required")
 	}
-	if options.dir == "" {
-		options.dir = resolveCLISessionDir()
-	} else {
-		options.dir = machineProjectSessionDir(options.dir)
-	}
+	options.dir = resolveMachineSessionDir(options.dir, options.projectRoot)
 	identityKey, err := loadMachineIdentityKey()
 	if err != nil {
 		return writeMachineError(out, command, "machine_identity_unavailable", "machine identity is unavailable")
@@ -145,8 +142,17 @@ func runSessionCommand(args []string, out io.Writer) int {
 	return writeMachineError(out, command, "session_not_found", "session was not found")
 }
 
-// machineProjectSessionDir maps the public --dir project-root argument to the
-// per-project session store used by the machine interface.
+func resolveMachineSessionDir(sessionDir, projectRoot string) string {
+	if projectRoot != "" {
+		return machineProjectSessionDir(projectRoot)
+	}
+	if sessionDir != "" {
+		return sessionDir
+	}
+	return resolveCLISessionDir()
+}
+
+// machineProjectSessionDir maps a project root to its per-project session store.
 func machineProjectSessionDir(projectRoot string) string {
 	if dir := config.ProjectSessionDir(projectRoot); dir != "" {
 		return dir
@@ -166,6 +172,12 @@ func parseSessionMachineOptions(args []string, operation string) (sessionMachine
 			}
 			i++
 			options.dir = args[i]
+		case "--project-root":
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
+				return options, "invalid_argument", "--project-root requires a value"
+			}
+			i++
+			options.projectRoot = args[i]
 		case "--help", "-h":
 			return options, "invalid_argument", "use the documented machine interface"
 		default:
@@ -178,6 +190,9 @@ func parseSessionMachineOptions(args []string, operation string) (sessionMachine
 			}
 			options.target = arg
 		}
+	}
+	if options.dir != "" && options.projectRoot != "" {
+		return options, "invalid_argument", "--dir and --project-root cannot be combined"
 	}
 	if operation != "list" && operation != "recovery" && options.target == "" {
 		return options, "invalid_argument", "a session identifier is required"

--- a/internal/cli/session_machine_test.go
+++ b/internal/cli/session_machine_test.go
@@ -3,12 +3,14 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/provider"
 )
 
@@ -50,7 +52,7 @@ func TestSessionMachineShowAndStatusExposeOnlySafeState(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "busy", time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC))
-	path := filepath.Join(dir, "busy.jsonl")
+	path := filepath.Join(machineTestSessionDir(dir), "busy.jsonl")
 	lease, err := agent.TryAcquireSessionLease(path)
 	if err != nil {
 		t.Fatalf("acquire session lease: %v", err)
@@ -129,7 +131,11 @@ func TestSessionMachineErrorsAreJSONAndNonZero(t *testing.T) {
 
 func saveMachineTestSession(t *testing.T, dir, id string, updatedAt time.Time) {
 	t.Helper()
-	path := filepath.Join(dir, id+".jsonl")
+	sessionDir := config.ProjectSessionDir(dir)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatalf("create project session dir: %v", err)
+	}
+	path := filepath.Join(sessionDir, id+".jsonl")
 	session := agent.NewSession("")
 	session.Add(provider.Message{Role: provider.RoleUser, Content: "private prompt"})
 	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "private answer"})
@@ -147,4 +153,8 @@ func saveMachineTestSession(t *testing.T, dir, id string, updatedAt time.Time) {
 	}); err != nil {
 		t.Fatalf("save branch meta: %v", err)
 	}
+}
+
+func machineTestSessionDir(projectRoot string) string {
+	return config.ProjectSessionDir(projectRoot)
 }

--- a/internal/cli/session_machine_test.go
+++ b/internal/cli/session_machine_test.go
@@ -48,6 +48,18 @@ func TestSessionMachineListIsStableAndRedacted(t *testing.T) {
 	}
 }
 
+func TestMachineProjectSessionDirUsesProjectStore(t *testing.T) {
+	projectRoot := t.TempDir()
+	got := machineProjectSessionDir(projectRoot)
+	want := config.ProjectSessionDir(projectRoot)
+	if got != want {
+		t.Fatalf("machine project session dir = %q, want %q", got, want)
+	}
+	if got == projectRoot {
+		t.Fatalf("machine project session dir must not use the project root directly: %q", got)
+	}
+}
+
 func TestSessionMachineShowAndStatusExposeOnlySafeState(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()

--- a/internal/cli/session_machine_test.go
+++ b/internal/cli/session_machine_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -60,11 +59,30 @@ func TestMachineProjectSessionDirUsesProjectStore(t *testing.T) {
 	}
 }
 
+func TestSessionMachineProjectRootUsesProjectStore(t *testing.T) {
+	identityKey := installMachineTestIdentity(t)
+	projectRoot := t.TempDir()
+	sessionDir := config.ProjectSessionDir(projectRoot)
+	saveMachineTestSession(t, sessionDir, "project", time.Date(2026, 7, 23, 11, 30, 0, 0, time.UTC))
+
+	var out bytes.Buffer
+	if code := runSessionCommand([]string{"list", "--json", "--project-root", projectRoot}, &out); code != 0 {
+		t.Fatalf("list exit code = %d, output = %s", code, out.String())
+	}
+	var response machineSessionList
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(response.Sessions) != 1 || response.Sessions[0].ID != machineSessionIDWithKey("project", identityKey) {
+		t.Fatalf("sessions = %+v, want project session", response.Sessions)
+	}
+}
+
 func TestSessionMachineShowAndStatusExposeOnlySafeState(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "busy", time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC))
-	path := filepath.Join(machineTestSessionDir(dir), "busy.jsonl")
+	path := filepath.Join(dir, "busy.jsonl")
 	lease, err := agent.TryAcquireSessionLease(path)
 	if err != nil {
 		t.Fatalf("acquire session lease: %v", err)
@@ -120,6 +138,7 @@ func TestSessionMachineErrorsAreJSONAndNonZero(t *testing.T) {
 	}{
 		{name: "missing json", args: []string{"list", "--dir", dir}, code: 2, err: "invalid_argument"},
 		{name: "missing session", args: []string{"show", "--json", "missing", "--dir", dir}, code: 1, err: "session_not_found"},
+		{name: "conflicting session sources", args: []string{"list", "--json", "--dir", dir, "--project-root", dir}, code: 2, err: "invalid_argument"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -143,11 +162,7 @@ func TestSessionMachineErrorsAreJSONAndNonZero(t *testing.T) {
 
 func saveMachineTestSession(t *testing.T, dir, id string, updatedAt time.Time) {
 	t.Helper()
-	sessionDir := config.ProjectSessionDir(dir)
-	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
-		t.Fatalf("create project session dir: %v", err)
-	}
-	path := filepath.Join(sessionDir, id+".jsonl")
+	path := filepath.Join(dir, id+".jsonl")
 	session := agent.NewSession("")
 	session.Add(provider.Message{Role: provider.RoleUser, Content: "private prompt"})
 	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "private answer"})
@@ -165,8 +180,4 @@ func saveMachineTestSession(t *testing.T, dir, id string, updatedAt time.Time) {
 	}); err != nil {
 		t.Fatalf("save branch meta: %v", err)
 	}
-}
-
-func machineTestSessionDir(projectRoot string) string {
-	return config.ProjectSessionDir(projectRoot)
 }

--- a/internal/cli/task_machine.go
+++ b/internal/cli/task_machine.go
@@ -63,6 +63,8 @@ func runTaskCommand(args []string, out io.Writer) int {
 	}
 	if options.dir == "" {
 		options.dir = resolveCLISessionDir()
+	} else {
+		options.dir = machineProjectSessionDir(options.dir)
 	}
 	identityKey, err := loadMachineIdentityKey()
 	if err != nil {

--- a/internal/cli/task_machine.go
+++ b/internal/cli/task_machine.go
@@ -34,10 +34,11 @@ type machineTaskShow struct {
 }
 
 type taskMachineOptions struct {
-	dir       string
-	sessionID string
-	target    string
-	json      bool
+	dir         string
+	projectRoot string
+	sessionID   string
+	target      string
+	json        bool
 }
 
 func taskCommand(args []string) int {
@@ -61,11 +62,7 @@ func runTaskCommand(args []string, out io.Writer) int {
 	if !options.json {
 		return writeMachineError(out, command, "invalid_argument", "--json is required")
 	}
-	if options.dir == "" {
-		options.dir = resolveCLISessionDir()
-	} else {
-		options.dir = machineProjectSessionDir(options.dir)
-	}
+	options.dir = resolveMachineSessionDir(options.dir, options.projectRoot)
 	identityKey, err := loadMachineIdentityKey()
 	if err != nil {
 		return writeMachineError(out, command, "machine_identity_unavailable", "machine identity is unavailable")
@@ -105,6 +102,12 @@ func parseTaskMachineOptions(args []string, operation string) (taskMachineOption
 			}
 			i++
 			options.dir = args[i]
+		case "--project-root":
+			if i+1 >= len(args) || strings.TrimSpace(args[i+1]) == "" {
+				return options, "invalid_argument", "--project-root requires a value"
+			}
+			i++
+			options.projectRoot = args[i]
 		case "--session":
 			if i+1 >= len(args) || !validMachineID(args[i+1]) {
 				return options, "invalid_argument", "--session requires a valid identifier"
@@ -123,6 +126,9 @@ func parseTaskMachineOptions(args []string, operation string) (taskMachineOption
 			}
 			options.target = arg
 		}
+	}
+	if options.dir != "" && options.projectRoot != "" {
+		return options, "invalid_argument", "--dir and --project-root cannot be combined"
 	}
 	if operation == "show" && options.target == "" {
 		return options, "invalid_argument", "a task identifier is required"

--- a/internal/cli/task_machine_test.go
+++ b/internal/cli/task_machine_test.go
@@ -20,7 +20,8 @@ func TestTaskMachineListUsesContentFreePersistedMetadata(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "session", time.Date(2026, 7, 23, 13, 0, 0, 0, time.UTC))
-	path := filepath.Join(dir, "session.jsonl")
+	sessionDir := machineTestSessionDir(dir)
+	path := filepath.Join(sessionDir, "session.jsonl")
 	manager := jobs.NewManager(event.Discard)
 	manager.SetActiveSessionPath("session", path)
 	job := manager.StartForSession("session", "task", "PRIVATE TASK LABEL", func(context.Context, io.Writer) (string, error) {
@@ -70,7 +71,8 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "session", time.Now())
-	subDir := filepath.Join(dir, "subagents")
+	sessionDir := machineTestSessionDir(dir)
+	subDir := filepath.Join(sessionDir, "subagents")
 	if err := os.MkdirAll(subDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +95,7 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 		t.Fatal(err)
 	}
 
-	tasks, err := machineTasks(dir, machineSessionIDWithKey("session", identityKey), identityKey)
+	tasks, err := machineTasks(sessionDir, machineSessionIDWithKey("session", identityKey), identityKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,12 +113,12 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 		t.Fatalf("missing artifact projection = %+v", got)
 	}
 
-	lease, err := agent.TryAcquireSessionLease(filepath.Join(dir, "session.jsonl"))
+	lease, err := agent.TryAcquireSessionLease(filepath.Join(sessionDir, "session.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer lease.Release()
-	tasks, err = machineTasks(dir, machineSessionIDWithKey("session", identityKey), identityKey)
+	tasks, err = machineTasks(sessionDir, machineSessionIDWithKey("session", identityKey), identityKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/task_machine_test.go
+++ b/internal/cli/task_machine_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/jobs"
 )
@@ -20,8 +21,7 @@ func TestTaskMachineListUsesContentFreePersistedMetadata(t *testing.T) {
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "session", time.Date(2026, 7, 23, 13, 0, 0, 0, time.UTC))
-	sessionDir := machineTestSessionDir(dir)
-	path := filepath.Join(sessionDir, "session.jsonl")
+	path := filepath.Join(dir, "session.jsonl")
 	manager := jobs.NewManager(event.Discard)
 	manager.SetActiveSessionPath("session", path)
 	job := manager.StartForSession("session", "task", "PRIVATE TASK LABEL", func(context.Context, io.Writer) (string, error) {
@@ -71,8 +71,7 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 	identityKey := installMachineTestIdentity(t)
 	dir := t.TempDir()
 	saveMachineTestSession(t, dir, "session", time.Now())
-	sessionDir := machineTestSessionDir(dir)
-	subDir := filepath.Join(sessionDir, "subagents")
+	subDir := filepath.Join(dir, "subagents")
 	if err := os.MkdirAll(subDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +94,7 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 		t.Fatal(err)
 	}
 
-	tasks, err := machineTasks(sessionDir, machineSessionIDWithKey("session", identityKey), identityKey)
+	tasks, err := machineTasks(dir, machineSessionIDWithKey("session", identityKey), identityKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,12 +112,12 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 		t.Fatalf("missing artifact projection = %+v", got)
 	}
 
-	lease, err := agent.TryAcquireSessionLease(filepath.Join(sessionDir, "session.jsonl"))
+	lease, err := agent.TryAcquireSessionLease(filepath.Join(dir, "session.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer lease.Release()
-	tasks, err = machineTasks(sessionDir, machineSessionIDWithKey("session", identityKey), identityKey)
+	tasks, err = machineTasks(dir, machineSessionIDWithKey("session", identityKey), identityKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,6 +125,33 @@ func TestTaskMachineProjectsSubagentLifecycleAndArtifactCompleteness(t *testing.
 		if task.ID == "sa_running" && (task.Status != string(agent.SubagentRunning) || task.FinishedAt != "" || task.ArtifactComplete) {
 			t.Fatalf("live running projection = %+v", task)
 		}
+	}
+}
+
+func TestTaskMachineProjectRootUsesProjectStore(t *testing.T) {
+	identityKey := installMachineTestIdentity(t)
+	projectRoot := t.TempDir()
+	sessionDir := config.ProjectSessionDir(projectRoot)
+	saveMachineTestSession(t, sessionDir, "session", time.Date(2026, 7, 23, 13, 30, 0, 0, time.UTC))
+	path := filepath.Join(sessionDir, "session.jsonl")
+	manager := jobs.NewManager(event.Discard)
+	manager.SetActiveSessionPath("session", path)
+	job := manager.StartForSession("session", "task", "PRIVATE TASK LABEL", func(context.Context, io.Writer) (string, error) {
+		return "PRIVATE TASK OUTPUT", nil
+	})
+	manager.WaitForSession(context.Background(), "session", []string{job.ID}, 1)
+	manager.Close()
+
+	var out bytes.Buffer
+	if code := runTaskCommand([]string{"list", "--json", "--project-root", projectRoot}, &out); code != 0 {
+		t.Fatalf("task list exit code = %d, output = %s", code, out.String())
+	}
+	var response machineTaskList
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatalf("decode task list: %v", err)
+	}
+	if len(response.Tasks) != 1 || response.Tasks[0].ID != job.ID || response.Tasks[0].SessionID != machineSessionIDWithKey("session", identityKey) {
+		t.Fatalf("tasks = %+v, want project task", response.Tasks)
 	}
 }
 
@@ -157,5 +183,21 @@ func TestTaskMachineEmptyListUsesAnArray(t *testing.T) {
 	}
 	if response.Tasks == nil {
 		t.Fatalf("tasks must be [] in empty response: %s", out.String())
+	}
+}
+
+func TestTaskMachineRejectsConflictingSessionSources(t *testing.T) {
+	installMachineTestIdentity(t)
+	dir := t.TempDir()
+	var out bytes.Buffer
+	if code := runTaskCommand([]string{"list", "--json", "--dir", dir, "--project-root", dir}, &out); code != 2 {
+		t.Fatalf("exit code = %d, output = %s", code, out.String())
+	}
+	var response machineErrorResponse
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Error.Code != "invalid_argument" {
+		t.Fatalf("response = %+v", response)
 	}
 }


### PR DESCRIPTION
## 摘要

为 Session、Task 和 Recovery 的脱敏机器接口增加显式项目根目录选择，同时保留现有 `--dir SESSION_DIR` 契约。

## 对 Reasonix 的好处

- 多项目自动化可以用 `--project-root PATH` 稳定查询指定项目的 Session 和 Task；
- 已有使用 `--dir SESSION_DIR` 的调用方保持原行为，不会在升级后读到空列表或 `session_not_found`；
- Session、Task 和 Recovery 共享同一目录解析逻辑，避免作用域漂移；
- 默认不传目录参数时，仍然选择当前项目的 Session store。

## 参数语义

- `--dir SESSION_DIR`：直接选择 Session 存储目录，保持现有公开契约；
- `--project-root PATH`：通过 `config.ProjectSessionDir(PATH)` 解析项目 Session store；
- 两个参数不能同时使用，冲突时返回 `invalid_argument`；
- 两个参数都不传时，沿用当前项目作用域。

## 修复

- Session 和 Task machine interface 共享目录解析函数；
- Recovery 继续复用 Session 的解析结果；
- 增加 Session/Task 项目根目录端到端测试；
- 恢复并固定 `--dir SESSION_DIR` 的兼容性覆盖；
- 增加冲突参数测试；
- 更新中英文 CLI 文档。

## 向后兼容审计

| 契约 | 旧版本行为 | 本 PR 行为 | 结论 |
| --- | --- | --- | --- |
| 不传目录参数 | 查询当前项目 Session store | 不变 | 兼容 |
| `--dir SESSION_DIR` | 直接查询指定 Session store | 不变 | 兼容 |
| `--project-root PATH` | 不支持 | 查询该项目的 Session store | 兼容新增 |
| Session/Task JSON schema | schema version 1 | 字段和值类型不变 | 兼容 |
| Session 文件和 machine ID | 原格式 | 不变 | 兼容 |

## 验证

- `go test ./internal/cli -count=1`
- focused machine tests under `go test -race ./internal/cli`
- `go vet ./internal/cli`
- `env -u DEEPSEEK_API_KEY go test ./... -count=1`
- `./scripts/cache-guard.sh`
- `git diff --check`

## 安全与缓存

- 不读取或输出 Session 内容；
- 不改变 Session ID 脱敏、凭证或持久化格式；
- 不改变 provider-visible prompt、工具 schema 或请求序列化。
