### PR TITLE
Gate CI jobs on changed paths to cut Actions waste / 按变更路径门控 CI 以减少 Actions 浪费

### DIFF
--- a/.github/workflows/cache-impact.yml
+++ b/.github/workflows/cache-impact.yml
@@ -4,6 +4,18 @@ on:
   pull_request_target:
     branches: [main-v2]
     types: [opened, synchronize, reopened, edited, ready_for_review]
+    # The guard only cares about the prompt/tool surfaces listed in
+    # scripts/check-cache-impact.sh; PRs confined to clearly unrelated paths
+    # can never trip it, so skip the run entirely. Keep the ignore list
+    # conservative: when in doubt, run.
+    paths-ignore:
+      - 'docs/**'
+      - 'site/**'
+      - 'release-notes/**'
+      - 'workers/**'
+      - 'benchmarks/**'
+      - 'npm/**'
+      - '*.md'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cheap path gate for pull requests. PRs confined to docs/site/release-notes
+  # (or top-level Markdown) skip the heavy Go jobs, and PRs that cannot affect
+  # the desktop module skip the desktop jobs. Job-level `if` reports skipped,
+  # which satisfies the required status checks (lint, race, test) — a
+  # workflow-level paths-ignore would leave required checks pending and block
+  # merges. Detection fails open: any doubt means run everything. Pushes to
+  # main-v2 always run everything.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      desktop: ${{ steps.filter.outputs.desktop }}
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          code=true; desktop=true; site=true
+          base=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base="${{ github.event.before }}"
+          fi
+          if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
+            files=$(git diff --name-only "$base" HEAD)
+            if [ -n "$files" ]; then
+              code=false; desktop=false; site=false
+              # Root-module CI: desktop/ is a separate module, so only the
+              # clearly unrelated paths below can skip it.
+              if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|desktop/|workers/|[^/]+\.md$)'; then code=true; fi
+              # desktop/ imports the root kernel via `replace reasonix => ../`,
+              # so only this clearly-unrelated set is safe to skip.
+              if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|workers/|benchmarks/|npm/|[^/]+\.md$)'; then desktop=true; fi
+              if echo "$files" | grep -q '^site/'; then site=true; fi
+            fi
+          fi
+          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; } >> "$GITHUB_OUTPUT"
+
   test:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +127,8 @@ jobs:
         run: go test -p 4 -timeout=3m ./...
 
   race:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -115,6 +160,8 @@ jobs:
         run: go test -race ./...
 
   desktop:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -196,6 +243,8 @@ jobs:
   # desktop/ is a separate module, so the root macOS matrix above does not
   # compile or exercise the native PTY implementation.
   desktop-macos:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
     runs-on: macos-latest
     defaults:
       run:
@@ -217,6 +266,8 @@ jobs:
   # regression tests for that contract are named *OnWindows and can never
   # run on the ubuntu leg above.
   desktop-windows:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
     runs-on: windows-latest
     defaults:
       run:
@@ -267,6 +318,8 @@ jobs:
         run: ../scripts/desktop-build.sh windows/amd64 v0.0.0-ci canary
 
   lint:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -316,6 +369,8 @@ jobs:
   # builtins, so no `npm install` is needed — run them directly on every PR so
   # a regression in redirect validation fails the build instead of shipping.
   site:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -331,6 +386,8 @@ jobs:
         run: npm test
 
   govulncheck:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true # informational — stdlib vulns need a Go patch release
     steps:
@@ -348,6 +405,8 @@ jobs:
         run: govulncheck ./...
 
   coverage:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,10 @@ jobs:
   # the desktop module skip the desktop jobs. Job-level `if` reports skipped,
   # which satisfies the required status checks (lint, race, test) — a
   # workflow-level paths-ignore would leave required checks pending and block
