### PR TITLE
Stabilize Windows controller completion waits / 稳定 Windows 控制器完成等待

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -10031,7 +10031,11 @@ func startNonCooperativeSessionJob(t *testing.T, jm *jobs.Manager, sessionPath s
 
 func waitNotRunning(t *testing.T, ctrl control.SessionAPI) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
+	// Windows release runners can take more than one second to schedule the
+	// controller's asynchronous completion while the full desktop suite is
+	// active. Keep a bounded responsiveness check without treating scheduler
+	// delay as a leaked controller.
+	deadline := time.Now().Add(5 * time.Second)
 	for ctrl.Running() {
 		if time.Now().After(deadline) {
 			t.Fatal("controller still running")


### PR DESCRIPTION
## Summary

- keep the shared controller completion poll bounded
- extend its outer responsiveness window from one second to five seconds
- document the loaded Windows release-runner scheduling case

## Problem

The 1.18.0 release candidate hit the same failure shape twice in the full Windows desktop suite: first the Rewind workspace-prompt test, then the adjacent Fork test. Both failed before their semantic assertions because the shared helper allowed only one second for asynchronous controller completion. Windows then retained the lease lock during cleanup.

## Verification

- `go test . -run '^Test(Fork|Rewind)KeepsProjectWorkspacePrompt$' -count=20`
- `go test -race . -run '^Test(Fork|Rewind)KeepsProjectWorkspacePrompt$' -count=5`
- `go test ./...`
- Windows CI must confirm the full-suite behavior before the release proceeds

Cache-impact: none; test-only timeout bound, no provider-visible prompt, schema, ordering, or serialization change.

System-prompt-review: not applicable.