### PR TITLE
fix(desktop): prevent decision cards from overflowing behind the status bar / 修复决策卡片溢出被底部信息栏遮挡

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4565,37 +4565,6 @@ export default function App() {
               balance={state.balance}
             />
             </div>
-            <StatusBar
-              context={state.context}
-              usage={state.usage}
-              balance={state.balance}
-              running={state.running || rewindCommitting}
-              sessionTurns={sessionTurns}
-              sessionTokens={state.sessionTokens}
-              turnTokens={state.turnTotalTokens}
-              turnCost={state.turnCost}
-              cost={state.sessionCost}
-              currency={state.sessionCurrency}
-              modelLabel={state.meta?.label}
-              labelStyle={statusBarStyle}
-              items={statusBarItems}
-	              workspacePath={state.meta?.workspacePath || state.meta?.workspaceRoot || state.meta?.cwd}
-	              workspaceName={state.meta?.workspaceName}
-	              gitBranch={state.meta?.gitBranch}
-              onConnectRemote={connectAndOpenRemoteWorkspace}
-              onDisconnectRemote={(hostId) => void app.DisconnectRemoteHost(hostId).catch(() => {})}
-              onManageRemote={() => setSettingsTarget("remote")}
-              onOpenRemote={requestRemoteExplorer}
-              onOpenRemoteWorkspace={openRemoteWorkspaceFromStatus}
-              remoteHosts={remoteHosts}
-              remoteStatuses={remoteStatuses}
-              workbenchTarget={workbenchTarget}
-              onSwitchLocal={() => {
-                void app.WorkbenchSwitchLocal()
-                  .then(setWorkbenchTarget)
-                  .catch((err) => showToast(err instanceof Error ? err.message : String(err), "error"));
-              }}
-            />
           </footer>
           )}
           </>
@@ -4744,6 +4713,41 @@ export default function App() {
             </div>
           </aside>
         )}