-  # merges. Detection fails open: any doubt means run everything. Pushes to
-  # main-v2 always run everything.
+  # merges. Gated jobs skip only on an explicit `false` output: wrapped in
+  # `always()`, a failed `changes` job (or a missing output) makes them run
+  # the full matrix instead of silently passing required checks as skipped.
+  # Pushes to main-v2 always run everything.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -57,7 +59,7 @@ jobs:
 
   test:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +130,7 @@ jobs:
 
   race:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -161,7 +163,7 @@ jobs:
 
   desktop:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -244,7 +246,7 @@ jobs:
   # compile or exercise the native PTY implementation.
   desktop-macos:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: macos-latest
     defaults:
       run:
@@ -267,7 +269,7 @@ jobs:
   # run on the ubuntu leg above.
   desktop-windows:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.desktop != 'false')
     runs-on: windows-latest
     defaults:
       run:
@@ -319,7 +321,7 @@ jobs:
 
   lint:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -370,7 +372,7 @@ jobs:
   # a regression in redirect validation fails the build instead of shipping.
   site:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.site == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.site != 'false')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -387,7 +389,7 @@ jobs:
 
   govulncheck:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
     runs-on: ubuntu-latest
     continue-on-error: true # informational — stdlib vulns need a Go patch release
     steps:
@@ -406,7 +408,7 @@ jobs:
 
   coverage:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -457,6 +457,8 @@ jobs:
           name: dist-${{ matrix.name }}
           path: dist/*
           if-no-files-found: error
+          # Same-run handoff to the publish job only; 7 days covers debugging.
+          retention-days: 7
 
   publish:
     name: publish release
@@ -556,6 +558,8 @@ jobs:
           name: preview-dist
           path: dist/*
           if-no-files-found: error
+          # Same-run handoff to the mirror step only; 7 days covers debugging.
+          retention-days: 7
 
   attest-signing-contract:
     name: record standalone SignPath attestation


### PR DESCRIPTION
## Summary

Cuts GitHub Actions waste (~33k wall-minutes/month, ~6.6k runs/month) without weakening merge gates:

- **ci.yml**: new lightweight `changes` job detects PR changed paths and gates the heavy jobs on it.
  - PRs confined to `docs/`, `site/`, `release-notes/`, `workers/` or top-level Markdown skip `test` (3-OS matrix), `race`, `lint`, `govulncheck`, `coverage`.
  - PRs that cannot affect the desktop module skip `desktop` / `desktop-macos` / `desktop-windows`. The skip list is conservative because `desktop/go.mod` has `replace reasonix => ../` — root kernel changes can break the desktop module, so only `docs/`, `site/`, `release-notes/`, `workers/`, `benchmarks/`, `npm/` and top-level Markdown are skippable; anything unknown runs the jobs.
  - `site` job only runs for `site/` changes.
- **cache-impact.yml**: `paths-ignore` for clearly unrelated paths. The guard currently fires ~3k times/month on every PR event; the sensitive surface is the file list in `scripts/check-cache-impact.sh`, all under `internal/`, `scripts/` and `desktop/session_prompt.go`, so the ignored paths can never trip it.
- **release-desktop.yml**: `retention-days: 7` on `dist-*` and `preview-dist` artifacts (same-run handoffs to publish/mirror). They kept the 90-day default, accumulating ~17 GB of dead artifact storage.

## Why job-level `if` instead of workflow-level `paths-ignore` in ci.yml

The `Protect main-v2` ruleset requires `lint`, `race`, `test (ubuntu/macos/windows-latest)`. If the workflow never starts for a docs-only PR, those checks stay "Expected" forever and block the merge. A skipped job reports a successful status, so required checks still pass. Detection **fails open** (unknown base, empty diff, new unknown paths → run everything), and **pushes to main-v2 always run the full matrix**, so main stays fully checked.

## Verification

- `actionlint` v1.7.7 (same version and `-ignore` flags as the lint job) passes on all three modified workflows; YAML parses cleanly.
- Simulated the filter against 10 representative change sets (docs-only, root markdown, site-only, desktop-only, internal, npm-only, workers-only, workflow file, nested skill markdown, mixed) — every output matched the intended gating.
- This PR's own CI run demonstrates the full-run path (it touches `.github/workflows/`, so all jobs must execute).
