### PR TITLE
Fix Windows plugin Bash hook runtime detection / 修复 Windows 插件 Bash Hook 运行时探测

### DIFF
--- a/desktop/plugin_packages_app.go
+++ b/desktop/plugin_packages_app.go
@@ -9,6 +9,7 @@ import (
 
 	"reasonix/internal/command"
 	"reasonix/internal/config"
+	"reasonix/internal/hook"
 	"reasonix/internal/installsource"
 	"reasonix/internal/pluginpkg"
 )
@@ -313,6 +314,22 @@ func (a *App) PluginDoctor(name string) PluginView {
 		if _, err := os.Stat(p.Root); err != nil {
 			p.Error = err.Error()
 			return p
+		}
+		pkg, _, err := pluginpkg.ParseDir(p.Root)
+		if err != nil {
+			p.Error = err.Error()
+			return p
+		}
+		cfg, _ := config.LoadForRootReadOnly(a.activeWorkspaceRoot())
+		runtimeOptions := hook.RuntimeOptions{}
+		if cfg != nil {
+			runtimeOptions = hook.RuntimeOptionsForShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path)
+		}
+		for _, issue := range hook.CheckPackageRuntime(pkg, runtimeOptions) {
+			p.Warnings = append(p.Warnings, fmt.Sprintf(
+				"%s hook is unavailable: %v; install Git for Windows or configure a usable Bash path",
+				issue.Event, issue.Err,
+			))
 		}
 		return p
 	}

--- a/docs/DESKTOP_HOOKS.zh-CN.md
+++ b/docs/DESKTOP_HOOKS.zh-CN.md
@@ -105,7 +105,8 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 `command` 默认通过平台 shell 执行：macOS/Linux 使用 `sh -c`，Windows 使用
 `cmd /c`。如果 Windows hook 自己显式写了裸命令 `sh -c` 或 `bash -c`，Reasonix
 会查找 Git for Windows 自带的 Bash 并直接使用它；带目录的显式解释器路径保持不变。
-找不到 Git Bash 时会返回可操作的依赖提示。Hook stdout/stderr 中的 Windows 旧代码页
+通过 `[tools.shell]` 配置的自定义 Bash 路径同样会被 Hook 复用；找不到 Git Bash 时，
+插件 Doctor 和能力诊断会提前显示可操作的依赖提示。Hook stdout/stderr 中的 Windows 旧代码页
 文本会转换为 UTF-8，避免中文错误信息显示成乱码。stdin 是 Reasonix 写入的一行 JSON，
 见下面的 payload 表。
 

