### PR TITLE
fix(desktop): preserve pasted text and file ref inline cards across session switches / 修复桌面端切换会话后粘贴文本与文件引用内联卡片状态丢失

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	goruntime "runtime"
 	"sort"
 	"strconv"
@@ -5501,6 +5502,71 @@ func (a *App) HistoryCheckpointTurnsForTab(tabID string) []int {
 	)
 }
 
+var pastedTextDisplayLabelPattern = regexp.MustCompile(`^\[(?:已粘贴文本|已貼上文字|Pasted text) #[0-9]+ · [0-9]+ (?:行|lines)\]$`)
+
+// historyReplayUserContent keeps only user-authored replay data. Provider-facing
+// capability, goal, hook, and resolved-reference context must not be resubmitted.
+func historyReplayUserContent(content string) string {
+	return control.StripReferencedContextPrefix(control.StripComposePrefixes(content))
+}
+
+// collapseLegacyExpandedPasteDisplay repairs sessions saved before RawContent
+// stored the compact pasted-text label. The expanded block remains in SubmitText
+// so edit replay can still reconstruct the card and recover its full payload.
+func collapseLegacyExpandedPasteDisplay(content string) string {
+	const beginPrefix = "--- Begin "
+	for scan := 0; scan < len(content); {
+		beginOffset := strings.Index(content[scan:], beginPrefix)
+		if beginOffset < 0 {
+			break
+		}
+		begin := scan + beginOffset
+		labelStart := begin + len(beginPrefix)
+		labelEndOffset := strings.Index(content[labelStart:], " ---")
+		if labelEndOffset < 0 {
+			break
+		}
+		labelEnd := labelStart + labelEndOffset
+		label := content[labelStart:labelEnd]
+		beginEnd := labelEnd + len(" ---")
+		if !pastedTextDisplayLabelPattern.MatchString(label) {
+			scan = beginEnd
+			continue
+		}
+		endMarker := "--- End " + label + " ---"
+		endOffset := strings.Index(content[beginEnd:], endMarker)
+		if endOffset < 0 {
+			scan = beginEnd
+			continue
+		}
+		labelCopy := strings.LastIndex(content[:begin], label)
+		if labelCopy < 0 || strings.TrimSpace(content[labelCopy+len(label):begin]) != "" {
+			scan = beginEnd
+			continue
+		}
+		end := beginEnd + endOffset + len(endMarker)
+		content = content[:labelCopy+len(label)] + content[end:]
+		scan = labelCopy + len(label)
+	}
+	return strings.TrimSpace(content)
+}
+
+// historyUserDisplayContent prefers a persisted display sidecar when one exists.
+// Comparing it with the deterministic fallback distinguishes a sidecar hit
+// without changing the resolver API used throughout history pagination.
+func historyUserDisplayContent(msg provider.Message, resolveUserContent func(string) string) string {
+	if msg.RawContent == "" {
+		return resolveUserContent(msg.Content)
+	}
+	raw := agent.UserMessageText(msg)
+	resolved := strings.TrimSpace(resolveUserContent(msg.Content))
+	fallback := strings.TrimSpace(historyReplayUserContent(msg.Content))
+	if resolved != "" && resolved != fallback {
+		return resolved
+	}
+	return collapseLegacyExpandedPasteDisplay(raw)
+}
+
 func historyCheckpointTurns(msgs []provider.Message, resolveUserContent func(string) string, checkpointTurns map[int]int) []int {
 	out := make([]int, 0)
 	for index, msg := range msgs {
@@ -5511,9 +5577,7 @@ func historyCheckpointTurns(msgs []provider.Message, resolveUserContent func(str
 		if _, isSteer := agent.SteerText(content); isSteer {
 			continue
 		}
-		if msg.RawContent == "" {
-			content = resolveUserContent(msg.Content)
-		}
+		content = historyUserDisplayContent(msg, resolveUserContent)
 		if control.IsSyntheticUserMessage(content) {
 			continue
 		}
@@ -5567,11 +5631,7 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 				out = append(out, HistoryMessage{Role: "notice", Content: "↪ " + steerText})
 				continue
 			}
-			if m.RawContent != "" {
-				content = agent.UserMessageText(m)
-			} else {
-				content = resolveUserContent(m.Content)
-			}
+			content = historyUserDisplayContent(m, resolveUserContent)
 			if control.IsSyntheticUserMessage(content) {
 				continue
 			}
@@ -5593,15 +5653,16 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 			hm.MemoryCitations = append([]provider.MemoryCitation(nil), m.MemoryCitations...)
 		}
 		if m.Role == provider.RoleUser && content != m.Content {
+			replay := historyReplayUserContent(m.Content)
 			if agent.ContainsMemoryCompilerExecution(m.Content) {
 				// Never expose the compiler contract itself. A safely unwrapped
 				// slash invocation is useful display metadata, though: it lets the
 				// frontend restore the selected skill/subagent in history and trash.
-				if replay := control.StripComposePrefixes(m.Content); strings.HasPrefix(strings.TrimSpace(replay), "/") && replay != content {
+				if strings.HasPrefix(strings.TrimSpace(replay), "/") && replay != content {
 					hm.SubmitText = replay
 				}
-			} else {
-				hm.SubmitText = m.Content
+			} else if replay != content {
+				hm.SubmitText = replay
 			}
 		}
 		if (m.Role == provider.RoleAssistant || m.LocalOnly) && len(m.ToolCalls) > 0 {
@@ -5708,9 +5769,7 @@ func isVisibleHistoryUser(msg provider.Message, resolveUserContent func(string) 
 	if _, isSteer := agent.SteerText(content); isSteer {
 		return false
 	}
-	if msg.RawContent == "" {
-		content = resolveUserContent(msg.Content)
-	}
+	content = historyUserDisplayContent(msg, resolveUserContent)
 	return !control.IsSyntheticUserMessage(content)
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5600,8 +5600,6 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 				if replay := control.StripComposePrefixes(m.Content); strings.HasPrefix(strings.TrimSpace(replay), "/") && replay != content {
 					hm.SubmitText = replay
 				}
-			} else if m.RawContent != "" {
-				hm.SubmitText = m.Content
 			} else {
 				hm.SubmitText = m.Content
 			}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5510,9 +5510,10 @@ func historyReplayUserContent(content string) string {
 	return control.StripReferencedContextPrefix(control.StripComposePrefixes(content))
 }
 
-// collapseLegacyExpandedPasteDisplay repairs sessions saved before RawContent
-// stored the compact pasted-text label. The expanded block remains in SubmitText
-// so edit replay can still reconstruct the card and recover its full payload.
+// collapseLegacyExpandedPasteDisplay repairs sessions whose user-authored replay
+// source still contains an expanded pasted-text block. This includes transcripts
+// written before RawContent existed. The expanded block remains in SubmitText so
+// edit replay can still reconstruct the card and recover its full payload.
 func collapseLegacyExpandedPasteDisplay(content string) string {
 	const beginPrefix = "--- Begin "
 	for scan := 0; scan < len(content); {
@@ -5555,16 +5556,16 @@ func collapseLegacyExpandedPasteDisplay(content string) string {
 // Comparing it with the deterministic fallback distinguishes a sidecar hit
 // without changing the resolver API used throughout history pagination.
 func historyUserDisplayContent(msg provider.Message, resolveUserContent func(string) string) string {
-	if msg.RawContent == "" {
-		return resolveUserContent(msg.Content)
-	}
-	raw := agent.UserMessageText(msg)
 	resolved := strings.TrimSpace(resolveUserContent(msg.Content))
 	fallback := strings.TrimSpace(historyReplayUserContent(msg.Content))
 	if resolved != "" && resolved != fallback {
 		return resolved
 	}
-	return collapseLegacyExpandedPasteDisplay(raw)
+	replaySource := agent.UserMessageText(msg)
+	if msg.RawContent == "" {
+		replaySource = fallback
+	}
+	return collapseLegacyExpandedPasteDisplay(replaySource)
 }
 
 func historyCheckpointTurns(msgs []provider.Message, resolveUserContent func(string) string, checkpointTurns map[int]int) []int {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5601,7 +5601,7 @@ func historyMessagesWithPlannerDisplaysAndLookups(
 					hm.SubmitText = replay
 				}
 			} else if m.RawContent != "" {
-				hm.SubmitText = content
+				hm.SubmitText = m.Content
 			} else {
 				hm.SubmitText = m.Content
 			}

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -82,18 +82,69 @@ func TestHistoryMessagesPreferPersistedRawUserContent(t *testing.T) {
 	const rendered = "<capability-route version=\"1\">\nuse review\n</capability-route>\n\nfix the bug"
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: rendered, RawContent: raw}}
 
-	got := historyMessages(msgs, func(string) string {
-		t.Fatal("raw_content should make provider wrapper parsing unnecessary")
-		return ""
-	})
+	got := historyMessages(msgs, historyReplayUserContent)
 	if len(got) != 1 || got[0].Content != raw {
 		t.Fatalf("history user content = %+v, want raw %q", got, raw)
 	}
-	if got[0].SubmitText != rendered {
-		t.Fatalf("history submit text = %q, want rendered %q", got[0].SubmitText, rendered)
+	if got[0].SubmitText != "" {
+		t.Fatalf("provider-only wrapper should not become replay text, got %q", got[0].SubmitText)
 	}
-	if strings.Contains(got[0].Content, "capability-route") {
+	if strings.Contains(got[0].Content, "capability-route") || strings.Contains(got[0].SubmitText, "capability-route") {
 		t.Fatalf("provider-only wrapper leaked into history: %+v", got[0])
+	}
+}
+
+func TestHistoryMessagesRecoverLegacyExpandedPasteWithoutSidecar(t *testing.T) {
+	const label = "[已粘贴文本 #1 · 3 行]"
+	const display = "review this\n\n" + label
+	const expanded = display + "\n\n--- Begin " + label + " ---\nfirst\nsecond\nthird\n--- End " + label + " ---"
+	const rendered = "<active-goal>\nship the release\n</active-goal>\n\n" + expanded
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: rendered, RawContent: expanded}}
+
+	got := historyMessages(msgs, historyReplayUserContent)
+	if len(got) != 1 || got[0].Content != display {
+		t.Fatalf("legacy pasted display = %+v, want %q", got, display)
+	}
+	if got[0].SubmitText != expanded {
+		t.Fatalf("legacy pasted replay = %q, want expanded user input", got[0].SubmitText)
+	}
+	if strings.Contains(got[0].SubmitText, "<active-goal>") {
+		t.Fatalf("transient goal leaked into legacy replay: %+v", got[0])
+	}
+}
+
+func TestHistoryMessagesPreferLegacySidecarDisplay(t *testing.T) {
+	const label = "[Pasted text #1 · 2 lines]"
+	const display = "inspect\n\n" + label
+	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
+	const rendered = "<capability-route version=\"1\">\nuse review\n</capability-route>\n\n" + expanded
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: rendered, RawContent: expanded}}
+
+	got := historyMessages(msgs, func(content string) string {
+		if content != rendered {
+			t.Fatalf("sidecar resolver content = %q, want rendered content", content)
+		}
+		return display
+	})
+	if len(got) != 1 || got[0].Content != display || got[0].SubmitText != expanded {
+		t.Fatalf("legacy sidecar history = %+v, want display %q and expanded replay", got, display)
+	}
+	if strings.Contains(got[0].SubmitText, "capability-route") {
+		t.Fatalf("provider-only wrapper leaked into sidecar replay: %+v", got[0])
+	}
+}
+
+func TestHistoryMessagesLegacyReferenceReplayExcludesResolvedContext(t *testing.T) {
+	const raw = "@src/main.go explain the entrypoint"
+	const rendered = "<capability-route version=\"1\">\nuse review\n</capability-route>\n\nReferenced context:\n\n<file path=\"src/main.go\">\npackage main\n</file>\n\n" + raw
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: rendered, RawContent: raw}}
+
+	got := historyMessages(msgs, historyReplayUserContent)
+	if len(got) != 1 || got[0].Content != raw || got[0].SubmitText != "" {
+		t.Fatalf("legacy reference history = %+v, want compact raw replay", got)
+	}
+	if strings.Contains(got[0].Content, "<file") || strings.Contains(got[0].SubmitText, "<file") {
+		t.Fatalf("resolved reference leaked into editable history: %+v", got[0])
 	}
 }
 
@@ -820,6 +871,35 @@ func TestPreviewSessionMessagesLoadsWithoutResuming(t *testing.T) {
 	}
 	if got[1].Reasoning != "saved reasoning" {
 		t.Fatalf("preview reasoning = %q, want saved reasoning", got[1].Reasoning)
+	}
+}
+
+func TestPreviewSessionMessagesUpgradesLegacyExpandedPaste(t *testing.T) {
+	const label = "[Pasted text #1 · 2 lines]"
+	const display = "inspect this\n\n" + label
+	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
+	const rendered = "<capability-route version=\"1\">\nuse review\n</capability-route>\n\n" + expanded
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	session := agent.NewSession("")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: rendered, RawContent: expanded})
+	if err := session.Save(path); err != nil {
+		t.Fatalf("Save legacy session: %v", err)
+	}
+	if err := recordSessionDisplay(dir, path, rendered, display); err != nil {
+		t.Fatalf("record legacy display: %v", err)
+	}
+
+	got, err := previewSessionMessages(dir, path)
+	if err != nil {
+		t.Fatalf("previewSessionMessages: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != display || got[0].SubmitText != expanded {
+		t.Fatalf("upgraded legacy preview = %+v, want display %q and expanded replay", got, display)
+	}
+	if strings.Contains(got[0].SubmitText, "capability-route") {
+		t.Fatalf("provider-only wrapper leaked after session restart: %+v", got[0])
 	}
 }
 

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -911,6 +911,29 @@ func TestPreviewSessionMessagesUpgradesLegacyExpandedPaste(t *testing.T) {
 	}
 }
 
