### PR TITLE
feat(Powershell): better windows support.

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -702,6 +702,14 @@ mcp_call_timeout_seconds = 300   # default MCP call safety cap; plugin/tool over
 prefer = "auto"   # auto (default) | bash | powershell | pwsh — force the shell tool's interpreter
 # path = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"   # explicit executable for the chosen shell
 
+# Dedicated powershell tool — opt-in (default off), Windows-oriented. Registered alongside
+# bash only when enabled = true; an explicit [tools].enabled list must also name "powershell".
+# Omitting this section keeps the default tool list (and cached prompt prefix) unchanged.
+# [tools.powershell]
+# enabled = true             # register the powershell tool
+# prefer  = "pwsh"           # pwsh (PowerShell 7+, default) | powershell (Windows PowerShell 5.1)
+# path    = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"   # explicit executable; empty = auto-discovery
+
 [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
 # excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -480,6 +480,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	searchSpec := builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, stderr)
 	bashTimeout := time.Duration(cfg.BashTimeoutSeconds()) * time.Second
+	// The powershell tool is opt-in: resolution (and its probe subprocesses)
+	// only runs when [tools.powershell] enabled = true.
+	psShell, psEnabled := resolvePowerShellTool(cfg, stderr, sandbox.ResolvePowerShell)
 	enabledBuiltins := cfg.Tools.Enabled
 	if tokenEconomy {
 		enabledBuiltins = tokenEconomyBuiltins(enabledBuiltins)
@@ -489,7 +492,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// startup built-ins. Do not pass that filtered empty slice to addBuiltins,
 	// where an empty list intentionally means "all built-ins".
 	if !tokenEconomy || len(cfg.Tools.Enabled) == 0 || len(enabledBuiltins) > 0 {
-		addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner)
+		addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner, psShell, psEnabled)
 	}
 	// Use the caller-supplied shared host when set, so controllers for the same
 	// workspace root reuse running MCP processes (e.g. one CodeGraph daemon
@@ -2242,24 +2245,36 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // and makes bash warn when a command references them. managedConfig names the
 // Reasonix-owned config files writable outside writeRoots after a fresh
 // per-write human approval.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths, overlay builtin.FileOverlay, terminal builtin.TerminalRunner) {
+// psEnabled gates the opt-in powershell tool ([tools.powershell] enabled =
+// true): unless set, the tool is kept out of the registry even when
+// [tools].enabled names it, so the default tool list — and the cache-stable
+// system-prompt prefix built from it — is byte-identical to a config without
+// the section. psShell is the resolved interpreter bound to the tool.
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths, overlay builtin.FileOverlay, terminal builtin.TerminalRunner, psShell sandbox.Shell, psEnabled bool) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig, FileOverlay: overlay, Terminal: terminal}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig, FileOverlay: overlay, Terminal: terminal, PowerShellEnabled: psEnabled, PowerShell: psShell}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}
 		return
 	}
 