--- a/docs/PLUGIN_PACKAGES.md
+++ b/docs/PLUGIN_PACKAGES.md
@@ -361,8 +361,12 @@ such as Superpowers and Claude-style skill packs, Reasonix maps:
   for Windows Bash even when it is not on `cmd.exe`'s `PATH`; an explicit
   interpreter path remains untouched. If no usable Bash is installed, the hook
   reports a clear prerequisite error instead of the localized `sh is not
-  recognized` output. Captured legacy-code-page output is normalized to UTF-8
-  before it reaches the UI. A `PreToolUse` or
+  recognized` output. A non-standard or portable Bash configured with
+  `[tools.shell] prefer = "bash"` and `path = ".../bash.exe"` is reused by
+  explicit Bash hooks. `reasonix plugin doctor <name>` and
+  `reasonix doctor capabilities` report a missing required shell before the
+  first hook invocation. Captured legacy-code-page output is normalized to
+  UTF-8 before it reaches the UI. A `PreToolUse` or
   `UserPromptSubmit` hook can still deny via exit code 2 or its JSON deny
   shape on exit 0 (`hookSpecificOutput.permissionDecision` for `PreToolUse`,
   top-level `decision:"block"` for `UserPromptSubmit`); an imported

--- a/docs/PLUGIN_PACKAGES.zh-CN.md
+++ b/docs/PLUGIN_PACKAGES.zh-CN.md
@@ -310,7 +310,10 @@ Reasonix 的对应实现，并不代表导入 Hook 的每一种运行时决策�
   `sh -c`/`bash -c` Hook 会复用 Git for Windows Bash 探测，即使 Bash 不在
   `cmd.exe` 的 `PATH` 中也能执行；带目录的显式解释器路径保持
   不变。如果机器确实没有可用 Bash，hook 会返回清晰的依赖提示，而不是本地化的
-  “无法识别 sh”乱码。旧代码页输出也会在进入界面前转换为 UTF-8。`PreToolUse` 和
+  “无法识别 sh”乱码。通过 `[tools.shell] prefer = "bash"` 和
+  `path = ".../bash.exe"` 配置的非标准目录或便携版 Bash 也会被显式 Bash Hook 复用。
+  `reasonix plugin doctor <名称>` 和 `reasonix doctor capabilities` 会在 Hook 首次触发前
+  报告缺失的 Shell 依赖。旧代码页输出也会在进入界面前转换为 UTF-8。`PreToolUse` 和
   `UserPromptSubmit` hook 仍可
   通过退出码 2 或退出码 0 时的 JSON 拒绝形态拒绝该次调用（`PreToolUse` 用
   `hookSpecificOutput.permissionDecision`，`UserPromptSubmit` 用顶层

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -741,9 +741,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if !cfg.SafeMode() {
 		resolvedHooks = hook.Load(hook.LoadOptions{ProjectRoot: root})
 	}
+	hookRuntime := hook.RuntimeOptions{}
+	if shell.Kind == sandbox.ShellBash {
+		hookRuntime.BashPath = shell.Path
+	}
 	hookRunner := hook.NewRunner(
-		resolvedHooks,
-		root, nil,
+		resolvedHooks, root, hook.NewDefaultSpawner(hookRuntime),
 		func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg}) },
 	)
 	// The `task` tool spawns sub-agents that reuse the parent's provider and

--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -67,7 +67,7 @@ func Collect(opts Options) Report {
 	instr := collectInstructions(root, home, disp)
 	skillsR, skillIssues := collectSkills(root, home, reasonixHome, cfg, disp)
 	cmdsR, cmdIssues := collectCommands(root, disp)
-	hooksR, hookIssues := collectHooks(root, home, reasonixHome, disp)
+	hooksR, hookIssues := collectHooks(root, home, reasonixHome, cfg, disp)
 	pluginsR, pluginIssues := collectPlugins(reasonixHome, disp)
 	mcpR, mcpIssues := collectMCP(cfg, root, home, disp)
 
@@ -272,7 +272,7 @@ func collectCommands(root string, disp func(string) string) (AssetReport, []Issu
 	return rep, issues
 }
 
-func collectHooks(root, home, reasonixHome string, disp func(string) string) (HookReport, []Issue) {
+func collectHooks(root, home, reasonixHome string, cfg *config.Config, disp func(string) string) (HookReport, []Issue) {
 	var issues []Issue
 	// Prefer explicit home for settings when tests isolate HOME.
 	homeDir := home
@@ -283,6 +283,10 @@ func collectHooks(root, home, reasonixHome string, disp func(string) string) (Ho
 		ProjectRoot: root,
 		HomeDir:     homeDir,
 	})
+	runtimeOptions := hook.RuntimeOptions{}
+	if cfg != nil {
+		runtimeOptions = hook.RuntimeOptionsForShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path)
+	}
 	rep := HookReport{
 		// Retained in schema v1 for compatibility; project hooks are enabled by
 		// default whenever a project root is present.
@@ -321,6 +325,9 @@ func collectHooks(root, home, reasonixHome string, disp func(string) string) (Ho
 				SettingsTab: "hooks",
 			})
 		}
+		if issue, ok := hookRuntimeIssue(e, hook.CheckEntryRuntime(e, runtimeOptions), disp); ok {
+			issues = append(issues, issue)
+		}
 		if e.ContextFile != "" {
 			if !hook.ContextFileUsable(e.ContextFile) {
 				issues = append(issues, Issue{
@@ -352,6 +359,19 @@ func collectHooks(root, home, reasonixHome string, disp func(string) string) (Ho
 		}
 	}
 	return rep, issues
+}
+
+func hookRuntimeIssue(entry hook.Entry, err error, disp func(string) string) (Issue, bool) {
+	if err == nil {
+		return Issue{}, false
+	}
+	return Issue{
+		Severity: "error", Code: "hook.shell_unavailable", Subsystem: "hooks",
+		Name: string(entry.Event), Source: disp(entry.Source),
+		Message:     sanitizeErrText(err.Error()),
+		Remediation: "Install Git for Windows, or configure [tools.shell] prefer=\"bash\" and path to a usable bash.exe, then re-run doctor capabilities",
+		SettingsTab: "hooks",
+	}, true
 }
 
 func collectPlugins(reasonixHome string, disp func(string) string) (PluginPackageReport, []Issue) {

--- a/internal/capdiag/hook_runtime_test.go
+++ b/internal/capdiag/hook_runtime_test.go
@@ -1,0 +1,40 @@
+package capdiag
+
+import (
+	"errors"
+	"testing"
+
+	"reasonix/internal/hook"
+)
+
+func TestHookRuntimeIssueIsActionableAndScoped(t *testing.T) {
+	entry := hook.Entry{
+		Event:  hook.SessionStart,
+		Scope:  hook.ScopePlugin,
+		Source: `C:\Users\Test\AppData\Roaming\reasonix\plugins\superpowers\.codex-plugin\plugin.json`,
+	}
+	issue, ok := hookRuntimeIssue(entry, errors.New("hook requires a POSIX shell on Windows, but no usable Git Bash was found"), func(string) string {
+		return "<reasonix-home>/plugins/superpowers/.codex-plugin/plugin.json"
+	})
+	if !ok {
+		t.Fatal("missing runtime dependency should produce a diagnostic issue")
+	}
+	if issue.Code != "hook.shell_unavailable" || issue.Severity != "error" || issue.Subsystem != "hooks" {
+		t.Fatalf("issue identity = %+v", issue)
+	}
+	if issue.Name != string(hook.SessionStart) || issue.SettingsTab != "hooks" {
+		t.Fatalf("issue scope = %+v", issue)
+	}
+	if issue.Source != "<reasonix-home>/plugins/superpowers/.codex-plugin/plugin.json" {
+		t.Fatalf("issue source = %q", issue.Source)
+	}
+	if issue.Remediation == "" {
+		t.Fatal("runtime dependency issue must include remediation")
+	}
+}
+
+func TestHookRuntimeIssueIgnoresAvailableRuntime(t *testing.T) {
+	if _, ok := hookRuntimeIssue(hook.Entry{}, nil, func(path string) string { return path }); ok {
+		t.Fatal("available runtime must not produce an issue")
+	}
+}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"reasonix/internal/config"
+	"reasonix/internal/hook"
 	"reasonix/internal/installsource"
 	"reasonix/internal/pluginpkg"
 )
@@ -335,6 +336,20 @@ func pluginDoctorCommand(args []string) int {
 	}
 	for _, warning := range warnings {
 		fmt.Println("warning:", warning)
+	}
+	workspaceRoot, _ := os.Getwd()
+	cfg, _ := config.LoadForRootReadOnly(workspaceRoot)
+	runtimeOptions := hook.RuntimeOptions{}
+	if cfg != nil {
+		runtimeOptions = hook.RuntimeOptionsForShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path)
+	}
+	runtimeIssues := hook.CheckPackageRuntime(pkg, runtimeOptions)
+	for _, issue := range runtimeIssues {
+		fmt.Fprintf(os.Stderr, "unavailable %s hook: %v\n", issue.Event, issue.Err)
+	}
+	if len(runtimeIssues) > 0 {
+		fmt.Fprintln(os.Stderr, "remediation: install Git for Windows, or configure [tools.shell] prefer=\"bash\" and path to a usable bash.exe")
+		return 1
 	}
 	fmt.Printf("ok: %s (%s)\n", p.Name, filepath.Clean(root))
 	return 0

--- a/internal/hook/execution_contract_test.go
+++ b/internal/hook/execution_contract_test.go
@@ -78,7 +78,7 @@ func TestSpawnCommandExecutionContractMatrix(t *testing.T) {
 		t.Fatal(err)
 	}
 	literalArgs := []string{"", "$VALUE", "a && b", `nested"quote`}