+func TestPreviewSessionMessagesUpgradesContentOnlyExpandedPaste(t *testing.T) {
+	const label = "[Pasted text #1 · 2 lines]"
+	const display = "inspect this\n\n" + label
+	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "content-only.jsonl")
+	session := agent.NewSession("")
+	// Releases before Context Engine v2 persisted user turns without RawContent.
+	session.Add(provider.Message{Role: provider.RoleUser, Content: expanded})
+	if err := session.Save(path); err != nil {
+		t.Fatalf("Save content-only session: %v", err)
+	}
+
+	got, err := previewSessionMessages(dir, path)
+	if err != nil {
+		t.Fatalf("previewSessionMessages: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != display || got[0].SubmitText != expanded {
+		t.Fatalf("upgraded content-only preview = %+v, want display %q and expanded replay", got, display)
+	}
+}
+
 func TestPreviewSessionMessagesIncludesProcessEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -113,12 +113,20 @@ func TestHistoryMessagesRecoverLegacyExpandedPasteWithoutSidecar(t *testing.T) {
 	}
 }
 
-func TestHistoryMessagesPreferLegacySidecarDisplay(t *testing.T) {
+func TestHistoryMessagesExpandedRawSupportsSidecarAndPreviousClients(t *testing.T) {
 	const label = "[Pasted text #1 · 2 lines]"
 	const display = "inspect\n\n" + label
 	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
 	const rendered = "<capability-route version=\"1\">\nuse review\n</capability-route>\n\n" + expanded
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: rendered, RawContent: expanded}}
+
+	// Previous desktop releases use RawContent as their replay source. Keeping
+	// the expanded markers there lets them reconstruct the same inline card
+	// instead of rendering an opaque label with no accessible payload.
+	previousReplay := agent.UserMessageText(msgs[0])
+	if !strings.Contains(previousReplay, "--- Begin "+label+" ---") || !strings.Contains(previousReplay, "--- End "+label+" ---") {
+		t.Fatalf("previous-client replay lost pasted payload markers: %q", previousReplay)
+	}
 
 	got := historyMessages(msgs, func(content string) string {
 		if content != rendered {

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -89,8 +89,8 @@ func TestHistoryMessagesPreferPersistedRawUserContent(t *testing.T) {
 	if len(got) != 1 || got[0].Content != raw {
 		t.Fatalf("history user content = %+v, want raw %q", got, raw)
 	}
-	if got[0].SubmitText != raw {
-		t.Fatalf("history submit text = %q, want raw %q", got[0].SubmitText, raw)
+	if got[0].SubmitText != rendered {
+		t.Fatalf("history submit text = %q, want rendered %q", got[0].SubmitText, rendered)
 	}
 	if strings.Contains(got[0].Content, "capability-route") {
 		t.Fatalf("provider-only wrapper leaked into history: %+v", got[0])

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -1269,7 +1269,7 @@ func sessionDisplayResolverFromMap(displays sessionDisplayMap, sessionPath strin
 				return display
 			}
 		}
-		return control.StripComposePrefixes(content)
+		return control.StripReferencedContextPrefix(control.StripComposePrefixes(content))
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -15,7 +15,6 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
-	"reasonix/internal/control"
 	"reasonix/internal/filelock"
 	"reasonix/internal/fileutil"
 	"reasonix/internal/store"
@@ -1269,7 +1268,7 @@ func sessionDisplayResolverFromMap(displays sessionDisplayMap, sessionPath strin
 				return display
 			}
 		}
-		return control.StripReferencedContextPrefix(control.StripComposePrefixes(content))
+		return historyReplayUserContent(content)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1605,9 +1605,9 @@ func (c *Controller) runRefTurnWithResolverSync(ctx context.Context, input, refL
 		sent = "Referenced context:\n\n" + block + "\n\n" + input
 	}
 	if strings.TrimSpace(original) != "" {
-		return c.runEditedGoalLoopWithRawDisplay(ctx, sent, input, display, original)
+		return c.runEditedGoalLoopWithRawDisplay(ctx, sent, display, display, original)
 	}
-	return c.runGoalLoopWithRawDisplay(ctx, sent, input, display)
+	return c.runGoalLoopWithRawDisplay(ctx, sent, display, display)
 }
 
 // notice emits an informational Notice event.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1605,9 +1605,9 @@ func (c *Controller) runRefTurnWithResolverSync(ctx context.Context, input, refL
 		sent = "Referenced context:\n\n" + block + "\n\n" + input
 	}
 	if strings.TrimSpace(original) != "" {
-		return c.runEditedGoalLoopWithRawDisplay(ctx, sent, display, display, original)
+		return c.runEditedGoalLoopWithRawDisplay(ctx, sent, input, display, original)
 	}
-	return c.runGoalLoopWithRawDisplay(ctx, sent, display, display)
+	return c.runGoalLoopWithRawDisplay(ctx, sent, input, display)
 }
 
 // notice emits an informational Notice event.

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -16,6 +16,7 @@ import (
 	"reasonix/internal/evidence"
 	"reasonix/internal/hook"
 	"reasonix/internal/provider"
+	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
 
@@ -381,15 +382,27 @@ func TestTurnOrchestratorRefTurnRecordsVisibleDisplay(t *testing.T) {
 	}
 }
 
-func TestTurnOrchestratorRefTurnPersistsCompactPasteDisplay(t *testing.T) {
+func TestTurnOrchestratorRefTurnPreservesExpandedPasteForRouting(t *testing.T) {
 	const label = "[Pasted text #1 · 2 lines]"
 	const display = "inspect\n\n" + label
-	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
+	const expanded = display + "\n\n--- Begin " + label + " ---\nroute-expanded-paste\nfunc main() {}\n--- End " + label + " ---"
 
 	sess := agent.NewSession("sys")
 	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
 	runner := &recordingSessionRunner{session: sess}
-	c := New(Options{Runner: runner, Executor: exec})
+	reg := tool.NewRegistry()
+	reg.Add(capabilityTestTool{name: "run_skill"})
+	c := New(Options{
+		Runner:   runner,
+		Executor: exec,
+		Registry: reg,
+		Skills: []skill.Skill{{
+			Name:        "paste-review",
+			Description: "review code",
+			Triggers:    []string{"route-expanded-paste"},
+			Scope:       skill.ScopeBuiltin,
+		}},
+	})
 	resolve := func(context.Context, string) (string, []string) {
 		return "<file path=\"notes.txt\">\nreference\n</file>", nil
 	}
@@ -400,8 +413,11 @@ func TestTurnOrchestratorRefTurnPersistsCompactPasteDisplay(t *testing.T) {
 	if len(runner.inputs) != 1 || !strings.Contains(runner.inputs[0], "Referenced context:") || !strings.Contains(runner.inputs[0], expanded) {
 		t.Fatalf("provider input = %+v, want resolved context and expanded paste", runner.inputs)
 	}
-	if len(runner.raw) != 1 || runner.raw[0] != display {
-		t.Fatalf("persisted raw input = %+v, want compact display %q", runner.raw, display)
+	if !strings.Contains(runner.inputs[0], "skill:paste-review prefer") {
+		t.Fatalf("expanded pasted text did not drive capability routing:\n%s", runner.inputs[0])
+	}
+	if len(runner.raw) != 1 || runner.raw[0] != expanded {
+		t.Fatalf("persisted raw input = %+v, want complete user input %q", runner.raw, expanded)
 	}
 }
 

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -139,6 +139,7 @@ func TestTurnOrchestratorStopHookIgnoresCanceledTurnContext(t *testing.T) {
 type recordingSessionRunner struct {
 	session *agent.Session
 	inputs  []string
+	raw     []string
 }
 
 type deliveryScopeErrorRunner struct {
@@ -236,6 +237,7 @@ func TestRecoveryPauseKeepsGoalRunningAndDeliveryScope(t *testing.T) {
 
 func (r *recordingSessionRunner) Run(ctx context.Context, input string) error {
 	r.inputs = append(r.inputs, input)
+	r.raw = append(r.raw, agent.RawUserInput(ctx, input))
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	return nil
 }
@@ -376,6 +378,30 @@ func TestTurnOrchestratorRefTurnRecordsVisibleDisplay(t *testing.T) {
 	}
 	if gotContent != runner.inputs[0] {
 		t.Fatalf("display recorder content = %q, want persisted model input %q", gotContent, runner.inputs[0])
+	}
+}
+
+func TestTurnOrchestratorRefTurnPersistsCompactPasteDisplay(t *testing.T) {
+	const label = "[Pasted text #1 · 2 lines]"
+	const display = "inspect\n\n" + label
+	const expanded = display + "\n\n--- Begin " + label + " ---\none\ntwo\n--- End " + label + " ---"
+
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &recordingSessionRunner{session: sess}
+	c := New(Options{Runner: runner, Executor: exec})
+	resolve := func(context.Context, string) (string, []string) {
+		return "<file path=\"notes.txt\">\nreference\n</file>", nil
+	}
+
+	if err := c.runRefTurnWithResolverSync(context.Background(), expanded, expanded, display, "", resolve); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.inputs) != 1 || !strings.Contains(runner.inputs[0], "Referenced context:") || !strings.Contains(runner.inputs[0], expanded) {
+		t.Fatalf("provider input = %+v, want resolved context and expanded paste", runner.inputs)
+	}
+	if len(runner.raw) != 1 || runner.raw[0] != display {
+		t.Fatalf("persisted raw input = %+v, want compact display %q", runner.raw, display)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #7051. Pasted-text and file-reference inline cards now stay compact after switching sessions or restarting Desktop, while the complete user-authored input remains available for capability routing, memory recall, planning, edit replay, and older Desktop clients.

## Root cause

History loading preferred persisted `RawContent` directly. Context Engine v2 sessions can contain expanded pasted-text payloads there, while older transcripts may have no `RawContent` and keep the same expanded payload only in `Content`. In both cases the message bubble exposed `--- Begin / End ---` markers instead of restoring the inline card.

Provider-facing `Content` cannot be replayed verbatim either because it can include transient capability, goal, hook, and resolved-reference context.

## Changes

1. Keep the complete pasted/reference input as the controller's semantic and persisted raw value. The compact display string remains a separate display concern.
2. Prefer the persisted `.display.json` sidecar for history display; when it is unavailable, collapse recognized legacy pasted-text blocks deterministically from either `RawContent` or sanitized Content-only transcripts.
3. Build `SubmitText` from sanitized user-authored content so edit replay retains paste/selection payloads without resubmitting transient composed context.
4. Apply the same display recovery to history pagination, checkpoint lookup, visibility checks, and session fallback.
5. Add regressions for capability routing from pasted text, current-client sidecar recovery, Content-only pre-Context Engine sessions, expanded `RawContent`, and previous-client replay.

## Backward compatibility

| Path | Result |
| --- | --- |
| Provider input and routing | Complete user input is preserved |
| Existing expanded `RawContent` → current Desktop | Sidecar or deterministic fallback restores the compact card |
| Pre-Context Engine Content-only history → current Desktop | Sanitized `Content` restores the compact card while retaining the full payload in `SubmitText` |
| New history → previous Desktop | Expanded paste markers remain in `RawContent`, so the payload can still be reconstructed |
| Session/Wails schema | No schema changes |

## Verification

- [x] `go test ./...`
- [x] `cd desktop && go test ./...`
- [x] `./scripts/cache-guard.sh` — all 8 cases passed
- [x] Frontend edit replay tests — 17/17 passed
- [x] Frontend pasted-block tests — 9/9 passed
- [x] `git diff --check`

## Cache impact

Cache-impact: none

The stable system/tool prefix is unchanged. Preserving complete raw input restores the existing per-turn capability, memory, and planner behavior. The cache guard passed.

## Issues

Fixes #7051

---

## 摘要

修复 #7051。切换会话或重启 Desktop 后，粘贴文本和文件引用内联卡片会继续保持紧凑展示；同时保留完整的用户原始输入，用于能力路由、记忆召回、规划、编辑重放以及旧版 Desktop 的兼容恢复。

## 根因

历史加载直接优先使用持久化的 `RawContent`。Context Engine v2 会话可能在其中保存展开后的粘贴正文；更早的 transcript 则可能没有 `RawContent`，仅在 `Content` 中保存相同的展开内容。两种情况下都会导致消息气泡显示 `--- Begin / End ---` 标记，而不是恢复内联卡片。

另一方面，面向 Provider 的 `Content` 可能包含临时的能力、目标、Hook 和已解析引用上下文，也不能原样用于编辑重放。

## 修复内容

1. 控制器继续使用完整的粘贴/引用输入作为语义和持久化 raw 值，紧凑文本仅承担展示职责。
2. 历史展示优先使用 `.display.json` sidecar；缺失时，从 `RawContent` 或已清理的 Content-only transcript 中确定性折叠可识别的旧版粘贴块。
3. 从已清理的用户原始内容生成 `SubmitText`，保留粘贴/选区数据，同时避免重放临时组合上下文。
4. 将同一套恢复逻辑应用到历史分页、检查点定位、可见性判断和会话回退路径。
5. 新增粘贴正文触发能力路由、当前客户端 sidecar 恢复、Context Engine 之前的 Content-only 会话、展开 `RawContent` 和旧客户端重放回归测试。

## 向后兼容

| 路径 | 结果 |
| --- | --- |
| Provider 输入与能力路由 | 保留完整用户输入 |
| 旧版展开 `RawContent` → 当前 Desktop | 通过 sidecar 或确定性回退恢复紧凑卡片 |
| Context Engine 之前的 Content-only 历史 → 当前 Desktop | 从已清理的 `Content` 恢复紧凑卡片，并在 `SubmitText` 中保留完整正文 |
| 新历史记录 → 旧版 Desktop | `RawContent` 仍保留展开标记，可继续重建粘贴卡片 |
| Session/Wails schema | 无变更 |

## 验证

- [x] `go test ./...`
- [x] `cd desktop && go test ./...`
- [x] `./scripts/cache-guard.sh` — 8 个场景全部通过
- [x] 前端编辑重放测试 — 17/17 通过
- [x] 前端粘贴块测试 — 9/9 通过
- [x] `git diff --check`
