### PR TITLE
Update v1.18.0 bilingual release notes / 更新 v1.18.0 中英发布说明

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -10,11 +10,17 @@
         "zh": "新增 Kimi K3 支持、预览与稳定发布渠道、签名完整性保障"
       },
       "summary": {
-        "en": "This release introduces support for the Kimi K3 model, desktop release channels (Preview and Stable), and hardening of the release signing process.",
-        "zh": "本次发布新增对 Kimi K3 模型的支持，推出桌面版预览与稳定双渠道，并强化了发布签名流程。"
+        "en": "This release adds Kimi K3 support to the official Kimi APIs and OpenCode Go, introduces Preview and Stable channels for Desktop and native CLI, and hardens the Windows release signing process.",
+        "zh": "本次发布为官方 Kimi API 与 OpenCode Go 新增 Kimi K3 支持，为桌面版和原生 CLI 推出 Preview 与 Stable 双渠道，并强化 Windows 发布签名流程。"
       },
       "surfaces": [
-        "desktop"
+        "agent",
+        "cli",
+        "desktop",
+        "provider",
+        "remote",
+        "security",
+        "updates"
       ],
       "guides": [
         {
@@ -81,8 +87,8 @@
             "zh": "支持 Kimi K3 模型"
           },
           "body": {
-            "en": "We’ve added the Kimi K3 model to the official Kimi CN and Kimi Global direct-API providers, with native vision, a 1,048,576-token context window, and low/high/max reasoning scale.",
-            "zh": "我们已将 Kimi K3 模型添加到官方 Kimi 国内版和全球版直接 API 提供商中，支持原生视觉、1,048,576 token 上下文窗口以及低/高/最高推理等级。"
+            "en": "Kimi K3 is now available through the official Kimi CN and Global direct APIs and OpenCode Go. Official APIs support native vision, a 1,048,576-token context window, and low/high/max reasoning; OpenCode Go keeps its relay-specific high/max scale.",
+            "zh": "Kimi K3 现已支持官方 Kimi 国内版、全球版直接 API 及 OpenCode Go。官方 API 支持原生视觉、1,048,576 token 上下文窗口和低/高/最高推理等级；OpenCode Go 保留其专用的高/最高等级。"
           },
           "refs": [
             6921
@@ -95,8 +101,8 @@
             "zh": "预览版与稳定版发布渠道"
           },
           "body": {
-            "en": "Reasonix Desktop now offers two update channels: Preview for early access features and Stable for production use. You can switch channels in Settings.",
-            "zh": "Reasonix 桌面版现提供两种更新渠道：预览渠道可提前体验新功能，稳定渠道适用于正式使用。您可在设置中切换渠道。"
+            "en": "Reasonix Desktop and native CLI now expose two public product channels: Preview for early access and Stable for production use. Desktop users can switch channels in Settings.",
+            "zh": "Reasonix 桌面版和原生 CLI 现提供两个公开产品渠道：Preview 用于抢先体验，Stable 用于正式使用。桌面用户可在设置中切换渠道。"
           },
           "refs": [
             6155
@@ -134,6 +140,19 @@
           },
           {
             "title": {
+              "en": "Kimi K3 support in OpenCode Go",
+              "zh": "OpenCode Go 支持 Kimi K3"
+            },
+            "body": {
+              "en": "OpenCode Go now exposes Kimi K3 with its relay-specific high/max reasoning scale and existing OpenAI-compatible request behavior.",
+              "zh": "OpenCode Go 现支持 Kimi K3，并保留中继专用的高/最高推理等级及现有 OpenAI 兼容请求行为。"
+            },
+            "refs": [
+              6921
+            ]
+          },
+          {
+            "title": {
               "en": "Native vision and 1M context for Kimi K3",
               "zh": "Kimi K3 支持原生视觉和百万级上下文"
             },
@@ -147,12 +166,12 @@
           },
           {
             "title": {
-              "en": "Desktop release channels",
-              "zh": "桌面版发布渠道"
+              "en": "Desktop and native CLI release channels",
+              "zh": "桌面版和原生 CLI 发布渠道"
             },
             "body": {
-              "en": "Introduced Preview and Stable channels for desktop updates, selectable in Settings.",
-              "zh": "推出桌面版预览与稳定更新渠道，可在设置中选择。"
+              "en": "Introduced Preview and Stable channels for Desktop updates and native CLI archives; Desktop users can select their channel in Settings.",
+              "zh": "为桌面更新和原生 CLI 归档推出 Preview 与 Stable 渠道；桌面用户可在设置中选择渠道。"
             },
             "refs": [
               6155

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -6,53 +6,97 @@
       "date": "2026-07-27",
       "channel": "stable",
       "title": {
-        "en": "Stable and Preview channels with hardened Windows release signing",
-        "zh": "Stable 与 Preview 渠道及强化的 Windows 发布签名"
+        "en": "Kimi K3 Support, Preview & Stable Channels, and Signing Integrity",
+        "zh": "新增 Kimi K3 支持、预览与稳定发布渠道、签名完整性保障"
       },
       "summary": {
-        "en": "This release introduces Stable and Preview public channels for Desktop and native CLI, and hardens the stable Windows signing path with a machine-readable contract, protected workflow checks, and a zero-publication dual-architecture preflight.",
-        "zh": "此版本为桌面和原生 CLI 引入 Stable 与 Preview 双公开渠道，并通过机器可读契约、受保护的工作流检查及双架构零发布预检，强化稳定版 Windows 签名链路。"
+        "en": "This release introduces support for the Kimi K3 model, desktop release channels (Preview and Stable), and hardening of the release signing process.",
+        "zh": "本次发布新增对 Kimi K3 模型的支持，推出桌面版预览与稳定双渠道，并强化了发布签名流程。"
       },
       "surfaces": [
-        "desktop",
-        "cli",
-        "security",
-        "updates"
+        "desktop"
       ],
       "guides": [
+        {
+          "title": {
+            "en": "Reasonix User Guide",
+            "zh": "用户指南"
+          },
+          "body": {
+            "en": "Comprehensive guide for using Reasonix.",
+            "zh": "Reasonix 使用综合指南。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/GUIDE.md"
+        },
+        {
+          "title": {
+            "en": "Reasonix User Guide (Chinese)",
+            "zh": "用户指南（中文）"
+          },
+          "body": {
+            "en": "Comprehensive guide for using Reasonix in Chinese.",
+            "zh": "Reasonix 使用综合指南（中文版）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/GUIDE.zh-CN.md"
+        },
+        {
+          "title": {
+            "en": "Reasoning Providers Configuration",
+            "zh": "推理提供商配置"
+          },
+          "body": {
+            "en": "How to configure AI model providers in Reasonix.",
+            "zh": "如何在 Reasonix 中配置 AI 模型提供商。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/REASONING_PROVIDERS.md"
+        },
         {
           "title": {
             "en": "Release Process",
             "zh": "发布流程"
           },
           "body": {
-            "en": "Documentation for the release process including Stable and Preview channels.",
-            "zh": "包含 Stable 与 Preview 渠道的发布流程文档。"
+            "en": "Details on Reasonix release channels and process.",
+            "zh": "Reasonix 发布渠道与流程详情。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/c846ad5559ca195ec2adbf7105348858c341227e/docs/RELEASING.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/RELEASING.md"
         },
         {
           "title": {
-            "en": "Windows Signing Standard Operating Procedure",
-            "zh": "Windows 签名标准操作程序"
+            "en": "Windows Signing Admin SOP",
+            "zh": "Windows 签名管理 SOP"
           },
           "body": {
-            "en": "Procedure for Windows code signing and verification.",
-            "zh": "Windows 代码签名与验证程序。"
+            "en": "Standard operating procedure for Windows code signing.",
+            "zh": "Windows 代码签名标准操作流程。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/c846ad5559ca195ec2adbf7105348858c341227e/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md"
         }
       ],
       "highlights": [
         {
           "kind": "new",
           "title": {
-            "en": "Stable and Preview release channels",
-            "zh": "Stable 与 Preview 双发布渠道"
+            "en": "Kimi K3 model support",
+            "zh": "支持 Kimi K3 模型"
           },
           "body": {
-            "en": "Introduced two public product channels: Stable and Preview. Stable remains the weekly release, while Preview provides early access to upcoming features across Desktop and native CLI with channel-aware routing and signing.",
-            "zh": "新增两个公开产品渠道：Stable 与 Preview。Stable 保持每周发布，Preview 为桌面和原生 CLI 提供早期功能体验，并采用渠道感知的路由与签名。"
+            "en": "We’ve added the Kimi K3 model to the official Kimi CN and Kimi Global direct-API providers, with native vision, a 1,048,576-token context window, and low/high/max reasoning scale.",
+            "zh": "我们已将 Kimi K3 模型添加到官方 Kimi 国内版和全球版直接 API 提供商中，支持原生视觉、1,048,576 token 上下文窗口以及低/高/最高推理等级。"
+          },
+          "refs": [
+            6921
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Preview and Stable release channels",
+            "zh": "预览版与稳定版发布渠道"
+          },
+          "body": {
+            "en": "Reasonix Desktop now offers two update channels: Preview for early access features and Stable for production use. You can switch channels in Settings.",
+            "zh": "Reasonix 桌面版现提供两种更新渠道：预览渠道可提前体验新功能，稳定渠道适用于正式使用。您可在设置中切换渠道。"
           },
           "refs": [
             6155
@@ -61,12 +105,12 @@
         {
           "kind": "security",
           "title": {
-            "en": "Protected Windows signing release gate",
-            "zh": "受保护的 Windows 签名发布门禁"
+            "en": "Release signing integrity hardening",
+            "zh": "加强发布签名完整性"
           },
           "body": {
-            "en": "Stable Desktop publishing now validates the SignPath contract, workflow call graph, protected fingerprints, CODEOWNERS coverage, and both Windows architectures before any public artifact is published.",
-            "zh": "稳定版桌面发布现在会在发布任何公开产物前，校验 SignPath 契约、工作流调用图、受保护指纹、CODEOWNERS 覆盖范围及两个 Windows 架构。"
+            "en": "We fixed a signing configuration that blocked the v1.17.21 Desktop release and added automated checks to verify the signing contract for all future releases.",
+            "zh": "我们修复了导致 v1.17.21 桌面版发布受阻的签名配置，并增加了自动化检查以验证所有未来发布的签名合约。"
           },
           "refs": [
             6944
@@ -77,25 +121,38 @@
         "new": [
           {
             "title": {
-              "en": "Dual release channels for Desktop and CLI",
-              "zh": "桌面和 CLI 的双发布渠道"
+              "en": "Kimi K3 model available in official providers",
+              "zh": "官方提供商支持 Kimi K3 模型"
             },
             "body": {
-              "en": "Added Stable and Preview channels with distinct update tracks, verification, and distribution.",
-              "zh": "添加了 Stable 与 Preview 渠道，具备独立的更新轨迹、验证和分发机制。"
+              "en": "The Kimi K3 model is now available in the Kimi CN and Kimi Global providers.",
+              "zh": "Kimi K3 模型现已在 Kimi 国内版和全球版提供商中可用。"
             },
             "refs": [
-              6155
+              6921
             ]
           },
           {
             "title": {
-              "en": "Channel-aware Desktop updates",
-              "zh": "支持渠道感知的桌面更新"
+              "en": "Native vision and 1M context for Kimi K3",
+              "zh": "Kimi K3 支持原生视觉和百万级上下文"
             },
             "body": {
-              "en": "Desktop now persists Stable or Preview selection, routes manifests and downloads through the selected channel, and keeps legacy Canary settings compatible during migration.",
-              "zh": "桌面现在会持久化 Stable 或 Preview 选择，按所选渠道路由清单与下载，并在迁移期间兼容旧的 Canary 设置。"
+              "en": "Kimi K3 comes with native vision support, a 1,048,576-token context window, and low/high/max reasoning scale.",
+              "zh": "Kimi K3 具备原生视觉支持、1,048,576 token 上下文窗口以及低/高/最高推理等级。"
+            },
+            "refs": [
+              6921
+            ]
+          },
+          {
+            "title": {
+              "en": "Desktop release channels",
+              "zh": "桌面版发布渠道"
+            },
+            "body": {
+              "en": "Introduced Preview and Stable channels for desktop updates, selectable in Settings.",
+              "zh": "推出桌面版预览与稳定更新渠道，可在设置中选择。"
             },
             "refs": [
               6155
@@ -105,12 +162,12 @@
         "improved": [
           {
             "title": {
-              "en": "Machine-checked stable signing contract",
-              "zh": "机器校验的稳定版签名契约"
+              "en": "Signing contract automated validation",
+              "zh": "签名合约自动验证"
             },
             "body": {
-              "en": "Release workflows now validate exact SignPath build definitions and the main-v2 origin, while a contract fingerprint replaces the mutable standalone readiness switch.",
-              "zh": "发布工作流现在会校验精确的 SignPath 构建定义和 main-v2 来源，并以契约指纹替代可变的独立就绪开关。"
+              "en": "The release process now validates the signing contract automatically to prevent misconfigurations.",
+              "zh": "发布流程现自动验证签名合约，防止配置错误。"
             },
             "refs": [
               6944
@@ -120,12 +177,12 @@
         "fixed": [
           {
             "title": {
-              "en": "Stable release SignPath routing",
-              "zh": "稳定版发布的 SignPath 路由"
+              "en": "Fixed v1.17.21 Desktop release signing",
+              "zh": "修复 v1.17.21 桌面版发布签名"
             },
             "body": {
-              "en": "The stable orchestrator now participates in the allowed production signing path instead of reaching a provider policy that only recognized the Desktop workflow.",
-              "zh": "稳定版编排器现在使用获准的生产签名路径，不再落入仅识别桌面工作流的提供商策略。"
+              "en": "Resolved a signing issue that prevented the previous Desktop release from being published.",
+              "zh": "解决了导致前一个桌面版发布未能发布的签名问题。"
             },
             "refs": [
               6944


### PR DESCRIPTION
## Summary

- Regenerate the v1.18.0 bilingual release catalog from the current `main-v2` boundary.
- Add Kimi K3 support from #6921 across the official Kimi APIs and OpenCode Go while preserving their distinct reasoning scales.
- Keep the Desktop/native CLI Preview and Stable channel copy from #6155 and the Windows signing hardening from #6944.
- Correct the affected product surfaces and pin the relevant user and operator guides to the reviewed source commit.

## Verification

- `node scripts/release-notes.mjs validate`
- `node --test scripts/release-notes.test.mjs`
- Rendered and reviewed both English and Chinese v1.18.0 notes
- `git diff --check`

Cache-impact: none; this PR changes release catalog copy only.
System-prompt-review: N/A