### PR TITLE
Raise test real-spawn timeout to deflake Windows CI / 提高测试真实子进程超时时长以消除 Windows CI 抖动

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -70,7 +70,12 @@ func requireNode(t *testing.T) {
 // built test binary can stall for seconds on a loaded machine, and these
 // tests assert behavior, not latency. Tests asserting the timeout path keep
 // their own tight budgets — that direction cannot flake under load.
-const realSpawnTimeout = 15 * time.Second
+//
+// 15s proved insufficient on a loaded Windows GitHub runner
+// (TestLoadNormalizesQuotedNodeEvalHooksPerProject timed out at 15.03s in
+// CI), so the budget is 60s; the ceiling only fires on a genuine hang, so
+// a larger value costs nothing when children exit normally.
+const realSpawnTimeout = 60 * time.Second
 
 const sampleSettings = `{"hooks":{"PreToolUse":[{"match":"bash","command":"echo pre"}],"Stop":[{"command":"echo stop"}]}}`
 


### PR DESCRIPTION
## Summary

`TestLoadNormalizesQuotedNodeEvalHooksPerProject` flaked on the Windows CI leg: the `node -e` hook child was killed at the 15.03s timeout on a loaded runner (observed in #7023's checks; same diff passed twice at ~3m and main-v2 was green, confirming flake over code).

**Root cause**: `realSpawnTimeout` (15s) in `internal/hook/hook_test.go` feeds the per-hook `Timeout` for every test that spawns a real child process. The constant's own comment says these tests assert behavior, not latency — 15s simply wasn't generous enough for a saturated Windows GitHub runner.

**Fix**: raise the constant to 60s. The ceiling only fires on a genuine hang, so the budget costs nothing when children exit normally. Tests asserting the timeout path keep their own tight budgets (50–100ms) and are untouched. All real-spawn tests share this one constant (`execution_contract_test.go`, `windows_batch_test.go`, `hook_test.go`), so the single bump deflakes every call site.

## Verification

- `go test ./internal/hook -count=1` passes locally (1.5s, node v22).
- This PR's CI runs the Windows smoke suite, which includes `internal/hook`.