### PR TITLE
fix(desktop): resolve eligible defaults for new sessions / 为桌面新会话解析可用默认模型

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -790,16 +790,18 @@ func desktopNewSessionDefaults(scope, workspaceRoot string) (string, string) {
 // default_model that resolves but has no API key in the current environment
 // would boot every new tab straight into the missing-key notice, so fall
 // through to the first provider that is actually configured, mirroring the
-// Configured() gate in Config.ResolveModelWithFallback's fallback chain. When
-// nothing is configured, the raw default is returned unchanged so the
-// existing missing-key notice still tells the user what to fix.
+// Configured() gate in Config.ResolveModelWithFallback's fallback chain. An
+// allowed chat default is preserved when every eligible provider is keyless so
+// the existing missing-key notice still tells the user what to fix. When no
+// desktop-accessible chat model exists, the empty result lets tab startup show
+// an actionable setup error instead of re-admitting an ineligible default.
 func resolveNewSessionModel(cfg *config.Config) string {
 	def := strings.TrimSpace(cfg.DefaultModel)
 	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, def)
 	if resolved, _, ok := cfg.ResolveDesktopNewSessionModel(); ok {
 		return resolved
 	}
-	return def
+	return ""
 }
 
 func (a *App) createTabEntryWithID(scope, workspaceRoot, topicID, id string) *WorkspaceTab {
@@ -8984,11 +8986,10 @@ func (a *App) ModelsForTab(tabID string) []ModelInfo {
 	if entry, ok := cfg.ResolveModel(curModel); ok {
 		curModel = entry.Name + "/" + entry.Model
 	}
-	access := providerAccessSet(cfg.Desktop.ProviderAccess)
 	out := []ModelInfo{}
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
-		if !modelProviderAccessAllowed(access, p.Name) || !p.Configured() {
+		if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, p.Name) || !p.Configured() {
 			continue
 		}
 		for _, m := range p.ChatModelList() {
@@ -8999,11 +9000,17 @@ func (a *App) ModelsForTab(tabID string) []ModelInfo {
 	return out
 }
 
-func modelProviderAccessAllowed(access map[string]bool, name string) bool {
-	if len(access) == 0 {
+func modelProviderAccessAllowed(access []string, name string) bool {
+	if access == nil {
 		return true
 	}
-	return access[strings.TrimSpace(name)]
+	name = strings.TrimSpace(name)
+	for _, candidate := range access {
+		if strings.TrimSpace(candidate) == name {
+			return true
+		}
+	}
+	return false
 }
 
 func controllerHasActiveRuntimeWork(ctrl control.SessionAPI) bool {
@@ -9208,7 +9215,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if !ok {
 		return fmt.Errorf("unknown model %q", name)
 	}
-	if !modelProviderAccessAllowed(providerAccessSet(cfg.Desktop.ProviderAccess), entry.Name) {
+	if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, entry.Name) {
 		return fmt.Errorf("model %q is not available because provider %q is not added", name, entry.Name)
 	}
 	name = entry.Name + "/" + entry.Model
@@ -11053,10 +11060,9 @@ func (a *App) NeedsOnboarding() bool {
 		// Do not cover their recovery path with an onboarding gate.
 		return false
 	}
-	access := providerAccessSet(cfg.Desktop.ProviderAccess)
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
-		if !modelProviderAccessAllowed(access, p.Name) || !p.Configured() || len(p.ChatModelList()) == 0 {
+		if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, p.Name) || !p.Configured() || len(p.ChatModelList()) == 0 {
 			continue
 		}
 		return false

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -777,7 +777,32 @@ func (a *App) createTabEntry(scope, workspaceRoot, topicID string) *WorkspaceTab
 
 func desktopNewSessionDefaults() (string, string) {
 	cfg := config.LoadForEdit(config.UserConfigPath())
-	return strings.TrimSpace(cfg.DefaultModel), normalizeToolApprovalMode(cfg.DesktopDefaultToolApprovalMode())
+	return resolveNewSessionModel(cfg), normalizeToolApprovalMode(cfg.DesktopDefaultToolApprovalMode())
+}
+
+// resolveNewSessionModel picks the model a fresh session starts on. A
+// default_model that resolves but has no API key in the current environment
+// would boot every new tab straight into the missing-key notice, so fall
+// through to the first provider that is actually configured, mirroring the
+// Configured() gate in Config.ResolveModelWithFallback's fallback chain. When
+// nothing is configured, the raw default is returned unchanged so the
+// existing missing-key notice still tells the user what to fix.
+func resolveNewSessionModel(cfg *config.Config) string {
+	def := strings.TrimSpace(cfg.DefaultModel)
+	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, def)
+	if def != "" {
+		if entry, ok := cfg.ResolveModel(def); ok && entry.Configured() {
+			return def
+		}
+	}
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if len(p.ModelList()) == 0 || !p.Configured() {
+			continue
+		}
+		return p.Name + "/" + p.DefaultModel()
+	}
+	return def
 }
 
 func (a *App) createTabEntryWithID(scope, workspaceRoot, topicID, id string) *WorkspaceTab {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -775,9 +775,15 @@ func (a *App) createTabEntry(scope, workspaceRoot, topicID string) *WorkspaceTab
 	return a.createTabEntryWithID(scope, workspaceRoot, topicID, newTabID())
 }
 
-func desktopNewSessionDefaults() (string, string) {
-	cfg := config.LoadForEdit(config.UserConfigPath())
-	return resolveNewSessionModel(cfg), normalizeToolApprovalMode(cfg.DesktopDefaultToolApprovalMode())
+func desktopNewSessionDefaults(scope, workspaceRoot string) (string, string) {
+	userCfg := config.LoadForEdit(config.UserConfigPath())
+	modelCfg := userCfg
+	if strings.TrimSpace(scope) == "project" && strings.TrimSpace(workspaceRoot) != "" {
+		if cfg, err := config.LoadForRootReadOnly(workspaceRoot); err == nil {
+			modelCfg = cfg
+		}
+	}
+	return resolveNewSessionModel(modelCfg), normalizeToolApprovalMode(userCfg.DesktopDefaultToolApprovalMode())
 }
 
 // resolveNewSessionModel picks the model a fresh session starts on. A
@@ -790,23 +796,14 @@ func desktopNewSessionDefaults() (string, string) {
 func resolveNewSessionModel(cfg *config.Config) string {
 	def := strings.TrimSpace(cfg.DefaultModel)
 	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, def)
-	if def != "" {
-		if entry, ok := cfg.ResolveModel(def); ok && entry.Configured() {
-			return def
-		}
-	}
-	for i := range cfg.Providers {
-		p := &cfg.Providers[i]
-		if len(p.ModelList()) == 0 || !p.Configured() {
-			continue
-		}
-		return p.Name + "/" + p.DefaultModel()
+	if resolved, _, ok := cfg.ResolveDesktopNewSessionModel(); ok {
+		return resolved
 	}
 	return def
 }
 
 func (a *App) createTabEntryWithID(scope, workspaceRoot, topicID, id string) *WorkspaceTab {
-	model, toolApprovalMode := desktopNewSessionDefaults()
+	model, toolApprovalMode := desktopNewSessionDefaults(scope, workspaceRoot)
 	return &WorkspaceTab{
 		ID:               id,
 		Scope:            scope,
@@ -3434,7 +3431,7 @@ func (a *App) openTransientBlankRuntime(scope, workspaceRoot string) error {
 		}
 	}
 
-	model, toolApprovalMode := desktopNewSessionDefaults()
+	model, toolApprovalMode := desktopNewSessionDefaults(scope, actualRoot)
 	sessionPath, err := createEmptySessionFile(desktopSessionDir(actualRoot), model)
 	if err != nil {
 		return err

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2847,6 +2847,21 @@ func TestModelsForTabOnlyListsProviderAccessWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestModelsForTabListsNothingWhenProviderAccessExplicitlyEmpty(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.Desktop.ProviderAccess = []string{}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	if models := NewApp().Models(); len(models) != 0 {
+		t.Fatalf("Models() = %+v, want no models when provider access is explicitly empty", models)
+	}
+}
+
 func TestModelsForTabListsCustomMultiModelProviderWithoutMetadata(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	setDesktopTestCredential(t, "LOCAL_API_KEY", "sk-test")

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -225,6 +225,83 @@ func TestDesktopNewSessionDefaultsKeepsKeylessDefaultWhenNothingConfigured(t *te
 	}
 }
 
+func TestDesktopNewSessionDefaultsRejectsNonChatDefaultWithoutFallback(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_AUDIO_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "audio",
+		Kind:      "openai",
+		BaseURL:   "https://audio.example.com",
+		Model:     "tts-1",
+		APIKeyEnv: "REASONIX_TEST_AUDIO_KEY",
+	}}
+	cfg.Desktop.ProviderAccess = []string{"audio"}
+	if err := cfg.SetDefaultModel("audio/tts-1"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	app := NewApp()
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	created := app.tabs[meta.ID]
+	if created == nil {
+		t.Fatalf("new tab %q missing from app.tabs", meta.ID)
+	}
+	if created.model != "" {
+		t.Fatalf("new session model = %q, want no ineligible model selected", created.model)
+	}
+	if created.Ctrl != nil || !strings.Contains(created.StartupErr, "chat-capable provider") {
+		t.Fatalf("new session runtime = (%v, %q), want an actionable no-chat-model startup error", created.Ctrl, created.StartupErr)
+	}
+}
+
+func TestDesktopNewSessionDefaultsHonorExplicitEmptyProviderAccess(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_SESSION_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "test-prov",
+		Kind:      "openai",
+		BaseURL:   "https://example.com",
+		Model:     "test-model",
+		APIKeyEnv: "REASONIX_TEST_SESSION_KEY",
+	}}
+	cfg.Desktop.ProviderAccess = []string{}
+	if err := cfg.SetDefaultModel("test-prov/test-model"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	app := NewApp()
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	created := app.tabs[meta.ID]
+	if created == nil {
+		t.Fatalf("new tab %q missing from app.tabs", meta.ID)
+	}
+	if created.model != "" {
+		t.Fatalf("new session model = %q, want no provider selected", created.model)
+	}
+	if created.Ctrl != nil || !strings.Contains(created.StartupErr, "chat-capable provider") {
+		t.Fatalf("new session runtime = (%v, %q), want an actionable no-provider startup error", created.Ctrl, created.StartupErr)
+	}
+	if !app.NeedsOnboarding() {
+		t.Fatal("NeedsOnboarding should be true when provider access is explicitly empty")
+	}
+}
+
 func TestDesktopNewSessionDefaultsUsesProjectDefaultAndSkipsItsKeylessProvider(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	seedUserCredentials(t, "REASONIX_TEST_SESSION_KEY=test-key\n")

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -143,7 +143,7 @@ func TestDesktopNewSessionDefaultsHonorExplicitAsk(t *testing.T) {
 		t.Fatalf("save user config: %v", err)
 	}
 
-	_, approvalMode := desktopNewSessionDefaults()
+	_, approvalMode := desktopNewSessionDefaults("global", "")
 	if approvalMode != control.ToolApprovalAsk {
 		t.Fatalf("explicit desktop approval default = %q, want ask", approvalMode)
 	}
@@ -181,7 +181,7 @@ func TestDesktopNewSessionDefaultsSkipsKeylessDefaultModel(t *testing.T) {
 		t.Fatalf("save user config: %v", err)
 	}
 
-	model, _ := desktopNewSessionDefaults()
+	model, _ := desktopNewSessionDefaults("global", "")
 	if model != "test-prov/test-model" {
 		t.Fatalf("new session model = %q, want fallback to configured provider test-prov/test-model", model)
 	}
@@ -199,7 +199,7 @@ func TestDesktopNewSessionDefaultsKeepsConfiguredDefaultModel(t *testing.T) {
 		t.Fatalf("save user config: %v", err)
 	}
 
-	model, _ := desktopNewSessionDefaults()
+	model, _ := desktopNewSessionDefaults("global", "")
 	if model != "deepseek-pro/deepseek-v4-pro" {
 		t.Fatalf("new session model = %q, want configured default verbatim", model)
 	}
@@ -219,8 +219,50 @@ func TestDesktopNewSessionDefaultsKeepsKeylessDefaultWhenNothingConfigured(t *te
 
 	// With no configured provider at all, the raw default must survive so the
 	// boot-time missing-key notice still tells the user what to fix.
-	model, _ := desktopNewSessionDefaults()
+	model, _ := desktopNewSessionDefaults("global", "")
 	if model != "deepseek-pro/deepseek-v4-pro" {
 		t.Fatalf("new session model = %q, want raw keyless default preserved", model)
+	}
+}
+
+func TestDesktopNewSessionDefaultsUsesProjectDefaultAndSkipsItsKeylessProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_SESSION_KEY=test-key\n")
+
+	userCfg := config.LoadForEdit(config.UserConfigPath())
+	userCfg.Providers = append(userCfg.Providers, config.ProviderEntry{
+		Name:      "test-prov",
+		Kind:      "openai",
+		BaseURL:   "https://example.com",
+		Model:     "test-model",
+		APIKeyEnv: "REASONIX_TEST_SESSION_KEY",
+	})
+	if err := userCfg.SetDefaultModel("test-prov/test-model"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := userCfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	workspace := robustTempDir(t)
+	if err := os.WriteFile(filepath.Join(workspace, "reasonix.toml"), []byte(`default_model = "deepseek-pro/deepseek-v4-pro"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	app := NewApp()
+	meta, err := app.EnsureBlankTab("project", workspace)
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	created := app.tabs[meta.ID]
+	if created == nil {
+		t.Fatalf("new tab %q missing from app.tabs", meta.ID)
+	}
+	if created.model != "test-prov/test-model" {
+		t.Fatalf("new project session model = %q, want configured fallback test-prov/test-model", created.model)
+	}
+	if !strings.Contains(filepath.Base(created.SessionPath), "test-model") {
+		t.Fatalf("new project session path = %q, want filename seeded by fallback model", created.SessionPath)
 	}
 }

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -73,6 +73,10 @@ func TestEnsureBlankTabInheritsActiveTabLocalSettings(t *testing.T) {
 
 func TestEnsureBlankTabUsesGlobalSessionDefaultsForModelAndToolApproval(t *testing.T) {
 	isolateDesktopUserDirs(t)
+	// Seed the key into Reasonix's user credentials store (the only source
+	// Configured() consults) so the default resolves as configured and is
+	// inherited verbatim regardless of the developer machine's environment.
+	seedUserCredentials(t, "DEEPSEEK_API_KEY=test-key\n")
 	workspace := robustTempDir(t)
 	if err := os.WriteFile(filepath.Join(workspace, "reasonix.toml"),
 		[]byte(""), 0o644); err != nil {
@@ -142,5 +146,81 @@ func TestDesktopNewSessionDefaultsHonorExplicitAsk(t *testing.T) {
 	_, approvalMode := desktopNewSessionDefaults()
 	if approvalMode != control.ToolApprovalAsk {
 		t.Fatalf("explicit desktop approval default = %q, want ask", approvalMode)
+	}
+}
+
+// seedUserCredentials writes key=value lines into Reasonix's user credentials
+// store. ProviderEntry.Configured() resolves keys only from that store, not
+// from process env, so tests must seed it explicitly.
+func seedUserCredentials(t *testing.T, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(config.UserCredentialsPath()), 0o755); err != nil {
+		t.Fatalf("mkdir credentials dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserCredentialsPath(), []byte(data), 0o600); err != nil {
+		t.Fatalf("write user credentials: %v", err)
+	}
+}
+
+func TestDesktopNewSessionDefaultsSkipsKeylessDefaultModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_SESSION_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers = append(cfg.Providers, config.ProviderEntry{
+		Name:      "test-prov",
+		Kind:      "openai",
+		BaseURL:   "https://example.com",
+		Model:     "test-model",
+		APIKeyEnv: "REASONIX_TEST_SESSION_KEY",
+	})
+	if err := cfg.SetDefaultModel("deepseek-pro/deepseek-v4-pro"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	model, _ := desktopNewSessionDefaults()
+	if model != "test-prov/test-model" {
+		t.Fatalf("new session model = %q, want fallback to configured provider test-prov/test-model", model)
+	}
+}
+
+func TestDesktopNewSessionDefaultsKeepsConfiguredDefaultModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "DEEPSEEK_API_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if err := cfg.SetDefaultModel("deepseek-pro/deepseek-v4-pro"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	model, _ := desktopNewSessionDefaults()
+	if model != "deepseek-pro/deepseek-v4-pro" {
+		t.Fatalf("new session model = %q, want configured default verbatim", model)
+	}
+}
+
+func TestDesktopNewSessionDefaultsKeepsKeylessDefaultWhenNothingConfigured(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	// No credentials seeded: every provider resolves as unconfigured.
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if err := cfg.SetDefaultModel("deepseek-pro/deepseek-v4-pro"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	// With no configured provider at all, the raw default must survive so the
+	// boot-time missing-key notice still tells the user what to fix.
+	model, _ := desktopNewSessionDefaults()
+	if model != "deepseek-pro/deepseek-v4-pro" {
+		t.Fatalf("new session model = %q, want raw keyless default preserved", model)
 	}
 }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1772,7 +1772,7 @@ func selectableDesktopModelRef(c *config.Config, ref string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("unknown model %q", ref)
 	}
-	if !modelProviderAccessAllowed(providerAccessSet(c.Desktop.ProviderAccess), entry.Name) {
+	if !modelProviderAccessAllowed(c.Desktop.ProviderAccess, entry.Name) {
 		return "", fmt.Errorf("model %q is not available because provider %q is not added", ref, entry.Name)
 	}
 	if !entry.Configured() {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2559,7 +2559,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 	if scope == "global" {
 		actualRoot = globalRoot
 	}
-	defaultModel, defaultToolApprovalMode := desktopNewSessionDefaults()
+	defaultModel, defaultToolApprovalMode := desktopNewSessionDefaults(scope, actualRoot)
 
 	a.mu.Lock()
 	for _, id := range a.orderedTabIDsLocked() {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -50,6 +50,8 @@ type tabDisplayState struct {
 
 const displayPersistRetryLimit = 4
 
+var errNoDesktopChatModel = errors.New("no desktop chat model is available; add a chat-capable provider in Settings > Model > Access")
+
 type pendingDisplayWrite struct {
 	dir         string
 	sessionPath string
@@ -3465,6 +3467,28 @@ func clearTabStartupError(tab *WorkspaceTab) {
 	tab.StartupErrLeaseHeld = false
 }
 
+func (a *App) recordTabStartupFailure(tab *WorkspaceTab, buildGeneration uint64, wailsCtx context.Context, err error) {
+	leaseHeld := false
+	a.mu.Lock()
+	if a.tabBuildSupersededLocked(tab, buildGeneration) {
+		a.mu.Unlock()
+		return
+	}
+	leaseHeld = setTabStartupError(tab, err)
+	tab.Ready = false
+	if leaseHeld {
+		a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
+	} else {
+		a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
+	}
+	tab.releaseSessionLease()
+	a.mu.Unlock()
+	if leaseHeld {
+		a.scheduleDeferredStartupBuild(tab.ID)
+	}
+	a.emitReady(wailsCtx, tab.ID)
+}
+
 func (a *App) buildTabControllerWithContext(tab *WorkspaceTab, loadedSession loadedTabSession, buildCtx context.Context, buildGeneration uint64, buildCancel context.CancelFunc) {
 	a.runtimeAdmissionMu.RLock()
 	defer a.runtimeAdmissionMu.RUnlock()
@@ -3518,25 +3542,7 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 	_ = config.MigrateLegacyCredentialsForRoot(root)
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
-		leaseHeld := false
-		a.mu.Lock()
-		if a.tabBuildSupersededLocked(tab, buildGeneration) {
-			a.mu.Unlock()
-			return
-		}
-		leaseHeld = setTabStartupError(tab, err)
-		tab.Ready = false
-		if leaseHeld {
-			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, err)
-		} else {
-			a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, err)
-		}
-		tab.releaseSessionLease()
-		a.mu.Unlock()
-		if leaseHeld {
-			a.scheduleDeferredStartupBuild(tab.ID)
-		}
-		a.emitReady(wailsCtx, tab.ID)
+		a.recordTabStartupFailure(tab, buildGeneration, wailsCtx, err)
 		return
 	}
 
@@ -3598,7 +3604,12 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 		}
 	}
 	if model == "" {
-		model = cfg.DefaultModel
+		resolved, _, ok := cfg.ResolveDesktopNewSessionModel()
+		if !ok {
+			a.recordTabStartupFailure(tab, buildGeneration, wailsCtx, errNoDesktopChatModel)
+			return
+		}
+		model = resolved
 	}
 	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, model)
 	requestedModel := model

--- a/desktop/workbench_adapter.go
+++ b/desktop/workbench_adapter.go
@@ -689,11 +689,10 @@ func localProviderRefs(cfg *config.Config) []string {
 	if cfg == nil {
 		return nil
 	}
-	access := providerAccessSet(cfg.Desktop.ProviderAccess)
 	refs := make([]string, 0, len(cfg.Providers))
 	for i := range cfg.Providers {
 		pe := &cfg.Providers[i]
-		if !modelProviderAccessAllowed(access, pe.Name) || !pe.Configured() {
+		if !modelProviderAccessAllowed(cfg.Desktop.ProviderAccess, pe.Name) || !pe.Configured() {
 			continue
 		}
 		models := pe.ChatModelList()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1836,6 +1836,49 @@ func (c *Config) ResolveModelWithFallback(ref string) (resolvedRef string, fallb
 	return "", false, false
 }
 
+// ResolveDesktopNewSessionModel selects the model for a newly-created desktop
+// session. Unlike ResolveModelWithFallback, the configured default must be
+// immediately usable: its provider must be available in the desktop catalog,
+// configured, and expose the selected model as a chat model. Fallbacks apply
+// the same constraints and preserve provider order.
+func (c *Config) ResolveDesktopNewSessionModel() (resolvedRef string, fallback bool, ok bool) {
+	if c == nil {
+		return "", false, false
+	}
+	access := desktopProviderAccessMap(c.Desktop.ProviderAccess)
+	providerAllowed := func(name string) bool {
+		return len(access) == 0 || access[strings.TrimSpace(name)]
+	}
+
+	def := strings.TrimSpace(c.DefaultModel)
+	if def != "" {
+		if entry, found := c.ResolveModel(def); found &&
+			providerAllowed(entry.Name) && entry.Configured() && IsLikelyChatModel(entry.Model) {
+			return def, false, true
+		}
+	}
+
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		if !providerAllowed(p.Name) || !p.Configured() {
+			continue
+		}
+		chatModels := p.ChatModelList()
+		if len(chatModels) == 0 {
+			continue
+		}
+		model := chatModels[0]
+		for _, candidate := range chatModels {
+			if candidate == p.DefaultModel() {
+				model = candidate
+				break
+			}
+		}
+		return p.Name + "/" + model, true, true
+	}
+	return "", false, false
+}
+
 // APIKey resolves the entry's API key from its api_key_env.
 func (e *ProviderEntry) APIKey() string {
 	if e == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1837,30 +1837,36 @@ func (c *Config) ResolveModelWithFallback(ref string) (resolvedRef string, fallb
 }
 
 // ResolveDesktopNewSessionModel selects the model for a newly-created desktop
-// session. Unlike ResolveModelWithFallback, the configured default must be
-// immediately usable: its provider must be available in the desktop catalog,
-// configured, and expose the selected model as a chat model. Fallbacks apply
-// the same constraints and preserve provider order.
+// session. Its provider must be available in the desktop catalog and expose a
+// chat model. Configured candidates win; if every eligible candidate is
+// keyless, the allowed default (or first allowed chat model) is preserved so
+// desktop can show the existing missing-key recovery UI. Provider order is
+// otherwise stable.
 func (c *Config) ResolveDesktopNewSessionModel() (resolvedRef string, fallback bool, ok bool) {
 	if c == nil {
 		return "", false, false
 	}
 	access := desktopProviderAccessMap(c.Desktop.ProviderAccess)
 	providerAllowed := func(name string) bool {
-		return len(access) == 0 || access[strings.TrimSpace(name)]
+		return c.Desktop.ProviderAccess == nil || access[strings.TrimSpace(name)]
 	}
 
 	def := strings.TrimSpace(c.DefaultModel)
+	keylessDefault := ""
 	if def != "" {
 		if entry, found := c.ResolveModel(def); found &&
-			providerAllowed(entry.Name) && entry.Configured() && IsLikelyChatModel(entry.Model) {
-			return def, false, true
+			providerAllowed(entry.Name) && IsLikelyChatModel(entry.Model) {
+			if entry.Configured() {
+				return def, false, true
+			}
+			keylessDefault = def
 		}
 	}
 
+	keylessFallback := ""
 	for i := range c.Providers {
 		p := &c.Providers[i]
-		if !providerAllowed(p.Name) || !p.Configured() {
+		if !providerAllowed(p.Name) {
 			continue
 		}
 		chatModels := p.ChatModelList()
@@ -1874,7 +1880,19 @@ func (c *Config) ResolveDesktopNewSessionModel() (resolvedRef string, fallback b
 				break
 			}
 		}
-		return p.Name + "/" + model, true, true
+		resolved := p.Name + "/" + model
+		if p.Configured() {
+			return resolved, true, true
+		}
+		if keylessFallback == "" {
+			keylessFallback = resolved
+		}
+	}
+	if keylessDefault != "" {
+		return keylessDefault, false, true
+	}
+	if keylessFallback != "" {
+		return keylessFallback, true, true
 	}
 	return "", false, false
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -491,6 +491,12 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 		if !meta.IsDefined("desktop", "provider_access") {
 			continue
 		}
+		if !saw {
+			// Preserve declaration state even when the list is explicitly empty.
+			// A nil slice means legacy/undeclared access; a non-nil empty slice
+			// means the user intentionally removed every desktop provider.
+			merged = []string{}
+		}
 		saw = true
 		for _, name := range f.Desktop.ProviderAccess {
 			name = strings.TrimSpace(name)

--- a/internal/config/loadedit_test.go
+++ b/internal/config/loadedit_test.go
@@ -40,6 +40,24 @@ api_key_env = "X_KEY"
 	}
 }
 
+func TestMergeTOMLProviderAccessPreservesExplicitEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	if err := os.WriteFile(path, []byte("[desktop]\nprovider_access = []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	access, declared, err := mergeTOMLProviderAccess([]string{path})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if !declared {
+		t.Fatal("provider_access declaration was not detected")
+	}
+	if access == nil || len(access) != 0 {
+		t.Fatalf("provider_access = %#v, want a non-nil empty slice", access)
+	}
+}
+
 func TestLoadForEditDecodesGB18030TOML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -124,6 +124,67 @@ func TestResolveDesktopNewSessionModelFiltersUnavailableAndNonChatProviders(t *t
 	}
 }
 
+func TestResolveDesktopNewSessionModelDoesNotReadmitIneligibleDefaultWithoutFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{
+			name: "provider is outside desktop access",
+			cfg: &Config{
+				DefaultModel: "hidden/chat",
+				Desktop:      DesktopConfig{ProviderAccess: []string{"audio"}},
+				Providers: []ProviderEntry{
+					{Name: "hidden", BaseURL: "https://hidden.example.com", Model: "chat", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+					{Name: "audio", BaseURL: "https://audio.example.com", Model: "tts-1", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+				},
+			},
+		},
+		{
+			name: "default is not a chat model",
+			cfg: &Config{
+				DefaultModel: "audio/tts-1",
+				Desktop:      DesktopConfig{ProviderAccess: []string{"audio"}},
+				Providers: []ProviderEntry{
+					{Name: "audio", BaseURL: "https://audio.example.com", Model: "tts-1", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, fallback, ok := tt.cfg.ResolveDesktopNewSessionModel(); got != "" || fallback || ok {
+				t.Fatalf("ResolveDesktopNewSessionModel() = (%q, %v, %v), want no eligible model", got, fallback, ok)
+			}
+		})
+	}
+}
+
+func TestResolveDesktopNewSessionModelHonorsExplicitEmptyAccess(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.Desktop.ProviderAccess = []string{}
+
+	if got, fallback, ok := c.ResolveDesktopNewSessionModel(); got != "" || fallback || ok {
+		t.Fatalf("ResolveDesktopNewSessionModel() = (%q, %v, %v), want no model when provider access is explicitly empty", got, fallback, ok)
+	}
+}
+
+func TestResolveDesktopNewSessionModelKeepsAllowedKeylessDefaultWithoutFallback(t *testing.T) {
+	c := &Config{
+		DefaultModel: "keyless/chat",
+		Desktop:      DesktopConfig{ProviderAccess: []string{"keyless"}},
+		Providers: []ProviderEntry{
+			{Name: "keyless", BaseURL: "https://keyless.example.com", Model: "chat", APIKeyEnv: "MISSING_KEY"},
+		},
+	}
+
+	got, fallback, ok := c.ResolveDesktopNewSessionModel()
+	if !ok || fallback || got != "keyless/chat" {
+		t.Fatalf("ResolveDesktopNewSessionModel() = (%q, %v, %v), want raw allowed keyless default", got, fallback, ok)
+	}
+}
+
 func TestResolveDesktopNewSessionModelKeepsUsableDefaultVerbatim(t *testing.T) {
 	c := testModelFallbackConfig(t)
 	c.DefaultModel = "prov-b"

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -107,6 +107,34 @@ func TestResolveModelWithFallbackHonorsDefaultModel(t *testing.T) {
 	}
 }
 
+func TestResolveDesktopNewSessionModelFiltersUnavailableAndNonChatProviders(t *testing.T) {
+	c := &Config{
+		DefaultModel: "hidden/chat",
+		Desktop:      DesktopConfig{ProviderAccess: []string{"audio", "visible"}},
+		Providers: []ProviderEntry{
+			{Name: "hidden", BaseURL: "https://hidden.example.com", Model: "chat", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+			{Name: "audio", BaseURL: "https://audio.example.com", Model: "tts-1", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+			{Name: "visible", BaseURL: "https://visible.example.com", Models: []string{"text-embedding-3-small", "chat-model"}, Default: "text-embedding-3-small", APIKeyEnv: "KEY", resolvedAPIKey: "sk-test"},
+		},
+	}
+
+	got, fallback, ok := c.ResolveDesktopNewSessionModel()
+	if !ok || !fallback || got != "visible/chat-model" {
+		t.Fatalf("ResolveDesktopNewSessionModel() = (%q, %v, %v), want (visible/chat-model, true, true)", got, fallback, ok)
+	}
+}
+
+func TestResolveDesktopNewSessionModelKeepsUsableDefaultVerbatim(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.DefaultModel = "prov-b"
+	c.Desktop.ProviderAccess = []string{"prov-b"}
+
+	got, fallback, ok := c.ResolveDesktopNewSessionModel()
+	if !ok || fallback || got != "prov-b" {
+		t.Fatalf("ResolveDesktopNewSessionModel() = (%q, %v, %v), want (prov-b, false, true)", got, fallback, ok)
+	}
+}
+
 func TestModelRefsProvider(t *testing.T) {
 	if !ModelRefsProvider("deepseek-flash", "deepseek-flash") {
 		t.Fatal("bare provider ref should match provider")


### PR DESCRIPTION
## Summary

- New desktop sessions no longer boot onto a `default_model` whose provider has no API key in Reasonix's credential store. Previously every new tab landed on the keyless default and showed "当前模型缺少 API key" until the user switched models by hand.
- Global sessions evaluate the user config, while project sessions evaluate the merged project `reasonix.toml` plus user config. Desktop tool-approval defaults remain user-global.
- New-session selection preserves a configured default only when it is available through desktop provider access and is a chat model. Otherwise it selects the first configured, desktop-accessible chat provider.
- When every eligible chat provider is keyless, the allowed default (or first allowed chat fallback) is preserved so the existing missing-key recovery UI can tell the user what to configure. When no desktop-accessible chat model exists, startup remains blocked with an actionable setup error instead of re-admitting a hidden or non-chat default.
- An omitted `desktop.provider_access` retains legacy "all providers" behavior. An explicit `provider_access = []` remains distinct and exposes no desktop models across new-session selection, the model switcher, onboarding, and local Workbench discovery.
- `ResolveModelWithFallback` semantics are unchanged: stored or explicitly selected tab models are not silently rewritten.

Fixes #6996

## Why a dedicated resolver is needed

Calling `ResolveModelWithFallback(cfg.DefaultModel)` alone does not fix the reported scenario. That method deliberately accepts a resolvable explicit ref without applying its `Configured()` gate. New-session defaults need a narrower contract: configured candidates are preferred, and any keyless candidate retained for recovery must still be visible in desktop provider access and usable for chat.

The dedicated `ResolveDesktopNewSessionModel` method centralizes that contract in the config layer so the desktop entry points do not duplicate provider fallback rules.

## Verification

- `go test ./internal/config` - pass.
- `cd desktop && go test ./...` - pass.
- `cd desktop && go test -race -run 'TestDesktopNewSessionDefaults|TestModelsForTabListsNothingWhenProviderAccessExplicitlyEmpty|TestSettingsDoesNotInferProviderAccessWhenExplicitlyEmpty|TestNeedsOnboarding' .` - pass.
- `go vet ./...` - pass.
- `cd desktop && go vet ./...` - pass.
- `./scripts/cache-guard.sh` - pass; all eight cache scenarios remain above the 90% threshold.
- `env -u DEEPSEEK_API_KEY REASONIX_HOME=<isolated> REASONIX_CREDENTIALS_STORE=file go test ./internal/provider/openai -count=1` - pass. The ordinary root suite inherited an invalid local live-probe key and failed only `TestRealDeepSeekCacheProbe` with HTTP 401; the isolated deterministic provider package passed.
- GitHub CI - pass on Ubuntu, macOS, Windows, race, desktop, desktop-windows, lint, coverage, govulncheck, CodeQL, site, and cache-impact.
- `git diff --check` - pass.

## Compatibility

No persisted-format changes are introduced. Existing tabs and explicit session model selections remain authoritative.

| Touch point | Old-data behavior | Conclusion |
| --- | --- | --- |
| Stored tabs / session files | Loaded model remains authoritative; runtime fallback path is unchanged | Compatible |
| User `config.toml` | Read-only during selection; still supplies global defaults and desktop tool approval | Compatible |
| Project `reasonix.toml` | Its `default_model` participates in new project-session selection as documented by config precedence | Compatible behavior fix |
| Omitted `desktop.provider_access` | Nil/undeclared access keeps legacy all-provider behavior | Compatible |
| Explicit `provider_access = []` | The empty declaration is preserved instead of being collapsed into legacy nil access | Correctness fix |
| Credentials `.env` | Read-only; no schema or storage change | Compatible |

Cache-impact: none - this changes only pre-build model selection and desktop catalog eligibility; no provider-visible prompt prefix, tool schema/order, request serialization, compaction, reasoning, or memory bytes change.
Cache-guard: `./scripts/cache-guard.sh` passed all eight scenarios with tail averages of 92-95% against the 90% threshold.
System-prompt-review: Reviewed and approved; no system prompt construction, content, ordering, or dynamic prefix bytes are changed.