+
+          {!sidebarImDetailConnection && (
+          <StatusBar
+            context={state.context}
+            usage={state.usage}
+            balance={state.balance}
+            running={state.running || rewindCommitting}
+            sessionTurns={sessionTurns}
+            sessionTokens={state.sessionTokens}
+            turnTokens={state.turnTotalTokens}
+            turnCost={state.turnCost}
+            cost={state.sessionCost}
+            currency={state.sessionCurrency}
+            modelLabel={state.meta?.label}
+            labelStyle={statusBarStyle}
+            items={statusBarItems}
+	              workspacePath={state.meta?.workspacePath || state.meta?.workspaceRoot || state.meta?.cwd}
+	              workspaceName={state.meta?.workspaceName}
+	              gitBranch={state.meta?.gitBranch}
+            onConnectRemote={connectAndOpenRemoteWorkspace}
+            onDisconnectRemote={(hostId) => void app.DisconnectRemoteHost(hostId).catch(() => {})}
+            onManageRemote={() => setSettingsTarget("remote")}
+            onOpenRemote={requestRemoteExplorer}
+            onOpenRemoteWorkspace={openRemoteWorkspaceFromStatus}
+            remoteHosts={remoteHosts}
+            remoteStatuses={remoteStatuses}
+            workbenchTarget={workbenchTarget}
+            onSwitchLocal={() => {
+              void app.WorkbenchSwitchLocal()
+                .then(setWorkbenchTarget)
+                .catch((err) => showToast(err instanceof Error ? err.message : String(err), "error"));
+            }}
+          />
+          )}
+
       </div>
 
       {histView !== null && (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3841,6 +3841,7 @@ export default function App() {
           sidebarWorkbench ? "layout--workbench" : "",
           workbenchChromeHidden ? "layout--workbench-chrome-hidden" : "",
           sidebarCreation ? "layout--creation-chrome-hidden" : "",
+          sidebarImDetailConnection ? "layout--statusbar-hidden" : "",
           sidebarCollapsed ? "layout--sidebar-collapsed" : "",
           sidebarResizing ? "layout--resizing layout--sidebar-resizing" : "",
           workspacePanelGridOpen ? "layout--workspace-open" : "",
@@ -4714,7 +4715,7 @@ export default function App() {
           </aside>
         )}
 
-          {!sidebarImDetailConnection && (
+        {!sidebarImDetailConnection && (
           <StatusBar
             context={state.context}
             usage={state.usage}
@@ -4729,9 +4730,9 @@ export default function App() {
             modelLabel={state.meta?.label}
             labelStyle={statusBarStyle}
             items={statusBarItems}
-	              workspacePath={state.meta?.workspacePath || state.meta?.workspaceRoot || state.meta?.cwd}
-	              workspaceName={state.meta?.workspaceName}
-	              gitBranch={state.meta?.gitBranch}
+            workspacePath={state.meta?.workspacePath || state.meta?.workspaceRoot || state.meta?.cwd}
+            workspaceName={state.meta?.workspaceName}
+            gitBranch={state.meta?.gitBranch}
             onConnectRemote={connectAndOpenRemoteWorkspace}
             onDisconnectRemote={(hostId) => void app.DisconnectRemoteHost(hostId).catch(() => {})}
             onManageRemote={() => setSettingsTarget("remote")}
@@ -4746,7 +4747,7 @@ export default function App() {
                 .catch((err) => showToast(err instanceof Error ? err.message : String(err), "error"));
             }}
           />
-          )}
+        )}
 
       </div>
 

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -608,7 +608,7 @@ for (const selector of [
 ]) {
   ok(
     finalDeclaration(selector, "--app-chrome-height") === "0px" &&
-      finalDeclaration(selector, "grid-template-rows") === "minmax(0, 1fr)" &&
+	      finalDeclaration(selector, "grid-template-rows") === "minmax(0, 1fr) var(--statusbar-dock-height)" &&
       finalDeclaration(selector, "background") === "var(--bg)",
     `${selector} removes the workbench chrome row`,
   );

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -608,7 +608,7 @@ for (const selector of [
 ]) {
   ok(
     finalDeclaration(selector, "--app-chrome-height") === "0px" &&
-	      finalDeclaration(selector, "grid-template-rows") === "minmax(0, 1fr) var(--statusbar-dock-height)" &&
+      finalDeclaration(selector, "grid-template-rows") === "minmax(0, 1fr) var(--statusbar-height)" &&
       finalDeclaration(selector, "background") === "var(--bg)",
     `${selector} removes the workbench chrome row`,
   );

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -174,11 +174,28 @@ eq(
   true,
   "terminal drawer stays visible on narrow viewports",
 );
-	eq(
-	  /\.layout--terminal-open \{[\s\S]*?grid-template-rows: var\(--app-chrome-height\) minmax\(0, 1fr\) minmax\(220px, min\(42vh, 440px\)\) var\(--statusbar-dock-height\)/.test(stylesSource),
-	  true,
-	  "terminal-open layout reserves a grid row for the status bar below the terminal drawer",
-	);
+eq(
+  /\.layout--terminal-open \{[\s\S]*?grid-template-rows: var\(--app-chrome-height\) minmax\(0, 1fr\) minmax\(220px, min\(42vh, 440px\)\) var\(--statusbar-height\)/.test(stylesSource),
+  true,
+  "terminal-open layout reserves a grid row for the status bar below the terminal drawer",
+);
+eq(
+  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-open \.workbench-dock,[\s\S]*?grid-row: 3;[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-open \.workbench-dock,[\s\S]*?grid-row: 2;/.test(stylesSource),
+  true,
+  "narrow classic terminal stays below chat while chrome-hidden terminal uses row two",
+);
+eq(
+  /sidebarImDetailConnection \? "layout--statusbar-hidden" : ""/.test(appSource)
+    && /\.layout\.layout--statusbar-hidden,[\s\S]*?--statusbar-height: 0px;/.test(stylesSource),
+  true,
+  "IM detail collapses the status bar row when the bar is not rendered",
+);
+eq(
+  /\.sidebar--workbench \{[\s\S]*?padding: 16px 16px 10px;/.test(stylesSource)
+    && /\.app--darwin \.sidebar--workbench,\s*\.sidebar--workbench \{[\s\S]*?padding: 14px 12px 10px;/.test(stylesSource),
+  true,
+  "workbench sidebar does not reserve the docked status bar twice",
+);
 eq(
   /\.layout--terminal-open \.workbench-dock__tools \{\s*display: none;\s*\}/.test(stylesSource),
   true,

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -174,11 +174,11 @@ eq(
   true,
   "terminal drawer stays visible on narrow viewports",
 );
-eq(
-  /\.layout--terminal-open \.workbench-dock \{[\s\S]*?padding-bottom: var\(--statusbar-height\)/.test(stylesSource),
-  true,
-  "terminal drawer reserves the fixed status bar safe area",
-);
+	eq(
+	  /\.layout--terminal-open \{[\s\S]*?grid-template-rows: var\(--app-chrome-height\) minmax\(0, 1fr\) minmax\(220px, min\(42vh, 440px\)\) var\(--statusbar-dock-height\)/.test(stylesSource),
+	  true,
+	  "terminal-open layout reserves a grid row for the status bar below the terminal drawer",
+	);
 eq(
   /\.layout--terminal-open \.workbench-dock__tools \{\s*display: none;\s*\}/.test(stylesSource),
   true,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2016,17 +2016,17 @@ a[href] {
   --workspace-width: 420px;
   --workspace-resizer-width: 8px;
   --app-chrome-height: 38px;
-  --topicbar-height: 56px;
-  --statusbar-height: 0px;
-  --chrome-toggle-size: 42px;
+	  --topicbar-height: 56px;
+	  --statusbar-height: var(--statusbar-dock-height);
+	  --chrome-toggle-size: 42px;
   --chrome-left-safe-offset: 0px;
   --chrome-left-toggle-offset: max(var(--sidebar-width), var(--chrome-left-safe-offset));
   --chrome-right-toggle-offset: 0px;
   position: relative;
   display: grid;
   justify-content: start;
-  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+	  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) var(--statusbar-dock-height);
+	  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   width: 100%;
@@ -2085,36 +2085,42 @@ a[href] {
 }
 .layout--terminal-open {
   grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
-  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) minmax(220px, min(42vh, 440px));
+	  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
 }
 .layout--terminal-open.layout--sidebar-collapsed {
   grid-template-columns: 0px minmax(0, 1fr);
 }
 .layout--terminal-open .workbench-dock {
-  grid-row: 3;
-  grid-column: 2;
-  width: 100%;
-  height: auto;
-  max-width: none;
-  padding-bottom: var(--statusbar-height);
-  border-top: 1px solid var(--border-soft);
-  border-left: 0;
-}
+	  grid-row: 3;
+	  grid-column: 2;
+	  width: 100%;
+	  height: auto;
+	  max-width: none;
+	  border-top: 1px solid var(--border-soft);
+	  border-left: 0;
+	}
 .layout--terminal-open .workbench-dock__tools {
   display: none;
 }
 .layout--terminal-open .workspace-panel-resizer {
-  display: none;
-}
+	  display: none;
+	}
+	.layout--terminal-open .statusbar {
+	  grid-row: 4;
+	}
 .layout--workbench-chrome-hidden.layout--terminal-open {
-  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
-}
-.layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock {
-  grid-row: 2;
-}
-.app--creation .layout--creation-chrome-hidden.layout--terminal-open {
-  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
-}
+	  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
+	}
+	.layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock {
+	  grid-row: 2;
+	}
+	
+	.layout--workbench-chrome-hidden.layout--terminal-open .statusbar {
+	  grid-row: 3;
+	}
+	.app--creation .layout--creation-chrome-hidden.layout--terminal-open {
+	  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
+	}
 .app--creation .layout--creation-chrome-hidden.layout--terminal-open .workbench-dock {
   grid-row: 2;
 }
@@ -2126,18 +2132,22 @@ a[href] {
 }
 
 .layout--workbench-chrome-hidden {
-  --app-chrome-height: 0px;
-  grid-template-rows: minmax(0, 1fr);
-  background: var(--bg);
-}
-
-.layout--workbench-chrome-hidden .sidebar,
-.layout--workbench-chrome-hidden .chat-pane,
-.layout--workbench-chrome-hidden .workspace-panel-resizer,
-.layout--workbench-chrome-hidden .context-inspector,
-.layout--workbench-chrome-hidden .workbench-dock {
-  grid-row: 1;
-}
+	  --app-chrome-height: 0px;
+	  grid-template-rows: minmax(0, 1fr) var(--statusbar-dock-height);
+	  background: var(--bg);
+	}
+	
+	.layout--workbench-chrome-hidden .sidebar,
+	.layout--workbench-chrome-hidden .chat-pane,
+	.layout--workbench-chrome-hidden .workspace-panel-resizer,
+	.layout--workbench-chrome-hidden .context-inspector,
+	.layout--workbench-chrome-hidden .workbench-dock {
+	  grid-row: 1;
+	}
+	
+	.layout--workbench-chrome-hidden .statusbar {
+	  grid-row: 2;
+	}
 
 .app--darwin .layout--workbench-chrome-hidden.layout--sidebar-collapsed .topicbar {
   padding-left: 96px;
@@ -2148,15 +2158,15 @@ a[href] {
 }
 
 .sidebar {
-  --sidebar-entry-content-inset: 12px;
-  grid-row: 2;
-  grid-column: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  padding: 12px 10px calc(12px + var(--statusbar-height));
-  background: var(--sidebar-bg);
-  border-right: 1px solid var(--border-soft);
+	  --sidebar-entry-content-inset: 12px;
+	  grid-row: 2;
+	  grid-column: 1;
+	  display: flex;
+	  flex-direction: column;
+	  min-width: 0;
+	  padding: 12px 10px 12px;
+	  background: var(--sidebar-bg);
+	  border-right: 1px solid var(--border-soft);
   --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
@@ -2609,11 +2619,11 @@ a[href] {
   justify-self: start;
   width: 1px;
   min-width: 1px;
-  height: calc(100% - var(--statusbar-height));
-  padding: 0;
-  border: 0;
-  background: var(--border-soft);
-  cursor: col-resize;
+	  height: 100%;
+	  padding: 0;
+	  border: 0;
+	  background: var(--border-soft);
+	  cursor: col-resize;
   touch-action: none;
   z-index: var(--z-layout-resizer-active);
 }
@@ -5845,11 +5855,13 @@ body > .mermaid-diagram--fullscreen {
 
 /* ── footer: composer + status line ──────────────────────────────────────── */
 .footer {
-  flex: 0 0 auto;
-  border-top: 1px solid var(--border-soft);
-  background: var(--chat-bg);
-  padding: 12px 32px 10px;
-}
+			  flex: 0 0 auto;
+			  max-height: calc(100% - var(--topicbar-height));
+			  overflow-y: auto;
+			  border-top: 1px solid var(--border-soft);
+			  background: var(--chat-bg);
+			  padding: 12px 32px 10px;
+			}
 
 /* ── undo-rewind banner (above composer after a rewind) ─────────────── */
 .undo-rewind {
@@ -7354,8 +7366,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .statusbar {
-  max-width: var(--maxw);
-  margin: 7px auto 0;
+	  grid-row: 3;
+	  grid-column: 1 / -1;
+	  max-width: var(--maxw);
+	  margin: 7px auto 0;
   display: flex;
   align-items: center;
   gap: 0;
@@ -23680,17 +23694,16 @@ body > .mermaid-diagram--fullscreen {
 
 .context-inspector,
 .workbench-dock {
-  grid-row: 2;
-  grid-column: 3;
-  min-width: 0;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  padding-bottom: var(--statusbar-height);
-  background: var(--workspace-files-bg);
-  border-left: 1px solid var(--border-soft);
-  overflow: hidden;
-}
+	  grid-row: 2;
+	  grid-column: 3;
+	  min-width: 0;
+	  height: 100%;
+	  display: flex;
+	  flex-direction: column;
+	  background: var(--workspace-files-bg);
+	  border-left: 1px solid var(--border-soft);
+	  overflow: hidden;
+	}
 
 .workbench-dock {
   justify-self: stretch;
@@ -25242,9 +25255,9 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .sidebar {
-  padding: 12px 10px calc(12px + var(--statusbar-height));
-  background: var(--sidebar-bg);
-  border-right-color: var(--border-soft);
+	  padding: 12px 10px 12px;
+	  background: var(--sidebar-bg);
+	  border-right-color: var(--border-soft);
 }
 
 .sidebar__brand {
@@ -25597,9 +25610,9 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .workbench-dock {
-  background: color-mix(in srgb, var(--bg-elev) 60%, var(--chat-bg));
-  border-left: 1px solid var(--border-soft);
-}
+	  background: color-mix(in srgb, var(--bg-elev) 60%, var(--chat-bg));
+	  border-left: 1px solid var(--border-soft);
+	}
 
 .workbench-dock__tools {
   height: 52px;
@@ -25721,12 +25734,12 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .layout--workbench-chrome-hidden {
-  --app-chrome-height: 0px;
-  grid-template-rows: minmax(0, 1fr);
-  background: var(--bg);
-}
-
-:root[data-theme-style] .app--darwin .layout {
+	  --app-chrome-height: 0px;
+	  grid-template-rows: minmax(0, 1fr) var(--statusbar-dock-height);
+	  background: var(--bg);
+	}
+	
+	:root[data-theme-style] .app--darwin .layout {
   --app-chrome-height: 46px;
 }
 
@@ -26234,10 +26247,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .sidebar {
-  padding: 14px 12px calc(8px + var(--statusbar-height));
-  background: var(--sidebar-bg);
-  border-right: 1px solid var(--border-soft);
-}
+		  padding: 14px 12px 8px;
+		  background: var(--sidebar-bg);
+		  border-right: 1px solid var(--border-soft);
+		}
 
 :root[data-theme-style] .sidebar__nav {
   padding-bottom: 0;
@@ -27006,10 +27019,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .footer {
-  padding: 12px 16px 38px;
-  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
-  border-top: 1px solid var(--border-soft);
-}
+	  padding: 12px 16px 10px;
+	  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
+	  border-top: 1px solid var(--border-soft);
+	}
 
 :root[data-theme-style] .composer-wrap {
   width: 100%;
@@ -27168,25 +27181,20 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .statusbar {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: var(--z-dock);
-  max-width: none;
-  width: auto;
-  height: var(--statusbar-dock-height);
-  min-height: var(--statusbar-dock-height);
-  margin: 0;
-  padding: 0 16px;
-  gap: 0;
-  border-top: 1px solid var(--border);
-  background: var(--panel);
-  box-sizing: border-box;
-  color: var(--fg-faint);
-  font-size: var(--font-status);
-  justify-content: flex-start;
-}
+	  width: 100%;
+	  max-width: none;
+	  height: var(--statusbar-dock-height);
+	  min-height: var(--statusbar-dock-height);
+	  margin: 0;
+	  padding: 0 16px;
+	  gap: 0;
+	  border-top: 1px solid var(--border);
+	  background: var(--panel);
+	  box-sizing: border-box;
+	  color: var(--fg-faint);
+	  font-size: var(--font-status);
+	  justify-content: flex-start;
+	}
 
 :root[data-theme-style] .statusbar__group + .statusbar__group {
   margin-left: 12px;
@@ -29098,10 +29106,14 @@ body > .mermaid-diagram--fullscreen {
      --scrollbar-size) — override them scoped to .app--creation if needed.
    ========================================================================== */
 .app--creation .layout--creation-chrome-hidden {
-  --app-chrome-height: 0px;
-  --statusbar-height: 0px;
-  grid-template-rows: minmax(0, 1fr);
-}
+	  --app-chrome-height: 0px;
+	  --statusbar-height: 0px;
+	  grid-template-rows: minmax(0, 1fr);
+	}
+	
+	.app--creation .statusbar {
+	  display: none;
+	}
 
 .app--creation .settings-modal-backdrop,
 :root[data-theme-style] .app--creation .settings-modal-backdrop {
@@ -33159,12 +33171,12 @@ body > .mermaid-diagram--fullscreen {
   :root[data-theme-style] .app .layout--terminal-open .workbench-dock {
     display: flex !important;
     grid-column: 1 !important;
-    grid-row: 3;
+    grid-row: 2;
   }
 
   .app .layout--workbench-chrome-hidden.layout--terminal-open,
   :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-open {
-    grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
+    grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
   }
 
   .app .layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2016,22 +2016,27 @@ a[href] {
   --workspace-width: 420px;
   --workspace-resizer-width: 8px;
   --app-chrome-height: 38px;
-	  --topicbar-height: 56px;
-	  --statusbar-height: var(--statusbar-dock-height);
-	  --chrome-toggle-size: 42px;
+  --topicbar-height: 56px;
+  --statusbar-height: var(--statusbar-dock-height);
+  --chrome-toggle-size: 42px;
   --chrome-left-safe-offset: 0px;
   --chrome-left-toggle-offset: max(var(--sidebar-width), var(--chrome-left-safe-offset));
   --chrome-right-toggle-offset: 0px;
   position: relative;
   display: grid;
   justify-content: start;
-	  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) var(--statusbar-dock-height);
-	  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) var(--statusbar-height);
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   height: 100%;
   min-height: 0;
   width: 100%;
   background: var(--bg);
   transition: grid-template-columns 0.16s ease, min-width 0.16s ease;
+}
+
+.layout.layout--statusbar-hidden,
+:root[data-theme-style] .layout.layout--statusbar-hidden {
+  --statusbar-height: 0px;
 }
 
 .app--darwin .layout {
@@ -2085,42 +2090,42 @@ a[href] {
 }
 .layout--terminal-open {
   grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
-	  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
+  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-height);
 }
 .layout--terminal-open.layout--sidebar-collapsed {
   grid-template-columns: 0px minmax(0, 1fr);
 }
 .layout--terminal-open .workbench-dock {
-	  grid-row: 3;
-	  grid-column: 2;
-	  width: 100%;
-	  height: auto;
-	  max-width: none;
-	  border-top: 1px solid var(--border-soft);
-	  border-left: 0;
-	}
+  grid-row: 3;
+  grid-column: 2;
+  width: 100%;
+  height: auto;
+  max-width: none;
+  border-top: 1px solid var(--border-soft);
+  border-left: 0;
+}
 .layout--terminal-open .workbench-dock__tools {
   display: none;
 }
 .layout--terminal-open .workspace-panel-resizer {
-	  display: none;
-	}
-	.layout--terminal-open .statusbar {
-	  grid-row: 4;
-	}
+  display: none;
+}
+.layout--terminal-open .statusbar {
+  grid-row: 4;
+}
 .layout--workbench-chrome-hidden.layout--terminal-open {
-	  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
-	}
-	.layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock {
-	  grid-row: 2;
-	}
-	
-	.layout--workbench-chrome-hidden.layout--terminal-open .statusbar {
-	  grid-row: 3;
-	}
-	.app--creation .layout--creation-chrome-hidden.layout--terminal-open {
-	  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
-	}
+  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-height);
+}
+.layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock {
+  grid-row: 2;
+}
+
+.layout--workbench-chrome-hidden.layout--terminal-open .statusbar {
+  grid-row: 3;
+}
+.app--creation .layout--creation-chrome-hidden.layout--terminal-open {
+  grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px));
+}
 .app--creation .layout--creation-chrome-hidden.layout--terminal-open .workbench-dock {
   grid-row: 2;
 }
@@ -2132,22 +2137,22 @@ a[href] {
 }
 
 .layout--workbench-chrome-hidden {
-	  --app-chrome-height: 0px;
-	  grid-template-rows: minmax(0, 1fr) var(--statusbar-dock-height);
-	  background: var(--bg);
-	}
-	
-	.layout--workbench-chrome-hidden .sidebar,
-	.layout--workbench-chrome-hidden .chat-pane,
-	.layout--workbench-chrome-hidden .workspace-panel-resizer,
-	.layout--workbench-chrome-hidden .context-inspector,
-	.layout--workbench-chrome-hidden .workbench-dock {
-	  grid-row: 1;
-	}
-	
-	.layout--workbench-chrome-hidden .statusbar {
-	  grid-row: 2;
-	}
+  --app-chrome-height: 0px;
+  grid-template-rows: minmax(0, 1fr) var(--statusbar-height);
+  background: var(--bg);
+}
+
+.layout--workbench-chrome-hidden .sidebar,
+.layout--workbench-chrome-hidden .chat-pane,
+.layout--workbench-chrome-hidden .workspace-panel-resizer,
+.layout--workbench-chrome-hidden .context-inspector,
+.layout--workbench-chrome-hidden .workbench-dock {
+  grid-row: 1;
+}
+
+.layout--workbench-chrome-hidden .statusbar {
+  grid-row: 2;
+}
 
 .app--darwin .layout--workbench-chrome-hidden.layout--sidebar-collapsed .topicbar {
   padding-left: 96px;
@@ -2158,15 +2163,15 @@ a[href] {
 }
 
 .sidebar {
-	  --sidebar-entry-content-inset: 12px;
-	  grid-row: 2;
-	  grid-column: 1;
-	  display: flex;
-	  flex-direction: column;
-	  min-width: 0;
-	  padding: 12px 10px 12px;
-	  background: var(--sidebar-bg);
-	  border-right: 1px solid var(--border-soft);
+  --sidebar-entry-content-inset: 12px;
+  grid-row: 2;
+  grid-column: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 12px 10px 12px;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border-soft);
   --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
@@ -2619,11 +2624,11 @@ a[href] {
   justify-self: start;
   width: 1px;
   min-width: 1px;
-	  height: 100%;
-	  padding: 0;
-	  border: 0;
-	  background: var(--border-soft);
-	  cursor: col-resize;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: var(--border-soft);
+  cursor: col-resize;
   touch-action: none;
   z-index: var(--z-layout-resizer-active);
 }
@@ -5855,13 +5860,13 @@ body > .mermaid-diagram--fullscreen {
 
 /* ── footer: composer + status line ──────────────────────────────────────── */
 .footer {
-			  flex: 0 0 auto;
-			  max-height: calc(100% - var(--topicbar-height));
-			  overflow-y: auto;
-			  border-top: 1px solid var(--border-soft);
-			  background: var(--chat-bg);
-			  padding: 12px 32px 10px;
-			}
+  flex: 0 0 auto;
+  max-height: calc(100% - var(--topicbar-height));
+  overflow-y: auto;
+  border-top: 1px solid var(--border-soft);
+  background: var(--chat-bg);
+  padding: 12px 32px 10px;
+}
 
 /* ── undo-rewind banner (above composer after a rewind) ─────────────── */
 .undo-rewind {
@@ -7366,10 +7371,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .statusbar {
-	  grid-row: 3;
-	  grid-column: 1 / -1;
-	  max-width: var(--maxw);
-	  margin: 7px auto 0;
+  grid-row: 3;
+  grid-column: 1 / -1;
+  max-width: var(--maxw);
+  margin: 7px auto 0;
   display: flex;
   align-items: center;
   gap: 0;
@@ -23694,16 +23699,16 @@ body > .mermaid-diagram--fullscreen {
 
 .context-inspector,
 .workbench-dock {
-	  grid-row: 2;
-	  grid-column: 3;
-	  min-width: 0;
-	  height: 100%;
-	  display: flex;
-	  flex-direction: column;
-	  background: var(--workspace-files-bg);
-	  border-left: 1px solid var(--border-soft);
-	  overflow: hidden;
-	}
+  grid-row: 2;
+  grid-column: 3;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--workspace-files-bg);
+  border-left: 1px solid var(--border-soft);
+  overflow: hidden;
+}
 
 .workbench-dock {
   justify-self: stretch;
@@ -25255,9 +25260,9 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .sidebar {
-	  padding: 12px 10px 12px;
-	  background: var(--sidebar-bg);
-	  border-right-color: var(--border-soft);
+  padding: 12px 10px 12px;
+  background: var(--sidebar-bg);
+  border-right-color: var(--border-soft);
 }
 
 .sidebar__brand {
@@ -25610,9 +25615,9 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .workbench-dock {
-	  background: color-mix(in srgb, var(--bg-elev) 60%, var(--chat-bg));
-	  border-left: 1px solid var(--border-soft);
-	}
+  background: color-mix(in srgb, var(--bg-elev) 60%, var(--chat-bg));
+  border-left: 1px solid var(--border-soft);
+}
 
 .workbench-dock__tools {
   height: 52px;
@@ -25734,12 +25739,12 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .layout--workbench-chrome-hidden {
-	  --app-chrome-height: 0px;
-	  grid-template-rows: minmax(0, 1fr) var(--statusbar-dock-height);
-	  background: var(--bg);
-	}
-	
-	:root[data-theme-style] .app--darwin .layout {
+  --app-chrome-height: 0px;
+  grid-template-rows: minmax(0, 1fr) var(--statusbar-height);
+  background: var(--bg);
+}
+
+:root[data-theme-style] .app--darwin .layout {
   --app-chrome-height: 46px;
 }
 
@@ -26247,10 +26252,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .sidebar {
-		  padding: 14px 12px 8px;
-		  background: var(--sidebar-bg);
-		  border-right: 1px solid var(--border-soft);
-		}
+  padding: 14px 12px 8px;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border-soft);
+}
 
 :root[data-theme-style] .sidebar__nav {
   padding-bottom: 0;
@@ -27019,10 +27024,10 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .footer {
-	  padding: 12px 16px 10px;
-	  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
-	  border-top: 1px solid var(--border-soft);
-	}
+  padding: 12px 16px 10px;
+  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
+  border-top: 1px solid var(--border-soft);
+}
 
 :root[data-theme-style] .composer-wrap {
   width: 100%;
@@ -27181,20 +27186,20 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .statusbar {
-	  width: 100%;
-	  max-width: none;
-	  height: var(--statusbar-dock-height);
-	  min-height: var(--statusbar-dock-height);
-	  margin: 0;
-	  padding: 0 16px;
-	  gap: 0;
-	  border-top: 1px solid var(--border);
-	  background: var(--panel);
-	  box-sizing: border-box;
-	  color: var(--fg-faint);
-	  font-size: var(--font-status);
-	  justify-content: flex-start;
-	}
+  width: 100%;
+  max-width: none;
+  height: var(--statusbar-dock-height);
+  min-height: var(--statusbar-dock-height);
+  margin: 0;
+  padding: 0 16px;
+  gap: 0;
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+  box-sizing: border-box;
+  color: var(--fg-faint);
+  font-size: var(--font-status);
+  justify-content: flex-start;
+}
 
 :root[data-theme-style] .statusbar__group + .statusbar__group {
   margin-left: 12px;
@@ -28195,12 +28200,12 @@ body > .mermaid-diagram--fullscreen {
   --sidebar-workbench-fill-strong: color-mix(in srgb, var(--bg-elev) 88%, var(--sidebar-bg));
   --sidebar-workbench-active: color-mix(in srgb, var(--accent) 12%, var(--bg-elev));
   --sidebar-workbench-active-border: color-mix(in srgb, var(--accent) 28%, transparent);
-  padding: 16px 16px calc(10px + var(--statusbar-height));
+  padding: 16px 16px 10px;
 }
 
 .app--darwin .sidebar--workbench,
 .sidebar--workbench {
-  padding: 14px 12px calc(10px + var(--statusbar-height));
+  padding: 14px 12px 10px;
 }
 
 .app--darwin .layout--workbench-chrome-hidden .sidebar--workbench {
@@ -29106,14 +29111,14 @@ body > .mermaid-diagram--fullscreen {
      --scrollbar-size) — override them scoped to .app--creation if needed.
    ========================================================================== */
 .app--creation .layout--creation-chrome-hidden {
-	  --app-chrome-height: 0px;
-	  --statusbar-height: 0px;
-	  grid-template-rows: minmax(0, 1fr);
-	}
-	
-	.app--creation .statusbar {
-	  display: none;
-	}
+  --app-chrome-height: 0px;
+  --statusbar-height: 0px;
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.app--creation .statusbar {
+  display: none;
+}
 
 .app--creation .settings-modal-backdrop,
 :root[data-theme-style] .app--creation .settings-modal-backdrop {
@@ -33171,12 +33176,12 @@ body > .mermaid-diagram--fullscreen {
   :root[data-theme-style] .app .layout--terminal-open .workbench-dock {
     display: flex !important;
     grid-column: 1 !important;
-    grid-row: 2;
+    grid-row: 3;
   }
 
   .app .layout--workbench-chrome-hidden.layout--terminal-open,
   :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-open {
-    grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-dock-height);
+    grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-height);
   }
 
   .app .layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock,


### PR DESCRIPTION
### Summary

This PR fixes the visual overlap between the left sidebar, right workspace panel, and the semi-transparent bottom status bar in the classic and workbench desktop layouts (issue #7030). Previously the sidebar and workspace panel backgrounds extended behind the fixed status bar, and long plan-approval content could push approval buttons under or past the bar.

The fix restructures the layout so the status bar lives in its own dedicated CSS Grid row, cleanly separated from the content area. The sidebar and workspace panel now end exactly at the status bar's top edge. All residual spacing that was reserved for the old `position: fixed` status bar has been removed, and the footer now has a `max-height` constraint so decision cards scroll instead of overflowing the viewport.

**149 additions, 135 deletions across 3 files.**

### Changes

**`desktop/frontend/src/App.tsx`** (66 lines changed)
- Extract `<StatusBar>` from the `<footer>` and place it as a direct child of the `.layout` grid, after the workspace panel. The element remains guarded by `{!sidebarImDetailConnection && (…)}` so IM/bot detail views are unaffected.

**`desktop/frontend/src/styles.css`** (216 lines changed)

*Grid restructuring*
- Change `.layout` from 2 rows to 3 rows: `var(--app-chrome-height) minmax(0, 1fr) var(--statusbar-dock-height)`. The same statusbar row is added to every grid variant: `--workbench-chrome-hidden`, `--terminal-open`, chrome-hidden + terminal-open, creation + terminal-open, and the narrow-viewport media-query overrides. Creation mode keeps its 2-row grid.
- Update `--statusbar-height` from `0px` to `var(--statusbar-dock-height)` so that sidebar-resizer positioning tracks the grid row height.

*StatusBar placement*
- Base `.statusbar`: add `grid-row: 3; grid-column: 1 / -1;`.
- Workbench-chrome-hidden (2 rows): override to `grid-row: 2`.
- Terminal-open + workbench-chrome-hidden (3 rows): override to `grid-row: 3`.
- Creation mode: `.app--creation .statusbar { display: none; }`.

*Remove `position: fixed`*
- `:root[data-theme-style] .statusbar` no longer uses `position: fixed; left: 0; right: 0; bottom: 0; z-index: var(--z-dock)`. The grid row anchors the bar to the viewport bottom. Themed visual properties (height, background, border, padding) are preserved.

*Clean up residual spacing*
- Sidebar bottom padding simplified from `calc(12px + var(--statusbar-height))` to `12px` (3 instances: base, workbench refresh, data-theme-style).
- Workbench-dock `padding-bottom: var(--statusbar-height)` removed.
- `:root[data-theme-style] .footer` bottom padding reduced from 38px to 10px.
- Workspace-panel-resizer height changed from `calc(100% - var(--statusbar-height))` to `100%`.
- Sidebar-resizer `bottom` and `height` keep referencing `--statusbar-height` (now `var(--statusbar-dock-height)`), which correctly aligns them with the grid row boundary.

*Footer overflow guard*
- Add `max-height: calc(100% - var(--topicbar-height)); overflow-y: auto;` to `.footer`. Footer keeps `flex: 0 0 auto` so the composer is never squashed during normal use. The max-height cap only activates when decision cards (ApprovalModal, AskCard, TodoPanel) are too tall for the available space, making the footer scrollable instead of overflowing.

**`desktop/frontend/src/__tests__/app-chrome-tabs.test.ts`** (2 lines changed)
- Update `grid-template-rows` assertion to match `minmax(0, 1fr) var(--statusbar-dock-height)`.

### Issues

Fixes #7030

### Verification

- TypeScript compilation: ✅
- CSS syntax check: ✅
- `workspace-layout.test.ts`: 27/27 passed
- `app-chrome-tabs.test.ts`: 110/110 passed
- Manual testing on Windows 11 with classic and workbench layouts across graphite, aurora, and slate themes:
  - No overlap between sidebar/workspace and status bar
  - No dead space below composer or between panels and status bar
  - Decision cards scroll within the footer instead of overflowing
  - Status bar correctly anchored at the viewport bottom in all modes
  - Creation mode unchanged (status bar hidden)

### Cache impact

Cache-impact: none
Cache-guard: N/A
System-prompt-review: N/A

---

### 摘要

本 PR 修复了经典布局和工作台布局下左侧边栏、右侧工作区面板与半透明底部信息栏之间的视觉重叠问题（issue #7030）。此前侧边栏和工作区面板的背景会延伸到固定定位的信息栏后方，且较长的计划批准内容可能导致批准按钮被遮挡或溢出屏幕。

修复方案是将信息栏独立为 CSS Grid 的专属行，与内容区域清晰分离。侧边栏和工作区面板现在精确终止于信息栏的上边界。所有为旧 `position: fixed` 信息栏预留的冗余间距均已移除，footer 增加了 `max-height` 约束使决策卡片在内容过长时可滚动而非溢出视口。

**149 行新增，135 行删除，涉及 3 个文件。**

### 变更内容

**`desktop/frontend/src/App.tsx`**（66 行变更）
- 将 `<StatusBar>` 从 `<footer>` 中提取，作为 `.layout` Grid 的直接子元素置于工作区面板之后，仍由 `{!sidebarImDetailConnection && (…)}` 守卫。

**`desktop/frontend/src/styles.css`**（216 行变更）

*Grid 重构*
- `.layout` 从 2 行改为 3 行：`var(--app-chrome-height) minmax(0, 1fr) var(--statusbar-dock-height)`。所有 Grid 变体均已同步更新。创作模式保持 2 行不变。
- `--statusbar-height` 从 `0px` 更新为 `var(--statusbar-dock-height)`。

*StatusBar 定位*
- 基础 `.statusbar`：添加 `grid-row: 3; grid-column: 1 / -1;`。
- 工作台模式（2 行）：覆盖为 `grid-row: 2`。
- 终端+工作台模式（3 行）：覆盖为 `grid-row: 3`。
- 创作模式：`.app--creation .statusbar { display: none; }`。

*移除 `position: fixed`*
- `:root[data-theme-style] .statusbar` 不再使用固定定位，Grid 行将其自然锚定在视口底部，主题视觉属性完整保留。

*清理冗余间距*
- 侧边栏底部 padding 从 `calc(12px + 30px)` 简化为 `12px`（3 处）。
- Workbench-dock 的 `padding-bottom: 30px` 移除。
- `:root[data-theme-style] .footer` 底部 padding 从 38px 降至 10px。
- Workspace-panel-resizer 高度从 `calc(100% - 30px)` 改为 `100%`。

*Footer 溢出保护*
- 添加 `max-height: calc(100% - var(--topicbar-height)); overflow-y: auto;`，保持 `flex: 0 0 auto`。日常使用时 composer 不受影响，决策卡片过高时 footer 出现滚动条。

**`desktop/frontend/src/__tests__/app-chrome-tabs.test.ts`**（2 行变更）
- Grid 断言更新。

### 相关 Issue

Fixes #7030

### 验证

- TypeScript 编译：✅
- CSS 语法检查：✅
- 测试全部通过
- Windows 11 下手动测试经典/工作台布局 × 多主题：无重叠、无多余空白、决策卡片可滚动、信息栏定位正确、创作模式不受影响。

### 缓存影响

Cache-impact: none
Cache-guard: N/A
System-prompt-review: N/A

---

### 效果展示

https://github.com/user-attachments/assets/e156dd65-108f-4a38-aadd-98e313c725e1