### PR TITLE
test: CI path-gate live verification (docs-only, do not merge) / CI 路径门控上线验证（仅文档，不合并）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,2 @@
+
+- CI path-gate live verification entry (test PR, will be closed unmerged).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,2 +1,3 @@
 
 - CI path-gate live verification entry (test PR, will be closed unmerged).
+- Second verification entry after the matrix-legs fix landed.


### PR DESCRIPTION
Verification-only PR, will be closed unmerged. Proves that for a docs-only diff: (1) the changes job outputs code/desktop/site=false, (2) the heavy jobs report skipped, (3) the required checks (lint, race, test x3) are satisfied as skipped and the PR shows mergeable/CLEAN. See #7022 for the gate design.