### PR TITLE
Ask before closing reports too old to confirm

### DIFF
--- a/.github/workflows/stale-report-sweep.yml
+++ b/.github/workflows/stale-report-sweep.yml
@@ -1,0 +1,68 @@
+name: Sweep stale version reports
+
+# Reports filed many minors back cannot be confirmed against a current build,
+# and 65% of the open tracker has never had a reply. This asks, waits, then
+# closes — never closing anything that was not asked first.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print what would happen without commenting
+        required: false
+        default: true
+        type: boolean
+      limit:
+        description: Maximum issues to touch in this run
+        required: false
+        default: '40'
+        type: string
+  schedule:
+    - cron: '17 3 * * 1'
+  push:
+    branches:
+      - main-v2
+    paths:
+      - '.github/workflows/stale-report-sweep.yml'
+      - 'scripts/stale-report-sweep.mjs'
+      - 'scripts/stale-report-sweep.test.mjs'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: stale-report-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    if: github.repository == 'esengine/DeepSeek-Reasonix'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Test sweeper
+        run: node --test scripts/stale-report-sweep.test.mjs
+      # A push that only touched the sweeper runs its tests and stops there.
+      - name: Sweep
+        if: github.event_name != 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIMIT: ${{ github.event.inputs.limit || '40' }}
+          # Posting stays off until this repository variable is set to "true", so
+          # merging the sweeper cannot start commenting on its own.
+          ENABLED: ${{ vars.STALE_SWEEP_ENABLED }}
+          REQUESTED_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+        run: |
+          set -euo pipefail
+          args=(--limit "$LIMIT")
+          if [ "$ENABLED" != "true" ] || [ "$REQUESTED_DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+            echo "::notice::dry run (STALE_SWEEP_ENABLED=${ENABLED:-unset})"
+          fi
+          node scripts/stale-report-sweep.mjs "${args[@]}"

--- a/scripts/stale-report-sweep.mjs
+++ b/scripts/stale-report-sweep.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Ask, wait, then close — for bug reports filed against a version far enough
+// back that nobody can tell whether they still reproduce.
+//
+// Age alone is never the reason. The close only ever follows an unanswered
+// question, the window is long, and the reason is "not planned" with reopening
+// invited, so a wrong guess costs the reporter one click.
+//
+// Usage:
+//   GH_TOKEN=... node scripts/stale-report-sweep.mjs [--dry-run] [--limit N]
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+// A report this far back predates rewrites large enough that its symptom cannot
+// be assumed to survive; anything newer is still close enough to reason about.
+export const CUTOFF_MINOR = 10;
+// Consequences too expensive to guess at. These stay for a human.
+export const SEVERITY_LABELS = ["data-loss", "security", "crash"];
+// A maintainer reply means the report was already judged; a bot must not
+// overrule that by timing it out.
+export const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+// Long enough to see a notification, install a release and actually re-test.
+export const WINDOW_DAYS = 21;
+export const ASK_MARKER = "<!-- stale-report-sweep:ask -->";
+
+export function parseReportedVersion(body) {
+  const section = (body || "").split(/^###\s+/m).find((s) => /^Exact version/i.test(s));
+  const m = /(\d+)\.(\d+)\.(\d+)/.exec(section || "");
+  return m ? { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]), raw: m[0] } : null;
+}
+
+// "1.7.18" parses cleanly and 1.7.0 shipped, so a dropped digit in "1.17.18"
+// reads as a release eleven minors old instead of the current one. Only a
+// version that was actually published counts as evidence of age.
+export function isStaleVersion(version, cutoffMinor = CUTOFF_MINOR, released = null) {
+  if (!version) return false;
+  if (released && !released.has(`${version.major}.${version.minor}.${version.patch}`)) return false;
+  return version.major < 1 || (version.major === 1 && version.minor < cutoffMinor);
+}
+
+export function releasedVersions(tags) {
+  const out = new Set();
+  for (const tag of tags) {
+    const m = /(\d+)\.(\d+)\.(\d+)$/.exec(tag);
+    if (m) out.add(`${Number(m[1])}.${Number(m[2])}.${Number(m[3])}`);
+  }
+  return out;
+}
+
+export function hasMaintainerReply(comments = []) {
+  return comments.some((c) => MAINTAINER_ASSOCIATIONS.has(c.authorAssociation));
+}
+
+export function findAsk(comments = []) {
+  return comments.find((c) => (c.body || "").includes(ASK_MARKER)) || null;
+}
+
+export function shouldAsk(issue, { cutoffMinor = CUTOFF_MINOR, released = null } = {}) {
+  if (!isStaleVersion(issue.version, cutoffMinor, released)) return false;
+  if ((issue.labels || []).some((l) => SEVERITY_LABELS.includes(l))) return false;
+  if (hasMaintainerReply(issue.comments)) return false;
+  return !findAsk(issue.comments);
+}
+
+// Only an ask that nobody answered may expire. Any later comment — from the
+// reporter, a bystander or a maintainer — takes the issue back out of the sweep.
+export function shouldClose(issue, { now, windowDays = WINDOW_DAYS } = {}) {
+  const ask = findAsk(issue.comments);
+  if (!ask) return false;
+  if ((issue.labels || []).some((l) => SEVERITY_LABELS.includes(l))) return false;
+  const askedAt = Date.parse(ask.createdAt);
+  if (Number.isNaN(askedAt)) return false;
+  const answered = (issue.comments || []).some((c) => Date.parse(c.createdAt) > askedAt);
+  if (answered) return false;
+  return Date.parse(now) - askedAt >= windowDays * 86400000;
+}
+
+export function renderAsk({ version, current, windowDays = WINDOW_DAYS }) {
+  return [
+    ASK_MARKER,
+    `This was reported against **${version}**, and the current release is **${current}** — far enough apart that we cannot tell from here whether it still happens.`,
+    "",
+    "Does it still reproduce on the current release?",
+    "",
+    `If we hear nothing in ${windowDays} days this gets closed as stale, which is a bookkeeping state and not a judgement about the report. Reopening takes one click, and a reply at any point — including after it closes — brings it back.`,
+  ].join("\n");
+}
+
+export function renderClose({ windowDays = WINDOW_DAYS }) {
+  return [
+    `Closing as stale — the verification question above went ${windowDays} days without an answer.`,
+    "",
+    "This is not a decision that the report was invalid. It means nobody can confirm the symptom against a current build, and leaving it open makes the tracker less useful for the reports that can be acted on.",
+    "",
+    "If you hit this again, comment here and it reopens — no need to file a new one.",
+  ].join("\n");
+}
+
+function gh(args, { json = true } = {}) {
+  const out = execFileSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  return json ? JSON.parse(out) : out;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes("--dry-run");
+  const li = argv.indexOf("--limit");
+  const limit = li >= 0 ? Number(argv[li + 1]) : 40;
+  const now = new Date().toISOString();
+
+  const repo = gh(["repo", "view", "--json", "nameWithOwner"]).nameWithOwner;
+  const current = gh(["release", "list", "--limit", "40", "--json", "tagName"])
+    .map((r) => r.tagName)
+    .find((t) => t.startsWith("desktop-v")) || "the latest release";
+
+  const released = releasedVersions(gh(["api", `repos/${repo}/tags`, "--paginate"]).map((t) => t.name));
+  const issues = gh([
+    "issue", "list", "--state", "open", "--limit", "1200",
+    "--json", "number,body,labels,comments",
+  ]).map((i) => ({
+    number: i.number,
+    version: parseReportedVersion(i.body),
+    labels: (i.labels || []).map((l) => l.name),
+    comments: (i.comments || []).map((c) => ({
+      body: c.body,
+      createdAt: c.createdAt,
+      authorAssociation: c.authorAssociation,
+    })),
+  }));
+
+  const toClose = issues.filter((i) => shouldClose(i, { now })).slice(0, limit);
+  const toAsk = issues.filter((i) => shouldAsk(i, { released })).slice(0, limit);
+  console.log(`${issues.length} open; ${toAsk.length} to ask (cap ${limit}), ${toClose.length} to close`);
+
+  for (const issue of toClose) {
+    if (dryRun) {
+      console.log(`[dry-run] close #${issue.number}`);
+      continue;
+    }
+    gh(["issue", "comment", String(issue.number), "--body", renderClose({})], { json: false });
+    gh(["issue", "close", String(issue.number), "--reason", "not planned"], { json: false });
+    console.log(`closed #${issue.number}`);
+    await sleep(3000);
+  }
+
+  for (const issue of toAsk) {
+    const body = renderAsk({ version: issue.version.raw, current });
+    if (dryRun) {
+      console.log(`[dry-run] ask #${issue.number} (reported ${issue.version.raw})`);
+      continue;
+    }
+    gh(["issue", "comment", String(issue.number), "--body", body], { json: false });
+    console.log(`asked #${issue.number}`);
+    await sleep(3000);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/stale-report-sweep.test.mjs
+++ b/scripts/stale-report-sweep.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ASK_MARKER,
+  CUTOFF_MINOR,
+  WINDOW_DAYS,
+  isStaleVersion,
+  parseReportedVersion,
+  releasedVersions,
+  renderAsk,
+  renderClose,
+  shouldAsk,
+  shouldClose,
+} from "./stale-report-sweep.mjs";
+
+const NOW = "2026-07-30T00:00:00Z";
+const daysBefore = (n) => new Date(Date.parse(NOW) - n * 86400000).toISOString();
+const ask = (createdAt) => ({ body: `${ASK_MARKER}\nstill reproducing?`, createdAt, authorAssociation: "OWNER" });
+
+test("the reported version comes from the form field, not from prose", () => {
+  const body = "### Version line\n\nv2\n\n### Exact version\n\n1.8.1\n\n### What happened?\n\nsaw 1.17.9 mentioned in a log";
+  assert.deepEqual(parseReportedVersion(body), { major: 1, minor: 8, patch: 1, raw: "1.8.1" });
+  assert.equal(parseReportedVersion("### What happened?\n\n1.2.3"), null);
+});
+
+test("staleness is a version cutoff, and an unparsable version is never stale", () => {
+  assert.equal(isStaleVersion(parseReportedVersion("### Exact version\n\n1.8.1")), true);
+  assert.equal(isStaleVersion(parseReportedVersion("### Exact version\n\n1.17.21")), false);
+  assert.equal(isStaleVersion(parseReportedVersion("### Exact version\n\n1.10.0")), false);
+  assert.equal(isStaleVersion(null), false);
+});
+
+test("a version that was never released is a typo, not an old release", () => {
+  const released = releasedVersions(["desktop-v1.7.0", "desktop-v1.17.18", "desktop-v1.18.0", "npm-v1.17.18"]);
+  const typo = parseReportedVersion("### Exact version\n\n1.7.18"); // dropped digit from 1.17.18
+  const real = parseReportedVersion("### Exact version\n\n1.7.0");
+  assert.equal(isStaleVersion(typo, CUTOFF_MINOR, released), false);
+  assert.equal(isStaleVersion(real, CUTOFF_MINOR, released), true);
+  // without the tag list there is nothing to catch it, which is why main passes one
+  assert.equal(isStaleVersion(typo), true);
+});
+
+test("released versions are collected across every tag series", () => {
+  const released = releasedVersions(["v1.18.0", "desktop-v1.17.21", "npm-v1.17.21", "not-a-tag", "desktop-v1.7.0"]);
+  assert.deepEqual([...released].sort(), ["1.17.21", "1.18.0", "1.7.0"]);
+});
+
+test("severity labels are never swept, however old the report", () => {
+  const base = { version: { major: 1, minor: 2, patch: 0, raw: "1.2.0" }, comments: [] };
+  for (const label of ["data-loss", "security", "crash"]) {
+    assert.equal(shouldAsk({ ...base, labels: [label] }), false, label);
+  }
+  assert.equal(shouldAsk({ ...base, labels: ["bug", "windows"] }), true);
+});
+
+test("a maintainer reply takes the report out of the sweep", () => {
+  const base = { version: { major: 1, minor: 2, patch: 0, raw: "1.2.0" }, labels: ["bug"] };
+  const reporter = { body: "me too", createdAt: daysBefore(40), authorAssociation: "NONE" };
+  const maintainer = { body: "looking", createdAt: daysBefore(40), authorAssociation: "COLLABORATOR" };
+  assert.equal(shouldAsk({ ...base, comments: [reporter] }), true);
+  assert.equal(shouldAsk({ ...base, comments: [maintainer] }), false);
+});
+
+test("the same issue is never asked twice", () => {
+  const issue = {
+    version: { major: 1, minor: 2, patch: 0, raw: "1.2.0" },
+    labels: ["bug"],
+    comments: [ask(daysBefore(3))],
+  };
+  assert.equal(shouldAsk(issue), false);
+});
+
+test("closing requires an ask that nobody answered and a window that elapsed", () => {
+  const labels = ["bug"];
+  assert.equal(shouldClose({ labels, comments: [] }, { now: NOW }), false, "never asked");
+  assert.equal(
+    shouldClose({ labels, comments: [ask(daysBefore(WINDOW_DAYS - 1))] }, { now: NOW }),
+    false,
+    "window not elapsed",
+  );
+  assert.equal(shouldClose({ labels, comments: [ask(daysBefore(WINDOW_DAYS))] }, { now: NOW }), true);
+});
+
+test("any reply after the ask cancels the close, whoever wrote it", () => {
+  const labels = ["bug"];
+  const asked = ask(daysBefore(60));
+  for (const association of ["NONE", "CONTRIBUTOR", "COLLABORATOR"]) {
+    const reply = { body: "still broken", createdAt: daysBefore(1), authorAssociation: association };
+    assert.equal(shouldClose({ labels, comments: [asked, reply] }, { now: NOW }), false, association);
+  }
+  // a comment predating the ask is not an answer to it
+  const older = { body: "me too", createdAt: daysBefore(90), authorAssociation: "NONE" };
+  assert.equal(shouldClose({ labels, comments: [older, asked] }, { now: NOW }), true);
+});
+
+test("a severity label added after the ask still blocks the close", () => {
+  const comments = [ask(daysBefore(60))];
+  assert.equal(shouldClose({ labels: ["bug"], comments }, { now: NOW }), true);
+  assert.equal(shouldClose({ labels: ["bug", "data-loss"], comments }, { now: NOW }), false);
+});
+
+test("the ask states both versions and the deadline; the close invites reopening", () => {
+  const body = renderAsk({ version: "1.8.1", current: "desktop-v1.18.0" });
+  assert.ok(body.startsWith(ASK_MARKER));
+  assert.match(body, /1\.8\.1/);
+  assert.match(body, /desktop-v1\.18\.0/);
+  assert.match(body, new RegExp(`${WINDOW_DAYS} days`));
+  const closed = renderClose({});
+  assert.match(closed, /reopens/);
+  assert.match(closed, new RegExp(`${WINDOW_DAYS} days`));
+  // stale is a bookkeeping state; claiming a fix we never verified would be a lie
+  assert.doesNotMatch(closed, /\bfixed\b|\bresolved\b/i);
+});


### PR DESCRIPTION
## The decision this encodes

65% of the open tracker (726 of 1115) has never had a reply, and 160 open bug reports name a release nine or more minors back — far enough that nobody can say whether the symptom survived. Leaving them open costs the reports that can be acted on. Closing them on age alone would be a guess dressed up as triage.

So the rule is: **ask, wait, then close only what nobody answered.** Parameters, and why:

| Parameter | Value | Why |
| --- | --- | --- |
| Scope | reported version ≤ 1.9.x | spans rewrites large enough that the symptom cannot be assumed to survive |
| Window | 21 days | long enough to see a notification, install a release, and actually re-test |
| Never swept | `data-loss`, `security`, `crash` | consequences too expensive to guess at |
| Never swept | anything a maintainer replied to | that report was already judged; a bot must not time out a human decision |
| Cancels the close | any comment after the ask, from anyone | including a bystander's "me too" |

A close is `not planned` with reopening invited, and the comment says outright that stale is a bookkeeping state, not a verdict on the report. It never claims the bug was fixed — a test asserts that, because we never verified it.

## The check that matters most

Version staleness is validated **against the published tag list**, not the version format.

The first dry run targeted six issues reporting `1.7.18`, `1.7.13` and `1.7.10`. But `1.7.x` only ever reached **1.7.0** — those are dropped digits from `1.17.x`, i.e. current releases that parse cleanly as eleven-minor-old ones. All six were filed in July, on the current line. Without the tag check, six current reports would have been swept as ancient, and because 1.7.0 genuinely shipped, nothing about them looks wrong on inspection.

Dry run before the check: 166 targets. After: 160, with zero impossible versions surviving.

## Safety

- Posting stays behind the `STALE_SWEEP_ENABLED` repository variable. Merging this **cannot** start commenting on its own — the scheduled run does a dry run and logs what it would do until the variable is set to `true`.
- `workflow_dispatch` defaults to `dry_run: true`.
- Default cap of 40 issues per run, 3s between writes, to stay under GitHub's secondary content-creation limit.
- Ask is idempotent via an HTML marker, so a re-run cannot double-ask.

## Verification

- `node --test scripts/stale-report-sweep.test.mjs` — 11 tests, including the typo case, the "reply cancels the close" matrix across author associations, and a severity label added *after* the ask still blocking the close
- Live dry run: 1116 open → 160 to ask → 0 to close (nothing has been asked yet, so nothing can expire — the ordering is correct)

Same shape as `release-verify-issues.mjs` and `release-notes.mjs`: pure logic in a script with a `node --test` companion, thin workflow that runs the tests before the job.