-	cmd, err := spawnCommand(context.Background(), executable, ExecutionExec, "bash", literalArgs)
+	cmd, err := spawnCommand(context.Background(), executable, ExecutionExec, "bash", literalArgs, RuntimeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,16 +86,16 @@ func TestSpawnCommandExecutionContractMatrix(t *testing.T) {
 		t.Fatalf("exec argv = %#v, want %#v", cmd.Args[1:], literalArgs)
 	}
 
-	if _, err := spawnCommand(context.Background(), "ignored", ExecutionMode("future"), "", nil); err == nil ||
+	if _, err := spawnCommand(context.Background(), "ignored", ExecutionMode("future"), "", nil, RuntimeOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "unsupported hook execution mode") {
 		t.Fatalf("unknown execution mode error = %v", err)
 	}
-	if _, err := spawnCommand(context.Background(), "ignored", ExecutionShell, "fish", nil); err == nil ||
+	if _, err := spawnCommand(context.Background(), "ignored", ExecutionShell, "fish", nil, RuntimeOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "unsupported hook shell") {
 		t.Fatalf("unknown shell error = %v", err)
 	}
 	if runtime.GOOS != "windows" {
-		if _, err := spawnCommand(context.Background(), "echo ok", ExecutionShell, "cmd", nil); err == nil ||
+		if _, err := spawnCommand(context.Background(), "echo ok", ExecutionShell, "cmd", nil, RuntimeOptions{}); err == nil ||
 			!strings.Contains(err.Error(), "only available on Windows") {
 			t.Fatalf("non-Windows cmd error = %v", err)
 		}
@@ -118,7 +118,7 @@ func TestShellSelectionBuildsExactInterpreterArgv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := spawnShellCommand(context.Background(), script, tt.preferred)
+			cmd, err := spawnShellCommand(context.Background(), script, tt.preferred, RuntimeOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -129,7 +129,7 @@ func TestShellSelectionBuildsExactInterpreterArgv(t *testing.T) {
 	}
 
 	if _, err := exec.LookPath("pwsh"); err != nil {
-		if _, err := spawnShellCommand(context.Background(), script, "pwsh"); err == nil ||
+		if _, err := spawnShellCommand(context.Background(), script, "pwsh", RuntimeOptions{}); err == nil ||
 			!strings.Contains(err.Error(), "no usable PowerShell") {
 			t.Fatalf("missing pwsh error = %v", err)
 		}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -315,29 +315,7 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				continue
 			}
 			for _, h := range pkg.Manifest.Hooks[eventName] {
-				mode := ExecutionLegacy
-				switch {
-				case h.ArgsSet:
-					mode = ExecutionExec
-				case h.ShellCommand:
-					mode = ExecutionShell
-				}
-				command := expandPluginRoot(h.Command, pkg.Root)
-				resolveFromPluginRoot := mode != ExecutionShell &&
-					!(mode == ExecutionExec && h.PayloadFormat == "claude")
-				if command != "" && resolveFromPluginRoot && !filepath.IsAbs(command) {
-					command = filepath.Join(pkg.Root, filepath.FromSlash(command))
-				}
-				if mode == ExecutionLegacy {
-					command = NormalizeCommand(command)
-				}
-				var argv []string
-				if h.ArgsSet {
-					argv = make([]string, 0, len(h.Args))
-				}
-				for _, arg := range h.Args {
-					argv = append(argv, expandPluginRoot(arg, pkg.Root))
-				}
+				execution := pluginHookExecutionConfig(h, pkg.Root)
 				contextFile := expandPluginRoot(h.ContextFile, pkg.Root)
 				if contextFile != "" {
 					contextFile = filepath.FromSlash(contextFile)
@@ -374,9 +352,9 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				*out = append(*out, ResolvedHook{
 					HookConfig: HookConfig{
 						Match:         h.Match,
-						Command:       command,
-						Argv:          argv,
-						ExecutionMode: mode,
+						Command:       execution.Command,
+						Argv:          execution.Argv,
+						ExecutionMode: execution.ExecutionMode,
 						Shell:         h.Shell,
 						ContextFile:   contextFile,
 						Description:   h.Description,
@@ -392,6 +370,46 @@ func appendPluginHooks(out *[]ResolvedHook, reasonixHomeDir, projectRoot string)
 				})
 			}
 		}
+	}
+}
+
+func pluginHookExecutionConfig(h pluginpkg.Hook, root string) HookConfig {
+	return pluginHookExecutionConfigForPlatform(h, root, runtime.GOOS)
+}
+
+func pluginHookExecutionConfigForPlatform(h pluginpkg.Hook, root, goos string) HookConfig {
+	mode := ExecutionLegacy
+	switch {
+	case h.ArgsSet:
+		mode = ExecutionExec
+	case h.ShellCommand:
+		mode = ExecutionShell
+	}
+	expansionRoot := root
+	if goos == "windows" && mode == ExecutionShell && strings.EqualFold(strings.TrimSpace(h.Shell), "bash") {
+		expansionRoot = strings.ReplaceAll(root, `\`, "/")
+	}
+	command := expandPluginRoot(h.Command, expansionRoot)
+	resolveFromPluginRoot := mode != ExecutionShell &&
+		!(mode == ExecutionExec && h.PayloadFormat == "claude")
+	if command != "" && resolveFromPluginRoot && !filepath.IsAbs(command) {
+		command = filepath.Join(root, filepath.FromSlash(command))
+	}
+	if mode == ExecutionLegacy {
+		command = NormalizeCommand(command)
+	}
+	var argv []string
+	if h.ArgsSet {
+		argv = make([]string, 0, len(h.Args))
+	}
+	for _, arg := range h.Args {
+		argv = append(argv, expandPluginRoot(arg, root))
+	}
+	return HookConfig{
+		Command:       command,
+		Argv:          argv,
+		ExecutionMode: mode,
+		Shell:         h.Shell,
 	}
 }
 
@@ -1052,6 +1070,49 @@ type SpawnInput struct {
 	Timeout time.Duration
 }
 
+// RuntimeOptions carries resolved host dependencies into Hook execution.
+// It is runtime-only and never changes persisted Hook configuration.
+type RuntimeOptions struct {
+	BashPath string
+}
+
+// RuntimeOptionsForShell carries an explicitly configured Bash path into Hook
+// execution while leaving other interpreter preferences independent.
+func RuntimeOptionsForShell(prefer, path string) RuntimeOptions {
+	if !strings.EqualFold(strings.TrimSpace(prefer), "bash") {
+		return RuntimeOptions{}
+	}
+	return RuntimeOptions{BashPath: strings.TrimSpace(path)}
+}
+
+// RuntimeIssue identifies one plugin Hook whose host dependency is unavailable.
+type RuntimeIssue struct {
+	Event       Event
+	Description string
+	Err         error
+}
+
+// CheckPackageRuntime validates every Hook exported by a plugin package without
+// launching commands.
+func CheckPackageRuntime(pkg pluginpkg.Package, options RuntimeOptions) []RuntimeIssue {
+	events := make([]string, 0, len(pkg.Manifest.Hooks))
+	for event := range pkg.Manifest.Hooks {
+		events = append(events, event)
+	}
+	sort.Strings(events)
+	var issues []RuntimeIssue
+	for _, eventName := range events {
+		for _, h := range pkg.Manifest.Hooks[eventName] {
+			if err := CheckRuntime(pluginHookExecutionConfig(h, pkg.Root), options); err != nil {
+				issues = append(issues, RuntimeIssue{
+					Event: Event(eventName), Description: h.Description, Err: err,
+				})
+			}
+		}
+	}
+	return issues
+}
+
 type SpawnResult struct {
 	ExitCode  int
 	Stdout    string
@@ -1222,10 +1283,22 @@ func stderrFor(r SpawnResult, timeout time.Duration) string {
 // contract, with the payload on stdin, capped output, and both per-hook timeout
 // and parent-context cancellation.
 func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
+	return defaultSpawner(ctx, in, RuntimeOptions{})
+}
+
+// NewDefaultSpawner returns the standard Hook spawner with effective host
+// runtime paths supplied by boot configuration.
+func NewDefaultSpawner(options RuntimeOptions) Spawner {
+	return func(ctx context.Context, in SpawnInput) SpawnResult {
+		return defaultSpawner(ctx, in, options)
+	}
+}
+
+func defaultSpawner(ctx context.Context, in SpawnInput, options RuntimeOptions) SpawnResult {
 	cctx, cancel := context.WithTimeout(ctx, in.Timeout)
 	defer cancel()
 
-	cmd, spawnErr := spawnCommand(cctx, in.Command, in.Mode, in.Shell, in.Args)
+	cmd, spawnErr := spawnCommand(cctx, in.Command, in.Mode, in.Shell, in.Args, options)
 	if spawnErr != nil {
 		return SpawnResult{ExitCode: -1, SpawnErr: spawnErr}
 	}
@@ -1280,25 +1353,27 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 // Explicit exec-form hooks pass their argv directly to the executable;
 // explicit shell-form hooks pass the raw command to the selected interpreter.
 // Legacy settings retain Reasonix's historical shell behavior and repairs.
-func spawnCommand(ctx context.Context, command string, mode ExecutionMode, shell string, args []string) (*exec.Cmd, error) {
+func spawnCommand(ctx context.Context, command string, mode ExecutionMode, shell string, args []string, options RuntimeOptions) (*exec.Cmd, error) {
 	switch mode {
 	case ExecutionExec:
-		return spawnExecCommand(ctx, command, args)
+		return spawnExecCommand(ctx, command, args, options)
 	case ExecutionShell:
-		return spawnShellCommand(ctx, command, shell)
+		return spawnShellCommand(ctx, command, shell, options)
 	case ExecutionLegacy:
-		return spawnLegacyCommand(ctx, command, args)
+		return spawnLegacyCommand(ctx, command, args, options)
 	default:
 		return nil, fmt.Errorf("unsupported hook execution mode %q", mode)
 	}
 }
 
-func spawnExecCommand(ctx context.Context, command string, args []string) (*exec.Cmd, error) {
+func spawnExecCommand(ctx context.Context, command string, args []string, options RuntimeOptions) (*exec.Cmd, error) {
 	if runtime.GOOS == "windows" {
 		if cmd, matched := windowsBatchArgvCommand(ctx, command, args); matched {
 			return cmd, nil
 		}
-		if resolvedShell, resolvedArgs, matched, err := windowsPOSIXShellArgvInvocation(command, args); matched {
+		if resolvedShell, resolvedArgs, matched, err := windowsPOSIXShellArgvInvocationWith(command, args, func() (string, error) {
+			return resolveWindowsHookBash(options.BashPath)
+		}); matched {
 			if err != nil {
 				return nil, err
 			}
@@ -1320,9 +1395,9 @@ func spawnExecCommand(ctx context.Context, command string, args []string) (*exec
 // POSIX commands that were already well-formed keep their shell semantics
 // verbatim — normalizeStaticNodeEval's rendering escapes $ and backticks, so
 // even repaired commands re-entering here behave identically under sh -c.
-func spawnLegacyCommand(ctx context.Context, command string, args []string) (*exec.Cmd, error) {
+func spawnLegacyCommand(ctx context.Context, command string, args []string, options RuntimeOptions) (*exec.Cmd, error) {
 	if args != nil {
-		return spawnExecCommand(ctx, command, args)
+		return spawnExecCommand(ctx, command, args, options)
 	}
 	if node, flag, script, ok := repairableNodeEvalArgs(command); ok {
 		return exec.CommandContext(ctx, node, flag, script), nil
@@ -1334,7 +1409,9 @@ func spawnLegacyCommand(ctx context.Context, command string, args []string) (*ex
 		if cmd, matched := windowsBatchCommand(ctx, command); matched {
 			return cmd, nil
 		}
-		if shell, args, matched, err := windowsPOSIXShellInvocation(command); matched {
+		if shell, args, matched, err := windowsPOSIXShellInvocationWith(command, func() (string, error) {
+			return resolveWindowsHookBash(options.BashPath)
+		}); matched {
 			if err != nil {
 				return nil, err
 			}
@@ -1351,7 +1428,7 @@ func spawnLegacyCommand(ctx context.Context, command string, args []string) (*ex
 	return exec.CommandContext(ctx, name, args...), nil
 }
 
-func spawnShellCommand(ctx context.Context, command, preferred string) (*exec.Cmd, error) {
+func spawnShellCommand(ctx context.Context, command, preferred string, options RuntimeOptions) (*exec.Cmd, error) {
 	preferred = strings.ToLower(strings.TrimSpace(preferred))
 	switch preferred {
 	case "", "auto":
@@ -1371,7 +1448,7 @@ func spawnShellCommand(ctx context.Context, command, preferred string) (*exec.Cm
 		return exec.CommandContext(ctx, "sh", "-c", command), nil
 	case "bash":
 		if runtime.GOOS == "windows" {
-			path, err := cachedWindowsHookBash()
+			path, err := resolveWindowsHookBash(options.BashPath)
 			if err != nil {
 				return nil, err
 			}
@@ -1395,6 +1472,36 @@ func spawnShellCommand(ctx context.Context, command, preferred string) (*exec.Cm
 		return nil, errors.New("hook shell \"cmd\" is only available on Windows")
 	default:
 		return nil, fmt.Errorf("unsupported hook shell %q", preferred)
+	}
+}
+
+// CheckRuntime reports an unavailable host dependency without running a Hook.
+func CheckRuntime(config HookConfig, options RuntimeOptions) error {
+	return checkRuntimeForPlatform(config, options, runtime.GOOS, resolveWindowsHookBash)
+}
+
+func checkRuntimeForPlatform(config HookConfig, options RuntimeOptions, goos string, resolveBash func(string) (string, error)) error {
+	if goos != "windows" || !requiresWindowsBash(config) {
+		return nil
+	}
+	_, err := resolveBash(options.BashPath)
+	return err
+}
+
+func requiresWindowsBash(config HookConfig) bool {
+	switch config.ExecutionMode {
+	case ExecutionShell:
+		return strings.EqualFold(strings.TrimSpace(config.Shell), "bash")
+	case ExecutionExec:
+		return isBarePOSIXShellWord(config.Command) && hasCommandStringFlag(config.Argv)
+	case ExecutionLegacy:
+		if config.Argv != nil {
+			return isBarePOSIXShellWord(config.Command) && hasCommandStringFlag(config.Argv)
+		}
+		fields, _, _, ok := parseSimpleHookCommandFields(config.Command)
+		return ok && len(fields) >= 3 && isBarePOSIXShellWord(fields[0]) && hasCommandStringFlag(fields[1:])
+	default:
+		return false
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -470,7 +470,7 @@ func TestLoadSuperpowersV620PreservesExplicitBashRequirement(t *testing.T) {
 	if !requiresWindowsBash(h.HookConfig) {
 		t.Fatal("superpowers 6.2.0 hook should declare a Windows Bash runtime dependency")
 	}
-	if want := `"` + root + `/hooks/run-hook.cmd" session-start`; h.Command != want {
+	if want := `"` + filepath.ToSlash(root) + `/hooks/run-hook.cmd" session-start`; h.Command != want {
 		t.Fatalf("command = %q, want %q", h.Command, want)
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -426,6 +426,101 @@ func TestLoadSuperpowersV611SessionStartExecutionContract(t *testing.T) {
 	}
 }
 
+func TestLoadSuperpowersV620PreservesExplicitBashRequirement(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".reasonix", "plugins", "superpowers")
+	writeHookTestFile(t, filepath.Join(root, pluginpkg.CodexManifest), `{
+  "name": "superpowers",
+  "version": "6.2.0",
+  "skills": "./skills/"
+}`)
+	writeHookTestFile(t, filepath.Join(root, "hooks", "hooks.json"), `{
+  "hooks": {
+    "SessionStart": [{
+      "matcher": "startup|clear|compact",
+      "hooks": [{
+        "type": "command",
+        "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+        "shell": "bash",
+        "async": false
+      }]
+    }]
+  }
+}`)
+	writeHookTestFile(t, filepath.Join(root, "hooks", "run-hook.cmd"), "@echo off\r\n")
+	if err := pluginpkg.Upsert(filepath.Join(home, ".reasonix"), pluginpkg.InstalledPlugin{
+		Name:         "superpowers",
+		Root:         "plugins/superpowers",
+		Version:      "6.2.0",
+		ManifestKind: "codex",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Load(LoadOptions{HomeDir: home, ProjectRoot: filepath.Join(home, "workspace")})
+	if len(got) != 1 {
+		t.Fatalf("hooks = %+v, want the upstream superpowers 6.2.0 SessionStart hook", got)
+	}
+	h := got[0]
+	if h.ExecutionMode != ExecutionShell || h.Shell != "bash" || h.Argv != nil {
+		t.Fatalf("execution contract = mode %q shell %q argv %#v, want explicit Bash shell form",
+			h.ExecutionMode, h.Shell, h.Argv)
+	}
+	if !requiresWindowsBash(h.HookConfig) {
+		t.Fatal("superpowers 6.2.0 hook should declare a Windows Bash runtime dependency")
+	}
+	if want := `"` + root + `/hooks/run-hook.cmd" session-start`; h.Command != want {
+		t.Fatalf("command = %q, want %q", h.Command, want)
+	}
+}
+
+func TestPluginExplicitBashCommandUsesPOSIXCompatibleRoot(t *testing.T) {
+	root := `C:\Users\Test User\AppData\Roaming\reasonix\plugins\superpowers`
+	config := pluginHookExecutionConfigForPlatform(pluginpkg.Hook{
+		Command:      `"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start`,
+		ShellCommand: true,
+		Shell:        "bash",
+	}, root, "windows")
+	want := `"C:/Users/Test User/AppData/Roaming/reasonix/plugins/superpowers/hooks/run-hook.cmd" session-start`
+	if config.Command != want {
+		t.Fatalf("explicit Bash command = %q, want POSIX-compatible root %q", config.Command, want)
+	}
+}
+
+func TestExplicitBashRuntimeUsesConfiguredPath(t *testing.T) {
+	wantPath := filepath.Join(t.TempDir(), "PortableGit", "bin", "bash.exe")
+	var resolvedPath string
+	options := RuntimeOptionsForShell("bash", wantPath)
+	err := checkRuntimeForPlatform(HookConfig{
+		Command:       `"C:\\Users\\Test User\\plugins\\superpowers\\hooks\\run-hook.cmd" session-start`,
+		ExecutionMode: ExecutionShell,
+		Shell:         "bash",
+	}, options, "windows", func(path string) (string, error) {
+		resolvedPath = path
+		return path, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolvedPath != wantPath {
+		t.Fatalf("resolved Bash path = %q, want configured path %q", resolvedPath, wantPath)
+	}
+}
+
+func TestExplicitBashRuntimeReportsMissingDependency(t *testing.T) {
+	err := checkRuntimeForPlatform(HookConfig{
+		Command:       `"C:\\Users\\Test User\\plugins\\superpowers\\hooks\\run-hook.cmd" session-start`,
+		ExecutionMode: ExecutionShell,
+		Shell:         "bash",
+	}, RuntimeOptions{}, "windows", func(string) (string, error) {
+		return "", missingWindowsHookBashError()
+	})
+	if err == nil || !strings.Contains(err.Error(), "Git Bash") {
+		t.Fatalf("missing Bash runtime error = %v", err)
+	}
+}
+
 func TestLoadIncludesPluginSessionStartHook(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(home, ".reasonix")

--- a/internal/hook/inspect.go
+++ b/internal/hook/inspect.go
@@ -24,15 +24,16 @@ type SourceStatus struct {
 
 // Entry is one configured hook with diagnostic annotations.
 type Entry struct {
-	Event       Event
-	Match       string
-	Command     string
-	ContextFile string
-	Description string
-	Timeout     int
-	Scope       Scope
-	Source      string
-	Issues      []string // stable codes attached at collect time (optional)
+	Event         Event
+	Match         string
+	Command       string
+	ContextFile   string
+	Description   string
+	Timeout       int
+	Scope         Scope
+	Source        string
+	Issues        []string // stable codes attached at collect time (optional)
+	runtimeConfig HookConfig
 }
 
 // Inspection is a read-only hook configuration snapshot. It does not execute
@@ -138,14 +139,15 @@ func appendInspectEntries(out *Inspection, s *Settings, scope Scope, source stri
 			seen[event] = true
 			for _, cfg := range hooks {
 				out.Entries = append(out.Entries, Entry{
-					Event:       event,
-					Match:       cfg.Match,
-					Command:     cfg.Command,
-					ContextFile: cfg.ContextFile,
-					Description: cfg.Description,
-					Timeout:     cfg.Timeout,
-					Scope:       scope,
-					Source:      source,
+					Event:         event,
+					Match:         cfg.Match,
+					Command:       cfg.Command,
+					ContextFile:   cfg.ContextFile,
+					Description:   cfg.Description,
+					Timeout:       cfg.Timeout,
+					Scope:         scope,
+					Source:        source,
+					runtimeConfig: cfg,
 				})
 			}
 		}
@@ -160,14 +162,15 @@ func appendInspectEntries(out *Inspection, s *Settings, scope Scope, source stri
 	for _, event := range unknown {
 		for _, cfg := range s.Hooks[event] {
 			out.Entries = append(out.Entries, Entry{
-				Event:       event,
-				Match:       cfg.Match,
-				Command:     cfg.Command,
-				ContextFile: cfg.ContextFile,
-				Description: cfg.Description,
-				Timeout:     cfg.Timeout,
-				Scope:       scope,
-				Source:      source,
+				Event:         event,
+				Match:         cfg.Match,
+				Command:       cfg.Command,
+				ContextFile:   cfg.ContextFile,
+				Description:   cfg.Description,
+				Timeout:       cfg.Timeout,
+				Scope:         scope,
+				Source:        source,
+				runtimeConfig: cfg,
 			})
 		}
 	}
@@ -192,10 +195,7 @@ func appendPluginInspect(out *Inspection, reasonixHomeDir, projectRoot string) {
 			// Keep unknown event names so diagnostics can report them.
 			for _, h := range pkg.Manifest.Hooks[eventName] {
 				count++
-				command := expandPluginRoot(h.Command, pkg.Root)
-				if command != "" && !h.ShellCommand && !filepath.IsAbs(command) {
-					command = filepath.Join(pkg.Root, filepath.FromSlash(command))
-				}
+				execution := pluginHookExecutionConfig(h, pkg.Root)
 				contextFile := expandPluginRoot(h.ContextFile, pkg.Root)
 				if contextFile != "" {
 					contextFile = filepath.FromSlash(contextFile)
@@ -206,14 +206,15 @@ func appendPluginInspect(out *Inspection, reasonixHomeDir, projectRoot string) {
 					}
 				}
 				out.Entries = append(out.Entries, Entry{
-					Event:       event,
-					Match:       h.Match,
-					Command:     command,
-					ContextFile: contextFile,
-					Description: h.Description,
-					Timeout:     h.Timeout,
-					Scope:       ScopePlugin,
-					Source:      src,
+					Event:         event,
+					Match:         h.Match,
+					Command:       execution.Command,
+					ContextFile:   contextFile,
+					Description:   h.Description,
+					Timeout:       h.Timeout,
+					Scope:         ScopePlugin,
+					Source:        src,
+					runtimeConfig: execution,
 				})
 			}
 		}
@@ -229,6 +230,12 @@ func appendPluginInspect(out *Inspection, reasonixHomeDir, projectRoot string) {
 		})
 		_ = projectRoot
 	}
+}
+
+// CheckEntryRuntime validates the host dependencies required by an inspected
+// Hook without executing the command.
+func CheckEntryRuntime(entry Entry, options RuntimeOptions) error {
+	return CheckRuntime(entry.runtimeConfig, options)
 }
 
 // ValidateMatcher returns an error string when match is an invalid anchored regex.

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -26,18 +26,8 @@ var windowsDefaultHookShell struct {
 	err   error
 }
 
-// windowsPOSIXShellInvocation preserves explicit `sh -c` / `bash -c` hook
-// contracts on Windows. Git for Windows normally ships a real Bash outside the
-// cmd.exe PATH, so reuse the same hardened discovery path as the shell tool
-// instead of asking cmd.exe to find an executable it cannot see.
-func windowsPOSIXShellInvocation(command string) (string, []string, bool, error) {
-	return windowsPOSIXShellInvocationWith(command, cachedWindowsHookBash)
-}
-
-func windowsPOSIXShellArgvInvocation(command string, args []string) (string, []string, bool, error) {
-	return windowsPOSIXShellArgvInvocationWith(command, args, cachedWindowsHookBash)
-}
-
+// These helpers preserve explicit `sh -c` / `bash -c` hook contracts on
+// Windows while allowing the caller to supply the effective configured Bash.
 func windowsPOSIXShellArgvInvocationWith(command string, args []string, resolve func() (string, error)) (string, []string, bool, error) {
 	if !isBarePOSIXShellWord(command) || !hasCommandStringFlag(args) {
 		return "", nil, false, nil

--- a/internal/hook/windows_compat.go
+++ b/internal/hook/windows_compat.go
@@ -213,19 +213,28 @@ func bashLongOptionNeedsOperand(name string) bool {
 
 func cachedWindowsHookBash() (string, error) {
 	windowsHookBash.Do(func() {
-		shell := sandbox.ResolveShell("bash", "", nil)
-		if shell.Kind != sandbox.ShellBash {
-			windowsHookBash.err = missingWindowsHookBashError()
-			return
-		}
-		path, err := resolvedHookShellPath(shell)
-		if err != nil {
-			windowsHookBash.err = missingWindowsHookBashError()
-			return
-		}
-		windowsHookBash.path = path
+		windowsHookBash.path, windowsHookBash.err = discoverWindowsHookBash("")
 	})
 	return windowsHookBash.path, windowsHookBash.err
+}
+
+func resolveWindowsHookBash(preferredPath string) (string, error) {
+	if strings.TrimSpace(preferredPath) == "" {
+		return cachedWindowsHookBash()
+	}
+	return discoverWindowsHookBash(preferredPath)
+}
+
+func discoverWindowsHookBash(preferredPath string) (string, error) {
+	shell := sandbox.ResolveShell("bash", preferredPath, nil)
+	if shell.Kind != sandbox.ShellBash {
+		return "", missingWindowsHookBashError()
+	}
+	path, err := resolvedHookShellPath(shell)
+	if err != nil {
+		return "", missingWindowsHookBashError()
+	}
+	return path, nil
 }
 
 func cachedWindowsDefaultHookShell() (sandbox.Shell, error) {


### PR DESCRIPTION
## Summary

- Propagate the effective Bash executable configured through `[tools.shell]` into plugin Hook execution instead of rediscovering Bash independently.
- Normalize expanded Windows plugin-root paths to `C:/...` form for shell-form Hooks that explicitly request `shell: "bash"`, while preserving native execution behavior for other Hooks.
- Report missing Bash dependencies consistently through `reasonix plugin doctor`, Desktop Plugin Doctor, and `reasonix doctor capabilities`.
- Add regression coverage for Superpowers 6.2.0, custom/non-standard Git Bash locations, missing runtime diagnostics, and the existing Hook execution contract.
- Update the English and Chinese plugin/Hook documentation.

This fixes the Windows regression reported after upgrading from 1.17.20 to 1.17.21. Version 1.17.21 correctly preserves an explicit `shell: "bash"` declaration, but Hook execution did not honor the configured Bash path and expanded plugin paths in a form that Git Bash could not reliably consume.

## Backward compatibility

| Surface | Existing/old-data behavior | Conclusion |
| --- | --- | --- |
| Plugin Hook JSON | Existing Hook fields and `shell` values are unchanged; Hooks without explicit Bash keep their prior execution path. | Compatible |
| `[tools.shell]` configuration | Existing optional Bash paths are now honored by Hook execution; absent values continue to use runtime discovery. | Compatible |
| Persisted state and Wails contracts | No state, session, config schema, enum, identifier, or Wails JSON format changed. | Compatible |
| Cross-version coexistence | The change affects runtime resolution and diagnostics only; no new data is written for older versions to read. | Compatible |

## Verification

- `go test ./internal/hook ./internal/capdiag ./internal/boot ./internal/cli`
- `go test -race ./internal/hook ./internal/capdiag`
- `env -u DEEPSEEK_API_KEY go test ./...`
- `(cd desktop && go test ./...)`
- `go vet ./internal/hook ./internal/capdiag ./internal/boot ./internal/cli`
- `(cd desktop && go vet ./...)`
- Windows amd64 cross-compilation checks for the affected Hook, capability diagnostics, boot, CLI, and Desktop packages
- `git diff --check`

## Cache impact

Cache-impact: none - the change does not modify prompt construction, provider request serialization, tool schemas/order, compaction, memory prefixes, or skill indexing.
Cache-guard: N/A - runtime Hook resolution and diagnostics are outside provider-visible cache inputs.
System-prompt-review: Reviewed - the `internal/boot` change only forwards the resolved Bash path to Hook execution and does not alter any provider-visible system prompt, memory prefix, output style, or skill index content.
