### PR TITLE
Take the sweep's age from the whole report, not the version field

### DIFF
--- a/scripts/stale-report-sweep.mjs
+++ b/scripts/stale-report-sweep.mjs
@@ -40,6 +40,23 @@ export function isStaleVersion(version, cutoffMinor = CUTOFF_MINOR, released = n
   return version.major < 1 || (version.major === 1 && version.minor < cutoffMinor);
 }
 
+// The form's version field is whatever the reporter typed there, and they get
+// it wrong in both directions: a dropped digit, or the default left in place
+// while the real build is named further down the body. A report cannot be older
+// than the newest release it mentions anywhere, so that is what age is measured
+// from. Filtering to published versions keeps Node versions and timestamps out.
+export function highestMentionedVersion(body, released) {
+  let best = null;
+  for (const m of (body || "").matchAll(/(\d+)\.(\d+)\.(\d+)/g)) {
+    const v = { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]), raw: m[0] };
+    if (released && !released.has(`${v.major}.${v.minor}.${v.patch}`)) continue;
+    if (!best || v.major > best.major || (v.major === best.major && (v.minor > best.minor || (v.minor === best.minor && v.patch > best.patch)))) {
+      best = v;
+    }
+  }
+  return best;
+}
+
 export function releasedVersions(tags) {
   const out = new Set();
   for (const tag of tags) {
@@ -58,6 +75,9 @@ export function findAsk(comments = []) {
 }
 
 export function shouldAsk(issue, { cutoffMinor = CUTOFF_MINOR, released = null } = {}) {
+  // "does it still reproduce" is a question only a defect report can answer; a
+  // feature request does not go stale because the version moved on.
+  if (!(issue.labels || []).includes("bug")) return false;
   if (!isStaleVersion(issue.version, cutoffMinor, released)) return false;
   if ((issue.labels || []).some((l) => SEVERITY_LABELS.includes(l))) return false;
   if (hasMaintainerReply(issue.comments)) return false;
@@ -123,7 +143,7 @@ async function main() {
     "--json", "number,body,labels,comments",
   ]).map((i) => ({
     number: i.number,
-    version: parseReportedVersion(i.body),
+    version: highestMentionedVersion(i.body, released),
     labels: (i.labels || []).map((l) => l.name),
     comments: (i.comments || []).map((c) => ({
       body: c.body,

--- a/scripts/stale-report-sweep.test.mjs
+++ b/scripts/stale-report-sweep.test.mjs
@@ -4,6 +4,7 @@ import {
   ASK_MARKER,
   CUTOFF_MINOR,
   WINDOW_DAYS,
+  highestMentionedVersion,
   isStaleVersion,
   parseReportedVersion,
   releasedVersions,
@@ -40,15 +41,38 @@ test("a version that was never released is a typo, not an old release", () => {
   assert.equal(isStaleVersion(typo), true);
 });
 
+test("a version named elsewhere in the body outranks a wrong form field", () => {
+  const released = releasedVersions(["desktop-v1.0.0", "desktop-v1.17.13", "desktop-v1.18.0"]);
+  // real shape: the form field kept its default while the true build is in prose
+  const body = "### Exact version\n\n1.0.0\n\n### Steps to reproduce\n\nwin64 vscode, 软件版本 v1.17.13";
+  assert.equal(parseReportedVersion(body).raw, "1.0.0");
+  assert.equal(highestMentionedVersion(body, released).raw, "1.17.13");
+  assert.equal(isStaleVersion(highestMentionedVersion(body, released), CUTOFF_MINOR, released), false);
+});
+
+test("unreleased numbers in the body are ignored, so Node versions cannot age a report", () => {
+  const released = releasedVersions(["desktop-v1.8.1", "desktop-v1.18.0"]);
+  const body = "### Exact version\n\n1.8.1\n\n**Node**: v26.3.1\n**Terminal size**: 65.0.0";
+  assert.equal(highestMentionedVersion(body, released).raw, "1.8.1");
+  assert.equal(highestMentionedVersion("no versions here", released), null);
+});
+
 test("released versions are collected across every tag series", () => {
   const released = releasedVersions(["v1.18.0", "desktop-v1.17.21", "npm-v1.17.21", "not-a-tag", "desktop-v1.7.0"]);
   assert.deepEqual([...released].sort(), ["1.17.21", "1.18.0", "1.7.0"]);
 });
 
+test("only defect reports are swept — a feature request cannot answer the question", () => {
+  const base = { version: { major: 1, minor: 2, patch: 0, raw: "1.2.0" }, comments: [] };
+  assert.equal(shouldAsk({ ...base, labels: ["enhancement", "desktop"] }), false);
+  assert.equal(shouldAsk({ ...base, labels: [] }), false);
+  assert.equal(shouldAsk({ ...base, labels: ["bug", "enhancement"] }), true);
+});
+
 test("severity labels are never swept, however old the report", () => {
   const base = { version: { major: 1, minor: 2, patch: 0, raw: "1.2.0" }, comments: [] };
   for (const label of ["data-loss", "security", "crash"]) {
-    assert.equal(shouldAsk({ ...base, labels: [label] }), false, label);
+    assert.equal(shouldAsk({ ...base, labels: ["bug", label] }), false, label);
   }
   assert.equal(shouldAsk({ ...base, labels: ["bug", "windows"] }), true);
 });


### PR DESCRIPTION
Follow-up to #7058, from validating it against live data before turning it on. The sweeper is still gated off (`STALE_SWEEP_ENABLED` unset), so nothing was posted.

## Two ways it would have aged current reports

**The form's version field is not evidence.** #6563 filled it with `1.0.0` and named the real build, `v1.17.13`, further down in the reproduction steps. `1.0.0` genuinely shipped, so the published-tag check added in #7058 could not catch it — the report would have been swept as seventeen minors old, and nothing about it looks wrong on inspection.

Age now comes from the **newest released version mentioned anywhere in the body**. A report cannot be older than the newest build it names. Filtering to published versions keeps `Node: v26.3.1` and window sizes from counting as releases.

**Reading the whole body let feature requests in.** Seven enhancement-only issues entered the target set, and "does it still reproduce" is a question only a defect report can answer — a feature request does not go stale because the version moved on. The sweep now requires the `bug` label.

## Effect

Target count is unchanged at 160, but the membership is not:

| | |
| --- | --- |
| before | 160 (form field only) |
| after whole-body reading | 188 |
| after requiring `bug` | 160 |

Six typo'd reports and seven feature requests left; old reports whose only version evidence was in prose came in.

## Verification

- `node --test scripts/stale-report-sweep.test.mjs` — 14 tests, up from 11; the two new cases use the real shapes from #6563 and from a crash-template body carrying a Node version
- Live dry run: 1117 open → 160 to ask → 0 to close, with #6563 confirmed excluded
