### PR TITLE
Bound ACP prompt waits on Windows / 限定 Windows ACP 提示等待窗口

### DIFF
--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -523,7 +523,11 @@ func drainPrompt(t *testing.T, c *rpcClient, promptCh chan frame) ([]frame, fram
 					return notifs, resp
 				}
 			}
-		case <-time.After(2 * time.Second):
+		// A full prompt crosses the ACP server, controller, agent, and transcript
+		// persistence path. Loaded Windows release runners can leave that
+		// asynchronous pipeline idle for more than two seconds, so keep a
+		// generous but bounded responsiveness limit for the end-to-end helper.
+		case <-time.After(5 * time.Second):
 			t.Fatal("session/prompt: timed out")
 		}
 	}


### PR DESCRIPTION
## Summary

- keep ACP end-to-end prompt waits bounded
- extend the idle response window from two seconds to five seconds
- document the full asynchronous pipeline covered by the helper

## Problem

The 1.18.0 release candidate's full Windows sweep timed out both the tool-turn persistence scenario and the session-load scenario. The shared helper allowed only two seconds without a frame while the request crossed the ACP server, controller, agent, tool loop, and transcript persistence. The timed-out sessions then retained lease locks during cleanup.

## Verification

- `go test ./internal/acp -run '^TestE2E(ToolTurnAndPersistence|SessionLoad)$' -count=20`
- `go test -race ./internal/acp -run '^TestE2E(ToolTurnAndPersistence|SessionLoad)$' -count=5`
- `go test ./internal/acp`
- Windows push CI must confirm the full-repository load case before release

Cache-impact: none; test-only idle bound, no provider-visible prompt, schema, ordering, or serialization change.

System-prompt-review: not applicable.