+	psAllowed := psEnabled && builtinToolEnabled(enabled, "powershell")
 	if len(enabled) == 0 {
 		for _, t := range tool.Builtins() {
+			if t.Name() == "powershell" && !psAllowed {
+				continue
+			}
 			reg.Add(t)
 		}
 	} else {
 		for _, name := range enabled {
+			if name == "powershell" && !psAllowed {
+				continue
+			}
 			if t, ok := tool.LookupBuiltin(name); ok {
 				reg.Add(t)
 			} else {
@@ -2276,11 +2291,31 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 		builtin.ConfineSearch(searchSpec, bashSpec, forbidReadRoots),
 		builtin.ConfineWebFetch(proxySpec))
 	confined = append(confined, builtin.ConfineReaders(forbidReadRoots)...)
+	if psAllowed {
+		confined = append(confined, builtin.ConfinePowerShell(bashSpec, psShell, sessionGuard, bashTimeout))
+	}
 	for _, t := range confined {
 		if _, ok := reg.Get(t.Name()); ok {
 			reg.Add(t)
 		}
 	}
+}
+
+// resolvePowerShellTool resolves the interpreter for the opt-in powershell
+// tool. The tool is disabled by default: when [tools.powershell] enabled is
+// unset/false this returns psEnabled=false without touching the resolver, so a
+// default boot never pays for (or warns from) PowerShell discovery. When
+// enabled but no interpreter is found, the tool stays registered — it reports
+// an actionable error per call — and boot warns once here.
+func resolvePowerShellTool(cfg *config.Config, stderr io.Writer, resolve func(prefer, path string, warn io.Writer) sandbox.Shell) (sandbox.Shell, bool) {
+	if !cfg.PowerShellToolEnabled() {
+		return sandbox.Shell{}, false
+	}
+	sh := resolve(cfg.Tools.PowerShell.Prefer, cfg.Tools.PowerShell.Path, stderr)
+	if sh.Path == "" {
+		fmt.Fprintln(stderr, "warning: [tools.powershell] is enabled but no PowerShell interpreter was found; the powershell tool will report an error on each call. Install PowerShell 7 or set [tools.powershell] path.")
+	}
+	return sh, true
 }
 
 func builtinToolEnabled(enabled []string, name string) bool {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3091,7 +3091,7 @@ model = "x"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil)
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil, sandbox.Shell{}, false)
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/boot/powershell_gate_test.go
+++ b/internal/boot/powershell_gate_test.go
@@ -1,0 +1,170 @@
+package boot
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/netclient"
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+// goldenDefaultToolList is the exact default per-run tool list (registry
+// order) a config without [tools.powershell] must produce — the system-prompt
+// prefix is built from it, so any drift here cold-starts the provider's
+// prefix cache. The opt-in powershell tool is registered for lookup only and
+// must stay out of this list unless its config gate is open.
+var goldenDefaultToolList = []string{
+	"bash", "bash_output", "code_index", "complete_step", "delete_range",
+	"delete_symbol", "edit_file", "glob", "grep", "kill_shell", "ls",
+	"move_file", "multi_edit", "notebook_edit", "read_file", "todo_write",
+	"wait", "web_fetch", "write_file",
+}
+
+func addBuiltinsForTest(enabled []string, workDir string, psEnabled bool) (*tool.Registry, *bytes.Buffer) {
+	reg := tool.NewRegistry()
+	var stderr bytes.Buffer
+	addBuiltins(reg, enabled, nil, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, workDir,
+		netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil,
+		sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: `C:\ps\pwsh.exe`, MajorVersion: 7}, psEnabled)
+	return reg, &stderr
+}
+
+func TestAddBuiltinsPowerShellGate(t *testing.T) {
+	cases := []struct {
+		name      string
+		enabled   []string
+		workDir   string
+		psEnabled bool
+		wantTool  bool
+	}{
+		{"gate off, empty enabled", nil, "", false, false},
+		{"gate off, explicitly named", []string{"powershell", "bash"}, "", false, false},
+		{"gate on, empty enabled", nil, "", true, true},
+		{"gate on, allow-list without it", []string{"bash"}, "", true, false},
+		{"gate on, allow-list with it", []string{"powershell"}, "", true, true},
+		{"workspace, gate off", nil, `C:\ws`, false, false},
+		{"workspace, gate on", nil, `C:\ws`, true, true},
+		{"workspace, gate on, allow-list without it", []string{"bash"}, `C:\ws`, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, stderr := addBuiltinsForTest(tc.enabled, tc.workDir, tc.psEnabled)
+			_, ok := reg.Get("powershell")
+			if ok != tc.wantTool {
+				t.Errorf("powershell in registry = %v, want %v (names: %v)", ok, tc.wantTool, reg.Names())
+			}
+			// The zero-value powershell is registered for lookup, so naming it
+			// must never produce an "unknown built-in" warning.
+			if strings.Contains(stderr.String(), "unknown built-in") {
+				t.Errorf("unexpected warning: %q", stderr.String())
+			}
+			// bash stays registered in every configuration.
+			if _, ok := reg.Get("bash"); !ok && builtinToolEnabled(tc.enabled, "bash") {
+				t.Errorf("bash missing from registry: %v", reg.Names())
+			}
+		})
+	}
+}
+
+func TestDefaultToolListPrefixStability(t *testing.T) {
+	// Gate off: the tool list is byte-identical to the pre-powershell default.
+	reg, _ := addBuiltinsForTest(nil, "", false)
+	got := reg.Names()
+	if len(got) != len(goldenDefaultToolList) {
+		t.Fatalf("default tool count = %d, want %d: %v", len(got), len(goldenDefaultToolList), got)
+	}
+	for i, name := range goldenDefaultToolList {
+		if got[i] != name {
+			t.Fatalf("default tool list drifted at index %d: got %v, want %v", i, got, goldenDefaultToolList)
+		}
+	}
+
+	// Gate on: the list gains exactly "powershell" in sorted-registry position
+	// (between notebook_edit and read_file); everything else is unchanged.
+	regOn, _ := addBuiltinsForTest(nil, "", true)
+	gotOn := regOn.Names()
+	wantOn := make([]string, 0, len(goldenDefaultToolList)+1)
+	for _, name := range goldenDefaultToolList {
+		if name == "read_file" {
+			wantOn = append(wantOn, "powershell")
+		}
+		wantOn = append(wantOn, name)
+	}
+	if len(gotOn) != len(wantOn) {
+		t.Fatalf("gated tool count = %d, want %d: %v", len(gotOn), len(wantOn), gotOn)
+	}
+	for i, name := range wantOn {
+		if gotOn[i] != name {
+			t.Fatalf("gated tool list drifted at index %d: got %v, want %v", i, gotOn, wantOn)
+		}
+	}
+}
+
+func TestResolvePowerShellToolGateAndWarning(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+	pwsh := sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: `C:\ps\pwsh.exe`, MajorVersion: 7}
+
+	t.Run("gate off: resolver untouched, silent", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Tools.PowerShell.Enabled = boolPtr(false)
+		var stderr bytes.Buffer
+		called := false
+		sh, enabled := resolvePowerShellTool(cfg, &stderr, func(string, string, io.Writer) sandbox.Shell {
+			called = true
+			return pwsh
+		})
+		if called {
+			t.Error("resolver must not run when the tool is disabled")
+		}
+		if enabled || sh.Path != "" {
+			t.Errorf("gate off: got (%+v, %v), want zero shell and false", sh, enabled)
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("gate off must be silent, got %q", stderr.String())
+		}
+	})
+
+	t.Run("gate on, interpreter found: no warning", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Tools.PowerShell.Enabled = boolPtr(true)
+		var stderr bytes.Buffer
+		sh, enabled := resolvePowerShellTool(cfg, &stderr, func(prefer, path string, warn io.Writer) sandbox.Shell {
+			// The configured prefer passes through verbatim; an empty default
+			// means pwsh-first to the resolver.
+			if prefer != "" {
+				t.Errorf("prefer = %q, want the empty default", prefer)
+			}
+			return pwsh
+		})
+		if !enabled || sh.Path != pwsh.Path {
+			t.Errorf("gate on: got (%+v, %v), want the resolved shell and true", sh, enabled)
+		}
+		if strings.Contains(stderr.String(), "no PowerShell interpreter") {
+			t.Errorf("found interpreter should not warn: %q", stderr.String())
+		}
+	})
+
+	t.Run("gate on, resolution fails: startup warning", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Tools.PowerShell.Enabled = boolPtr(true)
+		var stderr bytes.Buffer
+		sh, enabled := resolvePowerShellTool(cfg, &stderr, func(string, string, io.Writer) sandbox.Shell {
+			return sandbox.Shell{}
+		})
+		if !enabled {
+			t.Error("gate on should report enabled even when resolution fails")
+		}
+		if sh.Path != "" {
+			t.Errorf("failed resolution should return the zero shell, got %+v", sh)
+		}
+		if !strings.Contains(stderr.String(), "no PowerShell interpreter was found") {
+			t.Errorf("missing startup warning, got %q", stderr.String())
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1474,6 +1474,7 @@ type ToolsConfig struct {
 	BackgroundJobs        BackgroundJobsConfig `toml:"background_jobs"`
 	Search                SearchConfig         `toml:"search"`
 	Shell                 ShellConfig          `toml:"shell"`
+	PowerShell            PowerShellConfig     `toml:"powershell"`
 }
 
 const (
@@ -1539,6 +1540,30 @@ type SearchConfig struct {
 type ShellConfig struct {
 	Prefer string `toml:"prefer"`
 	Path   string `toml:"path"`
+}
+
+// PowerShellConfig gates and tunes the dedicated powershell tool. The tool is
+// opt-in: Enabled omitted/false keeps it out of the per-run registry, so the
+// default tool list (and the cache-stable system-prompt prefix built from it)
+// is byte-identical to a config without this section. Prefer is "pwsh"
+// (default — PowerShell 7+) or "powershell" (Windows PowerShell 5.1); Path
+// optionally points at a specific executable, bypassing discovery.
+type PowerShellConfig struct {
+	Enabled *bool  `toml:"enabled"`
+	Prefer  string `toml:"prefer"`
+	Path    string `toml:"path"`
+}
+
+// PowerShellToolEnabled reports whether the dedicated powershell tool is
+// registered for a run. The default is false — an omitted [tools.powershell]
+// section (or a nil Config) leaves the tool unregistered. An explicit
+// [tools].enabled allow-list must additionally name "powershell" for the tool
+// to appear (defense in depth against accidental prefix changes).
+func (c *Config) PowerShellToolEnabled() bool {
+	if c == nil || c.Tools.PowerShell.Enabled == nil {
+		return false
+	}
+	return *c.Tools.PowerShell.Enabled
 }
 
 // PermissionsConfig declares the per-call permission policy (see

--- a/internal/config/powershell_config_test.go
+++ b/internal/config/powershell_config_test.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// The shipped example config must stay parseable, and its commented
+// [tools.powershell] block must leave the tool disabled — the example is the
+// reference users copy from, so a drift here either breaks first-run configs
+// or silently changes the default tool list.
+func TestExampleTOMLParsesWithPowerShellDisabled(t *testing.T) {
+	var c Config
+	if _, err := toml.DecodeFile(filepath.Join("..", "..", "reasonix.example.toml"), &c); err != nil {
+		t.Fatalf("reasonix.example.toml does not parse: %v", err)
+	}
+	if c.PowerShellToolEnabled() {
+		t.Fatal("reasonix.example.toml must keep the powershell tool disabled by default")
+	}
+}
+
+func TestPowerShellToolEnabledDefault(t *testing.T) {
+	tru, fls := true, false
+	cases := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"zero config", &Config{}, false},
+		{"nil enabled", &Config{Tools: ToolsConfig{PowerShell: PowerShellConfig{Prefer: "pwsh"}}}, false},
+		{"explicit false", &Config{Tools: ToolsConfig{PowerShell: PowerShellConfig{Enabled: &fls}}}, false},
+		{"explicit true", &Config{Tools: ToolsConfig{PowerShell: PowerShellConfig{Enabled: &tru}}}, true},
+	}
+	for _, tc := range cases {
+		if got := tc.cfg.PowerShellToolEnabled(); got != tc.want {
+			t.Errorf("%s: PowerShellToolEnabled() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestPowerShellConfigParses(t *testing.T) {
+	cases := []struct {
+		name string
+		toml string
+		want PowerShellConfig
+	}{
+		{
+			name: "enabled true",
+			toml: "[tools.powershell]\nenabled = true\n",
+			want: PowerShellConfig{Enabled: boolPtr(true)},
+		},
+		{
+			name: "full block",
+			toml: "[tools.powershell]\nenabled = true\nprefer = \"powershell\"\npath = \"C:\\\\pwsh.exe\"\n",
+			want: PowerShellConfig{Enabled: boolPtr(true), Prefer: "powershell", Path: `C:\pwsh.exe`},
+		},
+		{
+			name: "absent section",
+			toml: "[tools]\nbash_timeout_seconds = 60\n",
+			want: PowerShellConfig{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Config
+			if _, err := toml.Decode(tc.toml, &c); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			got := c.Tools.PowerShell
+			if (got.Enabled == nil) != (tc.want.Enabled == nil) {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tc.want.Enabled)
+			}
+			if got.Enabled != nil && *got.Enabled != *tc.want.Enabled {
+				t.Fatalf("Enabled = %v, want %v", *got.Enabled, *tc.want.Enabled)
+			}
+			if got.Prefer != tc.want.Prefer || got.Path != tc.want.Path {
+				t.Fatalf("PowerShell = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderTOMLPowerShellRoundTrip(t *testing.T) {
+	orig := Default()
+	orig.Tools.PowerShell.Enabled = boolPtr(true)
+	orig.Tools.PowerShell.Prefer = "powershell"
+	orig.Tools.PowerShell.Path = `C:\tools\pwsh.exe`
+
+	rendered := RenderTOML(orig)
+	for _, want := range []string{"[tools.powershell]", "enabled = true", `prefer = "powershell"`, `path   = "C:\\tools\\pwsh.exe"`} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered config missing %q", want)
+		}
+	}
+
+	got := Default()
+	if _, err := toml.Decode(rendered, got); err != nil {
+		t.Fatalf("re-parse rendered config: %v", err)
+	}
+	if !got.PowerShellToolEnabled() {
+		t.Fatalf("round-trip lost enabled=true: %+v", got.Tools.PowerShell)
+	}
+	if got.Tools.PowerShell.Prefer != "powershell" || got.Tools.PowerShell.Path != `C:\tools\pwsh.exe` {
+		t.Fatalf("round-trip PowerShell = %+v", got.Tools.PowerShell)
+	}
+}
+
+func TestRenderTOMLPowerShellDefaultOmitsBlock(t *testing.T) {
+	rendered := RenderTOML(Default())
+	if strings.Contains(rendered, "[tools.powershell]") {
+		t.Fatalf("default config must not render [tools.powershell] (tool list byte-stability)")
+	}
+
+	// Explicitly disabled also renders the block (it was explicitly set) but
+	// keeps the gate off after re-parse.
+	c := Default()
+	c.Tools.PowerShell.Enabled = boolPtr(false)
+	got := Default()
+	if _, err := toml.Decode(RenderTOML(c), got); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if got.PowerShellToolEnabled() {
+		t.Fatal("enabled=false must keep the tool disabled after round-trip")
+	}
+}
+
+func TestProjectDeltaRendersPowerShellOverrides(t *testing.T) {
+	c := Default()
+	c.Tools.PowerShell.Enabled = boolPtr(true)
+
+	delta := RenderTOMLProjectDelta(c)
+	for _, want := range []string{"[tools.powershell]", "enabled = true"} {
+		if !strings.Contains(delta, want) {
+			t.Fatalf("project delta missing %q:\n%s", want, delta)
+		}
+	}
+
+	got := Default()
+	if _, err := toml.Decode(delta, got); err != nil {
+		t.Fatalf("decode project delta: %v\n%s", err, delta)
+	}
+	if !got.PowerShellToolEnabled() {
+		t.Fatalf("project delta lost powershell enabled: %+v", got.Tools.PowerShell)
+	}
+}
+
+func TestProjectDeltaOmitsPowerShellByDefault(t *testing.T) {
+	delta := RenderTOMLProjectDelta(Default())
+	if strings.Contains(delta, "[tools.powershell]") {
+		t.Fatalf("default project delta must not emit [tools.powershell]:\n%s", delta)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -411,6 +411,23 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("# path   = \"/opt/homebrew/bin/bash\"   # absolute path to the shell executable; empty = PATH lookup\n\n")
 	}
 
+	// [tools.powershell] is opt-in and rendered only when configured, so a
+	// default config round-trips to a byte-identical tool list.
+	if ps := c.Tools.PowerShell; ps.Enabled != nil || ps.Prefer != "" || ps.Path != "" {
+		b.WriteString("[tools.powershell]\n")
+		fmt.Fprintf(&b, "enabled = %t   # opt-in dedicated PowerShell tool (default off; Windows-oriented)\n", c.PowerShellToolEnabled())
+		if ps.Prefer != "" {
+			fmt.Fprintf(&b, "prefer = %q   # pwsh|powershell; empty/default = pwsh (PowerShell 7+)\n", ps.Prefer)
+		} else {
+			b.WriteString("# prefer = \"pwsh\"   # pwsh|powershell; empty/default = pwsh (PowerShell 7+)\n")
+		}
+		if ps.Path != "" {
+			fmt.Fprintf(&b, "path   = %q   # absolute path to the PowerShell executable; empty = discovery\n\n", ps.Path)
+		} else {
+			b.WriteString("# path   = \"C:\\Program Files\\PowerShell\\7\\pwsh.exe\"   # absolute path to the PowerShell executable; empty = discovery\n\n")
+		}
+	}
+
 	renderLSPConfig(&b, c.LSP)
 
 	b.WriteString("[skills]\n")
@@ -1085,6 +1102,21 @@ func RenderTOMLProjectDelta(c *Config) string {
 		}
 		if c.Tools.Shell.Path != d.Tools.Shell.Path {
 			fmt.Fprintf(&b, "path = %q\n", c.Tools.Shell.Path)
+		}
+		b.WriteString("\n")
+	}
+
+	// [tools.powershell]
+	if !reflect.DeepEqual(c.Tools.PowerShell, d.Tools.PowerShell) {
+		b.WriteString("[tools.powershell]\n")
+		if !reflect.DeepEqual(c.Tools.PowerShell.Enabled, d.Tools.PowerShell.Enabled) && c.Tools.PowerShell.Enabled != nil {
+			fmt.Fprintf(&b, "enabled = %t\n", *c.Tools.PowerShell.Enabled)
+		}
+		if c.Tools.PowerShell.Prefer != d.Tools.PowerShell.Prefer {
+			fmt.Fprintf(&b, "prefer = %q\n", c.Tools.PowerShell.Prefer)
+		}
+		if c.Tools.PowerShell.Path != d.Tools.PowerShell.Path {
+			fmt.Fprintf(&b, "path = %q\n", c.Tools.PowerShell.Path)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/sandbox/powershell_resolve.go
+++ b/internal/sandbox/powershell_resolve.go
@@ -1,0 +1,183 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
+)
+
+// ResolvePowerShell finds the PowerShell interpreter for the dedicated
+// powershell tool. prefer is "pwsh" (default — PowerShell 7+ first) or
+// "powershell" (Windows PowerShell 5.1 first); path, when set, is an explicit
+// executable that wins over discovery. Unlike ResolveShell there is no bash
+// fallback: a host with no PowerShell returns the zero Shell and the caller
+// surfaces a clear error, so the tool never silently runs under a different
+// interpreter than its name promises. The result (including the not-found
+// zero value) is memoized per process so the version probe runs once.
+func ResolvePowerShell(prefer, path string, warn io.Writer) Shell {
+	key := prefer + "\x00" + path
+	pwshResolveMu.Lock()
+	sh, ok := pwshResolveCache[key]
+	pwshResolveMu.Unlock()
+	if ok {
+		return sh
+	}
+
+	sh = resolvePowerShell(prefer, path, warn, exec.LookPath, fileExists, windowsPowerShellCandidates(), probePowerShellMajor)
+
+	pwshResolveMu.Lock()
+	pwshResolveCache[key] = sh
+	pwshResolveMu.Unlock()
+	return sh
+}
+
+var (
+	pwshResolveMu    sync.Mutex
+	pwshResolveCache = map[string]Shell{}
+)
+
+// resolvePowerShell is ResolvePowerShell with its environment lookups injected
+// — PATH lookup, file existence, the fixed install candidates (which derive
+// from Windows-only env vars and so are empty elsewhere), and the version
+// probe — so the decision table is deterministically testable on any host.
+// Windows-ness is entirely captured by the candidate list, so no goos
+// parameter is needed.
+func resolvePowerShell(prefer, path string, warn io.Writer, lookPath func(string) (string, error), exists func(string) bool, candidates []string, probe func(string) int) Shell {
+	// An explicit path wins outright: only file existence is validated (the
+	// user pointed at it), and the version comes from the install layout or a
+	// probe — unknown (0) is acceptable for a user-chosen binary. A missing
+	// explicit path warns and falls through to discovery rather than leaving
+	// the tool broken.
+	if path != "" {
+		if exists(path) {
+			return Shell{Kind: ShellPowerShell, Path: path, MajorVersion: powerShellMajor(path, probe)}
+		}
+		if warn != nil {
+			fmt.Fprintf(warn, "warning: [tools.powershell] path=%q does not exist; falling back to auto-discovery\n", path)
+		}
+	}
+
+	// Two search lanes. The pwsh lane trusts the versioned install layout
+	// (...\PowerShell\7\pwsh.exe is version-guaranteed — no probe subprocess)
+	// and then PATH. The powershell lane probes each candidate for its real
+	// major version; a candidate that cannot report one (store stub, wrapper
+	// script, broken install) is rejected rather than trusted blindly.
+	pwshLane := func() (Shell, bool) {
+		for _, p := range candidates {
+			if isVersionedPwsh7Install(p) && !isWindowsAppsStub(p) && exists(p) {
+				return Shell{Kind: ShellPowerShell, Path: p, MajorVersion: 7}, true
+			}
+		}
+		if p, err := lookPath("pwsh"); err == nil && !isWindowsAppsStub(p) {
+			if major := probe(p); major > 0 {
+				return Shell{Kind: ShellPowerShell, Path: p, MajorVersion: major}, true
+			}
+		}
+		return Shell{}, false
+	}
+	powershellLane := func() (Shell, bool) {
+		for _, p := range candidates {
+			if isVersionedPwsh7Install(p) || isWindowsAppsStub(p) || !exists(p) {
+				continue
+			}
+			if major := probe(p); major > 0 {
+				return Shell{Kind: ShellPowerShell, Path: p, MajorVersion: major}, true
+			}
+		}
+		if p, err := lookPath("powershell"); err == nil && !isWindowsAppsStub(p) {
+			if major := probe(p); major > 0 {
+				return Shell{Kind: ShellPowerShell, Path: p, MajorVersion: major}, true
+			}
+		}
+		return Shell{}, false
+	}
+
+	lanes := []func() (Shell, bool){pwshLane, powershellLane}
+	switch strings.ToLower(strings.TrimSpace(prefer)) {
+	case "", "pwsh":
+	case "powershell":
+		lanes[0], lanes[1] = lanes[1], lanes[0]
+	default:
+		if warn != nil {
+			fmt.Fprintf(warn, "warning: [tools.powershell] prefer=%q is not recognised (use pwsh/powershell); using the default order\n", prefer)
+		}
+	}
+	for _, lane := range lanes {
+		if sh, ok := lane(); ok {
+			return sh
+		}
+	}
+
+	if warn != nil {
+		fmt.Fprintln(warn, "warning: no PowerShell interpreter found; install PowerShell 7 (https://aka.ms/powershell) or set [tools.powershell] path")
+	}
+	return Shell{}
+}
+
+// powerShellMajor determines a candidate's major version without spawning a
+// process when the install layout guarantees it; otherwise it probes.
+func powerShellMajor(path string, probe func(string) int) int {
+	if isVersionedPwsh7Install(path) {
+		return 7
+	}
+	return probe(path)
+}
+
+// isVersionedPwsh7Install reports whether path ends in ...\PowerShell\7\pwsh.exe
+// (any separator style, case-insensitive). The versioned MSI layout guarantees
+// PowerShell 7, so callers may skip the version probe for these paths.
+func isVersionedPwsh7Install(path string) bool {
+	segments := strings.FieldsFunc(strings.ToLower(path), func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	if len(segments) < 3 {
+		return false
+	}
+	tail := segments[len(segments)-3:]
+	return tail[0] == "powershell" && tail[1] == "7" && tail[2] == "pwsh.exe"
+}
+
+// isWindowsAppsStub reports whether path goes through the WindowsApps store
+// alias directory. Those executables are 0-byte reparse points that fail to
+// spawn (or open the Microsoft Store) unless the app is installed, so
+// discovery must skip them in favor of a real install.
+func isWindowsAppsStub(path string) bool {
+	for _, segment := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if strings.EqualFold(segment, "WindowsApps") {
+			return true
+		}
+	}
+	return false
+}
+
+// probePowerShellMajor runs a candidate just long enough to report its major
+// version, returning 0 when the executable cannot be spawned or does not
+// answer with a number. The probe is timeout-bounded so a blocking stub can
+// never wedge startup, and honors [secrets] filter_subprocess_env like every
+// other subprocess Reasonix spawns.
+func probePowerShellMajor(path string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "-NoProfile", "-NonInteractive", "-Command", "$PSVersionTable.PSVersion.Major")
+	cmd.Env = secrets.ProcessEnv()
+	proc.HideWindow(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	major, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0
+	}
+	return major
+}

--- a/internal/sandbox/powershell_resolve_test.go
+++ b/internal/sandbox/powershell_resolve_test.go
@@ -1,0 +1,258 @@
+package sandbox
+
+import (
+	"bytes"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolvePowerShellDecisionTable(t *testing.T) {
+	onPath := func(entries map[string]string) func(string) (string, error) {
+		return func(name string) (string, error) {
+			if p, ok := entries[name]; ok {
+				return p, nil
+			}
+			return "", exec.ErrNotFound
+		}
+	}
+	noneOnPath := onPath(nil)
+	always := func(string) bool { return true }
+	never := func(string) bool { return false }
+	versioned := `C:\Program Files\PowerShell\7\pwsh.exe`
+	systemPS := `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+	storeStub := `C:\Users\me\AppData\Local\Microsoft\WindowsApps\pwsh.exe`
+
+	probe7 := func(string) int { return 7 }
+	probe5 := func(string) int { return 5 }
+	probeFails := func(string) int { return 0 }
+	probeMustNotRun := func(string) int {
+		t.Error("versioned pwsh 7 install must be accepted without a probe subprocess")
+		return 0
+	}
+	probeByPath := func(table map[string]int) func(string) int {
+		return func(p string) int { return table[p] }
+	}
+
+	cases := []struct {
+		name       string
+		prefer     string
+		path       string
+		lookPath   func(string) (string, error)
+		exists     func(string) bool
+		candidates []string
+		probe      func(string) int
+		wantShell  Shell
+		wantWarn   string // substring; empty = no warning expected
+	}{
+		{
+			name:      "explicit path wins",
+			path:      `C:\custom\ps.exe`,
+			lookPath:  noneOnPath,
+			exists:    always,
+			probe:     probe7,
+			wantShell: Shell{Kind: ShellPowerShell, Path: `C:\custom\ps.exe`, MajorVersion: 7},
+		},
+		{
+			name:      "explicit versioned path needs no probe",
+			path:      versioned,
+			lookPath:  noneOnPath,
+			exists:    always,
+			probe:     probeMustNotRun,
+			wantShell: Shell{Kind: ShellPowerShell, Path: versioned, MajorVersion: 7},
+		},
+		{
+			name:      "missing explicit path warns and discovers",
+			path:      `C:\nope\ps.exe`,
+			lookPath:  onPath(map[string]string{"pwsh": `C:\real\pwsh.exe`}),
+			exists:    never,
+			probe:     probe7,
+			wantShell: Shell{Kind: ShellPowerShell, Path: `C:\real\pwsh.exe`, MajorVersion: 7},
+			wantWarn:  "does not exist",
+		},
+		{
+			name:       "versioned install beats PATH without probing",
+			lookPath:   onPath(map[string]string{"pwsh": `C:\real\pwsh.exe`}),
+			exists:     always,
+			candidates: []string{versioned},
+			probe:      probeMustNotRun,
+			wantShell:  Shell{Kind: ShellPowerShell, Path: versioned, MajorVersion: 7},
+		},
+		{
+			name:      "WindowsApps stub skipped for real PATH hit",
+			lookPath:  onPath(map[string]string{"pwsh": storeStub, "powershell": systemPS}),
+			exists:    never,
+			probe:     probeByPath(map[string]int{systemPS: 5}),
+			wantShell: Shell{Kind: ShellPowerShell, Path: systemPS, MajorVersion: 5},
+		},
+		{
+			name:       "prefer=powershell reverses order",
+			prefer:     "powershell",
+			lookPath:   noneOnPath,
+			exists:     always,
+			candidates: []string{versioned, systemPS},
+			probe:      probeByPath(map[string]int{systemPS: 5}),
+			wantShell:  Shell{Kind: ShellPowerShell, Path: systemPS, MajorVersion: 5},
+		},
+		{
+			name:       "probe failure rejects candidate",
+			lookPath:   noneOnPath,
+			exists:     always,
+			candidates: []string{systemPS},
+			probe:      probeFails,
+			wantShell:  Shell{},
+			wantWarn:   "no PowerShell interpreter found",
+		},
+		{
+			name:      "pwsh from PATH probed for its version",
+			lookPath:  onPath(map[string]string{"pwsh": `C:\real\pwsh.exe`}),
+			exists:    never,
+			probe:     probe7,
+			wantShell: Shell{Kind: ShellPowerShell, Path: `C:\real\pwsh.exe`, MajorVersion: 7},
+		},
+		{
+			name:      "renamed pwsh reports probed version",
+			lookPath:  onPath(map[string]string{"pwsh": `C:\real\renamed.exe`}),
+			exists:    never,
+			probe:     probe5,
+			wantShell: Shell{Kind: ShellPowerShell, Path: `C:\real\renamed.exe`, MajorVersion: 5},
+		},
+		{
+			name:      "nothing found returns zero Shell with guidance",
+			lookPath:  noneOnPath,
+			exists:    never,
+			probe:     probeFails,
+			wantShell: Shell{},
+			wantWarn:  "install PowerShell 7",
+		},
+		{
+			name:      "unrecognised prefer warns and uses default order",
+			prefer:    "zsh",
+			lookPath:  onPath(map[string]string{"pwsh": `C:\real\pwsh.exe`}),
+			exists:    never,
+			probe:     probe7,
+			wantShell: Shell{Kind: ShellPowerShell, Path: `C:\real\pwsh.exe`, MajorVersion: 7},
+			wantWarn:  "not recognised",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var warn bytes.Buffer
+			got := resolvePowerShell(tc.prefer, tc.path, &warn, tc.lookPath, tc.exists, tc.candidates, tc.probe)
+			if got != tc.wantShell {
+				t.Errorf("resolvePowerShell() = %+v, want %+v", got, tc.wantShell)
+			}
+			if tc.wantWarn == "" && warn.Len() != 0 {
+				t.Errorf("unexpected warning: %q", warn.String())
+			}
+			if tc.wantWarn != "" && !strings.Contains(warn.String(), tc.wantWarn) {
+				t.Errorf("warning %q missing %q", warn.String(), tc.wantWarn)
+			}
+		})
+	}
+}
+
+func TestIsWindowsAppsStub(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Users\me\AppData\Local\Microsoft\WindowsApps\pwsh.exe`, true},
+		{`C:\Users\me\AppData\Local\Microsoft\windowsapps\powershell.exe`, true}, // case-insensitive
+		{`C:/Users/me/AppData/Local/Microsoft/WindowsApps/pwsh.exe`, true},       // forward slashes
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, false},
+		{`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, false},
+		{`C:\Users\me\Apps\pwsh.exe`, false}, // substring, not a path segment
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isWindowsAppsStub(tc.path); got != tc.want {
+			t.Errorf("isWindowsAppsStub(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestIsVersionedPwsh7Install(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Program Files\PowerShell\7\pwsh.exe`, true},
+		{`C:/Program Files/PowerShell/7/pwsh.exe`, true},
+		{`C:\program files\powershell\7\PWSH.EXE`, true},
+		{`C:\Program Files\PowerShell\7-preview\pwsh.exe`, false},
+		{`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, false},
+		{`pwsh.exe`, false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isVersionedPwsh7Install(tc.path); got != tc.want {
+			t.Errorf("isVersionedPwsh7Install(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestSupportsChainingWithMajorVersion(t *testing.T) {
+	cases := []struct {
+		name  string
+		shell Shell
+		want  bool
+	}{
+		{"probed 7 wins over filename", Shell{Kind: ShellPowerShell, Path: `C:\ps\powershell.exe`, MajorVersion: 7}, true},
+		{"probed 5 wins over filename", Shell{Kind: ShellPowerShell, Path: `C:\ps\pwsh.exe`, MajorVersion: 5}, false},
+		{"probed 5.1 as 5", Shell{Kind: ShellPowerShell, Path: "powershell", MajorVersion: 5}, false},
+		{"unknown falls back to pwsh name", Shell{Kind: ShellPowerShell, Path: "pwsh"}, true},
+		{"unknown falls back to powershell name", Shell{Kind: ShellPowerShell, Path: "powershell"}, false},
+		{"bash always chains", Shell{Kind: ShellBash, Path: "bash"}, true},
+	}
+	for _, tc := range cases {
+		if got := tc.shell.SupportsChaining(); got != tc.want {
+			t.Errorf("%s: SupportsChaining() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolvePowerShellMemoized(t *testing.T) {
+	prefer, path := "__memo_test__", `C:\memo\ps.exe`
+	key := prefer + "\x00" + path
+	pwshResolveMu.Lock()
+	delete(pwshResolveCache, key)
+	pwshResolveMu.Unlock()
+
+	// The explicit path doesn't exist, so resolution lands on discovery; the
+	// exact result is host-dependent — what matters is that the second call is
+	// served from the cache (identical result, entry present).
+	first := ResolvePowerShell(prefer, path, nil)
+	second := ResolvePowerShell(prefer, path, nil)
+	if first != second {
+		t.Fatalf("memoized resolution diverged: %+v vs %+v", first, second)
+	}
+	pwshResolveMu.Lock()
+	_, cached := pwshResolveCache[key]
+	pwshResolveMu.Unlock()
+	if !cached {
+		t.Fatal("resolution was not memoized")
+	}
+}
+
+func TestResolvePowerShellRealHost(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("real-host resolution is windows-only")
+	}
+	sh := ResolvePowerShell("", "", nil)
+	if sh.Path == "" {
+		t.Skip("no PowerShell interpreter on this host")
+	}
+	if sh.Kind != ShellPowerShell {
+		t.Fatalf("kind = %v, want ShellPowerShell", sh.Kind)
+	}
+	if sh.MajorVersion < 5 {
+		t.Fatalf("MajorVersion = %d, want 5 (Windows PowerShell) or 7+ (pwsh)", sh.MajorVersion)
+	}
+	// A real interpreter must answer the chaining question consistently with
+	// its probed version.
+	if got, want := sh.SupportsChaining(), sh.MajorVersion >= 7; got != want {
+		t.Fatalf("SupportsChaining() = %v, want %v for major %d", got, want, sh.MajorVersion)
+	}
+}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -43,10 +43,14 @@ func (k ShellKind) String() string {
 }
 
 // Shell is the resolved interpreter the bash tool executes commands with: a kind
-// (so callers can adapt prompts) and the executable to invoke.
+// (so callers can adapt prompts) and the executable to invoke. MajorVersion is
+// the interpreter's major version when resolution could determine it (a
+// versioned install layout or a version probe); 0 means unknown, in which case
+// callers fall back to filename heuristics.
 type Shell struct {
-	Kind ShellKind
-	Path string
+	Kind         ShellKind
+	Path         string
+	MajorVersion int
 }
 
 // ResolveShell picks the interpreter the shell tool runs commands under. With
@@ -370,9 +374,14 @@ func (s Shell) argv(command string) []string {
 
 // SupportsChaining reports whether the shell parses '&&' / '||'. bash does;
 // Windows PowerShell 5.1 (powershell.exe) does not — only PowerShell 7+ (pwsh).
+// A probed MajorVersion settles the question even for a renamed executable;
+// with the version unknown (0) the filename heuristic decides.
 func (s Shell) SupportsChaining() bool {
 	if s.Kind != ShellPowerShell {
 		return true
+	}
+	if s.MajorVersion > 0 {
+		return s.MajorVersion >= 7
 	}
 	base := strings.ToLower(pathBase(s.Path))
 	return base == "pwsh" || base == "pwsh.exe"

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -32,6 +32,21 @@ func ConfineBash(spec sandbox.Spec, guard SessionDataGuard, timeout ...time.Dura
 	return b
 }
 
+// ConfinePowerShell returns the opt-in powershell built-in bound to an
+// OS-sandbox spec and a resolved PowerShell interpreter (see
+// sandbox.ResolvePowerShell), overriding the lookup-only zero value registered
+// at init. spec.Shell is the BASH interpreter and is deliberately not used as
+// the fallback — the powershell tool must never run under a different shell
+// than its name promises; an unresolved shell surfaces the tool's actionable
+// not-found error instead. guard and timeout mirror ConfineBash.
+func ConfinePowerShell(spec sandbox.Spec, shell sandbox.Shell, guard SessionDataGuard, timeout ...time.Duration) tool.Tool {
+	p := powershell{sb: spec, shell: shell, guard: guard}
+	if len(timeout) > 0 {
+		p.timeout = timeout[0]
+	}
+	return p
+}
+
 // RebindBashWriteRoots returns a copy of bash with its complete write surface
 // narrowed to roots. ok is false when tl is not a confined bash tool, when the
 // sandbox is not enforcing (cannot honour narrower roots), or when roots is empty.

--- a/internal/tool/builtin/powershell.go
+++ b/internal/tool/builtin/powershell.go
@@ -1,0 +1,322 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+	"unicode/utf16"
+
+	"reasonix/internal/i18n"
+	"reasonix/internal/jobs"
+	"reasonix/internal/proc"
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+)
+
+// pwshCommandArgLimit is the wrapped-script length above which the command is
+// passed as -EncodedCommand (UTF-16LE Base64) instead of -Command. Encoded
+// form is immune to every quoting/escaping hazard and stays well under the
+// Win32 32K command-line limit; 8000 leaves generous headroom for the argv
+// prefix and any sandbox wrapper.
+const pwshCommandArgLimit = 8000
+
+var errPowerShellTimeout = errors.New("powershell foreground timeout")
+
+// Registered so tool.LookupBuiltin("powershell") works and an explicit
+// [tools].enabled = ["powershell", ...] doesn't warn "unknown built-in".
+// Registration into per-run registries is gated on [tools.powershell]
+// enabled = true (see Workspace.Tools and boot's addBuiltins), so the default
+// tool list — and the cache-stable system-prompt prefix — is unchanged.
+func init() { tool.RegisterBuiltin(powershell{}) }
+
+var powershellSandboxCommandArgs = sandbox.CommandArgs
+
+// powershell runs a command under a real PowerShell interpreter (pwsh 7+
+// preferred, Windows PowerShell 5.1 as fallback). It is the Windows-oriented
+// counterpart of bash: same plumbing (job manager, tracked spawn, sandbox
+// approval flow, streaming progress), but argv is built for PowerShell
+// semantics — process-scoped execution-policy bypass, UTF-8 console, real
+// native exit codes, EncodedCommand for long scripts. shell is the resolved
+// interpreter; the zero value resolves lazily via sandbox.ResolvePowerShell.
+// sb, workDir, timeout and guard mirror the bash fields. There is no
+// host-terminal handoff: the terminal runner executes whatever the host
+// shell is, which for a tool named powershell would be a silent interpreter
+// swap — foreground commands always run locally.
+type powershell struct {
+	sb      sandbox.Spec
+	shell   sandbox.Shell
+	guard   SessionDataGuard
+	workDir string
+	timeout time.Duration
+}
+
+type powershellParams struct {
+	Command         string `json:"command"`
+	RunInBackground bool   `json:"run_in_background"`
+	TimeoutSeconds  int    `json:"timeout_seconds"`
+}
+
+func (powershell) Name() string { return "powershell" }
+
+func (p powershell) Description() string {
+	sh := p.resolved()
+	shellName := "PowerShell 7 (pwsh)"
+	chaining := "'&&' and '||' are parsed for conditional chaining; ';' runs both regardless."
+	if sh.Kind == sandbox.ShellPowerShell && sh.Path != "" && !sh.SupportsChaining() {
+		shellName = "Windows PowerShell 5.1"
+		chaining = "';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed."
+	}
+	return fmt.Sprintf("Run a PowerShell command under %s and return combined stdout/stderr. Prefer this over bash for PowerShell-native work (cmdlets, .NET APIs, Windows automation); use bash for POSIX pipelines."+
+		" PowerShell quick reference:\n"+
+		"  - chaining: %s\n"+
+		"  - cmdlets are Verb-Noun; the pipeline passes .NET objects, not text — shape with Where-Object, Select-Object, ForEach-Object, Sort-Object, Measure-Object.\n"+
+		"  - splat parameters with @{}: `$p = @{LiteralPath=$f; Destination=$d}; Copy-Item @p`. Parameter value expressions must be parenthesized: `-Index (100..120)`.\n"+
+		"  - `foreach (...) { }` is a statement, not an expression — it cannot be piped; assign first or use ForEach-Object.\n"+
+		"  - comparisons: -eq -ne -gt -ge -lt -le, -like (wildcard), -match (regex), -contains (collection). Logical: -and -or -not (or `!`).\n"+
+		"  - strings: 'single' is literal; \"double\" expands $variables and $(subexpressions). Use ${name}_suffix for variable boundaries. Here-strings: @'...'@ (literal) / @\"...\"@ (expanded); the closing delimiter must be alone at line start.\n"+
+		"  - environment: $env:NAME (session-scoped). Append PATH with `$env:PATH += ';new\\path'` — never overwrite. Child-process env changes do not propagate back.\n"+
+		"  - native commands: `& $exe @argList`. $LASTEXITCODE holds the last native exit code; $? is whether the last command succeeded. Capture $LASTEXITCODE before piping.\n"+
+		"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Move-Item (mv), Select-String (grep). No head/tail/which/touch: Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n"+
+		"  - paths: use backslashes (C:\\path\\to\\file); quote paths containing spaces. $null not /dev/null; '2>$null' drops stderr."+
+		bashToolSteer, shellName, chaining)
+}
+
+func (powershell) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"PowerShell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"timeout_seconds":{"type":"integer","description":"Optional per-call foreground cap in seconds. Can only tighten the configured bash_timeout_seconds cap, never loosen it; omit for the default."}},"required":["command"]}`)
+}
+
+// ReadOnly is false for the same reason as bash: the effect of a PowerShell
+// command cannot be inferred from its text.
+func (powershell) ReadOnly() bool { return false }
+
+func (powershell) SnipHint() tool.SnipHint {
+	return tool.SnipHint{Head: 40, Tail: 40, HeadChars: 8000, TailChars: 8000}
+}
+
+// resolved returns the bound interpreter, resolving lazily for the zero-value
+// instance. The result is memoized process-wide by ResolvePowerShell.
+func (p powershell) resolved() sandbox.Shell {
+	if p.shell.Path != "" {
+		return p.shell
+	}
+	if p.sb.Shell.Path != "" && p.sb.Shell.Kind == sandbox.ShellPowerShell {
+		return p.sb.Shell
+	}
+	return sandbox.ResolvePowerShell("", "", nil)
+}
+
+func (p powershell) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var pp powershellParams
+	if err := json.Unmarshal(args, &pp); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if err := validatePowerShellCommand(pp.Command); err != nil {
+		return "", err
+	}
+
+	sh := p.resolved()
+	if sh.Path == "" || sh.Kind != sandbox.ShellPowerShell {
+		return "", fmt.Errorf("no PowerShell interpreter found on this host; install PowerShell 7 (https://aka.ms/powershell) or set [tools.powershell] path")
+	}
+	if !sh.SupportsChaining() && (hasUnquotedSeq(pp.Command, "&&") || hasUnquotedSeq(pp.Command, "||")) {
+		return "", fmt.Errorf("this shell is Windows PowerShell 5.1, which does not parse '&&' or '||'. " +
+			"Sequence with ';' (both run regardless of the first's result), use 'if ($?) { ... }' for " +
+			"conditional chaining, or issue the commands as separate calls")
+	}
+
+	// wrap → encode → sandbox-wrap argv. The console init + try/catch wrapper
+	// makes terminating errors non-zero and preserves real native exit codes;
+	// pwshArgv switches to EncodedCommand past the length limit; the OS
+	// sandbox wraps the finished argv (on Windows it returns argv unwrapped).
+	wrapped := wrapPowerShellCommand(pp.Command)
+	argv, sandboxed := powershellSandboxCommandArgs(p.sb, pwshArgv(sh, wrapped))
+	if p.sb.Enforce() && bashSandboxEscapeSessionAllowed(ctx, pp.Command, args) {
+		argv = pwshArgv(sh, wrapped)
+		sandboxed = false
+	} else if p.sb.Enforce() && !sandboxed {
+		allow, reason, err := approveBashSandboxEscape(ctx, pp.Command, args, i18n.M.SandboxEscapeWrapReason)
+		if err != nil {
+			return "", err
+		}
+		if !allow {
+			if reason != "" {
+				return "", fmt.Errorf("%s", reason)
+			}
+			return "", fmt.Errorf("%s", sandbox.UnavailableMessage())
+		}
+		argv = pwshArgv(sh, wrapped)
+	}
+	cmdEnv := bashCommandEnv(ctx)
+
+	if pp.RunInBackground {
+		jm, ok := jobs.FromContext(ctx)
+		if !ok {
+			return "", fmt.Errorf("background execution is not available in this context")
+		}
+		workDir := p.workDir
+		// The job runs under the manager's session context (no foreground timeout), so it
+		// survives this turn; its combined output streams to the job buffer.
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "powershell", commandPreview(pp.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
+			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
+			cmd.Dir = workDir
+			cmd.Env = cmdEnv
+			cmd.WaitDelay = bashWaitDelay
+			cmd.Stdout = out
+			cmd.Stderr = out
+			tracked, runErr := runPowerShellProcess(jobCtx, cmd, sh, pp.Command, shouldTrackShellProcess(sandboxed, sh, pp.Command, false))
+			if shouldReapAfterRun(jobCtx, sh, pp.Command, false) {
+				reapShellProcess(cmd, tracked) // reap process-group stragglers the job left running (#3702)
+			}
+			return "", normalizeBashRunError(jobCtx, runErr, false)
+		})
+		msg := fmt.Sprintf("Started background job %q. It keeps running across turns; read new output with bash_output(job_id=%q), wait for it with wait, or stop it with kill_shell(job_id=%q).", job.ID, job.ID, job.ID)
+		return appendSessionDataHint(msg, p.guard.CommandHint(p.workDir, pp.Command)), nil
+	}
+
+	out, err := p.runForeground(ctx, pp, sh, argv, sandboxed, cmdEnv)
+	return appendSessionDataHint(out, p.guard.CommandHint(p.workDir, pp.Command)), err
+}
+
+func (p powershell) runForeground(ctx context.Context, pp powershellParams, sh sandbox.Shell, argv []string, sandboxed bool, cmdEnv []string) (string, error) {
+	runCtx := ctx
+	timeout := p.foregroundTimeout(pp.TimeoutSeconds)
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeoutCause(ctx, timeout, errPowerShellTimeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
+	cmd.Dir = p.workDir // "" lets exec use the process working directory
+	cmd.Env = cmdEnv
+	cmd.WaitDelay = bashWaitDelay
+	var buf bytes.Buffer
+	w := io.Writer(&buf)
+	if emit, ok := tool.ProgressFrom(ctx); ok {
+		w = io.MultiWriter(&buf, newProgressWriter(emit))
+	}
+	cmd.Stdout = w
+	cmd.Stderr = w
+	tracked, err := runPowerShellProcess(runCtx, cmd, sh, pp.Command, shouldTrackShellProcess(sandboxed, sh, pp.Command, false))
+	if shouldReapAfterRun(runCtx, sh, pp.Command, false) {
+		reapShellProcess(cmd, tracked)
+	}
+	err = normalizeBashRunError(runCtx, err, false)
+	out := buf.String()
+
+	if errors.Is(context.Cause(runCtx), errPowerShellTimeout) {
+		return out, fmt.Errorf("command timed out (> %s)", timeout)
+	}
+	if err != nil {
+		// Non-zero exit: feed output and error back so the model can self-correct.
+		return out, fmt.Errorf("command exited: %w", err)
+	}
+	return out, nil
+}
+
+// foregroundTimeout caps a foreground call. The per-call timeout_seconds can
+// only tighten the configured cap, never loosen it.
+func (p powershell) foregroundTimeout(perCallSeconds int) time.Duration {
+	timeout := p.timeout
+	if perCallSeconds > 0 {
+		perCall := time.Duration(perCallSeconds) * time.Second
+		if timeout <= 0 || perCall < timeout {
+			timeout = perCall
+		}
+	}
+	return timeout
+}
+
+func runPowerShellProcess(ctx context.Context, cmd *exec.Cmd, sh sandbox.Shell, command string, track bool) (*proc.TrackedCommand, error) {
+	return proc.RunCommand(ctx, cmd, proc.RunOptions{
+		Track:           track,
+		CancelWaitGrace: bashWaitDelay + time.Second,
+		Source:          "powershell_tool",
+		ShellKind:       sh.Kind.String(),
+		ShellPath:       sh.Path,
+		CommandPreview:  commandPreview(command),
+	})
+}
+
+// wrapPowerShellCommand prepares cmd for captured execution: the UTF-8 console
+// prologue (shared with the bash PowerShell fallback), Ctrl-C passthrough, and
+// a try/catch that turns terminating errors into exit 1 while letting real
+// native exit codes survive — a bare -Command flattens every failure to 1.
+func wrapPowerShellCommand(cmd string) string {
+	return sandbox.PowerShellUTF8Script(
+		"try{[Console]::TreatControlCAsInput=$true}catch{};" +
+			"try{" + cmd + "}catch{$_|Out-String|Write-Error;exit 1};exit $LASTEXITCODE")
+}
+
+// pwshArgv builds the invocation argv: stable flags first (process-scoped
+// execution-policy bypass — it never mutates system policy), then exactly one
+// payload argument, always last. Scripts longer than pwshCommandArgLimit go as
+// -EncodedCommand (UTF-16LE Base64), which is immune to all quoting issues.
+func pwshArgv(sh sandbox.Shell, wrapped string) []string {
+	path := sh.Path
+	if path == "" {
+		path = sh.Kind.String()
+	}
+	argv := []string{path, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-NoLogo"}
+	if len(wrapped) > pwshCommandArgLimit {
+		return append(argv, "-EncodedCommand", encodePowerShellCommand(wrapped))
+	}
+	return append(argv, "-Command", wrapped)
+}
+
+// encodePowerShellCommand renders the -EncodedCommand payload: UTF-16LE bytes,
+// Base64. (PowerShell's -EncodedCommand contract is UCS-2/UTF-16LE.)
+func encodePowerShellCommand(s string) string {
+	units := utf16.Encode([]rune(s))
+	buf := make([]byte, 0, len(units)*2)
+	for _, u := range units {
+		buf = append(buf, byte(u), byte(u>>8))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// validatePowerShellCommand fail-fast checks the command text before any
+// process is spawned: empty commands are rejected, and a double quote left
+// open at end of input almost always means the model mis-escaped something —
+// better to return an actionable error than a cryptic parser message. The
+// quote check is a heuristic: it tracks single-quoted spans (where " is
+// literal), backtick escapes, and PowerShell's doubled-quote escapes; exotic
+// constructs can still slip past either way, so it only rejects the certain
+// case.
+func validatePowerShellCommand(cmd string) error {
+	if strings.TrimSpace(cmd) == "" {
+		return fmt.Errorf("command is required")
+	}
+	var quote byte
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+		if quote != 0 {
+			if c == '`' && quote == '"' && i+1 < len(cmd) {
+				i++ // backtick escape inside a double-quoted string
+				continue
+			}
+			if c == quote {
+				if i+1 < len(cmd) && cmd[i+1] == quote {
+					i++ // doubled-quote escape ('' inside '', "" inside "")
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+		}
+	}
+	if quote == '"' {
+		return fmt.Errorf("command has unbalanced double quotes — check quoting/escaping (use 'single quotes' for literal text, backtick-escape `\" inside \"...\", or a here-string)")
+	}
+	return nil
+}

--- a/internal/tool/builtin/powershell_test.go
+++ b/internal/tool/builtin/powershell_test.go
@@ -1,0 +1,337 @@
+package builtin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf16"
+
+	"reasonix/internal/sandbox"
+)
+
+// --- dry-run tests: pure construction/decision logic, run on any host ---
+
+func pwsh7Shell() sandbox.Shell {
+	return sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: `C:\Program Files\PowerShell\7\pwsh.exe`, MajorVersion: 7}
+}
+
+func ps51Shell() sandbox.Shell {
+	return sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "powershell", MajorVersion: 5}
+}
+
+func TestPwshArgvPlain(t *testing.T) {
+	wrapped := wrapPowerShellCommand("Write-Output hi")
+	argv := pwshArgv(pwsh7Shell(), wrapped)
+
+	wantFlags := []string{"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-NoLogo"}
+	if len(argv) != 1+len(wantFlags)+2 {
+		t.Fatalf("argv length = %d, want %d: %v", len(argv), 1+len(wantFlags)+2, argv)
+	}
+	if argv[0] != pwsh7Shell().Path {
+		t.Errorf("argv[0] = %q, want the shell path", argv[0])
+	}
+	for i, f := range wantFlags {
+		if argv[1+i] != f {
+			t.Errorf("argv[%d] = %q, want %q", 1+i, argv[1+i], f)
+		}
+	}
+	// The payload is exactly one argument, always last.
+	if argv[len(argv)-2] != "-Command" || argv[len(argv)-1] != wrapped {
+		t.Errorf("payload tail = %q %q..., want -Command <wrapped>", argv[len(argv)-2], truncate(argv[len(argv)-1], 30))
+	}
+	// The wrapper carries the UTF-8 prologue, terminating-error trap and the
+	// native-exit-code passthrough.
+	for _, want := range []string{"OutputEncoding", "UTF8", "try{", "catch{", "Write-Error", "exit $LASTEXITCODE"} {
+		if !strings.Contains(wrapped, want) {
+			t.Errorf("wrapped script missing %q: %q", want, wrapped)
+		}
+	}
+	if !strings.Contains(wrapped, "try{Write-Output hi}") {
+		t.Errorf("user command should sit inside the try block: %q", wrapped)
+	}
+}
+
+func TestPwshArgvEncoded(t *testing.T) {
+	wrapped := wrapPowerShellCommand("Write-Output x") + strings.Repeat("# padding", 8010)
+	if len(wrapped) <= pwshCommandArgLimit {
+		t.Fatalf("test setup: wrapped length %d should exceed %d", len(wrapped), pwshCommandArgLimit)
+	}
+	argv := pwshArgv(pwsh7Shell(), wrapped)
+	if argv[len(argv)-2] != "-EncodedCommand" {
+		t.Fatalf("argv payload flag = %q, want -EncodedCommand", argv[len(argv)-2])
+	}
+	if got := decodePowerShellCommand(t, argv[len(argv)-1]); got != wrapped {
+		t.Fatalf("EncodedCommand round-trip mismatch:\n got %q\nwant %q", truncate(got, 80), truncate(wrapped, 80))
+	}
+}
+
+func TestPwshArgvThreshold(t *testing.T) {
+	for _, n := range []int{pwshCommandArgLimit - 1, pwshCommandArgLimit, pwshCommandArgLimit + 1} {
+		wrapped := strings.Repeat("x", n)
+		argv := pwshArgv(pwsh7Shell(), wrapped)
+		flag := argv[len(argv)-2]
+		want := "-Command"
+		if n > pwshCommandArgLimit {
+			want = "-EncodedCommand"
+		}
+		if flag != want {
+			t.Errorf("len(wrapped)=%d: payload flag = %q, want %q", n, flag, want)
+		}
+	}
+}
+
+func decodePowerShellCommand(t *testing.T, encoded string) string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("EncodedCommand payload is not valid base64: %v", err)
+	}
+	if len(raw)%2 != 0 {
+		t.Fatalf("UTF-16LE payload has odd byte count %d", len(raw))
+	}
+	units := make([]uint16, len(raw)/2)
+	for i := range units {
+		units[i] = uint16(raw[2*i]) | uint16(raw[2*i+1])<<8
+	}
+	return string(utf16.Decode(units))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func TestPowerShellValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmd     string
+		wantErr string // substring; empty = valid
+	}{
+		{"empty", "", "required"},
+		{"whitespace only", "   \n ", "required"},
+		{"odd double quotes", `Write-Output "a`, "unbalanced"},
+		{"even double quotes", `Write-Output "a"`, ""},
+		{"double quote inside single quotes", `Write-Output 'a " b'`, ""},
+		{"backtick-escaped quote", "Write-Output \"a `\" b\"", ""},
+		{"doubled-quote escape", `Write-Output "a "" b"`, ""},
+		{"doubled single-quote escape", `Write-Output 'it''s "fine"'`, ""},
+		{"plain command", "Get-ChildItem", ""},
+		// Heuristic limit, documented: an unbalanced SINGLE quote is not
+		// rejected (apostrophes in comments are common); the interpreter's own
+		// parser error covers it.
+		{"odd single quotes pass", `Write-Output 'a`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePowerShellCommand(tc.cmd)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validatePowerShellCommand(%q) = %v, want nil", tc.cmd, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validatePowerShellCommand(%q) = %v, want error containing %q", tc.cmd, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestPowerShellRejectsChainingOn51(t *testing.T) {
+	p := powershell{shell: ps51Shell()}
+	for _, cmd := range []string{"echo a && echo b", "echo a || echo b"} {
+		args, _ := json.Marshal(map[string]string{"command": cmd})
+		out, err := p.Execute(context.Background(), args)
+		if err == nil {
+			t.Errorf("%q should be rejected on PowerShell 5.1, got out=%q", cmd, out)
+		} else if !strings.Contains(err.Error(), "does not parse") {
+			t.Errorf("%q error should explain the chaining limitation, got %v", cmd, err)
+		}
+	}
+
+	// "&&" inside a string literal is data, not chaining — the guard must not
+	// fire. (On CI without PowerShell the run itself may fail; only the guard
+	// verdict is asserted.)
+	args, _ := json.Marshal(map[string]string{"command": `Write-Output "a && b"`})
+	if _, err := p.Execute(context.Background(), args); err != nil && strings.Contains(err.Error(), "does not parse") {
+		t.Errorf("quoted && must not trip the chaining guard: %v", err)
+	}
+
+	// pwsh 7 parses && — never rejected.
+	p7 := powershell{shell: pwsh7Shell()}
+	args, _ = json.Marshal(map[string]string{"command": "echo a && echo b"})
+	if _, err := p7.Execute(context.Background(), args); err != nil && strings.Contains(err.Error(), "does not parse") {
+		t.Errorf("pwsh 7 should not be blocked by the chaining guard: %v", err)
+	}
+}
+
+func TestPowerShellMissingInterpreter(t *testing.T) {
+	// A binding that resolved to a non-PowerShell interpreter must not run:
+	// the tool errors with install/config guidance instead of silently
+	// executing under a different shell than its name promises.
+	p := powershell{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}}
+	args, _ := json.Marshal(map[string]string{"command": "Get-Date"})
+	if _, err := p.Execute(context.Background(), args); err == nil ||
+		!strings.Contains(err.Error(), "install PowerShell 7") {
+		t.Fatalf("missing interpreter error should advise install/config, got %v", err)
+	}
+}
+
+func TestPowerShellDescriptionReflectsVersion(t *testing.T) {
+	desc51 := powershell{shell: ps51Shell()}.Description()
+	if !strings.Contains(desc51, "'&&' and '||' are NOT parsed") {
+		t.Errorf("5.1 description should warn about unsupported chaining: %q", desc51)
+	}
+	if !strings.Contains(desc51, "backslash") {
+		t.Errorf("5.1 description should mention backslash paths: %q", desc51)
+	}
+
+	desc7 := powershell{shell: pwsh7Shell()}.Description()
+	if !strings.Contains(desc7, "'&&' and '||' are parsed") {
+		t.Errorf("pwsh 7 description should allow conditional chaining: %q", desc7)
+	}
+	if strings.Contains(desc7, "NOT parsed") {
+		t.Errorf("pwsh 7 description should not reuse the 5.1 chaining warning: %q", desc7)
+	}
+	if !strings.Contains(desc7, "backslash") {
+		t.Errorf("pwsh 7 description should mention backslash paths: %q", desc7)
+	}
+
+	// The bash description is untouched by the new tool.
+	if strings.Contains(bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}}.Description(), "Prefer this over bash") {
+		t.Error("bash description should not carry the powershell cross-reference")
+	}
+}
+
+func TestPowerShellSchema(t *testing.T) {
+	var schema struct {
+		Type       string                     `json:"type"`
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	}
+	if err := json.Unmarshal(powershell{}.Schema(), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if schema.Type != "object" {
+		t.Errorf("schema type = %q, want object", schema.Type)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "command" {
+		t.Errorf("required = %v, want [command]", schema.Required)
+	}
+	for _, prop := range []string{"command", "run_in_background", "timeout_seconds"} {
+		if _, ok := schema.Properties[prop]; !ok {
+			t.Errorf("schema properties missing %q", prop)
+		}
+	}
+}
+
+func TestPowerShellForegroundTimeoutTightensOnly(t *testing.T) {
+	p := powershell{timeout: 120 * time.Second}
+	if got := p.foregroundTimeout(0); got != 120*time.Second {
+		t.Errorf("no per-call cap: %v, want 120s", got)
+	}
+	if got := p.foregroundTimeout(30); got != 30*time.Second {
+		t.Errorf("tighter per-call cap: %v, want 30s", got)
+	}
+	if got := p.foregroundTimeout(300); got != 120*time.Second {
+		t.Errorf("looser per-call cap must not win: %v, want 120s", got)
+	}
+	uncapped := powershell{}
+	if got := uncapped.foregroundTimeout(30); got != 30*time.Second {
+		t.Errorf("per-call cap with no configured cap: %v, want 30s", got)
+	}
+	if got := uncapped.foregroundTimeout(0); got != 0 {
+		t.Errorf("no caps at all: %v, want 0", got)
+	}
+}
+
+// --- Windows-gated e2e tests: spawn a real PowerShell ---
+
+func resolveTestPowerShell(t *testing.T) sandbox.Shell {
+	t.Helper()
+	sh := sandbox.ResolvePowerShell("", "", nil)
+	if sh.Path == "" {
+		t.Skip("no PowerShell interpreter on this host")
+	}
+	return sh
+}
+
+func runPowerShell(t *testing.T, command string) (string, error) {
+	t.Helper()
+	p := powershell{shell: resolveTestPowerShell(t)}
+	args, _ := json.Marshal(map[string]string{"command": command})
+	return p.Execute(context.Background(), args)
+}
+
+func TestPowerShellRunsNativeCommand(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	out, err := runPowerShell(t, "Write-Output reasonix-ok")
+	if err != nil {
+		t.Fatalf("powershell command failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "reasonix-ok") {
+		t.Fatalf("output = %q, want it to contain reasonix-ok", out)
+	}
+}
+
+func TestPowerShellPreservesNativeExitCode(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	_, err := runPowerShell(t, "exit 3")
+	if err == nil {
+		t.Fatal("non-zero exit should surface as an error")
+	}
+	if !strings.Contains(err.Error(), "exit status 3") {
+		t.Fatalf("real exit code should survive the wrapper; got %v", err)
+	}
+}
+
+func TestPowerShellTerminatingErrorIsNonZero(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	out, err := runPowerShell(t, "throw 'boom'")
+	if err == nil {
+		t.Fatal("a terminating error should produce a non-zero exit")
+	}
+	if !strings.Contains(out, "boom") {
+		t.Fatalf("the error text should reach the output, got %q", out)
+	}
+}
+
+func TestPowerShellOutputIsUTF8(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	out, err := runPowerShell(t, "Write-Output 'AB-中文-CD'")
+	if err != nil {
+		t.Fatalf("command failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "中文") {
+		t.Fatalf("non-ASCII output mojibake — got %q (want it to contain 中文)", out)
+	}
+}
+
+func TestPowerShellEncodedCommandRunsLongScript(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	// > 8000 chars after wrapping → the -EncodedCommand path executes.
+	script := "$x = '" + strings.Repeat("a", 9000) + "'; Write-Output $x.Length"
+	out, err := runPowerShell(t, script)
+	if err != nil {
+		t.Fatalf("long EncodedCommand script failed: %v (out=%q)", err, truncate(out, 200))
+	}
+	if !strings.Contains(out, "9000") {
+		t.Fatalf("output = %q, want it to contain 9000", truncate(out, 200))
+	}
+}

--- a/internal/tool/builtin/powershell_workspace_test.go
+++ b/internal/tool/builtin/powershell_workspace_test.go
@@ -1,0 +1,105 @@
+package builtin
+
+import (
+	"testing"
+	"time"
+
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+)
+
+func toolNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, t.Name())
+	}
+	return names
+}
+
+func containsTool(tools []tool.Tool, name string) bool {
+	for _, t := range tools {
+		if t.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func findTool(tools []tool.Tool, name string) tool.Tool {
+	for _, t := range tools {
+		if t.Name() == name {
+			return t
+		}
+	}
+	return nil
+}
+
+func TestWorkspaceToolsExcludesPowerShellByDefault(t *testing.T) {
+	// Default workspace, empty enabled list: every built-in except the opt-in
+	// powershell tool.
+	def := Workspace{}.Tools()
+	if !containsTool(def, "bash") {
+		t.Fatal("default workspace tools should contain bash")
+	}
+	if containsTool(def, "powershell") {
+		t.Fatal("powershell must not be in the default tool list (prefix byte-stability)")
+	}
+
+	// Gate on: the tool appears.
+	if gated := (Workspace{PowerShellEnabled: true}).Tools(); !containsTool(gated, "powershell") {
+		t.Fatal("PowerShellEnabled=true should include the powershell tool")
+	}
+
+	// Explicitly named but gate off: still absent (defense in depth).
+	if named := (Workspace{}).Tools("powershell"); containsTool(named, "powershell") {
+		t.Fatal("naming powershell without the gate must not enable it")
+	}
+
+	// Named and gate on: present, and bound to the workspace (workDir/timeout/
+	// shell propagated).
+	ws := Workspace{
+		Dir:               `C:\ws`,
+		BashTimeout:       42 * time.Second,
+		PowerShellEnabled: true,
+		PowerShell:        sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: `C:\ps\pwsh.exe`, MajorVersion: 7},
+	}
+	named := ws.Tools("powershell")
+	tl := findTool(named, "powershell")
+	if tl == nil {
+		t.Fatal("gated + named powershell should be present")
+	}
+	p, ok := tl.(powershell)
+	if !ok {
+		t.Fatalf("workspace powershell tool type = %T, want builtin.powershell", tl)
+	}
+	if p.workDir != `C:\ws` {
+		t.Errorf("workDir = %q, want the workspace dir", p.workDir)
+	}
+	if p.timeout != 42*time.Second {
+		t.Errorf("timeout = %v, want 42s", p.timeout)
+	}
+	if p.shell.Path != `C:\ps\pwsh.exe` {
+		t.Errorf("shell = %+v, want the resolved interpreter", p.shell)
+	}
+}
+
+func TestConfinePowerShellBindsFields(t *testing.T) {
+	spec := sandbox.Spec{Mode: "enforce"}
+	sh := sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: `C:\ps\pwsh.exe`, MajorVersion: 7}
+	tl := ConfinePowerShell(spec, sh, SessionDataGuard{}, 60*time.Second)
+	p, ok := tl.(powershell)
+	if !ok {
+		t.Fatalf("ConfinePowerShell type = %T, want builtin.powershell", tl)
+	}
+	if p.shell.Path != sh.Path || p.timeout != 60*time.Second || !p.sb.Enforce() {
+		t.Errorf("ConfinePowerShell bound %+v, want shell/timeout/spec propagated", p)
+	}
+	// spec.Shell is the bash interpreter and must never leak into the
+	// powershell tool.
+	specWithBash := spec
+	specWithBash.Shell = sandbox.Shell{Kind: sandbox.ShellBash, Path: "/bin/bash"}
+	p = ConfinePowerShell(specWithBash, sh, SessionDataGuard{}).(powershell)
+	if p.resolved().Kind != sandbox.ShellPowerShell {
+		t.Errorf("resolved() = %+v, want the PowerShell interpreter, not spec.Shell", p.resolved())
+	}
+}

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -45,6 +45,13 @@ type Workspace struct {
 	// sandbox is not enforcing. Both are nil outside host transports like ACP.
 	FileOverlay FileOverlay
 	Terminal    TerminalRunner
+	// PowerShellEnabled gates the opt-in powershell tool: unless true, the
+	// tool is excluded from Tools() even when named explicitly, so the default
+	// tool list (and the system-prompt prefix built from it) is unchanged.
+	// PowerShell is the resolved interpreter bound to the tool (see
+	// sandbox.ResolvePowerShell); empty resolves lazily.
+	PowerShellEnabled bool
+	PowerShell        sandbox.Shell
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -75,15 +82,21 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"glob":          globTool{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
 		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash},
 		"web_fetch":     webFetch{proxySpec: w.ProxySpec},
+		"powershell":    powershell{workDir: w.Dir, sb: w.Bash, shell: w.PowerShell, timeout: w.BashTimeout, guard: w.SessionGuard},
 	}
 	all := tool.Builtins()
 	if len(enabled) == 0 {
-		for i, t := range all {
-			if bound, ok := overrides[t.Name()]; ok {
-				all[i] = bound
+		out := all[:0]
+		for _, t := range all {
+			if t.Name() == "powershell" && !w.PowerShellEnabled {
+				continue
 			}
+			if bound, ok := overrides[t.Name()]; ok {
+				t = bound
+			}
+			out = append(out, t)
 		}
-		return all
+		return out
 	}
 	want := make(map[string]bool, len(enabled))
 	for _, n := range enabled {
@@ -91,6 +104,9 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 	}
 	out := make([]tool.Tool, 0, len(enabled))
 	for _, t := range all {
+		if t.Name() == "powershell" && !w.PowerShellEnabled {
+			continue
+		}
 		if want[t.Name()] {
 			if bound, ok := overrides[t.Name()]; ok {
 				t = bound

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -124,6 +124,16 @@ mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool 
 [tools.background_jobs]
 stalled_warning_seconds = 900   # warn once per background job after this many quiet seconds; 0 disables
 
+# Dedicated PowerShell tool — opt-in (default off), Windows-oriented. When
+# enabled, a `powershell` tool is registered alongside `bash`, running commands
+# under PowerShell 7 (pwsh) with hardened invocation (execution-policy bypass
+# is process-scoped, UTF-8 output, real exit codes, EncodedCommand for long
+# scripts). Leaving this section out keeps the default tool list unchanged.
+# [tools.powershell]
+# enabled = true   # register the powershell tool; [tools].enabled must also list it when non-empty
+# prefer  = "pwsh"   # pwsh (PowerShell 7+, default) | powershell (Windows PowerShell 5.1)
+# path    = "C:\Program Files\PowerShell\7\pwsh.exe"   # explicit executable; empty = auto-discovery
+
 # Sandbox confinement bounds the blast radius of tool calls. Writers may only
 # modify workspace_root (empty = current directory) plus allow_write. forbid_read
 # hides sensitive directories from read/list/search tools and from sandboxed bash


### PR DESCRIPTION
## Summary

This PR introduces a **dedicated powershell tool** — the Windows counterpart to the existing bash tool. It allows agents to run PowerShell commands natively under PowerShell 7 (pwsh) or Windows PowerShell 5.1, using the same job-manager, sandbox, and streaming-progress plumbing as bash.

## Issue

- Windows-native automation: Many Windows workflows (cmdlets, .NET APIs, COM automation, registry, certificate stores) are awkward or impossible from bash. A powershell tool eliminates the impedance mismatch.
- Hardened invocation: Commands run with process-scoped -ExecutionPolicy Bypass, UTF-8 console output, real native exit codes ($LASTEXITCODE), and -EncodedCommand (UTF-16LE Base64) for long scripts — immune to quoting/escaping hazards and the 32K Win32 command-line limit.
- Opt-in by design — zero impact on existing users: The tool is disabled by default. Unless [tools.powershell] enabled = true is explicitly set, the tool is never registered, so the default tool list and the cache-stable system-prompt prefix remain byte-identical to a config without this section. An explicit [tools].enabled allow-list must additionally name "powershell" (defense-in-depth against accidental prefix changes).
- Intelligent auto-discovery: ResolvePowerShell probes the host for the best available interpreter — preferring PowerShell 7+ (pwsh) over Windows PowerShell 5.1 — and memoizes the result. An explicit path config option bypasses discovery entirely. If no interpreter is found, the tool stays registered but surfaces a clear, actionable error on each call rather than silently running under a different shell.
## Verification

All feature covered by unit-tests, reviewed by human. Config appended, default disabled for non-breaking.

## Cache impact
- Cache-impact: none — the powershell tool is opt-in ([tools.powershell] enabled defaults to false); the default config produces a byte-identical tool registry and system-prompt prefix.
- Cache-guard: `go test ./internal/boot -run '^TestDefaultToolListPrefixStability$' -v`
- System-prompt-review: MaxwellGeng
