### PR TITLE
Fix Windows config-lock permission test / 修复 Windows 配置锁权限测试

### DIFF
--- a/internal/config/mutate_test.go
+++ b/internal/config/mutate_test.go
@@ -450,6 +450,9 @@ func TestAcquireConfigEditLockRejectsSymlinkRegistry(t *testing.T) {
 }
 
 func TestAcquireConfigEditLockSecuresRegistryPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows protects the per-user lock registry through inherited ACLs, not Unix permission bits")
+	}
 	dir := filepath.Join(t.TempDir(), "locks")
 	if err := os.Mkdir(dir, 0o755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Problem

The latest main-v2 candidate is blocked because the Windows test job expects the config-lock registry directory to report Unix mode 0700. Windows reports 0777 through FileMode.Perm even when the per-user directory is protected by inherited ACLs.

## Root cause

The security assertion is valid for the shared Unix temporary registry, but Unix permission bits do not represent the Windows ACL used by the per-user registry under the OS profile.

## Fix

Skip only the Unix permission-bit assertion on Windows. Cross-process serialization, stable per-user registry placement, symlink rejection, and all Unix permission checks remain unchanged.

## Verification

- go test ./internal/config -run 'TestAcquireConfigEditLock|TestLockUserConfigEdits' -count=1
- go test ./internal/config
- go vet ./internal/config
- GOOS=windows GOARCH=amd64 go test -c ./internal/config

## Backward compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Config/session/state formats | No production code or persisted format changed | Safe |
| Windows lock registry | Runtime behavior is unchanged; the existing inherited ACL model remains in use | Safe |
| Unix lock registry | Mode 0700 assertion remains active | Safe |

Cache-impact: none
Cache-guard: not required; test-only change