### PR TITLE
fix(desktop): separate terminal drawer from workspace dock, add resize handle and accordion animation / 终端独立为底部抽屉，添加拖拽调整和手风琴动画

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -151,12 +151,15 @@ import {
   type RightDockMode,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
+  TERMINAL_DEFAULT_HEIGHT,
+  TERMINAL_MIN_HEIGHT,
   applyLayoutStyleDefaults,
   clampCreationRightDockTreeWidth,
   clampCreationSidebarWidth,
   clampRightDockPreviewWidth,
   clampRightDockTreeWidth,
   clampSidebarWidth,
+  clampTerminalHeight,
   defaultCreationRightDockTreeWidth,
   defaultCreationSidebarWidth,
   defaultRightDockTreeWidth,
@@ -164,8 +167,10 @@ import {
   saveRightDockPreviewWidth,
   saveRightDockTreeWidth,
   saveSidebarCollapsed,
-  saveWorkspacePanelOpen,
   saveSidebarWidth,
+  saveTerminalHeight,
+  saveTerminalPanelOpen,
+  saveWorkspacePanelOpen,
   useLayoutStore,
 } from "./store/layout";
 import { useOverlayStore } from "./store/overlays";
@@ -1243,10 +1248,17 @@ export default function App() {
 
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);
   const [liveWorkspacePanelRenderWidth, setLiveWorkspacePanelRenderWidth] = useState<number | null>(null);
+  const [liveTerminalHeight, setLiveTerminalHeight] = useState<number | null>(null);
+  const [terminalContentVisible, setTerminalContentVisible] = useState(false);
+  const terminalResizing = liveTerminalHeight !== null;
   const workspacePanelMaximized = useLayoutStore((s) => s.workspacePanelMaximized);
   const setWorkspacePanelMaximized = useLayoutStore((s) => s.setWorkspacePanelMaximized);
   const rightDockMode = useLayoutStore((s) => s.rightDockMode);
   const setRightDockMode = useLayoutStore((s) => s.setRightDockMode);
+  const terminalPanelOpen = useLayoutStore((s) => s.terminalPanelOpen);
+  const setTerminalPanelOpen = useLayoutStore((s) => s.setTerminalPanelOpen);
+  const terminalHeight = useLayoutStore((s) => s.terminalHeight);
+  const setTerminalHeight = useLayoutStore((s) => s.setTerminalHeight);
   const [dockRefreshKey, setDockRefreshKey] = useState(0);
   const [fileRefRefreshKey, setFileRefRefreshKey] = useState(0);
   const refreshComposerFileRefs = useCallback(() => setFileRefRefreshKey((value) => value + 1), []);
@@ -1546,12 +1558,11 @@ export default function App() {
 
   const storedWorkspacePanelRenderWidth = workspacePanelMaximized ? preferredWorkspacePanelWidth : resolvedWorkspacePanelWidth;
   const workspacePanelRenderWidth = liveWorkspacePanelRenderWidth ?? storedWorkspacePanelRenderWidth;
-  // The terminal is a bottom drawer, so it must remain available even when a
-  // narrow window cannot satisfy the right-side workspace panel's width.
+  // The terminal is an independent bottom drawer; workspace panel renderability
+  // no longer depends on terminal mode.
   const workspacePanelRenderable =
     workspacePanelOpen && (
       workspacePanelMaximized ||
-      rightDockMode === "terminal" ||
       workspacePanelRenderWidth >= rightDockMinRenderWidth
     );
   const workspacePanelGridOpen = workspacePanelRenderable && !workspacePanelMaximized;
@@ -2683,6 +2694,63 @@ export default function App() {
     [rightDockDetailActive, rightDockTreeMinWidth, setSavedWorkspacePanelWidth, workspacePanelRenderWidth],
   );
 
+  const startTerminalResize = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!terminalPanelOpen) return;
+      const layout = layoutRef.current;
+      if (!layout) return;
+      event.preventDefault();
+      closeTransientOverlays();
+      const startY = event.clientY;
+      const startHeight = terminalHeight;
+      const viewportHeight = window.innerHeight;
+      let nextHeight = startHeight;
+      const liveResize = createRafResizeUpdater({
+        target: layout,
+        separator: event.currentTarget,
+        cssVar: "--terminal-height",
+        onApply: setLiveTerminalHeight,
+      });
+      const onMove = (moveEvent: PointerEvent) => {
+        const delta = startY - moveEvent.clientY;
+        nextHeight = clampTerminalHeight(startHeight + delta, viewportHeight);
+        liveResize.schedule(nextHeight);
+      };
+      const onDone = () => {
+        liveResize.flush();
+        setLiveTerminalHeight(null);
+        setTerminalHeight(nextHeight);
+        saveTerminalHeight(nextHeight);
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onDone);
+        window.removeEventListener("pointercancel", onDone);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onDone);
+      window.addEventListener("pointercancel", onDone);
+    },
+    [closeTransientOverlays, setLiveTerminalHeight, setTerminalHeight, terminalHeight, terminalPanelOpen],
+  );
+
+  // Manage terminal content visibility for open/close animation.
+  // On open: mount content immediately. On close: wait for the grid-template-rows
+  // transition to finish before unmounting.
+  const handleTerminalTransitionEnd = useCallback((event: React.TransitionEvent<HTMLDivElement>) => {
+    if (event.propertyName === "grid-template-rows" && !terminalPanelOpen) {
+      setTerminalContentVisible(false);
+    }
+  }, [terminalPanelOpen]);
+
+  useEffect(() => {
+    if (terminalPanelOpen) {
+      setTerminalContentVisible(true);
+    }
+  }, [terminalPanelOpen]);
+
   const openWorkspacePanel = useCallback(
     (mode: RightDockMode = rightDockMode) => {
       closeTransientOverlays();
@@ -2742,24 +2810,33 @@ export default function App() {
     [openWorkspacePanel],
   );
 
+  const toggleTerminalPanel = useCallback(() => {
+    setTerminalPanelOpen((prev) => {
+      const next = !prev;
+      saveTerminalPanelOpen(next);
+      return next;
+    });
+  }, [setTerminalPanelOpen]);
+
   const openTerminalForPath = useCallback(
     (path = ".") => {
-      openRightDockMode("terminal");
+      setTerminalPanelOpen(true);
+      saveTerminalPanelOpen(true);
       if (!activeTabId) return;
       void useTerminalStore.getState().createSession(activeTabId, path || ".", "default").catch(() => {});
     },
-    [activeTabId, openRightDockMode],
+    [activeTabId, setTerminalPanelOpen],
   );
 
   useGlobalShortcut("terminal.toggle", () => {
-    if (workspacePanelRenderable && rightDockMode === "terminal") closeWorkspacePanel();
-    else openRightDockMode("terminal");
-  }, [closeWorkspacePanel, openRightDockMode, rightDockMode, workspacePanelRenderable]);
+    toggleTerminalPanel();
+  }, [toggleTerminalPanel]);
   useGlobalShortcut("terminal.newSession", () => {
     if (!activeTabId) return;
-    openRightDockMode("terminal");
+    setTerminalPanelOpen(true);
+    saveTerminalPanelOpen(true);
     void useTerminalStore.getState().createSession(activeTabId, ".", "default").catch(() => {});
-  }, [activeTabId, openRightDockMode]);
+  }, [activeTabId, setTerminalPanelOpen]);
 
   useEffect(() => {
     if (!remoteExplorerOpen) return;
@@ -2861,8 +2938,9 @@ export default function App() {
         "--chat-min-width": `${chatReservedWidth}px`,
         "--workspace-width": `${workspacePanelRenderWidth}px`,
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
+        "--terminal-height": `${liveTerminalHeight ?? (terminalPanelOpen ? terminalHeight : 0)}px`,
       }) as CSSProperties,
-    [chatReservedWidth, sidebarRenderWidth, workspacePanelRenderWidth],
+    [chatReservedWidth, liveTerminalHeight, sidebarRenderWidth, terminalHeight, terminalPanelOpen, workspacePanelRenderWidth],
   );
 
   const setWorkspacePanel = useCallback((open: boolean) => {
@@ -3568,7 +3646,7 @@ export default function App() {
       },
       { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, compact: true, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
       { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, compact: true, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
-      { id: "cmd-terminal", group: t("palette.group.commands"), title: t("rightDock.terminal"), icon: <TerminalSquare size={15} />, compact: true, keywords: ["terminal", "shell", "终端"], run: () => openRightDockMode("terminal") },
+      { id: "cmd-terminal", group: t("palette.group.commands"), title: t("rightDock.terminal"), icon: <TerminalSquare size={15} />, compact: true, keywords: ["terminal", "shell", "终端"], run: () => toggleTerminalPanel() },
     ];
     const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
     const dayLabel = (ms: number) => {
@@ -3845,13 +3923,16 @@ export default function App() {
           sidebarCollapsed ? "layout--sidebar-collapsed" : "",
           sidebarResizing ? "layout--resizing layout--sidebar-resizing" : "",
           workspacePanelGridOpen ? "layout--workspace-open" : "",
-          workspacePanelGridOpen && rightDockMode === "terminal" ? "layout--terminal-open" : "",
+          "layout--terminal-drawer-open",
+          terminalPanelOpen ? "layout--terminal-drawer-expanded" : "",
+          terminalResizing ? "layout--terminal-resizing" : "",
           workspacePanelOpen && workspacePanelMaximized ? "layout--workspace-maximized" : "",
           workspacePanelResizing ? "layout--resizing layout--workspace-resizing" : "",
         ]
           .filter(Boolean)
           .join(" ")}
         style={layoutStyle}
+        onTransitionEnd={handleTerminalTransitionEnd}
       >
         {!appChromeHidden && (
           <AppChrome
@@ -4291,8 +4372,8 @@ export default function App() {
                     className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
                     type="button"
                     aria-label={t("rightDock.terminal")}
-                    aria-pressed={workspacePanelRenderable && rightDockMode === "terminal"}
-                    onClick={() => openRightDockMode("terminal")}
+                    aria-pressed={terminalPanelOpen}
+                    onClick={toggleTerminalPanel}
                   >
                     <TerminalSquare size={14} />
                   </button>
@@ -4421,7 +4502,7 @@ export default function App() {
           </main>
 
           {!sidebarImDetailConnection && (
-          <footer className="footer" ref={footerRef}>
+          <footer className={["footer", terminalPanelOpen && !sidebarCreation ? "footer--compact" : ""].filter(Boolean).join(" ")} ref={footerRef}>
             {showTodos && (
               <TodoPanel
                 key={scopedTodoBatch}
@@ -4644,9 +4725,9 @@ export default function App() {
                 <button
                   type="button"
                   role="tab"
-                  aria-selected={rightDockMode === "terminal"}
-                  className={`workbench-dock__tab${rightDockMode === "terminal" ? " workbench-dock__tab--active" : ""}`}
-                  onClick={() => openRightDockMode("terminal")}
+                  aria-selected={terminalPanelOpen}
+                  className={`workbench-dock__tab${terminalPanelOpen ? " workbench-dock__tab--active" : ""}`}
+                  onClick={toggleTerminalPanel}
                 >
                   <TerminalSquare size={13} />
                   <span className="workbench-dock__tab-label">{t("rightDock.terminal")}</span>
@@ -4657,16 +4738,6 @@ export default function App() {
               {rightDockMode === "remote" ? (
                 <Suspense fallback={null}>
                   <RemotePanel onClose={() => setWorkspacePanel(false)} />
-                </Suspense>
-              ) : rightDockMode === "terminal" ? (
-                <Suspense fallback={<div className="terminal-empty"><span className="terminal-empty__spinner" />{t("terminal.loading")}</div>}>
-                  <TerminalPanel
-                    tabId={activeTabId ?? ""}
-                    cwd={state.meta?.cwd}
-                    readOnly={Boolean(activeTab?.readOnly)}
-                    onClose={() => setWorkspacePanel(false)}
-                    onAddOutput={(sessionId) => void addTerminalOutputToComposer(sessionId)}
-                  />
                 </Suspense>
               ) : rightDockMode === "context" && desktopLayoutStyle !== "creation" ? (
                 <ContextPanel
@@ -4715,6 +4786,43 @@ export default function App() {
           </aside>
         )}
 
+        <>
+          <aside
+            className="terminal-drawer"
+            aria-label={t("terminal.title")}
+          >
+            {terminalContentVisible && (
+              <Suspense fallback={<div className="terminal-empty"><span className="terminal-empty__spinner" />{t("terminal.loading")}</div>}>
+                <TerminalPanel
+                  tabId={activeTabId ?? ""}
+                  cwd={state.meta?.cwd}
+                  readOnly={Boolean(activeTab?.readOnly)}
+                  onClose={() => {
+                    setTerminalPanelOpen(false);
+                    saveTerminalPanelOpen(false);
+                  }}
+                  onAddOutput={(sessionId) => void addTerminalOutputToComposer(sessionId)}
+                />
+              </Suspense>
+            )}
+          </aside>
+          <button
+            className="terminal-drawer-resizer"
+            type="button"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label={t("terminal.resize")}
+            aria-valuemin={TERMINAL_MIN_HEIGHT}
+            aria-valuemax={Math.floor(window.innerHeight * 0.5)}
+            aria-valuenow={terminalHeight}
+            onPointerDown={startTerminalResize}
+            onDoubleClick={() => {
+              setTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
+              saveTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
+            }}
+          />
+        </>
+
         {!sidebarImDetailConnection && (
           <StatusBar
             context={state.context}
@@ -4748,7 +4856,6 @@ export default function App() {
             }}
           />
         )}
-
       </div>
 
       {histView !== null && (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -170,6 +170,7 @@ import {
   saveSidebarWidth,
   saveTerminalHeight,
   saveTerminalPanelOpen,
+  terminalMaxHeight,
   saveWorkspacePanelOpen,
   useLayoutStore,
 } from "./store/layout";
@@ -1193,6 +1194,7 @@ export default function App() {
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [liveSidebarWidth, setLiveSidebarWidth] = useState<number | null>(null);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
+  const [viewportHeight, setViewportHeight] = useState(() => (typeof window === "undefined" ? 720 : window.innerHeight));
   const workspacePanelOpen = useLayoutStore((s) => s.workspacePanelOpen);
   const setWorkspacePanelOpen = useLayoutStore((s) => s.setWorkspacePanelOpen);
   const rightDockTreeWidth = useLayoutStore((s) => s.rightDockTreeWidth);
@@ -1495,7 +1497,10 @@ export default function App() {
   }, [closeTransientOverlays]);
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onResize = () => setViewportWidth(window.innerWidth);
+    const onResize = () => {
+      setViewportWidth(window.innerWidth);
+      setViewportHeight(window.innerHeight);
+    };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
@@ -2694,6 +2699,17 @@ export default function App() {
     [rightDockDetailActive, rightDockTreeMinWidth, setSavedWorkspacePanelWidth, workspacePanelRenderWidth],
   );
 
+  const terminalRenderHeight = clampTerminalHeight(terminalHeight, viewportHeight);
+  const terminalResizeMaxHeight = terminalMaxHeight(viewportHeight);
+  const setSavedTerminalHeight = useCallback(
+    (height: number) => {
+      const next = clampTerminalHeight(height, viewportHeight);
+      setTerminalHeight(next);
+      saveTerminalHeight(next);
+    },
+    [setTerminalHeight, viewportHeight],
+  );
+
   const startTerminalResize = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       if (!terminalPanelOpen) return;
@@ -2702,8 +2718,7 @@ export default function App() {
       event.preventDefault();
       closeTransientOverlays();
       const startY = event.clientY;
-      const startHeight = terminalHeight;
-      const viewportHeight = window.innerHeight;
+      const startHeight = terminalRenderHeight;
       let nextHeight = startHeight;
       const liveResize = createRafResizeUpdater({
         target: layout,
@@ -2719,8 +2734,7 @@ export default function App() {
       const onDone = () => {
         liveResize.flush();
         setLiveTerminalHeight(null);
-        setTerminalHeight(nextHeight);
-        saveTerminalHeight(nextHeight);
+        setSavedTerminalHeight(nextHeight);
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onDone);
         window.removeEventListener("pointercancel", onDone);
@@ -2733,7 +2747,24 @@ export default function App() {
       window.addEventListener("pointerup", onDone);
       window.addEventListener("pointercancel", onDone);
     },
-    [closeTransientOverlays, setLiveTerminalHeight, setTerminalHeight, terminalHeight, terminalPanelOpen],
+    [closeTransientOverlays, setLiveTerminalHeight, setSavedTerminalHeight, terminalPanelOpen, terminalRenderHeight, viewportHeight],
+  );
+
+  const resizeTerminalWithKeyboard = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (!terminalPanelOpen) return;
+      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+        event.preventDefault();
+        setSavedTerminalHeight(terminalRenderHeight + (event.key === "ArrowUp" ? 16 : -16));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setSavedTerminalHeight(TERMINAL_MIN_HEIGHT);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setSavedTerminalHeight(terminalResizeMaxHeight);
+      }
+    },
+    [setSavedTerminalHeight, terminalPanelOpen, terminalRenderHeight, terminalResizeMaxHeight],
   );
 
   // Manage terminal content visibility for open/close animation.
@@ -2938,9 +2969,9 @@ export default function App() {
         "--chat-min-width": `${chatReservedWidth}px`,
         "--workspace-width": `${workspacePanelRenderWidth}px`,
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
-        "--terminal-height": `${liveTerminalHeight ?? (terminalPanelOpen ? terminalHeight : 0)}px`,
+        "--terminal-height": `${liveTerminalHeight ?? (terminalPanelOpen ? terminalRenderHeight : 0)}px`,
       }) as CSSProperties,
-    [chatReservedWidth, liveTerminalHeight, sidebarRenderWidth, terminalHeight, terminalPanelOpen, workspacePanelRenderWidth],
+    [chatReservedWidth, liveTerminalHeight, sidebarRenderWidth, terminalPanelOpen, terminalRenderHeight, workspacePanelRenderWidth],
   );
 
   const setWorkspacePanel = useCallback((open: boolean) => {
@@ -4813,12 +4844,14 @@ export default function App() {
             aria-orientation="horizontal"
             aria-label={t("terminal.resize")}
             aria-valuemin={TERMINAL_MIN_HEIGHT}
-            aria-valuemax={Math.floor(window.innerHeight * 0.5)}
-            aria-valuenow={terminalHeight}
+            aria-valuemax={terminalResizeMaxHeight}
+            aria-valuenow={liveTerminalHeight ?? terminalRenderHeight}
+            aria-hidden={!terminalPanelOpen}
+            tabIndex={terminalPanelOpen ? 0 : -1}
             onPointerDown={startTerminalResize}
+            onKeyDown={resizeTerminalWithKeyboard}
             onDoubleClick={() => {
-              setTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
-              saveTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
+              setSavedTerminalHeight(TERMINAL_DEFAULT_HEIGHT);
             }}
           />
         </>

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -9,6 +9,10 @@ import {
   resolveWorkspacePanelWidth,
   workspacePanelAriaMinWidth,
 } from "../lib/workspaceLayout";
+import {
+  clampTerminalHeight,
+  terminalMaxHeight,
+} from "../store/layout";
 
 let passed = 0;
 let failed = 0;
@@ -149,6 +153,10 @@ eq(
   212,
   "live sidebar drag recomputes dock width from the dragged sidebar width",
 );
+eq(terminalMaxHeight(480), 240, "terminal maximum follows half of the current viewport height");
+eq(terminalMaxHeight(180), 120, "terminal maximum never falls below the accessible minimum");
+eq(clampTerminalHeight(680, 480), 240, "restored terminal height clamps after the window shrinks");
+eq(clampTerminalHeight(80, 720), 120, "terminal height clamps to its minimum");
 eq(
   /const closeWorkspacePanel = useCallback\(\(\) => \{[\s\S]*?setLiveWorkspacePanelRenderWidth\(null\);[\s\S]*?setWorkspacePanelOpen\(false\);[\s\S]*?saveWorkspacePanelOpen\(false\);/.test(appSource),
   true,
@@ -180,9 +188,28 @@ eq(
   "terminal-drawer-open layout reserves a grid row for the status bar below the terminal drawer",
 );
 eq(
-  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-drawer-open \.terminal-drawer[\s\S]*?display: flex !important[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-drawer-open[\s\S]*?minmax\(0, 1fr\) var\(--terminal-height, 280px\) var\(--statusbar-height\)/.test(stylesSource),
+  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-drawer-open \.terminal-drawer-resizer[\s\S]*?grid-column: 1 !important[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-drawer-open \.terminal-drawer[\s\S]*?grid-row: 2;[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-drawer-open[\s\S]*?minmax\(0, 1fr\) var\(--terminal-height, 280px\) var\(--statusbar-height\)/.test(stylesSource),
   true,
-  "narrow viewport shows terminal drawer with status bar row below",
+  "narrow viewport keeps the resizer and drawer in the content column above the status bar",
+);
+eq(
+  /const terminalRenderHeight = clampTerminalHeight\(terminalHeight, viewportHeight\)/.test(appSource)
+    && /"--terminal-height": `\$\{liveTerminalHeight \?\? \(terminalPanelOpen \? terminalRenderHeight : 0\)\}px`/.test(appSource),
+  true,
+  "terminal render height re-clamps whenever the viewport changes",
+);
+eq(
+  /aria-hidden=\{!terminalPanelOpen\}/.test(appSource)
+    && /tabIndex=\{terminalPanelOpen \? 0 : -1\}/.test(appSource)
+    && /onKeyDown=\{resizeTerminalWithKeyboard\}/.test(appSource),
+  true,
+  "closed terminal resizer leaves the tab order and open resizer supports keyboard adjustment",
+);
+eq(
+  /terminalPanelOpen && !sidebarCreation \? "footer--compact" : ""/.test(appSource)
+    && !/\.layout\.layout--terminal-drawer-open \.footer/.test(stylesSource),
+  true,
+  "footer compaction applies only while the terminal is expanded outside Creation mode",
 );
 eq(
   /sidebarImDetailConnection \? "layout--statusbar-hidden" : ""/.test(appSource)

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -160,9 +160,9 @@ eq(
   "opening the dock persists the expanded preference for the next launch",
 );
 eq(
-  /rightDockMode === "terminal"[\s\S]*?workspacePanelRenderWidth >= rightDockMinRenderWidth/.test(appSource),
+  /terminalPanelOpen[\s\S]*?terminal-drawer/.test(appSource),
   true,
-  "terminal remains renderable when a narrow viewport cannot fit the side dock",
+  "terminal drawer is an independent panel, not a workspace dock mode",
 );
 eq(
   /const addTerminalOutputToComposer = useCallback\(async \(sessionId: string\) => \{[\s\S]*?app\.TerminalOutputForTab\(activeTabId, sessionId\)[\s\S]*?addWorkspaceTextToComposer\(/.test(appSource),
@@ -170,19 +170,19 @@ eq(
   "terminal output reaches chat only through the explicit add-output action",
 );
 eq(
-  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-open \.workbench-dock[\s\S]*?display: flex !important/.test(stylesSource),
+  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-drawer-open \.terminal-drawer[\s\S]*?display: flex !important/.test(stylesSource),
   true,
   "terminal drawer stays visible on narrow viewports",
 );
 eq(
-  /\.layout--terminal-open \{[\s\S]*?grid-template-rows: var\(--app-chrome-height\) minmax\(0, 1fr\) minmax\(220px, min\(42vh, 440px\)\) var\(--statusbar-height\)/.test(stylesSource),
+  /\.layout--terminal-drawer-open \{[\s\S]*?grid-template-rows: var\(--app-chrome-height\) minmax\(0, 1fr\) var\(--terminal-height, 280px\) var\(--statusbar-height\)/.test(stylesSource),
   true,
-  "terminal-open layout reserves a grid row for the status bar below the terminal drawer",
+  "terminal-drawer-open layout reserves a grid row for the status bar below the terminal drawer",
 );
 eq(
-  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-open \.workbench-dock,[\s\S]*?grid-row: 3;[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-open \.workbench-dock,[\s\S]*?grid-row: 2;/.test(stylesSource),
+  /@media \(max-width: 820px\) \{[\s\S]*?\.layout--terminal-drawer-open \.terminal-drawer[\s\S]*?display: flex !important[\s\S]*?\.layout--workbench-chrome-hidden\.layout--terminal-drawer-open[\s\S]*?minmax\(0, 1fr\) var\(--terminal-height, 280px\) var\(--statusbar-height\)/.test(stylesSource),
   true,
-  "narrow classic terminal stays below chat while chrome-hidden terminal uses row two",
+  "narrow viewport shows terminal drawer with status bar row below",
 );
 eq(
   /sidebarImDetailConnection \? "layout--statusbar-hidden" : ""/.test(appSource)
@@ -191,19 +191,23 @@ eq(
   "IM detail collapses the status bar row when the bar is not rendered",
 );
 eq(
+  /\.layout--terminal-drawer-expanded \.terminal-drawer \{[\s\S]*?border-top: 1px solid var\(--border-soft\)/.test(stylesSource),
+  true,
+  "terminal drawer has a top border only when expanded, avoiding a collapsed artifact line",
+);
+eq(
   /\.sidebar--workbench \{[\s\S]*?padding: 16px 16px 10px;/.test(stylesSource)
     && /\.app--darwin \.sidebar--workbench,\s*\.sidebar--workbench \{[\s\S]*?padding: 14px 12px 10px;/.test(stylesSource),
   true,
   "workbench sidebar does not reserve the docked status bar twice",
 );
 eq(
-  /\.layout--terminal-open \.workbench-dock__tools \{\s*display: none;\s*\}/.test(stylesSource),
+  /workbench-dock__tab[\s\S]*?terminalPanelOpen/.test(appSource),
   true,
-  "terminal drawer hides the redundant workspace tab strip",
+  "terminal tab in workspace dock toggles the independent terminal panel, not rightDockMode",
 );
 eq(
-  /\.app--creation \.layout--creation-chrome-hidden\.layout--terminal-open \{[\s\S]*?grid-template-rows: minmax\(0, 1fr\) minmax\(220px, min\(42vh, 440px\)\)/.test(stylesSource)
-    && /\.app--creation \.layout--creation-chrome-hidden\.layout--terminal-open \.workbench-dock \{[\s\S]*?grid-row: 2/.test(stylesSource),
+  /\.app--creation \.layout\.layout--creation-chrome-hidden\.layout--terminal-drawer-open \{[\s\S]*?grid-template-rows: minmax\(0, 1fr\) var\(--terminal-height, 280px\)/.test(stylesSource),
   true,
   "creation style keeps the terminal drawer below the chat pane",
 );

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -250,6 +250,7 @@ export const en = {
   "terminal.loading": "Loading terminal…",
   "terminal.retry": "Retry",
   "terminal.dismissError": "Dismiss terminal error",
+  "terminal.resize": "Resize terminal height",
   "terminal.empty": "Start a shell in this workspace.",
   "terminal.readOnly": "This channel is read-only.",
   "terminal.addOutput": "Add terminal output to chat",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2127,6 +2127,7 @@ export const zhTW: Record<DictKey, string> = {
   "terminal.loading": "正在載入終端機…",
   "terminal.retry": "重試",
   "terminal.dismissError": "關閉終端機錯誤提示",
+  "terminal.resize": "調整終端機高度",
   "terminal.empty": "在目前工作區啟動 shell。",
   "terminal.readOnly": "此頻道為唯讀。",
   "terminal.addOutput": "將終端機輸出加入聊天",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -251,6 +251,7 @@ export const zh: Record<DictKey, string> = {
   "terminal.loading": "正在加载终端…",
   "terminal.retry": "重试",
   "terminal.dismissError": "关闭终端错误提示",
+  "terminal.resize": "调整终端高度",
   "terminal.empty": "在当前工作区启动一个 shell。",
   "terminal.readOnly": "此频道为只读。",
   "terminal.addOutput": "将终端输出加入聊天",

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -193,8 +193,12 @@ export function saveTerminalHeight(height: number): void {
   }
 }
 
+export function terminalMaxHeight(viewportHeight: number): number {
+  return Math.max(TERMINAL_MIN_HEIGHT, Math.floor(Math.max(0, viewportHeight) * TERMINAL_MAX_HEIGHT_RATIO));
+}
+
 export function clampTerminalHeight(height: number, viewportHeight: number): number {
-  const max = Math.floor(viewportHeight * TERMINAL_MAX_HEIGHT_RATIO);
+  const max = terminalMaxHeight(viewportHeight);
   return Math.min(max, Math.max(TERMINAL_MIN_HEIGHT, Math.round(height)));
 }
 

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -138,7 +138,65 @@ export function saveRightDockPreviewWidth(width: number): void {
 // dock survives restart. maximized/preview stay session-local — they are view
 // layout, not a durable preference. (Resize drag flags, button-press animation
 // flags, measured footer height, and viewport width stay as useState in App.tsx.)
-export type RightDockMode = "context" | "files" | "changed" | "remote" | "terminal";
+export type RightDockMode = "context" | "files" | "changed" | "remote";
+
+// terminalPanelOpen is independent from rightDockMode — the terminal is a
+// bottom drawer that coexists with the workspace panel, not a mode of it.
+// Persisted to localStorage so it survives restart.
+const TERMINAL_PANEL_OPEN_KEY = "reasonix.terminalPanel.open";
+const TERMINAL_PANEL_DEFAULT_OPEN = false;
+
+function loadTerminalPanelOpen(): boolean {
+  if (typeof window === "undefined") return TERMINAL_PANEL_DEFAULT_OPEN;
+  try {
+    return window.localStorage.getItem(TERMINAL_PANEL_OPEN_KEY) === "1";
+  } catch {
+    return TERMINAL_PANEL_DEFAULT_OPEN;
+  }
+}
+
+export function saveTerminalPanelOpen(open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TERMINAL_PANEL_OPEN_KEY, open ? "1" : "0");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+// Terminal height defaults and clamps for the bottom drawer.
+export const TERMINAL_DEFAULT_HEIGHT = 280;
+export const TERMINAL_MIN_HEIGHT = 120;
+export const TERMINAL_MAX_HEIGHT_RATIO = 0.5; // max 50% of viewport height
+
+const TERMINAL_HEIGHT_KEY = "reasonix.terminalPanel.height";
+
+function loadTerminalHeight(): number {
+  if (typeof window === "undefined") return TERMINAL_DEFAULT_HEIGHT;
+  try {
+    const raw = window.localStorage.getItem(TERMINAL_HEIGHT_KEY);
+    if (raw === null) return TERMINAL_DEFAULT_HEIGHT;
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= TERMINAL_MIN_HEIGHT) return parsed;
+    return TERMINAL_DEFAULT_HEIGHT;
+  } catch {
+    return TERMINAL_DEFAULT_HEIGHT;
+  }
+}
+
+export function saveTerminalHeight(height: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TERMINAL_HEIGHT_KEY, String(Math.round(height)));
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+export function clampTerminalHeight(height: number, viewportHeight: number): number {
+  const max = Math.floor(viewportHeight * TERMINAL_MAX_HEIGHT_RATIO);
+  return Math.min(max, Math.max(TERMINAL_MIN_HEIGHT, Math.round(height)));
+}
 
 function loadWorkspacePanelOpen(): boolean {
   if (typeof window === "undefined") return WORKSPACE_PANEL_DEFAULT_OPEN;
@@ -169,6 +227,8 @@ export type LayoutState = {
   workspacePanelMaximized: boolean;
   workspacePreviewActive: boolean;
   rightDockMode: RightDockMode;
+  terminalPanelOpen: boolean;
+  terminalHeight: number;
   setSidebarCollapsed: (collapsed: boolean) => void;
   setSidebarWidth: (width: number) => void;
   setRightDockTreeWidth: (width: number) => void;
@@ -177,6 +237,8 @@ export type LayoutState = {
   setWorkspacePanelMaximized: Dispatch<SetStateAction<boolean>>;
   setWorkspacePreviewActive: Dispatch<SetStateAction<boolean>>;
   setRightDockMode: Dispatch<SetStateAction<RightDockMode>>;
+  setTerminalPanelOpen: Dispatch<SetStateAction<boolean>>;
+  setTerminalHeight: (height: number) => void;
 };
 
 export const useLayoutStore = create<LayoutState>((set) => ({
@@ -188,6 +250,8 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   workspacePanelMaximized: false,
   workspacePreviewActive: false,
   rightDockMode: "context",
+  terminalPanelOpen: loadTerminalPanelOpen(),
+  terminalHeight: loadTerminalHeight(),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   setSidebarWidth: (width) => set({ sidebarWidth: width }),
   setRightDockTreeWidth: (width) => set({ rightDockTreeWidth: width }),
@@ -196,6 +260,8 @@ export const useLayoutStore = create<LayoutState>((set) => ({
   setWorkspacePanelMaximized: (update) => set((s) => ({ workspacePanelMaximized: applySetState(s.workspacePanelMaximized, update) })),
   setWorkspacePreviewActive: (update) => set((s) => ({ workspacePreviewActive: applySetState(s.workspacePreviewActive, update) })),
   setRightDockMode: (update) => set((s) => ({ rightDockMode: applySetState(s.rightDockMode, update) })),
+  setTerminalPanelOpen: (update) => set((s) => ({ terminalPanelOpen: applySetState(s.terminalPanelOpen, update) })),
+  setTerminalHeight: (height) => set({ terminalHeight: height }),
 }));
 
 export function applyLayoutStyleDefaults(style: "classic" | "workbench" | "creation"): void {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2100,11 +2100,6 @@ a[href] {
 .layout--terminal-resizing.layout--terminal-drawer-open {
   transition: grid-template-columns 0.16s ease, min-width 0.16s ease;
 }
-/* When the terminal occupies the bottom, the status bar sits between the
-   composer and the terminal — reduce only the footer bottom padding. */
-.layout.layout--terminal-drawer-open .footer {
-  padding-bottom: 4px;
-}
 .layout--terminal-drawer-open .terminal-drawer-resizer {
   grid-row: 2;
   grid-column: 2;
@@ -33313,6 +33308,18 @@ body > .mermaid-diagram--fullscreen {
     display: flex !important;
     grid-column: 1 !important;
     grid-row: 3;
+  }
+
+  .app .layout--terminal-drawer-open .terminal-drawer-resizer,
+  :root[data-theme-style] .app .layout--terminal-drawer-open .terminal-drawer-resizer {
+    grid-column: 1 !important;
+  }
+
+  .app .layout--workbench-chrome-hidden.layout--terminal-drawer-open .terminal-drawer,
+  :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-drawer-open .terminal-drawer,
+  .app--creation .layout--creation-chrome-hidden.layout--terminal-drawer-open .terminal-drawer,
+  :root[data-theme-style] .app--creation .layout--creation-chrome-hidden.layout--terminal-drawer-open .terminal-drawer {
+    grid-row: 2;
   }
 
   .app .layout--workbench-chrome-hidden.layout--terminal-drawer-open,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2015,6 +2015,7 @@ a[href] {
   --chat-min-width: 760px;
   --workspace-width: 420px;
   --workspace-resizer-width: 8px;
+  --terminal-height: 280px;
   --app-chrome-height: 38px;
   --topicbar-height: 56px;
   --statusbar-height: var(--statusbar-dock-height);
@@ -2088,6 +2089,107 @@ a[href] {
 .layout--workspace-maximized.layout--sidebar-collapsed {
   grid-template-columns: 0px minmax(0, 1fr);
 }
+/* Terminal drawer — an independent bottom panel below the chat pane.
+   Sidebar and workspace panel stay full-height in columns 1 and 3;
+   the terminal occupies column 2 row 3, statusbar at row 4. */
+.layout--terminal-drawer-open {
+  grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) var(--terminal-height, 280px) var(--statusbar-height);
+  transition: grid-template-columns 0.16s ease, min-width 0.16s ease, grid-template-rows 0.25s ease;
+}
+/* Disable the open/close transition during a terminal resize drag. */
+.layout--terminal-resizing.layout--terminal-drawer-open {
+  transition: grid-template-columns 0.16s ease, min-width 0.16s ease;
+}
+/* When the terminal occupies the bottom, the status bar sits between the
+   composer and the terminal — reduce only the footer bottom padding. */
+.layout.layout--terminal-drawer-open .footer {
+  padding-bottom: 4px;
+}
+.layout--terminal-drawer-open .terminal-drawer-resizer {
+  grid-row: 2;
+  grid-column: 2;
+  align-self: end;
+  position: relative;
+  height: 8px;
+  width: 100%;
+  cursor: row-resize;
+  z-index: var(--z-local-handle);
+  background: transparent;
+  border: 0;
+  margin-bottom: -4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, background 0.12s ease;
+}
+/* Show the resizer only when the terminal is actually expanded. */
+.layout--terminal-drawer-expanded .terminal-drawer-resizer {
+  opacity: 1;
+  pointer-events: auto;
+}
+.layout--terminal-drawer-open .terminal-drawer-resizer:hover,
+.layout--terminal-drawer-open .terminal-drawer-resizer:active {
+  background: var(--accent-soft);
+}
+.layout--terminal-drawer-open .terminal-drawer {
+  grid-row: 3;
+  grid-column: 2;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+/* Border and background only visible when the terminal is actually expanded,
+   avoiding a 1px artifact line when the drawer is collapsed to 0px. */
+.layout--terminal-drawer-expanded .terminal-drawer {
+  background: var(--terminal-bg, #111315);
+  border-top: 1px solid var(--border-soft);
+}
+.layout--terminal-drawer-open .terminal-drawer .terminal-panel {
+  height: 100%;
+}
+.layout--terminal-drawer-open .terminal-drawer .terminal-panel__header {
+  border-bottom: 1px solid var(--border-soft);
+}
+/* When the terminal drawer is open, the sidebar and workspace panel span the
+   full content height (rows 2–3) so only the chat pane is shortened. */
+.layout.layout--terminal-drawer-open .sidebar {
+  grid-row: 2 / 4;
+}
+.layout.layout--terminal-drawer-open .workbench-dock {
+  grid-row: 2 / 4;
+}
+/* Chrome-hidden variants: rows shift up by one (3 rows total: content, terminal, statusbar). */
+.layout.layout--workbench-chrome-hidden.layout--terminal-drawer-open .sidebar {
+  grid-row: 1 / 3 !important;
+}
+.layout.layout--workbench-chrome-hidden.layout--terminal-drawer-open .workbench-dock {
+  grid-row: 1 / 3 !important;
+}
+.app--creation .layout.layout--creation-chrome-hidden.layout--terminal-drawer-open .sidebar {
+  grid-row: 1 / 3 !important;
+}
+.app--creation .layout.layout--creation-chrome-hidden.layout--terminal-drawer-open .workbench-dock {
+  grid-row: 1 / 3 !important;
+}
+.layout.layout--workbench-chrome-hidden.layout--terminal-drawer-open {
+  grid-template-rows: minmax(0, 1fr) var(--terminal-height, 280px) var(--statusbar-height) !important;
+  transition: grid-template-columns 0.16s ease, min-width 0.16s ease, grid-template-rows 0.25s ease !important;
+}
+.app--creation .layout.layout--creation-chrome-hidden.layout--terminal-drawer-open {
+  grid-template-rows: minmax(0, 1fr) var(--terminal-height, 280px) !important;
+  transition: grid-template-columns 0.16s ease, min-width 0.16s ease, grid-template-rows 0.25s ease !important;
+}
+/* StatusBar shifts to row 4 when the terminal drawer adds an extra row. */
+.layout--terminal-drawer-open .statusbar {
+  grid-row: 4;
+}
+.layout--workbench-chrome-hidden.layout--terminal-drawer-open .statusbar {
+  grid-row: 3;
+}
+
+/* Keep the old layout--terminal-open rules for backward compat — they are
+   no longer added by App.tsx but may remain in cached localStorage styles. */
 .layout--terminal-open {
   grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
   grid-template-rows: var(--app-chrome-height) minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-height);
@@ -2148,6 +2250,18 @@ a[href] {
 .layout--workbench-chrome-hidden .context-inspector,
 .layout--workbench-chrome-hidden .workbench-dock {
   grid-row: 1;
+}
+.layout--workbench-chrome-hidden .terminal-drawer-resizer {
+  grid-row: 1;
+}
+.layout--workbench-chrome-hidden .terminal-drawer {
+  grid-row: 2;
+}
+.app--creation .layout--creation-chrome-hidden .terminal-drawer-resizer {
+  grid-row: 1;
+}
+.app--creation .layout--creation-chrome-hidden .terminal-drawer {
+  grid-row: 2;
 }
 
 .layout--workbench-chrome-hidden .statusbar {
@@ -33194,21 +33308,16 @@ body > .mermaid-diagram--fullscreen {
     display: none !important;
   }
 
-  .app .layout--terminal-open .workbench-dock,
-  :root[data-theme-style] .app .layout--terminal-open .workbench-dock {
+  .app .layout--terminal-drawer-open .terminal-drawer,
+  :root[data-theme-style] .app .layout--terminal-drawer-open .terminal-drawer {
     display: flex !important;
     grid-column: 1 !important;
     grid-row: 3;
   }
 
-  .app .layout--workbench-chrome-hidden.layout--terminal-open,
-  :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-open {
-    grid-template-rows: minmax(0, 1fr) minmax(220px, min(42vh, 440px)) var(--statusbar-height);
-  }
-
-  .app .layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock,
-  :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-open .workbench-dock {
-    grid-row: 2;
+  .app .layout--workbench-chrome-hidden.layout--terminal-drawer-open,
+  :root[data-theme-style] .app .layout--workbench-chrome-hidden.layout--terminal-drawer-open {
+    grid-template-rows: minmax(0, 1fr) var(--terminal-height, 280px) var(--statusbar-height);
   }
 
   .app .chat-pane,
@@ -36012,4 +36121,13 @@ body > .mermaid-diagram--fullscreen {
     width: auto;
     height: 3px;
   }
+}
+
+/* Terminal-drawer footer compaction (terminal is open + non-Creation layout).
+   !important is necessary because the footer padding is set by multiple theme /
+   media-query rules with varying specificity that are hard to predict.
+   Keep the top spacing (composer→statusbar) intact; only reduce the bottom
+   padding that would otherwise waste space between the status bar and terminal. */
+.footer.footer--compact {
+  padding-bottom: 4px !important;
 }


### PR DESCRIPTION
## Summary

This PR fixes two layout bugs in the integrated terminal and re-architects the terminal as an independent bottom drawer that coexists with the workspace panel. Rebased onto latest main-v2 (includes #7069 status bar grid-row refactor).

### Changes

**Architecture** (`store/layout.ts`, `App.tsx`)
- Removed `"terminal"` from `RightDockMode`. The terminal is no longer a mode of the right dock — it is an independent bottom drawer controlled by a new `terminalPanelOpen` state with its own `terminalHeight` (persisted to localStorage).
- Added `liveTerminalHeight` state (mirroring the existing `liveSidebarWidth` pattern) so the resize drag stays in sync with React re-renders.
- The terminal DOM elements (`.terminal-drawer` + `.terminal-drawer-resizer`) are separate from `<aside class="workbench-dock">`, allowing the workspace panel to stay open showing files/context/changes while the terminal is visible.

**Layout** (`styles.css`)
- Replaced the conflicting `layout--workspace-open` + `layout--terminal-open` dual-class grid with `layout--terminal-drawer-open` (always on the layout div) + `layout--terminal-drawer-expanded` (toggled by `terminalPanelOpen`).
- The base grid has 3 rows (app-chrome, content, statusbar). When the terminal opens, the grid expands to 4 rows (app-chrome, content, terminal, statusbar). The terminal row height is controlled by `--terminal-height` CSS variable (0px when closed, stored value when open).
- `transition: grid-template-rows 0.25s ease` provides accordion open/close animation. Disabled during drag resize via `layout--terminal-resizing`.
- Sidebar and workspace panel span rows 2–3 (`grid-row: 2 / 4`) so they stay full-height when the terminal is open, ending at the status bar's top edge; only the chat pane is shortened.
- Added `layout--terminal-drawer-open .statusbar { grid-row: 4; }` so the status bar shifts below the terminal drawer without overlap.
- Added `.terminal-drawer-resizer` — a horizontal drag handle between the chat pane and terminal. Uses `createRafResizeUpdater` with `onApply` (same pattern as sidebar/workspace resizers).
- Footer compacts via `.footer--compact` class when the terminal is open (reduces `padding-bottom` to 4px), eliminating wasted space between the composer and the terminal. Skipped in Creation mode.
- All chrome-hidden grid rules use `!important` to override theme/media-query rules that would otherwise collapse the terminal row.
- Mobile breakpoint (`max-width: 820px`) updated to reference `.terminal-drawer` instead of `.workbench-dock`, with the full 3-row grid (content, terminal, statusbar).

**i18n** (`locales/en.ts`, `zh.ts`, `zh-TW.ts`)
- Added `terminal.resize` key for the resize handle ARIA label.

**Tests** (`workspace-layout.test.ts`)
- Updated 31 layout contract tests: removed checks for the old `rightDockMode === "terminal"` pattern, added checks for `terminalPanelOpen` independence, updated CSS selector regexes to match the new class names and the 4-row grid with status bar.

### Terminal tab in workspace dock

The terminal tab button in the right dock toolbar is intentionally preserved. It toggles `terminalPanelOpen` (the independent drawer) rather than changing `rightDockMode`. This keeps the terminal discoverable from the right panel while remaining functionally separate from the workspace panel modes.

### Conflict resolution with #7069

PR #7069 (status bar grid-row refactor) was merged after this branch was created. The rebase reconciled the two approaches: the status bar remains a dedicated grid row (per #7069), and the terminal drawer occupies the row between the content area and the status bar. The `padding-bottom: var(--statusbar-height)` on the terminal drawer was removed since the status bar now occupies its own grid row, and the sidebar/workbench-dock naturally end at the status bar's top edge via their `grid-row: 2 / 4` span.

## Issues

Fixes #7046
Fixes #7047
Fixes #7075 

## Verification

- Built and tested on Windows amd64 with Wails v2.13.0.
- Verified in all three desktop layout styles (Classic, Workbench, Creation):
  - Terminal opens/closes correctly coexisting with the workspace panel.
  - Resize handle works (drag to adjust height, double-click to reset).
  - Accordion animation plays on open and close.
  - Footer compacts when terminal is open (Classic/Workbench).
  - Status bar remains at the bottom with no overlap from sidebar, workspace panel, or terminal drawer.
- Frontend checks: `tsc --noEmit` ✓, CSS syntax ✓
- Frontend tests: 31/31 workspace-layout tests pass ✓
- `go vet ./...` ✓

## Cache impact

Cache-impact: none — desktop frontend-only changes, no provider-visible system prompt, memory prefix, output style, tool schema, or skill index changes.

Cache-guard: desktop-only layout/CSS changes; no files under internal/boot/, internal/tool/, internal/provider/, or other cache-sensitive paths modified

System-prompt-review: N/A

---

## 摘要

本 PR 修复了集成终端的两个布局缺陷，并将终端重新架构为独立于右侧工作区面板的底部抽屉。已变基到最新 main-v2（包含 #7069 状态栏 Grid 行重构）。

### 修改

**架构** (`store/layout.ts`, `App.tsx`)
- 从 `RightDockMode` 中移除 `"terminal"`。终端不再是右侧面板的一个模式，而是由独立的 `terminalPanelOpen` 状态控制的底部抽屉，拥有独立的 `terminalHeight`（持久化到 localStorage）。
- 新增 `liveTerminalHeight` 状态（模仿已有的 `liveSidebarWidth` 模式），确保拖拽调整大小时与 React 重渲染保持同步。
- 终端 DOM 元素（`.terminal-drawer` + `.terminal-drawer-resizer`）从 `<aside class="workbench-dock">` 中分离，使右侧面板可以在终端可见时继续显示文件/上下文/改动等内容。

**布局** (`styles.css`)
- 将冲突的 `layout--workspace-open` + `layout--terminal-open` 双类 grid 替换为 `layout--terminal-drawer-open`（始终在 layout div 上）+ `layout--terminal-drawer-expanded`（由 `terminalPanelOpen` 切换）。
- 基础 Grid 为 3 行（顶部栏、内容区、状态栏）。终端打开时扩展为 4 行（顶部栏、内容区、终端、状态栏）。终端行高度由 `--terminal-height` CSS 变量控制（关闭时为 0px，打开时为存储值）。
- `transition: grid-template-rows 0.25s ease` 提供手风琴开/关动画。拖拽调整大小时通过 `layout--terminal-resizing` 禁用过渡。
- 侧边栏和工作区面板跨越第 2–3 行（`grid-row: 2 / 4`），在终端打开时保持全高，底部刚好到状态栏顶部；仅聊天面板被缩短。
- 新增 `layout--terminal-drawer-open .statusbar { grid-row: 4; }`，使状态栏在终端打开时自动下移，不与终端重叠。
- 新增 `.terminal-drawer-resizer`——聊天面板与终端之间的水平拖拽手柄。使用 `createRafResizeUpdater` 配合 `onApply`（与侧边栏/工作区拖拽手柄相同的模式）。
- 终端打开时通过 `.footer--compact` 类压缩 footer（将 `padding-bottom` 减至 4px），消除输入框与终端之间的浪费空间。创作风格下跳过此压缩。
- 所有 chrome-hidden grid 规则使用 `!important`，以覆盖可能将终端行折叠的主题/媒体查询规则。
- 移动端断点（`max-width: 820px`）更新为引用 `.terminal-drawer` 替代 `.workbench-dock`，包含完整的 3 行 grid（内容区、终端、状态栏）。

**国际化** (`locales/en.ts`, `zh.ts`, `zh-TW.ts`)
- 为拖拽手柄 ARIA 标签添加 `terminal.resize` 键。

**测试** (`workspace-layout.test.ts`)
- 更新 31 个布局契约测试：移除对旧 `rightDockMode === "terminal"` 模式的检查，添加对 `terminalPanelOpen` 独立性的检查，更新 CSS 选择器正则表达式以匹配新类名和含状态栏的 4 行 Grid。

### 关于右侧面板中的终端标签

有意保留了右侧面板工具栏中的终端标签按钮。它切换的是 `terminalPanelOpen`（独立抽屉），而非改变 `rightDockMode`。这样终端可以从右侧面板被发现，同时在功能上保持与工作区面板模式的分离。

### 与 #7069 的冲突解决

PR #7069（状态栏 Grid 行重构）在本分支创建后被合并。变基时协调了两种方案：状态栏保持为独立 Grid 行（按 #7069 方案），终端抽屉占据内容区和状态栏之间的行。终端抽屉上原有的 `padding-bottom: var(--statusbar-height)` 已删除（状态栏现占用自己的 Grid 行），侧边栏和工作区面板通过 `grid-row: 2 / 4` 自然终止于状态栏顶部边缘。

## 相关 Issue

Fixes #7046
Fixes #7047
Fixes #7075 

## 验证

- 在 Windows amd64 上使用 Wails v2.13.0 构建并测试。
- 在三种桌面布局风格（经典、工作台、创作）下验证：
  - 终端与工作区面板共存，正常开/关。
  - 拖拽手柄可用（拖拽调整高度、双击重置）。
  - 手风琴动画在打开和关闭时播放。
  - 终端打开时 footer 压缩（经典/工作台风格）。
  - 状态栏始终在底部，侧边栏、工作区面板、终端抽屉均不与状态栏重叠。
- 前端检查：`tsc --noEmit` ✓，CSS 语法 ✓
- 前端测试：31/31 工作区布局测试通过 ✓
- `go vet ./...` ✓

## 缓存影响

Cache-impact: none — 仅桌面前端修改，不影响 provider 可见的系统提示词、记忆前缀、输出样式、工具 schema 或技能索引。

Cache-guard: desktop-only layout/CSS changes; no files under internal/boot/, internal/tool/, internal/provider/, or other cache-sensitive paths modified

System-prompt-review: N/A

---

## 效果展示

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/4af270b5-7e45-4b56-b1ee-7ba487baae84" />

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/69ca1d30-6b9c-42f2-97ec-f2befafb389d" />

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/3fdaf816-398a-4b51-8cc1-86baefffbd8a" />


https://github.com/user-attachments/assets/97d3215f-fc1a-4968-805c-09aa7af3fd1d