### PR TITLE
Finalize v1.18.0 bilingual release notes / 完成 v1.18.0 中英发布说明

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -3,22 +3,23 @@
   "releases": [
     {
       "version": "1.18.0",
-      "date": "2026-07-27",
+      "date": "2026-07-29",
       "channel": "stable",
       "title": {
-        "en": "Kimi K3 Support, Preview & Stable Channels, and Signing Integrity",
-        "zh": "新增 Kimi K3 支持、预览与稳定发布渠道、签名完整性保障"
+        "en": "Context Engine v2, Integrated Terminal, and Dual Release Channels",
+        "zh": "上下文引擎 v2、内置终端与双发布渠道"
       },
       "summary": {
-        "en": "This release adds Kimi K3 support to the official Kimi APIs and OpenCode Go, introduces Preview and Stable channels for Desktop and native CLI, and hardens the Windows release signing process.",
-        "zh": "本次发布为官方 Kimi API 与 OpenCode Go 新增 Kimi K3 支持，为桌面版和原生 CLI 推出 Preview 与 Stable 双渠道，并强化 Windows 发布签名流程。"
+        "en": "Reasonix 1.18.0 introduces Context Engine v2, integrated Desktop terminal sessions, and public Stable and Preview channels. It also adds Kimi K3, regional CNY/USD pricing and broader localization, improves large-session responsiveness, and hardens repair, authorization, artifact, telemetry, and release paths.",
+        "zh": "Reasonix 1.18.0 引入上下文引擎 v2、桌面端内置终端会话，以及公开的 Stable 与 Preview 双渠道；同时新增 Kimi K3、区域化人民币/美元计价与更完整的本地化，改善大型会话响应，并加固修复、授权、产物、遥测和发布链路。"
       },
       "surfaces": [
         "agent",
         "cli",
+        "config",
         "desktop",
+        "mcp",
         "provider",
-        "remote",
         "security",
         "updates"
       ],
@@ -32,7 +33,7 @@
             "en": "Comprehensive guide for using Reasonix.",
             "zh": "Reasonix 使用综合指南。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/GUIDE.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ba2c4d31b7ad39cd635b153dc015f454ed14ee1a/docs/GUIDE.md"
         },
         {
           "title": {
@@ -43,7 +44,7 @@
             "en": "Comprehensive guide for using Reasonix in Chinese.",
             "zh": "Reasonix 使用综合指南（中文版）。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/GUIDE.zh-CN.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ba2c4d31b7ad39cd635b153dc015f454ed14ee1a/docs/GUIDE.zh-CN.md"
         },
         {
           "title": {
@@ -54,7 +55,7 @@
             "en": "How to configure AI model providers in Reasonix.",
             "zh": "如何在 Reasonix 中配置 AI 模型提供商。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/REASONING_PROVIDERS.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ba2c4d31b7ad39cd635b153dc015f454ed14ee1a/docs/REASONING_PROVIDERS.md"
         },
         {
           "title": {
@@ -65,61 +66,67 @@
             "en": "Details on Reasonix release channels and process.",
             "zh": "Reasonix 发布渠道与流程详情。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/RELEASING.md"
-        },
-        {
-          "title": {
-            "en": "Windows Signing Admin SOP",
-            "zh": "Windows 签名管理 SOP"
-          },
-          "body": {
-            "en": "Standard operating procedure for Windows code signing.",
-            "zh": "Windows 代码签名标准操作流程。"
-          },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/acc4c54009e34c4b08e971a29710426ce4db1dae/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ba2c4d31b7ad39cd635b153dc015f454ed14ee1a/docs/RELEASING.md"
         }
       ],
       "highlights": [
         {
           "kind": "new",
           "title": {
-            "en": "Kimi K3 model support",
-            "zh": "支持 Kimi K3 模型"
+            "en": "Context Engine v2",
+            "zh": "上下文引擎 v2"
           },
           "body": {
-            "en": "Kimi K3 is now available through the official Kimi CN and Global direct APIs and OpenCode Go. Official APIs support native vision, a 1,048,576-token context window, and low/high/max reasoning; OpenCode Go keeps its relay-specific high/max scale.",
-            "zh": "Kimi K3 现已支持官方 Kimi 国内版、全球版直接 API 及 OpenCode Go。官方 API 支持原生视觉、1,048,576 token 上下文窗口和低/高/最高推理等级；OpenCode Go 保留其专用的高/最高等级。"
+            "en": "The new context engine coordinates context budgeting, source breakdowns, compaction, and model-aware limits across CLI and Desktop sessions.",
+            "zh": "全新的上下文引擎统一协调 CLI 与桌面会话的上下文预算、来源明细、压缩和模型感知限制。"
           },
           "refs": [
-            6921
+            7001
           ]
         },
         {
           "kind": "new",
           "title": {
-            "en": "Preview and Stable release channels",
-            "zh": "预览版与稳定版发布渠道"
+            "en": "Integrated Desktop terminal sessions",
+            "zh": "桌面端内置终端会话"
           },
           "body": {
-            "en": "Reasonix Desktop and native CLI now expose two public product channels: Preview for early access and Stable for production use. Desktop users can switch channels in Settings.",
-            "zh": "Reasonix 桌面版和原生 CLI 现提供两个公开产品渠道：Preview 用于抢先体验，Stable 用于正式使用。桌面用户可在设置中切换渠道。"
+            "en": "Desktop workspaces can now create and manage integrated terminal sessions, including shell selection, persisted output history, and explicit Add to Chat handoff.",
+            "zh": "桌面工作区现可创建和管理内置终端会话，支持选择 Shell、保留输出历史，并通过明确的“添加到聊天”操作传递内容。"
           },
           "refs": [
-            6155
+            6994
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Stable and Preview channels",
+            "zh": "Stable 与 Preview 双发布渠道"
+          },
+          "body": {
+            "en": "Desktop and native CLI now expose separate public Stable and Preview channels. Preview versions use independent prerelease identifiers while sharing the same 1.18.0 base version.",
+            "zh": "桌面版和原生 CLI 现提供独立的公开 Stable 与 Preview 渠道。预览版使用独立的预发布标识，同时与稳定版共享 1.18.0 基础版本。"
+          },
+          "refs": [
+            6155,
+            6997
           ]
         },
         {
           "kind": "security",
           "title": {
-            "en": "Release signing integrity hardening",
-            "zh": "加强发布签名完整性"
+            "en": "Safer repairs, authorization, and artifacts",
+            "zh": "更安全的修复、授权与产物处理"
           },
           "body": {
-            "en": "We fixed a signing configuration that blocked the v1.17.21 Desktop release and added automated checks to verify the signing contract for all future releases.",
-            "zh": "我们修复了导致 v1.17.21 桌面版发布受阻的签名配置，并增加了自动化检查以验证所有未来发布的签名合约。"
+            "en": "Guard repair previews are now bound to the exact approved state, dynamic Bash authorization fails closed when ownership is unclear, and background-job artifact paths reject traversal attempts.",
+            "zh": "Guard 修复预览现与获批的精确状态绑定；动态 Bash 授权在所有权不明确时安全拒绝；后台任务产物路径会拒绝路径穿越。"
           },
           "refs": [
-            6944
+            6973,
+            6985,
+            6936
           ]
         }
       ],
@@ -127,12 +134,12 @@
         "new": [
           {
             "title": {
-              "en": "Kimi K3 model available in official providers",
-              "zh": "官方提供商支持 Kimi K3 模型"
+              "en": "Kimi K3 for official APIs and OpenCode Go",
+              "zh": "官方 API 与 OpenCode Go 支持 Kimi K3"
             },
             "body": {
-              "en": "The Kimi K3 model is now available in the Kimi CN and Kimi Global providers.",
-              "zh": "Kimi K3 模型现已在 Kimi 国内版和全球版提供商中可用。"
+              "en": "Kimi K3 is available through Kimi CN, Kimi Global, and OpenCode Go. Official APIs include native vision, a 1,048,576-token context window, and model-specific reasoning controls.",
+              "zh": "Kimi K3 现已支持 Kimi 国内版、Kimi 全球版与 OpenCode Go；官方 API 具备原生视觉、1,048,576 token 上下文窗口和模型专用推理控制。"
             },
             "refs": [
               6921
@@ -140,79 +147,185 @@
           },
           {
             "title": {
-              "en": "Kimi K3 support in OpenCode Go",
-              "zh": "OpenCode Go 支持 Kimi K3"
+              "en": "Regional pricing and broader localization",
+              "zh": "区域化计价与更完整的本地化"
             },
             "body": {
-              "en": "OpenCode Go now exposes Kimi K3 with its relay-specific high/max reasoning scale and existing OpenAI-compatible request behavior.",
-              "zh": "OpenCode Go 现支持 Kimi K3，并保留中继专用的高/最高推理等级及现有 OpenAI 兼容请求行为。"
+              "en": "Official DeepSeek usage can use CNY or USD regional pricing, CLI output carries structured currency totals, and more Desktop and Web text follows the selected language.",
+              "zh": "DeepSeek 官方用量可使用人民币或美元区域价格；CLI 输出包含结构化币种总额；更多桌面端与 Web 文案会跟随所选语言。"
             },
             "refs": [
-              6921
+              6945
             ]
           },
           {
             "title": {
-              "en": "Native vision and 1M context for Kimi K3",
-              "zh": "Kimi K3 支持原生视觉和百万级上下文"
+              "en": "Project-root scope for machine interfaces",
+              "zh": "机器接口支持项目根目录作用域"
             },
             "body": {
-              "en": "Kimi K3 comes with native vision support, a 1,048,576-token context window, and low/high/max reasoning scale.",
-              "zh": "Kimi K3 具备原生视觉支持、1,048,576 token 上下文窗口以及低/高/最高推理等级。"
+              "en": "Session, Task, and Recovery machine interfaces can select a project with --project-root while preserving the existing --dir session-store contract.",
+              "zh": "Session、Task 与 Recovery 机器接口可通过 --project-root 选择项目，同时保留现有 --dir Session 存储目录契约。"
             },
             "refs": [
-              6921
+              6970
             ]
           },
           {
             "title": {
-              "en": "Desktop and native CLI release channels",
-              "zh": "桌面版和原生 CLI 发布渠道"
+              "en": "Privacy-preserving CLI telemetry and crash reports",
+              "zh": "隐私友好的 CLI 遥测与崩溃报告"
             },
             "body": {
-              "en": "Introduced Preview and Stable channels for Desktop updates and native CLI archives; Desktop users can select their channel in Settings.",
-              "zh": "为桌面更新和原生 CLI 归档推出 Preview 与 Stable 渠道；桌面用户可在设置中选择渠道。"
+              "en": "CLI diagnostics can report bounded, redacted reliability signals without including prompts, responses, credentials, or local paths.",
+              "zh": "CLI 诊断可上报经过限制与脱敏的可靠性信号，不包含提示词、响应、凭据或本地路径。"
             },
             "refs": [
-              6155
+              6984
             ]
           }
         ],
         "improved": [
           {
             "title": {
-              "en": "Signing contract automated validation",
-              "zh": "签名合约自动验证"
+              "en": "Skills can be inserted anywhere in the composer",
+              "zh": "可在输入框任意位置插入 Skill"
             },
             "body": {
-              "en": "The release process now validates the signing contract automatically to prevent misconfigurations.",
-              "zh": "发布流程现自动验证签名合约，防止配置错误。"
+              "en": "Desktop slash completion now preserves surrounding text and structured ordering when inserting skills or subagents at the beginning, middle, or end of a task.",
+              "zh": "桌面端斜杠补全现在可在任务开头、中间或末尾插入 Skill 或 Subagent，并保留周围文本及结构化顺序。"
             },
             "refs": [
-              6944
+              6964
+            ]
+          },
+          {
+            "title": {
+              "en": "More reliable model defaults and configuration saves",
+              "zh": "更可靠的模型默认值与配置保存"
+            },
+            "body": {
+              "en": "New sessions resolve an eligible configured model, keyless CLI startup falls back safely, and MCP entries remain in their owning configuration source when saved.",
+              "zh": "新会话会解析可用的已配置模型；CLI 无密钥启动会安全回退；保存配置时 MCP 条目仍保留在其所属来源中。"
+            },
+            "refs": [
+              6999,
+              7002,
+              6913
+            ]
+          },
+          {
+            "title": {
+              "en": "Large-session responsiveness",
+              "zh": "大型会话响应性能"
+            },
+            "body": {
+              "en": "Desktop history and transcript processing now archive heavy tool payloads and reduce repeated work, preventing freezes in large sessions.",
+              "zh": "桌面端历史记录与会话处理会归档大型工具载荷并减少重复计算，避免大型会话卡顿。"
+            },
+            "refs": [
+              6993
+            ]
+          },
+          {
+            "title": {
+              "en": "Release integrity and faster CI",
+              "zh": "发布完整性与更快的 CI"
+            },
+            "body": {
+              "en": "Stable and Preview publishing now verifies candidate identity, signing contracts, channel manifests, and required per-OS checks while avoiding unrelated CI work.",
+              "zh": "Stable 与 Preview 发布现会校验候选提交身份、签名合约、渠道清单和各系统必需检查，同时跳过无关 CI 工作。"
+            },
+            "refs": [
+              6944,
+              6997,
+              7022,
+              7023,
+              7025
             ]
           }
         ],
         "fixed": [
           {
             "title": {
-              "en": "Fixed v1.17.21 Desktop release signing",
-              "zh": "修复 v1.17.21 桌面版发布签名"
+              "en": "Goal and agent continuation reliability",
+              "zh": "Goal 与 Agent 续跑可靠性"
             },
             "body": {
-              "en": "Resolved a signing issue that prevented the previous Desktop release from being published.",
-              "zh": "解决了导致前一个桌面版发布未能发布的签名问题。"
+              "en": "Initial Goal messages can invoke skills correctly, and stale edit retries no longer loop across Goal continuations.",
+              "zh": "Goal 首条消息现在可以正确调用 Skill，陈旧的编辑重试也不会在 Goal 续跑之间形成循环。"
             },
             "refs": [
-              6944
+              6991,
+              7012
+            ]
+          },
+          {
+            "title": {
+              "en": "Clean tab and session transitions",
+              "zh": "干净可靠的标签页与会话切换"
+            },
+            "body": {
+              "en": "Reusing a blank tab no longer restores stale transcript or tool data after a newer navigation intent.",
+              "zh": "复用空白标签页时，不再于较新的导航操作之后恢复旧会话或工具数据。"
+            },
+            "refs": [
+              6909
+            ]
+          },
+          {
+            "title": {
+              "en": "Windows Desktop rendering and plugin hooks",
+              "zh": "Windows 桌面渲染与插件 Hook"
+            },
+            "body": {
+              "en": "Windows transcripts repaint cleanly without stale pixels, and plugin Bash hooks detect the correct runtime.",
+              "zh": "Windows 会话内容现在可干净重绘、不再残留像素，插件 Bash Hook 也会检测正确的运行时。"
+            },
+            "refs": [
+              7019,
+              6980
+            ]
+          },
+          {
+            "title": {
+              "en": "Trusted session artifact semantics",
+              "zh": "可信 Session 产物路径语义"
+            },
+            "body": {
+              "en": "Artifact routing preserves valid trusted session paths while rejecting control-character rebinding and clearing stale persistence bindings.",
+              "zh": "产物路由在保留合法可信 Session 路径语义的同时，会拒绝控制字符重绑定并清除陈旧持久化绑定。"
+            },
+            "refs": [
+              6937
             ]
           }
         ]
       },
-      "upgrade": [],
+      "upgrade": [
+        {
+          "level": "warning",
+          "title": {
+            "en": "Guard automation must bind the reviewed preview",
+            "zh": "Guard 自动化必须绑定已审阅预览"
+          },
+          "body": {
+            "en": "Non-interactive reasonix-guard apply-plan --yes now requires the preview ID returned by the reviewed plan. Interactive use continues to bind it automatically.",
+            "zh": "非交互执行 reasonix-guard apply-plan --yes 现在必须携带已审阅计划返回的 preview ID；交互式使用仍会自动绑定。"
+          },
+          "refs": [
+            6973
+          ]
+        }
+      ],
       "risks": [],
       "contributors": [
-        "SivanCola"
+        "SivanCola",
+        "PaulDing98",
+        "mchenziyi",
+        "myipanta",
+        "par73e",
+        "xiaoshuai1024"
       ],
       "links": {
         "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.18.0",


### PR DESCRIPTION
## Summary

- replace the stale v1.18.0 draft with a source-grounded bilingual summary of the full v1.17.21..main-v2 range
- cover Context Engine v2, integrated terminal sessions, Stable/Preview channels, Kimi K3, regional pricing, localization, reliability fixes, and security hardening
- document the intentional Guard automation change requiring the reviewed preview ID for non-interactive apply-plan
- credit all contributors represented by merged PRs

## Why this PR is manual

The dedicated Prepare Release Notes workflow was attempted twice. Both attempts reached the configured model but received truncated JSON and failed before opening a review PR. This deterministic draft cites only PRs in the release range.

## Verification

- node scripts/release-notes.mjs validate
- node --test scripts/release-notes.test.mjs
- rendered both zh and en variants
- all cited PRs checked against the release range
- public-text privacy scan found no local paths or email addresses
- git diff --check

Cache-impact: none. This changes public release metadata only; provider-visible prompts, tool schemas, ordering, and request bytes are unchanged.