### PR TITLE
fix(desktop): persist right-panel & status-bar data across session switches / 修复切换会话后右侧栏和状态栏数据丢失

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6037,6 +6037,7 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	a.mu.RUnlock()
 
 	var info ContextInfo
+	var snap tabTelemetrySnapshot
 	if tab != nil {
 		// Re-key first: a controller-side rotation (typed /new) may have
 		// swapped sessions without the App noticing, and the stale totals
@@ -6047,7 +6048,7 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 				tab.syncTelemetryToSession(sp)
 			}
 		}
-		snap := tab.telemetrySnapshot()
+		snap = tab.telemetrySnapshot()
 		info.SessionTokens = snap.Usage.TotalTokens
 		info.SessionCost = snap.Usage.SessionCost
 		info.SessionCurrency = snap.Usage.SessionCurrency
@@ -6061,6 +6062,13 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	used, window := ctrl.ContextSnapshot()
 	info.Used = used
 	info.Window = window
+	// Session rebind (project-tree switch) rebuilds the controller: the fresh
+	// executor has no per-turn usage yet, so ContextSnapshot reports used=0.
+	// Fall back to the telemetry-persisted last-used value so the status bar
+	// shows the fill percentage from the last turn instead of 0%.
+	if used == 0 && snap.Usage.LastUsedTokens > 0 {
+		info.Used = snap.Usage.LastUsedTokens
+	}
 	info.CompactRatio = ctrl.CompactRatio()
 	return info
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4463,7 +4463,7 @@ export default function App() {
                   turnCost={state.turnCost}
                   balance={state.balance}
                   sessionGen={state.sessionGen}
-                  refreshKey={dockRefreshKey}
+                  refreshKey={dockRefreshKey + state.contextPanelSeq}
                   usageSeq={state.usageSeq}
                 />
               ) : (

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -560,6 +560,7 @@ await act(async () => {
   await contextDGate.promise;
   await flushPromises();
 });
+eq(contextDCalls, 1, "open topic hydration issues one context request");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "history D") ?? false, "topic history replaces the hydration placeholder");
 eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "topic history clears the hydration placeholder");
 

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2429,27 +2429,6 @@ export function useController() {
     };
   }, [activeTabId, activeState.meta?.ready, activeState.meta?.startupErr, activeState.backendActivationPending, refreshMetaOnlyForTab]);
 
