### PR TITLE
fix(jobs): serialize j.status reads through a locking helper

### DIFF
--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -147,6 +147,17 @@ type Job struct {
 	evidenceCommitted bool
 }
 
+// Status returns the current job lifecycle status under the job's mutex.
+// Use this when reading j.status from outside the goroutine that wrote it
+// (for example, from a test that observes a job returned by StartForSession
+// before the run goroutine has finished). Reading j.status directly is a
+// data race and triggers `go test -race`.
+func (j *Job) Status() Status {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.status
+}
+
 // Manager is the session's background-job table. It is safe for concurrent use.
 type Manager struct {
 	sink       event.Sink

--- a/internal/jobs/jobs_security_test.go
+++ b/internal/jobs/jobs_security_test.go
@@ -151,8 +151,8 @@ func TestStartForSession_AcceptsValidInput(t *testing.T) {
 		close(done)
 		return "ok", nil
 	})
-	if j.status != Running {
-		t.Fatalf("job status = %q, want Running (artifactErr=%q)", j.status, j.artifactErr)
+	if j.Status() != Running {
+		t.Fatalf("job status = %q, want Running (artifactErr=%q)", j.Status(), j.artifactErr)
 	}
 	if j.artifactPath == "" {
 		t.Fatal("artifactPath empty; expected a path under the temp root")


### PR DESCRIPTION
Refs #6936. Race evidence surfaced by #6937's CI run.

## Summary / 摘要

`TestStartForSession_AcceptsValidInput` (added in #6936) reads `j.status` from the test goroutine without taking `j.mu`, while the run goroutine writes `j.status = st` under `j.mu`. `go test -race` flags this as a data race. The field has been mutated without the lock since long before #6936; the race detector only caught it once a test started observing the field from outside the goroutine that wrote it.

`TestStartForSession_AcceptsValidInput`（在 #6936 引入）从 test goroutine 读 `j.status` 时没拿 `j.mu`，而 run goroutine 写 `j.status = st` 时在 `j.mu` 下。`go test -race` 把这个标记成 data race。`j.status` 字段在 #6936 之前就是无锁写的——只有 #6936 加的 test 让 race detector 看见。

## Root cause / 根因

`internal/jobs/jobs.go` writes `j.status` in several places, but only some of them hold `j.mu`:

  - `StartForSession` line 337 (`status: Running`) and the `startInvalid` helper (`status: Failed`) write without the lock because the goroutine has not yet been scheduled.
  - The run goroutine line 506 (`j.status = st`) and the kill paths line 950 / 1582 / 1761 do hold `j.mu` around the write.

`TestStartForSession_AcceptsValidInput` reads `j.status` directly after `StartForSession` returns, with no lock. The race detector only sees the conflict when the test goroutine observes the field while the run goroutine is mid-write under `j.mu`.

## Fix / 修复

Adds `Job.Status() Status`, a public helper that takes the job's mutex and returns the current status. Updates `TestStartForSession_AcceptsValidInput` to use the helper. The change is mechanical: the lock is acquired by the helper, so the read is now race-free.

The fix is intentionally narrow. Many other internal call sites still read `j.status` without the lock (within `Manager` methods that hold `m.mu`, or in code that runs only on the run goroutine after the lock release), but `go test -race` did not report those as races and they are out of scope for this fix. If we ever want to make `j.status` a plain value with a public contract, that is a larger follow-up.

加 `Job.Status() Status` 公共 helper（拿 job 的 mutex 返回当前 status）。改 `TestStartForSession_AcceptsValidInput` 用 helper。改动是机械的：锁由 helper 获取，读现在是 race-free。

修复故意做得很小。其他内部读 `j.status` 的地方（持有 `m.mu` 的 Manager 方法内，或只在 run goroutine 内执行的代码）仍是无锁读，但 `go test -race` 没报告这些为 race，scope 之外。如果要把 `j.status` 变成有 public contract 的 plain value，那是更大的后续。

## Changes / 改动

| File | Change |
|:--|:--|
| `internal/jobs/jobs.go` | Add `Job.Status()` helper that returns the current status under the job's mutex. |
| `internal/jobs/jobs_security_test.go` | Update `TestStartForSession_AcceptsValidInput` to call `j.Status()` instead of reading `j.status` directly. |

## Verification / 验证

- `go build ./...` — passed
- `go vet ./...` — passed
- `gofmt -l internal/jobs/` — clean
- `go test -count=1 ./internal/jobs/...` — passed (4.7s, no regression)
- `go test -race` skipped locally (Windows without gcc); Linux CI runs it and was the place where the original race was caught

Race evidence captured from #6937's CI run:
  https://github.com/esengine/DeepSeek-Reasonix/actions/runs/30275206427/job/90012258161

## Compatibility / 兼容性

| Surface | Existing-data behavior | Conclusion |
|:--|:--|:--|
| Persisted state, sessions, jobs | No schema or file-format changes | Backward compatible |
| Public API of `Job` | New `Status()` method added; existing public fields (`ID`, `Kind`, `Label`, `SessionID`) unchanged. The unexported `status` field continues to be read directly by internal `Manager` methods, so internal code paths are unchanged. | Additive only |
| Wails / frontend contracts | No binding, JSON, or frontend changes | Backward compatible |
| CLI | No command-line, prompt, or tool-schema changes | Backward compatible |
| Test behaviour | `TestStartForSession_AcceptsValidInput` still asserts the job is `Running` immediately after `StartForSession` returns. The only change is that the read is now under the lock. | Behaviour preserved |

Cache-impact: none — no provider-visible serialization, prompt, tool-schema, memory, or model call path is touched.
Cache-guard: N/A — no cache-sensitive path changed.
System-prompt-review: N/A — no system prompt or tool schema changed.