-  // Fallback context fetch when activeTabId changes and the target tab's
-  // state.context is empty (e.g. the switch-tab ancillary ContextUsageForTab
-  // dispatch was skipped by a rapid A→B→A switch that invalidated stillVisible
-  // before the call returned). StatusBar reads state.context directly and has
-  // no self-fetching logic, so it would remain blank until the next turn_done
-  // without this catch-up path.
-  useEffect(() => {
-    const tabId = activeTabId;
-    if (!tabId) return;
-    const st = statesRef.current.get(tabId);
-    if (st?.context && (st.context.used > 0 || st.context.window > 0)) return;
-    let cancelled = false;
-    void app.ContextUsageForTab(tabId).then((context) => {
-      if (cancelled || activeTabIdRef.current !== tabId) return;
-      dispatchTo(tabId, { type: "context", context });
-    }).catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [activeTabId, dispatchTo]);
-
   // Stale-turn watchdog: if the frontend thinks the agent is running but the
   // turn stream has gone quiet, reconcile with the backend. This catches cases
   // where the Wails event channel silently drops turn_done after the final

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -190,6 +190,11 @@ interface State {
   retry?: { attempt: number; max: number; observedAt: number };
   seq: number;
   sessionGen: number;
+  // Per-session counter bumped after hydration ancillary data (context, effort,
+  // jobs) arrives. ContextPanel reads this (merged into refreshKey) so the
+  // right-side panel re-fetches after a session rebind instead of showing stale
+  // RequestCount / ElapsedMs / SessionCost from before the swap.
+  contextPanelSeq: number;
   // Monotonic count of usage events from ANY source (executor, subagent,
   // title…). Drives right-panel snapshot refreshes so sub-agent activity keeps
   // the session metrics live; state.usage stays executor-gated for the gauge.
@@ -226,6 +231,7 @@ export const initialState: State = {
   sessionCurrency: "¥",
   seq: 0,
   sessionGen: 0,
+  contextPanelSeq: 0,
   usageSeq: 0,
 };
 
@@ -494,7 +500,8 @@ type Action =
   | { type: "approval_drained"; ids: string[]; epoch: number }
   | { type: "submit_prompt_failed"; id: string; epoch: number }
   | { type: "controller_rebuilt" }
-  | { type: "reset" };
+  | { type: "reset" }
+  | { type: "context_panel_refresh" };
 
 function backendStatusFromRuntimeMeta(meta: RuntimeMetaSnapshot): Extract<Action, { type: "backend_status" }> {
   const foregroundRunning = foregroundRunningFromRuntimeMeta(meta);
@@ -1416,6 +1423,7 @@ export function reducer(s: State, a: Action): State {
     case "controller_rebuilt":
       return { ...s, promptEpoch: s.promptEpoch + 1, resolvedPromptId: undefined, promptArrivedId: undefined, promptArrivedAt: undefined };
     case "reset": return { ...initialState, meta: metaWithoutCanonicalTodos(s.meta), context: { used: 0, window: s.context.window, sessionTokens: 0, compactRatio: s.context.compactRatio }, balance: s.balance, effort: s.effort, jobs: s.jobs, hydrating: s.hydrating, hydrateReason: s.hydrateReason, hydrateError: s.hydrateError, hydrateHistoryLoaded: s.hydrateHistoryLoaded, hydratePlaceholderItems: s.hydratePlaceholderItems, backendActivationPending: s.backendActivationPending, sessionGen: s.sessionGen + 1, promptEpoch: s.promptEpoch + 1 };
+    case "context_panel_refresh": return { ...s, contextPanelSeq: s.contextPanelSeq + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }
@@ -2038,13 +2046,14 @@ export function useController() {
         loadAncillary("context", () => app.ContextUsageForTab(tabId)),
       ]);
       if (!stillCurrent()) return;
-      if (!stillVisible()) {
-        addBreadcrumb("tab.hydrate", `ancillary ignored inactive ${reason} ${tabId}`);
-        return;
-      }
       if (effort !== undefined) dispatchTo(tabId, { type: "effort", effort });
       if (jobs !== undefined) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
       if (context !== undefined) dispatchTo(tabId, { type: "context", context });
+      // Signal ContextPanel to re-fetch now that ancillary data (context,
+      // effort, jobs) has landed. Without this, the right-side panel keeps
+      // stale RequestCount / ElapsedMs / SessionCost from before a session
+      // rebind because its refreshKey (dockRefreshKey) only bumps on turn_done.
+      dispatchTo(tabId, { type: "context_panel_refresh" });
       await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
       if (!stillCurrent()) return;
       if (!stillVisible()) {
@@ -2419,6 +2428,27 @@ export function useController() {
       if (timer !== undefined) window.clearTimeout(timer);
     };
   }, [activeTabId, activeState.meta?.ready, activeState.meta?.startupErr, activeState.backendActivationPending, refreshMetaOnlyForTab]);
+
+  // Fallback context fetch when activeTabId changes and the target tab's
+  // state.context is empty (e.g. the switch-tab ancillary ContextUsageForTab
+  // dispatch was skipped by a rapid A→B→A switch that invalidated stillVisible
+  // before the call returned). StatusBar reads state.context directly and has
+  // no self-fetching logic, so it would remain blank until the next turn_done
+  // without this catch-up path.
+  useEffect(() => {
+    const tabId = activeTabId;
+    if (!tabId) return;
+    const st = statesRef.current.get(tabId);
+    if (st?.context && (st.context.used > 0 || st.context.window > 0)) return;
+    let cancelled = false;
+    void app.ContextUsageForTab(tabId).then((context) => {
+      if (cancelled || activeTabIdRef.current !== tabId) return;
+      dispatchTo(tabId, { type: "context", context });
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTabId, dispatchTo]);
 
   // Stale-turn watchdog: if the frontend thinks the agent is running but the
   // turn stream has gone quiet, reconcile with the backend. This catches cases

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -255,15 +255,15 @@ type sessionUsageStats struct {
 	// from the most recent turn. It is persisted so the status bar / context
 	// panel can show a meaningful fill percentage after a session rebind
 	// rebuilds the controller (which resets the in-memory executor state).
-	LastUsedTokens int `json:"lastUsedTokens"`
+	LastUsedTokens int `json:"lastUsedTokens,omitempty"`
 	// Per-turn token breakdown from the most recent turn. Persisted separately
 	// from the cumulative totals above so the context-panel donut chart and
 	// type breakdown survive a session rebind (which resets executor.LastUsage).
-	LastPromptTokens     int                         `json:"lastPromptTokens"`
-	LastCompletionTokens int                         `json:"lastCompletionTokens"`
-	LastReasoningTokens  int                         `json:"lastReasoningTokens"`
-	LastCacheHitTokens   int                         `json:"lastCacheHitTokens"`
-	LastCacheMissTokens  int                         `json:"lastCacheMissTokens"`
+	LastPromptTokens     int                         `json:"lastPromptTokens,omitempty"`
+	LastCompletionTokens int                         `json:"lastCompletionTokens,omitempty"`
+	LastReasoningTokens  int                         `json:"lastReasoningTokens,omitempty"`
+	LastCacheHitTokens   int                         `json:"lastCacheHitTokens,omitempty"`
+	LastCacheMissTokens  int                         `json:"lastCacheMissTokens,omitempty"`
 	RequestCount         int                         `json:"requestCount"`
 	ElapsedMs            int64                       `json:"elapsedMs"`
 	SessionCost          float64                     `json:"sessionCost,omitempty"`
@@ -943,12 +943,14 @@ func (t *WorkspaceTab) recordUsage(e event.Event) {
 	t.usageTelemetry.CacheHitTokens += cacheHitTokens
 	t.usageTelemetry.CacheMissTokens += cacheMissTokens
 	t.usageTelemetry.RequestCount++
-	t.usageTelemetry.LastUsedTokens = u.PromptTokens + u.CompletionTokens
-	t.usageTelemetry.LastPromptTokens = u.PromptTokens
-	t.usageTelemetry.LastCompletionTokens = u.CompletionTokens
-	t.usageTelemetry.LastReasoningTokens = u.ReasoningTokens
-	t.usageTelemetry.LastCacheHitTokens = cacheHitTokens
-	t.usageTelemetry.LastCacheMissTokens = cacheMissTokens
+	if source == event.UsageSourceExecutor {
+		t.usageTelemetry.LastUsedTokens = u.PromptTokens + u.CompletionTokens
+		t.usageTelemetry.LastPromptTokens = u.PromptTokens
+		t.usageTelemetry.LastCompletionTokens = u.CompletionTokens
+		t.usageTelemetry.LastReasoningTokens = u.ReasoningTokens
+		t.usageTelemetry.LastCacheHitTokens = cacheHitTokens
+		t.usageTelemetry.LastCacheMissTokens = cacheMissTokens
+	}
 	if t.usageTelemetry.Sources == nil {
 		t.usageTelemetry.Sources = map[string]usageSourceStats{}
 	}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -245,18 +245,31 @@ type readFileRecord struct {
 }
 
 type sessionUsageStats struct {
-	PromptTokens     int                         `json:"promptTokens"`
-	CompletionTokens int                         `json:"completionTokens"`
-	TotalTokens      int                         `json:"totalTokens"`
-	ReasoningTokens  int                         `json:"reasoningTokens"`
-	CacheHitTokens   int                         `json:"cacheHitTokens"`
-	CacheMissTokens  int                         `json:"cacheMissTokens"`
-	RequestCount     int                         `json:"requestCount"`
-	ElapsedMs        int64                       `json:"elapsedMs"`
-	SessionCost      float64                     `json:"sessionCost,omitempty"`
-	SessionCurrency  string                      `json:"sessionCurrency,omitempty"`
-	SessionCostUsd   float64                     `json:"sessionCostUsd,omitempty"`
-	Sources          map[string]usageSourceStats `json:"sources,omitempty"`
+	PromptTokens     int `json:"promptTokens"`
+	CompletionTokens int `json:"completionTokens"`
+	TotalTokens      int `json:"totalTokens"`
+	ReasoningTokens  int `json:"reasoningTokens"`
+	CacheHitTokens   int `json:"cacheHitTokens"`
+	CacheMissTokens  int `json:"cacheMissTokens"`
+	// LastUsedTokens is the executor-reported context fill (prompt+completion)
+	// from the most recent turn. It is persisted so the status bar / context
+	// panel can show a meaningful fill percentage after a session rebind
+	// rebuilds the controller (which resets the in-memory executor state).
+	LastUsedTokens int `json:"lastUsedTokens"`
+	// Per-turn token breakdown from the most recent turn. Persisted separately
+	// from the cumulative totals above so the context-panel donut chart and
+	// type breakdown survive a session rebind (which resets executor.LastUsage).
+	LastPromptTokens     int                         `json:"lastPromptTokens"`
+	LastCompletionTokens int                         `json:"lastCompletionTokens"`
+	LastReasoningTokens  int                         `json:"lastReasoningTokens"`
+	LastCacheHitTokens   int                         `json:"lastCacheHitTokens"`
+	LastCacheMissTokens  int                         `json:"lastCacheMissTokens"`
+	RequestCount         int                         `json:"requestCount"`
+	ElapsedMs            int64                       `json:"elapsedMs"`
+	SessionCost          float64                     `json:"sessionCost,omitempty"`
+	SessionCurrency      string                      `json:"sessionCurrency,omitempty"`
+	SessionCostUsd       float64                     `json:"sessionCostUsd,omitempty"`
+	Sources              map[string]usageSourceStats `json:"sources,omitempty"`
 
 	activeTurnStartedAt int64
 	sourceSessionCache  map[string]sourceSessionCacheCounters
@@ -930,6 +943,12 @@ func (t *WorkspaceTab) recordUsage(e event.Event) {
 	t.usageTelemetry.CacheHitTokens += cacheHitTokens
 	t.usageTelemetry.CacheMissTokens += cacheMissTokens
 	t.usageTelemetry.RequestCount++
+	t.usageTelemetry.LastUsedTokens = u.PromptTokens + u.CompletionTokens
+	t.usageTelemetry.LastPromptTokens = u.PromptTokens
+	t.usageTelemetry.LastCompletionTokens = u.CompletionTokens
+	t.usageTelemetry.LastReasoningTokens = u.ReasoningTokens
+	t.usageTelemetry.LastCacheHitTokens = cacheHitTokens
+	t.usageTelemetry.LastCacheMissTokens = cacheMissTokens
 	if t.usageTelemetry.Sources == nil {
 		t.usageTelemetry.Sources = map[string]usageSourceStats{}
 	}
@@ -7930,6 +7949,14 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 		used, window := ctrl.ContextSnapshot()
 		info.UsedTokens = used
 		info.WindowTokens = window
+		// Session rebind rebuilds the controller: the fresh executor has no
+		// per-turn usage yet, so ContextSnapshot reports used=0. Fall back to
+		// the telemetry-persisted last-used value from the most recent turn.
+		if used == 0 {
+			if snap := tab.telemetrySnapshot(); snap.Usage.LastUsedTokens > 0 {
+				info.UsedTokens = snap.Usage.LastUsedTokens
+			}
+		}
 		// Per-turn token breakdown from LastUsage (same snapshot as UsedTokens)
 		// so the donut segments are proportional to the current context fill,
 		// not inflated by cumulative session totals.
@@ -7939,6 +7966,16 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 			info.ReasoningTokens = u.ReasoningTokens
 			info.CacheHitTokens = u.CacheHitTokens
 			info.CacheMissTokens = u.CacheMissTokens
+		} else {
+			// Executor rebuilt (session rebind): fall back to the telemetry-
+			// persisted per-turn breakdown so the donut chart and type
+			// breakdown show the last turn's composition instead of "other".
+			snap := tab.telemetrySnapshot()
+			info.PromptTokens = snap.Usage.LastPromptTokens
+			info.CompletionTokens = snap.Usage.LastCompletionTokens
+			info.ReasoningTokens = snap.Usage.LastReasoningTokens
+			info.CacheHitTokens = snap.Usage.LastCacheHitTokens
+			info.CacheMissTokens = snap.Usage.LastCacheMissTokens
 		}
 	}
 

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -208,6 +208,133 @@ func TestWorkspaceTabTracksPlannerAndExecutorCacheBySource(t *testing.T) {
 	}
 }
 
+func TestWorkspaceTabKeepsLastContextScopedToExecutor(t *testing.T) {
+	tab := &WorkspaceTab{}
+	tab.recordUsage(event.Event{
+		Usage: &provider.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			ReasoningTokens:  8,
+			CacheHitTokens:   70,
+			CacheMissTokens:  30,
+		},
+		UsageSource: event.UsageSourceExecutor,
+	})
+	tab.recordUsage(event.Event{
+		Usage: &provider.Usage{
+			PromptTokens:     900,
+			CompletionTokens: 90,
+			TotalTokens:      990,
+			ReasoningTokens:  40,
+			CacheHitTokens:   10,
+			CacheMissTokens:  890,
+		},
+		UsageSource: event.UsageSourceSubagent,
+	})
+
+	got := tab.telemetrySnapshot().Usage
+	if got.LastUsedTokens != 120 ||
+		got.LastPromptTokens != 100 ||
+		got.LastCompletionTokens != 20 ||
+		got.LastReasoningTokens != 8 ||
+		got.LastCacheHitTokens != 70 ||
+		got.LastCacheMissTokens != 30 {
+		t.Fatalf("last executor usage overwritten by ancillary source: %+v", got)
+	}
+	if got.TotalTokens != 1110 || got.Sources[event.UsageSourceSubagent].TotalTokens != 990 {
+		t.Fatalf("all-source totals lost while preserving executor usage: %+v", got)
+	}
+}
+
+func TestTelemetryLastContextRoundTripAndLegacyDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl.telemetry.json")
+	want := tabTelemetrySnapshot{
+		Version: 2,
+		Usage: sessionUsageStats{
+			PromptTokens:         100,
+			TotalTokens:          120,
+			LastUsedTokens:       120,
+			LastPromptTokens:     100,
+			LastCompletionTokens: 20,
+			LastReasoningTokens:  8,
+			LastCacheHitTokens:   70,
+			LastCacheMissTokens:  30,
+		},
+	}
+	if err := saveTelemetry(path, want); err != nil {
+		t.Fatalf("save telemetry: %v", err)
+	}
+	got := loadTelemetry(path).Usage
+	if got.LastUsedTokens != want.Usage.LastUsedTokens ||
+		got.LastPromptTokens != want.Usage.LastPromptTokens ||
+		got.LastCompletionTokens != want.Usage.LastCompletionTokens ||
+		got.LastReasoningTokens != want.Usage.LastReasoningTokens ||
+		got.LastCacheHitTokens != want.Usage.LastCacheHitTokens ||
+		got.LastCacheMissTokens != want.Usage.LastCacheMissTokens {
+		t.Fatalf("last context round trip = %+v, want %+v", got, want.Usage)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"version":2,"usage":{"promptTokens":50,"totalTokens":50}}`), 0o644); err != nil {
+		t.Fatalf("write pre-last-context telemetry: %v", err)
+	}
+	legacy := loadTelemetry(path).Usage
+	if legacy.LastUsedTokens != 0 ||
+		legacy.LastPromptTokens != 0 ||
+		legacy.LastCompletionTokens != 0 ||
+		legacy.LastReasoningTokens != 0 ||
+		legacy.LastCacheHitTokens != 0 ||
+		legacy.LastCacheMissTokens != 0 {
+		t.Fatalf("legacy telemetry last context = %+v, want zero defaults", legacy)
+	}
+}
+
+func TestContextFallbackUsesPersistedExecutorUsageAfterRebind(t *testing.T) {
+	ag := agent.New(
+		usageProvider{usage: nil},
+		tool.NewRegistry(),
+		agent.NewSession("system"),
+		agent.Options{ContextWindow: 200},
+		event.Discard,
+	)
+	tab := &WorkspaceTab{
+		ID:    "tab",
+		Ctrl:  control.New(control.Options{Executor: ag, Sink: event.Discard}),
+		Scope: "global",
+		Ready: true,
+	}
+	tab.recordUsage(event.Event{
+		Usage: &provider.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			ReasoningTokens:  8,
+			CacheHitTokens:   70,
+			CacheMissTokens:  30,
+		},
+		UsageSource: event.UsageSourceExecutor,
+	})
+	tab.recordUsage(event.Event{
+		Usage:       &provider.Usage{PromptTokens: 900, CompletionTokens: 90, TotalTokens: 990},
+		UsageSource: event.UsageSourceSubagent,
+	})
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+
+	context := app.ContextUsageForTab("tab")
+	if context.Used != 120 || context.Window != 200 {
+		t.Fatalf("context fallback = used:%d window:%d, want 120/200", context.Used, context.Window)
+	}
+	panel := app.ContextPanel("tab")
+	if panel.UsedTokens != 120 ||
+		panel.PromptTokens != 100 ||
+		panel.CompletionTokens != 20 ||
+		panel.ReasoningTokens != 8 ||
+		panel.CacheHitTokens != 70 ||
+		panel.CacheMissTokens != 30 {
+		t.Fatalf("context panel fallback = %+v, want persisted executor breakdown", panel)
+	}
+}
+
 func TestContextPanelUsesLastUsageBreakdownWithTelemetryTotal(t *testing.T) {
 	lastUsage := &provider.Usage{
 		PromptTokens:     10,


### PR DESCRIPTION
Fixes #5335. Fixes #5766. Fixes #7068.

---

### Summary

Switching a saved session from the project tree rebuilds that tab's controller. The fresh executor has no in-memory `LastUsage()` yet and initially reports `used=0`, while the existing telemetry sidecar only restores cumulative totals. As a result, the status bar and context panel can lose the previous executor turn's context fill and token breakdown, and the panel can keep stale request/cost values until it is reopened.

### Root cause

| Layer | Problem |
| --- | --- |
| Backend persistence | Cumulative session telemetry was persisted, but the latest executor turn's context fill and token breakdown were not. |
| Frontend hydration | An ancillary request that started for the visible tab could finish after the user switched away; the old visibility guard discarded the tab-scoped result even when the session generation still matched. |
| Panel refresh | `ContextPanel` had no post-ancillary refresh signal, so it could retain the snapshot fetched before the controller rebind completed. |

### Changes

**Backend (`desktop/tabs.go`, `desktop/app.go`)**

- Persist the latest executor turn's context fill and prompt/completion/reasoning/cache breakdown as optional `Last*` telemetry fields.
- Update those fields only for `executor` usage. Planner, subagent, title, and compaction telemetry still contributes to its existing cumulative source buckets but cannot overwrite the primary session gauge.
- Fall back to the persisted executor values when a freshly rebuilt controller reports no in-memory latest usage.

**Frontend (`desktop/frontend/src/lib/useController.ts`, `desktop/frontend/src/App.tsx`)**

- Keep tab-scoped ancillary context/effort/jobs results when the user switches away while the requests are already in flight, provided the tab's session generation is still current.
- Add a per-tab `contextPanelSeq` signal after ancillary hydration so `ContextPanel` refreshes request count, elapsed time, and session cost after rebind.
- Keep one authoritative context request in the hydration path. There is no separate `activeTabId` catch-up effect, avoiding duplicate requests.

### Compatibility

| Data or contract | Existing/older behavior | Result |
| --- | --- | --- |
| Telemetry files without `Last*` keys | Missing optional fields decode to zero; cumulative totals and source buckets are preserved. The latest-turn breakdown becomes available after the next executor response for that session because older files do not contain enough exact per-turn data to reconstruct it safely. | Backward-safe, non-retroactive migration |
| New telemetry read by an older Desktop build | Unknown JSON keys are ignored. An older writer may drop the optional `Last*` values on its next rewrite, degrading only to the previous display behavior. | Cross-version readable; no session corruption |
| Wails/frontend contracts | No existing field is removed or made required; zero values retain the previous empty-state behavior. | Backward-safe |
| Mixed usage sources | Only executor usage owns the persisted latest-turn gauge; other sources retain cumulative accounting. | Preserves status-bar ownership semantics |

### Verification

- `cd desktop && go test ./...`
- Frontend production and test TypeScript checks
- Frontend production build and bundle budgets
- 386 focused assertions covering tab switching, rapid navigation, session reset, context panel, status bar, and current layout integration
- Clean synthetic merge and the same critical-path checks against the latest `main-v2`, including the session-reattach changes from #6957

### Cache impact

```text
Cache-impact: none — changes are limited to Desktop telemetry persistence and React hydration state. No provider request, prompt, tool schema, ordering, compaction, memory, or skill path changes.
Cache-guard: N/A
System-prompt-review: N/A
```

---

### 概述

通过项目树切换已保存会话时，会重建对应标签页的 controller。新 executor 尚无内存中的 `LastUsage()`，并会暂时返回 `used=0`；原有 telemetry sidecar 又只保存累计指标。因此，状态栏和上下文面板会丢失上一轮 executor 的上下文占用及 token 明细，面板中的请求数、耗时和费用也可能保持为切换前的旧值，直到用户重新打开面板。

### 根因

| 层 | 问题 |
| --- | --- |
| 后端持久化 | 只持久化了会话累计 telemetry，没有保存最近一次 executor 请求的上下文占用和 token 明细。 |
| 前端 hydration | ancillary 请求为可见标签页启动后，如果用户在请求完成前切走，旧的可见性检查会丢弃仍属于当前 session generation 的标签页级结果。 |
| 面板刷新 | controller rebind 完成后的 ancillary 阶段没有刷新信号，`ContextPanel` 可能继续显示 rebind 前取得的快照。 |

### 修改内容

**后端（`desktop/tabs.go`、`desktop/app.go`）**

- 使用可选 `Last*` telemetry 字段持久化最近一次 executor 的上下文占用，以及 prompt/completion/reasoning/cache 明细。
- 只有 `executor` usage 可以更新这些字段。Planner、subagent、title 和 compaction 仍按原有逻辑计入累计来源统计，但不会覆盖主会话仪表。
- controller 重建后尚无内存 usage 时，回退使用持久化的 executor 数据。

**前端（`desktop/frontend/src/lib/useController.ts`、`desktop/frontend/src/App.tsx`）**

- ancillary context/effort/jobs 请求已经启动后，即使用户切换到其他标签页，只要对应 session generation 仍有效，就保留其标签页级结果。
- ancillary hydration 完成后递增 per-tab `contextPanelSeq`，让 `ContextPanel` 立即刷新请求数、耗时和会话费用。
- context 只由权威 hydration 路径请求；不再设置独立的 `activeTabId` 兜底 effect，避免重复请求。

### 兼容性

| 数据或契约 | 旧数据/旧版本行为 | 结论 |
| --- | --- | --- |
| 不含 `Last*` 字段的 telemetry 文件 | 缺失的可选字段安全解码为零；累计总量和来源统计保持不变。旧文件没有足够的精确单轮数据，无法安全反推，因此对应会话在下一次 executor 回复后才会获得最近一轮明细。 | 向后安全，但不追溯回填 |
| 旧版 Desktop 读取新 telemetry | 未识别的 JSON 字段会被忽略；旧版再次写入时可能丢弃可选 `Last*`，只会退化为旧版显示行为。 | 跨版本可读，不损坏会话 |
| Wails/前端契约 | 未移除已有字段，也未新增必填字段；零值沿用原有空状态。 | 向后安全 |
| 多种 usage 来源 | 持久化的最近一轮仪表仅由 executor 拥有，其他来源继续保留累计统计。 | 保持状态栏指标语义 |

### 验证

- `cd desktop && go test ./...`
- 前端生产与测试 TypeScript 检查
- 前端生产构建及 bundle budgets
- 386 个聚焦断言，覆盖标签页切换、快速导航、会话重置、上下文面板、状态栏及当前布局集成
- 与最新 `main-v2` 进行无冲突合并树验证，并覆盖已合入 #6957 的 session reattach 改动

### 缓存影响

```text
Cache-impact: none — 修改仅涉及 Desktop telemetry 持久化和 React hydration 状态；未改变 provider 请求、prompt、tool schema/顺序、compaction、memory 或 skill 路径。
Cache-guard: N/A
System-prompt-review: N/A
```
